### PR TITLE
[FEATURE] Gérer le reset du formulaire selon s'il a pu être transmis ou non à l'API (PIX-21010)

### DIFF
--- a/mon-pix/app/components/module/issue-report/issue-report-modal.gjs
+++ b/mon-pix/app/components/module/issue-report/issue-report-modal.gjs
@@ -11,6 +11,7 @@ import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 import { eq } from 'ember-truth-helpers';
 import InElement from 'mon-pix/components/in-element';
+import htmlUnsafe from 'mon-pix/helpers/html-unsafe';
 
 import { categoriesKey } from '../../../models/module-issue-report';
 
@@ -83,7 +84,9 @@ export default class ModulixIssueReportModal extends Component {
     }
 
     if (this.args.sentStatus === 'error') {
-      return this.intl.t('pages.modulix.issue-report.modal.confirmation-message.error');
+      const errorInfo = this.intl.t('pages.modulix.issue-report.modal.confirmation-message.error.info');
+      const errorRetry = this.intl.t('pages.modulix.issue-report.modal.confirmation-message.error.retry');
+      return `${errorInfo}<br>${errorRetry}`;
     }
 
     return this.intl.t('pages.modulix.issue-report.modal.confirmation-message.success');
@@ -180,7 +183,7 @@ export default class ModulixIssueReportModal extends Component {
               @withIcon={{true}}
               @class="{{if (eq this.notificationStatusType 'error') 'issue-report-modal__error-message'}}"
             >
-              {{this.statusMessage}}
+              {{htmlUnsafe this.statusMessage}}
             </PixNotificationAlert>
           {{/if}}
         </:content>

--- a/mon-pix/app/components/module/issue-report/issue-report-modal.gjs
+++ b/mon-pix/app/components/module/issue-report/issue-report-modal.gjs
@@ -77,18 +77,24 @@ export default class ModulixIssueReportModal extends Component {
     }));
   }
 
-  get errorMessageDisplayed() {
-    if (this.args.sentStatus === 'error') return this.sentStatusMessage;
-    return this.errorMessage;
+  get statusMessage() {
+    if (!this.args.sentStatus) {
+      return this.errorMessage ?? '';
+    }
+
+    if (this.args.sentStatus === 'error') {
+      return this.intl.t('pages.modulix.issue-report.modal.confirmation-message.error');
+    }
+
+    return this.intl.t('pages.modulix.issue-report.modal.confirmation-message.success');
   }
 
-  get sentStatusMessage() {
-    if (!this.args.sentStatus) {
-      return '';
+  get notificationStatusType() {
+    if (this.errorMessage || this.args.sentStatus === 'error') {
+      return 'error';
     }
-    return this.args.sentStatus === 'success'
-      ? this.intl.t('pages.modulix.issue-report.modal.confirmation-message.success')
-      : this.intl.t('pages.modulix.issue-report.modal.confirmation-message.error');
+
+    return 'success';
   }
 
   @action
@@ -124,7 +130,8 @@ export default class ModulixIssueReportModal extends Component {
     if (moduleIssueReportForm) {
       moduleIssueReportForm.reset();
       this.selectedCategory = this.categories[0].value;
-      this.comment = null;
+      this.comment = '';
+      this.errorMessage = null;
     }
   }
 
@@ -137,14 +144,10 @@ export default class ModulixIssueReportModal extends Component {
         @showModal={{@showModal}}
       >
         <:content>
-          <p class="issue-report-modal__mandatory">
-            {{t "common.form.mandatory-all-fields"}}
-          </p>
-          {{#if (eq @sentStatus "success")}}
-            <PixNotificationAlert @type={{@sentStatus}} @withIcon={{true}}>
-              {{this.sentStatusMessage}}
-            </PixNotificationAlert>
-          {{else}}
+          {{#unless (eq @sentStatus "success")}}
+            <p class="issue-report-modal__mandatory">
+              {{t "common.form.mandatory-all-fields"}}
+            </p>
             <form class="issue-report-modal-form" id="module-issue-report-form">
               <fieldset class="issue-report-modal-form__fieldset">
                 <legend class="sr-only">{{t "pages.modulix.issue-report.modal.legend"}}</legend>
@@ -170,16 +173,19 @@ export default class ModulixIssueReportModal extends Component {
                 </PixTextarea>
               </fieldset>
             </form>
-
-            {{#if this.errorMessageDisplayed}}
-              <PixNotificationAlert @type="error" class="issue-report-modal__error-message">
-                {{this.errorMessageDisplayed}}
-              </PixNotificationAlert>
-            {{/if}}
+          {{/unless}}
+          {{#if this.statusMessage}}
+            <PixNotificationAlert
+              @type={{this.notificationStatusType}}
+              @withIcon={{true}}
+              @class="{{if (eq this.notificationStatusType 'error') 'issue-report-modal__error-message'}}"
+            >
+              {{this.statusMessage}}
+            </PixNotificationAlert>
           {{/if}}
         </:content>
         <:footer>
-          {{#if @sentStatus}}
+          {{#if (eq @sentStatus "success")}}
             <div class="issue-report-modal-form__action-buttons">
               <PixButton @triggerAction={{this.hideModal}}>{{t "common.actions.close"}}</PixButton>
             </div>

--- a/mon-pix/tests/integration/components/module/issue-report/issue-report-block_test.gjs
+++ b/mon-pix/tests/integration/components/module/issue-report/issue-report-block_test.gjs
@@ -160,7 +160,12 @@ module('Integration | Component | Module | Issue Report | Issue Report Block', f
           await click(screen.getByRole('button', { name: t('common.actions.send') }));
 
           // then
-          assert.dom(screen.getByText(t('pages.modulix.issue-report.modal.confirmation-message.error')));
+          const content = screen.getByText(
+            (content) =>
+              content.startsWith('Une erreur est survenue lors de l‘envoi du commentaire.') &&
+              content.endsWith('Veuillez réessayer plus tard.'),
+          );
+          assert.dom(content).exists();
           assert
             .dom(screen.getByRole('textbox', { name: t('pages.modulix.issue-report.modal.textarea-label') }))
             .hasValue(comment);

--- a/mon-pix/tests/integration/components/module/issue-report/issue-report-block_test.gjs
+++ b/mon-pix/tests/integration/components/module/issue-report/issue-report-block_test.gjs
@@ -110,14 +110,16 @@ module('Integration | Component | Module | Issue Report | Issue Report Block', f
 
           await click(screen.getByRole('button', { name: t('common.actions.send') }));
 
-        // then
-        const buttons = screen.getAllByRole('button', { name: t('common.actions.close') });
-        assert.strictEqual(buttons.length, 2);
-        assert.dom(screen.getByText(t('pages.modulix.issue-report.modal.confirmation-message.success')));
+          // then
+          assert
+            .dom(screen.queryByRole('textbox', { name: t('pages.modulix.issue-report.modal.textarea-label') }))
+            .doesNotExist();
+          const closeButtons = screen.getAllByRole('button', { name: t('common.actions.close') });
+          assert.strictEqual(closeButtons.length, 2);
+          assert.dom(screen.getByText(t('pages.modulix.issue-report.modal.confirmation-message.success')));
 
-        const closeButtons = screen.getAllByRole('button', { name: t('common.actions.close') });
-        await click(closeButtons[0]);
-        await waitForDialogClose();
+          await click(closeButtons[0]);
+          await waitForDialogClose();
 
           assert
             .dom(screen.queryByRole('heading', { name: t('pages.modulix.issue-report.modal.title'), level: 1 }))

--- a/mon-pix/tests/integration/components/module/issue-report/issue-report-block_test.gjs
+++ b/mon-pix/tests/integration/components/module/issue-report/issue-report-block_test.gjs
@@ -24,7 +24,8 @@ module('Integration | Component | Module | Issue Report | Issue Report Block', f
       // when
       const screen = await render(
         <template>
-          <div id="modal-container"></div><ModuleIssueReportBlock />
+          <div id="modal-container"></div>
+          <ModuleIssueReportBlock />
         </template>,
       );
       await click(screen.getByRole('button', { name: t('pages.modulix.issue-report.aria-label') }));
@@ -49,7 +50,8 @@ module('Integration | Component | Module | Issue Report | Issue Report Block', f
         // when
         const screen = await render(
           <template>
-            <div id="modal-container"></div><ModuleIssueReportBlock @reportInfo={{reportInfo}} />
+            <div id="modal-container"></div>
+            <ModuleIssueReportBlock @reportInfo={{reportInfo}} />
           </template>,
         );
         await click(screen.getByRole('button', { name: t('pages.modulix.issue-report.aria-label') }));
@@ -76,35 +78,37 @@ module('Integration | Component | Module | Issue Report | Issue Report Block', f
         assert.ok(true);
       });
 
-      test('should display a confirmation message', async function (assert) {
-        // given
-        const issueReportService = this.owner.lookup('service:moduleIssueReport');
-        const elementId = 'b37e8e8d-9875-4b15-85c0-0373ffbb0805';
-        const answer = 42;
-        const comment = 'Mon super commentaire de Noel et de joie';
-        const reportInfo = { elementId, answer };
+      module('when api call has succeed', function () {
+        test('should hide form and display a confirmation message', async function (assert) {
+          // given
+          const issueReportService = this.owner.lookup('service:moduleIssueReport');
+          const elementId = 'b37e8e8d-9875-4b15-85c0-0373ffbb0805';
+          const answer = 42;
+          const comment = 'Mon super commentaire de Noel et de joie';
+          const reportInfo = { elementId, answer };
 
-        sinon.stub(issueReportService, 'record').resolves();
+          sinon.stub(issueReportService, 'record').resolves();
 
-        // when
-        const screen = await render(
-          <template>
-            <div id="modal-container"></div><ModuleIssueReportBlock @reportInfo={{reportInfo}} />
-          </template>,
-        );
-        await click(screen.getByRole('button', { name: t('pages.modulix.issue-report.aria-label') }));
-        await waitForDialog();
+          // when
+          const screen = await render(
+            <template>
+              <div id="modal-container"></div>
+              <ModuleIssueReportBlock @reportInfo={{reportInfo}} />
+            </template>,
+          );
+          await click(screen.getByRole('button', { name: t('pages.modulix.issue-report.aria-label') }));
+          await waitForDialog();
 
-        await click(screen.getByRole('button', { name: t('pages.modulix.issue-report.modal.select-label') }));
-        await screen.findByRole('listbox');
-        await click(screen.getByRole('option', { name: 'Problème d’accessibilité' }));
+          await click(screen.getByRole('button', { name: t('pages.modulix.issue-report.modal.select-label') }));
+          await screen.findByRole('listbox');
+          await click(screen.getByRole('option', { name: 'Problème d’accessibilité' }));
 
-        await fillIn(
-          screen.getByRole('textbox', { name: t('pages.modulix.issue-report.modal.textarea-label') }),
-          comment,
-        );
+          await fillIn(
+            screen.getByRole('textbox', { name: t('pages.modulix.issue-report.modal.textarea-label') }),
+            comment,
+          );
 
-        await click(screen.getByRole('button', { name: t('common.actions.send') }));
+          await click(screen.getByRole('button', { name: t('common.actions.send') }));
 
         // then
         const buttons = screen.getAllByRole('button', { name: t('common.actions.close') });
@@ -115,45 +119,50 @@ module('Integration | Component | Module | Issue Report | Issue Report Block', f
         await click(closeButtons[0]);
         await waitForDialogClose();
 
-        assert
-          .dom(screen.queryByRole('heading', { name: t('pages.modulix.issue-report.modal.title'), level: 1 }))
-          .doesNotExist();
+          assert
+            .dom(screen.queryByRole('heading', { name: t('pages.modulix.issue-report.modal.title'), level: 1 }))
+            .doesNotExist();
+        });
       });
 
-      test('should display an error message when api call has failed', async function (assert) {
-        // given
-        const issueReportService = this.owner.lookup('service:moduleIssueReport');
-        const elementId = 'b37e8e8d-9875-4b15-85c0-0373ffbb0805';
-        const answer = 42;
-        const comment = 'Mon super commentaire de Noel et de joie';
-        const reportInfo = { elementId, answer };
+      module('when api call has failed', function () {
+        test('should display an error message and keep form fulfilled', async function (assert) {
+          // given
+          const issueReportService = this.owner.lookup('service:moduleIssueReport');
+          const elementId = 'b37e8e8d-9875-4b15-85c0-0373ffbb0805';
+          const answer = 42;
+          const comment = 'Mon super commentaire de Noel et de joie';
+          const reportInfo = { elementId, answer };
 
-        sinon.stub(issueReportService, 'record').rejects();
+          sinon.stub(issueReportService, 'record').rejects();
 
-        // when
-        const screen = await render(
-          <template>
-            <div id="modal-container"></div><ModuleIssueReportBlock @reportInfo={{reportInfo}} />
-          </template>,
-        );
-        await click(screen.getByRole('button', { name: t('pages.modulix.issue-report.aria-label') }));
-        await waitForDialog();
+          // when
+          const screen = await render(
+            <template>
+              <div id="modal-container"></div>
+              <ModuleIssueReportBlock @reportInfo={{reportInfo}} />
+            </template>,
+          );
+          await click(screen.getByRole('button', { name: t('pages.modulix.issue-report.aria-label') }));
+          await waitForDialog();
 
-        await click(screen.getByRole('button', { name: t('pages.modulix.issue-report.modal.select-label') }));
-        await screen.findByRole('listbox');
-        await click(screen.getByRole('option', { name: 'Problème d’accessibilité' }));
+          await click(screen.getByRole('button', { name: t('pages.modulix.issue-report.modal.select-label') }));
+          await screen.findByRole('listbox');
+          await click(screen.getByRole('option', { name: 'Problème d’accessibilité' }));
 
-        await fillIn(
-          screen.getByRole('textbox', { name: t('pages.modulix.issue-report.modal.textarea-label') }),
-          comment,
-        );
+          await fillIn(
+            screen.getByRole('textbox', { name: t('pages.modulix.issue-report.modal.textarea-label') }),
+            comment,
+          );
 
-        await click(screen.getByRole('button', { name: t('common.actions.send') }));
+          await click(screen.getByRole('button', { name: t('common.actions.send') }));
 
-        // then
-        const buttons = screen.getAllByRole('button', { name: t('common.actions.close') });
-        assert.strictEqual(buttons.length, 2);
-        assert.dom(screen.getByText(t('pages.modulix.issue-report.modal.confirmation-message.error')));
+          // then
+          assert.dom(screen.getByText(t('pages.modulix.issue-report.modal.confirmation-message.error')));
+          assert
+            .dom(screen.getByRole('textbox', { name: t('pages.modulix.issue-report.modal.textarea-label') }))
+            .hasValue(comment);
+        });
       });
     });
 
@@ -167,7 +176,8 @@ module('Integration | Component | Module | Issue Report | Issue Report Block', f
         // when
         const screen = await render(
           <template>
-            <div id="modal-container"></div><ModuleIssueReportBlock @reportInfo={{reportInfo}} />
+            <div id="modal-container"></div>
+            <ModuleIssueReportBlock @reportInfo={{reportInfo}} />
           </template>,
         );
 

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1686,7 +1686,10 @@
             }
           },
           "confirmation-message": {
-            "error": "An error occurred when sending the comment.",
+            "error": {
+              "info": "An error occurred when sending the comment.",
+              "retry": "Please retry later."
+            },
             "success": "Thank you for your comment."
           },
           "legend": "Information required to send a report",

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1682,7 +1682,10 @@
             }
           },
           "confirmation-message": {
-            "error": "Se ha producido un error al enviar el comentario.",
+            "error": {
+              "info": "Se ha producido un error al enviar el comentario.",
+              "retry": "Vuelva a intentarlo más tarde."
+            },
             "success": "Gracias, hemos tomado nota de su comentario."
           },
           "legend": "Información necesaria para enviar una denuncia",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1694,7 +1694,10 @@
             }
           },
           "confirmation-message": {
-            "error": "Une erreur est survenue lors de l‘envoi du commentaire.",
+            "error": {
+              "info": "Une erreur est survenue lors de l‘envoi du commentaire.",
+              "retry": "Veuillez réessayer plus tard."
+            },
             "success": "Merci votre commentaire a été bien pris en compte."
           },
           "legend": "Informations requises pour envoyer un signalement",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1686,7 +1686,10 @@
             }
           },
           "confirmation-message": {
-            "error": "Er is een fout opgetreden bij het verzenden van de opmerking.",
+            "error": {
+              "info": "Er is een fout opgetreden bij het verzenden van de opmerking.",
+              "retry": "Probeer het later nog eens."
+            },
             "success": "Bedankt, uw opmerking is genoteerd."
           },
           "legend": "Informatie die nodig is om een melding te versturen",


### PR DESCRIPTION
## ❄️ Problème

Aujourd'hui, si j'envoie un signalement mais qu'il y a une erreur côté API, la modale de signalement se ferme et remet à zéro tous les champs.

## 🛷 Proposition

Lors d'une erreur API lors de l'envoi, laisser le formulaire affiché, avec ses champs remplis. Une notification précisant que l'envoi a échoué apparaît en dessous du formulaire.

## ☃️ Remarques

- On en a profité pour refacto le code dans issue-report-modal, au niveau de la gestion des notifications

## 🧑‍🎄 Pour tester

- Récupérer la branche localement
- Ouvrir le module [bac-a-sable](https://app-pr14874.review.pix.fr/modules/6a68bf32/bac-a-sable/passage)

### Cas envoi réussi
- Cliquer sur le bouton de signalement
- Remplir le formulaire et l'envoyer
- Le formulaire disparait et une notification indiquant le succès de l'envoi s'affiche
- Cliquer sur "Fermer" pour fermer la modale

### Cas envoi échoué
- Modifier localement l'API pour générer une erreur dans l'appel par le Front
- Dans un [module](https://app-pr14874.review.pix.fr/modules/6a68bf32/bac-a-sable/passage), cliquer sur le bouton de signalement
- Remplir le formulaire et l'envoyer
- Le formulaire doit rester affiché, et une notification indiquant l'erreur de l'envoi s'affiche
- Les boutons en dessous sont "Annuler" et "Envoyer"
