### PR TITLE
[BUGFIX] Metrics learning content : Incrémenter le compteur de lecture type "find"

### DIFF
--- a/api/src/shared/infrastructure/repositories/learning-content-repository.js
+++ b/api/src/shared/infrastructure/repositories/learning-content-repository.js
@@ -80,6 +80,8 @@ export class LearningContentRepository {
    * @returns {Promise<object[]>}
    */
   async find(cacheKey, callback) {
+    this.#metrics.findRead.inc();
+
     let dtos = this.#findCache.get(cacheKey);
     if (dtos) return dtos;
 


### PR DESCRIPTION
## ❄️ Problème

On a oublié d’incrémenter le compteur de lectures de type "find".

## 🛷 Proposition

Incrémenter le compteur quand une lecture de type "find" est faite.

## ☃️ Remarques

N/A

## 🧑‍🎄 Pour tester

Vérifier que la metric remonte bien depuis la RA :
https://grafana.sandbox.pix.digital/explore?schemaVersion=1&panes=%7B%22xd2%22:%7B%22datasource%22:%22prometheus%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22pix_api_lc_read%7Bjob%3D%5C%22pix-api-review-pr14790-web-1%5C%22,%20type%3D%5C%22find%5C%22%7D%22,%22range%22:true,%22instant%22:true,%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22prometheus%22%7D,%22editorMode%22:%22builder%22,%22legendFormat%22:%22__auto%22%7D%5D,%22range%22:%7B%22from%22:%22now-1h%22,%22to%22:%22now%22%7D,%22compact%22:false%7D%7D&orgId=1