### PR TITLE
[FEATURE] Rendre obligatoire le nombre de places pour la création de lots (PIX-21188).

### DIFF
--- a/admin/app/components/organizations/places-lot-creation-form.gjs
+++ b/admin/app/components/organizations/places-lot-creation-form.gjs
@@ -95,6 +95,7 @@ export default class PlacesLotCreationForm extends Component {
             <PixInput
               class={{if @errors.count "form-control is-invalid" "form-control"}}
               @value={{this.count}}
+              @requiredLabel={{t "common.forms.mandatory"}}
               {{on "input" this.onCountChange}}
             ><:label>Nombre :</:label></PixInput>
 

--- a/admin/app/components/organizations/places-lot-creation-form.gjs
+++ b/admin/app/components/organizations/places-lot-creation-form.gjs
@@ -95,6 +95,7 @@ export default class PlacesLotCreationForm extends Component {
             <PixInput
               class={{if @errors.count "form-control is-invalid" "form-control"}}
               @value={{this.count}}
+              type="number"
               @requiredLabel={{t "common.forms.mandatory"}}
               {{on "input" this.onCountChange}}
             ><:label>Nombre :</:label></PixInput>

--- a/admin/tests/integration/components/organizations/places-lot-creation-form-test.gjs
+++ b/admin/tests/integration/components/organizations/places-lot-creation-form-test.gjs
@@ -1,4 +1,4 @@
-import { fillByLabel, render } from '@1024pix/ember-testing-library';
+import { render } from '@1024pix/ember-testing-library';
 import { click, fillIn } from '@ember/test-helpers';
 import PlacesLotCreationForm from 'pix-admin/components/organizations/places-lot-creation-form';
 import { module, test } from 'qunit';
@@ -16,7 +16,7 @@ module('Integration | Component | organizations/places-lot-creation-form', funct
     const screen = await render(<template><PlacesLotCreationForm @create={{create}} /></template>);
 
     // when
-    await fillIn(screen.getByLabelText("Nombre : *", { exact: false }), '10');
+    await fillIn(screen.getByLabelText('Nombre : *', { exact: false }), 10);
     await fillIn(screen.getByLabelText("Date d'activation *", { exact: false }), '2022-10-20');
     await fillIn(screen.getByLabelText("Date d'expiration *", { exact: false }), '2022-10-20');
 
@@ -40,7 +40,7 @@ module('Integration | Component | organizations/places-lot-creation-form', funct
     const screen = await render(<template><PlacesLotCreationForm @create={{create}} /></template>);
 
     // when
-    await fillIn(screen.getByLabelText("Nombre : *", { exact: false }), '10');
+    await fillIn(screen.getByLabelText('Nombre : *', { exact: false }), 10);
     await fillIn(screen.getByLabelText("Date d'activation *", { exact: false }), '2022-10-20');
     await fillIn(screen.getByLabelText("Date d'expiration *", { exact: false }), '2022-12-20');
 

--- a/admin/tests/integration/components/organizations/places-lot-creation-form-test.gjs
+++ b/admin/tests/integration/components/organizations/places-lot-creation-form-test.gjs
@@ -16,7 +16,7 @@ module('Integration | Component | organizations/places-lot-creation-form', funct
     const screen = await render(<template><PlacesLotCreationForm @create={{create}} /></template>);
 
     // when
-    await fillByLabel('Nombre :', '10');
+    await fillIn(screen.getByLabelText("Nombre : *", { exact: false }), '10');
     await fillIn(screen.getByLabelText("Date d'activation *", { exact: false }), '2022-10-20');
     await fillIn(screen.getByLabelText("Date d'expiration *", { exact: false }), '2022-10-20');
 
@@ -40,7 +40,7 @@ module('Integration | Component | organizations/places-lot-creation-form', funct
     const screen = await render(<template><PlacesLotCreationForm @create={{create}} /></template>);
 
     // when
-    await fillByLabel('Nombre :', '10');
+    await fillIn(screen.getByLabelText("Nombre : *", { exact: false }), '10');
     await fillIn(screen.getByLabelText("Date d'activation *", { exact: false }), '2022-10-20');
     await fillIn(screen.getByLabelText("Date d'expiration *", { exact: false }), '2022-12-20');
 

--- a/api/src/prescription/organization-place/application/organization-place-route.js
+++ b/api/src/prescription/organization-place/application/organization-place-route.js
@@ -93,7 +93,7 @@ const register = async (server) => {
           payload: Joi.object({
             data: Joi.object({
               attributes: Joi.object({
-                count: Joi.number().integer().min(0).allow(null),
+                count: Joi.number().integer().min(0).required(),
                 category: Joi.string().required(),
                 reference: Joi.string().required(),
                 'activation-date': Joi.date().required(),

--- a/api/src/prescription/organization-place/domain/validators/organization-places-lot-validator.js
+++ b/api/src/prescription/organization-place/domain/validators/organization-places-lot-validator.js
@@ -1,8 +1,11 @@
 import JoiDate from '@joi/date';
 import BaseJoi from 'joi';
 const Joi = BaseJoi.extend(JoiDate);
+
 import { EntityValidationError } from '../../../../shared/domain/errors.js';
 import * as categories from '../constants/organization-places-categories.js';
+
+const MINIMUM_DATE_FOR_PLACES_LOT_CREATION = '2015-01-01';
 
 const schema = Joi.object({
   organizationId: Joi.number().integer().required().messages({
@@ -14,8 +17,9 @@ const schema = Joi.object({
     'number.positive': `Le nombre de places doit être un nombre sans virgule supérieur à 0.`,
     'number.integer': `Le nombre de places doit être un nombre sans virgule supérieur à 0.`,
   }),
-  activationDate: Joi.date().format('YYYY-MM-DD').required().messages({
+  activationDate: Joi.date().format('YYYY-MM-DD').greater(MINIMUM_DATE_FOR_PLACES_LOT_CREATION).required().messages({
     'any.required': `Les dates d'activation et d'expiration sont obligatoires.`,
+    'date.greater': `La date d'activation est trop ancienne.`,
     'date.format': `Le format de La date n'est pas correct.`,
   }),
   expirationDate: Joi.date()

--- a/api/src/prescription/organization-place/domain/validators/organization-places-lot-validator.js
+++ b/api/src/prescription/organization-place/domain/validators/organization-places-lot-validator.js
@@ -9,7 +9,7 @@ const schema = Joi.object({
     'any.required': `L'organisationId est obligatoire.`,
     'number.base': `L'identifiant de l'organisation doit être un nombre.`,
   }),
-  count: Joi.number().integer().positive().allow(null).messages({
+  count: Joi.number().integer().positive().required().messages({
     'number.base': `Le nombre de places doit être un nombre sans virgule supérieur à 0.`,
     'number.positive': `Le nombre de places doit être un nombre sans virgule supérieur à 0.`,
     'number.integer': `Le nombre de places doit être un nombre sans virgule supérieur à 0.`,

--- a/api/tests/prescription/organization-place/integration/infrastructure/repositories/organization-places-lot-repository_test.js
+++ b/api/tests/prescription/organization-place/integration/infrastructure/repositories/organization-places-lot-repository_test.js
@@ -294,7 +294,7 @@ describe('Integration | Repository | Organization Places Lot', function () {
         count: 66,
         category: categories.FREE_RATE,
         reference: 'Godzilla',
-        activationDate: new Date('2014-05-13'),
+        activationDate: new Date('2020-05-13'),
         expirationDate: new Date('2021-07-01'),
         createdBy: user.id,
       });

--- a/api/tests/prescription/organization-place/unit/domain/models/OrganizationPlacesLot_test.js
+++ b/api/tests/prescription/organization-place/unit/domain/models/OrganizationPlacesLot_test.js
@@ -279,6 +279,31 @@ describe('Unit | Domain | Models | OrganizationPlacesLotForManagement', function
             },
           ]);
         });
+
+        it('it should throw an exception when activationDate is too ancient', function () {
+          //given
+          const attributes = {
+            ...initialAttributes,
+            activationDate: '1999-10-10',
+          };
+
+          //when
+          let error;
+          try {
+            new OrganizationPlacesLotForManagement(attributes);
+          } catch (e) {
+            error = e;
+          }
+
+          //then
+          expect(error).to.be.instanceOf(EntityValidationError);
+          expect(error.invalidAttributes).to.deep.equals([
+            {
+              attribute: 'activationDate',
+              message: `La date d'activation est trop ancienne.`,
+            },
+          ]);
+        });
       });
 
       context('#expirationDate', function () {

--- a/api/tests/prescription/organization-place/unit/domain/models/OrganizationPlacesLot_test.js
+++ b/api/tests/prescription/organization-place/unit/domain/models/OrganizationPlacesLot_test.js
@@ -202,6 +202,31 @@ describe('Unit | Domain | Models | OrganizationPlacesLotForManagement', function
             },
           ]);
         });
+
+        it('it should throw an exception when count is missing', function () {
+          //given
+          const attributes = {
+            ...initialAttributes,
+            count: undefined,
+          };
+
+          //when
+          let error;
+          try {
+            new OrganizationPlacesLotForManagement(attributes);
+          } catch (e) {
+            error = e;
+          }
+
+          //then
+          expect(error).to.be.instanceOf(EntityValidationError);
+          expect(error.invalidAttributes).to.deep.equals([
+            {
+              attribute: 'count',
+              message: `Le nombre de places doit être un nombre sans virgule supérieur à 0.`,
+            },
+          ]);
+        });
       });
 
       context('#activationDate', function () {


### PR DESCRIPTION
## ❄️ Problème

Il est possible de créer un lot de places vide.

## 🛷 Proposition

Rendre le nombre de places obligatoire à la création

## ☃️ Remarques

On profite de cette PR pour également rendre impossible la création d'un lot de places à une date trop ancienne pour être logique.

## 🧑‍🎄 Pour tester

- Se connecter à Pix-Admin
- Créer un lot de places sans nombre pour une organisation
- Vérifier qu'une erreur se produit et que rien n'est enregistré
- Créer un lot de places antérieur au 01/01/2020
- Vérifier qu'une erreur se produit et que rien n'est enregistré
