### PR TITLE
[FEATURE] Afficher le détail du référentiel coeur/transverse (PIX-20903).

### DIFF
--- a/admin/app/components/certification-frameworks/item/framework.gjs
+++ b/admin/app/components/certification-frameworks/item/framework.gjs
@@ -10,7 +10,7 @@ import FrameworkDetails from './framework/framework-details';
 import FrameworkHistory from './framework/framework-history';
 import History from './target-profile/history';
 
-export default class ComplementaryCertificationFramework extends Component {
+export default class CertificationFramework extends Component {
   @service currentUser;
   @service store;
   @tracked targetProfilesHistory;
@@ -24,17 +24,20 @@ export default class ComplementaryCertificationFramework extends Component {
   }
 
   async #onMount() {
+    const frameworkKey = this.args.frameworkKey;
     const complementaryCertification = this.args.complementaryCertification;
-    await complementaryCertification.reload();
 
-    this.targetProfilesHistory = complementaryCertification.targetProfilesHistory;
+    if (complementaryCertification) {
+      await complementaryCertification.reload();
+      this.targetProfilesHistory = complementaryCertification.targetProfilesHistory;
+    }
 
     this.currentConsolidatedFramework = await this.store.findRecord(
       'certification-consolidated-framework',
-      complementaryCertification.key,
+      frameworkKey,
     );
 
-    const frameworkHistory = await this.store.queryRecord('framework-history', complementaryCertification.key);
+    const frameworkHistory = await this.store.queryRecord('framework-history', frameworkKey);
     this.frameworkHistory = frameworkHistory?.history;
   }
 
@@ -61,7 +64,7 @@ export default class ComplementaryCertificationFramework extends Component {
       <FrameworkDetails @currentConsolidatedFramework={{this.currentConsolidatedFramework}} />
     {{/if}}
 
-    {{#if this.frameworkHistory.length}}
+    {{#if this.frameworkHistory}}
       <FrameworkHistory @history={{this.frameworkHistory}} />
     {{/if}}
 

--- a/admin/app/components/certification-frameworks/item/header.gjs
+++ b/admin/app/components/certification-frameworks/item/header.gjs
@@ -6,6 +6,10 @@ import { t } from 'ember-intl';
 export default class Header extends Component {
   @service intl;
 
+  get isComplementaryCertification() {
+    return this.args.complementaryCertification;
+  }
+
   get links() {
     return [
       {
@@ -13,7 +17,8 @@ export default class Header extends Component {
         label: this.intl.t('components.layout.sidebar.certification-frameworks'),
       },
       {
-        label: this.args.complementaryCertification.label,
+        label:
+          this.args.complementaryCertification?.label || this.intl.t('components.certification-frameworks.labels.CORE'),
       },
     ];
   }
@@ -26,13 +31,23 @@ export default class Header extends Component {
     <div class="certification-framework-header">
       <h1 class="certification-framework-header__title">
         <small>
-          {{#if @complementaryCertification.hasComplementaryReferential}}
-            {{t "components.complementary-certifications.item.certification-framework"}}
+          {{#if this.isComplementaryCertification}}
+            {{#if @complementaryCertification.hasComplementaryReferential}}
+              {{t "components.complementary-certifications.item.certification-framework"}}
+            {{else}}
+              {{t "components.complementary-certifications.item.target-profile"}}
+            {{/if}}
           {{else}}
-            {{t "components.complementary-certifications.item.target-profile"}}
+            {{t "components.complementary-certifications.item.certification-framework"}}
           {{/if}}
         </small>
-        <span>{{@complementaryCertification.label}}</span>
+        <span>
+          {{#if this.isComplementaryCertification}}
+            {{@complementaryCertification.label}}
+          {{else}}
+            {{t "components.certification-frameworks.labels.CORE"}}
+          {{/if}}
+        </span>
       </h1>
     </div>
   </template>

--- a/admin/app/components/certification-frameworks/list.gjs
+++ b/admin/app/components/certification-frameworks/list.gjs
@@ -8,14 +8,12 @@ import formatDate from 'ember-intl/helpers/format-date';
 export default class List extends Component {
   get frameworks() {
     return this.args.certificationFrameworks.map((framework) => {
-      const complementaryCertification = this.args.complementaryCertifications.find((cc) => cc.key === framework.id);
-
       return {
         id: framework.id,
         name: framework.name,
         label: `components.certification-frameworks.labels.${framework.id}`,
         activeVersionStartDate: framework.activeVersionStartDate,
-        complementaryCertificationKey: complementaryCertification?.key,
+        frameworkKey: framework.id,
       };
     });
   }
@@ -32,16 +30,9 @@ export default class List extends Component {
             {{t "components.certification-frameworks.list.name"}}
           </:header>
           <:cell>
-            {{#if framework.complementaryCertificationKey}}
-              <LinkTo
-                @route="authenticated.certification-frameworks.item"
-                @model={{framework.complementaryCertificationKey}}
-              >
-                {{t framework.label}}
-              </LinkTo>
-            {{else}}
+            <LinkTo @route="authenticated.certification-frameworks.item" @model={{framework.frameworkKey}}>
               {{t framework.label}}
-            {{/if}}
+            </LinkTo>
           </:cell>
         </PixTableColumn>
         <PixTableColumn @context={{context}}>

--- a/admin/app/routes/authenticated/certification-frameworks/item.js
+++ b/admin/app/routes/authenticated/certification-frameworks/item.js
@@ -10,13 +10,20 @@ export default class ItemRoute extends Route {
   }
 
   model(params) {
+    this.certificationFrameworkKey = params.certification_framework_key;
     const complementaryCertifications = this.store.peekAll('complementary-certification');
-    return complementaryCertifications.find((cc) => cc.key === params.certification_framework_key);
+    const currentComplementaryCertification = complementaryCertifications.find(
+      (cc) => cc.key === params.certification_framework_key,
+    );
+    return {
+      frameworkKey: this.certificationFrameworkKey,
+      currentComplementaryCertification,
+    };
   }
 
   redirect(model, transition) {
     if (transition.to.name === 'authenticated.certification-frameworks.item.index') {
-      if (model.hasComplementaryReferential) {
+      if (this.certificationFrameworkKey !== 'CLEA') {
         this.router.transitionTo('authenticated.certification-frameworks.item.framework');
       } else {
         this.router.transitionTo('authenticated.certification-frameworks.item.target-profile');

--- a/admin/app/routes/authenticated/certification-frameworks/item/target-profile/index.js
+++ b/admin/app/routes/authenticated/certification-frameworks/item/target-profile/index.js
@@ -2,8 +2,8 @@ import Route from '@ember/routing/route';
 
 export default class TargetProfileIndexRoute extends Route {
   async model() {
-    const complementaryCertification = await this.modelFor('authenticated.certification-frameworks.item');
-    await complementaryCertification.reload();
-    return complementaryCertification;
+    const { currentComplementaryCertification } = await this.modelFor('authenticated.certification-frameworks.item');
+    await currentComplementaryCertification.reload();
+    return currentComplementaryCertification;
   }
 }

--- a/admin/app/routes/authenticated/certification-frameworks/item/target-profile/new.js
+++ b/admin/app/routes/authenticated/certification-frameworks/item/target-profile/new.js
@@ -9,10 +9,12 @@ export default class AttachTargetProfileNewRoute extends Route {
   }
 
   model(_) {
-    const complementaryCertification = this.modelFor('authenticated.certification-frameworks.item.target-profile');
+    const { currentComplementaryCertification } = this.modelFor(
+      'authenticated.certification-frameworks.item.target-profile',
+    );
 
     return {
-      complementaryCertification,
+      complementaryCertification: currentComplementaryCertification,
       currentTargetProfile: null,
     };
   }

--- a/admin/app/routes/authenticated/certification-frameworks/item/target-profile/update.js
+++ b/admin/app/routes/authenticated/certification-frameworks/item/target-profile/update.js
@@ -9,13 +9,17 @@ export default class AttachTargetProfileRoute extends Route {
   }
 
   model(params) {
-    const complementaryCertification = this.modelFor('authenticated.certification-frameworks.item.target-profile');
+    const { currentComplementaryCertification } = this.modelFor(
+      'authenticated.certification-frameworks.item.target-profile',
+    );
 
     const targetProfileId = parseInt(params.target_profile_id);
 
     return {
-      complementaryCertification,
-      currentTargetProfile: complementaryCertification.currentTargetProfiles?.find(({ id }) => id === targetProfileId),
+      complementaryCertification: currentComplementaryCertification,
+      currentTargetProfile: currentComplementaryCertification.currentTargetProfiles?.find(
+        ({ id }) => id === targetProfileId,
+      ),
     };
   }
 }

--- a/admin/app/templates/authenticated/certification-frameworks/item.gjs
+++ b/admin/app/templates/authenticated/certification-frameworks/item.gjs
@@ -5,7 +5,7 @@ import Header from 'pix-admin/components/certification-frameworks/item/header';
   {{pageTitle "Référentiel " @model.label " | Pix Admin" replace=true}}
 
   <div class="page">
-    <Header @complementaryCertification={{@model}} />
+    <Header @complementaryCertification={{@model.currentComplementaryCertification}} />
 
     <section class="page-body certification-framework certification-framework__header">
       {{outlet}}

--- a/admin/app/templates/authenticated/certification-frameworks/item/framework/index.gjs
+++ b/admin/app/templates/authenticated/certification-frameworks/item/framework/index.gjs
@@ -1,3 +1,8 @@
 import Framework from 'pix-admin/components/certification-frameworks/item/framework';
 
-<template><Framework @complementaryCertification={{@model}} /></template>
+<template>
+  <Framework
+    @frameworkKey={{@model.frameworkKey}}
+    @complementaryCertification={{@model.currentComplementaryCertification}}
+  />
+</template>

--- a/admin/tests/acceptance/authenticated/certification-frameworks/item-test.js
+++ b/admin/tests/acceptance/authenticated/certification-frameworks/item-test.js
@@ -29,28 +29,34 @@ module('Acceptance | Complementary certifications | Complementary certification 
     assert.strictEqual(currentURL(), '/certification-frameworks/KEY/framework');
   });
 
-  test('it should render target profile page when complementary has no complementary referential', async function (assert) {
+  test('it should render target profile page when the framework is CLEA', async function (assert) {
     // given
     await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+
     server.create('complementary-certification', {
       id: 1,
       hasComplementaryReferential: false,
-      key: 'KEY',
-      label: 'MARIANNE CERTIF',
+      key: 'CLEA',
+      label: 'Cléa',
       targetProfilesHistory: [
         { name: 'ALEX TARGET', id: 3, attachedAt: new Date('2023-10-10T10:50:00Z') },
         { name: 'JEREM TARGET', id: 2, attachedAt: new Date('2020-10-10T10:50:00Z') },
       ],
     });
+
     server.create('target-profile', {
       id: 2,
       name: 'JEREM TARGET',
     });
 
+    server.create('certification-consolidated-framework', {
+      id: 'CLEA',
+    });
+
     // when
-    await visit('/certification-frameworks/KEY');
+    await visit('/certification-frameworks/CLEA/');
 
     // then
-    assert.strictEqual(currentURL(), '/certification-frameworks/KEY/target-profile');
+    assert.strictEqual(currentURL(), '/certification-frameworks/CLEA/target-profile');
   });
 });

--- a/admin/tests/acceptance/authenticated/certification-frameworks/list-test.js
+++ b/admin/tests/acceptance/authenticated/certification-frameworks/list-test.js
@@ -1,5 +1,6 @@
 import { visit } from '@1024pix/ember-testing-library';
 import { click, currentURL } from '@ember/test-helpers';
+import { t } from 'ember-intl/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateAdminMemberWithRole } from 'pix-admin/tests/helpers/test-init';
 import { setupMirage } from 'pix-admin/tests/test-support/setup-mirage';
@@ -49,37 +50,27 @@ module('Acceptance | Certification frameworks | list', function (hooks) {
       const screen = await visit('/certification-frameworks');
 
       // then
-      assert.dom(screen.getByText('Nom')).exists({ count: 1 });
-      assert.dom(screen.getByRole('link', { name: 'Pix+ Droit' })).exists({ count: 1 });
-      assert.dom(screen.getByText('Date de début de la version active')).exists({ count: 1 });
+      assert.dom(screen.getByText(t('components.certification-frameworks.list.name'))).exists({ count: 1 });
+      assert
+        .dom(screen.getByRole('link', { name: t('components.certification-frameworks.labels.DROIT') }))
+        .exists({ count: 1 });
+      assert
+        .dom(screen.getByText(t('components.certification-frameworks.list.active-version-start-date')))
+        .exists({ count: 1 });
     });
 
-    test('it should redirect to certification framework details on click', async function (assert) {
+    test('it should redirect to the certification framework details on click', async function (assert) {
       // given
-      server.create('certification-framework', { id: 'DROIT' });
-      server.create('complementary-certification', {
-        id: 1,
-        key: 'DROIT',
-        label: 'Pix+ Droit',
-        hasComplementaryReferential: true,
-        targetProfilesHistory: [
-          {
-            id: 52,
-            name: 'Stephen target',
-            badges: [],
-          },
-        ],
-      });
-
-      server.create('certification-consolidated-framework', { id: 'DROIT' });
+      server.create('certification-framework', { id: 'CORE' });
+      server.create('certification-consolidated-framework', { id: 'CORE' });
 
       const screen = await visit('/certification-frameworks');
 
       // when
-      await click(screen.getByRole('link', { name: 'Pix+ Droit' }));
+      await click(screen.getByRole('link', { name: t('components.certification-frameworks.labels.CORE') }));
 
       // then
-      assert.strictEqual(currentURL(), '/certification-frameworks/DROIT/framework');
+      assert.strictEqual(currentURL(), '/certification-frameworks/CORE/framework');
     });
   });
 });

--- a/admin/tests/integration/components/certification-frameworks/item/framework-test.gjs
+++ b/admin/tests/integration/components/certification-frameworks/item/framework-test.gjs
@@ -25,7 +25,6 @@ module('Integration | Component | complementary-certifications/item/framework', 
     });
 
     test('it should display a framework creation button', async function (assert) {
-      // given
       const complementaryCertification = {
         key: 'complementary-certification-key',
         targetProfilesHistory: [],
@@ -33,49 +32,41 @@ module('Integration | Component | complementary-certifications/item/framework', 
       };
       store.findRecord = sinon.stub().returns();
 
-      // when
       const screen = await render(
         <template><Framework @complementaryCertification={{complementaryCertification}} /></template>,
       );
 
-      // then
       assert.dom(screen.getByText(t('components.complementary-certifications.item.framework.create-button'))).exists();
     });
 
-    module('when there is no current consolidated framework', function () {
-      test('it should display the information and not the details component', async function (assert) {
-        // given
-        const complementaryCertification = {
-          key: 'complementary-certification-key',
-          targetProfilesHistory: [],
-          reload: sinon.stub().resolves(),
-        };
-        store.findRecord = sinon.stub().returns();
+    test('it should display the information and not the details component when there is no current consolidated framework', async function (assert) {
+      const complementaryCertification = {
+        key: 'complementary-certification-key',
+        targetProfilesHistory: [],
+        reload: sinon.stub().resolves(),
+      };
+      store.findRecord = sinon.stub().returns();
 
-        // when
-        const screen = await render(
-          <template><Framework @complementaryCertification={{complementaryCertification}} /></template>,
-        );
+      const screen = await render(
+        <template><Framework @complementaryCertification={{complementaryCertification}} /></template>,
+      );
 
-        // then
-        assert
-          .dom(screen.getByText(t('components.complementary-certifications.item.framework.no-current-framework')))
-          .exists();
+      assert
+        .dom(screen.getByText(t('components.complementary-certifications.item.framework.no-current-framework')))
+        .exists();
 
-        assert
-          .dom(
-            screen.queryByRole('heading', {
-              name: t('components.complementary-certifications.item.framework.details.title'),
-            }),
-          )
-          .doesNotExist();
-      });
+      assert
+        .dom(
+          screen.queryByRole('heading', {
+            name: t('components.complementary-certifications.item.framework.details.title'),
+          }),
+        )
+        .doesNotExist();
     });
   });
 
   module('when user has another accepted role', function () {
     test('it should not display a framework creation button', async function (assert) {
-      // given
       const complementaryCertification = {
         key: 'complementary-certification-key',
         targetProfilesHistory: [],
@@ -83,113 +74,196 @@ module('Integration | Component | complementary-certifications/item/framework', 
       };
       store.findRecord = sinon.stub().returns();
 
-      // when
       const screen = await render(
         <template><Framework @complementaryCertification={{complementaryCertification}} /></template>,
       );
 
-      // then
       assert
         .dom(screen.queryByText(t('components.complementary-certifications.item.framework.create-button')))
         .doesNotExist();
     });
   });
 
-  module('for all accepted roles', function () {
-    module('when a current consolidated framework exists', function () {
-      test('it should display the details component', async function (assert) {
-        // given
-        const complementaryCertification = {
-          key: 'complementary-certification-key',
-          targetProfilesHistory: [],
-          reload: sinon.stub().resolves(),
-        };
-        store.findRecord = sinon.stub().resolves({
-          hasMany: sinon.stub().returns({
-            value: sinon.stub().returns([]),
-          }),
-        });
-
-        // when
-        const screen = await render(
-          <template><Framework @complementaryCertification={{complementaryCertification}} /></template>,
-        );
-
-        // then
-        assert
-          .dom(
-            screen.getByRole('heading', {
-              name: t('components.complementary-certifications.item.framework.details.title'),
-            }),
-          )
-          .exists();
+  module('when a current consolidated framework exists', function () {
+    test('it should display the details component', async function (assert) {
+      const complementaryCertification = {
+        key: 'complementary-certification-key',
+        targetProfilesHistory: [],
+        reload: sinon.stub().resolves(),
+      };
+      store.findRecord = sinon.stub().resolves({
+        hasMany: sinon.stub().returns({
+          value: sinon.stub().returns([]),
+        }),
       });
+
+      const screen = await render(
+        <template><Framework @complementaryCertification={{complementaryCertification}} /></template>,
+      );
+
+      assert
+        .dom(
+          screen.getByRole('heading', {
+            name: t('components.complementary-certifications.item.framework.details.title'),
+          }),
+        )
+        .exists();
+    });
+  });
+
+  module('#frameworkHistory', function () {
+    test('it should not display the framework history when there is no existing framework history', async function (assert) {
+      const complementaryCertification = {
+        key: 'complementary-certification-key',
+        targetProfilesHistory: [],
+        reload: sinon.stub().resolves(),
+      };
+      store.findRecord = sinon.stub().resolves({
+        hasMany: sinon.stub().returns({
+          value: sinon.stub().returns([]),
+        }),
+      });
+      store.queryRecord = sinon.stub().resolves({ history: [] });
+
+      const screen = await render(
+        <template><Framework @complementaryCertification={{complementaryCertification}} /></template>,
+      );
+
+      assert
+        .dom(
+          screen.queryByRole('heading', {
+            name: t('components.complementary-certifications.item.framework.history.title'),
+          }),
+        )
+        .doesNotExist();
     });
 
-    module('#frameworkHistory', function () {
-      module('when there is no existing framework history', function () {
-        test('it should not display the framework history', async function (assert) {
-          // given
-          const complementaryCertification = {
-            key: 'complementary-certification-key',
-            targetProfilesHistory: [],
-            reload: sinon.stub().resolves(),
-          };
-          store.findRecord = sinon.stub().resolves({
-            hasMany: sinon.stub().returns({
-              value: sinon.stub().returns([]),
-            }),
-          });
-          store.queryRecord = sinon.stub().resolves({ history: [] });
-
-          // when
-          const screen = await render(
-            <template><Framework @complementaryCertification={{complementaryCertification}} /></template>,
-          );
-
-          // then
-          assert
-            .dom(
-              screen.queryByRole('heading', {
-                name: t('components.complementary-certifications.item.framework.history.title'),
-              }),
-            )
-            .doesNotExist();
-        });
+    test('it should display the framework history when there are existing framework versions', async function (assert) {
+      const complementaryCertification = {
+        key: 'complementary-certification-key',
+        targetProfilesHistory: [],
+        reload: sinon.stub().resolves(),
+      };
+      store.findRecord = sinon.stub().resolves({
+        hasMany: sinon.stub().returns({
+          value: sinon.stub().returns([]),
+        }),
       });
+      store.queryRecord = sinon.stub().resolves({ history: ['20250101080000', '20240101080000', '20230101080000'] });
 
-      module('when there are existing framework versions', function () {
-        test('it should display the framework history', async function (assert) {
-          // given
-          const complementaryCertification = {
-            key: 'complementary-certification-key',
-            targetProfilesHistory: [],
-            reload: sinon.stub().resolves(),
-          };
-          store.findRecord = sinon.stub().resolves({
-            hasMany: sinon.stub().returns({
-              value: sinon.stub().returns([]),
-            }),
-          });
-          store.queryRecord = sinon
-            .stub()
-            .resolves({ history: ['20250101080000', '20240101080000', '20230101080000'] });
+      const screen = await render(
+        <template><Framework @complementaryCertification={{complementaryCertification}} /></template>,
+      );
 
-          // when
-          const screen = await render(
-            <template><Framework @complementaryCertification={{complementaryCertification}} /></template>,
-          );
+      assert
+        .dom(
+          screen.getByRole('heading', {
+            name: t('components.complementary-certifications.item.framework.history.title'),
+          }),
+        )
+        .exists();
+    });
+  });
 
-          // then
-          assert
-            .dom(
-              screen.getByRole('heading', {
-                name: t('components.complementary-certifications.item.framework.history.title'),
-              }),
-            )
-            .exists();
-        });
+  module('when the framework is CORE', function () {
+    test('it should load and display CORE framework', async function (assert) {
+      store.findRecord = sinon.stub().resolves({
+        hasMany: sinon.stub().returns({
+          value: sinon.stub().returns([]),
+        }),
       });
+      store.queryRecord = sinon.stub().resolves({ history: [] });
+
+      const screen = await render(<template><Framework /></template>);
+
+      assert.ok(
+        store.findRecord.calledWith('certification-consolidated-framework', 'CORE'),
+        'should load CORE framework',
+      );
+      assert
+        .dom(
+          screen.getByRole('heading', {
+            name: t('components.complementary-certifications.item.framework.details.title'),
+          }),
+        )
+        .exists();
+    });
+
+    test('it should not display target profiles history section', async function (assert) {
+      store.findRecord = sinon.stub().resolves({
+        hasMany: sinon.stub().returns({
+          value: sinon.stub().returns([]),
+        }),
+      });
+      store.queryRecord = sinon.stub().resolves({ history: [] });
+
+      const screen = await render(<template><Framework /></template>);
+
+      assert
+        .dom(
+          screen.queryByRole('heading', {
+            name: t('components.complementary-certifications.target-profiles.history-list.title'),
+          }),
+        )
+        .doesNotExist();
+    });
+  });
+
+  module('when the framework is a complementary', function () {
+    test('it should load and display complementary framework', async function (assert) {
+      const complementaryCertification = {
+        key: 'DROIT',
+        targetProfilesHistory: [{ id: 1 }, { id: 2 }],
+        reload: sinon.stub().resolves(),
+      };
+      store.findRecord = sinon.stub().resolves({
+        hasMany: sinon.stub().returns({
+          value: sinon.stub().returns([]),
+        }),
+      });
+      store.queryRecord = sinon.stub().resolves({ history: [] });
+
+      const screen = await render(
+        <template><Framework @complementaryCertification={{complementaryCertification}} /></template>,
+      );
+
+      assert.ok(
+        store.findRecord.calledWith('certification-consolidated-framework', 'DROIT'),
+        'should load complementary framework',
+      );
+      assert
+        .dom(
+          screen.getByRole('heading', {
+            name: t('components.complementary-certifications.item.framework.details.title'),
+          }),
+        )
+        .exists();
+    });
+
+    test('it should display target profiles history section', async function (assert) {
+      const complementaryCertification = {
+        key: 'DROIT',
+        targetProfilesHistory: [{ id: 1 }, { id: 2 }],
+        reload: sinon.stub().resolves(),
+      };
+      store.findRecord = sinon.stub().resolves({
+        hasMany: sinon.stub().returns({
+          value: sinon.stub().returns([]),
+        }),
+      });
+      store.queryRecord = sinon.stub().resolves({ history: [] });
+
+      const screen = await render(
+        <template><Framework @complementaryCertification={{complementaryCertification}} /></template>,
+      );
+
+      assert
+        .dom(
+          screen.getByRole('heading', {
+            name: t('components.complementary-certifications.target-profiles.history-list.title'),
+          }),
+        )
+        .exists();
     });
   });
 });

--- a/admin/tests/integration/components/certification-frameworks/item/framework-test.gjs
+++ b/admin/tests/integration/components/certification-frameworks/item/framework-test.gjs
@@ -5,7 +5,7 @@ import sinon from 'sinon';
 
 import setupIntlRenderingTest, { t } from '../../../../helpers/setup-intl-rendering';
 
-module('Integration | Component | complementary-certifications/item/framework', function (hooks) {
+module('Integration | Component | certification-frameworks/item/framework', function (hooks) {
   setupIntlRenderingTest(hooks);
 
   let store;
@@ -33,7 +33,12 @@ module('Integration | Component | complementary-certifications/item/framework', 
       store.findRecord = sinon.stub().returns();
 
       const screen = await render(
-        <template><Framework @complementaryCertification={{complementaryCertification}} /></template>,
+        <template>
+          <Framework
+            @complementaryCertification={{complementaryCertification}}
+            @frameworkKey={{complementaryCertification.key}}
+          />
+        </template>,
       );
 
       assert.dom(screen.getByText(t('components.complementary-certifications.item.framework.create-button'))).exists();
@@ -48,7 +53,12 @@ module('Integration | Component | complementary-certifications/item/framework', 
       store.findRecord = sinon.stub().returns();
 
       const screen = await render(
-        <template><Framework @complementaryCertification={{complementaryCertification}} /></template>,
+        <template>
+          <Framework
+            @complementaryCertification={{complementaryCertification}}
+            @frameworkKey={{complementaryCertification.key}}
+          />
+        </template>,
       );
 
       assert
@@ -75,7 +85,12 @@ module('Integration | Component | complementary-certifications/item/framework', 
       store.findRecord = sinon.stub().returns();
 
       const screen = await render(
-        <template><Framework @complementaryCertification={{complementaryCertification}} /></template>,
+        <template>
+          <Framework
+            @complementaryCertification={{complementaryCertification}}
+            @frameworkKey={{complementaryCertification.key}}
+          />
+        </template>,
       );
 
       assert
@@ -98,7 +113,12 @@ module('Integration | Component | complementary-certifications/item/framework', 
       });
 
       const screen = await render(
-        <template><Framework @complementaryCertification={{complementaryCertification}} /></template>,
+        <template>
+          <Framework
+            @complementaryCertification={{complementaryCertification}}
+            @frameworkKey={{complementaryCertification.key}}
+          />
+        </template>,
       );
 
       assert
@@ -126,7 +146,12 @@ module('Integration | Component | complementary-certifications/item/framework', 
       store.queryRecord = sinon.stub().resolves({ history: [] });
 
       const screen = await render(
-        <template><Framework @complementaryCertification={{complementaryCertification}} /></template>,
+        <template>
+          <Framework
+            @complementaryCertification={{complementaryCertification}}
+            @frameworkKey={{complementaryCertification.key}}
+          />
+        </template>,
       );
 
       assert
@@ -152,7 +177,12 @@ module('Integration | Component | complementary-certifications/item/framework', 
       store.queryRecord = sinon.stub().resolves({ history: ['20250101080000', '20240101080000', '20230101080000'] });
 
       const screen = await render(
-        <template><Framework @complementaryCertification={{complementaryCertification}} /></template>,
+        <template>
+          <Framework
+            @complementaryCertification={{complementaryCertification}}
+            @frameworkKey={{complementaryCertification.key}}
+          />
+        </template>,
       );
 
       assert
@@ -174,7 +204,7 @@ module('Integration | Component | complementary-certifications/item/framework', 
       });
       store.queryRecord = sinon.stub().resolves({ history: [] });
 
-      const screen = await render(<template><Framework /></template>);
+      const screen = await render(<template><Framework @frameworkKey="CORE" /></template>);
 
       assert.ok(
         store.findRecord.calledWith('certification-consolidated-framework', 'CORE'),
@@ -197,7 +227,7 @@ module('Integration | Component | complementary-certifications/item/framework', 
       });
       store.queryRecord = sinon.stub().resolves({ history: [] });
 
-      const screen = await render(<template><Framework /></template>);
+      const screen = await render(<template><Framework @frameworkKey="CORE" /></template>);
 
       assert
         .dom(
@@ -224,7 +254,12 @@ module('Integration | Component | complementary-certifications/item/framework', 
       store.queryRecord = sinon.stub().resolves({ history: [] });
 
       const screen = await render(
-        <template><Framework @complementaryCertification={{complementaryCertification}} /></template>,
+        <template>
+          <Framework
+            @complementaryCertification={{complementaryCertification}}
+            @frameworkKey={{complementaryCertification.key}}
+          />
+        </template>,
       );
 
       assert.ok(
@@ -254,7 +289,12 @@ module('Integration | Component | complementary-certifications/item/framework', 
       store.queryRecord = sinon.stub().resolves({ history: [] });
 
       const screen = await render(
-        <template><Framework @complementaryCertification={{complementaryCertification}} /></template>,
+        <template>
+          <Framework
+            @complementaryCertification={{complementaryCertification}}
+            @frameworkKey={{complementaryCertification.key}}
+          />
+        </template>,
       );
 
       assert

--- a/admin/tests/integration/components/certification-frameworks/item/header-test.gjs
+++ b/admin/tests/integration/components/certification-frameworks/item/header-test.gjs
@@ -7,51 +7,73 @@ import setupIntlRenderingTest, { t } from '../../../../helpers/setup-intl-render
 module('Integration | Component | complementary-certifications/item/header', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  module('when hasComplementaryReferential is true', function () {
-    test('it should display "Référentiel de certification" as title', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const complementaryCertification = store.createRecord('complementary-certification', {
-        id: '0',
-        key: 'DROIT',
-        label: 'Pix+Droit',
-        hasComplementaryReferential: true,
-      });
-
+  module('when the framework is CORE', function () {
+    test('it should display CORE label in breadcrumb', async function (assert) {
       // when
-      const screen = await render(
-        <template><Header @complementaryCertification={{complementaryCertification}} /></template>,
-      );
+      const screen = await render(<template><Header /></template>);
 
       // then
-      const expectedTitle = `${t('components.complementary-certifications.item.certification-framework')} ${complementaryCertification.label}`;
-      assert.ok(screen.getByRole('heading', { name: expectedTitle, level: 1 }));
       const nav = screen.getByRole('navigation');
-      assert.ok(within(nav).getByRole('link', { name: t('components.layout.sidebar.certification-frameworks') }));
+      assert.ok(within(nav).getByText(t('components.certification-frameworks.labels.CORE')));
+    });
+
+    test('it should display "Référentiel de certification" as title', async function (assert) {
+      // when
+      const screen = await render(<template><Header /></template>);
+
+      // then
+      const expectedTitle = `${t('components.complementary-certifications.item.certification-framework')} ${t('components.certification-frameworks.labels.CORE')}`;
+      assert.ok(screen.getByRole('heading', { name: expectedTitle, level: 1 }));
     });
   });
 
-  module('when hasComplementaryReferential is false', function () {
-    test('it should display "Profil cible" as title', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const complementaryCertification = store.createRecord('complementary-certification', {
-        id: '0',
-        key: 'CLEA',
-        label: 'CléA Numérique',
-        hasComplementaryReferential: false,
+  module('when the framework is a complementary', function () {
+    module('when hasComplementaryReferential is true', function () {
+      test('it should display "Référentiel de certification" as title', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const complementaryCertification = store.createRecord('complementary-certification', {
+          id: '0',
+          key: 'DROIT',
+          label: 'Pix+Droit',
+          hasComplementaryReferential: true,
+        });
+
+        // when
+        const screen = await render(
+          <template><Header @complementaryCertification={{complementaryCertification}} /></template>,
+        );
+
+        // then
+        const expectedTitle = `${t('components.complementary-certifications.item.certification-framework')} ${complementaryCertification.label}`;
+        assert.ok(screen.getByRole('heading', { name: expectedTitle, level: 1 }));
+        const nav = screen.getByRole('navigation');
+        assert.ok(within(nav).getByRole('link', { name: t('components.layout.sidebar.certification-frameworks') }));
       });
+    });
 
-      // when
-      const screen = await render(
-        <template><Header @complementaryCertification={{complementaryCertification}} /></template>,
-      );
+    module('when hasComplementaryReferential is false', function () {
+      test('it should display "Profil cible" as title', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const complementaryCertification = store.createRecord('complementary-certification', {
+          id: '0',
+          key: 'CLEA',
+          label: 'CléA Numérique',
+          hasComplementaryReferential: false,
+        });
 
-      // then
-      const expectedTitle = `${t('components.complementary-certifications.item.target-profile')} ${complementaryCertification.label}`;
-      assert.ok(screen.getByRole('heading', { name: expectedTitle, level: 1 }));
-      const nav = screen.getByRole('navigation');
-      assert.ok(within(nav).getByRole('link', { name: t('components.layout.sidebar.certification-frameworks') }));
+        // when
+        const screen = await render(
+          <template><Header @complementaryCertification={{complementaryCertification}} /></template>,
+        );
+
+        // then
+        const expectedTitle = `${t('components.complementary-certifications.item.target-profile')} ${complementaryCertification.label}`;
+        assert.ok(screen.getByRole('heading', { name: expectedTitle, level: 1 }));
+        const nav = screen.getByRole('navigation');
+        assert.ok(within(nav).getByRole('link', { name: t('components.layout.sidebar.certification-frameworks') }));
+      });
     });
   });
 });

--- a/admin/tests/integration/components/certification-frameworks/list-test.gjs
+++ b/admin/tests/integration/components/certification-frameworks/list-test.gjs
@@ -77,7 +77,7 @@ module('Integration | Component | certification-frameworks/list', function (hook
     assert.dom(screen.getByText('-')).exists();
   });
 
-  test('it should display a link to item route when complementary certification exists', async function (assert) {
+  test('it should display a link to item route when the framework exists', async function (assert) {
     // given
     const store = this.owner.lookup('service:store');
     const certificationFrameworks = [
@@ -107,33 +107,5 @@ module('Integration | Component | certification-frameworks/list', function (hook
     const link = screen.getByRole('link', { name: t('components.certification-frameworks.labels.DROIT') });
     assert.dom(link).exists();
     assert.dom(link).hasAttribute('href', '/certification-frameworks/DROIT');
-  });
-
-  test('it should display plain text when complementary certification does not exist', async function (assert) {
-    // given
-    const store = this.owner.lookup('service:store');
-    const certificationFrameworks = [
-      store.createRecord('certification-framework', {
-        id: 'CORE',
-        name: 'Pix',
-      }),
-    ];
-    const complementaryCertifications = [];
-
-    // when
-    const screen = await render(
-      <template>
-        <List
-          @certificationFrameworks={{certificationFrameworks}}
-          @complementaryCertifications={{complementaryCertifications}}
-        />
-      </template>,
-    );
-
-    // then
-    assert
-      .dom(screen.queryByRole('link', { name: t('components.certification-frameworks.labels.CORE') }))
-      .doesNotExist();
-    assert.dom(screen.getByText(t('components.certification-frameworks.labels.CORE'))).exists();
   });
 });


### PR DESCRIPTION
## ❄️ Problème

Jusqu'à présent, nous ne savons afficher que le détail des certifications complémentaires.

Or, aujourd’hui nous listons tous les référentiels, donc Pix Coeur.

## 🛷 Proposition

- Adapter le code pour afficher le détail de référentiel Pix Coeur
- Ajouter le lien vers ce référentiel dans la liste des référentiels de certification

## 🧑‍🎄 Pour tester

- Visiter la page des référentiels de certif sur [PixAdmin en RA](https://admin-pr14645.review.pix.fr/certification-frameworks)
- Constater qu'on peut cliquer sur le lien du référentiel coeur
- Visualiser son détail (référentiel cadre + historique des versions)
