### PR TITLE
[BUGFIX] Les vidéos courtes ne se lancent pas en preview 🔮 (PIX-20985)

### DIFF
--- a/mon-pix/app/components/module/element/short-video.gjs
+++ b/mon-pix/app/components/module/element/short-video.gjs
@@ -37,7 +37,7 @@ export default class ModulixShortVideoElement extends ModuleElement {
 
   <template>
     <div class="element-short-video">
-      <video class="element-short-video__video" autoplay loop muted src={{@element.url}}></video>
+      <video class="element-short-video__video" autoplay loop muted={{true}} src={{@element.url}}></video>
       <PixButton @variant="tertiary" @triggerAction={{this.showModal}}>
         {{t "pages.modulix.buttons.element.transcription"}}
       </PixButton>

--- a/mon-pix/tests/integration/components/module/element/short-video_test.gjs
+++ b/mon-pix/tests/integration/components/module/element/short-video_test.gjs
@@ -16,7 +16,7 @@ module('Integration | Component | Module | ShortVideo', function (hooks) {
     // then
     assert.dom('video').hasAttribute('autoplay');
     assert.dom('video').hasAttribute('loop');
-    assert.dom('video').hasAttribute('muted');
+    assert.dom('video').doesNotHaveAttribute('muted');
   });
 
   test('it should display a video element with src attribute', async function (assert) {


### PR DESCRIPTION
## ❄️ Problème

Les vidéos courtes ne se lancent pas automatiquement en preview. Elles ne sont pas considérées comme "en sourdine" (muted) ce qui est obligatoire pour qu'une vidéo se lance automatiquement.

Le problème semble être dû au fait que l'attribut `muted=""` sous cette forme est ignoré. C'est pourtant le HTML qui est rendu par Ember quand on inclut l'attribut `muted` dans le template HBS. 

Si on sélectionne l'élément `video` avec l'inspecteur et qu'on entre `$0.muted` dans la console, le résultat est `false`.  Pourquoi ? Mystère 🔮

## 🛷 Proposition

Écrire l'argument `muted` sous la forme `muted={{true}}`. Dans ce cas, l'attribut `muted=""` n'apparaît plus dans le HTML rendu mais il est bien pris en compte (`$0.muted` renvoie `true`) et la vidéo se lancent bien automatiquement. Pourquoi ? Le mystère s'épaissit 🔮🔮

## ☃️ Remarques

- Le problème ne semble pas affecter les autres attributs (`autoplay`, `loop`) pour lesquels cette manipulation n'est pas nécessaire.
- Le problème ne semble affecter que la preview et pas les modules en mode normal.

Pourquoi ? Le mystère est total 🔮🔮🔮

<img src="https://i.makeagif.com/media/11-05-2015/FvahvF.gif" alt="Dramatic look and cool cat" />

## 🧑‍🎄 Pour tester

1. Accéder à un module en mode preview
2. Vérifier que les vidéos courtes se lancent automatiquement 
