### PR TITLE
[TECH] Utiliser les shortIds dans les seeds de parcours combinés (pix-20969)

### DIFF
--- a/api/db/seeds/data/team-prescription/build-combined-courses.js
+++ b/api/db/seeds/data/team-prescription/build-combined-courses.js
@@ -182,12 +182,12 @@ export const buildCombinedCourseBlueprints = (databaseBuilder) => {
   const targetProfileId = databaseBuilder.factory.buildTargetProfile({
     name: 'Mon profil cible de parcours combiné',
   }).id;
-  const moduleId = 'eeeb4951-6f38-4467-a4ba-0c85ed71321a';
+  const moduleShortId = '27d6ca4f';
 
   buildCombinedCourseBlueprint({
     name: 'Mon parcours combiné 2',
     internalName: 'Mon schéma de parcours combiné 2',
-    content: CombinedCourseBlueprint.buildContentItems([{ targetProfileId }, { moduleId }]),
+    content: CombinedCourseBlueprint.buildContentItems([{ targetProfileId }, { moduleShortId }]),
   });
 };
 

--- a/api/src/quest/domain/models/CombinedCourseBlueprint.js
+++ b/api/src/quest/domain/models/CombinedCourseBlueprint.js
@@ -86,11 +86,12 @@ export class CombinedCourseBlueprint {
     }
   }
   static buildContentItems(items) {
-    return items.map(({ moduleShortId, targetProfileId }) => {
+    const data = items.map(({ moduleShortId, targetProfileId }) => {
       return moduleShortId
         ? { type: COMBINED_COURSE_BLUEPRINT_ITEMS.MODULE, value: moduleShortId }
         : { type: COMBINED_COURSE_BLUEPRINT_ITEMS.EVALUATION, value: targetProfileId };
     });
+    return Joi.attempt(data, contentSchema);
   }
 }
 
@@ -105,18 +106,20 @@ export const contentSchema = Joi.array()
       type: Joi.string()
         .valid(COMBINED_COURSE_BLUEPRINT_ITEMS.EVALUATION, COMBINED_COURSE_BLUEPRINT_ITEMS.MODULE)
         .required(),
-      value: Joi.alternatives().conditional('type', {
-        switch: [
-          {
-            is: COMBINED_COURSE_BLUEPRINT_ITEMS.EVALUATION,
-            then: Joi.number().integer().required(),
-          },
-          {
-            is: COMBINED_COURSE_BLUEPRINT_ITEMS.MODULE,
-            then: Joi.string().required(),
-          },
-        ],
-      }),
+      value: Joi.alternatives()
+        .conditional('type', {
+          switch: [
+            {
+              is: COMBINED_COURSE_BLUEPRINT_ITEMS.EVALUATION,
+              then: Joi.number().integer(),
+            },
+            {
+              is: COMBINED_COURSE_BLUEPRINT_ITEMS.MODULE,
+              then: Joi.string(),
+            },
+          ],
+        })
+        .required(),
     }),
   )
   .required()

--- a/api/tests/quest/integration/domain/usecases/find-combined-course-blueprints_test.js
+++ b/api/tests/quest/integration/domain/usecases/find-combined-course-blueprints_test.js
@@ -5,7 +5,7 @@ import { databaseBuilder, expect } from '../../../../test-helper.js';
 describe('Integration | Quest | Domain | UseCases | find-combined-course-blueprints', function () {
   it('should return combined course blueprints array if at least a result is found', async function () {
     databaseBuilder.factory.buildCombinedCourseBlueprint({
-      content: CombinedCourseBlueprint.buildContentItems([{ moduleId: 'abc-123' }]),
+      content: CombinedCourseBlueprint.buildContentItems([{ moduleShortId: 'abc-123' }]),
     });
     await databaseBuilder.commit();
     const results = await usecases.findCombinedCourseBlueprints();

--- a/api/tests/tooling/domain-builder/factory/prescription/combined-course-blueprint/combined-course-blueprint.js
+++ b/api/tests/tooling/domain-builder/factory/prescription/combined-course-blueprint/combined-course-blueprint.js
@@ -8,7 +8,7 @@ export const buildCombinedCourseBlueprint = function ({
   illustration = 'images/illustration.svg',
   createdAt = new Date(),
   updatedAt,
-  content = [CombinedCourseBlueprint.buildContentItems([{ moduleId: 'module-id' }, { targetProfileId: 123 }])],
+  content = [CombinedCourseBlueprint.buildContentItems([{ moduleShortId: 'module-id' }, { targetProfileId: 123 }])],
 } = {}) {
   return new CombinedCourseBlueprint({
     id,


### PR DESCRIPTION
## ❄️ Problème

Suite à l'utilisation des moduleShortId, on a omis de faire la modif dans les seed / builder.

## 🛷 Proposition

On corrige l'utilisation du moduleId en moduleShortId

## ☃️ Remarques

On profite de la PR pour rajouter la validation du schéma et lancer une erreur si il y a un probleme.
Pour info, l'utilisation du .required manquait ou plutôt n'était pas au bon endroit.

## 🧑‍🎄 Pour tester

RAS
