### PR TITLE
[TECH] Ajout d'un raccourci pour installer facilement le package pix-epreuves-components là où c'est nécessaire

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "clean:junior": "cd junior && npm run clean",
     "clean:root": "rm -rf node_modules && rm -rf tmp",
     "configure": "./scripts/configure.sh",
+    "install:components": "cd api && npm i @1024pix/epreuves-components@latest && cd ../mon-pix && npm i @1024pix/epreuves-components@latest && cd ../junior && npm i @1024pix/epreuves-components@latest",
     "lint": "run-p --print-label lint:*",
     "lint:admin": "cd admin && npm run lint",
     "lint:api": "cd api && npm run lint",


### PR DESCRIPTION
## ❄️ Problème
On doit installer le package pix-epreuves-components sur 3 dossiers du mono repo.

## 🛷 Proposition
Dans package.json du dossier `api` on créé un raccourci qui installe le package dans les 3 dossiers attendus `install:components`

## ☃️ Remarques
RAS

## 🧑‍🎄 Pour tester
Tester la commande et voir que ça renvoie pas d'erreur ?