### PR TITLE
[FEATURE] Après envoi du signalement, afficher un message de confirmation (PIX-20913)

### DIFF
--- a/mon-pix/app/components/module/issue-report/issue-report-block.gjs
+++ b/mon-pix/app/components/module/issue-report/issue-report-block.gjs
@@ -10,11 +10,13 @@ import ModulixIssueReportModal from './issue-report-modal';
 export default class ModulixIssueReportBlock extends Component {
   @service featureToggles;
   @tracked showModal = false;
+  @tracked sentStatus = null;
   @service moduleIssueReport;
 
   @action
   onReportClick() {
     this.showModal = true;
+    this.sentStatus = null;
   }
 
   @action
@@ -23,13 +25,18 @@ export default class ModulixIssueReportBlock extends Component {
   }
 
   @action
-  onSend({ categoryKey, comment }) {
-    this.moduleIssueReport.record({
-      categoryKey,
-      comment,
-      elementId: this.args.reportInfo.elementId,
-      answer: this.args.reportInfo.answer,
-    });
+  async onSend({ categoryKey, comment }) {
+    try {
+      await this.moduleIssueReport.record({
+        categoryKey,
+        comment,
+        elementId: this.args.reportInfo.elementId,
+        answer: this.args.reportInfo.answer,
+      });
+      this.sentStatus = 'success';
+    } catch {
+      this.sentStatus = 'error';
+    }
   }
 
   <template>
@@ -47,6 +54,7 @@ export default class ModulixIssueReportBlock extends Component {
         @showModal={{this.showModal}}
         @hideModal={{this.hideModal}}
         @onSendReport={{this.onSend}}
+        @sentStatus={{this.sentStatus}}
       />
     {{/if}}
   </template>

--- a/mon-pix/app/components/module/issue-report/issue-report-modal.gjs
+++ b/mon-pix/app/components/module/issue-report/issue-report-modal.gjs
@@ -113,7 +113,7 @@ export default class ModulixIssueReportModal extends Component {
   @action
   resetForm() {
     const moduleIssueReportForm = document.getElementById('module-issue-report-form');
-    if(moduleIssueReportForm) {
+    if (moduleIssueReportForm) {
       moduleIssueReportForm.reset();
       this.selectedCategory = this.categories[0].value;
       this.comment = null;
@@ -121,7 +121,7 @@ export default class ModulixIssueReportModal extends Component {
   }
 
   <template>
-    <InElement @destinationId="modal-container">
+    <InElement @destinationId="modal-container" @waitForElement={{true}}>
       <PixModal
         class="issue-report-modal"
         @title={{t "pages.modulix.issue-report.modal.title"}}
@@ -178,10 +178,12 @@ export default class ModulixIssueReportModal extends Component {
             </div>
           {{else}}
             <ul class="issue-report-modal-form__action-buttons">
-              <li><PixButton @variant="secondary" @triggerAction={{this.hideModal}}>{{t
+              <li>
+                <PixButton @variant="secondary" @triggerAction={{this.hideModal}}>{{t
                     "common.actions.cancel"
                   }}</PixButton></li>
-              <li><PixButton @triggerAction={{this.sendReport}}>{{t "common.actions.send"}}</PixButton></li>
+              <li>
+                <PixButton @triggerAction={{this.sendReport}}>{{t "common.actions.send"}}</PixButton></li>
             </ul>
           {{/if}}
         </:footer>

--- a/mon-pix/app/components/module/issue-report/issue-report-modal.gjs
+++ b/mon-pix/app/components/module/issue-report/issue-report-modal.gjs
@@ -76,6 +76,15 @@ export default class ModulixIssueReportModal extends Component {
     }));
   }
 
+  get sentStatusMessage() {
+    if (!this.args.sentStatus) {
+      return '';
+    }
+    return this.args.sentStatus === 'success'
+      ? this.intl.t('pages.modulix.issue-report.modal.confirmation-message.success')
+      : this.intl.t('pages.modulix.issue-report.modal.confirmation-message.error');
+  }
+
   @action
   hideModal() {
     this.resetForm();
@@ -98,14 +107,17 @@ export default class ModulixIssueReportModal extends Component {
       return;
     }
     this.args.onSendReport({ categoryKey: this.selectedCategory, comment: this.comment });
-    this.hideModal();
+    this.resetForm();
   }
 
   @action
   resetForm() {
-    document.getElementById('module-issue-report-form').reset();
-    this.selectedCategory = this.categories[0].value;
-    this.comment = null;
+    const moduleIssueReportForm = document.getElementById('module-issue-report-form');
+    if(moduleIssueReportForm) {
+      moduleIssueReportForm.reset();
+      this.selectedCategory = this.categories[0].value;
+      this.comment = null;
+    }
   }
 
   <template>
@@ -117,49 +129,61 @@ export default class ModulixIssueReportModal extends Component {
         @showModal={{@showModal}}
       >
         <:content>
-          <p class="issue-report-modal__mandatory">
-            {{t "common.form.mandatory-all-fields"}}
-          </p>
-
-          <form class="issue-report-modal-form" id="module-issue-report-form">
-            <fieldset class="issue-report-modal-form__fieldset">
-              <legend class="sr-only">{{t "pages.modulix.issue-report.modal.legend"}}</legend>
-              <PixSelect
-                @hideDefaultOption={{true}}
-                @options={{this.categories}}
-                @value={{this.selectedCategory}}
-                @onChange={{this.onChangeCategory}}
-                required
-              >
-                <:label>{{t "pages.modulix.issue-report.modal.select-label"}}</:label>
-              </PixSelect>
-              <PixTextarea
-                class="issue-report-modal-form__comment"
-                @maxlength="200"
-                rows="5"
-                required
-                aria-required="true"
-                placeholder={{t "pages.modulix.issue-report.modal.textarea-placeholder"}}
-                {{on "input" this.onChangeComment}}
-              >
-                <:label>{{t "pages.modulix.issue-report.modal.textarea-label"}}</:label>
-              </PixTextarea>
-            </fieldset>
-          </form>
-
-          {{#if this.errorMessage}}
-            <PixNotificationAlert @type="error" class="issue-report-modal__error-message">
-              {{this.errorMessage}}
+          {{#if @sentStatus}}
+            <PixNotificationAlert @type={{@sentStatus}} @withIcon={{true}}>
+              {{this.sentStatusMessage}}
             </PixNotificationAlert>
+          {{else}}
+            <p class="issue-report-modal__mandatory">
+              {{t "common.form.mandatory-all-fields"}}
+            </p>
+
+            <form class="issue-report-modal-form" id="module-issue-report-form">
+              <fieldset class="issue-report-modal-form__fieldset">
+                <legend class="sr-only">{{t "pages.modulix.issue-report.modal.legend"}}</legend>
+                <PixSelect
+                  @hideDefaultOption={{true}}
+                  @options={{this.categories}}
+                  @value={{this.selectedCategory}}
+                  @onChange={{this.onChangeCategory}}
+                  required
+                >
+                  <:label>{{t "pages.modulix.issue-report.modal.select-label"}}</:label>
+                </PixSelect>
+                <PixTextarea
+                  class="issue-report-modal-form__comment"
+                  @maxlength="200"
+                  rows="5"
+                  required
+                  aria-required="true"
+                  placeholder={{t "pages.modulix.issue-report.modal.textarea-placeholder"}}
+                  {{on "input" this.onChangeComment}}
+                >
+                  <:label>{{t "pages.modulix.issue-report.modal.textarea-label"}}</:label>
+                </PixTextarea>
+              </fieldset>
+            </form>
+
+            {{#if this.errorMessage}}
+              <PixNotificationAlert @type="error" class="issue-report-modal__error-message">
+                {{this.errorMessage}}
+              </PixNotificationAlert>
+            {{/if}}
           {{/if}}
         </:content>
         <:footer>
-          <ul class="issue-report-modal-form__action-buttons">
-            <li><PixButton @variant="secondary" @triggerAction={{this.hideModal}}>{{t
-                  "common.actions.cancel"
-                }}</PixButton></li>
-            <li><PixButton @triggerAction={{this.sendReport}}>{{t "common.actions.send"}}</PixButton></li>
-          </ul>
+          {{#if @sentStatus}}
+            <div class="issue-report-modal-form__action-buttons">
+              <PixButton @triggerAction={{this.hideModal}}>{{t "common.actions.close"}}</PixButton>
+            </div>
+          {{else}}
+            <ul class="issue-report-modal-form__action-buttons">
+              <li><PixButton @variant="secondary" @triggerAction={{this.hideModal}}>{{t
+                    "common.actions.cancel"
+                  }}</PixButton></li>
+              <li><PixButton @triggerAction={{this.sendReport}}>{{t "common.actions.send"}}</PixButton></li>
+            </ul>
+          {{/if}}
         </:footer>
       </PixModal>
     </InElement>

--- a/mon-pix/app/services/module-issue-report.js
+++ b/mon-pix/app/services/module-issue-report.js
@@ -9,7 +9,7 @@ export default class ModuleIssueReport extends Service {
     this.passageId = passageId;
   }
 
-  record({ elementId, answer, categoryKey, comment }) {
+  async record({ elementId, answer, categoryKey, comment }) {
     const moduleIssueReport = {
       'module-id': this.moduleId,
       'passage-id': this.passageId,
@@ -19,7 +19,7 @@ export default class ModuleIssueReport extends Service {
       comment,
     };
 
-    this.requestManager.request({
+    await this.requestManager.request({
       url: `${ENV.APP.API_HOST}/api/module-issue-reports`,
       method: 'POST',
       body: JSON.stringify({ data: { attributes: moduleIssueReport, type: 'module-issue-reports' } }),

--- a/mon-pix/tests/acceptance/module/send-issue-report_test.js
+++ b/mon-pix/tests/acceptance/module/send-issue-report_test.js
@@ -77,6 +77,8 @@ module('Acceptance | Module | Routes | sendIssueReport', function (hooks) {
       );
 
       await click(screen.getByRole('button', { name: t('common.actions.send') }));
+      const closeButtons = screen.getAllByRole('button', { name: t('common.actions.close') });
+      await click(closeButtons[1]);
       await waitForDialogClose();
 
       // then

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1694,6 +1694,10 @@
               "response-issue": "I don't agree with the answer"
             }
           },
+          "confirmation-message": {
+            "error": "An error occurred when sending the comment.",
+            "success": "Thank you for your comment."
+          },
           "legend": "Information required to send a report",
           "select-label": "Reason for reporting",
           "textarea-label": "Comment",

--- a/mon-pix/translations/es-419.json
+++ b/mon-pix/translations/es-419.json
@@ -1690,6 +1690,10 @@
               "response-issue": "No estoy de acuerdo con la respuesta."
             }
           },
+          "confirmation-message": {
+            "error": "Se ha producido un error al enviar el comentario.",
+            "success": "Gracias, hemos tomado nota de su comentario."
+          },
           "legend": "Información necesaria para enviar una denuncia",
           "select-label": "Motivo de la notificación",
           "textarea-label": "Comentario",

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1690,6 +1690,10 @@
               "response-issue": "No estoy de acuerdo con la respuesta"
             }
           },
+          "confirmation-message": {
+            "error": "Se ha producido un error al enviar el comentario.",
+            "success": "Gracias, hemos tomado nota de su comentario."
+          },
           "legend": "Información necesaria para enviar una denuncia",
           "select-label": "Motivo de la notificación",
           "textarea-label": "Comentario",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1702,6 +1702,10 @@
               "response-issue": "Je ne suis pas d’accord avec la réponse"
             }
           },
+          "confirmation-message": {
+            "error": "Une erreur est survenue lors de l‘envoi du commentaire.",
+            "success": "Merci votre commentaire a été bien pris en compte."
+          },
           "legend": "Informations requises pour envoyer un signalement",
           "select-label": "Raison du signalement",
           "textarea-label": "Commentaire",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1694,6 +1694,10 @@
               "response-issue": "Ik ben het niet eens met het antwoord"
             }
           },
+          "confirmation-message": {
+            "error": "Er is een fout opgetreden bij het verzenden van de opmerking.",
+            "success": "Bedankt, uw opmerking is genoteerd."
+          },
           "legend": "Informatie die nodig is om een melding te versturen",
           "select-label": "Reden voor de melding",
           "textarea-label": "Opmerking",


### PR DESCRIPTION
## ❄️ Problème

Une fois qu'un utilisateur envoie son signalement, il ne reçoit pas de message qui confirmerait ou non que le signalement a bien été transmis.

## 🛷 Proposition

Après avoir cliqué sur "Envoyer" dans la modale de signalement, une notification est affichée dans la modale indiquant si oui, ou non, le signalement a bien été envoyé.
La notification est en vert en cas de succès, en rouge en cas d'erreur côté API.

Design proposé par Andreia et accepté par Pierre : 

<img width="1400" height="650" alt="Capture d’écran 2026-01-06 à 14 26 51" src="https://github.com/user-attachments/assets/fabd551a-355b-49de-bfea-40cbebd0b91c" />

## ☃️ Remarques

- On en a profité pour corriger le fait que la modale ne s'affichait pas pour certains éléments lorsqu'ils étaient dans le premier grain d'un module.

## 🧑‍🎄 Pour tester

### Message de confirmation OK
- Ouvrir le [bac-a-sable](https://app-pr14624.review.pix.fr/modules/6a68bf32/bac-a-sable/details)
- Afficher un feedback en répondant à un élément
- Cliquer sur "Signaler" et remplir la modale 
- Cliquer sur "Envoyer"
- Le formulaire disparaît et une notification dans la modale mentionne que le signalement a bien été envoyé
- Cliquer sur "Fermer", la modale doit se fermer.

### Fix de la modale pour un élément du premier grain
- Ouvrir le module [ia-def-ind](https://app-pr14624.review.pix.fr/modules/43e420e6/ia-def-ind) et commencer.
- Pour le POI message-conversation du premier grain, cliquer sur "Signaler"
- La modale de signalement doit s'ouvrir
