### PR TITLE
[FEATURE] Partager un schéma de parcours à une organisation (PIX-211124)

### DIFF
--- a/admin/app/adapters/combined-course-blueprint.js
+++ b/admin/app/adapters/combined-course-blueprint.js
@@ -7,4 +7,11 @@ export default class CombinedCourseBlueprintAdapter extends ApplicationAdapter {
     const url = `${this.host}/${this.namespace}/combined-course-blueprints/${combinedCourseBlueprintId}/organizations/${organizationId}`;
     await this.ajax(url, 'DELETE');
   }
+  async attachOrganizations({ combinedCourseBlueprintId, organizationIds }) {
+    const url = `${this.host}/${this.namespace}/combined-course-blueprints/${combinedCourseBlueprintId}/organizations`;
+    const result = await this.ajax(url, 'POST', {
+      data: { 'organization-ids': organizationIds },
+    });
+    return result;
+  }
 }

--- a/admin/app/components/combined-course-blueprints/organizations.gjs
+++ b/admin/app/components/combined-course-blueprints/organizations.gjs
@@ -1,3 +1,4 @@
+import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import AttachOrganizationsForm from 'pix-admin/components/organizations/attach-organizations-form';
@@ -5,9 +6,49 @@ import ListItems from 'pix-admin/components/organizations/list-items';
 
 export default class Organizations extends Component {
   @service currentUser;
+  @service store;
+  @service intl;
+  @service pixToast;
+  @service router;
 
   get isSuperAdminOrMetier() {
     return this.currentUser.adminMember.isSuperAdmin || this.currentUser.adminMember.isMetier;
+  }
+
+  @action
+  _handleResponseError({ errors }) {
+    const genericErrorMessage = this.intl.t('common.notifications.generic-error');
+
+    if (!errors) {
+      return this.pixToast.sendErrorNotification({ message: genericErrorMessage });
+    }
+    errors.forEach((error) => {
+      if (['404', '412'].includes(error.status)) {
+        return this.pixToast.sendErrorNotification({ message: error.detail });
+      }
+      return this.pixToast.sendErrorNotification({ message: genericErrorMessage });
+    });
+  }
+
+  @action
+  async reloadCurrentPage() {
+    return this.router.replaceWith('authenticated.combined-course-blueprints.combined-course-blueprint.organizations');
+  }
+
+  @action
+  async attachOrganizations(organizationsToAttach) {
+    const combinedCourseBlueprint = this.args.combinedCourseBlueprint;
+    const adapter = this.store.adapterFor('combined-course-blueprint');
+    try {
+      const response = await adapter.attachOrganizations({
+        organizationIds: organizationsToAttach,
+        combinedCourseBlueprintId: combinedCourseBlueprint.id,
+      });
+      const { 'attached-ids': attachedIds, 'duplicated-ids': duplicatedIds } = response.data.attributes;
+      return { attachedIds, duplicatedIds };
+    } catch (responseError) {
+      this._handleResponseError(responseError);
+    }
   }
 
   <template>
@@ -15,6 +56,11 @@ export default class Organizations extends Component {
       <header class="page-section__header">
         <h2 class="page-section__title">Organisations</h2>
       </header>
+
+      <AttachOrganizationsForm
+        @attachOrganizations={{this.attachOrganizations}}
+        @reloadAfterSuccess={{this.reloadCurrentPage}}
+      />
 
       <ListItems
         @organizations={{@organizations}}

--- a/admin/app/components/combined-course-blueprints/organizations.gjs
+++ b/admin/app/components/combined-course-blueprints/organizations.gjs
@@ -1,5 +1,6 @@
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
+import AttachOrganizationsForm from 'pix-admin/components/organizations/attach-organizations-form';
 import ListItems from 'pix-admin/components/organizations/list-items';
 
 export default class Organizations extends Component {

--- a/admin/app/components/combined-course-blueprints/organizations.gjs
+++ b/admin/app/components/combined-course-blueprints/organizations.gjs
@@ -52,7 +52,7 @@ export default class Organizations extends Component {
   }
 
   <template>
-    <section class="page-section organizations-list">
+    <section class="page-section combined-course-blueprint-organizations organizations-list">
       <header class="page-section__header">
         <h2 class="page-section__title">Organisations</h2>
       </header>

--- a/admin/app/components/organizations/attach-organizations-form.gjs
+++ b/admin/app/components/organizations/attach-organizations-form.gjs
@@ -1,0 +1,86 @@
+import PixButton from '@1024pix/pix-ui/components/pix-button';
+import PixInput from '@1024pix/pix-ui/components/pix-input';
+import { on } from '@ember/modifier';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import { htmlSafe } from '@ember/template';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { t } from 'ember-intl';
+import uniq from 'lodash/uniq';
+
+export default class AttachOrganizationsForm extends Component {
+  @tracked organizationsToAttach = '';
+  @service pixToast;
+
+  get isDisabledAttachOrganizations() {
+    return this.organizationsToAttach === '';
+  }
+
+  _getUniqueOrganizations() {
+    const organizationIds = this.organizationsToAttach.split(',').map((organizationId) => parseInt(organizationId));
+    return uniq(organizationIds);
+  }
+
+  @action
+  onOrganizationsToAttachChange(event) {
+    this.organizationsToAttach = event.target.value;
+  }
+
+  @action
+  async attachOrganizations(e) {
+    e.preventDefault();
+    if (this.isDisabledAttachOrganizations) return;
+
+    const organizationsToAttach = this._getUniqueOrganizations();
+    const { attachedIds, duplicatedIds } = await this.args.attachOrganizations(organizationsToAttach);
+
+    this.organizationsToAttach = '';
+    const hasInsertedOrganizations = attachedIds.length > 0;
+    const hasDuplicatedOrganizations = duplicatedIds.length > 0;
+    const message = [];
+
+    if (hasInsertedOrganizations) {
+      message.push('Organisation(s) rattaché(es) avec succès.');
+    }
+
+    if (hasInsertedOrganizations && hasDuplicatedOrganizations) {
+      message.push('<br />');
+    }
+
+    if (hasDuplicatedOrganizations) {
+      message.push(
+        `Le(s) organisation(s) suivantes étai(en)t déjà rattachée(s) à ce profil cible : ${duplicatedIds.join(', ')}`,
+      );
+    }
+
+    await this.pixToast.sendSuccessNotification({ message: htmlSafe(message.join('')) });
+
+    return this.args.reloadAfterSuccess();
+  }
+
+  <template>
+    <form class="organization__form" {{on "submit" this.attachOrganizations}}>
+      <label for="attach-organizations">Rattacher une ou plusieurs organisation(s)</label>
+      <div class="organization__sub-form">
+        <PixInput
+          id="attach-organizations"
+          @value={{this.organizationsToAttach}}
+          class="form-field__text form-control"
+          placeholder="1, 2"
+          aria-describedby="attach-organizations-info"
+          {{on "input" this.onOrganizationsToAttachChange}}
+        />
+        <p id="attach-organizations-info" hidden>Ids des organisations, séparés par une virgule</p>
+        <PixButton
+          @type="submit"
+          @size="small"
+          aria-label="Valider le rattachement"
+          @isDisabled={{this.isDisabledAttachOrganizations}}
+        >
+          {{t "common.actions.validate"}}
+        </PixButton>
+      </div>
+    </form>
+  </template>
+}

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -28,6 +28,7 @@
 @use 'components/quests/form' as *;
 @use 'components/combined-course/form' as *;
 @use 'components/combined-course-blueprints/list' as *;
+@use 'components/combined-course-blueprints/organizations' as *;
 @use 'components/administration' as *;
 @use 'components/administration/certification/certification-scoring-configuration' as *;
 @use 'components/administration/certification/competence-scoring-configuration' as *;

--- a/admin/app/styles/components/combined-course-blueprints/organizations.scss
+++ b/admin/app/styles/components/combined-course-blueprints/organizations.scss
@@ -1,0 +1,23 @@
+/* stylelint-disable selector-class-pattern */
+.combined-course-blueprint-organizations {
+  label {
+    font-weight: bold;
+    font-size: 1.125rem;
+  }
+
+  .organization__form {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+
+    .organization__sub-form {
+      display: flex;
+      align-items: center;
+      min-width: 300px;
+    }
+
+    .pix-button {
+      margin-left: 8px;
+    }
+  }
+}

--- a/admin/app/templates/authenticated/combined-course-blueprints/combined-course-blueprint/organizations.gjs
+++ b/admin/app/templates/authenticated/combined-course-blueprints/combined-course-blueprint/organizations.gjs
@@ -2,7 +2,7 @@ import Organizations from 'pix-admin/components/combined-course-blueprints/organ
 
 <template>
   <Organizations
-    @blueprint={{@model.blueprint}}
+    @combinedCourseBlueprint={{@model.blueprint}}
     @organizations={{@model.organizations}}
     @administrationTeams={{@model.administrationTeams}}
     @triggerFiltering={{@controller.triggerFiltering}}

--- a/admin/tests/acceptance/authenticated/combined-course-blueprints/attach-organizations-form-test.js
+++ b/admin/tests/acceptance/authenticated/combined-course-blueprints/attach-organizations-form-test.js
@@ -1,0 +1,36 @@
+import { clickByName, fillByLabel, visit } from '@1024pix/ember-testing-library';
+import { setupApplicationTest } from 'ember-qunit';
+import { authenticateAdminMemberWithRole } from 'pix-admin/tests/helpers/test-init';
+import { setupMirage } from 'pix-admin/tests/test-support/setup-mirage';
+import { module, test } from 'qunit';
+
+import setupIntl from '../../../helpers/setup-intl';
+
+module('Acceptance | Attach organizations form', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+  setupIntl(hooks);
+  let combinedCourseBlueprintId;
+
+  hooks.beforeEach(async function () {
+    await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+
+    combinedCourseBlueprintId = 1;
+    server.create('combined-course-blueprint', { id: combinedCourseBlueprintId, internalName: 'toto' });
+
+    await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+  });
+
+  //then
+  test('should be able to add new organization to the target profile', async function (assert) {
+    // given
+    const screen = await visit(`/combined-course-blueprints/${combinedCourseBlueprintId}/organizations`);
+
+    // when
+    await fillByLabel('Rattacher une ou plusieurs organisation(s)', '42');
+    await clickByName('Valider le rattachement');
+
+    // then
+    assert.dom(await screen.findByRole('cell', { name: 'Organization 42' })).exists();
+  });
+});

--- a/admin/tests/integration/components/target-profiles/organizations-test.gjs
+++ b/admin/tests/integration/components/target-profiles/organizations-test.gjs
@@ -115,7 +115,6 @@ module('Integration | Component | target-profiles | Organizations', function (ho
       </template>,
     );
     await fillByLabel('Rattacher une ou plusieurs organisation(s)', '1, 2');
-    await clickByName('Valider le rattachement');
 
     assert.dom('[placeholder="1, 2"]').hasValue('1, 2');
   });
@@ -137,7 +136,6 @@ module('Integration | Component | target-profiles | Organizations', function (ho
       </template>,
     );
     await fillByLabel("Rattacher les organisations d'un profil cible existant", 1);
-    await clickByName('Valider le rattachement à partir de ce profil cible');
 
     assert.dom('[placeholder="1135"]').hasValue('1');
   });
@@ -292,6 +290,8 @@ module('Integration | Component | target-profiles | Organizations', function (ho
       const attachOrganizationsStub = sinon.stub(adapter, 'attachOrganizations').resolves({
         data: { attributes: { 'duplicated-ids': [], 'attached-ids': [1, 2] } },
       });
+      const router = this.owner.lookup('service:router');
+      const replaceWithStub = sinon.stub(router, 'replaceWith').resolves();
 
       // when
       await render(
@@ -311,6 +311,7 @@ module('Integration | Component | target-profiles | Organizations', function (ho
 
       // then
       assert.ok(attachOrganizationsStub.calledWith({ organizationIds: [1, 2], targetProfileId: 56 }));
+      assert.ok(replaceWithStub.calledWith('authenticated.target-profiles.target-profile.organizations'));
     });
 
     test('it should enable button for existing target profile attachment', async function (assert) {

--- a/admin/tests/mirage/handlers/combined-course-blueprint.js
+++ b/admin/tests/mirage/handlers/combined-course-blueprint.js
@@ -1,0 +1,9 @@
+export function attachCombinedCourseBlueprintToOrganizations(schema, request) {
+  const params = JSON.parse(request.requestBody);
+  const organizationsToAttach = params['organization-ids'];
+  organizationsToAttach.forEach((organizationId) =>
+    schema.organizations.create({ id: organizationId, name: `Organization ${organizationId}` }),
+  );
+
+  return { data: { attributes: { 'duplicated-ids': [], 'attached-ids': organizationsToAttach } } };
+}

--- a/admin/tests/mirage/routes.js
+++ b/admin/tests/mirage/routes.js
@@ -12,6 +12,7 @@ import {
 import { updateBadgeCriterion } from './handlers/badge-criteria';
 import { findPaginatedFilteredCampaignParticipations } from './handlers/campaign-participations';
 import { findPaginatedFilteredCertificationCenters } from './handlers/certification-centers';
+import { attachCombinedCourseBlueprintToOrganizations } from './handlers/combined-course-blueprint.js';
 import { findPaginatedAndFilteredSessions } from './handlers/find-paginated-and-filtered-sessions';
 import { findFrameworkAreas } from './handlers/frameworks';
 import { getPaginatedJuryCertificationSummariesBySessionId } from './handlers/get-jury-certification-summaries-by-session-id';
@@ -716,6 +717,10 @@ export default function routes() {
 
   this.get('/admin/combined-course-blueprints');
   this.post('/admin/combined-course-blueprints');
+  this.post(
+    '/admin/combined-course-blueprints/:combinedCourseBlueprintId/organizations',
+    attachCombinedCourseBlueprintToOrganizations,
+  );
 
   this.get('/admin/modules-metadata', () => {
     return {

--- a/api/src/quest/application/combined-course-blueprint-controller.js
+++ b/api/src/quest/application/combined-course-blueprint-controller.js
@@ -1,4 +1,5 @@
 import { usecases } from '../domain/usecases/index.js';
+import * as combinedCourseBlueprintOrganizationSerializer from '../infrastructure/serializers/combined-course-blueprint-organization-serializer.js';
 import * as combinedCourseBlueprintSerializer from '../infrastructure/serializers/combined-course-blueprint-serializer.js';
 
 export const findAll = async (request, _, dependencies = { combinedCourseBlueprintSerializer }) => {
@@ -23,4 +24,21 @@ export const detachOrganization = async (request, h) => {
     organizationId: request.params.organizationId,
   });
   return h.response().code(204);
+};
+
+export const attachOrganizations = async (
+  request,
+  h,
+  dependencies = { combinedCourseBlueprintOrganizationSerializer },
+) => {
+  const combinedCourseBlueprintId = request.params.blueprintId;
+  const results = await usecases.attachOrganizationsToCombinedCourseBlueprint({
+    combinedCourseBlueprintId,
+    organizationIds: request.payload['organization-ids'],
+  });
+  return h
+    .response(
+      dependencies.combinedCourseBlueprintOrganizationSerializer.serialize({ ...results, combinedCourseBlueprintId }),
+    )
+    .code(201);
 };

--- a/api/src/quest/application/combined-course-blueprint-route.js
+++ b/api/src/quest/application/combined-course-blueprint-route.js
@@ -118,6 +118,33 @@ const register = async function (server) {
         tags: ['api', 'combined-course'],
       },
     },
+    {
+      method: 'POST',
+      path: '/api/admin/combined-course-blueprints/{blueprintId}/organizations',
+      config: {
+        validate: {
+          params: Joi.object({
+            blueprintId: identifiersType.combinedCourseBlueprintId,
+          }),
+          payload: Joi.object({
+            'organization-ids': Joi.array().items(Joi.number().integer()).required(),
+          }),
+        },
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.hasAtLeastOneAccessOf([
+                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+                securityPreHandlers.checkAdminMemberHasRoleMetier,
+              ])(request, h),
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        handler: combinedCourseBlueprintController.attachOrganizations,
+        notes: ["- Retire l'accès à un schéma de parcours combinés pour une organisation donnée"],
+        tags: ['api', 'combined-course'],
+      },
+    },
   ]);
 };
 

--- a/api/src/quest/domain/models/CombinedCourseBlueprint.js
+++ b/api/src/quest/domain/models/CombinedCourseBlueprint.js
@@ -16,6 +16,8 @@ export class CombinedCourseBlueprint {
     createdAt,
     updatedAt,
     organizationIds = [],
+    duplicatedOrganizationIds = [],
+    attachedOrganizationIds = [],
   }) {
     this.id = id;
     this.name = name;
@@ -26,6 +28,8 @@ export class CombinedCourseBlueprint {
     this.createdAt = createdAt;
     this.updatedAt = updatedAt;
     this.organizationIds = organizationIds;
+    this.duplicatedOrganizationIds = duplicatedOrganizationIds;
+    this.attachedOrganizationIds = attachedOrganizationIds;
   }
 
   get targetProfileIds() {
@@ -113,6 +117,17 @@ export class CombinedCourseBlueprint {
   }
   detachOrganization({ organizationId }) {
     this.organizationIds = this.organizationIds.filter((id) => id !== organizationId);
+  }
+  attachOrganizations({ organizationIds }) {
+    organizationIds.map((organizationId) => {
+      if (this.organizationIds.includes(organizationId)) {
+        this.duplicatedOrganizationIds.push(organizationId);
+      } else {
+        this.attachedOrganizationIds.push(organizationId);
+      }
+    });
+
+    this.organizationIds.push(...this.attachedOrganizationIds);
   }
 }
 

--- a/api/src/quest/domain/models/CombinedCourseBlueprint.js
+++ b/api/src/quest/domain/models/CombinedCourseBlueprint.js
@@ -16,8 +16,6 @@ export class CombinedCourseBlueprint {
     createdAt,
     updatedAt,
     organizationIds = [],
-    duplicatedOrganizationIds = [],
-    attachedOrganizationIds = [],
   }) {
     this.id = id;
     this.name = name;
@@ -28,8 +26,6 @@ export class CombinedCourseBlueprint {
     this.createdAt = createdAt;
     this.updatedAt = updatedAt;
     this.organizationIds = organizationIds;
-    this.duplicatedOrganizationIds = duplicatedOrganizationIds;
-    this.attachedOrganizationIds = attachedOrganizationIds;
   }
 
   get targetProfileIds() {
@@ -93,7 +89,10 @@ export class CombinedCourseBlueprint {
         comparison: REQUIREMENT_COMPARISONS.ALL,
         data: {
           campaignId: { data: campaignId, comparison: CRITERION_COMPARISONS.EQUAL },
-          status: { data: CampaignParticipationStatuses.SHARED, comparison: CRITERION_COMPARISONS.EQUAL },
+          status: {
+            data: CampaignParticipationStatuses.SHARED,
+            comparison: CRITERION_COMPARISONS.EQUAL,
+          },
         },
       });
     } else if (moduleId) {
@@ -119,15 +118,18 @@ export class CombinedCourseBlueprint {
     this.organizationIds = this.organizationIds.filter((id) => id !== organizationId);
   }
   attachOrganizations({ organizationIds }) {
+    const duplicatedOrganizationIds = [];
+    const attachedOrganizationIds = [];
     organizationIds.map((organizationId) => {
       if (this.organizationIds.includes(organizationId)) {
-        this.duplicatedOrganizationIds.push(organizationId);
+        duplicatedOrganizationIds.push(organizationId);
       } else {
-        this.attachedOrganizationIds.push(organizationId);
+        attachedOrganizationIds.push(organizationId);
       }
     });
 
-    this.organizationIds.push(...this.attachedOrganizationIds);
+    this.organizationIds.push(...attachedOrganizationIds);
+    return { duplicatedOrganizationIds, attachedOrganizationIds };
   }
 }
 

--- a/api/src/quest/domain/usecases/attach-organizations-to-combined-course-blueprint.js
+++ b/api/src/quest/domain/usecases/attach-organizations-to-combined-course-blueprint.js
@@ -1,0 +1,21 @@
+import { NotFoundError } from '../../../shared/domain/errors.js';
+
+export async function attachOrganizationsToCombinedCourseBlueprint({
+  organizationIds,
+  combinedCourseBlueprintId,
+  combinedCourseBlueprintRepository,
+}) {
+  const blueprint = await combinedCourseBlueprintRepository.findById({
+    id: combinedCourseBlueprintId,
+  });
+  if (!blueprint) {
+    throw new NotFoundError(`Combined course blueprint with id:${combinedCourseBlueprintId} not found`);
+  }
+  const { attachedOrganizationIds, duplicatedOrganizationIds } = blueprint.attachOrganizations({
+    organizationIds,
+  });
+  await combinedCourseBlueprintRepository.save({
+    combinedCourseBlueprint: blueprint,
+  });
+  return { attachedIds: attachedOrganizationIds, duplicatedIds: duplicatedOrganizationIds };
+}

--- a/api/src/quest/domain/usecases/index.js
+++ b/api/src/quest/domain/usecases/index.js
@@ -43,6 +43,7 @@ const dependencies = {
   logger,
 };
 
+import { attachOrganizationsToCombinedCourseBlueprint } from './attach-organizations-to-combined-course-blueprint.js';
 import { checkUserQuest } from './check-user-quest-success.js';
 import { createCombinedCourseBlueprint } from './create-combined-course-blueprint.js';
 import { createCombinedCourses } from './create-combined-courses.js';
@@ -65,6 +66,7 @@ import { startCombinedCourse } from './start-combined-course.js';
 import { updateCombinedCourse } from './update-combined-course.js';
 
 const usecasesWithoutInjectedDependencies = {
+  attachOrganizationsToCombinedCourseBlueprint,
   checkUserQuest,
   createOrUpdateQuestsInBatch,
   detachOrganizationFromCombinedCourseBlueprint,

--- a/api/src/quest/infrastructure/repositories/combined-course-blueprint-repository.js
+++ b/api/src/quest/infrastructure/repositories/combined-course-blueprint-repository.js
@@ -35,8 +35,6 @@ export async function save({ combinedCourseBlueprint }) {
   return new CombinedCourseBlueprint({
     ...updatedValues,
     organizationIds: combinedCourseBlueprint.organizationIds,
-    duplicatedOrganizationIds: combinedCourseBlueprint.duplicatedOrganizationIds,
-    attachedOrganizationIds: combinedCourseBlueprint.attachedOrganizationIds,
   });
 }
 

--- a/api/src/quest/infrastructure/serializers/combined-course-blueprint-organization-serializer.js
+++ b/api/src/quest/infrastructure/serializers/combined-course-blueprint-organization-serializer.js
@@ -1,0 +1,12 @@
+import jsonapiSerializer from 'jsonapi-serializer';
+
+const { Serializer } = jsonapiSerializer;
+
+const serialize = function (model) {
+  return new Serializer('combined-course-blueprint-organizations', {
+    id: 'combinedCourseBlueprintId',
+    attributes: ['duplicatedIds', 'attachedIds'],
+  }).serialize(model);
+};
+
+export { serialize };

--- a/api/tests/quest/integration/domain/usecases/attach-organizations-to-combined-course-blueprint_test.js
+++ b/api/tests/quest/integration/domain/usecases/attach-organizations-to-combined-course-blueprint_test.js
@@ -1,0 +1,35 @@
+import { usecases } from '../../../../../src/quest/domain/usecases/index.js';
+import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
+import { catchErr, databaseBuilder, expect } from '../../../../test-helper.js';
+
+describe('Integration | Combined course | Domain | UseCases | attach-organizations-to-combined-course-blueprint', function () {
+  it('should return duplicated ids and attached ids for a given combined course blueprint', async function () {
+    // given
+    const organizationToAttach = databaseBuilder.factory.buildOrganization();
+    const existingCombinedCourseBlueprintShare = databaseBuilder.factory.buildCombinedCourseBlueprintShare();
+
+    await databaseBuilder.commit();
+
+    // when
+    const result = await usecases.attachOrganizationsToCombinedCourseBlueprint({
+      combinedCourseBlueprintId: existingCombinedCourseBlueprintShare.combinedCourseBlueprintId,
+      organizationIds: [existingCombinedCourseBlueprintShare.organizationId, organizationToAttach.id],
+    });
+
+    expect(result).to.deep.equal({
+      duplicatedIds: [existingCombinedCourseBlueprintShare.organizationId],
+      attachedIds: [organizationToAttach.id],
+    });
+  });
+
+  it('should throw if combined course blueprint is not found', async function () {
+    // when
+    const error = await catchErr(usecases.attachOrganizationsToCombinedCourseBlueprint)({
+      combinedCourseBlueprintId: 123,
+      organizationId: 445,
+    });
+
+    // then
+    expect(error).instanceOf(NotFoundError);
+  });
+});

--- a/api/tests/quest/integration/infrastructure/repositories/combined-course-blueprint-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/combined-course-blueprint-repository_test.js
@@ -63,14 +63,14 @@ describe('Quest | Integration | Repository | combined-course-blueprint', functio
         id: combinedCourseBlueprintShare.combinedCourseBlueprintId,
       });
 
-      combinedCourseBlueprint.attachOrganizations({ organizationIds: [organization1.id, organization2.id] });
+      combinedCourseBlueprint.attachOrganizations({
+        organizationIds: [organization1.id, organization2.id],
+      });
 
       // when
       const result = await combinedCourseBluePrintRepository.save({ combinedCourseBlueprint });
 
       expect(result.organizationIds).deep.equal([organization1.id, organization2.id]);
-      expect(result.duplicatedOrganizationIds).deep.equal([organization1.id]);
-      expect(result.attachedOrganizationIds).deep.equal([organization2.id]);
     });
 
     it('should throw a NotFound error when combined course blueprint does not exist', async function () {

--- a/api/tests/quest/integration/infrastructure/repositories/combined-course-blueprint-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/combined-course-blueprint-repository_test.js
@@ -48,6 +48,31 @@ describe('Quest | Integration | Repository | combined-course-blueprint', functio
       expect(result.organizationIds).deep.equal([combinedCourseBlueprintShare2.organizationId]);
     });
 
+    it('should add combined course blueprint share for a given organizationId', async function () {
+      // given
+      const organization1 = databaseBuilder.factory.buildOrganization();
+      const organization2 = databaseBuilder.factory.buildOrganization();
+
+      const combinedCourseBlueprintShare = databaseBuilder.factory.buildCombinedCourseBlueprintShare({
+        organizationId: organization1.id,
+      });
+
+      await databaseBuilder.commit();
+
+      const combinedCourseBlueprint = await combinedCourseBluePrintRepository.findById({
+        id: combinedCourseBlueprintShare.combinedCourseBlueprintId,
+      });
+
+      combinedCourseBlueprint.attachOrganizations({ organizationIds: [organization1.id, organization2.id] });
+
+      // when
+      const result = await combinedCourseBluePrintRepository.save({ combinedCourseBlueprint });
+
+      expect(result.organizationIds).deep.equal([organization1.id, organization2.id]);
+      expect(result.duplicatedOrganizationIds).deep.equal([organization1.id]);
+      expect(result.attachedOrganizationIds).deep.equal([organization2.id]);
+    });
+
     it('should throw a NotFound error when combined course blueprint does not exist', async function () {
       // given
       const combinedCourseBlueprintShare = databaseBuilder.factory.buildCombinedCourseBlueprintShare();

--- a/api/tests/quest/unit/domain/models/CombinedCourseBlueprint_test.js
+++ b/api/tests/quest/unit/domain/models/CombinedCourseBlueprint_test.js
@@ -257,4 +257,22 @@ describe('Quest | Unit | Domain | Models | CombinedCourseBlueprint ', function (
       expect(combinedCourseBlueprint.organizationIds).empty;
     });
   });
+  describe('#attachOrganizations', function () {
+    it('should add organization ids to the model instance', async function () {
+      //given
+      const combinedCourseBlueprint = new CombinedCourseBlueprint({
+        name: 'Blueprint1',
+        content: [],
+        description: '',
+        illustration: '',
+        organizationIds: [1],
+      });
+
+      //when
+      combinedCourseBlueprint.attachOrganizations({ organizationIds: [2, 3] });
+
+      //then
+      expect(combinedCourseBlueprint.organizationIds).to.equal([1, 2, 3]);
+    });
+  });
 });

--- a/api/tests/quest/unit/domain/models/CombinedCourseBlueprint_test.js
+++ b/api/tests/quest/unit/domain/models/CombinedCourseBlueprint_test.js
@@ -272,7 +272,27 @@ describe('Quest | Unit | Domain | Models | CombinedCourseBlueprint ', function (
       combinedCourseBlueprint.attachOrganizations({ organizationIds: [2, 3] });
 
       //then
-      expect(combinedCourseBlueprint.organizationIds).to.equal([1, 2, 3]);
+      expect(combinedCourseBlueprint.organizationIds).to.deep.equal([1, 2, 3]);
+    });
+
+    it('should return attached organization ids and duplicated ids', async function () {
+      //given
+      const combinedCourseBlueprint = new CombinedCourseBlueprint({
+        name: 'Blueprint1',
+        content: [],
+        description: '',
+        illustration: '',
+        organizationIds: [1],
+      });
+
+      //when
+      const { attachedOrganizationIds, duplicatedOrganizationIds } = combinedCourseBlueprint.attachOrganizations({
+        organizationIds: [1, 2, 3],
+      });
+
+      //then
+      expect(attachedOrganizationIds).to.deep.equal([2, 3]);
+      expect(duplicatedOrganizationIds).to.deep.equal([1]);
     });
   });
 });


### PR DESCRIPTION
## ❄️ Problème
A l'image de ce qui se fait sur les profils cibles, on veut pouvoir rendre disponible un schéma de parcours combiné à des organisations.

## 🛷 Proposition
On construit une route POST /api/admin/combined-course-blueprints/{blueprintId}/organizations.
On utilise la méthode save du repository pour ajouter des combined_course_blueprint_shares et on crée une méthode dans le model CombinedCourseBlueprint pour attacher des organisations ainsi que renvoyer le tuple { duplicatedIds, attachedIds }.

## 🧑‍🎄 Pour tester
PixAdmin -> Schémas de parcours combinés
On va dans la partie "Organisations" et on rattache plusieurs organisations.
On fait une 2e tentative avec un id similaire pour avoir le message liés aux ids dupliqués.