### PR TITLE
[TECH] Autoriser le champs ownerOrganizationId à devenir nullable (PIX-21130).

### DIFF
--- a/api/db/migrations/20260116143927_allow-nullable-organizationId-target-profiles.js
+++ b/api/db/migrations/20260116143927_allow-nullable-organizationId-target-profiles.js
@@ -1,0 +1,15 @@
+const TABLE_NAME = 'target-profiles';
+
+const up = function (knex) {
+  return knex.schema.alterTable(TABLE_NAME, function (table) {
+    table.integer('ownerOrganizationId').nullable().alter();
+  });
+};
+
+const down = function (knex) {
+  return knex.schema.alterTable(TABLE_NAME, function (table) {
+    table.integer('ownerOrganizationId').notNullable().alter();
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## ❄️ Problème

Ce champs est required tout le temps. et des fois ça sert à R

## 🛷 Proposition

Autoriser ce champs a devenir nullable. pour permettre de ne pas le renseigner dans un futur proche

## ☃️ Remarques

RAS

## 🧑‍🎄 Pour tester

CI au vert 