### PR TITLE
[TECH] :card_file_box: Ajoute un index sur la colonne `rewardId` dans la table `quests`

### DIFF
--- a/api/db/migrations/20260127095811_add-reward-id-index-to-quests-table.js
+++ b/api/db/migrations/20260127095811_add-reward-id-index-to-quests-table.js
@@ -1,0 +1,24 @@
+const TABLE_NAME = 'quests';
+const COLUMN_NAME = 'rewardId';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  return knex.schema.table(TABLE_NAME, function (table) {
+    table.index(COLUMN_NAME);
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  return knex.schema.table(TABLE_NAME, function (table) {
+    table.dropIndex(COLUMN_NAME);
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## ❄️ Problème

La requête suviant fait partir du top 3 des requêtes les plus couteuses ce mardi 27 janvier au matin...

```SQL
select * from quests where "rewardId" is not null;
```

<img width="1610" height="124" alt="image" src="https://github.com/user-attachments/assets/56736190-20c1-4a98-9791-7309d0a6603b" />


## 🛷 Proposition

Ajouter un index sur la colonne `rewardId`.

## ☃️ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🧑‍🎄 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
