### PR TITLE
[FEATURE] Permettre de faire évoluer le fichier d'import des apprenants en conservant l'historique (PIX-20989).

### DIFF
--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -166,7 +166,7 @@
         "upload-button": "Import JSON file"
       },
       "organization-import-format": {
-        "description": "Only existing format imports will be updated. If the name does not match, no format import will be created.",
+        "description": "Insert new import format. It will update existing import format with same name.",
         "notifications": {
           "success": "Format imports are updated correctly"
         },

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -167,7 +167,7 @@
         "upload-button": "Importer un fichier JSON"
       },
       "organization-import-format": {
-        "description": "Seul les imports à format existants seront mis à jour. Dans le cas où le nom ne correspond pas, il n'y aura pas de création d'import à format.",
+        "description": "Créer un nouvel import à format. Si un format du même nom existe il sera mis à jour.",
         "notifications": {
           "success": "Les imports à formats sont bien mis à jour"
         },

--- a/api/db/seeds/data/common/organization-learner-import-formats.js
+++ b/api/db/seeds/data/common/organization-learner-import-formats.js
@@ -165,4 +165,76 @@ export const organizationLearnerImportFormat = async function ({ databaseBuilder
     createdAt: new Date('2024-01-01'),
     createdBy: REAL_PIX_SUPER_ADMIN_ID,
   });
+
+  await databaseBuilder.factory.buildOrganizationLearnerImportFormat({
+    name: 'GENERIC_V2',
+    fileType: 'csv',
+    config: {
+      acceptedEncoding: ['utf8'],
+      unicityColumns: ['Nom apprenant', 'Prénom apprenant', 'Date de naissance'],
+      headers: [
+        {
+          name: 'Nom apprenant',
+          required: true,
+          config: {
+            property: 'lastName',
+            validate: { type: 'string', required: true },
+            reconcile: { fieldId: 'reconcileField1', name: IMPORT_KEY_FIELD.COMMON_LASTNAME, position: 1 },
+          },
+        },
+        {
+          name: 'Prénom apprenant',
+          required: true,
+          config: {
+            property: 'firstName',
+            validate: { type: 'string', required: true },
+            reconcile: {
+              fieldId: 'reconcileField2',
+              name: IMPORT_KEY_FIELD.COMMON_FIRSTNAME,
+              position: 2,
+            },
+          },
+        },
+        {
+          name: 'Divisions',
+          required: true,
+          config: {
+            exportable: true,
+            validate: { type: 'string', required: true },
+            mappingColumn: 'Classe',
+            mappingValues: {
+              Première: '1ère',
+              Deuxième: '2ème',
+              Troisième: '3ème',
+            },
+            displayable: {
+              position: 1,
+              name: IMPORT_KEY_FIELD.COMMON_DIVISION,
+              filterable: {
+                type: 'string',
+              },
+            },
+          },
+        },
+        {
+          name: 'Date de naissance',
+          required: true,
+          config: {
+            reconcile: {
+              fieldId: 'reconcileField3',
+              name: IMPORT_KEY_FIELD.COMMON_BIRTHDATE,
+              position: 3,
+            },
+            validate: { type: 'date', format: 'YYYY-MM-DD', required: true },
+            displayable: {
+              position: 2,
+              name: IMPORT_KEY_FIELD.COMMON_BIRTHDATE,
+            },
+          },
+        },
+      ],
+    },
+    createdAt: new Date('2025-01-01'),
+    createdBy: REAL_PIX_SUPER_ADMIN_ID,
+  });
 };

--- a/api/src/prescription/learner-management/application/organization-import-controller.js
+++ b/api/src/prescription/learner-management/application/organization-import-controller.js
@@ -1,4 +1,3 @@
-import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { usecases } from '../domain/usecases/index.js';
 import * as organizationImportDetailSerializer from '../infrastructure/serializers/jsonapi/organization-import-detail-serializer.js';
 
@@ -11,14 +10,13 @@ const getOrganizationImportStatus = async function (request, h, dependencies = {
   return h.response(dependencies.organizationImportDetailSerializer.serialize(organizationImportDetail)).code(200);
 };
 
-const updateOrganizationLearnerImportFormats = async function (request) {
-  await DomainTransaction.execute(async () => {
-    await usecases.updateOrganizationLearnerImportFormats({ payload: request.payload });
-  });
+const saveOrganizationLearnerImportFormats = async function (request) {
+  const authenticatedUserId = request.auth.credentials.userId;
+  await usecases.saveOrganizationLearnerImportFormats({ userId: authenticatedUserId, payload: request.payload });
 
   return null;
 };
 
-const organizationImportController = { getOrganizationImportStatus, updateOrganizationLearnerImportFormats };
+const organizationImportController = { getOrganizationImportStatus, saveOrganizationLearnerImportFormats };
 
 export { organizationImportController };

--- a/api/src/prescription/learner-management/application/organization-import-route.js
+++ b/api/src/prescription/learner-management/application/organization-import-route.js
@@ -70,10 +70,10 @@ const register = async (server) => {
             );
           },
         },
-        handler: organizationImportController.updateOrganizationLearnerImportFormats,
+        handler: organizationImportController.saveOrganizationLearnerImportFormats,
         notes: [
           "- **Cette route est restreinte aux utilisateurs authentifiés en tant qu'administrateur de l'organisation**\n" +
-            "- Elle permet de mettre à jour la liste des participants de l'organisation.",
+            "- Elle permet d'ajouter/modifier des imports à format.",
         ],
         tags: ['api', 'organization-learners'],
       },

--- a/api/src/prescription/learner-management/domain/models/ImportOrganizationLearnerSet.js
+++ b/api/src/prescription/learner-management/domain/models/ImportOrganizationLearnerSet.js
@@ -108,7 +108,11 @@ class ImportOrganizationLearnerSet {
       if (column.config?.property) {
         learnerAttributes[column.config.property] = value;
       } else {
-        learnerAttributes[column.name] = this.#formatLearnerAttribute({ attribute: value, columnName: column.name });
+        const columnName = column.config?.mappingColumn ?? column.name;
+        learnerAttributes[columnName] = this.#formatLearnerAttribute({
+          attribute: value,
+          columnName,
+        });
       }
     });
 

--- a/api/src/prescription/learner-management/domain/models/ImportOrganizationLearnerSet.js
+++ b/api/src/prescription/learner-management/domain/models/ImportOrganizationLearnerSet.js
@@ -104,7 +104,12 @@ class ImportOrganizationLearnerSet {
     const learnerAttributes = { organizationId: this.#organizationId };
 
     this.#columnMapping.forEach((column) => {
-      const value = learner[column.name];
+      let value = learner[column.name];
+
+      if (column.config?.mappingValues && column.config.mappingValues[value]) {
+        value = column.config.mappingValues[value];
+      }
+
       if (column.config?.property) {
         learnerAttributes[column.config.property] = value;
       } else {

--- a/api/src/prescription/learner-management/domain/models/OrganizationLearnerImportFormat.js
+++ b/api/src/prescription/learner-management/domain/models/OrganizationLearnerImportFormat.js
@@ -6,6 +6,8 @@ const organizationLearnerImportFormatSchame = Joi.object({
   name: Joi.string().required(),
   config: Joi.object().required(),
   fileType: Joi.string().valid('csv', 'xml'),
+  createdAt: Joi.date().required(),
+  createdBy: Joi.number().required(),
 });
 class OrganizationLearnerImportFormat {
   /**
@@ -13,11 +15,15 @@ class OrganizationLearnerImportFormat {
    * @param {string} data.name
    * @param {string} data.fileType
    * @param {Object} data.config
+   * @param {Object} data.createdAt
+   * @param {Object} data.createdBy
    */
-  constructor({ name, fileType, config } = {}) {
+  constructor({ name, fileType, config, createdAt, createdBy } = {}) {
     this.name = name;
     this.fileType = fileType;
     this.config = config;
+    this.createdAt = createdAt;
+    this.createdBy = createdBy;
 
     this.#validate();
   }

--- a/api/src/prescription/learner-management/domain/models/OrganizationLearnerImportFormat.js
+++ b/api/src/prescription/learner-management/domain/models/OrganizationLearnerImportFormat.js
@@ -80,24 +80,28 @@ class OrganizationLearnerImportFormat {
   }
 
   get columnsToDisplay() {
-    return this.orderedDisplayableColumns.map((column) => column.name);
+    return this.orderedDisplayableColumns.map((column) => column?.config?.mappingColumn ?? column.name);
   }
 
   get filtersToDisplay() {
-    return this.orderedFilterableColumns.map((column) => column.name);
+    return this.orderedFilterableColumns.map((column) => column?.config?.mappingColumn ?? column.name);
   }
 
   get extraColumns() {
     return this.#displayable.map((header) => {
+      const key = header.config.mappingColumn ?? header.name;
+
       return {
         name: header.config.displayable.name,
-        key: header.name,
+        key,
       };
     });
   }
 
   get exportableColumns() {
-    return this.config.headers.flatMap(({ name, config }) => (config?.exportable ? { columnName: name } : []));
+    return this.config.headers.flatMap(({ name, config }) =>
+      config?.exportable ? { columnName: config.mappingColumn ?? name } : [],
+    );
   }
 
   /**

--- a/api/src/prescription/learner-management/domain/usecases/index.js
+++ b/api/src/prescription/learner-management/domain/usecases/index.js
@@ -93,7 +93,7 @@ import { reconcileCommonOrganizationLearner } from './reconcile-common-organizat
 import { reconcileScoOrganizationLearnerAutomatically } from './reconcile-sco-organization-learner-automatically.js';
 import { reconcileScoOrganizationLearnerManually } from './reconcile-sco-organization-learner-manually.js';
 import { reconcileSupOrganizationLearner } from './reconcile-sup-organization-learner.js';
-import { updateOrganizationLearnerImportFormats } from './update-organization-learner-import-formats.js';
+import { saveOrganizationLearnerImportFormats } from './save-organization-learner-import-formats.js';
 import { updateOrganizationLearnerName } from './update-organization-learner-name.js';
 import { updateStudentNumber } from './update-student-number.js';
 import { uploadCsvFile } from './upload-csv-file.js';
@@ -123,7 +123,7 @@ const usecasesWithoutInjectedDependencies = {
   reconcileScoOrganizationLearnerAutomatically,
   reconcileScoOrganizationLearnerManually,
   reconcileSupOrganizationLearner,
-  updateOrganizationLearnerImportFormats,
+  saveOrganizationLearnerImportFormats,
   updateOrganizationLearnerName,
   updateStudentNumber,
   uploadCsvFile,

--- a/api/src/prescription/learner-management/domain/usecases/save-organization-learner-import-formats.js
+++ b/api/src/prescription/learner-management/domain/usecases/save-organization-learner-import-formats.js
@@ -1,5 +1,6 @@
 import { readFile } from 'node:fs/promises';
 
+import { withTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { EntityValidationError, FileValidationError } from '../../../../shared/domain/errors.js';
 import { OrganizationLearnerImportFormat } from '../models/OrganizationLearnerImportFormat.js';
 /**
@@ -8,7 +9,8 @@ import { OrganizationLearnerImportFormat } from '../models/OrganizationLearnerIm
  * @param {OrganizationLearnerImportFormatRepository} params.organizationLearnerImportFormatRepository
  * @returns {Promise<void>}
  */
-const updateOrganizationLearnerImportFormats = async function ({
+const saveOrganizationLearnerImportFormats = withTransaction(async function ({
+  userId,
   payload,
   organizationLearnerImportFormatRepository,
   dependencies = { readFile, jsonParse: JSON.parse },
@@ -24,7 +26,7 @@ const updateOrganizationLearnerImportFormats = async function ({
 
   const organizationLearnerImportFormats = rawImportFormats.flatMap((rawImportFormat) => {
     try {
-      return new OrganizationLearnerImportFormat(rawImportFormat);
+      return new OrganizationLearnerImportFormat({ ...rawImportFormat, createdAt: new Date(), createdBy: userId });
     } catch (error) {
       errors.push(error);
       return null;
@@ -35,7 +37,7 @@ const updateOrganizationLearnerImportFormats = async function ({
     throw EntityValidationError.fromMultipleEntityValidationErrors(errors);
   }
 
-  return organizationLearnerImportFormatRepository.updateAllByName({ organizationLearnerImportFormats });
-};
+  return organizationLearnerImportFormatRepository.save({ organizationLearnerImportFormats });
+});
 
-export { updateOrganizationLearnerImportFormats };
+export { saveOrganizationLearnerImportFormats };

--- a/api/src/prescription/learner-management/infrastructure/repositories/organization-learner-import-format-repository.js
+++ b/api/src/prescription/learner-management/infrastructure/repositories/organization-learner-import-format-repository.js
@@ -36,15 +36,16 @@ const get = async function (organizationId) {
  * @param {Array|Object} params.organizationLearnerImportFormats
  * @return {Promise<void>}
  */
-const updateAllByName = async function ({ organizationLearnerImportFormats }) {
+const save = async function ({ organizationLearnerImportFormats }) {
   const knexConn = DomainTransaction.getConnection();
   const updatedAt = new Date();
 
   for (const organizationLearnerImport of organizationLearnerImportFormats) {
     await knexConn('organization-learner-import-formats')
-      .where({ name: organizationLearnerImport.name })
-      .update({ fileType: organizationLearnerImport.fileType, config: organizationLearnerImport.config, updatedAt });
+      .insert({ ...organizationLearnerImport, updatedAt })
+      .onConflict('name')
+      .merge(['config', 'fileType', 'updatedAt']);
   }
 };
 
-export { get, updateAllByName };
+export { get, save };

--- a/api/tests/prescription/learner-management/integration/domain/usecases/save-organization-learner-import-formats_test.js
+++ b/api/tests/prescription/learner-management/integration/domain/usecases/save-organization-learner-import-formats_test.js
@@ -9,8 +9,11 @@ import { catchErr, databaseBuilder, expect, knex } from '../../../../../test-hel
 // Get __dirname in ESM
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
 
-describe('Integration | Organizational Entities | Domain | UseCase | update-organization-learner-import-formats', function () {
+describe('Integration | Organizational Entities | Domain | UseCase | save-organization-learner-import-formats', function () {
+  let userId;
+
   beforeEach(function () {
+    userId = databaseBuilder.factory.buildUser().id;
     databaseBuilder.factory.buildOrganizationLearnerImportFormat({
       name: 'FIRST_FORMAT',
       fileType: 'xml',
@@ -31,7 +34,8 @@ describe('Integration | Organizational Entities | Domain | UseCase | update-orga
       // given
       const payload = fs.createReadStream(path.join(__dirname, 'test-file/import-format-file', 'ok.json'));
       // when
-      await usecases.updateOrganizationLearnerImportFormats({
+      await usecases.saveOrganizationLearnerImportFormats({
+        userId,
         payload,
       });
 
@@ -48,7 +52,8 @@ describe('Integration | Organizational Entities | Domain | UseCase | update-orga
       // given && when
       const payload = fs.createReadStream(path.join(__dirname, 'test-file/import-format-file', 'ko.json'));
 
-      const error = await catchErr(usecases.updateOrganizationLearnerImportFormats)({
+      const error = await catchErr(usecases.saveOrganizationLearnerImportFormats)({
+        userId,
         payload,
       });
 
@@ -74,7 +79,8 @@ describe('Integration | Organizational Entities | Domain | UseCase | update-orga
       // given && when
       const payload = fs.createReadStream(path.join(__dirname, 'test-file/import-format-file', 'not-a-json.json'));
 
-      const error = await catchErr(usecases.updateOrganizationLearnerImportFormats)({
+      const error = await catchErr(usecases.saveOrganizationLearnerImportFormats)({
+        userId,
         payload,
       });
 

--- a/api/tests/prescription/learner-management/unit/application/organization-import-controller_test.js
+++ b/api/tests/prescription/learner-management/unit/application/organization-import-controller_test.js
@@ -1,6 +1,5 @@
 import { organizationImportController } from '../../../../../src/prescription/learner-management/application/organization-import-controller.js';
 import { usecases } from '../../../../../src/prescription/learner-management/domain/usecases/index.js';
-import { DomainTransaction } from '../../../../../src/shared/domain/DomainTransaction.js';
 import { expect, hFake, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Application | Learner Management | organization-import-controller', function () {
@@ -30,20 +29,21 @@ describe('Unit | Application | Learner Management | organization-import-controll
     });
   });
 
-  describe('#updateOrganizationLearnerImportFormats', function () {
-    let request, payload;
+  describe('#saveOrganizationLearnerImportFormats', function () {
+    let request, payload, userId;
 
     beforeEach(function () {
       payload = Symbol('Payload');
+      userId = Symbol('userId');
       request = {
+        auth: {
+          credentials: { userId },
+        },
         payload,
       };
 
-      sinon.stub(DomainTransaction, 'execute');
-      DomainTransaction.execute.callsFake((callback) => callback());
-
-      sinon.stub(usecases, 'updateOrganizationLearnerImportFormats');
-      usecases.updateOrganizationLearnerImportFormats.resolves(null);
+      sinon.stub(usecases, 'saveOrganizationLearnerImportFormats');
+      usecases.saveOrganizationLearnerImportFormats.resolves(null);
     });
 
     afterEach(function () {
@@ -51,8 +51,9 @@ describe('Unit | Application | Learner Management | organization-import-controll
     });
 
     it('should update organization import format', async function () {
-      await organizationImportController.updateOrganizationLearnerImportFormats(request);
-      expect(usecases.updateOrganizationLearnerImportFormats).to.have.been.calledOnceWithExactly({
+      await organizationImportController.saveOrganizationLearnerImportFormats(request);
+      expect(usecases.saveOrganizationLearnerImportFormats).to.have.been.calledOnceWithExactly({
+        userId,
         payload,
       });
     });

--- a/api/tests/prescription/learner-management/unit/application/organization-import-route_test.js
+++ b/api/tests/prescription/learner-management/unit/application/organization-import-route_test.js
@@ -187,15 +187,15 @@ describe('Unit | Router | organization-import-router', function () {
   });
 
   describe('POST /api/admin/import-organization-learners-format', function () {
-    let hasAtLeastOneAccessOfStub, updateOrganizationLearnerImportFormatsStub;
+    let hasAtLeastOneAccessOfStub, saveOrganizationLearnerImportFormatsStub;
 
     beforeEach(function () {
       hasAtLeastOneAccessOfStub = sinon
         .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
         .withArgs([securityPreHandlers.checkAdminMemberHasRoleSuperAdmin]);
 
-      updateOrganizationLearnerImportFormatsStub = sinon
-        .stub(organizationImportController, 'updateOrganizationLearnerImportFormats')
+      saveOrganizationLearnerImportFormatsStub = sinon
+        .stub(organizationImportController, 'saveOrganizationLearnerImportFormats')
         .resolves(null);
     });
 
@@ -215,7 +215,7 @@ describe('Unit | Router | organization-import-router', function () {
 
       await httpTestServer.request(method, url);
 
-      expect(updateOrganizationLearnerImportFormatsStub.notCalled).to.be.true;
+      expect(saveOrganizationLearnerImportFormatsStub.notCalled).to.be.true;
     });
 
     it('should called controller when user is super admin', async function () {
@@ -228,7 +228,7 @@ describe('Unit | Router | organization-import-router', function () {
 
       await httpTestServer.request(method, url);
 
-      expect(updateOrganizationLearnerImportFormatsStub.called).to.be.true;
+      expect(saveOrganizationLearnerImportFormatsStub.called).to.be.true;
     });
   });
 });

--- a/api/tests/prescription/learner-management/unit/domain/models/ImportOrganizationLearnerSet_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/models/ImportOrganizationLearnerSet_test.js
@@ -83,7 +83,7 @@ describe('Unit | Models | ImportOrganizationLearnerSet', function () {
               },
               {
                 name: 'category',
-                config: { mappingColumn: 'group' },
+                config: { mappingColumn: 'group', mappingValues: { Solo: 'PreviousMappedValue_SOLO' } },
               },
               {
                 name: 'TonNomCommun',
@@ -114,7 +114,7 @@ describe('Unit | Models | ImportOrganizationLearnerSet', function () {
             lastName: 'Katana',
             organizationId,
             "nom d'usage": 'Yolo',
-            group: 'Solo',
+            group: 'PreviousMappedValue_SOLO',
           }),
         ]);
       });
@@ -159,7 +159,7 @@ describe('Unit | Models | ImportOrganizationLearnerSet', function () {
         expect(learners.list).lengthOf(1);
       });
 
-      it('map new learner into previous config', function () {
+      it('updates existing learner into previous config', function () {
         const importFormat = {
           config: {
             unicityColumns: ['prénom'],
@@ -174,7 +174,7 @@ describe('Unit | Models | ImportOrganizationLearnerSet', function () {
               },
               {
                 name: 'category',
-                config: { mappingColumn: 'group' },
+                config: { mappingColumn: 'group', mappingValues: { Solo: 'PreviousMappedValue_SOLO' } },
               },
               {
                 name: 'TonNomCommun',

--- a/api/tests/prescription/learner-management/unit/domain/models/ImportOrganizationLearnerSet_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/models/ImportOrganizationLearnerSet_test.js
@@ -68,6 +68,57 @@ describe('Unit | Models | ImportOrganizationLearnerSet', function () {
         ]);
       });
 
+      it('should add a learner with previous configuration', function () {
+        const importFormat = {
+          config: {
+            unicityColumns: ['prénom'],
+            headers: [
+              {
+                name: 'prénom',
+                config: { property: 'firstName' },
+              },
+              {
+                name: 'nom',
+                config: { property: 'lastName' },
+              },
+              {
+                name: 'category',
+                config: { mappingColumn: 'group' },
+              },
+              {
+                name: 'TonNomCommun',
+                config: { mappingColumn: "nom d'usage" },
+              },
+            ],
+          },
+        };
+
+        const learnerSet = ImportOrganizationLearnerSet.buildSet({ organizationId, importFormat });
+
+        const newLearnerAttributes = {
+          prénom: 'Tomie',
+          nom: 'Katana',
+          TonNomCommun: 'Yolo',
+          category: 'Solo',
+        };
+
+        learnerSet.addLearners([newLearnerAttributes]);
+
+        const learners = learnerSet.learners;
+
+        expect(learners.list).to.lengthOf(1);
+        expect(learners.list[0]).to.be.an.instanceOf(CommonOrganizationLearner);
+        expect(learners.list).to.deep.equal([
+          new CommonOrganizationLearner({
+            firstName: 'Tomie',
+            lastName: 'Katana',
+            organizationId,
+            "nom d'usage": 'Yolo',
+            group: 'Solo',
+          }),
+        ]);
+      });
+
       it('should return multiple learners', function () {
         const learnerSet = ImportOrganizationLearnerSet.buildSet({ organizationId, importFormat });
 
@@ -106,6 +157,71 @@ describe('Unit | Models | ImportOrganizationLearnerSet', function () {
         const learners = learnerSet.learners;
 
         expect(learners.list).lengthOf(1);
+      });
+
+      it('map new learner into previous config', function () {
+        const importFormat = {
+          config: {
+            unicityColumns: ['prénom'],
+            headers: [
+              {
+                name: 'prénom',
+                config: { property: 'firstName' },
+              },
+              {
+                name: 'nom',
+                config: { property: 'lastName' },
+              },
+              {
+                name: 'category',
+                config: { mappingColumn: 'group' },
+              },
+              {
+                name: 'TonNomCommun',
+                config: { mappingColumn: "nom d'usage" },
+              },
+            ],
+          },
+        };
+
+        const learnerSet = ImportOrganizationLearnerSet.buildSet({ organizationId, importFormat });
+
+        const newLearnerAttributes = {
+          prénom: 'Tomie',
+          nom: 'Katana',
+          TonNomCommun: 'Yalalala',
+          category: 'Sola',
+        };
+
+        learnerSet.addLearners([newLearnerAttributes]);
+
+        const learnerFromDB1 = new CommonOrganizationLearner({
+          id: 666,
+          userId: 24,
+          firstName: 'Tomie',
+          lastName: 'Katana',
+          "nom d'usage": 'YoYo',
+          group: 'Solo',
+          organizationId,
+        });
+
+        learnerSet.setExistingLearners([learnerFromDB1]);
+
+        const learners = learnerSet.learners;
+
+        expect(learners.list).to.lengthOf(1);
+        expect(learners.list[0]).to.be.an.instanceOf(CommonOrganizationLearner);
+        expect(learners.list).to.deep.equal([
+          new CommonOrganizationLearner({
+            firstName: 'Tomie',
+            lastName: 'Katana',
+            id: 666,
+            userId: 24,
+            organizationId,
+            "nom d'usage": 'Yalalala',
+            group: 'Sola',
+          }),
+        ]);
       });
 
       it('return distinct list of learner to create or update', function () {

--- a/api/tests/prescription/learner-management/unit/domain/models/OrganizationLearnerImportFormat_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/models/OrganizationLearnerImportFormat_test.js
@@ -71,12 +71,16 @@ describe('Unit | Models | OrganizationLearnerImportFormat', function () {
         name: 'SAY_MY_NAME',
         config: { basic_config: 'toto' },
         fileType: 'csv',
+        createdAt: new Date('2025-01-01'),
+        createdBy: 12,
       });
       // then
       expect(organizationLearnerImportFormat).to.deep.equal({
         name: 'SAY_MY_NAME',
         config: { basic_config: 'toto' },
         fileType: 'csv',
+        createdBy: 12,
+        createdAt: new Date('2025-01-01'),
       });
     });
 
@@ -88,6 +92,8 @@ describe('Unit | Models | OrganizationLearnerImportFormat', function () {
             name: 'SAY_MY_NAME',
             config: { basic_config: 'toto' },
             fileType: 'incalif_file_type',
+            createdAt: new Date('2025-01-01'),
+            createdBy: 12,
           });
         } catch (error) {
           // then
@@ -102,6 +108,8 @@ describe('Unit | Models | OrganizationLearnerImportFormat', function () {
           new OrganizationLearnerImportFormat({
             config: { basic_config: 'toto' },
             fileType: 'csv',
+            createdAt: new Date('2025-01-01'),
+            createdBy: 12,
           });
         } catch (error) {
           // then
@@ -116,6 +124,8 @@ describe('Unit | Models | OrganizationLearnerImportFormat', function () {
           new OrganizationLearnerImportFormat({
             name: 'SAY_MY_NAME',
             fileType: 'csv',
+            createdAt: new Date('2025-01-01'),
+            createdBy: 12,
           });
         } catch (error) {
           // then
@@ -129,6 +139,8 @@ describe('Unit | Models | OrganizationLearnerImportFormat', function () {
         try {
           new OrganizationLearnerImportFormat({
             fileType: 'csv',
+            createdAt: new Date('2025-01-01'),
+            createdBy: 12,
           });
         } catch (error) {
           // then

--- a/api/tests/prescription/learner-management/unit/domain/models/OrganizationLearnerImportFormat_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/models/OrganizationLearnerImportFormat_test.js
@@ -34,9 +34,10 @@ describe('Unit | Models | OrganizationLearnerImportFormat', function () {
             required: true,
           },
           {
-            name: 'catégorie',
+            name: 'CATEGORY',
             required: true,
             config: {
+              mappingColumn: 'catégorie',
               displayable: {
                 position: 2,
                 name: IMPORT_KEY_FIELD.COMMON_DIVISION,
@@ -343,7 +344,7 @@ describe('Unit | Models | OrganizationLearnerImportFormat', function () {
       expect(organizationLearnerImportFormat.headersName).to.deep.equal([
         { name: 'Nom apprenant' },
         { name: 'Prénom apprenant' },
-        { name: 'catégorie' },
+        { name: 'CATEGORY' },
         { name: 'Date de naissance' },
         { name: 'unicity key' },
       ]);

--- a/api/tests/prescription/learner-management/unit/domain/usecases/get-organization-learners-csv-template_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/usecases/get-organization-learners-csv-template_test.js
@@ -34,6 +34,8 @@ describe('Unit | UseCase | get-organization-learners-csv-template', function () 
               { name: 'Date de naissance', required: true },
             ],
           },
+          createdAt: new Date('2025-01-01'),
+          createdBy: 12,
         }),
       );
 

--- a/api/tests/prescription/organization-learner/unit/domain/models/OrganizationToJoin_test.js
+++ b/api/tests/prescription/organization-learner/unit/domain/models/OrganizationToJoin_test.js
@@ -33,6 +33,8 @@ describe('Unit | Domain | Read-Models | OrganizationToJoin', function () {
             },
           ],
         },
+        createdAt: new Date('2025-01-01'),
+        createdBy: 12,
       });
       const organizationToJoin = new OrganizationToJoin({
         id: 1,

--- a/api/tests/prescription/organization-learner/unit/infrastructure/repositories/organization-to-join-repository_test.js
+++ b/api/tests/prescription/organization-learner/unit/infrastructure/repositories/organization-to-join-repository_test.js
@@ -33,6 +33,8 @@ describe('Unit | Repository | organization-to-join-repository', function () {
           },
         ],
       },
+      createdAt: new Date('2025-01-01'),
+      createdBy: 12,
     });
 
     const organizationId = 1;

--- a/api/tests/tooling/domain-builder/factory/prescription/learner-management/build-organization-learner-import-format.js
+++ b/api/tests/tooling/domain-builder/factory/prescription/learner-management/build-organization-learner-import-format.js
@@ -26,10 +26,14 @@ export const buildOrganizationLearnerImportFormat = function ({
       },
     ],
   },
+  createdAt = new Date('2025-01-01'),
+  createdBy = 12,
 } = {}) {
   return new OrganizationLearnerImportFormat({
     name,
     fileType,
     config,
+    createdAt,
+    createdBy,
   });
 };


### PR DESCRIPTION
## ❄️ Problème

Si une nouvelle version du fichier d'import arrive, nous ne sommes pas en capacité de garantir une rétrocompatibilité

## 🛷 Proposition

Permettre grâce à un argument dans la config de faire le mapping du fchier vers l'ancienne version afin de garantir une liste  cohérente dans la liste des apprenants. 

Permettre aussi de faire un mapping de valeur ( dans le cas d'une liste possible Oui / Non devient Yes / No ) pour ne stocker qu'une seule est même liste.

## ☃️ Remarques

cette solution tout comme l'autre ne permet pas de changer la clé d'unicité des apprenants. Puisque rien ne garantit que les apprenants a Import -1 soit bien unique avec cette nouvelle clé.

la solution de tendre vers l'ancienne version est celle qui était la plus simple à mettre en oeuvre. le mapping des anciennes données vers le nouveau format est trop compliqué pour simplement une question de stockage dans un champs en bdd. 

le mapping vers le 1er nom semble le plus judicieux.

Il serait intéressant aussi de n'insérer que les données que nous exploitons côté FRONT. ce point pourra venir dans un second temps. si nécessaire. 
## 🧑‍🎄 Pour tester

Faire un import generic sur l'orga Pro Classic ( avec l'import generic .csv )
Modifier en BDD la feature d'import avec l'id de la V2
Faire un nouvel Import avec la V2 et vérifier que la Divisions est bien envoyé dans Classe. et que le contenu des Classes est bien transformé vers une nouvelle valeur définit. 
