### PR TITLE
[TECH] :broom: Suppression d'une fonction inutilisé dans le `assessement-repository` (PIX-20963)

### DIFF
--- a/api/src/shared/infrastructure/repositories/assessment-repository.js
+++ b/api/src/shared/infrastructure/repositories/assessment-repository.js
@@ -101,15 +101,11 @@ async function _getAssociatedCampaign(campaignParticipationId) {
 }
 
 const abortByAssessmentId = function (assessmentId) {
-  return this._updateStateById({ id: assessmentId, state: Assessment.states.ABORTED });
+  return _updateStateById({ id: assessmentId, state: Assessment.states.ABORTED });
 };
 
 const completeByAssessmentId = function (assessmentId) {
-  return this._updateStateById({ id: assessmentId, state: Assessment.states.COMPLETED });
-};
-
-const endByInvigilatorByAssessmentId = function (assessmentId) {
-  return this._updateStateById({ id: assessmentId, state: Assessment.states.ENDED_BY_INVIGILATOR });
+  return _updateStateById({ id: assessmentId, state: Assessment.states.COMPLETED });
 };
 
 const getByCertificationCandidateId = async function (certificationCandidateId) {
@@ -207,10 +203,8 @@ const updateCampaignParticipationId = async function (assessment) {
 };
 
 export {
-  _updateStateById,
   abortByAssessmentId,
   completeByAssessmentId,
-  endByInvigilatorByAssessmentId,
   findLastCompletedAssessmentsForEachCompetenceByUser,
   findNotAbortedCampaignAssessmentsByUserId,
   get,

--- a/api/tests/shared/integration/infrastructure/repositories/assessment-repository_test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/assessment-repository_test.js
@@ -539,28 +539,6 @@ describe('Integration | Infrastructure | Repositories | assessment-repository', 
     });
   });
 
-  describe('#endByInvigilatorByAssessmentId', function () {
-    it('should end an assessment', async function () {
-      // given
-      const userId = databaseBuilder.factory.buildUser().id;
-
-      const assessmentId = databaseBuilder.factory.buildAssessment({
-        userId,
-        type: Assessment.types.COMPETENCE_EVALUATION,
-        state: Assessment.states.STARTED,
-      }).id;
-
-      await databaseBuilder.commit();
-
-      // when
-      await assessmentRepository.endByInvigilatorByAssessmentId(assessmentId);
-
-      // then
-      const { state } = await knex('assessments').where('id', assessmentId).first('state');
-      expect(state).to.equal(Assessment.states.ENDED_BY_INVIGILATOR);
-    });
-  });
-
   describe('#ownedByUser', function () {
     let user;
     let userWithNoAssessment;


### PR DESCRIPTION
## ❄️ Problème

Dans le module `assessment-repository` nous avons une fonction qui n'est appelée par personne.

## 🛷 Proposition

Supprimer la fonction qui n'est pas utilisée.

## ☃️ Remarques

Nous en avons profité pour supprimer un export d'une fonction interne.

## 🧑‍🎄 Pour tester

- En tant que surveillante : démarrer une certif depuis PixCertif
- En tant que surveillante : ouvrir l'espace surveillante (depuis PixCertif)
- En tant que candidate : démarre un parcour de certif sur monPix (connexion avec certif-success puis identification à la session de certif avec Max Lagagne). Passer une ou deux questions
- En tant que surveillante : mettre fin à la session de Max Lagagne dans l'espace surveillant

La session de certification est interrompue pour la candidate. 
La surveillante doit voir que cette candidate à sa session finalisée par la surveillante.
