### PR TITLE
[TECH] Corriger les seeds lors du deploiement de la RA API

### DIFF
--- a/api/db/seeds/data/team-acces/build-oidc-providers.js
+++ b/api/db/seeds/data/team-acces/build-oidc-providers.js
@@ -127,10 +127,8 @@ async function _buildOidcProvidersFromEnv(databaseBuilder) {
 
   const oidcProviders = JSON.parse(oidcProvidersJson);
 
-  await Promise.all(
-    oidcProviders.map(async (oidcProviderProperties) => {
-      debugOidcProvidersSeeds(`Loading configuration for OIDC provider "${oidcProviderProperties.identityProvider}"…`);
-      return databaseBuilder.factory.buildOidcProvider(oidcProviderProperties);
-    }),
-  );
+  for (const oidcProviderProperties of oidcProviders) {
+    debugOidcProvidersSeeds(`Loading configuration for OIDC provider "${oidcProviderProperties.identityProvider}"…`);
+    await databaseBuilder.factory.buildOidcProvider(oidcProviderProperties);
+  }
 }

--- a/api/db/seeds/data/team-certification/cases/simple-CLEA-v3.js
+++ b/api/db/seeds/data/team-certification/cases/simple-CLEA-v3.js
@@ -65,23 +65,20 @@ export class CleaV3Seed {
     await this.#initCertificationReferentials();
     const sessionReadyToStart = await this.#addReadyToStartSession({ certificationCenterMember, certificationCenter });
 
-    await Promise.all(
-      certifiableUsers.map((user) => this.#addCandidateToSession({ pixAppUser: user, session: sessionReadyToStart })),
-    );
+    for (const user of certifiableUsers) {
+      await this.#addCandidateToSession({ pixAppUser: user, session: sessionReadyToStart });
+    }
 
     /**
      * Session with a published certification
      */
     const sessionToPublish = await this.#addSessionToPublish({ certificationCenterMember, certificationCenter });
 
-    const candidatesToPublish = await Promise.all(
-      certifiableUsers.map((user) =>
-        this.#addCandidateToSession({
-          pixAppUser: user,
-          session: sessionToPublish,
-        }),
-      ),
-    );
+    const candidatesToPublish = [];
+    for (const user of certifiableUsers) {
+      const candidate = await this.#addCandidateToSession({ pixAppUser: user, session: sessionToPublish });
+      candidatesToPublish.push(candidate);
+    }
 
     await publishSessionWithValidatedCertification({
       databaseBuilder: this.databaseBuilder,

--- a/api/db/seeds/data/team-certification/cases/simple-pro-certification.js
+++ b/api/db/seeds/data/team-certification/cases/simple-pro-certification.js
@@ -49,25 +49,20 @@ export class ProSeed {
     await this.#initCertificationReferentials();
     const sessionReadyToStart = await this.#addReadyToStartSession({ certificationCenterMember, certificationCenter });
 
-    await Promise.all(
-      certifiableUsers.map((certifiableUser) =>
-        this.#addCandidateToSession({ pixAppUser: certifiableUser, session: sessionReadyToStart }),
-      ),
-    );
+    for (const certifiableUser of certifiableUsers) {
+      await this.#addCandidateToSession({ pixAppUser: certifiableUser, session: sessionReadyToStart });
+    }
 
     /**
      * Session with a published certification
      */
     const sessionToPublish = await this.#addSessionToPublish({ certificationCenterMember, certificationCenter });
 
-    const candidatesToPublish = await Promise.all(
-      certifiableUsers.map(async (certifiableUser) => {
-        return this.#addCandidateToSession({
-          pixAppUser: certifiableUser,
-          session: sessionToPublish,
-        });
-      }),
-    );
+    const candidatesToPublish = [];
+    for (const user of certifiableUsers) {
+      const candidate = await this.#addCandidateToSession({ pixAppUser: user, session: sessionToPublish });
+      candidatesToPublish.push(candidate);
+    }
 
     await publishSessionWithValidatedCertification({
       databaseBuilder: this.databaseBuilder,

--- a/api/db/seeds/data/team-certification/cases/simple-sco-managing-students-certification.js
+++ b/api/db/seeds/data/team-certification/cases/simple-sco-managing-students-certification.js
@@ -51,11 +51,9 @@ export class ScoManagingStudent {
       certificationCenter,
     });
 
-    await Promise.all(
-      organizationLearners.map((organizationLearner) =>
-        this.#addCandidateToSession({ organizationLearner, session: sessionReadyToStart }),
-      ),
-    );
+    for (const organizationLearner of organizationLearners) {
+      await this.#addCandidateToSession({ organizationLearner, session: sessionReadyToStart });
+    }
 
     /**
      * Session with a published certification
@@ -65,14 +63,11 @@ export class ScoManagingStudent {
       certificationCenter,
     });
 
-    const candidatesToPublish = await Promise.all(
-      organizationLearners.map((organizationLearner) =>
-        this.#addCandidateToSession({
-          organizationLearner,
-          session: sessionToPublish,
-        }),
-      ),
-    );
+    const candidatesToPublish = [];
+    for (const organizationLearner of organizationLearners) {
+      const candidate = await this.#addCandidateToSession({ organizationLearner, session: sessionToPublish });
+      candidatesToPublish.push(candidate);
+    }
 
     await publishSessionWithValidatedCertification({
       databaseBuilder: this.databaseBuilder,

--- a/api/db/seeds/data/team-certification/cases/sup-certification-centre-with-habilitations.js
+++ b/api/db/seeds/data/team-certification/cases/sup-certification-centre-with-habilitations.js
@@ -60,20 +60,18 @@ export class SupWithHabilitationsSeed {
       forceSessionId: STARTED_PIX_EDU_1ER_DEGRE_CERTIFICATION_SESSION,
     });
 
-    await Promise.all(
-      certifiableUsers.map((certifiableUser) =>
-        this.#addCandidateToSession({
-          pixAppUser: certifiableUser,
-          session: sessionDroitReadyToStart,
-          subscriptions: [
-            Subscription.buildComplementary({
-              certificationCandidateId: null,
-              complementaryCertificationKey: ComplementaryCertificationKeys.PIX_PLUS_EDU_1ER_DEGRE,
-            }),
-          ],
-        }),
-      ),
-    );
+    for (const certifiableUser of certifiableUsers) {
+      await this.#addCandidateToSession({
+        pixAppUser: certifiableUser,
+        session: sessionDroitReadyToStart,
+        subscriptions: [
+          Subscription.buildComplementary({
+            certificationCandidateId: null,
+            complementaryCertificationKey: ComplementaryCertificationKeys.PIX_PLUS_EDU_1ER_DEGRE,
+          }),
+        ],
+      });
+    }
 
     /**
      * Session Pix+Droit with candidate ready to start his certification
@@ -85,20 +83,19 @@ export class SupWithHabilitationsSeed {
       description: 'Pix+Droit session with candidate ready to start',
       forceSessionId: STARTED_PIX_DROIT_CERTIFICATION_SESSION,
     });
-    await Promise.all(
-      certifiableUsers.map((certifiableUser) =>
-        this.#addCandidateToSession({
-          pixAppUser: certifiableUser,
-          session: sessionEduReadyToStart,
-          subscriptions: [
-            Subscription.buildComplementary({
-              certificationCandidateId: null,
-              complementaryCertificationKey: ComplementaryCertificationKeys.PIX_PLUS_DROIT,
-            }),
-          ],
-        }),
-      ),
-    );
+
+    for (const certifiableUser of certifiableUsers) {
+      await this.#addCandidateToSession({
+        pixAppUser: certifiableUser,
+        session: sessionEduReadyToStart,
+        subscriptions: [
+          Subscription.buildComplementary({
+            certificationCandidateId: null,
+            complementaryCertificationKey: ComplementaryCertificationKeys.PIX_PLUS_DROIT,
+          }),
+        ],
+      });
+    }
   }
 
   async #initCertificationReferentials() {


### PR DESCRIPTION
## ❄️ Problème

Lors du déploiement de la RA de l'API, le seeding de la base de données plante par manque de connexions disponibles.

<img width="1744" height="229" alt="image" src="https://github.com/user-attachments/assets/8cbcd40f-d5f9-4751-b627-c5570e47ea78" />


## 🛷 Proposition

Remplacer tous les `Promise.all` dans `api/db/seeds` qui prennent un grand nombre de connexion lors du seeding.

## ☃️ Remarques

N/A

## 🧑‍🎄 Pour tester

Le déploiement de l'API et le seeding de la base de donnée fonctionnent : https://dashboard.scalingo.com/apps/osc-fr1/pix-api-review-pr14855/deploy/list

**Test manuel :** se connecter à la RA et faire `npm run db:seed`.
