### PR TITLE
[TECH] Rechercher un centre de certif sans tenir compte des accents ET des caractères spéciaux (PIX-20416)

### DIFF
--- a/api/src/organizational-entities/infrastructure/repositories/certification-center.repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/certification-center.repository.js
@@ -89,7 +89,14 @@ const _setSearchFiltersForQueryBuilder = (filters, queryBuilder) => {
     queryBuilder.whereRaw('CAST(id as TEXT) LIKE ?', `%${id.toString().toLowerCase()}%`);
   }
   if (name) {
-    queryBuilder.whereRaw('unaccent(name) ILIKE unaccent(?)', [`%${name}%`]);
+    queryBuilder.whereRaw(
+      `
+      regexp_replace(unaccent(name), '[^[:alnum:]]', '', 'g')
+      ILIKE
+      '%' || regexp_replace(unaccent(?), '[^[:alnum:]]', '', 'g') || '%'
+      `,
+      [name],
+    );
   }
   if (type) {
     queryBuilder.whereILike('type', `%${type}%`);

--- a/api/src/organizational-entities/infrastructure/repositories/certification-center.repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/certification-center.repository.js
@@ -89,7 +89,7 @@ const _setSearchFiltersForQueryBuilder = (filters, queryBuilder) => {
     queryBuilder.whereRaw('CAST(id as TEXT) LIKE ?', `%${id.toString().toLowerCase()}%`);
   }
   if (name) {
-    queryBuilder.whereILike('name', `%${name}%`);
+    queryBuilder.whereRaw('unaccent(name) ILIKE unaccent(?)', [`%${name}%`]);
   }
   if (type) {
     queryBuilder.whereILike('type', `%${type}%`);

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/certification-center.repository.test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/certification-center.repository.test.js
@@ -335,6 +335,35 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
         ]);
         expect(pagination).to.deep.equal(expectedPagination);
       });
+
+      it('should return certification centers matching "name" with accents ignored', async function () {
+        // given
+        databaseBuilder.factory.buildCertificationCenter({ name: 'Centre de certification College' });
+        databaseBuilder.factory.buildCertificationCenter({ name: 'Centre de certification Collège' });
+        databaseBuilder.factory.buildCertificationCenter({ name: 'Centre de certification Broca & co' });
+        databaseBuilder.factory.buildCertificationCenter({ name: 'Centre de certification Donnie & co' });
+
+        await databaseBuilder.commit();
+
+        const filter = { name: 'college' };
+        const page = { number: 1, size: 10 };
+        const expectedPagination = { page: page.number, pageSize: page.size, pageCount: 1, rowCount: 2 };
+
+        // when
+        const { models: matchingOrganizations, pagination } = await certificationCenterRepository.findPaginatedFiltered(
+          {
+            filter,
+            page,
+          },
+        );
+
+        // then
+        expect(_.map(matchingOrganizations, 'name')).to.have.members([
+          'Centre de certification College',
+          'Centre de certification Collège',
+        ]);
+        expect(pagination).to.deep.equal(expectedPagination);
+      });
     });
 
     context('when there are multiple CertificationCenters matching the same "type" search pattern', function () {

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/certification-center.repository.test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/certification-center.repository.test.js
@@ -339,7 +339,7 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
       it('should return certification centers matching "name" with accents ignored', async function () {
         // given
         databaseBuilder.factory.buildCertificationCenter({ name: 'Centre de certification College' });
-        databaseBuilder.factory.buildCertificationCenter({ name: 'Centre de certification Collège' });
+        databaseBuilder.factory.buildCertificationCenter({ name: 'Centre de certification Collège+' });
         databaseBuilder.factory.buildCertificationCenter({ name: 'Centre de certification Broca & co' });
         databaseBuilder.factory.buildCertificationCenter({ name: 'Centre de certification Donnie & co' });
 
@@ -360,7 +360,7 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
         // then
         expect(_.map(matchingOrganizations, 'name')).to.have.members([
           'Centre de certification College',
-          'Centre de certification Collège',
+          'Centre de certification Collège+',
         ]);
         expect(pagination).to.deep.equal(expectedPagination);
       });


### PR DESCRIPTION
## ❄️ Problème

La recherche centre de certification par nom ne retourne pas les résultats suivant que l'on rentre des accents, des caractères spéciaux ou non.

Ex: "franche-comté", "franche comté++" et "franche comté" renvoient des résultats différents.

## 🛷 Proposition

On filtre via la regexp PG `[^[:alnum:]]` (filtre sur caractères alpha-numériques)

## ☃️ Remarques

Tout pareil que #14658 et #14363

## 🧑‍🎄 Pour tester

- Sur pix-admin, checker que des résultats avec ou sans caractères spéciaux renvoient le même résultat 
-  Example avec "pro certification center" : 

<img width="1616" height="410" alt="image" src="https://github.com/user-attachments/assets/d67b1624-90ba-4082-84ba-bdc8e273a491" />

