### PR TITLE
[TECH] Ajouter les traces d'apprentissages sur l'élément audio (PIX-21112)

### DIFF
--- a/api/src/devcomp/domain/factories/passage-event-factory.js
+++ b/api/src/devcomp/domain/factories/passage-event-factory.js
@@ -8,6 +8,8 @@ import {
   QROCMAnsweredEvent,
 } from '../models/passage-events/answerable-element-events.js';
 import {
+  AudioPlayedEvent,
+  AudioTranscriptionOpenedEvent,
   ExpandClosedEvent,
   ExpandOpenedEvent,
   FileDownloadedEvent,
@@ -31,6 +33,10 @@ import { StepperNextStepEvent } from '../models/passage-events/stepper-events.js
 class PassageEventFactory {
   static build(eventData) {
     switch (eventData.type) {
+      case 'AUDIO_TRANSCRIPTION_OPENED':
+        return new AudioTranscriptionOpenedEvent(eventData);
+      case 'AUDIO_PLAYED':
+        return new AudioPlayedEvent(eventData);
       case 'EMBED_ANSWERED':
         return new EmbedAnsweredEvent(eventData);
       case 'EXPAND_OPENED':

--- a/api/src/devcomp/domain/models/passage-events/events.js
+++ b/api/src/devcomp/domain/models/passage-events/events.js
@@ -1,6 +1,48 @@
 import { PassageEventWithElement } from './PassageEventWithElement.js';
 
 /**
+ * @class AudioPlayedEvent
+ * See PassageEventWithElement for more info.
+ *
+ * This event is generated when the user plays an audio.
+ *
+ * */
+class AudioPlayedEvent extends PassageEventWithElement {
+  constructor({ id, occurredAt, createdAt, passageId, sequenceNumber, elementId }) {
+    super({
+      type: 'AUDIO_PLAYED',
+      id,
+      occurredAt,
+      createdAt,
+      passageId,
+      sequenceNumber,
+      elementId,
+    });
+  }
+}
+
+/**
+ * @class AudioTranscriptionOpenedEvent
+ * See PassageEventWithElement for more info.
+ *
+ * This event is generated when the user displays an audio transcription.
+ *
+ * */
+class AudioTranscriptionOpenedEvent extends PassageEventWithElement {
+  constructor({ id, occurredAt, createdAt, passageId, sequenceNumber, elementId }) {
+    super({
+      type: 'AUDIO_TRANSCRIPTION_OPENED',
+      id,
+      occurredAt,
+      createdAt,
+      passageId,
+      sequenceNumber,
+      elementId,
+    });
+  }
+}
+
+/**
  * @class ExpandClosedEvent
  * See PassageEventWithElement for more info.
  *
@@ -146,6 +188,8 @@ class FileDownloadedEvent extends PassageEventWithElement {
 }
 
 export {
+  AudioPlayedEvent,
+  AudioTranscriptionOpenedEvent,
   ExpandClosedEvent,
   ExpandOpenedEvent,
   FileDownloadedEvent,

--- a/api/tests/devcomp/integration/domain/models/passage-events/events_test.js
+++ b/api/tests/devcomp/integration/domain/models/passage-events/events_test.js
@@ -1,4 +1,8 @@
-import { ShortVideoTranscriptionOpenedEvent } from '../../../../../../src/devcomp/domain/models/passage-events/events.js';
+import {
+  AudioPlayedEvent,
+  AudioTranscriptionOpenedEvent,
+  ShortVideoTranscriptionOpenedEvent,
+} from '../../../../../../src/devcomp/domain/models/passage-events/events.js';
 import { expect } from '../../../../../test-helper.js';
 
 describe('Integration | Devcomp | Domain | Models | passage-events | events', function () {
@@ -28,6 +32,68 @@ describe('Integration | Devcomp | Domain | Models | passage-events | events', fu
       expect(event.occurredAt).to.equal(occurredAt);
       expect(event.createdAt).to.equal(createdAt);
       expect(event.passageId).to.equal(passageId);
+      expect(event.sequenceNumber).to.equal(sequenceNumber);
+      expect(event.data).to.deep.equal({ elementId });
+    });
+  });
+  describe('#AudioPlayedEvent', function () {
+    it('should init and keep attributes', function () {
+      // given
+      const id = Symbol('id');
+      const occurredAt = new Date();
+      const createdAt = Symbol('date');
+      const passageId = 1234;
+      const sequenceNumber = 2;
+      const elementId = '48fe5289-c2eb-46eb-b721-983ca8820be4';
+
+      // when
+      const event = new AudioPlayedEvent({
+        id,
+        occurredAt,
+        createdAt,
+        passageId,
+        sequenceNumber,
+        elementId,
+      });
+
+      // then
+      expect(event.id).to.equal(id);
+      expect(event.type).to.equal('AUDIO_PLAYED');
+      expect(event.occurredAt).to.equal(occurredAt);
+      expect(event.createdAt).to.equal(createdAt);
+      expect(event.passageId).to.equal(passageId);
+      expect(event.sequenceNumber).to.equal(sequenceNumber);
+      expect(event.data).to.deep.equal({ elementId });
+    });
+  });
+
+  describe('#AudioTranscriptionOpenedEvent', function () {
+    it('should init and keep attributes', function () {
+      // given
+      const id = Symbol('id');
+      const occurredAt = new Date();
+      const createdAt = Symbol('date');
+      const passageId = 1234;
+      const sequenceNumber = 2;
+      const elementId = '4de85234-eb12-48fc-8a9d-aae1897b136d';
+
+      // when
+      const event = new AudioTranscriptionOpenedEvent({
+        id,
+        occurredAt,
+        createdAt,
+        passageId,
+        sequenceNumber,
+        elementId,
+      });
+
+      // then
+      expect(event.id).to.equal(id);
+      expect(event.type).to.equal('AUDIO_TRANSCRIPTION_OPENED');
+      expect(event.occurredAt).to.equal(occurredAt);
+      expect(event.createdAt).to.equal(createdAt);
+      expect(event.passageId).to.equal(passageId);
+      expect(event.sequenceNumber).to.equal(sequenceNumber);
       expect(event.data).to.deep.equal({ elementId });
     });
   });

--- a/api/tests/devcomp/unit/domain/factories/passage-event-factory_test.js
+++ b/api/tests/devcomp/unit/domain/factories/passage-event-factory_test.js
@@ -10,6 +10,8 @@ import {
   QROCMAnsweredEvent,
 } from '../../../../../src/devcomp/domain/models/passage-events/answerable-element-events.js';
 import {
+  AudioPlayedEvent,
+  AudioTranscriptionOpenedEvent,
   ExpandClosedEvent,
   ExpandOpenedEvent,
   FileDownloadedEvent,
@@ -60,6 +62,44 @@ describe('Unit | Devcomp | Domain | Models | Block | BlockInput', function () {
         // then
         expect(error).to.be.instanceof(DomainError);
         expect(error.message).to.equal('Passage event with type UNKNOWN does not exist');
+      });
+    });
+
+    describe('when given an AUDIO_PLAYED', function () {
+      it('should return an AudioPlayedEvent instance', function () {
+        // given
+        const rawEvent = {
+          occurredAt: new Date(),
+          passageId: 102,
+          sequenceNumber: 34,
+          elementId: '1e3940ef-c557-415d-b5ef-6f9f77b527f4',
+          type: 'AUDIO_PLAYED',
+        };
+
+        // when
+        const builtEvent = PassageEventFactory.build(rawEvent);
+
+        // then
+        expect(builtEvent).to.be.instanceOf(AudioPlayedEvent);
+      });
+    });
+
+    describe('when given an AUDIO_TRANSCRIPTION_OPENED', function () {
+      it('should return an AudioTranscriptionOpenedEvent instance', function () {
+        // given
+        const rawEvent = {
+          occurredAt: new Date(),
+          passageId: 102,
+          sequenceNumber: 34,
+          elementId: '46eaf84c-eac8-4cb5-b984-4307dde46ea7',
+          type: 'AUDIO_TRANSCRIPTION_OPENED',
+        };
+
+        // when
+        const builtEvent = PassageEventFactory.build(rawEvent);
+
+        // then
+        expect(builtEvent).to.be.instanceOf(AudioTranscriptionOpenedEvent);
       });
     });
 

--- a/mon-pix/app/components/module/element/audio.gjs
+++ b/mon-pix/app/components/module/element/audio.gjs
@@ -1,6 +1,8 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixModal from '@1024pix/pix-ui/components/pix-modal';
+import { on } from '@ember/modifier';
 import { action } from '@ember/object';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
@@ -8,9 +10,28 @@ import { htmlUnsafe } from 'mon-pix/helpers/html-unsafe';
 export default class ModulixAudio extends Component {
   @tracked modalIsOpen = false;
 
+  @service passageEvents;
+
+  @action
+  onPlay() {
+    this.passageEvents.record({
+      type: 'AUDIO_PLAYED',
+      data: {
+        elementId: this.args.audio.id,
+      },
+    });
+  }
+
   @action
   showModal() {
     this.modalIsOpen = true;
+
+    this.passageEvents.record({
+      type: 'AUDIO_TRANSCRIPTION_OPENED',
+      data: {
+        elementId: this.args.audio.id,
+      },
+    });
   }
 
   @action
@@ -26,7 +47,14 @@ export default class ModulixAudio extends Component {
       <div class="element-audio__container">
         <p class="element-audio__container__title">{{@audio.title}}</p>
         {{! template-lint-disable require-media-caption }}
-        <audio ref="audio" class="pix-audio-player" controls src="{{@audio.url}}"></audio>
+        <audio
+          id={{@audio.id}}
+          ref="audio"
+          class="pix-audio-player"
+          controls
+          src="{{@audio.url}}"
+          {{on "play" this.onPlay}}
+        ></audio>
 
         {{#if this.hasTranscription}}
           <PixButton @variant="tertiary" @triggerAction={{this.showModal}}>

--- a/mon-pix/tests/integration/components/module/audio_test.gjs
+++ b/mon-pix/tests/integration/components/module/audio_test.gjs
@@ -1,7 +1,9 @@
 import { render } from '@1024pix/ember-testing-library';
-import { click, findAll } from '@ember/test-helpers';
+// eslint-disable-next-line no-restricted-imports
+import { click, find, findAll } from '@ember/test-helpers';
 import ModulixAudioElement from 'mon-pix/components/module/element/audio';
 import { module, test } from 'qunit';
+import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import { waitForDialogClose } from '../../../helpers/wait-for';
@@ -38,6 +40,10 @@ module('Integration | Component | Module | Audio', function (hooks) {
       transcription: 'transcription',
     };
 
+    const passageEventService = this.owner.lookup('service:passageEvents');
+
+    const passageEventRecordStub = sinon.stub(passageEventService, 'record');
+
     //  when
     const screen = await render(<template><ModulixAudioElement @audio={{audioElement}} /></template>);
 
@@ -50,5 +56,43 @@ module('Integration | Component | Module | Audio', function (hooks) {
     await waitForDialogClose();
 
     assert.dom(screen.queryByRole('dialog')).doesNotExist();
+    sinon.assert.calledWithExactly(passageEventRecordStub, {
+      type: 'AUDIO_TRANSCRIPTION_OPENED',
+      data: {
+        elementId: audioElement.id,
+      },
+    });
+  });
+
+  test('should send a passage event when clicking on play', async function (assert) {
+    // given
+    const url = 'https://assets.pix.fr/modulix/placeholder-audio.mp3';
+
+    const audioElement = {
+      url,
+      id: 'bc54e212-71d2-420b-8c73-bd5d8b729f9c',
+      title: 'title',
+      transcription: 'transcription',
+    };
+
+    const passageEventService = this.owner.lookup('service:passageEvents');
+
+    const passageEventRecordStub = sinon.stub(passageEventService, 'record');
+
+    //  when
+    await render(<template><ModulixAudioElement @audio={{audioElement}} /></template>);
+    const audio = find(`#${audioElement.id}`);
+
+    const event = new Event('play');
+    audio.dispatchEvent(event);
+
+    // then
+    sinon.assert.calledWithExactly(passageEventRecordStub, {
+      type: 'AUDIO_PLAYED',
+      data: {
+        elementId: audioElement.id,
+      },
+    });
+    assert.ok(true);
   });
 });


### PR DESCRIPTION
## ❄️ Problème

Les traces d'apprentissage pour l'élément Audio ne sont pas enregistrées.

## 🛷 Proposition

Enregistrer les traces d'apprentissage pour l'élément Audio.

## ☃️ Remarques


## 🧑‍🎄 Pour tester

1. Se rendre sur le module [bac-a-sable](https://app-pr14851.review.pix.fr/modules/bac-a-sable)
2. Ouvrir la transcription d'un audio
3. Lancer la lecture d'un audio
4. Constater l'enregistrement d'une trace d'apprentissage dans la table `passage-events` 