### PR TITLE
[TECH] Masquer certains modules qui ont le même titre (PIX-21113)

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenPrompt_IND_altconfig.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenPrompt_IND_altconfig.json
@@ -4,7 +4,7 @@
   "slug": "prompt-intermediaire-alt",
   "title": "J’améliore mes prompts !",
   "isBeta": true,
-  "visibility": "public",
+  "visibility": "private",
   "details": {
     "image": "https://assets.pix.org/modules/jameliore-mes-prompts/picto_moduleIA_prompt2.svg",
     "description": "<p>Les logiciels d’IA générative permettent de répondre à une grande variété de nos demandes. Mais la qualité de leurs réponses dépend beaucoup des questions qu’on leur pose, c’est-à-dire, des prompts qu’on leur donne. Dans ce module, vous allez apprendre à formuler des prompts efficaces et à ajuster vos demandes pour améliorer le résultat proposé par le logiciel d’IA générative.&nbsp;<br></p>",
@@ -150,12 +150,7 @@
                     "diagnosis": "<p>Il faut donner le plus de précisions possible. Plus l’IA a d’informations sur la situation, meilleure sera sa réponse.&nbsp;<br></p>"
                   }
                 },
-                "solutions": [
-                  "1",
-                  "2",
-                  "3",
-                  "4"
-                ]
+                "solutions": ["1", "2", "3", "4"]
               }
             }
           ]
@@ -475,10 +470,7 @@
                           "diagnosis": "<p>Ici, le <strong>format </strong>est le <strong>dialogue </strong>et le <strong>contexte</strong>, celui du <strong>match de volley.</strong></p>"
                         }
                       },
-                      "solutions": [
-                        "1",
-                        "2"
-                      ]
+                      "solutions": ["1", "2"]
                     }
                   ]
                 },
@@ -517,11 +509,7 @@
                           "diagnosis": "<p>Ici, le <strong>format </strong>est un court <strong>discours</strong>, le <strong>ton </strong>est <strong>amusant</strong>. Le <strong>contexte </strong>est le <strong>pot de départ </strong>d’un joueur de volley, décrit avec des éléments précis comme ses qualités et ses défauts.</p>"
                         }
                       },
-                      "solutions": [
-                        "1",
-                        "2",
-                        "3"
-                      ]
+                      "solutions": ["1", "2", "3"]
                     }
                   ]
                 }
@@ -630,11 +618,7 @@
                     "placeholder": "Nom du gymnase",
                     "ariaLabel": "Nom du gymnase",
                     "defaultValue": "",
-                    "tolerances": [
-                      "t1",
-                      "t2",
-                      "t3"
-                    ],
+                    "tolerances": ["t1", "t2", "t3"],
                     "solutions": [
                       "Le gymnase des 3 sapins",
                       "gymnase des 3 sapins",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenPrompt_NOV_altconfig.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenPrompt_NOV_altconfig.json
@@ -4,7 +4,7 @@
   "slug": "ia-premier-prompt-alt",
   "title": "Mon premier prompt !",
   "isBeta": true,
-  "visibility": "public",
+  "visibility": "private",
   "details": {
     "image": "https://assets.pix.org/modules/placeholder-details.svg",
     "description": "<p>Les logiciels d’IA générative comme Le Chat, ChatGPT, Gemini ou encore DeepSeek, vous en avez déjà entendu parler. Mais, savez-vous comment on les utilise ?</p><p>Le secret tient en un mot : prompt. C’est quoi au juste un prompt ? C’est ce que vous allez découvrir dans ce module.</p>",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/ia-deepfakes-alt.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/ia-deepfakes-alt.json
@@ -4,7 +4,7 @@
   "slug": "ia-deepfakes-alt",
   "title": "Les deepfakes (hypertrucages) : c’est quoi ?",
   "isBeta": true,
-  "visibility": "public",
+  "visibility": "private",
   "details": {
     "image": "https://assets.pix.org/modules/placeholder-details.svg",
     "description": "<p>Sur internet, on trouve des images, des vidéos et des sons. Certains sont vrais mais d'autres sont faux&nbsp;: ils sont créés pour ressembler à la réalité.<br>Dans ce module, vous allez découvrir comment les deepfakes (ou hypertrucages en français) sont créés et pourquoi.</p>",
@@ -700,10 +700,7 @@
                           "diagnosis": "<p>La création d'un deepfake ne demande pas beaucoup de matériel ni de compétences.</p>"
                         }
                       },
-                      "solutions": [
-                        "1",
-                        "3"
-                      ]
+                      "solutions": ["1", "3"]
                     }
                   ]
                 },


### PR DESCRIPTION
## ❄️ Problème

On a remarqué que plusieurs modules ont le même titre. Cela est problématique, côté Pix Admin, car on ne sait pas lequel sélectionner.

## 🛷 Proposition
Passer l'attribut visibility à `private` sur les modules avec un slug contenant un alt.

## ☃️ Remarques

RAS

## 🧑‍🎄 Pour tester

- Se connecter à Pix Admin et aller sur le formulaire de création ou de mise à jour d'un CF ([lien](https://admin-pr14738.review.pix.fr/trainings/new))
- Sélectionner le format Modulix
- Vérifier qu'il n'y a plus de titres de modules dupliqués
