### PR TITLE
[FEATURE] Valider l'existence des items de schéma de parcours combiné au moment de leur ajout (PIX-20891)

### DIFF
--- a/admin/app/adapters/module.js
+++ b/admin/app/adapters/module.js
@@ -1,0 +1,7 @@
+import ApplicationAdapter from './application';
+
+export default class Module extends ApplicationAdapter {
+  urlForFindRecord(id) {
+    return `${this.host}/${this.namespace}/modules/v2/${id}`;
+  }
+}

--- a/admin/app/components/combined-course-blueprints/form.gjs
+++ b/admin/app/components/combined-course-blueprints/form.gjs
@@ -52,25 +52,26 @@ export default class CombineCourseBluePrintForm extends Component {
   }
 
   async addTargetProfile() {
-    await this.store.findRecord('target-profile', this.itemValue);
-
+    const targetProfile = await this.store.findRecord('target-profile', this.itemValue);
     this.blueprint.content = [
       ...this.blueprint.content,
       {
         type: 'evaluation',
         value: Number(this.itemValue),
+        label: targetProfile.internalName,
       },
     ];
   }
 
   async addModule() {
-    await this.store.findRecord('module', this.itemValue);
+    const module = await this.store.findRecord('module', this.itemValue);
 
     this.blueprint.content = [
       ...this.blueprint.content,
       {
         type: 'module',
         value: this.itemValue,
+        label: module.title,
       },
     ];
   }
@@ -245,7 +246,12 @@ export default class CombineCourseBluePrintForm extends Component {
         {{#if (gt this.blueprint.content.length 0)}}
           <ul class="combined-course-page__list">
             {{#each this.blueprint.content as |item|}}
-              <li><RequirementTag @type={{item.type}} @value={{item.value}} @onRemove={{this.removeRequirement}} />
+              <li><RequirementTag
+                  @type={{item.type}}
+                  @value={{item.value}}
+                  @label={{item.label}}
+                  @onRemove={{this.removeRequirement}}
+                />
               </li>
             {{/each}}
           </ul>

--- a/admin/app/components/combined-course-blueprints/list-summary-items.gjs
+++ b/admin/app/components/combined-course-blueprints/list-summary-items.gjs
@@ -74,7 +74,11 @@ export default class CombineCourseBluePrintList extends Component {
               <details>
                 <summary>{{t "components.combined-course-blueprints.list.content"}}</summary>
                 {{#each blueprint.content as |requirement|}}
-                  <RequirementTag @type={{requirement.type}} @value={{requirement.value}} />
+                  <RequirementTag
+                    @type={{requirement.type}}
+                    @value={{requirement.value}}
+                    @label={{requirement.value}}
+                  />
                 {{/each}}
               </details>
             </:cell>

--- a/admin/app/components/common/combined-courses/requirement-tag.gjs
+++ b/admin/app/components/common/combined-courses/requirement-tag.gjs
@@ -32,12 +32,12 @@ export default class RequirementTag extends Component {
         >
           {{t (getItemType @type)}}
           -
-          {{@value}}</LinkTo>
+          {{@label}}</LinkTo>
       {{else}}
         <a target="_blank" rel="noopener noreferrer" href="https://app.recette.pix.fr/modules/{{@value}}/slug/details">
           {{t (getItemType @type)}}
           -
-          {{@value}}
+          {{@label}}
         </a>
       {{/if}}
     </PixTag>

--- a/admin/app/models/module.js
+++ b/admin/app/models/module.js
@@ -1,0 +1,6 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class Module extends Model {
+  @attr('string') shortId;
+  @attr('string') slug;
+}

--- a/admin/app/models/module.js
+++ b/admin/app/models/module.js
@@ -2,5 +2,5 @@ import Model, { attr } from '@ember-data/model';
 
 export default class Module extends Model {
   @attr('string') shortId;
-  @attr('string') slug;
+  @attr('string') title;
 }

--- a/admin/app/serializers/combined-course-blueprint.js
+++ b/admin/app/serializers/combined-course-blueprint.js
@@ -1,0 +1,8 @@
+import ApplicationSerializer from './application';
+export default class CombinedCourseBlueprintSerializer extends ApplicationSerializer {
+  serialize() {
+    const json = super.serialize(...arguments);
+    json.data.attributes.content = json.data.attributes.content.map(({ type, value }) => ({ type, value }));
+    return json;
+  }
+}

--- a/admin/tests/integration/components/combined-course-blueprints/form-test.gjs
+++ b/admin/tests/integration/components/combined-course-blueprints/form-test.gjs
@@ -27,8 +27,8 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
 
     sinon.stub(store, 'createRecord').withArgs('combined-course-blueprint').returns(blueprintStub);
     const findRecordStub = sinon.stub(store, 'findRecord');
-    findRecordStub.withArgs('module').resolves();
-    findRecordStub.withArgs('target-profile').resolves();
+    findRecordStub.withArgs('module', 'module-123').resolves({ title: 'module 123' });
+    findRecordStub.withArgs('target-profile', '1').resolves({ internalName: 'super pc' });
 
     //when
 
@@ -72,8 +72,8 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
     assert.strictEqual(blueprintStub.name, 'name');
     assert.strictEqual(blueprintStub.internalName, 'internalName');
     assert.deepEqual(blueprintStub.content, [
-      { type: 'evaluation', value: 1 },
-      { type: 'module', value: 'module-123' },
+      { type: 'evaluation', value: 1, label: 'super pc' },
+      { type: 'module', value: 'module-123', label: 'module 123' },
     ]);
     assert.strictEqual(blueprintStub.illustration, 'illustrations/hello.svg');
     assert.strictEqual(blueprintStub.description, 'description');
@@ -82,33 +82,6 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
         message: t('components.combined-course-blueprints.create.notifications.success'),
       }),
     );
-  });
-
-  test('it should remove item when user clicks on remove button', async function (assert) {
-    // given
-    const pixToast = this.owner.lookup('service:pixToast');
-    const store = this.owner.lookup('service:store');
-
-    sinon.stub(pixToast, 'sendSuccessNotification');
-    const findRecordStub = sinon.stub(store, 'findRecord');
-
-    findRecordStub.withArgs('target-profile').resolves();
-    //when
-
-    const screen = await render(<template><CombinedCourseBlueprintForm /></template>);
-
-    await fillIn(
-      screen.getByLabelText(t('components.combined-course-blueprints.create.labels.itemId'), { exact: false }),
-      1,
-    );
-    await click(screen.getByRole('button', { name: t('components.combined-course-blueprints.create.addItemButton') }));
-
-    assert.ok(screen.getByText(/Profil Cible - 1/));
-
-    await click(screen.getByRole('button', { name: 'Supprimer' }));
-
-    //then
-    assert.notOk(screen.queryByText(/Profil Cible - 1/));
   });
 
   module('error cases', function () {
@@ -300,6 +273,62 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
           message: t('components.combined-course-blueprints.create.notifications.addItemError'),
         }),
       );
+    });
+  });
+
+  module('combined course blueprint items', function () {
+    test('should display tag for item when added', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const findRecordStub = sinon.stub(store, 'findRecord');
+      findRecordStub.withArgs('module', 'module-123').resolves({ title: 'module 123' });
+      findRecordStub.withArgs('target-profile', '1').resolves({ internalName: 'super pc' });
+      //when
+      const screen = await render(<template><CombinedCourseBlueprintForm /></template>);
+
+      await fillIn(
+        screen.getByLabelText(t('components.combined-course-blueprints.create.labels.itemId'), { exact: false }),
+        1,
+      );
+      await click(
+        screen.getByRole('button', { name: t('components.combined-course-blueprints.create.addItemButton') }),
+      );
+      await click(screen.getByLabelText(t('components.combined-course-blueprints.create.labels.module')));
+      await fillIn(
+        screen.getByLabelText(t('components.combined-course-blueprints.create.labels.itemId'), { exact: false }),
+        'module-123',
+      );
+      await click(
+        screen.getByRole('button', { name: t('components.combined-course-blueprints.create.addItemButton') }),
+      );
+
+      assert.ok(screen.getByText(/Profil Cible - super pc/));
+      assert.ok(screen.getByText(/Module - module 123/));
+    });
+    test('it should remove item when user clicks on remove button', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+
+      const findRecordStub = sinon.stub(store, 'findRecord');
+
+      findRecordStub.withArgs('target-profile', '1').resolves({ internalName: 'super pc' });
+      //when
+
+      const screen = await render(<template><CombinedCourseBlueprintForm /></template>);
+
+      await fillIn(
+        screen.getByLabelText(t('components.combined-course-blueprints.create.labels.itemId'), { exact: false }),
+        1,
+      );
+      await click(
+        screen.getByRole('button', { name: t('components.combined-course-blueprints.create.addItemButton') }),
+      );
+
+      assert.ok(screen.getByText(/Profil Cible - super pc/));
+      await click(screen.getByRole('button', { name: 'Supprimer' }));
+
+      //then
+      assert.notOk(screen.queryByText(/Profil Cible - super pc/));
     });
   });
 });

--- a/admin/tests/unit/serializers/combined-course-blueprint-test.js
+++ b/admin/tests/unit/serializers/combined-course-blueprint-test.js
@@ -1,0 +1,45 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Unit | Serializer | combined-course-blueprint', function (hooks) {
+  setupTest(hooks);
+
+  test('it serializes records', function (assert) {
+    const store = this.owner.lookup('service:store');
+    const record = store.createRecord('combined-course-blueprint', {
+      name: 'parcours',
+      internalName: 'Nom interne',
+      content: [
+        {
+          type: 'evaluation',
+          value: 1,
+          label: 'Profil cilble 1',
+        },
+      ],
+    });
+
+    const serializedRecord = record.serialize();
+
+    assert.deepEqual(
+      {
+        data: {
+          type: 'combined-course-blueprints',
+          attributes: {
+            name: 'parcours',
+            'internal-name': 'Nom interne',
+            'created-at': undefined,
+            illustration: null,
+            description: null,
+            content: [
+              {
+                type: 'evaluation',
+                value: 1,
+              },
+            ],
+          },
+        },
+      },
+      serializedRecord,
+    );
+  });
+});

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -473,8 +473,11 @@
           "target-profile": "Target profile"
         },
         "notifications": {
-          "error": "Oups. Something went wrong. Please try again.",
-          "success": "Combined course blueprint created successfully!"
+          "addItemError": "Oops. Resource not found.",
+          "error": "Oops. Something went wrong. Please try again.",
+          "moduleNotFound": "No module found with given short id",
+          "success": "Combined course blueprint created successfully!",
+          "targetProfileNotFound": "No target profile found with given id"
         },
         "title": "Create a combined course blueprint"
       },

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -474,8 +474,11 @@
           "target-profile": "Profil cible"
         },
         "notifications": {
+          "addItemError": "Oups. Une erreur est survenue lors de l'ajout de la ressource.",
           "error": "Oups. Une erreur est survenue lors de la création du schéma de parcours.",
-          "success": "Création du schéma de parcours réussi !"
+          "moduleNotFound": "Il n'existe pas de module avec l'identifiant saisi",
+          "success": "Création du schéma de parcours réussi !",
+          "targetProfileNotFound": "Il n'existe pas de profil cible avec l'identifiant saisi"
         },
         "title": "Créer un schéma de parcours"
       },


### PR DESCRIPTION
## ❄️ Problème

On veut faciliter la création des schémas de parcours combiné et limiter les erreurs.

## 🛷 Proposition

On propose d'aller vérifier l'existence de chaque item au moment de leur ajout dans le schéma.
Pour cela, on interroge le store.

## ☃️ Remarques

## 🧑‍🎄 Pour tester
Dans PixAdmin
Aller dans "Schéma de parcours", cliquer sur le bouton de création de schéma.
Puis vérifier à l'ajout d'un module ou d'un profil cible qu'un message d'errreur s'affiche bien si ledit module ou PC n'existe pas.
Tester la non-régression également.