### PR TITLE
[FEATURE] Créer le compte et connecter l'utilisateur via SSO Pix Orga (PIX-20666)

### DIFF
--- a/api/src/team/application/organization-invitations/organization-invitation.controller.js
+++ b/api/src/team/application/organization-invitations/organization-invitation.controller.js
@@ -8,14 +8,14 @@ import { serializer as scoOrganizationInvitationSerializer } from '../../infrast
 
 const acceptOrganizationInvitation = async function (request) {
   const organizationInvitationId = request.params.id;
-  const { code, email: rawEmail } = request.payload.data.attributes;
+  const { code, email, 'user-id': userId } = request.payload.data.attributes;
   const locale = getUserLocale(request);
-  const email = rawEmail?.trim().toLowerCase();
 
   const membership = await usecases.acceptOrganizationInvitation({
     organizationInvitationId,
     code,
     email,
+    userId,
     locale,
   });
   await usecases.createCertificationCenterMembershipForScoOrganizationAdminMember({ membership });

--- a/api/src/team/application/organization-invitations/organization-invitation.route.js
+++ b/api/src/team/application/organization-invitations/organization-invitation.route.js
@@ -36,18 +36,21 @@ export const organizationInvitationRoutes = [
           id: identifiersType.organizationInvitationId,
         }),
         payload: Joi.object({
-          data: {
+          data: Joi.object({
             id: Joi.string().required(),
             type: Joi.string().required(),
-            attributes: {
+            attributes: Joi.object({
               code: Joi.string().required(),
-              email: Joi.string().email().required(),
-            },
-          },
+              'user-id': Joi.number().integer().allow(null).empty(null),
+              email: Joi.string().email().allow(null).empty(null),
+            })
+              .xor('user-id', 'email')
+              .required(),
+          }),
         }),
       },
       notes: [
-        "- Cette route permet d'accepter l'invitation à rejoindre une organisation, via un **code** et un **email**",
+        "- Cette route permet d'accepter l'invitation à rejoindre une organisation, via un **code** et un **email** ou via un **code** et un **userId**",
       ],
       tags: ['api', 'invitations'],
     },

--- a/api/src/team/domain/usecases/accept-organization-invitation.usecase.js
+++ b/api/src/team/domain/usecases/accept-organization-invitation.usecase.js
@@ -17,6 +17,7 @@ const acceptOrganizationInvitation = async function ({
   organizationInvitationId,
   code,
   email,
+  userId,
   locale,
   organizationInvitationRepository,
   organizationInvitedUserRepository,
@@ -24,7 +25,7 @@ const acceptOrganizationInvitation = async function ({
 }) {
   let organizationInvitedUser;
   try {
-    organizationInvitedUser = await organizationInvitedUserRepository.get({ organizationInvitationId, email });
+    organizationInvitedUser = await organizationInvitedUserRepository.get({ organizationInvitationId, email, userId });
     organizationInvitedUser.acceptInvitation({ code });
   } catch (error) {
     if (error instanceof AlreadyExistingMembershipError) {

--- a/api/tests/team/acceptance/application/organization-invitations/organization-invitation.route.test.js
+++ b/api/tests/team/acceptance/application/organization-invitations/organization-invitation.route.test.js
@@ -120,178 +120,354 @@ describe('Acceptance | Team | Application | Controller | organization-invitation
   });
 
   describe('POST /api/organization-invitations/{id}/response', function () {
-    context('Success cases', function () {
-      let organizationId;
-      let options;
+    describe('When user is looked up by email', function () {
+      context('Success cases', function () {
+        let organizationId;
+        let options;
 
-      beforeEach(async function () {
-        organizationId = databaseBuilder.factory.buildOrganization().id;
-        const adminOrganizationUserId = databaseBuilder.factory.buildUser().id;
+        beforeEach(async function () {
+          organizationId = databaseBuilder.factory.buildOrganization().id;
+          const adminOrganizationUserId = databaseBuilder.factory.buildUser().id;
 
-        databaseBuilder.factory.buildMembership({
-          userId: adminOrganizationUserId,
-          organizationId,
-          organizationRole: Membership.roles.ADMIN,
-        });
+          databaseBuilder.factory.buildMembership({
+            userId: adminOrganizationUserId,
+            organizationId,
+            organizationRole: Membership.roles.ADMIN,
+          });
 
-        const userToInviteEmail = databaseBuilder.factory.buildUser().email;
-        const code = 'ABCDEFGH01';
+          const userToInviteEmail = databaseBuilder.factory.buildUser().email;
+          const code = 'ABCDEFGH01';
 
-        const organizationInvitationId = databaseBuilder.factory.buildOrganizationInvitation({
-          organizationId,
-          status: OrganizationInvitation.StatusType.PENDING,
-          code: code,
-        }).id;
+          const organizationInvitationId = databaseBuilder.factory.buildOrganizationInvitation({
+            organizationId,
+            status: OrganizationInvitation.StatusType.PENDING,
+            code: code,
+          }).id;
 
-        options = {
-          method: 'POST',
-          url: `/api/organization-invitations/${organizationInvitationId}/response`,
-          payload: {
-            data: {
-              id: '100047_DZWMP7L5UM',
-              type: 'organization-invitation-responses',
-              attributes: {
-                code,
-                email: userToInviteEmail.toUpperCase(),
+          options = {
+            method: 'POST',
+            url: `/api/organization-invitations/${organizationInvitationId}/response`,
+            payload: {
+              data: {
+                id: '100047_DZWMP7L5UM',
+                type: 'organization-invitation-responses',
+                attributes: {
+                  code,
+                  email: userToInviteEmail.toUpperCase(),
+                },
               },
             },
-          },
-        };
+          };
 
-        await databaseBuilder.commit();
+          await databaseBuilder.commit();
+        });
+
+        it('should return 204 HTTP status code', async function () {
+          // when
+          const response = await server.inject(options);
+
+          // then
+          expect(response.statusCode).to.equal(204);
+        });
       });
+      context('Error cases', function () {
+        it('should respond with a 404 if organization-invitation does not exist with id and code', async function () {
+          // given
+          const user = databaseBuilder.factory.buildUser({ email: 'user@example.net' });
+          const organizationInvitation = databaseBuilder.factory.buildOrganizationInvitation({});
+          await databaseBuilder.commit();
 
-      it('should return 204 HTTP status code', async function () {
-        // when
-        const response = await server.inject(options);
+          const options = {
+            method: 'POST',
+            url: `/api/organization-invitations/${organizationInvitation.id}/response`,
+            payload: {
+              data: {
+                id: '100047_DZWMP7L5UM',
+                type: 'organization-invitation-responses',
+                attributes: {
+                  code: 'notExistCode',
+                  email: user.email,
+                },
+              },
+            },
+          };
 
-        // then
-        expect(response.statusCode).to.equal(204);
+          // when
+          const response = await server.inject(options);
+
+          // then
+          expect(response.statusCode).to.equal(404);
+        });
+
+        it('should respond with a 409 if organization-invitation is already accepted', async function () {
+          // given
+          const user = databaseBuilder.factory.buildUser({ email: 'user@example.net' });
+          const organizationInvitation = databaseBuilder.factory.buildOrganizationInvitation({
+            status: OrganizationInvitation.StatusType.ACCEPTED,
+            code: 'DEFRTG123',
+          });
+
+          const options = {
+            method: 'POST',
+            url: `/api/organization-invitations/${organizationInvitation.id}/response`,
+            payload: {
+              data: {
+                id: '100047_DZWMP7L5UM',
+                type: 'organization-invitation-responses',
+                attributes: {
+                  code: organizationInvitation.code,
+                  email: user.email,
+                },
+              },
+            },
+          };
+
+          await databaseBuilder.commit();
+
+          // when
+          const response = await server.inject(options);
+
+          // then
+          expect(response.statusCode).to.equal(409);
+        });
+
+        it('should respond with a 401 if given email is not linked to an existing user', async function () {
+          // given
+          const organizationInvitation = databaseBuilder.factory.buildOrganizationInvitation({
+            status: OrganizationInvitation.StatusType.PENDING,
+          });
+          await databaseBuilder.commit();
+
+          const options = {
+            method: 'POST',
+            url: `/api/organization-invitations/${organizationInvitation.id}/response`,
+            payload: {
+              data: {
+                id: '100047_DZWMP7L5UM',
+                type: 'organization-invitation-responses',
+                attributes: {
+                  code: organizationInvitation.code,
+                  email: 'random@email.com',
+                },
+              },
+            },
+          };
+
+          // when
+          const response = await server.inject(options);
+
+          // then
+          expect(response.statusCode).to.equal(401);
+          expect(response.result.errors[0].code).to.equal('MISSING_OR_INVALID_CREDENTIALS');
+        });
+
+        it('should respond with a 412 if membership already exist with userId and OrganizationId', async function () {
+          // given
+          const organization = databaseBuilder.factory.buildOrganization();
+          const { id: userId, email } = databaseBuilder.factory.buildUser();
+          databaseBuilder.factory.buildMembership({ userId, organizationId: organization.id });
+          const { id: organizationInvitationId, code } = databaseBuilder.factory.buildOrganizationInvitation({
+            organizationId: organization.id,
+            status: OrganizationInvitation.StatusType.PENDING,
+          });
+          await databaseBuilder.commit();
+
+          const options = {
+            method: 'POST',
+            url: `/api/organization-invitations/${organizationInvitationId}/response`,
+            payload: {
+              data: {
+                id: '100047_DZWMP7L5UM',
+                type: 'organization-invitation-responses',
+                attributes: {
+                  code: code,
+                  email: email,
+                },
+              },
+            },
+          };
+
+          // when
+          const response = await server.inject(options);
+
+          // then
+          expect(response.statusCode).to.equal(412);
+        });
       });
     });
+    describe('When user is looked up by id', function () {
+      context('Success cases', function () {
+        let organizationId;
+        let options;
 
-    context('Error cases', function () {
-      it('should respond with a 404 if organization-invitation does not exist with id and code', async function () {
-        // given
-        const user = databaseBuilder.factory.buildUser({ email: 'user@example.net' });
-        const organizationInvitation = databaseBuilder.factory.buildOrganizationInvitation({});
-        await databaseBuilder.commit();
+        beforeEach(async function () {
+          organizationId = databaseBuilder.factory.buildOrganization().id;
+          const adminOrganizationUserId = databaseBuilder.factory.buildUser().id;
 
-        const options = {
-          method: 'POST',
-          url: `/api/organization-invitations/${organizationInvitation.id}/response`,
-          payload: {
-            data: {
-              id: '100047_DZWMP7L5UM',
-              type: 'organization-invitation-responses',
-              attributes: {
-                code: 'notExistCode',
-                email: user.email,
+          databaseBuilder.factory.buildMembership({
+            userId: adminOrganizationUserId,
+            organizationId,
+            organizationRole: Membership.roles.ADMIN,
+          });
+
+          const userToInviteId = databaseBuilder.factory.buildUser().id;
+          const code = 'ABCDEFGH01';
+
+          const organizationInvitationId = databaseBuilder.factory.buildOrganizationInvitation({
+            organizationId,
+            status: OrganizationInvitation.StatusType.PENDING,
+            code: code,
+          }).id;
+
+          options = {
+            method: 'POST',
+            url: `/api/organization-invitations/${organizationInvitationId}/response`,
+            payload: {
+              data: {
+                id: '100047_DZWMP7L5UM',
+                type: 'organization-invitation-responses',
+                attributes: {
+                  code,
+                  'user-id': userToInviteId,
+                },
               },
             },
-          },
-        };
+          };
 
-        // when
-        const response = await server.inject(options);
-
-        // then
-        expect(response.statusCode).to.equal(404);
-      });
-
-      it('should respond with a 409 if organization-invitation is already accepted', async function () {
-        // given
-        const user = databaseBuilder.factory.buildUser({ email: 'user@example.net' });
-        const organizationInvitation = databaseBuilder.factory.buildOrganizationInvitation({
-          status: OrganizationInvitation.StatusType.ACCEPTED,
-          code: 'DEFRTG123',
+          await databaseBuilder.commit();
         });
 
-        const options = {
-          method: 'POST',
-          url: `/api/organization-invitations/${organizationInvitation.id}/response`,
-          payload: {
-            data: {
-              id: '100047_DZWMP7L5UM',
-              type: 'organization-invitation-responses',
-              attributes: {
-                code: organizationInvitation.code,
-                email: user.email,
-              },
-            },
-          },
-        };
+        it('should return 204 HTTP status code', async function () {
+          // when
+          const response = await server.inject(options);
 
-        await databaseBuilder.commit();
-
-        // when
-        const response = await server.inject(options);
-
-        // then
-        expect(response.statusCode).to.equal(409);
-      });
-
-      it('should respond with a 401 if given email is not linked to an existing user', async function () {
-        // given
-        const organizationInvitation = databaseBuilder.factory.buildOrganizationInvitation({
-          status: OrganizationInvitation.StatusType.PENDING,
+          // then
+          expect(response.statusCode).to.equal(204);
         });
-        await databaseBuilder.commit();
-
-        const options = {
-          method: 'POST',
-          url: `/api/organization-invitations/${organizationInvitation.id}/response`,
-          payload: {
-            data: {
-              id: '100047_DZWMP7L5UM',
-              type: 'organization-invitation-responses',
-              attributes: {
-                code: organizationInvitation.code,
-                email: 'random@email.com',
-              },
-            },
-          },
-        };
-
-        // when
-        const response = await server.inject(options);
-
-        // then
-        expect(response.statusCode).to.equal(401);
-        expect(response.result.errors[0].code).to.equal('MISSING_OR_INVALID_CREDENTIALS');
       });
+      context('Error cases', function () {
+        it('should respond with a 404 if organization-invitation does not exist with id and code', async function () {
+          // given
+          const user = databaseBuilder.factory.buildUser();
+          const organizationInvitation = databaseBuilder.factory.buildOrganizationInvitation({});
+          await databaseBuilder.commit();
 
-      it('should respond with a 412 if membership already exist with userId and OrganizationId', async function () {
-        // given
-        const organization = databaseBuilder.factory.buildOrganization();
-        const { id: userId, email } = databaseBuilder.factory.buildUser();
-        databaseBuilder.factory.buildMembership({ userId, organizationId: organization.id });
-        const { id: organizationInvitationId, code } = databaseBuilder.factory.buildOrganizationInvitation({
-          organizationId: organization.id,
-          status: OrganizationInvitation.StatusType.PENDING,
-        });
-        await databaseBuilder.commit();
-
-        const options = {
-          method: 'POST',
-          url: `/api/organization-invitations/${organizationInvitationId}/response`,
-          payload: {
-            data: {
-              id: '100047_DZWMP7L5UM',
-              type: 'organization-invitation-responses',
-              attributes: {
-                code: code,
-                email: email,
+          const options = {
+            method: 'POST',
+            url: `/api/organization-invitations/${organizationInvitation.id}/response`,
+            payload: {
+              data: {
+                id: '100047_DZWMP7L5UM',
+                type: 'organization-invitation-responses',
+                attributes: {
+                  code: 'notExistCode',
+                  'user-id': user.id,
+                },
               },
             },
-          },
-        };
+          };
 
-        // when
-        const response = await server.inject(options);
+          // when
+          const response = await server.inject(options);
 
-        // then
-        expect(response.statusCode).to.equal(412);
+          // then
+          expect(response.statusCode).to.equal(404);
+        });
+
+        it('should respond with a 409 if organization-invitation is already accepted', async function () {
+          // given
+          const user = databaseBuilder.factory.buildUser();
+          const organizationInvitation = databaseBuilder.factory.buildOrganizationInvitation({
+            status: OrganizationInvitation.StatusType.ACCEPTED,
+            code: 'DEFRTG123',
+          });
+
+          const options = {
+            method: 'POST',
+            url: `/api/organization-invitations/${organizationInvitation.id}/response`,
+            payload: {
+              data: {
+                id: '100047_DZWMP7L5UM',
+                type: 'organization-invitation-responses',
+                attributes: {
+                  code: organizationInvitation.code,
+                  'user-id': user.id,
+                },
+              },
+            },
+          };
+
+          await databaseBuilder.commit();
+
+          // when
+          const response = await server.inject(options);
+
+          // then
+          expect(response.statusCode).to.equal(409);
+        });
+
+        it('should respond with a 401 if user does not exist', async function () {
+          // given
+          const organizationInvitation = databaseBuilder.factory.buildOrganizationInvitation({
+            status: OrganizationInvitation.StatusType.PENDING,
+          });
+          await databaseBuilder.commit();
+
+          const options = {
+            method: 'POST',
+            url: `/api/organization-invitations/${organizationInvitation.id}/response`,
+            payload: {
+              data: {
+                id: '100047_DZWMP7L5UM',
+                type: 'organization-invitation-responses',
+                attributes: {
+                  code: organizationInvitation.code,
+                  'user-id': '123',
+                },
+              },
+            },
+          };
+
+          // when
+          const response = await server.inject(options);
+
+          // then
+          expect(response.statusCode).to.equal(401);
+          expect(response.result.errors[0].code).to.equal('MISSING_OR_INVALID_CREDENTIALS');
+        });
+
+        it('should respond with a 412 if membership already exist with userId and OrganizationId', async function () {
+          // given
+          const organization = databaseBuilder.factory.buildOrganization();
+          const { id: userId } = databaseBuilder.factory.buildUser();
+          databaseBuilder.factory.buildMembership({ userId, organizationId: organization.id });
+          const { id: organizationInvitationId, code } = databaseBuilder.factory.buildOrganizationInvitation({
+            organizationId: organization.id,
+            status: OrganizationInvitation.StatusType.PENDING,
+          });
+          await databaseBuilder.commit();
+
+          const options = {
+            method: 'POST',
+            url: `/api/organization-invitations/${organizationInvitationId}/response`,
+            payload: {
+              data: {
+                id: '100047_DZWMP7L5UM',
+                type: 'organization-invitation-responses',
+                attributes: {
+                  code: code,
+                  'user-id': userId,
+                },
+              },
+            },
+          };
+
+          // when
+          const response = await server.inject(options);
+
+          // then
+          expect(response.statusCode).to.equal(412);
+        });
       });
     });
   });

--- a/api/tests/team/integration/application/organization-invitation/organization-invitation.admin.route.test.js
+++ b/api/tests/team/integration/application/organization-invitation/organization-invitation.admin.route.test.js
@@ -38,24 +38,48 @@ describe('Integration | Team | Application | Route | Admin | organization-invita
       await httpTestServer.register(teamRoutes[0]);
     });
 
-    it('should return 200 when payload is valid', async function () {
-      // given
-      const payload = {
-        data: {
-          id: '100047_DZWMP7L5UM',
-          type: 'organization-invitation-responses',
-          attributes: {
-            code: 'DZWMP7L5UM',
-            email: 'user@example.net',
+    describe('when user has an email in a valid payload', function () {
+      it('returns 204', async function () {
+        // given
+        const payload = {
+          data: {
+            id: '100047_DZWMP7L5UM',
+            type: 'organization-invitation-responses',
+            attributes: {
+              code: 'DZWMP7L5UM',
+              email: 'user@example.net',
+            },
           },
-        },
-      };
+        };
 
-      // when
-      const response = await httpTestServer.request(method, url, payload);
+        // when
+        const response = await httpTestServer.request(method, url, payload);
 
-      // then
-      expect(response.statusCode).to.equal(204);
+        // then
+        expect(response.statusCode).to.equal(204);
+      });
+    });
+
+    describe('when user has an id in a valid payload', function () {
+      it('returns 204', async function () {
+        // given
+        const payload = {
+          data: {
+            id: '100047_DZWMP7L5UM',
+            type: 'organization-invitation-responses',
+            attributes: {
+              code: 'DZWMP7L5UM',
+              'user-id': 123,
+            },
+          },
+        };
+
+        // when
+        const response = await httpTestServer.request(method, url, payload);
+
+        // then
+        expect(response.statusCode).to.equal(204);
+      });
     });
 
     it('should return 400 when payload is missing', async function () {
@@ -64,6 +88,30 @@ describe('Integration | Team | Application | Route | Admin | organization-invita
 
       // then
       expect(response.statusCode).to.equal(400);
+    });
+
+    it('returns 400 when payload violates xor constraint (user-id and email both provided)', async function () {
+      // given
+      const payload = {
+        data: {
+          id: '100047_DZWMP7L5UM',
+          type: 'organization-invitation-responses',
+          attributes: {
+            code: 'DZWMP7L5UM',
+            email: 'user@example.net',
+            'user-id': 123,
+          },
+        },
+      };
+
+      // when
+      const response = await httpTestServer.request(method, url, payload);
+
+      // then
+      expect(response.statusCode).to.equal(400);
+      expect(response.result.errors[0].detail).to.equal(
+        '"data.attributes" contains a conflict between exclusive peers [user-id, email]',
+      );
     });
   });
 

--- a/api/tests/team/integration/application/organization-invitation/organization-invitation.controller.test.js
+++ b/api/tests/team/integration/application/organization-invitation/organization-invitation.controller.test.js
@@ -38,63 +38,124 @@ describe('Integration | Team | Application | Controller | Organization invitatio
   });
 
   describe('#acceptOrganizationInvitation', function () {
-    const payload = {
-      data: {
-        id: '100047_DZWMP7L5UM',
-        type: 'organization-invitation-responses',
-        attributes: {
-          code: 'DZWMP7L5UM',
-          email: 'USER@example.net',
+    describe('when user has an email', function () {
+      const payload = {
+        data: {
+          id: '100047_DZWMP7L5UM',
+          type: 'organization-invitation-responses',
+          attributes: {
+            code: 'DZWMP7L5UM',
+            email: 'USER@example.net',
+          },
         },
-      },
-    };
+      };
+      context('Success cases', function () {
+        it('should return an HTTP response with status code 204', async function () {
+          // given
+          usecases.acceptOrganizationInvitation.resolves();
+          usecases.createCertificationCenterMembershipForScoOrganizationAdminMember.resolves();
 
-    context('Success cases', function () {
-      it('should return an HTTP response with status code 204', async function () {
-        // given
-        usecases.acceptOrganizationInvitation.resolves();
-        usecases.createCertificationCenterMembershipForScoOrganizationAdminMember.resolves();
+          // when
+          const response = await httpTestServer.request('POST', '/api/organization-invitations/1/response', payload);
 
-        // when
-        const response = await httpTestServer.request('POST', '/api/organization-invitations/1/response', payload);
+          // then
+          expect(response.statusCode).to.equal(204);
+        });
+      });
 
-        // then
-        expect(response.statusCode).to.equal(204);
+      context('Error cases', function () {
+        it('responses an HTTP response with status code 412 when AlreadyExistingInvitationError', async function () {
+          // given
+          usecases.acceptOrganizationInvitation.rejects(new AlreadyExistingInvitationError());
+
+          // when
+          const response = await httpTestServer.request('POST', '/api/organization-invitations/1/response', payload);
+
+          // then
+          expect(response.statusCode).to.equal(412);
+        });
+
+        it('responses an HTTP response with status code 404 when NotFoundError', async function () {
+          // given
+          usecases.acceptOrganizationInvitation.rejects(new NotFoundError());
+
+          // when
+          const response = await httpTestServer.request('POST', '/api/organization-invitations/1/response', payload);
+
+          // then
+          expect(response.statusCode).to.equal(404);
+        });
+
+        it('responses an HTTP response with status code 404 when UserNotFoundError', async function () {
+          // given
+          usecases.acceptOrganizationInvitation.rejects(new UserNotFoundError());
+
+          // when
+          const response = await httpTestServer.request('POST', '/api/organization-invitations/1/response', payload);
+
+          // then
+          expect(response.statusCode).to.equal(404);
+        });
       });
     });
+    describe('when user has an id', function () {
+      const payload = {
+        data: {
+          id: '100047_DZWMP7L5UM',
+          type: 'organization-invitation-responses',
+          attributes: {
+            code: 'DZWMP7L5UM',
+            'user-id': '123',
+          },
+        },
+      };
+      context('Success cases', function () {
+        it('should return an HTTP response with status code 204', async function () {
+          // given
+          usecases.acceptOrganizationInvitation.resolves();
+          usecases.createCertificationCenterMembershipForScoOrganizationAdminMember.resolves();
 
-    context('Error cases', function () {
-      it('should respond an HTTP response with status code 412 when AlreadyExistingInvitationError', async function () {
-        // given
-        usecases.acceptOrganizationInvitation.rejects(new AlreadyExistingInvitationError());
+          // when
+          const response = await httpTestServer.request('POST', '/api/organization-invitations/1/response', payload);
 
-        // when
-        const response = await httpTestServer.request('POST', '/api/organization-invitations/1/response', payload);
-
-        // then
-        expect(response.statusCode).to.equal(412);
+          // then
+          expect(response.statusCode).to.equal(204);
+        });
       });
 
-      it('should respond an HTTP response with status code 404 when NotFoundError', async function () {
-        // given
-        usecases.acceptOrganizationInvitation.rejects(new NotFoundError());
+      context('Error cases', function () {
+        it('responses an HTTP response with status code 412 when AlreadyExistingInvitationError', async function () {
+          // given
+          usecases.acceptOrganizationInvitation.rejects(new AlreadyExistingInvitationError());
 
-        // when
-        const response = await httpTestServer.request('POST', '/api/organization-invitations/1/response', payload);
+          // when
+          const response = await httpTestServer.request('POST', '/api/organization-invitations/1/response', payload);
 
-        // then
-        expect(response.statusCode).to.equal(404);
-      });
+          // then
+          expect(response.statusCode).to.equal(412);
+        });
 
-      it('should respond an HTTP response with status code 404 when UserNotFoundError', async function () {
-        // given
-        usecases.acceptOrganizationInvitation.rejects(new UserNotFoundError());
+        it('responses an HTTP response with status code 404 when NotFoundError', async function () {
+          // given
+          usecases.acceptOrganizationInvitation.rejects(new NotFoundError());
 
-        // when
-        const response = await httpTestServer.request('POST', '/api/organization-invitations/1/response', payload);
+          // when
+          const response = await httpTestServer.request('POST', '/api/organization-invitations/1/response', payload);
 
-        // then
-        expect(response.statusCode).to.equal(404);
+          // then
+          expect(response.statusCode).to.equal(404);
+        });
+
+        it('responses an HTTP response with status code 404 when UserNotFoundError', async function () {
+          // given
+          usecases.acceptOrganizationInvitation.rejects(new UserNotFoundError());
+
+          // when
+          const response = await httpTestServer.request('POST', '/api/organization-invitations/1/response', payload);
+
+          // then
+          expect(response.statusCode).to.equal(404);
+        });
       });
     });
   });

--- a/api/tests/team/unit/application/organization-invitation/organization-invitation.controller.test.js
+++ b/api/tests/team/unit/application/organization-invitation/organization-invitation.controller.test.js
@@ -7,35 +7,74 @@ import { catchErr, domainBuilder, expect, hFake, sinon } from '../../../../../te
 
 describe('Unit | Team | Application | Controller | organization-invitation', function () {
   describe('#acceptOrganizationInvitation', function () {
-    it('calls acceptOrganizationInvitation usecase to accept invitation with organizationInvitationId and code', async function () {
-      // given
-      const code = 'ABCDEFGH01';
-      const email = 'random@email.com';
-      const locale = 'fr-FR';
-      const organizationInvitation = domainBuilder.buildOrganizationInvitation({ code, email });
-      const request = {
-        params: { id: organizationInvitation.id },
-        payload: {
-          data: {
-            type: 'organization-invitations',
-            attributes: { code, email: email.toUpperCase() },
+    describe('When the provider parameter is an email', function () {
+      it('calls acceptOrganizationInvitation usecase to accept invitation with organizationInvitationId and code', async function () {
+        // given
+        const code = 'ABCDEFGH01';
+        const email = 'random@email.com';
+        const locale = 'fr-FR';
+        const organizationInvitation = domainBuilder.buildOrganizationInvitation({ code, email });
+        const request = {
+          params: { id: organizationInvitation.id },
+          payload: {
+            data: {
+              type: 'organization-invitation-responses',
+              attributes: { code, email },
+            },
           },
-        },
-        state: { locale },
-      };
+          state: { locale },
+        };
 
-      sinon.stub(usecases, 'acceptOrganizationInvitation').resolves();
-      sinon.stub(usecases, 'createCertificationCenterMembershipForScoOrganizationAdminMember').resolves();
+        sinon.stub(usecases, 'acceptOrganizationInvitation').resolves();
+        sinon.stub(usecases, 'createCertificationCenterMembershipForScoOrganizationAdminMember').resolves();
 
-      // when
-      await organizationInvitationController.acceptOrganizationInvitation(request);
+        // when
+        await organizationInvitationController.acceptOrganizationInvitation(request);
 
-      // then
-      expect(usecases.acceptOrganizationInvitation).to.have.been.calledWithExactly({
-        organizationInvitationId: organizationInvitation.id,
-        code,
-        email,
-        locale,
+        // then
+        expect(usecases.acceptOrganizationInvitation).to.have.been.calledWithExactly({
+          organizationInvitationId: organizationInvitation.id,
+          code,
+          email,
+          locale,
+          userId: undefined,
+        });
+      });
+    });
+
+    describe('When the provider parameter is a user id', function () {
+      it('calls acceptOrganizationInvitation usecase to accept invitation with organizationInvitationId and code', async function () {
+        // given
+        const code = 'ABCDEFGH01';
+        const userId = 1;
+        const locale = 'fr-FR';
+        const email = 'random@email.com';
+        const organizationInvitation = domainBuilder.buildOrganizationInvitation({ code, email });
+        const request = {
+          params: { id: organizationInvitation.id },
+          payload: {
+            data: {
+              type: 'organization-invitation-responses',
+              attributes: { code, 'user-id': userId },
+            },
+          },
+          state: { locale },
+        };
+
+        sinon.stub(usecases, 'acceptOrganizationInvitation').resolves();
+        sinon.stub(usecases, 'createCertificationCenterMembershipForScoOrganizationAdminMember').resolves();
+
+        // when
+        await organizationInvitationController.acceptOrganizationInvitation(request);
+
+        // then
+        expect(usecases.acceptOrganizationInvitation).to.have.been.calledWithExactly({
+          organizationInvitationId: organizationInvitation.id,
+          code,
+          userId,
+          locale,
+          email: undefined,
+        });
       });
     });
 
@@ -49,7 +88,7 @@ describe('Unit | Team | Application | Controller | organization-invitation', fun
         params: { id: organizationInvitation.id },
         payload: {
           data: {
-            type: 'organization-invitations',
+            type: 'organization-invitation-responses',
             attributes: { code, email },
           },
         },

--- a/api/tests/team/unit/domain/usecases/accept-organization-invitation.usecase.test.js
+++ b/api/tests/team/unit/domain/usecases/accept-organization-invitation.usecase.test.js
@@ -42,7 +42,7 @@ describe('Unit | Domain | UseCases | accept-organization-invitation', function (
         status: organizationInvitation.status,
       });
       organizationInvitedUserRepository.get
-        .withArgs({ organizationInvitationId: organizationInvitation.id, email })
+        .withArgs({ organizationInvitationId: organizationInvitation.id, email, userId: undefined })
         .resolves(organizationInvitedUser);
 
       // when
@@ -164,7 +164,9 @@ function createContext({ organizationInvitedUserRepository, userRepository, user
     userId: user.id,
     invitation: { code, id: organizationInvitationId },
   });
-  organizationInvitedUserRepository.get.withArgs({ organizationInvitationId, email }).resolves(organizationInvitedUser);
+  organizationInvitedUserRepository.get
+    .withArgs({ organizationInvitationId, email, userId: undefined })
+    .resolves(organizationInvitedUser);
 
   sinon.stub(organizationInvitedUser, 'acceptInvitation').resolves();
 

--- a/orga/app/components/authentication/oidc-signup-form.gjs
+++ b/orga/app/components/authentication/oidc-signup-form.gjs
@@ -7,15 +7,25 @@ import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import t from 'ember-intl/helpers/t';
+import get from 'lodash/get';
+
+const ERROR_INPUT_MESSAGE_MAP = {
+  termsOfServiceNotSelected: 'pages.oidc-signup-or-login.error.error-message',
+};
 
 export default class OidcSignupForm extends Component {
   @service oidcIdentityProviders;
   @service intl;
   @service url;
+  @service locale;
+  @service authErrorMessages;
+  @service store;
+  @service session;
 
   @tracked isTermsOfServiceValidated = false;
   @tracked signupErrorMessage = null;
   @tracked isLoading = false;
+  @tracked globalError = null;
 
   get userClaimsToDisplay() {
     const { userClaims } = this.args;
@@ -51,8 +61,43 @@ export default class OidcSignupForm extends Component {
   }
 
   @action
-  signup() {
-    //TODO signup user
+  async signup() {
+    if (!this.isTermsOfServiceValidated) {
+      this.signupErrorMessage = this.intl.t(ERROR_INPUT_MESSAGE_MAP['termsOfServiceNotSelected']);
+      return;
+    }
+
+    this.isLoading = true;
+    this.signupErrorMessage = null;
+    try {
+      this.session.set('skipAuthentication', true);
+      await this.session.authenticate('authenticator:oidc', {
+        authenticationKey: this.args.authenticationKey,
+        identityProviderSlug: this.args.identityProviderSlug,
+        hostSlug: 'users',
+      });
+      const createdUserId = this.session.data.authenticated.user_id;
+      await this._acceptOrganizationInvitation(this.args.invitationId, this.args.invitationCode, createdUserId);
+
+      this.session.set('skipAuthentication', false);
+      await this.session.handleAuthentication();
+    } catch (responseError) {
+      const error = get(responseError, 'errors[0]');
+      this.signupErrorMessage = this.authErrorMessages.getAuthenticationErrorMessage(error);
+    } finally {
+      this.isLoading = false;
+      this.session.set('skipAuthentication', false);
+    }
+  }
+
+  _acceptOrganizationInvitation(organizationInvitationId, organizationInvitationCode, createdUserId) {
+    return this.store
+      .createRecord('organization-invitation-response', {
+        id: organizationInvitationId + '_' + organizationInvitationCode,
+        code: organizationInvitationCode,
+        userId: createdUserId,
+      })
+      .save({ adapterOptions: { organizationInvitationId } });
   }
 
   <template>

--- a/orga/app/components/authentication/oidc-signup-form.gjs
+++ b/orga/app/components/authentication/oidc-signup-form.gjs
@@ -9,15 +9,10 @@ import { tracked } from '@glimmer/tracking';
 import t from 'ember-intl/helpers/t';
 import get from 'lodash/get';
 
-const ERROR_INPUT_MESSAGE_MAP = {
-  termsOfServiceNotSelected: 'pages.oidc-signup-or-login.error.error-message',
-};
-
 export default class OidcSignupForm extends Component {
   @service oidcIdentityProviders;
   @service intl;
   @service url;
-  @service locale;
   @service authErrorMessages;
   @service store;
   @service session;
@@ -25,7 +20,6 @@ export default class OidcSignupForm extends Component {
   @tracked isTermsOfServiceValidated = false;
   @tracked signupErrorMessage = null;
   @tracked isLoading = false;
-  @tracked globalError = null;
 
   get userClaimsToDisplay() {
     const { userClaims } = this.args;
@@ -63,7 +57,7 @@ export default class OidcSignupForm extends Component {
   @action
   async signup() {
     if (!this.isTermsOfServiceValidated) {
-      this.signupErrorMessage = this.intl.t(ERROR_INPUT_MESSAGE_MAP['termsOfServiceNotSelected']);
+      this.signupErrorMessage = this.intl.t('pages.oidc.signup.error.cgu');
       return;
     }
 

--- a/orga/app/controllers/authentication/oidc/signup.js
+++ b/orga/app/controllers/authentication/oidc/signup.js
@@ -12,4 +12,16 @@ export default class OidcSignupController extends Controller {
   get userClaims() {
     return oidcUserAuthenticationStorage.get()?.userClaims;
   }
+
+  get authenticationKey() {
+    return oidcUserAuthenticationStorage.get()?.authenticationKey;
+  }
+
+  get invitationId() {
+    return invitationStorage.get()?.invitationId;
+  }
+
+  get invitationCode() {
+    return invitationStorage.get()?.code;
+  }
 }

--- a/orga/app/models/organization-invitation-response.js
+++ b/orga/app/models/organization-invitation-response.js
@@ -3,4 +3,5 @@ import Model, { attr } from '@ember-data/model';
 export default class OrganizationInvitationResponse extends Model {
   @attr('string') code;
   @attr('string') email;
+  @attr('number') userId;
 }

--- a/orga/app/services/session.js
+++ b/orga/app/services/session.js
@@ -9,6 +9,9 @@ export default class CurrentSessionService extends SessionService {
   routeAfterAuthentication = 'authenticated';
 
   async handleAuthentication() {
+    if (this.skipAuthentication) {
+      return;
+    }
     await this.currentUser.load();
 
     super.handleAuthentication(this.routeAfterAuthentication);

--- a/orga/app/templates/authentication/oidc/signup.gjs
+++ b/orga/app/templates/authentication/oidc/signup.gjs
@@ -25,8 +25,10 @@ import AuthenticationLayout from 'pix-orga/components/authentication-layout/inde
         <OidcSignupForm
           @userClaims={{@controller.userClaims}}
           @identityProviderSlug={{@model.identity_provider_slug}}
+          @authenticationKey={{@controller.authenticationKey}}
+          @invitationId={{@controller.invitationId}}
+          @invitationCode={{@controller.invitationCode}}
         />
-
         <PixButtonLink @variant="secondary" @route="authentication.oidc.login" @model={{@model.identity_provider_slug}}>
           {{t "pages.oidc.signup.login-button"}}
         </PixButtonLink>

--- a/orga/app/templates/authentication/oidc/signup.gjs
+++ b/orga/app/templates/authentication/oidc/signup.gjs
@@ -34,7 +34,7 @@ import AuthenticationLayout from 'pix-orga/components/authentication-layout/inde
         </PixButtonLink>
       {{else}}
         <PixNotificationAlert @type="error" class="oidc-signup-form__error">
-          {{t "pages.oidc.signup.error"}}
+          {{t "pages.oidc.signup.error.claims"}}
         </PixNotificationAlert>
       {{/if}}
     </:content>

--- a/orga/mirage/config.js
+++ b/orga/mirage/config.js
@@ -754,12 +754,19 @@ function routes() {
   this.post('/oidc/users', (schema, request) => {
     const payload = JSON.parse(request.requestBody);
     const identityProvider = payload.data.attributes.identity_provider;
-    const profile = schema.profiles.create({ pixScore: 1 });
     const createdUser = schema.users.create({
       firstName: 'Lloyd',
       lastName: 'Cé',
       lang: 'fr',
-      profile,
+    });
+    schema.prescribers.create({
+      id: createdUser.id,
+      lang: createdUser.lang,
+      firstName: createdUser.firstName,
+      lastName: createdUser.lastName,
+      features: {
+        PLACES_MANAGEMENT: { active: false },
+      },
     });
 
     return {

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -1419,7 +1419,10 @@
           "title": "Title"
         },
         "description": "An account will be created based on the information sent by the organisation",
-        "error": "We were unable to retrieve your identity information from the service used. We invite you to contact this organisation's IT support.",
+        "error": {
+          "cgu": "You must accept to the Pix terms of use and personal data protection policy to create an account.",
+          "claims": "We were unable to retrieve your identity information from the service used. We invite you to contact this organisation's IT support."
+        },
         "login-button": "I already have an account, I'm logging in",
         "signup-button": "Create my account",
         "sub-title": "to access your Pix Orga workspace",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -1407,7 +1407,10 @@
           "title": "Fonction"
         },
         "description": "Un compte va être créé à partir des éléments transmis par l'organisme",
-        "error": "Nous n’avons pas pu récupérer vos informations d’identité auprès du service utilisé. Nous vous invitons à contacter le support informatique de cette organisation.",
+        "error": {
+          "cgu": "Vous devez accepter les conditions d’utilisation de Pix et la politique de confidentialité pour créer un compte.",
+          "claims": "Nous n’avons pas pu récupérer vos informations d’identité auprès du service utilisé. Nous vous invitons à contacter le support informatique de cette organisation."
+        },
         "login-button": "J'ai déjà un compte, je me connecte",
         "signup-button": "Je m'inscris sur Pix",
         "sub-title": "pour accéder à votre espace Pix Orga",

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -1401,7 +1401,10 @@
           "title": "rol"
         },
         "description": "Er wordt een account aangemaakt met de informatie die door de organisatie is verstrekt",
-        "error": "We konden uw identiteitsgegevens niet ophalen bij de gebruikte dienst. Neem contact op met de IT-ondersteuning van deze organisatie.",
+        "error": {
+          "cgu": "Je moet de gebruiksvoorwaarden en het privacybeleid van Pix accepteren om een account aan te maken.",
+          "claims": "We konden uw identiteitsgegevens niet ophalen bij de gebruikte dienst. Neem contact op met de IT-ondersteuning van deze organisatie."
+        },
         "login-button": "Ik heb al een account, ik log in",
         "signup-button": "Ik maak mijn account aan",
         "sub-title": "om toegang te krijgen tot uw Pix Orga-werkruimte",


### PR DESCRIPTION
## ❄️ Problème

Suite au ticket https://1024pix.atlassian.net/browse/PIX-20540 , il faut créer le compte et connecter l’utilisateur à l’organisation, quand l’utilisateur clique sur “Je m’inscris sur Pix” .

- l’utilisateur est créé (voir code d’association sur Pix App)

- l’authentication method est créée (voir code d’association sur Pix App)

- l’invitation est marquée comme utilisée (voir code actuel du signup login/mdp sur orga)

- le membership est créé (voir code actuel du signup login/mdp sur orga)

- L'utilisateur est connecté à Pix Orga et a accédé à l’organisation  (voir code actuel du signup login/mdp sur orga)

## 🛷 Proposition

En front : 
- ajouter dans le formulaire oidc de signUp les propriétés nécessaires à la création de compte sur Pix Orga via un SSO (clé d'authentification, id et code de l'invitation
- après la création du user, éviter la redirection trop rapide (avant la création du membership) vers /authenticated

En back :
Adapter la route /api/organization-invitations/{id}/response pour qu'elle accepte une payload sans email mais avec userId.

## ☃️ Remarques

- Les cas d'erreurs de création de compte/membership ne sont peut-être pas bien couverts par les tests, je suis preneuse de vos retours sur le sujet
- Il faudra probalement faire un ticket dédié au remaniement des tests existants pour qu'ils soient conformes à nos bonnes pratiques 


## 🧑‍🎄 Pour tester

### A tester en local

* Lancer Pix Orga et se connecter avec [orgacces@example.net](mailto:orgacces@example.net)
* Inviter un compte n'ayant pas de compte Pix à rejoindre l'organisation (possible de mettre une adresse mail random et d'utiliser [mailpit](http://localhost:8025/) pour intercepter le mail d'invitation)
* Suivre le lien d'invitation
* Cliquer sur "Choisir une autre méthode de connexion"
* Choisir ProConnect dans la liste déroulante puis cliquer sur Je me connecte
* Sur ProConnect, utiliser l'adresse de test
* Une fois revenu sur Pix Orga, cliquer sur "Je n'ai pas de compte, je m'inscris avec mon organisation"
* Vérifier que les claims de l'utilisateur (prenom John, nom Doe) s'affichent
* cocher la case des CGU et cliquer sur "Je m'inscris sur Pix"
* Vérifier que la page d'acceptation des CGU de Pix Orga s'affiche
* Cliquer sur "J’accepte les conditions d’utilisation"
* Vérifier que l'on arriver bien sur la page de l'utilisateur connecté membre de l'organisation à laquelle il a été invité
* vérifier les ajouts ou mises à jour dans les tables : users, memberships, authentication-methods, organization-invitations
