### PR TITLE
[FEATURE] Recherche d'un nom d'orga malgré l'utilisation de caractères spéciaux (PIX-20770).

### DIFF
--- a/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
@@ -383,7 +383,16 @@ function _setSearchFiltersForQueryBuilder(qb, filter) {
     qb.where('organizations.id', id);
   }
   if (name) {
-    qb.where(knex.raw('unaccent(organizations.name) ILIKE unaccent(?)', [`%${name}%`]));
+    qb.where(
+      knex.raw(
+        `
+      regexp_replace(unaccent(organizations.name), '[^[:alnum:]]', '', 'g')
+      ILIKE
+      '%' || regexp_replace(unaccent(?), '[^[:alnum:]]', '', 'g') || '%'
+      `,
+        [name],
+      ),
+    );
   }
   if (type) {
     qb.where('type', type);

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/organization-for-admin.repository.test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/organization-for-admin.repository.test.js
@@ -124,14 +124,14 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
     context('when there are multiple Organizations matching the same "name" search pattern', function () {
       it('should return only Organizations matching "name" if given in filters', async function () {
         // given
-        databaseBuilder.factory.buildOrganization({ name: 'Dragon & co' });
-        databaseBuilder.factory.buildOrganization({ name: 'Dragonades & co' });
+        databaseBuilder.factory.buildOrganization({ name: 'Dragonades co' });
         databaseBuilder.factory.buildOrganization({ name: 'Broca & co' });
+        databaseBuilder.factory.buildOrganization({ name: 'Dragonades & co+' });
         databaseBuilder.factory.buildOrganization({ name: 'Donnie & co' });
 
         await databaseBuilder.commit();
 
-        const filter = { name: 'dra' };
+        const filter = { name: 'dragonadesCo' };
         const page = { number: 1, size: 10 };
         const expectedPagination = { page: page.number, pageSize: page.size, pageCount: 1, rowCount: 2 };
 
@@ -144,7 +144,7 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
 
         // then
         expect(matchingOrganizations).to.have.lengthOf(2);
-        expect(_.map(matchingOrganizations, 'name')).to.have.members(['Dragon & co', 'Dragonades & co']);
+        expect(_.map(matchingOrganizations, 'name')).to.have.members(['Dragonades co', 'Dragonades & co+']);
         expect(pagination).to.deep.equal(expectedPagination);
       });
 


### PR DESCRIPTION
## ❄️ Problème

La recherche de nom par orga ne retourne pas les résultats suivant que l'on rentre des caractères spéciaux ou non.
Ex: "franche-comté" et "franche comté" renvoient deux résultats différents.

## 🛷 Proposition

On filtre via la regexp PG `[^[:alnum:]]` (filtre sur caractères alpha-numériques)

## ☃️ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🧑‍🎄 Pour tester

- Sur pix-admin, checker que des résultats avec ou sans caractères spéciaux renvoient le même résultat
