### PR TITLE
[FEATURE] Empêcher la possibilité d'ajouter un lot de places si la fonctionnalité "places" n'est pas activée sur une orga (PIX-20907)

### DIFF
--- a/admin/app/controllers/authenticated/organizations/get.js
+++ b/admin/app/controllers/authenticated/organizations/get.js
@@ -14,6 +14,7 @@ export default class GetController extends Controller {
     try {
       await this.model.save();
       this.pixToast.sendSuccessNotification({ message: "L'organisation a bien été modifiée." });
+      this.router.transitionTo('authenticated.organizations.get');
     } catch (responseError) {
       this.model.rollbackAttributes();
       const error = get(responseError, 'errors[0]');

--- a/admin/app/routes/authenticated/organizations/get/places/list.js
+++ b/admin/app/routes/authenticated/organizations/get/places/list.js
@@ -3,10 +3,12 @@ import Route from '@ember/routing/route';
 import { service } from '@ember/service';
 
 export default class Places extends Route {
+  @service router;
   @service store;
 
   async model() {
     const organization = await this.modelFor('authenticated.organizations.get');
+
     const places = await this.store.query('organization-place', {
       organizationId: organization.id,
     });
@@ -15,6 +17,12 @@ export default class Places extends Route {
     });
 
     return { organization, places, placesStatistics };
+  }
+
+  afterModel(model) {
+    if (!model.organization.isPlacesManagementEnabled) {
+      this.router.replaceWith('authenticated.organizations.get.team');
+    }
   }
 
   @action

--- a/admin/app/routes/authenticated/organizations/get/places/new.js
+++ b/admin/app/routes/authenticated/organizations/get/places/new.js
@@ -4,6 +4,7 @@ import { service } from '@ember/service';
 export default class New extends Route {
   @service accessControl;
   @service store;
+  @service router;
 
   beforeModel() {
     this.accessControl.restrictAccessTo(['isSuperAdmin', 'isMetier'], 'authenticated');
@@ -13,5 +14,13 @@ export default class New extends Route {
     const organization = await this.modelFor('authenticated.organizations.get');
 
     return this.store.createRecord('organization-place', { organizationId: organization.id });
+  }
+
+  async afterModel() {
+    const organization = await this.modelFor('authenticated.organizations.get');
+
+    if (!organization.isPlacesManagementEnabled) {
+      this.router.replaceWith('authenticated.organizations.get.team');
+    }
   }
 }

--- a/admin/app/templates/authenticated/organizations/get.gjs
+++ b/admin/app/templates/authenticated/organizations/get.gjs
@@ -37,14 +37,18 @@ import InformationSection from 'pix-admin/components/organizations/information-s
         {{t "pages.organization.navbar.campaigns"}}
       </LinkTo>
 
-      <LinkTo @route="authenticated.organizations.get.places" @model={{@model}}>
-        {{t "pages.organization.navbar.places"}}
-      </LinkTo>
+      {{#if @model.isPlacesManagementEnabled}}
+        <LinkTo @route="authenticated.organizations.get.places" @model={{@model}}>
+          {{t "pages.organization.navbar.places"}}
+        </LinkTo>
+      {{/if}}
+
       {{#if @controller.accessControl.hasAccessToOrganizationActionsScope}}
         <LinkTo @route="authenticated.organizations.get.all-tags" @model={{@model}}>
           {{t "pages.organization.navbar.tags"}}
         </LinkTo>
       {{/if}}
+
       <LinkTo @route="authenticated.organizations.get.children" @model={{@model}}>
         {{t "pages.organization.navbar.children"}}
         ({{@model.children.length}})

--- a/admin/app/templates/authenticated/organizations/get.gjs
+++ b/admin/app/templates/authenticated/organizations/get.gjs
@@ -21,28 +21,28 @@ import InformationSection from 'pix-admin/components/organizations/information-s
 
       {{#unless @model.isArchived}}
         <LinkTo @route="authenticated.organizations.get.team" @model={{@model}}>
-          Équipe
+          {{t "pages.organization.navbar.team"}}
         </LinkTo>
 
         <LinkTo @route="authenticated.organizations.get.invitations" @model={{@model}}>
-          Invitations
+          {{t "pages.organization.navbar.invitations"}}
         </LinkTo>
       {{/unless}}
 
       <LinkTo @route="authenticated.organizations.get.target-profiles" @model={{@model}}>
-        Profils cibles
+        {{t "pages.organization.navbar.target-profiles"}}
       </LinkTo>
 
       <LinkTo @route="authenticated.organizations.get.campaigns" @model={{@model}}>
-        Campagnes
+        {{t "pages.organization.navbar.campaigns"}}
       </LinkTo>
 
       <LinkTo @route="authenticated.organizations.get.places" @model={{@model}}>
-        Places
+        {{t "pages.organization.navbar.places"}}
       </LinkTo>
       {{#if @controller.accessControl.hasAccessToOrganizationActionsScope}}
         <LinkTo @route="authenticated.organizations.get.all-tags" @model={{@model}}>
-          Tags
+          {{t "pages.organization.navbar.tags"}}
         </LinkTo>
       {{/if}}
       <LinkTo @route="authenticated.organizations.get.children" @model={{@model}}>

--- a/admin/tests/acceptance/authenticated/combined-course-blueprints/organizations-test.js
+++ b/admin/tests/acceptance/authenticated/combined-course-blueprints/organizations-test.js
@@ -26,7 +26,11 @@ module('Acceptance | combined course blueprint Organizations', function (hooks) 
       module('when admin member has role "SUPER_ADMIN", "CERTIF", "SUPPORT" or "METIER"', function (hooks) {
         hooks.beforeEach(async function () {
           await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
-          server.create('organization', { id: 456, name: 'My organization' });
+          server.create('organization', {
+            id: 456,
+            name: 'My organization',
+            features: { PLACES_MANAGEMENT: { active: false } },
+          });
           server.create('combined-course-blueprint', {
             id: 1,
             name: 'le blueprint ia',
@@ -67,8 +71,16 @@ module('Acceptance | combined course blueprint Organizations', function (hooks) 
 
     module('with multiple organizations', function (hooks) {
       hooks.beforeEach(async function () {
-        server.create('organization', { id: 456, name: 'My organization' });
-        server.create('organization', { id: 789, name: 'My other organization' });
+        server.create('organization', {
+          id: 456,
+          name: 'My organization',
+          features: { PLACES_MANAGEMENT: { active: false } },
+        });
+        server.create('organization', {
+          id: 789,
+          name: 'My other organization',
+          features: { PLACES_MANAGEMENT: { active: false } },
+        });
       });
 
       test('should list organizations', async function (assert) {

--- a/admin/tests/acceptance/authenticated/organizations/create-organization-test.js
+++ b/admin/tests/acceptance/authenticated/organizations/create-organization-test.js
@@ -55,7 +55,10 @@ module('Acceptance | Organizations | Create', function (hooks) {
     let parentOrganization;
 
     hooks.beforeEach(function () {
-      parentOrganization = server.create('organization', { name: 'Wayne Enterprises' });
+      parentOrganization = server.create('organization', {
+        name: 'Wayne Enterprises',
+        features: { PLACES_MANAGEMENT: { active: true } },
+      });
     });
 
     test('it shows the creation form with parent organization name', async function (assert) {

--- a/admin/tests/acceptance/authenticated/organizations/get/children-test.js
+++ b/admin/tests/acceptance/authenticated/organizations/get/children-test.js
@@ -21,7 +21,10 @@ module('Acceptance | Organizations | Children', function (hooks) {
 
     test('"Organisations filles" tab exists', async function (assert) {
       // given
-      const organizationId = this.server.create('organization', { name: 'Orga name' }).id;
+      const organizationId = this.server.create('organization', {
+        name: 'Orga name',
+        features: { PLACES_MANAGEMENT: { active: true } },
+      }).id;
 
       // when
       const screen = await visit(`/organizations/${organizationId}/children`);
@@ -33,8 +36,17 @@ module('Acceptance | Organizations | Children', function (hooks) {
 
     test('Displays the number of child organisations in tab name', async function (assert) {
       // given
-      const parentOrganizationId = this.server.create('organization', { id: 1, name: 'Orga name' }).id;
-      this.server.create('organization', { id: 2, parentOrganizationId: 1, name: 'Child' });
+      const parentOrganizationId = this.server.create('organization', {
+        id: 1,
+        name: 'Orga name',
+        features: { PLACES_MANAGEMENT: { active: true } },
+      }).id;
+      this.server.create('organization', {
+        id: 2,
+        parentOrganizationId: 1,
+        name: 'Child',
+        features: { PLACES_MANAGEMENT: { active: true } },
+      });
 
       // when
       const screen = await visit(`/organizations/${parentOrganizationId}/children`);
@@ -46,7 +58,10 @@ module('Acceptance | Organizations | Children', function (hooks) {
     module('when there is no child organization', function () {
       test('displays a message', async function (assert) {
         // given
-        const organizationId = this.server.create('organization', { name: 'Orga name' }).id;
+        const organizationId = this.server.create('organization', {
+          name: 'Orga name',
+          features: { PLACES_MANAGEMENT: { active: true } },
+        }).id;
         this.server.get(`/admin/organizations/${organizationId}/children`, () => ({ data: [] }));
 
         // when
@@ -61,8 +76,17 @@ module('Acceptance | Organizations | Children', function (hooks) {
     module('when there is at least one child organization', function () {
       test('displays a list of child organizations', async function (assert) {
         // given
-        const parentOrganizationId = this.server.create('organization', { id: 1, name: 'Orga name' }).id;
-        this.server.create('organization', { id: 2, parentOrganizationId: 1, name: 'Child' });
+        const parentOrganizationId = this.server.create('organization', {
+          id: 1,
+          name: 'Orga name',
+          features: { PLACES_MANAGEMENT: { active: true } },
+        }).id;
+        this.server.create('organization', {
+          id: 2,
+          parentOrganizationId: 1,
+          name: 'Child',
+          features: { PLACES_MANAGEMENT: { active: true } },
+        });
 
         // when
         const screen = await visit(`/organizations/${parentOrganizationId}/children`);
@@ -76,8 +100,16 @@ module('Acceptance | Organizations | Children', function (hooks) {
     module('when attaching child organization', function () {
       test('attaches child organization to parent organization and displays success notification', async function (assert) {
         // given
-        const parentOrganization = this.server.create('organization', { id: 1, name: 'Parent Organization Name' });
-        this.server.create('organization', { id: 2, name: 'Child Organization Name' });
+        const parentOrganization = this.server.create('organization', {
+          id: 1,
+          name: 'Parent Organization Name',
+          features: { PLACES_MANAGEMENT: { active: true } },
+        });
+        this.server.create('organization', {
+          id: 2,
+          name: 'Child Organization Name',
+          features: { PLACES_MANAGEMENT: { active: true } },
+        });
         const screen = await visit(`/organizations/${parentOrganization.id}/children`);
         await fillByLabel(`Ajouter une ou plusieurs organisations filles ID d'organisation(s) à ajouter`, '2');
 
@@ -93,7 +125,11 @@ module('Acceptance | Organizations | Children', function (hooks) {
     module('when detaching child organization', function () {
       test('it should display success notification and remove child organization from list', async function (assert) {
         // given
-        const parentOrganization = this.server.create('organization', { id: 1, name: 'Parent Organization Name' });
+        const parentOrganization = this.server.create('organization', {
+          id: 1,
+          name: 'Parent Organization Name',
+          features: { PLACES_MANAGEMENT: { active: true } },
+        });
         this.server.create('organization', {
           id: 2,
           name: 'Child Organization Name',
@@ -123,7 +159,11 @@ module('Acceptance | Organizations | Children', function (hooks) {
     module('when creating child organization from parent page', function () {
       test('it should redirect to New organization page, with parent id in query params', async function (assert) {
         // given
-        const parentOrganization = this.server.create('organization', { id: 1, name: 'Parent Organization Name' });
+        const parentOrganization = this.server.create('organization', {
+          id: 1,
+          name: 'Parent Organization Name',
+          features: { PLACES_MANAGEMENT: { active: true } },
+        });
         const screen = await visit(`/organizations/${parentOrganization.id}/children`);
 
         // when
@@ -148,7 +188,10 @@ module('Acceptance | Organizations | Children', function (hooks) {
 
       hooks.beforeEach(async function () {
         await authenticateAdminMemberWithRole(role.authData)(server);
-        parentOrganizationId = this.server.create('organization', { name: 'Parent Orga name' }).id;
+        parentOrganizationId = this.server.create('organization', {
+          name: 'Parent Orga name',
+          features: { PLACES_MANAGEMENT: { active: true } },
+        }).id;
       });
 
       test('it displays actions section with create child organization button', async function (assert) {
@@ -166,8 +209,15 @@ module('Acceptance | Organizations | Children', function (hooks) {
   module('when user has role "CERTIF"', function () {
     test('it should not display actions section', async function (assert) {
       await authenticateAdminMemberWithRole({ isCertif: true })(server);
-      const parentOrganizationId = this.server.create('organization', { name: 'Parent Orga name' }).id;
-      this.server.create('organization', { name: 'Child Orga name', parentOrganizationId });
+      const parentOrganizationId = this.server.create('organization', {
+        name: 'Parent Orga name',
+        features: { PLACES_MANAGEMENT: { active: true } },
+      }).id;
+      this.server.create('organization', {
+        name: 'Child Orga name',
+        parentOrganizationId,
+        features: { PLACES_MANAGEMENT: { active: true } },
+      });
 
       // when
       const screen = await visit(`/organizations/${parentOrganizationId}/children`);

--- a/admin/tests/acceptance/authenticated/organizations/information-management-test.js
+++ b/admin/tests/acceptance/authenticated/organizations/information-management-test.js
@@ -83,6 +83,42 @@ module('Acceptance | Organizations | Information management', function (hooks) {
     });
   });
 
+  module('when PLACES_MANAGEMENT feature is enabled', function () {
+    test('should display Places menu item', async function (assert) {
+      // given
+      const organization = this.server.create('organization', {
+        name: 'organizationName',
+        features: {
+          PLACES_MANAGEMENT: { active: true },
+        },
+      });
+
+      // when
+      const screen = await visit(`/organizations/${organization.id}`);
+
+      // then
+      assert.dom(screen.getByRole('link', { name: t('pages.organization.navbar.places') })).exists();
+    });
+  });
+
+  module('when PLACES_MANAGEMENT feature is disabled', function () {
+    test('should not display Places menu item', async function (assert) {
+      // given
+      const organization = this.server.create('organization', {
+        name: 'organizationName',
+        features: {
+          PLACES_MANAGEMENT: { active: false },
+        },
+      });
+
+      // when
+      const screen = await visit(`/organizations/${organization.id}`);
+
+      // then
+      assert.dom(screen.queryByRole('link', { name: t('pages.organization.navbar.places') })).doesNotExist();
+    });
+  });
+
   module('when organization is archived', function () {
     test('should redirect to organization target profiles page', async function (assert) {
       // given

--- a/admin/tests/acceptance/authenticated/organizations/information-management-test.js
+++ b/admin/tests/acceptance/authenticated/organizations/information-management-test.js
@@ -32,7 +32,7 @@ module('Acceptance | Organizations | Information management', function (hooks) {
         administrationTeamId: 456,
         countryCode: 99100,
       });
-      this.server.create('organization', { id: '1234' });
+      this.server.create('organization', { id: '1234', features: { PLACES_MANAGEMENT: { active: true } } });
 
       const screen = await visit(`/organizations/${organization.id}`);
 
@@ -69,7 +69,7 @@ module('Acceptance | Organizations | Information management', function (hooks) {
         administrationTeamId: null,
       });
 
-      this.server.create('organization', { id: '1234' });
+      this.server.create('organization', { id: '1234', features: { PLACES_MANAGEMENT: { active: true } } });
 
       const screen = await visit(`/organizations/${organization.id}`);
 
@@ -126,6 +126,7 @@ module('Acceptance | Organizations | Information management', function (hooks) {
         name: 'oldOrganizationName',
         archivedAt: '2022-12-25',
         archivistFullName: 'Clément Tine',
+        features: { PLACES_MANAGEMENT: { active: true } },
       });
 
       // when
@@ -141,6 +142,7 @@ module('Acceptance | Organizations | Information management', function (hooks) {
         name: 'oldOrganizationName',
         archivedAt: '2022-12-25',
         archivistFullName: 'Clément Tine',
+        features: { PLACES_MANAGEMENT: { active: true } },
       });
 
       // when
@@ -157,6 +159,7 @@ module('Acceptance | Organizations | Information management', function (hooks) {
         name: 'oldOrganizationName',
         archivedAt: '2022-12-25',
         archivistFullName: 'Clément Tine',
+        features: { PLACES_MANAGEMENT: { active: true } },
       });
 
       // when
@@ -174,6 +177,7 @@ module('Acceptance | Organizations | Information management', function (hooks) {
         // given
         const organization = this.server.create('organization', {
           name: 'Aude Javel Company',
+          features: { PLACES_MANAGEMENT: { active: true } },
         });
         const screen = await visit(`/organizations/${organization.id}`);
 
@@ -191,6 +195,7 @@ module('Acceptance | Organizations | Information management', function (hooks) {
           // given
           const organization = this.server.create('organization', {
             name: 'Aude Javel Company',
+            features: { PLACES_MANAGEMENT: { active: true } },
           });
           const screen = await visit(`/organizations/${organization.id}`);
           await clickByName("Archiver l'organisation");
@@ -207,6 +212,7 @@ module('Acceptance | Organizations | Information management', function (hooks) {
           // given
           const organization = this.server.create('organization', {
             name: 'Aude Javel Company',
+            features: { PLACES_MANAGEMENT: { active: true } },
           });
           const screen = await visit(`/organizations/${organization.id}`);
           await clickByName("Archiver l'organisation");
@@ -225,6 +231,7 @@ module('Acceptance | Organizations | Information management', function (hooks) {
       // given
       const organization = this.server.create('organization', {
         name: 'Aude Javel Company',
+        features: { PLACES_MANAGEMENT: { active: true } },
       });
       const screen = await visit(`/organizations/${organization.id}`);
       await clickByName("Archiver l'organisation");
@@ -242,6 +249,7 @@ module('Acceptance | Organizations | Information management', function (hooks) {
       // given
       const organization = this.server.create('organization', {
         name: 'Aude Javel Company',
+        features: { PLACES_MANAGEMENT: { active: true } },
       });
       this.server.post(
         '/admin/organizations/:id/archive',
@@ -270,6 +278,7 @@ module('Acceptance | Organizations | Information management', function (hooks) {
       // given
       const organization = this.server.create('organization', {
         name: 'Aude Javel Company',
+        features: { PLACES_MANAGEMENT: { active: true } },
       });
       this.server.post(
         '/admin/organizations/:id/archive',

--- a/admin/tests/acceptance/authenticated/organizations/invitations-management-test.js
+++ b/admin/tests/acceptance/authenticated/organizations/invitations-management-test.js
@@ -22,6 +22,7 @@ module('Acceptance | Organizations | Invitations management', function (hooks) {
     await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
     const organization = this.server.create('organization', {
       name: 'Aude Javel Company',
+      features: { PLACES_MANAGEMENT: { active: true } },
     });
 
     // when
@@ -39,6 +40,7 @@ module('Acceptance | Organizations | Invitations management', function (hooks) {
     await authenticateAdminMemberWithRole({ isCertif: true })(server);
     const organization = this.server.create('organization', {
       name: 'Aude Javel Company',
+      features: { PLACES_MANAGEMENT: { active: true } },
     });
 
     // when
@@ -55,6 +57,7 @@ module('Acceptance | Organizations | Invitations management', function (hooks) {
       const organization = this.server.create('organization', {
         id: 5,
         name: 'Kabuki',
+        features: { PLACES_MANAGEMENT: { active: true } },
       });
       this.server.create('organization-invitation', {
         email: 'kabuki@example.net',
@@ -79,6 +82,7 @@ module('Acceptance | Organizations | Invitations management', function (hooks) {
         const organization = this.server.create('organization', {
           id: 5,
           name: 'Kabuki',
+          features: { PLACES_MANAGEMENT: { active: true } },
         });
         const organizationInvitation = this.server.create('organization-invitation', {
           id: 10,

--- a/admin/tests/acceptance/authenticated/organizations/list-test.js
+++ b/admin/tests/acceptance/authenticated/organizations/list-test.js
@@ -43,8 +43,8 @@ module('Acceptance | Organizations | List', function (hooks) {
 
     test('it should list the organizations', async function (assert) {
       // given
-      server.create('organization', { name: 'Tic' });
-      server.create('organization', { name: 'Tac' });
+      server.create('organization', { name: 'Tic', features: { PLACES_MANAGEMENT: { active: false } } });
+      server.create('organization', { name: 'Tac', features: { PLACES_MANAGEMENT: { active: false } } });
 
       // when
       const screen = await visit('/organizations/list');
@@ -57,8 +57,8 @@ module('Acceptance | Organizations | List', function (hooks) {
 
     test('it should not show an Actions column', async function (assert) {
       // given
-      server.create('organization', { name: 'Tic' });
-      server.create('organization', { name: 'Tac' });
+      server.create('organization', { name: 'Tic', features: { PLACES_MANAGEMENT: { active: false } } });
+      server.create('organization', { name: 'Tac', features: { PLACES_MANAGEMENT: { active: false } } });
 
       // when
       const screen = await visit('/organizations/list');
@@ -124,7 +124,7 @@ module('Acceptance | Organizations | List', function (hooks) {
 
     test('it should redirect to organization details on click', async function (assert) {
       // given
-      server.create('organization', { id: 1, name: 'Orga name' });
+      server.create('organization', { id: 1, name: 'Orga name', features: { PLACES_MANAGEMENT: { active: false } } });
       const screen = await visit('/organizations/list');
 
       // when

--- a/admin/tests/acceptance/authenticated/organizations/memberships-management-test.js
+++ b/admin/tests/acceptance/authenticated/organizations/memberships-management-test.js
@@ -14,7 +14,10 @@ module('Acceptance | Organizations | Memberships management', function (hooks) {
 
   hooks.beforeEach(async function () {
     await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
-    organization = this.server.create('organization', { name: 'Orga name' });
+    organization = this.server.create('organization', {
+      name: 'Orga name',
+      features: { PLACES_MANAGEMENT: { active: true } },
+    });
   });
 
   test('should redirect to organization team page', async function (assert) {
@@ -182,6 +185,7 @@ module('Acceptance | Organizations | Memberships management', function (hooks) {
       await authenticateAdminMemberWithRole({ isCertif: true })(server);
       const organization = this.server.create('organization', {
         name: 'Aude Javel Company',
+        features: { PLACES_MANAGEMENT: { active: true } },
       });
 
       // when

--- a/admin/tests/acceptance/authenticated/organizations/places-lot-creation-form-test.js
+++ b/admin/tests/acceptance/authenticated/organizations/places-lot-creation-form-test.js
@@ -12,7 +12,10 @@ module('Acceptance | Organizations | places lot creation form', function (hooks)
   test('should go to places listing page', async function (assert) {
     // given
     await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
-    const ownerOrganizationId = this.server.create('organization', { name: 'Orga name' }).id;
+    const ownerOrganizationId = this.server.create('organization', {
+      name: 'Orga name',
+      features: { PLACES_MANAGEMENT: { active: true } },
+    }).id;
 
     const screen = await visit(`/organizations/${ownerOrganizationId}/places/new`);
 

--- a/admin/tests/acceptance/authenticated/organizations/places-lot-creation-form-test.js
+++ b/admin/tests/acceptance/authenticated/organizations/places-lot-creation-form-test.js
@@ -9,20 +9,56 @@ module('Acceptance | Organizations | places lot creation form', function (hooks)
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  test('should go to places listing page', async function (assert) {
-    // given
-    await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
-    const ownerOrganizationId = this.server.create('organization', {
-      name: 'Orga name',
-      features: { PLACES_MANAGEMENT: { active: true } },
-    }).id;
+  module('when cancelling action', function () {
+    test('should go to places listing page', async function (assert) {
+      // given
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+      const ownerOrganizationId = this.server.create('organization', {
+        name: 'Orga name',
+        features: { PLACES_MANAGEMENT: { active: true } },
+      }).id;
 
-    const screen = await visit(`/organizations/${ownerOrganizationId}/places/new`);
+      const screen = await visit(`/organizations/${ownerOrganizationId}/places/new`);
 
-    // when
-    await click(screen.getByRole('link', { name: 'Annuler' }));
+      // when
+      await click(screen.getByRole('link', { name: 'Annuler' }));
 
-    // then
-    assert.strictEqual(currentURL(), `/organizations/${ownerOrganizationId}/places`);
+      // then
+      assert.strictEqual(currentURL(), `/organizations/${ownerOrganizationId}/places`);
+    });
+  });
+
+  module('when PLACES_MANAGEMENT feature is not enabled', function () {
+    test('should go to organization team', async function (assert) {
+      // given
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+      const ownerOrganizationId = this.server.create('organization', {
+        name: 'Orga name',
+        features: { PLACES_MANAGEMENT: { active: false } },
+      }).id;
+
+      // when
+      await visit(`/organizations/${ownerOrganizationId}/places/new`);
+
+      // then
+      assert.strictEqual(currentURL(), `/organizations/${ownerOrganizationId}/team`);
+    });
+  });
+
+  module('when PLACES_MANAGEMENT feature is enabled', function () {
+    test('should allow place creation form', async function (assert) {
+      // given
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+      const ownerOrganizationId = this.server.create('organization', {
+        name: 'Orga name',
+        features: { PLACES_MANAGEMENT: { active: true } },
+      }).id;
+
+      // when
+      await visit(`/organizations/${ownerOrganizationId}/places/new`);
+
+      // then
+      assert.strictEqual(currentURL(), `/organizations/${ownerOrganizationId}/places/new`);
+    });
   });
 });

--- a/admin/tests/acceptance/authenticated/organizations/places-test.js
+++ b/admin/tests/acceptance/authenticated/organizations/places-test.js
@@ -9,59 +9,85 @@ module('Acceptance | Organizations | places', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  module('When user is authenticated as support', function (hooks) {
-    hooks.beforeEach(async function () {
-      await authenticateAdminMemberWithRole({ isSupport: true })(server);
-    });
-
-    test('should display organization places', async function (assert) {
-      // given
-      const ownerOrganizationId = this.server.create('organization', { name: 'Orga name' }).id;
-      this.server.create('organization-place', {
-        count: 7777,
-        reference: 'FFVII',
-        category: 'SquareEnix',
-        status: 'ACTIVE',
-        activationDate: '1997-01-31',
-        expirationDate: '2100-12-31',
-        createdAt: '1996-01-12',
-        creatorFullName: 'Hironobu Sakaguchi',
+  module('when PLACES_MANAGEMENT feature is enabled', function () {
+    module('When user is authenticated as support', function (hooks) {
+      let ownerOrganizationId;
+      hooks.beforeEach(async function () {
+        ownerOrganizationId = this.server.create('organization', {
+          name: 'Orga name',
+          features: { PLACES_MANAGEMENT: { active: true } },
+        }).id;
+        await authenticateAdminMemberWithRole({ isSupport: true })(server);
       });
 
-      // when
-      const screen = await visit(`/organizations/${ownerOrganizationId}/places`);
+      test('should display organization places', async function (assert) {
+        // given
+        this.server.create('organization-place', {
+          count: 7777,
+          reference: 'FFVII',
+          category: 'SquareEnix',
+          status: 'ACTIVE',
+          activationDate: '1997-01-31',
+          expirationDate: '2100-12-31',
+          createdAt: '1996-01-12',
+          creatorFullName: 'Hironobu Sakaguchi',
+        });
 
-      // then
-      assert.dom(screen.getByText('FFVII')).exists();
+        // when
+        const screen = await visit(`/organizations/${ownerOrganizationId}/places`);
+
+        // then
+        assert.dom(screen.getByText('FFVII')).exists();
+      });
+
+      test('should not diplay add places lot button', async function (assert) {
+        // given
+
+        // when
+        const screen = await visit(`/organizations/${ownerOrganizationId}/places`);
+
+        // then
+        assert.dom(screen.queryByText('Ajouter des places')).doesNotExist();
+      });
     });
 
-    test('should not diplay add places lot button', async function (assert) {
-      // given
-      const ownerOrganizationId = this.server.create('organization', { name: 'Orga name' }).id;
+    module('When user is authenticated as super admin', function (hooks) {
+      let ownerOrganizationId;
+      hooks.beforeEach(async function () {
+        ownerOrganizationId = this.server.create('organization', {
+          name: 'Orga name',
+          features: { PLACES_MANAGEMENT: { active: true } },
+        }).id;
+        await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+      });
 
-      // when
-      const screen = await visit(`/organizations/${ownerOrganizationId}/places`);
+      test('should go to add places lot page', async function (assert) {
+        // given
 
-      // then
-      assert.dom(screen.queryByText('Ajouter des places')).doesNotExist();
+        const screen = await visit(`/organizations/${ownerOrganizationId}/places`);
+        // when
+        await click(screen.getByRole('link', { name: 'Ajouter des places' }));
+
+        // then
+        assert.strictEqual(currentURL(), `/organizations/${ownerOrganizationId}/places/new`);
+      });
     });
   });
 
-  module('When user is authenticated as super admin', function (hooks) {
-    hooks.beforeEach(async function () {
-      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
-    });
-
-    test('should go to add places lot page', async function (assert) {
+  module('when PLACES_MANAGEMENT feature is disabled', function () {
+    test('should redirect to organization details page', async function (assert) {
       // given
-      const ownerOrganizationId = this.server.create('organization', { name: 'Orga name' }).id;
+      const ownerOrganizationId = this.server.create('organization', {
+        name: 'Orga name',
+        features: { PLACES_MANAGEMENT: { active: false } },
+      }).id;
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
 
-      const screen = await visit(`/organizations/${ownerOrganizationId}/places`);
       // when
-      await click(screen.getByRole('link', { name: 'Ajouter des places' }));
+      await visit(`/organizations/${ownerOrganizationId}/places`);
 
       // then
-      assert.strictEqual(currentURL(), `/organizations/${ownerOrganizationId}/places/new`);
+      assert.strictEqual(currentURL(), `/organizations/${ownerOrganizationId}/team`);
     });
   });
 });

--- a/admin/tests/acceptance/authenticated/organizations/target-profiles-management-test.js
+++ b/admin/tests/acceptance/authenticated/organizations/target-profiles-management-test.js
@@ -15,7 +15,10 @@ module('Acceptance | Organizations | Target profiles management', function (hook
 
   test('should display organization target profiles', async function (assert) {
     // given
-    const ownerOrganizationId = this.server.create('organization', { name: 'Orga name' }).id;
+    const ownerOrganizationId = this.server.create('organization', {
+      name: 'Orga name',
+      features: { PLACES_MANAGEMENT: { active: true } },
+    }).id;
     this.server.create('target-profile-summary', { internalName: 'Profil cible du ghetto' });
 
     // when
@@ -31,7 +34,10 @@ module('Acceptance | Organizations | Target profiles management', function (hook
 
   test('should add a target profile to an organization', async function (assert) {
     // given
-    const organization = this.server.create('organization', { name: 'Orga name' });
+    const organization = this.server.create('organization', {
+      name: 'Orga name',
+      features: { PLACES_MANAGEMENT: { active: true } },
+    });
 
     // when
     const screen = await visit(`/organizations/${organization.id}/target-profiles`);
@@ -52,7 +58,10 @@ module('Acceptance | Organizations | Target profiles management', function (hook
   test('should not display organization target profiles when user does not have access', async function (assert) {
     // given
     await authenticateAdminMemberWithRole({ isCertif: true })(server);
-    const ownerOrganizationId = this.server.create('organization', { name: 'Orga name' }).id;
+    const ownerOrganizationId = this.server.create('organization', {
+      name: 'Orga name',
+      features: { PLACES_MANAGEMENT: { active: true } },
+    }).id;
     this.server.create('target-profile-summary', { internalName: 'Profil cible du ghetto', ownerOrganizationId });
 
     // when

--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile/organizations-test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile/organizations-test.js
@@ -25,7 +25,11 @@ module('Acceptance | Target Profile Organizations', function (hooks) {
       module('when admin member has role "SUPER_ADMIN", "SUPPORT" or "METIER"', function (hooks) {
         hooks.beforeEach(async function () {
           await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
-          server.create('organization', { id: 456, name: 'My organization' });
+          server.create('organization', {
+            id: 456,
+            name: 'My organization',
+            features: { PLACES_MANAGEMENT: { active: false } },
+          });
           server.create('target-profile', { id: 1, ownerOrganizationId: 456, name: 'Mon super profil cible' });
         });
 
@@ -50,7 +54,11 @@ module('Acceptance | Target Profile Organizations', function (hooks) {
         test('it should be redirected to Organizations page', async function (assert) {
           // given
           await authenticateAdminMemberWithRole({ isCertif: true })(server);
-          server.create('organization', { id: 456, name: 'My organization' });
+          server.create('organization', {
+            id: 456,
+            name: 'My organization',
+            features: { PLACES_MANAGEMENT: { active: false } },
+          });
           server.create('target-profile', { id: 2, ownerOrganizationId: 456 });
 
           // when
@@ -71,8 +79,16 @@ module('Acceptance | Target Profile Organizations', function (hooks) {
 
     module('with multiple organizations', function (hooks) {
       hooks.beforeEach(async function () {
-        server.create('organization', { id: 456, name: 'My organization' });
-        server.create('organization', { id: 789, name: 'My other organization' });
+        server.create('organization', {
+          id: 456,
+          name: 'My organization',
+          features: { PLACES_MANAGEMENT: { active: false } },
+        });
+        server.create('organization', {
+          id: 789,
+          name: 'My other organization',
+          features: { PLACES_MANAGEMENT: { active: false } },
+        });
       });
 
       test('should list organizations', async function (assert) {

--- a/admin/tests/acceptance/organization-invitations-management-test.js
+++ b/admin/tests/acceptance/organization-invitations-management-test.js
@@ -27,7 +27,10 @@ module('Acceptance | organization invitations management', function (hooks) {
   test('should display invitations tab', async function (assert) {
     // given
     await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
-    const organization = this.server.create('organization', { name: 'Orga name' });
+    const organization = this.server.create('organization', {
+      name: 'Orga name',
+      features: { PLACES_MANAGEMENT: { active: true } },
+    });
 
     // when
     const screen = await visit(`/organizations/${organization.id}`);
@@ -40,7 +43,10 @@ module('Acceptance | organization invitations management', function (hooks) {
     test('should create an organization-invitation', async function (assert) {
       // given
       await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
-      const organization = this.server.create('organization', { name: 'Orga name' });
+      const organization = this.server.create('organization', {
+        name: 'Orga name',
+        features: { PLACES_MANAGEMENT: { active: true } },
+      });
 
       // when
       const screen = await visit(`/organizations/${organization.id}/invitations`);
@@ -57,7 +63,10 @@ module('Acceptance | organization invitations management', function (hooks) {
     test('should display an error if the creation has failed', async function (assert) {
       // given
       await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
-      const organization = this.server.create('organization', { name: 'Orga name' });
+      const organization = this.server.create('organization', {
+        name: 'Orga name',
+        features: { PLACES_MANAGEMENT: { active: true } },
+      });
 
       this.server.post(
         '/admin/organizations/:id/invitations',

--- a/admin/tests/mirage/routes.js
+++ b/admin/tests/mirage/routes.js
@@ -378,6 +378,9 @@ export default function routes() {
       dataProtectionOfficerFirstName: attributes['data-protection-officer-first-name'],
       dataProtectionOfficerLastName: attributes['data-protection-officer-last-name'],
       dataProtectionOfficerEmail: attributes['data-protection-officer-email'],
+      features: {
+        PLACES_MANAGEMENT: { active: false },
+      },
     };
 
     return schema.create('organization', organization);

--- a/admin/tests/unit/controllers/authenticated/organizations/get-test.js
+++ b/admin/tests/unit/controllers/authenticated/organizations/get-test.js
@@ -14,6 +14,7 @@ module('Unit | Controller | authenticated/organizations/get', function (hooks) {
       test('displays a success notification', async function (assert) {
         // Given
         const controller = this.owner.lookup('controller:authenticated.organizations.get');
+        controller.router = { transitionTo: sinon.stub() };
         controller.model = {
           id: 3,
           save: sinon.stub(),

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -1268,7 +1268,13 @@
     },
     "organization": {
       "navbar": {
-        "children": "Children organisations"
+        "campaigns": "Campaigns",
+        "children": "Children organisations",
+        "invitations": "Invitations",
+        "places": "Places",
+        "tags": "Tags",
+        "target-profiles": "Target profiles",
+        "team": "Team"
       }
     },
     "organization-children": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -1271,7 +1271,13 @@
     },
     "organization": {
       "navbar": {
-        "children": "Organisations filles"
+        "campaigns": "Campagnes",
+        "children": "Organisations filles",
+        "invitations": "Invitations",
+        "places": "Places",
+        "tags": "Tags",
+        "target-profiles": "Profils cibles",
+        "team": "Équipe"
       }
     },
     "organization-children": {

--- a/api/src/prescription/organization-place/application/organization-place-route.js
+++ b/api/src/prescription/organization-place/application/organization-place-route.js
@@ -77,6 +77,10 @@ const register = async (server) => {
                 securityPreHandlers.checkAdminMemberHasRoleMetier,
               ])(request, h),
           },
+          {
+            method: securityPreHandlers.makeCheckOrganizationHasFeature(ORGANIZATION_FEATURE.PLACES_MANAGEMENT.key),
+            assign: 'checkOrganizationHasPlacesFeature',
+          },
         ],
         handler: organizationPlaceController.createOrganizationPlacesLot,
         validate: {

--- a/api/tests/prescription/organization-place/acceptance/application/create-organization-places-lot_test.js
+++ b/api/tests/prescription/organization-place/acceptance/application/create-organization-places-lot_test.js
@@ -1,4 +1,5 @@
 import * as organizationPlacesCategories from '../../../../../src/prescription/organization-place/domain/constants/organization-places-categories.js';
+import { ORGANIZATION_FEATURE } from '../../../../../src/shared/domain/constants.js';
 import {
   createServer,
   databaseBuilder,
@@ -14,7 +15,18 @@ describe('Acceptance | Route | Create Organization Places Lot', function () {
       const server = await createServer();
 
       const adminUser = await insertUserWithRoleSuperAdmin();
+      const placeManagementFeature = databaseBuilder.factory.buildFeature({
+        key: ORGANIZATION_FEATURE.PLACES_MANAGEMENT.key,
+      });
       const organizationId = databaseBuilder.factory.buildOrganization().id;
+
+      databaseBuilder.factory.buildOrganizationFeature({
+        organizationId,
+        featureId: placeManagementFeature.id,
+        params: {
+          enableMaximumPlacesLimit: false,
+        },
+      });
 
       const options = {
         method: 'POST',


### PR DESCRIPTION
## ❄️ Problème

On voudrait emêpcher l'accès aux  fonctionnalités de gestion des places dans pix admin si la fonctionnalité n'est pas activée.

## 🛷 Proposition

- Masquer l'onglet "Places" dans la page de détail d'une orga
- Empecher l'accès aux routes front "/places" et "/places/new"
- Ajouter un check sur la route api d'ajout de place pour vérifier que la fonctionnalité est activée pour l'organisation

## ☃️ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🧑‍🎄 Pour tester

- Se connecter sur pix-admin
- Aller voir le détail d'une orga
- Si la fonctionnalité de gestion des places n'est pas activée, l'onglet "places" ne doit pas être visible

<img width="1296" height="839" alt="image" src="https://github.com/user-attachments/assets/82519e13-ac5b-4644-bec0-bdef3507633a" />

<img width="1296" height="839" alt="image" src="https://github.com/user-attachments/assets/4234b3ef-8265-4bce-93c8-8c509260cfc3" />

