### PR TITLE
[FEATURE] Détacher une organization d'un schéma de parcours combiné (PIX-21094)

### DIFF
--- a/admin/app/adapters/combined-course-blueprint.js
+++ b/admin/app/adapters/combined-course-blueprint.js
@@ -2,4 +2,9 @@ import ApplicationAdapter from './application';
 
 export default class CombinedCourseBlueprintAdapter extends ApplicationAdapter {
   namespace = 'api/admin';
+
+  async detachOrganizations(combinedCourseBlueprintId, organizationId) {
+    const url = `${this.host}/${this.namespace}/combined-course-blueprints/${combinedCourseBlueprintId}/organizations/${organizationId}`;
+    await this.ajax(url, 'DELETE');
+  }
 }

--- a/admin/app/components/combined-course-blueprints/organizations.gjs
+++ b/admin/app/components/combined-course-blueprints/organizations.gjs
@@ -1,24 +1,37 @@
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
 import ListItems from 'pix-admin/components/organizations/list-items';
 
-<template>
-  <section class="page-section organizations-list">
-    <header class="page-section__header">
-      <h2 class="page-section__title">Organisations pouet</h2>
-    </header>
+export default class Organizations extends Component {
+  @service currentUser;
 
-    <ListItems
-      @organizations={{@organizations}}
-      @administrationTeams={{@administrationTeams}}
-      @triggerFiltering={{@triggerFiltering}}
-      @onResetFilter={{@onResetFilter}}
-      @goToOrganizationPage={{@goToOrganizationPage}}
-      @entityName={{@blueprint.internalName}}
-      @id={{@id}}
-      @name={{@name}}
-      @hideArchived={{@hideArchived}}
-      @type={{@type}}
-      @externalId={{@externalId}}
-      @administrationTeamId={{@administrationTeamId}}
-    />
-  </section>
-</template>
+  get isSuperAdminOrMetier() {
+    return this.currentUser.adminMember.isSuperAdmin || this.currentUser.adminMember.isMetier;
+  }
+
+  <template>
+    <section class="page-section organizations-list">
+      <header class="page-section__header">
+        <h2 class="page-section__title">Organisations</h2>
+      </header>
+
+      <ListItems
+        @organizations={{@organizations}}
+        @administrationTeams={{@administrationTeams}}
+        @triggerFiltering={{@triggerFiltering}}
+        @onResetFilter={{@onResetFilter}}
+        @goToOrganizationPage={{@goToOrganizationPage}}
+        @entityName={{@blueprint.internalName}}
+        @id={{@id}}
+        @name={{@name}}
+        @hideArchived={{@hideArchived}}
+        @type={{@type}}
+        @externalId={{@externalId}}
+        @administrationTeamId={{@administrationTeamId}}
+        @showDetachColumn={{this.isSuperAdminOrMetier}}
+        @detachOrganizations={{@detachOrganizations}}
+        @confirmationLabel="components.combined-course-blueprints.organizations.detach-organization"
+      />
+    </section>
+  </template>
+}

--- a/admin/app/components/organizations/list-items.gjs
+++ b/admin/app/components/organizations/list-items.gjs
@@ -14,7 +14,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 
-export default class ActionsOnUsersRoleInOrganization extends Component {
+export default class OrganizationListItems extends Component {
   @tracked showModal = false;
   @tracked organizationToDetach;
 

--- a/admin/app/controllers/authenticated/combined-course-blueprints/combined-course-blueprint/organizations.js
+++ b/admin/app/controllers/authenticated/combined-course-blueprints/combined-course-blueprint/organizations.js
@@ -13,6 +13,7 @@ export default class CombinedCourseBlueprintOrganizationsController extends Cont
   @service router;
   @service pixToast;
   @service store;
+  @service intl;
 
   @tracked pageNumber = DEFAULT_PAGE_NUMBER;
   @tracked pageSize = 10;
@@ -38,6 +39,25 @@ export default class CombinedCourseBlueprintOrganizationsController extends Cont
   @action
   goToOrganizationPage(organizationId) {
     this.router.transitionTo('authenticated.organizations.get', organizationId);
+  }
+
+  @action
+  async detachOrganizations(organizationId) {
+    const adapter = this.store.adapterFor('combined-course-blueprint');
+    const organization = await this.store.findRecord('organization', organizationId);
+
+    try {
+      await adapter.detachOrganizations(this.model.blueprint.id, organizationId);
+
+      await this.pixToast.sendSuccessNotification({
+        message: this.intl.t('components.combined-course-blueprints.organizations.detach-organization-success', {
+          name: organization.name,
+        }),
+      });
+      this.router.transitionTo('authenticated.combined-course-blueprints.combined-course-blueprint.organizations');
+    } catch {
+      return this.pixToast.sendErrorNotification({ message: this.intl.t('common.notifications.generic-error') });
+    }
   }
 
   @action

--- a/admin/app/templates/authenticated/combined-course-blueprints/combined-course-blueprint/organizations.gjs
+++ b/admin/app/templates/authenticated/combined-course-blueprints/combined-course-blueprint/organizations.gjs
@@ -14,5 +14,6 @@ import Organizations from 'pix-admin/components/combined-course-blueprints/organ
     @externalId={{@controller.externalId}}
     @hideArchived={{@controller.hideArchived}}
     @administrationTeamId={{@controller.administrationTeamId}}
+    @detachOrganizations={{@controller.detachOrganizations}}
   />
 </template>

--- a/admin/tests/acceptance/authenticated/combined-course-blueprints/organizations-test.js
+++ b/admin/tests/acceptance/authenticated/combined-course-blueprints/organizations-test.js
@@ -1,5 +1,5 @@
-import { clickByName, visit } from '@1024pix/ember-testing-library';
-import { currentURL } from '@ember/test-helpers';
+import { visit } from '@1024pix/ember-testing-library';
+import { click, currentURL } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'pix-admin/tests/test-support/setup-mirage';
@@ -79,12 +79,27 @@ module('Acceptance | combined course blueprint Organizations', function (hooks) 
 
       test('it should redirect to organization details on click', async function (assert) {
         // given
-        await visit('/combined-course-blueprints/1');
+        const screen = await visit('/combined-course-blueprints/1');
         // when
-        await clickByName('456');
+        await click(screen.getByRole('link', { name: '456' }));
 
         // then
         assert.deepEqual(currentURL(), '/organizations/456/team');
+      });
+
+      test('it should redirect to combined course blueprint details after detach', async function (assert) {
+        // given
+        const screen = await visit('/combined-course-blueprints/1');
+
+        const detachButton = screen.getAllByRole('button', { name: 'Détacher' })[0];
+
+        // when
+        await click(detachButton);
+
+        const confirmButton = await screen.findByRole('button', { name: 'Confirmer' });
+        await click(confirmButton);
+
+        assert.deepEqual(currentURL(), '/combined-course-blueprints/1/organizations');
       });
     });
   });

--- a/admin/tests/integration/components/combined-course-blueprints/organizations-test.gjs
+++ b/admin/tests/integration/components/combined-course-blueprints/organizations-test.gjs
@@ -1,0 +1,78 @@
+import { render, within } from '@1024pix/ember-testing-library';
+import Organizations from 'pix-admin/components/combined-course-blueprints/organizations';
+import setupIntlRenderingTest from 'pix-admin/tests/helpers/setup-intl-rendering';
+import { module, test } from 'qunit';
+
+module('Integration | Component | CombinedCourseBlueprints::Organizations', function (hooks) {
+  setupIntlRenderingTest(hooks);
+  let currentUser;
+
+  hooks.beforeEach(function () {
+    currentUser = this.owner.lookup('service:current-user');
+  });
+
+  module('show detach column', function () {
+    test('it should display detach column when user is super admin or metier', async function (assert) {
+      currentUser.adminMember = { userId: 456, isSuperAdmin: true };
+      const organizations = [
+        { id: 123, name: 'orga', type: 'SCO', administrationTeamName: 'Team Rocket', externalId: 345 },
+      ];
+      const administrationTeams = [];
+      const screen = await render(
+        <template>
+          <Organizations @organizations={{organizations}} @administrationTeams={{administrationTeams}} />
+        </template>,
+      );
+
+      assert.ok(screen.getByRole('columnheader', { name: 'Actions' }));
+      assert.ok(screen.getByRole('button', { name: 'Détacher' }));
+    });
+
+    test('it should hide detach column when user is not super admin or metier', async function (assert) {
+      currentUser.adminMember = { userId: 456, isSuperAdmin: false };
+      const organizations = [
+        { id: 123, name: 'orga', type: 'SCO', administrationTeamName: 'Team Rocket', externalId: 345 },
+      ];
+      const administrationTeams = [];
+
+      const screen = await render(
+        <template>
+          <Organizations @organizations={{organizations}} @administrationTeams={{administrationTeams}} />
+        </template>,
+      );
+
+      assert.notOk(screen.queryByRole('columnheader', { name: 'Actions' }));
+      assert.notOk(screen.queryByRole('button', { name: 'Détacher' }));
+    });
+  });
+  module('filter values', function () {
+    test('it should populate filters', async function (assert) {
+      currentUser.adminMember = { userId: 456, isSuperAdmin: true };
+      const organizations = [
+        { id: 123, name: 'orga', type: 'SUP', administrationTeamName: 'Team Rocket', externalId: 345 },
+      ];
+      const administrationTeams = [{ id: 456, name: 'Team Rocket' }];
+      const screen = await render(
+        <template>
+          <Organizations
+            @organizations={{organizations}}
+            @administrationTeams={{administrationTeams}}
+            @id={{123}}
+            @name="orga"
+            @type="SCO"
+            @externalId="abc"
+            @hideArchived={{true}}
+            @administrationTeamId={{456}}
+          />
+        </template>,
+      );
+
+      assert.ok(screen.getByDisplayValue(123));
+      assert.ok(screen.getByDisplayValue('orga'));
+      assert.ok(within(screen.getByLabelText('Type')).getByText('SCO'));
+      assert.ok(within(screen.getByLabelText('Équipe')).getByText('Team Rocket'));
+      assert.ok(screen.getByDisplayValue('abc'));
+      assert.ok(screen.getByRole('button', { name: 'Masquer les organisations archivées', pressed: true }));
+    });
+  });
+});

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -499,7 +499,8 @@
         "title": "All learner courses"
       },
        "organizations": {
-        "detach-organization": "Are you sure you want to detach <strong>{organizationName}</strong> from combined course blueprint <strong>{name}</strong>"
+        "detach-organization": "Are you sure you want to detach <strong>{organizationName}</strong> from combined course blueprint <strong>{name}</strong>",
+        "detach-organization-success": "Blueprint is not shared with organization {name} anymore."
       }
     },
     "complementary-certifications": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -500,7 +500,8 @@
         "title": "Tous les schémas de parcours combinés"
       },
        "organizations": {
-        "detach-organization": "Etes-vous sûr de vouloir détacher l'organisation <strong>{organizationName}</strong> du schéma de parcours <strong>{name}</strong>"
+        "detach-organization": "Etes-vous sûr de vouloir détacher l'organisation <strong>{organizationName}</strong> du schéma de parcours <strong>{name}</strong>",
+        "detach-organization-success": "Le schéma de parcours n'est plus partagé avec l'organisation {name}."
       }
     },
     "complementary-certifications": {

--- a/api/db/database-builder/factory/build-combined-course-blueprint.js
+++ b/api/db/database-builder/factory/build-combined-course-blueprint.js
@@ -8,7 +8,7 @@ const buildCombinedCourseBlueprint = function ({
   illustration = 'images/illustration.svg',
   createdAt = new Date(),
   updatedAt,
-  content,
+  content = [],
 } = {}) {
   const values = {
     id,

--- a/api/src/quest/application/combined-course-blueprint-controller.js
+++ b/api/src/quest/application/combined-course-blueprint-controller.js
@@ -16,3 +16,11 @@ export const getById = async (request, _, dependencies = { combinedCourseBluepri
   const combinedCourseBlueprint = await usecases.getCombinedCourseBlueprintById({ id: request.params.blueprintId });
   return dependencies.combinedCourseBlueprintSerializer.serialize(combinedCourseBlueprint);
 };
+
+export const detachOrganization = async (request, h) => {
+  await usecases.detachOrganizationFromCombinedCourseBlueprint({
+    combinedCourseBlueprintId: request.params.blueprintId,
+    organizationId: request.params.organizationId,
+  });
+  return h.response().code(204);
+};

--- a/api/src/quest/application/combined-course-blueprint-route.js
+++ b/api/src/quest/application/combined-course-blueprint-route.js
@@ -1,6 +1,7 @@
 import Joi from 'joi';
 
 import { securityPreHandlers } from '../../shared/application/security-pre-handlers.js';
+import { identifiersType } from '../../shared/domain/types/identifiers-type.js';
 import { contentSchema } from '../domain/models/CombinedCourseBlueprint.js';
 import * as combinedCourseBlueprintController from './combined-course-blueprint-controller.js';
 
@@ -83,7 +84,37 @@ const register = async function (server) {
           },
         ],
         handler: combinedCourseBlueprintController.getById,
+        validate: {
+          params: Joi.object({
+            blueprintId: identifiersType.combinedCourseBlueprintId,
+          }),
+        },
         notes: ['- Récupération d‘un schémas de parcours combinés pour un identifiant donné'],
+        tags: ['api', 'combined-course'],
+      },
+    },
+    {
+      method: 'DELETE',
+      path: '/api/admin/combined-course-blueprints/{blueprintId}/organizations/{organizationId}',
+      config: {
+        validate: {
+          params: Joi.object({
+            blueprintId: identifiersType.combinedCourseBlueprintId,
+            organizationId: identifiersType.organizationId,
+          }),
+        },
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.hasAtLeastOneAccessOf([
+                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+                securityPreHandlers.checkAdminMemberHasRoleMetier,
+              ])(request, h),
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        handler: combinedCourseBlueprintController.detachOrganization,
+        notes: ["- Retire l'accès à un schéma de parcours combinés pour une organisation donnée"],
         tags: ['api', 'combined-course'],
       },
     },

--- a/api/src/quest/domain/models/CombinedCourseBlueprint.js
+++ b/api/src/quest/domain/models/CombinedCourseBlueprint.js
@@ -6,7 +6,17 @@ import { CRITERION_COMPARISONS, Quest, REQUIREMENT_COMPARISONS, REQUIREMENT_TYPE
 import { buildRequirement } from './Requirement.js';
 
 export class CombinedCourseBlueprint {
-  constructor({ id, name, internalName, description, illustration, content, createdAt, updatedAt }) {
+  constructor({
+    id,
+    name,
+    internalName,
+    description,
+    illustration,
+    content,
+    createdAt,
+    updatedAt,
+    organizationIds = [],
+  }) {
     this.id = id;
     this.name = name;
     this.internalName = internalName;
@@ -15,6 +25,7 @@ export class CombinedCourseBlueprint {
     this.content = content;
     this.createdAt = createdAt;
     this.updatedAt = updatedAt;
+    this.organizationIds = organizationIds;
   }
 
   get targetProfileIds() {
@@ -99,6 +110,9 @@ export class CombinedCourseBlueprint {
         : { type: COMBINED_COURSE_BLUEPRINT_ITEMS.EVALUATION, value: targetProfileId };
     });
     return Joi.attempt(data, contentSchema);
+  }
+  detachOrganization({ organizationId }) {
+    this.organizationIds = this.organizationIds.filter((id) => id !== organizationId);
   }
 }
 

--- a/api/src/quest/domain/usecases/detach-organization-from-combined-course-blueprint.js
+++ b/api/src/quest/domain/usecases/detach-organization-from-combined-course-blueprint.js
@@ -1,0 +1,14 @@
+import { NotFoundError } from '../../../shared/domain/errors.js';
+
+export async function detachOrganizationFromCombinedCourseBlueprint({
+  organizationId,
+  combinedCourseBlueprintId,
+  combinedCourseBlueprintRepository,
+}) {
+  const blueprint = await combinedCourseBlueprintRepository.findById({ id: combinedCourseBlueprintId });
+  if (!blueprint) {
+    throw new NotFoundError(`Combined course blueprint with id:${combinedCourseBlueprintId} not found`);
+  }
+  blueprint.detachOrganization({ organizationId });
+  await combinedCourseBlueprintRepository.save({ combinedCourseBlueprint: blueprint });
+}

--- a/api/src/quest/domain/usecases/index.js
+++ b/api/src/quest/domain/usecases/index.js
@@ -47,6 +47,7 @@ import { checkUserQuest } from './check-user-quest-success.js';
 import { createCombinedCourseBlueprint } from './create-combined-course-blueprint.js';
 import { createCombinedCourses } from './create-combined-courses.js';
 import { createOrUpdateQuestsInBatch } from './create-or-update-quests-in-batch.js';
+import { detachOrganizationFromCombinedCourseBlueprint } from './detach-organization-from-combined-course-blueprint.js';
 import { findCombinedCourseBlueprints } from './find-combined-course-blueprints.js';
 import { findCombinedCourseByCampaignId } from './find-combined-course-by-campaign-id.js';
 import { findCombinedCourseByModuleIdAndUserId } from './find-combined-course-by-moduleId-and-user-id.js';
@@ -66,6 +67,7 @@ import { updateCombinedCourse } from './update-combined-course.js';
 const usecasesWithoutInjectedDependencies = {
   checkUserQuest,
   createOrUpdateQuestsInBatch,
+  detachOrganizationFromCombinedCourseBlueprint,
   findCombinedCourseByCampaignId,
   findCombinedCourseByModuleIdAndUserId,
   getCombinedCourseByCode,

--- a/api/src/quest/infrastructure/repositories/combined-course-blueprint-repository.js
+++ b/api/src/quest/infrastructure/repositories/combined-course-blueprint-repository.js
@@ -1,4 +1,7 @@
+import difference from 'lodash/difference.js';
+
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
+import { NotFoundError } from '../../../shared/domain/errors.js';
 import { CombinedCourseBlueprint } from '../../domain/models/CombinedCourseBlueprint.js';
 
 /**
@@ -14,21 +17,80 @@ export async function findAll() {
 
 export async function save({ combinedCourseBlueprint }) {
   const knexConn = DomainTransaction.getConnection();
-  const [insertedValues] = await knexConn('combined_course_blueprints')
-    .insert({
-      ...combinedCourseBlueprint,
-      content: JSON.stringify(combinedCourseBlueprint.content),
-    })
-    .returning('*');
 
-  return new CombinedCourseBlueprint(insertedValues);
+  if (!combinedCourseBlueprint.id) {
+    const [insertedValues] = await knexConn('combined_course_blueprints')
+      .insert(_toDTO({ combinedCourseBlueprint }))
+      .returning('*');
+
+    return new CombinedCourseBlueprint(insertedValues);
+  }
+
+  const [updatedValues] = await knexConn('combined_course_blueprints')
+    .update(_toDTO({ combinedCourseBlueprint }))
+    .where({ id: combinedCourseBlueprint.id })
+    .returning('*');
+  await updateShares({ combinedCourseBlueprint, knexConn });
+
+  return new CombinedCourseBlueprint({ ...updatedValues, organizationIds: combinedCourseBlueprint.organizationIds });
+}
+
+async function updateShares({ combinedCourseBlueprint, knexConn }) {
+  const currentCombinedCourseBlueprint = await findById({ id: combinedCourseBlueprint.id });
+  if (!currentCombinedCourseBlueprint) {
+    throw new NotFoundError(`No combined course blueprint found with id ${combinedCourseBlueprint.id}`);
+  }
+
+  const organizationIdsToRemove = difference(
+    currentCombinedCourseBlueprint.organizationIds,
+    combinedCourseBlueprint.organizationIds,
+  );
+
+  if (organizationIdsToRemove.length > 0) {
+    await knexConn('combined_course_blueprint_shares').delete().whereIn('organizationId', organizationIdsToRemove);
+  }
 }
 
 export async function findById({ id }) {
   const knexConn = DomainTransaction.getConnection();
-  const result = await knexConn('combined_course_blueprints').where({ id }).first();
+  const result = await knexConn('combined_course_blueprints')
+    .select({
+      id: 'combined_course_blueprints.id',
+      name: 'combined_course_blueprints.name',
+      internalName: 'combined_course_blueprints.internalName',
+      description: 'combined_course_blueprints.description',
+      illustration: 'combined_course_blueprints.illustration',
+      content: 'combined_course_blueprints.content',
+      createdAt: 'combined_course_blueprints.createdAt',
+      updatedAt: 'combined_course_blueprints.updatedAt',
+      organizationIds: knexConn.raw(
+        `array_remove(array_agg("combined_course_blueprint_shares"."organizationId"), NULL)`,
+      ),
+    })
+    .leftJoin(
+      'combined_course_blueprint_shares',
+      'combined_course_blueprints.id',
+      'combined_course_blueprint_shares.combinedCourseBlueprintId',
+    )
+    .groupBy('combined_course_blueprints.id')
+    .where('combined_course_blueprints.id', id)
+    .first();
+
   if (!result) {
     return null;
   }
   return new CombinedCourseBlueprint(result);
+}
+
+function _toDTO({ combinedCourseBlueprint }) {
+  return {
+    id: combinedCourseBlueprint.id,
+    name: combinedCourseBlueprint.name,
+    internalName: combinedCourseBlueprint.internalName,
+    description: combinedCourseBlueprint.description,
+    illustration: combinedCourseBlueprint.illustration,
+    content: JSON.stringify(combinedCourseBlueprint.content),
+    createdAt: combinedCourseBlueprint.createdAt,
+    updatedAt: combinedCourseBlueprint.updatedAt,
+  };
 }

--- a/api/src/shared/domain/types/identifiers-type.js
+++ b/api/src/shared/domain/types/identifiers-type.js
@@ -61,6 +61,7 @@ const typesPositiveInteger32bits = [
   'certificationIssueReportId',
   'certificationVersionId',
   'combinedCourseId',
+  'combinedCourseBlueprintId',
   'complementaryCertificationBadgeId',
   'complementaryCertificationCourseId',
   'complementaryCertificationId',

--- a/api/tests/quest/acceptance/application/combined-course-blueprint-route_test.js
+++ b/api/tests/quest/acceptance/application/combined-course-blueprint-route_test.js
@@ -78,7 +78,7 @@ describe('Quest | Acceptance | Application | Combined course blueprint Route ', 
     });
   });
 
-  describe('GET /api/admin/combined-course-blueprints/:id', function () {
+  describe('GET /api/admin/combined-course-blueprints/:blueprintId', function () {
     context('when user is admin ', function () {
       it('should return combined course blueprint for given id', async function () {
         // given
@@ -102,6 +102,31 @@ describe('Quest | Acceptance | Application | Combined course blueprint Route ', 
         expect(response.statusCode).to.equal(200);
         expect(response.result.data.id).to.equal(combinedCourseBlueprint.id.toString());
         expect(response.result.data.type).to.equal('combined-course-blueprints');
+      });
+    });
+  });
+
+  describe('DELETE /api/admin/combined-course-blueprints/:blueprintId/organizations/:organizationId', function () {
+    context('when user is admin ', function () {
+      it('should detach a combined course blueprint from organization', async function () {
+        // given
+        const adminUser = await insertUserWithRoleSuperAdmin();
+
+        const { combinedCourseBlueprintId, organizationId } =
+          databaseBuilder.factory.buildCombinedCourseBlueprintShare();
+        await databaseBuilder.commit();
+
+        const options = {
+          method: 'DELETE',
+          url: `/api/admin/combined-course-blueprints/${combinedCourseBlueprintId}/organizations/${organizationId}`,
+          headers: generateAuthenticatedUserRequestHeaders({ userId: adminUser.id }),
+        };
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(204);
       });
     });
   });

--- a/api/tests/quest/integration/domain/usecases/detach-organization-from-combined-course-blueprint_test.js
+++ b/api/tests/quest/integration/domain/usecases/detach-organization-from-combined-course-blueprint_test.js
@@ -1,0 +1,39 @@
+import { usecases } from '../../../../../src/quest/domain/usecases/index.js';
+import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
+import { catchErr, databaseBuilder, expect } from '../../../../test-helper.js';
+
+describe('Integration | Combined course | Domain | UseCases | detach-organization-from-combined-course-blueprint', function () {
+  it('should detach an organization from a combined course blueprint', async function () {
+    // given
+    const combinedCourseBlueprintShare = databaseBuilder.factory.buildCombinedCourseBlueprintShare();
+    const combinedCourseBlueprintShare2 = databaseBuilder.factory.buildCombinedCourseBlueprintShare({
+      combinedCourseBlueprintId: combinedCourseBlueprintShare.combinedCourseBlueprintId,
+    });
+
+    await databaseBuilder.commit();
+
+    // when
+    await usecases.detachOrganizationFromCombinedCourseBlueprint({
+      combinedCourseBlueprintId: combinedCourseBlueprintShare.combinedCourseBlueprintId,
+      organizationId: combinedCourseBlueprintShare.organizationId,
+    });
+
+    // then
+    const result = await usecases.getCombinedCourseBlueprintById({
+      id: combinedCourseBlueprintShare.combinedCourseBlueprintId,
+    });
+
+    expect(result.organizationIds).deep.equal([combinedCourseBlueprintShare2.organizationId]);
+  });
+
+  it('should throw if combined course blueprint is not found', async function () {
+    // when
+    const error = await catchErr(usecases.detachOrganizationFromCombinedCourseBlueprint)({
+      combinedCourseBlueprintId: 123,
+      organizationId: 445,
+    });
+
+    // then
+    expect(error).instanceOf(NotFoundError);
+  });
+});

--- a/api/tests/quest/integration/domain/usecases/get-combined-course-blueprint-by-id_test.js
+++ b/api/tests/quest/integration/domain/usecases/get-combined-course-blueprint-by-id_test.js
@@ -35,6 +35,7 @@ describe('Integration | Quest | Domain | UseCases | get-combined-course-blueprin
       createdAt: now,
       updatedAt: now,
       content: [],
+      organizationIds: [],
     });
   });
 

--- a/api/tests/quest/integration/infrastructure/repositories/combined-course-blueprint-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/combined-course-blueprint-repository_test.js
@@ -1,48 +1,76 @@
 import { CombinedCourseBlueprint } from '../../../../../src/quest/domain/models/CombinedCourseBlueprint.js';
 import * as combinedCourseBluePrintRepository from '../../../../../src/quest/infrastructure/repositories/combined-course-blueprint-repository.js';
-import { databaseBuilder, domainBuilder, expect } from '../../../../test-helper.js';
+import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
+import { catchErr, databaseBuilder, domainBuilder, expect } from '../../../../test-helper.js';
 
 describe('Quest | Integration | Repository | combined-course-blueprint', function () {
   describe('#save', function () {
-    it('should save a combined course blueprint', async function () {
+    it('should create a combined course blueprint', async function () {
       // given
       const combinedCourseBlueprint = {
-        id: 1,
         name: 'Combined course IA',
         internalName: 'Ia combined course blueprint',
         description: "L'ia c'est magique",
         illustration: 'illustration/ia.svg',
-        createdAt: new Date(),
-        updatedAt: new Date(),
         content: CombinedCourseBlueprint.buildContentItems([{ moduleShortId: 'modulix' }]),
+        organizationIds: [],
       };
 
       // when
-      await combinedCourseBluePrintRepository.save({ combinedCourseBlueprint });
+      const savedCombinedCourseBlueprint = await combinedCourseBluePrintRepository.save({ combinedCourseBlueprint });
 
       // then
       const results = await combinedCourseBluePrintRepository.findAll();
       expect(results).lengthOf(1);
-      expect(results[0]).deep.equal(combinedCourseBlueprint);
+      expect(results[0]).deep.equal(savedCombinedCourseBlueprint);
+
+      expect(savedCombinedCourseBlueprint).deep.contain(combinedCourseBlueprint);
     });
 
-    it('should return created combined course blueprint', async function () {
+    it('should delete combined course blueprint share for a given organizationId', async function () {
       // given
-      const combinedCourseBlueprint = {
-        id: 1,
-        name: 'Combined course IA',
-        internalName: 'Ia combined course blueprint',
-        description: "L'ia c'est magique",
-        illustration: 'illustration/ia.svg',
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        content: CombinedCourseBlueprint.buildContentItems([{ moduleShortId: 'modulix' }]),
-      };
+      const combinedCourseBlueprintShare = databaseBuilder.factory.buildCombinedCourseBlueprintShare();
+      const combinedCourseBlueprintShare2 = databaseBuilder.factory.buildCombinedCourseBlueprintShare({
+        combinedCourseBlueprintId: combinedCourseBlueprintShare.combinedCourseBlueprintId,
+      });
+
+      await databaseBuilder.commit();
+
+      const combinedCourseBlueprint = await combinedCourseBluePrintRepository.findById({
+        id: combinedCourseBlueprintShare.combinedCourseBlueprintId,
+      });
+
+      combinedCourseBlueprint.detachOrganization({ organizationId: combinedCourseBlueprintShare.organizationId });
 
       // when
       const result = await combinedCourseBluePrintRepository.save({ combinedCourseBlueprint });
 
-      expect(result).deep.equal(combinedCourseBlueprint);
+      expect(result.organizationIds).deep.equal([combinedCourseBlueprintShare2.organizationId]);
+    });
+
+    it('should throw a NotFound error when combined course blueprint does not exist', async function () {
+      // given
+      const combinedCourseBlueprintShare = databaseBuilder.factory.buildCombinedCourseBlueprintShare();
+      databaseBuilder.factory.buildCombinedCourseBlueprintShare({
+        combinedCourseBlueprintId: combinedCourseBlueprintShare.combinedCourseBlueprintId,
+      });
+
+      await databaseBuilder.commit();
+
+      const combinedCourseBlueprint = await combinedCourseBluePrintRepository.findById({
+        id: combinedCourseBlueprintShare.combinedCourseBlueprintId,
+      });
+
+      combinedCourseBlueprint.detachOrganization({ organizationId: combinedCourseBlueprintShare.organizationId });
+
+      // when
+      const nonExistingCombinedCourseBlueprint = { ...combinedCourseBlueprint, id: 404 };
+      const error = await catchErr(combinedCourseBluePrintRepository.save)({
+        combinedCourseBlueprint: nonExistingCombinedCourseBlueprint,
+      });
+
+      // then
+      expect(error).instanceOf(NotFoundError);
     });
   });
 
@@ -63,12 +91,36 @@ describe('Quest | Integration | Repository | combined-course-blueprint', functio
     });
   });
   describe('#findById', function () {
-    it('should return combined course blueprint by its id', async function () {
-      const expectedCombinedCourseBlueprint = domainBuilder.buildCombinedCourseBlueprint();
-      databaseBuilder.factory.buildCombinedCourseBlueprint(expectedCombinedCourseBlueprint);
+    it('should return combined course blueprint by its id with shared organization ids', async function () {
+      const combinedCourseBlueprint = databaseBuilder.factory.buildCombinedCourseBlueprint();
+      const combinedCourseBlueprintShare = databaseBuilder.factory.buildCombinedCourseBlueprintShare({
+        combinedCourseBlueprintId: combinedCourseBlueprint.id,
+      });
       await databaseBuilder.commit();
 
+      const expectedCombinedCourseBlueprint = domainBuilder.buildCombinedCourseBlueprint({
+        ...combinedCourseBlueprint,
+        content: [],
+        organizationIds: [combinedCourseBlueprintShare.organizationId],
+      });
+
       const result = await combinedCourseBluePrintRepository.findById({ id: expectedCombinedCourseBlueprint.id });
+      expect(result.organizationIds).to.deep.equal([combinedCourseBlueprintShare.organizationId]);
+      expect(result).to.be.instanceOf(CombinedCourseBlueprint);
+      expect(result).to.deep.equal(expectedCombinedCourseBlueprint);
+    });
+
+    it('should return combined course blueprint by its id when it is not shared', async function () {
+      const combinedCourseBlueprint = databaseBuilder.factory.buildCombinedCourseBlueprint();
+      await databaseBuilder.commit();
+
+      const expectedCombinedCourseBlueprint = domainBuilder.buildCombinedCourseBlueprint({
+        ...combinedCourseBlueprint,
+        content: [],
+      });
+
+      const result = await combinedCourseBluePrintRepository.findById({ id: expectedCombinedCourseBlueprint.id });
+      expect(result.organizationIds).to.deep.equal([]);
       expect(result).to.be.instanceOf(CombinedCourseBlueprint);
       expect(result).to.deep.equal(expectedCombinedCourseBlueprint);
     });

--- a/api/tests/quest/unit/domain/models/CombinedCourseBlueprint_test.js
+++ b/api/tests/quest/unit/domain/models/CombinedCourseBlueprint_test.js
@@ -25,6 +25,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourseBlueprint ', function (
         content: CombinedCourseBlueprint.buildContentItems([{ moduleShortId: '123' }]),
         createdAt: new Date('2024-01-25'),
         updatedAt: new Date('2024-01-26'),
+        organizationIds: [],
       };
       // when
       const blueprint = new CombinedCourseBlueprint(values);
@@ -235,6 +236,25 @@ describe('Quest | Unit | Domain | Models | CombinedCourseBlueprint ', function (
       expect(combinedCourse.illustration).to.equal(illustration);
       expect(combinedCourse.code).to.equal(code);
       expect(combinedCourse.organizationId).to.equal(organizationId);
+    });
+  });
+
+  describe('#detachOrganization', function () {
+    it('should retrieve organization id from model instance', async function () {
+      //given
+      const combinedCourseBlueprint = new CombinedCourseBlueprint({
+        name: 'Blueprint1',
+        content: [],
+        description: '',
+        illustration: '',
+        organizationIds: [1],
+      });
+
+      //when
+      combinedCourseBlueprint.detachOrganization({ organizationId: 1 });
+
+      //then
+      expect(combinedCourseBlueprint.organizationIds).empty;
     });
   });
 });

--- a/api/tests/tooling/domain-builder/factory/build-combined-course-blueprint.js
+++ b/api/tests/tooling/domain-builder/factory/build-combined-course-blueprint.js
@@ -12,6 +12,7 @@ function buildCombinedCourseBlueprint({
   createdAt = new Date(),
   updatedAt = new Date(),
   content = [{ type: COMBINED_COURSE_BLUEPRINT_ITEMS.MODULE, value: 'module-123' }],
+  organizationIds = [],
 } = {}) {
   return new CombinedCourseBlueprint({
     id,
@@ -22,6 +23,7 @@ function buildCombinedCourseBlueprint({
     content,
     createdAt,
     updatedAt,
+    organizationIds,
   });
 }
 


### PR DESCRIPTION
## ❄️ Problème

On ne peut pas détacher une organization d'un schéma de parcours.

## 🛷 Proposition

Permettre le détachement d'une organisation

## ☃️ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🧑‍🎄 Pour tester

- Aller sur “Schémas de parcours combiné”,
- partie “Organisations” 
- cliquer sur “Détacher” dans la ligne de l’organisation
- ne plus voir l'organisation
- Vérifier en BDD que la ligne dans combined_course_blueprint_shares n’existe plus.
