### PR TITLE
[TECH] Retirer la présence de la notion de "superviseur" partout dans le code de certification (PIX-21211)

### DIFF
--- a/admin/app/components/certifications/certification/details-v3.gjs
+++ b/admin/app/components/certifications/certification/details-v3.gjs
@@ -80,10 +80,6 @@ const assessmentStateMap = {
     label: 'pages.certifications.certification.details.v3.assessment-state.ended-by-invigilator',
     color: secondaryColor,
   },
-  ['endedBySupervisor']: {
-    label: 'pages.certifications.certification.details.v3.assessment-state.ended-by-invigilator',
-    color: secondaryColor,
-  },
   [assessmentStates.ENDED_DUE_TO_FINALIZATION]: {
     label: 'pages.certifications.certification.details.v3.assessment-state.ended-due-to-finalization',
     color: tertiaryColor,

--- a/admin/app/components/sessions/certifications/status.gjs
+++ b/admin/app/components/sessions/certifications/status.gjs
@@ -8,7 +8,6 @@ export default class CertificationStatusComponent extends Component {
       assessmentStates.STARTED,
       assessmentResultStatus.ERROR,
       assessmentStates.ENDED_BY_INVIGILATOR,
-      'endedBySupervisor',
     ];
     return includes(blockingStatuses, this.args.record.status) || this.args.record.isFlaggedAborted;
   }

--- a/admin/app/models/v3-certification-course-details-for-administration.js
+++ b/admin/app/models/v3-certification-course-details-for-administration.js
@@ -36,9 +36,7 @@ export default class V3CertificationCourseDetailsForAdministration extends Model
   }
 
   get wasEndedByInvigilator() {
-    return (
-      this.assessmentState === assessmentStates.ENDED_BY_INVIGILATOR || this.assessmentState === 'endedBySupervisor'
-    );
+    return this.assessmentState === assessmentStates.ENDED_BY_INVIGILATOR;
   }
 
   get wasCompleted() {
@@ -81,10 +79,8 @@ export default class V3CertificationCourseDetailsForAdministration extends Model
   }
 
   get hasNotBeenCompletedByCandidate() {
-    return [
-      'endedBySupervisor',
-      assessmentStates.ENDED_BY_INVIGILATOR,
-      assessmentStates.ENDED_DUE_TO_FINALIZATION,
-    ].includes(this.assessmentState);
+    return [assessmentStates.ENDED_BY_INVIGILATOR, assessmentStates.ENDED_DUE_TO_FINALIZATION].includes(
+      this.assessmentState,
+    );
   }
 }

--- a/api/src/certification/session-management/domain/models/CertificationAssessment.js
+++ b/api/src/certification/session-management/domain/models/CertificationAssessment.js
@@ -28,7 +28,6 @@ const certificationAssessmentSchema = Joi.object({
       Assessment.states.STARTED,
       Assessment.states.ENDED_BY_INVIGILATOR,
       Assessment.states.ENDED_DUE_TO_FINALIZATION,
-      'endedBySupervisor',
     )
     .required(),
   version: Joi.number()
@@ -186,17 +185,11 @@ export class CertificationAssessment {
     });
   }
 
-  /**
-   * Added `endedBySupervisor` during transition to rename this value to `endedByInvigilator`
-   * This function is used in SessionRepository to count uncompletedCertificationAssessment
-   * to be compared with abortReason in finalizationUseCase
-   */
   static get uncompletedAssessmentStates() {
     return [
       Assessment.states.STARTED,
       Assessment.states.ENDED_BY_INVIGILATOR,
       Assessment.states.ENDED_DUE_TO_FINALIZATION,
-      'endedBySupervisor',
     ];
   }
 

--- a/api/src/certification/session-management/infrastructure/repositories/jury-certification-summary-repository.js
+++ b/api/src/certification/session-management/infrastructure/repositories/jury-certification-summary-repository.js
@@ -139,9 +139,7 @@ function _toDomain(juryCertificationSummaryDTO) {
   return new JuryCertificationSummary({
     ...juryCertificationSummaryDTO,
     status: juryCertificationSummaryDTO.assessmentResultStatus,
-    isEndedByInvigilator:
-      juryCertificationSummaryDTO.assessmentState === Assessment.states.ENDED_BY_INVIGILATOR ||
-      juryCertificationSummaryDTO.assessmentState === 'endedBySupervisor',
+    isEndedByInvigilator: juryCertificationSummaryDTO.assessmentState === Assessment.states.ENDED_BY_INVIGILATOR,
     certificationIssueReports,
   });
 }

--- a/api/src/shared/domain/models/Assessment.js
+++ b/api/src/shared/domain/models/Assessment.js
@@ -71,11 +71,6 @@ class Assessment {
     challengeLiveAlerts,
     companionLiveAlerts,
   } = {}) {
-    // Hack during transition to rename to invigilator
-    if (state === 'endedBySupervisor') {
-      state = Assessment.states.ENDED_BY_INVIGILATOR;
-    }
-
     this.id = id;
     this.createdAt = createdAt;
     this.updatedAt = updatedAt;
@@ -108,11 +103,8 @@ class Assessment {
     return this.state === Assessment.states.STARTED;
   }
 
-  /**
-   * Add `endedBySupervisor` condition for transition to rename state to `invigilator`
-   */
   isEndedByInvigilator() {
-    return this.state === Assessment.states.ENDED_BY_INVIGILATOR || this.state === 'endedBySupervisor';
+    return this.state === Assessment.states.ENDED_BY_INVIGILATOR;
   }
 
   hasBeenEndedDueToFinalization() {

--- a/api/tests/certification/session-management/unit/domain/models/CertificationAssessment_test.js
+++ b/api/tests/certification/session-management/unit/domain/models/CertificationAssessment_test.js
@@ -488,7 +488,7 @@ describe('Unit | Domain | Models | CertificationAssessment', function () {
   });
 
   describe('#endByInvigilator', function () {
-    it('should change the assessment state to "endBySupervisor"', function () {
+    it('should change the assessment state to "endedByInvigilator"', function () {
       // given
       const now = new Date('2020-12-31');
       const certificationAssessment = domainBuilder.buildCertificationAssessment({
@@ -924,7 +924,6 @@ describe('Unit | Domain | Models | CertificationAssessment', function () {
         Assessment.states.STARTED,
         Assessment.states.ENDED_BY_INVIGILATOR,
         Assessment.states.ENDED_DUE_TO_FINALIZATION,
-        'endedBySupervisor',
       ]);
     });
   });

--- a/api/tests/shared/unit/domain/models/Assessment_test.js
+++ b/api/tests/shared/unit/domain/models/Assessment_test.js
@@ -44,17 +44,6 @@ describe('Unit | Domain | Models | Assessment', function () {
   });
 
   describe('#isEndedByInvigilator', function () {
-    it('should return true when its state is endedBySupervisor (to remove after transition to endedByInvigilator)', function () {
-      // given
-      const assessment = new Assessment({ state: 'endedBySupervisor' });
-
-      // when
-      const isEndedByInvigilator = assessment.isEndedByInvigilator();
-
-      // then
-      expect(isEndedByInvigilator).to.be.true;
-    });
-
     it('should return true when its state is endedByInvigilator', function () {
       // given
       const assessment = new Assessment({ state: Assessment.states.ENDED_BY_INVIGILATOR });

--- a/certif/app/models/certification-candidate-for-supervising.js
+++ b/certif/app/models/certification-candidate-for-supervising.js
@@ -33,9 +33,7 @@ export default class CertificationCandidateForSupervising extends Model {
   }
 
   get hasCompleted() {
-    return [assessmentStates.COMPLETED, assessmentStates.ENDED_BY_INVIGILATOR, 'endedBySupervisor'].includes(
-      this.assessmentStatus,
-    );
+    return [assessmentStates.COMPLETED, assessmentStates.ENDED_BY_INVIGILATOR].includes(this.assessmentStatus);
   }
 
   get hasOngoingChallengeLiveAlert() {

--- a/mon-pix/app/controllers/authenticated/certifications/results.js
+++ b/mon-pix/app/controllers/authenticated/certifications/results.js
@@ -3,10 +3,7 @@ import { assessmentStates } from 'mon-pix/models/assessment';
 
 export default class CertificationResultsController extends Controller {
   get isEndedByInvigilator() {
-    return (
-      this.model.assessment.get('state') === assessmentStates.ENDED_BY_INVIGILATOR ||
-      this.model.assessment.get('state') === 'endedBySupervisor'
-    );
+    return this.model.assessment.get('state') === assessmentStates.ENDED_BY_INVIGILATOR;
   }
 
   get hasBeenEndedDueToFinalization() {


### PR DESCRIPTION
## ❄️ Problème

Après plusieurs PRs, nous arrivons enfin à la finale pour retirer définitivement toute mention au terme "superviseur" quand il s'agit du surveillant.

## 🛷 Proposition

Supprimer toutes les occurrences

## ☃️ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🧑‍🎄 Pour tester

Non régression sur un test classique de test de certif + fin par surveillant + publication
