### PR TITLE
[FEATURE] Recevoir les réponses vides des embeds (PIX-21115)

### DIFF
--- a/mon-pix/app/components/challenge-item/challenge-item-qroc.gjs
+++ b/mon-pix/app/components/challenge-item/challenge-item-qroc.gjs
@@ -213,9 +213,8 @@ export default class ChallengeItemQroc extends ChallengeItemGeneric {
 
   _receiveEmbedMessage(event) {
     const message = this._getMessageFromEventData(event);
-    if (message && message.answer && message.from === 'pix') {
-      this.autoReplyAnswer = message.answer;
-    }
+    if (message == null || message.answer == null || message.from !== 'pix') return;
+    this.autoReplyAnswer = message.answer;
   }
 
   _getMessageFromEventData(event) {


### PR DESCRIPTION
## ❄️ Problème

Sur un QCM image quand on coche des réponses puis qu’on décoche tout, la dernière réponse cochée est gardée en mémoire.
On souhaite que le décochage de la dernière réponse soit pris en compte.

## 🛷 Proposition

Écouter les réponses vides des emneds

## ☃️ Remarques

N/A

## 🧑‍🎄 Pour tester

Aller sur https://app-pr14742.review.pix.fr/challenges/challenge100eoixavkx0kM/preview
Essayer de cocher des réponses puis de tout décocher et de valider.