### PR TITLE
[FEATURE] Ajuster les tailles de textes et les marges sur les modules (PIX-21076)

### DIFF
--- a/mon-pix/app/components/module/_normalize.scss
+++ b/mon-pix/app/components/module/_normalize.scss
@@ -6,7 +6,7 @@
   h5,
   h6,
   p {
-    margin: var(--pix-spacing-1x) 0;
+    margin: 0;
   }
 
   h4 {

--- a/mon-pix/app/components/module/_passage.scss
+++ b/mon-pix/app/components/module/_passage.scss
@@ -26,12 +26,12 @@
   &__title {
     @extend %pix-title-m;
 
-    margin: var(--pix-spacing-12x) var(--pix-spacing-2x);
+    margin: var(--pix-spacing-8x) 0;
     text-align: center;
   }
 
   &__content {
-    --modulix-grains-gap: 56px;
+    --modulix-grains-gap: var(--pix-spacing-8x);
 
     display: flex;
     flex-direction: column;

--- a/mon-pix/app/styles/pages/_module.scss
+++ b/mon-pix/app/styles/pages/_module.scss
@@ -1,7 +1,7 @@
 @use 'pix-design-tokens/typography';
 
 .modulix {
-  @extend %pix-body-l;
+  @extend %pix-body-m;
 
   --modulix-max-content-width: 820px;
   --modulix-radius-xs: 4px;


### PR DESCRIPTION
## ❄️ Contexte

Mob Design avec Pierre le 13 Janvier modifié suite aux échanges avec lui.

## 🛷 Proposition

Voici les changements apportés sur les tailles de texte :
  - Passer la font-size des textes des passages en` pix-body-m` au lieu de l
  - Titre de module: marge côtés à 0, reste en 8x au lieu de 12x
  - Titre de section: 8x de gap 
  - Dans module-passage, enlever le margin 1x qui touche les p, titres etc.

## ☃️ Remarques

- Les modifications sur les feedbacks ont été enlevées et seront faites sur une autre PR.
- Pierre est en train de finir des maquettes sur les nouveaux feedbacks, où les couleurs et boutons "Signaler" et "Réessayer" vont aussi changer.
- On va voir pour faire passer pix-app à la version 56 de pix-ui rapidement. Pix-ui va en effet bientôt contenir les nouvelles tailles de typo, utiles pour Modulix.

## 🧑‍🎄 Pour tester

- Ouvrir un [module](https://app-pr14707.review.pix.fr/modules/preview/ia-def-ind)
- Constater le nouveau rendu
