### PR TITLE
[FEATURE] Pré-remplissage de champs lors de la création d'une organisation fille (PIX-20729).

### DIFF
--- a/admin/app/components/organizations/creation-form.gjs
+++ b/admin/app/components/organizations/creation-form.gjs
@@ -14,7 +14,9 @@ export default class OrganizationCreationForm extends Component {
   @service store;
   @service intl;
 
-  @tracked form = {};
+  @tracked form = {
+    administrationTeamId: this.parentOrganizationAdministrationTeamId,
+  };
 
   organizationTypes = [
     { value: 'PRO', label: 'Organisation professionnelle' },
@@ -48,6 +50,12 @@ export default class OrganizationCreationForm extends Component {
 
   get dpoSectionTitle() {
     return `${this.intl.t('components.organizations.creation.dpo.definition')} (${this.intl.t('components.organizations.creation.dpo.acronym')})`;
+  }
+
+  get parentOrganizationAdministrationTeamId() {
+    return this.args.parentOrganization?.administrationTeamId
+      ? `${this.args.parentOrganization.administrationTeamId}`
+      : undefined;
   }
 
   handleInputChange = (key, event) => {

--- a/admin/app/components/organizations/creation-form.gjs
+++ b/admin/app/components/organizations/creation-form.gjs
@@ -16,6 +16,7 @@ export default class OrganizationCreationForm extends Component {
 
   @tracked form = {
     administrationTeamId: this.parentOrganizationAdministrationTeamId,
+    type: this.parentOrganizationType,
   };
 
   organizationTypes = [
@@ -56,6 +57,10 @@ export default class OrganizationCreationForm extends Component {
     return this.args.parentOrganization?.administrationTeamId
       ? `${this.args.parentOrganization.administrationTeamId}`
       : undefined;
+  }
+
+  get parentOrganizationType() {
+    return this.args.parentOrganization?.type ? `${this.args.parentOrganization.type}` : undefined;
   }
 
   handleInputChange = (key, event) => {

--- a/admin/app/components/organizations/creation-form.gjs
+++ b/admin/app/components/organizations/creation-form.gjs
@@ -17,7 +17,8 @@ export default class OrganizationCreationForm extends Component {
   @tracked form = {
     administrationTeamId: this.parentOrganizationAdministrationTeamId,
     type: this.parentOrganizationType,
-    countryCode: this.parentOrganizationCountryCode
+    countryCode: this.parentOrganizationCountryCode,
+    documentationUrl: this.parentOrganizationDocumentationUrl,
   };
 
   organizationTypes = [
@@ -66,6 +67,12 @@ export default class OrganizationCreationForm extends Component {
 
   get parentOrganizationCountryCode() {
     return this.args.parentOrganization?.countryCode ? `${this.args.parentOrganization.countryCode}` : undefined;
+  }
+
+  get parentOrganizationDocumentationUrl() {
+    return this.args.parentOrganization?.documentationUrl
+      ? `${this.args.parentOrganization.documentationUrl}`
+      : undefined;
   }
 
   handleInputChange = (key, event) => {
@@ -186,6 +193,7 @@ export default class OrganizationCreationForm extends Component {
               @id="documentationUrl"
               {{on "change" (fn this.handleInputChange "documentationUrl")}}
               placeholder={{concat (t "common.words.example-abbr") " https://www.documentation.org"}}
+              @value="{{this.form.documentationUrl}}"
             >
               <:label>{{t "components.organizations.creation.documentation-link"}}</:label>
             </PixInput>

--- a/admin/app/components/organizations/creation-form.gjs
+++ b/admin/app/components/organizations/creation-form.gjs
@@ -41,7 +41,7 @@ export default class OrganizationCreationForm extends Component {
   }
 
   get submitButtonText() {
-    return this.args.parentOrganizationName
+    return this.args.parentOrganization?.name
       ? 'components.organizations.creation.actions.add-child-organization'
       : 'common.actions.add';
   }
@@ -73,11 +73,11 @@ export default class OrganizationCreationForm extends Component {
           class="admin-form__card organization-creation-form__card"
           @title={{t "components.organizations.creation.general-information"}}
         >
-          {{#if @parentOrganizationName}}
+          {{#if @parentOrganization}}
             <h2 class="admin-form__content title organization-creation-form__parent-name--full">
               {{t
                 "components.organizations.creation.parent-organization-name"
-                parentOrganizationName=@parentOrganizationName
+                parentOrganizationName=@parentOrganization.name
               }}
             </h2>
           {{/if}}

--- a/admin/app/components/organizations/creation-form.gjs
+++ b/admin/app/components/organizations/creation-form.gjs
@@ -17,6 +17,7 @@ export default class OrganizationCreationForm extends Component {
   @tracked form = {
     administrationTeamId: this.parentOrganizationAdministrationTeamId,
     type: this.parentOrganizationType,
+    countryCode: this.parentOrganizationCountryCode
   };
 
   organizationTypes = [
@@ -61,6 +62,10 @@ export default class OrganizationCreationForm extends Component {
 
   get parentOrganizationType() {
     return this.args.parentOrganization?.type ? `${this.args.parentOrganization.type}` : undefined;
+  }
+
+  get parentOrganizationCountryCode() {
+    return this.args.parentOrganization?.countryCode ? `${this.args.parentOrganization.countryCode}` : undefined;
   }
 
   handleInputChange = (key, event) => {

--- a/admin/app/controllers/authenticated/organizations/new.js
+++ b/admin/app/controllers/authenticated/organizations/new.js
@@ -13,10 +13,6 @@ export default class NewController extends Controller {
 
   @tracked parentOrganizationId = null;
 
-  get parentOrganizationName() {
-    return this.model.parentOrganization ? this.model.parentOrganization.name : null;
-  }
-
   @action
   redirectOnCancel() {
     if (this.parentOrganizationId) {

--- a/admin/app/templates/authenticated/organizations/new.gjs
+++ b/admin/app/templates/authenticated/organizations/new.gjs
@@ -6,7 +6,7 @@ import CreationForm from 'pix-admin/components/organizations/creation-form';
 <template>
   {{pageTitle "Nouvelle orga"}}
   <header class="page-header">
-    {{#if @controller.parentOrganizationName}}
+    {{#if @model.parentOrganization}}
       <Breadcrumb @currentPageLabel={{t "pages.organizations.breadcrumb.new-child-organization-page"}} />
     {{else}}
       <Breadcrumb @currentPageLabel={{t "pages.organizations.breadcrumb.new-organization-page"}} />
@@ -19,7 +19,7 @@ import CreationForm from 'pix-admin/components/organizations/creation-form';
       @countries={{@model.countries}}
       @onSubmit={{@controller.addOrganization}}
       @onCancel={{@controller.redirectOnCancel}}
-      @parentOrganizationName={{@controller.parentOrganizationName}}
+      @parentOrganization={{@model.parentOrganization}}
     />
   </main>
 </template>

--- a/admin/tests/integration/components/organizations/creation-form-test.gjs
+++ b/admin/tests/integration/components/organizations/creation-form-test.gjs
@@ -154,6 +154,30 @@ module('Integration | Component | organizations/creation-form', function (hooks)
           'Danemark (99101)',
         );
       });
+
+      test("it prefills the documentation url with its parent's", async function (assert) {
+        // given - when
+        const organization = store.createRecord('organization', {
+          documentationUrl: 'https://example-documentation.com',
+        });
+
+        const screen = await render(
+          <template>
+            <CreationForm
+              @parentOrganization={{organization}}
+              @administrationTeams={{administrationTeams}}
+              @countries={{countries}}
+              @onSubmit={{onSubmit}}
+              @onCancel={{onCancel}}
+            />
+          </template>,
+        );
+
+        // then
+        assert
+          .dom(screen.getByRole('textbox', { name: 'Lien vers la documentation' }))
+          .hasValue('https://example-documentation.com');
+      });
     });
 
     module('when there is no parent organization', function () {
@@ -202,21 +226,43 @@ module('Integration | Component | organizations/creation-form', function (hooks)
       test('it does not prefill the country selector', async function (assert) {
         // given - when
         const screen = await render(
-        <template>
-          <CreationForm
-            @parentOrganization={{null}}
-            @administrationTeams={{administrationTeams}}
-            @countries={{countries}}
-            @onSubmit={{onSubmit}}
-            @onCancel={{onCancel}}
-          />
-        </template>,
+          <template>
+            <CreationForm
+              @parentOrganization={{null}}
+              @administrationTeams={{administrationTeams}}
+              @countries={{countries}}
+              @onSubmit={{onSubmit}}
+              @onCancel={{onCancel}}
+            />
+          </template>,
         );
 
         // then
         assert.strictEqual(
-          await screen.getByRole('button', { name: "Pays (code INSEE) *" }).innerText,
+          await screen.getByRole('button', { name: 'Pays (code INSEE) *' }).innerText,
           'Sélectionner un pays',
+        );
+      });
+
+      test('it does not prefill the documentation url input', async function (assert) {
+        // given - when
+        const screen = await render(
+          <template>
+            <CreationForm
+              @parentOrganization={{null}}
+              @administrationTeams={{administrationTeams}}
+              @countries={{countries}}
+              @onSubmit={{onSubmit}}
+              @onCancel={{onCancel}}
+            />
+          </template>,
+        );
+
+        // then
+        assert.dom(screen.getByRole('textbox', { name: 'Lien vers la documentation' })).hasValue('');
+        assert.strictEqual(
+          screen.getByRole('textbox', { name: 'Lien vers la documentation' }).placeholder,
+          'ex: https://www.documentation.org',
         );
       });
     });

--- a/admin/tests/integration/components/organizations/creation-form-test.gjs
+++ b/admin/tests/integration/components/organizations/creation-form-test.gjs
@@ -131,6 +131,29 @@ module('Integration | Component | organizations/creation-form', function (hooks)
           'Établissement scolaire',
         );
       });
+
+      test("it prefills the country selector with its parent's", async function (assert) {
+        // given - when
+        const organization = store.createRecord('organization', { countryCode: '99101' });
+
+        const screen = await render(
+          <template>
+            <CreationForm
+              @parentOrganization={{organization}}
+              @administrationTeams={{administrationTeams}}
+              @countries={{countries}}
+              @onSubmit={{onSubmit}}
+              @onCancel={{onCancel}}
+            />
+          </template>,
+        );
+
+        // then
+        assert.strictEqual(
+          await screen.getByRole('button', { name: 'Pays (code INSEE) *' }).innerText,
+          'Danemark (99101)',
+        );
+      });
     });
 
     module('when there is no parent organization', function () {
@@ -173,6 +196,27 @@ module('Integration | Component | organizations/creation-form', function (hooks)
         assert.strictEqual(
           await screen.getByRole('button', { name: "Type de l'organisation *" }).innerText,
           'Sélectionner un type',
+        );
+      });
+
+      test('it does not prefill the country selector', async function (assert) {
+        // given - when
+        const screen = await render(
+        <template>
+          <CreationForm
+            @parentOrganization={{null}}
+            @administrationTeams={{administrationTeams}}
+            @countries={{countries}}
+            @onSubmit={{onSubmit}}
+            @onCancel={{onCancel}}
+          />
+        </template>,
+        );
+
+        // then
+        assert.strictEqual(
+          await screen.getByRole('button', { name: "Pays (code INSEE) *" }).innerText,
+          'Sélectionner un pays',
         );
       });
     });

--- a/admin/tests/integration/components/organizations/creation-form-test.gjs
+++ b/admin/tests/integration/components/organizations/creation-form-test.gjs
@@ -108,6 +108,29 @@ module('Integration | Component | organizations/creation-form', function (hooks)
         // then
         assert.strictEqual(await screen.getByRole('button', { name: 'Équipe en charge *' }).innerText, 'Équipe 1');
       });
+
+      test("it prefills the type selector with its parent's", async function (assert) {
+        // given - when
+        const organization = store.createRecord('organization', { type: 'SCO' });
+
+        const screen = await render(
+          <template>
+            <CreationForm
+              @parentOrganization={{organization}}
+              @administrationTeams={{administrationTeams}}
+              @countries={{countries}}
+              @onSubmit={{onSubmit}}
+              @onCancel={{onCancel}}
+            />
+          </template>,
+        );
+
+        // then
+        assert.strictEqual(
+          await screen.getByRole('button', { name: "Type de l'organisation *" }).innerText,
+          'Établissement scolaire',
+        );
+      });
     });
 
     module('when there is no parent organization', function () {
@@ -129,6 +152,27 @@ module('Integration | Component | organizations/creation-form', function (hooks)
         assert.strictEqual(
           await screen.getByRole('button', { name: 'Équipe en charge *' }).innerText,
           'Sélectionner une équipe',
+        );
+      });
+
+      test('it does not prefill the type selector', async function (assert) {
+        // given - when
+        const screen = await render(
+          <template>
+            <CreationForm
+              @parentOrganization={{null}}
+              @administrationTeams={{administrationTeams}}
+              @countries={{countries}}
+              @onSubmit={{onSubmit}}
+              @onCancel={{onCancel}}
+            />
+          </template>,
+        );
+
+        // then
+        assert.strictEqual(
+          await screen.getByRole('button', { name: "Type de l'organisation *" }).innerText,
+          'Sélectionner un type',
         );
       });
     });

--- a/admin/tests/integration/components/organizations/creation-form-test.gjs
+++ b/admin/tests/integration/components/organizations/creation-form-test.gjs
@@ -87,6 +87,51 @@ module('Integration | Component | organizations/creation-form', function (hooks)
       assert.strictEqual(options[0].title, 'France (99100)');
       assert.strictEqual(options[1].title, 'Danemark (99101)');
     });
+
+    module('when there is a parent organization', function () {
+      test("it prefills the administration team selector with its parent's", async function (assert) {
+        // given - when
+        const organization = store.createRecord('organization', { administrationTeamId: 'team-1' });
+
+        const screen = await render(
+          <template>
+            <CreationForm
+              @parentOrganization={{organization}}
+              @administrationTeams={{administrationTeams}}
+              @countries={{countries}}
+              @onSubmit={{onSubmit}}
+              @onCancel={{onCancel}}
+            />
+          </template>,
+        );
+
+        // then
+        assert.strictEqual(await screen.getByRole('button', { name: 'Équipe en charge *' }).innerText, 'Équipe 1');
+      });
+    });
+
+    module('when there is no parent organization', function () {
+      test('it does not prefill the administration team selector', async function (assert) {
+        // given - when
+        const screen = await render(
+          <template>
+            <CreationForm
+              @parentOrganization={{null}}
+              @administrationTeams={{administrationTeams}}
+              @countries={{countries}}
+              @onSubmit={{onSubmit}}
+              @onCancel={{onCancel}}
+            />
+          </template>,
+        );
+
+        // then
+        assert.strictEqual(
+          await screen.getByRole('button', { name: 'Équipe en charge *' }).innerText,
+          'Sélectionner une équipe',
+        );
+      });
+    });
   });
 
   module('when submitting form', function () {


### PR DESCRIPTION
## ❄️ Problème

Lors de la création d'une organisation fille, certains champs ne sont pas pré-renseignés alors que leur valeur n'a pas de raison de changer.

## 🛷 Proposition

Pré-remplissage des valeurs : 
- Equipe en charge
- Type d’organisation
- Pays 
- URL De documentation

## ☃️ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🧑‍🎄 Pour tester

Sur Pix-Admin, créer une organisation fille et vérifier que les champs mentionnés sont pré-remplis.
Vérifier que les champs ne sont pas pré-remplis dans le cadre de la création d'une organisation mère.
