### PR TITLE
[TECH] Corriger un problème de reload dans les tests front sur Pix Admin sous Firefox

### DIFF
--- a/admin/app/components/autonomous-courses/new/index.gjs
+++ b/admin/app/components/autonomous-courses/new/index.gjs
@@ -56,6 +56,7 @@ export default class NewAutonomousCourse extends Component {
 
   @action
   async onSubmit(event) {
+    event.preventDefault();
     const autonomousCourse = {
       internalTitle: this.args.autonomousCourse.internalTitle,
       publicTitle: this.args.autonomousCourse.publicTitle,
@@ -64,7 +65,7 @@ export default class NewAutonomousCourse extends Component {
     };
     try {
       this.submitting = true;
-      await this.args.onSubmit(event, autonomousCourse);
+      await this.args.onSubmit(autonomousCourse);
     } finally {
       this.submitting = false;
     }

--- a/admin/app/controllers/authenticated/autonomous-courses/new.js
+++ b/admin/app/controllers/authenticated/autonomous-courses/new.js
@@ -18,8 +18,7 @@ export default class NewController extends Controller {
   }
 
   @action
-  async createAutonomousCourse(event, autonomousCourse) {
-    event.preventDefault();
+  async createAutonomousCourse(autonomousCourse) {
     try {
       const { id: autonomousCourseId } = await this.store.createRecord('autonomous-course', autonomousCourse).save();
       this.pixToast.sendSuccessNotification({ message: 'Le parcours autonome a été créé avec succès.' });

--- a/admin/tests/unit/controllers/authenticated/autonomous-courses/new-test.js
+++ b/admin/tests/unit/controllers/authenticated/autonomous-courses/new-test.js
@@ -61,12 +61,8 @@ module('Unit | Controller | authenticated/autonomous-courses/new', function (hoo
         sendSuccessNotification: sinon.stub(),
       };
 
-      const event = {
-        preventDefault: sinon.stub(),
-      };
-
       // when
-      await controller.createAutonomousCourse(event, autonomousCourse);
+      await controller.createAutonomousCourse(autonomousCourse);
 
       // then
       assert.ok(saveStub.called);
@@ -93,12 +89,8 @@ module('Unit | Controller | authenticated/autonomous-courses/new', function (hoo
 
       controller.store.createRecord = sinon.stub().returns({ save: saveStub });
 
-      const event = {
-        preventDefault: sinon.stub(),
-      };
-
       // when
-      await controller.createAutonomousCourse(event, autonomousCourse);
+      await controller.createAutonomousCourse(autonomousCourse);
 
       // then
       assert.ok(saveStub.called);
@@ -122,12 +114,8 @@ module('Unit | Controller | authenticated/autonomous-courses/new', function (hoo
 
       controller.store.createRecord = sinon.stub().returns({ save: saveStub });
 
-      const event = {
-        preventDefault: sinon.stub(),
-      };
-
       // when
-      await controller.createAutonomousCourse(event, autonomousCourse);
+      await controller.createAutonomousCourse(autonomousCourse);
 
       // then
       assert.ok(saveStub.called);
@@ -147,12 +135,9 @@ module('Unit | Controller | authenticated/autonomous-courses/new', function (hoo
       };
       const saveStub = sinon.stub().rejects(errors);
       controller.store.createRecord = sinon.stub().returns({ save: saveStub });
-      const event = {
-        preventDefault: sinon.stub(),
-      };
 
       // when
-      await controller.createAutonomousCourse(event, autonomousCourse);
+      await controller.createAutonomousCourse(autonomousCourse);
 
       // then
       assert.ok(saveStub.called);
@@ -180,12 +165,8 @@ module('Unit | Controller | authenticated/autonomous-courses/new', function (hoo
 
       controller.store.createRecord = sinon.stub().returns({ save: saveStub });
 
-      const event = {
-        preventDefault: sinon.stub(),
-      };
-
       // when
-      await controller.createAutonomousCourse(event, autonomousCourse);
+      await controller.createAutonomousCourse(autonomousCourse);
 
       // then
       assert.ok(saveStub.called);


### PR DESCRIPTION
## ❄️ Problème

En local, sous Firefox, lorsqu'on exécute les tests de Pix Admin dans le navigateur, le processus s'arrête et se relance du début aux alentours du 470è test. La cause du problème avait déjà été identifiée par @bpetetot et @La-toile-cosmique mais pas encore adressé. C'est dû au manque d'un `event.preventDefault()` dans une soumission de formulaire. Ce manque est toléré dans les tests par Chrome mais pas par Firefox.

## 🛷 Proposition

Ajouter ce `preventDefault` manquant dans le composant et le supprimer du controller.

## ☃️ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🧑‍🎄 Pour tester

CI au vert.
Sur Pix Admin:
- sur la page **Parcours autonomes**
- vérifier qu'il est toujours possible de créer un nouveau **Parcours autonome**
- tester sur Firefox et Chrome
- dans l'idéal, cloner la branche en local, lancer les tests de Pix Admin dans Firefox (http://localhost:4202/tests) et vérifier que le processus va bien jusqu'au bout
