### PR TITLE
[FEATURE] Renommer la fonctionnalité "Afficher la page places" (PIX-20908)

### DIFF
--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -775,7 +775,7 @@
             "enabled": "with auto block",
             "label": "Block organization in case of places limit exceeded"
           },
-          "PLACES_MANAGEMENT": "Display the Places page on PixOrga",
+          "PLACES_MANAGEMENT": "Places management",
           "SHOW_NPS": "Net Promoter Score display",
           "SHOW_SKILLS": "Displaying skills in the results export",
           "attestation-list": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -777,7 +777,7 @@
             "enabled": "Avec blocage automatique",
             "label": "Blocage de l'organisation en cas de dépassement des places"
           },
-          "PLACES_MANAGEMENT": "Affichage de la page Places sur PixOrga",
+          "PLACES_MANAGEMENT": "Gestion des places",
           "SHOW_NPS": "Affichage du Net Promoter Score",
           "SHOW_SKILLS": "Affichage des acquis dans l'export de résultats",
           "attestation-list": {


### PR DESCRIPTION
## ❄️ Problème

Auj, la fonctionnalité s’appelle “Affichage de la page Places sur PixOrga”. Cette fonctionnalité ne se résumé plus qu'à afficher la page. Ca va aussi bloquer la possibilité d’ajouter un lot de places si la case n’est pas cochée par exemple


## 🛷 Proposition

Proposition, renommer cette fonctionnalité par “Gestion des places”


## 🧑‍🎄 Pour tester

- Depuis pix-admin
- Aller sur la page de détail d'une orga
- Vérifier la présence de la fonctionnalité "Gestion des places" dans la liste des fonctionnalités

<img width="1616" height="414" alt="image" src="https://github.com/user-attachments/assets/e65433a6-b752-42ad-b40b-898af6b39d66" />
