### PR TITLE
[FEATURE] Remonter le pourcentage d'acquisition des badges des participations aux campagnes sur Maddo (PIX-20799)

### DIFF
--- a/api/src/maddo/application/campaigns-routes.js
+++ b/api/src/maddo/application/campaigns-routes.js
@@ -77,6 +77,10 @@ const register = async function (server) {
                           key: Joi.string().description('Clé unique du badge'),
                           title: Joi.string().description('Titre du badge'),
                           isAcquired: Joi.boolean().description('Indique si le badge a été obtenu'),
+                          acquisitionPercentage: Joi.number()
+                            .min(0)
+                            .max(100)
+                            .description("Le pourcentage d'obtention du badge"),
                         }).label('CampaignParticipationBadge'),
                       )
                       .description(

--- a/api/src/prescription/campaign-participation/domain/usecases/get-user-campaign-assessment-result.js
+++ b/api/src/prescription/campaign-participation/domain/usecases/get-user-campaign-assessment-result.js
@@ -31,12 +31,12 @@ const getUserCampaignAssessmentResult = async function ({
         campaignParticipationId: campaignParticipation.id,
       }),
     ]);
-    const stillValidBadgeIds = await _checkStillValidBadges(
+    const stillValidBadgeIds = await checkStillValidBadges(
       campaignId,
       knowledgeElements,
       badgeForCalculationRepository,
     );
-    const badgeWithAcquisitionPercentage = await _getBadgeAcquisitionPercentage(
+    const badgeWithAcquisitionPercentage = await getBadgeAcquisitionPercentage(
       campaignId,
       knowledgeElements,
       badgeForCalculationRepository,
@@ -77,12 +77,14 @@ const getUserCampaignAssessmentResult = async function ({
 
 export { getUserCampaignAssessmentResult };
 
-async function _checkStillValidBadges(campaignId, knowledgeElements, badgeForCalculationRepository) {
+async function checkStillValidBadges(campaignId, knowledgeElements, badgeForCalculationRepository) {
   const badgesForCalculation = await badgeForCalculationRepository.findByCampaignId({ campaignId });
   return badgesForCalculation.filter((badge) => badge.shouldBeObtained(knowledgeElements)).map(({ id }) => id);
 }
 
-async function _getBadgeAcquisitionPercentage(campaignId, knowledgeElements, badgeForCalculationRepository) {
+// TODO PIX-21173 Create dedicated repository or service for badges to remove logic duplication for acquisition percentage
+// TODO PIX-21173 part2 We can use badgeAcquisitionRepository to avoid unnecessary calculation
+async function getBadgeAcquisitionPercentage(campaignId, knowledgeElements, badgeForCalculationRepository) {
   const badgesForCalculation = await badgeForCalculationRepository.findByCampaignId({ campaignId });
   return badgesForCalculation.map((badge) => ({
     id: badge.id,

--- a/api/src/prescription/campaign/domain/read-models/CampaignParticipation.js
+++ b/api/src/prescription/campaign/domain/read-models/CampaignParticipation.js
@@ -90,13 +90,14 @@ class ProfilesCollectionCampaignParticipation extends CampaignParticipation {
 }
 
 class Badge {
-  constructor({ id, key, title, imageUrl, altMessage, isAcquired }) {
+  constructor({ id, key, title, imageUrl, altMessage, isAcquired, acquisitionPercentage }) {
     this.id = id;
     this.key = key;
     this.title = title;
     this.imageUrl = imageUrl;
     this.altMessage = altMessage;
     this.isAcquired = isAcquired;
+    this.acquisitionPercentage = acquisitionPercentage;
   }
 }
 

--- a/api/src/prescription/campaign/domain/usecases/get-campaign-participations.js
+++ b/api/src/prescription/campaign/domain/usecases/get-campaign-participations.js
@@ -28,7 +28,7 @@ const getStagesAndStageAcquisitions = async (
   return { stages, acquiredStagesByParticipation };
 };
 
-const getBadgesAndBadesAcquisitions = async (
+const getBadgesAndBadgesAcquisitions = async (
   badgeRepository,
   campaignId,
   badgeAcquisitionRepository,
@@ -104,7 +104,7 @@ export const getCampaignParticipations = async function ({
     participationIds,
   );
 
-  const { badges, acquiredBadgesByParticipation } = await getBadgesAndBadesAcquisitions(
+  const { badges, acquiredBadgesByParticipation } = await getBadgesAndBadgesAcquisitions(
     badgeRepository,
     campaignId,
     badgeAcquisitionRepository,

--- a/api/src/prescription/campaign/domain/usecases/index.js
+++ b/api/src/prescription/campaign/domain/usecases/index.js
@@ -12,6 +12,7 @@ import { featureToggles } from '../../../../shared/infrastructure/feature-toggle
 import * as accessCodeRepository from '../../../../shared/infrastructure/repositories/access-code-repository.js';
 import { adminMemberRepository } from '../../../../shared/infrastructure/repositories/admin-member.repository.js';
 import * as assessmentRepository from '../../../../shared/infrastructure/repositories/assessment-repository.js';
+import * as badgeForCalculationRepository from '../../../../shared/infrastructure/repositories/badge-for-calculation-repository.js';
 import * as competenceRepository from '../../../../shared/infrastructure/repositories/competence-repository.js';
 import { eventLoggingJobRepository } from '../../../../shared/infrastructure/repositories/jobs/event-logging-job.repository.js';
 import * as knowledgeElementRepository from '../../../../shared/infrastructure/repositories/knowledge-element-repository.js';
@@ -44,6 +45,7 @@ import * as campaignUpdateValidator from '../validators/campaign-update-validato
 const dependencies = {
   assessmentRepository,
   adminMemberRepository,
+  badgeForCalculationRepository,
   badgeAcquisitionRepository,
   badgeRepository,
   campaignAdministrationRepository,

--- a/api/tests/prescription/campaign/integration/application/api/campaigns-api_test.js
+++ b/api/tests/prescription/campaign/integration/application/api/campaigns-api_test.js
@@ -48,6 +48,8 @@ describe('Integration | Application | campaign-api', function () {
   describe('#getCampaignParticipations', function () {
     it('should return an array of campaign participations', async function () {
       // given
+      const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+      const badge = databaseBuilder.factory.buildBadge({ targetProfileId });
       const frameworkId = databaseBuilder.factory.learningContent.buildFramework().id;
       const areaId = databaseBuilder.factory.learningContent.buildArea({ frameworkId }).id;
       const competenceId = databaseBuilder.factory.learningContent.buildCompetence({ areaId }).id;
@@ -63,7 +65,7 @@ describe('Integration | Application | campaign-api', function () {
         firstName: 'firstname 1',
         lastName: 'lastname 1',
       });
-      const campaign = databaseBuilder.factory.buildCampaign({ type: CampaignTypes.ASSESSMENT });
+      const campaign = databaseBuilder.factory.buildCampaign({ type: CampaignTypes.ASSESSMENT, targetProfileId });
       databaseBuilder.factory.buildCampaignSkill({ campaignId: campaign.id, skillId });
       const participation1 = databaseBuilder.factory.buildCampaignParticipation({
         campaignId: campaign.id,
@@ -81,6 +83,11 @@ describe('Integration | Application | campaign-api', function () {
         status: KnowledgeElement.StatusType.VALIDATED,
         skillId,
         userId: participation1.userId,
+      });
+      databaseBuilder.factory.buildBadgeAcquisition({
+        userId: organizationLearner1.userId,
+        campaignParticipationId: participation1.id,
+        badgeId: badge.id,
       });
 
       databaseBuilder.factory.buildKnowledgeElementSnapshot({
@@ -126,7 +133,7 @@ describe('Integration | Application | campaign-api', function () {
       // then
       expect(result.models[0]).instanceOf(CampaignParticipation);
       expect(result.models[1]).instanceOf(CampaignParticipation);
-      expect(result.models).to.deep.equal([
+      expect(result.models).to.deep.members([
         {
           campaignParticipationId: participation2.id,
           participantFirstName: organizationLearner2.firstName,
@@ -142,7 +149,16 @@ describe('Integration | Application | campaign-api', function () {
             numberOfStages: 0,
             reachedStage: 0,
           },
-          badges: [],
+          badges: [
+            {
+              altMessage: badge.altMessage,
+              id: badge.id,
+              imageUrl: badge.imageUrl,
+              key: badge.key,
+              title: badge.title,
+              isAcquired: false,
+            },
+          ],
         },
         {
           campaignParticipationId: participation1.id,
@@ -168,7 +184,16 @@ describe('Integration | Application | campaign-api', function () {
             numberOfStages: 0,
             reachedStage: 0,
           },
-          badges: [],
+          badges: [
+            {
+              altMessage: badge.altMessage,
+              id: badge.id,
+              imageUrl: badge.imageUrl,
+              key: badge.key,
+              title: badge.title,
+              isAcquired: true,
+            },
+          ],
         },
       ]);
       expect(result.meta).to.deep.equal({


### PR DESCRIPTION
## ❄️ Problème

Actuellement, on ne remonte que si un utilisateur a acquis ou non un badge sur sa participation.

## 🛷 Proposition

Ajouter le pourcentage d'acquisition qui détermine à quel point l'utilisateur était proche d'acquérir son badge selon les critères d'obtention.

## ☃️ Remarques

Cette donnée est désormais accessible partout via le usecase général de prescription (qui remonte via la campaign api sur maddo)

## 🧑‍🎄 Pour tester

Vérifier la présence de `acquisitionPercentage` via un curl sur la route maddo

```sh
PR_NUMBER=14785
CAMPAIGN_ID=1000001
API_URL="https://pix-api-maddo-review-pr${PR_NUMBER}.osc-fr1.scalingo.io"

#
SECRET=$(scalingo --app pix-api-maddo-review-pr${PR_NUMBER} env-get 'AUTH_SECRET')
EXPIRY=$(($(date +%s) + 3600)) 

#
HEADER='{"alg":"HS256","typ":"JWT"}'
HEADER_B64=$(echo -n "$HEADER" | base64 -w 0 | tr -d '=' | tr '+/' '-_')

#
PAYLOAD="{\"client_id\":\"maddo-client\",\"source\":\"pix-client\",\"scope\":\"campaigns\",\"exp\":$EXPIRY}"
PAYLOAD_B64=$(echo -n "$PAYLOAD" | base64 -w 0 | tr -d '=' | tr '+/' '-_')

#
SIGNATURE_B64=$(echo -n "${HEADER_B64}.${PAYLOAD_B64}" | openssl dgst -sha256 -hmac "$SECRET" -binary | base64 -w 0 | tr -d '=' | tr '+/' '-_')

#
TOKEN="${HEADER_B64}.${PAYLOAD_B64}.${SIGNATURE_B64}"

curl -X GET "${API_URL}/api/campaigns/${CAMPAIGN_ID}/participations" -H "Authorization: Bearer ${TOKEN}" -H "Content-Type: application/json" | jq
```

Vérifier qu'il y a 2 badges, l'un avec 67% et l'autre avec 100% d'acquisitionPercentage