### PR TITLE
[FEATURE] Améliorer le diagnostique et les actions liés aux client_applications

### DIFF
--- a/api/src/identity-access-management/domain/usecases/add-oidc-provider.js
+++ b/api/src/identity-access-management/domain/usecases/add-oidc-provider.js
@@ -87,7 +87,7 @@ const addOidcProvider = async function ({
   addOidcProviderValidator.validate(properties);
 
   const encryptedClientSecret = await cryptoService.encrypt(clientSecret);
-  // eslint-disable-next-line no-unused-vars
+  // eslint-disable-next-line no-unused-vars -- extract clientSecret because only the encrypted value is stored
   const { clientSecret: _, ...propertiesWithoutClientSecret } = properties;
   const propertiesWithEncryptedClientSecret = { encryptedClientSecret, ...propertiesWithoutClientSecret };
 

--- a/api/src/identity-access-management/infrastructure/repositories/client-application.repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/client-application.repository.js
@@ -15,7 +15,12 @@ export const clientApplicationRepository = {
 
   async list() {
     const dtos = await knex.select().from(TABLE_NAME).orderBy('name');
-    return dtos.map(toDomain);
+    return dtos.map((dto) => {
+      const clientApplication = toDomain(dto);
+      // eslint-disable-next-line no-unused-vars -- extract clientSecret so that it's not returned/displayed
+      const { clientSecret, ...clientApplicationWithoutClientSecret } = clientApplication;
+      return clientApplicationWithoutClientSecret;
+    });
   },
 
   async create({ name, clientId, clientSecret, scopes, jurisdiction }) {

--- a/api/src/identity-access-management/infrastructure/repositories/user.repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/user.repository.js
@@ -526,7 +526,7 @@ function _fromKnexDTOToUserDetailsForAdmin({
       authenticationMethod.identityProvider === NON_OIDC_IDENTITY_PROVIDERS.PIX.code &&
       authenticationMethod.authenticationComplement;
     if (isPixAuthenticationMethodWithAuthenticationComplement) {
-      // eslint-disable-next-line no-unused-vars
+      // eslint-disable-next-line no-unused-vars -- extract password so that it's not returned/displayed
       const { password, ...authenticationComplement } = authenticationMethod.authenticationComplement;
       return {
         ...authenticationMethod,

--- a/api/src/identity-access-management/infrastructure/server-authentication.js
+++ b/api/src/identity-access-management/infrastructure/server-authentication.js
@@ -74,6 +74,11 @@ async function validateUser(decodedAccessToken, { request, revokedUserAccessRepo
 
 async function validateClientApplication(decodedAccessToken) {
   if (!decodedAccessToken.client_id) {
+    logger.warn({
+      message: 'decodedAccessToken has no client_id',
+      decodedAccessToken,
+    });
+
     return { isValid: false };
   }
 
@@ -91,16 +96,28 @@ function authenticateJWT({ key, validate }) {
   return async (request, h) => {
     const authorizationHeader = request.headers.authorization;
     if (!authorizationHeader) {
+      logger.warn({
+        message: 'request has no authorizationHeader',
+      });
+
       return boom.unauthorized(null, 'jwt');
     }
 
     const accessToken = tokenService.extractTokenFromAuthChain(authorizationHeader);
     if (!accessToken) {
+      logger.warn({
+        message: 'authorizationHeader has no accessToken',
+      });
+
       return boom.unauthorized();
     }
 
     const decodedAccessToken = tokenService.getDecodedToken(accessToken, key);
     if (!decodedAccessToken) {
+      logger.warn({
+        message: 'accessToken invalid wrt tokenService',
+      });
+
       return boom.unauthorized();
     }
 

--- a/api/tests/identity-access-management/integration/infrastructure/repositories/client-application.repository.test.js
+++ b/api/tests/identity-access-management/integration/infrastructure/repositories/client-application.repository.test.js
@@ -66,8 +66,16 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
 
       // then
       expect(applications).to.have.lengthOf(2);
-      expect(applications[0]).to.deepEqualInstance(domainBuilder.buildClientApplication(application1));
-      expect(applications[1]).to.deepEqualInstance(domainBuilder.buildClientApplication(application2));
+
+      // eslint-disable-next-line no-unused-vars -- extract clientSecret so that it's not returned/displayed
+      const { clientSecret: _1, ...application1WithoutClientSecret } =
+        domainBuilder.buildClientApplication(application1);
+      expect(applications[0]).to.deep.equal(application1WithoutClientSecret);
+
+      // eslint-disable-next-line no-unused-vars -- extract clientSecret so that it's not returned/displayed
+      const { clientSecret: _2, ...application2WithoutClientSecret } =
+        domainBuilder.buildClientApplication(application2);
+      expect(applications[1]).to.deep.equal(application2WithoutClientSecret);
     });
   });
 


### PR DESCRIPTION
## ❄️ Problème

En production lorsqu’on a des problèmes d’utilisation de MADDO il est difficile de diagnostiquer et lorsqu’il faut agir dans le stress il est nécessaire que les interfaces utilisateurs empêchent de faire des erreurs.

## 🛷 Proposition

* Ajouter des logs pour les erreurs d’accès par les _client_applications_
* Ne plus afficher la colonne `clientSecret` dans le listing de la CLI de gestion des applications clientes. En effet, dans des conditions de stress il a été démontré que des admins pensent que le  `clientSecret` affiché dans cette colonne était à utiliser pour obtenir un Acces Token, alors que le contenu de cette colonne est un hash. En n’affichant pas cette colonne les admins vont penser qu’il faut chercher cette information du `clientSecret` ailleurs ou que si on ne l’a pas c’est qu’il faut se créer une nouvelle client_application dédiée,  éventuellement temporaire. Enfin lorsqu’on partage son écran, afficher des secrets, même hashés, n’est pas une bonne pratique.

<img width="1433" height="147" alt="client_applications_list" src="https://github.com/user-attachments/assets/97e7190b-a062-4d86-981f-34307d277ebb" />

## ☃️ Remarques

RAS

## 🧑‍🎄 Pour tester

* Exécuter la commande suivante et vérifier que la colonne `clientSecret` n’est pas affichée : 
   ```shell
   node scripts/identity-access-management/client-applications.js list
   ```
   
* Exécuter la commande suivante et vérifier que le message `accessToken invalid wrt tokenService` est affiché dans la console : 
   ```shell
   curl -X POST -H "Authorization: Bearer DUMMY" http://localhost:3000/api/application/parcoursup/certification/search
   ```