### PR TITLE
[FEATURE] Afficher un message d'erreur quand l'utilisateur n'a pas de droits Pix Orga (PIX-20977)

### DIFF
--- a/orga/app/authenticators/oidc.js
+++ b/orga/app/authenticators/oidc.js
@@ -75,7 +75,7 @@ export default class OidcAuthenticator extends BaseAuthenticator {
    */
   async invalidate(data) {
     const { access_token, shouldCloseSession, identityProviderCode, logoutUrlUuid } = data || {};
-    if (!shouldCloseSession) {
+    if (!shouldCloseSession || this.session.routeAfterInvalidation) {
       return;
     }
 


### PR DESCRIPTION
## ❄️ Problème
Si un personne tente de se connecter via SSO, mais n’a pas de compte ou d’accès à une orga, un message d’erreur doit apparaître, mais actuellement aucun n’est affiché dans ces cas.

## 🛷 Proposition
Quand un utilisateur va sur la page de connexion de Pix Orga, sélectionne un SSO et se connecte avec, pour les les cas suivants : 

- S’il n’a pas de compte Pix existant
- S’il a un compte Pix mais accès à aucune organisation

Alors, ne pas le connecter et rediriger vers la page de login (/connexion) avec le même message d’erreur quand un utilisateur tente de se connecter avec un login mais n’a accès à aucune organisation.

## ☃️ Remarques

Il reste un clignotement à la déconnexion (après connexion via SSO) qu'il faudra corriger

## 🧑‍🎄 Pour tester

**Cas n°1 - sans invitation**
1.1. J'ai un compte Pix trouvé avec le sub, pas de droits Pix Orga (pas de membership), et je me connecte sans invitation via SSO > pas d'affichage de formulaire Pix, ERROR [l'affichage du message est pris en charge par cette PR]

1.2. J'ai un compte Pix trouvé avec le sub, j'ai des droits Pix Orga, et je me connecte sans invitation via SSO > pas d'affichage de formulaire Pix, SUCCESS

**Cas n°2 - sans invitation**
2.1 Je n'ai pas de compte Pix trouvé avec le sub, et je me connecte sans invitation via SSO > formulaire d'association de compte > je n'ai de droits PixOrga > ERROR  [l'affichage du message est pris en charge par cette PR]

Les cas suivants sont des scénarios pour lesquels il faut simplement vérifier la non-régression :

2.2. Je n'ai pas de compte pix trouvé avec le sub, et je me connecte sans invitation via SSO > formulaire d'association de compte > j'ai des droits Pix Orga > SUCCESS (association du compte Pix et du SSO)
Notons que si les droits pix Orga ont été obtenus via un ajout direct sur Pix Admin, l'utilisateur ne s'est jamais connecté à Pix Orga donc il est redirigé vers les CGU.

**Cas n°3 - avec invitation**
3.1. Je n'ai pas de compte Pix trouvé avec le sub, j'ai déjà des droits Pix Orga, et je me connecte avec invitation via SSO (association) > SUCCESS
3.2. Je n'ai pas de compte Pix trouvé avec le sub, et je crée mon compte Pix avec invitation via SSO > connexion > SUCCESS

**Cas n°4 - avec invitation**
J'ai un compte Pix trouvé avec le sub, pas de droits Pix Orga (pas de membership), et je me connecte avec invitation via SSO > SUCCES

