### PR TITLE
[FEATURE] Ajouter une metrique plausible pour la transcription d'un élement audio (PIX-21114)

### DIFF
--- a/mon-pix/app/components/module/element/audio.gjs
+++ b/mon-pix/app/components/module/element/audio.gjs
@@ -7,10 +7,12 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 import { htmlUnsafe } from 'mon-pix/helpers/html-unsafe';
+
 export default class ModulixAudio extends Component {
   @tracked modalIsOpen = false;
 
   @service passageEvents;
+  @service pixMetrics;
 
   @action
   onPlay() {
@@ -32,12 +34,18 @@ export default class ModulixAudio extends Component {
         elementId: this.args.audio.id,
       },
     });
+
+    this.pixMetrics.trackEvent('Clic sur le bouton transcription d’un audio', {
+      category: 'Modulix',
+      elementId: this.args.audio.id,
+    });
   }
 
   @action
   closeModal() {
     this.modalIsOpen = false;
   }
+
   get hasTranscription() {
     return this.args.audio.transcription.length > 0;
   }

--- a/mon-pix/tests/integration/components/module/audio_test.gjs
+++ b/mon-pix/tests/integration/components/module/audio_test.gjs
@@ -44,6 +44,9 @@ module('Integration | Component | Module | Audio', function (hooks) {
 
     const passageEventRecordStub = sinon.stub(passageEventService, 'record');
 
+    const metricsService = this.owner.lookup('service:pix-metrics');
+    const trackEventStub = sinon.stub(metricsService, 'trackEvent');
+
     //  when
     const screen = await render(<template><ModulixAudioElement @audio={{audioElement}} /></template>);
 
@@ -61,6 +64,10 @@ module('Integration | Component | Module | Audio', function (hooks) {
       data: {
         elementId: audioElement.id,
       },
+    });
+    sinon.assert.calledWithExactly(trackEventStub, 'Clic sur le bouton transcription d’un audio', {
+      category: 'Modulix',
+      elementId: audioElement.id,
     });
   });
 


### PR DESCRIPTION
## ❄️ Problème
Nous souhaitons suivre l'utilisation de la transcription d'un élément audio

## 🛷 Proposition
Remontons cette information dans plausible

## ☃️ Remarques
Il restera à ajouter l'évènement sur le plausible de PROD une fois la PR mergée

## 🧑‍🎄 Pour tester

- Écouter des [ronrons](https://app-pr14862.review.pix.fr/modules/galerie)
- Ouvrir la transcription
- Aller sur plausible
- Vérifier que l'évènement a bien été remonté
