### PR TITLE
[FEATURE] Message d’erreur de validation spécifique pour certains embeds (PIX-21154)

### DIFF
--- a/mon-pix/app/components/challenge-item/challenge-item-qroc.gjs
+++ b/mon-pix/app/components/challenge-item/challenge-item-qroc.gjs
@@ -168,6 +168,7 @@ export default class ChallengeItemQroc extends ChallengeItemGeneric {
   @service intl;
 
   @tracked autoReplyAnswer = '';
+  @tracked autoReplyErrorMessage = '';
   @tracked qrocProposalAnswerValue = '';
   postMessageHandler = null;
 
@@ -195,15 +196,11 @@ export default class ChallengeItemQroc extends ChallengeItemGeneric {
   }
 
   _getErrorMessage() {
-    let errorMessage;
-    if (this.args.challenge.autoReply) {
-      errorMessage = 'pages.challenge.skip-error-message.qroc-auto-reply';
-    } else if (this.args.challenge.format === 'nombre') {
-      errorMessage = 'pages.challenge.skip-error-message.qroc-positive-number';
-    } else {
-      errorMessage = 'pages.challenge.skip-error-message.qroc';
-    }
-    return this.intl.t(errorMessage);
+    if (this.autoReplyErrorMessage) return this.autoReplyErrorMessage;
+    if (this.args.challenge.autoReply) return this.intl.t('pages.challenge.skip-error-message.qroc-auto-reply');
+    if (this.args.challenge.format === 'nombre')
+      return this.intl.t('pages.challenge.skip-error-message.qroc-positive-number');
+    return this.intl.t('pages.challenge.skip-error-message.qroc');
   }
 
   _addEventListener() {
@@ -213,7 +210,11 @@ export default class ChallengeItemQroc extends ChallengeItemGeneric {
 
   _receiveEmbedMessage(event) {
     const message = this._getMessageFromEventData(event);
-    if (message == null || message.answer == null || message.from !== 'pix') return;
+    if (message == null || message.from !== 'pix') return;
+
+    if (message.validity != null) this.autoReplyErrorMessage = message.validity;
+
+    if (message.answer == null) return;
     this.autoReplyAnswer = message.answer;
   }
 

--- a/mon-pix/tests/acceptance/challenge-item-qroc-test.js
+++ b/mon-pix/tests/acceptance/challenge-item-qroc-test.js
@@ -53,13 +53,33 @@ module('Acceptance | Displaying a QROC challenge', function (hooks) {
         // when
         const event = document.createEvent('Event');
         event.initEvent('message', true, true);
-        event.data = 'custom answer from embed';
+        event.data = { answer: 'custom answer from embed', validity: '', from: 'pix' };
         event.origin = 'https://epreuves.pix.fr';
         find('.embed__iframe').dispatchEvent(event);
 
         // then
         await click(screen.getByLabelText(t('pages.challenge.actions.validate-go-to-next')));
         assert.strictEqual(currentURL(), `/assessments/${assessment.id}/challenges/2`);
+      });
+
+      test('should display custom alert box when user validates without respecting embed validation', async function (assert) {
+        // given
+        const event = document.createEvent('Event');
+        event.initEvent('message', true, true);
+        event.data = { answer: '', validity: 'C’est l’embed qui décide quand vous pouvez valider.', from: 'pix' };
+        event.origin = 'https://epreuves.pix.fr';
+        find('.embed__iframe').dispatchEvent(event);
+
+        // when
+        assert.dom('.challenge-response__alert').doesNotExist();
+        await click(screen.getByLabelText(t('pages.challenge.actions.validate-go-to-next')));
+
+        // then
+        assert.dom('.challenge-response__alert[role="alert"]').exists();
+        assert.strictEqual(
+          find('.challenge-response__alert').textContent.trim(),
+          'C’est l’embed qui décide quand vous pouvez valider.',
+        );
       });
     });
 


### PR DESCRIPTION
## ❄️ Problème

Aujourd’hui, si on valide une épreuve possédant un QCM Image et qu’aucun élément n’a été sélectionné, le message d’erreur suivant s’affiche pour l’utilisateur : `“Vous pouvez valider” s‘affiche quand l‘épreuve est réussie. Essayez encore ou passez.`.

## 🛷 Proposition

Permettre d’afficher le message : “Pour valider, sélectionnez au moins deux réponses. Sinon, passez.”

## ☃️ Remarques

Il faut ajouter au mois un test.

## 🧑‍🎄 Pour tester

 - Faire une preview du challenge `challenge1wkZ5i4OqCPS1J`, le message de validation custom doit s’afficher
 - Faire une preview du challenge `challenge2jJnqD39CqWDoF`, le message d’erreur classique doit s’afficher
