### PR TITLE
[BUGFIX] Corriger les liens cassés vers le doc "Interprétation des résultats" (PIX-21129).

### DIFF
--- a/orga/tests/acceptance/certifications-test.js
+++ b/orga/tests/acceptance/certifications-test.js
@@ -91,7 +91,7 @@ module('Acceptance | Certifications page', function (hooks) {
         // then
         assert
           .dom(screen.getByRole('link', { name: 'Interprétation des résultats Ouverture dans une nouvelle fenêtre' }))
-          .hasAttribute('href', 'https://cloud.pix.fr/s/8pJqgNNntwDtsDY');
+          .hasAttribute('href', 'https://cloud.pix.fr/s/oqnYJWHoSXz8LJk');
       });
 
       test('should display attestation download button', async function (assert) {

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -1068,7 +1068,7 @@
     },
     "certifications": {
       "description": "Please select the class for which you would like to export the certification results (.csv) or download certificates (.pdf).",
-      "documentation-link": "https://cloud.pix.fr/s/dqCoeH8q4fjWZjq",
+      "documentation-link": "https://cloud.pix.fr/s/APNirYfz3SRbZLz",
       "documentation-link-label": "Interpreting the results",
       "documentation-link-notice": "Follow this link to find indications on how to interpret the results: ",
       "download-attestations-button": "Download certificates",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -1056,7 +1056,7 @@
     },
     "certifications": {
       "description": "Sélectionnez la classe pour laquelle vous souhaitez exporter les résultats de certification (.csv) ou télécharger les certificats (.pdf).\n Vous pouvez filtrer cette liste en renseignant le nom de la classe directement dans le champ.",
-      "documentation-link": "https://cloud.pix.fr/s/8pJqgNNntwDtsDY",
+      "documentation-link": "https://cloud.pix.fr/s/oqnYJWHoSXz8LJk",
       "documentation-link-label": "Interprétation des résultats",
       "documentation-link-notice": "Vous trouverez en suivant ce lien quelques éléments pour interpréter les résultats : ",
       "download-attestations-button": "Télécharger les certificats",

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -1055,7 +1055,7 @@
     },
     "certifications": {
       "description": "Selecteer de klas waarvoor je de certificeringsresultaten wilt exporteren (.csv) of de certificaten wilt downloaden (.pdf).'<br>' Je kunt deze lijst filteren door de naam van de klas direct in het veld in te voeren.",
-      "documentation-link": "https://cloud.pix.fr/s/8pJqgNNntwDtsDY",
+      "documentation-link": "https://cloud.pix.fr/s/APNirYfz3SRbZLz",
       "documentation-link-label": "Interpretatie van de resultaten.",
       "documentation-link-notice": "Volg deze link voor meer informatie over de interpretatie van de resultaten:",
       "download-attestations-button": "Getuigschriften downloaden",


### PR DESCRIPTION
## ❄️ Problème

Le doc "Interprétation des résultats" est disponible en lien dans le mail envoyé aux destinataires des résultats mais aussi sur Pix Orga pour le SCO.

Mais les liens sur le mail au destinataire des résultats et sur Pix Orga sont cassés.

## 🛷 Proposition

Remplacer les liens morts avec les nouveaux liens.

Sur PixOrga, c'est modifié dans les fichiers de trad.
Pour les mails, c'est corrigé sur Brevo.

## 🧑‍🎄 Pour tester

Vérifier les liens en RA.
