### PR TITLE
[BUGFIX] Réparer des tests flakys

### DIFF
--- a/mon-pix/tests/helpers/wait-for.js
+++ b/mon-pix/tests/helpers/wait-for.js
@@ -1,28 +1,36 @@
 import { getScreen } from '@1024pix/ember-testing-library';
 import { waitUntil } from '@ember/test-helpers';
 
+const WAIT_UNTIL_TIMEOUT = 3000;
+
 export async function waitForDialog() {
   const screen = await getScreen();
 
-  await waitUntil(() => {
-    try {
-      screen.getByRole('dialog');
-      return true;
-    } catch {
-      return false;
-    }
-  });
+  await waitUntil(
+    () => {
+      try {
+        screen.getByRole('dialog');
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    { timeout: WAIT_UNTIL_TIMEOUT },
+  );
 }
 
 export async function waitForDialogClose() {
   const screen = await getScreen();
 
-  await waitUntil(() => {
-    try {
-      screen.getByRole('dialog');
-      return false;
-    } catch {
-      return true;
-    }
-  });
+  await waitUntil(
+    () => {
+      try {
+        screen.getByRole('dialog');
+        return false;
+      } catch {
+        return true;
+      }
+    },
+    { timeout: WAIT_UNTIL_TIMEOUT },
+  );
 }

--- a/mon-pix/tests/integration/components/assessment-banner-test.js
+++ b/mon-pix/tests/integration/components/assessment-banner-test.js
@@ -6,7 +6,7 @@ import { module, test } from 'qunit';
 import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
-import { waitForDialog } from '../../helpers/wait-for';
+import { waitForDialog, waitForDialogClose } from '../../helpers/wait-for';
 
 module('Integration | Component | assessment-banner', function (hooks) {
   setupIntlRenderingTest(hooks);
@@ -58,6 +58,7 @@ module('Integration | Component | assessment-banner', function (hooks) {
       await click(screen.getByText('Rester'));
 
       // then
+      await waitForDialogClose();
       assert.dom(screen.queryByRole('dialog', { name: "Besoin d'une pause ?" })).doesNotExist();
     });
 


### PR DESCRIPTION
## ❄️ Problème
Des tests flakys surviennent de temps en temps, ce qui rend laborieux le merge des PR et nous coute de précieux tokens circleCI.

## 🛷 Proposition
Les corriger

## ☃️ Remarques
- Le premier commit introduit une option `timeout` pour l'utilitaire waitUntil de ember/test-helpers. En effet, [par défaut](https://github.com/emberjs/ember-test-helpers/blob/66981f7178323fad37e5bffcfcafb04628441fa8/addon/src/wait-until.ts#L38) il est à `1000ms`, mais cela est peut être trop faible si le conteneur de circle-ci a des lenteurs. En le passant à `3000ms`, on a bon espoir de se prémunir de futurs flakys, mais seul l'avenir nous donnera raison 🔮 

- Dans le deuxième commit, on répare le test qui était friable en attendant que la modale ne soit plus affichée avant de faire l'assertion du test.

## 🧑‍🎄 Pour tester
- la CI est verte 🟢
- di'ci le prochain tech-time, les tests fixés dans cette PR ne sont plus flakys (et on vérifiera qu'ils ne remontent pas dans les insights de circle ci). 
