### PR TITLE
[BUMP] Upgrade @1024pix/epreuves-components to 2.5.1

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -79,7 +79,7 @@
         "yargs": "^18.0.0"
       },
       "devDependencies": {
-        "@1024pix/epreuves-components": "^2.4.7",
+        "@1024pix/epreuves-components": "^2.5.1",
         "@1024pix/eslint-plugin": "^2.1.15",
         "@babel/eslint-parser": "^7.18.2",
         "@babel/plugin-syntax-import-attributes": "^7.24.1",
@@ -120,9 +120,9 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "2.4.7",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-2.4.7.tgz",
-      "integrity": "sha512-hX3bH7WGTtjqlETfzovH1aDnuCnk454s6AUgyhbTqFvEGpXp0CstwpOpDwL4G1ax3yxBf/ZFieW1wFWx/9sXCg==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-2.5.1.tgz",
+      "integrity": "sha512-slVMNFriZ9FLiazRpGCG1lgP2M6AUZnj/4URQZ6jx8j2UNqSGFmxIqiqFddCYlJvnvXQqSIKMoOdNLihyechPg==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {

--- a/api/package.json
+++ b/api/package.json
@@ -85,7 +85,7 @@
     "yargs": "^18.0.0"
   },
   "devDependencies": {
-    "@1024pix/epreuves-components": "^2.4.7",
+    "@1024pix/epreuves-components": "^2.5.1",
     "@1024pix/eslint-plugin": "^2.1.15",
     "@babel/eslint-parser": "^7.18.2",
     "@babel/plugin-syntax-import-attributes": "^7.24.1",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-epreuves-components.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-epreuves-components.json
@@ -1090,6 +1090,108 @@
           ]
         },
         {
+          "id": "b592e5da-8e4c-49b3-a04a-00a825363693",
+          "type": "discovery",
+          "title": "pix-anonymisation",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "597659ac-e0d6-4a6b-b61d-9a9e2fc7b921",
+                "type": "text",
+                "content": "<p>pix-anonymisation</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "fbe5e7df-f3b5-4d85-b23f-e98d3b07955a",
+                "type": "custom",
+                "instruction": "",
+                "tagName": "pix-anonymisation",
+                "props": {
+                  "titleLevel": 2,
+                  "steps": [
+                    {
+                      "fullSentence": [
+                        {
+                          "content": "J'habite au 12 rue des Lilas, Joliville,",
+                          "isAnonymizable": true
+                        },
+                        {
+                          "content": "je m'appelle Cédric Fostabley,",
+                          "isAnonymizable": true
+                        },
+                        {
+                          "content": "je suis maçon"
+                        },
+                        {
+                          "content": "mon numéro est le 06 12 34 56 78.",
+                          "isAnonymizable": true
+                        },
+                        {
+                          "content": "Peux-tu me faire une carte de visite professionnelle et originale?"
+                        }
+                      ],
+                      "rephrase": "Je suis maçon et j’aimerai une idée de carte de visite professionnelle et originale. Peux tu me proposer un modèle que je pourrais compléter avec mes informations ?",
+                      "feedback": "On reformule ici afin d’éviter de donner des informations perso à une IA, c’est pas bieng faut pas le faire"
+                    },
+                    {
+                      "fullSentence": [
+                        {
+                          "content": "Peux-tu écrire une lettre"
+                        },
+                        {
+                          "content": "pour le docteur Vanderbrooke",
+                          "isAnonymizable": true
+                        },
+                        {
+                          "content": "lui demandant de soigner"
+                        },
+                        {
+                          "content": "Madame Sarfati",
+                          "isAnonymizable": true
+                        },
+                        {
+                          "content": "suivie pour son diabète"
+                        },
+                        {
+                          "content": "depuis 5 ans ?"
+                        }
+                      ],
+                      "rephrase": "Peux-tu écrire une lettre pour un collègue médecin lui demandant de prendre en charge une patiente que je suis pour son diabète depuis 5 ans déjà ?",
+                      "feedback": "On reformule ici afin d’éviter de donner des informations perso à une IA, c’est pas bieng faut pas le faire"
+                    },
+                    {
+                      "fullSentence": [
+                        {
+                          "content": "Peux-tu rédiger un mail pour mon équipe"
+                        },
+                        {
+                          "content": "afin de lui rappeler que le mot de passe du wifi est AzErTy2024!",
+                          "isAnonymizable": true
+                        },
+                        {
+                          "content": "et qu’ils doivent suivre le mode d’emploi suivant :"
+                        },
+                        {
+                          "content": " http://intranet.example.invalid/procedure-connexion",
+                          "isAnonymizable": true
+                        },
+                        {
+                          "content": "pour s’y connecter ?"
+                        }
+                      ],
+                      "rephrase": "Peux-tu me proposer un exemple de mail expliquant à une équipe comment se connecter au WiFi d’une organisation ?Je compléterai moi-même ensuite les informations sensibles (mot de passe, lien interne, instructions).",
+                      "feedback": "On reformule ici afin d’éviter de donner des informations perso à une IA, c’est pas bieng faut pas le faire"
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        {
           "id": "6425a4f1-8fcf-4a03-9cef-fc298318e742",
           "type": "discovery",
           "title": "pix-article",

--- a/junior/package-lock.json
+++ b/junior/package-lock.json
@@ -11,7 +11,7 @@
       "license": "AGPL-3.0",
       "devDependencies": {
         "@1024pix/ember-testing-library": "^3.0.25",
-        "@1024pix/epreuves-components": "^2.4.7",
+        "@1024pix/epreuves-components": "^2.5.1",
         "@1024pix/eslint-plugin": "^2.1.15",
         "@1024pix/pix-ui": "^55.34.0",
         "@1024pix/stylelint-config": "^5.1.37",
@@ -180,9 +180,9 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "2.4.7",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-2.4.7.tgz",
-      "integrity": "sha512-hX3bH7WGTtjqlETfzovH1aDnuCnk454s6AUgyhbTqFvEGpXp0CstwpOpDwL4G1ax3yxBf/ZFieW1wFWx/9sXCg==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-2.5.1.tgz",
+      "integrity": "sha512-slVMNFriZ9FLiazRpGCG1lgP2M6AUZnj/4URQZ6jx8j2UNqSGFmxIqiqFddCYlJvnvXQqSIKMoOdNLihyechPg==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {

--- a/junior/package.json
+++ b/junior/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^3.0.25",
-    "@1024pix/epreuves-components": "^2.4.7",
+    "@1024pix/epreuves-components": "^2.5.1",
     "@1024pix/eslint-plugin": "^2.1.15",
     "@1024pix/pix-ui": "^55.34.0",
     "@1024pix/stylelint-config": "^5.1.37",

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -12,7 +12,7 @@
       "devDependencies": {
         "@1024pix/ember-api-actions": "^1.1.0",
         "@1024pix/ember-testing-library": "^3.0.25",
-        "@1024pix/epreuves-components": "^2.4.7",
+        "@1024pix/epreuves-components": "^2.5.1",
         "@1024pix/eslint-plugin": "^2.1.15",
         "@1024pix/pix-ui": "^55.34.0",
         "@1024pix/stylelint-config": "^5.1.37",
@@ -818,9 +818,9 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "2.4.7",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-2.4.7.tgz",
-      "integrity": "sha512-hX3bH7WGTtjqlETfzovH1aDnuCnk454s6AUgyhbTqFvEGpXp0CstwpOpDwL4G1ax3yxBf/ZFieW1wFWx/9sXCg==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-2.5.1.tgz",
+      "integrity": "sha512-slVMNFriZ9FLiazRpGCG1lgP2M6AUZnj/4URQZ6jx8j2UNqSGFmxIqiqFddCYlJvnvXQqSIKMoOdNLihyechPg==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@1024pix/ember-api-actions": "^1.1.0",
     "@1024pix/ember-testing-library": "^3.0.25",
-    "@1024pix/epreuves-components": "^2.4.7",
+    "@1024pix/epreuves-components": "^2.5.1",
     "@1024pix/eslint-plugin": "^2.1.15",
     "@1024pix/pix-ui": "^55.34.0",
     "@1024pix/stylelint-config": "^5.1.37",


### PR DESCRIPTION
## ❄️ Problème

Il y a une nouvelle version de `@1024pix/epreuves-components`

## 🛷 Proposition

Mettre à jour en 2.5.1 et ajouter le POI `pix-anonymisation` dans le module `demo-epreuves-components`.

## ☃️ Remarques

N/A

## 🧑‍🎄 Pour tester

Aller sur le module  `demo-epreuves-components` :
 - Vérifier que les images de `flip-cards` s’affichent bien
 - Vérifier que `pix-anonymisation` s’affiche bien
 - Vérifier qu’il n’y a pas de régressions sur les autres composants