### PR TITLE
[TECH] Ajouter des informations de monitoring supplémentaires sur les appels de l’openIdClient (PIX-20681)

### DIFF
--- a/api/src/identity-access-management/domain/services/oidc-authentication-service.js
+++ b/api/src/identity-access-management/domain/services/oidc-authentication-service.js
@@ -333,9 +333,13 @@ function _monitorOidcError(message, { data, error, event }) {
   };
 
   if (error) {
-    monitoringData.error = { name: error.constructor.name };
-    error.error_uri && Object.assign(monitoringData.error, { errorUri: error.error_uri });
-    error.response && Object.assign(monitoringData.error, { response: error.response });
+    monitoringData.error = {
+      name: error.constructor.name,
+      message: error.message,
+      stack: error.stack,
+      ...(error.error_uri && { errorUri: error.error_uri }),
+      ...(error.response && { response: error.response }),
+    };
   }
 
   logger.error(monitoringData);

--- a/api/src/identity-access-management/domain/services/oidc-authentication-service.js
+++ b/api/src/identity-access-management/domain/services/oidc-authentication-service.js
@@ -129,7 +129,11 @@ export class OidcAuthenticationService {
         metadata,
       );
     } catch (error) {
-      logger.error(`OIDC Provider "${this.identityProvider}" is UNAVAILABLE: ${error}`);
+      _monitorOidcError(`Failed init for OIDC Provider "${this.identityProvider}"`, {
+        data: { organizationName: this.organizationName },
+        error,
+        event: 'initialize-client-config',
+      });
     }
   }
 

--- a/api/tests/identity-access-management/unit/domain/services/oidc-authentication-service.test.js
+++ b/api/tests/identity-access-management/unit/domain/services/oidc-authentication-service.test.js
@@ -242,7 +242,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
       );
     });
 
-    context('when OpenId Client endSessionUrl fails', function () {
+    context('when openIdClient endSessionUrl fails', function () {
       it('throws an error and logs a message in datadog', async function () {
         // given
         const idToken = 'some_dummy_id_token';
@@ -334,7 +334,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
       expect(result).to.deep.equal(oidcAuthenticationSessionContent);
     });
 
-    context('when OpenId Client callback fails', function () {
+    context('when openIdClient callback fails', function () {
       it('throws an error and logs a message in datadog', async function () {
         const clientId = 'clientId';
         const clientSecret = 'clientSecret';
@@ -735,7 +735,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
       });
     });
 
-    context('when OpenId Client userinfo fails', function () {
+    context('when openIdClient userinfo fails', function () {
       it('throws an error and logs a message in datadog', async function () {
         const clientId = 'OIDC_CLIENT_ID';
         const clientSecret = 'OIDC_CLIENT_SECRET';
@@ -1061,7 +1061,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
   });
 
   describe('#initializeClientConfig', function () {
-    it('creates an openid client', async function () {
+    it('creates an openIdClient', async function () {
       // given
       const clientId = 'clientId';
       const clientSecret = 'clientSecret';
@@ -1089,7 +1089,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
       });
     });
 
-    it('creates an openid client with extra metadata', async function () {
+    it('creates an openIdClient with extra metadata', async function () {
       // given
       const clientId = 'clientId';
       const clientSecret = 'clientSecret';

--- a/api/tests/identity-access-management/unit/domain/services/oidc-authentication-service.test.js
+++ b/api/tests/identity-access-management/unit/domain/services/oidc-authentication-service.test.js
@@ -243,7 +243,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
     });
 
     context('when openIdClient endSessionUrl fails', function () {
-      it('throws an error and logs a message in datadog', async function () {
+      it('throws an error and logs monitoring data', async function () {
         // given
         const idToken = 'some_dummy_id_token';
         const userId = 'some_dummy_user_id';
@@ -335,7 +335,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
     });
 
     context('when openIdClient callback fails', function () {
-      it('throws an error and logs a message in datadog', async function () {
+      it('throws an error and logs monitoring data', async function () {
         const clientId = 'clientId';
         const clientSecret = 'clientSecret';
         const identityProvider = 'identityProvider';
@@ -441,7 +441,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
     });
 
     context('when generating the authorization url fails', function () {
-      it('throws an error and logs a message in datadog', async function () {
+      it('throws an error and logs monitoring data', async function () {
         // given
         const clientId = 'clientId';
         const clientSecret = 'clientSecret';
@@ -736,7 +736,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
     });
 
     context('when openIdClient userinfo fails', function () {
-      it('throws an error and logs a message in datadog', async function () {
+      it('throws an error and logs monitoring data', async function () {
         const clientId = 'OIDC_CLIENT_ID';
         const clientSecret = 'OIDC_CLIENT_SECRET';
         const identityProvider = 'identityProvider';

--- a/api/tests/identity-access-management/unit/domain/services/oidc-authentication-service.test.js
+++ b/api/tests/identity-access-management/unit/domain/services/oidc-authentication-service.test.js
@@ -273,7 +273,11 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         expect(logger.error).to.have.been.calledWithExactly({
           context: 'oidc',
           data: { organizationName: 'Oidc Example' },
-          error: { name: errorThrown.name },
+          error: {
+            name: errorThrown.name,
+            message: errorThrown.message,
+            stack: sinon.match.string,
+          },
           event: 'get-redirect-logout-url',
           message: errorThrown.message,
           team: 'acces',
@@ -383,6 +387,8 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
           },
           error: {
             name: errorThrown.name,
+            message: errorThrown.message,
+            stack: sinon.match.string,
             errorUri: '/oauth2/token',
             response: 'api call response here',
           },
@@ -468,7 +474,11 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         expect(logger.error).to.have.been.calledWithExactly({
           context: 'oidc',
           data: { organizationName: 'Oidc Example' },
-          error: { name: errorThrown.name },
+          error: {
+            name: errorThrown.name,
+            message: errorThrown.message,
+            stack: sinon.match.string,
+          },
           event: 'generate-authorization-url',
           message: errorThrown.message,
           team: 'acces',
@@ -759,7 +769,11 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
           message: errorThrown.message,
           context: 'oidc',
           data: { organizationName: 'Oidc Example' },
-          error: { name: errorThrown.name },
+          error: {
+            name: errorThrown.name,
+            message: errorThrown.message,
+            stack: sinon.match.string,
+          },
           event: 'get-user-info-from-endpoint',
           team: 'acces',
         });

--- a/api/tests/identity-access-management/unit/domain/services/oidc-authentication-service.test.js
+++ b/api/tests/identity-access-management/unit/domain/services/oidc-authentication-service.test.js
@@ -1089,7 +1089,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
       });
     });
 
-    it('creates an openid client with extra meatadata', async function () {
+    it('creates an openid client with extra metadata', async function () {
       // given
       const clientId = 'clientId';
       const clientSecret = 'clientSecret';

--- a/mon-pix/app/models/organization-to-join.js
+++ b/mon-pix/app/models/organization-to-join.js
@@ -9,8 +9,4 @@ export default class OrganizationToJoin extends Model {
   @attr('boolean') isReconciliationRequired;
   @attr('boolean') hasReconciliationFields;
   @attr() reconciliationFields;
-
-  isRestrictedByIdentityProvider(identityProviderCode) {
-    return this.identityProvider === identityProviderCode;
-  }
 }

--- a/mon-pix/app/routes/organizations/access.js
+++ b/mon-pix/app/routes/organizations/access.js
@@ -17,13 +17,13 @@ export default class AccessRoute extends Route {
 
   async beforeModel(transition) {
     const { organizationToJoin, verifiedCode } = this.modelFor('organizations');
-    const identityProviderToVisit = this.oidcIdentityProviders.list.find((identityProvider) => {
-      const isUserLoggedInToIdentityProvider =
-        get(this.session, 'data.authenticated.identityProviderCode') === identityProvider.code;
-      return (
-        organizationToJoin.isRestrictedByIdentityProvider(identityProvider.code) && !isUserLoggedInToIdentityProvider
-      );
-    });
+    const organizationToJoinIdentityProviderCode = organizationToJoin.identityProvider;
+    const authenticatedIdentityProviderCode = get(this.session, 'data.authenticated.identityProviderCode');
+    const organizationToJoinIdentityProvider = this.oidcIdentityProviders.findByCode(
+      organizationToJoinIdentityProviderCode,
+    );
+    const identityProviderToVisit =
+      authenticatedIdentityProviderCode != organizationToJoinIdentityProviderCode && organizationToJoinIdentityProvider;
 
     this.authenticationRoute = 'inscription';
 

--- a/mon-pix/app/routes/organizations/access.js
+++ b/mon-pix/app/routes/organizations/access.js
@@ -29,7 +29,7 @@ export default class AccessRoute extends Route {
 
     if (identityProviderToVisit) {
       this.session.setAttemptedTransition(transition);
-      return this.router.replaceWith('authentication.login-oidc', identityProviderToVisit.id);
+      return this.router.replaceWith('authentication.login-oidc', identityProviderToVisit.slug);
     } else if (this._shouldLoginToAccessSCORestrictedCampaign(organizationToJoin)) {
       this.authenticationRoute = 'organizations.join.student-sco';
     } else if (this._shouldJoinFromMediacentre(organizationToJoin)) {

--- a/mon-pix/app/services/oidc-identity-providers.js
+++ b/mon-pix/app/services/oidc-identity-providers.js
@@ -29,6 +29,10 @@ export default class OidcIdentityProviders extends Service {
     return this.list.length > 0;
   }
 
+  findByCode(identityProviderCode) {
+    return this.list.find((oidcProvider) => oidcProvider.code === identityProviderCode);
+  }
+
   // TODO: Manage this through the API
   get featuredIdentityProvider() {
     return this.list.find((identityProvider) => {

--- a/mon-pix/app/services/session.js
+++ b/mon-pix/app/services/session.js
@@ -25,13 +25,9 @@ export default class CurrentSessionService extends SessionService {
     await this.currentUser.load();
 
     const nextURL = this.data.nextURL;
-    const isFromIdentityProviderLoginPage = this.oidcIdentityProviders.list.some((identityProvider) => {
-      const isUserLoggedInToIdentityProvider =
-        get(this, 'data.authenticated.identityProviderCode') === identityProvider.code;
-      return nextURL && isUserLoggedInToIdentityProvider;
-    });
-
-    if (isFromIdentityProviderLoginPage) {
+    const authenticatedIdentityProviderCode = get(this, 'data.authenticated.identityProviderCode');
+    const identityProvider = this.oidcIdentityProviders.findByCode(authenticatedIdentityProviderCode);
+    if (nextURL && identityProvider) {
       // eslint-disable-next-line ember/classic-decorator-no-classic-methods
       this.set('data.nextURL', undefined);
       this.router.replaceWith(nextURL);

--- a/mon-pix/tests/helpers/service-stubs.js
+++ b/mon-pix/tests/helpers/service-stubs.js
@@ -185,6 +185,10 @@ export function stubOidcIdentityProvidersService(owner, { oidcIdentityProviders,
       return this.list.length > 0;
     }
 
+    findByCode(identityProviderCode) {
+      return this.list.find((oidcProvider) => oidcProvider.code === identityProviderCode);
+    }
+
     get featuredIdentityProvider() {
       return this.list.find((identityProvider) => {
         return identityProvider.code === this.featuredIdentityProviderCode;

--- a/mon-pix/tests/unit/services/oidc-identity-providers-test.js
+++ b/mon-pix/tests/unit/services/oidc-identity-providers-test.js
@@ -7,6 +7,22 @@ import sinon from 'sinon';
 module('Unit | Service | oidc-identity-providers', function (hooks) {
   setupTest(hooks);
 
+  let oidcIdentityProvidersService;
+  let storeStub;
+
+  const oidcPartner = {
+    id: 'oidc-partner',
+    code: 'OIDC_PARTNER',
+    slug: 'partenaire-oidc',
+    organizationName: 'Partenaire OIDC',
+    shouldCloseSession: false,
+    source: 'oidc-externe',
+  };
+
+  hooks.beforeEach(function () {
+    oidcIdentityProvidersService = this.owner.lookup('service:oidcIdentityProviders');
+  });
+
   module('load', function () {
     test('should contain identity providers by id and retrieve the whole list', async function (assert) {
       // given
@@ -119,6 +135,42 @@ module('Unit | Service | oidc-identity-providers', function (hooks) {
 
         // then
         assert.strictEqual(hasIdentityProviders, false);
+      });
+    });
+  });
+
+  module('findByCode', function () {
+    module('when the requested identity provider is available', function () {
+      test('returns the identity provider', async function (assert) {
+        // given
+        storeStub = Service.create({
+          findAll: sinon.stub().resolves([Object.create(oidcPartner)]),
+          peekAll: sinon.stub().returns([Object.create(oidcPartner)]),
+        });
+        oidcIdentityProvidersService.set('store', storeStub);
+
+        // when
+        const identityProvider = await oidcIdentityProvidersService.findByCode(oidcPartner.code);
+
+        // then
+        assert.strictEqual(identityProvider.code, oidcPartner.code);
+      });
+    });
+
+    module('when the requested identity provider is not available', function () {
+      test('returns undefined', async function (assert) {
+        // given
+        storeStub = Service.create({
+          findAll: sinon.stub().resolves([Object.create(oidcPartner)]),
+          peekAll: sinon.stub().returns([Object.create(oidcPartner)]),
+        });
+        oidcIdentityProvidersService.set('store', storeStub);
+
+        // when
+        const identityProvider = await oidcIdentityProvidersService.findByCode('not-existing-code');
+
+        // then
+        assert.strictEqual(identityProvider, undefined);
       });
     });
   });

--- a/mon-pix/tests/unit/services/oidc-identity-providers-test.js
+++ b/mon-pix/tests/unit/services/oidc-identity-providers-test.js
@@ -26,20 +26,10 @@ module('Unit | Service | oidc-identity-providers', function (hooks) {
   module('load', function () {
     test('should contain identity providers by id and retrieve the whole list', async function (assert) {
       // given
-      const oidcPartner = {
-        id: 'oidc-partner',
-        code: 'OIDC_PARTNER',
-        organizationName: 'Partenaire OIDC',
-        slug: 'partenaire-oidc',
-        shouldCloseSession: false,
-        source: 'oidc-externe',
-      };
-      const oidcPartnerObject = Object.create(oidcPartner);
-      const storeStub = Service.create({
-        findAll: sinon.stub().resolves([oidcPartnerObject]),
-        peekAll: sinon.stub().returns([oidcPartnerObject]),
+      storeStub = Service.create({
+        findAll: sinon.stub().resolves([oidcPartner]),
+        peekAll: sinon.stub().returns([oidcPartner]),
       });
-      const oidcIdentityProvidersService = this.owner.lookup('service:oidcIdentityProviders');
       oidcIdentityProvidersService.set('store', storeStub);
 
       // when
@@ -63,28 +53,27 @@ module('Unit | Service | oidc-identity-providers', function (hooks) {
   module('getIdentityProviderNamesByAuthenticationMethods', function () {
     test('should return identity provider names for methods', function (assert) {
       // given
-      const methods = [{ identityProvider: 'FRANCE_CONNECT' }, { identityProvider: 'IMPOTS_GOUV' }];
-      const oidcPartnerObject = Object.create({
+      const oidcPartner2 = Object.create({
         id: 'france-connect',
         code: 'FRANCE_CONNECT',
         organizationName: 'France Connect',
         shouldCloseSession: false,
         source: 'france-connect',
       });
-      const otherOidcPartnerObject = Object.create({
+      const oidcPartner3 = Object.create({
         id: 'impots-gouv',
         code: 'IMPOTS_GOUV',
         organizationName: 'Impots.gouv',
         shouldCloseSession: false,
         source: 'impots-gouv',
       });
-      const oidcIdentityProvidersService = this.owner.lookup('service:oidcIdentityProviders');
-      oidcIdentityProvidersService.set(
-        'store',
-        Service.create({
-          peekAll: sinon.stub().returns([oidcPartnerObject, otherOidcPartnerObject]),
-        }),
-      );
+      storeStub = Service.create({
+        findAll: sinon.stub().resolves([oidcPartner2, oidcPartner3]),
+        peekAll: sinon.stub().returns([oidcPartner2, oidcPartner3]),
+      });
+      oidcIdentityProvidersService.set('store', storeStub);
+
+      const methods = [{ identityProvider: 'FRANCE_CONNECT' }, { identityProvider: 'IMPOTS_GOUV' }];
 
       // when
       const names = oidcIdentityProvidersService.getIdentityProviderNamesByAuthenticationMethods(methods);
@@ -98,19 +87,10 @@ module('Unit | Service | oidc-identity-providers', function (hooks) {
     module('when there is some identity providers', function () {
       test('returns true', async function () {
         // given
-        const oidcPartner = {
-          id: 'oidc-partner',
-          code: 'OIDC_PARTNER',
-          organizationName: 'Partenaire OIDC',
-          slug: 'partenaire-oidc',
-          shouldCloseSession: false,
-          source: 'oidc-externe',
-        };
-        const oidcPartnerObject = Object.create(oidcPartner);
-        const storeStub = Service.create({
-          peekAll: sinon.stub().returns([oidcPartnerObject]),
+        storeStub = Service.create({
+          findAll: sinon.stub().resolves([oidcPartner]),
+          peekAll: sinon.stub().returns([oidcPartner]),
         });
-        const oidcIdentityProvidersService = this.owner.lookup('service:oidcIdentityProviders');
         oidcIdentityProvidersService.set('store', storeStub);
 
         // when
@@ -125,6 +105,7 @@ module('Unit | Service | oidc-identity-providers', function (hooks) {
       test('returns false', async function () {
         // given
         const storeStub = Service.create({
+          findAll: sinon.stub().resolves([]),
           peekAll: sinon.stub().returns([]),
         });
         const oidcIdentityProvidersService = this.owner.lookup('service:oidcIdentityProviders');
@@ -182,7 +163,7 @@ module('Unit | Service | oidc-identity-providers', function (hooks) {
         const currentDomainService = this.owner.lookup('service:currentDomain');
         sinon.stub(currentDomainService, 'isFranceDomain').value(false);
 
-        const oidcPartner = {
+        const oidcFwb = {
           id: 'fwb',
           code: 'FWB',
           organizationName: 'FWB',
@@ -190,42 +171,32 @@ module('Unit | Service | oidc-identity-providers', function (hooks) {
           shouldCloseSession: false,
           source: 'fwb',
         };
-        const oidcPartnerObject = Object.create(oidcPartner);
-        const storeStub = Service.create({
-          peekAll: sinon.stub().returns([oidcPartnerObject]),
+        storeStub = Service.create({
+          findAll: sinon.stub().resolves([Object.create(oidcFwb)]),
+          peekAll: sinon.stub().returns([Object.create(oidcFwb)]),
         });
-        const oidcIdentityProvidersService = this.owner.lookup('service:oidcIdentityProviders');
         oidcIdentityProvidersService.set('store', storeStub);
 
         // when
         const featuredIdentityProvider = await oidcIdentityProvidersService.featuredIdentityProvider;
 
         // then
-        assert.strictEqual(featuredIdentityProvider.id, oidcPartner.id);
-        assert.strictEqual(featuredIdentityProvider.code, oidcPartner.code);
-        assert.strictEqual(featuredIdentityProvider.organizationName, oidcPartner.organizationName);
-        assert.strictEqual(featuredIdentityProvider.slug, oidcPartner.slug);
-        assert.strictEqual(featuredIdentityProvider.shouldCloseSession, oidcPartner.shouldCloseSession);
-        assert.strictEqual(featuredIdentityProvider.source, oidcPartner.source);
+        assert.strictEqual(featuredIdentityProvider.id, oidcFwb.id);
+        assert.strictEqual(featuredIdentityProvider.code, oidcFwb.code);
+        assert.strictEqual(featuredIdentityProvider.organizationName, oidcFwb.organizationName);
+        assert.strictEqual(featuredIdentityProvider.slug, oidcFwb.slug);
+        assert.strictEqual(featuredIdentityProvider.shouldCloseSession, oidcFwb.shouldCloseSession);
+        assert.strictEqual(featuredIdentityProvider.source, oidcFwb.source);
       });
     });
 
     module('when there is some identity providers but no featured one', function () {
       test('returns undefined', async function () {
         // given
-        const oidcPartner = {
-          id: 'oidc-partner',
-          code: 'OIDC_PARTNER',
-          organizationName: 'Partenaire OIDC',
-          slug: 'partenaire-oidc',
-          shouldCloseSession: false,
-          source: 'oidc-externe',
-        };
-        const oidcPartnerObject = Object.create(oidcPartner);
-        const storeStub = Service.create({
-          peekAll: sinon.stub().returns([oidcPartnerObject]),
+        storeStub = Service.create({
+          findAll: sinon.stub().resolves([Object.create(oidcPartner)]),
+          peekAll: sinon.stub().returns([Object.create(oidcPartner)]),
         });
-        const oidcIdentityProvidersService = this.owner.lookup('service:oidcIdentityProviders');
         oidcIdentityProvidersService.set('store', storeStub);
 
         // when
@@ -240,6 +211,7 @@ module('Unit | Service | oidc-identity-providers', function (hooks) {
       test('returns undefined', async function () {
         // given
         const storeStub = Service.create({
+          findAll: sinon.stub().resolves([]),
           peekAll: sinon.stub().returns([]),
         });
         const oidcIdentityProvidersService = this.owner.lookup('service:oidcIdentityProviders');
@@ -264,19 +236,10 @@ module('Unit | Service | oidc-identity-providers', function (hooks) {
       module('when there is some other identity providers', function () {
         test('returns true', async function () {
           // given
-          const oidcPartner = {
-            id: 'oidc-partner',
-            code: 'OIDC_PARTNER',
-            organizationName: 'Partenaire OIDC',
-            slug: 'partenaire-oidc',
-            shouldCloseSession: false,
-            source: 'oidc-externe',
-          };
-          const oidcPartnerObject = Object.create(oidcPartner);
-          const storeStub = Service.create({
-            peekAll: sinon.stub().returns([oidcPartnerObject]),
+          storeStub = Service.create({
+            findAll: sinon.stub().resolves([Object.create(oidcPartner)]),
+            peekAll: sinon.stub().returns([Object.create(oidcPartner)]),
           });
-          const oidcIdentityProvidersService = this.owner.lookup('service:oidcIdentityProviders');
           oidcIdentityProvidersService.set('store', storeStub);
 
           // when
@@ -291,9 +254,9 @@ module('Unit | Service | oidc-identity-providers', function (hooks) {
         test('returns false', async function () {
           // given
           const storeStub = Service.create({
+            findAll: sinon.stub().resolves([]),
             peekAll: sinon.stub().returns([]),
           });
-          const oidcIdentityProvidersService = this.owner.lookup('service:oidcIdentityProviders');
           oidcIdentityProvidersService.set('store', storeStub);
 
           // when
@@ -305,27 +268,16 @@ module('Unit | Service | oidc-identity-providers', function (hooks) {
       });
     });
 
-    module('when not in France domain', function (hooks) {
-      hooks.beforeEach(function () {
-        const currentDomainService = this.owner.lookup('service:currentDomain');
-        sinon.stub(currentDomainService, 'isFranceDomain').value(false);
-      });
-
+    module('when not in France domain', function () {
       test('returns false', async function () {
         // given
-        const oidcPartner = {
-          id: 'oidc-partner',
-          code: 'OIDC_PARTNER',
-          organizationName: 'Partenaire OIDC',
-          slug: 'partenaire-oidc',
-          shouldCloseSession: false,
-          source: 'oidc-externe',
-        };
-        const oidcPartnerObject = Object.create(oidcPartner);
-        const storeStub = Service.create({
-          peekAll: sinon.stub().returns([oidcPartnerObject]),
+        const currentDomainService = this.owner.lookup('service:currentDomain');
+        sinon.stub(currentDomainService, 'isFranceDomain').value(false);
+
+        storeStub = Service.create({
+          findAll: sinon.stub().resolves([Object.create(oidcPartner)]),
+          peekAll: sinon.stub().returns([Object.create(oidcPartner)]),
         });
-        const oidcIdentityProvidersService = this.owner.lookup('service:oidcIdentityProviders');
         oidcIdentityProvidersService.set('store', storeStub);
 
         // when
@@ -339,9 +291,6 @@ module('Unit | Service | oidc-identity-providers', function (hooks) {
 
   module('shouldDisplayAccountRecoveryBanner', function () {
     test('returns true if SSO code is in USER_ACCOUNT_RECOVERY_FOR_IDENTITY_PROVIDER_CODES', async function (assert) {
-      // given
-      const oidcIdentityProvidersService = this.owner.lookup('service:oidcIdentityProviders');
-
       // when
       const shouldDisplayAccountRecoveryBanner =
         await oidcIdentityProvidersService.shouldDisplayAccountRecoveryBanner('FER');

--- a/mon-pix/tests/unit/services/session-test.js
+++ b/mon-pix/tests/unit/services/session-test.js
@@ -1,8 +1,9 @@
-import Service from '@ember/service';
 import { setupTest } from 'ember-qunit';
 import { SessionStorageEntry } from 'mon-pix/utils/session-storage-entry.js';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
+
+import { stubOidcIdentityProvidersService } from '../../helpers/service-stubs.js';
 
 module('Unit | Services | session', function (hooks) {
   setupTest(hooks);
@@ -66,20 +67,16 @@ module('Unit | Services | session', function (hooks) {
 
   module('#handleAuthentication', function (hooks) {
     hooks.beforeEach(function () {
-      const oidcPartner = {
-        id: 'oidc-partner',
-        code: 'OIDC_PARTNER',
-        organizationName: 'Partenaire OIDC',
-        shouldCloseSession: false,
-        source: 'oidc-externe',
-      };
-
-      class OidcIdentityProvidersStub extends Service {
-        'oidc-partner' = oidcPartner;
-        list = [oidcPartner];
-      }
-
-      this.owner.register('service:oidcIdentityProviders', OidcIdentityProvidersStub);
+      stubOidcIdentityProvidersService(this.owner, {
+        oidcIdentityProviders: [
+          {
+            id: 'oidc-partner',
+            slug: 'oidc-partner',
+            code: 'OIDC_PARTNER',
+            organizationName: 'OIDC Partner',
+          },
+        ],
+      });
     });
 
     test('loads current user', async function (assert) {

--- a/orga/tests/unit/services/oidc-identity-providers-test.js
+++ b/orga/tests/unit/services/oidc-identity-providers-test.js
@@ -107,7 +107,7 @@ module('Unit | Service | oidc-identity-providers', function (hooks) {
   });
 
   module('findBySlug', function () {
-    module('when an identity provider is found', function () {
+    module('when the requested identity provider is available', function () {
       test('returns the identity provider', async function (assert) {
         // given
         storeStub = Service.create({
@@ -124,7 +124,7 @@ module('Unit | Service | oidc-identity-providers', function (hooks) {
       });
     });
 
-    module('when an identity provider is not found', function () {
+    module('when the requested identity provider is not available', function () {
       test('returns undefined', async function (assert) {
         // given
         storeStub = Service.create({


### PR DESCRIPTION
## ❄️ Problème

Parfois (ce n’est pas du tout systématique), _et particulièrement avec certains OIDC Providers_, des actions impliquant les SSO ne produisent pas l’effet prévu et l’utilisateur est redirigé vers la page de connexion de Pix.

💥 Exemple d’un cas précis : Dans le cadre d’une organisation ayant un `identityProviderForCampaigns`, un utilisateur qui suit un lien de campagne (du type `/campagnes/XXX`) est redirigé sur la page de connexion de Pix au lieu d'arriver sur la page de la campagne où il devra s’authentifier avec le SSO de l’organisation puis ensuite d’être redirigé sur le contenu de la campagne.

🔎 En examinant les différents logs de monitoring et les erreurs renvoyées par l’API il a été déterminé que certains appels réseau faits vers des OIDC Providers recevaient des erreurs en retour ou ne recevaient pas de réponse du tout, générant des timeouts. Cela arrive particulièrement avec certains OIDC Providers qu’on peut imaginer moins robustes et/ou plus sollicités que les autres. Et le code de `OidcAuthenticationService` ne gère pas de retry en cas d’erreur ou de timeout sur un appel à un OIDC Provider. Et _openid-client_ ne gère pas de _retry_ non plus : https://github.com/panva/openid-client/discussions/450

## 🛷 Proposition

Clairement la solution est de faire un _retry_ sur certaines erreurs comme les timeouts. Mais il faut d’abord pouvoir analyser précisément tous les types erreurs OIDC que nous avons en production avec les appels de l’`openIdClient`. Mais actuellement le monitoring de ces erreurs est partiel en n’enregistrant pas leur `stack`. De plus le `message` des erreurs n’est pas enregistré lorsque le message passé en argument à `_monitorOidcError` n’est pas celui de l’erreur.

Donc la proposition est de, dans cette PR, d’ajouter des informations de monitoring supplémentaires sur les appels de l’`openIdClient`, et dans une PR suivante, après analyse des erreurs en production, d’ajouter une gestion du _retry_ sur les appels de l’`openIdClient`.

Par ailleurs lors de l’analyse de ces erreurs OIDC du code difficile à comprendre a dû être lu, débogué et réécrit. Ces réécritures ont donc été ajoutées à cette PR.

## ☃️ Remarques

RAS

## 🧑‍🎄 Pour tester

### En local tester que le monitoring des erreurs OIDC est bien augmenté

1. Modifier la fonction `initializeClientConfig` en y ajoutant une erreur comme ci-dessous : 
   ```javascript

    try {
      const metadata = {
        client_secret: this.clientSecret,
        ...this.openidClientExtraMetadata,
      };

      // Ajouter cette erreur
      throw new Error('TEST')

      this.#openIdClientConfig = await this.#openIdClient.discovery(
        new URL(this.openidConfigurationUrl),
        this.clientId,
        metadata,
      );
    } catch (error) {
   ```
2. Sur Pix App, sans être authentifié, aller sur `Se connecter avec France Travail` ou sur n’importe quelle autre organisation
3. Constater qu’une erreur est loggée dans le terminal avec sa _stack trace_

### En local tester la non-régression

1. Dans Pix Admin créer une organisation ayant un SSO (`identityProviderForCampaigns`), et donner un membership `ADMIN` à un utilisateur (par exemple `allorga@example.net`)
4. Dans Pix Admin créer un profil cible pour cette organisation
5. Dans Pix Orga créer une campagne pour cette organisation avec pour object `Évaluer les participants`, noter le `codeCampagne`
6. Sur Pix App, sans être authentifié, aller sur le lien `/campagnes/${codeCampagne}` de la campagne précédemment créée
7. Constater que l’utilisateur arrive sur la page de la campagne et qu’il doit s’authentifier avec le SSO de l’organisation puis qu’il est redirigé sur le contenu de la campagne
