### PR TITLE
[TECH] Ajouter un pre handler sur la route de modification des numéros étudiants (PIX-19093).

### DIFF
--- a/api/src/prescription/learner-management/application/sup-organization-management-route.js
+++ b/api/src/prescription/learner-management/application/sup-organization-management-route.js
@@ -3,7 +3,6 @@ import BaseJoi from 'joi';
 const Joi = BaseJoi.extend(JoiDate);
 
 import {
-  NotFoundError,
   PayloadTooLargeError,
   sendJsonApiError,
   UnprocessableEntityError,
@@ -154,6 +153,9 @@ const register = async function (server) {
           {
             method: securityPreHandlers.checkUserIsAdminInSUPOrganizationManagingStudents,
           },
+          {
+            method: securityPreHandlers.checkUserBelongsToLearnersOrganization,
+          },
         ],
         handler: supOrganizationManagementController.updateStudentNumber,
         validate: {
@@ -171,13 +173,6 @@ const register = async function (server) {
               },
             },
           }),
-          failAction: (request, h, err) => {
-            const isStudentNumber = err.details[0].path.includes('student-number');
-            if (isStudentNumber) {
-              return sendJsonApiError(new UnprocessableEntityError('Un des champs saisis n’est pas valide.'), h);
-            }
-            return sendJsonApiError(new NotFoundError('Ressource non trouvée'), h);
-          },
         },
         notes: [
           "- **Cette route est restreinte aux utilisateurs authentifiés et admin au sein de l'orga**\n" +

--- a/api/tests/prescription/learner-management/integration/application/sup-organization-management-routes_test.js
+++ b/api/tests/prescription/learner-management/integration/application/sup-organization-management-routes_test.js
@@ -1,7 +1,6 @@
 import { supOrganizationManagementController } from '../../../../../src/prescription/learner-management/application/sup-organization-management-controller.js';
 import * as moduleUnderTest from '../../../../../src/prescription/learner-management/application/sup-organization-management-route.js';
-import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
-import { expect, generateAuthenticatedUserRequestHeaders, HttpTestServer, sinon } from '../../../../test-helper.js';
+import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
 
 describe('Integration | Application | Route | sup-organization-learners', function () {
   let httpTestServer;
@@ -11,130 +10,8 @@ describe('Integration | Application | Route | sup-organization-learners', functi
       .stub(supOrganizationManagementController, 'reconcileSupOrganizationLearner')
       .callsFake((request, h) => h.response('ok').code(204));
 
-    sinon
-      .stub(securityPreHandlers, 'checkUserIsAdminInSUPOrganizationManagingStudents')
-      .callsFake((request, h) => h.response(true));
-    sinon.stub(supOrganizationManagementController, 'updateStudentNumber').returns('ok');
-
     httpTestServer = new HttpTestServer();
     await httpTestServer.register(moduleUnderTest);
-  });
-
-  describe('PATCH /api/organizations/id/sup-organization-learners/organizationLearnerId', function () {
-    const method = 'PATCH';
-    const organizationId = 2;
-    const organizationLearnerId = '1234';
-    const userId = 2;
-    let headers;
-
-    beforeEach(function () {
-      headers = generateAuthenticatedUserRequestHeaders({ userId });
-    });
-
-    context('when the user is authenticated', function () {
-      it('should exist', async function () {
-        // given
-        const url = `/api/organizations/${organizationId}/sup-organization-learners/${organizationLearnerId}`;
-        const payload = {
-          data: {
-            attributes: {
-              'student-number': '1234',
-            },
-          },
-        };
-        // when
-        const response = await httpTestServer.request(method, url, payload, null, headers);
-
-        // then
-        expect(response.statusCode).to.equal(200);
-      });
-
-      it('should return a 422 status error when student-number parameter is not a string', async function () {
-        // given
-        const url = `/api/organizations/${organizationId}/sup-organization-learners/${organizationLearnerId}`;
-        const payload = {
-          data: {
-            attributes: {
-              'student-number': 1234,
-            },
-          },
-        };
-
-        // when
-        const response = await httpTestServer.request(method, url, payload, null, headers);
-
-        // then
-        const responsePayload = JSON.parse(response.payload);
-        expect(response.statusCode).to.equal(422);
-        expect(responsePayload.errors[0].title).to.equal('Unprocessable entity');
-        expect(responsePayload.errors[0].detail).to.equal('Un des champs saisis n’est pas valide.');
-      });
-
-      it('should return a 404 status error when organizationId parameter is not a number', async function () {
-        // given
-        const url = `/api/organizations/FAKE_ORGANIZATION_ID/sup-organization-learners/${organizationLearnerId}`;
-        const payload = {
-          data: {
-            attributes: {
-              'student-number': '1234',
-            },
-          },
-        };
-
-        // when
-        const response = await httpTestServer.request(method, url, payload, null, headers);
-
-        // then
-        const responsePayload = JSON.parse(response.payload);
-        expect(response.statusCode).to.equal(404);
-        expect(responsePayload.errors[0].title).to.equal('Not Found');
-        expect(responsePayload.errors[0].detail).to.equal('Ressource non trouvée');
-      });
-
-      it('should return a 404 status error when studentId parameter is not a number', async function () {
-        // given
-        const url = `/api/organizations/${organizationId}/sup-organization-learners/FAKE_STUDENT_ID`;
-        const payload = {
-          data: {
-            attributes: {
-              'student-number': '1234',
-            },
-          },
-        };
-
-        // when
-        const response = await httpTestServer.request(method, url, payload, null, headers);
-
-        // then
-        const responsePayload = JSON.parse(response.payload);
-        expect(response.statusCode).to.equal(404);
-        expect(responsePayload.errors[0].title).to.equal('Not Found');
-        expect(responsePayload.errors[0].detail).to.equal('Ressource non trouvée');
-      });
-    });
-
-    context('when the user is not authenticated', function () {
-      it('should return an error when the user is not authenticated', async function () {
-        // given
-        securityPreHandlers.checkUserIsAdminInSUPOrganizationManagingStudents.callsFake((request, h) =>
-          h.response().code(403).takeover(),
-        );
-        const url = `/api/organizations/${organizationId}/sup-organization-learners/${organizationLearnerId}`;
-        const payload = {
-          data: {
-            attributes: {
-              'student-number': '1234',
-            },
-          },
-        };
-
-        // when
-        const response = await httpTestServer.request(method, url, payload, null, headers);
-
-        // then
-        expect(response.statusCode).to.equal(403);
-      });
-    });
   });
 
   describe('POST /api/sup-organization-learners/association', function () {


### PR DESCRIPTION
## ❄️ Problème


## 🛷 Proposition

Ajouter un pre handler dans la modification de route de numéro étudiant

## ☃️ Remarques

RAS

## 🧑‍🎄 Pour tester

CI au vert, modification du numéro étidiant sur une organisation SUP fonctionnel