### PR TITLE
[TECH] Renommer le script d'attestation et mettre à jour les profils cibles (PIX-21015)

### DIFF
--- a/api/src/profile/scripts/attestation-reward-recovery.js
+++ b/api/src/profile/scripts/attestation-reward-recovery.js
@@ -7,7 +7,7 @@ import { Script } from '../../shared/application/scripts/script.js';
 import { ScriptRunner } from '../../shared/application/scripts/script-runner.js';
 import { DomainTransaction } from '../../shared/domain/DomainTransaction.js';
 
-export const PRODUCTION_SIXTH_GRADE_TARGET_PROFILE_IDS = [3652, 3739, 3740, 3923, 3924, 3925];
+export const TARGET_PROFILE_IDS = [6078, 6079, 6080, 6081, 6082, 6083, 6155];
 
 const options = {
   start: {
@@ -26,15 +26,12 @@ const options = {
   },
 };
 
-/**
- * Script to reward sixth-grade students who have already completed a campaign linked to a specific target profile.
- */
-export class SixthGradeAttestationRewardScript extends Script {
+export class AttestationRewardRecoveryScript extends Script {
   constructor() {
     super({
       description:
         'This script process attestations rewards for users who have already completed a campaign linked to specific target profiles.',
-      permanent: false,
+      permanent: true,
       options,
     });
   }
@@ -91,7 +88,7 @@ export class SixthGradeAttestationRewardScript extends Script {
       .where('campaign-participations.createdAt', '>=', formatedStartDate)
       .where('campaign-participations.createdAt', '<=', formatedEndDate)
       .where('campaign-participations.status', '<>', CampaignParticipationStatuses.STARTED)
-      .whereIn('campaigns.targetProfileId', PRODUCTION_SIXTH_GRADE_TARGET_PROFILE_IDS);
+      .whereIn('campaigns.targetProfileId', TARGET_PROFILE_IDS);
 
     return users.map(({ userId }) => userId);
   }
@@ -116,4 +113,4 @@ export class SixthGradeAttestationRewardScript extends Script {
   }
 }
 
-await ScriptRunner.execute(import.meta.url, SixthGradeAttestationRewardScript);
+await ScriptRunner.execute(import.meta.url, AttestationRewardRecoveryScript);

--- a/api/tests/profile/integration/scripts/attestation-reward-recovery_test.js
+++ b/api/tests/profile/integration/scripts/attestation-reward-recovery_test.js
@@ -2,9 +2,9 @@ import sinon from 'sinon';
 
 import { CampaignParticipationStatuses } from '../../../../src/prescription/shared/domain/constants.js';
 import {
-  PRODUCTION_SIXTH_GRADE_TARGET_PROFILE_IDS,
-  SixthGradeAttestationRewardScript,
-} from '../../../../src/profile/scripts/sixth-grade-attestation-reward.js';
+  AttestationRewardRecoveryScript,
+  TARGET_PROFILE_IDS,
+} from '../../../../src/profile/scripts/attestation-reward-recovery.js';
 import { catchErr, databaseBuilder, expect } from '../../../test-helper.js';
 
 describe('Integration | Profile | Scripts | sixth-grade-attestation-reward', function () {
@@ -12,7 +12,7 @@ describe('Integration | Profile | Scripts | sixth-grade-attestation-reward', fun
     it('parses dates correctly', function () {
       const startDate = '2024-01-01';
       const endDate = { whut: 'idontknow' };
-      const script = new SixthGradeAttestationRewardScript();
+      const script = new AttestationRewardRecoveryScript();
       const { options } = script.metaInfo;
       const parsedDate = options.start.coerce(startDate);
       expect(parsedDate).to.be.a.instanceOf(Date);
@@ -24,12 +24,12 @@ describe('Integration | Profile | Scripts | sixth-grade-attestation-reward', fun
     let script;
 
     beforeEach(async function () {
-      script = new SixthGradeAttestationRewardScript();
+      script = new AttestationRewardRecoveryScript();
     });
 
     it('should not return the user if the participation date is not included between the start date and the end date ', async function () {
       const { id: targetProfileId } = databaseBuilder.factory.buildTargetProfile({
-        id: PRODUCTION_SIXTH_GRADE_TARGET_PROFILE_IDS[0],
+        id: TARGET_PROFILE_IDS[0],
       });
       const campaign = databaseBuilder.factory.buildCampaign({ targetProfileId });
       const { userId } = databaseBuilder.factory.buildCampaignParticipation({
@@ -56,7 +56,7 @@ describe('Integration | Profile | Scripts | sixth-grade-attestation-reward', fun
 
     it('should only return the user if participation status is different than started', async function () {
       const { id: targetProfileId } = databaseBuilder.factory.buildTargetProfile({
-        id: PRODUCTION_SIXTH_GRADE_TARGET_PROFILE_IDS[0],
+        id: TARGET_PROFILE_IDS[0],
       });
       const campaign = databaseBuilder.factory.buildCampaign({ targetProfileId });
       const { userId } = databaseBuilder.factory.buildCampaignParticipation({
@@ -83,13 +83,13 @@ describe('Integration | Profile | Scripts | sixth-grade-attestation-reward', fun
 
     it('should not return the user if the campaign target profile is not included in targeted target profiles', async function () {
       const { id: targetProfileId1 } = databaseBuilder.factory.buildTargetProfile({
-        id: PRODUCTION_SIXTH_GRADE_TARGET_PROFILE_IDS[0],
+        id: TARGET_PROFILE_IDS[0],
       });
       const { id: targetProfileId2 } = databaseBuilder.factory.buildTargetProfile({
-        id: PRODUCTION_SIXTH_GRADE_TARGET_PROFILE_IDS[1],
+        id: TARGET_PROFILE_IDS[1],
       });
       const { id: targetProfileId3 } = databaseBuilder.factory.buildTargetProfile({
-        id: PRODUCTION_SIXTH_GRADE_TARGET_PROFILE_IDS[2],
+        id: TARGET_PROFILE_IDS[2],
       });
       const { id: targetProfileId4 } = databaseBuilder.factory.buildTargetProfile();
       const campaign1 = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfileId1 });
@@ -123,13 +123,13 @@ describe('Integration | Profile | Scripts | sixth-grade-attestation-reward', fun
 
     it('should return a user only once if the user has several participations for several campaigns including the targeted target profiles', async function () {
       const { id: targetProfileId1 } = databaseBuilder.factory.buildTargetProfile({
-        id: PRODUCTION_SIXTH_GRADE_TARGET_PROFILE_IDS[0],
+        id: TARGET_PROFILE_IDS[0],
       });
       const { id: targetProfileId2 } = databaseBuilder.factory.buildTargetProfile({
-        id: PRODUCTION_SIXTH_GRADE_TARGET_PROFILE_IDS[1],
+        id: TARGET_PROFILE_IDS[1],
       });
       const { id: targetProfileId3 } = databaseBuilder.factory.buildTargetProfile({
-        id: PRODUCTION_SIXTH_GRADE_TARGET_PROFILE_IDS[2],
+        id: TARGET_PROFILE_IDS[2],
       });
 
       const user = databaseBuilder.factory.buildUser();
@@ -168,13 +168,13 @@ describe('Integration | Profile | Scripts | sixth-grade-attestation-reward', fun
 
     it('should return expected users', async function () {
       const { id: targetProfileId1 } = databaseBuilder.factory.buildTargetProfile({
-        id: PRODUCTION_SIXTH_GRADE_TARGET_PROFILE_IDS[0],
+        id: TARGET_PROFILE_IDS[0],
       });
       const { id: targetProfileId2 } = databaseBuilder.factory.buildTargetProfile({
-        id: PRODUCTION_SIXTH_GRADE_TARGET_PROFILE_IDS[1],
+        id: TARGET_PROFILE_IDS[1],
       });
       const { id: targetProfileId3 } = databaseBuilder.factory.buildTargetProfile({
-        id: PRODUCTION_SIXTH_GRADE_TARGET_PROFILE_IDS[2],
+        id: TARGET_PROFILE_IDS[2],
       });
       const campaign1 = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfileId1 });
       const campaign2 = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfileId2 });
@@ -214,13 +214,13 @@ describe('Integration | Profile | Scripts | sixth-grade-attestation-reward', fun
   describe('#handle', function () {
     it('should log information for each userId', async function () {
       const { id: targetProfileId1 } = databaseBuilder.factory.buildTargetProfile({
-        id: PRODUCTION_SIXTH_GRADE_TARGET_PROFILE_IDS[2],
+        id: TARGET_PROFILE_IDS[2],
       });
       const { id: targetProfileId2 } = databaseBuilder.factory.buildTargetProfile({
-        id: PRODUCTION_SIXTH_GRADE_TARGET_PROFILE_IDS[0],
+        id: TARGET_PROFILE_IDS[0],
       });
       const { id: targetProfileId3 } = databaseBuilder.factory.buildTargetProfile({
-        id: PRODUCTION_SIXTH_GRADE_TARGET_PROFILE_IDS[1],
+        id: TARGET_PROFILE_IDS[1],
       });
       const campaign1 = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfileId1 });
       const campaign2 = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfileId2 });
@@ -243,7 +243,7 @@ describe('Integration | Profile | Scripts | sixth-grade-attestation-reward', fun
 
       await databaseBuilder.commit();
 
-      const script = new SixthGradeAttestationRewardScript();
+      const script = new AttestationRewardRecoveryScript();
       const logger = { info: sinon.spy(), error: sinon.spy() };
       const usecases = { rewardUser: sinon.stub() };
 
@@ -260,7 +260,7 @@ describe('Integration | Profile | Scripts | sixth-grade-attestation-reward', fun
     });
 
     it('should throw an error if end comes before start.', async function () {
-      const script = new SixthGradeAttestationRewardScript();
+      const script = new AttestationRewardRecoveryScript();
       const logger = { info: sinon.spy(), error: sinon.spy() };
       const usecases = { rewardUser: sinon.stub() };
 
@@ -277,7 +277,7 @@ describe('Integration | Profile | Scripts | sixth-grade-attestation-reward', fun
     });
 
     it('should stop execution if there are no users', async function () {
-      const script = new SixthGradeAttestationRewardScript();
+      const script = new AttestationRewardRecoveryScript();
       const logger = { info: sinon.spy(), error: sinon.spy() };
       const usecases = { rewardUser: sinon.stub() };
 


### PR DESCRIPTION
## ❄️ Problème

Le script `sixth-grade-attestation-reward.js` était spécifique aux élèves de 6ème et utilisait des IDs de profils cibles obsolètes. Le nom du script et de la classe ne reflétaient pas son usage plus général pour la récupération de récompenses d'attestation.

## 🛷 Proposition

### Renommage pour généralisation :
- **Fichier** : `sixth-grade-attestation-reward.js` → `attestation-reward-recovery.js`
- **Classe** : `SixthGradeAttestationRewardScript` → `AttestationRewardRecoveryScript`
- **Constante** : `PRODUCTION_SIXTH_GRADE_TARGET_PROFILE_IDS` → `TARGET_PROFILE_IDS`

## ☃️ Remarques

Ce renommage permet :
- Une meilleure réutilisabilité du script pour d'autres niveaux scolaires
- Une mise à jour vers les profils cibles actuellement utilisés en production
- Une meilleure clarté sur l'objectif du script (récupération de récompenses d'attestation)

## 🧑‍🎄 Pour tester

Exécuter les tests d'intégration :
```bash
npm run test:api:path -- 'tests/profile/integration/scripts/sixth-grade-attestation-reward_test.js'
```

Vérifier que le script peut être exécuté :
```bash
node api/src/profile/scripts/attestation-reward-recovery.js --start 2024-01-01 --end 2024-12-31
```