### PR TITLE
[FEATURE] Editer l'ordre des types de grain dans le schema d'un module (PIX-21069)

### DIFF
--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-schema.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-schema.js
@@ -78,7 +78,7 @@ const componentStepperSchema = Joi.object({
 const grainSchema = Joi.object({
   id: uuidSchema,
   type: Joi.string()
-    .valid('lesson', 'activity', 'discovery', 'challenge', 'summary', 'transition', 'short-lesson')
+    .valid('short-lesson', 'discovery', 'activity', 'challenge', 'lesson', 'summary', 'transition')
     .required(),
   title: htmlNotAllowedSchema.required().allow(''),
   components: Joi.array()


### PR DESCRIPTION
## ❄️ Problème

Les grains affichés dans Modulix Editor suivent un ordre peu pratique pour le contenu. Ex: le grain `short-lesson`est en dernier, alors qu'il serait mieux en première place dans le select.
<img width="217" height="222" alt="image" src="https://github.com/user-attachments/assets/93bb5353-0f37-46a5-9fa1-ec8245576603" />

## 🛷 Proposition

Modifier le schema Joi d'un module pour changer l'ordre des types de grain. Ordre demandé par le métier:
1. short-lesson
2. discovery
3. activity
4. le reste

## ☃️ Remarques

- Il faudra aussi éditer le schéma Modulix Editor pour que la modif soit prise en compte

## 🧑‍🎄 Pour tester

- Récupérer branche localement
- Lancer le script `convert-joi-schema-to-json-schema.js`avec Node
- Vérifier en sortie que le tableau de type de grains a bien ses éléments dans l'ordre souhaité
