### PR TITLE
[TECH] Supprimer la table certification-data-active-calibrated-challenges (PIX-20641).

### DIFF
--- a/api/db/migrations/20260109153000_drop-certification-data-active-calibrated-challenges-table.js
+++ b/api/db/migrations/20260109153000_drop-certification-data-active-calibrated-challenges-table.js
@@ -1,0 +1,23 @@
+const TABLE_NAME = 'certification-data-active-calibrated-challenges';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.dropTable(TABLE_NAME);
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.createTable(TABLE_NAME, function (table) {
+    table.string('challengeId').primary().comment('Challenge id');
+    table.float('alpha').comment('Discriminant');
+    table.float('delta').comment('Difficulty');
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## ❄️ Problème

Depuis [cette PR](https://github.com/1024pix/pix/pull/14274), nous n'avons plus l'usage de la table “quick and dirty“ `certification-data-active-calibrated-challenges`. 

## 🛷 Proposition

Supprimer la table via une migration.

## 🧑‍🎄 Pour tester

Tests verts ✅ 
