### PR TITLE
[FEATURE] Créer un élément Audio pour Modulix dans l'API (PIX-20534)

### DIFF
--- a/api/scripts/modulix/get-elements-csv.js
+++ b/api/scripts/modulix/get-elements-csv.js
@@ -36,6 +36,7 @@ if (import.meta.url.startsWith('file:')) {
 
 export function getElements(modules) {
   const ELEMENT_TYPES = [
+    'audio',
     'download',
     'embed',
     'expand',

--- a/api/src/devcomp/domain/models/element/Audio.js
+++ b/api/src/devcomp/domain/models/element/Audio.js
@@ -1,0 +1,29 @@
+import { DomainError } from '../../../../shared/domain/errors.js';
+import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
+import { Element } from './Element.js';
+
+class Audio extends Element {
+  static #VALID_HOSTNAME = 'assets.pix.org';
+
+  constructor({ id, title, url, transcription }) {
+    super({ id, type: 'audio' });
+
+    assertNotNullOrUndefined(title, 'The title is required for an audio');
+    assertNotNullOrUndefined(url, 'The URL is required for an audio');
+    assertNotNullOrUndefined(transcription, 'The transcription is required for an audio');
+
+    if (!URL.canParse(url)) {
+      throw new DomainError('The URL must be a valid URL for an audio');
+    }
+
+    this.url = url;
+    this.title = title;
+    this.transcription = transcription;
+
+    if (URL.parse(url).hostname !== Audio.#VALID_HOSTNAME) {
+      throw new DomainError('The audio URL must be from "assets.pix.org"');
+    }
+  }
+}
+
+export { Audio };

--- a/api/src/devcomp/domain/models/element/Audio.js
+++ b/api/src/devcomp/domain/models/element/Audio.js
@@ -16,13 +16,12 @@ class Audio extends Element {
       throw new DomainError('The URL must be a valid URL for an audio');
     }
 
-    this.url = url;
-    this.title = title;
-    this.transcription = transcription;
-
     if (URL.parse(url).hostname !== Audio.#VALID_HOSTNAME) {
       throw new DomainError('The audio URL must be from "assets.pix.org"');
     }
+    this.url = url;
+    this.title = title;
+    this.transcription = transcription;
   }
 }
 

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
@@ -26,6 +26,16 @@
             {
               "type": "element",
               "element": {
+                "id": "dcd0ef70-e34e-496f-9cd0-529b3168a14f",
+                "type": "audio",
+                "title": "Audio de ronron de chat",
+                "url": "https://assets.pix.org/test/ronron.mp3",
+                "transcription": "<p>ron... ron...</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
                 "id": "96e29215-3610-4bc6-b4a6-026bf13276b8",
                 "type": "short-video",
                 "title": "Exemple de vidéo courte",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
@@ -26,7 +26,7 @@
             {
               "type": "element",
               "element": {
-                "id": "dcd0ef70-e34e-496f-9cd0-529b3168a14f",
+                "id": "d1ece1a1-aed8-4293-9042-40984a90a670",
                 "type": "audio",
                 "title": "Audio de ronron de chat",
                 "url": "https://assets.pix.org/test/ronron.mp3",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/galerie.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/galerie.json
@@ -49,6 +49,23 @@
           ]
         },
         {
+          "id": "898768e1-3643-4c82-bfa9-2c9df8abb00c",
+          "type": "challenge",
+          "title": "audio",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "dcd0ef70-e34e-496f-9cd0-529b3168a14f",
+                "type": "audio",
+                "title": "Audio de ronron de chat",
+                "url": "https://assets.pix.org/test/ronron.mp3",
+                "transcription": "<p>ron... ron...</p>"
+              }
+            }
+          ]
+        },
+        {
           "id": "53a06209-b581-4023-be5f-f194a4668ff0",
           "type": "challenge",
           "title": "custom",
@@ -475,48 +492,48 @@
           "id": "3e553e69-d451-4a2a-b6e8-8bc70917f2b7",
           "type": "challenge",
           "title": "qcu-discovery",
-        "components": [
-          {
-            "type": "element",
-            "element": {
-              "id": "cc995548-b3d4-4fd6-a974-d5c969c920d6",
-              "type": "text",
-              "content": "<p><strong>qcu-discovery</strong></p><p>Il permet d'afficher une question à choix unique pour découvrir une notion pédagogique.</p>"
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "cc995548-b3d4-4fd6-a974-d5c969c920d6",
+                "type": "text",
+                "content": "<p><strong>qcu-discovery</strong></p><p>Il permet d'afficher une question à choix unique pour découvrir une notion pédagogique.</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "f40e5a81-271b-492c-9f63-9f4a50829279",
+                "type": "qcu-discovery",
+                "instruction": "<p>Pourquoi ce module galerie est très pertinent ?</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "Pour connaître l'ensemble des modalités disponibles pour rédiger un module",
+                    "feedback": {
+                      "diagnosis": "<p>Exactement ! En une page, on a accès à toutes les possibilités de modalités que propose Modulix.</p>"
+                    }
+                  },
+                  {
+                    "id": "2",
+                    "content": "Pour faire semblant de travailler quand je suis sur mon ordinateur",
+                    "feedback": {
+                      "diagnosis": "<p>Eh non, tout le monde verra quand même que vous ne travaillez pas.</p>"
+                    }
+                  },
+                  {
+                    "id": "3",
+                    "content": "Pour améliorer mes compétences numériques",
+                    "feedback": {
+                      "diagnosis": "<p>Eh non, il n'y a aucune notion pédagogique dans ce module !</p>"
+                    }
+                  }
+                ],
+                "solution": "1"
+              }
             }
-          },
-          {
-            "type": "element",
-            "element": {
-              "id": "f40e5a81-271b-492c-9f63-9f4a50829279",
-              "type": "qcu-discovery",
-              "instruction": "<p>Pourquoi ce module galerie est très pertinent ?</p>",
-              "proposals": [
-                {
-                  "id": "1",
-                  "content": "Pour connaître l'ensemble des modalités disponibles pour rédiger un module",
-                  "feedback": {
-                    "diagnosis": "<p>Exactement ! En une page, on a accès à toutes les possibilités de modalités que propose Modulix.</p>"
-                  }
-                },
-                {
-                  "id": "2",
-                  "content": "Pour faire semblant de travailler quand je suis sur mon ordinateur",
-                  "feedback": {
-                    "diagnosis": "<p>Eh non, tout le monde verra quand même que vous ne travaillez pas.</p>"
-                  }
-                },
-                {
-                  "id": "3",
-                  "content": "Pour améliorer mes compétences numériques",
-                  "feedback": {
-                    "diagnosis": "<p>Eh non, il n'y a aucune notion pédagogique dans ce module !</p>"
-                  }
-                }
-              ],
-              "solution": "1"
-            }
-          }
-        ]
+          ]
         },
         {
           "id": "3003eabf-e49a-43c9-8962-332bf989149a",

--- a/api/src/devcomp/infrastructure/factories/module-factory.js
+++ b/api/src/devcomp/infrastructure/factories/module-factory.js
@@ -1,7 +1,6 @@
 import { getAssetInfos } from '../../../shared/infrastructure/repositories/pix-assets-repository.js';
 import { logger } from '../../../shared/infrastructure/utils/logger.js';
 import { ModuleInstantiationError } from '../../domain/errors.js';
-import { Audio } from '../../domain/models/element/Audio.js';
 import { BlockInput } from '../../domain/models/block/BlockInput.js';
 import { BlockSelect } from '../../domain/models/block/BlockSelect.js';
 import { BlockSelectOption } from '../../domain/models/block/BlockSelectOption.js';
@@ -9,6 +8,7 @@ import { BlockText } from '../../domain/models/block/BlockText.js';
 import { ComponentElement } from '../../domain/models/component/ComponentElement.js';
 import { ComponentStepper } from '../../domain/models/component/ComponentStepper.js';
 import { Step } from '../../domain/models/component/Step.js';
+import { Audio } from '../../domain/models/element/Audio.js';
 import { CustomDraft } from '../../domain/models/element/CustomDraft.js';
 import { CustomElement } from '../../domain/models/element/CustomElement.js';
 import { Download } from '../../domain/models/element/Download.js';

--- a/api/src/devcomp/infrastructure/factories/module-factory.js
+++ b/api/src/devcomp/infrastructure/factories/module-factory.js
@@ -1,6 +1,7 @@
 import { getAssetInfos } from '../../../shared/infrastructure/repositories/pix-assets-repository.js';
 import { logger } from '../../../shared/infrastructure/utils/logger.js';
 import { ModuleInstantiationError } from '../../domain/errors.js';
+import { Audio } from '../../domain/models/element/Audio.js';
 import { BlockInput } from '../../domain/models/block/BlockInput.js';
 import { BlockSelect } from '../../domain/models/block/BlockSelect.js';
 import { BlockSelectOption } from '../../domain/models/block/BlockSelectOption.js';
@@ -118,6 +119,8 @@ export class ModuleFactory {
 
   static async #buildElement(element) {
     switch (element.type) {
+      case 'audio':
+        return ModuleFactory.#buildAudio(element);
       case 'custom':
         return ModuleFactory.#buildCustom(element);
       case 'custom-draft':
@@ -159,6 +162,14 @@ export class ModuleFactory {
         });
         return undefined;
     }
+  }
+  static #buildAudio(element) {
+    return new Audio({
+      id: element.id,
+      title: element.title,
+      url: element.url,
+      transcription: element.transcription,
+    });
   }
 
   static #buildCustom(element) {

--- a/api/tests/devcomp/acceptance/scripts/get-elements-csv_test.js
+++ b/api/tests/devcomp/acceptance/scripts/get-elements-csv_test.js
@@ -115,7 +115,8 @@ describe('Acceptance | Script | Get Elements as CSV', function () {
 "6282925d-4775-4bca-b513-4c3009ec5886"\t"5bf1c672-3746-4480-b9ac-1f0af9c7c509"\t"46577fb1-aadb-49ba-b3fd-721a11da8eb5"\t"f00133f5-0653-425b-a25f-3c9604820529"\t"custom-draft"\t"Elément custom"\t1\t9\t17\t"<p>Retournez les cartes.</p>"
 "6282925d-4775-4bca-b513-4c3009ec5886"\t"5bf1c672-3746-4480-b9ac-1f0af9c7c509"\t"46577fb1-aadb-49ba-b3fd-721a11da8eb5"\t"0e3315fd-98ad-492f-9046-4aa867495d85"\t"custom"\t"Elément custom"\t1\t9\t18\t"Voici un extrait de conversation"
 "6282925d-4775-4bca-b513-4c3009ec5886"\t"5bf1c672-3746-4480-b9ac-1f0af9c7c509"\t"cf436761-f56d-4b01-83f9-942afe9ce72c"\t"ed795d29-5f04-499c-a9c8-4019125c5cb1"\t"qab"\t"test qab"\t1\t10\t19\t"<p><strong>Maintenant, entraînez-vous sur des exemples concrets !</strong> </p> <p> Pour chaque exemple, choisissez si l’affirmation est <strong>vraie</strong> ou <strong>fausse</strong>.</p>"
-"6282925d-4775-4bca-b513-4c3009ec5886"\t"5bf1c672-3746-4480-b9ac-1f0af9c7c509"\t"cef7d350-008b-410b-8a6a-39b56efdbe8d"\t"0c397035-a940-441f-8936-050db7f997af"\t"qcu-discovery"\t"test qcu-discovery"\t1\t11\t20\t"<p>Quel est le dessert classique idéal lors d’un goûter&nbsp;?</p>"`);
+"6282925d-4775-4bca-b513-4c3009ec5886"\t"5bf1c672-3746-4480-b9ac-1f0af9c7c509"\t"cef7d350-008b-410b-8a6a-39b56efdbe8d"\t"0c397035-a940-441f-8936-050db7f997af"\t"qcu-discovery"\t"test qcu-discovery"\t1\t11\t20\t"<p>Quel est le dessert classique idéal lors d’un goûter&nbsp;?</p>"
+"6282925d-4775-4bca-b513-4c3009ec5886"\t"5bf1c672-3746-4480-b9ac-1f0af9c7c509"\t"cef7d350-008b-410b-8a6a-39b56efdbe8d"\t"42260c2a-31a9-4d71-86d9-d38ccf408579"\t"audio"\t"test qcu-discovery"\t1\t11\t21\t`);
     });
   });
 });

--- a/api/tests/devcomp/acceptance/scripts/get-modules-csv_test.js
+++ b/api/tests/devcomp/acceptance/scripts/get-modules-csv_test.js
@@ -16,6 +16,6 @@ describe('Acceptance | Script | Get Modules as CSV', function () {
     expect(modulesListAsCsv).to.be.a('string');
     expect(modulesListAsCsv).to
       .equal(`\ufeff"Module"\t"ModuleSlug"\t"ModuleLevel"\t"ModuleLink"\t"ModuleTotalGrains"\t"ModuleTotalActivities"\t"ModuleTotalLessons"\t"ModuleDuration"\t"ModuleTotalElements"
-"6282925d-4775-4bca-b513-4c3009ec5886"\t"bac-a-sable"\t"Débutant"\t"https://app.recette.pix.fr/modules/bac-a-sable"\t11\t4\t2\t"=TEXT(5/24/60; ""mm:ss"")"\t20`);
+"6282925d-4775-4bca-b513-4c3009ec5886"\t"bac-a-sable"\t"Débutant"\t"https://app.recette.pix.fr/modules/bac-a-sable"\t11\t4\t2\t"=TEXT(5/24/60; ""mm:ss"")"\t21`);
   });
 });

--- a/api/tests/devcomp/acceptance/scripts/test-module.json
+++ b/api/tests/devcomp/acceptance/scripts/test-module.json
@@ -563,6 +563,16 @@
                 ],
                 "solution": "1"
               }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "42260c2a-31a9-4d71-86d9-d38ccf408579",
+                "type": "audio",
+                "title": "Audio de ronron de chat",
+                "url": "https://assets.pix.org/test/ronron.mp3",
+                "transcription": "<p>ron... ron...</p>"
+              }
             }
           ]
         }

--- a/api/tests/devcomp/integration/infrastructure/factories/module-factory_test.js
+++ b/api/tests/devcomp/integration/infrastructure/factories/module-factory_test.js
@@ -1,7 +1,7 @@
 import { ModuleInstantiationError } from '../../../../../src/devcomp/domain/errors.js';
-import { Audio } from '../../../../../src/devcomp/domain/models/element/Audio.js';
 import { ComponentStepper } from '../../../../../src/devcomp/domain/models/component/ComponentStepper.js';
 import { Step } from '../../../../../src/devcomp/domain/models/component/Step.js';
+import { Audio } from '../../../../../src/devcomp/domain/models/element/Audio.js';
 import { CustomDraft } from '../../../../../src/devcomp/domain/models/element/CustomDraft.js';
 import { CustomElement } from '../../../../../src/devcomp/domain/models/element/CustomElement.js';
 import { Download } from '../../../../../src/devcomp/domain/models/element/Download.js';

--- a/api/tests/devcomp/integration/infrastructure/factories/module-factory_test.js
+++ b/api/tests/devcomp/integration/infrastructure/factories/module-factory_test.js
@@ -1,4 +1,5 @@
 import { ModuleInstantiationError } from '../../../../../src/devcomp/domain/errors.js';
+import { Audio } from '../../../../../src/devcomp/domain/models/element/Audio.js';
 import { ComponentStepper } from '../../../../../src/devcomp/domain/models/component/ComponentStepper.js';
 import { Step } from '../../../../../src/devcomp/domain/models/component/Step.js';
 import { CustomDraft } from '../../../../../src/devcomp/domain/models/element/CustomDraft.js';
@@ -574,6 +575,64 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
 
         // then
         expect(module.sections[0].grains[0].components[0].element).to.be.an.instanceOf(Text);
+      });
+      it('should instantiate a Module with a ComponentElement which contains a Audio Element', async function () {
+        // given
+        const moduleData = {
+          id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          shortId: 'giedjc7f3',
+          slug: 'title',
+          title: 'title',
+          isBeta: true,
+          visibility: 'public',
+          details: {
+            image: 'https://assets.pix.org/modules/placeholder-details.svg',
+            description: 'Description',
+            duration: 5,
+            level: 'novice',
+            tabletSupport: 'comfortable',
+            objectives: ['Objective 1'],
+          },
+          sections: [
+            {
+              id: '5bf1c672-3746-4480-b9ac-1f0af9c7c509',
+              type: 'practise',
+              grains: [
+                {
+                  id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+                  type: 'lesson',
+                  title: 'title',
+                  components: [
+                    {
+                      type: 'element',
+                      element: {
+                        id: '3a9f2269-99ba-4631-b6fd-6802c88d5c26',
+                        type: 'audio',
+                        title: 'Le pouvoir du ronronnement',
+                        url: 'https://assets.pix.org/modules/chat.mp3',
+                        transcription: 'Insert transcription here',
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        };
+
+        // when
+        const module = await ModuleFactory.build(moduleData);
+
+        // then
+        expect(module.sections[0].grains[0].components[0].element).to.be.an.instanceOf(Audio);
+        expect(module.sections[0].grains[0].components[0].element).to.deep.equal({
+          id: '3a9f2269-99ba-4631-b6fd-6802c88d5c26',
+          type: 'audio',
+          title: 'Le pouvoir du ronronnement',
+          url: 'https://assets.pix.org/modules/chat.mp3',
+          transcription: 'Insert transcription here',
+          isAnswerable: false,
+        });
       });
 
       it('should instantiate a Module with a ComponentElement which contains a Video Element', async function () {

--- a/api/tests/devcomp/unit/domain/models/element/Audio_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/Audio_test.js
@@ -1,0 +1,105 @@
+import { Audio } from '../../../../../../src/devcomp/domain/models/element/Audio.js';
+import { DomainError } from '../../../../../../src/shared/domain/errors.js';
+import { catchErrSync, expect } from '../../../../../test-helper.js';
+
+describe('Unit | Devcomp | Domain | Models | Element | Audio', function () {
+  describe('#constructor', function () {
+    it('should create an audio and keep attributes', function () {
+      // when
+      const audio = new Audio({
+        id: 'id',
+        title: 'title',
+        url: 'https://assets.pix.org/modules/audio.mp4',
+        transcription: 'transcription',
+      });
+
+      // then
+      expect(audio.id).to.equal('id');
+      expect(audio.type).to.equal('audio');
+      expect(audio.title).to.equal('title');
+      expect(audio.url).to.equal('https://assets.pix.org/modules/audio.mp4');
+      expect(audio.transcription).to.equal('transcription');
+    });
+  });
+
+  describe('An audio without id', function () {
+    it('should throw an error', function () {
+      // when
+      const error = catchErrSync(() => new Audio({}))();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The id is required for an element');
+    });
+  });
+
+  describe('An audio without a title', function () {
+    it('should throw an error', function () {
+      // when
+      const error = catchErrSync(() => new Audio({ id: 'id' }))();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The title is required for an audio');
+    });
+  });
+
+  describe('An audio without a url', function () {
+    it('should throw an error', function () {
+      // when
+      const error = catchErrSync(() => new Audio({ id: 'id', title: 'title' }))();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The URL is required for an audio');
+    });
+  });
+
+  describe('An audio without a valid url', function () {
+    it('should throw an error', function () {
+      // when
+      const error = catchErrSync(() => new Audio({ id: 'id', title: 'title', url: 'url', transcription: '' }))();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The URL must be a valid URL for an audio');
+    });
+  });
+
+  describe('An audio without a transcription', function () {
+    it('should throw an error', function () {
+      // when
+      const error = catchErrSync(
+        () =>
+          new Audio({
+            id: 'id',
+            title: 'title',
+            url: 'https://assets.pix.org/audio.mp4',
+          }),
+      )();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The transcription is required for an audio');
+    });
+  });
+
+  describe('When audio URL is not from assets.pix.org', function () {
+    it('should throw an error', function () {
+      // given & when
+      const error = catchErrSync(
+        () =>
+          new Audio({
+            id: 'id',
+            title: 'title',
+            url: 'https://example.com/modules/audio.mp4',
+            transcription: 'transcription',
+          }),
+      )();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The audio URL must be from "assets.pix.org"');
+    });
+  });
+});

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/audio-schema.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/audio-schema.js
@@ -7,7 +7,7 @@ const audioElementSchema = Joi.object({
   type: Joi.string().valid('audio').required(),
   title: htmlNotAllowedSchema.required(),
   url: Joi.string().uri().required(),
-  transcription: htmlSchema.allow(''),
+  transcription: htmlSchema.required(),
 }).required();
 
 export { audioElementSchema };

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/audio-schema.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/audio-schema.js
@@ -1,0 +1,13 @@
+import Joi from 'joi';
+
+import { htmlNotAllowedSchema, htmlSchema, uuidSchema } from '../utils.js';
+
+const audioElementSchema = Joi.object({
+  id: uuidSchema,
+  type: Joi.string().valid('audio').required(),
+  title: htmlNotAllowedSchema.required(),
+  url: Joi.string().uri().required(),
+  transcription: htmlSchema.allow(''),
+}).required();
+
+export { audioElementSchema };

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-schema.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-schema.js
@@ -1,5 +1,6 @@
 import Joi from 'joi';
 
+import { audioElementSchema } from './element/audio-schema.js';
 import { customDraftElementSchema } from './element/custom-draft-element-schema.js';
 import { customElementSchema } from './element/custom-element-schema.js';
 import { downloadElementSchema } from './element/download-schema.js';
@@ -20,6 +21,7 @@ import { videoElementSchema } from './element/video-schema.js';
 import { htmlNotAllowedSchema, htmlSchema, uuidSchema } from './utils.js';
 
 const ALLOWED_ELEMENTS_SCHEMA = [
+  { is: 'audio', then: audioElementSchema },
   { is: 'custom', then: customElementSchema },
   { is: 'custom-draft', then: customDraftElementSchema },
   { is: 'download', then: downloadElementSchema },

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto';
 
 import { expect } from '../../../../../../test-helper.js';
+import { audioElementSchema } from './element/audio-schema.js';
 import { customDraftElementSchema } from './element/custom-draft-element-schema.js';
 import { customElementSchema } from './element/custom-element-schema.js';
 import { downloadElementSchema } from './element/download-schema.js';
@@ -499,6 +500,25 @@ describe('Unit | Infrastructure | Datasources | Learning Content | Module Dataso
         expect(joiError).to.equal(undefined, formattedError);
       }
     });
+
+    it('should validate sample audio structure', async function () {
+      try {
+        const sample = {
+          id: randomUUID(),
+          type: 'audio',
+          title: 'Un audio',
+          url: 'https://assets.pix.org/modules/placeholder-audio.mp3',
+          transcription: '<p>Audio manquant</p>',
+        };
+
+        await audioElementSchema.validateAsync(sample, {
+          abortEarly: false,
+        });
+      } catch (joiError) {
+        const formattedError = joiErrorParser.format(joiError);
+        expect(joiError).to.equal(undefined, formattedError);
+      }
+    });
   });
 
   describe('when element contains not allowed HTML', function () {
@@ -520,6 +540,28 @@ describe('Unit | Infrastructure | Datasources | Learning Content | Module Dataso
       } catch (joiError) {
         expect(joiError.message).to.deep.equal(
           '"alt" failed custom validation because HTML is not allowed in this field',
+        );
+      }
+    });
+
+    it('should throw htmlNotAllowedSchema custom error for audio.title field', async function () {
+      // given
+      const invalidAudio = {
+        id: '73ac3644-7637-4cee-86d4-1a75f53f0b9c',
+        type: 'audio',
+        title: '<h1>Un audio</h1>',
+        url: 'https://assets.pix.fr/modulix/placeholder-audio.mp3',
+        transcription: '<p>Audio manquante</p>',
+      };
+
+      try {
+        await audioElementSchema.validateAsync(invalidAudio, {
+          abortEarly: false,
+        });
+        throw new Error('Joi validation should have thrown');
+      } catch (joiError) {
+        expect(joiError.message).to.deep.equal(
+          '"title" failed custom validation because HTML is not allowed in this field',
         );
       }
     });


### PR DESCRIPTION
## ❄️ Problème

Nous avons besoin d'un nouvel élément permettant d'écouter des audios pour les Modulix.

## 🛷 Proposition

Ajout d'un nouveau modèle pour l'élément Audio dans l'API.

## ☃️ Remarques

Pas de design indiqué pour le moment
Pas d'ajout de trace d'apprentissage pour le moment

## 🧑‍🎄 Pour tester

- Aller sur le bac à sable : https://app-pr14784.review.pix.fr/modules/bac-a-sable
- Vérifier dans les appels réseaux que lors de la récupération du module bac-a-sable, on a bien un élément "audio" dans le JSON.
