### PR TITLE
[FEATURE] Mettre à disposition et utiliser une nouvelle route /api/config #14454 

### DIFF
--- a/admin/app/components/login-form.gjs
+++ b/admin/app/components/login-form.gjs
@@ -17,6 +17,7 @@ const SSO_LOGO_BASE_URL = 'https://assets.pix.org/sso-logos/';
 const SSO_LOGO_BASE_FILE_PREFIX = 'sso-logo-';
 
 export default class LoginForm extends Component {
+  @service config;
   @service url;
   @service intl;
   @service session;
@@ -25,6 +26,10 @@ export default class LoginForm extends Component {
   @tracked password;
   @tracked errorMessage;
   @service oidcIdentityProviders;
+
+  get permitPixAdminLoginFromPassword() {
+    return this.config.permitPixAdminLoginFromPassword;
+  }
 
   get useSsoProviders() {
     return this.oidcIdentityProviders.hasIdentityProviders;
@@ -142,7 +147,8 @@ export default class LoginForm extends Component {
               plateforme.
             </PixNotificationAlert>
           {{/if}}
-        {{else}}
+        {{/if}}
+        {{#if this.permitPixAdminLoginFromPassword}}
           <PixInput required="true" @value={{this.email}} autocomplete="true" {{on "input" this.onEmailChange}}>
             <:label>{{t "pages.login.fields.email.label"}} </:label>
           </PixInput>

--- a/admin/app/routes/application.js
+++ b/admin/app/routes/application.js
@@ -3,6 +3,7 @@ import { service } from '@ember/service';
 import { formats } from 'pix-admin/ember-intl';
 
 export default class ApplicationRoute extends Route {
+  @service config;
   @service session;
   @service featureToggles;
   @service currentUser;
@@ -10,6 +11,8 @@ export default class ApplicationRoute extends Route {
   @service intl;
 
   async beforeModel(transition) {
+    await this.config.load();
+
     const queryParams = transition?.to?.queryParams;
     this.intl.setFormats(formats);
     this.locale.setBestLocale({ queryParams });

--- a/admin/app/routes/application.js
+++ b/admin/app/routes/application.js
@@ -17,7 +17,6 @@ export default class ApplicationRoute extends Route {
     this.intl.setFormats(formats);
     this.locale.setBestLocale({ queryParams });
     await this.session.setup();
-    await this.featureToggles.load();
     await this.currentUser.load();
   }
 }

--- a/admin/app/services/config.js
+++ b/admin/app/services/config.js
@@ -1,0 +1,20 @@
+import Service, { service } from '@ember/service';
+import ENV from 'pix-admin/config/environment';
+
+export default class ConfigService extends Service {
+  @service requestManager;
+
+  featureToggles = {};
+  permitPixAdminLoginFromPassword = false;
+
+  async load() {
+    const response = await this.requestManager.request({
+      url: `${ENV.APP.API_HOST}/api/config`,
+      method: 'GET',
+    });
+
+    const { featureToggles, permitPixAdminLoginFromPassword } = response.content;
+    this.featureToggles = featureToggles;
+    this.permitPixAdminLoginFromPassword = permitPixAdminLoginFromPassword;
+  }
+}

--- a/admin/app/services/feature-toggles.js
+++ b/admin/app/services/feature-toggles.js
@@ -1,15 +1,9 @@
 import Service, { service } from '@ember/service';
 
 export default class FeatureTogglesService extends Service {
-  @service store;
-
-  _featureToggles = undefined;
+  @service config;
 
   get featureToggles() {
-    return this._featureToggles;
-  }
-
-  async load() {
-    this._featureToggles = await this.store.queryRecord('feature-toggle', { id: 0 });
+    return this.config.featureToggles;
   }
 }

--- a/admin/tests/helpers/service-stubs.js
+++ b/admin/tests/helpers/service-stubs.js
@@ -1,0 +1,20 @@
+import Service from '@ember/service';
+
+export function stubConfigService(owner, { featureToggles, permitPixAdminLoginFromPassword } = {}) {
+  class ConfigServiceStub extends Service {
+    constructor() {
+      super();
+
+      this.featureToggles = featureToggles ?? {};
+      this.permitPixAdminLoginFromPassword = permitPixAdminLoginFromPassword ?? false;
+    }
+
+    load() {
+      return Promise.resolve();
+    }
+  }
+
+  owner.unregister('service:config');
+  owner.register('service:config', ConfigServiceStub);
+  return owner.lookup('service:config');
+}

--- a/admin/tests/integration/components/login-form-test.gjs
+++ b/admin/tests/integration/components/login-form-test.gjs
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import { reject } from 'rsvp';
 import sinon from 'sinon';
 
+import { stubConfigService } from '../../helpers/service-stubs.js';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 
 const ApiErrorMessages = ENV.APP.API_ERROR_MESSAGES;
@@ -23,24 +24,34 @@ module('Integration | Component | login-form', function (hooks) {
     assert.dom(screen.getByText("L'accès à Pix Admin est limité aux administrateurs de la plateforme")).exists();
   });
 
-  module('when there is no identity provider enabled for Pix Admin', function () {
-    test('it displays an email/password login form', async function (assert) {
-      // given
-      class IdentityProviderServiceStub extends Service {
-        isProviderEnabled = sinon.stub();
-      }
-      this.owner.register('service:oidcIdentityProviders', IdentityProviderServiceStub);
-      const identityProvidersServiceStub = this.owner.lookup('service:oidcIdentityProviders');
-      identityProvidersServiceStub.isProviderEnabled.withArgs('google').returns(false);
+  module('Password login form', function () {
+    module('when permitPixAdminLoginFromPassword is enabled', function () {
+      test('displays a password login form', async function (assert) {
+        // given
+        stubConfigService(this.owner, { permitPixAdminLoginFromPassword: true });
 
-      // when
-      const screen = await render(<template><LoginForm /></template>);
+        // when
+        const screen = await render(<template><LoginForm /></template>);
 
-      // then
-      assert.dom(screen.getByRole('textbox', { name: 'Adresse e-mail' })).exists();
-      assert.dom(screen.getByLabelText('Mot de passe')).exists();
-      assert.dom(screen.getByRole('button', { name: 'Je me connecte' })).exists();
-      assert.dom(screen.queryByRole('link', { name: 'Se connecter avec Google' })).doesNotExist();
+        // then
+        assert.dom(screen.getByRole('textbox', { name: 'Adresse e-mail' })).exists();
+        assert.dom(screen.getByLabelText('Mot de passe')).exists();
+        assert.dom(screen.getByRole('button', { name: 'Je me connecte' })).exists();
+      });
+    });
+
+    module('when permitPixAdminLoginFromPassword is disabled', function () {
+      test('does not display a password login form', async function (assert) {
+        // given
+        stubConfigService(this.owner, { permitPixAdminLoginFromPassword: false });
+
+        // when
+        const screen = await render(<template><LoginForm /></template>);
+
+        // then
+        assert.dom(screen.queryByRole('textbox', { name: 'Adresse e-mail' })).doesNotExist();
+        assert.dom(screen.queryByLabelText('Mot de passe')).doesNotExist();
+      });
     });
   });
 
@@ -65,6 +76,7 @@ module('Integration | Component | login-form', function (hooks) {
       // when
       const screen = await render(<template><LoginForm /></template>);
 
+      // then
       assert
         .dom(
           screen.getByRole('link', {
@@ -72,8 +84,6 @@ module('Integration | Component | login-form', function (hooks) {
           }),
         )
         .exists();
-
-      assert.dom(screen.queryByRole('button', { name: 'Je me connecte' })).doesNotExist();
     });
 
     module('when user has no Pix account', function () {
@@ -142,6 +152,8 @@ module('Integration | Component | login-form', function (hooks) {
     let sessionStub;
 
     hooks.beforeEach(function () {
+      stubConfigService(this.owner, { permitPixAdminLoginFromPassword: true });
+
       this.owner.register('service:session', SessionStub);
       sessionStub = this.owner.lookup('service:session');
     });

--- a/admin/tests/mirage/routes.js
+++ b/admin/tests/mirage/routes.js
@@ -64,6 +64,13 @@ export default function routes() {
   this.get('feature-toggles', (schema) => {
     return schema.featureToggles.findOrCreateBy({ id: 0 });
   });
+  this.get('/config', (schema) => {
+    return {
+      featureToggles: schema.featureToggles.findOrCreateBy({ id: '0' }),
+      permitPixAdminLoginFromPassword: true,
+      autonomousCoursesOrganizationId: 999,
+    };
+  });
 
   this.get('/admin/autonomous-courses/target-profiles', findAutonomousCourseTargetProfiles);
   this.post('/admin/autonomous-courses', createAutonomousCourse);

--- a/admin/tests/unit/services/config-test.js
+++ b/admin/tests/unit/services/config-test.js
@@ -1,0 +1,26 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module('Unit | Service | config', function (hooks) {
+  setupTest(hooks);
+
+  module('load', function () {
+    test('fetches config from API', async function (assert) {
+      // given
+      const requestManager = this.owner.lookup('service:request-manager');
+      sinon
+        .stub(requestManager, 'request')
+        .resolves({ content: { featureToggles: {}, permitPixAdminLoginFromPassword: true } });
+
+      const configService = this.owner.lookup('service:config');
+
+      // when
+      await configService.load();
+
+      // then
+      assert.deepEqual(configService.featureToggles, {});
+      assert.true(configService.permitPixAdminLoginFromPassword);
+    });
+  });
+});

--- a/admin/tests/unit/services/feature-toggles-test.js
+++ b/admin/tests/unit/services/feature-toggles-test.js
@@ -1,29 +1,23 @@
-import Object from '@ember/object';
-import Service from '@ember/service';
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
-import { resolve } from 'rsvp';
+import sinon from 'sinon';
 
-module('Unit | Service | feature toggles', function (hooks) {
+module('Unit | Service | feature-toggles', function (hooks) {
   setupTest(hooks);
 
-  module('feature toggles are loaded', function () {
-    test('should load the feature toggles', async function (assert) {
-      // Given
-      const featureToggles = Object.create({
-        aFakeFeatureToggle: false,
-      });
-      const storeStub = Service.create({
-        queryRecord: () => resolve(featureToggles),
-      });
+  module('featureToggles', function () {
+    test('returns properties', async function (assert) {
+      // given
+      const configService = this.owner.lookup('service:config');
+      sinon.stub(configService, 'featureToggles').value({ aProperty: 'some value' });
+
       const featureToggleService = this.owner.lookup('service:featureToggles');
-      featureToggleService.set('store', storeStub);
 
-      // When
-      await featureToggleService.load();
+      // when
+      const featureToggles = await featureToggleService.featureToggles;
 
-      // Then
-      assert.false(featureToggleService.featureToggles.aFakeFeatureToggle);
+      // then
+      assert.deepEqual(featureToggles, { aProperty: 'some value' });
     });
   });
 });

--- a/api/src/shared/application/config/config.controller.js
+++ b/api/src/shared/application/config/config.controller.js
@@ -1,0 +1,19 @@
+import { config } from '../../config.js';
+import { constants } from '../../domain/constants.js';
+import { featureToggles as featureToggleService } from '../../infrastructure/feature-toggles/index.js';
+
+const getConfig = async function () {
+  const featureToggles = await featureToggleService.withTag('frontend');
+  const permitPixAdminLoginFromPassword = config.authentication.permitPixAdminLoginFromPassword;
+  const autonomousCoursesOrganizationId = constants.AUTONOMOUS_COURSES_ORGANIZATION_ID;
+
+  return {
+    featureToggles,
+    permitPixAdminLoginFromPassword,
+    autonomousCoursesOrganizationId,
+  };
+};
+
+const configController = { getConfig };
+
+export { configController };

--- a/api/src/shared/application/config/config.route.js
+++ b/api/src/shared/application/config/config.route.js
@@ -1,0 +1,24 @@
+import { configController } from './config.controller.js';
+
+const register = async function (server) {
+  server.route([
+    {
+      method: 'GET',
+      path: '/api/config',
+      options: {
+        auth: false,
+        handler: configController.getConfig,
+        notes: [
+          'Cette route renvoie la configuration, constituée de propriétés, ' +
+            'à disposition de tous les clients/applications sans authentification ,' +
+            'fournissant des informations préalables à l’utilisation de l’API.',
+        ],
+        tags: ['shared', 'api', 'config'],
+        cache: false,
+      },
+    },
+  ]);
+};
+
+const name = 'config-api';
+export { name, register };

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -502,6 +502,10 @@ const configuration = (function () {
     config.auditLogger.baseUrl = 'http://audit-logger.local';
     config.auditLogger.clientSecret = 'client-super-secret';
 
+    config.autonomousCourse = {
+      autonomousCoursesOrganizationId: 9000000,
+    };
+
     config.baseUrl = 'https://api.test.pix.fr';
 
     config.oidcExampleNet = {

--- a/api/src/shared/routes.js
+++ b/api/src/shared/routes.js
@@ -1,9 +1,10 @@
 import * as assessmentsRoutes from './application/assessments/index.js';
 import * as challengesRoutes from './application/challenges/index.js';
+import * as configRoutes from './application/config/config.route.js';
 import * as countryRoutes from './application/country/country-route.js';
 import * as featureToggles from './application/feature-toggles/index.js';
 import * as healthcheck from './application/healthcheck/index.js';
 
-const sharedRoutes = [healthcheck, assessmentsRoutes, challengesRoutes, featureToggles, countryRoutes];
+const sharedRoutes = [healthcheck, assessmentsRoutes, challengesRoutes, configRoutes, featureToggles, countryRoutes];
 
 export { sharedRoutes };

--- a/api/tests/shared/acceptance/application/config.route.test.js
+++ b/api/tests/shared/acceptance/application/config.route.test.js
@@ -1,0 +1,45 @@
+import { config } from '../../../../src/shared/config.js';
+import { createServer, expect, sinon } from '../../../test-helper.js';
+
+describe('Acceptance | Shared | Application | Route | config', function () {
+  let server;
+  beforeEach(async function () {
+    server = await createServer();
+  });
+
+  describe('GET /api/config', function () {
+    const options = {
+      method: 'GET',
+      url: '/api/config',
+    };
+
+    it('returns HTTP status code 200 with config', async function () {
+      // given
+      sinon.stub(config.authentication, 'permitPixAdminLoginFromPassword').value(true);
+      // There is no effect in stubbing config.autonomousCourse.autonomousCoursesOrganizationId
+      // because all the code uses constants.AUTONOMOUS_COURSES_ORGANIZATION_ID
+      // sinon.stub(config.autonomousCourse, 'autonomousCoursesOrganizationId').value(987654);
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result).to.deep.equal({
+        featureToggles: {
+          areModuleShortIdUrlsEnabled: false,
+          dynamicFeatureToggleSystem: false,
+          isAsyncQuestRewardingCalculationEnabled: false,
+          isPixPlusCandidateA11yEnabled: false,
+          isQuestEnabled: true,
+          isSelfAccountDeletionEnabled: true,
+          isSurveyEnabledForCombinedCourses: true,
+          isTextToSpeechButtonEnabled: true,
+          usePixOrgaNewAuthDesign: false,
+        },
+        permitPixAdminLoginFromPassword: true,
+        autonomousCoursesOrganizationId: 9000000,
+      });
+    });
+  });
+});

--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/index.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/index.gjs
@@ -12,7 +12,6 @@ import CustomParseFormat from 'dayjs/plugin/customParseFormat';
 import LocalizedFormat from 'dayjs/plugin/localizedFormat';
 import { t } from 'ember-intl';
 import or from 'ember-truth-helpers/helpers/or';
-import ENV from 'mon-pix/config/environment';
 
 import MarkdownToHtml from '../../../../markdown-to-html';
 import AcquiredBadges from './acquired-badges';
@@ -24,8 +23,8 @@ dayjs.extend(LocalizedFormat);
 dayjs.extend(CustomParseFormat);
 
 export default class EvaluationResultsHero extends Component {
+  @service config;
   @service currentUser;
-
   @service pixMetrics;
   @service router;
   @service store;
@@ -54,7 +53,7 @@ export default class EvaluationResultsHero extends Component {
   }
 
   get isCampaignAutonomousCourse() {
-    return this.args.campaign.organizationId === ENV.APP.AUTONOMOUS_COURSES_ORGANIZATION_ID;
+    return this.args.campaign.organizationId === this.config.autonomousCoursesOrganizationId;
   }
 
   get showCustomOrganizationBlock() {

--- a/mon-pix/app/controllers/campaigns/campaign-landing-page.js
+++ b/mon-pix/app/controllers/campaigns/campaign-landing-page.js
@@ -1,9 +1,9 @@
 import { action } from '@ember/object';
 import { service } from '@ember/service';
-import ENV from 'mon-pix/config/environment';
 import UtmQueryParamsController from 'mon-pix/services/UtmQueryParamsController';
 
 export default class CampaignLandingPageController extends UtmQueryParamsController {
+  @service config;
   @service currentDomain;
   @service router;
   @service session;
@@ -13,7 +13,7 @@ export default class CampaignLandingPageController extends UtmQueryParamsControl
   }
 
   get isAutonomousCourse() {
-    return this.model.organizationId === ENV.APP.AUTONOMOUS_COURSES_ORGANIZATION_ID;
+    return this.model.organizationId === this.config.autonomousCoursesOrganizationId;
   }
 
   get isInternationalDomain() {

--- a/mon-pix/app/routes/application.js
+++ b/mon-pix/app/routes/application.js
@@ -41,7 +41,6 @@ export default class ApplicationRoute extends Route {
     this.intl.setFormats(formats);
     this.locale.setBestLocale({ queryParams });
     await this.session.setup();
-    await this.featureToggles.load().catch();
     await this.oidcIdentityProviders.load().catch();
     await this.authentication.handleAnonymousAuthentication(transition);
     await this.currentUser.load();

--- a/mon-pix/app/routes/application.js
+++ b/mon-pix/app/routes/application.js
@@ -5,6 +5,7 @@ import ENV from 'mon-pix/config/environment';
 import { formats } from 'mon-pix/ember-intl';
 
 export default class ApplicationRoute extends Route {
+  @service config;
   @service authentication;
   @service featureToggles;
   @service intl;
@@ -34,6 +35,8 @@ export default class ApplicationRoute extends Route {
   }
 
   async beforeModel(transition) {
+    await this.config.load();
+
     const queryParams = transition?.to?.queryParams;
     this.intl.setFormats(formats);
     this.locale.setBestLocale({ queryParams });

--- a/mon-pix/app/routes/campaigns/entry-point.js
+++ b/mon-pix/app/routes/campaigns/entry-point.js
@@ -1,9 +1,9 @@
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
-import ENV from 'mon-pix/config/environment';
 import Location from 'mon-pix/utils/location';
 
 export default class EntryPoint extends Route {
+  @service config;
   @service currentUser;
   @service currentDomain;
   @service campaignStorage;
@@ -69,7 +69,7 @@ export default class EntryPoint extends Route {
       this.campaignStorage.set(campaign.code, 'hasParticipated', hasParticipated);
     }
 
-    const isAutonomousCourse = campaign.organizationId === ENV.APP.AUTONOMOUS_COURSES_ORGANIZATION_ID;
+    const isAutonomousCourse = campaign.organizationId === this.config.autonomousCoursesOrganizationId;
     if (!campaign.isAccessible && !hasParticipated) {
       this.router.replaceWith('campaigns.archived-error', campaign.code);
     } else if (hasParticipated && !isAutonomousCourse) {

--- a/mon-pix/app/services/config.js
+++ b/mon-pix/app/services/config.js
@@ -1,0 +1,20 @@
+import Service, { service } from '@ember/service';
+import ENV from 'mon-pix/config/environment';
+
+export default class ConfigService extends Service {
+  @service requestManager;
+
+  featureToggles = {};
+  autonomousCoursesOrganizationId;
+
+  async load() {
+    const response = await this.requestManager.request({
+      url: `${ENV.APP.API_HOST}/api/config`,
+      method: 'GET',
+    });
+
+    const { featureToggles, autonomousCoursesOrganizationId } = response.content;
+    this.featureToggles = featureToggles;
+    this.autonomousCoursesOrganizationId = autonomousCoursesOrganizationId;
+  }
+}

--- a/mon-pix/app/services/feature-toggles.js
+++ b/mon-pix/app/services/feature-toggles.js
@@ -1,15 +1,9 @@
 import Service, { service } from '@ember/service';
 
 export default class FeatureTogglesService extends Service {
-  @service store;
-
-  _featureToggles = undefined;
+  @service config;
 
   get featureToggles() {
-    return this._featureToggles;
-  }
-
-  async load() {
-    this._featureToggles = await this.store.queryRecord('feature-toggle', { id: 0 });
+    return this.config.featureToggles;
   }
 }

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -127,7 +127,6 @@ module.exports = function (environment) {
       },
       AUTHENTICATED_SOURCE_FROM_GAR: 'external',
       COOKIE_LOCALE_LIFESPAN_IN_SECONDS: 31536000, // 1 year in seconds
-      AUTONOMOUS_COURSES_ORGANIZATION_ID: parseInt(process.env.AUTONOMOUS_COURSES_ORGANIZATION_ID, 10),
       APP_VERSION: process.env.SOURCE_VERSION || 'development',
       AUTO_SHARE_AFTER_DATE: process.env.AUTO_SHARE_AFTER_DATE || '2025-07-18',
       COMBINIX_SURVEY_LINK:
@@ -190,7 +189,6 @@ module.exports = function (environment) {
     ENV.APP.LOG_TRANSITIONS = false;
     ENV.APP.LOG_TRANSITIONS_INTERNAL = false;
     ENV.APP.LOG_VIEW_LOOKUPS = false;
-    ENV.APP.AUTONOMOUS_COURSES_ORGANIZATION_ID = 9000000;
     ENV.companion.disabled = true;
   }
 
@@ -213,7 +211,6 @@ module.exports = function (environment) {
     ENV.APP.isTimerCountdownEnabled = false;
     ENV.APP.LOAD_EXTERNAL_SCRIPT = false;
     ENV.APP.FT_FOCUS_CHALLENGE_ENABLED = true;
-    ENV.APP.AUTONOMOUS_COURSES_ORGANIZATION_ID = 999;
     ENV.APP.AUTO_SHARE_AFTER_DATE = '2025-07-18';
     ENV.APP.COMBINIX_SURVEY_LINK =
       'https://app-eu.123formbuilder.com/index.php?p=login&pactionafter=edit_fields%26id%3D86361%26startup_panel%3Deditor%26click_from%3Dyour_forms';

--- a/mon-pix/mirage/config.js
+++ b/mon-pix/mirage/config.js
@@ -20,6 +20,7 @@ import getChallenge from './routes/get-challenge';
 import getChallenges from './routes/get-challenges';
 import getCombinedCourses from './routes/get-combined-courses';
 import getCompetenceEvaluationsByAssessment from './routes/get-competence-evaluations-by-assessment';
+import getConfig from './routes/get-config';
 import getFeatureToggles from './routes/get-feature-toggles';
 import getInformationBanners from './routes/get-information-banners';
 import getOrganizationsToJoin from './routes/get-organizations-to-join';
@@ -112,6 +113,7 @@ function routes() {
   this.del('/users/tutorials/:tutorialId', deleteUserSavedTutorial);
   this.put('/users/tutorials/:tutorialId/evaluate', putTutorialEvaluation);
 
+  this.get('/config', getConfig);
   this.get('/feature-toggles', getFeatureToggles);
 
   this.post('/shared-certifications', postSharedCertifications);

--- a/mon-pix/mirage/factories/campaign.js
+++ b/mon-pix/mirage/factories/campaign.js
@@ -1,5 +1,4 @@
 import { Factory, trait } from 'miragejs';
-import ENV from 'mon-pix/config/environment';
 
 export default Factory.extend({
   title() {
@@ -93,7 +92,7 @@ export default Factory.extend({
       const verifiedCode = server.schema.verifiedCodes.find(campaign.code);
       campaign.update({
         code: 'AUTOCOUR1',
-        organizationId: ENV.APP.AUTONOMOUS_COURSES_ORGANIZATION_ID,
+        organizationId: 999, // must be same value as in get-config
         title: 'Dummy title',
         customLandingPageText: 'Dummy landing page text',
       });

--- a/mon-pix/mirage/routes/get-config.js
+++ b/mon-pix/mirage/routes/get-config.js
@@ -1,0 +1,7 @@
+export default function (schema) {
+  return {
+    featureToggles: schema.featureToggles.findOrCreateBy({ id: '0' }),
+    permitPixAdminLoginFromPassword: true,
+    autonomousCoursesOrganizationId: 999,
+  };
+}

--- a/mon-pix/sample.env
+++ b/mon-pix/sample.env
@@ -107,15 +107,6 @@
 # default: "https://epreuves.pix.fr,https://1024pix.github.io"
 # EMBED_ALLOWED_ORIGINS=https://epreuves.pix.fr,https://1024pix.github.io
 
-# ==================
-# Autonomous courses
-# ==================
-
-# presence: optional
-# type: String
-# default: <empty>
-# AUTONOMOUS_COURSES_ORGANIZATION_ID=xxx
-
 # =========
 # Campaigns
 # =========

--- a/mon-pix/tests/helpers/service-stubs.js
+++ b/mon-pix/tests/helpers/service-stubs.js
@@ -3,6 +3,29 @@ import { tracked } from '@glimmer/tracking';
 import omit from 'lodash/omit';
 import sinon from 'sinon';
 
+export function stubConfigService(
+  owner,
+  { featureToggles, permitPixAdminLoginFromPassword, autonomousCoursesOrganizationId } = {},
+) {
+  class ConfigServiceStub extends Service {
+    constructor() {
+      super();
+
+      this.featureToggles = featureToggles ?? {};
+      this.permitPixAdminLoginFromPassword = permitPixAdminLoginFromPassword ?? false;
+      this.autonomousCoursesOrganizationId = autonomousCoursesOrganizationId ?? 999;
+    }
+
+    load() {
+      return Promise.resolve();
+    }
+  }
+
+  owner.unregister('service:config');
+  owner.register('service:config', ConfigServiceStub);
+  return owner.lookup('service:config');
+}
+
 /**
  * Stub the session service.
  *

--- a/mon-pix/tests/integration/components/routes/campaigns/assessment/evaluation-results-test.js
+++ b/mon-pix/tests/integration/components/routes/campaigns/assessment/evaluation-results-test.js
@@ -4,6 +4,7 @@ import { hbs } from 'ember-cli-htmlbars';
 import { t } from 'ember-intl/test-support';
 import { module, test } from 'qunit';
 
+import { stubConfigService } from '../../../../../helpers/service-stubs.js';
 import setupIntlRenderingTest from '../../../../../helpers/setup-intl-rendering';
 
 module('Integration | Components | Routes | Campaigns | Assessment | Evaluation Results', function (hooks) {
@@ -13,6 +14,7 @@ module('Integration | Components | Routes | Campaigns | Assessment | Evaluation 
 
   hooks.beforeEach(async function () {
     // given
+    stubConfigService(this.owner);
     const store = this.owner.lookup('service:store');
 
     const campaign = store.createRecord('campaign', {

--- a/mon-pix/tests/unit/routes/application-test.js
+++ b/mon-pix/tests/unit/routes/application-test.js
@@ -26,21 +26,12 @@ module('Unit | Route | application', function (hooks) {
   });
 
   module('#beforeModel', function (hooks) {
-    let configServiceStub,
-      localeServiceStub,
-      currentUserServiceStub,
-      featureTogglesServiceStub,
-      sessionServiceStub,
-      oidcIdentityProvidersStub;
+    let configServiceStub, localeServiceStub, currentUserServiceStub, sessionServiceStub, oidcIdentityProvidersStub;
 
     hooks.beforeEach(function () {
       const catchStub = sinon.stub();
 
       configServiceStub = Service.create({
-        load: sinon.stub().resolves(catchStub),
-      });
-
-      featureTogglesServiceStub = Service.create({
         load: sinon.stub().resolves(catchStub),
       });
 
@@ -67,7 +58,6 @@ module('Unit | Route | application', function (hooks) {
       // given
       const route = this.owner.lookup('route:application');
       route.set('config', configServiceStub);
-      route.set('featureToggles', featureTogglesServiceStub);
       route.set('session', sessionServiceStub);
       route.set('currentUser', currentUserServiceStub);
       route.set('locale', localeServiceStub);
@@ -85,7 +75,6 @@ module('Unit | Route | application', function (hooks) {
       // given
       const route = this.owner.lookup('route:application');
       route.set('config', configServiceStub);
-      route.set('featureToggles', featureTogglesServiceStub);
       route.set('session', sessionServiceStub);
       route.set('currentUser', currentUserServiceStub);
       route.set('locale', localeServiceStub);
@@ -104,7 +93,6 @@ module('Unit | Route | application', function (hooks) {
       // given
       const route = this.owner.lookup('route:application');
       route.set('config', configServiceStub);
-      route.set('featureToggles', featureTogglesServiceStub);
       route.set('session', sessionServiceStub);
       route.set('currentUser', currentUserServiceStub);
       route.set('locale', localeServiceStub);
@@ -118,29 +106,10 @@ module('Unit | Route | application', function (hooks) {
       assert.ok(true);
     });
 
-    test('gets feature toggles', async function (assert) {
-      // given
-      const route = this.owner.lookup('route:application');
-      route.set('config', configServiceStub);
-      route.set('featureToggles', featureTogglesServiceStub);
-      route.set('session', sessionServiceStub);
-      route.set('currentUser', currentUserServiceStub);
-      route.set('locale', localeServiceStub);
-      route.set('oidcIdentityProviders', oidcIdentityProvidersStub);
-
-      // when
-      await route.beforeModel();
-
-      // then
-      sinon.assert.calledOnce(featureTogglesServiceStub.load);
-      assert.ok(true);
-    });
-
     test('gets current user', async function (assert) {
       // given
       const route = this.owner.lookup('route:application');
       route.set('config', configServiceStub);
-      route.set('featureToggles', featureTogglesServiceStub);
       route.set('session', sessionServiceStub);
       route.set('currentUser', currentUserServiceStub);
       route.set('locale', localeServiceStub);

--- a/mon-pix/tests/unit/routes/application-test.js
+++ b/mon-pix/tests/unit/routes/application-test.js
@@ -26,7 +26,8 @@ module('Unit | Route | application', function (hooks) {
   });
 
   module('#beforeModel', function (hooks) {
-    let localeServiceStub,
+    let configServiceStub,
+      localeServiceStub,
       currentUserServiceStub,
       featureTogglesServiceStub,
       sessionServiceStub,
@@ -35,9 +36,14 @@ module('Unit | Route | application', function (hooks) {
     hooks.beforeEach(function () {
       const catchStub = sinon.stub();
 
+      configServiceStub = Service.create({
+        load: sinon.stub().resolves(catchStub),
+      });
+
       featureTogglesServiceStub = Service.create({
         load: sinon.stub().resolves(catchStub),
       });
+
       sessionServiceStub = Service.create({
         setup: sinon.stub().resolves(),
       });
@@ -57,9 +63,28 @@ module('Unit | Route | application', function (hooks) {
       this.intl = this.owner.lookup('service:intl');
     });
 
+    test('fetches the config', async function (assert) {
+      // given
+      const route = this.owner.lookup('route:application');
+      route.set('config', configServiceStub);
+      route.set('featureToggles', featureTogglesServiceStub);
+      route.set('session', sessionServiceStub);
+      route.set('currentUser', currentUserServiceStub);
+      route.set('locale', localeServiceStub);
+      route.set('oidcIdentityProviders', oidcIdentityProvidersStub);
+
+      // when
+      await route.beforeModel();
+
+      // then
+      sinon.assert.calledOnce(configServiceStub.load);
+      assert.ok(true);
+    });
+
     test('sets best locale', async function (assert) {
       // given
       const route = this.owner.lookup('route:application');
+      route.set('config', configServiceStub);
       route.set('featureToggles', featureTogglesServiceStub);
       route.set('session', sessionServiceStub);
       route.set('currentUser', currentUserServiceStub);
@@ -78,6 +103,7 @@ module('Unit | Route | application', function (hooks) {
     test('sets up the session', async function (assert) {
       // given
       const route = this.owner.lookup('route:application');
+      route.set('config', configServiceStub);
       route.set('featureToggles', featureTogglesServiceStub);
       route.set('session', sessionServiceStub);
       route.set('currentUser', currentUserServiceStub);
@@ -95,6 +121,7 @@ module('Unit | Route | application', function (hooks) {
     test('gets feature toggles', async function (assert) {
       // given
       const route = this.owner.lookup('route:application');
+      route.set('config', configServiceStub);
       route.set('featureToggles', featureTogglesServiceStub);
       route.set('session', sessionServiceStub);
       route.set('currentUser', currentUserServiceStub);
@@ -112,6 +139,7 @@ module('Unit | Route | application', function (hooks) {
     test('gets current user', async function (assert) {
       // given
       const route = this.owner.lookup('route:application');
+      route.set('config', configServiceStub);
       route.set('featureToggles', featureTogglesServiceStub);
       route.set('session', sessionServiceStub);
       route.set('currentUser', currentUserServiceStub);

--- a/mon-pix/tests/unit/routes/campaigns/entry-point-test.js
+++ b/mon-pix/tests/unit/routes/campaigns/entry-point-test.js
@@ -1,9 +1,10 @@
 import EmberObject from '@ember/object';
 import { setupTest } from 'ember-qunit';
-import ENV from 'mon-pix/config/environment';
 import Location from 'mon-pix/utils/location';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
+
+import { stubConfigService } from '../../../helpers/service-stubs.js';
 
 module('Unit | Route | Entry Point', function (hooks) {
   setupTest(hooks);
@@ -11,6 +12,8 @@ module('Unit | Route | Entry Point', function (hooks) {
   let route, campaign;
 
   hooks.beforeEach(function () {
+    stubConfigService(this.owner, { autonomousCoursesOrganizationId: 9999 });
+
     campaign = EmberObject.create({
       id: '3',
       code: 'NEW_CODE',
@@ -167,7 +170,7 @@ module('Unit | Route | Entry Point', function (hooks) {
           .withArgs('campaign-participation', {
             campaignId: 3,
             userId: 12,
-            organizationId: ENV.APP.AUTONOMOUS_COURSES_ORGANIZATION_ID,
+            organizationId: 9999,
           })
           .resolves('Existing campaign participation');
 

--- a/mon-pix/tests/unit/services/config-test.js
+++ b/mon-pix/tests/unit/services/config-test.js
@@ -1,0 +1,26 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module('Unit | Service | config', function (hooks) {
+  setupTest(hooks);
+
+  module('load', function () {
+    test('fetches config from API', async function (assert) {
+      // given
+      const requestManager = this.owner.lookup('service:request-manager');
+      sinon
+        .stub(requestManager, 'request')
+        .resolves({ content: { featureToggles: {}, autonomousCoursesOrganizationId: 1234567 } });
+
+      const configService = this.owner.lookup('service:config');
+
+      // when
+      await configService.load();
+
+      // then
+      assert.deepEqual(configService.featureToggles, {});
+      assert.strictEqual(configService.autonomousCoursesOrganizationId, 1234567);
+    });
+  });
+});

--- a/mon-pix/tests/unit/services/feature-toggles-test.js
+++ b/mon-pix/tests/unit/services/feature-toggles-test.js
@@ -1,5 +1,3 @@
-import Object from '@ember/object';
-import Service from '@ember/service';
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
@@ -7,41 +5,19 @@ import sinon from 'sinon';
 module('Unit | Service | feature-toggles', function (hooks) {
   setupTest(hooks);
 
-  module('feature toggles are loaded', function (hooks) {
-    const featureToggles = Object.create({
-      isTextToSpeechButtonEnabled: false,
-    });
-
-    let storeStub;
-
-    hooks.beforeEach(function () {
-      storeStub = Service.create({
-        queryRecord: sinon.stub().resolves(featureToggles),
-      });
-    });
-
-    test('should load the feature toggles', async function (assert) {
+  module('featureToggles', function () {
+    test('returns properties', async function (assert) {
       // given
+      const configService = this.owner.lookup('service:config');
+      sinon.stub(configService, 'featureToggles').value({ aProperty: 'some value' });
+
       const featureToggleService = this.owner.lookup('service:featureToggles');
-      featureToggleService.set('store', storeStub);
 
       // when
-      await featureToggleService.load();
+      const featureToggles = await featureToggleService.featureToggles;
 
       // then
-      assert.deepEqual(featureToggleService.featureToggles, featureToggles);
-    });
-
-    test('it should initialize the feature toggle isTextToSpeechButtonEnabled to false', async function (assert) {
-      // given
-      const featureToggleService = this.owner.lookup('service:featureToggles');
-      featureToggleService.set('store', storeStub);
-
-      // when
-      await featureToggleService.load();
-
-      // then
-      assert.false(featureToggleService.featureToggles.isTextToSpeechButtonEnabled);
+      assert.deepEqual(featureToggles, { aProperty: 'some value' });
     });
   });
 });


### PR DESCRIPTION
## ❄️ Problème

Il manque certaines informations de contexte aux frontaux et ces manques diminuent l’utilisabilité de certains fonctionnements ou obligent à faire des contournements plus ou moins sales :
* Le manque de l’information `PIX_ADMIN_LOGIN_FROM_PASSWORD_ENABLED` côté Front empêche de gérer proprement les différents comportements possibles de la page de login de Pix Admin
* Le manque de l’information `AUTONOMOUS_COURSES_ORGANIZATION_ID` côté Front fait définir côté Front une variable d’environnement `AUTONOMOUS_COURSES_ORGANIZATION_ID` qui a le risque d’être désynchronisée du Back (ce qui arrive souvent sur les RA, en local et potentiellement dès qu’un nouvel environnement est mis en place).

## 🛷 Proposition

Cette PR est la reprise de #14064

Faire un nouveau endpoint `/api/config`, porteur d’informations de configuration plus larges que les seuls _feature toggles_, et qui contient donc :
* les `featureToggles`
* et d’autres propriétés :
   * `PIX_ADMIN_LOGIN_FROM_PASSWORD_ENABLED`,
   * `AUTONOMOUS_COURSES_ORGANIZATION_ID`,
   * `pixLegalDocumentPath`

Faire utiliser ce nouveau endpoint à tous les frontaux mais ne pas supprimer l’ancienne route `/api/feature-toggles` dans cette PR. En effet les frontaux chargés dans les navigateurs continuent d’appeler cette route au logout des utilisateurs (invalidate de _ember-simple-auth_).

À noter que la solution choisie n’est pas de transformer `PIX_ADMIN_LOGIN_FROM_PASSWORD_ENABLED` et `AUTONOMOUS_COURSES_ORGANIZATION_ID` en feature toggles car ces valeurs ne sont pas volatiles et ont même des implications de sécurité forte. Ainsi on ne veut surtout pas que `PIX_ADMIN_LOGIN_FROM_PASSWORD_ENABLED` puisse être modifiée de la valeur à laquelle elle a été fixée en variable d’environnement.

:information_source: Cette PR est aussi l’occasion de montrer et démontrer une non-utilisation légitime de JSON:API pour le cas où l’API renvoie un simple singleton sans relation et non une collection.

## ☃️ Remarques

⚙️ Voir avec les captains pour la configuration du cache pour la nouvelle route `/api/config`, à mettre en rapport avec la stratégie de cache actuellement mise en place sur la route `/api/feature-toggles`.

## 🧑‍🎄 Pour tester

1. Se rendre sur les frontaux Pix App et Pix Admin, vérifier que l’application s’affiche sans problème et que la route `/api/config` est bien appelée et renvoie un `200`
2. Modifier des feature toggles côté Back (par exemple `isSelfAccountDeletionEnabled`) : 
   ```shell
   npm run toggles -- --key isSelfAccountDeletionEnabled --value false
   npm run toggles -- --key isSelfAccountDeletionEnabled --value true
   ```
3. Recharger Pix App
4. Constater que ce/ces feature toggles ont bien été pris en compte (par exemple pour `isSelfAccountDeletionEnabled` possibilité de supprimer ou non un compte nouvellement créé dans la page _« Mon compte »_)
5. Modifier la variable d’environnement  `AUTONOMOUS_COURSES_ORGANIZATION_ID` côté Back
6. Recharger Pix App
7. Constater que c’est bien la valeur qui est utilisée côté Front pour les parcours autonomes

### Pix Admin avec PIX_ADMIN_LOGIN_FROM_PASSWORD_ENABLED=true

Remarque : Si vous n’avez pas le bouton pour se connecter à ProConnect par SSO ce n’est pas grave, ceci dépend de la configuration des OIDC Providers qui est complètement indépendante de cette PR.

<img width="754" height="770" alt="Pix_Admin-with_login_password_form" src="https://github.com/user-attachments/assets/912a2bfd-43a4-4cfc-8c12-9e8051d6e017" />

### Pix Admin avec PIX_ADMIN_LOGIN_FROM_PASSWORD_ENABLED=false

Remarque : Si vous n’avez pas le bouton pour se connecter à ProConnect par SSO ce n’est pas grave, ceci dépend de la configuration des OIDC Providers qui est complètement indépendante de cette PR.

<img width="754" height="770" alt="Pix_Admin-without_login_password_form" src="https://github.com/user-attachments/assets/f6a849bc-6bb7-488d-900a-7004aa29483d" />
