### PR TITLE
[FEATURE] Ajouter une bordure aux POI non interactifs dans les modules (PIX-20761).

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/ia-cadre-usage-educ-nov.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/ia-cadre-usage-educ-nov.json
@@ -303,7 +303,7 @@
         {
           "id": "de075f3c-b944-4d57-8e64-ecafc1a0f58a",
           "type": "activity",
-          "title": "Discussion intercative 3",
+          "title": "Discussion interactive 3",
           "components": [
             {
               "type": "element",

--- a/mon-pix/app/components/module/element/_custom-element.scss
+++ b/mon-pix/app/components/module/element/_custom-element.scss
@@ -41,7 +41,7 @@ message-conversation::part(conversation) {
     border-radius: 16px 16px 16px 0;
   }
 
-  &--reset-intercative-state{
+  &--reset-interactive-state{
     border-radius: 16px 16px 16px 0;
   }
 }

--- a/mon-pix/app/components/module/element/custom-element.gjs
+++ b/mon-pix/app/components/module/element/custom-element.gjs
@@ -61,7 +61,7 @@ export default class ModulixCustomElement extends ModuleElement {
       {{#if this.isInteractive}}
         <fieldset
           class="element-custom__container
-            {{if this.resetButtonDisplayed 'element-custom--reset-intercative-state' ''}}"
+            {{if this.resetButtonDisplayed 'element-custom--reset-interactive-state' ''}}"
         >
           <legend class="element-custom__legend">
             <PixIcon @name="leftClick" @plainIcon={{false}} @ariaHidden={{true}} />

--- a/mon-pix/app/components/module/element/custom-element.gjs
+++ b/mon-pix/app/components/module/element/custom-element.gjs
@@ -71,7 +71,7 @@ export default class ModulixCustomElement extends ModuleElement {
         </fieldset>
       {{else}}
         <div
-          class={{if this.resetButtonDisplayed "element-custom--reset-state" ""}}
+          class="element-custom__container {{if this.resetButtonDisplayed 'element-custom--reset-state'}}"
           {{didInsert this.mountCustomElement}}
         />
       {{/if}}


### PR DESCRIPTION
## ❄️ Problème

Dans les modules, les POI interactifs présentent une bordure avec une mention élément interactif. Les POI non-interactif en revanche n'ont rien.

## 🛷 Proposition

Ajouter une bordure aux POI non interactifs (sans mention)

## 🧑‍🎄 Pour tester

https://app-pr14665.review.pix.fr/modules/0aefd71f/demo-epreuves-components/details

POI non interactif 

<img width="740" height="676" alt="Capture d’écran 2026-01-08 à 17 50 42" src="https://github.com/user-attachments/assets/7901df1f-e6d5-4b75-8d2c-1882affcf28d" />

