### PR TITLE
[TECH] Utiliser uniquement la valeur dans config.v3certification de maxReachableLevel dans le scope certif (PIX-20956)

### DIFF
--- a/api/src/certification/evaluation/domain/usecases/retrieve-last-or-create-certification-course.js
+++ b/api/src/certification/evaluation/domain/usecases/retrieve-last-or-create-certification-course.js
@@ -28,8 +28,6 @@ import { CertificationCourse } from '../../../shared/domain/models/Certification
 import { ComplementaryCertificationKeys } from '../../../shared/domain/models/ComplementaryCertificationKeys.js';
 import { Scopes } from '../../../shared/domain/models/Scopes.js';
 
-const { features } = config;
-
 /**
  * @param {Object} params
  * @param {AssessmentRepository} params.assessmentRepository
@@ -285,7 +283,7 @@ async function _createCertificationCourse({
 
   const newCertificationCourse = CertificationCourse.from({
     certificationCandidate,
-    maxReachableLevelOnCertificationDate: features.maxReachableLevel,
+    maxReachableLevelOnCertificationDate: config.v3Certification.maxReachableLevel,
     complementaryCertificationCourse,
     verificationCode,
     algorithmEngineVersion: AlgorithmEngineVersion.V3,

--- a/api/tests/certification/evaluation/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
+++ b/api/tests/certification/evaluation/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
@@ -5,7 +5,7 @@ import { CenterHabilitationError } from '../../../../../../src/certification/sha
 import { AlgorithmEngineVersion } from '../../../../../../src/certification/shared/domain/models/AlgorithmEngineVersion.js';
 import { CertificationCourse } from '../../../../../../src/certification/shared/domain/models/CertificationCourse.js';
 import { ComplementaryCertificationKeys } from '../../../../../../src/certification/shared/domain/models/ComplementaryCertificationKeys.js';
-import { MAX_REACHABLE_LEVEL } from '../../../../../../src/shared/domain/constants.js';
+import { config } from '../../../../../../src/shared/config.js';
 import { DomainTransaction } from '../../../../../../src/shared/domain/DomainTransaction.js';
 import {
   CandidateNotAuthorizedToJoinSessionError,
@@ -34,6 +34,8 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
   const verifyCertificateCodeService = {};
   const userRepository = {};
   const versionRepository = {};
+
+  const MAX_REACHABLE_LEVEL = config.v3Certification.maxReachableLevel;
 
   const injectables = {
     assessmentRepository,


### PR DESCRIPTION
## ❄️ Problème

On s’est rendu compte que `api/src/certification/evaluation/domain/usecases/retrieve-last-or-create-certification-course.js` utilise la valeur `maxReachableLevel` de `config.features`, qui est utilisé par les autres scopes, alors que le reste du scoring de certif utilise la valeur dans `config.v3Certification`.
## 🛷 Proposition

Utiliser la valeur dans `config.v3Certification` pour unifier les usages.

## ☃️ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🧑‍🎄 Pour tester

Créer un `CertificationCourse` (créer une session puis rentrer en session) et vérifier en BDD que la valeur de `maxReachableLevelOnCertificationDate` est correcte (7). 
