### PR TITLE
[TECH] Ajouter les codeowners pour les dossiers de seeds

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,7 @@
 
 # Directories maintained by team Devcomp
 # @1024pix/devcomp owns any file in the `/api/src/devcomp/` directory in the root of your repository and any of its subdirectories.
+/api/db/seeds/data/team-devcomp/ @1024pix/team-devcomp
 /api/scripts/modulix/ @1024pix/team-devcomp
 /api/src/devcomp/application/ @1024pix/team-devcomp
 /api/src/devcomp/domain/ @1024pix/team-devcomp
@@ -25,27 +26,31 @@
 
 
 # Directories maintained by team Certification
+/api/db/seeds/data/team-certification/ @1024pix/team-certification
 /api/src/certification/ @1024pix/team-certification
 /api/tests/certification/ @1024pix/team-certification
 
-
 # Directories maintained by team Evaluation
+/api/db/seeds/data/team-evaluation/ @1024pix/team-evaluation
 /api/src/evaluation/ @1024pix/team-evaluation
 /api/tests/evaluation/ @1024pix/team-evaluation
 
 
 # Directories maintained by team Prescription
+/api/db/seeds/data/team-prescription/ @1024pix/team-prescription
 /api/src/prescription/ @1024pix/team-prescription
 /api/tests/prescription/ @1024pix/team-prescription
 
 
 # Directories maintained by team Junior
+/api/db/seeds/data/team-1d/ @1024pix/team-junior
 /api/src/school/ @1024pix/team-junior
 /api/tests/school/ @1024pix/team-junior
 
 
 # Directories maintained by team Accès
 /audit-logger/ @1024pix/team-acces
+/api/db/seeds/data/team-acces/ @1024pix/team-acces
 /api/src/shared/domain/models/jobs/EventLoggingJob.js @1024pix/team-acces
 /api/src/shared/application/jobs/event-logging.job-controller.js @1024pix/team-acces
 /api/src/shared/infrastructure/repositories/jobs/event-logging-job.repository.js @1024pix/team-acces


### PR DESCRIPTION
## ❄️ Problème
Actuellement, quand on met à jours les seeds d'une autre équipe, la PR n'utilise pas les code owners pour ping les team correspondantes

## 🛷 Proposition
Ajouter les équipes au fichier de codeowners pour les dossiers des seeds

## ☃️ Remarques

## 🧑‍🎄 Pour tester
Constater lors de futurs PR de l'ajout des codeowners lorsqu'on modifie les seeds d'une autre team
