### PR TITLE
[FEATURE] Ajouter un feature toggle isModuleSelectionForTrainingEnabled (PIX-20920)

### DIFF
--- a/admin/app/models/feature-toggle.js
+++ b/admin/app/models/feature-toggle.js
@@ -1,3 +1,5 @@
-import Model from '@ember-data/model';
+import Model, { attr } from '@ember-data/model';
 
-export default class FeatureToggle extends Model {}
+export default class FeatureToggle extends Model {
+  @attr('boolean') isModuleSelectionForTrainingEnabled;
+}

--- a/api/config/feature-toggles-config.js
+++ b/api/config/feature-toggles-config.js
@@ -89,4 +89,11 @@ export default {
     devDefaultValues: { test: false, reviewApp: true },
     tags: ['frontend', 'team-devcomp', 'modulix', 'pix-app'],
   },
+  isModuleSelectionForTrainingEnabled: {
+    type: 'boolean',
+    description: 'Enable module selection on training form',
+    defaultValue: false,
+    devDefaultValues: { test: false, reviewApp: true },
+    tags: ['frontend', 'team-devcomp', 'modulix', 'admin'],
+  },
 };

--- a/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
+++ b/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
@@ -31,6 +31,7 @@ describe('Acceptance | Shared | Application | Controller | feature-toggle', func
             'use-pix-orga-new-auth-design': false,
             'is-pix-plus-candidate-a11y-enabled': false,
             'are-module-short-id-urls-enabled': false,
+            'is-module-selection-for-training-enabled': false,
           },
         },
       };


### PR DESCRIPTION
## 🛷 Proposition

Créer un feature toggle pour l'implémentation de la sélection des modules lors de la création ou mise à jour d'un contenu formatif sur Pix Admin.

On l'appelle `isModuleSelectionForTrainingEnabled`.

## 🧑‍🎄 Pour tester
- Vérifier, grâce à la console dev, que la requête vers l'API `feature-toggles` renvoie bien `isModuleSelectionForTrainingEnabled`à `false`
