### PR TITLE
[BUGFIX] Impossible de retenter une compétence (PIX-21157)

### DIFF
--- a/mon-pix/app/adapters/competence-evaluation.js
+++ b/mon-pix/app/adapters/competence-evaluation.js
@@ -35,7 +35,7 @@ export default class CompetenceEvaluation extends ApplicationAdapter {
     if (query.improve) {
       const url = this.buildURL(type.modelName, null, null, 'queryRecord', query);
 
-      return this.ajax(url, 'PUT', { data: { userId: query.userId, competenceId: query.competenceId } });
+      return this.ajax(url, 'PUT', { data: { competenceId: query.competenceId } });
     }
 
     return super.queryRecord(...arguments);


### PR DESCRIPTION
## ❄️ Problème

La requête envoyée au backend ne passe pas la validation, la payload contient un `userId` qui n’est pas utilisé.

## 🛷 Proposition

Supprimer le `userId` dans la payload envoyée.

## ☃️ Remarques

N/A

## 🧑‍🎄 Pour tester

Se connecter avec `certifiable-contenu-user@example.net` et retenter une compétence.