### PR TITLE
[FEATURE] Créer la route permettant de récupérer la liste des modules pour Pix Admin (PIX-20919).

### DIFF
--- a/api/src/devcomp/application/api/modules-api.js
+++ b/api/src/devcomp/application/api/modules-api.js
@@ -14,7 +14,7 @@ const getModulesByIds = async ({ moduleIds }) => {
     return [];
   }
 
-  const modules = await usecases.getModuleMetadataList({ ids: moduleIds });
+  const modules = await usecases.getModuleMetadataListByIds({ ids: moduleIds });
   return modules.map((module) => new Module(module));
 };
 
@@ -46,7 +46,7 @@ const getUserModuleStatuses = async ({ userId, moduleIds }) => {
     return [];
   }
 
-  const moduleMetadataList = await usecases.getModuleMetadataList({ ids: moduleIds });
+  const moduleMetadataList = await usecases.getModuleMetadataListByIds({ ids: moduleIds });
   const userModuleStatus = await usecases.getUserModuleStatuses({ userId, moduleIds });
 
   const moduleMetadataId = new Map();

--- a/api/src/devcomp/application/modules-metadata/module-metadata-controller.js
+++ b/api/src/devcomp/application/modules-metadata/module-metadata-controller.js
@@ -1,0 +1,14 @@
+import { usecases } from '../../domain/usecases/index.js';
+import * as moduleMetadataSerializer from '../../infrastructure/serializers/jsonapi/module-metadata-serializer.js';
+
+async function getAllModulesMetadata() {
+  const modulesMetadata = await usecases.getModuleMetadataList();
+
+  return moduleMetadataSerializer.serialize(modulesMetadata);
+}
+
+const moduleMetadataController = {
+  getAllModulesMetadata,
+};
+
+export { moduleMetadataController };

--- a/api/src/devcomp/application/modules-metadata/module-metadata-route.js
+++ b/api/src/devcomp/application/modules-metadata/module-metadata-route.js
@@ -1,0 +1,28 @@
+import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
+import { moduleMetadataController } from './module-metadata-controller.js';
+
+const register = async function (server) {
+  server.route([
+    {
+      method: 'GET',
+      path: '/api/admin/modules-metadata',
+      config: {
+        handler: (request, h) => moduleMetadataController.getAllModulesMetadata(request, h),
+        notes: ['- Permet de récupérer la liste des métadonnées des modules dans Pix Admin'],
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.hasAtLeastOneAccessOf([
+                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+                securityPreHandlers.checkAdminMemberHasRoleMetier,
+              ])(request, h),
+          },
+        ],
+        tags: ['api', 'admin', 'modules-metadata'],
+      },
+    },
+  ]);
+};
+
+const name = 'modules-metadata-api';
+export { name, register };

--- a/api/src/devcomp/domain/models/module/ModuleMetadata.js
+++ b/api/src/devcomp/domain/models/module/ModuleMetadata.js
@@ -19,6 +19,7 @@ export class ModuleMetadata {
     this.isBeta = isBeta;
     this.duration = Number(duration);
     this.image = image;
+    this.link = `/modules/${this.shortId}/${this.slug}`;
   }
 
   #assertDurationHasPositiveValue(duration) {

--- a/api/src/devcomp/domain/usecases/get-module-metadata-list-by-ids.js
+++ b/api/src/devcomp/domain/usecases/get-module-metadata-list-by-ids.js
@@ -1,0 +1,5 @@
+async function getModuleMetadataListByIds({ ids, moduleMetadataRepository }) {
+  return moduleMetadataRepository.getAllByIds({ ids });
+}
+
+export { getModuleMetadataListByIds };

--- a/api/src/devcomp/domain/usecases/get-module-metadata-list.js
+++ b/api/src/devcomp/domain/usecases/get-module-metadata-list.js
@@ -1,5 +1,5 @@
-async function getModuleMetadataList({ ids, moduleMetadataRepository }) {
-  return moduleMetadataRepository.getAllByIds({ ids });
+async function getModuleMetadataList({ moduleMetadataRepository }) {
+  return moduleMetadataRepository.list();
 }
 
 export { getModuleMetadataList };

--- a/api/src/devcomp/domain/usecases/index.js
+++ b/api/src/devcomp/domain/usecases/index.js
@@ -52,6 +52,7 @@ import { findTargetProfileSummariesForTraining } from './find-target-profile-sum
 import { findTutorials } from './find-tutorials.js';
 import { getModule } from './get-module.js';
 import { getModuleByShortId } from './get-module-by-short-id.js';
+import { getModuleMetadataList } from './get-module-metadata-list.js';
 import { getModuleMetadataListByIds } from './get-module-metadata-list-by-ids.js';
 import { getModuleMetadataListByShortIds } from './get-module-metadata-list-by-short-ids.js';
 import { getTraining } from './get-training.js';
@@ -84,6 +85,7 @@ const usecasesWithoutInjectedDependencies = {
   findRecommendableModulesByTargetProfileIds,
   findTargetProfileSummariesForTraining,
   findTutorials,
+  getModuleMetadataList,
   getModuleMetadataListByIds,
   getModuleMetadataListByShortIds,
   getModule,

--- a/api/src/devcomp/domain/usecases/index.js
+++ b/api/src/devcomp/domain/usecases/index.js
@@ -52,7 +52,7 @@ import { findTargetProfileSummariesForTraining } from './find-target-profile-sum
 import { findTutorials } from './find-tutorials.js';
 import { getModule } from './get-module.js';
 import { getModuleByShortId } from './get-module-by-short-id.js';
-import { getModuleMetadataList } from './get-module-metadata-list.js';
+import { getModuleMetadataListByIds } from './get-module-metadata-list-by-ids.js';
 import { getModuleMetadataListByShortIds } from './get-module-metadata-list-by-short-ids.js';
 import { getTraining } from './get-training.js';
 import { getUserModuleStatuses } from './get-user-module-statuses.js';
@@ -84,7 +84,7 @@ const usecasesWithoutInjectedDependencies = {
   findRecommendableModulesByTargetProfileIds,
   findTargetProfileSummariesForTraining,
   findTutorials,
-  getModuleMetadataList,
+  getModuleMetadataListByIds,
   getModuleMetadataListByShortIds,
   getModule,
   getModuleByShortId,

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/galerie.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/galerie.json
@@ -7,7 +7,7 @@
   "details": {
     "image": "https://assets.pix.org/modules/placeholder-details.svg",
     "description": "<p>Ce module est dédié à des tests internes à Pix.</p><p>Il permet de visualiser tous les modules existants.</p>",
-    "duration": 0,
+    "duration": 1,
     "level": "novice",
     "objectives": [
       "<p>Découvrir les éléments de la galerie Modulix</p>"

--- a/api/src/devcomp/infrastructure/repositories/module-metadata-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/module-metadata-repository.js
@@ -37,9 +37,14 @@ async function getBySlug({ slug, moduleDatasource }) {
   }
 }
 
+async function list({ moduleDatasource }) {
+  const modules = await moduleDatasource.list();
+  return modules.map(_toDomain);
+}
+
 function _toDomain(module) {
   const { id, shortId, slug, title, isBeta, details } = module;
   return new ModuleMetadata({ id, shortId, slug, title, isBeta, duration: details.duration, image: details.image });
 }
 
-export { getAllByIds, getAllByShortIds, getByShortId, getBySlug };
+export { getAllByIds, getAllByShortIds, getByShortId, getBySlug, list };

--- a/api/src/devcomp/infrastructure/serializers/jsonapi/module-metadata-serializer.js
+++ b/api/src/devcomp/infrastructure/serializers/jsonapi/module-metadata-serializer.js
@@ -1,0 +1,11 @@
+import jsonapiSerializer from 'jsonapi-serializer';
+
+const { Serializer } = jsonapiSerializer;
+
+const serialize = function (moduleMetadataList) {
+  return new Serializer('module-metadata', {
+    attributes: ['shortId', 'slug', 'title', 'isBeta', 'duration', 'image', 'link'],
+  }).serialize(moduleMetadataList);
+};
+
+export { serialize };

--- a/api/src/devcomp/routes.js
+++ b/api/src/devcomp/routes.js
@@ -1,6 +1,7 @@
 import * as campaignParticipationRoute from './application/campaign-participations/campaign-participation-route.js';
 import * as moduleIssueReport from './application/module-issue-report/module-issue-report-route.js';
 import * as modulesRoutes from './application/modules/module-route.js';
+import * as modulesMetadataRoutes from './application/modules-metadata/module-metadata-route.js';
 import * as passageEvents from './application/passage-events/passage-event-route.js';
 import * as passages from './application/passages/passage-route.js';
 import * as trainings from './application/trainings/training-route.js';
@@ -12,6 +13,7 @@ const devcompRoutes = [
   campaignParticipationRoute,
   moduleIssueReport,
   modulesRoutes,
+  modulesMetadataRoutes,
   passages,
   passageEvents,
   trainings,

--- a/api/tests/devcomp/acceptance/application/modules-metadata/module-metadata-route_test.js
+++ b/api/tests/devcomp/acceptance/application/modules-metadata/module-metadata-route_test.js
@@ -1,0 +1,35 @@
+import {
+  createServer,
+  databaseBuilder,
+  expect,
+  generateAuthenticatedUserRequestHeaders,
+  insertUserWithRoleSuperAdmin,
+} from '../../../../test-helper.js';
+
+describe('Acceptance | Controller | Modules Metadata | Route', function () {
+  let server;
+
+  beforeEach(async function () {
+    server = await createServer();
+  });
+
+  describe('GET /api/admin/modules-metadata', function () {
+    context('when modules exists', function () {
+      it('should return modules metadata', async function () {
+        // given
+        const superAdmin = await insertUserWithRoleSuperAdmin();
+        await databaseBuilder.commit();
+
+        const options = {
+          method: 'GET',
+          url: `/api/admin/modules-metadata`,
+          headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
+        };
+
+        const response = await server.inject(options);
+
+        expect(response.statusCode).to.equal(200);
+      });
+    });
+  });
+});

--- a/api/tests/devcomp/integration/application/modules-metadata/modules-metadata-route-test.js
+++ b/api/tests/devcomp/integration/application/modules-metadata/modules-metadata-route-test.js
@@ -1,0 +1,38 @@
+import { PIX_ADMIN } from '../../../../../src/authorization/domain/constants.js';
+import * as moduleUnderTest from '../../../../../src/devcomp/application/modules-metadata/module-metadata-route.js';
+import {
+  databaseBuilder,
+  expect,
+  generateAuthenticatedUserRequestHeaders,
+  HttpTestServer,
+} from '../../../../test-helper.js';
+
+describe('Integration | Devcomp | Application | Route | ModulesMetadata', function () {
+  let httpTestServer;
+
+  beforeEach(async function () {
+    httpTestServer = new HttpTestServer();
+    httpTestServer.setupAuthentication();
+    await httpTestServer.register(moduleUnderTest);
+  });
+
+  describe('GET /api/admin/modules-metadata', function () {
+    context('when user does not have superadmin or metier role', function () {
+      it('returns 403 HTTP status code', async function () {
+        // given
+        const user = databaseBuilder.factory.buildUser.withRole({ role: PIX_ADMIN.ROLES.CERTIF });
+        //  when
+        const response = await httpTestServer.request(
+          'GET',
+          '/api/admin/modules-metadata',
+          null,
+          null,
+          generateAuthenticatedUserRequestHeaders({ userId: user.id }),
+        );
+
+        // then
+        expect(response.statusCode).to.equal(403);
+      });
+    });
+  });
+});

--- a/api/tests/devcomp/integration/repositories/module-metadata-repository_test.js
+++ b/api/tests/devcomp/integration/repositories/module-metadata-repository_test.js
@@ -479,4 +479,327 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
       expect(error).to.be.instanceOf(NotFoundError);
     });
   });
+
+  describe('#list', function () {
+    it('should return a list of modules metadata', async function () {
+      const emailModule = {
+        id: 'f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d',
+        shortId: 'gbsri73s',
+        slug: 'bien-ecrire-son-adresse-mail',
+        title: 'Bien écrire son adresse mail',
+        isBeta: true,
+        details: {
+          image: 'https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-details.svg',
+          description:
+            'Apprendre à rédiger correctement une adresse e-mail pour assurer une meilleure communication et éviter les erreurs courantes.',
+          duration: 12,
+          level: 'novice',
+          tabletSupport: 'comfortable',
+          objectives: [
+            'Écrire une adresse mail correctement, en évitant les erreurs courantes',
+            'Connaître les parties d’une adresse mail et les identifier sur des exemples',
+            'Comprendre les fonctions des parties d’une adresse mail',
+          ],
+        },
+        sections: [
+          {
+            id: '5bf1c672-3746-4480-b9ac-1f0af9c7c509',
+            type: 'practise',
+            grains: [
+              {
+                id: 'z1f3c8c7-6d5c-4c6c-9c4d-1a3d8f7e9f5d',
+                type: 'lesson',
+                title: 'Explications : les parties d’une adresse mail',
+                components: [
+                  {
+                    type: 'element',
+                    element: {
+                      id: 'd9e8a7b6-5c4d-3e2f-1a0b-9f8e7d6c5b4a',
+                      type: 'text',
+                      content:
+                        "<h4 class='screen-reader-only'>L'arobase</h4><p>L’arobase est dans toutes les adresses mails. Il sépare l’identifiant et le fournisseur d’adresse mail.</p><p><span aria-hidden='true'>🇬🇧</span> En anglais, ce symbole se lit <i lang='en'>“at”</i> qui veut dire “chez”.</p><p><span aria-hidden='true'>🤔</span> Le saviez-vous : c’est un symbole qui était utilisé bien avant l’informatique ! Par exemple, pour compter des quantités.</p>",
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+      const bacASableModule = {
+        id: '6282925d-4775-4bca-b513-4c3009ec5886',
+        shortId: '6a68bf32',
+        slug: 'bac-a-sable',
+        title: 'Bac à sable',
+        isBeta: true,
+        details: {
+          image: 'https://assets.pix.org/modules/placeholder-details.svg',
+          description:
+            "<p>Ce module est dédié à des tests internes à Pix.</p><p>Il contient normalement l'intégralité des fonctionnalités disponibles à date.</p>",
+          duration: 5,
+          level: 'novice',
+          tabletSupport: 'inconvenient',
+          objectives: ['Non régression fonctionnelle'],
+        },
+        sections: [
+          {
+            id: 'cfaefec9-e185-43b8-8258-e8beff6dd56b',
+            type: 'question-yourself',
+            grains: [
+              {
+                id: '533c69b8-a836-41be-8ffc-8d4636e31224',
+                type: 'activity',
+                title: 'Voici un vrai-faux',
+                components: [
+                  {
+                    type: 'element',
+                    element: {
+                      id: '96e29215-3610-4bc6-b4a6-026bf13276b8',
+                      type: 'short-video',
+                      title: 'Exemple de vidéo courte',
+                      url: 'https://assets.pix.org/modules/bac-a-sable/clic-droit.mp4',
+                      transcription: 'Je clique avec le bouton droit de la souris.',
+                    },
+                  },
+                  {
+                    type: 'stepper',
+                    steps: [
+                      {
+                        elements: [
+                          {
+                            id: '71de6394-ff88-4de3-8834-a40057a50ff4',
+                            type: 'qcu',
+                            instruction: '<p>Pix évalue 16 compétences numériques différentes.</p>',
+                            proposals: [
+                              {
+                                id: '1',
+                                content: 'Vrai',
+                                feedback: {
+                                  state: 'Correct&#8239;!',
+                                  diagnosis: '<p> Ces 16 compétences sont rangées dans 5 domaines.</p>',
+                                },
+                              },
+                              {
+                                id: '2',
+                                content: 'Faux',
+                                feedback: {
+                                  state: 'Incorrect.',
+                                  diagnosis:
+                                    '<p> Retourner voir la vidéo si besoin&nbsp;<span aria-hidden="true">👆</span>!</p>',
+                                },
+                              },
+                            ],
+                            solution: '1',
+                          },
+                        ],
+                      },
+                      {
+                        elements: [
+                          {
+                            id: '0f8eb663-be85-4cb1-9168-e5c39f4ec1bd',
+                            type: 'qrocm',
+                            instruction: '<p>Compléter le texte suivant :</p>',
+                            proposals: [
+                              {
+                                type: 'text',
+                                content: '<span>Pix est un</span>',
+                              },
+                              {
+                                input: 'pix-name',
+                                type: 'input',
+                                inputType: 'text',
+                                size: 10,
+                                display: 'inline',
+                                placeholder: '',
+                                ariaLabel: 'Mot à trouver',
+                                defaultValue: '',
+                                tolerances: ['t1', 't3'],
+                                solutions: ['Groupement'],
+                              },
+                              {
+                                type: 'text',
+                                content: "<span>d'intérêt public qui a été créée en</span>",
+                              },
+                              {
+                                input: 'pix-birth',
+                                type: 'input',
+                                inputType: 'number',
+                                size: 10,
+                                display: 'inline',
+                                placeholder: '',
+                                ariaLabel: 'Année à trouver',
+                                defaultValue: '',
+                                tolerances: [],
+                                solutions: [2016],
+                              },
+                            ],
+                            feedbacks: {
+                              valid: {
+                                state: 'Correct&#8239;!',
+                                diagnosis:
+                                  '<p> vous nous connaissez bien &nbsp; <span aria-hidden="true">🎉</span></p>',
+                              },
+                              invalid: {
+                                state: 'Incorrect&#8239;!',
+                                diagnosis: '<p> vous y arriverez la prochaine fois&#8239;!</p>',
+                              },
+                            },
+                          },
+                        ],
+                      },
+                      {
+                        elements: [
+                          {
+                            id: '79dc17f9-142b-4e19-bcbe-bfde4e170d3f',
+                            type: 'qcu-declarative',
+                            instruction: '<p>Pix est découpé en 6 domaines.</p>',
+                            proposals: [
+                              {
+                                id: '1',
+                                content: 'Vrai',
+                                feedback: {
+                                  diagnosis: '<p> Et non ! Il y a seulement 5 domaines sur Pix.</p>',
+                                },
+                              },
+                              {
+                                id: '2',
+                                content: 'Faux',
+                                feedback: {
+                                  diagnosis: '<p> Bien vu !</p>',
+                                },
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                      {
+                        elements: [
+                          {
+                            id: 'ef18ed04-9551-4cee-9648-9f14a28aab1b',
+                            type: 'qcm',
+                            instruction: '<p>Quels sont les 3 piliers de Pix&#8239;?</p>',
+                            proposals: [
+                              {
+                                id: '1',
+                                content: 'Evaluer ses connaissances et savoir-faire sur 16 compétences du numérique',
+                              },
+                              {
+                                id: '2',
+                                content: 'Développer son savoir-faire sur les jeux de type TPS',
+                              },
+                              {
+                                id: '3',
+                                content: 'Développer ses compétences numériques',
+                              },
+                              {
+                                id: '4',
+                                content: 'Certifier ses compétences Pix',
+                              },
+                              {
+                                id: '5',
+                                content: 'Evaluer ses compétences de logique et compréhension mathématique',
+                              },
+                            ],
+                            feedbacks: {
+                              valid: {
+                                state: 'Correct&#8239;!',
+                                diagnosis: '<p>Vous nous avez bien cernés&nbsp;:)</p>',
+                              },
+                              invalid: {
+                                state: 'Et non&#8239;!',
+                                diagnosis:
+                                  '<p> Pix sert à évaluer, certifier et développer ses compétences numériques.</p>',
+                              },
+                            },
+                            solutions: ['1', '3', '4'],
+                          },
+                        ],
+                      },
+                      {
+                        elements: [
+                          {
+                            id: '7fb4c1c6-46f8-49a4-9547-f9febf545447',
+                            type: 'text',
+                            content: '<p>Voici des photographies de chiens et de bagels.</p>',
+                          },
+                          {
+                            id: '5c25213f-14ec-4107-a1cf-ab1b97271476',
+                            type: 'image',
+                            url: 'https://assets.pix.org/modules/bac-a-sable/des-chiens-et-des-bagels.jpg',
+                            alt: 'Une photo comportant des chiens et des bagels',
+                            alternativeText: '',
+                            legend: '',
+                            licence: '',
+                          },
+                        ],
+                      },
+                      {
+                        elements: [
+                          {
+                            id: 'b1ef75c8-714b-4b2d-8e88-e279c5737095',
+                            type: 'qcu-discovery',
+                            instruction: "<p>Selon vous, combien y'a t-il de chiens dans la photo ?<br></p>",
+                            proposals: [
+                              {
+                                id: '1',
+                                content: '<p>8</p>',
+                                feedback: {
+                                  diagnosis: '<p>Bien joué !</p>',
+                                },
+                              },
+                              {
+                                id: '2',
+                                content: '<p>9</p>',
+                                feedback: {
+                                  diagnosis: "<p>Eh non ! Y'a un bagel dans votre calcul 🥯</p>",
+                                },
+                              },
+                            ],
+                            solution: '1',
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+      const moduleDatasourceStub = {
+        list: sinon.stub(),
+      };
+      moduleDatasourceStub.list.resolves([emailModule, bacASableModule]);
+
+      // when
+      const modulesMetadata = await moduleMetadataRepository.list({ moduleDatasource: moduleDatasourceStub });
+
+      // then
+      const expectedResult = [
+        {
+          id: emailModule.id,
+          shortId: emailModule.shortId,
+          slug: emailModule.slug,
+          title: emailModule.title,
+          isBeta: emailModule.isBeta,
+          duration: emailModule.details.duration,
+          image: emailModule.details.image,
+          link: `/modules/${emailModule.shortId}/${emailModule.slug}`,
+        },
+        {
+          id: bacASableModule.id,
+          shortId: bacASableModule.shortId,
+          slug: bacASableModule.slug,
+          title: bacASableModule.title,
+          isBeta: bacASableModule.isBeta,
+          duration: bacASableModule.details.duration,
+          image: bacASableModule.details.image,
+          link: `/modules/${bacASableModule.shortId}/${bacASableModule.slug}`,
+        },
+      ];
+
+      expect(modulesMetadata).to.deep.equal(expectedResult);
+    });
+  });
 });

--- a/api/tests/devcomp/unit/domain/models/module/ModuleMetadata_test.js
+++ b/api/tests/devcomp/unit/domain/models/module/ModuleMetadata_test.js
@@ -27,6 +27,7 @@ describe('Unit | Devcomp | Domain | Models | Module | ModuleMetadata', function 
     expect(module.isBeta).to.equal(isBeta);
     expect(module.duration).to.equal(duration);
     expect(module.image).to.equal(image);
+    expect(module.link).to.equal(`/modules/${shortId}/${slug}`);
   });
 
   describe('if a module does not have an id', function () {

--- a/api/tests/devcomp/unit/domain/usecases/get-module-metadata-list-by-ids_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/get-module-metadata-list-by-ids_test.js
@@ -1,0 +1,42 @@
+import { getModuleMetadataListByIds } from '../../../../../src/devcomp/domain/usecases/get-module-metadata-list-by-ids.js';
+import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
+import { catchErr, expect, sinon } from '../../../../test-helper.js';
+
+describe('Unit | Devcomp | Domain | UseCases | get-module-metadata-list-by-ids', function () {
+  it('should return a list of ModuleMetadata', async function () {
+    // given
+    const moduleMetadataList = Symbol('moduleMetadataList');
+    const firstId = Symbol('firstId');
+    const secondId = Symbol('secondId');
+    const ids = [firstId, secondId];
+    const moduleMetadataRepository = {
+      getAllByIds: sinon.stub(),
+    };
+
+    moduleMetadataRepository.getAllByIds.withArgs({ ids }).resolves(moduleMetadataList);
+
+    // when
+    const result = await getModuleMetadataListByIds({ ids, moduleMetadataRepository });
+
+    // then
+    expect(result).to.deep.equal(moduleMetadataList);
+    expect(moduleMetadataRepository.getAllByIds).to.have.been.calledWithExactly({ ids });
+  });
+
+  context('when a module id does not exist', function () {
+    it('should throw the NotFoundError thrown by repository', async function () {
+      // given
+      const ids = ['notFoundModuleId1', 'notFoundModuleId2'];
+      const moduleMetadataRepository = {
+        getAllByIds: sinon.stub(),
+      };
+      moduleMetadataRepository.getAllByIds.withArgs({ ids }).throws(new NotFoundError());
+
+      // when
+      const error = await catchErr(getModuleMetadataListByIds)({ ids, moduleMetadataRepository });
+
+      // then
+      expect(error).to.be.instanceOf(NotFoundError);
+    });
+  });
+});

--- a/api/tests/devcomp/unit/domain/usecases/get-module-metadata-list_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/get-module-metadata-list_test.js
@@ -1,138 +1,23 @@
-import { ModuleMetadata } from '../../../../../src/devcomp/domain/models/module/ModuleMetadata.js';
 import { getModuleMetadataList } from '../../../../../src/devcomp/domain/usecases/get-module-metadata-list.js';
-import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
-import { catchErr, expect, sinon } from '../../../../test-helper.js';
+import { expect, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Devcomp | Domain | UseCases | get-module-metadata-list', function () {
-  let firstModule, secondModule, modules;
-
-  beforeEach(function () {
-    firstModule = {
-      id: 'f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d',
-      shortId: 'jh87et25',
-      slug: 'getAllByIdsModuleSlug1',
-      title: 'Bien écrire son adresse mail',
-      isBeta: true,
-      details: {
-        image: 'https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-details.svg',
-        description:
-          'Apprendre à rédiger correctement une adresse e-mail pour assurer une meilleure communication et éviter les erreurs courantes.',
-        duration: 12,
-        level: 'novice',
-        tabletSupport: 'comfortable',
-        objectives: [
-          'Écrire une adresse mail correctement, en évitant les erreurs courantes',
-          'Connaître les parties d’une adresse mail et les identifier sur des exemples',
-          'Comprendre les fonctions des parties d’une adresse mail',
-        ],
-      },
-      grains: [
-        {
-          id: 'z1f3c8c7-6d5c-4c6c-9c4d-1a3d8f7e9f5d',
-          type: 'lesson',
-          title: 'Explications : les parties d’une adresse mail',
-          components: [
-            {
-              type: 'element',
-              element: {
-                id: 'd9e8a7b6-5c4d-3e2f-1a0b-9f8e7d6c5b4a',
-                type: 'text',
-                content:
-                  "<h4 class='screen-reader-only'>L'arobase</h4><p>L’arobase est dans toutes les adresses mails. Il sépare l’identifiant et le fournisseur d’adresse mail.</p><p><span aria-hidden='true'>🇬🇧</span> En anglais, ce symbole se lit <i lang='en'>“at”</i> qui veut dire “chez”.</p><p><span aria-hidden='true'>🤔</span> Le saviez-vous : c’est un symbole qui était utilisé bien avant l’informatique ! Par exemple, pour compter des quantités.</p>",
-              },
-            },
-          ],
-        },
-      ],
-    };
-    secondModule = {
-      id: '6282925d-4775-4bca-b513-4c3009ec5886',
-      shortId: '87ki0tr7',
-      slug: 'getAllByIdsModuleSlug2',
-      title: 'Bac à sable',
-      isBeta: true,
-      details: {
-        image: 'https://assets.pix.org/modules/placeholder-details.svg',
-        description:
-          "<p>Ce module est dédié à des tests internes à Pix.</p><p>Il contient normalement l'intégralité des fonctionnalités disponibles à date.</p>",
-        duration: 5,
-        level: 'novice',
-        tabletSupport: 'inconvenient',
-        objectives: ['Non régression fonctionnelle'],
-      },
-      grains: [
-        {
-          id: 'z1f3c8c7-6d5c-4c6c-9c4d-1a3d8f7e9f5d',
-          type: 'lesson',
-          title: 'Explications : les parties d’une adresse mail',
-          components: [
-            {
-              type: 'element',
-              element: {
-                id: 'd9e8a7b6-5c4d-3e2f-1a0b-9f8e7d6c5b4a',
-                type: 'text',
-                content:
-                  "<h4 class='screen-reader-only'>L'arobase</h4><p>L’arobase est dans toutes les adresses mails. Il sépare l’identifiant et le fournisseur d’adresse mail.</p><p><span aria-hidden='true'>🇬🇧</span> En anglais, ce symbole se lit <i lang='en'>“at”</i> qui veut dire “chez”.</p><p><span aria-hidden='true'>🤔</span> Le saviez-vous : c’est un symbole qui était utilisé bien avant l’informatique ! Par exemple, pour compter des quantités.</p>",
-              },
-            },
-          ],
-        },
-      ],
-    };
-    modules = [firstModule, secondModule];
-  });
-
   it('should return a list of ModuleMetadata', async function () {
     // given
-    const ids = [modules[0].id, modules[1].id];
+    const firstModule = Symbol('firstModule');
+    const secondModule = Symbol('secondModule');
+
     const moduleMetadataRepository = {
-      getAllByIds: sinon.stub(),
+      list: sinon.stub(),
     };
-    const moduleMetadataList = [
-      new ModuleMetadata({
-        id: firstModule.id,
-        shortId: firstModule.shortId,
-        slug: firstModule.slug,
-        title: firstModule.title,
-        isBeta: firstModule.isBeta,
-        duration: firstModule.details.duration,
-        image: firstModule.details.image,
-      }),
-      new ModuleMetadata({
-        id: secondModule.id,
-        shortId: secondModule.shortId,
-        slug: secondModule.slug,
-        title: secondModule.title,
-        isBeta: secondModule.isBeta,
-        duration: secondModule.details.duration,
-        image: secondModule.details.image,
-      }),
-    ];
-    moduleMetadataRepository.getAllByIds.withArgs({ ids }).resolves(moduleMetadataList);
+
+    const moduleMetadataList = [firstModule, secondModule];
+    moduleMetadataRepository.list.withArgs().resolves(moduleMetadataList);
 
     // when
-    const result = await getModuleMetadataList({ ids, moduleMetadataRepository });
+    const result = await getModuleMetadataList({ moduleMetadataRepository });
 
     // then
     expect(result).to.deep.equal(moduleMetadataList);
-    expect(result[0]).instanceOf(ModuleMetadata);
-    expect(result[1]).instanceOf(ModuleMetadata);
-  });
-
-  context('when a module id does not exist', function () {
-    it('should throw the NotFoundError thrown by repository', async function () {
-      // given
-      const ids = ['notFoundModuleId1', 'notFoundModuleId2'];
-      const moduleMetadataRepository = {
-        getAllByIds: sinon.stub(),
-      };
-      moduleMetadataRepository.getAllByIds.withArgs({ ids }).throws(new NotFoundError());
-
-      // when
-      const error = await catchErr(getModuleMetadataList)({ ids, moduleMetadataRepository });
-
-      // then
-      expect(error).to.be.instanceOf(NotFoundError);
-    });
   });
 });

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-metadata-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-metadata-serializer_test.js
@@ -1,0 +1,67 @@
+import { ModuleMetadata } from '../../../../../../src/devcomp/domain/models/module/ModuleMetadata.js';
+import * as moduleMetadataSerializer from '../../../../../../src/devcomp/infrastructure/serializers/jsonapi/module-metadata-serializer.js';
+import { expect } from '../../../../../test-helper.js';
+
+describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleMetadataSerializer', function () {
+  describe('#serialize', function () {
+    it('should serialize', function () {
+      // given
+      const firstModuleMetadata = new ModuleMetadata({
+        id: '5d7f6af1-5a56-4efd-9194-bf7c15384c09',
+        shortId: 'bienecri',
+        slug: 'slug',
+        title: 'title',
+        isBeta: false,
+        duration: 10,
+        image: 'https://example.net',
+      });
+
+      const secondModuleMetadata = new ModuleMetadata({
+        id: '53b81e35-fe1d-4bca-9809-c7ef78efefca',
+        shortId: 'bienecr2',
+        slug: 'slug2',
+        title: 'title2',
+        isBeta: false,
+        duration: 20,
+        image: 'https://example.net',
+      });
+
+      const expectedJson = {
+        data: [
+          {
+            type: 'module-metadata',
+            id: firstModuleMetadata.id,
+            attributes: {
+              'short-id': firstModuleMetadata.shortId,
+              slug: firstModuleMetadata.slug,
+              title: firstModuleMetadata.title,
+              'is-beta': firstModuleMetadata.isBeta,
+              duration: firstModuleMetadata.duration,
+              image: firstModuleMetadata.image,
+              link: `/modules/${firstModuleMetadata.shortId}/${firstModuleMetadata.slug}`,
+            },
+          },
+          {
+            type: 'module-metadata',
+            id: secondModuleMetadata.id,
+            attributes: {
+              'short-id': secondModuleMetadata.shortId,
+              slug: secondModuleMetadata.slug,
+              title: secondModuleMetadata.title,
+              'is-beta': secondModuleMetadata.isBeta,
+              duration: secondModuleMetadata.duration,
+              image: secondModuleMetadata.image,
+              link: `/modules/${secondModuleMetadata.shortId}/${secondModuleMetadata.slug}`,
+            },
+          },
+        ],
+      };
+
+      // when
+      const json = moduleMetadataSerializer.serialize([firstModuleMetadata, secondModuleMetadata]);
+
+      // then
+      expect(json).to.deep.equal(expectedJson);
+    });
+  });
+});


### PR DESCRIPTION
## ❄️ Problème
Actuellement, lors de la création d'un contenu formatif, il faut taper à la main le lien qui dirige vers le module associé. Cela est fastidieux.

## 🛷 Proposition
Créer une route api qui ramène une liste de metadata de modules

## ☃️ Remarques


## 🧑‍🎄 Pour tester
- aller [sur pix admin ](https://admin-pr14646.review.pix.fr/trainings) avec un super admin 
- copier le token
- faire un curl sur la route `/api/admin/modules-metadata`
- vérifier qu'on obtient une liste de metadonnées de modules
