### PR TITLE
[FEATURE] Ajout de l'élément Audio pour Modulix coté front (PIX-21110)

### DIFF
--- a/mon-pix/app/components/module/component/element.gjs
+++ b/mon-pix/app/components/module/component/element.gjs
@@ -1,6 +1,7 @@
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { eq } from 'ember-truth-helpers';
+import AudioElement from 'mon-pix/components/module/element/audio';
 import CustomDraftElement from 'mon-pix/components/module/element/custom-draft';
 import CustomElement from 'mon-pix/components/module/element/custom-element';
 import DownloadElement from 'mon-pix/components/module/element/download';
@@ -38,6 +39,8 @@ export default class ModulixElement extends Component {
       <VideoElement @video={{@element}} @onTranscriptionOpen={{@onVideoTranscriptionOpen}} />
     {{else if (eq @element.type "short-video")}}
       <ShortVideoElement @element={{@element}} />
+    {{else if (eq @element.type "audio")}}
+      <AudioElement @audio={{@element}} />
     {{else if (eq @element.type "download")}}
       <DownloadElement @download={{@element}} @onDownload={{@onFileDownload}} />
     {{else if (eq @element.type "embed")}}

--- a/mon-pix/app/components/module/element/_audio.scss
+++ b/mon-pix/app/components/module/element/_audio.scss
@@ -5,11 +5,11 @@
     border-radius: 8px;
 
     &__title {
-      margin: 0 10px 0 0;
+      margin: var(--pix-spacing-3x) 0;
     }
   }
 }
 
 .pix-audio-player {
-  width: 50%;
+  width: 100%;
 }

--- a/mon-pix/app/components/module/element/_audio.scss
+++ b/mon-pix/app/components/module/element/_audio.scss
@@ -1,0 +1,15 @@
+.element-audio{
+  &__container {
+    padding: var(--pix-spacing-4x);
+    border: 1px solid var(--pix-neutral-100);
+    border-radius: 8px;
+
+    &__title {
+      margin: 0 10px 0 0;
+    }
+  }
+}
+
+.pix-audio-player {
+  width: 50%;
+}

--- a/mon-pix/app/components/module/element/audio.gjs
+++ b/mon-pix/app/components/module/element/audio.gjs
@@ -1,0 +1,49 @@
+import PixButton from '@1024pix/pix-ui/components/pix-button';
+import PixModal from '@1024pix/pix-ui/components/pix-modal';
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { t } from 'ember-intl';
+import { htmlUnsafe } from 'mon-pix/helpers/html-unsafe';
+export default class ModulixAudio extends Component {
+  @tracked modalIsOpen = false;
+
+  @action
+  showModal() {
+    this.modalIsOpen = true;
+  }
+
+  @action
+  closeModal() {
+    this.modalIsOpen = false;
+  }
+  get hasTranscription() {
+    return this.args.audio.transcription.length > 0;
+  }
+
+  <template>
+    <div class="element-audio">
+      <div class="element-audio__container">
+        <div class="element-audio__container__title">{{@audio.title}}</div>
+        {{! template-lint-disable require-media-caption }}
+        <audio ref="audio" class="pix-audio-player" controls src="{{@audio.url}}"></audio>
+
+        {{#if this.hasTranscription}}
+          <PixButton @variant="tertiary" @triggerAction={{this.showModal}}>
+            {{t "pages.modulix.buttons.element.transcription"}}
+          </PixButton>
+          <PixModal
+            @title={{t "pages.modulix.modals.transcription.title"}}
+            @showModal={{this.modalIsOpen}}
+            @onCloseButtonClick={{this.closeModal}}
+          >
+            <:content>
+              {{htmlUnsafe @audio.transcription}}
+            </:content>
+          </PixModal>
+        {{/if}}
+
+      </div>
+    </div>
+  </template>
+}

--- a/mon-pix/app/components/module/element/audio.gjs
+++ b/mon-pix/app/components/module/element/audio.gjs
@@ -24,7 +24,7 @@ export default class ModulixAudio extends Component {
   <template>
     <div class="element-audio">
       <div class="element-audio__container">
-        <div class="element-audio__container__title">{{@audio.title}}</div>
+        <p class="element-audio__container__title">{{@audio.title}}</p>
         {{! template-lint-disable require-media-caption }}
         <audio ref="audio" class="pix-audio-player" controls src="{{@audio.url}}"></audio>
 

--- a/mon-pix/app/components/module/grain/grain.gjs
+++ b/mon-pix/app/components/module/grain/grain.gjs
@@ -25,6 +25,7 @@ export default class ModuleGrain extends Component {
   };
 
   static AVAILABLE_ELEMENT_TYPES = [
+    'audio',
     'custom',
     'custom-draft',
     'download',

--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -88,6 +88,7 @@ of an adaptative/mobile-first approach — refactoring is welcome here */
 @use '../components/module/issue-report/issue-report-modal' as *;
 @use '../components/module/passage' as *;
 @use '../components/module/component/stepper' as *;
+@use '../components/module/element/audio' as *;
 @use '../components/module/element/custom-element' as *;
 @use '../components/module/element/custom-draft' as *;
 @use '../components/module/element/download' as *;

--- a/mon-pix/tests/integration/components/module/audio_test.gjs
+++ b/mon-pix/tests/integration/components/module/audio_test.gjs
@@ -1,0 +1,54 @@
+import { render } from '@1024pix/ember-testing-library';
+import { click, findAll } from '@ember/test-helpers';
+import ModulixAudioElement from 'mon-pix/components/module/element/audio';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+import { waitForDialogClose } from '../../../helpers/wait-for';
+
+module('Integration | Component | Module | Audio', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('should display an audio', async function (assert) {
+    // given
+    const url = 'https://assets.pix.fr/modulix/placeholder-audio.mp3';
+
+    const audioElement = {
+      url,
+      title: 'title',
+      transcription: '',
+    };
+
+    //  when
+    const screen = await render(<template><ModulixAudioElement @audio={{audioElement}} /></template>);
+
+    // then
+    assert.ok(screen);
+    assert.strictEqual(findAll('.element-audio').length, 1);
+    assert.ok(document.getElementsByClassName('pix-audio-player'));
+  });
+
+  test('should be able to open and close the modal for transcription', async function (assert) {
+    // given
+    const url = 'https://assets.pix.fr/modulix/placeholder-audio.mp3';
+
+    const audioElement = {
+      url,
+      title: 'title',
+      transcription: 'transcription',
+    };
+
+    //  when
+    const screen = await render(<template><ModulixAudioElement @audio={{audioElement}} /></template>);
+
+    // then
+    await click(screen.getByRole('button', { name: 'Afficher la transcription' }));
+    assert.ok(await screen.findByRole('dialog'));
+    assert.ok(screen.getByText('transcription'));
+
+    await click(screen.getByRole('button', { name: 'Fermer' }));
+    await waitForDialogClose();
+
+    assert.dom(screen.queryByRole('dialog')).doesNotExist();
+  });
+});

--- a/mon-pix/tests/integration/components/module/component/element_test.gjs
+++ b/mon-pix/tests/integration/components/module/component/element_test.gjs
@@ -182,6 +182,24 @@ module('Integration | Component | Module | Element', function (hooks) {
     assert.dom(screen.getByRole('button', { name: 'Afficher la transcription' })).exists();
   });
 
+  test('should display an element with an audio element', async function (assert) {
+    // given
+    const element = {
+      id: '3a9f2269-99ba-4631-b6fd-6802c88d5c26',
+      type: 'audio',
+      title: 'Musique',
+      url: 'https://assets.pix.org/modules/placeholder-audio.mp3',
+      transcription: '<p>transcription</p>',
+    };
+
+    // when
+    const screen = await render(<template><ModulixElement @element={{element}} /></template>);
+
+    // then
+    assert.strictEqual(findAll('.element-audio').length, 1);
+    assert.dom(screen.getByRole('button', { name: 'Afficher la transcription' })).exists();
+  });
+
   test('should display an element with an download element', async function (assert) {
     // given
     const element = {


### PR DESCRIPTION
## ❄️ Problème

Besoin d'afficher l'élément Audio coté front pour Modulix

## 🛷 Proposition

Ajout d'un élément Audio (proche de celui de Video).

## ☃️ Remarques

Le style est simple, avec uniquement un encadré pour qu'il reste visible entre toutes les activités.

## 🧑‍🎄 Pour tester

Aller sur le bac à sable : https://app-pr14813.review.pix.fr/modules/bac-a-sable et voir en haut l'élément audio
