### PR TITLE
[TECH] Améliorer les performances des apis de recommandation de modules (PIX-20875)

### DIFF
--- a/api/scripts/modulix/update-modulix-trainings-link.js
+++ b/api/scripts/modulix/update-modulix-trainings-link.js
@@ -31,7 +31,7 @@ export class UpdateModulixTrainingsLink extends Script {
         const splittedLink = training.link.split('modules');
         const module = await moduleService.getModuleByLink({
           link: training.link,
-          moduleRepository: repositories.moduleRepository,
+          moduleMetadataRepository: repositories.moduleMetadataRepository,
         });
         const tmpSlug = splittedLink[1].split('tmp-');
         const newLink = `${splittedLink[0]}modules/${module.shortId}${tmpSlug.join('')}`;

--- a/api/src/devcomp/domain/services/module-service.js
+++ b/api/src/devcomp/domain/services/module-service.js
@@ -3,17 +3,17 @@ import { ModuleDoesNotExistError } from '../errors.js';
 const linkWithSlugRegexp = /\/modules\/([a-z0-9-]*)/;
 const linkWithShortIdRegexp = /\/modules\/([a-z0-9]{8})\/([a-z0-9-]*)/;
 
-const getModuleByLink = async function ({ link, moduleRepository }) {
+const getModuleByLink = async function ({ link, moduleMetadataRepository }) {
   if (linkWithShortIdRegexp.test(link)) {
-    return await _getModuleByLinkWithShortId({ link, moduleRepository });
+    return await _getModuleByLinkWithShortId({ link, moduleMetadataRepository });
   }
 
-  return await _getModuleByLinkWithSlug({ link, moduleRepository });
+  return await _getModuleByLinkWithSlug({ link, moduleMetadataRepository });
 };
 
 export default { getModuleByLink };
 
-async function _getModuleByLinkWithSlug({ link, moduleRepository }) {
+async function _getModuleByLinkWithSlug({ link, moduleMetadataRepository }) {
   const result = linkWithSlugRegexp.exec(link);
 
   if (!result) {
@@ -22,18 +22,18 @@ async function _getModuleByLinkWithSlug({ link, moduleRepository }) {
   const slug = result[1];
 
   try {
-    return await moduleRepository.getBySlug({ slug });
+    return await moduleMetadataRepository.getBySlug({ slug });
   } catch {
     throw new ModuleDoesNotExistError(`No module found for link: ${link}`);
   }
 }
 
-async function _getModuleByLinkWithShortId({ link, moduleRepository }) {
+async function _getModuleByLinkWithShortId({ link, moduleMetadataRepository }) {
   const result = linkWithShortIdRegexp.exec(link);
   const shortId = result[1];
 
   try {
-    return await moduleRepository.getByShortId({ shortId: shortId });
+    return await moduleMetadataRepository.getByShortId({ shortId: shortId });
   } catch {
     throw new ModuleDoesNotExistError(`No module found for link: ${link}`);
   }

--- a/api/src/devcomp/domain/usecases/find-recommendable-modules-by-target-profile-ids.js
+++ b/api/src/devcomp/domain/usecases/find-recommendable-modules-by-target-profile-ids.js
@@ -4,7 +4,7 @@ import moduleService from '../services/module-service.js';
 const findRecommendableModulesByTargetProfileIds = async function ({
   targetProfileIds,
   trainingRepository,
-  moduleRepository,
+  moduleMetadataRepository,
   logger,
 }) {
   const recommendedTrainings = await trainingRepository.findModulesByTargetProfileIds({ targetProfileIds });
@@ -12,7 +12,7 @@ const findRecommendableModulesByTargetProfileIds = async function ({
   const recommendedModules = await Promise.all(
     recommendedTrainings.map(async ({ id, link, targetProfileIds }) => {
       try {
-        const module = await moduleService.getModuleByLink({ link, moduleRepository });
+        const module = await moduleService.getModuleByLink({ link, moduleMetadataRepository });
         return { id, moduleId: module.id, shortId: module.shortId, targetProfileIds };
       } catch {
         logger.error({ message: `Erreur sur le lien de la ressource : ${link}` });

--- a/api/src/devcomp/domain/usecases/find-recommended-modules-by-campaign-participation-ids.js
+++ b/api/src/devcomp/domain/usecases/find-recommended-modules-by-campaign-participation-ids.js
@@ -3,7 +3,7 @@ import moduleService from '../services/module-service.js';
 
 export const findRecommendedModulesByCampaignParticipationIds = async function ({
   campaignParticipationIds,
-  moduleRepository,
+  moduleMetadataRepository,
   userRecommendedTrainingRepository,
   logger,
 }) {
@@ -13,7 +13,7 @@ export const findRecommendedModulesByCampaignParticipationIds = async function (
   const userRecommendedModules = await Promise.all(
     userRecommendedTrainings.map(async ({ id, link }) => {
       try {
-        const module = await moduleService.getModuleByLink({ link, moduleRepository });
+        const module = await moduleService.getModuleByLink({ link, moduleMetadataRepository });
         return { id, moduleId: module.id, shortId: module.shortId };
       } catch {
         logger.error({ message: `Erreur sur le lien de la ressource : ${link}` });

--- a/api/src/devcomp/infrastructure/repositories/module-metadata-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/module-metadata-repository.js
@@ -1,7 +1,7 @@
 import { NotFoundError } from '../../../shared/domain/errors.js';
 import { ModuleMetadata } from '../../domain/models/module/ModuleMetadata.js';
 
-export async function getAllByIds({ ids, moduleDatasource }) {
+async function getAllByIds({ ids, moduleDatasource }) {
   try {
     const modules = await moduleDatasource.getAllByIds(ids);
     return modules.map(_toDomain);
@@ -10,7 +10,16 @@ export async function getAllByIds({ ids, moduleDatasource }) {
   }
 }
 
-export async function getBySlug({ slug, moduleDatasource }) {
+async function getByShortId({ shortId, moduleDatasource }) {
+  try {
+    const module = await moduleDatasource.getByShortId(shortId);
+    return _toDomain(module);
+  } catch (error) {
+    throw new NotFoundError(error.message);
+  }
+}
+
+async function getBySlug({ slug, moduleDatasource }) {
   try {
     const module = await moduleDatasource.getBySlug(slug);
     return _toDomain(module);
@@ -23,3 +32,5 @@ function _toDomain(module) {
   const { id, shortId, slug, title, isBeta, details } = module;
   return new ModuleMetadata({ id, shortId, slug, title, isBeta, duration: details.duration, image: details.image });
 }
+
+export { getAllByIds, getByShortId, getBySlug };

--- a/api/src/devcomp/infrastructure/repositories/module-metadata-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/module-metadata-repository.js
@@ -10,6 +10,15 @@ export async function getAllByIds({ ids, moduleDatasource }) {
   }
 }
 
+export async function getBySlug({ slug, moduleDatasource }) {
+  try {
+    const module = await moduleDatasource.getBySlug(slug);
+    return _toDomain(module);
+  } catch (error) {
+    throw new NotFoundError(error.message);
+  }
+}
+
 function _toDomain(module) {
   const { id, shortId, slug, title, isBeta, details } = module;
   return new ModuleMetadata({ id, shortId, slug, title, isBeta, duration: details.duration, image: details.image });

--- a/api/tests/devcomp/integration/repositories/module-metadata-repository_test.js
+++ b/api/tests/devcomp/integration/repositories/module-metadata-repository_test.js
@@ -154,6 +154,95 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
     });
   });
 
+  describe('getByShortId', function () {
+    it('should return a module with its metadata', async function () {
+      const existingModuleShortId = 'gbsri73s';
+      const stubModule = {
+        id: 'f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d',
+        shortId: existingModuleShortId,
+        slug: 'slug',
+        title: 'Bien écrire son adresse mail',
+        isBeta: true,
+        details: {
+          image: 'https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-details.svg',
+          description:
+            'Apprendre à rédiger correctement une adresse e-mail pour assurer une meilleure communication et éviter les erreurs courantes.',
+          duration: 12,
+          level: 'novice',
+          tabletSupport: 'comfortable',
+          objectives: [
+            'Écrire une adresse mail correctement, en évitant les erreurs courantes',
+            'Connaître les parties d’une adresse mail et les identifier sur des exemples',
+            'Comprendre les fonctions des parties d’une adresse mail',
+          ],
+        },
+        sections: [
+          {
+            id: '5bf1c672-3746-4480-b9ac-1f0af9c7c509',
+            type: 'practise',
+            grains: [
+              {
+                id: 'z1f3c8c7-6d5c-4c6c-9c4d-1a3d8f7e9f5d',
+                type: 'lesson',
+                title: 'Explications : les parties d’une adresse mail',
+                components: [
+                  {
+                    type: 'element',
+                    element: {
+                      id: 'd9e8a7b6-5c4d-3e2f-1a0b-9f8e7d6c5b4a',
+                      type: 'text',
+                      content:
+                        "<h4 class='screen-reader-only'>L'arobase</h4><p>L’arobase est dans toutes les adresses mails. Il sépare l’identifiant et le fournisseur d’adresse mail.</p><p><span aria-hidden='true'>🇬🇧</span> En anglais, ce symbole se lit <i lang='en'>“at”</i> qui veut dire “chez”.</p><p><span aria-hidden='true'>🤔</span> Le saviez-vous : c’est un symbole qui était utilisé bien avant l’informatique ! Par exemple, pour compter des quantités.</p>",
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+
+      const moduleDatasourceStub = {
+        getByShortId: sinon.stub(),
+      };
+      moduleDatasourceStub.getByShortId.withArgs(existingModuleShortId).resolves(stubModule);
+
+      // when
+      const moduleMetadata = await moduleMetadataRepository.getByShortId({
+        shortId: existingModuleShortId,
+        moduleDatasource: moduleDatasourceStub,
+      });
+
+      // then
+      const expectedModuleMetadata = new ModuleMetadata({
+        id: stubModule.id,
+        shortId: existingModuleShortId,
+        slug: stubModule.slug,
+        title: stubModule.title,
+        isBeta: stubModule.isBeta,
+        duration: stubModule.details.duration,
+        image: stubModule.details.image,
+      });
+
+      expect(moduleMetadata).to.be.instanceOf(ModuleMetadata);
+      expect(moduleMetadata).to.deep.equal(expectedModuleMetadata);
+    });
+
+    it('should throw a NotFoundError if the module does not exist', async function () {
+      // given
+      const nonExistingShortId = 'not-existing-module-short-id';
+
+      // when
+      const error = await catchErr(moduleMetadataRepository.getByShortId)({
+        slug: nonExistingShortId,
+        moduleDatasource,
+      });
+
+      // then
+      expect(error).to.be.instanceOf(NotFoundError);
+    });
+  });
+
   describe('#getBySlug', function () {
     it('should return a module with its metadata', async function () {
       const existingModuleSlug = 'bien-ecrire-son-adresse-mail';

--- a/api/tests/devcomp/unit/domain/services/module-service_test.js
+++ b/api/tests/devcomp/unit/domain/services/module-service_test.js
@@ -16,20 +16,20 @@ describe('#getModuleByLink', function () {
 
   describe('with slug', function () {
     it('should throw an error if link slug does not match any module', async function () {
-      const moduleRepository = { getBySlug: sinon.stub() };
-      moduleRepository.getBySlug.withArgs({ slug: 'wrong-slug' }).rejects(new NotFoundError());
-      const error = await catchErr(getModuleByLink)({ link: '/modules/wrong-slug', moduleRepository });
+      const moduleMetadataRepository = { getBySlug: sinon.stub() };
+      moduleMetadataRepository.getBySlug.withArgs({ slug: 'wrong-slug' }).rejects(new NotFoundError());
+      const error = await catchErr(getModuleByLink)({ link: '/modules/wrong-slug', moduleMetadataRepository });
       expect(error).to.be.instanceOf(ModuleDoesNotExistError);
     });
 
     it('should return module if link slug matches a module', async function () {
       // given
-      const moduleRepository = { getBySlug: sinon.stub() };
+      const moduleMetadataRepository = { getBySlug: sinon.stub() };
       const expectedModule = Symbol('module');
-      moduleRepository.getBySlug.withArgs({ slug: 'good-slug' }).resolves(expectedModule);
+      moduleMetadataRepository.getBySlug.withArgs({ slug: 'good-slug' }).resolves(expectedModule);
 
       // when
-      const module = await getModuleByLink({ link: '/modules/good-slug', moduleRepository });
+      const module = await getModuleByLink({ link: '/modules/good-slug', moduleMetadataRepository });
 
       // then
       expect(module).to.equal(expectedModule);
@@ -37,12 +37,12 @@ describe('#getModuleByLink', function () {
 
     it('should return module if absolute link slug matches a module', async function () {
       // given
-      const moduleRepository = { getBySlug: sinon.stub() };
+      const moduleMetadataRepository = { getBySlug: sinon.stub() };
       const expectedModule = Symbol('module');
-      moduleRepository.getBySlug.withArgs({ slug: 'good-slug' }).resolves(expectedModule);
+      moduleMetadataRepository.getBySlug.withArgs({ slug: 'good-slug' }).resolves(expectedModule);
 
       // when
-      const module = await getModuleByLink({ link: 'https://app.pix.fr/modules/good-slug', moduleRepository });
+      const module = await getModuleByLink({ link: 'https://app.pix.fr/modules/good-slug', moduleMetadataRepository });
 
       // then
       expect(module).to.equal(expectedModule);
@@ -51,27 +51,30 @@ describe('#getModuleByLink', function () {
 
   describe('with short id', function () {
     it('should throw an error if link slug does not match any module', async function () {
-      const moduleRepository = { getByShortId: sinon.stub() };
-      moduleRepository.getByShortId.withArgs({ shortId: 'wrong-short-id' }).rejects(new NotFoundError());
-      const error = await catchErr(getModuleByLink)({ link: '/modules/wrong-short-id/wrong-slug', moduleRepository });
+      const moduleMetadataRepository = { getByShortId: sinon.stub() };
+      moduleMetadataRepository.getByShortId.withArgs({ shortId: 'wrong-short-id' }).rejects(new NotFoundError());
+      const error = await catchErr(getModuleByLink)({
+        link: '/modules/wrong-short-id/wrong-slug',
+        moduleMetadataRepository,
+      });
       expect(error).to.be.instanceOf(ModuleDoesNotExistError);
     });
 
     it('should throw an error if short id does not match expected format', async function () {
-      const moduleRepository = { getByShortId: sinon.stub() };
-      moduleRepository.getByShortId.withArgs({ shortId: 'wrong-short-id' }).rejects(new NotFoundError());
-      const error = await catchErr(getModuleByLink)({ link: '/modules/bac-a-sable/details', moduleRepository });
+      const moduleMetadataRepository = { getByShortId: sinon.stub() };
+      moduleMetadataRepository.getByShortId.withArgs({ shortId: 'wrong-short-id' }).rejects(new NotFoundError());
+      const error = await catchErr(getModuleByLink)({ link: '/modules/bac-a-sable/details', moduleMetadataRepository });
       expect(error).to.be.instanceOf(ModuleDoesNotExistError);
     });
 
     it('should return module if link slug matches a module', async function () {
       // given
-      const moduleRepository = { getByShortId: sinon.stub() };
+      const moduleMetadataRepository = { getByShortId: sinon.stub() };
       const expectedModule = Symbol('module');
-      moduleRepository.getByShortId.withArgs({ shortId: 'abcd1234' }).resolves(expectedModule);
+      moduleMetadataRepository.getByShortId.withArgs({ shortId: 'abcd1234' }).resolves(expectedModule);
 
       // when
-      const module = await getModuleByLink({ link: '/modules/abcd1234/good-slug', moduleRepository });
+      const module = await getModuleByLink({ link: '/modules/abcd1234/good-slug', moduleMetadataRepository });
 
       // then
       expect(module).to.equal(expectedModule);
@@ -79,14 +82,14 @@ describe('#getModuleByLink', function () {
 
     it('should return module if absolute link slug matches a module', async function () {
       // given
-      const moduleRepository = { getByShortId: sinon.stub() };
+      const moduleMetadataRepository = { getByShortId: sinon.stub() };
       const expectedModule = Symbol('module');
-      moduleRepository.getByShortId.withArgs({ shortId: 'edfg5678' }).resolves(expectedModule);
+      moduleMetadataRepository.getByShortId.withArgs({ shortId: 'edfg5678' }).resolves(expectedModule);
 
       // when
       const module = await getModuleByLink({
         link: 'https://app.pix.fr/modules/edfg5678/good-slug',
-        moduleRepository,
+        moduleMetadataRepository,
       });
 
       // then


### PR DESCRIPTION
## ❄️ Problème

Sur les apis internes dans le fichier [recommended-modules-api](https://github.com/1024pix/pix/blob/dev/api/src/devcomp/application/api/recommended-modules-api.js), nous utilisons, dans les usecases, le moduleService pour récupérer les informations d’un module.

Mais nous n’avons en fait besoin que de l’id et du shortId dans ces 2 usecases ([usecase1](https://github.com/1024pix/pix/blob/dev/api/src/devcomp/domain/usecases/find-recommended-modules-by-campaign-participation-ids.js#L17), [usecase2](https://github.com/1024pix/pix/blob/dev/api/src/devcomp/domain/usecases/find-recommendable-modules-by-target-profile-ids.js)). Ce qui fait qu’on passe par la factory pour rien…

Cela entraîne des appels vers pix-assets sur du contenu qui n’est pas utilisé.

## 🛷 Proposition

Ajouter des fonctions pour renvoyer des objets ModuleMetadata dans le repository correspondant. Puis utiliser ces nouvelles fonctions à la place de ce qu'il y avait avant.

## ☃️ Remarques

RAS

## 🧑‍🎄 Pour tester

CI au vert ✅ 
