### PR TITLE
[FEATURE] Connexion via SSO - Message d'erreur si accès interdit à l'utilisateur (PIX-20977). 

### DIFF
--- a/api/src/shared/application/error-manager.js
+++ b/api/src/shared/application/error-manager.js
@@ -411,7 +411,7 @@ function _mapToHttpError(error) {
     return new HttpErrors.BadRequestError(error.message);
   }
   if (error instanceof UserNotMemberOfOrganizationError) {
-    return new HttpErrors.UnprocessableEntityError(error.message);
+    return new HttpErrors.UnprocessableEntityError(error.message, error.code);
   }
   if (error instanceof SharedDomainErrors.TargetProfileInvalidError) {
     return new HttpErrors.PreconditionFailedError(error.message);

--- a/api/src/team/domain/errors.js
+++ b/api/src/team/domain/errors.js
@@ -32,7 +32,7 @@ class UncancellableOrganizationInvitationError extends DomainError {
 
 class UserNotMemberOfOrganizationError extends DomainError {
   constructor(message = "L'utilisateur n'est pas membre de l'organisation.") {
-    super(message);
+    super(message, 'USER_NOT_MEMBER_OF_ORGANIZATION');
   }
 }
 

--- a/api/tests/identity-access-management/acceptance/application/oidc-provider.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/oidc-provider.route.test.js
@@ -679,6 +679,13 @@ describe('Acceptance | Identity Access Management | Application | Route | oidc-p
             const externalIdentifier = 'sub';
 
             const userId = databaseBuilder.factory.buildUser({ firstName, lastName }).id;
+            const organizationId = databaseBuilder.factory.buildOrganization().id;
+            databaseBuilder.factory.buildMembership({
+              userId,
+              organizationId,
+              organizationRole: 'MEMBER',
+            });
+
             databaseBuilder.factory.buildAuthenticationMethod.withIdentityProvider({
               identityProvider: 'OIDC_EXAMPLE_NET',
               externalIdentifier,

--- a/api/tests/identity-access-management/unit/domain/usecases/authenticate-oidc-user.usecase.test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/authenticate-oidc-user.usecase.test.js
@@ -106,6 +106,38 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-oi
           });
         });
       });
+
+      context('when requestedApplication is Pix Orga', function () {
+        const requestedApplication = new RequestedApplication({ applicationName: 'orga', applicationTld: '.fr' });
+
+        context('when user is not linked to any organization', function () {
+          it('throws PIX_ORGA_ACCESS_NOT_ALLOWED and ForbiddenAccess when user is not linked', async function () {
+            // given
+            _fakeOidcAPI({ oidcAuthenticationService, externalIdentityId });
+
+            const user = domainBuilder.buildUser({ id: 202, memberships: [] });
+            sinon.stub(user, 'isLinkedToOrganizations').returns(false);
+
+            userRepository.findByExternalIdentifier.resolves(user);
+
+            oidcAuthenticationService.createAuthenticationComplement.returns(
+              new AuthenticationMethod.OidcAuthenticationComplement({ given_name: 'No', family_name: 'Org' }),
+            );
+
+            // when
+            const error = await catchErr(authenticateOidcUser)({
+              requestedApplication,
+              oidcAuthenticationServiceRegistry,
+              userRepository,
+              adminMemberRepository,
+            });
+
+            // then
+            expect(error).to.be.an.instanceOf(ForbiddenAccess);
+            expect(error.code).to.equal('PIX_ORGA_ACCESS_NOT_ALLOWED');
+          });
+        });
+      });
     });
 
     context('when user does not have an account', function () {

--- a/orga/app/authenticators/oidc.js
+++ b/orga/app/authenticators/oidc.js
@@ -75,7 +75,7 @@ export default class OidcAuthenticator extends BaseAuthenticator {
    */
   async invalidate(data) {
     const { access_token, shouldCloseSession, identityProviderCode, logoutUrlUuid } = data || {};
-    if (!shouldCloseSession) {
+    if (!shouldCloseSession || this.session.alternativeRootURL) {
       return;
     }
 

--- a/orga/app/router.js
+++ b/orga/app/router.js
@@ -19,6 +19,7 @@ export default class Router extends EmberRouter {
 Router.map(function () {
   this.route('authentication', { path: 'connexion' }, function () {
     this.route('login', { path: '' });
+    this.route('error');
     this.route('sso-selection');
     this.route('oidc.flow', { path: '/:identity_provider_slug' });
     this.route('oidc.login', { path: '/:identity_provider_slug/login' });

--- a/orga/app/routes/authenticated.js
+++ b/orga/app/routes/authenticated.js
@@ -6,9 +6,17 @@ export default class AuthenticatedRoute extends Route {
   @service router;
   @service session;
   @service store;
+  @service joinInvitation;
 
-  beforeModel(transition) {
+  async beforeModel(transition) {
     this.session.requireAuthentication(transition, 'authentication.login');
+
+    if (this.joinInvitation.invitation) {
+      const userId = this.session.data.authenticated.user_id;
+      await this.joinInvitation.acceptInvitationByUserId(userId);
+    }
+
+    await this.currentUser.load();
 
     if (transition.isAborted) {
       return;

--- a/orga/app/routes/authentication/oidc/flow.js
+++ b/orga/app/routes/authentication/oidc/flow.js
@@ -55,6 +55,9 @@ export default class LoginOidcRoute extends Route {
     const { identityProviderSlug, shouldCreateUserAccount } = model;
 
     if (shouldCreateUserAccount) {
+      //if (!this.joinInvitation.invitation) {
+      // this.router.transitionTo('authentication.login', { queryParams: { error: 'PIX_ORGA_ACCESS_NOT_ALLOWED' } });
+      //}
       this.router.transitionTo('authentication.oidc.signup', identityProviderSlug);
     }
   }
@@ -113,10 +116,13 @@ export default class LoginOidcRoute extends Route {
       if (apiError.code == 'MISSING_OIDC_STATE') {
         this.router.transitionTo('authentication.login');
         return;
+      } else if (apiError.code == 'PIX_ORGA_ACCESS_NOT_ALLOWED') {
+        this.router.transitionTo('authentication.login', { queryParams: { error: apiError.code } });
+        return;
       }
 
-      const shouldValidateCgu = apiError.code === 'SHOULD_VALIDATE_CGU';
-      if (shouldValidateCgu && apiError.meta.authenticationKey) {
+      const userNotFound = apiError.code === 'SHOULD_VALIDATE_CGU';
+      if (userNotFound && apiError.meta.authenticationKey) {
         oidcUserAuthenticationStorage.set(apiError.meta);
 
         return { identityProviderSlug, shouldCreateUserAccount: true };

--- a/orga/app/routes/authentication/oidc/flow.js
+++ b/orga/app/routes/authentication/oidc/flow.js
@@ -56,10 +56,11 @@ export default class LoginOidcRoute extends Route {
     const { identityProviderSlug, shouldCreateUserAccount } = model;
 
     if (shouldCreateUserAccount) {
+      // TODO: doit être déplacé dans le beforeModel de la route 'authentication.oidc.signup'
       if (!this.joinInvitation.invitation) {
         return this.router.transitionTo('authentication.error');
       }
-
+      // FIN TODO
       this.router.transitionTo('authentication.oidc.signup', identityProviderSlug);
     }
   }

--- a/orga/app/routes/authentication/oidc/flow.js
+++ b/orga/app/routes/authentication/oidc/flow.js
@@ -13,6 +13,7 @@ export default class LoginOidcRoute extends Route {
   @service oidcIdentityProviders;
   @service router;
   @service session;
+  @service joinInvitation;
 
   async beforeModel(transition) {
     const queryParams = transition.to.queryParams;
@@ -55,9 +56,10 @@ export default class LoginOidcRoute extends Route {
     const { identityProviderSlug, shouldCreateUserAccount } = model;
 
     if (shouldCreateUserAccount) {
-      //if (!this.joinInvitation.invitation) {
-      // this.router.transitionTo('authentication.login', { queryParams: { error: 'PIX_ORGA_ACCESS_NOT_ALLOWED' } });
-      //}
+      if (!this.joinInvitation.invitation) {
+        return this.router.transitionTo('authentication.error');
+      }
+
       this.router.transitionTo('authentication.oidc.signup', identityProviderSlug);
     }
   }
@@ -115,9 +117,6 @@ export default class LoginOidcRoute extends Route {
 
       if (apiError.code == 'MISSING_OIDC_STATE') {
         this.router.transitionTo('authentication.login');
-        return;
-      } else if (apiError.code == 'PIX_ORGA_ACCESS_NOT_ALLOWED') {
-        this.router.transitionTo('authentication.login', { queryParams: { error: apiError.code } });
         return;
       }
 

--- a/orga/app/services/current-user.js
+++ b/orga/app/services/current-user.js
@@ -1,9 +1,12 @@
 import Service, { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
+import get from 'lodash/get';
 
 export default class CurrentUserService extends Service {
   @service session;
   @service store;
+  @service router;
+  @service pixToast;
 
   @tracked prescriber;
   @tracked memberships;
@@ -104,7 +107,15 @@ export default class CurrentUserService extends Service {
         await membership.save({
           adapterOptions: { updateLastAccessedAt: true },
         });
-      } catch {
+      } catch (error) {
+        // Handling error for those different cases: EmberSimpleAuth, JSON:API response, non-JSON:API response
+        const extractedError = get(error, error.responseJSON ? 'responseJSON.errors[0]' : 'errors[0]') ?? error;
+        if (extractedError.code == 'USER_NOT_MEMBER_OF_ORGANIZATION') {
+          this.session.alternativeRootURL = 'error';
+          // await this.session.invalidate();
+          //this.router.transitionTo('authentication.login', { queryParams: { error: error.code } });
+        }
+
         this.prescriber = null;
         this.memberships = null;
         return this.session.invalidate();

--- a/orga/app/services/join-invitation.js
+++ b/orga/app/services/join-invitation.js
@@ -45,6 +45,7 @@ export default class JoinInvitationService extends Service {
 
   /** Accepts an invitation from either an email or a userId. */
   async #acceptInvitation({ email, userId }) {
+    console.log({ userId });
     if (!this.invitation) return;
 
     let record;
@@ -57,6 +58,7 @@ export default class JoinInvitationService extends Service {
       record = this.store.createRecord('organization-invitation-response', { id, code, email, userId });
       await record.save({ adapterOptions: { organizationInvitationId: invitationId } });
     } catch (responseError) {
+      console.log('ERROR', { responseError });
       record?.deleteRecord();
       const error = responseError?.errors[0];
       const isUserAlreadyOrganizationMember = error?.status === '412';

--- a/orga/app/services/session.js
+++ b/orga/app/services/session.js
@@ -8,14 +8,14 @@ export default class CurrentSessionService extends SessionService {
 
   routeAfterAuthentication = 'authenticated';
 
-  async handleAuthentication() {
-    if (this.skipAuthentication) {
-      return;
-    }
-    await this.currentUser.load();
+  // async handleAuthentication() {
+  //   // if (this.skipAuthentication) {
+  //   //   return;
+  //   // }
+  //   await this.currentUser.load();
 
-    super.handleAuthentication(this.routeAfterAuthentication);
-  }
+  //   super.handleAuthentication(this.routeAfterAuthentication);
+  // }
 
   handleInvalidation() {
     this.store.clear();

--- a/orga/app/templates/authentication/error.gjs
+++ b/orga/app/templates/authentication/error.gjs
@@ -1,0 +1,1 @@
+<template>GROSSE ERREUR</template>

--- a/orga/tests/integration/components/authentication/login-form-test.gjs
+++ b/orga/tests/integration/components/authentication/login-form-test.gjs
@@ -51,4 +51,19 @@ module('Integration | Component | LoginForm', function (hooks) {
       assert.dom(screen.getByText('This is an error')).exists();
     });
   });
+
+  module('when there is an organization access error during an OIDC authentication', function () {
+    test('it displays an error message', async function (assert) {
+      // given & when
+      const onSubmitStub = sinon.stub();
+      const screen = await render(
+        <template>
+          <LoginForm @onSubmit={{onSubmitStub}} @errorMessage={{t "pages.login-form.errors.access-not-allowed"}} />
+        </template>,
+      );
+
+      // then
+      assert.dom(screen.getByText(t('pages.login-form.errors.access-not-allowed'))).exists();
+    });
+  });
 });

--- a/orga/tests/unit/routes/authentication/oidc/flow-test.js
+++ b/orga/tests/unit/routes/authentication/oidc/flow-test.js
@@ -79,6 +79,66 @@ module('Unit | Route | Authentication | OIDC | flow', function (hooks) {
       });
     });
 
+    module('when there is a PIX_ORGA_ACCESS_NOT_ALLOWED error', function () {
+      test('it redirects to authentication.login page with an error code in query params', async function (assert) {
+        // given
+        const authenticateStub = sinon.stub().rejects({
+          errors: [
+            {
+              code: 'PIX_ORGA_ACCESS_NOT_ALLOWED',
+            },
+          ],
+        });
+        const sessionStub = Service.create({
+          authenticate: authenticateStub,
+          data: {},
+        });
+        const route = this.owner.lookup('route:authentication/oidc.flow');
+        route.set('session', sessionStub);
+        route.router = { transitionTo: sinon.stub() };
+
+        // when
+        await route.model({ identity_provider_slug: 'oidc-partner' }, { to: { queryParams: { code: 'test' } } });
+
+        // then
+        sinon.assert.calledOnce(authenticateStub);
+        sinon.assert.calledWith(route.router.transitionTo, 'authentication.login', {
+          queryParams: { error: 'PIX_ORGA_ACCESS_NOT_ALLOWED' },
+        });
+        assert.ok(true);
+      });
+    });
+
+    module('when there is a SHOULD_VALIDATE_CGU error', function () {
+      test('it redirects to authentication.login page with an error code in query params', async function (assert) {
+        // given
+        const authenticateStub = sinon.stub().rejects({
+          errors: [
+            {
+              code: 'SHOULD_VALIDATE_CGU',
+            },
+          ],
+        });
+        const sessionStub = Service.create({
+          authenticate: authenticateStub,
+          data: {},
+        });
+        const route = this.owner.lookup('route:authentication/oidc.flow');
+        route.set('session', sessionStub);
+        route.router = { transitionTo: sinon.stub() };
+
+        // when
+        await route.model({ identity_provider_slug: 'oidc-partner' }, { to: { queryParams: { code: 'test' } } });
+
+        // then
+        sinon.assert.calledOnce(authenticateStub);
+        sinon.assert.calledWith(route.router.transitionTo, 'authentication.login', {
+          queryParams: { error: 'SHOULD_VALIDATE_CGU' },
+        });
+        assert.ok(true);
+      });
+    });
+
     module('when CGU are already validated but authenticate fails', function () {
       test('it throws an error', async function (assert) {
         // given


### PR DESCRIPTION
## ❄️ Problème
Si un personne tente de se connecter via SSO, mais n’a pas de compte ou d’accès à une orga, un message d’erreur doit apparaître.

## 🛷 Proposition
Quand un utilisateur va sur la page de connexion de Pix Orga, sélectionne un SSO et se connecte avec, pour les les cas suivants : 

- S’il n’a pas de compte Pix existant
- S’il a un compte Pix mais accès à aucune organisation

Alors, ne pas le connecter et rediriger vers la page de login (/connexion) avec le même message d’erreur quand un utilisateur tente de se connecter avec un login mais n’a accès à aucune organisation.

## ☃️ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🧑‍🎄 Pour tester

**Cas n°1 - sans invitation**
J'ai un compte Pix trouvé avec le sub, pas de droits Pix Orga (pas de membership), et je me connecte sans invitation via SSO > pas d'affichage de formulaire Pix, ERROR [L'affichage du message d'erreur est gérée par cette PR]

**Cas n°2 - sans invitation**
2.1 Je n'ai pas de compte Pix trouvé avec le sub (le sub n'a pas permis de trouver mon compte), et je me connecte sans invitation via SSO > formulaire d'association de compte > je n'ai pas de de compte autorisé > ERROR  [L'affichage du message d'erreur est gérée par cette PR]

2.2. Je n'ai pas de compte pix trouvé avec le sub, et je me connecte sans invitation via SSO > formulaire d'association de compte > j'ai un compte autorisé > SUCCESS (association du compte Pix et du SSO)

**Cas n°3 - avec invitation**
3.1. Je n'ai pas de compte Pix trouvé avec le sub, des droits Pix Orga, et je me connecte avec invitation via SSO (association) > SUCCESS
3.2. Je n'ai pas de compte Pix trouvé avec le sub, et je crée mon compte Pix avec invitation via SSO > connexion > SUCCESS

**Cas n°4 - avec invitation**
J'ai un compte Pix trouvé avec le sub, pas de droits Pix Orga (pas de membership), et je me connecte avec invitation via SSO > SUCCES

A tester en local pour la connexion SSO : 
- Charger les OIDC Providers grâce à la commande `export OIDC_PROVIDERS=$(cat OIDC_PROVIDERS.json)`
- Réinitialiser la base pour être sûr de n'avoir pas de compte lié à une connexion SSO
- Lancer Pix Orga
- Se connecter via SSO 
- Après le retour du fournisseur de connexion, constater qu'une erreur apparait sur la page de connexion

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
