### PR TITLE
[TECH] Création d'un script pour la modification des urls des badges de complémentaire pour qu'ils pointent sur assets (PIX-21109).

### DIFF
--- a/api/db/seeds/data/common/complementary-certification-builder.js
+++ b/api/db/seeds/data/common/complementary-certification-builder.js
@@ -595,7 +595,7 @@ function _createComplementaryWithHasComplementaryReferential(databaseBuilder) {
     badgeId: PIX_DROIT_INITIE_CERTIFIABLE_BADGE_ID,
     complementaryCertificationId: PIX_DROIT_COMPLEMENTARY_CERTIFICATION_ID,
     level: 1,
-    imageUrl: 'https://images.pix.fr/badges-certifies/pix-droit/initie.svg',
+    imageUrl: 'https://assets.pix.org/badges-certifies/pix-droit/initie.svg',
     label: 'Pix+ Droit Initié',
     certificateMessage: null,
     temporaryCertificateMessage: null,

--- a/api/scripts/modulix/modify-urls-domain-for-pix-assets.js
+++ b/api/scripts/modulix/modify-urls-domain-for-pix-assets.js
@@ -1,0 +1,76 @@
+import { knex } from '../../db/knex-database-connection.js';
+import { Script } from '../../src/shared/application/scripts/script.js';
+import { ScriptRunner } from '../../src/shared/application/scripts/script-runner.js';
+
+const OLD_DOMAIN = 'images.pix.fr';
+const NEW_DOMAIN = 'assets.pix.org';
+
+export class ModifyComplementaryCertificationBadgeUrlsDomain extends Script {
+  constructor() {
+    super({
+      description: 'Change the domain of complementary certification badge URLs for Pix Assets',
+      permanent: false,
+      options: {
+        dryRun: {
+          type: 'boolean',
+          describe: 'Run the script without making any database changes',
+          default: false,
+        },
+      },
+    });
+  }
+
+  async handle({ logger, options }) {
+    const { dryRun } = options;
+    logger.info('Script execution started');
+
+    const trx = await knex.transaction();
+    try {
+      const complementaryCertificationBadgesToBeUpdated = await trx('complementary-certification-badges').whereLike(
+        'imageUrl',
+        `%${OLD_DOMAIN}%`,
+      );
+      logger.info(
+        `Number of complementary certification badges with a imageUrl containing the old domain: ${complementaryCertificationBadgesToBeUpdated.length}`,
+      );
+
+      for (const complementaryCertificationBadge of complementaryCertificationBadgesToBeUpdated) {
+        complementaryCertificationBadge.imageUrl = modifyUrlWithNewDomain(complementaryCertificationBadge.imageUrl);
+        await trx('complementary-certification-badges')
+          .update({ imageUrl: complementaryCertificationBadge.imageUrl })
+          .where({ id: complementaryCertificationBadge.id });
+      }
+
+      if (dryRun) {
+        const complementaryCertificationBadges = await trx('complementary-certification-badges')
+          .select('imageUrl')
+          .whereLike('imageUrl', `%${OLD_DOMAIN}%`);
+        const complementaryCertificationBadgesUrlUpdated = complementaryCertificationBadges.map(
+          (item) => item.imageUrl,
+        );
+
+        logger.info(
+          `Complementary certification badges list with old domain after update : ${complementaryCertificationBadgesUrlUpdated}`,
+        );
+
+        await trx.rollback();
+        return;
+      }
+
+      await trx.commit();
+      logger.info(
+        `${complementaryCertificationBadgesToBeUpdated.length} complementary certification badges have been successfully updated`,
+      );
+      return;
+    } catch (error) {
+      await trx.rollback();
+      throw error;
+    }
+  }
+}
+
+function modifyUrlWithNewDomain(url) {
+  return url.replace(`https://${OLD_DOMAIN}`, `https://${NEW_DOMAIN}`);
+}
+
+await ScriptRunner.execute(import.meta.url, ModifyComplementaryCertificationBadgeUrlsDomain);

--- a/api/tests/integration/scripts/modulix/modify-urls-domain-for-pix-assets_test.js
+++ b/api/tests/integration/scripts/modulix/modify-urls-domain-for-pix-assets_test.js
@@ -1,0 +1,115 @@
+import { ModifyComplementaryCertificationBadgeUrlsDomain } from '../../../../scripts/modulix/modify-urls-domain-for-pix-assets.js';
+import { databaseBuilder, expect, knex, sinon } from '../../../test-helper.js';
+
+const OLD_DOMAIN = 'images.pix.fr';
+const NEW_DOMAIN = 'assets.pix.org';
+
+describe('integration | modulix | scripts | modify-urls-domain-for-pix-assets', function () {
+  describe('#handle', function () {
+    let file;
+    let script;
+    let logger;
+
+    beforeEach(function () {
+      script = new ModifyComplementaryCertificationBadgeUrlsDomain();
+      logger = { info: sinon.spy(), error: sinon.spy() };
+    });
+
+    it('runs the script with dryRun', async function () {
+      // given
+      const complementaryCertification = databaseBuilder.factory.buildComplementaryCertification({
+        id: 1,
+        label: 'Pix+ Édu 2nd degré',
+        key: 'Édu',
+      });
+      const otherComplementaryCertification = databaseBuilder.factory.buildComplementaryCertification({
+        id: 2,
+        label: 'Pix+ Droit',
+        key: 'Droit',
+      });
+      databaseBuilder.factory.buildComplementaryCertificationBadge({
+        id: 1,
+        imageUrl: `https://${OLD_DOMAIN}/badges/edu.svg`,
+        complementaryCertificationId: complementaryCertification.id,
+      });
+      databaseBuilder.factory.buildComplementaryCertificationBadge({
+        id: 2,
+        imageUrl: `https://${OLD_DOMAIN}/badges-certifies/edu.svg`,
+        complementaryCertificationId: otherComplementaryCertification.id,
+      });
+      await databaseBuilder.commit();
+
+      // when
+      await script.handle({
+        options: { file, dryRun: true },
+        logger,
+      });
+
+      // then
+      expect(logger.info).to.have.been.calledWith(
+        'Complementary certification badges list with old domain after update : ',
+      );
+
+      const complementaryCertificationBadges = await knex('complementary-certification-badges').orderBy('id');
+      expect(complementaryCertificationBadges[0].imageUrl).to.equal(`https://${OLD_DOMAIN}/badges/edu.svg`);
+      expect(complementaryCertificationBadges[1].imageUrl).to.equal(`https://${OLD_DOMAIN}/badges-certifies/edu.svg`);
+    });
+
+    describe('For complementary certification badge imageUrl', function () {
+      it('modify the urls domain', async function () {
+        // given
+        const complementaryCertification = databaseBuilder.factory.buildComplementaryCertification({
+          id: 1,
+          label: 'Pix+ Édu 2nd degré',
+          key: 'Édu',
+        });
+        const otherComplementaryCertification = databaseBuilder.factory.buildComplementaryCertification({
+          id: 2,
+          label: 'Pix+ Droit',
+          key: 'Droit',
+        });
+        databaseBuilder.factory.buildComplementaryCertificationBadge({
+          id: 1,
+          imageUrl: `https://${OLD_DOMAIN}/badges/edu.svg`,
+          complementaryCertificationId: complementaryCertification.id,
+        });
+        databaseBuilder.factory.buildComplementaryCertificationBadge({
+          id: 2,
+          imageUrl: `https://${OLD_DOMAIN}/badges/edu2.svg`,
+          complementaryCertificationId: complementaryCertification.id,
+        });
+        databaseBuilder.factory.buildComplementaryCertificationBadge({
+          id: 3,
+          imageUrl: `https://${OLD_DOMAIN}/badges/Pix_plus_Edu-4-Expert-certif.svg`,
+          complementaryCertificationId: otherComplementaryCertification.id,
+        });
+        databaseBuilder.factory.buildComplementaryCertificationBadge({
+          id: 4,
+          imageUrl: `https://${OLD_DOMAIN}/badges-certifies/edu.svg`,
+          complementaryCertificationId: complementaryCertification.id,
+        });
+        await databaseBuilder.commit();
+
+        // when
+        await script.handle({
+          options: { file },
+          logger,
+        });
+
+        // then
+        const complementaryCertificationBadges = await knex('complementary-certification-badges').orderBy('id');
+        expect(complementaryCertificationBadges[0].imageUrl).to.equal(`https://${NEW_DOMAIN}/badges/edu.svg`);
+        expect(complementaryCertificationBadges[1].imageUrl).to.equal(`https://${NEW_DOMAIN}/badges/edu2.svg`);
+        expect(complementaryCertificationBadges[2].imageUrl).to.equal(
+          `https://${NEW_DOMAIN}/badges/Pix_plus_Edu-4-Expert-certif.svg`,
+        );
+
+        expect(complementaryCertificationBadges[3].imageUrl).to.equal(`https://${NEW_DOMAIN}/badges-certifies/edu.svg`);
+
+        expect(logger.info).to.have.been.calledWith(
+          'Number of complementary certification badges with a imageUrl containing the old domain: 4',
+        );
+      });
+    });
+  });
+});


### PR DESCRIPTION
## ❄️ Problème
Un chantier a été lancé fin 2025 pour faire la migration du dossier `badges` et `contenu-formatifs` de `pix-images` vers `pix-assets`. Le dossier badges à du coup été supprimé coté `pix-images`.

Or les badges des complémentaires possèdent en BDD des liens qui pointaient encore sur `images.pix.fr`.

## 🛷 Proposition

Créer un script permettant de modifier ces liens vers assets.pix.org

## ☃️ Remarques

Un script avait déjà été créé pour modifier les liens des tables `badges` et `trainings`, je suis partie de ce dernier pour celui-ci https://github.com/1024pix/pix/pull/14271

## 🧑‍🎄 Pour tester
En local, modifier des urls coté complementary-certification-badges (`imageUrl`) avec les formats suivants : 

`https://images.pix.fr./badges/CleA_Num_certif.svg`
`https://images.pix.fr/badges-certifies/ce-lien-doit-aussi-changer.svg`
`https://images.pix.fr/badges/Pix_plus_Edu-1-Initie-certif.svg`

---

=> Lancer le script en DRYRUN

```shell
node --env-file-if-exists=api/.env api/scripts/modulix/modify-urls-domain-for-pix-assets.js --dryRun
```

Constater que les logs listent les urls corrigées mais que votre BDD n'a pas été impactée.

---

=> Lancer le script

```shell
LOG_LEVEL=debug LOG_ENABLED=true node api/scripts/modulix/modify-urls-domain-for-pix-assets.js
```

Constater : 
- Que les urls possèdent le domaine `assets.pix.org 
`