### PR TITLE
[TECH] :recycle: Utilise les status de l'`Assessment` uniquement (pix-20953)

### DIFF
--- a/api/src/certification/session-management/domain/read-models/JuryCertificationSummary.js
+++ b/api/src/certification/session-management/domain/read-models/JuryCertificationSummary.js
@@ -1,11 +1,13 @@
 import { status as assessmentResultStatuses } from '../../../../shared/domain/models/AssessmentResult.js';
 import { ComplementaryCertificationKeys } from '../../../shared/domain/models/ComplementaryCertificationKeys.js';
+
 const STARTED = 'started';
 const ENDED_BY_INVIGILATOR = 'endedBySupervisor';
+
 const CORE_CERTIFICATION = 'CORE';
 const DOUBLE_CORE_CLEA_CERTIFICATION = 'DOUBLE_CORE_CLEA';
 
-class JuryCertificationSummary {
+export class JuryCertificationSummary {
   constructor({
     id,
     firstName,
@@ -42,11 +44,11 @@ class JuryCertificationSummary {
   }
 
   hasScoringError() {
-    return this.status === JuryCertificationSummary.statuses.ERROR;
+    return this.status === assessmentResultStatuses.ERROR;
   }
 
   hasCompletedAssessment() {
-    return this.status !== JuryCertificationSummary.statuses.STARTED;
+    return this.status !== STARTED;
   }
 
   getCertificationLabel(translate) {
@@ -85,9 +87,3 @@ function _getCertificationObtained({ complementaryCertificationLabelObtained, co
   }
   return complementaryCertificationLabelObtained;
 }
-
-const statuses = { ...assessmentResultStatuses, STARTED, ENDED_BY_INVIGILATOR };
-
-JuryCertificationSummary.statuses = statuses;
-
-export { CORE_CERTIFICATION, DOUBLE_CORE_CLEA_CERTIFICATION, JuryCertificationSummary, statuses };

--- a/api/src/certification/session-management/domain/read-models/JuryCertificationSummary.js
+++ b/api/src/certification/session-management/domain/read-models/JuryCertificationSummary.js
@@ -1,7 +1,7 @@
-import { Assessment } from '../../../../shared/domain/models/Assessment.js';
 import { status as assessmentResultStatuses } from '../../../../shared/domain/models/AssessmentResult.js';
 import { ComplementaryCertificationKeys } from '../../../shared/domain/models/ComplementaryCertificationKeys.js';
-
+const STARTED = 'started';
+const ENDED_BY_INVIGILATOR = 'endedBySupervisor';
 const CORE_CERTIFICATION = 'CORE';
 const DOUBLE_CORE_CLEA_CERTIFICATION = 'DOUBLE_CORE_CLEA';
 
@@ -46,7 +46,7 @@ export class JuryCertificationSummary {
   }
 
   hasCompletedAssessment() {
-    return this.status !== Assessment.states.STARTED;
+    return this.status !== STARTED;
   }
 
   getCertificationLabel(translate) {
@@ -66,11 +66,11 @@ export class JuryCertificationSummary {
 
 function _getStatus({ status, isEndedByInvigilator }) {
   if (isEndedByInvigilator) {
-    return Assessment.states.ENDED_BY_INVIGILATOR;
+    return ENDED_BY_INVIGILATOR;
   }
 
   if (!Object.values(assessmentResultStatuses).includes(status)) {
-    return Assessment.states.STARTED;
+    return STARTED;
   }
 
   return status;

--- a/api/src/certification/session-management/domain/read-models/JuryCertificationSummary.js
+++ b/api/src/certification/session-management/domain/read-models/JuryCertificationSummary.js
@@ -1,8 +1,6 @@
+import { Assessment } from '../../../../shared/domain/models/Assessment.js';
 import { status as assessmentResultStatuses } from '../../../../shared/domain/models/AssessmentResult.js';
 import { ComplementaryCertificationKeys } from '../../../shared/domain/models/ComplementaryCertificationKeys.js';
-
-const STARTED = 'started';
-const ENDED_BY_INVIGILATOR = 'endedBySupervisor';
 
 const CORE_CERTIFICATION = 'CORE';
 const DOUBLE_CORE_CLEA_CERTIFICATION = 'DOUBLE_CORE_CLEA';
@@ -48,7 +46,7 @@ export class JuryCertificationSummary {
   }
 
   hasCompletedAssessment() {
-    return this.status !== STARTED;
+    return this.status !== Assessment.states.STARTED;
   }
 
   getCertificationLabel(translate) {
@@ -68,11 +66,11 @@ export class JuryCertificationSummary {
 
 function _getStatus({ status, isEndedByInvigilator }) {
   if (isEndedByInvigilator) {
-    return ENDED_BY_INVIGILATOR;
+    return Assessment.states.ENDED_BY_INVIGILATOR;
   }
 
   if (!Object.values(assessmentResultStatuses).includes(status)) {
-    return STARTED;
+    return Assessment.states.STARTED;
   }
 
   return status;

--- a/api/tests/certification/enrolment/unit/domain/usecases/get-candidate-timeline_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/get-candidate-timeline_test.js
@@ -9,7 +9,7 @@ import { CertificationEndedEvent } from '../../../../../../src/certification/enr
 import { CertificationStartedEvent } from '../../../../../../src/certification/enrolment/domain/models/timeline/CertificationStartedEvent.js';
 import { UserCertificationEligibility } from '../../../../../../src/certification/enrolment/domain/read-models/UserCertificationEligibility.js';
 import { getCandidateTimeline } from '../../../../../../src/certification/enrolment/domain/usecases/get-candidate-timeline.js';
-import { CertificationAssessment } from '../../../../../../src/certification/session-management/domain/models/CertificationAssessment.js';
+import { Assessment } from '../../../../../../src/shared/domain/models/Assessment.js';
 import { domainBuilder, expect, sinon } from '../../../../../test-helper.js';
 
 describe('Certification | Enrolment | Unit | Domain | UseCase | get-candidate-timeline', function () {
@@ -375,7 +375,7 @@ describe('Certification | Enrolment | Unit | Domain | UseCase | get-candidate-ti
           expect(candidateTimeline.events).to.deep.includes(
             new CertificationEndedEvent({
               when: assessment.endedAt,
-              assessmentState: CertificationAssessment.states.ENDED_BY_INVIGILATOR,
+              assessmentState: Assessment.states.ENDED_BY_INVIGILATOR,
             }),
           );
         });
@@ -418,7 +418,7 @@ describe('Certification | Enrolment | Unit | Domain | UseCase | get-candidate-ti
           expect(candidateTimeline.events).to.deep.includes(
             new CertificationEndedEvent({
               when: assessment.endedAt,
-              assessmentState: CertificationAssessment.states.ENDED_DUE_TO_FINALIZATION,
+              assessmentState: Assessment.states.ENDED_DUE_TO_FINALIZATION,
             }),
           );
         });

--- a/api/tests/certification/evaluation/unit/domain/services/scoring/scoring-v2_test.js
+++ b/api/tests/certification/evaluation/unit/domain/services/scoring/scoring-v2_test.js
@@ -7,16 +7,13 @@ import {
   calculateCertificationAssessmentScore,
   handleV2CertificationScoring,
 } from '../../../../../../../src/certification/evaluation/domain/services/scoring/scoring-v2.js';
-// TODO : cross-bounded context violation
-import {
-  CertificationAssessment,
-  states,
-} from '../../../../../../../src/certification/session-management/domain/models/CertificationAssessment.js';
+import { CertificationAssessment } from '../../../../../../../src/certification/session-management/domain/models/CertificationAssessment.js';
 import { AlgorithmEngineVersion } from '../../../../../../../src/certification/shared/domain/models/AlgorithmEngineVersion.js';
 import { ABORT_REASONS } from '../../../../../../../src/certification/shared/domain/models/CertificationCourse.js';
 import { AutoJuryCommentKeys } from '../../../../../../../src/certification/shared/domain/models/JuryComment.js';
 import * as scoringService from '../../../../../../../src/evaluation/domain/services/scoring/scoring-service.js';
 import CertificationCancelled from '../../../../../../../src/shared/domain/events/CertificationCancelled.js';
+import { Assessment } from '../../../../../../../src/shared/domain/models/Assessment.js';
 import { AssessmentResult, status } from '../../../../../../../src/shared/domain/models/AssessmentResult.js';
 import { catchErr, domainBuilder, expect, sinon } from '../../../../../../test-helper.js';
 
@@ -443,7 +440,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V2', f
           certificationCourseId: certificationCourse.getId(),
           createdAt: new Date('2020-01-01'),
           completedAt: new Date('2020-01-01'),
-          state: CertificationAssessment.states.STARTED,
+          state: Assessment.states.STARTED,
           version: 2,
           certificationChallenges: [
             domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false }),
@@ -516,7 +513,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V2', f
             certificationCourseId: 789,
             createdAt: new Date('2020-01-01'),
             completedAt: new Date('2020-01-01'),
-            state: CertificationAssessment.states.STARTED,
+            state: Assessment.states.STARTED,
             version: 2,
             certificationChallenges: [
               domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false }),
@@ -632,7 +629,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V2', f
             certificationCourseId: 789,
             createdAt: new Date('2020-01-01'),
             completedAt: new Date('2020-01-01'),
-            state: CertificationAssessment.states.STARTED,
+            state: Assessment.states.STARTED,
             version: 2,
             certificationChallenges: [
               domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false }),
@@ -704,7 +701,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V2', f
               certificationCourseId: 789,
               createdAt: new Date('2020-01-01'),
               completedAt: new Date('2020-01-01'),
-              state: CertificationAssessment.states.STARTED,
+              state: Assessment.states.STARTED,
               version: 2,
               certificationChallenges: [
                 domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false }),
@@ -770,7 +767,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V2', f
               certificationCourseId: 789,
               createdAt: new Date('2020-01-01'),
               completedAt: new Date('2020-01-01'),
-              state: CertificationAssessment.states.ENDED_BY_INVIGILATOR,
+              state: Assessment.states.ENDED_BY_INVIGILATOR,
               version: 2,
               certificationChallenges: [
                 domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false }),
@@ -837,7 +834,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V2', f
                 certificationCourseId: 789,
                 createdAt: new Date('2020-01-01'),
                 completedAt: new Date('2020-01-01'),
-                state: CertificationAssessment.states.ENDED_BY_INVIGILATOR,
+                state: Assessment.states.ENDED_BY_INVIGILATOR,
                 version: 2,
                 certificationChallenges: [domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false })],
                 certificationAnswersByDate: ['answer'],
@@ -906,7 +903,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V2', f
         certificationCourseId: 111,
         createdAt: '2020-02-01T00:00:00Z',
         completedAt: '2020-02-01T00:00:00Z',
-        state: states.COMPLETED,
+        state: Assessment.states.COMPLETED,
         version: 2,
       };
       competenceWithMarks_1_1 = domainBuilder.buildCompetenceMark({
@@ -1231,7 +1228,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V2', f
           startedCertificationAssessment = domainBuilder.buildCertificationAssessment({
             ...certificationAssessment,
             completedAt: null,
-            state: states.STARTED,
+            state: Assessment.states.STARTED,
           });
         });
 

--- a/api/tests/certification/evaluation/unit/domain/usecases/deneutralize-challenge_test.js
+++ b/api/tests/certification/evaluation/unit/domain/usecases/deneutralize-challenge_test.js
@@ -1,6 +1,7 @@
 import { ChallengeDeneutralized } from '../../../../../../src/certification/evaluation/domain/events/ChallengeDeneutralized.js';
 import { deneutralizeChallenge } from '../../../../../../src/certification/evaluation/domain/usecases/deneutralize-challenge.js';
 import { CertificationAssessment } from '../../../../../../src/certification/session-management/domain/models/CertificationAssessment.js';
+import { Assessment } from '../../../../../../src/shared/domain/models/Assessment.js';
 import { domainBuilder, expect, sinon } from '../../../../../test-helper.js';
 
 describe('Unit | UseCase | deneutralize-challenge', function () {
@@ -62,7 +63,7 @@ describe('Unit | UseCase | deneutralize-challenge', function () {
       certificationCourseId: 1,
       createdAt: new Date('2020-01-01'),
       completedAt: new Date('2020-01-01'),
-      state: CertificationAssessment.states.STARTED,
+      state: Assessment.states.STARTED,
       version: 2,
       certificationChallenges: [
         challengeToBeDeneutralized,

--- a/api/tests/certification/evaluation/unit/domain/usecases/neutralize-challenge_test.js
+++ b/api/tests/certification/evaluation/unit/domain/usecases/neutralize-challenge_test.js
@@ -1,6 +1,7 @@
 import { ChallengeNeutralized } from '../../../../../../src/certification/evaluation/domain/events/ChallengeNeutralized.js';
 import { neutralizeChallenge } from '../../../../../../src/certification/evaluation/domain/usecases/neutralize-challenge.js';
 import { CertificationAssessment } from '../../../../../../src/certification/session-management/domain/models/CertificationAssessment.js';
+import { Assessment } from '../../../../../../src/shared/domain/models/Assessment.js';
 import { domainBuilder, expect, sinon } from '../../../../../test-helper.js';
 
 describe('Certification | Evaluation | Unit | UseCase | neutralize-challenge', function () {
@@ -22,7 +23,7 @@ describe('Certification | Evaluation | Unit | UseCase | neutralize-challenge', f
       certificationCourseId: 1,
       createdAt: new Date('2020-01-01'),
       completedAt: new Date('2020-01-01'),
-      state: CertificationAssessment.states.STARTED,
+      state: Assessment.states.STARTED,
       version: 2,
       certificationChallenges: [
         challengeToBeNeutralized,
@@ -69,7 +70,7 @@ describe('Certification | Evaluation | Unit | UseCase | neutralize-challenge', f
       certificationCourseId: 1,
       createdAt: new Date('2020-01-01'),
       completedAt: new Date('2020-01-01'),
-      state: CertificationAssessment.states.STARTED,
+      state: Assessment.states.STARTED,
       version: 2,
       certificationChallenges: [
         challengeToBeNeutralized,

--- a/api/tests/certification/evaluation/unit/domain/usecases/rescore-v2-certification_test.js
+++ b/api/tests/certification/evaluation/unit/domain/usecases/rescore-v2-certification_test.js
@@ -5,6 +5,7 @@ import { SessionAlreadyPublishedError } from '../../../../../../src/certificatio
 import { CertificationCourseRejected } from '../../../../../../src/certification/session-management/domain/events/CertificationCourseRejected.js';
 import { CertificationAssessment } from '../../../../../../src/certification/session-management/domain/models/CertificationAssessment.js';
 import { NotFinalizedSessionError } from '../../../../../../src/shared/domain/errors.js';
+import { Assessment } from '../../../../../../src/shared/domain/models/Assessment.js';
 import { AssessmentResult } from '../../../../../../src/shared/domain/models/AssessmentResult.js';
 import { catchErr, domainBuilder, expect, sinon } from '../../../../../test-helper.js';
 
@@ -99,7 +100,7 @@ describe('Unit | Certification | Evaluation | UseCases | rescore-v2-certificatio
           certificationCourseId: 789,
           createdAt: new Date('2020-01-01'),
           completedAt: new Date('2020-01-01'),
-          state: CertificationAssessment.states.STARTED,
+          state: Assessment.states.STARTED,
           version: 2,
           certificationChallenges: [
             domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false }),

--- a/api/tests/certification/session-management/integration/infrastructure/repositories/jury-certification-summary-repository_test.js
+++ b/api/tests/certification/session-management/integration/infrastructure/repositories/jury-certification-summary-repository_test.js
@@ -1,8 +1,3 @@
-import {
-  CORE_CERTIFICATION,
-  DOUBLE_CORE_CLEA_CERTIFICATION,
-  JuryCertificationSummary,
-} from '../../../../../../src/certification/session-management/domain/read-models/JuryCertificationSummary.js';
 import * as juryCertificationSummaryRepository from '../../../../../../src/certification/session-management/infrastructure/repositories/jury-certification-summary-repository.js';
 import {
   CertificationIssueReportCategory,
@@ -11,7 +6,7 @@ import {
 } from '../../../../../../src/certification/shared/domain/models/CertificationIssueReportCategory.js';
 import { ComplementaryCertificationKeys } from '../../../../../../src/certification/shared/domain/models/ComplementaryCertificationKeys.js';
 import { Assessment } from '../../../../../../src/shared/domain/models/Assessment.js';
-import { status as assessmentResultStatuses } from '../../../../../../src/shared/domain/models/AssessmentResult.js';
+import { AssessmentResult } from '../../../../../../src/shared/domain/models/AssessmentResult.js';
 import { databaseBuilder, domainBuilder, expect } from '../../../../../test-helper.js';
 
 describe('Integration | Repository | JuryCertificationSummary', function () {
@@ -72,7 +67,7 @@ describe('Integration | Repository | JuryCertificationSummary', function () {
           certificationCourseId: manyAsrCertification.id,
           assessmentId: manyAsrAssessmentId,
           createdAt: new Date('2018-04-15T00:00:00Z'),
-          status: assessmentResultStatuses.VALIDATED,
+          status: AssessmentResult.status.VALIDATED,
         });
 
         return databaseBuilder.commit();
@@ -117,7 +112,7 @@ describe('Integration | Repository | JuryCertificationSummary', function () {
 
           // then
           expect(juryCertificationSummaries[0].pixScore).to.equal(latestAssessmentResult.pixScore);
-          expect(juryCertificationSummaries[0].status).to.equal(JuryCertificationSummary.statuses.VALIDATED);
+          expect(juryCertificationSummaries[0].status).to.equal(AssessmentResult.status.VALIDATED);
           expect(juryCertificationSummaries[0].firstName).to.equal(manyAsrCertification.firstName);
           expect(juryCertificationSummaries[0].lastName).to.equal(manyAsrCertification.lastName);
           expect(juryCertificationSummaries[0].createdAt).to.deep.equal(manyAsrCertification.createdAt);
@@ -133,10 +128,10 @@ describe('Integration | Repository | JuryCertificationSummary', function () {
 
           // then
           expect(juryCertificationSummaries[1].id).to.equal(startedCertification.id);
-          expect(juryCertificationSummaries[1].status).to.equal(JuryCertificationSummary.statuses.STARTED);
+          expect(juryCertificationSummaries[1].status).to.equal(Assessment.states.STARTED);
 
           expect(juryCertificationSummaries[2].id).to.equal(otherStartedCertification.id);
-          expect(juryCertificationSummaries[2].status).to.equal(JuryCertificationSummary.statuses.STARTED);
+          expect(juryCertificationSummaries[2].status).to.equal(Assessment.states.STARTED);
         });
       });
     });
@@ -200,7 +195,7 @@ describe('Integration | Repository | JuryCertificationSummary', function () {
         dbf.buildAssessmentResult({
           assessmentId: manyAsrAssessmentId,
           createdAt: new Date('2018-04-15T00:00:00Z'),
-          status: assessmentResultStatuses.VALIDATED,
+          status: AssessmentResult.status.VALIDATED,
         });
 
         await databaseBuilder.commit();
@@ -311,7 +306,7 @@ describe('Integration | Repository | JuryCertificationSummary', function () {
 
         // then
         expect(juryCertificationSummaries).to.have.lengthOf(1);
-        expect(juryCertificationSummaries[0].certificationObtained).to.equal(DOUBLE_CORE_CLEA_CERTIFICATION);
+        expect(juryCertificationSummaries[0].certificationObtained).to.equal('DOUBLE_CORE_CLEA');
       });
     });
 
@@ -331,7 +326,7 @@ describe('Integration | Repository | JuryCertificationSummary', function () {
 
         // then
         expect(juryCertificationSummaries).to.have.lengthOf(1);
-        expect(juryCertificationSummaries[0].certificationObtained).to.equal(CORE_CERTIFICATION);
+        expect(juryCertificationSummaries[0].certificationObtained).to.equal('CORE');
       });
     });
   });
@@ -373,7 +368,7 @@ describe('Integration | Repository | JuryCertificationSummary', function () {
           certificationCourseId: manyAsrCertification.id,
           assessmentId: manyAsrAssessmentId,
           createdAt: new Date('2018-04-15T00:00:00Z'),
-          status: assessmentResultStatuses.VALIDATED,
+          status: AssessmentResult.status.VALIDATED,
         });
 
         const categoryId = dbf.buildIssueReportCategory({
@@ -426,7 +421,7 @@ describe('Integration | Repository | JuryCertificationSummary', function () {
 
         // then
         expect(juryCertificationSummary.pixScore).to.equal(latestAssessmentResult.pixScore);
-        expect(juryCertificationSummary.status).to.equal(JuryCertificationSummary.statuses.VALIDATED);
+        expect(juryCertificationSummary.status).to.equal(AssessmentResult.status.VALIDATED);
         expect(juryCertificationSummary.firstName).to.equal(manyAsrCertification.firstName);
         expect(juryCertificationSummary.lastName).to.equal(manyAsrCertification.lastName);
         expect(juryCertificationSummary.createdAt).to.deep.equal(manyAsrCertification.createdAt);

--- a/api/tests/certification/session-management/integration/infrastructure/repositories/jury-session-repository_test.js
+++ b/api/tests/certification/session-management/integration/infrastructure/repositories/jury-session-repository_test.js
@@ -1,6 +1,5 @@
 import _ from 'lodash';
 
-import { states } from '../../../../../../src/certification/session-management/domain/models/CertificationAssessment.js';
 import { CertificationOfficer } from '../../../../../../src/certification/session-management/domain/models/CertificationOfficer.js';
 import {
   JurySession,
@@ -606,7 +605,7 @@ describe('Integration | Repository | JurySession', function () {
         databaseBuilder.factory.buildAssessment({
           certificationCourseId: certificationCourse.id,
           type: Assessment.types.CERTIFICATION,
-          state: i % 2 ? states.STARTED : states.COMPLETED,
+          state: i % 2 ? Assessment.states.STARTED : Assessment.states.COMPLETED,
         });
       }
 
@@ -628,7 +627,7 @@ describe('Integration | Repository | JurySession', function () {
         const assessment = databaseBuilder.factory.buildAssessment({
           certificationCourseId: certificationCourse.id,
           type: Assessment.types.CERTIFICATION,
-          state: states.COMPLETED,
+          state: Assessment.states.COMPLETED,
         });
 
         const assessmentResult = databaseBuilder.factory.buildAssessmentResult({
@@ -661,7 +660,7 @@ describe('Integration | Repository | JurySession', function () {
       databaseBuilder.factory.buildAssessment({
         certificationCourseId: certificationCourseWithoutReport.id,
         type: Assessment.types.CERTIFICATION,
-        state: states.COMPLETED,
+        state: Assessment.states.COMPLETED,
       });
 
       const certificationCourseWithReportNotImpactfulOne = databaseBuilder.factory.buildCertificationCourse({
@@ -670,7 +669,7 @@ describe('Integration | Repository | JurySession', function () {
       databaseBuilder.factory.buildAssessment({
         certificationCourseId: certificationCourseWithReportNotImpactfulOne.id,
         type: Assessment.types.CERTIFICATION,
-        state: states.ENDED_BY_INVIGILATOR,
+        state: Assessment.states.ENDED_BY_INVIGILATOR,
       });
 
       databaseBuilder.factory.buildCertificationIssueReport({
@@ -684,7 +683,7 @@ describe('Integration | Repository | JurySession', function () {
       databaseBuilder.factory.buildAssessment({
         certificationCourseId: certificationCourseWithReportNotImpactfulTwo.id,
         type: Assessment.types.CERTIFICATION,
-        state: states.ENDED_BY_INVIGILATOR,
+        state: Assessment.states.ENDED_BY_INVIGILATOR,
       });
 
       databaseBuilder.factory.buildCertificationIssueReport({
@@ -698,7 +697,7 @@ describe('Integration | Repository | JurySession', function () {
       databaseBuilder.factory.buildAssessment({
         certificationCourseId: certificationCourseWithImpactfulCategory.id,
         type: Assessment.types.CERTIFICATION,
-        state: states.ENDED_DUE_TO_FINALIZATION,
+        state: Assessment.states.ENDED_DUE_TO_FINALIZATION,
       });
       databaseBuilder.factory.buildCertificationIssueReport({
         certificationCourseId: certificationCourseWithImpactfulCategory.id,
@@ -725,7 +724,7 @@ describe('Integration | Repository | JurySession', function () {
       databaseBuilder.factory.buildAssessment({
         certificationCourseId: certificationCourseWithoutReport.id,
         type: Assessment.types.CERTIFICATION,
-        state: states.COMPLETED,
+        state: Assessment.states.COMPLETED,
       });
 
       const certificationCourseWithReportNotImpactfulOne = databaseBuilder.factory.buildCertificationCourse({
@@ -734,7 +733,7 @@ describe('Integration | Repository | JurySession', function () {
       databaseBuilder.factory.buildAssessment({
         certificationCourseId: certificationCourseWithReportNotImpactfulOne.id,
         type: Assessment.types.CERTIFICATION,
-        state: states.ENDED_BY_INVIGILATOR,
+        state: Assessment.states.ENDED_BY_INVIGILATOR,
       });
 
       databaseBuilder.factory.buildCertificationIssueReport({
@@ -748,7 +747,7 @@ describe('Integration | Repository | JurySession', function () {
       databaseBuilder.factory.buildAssessment({
         certificationCourseId: certificationCourseWithImpactfulCategory.id,
         type: Assessment.types.CERTIFICATION,
-        state: states.ENDED_DUE_TO_FINALIZATION,
+        state: Assessment.states.ENDED_DUE_TO_FINALIZATION,
       });
       databaseBuilder.factory.buildCertificationIssueReport({
         certificationCourseId: certificationCourseWithImpactfulCategory.id,
@@ -761,7 +760,7 @@ describe('Integration | Repository | JurySession', function () {
       databaseBuilder.factory.buildAssessment({
         certificationCourseId: certificationCourseWithImpactfulSubCategory.id,
         type: Assessment.types.CERTIFICATION,
-        state: states.ENDED_BY_INVIGILATOR,
+        state: Assessment.states.ENDED_BY_INVIGILATOR,
       });
       databaseBuilder.factory.buildCertificationIssueReport({
         certificationCourseId: certificationCourseWithImpactfulSubCategory.id,

--- a/api/tests/certification/session-management/integration/infrastructure/repositories/session-repository_test.js
+++ b/api/tests/certification/session-management/integration/infrastructure/repositories/session-repository_test.js
@@ -1,9 +1,9 @@
-import { CertificationAssessment } from '../../../../../../src/certification/session-management/domain/models/CertificationAssessment.js';
 import { SessionManagement } from '../../../../../../src/certification/session-management/domain/models/SessionManagement.js';
 import * as sessionRepository from '../../../../../../src/certification/session-management/infrastructure/repositories/session-repository.js';
 import { SESSION_STATUSES } from '../../../../../../src/certification/shared/domain/constants.js';
 import { DomainTransaction } from '../../../../../../src/shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
+import { Assessment } from '../../../../../../src/shared/domain/models/Assessment.js';
 import { catchErr, databaseBuilder, expect, knex } from '../../../../../test-helper.js';
 
 describe('Integration | Repository | Certification | session | SessionManagement', function () {
@@ -528,7 +528,7 @@ describe('Integration | Repository | Certification | session | SessionManagement
         });
         databaseBuilder.factory.buildAssessment({
           certificationCourseId: 97,
-          state: CertificationAssessment.states.STARTED,
+          state: Assessment.states.STARTED,
         });
 
         const userId2 = databaseBuilder.factory.buildUser().id;
@@ -541,7 +541,7 @@ describe('Integration | Repository | Certification | session | SessionManagement
         });
         databaseBuilder.factory.buildAssessment({
           certificationCourseId: 98,
-          state: CertificationAssessment.states.ENDED_BY_INVIGILATOR,
+          state: Assessment.states.ENDED_BY_INVIGILATOR,
         });
 
         const userId3 = databaseBuilder.factory.buildUser().id;
@@ -554,7 +554,7 @@ describe('Integration | Repository | Certification | session | SessionManagement
         });
         databaseBuilder.factory.buildAssessment({
           certificationCourseId: 99,
-          state: CertificationAssessment.states.ENDED_DUE_TO_FINALIZATION,
+          state: Assessment.states.ENDED_DUE_TO_FINALIZATION,
         });
 
         const userId4 = databaseBuilder.factory.buildUser().id;
@@ -567,7 +567,7 @@ describe('Integration | Repository | Certification | session | SessionManagement
         });
         databaseBuilder.factory.buildAssessment({
           certificationCourseId: 100,
-          state: CertificationAssessment.states.COMPLETED,
+          state: Assessment.states.COMPLETED,
         });
 
         await databaseBuilder.commit();
@@ -596,7 +596,7 @@ describe('Integration | Repository | Certification | session | SessionManagement
         });
         databaseBuilder.factory.buildAssessment({
           certificationCourseId: 97,
-          state: CertificationAssessment.states.COMPLETED,
+          state: Assessment.states.COMPLETED,
         });
 
         await databaseBuilder.commit();

--- a/api/tests/certification/session-management/unit/domain/models/CertificationAssessment_test.js
+++ b/api/tests/certification/session-management/unit/domain/models/CertificationAssessment_test.js
@@ -1,5 +1,3 @@
-import _ from 'lodash';
-
 import {
   ChallengeToBeDeneutralizedNotFoundError,
   ChallengeToBeNeutralizedNotFoundError,
@@ -9,6 +7,7 @@ import { CertificationAssessment } from '../../../../../../src/certification/ses
 import { NeutralizationAttempt } from '../../../../../../src/certification/session-management/domain/models/NeutralizationAttempt.js';
 import { ObjectValidationError } from '../../../../../../src/shared/domain/errors.js';
 import { AnswerStatus } from '../../../../../../src/shared/domain/models/AnswerStatus.js';
+import { Assessment } from '../../../../../../src/shared/domain/models/Assessment.js';
 import { domainBuilder, expect } from '../../../../../test-helper.js';
 
 describe('Unit | Domain | Models | CertificationAssessment', function () {
@@ -22,7 +21,7 @@ describe('Unit | Domain | Models | CertificationAssessment', function () {
         certificationCourseId: 123,
         createdAt: new Date('2020-01-01'),
         completedAt: new Date('2020-01-01'),
-        state: CertificationAssessment.states.STARTED,
+        state: Assessment.states.STARTED,
         version: 2,
         certificationChallenges: [],
         certificationAnswersByDate: ['answer'],
@@ -67,7 +66,12 @@ describe('Unit | Domain | Models | CertificationAssessment', function () {
       );
     });
 
-    _.forIn(CertificationAssessment.states, (value) => {
+    [
+      Assessment.states.COMPLETED,
+      Assessment.states.STARTED,
+      Assessment.states.ENDED_BY_INVIGILATOR,
+      Assessment.states.ENDED_DUE_TO_FINALIZATION,
+    ].forEach((value) => {
       it(`should not throw an ObjectValidationError when state is ${value}`, function () {
         // when
         expect(() => new CertificationAssessment({ ...validArguments, state: value })).not.to.throw(
@@ -153,7 +157,7 @@ describe('Unit | Domain | Models | CertificationAssessment', function () {
         certificationCourseId: 123,
         createdAt: new Date('2020-01-01'),
         completedAt: new Date('2020-01-01'),
-        state: CertificationAssessment.states.STARTED,
+        state: Assessment.states.STARTED,
         version: 2,
         certificationChallenges: [
           challengeToBeNeutralized,
@@ -185,7 +189,7 @@ describe('Unit | Domain | Models | CertificationAssessment', function () {
         certificationCourseId: 123,
         createdAt: new Date('2020-01-01'),
         completedAt: new Date('2020-01-01'),
-        state: CertificationAssessment.states.STARTED,
+        state: Assessment.states.STARTED,
         version: 2,
         certificationChallenges: [
           domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec2', isNeutralized: false }),
@@ -215,7 +219,7 @@ describe('Unit | Domain | Models | CertificationAssessment', function () {
         certificationCourseId: 123,
         createdAt: new Date('2020-01-01'),
         completedAt: new Date('2020-01-01'),
-        state: CertificationAssessment.states.STARTED,
+        state: Assessment.states.STARTED,
         version: 2,
         certificationChallenges: [
           challengeToBeDeneutralized,
@@ -247,7 +251,7 @@ describe('Unit | Domain | Models | CertificationAssessment', function () {
         certificationCourseId: 123,
         createdAt: new Date('2020-01-01'),
         completedAt: new Date('2020-01-01'),
-        state: CertificationAssessment.states.STARTED,
+        state: Assessment.states.STARTED,
         version: 2,
         certificationChallenges: [
           domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec2', isNeutralized: false }),
@@ -277,7 +281,7 @@ describe('Unit | Domain | Models | CertificationAssessment', function () {
         certificationCourseId: 123,
         createdAt: new Date('2020-01-01'),
         completedAt: new Date('2020-01-01'),
-        state: CertificationAssessment.states.STARTED,
+        state: Assessment.states.STARTED,
         version: 2,
         certificationChallenges: [challengeKoToBeNeutralized],
         certificationAnswersByDate: [
@@ -310,7 +314,7 @@ describe('Unit | Domain | Models | CertificationAssessment', function () {
         certificationCourseId: 123,
         createdAt: new Date('2020-01-01'),
         completedAt: new Date('2020-01-01'),
-        state: CertificationAssessment.states.STARTED,
+        state: Assessment.states.STARTED,
         version: 2,
         certificationChallenges: [challengeSkippedToBeNeutralized],
         certificationAnswersByDate: [
@@ -343,7 +347,7 @@ describe('Unit | Domain | Models | CertificationAssessment', function () {
         certificationCourseId: 123,
         createdAt: new Date('2020-01-01'),
         completedAt: new Date('2020-01-01'),
-        state: CertificationAssessment.states.STARTED,
+        state: Assessment.states.STARTED,
         version: 2,
         certificationChallenges: [challengeNotToBeNeutralized],
         certificationAnswersByDate: [
@@ -371,7 +375,7 @@ describe('Unit | Domain | Models | CertificationAssessment', function () {
         certificationCourseId: 123,
         createdAt: new Date('2020-01-01'),
         completedAt: new Date('2020-01-01'),
-        state: CertificationAssessment.states.STARTED,
+        state: Assessment.states.STARTED,
         version: 2,
         certificationChallenges: [
           domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec2', isNeutralized: false }),
@@ -412,7 +416,7 @@ describe('Unit | Domain | Models | CertificationAssessment', function () {
           createdAt: lastChallengeDate,
         });
         const certificationAssessment = domainBuilder.buildCertificationAssessment({
-          state: CertificationAssessment.states.STARTED,
+          state: Assessment.states.STARTED,
           certificationChallenges: [lastCertificationChallenge, certificationChallenge],
         });
 
@@ -420,7 +424,7 @@ describe('Unit | Domain | Models | CertificationAssessment', function () {
         certificationAssessment.endDueToFinalization();
 
         // then
-        expect(certificationAssessment.state).to.equal(CertificationAssessment.states.ENDED_DUE_TO_FINALIZATION);
+        expect(certificationAssessment.state).to.equal(Assessment.states.ENDED_DUE_TO_FINALIZATION);
       });
 
       describe('where there are challenges', function () {
@@ -435,7 +439,7 @@ describe('Unit | Domain | Models | CertificationAssessment', function () {
             createdAt: lastChallengeDate,
           });
           const certificationAssessment = domainBuilder.buildCertificationAssessment({
-            state: CertificationAssessment.states.STARTED,
+            state: Assessment.states.STARTED,
             certificationChallenges: [lastCertificationChallenge, certificationChallenge],
           });
 
@@ -453,7 +457,7 @@ describe('Unit | Domain | Models | CertificationAssessment', function () {
           const certificationCourseCreatedAt = new Date('2020-01-01');
 
           const certificationAssessment = domainBuilder.buildCertificationAssessment({
-            state: CertificationAssessment.states.STARTED,
+            state: Assessment.states.STARTED,
             createdAt: certificationCourseCreatedAt,
             certificationChallenges: [],
           });
@@ -471,14 +475,14 @@ describe('Unit | Domain | Models | CertificationAssessment', function () {
       it('should NOT change the assessment state"', function () {
         // given
         const certificationAssessment = domainBuilder.buildCertificationAssessment({
-          state: CertificationAssessment.states.ENDED_BY_INVIGILATOR,
+          state: Assessment.states.ENDED_BY_INVIGILATOR,
         });
 
         // when
         certificationAssessment.endDueToFinalization();
 
         // when then
-        expect(certificationAssessment.state).to.equal(CertificationAssessment.states.ENDED_BY_INVIGILATOR);
+        expect(certificationAssessment.state).to.equal(Assessment.states.ENDED_BY_INVIGILATOR);
       });
     });
   });
@@ -488,14 +492,14 @@ describe('Unit | Domain | Models | CertificationAssessment', function () {
       // given
       const now = new Date('2020-12-31');
       const certificationAssessment = domainBuilder.buildCertificationAssessment({
-        state: CertificationAssessment.states.STARTED,
+        state: Assessment.states.STARTED,
       });
 
       // when
       certificationAssessment.endByInvigilator({ now });
 
       // then
-      expect(certificationAssessment.state).to.equal(CertificationAssessment.states.ENDED_BY_INVIGILATOR);
+      expect(certificationAssessment.state).to.equal(Assessment.states.ENDED_BY_INVIGILATOR);
       expect(certificationAssessment.endedAt).to.deep.equal(now);
     });
   });
@@ -575,7 +579,7 @@ describe('Unit | Domain | Models | CertificationAssessment', function () {
     it('returns true when completed', function () {
       // given
       const certificationAssessment = domainBuilder.buildCertificationAssessment({
-        state: CertificationAssessment.states.COMPLETED,
+        state: Assessment.states.COMPLETED,
       });
       // when / then
       expect(certificationAssessment.isCompleted()).to.be.true;
@@ -584,7 +588,7 @@ describe('Unit | Domain | Models | CertificationAssessment', function () {
     it('returns false when only started', function () {
       // given
       const certificationAssessment = domainBuilder.buildCertificationAssessment({
-        state: CertificationAssessment.states.STARTED,
+        state: Assessment.states.STARTED,
       });
       // when / then
       expect(certificationAssessment.isCompleted()).to.be.false;
@@ -917,9 +921,9 @@ describe('Unit | Domain | Models | CertificationAssessment', function () {
 
       // then
       expect(result).to.deep.equal([
-        CertificationAssessment.states.STARTED,
-        CertificationAssessment.states.ENDED_BY_INVIGILATOR,
-        CertificationAssessment.states.ENDED_DUE_TO_FINALIZATION,
+        Assessment.states.STARTED,
+        Assessment.states.ENDED_BY_INVIGILATOR,
+        Assessment.states.ENDED_DUE_TO_FINALIZATION,
       ]);
     });
   });

--- a/api/tests/certification/session-management/unit/domain/read-models/CertificationDetails_test.js
+++ b/api/tests/certification/session-management/unit/domain/read-models/CertificationDetails_test.js
@@ -1,5 +1,5 @@
-import { states } from '../../../../../../src/certification/session-management/domain/models/CertificationAssessment.js';
 import { CertificationDetails } from '../../../../../../src/certification/session-management/domain/read-models/CertificationDetails.js';
+import { Assessment } from '../../../../../../src/shared/domain/models/Assessment.js';
 import { domainBuilder, expect } from '../../../../../test-helper.js';
 
 describe('Certification | Session-management | Unit | Domain | Read-models | CertificationDetails', function () {
@@ -25,7 +25,7 @@ describe('Certification | Session-management | Unit | Domain | Read-models | Cer
         userId: 456,
         createdAt: new Date('2020-01-01'),
         completedAt: new Date('2020-03-03'),
-        state: states.COMPLETED,
+        state: Assessment.states.COMPLETED,
         certificationChallenges: [certificationChallenge1, certificationChallenge2],
         certificationAnswersByDate: [answer1, answer2],
       });
@@ -64,7 +64,7 @@ describe('Certification | Session-management | Unit | Domain | Read-models | Cer
         userId: 456,
         createdAt: new Date('2020-01-01'),
         completedAt: new Date('2020-03-03'),
-        status: states.COMPLETED,
+        status: Assessment.states.COMPLETED,
         totalScore: 22,
         percentageCorrectAnswers: 50,
         competencesWithMark: [
@@ -291,7 +291,7 @@ describe('Certification | Session-management | Unit | Domain | Read-models | Cer
         userId: 456,
         createdAt: new Date('2020-01-01'),
         completedAt: new Date('2020-03-03'),
-        status: states.COMPLETED,
+        status: Assessment.states.COMPLETED,
         totalScore: 45,
         percentageCorrectAnswers: 12,
         competencesWithMark,
@@ -307,7 +307,7 @@ describe('Certification | Session-management | Unit | Domain | Read-models | Cer
         userId: 456,
         createdAt: new Date('2020-01-01'),
         completedAt: new Date('2020-03-03'),
-        status: states.COMPLETED,
+        status: Assessment.states.COMPLETED,
         totalScore: 45,
         percentageCorrectAnswers: 12,
         competencesWithMark: [...competencesWithMark],

--- a/api/tests/certification/session-management/unit/domain/read-models/JuryCertificationSummary_test.js
+++ b/api/tests/certification/session-management/unit/domain/read-models/JuryCertificationSummary_test.js
@@ -1,14 +1,9 @@
-import lodash from 'lodash';
-
-import {
-  CORE_CERTIFICATION,
-  JuryCertificationSummary,
-} from '../../../../../../src/certification/session-management/domain/read-models/JuryCertificationSummary.js';
+import { JuryCertificationSummary } from '../../../../../../src/certification/session-management/domain/read-models/JuryCertificationSummary.js';
 import { ComplementaryCertificationKeys } from '../../../../../../src/certification/shared/domain/models/ComplementaryCertificationKeys.js';
+import { Assessment } from '../../../../../../src/shared/domain/models/Assessment.js';
 import { AssessmentResult } from '../../../../../../src/shared/domain/models/AssessmentResult.js';
 import { getI18n } from '../../../../../../src/shared/infrastructure/i18n/i18n.js';
 import { domainBuilder, expect } from '../../../../../test-helper.js';
-const { forIn } = lodash;
 
 describe('Unit | Domain | Models | JuryCertificationSummary', function () {
   describe('#constructor', function () {
@@ -35,7 +30,7 @@ describe('Unit | Domain | Models | JuryCertificationSummary', function () {
       // then
       expect(juryCertificationSummary).to.deep.equal({
         certificationIssueReports: [notImpactfulIssueReport],
-        certificationObtained: CORE_CERTIFICATION,
+        certificationObtained: 'CORE',
         completedAt: new Date('2020-01-01'),
         createdAt: new Date('2020-01-02'),
         firstName: 'Mad',
@@ -50,25 +45,13 @@ describe('Unit | Domain | Models | JuryCertificationSummary', function () {
   });
 
   describe('#validate', function () {
-    context('when a status is given', function () {
-      forIn(AssessmentResult.status, (status, key) => {
-        it(`should returns "${status}" status`, function () {
-          // when
-          const juryCertificationSummary = new JuryCertificationSummary({ status });
-
-          // then
-          expect(juryCertificationSummary.status).equal(JuryCertificationSummary.statuses[key]);
-        });
-      });
-    });
-
     context('when assessment is ended by invigilator', function () {
       it(`should returns "endedByInvigilator" status`, function () {
         // when
         const juryCertificationSummary = new JuryCertificationSummary({ isEndedByInvigilator: true });
 
         // then
-        expect(juryCertificationSummary.status).equal(JuryCertificationSummary.statuses['ENDED_BY_INVIGILATOR']);
+        expect(juryCertificationSummary.status).equal('endedBySupervisor');
       });
     });
 
@@ -78,7 +61,7 @@ describe('Unit | Domain | Models | JuryCertificationSummary', function () {
         const juryCertificationSummary = new JuryCertificationSummary({ status: null });
 
         // then
-        expect(juryCertificationSummary.status).equal(JuryCertificationSummary.statuses.STARTED);
+        expect(juryCertificationSummary.status).equal(Assessment.states.STARTED);
       });
     });
   });

--- a/api/tests/certification/session-management/unit/domain/usecases/end-assessment-by-invigilator_test.js
+++ b/api/tests/certification/session-management/unit/domain/usecases/end-assessment-by-invigilator_test.js
@@ -1,5 +1,5 @@
-import { CertificationAssessment } from '../../../../../../src/certification/session-management/domain/models/CertificationAssessment.js';
 import { endAssessmentByInvigilator } from '../../../../../../src/certification/session-management/domain/usecases/end-assessment-by-invigilator.js';
+import { Assessment } from '../../../../../../src/shared/domain/models/Assessment.js';
 import { domainBuilder, expect, sinon } from '../../../../../test-helper.js';
 
 describe('Unit | UseCase | end-assessment-by-invigilator', function () {
@@ -19,7 +19,7 @@ describe('Unit | UseCase | end-assessment-by-invigilator', function () {
         subscriptions: [domainBuilder.certification.enrolment.buildCoreSubscription()],
       }).id;
       const completedCertificationAssessment = domainBuilder.buildCertificationAssessment({
-        state: CertificationAssessment.states.COMPLETED,
+        state: Assessment.states.COMPLETED,
       });
 
       certificationAssessmentRepository.getByCertificationCandidateId
@@ -43,7 +43,7 @@ describe('Unit | UseCase | end-assessment-by-invigilator', function () {
         subscriptions: [domainBuilder.certification.enrolment.buildCoreSubscription()],
       }).id;
       const startedCertificationAssessment = domainBuilder.buildCertificationAssessment({
-        state: CertificationAssessment.states.STARTED,
+        state: Assessment.states.STARTED,
       });
 
       certificationAssessmentRepository.getByCertificationCandidateId
@@ -57,7 +57,7 @@ describe('Unit | UseCase | end-assessment-by-invigilator', function () {
 
       // then
       expect(startedCertificationAssessment.endedAt).to.be.instanceOf(Date);
-      expect(startedCertificationAssessment.state).to.equal(CertificationAssessment.states.ENDED_BY_INVIGILATOR);
+      expect(startedCertificationAssessment.state).to.equal(Assessment.states.ENDED_BY_INVIGILATOR);
       expect(certificationAssessmentRepository.save).to.have.been.calledWithExactly(startedCertificationAssessment);
     });
   });

--- a/api/tests/certification/session-management/unit/domain/usecases/get-certification-details_test.js
+++ b/api/tests/certification/session-management/unit/domain/usecases/get-certification-details_test.js
@@ -1,6 +1,6 @@
-import { states as CertificationAssessmentStates } from '../../../../../../src/certification/session-management/domain/models/CertificationAssessment.js';
 import { CertificationDetails } from '../../../../../../src/certification/session-management/domain/read-models/CertificationDetails.js';
 import { getCertificationDetails } from '../../../../../../src/certification/session-management/domain/usecases/get-certification-details.js';
+import { Assessment } from '../../../../../../src/shared/domain/models/Assessment.js';
 import { domainBuilder, expect, sinon } from '../../../../../test-helper.js';
 
 describe('Certification | Session-management | Unit | Domain | UseCases | get-certification-details', function () {
@@ -33,7 +33,7 @@ describe('Certification | Session-management | Unit | Domain | UseCases | get-ce
         certificationCourseId,
         certificationChallenges: [certificationChallenge],
         certificationAnswersByDate: [answer],
-        state: CertificationAssessmentStates.COMPLETED,
+        state: Assessment.states.COMPLETED,
       });
 
       const competenceMark = domainBuilder.buildCompetenceMark({

--- a/api/tests/certification/session-management/unit/domain/usecases/process-auto-jury_test.js
+++ b/api/tests/certification/session-management/unit/domain/usecases/process-auto-jury_test.js
@@ -1,5 +1,4 @@
 import { CertificationJuryDone } from '../../../../../../src/certification/session-management/domain/events/CertificationJuryDone.js';
-import { CertificationAssessment } from '../../../../../../src/certification/session-management/domain/models/CertificationAssessment.js';
 import { SessionFinalized } from '../../../../../../src/certification/session-management/domain/read-models/SessionFinalized.js';
 import { processAutoJury } from '../../../../../../src/certification/session-management/domain/usecases/process-auto-jury.js';
 import { AlgorithmEngineVersion } from '../../../../../../src/certification/shared/domain/models/AlgorithmEngineVersion.js';
@@ -10,6 +9,7 @@ import {
 } from '../../../../../../src/certification/shared/domain/models/CertificationIssueReportCategory.js';
 import { DomainTransaction } from '../../../../../../src/shared/domain/DomainTransaction.js';
 import { AnswerStatus } from '../../../../../../src/shared/domain/models/AnswerStatus.js';
+import { Assessment } from '../../../../../../src/shared/domain/models/Assessment.js';
 import { domainBuilder, expect, sinon } from '../../../../../test-helper.js';
 
 describe('Unit | UseCase | process-auto-jury', function () {
@@ -570,7 +570,7 @@ describe('Unit | UseCase | process-auto-jury', function () {
       it('triggers a CertificationJuryDone rescoring event', async function () {
         // given
         const { certificationCourse } = _initializeV3CourseAndAssessment({
-          certificationState: CertificationAssessment.states.STARTED,
+          certificationState: Assessment.states.STARTED,
           certificationAssessmentRepository,
           certificationCourseRepository,
           certificationIssueReportRepository,
@@ -687,7 +687,7 @@ describe('Unit | UseCase | process-auto-jury', function () {
       it('triggers a CertificationJuryDone rescoring event', async function () {
         // given
         const { certificationCourse } = _initializeV3CourseAndAssessment({
-          certificationState: CertificationAssessment.states.ENDED_BY_INVIGILATOR,
+          certificationState: Assessment.states.ENDED_BY_INVIGILATOR,
           certificationAssessmentRepository,
           certificationCourseRepository,
           certificationIssueReportRepository,
@@ -724,7 +724,7 @@ describe('Unit | UseCase | process-auto-jury', function () {
       it('scores the certification', async function () {
         // given
         const { certificationCourse } = _initializeV3CourseAndAssessment({
-          certificationState: CertificationAssessment.states.ENDED_DUE_TO_FINALIZATION,
+          certificationState: Assessment.states.ENDED_DUE_TO_FINALIZATION,
           certificationAssessmentRepository,
           certificationCourseRepository,
           certificationIssueReportRepository,

--- a/api/tests/certification/session-management/unit/infrastructure/serializers/certification-details-serializer_test.js
+++ b/api/tests/certification/session-management/unit/infrastructure/serializers/certification-details-serializer_test.js
@@ -1,5 +1,5 @@
-import { states } from '../../../../../../src/certification/session-management/domain/models/CertificationAssessment.js';
 import * as serializer from '../../../../../../src/certification/session-management/infrastructure/serializers/certification-details-serializer.js';
+import { Assessment } from '../../../../../../src/shared/domain/models/Assessment.js';
 import { domainBuilder, expect } from '../../../../../test-helper.js';
 
 describe('Certification | Session-management | Unit | Infrastructure | Serializers | certification-details-serializer', function () {
@@ -11,7 +11,7 @@ describe('Certification | Session-management | Unit | Infrastructure | Serialize
         userId: 456,
         createdAt: new Date('2020-01-01'),
         completedAt: new Date('2020-03-03'),
-        status: states.COMPLETED,
+        status: Assessment.states.COMPLETED,
         totalScore: 555,
         percentageCorrectAnswers: 75,
         competencesWithMark: [
@@ -45,7 +45,7 @@ describe('Certification | Session-management | Unit | Infrastructure | Serialize
             'user-id': 456,
             'created-at': new Date('2020-01-01'),
             'completed-at': new Date('2020-03-03'),
-            status: states.COMPLETED,
+            status: Assessment.states.COMPLETED,
             'total-score': 555,
             'percentage-correct-answers': 75,
             'competences-with-mark': [

--- a/api/tests/certification/shared/integration/infrastructure/repositories/certification-assessment-repository_test.js
+++ b/api/tests/certification/shared/integration/infrastructure/repositories/certification-assessment-repository_test.js
@@ -100,7 +100,7 @@ describe('Integration | Infrastructure | Repositories | certification-assessment
       let secondAnswerInTime;
 
       beforeEach(function () {
-        expectedState = CertificationAssessment.states.COMPLETED;
+        expectedState = Assessment.states.COMPLETED;
         expectedCreatedAt = new Date('2020-01-01T00:00:00Z');
         expectedEndedAt = new Date('2020-01-02T00:00:00Z');
         expectedCompletedAt = new Date('2020-01-03T00:00:00Z');
@@ -377,7 +377,7 @@ describe('Integration | Infrastructure | Repositories | certification-assessment
       const certificationAssessmentToBeSaved = await certificationAssessmentRepository.getByCertificationCourseId({
         certificationCourseId,
       });
-      certificationAssessmentToBeSaved.state = CertificationAssessment.states.ENDED_DUE_TO_FINALIZATION;
+      certificationAssessmentToBeSaved.state = Assessment.states.ENDED_DUE_TO_FINALIZATION;
 
       // when
       await certificationAssessmentRepository.save(certificationAssessmentToBeSaved);
@@ -386,9 +386,7 @@ describe('Integration | Infrastructure | Repositories | certification-assessment
       const persistedCertificationAssessment = await certificationAssessmentRepository.getByCertificationCourseId({
         certificationCourseId,
       });
-      expect(persistedCertificationAssessment.state).to.deep.equal(
-        CertificationAssessment.states.ENDED_DUE_TO_FINALIZATION,
-      );
+      expect(persistedCertificationAssessment.state).to.deep.equal(Assessment.states.ENDED_DUE_TO_FINALIZATION);
     });
 
     it('persists the mutation of endedAt', async function () {

--- a/api/tests/tooling/domain-builder/factory/certification/session-management/build-certification-details.js
+++ b/api/tests/tooling/domain-builder/factory/certification/session-management/build-certification-details.js
@@ -1,12 +1,12 @@
-import { states } from '../../../../../../src/certification/session-management/domain/models/CertificationAssessment.js';
 import { CertificationDetails } from '../../../../../../src/certification/session-management/domain/read-models/CertificationDetails.js';
+import { Assessment } from '../../../../../../src/shared/domain/models/Assessment.js';
 
 const buildCertificationDetails = function ({
   id = 123,
   userId = 456,
   createdAt = new Date('2020-01-01'),
   completedAt = new Date('2020-03-03'),
-  status = states.COMPLETED,
+  status = Assessment.states.COMPLETED,
   totalScore = 555,
   percentageCorrectAnswers = 75,
   competencesWithMark = [


### PR DESCRIPTION
## ❄️ Problème

L'`ENUM` des status d'`Assessment` sont définis dans le modèle `Assessment` et dans le modèle `CertificationAssessment`. C'est un risque de désynchronisation.

Ils sont aussi redéfinis dans les applications front, avec une désynchronisation dans l'application `Certif` qui sera traité dans une autre PR.

## 🛷 Proposition

Utiliser uniquement l'ENUM du modèle `Assessment`.

## ☃️ Remarques

Il y a une sorte d'intrusion du domaine de certification dans ce modèle partagé qu'est l'`Assessment`. Mais démêler ceci nécessite une réflexion plus large que le champ de cette PR.

## 🧑‍🎄 Pour tester

- Passer une certification (entière) normalement
- Finaliser une certification par le surveillant
- Finaliser une certification par finalisation de la session.

Dans les trois cas, tout dois bien se passer au niveau des affichages de status.

