### PR TITLE
[BUGFIX] La rétrocompatibilité de la migration du statut endedBySupervisor vers endedByInvigilator n'était pas complète (PIX-21096)

### DIFF
--- a/admin/app/components/certifications/certification/details-v3.gjs
+++ b/admin/app/components/certifications/certification/details-v3.gjs
@@ -80,6 +80,10 @@ const assessmentStateMap = {
     label: 'pages.certifications.certification.details.v3.assessment-state.ended-by-invigilator',
     color: secondaryColor,
   },
+  ['endedBySupervisor']: {
+    label: 'pages.certifications.certification.details.v3.assessment-state.ended-by-invigilator',
+    color: secondaryColor,
+  },
   [assessmentStates.ENDED_DUE_TO_FINALIZATION]: {
     label: 'pages.certifications.certification.details.v3.assessment-state.ended-due-to-finalization',
     color: tertiaryColor,

--- a/admin/app/components/sessions/certifications/status.gjs
+++ b/admin/app/components/sessions/certifications/status.gjs
@@ -8,6 +8,7 @@ export default class CertificationStatusComponent extends Component {
       assessmentStates.STARTED,
       assessmentResultStatus.ERROR,
       assessmentStates.ENDED_BY_INVIGILATOR,
+      'endedBySupervisor',
     ];
     return includes(blockingStatuses, this.args.record.status) || this.args.record.isFlaggedAborted;
   }

--- a/admin/app/models/v3-certification-course-details-for-administration.js
+++ b/admin/app/models/v3-certification-course-details-for-administration.js
@@ -36,7 +36,9 @@ export default class V3CertificationCourseDetailsForAdministration extends Model
   }
 
   get wasEndedByInvigilator() {
-    return this.assessmentState === assessmentStates.ENDED_BY_INVIGILATOR;
+    return (
+      this.assessmentState === assessmentStates.ENDED_BY_INVIGILATOR || this.assessmentState === 'endedBySupervisor'
+    );
   }
 
   get wasCompleted() {
@@ -79,8 +81,10 @@ export default class V3CertificationCourseDetailsForAdministration extends Model
   }
 
   get hasNotBeenCompletedByCandidate() {
-    return [assessmentStates.ENDED_BY_INVIGILATOR, assessmentStates.ENDED_DUE_TO_FINALIZATION].includes(
-      this.assessmentState,
-    );
+    return [
+      'endedBySupervisor',
+      assessmentStates.ENDED_BY_INVIGILATOR,
+      assessmentStates.ENDED_DUE_TO_FINALIZATION,
+    ].includes(this.assessmentState);
   }
 }

--- a/api/src/certification/session-management/domain/models/CertificationAssessment.js
+++ b/api/src/certification/session-management/domain/models/CertificationAssessment.js
@@ -28,6 +28,7 @@ const certificationAssessmentSchema = Joi.object({
       Assessment.states.STARTED,
       Assessment.states.ENDED_BY_INVIGILATOR,
       Assessment.states.ENDED_DUE_TO_FINALIZATION,
+      'endedBySupervisor',
     )
     .required(),
   version: Joi.number()

--- a/api/src/certification/session-management/infrastructure/repositories/jury-certification-summary-repository.js
+++ b/api/src/certification/session-management/infrastructure/repositories/jury-certification-summary-repository.js
@@ -139,7 +139,9 @@ function _toDomain(juryCertificationSummaryDTO) {
   return new JuryCertificationSummary({
     ...juryCertificationSummaryDTO,
     status: juryCertificationSummaryDTO.assessmentResultStatus,
-    isEndedByInvigilator: juryCertificationSummaryDTO.assessmentState === Assessment.states.ENDED_BY_INVIGILATOR,
+    isEndedByInvigilator:
+      juryCertificationSummaryDTO.assessmentState === Assessment.states.ENDED_BY_INVIGILATOR ||
+      juryCertificationSummaryDTO.assessmentState === 'endedBySupervisor',
     certificationIssueReports,
   });
 }

--- a/certif/app/models/certification-candidate-for-supervising.js
+++ b/certif/app/models/certification-candidate-for-supervising.js
@@ -33,7 +33,9 @@ export default class CertificationCandidateForSupervising extends Model {
   }
 
   get hasCompleted() {
-    return [assessmentStates.COMPLETED, assessmentStates.ENDED_BY_INVIGILATOR].includes(this.assessmentStatus);
+    return [assessmentStates.COMPLETED, assessmentStates.ENDED_BY_INVIGILATOR, 'endedBySupervisor'].includes(
+      this.assessmentStatus,
+    );
   }
 
   get hasOngoingChallengeLiveAlert() {

--- a/mon-pix/app/controllers/authenticated/certifications/results.js
+++ b/mon-pix/app/controllers/authenticated/certifications/results.js
@@ -3,7 +3,10 @@ import { assessmentStates } from 'mon-pix/models/assessment';
 
 export default class CertificationResultsController extends Controller {
   get isEndedByInvigilator() {
-    return this.model.assessment.get('state') === assessmentStates.ENDED_BY_INVIGILATOR;
+    return (
+      this.model.assessment.get('state') === assessmentStates.ENDED_BY_INVIGILATOR ||
+      this.model.assessment.get('state') === 'endedBySupervisor'
+    );
   }
 
   get hasBeenEndedDueToFinalization() {


### PR DESCRIPTION
## ❄️ Problème

La migration du texte sur statut qualifiant un assessment ayant été terminé par le surveillant de la session est en cours.
Pendant cette durée, il faut s'assurer que les deux valeurs fonctionnent.
Malheureusement on a oublié certains endroits 😬 
Bugs causés :
- Erreur d'affichage sur l'espace surveillant pour un assessment avec "endedBySupervisor"
- Erreur lors du chargement de la timeline du candidat sur PixAdmin (sessions > candidats > cliquer sur le candidat)
- Erreur lors de la finalisation de la session

## 🛷 Proposition

S'assurer de la rétrocompatibilité du truc en mettant (probablement plus que de raison) partout où on a trouvé de la logique autour de la valeur 'endedByInvigilator" une équivalence avec "endedBySupervisor"

## ☃️ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🧑‍🎄 Pour tester

Tester en local :
- atteindre jusqu'à passer une certif avec un user
- ne pas finir
- terminer la certif via l'espace surveillant
- changer en BDD la valeur de l'assesment.state à endedBySupervisor
- ne plus reproduire les bugs mentionnés plus haut
