### PR TITLE
[TECH] Déplacer le mapping de statut TO_SHARE vers la couche de sérialisation (PIX-21015)

### DIFF
--- a/api/src/prescription/campaign-participation/domain/read-models/CampaignParticipationOverview.js
+++ b/api/src/prescription/campaign-participation/domain/read-models/CampaignParticipationOverview.js
@@ -4,7 +4,7 @@ import _ from 'lodash';
 import { MAX_MASTERY_RATE, MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING } from '../../../../shared/domain/constants.js';
 import { CampaignParticipationStatuses, CampaignTypes } from '../../../shared/domain/constants.js';
 
-const { SHARED, TO_SHARE, STARTED } = CampaignParticipationStatuses;
+const { SHARED } = CampaignParticipationStatuses;
 
 class CampaignParticipationOverview {
   constructor({
@@ -35,7 +35,7 @@ class CampaignParticipationOverview {
     this.isShared = status === SHARED;
     this.sharedAt = sharedAt;
     this.organizationName = organizationName;
-    this.status = status === TO_SHARE ? STARTED : status; // TODO: remove this mapping once the status is migrated
+    this.status = status;
     this.campaignId = campaignId;
     this.campaignCode = campaignCode;
     this.campaignTitle = campaignTitle;

--- a/api/src/prescription/campaign-participation/infrastructure/serializers/jsonapi/campaign-participation-overview-serializer.js
+++ b/api/src/prescription/campaign-participation/infrastructure/serializers/jsonapi/campaign-participation-overview-serializer.js
@@ -1,6 +1,9 @@
 import jsonapiSerializer from 'jsonapi-serializer';
 
+import { CampaignParticipationStatuses } from '../../../../shared/domain/constants.js';
+
 const { Serializer } = jsonapiSerializer;
+const { TO_SHARE, STARTED } = CampaignParticipationStatuses;
 
 const serialize = function (campaignParticipationOverviews) {
   return new Serializer('campaign-participation-overview', {
@@ -19,6 +22,14 @@ const serialize = function (campaignParticipationOverviews) {
       'canRetry',
       'campaignType',
     ],
+    transform(record) {
+      const transformed = { ...record };
+      // TODO: remove this mapping once the status is migrated
+      if (transformed.status === TO_SHARE) {
+        transformed.status = STARTED;
+      }
+      return transformed;
+    },
   }).serialize(campaignParticipationOverviews);
 };
 

--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-overview-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-overview-repository_test.js
@@ -262,7 +262,7 @@ describe('Integration | Repository | Campaign Participation Overview', function 
         organizationLearnerId,
       });
 
-      expect(campaignParticipation.status).to.equal(CampaignParticipationStatuses.STARTED);
+      expect(campaignParticipation.status).to.equal(CampaignParticipationStatuses.TO_SHARE);
     });
 
     it('retrieves the delete date', async function () {
@@ -485,7 +485,7 @@ describe('Integration | Repository | Campaign Participation Overview', function 
           userId,
         });
 
-        expect(campaignParticipation.status).to.equal(CampaignParticipationStatuses.STARTED);
+        expect(campaignParticipation.status).to.equal(CampaignParticipationStatuses.TO_SHARE);
       });
 
       it('retrieves the delete date', async function () {

--- a/api/tests/prescription/campaign-participation/unit/infrastructure/serializers/jsonapi/campaign-participation-overview-serializer_test.js
+++ b/api/tests/prescription/campaign-participation/unit/infrastructure/serializers/jsonapi/campaign-participation-overview-serializer_test.js
@@ -6,7 +6,7 @@ import {
 } from '../../../../../../../src/prescription/shared/domain/constants.js';
 import { expect } from '../../../../../../test-helper.js';
 
-const { SHARED } = CampaignParticipationStatuses;
+const { SHARED, TO_SHARE, STARTED } = CampaignParticipationStatuses;
 
 describe('Unit | Serializer | JSONAPI | campaign-participation-overview-serializer', function () {
   describe('#serialize', function () {
@@ -101,6 +101,26 @@ describe('Unit | Serializer | JSONAPI | campaign-participation-overview-serializ
 
       // then
       expect(json.data.attributes['can-retry']).to.be.false;
+    });
+
+    it('should map TO_SHARE status to STARTED in serialized output', function () {
+      // given
+      const campaignParticipationOverview = new CampaignParticipationOverview({
+        id: 8,
+        status: TO_SHARE,
+        createdAt: new Date('2018-02-05T14:12:44Z'),
+        sharedAt: null,
+        organizationName: 'My organization',
+        campaignCode: '1234',
+        campaignTitle: 'My campaign',
+        campaignType: CampaignTypes.ASSESSMENT,
+      });
+
+      // when
+      const json = serializer.serialize(campaignParticipationOverview);
+
+      // then
+      expect(json.data.attributes.status).to.equal(STARTED);
     });
   });
 });

--- a/api/tests/prescription/organization-learner/unit/application/api/models/OrganizationLearnerWithParticipations_test.js
+++ b/api/tests/prescription/organization-learner/unit/application/api/models/OrganizationLearnerWithParticipations_test.js
@@ -68,7 +68,7 @@ describe('Unit | Application| API | Models | OrganizationLearnerWithParticipatio
       {
         targetProfileId: 654,
         id: 456,
-        status: CampaignParticipationStatuses.STARTED,
+        status: CampaignParticipationStatuses.TO_SHARE,
         campaignName: 'Mon nom 2',
         campaignId: 77,
         masteryRate: 80,


### PR DESCRIPTION
## ❄️ Problème

Le mapping du statut `TO_SHARE` vers `STARTED` est effectué dans le read model `CampaignParticipationOverview`, ce qui engendre un bug sur l'obtention des attestations. En effet le usecase se base sur ce model pour tester l'éligibilité des quêtes et le statut attendu n'est pas le bon.

## 🛷 Proposition

- Déplacer le mapping `TO_SHARE` → `STARTED` du read model vers le serializer
- Le read model conserve maintenant le statut original

## 🧑‍🎄 Pour tester

- Tester l'obtention d'une attestation
- Tester l'affichage des `participation overviews cards` sur le front ( l'utilisateur Perfect Profile User a obtenu une attestation et a une participation definie manuellement en statut  TO_SHARE )