### PR TITLE
[TECH] :recycle: Rendre possible la migration de donnée des status d'`Assessment` (Pix-20965)

### DIFF
--- a/admin/app/models/certification.js
+++ b/admin/app/models/certification.js
@@ -5,7 +5,7 @@ export const assessmentStates = {
   COMPLETED: 'completed',
   STARTED: 'started',
   ABORTED: 'aborted',
-  ENDED_BY_INVIGILATOR: 'endedBySupervisor',
+  ENDED_BY_INVIGILATOR: 'endedByInvigilator',
   ENDED_DUE_TO_FINALIZATION: 'endedDueToFinalization',
 };
 

--- a/admin/tests/integration/components/certifications/certification/details-v3-test.gjs
+++ b/admin/tests/integration/components/certifications/certification/details-v3-test.gjs
@@ -335,7 +335,7 @@ module('Integration | Component | Certifications | certification > details v3', 
             ];
 
             const model = await store.createRecord('v3-certification-course-details-for-administration', {
-              assessmentState: 'endedBySupervisor',
+              assessmentState: 'endedByInvigilator',
               completedAt: null,
               // eslint-disable-next-line no-restricted-syntax
               endedAt: new Date('2023-01-13T08:05:00'),
@@ -361,7 +361,7 @@ module('Integration | Component | Certifications | certification > details v3', 
             ];
 
             const model = await store.createRecord('v3-certification-course-details-for-administration', {
-              assessmentState: 'endedBySupervisor',
+              assessmentState: 'endedByInvigilator',
               completedAt: null,
               // eslint-disable-next-line no-restricted-syntax
               endedAt: new Date('2023-01-13T08:05:00'),

--- a/admin/tests/unit/models/v3-certification-course-details-for-administration-test.js
+++ b/admin/tests/unit/models/v3-certification-course-details-for-administration-test.js
@@ -88,7 +88,7 @@ module('Unit | Model | v3-certification-course-details-for-administration', func
         endedAt: null,
       },
       {
-        assessmentState: 'endedBySupervisor',
+        assessmentState: 'endedByInvigilator',
         endedAt: new Date('2023-01-13T08:05:00Z'),
         completedAt: null,
       },

--- a/api/src/certification/session-management/domain/models/CertificationAssessment.js
+++ b/api/src/certification/session-management/domain/models/CertificationAssessment.js
@@ -185,11 +185,17 @@ export class CertificationAssessment {
     });
   }
 
+  /**
+   * Added `endedBySupervisor` during transition to rename this value to `endedByInvigilator`
+   * This function is used in SessionRepository to count uncompletedCertificationAssessment
+   * to be compared with abortReason in finalizationUseCase
+   */
   static get uncompletedAssessmentStates() {
     return [
       Assessment.states.STARTED,
       Assessment.states.ENDED_BY_INVIGILATOR,
       Assessment.states.ENDED_DUE_TO_FINALIZATION,
+      'endedBySupervisor',
     ];
   }
 

--- a/api/src/certification/session-management/domain/read-models/JuryCertificationSummary.js
+++ b/api/src/certification/session-management/domain/read-models/JuryCertificationSummary.js
@@ -1,7 +1,7 @@
 import { status as assessmentResultStatuses } from '../../../../shared/domain/models/AssessmentResult.js';
 import { ComplementaryCertificationKeys } from '../../../shared/domain/models/ComplementaryCertificationKeys.js';
 const STARTED = 'started';
-const ENDED_BY_INVIGILATOR = 'endedBySupervisor';
+const ENDED_BY_INVIGILATOR = 'endedByInvigilator';
 const CORE_CERTIFICATION = 'CORE';
 const DOUBLE_CORE_CLEA_CERTIFICATION = 'DOUBLE_CORE_CLEA';
 

--- a/api/src/shared/domain/models/Assessment.js
+++ b/api/src/shared/domain/models/Assessment.js
@@ -16,7 +16,7 @@ const states = {
   COMPLETED: 'completed',
   STARTED: 'started',
   ABORTED: 'aborted',
-  ENDED_BY_INVIGILATOR: 'endedBySupervisor',
+  ENDED_BY_INVIGILATOR: 'endedByInvigilator',
   ENDED_DUE_TO_FINALIZATION: 'endedDueToFinalization',
 };
 
@@ -71,6 +71,11 @@ class Assessment {
     challengeLiveAlerts,
     companionLiveAlerts,
   } = {}) {
+    // Hack during transition to rename to invigilator
+    if (state === 'endedBySupervisor') {
+      state = Assessment.states.ENDED_BY_INVIGILATOR;
+    }
+
     this.id = id;
     this.createdAt = createdAt;
     this.updatedAt = updatedAt;
@@ -103,8 +108,11 @@ class Assessment {
     return this.state === Assessment.states.STARTED;
   }
 
+  /**
+   * Add `endedBySupervisor` condition for transition to rename state to `invigilator`
+   */
   isEndedByInvigilator() {
-    return this.state === Assessment.states.ENDED_BY_INVIGILATOR;
+    return this.state === Assessment.states.ENDED_BY_INVIGILATOR || this.state === 'endedBySupervisor';
   }
 
   hasBeenEndedDueToFinalization() {

--- a/api/tests/certification/session-management/unit/domain/models/CertificationAssessment_test.js
+++ b/api/tests/certification/session-management/unit/domain/models/CertificationAssessment_test.js
@@ -924,6 +924,7 @@ describe('Unit | Domain | Models | CertificationAssessment', function () {
         Assessment.states.STARTED,
         Assessment.states.ENDED_BY_INVIGILATOR,
         Assessment.states.ENDED_DUE_TO_FINALIZATION,
+        'endedBySupervisor',
       ]);
     });
   });

--- a/api/tests/certification/session-management/unit/domain/read-models/JuryCertificationSummary_test.js
+++ b/api/tests/certification/session-management/unit/domain/read-models/JuryCertificationSummary_test.js
@@ -53,7 +53,7 @@ describe('Unit | Domain | Models | JuryCertificationSummary', function () {
         const juryCertificationSummary = new JuryCertificationSummary({ isEndedByInvigilator: true });
 
         // then
-        expect(juryCertificationSummary.status).equal('endedBySupervisor');
+        expect(juryCertificationSummary.status).equal('endedByInvigilator');
       });
     });
 

--- a/api/tests/shared/unit/domain/models/Assessment_test.js
+++ b/api/tests/shared/unit/domain/models/Assessment_test.js
@@ -44,6 +44,17 @@ describe('Unit | Domain | Models | Assessment', function () {
   });
 
   describe('#isEndedByInvigilator', function () {
+    it('should return true when its state is endedBySupervisor (to remove after transition to endedByInvigilator)', function () {
+      // given
+      const assessment = new Assessment({ state: 'endedBySupervisor' });
+
+      // when
+      const isEndedByInvigilator = assessment.isEndedByInvigilator();
+
+      // then
+      expect(isEndedByInvigilator).to.be.true;
+    });
+
     it('should return true when its state is endedByInvigilator', function () {
       // given
       const assessment = new Assessment({ state: Assessment.states.ENDED_BY_INVIGILATOR });

--- a/certif/app/models/certification-candidate-for-supervising.js
+++ b/certif/app/models/certification-candidate-for-supervising.js
@@ -5,7 +5,7 @@ const assessmentStates = {
   COMPLETED: 'completed',
   STARTED: 'started',
   ABORTED: 'aborted',
-  ENDED_BY_INVIGILATOR: 'endedBySupervisor',
+  ENDED_BY_INVIGILATOR: 'endedByInvigilator',
 };
 
 export default class CertificationCandidateForSupervising extends Model {

--- a/certif/tests/unit/models/certification-candidate-for-supervising-test.js
+++ b/certif/tests/unit/models/certification-candidate-for-supervising-test.js
@@ -131,7 +131,7 @@ module('Unit | Model | certification-candidate-for-supervising', function (hooks
     test('returns true if assessmentStatus is endedByInvigilator', function (assert) {
       // given
       const store = this.owner.lookup('service:store');
-      const data = { assessmentStatus: 'endedBySupervisor' };
+      const data = { assessmentStatus: 'endedByInvigilator' };
 
       // when
       const model = store.createRecord('certification-candidate-for-supervising', data);
@@ -150,12 +150,12 @@ module('Unit | Model | certification-candidate-for-supervising', function (hooks
           const challengeLiveAlert = { type: 'challenge', status: 'ongoing' };
 
           // when
-          const certificationCandidateForSupervising = store.createRecord('certification-candidate-for-supervising', {
+          const certificationCandidateForInvigilating = store.createRecord('certification-candidate-for-supervising', {
             challengeLiveAlert,
           });
 
           // then
-          assert.true(certificationCandidateForSupervising.hasOngoingChallengeLiveAlert);
+          assert.true(certificationCandidateForInvigilating.hasOngoingChallengeLiveAlert);
         });
       });
 
@@ -166,12 +166,12 @@ module('Unit | Model | certification-candidate-for-supervising', function (hooks
           const challengeLiveAlert = { status: 'validated' };
 
           // when
-          const certificationCandidateForSupervising = store.createRecord('certification-candidate-for-supervising', {
+          const certificationCandidateForInvigilating = store.createRecord('certification-candidate-for-supervising', {
             challengeLiveAlert,
           });
 
           // then
-          assert.false(certificationCandidateForSupervising.hasOngoingChallengeLiveAlert);
+          assert.false(certificationCandidateForInvigilating.hasOngoingChallengeLiveAlert);
         });
       });
 
@@ -183,13 +183,13 @@ module('Unit | Model | certification-candidate-for-supervising', function (hooks
           const companionLiveAlert = { status: 'ONGOING' };
 
           // when
-          const certificationCandidateForSupervising = store.createRecord('certification-candidate-for-supervising', {
+          const certificationCandidateForInvigilating = store.createRecord('certification-candidate-for-supervising', {
             challengeLiveAlert,
             companionLiveAlert,
           });
 
           // then
-          assert.false(certificationCandidateForSupervising.hasOngoingChallengeLiveAlert);
+          assert.false(certificationCandidateForInvigilating.hasOngoingChallengeLiveAlert);
         });
       });
     });
@@ -204,13 +204,13 @@ module('Unit | Model | certification-candidate-for-supervising', function (hooks
         const companionLiveAlert = { type: 'companion', status: 'ONGOING' };
 
         // when
-        const certificationCandidateForSupervising = store.createRecord('certification-candidate-for-supervising', {
+        const certificationCandidateForInvigilating = store.createRecord('certification-candidate-for-supervising', {
           challengeLiveAlert,
           companionLiveAlert,
         });
 
         // then
-        assert.deepEqual(certificationCandidateForSupervising.currentLiveAlert, companionLiveAlert);
+        assert.deepEqual(certificationCandidateForInvigilating.currentLiveAlert, companionLiveAlert);
       });
     });
   });
@@ -224,12 +224,12 @@ module('Unit | Model | certification-candidate-for-supervising', function (hooks
           const companionLiveAlert = { type: 'companion', status: 'ONGOING' };
 
           // when
-          const certificationCandidateForSupervising = store.createRecord('certification-candidate-for-supervising', {
+          const certificationCandidateForInvigilating = store.createRecord('certification-candidate-for-supervising', {
             companionLiveAlert,
           });
 
           // then
-          assert.true(certificationCandidateForSupervising.hasOngoingCompanionLiveAlert);
+          assert.true(certificationCandidateForInvigilating.hasOngoingCompanionLiveAlert);
         });
       });
 
@@ -240,12 +240,12 @@ module('Unit | Model | certification-candidate-for-supervising', function (hooks
           const companionLiveAlert = { type: 'companion', status: 'CLEARED' };
 
           // when
-          const certificationCandidateForSupervising = store.createRecord('certification-candidate-for-supervising', {
+          const certificationCandidateForInvigilating = store.createRecord('certification-candidate-for-supervising', {
             companionLiveAlert,
           });
 
           // then
-          assert.false(certificationCandidateForSupervising.hasOngoingCompanionLiveAlert);
+          assert.false(certificationCandidateForInvigilating.hasOngoingCompanionLiveAlert);
         });
       });
     });
@@ -258,13 +258,13 @@ module('Unit | Model | certification-candidate-for-supervising', function (hooks
         const companionLiveAlert = null;
 
         // when
-        const certificationCandidateForSupervising = store.createRecord('certification-candidate-for-supervising', {
+        const certificationCandidateForInvigilating = store.createRecord('certification-candidate-for-supervising', {
           challengeLiveAlert,
           companionLiveAlert,
         });
 
         // then
-        assert.false(certificationCandidateForSupervising.hasOngoingCompanionLiveAlert);
+        assert.false(certificationCandidateForInvigilating.hasOngoingCompanionLiveAlert);
       });
     });
   });

--- a/mon-pix/app/models/assessment.js
+++ b/mon-pix/app/models/assessment.js
@@ -8,7 +8,7 @@ export const assessmentStates = {
   COMPLETED: 'completed',
   STARTED: 'started',
   ABORTED: 'aborted',
-  ENDED_BY_INVIGILATOR: 'endedBySupervisor',
+  ENDED_BY_INVIGILATOR: 'endedByInvigilator',
   ENDED_DUE_TO_FINALIZATION: 'endedDueToFinalization',
 };
 export default class Assessment extends Model {


### PR DESCRIPTION
## ❄️ Problème

Le terme `supervisor` utilisé dans pix n'est pas le plus adapté. `Invigilator` convient mieux.

Nous avons un `enum` qui liste les status d'un `assessment` de certification qui contient la valeur `endedBySupervisor`.

Nous ne pouvons pas faire une migration, il y a trop de valeur à modifier.

## 🛷 Proposition

Faire en sorte que nous puissions avoir les deux valeurs `endedBySupervisor` et `endedByInvigilator` en base de données, sans que ça perturbe le fonctionnement de l'application.

Le plan, c'est de considérer dans les applications que nous avons maintenant `endedByInvigilator` comme valeur, et de faire en sorte de transformer les valeurs `endedBySupervisor` des anciens `Assessment` en `endedByInvigilator` le plus « tôt » possible.

## ☃️ Remarques

J'ai essayé d'organiser les commits, un pour Certif, un pour Admin, un pour MonPix et un pour l'API.


## 🧑‍🎄 Pour tester

- ETQ surveillante démarrer une certif 
- ETQ candidate commencer une certif
- ETQ surveillante, l'interrompre
- ETQ surveillante, visualiser que la certification à été interrompu par moi (ou une collègue)
- ETQ qu'administrateur de certif voir que la certif à été interrompu par la surveillante
