### PR TITLE
[TECH] Préfixer les routes des schémas de parcours combinés par /admin (PIX)

### DIFF
--- a/admin/app/adapters/combined-course-blueprint.js
+++ b/admin/app/adapters/combined-course-blueprint.js
@@ -1,0 +1,5 @@
+import ApplicationAdapter from './application';
+
+export default class CombinedCourseBlueprintAdapter extends ApplicationAdapter {
+  namespace = 'api/admin';
+}

--- a/admin/tests/mirage/routes.js
+++ b/admin/tests/mirage/routes.js
@@ -711,8 +711,8 @@ export default function routes() {
     };
   });
 
-  this.get('/combined-course-blueprints');
-  this.post('/combined-course-blueprints');
+  this.get('/admin/combined-course-blueprints');
+  this.post('/admin/combined-course-blueprints');
 
   _configureOrganizationsRoutes(this);
 }

--- a/api/src/quest/application/combined-course-blueprint-route.js
+++ b/api/src/quest/application/combined-course-blueprint-route.js
@@ -8,7 +8,7 @@ const register = async function (server) {
   server.route([
     {
       method: 'GET',
-      path: '/api/combined-course-blueprints',
+      path: '/api/admin/combined-course-blueprints',
       config: {
         pre: [
           {
@@ -29,7 +29,7 @@ const register = async function (server) {
     },
     {
       method: 'POST',
-      path: '/api/combined-course-blueprints',
+      path: '/api/admin/combined-course-blueprints',
       config: {
         pre: [
           {
@@ -68,7 +68,7 @@ const register = async function (server) {
     },
     {
       method: 'GET',
-      path: '/api/combined-course-blueprints/{blueprintId}',
+      path: '/api/admin/combined-course-blueprints/{blueprintId}',
       config: {
         pre: [
           {

--- a/api/tests/quest/acceptance/application/combined-course-blueprint-route_test.js
+++ b/api/tests/quest/acceptance/application/combined-course-blueprint-route_test.js
@@ -14,7 +14,7 @@ describe('Quest | Acceptance | Application | Combined course blueprint Route ', 
     server = await createServer();
   });
 
-  describe('GET /api/combined-course-blueprints', function () {
+  describe('GET /api/admin/combined-course-blueprints', function () {
     context('when user is admin ', function () {
       it('should return the list of combined course blueprints', async function () {
         // given
@@ -30,7 +30,7 @@ describe('Quest | Acceptance | Application | Combined course blueprint Route ', 
 
         const options = {
           method: 'GET',
-          url: `/api/combined-course-blueprints`,
+          url: `/api/admin/combined-course-blueprints`,
           headers: generateAuthenticatedUserRequestHeaders({ userId: adminUser.id }),
         };
 
@@ -44,7 +44,7 @@ describe('Quest | Acceptance | Application | Combined course blueprint Route ', 
     });
   });
 
-  describe('POST /api/combined-course-blueprints', function () {
+  describe('POST /api/admin/combined-course-blueprints', function () {
     context('when user is admin ', function () {
       it('should create a combined course blueprint', async function () {
         // given
@@ -63,7 +63,7 @@ describe('Quest | Acceptance | Application | Combined course blueprint Route ', 
         };
         const options = {
           method: 'POST',
-          url: `/api/combined-course-blueprints`,
+          url: `/api/admin/combined-course-blueprints`,
           headers: generateAuthenticatedUserRequestHeaders({ userId: adminUser.id }),
           payload,
         };
@@ -78,7 +78,7 @@ describe('Quest | Acceptance | Application | Combined course blueprint Route ', 
     });
   });
 
-  describe('GET /api/combined-course-blueprints/:id', function () {
+  describe('GET /api/admin/combined-course-blueprints/:id', function () {
     context('when user is admin ', function () {
       it('should return combined course blueprint for given id', async function () {
         // given
@@ -91,7 +91,7 @@ describe('Quest | Acceptance | Application | Combined course blueprint Route ', 
 
         const options = {
           method: 'GET',
-          url: `/api/combined-course-blueprints/${combinedCourseBlueprint.id}`,
+          url: `/api/admin/combined-course-blueprints/${combinedCourseBlueprint.id}`,
           headers: generateAuthenticatedUserRequestHeaders({ userId: adminUser.id }),
         };
 


### PR DESCRIPTION
## ❄️ Problème

Les routes des schémas de parcours combinés qui sont utilisés dans Admin ne respectent pas la convention : elles ne sont pas préfixées par api/admin mais juste par /api.

## 🛷 Proposition
On ajoute le préfixe souhaité.

## 🧑‍🎄 Pour tester
