### PR TITLE
[TECH] Ne pas avoir des équipes en charge en double dans les seeds (PIX-20803)

### DIFF
--- a/api/db/database-builder/factory/build-administration-team.js
+++ b/api/db/database-builder/factory/build-administration-team.js
@@ -2,7 +2,7 @@ import { databaseBuffer } from '../database-buffer.js';
 
 const buildAdministrationTeam = function ({
   id = databaseBuffer.getNextId(),
-  name = 'Équipe Alpha',
+  name = `Équipe ${id}`,
   createdAt = new Date('2020-01-01'),
   updatedAt = new Date('2020-01-02'),
 } = {}) {


### PR DESCRIPTION
## ❄️ Problème
On avait des équipes en charge en doublons voir plus dans les seeds. 
Le soucis étant que dans le builder d'organisation si on ne passait pas d'administrationTeamId, on en buildait automatiquement une nouvelle. 

## 🛷 Proposition
Utiliser un id en suffixe de "Equipe" pour avoir des noms d'équipe en charge unique

## ☃️ Remarques
Le builder d'organisation étant utilisé à la fois pour les seeds et pour les tests, on ne peut pas utiliser les id des équipes en charge dans celui ci. Car dans les tests ces équipes n'existant pas, nous avons des soucis lors de l'insertion en base.

## 🧑‍🎄 Pour tester
Aller vérifier dans le filtre des équipes en charge sur la page organisations que les équipes ne sont plus en double.