### PR TITLE
[BUGFIX] La mauvaise clé de cache est utilisée dans une des méthodes pour récupérer des épreuves depuis le cache mémoire

### DIFF
--- a/api/src/shared/infrastructure/repositories/challenge-repository.js
+++ b/api/src/shared/infrastructure/repositories/challenge-repository.js
@@ -87,7 +87,7 @@ export async function findValidatedByCompetenceId(competenceId, locale) {
 export async function findOperativeBySkills(skills, locale) {
   _assertLocaleIsDefined(locale);
   const skillIds = skills.map((skill) => skill.id);
-  const cacheKey = `findOperativeBySkillIds([${skillIds.sort()}], ${locale})`;
+  const cacheKey = `findOperativeBySkills([${skillIds.sort()}], ${locale})`;
   const findOperativeByLocaleBySkillIdsCallback = (knex) =>
     knex
       .whereRaw('?=ANY(??)', [locale, 'locales'])
@@ -102,7 +102,7 @@ export async function findOperativeBySkills(skills, locale) {
 export async function findValidatedBySkills(skills, locale) {
   _assertLocaleIsDefined(locale);
   const skillIds = skills.map((skill) => skill.id);
-  const cacheKey = `findOperativeBySkillIds([${skillIds.sort()}], ${locale})`;
+  const cacheKey = `findValidatedBySkills([${skillIds.sort()}], ${locale})`;
   const findOperativeByLocaleBySkillIdsCallback = (knex) =>
     knex
       .whereRaw('?=ANY(??)', [locale, 'locales'])


### PR DESCRIPTION
## ❄️ Problème

Le fonctionnement du cache du contenu pédagogique repose notamment sur l'utilisation appropriée des clés de cache. Ces clés doivent être des chaînes uniques pour chaque fonction + arguments.
Malheureusement une clé de cache a été doublonnée probablement lors d'un malheureux copier coller en tout probabilité.

## 🛷 Proposition
- Rétablir l'unicité des clés de cache
~~- Proposer un système moins sujet à l'erreur via une règle ESLint~~ -> à faire dans une future PR

## ☃️ Remarques

Le deuxième commit démontre le fonctionnement de la règle en laissant délibérément une erreur. L'adoption de cette solution pour rendre plus robuste l'ensemble est laissée à la discrétion des reviewers.
Aussi j'invite tout reviewer consciencieux a bien relire et améliorer au besoin l'implémentation de la règle ESLint : étant moi-même une chèvre en ESLint, j'admets avoir eu recours à un LLM pour ce code (et vu l'heure j'ai pas eu la force de relire sérieusement, vous m'en voyez navrée).

Aussi, dommage, mais les règles maison ESlint n'ont pas l'air d'être assimilées par Webstorm donc on sait qu'on viole la règle qu'après passage de linter.

edit by @HEYGUL :
je supprime les commits liés à la règle eslint qui me parait trop fragile (elle se base sur le nom de la variable).
A tester dans une autre PR : créer une règle eslint qui se base sur le fait de passer la `cacheKey` à la fonction `find`.

## 🧑‍🎄 Pour tester

S'assurer que toutes les clés de cache sont uniques.
