### PR TITLE
[BUMP] @1024pix/epreuves-components 2.6.0

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -79,7 +79,7 @@
         "yargs": "^18.0.0"
       },
       "devDependencies": {
-        "@1024pix/epreuves-components": "^2.5.1",
+        "@1024pix/epreuves-components": "^2.6.0",
         "@1024pix/eslint-plugin": "^2.1.17",
         "@eslint/compat": "^2.0.1",
         "@ls-lint/ls-lint": "^2.3.1",
@@ -117,9 +117,9 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-2.5.1.tgz",
-      "integrity": "sha512-slVMNFriZ9FLiazRpGCG1lgP2M6AUZnj/4URQZ6jx8j2UNqSGFmxIqiqFddCYlJvnvXQqSIKMoOdNLihyechPg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-2.6.0.tgz",
+      "integrity": "sha512-2P6Co2MQ7ImUHMzJK6DdbyZjuWF4Vs+5Tq5IC2aK8Mgv9GnQTsUVllAkUH5VQkLVtRQ0PLMHcc+SgBvwp6X2ww==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {

--- a/api/package.json
+++ b/api/package.json
@@ -85,7 +85,7 @@
     "yargs": "^18.0.0"
   },
   "devDependencies": {
-    "@1024pix/epreuves-components": "^2.5.1",
+    "@1024pix/epreuves-components": "^2.6.0",
     "@1024pix/eslint-plugin": "^2.1.17",
     "@eslint/compat": "^2.0.1",
     "@ls-lint/ls-lint": "^2.3.1",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYPhishing_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYPhishing_NOV.json
@@ -408,43 +408,7 @@
                 "type": "custom",
                 "instruction": "",
                 "tagName": "phishing-message",
-                "props": {
-                  "titleLevel": 0,
-                  "messages": [
-                    {
-                      "senderName": " Info ANTAI",
-                      "content": "Amende impayée de 35€.  Consultez votre dossier ANTAI avant majoration via : dossier-amende-gouv.antai",
-                      "title": "Retard de paiement : ",
-                      "goodFeelings": [
-                        "fear",
-                        "emergency"
-                      ],
-                      "victory": "Effectivement, avec ce message, l’escroc veut que vous ressentiez de la peur et un sentiment d’urgence. ",
-                      "loose": "En réalité, avec ce message, l’escroc veut que vous ressentiez de la peur et un sentiment d’urgence. "
-                    },
-                    {
-                      "senderName": "IMPOT",
-                      "content": "Vous avez un remboursement disponible de 826€.  Référence 125489 : accédez à votre formulaire de remboursement impot.gouv-remboursement.nt",
-                      "title": "Remboursement disponible :",
-                      "goodFeelings": [
-                        "hope"
-                      ],
-                      "victory": "Effectivement, avec ce message, l’escroc veut que vous ressentiez de l’espoir : recevoir une somme d’argent inattendue. ",
-                      "loose": "En réalité, avec ce message, l’escroc veut que vous ressentiez de l’espoir : recevoir une somme d’argent inattendue. "
-                    },
-                    {
-                      "senderName": " +33789542312",
-                      "content": "Salut, c'est ta cousine, j'ai besoin de ton aide, je suis coincée à l'étranger et j'ai perdu mes papiers.  Pour pouvoir rentrer, j'ai besoin que tu m'envoies 300€ ici : dT23.bitly.com Il n'y a que toi qui peut m'aider !",
-                      "title": "Un service à te demander",
-                      "goodFeelings": [
-                        "fear",
-                        "emergency"
-                      ],
-                      "victory": "Effectivement, avec ce message, l’escroc veut que vous ressentiez un sentiment de peur et d’urgence pour cette cousine bloquée à l’étranger. ",
-                      "loose": "En réalité avec ce message, l’escroc veut que vous ressentiez un sentiment d’urgence et de peur pour cette cousine bloquée à l’étranger. "
-                    }
-                  ]
-                }
+                "props": {}
               }
             }
           ]

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-epreuves-components.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-epreuves-components.json
@@ -962,34 +962,7 @@
                 "type": "custom",
                 "instruction": "",
                 "tagName": "phishing-message",
-                "props": {
-                  "messages": [
-                    {
-                      "senderName": "info ANTAI",
-                      "content": "Hello, la forme ? Tu as fais une petite infraction. \n Peux-tu me donner un peu d'argent pour que je t'oublie ?",
-                      "title": "Retard de paiement : ",
-                      "goodFeelings": ["fear", "emergency"],
-                      "victory": "Effectivement, avec ce message, l’escroc veut que le lecteur ressente de la peur et un sentiment d’urgence.",
-                      "loose": "Eh non ! Avec ce message, l’escroc veut que vous ressentiez de la peur et un sentiment d’urgence."
-                    },
-                    {
-                      "senderName": "info ANTAI 2",
-                      "content": "Azy donne ta thune, là ! TOUSUITE !",
-                      "title": "Retard de paiement : ",
-                      "goodFeelings": ["hope"],
-                      "victory": "Effectivement, avec ce message, l’escroc veut que vous ressentiez de l’espoir : recevoir une somme d’argent inattendue.",
-                      "loose": "Eh non ! Avec ce message, l’escroc veut que vous ressentiez de l’espoir : recevoir une somme d’argent inattendue."
-                    },
-                    {
-                      "senderName": "info ANTAI 3",
-                      "content": "Azy re-donne ta thune, là ! TOUSUITE !",
-                      "title": "Retard de paiement : ",
-                      "goodFeelings": ["fear", "emergency"],
-                      "victory": "Effectivement, avec ce message, l’escroc veut que vous ressentiez un sentiment d’urgence et de peur pour cette cousine bloquée à l’étranger.",
-                      "loose": " Eh non, avec ce message, l’escroc veut que vous ressentiez un sentiment d’urgence et de peur pour cette cousine bloquée à l’étranger."
-                    }
-                  ]
-                }
+                "props": {}
               }
             }
           ]

--- a/junior/package-lock.json
+++ b/junior/package-lock.json
@@ -11,7 +11,7 @@
       "license": "AGPL-3.0",
       "devDependencies": {
         "@1024pix/ember-testing-library": "^3.0.27",
-        "@1024pix/epreuves-components": "^2.5.1",
+        "@1024pix/epreuves-components": "^2.6.0",
         "@1024pix/eslint-plugin": "^2.1.17",
         "@1024pix/pix-ui": "^55.34.0",
         "@1024pix/stylelint-config": "^5.1.37",
@@ -180,9 +180,9 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-2.5.1.tgz",
-      "integrity": "sha512-slVMNFriZ9FLiazRpGCG1lgP2M6AUZnj/4URQZ6jx8j2UNqSGFmxIqiqFddCYlJvnvXQqSIKMoOdNLihyechPg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-2.6.0.tgz",
+      "integrity": "sha512-2P6Co2MQ7ImUHMzJK6DdbyZjuWF4Vs+5Tq5IC2aK8Mgv9GnQTsUVllAkUH5VQkLVtRQ0PLMHcc+SgBvwp6X2ww==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {

--- a/junior/package.json
+++ b/junior/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^3.0.27",
-    "@1024pix/epreuves-components": "^2.5.1",
+    "@1024pix/epreuves-components": "^2.6.0",
     "@1024pix/eslint-plugin": "^2.1.17",
     "@1024pix/pix-ui": "^55.34.0",
     "@1024pix/stylelint-config": "^5.1.37",

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -12,7 +12,7 @@
       "devDependencies": {
         "@1024pix/ember-api-actions": "^1.1.0",
         "@1024pix/ember-testing-library": "^3.0.27",
-        "@1024pix/epreuves-components": "^2.5.1",
+        "@1024pix/epreuves-components": "^2.6.0",
         "@1024pix/eslint-plugin": "^2.1.17",
         "@1024pix/pix-ui": "^56.1.0",
         "@1024pix/stylelint-config": "^5.1.37",
@@ -819,9 +819,9 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-2.5.1.tgz",
-      "integrity": "sha512-slVMNFriZ9FLiazRpGCG1lgP2M6AUZnj/4URQZ6jx8j2UNqSGFmxIqiqFddCYlJvnvXQqSIKMoOdNLihyechPg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-2.6.0.tgz",
+      "integrity": "sha512-2P6Co2MQ7ImUHMzJK6DdbyZjuWF4Vs+5Tq5IC2aK8Mgv9GnQTsUVllAkUH5VQkLVtRQ0PLMHcc+SgBvwp6X2ww==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@1024pix/ember-api-actions": "^1.1.0",
     "@1024pix/ember-testing-library": "^3.0.27",
-    "@1024pix/epreuves-components": "^2.5.1",
+    "@1024pix/epreuves-components": "^2.6.0",
     "@1024pix/eslint-plugin": "^2.1.17",
     "@1024pix/pix-ui": "^56.1.0",
     "@1024pix/stylelint-config": "^5.1.37",


### PR DESCRIPTION
## ❄️ Problème

Une mise à jour de @1024pix/epreuves-components est dispo.

## 🛷 Proposition

Installer la màj.

## ☃️ Remarques

N/A

## 🧑‍🎄 Pour tester

Aller sur le module demo-epreuves-components pour vérifier que tout est OK.