### PR TITLE
[BUGFIX] Les cartes de formation se chevauchent dans pix app (PIX-20712).

### DIFF
--- a/api/db/seeds/data/team-devcomp/build-trainings.js
+++ b/api/db/seeds/data/team-devcomp/build-trainings.js
@@ -2,7 +2,7 @@ import { DEVCOMP_BASE_TRAINING_ID, PIX_EDU_SMALL_TARGET_PROFILE_ID } from './con
 
 export function buildTrainings(databaseBuilder) {
   let trainingId = DEVCOMP_BASE_TRAINING_ID;
-  const frTrainingId = databaseBuilder.factory.buildTraining({
+  const frTrainingId1 = databaseBuilder.factory.buildTraining({
     id: trainingId++,
     title: 'Apprendre à manger un croissant comme les français',
     internalTitle: 'Apprendre à manger un croissant comme les français',
@@ -11,17 +11,75 @@ export function buildTrainings(databaseBuilder) {
 
   databaseBuilder.factory.buildTargetProfileTraining({
     targetProfileId: PIX_EDU_SMALL_TARGET_PROFILE_ID,
-    trainingId: frTrainingId,
+    trainingId: frTrainingId1,
   });
 
   const frTrainingTriggerId = databaseBuilder.factory.buildTrainingTrigger({
-    trainingId: frTrainingId,
+    trainingId: frTrainingId1,
     threshold: 0,
     type: 'prerequisite',
   }).id;
 
   databaseBuilder.factory.buildTrainingTriggerTube({
     trainingTriggerId: frTrainingTriggerId,
+    tubeId: 'tube1NLpOetQhutFlA',
+    level: 2,
+  });
+
+  const frTrainingId2 = databaseBuilder.factory.buildTraining({
+    id: trainingId++,
+    title: 'Apprendre à faire du snow dans Paris à Montmartre quand il a beaucoup neigé',
+    internalTitle: 'Apprendre à faire du snow dans Paris à Montmartre quand il a beaucoup neigé',
+    link: '/modules/6a68bf32/bac-a-sable/details',
+    duration: '00:10:00',
+    editorName: 'Pix',
+    editorLogoUrl: 'https://assets.pix.org/contenu-formatif/editeur/pix-logo.svg',
+    type: 'modulix',
+    locale: 'fr',
+  }).id;
+
+  databaseBuilder.factory.buildTargetProfileTraining({
+    targetProfileId: PIX_EDU_SMALL_TARGET_PROFILE_ID,
+    trainingId: frTrainingId2,
+  });
+
+  const frTrainingTriggerId2 = databaseBuilder.factory.buildTrainingTrigger({
+    trainingId: frTrainingId2,
+    threshold: 0,
+    type: 'prerequisite',
+  }).id;
+
+  databaseBuilder.factory.buildTrainingTriggerTube({
+    trainingTriggerId: frTrainingTriggerId2,
+    tubeId: 'tube1NLpOetQhutFlA',
+    level: 2,
+  });
+
+  const frTrainingId3 = databaseBuilder.factory.buildTraining({
+    id: trainingId++,
+    title: 'Apprendre à faire de la frangipane pour régaler ses convives',
+    internalTitle: 'Apprendre à faire de la frangipane pour régaler ses convives',
+    link: '/modules/6a68bf32/bac-a-sable/details',
+    duration: '00:10:00',
+    editorName: 'Pix',
+    editorLogoUrl: 'https://assets.pix.org/contenu-formatif/editeur/pix-logo.svg',
+    type: 'modulix',
+    locale: 'fr',
+  }).id;
+
+  databaseBuilder.factory.buildTargetProfileTraining({
+    targetProfileId: PIX_EDU_SMALL_TARGET_PROFILE_ID,
+    trainingId: frTrainingId3,
+  });
+
+  const frTrainingTriggerId3 = databaseBuilder.factory.buildTrainingTrigger({
+    trainingId: frTrainingId3,
+    threshold: 0,
+    type: 'prerequisite',
+  }).id;
+
+  databaseBuilder.factory.buildTrainingTriggerTube({
+    trainingTriggerId: frTrainingTriggerId3,
     tubeId: 'tube1NLpOetQhutFlA',
     level: 2,
   });
@@ -103,5 +161,5 @@ export function buildTrainings(databaseBuilder) {
     level: 2,
   });
 
-  return [frTrainingId, frFrTrainingId1, frFrTrainingId2, enTrainingId];
+  return [frTrainingId1, frTrainingId2, frTrainingId3, frFrTrainingId1, frFrTrainingId2, enTrainingId];
 }

--- a/mon-pix/app/styles/pages/_user-trainings.scss
+++ b/mon-pix/app/styles/pages/_user-trainings.scss
@@ -29,8 +29,6 @@
 .user-trainings-content {
   display: flex;
   flex-direction: column;
-  width: 100%;
-  min-height: inherit;
   margin: 0 auto;
   padding: var(--pix-spacing-6x) 20px 0;
   color: var(--pix-neutral-900);
@@ -43,41 +41,27 @@
     margin: 0 0 32px;
   }
 
-  &__container {
-    width: 100%;
-    margin: 0 auto;
-    padding: 0 20px;
-
-    @include breakpoints.device-is('desktop') {
-      max-width: 1280px;
-    }
-  }
-
   &__list {
-    display: grid;
-    grid-template-columns: 1fr;
+    display: flex;
+    flex-wrap: wrap;
     gap: var(--pix-spacing-6x);
     margin-bottom: var(--pix-spacing-8x);
-    padding: 0;
     list-style: none;
-
-    @include breakpoints.device-is('tablet') {
-      grid-template-columns: repeat(3, minmax(0, 1fr));
-    }
-
-    @include breakpoints.device-is('desktop') {
-      grid-template-columns: repeat(4, minmax(0, 1fr));
-    }
   }
 }
 
 .user-trainings-content-list {
   &__item {
+    flex-basis: 100%;
+
+    @include breakpoints.device-is('desktop') {
+      flex-basis: 30%;
+    }
+
     &:hover {
       border-radius: var(--pix-spacing-2x);
-      box-shadow:
-        0 7px 14px 0 var(--pix-neutral-100),
-        0 3px 6px 0 var(--pix-neutral-500);
+      box-shadow: 0 7px 14px 0 var(--pix-neutral-100),
+      0 3px 6px 0 var(--pix-neutral-500);
     }
   }
 }

--- a/mon-pix/app/templates/authenticated/user-trainings.gjs
+++ b/mon-pix/app/templates/authenticated/user-trainings.gjs
@@ -8,24 +8,22 @@ import Header from 'mon-pix/components/training/header';
 
   <main id="main" class="main" role="main">
     <Header />
-    <div class="user-trainings-content">
-      {{#if @model.trainings.meta.pagination.rowCount}}
-        <div class="user-trainings-content__container">
-          <ul class="user-trainings-content__list">
-            {{#each @model.trainings as |training|}}
-              <li class="user-trainings-content-list__item">
-                <Card @training={{training}} />
-              </li>
-            {{/each}}
-          </ul>
-          <PixPagination
-            @pagination={{@model.trainings.meta.pagination}}
-            @pageOptions={{@controller.pageOptions}}
-            @locale={{@controller.locale.currentLanguage}}
-            @isCondensed="true"
-          />
-        </div>
-      {{/if}}
-    </div>
+    {{#if @model.trainings.meta.pagination.rowCount}}
+      <div class="user-trainings-content">
+        <ul class="user-trainings-content__list">
+          {{#each @model.trainings as |training|}}
+            <li class="user-trainings-content-list__item">
+              <Card @training={{training}} />
+            </li>
+          {{/each}}
+        </ul>
+        <PixPagination
+          @pagination={{@model.trainings.meta.pagination}}
+          @pageOptions={{@controller.pageOptions}}
+          @locale={{@controller.locale.currentLanguage}}
+          @isCondensed="true"
+        />
+      </div>
+    {{/if}}
   </main>
 </template>

--- a/mon-pix/tests/acceptance/user-trainings-test.js
+++ b/mon-pix/tests/acceptance/user-trainings-test.js
@@ -46,7 +46,7 @@ module('Acceptance | mes-formations', function (hooks) {
           'Continuez à progresser grâce aux formations recommandées à l’issue de vos parcours d’évaluation.',
         ),
       );
-      assert.dom('.user-trainings-content__container').exists();
+      assert.dom('.user-trainings-content').exists();
       assert.dom('.user-trainings-content-list__item').exists();
       assert.dom('.user-trainings-content-list__item').exists({ count: 2 });
 

--- a/mon-pix/tests/acceptance/user-trainings-test.js
+++ b/mon-pix/tests/acceptance/user-trainings-test.js
@@ -1,4 +1,4 @@
-import { visit } from '@1024pix/ember-testing-library';
+import { visit, within } from '@1024pix/ember-testing-library';
 // eslint-disable-next-line no-restricted-imports
 import { currentURL, find } from '@ember/test-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -34,25 +34,27 @@ module('Acceptance | mes-formations', function (hooks) {
 
       // when
       await authenticate(user);
-      await visit('/mes-formations');
+      const screen = await visit('/mes-formations');
 
       // then
       assert.strictEqual(currentURL(), '/mes-formations');
-      assert.dom('.global-page-header__title').exists();
-      assert.ok(find('.global-page-header__title').textContent.includes('Mes formations'));
-      assert.dom('.global-page-header__description').exists();
-      assert.ok(
-        find('.global-page-header__description').textContent.includes(
-          'Continuez à progresser grâce aux formations recommandées à l’issue de vos parcours d’évaluation.',
-        ),
-      );
-      assert.dom('.user-trainings-content').exists();
-      assert.dom('.user-trainings-content-list__item').exists();
-      assert.dom('.user-trainings-content-list__item').exists({ count: 2 });
+      assert.dom('h1').hasText('Mes formations');
+      assert
+        .dom(
+          screen.getByText(
+            'Continuez à progresser grâce aux formations recommandées à l’issue de vos parcours d’évaluation.',
+          ),
+        )
+        .exists();
 
-      const pixPaginationTextContent = find('.pix-pagination__navigation').textContent;
-      assert.ok(pixPaginationTextContent.includes('2 éléments'));
-      assert.ok(pixPaginationTextContent.includes('Page 1 / 1'));
+      const mainContent = find('main');
+      const trainings = within(mainContent).getAllByRole('listitem');
+      assert.ok(trainings.length, 2);
+      assert.dom(screen.getByText('Devenir tailleur de citrouille')).exists();
+      assert.dom(screen.getByText('Apprendre à piloter des chauves-souris')).exists();
+
+      assert.dom(screen.getByText('2 éléments')).exists();
+      assert.dom(screen.getByText('Page 1 / 1')).exists();
     });
   });
 });


### PR DESCRIPTION
## ❄️ Problème
Actuellement, dans la section mes formations de Pix App, les cartes de formations se chevauchent sur les formats de type tablette.

## 🛷 Proposition
Modifier le style pour que les cartes ne se chevauchent plus.

## ☃️ Remarques
On en a profité pour:
- améliorer les seeds pour avoir plusieurs CF suggérés pour un utilisateur
- refacto des tests d'acceptance pour éviter de s'appuyer sur les classes CDD

## 🧑‍🎄 Pour tester
- Se connecter à [Pix App](https://app-pr14606.review.pix.fr/connexion)
- Reprendre un parcours avec dave-comp@example.net, et le partager
- Accéder à la page [Mes formations](https://app-pr14606.review.pix.fr/mes-formations)
- Dupliquer les formations à l'aide des dev tools
- Tester que les cartes ne se chevauchent plus sur les différents devices


