### PR TITLE
[TECH] Réparer la fin d'exécution de redis au refresh cache

### DIFF
--- a/api/scripts/refresh-cache.js
+++ b/api/scripts/refresh-cache.js
@@ -1,6 +1,16 @@
 import { usecases } from '../src/learning-content/domain/usecases/index.js';
 import { Script } from '../src/shared/application/scripts/script.js';
 import { ScriptRunner } from '../src/shared/application/scripts/script-runner.js';
+import { config } from '../src/shared/config.js';
+
+if (config.environment === 'development' || config.environment === 'test') {
+  process.on('uncaughtException', (error) => {
+    if (error?.message === 'Connection is closed.') {
+      return;
+    }
+    throw error;
+  });
+}
 
 export class RefreshCache extends Script {
   constructor() {


### PR DESCRIPTION
## ❄️ Problème

Il était courant d'avoir des erreurs `Error: Connection is closed.` lors de lancement du script `npm run cache:refresh`.
Surtout au lancement des tests e2e Playwright.

## 🛷 Proposition

Détecter l'erreur en dev local ou environnement de test pour éviter qu'elle ne casse la fin de script.

## 🧑‍🎄 Pour tester

✅ CI ok
