### PR TITLE
[FEATURE] Accéder rapidement au profil cible ou module depuis les tags du schéma d'un parcours combiné (PIX-20868).

### DIFF
--- a/admin/app/components/common/combined-courses/requirement-tag.gjs
+++ b/admin/app/components/common/combined-courses/requirement-tag.gjs
@@ -1,7 +1,9 @@
 import PixTag from '@1024pix/pix-ui/components/pix-tag';
 import { action } from '@ember/object';
+import { LinkTo } from '@ember/routing';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
+import { eq } from 'ember-truth-helpers';
 
 const getItemColor = (type) => (type === 'evaluation' ? 'purple' : 'blue');
 const getItemType = (type) =>
@@ -21,9 +23,23 @@ export default class RequirementTag extends Component {
 
   <template>
     <PixTag @color={{getItemColor @type}} @displayRemoveButton={{this.displayRemoveButton}} @onRemove={{this.onRemove}}>
-      {{t (getItemType @type)}}
-      -
-      {{@value}}
+      {{#if (eq @type "evaluation")}}
+        <LinkTo
+          @route="authenticated.target-profiles.target-profile.details"
+          @model={{@value}}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {{t (getItemType @type)}}
+          -
+          {{@value}}</LinkTo>
+      {{else}}
+        <a target="_blank" rel="noopener noreferrer" href="https://app.recette.pix.fr/modules/{{@value}}/slug/details">
+          {{t (getItemType @type)}}
+          -
+          {{@value}}
+        </a>
+      {{/if}}
     </PixTag>
   </template>
 }

--- a/admin/tests/integration/components/common/combined-courses/requirement-tag-test.gjs
+++ b/admin/tests/integration/components/common/combined-courses/requirement-tag-test.gjs
@@ -18,6 +18,8 @@ module('Integration | Component |  common/combined-courses/requirement-tag', fun
       <template><RequirementTag @type={{item.type}} @value={{item.value}} /></template>,
     );
     assert.ok(screen.getByText(t('components.combined-course-blueprints.items.module'), { exact: false }));
+    const link = screen.getByRole('link');
+    assert.ok(link.getAttribute('href').endsWith('modules/abc-123/slug/details'));
   });
   test('should display a target profile item when type is evaluation', async function (assert) {
     const item = {
@@ -27,7 +29,9 @@ module('Integration | Component |  common/combined-courses/requirement-tag', fun
     const screen = await renderScreen(
       <template><RequirementTag @type={{item.type}} @value={{item.value}} /></template>,
     );
+    const link = screen.getByRole('link');
     assert.ok(screen.getByText(t('components.combined-course-blueprints.items.targetProfile'), { exact: false }));
+    assert.ok(link.getAttribute('href').endsWith(`/target-profiles/${item.value}/details`));
   });
 
   test('should call onRemove with value and type when remove button is clicked', async function (assert) {


### PR DESCRIPTION
## ❄️ Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

C’est compliqué de savoir à quoi correspondent les éléments de contenu d’un schéma de parcours combiné.

## 🛷 Proposition

Permettre à l’utilisateur de cliquer sur les tag et afficher leur contenu dans une nouvelle fenêtre : - pour les PC on fait le lien vers pixAdmin - pour les modules on fait le lien vers la recette (app.recette.pix.fr/modules/shortId/slug/details)

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## ☃️ Remarques

RAS

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🧑‍🎄 Pour tester

Se rendre sur Pix Admin.
Dans la page listant les schémas de parcours, cliquer sur les tags `Profile cible` et/ou `Module` et vérifier qu'un nouvel onglet est ouvert sur le profil cible choisi ou sur le module (en recette) choisi.

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
