### PR TITLE
[TECH] Afficher les logs des appels mirage durant les tests dans la console sur PixAdmin

### DIFF
--- a/admin/tests/test-support/setup-mirage.js
+++ b/admin/tests/test-support/setup-mirage.js
@@ -9,6 +9,7 @@ import makeServer from '../mirage/config';
 export function setupMirage(hooks) {
   hooks.beforeEach(function () {
     this.server = makeServer({ environment: 'test' });
+    this.server.logging = true;
   });
 
   hooks.afterEach(async function () {


### PR DESCRIPTION
## ❄️ Problème

Depuis cette [PR](https://github.com/1024pix/pix/pull/14091), nous sommes passés sur mirage et ne sommes plus sur ember-mirage-js. Sur l'interface des tests, avec ember-mirage y avait possibilité de cocher une case pour avoir les logs des appels réseaux interceptés et simulés par mirage dans la console du développeur.
Depuis, cette coche a disparu 😢 

## 🛷 Proposition

Remettre les logs de l'activité réseau, affichage toujours actif.

## ☃️ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🧑‍🎄 Pour tester
Lancer les tests sur le navigateur puis voir les appels réseaux affichés dans la console
