### PR TITLE
[TECH] Créer test e2e d'accessibilité d'un module, avec playwright (PIX-20984)

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/galerie.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/galerie.json
@@ -10,9 +10,7 @@
     "description": "<p>Ce module est dédié à des tests internes à Pix.</p><p>Il permet de visualiser tous les modules existants.</p>",
     "duration": 1,
     "level": "novice",
-    "objectives": [
-      "<p>Découvrir les éléments de la galerie Modulix</p>"
-    ],
+    "objectives": ["<p>Découvrir les éléments de la galerie Modulix</p>"],
     "tabletSupport": "comfortable"
   },
   "sections": [
@@ -60,72 +58,45 @@
               "element": {
                 "id": "496a2f21-ea99-41ac-9d0a-84133c1f42ce",
                 "type": "text",
-                "content": "<p><strong>custom</strong></p>\n<p>Il permet d'afficher un POIP.</p>"
+                "content": "<p><strong>custom</strong></p>\n<p>Il permet d'afficher un POI.</p>"
               }
             },
             {
               "type": "element",
               "element": {
-                "id": "fe68ec1f-acca-4bb5-902b-9f9a6a5b3ca9",
+                "id": "8b29cafe-f978-4e3c-967d-6b32660eb273",
                 "type": "custom",
                 "instruction": "",
-                "tagName": "message-conversation",
+                "tagName": "llm-messages",
                 "props": {
-                  "title": "Confessions nocturnes",
                   "messages": [
                     {
-                      "userName": "Mel",
-                      "direction": "outgoing",
-                      "type": "Texte",
-                      "content": "Ouais c'est qui là ?"
+                      "direction": "outbound",
+                      "content": "Bonjour"
                     },
                     {
-                      "userName": "Vita",
-                      "direction": "incoming",
-                      "type": "Texte",
-                      "content": "Mel, c'est Vi ouvre moi."
+                      "direction": "inbound",
+                      "content": "<strong>Bonjour,</strong> je m’appelle ChatPix !<br>Comment puis-je vous aider aujourd’hui ?<br>Avez-vous, par pur hasard, besoin d’une recette de cookie géant ?"
                     },
                     {
-                      "userName": "Mel",
-                      "direction": "outgoing",
-                      "type": "Texte",
-                      "content": "Ça va Vi ?"
+                      "direction": "outbound",
+                      "content": "Pourquoi pas..."
                     },
                     {
-                      "userName": "Mel",
-                      "direction": "outgoing",
-                      "type": "Texte",
-                      "content": "T'as l'air bizarre. Qu'est ce qu'il y a ?"
+                      "direction": "inbound",
+                      "content": "Pour faire un cookie géant, prenez une recette de cookie, et multipliez toutes les doses par 10.<br>Ensuite, au lieu de faire des petits tas de pate, faites un gros tas de pate sur votre plaque de cuisson.<br><strong>Bon appétit ! 🍪✨</strong>"
                     },
                     {
-                      "userName": "Vita",
-                      "direction": "incoming",
-                      "type": "Texte",
-                      "content": "Non, ça va pas non."
+                      "direction": "outbound",
+                      "content": "Elle est bizarre ta recette."
                     },
                     {
-                      "userName": "Mel",
-                      "direction": "outgoing",
-                      "type": "Texte",
-                      "content": "Ben dis-moi, qu'est qu'il y a ?"
+                      "direction": "inbound",
+                      "content": "Désolé si ma recette ne vous plaît pas, souhaitez-vous une recette différente ?"
                     },
                     {
-                      "userName": "Vita",
-                      "direction": "incoming",
-                      "type": "Texte",
-                      "content": "Mel, assieds-toi faut que je te parle..."
-                    },
-                    {
-                      "userName": "Vita",
-                      "direction": "incoming",
-                      "type": "Texte",
-                      "content": "J'ai passé ma journée dans le noir."
-                    },
-                    {
-                      "userName": "Vita",
-                      "direction": "incoming",
-                      "type": "Texte",
-                      "content": "Mel, je le sens, je le sais, je le suis, il se fout de moi..."
+                      "direction": "outbound",
+                      "content": "Non, je m'en vais."
                     }
                   ]
                 }
@@ -199,9 +170,9 @@
                 "id": "f36ee13e-cd41-4aef-97fa-4e1e0ade5169",
                 "type": "embed",
                 "isCompletionRequired": false,
-                "title": "Simulateur de visioconférence",
-                "url": "https://epreuves.pix.fr/visio/visio.html?mode=visio3",
-                "instruction": "<p>Vous participez à la visioconférence ci-dessous.</p>",
+                "title": "QCM image",
+                "url": "https://epreuves.pix.fr/fr/qcm_image/example.html",
+                "instruction": "<p>Un QCM avec des images</p>",
                 "height": 600
               }
             }
@@ -598,11 +569,7 @@
                     "diagnosis": "<p> Pix sert à évaluer, certifier et développer ses compétences numériques.</p>"
                   }
                 },
-                "solutions": [
-                  "1",
-                  "3",
-                  "4"
-                ]
+                "solutions": ["1", "3", "4"]
               }
             }
           ]
@@ -640,13 +607,8 @@
                     "placeholder": "",
                     "ariaLabel": "Mot à trouver",
                     "defaultValue": "",
-                    "tolerances": [
-                      "t1",
-                      "t3"
-                    ],
-                    "solutions": [
-                      "Groupement"
-                    ]
+                    "tolerances": ["t1", "t3"],
+                    "solutions": ["Groupement"]
                   },
                   {
                     "type": "text",
@@ -662,9 +624,7 @@
                     "ariaLabel": "Année à trouver",
                     "defaultValue": "",
                     "tolerances": [],
-                    "solutions": [
-                      2016
-                    ]
+                    "solutions": [2016]
                   }
                 ],
                 "feedbacks": {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/galerie.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/galerie.json
@@ -501,6 +501,53 @@
           ]
         },
         {
+          "id": "3e553e69-d451-4a2a-b6e8-8bc70917f2b7",
+          "type": "challenge",
+          "title": "qcu-discovery",
+        "components": [
+          {
+            "type": "element",
+            "element": {
+              "id": "cc995548-b3d4-4fd6-a974-d5c969c920d6",
+              "type": "text",
+              "content": "<p><strong>qcu-discovery</strong></p><p>Il permet d'afficher une question à choix unique pour découvrir une notion pédagogique.</p>"
+            }
+          },
+          {
+            "type": "element",
+            "element": {
+              "id": "f40e5a81-271b-492c-9f63-9f4a50829279",
+              "type": "qcu-discovery",
+              "instruction": "<p>Pourquoi ce module galerie est très pertinent ?</p>",
+              "proposals": [
+                {
+                  "id": "1",
+                  "content": "Pour connaître l'ensemble des modalités disponibles pour rédiger un module",
+                  "feedback": {
+                    "diagnosis": "<p>Exactement ! En une page, on a accès à toutes les possibilités de modalités que propose Modulix.</p>"
+                  }
+                },
+                {
+                  "id": "2",
+                  "content": "Pour faire semblant de travailler quand je suis sur mon ordinateur",
+                  "feedback": {
+                    "diagnosis": "<p>Eh non, tout le monde verra quand même que vous ne travaillez pas.</p>"
+                  }
+                },
+                {
+                  "id": "3",
+                  "content": "Pour améliorer mes compétences numériques",
+                  "feedback": {
+                    "diagnosis": "<p>Eh non, il n'y a aucune notion pédagogique dans ce module !</p>"
+                  }
+                }
+              ],
+              "solution": "1"
+            }
+          }
+        ]
+        },
+        {
           "id": "3003eabf-e49a-43c9-8962-332bf989149a",
           "type": "challenge",
           "title": "qcm",

--- a/high-level-tests/e2e-playwright/README.md
+++ b/high-level-tests/e2e-playwright/README.md
@@ -15,7 +15,10 @@ npx playwright install --with-deps chromium
 
 ## Pré-requis
 
-Vous devez avoir démarré les conteneurs Docker Pix au préalable : `docker compose up` (à la racine du monorepo)
+- Démarrer les conteneurs Docker Pix au préalable : `docker compose up` (à la racine du monorepo)
+- Copier le fichier `sample.env.e2e` dans le dossier `e2e-playwright` sous le nom `.env.e2e`
+- Renseigner les variables d'environnement `LCMS_API_KEY` et `LCMS_API_URL` (NINA)
+- Installer les dépendances de l'API et des front : `npm run ci:all` (à la racine du monorepo)
 
 ## Exécuter en mode Headless
 

--- a/high-level-tests/e2e-playwright/tests/pix-app/modulix-a11y.test.ts
+++ b/high-level-tests/e2e-playwright/tests/pix-app/modulix-a11y.test.ts
@@ -1,0 +1,93 @@
+import AxeBuilder from '@axe-core/playwright';
+
+import { expect, test } from '../../helpers/fixtures.js';
+
+test('test modulix-a11y', async ({ page }) => {
+  await page.goto('http://localhost:4200/modules/b9414fc3/galerie/details');
+  await page.getByRole('button', { name: 'Commencer le module' }).click();
+  await page.getByRole('button', { name: 'Continuer' }).click();
+  await page.getByRole('button', { name: 'Continuer' }).click();
+
+  // Issue-report modal
+  //await page.getByRole('button', { name: 'Envoyer un problème ou une' }).click();
+  //await page.getByRole('button', { name: 'Raison du signalement' }).click();
+  //await page.getByRole('option', { name: 'Le simulateur / l’application' }).click();
+  //await page.getByRole('textbox', { name: 'Commentaire' }).click();
+  //await page.getByRole('textbox', { name: 'Commentaire' }).fill('Ca ne marche pas.');
+  //await page.getByRole('button', { name: 'Envoyer', exact: true }).click();
+  //await page.getByRole('button', { name: 'Fermer' }).nth(1).click();
+  await page.getByRole('button', { name: 'Continuer' }).click();
+  await page.getByRole('button', { name: 'Continuer' }).click();
+  await page.getByRole('button', { name: 'Continuer' }).click();
+  await page.getByRole('button', { name: 'Continuer' }).click();
+
+  // Expand
+  await page.getByText('Clique-moi pour en savoir').click();
+  await page.getByRole('button', { name: 'Continuer' }).click();
+
+  // Flashcards
+  await test.step('flashcards', async () => {
+    await page.getByRole('button', { name: 'Commencer', exact: true }).click();
+    await page.getByRole('button', { name: 'Voir la réponse' }).click();
+    await page.getByRole('button', { name: 'Presque' }).click();
+    await page.getByRole('button', { name: 'Voir la réponse' }).click();
+    await page.getByRole('button', { name: 'Oui !' }).click();
+    await page.getByRole('button', { name: 'Voir la réponse' }).click();
+    await page.getByRole('button', { name: 'Pas du tout' }).click();
+    await page.getByRole('button', { name: 'Continuer' }).click();
+  });
+
+  // Display modal for alternative text of image element
+  await page.getByRole('button', { name: "Afficher l'alternative" }).click();
+  await page.getByRole('button', { name: 'Fermer' }).click();
+  await page.getByRole('button', { name: 'Continuer' }).click();
+
+  // QAB
+  await test.step('qab', async () => {
+    await page.getByRole('button', { name: 'Option A: Vrai' }).click();
+    await page.getByRole('button', { name: 'Option B: Faux' }).click();
+    await page.getByRole('button', { name: 'Option B: Faux' }).click();
+    await page.getByRole('button', { name: 'Passer l’activité' }).click();
+  });
+
+  // QCU
+  await test.step('qcu', async () => {
+    await page.getByLabel('Des recettes de lasagne').click();
+    await page.getByRole('button', { name: 'Vérifier ma réponse' }).click();
+    await page.waitForSelector('role=status');
+    page.getByLabel('Incorrect.');
+    await page.getByRole('button', { name: 'Réessayer' }).nth(1).click();
+    await page.getByLabel('Des recettes végétariennes').click();
+    await page.getByRole('button', { name: 'Vérifier ma réponse' }).click();
+    await page.waitForSelector('role=status');
+    page.getByLabel('Correct!');
+    await page.getByRole('button', { name: 'Continuer' }).click();
+  });
+
+  // QCU Declarative
+  await page.getByRole('button', { name: 'Après avoir mis le dentifrice' }).click();
+  await page.getByRole('button', { name: 'Continuer' }).click();
+
+  // QCU Discovery
+  await page.getByRole('button', { name: "Pour connaître l'ensemble des" }).click();
+  await page.waitForSelector('role=status');
+  await page.getByRole('button', { name: 'Continuer' }).click();
+
+  // QCM
+  await test.step('qcm', async () => {
+    await page.getByLabel('Évaluer ses connaissances et').click();
+    await page.getByText('Développer ses compétences').click();
+    await page.getByLabel('Certifier ses compétences Pix').click();
+    await page.getByRole('button', { name: 'Vérifier ma réponse' }).click();
+    await page.waitForSelector('role=status');
+    page.getByLabel('Correct!');
+    await page.getByRole('button', { name: 'Continuer' }).click();
+    await page.getByRole('button', { name: 'Passer l’activité' }).click();
+    await page.getByRole('button', { name: 'Continuer' }).click();
+  });
+
+  const accessibilityScanResults = await new AxeBuilder({ page }).analyze();
+  expect(accessibilityScanResults.violations).toEqual([]);
+
+  await page.getByRole('button', { name: 'Terminer' }).click();
+});

--- a/mon-pix/app/components/module/element/flashcards/_flashcards-card.scss
+++ b/mon-pix/app/components/module/element/flashcards/_flashcards-card.scss
@@ -142,15 +142,15 @@
     font-weight: var(--pix-font-bold);
 
     &__yes {
-      color: var(--pix-success-500);
+      color: var(--pix-success-700);
     }
 
     &__almost {
-      color: var(--pix-warning-500);
+      color: var(--pix-warning-700);
     }
 
     &__no {
-      color: var(--pix-error-500);
+      color: var(--pix-error-700);
     }
   }
 }


### PR DESCRIPTION
## ❄️ Problème

Précédemment, on avait un test avec Cypress pour tester l'accessibilité du module galerie. Celui-ci était très flaky et a été supprimé dans [cette PR](https://github.com/1024pix/pix/pull/14521)

## 🛷 Proposition

- Créer un nouveau test a11y mais en utilisant Playwright : modulix-a11y.tests.ts
- Celui-ci utilise le module _galerie_

**Documentation**
- [getByRole](https://playwright.dev/docs/locators#locate-by-role) de Playwright, méthode asynchrone 
- J'ai utilisé la commande `npx generate codegen`pour enregistrer le parcours d'un module entier dans un navigateur, et ainsi générer le code du test pour Playwright

## ☃️ Remarques

- On a remplacé le simulateur `video3` par un simulateur qui ne génère pas d'erreur a11y (on n'a pas la main sur les simulateurs, c'est côté dev-contenu). De même, le POI a été changé.
- Le feature toggle `isModulixIssueReportDisplayed = false` empêche de mettre la modale de signalement dans le test. On a donc commenté la partie qui concerne le parcours de la modale, à décommenter quand on enlèvera le FT.
- J'en ai profité pour ajouter un `qcu-discovery`dans le module galerie

## 🧑‍🎄 Pour tester

- CI au vert 🍏 
