### PR TITLE
[FEATURE] Mettre en place une validation plus spécifique sur le formulaire de création d'organisation (PIX-20697)

### DIFF
--- a/admin/app/components/organizations/creation-form.gjs
+++ b/admin/app/components/organizations/creation-form.gjs
@@ -81,10 +81,13 @@ export default class OrganizationCreationForm extends Component {
   }
 
   handleInputChange = (key, event) => {
-    this.form = { ...this.form, [key]: event.target.value };
+    const { value } = event.target;
+    this.validator.validateField(key, value);
+    this.form = { ...this.form, [key]: value };
   };
 
   handleSelectChange = (key, value) => {
+    this.validator.validateField(key, value);
     this.form = { ...this.form, [key]: value };
   };
 

--- a/admin/app/components/organizations/creation-form.gjs
+++ b/admin/app/components/organizations/creation-form.gjs
@@ -126,14 +126,13 @@ export default class OrganizationCreationForm extends Component {
             <PixInput
               @id="organizationName"
               {{on "change" (fn this.handleInputChange "name")}}
-              required={{true}}
-              aria-required={{true}}
               @requiredLabel={{t "common.fields.required-field"}}
               placeholder={{concat
                 (t "common.words.example-abbr")
                 " "
                 (t "components.organizations.creation.name.placeholder")
               }}
+              required={{false}}
               @validationStatus={{if this.validator.errors.name "error"}}
               @errorMessage={{if this.validator.errors.name (t this.validator.errors.name)}}
             >
@@ -147,8 +146,6 @@ export default class OrganizationCreationForm extends Component {
             @placeholder={{t "components.organizations.creation.type.placeholder"}}
             @hideDefaultOption={{true}}
             @value={{this.form.type}}
-            required
-            aria-required={{true}}
             @requiredLabel={{t "common.fields.required-field"}}
             @errorMessage={{if this.validator.errors.type (t this.validator.errors.type)}}
           >
@@ -162,8 +159,6 @@ export default class OrganizationCreationForm extends Component {
             @placeholder={{t "components.organizations.creation.administration-team.selector.placeholder"}}
             @hideDefaultOption={{true}}
             @value={{this.form.administrationTeamId}}
-            required
-            aria-required={{true}}
             @requiredLabel={{t "common.fields.required-field"}}
             @errorMessage={{if
               this.validator.errors.administrationTeamId
@@ -179,8 +174,6 @@ export default class OrganizationCreationForm extends Component {
             @placeholder={{t "components.organizations.creation.country.selector.placeholder"}}
             @hideDefaultOption={{true}}
             @value={{this.form.countryCode}}
-            required
-            @aria-required={{true}}
             @requiredLabel={{t "common.fields.required-field"}}
             @isSearchable={{true}}
             @errorMessage={{if this.validator.errors.countryCode (t this.validator.errors.countryCode)}}

--- a/admin/app/controllers/authenticated/organizations/new.js
+++ b/admin/app/controllers/authenticated/organizations/new.js
@@ -23,15 +23,6 @@ export default class NewController extends Controller {
 
   @action
   async addOrganization(form) {
-    const { name, type, administrationTeamId, countryCode } = form;
-
-    if (!name || !type || !administrationTeamId || !countryCode) {
-      this.pixToast.sendErrorNotification({
-        message: this.intl.t('components.organizations.creation.required-fields-error'),
-      });
-      return;
-    }
-
     const organization = this.store.createRecord('organization', { ...form });
 
     if (this.parentOrganizationId) {

--- a/admin/tests/acceptance/authenticated/organizations/create-organization-test.js
+++ b/admin/tests/acceptance/authenticated/organizations/create-organization-test.js
@@ -141,7 +141,7 @@ module('Acceptance | Organizations | Create', function (hooks) {
       await clickByName(t('common.actions.add'));
 
       // then
-      assert.dom(screen.getByText(t('components.organizations.creation.required-fields-error'))).exists();
+      assert.dom(screen.getByText(t('components.organizations.creation.error-messages.error-toast'))).exists();
     });
   });
 });

--- a/admin/tests/acceptance/authenticated/organizations/create-organization-test.js
+++ b/admin/tests/acceptance/authenticated/organizations/create-organization-test.js
@@ -135,7 +135,6 @@ module('Acceptance | Organizations | Create', function (hooks) {
     test('it shows validation errors if form is not correctly filled', async function (assert) {
       // given
       const screen = await visit('/organizations/new');
-      await fillByLabel(`${t('components.organizations.creation.name.label')} *`, 'Stark Corp.');
 
       // when
       await clickByName(t('common.actions.add'));

--- a/admin/tests/integration/components/organizations/creation-form-test.gjs
+++ b/admin/tests/integration/components/organizations/creation-form-test.gjs
@@ -344,7 +344,7 @@ module('Integration | Component | organizations/creation-form', function (hooks)
     });
 
     module('errors', function () {
-      module('when required fields are not filled (except for name)', function () {
+      module('when required fields are not filled in', function () {
         test('should not submit form', async function (assert) {
           // given
           const handleSubmitStub = sinon.stub();
@@ -359,9 +359,6 @@ module('Integration | Component | organizations/creation-form', function (hooks)
             </template>,
           );
 
-          // name validation cannot be included in the tests because it is handled by native HTML required validation
-          await fillByLabel(`${t('components.organizations.creation.name.label')} *`, 'Organisation de Test');
-
           // when
           await click(screen.getByRole('button', { name: t('common.actions.add') }));
 
@@ -375,19 +372,18 @@ module('Integration | Component | organizations/creation-form', function (hooks)
             <template><CreationForm @administrationTeams={{administrationTeams}} @countries={{countries}} /></template>,
           );
 
-          // name validation cannot be included in the tests because it is handled by native HTML required validation
-          await fillByLabel(`${t('components.organizations.creation.name.label')} *`, 'Organisation de Test');
-
           // when
           await click(screen.getByRole('button', { name: t('common.actions.add') }));
 
           // then
+          const nameErrorMessage = screen.getByText(t('components.organizations.creation.error-messages.name'));
           const typeErrorMessage = screen.getByText(t('components.organizations.creation.error-messages.type'));
           const administrationTeamErrorMessage = screen.getByText(
             t('components.organizations.creation.error-messages.administration-team'),
           );
           const countryErrorMessage = screen.getByText(t('components.organizations.creation.error-messages.country'));
 
+          assert.ok(nameErrorMessage);
           assert.ok(typeErrorMessage);
           assert.ok(administrationTeamErrorMessage);
           assert.ok(countryErrorMessage);
@@ -406,7 +402,6 @@ module('Integration | Component | organizations/creation-form', function (hooks)
             <template><CreationForm @administrationTeams={{administrationTeams}} @countries={{countries}} /></template>,
           );
 
-          await fillByLabel(`${t('components.organizations.creation.name.label')} *`, 'Organisation de Test');
           await fillByLabel(t('components.organizations.creation.documentation-link'), 'non-valid-documentation-url');
           await fillByLabel(`${t('components.organizations.creation.dpo.email')}DPO`, 'non-valid-email');
 

--- a/admin/tests/unit/controllers/authenticated/organizations/new-test.js
+++ b/admin/tests/unit/controllers/authenticated/organizations/new-test.js
@@ -90,32 +90,5 @@ module('Unit | Controller | authenticated/organizations/new', function (hooks) {
         assert.true(findParentOrganizationModelStub.notCalled);
       });
     });
-
-    module('Mandatory fields', function (hooks) {
-      const mandatoryFields = { name: 'New Orga', type: 'SCO', administrationTeamId: '456', countryCode: '99100' };
-
-      const form = {
-        name: mandatoryFields.name,
-        type: mandatoryFields.type,
-        administrationTeamId: mandatoryFields.administrationTeamId,
-        countryCode: mandatoryFields.countryCode,
-      };
-
-      Object.keys(mandatoryFields).forEach(function (mandatoryField) {
-        hooks.afterEach(function () {
-          form[mandatoryField] = mandatoryFields[mandatoryField];
-        });
-        test(`should not create model if ${mandatoryField} property is missing`, async function (assert) {
-          // given
-          form[mandatoryField] = undefined;
-
-          // when
-          await controller.addOrganization(form);
-
-          // then
-          assert.true(createRecordStub.notCalled);
-        });
-      });
-    });
   });
 });

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -712,7 +712,6 @@
         },
         "parent-organization-name": "Parent organization: {parentOrganizationName}",
         "province-code": "Province code (3 digits)",
-        "required-fields-error": "Please fill in all required fields.",
         "type": {
           "label": "Type of the organization",
           "placeholder": "Select one type"

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -691,6 +691,15 @@
           "firstname": "Firstname of ",
           "lastname": "Lastname of "
         },
+        "error-messages": {
+          "administration-team": "Administration team is required",
+          "country": "Country is required",
+          "documentation-url": "The link to the documentation is not in the correct format",
+          "dpo-email": "The email adress is not in the correct format",
+          "error-toast": "Please correct the fields with errors.",
+          "name": "Name is required",
+          "type": "Organization type is required"
+        },
         "external-id": {
           "label": "External Identifier",
           "placeholder": "Specify the UAI, SIRET etc"

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -693,6 +693,15 @@
           "firstname": "Prénom du ",
           "lastname": "Nom du "
         },
+        "error-messages": {
+          "administration-team": "L'équipe en charge est requise",
+          "country": "Le pays est requis",
+          "documentation-url": "Le lien vers la documentation n'est pas au bon format",
+          "dpo-email": "L'adresse e-mail n'est pas au bon format",
+          "error-toast": "Veuillez corriger les champs en erreur.",
+          "name": "Le nom est requis",
+          "type": "Le type d'organisation est requis"
+        },
         "external-id": {
           "label": "Identifiant externe",
           "placeholder": "Spécifier l'UAI, le SIRET etc"

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -714,7 +714,6 @@
         },
         "parent-organization-name": "Organisation mère : {parentOrganizationName}",
         "province-code": "Département (en 3 chiffres)",
-        "required-fields-error": "Veuillez remplir tous les champs obligatoires.",
         "type": {
           "label": "Type de l'organisation",
           "placeholder": "Sélectionner un type"


### PR DESCRIPTION
## ❄️ Problème

Actuellement sur Pix Admin, lorsque le formulaire de création d'organisation n'est pas rempli correctement, on a seulement un message d'erreur générique indiquant: Veuillez remplir les champs obligatoires. De plus il n'y a pas de validation sur le lien vers la documentation (si le format n'est pas une url valide, on a une erreur 422 de l'API) ni sur l'adresse e-mail du DPO.

## 🛷 Proposition

Utiliser le nouveau FormValidator (https://github.com/1024pix/pix/pull/14382) sur le formulaire de création pour afficher un message spécifique sur chaque champ en erreur, et implémenter une validation sur les champs qui en ont besoin (lien vers la documentation et adresse e-mail du DPO)

## ☃️ Remarques

- Le message du toast d'erreur a été modifié pour être plus générique (l'erreur ne vient plus forcément d'un champ requis non rempli)
- Il n'est pas possible de tester dans les tests automatisés, la validation du champ "Nom" obligatoire, car c'est la validation native HTML d'un champ input required qui prend le dessus
- **EDIT**: suite au feedback fonctionnel de @ebarbier, nous avons trouvé un peu gênant d'avoir deux types de messages d'erreur (le message natif du navigateur pour le Nom et nos messages pour les autres champs). Un nouveau commit optionnel a donc été ajouté pour forcer l'attribut HTML `required` à `false` sur le composant `PixInput` du Nom, et ainsi passer outre la validation du navigateur. L'attribut `required` a aussi été supprimé des composants `PixSelect` (inutile car ne s'applique qu'aux input, et le `PixSelect` ne contient pas d'input sous le capot). L'attribut `aria-required` a aussi été supprimé car il faisait doublon avec les labels des champs qui contiennent déjà le mot "obligatoire" (les lecteurs d'écran lisent la description alternative de l'astérisque * symbolisant un champ obligatoire). Voir la doc ici : https://developer.mozilla.org/fr/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-required#exemples

## 🧑‍🎄 Pour tester

Sur Pix Admin, sur la page de création d'organisation:
- tenter de créer une organisation en omettant des champs obligatoires
- remplir les champs _Lien vers la documentation_ et _Adresse e-mail du DPO_ avec des formats non valides
- corriger une fois les erreurs apparues
- constater les différents messages d'erreur
- constater qu'on peut toujours créer une orga quand tout est correctement rempli
