### PR TITLE
[TECH] Mise à jour du wording du bandeau d'information d'envoi automatique des résultats (PIX-20964)

### DIFF
--- a/mon-pix/tests/integration/templates/assessments/checkpoint-test.gjs
+++ b/mon-pix/tests/integration/templates/assessments/checkpoint-test.gjs
@@ -30,7 +30,6 @@ module('Integration | Template | Assessments | Checkpoint', function (hooks) {
     });
   });
 
-  // module('display existing participation page', function () {
   module('sharing results banner', function () {
     test('it should display share results information banner', async function (assert) {
       // given

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1196,7 +1196,7 @@
         "label": "'<p class=\"sr-only\">'You have completed '</p>'{completionPercentage}%'<p class=\"sr-only\">' of your customised test.'</p>'"
       },
       "sharing-results": {
-        "information-banner": "By clicking on the 'Send my results' button, your results will be sent to the organiser."
+        "information-banner": "By clicking on the ‘View my results’ button, your results will be sent to the organiser."
       },
       "title": {
         "assessment-progress": "Progression",

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1192,7 +1192,7 @@
         "label": "'<p class=\"sr-only\">'Has completado el '</p>'{completionPercentage}%'<p class=\"sr-only\">' del test.'</p>'"
       },
       "sharing-results": {
-        "information-banner": "Al hacer clic en el botón «Enviar mis resultados», sus resultados se enviarán al organizador."
+        "information-banner": "Al hacer clic en el botón «Ver mis resultados», sus resultados se enviarán al organizador."
       },
       "title": {
         "assessment-progress": "Progreso",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1197,7 +1197,7 @@
         "label": "'<p class=\"sr-only\">'Vous avez effectué '</p>'{completionPercentage}%'<p class=\"sr-only\">' de votre parcours.'</p>'"
       },
       "sharing-results": {
-        "information-banner": "En cliquant sur le bouton \"J'envoie mes résultats\", vos résultats seront transmis à l'organisateur."
+        "information-banner": "En cliquant sur le bouton \"Voir mes résultats\", vos résultats seront transmis à l'organisateur."
       },
       "title": {
         "assessment-progress": "Avancement",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1196,7 +1196,7 @@
         "label": "'<p class=\"sr-only\">'Je hebt '</p>'{completionPercentage}%'<p class=\"sr-only\">' van je test voltooid.'</p>'"
       },
       "sharing-results": {
-        "information-banner": "Door op de knop \"Ik verstuur mijn resultaten\" te klikken, worden uw resultaten naar de organisator verzonden."
+        "information-banner": "Door op de knop \"Mijn resultaten bekijken\" te klikken, worden uw resultaten doorgestuurd naar de organisator."
       },
       "title": {
         "assessment-progress": "Vooruitgang",


### PR DESCRIPTION
## ❄️ Problème

Le wording du bouton du checkpoint a changé, mais pas dans la bannière d'information pour l'utilisateur.

## 🛷 Proposition

Mettre à jour le wording de la bannière.

## 🧑‍🎄 Pour tester

Commencer une participation à une campagne sans la terminer
Modifier sa date à une date antérieure à la variable d'ENV indiquant le début de l'envoi automatique des résultats
Reprendre la participation et s'arrêter au checkpoint final
Vérifier que le bandeau s'affiche avec le nouveau wording.
