### PR TITLE
[BUGFIX] [Pix Orga] Modifier le style du bloc d'invitation (PIX-21013)

### DIFF
--- a/high-level-tests/e2e/cypress/support/step_definitions/member.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/member.js
@@ -6,7 +6,7 @@ When(`je saisis l'URL de l'invitation`, () => {
 });
 
 Then(`je suis redirigé vers la page pour rejoindre l'organisation`, () => {
-  cy.get(".pix-notification-alert").should("contain", "Vous êtes invité(e) à rejoindre");
+  cy.get(".invitation-banner").should("contain", "Vous êtes invité(e) à rejoindre");
 });
 
 When(`je clique sur s'inscrire sur Pix`, () => {

--- a/orga/app/components/banner/invitation-banner.gjs
+++ b/orga/app/components/banner/invitation-banner.gjs
@@ -1,0 +1,7 @@
+import { t } from 'ember-intl';
+
+<template>
+  <div class="invitation-banner">
+    {{t "pages.login.join-invitation" organizationName=@organizationName}}
+  </div>
+</template>

--- a/orga/app/styles/components/banner/index.scss
+++ b/orga/app/styles/components/banner/index.scss
@@ -1,2 +1,3 @@
 @use 'top-banners';
-@use 'sco-communication'
+@use 'sco-communication';
+@use 'invitation-banner';

--- a/orga/app/styles/components/banner/invitation-banner.scss
+++ b/orga/app/styles/components/banner/invitation-banner.scss
@@ -1,0 +1,12 @@
+@use 'pix-design-tokens/typography';
+
+.invitation-banner {
+  @extend %pix-title-xxs;
+
+  padding: var(--pix-spacing-3x) var(--pix-spacing-4x);
+  color: var(--pix-neutral-0);
+  background-color: var(--pix-orga-500);
+  border: 1px solid currentcolor;
+  border-color: var(--pix-orga-500);
+  border-radius: var(--pix-spacing-2x);
+}

--- a/orga/app/templates/authentication/oidc/login.gjs
+++ b/orga/app/templates/authentication/oidc/login.gjs
@@ -1,9 +1,9 @@
 import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
-import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
 import t from 'ember-intl/helpers/t';
 import pageTitle from 'ember-page-title/helpers/page-title';
 import LoginForm from 'pix-orga/components/authentication/login-form';
 import AuthenticationLayout from 'pix-orga/components/authentication-layout/index';
+import InvitationBanner from 'pix-orga/components/banner/invitation-banner';
 
 <template>
   {{pageTitle (t "pages.login.title")}}
@@ -14,9 +14,7 @@ import AuthenticationLayout from 'pix-orga/components/authentication-layout/inde
 
     <:content>
       {{#if @controller.currentInvitation}}
-        <PixNotificationAlert @type="communication-orga">
-          {{t "pages.login.join-invitation" organizationName=@controller.currentInvitation.organizationName}}
-        </PixNotificationAlert>
+        <InvitationBanner @organizationName={{@controller.currentInvitation.organizationName}} />
       {{/if}}
 
       <div>

--- a/orga/app/templates/authentication/oidc/signup.gjs
+++ b/orga/app/templates/authentication/oidc/signup.gjs
@@ -4,16 +4,14 @@ import t from 'ember-intl/helpers/t';
 import pageTitle from 'ember-page-title/helpers/page-title';
 import OidcSignupForm from 'pix-orga/components/authentication/oidc-signup-form';
 import AuthenticationLayout from 'pix-orga/components/authentication-layout/index';
-
+import InvitationBanner from 'pix-orga/components/banner/invitation-banner';
 <template>
   {{pageTitle (t "pages.oidc.signup.title")}}
 
   <AuthenticationLayout class="signin-page-layout">
     <:content>
       {{#if @controller.currentInvitation}}
-        <PixNotificationAlert @type="communication-orga">
-          {{t "pages.login.join-invitation" organizationName=@controller.currentInvitation.organizationName}}
-        </PixNotificationAlert>
+        <InvitationBanner @organizationName={{@controller.currentInvitation.organizationName}} />
       {{/if}}
 
       <div>

--- a/orga/app/templates/authentication/sso-selection.gjs
+++ b/orga/app/templates/authentication/sso-selection.gjs
@@ -1,9 +1,9 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
 import t from 'ember-intl/helpers/t';
 import pageTitle from 'ember-page-title/helpers/page-title';
 import SsoSelectionForm from 'pix-orga/components/authentication/sso-selection-form';
 import AuthenticationLayout from 'pix-orga/components/authentication-layout/index';
+import InvitationBanner from 'pix-orga/components/banner/invitation-banner';
 
 <template>
   {{#if @controller.isForSignup}}
@@ -21,9 +21,7 @@ import AuthenticationLayout from 'pix-orga/components/authentication-layout/inde
 
     <:content>
       {{#if @model.organizationName}}
-        <PixNotificationAlert @type="communication-orga">
-          {{t "pages.login.join-invitation" organizationName=@model.organizationName}}
-        </PixNotificationAlert>
+        <InvitationBanner @organizationName={{@model.organizationName}} />
       {{/if}}
 
       {{#if @controller.isForSignup}}

--- a/orga/app/templates/join/index.gjs
+++ b/orga/app/templates/join/index.gjs
@@ -1,10 +1,10 @@
 import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
-import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
 import t from 'ember-intl/helpers/t';
 import pageTitle from 'ember-page-title/helpers/page-title';
 import AuthenticationIdentityProviders from 'pix-orga/components/authentication/authentication-identity-providers';
 import LoginForm from 'pix-orga/components/authentication/login-form';
 import AuthenticationLayout from 'pix-orga/components/authentication-layout/index';
+import InvitationBanner from 'pix-orga/components/banner/invitation-banner';
 
 <template>
   {{pageTitle (t "pages.login-or-register.title" organizationName=@model.organizationName)}}
@@ -17,9 +17,7 @@ import AuthenticationLayout from 'pix-orga/components/authentication-layout/inde
     </:header>
 
     <:content>
-      <PixNotificationAlert @type="communication-orga">
-        {{t "pages.login.join-invitation" organizationName=@model.organizationName}}
-      </PixNotificationAlert>
+      <InvitationBanner @organizationName={{@model.organizationName}} />
 
       <div>
         <h1 class="pix-title-m">{{t "pages.login.title"}}</h1>

--- a/orga/app/templates/join/signup.gjs
+++ b/orga/app/templates/join/signup.gjs
@@ -1,9 +1,9 @@
 import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
-import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
 import t from 'ember-intl/helpers/t';
 import pageTitle from 'ember-page-title/helpers/page-title';
 import AuthenticationIdentityProviders from 'pix-orga/components/authentication/authentication-identity-providers';
 import AuthenticationLayout from 'pix-orga/components/authentication-layout/index';
+import InvitationBanner from 'pix-orga/components/banner/invitation-banner';
 
 import SignupForm from '../../components/authentication/signup-form/index';
 
@@ -18,9 +18,7 @@ import SignupForm from '../../components/authentication/signup-form/index';
     </:header>
 
     <:content>
-      <PixNotificationAlert @type="communication-orga">
-        {{t "pages.login.join-invitation" organizationName=@model.organizationName}}
-      </PixNotificationAlert>
+      <InvitationBanner @organizationName={{@model.organizationName}} />
 
       <div>
         <h1 class="pix-title-m">{{t "pages.join.signup.title"}}</h1>


### PR DESCRIPTION
## ❄️ Problème

Le bloc d’invitation à Pix Orga n’a pas le bon style. Actuellement cela donne :

<img width="671" height="69" alt="avant" src="https://github.com/user-attachments/assets/0dbee088-3de2-41e6-b71d-c69609839a35" />

## 🛷 Proposition

Conformément aux recommandations du Design, pour le bloc d’invitation à Pix Orga ne plus utiliser le composant `PixNotificationAlert` mais définir un composant dédié. En effet le style du bloc d’invitation à Pix Orga ressemble au style du composant `PixNotificationAlert`, mais est volontairement différent et distinct. Il ne faut donc pas chercher à faire évoluer le style de `PixNotificationAlert` mais créer un nouveau composant `InvitationBanner` dédié avec son style dédié.

Et voici le style obtenu avec cette PR : 

<img width="671" height="84" alt="après" src="https://github.com/user-attachments/assets/526924aa-7b33-451f-a612-7ca436a939e0" />

## ☃️ Remarques

RAS

## 🧑‍🎄 Pour tester

Vérifier que l’affichage du bloc d’invitation à Pix Orga est correct dans tous les cas où ce bloc apparait.

**Rejoindre via login / mot de passe**
- Cliquer sur une invitation valide
  - _Voir l'alerte bleu de l'invitation à l'orga sur la page de connexion_

**Rejoindre via inscription login / mot de passe**
- Cliquer sur une invitation valide
- Cliquer sur s'inscrire
  - _Voir l'alerte bleu de l'invitation à l'orga sur la page d'inscription_

**Rejoindre via SSO et lié un compte login / mot de passe**
- Cliquer sur une invitation valide
- Cliquer sur "Choisir un autre moyen de connexion"
  - _Voir l'alerte bleu de l'invitation à l'orga_
- Sélectionner "Pro Connect"
- Se connecter via "Pro Connect"
  - _Vous êtes redirigé sur la page d'association_
  - _Voir l'alerte bleu de l'invitation à l'orga_

**Rejoindre via SSO et créé un nouveau compte**
- Cliquer sur une invitation valide
- Cliquer sur "Choisir un autre moyen de connexion"
  - _Voir l'alerte bleu de l'invitation à l'orga_
- Sélectionner "Pro Connect"
- Se connecter via "Pro Connect"
- Créer un nouveau compte
  - _Vous êtes redirigé sur la page d'association_
  - _Voir l'alerte bleu de l'invitation à l'orga_

