### PR TITLE
[FEATURE] Supprimer les valeurs par défaut pour les inputs et les selects des QROCM (PIX-21150)

### DIFF
--- a/api/src/devcomp/domain/models/block/BlockInput.js
+++ b/api/src/devcomp/domain/models/block/BlockInput.js
@@ -1,14 +1,13 @@
 import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
 
 class BlockInput {
-  constructor({ input, inputType, size, display, placeholder, ariaLabel, defaultValue, tolerances, solutions }) {
+  constructor({ input, inputType, size, display, placeholder, ariaLabel, tolerances, solutions }) {
     assertNotNullOrUndefined(input, 'The input is required for an input block');
     assertNotNullOrUndefined(inputType, 'The input type is required for an input block');
     assertNotNullOrUndefined(size, 'The size is required for an input block');
     assertNotNullOrUndefined(display, 'The display is required for an input block');
     assertNotNullOrUndefined(placeholder, 'The placeholder is required for an input block');
     assertNotNullOrUndefined(ariaLabel, 'The aria Label is required for an input block');
-    assertNotNullOrUndefined(defaultValue, 'The default value is required for an input block');
     assertNotNullOrUndefined(tolerances, 'The tolerances are required for an input block');
     assertNotNullOrUndefined(solutions, 'The solutions are required for an input block');
 
@@ -19,7 +18,6 @@ class BlockInput {
     this.display = display;
     this.placeholder = placeholder;
     this.ariaLabel = ariaLabel;
-    this.defaultValue = defaultValue;
     this.tolerances = tolerances;
     this.solutions = solutions;
   }

--- a/api/src/devcomp/domain/models/block/BlockSelect.js
+++ b/api/src/devcomp/domain/models/block/BlockSelect.js
@@ -1,12 +1,11 @@
 import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
 
 class BlockSelect {
-  constructor({ input, display, placeholder, ariaLabel, defaultValue, tolerances, options, solutions }) {
+  constructor({ input, display, placeholder, ariaLabel, tolerances, options, solutions }) {
     assertNotNullOrUndefined(input, 'The input is required for a select block');
     assertNotNullOrUndefined(display, 'The display is required for a select block');
     assertNotNullOrUndefined(placeholder, 'The placeholder is required for a select block');
     assertNotNullOrUndefined(ariaLabel, 'The aria Label is required for a select block');
-    assertNotNullOrUndefined(defaultValue, 'The default value is required for a select block');
     assertNotNullOrUndefined(tolerances, 'The tolerances are required for a select block');
     assertNotNullOrUndefined(options, 'The options are required for a select block');
     assertNotNullOrUndefined(solutions, 'The solutions are required for a select block');
@@ -16,7 +15,6 @@ class BlockSelect {
     this.display = display;
     this.placeholder = placeholder;
     this.ariaLabel = ariaLabel;
-    this.defaultValue = defaultValue;
     this.tolerances = tolerances;
     this.options = options;
     this.solutions = solutions;

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYAntivirus_IND.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYAntivirus_IND.json
@@ -469,7 +469,6 @@
                     "display": "inline",
                     "placeholder": "- deux mots manquants -",
                     "ariaLabel": "deux mots",
-                    "defaultValue": "",
                     "tolerances": [
                       "t1",
                       "t2",
@@ -492,7 +491,6 @@
                     "display": "inline",
                     "placeholder": "- trois mots manquants -",
                     "ariaLabel": "trois mots manquants",
-                    "defaultValue": "",
                     "tolerances": [
                       "t1",
                       "t2",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYGestionMDP_IND.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYGestionMDP_IND.json
@@ -143,7 +143,6 @@
                     "display": "inline",
                     "placeholder": "nombre de comptes",
                     "ariaLabel": "nombre de comptes",
-                    "defaultValue": "",
                     "tolerances": [],
                     "solutions": [
                       3
@@ -587,7 +586,6 @@
                     "display": "inline",
                     "placeholder": "- Sélectionner -",
                     "ariaLabel": "nom du gestionnaire",
-                    "defaultValue": "",
                     "tolerances": [
                       "t1",
                       "t2",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYMDP_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYMDP_NOV.json
@@ -816,7 +816,6 @@
                     "display": "inline",
                     "placeholder": "taper ici",
                     "ariaLabel": "taper le mot de passe ici",
-                    "defaultValue": "",
                     "tolerances": [],
                     "solutions": [
                       "Ls,jbdlsadcem3t!",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYMFA_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYMFA_NOV.json
@@ -446,7 +446,7 @@
                     "display": "inline",
                     "placeholder": "-Sélectionnez-",
                     "ariaLabel": "-Sélectionnez-",
-                    "defaultValue": "",
+
                     "tolerances": [],
                     "options": [
                       {
@@ -472,7 +472,6 @@
                     "display": "inline",
                     "placeholder": "-Sélectionnez-",
                     "ariaLabel": "-Sélectionnez-",
-                    "defaultValue": "",
                     "tolerances": [],
                     "options": [
                       {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYPhishing_AVA.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYPhishing_AVA.json
@@ -150,7 +150,6 @@
                     "display": "inline",
                     "placeholder": "- Sélectionner -",
                     "ariaLabel": "- Sélectionner -",
-                    "defaultValue": "",
                     "tolerances": [
                       "t1",
                       "t2",
@@ -184,7 +183,6 @@
                     "display": "inline",
                     "placeholder": "- Sélectionner -",
                     "ariaLabel": "- Sélectionner -",
-                    "defaultValue": "",
                     "tolerances": [
                       "t1",
                       "t2",
@@ -218,7 +216,6 @@
                     "display": "inline",
                     "placeholder": "- Sélectionner -",
                     "ariaLabel": "- Sélectionner -",
-                    "defaultValue": "",
                     "tolerances": [
                       "t1",
                       "t2",
@@ -252,7 +249,6 @@
                     "display": "inline",
                     "placeholder": "- Sélectionner -",
                     "ariaLabel": "- Sélectionner -",
-                    "defaultValue": "",
                     "tolerances": [
                       "t1",
                       "t2",
@@ -934,7 +930,6 @@
                           "display": "inline",
                           "placeholder": "- Sélectionner -",
                           "ariaLabel": "- Sélectionner -",
-                          "defaultValue": "",
                           "tolerances": [
                             "t1",
                             "t2",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYPhishing_IND.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYPhishing_IND.json
@@ -495,7 +495,6 @@
                     "display": "inline",
                     "placeholder": "-Sélectionner-",
                     "ariaLabel": "-Sélectionner-",
-                    "defaultValue": "",
                     "tolerances": [],
                     "options": [
                       {
@@ -525,7 +524,6 @@
                     "display": "inline",
                     "placeholder": "-Sélectionner-",
                     "ariaLabel": "-Sélectionner-",
-                    "defaultValue": "",
                     "tolerances": [],
                     "options": [
                       {
@@ -555,7 +553,6 @@
                     "display": "inline",
                     "placeholder": "-Sélectionner-",
                     "ariaLabel": "-Sélectionner-",
-                    "defaultValue": "",
                     "tolerances": [],
                     "options": [
                       {
@@ -618,7 +615,6 @@
                     "display": "inline",
                     "placeholder": "tapez le nom",
                     "ariaLabel": "tapez le nom",
-                    "defaultValue": "",
                     "tolerances": [
                       "t1"
                     ],

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IADefinition_IND.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IADefinition_IND.json
@@ -626,7 +626,6 @@
                     "display": "inline",
                     "placeholder": "Sélectionner",
                     "ariaLabel": "Sélectionner",
-                    "defaultValue": "",
                     "tolerances": [],
                     "options": [
                       {
@@ -652,7 +651,6 @@
                     "display": "inline",
                     "placeholder": "Sélectionner",
                     "ariaLabel": "Sélectionner",
-                    "defaultValue": "",
                     "tolerances": [],
                     "options": [
                       {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IADefinition_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IADefinition_NOV.json
@@ -427,7 +427,6 @@
                     "display": "inline",
                     "placeholder": "",
                     "ariaLabel": "nombre d’utilisation de l’IA",
-                    "defaultValue": "",
                     "tolerances": [],
                     "solutions": [
                       6

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenBiais_AVA.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenBiais_AVA.json
@@ -616,7 +616,6 @@
                     "display": "inline",
                     "placeholder": "Nom du pays",
                     "ariaLabel": "Nom du pays",
-                    "defaultValue": "",
                     "tolerances": [
                       "t1",
                       "t2",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenFonction_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenFonction_NOV.json
@@ -198,7 +198,6 @@
                           "display": "inline",
                           "placeholder": "votre mot",
                           "ariaLabel": "zone de saisie",
-                          "defaultValue": "",
                           "tolerances": [
                             "t1",
                             "t2",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenPrompt_IND.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenPrompt_IND.json
@@ -617,7 +617,6 @@
                     "display": "inline",
                     "placeholder": "Nom du gymnase",
                     "ariaLabel": "Nom du gymnase",
-                    "defaultValue": "",
                     "tolerances": ["t1", "t2", "t3"],
                     "solutions": [
                       "Le gymnase des 3 sapins",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenPrompt_IND_altconfig.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenPrompt_IND_altconfig.json
@@ -617,7 +617,6 @@
                     "display": "inline",
                     "placeholder": "Nom du gymnase",
                     "ariaLabel": "Nom du gymnase",
-                    "defaultValue": "",
                     "tolerances": ["t1", "t2", "t3"],
                     "solutions": [
                       "Le gymnase des 3 sapins",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/NR-Datacenter-NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/NR-Datacenter-NOV.json
@@ -830,7 +830,6 @@
                     "display": "inline",
                     "placeholder": "",
                     "ariaLabel": "départ de la demande",
-                    "defaultValue": "",
                     "tolerances": [],
                     "options": [
                       {
@@ -860,7 +859,6 @@
                     "display": "inline",
                     "placeholder": "",
                     "ariaLabel": "lieu de traitement",
-                    "defaultValue": "",
                     "tolerances": [],
                     "options": [
                       {
@@ -890,7 +888,6 @@
                     "display": "inline",
                     "placeholder": "",
                     "ariaLabel": "éléments de traitement",
-                    "defaultValue": "",
                     "tolerances": [],
                     "options": [
                       {
@@ -920,7 +917,6 @@
                     "display": "inline",
                     "placeholder": "",
                     "ariaLabel": "retour de la réponse",
-                    "defaultValue": "",
                     "tolerances": [],
                     "options": [
                       {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/NR-Durabilite-AVA.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/NR-Durabilite-AVA.json
@@ -631,7 +631,6 @@
                     "display": "block",
                     "placeholder": "- Sélectionnez -",
                     "ariaLabel": "Sélectionnez",
-                    "defaultValue": "",
                     "tolerances": [],
                     "options": [
                       {
@@ -665,7 +664,6 @@
                     "display": "block",
                     "placeholder": "- Sélectionnez -",
                     "ariaLabel": "Sélectionnez",
-                    "defaultValue": "",
                     "tolerances": [],
                     "options": [
                       {
@@ -699,7 +697,6 @@
                     "display": "block",
                     "placeholder": "- Sélectionnez -",
                     "ariaLabel": "Sélectionnez",
-                    "defaultValue": "",
                     "tolerances": [],
                     "options": [
                       {
@@ -733,7 +730,6 @@
                     "display": "block",
                     "placeholder": "- Sélectionnez -",
                     "ariaLabel": "Sélectionnez",
-                    "defaultValue": "",
                     "tolerances": [],
                     "options": [
                       {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/NR_Datacenter_AVA.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/NR_Datacenter_AVA.json
@@ -937,7 +937,6 @@
                     "display": "block",
                     "placeholder": "champs à remplir",
                     "ariaLabel": "champs à remplir",
-                    "defaultValue": "",
                     "tolerances": [
                       "t1",
                       "t2",
@@ -1026,7 +1025,6 @@
                     "display": "block",
                     "placeholder": "champs à remplir",
                     "ariaLabel": "champs à remplir",
-                    "defaultValue": "champs à remplir",
                     "tolerances": [
                       "t1",
                       "t2",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/NR_Evaluation_IND.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/NR_Evaluation_IND.json
@@ -338,7 +338,6 @@
                     "display": "inline",
                     "placeholder": "",
                     "ariaLabel": "étape la plus contributrice pour PM",
-                    "defaultValue": "",
                     "tolerances": [],
                     "options": [
                       {
@@ -372,7 +371,6 @@
                     "display": "inline",
                     "placeholder": "",
                     "ariaLabel": "ordre de grandeur de la part de l’utilisation pour PM",
-                    "defaultValue": "",
                     "tolerances": [],
                     "options": [
                       {
@@ -406,7 +404,6 @@
                     "display": "inline",
                     "placeholder": "",
                     "ariaLabel": "tier le plus contributif à l’étape utilisation pour PM",
-                    "defaultValue": "",
                     "tolerances": [],
                     "options": [
                       {
@@ -436,7 +433,6 @@
                     "display": "inline",
                     "placeholder": "",
                     "ariaLabel": "importance relative du transport pour PM",
-                    "defaultValue": "",
                     "tolerances": [],
                     "options": [
                       {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/adresse-ip-publique-et-vous.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/adresse-ip-publique-et-vous.json
@@ -439,7 +439,6 @@
                     "display": "inline",
                     "placeholder": "",
                     "ariaLabel": "Nom du pays :",
-                    "defaultValue": "",
                     "tolerances": [
                       "t1"
                     ],

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
@@ -93,7 +93,6 @@
                           "display": "inline",
                           "placeholder": "",
                           "ariaLabel": "Mot à trouver",
-                          "defaultValue": "",
                           "tolerances": ["t1", "t3"],
                           "solutions": ["Groupement"]
                         },
@@ -109,7 +108,6 @@
                           "display": "inline",
                           "placeholder": "",
                           "ariaLabel": "Année à trouver",
-                          "defaultValue": "",
                           "tolerances": [],
                           "solutions": [2016]
                         }
@@ -1094,7 +1092,6 @@
                     "display": "inline",
                     "placeholder": "",
                     "ariaLabel": "Mot à trouver",
-                    "defaultValue": "",
                     "tolerances": ["t1", "t3"],
                     "solutions": ["Groupement"]
                   },
@@ -1110,7 +1107,6 @@
                     "display": "inline",
                     "placeholder": "",
                     "ariaLabel": "Année à trouver",
-                    "defaultValue": "",
                     "tolerances": [],
                     "solutions": [2016]
                   }
@@ -1165,7 +1161,6 @@
                     "display": "inline",
                     "placeholder": "",
                     "ariaLabel": "Remplir le prénom de la personne qui est en train de parler dans la visioconférence",
-                    "defaultValue": "",
                     "tolerances": ["t1", "t2", "t3"],
                     "solutions": ["Katie"]
                   }
@@ -1239,7 +1234,6 @@
                     "display": "block",
                     "placeholder": "",
                     "ariaLabel": "Nom de ce produit",
-                    "defaultValue": "",
                     "tolerances": ["t1"],
                     "solutions": ["Modulix"]
                   }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bases-clavier-ordinateur-1.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bases-clavier-ordinateur-1.json
@@ -314,7 +314,6 @@
                     "display": "inline",
                     "placeholder": "Cliquer ici",
                     "ariaLabel": "Cliquer ici",
-                    "defaultValue": "",
                     "tolerances": [],
                     "solutions": [
                       "cornichons"
@@ -332,7 +331,6 @@
                     "display": "inline",
                     "placeholder": "Cliquer ici",
                     "ariaLabel": "Cliquer ici",
-                    "defaultValue": "",
                     "tolerances": [],
                     "solutions": [
                       "vide"
@@ -634,7 +632,6 @@
                     "display": "inline",
                     "placeholder": "Cliquer ici",
                     "ariaLabel": "Cliquer ici",
-                    "defaultValue": "",
                     "tolerances": [],
                     "solutions": [
                       "céleri"
@@ -675,7 +672,6 @@
                     "display": "inline",
                     "placeholder": "Cliquer ici",
                     "ariaLabel": "Cliquer ici",
-                    "defaultValue": "",
                     "tolerances": [],
                     "solutions": [
                       "pastèque"
@@ -716,7 +712,6 @@
                     "display": "inline",
                     "placeholder": "Cliquer ici",
                     "ariaLabel": "Cliquer ici",
-                    "defaultValue": "",
                     "tolerances": [],
                     "solutions": [
                       "bac à glaçons"

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bases-clavier-ordinateur-2.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bases-clavier-ordinateur-2.json
@@ -65,7 +65,6 @@
                     "display": "inline",
                     "placeholder": "Tapez ici",
                     "ariaLabel": "zone de saisie",
-                    "defaultValue": "",
                     "tolerances": [],
                     "solutions": [
                       "voilà le zèbre déçu",
@@ -356,7 +355,6 @@
                     "display": "inline",
                     "placeholder": "recopiez la phrase ",
                     "ariaLabel": "zone de saisie",
-                    "defaultValue": "",
                     "tolerances": [
                       "t1"
                     ],

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
@@ -241,7 +241,6 @@
                           "display": "inline",
                           "placeholder": "",
                           "ariaLabel": "Réponse 1 sur 1",
-                          "defaultValue": "",
                           "tolerances": [
                             "t1"
                           ],
@@ -285,7 +284,6 @@
                           "display": "inline",
                           "placeholder": "- Sélectionner -",
                           "ariaLabel": "Réponse 1 sur 2",
-                          "defaultValue": "",
                           "tolerances": [],
                           "options": [
                             {
@@ -315,7 +313,6 @@
                           "display": "inline",
                           "placeholder": "- Sélectionner -",
                           "ariaLabel": "Réponse 2 sur 2",
-                          "defaultValue": "",
                           "tolerances": [],
                           "options": [
                             {
@@ -539,7 +536,6 @@
                     "display": "inline",
                     "placeholder": "",
                     "ariaLabel": "Adresse mail de Naomi",
-                    "defaultValue": "",
                     "tolerances": [
                       "t1"
                     ],

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/comment-envoyer-un-mail.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/comment-envoyer-un-mail.json
@@ -389,7 +389,6 @@
                     "display": "inline",
                     "placeholder": "- Sélectionner -",
                     "ariaLabel": "expéditeur mail",
-                    "defaultValue": "",
                     "tolerances": [],
                     "options": [
                       {
@@ -423,7 +422,6 @@
                     "display": "inline",
                     "placeholder": "- Sélectionner - ",
                     "ariaLabel": "destinaire mail",
-                    "defaultValue": "",
                     "tolerances": [],
                     "options": [
                       {
@@ -457,7 +455,6 @@
                     "display": "inline",
                     "placeholder": "- Sélectionner -",
                     "ariaLabel": "objet mail",
-                    "defaultValue": "",
                     "tolerances": [],
                     "options": [
                       {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/galerie.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/galerie.json
@@ -623,7 +623,6 @@
                     "display": "inline",
                     "placeholder": "",
                     "ariaLabel": "Mot à trouver",
-                    "defaultValue": "",
                     "tolerances": ["t1", "t3"],
                     "solutions": ["Groupement"]
                   },
@@ -639,7 +638,6 @@
                     "display": "inline",
                     "placeholder": "",
                     "ariaLabel": "Année à trouver",
-                    "defaultValue": "",
                     "tolerances": [],
                     "solutions": [2016]
                   }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/mots-de-passe-securises.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/mots-de-passe-securises.json
@@ -57,7 +57,6 @@
                     "display": "block",
                     "placeholder": "",
                     "ariaLabel": "Mot de passe",
-                    "defaultValue": "",
                     "tolerances": [
                       "t1"
                     ],
@@ -192,7 +191,6 @@
                     "display": "block",
                     "placeholder": "",
                     "ariaLabel": "Mot de passe d'Austin",
-                    "defaultValue": "",
                     "tolerances": [
                       "t1"
                     ],

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/nr_durabilite_ind.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/nr_durabilite_ind.json
@@ -196,7 +196,6 @@
                     "display": "block",
                     "placeholder": "Sélectionnez une réponse.",
                     "ariaLabel": "Sélectionner un usage pour le lithium",
-                    "defaultValue": "",
                     "tolerances": [],
                     "options": [
                       {
@@ -226,7 +225,6 @@
                     "display": "block",
                     "placeholder": "Sélectionnez une réponse.",
                     "ariaLabel": "Sélectionner un usage pour les terres rares",
-                    "defaultValue": "",
                     "tolerances": [],
                     "options": [
                       {
@@ -256,7 +254,6 @@
                     "display": "block",
                     "placeholder": "Sélectionnez une réponse.",
                     "ariaLabel": "Sélectionner un usage pour l’or, le cuivre et l’argent",
-                    "defaultValue": "",
                     "tolerances": [],
                     "options": [
                       {
@@ -868,7 +865,6 @@
                     "display": "block",
                     "placeholder": "Sélectionner un rang",
                     "ariaLabel": "Sélectionner un rang pour l’achat d’un appareil neuf",
-                    "defaultValue": "",
                     "tolerances": [],
                     "options": [
                       {
@@ -902,7 +898,6 @@
                     "display": "block",
                     "placeholder": "Sélectionner un rang",
                     "ariaLabel": "Sélectionner un rang pour l’achat reconditionné alors que l’appareil fonctionne encore",
-                    "defaultValue": "",
                     "tolerances": [],
                     "options": [
                       {
@@ -936,7 +931,6 @@
                     "display": "block",
                     "placeholder": "Sélectionner un rang",
                     "ariaLabel": "Sélectionner un rang pour l’achat reconditionné après fin de vie",
-                    "defaultValue": "",
                     "tolerances": [],
                     "options": [
                       {
@@ -970,7 +964,6 @@
                     "display": "block",
                     "placeholder": "Sélectionner un rang",
                     "ariaLabel": "Sélectionner un rang pour la réparation",
-                    "defaultValue": "",
                     "tolerances": [],
                     "options": [
                       {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/principes-fondateurs-wikipedia.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/principes-fondateurs-wikipedia.json
@@ -466,7 +466,6 @@
                     "display": "block",
                     "placeholder": "",
                     "ariaLabel": "Remplir le nom de la cinquième section du sommaire de l'article Wikipédia proposé",
-                    "defaultValue": "",
                     "tolerances": [
                       "t1"
                     ],
@@ -514,7 +513,6 @@
                     "display": "block",
                     "placeholder": "",
                     "ariaLabel": "Remplir avec le nombre de notes et références",
-                    "defaultValue": "",
                     "tolerances": [
                       "t1"
                     ],
@@ -560,7 +558,6 @@
                     "display": "block",
                     "placeholder": "- Sélectionner -",
                     "ariaLabel": "Choisir le niveau de qualité estimé",
-                    "defaultValue": "",
                     "tolerances": [],
                     "options": [
                       {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/tmp08ef.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/tmp08ef.json
@@ -359,7 +359,6 @@
                     "display": "inline",
                     "placeholder": "",
                     "ariaLabel": "choisir le mot dans le menu déroulant",
-                    "defaultValue": "",
                     "tolerances": [],
                     "options": [
                       {
@@ -389,7 +388,6 @@
                     "display": "inline",
                     "placeholder": "",
                     "ariaLabel": "choisir le mot dans le menu déroulant",
-                    "defaultValue": "",
                     "tolerances": [],
                     "options": [
                       {
@@ -419,7 +417,6 @@
                     "display": "inline",
                     "placeholder": "",
                     "ariaLabel": "choisir le mot dans le menu déroulant",
-                    "defaultValue": "",
                     "tolerances": [],
                     "options": [
                       {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/tri-multicritere-tableau.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/tri-multicritere-tableau.json
@@ -338,7 +338,6 @@
                     "display": "inline",
                     "placeholder": "prénom",
                     "ariaLabel": "écrivez le prénom ici",
-                    "defaultValue": "",
                     "tolerances": [
                       "t3"
                     ],
@@ -358,7 +357,6 @@
                     "display": "inline",
                     "placeholder": "lot",
                     "ariaLabel": "écrivez le lot ici",
-                    "defaultValue": "",
                     "tolerances": [
                       "t3"
                     ],
@@ -541,7 +539,6 @@
                     "display": "inline",
                     "placeholder": "prénom",
                     "ariaLabel": "écrivez ici le prénom",
-                    "defaultValue": "",
                     "tolerances": [
                       "t3"
                     ],
@@ -561,7 +558,6 @@
                     "display": "inline",
                     "placeholder": "trésor",
                     "ariaLabel": "écrivez ici le contenu du trésor",
-                    "defaultValue": "",
                     "tolerances": [
                       "t3"
                     ],

--- a/api/tests/devcomp/integration/infrastructure/factories/module-factory_test.js
+++ b/api/tests/devcomp/integration/infrastructure/factories/module-factory_test.js
@@ -1206,7 +1206,6 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
                             display: 'inline',
                             placeholder: '',
                             ariaLabel: 'Réponse 1',
-                            defaultValue: '',
                             tolerances: ['t1'],
                             solutions: ['@'],
                           },
@@ -1216,7 +1215,6 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
                             display: 'inline',
                             placeholder: '',
                             ariaLabel: 'Réponse 2',
-                            defaultValue: '',
                             tolerances: [],
                             options: [
                               {
@@ -2164,7 +2162,6 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
                                   display: 'inline',
                                   placeholder: '',
                                   ariaLabel: 'Mot à trouver',
-                                  defaultValue: '',
                                   tolerances: ['t1', 't3'],
                                   solutions: ['Groupement'],
                                 },
@@ -2180,7 +2177,6 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
                                   display: 'inline',
                                   placeholder: '',
                                   ariaLabel: 'Année à trouver',
-                                  defaultValue: '',
                                   tolerances: [],
                                   solutions: ['2016'],
                                 },

--- a/api/tests/devcomp/unit/domain/models/block/BlockInput_test.js
+++ b/api/tests/devcomp/unit/domain/models/block/BlockInput_test.js
@@ -13,7 +13,6 @@ describe('Unit | Devcomp | Domain | Models | Block | BlockInput', function () {
         display: 'inline',
         placeholder: 'a placeholder',
         ariaLabel: 'Réponse 1',
-        defaultValue: 'default',
         tolerances: ['t1'],
         solutions: ['@'],
       };
@@ -29,7 +28,6 @@ describe('Unit | Devcomp | Domain | Models | Block | BlockInput', function () {
       expect(input.display).to.equal(constructor.display);
       expect(input.placeholder).to.equal(constructor.placeholder);
       expect(input.ariaLabel).to.equal(constructor.ariaLabel);
-      expect(input.defaultValue).to.equal(constructor.defaultValue);
       expect(input.tolerances).to.equal(constructor.tolerances);
       expect(input.solutions).to.equal(constructor.solutions);
     });
@@ -105,27 +103,6 @@ describe('Unit | Devcomp | Domain | Models | Block | BlockInput', function () {
     });
   });
 
-  describe('If defaultValue is missing', function () {
-    it('should throw an error', function () {
-      // when
-      const error = catchErrSync(
-        () =>
-          new BlockInput({
-            input: 'symbole',
-            inputType: 'text',
-            size: 1,
-            display: 'inline',
-            placeholder: '',
-            ariaLabel: 'Réponse 1',
-          }),
-      )();
-
-      // then
-      expect(error).to.be.instanceOf(DomainError);
-      expect(error.message).to.equal('The default value is required for an input block');
-    });
-  });
-
   describe('If tolerances are missing', function () {
     it('should throw an error', function () {
       // when
@@ -138,7 +115,6 @@ describe('Unit | Devcomp | Domain | Models | Block | BlockInput', function () {
             display: 'inline',
             placeholder: '',
             ariaLabel: 'Réponse 1',
-            defaultValue: '',
           }),
       )();
 
@@ -160,7 +136,6 @@ describe('Unit | Devcomp | Domain | Models | Block | BlockInput', function () {
             display: 'inline',
             placeholder: '',
             ariaLabel: 'Réponse 1',
-            defaultValue: '',
             tolerances: ['t1'],
           }),
       )();

--- a/api/tests/devcomp/unit/domain/models/block/BlockSelect_test.js
+++ b/api/tests/devcomp/unit/domain/models/block/BlockSelect_test.js
@@ -11,7 +11,6 @@ describe('Unit | Devcomp | Domain | Models | Block | BlockSelect', function () {
         display: 'inline',
         placeholder: 'a placeholder',
         ariaLabel: 'Réponse 1',
-        defaultValue: 'default',
         tolerances: ['t1'],
         options: [Symbol('option')],
         solutions: ['@'],
@@ -26,7 +25,6 @@ describe('Unit | Devcomp | Domain | Models | Block | BlockSelect', function () {
       expect(select.display).to.equal(constructor.display);
       expect(select.placeholder).to.equal(constructor.placeholder);
       expect(select.ariaLabel).to.equal(constructor.ariaLabel);
-      expect(select.defaultValue).to.equal(constructor.defaultValue);
       expect(select.tolerances).to.equal(constructor.tolerances);
       expect(select.options).to.equal(constructor.options);
       expect(select.solutions).to.equal(constructor.solutions);
@@ -79,25 +77,6 @@ describe('Unit | Devcomp | Domain | Models | Block | BlockSelect', function () {
     });
   });
 
-  describe('If defaultValue is missing', function () {
-    it('should throw an error', function () {
-      // when
-      const error = catchErrSync(
-        () =>
-          new BlockSelect({
-            input: 'symbole',
-            display: 'inline',
-            placeholder: 'a placeholder',
-            ariaLabel: 'Réponse 1',
-          }),
-      )();
-
-      // then
-      expect(error).to.be.instanceOf(DomainError);
-      expect(error.message).to.equal('The default value is required for a select block');
-    });
-  });
-
   describe('If tolerances are missing', function () {
     it('should throw an error', function () {
       // when
@@ -108,7 +87,6 @@ describe('Unit | Devcomp | Domain | Models | Block | BlockSelect', function () {
             display: 'inline',
             placeholder: 'a placeholder',
             ariaLabel: 'Réponse 1',
-            defaultValue: 'default',
           }),
       )();
 
@@ -128,7 +106,6 @@ describe('Unit | Devcomp | Domain | Models | Block | BlockSelect', function () {
             display: 'inline',
             placeholder: 'a placeholder',
             ariaLabel: 'Réponse 1',
-            defaultValue: 'default',
             tolerances: ['t1'],
           }),
       )();
@@ -149,7 +126,6 @@ describe('Unit | Devcomp | Domain | Models | Block | BlockSelect', function () {
             display: 'inline',
             placeholder: 'a placeholder',
             ariaLabel: 'Réponse 1',
-            defaultValue: 'default',
             tolerances: ['t1'],
             options: [Symbol('option')],
           }),

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qrocm-schema.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qrocm-schema.js
@@ -11,7 +11,6 @@ const blockInputSchema = Joi.object({
   display: Joi.string().valid('inline', 'block').required(),
   placeholder: htmlNotAllowedSchema.allow('').required(),
   ariaLabel: htmlNotAllowedSchema.required(),
-  defaultValue: htmlNotAllowedSchema.allow('').required(),
   tolerances: Joi.array()
     .unique()
     .items(Joi.string().valid('t1', 't2', 't3'))
@@ -27,9 +26,6 @@ const blockSelectSchema = Joi.object({
   display: Joi.string().valid('inline', 'block').required(),
   placeholder: htmlNotAllowedSchema.allow('').required(),
   ariaLabel: htmlNotAllowedSchema.required(),
-  defaultValue: Joi.string().valid('').required().messages({
-    'any.only': '"defaultValue" must be an empty string when type is select, but you provided {#value}',
-  }),
   tolerances: Joi.array().empty().required(),
   options: Joi.array()
     .items(

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js
@@ -375,7 +375,6 @@ describe('Unit | Infrastructure | Datasources | Learning Content | Module Dataso
               display: 'inline',
               placeholder: '',
               ariaLabel: "Remplir avec le caractère qui permet de séparer les deux parties d'une adresse mail",
-              defaultValue: '',
               tolerances: ['t1'],
               solutions: ['@'],
             },
@@ -389,7 +388,6 @@ describe('Unit | Infrastructure | Datasources | Learning Content | Module Dataso
               display: 'block',
               placeholder: '',
               ariaLabel: "Choisir l'adjectif le plus adapté",
-              defaultValue: '',
               tolerances: [],
               options: [
                 {
@@ -621,7 +619,6 @@ describe('Unit | Infrastructure | Datasources | Learning Content | Module Dataso
         display: 'inline',
         placeholder: '<br> hello',
         ariaLabel: "Remplir avec le <span>caractère</span> qui permet de séparer les deux parties d'une adresse mail",
-        defaultValue: '<div>cassé</div>',
         tolerances: ['t1'],
         solutions: ['@'],
       };
@@ -630,7 +627,6 @@ describe('Unit | Infrastructure | Datasources | Learning Content | Module Dataso
         '"input" failed custom validation because HTML is not allowed in this field',
         '"placeholder" failed custom validation because HTML is not allowed in this field',
         '"ariaLabel" failed custom validation because HTML is not allowed in this field',
-        '"defaultValue" failed custom validation because HTML is not allowed in this field',
       ];
 
       try {
@@ -651,7 +647,6 @@ describe('Unit | Infrastructure | Datasources | Learning Content | Module Dataso
         display: 'block',
         placeholder: '<br> hello',
         ariaLabel: "Remplir avec le <span>caractère</span> qui permet de séparer les deux parties d'une adresse mail",
-        defaultValue: '-Sélectionner-',
         tolerances: [],
         options: [
           {
@@ -666,7 +661,6 @@ describe('Unit | Infrastructure | Datasources | Learning Content | Module Dataso
         '"input" failed custom validation because HTML is not allowed in this field',
         '"placeholder" failed custom validation because HTML is not allowed in this field',
         '"ariaLabel" failed custom validation because HTML is not allowed in this field',
-        '"defaultValue" must be an empty string when type is select, but you provided -Sélectionner-',
         '"options[0].content" failed custom validation because HTML is not allowed in this field',
       ];
 

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
@@ -329,7 +329,6 @@ function getComponents() {
         display: 'inline',
         placeholder: '',
         ariaLabel: 'Adresse mail de Naomi',
-        defaultValue: '',
         tolerances: [],
         solutions: ['naomizao@yahoo.com', 'naomizao@yahoo.fr'],
       }),
@@ -338,7 +337,6 @@ function getComponents() {
         display: 'inline',
         placeholder: '',
         ariaLabel: 'Réponse 3',
-        defaultValue: '',
         tolerances: [],
         options: [
           new BlockSelectOption({
@@ -503,7 +501,6 @@ function getAttributesComponents() {
       },
       {
         ariaLabel: 'Adresse mail de Naomi',
-        defaultValue: '',
         display: 'inline',
         input: 'email',
         inputType: 'text',
@@ -515,7 +512,6 @@ function getAttributesComponents() {
       },
       {
         ariaLabel: 'Réponse 3',
-        defaultValue: '',
         display: 'inline',
         input: 'seconde-partie',
         options: [

--- a/mon-pix/app/components/module/element/qrocm.gjs
+++ b/mon-pix/app/components/module/element/qrocm.gjs
@@ -26,12 +26,6 @@ export default class ModuleQrocm extends ModuleElement {
 
   constructor() {
     super(...arguments);
-
-    this.element.proposals.forEach((proposal) => {
-      if (proposal.defaultValue) {
-        this.selectedValues[proposal.input] = proposal.defaultValue;
-      }
-    });
   }
 
   get correction() {

--- a/mon-pix/tests/acceptance/module/retry-qrocm_test.js
+++ b/mon-pix/tests/acceptance/module/retry-qrocm_test.js
@@ -25,7 +25,6 @@ module('Acceptance | Module | Routes | retryQrocm', function (hooks) {
           display: 'block',
           placeholder: '',
           ariaLabel: 'Réponse 1',
-          defaultValue: '',
           options: [
             {
               id: '1',
@@ -150,7 +149,6 @@ module('Acceptance | Module | Routes | retryQrocm', function (hooks) {
           display: 'block',
           placeholder: '',
           ariaLabel: 'Réponse 1',
-          defaultValue: '',
           solutions: ['@'],
         },
         {
@@ -159,7 +157,6 @@ module('Acceptance | Module | Routes | retryQrocm', function (hooks) {
           display: 'block',
           placeholder: '',
           ariaLabel: 'Réponse 2',
-          defaultValue: '',
           options: [
             {
               id: '1',

--- a/mon-pix/tests/integration/components/module/component/element_test.gjs
+++ b/mon-pix/tests/integration/components/module/component/element_test.gjs
@@ -340,7 +340,6 @@ module('Integration | Component | Module | Element', function (hooks) {
           size: 1,
           placeholder: '',
           ariaLabel: 'input-aria',
-          defaultValue: '',
           type: 'input',
         },
         {
@@ -349,7 +348,6 @@ module('Integration | Component | Module | Element', function (hooks) {
           display: 'inline',
           placeholder: '',
           ariaLabel: 'select-aria',
-          defaultValue: '',
           options: [
             {
               id: '1',

--- a/mon-pix/tests/integration/components/module/grain_test.gjs
+++ b/mon-pix/tests/integration/components/module/grain_test.gjs
@@ -230,7 +230,6 @@ module('Integration | Component | Module | Grain', function (hooks) {
               display: 'inline',
               placeholder: '',
               ariaLabel: 'Réponse 1',
-              defaultValue: '',
             },
             {
               input: 'premiere-partie',
@@ -238,7 +237,6 @@ module('Integration | Component | Module | Grain', function (hooks) {
               display: 'inline',
               placeholder: '',
               ariaLabel: 'Réponse 2',
-              defaultValue: '',
               options: [
                 {
                   id: '1',
@@ -644,7 +642,8 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
           // when
           const screen = await render(hbs`
-            <Module::Grain::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}} @onElementAnswer={{this.onElementAnswer}} @passage={{this.passage}} />`);
+            <Module::Grain::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}}
+                                  @onElementAnswer={{this.onElementAnswer}} @passage={{this.passage}} />`);
           await click(screen.getByLabelText('checkbox1'));
           await click(screen.getByLabelText('checkbox2'));
           const verifyButton = screen.getByRole('button', { name: 'Vérifier ma réponse' });
@@ -720,7 +719,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
       await render(
         hbs`
           <Module::Grain::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}}
-                         @onGrainContinue={{this.onGrainContinue}} />`,
+                                @onGrainContinue={{this.onGrainContinue}} />`,
       );
       await clickByName('Continuer');
 
@@ -807,8 +806,9 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
       // when
       const screen = await render(hbs`
-        <Module::Grain::Grain @grain={{this.grain}} @onElementAnswer={{this.onElementAnswer}} @onElementRetry={{this.onElementRetry}} @canMoveToNextGrain={{true}}
-                       @passage={{this.passage}} />`);
+        <Module::Grain::Grain @grain={{this.grain}} @onElementAnswer={{this.onElementAnswer}}
+                              @onElementRetry={{this.onElementRetry}} @canMoveToNextGrain={{true}}
+                              @passage={{this.passage}} />`);
       await click(screen.getByLabelText('I am the wrong answer!'));
       const verifyButton = screen.getByRole('button', { name: 'Vérifier ma réponse' });
       await click(verifyButton);
@@ -1006,7 +1006,9 @@ module('Integration | Component | Module | Grain', function (hooks) {
             ],
           },
         ];
+
         function getLastCorrectionForElementStub() {}
+
         const onElementAnswerStub = sinon.stub();
         const passageEventService = this.owner.lookup('service:passage-events');
         sinon.stub(passageEventService, 'record');
@@ -1027,7 +1029,8 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
         // when
         await render(hbs`
-          <Module::Grain::Grain @grain={{this.grain}} @passage={{this.passage}} @onElementAnswer={{this.onElementAnswer}} />`);
+          <Module::Grain::Grain @grain={{this.grain}} @passage={{this.passage}}
+                                @onElementAnswer={{this.onElementAnswer}} />`);
 
         // then
         await clickByName('radio1');
@@ -1100,7 +1103,8 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
         // when
         const screen = await render(hbs`
-          <Module::Grain::Grain @grain={{this.grain}} @passage={{this.passage}} @onElementAnswer={{this.onElementAnswer}} @onElementRetry={{this.onElementRetry}} />`);
+          <Module::Grain::Grain @grain={{this.grain}} @passage={{this.passage}}
+                                @onElementAnswer={{this.onElementAnswer}} @onElementRetry={{this.onElementRetry}} />`);
 
         // then
         await clickByName('radio1');
@@ -1159,7 +1163,8 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
           // when
           const screen = await render(hbs`
-          <Module::Grain::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}} @onElementRetry={{this.onElementRetry}}  />`);
+            <Module::Grain::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}}
+                                  @onElementRetry={{this.onElementRetry}}  />`);
 
           // then
           assert.dom(screen.getByRole('button', { name: t('pages.modulix.buttons.grain.skip') })).exists();
@@ -1208,7 +1213,8 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
           // when
           const screen = await render(hbs`
-          <Module::Grain::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}} @onElementRetry={{this.onElementRetry}}  />`);
+            <Module::Grain::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}}
+                                  @onElementRetry={{this.onElementRetry}}  />`);
 
           // then
           assert.dom(screen.queryByRole('button', { name: t('pages.modulix.buttons.grain.continue') })).doesNotExist();
@@ -1269,7 +1275,9 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
           // when
           const screen = await render(hbs`
-          <Module::Grain::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}} @onElementRetry={{this.onElementRetry}} @onStepperNextStep={{this.onStepperNextStep}} />`);
+            <Module::Grain::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}}
+                                  @onElementRetry={{this.onElementRetry}}
+                                  @onStepperNextStep={{this.onStepperNextStep}} />`);
           await clickByName(t('pages.modulix.buttons.stepper.next.ariaLabel'));
 
           // then
@@ -1317,7 +1325,9 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
           // when
           const screen = await render(hbs`
-          <Module::Grain::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}} @onElementRetry={{this.onElementRetry}} @onStepperNextStep={{this.onStepperNextStep}} />`);
+            <Module::Grain::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}}
+                                  @onElementRetry={{this.onElementRetry}}
+                                  @onStepperNextStep={{this.onStepperNextStep}} />`);
           await clickByName(t('pages.modulix.buttons.stepper.next.ariaLabel'));
 
           // then
@@ -1435,7 +1445,9 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
             // when
             const screen = await render(hbs`
-          <Module::Grain::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}} @onElementRetry={{this.onElementRetry}} @onStepperNextStep={{this.onStepperNextStep}} />`);
+              <Module::Grain::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}}
+                                    @onElementRetry={{this.onElementRetry}}
+                                    @onStepperNextStep={{this.onStepperNextStep}} />`);
 
             // then
             assert
@@ -1488,7 +1500,9 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
               // when
               const screen = await render(hbs`
-            <Module::Grain::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}} @onElementRetry={{this.onElementRetry}} @onStepperNextStep={{this.onStepperNextStep}} />`);
+                <Module::Grain::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}}
+                                      @onElementRetry={{this.onElementRetry}}
+                                      @onStepperNextStep={{this.onStepperNextStep}} />`);
               await clickByName(t('pages.modulix.buttons.stepper.next.ariaLabel'));
 
               // then
@@ -1537,7 +1551,9 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
               // when
               const screen = await render(hbs`
-            <Module::Grain::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}} @onElementRetry={{this.onElementRetry}} @onStepperNextStep={{this.onStepperNextStep}} />`);
+                <Module::Grain::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}}
+                                      @onElementRetry={{this.onElementRetry}}
+                                      @onStepperNextStep={{this.onStepperNextStep}} />`);
               await clickByName(t('pages.modulix.buttons.stepper.next.ariaLabel'));
 
               // then
@@ -1608,7 +1624,8 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
             // when
             const screen = await render(hbs`
-          <Module::Grain::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}} @onElementRetry={{this.onElementRetry}}  />`);
+              <Module::Grain::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}}
+                                    @onElementRetry={{this.onElementRetry}}  />`);
 
             // then
             assert.dom(screen.getByRole('button', { name: t('pages.modulix.buttons.grain.skipActivity') })).exists();
@@ -1670,7 +1687,8 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
             // when
             const screen = await render(hbs`
-          <Module::Grain::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}} @onElementRetry={{this.onElementRetry}}  />`);
+              <Module::Grain::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}}
+                                    @onElementRetry={{this.onElementRetry}}  />`);
 
             // then
             assert
@@ -1748,7 +1766,9 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
               // when
               const screen = await render(hbs`
-                <Module::Grain::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}} @onElementRetry={{this.onElementRetry}} @onStepperNextStep={{this.onStepperNextStep}} />`);
+                <Module::Grain::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}}
+                                      @onElementRetry={{this.onElementRetry}}
+                                      @onStepperNextStep={{this.onStepperNextStep}} />`);
 
               await clickByName(t('pages.modulix.buttons.stepper.next.ariaLabel'));
 
@@ -1813,7 +1833,9 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
               // when
               const screen = await render(hbs`
-                <Module::Grain::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}} @onElementRetry={{this.onElementRetry}} @onStepperNextStep={{this.onStepperNextStep}} />`);
+                <Module::Grain::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}}
+                                      @onElementRetry={{this.onElementRetry}}
+                                      @onStepperNextStep={{this.onStepperNextStep}} />`);
 
               await clickByName(t('pages.modulix.buttons.stepper.next.ariaLabel'));
 
@@ -1894,7 +1916,9 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
           // when
           const screen = await render(hbs`
-          <Module::Grain::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}} @onElementRetry={{this.onElementRetry}} @onStepperNextStep={{this.onStepperNextStep}} />`);
+            <Module::Grain::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}}
+                                  @onElementRetry={{this.onElementRetry}}
+                                  @onStepperNextStep={{this.onStepperNextStep}} />`);
 
           // then
           assert.dom(screen.queryByRole('button', { name: t('pages.modulix.buttons.grain.continue') })).doesNotExist();
@@ -1920,7 +1944,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
       // when
       const screen = await render(hbs`
-          <Module::Grain::Grain @grain={{this.grain}} />`);
+        <Module::Grain::Grain @grain={{this.grain}} />`);
 
       // then
       assert.dom(screen.getByText('Activité')).exists();

--- a/mon-pix/tests/integration/components/module/qrocm_test.gjs
+++ b/mon-pix/tests/integration/components/module/qrocm_test.gjs
@@ -40,7 +40,6 @@ module('Integration | Component | Module | QROCM', function (hooks) {
           size: 1,
           placeholder: '',
           ariaLabel: 'input-aria',
-          defaultValue: '',
           type: 'input',
         },
         {
@@ -49,7 +48,6 @@ module('Integration | Component | Module | QROCM', function (hooks) {
           display: 'block',
           placeholder: '',
           ariaLabel: 'select-aria',
-          defaultValue: '',
           options: [
             {
               id: '1',
@@ -86,53 +84,6 @@ module('Integration | Component | Module | QROCM', function (hooks) {
     assert.dom('.element-qrocm-proposals__input--block').exists({ count: 2 });
   });
 
-  test('should display a block QROCM with a default value', async function (assert) {
-    // given
-    const qrocm = {
-      id: '994b6a96-a3c2-47ae-a461-87548ac6e02b',
-      instruction: 'Mon instruction',
-      proposals: [
-        { content: '<span>Ma première proposition</span>', type: 'text' },
-        {
-          input: 'symbole',
-          inputType: 'text',
-          display: 'inline',
-          size: 1,
-          placeholder: '',
-          ariaLabel: 'input-aria',
-          defaultValue: 'tadaaa',
-          type: 'input',
-        },
-        {
-          input: 'deuxieme-partie',
-          type: 'select',
-          display: 'block',
-          placeholder: '',
-          ariaLabel: 'select-aria',
-          defaultValue: '1',
-          options: [
-            {
-              id: '1',
-              content: 'totoro',
-            },
-            {
-              id: '2',
-              content: 'taratata',
-            },
-          ],
-        },
-      ],
-      type: 'qrocm',
-    };
-    const screen = await render(<template><ModuleQrocm @element={{qrocm}} /></template>);
-
-    // then
-    const inputContent = screen.getByRole('textbox');
-    const buttonContent = find('.pix-select-button__text');
-    assert.dom(inputContent).hasValue('tadaaa');
-    assert.dom(buttonContent).hasText('totoro');
-  });
-
   test('should display an inline QROCM', async function (assert) {
     // given
     const qrocm = {
@@ -147,7 +98,6 @@ module('Integration | Component | Module | QROCM', function (hooks) {
           size: 1,
           placeholder: '',
           ariaLabel: 'input-aria',
-          defaultValue: '',
           type: 'input',
         },
         {
@@ -156,7 +106,6 @@ module('Integration | Component | Module | QROCM', function (hooks) {
           display: 'inline',
           placeholder: '',
           ariaLabel: 'select-aria',
-          defaultValue: '',
           options: [
             {
               id: '1',
@@ -201,7 +150,6 @@ module('Integration | Component | Module | QROCM', function (hooks) {
           display: 'block',
           placeholder: '',
           ariaLabel: 'select-aria',
-          defaultValue: '',
           options: [
             {
               id: '1',
@@ -282,7 +230,6 @@ module('Integration | Component | Module | QROCM', function (hooks) {
             display: 'block',
             placeholder: '',
             ariaLabel: 'Réponse 1',
-            defaultValue: '',
             solutions: ['Réponse 1'],
           },
         ],
@@ -446,7 +393,6 @@ module('Integration | Component | Module | QROCM', function (hooks) {
           size: 1,
           placeholder: '',
           ariaLabel: 'input-aria',
-          defaultValue: '',
           type: 'input',
         },
       ],
@@ -501,6 +447,7 @@ module('Integration | Component | Module | QROCM', function (hooks) {
       class PreviewModeServiceStub extends Service {
         isEnabled = true;
       }
+
       this.owner.register('service:modulixPreviewMode', PreviewModeServiceStub);
       const qrocm = prepareQrocm();
 
@@ -531,7 +478,6 @@ module('Integration | Component | Module | QROCM', function (hooks) {
               display: 'block',
               placeholder: '',
               ariaLabel: 'Réponse 1',
-              defaultValue: '',
               solutions: ['Réponse 1'],
             },
           ],
@@ -586,7 +532,6 @@ function prepareQrocm() {
         display: 'block',
         placeholder: '',
         ariaLabel: 'select-aria',
-        defaultValue: '',
         options: [
           {
             id: '1',


### PR DESCRIPTION
## ❄️ Problème
Les propriétés defaultValue les input et select des QROCM ne sont pas utilisées. Pire encore, elles créent une confusion car elles sont confondues avec les placeholder. Et encore plus pire encore, elles créent des bugs si elles sont remplies dans le cas des select.

## 🛷 Proposition
On 🔥 tout

## ☃️ Remarques
C'est toujours un plaisir de virer du code

## 🧑‍🎄 Pour tester
tester quelques modules et voir que tout va bien lors de l'intéraction avec les QROCM: 
- [pâtes à l'ail](https://app-pr14816.review.pix.fr/modules/ia-def-ind)
- [cyber-antivirus](https://app-pr14816.review.pix.fr/modules/cyber-antivirus)
- [adresse-ip-publique-et-vous](https://app-pr14816.review.pix.fr/modules/adresse-ip-publique-et-vous)
- tous les autres modules modifiés si le coeur vous en dit

Dans tous les cas la validation des json est dans un test auto, donc on est couverts ✅ 
