### PR TITLE
[FEATURE] Ajout d'un filtre sur les centres archivés dans pix-admin (PIX-20021).

### DIFF
--- a/admin/app/components/certification-centers/list-items.gjs
+++ b/admin/app/components/certification-centers/list-items.gjs
@@ -9,24 +9,28 @@ import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 
 export default class CertificationCenterListItems extends Component {
-  searchedId = this.args.id;
-  searchedName = this.args.name;
-  searchedType = this.args.type;
-  searchedExternalId = this.args.externalId;
+  get isClearFiltersButtonDisabled() {
+    return !this.args.id && !this.args.name && !this.args.type && !this.args.externalId;
+  }
 
   <template>
     <div class="certification-centers-list">
-      <PixFilterBanner @title={{t "common.filters.title"}}>
-        <PixInput value={{this.searchedId}} oninput={{fn @triggerFiltering "id"}} type="number">
+      <PixFilterBanner
+        @title={{t "common.filters.title"}}
+        @clearFiltersLabel={{t "common.filters.actions.clear"}}
+        @isClearFilterButtonDisabled={{this.isClearFiltersButtonDisabled}}
+        @onClearFilters={{@onResetFilter}}
+      >
+        <PixInput value={{@id}} oninput={{fn @triggerFiltering "id"}} type="number">
           <:label>Identifiant</:label>
         </PixInput>
-        <PixInput value={{this.searchedName}} oninput={{fn @triggerFiltering "name"}}>
+        <PixInput value={{@name}} oninput={{fn @triggerFiltering "name"}}>
           <:label>Nom</:label>
         </PixInput>
-        <PixInput value={{this.searchedType}} oninput={{fn @triggerFiltering "type"}}>
+        <PixInput value={{@type}} oninput={{fn @triggerFiltering "type"}}>
           <:label>Type</:label>
         </PixInput>
-        <PixInput value={{this.searchedExternalId}} oninput={{fn @triggerFiltering "externalId"}}>
+        <PixInput value={{@externalId}} oninput={{fn @triggerFiltering "externalId"}}>
           <:label>ID externe</:label>
         </PixInput>
       </PixFilterBanner>

--- a/admin/app/components/certification-centers/list-items.gjs
+++ b/admin/app/components/certification-centers/list-items.gjs
@@ -3,14 +3,22 @@ import PixInput from '@1024pix/pix-ui/components/pix-input';
 import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
 import PixTable from '@1024pix/pix-ui/components/pix-table';
 import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import PixToggleButton from '@1024pix/pix-ui/components/pix-toggle-button';
 import { fn } from '@ember/helper';
+import { action } from '@ember/object';
 import { LinkTo } from '@ember/routing';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 
 export default class CertificationCenterListItems extends Component {
   get isClearFiltersButtonDisabled() {
-    return !this.args.id && !this.args.name && !this.args.type && !this.args.externalId;
+    return !this.args.id && !this.args.name && !this.args.type && !this.args.externalId && !this.args.hideArchived;
+  }
+
+  @action
+  filterHideArchived(value) {
+    const event = { target: { value } };
+    this.args.triggerFiltering('hideArchived', event);
   }
 
   <template>
@@ -33,6 +41,11 @@ export default class CertificationCenterListItems extends Component {
         <PixInput value={{@externalId}} oninput={{fn @triggerFiltering "externalId"}}>
           <:label>ID externe</:label>
         </PixInput>
+        <PixToggleButton @onChange={{this.filterHideArchived}} @toggled={{@hideArchived}}>
+          <:label>Masquer les centres archivés</:label>
+          <:viewA>Oui</:viewA>
+          <:viewB>Non</:viewB>
+        </PixToggleButton>
       </PixFilterBanner>
 
       {{#if @certificationCenters}}

--- a/admin/app/controllers/authenticated/certification-centers/list.js
+++ b/admin/app/controllers/authenticated/certification-centers/list.js
@@ -28,4 +28,12 @@ export default class ListController extends Controller {
   triggerFiltering(fieldName, event) {
     debounceTask(this, 'updateFilters', { [fieldName]: event.target.value }, this.DEBOUNCE_MS);
   }
+
+  @action
+  onResetFilter() {
+    this.id = null;
+    this.name = null;
+    this.type = null;
+    this.externalId = null;
+  }
 }

--- a/admin/app/controllers/authenticated/certification-centers/list.js
+++ b/admin/app/controllers/authenticated/certification-centers/list.js
@@ -7,7 +7,7 @@ import config from 'pix-admin/config/environment';
 const DEFAULT_PAGE_NUMBER = 1;
 
 export default class ListController extends Controller {
-  queryParams = ['pageNumber', 'pageSize', 'id', 'name', 'type', 'externalId'];
+  queryParams = ['pageNumber', 'pageSize', 'id', 'name', 'type', 'externalId', 'hideArchived'];
   DEBOUNCE_MS = config.pagination.debounce;
 
   @tracked pageNumber = DEFAULT_PAGE_NUMBER;
@@ -16,6 +16,7 @@ export default class ListController extends Controller {
   @tracked name = null;
   @tracked type = null;
   @tracked externalId = null;
+  @tracked hideArchived = false;
 
   updateFilters(filters) {
     for (const filterKey of Object.keys(filters)) {
@@ -35,5 +36,6 @@ export default class ListController extends Controller {
     this.name = null;
     this.type = null;
     this.externalId = null;
+    this.hideArchived = false;
   }
 }

--- a/admin/app/routes/authenticated/certification-centers/list.js
+++ b/admin/app/routes/authenticated/certification-centers/list.js
@@ -9,6 +9,7 @@ export default class ListRoute extends Route {
     pageSize: { refreshModel: true },
     id: { refreshModel: true },
     name: { refreshModel: true },
+    hideArchived: { refreshModel: true },
     type: { refreshModel: true },
     externalId: { refreshModel: true },
   };
@@ -23,6 +24,7 @@ export default class ListRoute extends Route {
           name: params.name ? params.name.trim() : '',
           type: params.type ? params.type.trim() : '',
           externalId: params.externalId ? params.externalId.trim() : '',
+          hideArchived: params.hideArchived,
         },
         page: {
           number: params.pageNumber,

--- a/admin/app/templates/authenticated/certification-centers/list.gjs
+++ b/admin/app/templates/authenticated/certification-centers/list.gjs
@@ -21,6 +21,7 @@ import ListItems from 'pix-admin/components/certification-centers/list-items';
         @type={{@controller.type}}
         @externalId={{@controller.externalId}}
         @triggerFiltering={{@controller.triggerFiltering}}
+        @onResetFilter={{@controller.onResetFilter}}
       />
     </section>
   </main>

--- a/admin/app/templates/authenticated/certification-centers/list.gjs
+++ b/admin/app/templates/authenticated/certification-centers/list.gjs
@@ -1,6 +1,8 @@
 import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import { fn } from '@ember/helper';
 import pageTitle from 'ember-page-title/helpers/page-title';
 import ListItems from 'pix-admin/components/certification-centers/list-items';
+
 <template>
   {{pageTitle "Centres de certification"}}
   <header>
@@ -20,6 +22,8 @@ import ListItems from 'pix-admin/components/certification-centers/list-items';
         @name={{@controller.name}}
         @type={{@controller.type}}
         @externalId={{@controller.externalId}}
+        @hideArchived={{@controller.hideArchived}}
+        @toggleArchived={{fn (mut @controller.hideArchived)}}
         @triggerFiltering={{@controller.triggerFiltering}}
         @onResetFilter={{@controller.onResetFilter}}
       />

--- a/admin/tests/acceptance/authenticated/certification-centers/list-test.js
+++ b/admin/tests/acceptance/authenticated/certification-centers/list-test.js
@@ -40,17 +40,47 @@ module('Acceptance | Certification Centers | List', function (hooks) {
       assert.dom(screen.getByRole('link', { name: 'Centres de certifications' })).hasClass('active');
     });
 
-    test('it should display the current filter when certification-centers are filtered', async function (assert) {
-      // given
-      server.createList('certification-center', 1, { type: 'PRO' });
-      server.createList('certification-center', 2, { type: 'SCO' });
-      server.createList('certification-center', 3, { type: 'SUP' });
+    module('when filters are used', function (hooks) {
+      hooks.beforeEach(async () => {
+        server.create('certification-center', { name: 'center-1', type: 'PRO' });
+        server.create('certification-center', { name: 'center-2', type: 'SCO' });
+        server.create('certification-center', { name: 'center-3', type: 'SUP' });
+      });
 
-      // when
-      const screen = await visit('/certification-centers/list?type=sup');
+      test('it should display the current filter when certification centers are filtered by name', async function (assert) {
+        // when
+        const screen = await visit('/certification-centers/list?name=clea-center');
 
-      // then
-      assert.dom(screen.getByRole('textbox', { name: 'Type' })).hasValue('sup');
+        // then
+        assert.dom(screen.getByRole('textbox', { name: 'Nom' })).hasValue('clea-center');
+      });
+
+      test('it should display the current filter when certification centers are filtered by type', async function (assert) {
+        // when
+        const screen = await visit('/certification-centers/list?type=SCO');
+
+        // then
+        assert.dom(screen.getByRole('textbox', { name: 'Type' })).hasValue('SCO');
+      });
+
+      test('it should display the current filter when certification centers are filtered by externalId', async function (assert) {
+        // when
+        const screen = await visit('/certification-centers/list?externalId=1234567A');
+
+        // then
+        assert.dom(screen.getByRole('textbox', { name: 'ID externe' })).hasValue('1234567A');
+      });
+
+      test('it displays non archived certification centers', async function (assert) {
+        // given
+        const screen = await visit('/certification-centers/list');
+
+        // when
+        await click(screen.getByRole('button', { name: 'Masquer les centres archivés' }));
+
+        // then
+        assert.strictEqual(currentURL(), '/certification-centers/list?hideArchived=true');
+      });
     });
 
     test('should go to certification center page when line is clicked', async function (assert) {

--- a/admin/tests/integration/components/routes/authenticated/certification-centers/list-items-test.gjs
+++ b/admin/tests/integration/components/routes/authenticated/certification-centers/list-items-test.gjs
@@ -1,12 +1,18 @@
 import { render, within } from '@1024pix/ember-testing-library';
+import { click } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import ListItems from 'pix-admin/components/certification-centers/list-items';
 import { module, test } from 'qunit';
+import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | routes/authenticated/certification-centers | list-items', function (hooks) {
   setupIntlRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    this.intl = this.owner.lookup('service:intl');
+  });
 
   test('it should display certification-centers list', async function (assert) {
     // given
@@ -38,25 +44,75 @@ module('Integration | Component | routes/authenticated/certification-centers | l
     assert.strictEqual(rows.length, 4);
   });
 
-  test('it should display filters', async function (assert) {
-    // given
-    const certificationCenters = [{ id: 1, name: 'John', type: 'SCO', externalId: '123' }];
-    certificationCenters.meta = {
-      rowCount: 1,
-    };
-    const triggerFiltering = () => {};
+  module('filters', function () {
+    test('it should display filters', async function (assert) {
+      // given
+      const certificationCenters = [{ id: 1, name: 'John', type: 'SCO', externalId: '123' }];
+      certificationCenters.meta = {
+        rowCount: 1,
+      };
+      const triggerFiltering = () => {};
 
-    // when
-    const screen = await render(
-      <template>
-        <ListItems @certificationCenters={{certificationCenters}} @triggerFiltering={{triggerFiltering}} />
-      </template>,
-    );
+      // when
+      const screen = await render(
+        <template>
+          <ListItems @certificationCenters={{certificationCenters}} @triggerFiltering={{triggerFiltering}} />
+        </template>,
+      );
 
-    // then
-    assert.dom(screen.getByRole('textbox', { name: 'Type' })).exists();
-    assert.dom(screen.getByRole('spinbutton', { name: 'Identifiant' })).exists();
-    assert.dom(screen.getByRole('textbox', { name: 'Nom' })).exists();
-    assert.dom(screen.getByRole('textbox', { name: 'ID externe' })).exists();
+      // then
+      assert.dom(screen.getByRole('textbox', { name: 'Type' })).exists();
+      assert.dom(screen.getByRole('spinbutton', { name: 'Identifiant' })).exists();
+      assert.dom(screen.getByRole('textbox', { name: 'Nom' })).exists();
+      assert.dom(screen.getByRole('textbox', { name: 'ID externe' })).exists();
+    });
+
+    test('when one filter is active, click on reset filter button should trigger onResetFilters method', async function (assert) {
+      // given
+      const triggerFiltering = sinon.stub();
+      const resetFilter = sinon.stub();
+      const certificationCenters = [{ id: 1, name: 'John', type: 'SCO', externalId: '123' }];
+
+      const screen = await render(
+        <template>
+          <ListItems
+            @certificationCenters={{certificationCenters}}
+            @externalId="123"
+            @triggerFiltering={{triggerFiltering}}
+            @onResetFilter={{resetFilter}}
+          />
+        </template>,
+      );
+
+      // when
+      const button = screen.getByRole('button', { name: this.intl.t('common.filters.actions.clear') });
+      await click(button);
+
+      // then
+      assert.true(resetFilter.calledOnce);
+    });
+
+    test('when no filter is active, reset filter button should be disabled', async function (assert) {
+      // given
+      const triggerFiltering = sinon.stub();
+      const resetFilter = sinon.stub();
+      const certificationCenters = [{ id: 1, name: 'John', type: 'SCO', externalId: '123' }];
+
+      const screen = await render(
+        <template>
+          <ListItems
+            @certificationCenters={{certificationCenters}}
+            @triggerFiltering={{triggerFiltering}}
+            @onResetFilter={{resetFilter}}
+          />
+        </template>,
+      );
+
+      // when
+      const button = screen.getByRole('button', { name: this.intl.t('common.filters.actions.clear') });
+
+      // then
+      assert.ok(button.hasAttribute('aria-disabled'));
+    });
   });
 });

--- a/admin/tests/unit/routes/authenticated/certification-centers/list-test.js
+++ b/admin/tests/unit/routes/authenticated/certification-centers/list-test.js
@@ -25,7 +25,7 @@ module('Unit | Route | authenticated/certification-centers/list', function (hook
     });
 
     module('when queryParams filters are falsy', function () {
-      test('it should call store.query with no filters on name, type and externalId', async function (assert) {
+      test('it should call store.query with no filters on name, type and externalId and hideArchived', async function (assert) {
         // when
         await route.model(params);
         expectedQueryArgs.filter = {
@@ -33,6 +33,7 @@ module('Unit | Route | authenticated/certification-centers/list', function (hook
           name: '',
           type: '',
           externalId: '',
+          hideArchived: undefined,
         };
 
         // then
@@ -48,11 +49,13 @@ module('Unit | Route | authenticated/certification-centers/list', function (hook
         params.name = ' someName';
         params.type = 'someType ';
         params.externalId = ' someExternalId ';
+        params.hideArchived = true;
         expectedQueryArgs.filter = {
           id: '123456',
           name: 'someName',
           type: 'someType',
           externalId: 'someExternalId',
+          hideArchived: true,
         };
 
         // when

--- a/api/src/organizational-entities/application/certification-center/certification-center.admin.route.js
+++ b/api/src/organizational-entities/application/certification-center/certification-center.admin.route.js
@@ -40,6 +40,7 @@ const register = async function (server) {
               name: Joi.string().trim().empty('').allow(null).optional(),
               type: Joi.string().trim().empty('').allow(null).optional(),
               externalId: Joi.string().trim().empty('').allow(null).optional(),
+              hideArchived: Joi.boolean().optional(),
             }).default({}),
           }),
         },

--- a/api/src/organizational-entities/infrastructure/repositories/certification-center.repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/certification-center.repository.js
@@ -83,7 +83,7 @@ const _toDomain = ({ certificationCenter, habilitationsDTO }) => {
 };
 
 const _setSearchFiltersForQueryBuilder = (filters, queryBuilder) => {
-  const { id, name, type, externalId } = filters;
+  const { id, name, type, externalId, hideArchived } = filters;
 
   if (id) {
     queryBuilder.whereRaw('CAST(id as TEXT) LIKE ?', `%${id.toString().toLowerCase()}%`);
@@ -96,5 +96,8 @@ const _setSearchFiltersForQueryBuilder = (filters, queryBuilder) => {
   }
   if (externalId) {
     queryBuilder.whereILike('externalId', `%${externalId}%`);
+  }
+  if (hideArchived) {
+    queryBuilder.whereNull('archivedAt');
   }
 };

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/certification-center.repository.test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/certification-center.repository.test.js
@@ -408,6 +408,28 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
       },
     );
 
+    context('when there are archived certification centers', function () {
+      it('returns only non archived certification centers if given in filters', async function () {
+        // given
+        databaseBuilder.factory.buildCertificationCenter({ name: 'name_ok_1', archivedAt: null });
+        databaseBuilder.factory.buildCertificationCenter({ name: 'name_ko_2', archivedAt: new Date('2020-01-01') });
+        databaseBuilder.factory.buildCertificationCenter({ name: 'name_ok_3', archivedAt: null });
+        await databaseBuilder.commit();
+
+        const filter = { hideArchived: true };
+        const page = { number: 1, size: 10 };
+
+        // when
+        const { models: matchingCertificationCenters } = await certificationCenterRepository.findPaginatedFiltered({
+          filter,
+          page,
+        });
+
+        // then
+        expect(_.map(matchingCertificationCenters, 'name')).to.have.members(['name_ok_1', 'name_ok_3']);
+      });
+    });
+
     context('when there are filters that should be ignored', function () {
       it('ignores the filters and retrieve all certificationCenters', async function () {
         // given


### PR DESCRIPTION
## ❄️ Problème

Dans Pix-Admin, afin de savoir si un centre de certification est archivé lorsque l'on se trouve sur le listing des centres, il faut ouvrir la page de détails d'un centre pour obtenr l'information.

## 🛷 Proposition

On duplique ce qui est fait côté liste des organisations avec l'ajout d'un filtre sur les centres archivés.

## ☃️ Remarques

Afin d'uniformiser davantage les deux systèmes de recherche, on en profite également pour ajouter un système de remise à zéro des filtres

## 🧑‍🎄 Pour tester

Sur Pix-Admin : 
- Aller sur la page des centres de certification
- Ajouter des filtres (id, nom, type, archivage)
- Vérifier que le filtrage s'opère correctement
- Vérifier que la remise à zéro des filtres fonctionne
