### PR TITLE
[FEATURE] Faire du retry des appels réseau en échec de openid-client (PIX-20978)

### DIFF
--- a/api/src/identity-access-management/domain/helpers/openid-client-with-retry.js
+++ b/api/src/identity-access-management/domain/helpers/openid-client-with-retry.js
@@ -1,0 +1,89 @@
+import * as originalOpenidClient from 'openid-client';
+
+import { logger } from '../../../shared/infrastructure/utils/logger.js';
+
+const MAX_RETRY_COUNT = 4;
+const WAIT_DURATION_IN_MS = 2000;
+
+export class OpenidClientWithRetry {
+  #openidClient;
+  #maxRetryCount;
+  #waitDurationInMs;
+
+  constructor({ openidClient, maxRetryCount, durationInMs } = {}) {
+    this.#openidClient = openidClient ?? originalOpenidClient;
+    this.#maxRetryCount = maxRetryCount ?? MAX_RETRY_COUNT;
+    this.#waitDurationInMs = durationInMs ?? WAIT_DURATION_IN_MS;
+  }
+
+  /**
+   * See {@link originalOpenidClient.discovery}
+   */
+  async discovery() {
+    return this.#executeWithRetry(this.#openidClient.discovery, arguments);
+  }
+
+  /**
+   * See {@link originalOpenidClient.authorizationCodeGrant}
+   */
+  async authorizationCodeGrant() {
+    return await this.#executeWithRetry(this.#openidClient.authorizationCodeGrant, arguments);
+  }
+
+  /**
+   * See {@link originalOpenidClient.fetchUserInfo}
+   */
+  async fetchUserInfo() {
+    return this.#executeWithRetry(this.#openidClient.fetchUserInfo, arguments);
+  }
+
+  /**
+   * See {@link originalOpenidClient.buildAuthorizationUrl}
+   */
+  buildAuthorizationUrl() {
+    return this.#openidClient.buildAuthorizationUrl.apply(this.#openidClient, arguments);
+  }
+
+  /**
+   * See {@link originalOpenidClient.buildEndSessionUrl}
+   */
+  buildEndSessionUrl() {
+    return this.#openidClient.buildEndSessionUrl.apply(this.#openidClient, arguments);
+  }
+
+  async #executeWithRetry(f, params, retryCount = 0) {
+    try {
+      return await f.apply(this.#openidClient, params);
+    } catch (error) {
+      if (retryCount >= this.#maxRetryCount) {
+        throw error;
+      }
+
+      _monitorError(error, f, retryCount);
+
+      await new Promise((resolve) => setTimeout(() => resolve(), this.#waitDurationInMs));
+
+      return this.#executeWithRetry(f, params, retryCount + 1);
+    }
+  }
+}
+
+function _monitorError(error, f, retryCount) {
+  const monitoringData = {
+    message: `Error executing ${f.name}, retry = ${retryCount}`,
+    context: 'oidc',
+    team: 'acces',
+  };
+
+  monitoringData.error = {
+    name: error.constructor.name,
+    message: error.message,
+    stack: error.stack,
+    ...(error.error_uri && { errorUri: error.error_uri }),
+    ...(error.response && { response: error.response }),
+  };
+
+  logger.info(monitoringData);
+}
+
+export const openidClientWithRetry = new OpenidClientWithRetry();

--- a/api/src/identity-access-management/domain/services/oidc-authentication-service.js
+++ b/api/src/identity-access-management/domain/services/oidc-authentication-service.js
@@ -23,8 +23,8 @@ const defaultSessionTemporaryStorage = temporaryStorage.withPrefix('oidc-session
 export class OidcAuthenticationService {
   #isReady = false;
   #isReadyForPixAdmin = false;
-  #openIdClient;
-  #openIdClientConfig;
+  #openidClient;
+  #openidClientConfig;
 
   constructor(
     {
@@ -52,7 +52,7 @@ export class OidcAuthenticationService {
       isVisible = true,
       claimMapping,
     },
-    { sessionTemporaryStorage = defaultSessionTemporaryStorage, openIdClient = client } = {},
+    { sessionTemporaryStorage = defaultSessionTemporaryStorage, openidClient = client } = {},
   ) {
     this.accessTokenLifespanMs = ms(accessTokenLifespan);
     this.additionalRequiredProperties = additionalRequiredProperties;
@@ -76,7 +76,7 @@ export class OidcAuthenticationService {
     this.slug = slug;
     this.source = source;
     this.isVisible = isVisible;
-    this.#openIdClient = openIdClient;
+    this.#openidClient = openidClient;
 
     claimMapping = claimMapping || DEFAULT_CLAIM_MAPPING;
 
@@ -115,7 +115,7 @@ export class OidcAuthenticationService {
   }
 
   async initializeClientConfig() {
-    if (this.#openIdClientConfig) return;
+    if (this.#openidClientConfig) return;
 
     try {
       const metadata = {
@@ -123,7 +123,7 @@ export class OidcAuthenticationService {
         ...this.openidClientExtraMetadata,
       };
 
-      this.#openIdClientConfig = await this.#openIdClient.discovery(
+      this.#openidClientConfig = await this.#openidClient.discovery(
         new URL(this.openidConfigurationUrl),
         this.clientId,
         metadata,
@@ -167,8 +167,8 @@ export class OidcAuthenticationService {
 
       const checks = { expectedNonce: nonce, expectedState: sessionState };
 
-      const tokenResponse = await this.#openIdClient.authorizationCodeGrant(
-        this.#openIdClientConfig,
+      const tokenResponse = await this.#openidClient.authorizationCodeGrant(
+        this.#openidClientConfig,
         currentUrl,
         checks,
       );
@@ -201,7 +201,7 @@ export class OidcAuthenticationService {
         ...this.extraAuthorizationUrlParameters,
       };
 
-      const redirectTarget = this.#openIdClient.buildAuthorizationUrl(this.#openIdClientConfig, parameters);
+      const redirectTarget = this.#openidClient.buildAuthorizationUrl(this.#openidClientConfig, parameters);
 
       return { redirectTarget, state, nonce };
     } catch (error) {
@@ -271,7 +271,7 @@ export class OidcAuthenticationService {
     }
 
     try {
-      const endSessionUrl = this.#openIdClient.buildEndSessionUrl(this.#openIdClientConfig, parameters);
+      const endSessionUrl = this.#openidClient.buildEndSessionUrl(this.#openidClientConfig, parameters);
 
       await this.sessionTemporaryStorage.delete(key);
 
@@ -290,7 +290,7 @@ export class OidcAuthenticationService {
     let userInfo;
 
     try {
-      userInfo = await this.#openIdClient.fetchUserInfo(this.#openIdClientConfig, accessToken, expectedSubject);
+      userInfo = await this.#openidClient.fetchUserInfo(this.#openidClientConfig, accessToken, expectedSubject);
     } catch (error) {
       _monitorOidcError(error.message, {
         data: { organizationName: this.organizationName },

--- a/api/src/identity-access-management/domain/services/oidc-authentication-service.js
+++ b/api/src/identity-access-management/domain/services/oidc-authentication-service.js
@@ -3,7 +3,6 @@ import { randomUUID } from 'node:crypto';
 import jsonwebtoken from 'jsonwebtoken';
 import lodash from 'lodash';
 import ms from 'ms';
-import * as client from 'openid-client';
 
 import { config } from '../../../shared/config.js';
 import { OIDC_ERRORS } from '../../../shared/domain/constants.js';
@@ -13,6 +12,7 @@ import { AuthenticationSessionContent } from '../../../shared/domain/models/Auth
 import { temporaryStorage } from '../../../shared/infrastructure/key-value-storages/index.js';
 import { logger } from '../../../shared/infrastructure/utils/logger.js';
 import { DEFAULT_CLAIM_MAPPING } from '../constants/oidc-identity-providers.js';
+import { openidClientWithRetry } from '../helpers/openid-client-with-retry.js';
 import { AuthenticationMethod } from '../models/AuthenticationMethod.js';
 import { ClaimManager } from '../models/ClaimManager.js';
 
@@ -52,7 +52,7 @@ export class OidcAuthenticationService {
       isVisible = true,
       claimMapping,
     },
-    { sessionTemporaryStorage = defaultSessionTemporaryStorage, openidClient = client } = {},
+    { sessionTemporaryStorage = defaultSessionTemporaryStorage, openidClient = openidClientWithRetry } = {},
   ) {
     this.accessTokenLifespanMs = ms(accessTokenLifespan);
     this.additionalRequiredProperties = additionalRequiredProperties;

--- a/api/tests/identity-access-management/acceptance/application/oidc-provider.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/oidc-provider.route.test.js
@@ -17,7 +17,7 @@ import { createMockedTestOidcProvider } from '../../../tooling/openid-client/ope
 const UUID_PATTERN = new RegExp(/^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i);
 
 describe('Acceptance | Identity Access Management | Application | Route | oidc-provider', function () {
-  let server, openIdClientMock;
+  let server, openidClientMock;
 
   describe('GET /api/oidc/identity-providers', function () {
     beforeEach(async function () {
@@ -152,7 +152,7 @@ describe('Acceptance | Identity Access Management | Application | Route | oidc-p
           // given
           const idToken = jsonwebtoken.sign({ given_name: 'John', family_name: 'Doe', sub: 'sub' }, 'secret');
 
-          openIdClientMock.authorizationCodeGrant.resolves({
+          openidClientMock.authorizationCodeGrant.resolves({
             access_token: 'access_token',
             id_token: idToken,
             expires_in: 60,
@@ -217,7 +217,7 @@ describe('Acceptance | Identity Access Management | Application | Route | oidc-p
             'secret',
           );
 
-          openIdClientMock.authorizationCodeGrant.resolves({
+          openidClientMock.authorizationCodeGrant.resolves({
             access_token: 'access_token',
             id_token: idToken,
             expires_in: 60,
@@ -237,7 +237,7 @@ describe('Acceptance | Identity Access Management | Application | Route | oidc-p
           });
 
           // then
-          expect(openIdClientMock.authorizationCodeGrant).to.have.been.calledOnce;
+          expect(openidClientMock.authorizationCodeGrant).to.have.been.calledOnce;
           expect(response.result.access_token).to.exist;
 
           const decodedAccessToken = tokenService.getDecodedToken(response.result.access_token);
@@ -296,7 +296,7 @@ describe('Acceptance | Identity Access Management | Application | Route | oidc-p
             'secret',
           );
 
-          openIdClientMock.authorizationCodeGrant.resolves({
+          openidClientMock.authorizationCodeGrant.resolves({
             access_token: 'access_token',
             id_token: idToken,
             expires_in: 60,
@@ -316,7 +316,7 @@ describe('Acceptance | Identity Access Management | Application | Route | oidc-p
           });
 
           // then
-          expect(openIdClientMock.authorizationCodeGrant).to.have.been.calledOnce;
+          expect(openidClientMock.authorizationCodeGrant).to.have.been.calledOnce;
           expect(response.statusCode).to.equal(403);
         });
       });
@@ -341,7 +341,7 @@ describe('Acceptance | Identity Access Management | Application | Route | oidc-p
             'secret',
           );
 
-          openIdClientMock.authorizationCodeGrant.resolves({
+          openidClientMock.authorizationCodeGrant.resolves({
             access_token: 'access_token',
             id_token: idToken,
             expires_in: 60,
@@ -361,7 +361,7 @@ describe('Acceptance | Identity Access Management | Application | Route | oidc-p
           });
 
           // then
-          expect(openIdClientMock.authorizationCodeGrant).to.have.been.calledOnce;
+          expect(openidClientMock.authorizationCodeGrant).to.have.been.calledOnce;
           expect(response.result.access_token).to.exist;
 
           const decodedAccessToken = tokenService.getDecodedToken(response.result.access_token);
@@ -626,7 +626,7 @@ describe('Acceptance | Identity Access Management | Application | Route | oidc-p
             // given
             const idToken = jsonwebtoken.sign({ given_name: 'John', family_name: 'Doe', sub: 'sub' }, 'secret');
 
-            openIdClientMock.authorizationCodeGrant.resolves({
+            openidClientMock.authorizationCodeGrant.resolves({
               access_token: 'access_token',
               id_token: idToken,
               expires_in: 60,
@@ -691,7 +691,7 @@ describe('Acceptance | Identity Access Management | Application | Route | oidc-p
               'secret',
             );
 
-            openIdClientMock.authorizationCodeGrant.resolves({
+            openidClientMock.authorizationCodeGrant.resolves({
               access_token: 'access_token',
               id_token: idToken,
               expires_in: 60,
@@ -711,7 +711,7 @@ describe('Acceptance | Identity Access Management | Application | Route | oidc-p
             });
 
             // then
-            expect(openIdClientMock.authorizationCodeGrant).to.have.been.calledOnce;
+            expect(openidClientMock.authorizationCodeGrant).to.have.been.calledOnce;
             expect(response.result.access_token).to.exist;
 
             const decodedAccessToken = tokenService.getDecodedToken(response.result.access_token);
@@ -851,7 +851,7 @@ describe('Acceptance | Identity Access Management | Application | Route | oidc-p
     identityProvider,
     connectionMethodCode,
   }) {
-    openIdClientMock = await createMockedTestOidcProvider({
+    openidClientMock = await createMockedTestOidcProvider({
       application,
       applicationTld,
       identityProvider,

--- a/api/tests/identity-access-management/unit/domain/services/oidc-authentication-service.test.js
+++ b/api/tests/identity-access-management/unit/domain/services/oidc-authentication-service.test.js
@@ -18,10 +18,10 @@ const uuidV4Regex = /^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-
 const MOCK_OIDC_PROVIDER_CONFIG = Symbol('config');
 
 describe('Unit | Domain | Services | oidc-authentication-service', function () {
-  let openIdClient;
+  let openidClient;
 
   beforeEach(function () {
-    openIdClient = createOpenIdClientMock(MOCK_OIDC_PROVIDER_CONFIG);
+    openidClient = createOpenIdClientMock(MOCK_OIDC_PROVIDER_CONFIG);
     sinon.stub(logger, 'error');
   });
 
@@ -32,7 +32,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         const args = {};
 
         // when
-        const oidcAuthenticationService = new OidcAuthenticationService(args, { openIdClient });
+        const oidcAuthenticationService = new OidcAuthenticationService(args, { openidClient });
 
         // then
         expect(oidcAuthenticationService.shouldCloseSession).to.be.false;
@@ -47,7 +47,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         const args = { claimMapping: null, claimsToStore: null };
 
         // when
-        const { claimManager } = new OidcAuthenticationService(args, { openIdClient });
+        const { claimManager } = new OidcAuthenticationService(args, { openidClient });
         const claims = claimManager.getMissingMandatoryClaims();
 
         // then
@@ -61,7 +61,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         const args = { claimMapping: { firstName: ['hello'] }, claimsToStore: null };
 
         // when
-        const { claimManager } = new OidcAuthenticationService(args, { openIdClient });
+        const { claimManager } = new OidcAuthenticationService(args, { openidClient });
         const claims = claimManager.getMissingMandatoryClaims();
 
         // then
@@ -75,7 +75,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         const args = { claimMapping: { firstName: ['hello'] }, claimsToStore: 'employeeNumber,studentGroup' };
 
         // when
-        const { claimManager } = new OidcAuthenticationService(args, { openIdClient });
+        const { claimManager } = new OidcAuthenticationService(args, { openidClient });
         const claims = claimManager.getMissingMandatoryClaims();
 
         // then
@@ -99,7 +99,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
             openidConfigurationUrl: 'https://example.net/.well-known/openid-configuration',
             redirectUri: 'https://example.net/connexion/redirect',
           },
-          { openIdClient },
+          { openidClient },
         );
 
         // when
@@ -113,7 +113,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
     context('when not enabled in config', function () {
       it('returns false', function () {
         // given
-        const oidcAuthenticationService = new OidcAuthenticationService({}, { openIdClient });
+        const oidcAuthenticationService = new OidcAuthenticationService({}, { openidClient });
 
         // when
         const result = oidcAuthenticationService.isReady;
@@ -137,7 +137,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         .withArgs(payload, settings.authentication.secret, jwtOptions)
         .returns(accessToken);
 
-      const oidcAuthenticationService = new OidcAuthenticationService(settings.oidcExampleNet, { openIdClient });
+      const oidcAuthenticationService = new OidcAuthenticationService(settings.oidcExampleNet, { openidClient });
 
       // when
       const result = oidcAuthenticationService.createAccessToken({ userId, audience });
@@ -153,7 +153,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         // given
         const userInfo = {};
         const identityProvider = 'genericOidcProviderCode';
-        const oidcAuthenticationService = new OidcAuthenticationService({ identityProvider }, { openIdClient });
+        const oidcAuthenticationService = new OidcAuthenticationService({ identityProvider }, { openidClient });
 
         // when
         const result = oidcAuthenticationService.createAuthenticationComplement({ userInfo });
@@ -174,7 +174,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         const identityProvider = 'genericOidcProviderCode';
         const oidcAuthenticationService = new OidcAuthenticationService(
           { identityProvider, claimsToStore },
-          { openIdClient },
+          { openidClient },
         );
 
         // when
@@ -197,7 +197,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
 
       const oidcAuthenticationService = new OidcAuthenticationService(settings.oidcExampleNet, {
         sessionTemporaryStorage,
-        openIdClient,
+        openidClient,
       });
       await oidcAuthenticationService.initializeClientConfig();
 
@@ -221,11 +221,11 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
       };
       const postLogoutRedirectUriEncoded = encodeURIComponent(settings.oidcExampleNet.postLogoutRedirectUri);
       const endSessionUrl = `https://example.net/logout?post_logout_redirect_uri=${postLogoutRedirectUriEncoded}&id_token_hint=some_dummy_id_token`;
-      openIdClient.buildEndSessionUrl.resolves(endSessionUrl);
+      openidClient.buildEndSessionUrl.resolves(endSessionUrl);
 
       const oidcAuthenticationService = new OidcAuthenticationService(settings.oidcExampleNet, {
         sessionTemporaryStorage,
-        openIdClient,
+        openidClient,
       });
       await oidcAuthenticationService.initializeClientConfig();
 
@@ -233,7 +233,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
       const result = await oidcAuthenticationService.getRedirectLogoutUrl({ userId, logoutUrlUUID });
 
       // then
-      expect(openIdClient.buildEndSessionUrl).to.have.been.calledWith(MOCK_OIDC_PROVIDER_CONFIG, {
+      expect(openidClient.buildEndSessionUrl).to.have.been.calledWith(MOCK_OIDC_PROVIDER_CONFIG, {
         id_token_hint: idToken,
         post_logout_redirect_uri: settings.oidcExampleNet.postLogoutRedirectUri,
       });
@@ -242,7 +242,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
       );
     });
 
-    context('when openIdClient endSessionUrl fails', function () {
+    context('when openidClient endSessionUrl fails', function () {
       it('throws an error and logs monitoring data', async function () {
         // given
         const idToken = 'some_dummy_id_token';
@@ -253,11 +253,11 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
           delete: sinon.stub().resolves(),
         };
         const errorThrown = new Error('Fails to generate endSessionUrl');
-        openIdClient.buildEndSessionUrl.throws(errorThrown);
+        openidClient.buildEndSessionUrl.throws(errorThrown);
 
         const oidcAuthenticationService = new OidcAuthenticationService(settings.oidcExampleNet, {
           sessionTemporaryStorage,
-          openIdClient,
+          openidClient,
         });
         await oidcAuthenticationService.initializeClientConfig();
 
@@ -307,7 +307,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         expiresIn,
         refreshToken,
       });
-      openIdClient.authorizationCodeGrant.resolves({
+      openidClient.authorizationCodeGrant.resolves({
         access_token: accessToken,
         expires_in: expiresIn,
         id_token: idToken,
@@ -322,7 +322,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
           openidConfigurationUrl,
           tokenUrl,
         },
-        { openIdClient },
+        { openidClient },
       );
       await oidcAuthenticationService.initializeClientConfig();
 
@@ -334,7 +334,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
       expect(result).to.deep.equal(oidcAuthenticationSessionContent);
     });
 
-    context('when openIdClient callback fails', function () {
+    context('when openidClient callback fails', function () {
       it('throws an error and logs monitoring data', async function () {
         const clientId = 'clientId';
         const clientSecret = 'clientSecret';
@@ -351,7 +351,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         errorThrown.error_uri = '/oauth2/token';
         errorThrown.response = 'api call response here';
 
-        openIdClient.authorizationCodeGrant.rejects(errorThrown);
+        openidClient.authorizationCodeGrant.rejects(errorThrown);
 
         const oidcAuthenticationService = new OidcAuthenticationService(
           {
@@ -362,7 +362,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
             openidConfigurationUrl,
             organizationName: 'Oidc Example',
           },
-          { openIdClient },
+          { openidClient },
         );
         await oidcAuthenticationService.initializeClientConfig();
 
@@ -409,7 +409,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
       const redirectUri = 'https://example.org/please-redirect-to-me';
       const openidConfigurationUrl = 'https://example.org/oidc-provider-configuration';
 
-      openIdClient.buildAuthorizationUrl.returns('');
+      openidClient.buildAuthorizationUrl.returns('');
 
       const oidcAuthenticationService = new OidcAuthenticationService(
         {
@@ -420,7 +420,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
           openidConfigurationUrl,
           organizationName: 'Oidc Example',
         },
-        { openIdClient },
+        { openidClient },
       );
 
       await oidcAuthenticationService.initializeClientConfig();
@@ -432,7 +432,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
       expect(nonce).to.match(uuidV4Regex);
       expect(state).to.match(uuidV4Regex);
 
-      expect(openIdClient.buildAuthorizationUrl).to.have.been.calledWithExactly(MOCK_OIDC_PROVIDER_CONFIG, {
+      expect(openidClient.buildAuthorizationUrl).to.have.been.calledWithExactly(MOCK_OIDC_PROVIDER_CONFIG, {
         nonce,
         redirect_uri: 'https://example.org/please-redirect-to-me',
         scope: 'openid profile',
@@ -450,7 +450,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         const openidConfigurationUrl = 'https://example.org/oidc-provider-configuration';
         const errorThrown = new Error('Fails to generate authorization url');
 
-        openIdClient.buildAuthorizationUrl.throws(errorThrown);
+        openidClient.buildAuthorizationUrl.throws(errorThrown);
 
         const oidcAuthenticationService = new OidcAuthenticationService(
           {
@@ -461,7 +461,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
             openidConfigurationUrl,
             organizationName: 'Oidc Example',
           },
-          { openIdClient },
+          { openidClient },
         );
         await oidcAuthenticationService.initializeClientConfig();
 
@@ -500,7 +500,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         'secret',
       );
 
-      const oidcAuthenticationService = new OidcAuthenticationService({}, { openIdClient });
+      const oidcAuthenticationService = new OidcAuthenticationService({}, { openidClient });
 
       // when
       const result = await oidcAuthenticationService.getUserInfo({
@@ -532,7 +532,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
 
         const oidcAuthenticationService = new OidcAuthenticationService(
           { claimsToStore: 'employeeNumber' },
-          { openIdClient },
+          { openidClient },
         );
 
         // when
@@ -569,7 +569,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
           lastName: ['usual_name'],
           externalIdentityId: ['sub'],
         };
-        const oidcAuthenticationService = new OidcAuthenticationService({ claimMapping }, { openIdClient });
+        const oidcAuthenticationService = new OidcAuthenticationService({ claimMapping }, { openidClient });
 
         // when
         const result = await oidcAuthenticationService.getUserInfo({
@@ -607,7 +607,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         };
         const oidcAuthenticationService = new OidcAuthenticationService(
           { claimMapping, claimsToStore: 'employeeNumber' },
-          { openIdClient },
+          { openidClient },
         );
 
         // when
@@ -637,7 +637,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
           'secret',
         );
 
-        const oidcAuthenticationService = new OidcAuthenticationService({}, { openIdClient });
+        const oidcAuthenticationService = new OidcAuthenticationService({}, { openidClient });
         sinon.stub(oidcAuthenticationService, '_getUserInfoFromEndpoint').resolves({});
 
         // when
@@ -666,7 +666,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
 
         const oidcAuthenticationService = new OidcAuthenticationService(
           { claimsToStore: 'employeeNumber' },
-          { openIdClient },
+          { openidClient },
         );
         sinon.stub(oidcAuthenticationService, '_getUserInfoFromEndpoint').resolves({});
 
@@ -694,7 +694,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
       const redirectUri = 'https://example.org/please-redirect-to-me';
       const openidConfigurationUrl = 'https://example.org/oidc-provider-configuration';
 
-      openIdClient.fetchUserInfo.returns({
+      openidClient.fetchUserInfo.returns({
         sub: 'sub-id',
         given_name: 'givenName',
         family_name: 'familyName',
@@ -709,7 +709,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
           openidConfigurationUrl,
           organizationName: 'Oidc Example',
         },
-        { openIdClient },
+        { openidClient },
       );
 
       await oidcAuthenticationService.initializeClientConfig();
@@ -723,7 +723,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
       });
 
       // then
-      expect(openIdClient.fetchUserInfo).to.have.been.calledOnceWithExactly(
+      expect(openidClient.fetchUserInfo).to.have.been.calledOnceWithExactly(
         MOCK_OIDC_PROVIDER_CONFIG,
         accessToken,
         'sub-id',
@@ -735,7 +735,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
       });
     });
 
-    context('when openIdClient userinfo fails', function () {
+    context('when openidClient userinfo fails', function () {
       it('throws an error and logs monitoring data', async function () {
         const clientId = 'OIDC_CLIENT_ID';
         const clientSecret = 'OIDC_CLIENT_SECRET';
@@ -744,7 +744,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         const openidConfigurationUrl = 'https://example.org/oidc-provider-configuration';
         const errorThrown = new Error('Fails to get user info');
 
-        openIdClient.fetchUserInfo.rejects(errorThrown);
+        openidClient.fetchUserInfo.rejects(errorThrown);
 
         const oidcAuthenticationService = new OidcAuthenticationService(
           {
@@ -755,7 +755,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
             openidConfigurationUrl,
             organizationName: 'Oidc Example',
           },
-          { openIdClient },
+          { openidClient },
         );
         await oidcAuthenticationService.initializeClientConfig();
 
@@ -789,7 +789,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         const redirectUri = 'https://example.org/please-redirect-to-me';
         const openidConfigurationUrl = 'https://example.org/oidc-provider-configuration';
 
-        openIdClient.fetchUserInfo.returns({
+        openidClient.fetchUserInfo.returns({
           sub: 'sub-id',
           given_name: 'givenName',
           family_name: undefined,
@@ -804,7 +804,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
             openidConfigurationUrl,
             organizationName: 'Oidc Example',
           },
-          { openIdClient },
+          { openidClient },
         );
 
         await oidcAuthenticationService.initializeClientConfig();
@@ -848,7 +848,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         const redirectUri = 'https://example.org/please-redirect-to-me';
         const openidConfigurationUrl = 'https://example.org/oidc-provider-configuration';
 
-        openIdClient.fetchUserInfo.returns({
+        openidClient.fetchUserInfo.returns({
           sub: 'sub-id',
           given_name: 'givenName',
           family_name: 'familyName',
@@ -865,7 +865,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
             openidConfigurationUrl,
             organizationName: 'Oidc Example',
           },
-          { openIdClient },
+          { openidClient },
         );
         await oidcAuthenticationService.initializeClientConfig();
 
@@ -921,7 +921,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         externalIdentifier: externalIdentityId,
         userId,
       });
-      const oidcAuthenticationService = new OidcAuthenticationService({ identityProvider }, { openIdClient });
+      const oidcAuthenticationService = new OidcAuthenticationService({ identityProvider }, { openidClient });
 
       // when
       const result = await oidcAuthenticationService.createUserAccount({
@@ -957,7 +957,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
 
         const oidcAuthenticationService = new OidcAuthenticationService(
           { identityProvider, connectionMethodCode },
-          { openIdClient },
+          { openidClient },
         );
         const expectedAuthenticationMethod = new AuthenticationMethod({
           identityProvider: connectionMethodCode,
@@ -999,7 +999,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
           externalIdentifier: externalIdentityId,
           userId,
         });
-        const oidcAuthenticationService = new OidcAuthenticationService({ identityProvider }, { openIdClient });
+        const oidcAuthenticationService = new OidcAuthenticationService({ identityProvider }, { openidClient });
 
         // when
         await oidcAuthenticationService.createUserAccount({
@@ -1040,7 +1040,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         });
         const oidcAuthenticationService = new OidcAuthenticationService(
           { identityProvider, claimsToStore },
-          { openIdClient },
+          { openidClient },
         );
 
         // when
@@ -1061,7 +1061,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
   });
 
   describe('#initializeClientConfig', function () {
-    it('creates an openIdClient', async function () {
+    it('creates an openidClient', async function () {
       // given
       const clientId = 'clientId';
       const clientSecret = 'clientSecret';
@@ -1077,19 +1077,19 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
           redirectUri,
           openidConfigurationUrl,
         },
-        { openIdClient },
+        { openidClient },
       );
 
       // when
       await oidcAuthenticationService.initializeClientConfig();
 
       // then
-      expect(openIdClient.discovery).to.have.been.calledWithExactly(new URL(openidConfigurationUrl), clientId, {
+      expect(openidClient.discovery).to.have.been.calledWithExactly(new URL(openidConfigurationUrl), clientId, {
         client_secret: clientSecret,
       });
     });
 
-    it('creates an openIdClient with extra metadata', async function () {
+    it('creates an openidClient with extra metadata', async function () {
       // given
       const clientId = 'clientId';
       const clientSecret = 'clientSecret';
@@ -1107,14 +1107,14 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
           openidConfigurationUrl,
           openidClientExtraMetadata,
         },
-        { openIdClient },
+        { openidClient },
       );
 
       // when
       await oidcAuthenticationService.initializeClientConfig();
 
       // then
-      expect(openIdClient.discovery).to.have.been.calledWithExactly(new URL(openidConfigurationUrl), clientId, {
+      expect(openidClient.discovery).to.have.been.calledWithExactly(new URL(openidConfigurationUrl), clientId, {
         client_secret: clientSecret,
         token_endpoint_auth_method: 'client_secret_post',
       });

--- a/api/tests/identity-access-management/unit/domain/services/pole-emploi-oidc-authentication-service.test.js
+++ b/api/tests/identity-access-management/unit/domain/services/pole-emploi-oidc-authentication-service.test.js
@@ -5,10 +5,10 @@ import { expect, sinon } from '../../../../test-helper.js';
 import { createOpenIdClientMock } from '../../../../tooling/openid-client/openid-client-mocks.js';
 
 describe('Unit | Identity Access Management | Domain | Services | pole-emploi-oidc-authentication-service', function () {
-  let openIdClient;
+  let openidClient;
 
   beforeEach(function () {
-    openIdClient = createOpenIdClientMock();
+    openidClient = createOpenIdClientMock();
   });
 
   describe('#constructor', function () {
@@ -24,7 +24,7 @@ describe('Unit | Identity Access Management | Domain | Services | pole-emploi-oi
             slug: 'pole-emploi',
             source: 'pole_emploi_connect',
           },
-          { openIdClient },
+          { openidClient },
         );
 
         // then
@@ -48,14 +48,14 @@ describe('Unit | Identity Access Management | Domain | Services | pole-emploi-oi
           slug: 'pole-emploi',
           source: 'pole_emploi_connect',
         },
-        { openIdClient },
+        { openidClient },
       );
 
       // when
       await poleEmploiOidcAuthenticationService.initializeClientConfig();
 
       // then
-      expect(openIdClient.discovery).to.have.been.calledWithExactly(
+      expect(openidClient.discovery).to.have.been.calledWithExactly(
         new URL('https://oidc.example.net/.well-known/openid-configuration'),
         'client',
         { client_secret: 'secret' },
@@ -82,7 +82,7 @@ describe('Unit | Identity Access Management | Domain | Services | pole-emploi-oi
           slug: 'pole-emploi',
           source: 'pole_emploi_connect',
         },
-        { openIdClient },
+        { openidClient },
       );
 
       // when

--- a/api/tests/identity-access-management/unit/helpers/openid-client-with-retry.test.js
+++ b/api/tests/identity-access-management/unit/helpers/openid-client-with-retry.test.js
@@ -1,0 +1,223 @@
+import { OpenidClientWithRetry } from '../../../../src/identity-access-management/domain/helpers/openid-client-with-retry.js';
+import { logger } from '../../../../src/shared/infrastructure/utils/logger.js';
+import { expect, sinon } from '../../../test-helper.js';
+import { createOpenIdClientMock } from '../../../tooling/openid-client/openid-client-mocks.js';
+
+describe('Unit | Identity Access Management | Domain | Helper | openid-client-with-retry', function () {
+  const durationInMs = 0;
+
+  let openidClient;
+
+  beforeEach(function () {
+    openidClient = createOpenIdClientMock();
+    sinon.stub(logger, 'info');
+  });
+
+  describe('discovery', function () {
+    context('when the first call is successful', function () {
+      it('returns the result', async function () {
+        // given
+        const someParams = {};
+        const someResult = Symbol('someResult');
+        openidClient.discovery.resolves(someResult);
+        const openidClientWithRetry = new OpenidClientWithRetry({ openidClient, durationInMs });
+
+        // when
+        const result = await openidClientWithRetry.discovery(someParams);
+
+        // then
+        expect(openidClient.discovery).to.have.been.calledOnce;
+        expect(result).to.equal(someResult);
+      });
+    });
+
+    context('when the call fails once', function () {
+      it('retry once', async function () {
+        // given
+        const someParams = {};
+        const someResult = Symbol('someResult');
+        openidClient.discovery.onFirstCall().rejects(new Error()).onSecondCall().resolves(someResult);
+        const openidClientWithRetry = new OpenidClientWithRetry({ openidClient, durationInMs });
+
+        // when
+        const result = await openidClientWithRetry.discovery(someParams);
+
+        // then
+        expect(openidClient.discovery).to.have.been.calledTwice;
+        expect(logger.info).to.have.been.calledOnce;
+        expect(result).to.equal(someResult);
+      });
+    });
+
+    context('when maxRetryCount is reached', function () {
+      it('does not retry anymore and throws the error', async function () {
+        // given
+        const someParams = {};
+        openidClient.discovery.rejects(new Error());
+        const openidClientWithRetry = new OpenidClientWithRetry({ openidClient, durationInMs });
+
+        // when
+        try {
+          await openidClientWithRetry.discovery(someParams);
+          // eslint-disable-next-line no-unused-vars
+        } catch (_) {
+          // continue regardless of error
+        }
+
+        // then
+        expect(openidClient.discovery.callCount).to.equal(5);
+        expect(logger.info.callCount).to.equal(4);
+      });
+    });
+  });
+
+  describe('authorizationCodeGrant', function () {
+    context('when the first call is successful', function () {
+      it('returns the result', async function () {
+        // given
+        const someParams = {};
+        const someResult = Symbol('someResult');
+        openidClient.authorizationCodeGrant.resolves(someResult);
+        const openidClientWithRetry = new OpenidClientWithRetry({ openidClient, durationInMs });
+
+        // when
+        const result = await openidClientWithRetry.authorizationCodeGrant(someParams);
+
+        // then
+        expect(openidClient.authorizationCodeGrant).to.have.been.calledOnce;
+        expect(result).to.equal(someResult);
+      });
+    });
+
+    context('when the call fails once', function () {
+      it('retry once', async function () {
+        // given
+        const someParams = {};
+        const someResult = Symbol('someResult');
+        openidClient.authorizationCodeGrant.onFirstCall().rejects(new Error()).onSecondCall().resolves(someResult);
+        const openidClientWithRetry = new OpenidClientWithRetry({ openidClient, durationInMs });
+
+        // when
+        const result = await openidClientWithRetry.authorizationCodeGrant(someParams);
+
+        // then
+        expect(openidClient.authorizationCodeGrant).to.have.been.calledTwice;
+        expect(logger.info).to.have.been.calledOnce;
+        expect(result).to.equal(someResult);
+      });
+    });
+
+    context('when maxRetryCount is reached', function () {
+      it('does not retry anymore and throws the error', async function () {
+        // given
+        const someParams = {};
+        openidClient.authorizationCodeGrant.rejects(new Error());
+        const openidClientWithRetry = new OpenidClientWithRetry({ openidClient, durationInMs });
+
+        // when
+        try {
+          await openidClientWithRetry.authorizationCodeGrant(someParams);
+          // eslint-disable-next-line no-unused-vars
+        } catch (_) {
+          // continue regardless of error
+        }
+
+        // then
+        expect(openidClient.authorizationCodeGrant.callCount).to.equal(5);
+        expect(logger.info.callCount).to.equal(4);
+      });
+    });
+  });
+
+  describe('fetchUserInfo', function () {
+    context('when the first call is successful', function () {
+      it('returns the result', async function () {
+        // given
+        const someParams = {};
+        const someResult = Symbol('someResult');
+        openidClient.fetchUserInfo.resolves(someResult);
+        const openidClientWithRetry = new OpenidClientWithRetry({ openidClient, durationInMs });
+
+        // when
+        const result = await openidClientWithRetry.fetchUserInfo(someParams);
+
+        // then
+        expect(openidClient.fetchUserInfo).to.have.been.calledOnce;
+        expect(result).to.equal(someResult);
+      });
+    });
+
+    context('when the call fails once', function () {
+      it('retry once', async function () {
+        // given
+        const someParams = {};
+        const someResult = Symbol('someResult');
+        openidClient.fetchUserInfo.onFirstCall().rejects(new Error()).onSecondCall().resolves(someResult);
+        const openidClientWithRetry = new OpenidClientWithRetry({ openidClient, durationInMs });
+
+        // when
+        const result = await openidClientWithRetry.fetchUserInfo(someParams);
+
+        // then
+        expect(openidClient.fetchUserInfo).to.have.been.calledTwice;
+        expect(logger.info).to.have.been.calledOnce;
+        expect(result).to.equal(someResult);
+      });
+    });
+
+    context('when maxRetryCount is reached', function () {
+      it('does not retry anymore and throws the error', async function () {
+        // given
+        const someParams = {};
+        openidClient.fetchUserInfo.rejects(new Error());
+        const openidClientWithRetry = new OpenidClientWithRetry({ openidClient, durationInMs });
+
+        // when
+        try {
+          await openidClientWithRetry.fetchUserInfo(someParams);
+          // eslint-disable-next-line no-unused-vars
+        } catch (_) {
+          // continue regardless of error
+        }
+
+        // then
+        expect(openidClient.fetchUserInfo.callCount).to.equal(5);
+        expect(logger.info.callCount).to.equal(4);
+      });
+    });
+  });
+
+  describe('buildAuthorizationUrl', function () {
+    it('just proxies the call', async function () {
+      // given
+      const someParams = {};
+      const someResult = Symbol('someResult');
+      openidClient.buildAuthorizationUrl.returns(someResult);
+      const openidClientWithRetry = new OpenidClientWithRetry({ openidClient, durationInMs });
+
+      // when
+      const result = openidClientWithRetry.buildAuthorizationUrl(someParams);
+
+      // then
+      expect(openidClient.buildAuthorizationUrl).to.have.been.calledOnce;
+      expect(result).to.equal(someResult);
+    });
+  });
+
+  describe('buildEndSessionUrl', function () {
+    it('just proxies the call', async function () {
+      // given
+      const someParams = {};
+      const someResult = Symbol('someResult');
+      openidClient.buildEndSessionUrl.returns(someResult);
+      const openidClientWithRetry = new OpenidClientWithRetry({ openidClient, durationInMs });
+
+      // when
+      const result = openidClientWithRetry.buildEndSessionUrl(someParams);
+
+      // then
+      expect(openidClient.buildEndSessionUrl).to.have.been.calledOnce;
+      expect(result).to.equal(someResult);
+    });
+  });
+});

--- a/api/tests/tooling/openid-client/openid-client-mocks.js
+++ b/api/tests/tooling/openid-client/openid-client-mocks.js
@@ -58,15 +58,15 @@ async function createMockedTestOidcProvider({
 }) {
   oidcAuthenticationServiceRegistry.testOnly_reset();
 
-  const openIdClientMock = createOpenIdClientMock(openIdConfigurationResponse);
+  const openidClientMock = createOpenIdClientMock(openIdConfigurationResponse);
 
   const redirectUri = `https://${application}.dev.pix${applicationTld}/connexion/oidc-example-net`;
 
   const authorizationUrl = `${openIdConfigurationResponse.authorization_endpoint}?client_id=${clientId}&redirect_uri=${redirectUri}&response_type=code&scope=${scope}&state=state&nonce=nonce`;
-  openIdClientMock.buildAuthorizationUrl.returns(authorizationUrl);
+  openidClientMock.buildAuthorizationUrl.returns(authorizationUrl);
 
   const endSessionUrl = `${openIdConfigurationResponse.end_session_endpoint}?client_id=${clientId}`;
-  openIdClientMock.buildEndSessionUrl.returns(endSessionUrl);
+  openidClientMock.buildEndSessionUrl.returns(endSessionUrl);
 
   await oidcAuthenticationServiceRegistry.loadOidcProviderServices([
     new OidcAuthenticationService(
@@ -88,11 +88,11 @@ async function createMockedTestOidcProvider({
         slug: 'oidc-example-net',
         source: 'oidcexamplenet',
       },
-      { openIdClient: openIdClientMock },
+      { openidClient: openidClientMock },
     ),
   ]);
 
-  return openIdClientMock;
+  return openidClientMock;
 }
 
 export { createMockedTestOidcProvider, createOpenIdClientMock };


### PR DESCRIPTION
## ❄️ Problème

Nous avons déterminé que certains appels réseau faits vers des OIDC Providers recevaient des erreurs en retour ou ne recevaient pas de réponse du tout, générant des timeouts. Cela arrive particulièrement avec certains OIDC Providers qu’on peut imaginer moins robustes et/ou plus sollicités que les autres. Et le code de `OidcAuthenticationService` ne gère pas de retry en cas d’erreur ou de timeout sur un appel à un OIDC Provider. Et _openid-client_ ne gère pas de retry non plus.

## 🛷 Proposition

Créer un module `openid-client-with-retry` qui proxifie tous les appels vers `openid-client` en ajoutant du retry sur les 3 appels réseau qui échouent régulièrement, et uniquement sur ces appels là : 
* `discovery`
* `authorizationCodeGrant`
* `fetchUserInfo`

Le délai entre chaque appel réseau a été fixé à 2 secondes de manière à la fois : 
* à laisser le temps nécessaire au serveur OIDC indisponible de changer d’état (réveil d’état de veille, redémarrage de service planté, etc.), utiliser une valeur plus faible aurait peu de probabilité de produire des effets 😴
* à ne pas faire détecter Pix API comme faisant trop de requêtes et éviter que ses adresses IP soient bannies :warning: 
* à ne pas faire trop attendre l’utilisateur en cas de problème (le délai de 2s n’étant bien sûr appliqué que s’il y a un problème après l’appel réseau initial)

La proposition est fonctionnelle, mais il est évident que la bonne solution serait plutôt que la gestion du retry soit présente nativement dans _openid-client_. C’est pourquoi la solution proposée ici se substitue de manière transparente à _openid-client_ et on pourrait la débrancher pour remettre directement`openid-client` dans `OidcAuthenticationService` lorsque, on peut l’espérer, la fonctionnalité de retry arrivera dans _openid-client_ !

## ☃️ Remarques

:information_source: Noter l’utilisation du tag `@link` de JSDoc qui permet de pointer sur la doc des méthodes de `openid-client` sans avoir à les copier-coller ☺️ ce qui aurait fait qu’elles auraient été immanquablement désynchronisées.

## 🧑‍🎄 Pour tester

À tester en local.

### Test du fonctionnement sans erreur

* Tester la connexion par SSO sur Pix App `.fr`
* Tester la connexion par SSO sur Pix App `.org`
* Tester la connexion par SSO sur Pix Orga : 
   * Suivre une invitation en choisissant une autre méthode de connexion et en créant un compte
   * Suivre une invitation en choisissant une autre méthode de connexion et en associant un compte
   * Avec un compte déjà associé par SSO et avec des droits dans Pix Orga se connecter par SSO

### Test du fonctionnement sur erreur avec retry et délais

Modifier le code de `api/src/identity-access-management/domain/helpers/openid-client-with-retry.js` comme suit :
```javascript
  async #executeWithRetry(f, params, retryCount = 0) {
    try {
      // Start of code block to add for test purpose
      if (retryCount <= 2) {
        throw new Error('Error from test');
      }
      // End of code block to add for test purpose

      return await f.apply(this.#openidClient, params);
    } catch (error) {
      if (retryCount >= this.#maxRetryCount) {
        throw error;
      }

      _monitorError(error, f, retryCount);

      await new Promise((resolve) => setTimeout(() => resolve(), this.#waitDurationInMs));

      return this.#executeWithRetry(f, params, retryCount + 1);
    }
  }
```

1. Aller sur n’importe quelle application Pix Front et actionner le bouton pour démarrer une connexion par SSO,
2. Constater dans la console où Pix API s’exécute les 3 logs de monitoring apparaissant à 2 secondes d’intervale.
