### PR TITLE
[FEATURE] Ajoute les ids des pré-requis de parcours combinés (PIX-21131)

### DIFF
--- a/admin/app/components/combined-course-blueprints/details.gjs
+++ b/admin/app/components/combined-course-blueprints/details.gjs
@@ -77,7 +77,7 @@ export default class Details extends Component {
             </DescriptionList>
             <div class="combined-course-blueprint__content">
               {{#each @model.content as |requirement|}}
-                <RequirementTag @type={{requirement.type}} @value={{requirement.value}} @label={{requirement.value}} />
+                <RequirementTag @type={{requirement.type}} @value={{requirement.value}} @label={{requirement.label}} />
               {{/each}}
             </div>
           </div>

--- a/admin/app/components/common/combined-courses/requirement-tag.gjs
+++ b/admin/app/components/common/combined-courses/requirement-tag.gjs
@@ -32,10 +32,14 @@ export default class RequirementTag extends Component {
         >
           {{t (getItemType @type)}}
           -
+          {{@value}}
+          -
           {{@label}}</LinkTo>
       {{else}}
         <a target="_blank" rel="noopener noreferrer" href="https://app.recette.pix.fr/modules/{{@value}}/slug/details">
           {{t (getItemType @type)}}
+          -
+          {{@value}}
           -
           {{@label}}
         </a>

--- a/admin/app/styles/components/combined-course-blueprints/list.scss
+++ b/admin/app/styles/components/combined-course-blueprints/list.scss
@@ -15,7 +15,6 @@
     flex-direction: column;
 
     @include breakpoints.device-is('tablet') {
-      display: grid;
       grid-template-columns: 1fr 300px;
       gap: 2rem;
     }
@@ -26,6 +25,7 @@
     flex-direction: column;
     gap: var(--pix-spacing-4x);
     align-items: flex-start;
+    margin-bottom: var(--pix-spacing-8x);
   }
 
   &__breadcrumb {

--- a/admin/tests/integration/components/combined-course-blueprints/form-test.gjs
+++ b/admin/tests/integration/components/combined-course-blueprints/form-test.gjs
@@ -275,7 +275,7 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
       // given
       const store = this.owner.lookup('service:store');
       const findRecordStub = sinon.stub(store, 'findRecord');
-      findRecordStub.withArgs('module', 'module-123').resolves({ title: 'module 123' });
+      findRecordStub.withArgs('module', 'module123').resolves({ title: 'module 123' });
       findRecordStub.withArgs('target-profile', '1').resolves({ internalName: 'super pc' });
       //when
       const screen = await render(<template><CombinedCourseBlueprintForm /></template>);
@@ -290,14 +290,14 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
       await click(screen.getByLabelText(t('components.combined-course-blueprints.labels.module')));
       await fillIn(
         screen.getByLabelText(t('components.combined-course-blueprints.labels.itemId'), { exact: false }),
-        'module-123',
+        'module123',
       );
       await click(
         screen.getByRole('button', { name: t('components.combined-course-blueprints.create.addItemButton') }),
       );
 
-      assert.ok(screen.getByText(/Profil Cible - super pc/));
-      assert.ok(screen.getByText(/Module - module 123/));
+      assert.ok(screen.getByText(/Profil Cible - 1 - super pc/));
+      assert.ok(screen.getByText('Module - module123 - module 123'));
     });
     test('it should remove item when user clicks on remove button', async function (assert) {
       // given
@@ -318,11 +318,11 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
         screen.getByRole('button', { name: t('components.combined-course-blueprints.create.addItemButton') }),
       );
 
-      assert.ok(screen.getByText(/Profil Cible - super pc/));
+      assert.ok(screen.getByText(/Profil Cible - 1 - super pc/));
       await click(screen.getByRole('button', { name: 'Supprimer' }));
 
       //then
-      assert.notOk(screen.queryByText(/Profil Cible - super pc/));
+      assert.notOk(screen.queryByText(/Profil Cible - 1 - super pc/));
     });
   });
 });

--- a/admin/tests/integration/components/common/combined-courses/requirement-tag-test.gjs
+++ b/admin/tests/integration/components/common/combined-courses/requirement-tag-test.gjs
@@ -13,11 +13,14 @@ module('Integration | Component |  common/combined-courses/requirement-tag', fun
     const item = {
       type: 'module',
       value: 'abc-123',
+      label: 'Mon module',
     };
     const screen = await renderScreen(
-      <template><RequirementTag @type={{item.type}} @value={{item.value}} /></template>,
+      <template><RequirementTag @type={{item.type}} @value={{item.value}} @label={{item.label}} /></template>,
     );
     assert.ok(screen.getByText(t('components.combined-course-blueprints.items.module'), { exact: false }));
+    assert.ok(screen.getByText(item.value, { exact: false }));
+    assert.ok(screen.getByText(item.label, { exact: false }));
     const link = screen.getByRole('link');
     assert.ok(link.getAttribute('href').endsWith('modules/abc-123/slug/details'));
   });
@@ -25,12 +28,15 @@ module('Integration | Component |  common/combined-courses/requirement-tag', fun
     const item = {
       type: 'evaluation',
       value: 1,
+      label: 'Ma campagne',
     };
     const screen = await renderScreen(
-      <template><RequirementTag @type={{item.type}} @value={{item.value}} /></template>,
+      <template><RequirementTag @type={{item.type}} @value={{item.value}} @label={{item.label}} /></template>,
     );
     const link = screen.getByRole('link');
     assert.ok(screen.getByText(t('components.combined-course-blueprints.items.targetProfile'), { exact: false }));
+    assert.ok(screen.getByText(item.value, { exact: false }));
+    assert.ok(screen.getByText(item.label, { exact: false }));
     assert.ok(link.getAttribute('href').endsWith(`/target-profiles/${item.value}/details`));
   });
 

--- a/api/src/quest/domain/usecases/get-combined-course-blueprint-by-id.js
+++ b/api/src/quest/domain/usecases/get-combined-course-blueprint-by-id.js
@@ -1,9 +1,38 @@
 import { NotFoundError } from '../../../shared/domain/errors.js';
+import { COMBINED_COURSE_BLUEPRINT_ITEMS } from '../models/CombinedCourseBlueprint.js';
 
-export const getCombinedCourseBlueprintById = async ({ id, combinedCourseBlueprintRepository }) => {
+export const getCombinedCourseBlueprintById = async ({
+  id,
+  combinedCourseBlueprintRepository,
+  targetProfileRepository,
+  moduleRepository,
+}) => {
   const result = await combinedCourseBlueprintRepository.findById({ id });
   if (!result) {
     throw new NotFoundError('Combined course blueprint not found');
   }
+
+  const evaluationItemIds = result.content
+    .filter((item) => item.type === COMBINED_COURSE_BLUEPRINT_ITEMS.EVALUATION)
+    .map((item) => item.value);
+  const moduleItemShortIds = result.content
+    .filter((item) => item.type === COMBINED_COURSE_BLUEPRINT_ITEMS.MODULE)
+    .map((item) => item.value);
+
+  const evaluationItems = await targetProfileRepository.findByIds({ ids: evaluationItemIds });
+  const moduleItems = await moduleRepository.getByShortIds({ moduleShortIds: moduleItemShortIds });
+
+  const evaluationMap = new Map(evaluationItems.map((item) => [item.id, item]));
+
+  const moduleMap = new Map(moduleItems.map((item) => [item.shortId, item]));
+
+  result.content = result.content.map((item) => ({
+    ...item,
+    label:
+      item.type === COMBINED_COURSE_BLUEPRINT_ITEMS.EVALUATION
+        ? evaluationMap.get(item.value).name
+        : moduleMap.get(item.value).title,
+  }));
+
   return result;
 };

--- a/api/tests/quest/acceptance/application/combined-course-blueprint-route_test.js
+++ b/api/tests/quest/acceptance/application/combined-course-blueprint-route_test.js
@@ -85,7 +85,7 @@ describe('Quest | Acceptance | Application | Combined course blueprint Route ', 
         const adminUser = await insertUserWithRoleSuperAdmin();
 
         const combinedCourseBlueprint = databaseBuilder.factory.buildCombinedCourseBlueprint({
-          content: CombinedCourseBlueprint.buildContentItems([{ moduleShortId: 'mon-module' }]),
+          content: CombinedCourseBlueprint.buildContentItems([{ moduleShortId: 'e67ec5d0' }]),
         });
         await databaseBuilder.commit();
 

--- a/api/tests/quest/integration/domain/usecases/get-combined-course-blueprint-by-id_test.js
+++ b/api/tests/quest/integration/domain/usecases/get-combined-course-blueprint-by-id_test.js
@@ -1,4 +1,7 @@
-import { CombinedCourseBlueprint } from '../../../../../src/quest/domain/models/CombinedCourseBlueprint.js';
+import {
+  COMBINED_COURSE_BLUEPRINT_ITEMS,
+  CombinedCourseBlueprint,
+} from '../../../../../src/quest/domain/models/CombinedCourseBlueprint.js';
 import { usecases } from '../../../../../src/quest/domain/usecases/index.js';
 import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
 import { catchErr, databaseBuilder, expect, sinon } from '../../../../test-helper.js';
@@ -17,7 +20,15 @@ describe('Integration | Quest | Domain | UseCases | get-combined-course-blueprin
 
   it('should return a combined course blueprint for a given id', async function () {
     //given
-    await databaseBuilder.factory.buildCombinedCourseBlueprint({ id: 1, content: [] });
+    const targetProfile = await databaseBuilder.factory.buildTargetProfile({ name: 'Mon profil cible' });
+
+    await databaseBuilder.factory.buildCombinedCourseBlueprint({
+      id: 1,
+      content: [
+        { type: COMBINED_COURSE_BLUEPRINT_ITEMS.EVALUATION, value: targetProfile.id },
+        { type: COMBINED_COURSE_BLUEPRINT_ITEMS.MODULE, value: 'e074af34' },
+      ],
+    });
 
     await databaseBuilder.commit();
 
@@ -34,7 +45,14 @@ describe('Integration | Quest | Domain | UseCases | get-combined-course-blueprin
       illustration: 'images/illustration.svg',
       createdAt: now,
       updatedAt: now,
-      content: [],
+      content: [
+        { type: COMBINED_COURSE_BLUEPRINT_ITEMS.EVALUATION, value: targetProfile.id, label: targetProfile.name },
+        {
+          type: COMBINED_COURSE_BLUEPRINT_ITEMS.MODULE,
+          value: 'e074af34',
+          label: 'Au-delà des mots de passe : comment s’authentifier ?',
+        },
+      ],
       organizationIds: [],
     });
   });


### PR DESCRIPTION
## ❄️ Problème

Lorsqu’on crée un blueprint, on ajoute les éléments en saisissant l’id. 
Même s’il est très utile d’avoir le nom de l'élément sélectionné dans le contenu, il serait plus simple pour la relecture d’avoir également l’id. 

Lorsqu’on cherche le bon blueprint et que l’on regarde de quoi il est composé, il serait utile d’avoir en plus des ids des éléments qui le compose, leurs noms. 

Comme cela prendra plus de place, on peut inverser la position des éléments et de mettre l’illustration sur la droite en plus petit et la composition sous la description. 

## 🛷 Proposition

## ☃️ Remarques

## 🧑‍🎄 Pour tester

Pix Admin
Aller sur le formulaire de création de schéma de parcours combinés -> renseigner un id de profil cible et un short id de module, vérifier à l'ajout que les tags comportent bien le nom et l'id/le short id de l'item
Aller sur le listing des schémas de parcours combinés -> vérifier que les tags comportent bien l'id/short id et le nom de l'item
