### PR TITLE
[FEATURE] Faire le lien entre un schéma de parcours et un parcours combiné (PIX-20993).

### DIFF
--- a/admin/app/components/combined-course-blueprints/list-summary-items.gjs
+++ b/admin/app/components/combined-course-blueprints/list-summary-items.gjs
@@ -1,7 +1,6 @@
-import PixIconButton from '@1024pix/pix-ui/components/pix-icon-button';
+import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
 import PixTable from '@1024pix/pix-ui/components/pix-table';
 import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
-import { fn } from '@ember/helper';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
@@ -16,36 +15,23 @@ export default class CombineCourseBluePrintList extends Component {
   @service currentUser;
 
   @action
-  downloadCSV(blueprint) {
-    try {
-      const jsonParsed = JSON.stringify({
-        name: blueprint.name,
-        description: blueprint.description,
-        illustration: blueprint.illustration,
-        content: blueprint.content,
-      });
-      const exportedData = [
-        ['Identifiant des organisations*', 'Identifiant du createur des campagnes*', 'Json configuration for quest*'],
-        ['', this.currentUser.adminMember.userId.toString(), jsonParsed],
-      ];
+  makeHref(blueprint) {
+    const jsonParsed = JSON.stringify({
+      name: blueprint.name,
+      description: blueprint.description,
+      illustration: blueprint.illustration,
+      content: blueprint.content,
+    });
+    const exportedData = [
+      ['Identifiant des organisations*', 'Identifiant du createur des campagnes*', 'Json configuration for quest*'],
+      ['', this.currentUser.adminMember.userId.toString(), jsonParsed],
+    ];
 
-      const csvContent = exportedData
-        .map((line) => line.map((data) => `"${data.replaceAll('"', '""').replaceAll('\\""', '\\"')}"`).join(';'))
-        .join('\n');
+    const csvContent = exportedData
+      .map((line) => line.map((data) => `"${data.replaceAll('"', '""').replaceAll('\\""', '\\"')}"`).join(';'))
+      .join('\n');
 
-      const exportLink = document.createElement('a');
-      exportLink.setAttribute('href', 'data:text/csv;charset=utf-8,' + encodeURIComponent(csvContent));
-      exportLink.setAttribute('download', `${blueprint.name}.csv`);
-      exportLink.click();
-
-      this.pixToast.sendSuccessNotification({
-        message: this.intl.t('components.combined-course-blueprints.create.notifications.success'),
-      });
-    } catch {
-      this.pixToast.sendErrorNotification({
-        message: this.intl.t('components.combined-course-blueprints.create.notifications.error'),
-      });
-    }
+    return 'data:text/csv;charset=utf-8,' + encodeURIComponent(csvContent);
   }
 
   <template>
@@ -97,12 +83,9 @@ export default class CombineCourseBluePrintList extends Component {
               {{t "common.fields.actions"}}
             </:header>
             <:cell>
-              <PixIconButton
-                @ariaLabel={{t "components.combined-course-blueprints.list.downloadButton"}}
-                @iconName="download"
-                @size="small"
-                @triggerAction={{fn this.downloadCSV blueprint}}
-              />
+              <PixButtonLink @href={{this.makeHref blueprint}} download="{{blueprint.name}}.csv" @iconBefore="download">
+                {{t "components.combined-course-blueprints.list.downloadButton"}}
+              </PixButtonLink>
             </:cell>
           </PixTableColumn>
         </:columns>

--- a/admin/app/components/combined-course-blueprints/list-summary-items.gjs
+++ b/admin/app/components/combined-course-blueprints/list-summary-items.gjs
@@ -20,11 +20,15 @@ export default class CombineCourseBluePrintList extends Component {
       name: blueprint.name,
       description: blueprint.description,
       illustration: blueprint.illustration,
-      content: blueprint.content,
     });
     const exportedData = [
-      ['Identifiant des organisations*', 'Identifiant du createur des campagnes*', 'Json configuration for quest*'],
-      ['', this.currentUser.adminMember.userId.toString(), jsonParsed],
+      [
+        'Identifiant des organisations*',
+        'Identifiant du createur des campagnes*',
+        'Json configuration for quest*',
+        'Identifiant du schéma de parcours*',
+      ],
+      ['', this.currentUser.adminMember.userId.toString(), jsonParsed, blueprint.id.toString()],
     ];
 
     const csvContent = exportedData

--- a/admin/tests/integration/components/combined-course-blueprints/list-summary-items-test.gjs
+++ b/admin/tests/integration/components/combined-course-blueprints/list-summary-items-test.gjs
@@ -69,12 +69,16 @@ function getHref(blueprint, creatorId) {
     name: blueprint.name,
     description: blueprint.description,
     illustration: blueprint.illustration,
-    content: blueprint.content,
   });
 
   const exportedData = [
-    ['Identifiant des organisations*', 'Identifiant du createur des campagnes*', 'Json configuration for quest*'],
-    ['', creatorId.toString(), jsonParsed],
+    [
+      'Identifiant des organisations*',
+      'Identifiant du createur des campagnes*',
+      'Json configuration for quest*',
+      'Identifiant du schéma de parcours*',
+    ],
+    ['', creatorId.toString(), jsonParsed, blueprint.id.toString()],
   ];
 
   const csvContent = exportedData

--- a/admin/tests/integration/components/combined-course-blueprints/list-summary-items-test.gjs
+++ b/admin/tests/integration/components/combined-course-blueprints/list-summary-items-test.gjs
@@ -7,12 +7,20 @@ import { module, test } from 'qunit';
 module('Integration | Component | CombinedCourseBlueprints::ListSummaryItems', function (hooks) {
   setupIntlRenderingTest(hooks);
 
+  hooks.beforeEach(function () {
+    const currentUser = this.owner.lookup('service:current-user');
+    currentUser.adminMember = { userId: 456 };
+  });
+
   test('it should display combined courses summary', async function (assert) {
     // given
     const combinedCourseBlueprint = {
       id: 123,
       internalName: 'Modèle de parcours apprenant',
       createdAt: new Date('2025-12-25'),
+      name: 'Parcours apprenant',
+      description: 'Mon super parcours apprenant',
+      illustration: 'http://pix.fr/mon-illu.png',
       content: [{ type: 'module', value: 'abc-123' }],
     };
 
@@ -27,6 +35,51 @@ module('Integration | Component | CombinedCourseBlueprints::ListSummaryItems', f
     assert.dom(screen.getByText('25/12/2025')).exists();
     assert.dom(screen.getByText('Module', { exact: false })).exists();
     assert.dom(screen.getByText('abc-123', { exact: false })).exists();
-    assert.ok(screen.getByRole('button', { name: t('components.combined-course-blueprints.list.downloadButton') }));
+    assert.ok(screen.getByRole('link', { name: t('components.combined-course-blueprints.list.downloadButton') }));
+  });
+
+  test('it should download a csv ready to import for combined course creation', async function (assert) {
+    // given
+    const combinedCourseBlueprint = {
+      id: 123,
+      internalName: 'Modèle de parcours apprenant',
+      createdAt: new Date('2025-12-25'),
+      name: 'Parcours apprenant',
+      description: 'Mon super parcours apprenant',
+      illustration: 'http://pix.fr/mon-illu.png',
+      content: [{ type: 'module', value: 'abc-123' }],
+    };
+
+    const summaries = [combinedCourseBlueprint];
+
+    // when
+    const screen = await render(<template><ListSummaryItems @summaries={{summaries}} /></template>);
+
+    const expectedHref = getHref(combinedCourseBlueprint, 456);
+    const link = screen.getByRole('link', {
+      name: t('components.combined-course-blueprints.list.downloadButton'),
+    }).href;
+
+    assert.strictEqual(link, expectedHref);
   });
 });
+
+function getHref(blueprint, creatorId) {
+  const jsonParsed = JSON.stringify({
+    name: blueprint.name,
+    description: blueprint.description,
+    illustration: blueprint.illustration,
+    content: blueprint.content,
+  });
+
+  const exportedData = [
+    ['Identifiant des organisations*', 'Identifiant du createur des campagnes*', 'Json configuration for quest*'],
+    ['', creatorId.toString(), jsonParsed],
+  ];
+
+  const csvContent = exportedData
+    .map((line) => line.map((data) => `"${data.replaceAll('"', '""').replaceAll('\\""', '\\"')}"`).join(';'))
+    .join('\n');
+
+  return 'data:text/csv;charset=utf-8,' + encodeURIComponent(csvContent);
+}

--- a/api/src/quest/domain/constants.js
+++ b/api/src/quest/domain/constants.js
@@ -38,5 +38,10 @@ export const COMBINED_COURSE_HEADER = {
       name: 'Identifiant du createur des campagnes*',
       isRequired: false,
     }),
+    new CsvColumn({
+      property: 'combinedCourseBlueprintId',
+      name: 'Identifiant du schéma de parcours*',
+      isRequired: true,
+    }),
   ],
 };

--- a/api/src/quest/domain/models/CombinedCourse.js
+++ b/api/src/quest/domain/models/CombinedCourse.js
@@ -22,7 +22,10 @@ const schema = Joi.object({
 export class CombinedCourse {
   #quest;
 
-  constructor({ id, code, organizationId, name, description, illustration, participations = [], questId } = {}, quest) {
+  constructor(
+    { id, code, organizationId, name, description, illustration, participations = [], questId, blueprintId } = {},
+    quest,
+  ) {
     this.id = id;
     this.code = code;
     this.organizationId = organizationId;
@@ -31,6 +34,7 @@ export class CombinedCourse {
     this.illustration = illustration;
     this.participations = participations;
     this.questId = questId;
+    this.blueprintId = blueprintId;
 
     this.#validate({ id, code, organizationId, name, description, illustration });
 

--- a/api/src/quest/domain/models/CombinedCourseBlueprint.js
+++ b/api/src/quest/domain/models/CombinedCourseBlueprint.js
@@ -29,7 +29,7 @@ export class CombinedCourseBlueprint {
       .map(({ value }) => value);
   }
 
-  toCombinedCourse(code, organizationId, campaigns, modulesByShortId) {
+  toCombinedCourse({ code, organizationId, campaigns, modulesByShortId, name, illustration, description }) {
     const successRequirements = this.content.map((requirement) => {
       if (requirement.type === COMBINED_COURSE_BLUEPRINT_ITEMS.EVALUATION) {
         const requirementTargetProfileId = requirement.value;
@@ -59,7 +59,13 @@ export class CombinedCourseBlueprint {
     });
 
     return new CombinedCourse(
-      { name: this.name, code, organizationId, description: this.description, illustration: this.illustration },
+      {
+        name: name ?? this.name,
+        code,
+        organizationId,
+        description: description ?? this.description,
+        illustration: illustration ?? this.illustration,
+      },
       quest,
     );
   }

--- a/api/src/quest/domain/models/CombinedCourseBlueprint.js
+++ b/api/src/quest/domain/models/CombinedCourseBlueprint.js
@@ -60,6 +60,7 @@ export class CombinedCourseBlueprint {
 
     return new CombinedCourse(
       {
+        blueprintId: this.id,
         name: name ?? this.name,
         code,
         organizationId,

--- a/api/src/quest/domain/usecases/create-combined-course-blueprint.js
+++ b/api/src/quest/domain/usecases/create-combined-course-blueprint.js
@@ -9,5 +9,5 @@ export const createCombinedCourseBlueprint = async ({
     .filter((item) => item.type === COMBINED_COURSE_BLUEPRINT_ITEMS.EVALUATION)
     .map(({ value }) => value);
   await targetProfileRepository.findByIds({ ids: targetProfileIds });
-  return combinedCourseBlueprintRepository.save(combinedCourseBlueprint);
+  return combinedCourseBlueprintRepository.save({ combinedCourseBlueprint });
 };

--- a/api/src/quest/domain/usecases/create-combined-courses.js
+++ b/api/src/quest/domain/usecases/create-combined-courses.js
@@ -2,7 +2,6 @@ import { withTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { CsvParser } from '../../../shared/infrastructure/serializers/csv/csv-parser.js';
 import { COMBINED_COURSE_HEADER } from '../constants.js';
 import { Campaign } from '../models/Campaign.js';
-import { CombinedCourseBlueprint } from '../models/CombinedCourseBlueprint.js';
 
 export const createCombinedCourses = withTransaction(
   async ({
@@ -25,7 +24,9 @@ export const createCombinedCourses = withTransaction(
       const { organizationIds: organizationIdsSeparatedByComma, creatorId, content, combinedCourseBlueprintId } = row;
       const organizationIds = organizationIdsSeparatedByComma.split(',');
       const combinedCourseInformation = JSON.parse(content);
-      const combinedCourseBlueprint = await combinedCourseBlueprintRepository.findById({ combinedCourseBlueprintId });
+      const combinedCourseBlueprint = await combinedCourseBlueprintRepository.findById({
+        id: combinedCourseBlueprintId,
+      });
 
       const targetProfileIds = combinedCourseBlueprint.targetProfileIds;
       const targetProfiles = await targetProfileRepository.findByIds({ ids: targetProfileIds });

--- a/api/src/quest/domain/usecases/index.js
+++ b/api/src/quest/domain/usecases/index.js
@@ -2,6 +2,7 @@ import * as organizationLearnerPrescriptionRepository from '../../../prescriptio
 import * as codeGenerator from '../../../shared/domain/services/code-generator.js';
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
 import { logger } from '../../../shared/infrastructure/utils/logger.js';
+import * as combinedCourseBlueprintRepository from '../../infrastructure/repositories/combined-course-blueprint-repository.js';
 import { repositories } from '../../infrastructure/repositories/index.js';
 import * as organizationLearnerRepository from '../../infrastructure/repositories/organization-learner-repository.js';
 import combinedCourseDetailsService from '../services/combined-course-details-service.js';
@@ -37,7 +38,7 @@ const dependencies = {
   combinedCourseDetailsService: injectedCombinedCourseDetailsService,
   organizationLearnerRepository,
   organizationLearnerPrescriptionRepository,
-  combinedCourseBlueprintRepository: repositories.combinedCourseBlueprintRepository,
+  combinedCourseBlueprintRepository,
   codeGenerator,
   logger,
 };

--- a/api/src/quest/infrastructure/repositories/combined-course-blueprint-repository.js
+++ b/api/src/quest/infrastructure/repositories/combined-course-blueprint-repository.js
@@ -23,3 +23,12 @@ export async function save(combinedCourseBlueprint) {
 
   return new CombinedCourseBlueprint(insertedValues);
 }
+
+export async function findById(combinedCourseBlueprintId) {
+  const knexConn = DomainTransaction.getConnection();
+  const result = await knexConn('combined_course_blueprints').where({ id: combinedCourseBlueprintId }).first();
+  if (!result) {
+    return null;
+  }
+  return new CombinedCourseBlueprint(result);
+}

--- a/api/src/quest/infrastructure/repositories/combined-course-blueprint-repository.js
+++ b/api/src/quest/infrastructure/repositories/combined-course-blueprint-repository.js
@@ -24,9 +24,9 @@ export async function save(combinedCourseBlueprint) {
   return new CombinedCourseBlueprint(insertedValues);
 }
 
-export async function findById(combinedCourseBlueprintId) {
+export async function findById({ combinedCourseBlueprintId }) {
   const knexConn = DomainTransaction.getConnection();
-  const result = await knexConn('combined_course_blueprints').where({ id: combinedCourseBlueprintId }).first();
+  const result = await knexConn('combined_course_blueprints').where('id', combinedCourseBlueprintId).first();
   if (!result) {
     return null;
   }

--- a/api/src/quest/infrastructure/repositories/combined-course-blueprint-repository.js
+++ b/api/src/quest/infrastructure/repositories/combined-course-blueprint-repository.js
@@ -12,7 +12,7 @@ export async function findAll() {
   return results.map((data) => new CombinedCourseBlueprint(data));
 }
 
-export async function save(combinedCourseBlueprint) {
+export async function save({ combinedCourseBlueprint }) {
   const knexConn = DomainTransaction.getConnection();
   const [insertedValues] = await knexConn('combined_course_blueprints')
     .insert({
@@ -24,9 +24,9 @@ export async function save(combinedCourseBlueprint) {
   return new CombinedCourseBlueprint(insertedValues);
 }
 
-export async function findById({ combinedCourseBlueprintId }) {
+export async function findById({ id }) {
   const knexConn = DomainTransaction.getConnection();
-  const result = await knexConn('combined_course_blueprints').where('id', combinedCourseBlueprintId).first();
+  const result = await knexConn('combined_course_blueprints').where({ id }).first();
   if (!result) {
     return null;
   }

--- a/api/src/quest/infrastructure/repositories/combined-course-repository.js
+++ b/api/src/quest/infrastructure/repositories/combined-course-repository.js
@@ -90,6 +90,7 @@ const _toDTO = (combinedCourse) => {
       successRequirements: JSON.stringify(questDTO.successRequirements),
     },
     combinedCourse: {
+      combinedCourseBlueprintId: combinedCourse.blueprintId,
       organizationId: combinedCourse.organizationId,
       code: combinedCourse.code,
       name: combinedCourse.name,
@@ -110,6 +111,7 @@ const findByModuleIdAndOrganizationIds = async ({ moduleId, organizationIds }) =
       'combined_courses.description',
       'combined_courses.illustration',
       'combined_courses.questId',
+      'combined_courses.combinedCourseBlueprintId',
     )
     .join('quests', 'combined_courses.questId', 'quests.id')
     .whereIn('combined_courses.organizationId', organizationIds)
@@ -126,6 +128,7 @@ const _toDomain = ({
   description,
   illustration,
   questId,
+  combinedCourseBlueprintId,
 }) => {
   return new CombinedCourse({
     id,
@@ -135,6 +138,7 @@ const _toDomain = ({
     description,
     illustration,
     questId,
+    blueprintId: combinedCourseBlueprintId,
   });
 };
 

--- a/api/src/quest/infrastructure/repositories/combined-course-repository.js
+++ b/api/src/quest/infrastructure/repositories/combined-course-repository.js
@@ -14,7 +14,7 @@ const getByCode = async ({ code }) => {
     throw new NotFoundError(`Le parcours combiné portant le code ${code} n'existe pas`);
   }
 
-  return new CombinedCourse(combinedCourse);
+  return _toDomain(combinedCourse);
 };
 
 const getById = async ({ id }) => {
@@ -30,7 +30,7 @@ const getById = async ({ id }) => {
     throw new NotFoundError(`Le parcours combiné pour l'id ${id} n'existe pas`);
   }
 
-  return new CombinedCourse(combinedCourse);
+  return _toDomain(combinedCourse);
 };
 
 const findByOrganizationId = async ({ organizationId, page, size }) => {
@@ -47,7 +47,7 @@ const findByOrganizationId = async ({ organizationId, page, size }) => {
   });
 
   return {
-    combinedCourses: results.map((quest) => new CombinedCourse(quest)),
+    combinedCourses: results.map(_toDomain),
     meta: pagination,
   };
 };
@@ -67,7 +67,7 @@ const findByCampaignId = async ({ campaignId }) => {
     .join('quests', 'quests.id', 'combined_courses.questId')
     .whereJsonSupersetOf('quests.successRequirements', [{ data: { campaignId: { data: campaignId } } }]);
 
-  return combinedCourses.map((quest) => new CombinedCourse(quest));
+  return combinedCourses.map(_toDomain);
 };
 
 const saveInBatch = async ({ combinedCourses }) => {
@@ -115,7 +115,27 @@ const findByModuleIdAndOrganizationIds = async ({ moduleId, organizationIds }) =
     .whereIn('combined_courses.organizationId', organizationIds)
     .whereJsonSupersetOf('quests.successRequirements', [{ data: { moduleId: { data: moduleId } } }]);
 
-  return combinedCourses.map((quest) => new CombinedCourse(quest));
+  return combinedCourses.map(_toDomain);
+};
+
+const _toDomain = ({
+  id,
+  organizationId,
+  code,
+  name,
+  description,
+  illustration,
+  questId,
+}) => {
+  return new CombinedCourse({
+    id,
+    organizationId,
+    code,
+    name,
+    description,
+    illustration,
+    questId,
+  });
 };
 
 export { findByCampaignId, findByModuleIdAndOrganizationIds, findByOrganizationId, getByCode, getById, saveInBatch };

--- a/api/src/quest/infrastructure/repositories/index.js
+++ b/api/src/quest/infrastructure/repositories/index.js
@@ -13,7 +13,6 @@ import { temporaryStorage } from '../../../shared/infrastructure/key-value-stora
 import * as accessCodeRepository from '../../../shared/infrastructure/repositories/access-code-repository.js';
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
 import * as campaignRepository from './campaign-repository.js';
-import * as combinedCourseBlueprintRepository from './combined-course-blueprint-repository.js';
 import * as combinedCourseDetailsRepository from './combined-course-details-repository.js';
 import * as combinedCourseParticipantRepository from './combined-course-participant-repository.js';
 import * as combinedCourseParticipationRepository from './combined-course-participation-repository.js';
@@ -27,10 +26,6 @@ import * as rewardRepository from './reward-repository.js';
 import * as successRepository from './success-repository.js';
 import * as targetProfileRepository from './target-profile-repository.js';
 import * as userRepository from './user-repository.js';
-
-/**
- * @typedef {combinedCourseBlueprintRepository} combinedCourseBlueprintRepository;
- * **/
 
 const profileRewardTemporaryStorage = temporaryStorage.withPrefix('profile-rewards:');
 
@@ -50,7 +45,6 @@ const repositoriesWithoutInjectedDependencies = {
   userRepository,
   recommendedModuleRepository,
   targetProfileRepository,
-  combinedCourseBlueprintRepository,
 };
 
 const dependencies = {

--- a/api/tests/quest/acceptance/application/combined-course-route_test.js
+++ b/api/tests/quest/acceptance/application/combined-course-route_test.js
@@ -34,11 +34,12 @@ describe('Quest | Acceptance | Application | Combined course Route ', function (
       it('creates combined courses', async function () {
         // given
         const organizationId = databaseBuilder.factory.buildOrganization().id;
+        const combinedCourseBlueprint = databaseBuilder.factory.buildCombinedCourseBlueprint({ content: [] });
 
         await databaseBuilder.commit();
 
-        const input = `Identifiant des organisations*;Json configuration for quest*;Identifiant du createur des campagnes*
-${organizationId};"{""name"":""Combinix"",""content"":[],""description"":""ma description"", ""illustration"":""mon_illu.svg""}";${userId}`;
+        const input = `Identifiant des organisations*;Json configuration for quest*;Identifiant du createur des campagnes*;Identifiant du schéma de parcours*
+${organizationId};"{""name"":""Combinix"",""content"":[],""description"":""ma description"", ""illustration"":""mon_illu.svg""}";${userId};${combinedCourseBlueprint.id}`;
 
         const options = {
           method: 'POST',

--- a/api/tests/quest/integration/domain/usecases/create-combined-courses_test.js
+++ b/api/tests/quest/integration/domain/usecases/create-combined-courses_test.js
@@ -39,11 +39,26 @@ describe('Integration | Combined course | Domain | UseCases | create-combined-co
       trainingId: trainingId,
     });
 
-    await databaseBuilder.commit();
+    const blueprint1 = databaseBuilder.factory.buildCombinedCourseBlueprint({
+      content: [
+        { type: 'evaluation', value: targetProfile.id },
+        { type: 'module', value: '27d6ca4f' },
+        { type: 'module', value: 'df82ec66' },
+      ],
+    });
 
-    const input = `Identifiant des organisations*;Json configuration for quest*;Identifiant du createur des campagnes*
-${firstOrganizationId},${secondOrganizationId};"{""name"":""Combinix"",""content"":[{""type"":""evaluation"",""value"":${targetProfile.id}},{""type"":""module"",""value"":""27d6ca4f""},{""type"":""module"",""value"":""df82ec66""}],""description"":""ma description"", ""illustration"":""mon_illu.svg""}";${userId}
-${firstOrganizationId};"{""name"":""Combinix"",""content"":[{""type"":""evaluation"",""value"":${targetProfileWithTraining.id}},{""type"":""module"",""value"":""27d6ca4f""},{""type"":""module"",""value"":""df82ec66""}]}";${userId}
+    const blueprint2 = databaseBuilder.factory.buildCombinedCourseBlueprint({
+      content: [
+        { type: 'evaluation', value: targetProfileWithTraining.id },
+        { type: 'module', value: '27d6ca4f' },
+        { type: 'module', value: 'df82ec66' },
+      ],
+    });
+
+    await databaseBuilder.commit();
+    const input = `Identifiant des organisations*;Json configuration for quest*;Identifiant du createur des campagnes*;Identifiant du schéma de parcours*
+${firstOrganizationId},${secondOrganizationId};"{""name"":""Combinix"",""description"":""ma description"", ""illustration"":""mon_illu.svg""}";${userId};${blueprint1.id}
+${firstOrganizationId};"{""name"":""Combinix""}";${userId};${blueprint2.id}
 `;
 
     const payload = iconv.encode(input, 'UTF-8');
@@ -204,8 +219,11 @@ ${firstOrganizationId};"{""name"":""Combinix"",""content"":[{""type"":""evaluati
     expect(secondCreatedQuestForFirstOrganization.successRequirements).to.deep.equal(
       secondCreatedQuestForFirstOrganization.successRequirements,
     );
-    expect(secondCreatedQuestForFirstOrganization.description).null;
-    expect(secondCreatedQuestForFirstOrganization.illustration).null;
+    // expect(secondCreatedQuestForFirstOrganization.description).null;
+    expect(secondCreatedQuestForFirstOrganization.description).to.equal(blueprint2.description);
+
+    // expect(secondCreatedQuestForFirstOrganization.illustration).null;
+    expect(secondCreatedQuestForFirstOrganization.illustration).to.equal(blueprint2.illustration);
     //Campaign
     expect(secondCreatedCampaignForFirstOrganization.name).to.equal(targetProfileWithTraining.internalName);
     expect(secondCreatedCampaignForFirstOrganization.title).to.equal(targetProfileWithTraining.name);

--- a/api/tests/quest/integration/domain/usecases/create-combined-courses_test.js
+++ b/api/tests/quest/integration/domain/usecases/create-combined-courses_test.js
@@ -196,6 +196,7 @@ ${firstOrganizationId};"{""name"":""Combinix""}";${userId};${blueprint2.id}
 
     // 1st Organization
     // Quest
+    expect(firstCreatedQuestForFirstOrganization.combinedCourseBlueprintId).to.equal(blueprint1.id);
     expect(firstCreatedQuestForFirstOrganization.code).not.to.be.null;
     expect(firstCreatedQuestForFirstOrganization.name).to.equal(expectedFirstQuestForFirstOrganization.name);
     expect(firstCreatedQuestForFirstOrganization.successRequirements).to.deep.equal(
@@ -214,14 +215,17 @@ ${firstOrganizationId};"{""name"":""Combinix""}";${userId};${blueprint2.id}
     expect(firstCreatedCampaignForFirstOrganization.customResultPageButtonText).to.equal('Continuer');
 
     // Quest
+    expect(secondCreatedQuestForFirstOrganization.combinedCourseBlueprintId).to.equal(blueprint2.id);
     expect(secondCreatedQuestForFirstOrganization.code).not.to.be.null;
     expect(secondCreatedQuestForFirstOrganization.name).to.equal(expectedSecondQuestForFirstOrganization.name);
     expect(secondCreatedQuestForFirstOrganization.successRequirements).to.deep.equal(
       secondCreatedQuestForFirstOrganization.successRequirements,
     );
+    // TODO: voir avec Gégé si c'est ok
     // expect(secondCreatedQuestForFirstOrganization.description).null;
     expect(secondCreatedQuestForFirstOrganization.description).to.equal(blueprint2.description);
 
+    // TODO: voir avec Gégé si c'est ok
     // expect(secondCreatedQuestForFirstOrganization.illustration).null;
     expect(secondCreatedQuestForFirstOrganization.illustration).to.equal(blueprint2.illustration);
     //Campaign
@@ -232,6 +236,7 @@ ${firstOrganizationId};"{""name"":""Combinix""}";${userId};${blueprint2.id}
 
     // 2nd Organization
     // Quest
+    expect(createdQuestForSecondOrganization.combinedCourseBlueprintId).to.equal(blueprint1.id);
     expect(createdQuestForSecondOrganization.code).not.to.be.null;
     expect(createdQuestForSecondOrganization.name).to.equal(expectedQuestForSecondOrganization.name);
     expect(createdQuestForSecondOrganization.successRequirements).to.deep.equal(

--- a/api/tests/quest/integration/domain/usecases/find-combined-course-by-module-id-and-user-id_test.js
+++ b/api/tests/quest/integration/domain/usecases/find-combined-course-by-module-id-and-user-id_test.js
@@ -66,6 +66,7 @@ describe('Integration | Quest | Domain | UseCases | find-combined-course-by-modu
         illustration: combinedCourse1.illustration,
         participations: [],
         questId: combinedCourse1.questId,
+        blueprintId: null,
       },
       {
         id: combinedCourse2.id,
@@ -76,6 +77,7 @@ describe('Integration | Quest | Domain | UseCases | find-combined-course-by-modu
         illustration: combinedCourse2.illustration,
         participations: [],
         questId: combinedCourse2.questId,
+        blueprintId: null,
       },
     ]);
   });

--- a/api/tests/quest/integration/infrastructure/repositories/combined-course-blueprint-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/combined-course-blueprint-repository_test.js
@@ -62,4 +62,20 @@ describe('Quest | Integration | Repository | combined-course-blueprint', functio
       expect(result).lengthOf(0);
     });
   });
+  describe('#findById', function () {
+    it('should return combined course blueprint by its id', async function () {
+      const expectedCombinedCourseBlueprint = domainBuilder.buildCombinedCourseBlueprint();
+      databaseBuilder.factory.buildCombinedCourseBlueprint(expectedCombinedCourseBlueprint);
+      await databaseBuilder.commit();
+
+      const result = await combinedCourseBluePrintRepository.findById(expectedCombinedCourseBlueprint.id);
+      expect(result).to.be.instanceOf(CombinedCourseBlueprint);
+      expect(result).to.deep.equal(expectedCombinedCourseBlueprint);
+    });
+
+    it('should return null when no results are found', async function () {
+      const result = await combinedCourseBluePrintRepository.findById(123);
+      expect(result).null;
+    });
+  });
 });

--- a/api/tests/quest/integration/infrastructure/repositories/combined-course-blueprint-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/combined-course-blueprint-repository_test.js
@@ -6,7 +6,7 @@ describe('Quest | Integration | Repository | combined-course-blueprint', functio
   describe('#save', function () {
     it('should save a combined course blueprint', async function () {
       // given
-      const values = {
+      const combinedCourseBlueprint = {
         id: 1,
         name: 'Combined course IA',
         internalName: 'Ia combined course blueprint',
@@ -18,17 +18,17 @@ describe('Quest | Integration | Repository | combined-course-blueprint', functio
       };
 
       // when
-      await combinedCourseBluePrintRepository.save(values);
+      await combinedCourseBluePrintRepository.save({ combinedCourseBlueprint });
 
       // then
       const results = await combinedCourseBluePrintRepository.findAll();
       expect(results).lengthOf(1);
-      expect(results[0]).deep.equal(values);
+      expect(results[0]).deep.equal(combinedCourseBlueprint);
     });
 
     it('should return created combined course blueprint', async function () {
       // given
-      const values = {
+      const combinedCourseBlueprint = {
         id: 1,
         name: 'Combined course IA',
         internalName: 'Ia combined course blueprint',
@@ -40,9 +40,9 @@ describe('Quest | Integration | Repository | combined-course-blueprint', functio
       };
 
       // when
-      const result = await combinedCourseBluePrintRepository.save(values);
+      const result = await combinedCourseBluePrintRepository.save({ combinedCourseBlueprint });
 
-      expect(result).deep.equal(values);
+      expect(result).deep.equal(combinedCourseBlueprint);
     });
   });
 
@@ -68,13 +68,13 @@ describe('Quest | Integration | Repository | combined-course-blueprint', functio
       databaseBuilder.factory.buildCombinedCourseBlueprint(expectedCombinedCourseBlueprint);
       await databaseBuilder.commit();
 
-      const result = await combinedCourseBluePrintRepository.findById(expectedCombinedCourseBlueprint.id);
+      const result = await combinedCourseBluePrintRepository.findById({ id: expectedCombinedCourseBlueprint.id });
       expect(result).to.be.instanceOf(CombinedCourseBlueprint);
       expect(result).to.deep.equal(expectedCombinedCourseBlueprint);
     });
 
     it('should return null when no results are found', async function () {
-      const result = await combinedCourseBluePrintRepository.findById(123);
+      const result = await combinedCourseBluePrintRepository.findById({ id: 123 });
       expect(result).null;
     });
   });

--- a/api/tests/quest/integration/infrastructure/repositories/combined-course-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/combined-course-repository_test.js
@@ -282,6 +282,7 @@ describe('Quest | Integration | Repository | combined-course', function () {
           },
         },
       ];
+      const combinedCourseBlueprint = databaseBuilder.factory.buildCombinedCourseBlueprint({ content: [] });
       await databaseBuilder.commit();
 
       const quest = new Quest({
@@ -303,6 +304,7 @@ describe('Quest | Integration | Repository | combined-course', function () {
           name: 'secondCombinedCourse',
           code: 'secondCode',
           organizationId: secondOrganizationId,
+          blueprintId: combinedCourseBlueprint.id,
         },
         quest,
       );
@@ -318,11 +320,13 @@ describe('Quest | Integration | Repository | combined-course', function () {
         .where('combined_courses.organizationId', secondOrganizationId)
         .first();
 
+      expect(firstSavedCombinedCourse.combinedCourseBlueprintId).to.be.null;
       expect(firstSavedCombinedCourse.name).to.equal('firstCombinedCourse');
       expect(firstSavedCombinedCourse.description).equal('ma description');
       expect(firstSavedCombinedCourse.illustration).equal('mon_illu.svg');
       expect(firstSavedCombinedCourse.code).equal('firstCode');
 
+      expect(secondSavedCombinedCourse.combinedCourseBlueprintId).to.equal(combinedCourseBlueprint.id);
       expect(secondSavedCombinedCourse.name).to.equal('secondCombinedCourse');
       expect(secondSavedCombinedCourse.description).null;
       expect(secondSavedCombinedCourse.illustration).null;
@@ -387,6 +391,7 @@ describe('Quest | Integration | Repository | combined-course', function () {
           illustration: combinedCourseWithModule.illustration,
           participations: [],
           questId: combinedCourseWithModule.questId,
+          blueprintId: null,
         },
         {
           id: otherCombinedCourseWithModule.id,
@@ -397,6 +402,7 @@ describe('Quest | Integration | Repository | combined-course', function () {
           illustration: otherCombinedCourseWithModule.illustration,
           participations: [],
           questId: otherCombinedCourseWithModule.questId,
+          blueprintId: null,
         },
       ]);
     });
@@ -450,6 +456,7 @@ describe('Quest | Integration | Repository | combined-course', function () {
           illustration: combinedCourseWithModule.illustration,
           participations: [],
           questId: combinedCourseWithModule.questId,
+          blueprintId: null,
         },
         {
           id: combinedCourseWithModuleAndOtherOrga.id,
@@ -460,6 +467,7 @@ describe('Quest | Integration | Repository | combined-course', function () {
           illustration: combinedCourseWithModuleAndOtherOrga.illustration,
           participations: [],
           questId: combinedCourseWithModuleAndOtherOrga.questId,
+          blueprintId: null,
         },
       ]);
     });

--- a/api/tests/quest/unit/domain/models/CombinedCourseBlueprint_test.js
+++ b/api/tests/quest/unit/domain/models/CombinedCourseBlueprint_test.js
@@ -171,12 +171,12 @@ describe('Quest | Unit | Domain | Models | CombinedCourseBlueprint ', function (
         description,
         illustration,
       });
-      const combinedCourse = combinedCourseBlueprint.toCombinedCourse(
+      const combinedCourse = combinedCourseBlueprint.toCombinedCourse({
         code,
         organizationId,
         campaigns,
         modulesByShortId,
-      );
+      });
 
       // then
       const quest = new Quest({


### PR DESCRIPTION
## ❄️ Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

Actuellement, il est compliqué de recréer un parcours combiné identique à un autre.

On souhaite pouvoir remonter au schéma de parcours ayant servi à la création d’un parcours combiné afin de faciliter la création de parcours combiné avec le même contenu.

## 🛷 Proposition

On veut donc faire le lien entre un parcours et son schéma au moment de sa création.
Pour cela, on ajoute l'identifiant du schéma de parcours dans le fichier CSV exporté.
Lors de la création, on s'appuie sur cet identifiant pour retrouver le contenu du parcours combiné et on stocke l'identifiant dans la ligne du parcours combiné.

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## ☃️ Remarques

On donne la possiblité de surcharger nom, description et illustration du schéma lors de la création du parcours combiné.

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🧑‍🎄 Pour tester

Se rendre sur Pix Admin.
Dans la partie `Schéma de parcours`, créer un schéma.
Télécharger le fichier CSV du schéma créé.
Renseigner la colonne "organisation" dans le fichier.
Se rendre dans "Administration", dans la partie "Création de parcours combiné", cliquer que "Importer un CSV".
Vérifier que la colonne `combinedCourseBlueprintId` est bien renseignée.

Jouer le parcours combiné et vérifier que les nom, illustration et description sont bien ceux du schéma du parcours.

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
