### PR TITLE
[TECH] Supprimer le feature toggle isModulixIssueReportDisplayed (PIX-21067)

### DIFF
--- a/api/config/feature-toggles-config.js
+++ b/api/config/feature-toggles-config.js
@@ -30,13 +30,6 @@ export default {
     devDefaultValues: { test: true, reviewApp: true },
     tags: ['team-prescription', 'pix-api', 'backend'],
   },
-  isModulixIssueReportDisplayed: {
-    type: 'boolean',
-    description: 'Enable issue report in modules',
-    defaultValue: false,
-    devDefaultValues: { test: false, reviewApp: true },
-    tags: ['frontend', 'team-devcomp', 'modulix', 'pix-app'],
-  },
   isSelfAccountDeletionEnabled: {
     description: 'Toggle self account deletion feature',
     type: 'boolean',

--- a/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
+++ b/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
@@ -22,7 +22,6 @@ describe('Acceptance | Shared | Application | Controller | feature-toggle', func
           attributes: {
             'dynamic-feature-toggle-system': false,
             'is-async-quest-rewarding-calculation-enabled': false,
-            'is-modulix-issue-report-displayed': false,
             'is-survey-enabled-for-combined-courses': true,
             'is-quest-enabled': true,
             'is-self-account-deletion-enabled': true,

--- a/mon-pix/app/components/module/issue-report/issue-report-block.gjs
+++ b/mon-pix/app/components/module/issue-report/issue-report-block.gjs
@@ -8,7 +8,6 @@ import { t } from 'ember-intl';
 import ModulixIssueReportModal from './issue-report-modal';
 
 export default class ModulixIssueReportBlock extends Component {
-  @service featureToggles;
   @tracked showModal = false;
   @tracked sentStatus = null;
   @service moduleIssueReport;
@@ -40,22 +39,19 @@ export default class ModulixIssueReportBlock extends Component {
   }
 
   <template>
-    {{#if this.featureToggles.featureToggles.isModulixIssueReportDisplayed}}
-      <PixButton
-        class="feedback__report-button"
-        @variant="tertiary"
-        @iconBefore="flag"
-        aria-label={{t "pages.modulix.issue-report.aria-label"}}
-        @triggerAction={{this.onReportClick}}
-      >{{t "pages.modulix.issue-report.button"}}</PixButton>
-
-      <ModulixIssueReportModal
-        @elementType={{@reportInfo.elementType}}
-        @showModal={{this.showModal}}
-        @hideModal={{this.hideModal}}
-        @onSendReport={{this.onSend}}
-        @sentStatus={{this.sentStatus}}
-      />
-    {{/if}}
+    <PixButton
+      class="feedback__report-button"
+      @variant="tertiary"
+      @iconBefore="flag"
+      aria-label={{t "pages.modulix.issue-report.aria-label"}}
+      @triggerAction={{this.onReportClick}}
+    >{{t "pages.modulix.issue-report.button"}}</PixButton>
+    <ModulixIssueReportModal
+      @elementType={{@reportInfo.elementType}}
+      @showModal={{this.showModal}}
+      @hideModal={{this.hideModal}}
+      @onSendReport={{this.onSend}}
+      @sentStatus={{this.sentStatus}}
+    />
   </template>
 }

--- a/mon-pix/app/models/feature-toggle.js
+++ b/mon-pix/app/models/feature-toggle.js
@@ -5,5 +5,4 @@ export default class FeatureToggle extends Model {
   @attr('boolean') isQuestEnabled;
   @attr('boolean') isSurveyEnabledForCombinedCourses;
   @attr('boolean') areModuleShortIdUrlsEnabled;
-  @attr('boolean') isModulixIssueReportDisplayed;
 }

--- a/mon-pix/tests/acceptance/module/send-issue-report_test.js
+++ b/mon-pix/tests/acceptance/module/send-issue-report_test.js
@@ -50,11 +50,6 @@ module('Acceptance | Module | Routes | sendIssueReport', function (hooks) {
         sections: [section],
       });
 
-      server.create('feature-toggle', {
-        id: 0,
-        isModulixIssueReportDisplayed: true,
-      });
-
       // when
       const screen = await visit('/modules/3r7cl7m3/bien-ecrire-son-adresse-mail/passage');
       await click(screen.getByLabelText('I am the right answer!'));

--- a/mon-pix/tests/integration/components/module/custom-draft_test.gjs
+++ b/mon-pix/tests/integration/components/module/custom-draft_test.gjs
@@ -4,7 +4,6 @@ import { click, find } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import ModulixCustomDraft from 'mon-pix/components/module/element/custom-draft';
 import { module, test } from 'qunit';
-import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import { waitForDialog } from '../../../helpers/wait-for';
@@ -74,61 +73,25 @@ module('Integration | Component | Module | CustomDraft', function (hooks) {
     });
   });
 
-  module('when isModulixIssueReportDisplayed FT is enabled', function () {
-    test('should display report button', async function (assert) {
-      // given
-      const customDraft = {
-        id: 'id',
-        title: 'title',
-        url: 'https://example.org',
-        instruction: '<p>Instruction du POIC</p>',
-        height: 400,
-      };
-      const featureToggles = this.owner.lookup('service:featureToggles');
-      sinon.stub(featureToggles, 'featureToggles').value({ isModulixIssueReportDisplayed: true });
+  test('should display report button', async function (assert) {
+    // given
+    const customDraft = {
+      id: 'id',
+      title: 'title',
+      url: 'https://example.org',
+      instruction: '<p>Instruction du POIC</p>',
+      height: 400,
+    };
 
-      // when
-      const screen = await render(<template><ModulixCustomDraft @customDraft={{customDraft}} /></template>);
+    // when
+    const screen = await render(<template><ModulixCustomDraft @customDraft={{customDraft}} /></template>);
 
-      // then
-      assert.dom(screen.getByRole('button', { name: t('pages.modulix.issue-report.aria-label') })).exists();
-    });
-
-    module('when user clicks on report button', function () {
-      test('should display issue-report modal with a form inside', async function (assert) {
-        // given
-        const customDraft = {
-          id: 'id',
-          title: 'title',
-          url: 'https://example.org',
-          instruction: '<p>Instruction du POIC</p>',
-          height: 400,
-          type: 'custom-draft',
-        };
-        const featureToggles = this.owner.lookup('service:featureToggles');
-        sinon.stub(featureToggles, 'featureToggles').value({ isModulixIssueReportDisplayed: true });
-
-        // when
-        const screen = await render(
-          <template>
-            <div id="modal-container"></div>
-            <ModulixCustomDraft @customDraft={{customDraft}} />
-          </template>,
-        );
-        await click(screen.getByRole('button', { name: t('pages.modulix.issue-report.aria-label') }));
-        await waitForDialog();
-
-        // then
-        await click(screen.getByRole('button', { name: t('pages.modulix.issue-report.modal.select-label') }));
-        const listbox = await screen.findByRole('listbox');
-        const options = within(listbox).getAllByRole('option');
-        assert.strictEqual(options.length, 4);
-      });
-    });
+    // then
+    assert.dom(screen.getByRole('button', { name: t('pages.modulix.issue-report.aria-label') })).exists();
   });
 
-  module('when isModulixIssueReportDisplayed FT is disabled', function () {
-    test('should not display report button', async function (assert) {
+  module('when user clicks on report button', function () {
+    test('should display issue-report modal with a form inside', async function (assert) {
       // given
       const customDraft = {
         id: 'id',
@@ -136,15 +99,24 @@ module('Integration | Component | Module | CustomDraft', function (hooks) {
         url: 'https://example.org',
         instruction: '<p>Instruction du POIC</p>',
         height: 400,
+        type: 'custom-draft',
       };
-      const featureToggles = this.owner.lookup('service:featureToggles');
-      sinon.stub(featureToggles, 'featureToggles').value({ isModulixIssueReportDisplayed: false });
 
       // when
-      const screen = await render(<template><ModulixCustomDraft @customDraft={{customDraft}} /></template>);
+      const screen = await render(
+        <template>
+          <div id="modal-container"></div>
+          <ModulixCustomDraft @customDraft={{customDraft}} />
+        </template>,
+      );
+      await click(screen.getByRole('button', { name: t('pages.modulix.issue-report.aria-label') }));
+      await waitForDialog();
 
       // then
-      assert.dom(screen.queryByRole('button', { name: t('pages.modulix.issue-report.aria-label') })).doesNotExist();
+      await click(screen.getByRole('button', { name: t('pages.modulix.issue-report.modal.select-label') }));
+      const listbox = await screen.findByRole('listbox');
+      const options = within(listbox).getAllByRole('option');
+      assert.strictEqual(options.length, 4);
     });
   });
 });

--- a/mon-pix/tests/integration/components/module/custom-element_test.gjs
+++ b/mon-pix/tests/integration/components/module/custom-element_test.gjs
@@ -3,7 +3,6 @@ import { click } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import ModulixCustomElement from 'mon-pix/components/module/element/custom-element';
 import { module, test } from 'qunit';
-import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import { waitForDialog } from '../../../helpers/wait-for';
@@ -11,150 +10,69 @@ import { waitForDialog } from '../../../helpers/wait-for';
 module('Integration | Component | Module | Custom Element', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  module('when isModulixIssueReportDisplayed FT is enabled', function () {
-    test('should display report button', async function (assert) {
-      const customElement = {
-        id: 'id',
-        title: 'mon-custom-test',
-        instruction: 'Test POI quiz image',
-        tagName: 'image-quiz',
-        props: {
-          name: 'Liste d‘applications',
-          imageChoicesSize: 'icon',
-          choices: [
-            {
-              name: 'Google',
-              image: {
-                width: 534,
-                height: 544,
-                loading: 'lazy',
-                decoding: 'async',
-                src: 'https://epreuves.pix.fr/_astro/Google.B1bcY5Go_1BynY8.svg',
-              },
+  test('should display report button', async function (assert) {
+    const customElement = {
+      id: 'id',
+      title: 'mon-custom-test',
+      instruction: 'Test POI quiz image',
+      tagName: 'image-quiz',
+      props: {
+        name: 'Liste d‘applications',
+        imageChoicesSize: 'icon',
+        choices: [
+          {
+            name: 'Google',
+            image: {
+              width: 534,
+              height: 544,
+              loading: 'lazy',
+              decoding: 'async',
+              src: 'https://epreuves.pix.fr/_astro/Google.B1bcY5Go_1BynY8.svg',
             },
-            {
-              name: 'LibreOffice Writer',
-              image: {
-                width: 205,
-                height: 246,
-                loading: 'lazy',
-                decoding: 'async',
-                src: 'https://epreuves.pix.fr/_astro/writer.3bR8N2DK_Z1iWuJ9.webp',
-              },
-            },
-            {
-              name: 'Explorateur',
-              image: {
-                width: 128,
-                height: 128,
-                loading: 'lazy',
-                decoding: 'async',
-                src: 'https://epreuves.pix.fr/_astro/windows-file-explorer.CnF8MYwI_23driA.webp',
-              },
-            },
-            {
-              name: 'Geogebra',
-              image: {
-                width: 640,
-                height: 640,
-                loading: 'lazy',
-                decoding: 'async',
-                src: 'https://epreuves.pix.fr/_astro/geogebra.CZH9VYqc_19v4nj.webp',
-              },
-            },
-          ],
-        },
-      };
-      const featureToggles = this.owner.lookup('service:featureToggles');
-      sinon.stub(featureToggles, 'featureToggles').value({ isModulixIssueReportDisplayed: true });
-
-      // when
-      const screen = await render(<template><ModulixCustomElement @component={{customElement}} /></template>);
-
-      // then
-      assert.dom(screen.getByRole('button', { name: t('pages.modulix.issue-report.aria-label') })).exists();
-    });
-
-    module('when user clicks on report button', function () {
-      test('should display issue-report modal with a form inside', async function (assert) {
-        // given
-        const customElement = {
-          id: 'b0e9d79f-1727-4861-ac89-bd834473d62b',
-          title: 'mon-custom-test',
-          instruction: 'Test POI quiz image',
-          tagName: 'image-quiz',
-          props: {
-            name: 'Liste d‘applications',
-            imageChoicesSize: 'icon',
-            choices: [
-              {
-                name: 'Google',
-                image: {
-                  width: 534,
-                  height: 544,
-                  loading: 'lazy',
-                  decoding: 'async',
-                  src: 'https://epreuves.pix.fr/_astro/Google.B1bcY5Go_1BynY8.svg',
-                },
-              },
-              {
-                name: 'LibreOffice Writer',
-                image: {
-                  width: 205,
-                  height: 246,
-                  loading: 'lazy',
-                  decoding: 'async',
-                  src: 'https://epreuves.pix.fr/_astro/writer.3bR8N2DK_Z1iWuJ9.webp',
-                },
-              },
-              {
-                name: 'Explorateur',
-                image: {
-                  width: 128,
-                  height: 128,
-                  loading: 'lazy',
-                  decoding: 'async',
-                  src: 'https://epreuves.pix.fr/_astro/windows-file-explorer.CnF8MYwI_23driA.webp',
-                },
-              },
-              {
-                name: 'Geogebra',
-                image: {
-                  width: 640,
-                  height: 640,
-                  loading: 'lazy',
-                  decoding: 'async',
-                  src: 'https://epreuves.pix.fr/_astro/geogebra.CZH9VYqc_19v4nj.webp',
-                },
-              },
-            ],
           },
-          type: 'custom',
-        };
-        const featureToggles = this.owner.lookup('service:featureToggles');
-        sinon.stub(featureToggles, 'featureToggles').value({ isModulixIssueReportDisplayed: true });
+          {
+            name: 'LibreOffice Writer',
+            image: {
+              width: 205,
+              height: 246,
+              loading: 'lazy',
+              decoding: 'async',
+              src: 'https://epreuves.pix.fr/_astro/writer.3bR8N2DK_Z1iWuJ9.webp',
+            },
+          },
+          {
+            name: 'Explorateur',
+            image: {
+              width: 128,
+              height: 128,
+              loading: 'lazy',
+              decoding: 'async',
+              src: 'https://epreuves.pix.fr/_astro/windows-file-explorer.CnF8MYwI_23driA.webp',
+            },
+          },
+          {
+            name: 'Geogebra',
+            image: {
+              width: 640,
+              height: 640,
+              loading: 'lazy',
+              decoding: 'async',
+              src: 'https://epreuves.pix.fr/_astro/geogebra.CZH9VYqc_19v4nj.webp',
+            },
+          },
+        ],
+      },
+    };
 
-        // when
-        const screen = await render(
-          <template>
-            <div id="modal-container"></div>
-            <ModulixCustomElement @component={{customElement}} />
-          </template>,
-        );
-        await click(screen.getByRole('button', { name: t('pages.modulix.issue-report.aria-label') }));
-        await waitForDialog();
+    // when
+    const screen = await render(<template><ModulixCustomElement @component={{customElement}} /></template>);
 
-        // then
-        await click(screen.getByRole('button', { name: t('pages.modulix.issue-report.modal.select-label') }));
-        const listbox = await screen.findByRole('listbox');
-        const options = within(listbox).getAllByRole('option');
-        assert.strictEqual(options.length, 4);
-      });
-    });
+    // then
+    assert.dom(screen.getByRole('button', { name: t('pages.modulix.issue-report.aria-label') })).exists();
   });
 
-  module('when isModulixIssueReportDisplayed FT is disabled', function () {
-    test('should not display report button', async function (assert) {
+  module('when user clicks on report button', function () {
+    test('should display issue-report modal with a form inside', async function (assert) {
       // given
       const customElement = {
         id: 'b0e9d79f-1727-4861-ac89-bd834473d62b',
@@ -207,15 +125,24 @@ module('Integration | Component | Module | Custom Element', function (hooks) {
             },
           ],
         },
+        type: 'custom',
       };
-      const featureToggles = this.owner.lookup('service:featureToggles');
-      sinon.stub(featureToggles, 'featureToggles').value({ isModulixIssueReportDisplayed: false });
 
       // when
-      const screen = await render(<template><ModulixCustomElement @component={{customElement}} /></template>);
+      const screen = await render(
+        <template>
+          <div id="modal-container"></div>
+          <ModulixCustomElement @component={{customElement}} />
+        </template>,
+      );
+      await click(screen.getByRole('button', { name: t('pages.modulix.issue-report.aria-label') }));
+      await waitForDialog();
 
       // then
-      assert.dom(screen.queryByRole('button', { name: t('pages.modulix.issue-report.aria-label') })).doesNotExist();
+      await click(screen.getByRole('button', { name: t('pages.modulix.issue-report.modal.select-label') }));
+      const listbox = await screen.findByRole('listbox');
+      const options = within(listbox).getAllByRole('option');
+      assert.strictEqual(options.length, 4);
     });
   });
 });

--- a/mon-pix/tests/integration/components/module/embed_test.gjs
+++ b/mon-pix/tests/integration/components/module/embed_test.gjs
@@ -586,77 +586,50 @@ module('Integration | Component | Module | Embed', function (hooks) {
     });
   });
 
-  module('when isModulixIssueReportDisplayed FT is enabled', function () {
-    test('should display report button', async function (assert) {
-      // given
-      const featureToggles = this.owner.lookup('service:featureToggles');
-      sinon.stub(featureToggles, 'featureToggles').value({ isModulixIssueReportDisplayed: true });
-      const embed = {
-        id: 'id',
-        title: 'title',
-        isCompletionRequired: false,
-        url: 'https://example.org',
-        height: 800,
-      };
+  test('should display report button', async function (assert) {
+    // given
+    const embed = {
+      id: 'id',
+      title: 'title',
+      isCompletionRequired: false,
+      url: 'https://example.org',
+      height: 800,
+    };
 
-      // when
-      const screen = await render(<template><ModulixEmbed @embed={{embed}} /></template>);
+    // when
+    const screen = await render(<template><ModulixEmbed @embed={{embed}} /></template>);
 
-      // then
-      assert.dom(screen.getByRole('button', { name: t('pages.modulix.issue-report.aria-label') })).exists();
-    });
-
-    module('when user clicks on report button', function () {
-      test('should display issue-report modal with a form inside', async function (assert) {
-        // given
-        const featureToggles = this.owner.lookup('service:featureToggles');
-        sinon.stub(featureToggles, 'featureToggles').value({ isModulixIssueReportDisplayed: true });
-        const embed = {
-          id: 'id',
-          title: 'title',
-          isCompletionRequired: false,
-          url: 'https://example.org',
-          height: 800,
-          type: 'embed',
-        };
-
-        // when
-        const screen = await render(
-          <template>
-            <div id="modal-container"></div>
-            <ModulixEmbed @embed={{embed}} />
-          </template>,
-        );
-        await click(screen.getByRole('button', { name: t('pages.modulix.issue-report.aria-label') }));
-        await waitForDialog();
-
-        // then
-        await click(screen.getByRole('button', { name: t('pages.modulix.issue-report.modal.select-label') }));
-        const listbox = await screen.findByRole('listbox');
-        const options = within(listbox).getAllByRole('option');
-        assert.strictEqual(options.length, 4);
-      });
-    });
+    // then
+    assert.dom(screen.getByRole('button', { name: t('pages.modulix.issue-report.aria-label') })).exists();
   });
 
-  module('when isModulixIssueReportDisplayed FT is disabled', function () {
-    test('should not display report button', async function (assert) {
+  module('when user clicks on report button', function () {
+    test('should display issue-report modal with a form inside', async function (assert) {
       // given
-      const featureToggles = this.owner.lookup('service:featureToggles');
-      sinon.stub(featureToggles, 'featureToggles').value({ isModulixIssueReportDisplayed: false });
       const embed = {
         id: 'id',
         title: 'title',
         isCompletionRequired: false,
         url: 'https://example.org',
         height: 800,
+        type: 'embed',
       };
 
       // when
-      const screen = await render(<template><ModulixEmbed @embed={{embed}} /></template>);
+      const screen = await render(
+        <template>
+          <div id="modal-container"></div>
+          <ModulixEmbed @embed={{embed}} />
+        </template>,
+      );
+      await click(screen.getByRole('button', { name: t('pages.modulix.issue-report.aria-label') }));
+      await waitForDialog();
 
       // then
-      assert.dom(screen.queryByRole('button', { name: t('pages.modulix.issue-report.aria-label') })).doesNotExist();
+      await click(screen.getByRole('button', { name: t('pages.modulix.issue-report.modal.select-label') }));
+      const listbox = await screen.findByRole('listbox');
+      const options = within(listbox).getAllByRole('option');
+      assert.strictEqual(options.length, 4);
     });
   });
 });

--- a/mon-pix/tests/integration/components/module/feedback_test.gjs
+++ b/mon-pix/tests/integration/components/module/feedback_test.gjs
@@ -3,7 +3,6 @@ import { click } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import ModulixFeedback from 'mon-pix/components/module/feedback';
 import { module, test } from 'qunit';
-import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import { waitForDialog } from '../../../helpers/wait-for';
@@ -42,71 +41,43 @@ module('Integration | Component | Module | Feedback', function (hooks) {
     assert.dom(screen.getByText("C'est la bonne réponse !")).exists();
   });
 
-  module('when isModulixIssueReportDisplayed FT is enabled', function () {
-    test('should display report button', async function (assert) {
-      // given
-      const feedback = {
-        state: 'Correct !',
-        diagnosis: "<p>C'est la bonne réponse !</p>",
-      };
-      const featureToggles = this.owner.lookup('service:featureToggles');
-      sinon.stub(featureToggles, 'featureToggles').value({ isModulixIssueReportDisplayed: true });
+  test('should display report button', async function (assert) {
+    // given
+    const feedback = {
+      state: 'Correct !',
+      diagnosis: "<p>C'est la bonne réponse !</p>",
+    };
 
-      // when
-      const screen = await render(
-        <template><ModulixFeedback @answerIsValid={{true}} @feedback={{feedback}} /></template>,
-      );
+    // when
+    const screen = await render(
+      <template><ModulixFeedback @answerIsValid={{true}} @feedback={{feedback}} /></template>,
+    );
 
-      // then
-      assert.dom(screen.getByRole('button', { name: t('pages.modulix.issue-report.aria-label') })).exists();
-    });
-
-    module('when user clicks on report button', function () {
-      test('should display issue-report modal with a form inside', async function (assert) {
-        // given
-        const feedback = {
-          state: 'Correct !',
-          diagnosis: "<p>C'est la bonne réponse !</p>",
-        };
-        const featureToggles = this.owner.lookup('service:featureToggles');
-        sinon.stub(featureToggles, 'featureToggles').value({ isModulixIssueReportDisplayed: true });
-
-        // when
-        const screen = await render(
-          <template>
-            <div id="modal-container"></div>
-            <ModulixFeedback @answerIsValid={{true}} @feedback={{feedback}} />
-          </template>,
-        );
-        await click(screen.getByRole('button', { name: t('pages.modulix.issue-report.aria-label') }));
-        await waitForDialog();
-
-        // then
-        assert.dom(screen.getByRole('dialog')).exists();
-        assert
-          .dom(screen.getByRole('heading', { name: t('pages.modulix.issue-report.modal.title'), level: 1 }))
-          .exists();
-      });
-    });
+    // then
+    assert.dom(screen.getByRole('button', { name: t('pages.modulix.issue-report.aria-label') })).exists();
   });
 
-  module('when isModulixIssueReportDisplayed FT is disabled', function () {
-    test('should not display report button', async function (assert) {
+  module('when user clicks on report button', function () {
+    test('should display issue-report modal with a form inside', async function (assert) {
       // given
       const feedback = {
         state: 'Correct !',
         diagnosis: "<p>C'est la bonne réponse !</p>",
       };
-      const featureToggles = this.owner.lookup('service:featureToggles');
-      sinon.stub(featureToggles, 'featureToggles').value({ isModulixIssueReportDisplayed: false });
 
       // when
       const screen = await render(
-        <template><ModulixFeedback @answerIsValid={{true}} @feedback={{feedback}} /></template>,
+        <template>
+          <div id="modal-container"></div>
+          <ModulixFeedback @answerIsValid={{true}} @feedback={{feedback}} />
+        </template>,
       );
+      await click(screen.getByRole('button', { name: t('pages.modulix.issue-report.aria-label') }));
+      await waitForDialog();
 
       // then
-      assert.dom(screen.queryByRole('button', { name: t('pages.modulix.issue-report.aria-label') })).doesNotExist();
+      assert.dom(screen.getByRole('dialog')).exists();
+      assert.dom(screen.getByRole('heading', { name: t('pages.modulix.issue-report.modal.title'), level: 1 })).exists();
     });
   });
 });

--- a/mon-pix/tests/integration/components/module/issue-report/issue-report-block_test.gjs
+++ b/mon-pix/tests/integration/components/module/issue-report/issue-report-block_test.gjs
@@ -11,225 +11,191 @@ import { waitForDialog, waitForDialogClose } from '../../../../helpers/wait-for'
 module('Integration | Component | Module | Issue Report | Issue Report Block', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  module('when feature toggle isModulixIssueReportDisplayed is true', function () {
-    test('should display a report button', async function (assert) {
-      // given
-      const featureToggles = this.owner.lookup('service:featureToggles');
-      sinon.stub(featureToggles, 'featureToggles').value({ isModulixIssueReportDisplayed: true });
+  test('should display a report button', async function (assert) {
+    // when
+    const screen = await render(<template><ModuleIssueReportBlock /></template>);
 
+    // then
+    assert.dom(screen.getByRole('button', { name: t('pages.modulix.issue-report.aria-label') })).exists();
+  });
+
+  module('when user clicks on report button', function () {
+    test('should open the issue report modal', async function (assert) {
       // when
-      const screen = await render(<template><ModuleIssueReportBlock /></template>);
+      const screen = await render(
+        <template>
+          <div id="modal-container"></div><ModuleIssueReportBlock />
+        </template>,
+      );
+      await click(screen.getByRole('button', { name: t('pages.modulix.issue-report.aria-label') }));
+      await waitForDialog();
 
       // then
-      assert.dom(screen.getByRole('button', { name: t('pages.modulix.issue-report.aria-label') })).exists();
+      assert.dom(screen.getByRole('dialog')).exists();
+      assert.dom(screen.getByRole('heading', { name: t('pages.modulix.issue-report.modal.title'), level: 1 })).exists();
     });
 
-    module('when user clicks on report button', function () {
-      test('should open the issue report modal', async function (assert) {
+    module('when user clicks on send button', function () {
+      test('should send a report', async function (assert) {
         // given
-        const featureToggles = this.owner.lookup('service:featureToggles');
-        sinon.stub(featureToggles, 'featureToggles').value({ isModulixIssueReportDisplayed: true });
+        const issueReportService = this.owner.lookup('service:moduleIssueReport');
+        const recordStub = sinon.stub(issueReportService, 'record');
+        const elementId = 'b37e8e8d-9875-4b15-85c0-0373ffbb0805';
+        const answer = 42;
+        const categoryKey = 'ACCESSIBILITY_ISSUE';
+        const comment = 'Mon super commentaire de Noel et de joie';
+        const reportInfo = { elementId, answer };
 
         // when
         const screen = await render(
           <template>
-            <div id="modal-container"></div><ModuleIssueReportBlock />
+            <div id="modal-container"></div><ModuleIssueReportBlock @reportInfo={{reportInfo}} />
           </template>,
         );
         await click(screen.getByRole('button', { name: t('pages.modulix.issue-report.aria-label') }));
         await waitForDialog();
 
+        await click(screen.getByRole('button', { name: t('pages.modulix.issue-report.modal.select-label') }));
+        await screen.findByRole('listbox');
+        await click(screen.getByRole('option', { name: 'Problème d’accessibilité' }));
+
+        await fillIn(
+          screen.getByRole('textbox', { name: t('pages.modulix.issue-report.modal.textarea-label') }),
+          comment,
+        );
+
+        await click(screen.getByRole('button', { name: t('common.actions.send') }));
+
         // then
-        assert.dom(screen.getByRole('dialog')).exists();
+        sinon.assert.calledOnceWithExactly(recordStub, {
+          elementId,
+          answer,
+          categoryKey,
+          comment,
+        });
+        assert.ok(true);
+      });
+
+      test('should display a confirmation message', async function (assert) {
+        // given
+        const issueReportService = this.owner.lookup('service:moduleIssueReport');
+        const elementId = 'b37e8e8d-9875-4b15-85c0-0373ffbb0805';
+        const answer = 42;
+        const comment = 'Mon super commentaire de Noel et de joie';
+        const reportInfo = { elementId, answer };
+
+        sinon.stub(issueReportService, 'record').resolves();
+
+        // when
+        const screen = await render(
+          <template>
+            <div id="modal-container"></div><ModuleIssueReportBlock @reportInfo={{reportInfo}} />
+          </template>,
+        );
+        await click(screen.getByRole('button', { name: t('pages.modulix.issue-report.aria-label') }));
+        await waitForDialog();
+
+        await click(screen.getByRole('button', { name: t('pages.modulix.issue-report.modal.select-label') }));
+        await screen.findByRole('listbox');
+        await click(screen.getByRole('option', { name: 'Problème d’accessibilité' }));
+
+        await fillIn(
+          screen.getByRole('textbox', { name: t('pages.modulix.issue-report.modal.textarea-label') }),
+          comment,
+        );
+
+        await click(screen.getByRole('button', { name: t('common.actions.send') }));
+
+        // then
+        const buttons = screen.getAllByRole('button', { name: t('common.actions.close') });
+        assert.strictEqual(buttons.length, 2);
+        assert.dom(screen.getByText(t('pages.modulix.issue-report.modal.confirmation-message.success')));
+
+        const closeButtons = screen.getAllByRole('button', { name: t('common.actions.close') });
+        await click(closeButtons[0]);
+        await waitForDialogClose();
+
         assert
-          .dom(screen.getByRole('heading', { name: t('pages.modulix.issue-report.modal.title'), level: 1 }))
-          .exists();
+          .dom(screen.queryByRole('heading', { name: t('pages.modulix.issue-report.modal.title'), level: 1 }))
+          .doesNotExist();
       });
 
-      module('when user clicks on send button', function () {
-        test('should send a report', async function (assert) {
-          // given
-          const featureToggles = this.owner.lookup('service:featureToggles');
-          sinon.stub(featureToggles, 'featureToggles').value({ isModulixIssueReportDisplayed: true });
-          const issueReportService = this.owner.lookup('service:moduleIssueReport');
-          const recordStub = sinon.stub(issueReportService, 'record');
-          const elementId = 'b37e8e8d-9875-4b15-85c0-0373ffbb0805';
-          const answer = 42;
-          const categoryKey = 'ACCESSIBILITY_ISSUE';
-          const comment = 'Mon super commentaire de Noel et de joie';
-          const reportInfo = { elementId, answer };
+      test('should display an error message when api call has failed', async function (assert) {
+        // given
+        const issueReportService = this.owner.lookup('service:moduleIssueReport');
+        const elementId = 'b37e8e8d-9875-4b15-85c0-0373ffbb0805';
+        const answer = 42;
+        const comment = 'Mon super commentaire de Noel et de joie';
+        const reportInfo = { elementId, answer };
 
-          // when
-          const screen = await render(
-            <template>
-              <div id="modal-container"></div><ModuleIssueReportBlock @reportInfo={{reportInfo}} />
-            </template>,
-          );
-          await click(screen.getByRole('button', { name: t('pages.modulix.issue-report.aria-label') }));
-          await waitForDialog();
+        sinon.stub(issueReportService, 'record').rejects();
 
-          await click(screen.getByRole('button', { name: t('pages.modulix.issue-report.modal.select-label') }));
-          await screen.findByRole('listbox');
-          await click(screen.getByRole('option', { name: 'Problème d’accessibilité' }));
+        // when
+        const screen = await render(
+          <template>
+            <div id="modal-container"></div><ModuleIssueReportBlock @reportInfo={{reportInfo}} />
+          </template>,
+        );
+        await click(screen.getByRole('button', { name: t('pages.modulix.issue-report.aria-label') }));
+        await waitForDialog();
 
-          await fillIn(
-            screen.getByRole('textbox', { name: t('pages.modulix.issue-report.modal.textarea-label') }),
-            comment,
-          );
+        await click(screen.getByRole('button', { name: t('pages.modulix.issue-report.modal.select-label') }));
+        await screen.findByRole('listbox');
+        await click(screen.getByRole('option', { name: 'Problème d’accessibilité' }));
 
-          await click(screen.getByRole('button', { name: t('common.actions.send') }));
+        await fillIn(
+          screen.getByRole('textbox', { name: t('pages.modulix.issue-report.modal.textarea-label') }),
+          comment,
+        );
 
-          // then
-          sinon.assert.calledOnceWithExactly(recordStub, {
-            elementId,
-            answer,
-            categoryKey,
-            comment,
-          });
-          assert.ok(true);
-        });
+        await click(screen.getByRole('button', { name: t('common.actions.send') }));
 
-        test('should display a confirmation message', async function (assert) {
-          // given
-          const featureToggles = this.owner.lookup('service:featureToggles');
-          sinon.stub(featureToggles, 'featureToggles').value({ isModulixIssueReportDisplayed: true });
-          const issueReportService = this.owner.lookup('service:moduleIssueReport');
-          const elementId = 'b37e8e8d-9875-4b15-85c0-0373ffbb0805';
-          const answer = 42;
-          const comment = 'Mon super commentaire de Noel et de joie';
-          const reportInfo = { elementId, answer };
-
-          sinon.stub(issueReportService, 'record').resolves();
-
-          // when
-          const screen = await render(
-            <template>
-              <div id="modal-container"></div><ModuleIssueReportBlock @reportInfo={{reportInfo}} />
-            </template>,
-          );
-          await click(screen.getByRole('button', { name: t('pages.modulix.issue-report.aria-label') }));
-          await waitForDialog();
-
-          await click(screen.getByRole('button', { name: t('pages.modulix.issue-report.modal.select-label') }));
-          await screen.findByRole('listbox');
-          await click(screen.getByRole('option', { name: 'Problème d’accessibilité' }));
-
-          await fillIn(
-            screen.getByRole('textbox', { name: t('pages.modulix.issue-report.modal.textarea-label') }),
-            comment,
-          );
-
-          await click(screen.getByRole('button', { name: t('common.actions.send') }));
-
-          // then
-          const buttons = screen.getAllByRole('button', { name: t('common.actions.close') });
-          assert.strictEqual(buttons.length, 2);
-          assert.dom(screen.getByText(t('pages.modulix.issue-report.modal.confirmation-message.success')));
-
-          const closeButtons = screen.getAllByRole('button', { name: t('common.actions.close') });
-          await click(closeButtons[0]);
-          await waitForDialogClose();
-
-          assert
-            .dom(screen.queryByRole('heading', { name: t('pages.modulix.issue-report.modal.title'), level: 1 }))
-            .doesNotExist();
-        });
-
-        test('should display an error message when api call has failed', async function (assert) {
-          // given
-          const featureToggles = this.owner.lookup('service:featureToggles');
-          sinon.stub(featureToggles, 'featureToggles').value({ isModulixIssueReportDisplayed: true });
-          const issueReportService = this.owner.lookup('service:moduleIssueReport');
-          const elementId = 'b37e8e8d-9875-4b15-85c0-0373ffbb0805';
-          const answer = 42;
-          const comment = 'Mon super commentaire de Noel et de joie';
-          const reportInfo = { elementId, answer };
-
-          sinon.stub(issueReportService, 'record').rejects();
-
-          // when
-          const screen = await render(
-            <template>
-              <div id="modal-container"></div><ModuleIssueReportBlock @reportInfo={{reportInfo}} />
-            </template>,
-          );
-          await click(screen.getByRole('button', { name: t('pages.modulix.issue-report.aria-label') }));
-          await waitForDialog();
-
-          await click(screen.getByRole('button', { name: t('pages.modulix.issue-report.modal.select-label') }));
-          await screen.findByRole('listbox');
-          await click(screen.getByRole('option', { name: 'Problème d’accessibilité' }));
-
-          await fillIn(
-            screen.getByRole('textbox', { name: t('pages.modulix.issue-report.modal.textarea-label') }),
-            comment,
-          );
-
-          await click(screen.getByRole('button', { name: t('common.actions.send') }));
-
-          // then
-          const buttons = screen.getAllByRole('button', { name: t('common.actions.close') });
-          assert.strictEqual(buttons.length, 2);
-          assert.dom(screen.getByText(t('pages.modulix.issue-report.modal.confirmation-message.error')));
-        });
-      });
-
-      module('when user closes issue-report modal', function () {
-        test('should reset the form', async function (assert) {
-          // given
-          const featureToggles = this.owner.lookup('service:featureToggles');
-          sinon.stub(featureToggles, 'featureToggles').value({ isModulixIssueReportDisplayed: true });
-          const elementId = 'b37e8e8d-9875-4b15-85c0-0373ffbb0805';
-          const answer = 42;
-          const reportInfo = { elementId, answer };
-
-          // when
-          const screen = await render(
-            <template>
-              <div id="modal-container"></div><ModuleIssueReportBlock @reportInfo={{reportInfo}} />
-            </template>,
-          );
-
-          await click(screen.getByRole('button', { name: t('pages.modulix.issue-report.aria-label') }));
-          await waitForDialog();
-
-          await click(screen.getByRole('button', { name: t('pages.modulix.issue-report.modal.select-label') }));
-          await screen.findByRole('listbox');
-          await click(screen.getByRole('option', { name: 'Autre' }));
-
-          await fillIn(
-            screen.getByRole('textbox', { name: t('pages.modulix.issue-report.modal.textarea-label') }),
-            'Mon super commentaire',
-          );
-
-          await click(screen.getByRole('button', { name: t('common.actions.cancel') }));
-          await waitForDialogClose();
-
-          await click(screen.getByRole('button', { name: t('pages.modulix.issue-report.aria-label') }));
-          await waitForDialog();
-
-          // then
-          const allAccessibilityOptions = screen.getAllByText('Je ne comprends pas la question');
-          assert.strictEqual(allAccessibilityOptions.length, 2);
-          assert
-            .dom(screen.getByRole('textbox', { name: t('pages.modulix.issue-report.modal.textarea-label') }))
-            .hasValue('');
-        });
+        // then
+        const buttons = screen.getAllByRole('button', { name: t('common.actions.close') });
+        assert.strictEqual(buttons.length, 2);
+        assert.dom(screen.getByText(t('pages.modulix.issue-report.modal.confirmation-message.error')));
       });
     });
-  });
 
-  module('when feature toggle isModulixIssueReportDisplayed is false', function () {
-    test('should not display a report button', async function (assert) {
-      // given
-      const featureToggles = this.owner.lookup('service:featureToggles');
-      sinon.stub(featureToggles, 'featureToggles').value({ isModulixIssueReportDisplayed: false });
+    module('when user closes issue-report modal', function () {
+      test('should reset the form', async function (assert) {
+        // given
+        const elementId = 'b37e8e8d-9875-4b15-85c0-0373ffbb0805';
+        const answer = 42;
+        const reportInfo = { elementId, answer };
 
-      // when
-      const screen = await render(<template><ModuleIssueReportBlock /></template>);
+        // when
+        const screen = await render(
+          <template>
+            <div id="modal-container"></div><ModuleIssueReportBlock @reportInfo={{reportInfo}} />
+          </template>,
+        );
 
-      // then
-      assert.dom(screen.queryByRole('button', { name: t('pages.modulix.issue-report.aria-label') })).doesNotExist();
+        await click(screen.getByRole('button', { name: t('pages.modulix.issue-report.aria-label') }));
+        await waitForDialog();
+
+        await click(screen.getByRole('button', { name: t('pages.modulix.issue-report.modal.select-label') }));
+        await screen.findByRole('listbox');
+        await click(screen.getByRole('option', { name: 'Autre' }));
+
+        await fillIn(
+          screen.getByRole('textbox', { name: t('pages.modulix.issue-report.modal.textarea-label') }),
+          'Mon super commentaire',
+        );
+
+        await click(screen.getByRole('button', { name: t('common.actions.cancel') }));
+        await waitForDialogClose();
+
+        await click(screen.getByRole('button', { name: t('pages.modulix.issue-report.aria-label') }));
+        await waitForDialog();
+
+        // then
+        const allAccessibilityOptions = screen.getAllByText('Je ne comprends pas la question');
+        assert.strictEqual(allAccessibilityOptions.length, 2);
+        assert
+          .dom(screen.getByRole('textbox', { name: t('pages.modulix.issue-report.modal.textarea-label') }))
+          .hasValue('');
+      });
     });
   });
 });

--- a/mon-pix/tests/integration/components/module/qab_test.gjs
+++ b/mon-pix/tests/integration/components/module/qab_test.gjs
@@ -226,76 +226,37 @@ module('Integration | Component | Module | QAB', function (hooks) {
     });
   });
 
-  module('when isModulixIssueReportDisplayed FT is enabled', function () {
-    test('should display report button', async function (assert) {
-      // given
-      const featureToggles = this.owner.lookup('service:featureToggles');
-      sinon.stub(featureToggles, 'featureToggles').value({ isModulixIssueReportDisplayed: true });
-      const qabElement = _getQabElement();
-      const onAnswerStub = sinon.stub();
+  test('should display report button', async function (assert) {
+    // given
+    const qabElement = _getQabElement();
+    const onAnswerStub = sinon.stub();
 
-      // when
-      const screen = await render(
-        <template><ModuleQabElement @element={{qabElement}} @onAnswer={{onAnswerStub}} /></template>,
-      );
+    // when
+    const screen = await render(
+      <template><ModuleQabElement @element={{qabElement}} @onAnswer={{onAnswerStub}} /></template>,
+    );
 
-      await click(screen.getByRole('button', { name: 'Option A: Vrai' }));
-      await clock.tickAsync(NEXT_CARD_DELAY);
-      await click(screen.getByRole('button', { name: 'Option A: Vrai' }));
-      await clock.tickAsync(NEXT_CARD_DELAY);
+    await click(screen.getByRole('button', { name: 'Option A: Vrai' }));
+    await clock.tickAsync(NEXT_CARD_DELAY);
+    await click(screen.getByRole('button', { name: 'Option A: Vrai' }));
+    await clock.tickAsync(NEXT_CARD_DELAY);
 
-      // then
-      assert.dom(screen.getByRole('button', { name: t('pages.modulix.issue-report.aria-label') })).exists();
-    });
-
-    module('when user clicks on report button', function () {
-      test('should display issue-report modal with a form inside', async function (assert) {
-        // given
-        const featureToggles = this.owner.lookup('service:featureToggles');
-        sinon.stub(featureToggles, 'featureToggles').value({ isModulixIssueReportDisplayed: true });
-        const qabElement = _getQabElement();
-        const onAnswerStub = sinon.stub();
-
-        // when
-        const screen = await render(
-          <template>
-            <div id="modal-container"></div>
-            <ModuleQabElement @element={{qabElement}} @onAnswer={{onAnswerStub}} />
-          </template>,
-        );
-
-        await click(screen.getByRole('button', { name: 'Option A: Vrai' }));
-        await clock.tickAsync(NEXT_CARD_DELAY);
-        await click(screen.getByRole('button', { name: 'Option A: Vrai' }));
-        await clock.tickAsync(NEXT_CARD_DELAY);
-
-        /* Le runAllAsync permet de faire passer ce test, bloqué à cause du PixSelect présent dans la modale.
-        Le problème vient du modifier on-click-outside du PixSelect */
-        await clock.runAllAsync();
-
-        await click(screen.getByRole('button', { name: t('pages.modulix.issue-report.aria-label') }));
-        await waitForDialog();
-
-        // then
-        assert.dom(screen.getByRole('dialog')).exists();
-        assert
-          .dom(screen.getByRole('heading', { name: t('pages.modulix.issue-report.modal.title'), level: 1 }))
-          .exists();
-      });
-    });
+    // then
+    assert.dom(screen.getByRole('button', { name: t('pages.modulix.issue-report.aria-label') })).exists();
   });
 
-  module('when isModulixIssueReportDisplayed FT is disabled', function () {
-    test('should not display report button', async function (assert) {
+  module('when user clicks on report button', function () {
+    test('should display issue-report modal with a form inside', async function (assert) {
       // given
-      const featureToggles = this.owner.lookup('service:featureToggles');
-      sinon.stub(featureToggles, 'featureToggles').value({ isModulixIssueReportDisplayed: false });
       const qabElement = _getQabElement();
       const onAnswerStub = sinon.stub();
 
       // when
       const screen = await render(
-        <template><ModuleQabElement @element={{qabElement}} @onAnswer={{onAnswerStub}} /></template>,
+        <template>
+          <div id="modal-container"></div>
+          <ModuleQabElement @element={{qabElement}} @onAnswer={{onAnswerStub}} />
+        </template>,
       );
 
       await click(screen.getByRole('button', { name: 'Option A: Vrai' }));
@@ -303,8 +264,16 @@ module('Integration | Component | Module | QAB', function (hooks) {
       await click(screen.getByRole('button', { name: 'Option A: Vrai' }));
       await clock.tickAsync(NEXT_CARD_DELAY);
 
+      /* Le runAllAsync permet de faire passer ce test, bloqué à cause du PixSelect présent dans la modale.
+        Le problème vient du modifier on-click-outside du PixSelect */
+      await clock.runAllAsync();
+
+      await click(screen.getByRole('button', { name: t('pages.modulix.issue-report.aria-label') }));
+      await waitForDialog();
+
       // then
-      assert.dom(screen.queryByRole('button', { name: t('pages.modulix.issue-report.aria-label') })).doesNotExist();
+      assert.dom(screen.getByRole('dialog')).exists();
+      assert.dom(screen.getByRole('heading', { name: t('pages.modulix.issue-report.modal.title'), level: 1 })).exists();
     });
   });
 });

--- a/mon-pix/tests/integration/components/module/qcu-declarative_test.gjs
+++ b/mon-pix/tests/integration/components/module/qcu-declarative_test.gjs
@@ -119,84 +119,52 @@ module('Integration | Component | Module | QCUDeclarative', function (hooks) {
     });
   });
 
-  module('when isModulixIssueReportDisplayed FT is enabled', function () {
-    test('should display report button', async function (assert) {
-      // given
-      const passageEventService = this.owner.lookup('service:passageEvents');
-      sinon.stub(passageEventService, 'record');
-      const featureToggles = this.owner.lookup('service:featureToggles');
-      sinon.stub(featureToggles, 'featureToggles').value({ isModulixIssueReportDisplayed: true });
-      const qcuDeclarativeElement = _getQcuDeclarativeElement();
-      const onAnswerStub = sinon.stub();
+  test('should display report button', async function (assert) {
+    // given
+    const passageEventService = this.owner.lookup('service:passageEvents');
+    sinon.stub(passageEventService, 'record');
+    const qcuDeclarativeElement = _getQcuDeclarativeElement();
+    const onAnswerStub = sinon.stub();
 
-      // when
-      const screen = await render(
-        <template><ModuleQcuDeclarative @element={{qcuDeclarativeElement}} @onAnswer={{onAnswerStub}} /></template>,
-      );
-      const firstButton = screen.getByRole('button', { name: qcuDeclarativeElement.proposals[0].content });
-      await click(firstButton);
+    // when
+    const screen = await render(
+      <template><ModuleQcuDeclarative @element={{qcuDeclarativeElement}} @onAnswer={{onAnswerStub}} /></template>,
+    );
+    const firstButton = screen.getByRole('button', { name: qcuDeclarativeElement.proposals[0].content });
+    await click(firstButton);
 
-      await clock.tickAsync(VERIFY_RESPONSE_DELAY + 10);
+    await clock.tickAsync(VERIFY_RESPONSE_DELAY + 10);
 
-      // then
-      assert.dom(screen.getByRole('button', { name: t('pages.modulix.issue-report.aria-label') })).exists();
-    });
-
-    module('when user clicks on report button', function () {
-      test('should display issue-report modal with a form inside', async function (assert) {
-        // given
-        const passageEventService = this.owner.lookup('service:passageEvents');
-        sinon.stub(passageEventService, 'record');
-        const featureToggles = this.owner.lookup('service:featureToggles');
-        sinon.stub(featureToggles, 'featureToggles').value({ isModulixIssueReportDisplayed: true });
-        const qcuDeclarativeElement = _getQcuDeclarativeElement();
-        const onAnswerStub = sinon.stub();
-
-        // when
-        const screen = await render(
-          <template>
-            <div id="modal-container"></div>
-            <ModuleQcuDeclarative @element={{qcuDeclarativeElement}} @onAnswer={{onAnswerStub}} />
-          </template>,
-        );
-        const firstButton = screen.getByRole('button', { name: qcuDeclarativeElement.proposals[0].content });
-        await click(firstButton);
-
-        await clock.tickAsync(VERIFY_RESPONSE_DELAY + 10);
-
-        await click(screen.getByRole('button', { name: t('pages.modulix.issue-report.aria-label') }));
-        await waitForDialog();
-
-        // then
-        assert.dom(screen.getByRole('dialog')).exists();
-        assert
-          .dom(screen.getByRole('heading', { name: t('pages.modulix.issue-report.modal.title'), level: 1 }))
-          .exists();
-      });
-    });
+    // then
+    assert.dom(screen.getByRole('button', { name: t('pages.modulix.issue-report.aria-label') })).exists();
   });
 
-  module('when isModulixIssueReportDisplayed FT is disabled', function () {
-    test('should not display report button', async function (assert) {
+  module('when user clicks on report button', function () {
+    test('should display issue-report modal with a form inside', async function (assert) {
       // given
       const passageEventService = this.owner.lookup('service:passageEvents');
       sinon.stub(passageEventService, 'record');
-      const featureToggles = this.owner.lookup('service:featureToggles');
-      sinon.stub(featureToggles, 'featureToggles').value({ isModulixIssueReportDisplayed: false });
       const qcuDeclarativeElement = _getQcuDeclarativeElement();
       const onAnswerStub = sinon.stub();
 
       // when
       const screen = await render(
-        <template><ModuleQcuDeclarative @element={{qcuDeclarativeElement}} @onAnswer={{onAnswerStub}} /></template>,
+        <template>
+          <div id="modal-container"></div>
+          <ModuleQcuDeclarative @element={{qcuDeclarativeElement}} @onAnswer={{onAnswerStub}} />
+        </template>,
       );
       const firstButton = screen.getByRole('button', { name: qcuDeclarativeElement.proposals[0].content });
       await click(firstButton);
 
       await clock.tickAsync(VERIFY_RESPONSE_DELAY + 10);
 
+      await click(screen.getByRole('button', { name: t('pages.modulix.issue-report.aria-label') }));
+      await waitForDialog();
+
       // then
-      assert.dom(screen.queryByRole('button', { name: t('pages.modulix.issue-report.aria-label') })).doesNotExist();
+      assert.dom(screen.getByRole('dialog')).exists();
+      assert.dom(screen.getByRole('heading', { name: t('pages.modulix.issue-report.modal.title'), level: 1 })).exists();
     });
   });
 });

--- a/mon-pix/tests/integration/components/module/qcu-discovery_test.gjs
+++ b/mon-pix/tests/integration/components/module/qcu-discovery_test.gjs
@@ -136,72 +136,31 @@ module('Integration | Component | Module | QCUDiscovery', function (hooks) {
     });
   });
 
-  module('when isModulixIssueReportDisplayed FT is enabled', function () {
-    test('should display report button', async function (assert) {
-      // given
-      const featureToggles = this.owner.lookup('service:featureToggles');
-      sinon.stub(featureToggles, 'featureToggles').value({ isModulixIssueReportDisplayed: true });
-      const passageEventService = this.owner.lookup('service:passageEvents');
-      sinon.stub(passageEventService, 'record');
-      const onAnswerStub = sinon.stub();
+  test('should display report button', async function (assert) {
+    // given
+    const passageEventService = this.owner.lookup('service:passageEvents');
+    sinon.stub(passageEventService, 'record');
+    const onAnswerStub = sinon.stub();
 
-      const qcuDiscoveryElement = _getQcuDiscoveryElement();
-      const { proposals } = qcuDiscoveryElement;
+    const qcuDiscoveryElement = _getQcuDiscoveryElement();
+    const { proposals } = qcuDiscoveryElement;
 
-      // when
-      const screen = await render(
-        <template><ModuleQcuDiscovery @element={{qcuDiscoveryElement}} @onAnswer={{onAnswerStub}} /></template>,
-      );
-      const button1 = screen.getByRole('button', { name: proposals[0].content });
-      await click(button1);
+    // when
+    const screen = await render(
+      <template><ModuleQcuDiscovery @element={{qcuDiscoveryElement}} @onAnswer={{onAnswerStub}} /></template>,
+    );
+    const button1 = screen.getByRole('button', { name: proposals[0].content });
+    await click(button1);
 
-      await clock.tickAsync(VERIFY_RESPONSE_DELAY + 10);
+    await clock.tickAsync(VERIFY_RESPONSE_DELAY + 10);
 
-      // then
-      assert.dom(screen.getByRole('button', { name: t('pages.modulix.issue-report.aria-label') })).exists();
-    });
-
-    module('when user clicks on report button', function () {
-      test('should display issue-report modal with a form inside', async function (assert) {
-        // given
-        const featureToggles = this.owner.lookup('service:featureToggles');
-        sinon.stub(featureToggles, 'featureToggles').value({ isModulixIssueReportDisplayed: true });
-        const passageEventService = this.owner.lookup('service:passageEvents');
-        sinon.stub(passageEventService, 'record');
-        const onAnswerStub = sinon.stub();
-
-        const qcuDiscoveryElement = _getQcuDiscoveryElement();
-        const { proposals } = qcuDiscoveryElement;
-
-        // when
-        const screen = await render(
-          <template>
-            <div id="modal-container"></div>
-            <ModuleQcuDiscovery @element={{qcuDiscoveryElement}} @onAnswer={{onAnswerStub}} />
-          </template>,
-        );
-        const button1 = screen.getByRole('button', { name: proposals[0].content });
-        await click(button1);
-
-        await clock.tickAsync(VERIFY_RESPONSE_DELAY + 10);
-
-        await click(screen.getByRole('button', { name: t('pages.modulix.issue-report.aria-label') }));
-        await waitForDialog();
-
-        // then
-        assert.dom(screen.getByRole('dialog')).exists();
-        assert
-          .dom(screen.getByRole('heading', { name: t('pages.modulix.issue-report.modal.title'), level: 1 }))
-          .exists();
-      });
-    });
+    // then
+    assert.dom(screen.getByRole('button', { name: t('pages.modulix.issue-report.aria-label') })).exists();
   });
 
-  module('when isModulixIssueReportDisplayed FT is disabled', function () {
-    test('should not display report button', async function (assert) {
+  module('when user clicks on report button', function () {
+    test('should display issue-report modal with a form inside', async function (assert) {
       // given
-      const featureToggles = this.owner.lookup('service:featureToggles');
-      sinon.stub(featureToggles, 'featureToggles').value({ isModulixIssueReportDisplayed: false });
       const passageEventService = this.owner.lookup('service:passageEvents');
       sinon.stub(passageEventService, 'record');
       const onAnswerStub = sinon.stub();
@@ -211,15 +170,22 @@ module('Integration | Component | Module | QCUDiscovery', function (hooks) {
 
       // when
       const screen = await render(
-        <template><ModuleQcuDiscovery @element={{qcuDiscoveryElement}} @onAnswer={{onAnswerStub}} /></template>,
+        <template>
+          <div id="modal-container"></div>
+          <ModuleQcuDiscovery @element={{qcuDiscoveryElement}} @onAnswer={{onAnswerStub}} />
+        </template>,
       );
       const button1 = screen.getByRole('button', { name: proposals[0].content });
       await click(button1);
 
       await clock.tickAsync(VERIFY_RESPONSE_DELAY + 10);
 
+      await click(screen.getByRole('button', { name: t('pages.modulix.issue-report.aria-label') }));
+      await waitForDialog();
+
       // then
-      assert.dom(screen.queryByRole('button', { name: t('pages.modulix.issue-report.aria-label') })).doesNotExist();
+      assert.dom(screen.getByRole('dialog')).exists();
+      assert.dom(screen.getByRole('heading', { name: t('pages.modulix.issue-report.modal.title'), level: 1 })).exists();
     });
   });
 });


### PR DESCRIPTION
## ❄️ Problème

La fonctionnalité permettant d'envoyer un signalement a été activé en prod. Nous n'avons donc plus besoin du feature toggle `isModulixIssueReportDisplayed` ♻️ 

## 🛷 Proposition

Le supprimer

## ☃️ Remarques

RAS

## 🧑‍🎄 Pour tester

- Vérifier, dans le code, qu'il n'y a plus de mention du feature toggle `isModulixIssueReportDisplayed` 
- (Non régression) tester l'envoi d'un signalement par exemple sur le module [bac-a-sable](https://app-pr14766.review.pix.fr/modules/6a68bf32/bac-a-sable).
