### PR TITLE
[BUGFIX] Solutions interprétées en markdown à tort (PIX-21172)

### DIFF
--- a/mon-pix/app/components/solution-panel/formatted-solution.gjs
+++ b/mon-pix/app/components/solution-panel/formatted-solution.gjs
@@ -1,5 +1,6 @@
 import Component from '@glimmer/component';
 import MarkdownToHtml from 'mon-pix/components/markdown-to-html';
+import htmlUnsafe from 'mon-pix/helpers/html-unsafe';
 
 export default class FormattedSolution extends Component {
   get displayedSolution() {
@@ -7,5 +8,13 @@ export default class FormattedSolution extends Component {
     return this.args.solutionToDisplay?.replaceAll('\n', ' <br>');
   }
 
-  <template><MarkdownToHtml ...attributes @markdown={{this.displayedSolution}} /></template>
+  <template>
+    {{#if @isMarkdown}}
+      <MarkdownToHtml ...attributes @markdown={{this.displayedSolution}} />
+    {{else}}
+      <span ...attributes>
+        {{htmlUnsafe this.displayedSolution}}
+      </span>
+    {{/if}}
+  </template>
 }

--- a/mon-pix/app/components/solution-panel/qcu-solution-panel.gjs
+++ b/mon-pix/app/components/solution-panel/qcu-solution-panel.gjs
@@ -67,6 +67,7 @@ export default class QcuSolutionPanel extends Component {
             'pages.comparison-window.results.feedback.wrong'
             htmlSafe=true
           }} {{this.solutionAsText}}"
+          @isMarkdown={{true}}
         />
       {{/if}}
     </div>


### PR DESCRIPTION
## ❄️ Problème

Certaines solutions sont interprétées comme du markdown à tort dans la popin de correction/solution.

## 🛷 Proposition

Interprété comme du markdown uniquement quand cela est nécessaire.

## ☃️ Remarques

Voir #13925 pour l’introduction du pb.

## 🧑‍🎄 Pour tester

FIXME