### PR TITLE
[TECH] Supprimer la variable d'env LATEST_CERTIFICATION_CALIBRATION_DATE (PIX-20642).

### DIFF
--- a/api/sample.env
+++ b/api/sample.env
@@ -1165,14 +1165,3 @@ EMAIL_VALIDATION_DEMAND_TEMPORARY_STORAGE_LIFESPAN=3d
 # default: 4
 DAY_BEFORE_RETRYING=
 
-# ========
-# CERTIFICATION
-# ========
-
-# DATE of latest calibration
-#
-# presence: optional
-DD/MM/YYYY [-] HH:mm:ss [[].SSS]
-# type: String - Date format (YYYY-MM-DDTHH:mm:ssZ[ZZ])
-# default: 2025-02-01T12:00:00Z+0200
-LATEST_CERTIFICATION_CALIBRATION_DATE=

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -479,7 +479,6 @@ const configuration = (function () {
         maximumReachableScore: 895,
       },
       maxReachableLevel: 7,
-      latestCalibrationDate: new Date(process.env.LATEST_CERTIFICATION_CALIBRATION_DATE || '2021-12-31'),
     },
     version: process.env.CONTAINER_VERSION || 'development',
     autonomousCourse: {
@@ -645,8 +644,6 @@ const configuration = (function () {
     config.apiManager.url = 'http://external-partners-access/';
 
     config.infra.engineeringUserId = 800;
-
-    config.v3Certification.latestCalibrationDate = '2020-01-01';
   }
 
   return config;

--- a/api/tests/certification/evaluation/acceptance/application/certification-rescoring-route_test.js
+++ b/api/tests/certification/evaluation/acceptance/application/certification-rescoring-route_test.js
@@ -14,21 +14,18 @@ import {
 
 describe('Certification | Evaluation | Acceptance | Application |  certification rescoring', function () {
   describe('GET /api/admin/certifications/{certificationCourseId}/rescore', function () {
-    let server, originalConfigValue, originalCalibrationDateValue, calibrationId;
+    let server, originalConfigValue, calibrationId;
 
     beforeEach(async function () {
       calibrationId = 1;
       originalConfigValue = config.v3Certification.scoring.minimumAnswersRequiredToValidateACertification;
-      originalCalibrationDateValue = config.v3Certification.latestCalibrationDate;
       config.v3Certification.scoring.minimumAnswersRequiredToValidateACertification = 1;
-      config.v3Certification.latestCalibrationDate = new Date('2024-07-23');
 
       server = await createServer();
     });
 
     afterEach(function () {
       config.v3Certification.scoring.minimumAnswersRequiredToValidateACertification = originalConfigValue;
-      config.v3Certification.latestCalibrationDate = originalCalibrationDateValue;
     });
 
     describe('when scoring from the current framework', function () {

--- a/api/tests/certification/evaluation/unit/domain/services/scoring/calibrated-challenge-service_test.js
+++ b/api/tests/certification/evaluation/unit/domain/services/scoring/calibrated-challenge-service_test.js
@@ -8,10 +8,7 @@ const { minimumAnswersRequiredToValidateACertification } = config.v3Certificatio
 
 describe('Certification | Evaluation | Unit | Domain | Services | calibrated challenge service', function () {
   context('#findByCertificationCourseAndVersion', function () {
-    let challengeCalibrationRepository,
-      calibratedChallengeRepository,
-      certificationChallengeLiveAlertRepository,
-      originalLatestCalibrationDate;
+    let challengeCalibrationRepository, calibratedChallengeRepository, certificationChallengeLiveAlertRepository;
 
     let challengeList;
 
@@ -33,11 +30,6 @@ describe('Certification | Evaluation | Unit | Domain | Services | calibrated cha
       calibratedChallengeRepository = {
         getAllCalibratedChallenges: sinon.stub().rejects(new Error('Args mismatch')),
       };
-      originalLatestCalibrationDate = config.v3Certification.latestCalibrationDate;
-    });
-
-    afterEach(function () {
-      config.v3Certification.latestCalibrationDate = originalLatestCalibrationDate;
     });
 
     context('when there are no validated live alerts', function () {


### PR DESCRIPTION
## ❄️ Problème

Nous n'avons plus de dépendance a la table "quick & dirty" de l’ancienne calibration v3.
Ainsi, la variable d’env de switch en config ne sert plus a rien.

## 🛷 Proposition

Supprimer la variable d’env `LATEST_CERTIFICATION_CALIBRATION_DATE`.

## ☃️ Remarques

Une fois la PR mergée, la variable sera aussi supprimée sur les environnements.

## 🧑‍🎄 Pour tester

✅ All good ?
