### PR TITLE
[TECH] Créer un script pour modifier le statut des participations de campagne à partager (PIX-21134)

### DIFF
--- a/api/src/prescription/scripts/revert-campaign-participations-to-started.js
+++ b/api/src/prescription/scripts/revert-campaign-participations-to-started.js
@@ -1,0 +1,151 @@
+import { isoDateParser } from '../../shared/application/scripts/parsers.js';
+import { Script } from '../../shared/application/scripts/script.js';
+import { ScriptRunner } from '../../shared/application/scripts/script-runner.js';
+import { DomainTransaction } from '../../shared/domain/DomainTransaction.js';
+import { Assessment } from '../../shared/domain/models/Assessment.js';
+import { CampaignParticipationStatuses, CampaignTypes } from '../shared/domain/constants.js';
+
+const options = {
+  dryRun: {
+    type: 'boolean',
+    describe: 'Run the script without making any database changes',
+    default: true,
+  },
+  startDate: {
+    type: 'string',
+    describe: 'Start date of the period to process, day included, format "YYYY-MM-DD", (ex: "2024-01-20")',
+    demandOption: true,
+    requiresArg: true,
+    coerce: isoDateParser(),
+  },
+  endDate: {
+    type: 'string',
+    describe: 'End date of the period to process, day included, format "YYYY-MM-DD", (ex: "2024-02-27")',
+    demandOption: true,
+    requiresArg: true,
+    coerce: isoDateParser(),
+  },
+};
+
+export class RevertCampaignParticipationsToStartedScript extends Script {
+  constructor() {
+    super({
+      description:
+        'Revert campaign participations from TO_SHARE to STARTED status and update their last assessment state from completed to started',
+      permanent: false,
+      options,
+    });
+  }
+
+  async handle({ logger, options }) {
+    await DomainTransaction.execute(async () => {
+      const knexConn = DomainTransaction.getConnection();
+
+      logger.info('BEGIN: RevertCampaignParticipationsToStartedScript');
+      logger.info(
+        `Processing participations from ${options.startDate.toISOString()} to ${options.endDate.toISOString()}`,
+      );
+
+      const participationsToUpdate = await this.#fetchParticipationsToUpdate(
+        knexConn,
+        options.startDate,
+        options.endDate,
+      );
+
+      if (participationsToUpdate.length === 0) {
+        logger.info('No participations found to update');
+        return;
+      }
+
+      logger.info(`Found ${participationsToUpdate.length} participations to update`);
+
+      let updatedParticipationsCount = 0;
+      let updatedAssessmentsCount = 0;
+
+      for (const participation of participationsToUpdate) {
+        logger.info(`Processing participation id: ${participation.id}`);
+
+        logger.info(`Participation is of type: ${participation.type}`);
+
+        if (participation.deletedAt) {
+          logger.info(`Participation has been deleted at: ${participation.deletedAt}`);
+        }
+
+        logger.info(`Updating participation id: ${participation.id} status from TO_SHARE to STARTED`);
+
+        await knexConn('campaign-participations')
+          .where({ id: participation.id })
+          .update({ status: CampaignParticipationStatuses.STARTED });
+
+        updatedParticipationsCount++;
+
+        if (participation.type === CampaignTypes.PROFILES_COLLECTION) {
+          logger.info('Participation is of type PROFILES_COLLECTION, skipping assessment update');
+          continue;
+        }
+
+        if (participation.deletedAt) {
+          logger.info('Participation has been deleted, skipping assessment update');
+          continue;
+        }
+
+        const lastAssessment = await this.#fetchLastAssessmentForParticipation(knexConn, participation.id);
+
+        if (!lastAssessment) {
+          logger.warning(`No assessment found for participation id: ${participation.id}, skipping`);
+          continue;
+        }
+
+        if (lastAssessment.state !== Assessment.states.COMPLETED) {
+          logger.warning(
+            `Last assessment id: ${lastAssessment.id} for participation id: ${participation.id} is not in completed state (current state: ${lastAssessment.state}), skipping`,
+          );
+          continue;
+        }
+
+        logger.info(`Updating assessment id: ${lastAssessment.id} state from completed to started`);
+
+        await knexConn('assessments').where({ id: lastAssessment.id }).update({ state: Assessment.states.STARTED });
+
+        updatedAssessmentsCount++;
+      }
+
+      logger.info(`Updated ${updatedParticipationsCount} participations`);
+      logger.info(`Updated ${updatedAssessmentsCount} assessments`);
+
+      if (options.dryRun) {
+        await knexConn.rollback();
+        logger.info('ROLLBACK: RevertCampaignParticipationsToStartedScript (dry run mode)');
+        logger.info('Use --dryRun=false to persist changes');
+        return;
+      }
+
+      logger.info('COMMIT: RevertCampaignParticipationsToStartedScript');
+    });
+  }
+
+  async #fetchParticipationsToUpdate(knexConn, startDate, endDate) {
+    const formattedStartDate = startDate.toISOString().split('T')[0];
+
+    const adjustedEndDate = new Date(endDate);
+    adjustedEndDate.setDate(adjustedEndDate.getDate() + 1);
+    const formattedEndDate = adjustedEndDate.toISOString().split('T')[0];
+
+    return knexConn('campaign-participations')
+      .select('campaign-participations.id', 'campaigns.type', 'campaign-participations.deletedAt')
+      .join('campaigns', 'campaigns.id', 'campaign-participations.campaignId')
+      .where('status', CampaignParticipationStatuses.TO_SHARE)
+      .where('campaign-participations.createdAt', '>=', formattedStartDate)
+      .where('campaign-participations.createdAt', '<', formattedEndDate);
+  }
+
+  async #fetchLastAssessmentForParticipation(knexConn, campaignParticipationId) {
+    return knexConn('assessments')
+      .select('id', 'state')
+      .where({ campaignParticipationId })
+      .orderBy('createdAt', 'desc')
+      .first();
+  }
+}
+
+await ScriptRunner.execute(import.meta.url, RevertCampaignParticipationsToStartedScript);

--- a/api/tests/prescription/integration/scripts/revert-campaign-participations-to-started_test.js
+++ b/api/tests/prescription/integration/scripts/revert-campaign-participations-to-started_test.js
@@ -1,0 +1,389 @@
+import { RevertCampaignParticipationsToStartedScript } from '../../../../src/prescription/scripts/revert-campaign-participations-to-started.js';
+import { CampaignParticipationStatuses, CampaignTypes } from '../../../../src/prescription/shared/domain/constants.js';
+import { Assessment } from '../../../../src/shared/domain/models/Assessment.js';
+import { databaseBuilder, expect, knex, sinon } from '../../../test-helper.js';
+
+const { buildCampaignParticipation, buildCampaign, buildAssessment } = databaseBuilder.factory;
+
+describe('Integration | Prescription | Scripts | revert-campaign-participations-to-started', function () {
+  let script;
+  let logger;
+
+  beforeEach(function () {
+    script = new RevertCampaignParticipationsToStartedScript();
+    logger = {
+      info: sinon.stub(),
+      warning: sinon.stub(),
+      error: sinon.stub(),
+    };
+  });
+
+  describe('options', function () {
+    it('should have the correct options', function () {
+      const { options } = script.metaInfo;
+
+      expect(options.dryRun).to.deep.include({
+        type: 'boolean',
+        describe: 'Run the script without making any database changes',
+        default: true,
+      });
+      expect(options.startDate).to.deep.include({
+        type: 'string',
+        describe: 'Start date of the period to process, day included, format "YYYY-MM-DD", (ex: "2024-01-20")',
+        demandOption: true,
+        requiresArg: true,
+      });
+      expect(options.endDate).to.deep.include({
+        type: 'string',
+        describe: 'End date of the period to process, day included, format "YYYY-MM-DD", (ex: "2024-02-27")',
+        demandOption: true,
+        requiresArg: true,
+      });
+    });
+  });
+
+  describe('#handle', function () {
+    describe('when no participations are found', function () {
+      it('should not update anything and log appropriate message', async function () {
+        // given
+        const participation = buildCampaignParticipation({
+          status: CampaignParticipationStatuses.STARTED,
+          createdAt: new Date('2024-01-15'),
+        });
+        await databaseBuilder.commit();
+
+        const options = {
+          dryRun: false,
+          startDate: new Date('2024-01-01'),
+          endDate: new Date('2024-01-31'),
+        };
+
+        // when
+        await script.handle({ logger, options });
+
+        // then
+        expect(participation.status).to.equal(CampaignParticipationStatuses.STARTED);
+        expect(logger.info).to.have.been.calledWith('No participations found to update');
+      });
+    });
+
+    describe('when participations are found', function () {
+      describe('date range filtering', function () {
+        it('should only process participations within the date range (inclusive)', async function () {
+          // given
+          const beforeRangeParticipation = buildCampaignParticipation({
+            status: CampaignParticipationStatuses.TO_SHARE,
+            createdAt: new Date('2023-12-31T23:59:59Z'),
+          });
+          const startDateParticipation = buildCampaignParticipation({
+            status: CampaignParticipationStatuses.TO_SHARE,
+            createdAt: new Date('2024-01-01T00:00:00Z'),
+          });
+          const middleDateParticipation = buildCampaignParticipation({
+            status: CampaignParticipationStatuses.TO_SHARE,
+            createdAt: new Date('2024-01-15T12:00:00Z'),
+          });
+          const endDateParticipation = buildCampaignParticipation({
+            status: CampaignParticipationStatuses.TO_SHARE,
+            createdAt: new Date('2024-01-31T23:59:59Z'),
+          });
+          const afterRangeParticipation = buildCampaignParticipation({
+            status: CampaignParticipationStatuses.TO_SHARE,
+            createdAt: new Date('2024-02-01T00:00:00Z'),
+          });
+          await databaseBuilder.commit();
+
+          const options = {
+            dryRun: false,
+            startDate: new Date('2024-01-01'),
+            endDate: new Date('2024-01-31'),
+          };
+
+          // when
+          await script.handle({ logger, options });
+
+          // then
+          const beforeRangeResult = await knex('campaign-participations')
+            .where({ id: beforeRangeParticipation.id })
+            .first();
+          const startDateResult = await knex('campaign-participations')
+            .where({ id: startDateParticipation.id })
+            .first();
+          const middleDateResult = await knex('campaign-participations')
+            .where({ id: middleDateParticipation.id })
+            .first();
+          const endDateResult = await knex('campaign-participations').where({ id: endDateParticipation.id }).first();
+          const afterRangeResult = await knex('campaign-participations')
+            .where({ id: afterRangeParticipation.id })
+            .first();
+
+          expect(beforeRangeResult.status).to.equal(CampaignParticipationStatuses.TO_SHARE);
+          expect(startDateResult.status).to.equal(CampaignParticipationStatuses.STARTED);
+          expect(middleDateResult.status).to.equal(CampaignParticipationStatuses.STARTED);
+          expect(endDateResult.status).to.equal(CampaignParticipationStatuses.STARTED);
+          expect(afterRangeResult.status).to.equal(CampaignParticipationStatuses.TO_SHARE);
+        });
+      });
+
+      describe('assessment update', function () {
+        describe('when participation is of type ASSESSMENT', function () {
+          it('should update the last assessment state from completed to started', async function () {
+            // given
+            const campaignId = buildCampaign({ type: CampaignTypes.ASSESSMENT }).id;
+            const participation = buildCampaignParticipation({
+              campaignId,
+              type: CampaignTypes.ASSESSMENT,
+              status: CampaignParticipationStatuses.TO_SHARE,
+              createdAt: new Date('2024-01-15'),
+            });
+            const assessment = buildAssessment({
+              campaignParticipationId: participation.id,
+              state: Assessment.states.COMPLETED,
+              createdAt: new Date('2024-01-15'),
+            });
+            await databaseBuilder.commit();
+
+            const options = {
+              dryRun: false,
+              startDate: new Date('2024-01-01'),
+              endDate: new Date('2024-01-31'),
+            };
+
+            // when
+            await script.handle({ logger, options });
+
+            // then
+            const updatedAssessment = await knex('assessments').where({ id: assessment.id }).first();
+            expect(updatedAssessment.state).to.equal(Assessment.states.STARTED);
+          });
+
+          it('should update only the last assessment when multiple assessments exist', async function () {
+            // given
+            const campaignId = buildCampaign({ type: CampaignTypes.ASSESSMENT }).id;
+            const participation = buildCampaignParticipation({
+              campaignId,
+              type: CampaignTypes.ASSESSMENT,
+              status: CampaignParticipationStatuses.TO_SHARE,
+              createdAt: new Date('2024-01-15'),
+            });
+            const olderAssessment = buildAssessment({
+              campaignParticipationId: participation.id,
+              state: Assessment.states.COMPLETED,
+              createdAt: new Date('2024-01-15T10:00:00Z'),
+            });
+            const newerAssessment = buildAssessment({
+              campaignParticipationId: participation.id,
+              state: Assessment.states.COMPLETED,
+              createdAt: new Date('2024-01-15T14:00:00Z'),
+            });
+            await databaseBuilder.commit();
+
+            const options = {
+              dryRun: false,
+              startDate: new Date('2024-01-01'),
+              endDate: new Date('2024-01-31'),
+            };
+
+            // when
+            await script.handle({ logger, options });
+
+            // then
+            const updatedOlderAssessment = await knex('assessments').where({ id: olderAssessment.id }).first();
+            const updatedNewerAssessment = await knex('assessments').where({ id: newerAssessment.id }).first();
+            expect(updatedOlderAssessment.state).to.equal(Assessment.states.COMPLETED);
+            expect(updatedNewerAssessment.state).to.equal(Assessment.states.STARTED);
+          });
+
+          it('should not update assessment when its state is not completed', async function () {
+            // given
+            const campaignId = buildCampaign({ type: CampaignTypes.ASSESSMENT }).id;
+            const participation = buildCampaignParticipation({
+              campaignId,
+              type: CampaignTypes.ASSESSMENT,
+              status: CampaignParticipationStatuses.TO_SHARE,
+              createdAt: new Date('2024-01-15'),
+            });
+            const assessment = buildAssessment({
+              campaignParticipationId: participation.id,
+              state: Assessment.states.ENDED_BY_INVIGILATOR,
+              createdAt: new Date('2024-01-15'),
+            });
+            await databaseBuilder.commit();
+
+            const options = {
+              dryRun: false,
+              startDate: new Date('2024-01-01'),
+              endDate: new Date('2024-01-31'),
+            };
+
+            // when
+            await script.handle({ logger, options });
+
+            // then
+            const updatedAssessment = await knex('assessments').where({ id: assessment.id }).first();
+            expect(updatedAssessment.state).to.equal(Assessment.states.ENDED_BY_INVIGILATOR);
+            expect(logger.warning).to.have.been.calledWithMatch(
+              `Last assessment id: ${assessment.id} for participation id: ${participation.id} is not in completed state (current state: ${assessment.state}), skipping`,
+            );
+          });
+
+          it('should log a warning when no assessment is found for the participation', async function () {
+            // given
+            const campaignId = buildCampaign({ type: CampaignTypes.ASSESSMENT }).id;
+            const participation = buildCampaignParticipation({
+              campaignId,
+              type: CampaignTypes.ASSESSMENT,
+              status: CampaignParticipationStatuses.TO_SHARE,
+              createdAt: new Date('2024-01-15'),
+            });
+            await databaseBuilder.commit();
+
+            const options = {
+              dryRun: false,
+              startDate: new Date('2024-01-01'),
+              endDate: new Date('2024-01-31'),
+            };
+
+            // when
+            await script.handle({ logger, options });
+
+            // then
+            const updatedParticipation = await knex('campaign-participations').where({ id: participation.id }).first();
+            expect(updatedParticipation.status).to.equal(CampaignParticipationStatuses.STARTED);
+            expect(logger.warning).to.have.been.calledWithMatch(/No assessment found for participation id/);
+          });
+        });
+
+        describe('when participation is of type PROFILES_COLLECTION', function () {
+          it('should skip assessment update', async function () {
+            // given
+            const campaignId = buildCampaign({ type: CampaignTypes.PROFILES_COLLECTION }).id;
+            buildCampaignParticipation({
+              campaignId,
+              type: CampaignTypes.PROFILES_COLLECTION,
+              status: CampaignParticipationStatuses.TO_SHARE,
+              createdAt: new Date('2024-01-15'),
+            });
+            await databaseBuilder.commit();
+
+            const options = {
+              dryRun: false,
+              startDate: new Date('2024-01-01'),
+              endDate: new Date('2024-01-31'),
+            };
+
+            // when
+            await script.handle({ logger, options });
+
+            // then
+            expect(logger.info).to.have.been.calledWith(
+              'Participation is of type PROFILES_COLLECTION, skipping assessment update',
+            );
+          });
+        });
+
+        describe('when participation has been deleted', function () {
+          it('should skip assessment update', async function () {
+            // given
+            const campaignId = buildCampaign({ type: CampaignTypes.ASSESSMENT }).id;
+            buildCampaignParticipation({
+              campaignId,
+              type: CampaignTypes.ASSESSMENT,
+              status: CampaignParticipationStatuses.TO_SHARE,
+              createdAt: new Date('2024-01-15'),
+              deletedAt: new Date('2024-01-20'),
+            });
+            await databaseBuilder.commit();
+
+            const options = {
+              dryRun: false,
+              startDate: new Date('2024-01-01'),
+              endDate: new Date('2024-01-31'),
+            };
+
+            // when
+            await script.handle({ logger, options });
+
+            // then
+            expect(logger.info).to.have.been.calledWith('Participation has been deleted, skipping assessment update');
+          });
+        });
+      });
+
+      describe('dry run mode', function () {
+        it('should rollback all changes when dryRun is true', async function () {
+          // given
+          const campaignId = buildCampaign({ type: CampaignTypes.ASSESSMENT }).id;
+          const participation = buildCampaignParticipation({
+            campaignId,
+            type: CampaignTypes.ASSESSMENT,
+            status: CampaignParticipationStatuses.TO_SHARE,
+            createdAt: new Date('2024-01-15'),
+          });
+          const assessment = buildAssessment({
+            campaignParticipationId: participation.id,
+            state: Assessment.states.COMPLETED,
+            createdAt: new Date('2024-01-15'),
+          });
+          await databaseBuilder.commit();
+
+          const options = {
+            dryRun: true,
+            startDate: new Date('2024-01-01'),
+            endDate: new Date('2024-01-31'),
+          };
+
+          // when
+          await script.handle({ logger, options });
+
+          // then
+          const unchangedParticipation = await knex('campaign-participations').where({ id: participation.id }).first();
+          const unchangedAssessment = await knex('assessments').where({ id: assessment.id }).first();
+
+          expect(unchangedParticipation.status).to.equal(CampaignParticipationStatuses.TO_SHARE);
+          expect(unchangedAssessment.state).to.equal(Assessment.states.COMPLETED);
+          expect(logger.info).to.have.been.calledWith(
+            'ROLLBACK: RevertCampaignParticipationsToStartedScript (dry run mode)',
+          );
+          expect(logger.info).to.have.been.calledWith('Use --dryRun=false to persist changes');
+        });
+      });
+
+      describe('non-dry run mode', function () {
+        it('should commit all changes when dryRun is false', async function () {
+          // given
+          const campaignId = buildCampaign({ type: CampaignTypes.ASSESSMENT }).id;
+          const participation = buildCampaignParticipation({
+            campaignId,
+            type: CampaignTypes.ASSESSMENT,
+            status: CampaignParticipationStatuses.TO_SHARE,
+            createdAt: new Date('2024-01-15'),
+          });
+          const assessment = buildAssessment({
+            campaignParticipationId: participation.id,
+            state: Assessment.states.COMPLETED,
+            createdAt: new Date('2024-01-15'),
+          });
+          await databaseBuilder.commit();
+
+          const options = {
+            dryRun: false,
+            startDate: new Date('2024-01-01'),
+            endDate: new Date('2024-01-31'),
+          };
+
+          // when
+          await script.handle({ logger, options });
+
+          // then
+          const updatedParticipation = await knex('campaign-participations').where({ id: participation.id }).first();
+          const updatedAssessment = await knex('assessments').where({ id: assessment.id }).first();
+
+          expect(updatedParticipation.status).to.equal(CampaignParticipationStatuses.STARTED);
+          expect(updatedAssessment.state).to.equal(Assessment.states.STARTED);
+          expect(logger.info).to.have.been.calledWith('COMMIT: RevertCampaignParticipationsToStartedScript');
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
## ❄️ Problème

Nous avons entamé, depuis maintenant des temps immémoriaux, un travail pour décommissionner le statut `TO_SHARE` des participations de campagne. Nous avons commencé par ne plus enregistrer ce statut et ne plus le traiter ( on le fusionne avec le statut `STARTED`)

Maintenant que ce statut n'est plus actif, on peut migrer l'existant en base.

## 🛷 Proposition

Création d'un script pour modifier les données :
- Revenir le statut des participations de campagne de `TO_SHARE` vers `STARTED`
- Mettre à jour l'état de la dernière évaluation (assessment) associée de `completed` vers `started`
- Le script fonctionne par période (date de début et date de fin)
- Mode `dry-run` par défaut pour vérifier les modifications avant de les appliquer
- Gestion des cas particuliers :
  - Participations de type `PROFILES_COLLECTION` (pas d'évaluation à mettre à jour)
  - Participations supprimées (pas d'évaluation à mettre à jour)
  - Évaluations dans un état différent de `completed` (pas de mise à jour)

## 🧑‍🎄 Pour tester

```bash
node --env-file-if-exists=.env src/prescription/scripts/revert-campaign-participations-to-started.js --startDate=2024-06-01 --endDate=2025-01-01 --dryRun=true
```
On va commencer par lancer le script sur intégration puis sur la recette et enfin en prod.