### PR TITLE
[TECH] Améliorer l'autocomplétion des usecases

### DIFF
--- a/api/src/shared/infrastructure/utils/dependency-injection.js
+++ b/api/src/shared/infrastructure/utils/dependency-injection.js
@@ -4,6 +4,36 @@ function injectDefaults(defaults, targetFn) {
   return (args) => targetFn(Object.assign(Object.create(defaults), args));
 }
 
+/**
+ * Transforms a function type `BaseFunction` so that keys present in dependencies `Dependencies` become optional.
+ *
+ * @template BaseFunction
+ * @template {object} Dependencies
+ * @typedef {BaseFunction extends (args: infer FunctionArgs) => infer FunctionResult
+ *   ? (args: Omit<FunctionArgs, keyof Dependencies> & Partial<FunctionArgs>) => FunctionResult
+ *   : BaseFunction
+ * } MergeDeps
+ */
+
+/**
+ * Recursively traverses the object `BaseObject` to apply MergeDeps with the dependencies `Dependencies` to all its functions.
+ *
+ * @template {object} BaseObject
+ * @template {object} Dependencies
+ * @typedef {{
+ *   [Key in keyof BaseObject]: BaseObject[Key] extends Function
+ *     ? MergeDeps<BaseObject[Key], Dependencies>
+ *     : Inject<BaseObject[Key], Dependencies>
+ * }} Inject
+ */
+
+/**
+ * @template {object} ObjectToBeInjected
+ * @template {object} DependenciesToInject
+ * @param {ObjectToBeInjected} toBeInjected - An object (or nested objects) of functions.
+ * @param {DependenciesToInject} dependencies - An object of dependencies to inject.
+ * @returns {Inject<ObjectToBeInjected, DependenciesToInject>} The input object, but functions now only require dependencies that haven't been injected.
+ */
 function injectDependencies(toBeInjected, dependencies) {
   return _.mapValues(toBeInjected, (value) => {
     if (_.isFunction(value)) {


### PR DESCRIPTION
## ❄️ Problème

Les objets `usecases` n'ont pas d'autocomplétion.

https://github.com/user-attachments/assets/81844c56-3ba1-4319-b6a8-c45652ddce30

## 🛷 Proposition

Ajout de JSDoc sur la fonction `injectDependencies`, qui permet d'avoir une autocomplétion entièrement typée.

https://github.com/user-attachments/assets/f3b2adcd-60c0-4c01-93fc-b37cedbef845

## ☃️ Remarques

Les dépendances injectées sont bien indiquées comme des arguments optionnels.

## 🧑‍🎄 Pour tester

- En local, essayer d'interagir avec l'objet `usecases` afin de déclencher l'autocomplétion.
- Vérifier que les dépendances injectées (`repositories`) sont indiquées comme étant optionnelles.