### PR TITLE
[BUGFIX] Erreur 500 au (re)démarrage d’une compétence (PIX-21127)

### DIFF
--- a/api/src/evaluation/application/competence-evaluations/index.js
+++ b/api/src/evaluation/application/competence-evaluations/index.js
@@ -1,3 +1,7 @@
+
+
+
+
 import { competenceEvaluationController } from './competence-evaluation-controller.js';
 
 const register = async function (server) {

--- a/api/src/evaluation/application/competence-evaluations/index.js
+++ b/api/src/evaluation/application/competence-evaluations/index.js
@@ -1,6 +1,4 @@
-
-
-
+import Joi from 'joi';
 
 import { competenceEvaluationController } from './competence-evaluation-controller.js';
 
@@ -10,6 +8,11 @@ const register = async function (server) {
       method: 'POST',
       path: '/api/competence-evaluations/start-or-resume',
       config: {
+        validate: {
+          payload: Joi.object({
+            competenceId: Joi.string().required(),
+          }).required(),
+        },
         handler: competenceEvaluationController.startOrResume,
         notes: [
           '- **Route nécessitant une authentification**\n' +
@@ -23,6 +26,11 @@ const register = async function (server) {
       method: 'PUT',
       path: '/api/competence-evaluations/improve',
       config: {
+        validate: {
+          payload: Joi.object({
+            competenceId: Joi.string().required(),
+          }).required(),
+        },
         handler: competenceEvaluationController.improve,
         notes: [
           '- **Route nécessitant une authentification**\n' +

--- a/api/tests/evaluation/unit/application/competence-evaluations/index_test.js
+++ b/api/tests/evaluation/unit/application/competence-evaluations/index_test.js
@@ -1,0 +1,83 @@
+import { competenceEvaluationController } from '../../../../../src/evaluation/application/competence-evaluations/competence-evaluation-controller.js';
+import * as competenceEvaluationsRouter from '../../../../../src/evaluation/application/competence-evaluations/index.js';
+import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
+
+describe('Unit | Application | Router | competence-evaluations', function () {
+  let httpTestServer;
+
+  describe('POST /api/competence-evaluations/start-or-resume', function () {
+    beforeEach(async function () {
+      sinon.stub(competenceEvaluationController, 'startOrResume').callsFake((request, h) => h.response('ok').code(200));
+      httpTestServer = new HttpTestServer();
+      await httpTestServer.register(competenceEvaluationsRouter);
+    });
+
+    context('when payload is valid', function () {
+      it('should return 200', async function () {
+        // given
+        const payload = {
+          competenceId: 'competenceId',
+        };
+
+        // when
+        const response = await httpTestServer.request('POST', '/api/competence-evaluations/start-or-resume', payload);
+
+        // then
+        expect(response.statusCode).to.equal(200);
+      });
+    });
+
+    context('when competenceId is missing in payload', function () {
+      it('should return 400', async function () {
+        // given
+        const payload = {
+          competenceId: null,
+        };
+
+        // when
+        const response = await httpTestServer.request('POST', '/api/competence-evaluations/start-or-resume', payload);
+
+        // then
+        expect(response.statusCode).to.equal(400);
+      });
+    });
+  });
+
+  describe('PUT /api/competence-evaluations/improve', function () {
+    beforeEach(async function () {
+      sinon.stub(competenceEvaluationController, 'improve').callsFake((request, h) => h.response('ok').code(200));
+      httpTestServer = new HttpTestServer();
+      await httpTestServer.register(competenceEvaluationsRouter);
+    });
+
+    context('when payload is valid', function () {
+      it('should return 200', async function () {
+        // given
+        const payload = {
+          competenceId: 'competenceId',
+        };
+
+        // when
+        const response = await httpTestServer.request('PUT', '/api/competence-evaluations/improve', payload);
+
+        // then
+        expect(response.statusCode).to.equal(200);
+      });
+    });
+
+    context('when competenceId is missing in payload', function () {
+      it('should return 400', async function () {
+        // given
+        const payload = {
+          competenceId: null,
+        };
+
+        // when
+        const response = await httpTestServer.request('PUT', '/api/competence-evaluations/improve', payload);
+
+        // then
+        expect(response.statusCode).to.equal(400);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## ❄️ Problème

On a eu une erreur 500 sur la route d’API de (re)démarrage de compétence car le front n’a envoyé aucun ID de compétence.
On ne sait pas ce qui a provoqué ça côté front.

## 🛷 Proposition

Il faudrait ajouter de la validation de la payload afin d’éviter d’avoir une erreur 500 dans ce cas.

## ☃️ Remarques

N/A

## 🧑‍🎄 Pour tester

Démarrer une compétence.
Reprendre une compétence.
Améliorer une compétence.