### PR TITLE
[TECH] Migrer le singleton oidcAuthenticationServiceRegistry de api/lib/domain/usecases/index.js  vers src/ (PIX-20960)

### DIFF
--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -1,9 +1,0 @@
-import { OidcAuthenticationServiceRegistry } from '../../../src/identity-access-management/domain/services/oidc-authentication-service-registry.js';
-import * as oidcProviderRepository from '../../../src/identity-access-management/infrastructure/repositories/oidc-provider-repository.js';
-// userRepo should be import to avoid circular dependency
-//eslint-disable-next-line no-unused-vars
-import * as userRepository from '../../../src/identity-access-management/infrastructure/repositories/user.repository.js';
-
-const oidcAuthenticationServiceRegistry = new OidcAuthenticationServiceRegistry({ oidcProviderRepository });
-
-export { oidcAuthenticationServiceRegistry };

--- a/api/src/identity-access-management/application/oidc-provider/oidc-provider.admin.controller.js
+++ b/api/src/identity-access-management/application/oidc-provider/oidc-provider.admin.controller.js
@@ -1,6 +1,5 @@
-import { oidcAuthenticationServiceRegistry } from '../../../../lib/domain/usecases/index.js';
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
-import { usecases } from '../../domain/usecases/index.js';
+import { oidcAuthenticationServiceRegistry, usecases } from '../../domain/usecases/index.js';
 import * as oidcProviderSerializer from '../../infrastructure/serializers/jsonapi/oidc-identity-providers.serializer.js';
 import { getForwardedOrigin, RequestedApplication } from '../../infrastructure/utils/network.js';
 

--- a/api/src/identity-access-management/domain/usecases/index.js
+++ b/api/src/identity-access-management/domain/usecases/index.js
@@ -1,4 +1,6 @@
-import { oidcAuthenticationServiceRegistry } from '../../../../lib/domain/usecases/index.js';
+// eslint-disable-next-line simple-import-sort/imports -- import userRepository first to avoid circular dependency ("Cannot access 'campaignRepositories' before initialization")
+import * as userRepository from '../../infrastructure/repositories/user.repository.js';
+
 import * as centerRepository from '../../../certification/enrolment/infrastructure/repositories/center-repository.js';
 import * as userRecommendedTrainingRepository from '../../../devcomp/infrastructure/repositories/user-recommended-training-repository.js';
 import * as campaignRepository from '../../../prescription/campaign/infrastructure/repositories/campaign-repository.js';
@@ -39,15 +41,17 @@ import * as privacyUsersApiRepository from '../../infrastructure/repositories/pr
 import { refreshTokenRepository } from '../../infrastructure/repositories/refresh-token.repository.js';
 import { resetPasswordDemandRepository } from '../../infrastructure/repositories/reset-password-demand.repository.js';
 import { revokedUserAccessRepository } from '../../infrastructure/repositories/revoked-user-access.repository.js';
-import * as userRepository from '../../infrastructure/repositories/user.repository.js';
 import { userEmailRepository } from '../../infrastructure/repositories/user-email.repository.js';
 import { userToCreateRepository } from '../../infrastructure/repositories/user-to-create.repository.js';
 import { authenticationSessionService } from '../services/authentication-session.service.js';
+import { OidcAuthenticationServiceRegistry } from '../services/oidc-authentication-service-registry.js';
 import * as passwordGeneratorService from '../services/password-generator.service.js';
 import { pixAuthenticationService } from '../services/pix-authentication-service.js';
 import { resetPasswordService } from '../services/reset-password.service.js';
 import { scoAccountRecoveryService } from '../services/sco-account-recovery.service.js';
 import { addOidcProviderValidator } from '../validators/add-oidc-provider.validator.js';
+
+const oidcAuthenticationServiceRegistry = new OidcAuthenticationServiceRegistry({ oidcProviderRepository });
 
 const repositories = {
   accountRecoveryDemandRepository,
@@ -68,6 +72,7 @@ const repositories = {
   legalDocumentApiRepository,
   ltiPlatformRegistrationRepository,
   membershipRepository,
+  oidcAuthenticationServiceRegistry,
   oidcProviderRepository,
   organizationLearnerRepository,
   organizationRepository,
@@ -227,4 +232,4 @@ const usecasesWithoutInjectedDependencies = {
 
 const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);
 
-export { usecases };
+export { oidcAuthenticationServiceRegistry, usecases };

--- a/api/tests/identity-access-management/integration/application/oidc-provider.route.test.js
+++ b/api/tests/identity-access-management/integration/application/oidc-provider.route.test.js
@@ -1,6 +1,5 @@
 import jsonwebtoken from 'jsonwebtoken';
 
-import { oidcAuthenticationServiceRegistry } from '../../../../lib/domain/usecases/index.js';
 import { oidcProviderController } from '../../../../src/identity-access-management/application/oidc-provider/oidc-provider.controller.js';
 import { identityAccessManagementRoutes } from '../../../../src/identity-access-management/application/routes.js';
 import {
@@ -8,6 +7,7 @@ import {
   DifferentExternalIdentifierError,
 } from '../../../../src/identity-access-management/domain/errors.js';
 import { authenticationSessionService } from '../../../../src/identity-access-management/domain/services/authentication-session.service.js';
+import { oidcAuthenticationServiceRegistry } from '../../../../src/identity-access-management/domain/usecases/index.js';
 import { UserNotFoundError } from '../../../../src/shared/domain/errors.js';
 import { databaseBuilder, expect, HttpTestServer, sinon } from '../../../test-helper.js';
 

--- a/api/tests/identity-access-management/integration/domain/usecases/get-ready-identity-providers.usecase.test.js
+++ b/api/tests/identity-access-management/integration/domain/usecases/get-ready-identity-providers.usecase.test.js
@@ -1,6 +1,8 @@
-import { oidcAuthenticationServiceRegistry } from '../../../../../lib/domain/usecases/index.js';
 import { OidcAuthenticationService } from '../../../../../src/identity-access-management/domain/services/oidc-authentication-service.js';
-import { usecases } from '../../../../../src/identity-access-management/domain/usecases/index.js';
+import {
+  oidcAuthenticationServiceRegistry,
+  usecases,
+} from '../../../../../src/identity-access-management/domain/usecases/index.js';
 import { RequestedApplication } from '../../../../../src/identity-access-management/infrastructure/utils/network.js';
 import { databaseBuilder, expect } from '../../../../test-helper.js';
 

--- a/api/tests/tooling/openid-client/openid-client-mocks.js
+++ b/api/tests/tooling/openid-client/openid-client-mocks.js
@@ -1,5 +1,5 @@
-import { oidcAuthenticationServiceRegistry } from '../../../lib/domain/usecases/index.js';
 import { OidcAuthenticationService } from '../../../src/identity-access-management/domain/services/oidc-authentication-service.js';
+import { oidcAuthenticationServiceRegistry } from '../../../src/identity-access-management/domain/usecases/index.js';
 import { sinon } from '../../test-helper.js';
 
 const clientId = 'client';


### PR DESCRIPTION
## ❄️ Problème

Il y a encore quelques fichiers dans `lib/`, et notamment `api/lib/domain/usecases/index.js` qui contient le singleton `oidcAuthenticationServiceRegistry`.

## 🛷 Proposition

1. Déplacement du singleton `oidcAuthenticationServiceRegistry` de `api/lib/domain/usecases/index.js` vers `api/src/identity-access-management/domain/usecases/index.js`
2. Mise en première position de l’import du `userRepository` se trouvant `api/src/identity-access-management/domain/usecases/index.js` pour éviter un problème de dépendance circulaire avec `campaignRepositories`
3. Mise en place d’une instruction ESLint pour maintenir l’import du `userRepository` en 1ère position
4. Suppression du fichier `api/lib/domain/usecases/index.js`  (enfin ! 😃)

C’est l’instruction `eslint-disable-next-line simple-import-sort/imports` (la mieux adaptée) qui est utilisée pour que l’import de `userRepository` soit ignoré par le tri des imports réalisé par le plugin [`eslint-plugin-simple-import-sort`](https://www.npmjs.com/package/eslint-plugin-simple-import-sort) : 
https://github.com/lydell/eslint-plugin-simple-import-sort/blob/main/examples/ignore.js
 
## ☃️ Remarques

RAS

## 🧑‍🎄 Pour tester

### Dans les RA

* Constater que Pix App est bien démarrée et qu’on peut s’y authentifier par login/mot de passe
* Constater que Pix Orga est bien démarrée et qu’on peut s’y authentifier par login/mot de passe
* Constater que Pix Admin est bien démarrée et qu’on peut s’y authentifier par login/mot de passe

### En local avec les OIDC Providers chargés

* Constater que Pix App est bien démarrée et qu’on peut s’y authentifier par SSO OIDC
* Constater que Pix Orga est bien démarrée et qu’on peut s’y authentifier par SSO OIDC
* Constater que Pix Admin est bien démarrée et qu’on peut s’y authentifier par SSO OIDC
