### PR TITLE
[TECH] Afficher le nom de l'orga mère sur le formulaire sans utiliser les queryParams (PIX-20728)

### DIFF
--- a/admin/app/controllers/authenticated/organizations/new.js
+++ b/admin/app/controllers/authenticated/organizations/new.js
@@ -9,10 +9,13 @@ export default class NewController extends Controller {
   @service intl;
   @service store;
 
-  queryParams = ['parentOrganizationId', 'parentOrganizationName'];
+  queryParams = ['parentOrganizationId'];
 
   @tracked parentOrganizationId = null;
-  @tracked parentOrganizationName = null;
+
+  get parentOrganizationName() {
+    return this.model.parentOrganization ? this.model.parentOrganization.name : null;
+  }
 
   @action
   redirectOnCancel() {

--- a/admin/app/routes/authenticated/organizations/new.js
+++ b/admin/app/routes/authenticated/organizations/new.js
@@ -26,12 +26,18 @@ export default class NewRoute extends Route {
     }
   }
 
-  async model() {
+  async model(_, transition) {
     const administrationTeams = await this.store.findAll('administration-team');
     const countries = await this.store.findAll('country');
+    let parentOrganization = null;
+    const { parentOrganizationId } = transition.to.queryParams;
+    if (parentOrganizationId) {
+      parentOrganization = await this.store.findRecord('organization', parentOrganizationId);
+    }
     return RSVP.hash({
       administrationTeams,
       countries,
+      parentOrganization,
     });
   }
 

--- a/admin/app/routes/authenticated/organizations/new.js
+++ b/admin/app/routes/authenticated/organizations/new.js
@@ -9,21 +9,10 @@ export default class NewRoute extends Route {
 
   queryParams = {
     parentOrganizationId: { refreshModel: true },
-    parentOrganizationName: { refreshModel: true },
   };
 
-  beforeModel(transition) {
+  beforeModel() {
     this.accessControl.restrictAccessTo(['isSuperAdmin', 'isSupport', 'isMetier'], 'authenticated');
-    const queryParams = transition.to.queryParams;
-
-    if (_hasParentOrganizationQueryParamsAndOneIsMissing(queryParams)) {
-      this.router.replaceWith('authenticated', {
-        queryParams: {
-          parentOrganizationId: null,
-          parentOrganizationName: null,
-        },
-      });
-    }
   }
 
   async model(_, transition) {
@@ -44,15 +33,6 @@ export default class NewRoute extends Route {
   resetController(controller, isExiting) {
     if (isExiting) {
       controller.parentOrganizationId = null;
-      controller.parentOrganizationName = null;
     }
   }
-}
-
-function _hasParentOrganizationQueryParamsAndOneIsMissing(queryParams) {
-  return (
-    Object.keys(queryParams).length > 0 &&
-    (Boolean(!queryParams.parentOrganizationName && queryParams.parentOrganizationId) ||
-      Boolean(queryParams.parentOrganizationName && !queryParams.parentOrganizationId))
-  );
 }

--- a/admin/tests/acceptance/authenticated/organizations/create-organization-test.js
+++ b/admin/tests/acceptance/authenticated/organizations/create-organization-test.js
@@ -60,11 +60,7 @@ module('Acceptance | Organizations | Create', function (hooks) {
 
     test('it shows the creation form with parent organization name', async function (assert) {
       // when
-      const screen = await visit(
-        `/organizations/new?parentOrganizationId=${parentOrganization.id}&parentOrganizationName=${encodeURIComponent(
-          parentOrganization.name,
-        )}`,
-      );
+      const screen = await visit(`/organizations/new?parentOrganizationId=${parentOrganization.id}`);
 
       // then
       assert
@@ -89,11 +85,7 @@ module('Acceptance | Organizations | Create', function (hooks) {
 
     test('it redirects the user to parent organization page when cancelling', async function (assert) {
       // given
-      const screen = await visit(
-        `/organizations/new?parentOrganizationId=${parentOrganization.id}&parentOrganizationName=${encodeURIComponent(
-          parentOrganization.name,
-        )}`,
-      );
+      const screen = await visit(`/organizations/new?parentOrganizationId=${parentOrganization.id}`);
       // when
       const cancelButton = await screen.getByRole('button', { name: t('common.actions.cancel') });
       await click(cancelButton);

--- a/admin/tests/acceptance/authenticated/organizations/get/children-test.js
+++ b/admin/tests/acceptance/authenticated/organizations/get/children-test.js
@@ -121,7 +121,7 @@ module('Acceptance | Organizations | Children', function (hooks) {
     });
 
     module('when creating child organization from parent page', function () {
-      test('it should redirect to New organization page, with parent infos in query params', async function (assert) {
+      test('it should redirect to New organization page, with parent id in query params', async function (assert) {
         // given
         const parentOrganization = this.server.create('organization', { id: 1, name: 'Parent Organization Name' });
         const screen = await visit(`/organizations/${parentOrganization.id}/children`);
@@ -131,7 +131,7 @@ module('Acceptance | Organizations | Children', function (hooks) {
           screen.getByRole('link', { name: t('components.organizations.children.create-child-organization-button') }),
         );
 
-        const expectedQueryParams = `?parentOrganizationId=${parentOrganization.id}&parentOrganizationName=${encodeURIComponent(parentOrganization.name)}`;
+        const expectedQueryParams = `?parentOrganizationId=${parentOrganization.id}`;
 
         // then
         assert.strictEqual(currentURL(), `/organizations/new${expectedQueryParams}`);

--- a/admin/tests/unit/routes/authenticated/organizations/new-test.js
+++ b/admin/tests/unit/routes/authenticated/organizations/new-test.js
@@ -112,13 +112,12 @@ module('Unit | Route | authenticated/organizations/new', function (hooks) {
       }
       this.owner.register('service:access-control', AccessControlStub);
     });
-    test('it should allow parentOrganizationId and parentOrganizationName query params', async function (assert) {
+    test('it should allow parentOrganizationId query param', async function (assert) {
       // given
       const transition = {
         to: {
           queryParams: {
             parentOrganizationId: '1',
-            parentOrganizationName: 'Orga Name',
           },
         },
       };
@@ -128,72 +127,6 @@ module('Unit | Route | authenticated/organizations/new', function (hooks) {
 
       // then
       assert.ok(router.replaceWith.notCalled);
-    });
-
-    test('it should allow any other query params', async function (assert) {
-      // given
-      const transition = {
-        to: {
-          queryParams: {
-            otherQueryParam: 'A random query param',
-          },
-        },
-      };
-
-      // when
-      route.beforeModel(transition);
-
-      // then
-      assert.ok(router.replaceWith.notCalled);
-    });
-
-    test('it should redirect to home page and set query params to null if one of parentOrganizationId and parentOrganizationName is provided but the other is missing', async function (assert) {
-      // given
-      const routeToRedirect = 'authenticated';
-
-      const transition = {
-        to: {
-          queryParams: {
-            parentOrganizationId: '1',
-          },
-        },
-      };
-
-      // when
-      route.beforeModel(transition);
-
-      // then
-      assert.ok(
-        router.replaceWith.calledWith(routeToRedirect, {
-          queryParams: {
-            parentOrganizationId: null,
-            parentOrganizationName: null,
-          },
-        }),
-      );
-    });
-
-    module('when parentOrganizationId is provided', function () {
-      test('it should fetch the parent organization', async function (assert) {
-        // given
-        const transition = {
-          to: {
-            queryParams: {
-              parentOrganizationId: '1',
-            },
-          },
-        };
-        const store = route.store;
-        sinon.stub(store, 'findAll').resolves([]);
-        const findRecordStub = sinon.stub(store, 'findRecord').resolves({ id: '1', name: 'Parent Org' });
-
-        // when
-        const model = await route.model(undefined, transition);
-
-        // then
-        assert.ok(findRecordStub.calledWith('organization', '1'));
-        assert.deepEqual(model.parentOrganization, { id: '1', name: 'Parent Org' });
-      });
     });
   });
 });

--- a/admin/tests/unit/routes/authenticated/organizations/new-test.js
+++ b/admin/tests/unit/routes/authenticated/organizations/new-test.js
@@ -172,5 +172,28 @@ module('Unit | Route | authenticated/organizations/new', function (hooks) {
         }),
       );
     });
+
+    module('when parentOrganizationId is provided', function () {
+      test('it should fetch the parent organization', async function (assert) {
+        // given
+        const transition = {
+          to: {
+            queryParams: {
+              parentOrganizationId: '1',
+            },
+          },
+        };
+        const store = route.store;
+        sinon.stub(store, 'findAll').resolves([]);
+        const findRecordStub = sinon.stub(store, 'findRecord').resolves({ id: '1', name: 'Parent Org' });
+
+        // when
+        const model = await route.model(undefined, transition);
+
+        // then
+        assert.ok(findRecordStub.calledWith('organization', '1'));
+        assert.deepEqual(model.parentOrganization, { id: '1', name: 'Parent Org' });
+      });
+    });
   });
 });


### PR DESCRIPTION
## ❄️ Problème

On veut pouvoir afficher le nom de l’orga mère en récuperant les infos depuis le store d’ember ( ou via l’api si l’info n’est pas présente dans le store ) afin d’initier la suite et pré-remplir certains champs.

## 🛷 Proposition

Supprimer le parentOrganizationName des queryParams

## ☃️ Remarques

On a décidé de faire appel à l'api directement au chargement de la page pour éviter de perdre l'info lors d'un refresh.

## 🧑‍🎄 Pour tester

- Créer une orga fille depuis une orga
- Constater le nom de l'orga mère sur le formulraire de création