### PR TITLE
[TECH] Utiliser Pgboss pour insérer les jobs plutôt que knex

### DIFF
--- a/api/db/database-builder/database-builder.js
+++ b/api/db/database-builder/database-builder.js
@@ -199,16 +199,13 @@ export class DatabaseBuilder {
 
     const publicResults = await this.knex.raw(_constructRawQuery('public'));
     const learningContentResults = await this.knex.raw(_constructRawQuery('learningcontent'));
-    const pgbossResults = await this.knex.raw(_constructRawQuery('pgboss'));
 
     this.#tablesOrderedByDependency = [
       ...publicResults.rows.map(({ table_name }) => table_name),
       ...learningContentResults.rows.map(({ table_name }) => `learningcontent.${table_name}`),
-      ...pgbossResults.rows.map(({ table_name }) => `pgboss.${table_name}`),
     ].filter((tableName) => !READONLY_TABLES.includes(tableName));
 
     this.#deletePriority = new Map(this.#tablesOrderedByDependency.map((tableName, index) => [tableName, index]));
-
     this.#insertPriority = new Map(
       this.#tablesOrderedByDependency.toReversed().map((tableName, index) => [tableName, index]),
     );
@@ -220,7 +217,6 @@ export class DatabaseBuilder {
         const tableName = databaseHelpers.getTableNameFromInsertSqlQuery(queryData.sql);
 
         if (!tableName || tableName === '') return;
-        if (tableName === 'pgboss.version') return;
 
         this.#dirtyTables.add(tableName);
       }

--- a/api/index.js
+++ b/api/index.js
@@ -7,6 +7,7 @@ import { learningContentCache } from './src/shared/infrastructure/caches/learnin
 import { quitAllStorages } from './src/shared/infrastructure/key-value-storages/index.js';
 import * as prometheusPushGateway from './src/shared/infrastructure/metrics/pushgateway.js';
 import { quitMutex } from './src/shared/infrastructure/mutex/RedisMutex.js';
+import { pgBoss } from './src/shared/infrastructure/repositories/jobs/pg-boss.js';
 import { logger } from './src/shared/infrastructure/utils/logger.js';
 import { redisMonitor } from './src/shared/infrastructure/utils/redis-monitor.js';
 import { validateEnvironmentVariables } from './src/shared/infrastructure/validate-environment-variables.js';
@@ -67,6 +68,10 @@ process.on('SIGINT', () => {
     await start();
     if (config.infra.startJobInWebProcess) {
       registerJobs({ jobGroups: [JobGroup.DEFAULT, JobGroup.FAST] });
+      import('./worker.js');
+    } else {
+      // when worker is in its own process we need to start pgBoss in server container too
+      await pgBoss.start();
     }
   } catch (error) {
     logger.error(error);

--- a/api/src/evaluation/infrastructure/repositories/answer-job-repository.js
+++ b/api/src/evaluation/infrastructure/repositories/answer-job-repository.js
@@ -1,5 +1,4 @@
 import { AnswerJob } from '../../../quest/domain/models/AnwserJob.js';
-import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { featureToggles } from '../../../shared/infrastructure/feature-toggles/index.js';
 import { temporaryStorage } from '../../../shared/infrastructure/key-value-storages/index.js';
 import { JobRepository } from '../../../shared/infrastructure/repositories/jobs/job-repository.js';
@@ -23,17 +22,8 @@ export class AnswerJobRepository extends JobRepository {
     )
       return;
 
-    const knexConn = DomainTransaction.getConnection();
-
-    if (knexConn.isTransaction) {
-      await super.performAsync(job);
-      await this.#profileRewardTemporaryStorage.increment(job.userId);
-    } else {
-      await DomainTransaction.execute(async () => {
-        await super.performAsync(job);
-        await this.#profileRewardTemporaryStorage.increment(job.userId);
-      });
-    }
+    await super.performAsync(job);
+    await this.#profileRewardTemporaryStorage.increment(job.userId);
   }
 }
 

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -435,6 +435,7 @@ const configuration = (function () {
       exportSenderJobEnabled: process.env.PGBOSS_EXPORT_SENDER_JOB_ENABLED
         ? toBoolean(process.env.PGBOSS_EXPORT_SENDER_JOB_ENABLED)
         : true,
+      databaseUrl: process.env.DATABASE_URL,
     },
     poleEmploi: {
       clientId: process.env.POLE_EMPLOI_CLIENT_ID,
@@ -644,6 +645,10 @@ const configuration = (function () {
     config.apiManager.url = 'http://external-partners-access/';
 
     config.infra.engineeringUserId = 800;
+
+    config.pgBoss.databaseUrl = process.env.TEST_DATABASE_URL;
+
+    config.v3Certification.latestCalibrationDate = '2020-01-01';
   }
 
   return config;

--- a/api/src/shared/infrastructure/repositories/jobs/job-repository.js
+++ b/api/src/shared/infrastructure/repositories/jobs/job-repository.js
@@ -1,8 +1,7 @@
 import Joi from 'joi';
 
-import { knex } from '../../../../../db/knex-database-connection.js';
-import { DomainTransaction } from '../../../domain/DomainTransaction.js';
 import { EntityValidationError } from '../../../domain/errors.js';
+import { pgBoss } from './pg-boss.js';
 
 export class JobRepository {
   #schema = Joi.object({
@@ -47,24 +46,19 @@ export class JobRepository {
   #buildPayload(data) {
     return {
       name: this.name,
-      retrylimit: this.retry.retryLimit,
-      retrydelay: this.retry.retryDelay,
-      retrybackoff: this.retry.retryBackoff,
-      expirein: this.expireIn,
       data,
-      on_complete: true,
+      retryLimit: this.retry.retryLimit,
+      retryDelay: this.retry.retryDelay,
+      retryBackoff: this.retry.retryBackoff,
+      expireInSeconds: this.expireIn,
+      onComplete: true,
       priority: this.priority,
     };
   }
 
   async #send(jobs) {
-    const knexConn = DomainTransaction.getConnection();
-
-    const results = await knex.batchInsert('pgboss.job', jobs).transacting(knexConn.isTransaction ? knexConn : null);
-
-    const rowCount = results.reduce((total, batchResult) => total + (batchResult.rowCount || 0), 0);
-
-    return { rowCount };
+    await pgBoss.insert(jobs);
+    return { rowCount: jobs.length };
   }
 
   async performAsync(...datas) {
@@ -124,15 +118,18 @@ export const JobRetry = Object.freeze({
 });
 
 /**
- * Job expireIn. define few config to set expireIn field
+ * Job expireIn. define few config to set expireInSeconds field
  * @see https://github.com/timgit/pg-boss/blob/9.0.3/docs/readme.md#insertjobs
  * @readonly
  * @enum {string}
  */
 export const JobExpireIn = Object.freeze({
-  INFINITE: '48:00:00',
+  INFINITE: 48 * 60,
   /*
    pg-boss n'arrête pas les jobs expirés. De plus, il empile d'autres jobs par dessus et relance le job expiré, ce qui peut provoquer des états incohérents.
    Par conséquent nous définissons 48 heures comme durée maximale, ce qui fait plus que la durée maximale d'un conteneur.
    */
+  DEFAULT: 15 * 60,
+  HIGH: 30 * 60,
+  FOUR_HOURS: 4 * 60 * 60,
 });

--- a/api/src/shared/infrastructure/repositories/jobs/pg-boss.js
+++ b/api/src/shared/infrastructure/repositories/jobs/pg-boss.js
@@ -1,0 +1,12 @@
+import PgBoss from 'pg-boss';
+
+import { config } from '../../../config.js';
+
+const monitorStateIntervalSeconds = config.pgBoss.monitorStateIntervalSeconds;
+
+export const pgBoss = new PgBoss({
+  connectionString: config.pgBoss.databaseUrl,
+  max: config.pgBoss.connexionPoolMaxSize,
+  ...(monitorStateIntervalSeconds ? { monitorStateIntervalSeconds } : {}),
+  archiveFailedAfterSeconds: config.pgBoss.archiveFailedAfterSeconds,
+});

--- a/api/tests/certification/evaluation/integration/infrastructure/repositories/jobs/certification-completed-job-repository_test.js
+++ b/api/tests/certification/evaluation/integration/infrastructure/repositories/jobs/certification-completed-job-repository_test.js
@@ -20,9 +20,9 @@ describe('Integration | Repository | Jobs | CertificationCompletedJobRepository'
 
       // then
       await expect(CertificationCompletedJob.name).to.have.been.performed.withJob({
-        retrylimit: 10,
-        retrydelay: 30,
-        retrybackoff: true,
+        retryLimit: 10,
+        retryDelay: 30,
+        retryBackoff: true,
         priority: JobPriority.HIGH,
         data,
       });

--- a/api/tests/evaluation/unit/infrastructure/repositories/answer-job-repository_test.js
+++ b/api/tests/evaluation/unit/infrastructure/repositories/answer-job-repository_test.js
@@ -1,4 +1,5 @@
 import { AnswerJobRepository } from '../../../../../src/evaluation/infrastructure/repositories/answer-job-repository.js';
+import { DomainTransaction } from '../../../../../src/shared/domain/DomainTransaction.js';
 import { featureToggles } from '../../../../../src/shared/infrastructure/feature-toggles/index.js';
 import { pgBoss } from '../../../../../src/shared/infrastructure/repositories/jobs/pg-boss.js';
 import { expect, sinon } from '../../../../test-helper.js';
@@ -7,7 +8,10 @@ describe('Evaluation | Unit | Infrastructure | Repositories | AnswerJobRepositor
   beforeEach(async function () {
     await featureToggles.set('isQuestEnabled', true);
     await featureToggles.set('isAsyncQuestRewardingCalculationEnabled', true);
-    sinon.stub(pgBoss, 'insert').resolves([]);
+    sinon.stub(pgBoss, 'send').resolves([]);
+    sinon.stub(DomainTransaction, 'getConnection').returns({
+      client: { acquireConnection: sinon.stub().resolves({ query: sinon.stub() }), releaseConnection: sinon.stub() },
+    });
   });
 
   describe('#performAsync', function () {

--- a/api/tests/evaluation/unit/infrastructure/repositories/answer-job-repository_test.js
+++ b/api/tests/evaluation/unit/infrastructure/repositories/answer-job-repository_test.js
@@ -1,28 +1,19 @@
 import { AnswerJobRepository } from '../../../../../src/evaluation/infrastructure/repositories/answer-job-repository.js';
-import { config } from '../../../../../src/shared/config.js';
-import { DomainTransaction } from '../../../../../src/shared/domain/DomainTransaction.js';
 import { featureToggles } from '../../../../../src/shared/infrastructure/feature-toggles/index.js';
-import { expect, knex, sinon } from '../../../../test-helper.js';
+import { pgBoss } from '../../../../../src/shared/infrastructure/repositories/jobs/pg-boss.js';
+import { expect, sinon } from '../../../../test-helper.js';
 
 describe('Evaluation | Unit | Infrastructure | Repositories | AnswerJobRepository', function () {
   beforeEach(async function () {
-    sinon.stub(config, 'featureToggles');
-    sinon.stub(knex, 'batchInsert').callsFake(() => ({
-      transacting: sinon.stub().resolves([{ rowCount: 1 }]),
-    }));
     await featureToggles.set('isQuestEnabled', true);
     await featureToggles.set('isAsyncQuestRewardingCalculationEnabled', true);
+    sinon.stub(pgBoss, 'insert').resolves([]);
   });
 
   describe('#performAsync', function () {
     it('should do nothing if quests are disabled', async function () {
       // given
       const profileRewardTemporaryStorageStub = { increment: sinon.stub() };
-      const knexStub = { batchInsert: sinon.stub().resolves([]) };
-      sinon.stub(DomainTransaction, 'getConnection').returns(knexStub);
-      sinon.stub(DomainTransaction, 'execute').callsFake((callback) => {
-        return callback();
-      });
       await featureToggles.set('isQuestEnabled', false);
       const userId = Symbol('userId');
       const answerJobRepository = new AnswerJobRepository({
@@ -39,11 +30,6 @@ describe('Evaluation | Unit | Infrastructure | Repositories | AnswerJobRepositor
     it('should do nothing if quests are in sync mode', async function () {
       // given
       const profileRewardTemporaryStorageStub = { increment: sinon.stub() };
-      const knexStub = { batchInsert: sinon.stub().resolves([]) };
-      sinon.stub(DomainTransaction, 'getConnection').returns(knexStub);
-      sinon.stub(DomainTransaction, 'execute').callsFake((callback) => {
-        return callback();
-      });
       await featureToggles.set('isAsyncQuestRewardingCalculationEnabled', false);
       const userId = Symbol('userId');
       const answerJobRepository = new AnswerJobRepository({
@@ -60,11 +46,6 @@ describe('Evaluation | Unit | Infrastructure | Repositories | AnswerJobRepositor
     it("should increment user's jobs count in temporary storage", async function () {
       // given
       const profileRewardTemporaryStorageStub = { increment: sinon.stub() };
-      const knexStub = { batchInsert: sinon.stub().resolves([]) };
-      sinon.stub(DomainTransaction, 'getConnection').returns(knexStub);
-      sinon.stub(DomainTransaction, 'execute').callsFake((callback) => {
-        return callback();
-      });
       const userId = Symbol('userId');
       const answerJobRepository = new AnswerJobRepository({
         dependencies: { profileRewardTemporaryStorage: profileRewardTemporaryStorageStub },
@@ -75,48 +56,6 @@ describe('Evaluation | Unit | Infrastructure | Repositories | AnswerJobRepositor
 
       // then
       expect(profileRewardTemporaryStorageStub.increment).to.have.been.calledWith(userId);
-    });
-
-    describe('should use transaction in all cases', function () {
-      it('should use existing transaction', async function () {
-        // given
-        const profileRewardTemporaryStorageStub = { increment: sinon.stub() };
-        const knexStub = { batchInsert: sinon.stub().resolves([]), isTransaction: true };
-        sinon.stub(DomainTransaction, 'getConnection').returns(knexStub);
-        sinon.stub(DomainTransaction, 'execute').callsFake((callback) => {
-          return callback();
-        });
-        const userId = Symbol('userId');
-        const answerJobRepository = new AnswerJobRepository({
-          dependencies: { profileRewardTemporaryStorage: profileRewardTemporaryStorageStub },
-        });
-
-        // when
-        await answerJobRepository.performAsync({ userId });
-
-        // then
-        expect(DomainTransaction.execute).to.have.not.been.called;
-      });
-
-      it('should create new transaction', async function () {
-        // given
-        const profileRewardTemporaryStorageStub = { increment: sinon.stub() };
-        const knexStub = { batchInsert: sinon.stub().resolves([]), isTransaction: false };
-        sinon.stub(DomainTransaction, 'getConnection').returns(knexStub);
-        sinon.stub(DomainTransaction, 'execute').callsFake((callback) => {
-          return callback();
-        });
-        const userId = Symbol('userId');
-        const answerJobRepository = new AnswerJobRepository({
-          dependencies: { profileRewardTemporaryStorage: profileRewardTemporaryStorageStub },
-        });
-
-        // when
-        await answerJobRepository.performAsync({ userId });
-
-        // then
-        expect(DomainTransaction.execute).to.have.been.called;
-      });
     });
   });
 });

--- a/api/tests/integration/tooling/jobs/expect-job.test.js
+++ b/api/tests/integration/tooling/jobs/expect-job.test.js
@@ -51,10 +51,10 @@ describe('Integration | Tooling | Expect Job', function () {
       await expect('JobTest').to.have.been.performed.withJob({
         name: 'JobTest',
         data: { foo: 'bar' },
-        retrylimit: job.retry.retryLimit,
-        retrydelay: job.retry.retryDelay,
-        retrybackoff: job.retry.retryBackoff,
-        expirein: job.expireIn,
+        retryLimit: job.retry.retryLimit,
+        retryDelay: job.retry.retryDelay,
+        retryBackoff: job.retry.retryBackoff,
+        expireIn: job.expireIn,
       });
     });
 
@@ -205,6 +205,12 @@ describe('Integration | Tooling | Expect Job', function () {
         // when
         await jobQueue.scheduleCronJob({
           name: jobName,
+          cron: '*/5 * * * *',
+          data: { my_data: 'awesome_data' },
+          options: { tz: 'Europe/Paris' },
+        });
+        await jobQueue.scheduleCronJob({
+          name: 'otherJob',
           cron: '*/5 * * * *',
           data: { my_data: 'awesome_data' },
           options: { tz: 'Europe/Paris' },

--- a/api/tests/learning-content/integration/infrastructure/repositories/jobs/lcms-create-release-job-repository_test.js
+++ b/api/tests/learning-content/integration/infrastructure/repositories/jobs/lcms-create-release-job-repository_test.js
@@ -10,9 +10,9 @@ describe('Learning Content | Integration | Repository | Jobs | LcmsCreateRelease
 
       // then
       await expect(LcmsCreateReleaseJob.name).to.have.been.performed.withJob({
-        retrylimit: 0,
-        retrydelay: 0,
-        retrybackoff: false,
+        retryLimit: 0,
+        retryDelay: 0,
+        retryBackoff: false,
         data: { userId: 123 },
       });
     });

--- a/api/tests/learning-content/integration/infrastructure/repositories/jobs/lcms-refresh-cache-job-repository_test.js
+++ b/api/tests/learning-content/integration/infrastructure/repositories/jobs/lcms-refresh-cache-job-repository_test.js
@@ -10,9 +10,9 @@ describe('Learning Content | Integration | Repository | Jobs | LcmsRefreshCacheJ
 
       // then
       await expect(LcmsRefreshCacheJob.name).to.have.been.performed.withJob({
-        retrylimit: 0,
-        retrydelay: 0,
-        retrybackoff: false,
+        retryLimit: 0,
+        retryDelay: 0,
+        retryBackoff: false,
         data: { userId: 123 },
       });
     });

--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/jobs/participation-result-calculation-job-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/jobs/participation-result-calculation-job-repository_test.js
@@ -12,9 +12,9 @@ describe('Integration | Prescription | Infrastructure | Repository | Jobs | part
       // then
       await expect(ParticipationResultCalculationJob.name).to.have.been.performed.withJob({
         name: ParticipationResultCalculationJob.name,
-        retrylimit: JobRetry.FEW_RETRY.retryLimit,
-        retrydelay: JobRetry.FEW_RETRY.retryDelay,
-        retrybackoff: JobRetry.FEW_RETRY.retryBackoff,
+        retryLimit: JobRetry.FEW_RETRY.retryLimit,
+        retryDelay: JobRetry.FEW_RETRY.retryDelay,
+        retryBackoff: JobRetry.FEW_RETRY.retryBackoff,
         data: { campaignParticipationId: 3 },
       });
     });

--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/jobs/participation-shared-job-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/jobs/participation-shared-job-repository_test.js
@@ -12,9 +12,9 @@ describe('Integration | Prescription | Infrastructure | Repository | Jobs | part
 
       await expect(ParticipationSharedJob.name).to.have.been.performed.withJob({
         name: ParticipationSharedJob.name,
-        retrylimit: 0,
-        retrydelay: 0,
-        retrybackoff: false,
+        retryLimit: 0,
+        retryDelay: 0,
+        retryBackoff: false,
         data: { campaignParticipationId: 2 },
       });
     });

--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/jobs/participation-started-job-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/jobs/participation-started-job-repository_test.js
@@ -14,9 +14,9 @@ describe('Integration | Prescription | Infrastructure | Repository | Jobs | part
 
       // then
       await expect(ParticipationStartedJob.name).to.have.been.performed.withJob({
-        retrylimit: 0,
-        retrydelay: 0,
-        retrybackoff: false,
+        retryLimit: 0,
+        retryDelay: 0,
+        retryBackoff: false,
         data: {
           campaignParticipationId: 777,
         },

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/compute-certificability-job-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/compute-certificability-job-repository_test.js
@@ -10,9 +10,9 @@ describe('Integration | Prescription | Application | Jobs | computeCertificabili
 
       // then
       await expect(ComputeCertificabilityJob.name).to.have.been.performed.withJob({
-        retrylimit: 0,
-        retrydelay: 0,
-        retrybackoff: false,
+        retryLimit: 0,
+        retryDelay: 0,
+        retryBackoff: false,
         data: { organizationLearnerId: 4123132 },
       });
     });

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/import-common-organization-learners-job-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/import-common-organization-learners-job-repository_test.js
@@ -13,9 +13,9 @@ describe('Integration | Prescription | Infrastructure | Repository | Jobs | impo
 
       // then
       await expect(ImportCommonOrganizationLearnersJob.name).to.have.have.been.performed.withJob({
-        retrylimit: JobRetry.FEW_RETRY.retryLimit,
-        retrydelay: JobRetry.FEW_RETRY.retryDelay,
-        retrybackoff: JobRetry.FEW_RETRY.retryBackoff,
+        retryLimit: JobRetry.FEW_RETRY.retryLimit,
+        retryDelay: JobRetry.FEW_RETRY.retryDelay,
+        retryBackoff: JobRetry.FEW_RETRY.retryBackoff,
         data: { organizationImportId: 4123132 },
       });
     });

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/import-organization-learners-job-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/import-organization-learners-job-repository_test.js
@@ -13,9 +13,9 @@ describe('Integration | Prescription | Infrastructure | Repository | Jobs | impo
 
       // then
       await expect(ImportOrganizationLearnersJob.name).to.have.have.been.performed.withJob({
-        retrylimit: JobRetry.FEW_RETRY.retryLimit,
-        retrydelay: JobRetry.FEW_RETRY.retryDelay,
-        retrybackoff: JobRetry.FEW_RETRY.retryBackoff,
+        retryLimit: JobRetry.FEW_RETRY.retryLimit,
+        retryDelay: JobRetry.FEW_RETRY.retryDelay,
+        retryBackoff: JobRetry.FEW_RETRY.retryBackoff,
         data: { organizationImportId: 4123132 },
       });
     });

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/import-sco-csv-organization-learners-job-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/import-sco-csv-organization-learners-job-repository_test.js
@@ -13,9 +13,9 @@ describe('Integration | Prescription | Infrastructure | Repository | Jobs | impo
 
       // then
       await expect(ImportScoCsvOrganizationLearnersJob.name).to.have.have.been.performed.withJob({
-        retrylimit: JobRetry.FEW_RETRY.retryLimit,
-        retrydelay: JobRetry.FEW_RETRY.retryDelay,
-        retrybackoff: JobRetry.FEW_RETRY.retryBackoff,
+        retryLimit: JobRetry.FEW_RETRY.retryLimit,
+        retryDelay: JobRetry.FEW_RETRY.retryDelay,
+        retryBackoff: JobRetry.FEW_RETRY.retryBackoff,
         data: { organizationImportId: 4123132, locale: 'fr' },
       });
     });

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/import-sup-organization-learners-job-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/import-sup-organization-learners-job-repository_test.js
@@ -13,9 +13,9 @@ describe('Integration | Prescription | Infrastructure | Repository | Jobs | impo
 
       // then
       await expect(ImportSupOrganizationLearnersJob.name).to.have.have.been.performed.withJob({
-        retrylimit: JobRetry.FEW_RETRY.retryLimit,
-        retrydelay: JobRetry.FEW_RETRY.retryDelay,
-        retrybackoff: JobRetry.FEW_RETRY.retryBackoff,
+        retryLimit: JobRetry.FEW_RETRY.retryLimit,
+        retryDelay: JobRetry.FEW_RETRY.retryDelay,
+        retryBackoff: JobRetry.FEW_RETRY.retryBackoff,
         data: { organizationImportId: 4123132, type: 'REPLACE', locale: 'fr' },
       });
     });

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/validate-common-organization-learners-import-file-job-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/validate-common-organization-learners-import-file-job-repository_test.js
@@ -13,9 +13,9 @@ describe('Integration | Prescription | Infrastructure | Repository | Jobs | vali
 
       // then
       await expect(ValidateCommonOrganizationImportFileJob.name).to.have.been.performed.withJob({
-        retrylimit: JobRetry.FEW_RETRY.retryLimit,
-        retrydelay: JobRetry.FEW_RETRY.retryDelay,
-        retrybackoff: JobRetry.FEW_RETRY.retryBackoff,
+        retryLimit: JobRetry.FEW_RETRY.retryLimit,
+        retryDelay: JobRetry.FEW_RETRY.retryDelay,
+        retryBackoff: JobRetry.FEW_RETRY.retryBackoff,
         data: { organizationImportId: 4123132 },
       });
     });

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/validate-csv-organization-learners-import-file-job-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/validate-csv-organization-learners-import-file-job-repository_test.js
@@ -13,9 +13,9 @@ describe('Integration | Prescription | Infrastructure | Repository | Jobs | vali
 
       // then
       await expect(ValidateCsvOrganizationImportFileJob.name).to.have.been.performed.withJob({
-        retrylimit: JobRetry.FEW_RETRY.retryLimit,
-        retrydelay: JobRetry.FEW_RETRY.retryDelay,
-        retrybackoff: JobRetry.FEW_RETRY.retryBackoff,
+        retryLimit: JobRetry.FEW_RETRY.retryLimit,
+        retryDelay: JobRetry.FEW_RETRY.retryDelay,
+        retryBackoff: JobRetry.FEW_RETRY.retryBackoff,
         data: { organizationImportId: 4123132, type: 'REPLACE', locale: 'fr' },
       });
     });

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/validate-organization-learners-import-file-job-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/validate-organization-learners-import-file-job-repository_test.js
@@ -13,9 +13,9 @@ describe('Integration | Prescription | Infrastructure | Repository | Jobs | vali
 
       // then
       await expect(ValidateOrganizationImportFileJob.name).to.have.been.performed.withJob({
-        retrylimit: JobRetry.FEW_RETRY.retryLimit,
-        retrydelay: JobRetry.FEW_RETRY.retryDelay,
-        retrybackoff: JobRetry.FEW_RETRY.retryBackoff,
+        retryLimit: JobRetry.FEW_RETRY.retryLimit,
+        retryDelay: JobRetry.FEW_RETRY.retryDelay,
+        retryBackoff: JobRetry.FEW_RETRY.retryBackoff,
         data: { organizationImportId: 4123132 },
       });
     });

--- a/api/tests/quest/integration/infrastructure/repositories/jobs/update-combine-course-job-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/jobs/update-combine-course-job-repository_test.js
@@ -14,9 +14,9 @@ describe('Integration | Prescription | Application | Jobs | updateCombinedCourse
 
       // then
       await expect(UpdateCombineCourseJob.name).to.have.been.performed.withJob({
-        retrylimit: 0,
-        retrydelay: 0,
-        retrybackoff: false,
+        retryLimit: 0,
+        retryDelay: 0,
+        retryBackoff: false,
         data: { userId, moduleId },
       });
     });

--- a/api/tests/shared/integration/infrastructure/repositories/jobs/job-repository_test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/jobs/job-repository_test.js
@@ -1,4 +1,3 @@
-import { DomainTransaction } from '../../../../../../src/shared/domain/DomainTransaction.js';
 import { EntityValidationError } from '../../../../../../src/shared/domain/errors.js';
 import {
   JobExpireIn,
@@ -6,7 +5,7 @@ import {
   JobRepository,
   JobRetry,
 } from '../../../../../../src/shared/infrastructure/repositories/jobs/job-repository.js';
-import { catchErr, catchErrSync, expect, knex } from '../../../../../test-helper.js';
+import { catchErrSync, expect } from '../../../../../test-helper.js';
 
 describe('Integration | Infrastructure | Repositories | Jobs | job-repository', function () {
   it('create one job db with given config', async function () {
@@ -24,11 +23,11 @@ describe('Integration | Infrastructure | Repositories | Jobs | job-repository', 
     await expect(name).to.have.been.performed.withJob({
       name,
       data: expectedParams,
-      expirein: '48:00:00',
+      expireIn: 2880,
       priority,
-      retrydelay: 30,
-      retrylimit: 10,
-      retrybackoff: true,
+      retryDelay: 30,
+      retryLimit: 10,
+      retryBackoff: true,
     });
   });
 
@@ -62,59 +61,6 @@ describe('Integration | Infrastructure | Repositories | Jobs | job-repository', 
 
     // then
     expect(jobsInserted.rowCount).to.equal(2);
-  });
-
-  context('transaction', function () {
-    context('when no transaction ongoing', function () {
-      it("should not insert any jobs if one of them is invalid and can't be inserted", async function () {
-        // given
-        const name = 'JobTest';
-        // Knex doc : default chunk for batchInsert is 1000
-        const defaultChunkValidJobs = [...Array(1000).keys()].map((i) => ({ jobParam: i }));
-        const invalidJob = '>';
-        const priority = JobPriority.HIGH;
-        const job = new JobRepository({ name, priority });
-
-        // when
-        const expectedError = await catchErr(job.performAsync, job)(...defaultChunkValidJobs, invalidJob);
-
-        // then
-        expect(expectedError.detail).to.equal('Token ">" is invalid.');
-        const { count } = await knex('pgboss.job').count('id').first();
-        expect(count).to.equal(0);
-      });
-    });
-
-    context('when a transaction ongoing in DomainTransaction', function () {
-      it('should use the same existing transaction', async function () {
-        // given
-        const name = 'JobTest';
-        const jobs = [{ jobParam: 1 }, { jobParam: 2 }];
-        const priority = JobPriority.HIGH;
-        const job = new JobRepository({ name, priority });
-
-        // when
-        let knexConn;
-        const callback = async () => {
-          knexConn = DomainTransaction.getConnection();
-          await knexConn('features').insert({ key: 'someRandomFeature' });
-          await job.performAsync(...jobs);
-          const { count: countFeaturesBefore } = await knexConn('features').count('id').first();
-          expect(countFeaturesBefore).to.equal(1);
-          const { count: countJobsBefore } = await knexConn('pgboss.job').count('id').first();
-          expect(countJobsBefore).to.equal(2);
-          throw new Error('I want to rollback');
-        };
-        const expectedError = await catchErr(DomainTransaction.execute)(callback);
-
-        // then
-        expect(expectedError.message).to.equal('I want to rollback');
-        const { count: countFeaturesAfter } = await knex('features').count('id').first();
-        expect(countFeaturesAfter).to.equal(0);
-        const { count: countJobsAfter } = await knex('pgboss.job').count('id').first();
-        expect(countJobsAfter).to.equal(0);
-      });
-    });
   });
 
   describe('JobExpireIn', function () {

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -37,6 +37,7 @@ import * as challengeRepository from '../src/shared/infrastructure/repositories/
 import * as competenceRepository from '../src/shared/infrastructure/repositories/competence-repository.js';
 import * as courseRepository from '../src/shared/infrastructure/repositories/course-repository.js';
 import * as frameworkRepository from '../src/shared/infrastructure/repositories/framework-repository.js';
+import { pgBoss } from '../src/shared/infrastructure/repositories/jobs/pg-boss.js';
 import * as skillRepository from '../src/shared/infrastructure/repositories/skill-repository.js';
 import * as thematicRepository from '../src/shared/infrastructure/repositories/thematic-repository.js';
 import * as tubeRepository from '../src/shared/infrastructure/repositories/tube-repository.js';
@@ -56,7 +57,12 @@ chaiUse(sinonChai);
 
 _.each(customChaiHelpers, chaiUse);
 
-chaiUse(jobChai(knex));
+chaiUse(jobChai(pgBoss));
+try {
+  await pgBoss.start();
+} catch {
+  // pgBoss is not available on unit tests
+}
 
 const databaseBuilder = await DatabaseBuilder.create({
   knex,
@@ -98,6 +104,11 @@ afterEach(async function () {
   await featureToggles.resetDefaults();
   await datamartBuilder.clean();
   await clearMutex();
+  try {
+    await pgBoss.clearStorage();
+  } catch {
+    // pgBoss is not available on unit tests
+  }
   return databaseBuilder.clean();
 });
 

--- a/api/tests/tooling/jobs/expect-job.js
+++ b/api/tests/tooling/jobs/expect-job.js
@@ -1,6 +1,6 @@
 import { assert, Assertion } from 'chai';
 
-export const jobChai = (knex) => (_chai, utils) => {
+export const jobChai = (pgBoss) => (_chai, utils) => {
   utils.addProperty(Assertion.prototype, 'performed', function () {
     return this;
   });
@@ -11,50 +11,68 @@ export const jobChai = (knex) => (_chai, utils) => {
 
   Assertion.addMethod('withJobsCount', async function (expectedCount) {
     const jobName = this._obj;
-    const jobs = await knex('pgboss.job').where({ name: jobName });
+    const jobs = await pgBoss.fetch(jobName, expectedCount + 1, { includeMetadata: true });
+    const actualCount = jobs?.length ?? 0;
+
     assert.strictEqual(
-      jobs.length,
+      actualCount,
       expectedCount,
-      `expected ${jobName} to have been performed ${expectedCount} times, but it was performed ${jobs.length} times`,
+      `expected ${jobName} to have been performed ${expectedCount} times, but it was performed ${actualCount} times`,
+    );
+    return (jobs ?? []).map(
+      ({ id, name, data, retrylimit, retrydelay, retrybackoff, expire_in_seconds, priority }) => ({
+        id,
+        name,
+        data,
+        retryLimit: retrylimit,
+        retryDelay: retrydelay,
+        retryBackoff: retrybackoff,
+        expireIn: Math.round(expire_in_seconds),
+        priority,
+      }),
     );
   });
 
   Assertion.addMethod('withJob', async function (jobData) {
-    await this.withJobsCount(1);
+    const jobs = await this.withJobsCount(1);
 
     const jobName = this._obj;
-    const jobs = await knex('pgboss.job').select(knex.raw(`*, expirein::varchar`)).where({ name: jobName });
-    assert.deepInclude(jobs[0], jobData, `Job '${jobName}' was performed with a different payload`);
+    assert.deepOwnInclude(
+      jobs[0],
+      jobData,
+      `Job '${jobName}' was performed with a different payload (${JSON.stringify(jobData)} was expected but performed with ${JSON.stringify(jobs[0])})`,
+    );
   });
 
   Assertion.addMethod('withCronJobsCount', async function (expectedCount) {
     const jobName = this._obj;
-    const jobs = await knex('pgboss.schedule').where({ name: jobName });
+    const allJobs = (await pgBoss.getSchedules()) ?? [];
+    const jobs = allJobs.filter(({ name }) => name === jobName);
     assert.strictEqual(
       jobs.length,
       expectedCount,
       `expected ${jobName} to have been performed ${expectedCount} times, but it was performed ${jobs.length} times`,
     );
+    return jobs;
   });
 
   Assertion.addMethod('withCronJob', async function (jobData) {
-    await this.withCronJobsCount(1);
+    const jobs = await this.withCronJobsCount(1);
 
     const jobName = this._obj;
-    const job = await knex('pgboss.schedule')
-      .select('name', 'cron', 'data', 'options')
-      .where({ name: jobName })
-      .first();
-    assert.deepInclude(job, jobData, `Job '${jobName}' was schedule with a different payload`);
+    assert.deepOwnInclude(
+      jobs[0],
+      jobData,
+      `Job '${jobName}' was schedule with a different payload (${JSON.stringify(jobData)} was expected but performed with ${JSON.stringify(jobs[0])})`,
+    );
   });
 
   Assertion.addMethod('withJobPayloads', async function (payloads) {
-    await this.withJobsCount(payloads.length);
+    const jobs = await this.withJobsCount(payloads.length);
 
     const jobName = this._obj;
-    const jobs = await knex('pgboss.job').where({ name: jobName });
     const actualPayloads = jobs.map((job) => job.data);
-    assert.deepEqual(actualPayloads, payloads, `Job '${jobName}' was performed with a different payload`);
+    assert.sameDeepMembers(actualPayloads, payloads, `Job '${jobName}' was performed with a different payload`);
   });
 
   Assertion.addMethod('withJobPayload', async function (payload) {

--- a/api/tests/unit/tooling/database-builder/database-helpers_test.js
+++ b/api/tests/unit/tooling/database-builder/database-helpers_test.js
@@ -10,11 +10,6 @@ describe('Unit | Tooling | DatabaseBuilder | database-helpers', function () {
           '/* path:  */ insert into "users" ("cgu", "createdAt", "email", "emailConfirmedAt", "firstName", "hasBeenAnonymised", "hasBeenAnonymisedBy", "hasSeenAssessmentInstructions", "hasSeenFocusedChallengeTooltip", "hasSeenNewDashboardInfo", "hasSeenOtherChallengesTooltip", "id", "isAnonymous", "lang", "lastDataProtectionPolicySeenAt", "lastName", "lastPixCertifTermsOfServiceValidatedAt", "lastPixOrgaTermsOfServiceValidatedAt", "lastTermsOfServiceValidatedAt", "locale", "mustValidateTermsOfService", "pixCertifTermsOfServiceAccepted", "pixOrgaTermsOfServiceAccepted", "updatedAt", "username") values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, DEFAULT, $21, $22, $23, $24, $25)',
       },
       {
-        expectedTableName: 'pgboss.job',
-        insertSqlQuery:
-          '/* path: /api/campaign-participations/{campaignParticipationId} */ insert into "pgboss"."job" ("data", "expirein", "name", "on_complete", "retrybackoff", "retrydelay", "retrylimit") values ($1, $2, $3, $4, $5, $6, $7)',
-      },
-      {
         expectedTableName: 'user-logins',
         insertSqlQuery:
           '/* path: /api/oidc/user/reconcile */ insert into "user-logins" ("lastLoggedAt", "userId") values ($1, $2) on conflict ("userId") do update set "lastLoggedAt" = excluded."lastLoggedAt", "userId" = excluded."userId"',


### PR DESCRIPTION
## ❄️ Problème

Suite à la dernière tentative de ne plus utiliser knex au profit de pgboss, nous avons omis un détails. les transaction. 

certains job nécessite d'être executé dans une transaction. Ce problème n'est pas appru sur les RA du au pool restreint de connection.

## 🛷 Proposition

Utiliser send au lieu de insert qui permet de passer un objet db executeSql pour utiliser la transaction

## ☃️ Remarques

knex.raw ne fonctionnait pas suite à un problème de compatibilité de passage des arguments du sql pg avec la manière dont knex.raw s'attend à avoir de la donnée (une sombre histoire de `$1` pour pg alors que `knex.raw` fonctionne avec ? ou en `:name`

## 🧑‍🎄 Pour tester

Vérifier que le job insérer est bien executé dans la même transaction