### PR TITLE
[FEATURE] Récupérer les statistiques de places côté Admin (PIX-21032).

### DIFF
--- a/api/src/organizational-entities/application/organization/organization.admin.controller.js
+++ b/api/src/organizational-entities/application/organization/organization.admin.controller.js
@@ -7,6 +7,7 @@ import { usecases } from '../../domain/usecases/index.js';
 import { organizationTagCsvParser } from '../../infrastructure/parsers/csv/organization-tag-csv.parser.js';
 import * as organizationSerializer from '../../infrastructure/serializers/jsonapi/organization-serializer.js';
 import { organizationForAdminSerializer } from '../../infrastructure/serializers/jsonapi/organizations-administration/organization-for-admin.serializer.js';
+import * as organizationPlacesStatisticsSerializer from '../../infrastructure/serializers/jsonapi/organizations-administration/organization-places-statistics.serializer.js';
 
 const ADD_TAGS_TO_ORGANIZATIONS_HEADER = organizationTagCsvParser.CSV_HEADER;
 
@@ -125,6 +126,16 @@ const getOrganizationDetails = async function (request, h, dependencies = { orga
   return dependencies.organizationForAdminSerializer.serialize(organizationDetails);
 };
 
+const getOrganizationPlacesStatistics = async function (
+  request,
+  h,
+  dependencies = { organizationPlacesStatisticsSerializer },
+) {
+  const organizationId = request.params.organizationId;
+  const organizationPlacesStatistics = await usecases.getOrganizationPlacesStatistics({ organizationId });
+  return dependencies.organizationPlacesStatisticsSerializer.serialize(organizationPlacesStatistics);
+};
+
 const getTemplateForUpdateOrganizationsInBatch = async function (request, h) {
   const fields = ORGANIZATIONS_UPDATE_HEADER.columns.map(({ name }) => name);
   const csvTemplateFileContent = generateCSVTemplate(fields);
@@ -184,6 +195,7 @@ const organizationAdminController = {
   archiveOrganization,
   getTemplateForArchiveOrganizationsInBatch,
   archiveInBatch,
+  getOrganizationPlacesStatistics,
   attachChildOrganization,
   detachParentOrganization,
   getTemplateForAddOrganizationFeatureInBatch,

--- a/api/src/organizational-entities/application/organization/organization.admin.route.js
+++ b/api/src/organizational-entities/application/organization/organization.admin.route.js
@@ -494,6 +494,35 @@ const register = async function (server) {
         ],
       },
     },
+    {
+      method: 'GET',
+      path: '/api/admin/organizations/{organizationId}/places-statistics',
+      config: {
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.hasAtLeastOneAccessOf([
+                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+                securityPreHandlers.checkAdminMemberHasRoleCertif,
+                securityPreHandlers.checkAdminMemberHasRoleSupport,
+                securityPreHandlers.checkAdminMemberHasRoleMetier,
+              ])(request, h),
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        validate: {
+          params: Joi.object({
+            organizationId: identifiersType.organizationId,
+          }),
+        },
+        handler: (request, h) => organizationAdminController.getOrganizationPlacesStatistics(request, h),
+        tags: ['api', 'organizations'],
+        notes: [
+          "- **Cette route est restreinte aux utilisateurs authentifiés ayant un rôle SUPER_ADMIN, CERTIF, SUPPORT ou METIER permettant un accès à l'application d'administration de Pix**\n" +
+            "- Elle permet la récuperation des statistiques de places de l'organisation",
+        ],
+      },
+    },
   ]);
 };
 

--- a/api/src/organizational-entities/domain/models/ParticipantRepartition.js
+++ b/api/src/organizational-entities/domain/models/ParticipantRepartition.js
@@ -1,0 +1,8 @@
+class ParticipantRepartition {
+  constructor(participantList = []) {
+    this.totalRegisteredParticipant = participantList.filter(({ isAnonymous }) => !isAnonymous).length;
+    this.totalUnRegisteredParticipant = participantList.filter(({ isAnonymous }) => isAnonymous).length;
+  }
+}
+
+export { ParticipantRepartition };

--- a/api/src/organizational-entities/domain/read-models/PlacesLot.js
+++ b/api/src/organizational-entities/domain/read-models/PlacesLot.js
@@ -1,0 +1,65 @@
+import JoiDate from '@joi/date';
+import BaseJoi from 'joi';
+const Joi = BaseJoi.extend(JoiDate);
+import { validateEntity } from '../../../shared/domain/validators/entity-validator.js';
+
+const validationSchema = Joi.object({
+  id: Joi.number().required(),
+  count: Joi.number().required().allow(null),
+  organizationId: Joi.number(),
+  activationDate: Joi.date().required(),
+  expirationDate: Joi.date().required().allow(null),
+  deletedAt: Joi.date().required().allow(null),
+});
+
+const statuses = {
+  ACTIVE: 'ACTIVE',
+  EXPIRED: 'EXPIRED',
+  PENDING: 'PENDING',
+};
+
+export class PlacesLot {
+  #id;
+  #activationDate;
+  #expirationDate;
+  #deletedAt;
+  constructor(params = {}) {
+    validateEntity(validationSchema, params);
+    this.#id = params.id;
+    this.count = params.count;
+    this.organizationId = params.organizationId;
+    this.#activationDate = params.activationDate;
+    this.#expirationDate = params.expirationDate;
+    this.#deletedAt = params.deletedAt;
+  }
+
+  get id() {
+    return this.#id;
+  }
+
+  get isActive() {
+    return this.status === statuses.ACTIVE && !this.#deletedAt;
+  }
+
+  get activationDate() {
+    return this.#activationDate;
+  }
+
+  get expirationDate() {
+    return this.#expirationDate;
+  }
+
+  get status() {
+    const today = new Date();
+
+    if (Boolean(this.#expirationDate) && this.#expirationDate < today) {
+      return statuses.EXPIRED;
+    }
+
+    if (this.#activationDate < today) {
+      return statuses.ACTIVE;
+    }
+
+    return statuses.PENDING;
+  }
+}

--- a/api/src/organizational-entities/domain/read-models/PlacesStatistics.js
+++ b/api/src/organizational-entities/domain/read-models/PlacesStatistics.js
@@ -1,0 +1,56 @@
+import _ from 'lodash';
+
+import { config } from '../../../shared/config.js';
+
+export class PlacesStatistics {
+  #placesLots;
+  #placeRepartition;
+  #isMaximumPlacesLimitEnabled;
+
+  constructor({ placesLots = [], placeRepartition, organizationId, enableMaximumPlacesLimit } = {}) {
+    this.id = `${organizationId}_place_statistics`;
+    this.#placesLots = placesLots;
+    this.#placeRepartition = placeRepartition;
+    this.#isMaximumPlacesLimitEnabled = enableMaximumPlacesLimit;
+  }
+
+  static buildFrom({ placesLots, placeRepartition, organizationId, enableMaximumPlacesLimit } = {}) {
+    return new PlacesStatistics({ placesLots, placeRepartition, organizationId, enableMaximumPlacesLimit });
+  }
+
+  get #activePlacesLots() {
+    return this.#placesLots.filter((placesLot) => placesLot.isActive);
+  }
+
+  get total() {
+    if (!this.#placesLots) return 0;
+    const activePlaces = this.#activePlacesLots;
+    return _.sumBy(activePlaces, 'count');
+  }
+
+  get occupied() {
+    return this.#placeRepartition.totalRegisteredParticipant + this.#placeRepartition.totalUnRegisteredParticipant;
+  }
+
+  get anonymousSeat() {
+    return this.#placeRepartition.totalUnRegisteredParticipant;
+  }
+
+  get available() {
+    const available = this.total - this.occupied;
+    if (available < 0) return 0;
+    return available;
+  }
+
+  get placesLotsTotal() {
+    return this.#activePlacesLots.length;
+  }
+
+  get hasReachedMaximumPlacesLimit() {
+    if (!this.#isMaximumPlacesLimitEnabled || this.occupied === 0) return false;
+
+    const thresholdLock = config.features.organizationPlacesManagementThreshold;
+    const maximumPlaces = this.total + this.total * thresholdLock;
+    return this.occupied >= maximumPlaces;
+  }
+}

--- a/api/src/organizational-entities/domain/usecases/get-organization-places-statistics.usecase.js
+++ b/api/src/organizational-entities/domain/usecases/get-organization-places-statistics.usecase.js
@@ -1,0 +1,63 @@
+import { ORGANIZATION_FEATURE } from '../../../shared/domain/constants.js';
+import { PlacesStatistics } from '../read-models/PlacesStatistics.js';
+
+/**
+ * @function
+ * @name getOrganizationPlacesStatistics
+ * @typedef {object} payload
+ * @property {number} organizationId
+ * @property {organizationPlacesLotRepository} organizationPlacesLotRepository
+ * @property {organizationLearnerRepository} organizationLearnerRepository
+ * @property {organizationFeatureRepository} organizationFeatureRepository
+ * @returns {Promise<Array<PlaceStatistics>>}
+ */
+
+/**
+ * @typedef {object} organizationPlacesLotRepository
+ * @property {function} findAllByOrganizationId
+ */
+
+/**
+ * @typedef {object} organizationLearnerRepository
+ * @property {function} findAllLearnerWithAtLeastOneParticipationByOrganizationId
+ */
+
+/**
+ * @typedef {object} organizationFeatureRepository
+ * @property {function} findAllOrganizationFeaturesFromOrganizationId
+ */
+const getOrganizationPlacesStatistics = async function ({
+  organizationId,
+  organizationPlacesLotRepository,
+  organizationLearnerRepository,
+  organizationFeatureRepository,
+}) {
+  if (!organizationId) {
+    throw new Error('You must provide at least one organizationId.');
+  }
+
+  const placesLots = await organizationPlacesLotRepository.findAllByOrganizationIds({
+    organizationIds: [organizationId],
+  });
+
+  const placeRepartition =
+    await organizationLearnerRepository.findAllLearnerWithAtLeastOneParticipationByOrganizationId(organizationId);
+
+  const organizationFeatures = await organizationFeatureRepository.findAllOrganizationFeaturesFromOrganizationId({
+    organizationId,
+  });
+
+  const placesManagementFeature = organizationFeatures.find(
+    (feature) => feature.name === ORGANIZATION_FEATURE.PLACES_MANAGEMENT.key,
+  );
+  const isMaximumPlacesLimitEnabled = placesManagementFeature?.params?.enableMaximumPlacesLimit;
+
+  return PlacesStatistics.buildFrom({
+    placesLots,
+    placeRepartition,
+    organizationId,
+    enableMaximumPlacesLimit: isMaximumPlacesLimitEnabled,
+  });
+};
+
+export { getOrganizationPlacesStatistics };

--- a/api/src/organizational-entities/domain/usecases/index.js
+++ b/api/src/organizational-entities/domain/usecases/index.js
@@ -15,6 +15,8 @@ import * as complementaryCertificationHabilitationRepository from '../../infrast
 import * as dataProtectionOfficerRepository from '../../infrastructure/repositories/data-protection-officer.repository.js';
 import { repositories as organizationalEntitiesRepositories } from '../../infrastructure/repositories/index.js';
 import * as organizationFeatureRepository from '../../infrastructure/repositories/organization-feature-repository.js';
+import * as organizationLearnerRepository from '../../infrastructure/repositories/organization-learner.repository.js';
+import * as organizationPlacesLotRepository from '../../infrastructure/repositories/organization-places-lot.repository.js';
 import * as organizationTagRepository from '../../infrastructure/repositories/organization-tag.repository.js';
 import { tagRepository } from '../../infrastructure/repositories/tag.repository.js';
 import * as targetProfileShareRepository from '../../infrastructure/repositories/target-profile-share-repository.js';
@@ -31,6 +33,8 @@ import * as organizationValidator from '../validators/organization-with-tags-and
  * @typedef {import ('../../infrastructure/repositories/complementary-certification-habilitation-repository.js')} ComplementaryCertificationHabilitationRepository
  * @typedef {import ('../../infrastructure/repositories/data-protection-officer-repository.js')} DataProtectionOfficerRepository
  * @typedef {import ('../../infrastructure/repositories/organization-feature-repository.js')} OrganizationFeatureRepository
+ * @typedef {import ('../../infrastructure/repositories/organization-places-lot.repository.js')} OrganizationPlacesLotRepository
+ * @typedef {import ('../../infrastructure/repositories/organization-learner.repository.js')} OrganizationLearnerRepository
  * @typedef {import ('../../infrastructure/repositories/organization-for-admin.repository.js')} OrganizationForAdminRepository
  * @typedef {import ('../../infrastructure/repositories/tag.repository.js')} TagRepository
  * @typedef {import ('../../infrastructure/repositories/target-profile-share-repository.js')} TargetProfileShareRepository
@@ -57,6 +61,8 @@ const repositories = {
   complementaryCertificationHabilitationRepository,
   organizationForAdminRepository: organizationalEntitiesRepositories.organizationForAdminRepository,
   organizationFeatureRepository,
+  organizationLearnerRepository,
+  organizationPlacesLotRepository,
   schoolRepository,
   learnersApi,
   organizationRepository,
@@ -88,6 +94,7 @@ import { findPaginatedFilteredOrganizations } from './find-paginated-filtered-or
 import { getCenterForAdmin } from './get-center-for-admin.usecase.js';
 import { getOrganizationById } from './get-organization-by-id.js';
 import { getOrganizationDetails } from './get-organization-details.usecase.js';
+import { getOrganizationPlacesStatistics } from './get-organization-places-statistics.usecase.js';
 import { getRecentlyUsedTags } from './get-recently-used-tags.usecase.js';
 import { updateCertificationCenter } from './update-certification-center.usecase.js';
 import { updateCertificationCenterDataProtectionOfficerInformation } from './update-certification-center-data-protection-officer-information.usecase.js';
@@ -116,6 +123,7 @@ const usecasesWithoutInjectedDependencies = {
   getCenterForAdmin,
   getOrganizationById,
   getOrganizationDetails,
+  getOrganizationPlacesStatistics,
   getRecentlyUsedTags,
   updateCertificationCenterDataProtectionOfficerInformation,
   updateCertificationCenter,

--- a/api/src/organizational-entities/infrastructure/repositories/organization-learner.repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/organization-learner.repository.js
@@ -1,0 +1,32 @@
+import { knex } from '../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
+import { ParticipantRepartition } from '../../domain/models/ParticipantRepartition.js';
+
+/**
+ * @function
+ * @name findAllLearnerWithAtLeastOneParticipationByOrganizationId
+ * @typedef {number} organizationId
+ * @returns {Promise<ParticipantRepartition>}
+ */
+const findAllLearnerWithAtLeastOneParticipationByOrganizationId = async function (organizationId) {
+  // This code should be called via an internal API
+  // as it is a Prescription domain responsability
+  const knexConn = DomainTransaction.getConnection();
+  const result = await knexConn
+    .select('users.isAnonymous')
+    .distinct('view-active-organization-learners.id')
+    .from('view-active-organization-learners')
+    .join('users', 'users.id', 'view-active-organization-learners.userId')
+    .join('campaign-participations', function () {
+      this.on('campaign-participations.organizationLearnerId', 'view-active-organization-learners.id').andOnVal(
+        'campaign-participations.deletedAt',
+        knex.raw('IS'),
+        knex.raw('NULL'),
+      );
+    })
+    .where({ organizationId });
+
+  return new ParticipantRepartition(result);
+};
+
+export { findAllLearnerWithAtLeastOneParticipationByOrganizationId };

--- a/api/src/organizational-entities/infrastructure/repositories/organization-places-lot.repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/organization-places-lot.repository.js
@@ -1,0 +1,45 @@
+import { knex } from '../../../../db/knex-database-connection.js';
+import { PlacesLot } from '../../../organizational-entities/domain/read-models/PlacesLot.js';
+import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
+
+const findAllByOrganizationIds = async ({ organizationIds, callOrderByAndRemoveDeleted = false }) => {
+  const placesLots = await baseQuery({ organizationIds, callOrderByAndRemoveDeleted });
+  return placesLots.map((placesLot) => new PlacesLot(placesLot));
+};
+
+const baseQuery = ({ organizationIds, callOrderByAndRemoveDeleted = false }) => {
+  const knexConn = DomainTransaction.getConnection();
+
+  let query = knexConn('organization-places')
+    .select(
+      'organization-places.id',
+      'organization-places.count',
+      'organization-places.organizationId',
+      'organization-places.activationDate',
+      'organization-places.expirationDate',
+      'organization-places.deletedAt',
+    )
+    .whereIn('organization-places.organizationId', organizationIds);
+
+  if (callOrderByAndRemoveDeleted) {
+    query = orderByAndRemoveDeleted(query);
+  }
+
+  return query;
+};
+
+const orderByAndRemoveDeleted = (query) => {
+  return query
+    .whereNull('organization-places.deletedAt')
+    .orderBy(
+      knex.raw(
+        'CASE WHEN "organization-places"."activationDate" <= now() AND "organization-places"."expirationDate" >= now() THEN 1 WHEN "organization-places"."activationDate" > now() THEN 2 ELSE 3 END',
+      ),
+      'asc',
+    )
+    .orderBy('organization-places.expirationDate', 'desc')
+    .orderBy('organization-places.activationDate', 'desc')
+    .orderBy('organization-places.createdAt', 'desc');
+};
+
+export { findAllByOrganizationIds };

--- a/api/src/organizational-entities/infrastructure/serializers/jsonapi/organizations-administration/organization-places-statistics.serializer.js
+++ b/api/src/organizational-entities/infrastructure/serializers/jsonapi/organizations-administration/organization-places-statistics.serializer.js
@@ -1,0 +1,11 @@
+import jsonapiSerializer from 'jsonapi-serializer';
+
+const { Serializer } = jsonapiSerializer;
+
+const serialize = function (places) {
+  return new Serializer('organization-places-statistics', {
+    attributes: ['total', 'occupied', 'available', 'anonymousSeat', 'hasReachedMaximumPlacesLimit'],
+  }).serialize(places);
+};
+
+export { serialize };

--- a/api/tests/organizational-entities/integration/domain/usecases/get-organization-places-statistics.usecase.test.js
+++ b/api/tests/organizational-entities/integration/domain/usecases/get-organization-places-statistics.usecase.test.js
@@ -1,0 +1,68 @@
+import dayjs from 'dayjs';
+
+import { usecases } from '../../../../../src/organizational-entities/domain/usecases/index.js';
+import { ORGANIZATION_FEATURE } from '../../../../../src/shared/domain/constants.js';
+import { databaseBuilder, expect } from '../../../../test-helper.js';
+
+describe('Integration | Organizational-Entities | Domain | Use Cases | get-organization-places-statistics', function () {
+  it('should get the organization places statistics', async function () {
+    // given
+    const organizationId = databaseBuilder.factory.buildOrganization().id;
+
+    const anonymousUserId = databaseBuilder.factory.buildUser({ isAnonymous: true }).id;
+    const realUserId = databaseBuilder.factory.buildUser({ isAnonymous: false }).id;
+
+    const anonymousLearnerId = databaseBuilder.factory.buildOrganizationLearner({
+      userId: anonymousUserId,
+      organizationId,
+    }).id;
+    const realLearnerId = databaseBuilder.factory.buildOrganizationLearner({ userId: realUserId, organizationId }).id;
+
+    const campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
+
+    databaseBuilder.factory.buildCampaignParticipation();
+
+    databaseBuilder.factory.buildCampaignParticipation({
+      campaignId,
+      organizationLearnerId: anonymousLearnerId,
+      userId: anonymousUserId,
+    });
+    databaseBuilder.factory.buildCampaignParticipation({
+      campaignId,
+      organizationLearnerId: realLearnerId,
+      userId: realUserId,
+    });
+
+    const placesManagementFeatureId = databaseBuilder.factory.buildFeature({
+      key: ORGANIZATION_FEATURE.PLACES_MANAGEMENT.key,
+    }).id;
+
+    databaseBuilder.factory.buildOrganizationFeature({
+      organizationId,
+      featureId: placesManagementFeatureId,
+      params: {
+        enableMaximumPlacesLimit: true,
+      },
+    });
+
+    databaseBuilder.factory.buildOrganizationPlace({
+      organizationId,
+      activationDate: dayjs().subtract(1, 'months').toDate(),
+      count: 1,
+    });
+
+    await databaseBuilder.commit();
+
+    // when
+    const organizationPlacesStatistics = await usecases.getOrganizationPlacesStatistics({
+      organizationId,
+    });
+
+    // then
+    expect(organizationPlacesStatistics.total).to.equal(1);
+    expect(organizationPlacesStatistics.occupied).to.equal(2);
+    expect(organizationPlacesStatistics.anonymousSeat).to.equal(1);
+    expect(organizationPlacesStatistics.available).to.equal(0);
+    expect(organizationPlacesStatistics.hasReachedMaximumPlacesLimit).to.equal(true);
+  });
+});

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/organization-learner.repository.test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/organization-learner.repository.test.js
@@ -1,0 +1,116 @@
+import * as organizationLearnerRepository from '../../../../../src/organizational-entities/infrastructure/repositories/organization-learner.repository.js';
+import { databaseBuilder, expect } from '../../../../test-helper.js';
+
+describe('Integration | Organizational-Entities | Infrastructure | Repositories | Organization-Learner', function () {
+  describe('#findAllLearnerWithAtLeastOneParticipationByOrganizationId', function () {
+    let registeredParticipantId, unRegisteredParticipantId, organizationId;
+
+    beforeEach(async function () {
+      const anonymousUserId = databaseBuilder.factory.buildUser({
+        lastName: '',
+        firstName: '',
+        isAnonymous: true,
+      }).id;
+      organizationId = databaseBuilder.factory.buildOrganization().id;
+      registeredParticipantId = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
+      unRegisteredParticipantId = databaseBuilder.factory.buildOrganizationLearner({
+        organizationId,
+        userId: anonymousUserId,
+      }).id;
+      await databaseBuilder.commit();
+    });
+
+    it('should return count of active linked learner on account with at least one participation for given organizationId', async function () {
+      databaseBuilder.factory.buildCampaignParticipation({
+        organizationLearnerId: registeredParticipantId,
+      });
+
+      await databaseBuilder.commit();
+
+      const result =
+        await organizationLearnerRepository.findAllLearnerWithAtLeastOneParticipationByOrganizationId(organizationId);
+
+      expect(result.totalRegisteredParticipant).to.equal(1);
+      expect(result.totalUnRegisteredParticipant).to.equal(0);
+    });
+
+    it('should return count of active not linked learner on account with at least one participation for given organizationId', async function () {
+      databaseBuilder.factory.buildCampaignParticipation({
+        organizationLearnerId: unRegisteredParticipantId,
+      });
+
+      await databaseBuilder.commit();
+
+      const result =
+        await organizationLearnerRepository.findAllLearnerWithAtLeastOneParticipationByOrganizationId(organizationId);
+
+      expect(result.totalRegisteredParticipant).to.equal(0);
+      expect(result.totalUnRegisteredParticipant).to.equal(1);
+    });
+
+    it('should not count an active learner several times for given organizationId', async function () {
+      databaseBuilder.factory.buildCampaignParticipation({
+        organizationLearnerId: registeredParticipantId,
+      });
+      databaseBuilder.factory.buildCampaignParticipation({
+        organizationLearnerId: registeredParticipantId,
+      });
+
+      await databaseBuilder.commit();
+
+      const result =
+        await organizationLearnerRepository.findAllLearnerWithAtLeastOneParticipationByOrganizationId(organizationId);
+
+      expect(result.totalRegisteredParticipant).to.equal(1);
+    });
+
+    it('should return 0 for active learner without participation', async function () {
+      const result =
+        await organizationLearnerRepository.findAllLearnerWithAtLeastOneParticipationByOrganizationId(organizationId);
+
+      expect(result.totalRegisteredParticipant).to.equal(0);
+    });
+
+    it('should return 0 for active learner with deleted participation', async function () {
+      databaseBuilder.factory.buildCampaignParticipation({
+        organizationLearnerId: registeredParticipantId,
+        deletedAt: new Date(),
+      });
+      await databaseBuilder.commit();
+
+      const result =
+        await organizationLearnerRepository.findAllLearnerWithAtLeastOneParticipationByOrganizationId(organizationId);
+
+      expect(result.totalRegisteredParticipant).to.equal(0);
+    });
+
+    it('should return 0 for active learner with at least one participation from another organization', async function () {
+      const { id: activeOrganizationLearnerFromAnotherOrganizationId } =
+        databaseBuilder.factory.buildOrganizationLearner();
+      databaseBuilder.factory.buildCampaignParticipation({
+        organizationLearnerId: activeOrganizationLearnerFromAnotherOrganizationId,
+      });
+      await databaseBuilder.commit();
+
+      const result =
+        await organizationLearnerRepository.findAllLearnerWithAtLeastOneParticipationByOrganizationId(organizationId);
+
+      expect(result.totalRegisteredParticipant).to.equal(0);
+    });
+
+    it('should return 0 for deleted learner', async function () {
+      const deletedById = databaseBuilder.factory.buildUser().id;
+      databaseBuilder.factory.buildOrganizationLearner({
+        organizationId,
+        deletedAt: new Date(),
+        deletedBy: deletedById,
+      });
+      await databaseBuilder.commit();
+
+      const result =
+        await organizationLearnerRepository.findAllLearnerWithAtLeastOneParticipationByOrganizationId(organizationId);
+
+      expect(result.totalRegisteredParticipant).to.equal(0);
+    });
+  });
+});

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/organization-places-lot.repository.test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/organization-places-lot.repository.test.js
@@ -1,0 +1,69 @@
+import { PlacesLot } from '../../../../../src/organizational-entities/domain/read-models/PlacesLot.js';
+import * as organizationPlacesLotRepository from '../../../../../src/organizational-entities/infrastructure/repositories/organization-places-lot.repository.js';
+import { databaseBuilder, expect } from '../../../../test-helper.js';
+
+describe('Integration | Organizational-Entities | Infrastructure |Repositories | Organization-Places-Lot', function () {
+  describe('#findAllByOrganizationIds', function () {
+    let organizationId;
+
+    beforeEach(async function () {
+      organizationId = databaseBuilder.factory.buildOrganization().id;
+      await databaseBuilder.commit();
+    });
+
+    it('should return array of PlacesLot model', async function () {
+      databaseBuilder.factory.buildOrganizationPlace({ organizationId });
+      await databaseBuilder.commit();
+
+      const places = await organizationPlacesLotRepository.findAllByOrganizationIds({
+        organizationIds: [organizationId],
+      });
+
+      expect(places[0]).to.be.instanceOf(PlacesLot);
+    });
+
+    it('should return empty array if there is no placeslots', async function () {
+      await databaseBuilder.commit();
+
+      const places = await organizationPlacesLotRepository.findAllByOrganizationIds({
+        organizationIds: [organizationId],
+      });
+
+      expect(places).to.be.empty;
+    });
+
+    it('should return placeslots if there are places for given organizationId', async function () {
+      databaseBuilder.factory.buildOrganizationPlace({
+        organizationId,
+        count: 7,
+      });
+      databaseBuilder.factory.buildOrganizationPlace({
+        organizationId,
+        count: 3,
+        deletedAt: new Date(),
+      });
+      await databaseBuilder.commit();
+
+      const places = await organizationPlacesLotRepository.findAllByOrganizationIds({
+        organizationIds: [organizationId],
+      });
+
+      expect(places).to.have.lengthOf(2);
+      expect(places[0].count).to.equal(7);
+      expect(places[1].count).to.equal(3);
+    });
+
+    it('should not return places from another organizationId', async function () {
+      const anotherOrganizationId = databaseBuilder.factory.buildOrganization().id;
+
+      databaseBuilder.factory.buildOrganizationPlace({ organizationId });
+      await databaseBuilder.commit();
+
+      const places = await organizationPlacesLotRepository.findAllByOrganizationIds({
+        organizationIds: [anotherOrganizationId],
+      });
+
+      expect(places).to.have.lengthOf(0);
+    });
+  });
+});

--- a/api/tests/organizational-entities/unit/application/organization/organization.admin.controller.test.js
+++ b/api/tests/organizational-entities/unit/application/organization/organization.admin.controller.test.js
@@ -201,4 +201,36 @@ describe('Unit | Organizational Entities | Application | Controller | Admin | or
       expect(response.source).to.deep.equal(serializedOrganization);
     });
   });
+
+  describe('#getOrganizationPlacesStatistics', function () {
+    it('should call the usecase and serialize the response', async function () {
+      // given
+      const organizationId = 1234;
+      const request = { params: { organizationId } };
+
+      const organizationPlacesStatistics = Symbol('organizationPlaces');
+      const organizationPlacesStatisticsSerialized = Symbol('organizationPlacesSerialized');
+      sinon
+        .stub(usecases, 'getOrganizationPlacesStatistics')
+        .withArgs({ organizationId })
+        .resolves(organizationPlacesStatistics);
+      const organizationPlacesStatisticsSerializerStub = {
+        serialize: sinon.stub(),
+      };
+
+      organizationPlacesStatisticsSerializerStub.serialize
+        .withArgs(organizationPlacesStatistics)
+        .returns(organizationPlacesStatisticsSerialized);
+
+      const dependencies = {
+        organizationPlacesStatisticsSerializer: organizationPlacesStatisticsSerializerStub,
+      };
+
+      // when
+      const result = await organizationAdminController.getOrganizationPlacesStatistics(request, hFake, dependencies);
+
+      // then
+      expect(result).to.equal(organizationPlacesStatisticsSerialized);
+    });
+  });
 });

--- a/api/tests/organizational-entities/unit/domain/read-models/PlacesLot_test.js
+++ b/api/tests/organizational-entities/unit/domain/read-models/PlacesLot_test.js
@@ -1,0 +1,159 @@
+import { PlacesLot } from '../../../../../src/organizational-entities/domain/read-models/PlacesLot.js';
+import { expect, sinon } from '../../../../test-helper.js';
+
+describe('Unit | Domain | ReadModels | PlacesLot', function () {
+  let clock;
+  const now = new Date('2021-05-01');
+
+  beforeEach(async function () {
+    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+  });
+
+  afterEach(async function () {
+    clock.restore();
+  });
+
+  describe('#count', function () {
+    it('should return count', function () {
+      const placesLot = new PlacesLot({
+        id: 1,
+        count: 10,
+        activationDate: new Date(),
+        expirationDate: new Date(),
+        deletedAt: null,
+      });
+
+      expect(placesLot.count).to.equal(10);
+    });
+  });
+
+  describe('#isActive', function () {
+    it('should return true when place lots is active', function () {
+      const placesLot = new PlacesLot({
+        id: 1,
+        count: 1,
+        activationDate: new Date('2021-04-01'),
+        expirationDate: new Date('2021-12-31'),
+        deletedAt: null,
+      });
+
+      expect(placesLot.isActive).to.be.true;
+    });
+
+    it('should return false when place lots is expired', function () {
+      const placesLot = new PlacesLot({
+        id: 1,
+        count: 1,
+        activationDate: new Date('2021-04-20'),
+        expirationDate: new Date('2021-04-30'),
+        deletedAt: null,
+      });
+
+      expect(placesLot.isActive).to.be.false;
+    });
+
+    it('should return false when place lots is not active yet', function () {
+      const placesLot = new PlacesLot({
+        id: 1,
+        count: 1,
+        expirationDate: new Date('2021-07-07'),
+        activationDate: new Date('2021-06-06'),
+        deletedAt: null,
+      });
+
+      expect(placesLot.isActive).to.be.false;
+    });
+
+    it('should return 0 when there are only deleted place lots', function () {
+      const placesLot = new PlacesLot({
+        id: 1,
+        count: 1,
+        expirationDate: new Date('2021-07-07'),
+        activationDate: new Date('2021-06-06'),
+        deletedAt: new Date('2021-05-05'),
+      });
+
+      expect(placesLot.isActive).to.be.false;
+    });
+  });
+
+  describe('#id', function () {
+    it('should return id', function () {
+      const placesLot = new PlacesLot({
+        id: 1,
+        count: 1,
+        activationDate: new Date('2021-04-01'),
+        expirationDate: new Date('2021-12-31'),
+        deletedAt: null,
+      });
+
+      expect(placesLot.expirationDate).to.deep.equal(new Date('2021-12-31'));
+    });
+  });
+
+  describe('#activationDate', function () {
+    it('should return activation date', function () {
+      const placesLot = new PlacesLot({
+        id: 1,
+        count: 1,
+        activationDate: new Date('2021-04-01'),
+        expirationDate: new Date('2021-12-31'),
+        deletedAt: null,
+      });
+
+      expect(placesLot.activationDate).to.deep.equal(new Date('2021-04-01'));
+    });
+  });
+
+  describe('#expirationDate', function () {
+    it('should return activation date', function () {
+      const placesLot = new PlacesLot({
+        id: 1,
+        count: 1,
+        activationDate: new Date('2021-04-01'),
+        expirationDate: new Date('2021-12-31'),
+        deletedAt: null,
+      });
+
+      expect(placesLot.expirationDate).to.deep.equal(new Date('2021-12-31'));
+    });
+  });
+
+  describe('#status', function () {
+    it('should return Active status', function () {
+      const placesLot = new PlacesLot({
+        id: 1,
+        count: 1,
+        activationDate: new Date('2021-04-01'),
+        expirationDate: new Date('2021-12-31'),
+        deletedAt: null,
+      });
+
+      expect(placesLot.status).to.equal('ACTIVE');
+    });
+
+    it('should return Expired status', function () {
+      const placesLot = new PlacesLot({
+        id: 1,
+        count: 1,
+        activationDate: new Date('2021-04-01'),
+        expirationDate: new Date('2021-04-30'),
+        deletedAt: null,
+      });
+
+      expect(placesLot.status).to.equal('EXPIRED');
+    });
+
+    it('should return Pending status', function () {
+      const placesLot = new PlacesLot({
+        id: 1,
+        count: 1,
+        activationDate: new Date('2021-07-01'),
+        expirationDate: new Date('2021-09-30'),
+        deletedAt: null,
+      });
+
+      expect(placesLot.status).to.equal('PENDING');
+    });
+  });
+});

--- a/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/organizations-administration/organization-places-statistics.serializer.test.js
+++ b/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/organizations-administration/organization-places-statistics.serializer.test.js
@@ -1,0 +1,47 @@
+import dayjs from 'dayjs';
+
+import { PlacesStatistics } from '../../../../../../../src/organizational-entities/domain/read-models/PlacesStatistics.js';
+import * as organizationPlaceStatisticsSerializer from '../../../../../../../src/organizational-entities/infrastructure/serializers/jsonapi/organizations-administration/organization-places-statistics.serializer.js';
+import { PlacesLot } from '../../../../../../../src/prescription/organization-place/domain/read-models/PlacesLot.js';
+import { expect } from '../../../../../../test-helper.js';
+
+describe('Unit | Infrastructure | Serializers | JSONAPI | Organizations-Administrations | organization-places-statistics', function () {
+  describe('#serialize', function () {
+    it('should convert a PlacesStatistics entity into JSON API data', function () {
+      // given
+      const placesStatistics = new PlacesStatistics({
+        placesLots: [
+          new PlacesLot({
+            id: 1,
+            count: 10,
+            expirationDate: dayjs().add(1, 'months').toDate(),
+            activationDate: new Date('2019-04-01'),
+            deletedAt: null,
+          }),
+        ],
+        placeRepartition: { totalUnRegisteredParticipant: 3, totalRegisteredParticipant: 2 },
+        organizationId: 22,
+      });
+
+      const expectedJSON = {
+        data: {
+          type: 'organization-places-statistics',
+          id: '22_place_statistics',
+          attributes: {
+            total: 10,
+            occupied: 5,
+            available: 5,
+            'anonymous-seat': 3,
+            'has-reached-maximum-places-limit': false,
+          },
+        },
+      };
+
+      // when
+      const json = organizationPlaceStatisticsSerializer.serialize(placesStatistics);
+
+      // then
+      expect(json).to.deep.equal(expectedJSON);
+    });
+  });
+});


### PR DESCRIPTION
## ❄️ Problème

Il n'est pour l'heure pas possible d'afficher les informations des places des organisations dans Pix-Admin.

## 🛷 Proposition

Nous dupliquons ici ce qui à été fait côté prescription pour la récupération des stats de places dans un domaine nous appartenant.
Lorsque nous récupèrerons l'intégralité de la gestion des places, nous réaliserons une api interne, et pourrons potentillement supprimer tout l’ancien code.

## ☃️ Remarques

Nous ne traitons que la partie back-end dans ce ticket.

## 🧑‍🎄 Pour tester

Choisir un `ORGANIZATION_ID` (ex: `1005`) à remplacer dans le curl suivant et effectuer l'appel pour récupérer les informations des places de cette organisation : 

```bash
TOKEN=$(curl --insecure 'https://admin-pr14688.review.pix.fr/api/token' --data-raw 'grant_type=password&username=superadmin@example.net&password=pix123'  -H 'x-forwarded-host' 'admin' -H 'x-forwarded-proto' 'HTTP'  -X POST | jq -r .access_token)

curl https://admin-pr14688.review.pix.fr/api/admin/organizations/<ORGANIZATION_ID>/places-statistics \
    -H "Authorization: Bearer $TOKEN" \
    -H "Content-Type: application/json" \
    -H "Accept-language: fr-fr" \
    -X GET | jq '.'
```    
