### PR TITLE
[TECH] Tentative de stabiliser le test E2E portant sur le passage d'un test de certification

### DIFF
--- a/high-level-tests/e2e-playwright/pages/pix-certif/SessionManagementPage.ts
+++ b/high-level-tests/e2e-playwright/pages/pix-certif/SessionManagementPage.ts
@@ -61,7 +61,7 @@ export class SessionManagementPage {
     }
     await this.page.getByLabel('Nom de naissance').fill(lastName);
     await this.page.getByLabel('Prénom').fill(firstName);
-    await this.page.getByLabel('Date de naissance').pressSequentially(birthdate);
+    await this.page.getByLabel('Date de naissance').pressSequentially(birthdate, { delay: 100 });
     await this.page.getByRole('button', { name: 'Pays de naissance *' }).click();
     await this.page.getByRole('option', { name: birthCountry }).click();
     await this.page.getByRole('radio', { name: 'Code postal' }).check();


### PR DESCRIPTION
## ❄️ Problème

Ce test Playwright est flaky en l'état. Ce test implique de saisir une date de naissance dans la modale d'inscription d'un candidat en certification.
Le champ de date de naissance est un peu spécial. Il a du JS qui réagit lors de saisie au clavier pour ajouter des / aux bon moments : après jour et mois de sorte à visuellement avoir une date style JJ/MM/YY.

La méthode classique pour mettre du texte dans un input côté Playwright, à savoir locator.fill(), ne provoquait pas le déclenchement du script JS pour ajouter les /.
On avait donc opté pour un pressSequentially() qui imite davantage la saisie comme un utilisateur.
Malheureusement ça continue à ne pas être suffisant de temps en temps.

## 🛷 Proposition

Il est possible via les options d'activer un délai de saisie entre chaque touche dans le pressSequentially. On met 100ms pour voir 

## ☃️ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🧑‍🎄 Pour tester

e2e VERT + si ça le déflakyse ça serait fabuleux
