### PR TITLE
[TECH] Modifier le domaine de Pix Assets Manager dans les liens sur Pix Admin (PIX-21053).

### DIFF
--- a/admin/app/components/target-profiles/badge-form.gjs
+++ b/admin/app/components/target-profiles/badge-form.gjs
@@ -9,6 +9,7 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
+import ENV from 'pix-admin/config/environment';
 
 import Card from '../card';
 import Criteria from './badge-form/criteria';
@@ -95,6 +96,10 @@ export default class BadgeForm extends Component {
     });
   }
 
+  get badgeListUrl() {
+    return ENV.APP.PIX_ASSETS_MANAGER_URL + '/list/badges';
+  }
+
   <template>
     <form class="admin-form admin-form--badge-form" {{on "submit" this.submitBadgeCreation}}>
       <h2 class="badge-form__title">Création d'un badge</h2>
@@ -114,7 +119,7 @@ export default class BadgeForm extends Component {
             <p class="badge-form__information">
               <a
                 class="badge-form__information--link"
-                href="https://pix-assets-manager-tmp-poc.osc-fr1.scalingo.io/list/badges"
+                href={{this.badgeListUrl}}
                 target="_blank"
                 rel="noopener noreferrer"
               >

--- a/admin/app/components/trainings/create-or-update-training-form.gjs
+++ b/admin/app/components/trainings/create-or-update-training-form.gjs
@@ -11,6 +11,7 @@ import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 import { eq } from 'ember-truth-helpers';
 import set from 'lodash/set';
+import ENV from 'pix-admin/config/environment';
 
 import { optionsLocaleList, optionsTypeList } from '../../models/training';
 import Card from '../card';
@@ -109,6 +110,10 @@ export default class CreateOrUpdateTrainingForm extends Component {
     } finally {
       this.submitting = false;
     }
+  }
+
+  get trainingEditorLogoUrl() {
+    return ENV.APP.PIX_ASSETS_MANAGER_URL + '/list/contenu-formatif/editeur';
   }
 
   <template>
@@ -245,7 +250,7 @@ export default class CreateOrUpdateTrainingForm extends Component {
             <:label>Url du logo de l'éditeur (.svg)</:label>
           </PixInput>
           <a
-            href="https://pix-assets-manager-tmp-poc.osc-fr1.scalingo.io/list/contenu-formatif/editeur"
+            href={{this.trainingEditorLogoUrl}}
             target="_blank"
             rel="noopener noreferrer"
             class="training__logo-url-link"

--- a/admin/config/environment.js
+++ b/admin/config/environment.js
@@ -78,6 +78,7 @@ module.exports = function (environment) {
       TARGET_PROFILE_DASHBOARD_URL: process.env.TARGET_PROFILE_DASHBOARD_URL,
       CERTIFICATION_CENTER_DASHBOARD_URL: process.env.CERTIFICATION_CENTER_DASHBOARD_URL,
       USER_DASHBOARD_URL: process.env.USER_DASHBOARD_URL,
+      PIX_ASSETS_MANAGER_URL: process.env.PIX_ASSETS_MANAGER_URL,
       MAX_LEVEL: 8,
       MAX_REACHABLE_LEVEL: _getEnvironmentVariableAsNumber({
         environmentVariableName: 'MAX_REACHABLE_LEVEL',
@@ -136,7 +137,7 @@ module.exports = function (environment) {
 
     ENV.APP.rootElement = '#ember-testing';
     ENV.APP.autoboot = false;
-
+    ENV.APP.PIX_ASSETS_MANAGER_URL = 'https://example-assets.net';
     ENV['ember-cli-notifications'] = {
       clearDuration: 300,
     };

--- a/admin/sample.env
+++ b/admin/sample.env
@@ -17,6 +17,11 @@
 # default: developement
 # SOURCE_VERSION=v1.2.3
 
+# presence: optional
+# type: String
+# default: <empty>
+# PIX_ASSETS_MANAGER_URL=https://assets.pix.digital
+
 # ====
 # I18n
 # ====

--- a/admin/tests/integration/components/target-profiles/badge-form-test.gjs
+++ b/admin/tests/integration/components/target-profiles/badge-form-test.gjs
@@ -55,6 +55,9 @@ module('Integration | Component | BadgeForm', function (hooks) {
     // then
     assert.dom(screen.getByRole('checkbox', { name: "sur l'ensemble du profil cible" })).exists();
     assert.dom(screen.getByRole('checkbox', { name: 'sur une sélection de sujets du profil cible' })).exists();
+    assert
+      .dom(screen.getByRole('link', { name: 'Voir la liste des badges' }))
+      .hasAttribute('href', 'https://example-assets.net/list/badges');
   });
 
   test('it should stop creation and display error message if no criteria is selected', async function (assert) {

--- a/admin/tests/integration/components/trainings/create-or-update-training-form-test.gjs
+++ b/admin/tests/integration/components/trainings/create-or-update-training-form-test.gjs
@@ -51,6 +51,9 @@ module('Integration | Component | trainings | CreateOrUpdateTrainingForm', funct
       .exists();
     assert.dom(screen.getByRole('button', { name: 'Annuler' })).exists();
     assert.dom(screen.getByRole('button', { name: 'Créer le contenu formatif' })).exists();
+    assert
+      .dom(screen.getByRole('link', { name: 'Voir la liste des logos éditeur' }))
+      .hasAttribute('href', 'https://example-assets.net/list/contenu-formatif/editeur');
   });
 
   test('it should call onSubmit when form is valid', async function (assert) {


### PR DESCRIPTION
## ❄️ Problème
Pix Assets Manager fait peau neuve et dispose d'un tout nouveau domaine pour sa mise en PROD ✨ 
Mais sur Pix Admin, deux liens permettant au métier d'accéder à Pix Assets Manager affichent l'ancien domaine Scalingo.

## 🛷 Proposition

Modifier le domaine de Pix Assets Manager dans les liens : 
- de création d'un contenu formatif
- de création de badge

## ☃️ Remarques

On oublie l'écriture des liens en dur et on migre l'url de Pix Assets Manager dans une var d'env.
La var d'env à été ajouté en integ et en recette. Lorsque ce ticket sera mergé, un message sera envoyé aux captains pour la PROD

## 🧑‍🎄 Pour tester

Dans Pix Admin

- https://admin-pr14704.review.pix.fr/trainings/new
- Constater que le lien "Voir la liste des logos éditeur" pointe sur le nouveau domaine.
- Constater que le lien fonctionne


- https://admin-pr14704.review.pix.fr/target-profiles/108625/badges/new
- Constater que le lien "Voir la liste des badges" pointe sur le nouveau domaine.
- Constater que le lien fonctionne