### PR TITLE
[FEATURE] Supprimer l'avatar sur la page de confirmation d'association de SSO (PIX-21014)

### DIFF
--- a/mon-pix/tests/acceptance/oidc/oidc-authentication-flow-test.js
+++ b/mon-pix/tests/acceptance/oidc/oidc-authentication-flow-test.js
@@ -90,7 +90,7 @@ module('Acceptance | OIDC | authentication flow', function (hooks) {
           // then
           assert.ok(
             screen.getByRole('heading', {
-              name: "Attention ! Un nouveau moyen de connexion est sur le point d'être ajouté à votre compte Pix",
+              name: "Attention ! Une nouvelle méthode de connexion est sur le point d'être ajoutée à votre compte Pix",
             }),
           );
         });

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1805,7 +1805,7 @@
       "external-connection-via": "Connexion via",
       "information": "L'évaluation des compétences étant personnalisée, votre compte doit rester strictement personnel",
       "return": "Retour",
-      "sub-title": "Un nouveau moyen de connexion est sur le point d'être ajouté à votre compte Pix",
+      "sub-title": "Une nouvelle méthode de connexion est sur le point d'être ajoutée à votre compte Pix",
       "switch-account": "Changer de compte",
       "title": "Attention !",
       "username": "Identifiant"

--- a/orga/app/components/authentication/oidc-association-confirmation.gjs
+++ b/orga/app/components/authentication/oidc-association-confirmation.gjs
@@ -17,8 +17,7 @@ export default class OidcAssociationConfirmation extends Component {
     <div class="oidc-association__container">
 
       <div class="oidc-association__user-information">
-        <div class="oidc-association__avatar">
-          <PixIcon @name="userCircle" @plainIcon={{true}} @ariaHidden={{true}} />
+        <div class="oidc-association__user-fullname">
           <p>{{@fullNameFromPix}}</p>
         </div>
 

--- a/orga/app/components/authentication/oidc-association-confirmation.scss
+++ b/orga/app/components/authentication/oidc-association-confirmation.scss
@@ -22,19 +22,7 @@
     border-radius: var(--pix-spacing-2x);
   }
 
-  &__avatar {
-    display: flex;
-    gap: var(--pix-spacing-4x);
-    align-items: center;
-    justify-items: center;
-    padding: var(--pix-spacing-4x);
-
-    svg {
-      min-width: 48px;
-      height: 48px;
-      color: var(--pix-neutral-100);
-    }
-
+  &__user-fullname {
     p {
       @extend %pix-title-xs;
     }

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -354,7 +354,7 @@
         "external-connection": "Connexion externe",
         "external-connection-via": "Connexion via",
         "return": "Retour",
-        "title": "Un nouveau moyen de connexion est sur le point d'être ajouté à votre compte Pix",
+        "title": "Une nouvelle méthode de connexion est sur le point d'être ajoutée à votre compte Pix",
         "username": "Identifiant"
       },
       "oidc-provider-selector": {


### PR DESCRIPTION
## ❄️ Problème

Supprimer l'avatar sur la page de confirmation d'association de SSO (/connexion/pro-connect/confirm)

<img width="1674" height="996" alt="image-20260107-105208" src="https://github.com/user-attachments/assets/d5b80e02-0168-4e3f-b28d-75547582015a" />

## 🛷 Proposition

1. Suppresion de l’image/avatar de compte
2. Correction de la traduction `fr` de `moyen de connexion`→`méthode de connexion` pour maintenir la cohérence des termes employés

<img width="1234" height="1042" alt="pix-orga-association-confirmation-fr" src="https://github.com/user-attachments/assets/379b0ee8-c28e-4f51-9fc9-74ce9a37219f" />

<img width="1154" height="1046" alt="pix-orga-association-confirmation" src="https://github.com/user-attachments/assets/92acf25d-5f74-45bd-b73a-c6797c8113a1" />

## ☃️ Remarques

RAS

## 🧑‍🎄 Pour tester

1. Envoyer une invitation à rejoindre une organisation de Pix Orga
4. Suivre le lien de l’invitation
5. Utiliser son compte Pix
6. Constater sur la page de confirmation d’association qu’aucune image/avatar de compte n’est affiché
