### PR TITLE
[TECH] :recycle: Créé un index dans la table quests que s'il n'existe pas déjà

### DIFF
--- a/api/db/migrations/20260127095811_add-reward-id-index-to-quests-table.js
+++ b/api/db/migrations/20260127095811_add-reward-id-index-to-quests-table.js
@@ -6,9 +6,7 @@ const COLUMN_NAME = 'rewardId';
  * @returns { Promise<void> }
  */
 const up = async function (knex) {
-  return knex.schema.table(TABLE_NAME, function (table) {
-    table.index(COLUMN_NAME);
-  });
+  return knex.raw('create index if not exists "quests_rewardid_index" on quests ("rewardId")');
 };
 
 /**


### PR DESCRIPTION
## ❄️ Problème

Nous avons du créé l'index à la main en production. Le fichier de migration qui permet de garder une trace de cette action et de créer l'index dans les autres environnements lèvera une erreur en production.

## 🛷 Proposition

Modifier le fichier de migration pour que la création d'index ne se fasse que s'il n'existe pas déjà.

## ☃️ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🧑‍🎄 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
