### PR TITLE
[BUGFIX] Autoriser le rôle métier à accéder à la page de détails d'une certification (PIX-20949).

### DIFF
--- a/admin/app/components/sessions/certifications/list.gjs
+++ b/admin/app/components/sessions/certifications/list.gjs
@@ -2,12 +2,16 @@ import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
 import PixTable from '@1024pix/pix-ui/components/pix-table';
 import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
 import { LinkTo } from '@ember/routing';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 import sortBy from 'lodash/sortBy';
 
 import CertificationStatus from './status';
+
 export default class CertificationsHeader extends Component {
+  @service accessControl;
+
   get sortedCertificationJurySummaries() {
     return sortBy(
       this.args.juryCertificationSummaries,
@@ -28,9 +32,13 @@ export default class CertificationsHeader extends Component {
               {{t "pages.certifications.table.headers.id"}}
             </:header>
             <:cell>
-              <LinkTo @route="authenticated.sessions.certification.informations" @model={{certification.id}}>
+              {{#if this.accessControl.hasAccessToCertificationDetailLinks}}
+                <LinkTo @route="authenticated.sessions.certification.informations" @model={{certification.id}}>
+                  {{certification.id}}
+                </LinkTo>
+              {{else}}
                 {{certification.id}}
-              </LinkTo>
+              {{/if}}
             </:cell>
           </PixTableColumn>
           <PixTableColumn @context={{context}}>

--- a/admin/app/components/users/user-certification-courses.gjs
+++ b/admin/app/components/users/user-certification-courses.gjs
@@ -8,6 +8,7 @@ import formatDate from 'ember-intl/helpers/format-date';
 
 export default class UserCertificationCourses extends Component {
   @service intl;
+  @service accessControl;
 
   <template>
     <header class="page-section__header">
@@ -28,9 +29,13 @@ export default class UserCertificationCourses extends Component {
               {{t "components.users.certification-centers.certification-courses.table-headers.id"}}
             </:header>
             <:cell>
-              <LinkTo @route="authenticated.sessions.certification.informations" @model={{certificationCourse.id}}>
+              {{#if this.accessControl.hasAccessToCertificationDetailLinks}}
+                <LinkTo @route="authenticated.sessions.certification.informations" @model={{certificationCourse.id}}>
+                  {{certificationCourse.id}}
+                </LinkTo>
+              {{else}}
                 {{certificationCourse.id}}
-              </LinkTo>
+              {{/if}}
             </:cell>
           </PixTableColumn>
           <PixTableColumn @context={{context}}>

--- a/admin/app/services/access-control.js
+++ b/admin/app/services/access-control.js
@@ -79,4 +79,12 @@ export default class AccessControlService extends Service {
   get hasAccessToDetachChildOrganizationScope() {
     return !!this.currentUser.adminMember.isSuperAdmin;
   }
+
+  get hasAccessToCertificationDetailLinks() {
+    return !!(
+      this.currentUser.adminMember.isSuperAdmin ||
+      this.currentUser.adminMember.isSupport ||
+      this.currentUser.adminMember.isCertif
+    );
+  }
 }

--- a/admin/tests/integration/components/sessions/certifications/list-test.gjs
+++ b/admin/tests/integration/components/sessions/certifications/list-test.gjs
@@ -15,6 +15,9 @@ module('Integration | Component | certifications/list', function (hooks) {
 
   test('should display number of certification issue reports with required action', async function (assert) {
     // given
+    const currentUser = this.owner.lookup('service:currentUser');
+    currentUser.adminMember = { isSuperAdmin: true };
+
     const juryCertificationSummaries = [
       store.createRecord('jury-certification-summary', {
         id: '1',
@@ -38,6 +41,9 @@ module('Integration | Component | certifications/list', function (hooks) {
 
   test('should display the complementary certification', async function (assert) {
     // given
+    const currentUser = this.owner.lookup('service:currentUser');
+    currentUser.adminMember = { isSuperAdmin: true };
+
     const juryCertificationSummaries = [
       store.createRecord('jury-certification-summary', {
         certificationObtained: 'Pix+ Droit',
@@ -54,5 +60,56 @@ module('Integration | Component | certifications/list', function (hooks) {
 
     // then
     assert.dom(screen.getByText('Pix+ Droit', { exact: false })).exists();
+  });
+
+  module('when user has a SuperAdmin, Certif or Support role', function () {
+    test('it displays certification IDs as clickable links', async function (assert) {
+      // given
+      const currentUser = this.owner.lookup('service:currentUser');
+      currentUser.adminMember = { isSuperAdmin: true };
+
+      const juryCertificationSummaries = [
+        store.createRecord('jury-certification-summary', {
+          id: '1234',
+        }),
+      ];
+      const pagination = {};
+
+      // when
+      const screen = await render(
+        <template>
+          <List @juryCertificationSummaries={{juryCertificationSummaries}} @pagination={{pagination}} />
+        </template>,
+      );
+
+      // then
+      assert.dom(screen.getByRole('link', { name: '1234' })).exists();
+    });
+  });
+
+  module('when user has a metier role', function () {
+    test('it displays certification IDs as plain text', async function (assert) {
+      // given
+      const currentUser = this.owner.lookup('service:currentUser');
+      currentUser.adminMember = { isMetier: true };
+
+      const juryCertificationSummaries = [
+        store.createRecord('jury-certification-summary', {
+          id: '1234',
+        }),
+      ];
+      const pagination = {};
+
+      // when
+      const screen = await render(
+        <template>
+          <List @juryCertificationSummaries={{juryCertificationSummaries}} @pagination={{pagination}} />
+        </template>,
+      );
+
+      // then
+      assert.dom(screen.getByText('1234')).exists();
+      assert.dom(screen.queryByRole('link', { name: '1234' })).doesNotExist();
+    });
   });
 });

--- a/admin/tests/integration/components/users/user-certification-courses-test.gjs
+++ b/admin/tests/integration/components/users/user-certification-courses-test.gjs
@@ -21,7 +21,7 @@ module('Integration | Component | Users | User certification courses', function 
     sinon.stub(serviceRouter, 'currentRoute').value({ parent: { params: { user_id: userId } } });
   });
 
-  module('When user has no certification course', function () {
+  module('when user has no certification course', function () {
     test('displays a title and an info', async function (assert) {
       // given
       const certificationCourses = [];
@@ -46,49 +46,89 @@ module('Integration | Component | Users | User certification courses', function 
     });
   });
 
-  module('When user has certification courses', function () {
-    test('displays a table with a table of certification courses', async function (assert) {
-      // given
-      const certificationCourse = store.createRecord('user-certification-course', {
-        id: '1',
-        sessionId: 23,
-        createdAt: new Date('2025-04-01'),
-        isPublished: true,
+  module('when user has certification courses', function () {
+    module('when user has a SuperAdmin, Certif or Support role', function () {
+      test('displays a table with a table of certification courses', async function (assert) {
+        // given
+        const currentUser = this.owner.lookup('service:currentUser');
+        currentUser.adminMember = { isSuperAdmin: true };
+
+        const certificationCourse = store.createRecord('user-certification-course', {
+          id: '1',
+          sessionId: 23,
+          createdAt: new Date('2025-04-01'),
+          isPublished: true,
+        });
+        const certificationCourse2 = store.createRecord('user-certification-course', {
+          id: '2',
+          sessionId: 24,
+          createdAt: new Date('2025-04-02'),
+          isPublished: false,
+        });
+        const certificationCourseCreatedAt = intl.formatDate(certificationCourse.createdAt);
+
+        const certificationCourses = [certificationCourse, certificationCourse2];
+
+        // when
+        const screen = await render(
+          <template><UserCertificationCourses @certificationCourses={{certificationCourses}} /></template>,
+        );
+
+        // then
+        assert
+          .dom(
+            screen.getByRole('heading', {
+              name: t('components.users.certification-centers.certification-courses.section-title'),
+            }),
+          )
+          .exists();
+
+        const idCell = screen.getByRole('cell', { name: certificationCourse.id });
+        assert.dom(within(idCell).getByRole('link', { name: certificationCourse.id })).exists();
+
+        assert.dom(screen.getByRole('cell', { name: certificationCourseCreatedAt })).exists();
+
+        const sessionIdCell = screen.getByRole('cell', { name: certificationCourse.sessionId });
+        assert.dom(within(sessionIdCell).getByRole('link', { name: certificationCourse.sessionId })).exists();
+
+        assert.dom(screen.getByRole('cell', { name: t('pages.certifications.session-state.published') })).exists();
+        assert.dom(screen.getByRole('cell', { name: t('pages.certifications.session-state.not-published') })).exists();
       });
-      const certificationCourse2 = store.createRecord('user-certification-course', {
-        id: '2',
-        sessionId: 24,
-        createdAt: new Date('2025-04-02'),
-        isPublished: false,
+    });
+
+    module('when user has a metier role', function () {
+      test('it displays certification IDs as plain text and session IDs as links', async function (assert) {
+        // given
+        const currentUser = this.owner.lookup('service:currentUser');
+        currentUser.adminMember = { isMetier: true };
+
+        const certificationCourse = store.createRecord('user-certification-course', {
+          id: '1234',
+          sessionId: 5678,
+          createdAt: new Date('2025-04-01'),
+          isPublished: true,
+        });
+        const certificationCourseCreatedAt = intl.formatDate(certificationCourse.createdAt);
+
+        const certificationCourses = [certificationCourse];
+
+        // when
+        const screen = await render(
+          <template><UserCertificationCourses @certificationCourses={{certificationCourses}} /></template>,
+        );
+
+        // then
+        const idCell = screen.getByRole('cell', { name: '1234' });
+        assert.dom(within(idCell).queryByRole('link')).doesNotExist();
+        assert.dom(idCell).hasText('1234');
+
+        assert.dom(screen.getByRole('cell', { name: certificationCourseCreatedAt })).exists();
+
+        const sessionIdCell = screen.getByRole('cell', { name: '5678' });
+        assert.dom(within(sessionIdCell).getByRole('link', { name: '5678' })).exists();
+
+        assert.dom(screen.getByRole('cell', { name: t('pages.certifications.session-state.published') })).exists();
       });
-      const certificationCourseCreatedAt = intl.formatDate(certificationCourse.createdAt);
-
-      const certificationCourses = [certificationCourse, certificationCourse2];
-
-      // when
-      const screen = await render(
-        <template><UserCertificationCourses @certificationCourses={{certificationCourses}} /></template>,
-      );
-
-      // then
-      assert
-        .dom(
-          screen.getByRole('heading', {
-            name: t('components.users.certification-centers.certification-courses.section-title'),
-          }),
-        )
-        .exists();
-
-      const idCell = screen.getByRole('cell', { name: certificationCourse.id });
-      assert.dom(within(idCell).getByRole('link', { name: certificationCourse.id })).exists();
-
-      assert.dom(screen.getByRole('cell', { name: certificationCourseCreatedAt })).exists();
-
-      const sessionIdCell = screen.getByRole('cell', { name: certificationCourse.sessionId });
-      assert.dom(within(sessionIdCell).getByRole('link', { name: certificationCourse.sessionId })).exists();
-
-      assert.dom(screen.getByRole('cell', { name: t('pages.certifications.session-state.published') })).exists();
-      assert.dom(screen.getByRole('cell', { name: t('pages.certifications.session-state.not-published') })).exists();
     });
   });
 });

--- a/admin/tests/unit/services/access-control-test.js
+++ b/admin/tests/unit/services/access-control-test.js
@@ -358,4 +358,24 @@ module('Unit | Service | access-control', function (hooks) {
       });
     });
   });
+
+  module('#hasAccessToCertificationDetailLinks', function () {
+    [
+      { role: 'isSuperAdmin', hasAccess: true },
+      { role: 'isSupport', hasAccess: true },
+      { role: 'isCertif', hasAccess: true },
+      { role: 'isMetier', hasAccess: false },
+    ].forEach(function ({ role, hasAccess }) {
+      test(`should be ${hasAccess} if current admin member is ${role}`, function (assert) {
+        // given
+        const currentUser = this.owner.lookup('service:currentUser');
+        currentUser.adminMember = { [role]: true };
+
+        const service = this.owner.lookup('service:access-control');
+
+        // when / then
+        assert.deepEqual(service.hasAccessToCertificationDetailLinks, hasAccess);
+      });
+    });
+  });
 });

--- a/api/src/certification/results/application/user-route.js
+++ b/api/src/certification/results/application/user-route.js
@@ -17,6 +17,7 @@ const register = async function (server) {
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleCertif,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
+                securityPreHandlers.checkAdminMemberHasRoleMetier,
               ])(request, h),
             assign: 'hasAuthorizationToAccessAdminScope',
           },
@@ -28,7 +29,7 @@ const register = async function (server) {
         },
         handler: userController.findAllCertificationCourses,
         notes: [
-          '- **Cette route est restreinte aux utilisateurs authentifiés sur PixAdmin avec le rôle Super Admin, Certif et Support',
+          '- **Cette route est restreinte aux utilisateurs authentifiés sur PixAdmin avec le rôle SuperAdmin, Certif, Support et Métier',
           "- Récupération de liste des passages en certification d'un utilisateur spécifique",
         ],
         tags: ['api', 'admin', 'user', 'certification-courses'],


### PR DESCRIPTION
## ❄️ Problème

Les utilisateurs ayant un rôle métier sur PixAdmin n'ont pas accès à la liste des certifications d'un utilisateur spécifique.

## 🛷 Proposition

- Le rôle métier peut accéder à l'onglet "Certifications" dans la page "Utilisateur"
- En revanche, il faut désactiver les liens qui mènent vers le détail de chaque certification (en cliquant sur les ID en bleu) pour éviter qu'ils aient accès aux DP des candidats.

## ☃️ Remarques

Nous profitons de la PR pour aussi ne plus avoir de lien vers le détail des certifs dans l'onglet "Certifications" d'une session.

## 🧑‍🎄 Pour tester

- Se connecter sur [PixAdmin](https://admin-pr14520.review.pix.fr/users/7101) avec `metieradmin@example.net`
- ✅  Vérifier que l'utilisateur `7101` a bien une liste de certifications mais qu'aucun lien n'est cliquable.
- ✅  Vérifier la même chose pour la [liste des certifs de la session](https://admin-pr14520.review.pix.fr/sessions/7403/certifications) `7403`.

Enfin, **tester ensuite avec un autre rôle** pour vérifier que les liens vers les certifs sont bien actifs.
