### PR TITLE
[FEATURE] Permuter les écrans d'inscription et d'association quand on rejoint une orga par SSO (PIX-21011)

### DIFF
--- a/orga/app/routes/authentication/oidc/flow.js
+++ b/orga/app/routes/authentication/oidc/flow.js
@@ -55,7 +55,7 @@ export default class LoginOidcRoute extends Route {
     const { identityProviderSlug, shouldCreateUserAccount } = model;
 
     if (shouldCreateUserAccount) {
-      this.router.transitionTo('authentication.oidc.login', identityProviderSlug);
+      this.router.transitionTo('authentication.oidc.signup', identityProviderSlug);
     }
   }
 

--- a/orga/tests/acceptance/oidc/oidc-authentication-flow-test.js
+++ b/orga/tests/acceptance/oidc/oidc-authentication-flow-test.js
@@ -64,12 +64,12 @@ module('Acceptance | OIDC | authentication flow', function (hooks) {
     });
 
     module('when the wanted OIDC Provider is enabled and ready', function () {
-      test('the user is redirected to the Pix login form', async function (assert) {
+      test('the user is redirected to the Pix signup form', async function (assert) {
         // when
         await visit('/connexion/oidc-partner?code=code&state=state');
 
         // then
-        assert.strictEqual(currentURL(), '/connexion/oidc-partner/login');
+        assert.strictEqual(currentURL(), '/connexion/oidc-partner/signup');
       });
 
       module('when the user submits Pix login form', function () {
@@ -81,12 +81,13 @@ module('Acceptance | OIDC | authentication flow', function (hooks) {
             });
 
             const screen = await visit('/connexion/oidc-partner?code=code&state=state');
+            await click(await screen.getByRole('link', { name: t('pages.oidc.signup.login-button') }));
 
             // when
             await fillIn(await screen.getByRole('textbox', { name: t('pages.login-form.email.label') }), user.email);
             await fillIn(await screen.getByLabelText(t('pages.login-form.password')), 'pix123');
-
-            await click(await screen.getByRole('button', { name: 'Je me connecte' }));
+            const loginButton = screen.getByRole('button', { name: t('pages.login-form.login') });
+            await click(loginButton);
 
             // then
             assert.ok(
@@ -130,6 +131,7 @@ module('Acceptance | OIDC | authentication flow', function (hooks) {
               401,
             );
             const screen = await visit('/connexion/oidc-partner?code=code&state=state');
+            await click(await screen.getByRole('link', { name: t('pages.oidc.signup.login-button') }));
 
             // when
             await fillIn(
@@ -153,6 +155,7 @@ module('Acceptance | OIDC | authentication flow', function (hooks) {
             this.server.post('/oidc/user/check-reconciliation', undefined, 500);
 
             const screen = await visit('/connexion/oidc-partner?code=code&state=state');
+            await click(await screen.getByRole('link', { name: t('pages.oidc.signup.login-button') }));
 
             // when
             await fillIn(
@@ -211,6 +214,8 @@ module('Acceptance | OIDC | authentication flow', function (hooks) {
               createPrescriberByUser({ user });
 
               const screen = await visit('/connexion/oidc-partner?code=code&state=state');
+              await click(await screen.getByRole('link', { name: t('pages.oidc.signup.login-button') }));
+
               await fillInAndSubmitLoginForm(screen);
               await settled();
 
@@ -233,6 +238,8 @@ module('Acceptance | OIDC | authentication flow', function (hooks) {
               const user = createUserWithMembership();
               createPrescriberByUser({ user });
               screen = await visit('/connexion/oidc-partner?code=code&state=state');
+              await click(await screen.getByRole('link', { name: t('pages.oidc.signup.login-button') }));
+
               await fillInAndSubmitLoginForm(screen);
             });
 

--- a/orga/tests/acceptance/oidc/oidc-authentication-signup-test.js
+++ b/orga/tests/acceptance/oidc/oidc-authentication-signup-test.js
@@ -38,15 +38,8 @@ module('Acceptance | OIDC | authentication signup', function (hooks) {
   });
 
   test('the user signs up', async function (assert) {
-    // given
-    const screen = await visit('/connexion/oidc-partner?code=code&state=state');
-
     // when
-    const loginTitle = await screen.findByRole('heading', { name: t('pages.oidc.login.title') });
-    assert.dom(loginTitle).exists();
-
-    const signupButton = await screen.findByRole('link', { name: t('pages.oidc.login.signup-button') });
-    await click(signupButton);
+    const screen = await visit('/connexion/oidc-partner?code=code&state=state');
 
     // then
     const signUpTitle = await screen.findByRole('heading', { name: t('pages.oidc.signup.title') });
@@ -99,14 +92,8 @@ module('Acceptance | OIDC | authentication signup', function (hooks) {
         );
       });
 
-      const screen = await visit('/connexion/oidc-partner?code=code&state=state');
-
       // when
-      const loginTitle = await screen.findByRole('heading', { name: t('pages.oidc.login.title') });
-      assert.dom(loginTitle).exists();
-
-      const signupButton = await screen.findByRole('link', { name: t('pages.oidc.login.signup-button') });
-      await click(signupButton);
+      const screen = await visit('/connexion/oidc-partner?code=code&state=state');
 
       // then
       const signUpTitle = await screen.findByRole('heading', { name: t('pages.oidc.signup.title') });


### PR DESCRIPTION
## ❄️ Problème

Actuellement, quand un utilisateur rejoint une organisation via SSO pour le première fois, il tombe sur la page d’association en premier /connexion/pro-connect/login, ce qui est perturbant dans le flow, car la plupart du temps il s’attend à créer un nouveau compte.

## 🛷 Proposition

Permuter les deux écrans

## ☃️ Remarques

Sur l'erreur "Nous n’avons pas pu récupérer vos informations d’identité auprès du service utilisé. Nous vous invitons à contacter le support informatique de cette organisation."
- cette erreur ne figure que dans le template d'inscription (authentication/oidc/signup). auparavant pour la voir il fallait s'authentifier auprès de son fournisseur d'identité, puis arriver sur le formulaire de login de pix, puis cliquer sur 'Je n'ai pas de compte, je m'inscris avec mon organisation', > et là l'erreur apparaissait. C'était aussi un cul de sac, dans le sens où aucune action n'était possible à partir de là.

- actuellement ce problème ne se présente plus puisque l'utilisateur dont les claims ne sont pas récupérées arrive directement sur le message d'erreur du signup template. 

Questions (pas strictement dans le cadre de cette PR): 

- voulons nous garder cette impasse en cas d'erreur de claims? ou faut il un bouton vers ... quoi?
- pourquoi l'erreur ne figurait-elle jusqu'à maintenant que dans l'inscription et pas dans l'association? Et donc comment était gérée /devait être gérée l'absence de claims si l'utilisateur faisait le choix d'associer son compte à un compte existant, et non de créer un compte ?

## 🧑‍🎄 Pour tester

- en tant qu'admin de Pix Orga, faire deux invitations
- en récupérer une (mailpit)
- s'authentifier auprès de son fournisseur d'identité
- vérifier que la route de retour est bien `/connexion/pro-connect/signup` et non `/connexion/pro-connect/login`
- tester l'inscription (non régression)
- tester l'association avec le deuxième invité (non régression)
