### PR TITLE
[TECH] Réparer la fin d'exécution de redis au refresh cache

### DIFF
--- a/api/scripts/refresh-cache.js
+++ b/api/scripts/refresh-cache.js
@@ -19,6 +19,10 @@ export class RefreshCache extends Script {
       logger.error('Error while reloading cache');
     }
   }
+
+  async onFinished() {
+    process.exit(process.exitCode || 0); // eslint-disable-line n/no-process-exit
+  }
 }
 
 await ScriptRunner.execute(import.meta.url, RefreshCache);


### PR DESCRIPTION
## ❄️ Problème

Il était courant d'avoir des erreurs `Error: Connection is closed.` lors de lancement du script `npm run cache:refresh`.
Surtout au lancement des tests e2e Playwright.

## 🛷 Proposition

Forcer la fin d'exécution du script de refresh cache à sa finalisation.

## 🧑‍🎄 Pour tester

✅ CI ok
