### PR TITLE
[FEATURE] Permettre de sélectionner un module lors de la création/mise à jour d'un contenu formatif (PIX-20921)

### DIFF
--- a/admin/app/adapters/module-metadata.js
+++ b/admin/app/adapters/module-metadata.js
@@ -1,0 +1,7 @@
+import ApplicationAdapter from './application';
+
+export default class ModuleMetadata extends ApplicationAdapter {
+  urlForFindAll() {
+    return `${this.host}/${this.namespace}/admin/modules-metadata`;
+  }
+}

--- a/admin/app/components/trainings/create-or-update-training-form.gjs
+++ b/admin/app/components/trainings/create-or-update-training-form.gjs
@@ -45,14 +45,31 @@ class Form {
 
 export default class CreateOrUpdateTrainingForm extends Component {
   @service featureToggles;
+  @service store;
 
   @tracked submitting = false;
+  @tracked modules = [];
 
   constructor() {
     super(...arguments);
     this.optionsTypeList = optionsTypeList;
     this.optionsLocaleList = optionsLocaleList;
     this.form = new Form(this.args.model);
+    this.loadModules();
+  }
+
+  get formattedSortedModuleValues() {
+    const selectValues = this.modules.map((modules) => ({
+      value: modules.link,
+      label: modules.title,
+    }));
+
+    return selectValues.sort((moduleA, moduleB) => moduleA.label.localeCompare(moduleB.label));
+  }
+
+  async loadModules() {
+    const modulesMetadata = this.store.peekAll('module-metadata');
+    this.modules = modulesMetadata?.length ? modulesMetadata : await this.store.findAll('module-metadata');
   }
 
   @action
@@ -131,7 +148,20 @@ export default class CreateOrUpdateTrainingForm extends Component {
           {{#if this.form.type}}
             {{#if this.featureToggles.featureToggles.isModuleSelectionForTrainingEnabled}}
               {{#if (eq this.form.type "modulix")}}
-                <p>Todo : Ajouter un Pix Select "Lien" listant les modules</p>
+                <PixSelect
+                  @id="trainingModule"
+                  @placeholder="-- Sélectionnez un module --"
+                  @options={{this.formattedSortedModuleValues}}
+                  @value={{this.form.link}}
+                  @onChange={{fn this.updateSelect "link"}}
+                  @hideDefaultOption={{true}}
+                  @isSearchable={{true}}
+                  @searchLabel="Module à rechercher"
+                  required={{true}}
+                  aria-required={{true}}
+                >
+                  <:label>Module</:label>
+                </PixSelect>
               {{else}}
                 <PixInput
                   @id="trainingLink"

--- a/admin/app/models/module-metadata.js
+++ b/admin/app/models/module-metadata.js
@@ -1,0 +1,6 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class ModuleMetadata extends Model {
+  @attr('string') title;
+  @attr('string') link;
+}

--- a/admin/tests/integration/templates/authenticated/trainings/training-test.gjs
+++ b/admin/tests/integration/templates/authenticated/trainings/training-test.gjs
@@ -29,6 +29,7 @@ module('Integration | Component | Trainings | Training', function (hooks) {
       isRecommendable: true,
       isDisabled: false,
     });
+    store.createRecord('module-metadata', { title: 'Bac à sable', link: '/modules/bac-a-sable' });
 
     class AccessControlStub extends Service {
       hasAccessToTrainingsActionsScope = true;

--- a/admin/tests/mirage/routes.js
+++ b/admin/tests/mirage/routes.js
@@ -714,6 +714,26 @@ export default function routes() {
   this.get('/admin/combined-course-blueprints');
   this.post('/admin/combined-course-blueprints');
 
+  this.get('/admin/modules-metadata', () => {
+    return {
+      data: [
+        {
+          type: 'module-metadatas',
+          id: '6282925d',
+          attributes: {
+            'short-id': '6a68bf32',
+            slug: 'bac-a-sable',
+            title: 'Bac à sable',
+            'is-beta': true,
+            duration: 5,
+            image: 'https://assets.pix.org/modules/placeholder-details.svg',
+            link: '/modules/6a68bf32/bac-a-sable',
+          },
+        },
+      ],
+    };
+  });
+
   _configureOrganizationsRoutes(this);
 }
 

--- a/api/src/devcomp/application/trainings/training-route.js
+++ b/api/src/devcomp/application/trainings/training-route.js
@@ -125,7 +125,11 @@ const register = async function (server) {
           payload: Joi.object({
             data: Joi.object({
               attributes: Joi.object({
-                link: Joi.string().uri().required(),
+                link: Joi.when('type', {
+                  is: 'modulix',
+                  then: Joi.string().required(),
+                  otherwise: Joi.string().uri().required(),
+                }),
                 title: Joi.string().required(),
                 'internal-title': Joi.string().required(),
                 duration: Joi.object({

--- a/api/src/devcomp/infrastructure/serializers/jsonapi/module-metadata-serializer.js
+++ b/api/src/devcomp/infrastructure/serializers/jsonapi/module-metadata-serializer.js
@@ -3,7 +3,7 @@ import jsonapiSerializer from 'jsonapi-serializer';
 const { Serializer } = jsonapiSerializer;
 
 const serialize = function (moduleMetadataList) {
-  return new Serializer('module-metadata', {
+  return new Serializer('module-metadatas', {
     attributes: ['shortId', 'slug', 'title', 'isBeta', 'duration', 'image', 'link', 'visibility'],
   }).serialize(moduleMetadataList);
 };

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-metadata-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-metadata-serializer_test.js
@@ -31,7 +31,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleMetada
       const expectedJson = {
         data: [
           {
-            type: 'module-metadata',
+            type: 'module-metadatas',
             id: firstModuleMetadata.id,
             attributes: {
               'short-id': firstModuleMetadata.shortId,
@@ -45,7 +45,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleMetada
             },
           },
           {
-            type: 'module-metadata',
+            type: 'module-metadatas',
             id: secondModuleMetadata.id,
             attributes: {
               'short-id': secondModuleMetadata.shortId,


### PR DESCRIPTION
## ❄️ Problème

Sur Pix Admin, sous FT, lorsqu'on sélectionne le format Modules Pix pour un contenu formatif, un todo a été placé en vue d'y placer un sélecteur.
La route API permettant de lister les modules existants a été créé. 

## 🛷 Proposition

Permettre de sélectionner un module lors de la création/mise à jour d'un contenu formatif

## ☃️ Remarques

Plusieurs modifications ont été effectué coté API : 
- Ajout d'un S dans le type pour que Ember soit heureux :) 
- Ajout d'une condition dans le JOI de la création d'un contenu formatif. En effet en cas de CF modulix, on attend un simple path (/module/tutu) tandis que pour les autres on attend un uri

## 🧑‍🎄 Pour tester
Création d'un contenu formatif : https://admin-pr14691.review.pix.fr/trainings/new

- Remplir les champs
- Ajouter Modules Pix dans "Format"
- Constater que le sélecteur "Module" apparaît
- Sélectionner un module 
- Enregistrer
- Constater que le lien dans la page de détails pointe vers Pix App avec le bon module


Modification d'un contenu formatif : rester sur la page de détails

- Modifier le CF
- Constater que le sélecteur "Module" pointe sur le bon module précédemment sélectionné
- Modifier le module par un autre
- Enregistrer
- Constater que le lien a été modifié.