### PR TITLE
[TECH] Ajout de logs de debug pour le usecase reward user (PIX-21004)

### DIFF
--- a/api/src/quest/domain/usecases/reward-user.js
+++ b/api/src/quest/domain/usecases/reward-user.js
@@ -18,12 +18,16 @@ export const rewardUser = async ({
       return;
     }
 
+    logger.debug(`Found ${quests.length} quests with reward for user ${userId}`);
+
     const eligibilities = await eligibilityRepository.find({ userId });
     const rewards = await rewardRepository.getByUserId({ userId });
 
     const rewardIds = rewards.map((reward) => reward.rewardId);
 
     for (const quest of quests) {
+      logger.debug(`Parsing quest ${quest.id} with reward ${quest.rewardId} for user ${userId}`);
+
       if (rewardIds.includes(quest.rewardId)) {
         continue;
       }
@@ -37,14 +41,22 @@ export const rewardUser = async ({
       }
 
       for (const dataForQuest of dataForQuests) {
+        logger.debug(`Eligibilities found on quest ${quest.id} for user ${userId}`);
+        logger.debug({ dataForQuest }, `Eligibilities for quest ${quest.id}`);
+
         const campaignParticipationIds = quest.findCampaignParticipationIdsContributingToQuest(dataForQuest);
         const targetProfileIds =
           quest.findTargetProfileIdsWithoutCampaignParticipationContributingToQuest(dataForQuest);
+
         const success = await successRepository.find({ userId, campaignParticipationIds, targetProfileIds });
+        logger.debug({ success }, `Success for quest ${quest.id}`);
         dataForQuest.success = success;
+
         const userHasSucceedQuest = quest.isSuccessful(dataForQuest);
 
         if (userHasSucceedQuest) {
+          logger.debug(`Success found on quest ${quest.id} for user ${userId}. Pushing reward ${quest.rewardId}`);
+
           await rewardRepository.reward({ userId, rewardId: quest.rewardId });
           rewardIds.push(quest.rewardId);
           break;


### PR DESCRIPTION
## ❄️ Problème

Actuellement il n'est pas toujours simple de debugger l'attribution de rewards pour un user. 

## 🛷 Proposition

Ajouter des logs pour accéder plus simplement à des infos utiles :
- Critères d'éligibilité
- Critères de succès
- Données utilisateur

## 🧑‍🎄 Pour tester

Afficher les logs en debug en déclenchant le usecase `reward-user`
