### PR TITLE
[FEATURE] Permet de supprimer un élément du schéma de parcours (PIX-20862).

### DIFF
--- a/admin/app/components/combined-course-blueprints/form.gjs
+++ b/admin/app/components/combined-course-blueprints/form.gjs
@@ -42,7 +42,6 @@ export default class CombineCourseBluePrintForm extends Component {
     } else {
       this.addModule();
     }
-
     document.getElementsByName('itemType')[0].focus();
   }
 
@@ -111,6 +110,11 @@ export default class CombineCourseBluePrintForm extends Component {
       this.setItemValue(event);
       this.addItem(event);
     }
+  }
+
+  @action
+  removeRequirement({ type, value }) {
+    this.blueprint.content = this.blueprint.content.filter((item) => item.value !== value || item.type !== type);
   }
 
   <template>
@@ -223,7 +227,7 @@ export default class CombineCourseBluePrintForm extends Component {
         {{#if (gt this.blueprint.content.length 0)}}
           <ul class="combined-course-page__list">
             {{#each this.blueprint.content as |item|}}
-              <li><RequirementTag @type={{item.type}} @value={{item.value}} />
+              <li><RequirementTag @type={{item.type}} @value={{item.value}} @onRemove={{this.removeRequirement}} />
               </li>
             {{/each}}
           </ul>

--- a/admin/app/components/common/combined-courses/requirement-tag.gjs
+++ b/admin/app/components/common/combined-courses/requirement-tag.gjs
@@ -15,8 +15,12 @@ export default class RequirementTag extends Component {
     this.args.onRemove?.({ type: this.args.type, value: this.args.value });
   }
 
+  get displayRemoveButton() {
+    return this.args.onRemove;
+  }
+
   <template>
-    <PixTag @color={{getItemColor @type}} @displayRemoveButton={{true}} @onRemove={{this.onRemove}}>
+    <PixTag @color={{getItemColor @type}} @displayRemoveButton={{this.displayRemoveButton}} @onRemove={{this.onRemove}}>
       {{t (getItemType @type)}}
       -
       {{@value}}

--- a/admin/app/components/common/combined-courses/requirement-tag.gjs
+++ b/admin/app/components/common/combined-courses/requirement-tag.gjs
@@ -1,4 +1,6 @@
 import PixTag from '@1024pix/pix-ui/components/pix-tag';
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 
 const getItemColor = (type) => (type === 'evaluation' ? 'purple' : 'blue');
@@ -7,10 +9,17 @@ const getItemType = (type) =>
     ? 'components.combined-course-blueprints.items.targetProfile'
     : 'components.combined-course-blueprints.items.module';
 
-<template>
-  <PixTag @color={{getItemColor @type}}>
-    {{t (getItemType @type)}}
-    -
-    {{@value}}
-  </PixTag>
-</template>
+export default class RequirementTag extends Component {
+  @action
+  onRemove() {
+    this.args.onRemove?.({ type: this.args.type, value: this.args.value });
+  }
+
+  <template>
+    <PixTag @color={{getItemColor @type}} @displayRemoveButton={{true}} @onRemove={{this.onRemove}}>
+      {{t (getItemType @type)}}
+      -
+      {{@value}}
+    </PixTag>
+  </template>
+}

--- a/admin/tests/integration/components/combined-course-blueprints/form-test.gjs
+++ b/admin/tests/integration/components/combined-course-blueprints/form-test.gjs
@@ -1,5 +1,5 @@
 import { render } from '@1024pix/ember-testing-library';
-import { fillIn } from '@ember/test-helpers';
+import { click, fillIn } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import CombinedCourseBlueprintForm from 'pix-admin/components/combined-course-blueprints/form';
 import { module, test } from 'qunit';
@@ -17,6 +17,7 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
     // then
     assert.ok(screen.getByRole('heading', { level: 1, name: t('components.combined-course-blueprints.create.title') }));
   });
+
   test('it should save blueprint in store and transition to combined course blueprint screen when data is valid', async function (assert) {
     // given
     const store = this.owner.lookup('service:store');
@@ -77,6 +78,29 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
         message: t('components.combined-course-blueprints.create.notifications.success'),
       }),
     );
+  });
+
+  test('it should remove item when user clicks on remove button', async function (assert) {
+    // given
+    const pixToast = this.owner.lookup('service:pixToast');
+    sinon.stub(pixToast, 'sendSuccessNotification');
+
+    //when
+
+    const screen = await render(<template><CombinedCourseBlueprintForm /></template>);
+
+    await fillIn(
+      screen.getByLabelText(t('components.combined-course-blueprints.create.labels.itemId'), { exact: false }),
+      1,
+    );
+    await click(screen.getByRole('button', { name: t('components.combined-course-blueprints.create.addItemButton') }));
+
+    assert.ok(screen.getByText(/Profil Cible - 1/));
+
+    await click(screen.getByRole('button', { name: 'Supprimer' }));
+
+    //then
+    assert.notOk(screen.queryByText(/Profil Cible - 1/));
   });
 
   module('error cases', function () {

--- a/admin/tests/integration/components/common/combined-courses/requirement-tag-test.gjs
+++ b/admin/tests/integration/components/common/combined-courses/requirement-tag-test.gjs
@@ -45,4 +45,17 @@ module('Integration | Component |  common/combined-courses/requirement-tag', fun
 
     assert.ok(removeStub.calledOnceWith(item));
   });
+
+  test('should hide remove button when onRemove is not provided', async function (assert) {
+    const item = {
+      type: 'module',
+      value: 'abc-123',
+    };
+
+    const screen = await renderScreen(
+      <template><RequirementTag @type={{item.type}} @value={{item.value}} /></template>,
+    );
+
+    assert.notOk(screen.queryByRole('button'));
+  });
 });

--- a/admin/tests/integration/components/common/combined-courses/requirement-tag-test.gjs
+++ b/admin/tests/integration/components/common/combined-courses/requirement-tag-test.gjs
@@ -2,6 +2,7 @@ import { render as renderScreen } from '@1024pix/ember-testing-library';
 import { t } from 'ember-intl/test-support';
 import RequirementTag from 'pix-admin/components/common/combined-courses/requirement-tag';
 import { module, test } from 'qunit';
+import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 
@@ -27,5 +28,21 @@ module('Integration | Component |  common/combined-courses/requirement-tag', fun
       <template><RequirementTag @type={{item.type}} @value={{item.value}} /></template>,
     );
     assert.ok(screen.getByText(t('components.combined-course-blueprints.items.targetProfile'), { exact: false }));
+  });
+
+  test('should call onRemove with value and type when remove button is clicked', async function (assert) {
+    const item = {
+      type: 'module',
+      value: 'abc-123',
+    };
+    const removeStub = sinon.stub();
+
+    const screen = await renderScreen(
+      <template><RequirementTag @type={{item.type}} @value={{item.value}} @onRemove={{removeStub}} /></template>,
+    );
+
+    await screen.getByRole('button').click();
+
+    assert.ok(removeStub.calledOnceWith(item));
   });
 });


### PR DESCRIPTION
## ❄️ Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

Actuellement on ne peut pas supprimer un élément du contenu du schéma de parcours (Profil Cible ou module).

## 🛷 Proposition

On utilise le bouton du suppression du PixTag au sein du RequirementTag pour permettre la suppression d'un élément.

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## ☃️ Remarques

RAS

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🧑‍🎄 Pour tester

Sur Pix Admin, dans la page des schémas de parcours.
Cliquer sur "Créer un schéma de parcours".
Dans le formulaire, ajouter un profil cible et/ou un module.
Vérifier qu'un bouton de suppression est affiché dans le tag (partie "Contenu du parcours").
Vérifier que le clic sur ce bouton supprime le tag en question.
Cliquer sur "Créer le schéma de parcours"
Vérifier que le parcours créé ne contient pas l'élément supprimé.

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
