### PR TITLE
[FEATURE] [Pix Orga] Modifier le libellé et la mise en page autour des méthodes de connexion SSO à la connexion et à l'invitation (PIX-21009)

### DIFF
--- a/orga/app/components/authentication/authentication-identity-providers.gjs
+++ b/orga/app/components/authentication/authentication-identity-providers.gjs
@@ -29,13 +29,9 @@ export default class AuthenticationIdentityProviders extends Component {
   <template>
     {{#if this.oidcIdentityProviders.hasIdentityProviders}}
       <section class="authentication-identity-providers-authentication-section">
-        <h2 class="authentication-identity-providers-authentication-section__heading">
-          {{#if @isForSignup}}
-            {{t "components.authentication.authentication-identity-providers.signup.heading"}}
-          {{else}}
-            {{t "components.authentication.authentication-identity-providers.login.heading"}}
-          {{/if}}
-        </h2>
+        <p class="authentication-identity-providers-authentication-section__spacer">
+          {{t "components.authentication.authentication-identity-providers.spacer.or"}}
+        </p>
 
         <PixButtonLink
           @route="authentication.sso-selection"

--- a/orga/app/components/authentication/authentication-identity-providers.scss
+++ b/orga/app/components/authentication/authentication-identity-providers.scss
@@ -6,8 +6,8 @@
   &__spacer {
     display: flex;
     gap: var(--pix-spacing-6x);
-    margin-top: var(--pix-spacing-10x);
-    margin-bottom: var(--pix-spacing-10x);
+    margin-top: var(--pix-spacing-6x);
+    margin-bottom: var(--pix-spacing-6x);
     color: var(--pix-neutral-500);
   }
 

--- a/orga/app/components/authentication/authentication-identity-providers.scss
+++ b/orga/app/components/authentication/authentication-identity-providers.scss
@@ -3,7 +3,7 @@
   flex-direction: column;
   gap: var(--pix-spacing-4x);
 
-  &__heading {
+  &__spacer {
     display: flex;
     gap: var(--pix-spacing-6x);
     margin-top: var(--pix-spacing-10x);
@@ -11,8 +11,8 @@
     color: var(--pix-neutral-500);
   }
 
-  &__heading::before,
-  &__heading::after {
+  &__spacer::before,
+  &__spacer::after {
     flex: 1 1;
     margin: auto;
     border-bottom: 1px solid var(--pix-neutral-100);

--- a/orga/app/templates/authentication/login.gjs
+++ b/orga/app/templates/authentication/login.gjs
@@ -23,6 +23,9 @@ import AuthenticationLayout from 'pix-orga/components/authentication-layout/inde
         @isInvitationCancelled={{@controller.isInvitationCancelled}}
         @onSubmit={{@controller.authenticate}}
       />
+
+      <AuthenticationIdentityProviders />
+
       {{#if @controller.displayRecoveryLink}}
         <div class="authentication-login__recover-access">
           <p class="authentication-login__recover-access__question">
@@ -37,7 +40,6 @@ import AuthenticationLayout from 'pix-orga/components/authentication-layout/inde
         </div>
       {{/if}}
 
-      <AuthenticationIdentityProviders />
     </:content>
   </AuthenticationLayout>
 </template>

--- a/orga/tests/integration/components/authentication/authentication-identity-providers-test.gjs
+++ b/orga/tests/integration/components/authentication/authentication-identity-providers-test.gjs
@@ -23,9 +23,6 @@ module('Integration | Component | Authentication | authentication-identity-provi
         const screen = await render(<template><AuthenticationIdentityProviders /></template>);
 
         // then
-        const heading = t('components.authentication.authentication-identity-providers.login.heading');
-        assert.dom(screen.getByRole('heading', { name: heading })).exists();
-
         const link = await screen.findByRole('link', {
           name: t('components.authentication.authentication-identity-providers.select-another-organization-link'),
         });
@@ -42,9 +39,6 @@ module('Integration | Component | Authentication | authentication-identity-provi
         );
 
         // then
-        const heading = t('components.authentication.authentication-identity-providers.login.heading');
-        assert.dom(screen.getByRole('heading', { name: heading })).exists();
-
         const link = await screen.findByRole('link', {
           name: t('components.authentication.authentication-identity-providers.select-another-organization-link'),
         });
@@ -59,9 +53,6 @@ module('Integration | Component | Authentication | authentication-identity-provi
         const screen = await render(<template><AuthenticationIdentityProviders @isForSignup={{true}} /></template>);
 
         // then
-        const heading = t('components.authentication.authentication-identity-providers.signup.heading');
-        assert.dom(screen.getByRole('heading', { name: heading })).exists();
-
         const link = await screen.findByRole('link', {
           name: t('components.authentication.authentication-identity-providers.select-another-organization-link'),
         });
@@ -80,9 +71,6 @@ module('Integration | Component | Authentication | authentication-identity-provi
         );
 
         // then
-        const heading = t('components.authentication.authentication-identity-providers.signup.heading');
-        assert.dom(screen.getByRole('heading', { name: heading })).exists();
-
         const link = await screen.findByRole('link', {
           name: t('components.authentication.authentication-identity-providers.select-another-organization-link'),
         });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -338,12 +338,9 @@
     },
     "authentication": {
       "authentication-identity-providers": {
-        "login": {
-          "heading": "Other ways to log in"
-        },
         "select-another-organization-link": "Choose another way to log in",
-        "signup": {
-          "heading": "Other ways to sign up"
+        "spacer": {
+          "or": "or"
         }
       },
       "oidc-association-confirmation": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -338,12 +338,9 @@
     },
     "authentication": {
       "authentication-identity-providers": {
-        "login": {
-          "heading": "Autres méthodes de connexion"
-        },
         "select-another-organization-link": "Choisir une autre méthode de connexion",
-        "signup": {
-          "heading": "Autres méthodes d’inscription"
+        "spacer": {
+          "or": "ou"
         }
       },
       "oidc-association-confirmation": {

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -337,12 +337,9 @@
     },
     "authentication": {
       "authentication-identity-providers": {
-        "login": {
-          "heading": "Andere inlogmethodes"
-        },
         "select-another-organization-link": "Kies een andere organisatie",
-        "signup": {
-          "heading": "Andere registratiemethodes"
+        "spacer": {
+          "or": "of"
         }
       },
       "oidc-association-confirmation": {


### PR DESCRIPTION
## ❄️ Problème

À l’utilisation on se rend compte que la présentation des méthodes de connexion, cf. copie d’écran ci-dessous, mérite d’être rendue plus claire.

<img width="1279" height="1252" alt="Connectez-vous_Pix_Orga-avant" src="https://github.com/user-attachments/assets/b3853293-8db5-4fd5-a81a-bc8a8e9d5e28" />

## 🛷 Proposition

Sur les pages de « login », « rejoindre » et « rejoindre avec inscription »

* Le séparateur et le bouton _« Choisir une autre méthode de connexion »_ doivent être directement sous le bouton principal _« Je me connecte »_ / _« Je m’inscris »_
* Le libellé du séparateur _« Autres méthodes de connexion »_ doit être remplacé par _« ou »_
* Le bloc de texte de récupération _« Vous êtes personnel de direction ou directeur d'école ? »_ de la page de _« login »_ doit toujours être sous les 2 boutons
* Réduire l’espacement vertical entre les boutons séparés par le _« ou »_

Ce qui donne : 

<img width="1279" height="1252" alt="Connectez-vous_Pix_Orga-après" src="https://github.com/user-attachments/assets/2582be82-c9a6-4110-99c5-8eaa11240b87" />

## ☃️ Remarques

RAS

## 🧑‍🎄 Pour tester

### En local

1. Aller sur https://orga.dev.pix.fr/connexion et constater que le bloc de récupération est sous les 2 boutons
2. Aller sur https://orga.dev.pix.org/connexion et constater que le texte séparant les 2 boutons est _« ou »_ et que ce texte change correctement en fonction des changements sur le _LocaleSwitcher_
3. Aller sur https://orga.dev.pix.org/connexion et constater que la mise en page est satisfaisante, notamment au niveau des espacements
4. Envoyer une invitation à rejoindre une organisation
5. En suivant le lien de l’invitation, en passant de l’affichage _« Se connecter »_ à l‘affichage _« S’inscrire sur Pix »_, constater que le texte et l’espacement entre les boutons est bien celui attendu