### PR TITLE
[TECH] Supprimer le feature toggle de partage automatique (PIX-20962)

### DIFF
--- a/api/config/feature-toggles-config.js
+++ b/api/config/feature-toggles-config.js
@@ -55,13 +55,6 @@ export default {
     defaultValue: false,
     tags: ['modulix', 'team-contenu', 'llm', 'embed', 'pix-app'],
   },
-  isAutoShareEnabled: {
-    type: 'boolean',
-    description: 'Enable automatic campaign sharing.',
-    defaultValue: true,
-    devDefaultValues: { test: true, reviewApp: true },
-    tags: ['frontend', 'team-prescription', 'pix-app'],
-  },
   isSurveyEnabledForCombinedCourses: {
     type: 'boolean',
     description: 'Enables survey button at the end of the combined courses',

--- a/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
+++ b/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
@@ -22,7 +22,6 @@ describe('Acceptance | Shared | Application | Controller | feature-toggle', func
           attributes: {
             'dynamic-feature-toggle-system': false,
             'is-async-quest-rewarding-calculation-enabled': false,
-            'is-auto-share-enabled': true,
             'is-modulix-issue-report-displayed': false,
             'is-survey-enabled-for-combined-courses': true,
             'is-quest-enabled': true,

--- a/mon-pix/app/components/campaign-start-block.gjs
+++ b/mon-pix/app/components/campaign-start-block.gjs
@@ -96,9 +96,6 @@ export default class CampaignStartBlock extends Component {
   }
 
   get legalText() {
-    if (this.featureToggles.featureToggles?.isAutoShareEnabled && this.campaignType === 'assessment') {
-      return this.intl.t(`pages.campaign-landing.${this.campaignType}.legal-with-auto-share`);
-    }
     return this.intl.t(`pages.campaign-landing.${this.campaignType}.legal`);
   }
 

--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/retry-or-reset-block.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/retry-or-reset-block.gjs
@@ -72,8 +72,7 @@ export default class EvaluationResultsHeroRetryOrResetBlock extends Component {
 
   get retryOrResetExplanation() {
     const { canRetry, canReset } = this.args.campaignParticipationResult;
-    const isAutoShareEnabled = this.featureToggles?.featureToggles?.isAutoShareEnabled || false;
-    const suffix = isAutoShareEnabled ? 'notification-with-auto-share' : 'notification';
+    const suffix = 'notification';
 
     if (canReset && canRetry) {
       return this.intl.t(`pages.skill-review.retry-and-reset.${suffix}`);

--- a/mon-pix/app/controllers/assessments/checkpoint.js
+++ b/mon-pix/app/controllers/assessments/checkpoint.js
@@ -22,7 +22,11 @@ export default class CheckpointController extends Controller {
   }
 
   get displayShareResultsBanner() {
-    return this.finalCheckpoint && new Date(this.model.createdAt) <= new Date(ENV.APP.AUTO_SHARE_AFTER_DATE);
+    return (
+      this.finalCheckpoint &&
+      this.model.isForCampaign &&
+      new Date(this.model.createdAt) <= new Date(ENV.APP.AUTO_SHARE_AFTER_DATE)
+    );
   }
 
   get nextPageButtonText() {

--- a/mon-pix/app/models/feature-toggle.js
+++ b/mon-pix/app/models/feature-toggle.js
@@ -3,7 +3,6 @@ import Model, { attr } from '@ember-data/model';
 export default class FeatureToggle extends Model {
   @attr('boolean') isTextToSpeechButtonEnabled;
   @attr('boolean') isQuestEnabled;
-  @attr('boolean') isAutoShareEnabled;
   @attr('boolean') isSurveyEnabledForCombinedCourses;
   @attr('boolean') areModuleShortIdUrlsEnabled;
   @attr('boolean') isModulixIssueReportDisplayed;

--- a/mon-pix/app/routes/campaigns/assessment/results.js
+++ b/mon-pix/app/routes/campaigns/assessment/results.js
@@ -1,6 +1,5 @@
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
-import ENV from 'mon-pix/config/environment';
 
 export default class ResultsRoute extends Route {
   @service currentUser;
@@ -31,7 +30,6 @@ export default class ResultsRoute extends Route {
       }
 
       const trainings = await campaignParticipation.hasMany('trainings').reload();
-
       // Reload the user to display my trainings link on the navbar menu
       if (trainings?.length > 0 && !user.hasRecommendedTrainings) {
         await this.currentUser.load();
@@ -53,20 +51,9 @@ export default class ResultsRoute extends Route {
   }
 
   async afterModel(model) {
-    if (!this.featureToggles.featureToggles?.isAutoShareEnabled) {
-      return;
-    }
     if (model.campaignParticipationResult.isShared) {
       return;
     }
-    const disabledOrganizationIds = ENV.APP.AUTO_SHARE_DISABLED_ORGANIZATION_IDS.map(Number);
-    if (
-      model.campaignParticipation.createdAt <= new Date(ENV.APP.AUTO_SHARE_AFTER_DATE) ||
-      disabledOrganizationIds.includes(model.campaign.organizationId)
-    ) {
-      return;
-    }
-
     await this.store.adapterFor('campaign-participation-result').share(model.campaignParticipationResult.id);
     await model.campaignParticipationResult.reload({
       adapterOptions: { userId: this.currentUser.user.id, campaignId: model.campaign.id },

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -130,7 +130,6 @@ module.exports = function (environment) {
       AUTONOMOUS_COURSES_ORGANIZATION_ID: parseInt(process.env.AUTONOMOUS_COURSES_ORGANIZATION_ID, 10),
       APP_VERSION: process.env.SOURCE_VERSION || 'development',
       AUTO_SHARE_AFTER_DATE: process.env.AUTO_SHARE_AFTER_DATE || '2025-07-18',
-      AUTO_SHARE_DISABLED_ORGANIZATION_IDS: JSON.parse(process.env.AUTO_SHARE_DISABLED_ORGANIZATION_IDS || '[]'),
       COMBINIX_SURVEY_LINK:
         process.env.COMBINIX_SURVEY_LINK ||
         'https://app-eu.123formbuilder.com/index.php?p=login&pactionafter=edit_fields%26id%3D86361%26startup_panel%3Deditor%26click_from%3Dyour_forms',

--- a/mon-pix/sample.env
+++ b/mon-pix/sample.env
@@ -124,8 +124,3 @@
 # type: String
 # default: 2025-07-18
 # AUTO_SHARE_AFTER_DATE=2025-12-31
-
-# presence: optional
-# type: JSON
-# default: []
-# AUTO_SHARE_DISABLED_ORGANIZATION_IDS=[123, 456]

--- a/mon-pix/tests/acceptance/resume-campaigns-with-type-assessment-test.js
+++ b/mon-pix/tests/acceptance/resume-campaigns-with-type-assessment-test.js
@@ -85,21 +85,6 @@ module('Acceptance | Campaigns | Resume Campaigns with type Assessment', functio
       });
     });
 
-    module('When user has already send his results', function () {
-      test('should redirect directly to shared results', async function (assert) {
-        // given
-        const screen = await visit(`/campagnes/${campaign.code}`);
-        await click(screen.getByRole('link', { name: t('pages.checkpoint.actions.next-page.results') }));
-        await click(screen.getByRole('button', { name: "J'envoie mes résultats" }));
-
-        // when
-        await visit(`/campagnes/${campaign.code}`);
-
-        // then
-        assert.ok(currentURL().includes(`/campagnes/${campaign.code}/evaluation/resultats`));
-      });
-    });
-
     module('When the campaign is restricted and organization learner is disabled', function (hooks) {
       hooks.beforeEach(async function () {
         campaign = server.create('campaign', { code: 'FORBIDDEN', isRestricted: true, type: ASSESSMENT });

--- a/mon-pix/tests/integration/components/campaign-start-block-test.js
+++ b/mon-pix/tests/integration/components/campaign-start-block-test.js
@@ -11,11 +11,6 @@ import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 module('Integration | Component | campaign-start-block', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  hooks.beforeEach(function () {
-    const featureToggles = this.owner.lookup('service:featureToggles');
-    sinon.stub(featureToggles, 'featureToggles').value({ isAutoShareEnabled: false });
-  });
-
   module('When the organization has a logo and landing page text', function () {
     test('should display organization logo and landing page text', async function (assert) {
       // given
@@ -157,18 +152,14 @@ module('Integration | Component | campaign-start-block', function (hooks) {
         assert.dom(screen.getByText(t('pages.campaign-landing.assessment.legal'))).exists();
       });
 
-      test('should display legal with auto share', async function (assert) {
-        // given
-        const featureToggles = this.owner.lookup('service:featureToggles');
-        sinon.stub(featureToggles, 'featureToggles').value({ isAutoShareEnabled: true });
-
+      test('should display legal', async function (assert) {
         // when
         const screen = await render(
           hbs`<CampaignStartBlock @campaign={{this.campaign}} @startCampaignParticipation={{this.startCampaignParticipation}} />`,
         );
 
         // then
-        assert.ok(screen.getByText(t('pages.campaign-landing.assessment.legal-with-auto-share')));
+        assert.ok(screen.getByText(t('pages.campaign-landing.assessment.legal')));
       });
 
       test('should display the userName', async function (assert) {

--- a/mon-pix/tests/integration/components/campaigns/assessment/results/evaluation-results-hero/retry-or-reset-block-test.js
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results/evaluation-results-hero/retry-or-reset-block-test.js
@@ -37,6 +37,7 @@ module(
       // then
       assert.dom(screen.getByText(t('pages.skill-review.hero.retry.title'))).exists();
       assert.dom(screen.getByText(t('pages.skill-review.hero.retry.description'))).exists();
+
       assert.dom(screen.getByText(t('pages.skill-review.retry.notification'))).exists();
 
       assert.dom(screen.queryByRole('link', { name: t('pages.skill-review.hero.retry.actions.retry') })).doesNotExist();
@@ -96,64 +97,6 @@ module(
             exact: false,
           }),
         );
-      });
-    });
-
-    module('with auto share enabled', function (hooks) {
-      hooks.beforeEach(function () {
-        const featureToggles = this.owner.lookup('service:featureToggles');
-        sinon.stub(featureToggles, 'featureToggles').value({ isAutoShareEnabled: true });
-      });
-
-      test('should display retry message with auto share', async function (assert) {
-        //given
-        this.set('campaign', { code: 'CODECAMPAIGN' });
-        this.set('campaignParticipationResult', { canRetry: true, canReset: false });
-
-        //when
-        const screen = await render(
-          hbs`<Campaigns::Assessment::Results::EvaluationResultsHero::RetryOrResetBlock
-  @campaign={{this.campaign}}
-  @campaignParticipationResult={{this.campaignParticipationResult}}
-/>`,
-        );
-
-        //then
-        assert.dom(screen.getByText(t('pages.skill-review.retry.notification-with-auto-share'))).exists();
-      });
-
-      test('should display reset message with auto share', async function (assert) {
-        //given
-        this.set('campaign', { code: 'CODECAMPAIGN' });
-        this.set('campaignParticipationResult', { canRetry: false, canReset: true });
-
-        //when
-        const screen = await render(
-          hbs`<Campaigns::Assessment::Results::EvaluationResultsHero::RetryOrResetBlock
-  @campaign={{this.campaign}}
-  @campaignParticipationResult={{this.campaignParticipationResult}}
-/>`,
-        );
-
-        //then
-        assert.ok(screen.getByText(t('pages.skill-review.reset.notification-with-auto-share')));
-      });
-
-      test('should display reset and retry message with auto share', async function (assert) {
-        //given
-        this.set('campaign', { code: 'CODECAMPAIGN' });
-        this.set('campaignParticipationResult', { canRetry: true, canReset: true });
-
-        //when
-        const screen = await render(
-          hbs`<Campaigns::Assessment::Results::EvaluationResultsHero::RetryOrResetBlock
-  @campaign={{this.campaign}}
-  @campaignParticipationResult={{this.campaignParticipationResult}}
-/>`,
-        );
-
-        //then
-        assert.dom(screen.getByText(t('pages.skill-review.retry-and-reset.notification-with-auto-share'))).exists();
       });
     });
 

--- a/mon-pix/tests/unit/controllers/assessments/checkpoint-test.js
+++ b/mon-pix/tests/unit/controllers/assessments/checkpoint-test.js
@@ -12,14 +12,9 @@ module('Unit | Controller | Assessments | Checkpoint', function (hooks) {
   setupIntl(hooks);
 
   let controller;
-  const originalAutoShareDate = ENV.APP.AUTO_SHARE_AFTER_DATE;
 
   hooks.beforeEach(function () {
     controller = this.owner.lookup('controller:assessments/checkpoint');
-  });
-
-  hooks.afterEach(function () {
-    ENV.APP.AUTO_SHARE_AFTER_DATE = originalAutoShareDate;
   });
 
   module('#nextPageButtonText', function () {
@@ -149,10 +144,21 @@ module('Unit | Controller | Assessments | Checkpoint', function (hooks) {
   });
 
   module('#displayShareResultsBanner', function () {
+    test('should return false when assessment is not for campaign', function (assert) {
+      // given
+      ENV.APP.AUTO_SHARE_AFTER_DATE = '2024-01-01';
+      const model = { isForCampaign: false, createdAt: new Date('2023-01-01') };
+      controller.model = model;
+      controller.finalCheckpoint = true;
+
+      // then
+      assert.false(controller.displayShareResultsBanner);
+    });
+
     test('should return true when it is final checkpoint and when assessment created is before auto share date', function (assert) {
       // given
       ENV.APP.AUTO_SHARE_AFTER_DATE = '2024-01-01';
-      const model = { createdAt: new Date('2023-01-01') };
+      const model = { createdAt: new Date('2023-01-01'), isForCampaign: true };
       controller.model = model;
       controller.finalCheckpoint = true;
 
@@ -163,7 +169,7 @@ module('Unit | Controller | Assessments | Checkpoint', function (hooks) {
     test('should return false when assessment created is after auto share date', function (assert) {
       // given
       ENV.APP.AUTO_SHARE_AFTER_DATE = '2024-01-01';
-      const model = { createdAt: new Date('2025-01-01') };
+      const model = { createdAt: new Date('2025-01-01'), isForCampaign: true };
       controller.model = model;
       controller.finalCheckpoint = true;
 
@@ -174,7 +180,7 @@ module('Unit | Controller | Assessments | Checkpoint', function (hooks) {
     test('should return false when it is not final checkpoint', function (assert) {
       // given
       ENV.APP.AUTO_SHARE_AFTER_DATE = '2024-01-01';
-      const model = { createdAt: new Date('2023-01-01') };
+      const model = { createdAt: new Date('2023-01-01'), isForCampaign: true };
       controller.model = model;
       controller.finalCheckpoint = false;
 

--- a/mon-pix/tests/unit/routes/campaigns/assessment/results-test.js
+++ b/mon-pix/tests/unit/routes/campaigns/assessment/results-test.js
@@ -93,43 +93,4 @@ module('Unit | Route | Campaign | Assessment | Results', function (hooks) {
       });
     });
   });
-
-  module('afterModel', function () {
-    module('when isAutoshareEnable', function () {
-      test('should call share if campaign participation is not shared', async function (assert) {
-        // given
-        stubCurrentUserService(this.owner, { id: '1234' });
-        const featureToggleService = this.owner.lookup('service:feature-toggles');
-        sinon.stub(featureToggleService, 'featureToggles').value({ isAutoShareEnabled: true });
-        const store = this.owner.lookup('service:store');
-        const shareSpy = sinon.spy();
-        sinon.stub(store, 'adapterFor').withArgs('campaign-participation-result').returns({ share: shareSpy });
-        const reloadStub = sinon.stub();
-
-        // when
-        await route.afterModel({
-          campaign,
-          campaignParticipation: { createdAt: '2024-01-01' },
-          campaignParticipationResult: { id: 123, isShared: false, reload: reloadStub },
-        });
-
-        // then
-        assert.ok(shareSpy.calledOnce);
-        assert.ok(reloadStub.calledOnce);
-      });
-      test('should not call share if campaign participation is shared', async function (assert) {
-        // given
-        const featureToggleService = this.owner.lookup('service:feature-toggles');
-        sinon.stub(featureToggleService, 'featureToggles').value({ isAutoShareEnabled: true });
-        const store = this.owner.lookup('service:store');
-        const shareSpy = sinon.spy();
-        sinon.stub(store, 'adapterFor').withArgs('campaign-participation-result').returns({ share: shareSpy });
-        // when
-        await route.afterModel({ campaignParticipationResult: { id: 123, isShared: true } });
-
-        // then
-        assert.ok(shareSpy.notCalled);
-      });
-    });
-  });
 });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -601,8 +601,7 @@
           "description": "You will have to carry out searches online, use your digital working environment, test your knowledge, etc.",
           "title": "Measure your digital skills with fun and educational challenges that adapt to your level of proficiency  (through an adaptive algorithm)."
         },
-        "legal": "By clicking on “Begin“, information about your progress will be shared with the organiser so they can assist you if necessary. At the end of your customised test, your results will be shared with your organisation when clicking on “Submit my results“.",
-        "legal-with-auto-share": "By clicking on “Begin your test“, information about your progress will be shared with the organiser so they can assist you if necessary. At the end of your test, your results will be automatically shared with your organisation.",
+        "legal": "By clicking on “Begin your test“, information about your progress will be shared with the organiser so they can assist you if necessary. At the end of your test, your results will be automatically shared with your organisation.",
         "title": "Begin your customised test",
         "title-with-username": "'<span>'{userFirstName}'</span>','<br>' ready to assess your digital skills?"
       },
@@ -2120,18 +2119,15 @@
           "text": "You are about to reset and restart your customised test <strong>{targetProfileName}</strong>, in order to try to improve your results. At the end of this customised test, you can submit your results.",
           "warning-text": "Your pix score, levels and eligibility for certification obtained during this customised test will be deleted."
         },
-        "notification": "If you choose to reset and restart from the beginning, you will need to submit your new results for them to be taken into account by the organizer. Previously submitted results remain accessible to the organizer.",
-        "notification-with-auto-share": "Reset and restart from the beginning. The organiser will continue to have access to your previously submitted results."
+        "notification": "Reset and restart from the beginning. The organiser will continue to have access to your previously submitted results."
       },
       "retry": {
         "button": "Retake my customised test",
         "message": "{organizationName} encourages you to retake your test to measure your progress.",
-        "notification": "Retake the failed questions to improve your result and continue to progress. You will need to send in your results again so that they can be counted by the organiser. The organiser will continue to have access to your previously submitted results.",
-        "notification-with-auto-share": "Retake the failed questions to improve your result and continue to progress. The organiser will continue to have access to your previously submitted results."
+        "notification": "Retake the failed questions to improve your result and continue to progress. The organiser will continue to have access to your previously submitted results."
       },
       "retry-and-reset": {
-        "notification": "If you choose to retry the failed questions or reset and restart from the beginning, you will need to submit your new results for them to be taken into account by the organizer. Previously submitted results remain accessible to the organizer.",
-        "notification-with-auto-share": "Retry the failed questions to improve your result or reset and restart from the beginning. The organiser will continue to have access to your previously submitted results."
+        "notification": "Retry the failed questions to improve your result or reset and restart from the beginning. The organiser will continue to have access to your previously submitted results."
       },
       "send-results": "Don't forget to submit your results.",
       "send-status": {

--- a/mon-pix/translations/es-419.json
+++ b/mon-pix/translations/es-419.json
@@ -601,8 +601,7 @@
           "description": "Deberás realizar búsquedas en internet, utilizar tu entorno de trabajo digital, poner a prueba tus conocimientos, etc.",
           "title": "Medir tus competencias digitales con retos lúdicos y de aprendizaje que se adaptan a tu nivel de competencia (mediante un algoritmo adaptativo)."
         },
-        "legal": "Al hacer clic en «Empiezo» te conectarás a la plataforma y se enviará la información sobre tu progreso en el test al organizador del mismo para que pueda ayudarte si es necesario. Al final del test, haciendo clic en el botón «Envío mis resultados», se enviarán tus resultados al organizador.",
-        "legal-with-auto-share": "Al hacer clic en «Empiezo» te conectarás a la plataforma y se enviará la información sobre tu progreso en el test al organizador del mismo para que pueda ayudarte si es necesario. Al final del test, sus resultados se enviarán automáticamente al organizador.",
+        "legal": "Al hacer clic en «Empiezo» te conectarás a la plataforma y se enviará la información sobre tu progreso en el test al organizador del mismo para que pueda ayudarte si es necesario. Al final del test, sus resultados se enviarán automáticamente al organizador.",
         "title": "Empieza tu test Pix",
         "title-with-username": "'<span>'¿{userFirstName}'</span>','<br>' Listo para evaluar tus habilidades?"
       },
@@ -2107,18 +2106,15 @@
           "text": "Estás a punto de poner a cero el test <strong>{targetProfileName}</strong>, para intentar mejorar tu nivel. Al final del curso, podrás volver a enviar tus resultados.",
           "warning-text": "Tus Pix, niveles y certificabilidad obtenidos durante este test se van a eliminar."
         },
-        "notification": "Si pones a cero para volver a intentarlo todo, tu organización ya no podrá ver tu último resultado. Para que el organizador de la prueba contabilice tu resultado, tendrás que volver a enviarlo.",
-        "notification-with-auto-share": "Vuelva a cero para intentarlo de nuevo. El organizador seguirá teniendo acceso a sus resultados anteriores."
+        "notification": "Vuelva a cero para intentarlo de nuevo. El organizador seguirá teniendo acceso a sus resultados anteriores."
       },
       "retry": {
         "button": "Repetir el test",
         "message": "{organizationName} te invita a repetir este test para mejorar tus resultados y seguir progresando.",
-        "notification": "Vuelva a realizar las preguntas fallidas para mejorar su resultado y seguir progresando. Deberá enviar de nuevo sus resultados para que el organizador pueda contabilizarlos. El organizador seguirá teniendo acceso a tus resultados enviados anteriormente.",
-        "notification-with-auto-share": "Repite las preguntas fallidas para mejorar tu resultado y seguir progresando. El organizador seguirá teniendo acceso a tus resultados anteriores."
+        "notification": "Repite las preguntas fallidas para mejorar tu resultado y seguir progresando. El organizador seguirá teniendo acceso a tus resultados anteriores."
       },
       "retry-and-reset": {
-        "notification": "Si vuelves a intentar las preguntas fallidas o pones a cero para volver a intentarlo todo, tu organización ya no podrá ver tu último resultado. Para que el organizador de la prueba contabilice tu resultado, tendrás que volver a enviarlo.",
-        "notification-with-auto-share": "Repita las preguntas fallidas o vuelva a cero para intentarlo de nuevo. El organizador seguirá teniendo acceso a sus resultados anteriores."
+        "notification": "Repita las preguntas fallidas o vuelva a cero para intentarlo de nuevo. El organizador seguirá teniendo acceso a sus resultados anteriores."
       },
       "send-results": "No olvides enviar tus resultados al organizador del test.",
       "send-status": {

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -601,8 +601,7 @@
           "description": "Deberás realizar búsquedas en internet, utilizar tu entorno de trabajo digital, poner a prueba tus conocimientos, etc.",
           "title": "Medir tus competencias digitales con retos lúdicos y de aprendizaje que se adaptan a tu nivel de competencia (mediante un algoritmo adaptativo)."
         },
-        "legal": "Al hacer clic en «Empiezo» te conectarás a la plataforma y se enviará la información sobre tu progreso en el test al organizador del mismo para que pueda ayudarte si es necesario. Al final del test, haciendo clic en el botón «Envío mis resultados», se enviarán tus resultados al organizador.",
-        "legal-with-auto-share": "Al hacer clic en «Empiezo» te conectarás a la plataforma y se enviará la información sobre tu progreso en el test al organizador del mismo para que pueda ayudarte si es necesario. Al final del test, sus resultados se enviarán automáticamente al organizador.",
+        "legal": "Al hacer clic en «Empiezo» te conectarás a la plataforma y se enviará la información sobre tu progreso en el test al organizador del mismo para que pueda ayudarte si es necesario. Al final del test, sus resultados se enviarán automáticamente al organizador.",
         "title": "Empieza tu test Pix",
         "title-with-username": "'<span>'¿{userFirstName}'</span>','<br>' Listo para evaluar tus habilidades?"
       },
@@ -2107,18 +2106,15 @@
           "text": "Estás a punto de poner a cero el test <strong>{targetProfileName}</strong>, para intentar mejorar tu nivel. Al final del curso, podrás volver a enviar tus resultados.",
           "warning-text": "Tus Pix, niveles y certificabilidad obtenidos durante este test se van a eliminar."
         },
-        "notification": "Si pones a cero para volver a intentarlo todo, tu organización ya no podrá ver tu último resultado. Para que el organizador de la prueba contabilice tu resultado, tendrás que volver a enviarlo.",
-        "notification-with-auto-share": "Vuelva a cero para intentarlo de nuevo. El organizador seguirá teniendo acceso a sus resultados anteriores."
+        "notification": "Vuelva a cero para intentarlo de nuevo. El organizador seguirá teniendo acceso a sus resultados anteriores."
       },
       "retry": {
         "button": "Repetir el test",
         "message": "{organizationName} te invita a repetir este test para mejorar tus resultados y seguir progresando.",
-        "notification": "Vuelva a realizar las preguntas fallidas para mejorar su resultado y seguir progresando. Deberá enviar de nuevo sus resultados para que el organizador pueda contabilizarlos. El organizador seguirá teniendo acceso a tus resultados enviados anteriormente.",
-        "notification-with-auto-share": "Repite las preguntas fallidas para mejorar tu resultado y seguir progresando. El organizador seguirá teniendo acceso a tus resultados anteriores."
+        "notification": "Repite las preguntas fallidas para mejorar tu resultado y seguir progresando. El organizador seguirá teniendo acceso a tus resultados anteriores."
       },
       "retry-and-reset": {
-        "notification": "Si vuelves a intentar las preguntas fallidas o pones a cero para volver a intentarlo todo, tu organización ya no podrá ver tu último resultado. Para que el organizador de la prueba contabilice tu resultado, tendrás que volver a enviarlo.",
-        "notification-with-auto-share": "Repita las preguntas fallidas o vuelva a cero para intentarlo de nuevo. El organizador seguirá teniendo acceso a sus resultados anteriores."
+        "notification": "Repita las preguntas fallidas o vuelva a cero para intentarlo de nuevo. El organizador seguirá teniendo acceso a sus resultados anteriores."
       },
       "send-results": "No olvides enviar tus resultados al organizador del test.",
       "send-status": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -601,8 +601,7 @@
           "description": "Vous serez amené à effectuer des recherches sur internet, utiliser votre environnement numérique de travail, tester vos connaissances, etc.",
           "title": "Mesurer vos compétences numériques avec des défis ludiques et apprenants qui s'adaptent à votre niveau de maîtrise (via un algorithme adaptatif)."
         },
-        "legal": "En cliquant sur “Je commence”, les informations relatives à votre avancée dans le parcours seront transmises à l’organisateur du parcours pour lui permettre de vous accompagner. A la fin du parcours, en cliquant sur le bouton “J’envoie mes résultats” vos résultats seront transmis à l’organisateur.",
-        "legal-with-auto-share": "En cliquant sur “Je commence”, les informations relatives à votre avancée dans le parcours seront transmises à l’organisateur du parcours pour lui permettre de vous accompagner. À la fin du parcours, vos résultats seront transmis automatiquement à l’organisateur.",
+        "legal": "En cliquant sur “Je commence”, les informations relatives à votre avancée dans le parcours seront transmises à l’organisateur du parcours pour lui permettre de vous accompagner. À la fin du parcours, vos résultats seront transmis automatiquement à l’organisateur.",
         "title": "Commencez votre parcours Pix",
         "title-with-username": "'<span>'{userFirstName}'</span>','<br>' prêt à évaluer vos compétences numériques ?"
       },
@@ -2128,18 +2127,15 @@
           "text": "Vous êtes sur le point de remettre à zéro votre parcours <strong>{targetProfileName}</strong>, afin de tenter d’améliorer votre niveau. A la fin du parcours, vous pourrez à nouveau envoyer vos résultats.",
           "warning-text": "Vos Pix, vos niveaux et votre certificabilité obtenus lors de ce parcours vont être supprimés."
         },
-        "notification": "Si vous remettez à zéro pour tout retenter, vous devrez à nouveau envoyer vos résultats afin qu’ils soient comptabilisés par l’organisateur. Il continuera d’avoir accès à vos résultats précédemment envoyés.",
-        "notification-with-auto-share": "Remettez à zéro pour tout retenter. L'organisateur continuera d’avoir accès à vos résultats précédemment envoyés."
+        "notification": "Remettez à zéro pour tout retenter. L'organisateur continuera d’avoir accès à vos résultats précédemment envoyés."
       },
       "retry": {
         "button": "Repasser mon parcours",
         "message": "{organizationName} vous invite à repasser ce parcours afin d'améliorer votre résultat et de continuer à progresser.",
-        "notification": "Repassez les questions échouées afin d'améliorer votre résultat et de continuer à progresser. Vous devrez à nouveau envoyer vos résultats afin qu’ils soient comptabilités par l’organisateur. Il continuera d’avoir accès à vos résultats précédemment envoyés.",
-        "notification-with-auto-share": "Repassez les questions échouées afin d'améliorer votre résultat et de continuer à progresser. L'organisateur continuera d’avoir accès à vos résultats précédemment envoyés."
+        "notification": "Repassez les questions échouées afin d'améliorer votre résultat et de continuer à progresser. L'organisateur continuera d’avoir accès à vos résultats précédemment envoyés."
       },
       "retry-and-reset": {
-        "notification": "Si vous repassez les questions échouées ou remettez à zéro pour tout retenter, vous devrez à nouveau envoyer vos résultats afin qu’ils soient comptabilisés par l’organisateur. Il continuera d’avoir accès à vos résultats précédemment envoyés.",
-        "notification-with-auto-share": "Repassez les questions échouées ou remettez à zéro pour tout retenter. L'organisateur continuera d’avoir accès à vos résultats précédemment envoyés."
+        "notification": "Repassez les questions échouées ou remettez à zéro pour tout retenter. L'organisateur continuera d’avoir accès à vos résultats précédemment envoyés."
       },
       "send-results": "N'oubliez pas d'envoyer vos résultats à l'organisateur du parcours.",
       "send-status": {

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -601,8 +601,7 @@
           "description": "Je zult internetopzoekingen moeten doen, je digitale werkomgeving moeten gebruiken, je kennis moeten testen, enz.",
           "title": "Meet je digitale vaardigheden met leuke leeruitdagingen die zich aanpassen aan je vaardigheidsniveau (met behulp van een adaptief algoritme)."
         },
-        "legal": "Door op \"Ik begin\" te klikken, wordt informatie over je voortgang tijdens de cursus naar de cursusorganisator gestuurd zodat zij je kunnen ondersteunen. Als je aan het einde van de cursus op de knop \"Stuur mijn resultaten\" klikt, worden je resultaten naar de organisator gestuurd.",
-        "legal-with-auto-share": "Door op \"Ik begin\" te klikken, wordt informatie over je voortgang tijdens de cursus naar de cursusorganisator gestuurd zodat zij je kunnen ondersteunen. Aan het einde van je test worden je resultaten automatisch gedeeld met je organisatie.",
+        "legal": "Door op \"Ik begin\" te klikken, wordt informatie over je voortgang tijdens de cursus naar de cursusorganisator gestuurd zodat zij je kunnen ondersteunen. Aan het einde van je test worden je resultaten automatisch gedeeld met je organisatie.",
         "title": "Begin je Pix-reis",
         "title-with-username": "'<span>'{userFirstName}'</span>','<br>' ben je klaar om je vaardigheden te testen?"
       },
@@ -2111,18 +2110,15 @@
           "text": "Je staat op het punt om je <strong>{targetProfileName}</strong> cursus te resetten in een poging om je niveau te verbeteren. Aan het einde van de cursus kun je je resultaten weer insturen.",
           "warning-text": "Je Pix, niveaus en certificeerbaarheid verkregen tijdens deze cursus zullen worden verwijderd."
         },
-        "notification": "Als u alles op nul zet om opnieuw te beginnen, kan uw organisatie uw laatste resultaat niet meer zien. Om uw resultaat door de organisator van de test te laten meetellen, moet u het opnieuw indienen.",
-        "notification-with-auto-share": "Zet alles op nul om opnieuw te beginnen. De organisator blijft toegang hebben tot uw eerder ingediende resultaten."
+        "notification": "Zet alles op nul om opnieuw te beginnen. De organisator blijft toegang hebben tot uw eerder ingediende resultaten."
       },
       "retry": {
         "button": "Mijn reis naspelen",
         "message": "{organizationName} nodigt je uit om deze test opnieuw te doen om je resultaat te verbeteren en vooruitgang te blijven boeken.",
-        "notification": "Herhaal de vragen waarvoor je gezakt bent om je resultaat te verbeteren en verder te komen. Je moet je resultaten opnieuw insturen zodat ze kunnen worden geteld door de organisator. De organisator blijft toegang houden tot je eerder ingestuurde resultaten.",
-        "notification-with-auto-share": "Herhaal mislukte vragen om je resultaat te verbeteren en verder te gaan. De organisator blijft toegang houden tot je eerder ingediende resultaten."
+        "notification": "Herhaal mislukte vragen om je resultaat te verbeteren en verder te gaan. De organisator blijft toegang houden tot je eerder ingediende resultaten."
       },
       "retry-and-reset": {
-        "notification": "Als je de mislukte vragen opnieuw probeert of alles op nul zet om alles opnieuw te proberen, kan je organisatie je laatste resultaat niet meer zien. Om je resultaat mee te laten tellen door de organisator van de test, moet je het opnieuw insturen.",
-        "notification-with-auto-share": "Herhaal mislukte vragen of stel in op nul om het opnieuw te proberen. De organisator blijft toegang houden tot je eerder ingediende resultaten."
+        "notification": "Herhaal mislukte vragen of stel in op nul om het opnieuw te proberen. De organisator blijft toegang houden tot je eerder ingediende resultaten."
       },
       "send-results": "Vergeet niet je resultaten naar de cursusorganisator te sturen.",
       "send-status": {


### PR DESCRIPTION
## ❄️ Problème

Le feature toggle `isAutoShareEnabled` pour le partage automatique des résultats de campagne n'est plus nécessaire. La fonctionnalité est maintenant stable et activée par défaut pour toutes les organisations.

## 🛷 Proposition

Suppression du feature toggle et de toute la logique conditionnelle associée.

### Backend (API)

- Suppression du feature toggle `isAutoShareEnabled` dans `config/feature-toggles-config.js`

### Frontend (Mon Pix)
- Suppression de l'attribut `isAutoShareEnabled` du modèle `feature-toggle`
- Simplification de la logique dans `campaign-start-block.gjs` pour toujours afficher le texte légal avec auto-partage
- Simplification de `retry-or-reset-block.gjs` pour toujours utiliser les notifications avec auto-partage
- Nettoyage de la route `campaigns/assessment/results.js` pour supprimer les conditions basées sur le toggle
- Suppression de la variable d'environnement `AUTO_SHARE_DISABLED_ORGANIZATION_IDS`
- Mise à jour du contrôleur `assessments/checkpoint` pour vérifier que l'évaluation est bien pour une campagne avant d'afficher la bannière de partage

## ☃️ Remarques

On supprime egalement la variable d'environnement `AUTO_SHARE_DISABLED_ORGANIZATION_IDS`
On garde `AUTO_SHARE_AFTER_DATE` pour pouvoir afficher la bannière pour les campagnes débutées avant la généralisation du partage automatique.

## 🧑‍🎄 Pour tester

🆗 