### PR TITLE
[FEATURE] Modification de la page d'inscription via SSO (PIX-21012)

### DIFF
--- a/orga/app/components/authentication/oidc-signup-form.gjs
+++ b/orga/app/components/authentication/oidc-signup-form.gjs
@@ -28,8 +28,8 @@ export default class OidcSignupForm extends Component {
       const { firstName, lastName, ...rest } = userClaims;
 
       result.push(
-        htmlSafe(`${this.intl.t('pages.oidc.signup.claims.first-name-label')}<b>${firstName}</b>`),
-        htmlSafe(`${this.intl.t('pages.oidc.signup.claims.last-name-label')}<b>${lastName}</b>`),
+        htmlSafe(`${this.intl.t('pages.oidc.signup.claims.first-name-label')}<strong>${firstName}</strong>`),
+        htmlSafe(`${this.intl.t('pages.oidc.signup.claims.last-name-label')}<strong>${lastName}</strong>`),
       );
 
       Object.entries(rest).map(([key, _value]) => {
@@ -74,7 +74,7 @@ export default class OidcSignupForm extends Component {
     <div>
       <p class="oidc-signup-form__description">
         {{t "pages.oidc.signup.description"}}
-        <span class="oidc-signup-form__description__provider-name">{{@identityProviderName}}</span>&nbsp;:
+        <em>{{@identityProviderName}}</em>&nbsp;:
       </p>
       <div class="oidc-signup-form__information">
         <ul>

--- a/orga/app/components/authentication/oidc-signup-form.gjs
+++ b/orga/app/components/authentication/oidc-signup-form.gjs
@@ -4,6 +4,7 @@ import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-al
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
+import { htmlSafe } from '@ember/template';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import t from 'ember-intl/helpers/t';
@@ -18,15 +19,18 @@ export default class OidcSignupForm extends Component {
   @tracked signupErrorMessage = null;
   @tracked isLoading = false;
 
-  get userClaimsToDisplay() {
+  get formattedUserClaims() {
     const { userClaims } = this.args;
 
     const result = [];
 
     if (userClaims) {
       const { firstName, lastName, ...rest } = userClaims;
-      result.push(this.intl.t('pages.oidc.signup.claims.first-name-label-and-value', { firstName }));
-      result.push(this.intl.t('pages.oidc.signup.claims.last-name-label-and-value', { lastName }));
+
+      result.push(
+        htmlSafe(`${this.intl.t('pages.oidc.signup.claims.first-name-label')}<b>${firstName}</b>`),
+        htmlSafe(`${this.intl.t('pages.oidc.signup.claims.last-name-label')}<b>${lastName}</b>`),
+      );
 
       Object.entries(rest).map(([key, _value]) => {
         let label = `${this.intl.t(`pages.oidc.signup.claims.${key}`)}`;
@@ -70,12 +74,12 @@ export default class OidcSignupForm extends Component {
     <div>
       <p class="oidc-signup-form__description">
         {{t "pages.oidc.signup.description"}}
-        <em>{{@identityProviderName}}</em>&nbsp;:
+        <span class="oidc-signup-form__description__provider-name">{{@identityProviderName}}</span>&nbsp;:
       </p>
       <div class="oidc-signup-form__information">
         <ul>
-          {{#each this.userClaimsToDisplay as |userClaimToDisplay|}}
-            <li>{{userClaimToDisplay}}</li>
+          {{#each this.formattedUserClaims as |formattedUserClaim|}}
+            <li>{{formattedUserClaim}}</li>
           {{/each}}
         </ul>
       </div>

--- a/orga/app/components/authentication/oidc-signup-form.scss
+++ b/orga/app/components/authentication/oidc-signup-form.scss
@@ -16,22 +16,17 @@
     @extend %pix-body-m;
 
     margin: 0;
-    padding-bottom: 24px;
-    color: var(--pix-neutral-500);
-  }
+    padding-bottom: 1rem;
+    color: var(--pix-neutral-800);
 
-  &__description em {
-    padding-right: 0.2rem;
-    padding-left: 0.2rem;
-    color: var(--pix-neutral-900);
-    font-style: normal;
+    &__provider-name {
+      font-weight: var(--pix-font-bold);
+    }
   }
 
   &__information {
-    @extend %pix-body-m;
-
-    margin-bottom: 2rem;
-    color: var(--pix-neutral-500);
+    @extend %pix-body-s;
+    color: var(--pix-neutral-800);
 
     li {
       overflow-wrap: anywhere;
@@ -45,7 +40,6 @@
     display: flex;
     flex-direction: column;
     gap: var(--pix-spacing-2x);
-    padding: 0 0 24px;
 
     label {
       @extend %pix-body-s;

--- a/orga/app/components/authentication/oidc-signup-form.scss
+++ b/orga/app/components/authentication/oidc-signup-form.scss
@@ -19,7 +19,8 @@
     padding-bottom: 1rem;
     color: var(--pix-neutral-800);
 
-    &__provider-name {
+    em {
+      font-style: normal;
       font-weight: var(--pix-font-bold);
     }
   }

--- a/orga/app/components/authentication/oidc-signup-form.scss
+++ b/orga/app/components/authentication/oidc-signup-form.scss
@@ -16,7 +16,7 @@
     @extend %pix-body-m;
 
     margin: 0;
-    padding-bottom: 1rem;
+    padding-bottom: var(--pix-spacing-4x);
     color: var(--pix-neutral-800);
 
     em {

--- a/orga/tests/acceptance/oidc/oidc-authentication-signup-test.js
+++ b/orga/tests/acceptance/oidc/oidc-authentication-signup-test.js
@@ -49,15 +49,18 @@ module('Acceptance | OIDC | authentication signup', function (hooks) {
       t('pages.login.join-invitation', { organizationName: 'Super orga avec SSO' }),
     );
     assert.dom(invitationText).exists();
+    const expectedFirstNameLabelAndValue = `${t('pages.oidc.signup.claims.first-name-label')}test`;
+    const expectedLastNameLabelAndValue = `${t('pages.oidc.signup.claims.last-name-label')}PIX`;
 
-    const firstName = await screen.findByText(
-      t('pages.oidc.signup.claims.first-name-label-and-value', { firstName: 'test' }),
+    const foundFirstNameLabelAndValue = await screen.findByText(
+      (_, el) => el.textContent === expectedFirstNameLabelAndValue,
     );
-    const lastName = await screen.findByText(
-      t('pages.oidc.signup.claims.last-name-label-and-value', { lastName: 'PIX' }),
+    const foundLastNameLabelAndValue = await screen.findByText(
+      (_, el) => el.textContent === expectedLastNameLabelAndValue,
     );
-    assert.dom(firstName).exists();
-    assert.dom(lastName).exists();
+
+    assert.dom(foundFirstNameLabelAndValue).exists();
+    assert.dom(foundLastNameLabelAndValue).exists();
 
     // when
     await clickByName(t('common.cgu.label'));

--- a/orga/tests/integration/components/authentication/oidc-signup-form-test.gjs
+++ b/orga/tests/integration/components/authentication/oidc-signup-form-test.gjs
@@ -35,15 +35,17 @@ module('Integration | Component | Authentication | OidcSignupForm', function (ho
     const providerName = await screen.findByText(identityProviderName);
     assert.dom(providerName).exists();
 
-    const firstName = await screen.findByText(
-      t('pages.oidc.signup.claims.first-name-label-and-value', { firstName: 'John' }),
+    const expectedFirstNameLabelAndValue = `${t('pages.oidc.signup.claims.first-name-label')}John`;
+    const foundFirstNameLabelAndValue = await screen.findByText(
+      (_, el) => el.textContent === expectedFirstNameLabelAndValue,
     );
-    assert.dom(firstName).exists();
+    assert.dom(foundFirstNameLabelAndValue).exists();
 
-    const lastName = await screen.findByText(
-      t('pages.oidc.signup.claims.last-name-label-and-value', { lastName: 'Doe' }),
+    const expectedLastNameLabelAndValue = `${t('pages.oidc.signup.claims.last-name-label')}Doe`;
+    const foundLastNameLabelAndValue = await screen.findByText(
+      (_, el) => el.textContent === expectedLastNameLabelAndValue,
     );
-    assert.dom(lastName).exists();
+    assert.dom(foundLastNameLabelAndValue).exists();
 
     const title = await screen.findByText(t('pages.oidc.signup.claims.title'));
     assert.dom(title).exists();

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -1410,8 +1410,8 @@
           "FrEduNumenHash": "Technical identifier",
           "discipline": "School subject",
           "employeeNumber": "Employee number",
-          "first-name-label-and-value": "First name: {firstName}",
-          "last-name-label-and-value": "Last name: {lastName}",
+          "first-name-label": "First name: ",
+          "last-name-label": "Last name: ",
           "population": "Population",
           "rne": "Establishment of assignment",
           "title": "Title"
@@ -1421,7 +1421,7 @@
           "cgu": "You must accept to the Pix terms of use and personal data protection policy to create an account.",
           "claims": "We were unable to retrieve your identity information from the service used. We invite you to contact this organisation's IT support."
         },
-        "login-button": "I already have an account, I'm logging in",
+        "login-button": "I already have a Pix account, I'm logging in",
         "signup-button": "Create my account",
         "sub-title": "to access your Pix Orga workspace",
         "title": "Create your Account"

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -1398,8 +1398,8 @@
           "FrEduNumenHash": "Identifiant technique",
           "discipline": "Discipline",
           "employeeNumber": "Numéro d'employé",
-          "first-name-label-and-value": "Prénom : {firstName}",
-          "last-name-label-and-value": "Nom : {lastName}",
+          "first-name-label": "Prénom : ",
+          "last-name-label": "Nom : ",
           "population": "Population",
           "rne": "Etablissement d’affectation",
           "title": "Fonction"
@@ -1409,7 +1409,7 @@
           "cgu": "Vous devez accepter les conditions d’utilisation de Pix et la politique de confidentialité pour créer un compte.",
           "claims": "Nous n’avons pas pu récupérer vos informations d’identité auprès du service utilisé. Nous vous invitons à contacter le support informatique de cette organisation."
         },
-        "login-button": "J'ai déjà un compte, je me connecte",
+        "login-button": "J'ai déjà un compte Pix, je me connecte",
         "signup-button": "Je m'inscris sur Pix",
         "sub-title": "pour accéder à votre espace Pix Orga",
         "title": "Inscrivez-vous à Pix"

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -1392,8 +1392,8 @@
           "FrEduNumenHash": "Technische identificatiecode",
           "discipline": "Discipline",
           "employeeNumber": "Werknemersnummer",
-          "first-name-label-and-value": "Voornaam: {firstName}",
-          "last-name-label-and-value": "Naam: {lastName}",
+          "first-name-label": "Voornaam: ",
+          "last-name-label": "Naam: ",
           "population": "Bevolking",
           "rne": "Toewijzingsinstelling",
           "title": "rol"
@@ -1403,7 +1403,7 @@
           "cgu": "Je moet de gebruiksvoorwaarden en het privacybeleid van Pix accepteren om een account aan te maken.",
           "claims": "We konden uw identiteitsgegevens niet ophalen bij de gebruikte dienst. Neem contact op met de IT-ondersteuning van deze organisatie."
         },
-        "login-button": "Ik heb al een account, ik log in",
+        "login-button": "Ik heb al een Pix-account, ik log in",
         "signup-button": "Ik maak mijn account aan",
         "sub-title": "om toegang te krijgen tot uw Pix Orga-werkruimte",
         "title": "Registreer u bij Pix"


### PR DESCRIPTION
## ❄️ Problème
Des ajustements de styles sont nécessaires sur la page d’inscription via SSO /connexion/pro-connect/signup 

## 🛷 Proposition

Modifier le style (voir la maquette Figma) : https://www.figma.com/design/wDdAJwtswAllBk0ZtMLu4Y/Acc%C3%A8s?node-id=3810-40445&m=dev
- Pour la phrase “Un compte va être créé à partir…”
- Pour l’affichage des claims
- Et modifier le libellé du bouton “J’ai déjà un compte, je me connecte” en “J’ai déjà un compte Pix, je me connecte”

## ☃️ Remarques

Des espacements ont aussi été modifiés pour les rendre identiques à ceux de la maquette

## 🧑‍🎄 Pour tester (en local)

- En tant qu'admin sur Pix Orga, invitez quelqu'un
- En tant qu'invité, cliquez sur le lien d'invitation
- Identifiez-vous auprès d'un SSO
- Constatez que les modifications apportées sont correctes :
 -- Un compte va être créé à partir des éléments transmis par l'organisme ProConnect : ( couleur 800, le nom de l'organisme en gras)
-- les claims : couleur 800, valeur des claims "nom" et "prénom" en gras
-- le titre du bouton de login doit être : "J'ai déjà un compte Pix, je me connecte"