### PR TITLE
[TECH] Améliorer les perfs de l'api récupérant une liste de modules par son shortId (PIX-20982)

### DIFF
--- a/api/src/devcomp/application/api/modules-api.js
+++ b/api/src/devcomp/application/api/modules-api.js
@@ -73,10 +73,8 @@ const getUserModuleStatuses = async ({ userId, moduleIds }) => {
 };
 
 const getModulesByShortIds = async ({ moduleShortIds }) => {
-  const modules = [];
-  for (const shortId of moduleShortIds) {
-    modules.push(await usecases.getModuleByShortId({ shortId }));
-  }
-  return modules.map((module) => new Module(module));
+  const modulesMetadata = await usecases.getModuleMetadataListByShortIds({ shortIds: moduleShortIds });
+
+  return modulesMetadata.map((module) => new Module(module));
 };
 export { getModulesByIds, getModulesByShortIds, getUserModuleStatuses };

--- a/api/src/devcomp/domain/usecases/get-module-metadata-list-by-short-ids.js
+++ b/api/src/devcomp/domain/usecases/get-module-metadata-list-by-short-ids.js
@@ -1,0 +1,5 @@
+async function getModuleMetadataListByShortIds({ shortIds, moduleMetadataRepository }) {
+  return moduleMetadataRepository.getAllByShortIds({ shortIds });
+}
+
+export { getModuleMetadataListByShortIds };

--- a/api/src/devcomp/domain/usecases/index.js
+++ b/api/src/devcomp/domain/usecases/index.js
@@ -53,6 +53,7 @@ import { findTutorials } from './find-tutorials.js';
 import { getModule } from './get-module.js';
 import { getModuleByShortId } from './get-module-by-short-id.js';
 import { getModuleMetadataList } from './get-module-metadata-list.js';
+import { getModuleMetadataListByShortIds } from './get-module-metadata-list-by-short-ids.js';
 import { getTraining } from './get-training.js';
 import { getUserModuleStatuses } from './get-user-module-statuses.js';
 import { handleTrainingRecommendation } from './handle-training-recommendation.js';
@@ -84,6 +85,7 @@ const usecasesWithoutInjectedDependencies = {
   findTargetProfileSummariesForTraining,
   findTutorials,
   getModuleMetadataList,
+  getModuleMetadataListByShortIds,
   getModule,
   getModuleByShortId,
   getTraining,

--- a/api/src/devcomp/infrastructure/datasources/learning-content/module-datasource.js
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/module-datasource.js
@@ -20,6 +20,18 @@ const moduleDatasource = {
 
     return modules;
   },
+  getAllByShortIds: async (shortIds) => {
+    const modules = referential.modules.filter((module) => shortIds.includes(module.shortId));
+
+    const foundModulesIds = modules.map((module) => module.shortId);
+    const notFoundModulesShortIds = shortIds.filter((shortId) => !foundModulesIds.includes(shortId));
+
+    if (notFoundModulesShortIds.length > 0) {
+      throw new ModuleDoesNotExistError(`Short ids with no module: ${notFoundModulesShortIds}`);
+    }
+
+    return modules;
+  },
   getById: async (id) => {
     const foundModule = referential.modules.find((module) => module.id === id);
 

--- a/api/src/devcomp/infrastructure/repositories/module-metadata-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/module-metadata-repository.js
@@ -10,6 +10,15 @@ async function getAllByIds({ ids, moduleDatasource }) {
   }
 }
 
+async function getAllByShortIds({ shortIds, moduleDatasource }) {
+  try {
+    const modules = await moduleDatasource.getAllByShortIds(shortIds);
+    return modules.map(_toDomain);
+  } catch (error) {
+    throw new NotFoundError(error.message);
+  }
+}
+
 async function getByShortId({ shortId, moduleDatasource }) {
   try {
     const module = await moduleDatasource.getByShortId(shortId);
@@ -33,4 +42,4 @@ function _toDomain(module) {
   return new ModuleMetadata({ id, shortId, slug, title, isBeta, duration: details.duration, image: details.image });
 }
 
-export { getAllByIds, getByShortId, getBySlug };
+export { getAllByIds, getAllByShortIds, getByShortId, getBySlug };

--- a/api/tests/devcomp/integration/application/api/modules-api_test.js
+++ b/api/tests/devcomp/integration/application/api/modules-api_test.js
@@ -220,20 +220,20 @@ describe('Integration | Devcomp | Application | Api | Modules', function () {
       // then
       const expectedResult = [
         {
-          duration: undefined,
+          duration: 10,
           id: '5df14039-803b-4db4-9778-67e4b84afbbd',
           shortId: existingModuleShortId1,
           slug: 'adresse-ip-publique-et-vous',
           title: "L'adresse IP publique : ce qu'elle révèle sur vous !",
-          image: undefined,
+          image: 'https://assets.pix.org/modules/placeholder-details.svg',
         },
         {
           id: '9beb922f-4d8e-495d-9c85-0e7265ca78d6',
           shortId: existingModuleShortId2,
           slug: 'au-dela-des-mots-de-passe',
           title: 'Au-delà des mots de passe : comment s’authentifier ?',
-          duration: undefined,
-          image: undefined,
+          duration: 5,
+          image: 'https://assets.pix.org/modules/placeholder-details.svg',
         },
       ];
 

--- a/api/tests/devcomp/integration/repositories/module-metadata-repository_test.js
+++ b/api/tests/devcomp/integration/repositories/module-metadata-repository_test.js
@@ -154,6 +154,154 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
     });
   });
 
+  describe('#getAllByShortIds', function () {
+    it('should return all module with their metadata', async function () {
+      // given
+      const moduleShortIds = ['gbsri73s', '1bdri73s'];
+      const firstModule = {
+        id: moduleShortIds[0],
+        shortId: 'gbsri73s',
+        slug: 'getAllByIdsModuleSlug1',
+        title: 'Bien écrire son adresse mail',
+        isBeta: true,
+        details: {
+          image: 'https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-details.svg',
+          description:
+            'Apprendre à rédiger correctement une adresse e-mail pour assurer une meilleure communication et éviter les erreurs courantes.',
+          duration: 12,
+          level: 'novice',
+          tabletSupport: 'comfortable',
+          objectives: [
+            'Écrire une adresse mail correctement, en évitant les erreurs courantes',
+            'Connaître les parties d’une adresse mail et les identifier sur des exemples',
+            'Comprendre les fonctions des parties d’une adresse mail',
+          ],
+        },
+        sections: [
+          {
+            id: '5bf1c672-3746-4480-b9ac-1f0af9c7c509',
+            type: 'practise',
+            grains: [
+              {
+                id: 'z1f3c8c7-6d5c-4c6c-9c4d-1a3d8f7e9f5d',
+                type: 'lesson',
+                title: 'Explications : les parties d’une adresse mail',
+                components: [
+                  {
+                    type: 'element',
+                    element: {
+                      id: 'd9e8a7b6-5c4d-3e2f-1a0b-9f8e7d6c5b4a',
+                      type: 'text',
+                      content:
+                        "<h4 class='screen-reader-only'>L'arobase</h4><p>L’arobase est dans toutes les adresses mails. Il sépare l’identifiant et le fournisseur d’adresse mail.</p><p><span aria-hidden='true'>🇬🇧</span> En anglais, ce symbole se lit <i lang='en'>“at”</i> qui veut dire “chez”.</p><p><span aria-hidden='true'>🤔</span> Le saviez-vous : c’est un symbole qui était utilisé bien avant l’informatique ! Par exemple, pour compter des quantités.</p>",
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+      const secondModule = {
+        id: moduleShortIds[1],
+        shortId: '1bdri73s',
+        slug: 'getAllByIdsModuleSlug2',
+        title: 'Bac à sable',
+        isBeta: true,
+        details: {
+          image: 'https://assets.pix.org/modules/placeholder-details.svg',
+          description:
+            "<p>Ce module est dédié à des tests internes à Pix.</p><p>Il contient normalement l'intégralité des fonctionnalités disponibles à date.</p>",
+          duration: 5,
+          level: 'novice',
+          tabletSupport: 'inconvenient',
+          objectives: ['Non régression fonctionnelle'],
+        },
+        sections: [
+          {
+            id: 'd2ad3253-7f0a-41f5-b10e-0fa0f49d0cc7',
+            type: 'practise',
+            grains: [
+              {
+                id: 'z1f3c8c7-6d5c-4c6c-9c4d-1a3d8f7e9f5d',
+                type: 'lesson',
+                title: 'Explications : les parties d’une adresse mail',
+                components: [
+                  {
+                    type: 'element',
+                    element: {
+                      id: 'd9e8a7b6-5c4d-3e2f-1a0b-9f8e7d6c5b4a',
+                      type: 'text',
+                      content:
+                        "<h4 class='screen-reader-only'>L'arobase</h4><p>L’arobase est dans toutes les adresses mails. Il sépare l’identifiant et le fournisseur d’adresse mail.</p><p><span aria-hidden='true'>🇬🇧</span> En anglais, ce symbole se lit <i lang='en'>“at”</i> qui veut dire “chez”.</p><p><span aria-hidden='true'>🤔</span> Le saviez-vous : c’est un symbole qui était utilisé bien avant l’informatique ! Par exemple, pour compter des quantités.</p>",
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+
+      const moduleDatasourceStub = {
+        getAllByShortIds: sinon.stub(),
+      };
+      moduleDatasourceStub.getAllByShortIds.withArgs(moduleShortIds).resolves([firstModule, secondModule]);
+
+      // when
+      const modules = await moduleMetadataRepository.getAllByShortIds({
+        shortIds: moduleShortIds,
+        moduleDatasource: moduleDatasourceStub,
+      });
+
+      // then
+      const expectedResult = [
+        new ModuleMetadata({
+          id: firstModule.id,
+          shortId: firstModule.shortId,
+          slug: firstModule.slug,
+          title: firstModule.title,
+          isBeta: firstModule.isBeta,
+          duration: firstModule.details.duration,
+          image: firstModule.details.image,
+        }),
+        new ModuleMetadata({
+          id: secondModule.id,
+          shortId: secondModule.shortId,
+          slug: secondModule.slug,
+          title: secondModule.title,
+          isBeta: secondModule.isBeta,
+          duration: secondModule.details.duration,
+          image: secondModule.details.image,
+        }),
+      ];
+      expect(modules).to.have.lengthOf(2);
+      expect(modules).to.deep.equal(expectedResult);
+    });
+
+    it('should throw a "NotFoundError" when a module does not exist', async function () {
+      // given
+      const notExistingModuleShortIds = ['not-existing-module-short-id-1', 'not-existing-module-short-id-2'];
+      const expectedErrorMessage = `Modules with ids not found : ${notExistingModuleShortIds}`;
+      const moduleDatasourceStub = {
+        getAllByShortIds: sinon.stub(),
+      };
+      moduleDatasourceStub.getAllByShortIds
+        .withArgs(notExistingModuleShortIds)
+        .rejects(new ModuleDoesNotExistError(expectedErrorMessage));
+
+      // when
+      const error = await catchErr(moduleMetadataRepository.getAllByShortIds)({
+        shortIds: notExistingModuleShortIds,
+        moduleDatasource: moduleDatasourceStub,
+      });
+
+      // then
+      expect(error).to.be.instanceOf(NotFoundError);
+      expect(error.message).to.equal(expectedErrorMessage);
+    });
+  });
+
   describe('getByShortId', function () {
     it('should return a module with its metadata', async function () {
       const existingModuleShortId = 'gbsri73s';

--- a/api/tests/devcomp/unit/domain/usecases/get-module-metadata-list-by-short-ids_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/get-module-metadata-list-by-short-ids_test.js
@@ -1,0 +1,42 @@
+import { getModuleMetadataListByShortIds } from '../../../../../src/devcomp/domain/usecases/get-module-metadata-list-by-short-ids.js';
+import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
+import { catchErr, expect, sinon } from '../../../../test-helper.js';
+
+describe('Unit | Devcomp | Domain | UseCases | get-module-metadata-list-by-short-ids', function () {
+  it('should return a list of ModuleMetadata', async function () {
+    // given
+    const moduleMetadataList = Symbol('moduleMetadataList');
+    const firstShortId = Symbol('firstShortId');
+    const secondShortId = Symbol('secondShortId');
+    const shortIds = [firstShortId, secondShortId];
+    const moduleMetadataRepository = {
+      getAllByShortIds: sinon.stub(),
+    };
+
+    moduleMetadataRepository.getAllByShortIds.withArgs({ shortIds }).resolves(moduleMetadataList);
+
+    // when
+    const moduleMetadataListResult = await getModuleMetadataListByShortIds({ shortIds, moduleMetadataRepository });
+
+    // then
+    expect(moduleMetadataListResult).to.equal(moduleMetadataList);
+    expect(moduleMetadataRepository.getAllByShortIds).to.have.been.calledWithExactly({ shortIds });
+  });
+
+  context('when a module short id does not exist', function () {
+    it('should throw the NotFoundError thrown by repository', async function () {
+      // given
+      const shortIds = ['notFoundModuleId1', 'notFoundModuleId2'];
+      const moduleMetadataRepository = {
+        getAllByShortIds: sinon.stub(),
+      };
+      moduleMetadataRepository.getAllByShortIds.withArgs({ shortIds }).throws(new NotFoundError());
+
+      // when
+      const error = await catchErr(getModuleMetadataListByShortIds)({ shortIds, moduleMetadataRepository });
+
+      // then
+      expect(error).to.be.instanceOf(NotFoundError);
+    });
+  });
+});

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/module-datasource_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/module-datasource_test.js
@@ -43,6 +43,37 @@ describe('Unit | Infrastructure | Datasources | Learning Content | ModuleDatasou
     });
   });
 
+  describe('#getAllByShortIds', function () {
+    it('should return all modules with shortIds list in parameters', async function () {
+      // Given
+      const shortIds = ['6a68bf32', '9d4dcab8'];
+
+      // When
+      const modules = await moduleDatasource.getAllByShortIds(shortIds);
+
+      // Then
+      const moduleShortIds = modules.map((module) => module.shortId);
+      expect(moduleShortIds).to.have.lengthOf(2);
+      expect(moduleShortIds).to.deep.contains.members(shortIds);
+    });
+
+    context('when modules in the shortIds list do not exist', function () {
+      it('should throw a "ModuleDoesNotExistError" error', async function () {
+        // Given
+        const notExistingModuleShortIds = ['not-existing-module-short-id-1', 'not-existing-module-short-id-2'];
+
+        const shortIds = ['6a68bf32', '9d4dcab8', ...notExistingModuleShortIds];
+
+        // When
+        const error = await catchErr(moduleDatasource.getAllByShortIds)(shortIds);
+
+        // Then
+        expect(error).to.be.instanceOf(ModuleDoesNotExistError);
+        expect(error.message).to.equal(`Short ids with no module: ${notExistingModuleShortIds}`);
+      });
+    });
+  });
+
   describe('#getByShortId', function () {
     describe('when a module with the given shortId exist', function () {
       it('should return a module', async function () {


### PR DESCRIPTION
## ❄️ Problème

L’api interne [moduleApi.getByShortIds](https://github.com/1024pix/pix/blob/dev/api/src/devcomp/application/api/modules-api.js) passent par la moduleFactory pour récupérer des modules. Cela cause des appels inutiles à PixAssets.

## 🛷 Proposition

Ne pas passer par le moduleFactory pour récupérer les infos des modules (qui fait les appels) mais plutôt par le ModuleMetadata.

## ☃️ Remarques

RAS

## 🧑‍🎄 Pour tester

CI au vert ✅ 
