### PR TITLE
[FEATURE] MDX-11 #IAGen_Impact_NOV Changer "finlandais" en "suédois" dans qcu-stepper découverte

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenImpact_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenImpact_NOV.json
@@ -856,7 +856,7 @@
                     {
                       "id": "8e89075a-83e7-4c13-8673-8573438c65c3",
                       "type": "qcu-discovery",
-                      "instruction": "<p>Résume en français un document en finlandais de 25 pages.</p>",
+                      "instruction": "<p>Résume en français un document en suédois de 25 pages.</p>",
                       "proposals": [
                         {
                           "id": "1",


### PR DESCRIPTION
## ❄️ Problème

Le module utilisait le mot "finlandais" pour désigner la langue, alors qu'on utilise plutôt le terme "finnois" (même si les deux sont acceptés par l'académie française). Donc problème insoluble :
- "finlandais" : plus facile à comprendre, mais moins juste
- "finnois" : moins facile à comprendre

## 🛷 Proposition

Remplacer par "suédois".

## ☃️ Remarques

## 🧑‍🎄 Pour tester

https://app-pr14818.review.pix.fr/modules/preview/les-ia-generatives-consomment
