### PR TITLE
[BUMP] MàJ de @1024pix/epreuves-components en 2.4.7

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -79,7 +79,7 @@
         "yargs": "^18.0.0"
       },
       "devDependencies": {
-        "@1024pix/epreuves-components": "^2.4.6",
+        "@1024pix/epreuves-components": "^2.4.7",
         "@1024pix/eslint-plugin": "^2.1.15",
         "@babel/eslint-parser": "^7.18.2",
         "@babel/plugin-syntax-import-attributes": "^7.24.1",
@@ -120,9 +120,9 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "2.4.6",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-2.4.6.tgz",
-      "integrity": "sha512-DoTqOKeIjZ5qp+F2RbQ6+DplFzYHxRsgM8uWhPGQVEDtwfhYLbqfosbaQgzQfh7LfsRhIVxFMo07Y/rarcobYA==",
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-2.4.7.tgz",
+      "integrity": "sha512-hX3bH7WGTtjqlETfzovH1aDnuCnk454s6AUgyhbTqFvEGpXp0CstwpOpDwL4G1ax3yxBf/ZFieW1wFWx/9sXCg==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {

--- a/api/package.json
+++ b/api/package.json
@@ -85,7 +85,7 @@
     "yargs": "^18.0.0"
   },
   "devDependencies": {
-    "@1024pix/epreuves-components": "^2.4.6",
+    "@1024pix/epreuves-components": "^2.4.7",
     "@1024pix/eslint-plugin": "^2.1.15",
     "@babel/eslint-parser": "^7.18.2",
     "@babel/plugin-syntax-import-attributes": "^7.24.1",

--- a/junior/package-lock.json
+++ b/junior/package-lock.json
@@ -11,7 +11,7 @@
       "license": "AGPL-3.0",
       "devDependencies": {
         "@1024pix/ember-testing-library": "^3.0.25",
-        "@1024pix/epreuves-components": "^2.4.6",
+        "@1024pix/epreuves-components": "^2.4.7",
         "@1024pix/eslint-plugin": "^2.1.15",
         "@1024pix/pix-ui": "^55.33.1",
         "@1024pix/stylelint-config": "^5.1.37",
@@ -179,9 +179,9 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "2.4.6",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-2.4.6.tgz",
-      "integrity": "sha512-DoTqOKeIjZ5qp+F2RbQ6+DplFzYHxRsgM8uWhPGQVEDtwfhYLbqfosbaQgzQfh7LfsRhIVxFMo07Y/rarcobYA==",
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-2.4.7.tgz",
+      "integrity": "sha512-hX3bH7WGTtjqlETfzovH1aDnuCnk454s6AUgyhbTqFvEGpXp0CstwpOpDwL4G1ax3yxBf/ZFieW1wFWx/9sXCg==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {

--- a/junior/package.json
+++ b/junior/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^3.0.25",
-    "@1024pix/epreuves-components": "^2.4.6",
+    "@1024pix/epreuves-components": "^2.4.7",
     "@1024pix/eslint-plugin": "^2.1.15",
     "@1024pix/pix-ui": "^55.33.1",
     "@1024pix/stylelint-config": "^5.1.37",

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -12,7 +12,7 @@
       "devDependencies": {
         "@1024pix/ember-api-actions": "^1.1.0",
         "@1024pix/ember-testing-library": "^3.0.25",
-        "@1024pix/epreuves-components": "^2.4.6",
+        "@1024pix/epreuves-components": "^2.4.7",
         "@1024pix/eslint-plugin": "^2.1.15",
         "@1024pix/pix-ui": "^55.33.1",
         "@1024pix/stylelint-config": "^5.1.37",
@@ -818,9 +818,9 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "2.4.6",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-2.4.6.tgz",
-      "integrity": "sha512-DoTqOKeIjZ5qp+F2RbQ6+DplFzYHxRsgM8uWhPGQVEDtwfhYLbqfosbaQgzQfh7LfsRhIVxFMo07Y/rarcobYA==",
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-2.4.7.tgz",
+      "integrity": "sha512-hX3bH7WGTtjqlETfzovH1aDnuCnk454s6AUgyhbTqFvEGpXp0CstwpOpDwL4G1ax3yxBf/ZFieW1wFWx/9sXCg==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@1024pix/ember-api-actions": "^1.1.0",
     "@1024pix/ember-testing-library": "^3.0.25",
-    "@1024pix/epreuves-components": "^2.4.6",
+    "@1024pix/epreuves-components": "^2.4.7",
     "@1024pix/eslint-plugin": "^2.1.15",
     "@1024pix/pix-ui": "^55.33.1",
     "@1024pix/stylelint-config": "^5.1.37",


### PR DESCRIPTION
## ❄️ Problème

Il y a une nouvelle version de `@1024pix/epreuves-components`.

## 🛷 Proposition

Mettre à jour la dépendance.

## ☃️ Remarques

N/A

## 🧑‍🎄 Pour tester

Les tests de l’API doivent être OK.