### PR TITLE
[FEATURE] Masquer le champ Lien si le champ Format d'un contenu formatif n'est pas renseigné sur Pix Admin (PIX-20918).

### DIFF
--- a/admin/app/components/trainings/create-or-update-training-form.gjs
+++ b/admin/app/components/trainings/create-or-update-training-form.gjs
@@ -123,15 +123,19 @@ export default class CreateOrUpdateTrainingForm extends Component {
           >
             <:label>Format</:label>
           </PixSelect>
-          <PixInput
-            @id="trainingLink"
-            required={{true}}
-            aria-required={{true}}
-            @value={{this.form.link}}
-            {{on "change" (fn this.updateForm "link")}}
-          >
-            <:label>Lien</:label>
-          </PixInput>
+
+          {{#if this.form.type}}
+            <PixInput
+              @id="trainingLink"
+              required={{true}}
+              aria-required={{true}}
+              @value={{this.form.link}}
+              {{on "change" (fn this.updateForm "link")}}
+            >
+              <:label>Lien</:label>
+            </PixInput>
+          {{/if}}
+
           <div class="admin-form--training__duration">
             <PixInput
               @id="trainingDaysDuration"

--- a/admin/app/components/trainings/create-or-update-training-form.gjs
+++ b/admin/app/components/trainings/create-or-update-training-form.gjs
@@ -113,15 +113,6 @@ export default class CreateOrUpdateTrainingForm extends Component {
           >
             <:label>{{t "pages.trainings.training.details.internalTitle"}}</:label>
           </PixInput>
-          <PixInput
-            @id="trainingLink"
-            required={{true}}
-            aria-required={{true}}
-            @value={{this.form.link}}
-            {{on "change" (fn this.updateForm "link")}}
-          >
-            <:label>Lien</:label>
-          </PixInput>
           <PixSelect
             @placeholder="-- Sélectionnez un format --"
             @value={{this.form.type}}
@@ -132,6 +123,15 @@ export default class CreateOrUpdateTrainingForm extends Component {
           >
             <:label>Format</:label>
           </PixSelect>
+          <PixInput
+            @id="trainingLink"
+            required={{true}}
+            aria-required={{true}}
+            @value={{this.form.link}}
+            {{on "change" (fn this.updateForm "link")}}
+          >
+            <:label>Lien</:label>
+          </PixInput>
           <div class="admin-form--training__duration">
             <PixInput
               @id="trainingDaysDuration"

--- a/admin/app/components/trainings/create-or-update-training-form.gjs
+++ b/admin/app/components/trainings/create-or-update-training-form.gjs
@@ -5,9 +5,11 @@ import PixSelect from '@1024pix/pix-ui/components/pix-select';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
+import { eq } from 'ember-truth-helpers';
 import set from 'lodash/set';
 
 import { optionsLocaleList, optionsTypeList } from '../../models/training';
@@ -42,6 +44,8 @@ class Form {
 }
 
 export default class CreateOrUpdateTrainingForm extends Component {
+  @service featureToggles;
+
   @tracked submitting = false;
 
   constructor() {
@@ -125,15 +129,31 @@ export default class CreateOrUpdateTrainingForm extends Component {
           </PixSelect>
 
           {{#if this.form.type}}
-            <PixInput
-              @id="trainingLink"
-              required={{true}}
-              aria-required={{true}}
-              @value={{this.form.link}}
-              {{on "change" (fn this.updateForm "link")}}
-            >
-              <:label>Lien</:label>
-            </PixInput>
+            {{#if this.featureToggles.featureToggles.isModuleSelectionForTrainingEnabled}}
+              {{#if (eq this.form.type "modulix")}}
+                <p>Todo : Ajouter un Pix Select "Lien" listant les modules</p>
+              {{else}}
+                <PixInput
+                  @id="trainingLink"
+                  required={{true}}
+                  aria-required={{true}}
+                  @value={{this.form.link}}
+                  {{on "change" (fn this.updateForm "link")}}
+                >
+                  <:label>Lien</:label>
+                </PixInput>
+              {{/if}}
+            {{else}}
+              <PixInput
+                @id="trainingLink"
+                required={{true}}
+                aria-required={{true}}
+                @value={{this.form.link}}
+                {{on "change" (fn this.updateForm "link")}}
+              >
+                <:label>Lien</:label>
+              </PixInput>
+            {{/if}}
           {{/if}}
 
           <div class="admin-form--training__duration">

--- a/admin/tests/acceptance/authenticated/trainings/training-test.js
+++ b/admin/tests/acceptance/authenticated/trainings/training-test.js
@@ -82,8 +82,8 @@ module('Acceptance | Trainings | Training', function (hooks) {
 
         await fillByLabel(t('pages.trainings.training.details.title'), 'Nouveau contenu formatif');
         await fillByLabel(t('pages.trainings.training.details.internalTitle'), 'Mon titre interne');
-        await fillByLabel('Lien', 'http://www.example.net');
         await click(screen.getByText('Webinaire'));
+        await fillByLabel('Lien', 'http://www.example.net');
 
         await fillByLabel('Jours (JJ)', 1);
         await fillByLabel('Heures (HH)', 0);

--- a/admin/tests/integration/components/trainings/create-or-update-training-form-test.gjs
+++ b/admin/tests/integration/components/trainings/create-or-update-training-form-test.gjs
@@ -67,27 +67,6 @@ module('Integration | Component | trainings | CreateOrUpdateTrainingForm', funct
     assert.ok(onCancel.called);
   });
 
-  module('when type is provided', function () {
-    test('it should display the link field', async function (assert) {
-      // given
-      // when
-      const screen = await render(
-        <template><CreateOrUpdateTrainingForm @onSubmit={{onSubmit}} @onCancel={{onCancel}} /></template>,
-      );
-
-      //then
-      assert.dom(screen.queryByRole('textbox', { name: 'Lien' })).doesNotExist();
-
-      // when
-      await click(screen.getByRole('button', { name: 'Format' }));
-      await screen.findByRole('listbox');
-      await click(screen.getByRole('option', { name: 'Webinaire' }));
-
-      // then
-      assert.dom(screen.getByRole('textbox', { name: 'Lien' })).exists();
-    });
-  });
-
   module('when model is provided', function () {
     test('it should display the items with model values', async function (assert) {
       // given
@@ -209,6 +188,72 @@ module('Integration | Component | trainings | CreateOrUpdateTrainingForm', funct
       assert.ok(onSubmitStub.called);
       const submittedData = onSubmitStub.getCall(0).firstArg;
       assert.true(submittedData.isDisabled);
+    });
+  });
+
+  module('when isModuleSelectionForTrainingEnabled FT is enabled', function () {
+    module('when type provided is modulix', function () {
+      test('it should display the todo link selector', async function (assert) {
+        // given
+        const featureToggles = this.owner.lookup('service:featureToggles');
+        sinon.stub(featureToggles, 'featureToggles').value({ isModuleSelectionForTrainingEnabled: true });
+
+        // when
+        const screen = await render(
+          <template><CreateOrUpdateTrainingForm @onSubmit={{onSubmit}} @onCancel={{onCancel}} /></template>,
+        );
+
+        await click(screen.getByRole('button', { name: 'Format' }));
+        await screen.findByRole('listbox');
+        await click(screen.getByRole('option', { name: 'Module Pix' }));
+
+        // then
+        assert.dom(screen.queryByRole('textbox', { name: 'Lien' })).doesNotExist();
+        assert.dom(screen.getByText('Todo : Ajouter un Pix Select "Lien" listant les modules')).exists();
+      });
+    });
+
+    module('when type provided is not modulix', function () {
+      test('it should display the link field', async function (assert) {
+        // given
+        const featureToggles = this.owner.lookup('service:featureToggles');
+        sinon.stub(featureToggles, 'featureToggles').value({ isModuleSelectionForTrainingEnabled: true });
+
+        // when
+        const screen = await render(
+          <template><CreateOrUpdateTrainingForm @onSubmit={{onSubmit}} @onCancel={{onCancel}} /></template>,
+        );
+
+        await click(screen.getByRole('button', { name: 'Format' }));
+        await screen.findByRole('listbox');
+        await click(screen.getByRole('option', { name: 'Webinaire' }));
+
+        // then
+        assert.dom(screen.getByRole('textbox', { name: 'Lien' })).exists();
+      });
+    });
+  });
+
+  module('when isModuleSelectionForTrainingEnabled FT is disabled', function () {
+    module('when type is provided', function () {
+      test('it should display the link field', async function (assert) {
+        // given
+        // when
+        const screen = await render(
+          <template><CreateOrUpdateTrainingForm @onSubmit={{onSubmit}} @onCancel={{onCancel}} /></template>,
+        );
+
+        //then
+        assert.dom(screen.queryByRole('textbox', { name: 'Lien' })).doesNotExist();
+
+        // when
+        await click(screen.getByRole('button', { name: 'Format' }));
+        await screen.findByRole('listbox');
+        await click(screen.getByRole('option', { name: 'Module Pix' }));
+
+        // then
+        assert.dom(screen.getByRole('textbox', { name: 'Lien' })).exists();
+      });
     });
   });
 });

--- a/admin/tests/integration/components/trainings/create-or-update-training-form-test.gjs
+++ b/admin/tests/integration/components/trainings/create-or-update-training-form-test.gjs
@@ -23,7 +23,6 @@ module('Integration | Component | trainings | CreateOrUpdateTrainingForm', funct
     // then
     assert.dom(screen.getByLabelText(t('pages.trainings.training.details.title'))).exists();
     assert.dom(screen.getByLabelText(t('pages.trainings.training.details.internalTitle'))).exists();
-    assert.dom(screen.getByLabelText('Lien')).exists();
     assert.dom(screen.getByLabelText('Format')).exists();
     assert.dom(screen.getByLabelText('Jours (JJ)')).exists();
     assert.dom(screen.getByLabelText('Heures (HH)')).exists();
@@ -66,6 +65,27 @@ module('Integration | Component | trainings | CreateOrUpdateTrainingForm', funct
 
     // then
     assert.ok(onCancel.called);
+  });
+
+  module('when type is provided', function () {
+    test('it should display the link field', async function (assert) {
+      // given
+      // when
+      const screen = await render(
+        <template><CreateOrUpdateTrainingForm @onSubmit={{onSubmit}} @onCancel={{onCancel}} /></template>,
+      );
+
+      //then
+      assert.dom(screen.queryByRole('textbox', { name: 'Lien' })).doesNotExist();
+
+      // when
+      await click(screen.getByRole('button', { name: 'Format' }));
+      await screen.findByRole('listbox');
+      await click(screen.getByRole('option', { name: 'Webinaire' }));
+
+      // then
+      assert.dom(screen.getByRole('textbox', { name: 'Lien' })).exists();
+    });
   });
 
   module('when model is provided', function () {


### PR DESCRIPTION
## ❄️ Problème

Aujourd'hui lors de la création ou mise à jour d'une contenu formatif, si ce dernier concerne les modules Pix, le champs Lien se présente comme un simple champ texte pour accueillir un lien menant au module. Or ce format de champ est un risque que l'on fasse des coquilles, des erreurs en tout genre.

## 🛷 Proposition

Ici plusieurs choses : 
- on inverse le champs Format et Lien.
- on masque le champ Lien tant que Format n'a pas été rempli (ça permettra d'afficher le champ texte ou le futur sélecteur selon le choix)
- on affiche, sous FT, le champ Lien texte ou un todo sélecteur selon le choix dans Format

## ☃️ Remarques
> [!TIP]
> Je vous invite à faire la review commit par commit 

## 🧑‍🎄 Pour tester

FT à true

Création d'un contenu formatif : 

-  Aller ici https://admin-pr14626.review.pix.fr/trainings/new
- constater qu'il y a le champ Format mais pas le champ Lien
- Remplir le Format > Wébinaire
- Constater que le champ Lien apparaît, en format texte
- Remplir le Format > Module Pix
- Voir qu'à la place du champ Lien, un todo pour le futur sélecteur

https://github.com/user-attachments/assets/cb4e1773-913d-448d-b0d0-6d19f60afc66

---

Mise à jour d'un contenu formatif : 

- Aller ici https://admin-pr14626.review.pix.fr/trainings/8000/triggers
- Modifier ce contenu formatif
- Constater que le champ Lien ici c'est pas caché puisque renseigné
- Modifier le format > Module Pix
- Voir qu'à la place du champ Lien, un todo pour le futur sélecteur


https://github.com/user-attachments/assets/be10a769-64b5-4c9e-9cd1-702e34219ba4


FT à false

Faire la même manip mais le todo sélecteur n'apparaît pas
