### PR TITLE
[TECH] Ajout de JSDoc dans le `certification-candidate-repository`

### DIFF
--- a/api/db/database-builder/factory/build-certification-version.js
+++ b/api/db/database-builder/factory/build-certification-version.js
@@ -1,5 +1,5 @@
 import { DEFAULT_SESSION_DURATION_MINUTES } from '../../../src/certification/shared/domain/constants.js';
-import { Scopes } from '../../../src/certification/shared/domain/models/Scopes.js';
+import { SCOPES } from '../../../src/certification/shared/domain/models/Scopes.js';
 import { databaseBuffer } from '../database-buffer.js';
 
 const defaultChallengesConfiguration = {
@@ -137,7 +137,7 @@ const defaultCompetencesScoringConfiguration = [
 
 export const buildCertificationVersion = function ({
   id = databaseBuffer.getNextId(),
-  scope = Scopes.CORE,
+  scope = SCOPES.CORE,
   startDate = new Date('1977-10-19'),
   expirationDate = null,
   assessmentDuration = DEFAULT_SESSION_DURATION_MINUTES,

--- a/api/db/seeds/data/team-certification/shared/common-certification-versions.js
+++ b/api/db/seeds/data/team-certification/shared/common-certification-versions.js
@@ -2,7 +2,7 @@ import dayjs from 'dayjs';
 import _ from 'lodash';
 
 import { usecases as configurationUsecases } from '../../../../../src/certification/configuration/domain/usecases/index.js';
-import { Scopes } from '../../../../../src/certification/shared/domain/models/Scopes.js';
+import { SCOPES } from '../../../../../src/certification/shared/domain/models/Scopes.js';
 import { usecases as learningContentUsecases } from '../../../../../src/learning-content/domain/usecases/index.js';
 import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
 import { FRENCH_SPOKEN } from '../../../../../src/shared/domain/services/locale-service.js';
@@ -42,7 +42,7 @@ export class CommonCertificationVersions {
         this.coreVersion.currentVersionId = await this.#createActiveFrameworkVersion({
           databaseBuilder,
           fromLcmsFrameworkName: coreFrameworkName,
-          toFrameworkScope: Scopes.CORE,
+          toFrameworkScope: SCOPES.CORE,
         });
       }
     } catch (error) {
@@ -68,7 +68,7 @@ export class CommonCertificationVersions {
         this.pixPlusDroitVersion.currentVersionId = await this.#createActiveFrameworkVersion({
           databaseBuilder,
           fromLcmsFrameworkName: pixPlusDroitFrameworkName,
-          toFrameworkScope: Scopes.PIX_PLUS_DROIT,
+          toFrameworkScope: SCOPES.PIX_PLUS_DROIT,
         });
       }
     } catch (error) {
@@ -94,7 +94,7 @@ export class CommonCertificationVersions {
         this.pixPlusEdu1erDegreVersion.currentVersionId = await this.#createActiveFrameworkVersion({
           databaseBuilder,
           fromLcmsFrameworkName: pixPlusEdu1erDegreFrameworkName,
-          toFrameworkScope: Scopes.PIX_PLUS_EDU_1ER_DEGRE,
+          toFrameworkScope: SCOPES.PIX_PLUS_EDU_1ER_DEGRE,
         });
       }
     } catch (error) {
@@ -191,7 +191,7 @@ export class CommonCertificationVersions {
    */
   static async #createExpiredCoreVersion({ databaseBuilder }) {
     const expiredVersionId = await configurationUsecases.createCertificationVersion({
-      scope: Scopes.CORE,
+      scope: SCOPES.CORE,
       tubeIds: [],
     });
 

--- a/api/scripts/certification/delete-complementary-certification-frameworks-challenges.js
+++ b/api/scripts/certification/delete-complementary-certification-frameworks-challenges.js
@@ -1,5 +1,5 @@
 import { knex } from '../../db/knex-database-connection.js';
-import { Scopes } from '../../src/certification/shared/domain/models/Scopes.js';
+import { SCOPES } from '../../src/certification/shared/domain/models/Scopes.js';
 import { Script } from '../../src/shared/application/scripts/script.js';
 import { ScriptRunner } from '../../src/shared/application/scripts/script-runner.js';
 
@@ -25,10 +25,10 @@ export class DeleteComplementaryCertificationFrameworksChallenges extends Script
     const trx = await knex.transaction();
     try {
       const allChallenges = await trx('certification-frameworks-challenges');
-      const challengesToBeDeleted = await trx('certification-frameworks-challenges').where('scope', '!=', Scopes.CORE);
+      const challengesToBeDeleted = await trx('certification-frameworks-challenges').where('scope', '!=', SCOPES.CORE);
       logger.info(`Number of challenges to be deleted: ${challengesToBeDeleted.length}`);
 
-      await trx('certification-frameworks-challenges').where('scope', '!=', Scopes.CORE).delete();
+      await trx('certification-frameworks-challenges').where('scope', '!=', SCOPES.CORE).delete();
 
       if (dryRun) {
         await trx.rollback();

--- a/api/src/certification/configuration/application/certification-framework-route.js
+++ b/api/src/certification/configuration/application/certification-framework-route.js
@@ -1,7 +1,7 @@
 import Joi from 'joi';
 
 import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
-import { Scopes } from '../../shared/domain/models/Scopes.js';
+import { SCOPES } from '../../shared/domain/models/Scopes.js';
 import { certificationFrameworkController } from './certification-framework-controller.js';
 
 const register = async function (server) {
@@ -50,7 +50,7 @@ const register = async function (server) {
           params: Joi.object({
             scope: Joi.string()
               .required()
-              .valid(...Object.values(Scopes)),
+              .valid(...Object.values(SCOPES)),
           }),
         },
         handler: certificationFrameworkController.getActiveConsolidatedFramework,
@@ -82,7 +82,7 @@ const register = async function (server) {
           params: Joi.object({
             scope: Joi.string()
               .required()
-              .valid(...Object.values(Scopes)),
+              .valid(...Object.values(SCOPES)),
           }),
         },
         handler: certificationFrameworkController.getFrameworkHistory,

--- a/api/src/certification/configuration/application/certification-version-route.js
+++ b/api/src/certification/configuration/application/certification-version-route.js
@@ -5,7 +5,7 @@ const Joi = BaseJoi.extend(JoiDate);
 
 import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
 import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
-import { Scopes } from '../../shared/domain/models/Scopes.js';
+import { SCOPES } from '../../shared/domain/models/Scopes.js';
 import { certificationVersionController } from './certification-version-controller.js';
 
 const register = async function (server) {
@@ -28,7 +28,7 @@ const register = async function (server) {
           params: Joi.object({
             scope: Joi.string()
               .required()
-              .valid(...Object.values(Scopes)),
+              .valid(...Object.values(SCOPES)),
           }),
         },
         handler: certificationVersionController.getActiveVersionByScope,
@@ -80,7 +80,7 @@ const register = async function (server) {
               attributes: {
                 scope: Joi.string()
                   .required()
-                  .valid(...Object.values(Scopes)),
+                  .valid(...Object.values(SCOPES)),
                 'start-date': Joi.date().required(),
                 'expiration-date': Joi.date().allow(null).optional(),
                 'assessment-duration': Joi.number().integer().min(0).required(),

--- a/api/src/certification/configuration/domain/models/Version.js
+++ b/api/src/certification/configuration/domain/models/Version.js
@@ -1,19 +1,15 @@
-/**
- * @typedef {import('../../../shared/domain/models/Scopes.js').Scopes} Scopes
- */
-
 import Joi from 'joi';
 
 import { EntityValidationError } from '../../../../shared/domain/errors.js';
 import { FlashAssessmentAlgorithmConfiguration } from '../../../shared/domain/models/FlashAssessmentAlgorithmConfiguration.js';
-import { Scopes } from '../../../shared/domain/models/Scopes.js';
+import { SCOPES } from '../../../shared/domain/models/Scopes.js';
 
 export class Version {
   static #schema = Joi.object({
     id: Joi.number().optional(),
     scope: Joi.string()
       .required()
-      .valid(...Object.values(Scopes)),
+      .valid(...Object.values(SCOPES)),
     startDate: Joi.date().required(),
     expirationDate: Joi.date().allow(null).optional(),
     assessmentDuration: Joi.number().required(),
@@ -25,7 +21,7 @@ export class Version {
   /**
    * @param {object} params
    * @param {number} [params.id] - version identifier (optional for new versions)
-   * @param {Scopes} params.scope - Certification scope (CORE, DROIT, etc.)
+   * @param {SCOPES} params.scope - Certification scope (CORE, DROIT, etc.)
    * @param {Date} params.startDate - When this version becomes active
    * @param {Date|null} [params.expirationDate] - When this version expires (null if current)
    * @param {number} params.assessmentDuration - Assessment duration in minutes

--- a/api/src/certification/configuration/domain/usecases/create-certification-version.js
+++ b/api/src/certification/configuration/domain/usecases/create-certification-version.js
@@ -1,5 +1,5 @@
 /**
- * @typedef {import ('../../../shared/domain/models/Scopes.js').Scopes} Scopes
+ * @typedef {import ('../../../shared/domain/models/Scopes.js').SCOPES} SCOPES
  * @typedef {import ('./index.js').TubeRepository} TubeRepository
  * @typedef {import ('./index.js').SkillRepository} SkillRepository
  * @typedef {import ('./index.js').ChallengeRepository} ChallengeRepository
@@ -20,7 +20,7 @@ import { Version } from '../models/Version.js';
 export const createCertificationVersion = withTransaction(
   /**
    * @param {object} params
-   * @param {Scopes} params.scope
+   * @param {SCOPES} params.scope
    * @param {Array<string>} params.tubeIds
    * @param {TubeRepository} params.tubeRepository
    * @param {SkillRepository} params.skillRepository
@@ -36,7 +36,7 @@ export const createCertificationVersion = withTransaction(
 
 /**
  * @param {object} params
- * @param {Scopes} params.scope
+ * @param {SCOPES} params.scope
  * @param {VersionsRepository} params.versionsRepository
  */
 const _buildNewVersion = async ({ scope, versionsRepository }) => {

--- a/api/src/certification/configuration/domain/usecases/get-active-version-by-scope.js
+++ b/api/src/certification/configuration/domain/usecases/get-active-version-by-scope.js
@@ -1,14 +1,14 @@
 /**
  * @typedef {import('../../domain/models/Version.js').Version} Version
  * @typedef {import ('./index.js').VersionsRepository} VersionsRepository
- * @typedef {import('../../../shared/domain/models/Scopes.js').Scopes} Scopes
+ * @typedef {import('../../../shared/domain/models/Scopes.js').SCOPES} SCOPES
  */
 
 import { NotFoundError } from '../../../../shared/domain/errors.js';
 
 /**
  * @param {object} params
- * @param {Scopes} params.scope
+ * @param {SCOPES} params.scope
  * @param {VersionsRepository} params.versionsRepository
  * @returns {Promise<Version>}
  */

--- a/api/src/certification/configuration/infrastructure/repositories/versions-repository.js
+++ b/api/src/certification/configuration/infrastructure/repositories/versions-repository.js
@@ -1,6 +1,6 @@
 // @ts-check
 /**
- * @typedef {import('../../../shared/domain/models/Scopes.js').Scopes} Scopes
+ * @typedef {import('../../../shared/domain/models/Scopes.js').SCOPES} SCOPES
  * @typedef {import('../../../../shared/domain/models/Challenge.js').Challenge} Challenge
  */
 import { knex } from '../../../../../db/knex-database-connection.js';
@@ -41,7 +41,7 @@ export async function getById({ id }) {
 
 /**
  * @param {object} params
- * @param {Scopes} params.scope
+ * @param {SCOPES} params.scope
  * @returns {Promise<Version|null>}
  */
 export async function findActiveByScope({ scope }) {
@@ -125,7 +125,7 @@ export async function update({ version }) {
 
 /**
  * @param {object} params
- * @param {Scopes} params.scope
+ * @param {SCOPES} params.scope
  * @returns {Promise<Array<number>>}
  */
 export async function getFrameworkHistory({ scope }) {

--- a/api/src/certification/evaluation/domain/models/Candidate.js
+++ b/api/src/certification/evaluation/domain/models/Candidate.js
@@ -1,14 +1,14 @@
 import Joi from 'joi';
 
 import { EntityValidationError } from '../../../../shared/domain/errors.js';
-import { Scopes } from '../../../shared/domain/models/Scopes.js';
+import { SCOPES } from '../../../shared/domain/models/Scopes.js';
 
 export class Candidate {
   static #schema = Joi.object({
     accessibilityAdjustmentNeeded: Joi.boolean().optional(),
     reconciledAt: Joi.date().required(),
     subscriptionScope: Joi.string()
-      .valid(...Object.values(Scopes))
+      .valid(...Object.values(SCOPES))
       .required(),
   });
 
@@ -16,7 +16,7 @@ export class Candidate {
    * @param {object} params
    * @param {Date} params.reconciledAt
    * @param {boolean} [params.accessibilityAdjustmentNeeded]
-   * @param {Scopes} params.subscriptionScope
+   * @param {SCOPES} params.subscriptionScope
    */
   constructor({ accessibilityAdjustmentNeeded, reconciledAt, subscriptionScope } = {}) {
     this.accessibilityAdjustmentNeeded = !!accessibilityAdjustmentNeeded;

--- a/api/src/certification/evaluation/domain/services/scoring/score-complementary-certification-v2.js
+++ b/api/src/certification/evaluation/domain/services/scoring/score-complementary-certification-v2.js
@@ -10,7 +10,7 @@ import { AnswerCollectionForScoring } from '../../../../shared/domain/models/Ans
 import { ComplementaryCertificationCourseResult } from '../../../../shared/domain/models/ComplementaryCertificationCourseResult.js';
 import { ComplementaryCertificationKeys } from '../../../../shared/domain/models/ComplementaryCertificationKeys.js';
 import { ReproducibilityRate } from '../../../../shared/domain/models/ReproducibilityRate.js';
-import { Scopes } from '../../../../shared/domain/models/Scopes.js';
+import { SCOPES } from '../../../../shared/domain/models/Scopes.js';
 import { ComplementaryCertificationScoringWithComplementaryReferential } from '../../models/ComplementaryCertificationScoringWithComplementaryReferential.js';
 import { ComplementaryCertificationScoringWithoutComplementaryReferential } from '../../models/ComplementaryCertificationScoringWithoutComplementaryReferential.js';
 
@@ -49,7 +49,7 @@ export async function scoreComplementaryCertificationV2({
   });
 
   const complementaryCertificationKey =
-    candidate.subscriptionScope !== Scopes.CORE ? candidate.subscriptionScope : undefined;
+    candidate.subscriptionScope !== SCOPES.CORE ? candidate.subscriptionScope : undefined;
 
   const complementaryCertificationScoring = await _buildComplementaryCertificationScoring({
     certificationAssessmentRepository,

--- a/api/src/certification/evaluation/domain/usecases/retrieve-last-or-create-certification-course.js
+++ b/api/src/certification/evaluation/domain/usecases/retrieve-last-or-create-certification-course.js
@@ -26,7 +26,7 @@ import { CenterHabilitationError } from '../../../shared/domain/errors.js';
 import { AlgorithmEngineVersion } from '../../../shared/domain/models/AlgorithmEngineVersion.js';
 import { CertificationCourse } from '../../../shared/domain/models/CertificationCourse.js';
 import { ComplementaryCertificationKeys } from '../../../shared/domain/models/ComplementaryCertificationKeys.js';
-import { Scopes } from '../../../shared/domain/models/Scopes.js';
+import { SCOPES } from '../../../shared/domain/models/Scopes.js';
 
 /**
  * @param {object} params
@@ -68,7 +68,7 @@ export const retrieveLastOrCreateCertificationCourse = async function ({
 
   const certificationScope = certificationCandidate.isEnrolledToComplementaryOnly()
     ? certificationCandidate.complementaryCertification.key
-    : Scopes.CORE;
+    : SCOPES.CORE;
 
   const certificationVersion = await versionRepository.getByScopeAndReconciliationDate({
     scope: certificationScope,

--- a/api/src/certification/evaluation/infrastructure/repositories/certification-candidate-repository.js
+++ b/api/src/certification/evaluation/infrastructure/repositories/certification-candidate-repository.js
@@ -1,9 +1,28 @@
+// @ts-check
 import { knex } from '../../../../../db/knex-database-connection.js';
 import { CertificationCandidateNotFoundError } from '../../../../shared/domain/errors.js';
 import { Candidate } from '../../../evaluation/domain/models/Candidate.js';
 import { ComplementaryCertificationKeys } from '../../../shared/domain/models/ComplementaryCertificationKeys.js';
 import { Scopes } from '../../../shared/domain/models/Scopes.js';
 
+/**
+ * @typedef {import ('../../../shared/domain/models/Scopes.js').SCOPES} SCOPES
+ */
+
+/**
+ * @typedef {object} RawCertificationCandidateResult
+ * @property {boolean} accessibilityAdjustmentNeeded
+ * @property {Date} reconciledAt
+ * @property {ComplementaryCertificationKeys | null} complementaryCertificationKey
+ */
+
+/**
+ * @function
+ * @param {object} params
+ * @param {number} params.assessmentId
+ * @returns {Promise<Candidate>}
+ * @throws {CertificationCandidateNotFoundError}
+ */
 export const findByAssessmentId = async function ({ assessmentId }) {
   const result = await knex('certification-candidates')
     .select('certification-candidates.accessibilityAdjustmentNeeded', 'certification-candidates.reconciledAt', {
@@ -37,6 +56,11 @@ export const findByAssessmentId = async function ({ assessmentId }) {
   return _toDomain(result);
 };
 
+/**
+ * @function
+ * @param {RawCertificationCandidateResult} params
+ * @returns {Candidate}
+ */
 const _toDomain = ({ accessibilityAdjustmentNeeded, reconciledAt, complementaryCertificationKey }) => {
   return new Candidate({
     accessibilityAdjustmentNeeded,
@@ -45,6 +69,11 @@ const _toDomain = ({ accessibilityAdjustmentNeeded, reconciledAt, complementaryC
   });
 };
 
+/**
+ * @function
+ * @param {ComplementaryCertificationKeys | null} complementaryCertificationKey
+ * @returns {SCOPES}
+ */
 const _determineScope = (complementaryCertificationKey) => {
   if (complementaryCertificationKey && complementaryCertificationKey !== ComplementaryCertificationKeys.CLEA) {
     return complementaryCertificationKey;

--- a/api/src/certification/evaluation/infrastructure/repositories/certification-candidate-repository.js
+++ b/api/src/certification/evaluation/infrastructure/repositories/certification-candidate-repository.js
@@ -3,11 +3,7 @@ import { knex } from '../../../../../db/knex-database-connection.js';
 import { CertificationCandidateNotFoundError } from '../../../../shared/domain/errors.js';
 import { Candidate } from '../../../evaluation/domain/models/Candidate.js';
 import { ComplementaryCertificationKeys } from '../../../shared/domain/models/ComplementaryCertificationKeys.js';
-import { Scopes } from '../../../shared/domain/models/Scopes.js';
-
-/**
- * @typedef {import ('../../../shared/domain/models/Scopes.js').SCOPES} SCOPES
- */
+import { SCOPES } from '../../../shared/domain/models/Scopes.js';
 
 /**
  * @typedef {object} RawCertificationCandidateResult
@@ -78,5 +74,5 @@ const _determineScope = (complementaryCertificationKey) => {
   if (complementaryCertificationKey && complementaryCertificationKey !== ComplementaryCertificationKeys.CLEA) {
     return complementaryCertificationKey;
   }
-  return Scopes.CORE;
+  return SCOPES.CORE;
 };

--- a/api/src/certification/shared/domain/models/Scopes.js
+++ b/api/src/certification/shared/domain/models/Scopes.js
@@ -20,15 +20,10 @@ export const SCOPES = Object.freeze({
  * @returns {string} The scope value.
  * @throws {NotFoundError} If the scope is not found.
  */
-function getByName(name) {
+export function getScopeByName(name) {
   const scope = Object.values(SCOPES).find((value) => value === name);
   if (!scope) {
     throw new NotFoundError(`Scope with name "${name}" not found.`);
   }
   return scope;
 }
-
-export const Scopes = {
-  ...SCOPES,
-  getByName,
-};

--- a/api/src/certification/shared/domain/models/Scopes.js
+++ b/api/src/certification/shared/domain/models/Scopes.js
@@ -5,7 +5,7 @@ import { NotFoundError } from '../../../../shared/domain/errors.js';
  * @readonly
  * @enum {string}
  */
-const SCOPES = Object.freeze({
+export const SCOPES = Object.freeze({
   CORE: 'CORE',
   PIX_PLUS_DROIT: 'DROIT',
   PIX_PLUS_EDU_1ER_DEGRE: 'EDU_1ER_DEGRE',

--- a/api/src/certification/shared/domain/models/Version.js
+++ b/api/src/certification/shared/domain/models/Version.js
@@ -1,26 +1,22 @@
-/**
- * @typedef {import('./Scopes.js').Scopes} Scopes
- */
-
 import Joi from 'joi';
 
 import { EntityValidationError } from '../../../../shared/domain/errors.js';
 import { FlashAssessmentAlgorithmConfiguration } from '../../../shared/domain/models/FlashAssessmentAlgorithmConfiguration.js';
-import { Scopes } from './Scopes.js';
+import { SCOPES } from './Scopes.js';
 
 export class Version {
   static #schema = Joi.object({
     id: Joi.number().required(),
     scope: Joi.string()
       .required()
-      .valid(...Object.values(Scopes)),
+      .valid(...Object.values(SCOPES)),
     challengesConfiguration: Joi.object().instance(FlashAssessmentAlgorithmConfiguration).required(),
   });
 
   /**
    * @param {object} params
    * @param {number} params.id - version identifier
-   * @param {Scopes} params.scope - Certification scope (CORE, DROIT, etc.)
+   * @param {SCOPES} params.scope - Certification scope (CORE, DROIT, etc.)
    * @param {FlashAssessmentAlgorithmConfiguration} params.challengesConfiguration - Challenges configuration
    */
   constructor({ id, scope, challengesConfiguration }) {

--- a/api/src/certification/shared/infrastructure/repositories/certification-course-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/certification-course-repository.js
@@ -8,7 +8,7 @@ import { ComplementaryCertificationCourse } from '../../../session-management/do
 import { CertificationCourse } from '../../domain/models/CertificationCourse.js';
 import { CertificationIssueReport } from '../../domain/models/CertificationIssueReport.js';
 import { ComplementaryCertificationKeys } from '../../domain/models/ComplementaryCertificationKeys.js';
-import { Scopes } from '../../domain/models/Scopes.js';
+import { getScopeByName, SCOPES } from '../../domain/models/Scopes.js';
 
 async function save({ certificationCourse }) {
   const knexConn = DomainTransaction.getConnection();
@@ -208,7 +208,7 @@ async function findCertificationCoursesBySessionId({ sessionId }) {
 /**
  * @param {object} params
  * @param {number} params.courseId
- * @returns {Promise<Scopes>}
+ * @returns {Promise<SCOPES>}
  */
 async function getCertificationScope({ courseId }) {
   const knexConn = DomainTransaction.getConnection();
@@ -224,10 +224,10 @@ async function getCertificationScope({ courseId }) {
     .first();
 
   if (result?.key && result.key !== ComplementaryCertificationKeys.CLEA) {
-    return Scopes.getByName(result.key);
+    return getScopeByName(result.key);
   }
 
-  return Scopes.CORE;
+  return SCOPES.CORE;
 }
 
 export {

--- a/api/src/certification/shared/infrastructure/repositories/version-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/version-repository.js
@@ -1,5 +1,5 @@
 /**
- * @typedef {import('../../../shared/domain/models/Scopes.js').Scopes} Scopes
+ * @typedef {import('../../../shared/domain/models/Scopes.js').SCOPES} SCOPES
  */
 
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
@@ -28,7 +28,7 @@ export const getById = async (versionId) => {
 
 /**
  * @param {object} params
- * @param {Scopes} params.scope
+ * @param {SCOPES} params.scope
  * @param {Date} params.reconciliationDate
  * @returns {Promise<Version>}
  */

--- a/api/tests/certification/configuration/acceptance/application/certification-framework-route_test.js
+++ b/api/tests/certification/configuration/acceptance/application/certification-framework-route_test.js
@@ -1,5 +1,5 @@
 import { Frameworks } from '../../../../../src/certification/configuration/domain/models/Frameworks.js';
-import { Scopes } from '../../../../../src/certification/shared/domain/models/Scopes.js';
+import { SCOPES } from '../../../../../src/certification/shared/domain/models/Scopes.js';
 import {
   createServer,
   databaseBuilder,
@@ -30,7 +30,7 @@ describe('Acceptance | Application | Certification | ComplementaryCertification 
       const coreStartDate = new Date('2025-01-15');
 
       databaseBuilder.factory.buildCertificationVersion({
-        scope: Scopes.CORE,
+        scope: SCOPES.CORE,
         startDate: coreStartDate,
         expirationDate: null,
       });
@@ -136,7 +136,7 @@ describe('Acceptance | Application | Certification | ComplementaryCertification 
       await mockLearningContent(learningContentObjects);
 
       const certificationVersion = databaseBuilder.factory.buildCertificationVersion({
-        scope: Scopes.CORE,
+        scope: SCOPES.CORE,
         startDate: new Date('2025-01-15'),
         expirationDate: null,
       });
@@ -151,14 +151,14 @@ describe('Acceptance | Application | Certification | ComplementaryCertification 
 
       databaseBuilder.factory.buildCertificationFrameworksChallenge({
         challengeId: 'anotherScopeChallenge',
-        versionId: databaseBuilder.factory.buildCertificationVersion({ scope: Scopes.DROIT }).id,
+        versionId: databaseBuilder.factory.buildCertificationVersion({ scope: SCOPES.DROIT }).id,
       });
 
       await databaseBuilder.commit();
 
       const options = {
         method: 'GET',
-        url: `/api/admin/certification-frameworks/${Scopes.CORE}/active-consolidated-framework`,
+        url: `/api/admin/certification-frameworks/${SCOPES.CORE}/active-consolidated-framework`,
         headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
       };
 
@@ -168,10 +168,10 @@ describe('Acceptance | Application | Certification | ComplementaryCertification 
       // then
       expect(response.statusCode).to.equal(200);
       expect(response.result.data).to.deep.equal({
-        id: Scopes.CORE,
+        id: SCOPES.CORE,
         type: 'certification-consolidated-frameworks',
         attributes: {
-          'complementary-certification-key': Scopes.CORE,
+          'complementary-certification-key': SCOPES.CORE,
           version: String(certificationVersion.id),
         },
         relationships: {
@@ -194,13 +194,13 @@ describe('Acceptance | Application | Certification | ComplementaryCertification 
       const superAdmin = await insertUserWithRoleSuperAdmin();
 
       const newerVersion = databaseBuilder.factory.buildCertificationVersion({
-        scope: Scopes.CORE,
+        scope: SCOPES.CORE,
         startDate: new Date('2025-01-11'),
         expirationDate: null,
       });
 
       const olderVersion = databaseBuilder.factory.buildCertificationVersion({
-        scope: Scopes.CORE,
+        scope: SCOPES.CORE,
         startDate: new Date('2024-01-11'),
         expirationDate: newerVersion.expirationDate,
       });
@@ -209,7 +209,7 @@ describe('Acceptance | Application | Certification | ComplementaryCertification 
 
       const options = {
         method: 'GET',
-        url: `/api/admin/certification-frameworks/${Scopes.CORE}/framework-history`,
+        url: `/api/admin/certification-frameworks/${SCOPES.CORE}/framework-history`,
         headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
       };
 
@@ -219,10 +219,10 @@ describe('Acceptance | Application | Certification | ComplementaryCertification 
       // then
       expect(response.statusCode).to.equal(200);
       expect(response.result.data).to.deep.equal({
-        id: Scopes.CORE,
+        id: SCOPES.CORE,
         type: 'framework-histories',
         attributes: {
-          scope: Scopes.CORE,
+          scope: SCOPES.CORE,
           history: [
             { id: newerVersion.id, startDate: newerVersion.startDate, expirationDate: newerVersion.expirationDate },
             { id: olderVersion.id, startDate: olderVersion.startDate, expirationDate: olderVersion.expirationDate },

--- a/api/tests/certification/configuration/acceptance/application/certification-version-route_test.js
+++ b/api/tests/certification/configuration/acceptance/application/certification-version-route_test.js
@@ -1,5 +1,5 @@
 import { DEFAULT_SESSION_DURATION_MINUTES } from '../../../../../src/certification/shared/domain/constants.js';
-import { Scopes } from '../../../../../src/certification/shared/domain/models/Scopes.js';
+import { SCOPES } from '../../../../../src/certification/shared/domain/models/Scopes.js';
 import {
   createServer,
   databaseBuilder,
@@ -28,7 +28,7 @@ describe('Acceptance | Certification | Configuration | API | certification-versi
       });
 
       const existingVersion = databaseBuilder.factory.buildCertificationVersion({
-        scope: Scopes.CORE,
+        scope: SCOPES.CORE,
         startDate: new Date('2024-01-01'),
         expirationDate: null,
         assessmentDuration: DEFAULT_SESSION_DURATION_MINUTES,
@@ -43,7 +43,7 @@ describe('Acceptance | Certification | Configuration | API | certification-versi
 
       const options = {
         method: 'GET',
-        url: `/api/admin/certification-versions/${Scopes.CORE}/active`,
+        url: `/api/admin/certification-versions/${SCOPES.CORE}/active`,
         headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
       };
 
@@ -51,7 +51,7 @@ describe('Acceptance | Certification | Configuration | API | certification-versi
 
       expect(response.statusCode).to.equal(200);
       expect(response.result.data.id).to.equal(String(existingVersion.id));
-      expect(response.result.data.attributes.scope).to.equal(Scopes.CORE);
+      expect(response.result.data.attributes.scope).to.equal(SCOPES.CORE);
       expect(response.result.data.attributes['assessment-duration']).to.equal(DEFAULT_SESSION_DURATION_MINUTES);
       expect(response.result.data.attributes['challenges-configuration']).to.deep.equal(challengesConfiguration);
     });
@@ -63,7 +63,7 @@ describe('Acceptance | Certification | Configuration | API | certification-versi
 
       const options = {
         method: 'GET',
-        url: `/api/admin/certification-versions/${Scopes.CORE}/active`,
+        url: `/api/admin/certification-versions/${SCOPES.CORE}/active`,
         headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
       };
 
@@ -85,7 +85,7 @@ describe('Acceptance | Certification | Configuration | API | certification-versi
       });
 
       const existingVersion = databaseBuilder.factory.buildCertificationVersion({
-        scope: Scopes.PIX_PLUS_DROIT,
+        scope: SCOPES.PIX_PLUS_DROIT,
         startDate: new Date('2024-01-01'),
         expirationDate: null,
         assessmentDuration: DEFAULT_SESSION_DURATION_MINUTES,
@@ -115,7 +115,7 @@ describe('Acceptance | Certification | Configuration | API | certification-versi
             id: String(existingVersion.id),
             type: 'certification-versions',
             attributes: {
-              scope: Scopes.PIX_PLUS_DROIT,
+              scope: SCOPES.PIX_PLUS_DROIT,
               'start-date': '2024-01-01T00:00:00.000Z',
               'expiration-date': newExpirationDate,
               'assessment-duration': DEFAULT_SESSION_DURATION_MINUTES,

--- a/api/tests/certification/configuration/integration/application/certification-framework-route_test.js
+++ b/api/tests/certification/configuration/integration/application/certification-framework-route_test.js
@@ -1,6 +1,6 @@
 import { certificationFrameworkController } from '../../../../../src/certification/configuration/application/certification-framework-controller.js';
 import * as moduleUnderTest from '../../../../../src/certification/configuration/application/certification-framework-route.js';
-import { Scopes } from '../../../../../src/certification/shared/domain/models/Scopes.js';
+import { SCOPES } from '../../../../../src/certification/shared/domain/models/Scopes.js';
 import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
 import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
 import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
@@ -23,7 +23,7 @@ describe('Integration | Certification | Configuration | Application | Router | c
 
         const response = await httpTestServer.request(
           'GET',
-          `/api/admin/certification-frameworks/${Scopes.CORE}/active-consolidated-framework`,
+          `/api/admin/certification-frameworks/${SCOPES.CORE}/active-consolidated-framework`,
         );
 
         expect(response.statusCode).to.equal(404);

--- a/api/tests/certification/configuration/integration/domain/usecases/find-certification-frameworks_test.js
+++ b/api/tests/certification/configuration/integration/domain/usecases/find-certification-frameworks_test.js
@@ -1,6 +1,6 @@
 import { Frameworks } from '../../../../../../src/certification/configuration/domain/models/Frameworks.js';
 import { usecases } from '../../../../../../src/certification/configuration/domain/usecases/index.js';
-import { Scopes } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
+import { SCOPES } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
 import { databaseBuilder, expect } from '../../../../../test-helper.js';
 
 describe('Certification | Configuration | Integration | Domain | UseCase | find-certification-frameworks', function () {
@@ -11,24 +11,24 @@ describe('Certification | Configuration | Integration | Domain | UseCase | find-
     const edu1erDegreStartDate = new Date('2025-03-01');
 
     databaseBuilder.factory.buildCertificationVersion({
-      scope: Scopes.CORE,
+      scope: SCOPES.CORE,
       startDate: coreStartDate,
       expirationDate: null,
     });
 
     databaseBuilder.factory.buildCertificationVersion({
-      scope: Scopes.PIX_PLUS_DROIT,
+      scope: SCOPES.PIX_PLUS_DROIT,
       startDate: droitStartDate,
       expirationDate: null,
     });
 
     databaseBuilder.factory.buildCertificationVersion({
-      scope: Scopes.PIX_PLUS_EDU_1ER_DEGRE,
+      scope: SCOPES.PIX_PLUS_EDU_1ER_DEGRE,
       startDate: new Date(2020, 12, 12),
       expirationDate: new Date(2020, 12, 14),
     });
     databaseBuilder.factory.buildCertificationVersion({
-      scope: Scopes.PIX_PLUS_EDU_1ER_DEGRE,
+      scope: SCOPES.PIX_PLUS_EDU_1ER_DEGRE,
       startDate: edu1erDegreStartDate,
       expirationDate: null,
     });

--- a/api/tests/certification/configuration/integration/infrastructure/repositories/versions-repository_test.js
+++ b/api/tests/certification/configuration/integration/infrastructure/repositories/versions-repository_test.js
@@ -1,7 +1,7 @@
 import { Version } from '../../../../../../src/certification/configuration/domain/models/Version.js';
 import * as versionsRepository from '../../../../../../src/certification/configuration/infrastructure/repositories/versions-repository.js';
 import { DEFAULT_SESSION_DURATION_MINUTES } from '../../../../../../src/certification/shared/domain/constants.js';
-import { Scopes } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
+import { SCOPES } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
 import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
 import { catchErr, databaseBuilder, domainBuilder, expect, knex } from '../../../../../test-helper.js';
 
@@ -15,7 +15,7 @@ describe('Certification | Configuration | Integration | Repository | Versions', 
         defaultCandidateCapacity: -8,
       };
       const version = domainBuilder.certification.configuration.buildVersion({
-        scope: Scopes.PIX_PLUS_DROIT,
+        scope: SCOPES.PIX_PLUS_DROIT,
         startDate: new Date('2025-06-01'),
         expirationDate: new Date('2025-12-31'),
         assessmentDuration: DEFAULT_SESSION_DURATION_MINUTES,
@@ -88,7 +88,7 @@ describe('Certification | Configuration | Integration | Repository | Versions', 
         limitToOneQuestionPerTube: false,
       });
       const existingVersion = databaseBuilder.factory.buildCertificationVersion({
-        scope: Scopes.PIX_PLUS_DROIT,
+        scope: SCOPES.PIX_PLUS_DROIT,
         startDate: new Date('2024-01-01'),
         expirationDate: null,
         assessmentDuration: DEFAULT_SESSION_DURATION_MINUTES,
@@ -128,7 +128,7 @@ describe('Certification | Configuration | Integration | Repository | Versions', 
   describe('#findActiveByScope', function () {
     it('should return the current version for the given scope', async function () {
       // given
-      const scope = Scopes.PIX_PLUS_DROIT;
+      const scope = SCOPES.PIX_PLUS_DROIT;
 
       const oldConfig = {
         maximumAssessmentLength: 32,
@@ -196,7 +196,7 @@ describe('Certification | Configuration | Integration | Repository | Versions', 
         defaultCandidateCapacity: -8,
         defaultProbabilityToPickChallenge: 40,
       };
-      const aScopeWeAreNotInterestedIn = Scopes.CORE;
+      const aScopeWeAreNotInterestedIn = SCOPES.CORE;
       databaseBuilder.factory.buildCertificationVersion({
         scope: aScopeWeAreNotInterestedIn,
         startDate: new Date('2025-10-01'),
@@ -227,10 +227,10 @@ describe('Certification | Configuration | Integration | Repository | Versions', 
     context('when no version exists for the scope', function () {
       it('should return null', async function () {
         // given
-        const scope = Scopes.PIX_PLUS_EDU_CPE;
+        const scope = SCOPES.PIX_PLUS_EDU_CPE;
 
         databaseBuilder.factory.buildCertificationVersion({
-          scope: Scopes.CORE,
+          scope: SCOPES.CORE,
           startDate: new Date('2025-01-01'),
           expirationDate: null,
           assessmentDuration: 90,
@@ -253,7 +253,7 @@ describe('Certification | Configuration | Integration | Repository | Versions', 
   describe('#getById', function () {
     it('should return the version with the given id', async function () {
       // given
-      const scope = Scopes.PIX_PLUS_DROIT;
+      const scope = SCOPES.PIX_PLUS_DROIT;
       const expectedConfig = {
         maximumAssessmentLength: 30,
         challengesBetweenSameCompetence: 2,
@@ -307,7 +307,7 @@ describe('Certification | Configuration | Integration | Repository | Versions', 
   describe('#getFrameworkHistory', function () {
     it('should return an empty array when there is no framework history', async function () {
       // given
-      const scope = Scopes.PIX_PLUS_DROIT;
+      const scope = SCOPES.PIX_PLUS_DROIT;
 
       // when
       const frameworkHistory = await versionsRepository.getFrameworkHistory({ scope });
@@ -318,8 +318,8 @@ describe('Certification | Configuration | Integration | Repository | Versions', 
 
     it('should return the framework history ordered by start date descending', async function () {
       // given
-      const scope = Scopes.PIX_PLUS_DROIT;
-      const otherScope = Scopes.CLEA;
+      const scope = SCOPES.PIX_PLUS_DROIT;
+      const otherScope = SCOPES.CLEA;
 
       const version1 = databaseBuilder.factory.buildCertificationVersion({
         scope,

--- a/api/tests/certification/configuration/unit/application/certification-framework-route_test.js
+++ b/api/tests/certification/configuration/unit/application/certification-framework-route_test.js
@@ -1,6 +1,6 @@
 import { certificationFrameworkController } from '../../../../../src/certification/configuration/application/certification-framework-controller.js';
 import * as moduleUnderTest from '../../../../../src/certification/configuration/application/certification-framework-route.js';
-import { Scopes } from '../../../../../src/certification/shared/domain/models/Scopes.js';
+import { SCOPES } from '../../../../../src/certification/shared/domain/models/Scopes.js';
 import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
 import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
 
@@ -70,7 +70,7 @@ describe('Unit | Certification | Configuration | Application | Router | certific
         // when
         const response = await httpTestServer.request(
           'GET',
-          `/api/admin/certification-frameworks/${Scopes.CORE}/active-consolidated-framework`,
+          `/api/admin/certification-frameworks/${SCOPES.CORE}/active-consolidated-framework`,
         );
 
         // then
@@ -93,7 +93,7 @@ describe('Unit | Certification | Configuration | Application | Router | certific
           // when
           const response = await httpTestServer.request(
             'GET',
-            `/api/admin/certification-frameworks/${Scopes.CORE}/active-consolidated-framework`,
+            `/api/admin/certification-frameworks/${SCOPES.CORE}/active-consolidated-framework`,
           );
 
           // then
@@ -118,7 +118,7 @@ describe('Unit | Certification | Configuration | Application | Router | certific
         // when
         const response = await httpTestServer.request(
           'GET',
-          `/api/admin/certification-frameworks/${Scopes.CORE}/framework-history`,
+          `/api/admin/certification-frameworks/${SCOPES.CORE}/framework-history`,
         );
 
         // then
@@ -141,7 +141,7 @@ describe('Unit | Certification | Configuration | Application | Router | certific
           // when
           const response = await httpTestServer.request(
             'GET',
-            `/api/admin/certification-frameworks/${Scopes.PIX_PLUS_DROIT}/framework-history`,
+            `/api/admin/certification-frameworks/${SCOPES.PIX_PLUS_DROIT}/framework-history`,
           );
 
           // then

--- a/api/tests/certification/configuration/unit/application/certification-version-route_test.js
+++ b/api/tests/certification/configuration/unit/application/certification-version-route_test.js
@@ -1,6 +1,6 @@
 import { certificationVersionController } from '../../../../../src/certification/configuration/application/certification-version-controller.js';
 import * as moduleUnderTest from '../../../../../src/certification/configuration/application/certification-version-route.js';
-import { Scopes } from '../../../../../src/certification/shared/domain/models/Scopes.js';
+import { SCOPES } from '../../../../../src/certification/shared/domain/models/Scopes.js';
 import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
 import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
 
@@ -52,7 +52,7 @@ describe('Unit | Certification | Configuration | Application | Router | certific
             id: '123',
             type: 'certification-versions',
             attributes: {
-              scope: Scopes.PIX_PLUS_DROIT,
+              scope: SCOPES.PIX_PLUS_DROIT,
               'start-date': '2024-01-01T00:00:00.000Z',
               'expiration-date': null,
               'assessment-duration': 120,
@@ -109,7 +109,7 @@ describe('Unit | Certification | Configuration | Application | Router | certific
             id: '123',
             type: 'certification-versions',
             attributes: {
-              scope: Scopes.PIX_PLUS_DROIT,
+              scope: SCOPES.PIX_PLUS_DROIT,
               'start-date': '2024-01-01T00:00:00.000Z',
               'expiration-date': null,
               'assessment-duration': -10,
@@ -133,7 +133,7 @@ describe('Unit | Certification | Configuration | Application | Router | certific
             id: '123',
             type: 'certification-versions',
             attributes: {
-              scope: Scopes.PIX_PLUS_DROIT,
+              scope: SCOPES.PIX_PLUS_DROIT,
               'start-date': '2024-01-01T00:00:00.000Z',
               'expiration-date': null,
               'assessment-duration': 120,
@@ -155,7 +155,7 @@ describe('Unit | Certification | Configuration | Application | Router | certific
           data: {
             type: 'certification-versions',
             attributes: {
-              scope: Scopes.PIX_PLUS_DROIT,
+              scope: SCOPES.PIX_PLUS_DROIT,
               'start-date': '2024-01-01T00:00:00.000Z',
               'expiration-date': null,
               'assessment-duration': 120,
@@ -179,7 +179,7 @@ describe('Unit | Certification | Configuration | Application | Router | certific
             id: '456',
             type: 'certification-versions',
             attributes: {
-              scope: Scopes.PIX_PLUS_DROIT,
+              scope: SCOPES.PIX_PLUS_DROIT,
               'start-date': '2024-01-01T00:00:00.000Z',
               'expiration-date': null,
               'assessment-duration': 120,
@@ -203,7 +203,7 @@ describe('Unit | Certification | Configuration | Application | Router | certific
             id: '123',
             type: 'invalid-type',
             attributes: {
-              scope: Scopes.PIX_PLUS_DROIT,
+              scope: SCOPES.PIX_PLUS_DROIT,
               'start-date': '2024-01-01T00:00:00.000Z',
               'expiration-date': null,
               'assessment-duration': 120,
@@ -226,7 +226,7 @@ describe('Unit | Certification | Configuration | Application | Router | certific
           data: {
             id: '123',
             attributes: {
-              scope: Scopes.PIX_PLUS_DROIT,
+              scope: SCOPES.PIX_PLUS_DROIT,
               'start-date': '2024-01-01T00:00:00.000Z',
               'expiration-date': null,
               'assessment-duration': 120,
@@ -249,7 +249,7 @@ describe('Unit | Certification | Configuration | Application | Router | certific
           data: {
             id: 'certification-versions',
             attributes: {
-              scope: Scopes.PIX_PLUS_DROIT,
+              scope: SCOPES.PIX_PLUS_DROIT,
               'start-date': '2024-01-01T00:00:00.000Z',
               'expiration-date': null,
               'assessment-duration': 120,

--- a/api/tests/certification/configuration/unit/domain/models/Version_test.js
+++ b/api/tests/certification/configuration/unit/domain/models/Version_test.js
@@ -1,5 +1,5 @@
 import { Version } from '../../../../../../src/certification/configuration/domain/models/Version.js';
-import { Scopes } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
+import { SCOPES } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
 import { EntityValidationError } from '../../../../../../src/shared/domain/errors.js';
 import { catchErrSync, domainBuilder, expect } from '../../../../../test-helper.js';
 
@@ -12,7 +12,7 @@ describe('Unit | Certification | Configuration | Domain | Models | Version', fun
     });
     const versionData = {
       id: 123,
-      scope: Scopes.CORE,
+      scope: SCOPES.CORE,
       startDate: new Date('2025-01-01'),
       expirationDate: new Date('2025-12-31'),
       assessmentDuration: 120,
@@ -34,7 +34,7 @@ describe('Unit | Certification | Configuration | Domain | Models | Version', fun
     const challengesConfiguration = domainBuilder.buildFlashAlgorithmConfiguration();
     const versionData = {
       id: 456,
-      scope: Scopes.PIX_PLUS_DROIT,
+      scope: SCOPES.PIX_PLUS_DROIT,
       startDate: new Date('2025-06-01'),
       expirationDate: null,
       assessmentDuration: 90,
@@ -49,7 +49,7 @@ describe('Unit | Certification | Configuration | Domain | Models | Version', fun
     // then
     expect(version).to.be.instanceOf(Version);
     expect(version.id).to.equal(456);
-    expect(version.scope).to.equal(Scopes.PIX_PLUS_DROIT);
+    expect(version.scope).to.equal(SCOPES.PIX_PLUS_DROIT);
     expect(version.expirationDate).to.be.null;
     expect(version.globalScoringConfiguration).to.be.null;
     expect(version.competencesScoringConfiguration).to.be.null;
@@ -60,7 +60,7 @@ describe('Unit | Certification | Configuration | Domain | Models | Version', fun
     const challengesConfiguration = domainBuilder.buildFlashAlgorithmConfiguration();
     const invalidData = {
       id: 123,
-      scope: Scopes.CORE,
+      scope: SCOPES.CORE,
       startDate: 'not-a-date',
       assessmentDuration: 120,
       challengesConfiguration,
@@ -77,7 +77,7 @@ describe('Unit | Certification | Configuration | Domain | Models | Version', fun
     // given
     const invalidData = {
       id: 123,
-      scope: Scopes.CORE,
+      scope: SCOPES.CORE,
       startDate: new Date('2025-01-01'),
       assessmentDuration: 120,
       challengesConfiguration: { config: 'test' },

--- a/api/tests/certification/configuration/unit/domain/usecases/create-certification-version_test.js
+++ b/api/tests/certification/configuration/unit/domain/usecases/create-certification-version_test.js
@@ -2,7 +2,7 @@ import { Version } from '../../../../../../src/certification/configuration/domai
 import { createCertificationVersion } from '../../../../../../src/certification/configuration/domain/usecases/create-certification-version.js';
 import { DEFAULT_SESSION_DURATION_MINUTES } from '../../../../../../src/certification/shared/domain/constants.js';
 import { FlashAssessmentAlgorithmConfiguration } from '../../../../../../src/certification/shared/domain/models/FlashAssessmentAlgorithmConfiguration.js';
-import { Scopes } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
+import { SCOPES } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
 import { DomainTransaction } from '../../../../../../src/shared/domain/DomainTransaction.js';
 import { FRENCH_FRANCE, FRENCH_SPOKEN } from '../../../../../../src/shared/domain/services/locale-service.js';
 import { domainBuilder, expect, sinon } from '../../../../../test-helper.js';
@@ -35,7 +35,7 @@ describe('Certification | Configuration | Unit | UseCase | create-certification-
     it('should create a new certification version that takes place as the latest one', async function () {
       // given
       const clock = sinon.useFakeTimers({ now: new Date('2025-10-21T10:00:00Z'), toFake: ['Date'] });
-      const scope = Scopes.PIX_PLUS_PRO_SANTE;
+      const scope = SCOPES.PIX_PLUS_PRO_SANTE;
 
       const currentVersion = domainBuilder.certification.configuration.buildVersion({
         id: 123,
@@ -120,7 +120,7 @@ describe('Certification | Configuration | Unit | UseCase | create-certification-
     it('should create a brand new certification version', async function () {
       // given
       const clock = sinon.useFakeTimers({ now: new Date('2025-10-20T10:00:00Z'), toFake: ['Date'] });
-      const scope = Scopes.PIX_PLUS_DROIT;
+      const scope = SCOPES.PIX_PLUS_DROIT;
 
       const tube1 = domainBuilder.buildTube({
         id: 'recTube1',

--- a/api/tests/certification/configuration/unit/domain/usecases/get-active-version-by-scope_test.js
+++ b/api/tests/certification/configuration/unit/domain/usecases/get-active-version-by-scope_test.js
@@ -1,5 +1,5 @@
 import { getActiveVersionByScope } from '../../../../../../src/certification/configuration/domain/usecases/get-active-version-by-scope.js';
-import { Scopes } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
+import { SCOPES } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
 import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
 import { catchErr, domainBuilder, expect, sinon } from '../../../../../test-helper.js';
 
@@ -13,10 +13,10 @@ describe('Certification | Configuration | Unit | UseCase | get-active-version-by
   });
 
   it('should call the repository findActiveByScope method with the scope', async function () {
-    const scope = Scopes.CORE;
+    const scope = SCOPES.CORE;
     const expectedVersion = domainBuilder.certification.configuration.buildVersion({
       id: 123,
-      scope: Scopes.CORE,
+      scope: SCOPES.CORE,
       startDate: new Date('2024-01-01'),
       expirationDate: null,
       assessmentDuration: 120,
@@ -35,7 +35,7 @@ describe('Certification | Configuration | Unit | UseCase | get-active-version-by
   });
 
   it('should throw NotFoundError when no active version exists for the scope', async function () {
-    const scope = Scopes.CORE;
+    const scope = SCOPES.CORE;
 
     versionsRepository.findActiveByScope.resolves(null);
 

--- a/api/tests/certification/configuration/unit/domain/usecases/get-current-framework-version_test.js
+++ b/api/tests/certification/configuration/unit/domain/usecases/get-current-framework-version_test.js
@@ -1,5 +1,5 @@
 import { getCurrentFrameworkVersion } from '../../../../../../src/certification/configuration/domain/usecases/get-current-framework-version.js';
-import { Scopes } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
+import { SCOPES } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
 import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
 import { catchErr, domainBuilder, expect, sinon } from '../../../../../test-helper.js';
 
@@ -22,7 +22,7 @@ describe('Certification | Configuration | Unit | UseCase | get-current-framework
 
   it('should return the current framework', async function () {
     // given
-    const scope = Scopes.PIX_PLUS_DROIT;
+    const scope = SCOPES.PIX_PLUS_DROIT;
     const versionId = 123;
     const version = domainBuilder.certification.configuration.buildVersion({
       id: versionId,
@@ -67,7 +67,7 @@ describe('Certification | Configuration | Unit | UseCase | get-current-framework
 
   it('should throw NotFoundError when no active version exists', async function () {
     // given
-    const scope = Scopes.PIX_PLUS_DROIT;
+    const scope = SCOPES.PIX_PLUS_DROIT;
 
     versionsRepository.findActiveByScope.withArgs({ scope }).resolves(null);
 

--- a/api/tests/certification/configuration/unit/domain/usecases/update-certification-version_test.js
+++ b/api/tests/certification/configuration/unit/domain/usecases/update-certification-version_test.js
@@ -1,5 +1,5 @@
 import { updateCertificationVersion } from '../../../../../../src/certification/configuration/domain/usecases/update-certification-version.js';
-import { Scopes } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
+import { SCOPES } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
 import { domainBuilder, expect, sinon } from '../../../../../test-helper.js';
 
 describe('Certification | Configuration | Unit | UseCase | update-certification-version', function () {
@@ -14,7 +14,7 @@ describe('Certification | Configuration | Unit | UseCase | update-certification-
   it('should call the repository update method with the updated version', async function () {
     const updatedVersion = domainBuilder.certification.configuration.buildVersion({
       id: 123,
-      scope: Scopes.PIX_PLUS_DROIT,
+      scope: SCOPES.PIX_PLUS_DROIT,
       startDate: new Date('2024-01-01'),
       expirationDate: new Date('2025-10-21T10:00:00Z'),
       assessmentDuration: 120,

--- a/api/tests/certification/configuration/unit/infrastructure/serializers/certification-version-serializer_test.js
+++ b/api/tests/certification/configuration/unit/infrastructure/serializers/certification-version-serializer_test.js
@@ -1,5 +1,5 @@
 import * as serializer from '../../../../../../src/certification/configuration/infrastructure/serializers/certification-version-serializer.js';
-import { Scopes } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
+import { SCOPES } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
 import { expect } from '../../../../../test-helper.js';
 
 describe('Unit | Certification | Configuration | Serializer | certification-version-serializer', function () {
@@ -7,7 +7,7 @@ describe('Unit | Certification | Configuration | Serializer | certification-vers
     it('should convert a Version entity into JSON API format', function () {
       const certificationVersion = {
         id: 123,
-        scope: Scopes.CORE,
+        scope: SCOPES.CORE,
         startDate: new Date('2024-01-01T00:00:00Z'),
         expirationDate: new Date('2025-12-31T23:59:59Z'),
         assessmentDuration: 120,
@@ -32,7 +32,7 @@ describe('Unit | Certification | Configuration | Serializer | certification-vers
           id: '123',
           type: 'certification-versions',
           attributes: {
-            scope: Scopes.CORE,
+            scope: SCOPES.CORE,
             'start-date': new Date('2024-01-01T00:00:00Z'),
             'expiration-date': new Date('2025-12-31T23:59:59Z'),
             'assessment-duration': 120,
@@ -61,7 +61,7 @@ describe('Unit | Certification | Configuration | Serializer | certification-vers
           id: '123',
           type: 'certification-versions',
           attributes: {
-            scope: Scopes.PIX_PLUS_DROIT,
+            scope: SCOPES.PIX_PLUS_DROIT,
             'start-date': '2024-01-01T00:00:00Z',
             'expiration-date': '2025-12-31T23:59:59Z',
             'assessment-duration': 120,
@@ -85,7 +85,7 @@ describe('Unit | Certification | Configuration | Serializer | certification-vers
       const result = serializer.deserialize(json);
 
       expect(result.id).to.equal('123');
-      expect(result.scope).to.equal(Scopes.PIX_PLUS_DROIT);
+      expect(result.scope).to.equal(SCOPES.PIX_PLUS_DROIT);
       expect(result.startDate).to.deep.equal(new Date('2024-01-01T00:00:00Z'));
       expect(result.expirationDate).to.deep.equal(new Date('2025-12-31T23:59:59Z'));
       expect(result.assessmentDuration).to.equal(120);

--- a/api/tests/certification/configuration/unit/infrastructure/serializers/framework-history-serializer_test.js
+++ b/api/tests/certification/configuration/unit/infrastructure/serializers/framework-history-serializer_test.js
@@ -1,5 +1,5 @@
 import * as serializer from '../../../../../../src/certification/configuration/infrastructure/serializers/framework-history-serializer.js';
-import { Scopes } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
+import { SCOPES } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
 import { expect } from '../../../../../test-helper.js';
 
 describe('Certification | Configuration | Unit | Serializer | framework-history-serializer', function () {
@@ -7,7 +7,7 @@ describe('Certification | Configuration | Unit | Serializer | framework-history-
     it('should serialize a framework history to JSONAPI', function () {
       // given
       const frameworkHistory = [{ id: 456, startDate: new Date('2024-01-01'), expirationDate: new Date('2025-02-02') }];
-      const scope = Scopes.PIX_PLUS_DROIT;
+      const scope = SCOPES.PIX_PLUS_DROIT;
 
       // when
       const serializedFrameworkHistory = serializer.serialize({ scope, frameworkHistory });
@@ -16,10 +16,10 @@ describe('Certification | Configuration | Unit | Serializer | framework-history-
       expect(serializedFrameworkHistory).to.deep.equal({
         data: {
           attributes: {
-            scope: Scopes.PIX_PLUS_DROIT,
+            scope: SCOPES.PIX_PLUS_DROIT,
             history: frameworkHistory,
           },
-          id: Scopes.PIX_PLUS_DROIT,
+          id: SCOPES.PIX_PLUS_DROIT,
           type: 'framework-histories',
         },
       });

--- a/api/tests/certification/evaluation/integration/infrastructure/repositories/calibrated-challenge-repository_test.js
+++ b/api/tests/certification/evaluation/integration/infrastructure/repositories/calibrated-challenge-repository_test.js
@@ -1,6 +1,6 @@
 import { knex } from '../../../../../../db/knex-database-connection.js';
 import * as calibratedChallengeRepository from '../../../../../../src/certification/evaluation/infrastructure/repositories/calibrated-challenge-repository.js';
-import { Scopes } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
+import { SCOPES } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
 import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
 import { catchErr, databaseBuilder, domainBuilder, expect } from '../../../../../test-helper.js';
 
@@ -499,9 +499,9 @@ describe('Certification | Evaluation | Integration | Repository | calibrated-cha
 
     it('returns only valid calibrated flash compatible challenges', async function () {
       // given
-      const version = databaseBuilder.factory.buildCertificationVersion({ scope: Scopes.CORE });
+      const version = databaseBuilder.factory.buildCertificationVersion({ scope: SCOPES.CORE });
       const otherVersion = databaseBuilder.factory.buildCertificationVersion({
-        scope: Scopes.CORE,
+        scope: SCOPES.CORE,
       });
 
       challengesLC.push({
@@ -639,7 +639,7 @@ describe('Certification | Evaluation | Integration | Repository | calibrated-cha
       it('should throw a NotFound error', async function () {
         // given
         const versionWithoutChallenges = databaseBuilder.factory.buildCertificationVersion({
-          scope: Scopes.CORE,
+          scope: SCOPES.CORE,
         });
         await databaseBuilder.commit();
 
@@ -659,7 +659,7 @@ describe('Certification | Evaluation | Integration | Repository | calibrated-cha
       it('should throw a NotFound error', async function () {
         // given
         const version = databaseBuilder.factory.buildCertificationVersion({
-          scope: Scopes.CORE,
+          scope: SCOPES.CORE,
         });
         const challengeCalibrationNotInLCMS = databaseBuilder.factory.buildCertificationFrameworksChallenge({
           challengeId: 'challengeIdPipeauPipette',
@@ -697,9 +697,9 @@ describe('Certification | Evaluation | Integration | Repository | calibrated-cha
       });
 
       it('should return only the challenges for given locale', async function () {
-        const versionActive = databaseBuilder.factory.buildCertificationVersion({ scope: Scopes.CORE });
+        const versionActive = databaseBuilder.factory.buildCertificationVersion({ scope: SCOPES.CORE });
         const otherVersion = databaseBuilder.factory.buildCertificationVersion({
-          scope: Scopes.CORE,
+          scope: SCOPES.CORE,
         });
 
         challengesLC.push({

--- a/api/tests/certification/evaluation/integration/infrastructure/repositories/certification-candidate-repository_test.js
+++ b/api/tests/certification/evaluation/integration/infrastructure/repositories/certification-candidate-repository_test.js
@@ -1,6 +1,6 @@
 import * as certificationCandidateRepository from '../../../../../../src/certification/evaluation/infrastructure/repositories/certification-candidate-repository.js';
 import { ComplementaryCertificationKeys } from '../../../../../../src/certification/shared/domain/models/ComplementaryCertificationKeys.js';
-import { Scopes } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
+import { SCOPES } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
 import { CertificationCandidateNotFoundError } from '../../../../../../src/shared/domain/errors.js';
 import { Assessment } from '../../../../../../src/shared/domain/models/Assessment.js';
 import { catchErr, databaseBuilder, domainBuilder, expect } from '../../../../../test-helper.js';
@@ -45,7 +45,7 @@ describe('Integration | Repository | certification candidate', function () {
           expect(result).to.deep.equal(
             domainBuilder.certification.evaluation.buildCandidate({
               ...candidate,
-              subscriptionScope: Scopes.CORE,
+              subscriptionScope: SCOPES.CORE,
             }),
           );
         });
@@ -97,7 +97,7 @@ describe('Integration | Repository | certification candidate', function () {
           expect(result).to.deep.equal(
             domainBuilder.certification.evaluation.buildCandidate({
               ...candidate,
-              subscriptionScope: Scopes.PIX_PLUS_DROIT,
+              subscriptionScope: SCOPES.PIX_PLUS_DROIT,
             }),
           );
         });
@@ -153,7 +153,7 @@ describe('Integration | Repository | certification candidate', function () {
           expect(result).to.deep.equal(
             domainBuilder.certification.evaluation.buildCandidate({
               ...candidate,
-              subscriptionScope: Scopes.CORE,
+              subscriptionScope: SCOPES.CORE,
             }),
           );
         });
@@ -251,7 +251,7 @@ describe('Integration | Repository | certification candidate', function () {
           expect(result).to.deep.equal(
             domainBuilder.certification.evaluation.buildCandidate({
               ...candidate,
-              subscriptionScope: Scopes.CORE,
+              subscriptionScope: SCOPES.CORE,
             }),
           );
         });

--- a/api/tests/certification/evaluation/unit/domain/models/Candidate_test.js
+++ b/api/tests/certification/evaluation/unit/domain/models/Candidate_test.js
@@ -1,5 +1,5 @@
 import { Candidate } from '../../../../../../src/certification/evaluation/domain/models/Candidate.js';
-import { Scopes } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
+import { SCOPES } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
 import { EntityValidationError } from '../../../../../../src/shared/domain/errors.js';
 import { catchErrSync, expect } from '../../../../../test-helper.js';
 
@@ -10,14 +10,14 @@ describe('Certification | Evaluation | Unit | Domain | Models | Candidate', func
     const candidate = new Candidate({
       accessibilityAdjustmentNeeded: true,
       reconciledAt: new Date('2024-10-18'),
-      subscriptionScope: Scopes.CORE,
+      subscriptionScope: SCOPES.CORE,
     });
 
     // then
     expect(candidate).to.deep.equal({
       accessibilityAdjustmentNeeded: true,
       reconciledAt: new Date('2024-10-18'),
-      subscriptionScope: Scopes.CORE,
+      subscriptionScope: SCOPES.CORE,
     });
   });
 

--- a/api/tests/certification/evaluation/unit/domain/services/scoring/score-complementary-certification-v2_test.js
+++ b/api/tests/certification/evaluation/unit/domain/services/scoring/score-complementary-certification-v2_test.js
@@ -2,7 +2,7 @@ import range from 'lodash/range.js';
 
 import { scoreComplementaryCertificationV2 } from '../../../../../../../src/certification/evaluation/domain/services/scoring/score-complementary-certification-v2.js';
 import { ComplementaryCertificationCourseResult } from '../../../../../../../src/certification/shared/domain/models/ComplementaryCertificationCourseResult.js';
-import { Scopes } from '../../../../../../../src/certification/shared/domain/models/Scopes.js';
+import { SCOPES } from '../../../../../../../src/certification/shared/domain/models/Scopes.js';
 import { status as assessmentResultStatuses } from '../../../../../../../src/shared/domain/models/AssessmentResult.js';
 import { domainBuilder, expect, sinon } from '../../../../../../test-helper.js';
 
@@ -97,13 +97,13 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring Comple
         .withArgs({ assessmentId: assessmentResult.assessmentId })
         .resolves(
           domainBuilder.certification.evaluation.buildCandidate({
-            subscriptionScope: Scopes.PIX_PLUS_DROIT,
+            subscriptionScope: SCOPES.PIX_PLUS_DROIT,
           }),
         );
 
       complementaryCertificationRepository.get
         .withArgs({ id: complementaryCertificationId })
-        .resolves({ key: Scopes.PIX_PLUS_DROIT });
+        .resolves({ key: SCOPES.PIX_PLUS_DROIT });
 
       complementaryCertificationBadgesRepository.getAllWithSameTargetProfile.resolves([
         domainBuilder.certification.enrolment.buildComplementaryCertificationBadge({ id: 888 }),
@@ -399,7 +399,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring Comple
             });
 
             const evaluationCandidate = domainBuilder.certification.evaluation.buildCandidate({
-              subscriptionScope: Scopes.PIX_PLUS_DROIT,
+              subscriptionScope: SCOPES.PIX_PLUS_DROIT,
             });
 
             certificationCandidateRepository.findByAssessmentId
@@ -426,7 +426,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring Comple
 
             complementaryCertificationRepository.get
               .withArgs({ id: complementaryCertificationId })
-              .resolves({ key: Scopes.PIX_PLUS_DROIT });
+              .resolves({ key: SCOPES.PIX_PLUS_DROIT });
 
             // when
             await scoreComplementaryCertificationV2({
@@ -485,7 +485,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring Comple
             .withArgs({ assessmentId: assessmentResult.assessmentId })
             .resolves(
               domainBuilder.certification.evaluation.buildCandidate({
-                subscriptionScope: Scopes.PIX_PLUS_DROIT,
+                subscriptionScope: SCOPES.PIX_PLUS_DROIT,
               }),
             );
 
@@ -505,7 +505,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring Comple
 
           complementaryCertificationRepository.get
             .withArgs({ id: complementaryCertificationId })
-            .resolves({ key: Scopes.PIX_PLUS_DROIT });
+            .resolves({ key: SCOPES.PIX_PLUS_DROIT });
 
           complementaryCertificationBadgesRepository.getAllWithSameTargetProfile.resolves([
             domainBuilder.certification.enrolment.buildComplementaryCertificationBadge({ id: 888 }),
@@ -582,7 +582,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring Comple
 
             complementaryCertificationRepository.get
               .withArgs({ id: complementaryCertificationId })
-              .resolves({ key: Scopes.PIX_PLUS_DROIT });
+              .resolves({ key: SCOPES.PIX_PLUS_DROIT });
 
             const complementaryCertificationScoringCriteria =
               domainBuilder.certification.evaluation.buildComplementaryCertificationScoringCriteria({
@@ -610,7 +610,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring Comple
               .withArgs({ assessmentId: assessmentResult.assessmentId })
               .resolves(
                 domainBuilder.certification.evaluation.buildCandidate({
-                  subscriptionScope: Scopes.PIX_PLUS_DROIT,
+                  subscriptionScope: SCOPES.PIX_PLUS_DROIT,
                 }),
               );
 
@@ -688,7 +688,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring Comple
 
             complementaryCertificationRepository.get
               .withArgs({ id: complementaryCertificationId })
-              .resolves({ key: Scopes.PIX_PLUS_DROIT });
+              .resolves({ key: SCOPES.PIX_PLUS_DROIT });
 
             certificationAssessmentRepository.getByCertificationCourseId
               .withArgs({ certificationCourseId })
@@ -703,7 +703,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring Comple
               .withArgs({ assessmentId: assessmentResult.assessmentId })
               .resolves(
                 domainBuilder.certification.evaluation.buildCandidate({
-                  subscriptionScope: Scopes.PIX_PLUS_DROIT,
+                  subscriptionScope: SCOPES.PIX_PLUS_DROIT,
                 }),
               );
 
@@ -792,7 +792,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring Comple
 
                 complementaryCertificationRepository.get
                   .withArgs({ id: complementaryCertificationId })
-                  .resolves({ key: Scopes.PIX_PLUS_DROIT });
+                  .resolves({ key: SCOPES.PIX_PLUS_DROIT });
 
                 complementaryCertificationBadgesRepository.getAllWithSameTargetProfile.withArgs(888).resolves([
                   domainBuilder.certification.complementaryCertification.buildComplementaryCertificationBadge({
@@ -819,7 +819,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring Comple
                   .withArgs({ assessmentId: assessmentResult.assessmentId })
                   .resolves(
                     domainBuilder.certification.evaluation.buildCandidate({
-                      subscriptionScope: Scopes.PIX_PLUS_DROIT,
+                      subscriptionScope: SCOPES.PIX_PLUS_DROIT,
                     }),
                   );
 
@@ -901,7 +901,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring Comple
 
                 complementaryCertificationRepository.get
                   .withArgs({ id: complementaryCertificationId })
-                  .resolves({ key: Scopes.PIX_PLUS_DROIT });
+                  .resolves({ key: SCOPES.PIX_PLUS_DROIT });
 
                 complementaryCertificationBadgesRepository.getAllWithSameTargetProfile.withArgs(888).resolves([
                   domainBuilder.certification.complementaryCertification.buildComplementaryCertificationBadge({
@@ -923,7 +923,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring Comple
                   .withArgs({ assessmentId: assessmentResult.assessmentId })
                   .resolves(
                     domainBuilder.certification.evaluation.buildCandidate({
-                      subscriptionScope: Scopes.PIX_PLUS_DROIT,
+                      subscriptionScope: SCOPES.PIX_PLUS_DROIT,
                     }),
                   );
 
@@ -996,7 +996,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring Comple
         .withArgs({ assessmentId: assessmentResult.assessmentId })
         .resolves(
           domainBuilder.certification.evaluation.buildCandidate({
-            subscriptionScope: Scopes.CORE,
+            subscriptionScope: SCOPES.CORE,
           }),
         );
 
@@ -1016,7 +1016,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring Comple
 
       complementaryCertificationRepository.get
         .withArgs({ id: complementaryCertificationId })
-        .resolves({ key: Scopes.PIX_PLUS_DROIT });
+        .resolves({ key: SCOPES.PIX_PLUS_DROIT });
 
       // when
       await scoreComplementaryCertificationV2({
@@ -1069,7 +1069,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring Comple
           .withArgs({ assessmentId: assessmentResult.assessmentId })
           .resolves(
             domainBuilder.certification.evaluation.buildCandidate({
-              subscriptionScope: Scopes.CORE,
+              subscriptionScope: SCOPES.CORE,
             }),
           );
 
@@ -1103,7 +1103,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring Comple
 
         complementaryCertificationRepository.get
           .withArgs({ id: complementaryCertificationId })
-          .resolves({ key: Scopes.PIX_PLUS_DROIT });
+          .resolves({ key: SCOPES.PIX_PLUS_DROIT });
 
         // when
         await scoreComplementaryCertificationV2({
@@ -1173,7 +1173,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring Comple
           .withArgs({ assessmentId: assessmentResult.assessmentId })
           .resolves(
             domainBuilder.certification.evaluation.buildCandidate({
-              subscriptionScope: Scopes.CORE,
+              subscriptionScope: SCOPES.CORE,
             }),
           );
 
@@ -1193,7 +1193,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring Comple
 
         complementaryCertificationRepository.get
           .withArgs({ id: complementaryCertificationId })
-          .resolves({ key: Scopes.PIX_PLUS_DROIT });
+          .resolves({ key: SCOPES.PIX_PLUS_DROIT });
 
         // when
         await scoreComplementaryCertificationV2({
@@ -1263,7 +1263,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring Comple
           .withArgs({ assessmentId: assessmentResult.assessmentId })
           .resolves(
             domainBuilder.certification.evaluation.buildCandidate({
-              subscriptionScope: Scopes.CORE,
+              subscriptionScope: SCOPES.CORE,
             }),
           );
 
@@ -1283,7 +1283,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring Comple
 
         complementaryCertificationRepository.get
           .withArgs({ id: complementaryCertificationId })
-          .resolves({ key: Scopes.PIX_PLUS_DROIT });
+          .resolves({ key: SCOPES.PIX_PLUS_DROIT });
 
         // when
         await scoreComplementaryCertificationV2({
@@ -1353,7 +1353,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring Comple
           .withArgs({ assessmentId: assessmentResult.assessmentId })
           .resolves(
             domainBuilder.certification.evaluation.buildCandidate({
-              subscriptionScope: Scopes.CORE,
+              subscriptionScope: SCOPES.CORE,
             }),
           );
 
@@ -1373,7 +1373,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring Comple
 
         complementaryCertificationRepository.get
           .withArgs({ id: complementaryCertificationId })
-          .resolves({ key: Scopes.PIX_PLUS_DROIT });
+          .resolves({ key: SCOPES.PIX_PLUS_DROIT });
 
         // when
         await scoreComplementaryCertificationV2({
@@ -1443,7 +1443,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring Comple
           .withArgs({ assessmentId: assessmentResult.assessmentId })
           .resolves(
             domainBuilder.certification.evaluation.buildCandidate({
-              subscriptionScope: Scopes.CORE,
+              subscriptionScope: SCOPES.CORE,
             }),
           );
 
@@ -1462,7 +1462,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring Comple
         );
         complementaryCertificationRepository.get
           .withArgs({ id: complementaryCertificationId })
-          .resolves({ key: Scopes.PIX_PLUS_DROIT });
+          .resolves({ key: SCOPES.PIX_PLUS_DROIT });
 
         // when
         await scoreComplementaryCertificationV2({

--- a/api/tests/certification/evaluation/unit/domain/services/scoring/scoring-v3_test.js
+++ b/api/tests/certification/evaluation/unit/domain/services/scoring/scoring-v3_test.js
@@ -5,7 +5,7 @@ import { CertificationJuryDone } from '../../../../../../../src/certification/se
 import { AlgorithmEngineVersion } from '../../../../../../../src/certification/shared/domain/models/AlgorithmEngineVersion.js';
 import { ABORT_REASONS } from '../../../../../../../src/certification/shared/domain/models/CertificationCourse.js';
 import { AutoJuryCommentKeys } from '../../../../../../../src/certification/shared/domain/models/JuryComment.js';
-import { Scopes } from '../../../../../../../src/certification/shared/domain/models/Scopes.js';
+import { SCOPES } from '../../../../../../../src/certification/shared/domain/models/Scopes.js';
 import { config } from '../../../../../../../src/shared/config.js';
 import { DomainTransaction } from '../../../../../../../src/shared/domain/DomainTransaction.js';
 import { CertificationCandidateNotFoundError } from '../../../../../../../src/shared/domain/errors.js';
@@ -194,11 +194,11 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V3', f
 
         certificationCourseRepository.getCertificationScope
           .withArgs({ courseId: abortedCertificationCourse.getId() })
-          .resolves(Scopes.CORE);
+          .resolves(SCOPES.CORE);
 
         sharedVersionRepository.getByScopeAndReconciliationDate
           .withArgs({
-            scope: Scopes.CORE,
+            scope: SCOPES.CORE,
             reconciliationDate: candidate.reconciledAt,
           })
           .resolves(version);
@@ -312,7 +312,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V3', f
 
           certificationCourseRepository.getCertificationScope
             .withArgs({ courseId: certificationCourse.getId() })
-            .resolves(Scopes.CORE);
+            .resolves(SCOPES.CORE);
 
           // when
           const error = await catchErr(handleV3CertificationScoring)({
@@ -394,11 +394,11 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V3', f
 
             certificationCourseRepository.getCertificationScope
               .withArgs({ courseId: certificationCourse.getId() })
-              .resolves(Scopes.CORE);
+              .resolves(SCOPES.CORE);
 
             sharedVersionRepository.getByScopeAndReconciliationDate
               .withArgs({
-                scope: Scopes.CORE,
+                scope: SCOPES.CORE,
                 reconciliationDate: candidate.reconciledAt,
               })
               .resolves(version);
@@ -509,11 +509,11 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V3', f
 
               certificationCourseRepository.getCertificationScope
                 .withArgs({ courseId: certificationCourse.getId() })
-                .resolves(Scopes.CORE);
+                .resolves(SCOPES.CORE);
 
               sharedVersionRepository.getByScopeAndReconciliationDate
                 .withArgs({
-                  scope: Scopes.CORE,
+                  scope: SCOPES.CORE,
                   reconciliationDate: candidate.reconciledAt,
                 })
                 .resolves(version);
@@ -635,11 +635,11 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V3', f
 
               certificationCourseRepository.getCertificationScope
                 .withArgs({ courseId: certificationCourse.getId() })
-                .resolves(Scopes.CORE);
+                .resolves(SCOPES.CORE);
 
               sharedVersionRepository.getByScopeAndReconciliationDate
                 .withArgs({
-                  scope: Scopes.CORE,
+                  scope: SCOPES.CORE,
                   reconciliationDate: candidate.reconciledAt,
                 })
                 .resolves(version);
@@ -802,11 +802,11 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V3', f
 
             certificationCourseRepository.getCertificationScope
               .withArgs({ courseId: abortedCertificationCourse.getId() })
-              .resolves(Scopes.CORE);
+              .resolves(SCOPES.CORE);
 
             sharedVersionRepository.getByScopeAndReconciliationDate
               .withArgs({
-                scope: Scopes.CORE,
+                scope: SCOPES.CORE,
                 reconciliationDate: candidate.reconciledAt,
               })
               .resolves(version);
@@ -925,11 +925,11 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V3', f
 
             certificationCourseRepository.getCertificationScope
               .withArgs({ courseId: abortedCertificationCourse.getId() })
-              .resolves(Scopes.CORE);
+              .resolves(SCOPES.CORE);
 
             sharedVersionRepository.getByScopeAndReconciliationDate
               .withArgs({
-                scope: Scopes.CORE,
+                scope: SCOPES.CORE,
                 reconciliationDate: candidate.reconciledAt,
               })
               .resolves(version);
@@ -1061,11 +1061,11 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V3', f
 
             certificationCourseRepository.getCertificationScope
               .withArgs({ courseId: abortedCertificationCourse.getId() })
-              .resolves(Scopes.CORE);
+              .resolves(SCOPES.CORE);
 
             sharedVersionRepository.getByScopeAndReconciliationDate
               .withArgs({
-                scope: Scopes.CORE,
+                scope: SCOPES.CORE,
                 reconciliationDate: candidate.reconciledAt,
               })
               .resolves(version);
@@ -1192,11 +1192,11 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V3', f
 
             certificationCourseRepository.getCertificationScope
               .withArgs({ courseId: abortedCertificationCourse.getId() })
-              .resolves(Scopes.CORE);
+              .resolves(SCOPES.CORE);
 
             sharedVersionRepository.getByScopeAndReconciliationDate
               .withArgs({
-                scope: Scopes.CORE,
+                scope: SCOPES.CORE,
                 reconciliationDate: candidate.reconciledAt,
               })
               .resolves(version);
@@ -1318,11 +1318,11 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V3', f
 
             certificationCourseRepository.getCertificationScope
               .withArgs({ courseId: abortedCertificationCourse.getId() })
-              .resolves(Scopes.CORE);
+              .resolves(SCOPES.CORE);
 
             sharedVersionRepository.getByScopeAndReconciliationDate
               .withArgs({
-                scope: Scopes.CORE,
+                scope: SCOPES.CORE,
                 reconciliationDate: candidate.reconciledAt,
               })
               .resolves(version);
@@ -1446,11 +1446,11 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V3', f
 
             certificationCourseRepository.getCertificationScope
               .withArgs({ courseId: abortedCertificationCourse.getId() })
-              .resolves(Scopes.CORE);
+              .resolves(SCOPES.CORE);
 
             sharedVersionRepository.getByScopeAndReconciliationDate
               .withArgs({
-                scope: Scopes.CORE,
+                scope: SCOPES.CORE,
                 reconciliationDate: candidate.reconciledAt,
               })
               .resolves(version);
@@ -1572,11 +1572,11 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V3', f
 
             certificationCourseRepository.getCertificationScope
               .withArgs({ courseId: abortedCertificationCourse.getId() })
-              .resolves(Scopes.CORE);
+              .resolves(SCOPES.CORE);
 
             sharedVersionRepository.getByScopeAndReconciliationDate
               .withArgs({
-                scope: Scopes.CORE,
+                scope: SCOPES.CORE,
                 reconciliationDate: candidate.reconciledAt,
               })
               .resolves(version);

--- a/api/tests/certification/evaluation/unit/domain/usecases/get-certification-course_test.js
+++ b/api/tests/certification/evaluation/unit/domain/usecases/get-certification-course_test.js
@@ -1,6 +1,6 @@
 import { getCertificationCourse } from '../../../../../../src/certification/evaluation/domain/usecases/get-certification-course.js';
 import { AlgorithmEngineVersion } from '../../../../../../src/certification/shared/domain/models/AlgorithmEngineVersion.js';
-import { Scopes } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
+import { SCOPES } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
 import { domainBuilder, expect, sinon } from '../../../../../test-helper.js';
 
 describe('Unit | UseCase | get-certification-course', function () {
@@ -45,7 +45,7 @@ describe('Unit | UseCase | get-certification-course', function () {
   it('should get the certificationCourse with numberOfChallenges from version', async function () {
     certificationCourseRepository.get.withArgs({ id: certificationCourse.getId() }).resolves(certificationCourse);
     sharedCertificationCandidateRepository.getBySessionIdAndUserId.resolves(candidate);
-    certificationCourseRepository.getCertificationScope.resolves(Scopes.CORE);
+    certificationCourseRepository.getCertificationScope.resolves(SCOPES.CORE);
     versionRepository.getByScopeAndReconciliationDate.resolves(version);
 
     const actualCertificationCourse = await getCertificationCourse({
@@ -66,7 +66,7 @@ describe('Unit | UseCase | get-certification-course', function () {
       courseId: certificationCourse.getId(),
     });
     expect(versionRepository.getByScopeAndReconciliationDate).to.have.been.calledOnceWithExactly({
-      scope: Scopes.CORE,
+      scope: SCOPES.CORE,
       reconciliationDate: candidate.reconciledAt,
     });
     expect(actualCertificationCourse.getNumberOfChallenges()).to.equal(42);

--- a/api/tests/certification/evaluation/unit/domain/usecases/get-next-challenge_test.js
+++ b/api/tests/certification/evaluation/unit/domain/usecases/get-next-challenge_test.js
@@ -4,7 +4,7 @@ import {
 } from '../../../../../../src/certification/evaluation/domain/usecases/get-next-challenge.js';
 import { AlgorithmEngineVersion } from '../../../../../../src/certification/shared/domain/models/AlgorithmEngineVersion.js';
 import { ComplementaryCertificationKeys } from '../../../../../../src/certification/shared/domain/models/ComplementaryCertificationKeys.js';
-import { Scopes } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
+import { SCOPES } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
 import { AssessmentEndedError } from '../../../../../../src/shared/domain/errors.js';
 import { catchErr, domainBuilder, expect, sinon } from '../../../../../test-helper.js';
 
@@ -870,16 +870,16 @@ describe('Unit | Domain | Use Cases | get-next-challenge', function () {
         sharedChallengeRepository.get.resolves();
 
         const candidate = domainBuilder.certification.evaluation.buildCandidate({
-          subscriptionScope: Scopes.PIX_PLUS_EDU_CPE,
+          subscriptionScope: SCOPES.PIX_PLUS_EDU_CPE,
         });
         certificationCandidateRepository.findByAssessmentId
           .withArgs({ assessmentId: assessment.id })
           .resolves(candidate);
 
-        version = domainBuilder.certification.shared.buildVersion({ scope: Scopes.PIX_PLUS_EDU_CPE });
+        version = domainBuilder.certification.shared.buildVersion({ scope: SCOPES.PIX_PLUS_EDU_CPE });
         versionRepository.getByScopeAndReconciliationDate
           .withArgs({
-            scope: Scopes.PIX_PLUS_EDU_CPE,
+            scope: SCOPES.PIX_PLUS_EDU_CPE,
             reconciliationDate: candidate.reconciledAt,
           })
           .resolves(version);
@@ -940,7 +940,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge', function () {
         sharedChallengeRepository.get.resolves();
 
         const candidate = domainBuilder.certification.evaluation.buildCandidate({
-          subscriptionScope: Scopes.CORE,
+          subscriptionScope: SCOPES.CORE,
         });
         certificationCandidateRepository.findByAssessmentId
           .withArgs({ assessmentId: assessment.id })

--- a/api/tests/certification/evaluation/unit/domain/usecases/simulate-flash-assessment-scenario_test.js
+++ b/api/tests/certification/evaluation/unit/domain/usecases/simulate-flash-assessment-scenario_test.js
@@ -1,5 +1,5 @@
 import * as simulateFlashAssessmentScenarioModule from '../../../../../../src/certification/evaluation/domain/usecases/simulate-flash-assessment-scenario.js';
-import { Scopes } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
+import { SCOPES } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
 import { FRENCH_FRANCE } from '../../../../../../src/shared/domain/services/locale-service.js';
 import { catchErr, domainBuilder, expect, sinon } from '../../../../../test-helper.js';
 
@@ -15,7 +15,7 @@ describe('Unit | Domain | Usecases | simulate-flash-assessment-scenario', functi
       const challengesConfiguration = { minimumEstimatedSuccessRateRanges: [], defaultCandidateCapacity: -1 };
       const version = domainBuilder.certification.shared.buildVersion({
         id: versionId,
-        scope: Scopes.PIX_PLUS_DROIT,
+        scope: SCOPES.PIX_PLUS_DROIT,
         challengesConfiguration,
       });
 

--- a/api/tests/certification/shared/integration/infrastructure/repositories/version-repository_test.js
+++ b/api/tests/certification/shared/integration/infrastructure/repositories/version-repository_test.js
@@ -1,4 +1,4 @@
-import { Scopes } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
+import { SCOPES } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
 import { Version } from '../../../../../../src/certification/shared/domain/models/Version.js';
 import * as versionRepository from '../../../../../../src/certification/shared/infrastructure/repositories/version-repository.js';
 import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
@@ -13,7 +13,7 @@ describe('Integration | Certification | Evaluation | Infrastructure | Repository
       });
 
       const versionId = databaseBuilder.factory.buildCertificationVersion({
-        scope: Scopes.PIX_PLUS_DROIT,
+        scope: SCOPES.PIX_PLUS_DROIT,
         startDate: new Date('2025-03-01'),
         challengesConfiguration,
       }).id;
@@ -26,7 +26,7 @@ describe('Integration | Certification | Evaluation | Infrastructure | Repository
       // then
       expect(result).to.be.instanceOf(Version);
       expect(result.id).to.equal(versionId);
-      expect(result.scope).to.equal(Scopes.PIX_PLUS_DROIT);
+      expect(result.scope).to.equal(SCOPES.PIX_PLUS_DROIT);
       expect(result.challengesConfiguration).to.deep.equal(challengesConfiguration);
     });
 
@@ -49,7 +49,7 @@ describe('Integration | Certification | Evaluation | Infrastructure | Repository
     it('should return the most recent version before or equal to the reconciliation date', async function () {
       // given
       const reconciliationDate = new Date('2025-06-15');
-      const scope = Scopes.CORE;
+      const scope = SCOPES.CORE;
 
       databaseBuilder.factory.buildCertificationVersion({
         scope,
@@ -102,8 +102,8 @@ describe('Integration | Certification | Evaluation | Infrastructure | Repository
     it('should only consider versions of the specified scope', async function () {
       // given
       const reconciliationDate = new Date('2025-06-15');
-      const targetScope = Scopes.PIX_PLUS_PRO_SANTE;
-      const otherScope = Scopes.CORE;
+      const targetScope = SCOPES.PIX_PLUS_PRO_SANTE;
+      const otherScope = SCOPES.CORE;
 
       const expectedChallengeConf = domainBuilder.buildFlashAlgorithmConfiguration({ defaultCandidateCapacity: 1 });
       const expectedVersionId = databaseBuilder.factory.buildCertificationVersion({
@@ -145,7 +145,7 @@ describe('Integration | Certification | Evaluation | Infrastructure | Repository
       it('should return the exact version', async function () {
         // given
         const reconciliationDate = new Date('2025-06-01');
-        const scope = Scopes.PIX_PLUS_DROIT;
+        const scope = SCOPES.PIX_PLUS_DROIT;
 
         const expectedChallengeConf = domainBuilder.buildFlashAlgorithmConfiguration({ defaultCandidateCapacity: 1 });
         const expectedVersionId = databaseBuilder.factory.buildCertificationVersion({
@@ -177,10 +177,10 @@ describe('Integration | Certification | Evaluation | Infrastructure | Repository
       it('should throw a NotFoundError', async function () {
         // given
         const reconciliationDate = new Date('2025-06-15');
-        const scope = Scopes.PIX_PLUS_EDU_1ER_DEGRE;
+        const scope = SCOPES.PIX_PLUS_EDU_1ER_DEGRE;
 
         databaseBuilder.factory.buildCertificationVersion({
-          scope: Scopes.CORE,
+          scope: SCOPES.CORE,
           startDate: new Date('2025-01-01'),
           expirationDate: null,
           assessmentDuration: 90,
@@ -208,7 +208,7 @@ describe('Integration | Certification | Evaluation | Infrastructure | Repository
       it('should throw a NotFoundError', async function () {
         // given
         const reconciliationDate = new Date('2024-12-31');
-        const scope = Scopes.PIX_PLUS_EDU_2ND_DEGRE;
+        const scope = SCOPES.PIX_PLUS_EDU_2ND_DEGRE;
 
         databaseBuilder.factory.buildCertificationVersion({
           scope,

--- a/api/tests/certification/shared/unit/domain/models/Scopes_test.js
+++ b/api/tests/certification/shared/unit/domain/models/Scopes_test.js
@@ -1,18 +1,18 @@
-import { Scopes } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
+import { getScopeByName, SCOPES } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
 import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
 import { expect } from '../../../../../test-helper.js';
 
 describe('Unit | Certification | Shared | Domain | Models | Scopes', function () {
-  describe('getByName', function () {
+  describe('getScopeByName', function () {
     it('should return the scope when it exists', function () {
       // Given
       const scopeName = 'CORE';
 
       // When
-      const result = Scopes.getByName(scopeName);
+      const result = getScopeByName(scopeName);
 
       // Then
-      expect(result).to.equal(Scopes.CORE);
+      expect(result).to.equal(SCOPES.CORE);
     });
 
     it('should throw a NotFoundError when the scope does not exist', function () {
@@ -20,16 +20,16 @@ describe('Unit | Certification | Shared | Domain | Models | Scopes', function ()
       const scopeName = 'NON_EXISTENT';
 
       // When & Then
-      expect(() => Scopes.getByName(scopeName)).to.throw(NotFoundError, 'Scope with name "NON_EXISTENT" not found.');
+      expect(() => getScopeByName(scopeName)).to.throw(NotFoundError, 'Scope with name "NON_EXISTENT" not found.');
     });
   });
 
   it('should contain the supported Pix scopes', function () {
-    expect(Scopes.CORE).to.equal('CORE');
-    expect(Scopes.PIX_PLUS_DROIT).to.equal('DROIT');
-    expect(Scopes.PIX_PLUS_EDU_1ER_DEGRE).to.equal('EDU_1ER_DEGRE');
-    expect(Scopes.PIX_PLUS_EDU_2ND_DEGRE).to.equal('EDU_2ND_DEGRE');
-    expect(Scopes.PIX_PLUS_EDU_CPE).to.equal('EDU_CPE');
-    expect(Scopes.PIX_PLUS_PRO_SANTE).to.equal('PRO_SANTE');
+    expect(SCOPES.CORE).to.equal('CORE');
+    expect(SCOPES.PIX_PLUS_DROIT).to.equal('DROIT');
+    expect(SCOPES.PIX_PLUS_EDU_1ER_DEGRE).to.equal('EDU_1ER_DEGRE');
+    expect(SCOPES.PIX_PLUS_EDU_2ND_DEGRE).to.equal('EDU_2ND_DEGRE');
+    expect(SCOPES.PIX_PLUS_EDU_CPE).to.equal('EDU_CPE');
+    expect(SCOPES.PIX_PLUS_PRO_SANTE).to.equal('PRO_SANTE');
   });
 });

--- a/api/tests/certification/shared/unit/domain/models/Version_test.js
+++ b/api/tests/certification/shared/unit/domain/models/Version_test.js
@@ -1,5 +1,5 @@
 import { FlashAssessmentAlgorithmConfiguration } from '../../../../../../src/certification/shared/domain/models/FlashAssessmentAlgorithmConfiguration.js';
-import { Scopes } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
+import { SCOPES } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
 import { Version } from '../../../../../../src/certification/shared/domain/models/Version.js';
 import { EntityValidationError } from '../../../../../../src/shared/domain/errors.js';
 import { catchErrSync, expect } from '../../../../../test-helper.js';
@@ -10,7 +10,7 @@ describe('Unit | Certification | Evaluation | Domain | Models | Version', functi
       // given
       const versionData = {
         id: 123,
-        scope: Scopes.CORE,
+        scope: SCOPES.CORE,
         challengesConfiguration: new FlashAssessmentAlgorithmConfiguration({
           challengesBetweenSameCompetence: 0,
           maximumAssessmentLength: 10,
@@ -28,7 +28,7 @@ describe('Unit | Certification | Evaluation | Domain | Models | Version', functi
       // then
       expect(version).to.be.instanceOf(Version);
       expect(version.id).to.equal(123);
-      expect(version.scope).to.equal(Scopes.CORE);
+      expect(version.scope).to.equal(SCOPES.CORE);
       expect(version.challengesConfiguration).to.deep.equal(
         new FlashAssessmentAlgorithmConfiguration({
           challengesBetweenSameCompetence: 0,
@@ -46,7 +46,7 @@ describe('Unit | Certification | Evaluation | Domain | Models | Version', functi
       // given
       const versionData = {
         id: 456,
-        scope: Scopes.PIX_PLUS_DROIT,
+        scope: SCOPES.PIX_PLUS_DROIT,
         challengesConfiguration: new FlashAssessmentAlgorithmConfiguration({
           challengesBetweenSameCompetence: 0,
           maximumAssessmentLength: 10,
@@ -64,7 +64,7 @@ describe('Unit | Certification | Evaluation | Domain | Models | Version', functi
       // then
       expect(version).to.be.instanceOf(Version);
       expect(version.id).to.equal(456);
-      expect(version.scope).to.equal(Scopes.PIX_PLUS_DROIT);
+      expect(version.scope).to.equal(SCOPES.PIX_PLUS_DROIT);
       expect(version.challengesConfiguration).to.deep.equal(
         new FlashAssessmentAlgorithmConfiguration({
           challengesBetweenSameCompetence: 0,
@@ -81,7 +81,7 @@ describe('Unit | Certification | Evaluation | Domain | Models | Version', functi
     it('should throw an EntityValidationError when id is missing', function () {
       // given
       const invalidData = {
-        scope: Scopes.CORE,
+        scope: SCOPES.CORE,
       };
 
       // when
@@ -122,7 +122,7 @@ describe('Unit | Certification | Evaluation | Domain | Models | Version', functi
       // given
       const invalidData = {
         id: 'not-a-number',
-        scope: Scopes.CORE,
+        scope: SCOPES.CORE,
         challengesConfiguration: { config: 'test' },
       };
 
@@ -137,7 +137,7 @@ describe('Unit | Certification | Evaluation | Domain | Models | Version', functi
       // given
       const invalidData = {
         id: 123,
-        scope: Scopes.CORE,
+        scope: SCOPES.CORE,
       };
 
       // when
@@ -151,7 +151,7 @@ describe('Unit | Certification | Evaluation | Domain | Models | Version', functi
       // given
       const invalidData = {
         id: 123,
-        scope: Scopes.CORE,
+        scope: SCOPES.CORE,
         challengesConfiguration: { defaultCandidateCapacity: 'not-a-number' },
       };
 

--- a/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-for-certification_test.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-for-certification_test.js
@@ -1,7 +1,7 @@
 import { AlgorithmEngineVersion } from '../../../../../src/certification/shared/domain/models/AlgorithmEngineVersion.js';
 import { CertificationChallengeLiveAlertStatus } from '../../../../../src/certification/shared/domain/models/CertificationChallengeLiveAlert.js';
 import { CertificationCompanionLiveAlertStatus } from '../../../../../src/certification/shared/domain/models/CertificationCompanionLiveAlert.js';
-import { Scopes } from '../../../../../src/certification/shared/domain/models/Scopes.js';
+import { SCOPES } from '../../../../../src/certification/shared/domain/models/Scopes.js';
 import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
 import {
   createServer,
@@ -105,7 +105,7 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-certif
           reconciledAt: new Date('2020-01-15'),
         });
         const version = databaseBuilder.factory.buildCertificationVersion({
-          scope: Scopes.CORE,
+          scope: SCOPES.CORE,
           startDate: new Date('2020-01-10'),
         });
 
@@ -271,7 +271,7 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-certif
         });
         databaseBuilder.factory.buildCompetenceEvaluation({ assessmentId, competenceId, userId });
         const version = databaseBuilder.factory.buildCertificationVersion({
-          scope: Scopes.CORE,
+          scope: SCOPES.CORE,
           startDate: new Date('2019-01-01'),
         });
 

--- a/api/tests/tooling/domain-builder/factory/certification/configuration/build-version.js
+++ b/api/tests/tooling/domain-builder/factory/certification/configuration/build-version.js
@@ -1,10 +1,10 @@
 import { Version } from '../../../../../../src/certification/configuration/domain/models/Version.js';
-import { Scopes } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
+import { SCOPES } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
 import { buildFlashAlgorithmConfiguration } from '../../build-flash-algorithm-configuration.js';
 
 export const buildVersion = ({
   id = 1,
-  scope = Scopes.CORE,
+  scope = SCOPES.CORE,
   startDate = new Date(),
   expirationDate,
   assessmentDuration = 105,

--- a/api/tests/tooling/domain-builder/factory/certification/evaluation/build-candidate.js
+++ b/api/tests/tooling/domain-builder/factory/certification/evaluation/build-candidate.js
@@ -1,10 +1,10 @@
 import { Candidate } from '../../../../../../src/certification/evaluation/domain/models/Candidate.js';
-import { Scopes } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
+import { SCOPES } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
 
 export const buildEvaluationCandidate = function ({
   accessibilityAdjustmentNeeded,
   reconciledAt = new Date('2024-10-18'),
-  subscriptionScope = Scopes.CORE,
+  subscriptionScope = SCOPES.CORE,
 } = {}) {
   return new Candidate({
     accessibilityAdjustmentNeeded,

--- a/api/tests/tooling/domain-builder/factory/certification/shared/build-version.js
+++ b/api/tests/tooling/domain-builder/factory/certification/shared/build-version.js
@@ -1,8 +1,8 @@
-import { Scopes } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
+import { SCOPES } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
 import { Version } from '../../../../../../src/certification/shared/domain/models/Version.js';
 import { buildFlashAlgorithmConfiguration } from '../../build-flash-algorithm-configuration.js';
 
-export const buildVersion = ({ id = 1, scope = Scopes.CORE, challengesConfiguration } = {}) => {
+export const buildVersion = ({ id = 1, scope = SCOPES.CORE, challengesConfiguration } = {}) => {
   return new Version({
     id,
     scope,


### PR DESCRIPTION
## ❄️ Problème

La codebase de Pix n'est pas typée.

## 🛷 Proposition

Afin de faciliter la future transition de la codebase de Pix vers TypeScript, nous améliorons la JSDoc existante.

## ☃️ Remarques

Le fichier `Scopes.js` renvoyait un objet contenant à la fois un `enum` et une  `fonction` créant un type étrange.
Nous réécrivons le fichier afin de mieux séparer ce qui constitue ce fichier (et remplacer dans les différents endroits nécessaires)
 
## 🧑‍🎄 Pour tester

- Tests verts ✅ 
- Passe globale sur une certification coeur et une Pix+ (création, passage, finalisation, et publication)