### PR TITLE
[TECH] Ajouter un test e2e Playwright pour a11y de Modulix (PIX-20984)

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/galerie.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/galerie.json
@@ -56,6 +56,14 @@
             {
               "type": "element",
               "element": {
+                "id": "94c378e3-2c1a-49c5-86fc-45a04a0e383d",
+                "type": "text",
+                "content": "<p><strong>audio</strong></p>\n<p>Il permet d'afficher élément audio</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
                 "id": "dcd0ef70-e34e-496f-9cd0-529b3168a14f",
                 "type": "audio",
                 "title": "Audio de ronron de chat",

--- a/high-level-tests/e2e-playwright/tests/pix-app/modulix-a11y.test.ts
+++ b/high-level-tests/e2e-playwright/tests/pix-app/modulix-a11y.test.ts
@@ -1,0 +1,105 @@
+import AxeBuilder from '@axe-core/playwright';
+
+import { expect, test } from '../../fixtures/index.ts';
+
+test('test modulix a11y on galerie module', async ({ page }) => {
+  await page.goto(process.env.PIX_APP_URL + '/modules/b9414fc3/galerie/details');
+
+  // Module Details
+  await expect(page).toHaveTitle(/Galerie Modulix/);
+  await page.getByRole('button', { name: 'Commencer le module' }).click();
+
+  // Module Passage
+  await expect(page).toHaveURL(process.env.PIX_APP_URL + '/modules/b9414fc3/galerie/passage');
+  await expect(page).toHaveTitle(/Galerie Modulix/);
+  await page.getByRole('button', { name: 'Continuer' }).click();
+
+  // Text element
+  await expect(page.getByText('text', { exact: true })).toBeVisible();
+  await page.getByRole('button', { name: 'Continuer' }).click();
+
+  // Audio element
+  await expect(page.getByText('audio', { exact: true })).toBeVisible();
+  await page.getByRole('button', { name: 'Continuer' }).click();
+
+  // Custom element
+  await expect(page.getByText('custom', { exact: true })).toBeVisible();
+  await page.getByRole('button', { name: 'Continuer' }).click();
+
+  // Custom-draft element
+  await expect(page.getByText('custom-draft (todo)', { exact: true })).toBeVisible();
+  await page.getByRole('button', { name: 'Continuer' }).click();
+
+  // Download element
+  await expect(page.getByText('download', { exact: true })).toBeVisible();
+  await page.getByRole('button', { name: 'Continuer' }).click();
+
+  // Embed element
+  await expect(page.getByText('embed', { exact: true })).toBeVisible();
+  await page.getByRole('button', { name: 'Continuer' }).click();
+
+  // Expand element
+  await expect(page.getByText('expand', { exact: true })).toBeVisible();
+  await page.getByText('Clique-moi pour en savoir').click();
+  await expect(page.getByText('Souvent, pour s’amuser, les hommes d’équipage')).toBeVisible();
+  await page.getByRole('button', { name: 'Continuer' }).click();
+
+  // Flashcards element
+  await expect(page.getByText('flashcards', { exact: true })).toBeVisible();
+  await page.getByRole('button', { name: 'Passer l’activité' }).click();
+
+  // Image element
+  await expect(page.getByText('image', { exact: true })).toBeVisible();
+  await page.getByRole('button', { name: 'Continuer' }).click();
+
+  // QAB element
+  await expect(page.getByText('qab', { exact: true })).toBeVisible();
+  await page.getByRole('button', { name: 'Passer l’activité' }).click();
+
+  // QCU element
+  await expect(page.getByText('qcu', { exact: true })).toBeVisible();
+  await page.getByRole('button', { name: 'Passer l’activité' }).click();
+
+  // QCU declarative element
+  await expect(page.getByText('qcu-declarative', { exact: true })).toBeVisible();
+  await page.getByRole('button', { name: 'Passer l’activité' }).click();
+
+  // QCU discovery element
+  await expect(page.getByText('qcu-discovery', { exact: true })).toBeVisible();
+  await page.getByRole('button', { name: 'Passer l’activité' }).click();
+
+  // QCM element
+  await expect(page.getByText('qcm', { exact: true })).toBeVisible();
+  await page.getByRole('button', { name: 'Passer l’activité' }).click();
+
+  // QROCM element
+  await expect(page.getByText('qrocm', { exact: true })).toBeVisible();
+  await page.getByRole('button', { name: 'Passer l’activité' }).click();
+
+  // Separator element
+  await expect(page.getByText('separator', { exact: true })).toBeVisible();
+  await page.getByRole('button', { name: 'Continuer' }).click();
+
+  // Video element
+  await expect(page.getByText('video', { exact: true })).toBeVisible();
+
+  // Short video element
+  await expect(page.getByText('short video', { exact: true })).toBeVisible();
+
+  // Finish button
+  await page.getByRole('button', { name: 'Terminer' }).waitFor();
+
+  // A11Y testing
+  await page.waitForTimeout(2000);
+  const modulixElement = page.locator('.modulix');
+  await modulixElement.evaluate((e) => {
+    Promise.all(e.getAnimations({ subtree: true }).map((a) => a.finished));
+  });
+
+  const axeBuilder = new AxeBuilder({ page });
+  axeBuilder.include('.modulix');
+  axeBuilder.exclude('iframe');
+
+  const accessibilityScanResults = await axeBuilder.analyze();
+  expect(accessibilityScanResults.violations).toEqual([]);
+});


### PR DESCRIPTION
## ❄️ Problème

Les essais précédents créaient des tests flaky. Est-ce la fin de la flaky malédiction??

## 🛷 Proposition

Quelques éléments pour sécuriser l'affichage du module dans le test:
- vérifier, après avoir cliqué sur "Continuer", qu'on a bien les texts ou autres éléments attendus
- vérifier avant le test a11y qu'on a bien la section de la page qu'on va tester qui est affichée : https://playwright.dev/docs/accessibility-testing#configuring-axe-to-scan-a-specific-part-of-a-page
- déclarer le `new AxeBuilder`en spécifiant la section qu'on va tester ([même lien](https://playwright.dev/docs/accessibility-testing#configuring-axe-to-scan-a-specific-part-of-a-page))
- Utilisation du Promise.all() pour attendre la fin des transitions
- Exclusion de `iframe`dans les tests a11y pour éviter des erreurs hors contexte

## ☃️ Remarques

- On attend que les animations sur la page soient terminées avant de lancer les tests. Pour cela, on suit l'astuce évoqué ici : https://github.com/dequelabs/axe-core-npm/issues/952#issuecomment-1836718600
- Inch'allah, ça va fonctionner.

## 🧑‍🎄 Pour tester

CI super green
