### PR TITLE
[TECH] Ajouter le champ `requestId` dans la table `chat_messages` (PIX-20362)

### DIFF
--- a/api/db/migrations/20260114140234_add-requestId-to-chat_messages.js
+++ b/api/db/migrations/20260114140234_add-requestId-to-chat_messages.js
@@ -1,0 +1,24 @@
+const TABLE_NAME = 'chat_messages';
+const COLUMN_NAME = 'requestId';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.string(COLUMN_NAME).defaultTo(null).comment("Correlation context's request_id");
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+export { down, up };

--- a/api/src/llm/domain/usecases/prompt-chat.js
+++ b/api/src/llm/domain/usecases/prompt-chat.js
@@ -61,6 +61,7 @@ export async function promptChat({
       llmResponseHandler.llmResponseStream = await promptRepository.prompt({
         messages: chat.messagesForInference,
         configuration: chat.configuration,
+        chatId: chat.id,
       });
     }
 
@@ -132,7 +133,18 @@ async function runFlow({ chat, chatRepository, llmResponseHandler, logger = defa
 
     await chatRepository.save(chat);
   } catch (err) {
-    logger.error({ err, message: chat.lastUserMessage, llmResponseMetadata }, 'error in runFlow');
+    logger.error(
+      {
+        err,
+        context: 'prompt-chat',
+        data: {
+          chatId: chat.id,
+          lastUserMessage: chat.lastUserMessage,
+          llmResponseMetadata,
+        },
+      },
+      'error in runFlow',
+    );
     await llmResponseHandler.finish();
   } finally {
     await redisMutex.release(chat.id);

--- a/api/src/llm/infrastructure/repositories/chat-repository.js
+++ b/api/src/llm/infrastructure/repositories/chat-repository.js
@@ -1,4 +1,5 @@
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
+import { getCorrelationContext } from '../../../shared/infrastructure/monitoring-tools.js';
 import { Chat } from '../../domain/models/Chat.js';
 
 /**
@@ -104,5 +105,6 @@ function _buildDatabaseMessage({ chatId, message }) {
     emitter,
     index,
     wasModerated: wasModerated ?? null,
+    requestId: getCorrelationContext().request_id,
   };
 }

--- a/api/tests/llm/integration/domain/usecases/prompt-chat_test.js
+++ b/api/tests/llm/integration/domain/usecases/prompt-chat_test.js
@@ -1809,8 +1809,12 @@ describe('LLM | Integration | Domain | UseCases | prompt-chat', function () {
       expect(logger.error).to.have.been.calledOnceWith(
         {
           err: sinon.match.instanceOf(LLMApiError),
-          message: sinon.match.object,
-          llmResponseMetadata: sinon.match.object,
+          context: 'prompt-chat',
+          data: {
+            chatId,
+            lastUserMessage: sinon.match.object,
+            llmResponseMetadata: sinon.match.object,
+          },
         },
         'error in runFlow',
       );

--- a/api/tests/llm/integration/infrastructure/repositories/chat-repository_test.js
+++ b/api/tests/llm/integration/infrastructure/repositories/chat-repository_test.js
@@ -6,7 +6,7 @@ import { get, save } from '../../../../../src/llm/infrastructure/repositories/ch
 import { databaseBuilder, expect, knex, sinon } from '../../../../test-helper.js';
 
 describe('LLM | Integration | Infrastructure | Repositories | chat', function () {
-  describe('save', function () {
+  describe('#save', function () {
     let clock, now;
 
     beforeEach(function () {
@@ -201,6 +201,7 @@ describe('LLM | Integration | Infrastructure | Repositories | chat', function ()
           emitter: 'user',
           content: thirdMessage.content,
           wasModerated: null,
+          requestId: null,
         });
       });
     });


### PR DESCRIPTION
## ❄️ Problème

La `requestId` loggée dans le cadre des requêtes avec l'API LLM n'est pas facilement exploitable aujourd'hui.

## 🛷 Proposition

Persister `requestId` dans la table `chat_messages`.

## ☃️ Remarques

Amélioration des logs d'erreur dans les cas où `requestId` ne peut pas être persisté.

## 🧑‍🎄 Pour tester

CI OK ✅
