### PR TITLE
[FEATURE] Ajouter un attribut de visibilité pour les modules (PIX-21022).

### DIFF
--- a/api/src/devcomp/domain/models/module/Module.js
+++ b/api/src/devcomp/domain/models/module/Module.js
@@ -1,7 +1,12 @@
 import { assertIsArray, assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
 
 class Module {
-  constructor({ id, shortId, slug, title, isBeta, sections, details, version }) {
+  static VISIBILITY = Object.freeze({
+    PUBLIC: 'public',
+    PRIVATE: 'private',
+  });
+
+  constructor({ id, shortId, slug, title, isBeta, sections, details, version, visibility }) {
     assertNotNullOrUndefined(id, 'The id is required for a module');
     assertNotNullOrUndefined(shortId, 'The shortId is required for a module');
     assertNotNullOrUndefined(slug, 'The slug is required for a module');
@@ -9,6 +14,7 @@ class Module {
     assertNotNullOrUndefined(isBeta, 'isBeta value is required for a module');
     assertIsArray(sections, 'A list of sections is required for a module');
     assertNotNullOrUndefined(details, 'The details are required for a module');
+    assertNotNullOrUndefined(visibility, 'The visibility is required for a module');
 
     this.id = id;
     this.shortId = shortId;
@@ -18,6 +24,7 @@ class Module {
     this.sections = sections;
     this.details = details;
     this.version = version;
+    this.visibility = visibility;
   }
 
   setRedirectionUrl(url) {

--- a/api/src/devcomp/domain/models/module/ModuleMetadata.js
+++ b/api/src/devcomp/domain/models/module/ModuleMetadata.js
@@ -2,7 +2,7 @@ import { DomainError } from '../../../../shared/domain/errors.js';
 import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
 
 export class ModuleMetadata {
-  constructor({ id, shortId, slug, title, isBeta, duration, image }) {
+  constructor({ id, shortId, slug, title, isBeta, duration, image, visibility }) {
     assertNotNullOrUndefined(id, 'The id is required for a module metadata');
     assertNotNullOrUndefined(shortId, 'The short id is required for a module metadata');
     assertNotNullOrUndefined(slug, 'The slug is required for a module metadata');
@@ -10,6 +10,7 @@ export class ModuleMetadata {
     assertNotNullOrUndefined(isBeta, 'Field isBeta is required for a module metadata');
     assertNotNullOrUndefined(duration, 'The duration is required for a module metadata');
     assertNotNullOrUndefined(image, 'The image is required for a module metadata');
+    assertNotNullOrUndefined(visibility, 'The visibility is required for a module metadata');
     this.#assertDurationHasPositiveValue(Number(duration));
 
     this.id = id;
@@ -20,6 +21,7 @@ export class ModuleMetadata {
     this.duration = Number(duration);
     this.image = image;
     this.link = `/modules/${this.shortId}/${this.slug}`;
+    this.visibility = visibility;
   }
 
   #assertDurationHasPositiveValue(duration) {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYAntivirus_IND.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYAntivirus_IND.json
@@ -4,6 +4,7 @@
   "slug": "cyber-antivirus",
   "title": "Renforcez la protection de vos appareils contre les logiciels malveillants",
   "isBeta": true,
+  "visibility": "public",
   "details": {
     "image": "https://assets.pix.org/modules/placeholder-details.svg",
     "description": "<p>Les appareils numériques sont régulièrement exposés à des logiciels malveillants.<br>Dans ce module, vous allez découvrir deux méthodes complémentaires pour renforcer la protection des appareils numériques (smartphones, tablettes, ordinateurs) face à ces logiciels.&nbsp;🛡️<br><br><em>Module produit en partenariat avec cybermalveillance.gouv.fr</em></p>",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYGestionMDP_IND.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYGestionMDP_IND.json
@@ -4,6 +4,7 @@
   "slug": "cyber-gestionnaire",
   "title": "Un coffre-fort pour vos mots de passe",
   "isBeta": true,
+  "visibility": "public",
   "details": {
     "image": "https://assets.pix.org/draft/modules/cy-gestionmdp-ind/picto_cyber_gestion-mdp_ind.svg",
     "description": "<p>Vous avez des dizaines de comptes en ligne et autant de mots de passe ?<br> Découvrez comment un gestionnaire de mots de passe peut vous simplifier la vie, tout en renforçant votre sécurité numérique.&nbsp;🔐</p>",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYGestionMDP_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYGestionMDP_NOV.json
@@ -4,6 +4,7 @@
   "slug": "cyber-proteger-mdp",
   "title": "Protéger ses mots de passe",
   "isBeta": true,
+  "visibility": "public",
   "details": {
     "image": "https://assets.pix.org/modules/placeholder-details.svg",
     "description": "<p>Même si vous choisissez des mots de passe forts, ce n’est pas toujours suffisant pour protéger vos nombreux services en ligne. Dans ce module, découvrez comment garder vos mots de passe secrets, réagir en cas d’oubli et éviter les erreurs courantes.<br><br><em>Module produit en partenariat avec cybermalveillance.gouv.fr</em></p>",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYMDP_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYMDP_NOV.json
@@ -4,6 +4,7 @@
   "slug": "cyber-mdp-fort",
   "title": "Un mot de passe fort, c’est quoi ?",
   "isBeta": true,
+  "visibility": "public",
   "details": {
     "image": "https://assets.pix.org/modules/placeholder-details.svg",
     "description": "<p>Un mot de passe trop faible et donc trop simple, c’est une porte ouverte pour les pirates informatiques. Pour éviter cela, il est essentiel de choisir un mot de passe fort, c'est-à-dire difficile à deviner.<br>Dans ce module, vous allez découvrir des règles simples pour créer un mot de passe fort et protéger les comptes de vos services en ligne. 🔒</p>",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYMFA_IND.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYMFA_IND.json
@@ -4,6 +4,7 @@
   "slug": "mfa-authentification-multifacteur",
   "title": "Plus puissante qu’un mot de passe : l’authentification multifacteur",
   "isBeta": true,
+  "visibility": "public",
   "details": {
     "image": "https://assets.pix.org/modules/CYMFA_IND/picto_cyber_mfa_ind.svg",
     "description": "<p>Pour accéder à un compte en ligne ou déverrouiller ses appareils numériques, il faut s’authentifier, c’est-à-dire prouver qu’on est bien la personne que l’on prétend être. 🕵️ </p><p>En plus de donner son mot de passe, une seconde étape est parfois nécessaire. Dans ce module, découvrez pourquoi et comment on ajoute cette étape de sécurité supplémentaire. 🔒</p><p><br> <em>Module produit en partenariat avec cybermalveillance.gouv.fr</em><br><br></p>",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYMFA_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYMFA_NOV.json
@@ -4,6 +4,7 @@
   "slug": "cyber-double-authentification",
   "title": "Protéger ses données en ligne avec la double authentification",
   "isBeta": true,
+  "visibility": "public",
   "details": {
     "image": "https://assets.pix.org/modules/CY_MFA_NOV/picto_cyber_mfa_nov.svg",
     "description": "<p>Pour vous connectez à vos différents services en ligne, vous devez entrer votre identifiant puis votre mot de passe... et parfois un code en plus 🔐 <br>Dans ce module, vous allez voir pourquoi ces étapes sont importantes et comment la double authentification renforce votre sécurité en ligne.<br> <br> <em>Module produit en partenariat avec cybermalveillance.gouv.fr</em></p>",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYPhishing_AVA.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYPhishing_AVA.json
@@ -4,6 +4,7 @@
   "slug": "cyber-ingenierie-sociale",
   "title": "Cyberattaques : quand l’ingénierie sociale s’en mêle !",
   "isBeta": true,
+  "visibility": "public",
   "details": {
     "image": "https://assets.pix.org/modules/CYphishingava/picto_cyber_phishing_ava.svg",
     "description": "<p>Alors que les systèmes informatiques sont de mieux en mieux protégés et techniquement robustes, il suffit parfois parfois à des cyberattaquants de convaincre une personne d’agir volontairement contre ses propres intérêts pour arriver à leurs fins.🔓<br>Dans ce module, découvrez les mécanismes des attaques par ingénierie sociale et les différentes formes qu’elles peuvent prendre.<br><br><em>Module produit en partenariat avec cybermalveillance.gouv.fr.</em></p>",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYPhishing_IND.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYPhishing_IND.json
@@ -4,6 +4,7 @@
   "slug": "anatomie-message-arnaque",
   "title": "Anatomie d’un message d’arnaque",
   "isBeta": true,
+  "visibility": "public",
   "details": {
     "image": "https://assets.pix.org/draft/modules/cy_phishing_ind/picto_cyber_phishing_ind.svg",
     "description": "<p>Les messages et mails d’arnaque sont très courants et ressemblent à des messages sûrs.&nbsp;</p><p> Dans ce module, découvrez des indices et techniques qui permettent de vérifier vos messages. </p><p>Découvrez aussi des réflexes pour vous protéger et protéger les autres. 🕵️<br><br><em>Module produit en partenariat avec cybermalveillance.gouv.fr.</em></p>",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYPhishing_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYPhishing_NOV.json
@@ -4,6 +4,7 @@
   "slug": "cyber-message-arnaque",
   "title": "Vous avez un nouveau message ✉️ : attention aux arnaques",
   "isBeta": true,
+  "visibility": "public",
   "details": {
     "image": "https://assets.pix.org/modules/CYPhishingNov/cy-phishing-nov-picto.svg",
     "description": "<p>Chaque jour, nous recevons des messages par SMS ou messagerie instantanée. Certains d’entre eux cachent des arnaques.<br> Dans ce module, découvrez les réflexes à avoir pour éviter de tomber dans le piège. 🛡️<br><br><em>Module produit en partenariat avec cybermalveillance.gouv.fr.</em></p>",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYVirus_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYVirus_NOV.json
@@ -4,6 +4,7 @@
   "slug": "cyber-virus-nov",
   "title": "Mon ordinateur a attrapé un virus : comment est-ce possible ?",
   "isBeta": true,
+  "visibility": "public",
   "details": {
     "image": "https://assets.pix.org/modules/CYVirus_NOV/picto_cyber_virus_nov.svg",
     "description": "<p>Votre ordinateur fonctionne de manière étrange ? Cela peut venir d’un programme informatique malveillant qui s’est installé à votre insu.<br> Dans ce module, vous allez découvrir comment ces programmes arrivent, les risques pour vous et votre appareil, ainsi que les gestes sûrs à adopter pour les éviter.<br><br><em>Module produit en partenariat avec cybermalveillance.gouv.fr</em></p>",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IADefinition_IND.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IADefinition_IND.json
@@ -4,6 +4,7 @@
   "slug": "ia-def-ind",
   "title": "Une IA apprentie botaniste : un cas d’apprentissage supervisé.",
   "isBeta": true,
+  "visibility": "public",
   "details": {
     "image": "https://assets.pix.org/modules/IAGenDef_IND/picto_moduleIA_img.svg",
     "description": "<p>L’intelligence artificielle a de multiples applications : génération de texte, recommandation de contenus… Dans ce module, vous découvrirez l’une des techniques d’intelligence artificielle qui rend tout cela possible : l’apprentissage automatique supervisé.</p><p>A travers l’exemple de la reconnaissance d’image, vous allez voir les coulisses de cet apprentissage : de l’entraînement sur des données étiquetées jusqu’à des prédictions efficaces.</p>",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IADefinition_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IADefinition_NOV.json
@@ -4,6 +4,7 @@
   "slug": "ia-dit-ia",
   "title": "IA, vous avez dit IA ? ",
   "isBeta": true,
+  "visibility": "public",
   "details": {
     "image": "https://assets.pix.org/modules/ia-dit-ia/picto-ia-dit-ia.svg",
     "description": "<p>Depuis quelques années, on entend beaucoup parler de l’IA, dans la presse, à la télévision et même dans les discours politiques. Mais, c’est quoi au juste l’IA ?<br>C’est ce que vous allez découvrir dans ce module.</p>",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenBiais_AVA.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenBiais_AVA.json
@@ -4,6 +4,7 @@
   "slug": "iagenbiais-avance",
   "title": "IA génératives : Qui programme la morale ?",
   "isBeta": true,
+  "visibility": "public",
   "details": {
     "image": "https://assets.pix.org/modules/placeholder-details.svg",
     "description": "<p>Les IA génératives peuvent fournir des réponses utiles, mais aussi des erreurs ou des biais. Leur entraînement repose sur d’immenses ensembles de textes sélectionnés par des humains, ce qui influence profondément ce que l’IA juge acceptable ou non. Or ces choix reflètent des normes différentes selon les pays. Ce module vous aide à comprendre comment ces règles sont définies et qui programme la «&nbsp;morale&nbsp;» suivie par l’IA.</p>",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenBiais_IND.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenBiais_IND.json
@@ -4,6 +4,7 @@
   "slug": "ia-bias-ind",
   "title": "Les biais des IA génératives",
   "isBeta": false,
+  "visibility": "public",
   "details": {
     "image": "https://assets.pix.org/modules/IAGenBiais_IND/picto_moduleIA_biais.svg",
     "description": "<p>Les productions des logiciels d’IA génératives contiennent parfois des maladresses. Ce ne sont pas toujours des erreurs, mais des raccourcis, des stéréotypes ou des discriminations.  On dit que ces résultats comportent des biais. </p><p>Découvrez dans ce module d’où viennent les biais des réponses des IA génératives.<br></p>",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenBiais_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenBiais_NOV.json
@@ -4,6 +4,7 @@
   "slug": "ia-hallu",
   "title": "Elles hallucinent, ces IA génératives ! ",
   "isBeta": true,
+  "visibility": "public",
   "details": {
     "image": "https://assets.pix.org/modules/tmp-ia-hallu/picto_moduleIA_hallu.svg",
     "description": "<p>Les logiciels d’IA générative sont de plus en plus utilisés au quotidien. Mais leurs réponses sont-elles toujours correctes ?&nbsp;Et quand il y a des erreurs, d’où viennent-elles ?<br>C’est ce que nous allons découvrir dans ce module.&nbsp;</p>",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenBiais_NOV_alt.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenBiais_NOV_alt.json
@@ -4,6 +4,7 @@
   "slug": "ia-biais-ind-alt",
   "title": "Les biais des lA",
   "isBeta": true,
+  "visibility": "public",
   "details": {
     "image": "https://assets.pix.org/modules/IAGenBiais_IND/picto_moduleIA_biais.svg",
     "description": "<p>Les logiciels d’IA générative donnent l’impression d’avoir réponse à tout. Parfois, leurs productions contiennent des maladresses. Ce ne sont pas forcément des erreurs, mais des raccourcis, des stéréotypes ou des discriminations. 🚩 </p><p>On dit que ces résultats comportent des biais. Découvrez dans ce module d’où viennent les biais des réponses des IA génératives.🔍</p>",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenEthique_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenEthique_NOV.json
@@ -4,6 +4,7 @@
   "slug": "iagenethique",
   "title": "Ce qu’il faut éviter de dire à une IA générative",
   "isBeta": true,
+  "visibility": "public",
   "details": {
     "image": "https://assets.pix.org/modules/IAGenEthique_NOV/picto-ia-ethique-vector-1.svg",
     "description": "<p>Quand vous discutez avec un logiciel d’intelligence artificielle (IA) générative, la conversation n’est pas privée.</p><p>Tout ce que vous écrivez peut être enregistré et parfois réutilisé pour améliorer l’IA.</p><p>Dans ce module, vous allez comprendre pourquoi les échanges avec une IA générative ne sont pas totalement privés et quelles informations il vaut mieux éviter d’écrire dans vos instructions (prompts).</p>",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenFonction_IND.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenFonction_IND.json
@@ -4,6 +4,7 @@
   "slug": "ia-fonctionnement-ind",
   "title": "Comment l’IA générative apprend-elle à discuter avec vous ?",
   "isBeta": true,
+  "visibility": "public",
   "details": {
     "image": "https://assets.pix.org/modules/IAGenFonction_IND/picto_IAGenFonction_IND.svg",
     "description": "<p>Les logiciels d’IA génératives&nbsp;de texte sont capables de tenir des conversations étonnamment naturelles. Mais comment en sont-ils arrivés là ? Ce module vous emmène dans les coulisses de leur apprentissage&nbsp;: des montagnes de textes analysés aux techniques d’entraînement sophistiquées qui leur ont permis de comprendre, prédire et générer le langage humain.</p>",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenFonction_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenFonction_NOV.json
@@ -4,6 +4,7 @@
   "slug": "ia-fonctionnement-debut",
   "title": "Comment font les IA génératives pour répondre à nos demandes ?",
   "isBeta": true,
+  "visibility": "public",
   "details": {
     "image": "https://assets.pix.org/modules/IAGenFonction%20NOV/picto_IAGenFonction-NOV.svg",
     "description": "<p>ChatGPT, Gemini ou encore Le Chat sont des logiciels d’Intelligence Artificielle (IA) générative&nbsp;: un utilisateur peut discuter avec ces IA et avoir des réponses à ses demandes.&nbsp; <br>Ces IA peuvent résumer un texte, inventer des histoires, etc. Et ça, sur presque tous les sujets !</p><p><br>Dans ce module, vous allez découvrir comment un logiciel d’IA générative réussit toujours à donner une réponse à un utilisateur… mais pas forcément la bonne.</p>",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenImpact_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenImpact_NOV.json
@@ -4,6 +4,7 @@
   "slug": "les-ia-generatives-consomment",
   "title": "L‘IA générative, ça consomme !",
   "isBeta": true,
+  "visibility": "public",
   "details": {
     "image": "https://assets.pix.org/modules/les-ia-consomment/picto_moduleIA_conso.svg",
     "description": "<p>Quand vous échangez avec un logiciel d‘IA générative, vous ne voyez que l‘écran de discussion. </p><p>Pourtant, des ordinateurs très puissants, des réseaux et des bâtiments, situés partout dans le monde, sont utilisés pour répondre à vos demandes.</p><p>Dans ce module, vous allez découvrir les ressources que consomme l’utilisation des intelligences artificielles génératives.</p>",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenPrompt_IND.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenPrompt_IND.json
@@ -4,6 +4,7 @@
   "slug": "prompt-intermediaire",
   "title": "J’améliore mes prompts !",
   "isBeta": true,
+  "visibility": "public",
   "details": {
     "image": "https://assets.pix.org/modules/jameliore-mes-prompts/picto_moduleIA_prompt2.svg",
     "description": "<p>Les logiciels d’IA générative permettent de répondre à une grande variété de nos demandes. Mais la qualité de leurs réponses dépend beaucoup des questions qu’on leur pose, c’est-à-dire, des prompts qu’on leur donne. Dans ce module, vous allez apprendre à formuler des prompts efficaces et à ajuster vos demandes pour améliorer le résultat proposé par le logiciel d’IA générative.&nbsp;<br></p>",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenPrompt_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenPrompt_NOV.json
@@ -4,6 +4,7 @@
   "slug": "ia-premier-prompt",
   "title": "Mon premier prompt !",
   "isBeta": true,
+  "visibility": "public",
   "details": {
     "image": "https://assets.pix.org/modules/placeholder-details.svg",
     "description": "<p>Les logiciels d’IA générative comme Le Chat, ChatGPT, Gemini ou encore DeepSeek, vous en avez déjà entendu parler. Mais, savez-vous comment on les utilise ?</p><p>Le secret tient en un mot : prompt. C’est quoi au juste un prompt ? C’est ce que vous allez découvrir dans ce module.</p>",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAInfox_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAInfox_NOV.json
@@ -4,6 +4,7 @@
   "slug": "ia-deepfakes",
   "title": "Les deepfakes (hypertrucages) : c’est quoi ?",
   "isBeta": true,
+  "visibility": "public",
   "details": {
     "image": "https://assets.pix.org/modules/deepfakes/picto-deepfakes.svg",
     "description": "<p>Sur internet, on trouve des images, des vidéos et des sons. Certains sont vrais mais d'autres sont faux&nbsp;: ils sont créés pour ressembler à la réalité.<br>Dans ce module, vous allez découvrir comment les deepfakes (ou hypertrucages en français) sont créés et pourquoi.</p>",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/NR-Datacenter-IND.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/NR-Datacenter-IND.json
@@ -4,6 +4,7 @@
   "slug": "nr-coulisses-centre-donnees",
   "title": "Dans les coulisses d’un centre de données",
   "isBeta": true,
+  "visibility": "public",
   "details": {
     "image": "https://assets.pix.org/modules/placeholder-details.svg",
     "description": "<p>Hébergeant l’ensemble des données et services en ligne, les centres de données sont devenus indispensables à nos usages numériques. <br><br>Dans ce module, vous allez être plongé dans le fonctionnement d’un centre de données et allez découvrir comment les évolutions technologiques successives amènent à des usages toujours plus consommateurs d’énergie.<br></p>",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/NR-Datacenter-NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/NR-Datacenter-NOV.json
@@ -4,6 +4,7 @@
   "slug": "centre-de-donnee-novice",
   "title": "L’impact caché de nos usages numériques en ligne",
   "isBeta": true,
+  "visibility": "public",
   "details": {
     "image": "https://assets.pix.org/modules/placeholder-details.svg",
     "description": "<p>Chaque message envoyé, chaque vidéo regardée ou chaque «&nbsp;J’aime&nbsp;» mobilise des centres de données, souvent invisibles pour les utilisateurs. Ces lieux abritent des serveurs qui stockent, traitent et transmettent les informations, tout en consommant de l’électricité et parfois de l’eau. Dans ce module, vous allez comprendre le rôle des centres de données, pourquoi certains usages numériques consomment plus d’énergie que d’autres, et comment adopter des gestes simples pour réduire ces consommations au quotidien.</p>",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/NR-Durabilite-AVA.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/NR-Durabilite-AVA.json
@@ -4,6 +4,7 @@
   "slug": "nr-obsolescence-programmee",
   "title": "En finir avec l’obsolescence programmée ? ",
   "isBeta": true,
+  "visibility": "public",
   "details": {
     "image": "https://assets.pix.org/modules/placeholder-details.svg",
     "description": "<p>Extraction, fabrication, distribution, consommation… Produire de nouveaux appareils numériques a des impacts environnementaux importants. Le renouvellement toujours plus rapide des équipements accentue cette pression sur l’environnement. </p><p><br>Dans ce module, vous découvrirez les mécanismes d’obsolescence qui raccourcissent la durée de vie des appareils numériques et comprendrez comment s’amorce la transition vers une économie circulaire plus durable.</p>",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/NR_durabilite_Nov.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/NR_durabilite_Nov.json
@@ -4,6 +4,7 @@
   "slug": "nr-durabilite-nov",
   "title": "Smartphones : pourquoi les conserver plus longtemps ?",
   "isBeta": true,
+  "visibility": "public",
   "details": {
     "image": "https://assets.pix.org/modules/nr_durabilite-nov/picto-durab.jpg",
     "description": "<p>On a presque tous un portable aujourd’hui, mais sait-on vraiment comment a-t-il été fabriqué ?&nbsp; </p><p>Sa fabrication entraîne une forte pollution, des impacts écologiques importants et même des conditions humaines difficiles. </p><p>Connaître ce qu’il y a derrière toute la chaîne de production, c’est aussi comprendre l’importance d’adopter les bons gestes pour réduire ces impacts.</p>",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/NR_surequipement_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/NR_surequipement_NOV.json
@@ -4,6 +4,7 @@
   "slug": "surequipement",
   "title": "30 milliards d’appareils numériques :  et moi dans tout ça ?",
   "isBeta": true,
+  "visibility": "public",
   "details": {
     "image": "https://assets.pix.org/modules/placeholder-details.svg",
     "description": "<p>Une nouvelle télévision, un ordinateur plus puissant, un ancien téléphone oublié dans un tiroir… Sans toujours nous en rendre compte, nous accumulons au fil des années de plus en plus d’appareils numériques. </p><p>Dans ce module, vous comprendrez ce qu’est concrètement le suréquipement numérique. Vous allez découvrir comment vos appareils consomment même lorsqu’ils semblent “à l’arrêt” et comment certains gestes peuvent faire la différence.&nbsp;<br></p>",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/adresse-ip-publique-et-vous.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/adresse-ip-publique-et-vous.json
@@ -4,6 +4,7 @@
   "slug": "adresse-ip-publique-et-vous",
   "title": "L'adresse IP publique : ce qu'elle révèle sur vous !",
   "isBeta": true,
+  "visibility": "public",
   "details": {
     "image": "https://assets.pix.org/modules/placeholder-details.svg",
     "description": "<p>Quand vous naviguez sur internet, vous partagez des informations et laissez ainsi de nombreuses traces : adresse IP, cookies, historique, etc. Dans ce module, découvrez ce qu'est une adresse IP publique et ce qu’elle dévoile sur vous.</p>",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/au-dela-des-mots-de-passe.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/au-dela-des-mots-de-passe.json
@@ -4,6 +4,7 @@
   "slug": "au-dela-des-mots-de-passe",
   "title": "Au-delà des mots de passe : comment s’authentifier ?",
   "isBeta": true,
+  "visibility": "public",
   "details": {
     "image": "https://assets.pix.org/modules/placeholder-details.svg",
     "description": "<p>Code reçu par SMS, empreinte digitale, reconnaissance faciale… De plus en plus de moyens existent pour prouver son identité en ligne. <br>Dans ce module, vous allez découvrir les différentes façons de s’authentifier et pourquoi elles renforcent la sécurité de vos comptes. 🔐</p>",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
@@ -4,6 +4,7 @@
   "slug": "bac-a-sable",
   "title": "Bac à sable",
   "isBeta": true,
+  "visibility": "private",
   "details": {
     "image": "https://assets.pix.org/modules/placeholder-details.svg",
     "description": "<p>Ce module est dédié à des tests internes à Pix.</p><p>Il contient normalement l'intégralité des fonctionnalités disponibles à date.</p>",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bases-clavier-ordinateur-1.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bases-clavier-ordinateur-1.json
@@ -4,6 +4,7 @@
   "slug": "bases-clavier-1",
   "title": "Les bases du clavier sur ordinateur 1/2",
   "isBeta": true,
+  "visibility": "public",
   "details": {
     "image": "https://assets.pix.org/modules/placeholder-details.svg",
     "description": "<p>Dans ce module, découvrez ce qu’est un clavier et à quoi il sert. <span aria-hidden=\"true\">⌨️</span><br>Vous apprendrez à taper des mots simples et à modifier du texte.<br>Pour ce module, vous devez déjà savoir utiliser une souris d’ordinateur.</p>",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bases-clavier-ordinateur-2.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bases-clavier-ordinateur-2.json
@@ -4,6 +4,7 @@
   "slug": "bases-clavier-2",
   "title": "Les bases du clavier sur ordinateur 2/2",
   "isBeta": true,
+  "visibility": "public",
   "details": {
     "image": "https://assets.pix.org/modules/placeholder-details.svg",
     "description": "<p>Pour taper certains caractères, il suffit d’appuyer une fois sur une touche. Pour d’autres c’est un peu plus compliqué ! <br>Dans ce module, vous apprendrez à taper des caractères en appuyant sur deux touches en même temps&nbsp;: les majuscules ou la ponctuation par exemple.</p>",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
@@ -4,6 +4,7 @@
   "slug": "bien-ecrire-son-adresse-mail",
   "title": "Bien écrire une adresse mail",
   "isBeta": true,
+  "visibility": "public",
   "details": {
     "image": "https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-details.svg",
     "description": "Écrire une adresse mail, c'est la première étape pour communiquer avec vos contacts. Dans ce module, découvrez les différentes parties de l'adresse mail et apprenez à éviter des erreurs courantes.",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/chatgpt-vraiment-neutre.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/chatgpt-vraiment-neutre.json
@@ -4,6 +4,7 @@
   "slug": "chatgpt-vraiment-neutre",
   "title": "ChatGPT est-il vraiment neutre ?",
   "isBeta": true,
+  "visibility": "public",
   "details": {
     "image": "https://assets.pix.org/modules/placeholder-details.svg",
     "description": "<p>Les <i lang=\"en\">Large Language Models</i> (LLM) sont des systèmes d'intelligence artificielle générative. Ils donnent l'impression d’avoir réponse à tout mais, du fait de leurs biais, leurs productions sont parfois stéréotypées ou discriminantes. Dans ce module, vous allez découvrir les origines de ces biais et interroger directement des LLM pour les repérer !</p>",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/comment-envoyer-un-mail.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/comment-envoyer-un-mail.json
@@ -4,6 +4,7 @@
   "slug": "comment-envoyer-un-mail",
   "title": "Comment envoyer un mail ? ",
   "isBeta": true,
+  "visibility": "public",
   "details": {
     "image": "https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-details.svg",
     "description": "En contexte professionnel et associatif ou pour communiquer avec des proches, envoyer des mails est indispensable.<br>Dans ce module, découvrez les étapes pour envoyer un mail simplement et le rôle des champs dans un mail.",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/controle-parental.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/controle-parental.json
@@ -4,6 +4,7 @@
   "slug": "controle-parental",
   "title": "Le contrôle parental",
   "isBeta": true,
+  "visibility": "public",
   "details": {
     "image": "https://assets.pix.org/modules/placeholder-details.svg",
     "description": "<p>Les enfants et les adolescents utilisent le numérique au quotidien. Pour les protéger sur internet, le contrôle parental fait partie des solutions à la disposition des parents.&nbsp;🧑‍🧒<br>Dans ce module, découvrez le contrôle parental et ses fonctionnalités.</p>",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/decouverte-de-l-ent.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/decouverte-de-l-ent.json
@@ -4,6 +4,7 @@
   "slug": "decouverte-de-l-ent",
   "title": "À la découverte de l’ENT",
   "isBeta": true,
+  "visibility": "public",
   "details": {
     "image": "https://assets.pix.org/modules/placeholder-details.svg",
     "description": "<p>Aujourd’hui, le numérique fait partie du quotidien des familles, à la maison comme à l’école ! <span aria-hidden=\"true\">🎒</span></p><p>Dans ce module, partez à la découverte de l’espace numérique de travail (ENT), l’outil numérique utilisé dans les établissements scolaires.</p>",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-combinix-1.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-combinix-1.json
@@ -4,6 +4,7 @@
   "slug": "demo-combinix-1",
   "title": "Demo combinix 1",
   "isBeta": true,
+  "visibility": "private",
   "details": {
     "image": "https://assets.pix.org/modules/placeholder-details.svg",
     "description": "<p>Ce module est dédié à des tests internes à Pix.</p><p>Il permet d'avoir le scénario d'un module en arrivant rapidement à la fin</p>",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-combinix-2.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-combinix-2.json
@@ -4,6 +4,7 @@
   "slug": "demo-combinix-2",
   "title": "Demo combinix 2",
   "isBeta": true,
+  "visibility": "private",
   "details": {
     "image": "https://assets.pix.org/modules/placeholder-details.svg",
     "description": "<p>Ce module est dédié à des tests internes à Pix.</p><p>Il permet d'avoir le scénario d'un module en arrivant rapidement à la fin</p>",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-epreuves-components.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-epreuves-components.json
@@ -4,6 +4,7 @@
   "slug": "demo-epreuves-components",
   "title": "Démonstration des composants Pix Épreuves",
   "isBeta": true,
+  "visibility": "private",
   "details": {
     "image": "https://assets.pix.org/modules/placeholder-details.svg",
     "description": "<p>Ce module est dédié à des tests internes à Pix.</p><p>Il contient normalement tous les composants Pix Épreuves.</p>",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-llm.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-llm.json
@@ -4,6 +4,7 @@
   "slug": "demo-llm",
   "title": "Démo LLM",
   "isBeta": true,
+  "visibility": "private",
   "details": {
     "image": "https://assets.pix.org/modules/placeholder-details.svg",
     "description": "<p>Ce module est dédié à des tests internes à Pix.</p><p>Il contient un exemple d’intégration de ChatPix.</p>",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/distinguer-vrai-faux-sur-internet.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/distinguer-vrai-faux-sur-internet.json
@@ -4,6 +4,7 @@
   "slug": "distinguer-vrai-faux-sur-internet",
   "title": "Les informations sur internet : distinguer le vrai du faux",
   "isBeta": true,
+  "visibility": "public",
   "details": {
     "image": "https://assets.pix.org/modules/placeholder-details.svg",
     "description": "De nombreuses informations circulent sur internet et les réseaux sociaux. Ces informations sont parfois exagérées, trompeuses ou fausses. Dans ce module, vous allez découvrir une méthode pour analyser l'information et aiguiser votre esprit critique pour mieux distinguer le vrai du faux !",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/galerie.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/galerie.json
@@ -4,6 +4,7 @@
   "slug": "galerie",
   "title": "Galerie Modulix",
   "isBeta": true,
+  "visibility": "private",
   "details": {
     "image": "https://assets.pix.org/modules/placeholder-details.svg",
     "description": "<p>Ce module est dédié à des tests internes à Pix.</p><p>Il permet de visualiser tous les modules existants.</p>",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/ia-cadre-usage-educ-nov.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/ia-cadre-usage-educ-nov.json
@@ -4,6 +4,7 @@
   "slug": "ia-cadre-usage-educ-nov",
   "title": "IA et éducation, découverte du cadre d’usage",
   "isBeta": true,
+  "visibility": "public",
   "details": {
     "image": "https://assets.pix.org/modules/placeholder-details.svg",
     "description": "<p>L’usage des IA génératives par les élèves et par certains enseignants est déjà largement répandu. Ce développement rapide pose question, et a mené le ministère de l’Éducation nationale à élaborer des recommandations.&nbsp;</p><p>Vous allez en découvrir dans ce module les grandes lignes.</p>",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/ia-deepfakes-alt.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/ia-deepfakes-alt.json
@@ -4,6 +4,7 @@
   "slug": "ia-deepfakes-alt",
   "title": "Les deepfakes (hypertrucages) : c’est quoi ?",
   "isBeta": true,
+  "visibility": "public",
   "details": {
     "image": "https://assets.pix.org/modules/placeholder-details.svg",
     "description": "<p>Sur internet, on trouve des images, des vidéos et des sons. Certains sont vrais mais d'autres sont faux&nbsp;: ils sont créés pour ressembler à la réalité.<br>Dans ce module, vous allez découvrir comment les deepfakes (ou hypertrucages en français) sont créés et pourquoi.</p>",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/jeux-video-enfant.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/jeux-video-enfant.json
@@ -4,6 +4,7 @@
   "slug": "jeux-video-enfant",
   "title": "Choisir un jeu vidéo adapté à son enfant",
   "isBeta": true,
+  "visibility": "public",
   "details": {
     "image": "https://assets.pix.org/modules/ppn3_placeholder_details.svg",
     "description": "<p>Les jeux vidéo, c’est comme les livres ou les films&nbsp;: il y en a pour tous les goûts et tous les âges. <br>Alors, si votre enfant veut jouer sur smartphone, console ou ordinateur, il faut être vigilant pour bien choisir ses jeux ! 🔎 <br>Dans ce module, découvrez des informations clés à vérifier avant de choisir un jeu vidéo.</p>",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/mots-de-passe-securises.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/mots-de-passe-securises.json
@@ -4,6 +4,7 @@
   "slug": "mots-de-passe-securises",
   "title": "Des mots de passe solides",
   "isBeta": true,
+  "visibility": "public",
   "details": {
     "image": "https://assets.pix.org/modules/placeholder-details.svg",
     "description": "Aujourd'hui, on utilise des mots de passe pour tout : son téléphone, son adresse mail, ses réseaux sociaux. Dans ce module, vous allez découvrir pourquoi et comment créer des mots de passe solides.",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/nr_durabilite_ind.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/nr_durabilite_ind.json
@@ -4,6 +4,7 @@
   "slug": "metaux-eau-reemploi",
   "title": "Le numérique : pourquoi privilégier le réemploi ?",
   "isBeta": false,
+  "visibility": "public",
   "details": {
     "image": "https://assets.pix.org/modules/placeholder-details.svg",
     "description": "<p>Nos smartphones et ordinateurs contiennent de nombreux métaux (lithium, cobalt, terres rares) dont l’extraction consomme beaucoup d’eau et de produits chimiques, avec des impacts sur l’environnement et la santé. 🌍</p><p>Ce module vous montre les impacts de la fabrication des appareils numériques et montre comment le réemploi et le reconditionnement permettent d’en réduire l’empreinte. 🔁</p>",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/ports-connexions-essentiels.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/ports-connexions-essentiels.json
@@ -4,6 +4,7 @@
   "slug": "ports-connexions-essentiels",
   "title": "Les ports de connexion d’un ordinateur",
   "isBeta": true,
+  "visibility": "public",
   "details": {
     "image": "https://assets.pix.org/modules/placeholder-details.svg",
     "description": "<p>Pour savoir ce qu'on peut brancher ou non à un ordinateur, il faut bien connaître les principaux ports de connexion !</p>",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/principes-fondateurs-wikipedia.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/principes-fondateurs-wikipedia.json
@@ -4,6 +4,7 @@
   "slug": "principes-fondateurs-wikipedia",
   "title": "Les principes fondateurs de Wikipédia",
   "isBeta": true,
+  "visibility": "public",
   "details": {
     "image": "https://assets.pix.org/modules/placeholder-details.svg",
     "description": "Wikipédia est un site très connu, que vous avez sans doute déjà utilisé. Dans ce module, vous trouverez des explications sur les principes de Wikipédia. Vous découvrirez aussi des méthodes pour l'utiliser.",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/sources-informations.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/sources-informations.json
@@ -4,6 +4,7 @@
   "slug": "sources-informations",
   "title": "Les sources d'information",
   "isBeta": true,
+  "visibility": "public",
   "details": {
     "image": "https://assets.pix.org/modules/placeholder-details.svg",
     "description": "Sur internet et les réseaux sociaux, il est parfois difficile de savoir si une information est vraie ou fausse. Dans ce module, vous allez découvrir pourquoi il est important de s’intéresser à la source d’une information pour démêler le vrai du faux.",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/tmp08ef.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/tmp08ef.json
@@ -4,6 +4,7 @@
   "slug": "tmp08ef",
   "title": "Derrière le prompt : comment fonctionnent les IA génératives ?",
   "isBeta": true,
+  "visibility": "public",
   "details": {
     "image": "https://assets.pix.org/modules/placeholder-details.svg",
     "description": "<p>ChatGPT, Mistral, Dall-E : les systèmes d’Intelligence Artificielle (IA) générative sont de plus en plus utilisés par le grand public. Ce succès s’explique notamment par les prompts, ces commandes que l’on peut écrire simplement afin d’obtenir des résultats parfois bluffants. <span aria-hidden=\"true\">✨ </span> Mais ça n’a rien de magique… </p><br><p>Dans ce module, vous allez découvrir les coulisses du fonctionnement des prompts et comprendre comment les systèmes d’IA générative produisent leurs réponses en testant avec des exemples concrets.</p>",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/tri-multicritere-tableau.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/tri-multicritere-tableau.json
@@ -4,6 +4,7 @@
   "slug": "tri-multicritere-tableau",
   "title": "Trier un tableau selon plusieurs critères",
   "isBeta": true,
+  "visibility": "public",
   "details": {
     "image": "https://assets.pix.org/modules/placeholder-details.svg",
     "description": "<p>Trier des données dans une feuille de calcul peut permettre de trouver efficacement des informations. Parfois, un tri sur une seule colonne ne suffit pas. <br>Dans ce module, vous allez apprendre à trier vos données en combinant plusieurs critères.<br></p>",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/utiliser-souris-ordinateur-1.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/utiliser-souris-ordinateur-1.json
@@ -4,6 +4,7 @@
   "slug": "utiliser-souris-ordinateur-1",
   "title": "Utiliser une souris d'ordinateur - 1",
   "isBeta": true,
+  "visibility": "public",
   "details": {
     "image": "https://assets.pix.org/modules/placeholder-details.svg",
     "description": "<p>Dans ce module, vous découvrirez ce qu’est une souris et à quoi elle sert.&nbsp;</p><p>Vous apprendrez à la déplacer et à cliquer pour interagir avec votre ordinateur.</p><p>Si vous n'avez jamais utilisé de souris, nous vous conseillons d'être accompagné pour ce module.</p><br>",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/utiliser-souris-ordinateur-2.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/utiliser-souris-ordinateur-2.json
@@ -4,6 +4,7 @@
   "slug": "utiliser-souris-ordinateur-2",
   "title": "Utiliser une souris d'ordinateur - 2",
   "isBeta": true,
+  "visibility": "public",
   "details": {
     "image": "https://assets.pix.org/modules/placeholder-details.svg",
     "description": "<p>La souris est composée de trois boutons : le bouton gauche, la molette et le bouton droit. Le bouton gauche permet de faire un clic gauche, c’est le plus utilisé. Mais il existe d’autres façons d’utiliser la souris.<br><br> Dans ce module, vous apprendrez à faire d’autres clics et à utiliser les deux autres boutons de la souris. 🖱️</p>",

--- a/api/src/devcomp/infrastructure/factories/module-factory.js
+++ b/api/src/devcomp/infrastructure/factories/module-factory.js
@@ -44,6 +44,7 @@ export class ModuleFactory {
         title: moduleData.title,
         version: moduleData.version,
         isBeta: moduleData.isBeta,
+        visibility: moduleData.visibility,
         details: new Details(moduleData.details),
         sections: await Promise.all(
           await Promise.all(

--- a/api/src/devcomp/infrastructure/repositories/module-metadata-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/module-metadata-repository.js
@@ -43,8 +43,17 @@ async function list({ moduleDatasource }) {
 }
 
 function _toDomain(module) {
-  const { id, shortId, slug, title, isBeta, details } = module;
-  return new ModuleMetadata({ id, shortId, slug, title, isBeta, duration: details.duration, image: details.image });
+  const { id, shortId, slug, title, isBeta, details, visibility } = module;
+  return new ModuleMetadata({
+    id,
+    shortId,
+    slug,
+    title,
+    isBeta,
+    duration: details.duration,
+    image: details.image,
+    visibility,
+  });
 }
 
 export { getAllByIds, getAllByShortIds, getByShortId, getBySlug, list };

--- a/api/src/devcomp/infrastructure/serializers/jsonapi/module-metadata-serializer.js
+++ b/api/src/devcomp/infrastructure/serializers/jsonapi/module-metadata-serializer.js
@@ -4,7 +4,7 @@ const { Serializer } = jsonapiSerializer;
 
 const serialize = function (moduleMetadataList) {
   return new Serializer('module-metadata', {
-    attributes: ['shortId', 'slug', 'title', 'isBeta', 'duration', 'image', 'link'],
+    attributes: ['shortId', 'slug', 'title', 'isBeta', 'duration', 'image', 'link', 'visibility'],
   }).serialize(moduleMetadataList);
 };
 

--- a/api/tests/devcomp/acceptance/scripts/test-module.json
+++ b/api/tests/devcomp/acceptance/scripts/test-module.json
@@ -4,6 +4,7 @@
   "slug": "bac-a-sable",
   "title": "Bac à sable",
   "isBeta": true,
+  "visibility": "public",
   "details": {
     "image": "https://assets.pix.org/modules/placeholder-details.svg",
     "description": "<p>Découvrez avec ce didacticiel comment fonctionne Modulix !</p>",

--- a/api/tests/devcomp/integration/infrastructure/factories/module-factory_test.js
+++ b/api/tests/devcomp/integration/infrastructure/factories/module-factory_test.js
@@ -37,6 +37,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
             slug: 'title',
             title: 'title',
             isBeta: true,
+            visibility: 'public',
             details: {
               image: 'https://assets.pix.org/modules/placeholder-details.svg',
               description: 'Description',
@@ -93,6 +94,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
             slug: 'title',
             title: 'title',
             isBeta: true,
+            visibility: 'public',
             details: {
               image: 'https://assets.pix.org/modules/placeholder-details.svg',
               description: 'Description',
@@ -149,6 +151,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
             slug: 'title',
             title: 'title',
             isBeta: true,
+            visibility: 'public',
             details: {
               image: 'https://assets.pix.org/modules/placeholder-details.svg',
               description: 'Description',
@@ -215,6 +218,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
         title: 'title',
         version,
         isBeta: true,
+        visibility: 'public',
         details: {
           image: 'https://assets.pix.org/modules/placeholder-details.svg',
           description: 'Description',
@@ -272,6 +276,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
           slug: 'title',
           title: 'title',
           isBeta: true,
+          visibility: 'public',
           details: {
             image: 'https://assets.pix.org/modules/placeholder-details.svg',
             description: 'Description',
@@ -371,6 +376,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
           slug: 'title',
           title: 'title',
           isBeta: true,
+          visibility: 'public',
           details: {
             image: 'https://assets.pix.org/modules/placeholder-details.svg',
             description: 'Description',
@@ -423,6 +429,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
           slug: 'title',
           title: 'title',
           isBeta: true,
+          visibility: 'public',
           details: {
             image: 'https://assets.pix.org/modules/placeholder-details.svg',
             description: 'Description',
@@ -475,6 +482,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
           slug: 'title',
           title: 'title',
           isBeta: true,
+          visibility: 'public',
           details: {
             image: 'https://assets.pix.org/modules/placeholder-details.svg',
             description: 'Description',
@@ -527,6 +535,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
           slug: 'title',
           title: 'title',
           isBeta: true,
+          visibility: 'public',
           details: {
             image: 'https://assets.pix.org/modules/placeholder-details.svg',
             description: 'Description',
@@ -575,6 +584,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
           slug: 'title',
           title: 'title',
           isBeta: true,
+          visibility: 'public',
           details: {
             image: 'https://assets.pix.org/modules/placeholder-details.svg',
             description: 'Description',
@@ -637,6 +647,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
           slug: 'title',
           title: 'title',
           isBeta: true,
+          visibility: 'public',
           details: {
             image: 'https://assets.pix.org/modules/placeholder-details.svg',
             description: 'Description',
@@ -695,6 +706,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
           slug: 'title',
           title: 'title',
           isBeta: true,
+          visibility: 'public',
           details: {
             image: 'https://assets.pix.org/modules/placeholder-details.svg',
             description: 'Description',
@@ -748,6 +760,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
           slug: 'title',
           title: 'title',
           isBeta: true,
+          visibility: 'public',
           details: {
             image: 'https://assets.pix.org/modules/placeholder-details.svg',
             description: 'Description',
@@ -799,6 +812,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
           slug: 'title',
           title: 'title',
           isBeta: true,
+          visibility: 'public',
           details: {
             image: 'https://assets.pix.org/modules/placeholder-details.svg',
             description: 'Description',
@@ -861,6 +875,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
           slug: 'title',
           title: 'title',
           isBeta: true,
+          visibility: 'public',
           details: {
             image: 'https://assets.pix.org/modules/placeholder-details.svg',
             description: 'Description',
@@ -932,6 +947,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
           slug: 'title',
           title: 'title',
           isBeta: true,
+          visibility: 'public',
           details: {
             image: 'https://assets.pix.org/modules/placeholder-details.svg',
             description: 'Description',
@@ -1015,6 +1031,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
           slug: 'title',
           title: 'title',
           isBeta: true,
+          visibility: 'public',
           details: {
             image: 'https://assets.pix.org/modules/placeholder-details.svg',
             description: 'Description',
@@ -1091,6 +1108,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
           slug: 'title',
           title: 'title',
           isBeta: true,
+          visibility: 'public',
           details: {
             image: 'https://assets.pix.org/modules/placeholder-details.svg',
             description: 'Description',
@@ -1183,6 +1201,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
           slug: 'title',
           title: 'title',
           isBeta: true,
+          visibility: 'public',
           details: {
             image: 'https://assets.pix.org/modules/placeholder-details.svg',
             description: 'Description',
@@ -1254,6 +1273,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
           slug: 'title',
           title: 'title',
           isBeta: true,
+          visibility: 'public',
           details: {
             image: 'https://assets.pix.org/modules/placeholder-details.svg',
             description: 'Description',
@@ -1311,6 +1331,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
           slug: 'title',
           title: 'title',
           isBeta: true,
+          visibility: 'public',
           details: {
             image: 'https://assets.pix.org/modules/placeholder-details.svg',
             description: 'Description',
@@ -1390,6 +1411,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
           slug: 'title',
           title: 'title',
           isBeta: true,
+          visibility: 'public',
           details: {
             image: 'https://assets.pix.org/modules/placeholder-details.svg',
             description: 'Description',
@@ -1448,6 +1470,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
           slug: 'title',
           title: 'title',
           isBeta: true,
+          visibility: 'public',
           details: {
             image: 'https://assets.pix.org/modules/placeholder-details.svg',
             description: 'Description',
@@ -1503,6 +1526,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
           slug: 'title',
           title: 'title',
           isBeta: true,
+          visibility: 'public',
           details: {
             image: 'https://assets.pix.org/modules/placeholder-details.svg',
             description: 'Description',
@@ -1560,6 +1584,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
           slug: 'title',
           title: 'title',
           isBeta: true,
+          visibility: 'public',
           details: {
             image: 'https://assets.pix.org/modules/placeholder-details.svg',
             description: 'Description',
@@ -1620,6 +1645,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
           slug: 'title',
           title: 'title',
           isBeta: true,
+          visibility: 'public',
           details: {
             image: 'https://assets.pix.org/modules/placeholder-details.svg',
             description: 'Description',
@@ -1678,6 +1704,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
           slug: 'title',
           title: 'title',
           isBeta: true,
+          visibility: 'public',
           details: {
             image: 'https://assets.pix.org/modules/placeholder-details.svg',
             description: 'Description',
@@ -1739,6 +1766,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
           slug: 'title',
           title: 'title',
           isBeta: true,
+          visibility: 'public',
           details: {
             image: 'https://assets.pix.org/modules/placeholder-details.svg',
             description: 'Description',
@@ -1799,6 +1827,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
           slug: 'title',
           title: 'title',
           isBeta: true,
+          visibility: 'public',
           details: {
             image: 'https://assets.pix.org/modules/placeholder-details.svg',
             description: 'Description',
@@ -1870,6 +1899,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
           slug: 'title',
           title: 'title',
           isBeta: true,
+          visibility: 'public',
           details: {
             image: 'https://assets.pix.org/modules/placeholder-details.svg',
             description: 'Description',
@@ -1949,6 +1979,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
           slug: 'title',
           title: 'title',
           isBeta: true,
+          visibility: 'public',
           details: {
             image: 'https://assets.pix.org/modules/placeholder-details.svg',
             description: 'Description',
@@ -2033,6 +2064,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
           slug: 'title',
           title: 'title',
           isBeta: true,
+          visibility: 'public',
           details: {
             image: 'https://assets.pix.org/modules/placeholder-details.svg',
             description: 'Description',
@@ -2131,6 +2163,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
           slug: 'title',
           title: 'title',
           isBeta: true,
+          visibility: 'public',
           details: {
             image: 'https://assets.pix.org/modules/placeholder-details.svg',
             description: 'Description',
@@ -2208,6 +2241,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
           slug: 'title',
           title: 'title',
           isBeta: true,
+          visibility: 'public',
           details: {
             image: 'https://assets.pix.org/modules/placeholder-details.svg',
             description: 'Description',
@@ -2271,6 +2305,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
           slug: 'title',
           title: 'title',
           isBeta: true,
+          visibility: 'public',
           details: {
             image: 'https://assets.pix.org/modules/placeholder-details.svg',
             description: 'Description',
@@ -2336,6 +2371,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
           slug: 'title',
           title: 'title',
           isBeta: true,
+          visibility: 'public',
           details: {
             image: 'https://assets.pix.org/modules/placeholder-details.svg',
             description: 'Description',
@@ -2392,6 +2428,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
         slug: 'title',
         title: 'title',
         isBeta: true,
+        visibility: 'public',
         details: {
           image: 'https://assets.pix.org/modules/placeholder-details.svg',
           description: 'Description',
@@ -2451,6 +2488,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
         slug: 'title',
         title: 'title',
         isBeta: true,
+        visibility: 'public',
         details: {
           image: 'https://assets.pix.org/modules/placeholder-details.svg',
           description: 'Description',

--- a/api/tests/devcomp/integration/repositories/element-repository_test.js
+++ b/api/tests/devcomp/integration/repositories/element-repository_test.js
@@ -268,6 +268,7 @@ describe('Integration | DevComp | Repositories | ElementRepository', function ()
         slug: 'bac-a-sable',
         title: 'Bac à sable',
         isBeta: true,
+        visibility: 'public',
         details: {
           image: 'https://assets.pix.org/modules/placeholder-details.svg',
           description: 'Découvrez avec ce didacticiel comment fonctionne Modulix !',

--- a/api/tests/devcomp/integration/repositories/module-metadata-repository_test.js
+++ b/api/tests/devcomp/integration/repositories/module-metadata-repository_test.js
@@ -1,4 +1,5 @@
 import { ModuleDoesNotExistError } from '../../../../src/devcomp/domain/errors.js';
+import { Module } from '../../../../src/devcomp/domain/models/module/Module.js';
 import { ModuleMetadata } from '../../../../src/devcomp/domain/models/module/ModuleMetadata.js';
 import moduleDatasource from '../../../../src/devcomp/infrastructure/datasources/learning-content/module-datasource.js';
 import * as moduleMetadataRepository from '../../../../src/devcomp/infrastructure/repositories/module-metadata-repository.js';
@@ -16,6 +17,7 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
         slug: 'getAllByIdsModuleSlug1',
         title: 'Bien écrire son adresse mail',
         isBeta: true,
+        visibility: Module.VISIBILITY.PUBLIC,
         details: {
           image: 'https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-details.svg',
           description:
@@ -60,6 +62,7 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
         slug: 'getAllByIdsModuleSlug2',
         title: 'Bac à sable',
         isBeta: true,
+        visibility: Module.VISIBILITY.PUBLIC,
         details: {
           image: 'https://assets.pix.org/modules/placeholder-details.svg',
           description:
@@ -116,6 +119,7 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
           isBeta: firstModule.isBeta,
           duration: firstModule.details.duration,
           image: firstModule.details.image,
+          visibility: firstModule.visibility,
         }),
         new ModuleMetadata({
           id: secondModule.id,
@@ -125,6 +129,7 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
           isBeta: secondModule.isBeta,
           duration: secondModule.details.duration,
           image: secondModule.details.image,
+          visibility: secondModule.visibility,
         }),
       ];
       expect(modules).to.have.lengthOf(2);
@@ -164,6 +169,7 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
         slug: 'getAllByIdsModuleSlug1',
         title: 'Bien écrire son adresse mail',
         isBeta: true,
+        visibility: Module.VISIBILITY.PUBLIC,
         details: {
           image: 'https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-details.svg',
           description:
@@ -208,6 +214,7 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
         slug: 'getAllByIdsModuleSlug2',
         title: 'Bac à sable',
         isBeta: true,
+        visibility: Module.VISIBILITY.PUBLIC,
         details: {
           image: 'https://assets.pix.org/modules/placeholder-details.svg',
           description:
@@ -264,6 +271,7 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
           isBeta: firstModule.isBeta,
           duration: firstModule.details.duration,
           image: firstModule.details.image,
+          visibility: firstModule.visibility,
         }),
         new ModuleMetadata({
           id: secondModule.id,
@@ -273,6 +281,7 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
           isBeta: secondModule.isBeta,
           duration: secondModule.details.duration,
           image: secondModule.details.image,
+          visibility: secondModule.visibility,
         }),
       ];
       expect(modules).to.have.lengthOf(2);
@@ -311,6 +320,7 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
         slug: 'slug',
         title: 'Bien écrire son adresse mail',
         isBeta: true,
+        visibility: Module.VISIBILITY.PUBLIC,
         details: {
           image: 'https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-details.svg',
           description:
@@ -370,6 +380,7 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
         isBeta: stubModule.isBeta,
         duration: stubModule.details.duration,
         image: stubModule.details.image,
+        visibility: stubModule.visibility,
       });
 
       expect(moduleMetadata).to.be.instanceOf(ModuleMetadata);
@@ -400,6 +411,7 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
         slug: existingModuleSlug,
         title: 'Bien écrire son adresse mail',
         isBeta: true,
+        visibility: Module.VISIBILITY.PUBLIC,
         details: {
           image: 'https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-details.svg',
           description:
@@ -459,6 +471,7 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
         isBeta: stubModule.isBeta,
         duration: stubModule.details.duration,
         image: stubModule.details.image,
+        visibility: stubModule.visibility,
       });
 
       expect(moduleMetadata).to.be.instanceOf(ModuleMetadata);
@@ -488,6 +501,7 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
         slug: 'bien-ecrire-son-adresse-mail',
         title: 'Bien écrire son adresse mail',
         isBeta: true,
+        visibility: Module.VISIBILITY.PUBLIC,
         details: {
           image: 'https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-details.svg',
           description:
@@ -532,6 +546,7 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
         slug: 'bac-a-sable',
         title: 'Bac à sable',
         isBeta: true,
+        visibility: Module.VISIBILITY.PUBLIC,
         details: {
           image: 'https://assets.pix.org/modules/placeholder-details.svg',
           description:
@@ -786,6 +801,7 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
           duration: emailModule.details.duration,
           image: emailModule.details.image,
           link: `/modules/${emailModule.shortId}/${emailModule.slug}`,
+          visibility: emailModule.visibility,
         },
         {
           id: bacASableModule.id,
@@ -796,6 +812,7 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
           duration: bacASableModule.details.duration,
           image: bacASableModule.details.image,
           link: `/modules/${bacASableModule.shortId}/${bacASableModule.slug}`,
+          visibility: bacASableModule.visibility,
         },
       ];
 

--- a/api/tests/devcomp/integration/repositories/module-repository_test.js
+++ b/api/tests/devcomp/integration/repositories/module-repository_test.js
@@ -52,6 +52,7 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
         slug: 'existingModuleSlug',
         title: 'Bien écrire son adresse mail',
         isBeta: true,
+        visibility: 'public',
         details: {
           image: 'https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-details.svg',
           description:
@@ -209,6 +210,7 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
         slug: existingModuleSlug,
         title: 'Bien écrire son adresse mail',
         isBeta: true,
+        visibility: 'public',
         details: {
           image: 'https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-details.svg',
           description:
@@ -358,6 +360,7 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
         slug: existingModuleSlug,
         title: 'Bien écrire son adresse mail',
         isBeta: true,
+        visibility: 'public',
         details: {
           image: 'https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-details.svg',
           description:

--- a/api/tests/devcomp/unit/domain/models/module/ModuleMetadata_test.js
+++ b/api/tests/devcomp/unit/domain/models/module/ModuleMetadata_test.js
@@ -3,7 +3,7 @@ import { DomainError } from '../../../../../../src/shared/domain/errors.js';
 import { catchErrSync, expect } from '../../../../../test-helper.js';
 
 describe('Unit | Devcomp | Domain | Models | Module | ModuleMetadata', function () {
-  let id, isBeta, slug, title, duration, image, shortId;
+  let id, isBeta, slug, title, duration, image, shortId, visibility;
 
   beforeEach(function () {
     id = '12a3a2b4-e873-4789-ae1c-57f6f2b99890';
@@ -13,11 +13,12 @@ describe('Unit | Devcomp | Domain | Models | Module | ModuleMetadata', function 
     isBeta = false;
     duration = 10;
     image = 'emile';
+    visibility = Symbol('visibility');
   });
 
   it('should init and keep attributes', function () {
     // when
-    const module = new ModuleMetadata({ id, shortId, slug, title, isBeta, duration, image });
+    const module = new ModuleMetadata({ id, shortId, slug, title, isBeta, duration, image, visibility });
 
     // then
     expect(module.id).to.equal(id);
@@ -28,6 +29,7 @@ describe('Unit | Devcomp | Domain | Models | Module | ModuleMetadata', function 
     expect(module.duration).to.equal(duration);
     expect(module.image).to.equal(image);
     expect(module.link).to.equal(`/modules/${shortId}/${slug}`);
+    expect(module.visibility).to.equal(visibility);
   });
 
   describe('if a module does not have an id', function () {
@@ -171,6 +173,7 @@ describe('Unit | Devcomp | Domain | Models | Module | ModuleMetadata', function 
             isBeta,
             image,
             shortId,
+            visibility,
           }),
       )();
 
@@ -196,6 +199,7 @@ describe('Unit | Devcomp | Domain | Models | Module | ModuleMetadata', function 
             isBeta,
             image,
             shortId,
+            visibility,
           }),
       )();
 
@@ -223,6 +227,28 @@ describe('Unit | Devcomp | Domain | Models | Module | ModuleMetadata', function 
       // then
       expect(error).to.be.instanceOf(DomainError);
       expect(error.message).to.equal('The image is required for a module metadata');
+    });
+  });
+
+  describe('if the module does not have a visibility', function () {
+    it('should throw an error', function () {
+      // when
+      const error = catchErrSync(
+        () =>
+          new ModuleMetadata({
+            duration,
+            id,
+            title,
+            slug,
+            isBeta,
+            shortId,
+            image,
+          }),
+      )();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The visibility is required for a module metadata');
     });
   });
 });

--- a/api/tests/devcomp/unit/domain/models/module/Module_test.js
+++ b/api/tests/devcomp/unit/domain/models/module/Module_test.js
@@ -14,9 +14,10 @@ describe('Unit | Devcomp | Domain | Models | Module | Module', function () {
       const sections = [Symbol('text')];
       const details = Symbol('details');
       const version = Symbol('version');
+      const visibility = Symbol('visibility');
 
       // when
-      const module = new Module({ id, shortId, slug, title, isBeta, sections, details, version });
+      const module = new Module({ id, shortId, slug, title, isBeta, sections, details, version, visibility });
 
       // then
       expect(module.id).to.equal(id);
@@ -27,6 +28,7 @@ describe('Unit | Devcomp | Domain | Models | Module | Module', function () {
       expect(module.sections).to.have.lengthOf(sections.length);
       expect(module.details).to.deep.equal(details);
       expect(module.version).to.deep.equal(version);
+      expect(module.visibility).to.deep.equal(visibility);
     });
 
     describe('if a module does not have an id', function () {
@@ -153,6 +155,28 @@ describe('Unit | Devcomp | Domain | Models | Module | Module', function () {
         expect(error.message).to.equal('The details are required for a module');
       });
     });
+
+    describe('if a module does not have visibility', function () {
+      it('should throw an error', function () {
+        // when
+        const error = catchErrSync(
+          () =>
+            new Module({
+              id: 'id_module_1',
+              shortId: 'e074af34',
+              slug: 'bien-ecrire-son-adresse-mail',
+              title: 'Bien écrire son adresse mail',
+              isBeta: true,
+              sections: [Symbol('text')],
+              details: Symbol('details'),
+            }),
+        )();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The visibility is required for a module');
+      });
+    });
   });
 
   describe('#setRedirectionUrl', function () {
@@ -167,8 +191,9 @@ describe('Unit | Devcomp | Domain | Models | Module | Module', function () {
       const sections = [Symbol('text')];
       const details = Symbol('details');
       const version = Symbol('version');
+      const visibility = Symbol('visibility');
 
-      module = new Module({ id, shortId, slug, title, isBeta, sections, details, version });
+      module = new Module({ id, shortId, slug, title, isBeta, sections, details, version, visibility });
     });
 
     it('should set redirectionUrl', function () {

--- a/api/tests/devcomp/unit/domain/usecases/create-passage_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/create-passage_test.js
@@ -65,6 +65,7 @@ describe('Unit | Devcomp | Domain | UseCases | create-passage', function () {
 
     const title = 'Les adresses email';
     const isBeta = false;
+    const visibility = Symbol('visibility');
     const sections = [Symbol('text')];
     const details = Symbol('details');
     const version = Symbol('version');
@@ -77,6 +78,7 @@ describe('Unit | Devcomp | Domain | UseCases | create-passage', function () {
       sections,
       details,
       version,
+      visibility,
     });
 
     const passageCreatedAt = new Date('2025-03-05');

--- a/api/tests/devcomp/unit/domain/usecases/get-module-by-short-id_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/get-module-by-short-id_test.js
@@ -32,8 +32,9 @@ describe('Unit | Devcomp | Domain | UseCases | get-module-by-short-id', function
       const sections = [Symbol('text')];
       const details = Symbol('details');
       const version = Symbol('version');
+      const visibility = Symbol('visibility');
 
-      const expectedModule = new Module({ id, shortId, slug, title, isBeta, sections, details, version });
+      const expectedModule = new Module({ id, shortId, slug, title, isBeta, sections, details, version, visibility });
       const moduleRepository = {
         getByShortId: sinon.stub(),
       };

--- a/api/tests/devcomp/unit/domain/usecases/get-module_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/get-module_test.js
@@ -32,8 +32,9 @@ describe('Unit | Devcomp | Domain | UseCases | get-module', function () {
       const sections = [Symbol('text')];
       const details = Symbol('details');
       const version = Symbol('version');
+      const visibility = Symbol('visibility');
 
-      const expectedModule = new Module({ id, shortId, slug, title, isBeta, sections, details, version });
+      const expectedModule = new Module({ id, shortId, slug, title, isBeta, sections, details, version, visibility });
       const moduleRepository = {
         getBySlug: sinon.stub(),
       };

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-schema.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-schema.js
@@ -128,6 +128,7 @@ const moduleSchema = Joi.object({
     .required(),
   title: htmlNotAllowedSchema.required(),
   isBeta: Joi.boolean().required(),
+  visibility: Joi.string().valid('private', 'public').required(),
   details: moduleDetailsSchema.required(),
   sections: Joi.array().items(moduleSectionSchema).required(),
 }).required();

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js
@@ -667,6 +667,7 @@ describe('Unit | Infrastructure | Datasources | Learning Content | Module Dataso
         slug: 'bac-a-sable',
         title: '<h1>Bac à sable</h1>',
         isBeta: true,
+        visibility: 'public',
         details: {
           image: 'https://assets.pix.org/modules/placeholder-details.svg',
           description: 'Découvrez avec ce didacticiel comment fonctionne Modulix !',

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-metadata-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-metadata-serializer_test.js
@@ -14,6 +14,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleMetada
         isBeta: false,
         duration: 10,
         image: 'https://example.net',
+        visibility: 'public',
       });
 
       const secondModuleMetadata = new ModuleMetadata({
@@ -24,6 +25,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleMetada
         isBeta: false,
         duration: 20,
         image: 'https://example.net',
+        visibility: 'private',
       });
 
       const expectedJson = {
@@ -39,6 +41,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleMetada
               duration: firstModuleMetadata.duration,
               image: firstModuleMetadata.image,
               link: `/modules/${firstModuleMetadata.shortId}/${firstModuleMetadata.slug}`,
+              visibility: firstModuleMetadata.visibility,
             },
           },
           {
@@ -52,6 +55,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleMetada
               duration: secondModuleMetadata.duration,
               image: secondModuleMetadata.image,
               link: `/modules/${secondModuleMetadata.shortId}/${secondModuleMetadata.slug}`,
+              visibility: secondModuleMetadata.visibility,
             },
           },
         ],

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
@@ -31,6 +31,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
       const redirectionUrl = 'https://app.pix.fr/parcours/COMBINIX1';
       const isBeta = true;
       const version = Symbol('version');
+      const visibility = Symbol('visibility');
       const details = {
         image: 'https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-details.svg',
         description:
@@ -43,7 +44,17 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
           'Comprendre les fonctions des parties d’une adresse mail',
         ],
       };
-      const moduleFromDomain = new Module({ id, shortId, details, slug, title, sections: [], isBeta, version });
+      const moduleFromDomain = new Module({
+        id,
+        shortId,
+        details,
+        slug,
+        title,
+        sections: [],
+        isBeta,
+        version,
+        visibility,
+      });
       moduleFromDomain.setRedirectionUrl(redirectionUrl);
       const expectedJson = {
         data: {
@@ -81,6 +92,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
       const title = 'Bien écrire son adresse mail';
       const isBeta = true;
       const version = Symbol('version');
+      const visibility = Symbol('visibility');
       const details = {
         image: 'https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-details.svg',
         description:
@@ -102,6 +114,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
         sections: [],
         isBeta,
         version,
+        visibility,
       });
       const expectedJson = {
         data: {
@@ -138,6 +151,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
       const title = 'Bien écrire son adresse mail';
       const isBeta = true;
       const version = Symbol('version');
+      const visibility = Symbol('visibility');
       const details = {
         image: 'https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-details.svg',
         description:
@@ -159,6 +173,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
         sections: [{ id: 'section1', type: 'none', grains: [] }],
         isBeta,
         version,
+        visibility,
       });
       const expectedJson = {
         data: {
@@ -210,6 +225,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
       const title = 'Bien écrire son adresse mail';
       const isBeta = true;
       const version = Symbol('version');
+      const visibility = Symbol('visibility');
       const details = {
         image: 'https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-details.svg',
         description:
@@ -230,6 +246,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
         isBeta,
         version,
         details,
+        visibility,
         sections: [
           {
             id: 'section1',


### PR DESCRIPTION
## ❄️ Problème
Actuellement, nous utilisons des modules pour le développement. Dans le cadre de la feature de listing des modules dans pix admin, on souhaite pouvoir afficher uniquement des modules avec une visibilité publique.

## 🛷 Proposition
Créer un nouvel attribut `visibility` pour les modules. Cela permettra ensuite de créer une logique de filtre

## ☃️ Remarques
Le filtrage des modules privés et publics aura lieu dans une prochaine PR. Ici on se contente d'ajouter l'attribut `visibility` aux modules

## 🧑‍🎄 Pour tester
- aller [sur pix admin ](https://admin-pr14646.review.pix.fr/trainings)avec un super admin
- copier le token
- faire un curl sur la route /api/admin/modules-metadata
- vérifier qu'on obtient une liste de metadonnées de modules qui contiennent l'attribut visibility
