### PR TITLE
[TECH] Remplacement de `Object` par `object` dans la JSDoc du domaine certification

### DIFF
--- a/api/src/certification/configuration/domain/models/Center.js
+++ b/api/src/certification/configuration/domain/models/Center.js
@@ -10,7 +10,7 @@ export class Center {
   });
 
   /**
-   * @param {Object} props
+   * @param {object} props
    * @param {CenterTypes} props.type
    * @param {number} [props.id]
    * @param {string} [props.externalId]

--- a/api/src/certification/configuration/domain/models/CertificationFrameworksChallenge.js
+++ b/api/src/certification/configuration/domain/models/CertificationFrameworksChallenge.js
@@ -11,7 +11,7 @@ export class CertificationFrameworksChallenge {
   });
 
   /**
-   * @param {Object} params
+   * @param {object} params
    * @param {number} params.versionId
    * @param {string} params.challengeId
    * @param {number} [params.discriminant]

--- a/api/src/certification/configuration/domain/models/ComplementaryCertificationTargetProfileHistory.js
+++ b/api/src/certification/configuration/domain/models/ComplementaryCertificationTargetProfileHistory.js
@@ -4,7 +4,7 @@
 
 class ComplementaryCertificationTargetProfileHistory {
   /**
-   * @param {Object} params
+   * @param {object} params
    * @param {number} params.id - identifier of the complementary certification
    * @param {string} params.key
    * @param {string} params.label

--- a/api/src/certification/configuration/domain/models/ScoBlockedAccessDate.js
+++ b/api/src/certification/configuration/domain/models/ScoBlockedAccessDate.js
@@ -16,7 +16,7 @@ export class ScoBlockedAccessDate {
   });
 
   /**
-   * @param {Object} params
+   * @param {object} params
    * @param {ScoOrganizationTagName} params.scoOrganizationTagName
    * @param {Date} params.reopeningDate
    */

--- a/api/src/certification/configuration/domain/models/Version.js
+++ b/api/src/certification/configuration/domain/models/Version.js
@@ -23,14 +23,14 @@ export class Version {
   });
 
   /**
-   * @param {Object} params
+   * @param {object} params
    * @param {number} [params.id] - version identifier (optional for new versions)
    * @param {Scopes} params.scope - Certification scope (CORE, DROIT, etc.)
    * @param {Date} params.startDate - When this version becomes active
    * @param {Date|null} [params.expirationDate] - When this version expires (null if current)
    * @param {number} params.assessmentDuration - Assessment duration in minutes
-   * @param {Array<Object>} [params.globalScoringConfiguration] - Global scoring configuration
-   * @param {Array<Object>} [params.competencesScoringConfiguration] - Competences scoring configuration
+   * @param {Array<object>} [params.globalScoringConfiguration] - Global scoring configuration
+   * @param {Array<object>} [params.competencesScoringConfiguration] - Competences scoring configuration
    * @param {FlashAssessmentAlgorithmConfiguration} params.challengesConfiguration - Challenges configuration
    */
   constructor({

--- a/api/src/certification/configuration/domain/read-models/ActiveCalibratedChallenge.js
+++ b/api/src/certification/configuration/domain/read-models/ActiveCalibratedChallenge.js
@@ -1,6 +1,6 @@
 export class ActiveCalibratedChallenge {
   /**
-   * @param {Object} params
+   * @param {object} params
    * @param {ComplementaryCertificationKey} params.scope
    * @param {number} params.discriminant
    * @param {number} params.difficulty

--- a/api/src/certification/configuration/domain/usecases/attach-badges.js
+++ b/api/src/certification/configuration/domain/usecases/attach-badges.js
@@ -13,7 +13,7 @@ import { BadgeToAttach } from '../models/BadgeToAttach.js';
 const { isNil, uniq } = lodash;
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {ComplementaryCertification} params.complementaryCertification
  * @param {number} params.userId
  * @param {number|null} params.targetProfileIdToDetach
@@ -82,7 +82,7 @@ function _isRequiredInformationMissing(complementaryCertificationBadgesToAttachD
 }
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {ComplementaryCertificationBadgesRepository} params.complementaryCertificationBadgesRepository
  */
 async function _attachNewComplementaryCertificationBadges({
@@ -95,7 +95,7 @@ async function _attachNewComplementaryCertificationBadges({
 }
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {ComplementaryCertificationBadgesRepository} params.complementaryCertificationBadgesRepository
  */
 async function _detachExistingComplementaryCertificationBadge({
@@ -145,7 +145,7 @@ function _verifyThatLevelsAreConsistent({ complementaryCertificationBadgesToAtta
 }
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {ComplementaryCertificationBadgesRepository} params.complementaryCertificationBadgesRepository
  */
 async function _verifyThatBadgesToAttachExist({

--- a/api/src/certification/configuration/domain/usecases/calibrate-framework-version.js
+++ b/api/src/certification/configuration/domain/usecases/calibrate-framework-version.js
@@ -11,7 +11,7 @@ import { NotFoundError } from '../../../../shared/domain/errors.js';
 
 export const calibrateFrameworkVersion = withTransaction(
   /**
-   * @param {Object} params
+   * @param {object} params
    * @param {number} params.versionId
    * @param {number} params.calibrationId
    * @param {FrameworkChallengesRepository} params.frameworkChallengesRepository

--- a/api/src/certification/configuration/domain/usecases/create-certification-version.js
+++ b/api/src/certification/configuration/domain/usecases/create-certification-version.js
@@ -19,7 +19,7 @@ import { Version } from '../models/Version.js';
 
 export const createCertificationVersion = withTransaction(
   /**
-   * @param {Object} params
+   * @param {object} params
    * @param {Scopes} params.scope
    * @param {Array<string>} params.tubeIds
    * @param {TubeRepository} params.tubeRepository
@@ -35,7 +35,7 @@ export const createCertificationVersion = withTransaction(
 );
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {Scopes} params.scope
  * @param {VersionsRepository} params.versionsRepository
  */
@@ -76,7 +76,7 @@ const _buildNewVersion = async ({ scope, versionsRepository }) => {
 };
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {Array<string>} params.tubeIds
  * @param {TubeRepository} params.tubeRepository
  * @param {SkillRepository} params.skillRepository

--- a/api/src/certification/configuration/domain/usecases/export-sco-whitelist.js
+++ b/api/src/certification/configuration/domain/usecases/export-sco-whitelist.js
@@ -4,7 +4,7 @@
  */
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {CenterRepository} params.centerRepository
  * @returns {Promise<Array<Center>>}
  */

--- a/api/src/certification/configuration/domain/usecases/find-certification-frameworks.js
+++ b/api/src/certification/configuration/domain/usecases/find-certification-frameworks.js
@@ -1,7 +1,7 @@
 import { Frameworks } from '../models/Frameworks.js';
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {VersionsRepository} params.versionsRepository
  * @returns {Promise<Array<{id: string, name: string, versionStartDate: Date|null}>>}
  */

--- a/api/src/certification/configuration/domain/usecases/find-complementary-certifications.js
+++ b/api/src/certification/configuration/domain/usecases/find-complementary-certifications.js
@@ -3,7 +3,7 @@
  */
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {ComplementaryCertificationRepository} params.complementaryCertificationRepository
  */
 const findComplementaryCertifications = function ({ complementaryCertificationRepository }) {

--- a/api/src/certification/configuration/domain/usecases/get-active-version-by-scope.js
+++ b/api/src/certification/configuration/domain/usecases/get-active-version-by-scope.js
@@ -7,7 +7,7 @@
 import { NotFoundError } from '../../../../shared/domain/errors.js';
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {Scopes} params.scope
  * @param {VersionsRepository} params.versionsRepository
  * @returns {Promise<Version>}

--- a/api/src/certification/configuration/domain/usecases/get-complementary-certification-target-profile-history.js
+++ b/api/src/certification/configuration/domain/usecases/get-complementary-certification-target-profile-history.js
@@ -5,7 +5,7 @@
 import { ComplementaryCertificationTargetProfileHistory } from '../models/ComplementaryCertificationTargetProfileHistory.js';
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {string} params.complementaryCertificationKey
  * @param {TargetProfileHistoryRepository} params.targetProfileHistoryRepository
  * @param {ComplementaryCertificationForTargetProfileAttachmentRepository} params.complementaryCertificationForTargetProfileAttachmentRepository

--- a/api/src/certification/configuration/domain/usecases/get-current-framework-version.js
+++ b/api/src/certification/configuration/domain/usecases/get-current-framework-version.js
@@ -8,7 +8,7 @@
 import { NotFoundError } from '../../../../shared/domain/errors.js';
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {ComplementaryCertificationKeys} params.complementaryCertificationKey
  * @param {FrameworkChallengesRepository} params.frameworkChallengesRepository
  * @param {LearningContentRepository} params.learningContentRepository

--- a/api/src/certification/configuration/domain/usecases/get-framework-history.js
+++ b/api/src/certification/configuration/domain/usecases/get-framework-history.js
@@ -4,7 +4,7 @@
  */
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {ComplementaryCertificationKeys} params.complementaryCertificationKey
  * @param {VersionsRepository} params.versionsRepository
  */

--- a/api/src/certification/configuration/domain/usecases/get-sco-blocked-access-dates.js
+++ b/api/src/certification/configuration/domain/usecases/get-sco-blocked-access-dates.js
@@ -3,7 +3,7 @@
  */
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {ScoBlockedAccessDatesRepository} paramsScoBlockedAccessDatesRepository
  * @returns {Promise<Array<ScoBlockedAccessDate>>}
  */

--- a/api/src/certification/configuration/domain/usecases/import-sco-whitelist.js
+++ b/api/src/certification/configuration/domain/usecases/import-sco-whitelist.js
@@ -9,7 +9,7 @@ const INDEX_SHIFT_AND_CSV_HEADER = 2;
 
 export const importScoWhitelist = withTransaction(
   /**
-   * @param {Object} params
+   * @param {object} params
    * @param {CenterRepository} params.centerRepository
    */
   async ({ externalIds = [], centerRepository }) => {

--- a/api/src/certification/configuration/domain/usecases/search-attachable-target-profiles.js
+++ b/api/src/certification/configuration/domain/usecases/search-attachable-target-profiles.js
@@ -4,7 +4,7 @@
  */
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {string} [params.searchTerm]
  * @param {AttachableTargetProfileRepository} params.attachableTargetProfileRepository
  */

--- a/api/src/certification/configuration/domain/usecases/update-certification-version.js
+++ b/api/src/certification/configuration/domain/usecases/update-certification-version.js
@@ -4,7 +4,7 @@
  */
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {Version} params.updatedVersion
  * @param {VersionsRepository} params.versionsRepository
  * @returns {Promise<Version>}

--- a/api/src/certification/configuration/domain/usecases/update-sco-blocked-access-date.js
+++ b/api/src/certification/configuration/domain/usecases/update-sco-blocked-access-date.js
@@ -6,7 +6,7 @@ import { withTransaction } from '../../../../shared/domain/DomainTransaction.js'
 
 export const updateScoBlockedAccessDate = withTransaction(
   /**
-   * @param {Object} params
+   * @param {object} params
    * @param {ScoOrganisationTagName} params.scoOrganizationTagName
    * @param {Date} params.reopeningDate
    * @param {ScoBlockedAccessDatesRepository} params.ScoBlockedAccessDatesRepository

--- a/api/src/certification/configuration/infrastructure/repositories/active-calibrated-challenge-repository.js
+++ b/api/src/certification/configuration/infrastructure/repositories/active-calibrated-challenge-repository.js
@@ -6,7 +6,7 @@ import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { ActiveCalibratedChallenge } from '../../domain/read-models/ActiveCalibratedChallenge.js';
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {ComplementaryCertificationKeys} params.scope
  * @param {number} params.calibrationId
  * @returns {Promise<Array<ActiveCalibratedChallenge>>}

--- a/api/src/certification/configuration/infrastructure/repositories/attachable-target-profiles-repository.js
+++ b/api/src/certification/configuration/infrastructure/repositories/attachable-target-profiles-repository.js
@@ -4,7 +4,7 @@ import { isBlank } from '../../../../shared/infrastructure/utils/lodash-utils.js
 import { AttachableTargetProfile } from '../../domain/models/AttachableTargetProfile.js';
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {string} [params.searchTerm]
  * @returns {Promise<Array<AttachableTargetProfile>>}
  */

--- a/api/src/certification/configuration/infrastructure/repositories/center-repository.js
+++ b/api/src/certification/configuration/infrastructure/repositories/center-repository.js
@@ -4,7 +4,7 @@ import { Center } from '../../domain/models/Center.js';
 import { CenterTypes } from '../../domain/models/CenterTypes.js';
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {Array<string>} params.externalIds
  * @returns {Promise<Array<number>>} - number of rows affected
  */
@@ -49,7 +49,7 @@ export const getWhitelist = async () => {
 };
 
 /**
- * @param {Object} data
+ * @param {object} data
  * @param {number} data.id
  * @param {string} data.externalId
  * @param {CenterTypes} data.type

--- a/api/src/certification/configuration/infrastructure/repositories/complementary-certification-repository.js
+++ b/api/src/certification/configuration/infrastructure/repositories/complementary-certification-repository.js
@@ -9,7 +9,7 @@ import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { ComplementaryCertification } from '../../../complementary-certification/domain/models/ComplementaryCertification.js';
 
 /**
- * @param {Object} row
+ * @param {object} row
  * @param {number} row.id
  * @param {string} row.label
  * @param {ComplementaryCertificationKeys} row.key
@@ -46,7 +46,7 @@ const getByKey = async function (key) {
 };
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {number} params.id
  * @returns {Promise<ComplementaryCertification>}
  */

--- a/api/src/certification/configuration/infrastructure/repositories/framework-challenges-repository.js
+++ b/api/src/certification/configuration/infrastructure/repositories/framework-challenges-repository.js
@@ -4,7 +4,7 @@ import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { CertificationFrameworksChallenge } from '../../domain/models/CertificationFrameworksChallenge.js';
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {number} params.versionId
  * @returns {Promise<Array<CertificationFrameworksChallenge>>}
  * @throws {NotFoundError}

--- a/api/src/certification/configuration/infrastructure/repositories/sco-blocked-access-dates-repository.js
+++ b/api/src/certification/configuration/infrastructure/repositories/sco-blocked-access-dates-repository.js
@@ -37,7 +37,7 @@ export const getScoBlockedAccessDateByKey = async (scoOrganizationTagName) => {
 };
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {ScoBlockedAccessDate} params.scoBlockedAccessDate
  */
 export const updateScoBlockedAccessDate = async (scoBlockedAccessDate) => {

--- a/api/src/certification/configuration/infrastructure/repositories/versions-repository.js
+++ b/api/src/certification/configuration/infrastructure/repositories/versions-repository.js
@@ -10,7 +10,7 @@ import { FlashAssessmentAlgorithmConfiguration } from '../../../shared/domain/mo
 import { Version } from '../../domain/models/Version.js';
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {number} params.id
  * @returns {Promise<Version>}
  * @throws {NotFoundError}
@@ -40,7 +40,7 @@ export async function getById({ id }) {
 }
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {Scopes} params.scope
  * @returns {Promise<Version|null>}
  */
@@ -70,7 +70,7 @@ export async function findActiveByScope({ scope }) {
 }
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {Version} params.version
  * @param {Array<Challenge>} params.challenges
  * @returns {Promise<number>} versionId
@@ -110,7 +110,7 @@ export async function create({ version, challenges }) {
 }
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {Version} params.version
  * @returns {Promise<void>}
  */
@@ -124,7 +124,7 @@ export async function update({ version }) {
 }
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {Scopes} params.scope
  * @returns {Promise<Array<number>>}
  */

--- a/api/src/certification/configuration/infrastructure/serializers/csv/sco-whitelist-csv-serializer.js
+++ b/api/src/certification/configuration/infrastructure/serializers/csv/sco-whitelist-csv-serializer.js
@@ -1,7 +1,7 @@
 import { getCsvContent } from '../../../../../shared/infrastructure/utils/csv/write-csv-utils.js';
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {Array<Center>} params.centers
  * @returns {Promise<string>}
  */

--- a/api/src/certification/enrolment/application/api/candidates-api.js
+++ b/api/src/certification/enrolment/application/api/candidates-api.js
@@ -4,7 +4,7 @@ import { usecases } from '../../../enrolment/domain/usecases/index.js';
  * Checks if a user has been candidate to a certification
  *
  * @function
- * @param {Object} params
+ * @param {object} params
  * @param {number} params.userId user id to search for candidates
  * @returns {Promise<boolean>}
  * @throws {TypeError} preconditions failed

--- a/api/src/certification/enrolment/application/services/register-candidate-participation-service.js
+++ b/api/src/certification/enrolment/application/services/register-candidate-participation-service.js
@@ -6,7 +6,7 @@ import { usecases } from '../../domain/usecases/index.js';
 
 /**
  * Candidate entry to a certification is a multi step process
- * @param {Object} params
+ * @param {object} params
  * @param {number} params.userId
  * @param {number} params.sessionId
  * @param {string} params.firstName

--- a/api/src/certification/enrolment/domain/models/Candidate.js
+++ b/api/src/certification/enrolment/domain/models/Candidate.js
@@ -9,7 +9,7 @@ import { validate } from '../validators/candidate-validator.js';
 
 export class Candidate {
   /**
-   * @param {Object} params
+   * @param {object} params
    * @param {Array<Subscription>} [params.subscriptions=[]]
    */
   constructor({

--- a/api/src/certification/enrolment/domain/models/Center.js
+++ b/api/src/certification/enrolment/domain/models/Center.js
@@ -8,7 +8,7 @@ import { CenterTypes } from './CenterTypes.js';
 
 export class Center {
   /**
-   * @param {Object} props
+   * @param {object} props
    * @param {number} props.id
    * @param {string} props.name
    * @param {string} props.externalId

--- a/api/src/certification/enrolment/domain/models/ComplementaryCertificationCourseWithResults.js
+++ b/api/src/certification/enrolment/domain/models/ComplementaryCertificationCourseWithResults.js
@@ -1,7 +1,7 @@
 /**
  * @typedef {('PIX'|'EXTERNAL')} Source
  *
- * @typedef {Object} Results
+ * @typedef {object} Results
  * @property {number} id The id of the complementary certification badge for this result
  * @property {number} complementaryCertificationBadgeId The id of the complementary certification badge for this result
  * @property {number} level The level for this result
@@ -13,7 +13,7 @@ import { ChallengesReferential } from '../../../shared/domain/models/ChallengesR
 
 class ComplementaryCertificationCourseWithResults {
   /**
-   * @param {Object} params
+   * @param {object} params
    * @param {number} params.id
    * @param {boolean} params.hasExternalJury
    * @param {Array<Results>} params.results
@@ -35,7 +35,7 @@ class ComplementaryCertificationCourseWithResults {
   }
 
   /**
-   * @param {Object} params
+   * @param {object} params
    * @param {number} params.id
    * @param {boolean} params.hasExternalJury
    * @param {Array<Results>} params.results

--- a/api/src/certification/enrolment/domain/models/Habilitation.js
+++ b/api/src/certification/enrolment/domain/models/Habilitation.js
@@ -2,7 +2,7 @@ import { validate } from '../validators/habilitation-validator.js';
 
 export class Habilitation {
   /**
-   * @param {Object} props
+   * @param {object} props
    * @param {number} props.complementaryCertificationId - complementary certification id
    * @param {string} props.key - complementary certification key
    * @param {string} props.label - complementary certification label

--- a/api/src/certification/enrolment/domain/models/PixCertification.js
+++ b/api/src/certification/enrolment/domain/models/PixCertification.js
@@ -1,7 +1,7 @@
 export class PixCertification {
   constructor({ pixScore, status, isRejectedForFraud }) {
     /**
-     * @param {Object} props
+     * @param {object} props
      * @param {number} props.pixScore
      * @param {string} props.status
      * @param {boolean} props.isRejectedForFraud

--- a/api/src/certification/enrolment/domain/models/SessionEnrolment.js
+++ b/api/src/certification/enrolment/domain/models/SessionEnrolment.js
@@ -70,7 +70,7 @@ class SessionEnrolment {
   }
 
   /**
-   * @param {Object} params
+   * @param {object} params
    * @param {Array<Candidate>} params.candidates
    */
   hasReconciledCandidate({ candidates }) {
@@ -78,7 +78,7 @@ class SessionEnrolment {
   }
 
   /**
-   * @param {Object} params
+   * @param {object} params
    * @param {Array<Candidate>} params.candidates
    * @param {number} params.user
    */

--- a/api/src/certification/enrolment/domain/models/Subscription.js
+++ b/api/src/certification/enrolment/domain/models/Subscription.js
@@ -9,7 +9,7 @@ import { validate } from '../../../shared/domain/validators/subscription-validat
 
 class Subscription {
   /**
-   * @param {Object} params
+   * @param {object} params
    * @param {number | null} params.certificationCandidateId - identifier of the certification candidate
    * @param {SUBSCRIPTION_TYPES} params.type
    * @param {ComplementaryCertificationKeys | null} params.complementaryCertificationKey
@@ -22,7 +22,7 @@ class Subscription {
   }
 
   /**
-   * @param {Object} params
+   * @param {object} params
    * @param {number | null} params.certificationCandidateId   - identifier of the certification candidate
    */
   static buildCore({ certificationCandidateId }) {
@@ -34,7 +34,7 @@ class Subscription {
   }
 
   /**
-   * @param {Object} params
+   * @param {object} params
    * @param {number} params.certificationCandidateId - identifier of the certification candidate
    * @param {string} params.complementaryCertificationKey
    */

--- a/api/src/certification/enrolment/domain/models/User.js
+++ b/api/src/certification/enrolment/domain/models/User.js
@@ -1,6 +1,6 @@
 export class User {
   /**
-   * @param {Object} params
+   * @param {object} params
    * @param {number} params.id - identifier of the user
    * @param {string} params.lang
    */

--- a/api/src/certification/enrolment/domain/models/timeline/CandidateCertifiableEvent.js
+++ b/api/src/certification/enrolment/domain/models/timeline/CandidateCertifiableEvent.js
@@ -3,7 +3,7 @@ import { TimelineEvent } from './TimelineEvent.js';
 
 export class CandidateCertifiableEvent extends TimelineEvent {
   /**
-   * @param {Object} props
+   * @param {object} props
    * @param {Date} props.when
    */
   constructor({ when }) {

--- a/api/src/certification/enrolment/domain/models/timeline/CandidateCreatedEvent.js
+++ b/api/src/certification/enrolment/domain/models/timeline/CandidateCreatedEvent.js
@@ -3,7 +3,7 @@ import { TimelineEvent } from './TimelineEvent.js';
 
 export class CandidateCreatedEvent extends TimelineEvent {
   /**
-   * @param {Object} props
+   * @param {object} props
    * @param {Date} props.when
    */
   constructor({ when }) {

--- a/api/src/certification/enrolment/domain/models/timeline/CandidateDoubleCertificationEligibleEvent.js
+++ b/api/src/certification/enrolment/domain/models/timeline/CandidateDoubleCertificationEligibleEvent.js
@@ -3,7 +3,7 @@ import { TimelineEvent } from './TimelineEvent.js';
 
 export class CandidateDoubleCertificationEligibleEvent extends TimelineEvent {
   /**
-   * @param {Object} props
+   * @param {object} props
    * @param {Date} props.when
    */
   constructor({ when }) {

--- a/api/src/certification/enrolment/domain/models/timeline/CandidateEligibleButNotRegisteredToDoubleCertificationEvent.js
+++ b/api/src/certification/enrolment/domain/models/timeline/CandidateEligibleButNotRegisteredToDoubleCertificationEvent.js
@@ -3,7 +3,7 @@ import { TimelineEvent } from './TimelineEvent.js';
 
 export class CandidateEligibleButNotRegisteredToDoubleCertificationEvent extends TimelineEvent {
   /**
-   * @param {Object} props
+   * @param {object} props
    * @param {Date} props.when
    */
   constructor({ when }) {

--- a/api/src/certification/enrolment/domain/models/timeline/CandidateEndScreenEvent.js
+++ b/api/src/certification/enrolment/domain/models/timeline/CandidateEndScreenEvent.js
@@ -3,7 +3,7 @@ import { TimelineEvent } from './TimelineEvent.js';
 
 export class CandidateEndScreenEvent extends TimelineEvent {
   /**
-   * @param {Object} props
+   * @param {object} props
    * @param {Date} props.when
    */
   constructor({ when }) {

--- a/api/src/certification/enrolment/domain/models/timeline/CandidateNotCertifiableEvent.js
+++ b/api/src/certification/enrolment/domain/models/timeline/CandidateNotCertifiableEvent.js
@@ -3,7 +3,7 @@ import { TimelineEvent } from './TimelineEvent.js';
 
 export class CandidateNotCertifiableEvent extends TimelineEvent {
   /**
-   * @param {Object} props
+   * @param {object} props
    * @param {Date} props.when
    */
   constructor({ when }) {

--- a/api/src/certification/enrolment/domain/models/timeline/CandidateNotEligibleEvent.js
+++ b/api/src/certification/enrolment/domain/models/timeline/CandidateNotEligibleEvent.js
@@ -3,7 +3,7 @@ import { TimelineEvent } from './TimelineEvent.js';
 
 export class CandidateNotEligibleEvent extends TimelineEvent {
   /**
-   * @param {Object} props
+   * @param {object} props
    * @param {Date} props.when
    */
   constructor({ when }) {

--- a/api/src/certification/enrolment/domain/models/timeline/CandidateReconciledEvent.js
+++ b/api/src/certification/enrolment/domain/models/timeline/CandidateReconciledEvent.js
@@ -3,7 +3,7 @@ import { TimelineEvent } from './TimelineEvent.js';
 
 export class CandidateReconciledEvent extends TimelineEvent {
   /**
-   * @param {Object} props
+   * @param {object} props
    * @param {Date} props.when
    */
   constructor({ when }) {

--- a/api/src/certification/enrolment/domain/models/timeline/CandidateTimeline.js
+++ b/api/src/certification/enrolment/domain/models/timeline/CandidateTimeline.js
@@ -15,7 +15,7 @@ export class CandidateTimeline {
   });
 
   /**
-   * @param {Object} props
+   * @param {object} props
    * @param {number} props.certificationCandidateId
    */
   constructor({ certificationCandidateId }) {

--- a/api/src/certification/enrolment/domain/models/timeline/CertificationEndedEvent.js
+++ b/api/src/certification/enrolment/domain/models/timeline/CertificationEndedEvent.js
@@ -6,7 +6,7 @@ import { TimelineEvent } from './TimelineEvent.js';
 
 export class CertificationEndedEvent extends TimelineEvent {
   /**
-   * @param {Object} props
+   * @param {object} props
    * @param {Date} props.when
    * @param {states} props.assessmentState
    */

--- a/api/src/certification/enrolment/domain/models/timeline/CertificationStartedEvent.js
+++ b/api/src/certification/enrolment/domain/models/timeline/CertificationStartedEvent.js
@@ -3,7 +3,7 @@ import { TimelineEvent } from './TimelineEvent.js';
 
 export class CertificationStartedEvent extends TimelineEvent {
   /**
-   * @param {Object} props
+   * @param {object} props
    * @param {Date} props.when
    */
   constructor({ when }) {

--- a/api/src/certification/enrolment/domain/models/timeline/TimelineEvent.js
+++ b/api/src/certification/enrolment/domain/models/timeline/TimelineEvent.js
@@ -12,10 +12,10 @@ export class TimelineEvent {
   });
 
   /**
-   * @param {Object} props
+   * @param {object} props
    * @param {string} props.code
    * @param {Date} props.when
-   * @param {Object} [props.metadata]
+   * @param {object} [props.metadata]
    */
   constructor({ code, when, metadata = null }) {
     this.code = code;

--- a/api/src/certification/enrolment/domain/read-models/EnrolledCandidate.js
+++ b/api/src/certification/enrolment/domain/read-models/EnrolledCandidate.js
@@ -12,7 +12,7 @@ import { SUBSCRIPTION_TYPES } from '../../../shared/domain/constants.js';
  */
 export class EnrolledCandidate {
   /**
-   * @param {Object} params
+   * @param {object} params
    * @param {Array<Subscription>} params.subscriptions
    */
   constructor({

--- a/api/src/certification/enrolment/domain/usecases/add-candidate-to-session.js
+++ b/api/src/certification/enrolment/domain/usecases/add-candidate-to-session.js
@@ -18,7 +18,7 @@ import { CERTIFICATION_CANDIDATES_ERRORS } from '../../../shared/domain/constant
 import { ComplementaryCertificationKeys } from '../../../shared/domain/models/ComplementaryCertificationKeys.js';
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {SessionRepository} params.sessionRepository
  * @param {CandidateRepository} params.candidateRepository
  * @param {CertificationCpfService} params.certificationCpfService

--- a/api/src/certification/enrolment/domain/usecases/candidate-has-seen-certification-instructions.js
+++ b/api/src/certification/enrolment/domain/usecases/candidate-has-seen-certification-instructions.js
@@ -5,7 +5,7 @@
 import { CertificationCandidateNotFoundError } from '../errors.js';
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {number} params.certificationCandidateId
  * @param {CandidateRepository} params.candidateRepository
  * @returns {Candidate}

--- a/api/src/certification/enrolment/domain/usecases/create-session.js
+++ b/api/src/certification/enrolment/domain/usecases/create-session.js
@@ -8,7 +8,7 @@
 import { SessionEnrolment } from '../models/SessionEnrolment.js';
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {CenterRepository} params.centerRepository
  * @param {SessionRepository} params.sessionRepository
  * @param {SessionValidator} params.sessionValidator

--- a/api/src/certification/enrolment/domain/usecases/create-sessions.js
+++ b/api/src/certification/enrolment/domain/usecases/create-sessions.js
@@ -8,7 +8,7 @@ import { Candidate } from '../models/Candidate.js';
 import { SessionEnrolment } from '../models/SessionEnrolment.js';
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {deps["candidateRepository"]} params.candidateRepository
  * @param {deps["sessionRepository"]} params.sessionRepository
  * @param {deps["temporarySessionsStorageForMassImportService"]} params.temporarySessionsStorageForMassImportService

--- a/api/src/certification/enrolment/domain/usecases/delete-session.js
+++ b/api/src/certification/enrolment/domain/usecases/delete-session.js
@@ -6,7 +6,7 @@ import { SessionStartedDeletionError } from '../errors.js';
  */
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {SessionRepository} params.sessionRepository
  * @param {SessionManagementRepository} params.sessionManagementRepository
  */

--- a/api/src/certification/enrolment/domain/usecases/delete-unlinked-certification-candidate.js
+++ b/api/src/certification/enrolment/domain/usecases/delete-unlinked-certification-candidate.js
@@ -6,7 +6,7 @@ import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { CertificationCandidateForbiddenDeletionError } from '../errors.js';
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {CandidateRepository} params.candidateRepository
  */
 const deleteUnlinkedCertificationCandidate = async function ({ candidateId, candidateRepository }) {

--- a/api/src/certification/enrolment/domain/usecases/enrol-students-to-session.js
+++ b/api/src/certification/enrolment/domain/usecases/enrol-students-to-session.js
@@ -15,7 +15,7 @@ import { Subscription } from '../models/Subscription.js';
 const INSEE_PREFIX_CODE = '99';
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {ScoCertificationCandidateRepository} params.scoCertificationCandidateRepository
  * @param {OrganizationLearnerRepository} params.organizationLearnerRepository
  * @param {CenterRepository} params.centerRepository

--- a/api/src/certification/enrolment/domain/usecases/get-attendance-sheet.js
+++ b/api/src/certification/enrolment/domain/usecases/get-attendance-sheet.js
@@ -4,7 +4,7 @@
  */
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {SessionForAttendanceSheetRepository} params.sessionForAttendanceSheetRepository
  * @param {AttendanceSheetPdfUtils} params.attendanceSheetPdfUtils
  */

--- a/api/src/certification/enrolment/domain/usecases/get-candidate-import-sheet-data.js
+++ b/api/src/certification/enrolment/domain/usecases/get-candidate-import-sheet-data.js
@@ -5,7 +5,7 @@
  */
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {SessionRepository} params.sessionRepository
  * @param {EnrolledCandidateRepository} params.enrolledCandidateRepository
  * @param {CenterRepository} params.centerRepository

--- a/api/src/certification/enrolment/domain/usecases/get-candidate-timeline.js
+++ b/api/src/certification/enrolment/domain/usecases/get-candidate-timeline.js
@@ -29,7 +29,7 @@ import { CertificationEndedEvent } from '../models/timeline/CertificationEndedEv
 import { CertificationStartedEvent } from '../models/timeline/CertificationStartedEvent.js';
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {number} params.sessionId
  * @param {number} params.certificationCandidateId
  * @param {CandidateRepository} params.candidateRepository
@@ -110,7 +110,7 @@ export const getCandidateTimeline = async ({
 };
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {Candidate} params.candidate
  * @param {PlacementProfileService} params.placementProfileService
  * @param {CertificationBadgesService} params.certificationBadgesService
@@ -142,7 +142,7 @@ const _whenCandidateDidNotStartCertification = async ({
 };
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {Candidate} params.candidate
  * @param {CertificationCourse} params.certificationCourse
  * @param {CertificationBadgesService} params.certificationBadgesService
@@ -176,7 +176,7 @@ const _whenCandidateHasStartedTheTest = async ({
 };
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {number} params.userId
  * @param {Candidate} params.candidate
  * @param {Date} params.atDate
@@ -210,7 +210,7 @@ const _getCertificabilityEvent = async ({
 };
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {UserCertificationEligibility} params.userEligibility
  * @param {Date} params.atDate
  * @param {Candidate} params.candidate

--- a/api/src/certification/enrolment/domain/usecases/get-candidate.js
+++ b/api/src/certification/enrolment/domain/usecases/get-candidate.js
@@ -3,7 +3,7 @@
  */
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {CandidateRepository} params.candidateRepository
  */
 export async function getCandidate({ certificationCandidateId, candidateRepository }) {

--- a/api/src/certification/enrolment/domain/usecases/get-center.js
+++ b/api/src/certification/enrolment/domain/usecases/get-center.js
@@ -3,7 +3,7 @@
  */
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {CenterRepository} params.centerRepository
  */
 const getCenter = function ({ id, centerRepository }) {

--- a/api/src/certification/enrolment/domain/usecases/get-enrolled-candidates-in-session.js
+++ b/api/src/certification/enrolment/domain/usecases/get-enrolled-candidates-in-session.js
@@ -5,7 +5,7 @@
 
 /**
  * @function
- * @param {Object} params
+ * @param {object} params
  * @param {EnrolledCandidateRepository} params.enrolledCandidateRepository
  * @returns {Promise<Array<EnrolledCandidate>>}
  */

--- a/api/src/certification/enrolment/domain/usecases/get-mass-import-template-information.js
+++ b/api/src/certification/enrolment/domain/usecases/get-mass-import-template-information.js
@@ -6,7 +6,7 @@
  */
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {number} params.centerId
  * @param {CenterRepository} params.centerRepository
  *

--- a/api/src/certification/enrolment/domain/usecases/get-user-certification-eligibility.js
+++ b/api/src/certification/enrolment/domain/usecases/get-user-certification-eligibility.js
@@ -3,7 +3,7 @@
  */
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {EligibilityService} params.eligibilityService
  */
 const getUserCertificationEligibility = async function ({

--- a/api/src/certification/enrolment/domain/usecases/has-been-candidate.js
+++ b/api/src/certification/enrolment/domain/usecases/has-been-candidate.js
@@ -3,7 +3,7 @@
  */
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {number} params.userId
  * @param {CandidateRepository} params.candidateRepository
  */

--- a/api/src/certification/enrolment/domain/usecases/import-certification-candidates-from-candidates-import-sheet.js
+++ b/api/src/certification/enrolment/domain/usecases/import-certification-candidates-from-candidates-import-sheet.js
@@ -7,7 +7,7 @@ import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.j
 import { CandidateAlreadyLinkedToUserError } from '../../../../shared/domain/errors.js';
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {CandidateRepository} params.candidateRepository
  * @param {SessionRepository} params.sessionRepository
  */

--- a/api/src/certification/enrolment/domain/usecases/reconcile-candidate.js
+++ b/api/src/certification/enrolment/domain/usecases/reconcile-candidate.js
@@ -4,7 +4,7 @@
  */
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {Candidate} params.candidate
  * @param {number} params.userId
  * @param {CandidateRepository} params.candidateRepository

--- a/api/src/certification/enrolment/domain/usecases/update-enrolled-candidate.js
+++ b/api/src/certification/enrolment/domain/usecases/update-enrolled-candidate.js
@@ -9,7 +9,7 @@ import {
 } from '../../../../shared/domain/errors.js';
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {EditedCandidate} params.editedCandidate
  * @param {CandidateRepository} params.candidateRepository
  */

--- a/api/src/certification/enrolment/domain/usecases/update-session.js
+++ b/api/src/certification/enrolment/domain/usecases/update-session.js
@@ -5,7 +5,7 @@
  */
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {SessionRepository} params.sessionRepository
  * @param {SessionValidator} params.sessionValidator
  */

--- a/api/src/certification/enrolment/domain/usecases/validate-sessions.js
+++ b/api/src/certification/enrolment/domain/usecases/validate-sessions.js
@@ -8,7 +8,7 @@ import { SessionEnrolment } from '../models/SessionEnrolment.js';
 import { SessionMassImportReport } from '../models/SessionMassImportReport.js';
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {deps["sessionRepository"]} params.sessionRepository
  * @param {deps["certificationCpfCountryRepository"]} params.certificationCpfCountryRepository
  * @param {deps["certificationCpfCityRepository"]} params.certificationCpfCityRepository

--- a/api/src/certification/enrolment/domain/usecases/verify-candidate-identity.js
+++ b/api/src/certification/enrolment/domain/usecases/verify-candidate-identity.js
@@ -17,7 +17,7 @@ import {
 import { CertificationCourse } from '../../../shared/domain/models/CertificationCourse.js';
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {CandidateRepository} params.candidateRepository
  * @param {CenterRepository} params.centerRepository
  * @param {SessionRepository} params.sessionRepository
@@ -81,7 +81,7 @@ export const verifyCandidateIdentity = async ({
 };
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {Array<Candidate>} params.candidatesInSession
  */
 function findMatchingEnrolledCandidate({

--- a/api/src/certification/enrolment/domain/usecases/verify-candidate-reconciliation-requirements.js
+++ b/api/src/certification/enrolment/domain/usecases/verify-candidate-reconciliation-requirements.js
@@ -8,7 +8,7 @@ import { UserNotAuthorizedToCertifyError } from '../../../../shared/domain/error
 import { CenterHabilitationError } from '../../../shared/domain/errors.js';
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {Candidate} params.candidate
  * @param {number} params.sessionId
  * @param {PlacementProfileService} params.placementProfileService

--- a/api/src/certification/enrolment/infrastructure/files/candidates-import/CandidateData.js
+++ b/api/src/certification/enrolment/infrastructure/files/candidates-import/CandidateData.js
@@ -13,7 +13,7 @@ const FRANCE_COUNTRY_CODE = '99100';
 
 class CandidateData {
   /**
-   * @param {Object} params
+   * @param {object} params
    * @param {ComplementaryCertification|null} params.complementaryCertification
    */
   constructor({
@@ -122,7 +122,7 @@ class CandidateData {
   }
 
   /**
-   * @param {Object} params
+   * @param {object} params
    * @param {EnrolledCandidate} params.enrolledCandidate
    * @param {Array<Habilitation>} params.certificationCenterHabilitations
    * @param {number} params.number

--- a/api/src/certification/enrolment/infrastructure/files/candidates-import/fill-candidates-import-sheet.js
+++ b/api/src/certification/enrolment/infrastructure/files/candidates-import/fill-candidates-import-sheet.js
@@ -28,7 +28,7 @@ const CANDIDATE_TABLE_HEADER_ROW = 11;
 const CANDIDATE_TABLE_FIRST_ROW = 12;
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {SessionManagement} params.session
  * @param {Array<EnrolledCandidate>} params.enrolledCandidates
  * @param {Array<ComplementaryCertification>} params.certificationCenterHabilitations
@@ -150,7 +150,7 @@ function _addComplementaryCertificationColumns({ odsBuilder, certificationCenter
 }
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {OdsUtilsBuilder} params.odsBuilder
  */
 function _addCandidateRows({ odsBuilder, enrolledCandidates, certificationCenterHabilitations, i18n }) {

--- a/api/src/certification/enrolment/infrastructure/repositories/candidate-repository.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/candidate-repository.js
@@ -12,7 +12,7 @@ import { Subscription } from '../../domain/models/Subscription.js';
 
 /**
  * @function
- * @param {Object} params
+ * @param {object} params
  * @param {number} params.certificationCandidateId
  *
  * @returns {Promise<Candidate | null>}
@@ -28,7 +28,7 @@ export async function get({ certificationCandidateId }) {
 
 /**
  * @function
- * @param {Object} params
+ * @param {object} params
  * @param {number} params.sessionId
  *
  * @returns {Promise<Array<Candidate>>}
@@ -43,7 +43,7 @@ export async function findBySessionId({ sessionId }) {
 
 /**
  * @function
- * @param {Object} params
+ * @param {object} params
  * @param {number} params.userId
  *
  * @returns {Promise<Array<Candidate>>}
@@ -141,7 +141,7 @@ export async function insert(candidate) {
 
 /**
  * @function
- * @@param {Object} params
+ * @param {object} params
  * @param {number} params.sessionId
  * @returns {Promise<void>}
  */
@@ -156,7 +156,7 @@ export async function deleteBySessionId({ sessionId }) {
 
 /**
  * @function
- * @param {Object} params
+ * @param {object} params
  * @param {Candidate} params.candidate
  * @param {number} params.sessionId
  * @returns {Promise<number>} return saved candidate id
@@ -194,7 +194,7 @@ export async function saveInSession({ candidate, sessionId }) {
 
 /**
  * @function
- * @param {Object} params
+ * @param {object} params
  * @param {number} params.id
  * @returns {Promise<boolean>}
  */
@@ -240,7 +240,7 @@ function buildBaseReadQuery(knexConnection) {
 }
 
 /**
- * @typedef {Object} CandidateDBModel
+ * @typedef {object} CandidateDBModel
  * @property {number} userId
  * @property {number} sessionId
  * @property {string} firstName
@@ -299,7 +299,7 @@ function adaptModelToDb(candidate) {
 }
 
 /**
- * @typedef {Object} CandidateDTO
+ * @typedef {object} CandidateDTO
  * @property {number} id
  * @property {number} userId
  * @property {number} sessionId
@@ -328,7 +328,7 @@ function adaptModelToDb(candidate) {
  */
 
 /**
- * @typedef {Object} SubscriptionDTO
+ * @typedef {object} SubscriptionDTO
  * @property {string} type
  * @property {ComplementaryCertificationKeys} complementaryCertificationKey
  * @property {number} certificationCandidateId

--- a/api/src/certification/enrolment/infrastructure/repositories/center-repository.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/center-repository.js
@@ -12,7 +12,7 @@ import { Habilitation } from '../../domain/models/Habilitation.js';
 
 /**
  * @function
- * @param {Object} params
+ * @param {object} params
  * @param {number} params.id
  * @returns {Promise<Center>}
  * @throws {NotFoundError}
@@ -66,7 +66,7 @@ export async function getById({ id }) {
 }
 
 /**
- * @typedef {Object} CenterDTO
+ * @typedef {object} CenterDTO
  * @property {number} id
  * @property {string} name
  * @property {string} type
@@ -77,7 +77,7 @@ export async function getById({ id }) {
  */
 
 /**
- * @typedef {Object} HabilitationDTO
+ * @typedef {object} HabilitationDTO
  * @property {number} complementaryCertificationId
  * @property {ComplementaryCertificationKeys} key
  * @property {string} label

--- a/api/src/certification/enrolment/infrastructure/repositories/certification-cpf-city-repository.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/certification-cpf-city-repository.js
@@ -6,7 +6,7 @@ const COLUMNS = ['id', 'name', 'postalCode', 'INSEECode', 'isActualName'];
 
 /**
  * @function
- * @param {Object} params
+ * @param {object} params
  * @param {number} params.INSEECode
  * @returns {Promise<Array<CertificationCpfCity>> }
  */
@@ -23,7 +23,7 @@ const findByINSEECode = async function ({ INSEECode }) {
 
 /**
  * @function
- * @param {Object} params
+ * @param {object} params
  * @param {number} params.postalCode
  * @returns {Promise<Array<CertificationCpfCity>> }
  */

--- a/api/src/certification/enrolment/infrastructure/repositories/certification-cpf-country-repository.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/certification-cpf-country-repository.js
@@ -4,7 +4,7 @@ import { CertificationCpfCountry } from '../../../shared/domain/models/Certifica
 
 /**
  * @function
- * @param {Object} params
+ * @param {object} params
  * @param {string} params.matcher
  * @returns {Promise<CertificationCpfCountry | null> }
  */

--- a/api/src/certification/enrolment/infrastructure/repositories/complementary-certification-badge-with-offset-version-repository.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/complementary-certification-badge-with-offset-version-repository.js
@@ -4,7 +4,7 @@ import { ComplementaryCertificationBadgeWithOffsetVersion } from '../../domain/m
 
 /**
  * @function
- * @param {Object} params
+ * @param {object} params
  * @param {number} params.complementaryCertificationBadgeId
  * @returns {Promise<Array<ComplementaryCertificationBadgeWithOffsetVersion>>}
  */
@@ -37,7 +37,7 @@ export async function getAllWithSameTargetProfile({ complementaryCertificationBa
 }
 
 /**
- * @typedef {Object} ComplementaryCertificationBadgeWithOffsetVersionDTO
+ * @typedef {object} ComplementaryCertificationBadgeWithOffsetVersionDTO
  * @property {number} id
  * @property {number} minimumEarnedPix
  * @property {number} offsetVersion

--- a/api/src/certification/enrolment/infrastructure/repositories/complementary-certification-course-repository.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/complementary-certification-course-repository.js
@@ -3,7 +3,7 @@ import { ComplementaryCertificationCourseWithResults } from '../../domain/models
 
 /**
  * @function
- * @param {Object} params
+ * @param {object} params
  * @param {number} params.userId
  * @returns {Promise<Array<ComplementaryCertificationCourseWithResults>>}
  */

--- a/api/src/certification/enrolment/infrastructure/repositories/complementary-certification-repository.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/complementary-certification-repository.js
@@ -18,7 +18,7 @@ const findAll = async function () {
 export { findAll };
 
 /**
- * @typedef {Object} ComplementaryCertificationDTO
+ * @typedef {object} ComplementaryCertificationDTO
  * @property {number} id
  * @property {string} label
  * @property {ComplementaryCertificationKeys} key

--- a/api/src/certification/enrolment/infrastructure/repositories/enrolled-candidate-repository.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/enrolled-candidate-repository.js
@@ -4,13 +4,13 @@ import { Subscription } from '../../domain/models/Subscription.js';
 import { EnrolledCandidate } from '../../domain/read-models/EnrolledCandidate.js';
 
 /**
- * @typedef {Object} EnrolledCandidateQueryResult
+ * @typedef {object} EnrolledCandidateQueryResult
  * @property {number} id
  * @property {number} sessionId
  * @property {string} firstName
  * @property {string} lastName
  * @property {string} email
- * @property {Array<Object>} subscriptions
+ * @property {Array<object>} subscriptions
  * @property {string} subscriptions.type
  * @property {string} subscriptions.complementaryCertificationKey
  * @property {number} subscriptions.certificationCandidateId
@@ -19,7 +19,7 @@ import { EnrolledCandidate } from '../../domain/read-models/EnrolledCandidate.js
 
 /**
  * @function
- * @param {Object} params
+ * @param {object} params
  * @param {number} params.sessionId
  * @returns {Promise<Array<EnrolledCandidate>>}
  */
@@ -30,7 +30,7 @@ export async function findBySessionId({ sessionId }) {
 }
 
 /**
- * @typedef {Object} CandidateForComparison
+ * @typedef {object} CandidateForComparison
  * @property {string} firstName
  * @property {string} lastName
  */

--- a/api/src/certification/enrolment/infrastructure/repositories/sco-certification-candidate-repository.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/sco-certification-candidate-repository.js
@@ -8,7 +8,7 @@ import { Subscription } from '../../domain/models/Subscription.js';
 
 /**
  * @function
- * @param {Object} params
+ * @param {object} params
  * @param {number} params.sessionId
  * @param {Array<SCOCertificationCandidate>} params.scoCertificationCandidates
  * @returns {Promise<void>}
@@ -49,7 +49,7 @@ const addNonEnrolledCandidatesToSession = async function ({ sessionId, scoCertif
 export { addNonEnrolledCandidatesToSession };
 
 /**
- * @typedef {Object} SCOCertificationCandidateDTO
+ * @typedef {object} SCOCertificationCandidateDTO
  * @property {string} firstName
  * @property {string} lastName
  * @property {Date} birthdate

--- a/api/src/certification/enrolment/infrastructure/repositories/session-for-attendance-sheet-repository.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/session-for-attendance-sheet-repository.js
@@ -5,7 +5,7 @@ import { SessionForAttendanceSheet } from '../../domain/read-models/SessionForAt
 
 /**
  * @function
- * @param {Object} params
+ * @param {object} params
  * @param {number} params.id
  * @returns {Promise<SessionForAttendanceSheet>}
  * @throws {NotFoundError}
@@ -63,7 +63,7 @@ const getWithCertificationCandidates = async function ({ id }) {
 export { getWithCertificationCandidates };
 
 /**
- * @typedef {Object} Results
+ * @typedef {object} Results
  * @property {number} id
  * @property {Date} date
  * @property {Date} time
@@ -77,7 +77,7 @@ export { getWithCertificationCandidates };
  */
 
 /**
- * @typedef {Object} CertificationCandidateDTO
+ * @typedef {object} CertificationCandidateDTO
  * @property {string} firstName
  * @property {string} lastName
  * @property {Date} birthdate

--- a/api/src/certification/enrolment/infrastructure/repositories/session-repository.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/session-repository.js
@@ -8,7 +8,7 @@ import { SessionEnrolment } from '../../domain/models/SessionEnrolment.js';
 
 /**
  * @function
- * @param {Object} params
+ * @param {object} params
  * @param {SessionEnrolment} params.session
  * @returns {Promise<SessionEnrolment>}
  */
@@ -36,7 +36,7 @@ export async function save({ session }) {
 
 /**
  * @function
- * @param {Object} params
+ * @param {object} params
  * @param {number} params.id
  * @returns {Promise<SessionEnrolment>}
  * @throws {NotFoundError}
@@ -57,7 +57,7 @@ export async function get({ id }) {
 
 /**
  * @function
- * @param {Object} params
+ * @param {object} params
  * @param {string} params.address
  * @param {string} params.room
  * @param {Date} params.date
@@ -72,7 +72,7 @@ export async function isSessionExistingByCertificationCenterId({ address, room, 
 
 /**
  * @function
- * @param {Object} params
+ * @param {object} params
  * @param {number} params.sessionId
  * @param {number} params.certificationCenterId
  * @returns {Promise<boolean>}
@@ -103,7 +103,7 @@ export async function update(session) {
 
 /**
  * @function
- * @param {Object} params
+ * @param {object} params
  * @param {number} params.id
  * @returns {Promise<void>}
  * @throws {NotFoundError}

--- a/api/src/certification/evaluation/domain/events/CertificationRescored.js
+++ b/api/src/certification/evaluation/domain/events/CertificationRescored.js
@@ -2,7 +2,7 @@ import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asser
 
 export default class CertificationRescored {
   /**
-   * @param {Object} params
+   * @param {object} params
    * @param {number} params.certificationCourseId - certification course that will be rescored
    * @param {number} params.juryId - ID of the jury member that performs the rescoring action
    */

--- a/api/src/certification/evaluation/domain/models/Candidate.js
+++ b/api/src/certification/evaluation/domain/models/Candidate.js
@@ -13,7 +13,7 @@ export class Candidate {
   });
 
   /**
-   * @param {Object} params
+   * @param {object} params
    * @param {Date} params.reconciledAt
    * @param {boolean} [params.accessibilityAdjustmentNeeded]
    * @param {Scopes} params.subscriptionScope

--- a/api/src/certification/evaluation/domain/services/scoring/calibrated-challenge-service.js
+++ b/api/src/certification/evaluation/domain/services/scoring/calibrated-challenge-service.js
@@ -12,7 +12,7 @@
  * @typedef {import('../../models/CalibratedChallenge.js').CalibratedChallenge} CalibratedChallenge
  */
 /**
- * @typedef {Object} FindByCertificationCourseAndVersionResult
+ * @typedef {object} FindByCertificationCourseAndVersionResult
  * @property {Array<CalibratedChallenge>} allChallenges - All calibrated challenges for the version no matter the locale
  * @property {Array<CalibratedChallenge>} askedChallengesWithoutLiveAlerts - Calibrated challenges presented to the candidate, excluding those with validated live alerts.
  * @property {Array<ChallengeCalibration>} challengeCalibrationsWithoutLiveAlerts - Calibrations of challenges presented to the candidate, excluding those with validated live alerts.
@@ -21,7 +21,7 @@ import { withTransaction } from '../../../../../shared/domain/DomainTransaction.
 
 export const findByCertificationCourseAndVersion = withTransaction(
   /**
-   * @param {Object} params
+   * @param {object} params
    * @param {CertificationCourse} params.certificationCourse
    * @param {Version} params.version
    * @param {ChallengeCalibrationRepository} params.challengeCalibrationRepository
@@ -58,14 +58,14 @@ export const findByCertificationCourseAndVersion = withTransaction(
 );
 
 /**
- * @typedef {Object} FindByCertificationCourseIdObject
+ * @typedef {object} FindByCertificationCourseIdObject
  * @property {Array<CalibratedChallenge>} allChallenges - all challenges data + calibration for this version
  * @property {Array<CalibratedChallenge>} askedChallenges - all challenges data + calibrations PRESENTED to candidate
  * @property {Array<ChallengeCalibration>} challengesCalibrations - only calibrations of challenges PRESENTED to candidate
  */
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {Array<CalibratedChallenge>} params.compatibleChallenges
  * @param {number} params.certificationCourseId
  * @param {ChallengeCalibrationRepository} params.challengeCalibrationRepository

--- a/api/src/certification/evaluation/domain/services/scoring/score-complementary-certification-v2.js
+++ b/api/src/certification/evaluation/domain/services/scoring/score-complementary-certification-v2.js
@@ -15,7 +15,7 @@ import { ComplementaryCertificationScoringWithComplementaryReferential } from '.
 import { ComplementaryCertificationScoringWithoutComplementaryReferential } from '../../models/ComplementaryCertificationScoringWithoutComplementaryReferential.js';
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {AssessmentResultRepository} params.assessmentResultRepository
  * @param {CertificationAssessmentRepository} params.certificationAssessmentRepository
  * @param {ComplementaryCertificationCourseResultRepository} params.complementaryCertificationCourseResultRepository

--- a/api/src/certification/evaluation/domain/services/scoring/score-double-certification-v3.js
+++ b/api/src/certification/evaluation/domain/services/scoring/score-double-certification-v3.js
@@ -12,7 +12,7 @@ import { DoubleCertificationScoring } from '../../models/DoubleCertificationScor
 
 export const scoreDoubleCertificationV3 = withTransaction(
   /**
-   * @param {Object} params
+   * @param {object} params
    * @param {number} params.certificationCourseId
    * @param {CertificationCourseRepository} params.certificationCourseRepository
    * @param {AssessmentResultRepository} params.assessmentResultRepository

--- a/api/src/certification/evaluation/domain/services/scoring/scoring-v2.js
+++ b/api/src/certification/evaluation/domain/services/scoring/scoring-v2.js
@@ -23,7 +23,7 @@ import { CertifiedLevel } from '../../models/CertifiedLevel.js';
 import { CertificationContract } from '../CertificationContract.js';
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {{juryId: number}} params.[event]
  * @param {CertificationAssessment} params.certificationAssessment
  * @param {AssessmentResultRepository} params.assessmentResultRepository
@@ -33,7 +33,7 @@ import { CertificationContract } from '../CertificationContract.js';
  * @param {PlacementProfileService} params.placementProfileService
  * @param {ScoringService} params.scoringService
  * @param {CertificationCandidateRepository} params.certificationCandidateRepository
- * @param {Object} params.dependencies
+ * @param {object} params.dependencies
  * @param {calculateCertificationAssessmentScore} params.dependencies.calculateCertificationAssessmentScore
  */
 export const handleV2CertificationScoring = async ({
@@ -81,7 +81,7 @@ export const handleV2CertificationScoring = async ({
 };
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {CertificationAssessment} params.certificationAssessment
  * @param {ScoringService} params.scoringService
  * @param {CertificationCandidateRepository} params.certificationCandidateRepository
@@ -119,7 +119,7 @@ export const calculateCertificationAssessmentScore = async function ({
 };
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {PlacementProfileService} params.placementProfileService
  */
 async function _getTestedCompetences({ userId, limitDate, version, placementProfileService }) {
@@ -245,7 +245,7 @@ function _getResult(answers, certificationChallenges, testedCompetences, allArea
 }
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {CertificationAssessment} params.certificationAssessment
  */
 function _createV2AssessmentResult({
@@ -310,7 +310,7 @@ function _createV2AssessmentResult({
 }
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {AssessmentResultRepository} params.assessmentResultRepository
  * @param {CompetenceMarkRepository} params.competenceMarkRepository
  */

--- a/api/src/certification/evaluation/domain/services/scoring/scoring-v3.js
+++ b/api/src/certification/evaluation/domain/services/scoring/scoring-v3.js
@@ -3,7 +3,7 @@
  */
 
 /**
- * @typedef {Object} ScoringV3Dependencies
+ * @typedef {object} ScoringV3Dependencies
  * @property {FindByCertificationCourseAndVersion} findByCertificationCourseAndVersion
  */
 
@@ -32,7 +32,7 @@ import { CompetenceMark } from '../../../../shared/domain/models/CompetenceMark.
 
 export const handleV3CertificationScoring = withTransaction(
   /**
-   * @param {Object} params
+   * @param {object} params
    * @param {AssessmentResultRepository} params.assessmentResultRepository
    * @param {CertificationCourseRepository} params.certificationCourseRepository
    * @param {CompetenceMarkRepository} params.competenceMarkRepository
@@ -204,7 +204,7 @@ function _createV3AssessmentResult({
 }
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {AssessmentResultRepository} params.assessmentResultRepository
  * @param {CompetenceMarkRepository} params.competenceMarkRepository
  */

--- a/api/src/certification/evaluation/domain/usecases/create-companion-alert.js
+++ b/api/src/certification/evaluation/domain/usecases/create-companion-alert.js
@@ -6,7 +6,7 @@ import {
 
 export const createCompanionAlert = withTransaction(
   /**
-   * @param {Object} params
+   * @param {object} params
    * @param {number} params.assessmentId
    * @param {import('./index.js').CertificationCompanionAlertRepository} params.certificationCompanionAlertRepository
    **/

--- a/api/src/certification/evaluation/domain/usecases/deneutralize-challenge.js
+++ b/api/src/certification/evaluation/domain/usecases/deneutralize-challenge.js
@@ -5,7 +5,7 @@
 import { ChallengeDeneutralized } from '../events/ChallengeDeneutralized.js';
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {string} params.certificationCourseId
  * @param {string} params.challengeRecId
  * @param {string} params.juryId

--- a/api/src/certification/evaluation/domain/usecases/get-certification-course.js
+++ b/api/src/certification/evaluation/domain/usecases/get-certification-course.js
@@ -5,7 +5,7 @@
  */
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {number} params.certificationCourseId
  * @param {CertificationCandidateRepository} params.certificationCandidateRepository
  * @param {CertificationCourseRepository} params.certificationCourseRepository

--- a/api/src/certification/evaluation/domain/usecases/get-next-challenge.js
+++ b/api/src/certification/evaluation/domain/usecases/get-next-challenge.js
@@ -18,7 +18,7 @@ import { CertificationChallenge } from '../../../shared/domain/models/Certificat
 import { FlashAssessmentAlgorithm } from '../models/FlashAssessmentAlgorithm.js';
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {Assessment} params.assessment
  * @param {string} params.locale
  * @param {AnswerRepository} params.answerRepository

--- a/api/src/certification/evaluation/domain/usecases/neutralize-challenge.js
+++ b/api/src/certification/evaluation/domain/usecases/neutralize-challenge.js
@@ -5,7 +5,7 @@
 import { ChallengeNeutralized } from '../events/ChallengeNeutralized.js';
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {string} params.certificationCourseId
  * @param {string} params.challengeRecId
  * @param {string} params.juryId

--- a/api/src/certification/evaluation/domain/usecases/rescore-v2-certification.js
+++ b/api/src/certification/evaluation/domain/usecases/rescore-v2-certification.js
@@ -32,7 +32,7 @@ const eventTypes = [
 ];
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {AssessmentResultRepository} params.assessmentResultRepository
  * @param {CertificationAssessmentRepository} params.certificationAssessmentRepository
  * @param {ComplementaryCertificationScoringCriteriaRepository} params.complementaryCertificationScoringCriteriaRepository
@@ -72,7 +72,7 @@ export const rescoreV2Certification = async ({
 };
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {number} params.certificationCourseId
  * @param {EvaluationSessionRepository} params.evaluationSessionRepository
  *

--- a/api/src/certification/evaluation/domain/usecases/rescore-v3-certification.js
+++ b/api/src/certification/evaluation/domain/usecases/rescore-v3-certification.js
@@ -31,7 +31,7 @@ const eventTypes = [
 
 export const rescoreV3Certification = withTransaction(
   /**
-   * @param {Object} params
+   * @param {object} params
    * @param {CertificationAssessmentRepository} params.certificationAssessmentRepository
    * @param {EvaluationSessionRepository} params.evaluationSessionRepository
    * @param {Services} services
@@ -62,7 +62,7 @@ export const rescoreV3Certification = withTransaction(
 );
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {number} params.certificationCourseId
  * @param {EvaluationSessionRepository} params.evaluationSessionRepository
  *
@@ -83,11 +83,11 @@ const _verifySessionIsPublishable = async ({ certificationCourseId, evaluationSe
 };
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {CertificationAssessment} params.certificationAssessment
  * @param {CertificationRescoredEvent} params.event
  * @param {string} params.locale
- * @param {Object} params.services
+ * @param {object} params.services
  * @param {HandleV3CertificationScoringService} params.services.handleV3CertificationScoring
  * @param {FindByCertificationCourseAndVersionService} params.services.findByCertificationCourseAndVersionService
  * @param {ScoreDoubleCertificationV3Service} params.services.scoreDoubleCertificationV3

--- a/api/src/certification/evaluation/domain/usecases/retrieve-last-or-create-certification-course.js
+++ b/api/src/certification/evaluation/domain/usecases/retrieve-last-or-create-certification-course.js
@@ -29,7 +29,7 @@ import { ComplementaryCertificationKeys } from '../../../shared/domain/models/Co
 import { Scopes } from '../../../shared/domain/models/Scopes.js';
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {AssessmentRepository} params.assessmentRepository
  * @param {CertificationCandidateRepository} params.sharedCertificationCandidateRepository
  * @param {CertificationCourseRepository} params.certificationCourseRepository
@@ -159,7 +159,7 @@ async function _blockCandidateFromRestartingWithoutExplicitValidation(
 }
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {Session} params.session
  * @param {CertificationCourseRepository} params.certificationCourseRepository
  * @param {CertificationCenterRepository} params.certificationCenterRepository
@@ -244,7 +244,7 @@ async function _startNewCertification({
 }
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {CertificationCourseRepository} params.certificationCourseRepository
  * @param {UserId} params.userId
  * @param {SessionId} params.sessionId
@@ -258,7 +258,7 @@ async function _getCertificationCourseIfCreatedMeanwhile(certificationCourseRepo
 }
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {CertificationCourseRepository} params.certificationCourseRepository
  * @param {AssessmentRepository} params.assessmentRepository
  * @param {VerifyCertificateCodeService} params.verifyCertificateCodeService

--- a/api/src/certification/evaluation/domain/usecases/score-completed-certification.js
+++ b/api/src/certification/evaluation/domain/usecases/score-completed-certification.js
@@ -10,7 +10,7 @@ import { withTransaction } from '../../../../shared/domain/DomainTransaction.js'
 
 export const scoreCompletedCertification = withTransaction(
   /**
-   * @param {Object} params
+   * @param {object} params
    * @param {number} params.certificationCourseId
    * @param {string} params.locale
    * @param {CertificationCourseRepository} params.certificationCourseRepository

--- a/api/src/certification/evaluation/domain/usecases/simulate-flash-assessment-scenario.js
+++ b/api/src/certification/evaluation/domain/usecases/simulate-flash-assessment-scenario.js
@@ -9,7 +9,7 @@ import { AssessmentSimulatorSingleMeasureStrategy } from '../models/AssessmentSi
 import { FlashAssessmentAlgorithm } from '../models/FlashAssessmentAlgorithm.js';
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {number} params.stopAtChallenge - force scenario to stop at challenge before maximumAssessmentLength
  * @param {CalibratedChallengeRepository} params.calibratedChallengeRepository
  * @param {VersionRepository} params.versionRepository
@@ -44,7 +44,7 @@ export async function simulateFlashAssessmentScenario({
 }
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {CalibratedChallengeRepository} params.challengeRepository
  */
 async function _simulateCertificationScenario({

--- a/api/src/certification/evaluation/infrastructure/repositories/calibrated-challenge-repository.js
+++ b/api/src/certification/evaluation/infrastructure/repositories/calibrated-challenge-repository.js
@@ -14,7 +14,7 @@ const TABLE_NAME = 'learningcontent.challenges';
 const VALIDATED_STATUS = 'validé';
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {string} params.locale
  * @param {Version} params.version
  * @returns {Promise<CalibratedChallenge[]>} challenges with validated LCMS status
@@ -60,7 +60,7 @@ export async function findActiveFlashCompatible({
 }
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {Array<string>} params.ids - array of challenge ids
  * @param {Version} params.version
  * @returns {Promise<CalibratedChallenge[]>}
@@ -105,7 +105,7 @@ export async function getMany({
 }
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {Version} params.version
  * @returns {Promise<CalibratedChallenge[]>}
  */

--- a/api/src/certification/evaluation/infrastructure/repositories/certification-challenge-repository.js
+++ b/api/src/certification/evaluation/infrastructure/repositories/certification-challenge-repository.js
@@ -6,7 +6,7 @@
 
 /**
  * @function
- * @param {Object} params
+ * @param {object} params
  * @param {number} params.assessmentId - certification assessment id
  * @param {string} params.locale - candidate locale
  * @param {CertificationEvaluationApi} params.certificationEvaluationApi

--- a/api/src/certification/results/domain/models/CertificationResult.js
+++ b/api/src/certification/results/domain/models/CertificationResult.js
@@ -18,7 +18,7 @@ const status = {
 
 class CertificationResult {
   /**
-   * @param {Object} props
+   * @param {object} props
    * @param {number} props.id
    * @param {string} props.firstName
    * @param {string} props.lastName

--- a/api/src/certification/results/domain/models/PrivateCertificate.js
+++ b/api/src/certification/results/domain/models/PrivateCertificate.js
@@ -15,7 +15,7 @@ const status = Object.freeze({
 
 class PrivateCertificate {
   /**
-   * @param {Object} props
+   * @param {object} props
    * @param {number} props.id
    * @param {string} props.firstName
    * @param {string} props.lastName
@@ -29,7 +29,7 @@ class PrivateCertificate {
    * @param {status} props.status
    * @param {JuryComment} props.commentForCandidate
    * @param {Array<string>} props.certifiedBadgeImages
-   * @param {Object} props.resultCompetenceTree
+   * @param {object} props.resultCompetenceTree
    * @param {string} props.verificationCode
    * @param {Date} props.maxReachableLevelOnCertificationDate
    * @param {number} props.version
@@ -78,7 +78,7 @@ class PrivateCertificate {
   }
 
   /**
-   * @param {Object} props
+   * @param {object} props
    */
   static buildFrom({
     id,

--- a/api/src/certification/results/domain/models/v3/Certificate.js
+++ b/api/src/certification/results/domain/models/v3/Certificate.js
@@ -7,7 +7,7 @@ import { GlobalCertificationLevel } from './GlobalCertificationLevel.js';
 
 export class Certificate {
   /**
-   * @param {Object} props
+   * @param {object} props
    * @param {number} props.id - certification course id
    * @param {string} props.firstName
    * @param {string} props.lastName

--- a/api/src/certification/results/domain/models/v3/GlobalCertificationLevel.js
+++ b/api/src/certification/results/domain/models/v3/GlobalCertificationLevel.js
@@ -12,7 +12,7 @@ export class GlobalCertificationLevel {
   });
 
   /**
-   * @param {Object} props
+   * @param {object} props
    * @param {number} props.score - certification score in Pix
    * @param {MeshConfiguration} props.[configuration] - certification score in Pix
    */

--- a/api/src/certification/results/domain/models/v3/MeshConfiguration.js
+++ b/api/src/certification/results/domain/models/v3/MeshConfiguration.js
@@ -3,7 +3,7 @@ import { CERTIFICATE_LEVELS } from './CertificateLevels.js';
 
 export class MeshConfiguration {
   /**
-   * @typedef {Object} Mesh
+   * @typedef {object} Mesh
    * @property {number} weight - every mesh gives a certain number of pix, called weight
    * @property {number} coefficient - the higher the capacity associated to a mesh, the higher the coefficient
    */

--- a/api/src/certification/results/domain/read-models/CertificationCourseVersion.js
+++ b/api/src/certification/results/domain/read-models/CertificationCourseVersion.js
@@ -2,7 +2,7 @@ import { AlgorithmEngineVersion } from '../../../shared/domain/models/AlgorithmE
 
 class CertificationCourseVersion {
   /**
-   * @param {Object} props
+   * @param {object} props
    * @param {number} props.version
    */
   constructor({ version }) {

--- a/api/src/certification/results/domain/read-models/parcoursup/CertificationResult.js
+++ b/api/src/certification/results/domain/read-models/parcoursup/CertificationResult.js
@@ -2,7 +2,7 @@ import { GlobalCertificationLevel } from '../../models/v3/GlobalCertificationLev
 
 export class CertificationResult {
   /**
-   * @param {Object} props
+   * @param {object} props
    * @param {string} props.[ine]
    * @param {string} props.[organizationUai]
    * @param {string} props.lastName

--- a/api/src/certification/results/domain/read-models/parcoursup/Competence.js
+++ b/api/src/certification/results/domain/read-models/parcoursup/Competence.js
@@ -1,6 +1,6 @@
 export class Competence {
   /**
-   * @param {Object} props
+   * @param {object} props
    * @param {string} props.code
    * @param {string} props.name
    * @param {string} props.areaName

--- a/api/src/certification/results/domain/usecases/find-user-certification-courses.js
+++ b/api/src/certification/results/domain/usecases/find-user-certification-courses.js
@@ -1,5 +1,5 @@
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {number} params.userId
  * @param {import('./index.js').sharedCertificationCourseRepository} params.sharedCertificationCourseRepository
  **/

--- a/api/src/certification/results/domain/usecases/get-certificate.js
+++ b/api/src/certification/results/domain/usecases/get-certificate.js
@@ -3,7 +3,7 @@
  */
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {CertificateRepository} params.certificateRepository
  */
 export const getCertificate = async function ({ certificationCourseId, locale, certificateRepository }) {

--- a/api/src/certification/results/domain/usecases/get-certification-course-by-verification-code.js
+++ b/api/src/certification/results/domain/usecases/get-certification-course-by-verification-code.js
@@ -3,7 +3,7 @@
  */
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {string} params.verificationCode
  * @param {CertificationCourseRepository} params.certificationCourseRepository
  */

--- a/api/src/certification/results/domain/usecases/get-certification-course-version.js
+++ b/api/src/certification/results/domain/usecases/get-certification-course-version.js
@@ -1,5 +1,5 @@
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {number} params.certificationCourseId
  * @param {CertificationCourseRepository} params.certificationCourseRepository
  */

--- a/api/src/certification/results/domain/usecases/get-certification-result-for-parcoursup.js
+++ b/api/src/certification/results/domain/usecases/get-certification-result-for-parcoursup.js
@@ -7,7 +7,7 @@
 import { MoreThanOneMatchingCertificationError } from '../errors.js';
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {string} params.ine
  * @param {string} params.organizationUai
  * @param {string} params.lastName

--- a/api/src/certification/results/domain/usecases/get-private-certificate.js
+++ b/api/src/certification/results/domain/usecases/get-private-certificate.js
@@ -3,7 +3,7 @@
  */
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {number} params.certificationCourseId
  * @param {string} params.locale
  * @param {CertificateRepository} params.certificateRepository

--- a/api/src/certification/results/domain/usecases/get-sco-certification-results-by-division.js
+++ b/api/src/certification/results/domain/usecases/get-sco-certification-results-by-division.js
@@ -6,7 +6,7 @@
 import { NoCertificationResultForDivision } from '../errors.js';
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {CertificationResultRepository} params.certificationResultRepository
  * @param {ScoCertificationCandidateRepository} params.scoCertificationCandidateRepository
  */

--- a/api/src/certification/results/domain/usecases/get-session-certification-reports.js
+++ b/api/src/certification/results/domain/usecases/get-session-certification-reports.js
@@ -3,7 +3,7 @@
  */
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {CertificationReportRepository} params.certificationReportRepository
  */
 const getSessionCertificationReports = async function ({ sessionId, certificationReportRepository }) {

--- a/api/src/certification/results/domain/usecases/get-session-results.js
+++ b/api/src/certification/results/domain/usecases/get-session-results.js
@@ -4,7 +4,7 @@
  */
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {SessionEnrolmentRepository} params.sessionEnrolmentRepository
  * @param {CertificationResultRepository} params.certificationResultRepository
  */

--- a/api/src/certification/results/domain/usecases/get-shareable-certificate.js
+++ b/api/src/certification/results/domain/usecases/get-shareable-certificate.js
@@ -3,7 +3,7 @@
  */
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {number} params.certificationCourseId
  * @param {string} params.locale
  * @param {CertificateRepository} params.certificateRepository

--- a/api/src/certification/results/infrastructure/repositories/sco-certification-candidate-repository.js
+++ b/api/src/certification/results/infrastructure/repositories/sco-certification-candidate-repository.js
@@ -1,7 +1,7 @@
 import { knex } from '../../../../../db/knex-database-connection.js';
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {number} params.organizationId
  * @param {string} params.division
  * @returns {Promise<Array<number>>} candidates identifiers of active students participants to certification sessions within given division

--- a/api/src/certification/results/infrastructure/serializers/parcoursup-certification-serializer.js
+++ b/api/src/certification/results/infrastructure/serializers/parcoursup-certification-serializer.js
@@ -4,10 +4,10 @@
  */
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {CertificationResult} params.certificationResult
  * @param {GlobalCertificationLevel} params.globalMeshLevel
- * @param {Object} params.translate
+ * @param {object} params.translate
  */
 const serialize = ({ certificationResult, translate }) => {
   return {

--- a/api/src/certification/results/infrastructure/utils/pdf/generate-pdf-certificate.js
+++ b/api/src/certification/results/infrastructure/utils/pdf/generate-pdf-certificate.js
@@ -10,7 +10,7 @@ import { generateV3AttestationTemplate } from './templates/certificate.js';
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {Array<Certificate>} params.certificates
  */
 const generate = ({ certificates, i18n }) => {

--- a/api/src/certification/results/infrastructure/utils/pdf/generate-v2-pdf-certificate.js
+++ b/api/src/certification/results/infrastructure/utils/pdf/generate-v2-pdf-certificate.js
@@ -7,7 +7,7 @@ import { generateV2AttestationTemplate } from './templates/certificate.js';
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
 
 /**
- * @param {Object} params
+ * @param {object} params
  */
 const generate = ({ certificates, i18n, isFrenchDomainExtension }) => {
   const doc = new PDFDocument({

--- a/api/src/certification/results/infrastructure/utils/pdf/templates/certificate.js
+++ b/api/src/certification/results/infrastructure/utils/pdf/templates/certificate.js
@@ -12,7 +12,7 @@ const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
 const __badgesDirname = url.fileURLToPath(new URL('../badges/', import.meta.url));
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {Certificate} params.data
  */
 const generateV3AttestationTemplate = function ({ pdf, data, translate }) {

--- a/api/src/certification/scoring/domain/models/CertificationAssessmentHistory.js
+++ b/api/src/certification/scoring/domain/models/CertificationAssessmentHistory.js
@@ -10,7 +10,7 @@ export class CertificationAssessmentHistory {
     this.capacityHistory = capacityHistory;
   }
   /**
-   * @param {Object} params
+   * @param {object} params
    * @param {FlashAssessmentAlgorithm } params.algorithm
    * @param {Array<ChallengeCalibration>} params.challenges
    * @param {Array<Answer>} params.allAnswers

--- a/api/src/certification/scoring/domain/models/CertificationAssessmentScoreV3.js
+++ b/api/src/certification/scoring/domain/models/CertificationAssessmentScoreV3.js
@@ -30,7 +30,7 @@ export class CertificationAssessmentScoreV3 {
   }
 
   /**
-   * @param {Object} params
+   * @param {object} params
    * @param {FlashAssessmentAlgorithm} params.algorithm
    * @param {CalibratedChallenge[]} params.challenges
    * @param {Answer[]} params.allAnswers

--- a/api/src/certification/scoring/domain/services/scoring-degradation-service.js
+++ b/api/src/certification/scoring/domain/services/scoring-degradation-service.js
@@ -17,7 +17,7 @@ const PROBABILITY_TO_PICK_THE_MOST_USEFUL_CHALLENGE_FOR_CANDIDATE_EVALUATION = 1
 /**
  * Downgrades the given capacity based on the flash assessment algorithm configuration and remaining challenges.
  *
- * @param {Object} params
+ * @param {object} params
  * @param {CertificationAlgorithm} params.algorithm - The certification algorithm.
  * @param {number} params.capacity - The current capacity.
  * @param {Challenge[]} params.allChallenges - All available challenges.

--- a/api/src/certification/scoring/domain/usecases/save-certification-scoring-configuration.js
+++ b/api/src/certification/scoring/domain/usecases/save-certification-scoring-configuration.js
@@ -6,8 +6,8 @@ import { withTransaction } from '../../../../shared/domain/DomainTransaction.js'
 
 export const saveCertificationScoringConfiguration = withTransaction(
   /**
-   * @param {Object} params
-   * @param {Object} params.configuration
+   * @param {object} params
+   * @param {object} params.configuration
    * @param {ScoringConfigurationRepository} params.scoringConfigurationRepository
    */
   async ({ configuration, scoringConfigurationRepository }) => {

--- a/api/src/certification/scoring/domain/usecases/save-competence-for-scoring-configuration.js
+++ b/api/src/certification/scoring/domain/usecases/save-competence-for-scoring-configuration.js
@@ -6,8 +6,8 @@ import { withTransaction } from '../../../../shared/domain/DomainTransaction.js'
 
 export const saveCompetenceForScoringConfiguration = withTransaction(
   /**
-   * @param {Object} params
-   * @param {Object} params.configuration
+   * @param {object} params
+   * @param {object} params.configuration
    * @param {ScoringConfigurationRepository} params.scoringConfigurationRepository
    */
   async ({ configuration, scoringConfigurationRepository }) => {

--- a/api/src/certification/session-management/domain/models/CertificationAssessment.js
+++ b/api/src/certification/session-management/domain/models/CertificationAssessment.js
@@ -42,7 +42,7 @@ const certificationAssessmentSchema = Joi.object({
 
 class CertificationAssessment {
   /**
-   * @param {Object} params
+   * @param {object} params
    * @param {Date} params.createdAt certification course creation date
    * @param {Array<CertificationChallengeWithType>} params.certificationChallenges
    * @param {Array<Answer>} params.certificationAnswersByDate

--- a/api/src/certification/session-management/domain/models/CertificationCandidate.js
+++ b/api/src/certification/session-management/domain/models/CertificationCandidate.js
@@ -1,6 +1,6 @@
 class CertificationCandidate {
   /**
-   * @param {Object} param
+   * @param {object} param
    * @param {number} param.userId
    * @param {Date} param.reconciledAt
    */

--- a/api/src/certification/session-management/domain/models/CertificationRescoringByScriptJob.js
+++ b/api/src/certification/session-management/domain/models/CertificationRescoringByScriptJob.js
@@ -2,7 +2,7 @@ import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asser
 
 export class CertificationRescoringByScriptJob {
   /**
-   * @param {Object} params
+   * @param {object} params
    * @param {number} params.certificationCourseId - certification course that will be rescored
    */
   constructor({ certificationCourseId }) {

--- a/api/src/certification/session-management/domain/models/JuryCertification.js
+++ b/api/src/certification/session-management/domain/models/JuryCertification.js
@@ -3,7 +3,7 @@ import { JuryComment, JuryCommentContexts } from '../../../shared/domain/models/
 
 class JuryCertification {
   /**
-   * @param {Object} props
+   * @param {object} props
    * @param {number} props.certificationCourseId
    * @param {number} props.sessionId
    * @param {number} props.userId
@@ -26,8 +26,8 @@ class JuryCertification {
    * @param {JuryComment} props.commentForOrganization
    * @param {string} props.commentByJury
    * @param {Array<string>} props.certificationIssueReports
-   * @param {Object} props.complementaryCertificationCourseResultWithExternal
-   * @param {Object} props.commonComplementaryCertificationCourseResult
+   * @param {object} props.complementaryCertificationCourseResultWithExternal
+   * @param {object} props.commonComplementaryCertificationCourseResult
    * @param {string} props.version
    */
   constructor({

--- a/api/src/certification/session-management/domain/models/JurySession.js
+++ b/api/src/certification/session-management/domain/models/JurySession.js
@@ -7,7 +7,7 @@ import { SESSION_STATUSES } from '../../../shared/domain/constants.js';
 
 class JurySession {
   /**
-   * @param {Object} props
+   * @param {object} props
    * @param {number} props.id
    * @param {string} props.certificationCenterName
    * @param {string} props.certificationCenterType

--- a/api/src/certification/session-management/domain/read-models/AllowedCertificationCenterAccess.js
+++ b/api/src/certification/session-management/domain/read-models/AllowedCertificationCenterAccess.js
@@ -3,7 +3,7 @@
  */
 export class AllowedCertificationCenterAccess {
   /**
-   * @param {Object} params
+   * @param {object} params
    * @param {boolean} params.isAccessBlockedCollege
    * @param {boolean} params.isAccessBlockedLycee
    * @param {boolean} params.isAccessBlockedAEFE

--- a/api/src/certification/session-management/domain/read-models/JurySessionCounters.js
+++ b/api/src/certification/session-management/domain/read-models/JurySessionCounters.js
@@ -1,6 +1,6 @@
 /**
  * @typedef IssueReport
- * @type {Object}
+ * @type {object}
  * @property {string} category
  * @property {string} subcategory
  * @property {Date} resolvedAt
@@ -37,7 +37,7 @@ export class JurySessionCounters {
   impactfullIssueReports = 0;
 
   /**
-   * @param {Object} params
+   * @param {object} params
    * @param {number} params.startedCertifications
    * @param {number} params.certificationsWithScoringError
    * @param {Array<IssueReport>} params.issueReports

--- a/api/src/certification/session-management/domain/read-models/SessionForSupervising.js
+++ b/api/src/certification/session-management/domain/read-models/SessionForSupervising.js
@@ -1,5 +1,5 @@
 /**
- * @typedef {Object} LiveAlert
+ * @typedef {object} LiveAlert
  * @property {string} status
  * @property {boolean} hasImage
  * @property {boolean} hasAttachment
@@ -8,14 +8,14 @@
  */
 
 /**
- * @typedef {Object} ComplementaryCertification
+ * @typedef {object} ComplementaryCertification
  * @property {string} key
  * @property {string} label
  * @property {number} certificationExtraTime
  */
 
 /**
- * @typedef {Object} CertificationCandidateForSupervising
+ * @typedef {object} CertificationCandidateForSupervising
  * @property {number} id
  * @property {number} userId
  * @property {date} birthdate
@@ -30,7 +30,7 @@
 
 class SessionForSupervising {
   /**
-   * @param {Object} params
+   * @param {object} params
    * @param {number} params.id
    * @param {date} params.date
    * @param {string} params.time

--- a/api/src/certification/session-management/domain/services/mail-service.js
+++ b/api/src/certification/session-management/domain/services/mail-service.js
@@ -100,7 +100,7 @@ const mailService = {
 };
 
 /**
- * @typedef {Object} MailService
+ * @typedef {object} MailService
  * @property {function} sendCertificationResultEmail
  * @property {function} sendNotificationToCertificationCenterRefererForCleaResults
  */

--- a/api/src/certification/session-management/domain/services/session-publication-service.js
+++ b/api/src/certification/session-management/domain/services/session-publication-service.js
@@ -18,7 +18,7 @@ import { AssessmentResult } from '../../../../shared/domain/models/AssessmentRes
 import { logger } from '../../../../shared/infrastructure/utils/logger.js';
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {CertificationRepository} params.certificationRepository
  * @param {FinalizedSessionRepository} params.finalizedSessionRepository
  * @param {SessionRepository} params.sessionRepository
@@ -55,11 +55,11 @@ async function publishSession({
 }
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {certificationCenterRepository} params.certificationCenterRepository
  * @param {sessionRepository} params.sessionRepository
  * @param {Array<number>} params.startedCertificationCoursesUserIds
- * @param {Object} params.dependencies
+ * @param {object} params.dependencies
  * @param {mailService} params.dependencies.mailService
  */
 async function manageEmails({
@@ -102,7 +102,7 @@ async function manageEmails({
 }
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {CertificationCenterRepository} params.certificationCenterRepository
  * @param {SessionRepository} params.sessionRepository
  * @param {MailService} params.mailService
@@ -134,10 +134,10 @@ async function _manageCleaEmails({ session, certificationCenterRepository, sessi
 }
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {Array<number>} params.startedCertificationCoursesUserIds
  * @param {MailService} params.mailService
- * @return {Object}
+ * @return {object}
  */
 async function _managePrescriberEmails({ session, startedCertificationCoursesUserIds, mailService }) {
   const recipientEmails = _distinctCandidatesResultRecipientEmails(

--- a/api/src/certification/session-management/domain/usecases/assign-certification-officer-to-jury-session.js
+++ b/api/src/certification/session-management/domain/usecases/assign-certification-officer-to-jury-session.js
@@ -5,7 +5,7 @@
  */
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {JurySessionRepository} params.jurySessionRepository
  * @param {FinalizedSessionRepository} params.finalizedSessionRepository
  * @param {CertificationOfficerRepository} params.certificationOfficerRepository

--- a/api/src/certification/session-management/domain/usecases/authorize-certification-candidate-to-start.js
+++ b/api/src/certification/session-management/domain/usecases/authorize-certification-candidate-to-start.js
@@ -4,7 +4,7 @@
  */
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {CertificationCandidateForSupervisingRepository} params.certificationCandidateForSupervisingRepository
  */
 const authorizeCertificationCandidateToStart = async function ({

--- a/api/src/certification/session-management/domain/usecases/cancel.js
+++ b/api/src/certification/session-management/domain/usecases/cancel.js
@@ -10,7 +10,7 @@ import { CertificationCancelNotAllowedError, NotFinalizedSessionError } from '..
 import { AlgorithmEngineVersion } from '../../../shared/domain/models/AlgorithmEngineVersion.js';
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {number} params.certificationCourseId
  * @param {CertificationCourseRepository} params.certificationCourseRepository
  * @param {SessionRepository} params.sessionRepository

--- a/api/src/certification/session-management/domain/usecases/clear-companion-alert.js
+++ b/api/src/certification/session-management/domain/usecases/clear-companion-alert.js
@@ -2,7 +2,7 @@ import { withTransaction } from '../../../../shared/domain/DomainTransaction.js'
 
 export const clearCompanionAlert = withTransaction(
   /**
-   * @param {Object} params
+   * @param {object} params
    * @param {number} params.sessionId
    * @param {number} params.userId
    * @param {import('./index.js').CertificationCompanionAlertRepository} params.certificationCompanionAlertRepository

--- a/api/src/certification/session-management/domain/usecases/comment-session-as-jury.js
+++ b/api/src/certification/session-management/domain/usecases/comment-session-as-jury.js
@@ -3,7 +3,7 @@
  */
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {number} params.sessionId
  * @param {string} params.juryComment
  * @param {number} params.juryCommentAuthorId

--- a/api/src/certification/session-management/domain/usecases/correct-candidate-identity-in-certification-course.js
+++ b/api/src/certification/session-management/domain/usecases/correct-candidate-identity-in-certification-course.js
@@ -7,7 +7,7 @@ import { CertificationCandidatesError } from '../../../../../src/shared/domain/e
  */
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {CertificationCourseRepository} params.certificationCourseRepository
  * @param {CertificationCpfService} params.certificationCpfService
  * @param {CertificationCpfCountryRepository} params.certificationCpfCountryRepository

--- a/api/src/certification/session-management/domain/usecases/delete-session-jury-comment.js
+++ b/api/src/certification/session-management/domain/usecases/delete-session-jury-comment.js
@@ -3,7 +3,7 @@
  */
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {number} params.sessionId
  * @param {SessionJuryCommentRepository} params.sessionJuryCommentRepository
  **/

--- a/api/src/certification/session-management/domain/usecases/dismiss-live-alert.js
+++ b/api/src/certification/session-management/domain/usecases/dismiss-live-alert.js
@@ -5,7 +5,7 @@
 import { NotFoundError } from '../../../../shared/domain/errors.js';
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {CertificationChallengeLiveAlertRepository} params.certificationChallengeLiveAlertRepository
  */
 export const dismissLiveAlert = async ({ userId, sessionId, certificationChallengeLiveAlertRepository }) => {

--- a/api/src/certification/session-management/domain/usecases/finalize-session.js
+++ b/api/src/certification/session-management/domain/usecases/finalize-session.js
@@ -16,7 +16,7 @@ import { SessionFinalized } from '../read-models/SessionFinalized.js';
 
 const finalizeSession = withTransaction(
   /**
-   * @param {Object} params
+   * @param {object} params
    * @param {SessionRepository} params.sessionRepository
    * @param {CertificationCourseRepository} params.certificationCourseRepository
    * @param {CertificationReportRepository} params.certificationReportRepository

--- a/api/src/certification/session-management/domain/usecases/get-certification-details.js
+++ b/api/src/certification/session-management/domain/usecases/get-certification-details.js
@@ -7,7 +7,7 @@
 import { CertificationDetails } from '../read-models/CertificationDetails.js';
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {number} params.certificationCourseId
  * @param {CompetenceMarkRepository} params.competenceMarkRepository
  * @param {CertificationAssessmentRepository} params.certificationAssessmentRepository

--- a/api/src/certification/session-management/domain/usecases/get-cpf-presigned-urls.js
+++ b/api/src/certification/session-management/domain/usecases/get-cpf-presigned-urls.js
@@ -7,7 +7,7 @@
 import { CpfImportStatus } from '../models/CpfImportStatus.js';
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {CpfExportsStorage} params.cpfExportsStorage
  * @param {CpfExportRepository} params.cpfExportRepository
  */

--- a/api/src/certification/session-management/domain/usecases/get-invigilator-kit-session-info.js
+++ b/api/src/certification/session-management/domain/usecases/get-invigilator-kit-session-info.js
@@ -3,7 +3,7 @@
  */
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {SessionForInvigilatorKitRepository} params.sessionForInvigilatorKitRepository
  */
 const getInvigilatorKitSessionInfo = async function ({ sessionId, sessionForInvigilatorKitRepository }) {

--- a/api/src/certification/session-management/domain/usecases/get-jury-session.js
+++ b/api/src/certification/session-management/domain/usecases/get-jury-session.js
@@ -4,7 +4,7 @@
  */
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {JurySessionRepository} params.jurySessionRepository
  * @returns {JurySession}
  */

--- a/api/src/certification/session-management/domain/usecases/get-session-for-supervising.js
+++ b/api/src/certification/session-management/domain/usecases/get-session-for-supervising.js
@@ -10,7 +10,7 @@ import { DEFAULT_SESSION_DURATION_MINUTES } from '../../../shared/domain/constan
  */
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {SessionForSupervisingRepository} params.sessionForSupervisingRepository
  * @param {CertificationBadgesService} params.certificationBadgesService
  */

--- a/api/src/certification/session-management/domain/usecases/integrate-cpf-processing-receipts.js
+++ b/api/src/certification/session-management/domain/usecases/integrate-cpf-processing-receipts.js
@@ -8,7 +8,7 @@ import { logger } from '../../../../shared/infrastructure/utils/logger.js';
 import { PromiseUtils } from '../../../../shared/infrastructure/utils/promise-utils.js';
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {CpfReceiptsStorage} params.cpfReceiptsStorage
  * @param {CpfCertificationResultRepository} params.cpfCertificationResultRepository
  */
@@ -35,7 +35,7 @@ const integrateCpfProccessingReceipts = async function ({ cpfReceiptsStorage, cp
 export { integrateCpfProccessingReceipts };
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {CpfReceiptsStorage} params.cpfReceiptsStorage
  * @param {CpfCertificationResultRepository} params.cpfCertificationResultRepository
  */

--- a/api/src/certification/session-management/domain/usecases/process-auto-jury.js
+++ b/api/src/certification/session-management/domain/usecases/process-auto-jury.js
@@ -12,7 +12,7 @@ import { CertificationIssueReportResolutionAttempt } from '../models/Certificati
 import { CertificationIssueReportResolutionStrategies } from '../models/CertificationIssueReportResolutionStrategies.js';
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {CertificationRescoringRepository} params.certificationRescoringRepository
  * @param {CertificationCourseRepository} params.certificationCourseRepository
  * @param {CertificationAssessmentRepository} params.certificationAssessmentRepository
@@ -51,7 +51,7 @@ export async function processAutoJury({
 }
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {CertificationRescoringRepository} params.certificationRescoringRepository
  * @param {CertificationAssessmentRepository} params.certificationAssessmentRepository
  */
@@ -98,7 +98,7 @@ async function _handleAutoJuryV2({
 
 const _handleAutoJuryV3 = withTransaction(
   /**
-   * @param {Object} params
+   * @param {object} params
    * @param {CertificationRescoringRepository} params.certificationRescoringRepository
    * @param {CertificationAssessmentRepository} params.certificationAssessmentRepository
    */

--- a/api/src/certification/session-management/domain/usecases/publish-session.js
+++ b/api/src/certification/session-management/domain/usecases/publish-session.js
@@ -5,7 +5,7 @@ import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.j
  */
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {CertificationRepository} params.certificationRepository
  * @param {certificationCenterRepository} params.certificationCenterRepository
  * @param {FinalizedSessionRepository} params.finalizedSessionRepository

--- a/api/src/certification/session-management/domain/usecases/register-publishable-session.js
+++ b/api/src/certification/session-management/domain/usecases/register-publishable-session.js
@@ -9,7 +9,7 @@ import { FinalizedSession } from '../models/FinalizedSession.js';
 
 export const registerPublishableSession = withTransaction(
   /**
-   * @param {Object} params
+   * @param {object} params
    * @param {SessionFinalized} params.sessionFinalized
    * @param {JuryCertificationSummaryRepository} params.juryCertificationSummaryRepository
    * @param {FinalizedSessionRepository} params.finalizedSessionRepository

--- a/api/src/certification/session-management/domain/usecases/supervise-session.js
+++ b/api/src/certification/session-management/domain/usecases/supervise-session.js
@@ -15,7 +15,7 @@ import {
 
 export const superviseSession = withTransaction(
   /**
-   * @param {Object} params
+   * @param {object} params
    * @param {number} params.sessionId
    * @param {string} params.invigilatorPassword
    * @param {number} params.userId

--- a/api/src/certification/session-management/domain/usecases/uncancel.js
+++ b/api/src/certification/session-management/domain/usecases/uncancel.js
@@ -9,7 +9,7 @@ import CertificationUncancelled from '../../../../shared/domain/events/Certifica
 import { AlgorithmEngineVersion } from '../../../shared/domain/models/AlgorithmEngineVersion.js';
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {number} params.certificationCourseId
  * @param {number} params.juryId
  * @param {CertificationCourseRepository} params.certificationCourseRepository

--- a/api/src/certification/session-management/domain/usecases/unfinalize-session.js
+++ b/api/src/certification/session-management/domain/usecases/unfinalize-session.js
@@ -7,7 +7,7 @@ import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.j
 import { SessionAlreadyPublishedError } from '../errors.js';
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {SessionRepository} params.sessionRepository
  * @param {FinalizedSessionRepository} params.finalizedSessionRepository
  */

--- a/api/src/certification/session-management/domain/usecases/update-jury-comment.js
+++ b/api/src/certification/session-management/domain/usecases/update-jury-comment.js
@@ -7,7 +7,7 @@
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { CompetenceMark } from '../../../shared/domain/models/CompetenceMark.js';
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {number} params.certificationCourseId
  * @param {string} params.assessmentResultCommentByJury
  * @param {number} params.juryId

--- a/api/src/certification/session-management/domain/usecases/upload-cpf-files.js
+++ b/api/src/certification/session-management/domain/usecases/upload-cpf-files.js
@@ -3,7 +3,7 @@
  */
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {CpfExportsStorage} params.cpfExportsStorage
  */
 const uploadCpfFiles = async function ({ filename, readableStream, logger, cpfExportsStorage }) {

--- a/api/src/certification/session-management/domain/usecases/validate-live-alert.js
+++ b/api/src/certification/session-management/domain/usecases/validate-live-alert.js
@@ -11,7 +11,7 @@ import { CertificationIssueReport } from '../../../shared/domain/models/Certific
 import { CertificationIssueReportCategory } from '../../../shared/domain/models/CertificationIssueReportCategory.js';
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {CertificationChallengeLiveAlertRepository} params.certificationChallengeLiveAlertRepository
  * @param {AssessmentRepository} params.assessmentRepository
  * @param {IssueReportCategoryRepository} params.issueReportCategoryRepository

--- a/api/src/certification/session-management/infrastructure/repositories/certification-center-access-repository.js
+++ b/api/src/certification/session-management/infrastructure/repositories/certification-center-access-repository.js
@@ -8,7 +8,7 @@ import { AllowedCertificationCenterAccess } from '../../domain/read-models/Allow
  * @function
  * @name getCertificationCenterAccess
  *
- * @param {Object} params
+ * @param {object} params
  * @param {Number} params.certificationCenterId
  * @param {CertificationCenterAccessApi} [params.certificationCenterAccessApi]
  * @returns {Promise<AllowedCertificationCenterAccess>}
@@ -20,7 +20,7 @@ export const getCertificationCenterAccess = async ({ certificationCenterId, cert
 };
 
 /**
- * @param {Object} params
+ * @param {object} params
  */
 const _toDomain = (dto) => {
   return new AllowedCertificationCenterAccess(dto);

--- a/api/src/certification/session-management/infrastructure/repositories/certification-rescoring-repository.js
+++ b/api/src/certification/session-management/infrastructure/repositories/certification-rescoring-repository.js
@@ -5,7 +5,7 @@
  */
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {CertificationJuryDone|CertificationCourseRejected|CertificationCourseUnrejected|CertificationCancelled|CertificationRescored|CertificationUncancelled} params.event
  * @param {CertificationEvaluationApi} params.certificationEvaluationApi
  * @returns {Promise<void>}
@@ -17,7 +17,7 @@ export const rescoreV3Certification = async ({ event, certificationEvaluationApi
 };
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {ChallengeNeutralized|ChallengeDeneutralized|CertificationJuryDone|CertificationCourseRejected|CertificationCourseUnrejected|CertificationCancelled|CertificationRescored|CertificationUncancelled} params.event
  * @param {CertificationEvaluationApi} params.certificationEvaluationApi
  * @returns {Promise<void>}

--- a/api/src/certification/shared/domain/models/CertificationCandidate.js
+++ b/api/src/certification/shared/domain/models/CertificationCandidate.js
@@ -6,7 +6,7 @@ const { isNil } = lodash;
 
 class CertificationCandidate {
   /**
-   * @param {Object} param
+   * @param {object} param
    * @param {Array<Subscription>} param.subscriptions {@link Subscription>}
    */
   constructor({

--- a/api/src/certification/shared/domain/models/CertificationCourse.js
+++ b/api/src/certification/shared/domain/models/CertificationCourse.js
@@ -23,7 +23,7 @@ const V3_CERTIFICATION_AVAILABLE_LANGUAGES = ['fr', 'en'];
 
 export class CertificationCourse {
   /**
-   * @param {Object} props
+   * @param {object} props
    * @param {number} props.id
    * @param {string} props.firstName
    * @param {string} props.lastName

--- a/api/src/certification/shared/domain/models/ComplementaryCertification.js
+++ b/api/src/certification/shared/domain/models/ComplementaryCertification.js
@@ -4,7 +4,7 @@
 
 export class ComplementaryCertification {
   /**
-   * @param {Object} props
+   * @param {object} props
    * @param {number} props.id
    * @param {string} props.label
    * @param {ComplementaryCertificationKeys|string} props.key identifier key

--- a/api/src/certification/shared/domain/models/ComplementaryCertificationBadgeForAdmin.js
+++ b/api/src/certification/shared/domain/models/ComplementaryCertificationBadgeForAdmin.js
@@ -1,6 +1,6 @@
 class ComplementaryCertificationBadgeForAdmin {
   /**
-   * @param {Object} params
+   * @param {object} params
    * @param {number} params.id - Pix core badge identifier
    * @param {number} params.complementaryCertificationBadgeId - Complementary certification badge identifier
    * @param {string} params.label

--- a/api/src/certification/shared/domain/models/FlashAssessmentAlgorithmConfiguration.js
+++ b/api/src/certification/shared/domain/models/FlashAssessmentAlgorithmConfiguration.js
@@ -14,7 +14,7 @@ export class FlashAssessmentAlgorithmConfiguration {
   });
 
   /**
-   * @param {Object} props
+   * @param {object} props
    * @param {number} props.maximumAssessmentLength - limit for assessment length
    * @param {number} props.challengesBetweenSameCompetence - define a number of questions before getting another one on the same competence
    * @param {boolean} [props.limitToOneQuestionPerTube] - limits questions to one per tube

--- a/api/src/certification/shared/domain/models/JuryComment.js
+++ b/api/src/certification/shared/domain/models/JuryComment.js
@@ -27,7 +27,7 @@ const AutoJuryCommentKeys = Object.freeze({
 
 class JuryComment {
   /**
-   * @param {Object} props
+   * @param {object} props
    * @param {AutoJuryCommentKey} [props.commentByAutoJury]
    * @param {string} [props.fallbackComment]
    * @param {JuryCommentContext} props.context mandatory if AutoJuryCommentKeys given

--- a/api/src/certification/shared/domain/models/Version.js
+++ b/api/src/certification/shared/domain/models/Version.js
@@ -25,10 +25,10 @@ export class Version {
   });
 
   /**
-   * @param {Object} params
+   * @param {object} params
    * @param {number} params.id - version identifier
    * @param {Scopes} params.scope - Certification scope (CORE, DROIT, etc.)
-   * @param {Object} params.challengesConfiguration - Challenges configuration
+   * @param {object} params.challengesConfiguration - Challenges configuration
    * @param {number} params.challengesConfiguration.maximumAssessmentLength - limit for assessment length
    * @param {number} params.challengesConfiguration.challengesBetweenSameCompetence - define a number of questions before getting another one on the same competence
    * @param {number} params.challengesConfiguration.defaultCandidateCapacity - capacity when none has been yet determined

--- a/api/src/certification/shared/domain/read-models/CertificationIssueReportCategory.js
+++ b/api/src/certification/shared/domain/read-models/CertificationIssueReportCategory.js
@@ -1,6 +1,6 @@
 /**
  * Class representing a certification issue report category read model
- * @typedef {Object} CertificationIssueReportCategory
+ * @typedef {object} CertificationIssueReportCategory
  * @property {number} id
  */
 

--- a/api/src/certification/shared/domain/services/certification-badges-service.js
+++ b/api/src/certification/shared/domain/services/certification-badges-service.js
@@ -28,8 +28,8 @@ const findLatestBadgeAcquisitions = async function ({
 };
 
 /**
- * @param {Object} params
- * @param {Object} params.dependencies
+ * @param {object} params
+ * @param {object} params.dependencies
  * @param {certifiableBadgeAcquisitionRepository} params.dependencies.certifiableBadgeAcquisitionRepository
  * @param {knowledgeElementRepository} params.dependencies.knowledgeElementRepository
  * @param {badgeForCalculationRepository} params.dependencies.badgeForCalculationRepository

--- a/api/src/certification/shared/infrastructure/repositories/certification-candidate-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/certification-candidate-repository.js
@@ -5,7 +5,7 @@ import { CertificationCandidate } from '../../../shared/domain/models/Certificat
 import { ComplementaryCertification } from '../../domain/models/ComplementaryCertification.js';
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {number} params.sessionId
  * @param {number} params.userId
  * @returns {Promise<CertificationCandidate | undefined>}

--- a/api/src/certification/shared/infrastructure/repositories/certification-challenge-live-alert-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/certification-challenge-live-alert-repository.js
@@ -23,7 +23,7 @@ const getByAssessmentId = async ({ assessmentId }) => {
 };
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {number} params.assessmentId
  * @returns {Array<string>} array of challengeId with validated live alert raised for that assessment
  */

--- a/api/src/certification/shared/infrastructure/repositories/certification-course-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/certification-course-repository.js
@@ -150,7 +150,7 @@ async function findOneCertificationCourseByUserIdAndSessionId({ userId, sessionI
 }
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {number} params.userId
  * @returns {Promise<Array<CertificationCourse>>}
  */
@@ -206,7 +206,7 @@ async function findCertificationCoursesBySessionId({ sessionId }) {
 }
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {number} params.courseId
  * @returns {Promise<Scopes>}
  */

--- a/api/src/certification/shared/infrastructure/repositories/version-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/version-repository.js
@@ -27,7 +27,7 @@ export const getById = async (versionId) => {
 };
 
 /**
- * @param {Object} params
+ * @param {object} params
  * @param {Scopes} params.scope
  * @param {Date} params.reconciliationDate
  * @returns {Promise<Version>}


### PR DESCRIPTION
## ❄️ Problème

Beaucoup de JSDoc dans le domaine de certification contient des paramètres ou des retours contenant le type `Object`
Ce type est non recommandé par la documentation de TypeScript

https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html?utm_source=chatgpt.com

## 🛷 Proposition

Remplacement par le type `object`

## ☃️ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🧑‍🎄 Pour tester

Tests verts ✅ 
