### PR TITLE
[BUGFIX] Corrige l'identifiant du créateur des campagnes dans le csv exporté depuis les schémas de parcours.

### DIFF
--- a/admin/app/components/combined-course-blueprints/list-summary-items.gjs
+++ b/admin/app/components/combined-course-blueprints/list-summary-items.gjs
@@ -26,7 +26,7 @@ export default class CombineCourseBluePrintList extends Component {
       });
       const exportedData = [
         ['Identifiant des organisations*', 'Identifiant du createur des campagnes*', 'Json configuration for quest*'],
-        ['', this.currentUser.adminMember.id, jsonParsed],
+        ['', this.currentUser.adminMember.userId.toString(), jsonParsed],
       ];
 
       const csvContent = exportedData


### PR DESCRIPTION
## ❄️ Problème

L'identifiant de créateur de campagnes valorisé dans le fichier CSV d'un schéma de parcours combiné ne correspond à aucun identifiant d'utilisateur.
<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

## 🛷 Proposition

Après analyse, l'erreur vient du fait qu'on valorisait l'identifiant de créateur de campagnes avec l'identifiant de la ressource `AdminUser`.
Il faut utiliser la propriété `userId` de la ressource en question.


<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## ☃️ Remarques

Le `userId` étant un number, il faut le convertir en string lors de la création du CSV.

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🧑‍🎄 Pour tester

Se rendre dans la page des schémas de parcours combinés sur Pix Admin.
Télécharger un fichier CSV d'un des schémas.
Vérifier dans le fichier que l'identifiant de créateur de campagnes correspond à l'identifiant de l'utilisateur connecté.

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
