### PR TITLE
[TECH] Ajouter la table combined_course_blueprint_shares (PIX-20994)

### DIFF
--- a/api/db/migrations/20260107083850_add-combined-course-blueprint-shares.js
+++ b/api/db/migrations/20260107083850_add-combined-course-blueprint-shares.js
@@ -1,0 +1,33 @@
+const TABLE_NAME = 'combined_course_blueprint_shares';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.createTable(TABLE_NAME, function (table) {
+    table.increments('id').primary().comment('Combined course blueprint share identifier');
+    table
+      .integer('organizationId')
+      .notNullable()
+      .references('organizations.id')
+      .comment("Organization id - see 'organizations' table");
+    table
+      .integer('combinedCourseBlueprintId')
+      .notNullable()
+      .references('combined_course_blueprints.id')
+      .comment("CombinedCourseBlueprint id - see 'combined_course_blueprints' table");
+    table.unique(['organizationId', 'combinedCourseBlueprintId']);
+    table.comment('This table references which organization have access to which combined course blueprint');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  return knex.schema.dropTable(TABLE_NAME);
+};
+
+export { down, up };


### PR DESCRIPTION
## ❄️ Problème

On n'a pas de table pour stocker les liaisons entre organization et schéma de parcours

## 🛷 Proposition

on crée une nouvelle table

## ☃️ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🧑‍🎄 Pour tester

se connecter sur le cli scalingo pgsql-console
lancer la commande `\d+ combined_course_blueprint_shares`
se connecter sur le container de l'api et faire un `npm run db:rollback:latest` puis `npm run db:migrate`
