### PR TITLE
[FEATURE] Le champ transcription de short-video devient facultatif (PIX-21139)

### DIFF
--- a/api/src/devcomp/domain/models/element/ShortVideo.js
+++ b/api/src/devcomp/domain/models/element/ShortVideo.js
@@ -10,7 +10,6 @@ class ShortVideo extends Element {
 
     assertNotNullOrUndefined(title, 'The title is required for a short video');
     assertNotNullOrUndefined(url, 'The URL is required for a short video');
-    assertNotNullOrUndefined(transcription, 'The transcription is required for a short video');
 
     if (!URL.canParse(url)) {
       throw new DomainError('The URL must be a valid URL for a short video');

--- a/api/tests/devcomp/unit/domain/models/element/ShortVideo_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/ShortVideo_test.js
@@ -86,17 +86,4 @@ describe('Unit | Devcomp | Domain | Models | Element | ShortVideo', function () 
       expect(error.message).to.equal('The short video URL must be from "assets.pix.org"');
     });
   });
-
-  describe('A short video without a transcription', function () {
-    it('should throw an error', function () {
-      // when
-      const error = catchErrSync(
-        () => new ShortVideo({ id: 'id', title: 'title', url: 'http://assets.pix.org/modules/short-video.mp4' }),
-      )();
-
-      // then
-      expect(error).to.be.instanceOf(DomainError);
-      expect(error.message).to.equal('The transcription is required for a short video');
-    });
-  });
 });

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/short-video-schema.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/short-video-schema.js
@@ -7,7 +7,7 @@ const shortVideoElementSchema = Joi.object({
   type: Joi.string().valid('short-video').required(),
   title: htmlNotAllowedSchema.required(),
   url: Joi.string().uri().required(),
-  transcription: htmlSchema.required(),
+  transcription: htmlSchema.optional(),
 }).required();
 
 export { shortVideoElementSchema };


### PR DESCRIPTION
## ❄️ Problème

Ce champ est obligatoire mais ce n’est pas toujours pertinent.

## 🛷 Proposition

Le rendre facultatif.

## ☃️ Remarques

- La PR côté Modulix editor est ici : https://github.com/1024pix/modulix-editor/pull/34

## 🧑‍🎄 Pour tester

✅ CI OK
