### PR TITLE
PR de test pour le Pix Navigation réduit sur Pix Admin

### DIFF
--- a/admin/app/components/certification-centers/list-items.gjs
+++ b/admin/app/components/certification-centers/list-items.gjs
@@ -1,9 +1,9 @@
 import PixFilterBanner from '@1024pix/pix-ui/components/pix-filter-banner';
 import PixInput from '@1024pix/pix-ui/components/pix-input';
 import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
+import PixSegmentedControl from '@1024pix/pix-ui/components/pix-segmented-control';
 import PixTable from '@1024pix/pix-ui/components/pix-table';
 import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
-import PixToggleButton from '@1024pix/pix-ui/components/pix-toggle-button';
 import { fn } from '@ember/helper';
 import { action } from '@ember/object';
 import { LinkTo } from '@ember/routing';
@@ -41,11 +41,11 @@ export default class CertificationCenterListItems extends Component {
         <PixInput value={{@externalId}} oninput={{fn @triggerFiltering "externalId"}}>
           <:label>ID externe</:label>
         </PixInput>
-        <PixToggleButton @onChange={{this.filterHideArchived}} @toggled={{@hideArchived}}>
+        <PixSegmentedControl @onChange={{this.filterHideArchived}} @toggled={{@hideArchived}}>
           <:label>Masquer les centres archivés</:label>
           <:viewA>Oui</:viewA>
           <:viewB>Non</:viewB>
-        </PixToggleButton>
+        </PixSegmentedControl>
       </PixFilterBanner>
 
       {{#if @certificationCenters}}

--- a/admin/app/components/layout/sidebar.gjs
+++ b/admin/app/components/layout/sidebar.gjs
@@ -1,4 +1,3 @@
-import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
 import PixNavigation from '@1024pix/pix-ui/components/pix-navigation';
 import PixNavigationButton from '@1024pix/pix-ui/components/pix-navigation-button';
 import { LinkTo } from '@ember/routing';
@@ -22,6 +21,7 @@ export default class Sidebar extends Component {
       @navigationAriaLabel={{t "components.layout.sidebar.labels.main"}}
       @openLabel={{t "components.layout.sidebar.labels.open"}}
       @closeLabel={{t "components.layout.sidebar.labels.close"}}
+      @shrinkNavigation={{true}}
     >
       <:brand>
         <LinkTo @route="authenticated.index">
@@ -42,24 +42,14 @@ export default class Sidebar extends Component {
         <PixNavigationButton class="sidebar__link" @route="authenticated.users" @icon="infoUser">
           {{t "components.layout.sidebar.users"}}
         </PixNavigationButton>
-        <PixNavigationButton
-          class="sidebar__link"
-          @route="authenticated.certification-centers"
-          @icon="mapPin"
-          aria-label={{t "components.layout.sidebar.certification-centers-label"}}
-        >
+        <PixNavigationButton class="sidebar__link" @route="authenticated.certification-centers" @icon="mapPin">
           {{t "components.layout.sidebar.certification-centers"}}
         </PixNavigationButton>
         <PixNavigationButton class="sidebar__link" @route="authenticated.sessions" @icon="session">
           {{t "components.layout.sidebar.sessions"}}
         </PixNavigationButton>
 
-        <PixNavigationButton
-          class="sidebar__link"
-          @route="authenticated.certification-frameworks"
-          @icon="extension"
-          aria-label={{t "components.layout.sidebar.certification-frameworks-label"}}
-        >
+        <PixNavigationButton class="sidebar__link" @route="authenticated.certification-frameworks" @icon="extension">
           {{t "components.layout.sidebar.certification-frameworks"}}
         </PixNavigationButton>
         {{#if this.accessControl.hasAccessToTargetProfilesActionsScope}}
@@ -120,7 +110,9 @@ export default class Sidebar extends Component {
       </:navElements>
       <:footer>
         <p class="sidebar-footer__full-name">{{this.userFullName}}</p>
-        <PixButtonLink @variant="tertiary" @route="logout">{{t "components.layout.sidebar.logout"}}</PixButtonLink>
+        <PixNavigationButton @route="logout" @icon="power" class="sidebar-footer__logout-button">
+          {{t "components.layout.sidebar.logout"}}
+        </PixNavigationButton>
       </:footer>
     </PixNavigation>
   </template>

--- a/admin/app/components/organizations/list-items.gjs
+++ b/admin/app/components/organizations/list-items.gjs
@@ -3,10 +3,10 @@ import PixFilterBanner from '@1024pix/pix-ui/components/pix-filter-banner';
 import PixInput from '@1024pix/pix-ui/components/pix-input';
 import PixModal from '@1024pix/pix-ui/components/pix-modal';
 import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
+import PixSegmentedControl from '@1024pix/pix-ui/components/pix-segmented-control';
 import PixSelect from '@1024pix/pix-ui/components/pix-select';
 import PixTable from '@1024pix/pix-ui/components/pix-table';
 import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
-import PixToggleButton from '@1024pix/pix-ui/components/pix-toggle-button';
 import { fn } from '@ember/helper';
 import { action } from '@ember/object';
 import { LinkTo } from '@ember/routing';
@@ -113,11 +113,11 @@ export default class ActionsOnUsersRoleInOrganization extends Component {
       <PixInput value={{@externalId}} oninput={{fn @triggerFiltering "externalId"}}>
         <:label>Identifiant externe</:label>
       </PixInput>
-      <PixToggleButton @onChange={{this.filterHideArchived}} @toggled={{@hideArchived}}>
+      <PixSegmentedControl @onChange={{this.filterHideArchived}} @toggled={{@hideArchived}}>
         <:label>Masquer les organisations archivées</:label>
         <:viewA>Oui</:viewA>
         <:viewB>Non</:viewB>
-      </PixToggleButton>
+      </PixSegmentedControl>
     </PixFilterBanner>
 
     {{#if @organizations}}

--- a/admin/app/components/quests/form.gjs
+++ b/admin/app/components/quests/form.gjs
@@ -2,8 +2,8 @@ import PixBlock from '@1024pix/pix-ui/components/pix-block';
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
 import PixInput from '@1024pix/pix-ui/components/pix-input';
+import PixSegmentedControl from '@1024pix/pix-ui/components/pix-segmented-control';
 import PixTextarea from '@1024pix/pix-ui/components/pix-textarea';
-import PixToggleButton from '@1024pix/pix-ui/components/pix-toggle-button';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
@@ -203,11 +203,11 @@ export default class QuestForm extends Component {
       </PixBlock>
 
       <PixBlock @variant="admin" class="quest-button-edition quest-button-edition--column">
-        <PixToggleButton @toggled={{this.switchRequirements}} @onChange={{this.onChangeRequirements}}>
+        <PixSegmentedControl @toggled={{this.switchRequirements}} @onChange={{this.onChangeRequirements}}>
           <:label>Mes requirements :</:label>
           <:viewA>Éligibilités</:viewA>
           <:viewB>Succès</:viewB>
-        </PixToggleButton>
+        </PixSegmentedControl>
 
         <PixTextarea value={{this.requirementsStr}} {{on "change" this.updateRequirementsStr}} rows="15">
           <:label>Mes requirements ({{this.requirementState}})</:label>

--- a/admin/app/styles/layout/sidebar.scss
+++ b/admin/app/styles/layout/sidebar.scss
@@ -6,4 +6,10 @@
 
     font-weight: var(--pix-font-bold);
   }
+
+  &__logout-button {
+    text-decoration: underline;
+    display: flex;
+    justify-content: center;
+  }
 }

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -12,7 +12,7 @@
       "devDependencies": {
         "@1024pix/ember-testing-library": "^3.0.25",
         "@1024pix/eslint-plugin": "^2.1.15",
-        "@1024pix/pix-ui": "^56.1.0",
+        "@1024pix/pix-ui": "github:1024pix/pix-ui#PIX-16992-allow-to-collapse-admin-navigation",
         "@1024pix/stylelint-config": "^5.1.37",
         "@babel/eslint-parser": "^7.28.5",
         "@ember-intl/v1-compat": "^1.0.0",
@@ -121,9 +121,8 @@
       }
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "56.1.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-56.1.0.tgz",
-      "integrity": "sha512-5AkQ6My7as6RX2m3C9oEiym5yV02ZDHkdHQhUsSG7Czv5St24SvBQQwVtbTX2B8zAdF3svM3tyYzQr3Q2sS3qg==",
+      "version": "57.0.0",
+      "resolved": "git+ssh://git@github.com/1024pix/pix-ui.git#c3db97fab9841e257322e9cb845e26a2783bde96",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/admin/package.json
+++ b/admin/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@1024pix/ember-testing-library": "^3.0.25",
     "@1024pix/eslint-plugin": "^2.1.15",
-    "@1024pix/pix-ui": "^56.1.0",
+    "@1024pix/pix-ui": "github:1024pix/pix-ui#PIX-16992-allow-to-collapse-admin-navigation",
     "@1024pix/stylelint-config": "^5.1.37",
     "@babel/eslint-parser": "^7.28.5",
     "@ember-intl/v1-compat": "^1.0.0",

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -578,10 +578,8 @@
       "sidebar": {
         "administration": "Administration",
         "autonomous-courses": "Autonomous courses",
-        "certification-centers": "Certif centers",
-        "certification-centers-label": "Certifications centers",
-        "certification-frameworks": "Certif frameworks",
-        "certification-frameworks-label": "Certification frameworks",
+        "certification-centers": "Certification centers",
+        "certification-frameworks": "Certification frameworks",
         "certifications": "Certifications",
         "combined-course-blueprints": "Courses blueprints",
         "labels": {
@@ -591,8 +589,7 @@
         },
         "logout": "Log out",
         "organizations": "Organizations",
-        "sessions": "Certif sessions",
-        "sessions-label": "Certifications sessions",
+        "sessions": "Certification sessions",
         "target-profiles": "Target profiles",
         "team": "Team",
         "tools": "Tools",

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -580,10 +580,8 @@
       "sidebar": {
         "administration": "Administration",
         "autonomous-courses": "Parcours autonomes",
-        "certification-centers": "Centres de certif",
-        "certification-centers-label": "Centres de certifications",
-        "certification-frameworks": "Référentiels de certif",
-        "certification-frameworks-label": "Référentiels de certification",
+        "certification-centers": "Centres de certification",
+        "certification-frameworks": "Référentiels de certification",
         "certifications": "Certifications",
         "combined-course-blueprints": "Schémas de parcours",
         "labels": {
@@ -593,8 +591,7 @@
         },
         "logout": "Se déconnecter",
         "organizations": "Organisations",
-        "sessions": "Sessions de certif",
-        "sessions-label": "Sessions de certifications",
+        "sessions": "Sessions de certification",
         "target-profiles": "Profils cibles",
         "team": "Équipe",
         "tools": "Outils",


### PR DESCRIPTION
## 🛷 Proposition
PR de PIX UI : https://github.com/1024pix/pix-ui/pull/967

---

Review app : https://admin-pr14728.review.pix.fr/organizations/list

Dans cette PR : 

- Dans le menu, j'ai complété tous les labels sur lesquels il y avait écrit `certif.` pour `certification`. On avait mis ça pour pas allonger le menu plus que nécessaire. Avec la réduction de la nav, plus besoin de mot tronqué.
- J'ai ajouté. un logo "power" au bouton de déconnexion, pour qu'il puisse s'afficher en cas de réduction de la nav.


> [!IMPORTANT]
> @pierrepougetpix vu avec Xavier, la réduction de la navigation n'impacte pas les grands écrans, seulement les petits. Car on ne touche pas au max-width MAX définit (93rem) 

- Faire des tests d'affichages pour les petits écrans, c'est pour eux que cette navigation réduite va être le plus utile.
- Faire des tests au survol sur les boutons en version réduit, faire des tests au clavier

<img width="560" height="340" alt="techguide-comparatif-resolution-ecran-hd-full-hd-2k-3k-4k" src="https://github.com/user-attachments/assets/a0c3cb3b-40b8-4398-9932-99102e7b490f" />
