### PR TITLE
[TECH] Rendre required l'ensemble des attributs de FlashAssessmentAlgorithmConfiguration (PIX-20955)

### DIFF
--- a/api/src/certification/configuration/domain/usecases/create-certification-version.js
+++ b/api/src/certification/configuration/domain/usecases/create-certification-version.js
@@ -54,6 +54,8 @@ const _buildNewVersion = async ({ scope, versionsRepository }) => {
         variationPercent: 1,
         defaultCandidateCapacity: 0,
         defaultProbabilityToPickChallenge: DEFAULT_PROBABILITY_TO_PICK_CHALLENGE,
+        limitToOneQuestionPerTube: true,
+        enablePassageByAllCompetences: true,
       }),
     });
   }

--- a/api/src/certification/shared/domain/models/FlashAssessmentAlgorithmConfiguration.js
+++ b/api/src/certification/shared/domain/models/FlashAssessmentAlgorithmConfiguration.js
@@ -6,9 +6,9 @@ export class FlashAssessmentAlgorithmConfiguration {
   static #schema = Joi.object({
     maximumAssessmentLength: Joi.number().integer().min(0).required(),
     challengesBetweenSameCompetence: Joi.number().integer().min(0).required(),
-    limitToOneQuestionPerTube: Joi.boolean(),
-    enablePassageByAllCompetences: Joi.boolean(),
-    variationPercent: Joi.number().min(0).max(1),
+    limitToOneQuestionPerTube: Joi.boolean().required(),
+    enablePassageByAllCompetences: Joi.boolean().required(),
+    variationPercent: Joi.number().min(0).max(1).required(),
     defaultCandidateCapacity: Joi.number().required(),
     defaultProbabilityToPickChallenge: Joi.number().min(0).max(100).required(),
   });
@@ -17,8 +17,8 @@ export class FlashAssessmentAlgorithmConfiguration {
    * @param {object} props
    * @param {number} props.maximumAssessmentLength - limit for assessment length
    * @param {number} props.challengesBetweenSameCompetence - define a number of questions before getting another one on the same competence
-   * @param {boolean} [props.limitToOneQuestionPerTube] - limits questions to one per tube
-   * @param {boolean} [props.enablePassageByAllCompetences] - enable or disable the passage through all competences
+   * @param {boolean} props.limitToOneQuestionPerTube - limits questions to one per tube
+   * @param {boolean} props.enablePassageByAllCompetences - enable or disable the passage through all competences
    * @param {number} props.variationPercent
    * @param {number} props.defaultCandidateCapacity - starting candidate capacity for first challenge
    * @param {number} props.defaultProbabilityToPickChallenge - The probability (as a percentage, 0-100) that the ramdomizing function will pick a challenge from a list of possible challenges.
@@ -26,8 +26,8 @@ export class FlashAssessmentAlgorithmConfiguration {
   constructor({
     maximumAssessmentLength,
     challengesBetweenSameCompetence,
-    limitToOneQuestionPerTube = false,
-    enablePassageByAllCompetences = false,
+    limitToOneQuestionPerTube,
+    enablePassageByAllCompetences,
     variationPercent,
     defaultCandidateCapacity,
     defaultProbabilityToPickChallenge,

--- a/api/src/certification/shared/domain/models/Version.js
+++ b/api/src/certification/shared/domain/models/Version.js
@@ -5,6 +5,7 @@
 import Joi from 'joi';
 
 import { EntityValidationError } from '../../../../shared/domain/errors.js';
+import { FlashAssessmentAlgorithmConfiguration } from '../../../shared/domain/models/FlashAssessmentAlgorithmConfiguration.js';
 import { Scopes } from './Scopes.js';
 
 export class Version {
@@ -13,26 +14,14 @@ export class Version {
     scope: Joi.string()
       .required()
       .valid(...Object.values(Scopes)),
-    challengesConfiguration: Joi.object()
-      .keys({
-        maximumAssessmentLength: Joi.number().integer().min(0).required(),
-        challengesBetweenSameCompetence: Joi.number().integer().min(0).required(),
-        defaultCandidateCapacity: Joi.number().required(),
-        defaultProbabilityToPickChallenge: Joi.number().min(0).max(100).required(),
-      })
-      .unknown(true)
-      .required(),
+    challengesConfiguration: Joi.object().instance(FlashAssessmentAlgorithmConfiguration).required(),
   });
 
   /**
    * @param {object} params
    * @param {number} params.id - version identifier
    * @param {Scopes} params.scope - Certification scope (CORE, DROIT, etc.)
-   * @param {object} params.challengesConfiguration - Challenges configuration
-   * @param {number} params.challengesConfiguration.maximumAssessmentLength - limit for assessment length
-   * @param {number} params.challengesConfiguration.challengesBetweenSameCompetence - define a number of questions before getting another one on the same competence
-   * @param {number} params.challengesConfiguration.defaultCandidateCapacity - capacity when none has been yet determined
-   * @param {number} params.challengesConfiguration.defaultProbabilityToPickChallenge - The probability (as a percentage, 0-100) that the ramdomizing function will pick a challenge from a list of possible challenges.
+   * @param {FlashAssessmentAlgorithmConfiguration} params.challengesConfiguration - Challenges configuration
    */
   constructor({ id, scope, challengesConfiguration }) {
     this.id = id;

--- a/api/tests/certification/configuration/acceptance/application/complementary-certification-route_test.js
+++ b/api/tests/certification/configuration/acceptance/application/complementary-certification-route_test.js
@@ -309,8 +309,8 @@ describe('Certification | Configuration | Acceptance | API | complementary-certi
         variationPercent: 1,
         defaultCandidateCapacity: 0,
         maximumAssessmentLength: 32,
-        limitToOneQuestionPerTube: false,
-        enablePassageByAllCompetences: false,
+        limitToOneQuestionPerTube: true,
+        enablePassageByAllCompetences: true,
         defaultProbabilityToPickChallenge: 51,
       });
       expect(certificationVersion.startDate).to.exist;

--- a/api/tests/certification/configuration/unit/domain/usecases/create-certification-version_test.js
+++ b/api/tests/certification/configuration/unit/domain/usecases/create-certification-version_test.js
@@ -176,6 +176,8 @@ describe('Certification | Configuration | Unit | UseCase | create-certification-
             variationPercent: 1,
             defaultCandidateCapacity: 0,
             defaultProbabilityToPickChallenge: 51,
+            limitToOneQuestionPerTube: true,
+            enablePassageByAllCompetences: true,
           }),
         }),
       );

--- a/api/tests/certification/configuration/unit/infrastructure/serializers/certification-version-serializer_test.js
+++ b/api/tests/certification/configuration/unit/infrastructure/serializers/certification-version-serializer_test.js
@@ -20,6 +20,8 @@ describe('Unit | Certification | Configuration | Serializer | certification-vers
           limitToOneQuestionPerTube: true,
           defaultCandidateCapacity: -3,
           defaultProbabilityToPickChallenge: 51,
+          variationPercent: 0.5,
+          enablePassageByAllCompetences: false,
         },
       };
 
@@ -43,6 +45,8 @@ describe('Unit | Certification | Configuration | Serializer | certification-vers
               limitToOneQuestionPerTube: true,
               defaultCandidateCapacity: -3,
               defaultProbabilityToPickChallenge: 51,
+              variationPercent: 0.5,
+              enablePassageByAllCompetences: false,
             },
           },
         },
@@ -71,6 +75,8 @@ describe('Unit | Certification | Configuration | Serializer | certification-vers
               challengesBetweenSameCompetence: 0,
               variationPercent: 1,
               defaultProbabilityToPickChallenge: 51,
+              limitToOneQuestionPerTube: false,
+              enablePassageByAllCompetences: false,
             },
           },
         },

--- a/api/tests/certification/shared/unit/domain/models/FlashAssessmentAlgorithmConfiguration_test.js
+++ b/api/tests/certification/shared/unit/domain/models/FlashAssessmentAlgorithmConfiguration_test.js
@@ -11,7 +11,9 @@ describe('Unit | Domain | Models | FlashAssessmentAlgorithmConfiguration', funct
       enablePassageByAllCompetences: false,
       variationPercent: 0.2,
       defaultCandidateCapacity: -3,
+      defaultProbabilityToPickChallenge: 100,
     };
+
     context('maximumAssessmentLength', function () {
       it('should throw an EntityValidationError if it is missing', function () {
         // given
@@ -94,6 +96,16 @@ describe('Unit | Domain | Models | FlashAssessmentAlgorithmConfiguration', funct
     });
 
     context('limitToOneQuestionPerTube', function () {
+      it('should throw an EntityValidationError if it is missing', function () {
+        // given
+        delete params.limitToOneQuestionPerTube;
+
+        // when
+        const err = catchErrSync(() => new FlashAssessmentAlgorithmConfiguration(params))();
+
+        // then
+        expect(err).to.be.an.instanceOf(EntityValidationError);
+      });
       it('should throw an EntityValidationError if it is not a boolean', function () {
         // given
         params.limitToOneQuestionPerTube = 'string';
@@ -107,6 +119,16 @@ describe('Unit | Domain | Models | FlashAssessmentAlgorithmConfiguration', funct
     });
 
     context('enablePassageByAllCompetences', function () {
+      it('should throw an EntityValidationError if it is missing', function () {
+        // given
+        delete params.enablePassageByAllCompetences;
+
+        // when
+        const err = catchErrSync(() => new FlashAssessmentAlgorithmConfiguration(params))();
+
+        // then
+        expect(err).to.be.an.instanceOf(EntityValidationError);
+      });
       it('should throw an EntityValidationError if it is not a boolean', function () {
         // given
         params.enablePassageByAllCompetences = 'string';

--- a/api/tests/certification/shared/unit/domain/models/FlashAssessmentAlgorithm_test.js
+++ b/api/tests/certification/shared/unit/domain/models/FlashAssessmentAlgorithm_test.js
@@ -8,6 +8,7 @@ const baseFlashAssessmentAlgorithmConfig = {
   enablePassageByAllCompetences: false,
   defaultCandidateCapacity: -3,
   defaultProbabilityToPickChallenge: 51,
+  variationPercent: 0.5,
 };
 
 describe('Unit | Domain | Models | FlashAssessmentAlgorithm', function () {
@@ -171,6 +172,7 @@ describe('Unit | Domain | Models | FlashAssessmentAlgorithm', function () {
             flashAlgorithmImplementation,
             configuration: _getAlgorithmConfig({
               maximumAssessmentLength: alreadyAnsweredChallengesCount + remainingAnswersToGive,
+              limitToOneQuestionPerTube: false,
             }),
           });
 
@@ -247,6 +249,6 @@ const _getAlgorithmConfig = (options) => {
 };
 
 const _getCapacityAndErrorRateParams = (params) => ({
-  variationPercent: undefined,
+  variationPercent: baseFlashAssessmentAlgorithmConfig.variationPercent,
   ...params,
 });

--- a/api/tests/certification/shared/unit/domain/models/Version_test.js
+++ b/api/tests/certification/shared/unit/domain/models/Version_test.js
@@ -1,3 +1,4 @@
+import { FlashAssessmentAlgorithmConfiguration } from '../../../../../../src/certification/shared/domain/models/FlashAssessmentAlgorithmConfiguration.js';
 import { Scopes } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
 import { Version } from '../../../../../../src/certification/shared/domain/models/Version.js';
 import { EntityValidationError } from '../../../../../../src/shared/domain/errors.js';
@@ -10,12 +11,15 @@ describe('Unit | Certification | Evaluation | Domain | Models | Version', functi
       const versionData = {
         id: 123,
         scope: Scopes.CORE,
-        challengesConfiguration: {
+        challengesConfiguration: new FlashAssessmentAlgorithmConfiguration({
           challengesBetweenSameCompetence: 0,
           maximumAssessmentLength: 10,
           defaultCandidateCapacity: 1,
           defaultProbabilityToPickChallenge: 51,
-        },
+          limitToOneQuestionPerTube: false,
+          enablePassageByAllCompetences: false,
+          variationPercent: 0.5,
+        }),
       };
 
       // when
@@ -25,12 +29,17 @@ describe('Unit | Certification | Evaluation | Domain | Models | Version', functi
       expect(version).to.be.instanceOf(Version);
       expect(version.id).to.equal(123);
       expect(version.scope).to.equal(Scopes.CORE);
-      expect(version.challengesConfiguration).to.deep.equal({
-        challengesBetweenSameCompetence: 0,
-        maximumAssessmentLength: 10,
-        defaultCandidateCapacity: 1,
-        defaultProbabilityToPickChallenge: 51,
-      });
+      expect(version.challengesConfiguration).to.deep.equal(
+        new FlashAssessmentAlgorithmConfiguration({
+          challengesBetweenSameCompetence: 0,
+          maximumAssessmentLength: 10,
+          defaultCandidateCapacity: 1,
+          defaultProbabilityToPickChallenge: 51,
+          limitToOneQuestionPerTube: false,
+          enablePassageByAllCompetences: false,
+          variationPercent: 0.5,
+        }),
+      );
     });
 
     it('should build a Version with PIX_PLUS_DROIT scope', function () {
@@ -38,12 +47,15 @@ describe('Unit | Certification | Evaluation | Domain | Models | Version', functi
       const versionData = {
         id: 456,
         scope: Scopes.PIX_PLUS_DROIT,
-        challengesConfiguration: {
+        challengesConfiguration: new FlashAssessmentAlgorithmConfiguration({
           challengesBetweenSameCompetence: 0,
           maximumAssessmentLength: 10,
           defaultCandidateCapacity: -3,
           defaultProbabilityToPickChallenge: 51,
-        },
+          limitToOneQuestionPerTube: false,
+          enablePassageByAllCompetences: false,
+          variationPercent: 0.5,
+        }),
       };
 
       // when
@@ -53,12 +65,17 @@ describe('Unit | Certification | Evaluation | Domain | Models | Version', functi
       expect(version).to.be.instanceOf(Version);
       expect(version.id).to.equal(456);
       expect(version.scope).to.equal(Scopes.PIX_PLUS_DROIT);
-      expect(version.challengesConfiguration).to.deep.equal({
-        challengesBetweenSameCompetence: 0,
-        maximumAssessmentLength: 10,
-        defaultCandidateCapacity: -3,
-        defaultProbabilityToPickChallenge: 51,
-      });
+      expect(version.challengesConfiguration).to.deep.equal(
+        new FlashAssessmentAlgorithmConfiguration({
+          challengesBetweenSameCompetence: 0,
+          maximumAssessmentLength: 10,
+          defaultCandidateCapacity: -3,
+          defaultProbabilityToPickChallenge: 51,
+          limitToOneQuestionPerTube: false,
+          enablePassageByAllCompetences: false,
+          variationPercent: 0.5,
+        }),
+      );
     });
 
     it('should throw an EntityValidationError when id is missing', function () {


### PR DESCRIPTION
## ❄️ Problème

Certains attributs de `FlashAssessmentAlgorithmConfiguration` ne sont pas required.

## 🛷 Proposition

Afin de finir la refacto de `FlashAssessmentAlgorithmConfiguration`, rendre tous les attributs required et sans valeur par défaut.

## ☃️ Remarques

On en profite aussi pour modifer `Version` (domaine `certification/evaluation`) afin qu'il attende une instance de `FlashAssessmentAlgorithmConfiguration` pour l'attribut `challengeConfiguration`.

## 🧑‍🎄 Pour tester

Non régression sur le passage d'une certification
