### PR TITLE
[FEATURE] Empêcher l'archivage d'une organisation avec un/des lots de places actifs ou à venir (PIX-20906).

### DIFF
--- a/admin/app/controllers/authenticated/organizations/get.js
+++ b/admin/app/controllers/authenticated/organizations/get.js
@@ -44,7 +44,7 @@ export default class GetController extends Controller {
       const errorCode = get(responseError, 'errors[0].code');
       if (errorCode === 'ARCHIVE_ORGANIZATION_ERROR') {
         return this.pixToast.sendErrorNotification({
-          message: "Impossible d'archiver une organisation ayant au moins 1 lot de places actif.",
+          message: this.intl.t('pages.organization.get.archiving.notifications.active-places-lot-error'),
         });
       }
       if (status === '422') {

--- a/admin/app/controllers/authenticated/organizations/get.js
+++ b/admin/app/controllers/authenticated/organizations/get.js
@@ -41,6 +41,12 @@ export default class GetController extends Controller {
       this.router.transitionTo('authenticated.organizations.get');
     } catch (responseError) {
       const status = get(responseError, 'errors[0].status');
+      const errorCode = get(responseError, 'errors[0].code');
+      if (errorCode === 'ARCHIVE_ORGANIZATION_ERROR') {
+        return this.pixToast.sendErrorNotification({
+          message: "Impossible d'archiver une organisation ayant au moins 1 lot de places actif.",
+        });
+      }
       if (status === '422') {
         return this.pixToast.sendErrorNotification({ message: "L'organisation n'a pas pu être archivée." });
       }

--- a/admin/tests/acceptance/authenticated/organizations/information-management-test.js
+++ b/admin/tests/acceptance/authenticated/organizations/information-management-test.js
@@ -210,6 +210,39 @@ module('Acceptance | Organizations | Information management', function (hooks) {
           assert.dom(screen.getByText('Archivée le 02/02/2022 par Clément Tine.')).exists();
         });
 
+        module('when organization has at least one active places lot', function () {
+          test('should display an error notification', async function (assert) {
+            // given
+            const organization = this.server.create('organization', {
+              name: 'Aude Javel Company',
+            });
+            this.server.post(
+              '/admin/organizations/:id/archive',
+              () => ({
+                errors: [
+                  {
+                    code: 'ARCHIVE_ORGANIZATION_ERROR',
+                    status: '422',
+                  },
+                ],
+              }),
+              422,
+            );
+            const screen = await visit(`/organizations/${organization.id}`);
+            await clickByName("Archiver l'organisation");
+
+            await screen.findByRole('dialog');
+            // when
+            await clickByName('Confirmer');
+
+            // then
+            assert
+              .dom(screen.getByText("Impossible d'archiver une organisation ayant au moins 1 lot de places actif."))
+              .exists();
+            assert.dom(screen.queryByLabelText('Archivée le 02/02/2022 par Clément Tine.')).doesNotExist();
+          });
+        });
+
         test('should display error notification when archiving was not successful', async function (assert) {
           // given
           const organization = this.server.create('organization', {

--- a/admin/tests/acceptance/authenticated/organizations/information-management-test.js
+++ b/admin/tests/acceptance/authenticated/organizations/information-management-test.js
@@ -237,7 +237,7 @@ module('Acceptance | Organizations | Information management', function (hooks) {
 
             // then
             assert
-              .dom(screen.getByText("Impossible d'archiver une organisation ayant au moins 1 lot de places actif."))
+              .dom(screen.getByText(t('pages.organization.get.archiving.notifications.active-places-lot-error')))
               .exists();
             assert.dom(screen.queryByLabelText('Archivée le 02/02/2022 par Clément Tine.')).doesNotExist();
           });

--- a/admin/tests/acceptance/authenticated/organizations/information-management-test.js
+++ b/admin/tests/acceptance/authenticated/organizations/information-management-test.js
@@ -190,12 +190,89 @@ module('Acceptance | Organizations | Information management', function (hooks) {
         assert.dom(screen.getByRole('heading', { name: "Archiver l'organisation Aude Javel Company" })).exists();
         assert.dom(screen.getByText('Êtes-vous sûr de vouloir archiver cette organisation ?')).exists();
       });
+
+      module('when user confirms archiving', function () {
+        test('should archive organization and display archiving details', async function (assert) {
+          // given
+          const organization = this.server.create('organization', {
+            name: 'Aude Javel Company',
+            features: { PLACES_MANAGEMENT: { active: true } },
+          });
+          const screen = await visit(`/organizations/${organization.id}`);
+          await clickByName("Archiver l'organisation");
+
+          await screen.findByRole('dialog');
+          // when
+          await clickByName('Confirmer');
+
+          // then
+          assert.dom(screen.getByText('Cette organisation a bien été archivée.')).exists();
+          assert.dom(screen.getByText('Archivée le 02/02/2022 par Clément Tine.')).exists();
+        });
+
+        test('should display error notification when archiving was not successful', async function (assert) {
+          // given
+          const organization = this.server.create('organization', {
+            name: 'Aude Javel Company',
+            features: { PLACES_MANAGEMENT: { active: true } },
+          });
+          this.server.post(
+            '/admin/organizations/:id/archive',
+            () => ({
+              errors: [
+                {
+                  status: '422',
+                },
+              ],
+            }),
+            422,
+          );
+          const screen = await visit(`/organizations/${organization.id}`);
+          await clickByName("Archiver l'organisation");
+
+          await screen.findByRole('dialog');
+          // when
+          await clickByName('Confirmer');
+
+          // then
+          assert.dom(screen.getByText("L'organisation n'a pas pu être archivée.")).exists();
+          assert.dom(screen.queryByLabelText('Archivée le 02/02/2022 par Clément Tine.')).doesNotExist();
+        });
+
+        test('should display error notification for other errors', async function (assert) {
+          // given
+          const organization = this.server.create('organization', {
+            name: 'Aude Javel Company',
+          features: { PLACES_MANAGEMENT: { active: true } },});
+          this.server.post(
+            '/admin/organizations/:id/archive',
+            () => ({
+              errors: [
+                {
+                  status: '500',
+                },
+              ],
+            }),
+            500,
+          );
+          const screen = await visit(`/organizations/${organization.id}`);
+          await clickByName("Archiver l'organisation");
+
+          await screen.findByRole('dialog');
+          // when
+          await clickByName('Confirmer');
+
+          // then
+          assert.dom(screen.getByText('Une erreur est survenue.')).exists();
+          assert.dom(screen.queryByLabelText('Archivée le 02/02/2022 par Clément Tine.')).doesNotExist();
+        });
+      });
+
       module('when user click on cancel actions', function () {
         test('should close confirmation modal with cancel button', async function (assert) {
           // given
           const organization = this.server.create('organization', {
             name: 'Aude Javel Company',
-            features: { PLACES_MANAGEMENT: { active: true } },
           });
           const screen = await visit(`/organizations/${organization.id}`);
           await clickByName("Archiver l'organisation");
@@ -208,11 +285,11 @@ module('Acceptance | Organizations | Information management', function (hooks) {
           // then
           assert.dom(screen.queryByLabelText('Archivée le 02/02/2022 par Clément Tine.')).doesNotExist();
         });
+
         test('should close confirmation modal with modal close button', async function (assert) {
           // given
           const organization = this.server.create('organization', {
             name: 'Aude Javel Company',
-            features: { PLACES_MANAGEMENT: { active: true } },
           });
           const screen = await visit(`/organizations/${organization.id}`);
           await clickByName("Archiver l'organisation");
@@ -225,82 +302,6 @@ module('Acceptance | Organizations | Information management', function (hooks) {
           assert.dom(screen.queryByLabelText('Archivée le 02/02/2022 par Clément Tine.')).doesNotExist();
         });
       });
-    });
-
-    test('should archive organization and display archiving details', async function (assert) {
-      // given
-      const organization = this.server.create('organization', {
-        name: 'Aude Javel Company',
-        features: { PLACES_MANAGEMENT: { active: true } },
-      });
-      const screen = await visit(`/organizations/${organization.id}`);
-      await clickByName("Archiver l'organisation");
-
-      await screen.findByRole('dialog');
-      // when
-      await clickByName('Confirmer');
-
-      // then
-      assert.dom(screen.getByText('Cette organisation a bien été archivée.')).exists();
-      assert.dom(screen.getByText('Archivée le 02/02/2022 par Clément Tine.')).exists();
-    });
-
-    test('should display error notification when archiving was not successful', async function (assert) {
-      // given
-      const organization = this.server.create('organization', {
-        name: 'Aude Javel Company',
-        features: { PLACES_MANAGEMENT: { active: true } },
-      });
-      this.server.post(
-        '/admin/organizations/:id/archive',
-        () => ({
-          errors: [
-            {
-              status: '422',
-            },
-          ],
-        }),
-        422,
-      );
-      const screen = await visit(`/organizations/${organization.id}`);
-      await clickByName("Archiver l'organisation");
-
-      await screen.findByRole('dialog');
-      // when
-      await clickByName('Confirmer');
-
-      // then
-      assert.dom(screen.getByText("L'organisation n'a pas pu être archivée.")).exists();
-      assert.dom(screen.queryByLabelText('Archivée le 02/02/2022 par Clément Tine.')).doesNotExist();
-    });
-
-    test('should display error notification for other errors', async function (assert) {
-      // given
-      const organization = this.server.create('organization', {
-        name: 'Aude Javel Company',
-        features: { PLACES_MANAGEMENT: { active: true } },
-      });
-      this.server.post(
-        '/admin/organizations/:id/archive',
-        () => ({
-          errors: [
-            {
-              status: '500',
-            },
-          ],
-        }),
-        500,
-      );
-      const screen = await visit(`/organizations/${organization.id}`);
-      await clickByName("Archiver l'organisation");
-
-      await screen.findByRole('dialog');
-      // when
-      await clickByName('Confirmer');
-
-      // then
-      assert.dom(screen.getByText('Une erreur est survenue.')).exists();
-      assert.dom(screen.queryByLabelText('Archivée le 02/02/2022 par Clément Tine.')).doesNotExist();
     });
   });
 });

--- a/admin/tests/acceptance/authenticated/organizations/information-management-test.js
+++ b/admin/tests/acceptance/authenticated/organizations/information-management-test.js
@@ -215,6 +215,7 @@ module('Acceptance | Organizations | Information management', function (hooks) {
             // given
             const organization = this.server.create('organization', {
               name: 'Aude Javel Company',
+              features: { PLACES_MANAGEMENT: { active: true } },
             });
             this.server.post(
               '/admin/organizations/:id/archive',
@@ -276,7 +277,8 @@ module('Acceptance | Organizations | Information management', function (hooks) {
           // given
           const organization = this.server.create('organization', {
             name: 'Aude Javel Company',
-          features: { PLACES_MANAGEMENT: { active: true } },});
+            features: { PLACES_MANAGEMENT: { active: true } },
+          });
           this.server.post(
             '/admin/organizations/:id/archive',
             () => ({
@@ -306,6 +308,7 @@ module('Acceptance | Organizations | Information management', function (hooks) {
           // given
           const organization = this.server.create('organization', {
             name: 'Aude Javel Company',
+            features: { PLACES_MANAGEMENT: { active: true } },
           });
           const screen = await visit(`/organizations/${organization.id}`);
           await clickByName("Archiver l'organisation");
@@ -323,6 +326,7 @@ module('Acceptance | Organizations | Information management', function (hooks) {
           // given
           const organization = this.server.create('organization', {
             name: 'Aude Javel Company',
+            features: { PLACES_MANAGEMENT: { active: true } },
           });
           const screen = await visit(`/organizations/${organization.id}`);
           await clickByName("Archiver l'organisation");

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -1270,7 +1270,7 @@
       "get": {
         "archiving": {
           "notifications": {
-            "active-places-lot-error": "An organization with at least 1 active places lot cannot be archived"
+            "active-places-lot-error": "An organization with at either active or pending places lots cannot be archived"
           }
         }
       },

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -498,7 +498,7 @@
         },
         "title": "All learner courses"
       },
-       "organizations": {
+      "organizations": {
         "detach-organization": "Are you sure you want to detach <strong>{organizationName}</strong> from combined course blueprint <strong>{name}</strong>",
         "detach-organization-success": "Blueprint is not shared with organization {name} anymore."
       }
@@ -852,7 +852,7 @@
           "caption": "Liste des profil cibles. Contient l'identifiant, le nom interne, la catégorie, la date de création et le statut."
         }
       },
-       "organizations": {
+      "organizations": {
         "detach-organization": "Are you sure you want to detach <strong>{organizationName}</strong> from target profile <strong>{name}</strong>"
       }
     },
@@ -1267,6 +1267,13 @@
       "title": "Access to this Pix Admin space is limited to administrators."
     },
     "organization": {
+      "get": {
+        "archiving": {
+          "notifications": {
+            "active-places-lot-error": "An organization with at least 1 active places lot cannot be archived"
+          }
+        }
+      },
       "navbar": {
         "campaigns": "Campaigns",
         "children": "Children organisations",

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -499,7 +499,7 @@
         },
         "title": "Tous les schémas de parcours combinés"
       },
-       "organizations": {
+      "organizations": {
         "detach-organization": "Etes-vous sûr de vouloir détacher l'organisation <strong>{organizationName}</strong> du schéma de parcours <strong>{name}</strong>",
         "detach-organization-success": "Le schéma de parcours n'est plus partagé avec l'organisation {name}."
       }
@@ -1270,6 +1270,13 @@
       "title": "L'accès à Pix Admin est limité aux administrateurs de la plateforme"
     },
     "organization": {
+      "get": {
+        "archiving": {
+          "notifications": {
+            "active-places-lot-error": "Impossible d'archiver une organisation ayant au moins 1 lot de places actif."
+          }
+        }
+      },
       "navbar": {
         "campaigns": "Campagnes",
         "children": "Organisations filles",

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -1273,7 +1273,7 @@
       "get": {
         "archiving": {
           "notifications": {
-            "active-places-lot-error": "Impossible d'archiver une organisation ayant au moins 1 lot de places actif."
+            "active-places-lot-error": "Impossible d'archiver une organisation ayant au moins 1 lot de places actif ou à venir."
           }
         }
       },

--- a/api/src/organizational-entities/domain/errors.js
+++ b/api/src/organizational-entities/domain/errors.js
@@ -28,6 +28,15 @@ class ArchiveCertificationCentersInBatchError extends DomainError {
   }
 }
 
+class ArchiveOrganizationError extends DomainError {
+  constructor({ code = 'ARCHIVE_ORGANIZATION_ERROR', message = 'Error during organization archiving', meta } = {}) {
+    super(message);
+    this.code = code;
+    this.message = message;
+    this.meta = meta;
+  }
+}
+
 class ArchiveOrganizationsInBatchError extends DomainError {
   constructor({ meta } = {}) {
     super('Error during organizations batch archiving', 'ARCHIVE_ORGANIZATIONS_IN_BATCH_ERROR');
@@ -104,6 +113,7 @@ class UnableToDetachParentOrganizationFromChildOrganization extends DomainError 
 export {
   AdministrationTeamNotFound,
   ArchiveCertificationCentersInBatchError,
+  ArchiveOrganizationError,
   ArchiveOrganizationsInBatchError,
   CountryNotFoundError,
   DpoEmailInvalid,

--- a/api/src/organizational-entities/domain/read-models/PlacesLot.js
+++ b/api/src/organizational-entities/domain/read-models/PlacesLot.js
@@ -12,7 +12,7 @@ const validationSchema = Joi.object({
   deletedAt: Joi.date().required().allow(null),
 });
 
-const statuses = {
+export const statuses = {
   ACTIVE: 'ACTIVE',
   EXPIRED: 'EXPIRED',
   PENDING: 'PENDING',

--- a/api/src/organizational-entities/domain/usecases/archive-organization.usecase.js
+++ b/api/src/organizational-entities/domain/usecases/archive-organization.usecase.js
@@ -4,9 +4,22 @@ const archiveOrganization = withTransaction(async function ({
   organizationId,
   userId,
   organizationForAdminRepository,
+  organizationPlacesLotRepository,
 }) {
+  const organizationPlacesLots = await organizationPlacesLotRepository.findAllByOrganizationIds({
+    organizationIds: [organizationId],
+  });
+
+  if (_arePlacesLotsActive(organizationPlacesLots)) {
+    throw new Error();
+  }
+
   await organizationForAdminRepository.archive({ id: organizationId, archivedBy: userId });
   return await organizationForAdminRepository.get({ organizationId });
 });
+
+const _arePlacesLotsActive = (organizationPlacesLots) => {
+  return Boolean(organizationPlacesLots.find((organizationPlacesLot) => organizationPlacesLot.isActive()));
+};
 
 export { archiveOrganization };

--- a/api/src/organizational-entities/domain/usecases/archive-organization.usecase.js
+++ b/api/src/organizational-entities/domain/usecases/archive-organization.usecase.js
@@ -1,4 +1,5 @@
 import { withTransaction } from '../../../shared/domain/DomainTransaction.js';
+import { ArchiveOrganizationError } from '../errors.js';
 
 const archiveOrganization = withTransaction(async function ({
   organizationId,
@@ -11,7 +12,7 @@ const archiveOrganization = withTransaction(async function ({
   });
 
   if (_arePlacesLotsActive(organizationPlacesLots)) {
-    throw new Error();
+    throw new ArchiveOrganizationError({ message: 'Organization with active lots cannot be archived' });
   }
 
   await organizationForAdminRepository.archive({ id: organizationId, archivedBy: userId });
@@ -19,7 +20,7 @@ const archiveOrganization = withTransaction(async function ({
 });
 
 const _arePlacesLotsActive = (organizationPlacesLots) => {
-  return Boolean(organizationPlacesLots.find((organizationPlacesLot) => organizationPlacesLot.isActive()));
+  return Boolean(organizationPlacesLots.find((organizationPlacesLot) => organizationPlacesLot.isActive));
 };
 
 export { archiveOrganization };

--- a/api/src/shared/application/error-manager.js
+++ b/api/src/shared/application/error-manager.js
@@ -10,7 +10,10 @@ import {
 } from '../../certification/session-management/domain/errors.js';
 import { AlreadyRatedAssessmentError, EmptyAnswerError } from '../../evaluation/domain/errors.js';
 import * as LLMDomainErrors from '../../llm/domain/errors.js';
-import { UnableToAttachChildOrganizationToParentOrganizationError } from '../../organizational-entities/domain/errors.js';
+import {
+  ArchiveOrganizationError,
+  UnableToAttachChildOrganizationToParentOrganizationError,
+} from '../../organizational-entities/domain/errors.js';
 import { ArchivedCampaignError, DeletedCampaignError } from '../../prescription/campaign/domain/errors.js';
 import { CampaignParticipationDeletedError } from '../../prescription/campaign-participation/domain/errors.js';
 import { AggregateImportError, SiecleXmlImportError } from '../../prescription/learner-management/domain/errors.js';
@@ -529,6 +532,10 @@ function _mapToHttpError(error) {
 
   if (error instanceof LLMDomainErrors.IncorrectMessagesOrderingError) {
     return new HttpErrors.InternalServerError(error.message);
+  }
+
+  if (error instanceof ArchiveOrganizationError) {
+    return new HttpErrors.UnprocessableEntityError(error.message, error.code);
   }
 
   return new HttpErrors.BaseHttpError(error.message);

--- a/api/tests/organizational-entities/integration/domain/usecases/archive-organization.usecase.test.js
+++ b/api/tests/organizational-entities/integration/domain/usecases/archive-organization.usecase.test.js
@@ -1,29 +1,58 @@
+import dayjs from 'dayjs';
+
 import { usecases } from '../../../../../src/organizational-entities/domain/usecases/index.js';
 import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
 import { catchErr, databaseBuilder, expect, sinon } from '../../../../test-helper.js';
 
 describe('Integration | Organizational Entities | Domain | UseCase | archive-organization', function () {
   context('when the organization does exist', function () {
-    it('archives the organization', async function () {
-      // given
-      const now = new Date('2022-02-22');
-      const clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-      const superAdminUser = databaseBuilder.factory.buildUser.withRole();
-      const organization = databaseBuilder.factory.buildOrganization();
-      await databaseBuilder.commit();
+    context('when there is no active places lot', function () {
+      it('archives the organization', async function () {
+        // given
+        const now = new Date('2022-02-22');
+        const clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+        const superAdminUser = databaseBuilder.factory.buildUser.withRole();
+        const organization = databaseBuilder.factory.buildOrganization();
+        await databaseBuilder.commit();
 
-      // when
-      const archivedOrganization = await usecases.archiveOrganization({
-        organizationId: organization.id,
-        userId: superAdminUser.id,
+        // when
+        const archivedOrganization = await usecases.archiveOrganization({
+          organizationId: organization.id,
+          userId: superAdminUser.id,
+        });
+
+        // then
+        expect(archivedOrganization.archivedAt).to.deep.equal(now);
+        expect(archivedOrganization.archivistFirstName).to.deep.equal(superAdminUser.firstName);
+        expect(archivedOrganization.archivistLastName).to.deep.equal(superAdminUser.lastName);
+
+        clock.restore();
       });
+    });
 
-      // then
-      expect(archivedOrganization.archivedAt).to.deep.equal(now);
-      expect(archivedOrganization.archivistFirstName).to.deep.equal(superAdminUser.firstName);
-      expect(archivedOrganization.archivistLastName).to.deep.equal(superAdminUser.lastName);
+    context('when there are active places lots', function () {
+      it('throws an error', async function () {
+        // given
+        const superAdminUser = databaseBuilder.factory.buildUser.withRole();
+        const organization = databaseBuilder.factory.buildOrganization();
+        databaseBuilder.factory.buildOrganizationPlace({
+          organizationId: organization.id,
+          activationDate: new Date('2022-02-22'),
+          expirationDate: dayjs(new Date()).add(1, 'day').toDate(),
+          count: 1,
+        });
+        await databaseBuilder.commit();
 
-      clock.restore();
+        // when
+        const error = await catchErr(await usecases.archiveOrganization)({
+          organizationId: organization.id,
+          userId: superAdminUser.id,
+        });
+
+        // then
+        expect(error).to.be.instanceOf(Error);
+        clock.restore();
+      });
     });
   });
 

--- a/api/tests/organizational-entities/integration/domain/usecases/archive-organization.usecase.test.js
+++ b/api/tests/organizational-entities/integration/domain/usecases/archive-organization.usecase.test.js
@@ -52,7 +52,32 @@ describe('Integration | Organizational Entities | Domain | UseCase | archive-org
 
         // then
         expect(error).to.be.instanceOf(ArchiveOrganizationError);
-        expect(error.message).to.equal('Organization with active lots cannot be archived');
+        expect(error.message).to.equal('Organization with either active or pending lots cannot be archived');
+      });
+    });
+
+    context('when there are pending places lots', function () {
+      it('throws an ArchiveOrganizationError', async function () {
+        // given
+        const superAdminUser = databaseBuilder.factory.buildUser.withRole();
+        const organization = databaseBuilder.factory.buildOrganization();
+        databaseBuilder.factory.buildOrganizationPlace({
+          organizationId: organization.id,
+          activationDate: dayjs(new Date()).add(1, 'day').toDate(),
+          expirationDate: dayjs(new Date()).add(2, 'day').toDate(),
+          count: 1,
+        });
+        await databaseBuilder.commit();
+
+        // when
+        const error = await catchErr(await usecases.archiveOrganization)({
+          organizationId: organization.id,
+          userId: superAdminUser.id,
+        });
+
+        // then
+        expect(error).to.be.instanceOf(ArchiveOrganizationError);
+        expect(error.message).to.equal('Organization with either active or pending lots cannot be archived');
       });
     });
   });

--- a/api/tests/organizational-entities/integration/domain/usecases/archive-organization.usecase.test.js
+++ b/api/tests/organizational-entities/integration/domain/usecases/archive-organization.usecase.test.js
@@ -1,5 +1,6 @@
 import dayjs from 'dayjs';
 
+import { ArchiveOrganizationError } from '../../../../../src/organizational-entities/domain/errors.js';
 import { usecases } from '../../../../../src/organizational-entities/domain/usecases/index.js';
 import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
 import { catchErr, databaseBuilder, expect, sinon } from '../../../../test-helper.js';
@@ -31,7 +32,7 @@ describe('Integration | Organizational Entities | Domain | UseCase | archive-org
     });
 
     context('when there are active places lots', function () {
-      it('throws an error', async function () {
+      it('throws an ArchiveOrganizationError', async function () {
         // given
         const superAdminUser = databaseBuilder.factory.buildUser.withRole();
         const organization = databaseBuilder.factory.buildOrganization();
@@ -50,8 +51,8 @@ describe('Integration | Organizational Entities | Domain | UseCase | archive-org
         });
 
         // then
-        expect(error).to.be.instanceOf(Error);
-        clock.restore();
+        expect(error).to.be.instanceOf(ArchiveOrganizationError);
+        expect(error.message).to.equal('Organization with active lots cannot be archived');
       });
     });
   });


### PR DESCRIPTION
## ❄️ Problème

Il ne devrait pas être possible d'archiver une organisation ayant au moins un lot de places actif ou à venir.

## 🛷 Proposition

On empêche cette action d'être réalisée.

## ☃️ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🧑‍🎄 Pour tester

- Se connecter à Pix-Admin
- Ajouter un lot de places à une organisation
- Vérifier que l'archivage est impossible et qu'une notification d'erreur apparaît à l'écran
- Rendre non-actif le lot de places
- Vérifier que l'organisation peut être archivée

Refaire la même opération pour un lot de places à venir