### PR TITLE
[TECH] Ajouter un script pour calculer les capacités des certifications Pix+ v3 (PIX-21162).

### DIFF
--- a/api/db/database-builder/factory/build-complementary-certification.js
+++ b/api/db/database-builder/factory/build-complementary-certification.js
@@ -71,7 +71,7 @@ buildComplementaryCertification.pixEdu1erDegre = function ({
   minimumReproducibilityRateLowerLevel = 60,
   hasExternalJury = true,
   certificationExtraTime = 45,
-}) {
+} = {}) {
   return buildComplementaryCertification({
     id,
     label: 'Pix+ Édu 1er degré',
@@ -90,7 +90,7 @@ buildComplementaryCertification.pixEdu2ndDegre = function ({
   minimumReproducibilityRateLowerLevel = 60,
   hasExternalJury = true,
   certificationExtraTime = 45,
-}) {
+} = {}) {
   return buildComplementaryCertification({
     id,
     label: 'Pix+ Édu 2nd degré',

--- a/api/scripts/certification/calculate-capacities.js
+++ b/api/scripts/certification/calculate-capacities.js
@@ -1,0 +1,118 @@
+import { knex } from '../../db/knex-database-connection.js';
+import { FlashAssessmentAlgorithm } from '../../src/certification/evaluation/domain/models/FlashAssessmentAlgorithm.js';
+import * as flashAlgorithmService from '../../src/certification/evaluation/domain/services/algorithm-methods/flash.js';
+import { services as certificationEvaluationServices } from '../../src/certification/evaluation/domain/services/index.js';
+import * as certificationAssessmentHistoryRepository from '../../src/certification/evaluation/infrastructure/repositories/certification-assessment-history-repository.js';
+import * as certificationCandidateRepository from '../../src/certification/evaluation/infrastructure/repositories/certification-candidate-repository.js';
+import { CertificationAssessmentHistory } from '../../src/certification/scoring/domain/models/CertificationAssessmentHistory.js';
+import * as certificationAssessmentRepository from '../../src/certification/shared/infrastructure/repositories/certification-assessment-repository.js';
+import * as certificationCourseRepository from '../../src/certification/shared/infrastructure/repositories/certification-course-repository.js';
+import * as sharedVersionRepository from '../../src/certification/shared/infrastructure/repositories/version-repository.js';
+import { Script } from '../../src/shared/application/scripts/script.js';
+import { ScriptRunner } from '../../src/shared/application/scripts/script-runner.js';
+import { DomainTransaction } from '../../src/shared/domain/DomainTransaction.js';
+import * as answerRepository from '../../src/shared/infrastructure/repositories/answer-repository.js';
+
+export class CalculateCapacities extends Script {
+  constructor() {
+    super({
+      description: 'Calculate capacities for Pix Plus',
+      permanent: false,
+      options: {
+        dryRun: {
+          type: 'boolean',
+          describe: 'Run the script without making any database changes',
+          default: true,
+        },
+      },
+    });
+  }
+
+  async handle({ logger, options, computeCapacitiesFnc }) {
+    const computeCapacitiesVerySad = computeCapacitiesFnc ?? computeCapacities;
+    const { dryRun } = options;
+
+    const data = await knex.raw(
+      `select cv.*, cco.id course_id
+        from "certification-subscriptions" cs
+        join "certification-candidates" cca on cca.id = cs."certificationCandidateId"
+        join "certification-courses" cco on (cco."userId" = cca."userId" and cco."sessionId" = cca."sessionId")
+        join "sessions" on sessions.id = cco."sessionId"
+        join "complementary-certifications" cc on cc.id = cs."complementaryCertificationId"
+        join certification_versions cv on cv.scope = cc.key
+        where cv.scope != 'CORE' and cv."startDate" is not null and cv."expirationDate" is null and
+        cs.type = 'COMPLEMENTARY' and cca."reconciledAt" > cv."startDate" and sessions."finalizedAt" is not null
+        order by cv.id, course_id`,
+    );
+
+    const groupedData = Object.groupBy(data.rows, (item) => item.id);
+
+    for (const certifications of Object.values(groupedData)) {
+      logger.info(
+        `About to compute capacities for certification ${certifications[0].scope} for ${certifications.length} candidates`,
+      );
+      const algorithm = new FlashAssessmentAlgorithm({
+        flashAlgorithmImplementation: flashAlgorithmService,
+        configuration: certifications[0].challengesConfiguration,
+      });
+      let countSuccesses = 0;
+      let currentCertificationCourseId;
+
+      for (const certification of certifications) {
+        try {
+          currentCertificationCourseId = certification.course_id;
+          await DomainTransaction.execute(async () => {
+            await computeCapacitiesVerySad(currentCertificationCourseId, algorithm);
+            countSuccesses++;
+            if (dryRun) {
+              throw new Error('dryRun');
+            }
+          });
+        } catch (error) {
+          if (error.message !== 'dryRun') {
+            logger.error(
+              `An error occurred when computing capacities for certification ${currentCertificationCourseId}, error : ${error?.stack || error}`,
+            );
+          }
+        }
+      }
+      logger.info(
+        `Successfully computed capacities for certification ${certifications[0].scope} for ${countSuccesses}/${certifications.length} candidates`,
+      );
+    }
+  }
+}
+
+async function computeCapacities(certificationCourseId, algorithm) {
+  const certificationAssessment = await certificationAssessmentRepository.getByCertificationCourseId({
+    certificationCourseId,
+  });
+
+  const answers = await answerRepository.findByAssessment(certificationAssessment.id);
+
+  const candidate = await certificationCandidateRepository.findByAssessmentId({
+    assessmentId: certificationAssessment.id,
+  });
+
+  const version = await sharedVersionRepository.getByScopeAndReconciliationDate({
+    scope: candidate.subscriptionScope,
+    reconciliationDate: candidate.reconciledAt,
+  });
+
+  const certificationCourse = await certificationCourseRepository.get({ id: certificationCourseId });
+  const { challengeCalibrationsWithoutLiveAlerts } =
+    await certificationEvaluationServices.findByCertificationCourseAndVersion({
+      certificationCourse: certificationCourse,
+      version,
+    });
+
+  const certificationAssessmentHistory = CertificationAssessmentHistory.fromChallengesAndAnswers({
+    algorithm,
+    challenges: challengeCalibrationsWithoutLiveAlerts,
+    allAnswers: answers,
+  });
+
+  await certificationAssessmentHistoryRepository.save(certificationAssessmentHistory);
+}
+
+await ScriptRunner.execute(import.meta.url, CalculateCapacities);

--- a/api/tests/certification/scripts/integration/calculate-capacities_test.js
+++ b/api/tests/certification/scripts/integration/calculate-capacities_test.js
@@ -1,0 +1,313 @@
+import dayjs from 'dayjs';
+
+import { CalculateCapacities } from '../../../../scripts/certification/calculate-capacities.js';
+import { SCOPES } from '../../../../src/certification/shared/domain/models/Scopes.js';
+import { databaseBuilder, expect, sinon } from '../../../test-helper.js';
+
+describe('Integration | Certification | Scripts | CalculateCapacities', function () {
+  let stubComputeCapacities, logger, script;
+
+  let activationDatePixPlus,
+    activationDatePixCore,
+    complementaryCertificationIdForPixPlus,
+    sessionFinalizedId,
+    userId1,
+    userId2,
+    certificationCourseId1,
+    certificationCourseId2;
+
+  const challengesConfigurationPixPlusEdu2ndDegre = '{"for":"pixPlusEdu2ndDegre"}';
+  const challengesConfigurationPixCore = '{"for":"pixCore"}';
+
+  beforeEach(function () {
+    activationDatePixPlus = new Date('2025-01-15');
+    activationDatePixCore = new Date('2020-01-01');
+
+    stubComputeCapacities = sinon.stub().rejects();
+    logger = { info: sinon.stub(), error: sinon.stub() };
+
+    script = new CalculateCapacities();
+
+    complementaryCertificationIdForPixPlus =
+      databaseBuilder.factory.buildComplementaryCertification.pixEdu2ndDegre().id;
+
+    databaseBuilder.factory.buildCertificationVersion({
+      scope: SCOPES.CORE,
+      startDate: activationDatePixCore,
+      challengesConfiguration: challengesConfigurationPixCore,
+    });
+
+    databaseBuilder.factory.buildCertificationVersion({
+      scope: SCOPES.PIX_PLUS_EDU_2ND_DEGRE,
+      expirationDate: activationDatePixPlus,
+      challengesConfiguration: challengesConfigurationPixPlusEdu2ndDegre,
+    });
+    databaseBuilder.factory.buildCertificationVersion({
+      scope: SCOPES.PIX_PLUS_EDU_2ND_DEGRE,
+      startDate: activationDatePixPlus,
+      challengesConfiguration: challengesConfigurationPixPlusEdu2ndDegre,
+    });
+
+    sessionFinalizedId = databaseBuilder.factory.buildSession({ finalizedAt: new Date() }).id;
+
+    const ids1 = buildUserAndCertificationCourseAndAssessment(sessionFinalizedId);
+    userId1 = ids1.userId;
+    certificationCourseId1 = ids1.certificationCourseId;
+
+    const ids2 = buildUserAndCertificationCourseAndAssessment(sessionFinalizedId);
+    userId2 = ids2.userId;
+    certificationCourseId2 = ids2.certificationCourseId;
+  });
+
+  it('should only compute capacities for pix plus certifications', async function () {
+    stubComputeCapacities
+      .withArgs(certificationCourseId2, sinon.match({ _configuration: challengesConfigurationPixPlusEdu2ndDegre }))
+      .resolves();
+
+    const certificationCandidateId1 = databaseBuilder.factory.buildCertificationCandidate({
+      userId: userId1,
+      sessionId: sessionFinalizedId,
+      reconciledAt: dayjs(activationDatePixCore).add(2, 'days').toDate(),
+    }).id;
+    databaseBuilder.factory.buildCoreSubscription({
+      certificationCandidateId: certificationCandidateId1,
+    });
+
+    const certificationCandidateId2 = databaseBuilder.factory.buildCertificationCandidate({
+      userId: userId2,
+      sessionId: sessionFinalizedId,
+      reconciledAt: dayjs(activationDatePixPlus).add(2, 'days').toDate(),
+    }).id;
+    databaseBuilder.factory.buildComplementaryCertificationSubscription({
+      complementaryCertificationId: complementaryCertificationIdForPixPlus,
+      certificationCandidateId: certificationCandidateId2,
+    });
+    await databaseBuilder.commit();
+
+    await script.handle({ options: { dryRun: true }, logger, computeCapacitiesFnc: stubComputeCapacities });
+
+    expect(logger.info.callCount).to.equal(2);
+    expect(logger.info.getCall(0)).to.have.been.calledWithExactly(
+      'About to compute capacities for certification EDU_2ND_DEGRE for 1 candidates',
+    );
+    expect(logger.info.getCall(1)).to.have.been.calledWithExactly(
+      'Successfully computed capacities for certification EDU_2ND_DEGRE for 1/1 candidates',
+    );
+    expect(stubComputeCapacities.callCount).to.equal(1);
+  });
+
+  it('should only compute capacities for certification courses associated with the active version of the certification course', async function () {
+    stubComputeCapacities
+      .withArgs(certificationCourseId2, sinon.match({ _configuration: challengesConfigurationPixPlusEdu2ndDegre }))
+      .resolves();
+
+    const certificationCandidateId1 = databaseBuilder.factory.buildCertificationCandidate({
+      userId: userId1,
+      sessionId: sessionFinalizedId,
+      reconciledAt: dayjs(activationDatePixPlus).subtract(2, 'days').toDate(),
+    }).id;
+    databaseBuilder.factory.buildComplementaryCertificationSubscription({
+      complementaryCertificationId: complementaryCertificationIdForPixPlus,
+      certificationCandidateId: certificationCandidateId1,
+    });
+
+    const certificationCandidateId2 = databaseBuilder.factory.buildCertificationCandidate({
+      userId: userId2,
+      sessionId: sessionFinalizedId,
+      reconciledAt: dayjs(activationDatePixPlus).add(2, 'days').toDate(),
+    }).id;
+    databaseBuilder.factory.buildComplementaryCertificationSubscription({
+      complementaryCertificationId: complementaryCertificationIdForPixPlus,
+      certificationCandidateId: certificationCandidateId2,
+    });
+    await databaseBuilder.commit();
+
+    await script.handle({ options: { dryRun: true }, logger, computeCapacitiesFnc: stubComputeCapacities });
+
+    expect(logger.info.callCount).to.equal(2);
+    expect(logger.info.getCall(0)).to.have.been.calledWithExactly(
+      'About to compute capacities for certification EDU_2ND_DEGRE for 1 candidates',
+    );
+    expect(logger.info.getCall(1)).to.have.been.calledWithExactly(
+      'Successfully computed capacities for certification EDU_2ND_DEGRE for 1/1 candidates',
+    );
+    expect(stubComputeCapacities.callCount).to.equal(1);
+  });
+
+  context('when there is a non finalized session', function () {
+    it('should not compute capacities for certification courses associated to a non finalized session', async function () {
+      stubComputeCapacities
+        .withArgs(certificationCourseId2, sinon.match({ _configuration: challengesConfigurationPixPlusEdu2ndDegre }))
+        .resolves();
+
+      const sessionNotFinalizedId = databaseBuilder.factory.buildSession().id;
+      const ids1 = buildUserAndCertificationCourseAndAssessment(sessionNotFinalizedId);
+      userId1 = ids1.userId;
+      certificationCourseId1 = ids1.certificationCourseId;
+      const certificationCandidateId1 = databaseBuilder.factory.buildCertificationCandidate({
+        userId: userId1,
+        sessionId: sessionNotFinalizedId,
+        reconciledAt: dayjs(activationDatePixPlus).add(2, 'days').toDate(),
+      }).id;
+      databaseBuilder.factory.buildComplementaryCertificationSubscription({
+        complementaryCertificationId: complementaryCertificationIdForPixPlus,
+        certificationCandidateId: certificationCandidateId1,
+      });
+
+      const certificationCandidateId2 = databaseBuilder.factory.buildCertificationCandidate({
+        userId: userId2,
+        sessionId: sessionFinalizedId,
+        reconciledAt: dayjs(activationDatePixPlus).add(2, 'days').toDate(),
+      }).id;
+      databaseBuilder.factory.buildComplementaryCertificationSubscription({
+        complementaryCertificationId: complementaryCertificationIdForPixPlus,
+        certificationCandidateId: certificationCandidateId2,
+      });
+      await databaseBuilder.commit();
+
+      await script.handle({ options: { dryRun: true }, logger, computeCapacitiesFnc: stubComputeCapacities });
+
+      expect(logger.info.callCount).to.equal(2);
+      expect(logger.info.getCall(0)).to.have.been.calledWithExactly(
+        'About to compute capacities for certification EDU_2ND_DEGRE for 1 candidates',
+      );
+      expect(logger.info.getCall(1)).to.have.been.calledWithExactly(
+        'Successfully computed capacities for certification EDU_2ND_DEGRE for 1/1 candidates',
+      );
+      expect(stubComputeCapacities.callCount).to.equal(1);
+    });
+  });
+
+  context('when a certification course encounter an error while processing', function () {
+    it('should continue computing capacities for other certification courses', async function () {
+      stubComputeCapacities
+        .withArgs(certificationCourseId1, sinon.match({ _configuration: challengesConfigurationPixPlusEdu2ndDegre }))
+        .rejects();
+      stubComputeCapacities
+        .withArgs(certificationCourseId2, sinon.match({ _configuration: challengesConfigurationPixPlusEdu2ndDegre }))
+        .resolves();
+
+      const certificationCandidateId1 = databaseBuilder.factory.buildCertificationCandidate({
+        userId: userId1,
+        sessionId: sessionFinalizedId,
+        reconciledAt: dayjs(activationDatePixPlus).add(2, 'days').toDate(),
+      }).id;
+      databaseBuilder.factory.buildComplementaryCertificationSubscription({
+        complementaryCertificationId: complementaryCertificationIdForPixPlus,
+        certificationCandidateId: certificationCandidateId1,
+      });
+
+      const certificationCandidateId2 = databaseBuilder.factory.buildCertificationCandidate({
+        userId: userId2,
+        sessionId: sessionFinalizedId,
+        reconciledAt: dayjs(activationDatePixPlus).add(2, 'days').toDate(),
+      }).id;
+      databaseBuilder.factory.buildComplementaryCertificationSubscription({
+        complementaryCertificationId: complementaryCertificationIdForPixPlus,
+        certificationCandidateId: certificationCandidateId2,
+      });
+      await databaseBuilder.commit();
+
+      await script.handle({ options: { dryRun: true }, logger, computeCapacitiesFnc: stubComputeCapacities });
+
+      expect(logger.info.callCount).to.equal(2);
+      expect(logger.info.getCall(0)).to.have.been.calledWithExactly(
+        'About to compute capacities for certification EDU_2ND_DEGRE for 2 candidates',
+      );
+      expect(logger.info.getCall(1)).to.have.been.calledWithExactly(
+        'Successfully computed capacities for certification EDU_2ND_DEGRE for 1/2 candidates',
+      );
+      expect(logger.error.callCount).to.equal(1);
+      expect(logger.error).to.have.been.calledWith(
+        sinon.match(`An error occurred when computing capacities for certification ${certificationCourseId1}, error`),
+      );
+
+      expect(stubComputeCapacities.callCount).to.equal(2);
+    });
+  });
+
+  it('should compute capacities from multiple different certif version', async function () {
+    stubComputeCapacities
+      .withArgs(certificationCourseId1, sinon.match({ _configuration: challengesConfigurationPixPlusEdu2ndDegre }))
+      .resolves();
+
+    stubComputeCapacities
+      .withArgs(certificationCourseId2, sinon.match({ _configuration: challengesConfigurationPixPlusEdu2ndDegre }))
+      .resolves();
+
+    const certificationCandidateId1 = databaseBuilder.factory.buildCertificationCandidate({
+      userId: userId1,
+      sessionId: sessionFinalizedId,
+      reconciledAt: dayjs(activationDatePixPlus).add(2, 'days').toDate(),
+    }).id;
+    databaseBuilder.factory.buildComplementaryCertificationSubscription({
+      complementaryCertificationId: complementaryCertificationIdForPixPlus,
+      certificationCandidateId: certificationCandidateId1,
+    });
+
+    const certificationCandidateId2 = databaseBuilder.factory.buildCertificationCandidate({
+      userId: userId2,
+      sessionId: sessionFinalizedId,
+      reconciledAt: dayjs(activationDatePixPlus).add(2, 'days').toDate(),
+    }).id;
+    databaseBuilder.factory.buildComplementaryCertificationSubscription({
+      complementaryCertificationId: complementaryCertificationIdForPixPlus,
+      certificationCandidateId: certificationCandidateId2,
+    });
+
+    const challengesConfigurationPixPlusEdu1erDegre = '{"for":"pixPlusEdu1erDegre"}';
+    const complementaryCertificationIdForPixPlus2 =
+      databaseBuilder.factory.buildComplementaryCertification.pixEdu1erDegre().id;
+    databaseBuilder.factory.buildCertificationVersion({
+      scope: SCOPES.PIX_PLUS_EDU_1ER_DEGRE,
+      startDate: activationDatePixPlus,
+      challengesConfiguration: challengesConfigurationPixPlusEdu1erDegre,
+    });
+    const ids3 = buildUserAndCertificationCourseAndAssessment(sessionFinalizedId);
+    const userId3 = ids3.userId;
+    const certificationCourseId3 = ids3.certificationCourseId;
+    const certificationCandidateId3 = databaseBuilder.factory.buildCertificationCandidate({
+      userId: userId3,
+      sessionId: sessionFinalizedId,
+      reconciledAt: dayjs(activationDatePixPlus).add(2, 'days').toDate(),
+    }).id;
+    databaseBuilder.factory.buildComplementaryCertificationSubscription({
+      complementaryCertificationId: complementaryCertificationIdForPixPlus2,
+      certificationCandidateId: certificationCandidateId3,
+    });
+
+    stubComputeCapacities
+      .withArgs(certificationCourseId3, sinon.match({ _configuration: challengesConfigurationPixPlusEdu1erDegre }))
+      .resolves();
+
+    await databaseBuilder.commit();
+
+    await script.handle({ options: { dryRun: true }, logger, computeCapacitiesFnc: stubComputeCapacities });
+
+    expect(logger.info.callCount).to.equal(4);
+    expect(logger.info.getCall(0)).to.have.been.calledWithExactly(
+      'About to compute capacities for certification EDU_2ND_DEGRE for 2 candidates',
+    );
+    expect(logger.info.getCall(1)).to.have.been.calledWithExactly(
+      'Successfully computed capacities for certification EDU_2ND_DEGRE for 2/2 candidates',
+    );
+    expect(logger.info.getCall(2)).to.have.been.calledWithExactly(
+      'About to compute capacities for certification EDU_1ER_DEGRE for 1 candidates',
+    );
+    expect(logger.info.getCall(3)).to.have.been.calledWithExactly(
+      'Successfully computed capacities for certification EDU_1ER_DEGRE for 1/1 candidates',
+    );
+
+    expect(stubComputeCapacities.callCount).to.equal(3);
+  });
+});
+
+function buildUserAndCertificationCourseAndAssessment(sessionId) {
+  const userId = databaseBuilder.factory.buildUser().id;
+  const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
+    userId: userId,
+    sessionId: sessionId,
+  }).id;
+  databaseBuilder.factory.buildAssessment({ certificationCourseId });
+  return { userId, certificationCourseId };
+}


### PR DESCRIPTION
## ❄️ Problème

Les recherches pour l’algo de résultat sont en cours pour fournir un résultat aux certifications Pix+ Edu qui ont été passées depuis la réouverture des Pix+ avec l’algo de déroulé de test v3 le 17/11/2025.

Les réflexions actuelles entre métier, contenu et data tournent autour du positionnement de la borne sur l’échelle des capacités des candidats pour déterminer ceux qui seront admissibles au volet 2 (pratique professionnelle en jury externe) vs ceux qui sont non admissibles en fonction du résultat de leur volet 1 (certification Pix+ Edu sur Pix App).

Positionner cette borne de manière judicieuse est très complexe car c’est une toute nouvelle manière de certifier les candidats Pix+ Edu et il n’y a aucun point de repère.

## 🛷 Proposition

Afin d’aider rapidement le métier à choisir une borne, on souhaite fournir via script les capacités obtenues par tous les candidats ayant déjà passé leur volet 1 des certifications Pix+ Edu (1er degré, 2nd degré et CPE) depuis la réouverture (novembre 2025).

## 🧑‍🎄 Pour tester

- Passer une certif Pix+ et Pix ❤️ en RA, finaliser la session
- Lancer le script en dryRun puis sans dryRun (LOG_LEVEL=debug LOG_ENABLED=true node scripts/certification/calculate-capacities.js)
- Après ça, dans la table `certification-challenge-capacities`, les lignes correspondant à la certif Pix+ passée sont censées avoir des capacités ✅ 
