### PR TITLE
[FEATURE] Afficher la liste des organisations pour lesquelles un schéma de parcours combiné est à disposition (PIX-20996)

### DIFF
--- a/admin/app/components/combined-course-blueprints/combined-course-blueprint.gjs
+++ b/admin/app/components/combined-course-blueprints/combined-course-blueprint.gjs
@@ -1,0 +1,9 @@
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+
+import Details from './details';
+
+export default class CombinedCourseBlueprint extends Component {
+  @service intl;
+  <template><Details @model={{@model}} /></template>
+}

--- a/admin/app/components/combined-course-blueprints/list-summary-items.gjs
+++ b/admin/app/components/combined-course-blueprints/list-summary-items.gjs
@@ -35,8 +35,8 @@ export default class CombineCourseBluePrintList extends Component {
             </:header>
             <:cell>
               <LinkTo
-                @route="authenticated.combined-course-blueprints.details"
-                @model={{blueprint}}
+                @route="authenticated.combined-course-blueprints.combined-course-blueprint"
+                @model={{blueprint.id}}
               >{{blueprint.internalName}}</LinkTo>
 
             </:cell>

--- a/admin/app/components/combined-course-blueprints/organizations.gjs
+++ b/admin/app/components/combined-course-blueprints/organizations.gjs
@@ -1,0 +1,24 @@
+import ListItems from 'pix-admin/components/organizations/list-items';
+
+<template>
+  <section class="page-section organizations-list">
+    <header class="page-section__header">
+      <h2 class="page-section__title">Organisations pouet</h2>
+    </header>
+
+    <ListItems
+      @organizations={{@organizations}}
+      @administrationTeams={{@administrationTeams}}
+      @triggerFiltering={{@triggerFiltering}}
+      @onResetFilter={{@onResetFilter}}
+      @goToOrganizationPage={{@goToOrganizationPage}}
+      @entityName={{@blueprint.internalName}}
+      @id={{@id}}
+      @name={{@name}}
+      @hideArchived={{@hideArchived}}
+      @type={{@type}}
+      @externalId={{@externalId}}
+      @administrationTeamId={{@administrationTeamId}}
+    />
+  </section>
+</template>

--- a/admin/app/components/layout/sidebar.gjs
+++ b/admin/app/components/layout/sidebar.gjs
@@ -83,7 +83,7 @@ export default class Sidebar extends Component {
         {{#if this.currentUser.adminMember.isSuperAdmin}}
           <PixNavigationButton
             class="sidebar__link"
-            @route="authenticated.combined-course-blueprints.list"
+            @route="authenticated.combined-course-blueprints"
             @icon="studyLesson"
           >
             {{t "components.layout.sidebar.combined-course-blueprints"}}

--- a/admin/app/components/organizations/list-items.gjs
+++ b/admin/app/components/organizations/list-items.gjs
@@ -196,11 +196,7 @@ export default class ActionsOnUsersRoleInOrganization extends Component {
     >
       <:content>
         <p>
-          Etes-vous sûr de vouloir détacher l'organisation
-          <strong>{{this.organizationToDetach.name}}</strong>
-          du profil cible
-          <strong>{{@targetProfileName}}</strong>
-          ?
+          {{t @confirmationLabel htmlSafe=true organizationName=this.organizationToDetach.name name=@entityName}}
         </p>
       </:content>
       <:footer>

--- a/admin/app/components/target-profiles/organizations.gjs
+++ b/admin/app/components/target-profiles/organizations.gjs
@@ -191,7 +191,8 @@ export default class Organizations extends Component {
         @triggerFiltering={{@triggerFiltering}}
         @goToOrganizationPage={{@goToOrganizationPage}}
         @detachOrganizations={{@detachOrganizations}}
-        @targetProfileName={{@targetProfile.internalName}}
+        @entityName={{@targetProfile.internalName}}
+        @confirmationLabel="components.target-profiles.organizations.detach-organization"
         @hideArchived={{@hideArchived}}
         @showDetachColumn={{this.isSuperAdminOrMetier}}
         @administrationTeamId={{@administrationTeamId}}

--- a/admin/app/controllers/authenticated/combined-course-blueprints/combined-course-blueprint/organizations.js
+++ b/admin/app/controllers/authenticated/combined-course-blueprints/combined-course-blueprint/organizations.js
@@ -1,0 +1,52 @@
+import Controller from '@ember/controller';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+import { debounceTask } from 'ember-lifeline';
+import config from 'pix-admin/config/environment';
+
+const DEFAULT_PAGE_NUMBER = 1;
+
+export default class CombinedCourseBlueprintOrganizationsController extends Controller {
+  queryParams = ['pageNumber', 'pageSize', 'id', 'name', 'type', 'externalId', 'administrationTeamId', 'hideArchived'];
+  DEBOUNCE_MS = config.pagination.debounce;
+  @service router;
+  @service pixToast;
+  @service store;
+
+  @tracked pageNumber = DEFAULT_PAGE_NUMBER;
+  @tracked pageSize = 10;
+  @tracked id = null;
+  @tracked hideArchived = false;
+  @tracked name = null;
+  @tracked type = null;
+  @tracked externalId = null;
+  @tracked administrationTeamId = null;
+
+  updateFilters(filters) {
+    for (const filterKey of Object.keys(filters)) {
+      this[filterKey] = filters[filterKey];
+    }
+    this.pageNumber = DEFAULT_PAGE_NUMBER;
+  }
+
+  @action
+  triggerFiltering(fieldName, event) {
+    debounceTask(this, 'updateFilters', { [fieldName]: event.target.value }, this.DEBOUNCE_MS);
+  }
+
+  @action
+  goToOrganizationPage(organizationId) {
+    this.router.transitionTo('authenticated.organizations.get', organizationId);
+  }
+
+  @action
+  onResetFilter() {
+    this.id = null;
+    this.name = null;
+    this.type = null;
+    this.externalId = null;
+    this.hideArchived = false;
+    this.administrationTeamId = null;
+  }
+}

--- a/admin/app/router.js
+++ b/admin/app/router.js
@@ -180,7 +180,9 @@ Router.map(function () {
     this.route('combined-course-blueprints', function () {
       this.route('list');
       this.route('new');
-      this.route('details', { path: '/:combined_course_blueprint_id' });
+      this.route('combined-course-blueprint', { path: '/:combined_course_blueprint_id' }, function () {
+        this.route('organizations');
+      });
     });
   });
 

--- a/admin/app/routes/authenticated/combined-course-blueprints/combined-course-blueprint.js
+++ b/admin/app/routes/authenticated/combined-course-blueprints/combined-course-blueprint.js
@@ -4,7 +4,7 @@ import { inject as service } from '@ember/service';
 export default class BlueprintRoute extends Route {
   @service('store') store;
 
-  model(params) {
+  async model(params) {
     return this.store.findRecord('combined-course-blueprint', params.combined_course_blueprint_id);
   }
 }

--- a/admin/app/routes/authenticated/combined-course-blueprints/combined-course-blueprint/index.js
+++ b/admin/app/routes/authenticated/combined-course-blueprints/combined-course-blueprint/index.js
@@ -1,0 +1,10 @@
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+export default class CombinedCourseBlueprintRoute extends Route {
+  @service router;
+
+  beforeModel() {
+    this.router.replaceWith('authenticated.combined-course-blueprints.combined-course-blueprint.organizations');
+  }
+}

--- a/admin/app/routes/authenticated/combined-course-blueprints/combined-course-blueprint/organizations.js
+++ b/admin/app/routes/authenticated/combined-course-blueprints/combined-course-blueprint/organizations.js
@@ -1,0 +1,44 @@
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+export default class CombinedCourseBlueprintDetailsRoute extends Route {
+  @service accessControl;
+  @service store;
+
+  queryParams = {
+    pageNumber: { refreshModel: true },
+    pageSize: { refreshModel: true },
+    id: { refreshModel: true },
+    name: { refreshModel: true },
+    type: { refreshModel: true },
+    externalId: { refreshModel: true },
+    hideArchived: { refreshModel: true },
+    administrationTeamId: { refreshModel: true },
+  };
+
+  beforeModel() {
+    this.accessControl.restrictAccessTo(['isSuperAdmin', 'isSupport', 'isMetier'], 'authenticated');
+  }
+
+  async model(params) {
+    const blueprint = this.modelFor('authenticated.combined-course-blueprints.combined-course-blueprint');
+    const queryParams = {
+      page: {
+        size: params.pageSize,
+        number: params.pageNumber,
+      },
+      filter: {
+        id: params.id,
+        name: params.name,
+        type: params.type,
+        externalId: params.externalId,
+        hideArchived: params.hideArchived,
+        administrationTeamId: params.administrationTeamId,
+        combinedCourseBlueprintId: blueprint.id,
+      },
+    };
+    const administrationTeams = await this.store.findAll('administration-team');
+    const organizations = await this.store.query('organization', queryParams);
+    return { blueprint, organizations, administrationTeams };
+  }
+}

--- a/admin/app/routes/authenticated/combined-course-blueprints/index.js
+++ b/admin/app/routes/authenticated/combined-course-blueprints/index.js
@@ -1,0 +1,10 @@
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+export default class IndexRoute extends Route {
+  @service router;
+
+  beforeModel() {
+    this.router.transitionTo('authenticated.combined-course-blueprints.list');
+  }
+}

--- a/admin/app/templates/authenticated/combined-course-blueprints/combined-course-blueprint.gjs
+++ b/admin/app/templates/authenticated/combined-course-blueprints/combined-course-blueprint.gjs
@@ -1,0 +1,5 @@
+import CombinedCourseBlueprint from 'pix-admin/components/combined-course-blueprints/combined-course-blueprint';
+<template>
+  <CombinedCourseBlueprint @model={{@model}} />
+  {{outlet}}
+</template>

--- a/admin/app/templates/authenticated/combined-course-blueprints/combined-course-blueprint/organizations.gjs
+++ b/admin/app/templates/authenticated/combined-course-blueprints/combined-course-blueprint/organizations.gjs
@@ -1,0 +1,18 @@
+import Organizations from 'pix-admin/components/combined-course-blueprints/organizations';
+
+<template>
+  <Organizations
+    @blueprint={{@model.blueprint}}
+    @organizations={{@model.organizations}}
+    @administrationTeams={{@model.administrationTeams}}
+    @triggerFiltering={{@controller.triggerFiltering}}
+    @onResetFilter={{@controller.onResetFilter}}
+    @goToOrganizationPage={{@controller.goToOrganizationPage}}
+    @id={{@controller.id}}
+    @name={{@controller.name}}
+    @type={{@controller.type}}
+    @externalId={{@controller.externalId}}
+    @hideArchived={{@controller.hideArchived}}
+    @administrationTeamId={{@controller.administrationTeamId}}
+  />
+</template>

--- a/admin/app/templates/authenticated/combined-course-blueprints/details.gjs
+++ b/admin/app/templates/authenticated/combined-course-blueprints/details.gjs
@@ -1,3 +1,0 @@
-import Details from 'pix-admin/components/combined-course-blueprints/details';
-
-<template><Details @model={{@model}} /></template>

--- a/admin/tests/acceptance/authenticated/combined-course-blueprints/list-test.js
+++ b/admin/tests/acceptance/authenticated/combined-course-blueprints/list-test.js
@@ -41,6 +41,6 @@ module('Acceptance | Combined course blueprint | List', function (hooks) {
     // when
     await click(link);
     // then
-    assert.strictEqual(currentURL(), '/combined-course-blueprints/1');
+    assert.strictEqual(currentURL(), '/combined-course-blueprints/1/organizations');
   });
 });

--- a/admin/tests/acceptance/authenticated/combined-course-blueprints/organizations-test.js
+++ b/admin/tests/acceptance/authenticated/combined-course-blueprints/organizations-test.js
@@ -1,0 +1,91 @@
+import { clickByName, visit } from '@1024pix/ember-testing-library';
+import { currentURL } from '@ember/test-helpers';
+import { t } from 'ember-intl/test-support';
+import { setupApplicationTest } from 'ember-qunit';
+import { setupMirage } from 'pix-admin/tests/test-support/setup-mirage';
+import { module, test } from 'qunit';
+
+import { authenticateAdminMemberWithRole } from '../../../helpers/test-init';
+
+module('Acceptance | combined course blueprint Organizations', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  module('Access restriction stuff', function () {
+    module('When admin member is not logged in', function () {
+      test('it should not be accessible by an unauthenticated user', async function (assert) {
+        // when
+        await visit('/combined-course-blueprints/1/organizations');
+
+        // then
+        assert.strictEqual(currentURL(), '/login');
+      });
+    });
+
+    module('When admin member is logged in', function () {
+      module('when admin member has role "SUPER_ADMIN", "CERTIF", "SUPPORT" or "METIER"', function (hooks) {
+        hooks.beforeEach(async function () {
+          await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+          server.create('organization', { id: 456, name: 'My organization' });
+          server.create('combined-course-blueprint', {
+            id: 1,
+            name: 'le blueprint ia',
+            internalName: 'le blueprint -- nom interne',
+          });
+        });
+
+        test('it should be accessible for an authenticated user', async function (assert) {
+          // when
+          await visit('/combined-course-blueprints/1/organizations');
+
+          // then
+          assert.strictEqual(currentURL(), '/combined-course-blueprints/1/organizations');
+        });
+
+        test('it should set combined-course-blueprint menubar item active', async function (assert) {
+          // when
+          const screen = await visit(`/combined-course-blueprints/1/organizations`);
+
+          // then
+          assert
+            .dom(screen.getByRole('link', { name: t('components.layout.sidebar.combined-course-blueprints') }))
+            .hasClass('active');
+        });
+      });
+    });
+  });
+
+  module('Combined course blueprint organizations', function (hooks) {
+    hooks.beforeEach(async function () {
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+      server.create('combined-course-blueprint', {
+        id: 1,
+        name: 'le blueprint ia',
+        internalName: 'le blueprint -- nom interne',
+      });
+    });
+
+    module('with multiple organizations', function (hooks) {
+      hooks.beforeEach(async function () {
+        server.create('organization', { id: 456, name: 'My organization' });
+        server.create('organization', { id: 789, name: 'My other organization' });
+      });
+
+      test('should list organizations', async function (assert) {
+        const screen = await visit('/combined-course-blueprints/1');
+        assert.dom(screen.getByText('My organization')).exists();
+        assert.dom(screen.getByText('My other organization')).exists();
+      });
+
+      test('it should redirect to organization details on click', async function (assert) {
+        // given
+        await visit('/combined-course-blueprints/1');
+        // when
+        await clickByName('456');
+
+        // then
+        assert.deepEqual(currentURL(), '/organizations/456/team');
+      });
+    });
+  });
+});

--- a/admin/tests/mirage/routes.js
+++ b/admin/tests/mirage/routes.js
@@ -734,6 +734,7 @@ export default function routes() {
     };
   });
 
+  this.get('/admin/combined-course-blueprints/:id');
   _configureOrganizationsRoutes(this);
 }
 

--- a/admin/tests/unit/controllers/authenticated/combined-course-blueprints/combined-course-blueprint/organizations-test.js
+++ b/admin/tests/unit/controllers/authenticated/combined-course-blueprints/combined-course-blueprint/organizations-test.js
@@ -1,0 +1,102 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module(
+  'Unit | Controller | authenticated/combined-course-blueprints/combined-course-blueprint/organizations',
+  function (hooks) {
+    setupTest(hooks);
+    let controller;
+
+    hooks.beforeEach(function () {
+      controller = this.owner.lookup(
+        'controller:authenticated.combined-course-blueprints.combined-course-blueprint.organizations',
+      );
+    });
+
+    module('#updateFilters', function () {
+      module('updating name', function () {
+        test('it should update controller name field', async function (assert) {
+          // given
+          controller.name = 'someName';
+          const expectedValue = 'someOtherName';
+
+          // when
+          await controller.updateFilters({ name: expectedValue });
+
+          // then
+          assert.strictEqual(controller.name, expectedValue);
+        });
+      });
+
+      module('updating type', function () {
+        test('it should update controller type field', async function (assert) {
+          // given
+          controller.type = 'someType';
+          const expectedValue = 'someOtherType';
+
+          // when
+          await controller.updateFilters({ type: expectedValue });
+
+          // then
+          assert.strictEqual(controller.type, expectedValue);
+        });
+      });
+
+      module('updating externalId', function () {
+        test('it should update controller externalId field', async function (assert) {
+          // given
+          controller.externalId = 'someExternalId';
+          const expectedValue = 'someOtherExternalId';
+
+          // when
+          await controller.updateFilters({ externalId: expectedValue });
+
+          // then
+          assert.strictEqual(controller.externalId, expectedValue);
+        });
+      });
+
+      module('updating administrationTeam', function () {
+        test('it should update controller administrationTeam field', async function (assert) {
+          // given
+          controller.administrationTeamId = 'team1';
+          const expectedValue = 'teamId';
+
+          // when
+          await controller.updateFilters({ administrationTeamId: expectedValue });
+
+          // then
+          assert.strictEqual(controller.administrationTeamId, expectedValue);
+        });
+      });
+
+      module('updating hideArchived', function () {
+        test('it should update controller hideArchived field', async function (assert) {
+          // given
+          controller.hideArchived = false;
+          const expectedValue = true;
+
+          // when
+          await controller.updateFilters({ hideArchived: expectedValue });
+
+          // then
+          assert.strictEqual(controller.hideArchived, expectedValue);
+        });
+      });
+
+      module('updating id', function () {
+        test('it should update controller id field', async function (assert) {
+          // given
+          controller.id = '12';
+          const expectedValue = '987';
+
+          // when
+          await controller.updateFilters({ id: expectedValue });
+
+          // then
+          assert.strictEqual(controller.id, expectedValue);
+        });
+      });
+    });
+  },
+);

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -497,6 +497,9 @@
           "caption": "List of combined course blueprints"
         },
         "title": "All learner courses"
+      },
+       "organizations": {
+        "detach-organization": "Are you sure you want to detach <strong>{organizationName}</strong> from combined course blueprint <strong>{name}</strong>"
       }
     },
     "complementary-certifications": {
@@ -834,6 +837,9 @@
         "table": {
           "caption": "Liste des profil cibles. Contient l'identifiant, le nom interne, la catégorie, la date de création et le statut."
         }
+      },
+       "organizations": {
+        "detach-organization": "Are you sure you want to detach <strong>{organizationName}</strong> from target profile <strong>{name}</strong>"
       }
     },
     "users": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -498,6 +498,9 @@
           "caption": "Liste des schémas de parcours combinés"
         },
         "title": "Tous les schémas de parcours combinés"
+      },
+       "organizations": {
+        "detach-organization": "Etes-vous sûr de vouloir détacher l'organisation <strong>{organizationName}</strong> du schéma de parcours <strong>{name}</strong>"
       }
     },
     "complementary-certifications": {
@@ -836,6 +839,9 @@
         "table": {
           "caption": "Liste des profil cibles. Contient l'identifiant, le nom interne, la catégorie, la date de création et le statut."
         }
+      },
+      "organizations": {
+        "detach-organization": "Etes-vous sûr de vouloir détacher l'organisation <strong>{organizationName}</strong> du profil cible <strong>{name}</strong>"
       }
     },
     "users": {

--- a/api/db/database-builder/factory/build-combined-course-blueprint-share.js
+++ b/api/db/database-builder/factory/build-combined-course-blueprint-share.js
@@ -1,0 +1,22 @@
+import { databaseBuffer } from '../database-buffer.js';
+import { buildCombinedCourseBlueprint } from './build-combined-course-blueprint.js';
+import { buildOrganization } from './build-organization.js';
+
+const buildCombinedCourseBlueprintShare = function ({
+  id = databaseBuffer.getNextId(),
+  combinedCourseBlueprintId = buildCombinedCourseBlueprint({ content: [] }).id,
+  organizationId = buildOrganization().id,
+} = {}) {
+  const values = {
+    id,
+    combinedCourseBlueprintId,
+    organizationId,
+  };
+
+  return databaseBuffer.pushInsertable({
+    tableName: 'combined_course_blueprint_shares',
+    values,
+  });
+};
+
+export { buildCombinedCourseBlueprintShare };

--- a/api/db/seeds/data/team-prescription/build-combined-courses.js
+++ b/api/db/seeds/data/team-prescription/build-combined-courses.js
@@ -3,6 +3,13 @@ import { CombinedCourseBlueprint } from '../../../../src/quest/domain/models/Com
 import { OrganizationLearnerParticipationTypes } from '../../../../src/quest/domain/models/OrganizationLearnerParticipation.js';
 import { Assessment } from '../../../../src/shared/domain/models/Assessment.js';
 import { buildCombinedCourseBlueprint } from '../../../database-builder/factory/build-combined-course-blueprint.js';
+import { buildCombinedCourseBlueprintShare } from '../../../database-builder/factory/build-combined-course-blueprint-share.js';
+import {
+  PRO_ORGANIZATION_ID,
+  SCO_MANAGING_ORGANIZATION_ID,
+  SCO_ORGANIZATION_ID,
+  SUP_ORGANIZATION_ID,
+} from '../common/constants.js';
 import { PRO_COMBINED_COURSE } from './fixtures/pro-combined-course.js';
 import { COMBINED_COURSE_WITHOUT_CAMPAIGN } from './fixtures/pro-combined-course-without-campaign.js';
 import { COMBINED_COURSE_WITHOUT_MODULES } from './fixtures/pro-combined-course-without-modules.js';
@@ -184,11 +191,19 @@ export const buildCombinedCourseBlueprints = (databaseBuilder) => {
   }).id;
   const moduleShortId = '27d6ca4f';
 
-  buildCombinedCourseBlueprint({
+  const combinedCourseBlueprintId = buildCombinedCourseBlueprint({
     name: 'Mon parcours combiné 2',
     internalName: 'Mon schéma de parcours combiné 2',
     content: CombinedCourseBlueprint.buildContentItems([{ targetProfileId }, { moduleShortId }]),
-  });
+    illustration: 'https://assets.pix.org/combined-courses/illu_ia.svg',
+    description:
+      "Un parcours pour découvrir l’essentiel sur l'intelligence artificielle : comprendre sa définition, ses domaines d'application, comment elle fonctionne, ainsi que ses enjeux, notamment en matière d'impact environnemental.",
+  }).id;
+
+  buildCombinedCourseBlueprintShare({ combinedCourseBlueprintId, organizationId: PRO_ORGANIZATION_ID });
+  buildCombinedCourseBlueprintShare({ combinedCourseBlueprintId, organizationId: SCO_ORGANIZATION_ID });
+  buildCombinedCourseBlueprintShare({ combinedCourseBlueprintId, organizationId: SCO_MANAGING_ORGANIZATION_ID });
+  buildCombinedCourseBlueprintShare({ combinedCourseBlueprintId, organizationId: SUP_ORGANIZATION_ID });
 };
 
 export const buildCombinedCourses = (databaseBuilder) => {

--- a/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
@@ -378,12 +378,18 @@ async function _enableFeatures(knexConn, featuresToEnable, organizationId) {
 }
 
 function _setSearchFiltersForQueryBuilder(qb, filter) {
-  const { id, name, type, externalId, hideArchived, administrationTeamId, targetProfileId } = filter;
+  const { id, name, type, externalId, hideArchived, administrationTeamId, targetProfileId, combinedCourseBlueprintId } =
+    filter;
   if (id) {
     qb.where('organizations.id', id);
   }
   if (targetProfileId) {
     qb.join('target-profile-shares', 'organizationId', 'organizations.id').where({ targetProfileId });
+  }
+  if (combinedCourseBlueprintId) {
+    qb.join('combined_course_blueprint_shares', 'organizationId', 'organizations.id').where({
+      combinedCourseBlueprintId,
+    });
   }
   if (name) {
     qb.where(

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/organization-for-admin.repository.test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/organization-for-admin.repository.test.js
@@ -408,6 +408,43 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
         expect(pagination).to.deep.equal(expectedPagination);
       });
     });
+    context('when there are organization matching combined-course-blueprint-id filter', function () {
+      let blueprint;
+
+      beforeEach(function () {
+        blueprint = databaseBuilder.factory.buildCombinedCourseBlueprint({ content: [] });
+        const orgaA = databaseBuilder.factory.buildOrganization({ name: 'Org A1' });
+        const orgaB = databaseBuilder.factory.buildOrganization({ name: 'Org B1' });
+        databaseBuilder.factory.buildOrganization({ name: 'Org C1' });
+        databaseBuilder.factory.buildCombinedCourseBlueprintShare({
+          combinedCourseBlueprintId: blueprint.id,
+          organizationId: orgaA.id,
+        });
+        databaseBuilder.factory.buildCombinedCourseBlueprintShare({
+          combinedCourseBlueprintId: blueprint.id,
+          organizationId: orgaB.id,
+        });
+
+        return databaseBuilder.commit();
+      });
+
+      it('return only Organizations matching "combinedCourseBlueprintId" if given in filters', async function () {
+        // given
+        const filter = { combinedCourseBlueprintId: blueprint.id };
+        const page = { number: 1, size: 10 };
+        const expectedPagination = { page: page.number, pageSize: page.size, pageCount: 1, rowCount: 2 };
+        // when
+        const { models: matchingOrganizations, pagination } =
+          await repositories.organizationForAdminRepository.findPaginatedFiltered({
+            filter,
+            page,
+          });
+
+        // then
+        expect(_.map(matchingOrganizations, 'name')).to.have.members(['Org A1', 'Org B1']);
+        expect(pagination).to.deep.equal(expectedPagination);
+      });
+    });
   });
 
   describe('#archive', function () {


### PR DESCRIPTION
## ❄️ Problème

A l'image de ce qui se fait sur les profils cibles, on doit pouvoir savoir quelles organisations ont un schéma de parcours combiné à disposition.

## 🛷 Proposition

On se repose sur le même principe de pour les profils cible. on crée une sous route `organizations` qui va récupérer les organization liés à un schéma de parcours.

On cache temporairement les filtres pour n'afficher que la pagination.

## 🧑‍🎄 Pour tester
- Cliquer sur "Schéma de parcours combiné";
- Sélectionner un schéma de parcours;
- Voir les organisations liées au schéma;
- Tester la pagination