### PR TITLE
[BUGFIX] Réparer les QROCM des modules qui renseignent du valeur par défaut (PIX-21079).

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYGestionMDP_IND.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYGestionMDP_IND.json
@@ -587,7 +587,7 @@
                     "display": "inline",
                     "placeholder": "- Sélectionner -",
                     "ariaLabel": "nom du gestionnaire",
-                    "defaultValue": "- Sélectionner -",
+                    "defaultValue": "",
                     "tolerances": [
                       "t1",
                       "t2",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYPhishing_AVA.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYPhishing_AVA.json
@@ -150,7 +150,7 @@
                     "display": "inline",
                     "placeholder": "- Sélectionner -",
                     "ariaLabel": "- Sélectionner -",
-                    "defaultValue": "- Sélectionner -",
+                    "defaultValue": "",
                     "tolerances": [
                       "t1",
                       "t2",
@@ -184,7 +184,7 @@
                     "display": "inline",
                     "placeholder": "- Sélectionner -",
                     "ariaLabel": "- Sélectionner -",
-                    "defaultValue": "- Sélectionner -",
+                    "defaultValue": "",
                     "tolerances": [
                       "t1",
                       "t2",
@@ -218,7 +218,7 @@
                     "display": "inline",
                     "placeholder": "- Sélectionner -",
                     "ariaLabel": "- Sélectionner -",
-                    "defaultValue": "- Sélectionner -",
+                    "defaultValue": "",
                     "tolerances": [
                       "t1",
                       "t2",
@@ -252,7 +252,7 @@
                     "display": "inline",
                     "placeholder": "- Sélectionner -",
                     "ariaLabel": "- Sélectionner -",
-                    "defaultValue": "- Sélectionner -",
+                    "defaultValue": "",
                     "tolerances": [
                       "t1",
                       "t2",
@@ -934,7 +934,7 @@
                           "display": "inline",
                           "placeholder": "- Sélectionner -",
                           "ariaLabel": "- Sélectionner -",
-                          "defaultValue": "- Sélectionner -",
+                          "defaultValue": "",
                           "tolerances": [
                             "t1",
                             "t2",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYPhishing_IND.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYPhishing_IND.json
@@ -495,7 +495,7 @@
                     "display": "inline",
                     "placeholder": "-Sélectionner-",
                     "ariaLabel": "-Sélectionner-",
-                    "defaultValue": "-Sélectionner-",
+                    "defaultValue": "",
                     "tolerances": [],
                     "options": [
                       {
@@ -525,7 +525,7 @@
                     "display": "inline",
                     "placeholder": "-Sélectionner-",
                     "ariaLabel": "-Sélectionner-",
-                    "defaultValue": "-Sélectionner-",
+                    "defaultValue": "",
                     "tolerances": [],
                     "options": [
                       {
@@ -555,7 +555,7 @@
                     "display": "inline",
                     "placeholder": "-Sélectionner-",
                     "ariaLabel": "-Sélectionner-",
-                    "defaultValue": "-Sélectionner-",
+                    "defaultValue": "",
                     "tolerances": [],
                     "options": [
                       {
@@ -618,7 +618,7 @@
                     "display": "inline",
                     "placeholder": "tapez le nom",
                     "ariaLabel": "tapez le nom",
-                    "defaultValue": "tapez le nom",
+                    "defaultValue": "",
                     "tolerances": [
                       "t1"
                     ],

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IADefinition_IND.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IADefinition_IND.json
@@ -626,7 +626,7 @@
                     "display": "inline",
                     "placeholder": "Sélectionner",
                     "ariaLabel": "Sélectionner",
-                    "defaultValue": "Sélectionner",
+                    "defaultValue": "",
                     "tolerances": [],
                     "options": [
                       {
@@ -652,7 +652,7 @@
                     "display": "inline",
                     "placeholder": "Sélectionner",
                     "ariaLabel": "Sélectionner",
-                    "defaultValue": "Sélectionner",
+                    "defaultValue": "",
                     "tolerances": [],
                     "options": [
                       {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenBiais_AVA.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenBiais_AVA.json
@@ -616,7 +616,7 @@
                     "display": "inline",
                     "placeholder": "Nom du pays",
                     "ariaLabel": "Nom du pays",
-                    "defaultValue": "Nom du pays",
+                    "defaultValue": "",
                     "tolerances": [
                       "t1",
                       "t2",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/NR-Datacenter-NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/NR-Datacenter-NOV.json
@@ -920,7 +920,7 @@
                     "display": "inline",
                     "placeholder": "",
                     "ariaLabel": "retour de la réponse",
-                    "defaultValue": "retour de la réponse",
+                    "defaultValue": "",
                     "tolerances": [],
                     "options": [
                       {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/nr_durabilite_ind.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/nr_durabilite_ind.json
@@ -196,7 +196,7 @@
                     "display": "block",
                     "placeholder": "Sélectionnez une réponse.",
                     "ariaLabel": "Sélectionner un usage pour le lithium",
-                    "defaultValue": "Sélectionner un usage",
+                    "defaultValue": "",
                     "tolerances": [],
                     "options": [
                       {
@@ -226,7 +226,7 @@
                     "display": "block",
                     "placeholder": "Sélectionnez une réponse.",
                     "ariaLabel": "Sélectionner un usage pour les terres rares",
-                    "defaultValue": "Sélectionner un usage",
+                    "defaultValue": "",
                     "tolerances": [],
                     "options": [
                       {
@@ -256,7 +256,7 @@
                     "display": "block",
                     "placeholder": "Sélectionnez une réponse.",
                     "ariaLabel": "Sélectionner un usage pour l’or, le cuivre et l’argent",
-                    "defaultValue": "Sélectionner un usage",
+                    "defaultValue": "",
                     "tolerances": [],
                     "options": [
                       {
@@ -868,7 +868,7 @@
                     "display": "block",
                     "placeholder": "Sélectionner un rang",
                     "ariaLabel": "Sélectionner un rang pour l’achat d’un appareil neuf",
-                    "defaultValue": "Sélectionner un rang",
+                    "defaultValue": "",
                     "tolerances": [],
                     "options": [
                       {
@@ -902,7 +902,7 @@
                     "display": "block",
                     "placeholder": "Sélectionner un rang",
                     "ariaLabel": "Sélectionner un rang pour l’achat reconditionné alors que l’appareil fonctionne encore",
-                    "defaultValue": "Sélectionner un rang",
+                    "defaultValue": "",
                     "tolerances": [],
                     "options": [
                       {
@@ -936,7 +936,7 @@
                     "display": "block",
                     "placeholder": "Sélectionner un rang",
                     "ariaLabel": "Sélectionner un rang pour l’achat reconditionné après fin de vie",
-                    "defaultValue": "Sélectionner un rang",
+                    "defaultValue": "",
                     "tolerances": [],
                     "options": [
                       {
@@ -970,7 +970,7 @@
                     "display": "block",
                     "placeholder": "Sélectionner un rang",
                     "ariaLabel": "Sélectionner un rang pour la réparation",
-                    "defaultValue": "Sélectionner un rang",
+                    "defaultValue": "",
                     "tolerances": [],
                     "options": [
                       {

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qrocm-schema.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qrocm-schema.js
@@ -27,7 +27,9 @@ const blockSelectSchema = Joi.object({
   display: Joi.string().valid('inline', 'block').required(),
   placeholder: htmlNotAllowedSchema.allow('').required(),
   ariaLabel: htmlNotAllowedSchema.required(),
-  defaultValue: htmlNotAllowedSchema.allow('').required(),
+  defaultValue: Joi.string().valid('').required().messages({
+    'any.only': '"defaultValue" must be an empty string when type is select, but you provided {#value}',
+  }),
   tolerances: Joi.array().empty().required(),
   options: Joi.array()
     .items(

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js
@@ -609,7 +609,7 @@ describe('Unit | Infrastructure | Datasources | Learning Content | Module Dataso
         display: 'block',
         placeholder: '<br> hello',
         ariaLabel: "Remplir avec le <span>caractère</span> qui permet de séparer les deux parties d'une adresse mail",
-        defaultValue: '<div>cassé</div>',
+        defaultValue: '-Sélectionner-',
         tolerances: [],
         options: [
           {
@@ -624,7 +624,7 @@ describe('Unit | Infrastructure | Datasources | Learning Content | Module Dataso
         '"input" failed custom validation because HTML is not allowed in this field',
         '"placeholder" failed custom validation because HTML is not allowed in this field',
         '"ariaLabel" failed custom validation because HTML is not allowed in this field',
-        '"defaultValue" failed custom validation because HTML is not allowed in this field',
+        '"defaultValue" must be an empty string when type is select, but you provided -Sélectionner-',
         '"options[0].content" failed custom validation because HTML is not allowed in this field',
       ];
 


### PR DESCRIPTION
## ❄️ Problème
Actuellement, quand on clique sur vérifier la réponse d'un QROCM sans répondre aux propositions, cela affiche un feedback. Or, il devrait y avoir l'affichage d'une alerte qui indique qu'il faut répondre aux propositions.

## 🛷 Proposition
Le problème provient du fait qu'une valeur par défaut est renseignée dans les select des qrocm. Une première résolution est donc de la mettre à `''`. 

## ☃️ Remarques
L'utilité de ce champs dans le cas des select pour un qrocm se pose. Le supprimer de modulix editor permettrait de ne plus avoir le pb à l'avenir. Peut être pourrions nous également le supprimer des inputs ?

## 🧑‍🎄 Pour tester
Aller sur chaque module modifié et vérifier que le QROCM affiche bien l'alerte tant que Tous les champs n'ont pas été répondus:

- [x] https://app-pr14743.review.pix.fr/modules/cyber-gestionnaire
- [x] https://app-pr14743.review.pix.fr/modules/cyber-ingenierie-sociale
- [x] https://app-pr14743.review.pix.fr/modules/ia-def-ind
- [x] https://app-pr14743.review.pix.fr/modules/anatomie-message-arnaque
- [x] https://app-pr14743.review.pix.fr/modules/cyber-virus-nov
- [x] https://app-pr14743.review.pix.fr/modules/metaux-eau-reemploi
- [x] https://app-pr14743.review.pix.fr/modules/iagenbiais-avance
- [x] https://app-pr14743.review.pix.fr/modules/centre-de-donnee-novice