### PR TITLE
[FEATURE] Donner la possibilité aux prescripteurs de déployer un parcours combiné dans leur organisation (PIX-21179)

### DIFF
--- a/api/src/quest/application/combined-course-blueprint-controller.js
+++ b/api/src/quest/application/combined-course-blueprint-controller.js
@@ -42,3 +42,10 @@ export const attachOrganizations = async (
     )
     .code(201);
 };
+
+export const findByOrganizationId = async (request, _, dependencies = { combinedCourseBlueprintSerializer }) => {
+  const combinedCourseBlueprint = await usecases.findByOrganizationId({
+    organizationId: request.params.organizationId,
+  });
+  return dependencies.combinedCourseBlueprintSerializer.serialize(combinedCourseBlueprint);
+};

--- a/api/src/quest/application/combined-course-blueprint-route.js
+++ b/api/src/quest/application/combined-course-blueprint-route.js
@@ -145,6 +145,26 @@ const register = async function (server) {
         tags: ['api', 'combined-course'],
       },
     },
+    {
+      method: 'GET',
+      path: '/api/organizations/{organizationId}/combined-course-blueprints',
+      config: {
+        validate: {
+          params: Joi.object({
+            organizationId: identifiersType.organizationId,
+          }),
+        },
+        pre: [
+          {
+            method: securityPreHandlers.checkOrganizationAccess,
+            assign: 'checkOrganizationAccess',
+          },
+        ],
+        handler: combinedCourseBlueprintController.findByOrganizationId,
+        notes: ["- Récupère les schémas de parcours combinés partagés avec l'organisation"],
+        tags: ['api', 'combined-course'],
+      },
+    },
   ]);
 };
 

--- a/api/src/quest/application/combined-course-controller.js
+++ b/api/src/quest/application/combined-course-controller.js
@@ -95,6 +95,7 @@ const createCombinedCourses = async function (request, h) {
   const stream = createReadStream(filePath);
   const payload = await getDataBuffer(stream);
   await usecases.createCombinedCourses({ payload });
+
   return h.response(null).code(204);
 };
 

--- a/api/src/quest/application/combined-course-controller.js
+++ b/api/src/quest/application/combined-course-controller.js
@@ -3,13 +3,13 @@ import { createReadStream } from 'node:fs';
 import { getDataBuffer } from '../../prescription/learner-management/infrastructure/utils/bufferize/get-data-buffer.js';
 import { extractUserIdFromRequest } from '../../shared/infrastructure/utils/request-response-utils.js';
 import { usecases } from '../domain/usecases/index.js';
+import * as campaignTypeCombinedCourseSerializer from '../infrastructure/serializers/campaign-type-combined-course-serializer.js';
 import * as combinedCourseDetailsSerializer from '../infrastructure/serializers/combined-course-details-serializer.js';
 import * as combinedCourseListSerializer from '../infrastructure/serializers/combined-course-list-serializer.js';
 import * as combinedCourseParticipationDetailSerializer from '../infrastructure/serializers/combined-course-participation-detail-serializer.js';
 import * as combinedCourseParticipationSerializer from '../infrastructure/serializers/combined-course-participation-serializer.js';
 import * as combinedCourseSerializer from '../infrastructure/serializers/combined-course-serializer.js';
 import * as combinedCourseStatisticsSerializer from '../infrastructure/serializers/combined-course-statistics-serializer.js';
-
 const getByCode = async function (request, _, dependencies = { combinedCourseSerializer }) {
   const { code } = request.query.filter;
 
@@ -98,6 +98,30 @@ const createCombinedCourses = async function (request, h) {
   return h.response(null).code(204);
 };
 
+const createCombinedCourse = async function (request, h, dependencies = { campaignTypeCombinedCourseSerializer }) {
+  const data = request.payload.data;
+  const { userId } = request.auth.credentials;
+
+  const organizationId = parseInt(data.relationships.organization.data.id) || null;
+  const combinedCourseBlueprintId = parseInt(data.relationships['combined-course-blueprint'].data.id) || null;
+  const { name } = data.attributes;
+
+  const createdCombinedCourse = await usecases.createCombinedCourse({
+    name,
+    combinedCourseBlueprintId,
+    creatorId: userId,
+    organizationId,
+  });
+  return h
+    .response(
+      dependencies.campaignTypeCombinedCourseSerializer.serialize({
+        ...createdCombinedCourse,
+        type: 'COMBINED_COURSE',
+      }),
+    )
+    .created();
+};
+
 const combinedCourseController = {
   getByCode,
   getById,
@@ -108,6 +132,7 @@ const combinedCourseController = {
   start,
   reassessStatus,
   createCombinedCourses,
+  createCombinedCourse,
 };
 
 export { combinedCourseController };

--- a/api/src/quest/application/combined-course-route.js
+++ b/api/src/quest/application/combined-course-route.js
@@ -242,6 +242,21 @@ const register = async function (server) {
         tags: ['api', 'admin', 'combined-course'],
       },
     },
+    {
+      method: 'POST',
+      path: '/api/combined-courses',
+      config: {
+        pre: [
+          {
+            method: securityPreHandlers.checkOrganizationAccess,
+            assign: 'checkOrganizationAccess',
+          },
+        ],
+        handler: combinedCourseController.createCombinedCourse,
+        notes: ['- Permet au prescripteur connecté de déployer un parcours combiné dans son organisation.'],
+        tags: ['api', 'orga', 'combined-course'],
+      },
+    },
   ]);
 };
 const name = 'combined-courses-api';

--- a/api/src/quest/domain/models/Campaign.js
+++ b/api/src/quest/domain/models/Campaign.js
@@ -22,4 +22,35 @@ export class Campaign {
     this.customResultPageButtonUrl = customResultPageButtonUrl;
     this.customResultPageButtonText = customResultPageButtonText;
   }
+
+  static buildCampaignForCombinedCourse({
+    organizationId,
+    targetProfile,
+    creatorId,
+    combinedCourseCode,
+    recommendableModules,
+    modules,
+  }) {
+    let hasRecommendableModulesInTargetProfile;
+    if (recommendableModules) {
+      hasRecommendableModulesInTargetProfile =
+        recommendableModules.length > 0 &&
+        Boolean(recommendableModules.filter(({ moduleId }) => modules.map(({ id }) => id).includes(moduleId)));
+    }
+
+    let combinedCourseUrl = '/parcours/' + combinedCourseCode;
+
+    if (hasRecommendableModulesInTargetProfile) combinedCourseUrl += '/chargement';
+
+    return new Campaign({
+      organizationId: parseInt(organizationId),
+      targetProfileId: targetProfile.id,
+      creatorId: parseInt(creatorId),
+      ownerId: parseInt(creatorId),
+      name: targetProfile.internalName,
+      title: targetProfile.name,
+      customResultPageButtonUrl: combinedCourseUrl,
+      customResultPageButtonText: 'Continuer',
+    });
+  }
 }

--- a/api/src/quest/domain/services/combined-course-to-create-service.js
+++ b/api/src/quest/domain/services/combined-course-to-create-service.js
@@ -1,0 +1,69 @@
+import { Campaign } from '../../../prescription/campaign/domain/models/Campaign.js';
+
+const buildModulesAndCampaigns = async ({
+  organizationId,
+  combinedCourseBlueprint,
+  creatorId,
+  moduleRepository,
+  recommendedModuleRepository,
+  targetProfileRepository,
+  combinedCourseCode,
+}) => {
+  const targetProfileIds = combinedCourseBlueprint.targetProfileIds ?? [];
+  const targetProfiles = await targetProfileRepository.findByIds({ ids: targetProfileIds });
+  const campaignsToCreate = [];
+  let modules = [];
+
+  if (combinedCourseBlueprint.moduleShortIds) {
+    modules = await moduleRepository.getByShortIds({
+      moduleShortIds: combinedCourseBlueprint.moduleShortIds,
+    });
+  }
+
+  for (const targetProfile of targetProfiles) {
+    const campaignToCreate = await buildCampaign({
+      targetProfile,
+      modules,
+      organizationId,
+      creatorId,
+      recommendedModuleRepository,
+      combinedCourseCode,
+    });
+    campaignsToCreate.push(campaignToCreate);
+  }
+  return { campaignsToCreate, modules };
+};
+
+const buildCampaign = async ({
+  targetProfile,
+  combinedCourseCode,
+  modules,
+  organizationId,
+  creatorId,
+  recommendedModuleRepository,
+}) => {
+  const recommendableModules = await recommendedModuleRepository.findIdsByTargetProfileIds({
+    targetProfileIds: [targetProfile.id],
+  });
+
+  const hasRecommendableModulesInTargetProfile =
+    recommendableModules.length > 0 &&
+    Boolean(recommendableModules.filter(({ moduleId }) => modules.map(({ id }) => id).includes(moduleId)));
+
+  let combinedCourseUrl = '/parcours/' + combinedCourseCode;
+
+  if (hasRecommendableModulesInTargetProfile) combinedCourseUrl += '/chargement';
+
+  return new Campaign({
+    organizationId: parseInt(organizationId),
+    targetProfileId: targetProfile.id,
+    creatorId: parseInt(creatorId),
+    ownerId: parseInt(creatorId),
+    name: targetProfile.internalName,
+    title: targetProfile.name,
+    customResultPageButtonUrl: combinedCourseUrl,
+    customResultPageButtonText: 'Continuer',
+  });
+};
+
+export default { buildModulesAndCampaigns };

--- a/api/src/quest/domain/usecases/create-combined-course.js
+++ b/api/src/quest/domain/usecases/create-combined-course.js
@@ -1,0 +1,45 @@
+export const createCombinedCourse = async ({
+  combinedCourseBlueprintId,
+  name,
+  creatorId,
+  organizationId,
+  campaignRepository,
+  targetProfileRepository,
+  codeGenerator,
+  accessCodeRepository,
+  combinedCourseRepository,
+  combinedCourseBlueprintRepository,
+  recommendedModuleRepository,
+  moduleRepository,
+  combinedCourseToCreateService,
+}) => {
+  const combinedCourseBlueprint = await combinedCourseBlueprintRepository.findById({
+    id: combinedCourseBlueprintId,
+  });
+
+  const { campaignsToCreate, modules } = await combinedCourseToCreateService.buildModulesAndCampaigns({
+    organizationId,
+    combinedCourseBlueprint,
+    creatorId,
+    moduleRepository,
+    codeGenerator,
+    accessCodeRepository,
+    recommendedModuleRepository,
+    targetProfileRepository,
+  });
+
+  const createdCampaigns = await campaignRepository.save({ campaigns: campaignsToCreate });
+  const combinedCourseCode = await codeGenerator.generate(accessCodeRepository);
+
+  const combinedCourse = combinedCourseBlueprint.toCombinedCourse({
+    name,
+    description: combinedCourseBlueprint.description,
+    illustration: combinedCourseBlueprint.illustration,
+    code: combinedCourseCode,
+    organizationId,
+    campaigns: createdCampaigns,
+    modulesByShortId: Object.groupBy(modules, ({ shortId }) => shortId),
+  });
+
+  return combinedCourseRepository.save({ combinedCourse });
+};

--- a/api/src/quest/domain/usecases/create-combined-course.js
+++ b/api/src/quest/domain/usecases/create-combined-course.js
@@ -12,6 +12,7 @@ export const createCombinedCourse = async ({
   recommendedModuleRepository,
   moduleRepository,
   combinedCourseToCreateService,
+  questRepository,
 }) => {
   const combinedCourseBlueprint = await combinedCourseBlueprintRepository.findById({
     id: combinedCourseBlueprintId,
@@ -41,5 +42,5 @@ export const createCombinedCourse = async ({
     modulesByShortId: Object.groupBy(modules, ({ shortId }) => shortId),
   });
 
-  return combinedCourseRepository.save({ combinedCourse });
+  return combinedCourseRepository.save({ combinedCourse, questRepository });
 };

--- a/api/src/quest/domain/usecases/create-combined-courses.js
+++ b/api/src/quest/domain/usecases/create-combined-courses.js
@@ -14,6 +14,7 @@ export const createCombinedCourses = withTransaction(
     recommendedModuleRepository,
     moduleRepository,
     combinedCourseToCreateService,
+    questRepository,
   }) => {
     const csvParser = new CsvParser(payload, COMBINED_COURSE_HEADER, { delimiter: ';' });
     const csvData = csvParser.parse();
@@ -58,6 +59,6 @@ export const createCombinedCourses = withTransaction(
       }
     }
 
-    await combinedCourseRepository.saveInBatch({ combinedCourses });
+    await combinedCourseRepository.saveInBatch({ combinedCourses, questRepository });
   },
 );

--- a/api/src/quest/domain/usecases/create-combined-courses.js
+++ b/api/src/quest/domain/usecases/create-combined-courses.js
@@ -1,7 +1,6 @@
 import { withTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { CsvParser } from '../../../shared/infrastructure/serializers/csv/csv-parser.js';
 import { COMBINED_COURSE_HEADER } from '../constants.js';
-import { Campaign } from '../models/Campaign.js';
 
 export const createCombinedCourses = withTransaction(
   async ({
@@ -14,12 +13,14 @@ export const createCombinedCourses = withTransaction(
     combinedCourseBlueprintRepository,
     recommendedModuleRepository,
     moduleRepository,
+    combinedCourseToCreateService,
   }) => {
     const csvParser = new CsvParser(payload, COMBINED_COURSE_HEADER, { delimiter: ';' });
     const csvData = csvParser.parse();
 
     const combinedCourses = [];
     const pendingCodes = [];
+
     for (const row of csvData) {
       const { organizationIds: organizationIdsSeparatedByComma, creatorId, content, combinedCourseBlueprintId } = row;
       const organizationIds = organizationIdsSeparatedByComma.split(',');
@@ -28,46 +29,21 @@ export const createCombinedCourses = withTransaction(
         id: combinedCourseBlueprintId,
       });
 
-      const targetProfileIds = combinedCourseBlueprint.targetProfileIds;
-      const targetProfiles = await targetProfileRepository.findByIds({ ids: targetProfileIds });
-
       for (const organizationId of organizationIds) {
-        const campaigns = [];
         const combinedCourseCode = await codeGenerator.generate(accessCodeRepository, pendingCodes);
         pendingCodes.push(combinedCourseCode);
 
-        const modules = await moduleRepository.getByShortIds({
-          moduleShortIds: combinedCourseBlueprint.moduleShortIds,
+        const { campaignsToCreate, modules } = await combinedCourseToCreateService.buildModulesAndCampaigns({
+          organizationId,
+          combinedCourseBlueprint,
+          creatorId,
+          moduleRepository,
+          combinedCourseCode,
+          recommendedModuleRepository,
+          targetProfileRepository,
         });
 
-        for (const targetProfile of targetProfiles) {
-          const recommendableModules = await recommendedModuleRepository.findIdsByTargetProfileIds({
-            targetProfileIds: [targetProfile.id],
-          });
-
-          const hasRecommendableModulesInTargetProfile =
-            recommendableModules.length > 0 &&
-            Boolean(recommendableModules.filter(({ moduleId }) => modules.map(({ id }) => id).includes(moduleId)));
-
-          let combinedCourseUrl = '/parcours/' + combinedCourseCode;
-
-          if (hasRecommendableModulesInTargetProfile) combinedCourseUrl += '/chargement';
-
-          campaigns.push(
-            new Campaign({
-              organizationId: parseInt(organizationId),
-              targetProfileId: targetProfile.id,
-              creatorId: parseInt(creatorId),
-              ownerId: parseInt(creatorId),
-              name: targetProfile.internalName,
-              title: targetProfile.name,
-              customResultPageButtonUrl: combinedCourseUrl,
-              customResultPageButtonText: 'Continuer',
-            }),
-          );
-        }
-
-        const createdCampaigns = await campaignRepository.save({ campaigns });
+        const createdCampaigns = await campaignRepository.save({ campaigns: campaignsToCreate });
 
         const combinedCourse = combinedCourseBlueprint.toCombinedCourse({
           name: combinedCourseInformation.name,
@@ -84,5 +60,4 @@ export const createCombinedCourses = withTransaction(
 
     await combinedCourseRepository.saveInBatch({ combinedCourses });
   },
-  { isolationLevel: 'repeatable read' },
 );

--- a/api/src/quest/domain/usecases/find-by-organization-id.js
+++ b/api/src/quest/domain/usecases/find-by-organization-id.js
@@ -1,0 +1,8 @@
+/**
+ * @param {Object} params
+ * @param {import('./index.js').CombinedCourseBlueprintRepository} params.combinedCourseBlueprintRepository
+ * @returns {Promise<import('../models/CombinedCourseBlueprint.js').CombinedCourseBlueprint[]>}
+ **/
+export const findByOrganizationId = async ({ combinedCourseBlueprintRepository, organizationId }) => {
+  return combinedCourseBlueprintRepository.findByOrganizationId({ organizationId });
+};

--- a/api/src/quest/domain/usecases/index.js
+++ b/api/src/quest/domain/usecases/index.js
@@ -6,6 +6,7 @@ import * as combinedCourseBlueprintRepository from '../../infrastructure/reposit
 import { repositories } from '../../infrastructure/repositories/index.js';
 import * as organizationLearnerRepository from '../../infrastructure/repositories/organization-learner-repository.js';
 import combinedCourseDetailsService from '../services/combined-course-details-service.js';
+import combinedCourseToCreateService from '../services/combined-course-to-create-service.js';
 
 const { combinedCourseDetailsService: injectedCombinedCourseDetailsService } = injectDependencies(
   { combinedCourseDetailsService },
@@ -17,6 +18,17 @@ const { combinedCourseDetailsService: injectedCombinedCourseDetailsService } = i
     moduleRepository: repositories.moduleRepository,
     eligibilityRepository: repositories.eligibilityRepository,
     recommendedModuleRepository: repositories.recommendedModuleRepository,
+  },
+);
+
+const { combinedCourseToCreateService: injectedCombinedCourseToCreateService } = injectDependencies(
+  { combinedCourseToCreateService },
+  {
+    moduleRepository: repositories.moduleRepository,
+    codeGenerator,
+    accessCodeRepository: repositories.accessCodeRepository,
+    recommendedModuleRepository: repositories.recommendedModuleRepository,
+    targetProfileRepository: repositories.targetProfileRepository,
   },
 );
 
@@ -36,6 +48,7 @@ const dependencies = {
   targetProfileRepository: repositories.targetProfileRepository,
   organizationLearnerParticipationRepository: repositories.organizationLearnerParticipationRepository,
   combinedCourseDetailsService: injectedCombinedCourseDetailsService,
+  combinedCourseToCreateService: injectedCombinedCourseToCreateService,
   organizationLearnerRepository,
   organizationLearnerPrescriptionRepository,
   combinedCourseBlueprintRepository,
@@ -45,10 +58,12 @@ const dependencies = {
 
 import { attachOrganizationsToCombinedCourseBlueprint } from './attach-organizations-to-combined-course-blueprint.js';
 import { checkUserQuest } from './check-user-quest-success.js';
+import { createCombinedCourse } from './create-combined-course.js';
 import { createCombinedCourseBlueprint } from './create-combined-course-blueprint.js';
 import { createCombinedCourses } from './create-combined-courses.js';
 import { createOrUpdateQuestsInBatch } from './create-or-update-quests-in-batch.js';
 import { detachOrganizationFromCombinedCourseBlueprint } from './detach-organization-from-combined-course-blueprint.js';
+import { findByOrganizationId } from './find-by-organization-id.js';
 import { findCombinedCourseBlueprints } from './find-combined-course-blueprints.js';
 import { findCombinedCourseByCampaignId } from './find-combined-course-by-campaign-id.js';
 import { findCombinedCourseByModuleIdAndUserId } from './find-combined-course-by-moduleId-and-user-id.js';
@@ -87,6 +102,8 @@ const usecasesWithoutInjectedDependencies = {
   updateCombinedCourse,
   createCombinedCourses,
   createCombinedCourseBlueprint,
+  createCombinedCourse,
+  findByOrganizationId,
 };
 
 const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);

--- a/api/src/quest/infrastructure/repositories/combined-course-repository.js
+++ b/api/src/quest/infrastructure/repositories/combined-course-repository.js
@@ -82,6 +82,19 @@ const saveInBatch = async ({ combinedCourses }) => {
   }
 };
 
+const save = async ({ combinedCourse }) => {
+  const knexConn = DomainTransaction.getConnection();
+  const combinedCourseToSave = _toDTO(combinedCourse);
+  const [{ id: questId }] = await knexConn('quests')
+    .insert({ ...combinedCourseToSave.quest })
+    .returning('id');
+  const [{ id: createdCombinedCourseId }] = await knexConn('combined_courses')
+    .insert({ ...combinedCourseToSave.combinedCourse, questId })
+    .returning('id');
+
+  return getById({ id: createdCombinedCourseId });
+};
+
 const _toDTO = (combinedCourse) => {
   const questDTO = combinedCourse.quest.toDTO();
   return {
@@ -143,4 +156,12 @@ const _toDomain = ({
   });
 };
 
-export { findByCampaignId, findByModuleIdAndOrganizationIds, findByOrganizationId, getByCode, getById, saveInBatch };
+export {
+  findByCampaignId,
+  findByModuleIdAndOrganizationIds,
+  findByOrganizationId,
+  getByCode,
+  getById,
+  save,
+  saveInBatch,
+};

--- a/api/src/quest/infrastructure/repositories/combined-course-repository.js
+++ b/api/src/quest/infrastructure/repositories/combined-course-repository.js
@@ -71,46 +71,36 @@ const findByCampaignId = async ({ campaignId }) => {
   return combinedCourses.map(_toDomain);
 };
 
-const saveInBatch = async ({ combinedCourses }) => {
+const saveInBatch = async ({ combinedCourses, questRepository }) => {
   const knexConn = DomainTransaction.getConnection();
   const combinedCoursesToSave = combinedCourses.map(_toDTO);
-  for (const combinedCourseToSave of combinedCoursesToSave) {
-    const [{ id: questId }] = await knexConn('quests')
-      .insert({ ...combinedCourseToSave.quest })
-      .returning('id');
-    await knexConn('combined_courses').insert({ ...combinedCourseToSave.combinedCourse, questId });
+  const questsToSave = combinedCourses.map((combinedCourse) => combinedCourse.quest);
+  const questIds = await questRepository.saveInBatch({ quests: questsToSave });
+
+  for (let i = 0; i < questIds.length; i++) {
+    await knexConn('combined_courses').insert({ ...combinedCoursesToSave[i], questId: questIds[i] });
   }
 };
 
-const save = async ({ combinedCourse }) => {
+const save = async ({ combinedCourse, questRepository }) => {
   const knexConn = DomainTransaction.getConnection();
   const combinedCourseToSave = _toDTO(combinedCourse);
-  const [{ id: questId }] = await knexConn('quests')
-    .insert({ ...combinedCourseToSave.quest })
-    .returning('id');
+  const questId = await questRepository.save({ quest: combinedCourse.quest });
   const [{ id: createdCombinedCourseId }] = await knexConn('combined_courses')
-    .insert({ ...combinedCourseToSave.combinedCourse, questId })
+    .insert({ ...combinedCourseToSave, questId })
     .returning('id');
 
   return getById({ id: createdCombinedCourseId });
 };
 
 const _toDTO = (combinedCourse) => {
-  const questDTO = combinedCourse.quest.toDTO();
   return {
-    quest: {
-      ...questDTO,
-      eligibilityRequirements: JSON.stringify([]),
-      successRequirements: JSON.stringify(questDTO.successRequirements),
-    },
-    combinedCourse: {
-      combinedCourseBlueprintId: combinedCourse.blueprintId,
-      organizationId: combinedCourse.organizationId,
-      code: combinedCourse.code,
-      name: combinedCourse.name,
-      description: combinedCourse.description,
-      illustration: combinedCourse.illustration,
-    },
+    combinedCourseBlueprintId: combinedCourse.blueprintId,
+    organizationId: combinedCourse.organizationId,
+    code: combinedCourse.code,
+    name: combinedCourse.name,
+    description: combinedCourse.description,
+    illustration: combinedCourse.illustration,
   };
 };
 

--- a/api/src/quest/infrastructure/serializers/campaign-type-combined-course-serializer.js
+++ b/api/src/quest/infrastructure/serializers/campaign-type-combined-course-serializer.js
@@ -1,0 +1,11 @@
+import jsonapiSerializer from 'jsonapi-serializer';
+
+const { Serializer } = jsonapiSerializer;
+
+const serialize = function (campaign) {
+  return new Serializer('campaign', {
+    attributes: ['name', 'code', 'type'],
+  }).serialize(campaign);
+};
+
+export { serialize };

--- a/api/src/team/infrastructure/serializers/jsonapi/prescriber-serializer.js
+++ b/api/src/team/infrastructure/serializers/jsonapi/prescriber-serializer.js
@@ -60,6 +60,7 @@ const serialize = function (prescriber) {
           'isAgriculture',
           'identityProviderForCampaigns',
           'targetProfiles',
+          'combinedCourseBlueprints',
           'memberships',
           'divisions',
           'organizationInvitations',
@@ -97,6 +98,16 @@ const serialize = function (prescriber) {
           relationshipLinks: {
             related: function (record, current, parent) {
               return `/api/organizations/${parent.id}/target-profiles`;
+            },
+          },
+        },
+        combinedCourseBlueprints: {
+          ref: 'id',
+          ignoreRelationshipData: true,
+          nullIfMissing: true,
+          relationshipLinks: {
+            related: function (record, current, parent) {
+              return `/api/organizations/${parent.id}/combined-course-blueprints`;
             },
           },
         },

--- a/api/tests/quest/acceptance/application/combined-course-blueprint-route_test.js
+++ b/api/tests/quest/acceptance/application/combined-course-blueprint-route_test.js
@@ -176,4 +176,35 @@ describe('Quest | Acceptance | Application | Combined course blueprint Route ', 
       });
     });
   });
+  describe('GET /api/organizations/:id/combined-course-blueprints', function () {
+    context('when user is authenticated', function () {
+      let user;
+      let organization;
+
+      beforeEach(async function () {
+        user = databaseBuilder.factory.buildUser({});
+        organization = databaseBuilder.factory.buildOrganization({});
+        databaseBuilder.factory.buildMembership({
+          userId: user.id,
+          organizationId: organization.id,
+        });
+
+        await databaseBuilder.commit();
+      });
+
+      it('should return 200', async function () {
+        const options = {
+          method: 'GET',
+          url: `/api/organizations/${organization.id}/combined-course-blueprints`,
+          headers: generateAuthenticatedUserRequestHeaders({ userId: user.id }),
+        };
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(200);
+      });
+    });
+  });
 });

--- a/api/tests/quest/integration/domain/services/combined-course-to-create-service_test.js
+++ b/api/tests/quest/integration/domain/services/combined-course-to-create-service_test.js
@@ -1,0 +1,115 @@
+import { Campaign } from '../../../../../src/prescription/campaign/domain/models/Campaign.js';
+import { CombinedCourseBlueprint } from '../../../../../src/quest/domain/models/CombinedCourseBlueprint.js';
+import combinedCourseToCreateService from '../../../../../src/quest/domain/services/combined-course-to-create-service.js';
+import { repositories } from '../../../../../src/quest/infrastructure/repositories/index.js';
+import * as codeGenerator from '../../../../../src/shared/domain/services/code-generator.js';
+import { injectDependencies } from '../../../../../src/shared/infrastructure/utils/dependency-injection.js';
+import { databaseBuilder, expect } from '../../../../test-helper.js';
+
+const { combinedCourseToCreateService: CombinedCourseToCreateService } = injectDependencies(
+  { combinedCourseToCreateService },
+  {
+    moduleRepository: repositories.moduleRepository,
+    codeGenerator,
+    accessCodeRepository: repositories.accessCodeRepository,
+    recommendedModuleRepository: repositories.recommendedModuleRepository,
+    targetProfileRepository: repositories.targetProfileRepository,
+  },
+);
+
+describe('Integration | Quest | Domain | Services | CombinedCourseToCreateService', function () {
+  it('should not build campaigns and modules if combined course blueprint does not have them', async function () {
+    // given
+    const organization = databaseBuilder.factory.buildOrganization();
+    const combinedCourseBlueprint = databaseBuilder.factory.buildCombinedCourseBlueprint();
+    const creator = databaseBuilder.factory.buildUser();
+    databaseBuilder.factory.buildMembership({ organizationId: organization.id, userId: creator.id });
+    await databaseBuilder.commit();
+
+    //when
+    const result = await CombinedCourseToCreateService.buildModulesAndCampaigns({
+      organizationId: organization.id,
+      combinedCourseBlueprint,
+      creatorId: creator.id,
+    });
+
+    //then
+    expect(result).to.deep.equal({ campaignsToCreate: [], modules: [] });
+  });
+  it('should build campaigns and modules if combined course blueprint has them in its content', async function () {
+    // given
+    const organization = databaseBuilder.factory.buildOrganization();
+    const targetProfile = databaseBuilder.factory.buildTargetProfile({ id: 123 });
+    databaseBuilder.factory.buildCombinedCourseBlueprint({
+      content: [
+        { type: 'module', value: '6a68bf32' },
+        { type: 'evaluation', value: targetProfile.id },
+        { type: 'module', value: '9d4dcab8' },
+        { type: 'evaluation', value: targetProfile.id },
+      ],
+    });
+    const combinedCourseBlueprint = new CombinedCourseBlueprint({
+      content: [
+        { type: 'module', value: '6a68bf32' },
+        { type: 'evaluation', value: targetProfile.id },
+        { type: 'module', value: '9d4dcab8' },
+        { type: 'evaluation', value: targetProfile.id },
+      ],
+    });
+    const creator = databaseBuilder.factory.buildUser();
+    databaseBuilder.factory.buildMembership({ organizationId: organization.id, userId: creator.id });
+    await databaseBuilder.commit();
+
+    //when
+    const result = await CombinedCourseToCreateService.buildModulesAndCampaigns({
+      organizationId: organization.id,
+      combinedCourseBlueprint,
+      creatorId: creator.id,
+      combinedCourseCode: 'RANDOM',
+    });
+
+    //then
+    expect(result).to.deep.equal({
+      campaignsToCreate: [
+        new Campaign({
+          creatorId: creator.id,
+          targetProfileId: targetProfile.id,
+          organizationId: organization.id,
+          customResultPageButtonText: 'Continuer',
+          customResultPageButtonUrl: '/parcours/RANDOM',
+          ownerId: creator.id,
+          title: targetProfile.internalName,
+          name: targetProfile.name,
+        }),
+        new Campaign({
+          creatorId: creator.id,
+          targetProfileId: targetProfile.id,
+          organizationId: organization.id,
+          customResultPageButtonText: 'Continuer',
+          customResultPageButtonUrl: '/parcours/RANDOM',
+          ownerId: creator.id,
+          title: targetProfile.internalName,
+          name: targetProfile.name,
+        }),
+      ],
+      modules: [
+        {
+          duration: 5,
+          id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          image: 'https://assets.pix.org/modules/placeholder-details.svg',
+          shortId: '6a68bf32',
+          slug: 'bac-a-sable',
+          title: 'Bac à sable',
+        },
+        {
+          id: 'f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d',
+          shortId: '9d4dcab8',
+          slug: 'bien-ecrire-son-adresse-mail',
+          title: 'Bien écrire une adresse mail',
+          duration: 10,
+          image: 'https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-details.svg',
+        },
+      ],
+    });
+  });
+});

--- a/api/tests/quest/integration/domain/usecases/create-combined-course_test.js
+++ b/api/tests/quest/integration/domain/usecases/create-combined-course_test.js
@@ -1,0 +1,142 @@
+import { CampaignParticipationStatuses } from '../../../../../src/prescription/shared/domain/constants.js';
+import {
+  CRITERION_COMPARISONS,
+  REQUIREMENT_COMPARISONS,
+  REQUIREMENT_TYPES,
+} from '../../../../../src/quest/domain/models/Quest.js';
+import { usecases } from '../../../../../src/quest/domain/usecases/index.js';
+import { databaseBuilder, expect, knex } from '../../../../test-helper.js';
+
+describe('Integration | Combined course | Domain | UseCases | create-combined-course', function () {
+  it('should create combined course for given payload', async function () {
+    // given
+    const userId = databaseBuilder.factory.buildUser().id;
+    const organizationId = databaseBuilder.factory.buildOrganization().id;
+
+    const targetProfile = databaseBuilder.factory.buildTargetProfile({
+      ownerOrganizationId: organizationId,
+    });
+
+    const targetProfileWithTraining = databaseBuilder.factory.buildTargetProfile({
+      ownerOrganizationId: organizationId,
+    });
+    const trainingId = databaseBuilder.factory.buildTraining({
+      type: 'modulix',
+      title: 'Demo combinix 1',
+      link: '/modules/demo-combinix-1',
+      locale: 'fr-fr',
+    }).id;
+
+    databaseBuilder.factory.buildTargetProfileTraining({
+      targetProfileId: targetProfileWithTraining.id,
+      trainingId: trainingId,
+    });
+
+    const {
+      id: combinedCourseBlueprintId,
+      description,
+      illustration,
+    } = databaseBuilder.factory.buildCombinedCourseBlueprint({
+      content: [
+        { type: 'evaluation', value: targetProfile.id },
+        { type: 'module', value: '27d6ca4f' },
+        { type: 'module', value: 'df82ec66' },
+      ],
+    });
+
+    await databaseBuilder.commit();
+
+    const nameInput = 'Un parcours combiné';
+
+    // when
+    await usecases.createCombinedCourse({
+      name: nameInput,
+      combinedCourseBlueprintId,
+      creatorId: userId,
+      organizationId,
+    });
+
+    const [createdCampaign] = await knex('campaigns')
+      .where({ organizationId })
+      .whereIn('targetProfileId', [targetProfile.id, targetProfileWithTraining.id])
+      .orderBy('id');
+
+    const expectedModules = [
+      {
+        requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
+        comparison: CRITERION_COMPARISONS.ALL,
+        data: {
+          moduleId: {
+            data: 'eeeb4951-6f38-4467-a4ba-0c85ed71321a',
+            comparison: CRITERION_COMPARISONS.EQUAL,
+          },
+          isTerminated: {
+            data: true,
+            comparison: CRITERION_COMPARISONS.EQUAL,
+          },
+        },
+      },
+      {
+        requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
+        comparison: CRITERION_COMPARISONS.ALL,
+        data: {
+          moduleId: {
+            data: 'f32a2238-4f65-4698-b486-15d51935d335',
+            comparison: CRITERION_COMPARISONS.EQUAL,
+          },
+          isTerminated: {
+            data: true,
+            comparison: CRITERION_COMPARISONS.EQUAL,
+          },
+        },
+      },
+    ];
+
+    const expectedCreatedQuest = {
+      name: nameInput,
+      rewardType: null,
+      rewardId: null,
+      organizationId,
+      eligibilityRequirements: [],
+      successRequirements: [
+        {
+          requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
+          comparison: REQUIREMENT_COMPARISONS.ALL,
+          data: {
+            campaignId: {
+              data: createdCampaign.id,
+              comparison: CRITERION_COMPARISONS.EQUAL,
+            },
+            status: {
+              data: CampaignParticipationStatuses.SHARED,
+              comparison: CRITERION_COMPARISONS.EQUAL,
+            },
+          },
+        },
+        ...expectedModules,
+      ],
+      description,
+      illustration,
+    };
+
+    // then
+    const [createdQuest] = await knex('quests')
+      .join('combined_courses', 'combined_courses.questId', 'quests.id')
+      .where('combined_courses.organizationId', organizationId)
+      .orderBy('quests.id');
+
+    // Quest
+    expect(createdQuest.combinedCourseBlueprintId).to.equal(combinedCourseBlueprintId);
+    expect(createdQuest.code).not.to.be.null;
+    expect(createdQuest.name).to.equal(nameInput);
+    expect(createdQuest.successRequirements).to.deep.equal(createdQuest.successRequirements);
+    expect(createdQuest.description).to.equal(expectedCreatedQuest.description);
+    expect(createdQuest.illustration).to.equal(expectedCreatedQuest.illustration);
+
+    //Campaign 1
+    expect(createdCampaign.name).to.equal(targetProfile.internalName);
+    expect(createdCampaign.title).to.equal(targetProfile.name);
+    expect(createdCampaign.customResultPageButtonUrl.includes('/chargement')).false;
+    expect(createdCampaign.customResultPageButtonText).to.equal('Continuer');
+  });
+});

--- a/api/tests/quest/integration/domain/usecases/find-by-organization-id_test.js
+++ b/api/tests/quest/integration/domain/usecases/find-by-organization-id_test.js
@@ -1,0 +1,18 @@
+import { CombinedCourseBlueprint } from '../../../../../src/quest/domain/models/CombinedCourseBlueprint.js';
+import { usecases } from '../../../../../src/quest/domain/usecases/index.js';
+import { databaseBuilder, expect } from '../../../../test-helper.js';
+
+describe('Integration | Quest | Domain | UseCases | find-by-organization-id', function () {
+  it('should return combined course blueprints array if at least a result is found', async function () {
+    //given
+    const { organizationId } = databaseBuilder.factory.buildCombinedCourseBlueprintShare();
+    await databaseBuilder.commit();
+
+    //when
+    const results = await usecases.findByOrganizationId({ organizationId });
+
+    //then
+    expect(results).lengthOf(1);
+    expect(results[0]).to.be.instanceOf(CombinedCourseBlueprint);
+  });
+});

--- a/api/tests/quest/integration/infrastructure/repositories/combined-course-blueprint-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/combined-course-blueprint-repository_test.js
@@ -155,4 +155,49 @@ describe('Quest | Integration | Repository | combined-course-blueprint', functio
       expect(result).null;
     });
   });
+  describe('#findByOrganizationId', function () {
+    it('should return blueprint if the given organization has at least one combined course blueprint share', async function () {
+      //given
+      const blueprintShare = databaseBuilder.factory.buildCombinedCourseBlueprintShare();
+      const blueprintShare2 = databaseBuilder.factory.buildCombinedCourseBlueprintShare({
+        organizationId: blueprintShare.organizationId,
+      });
+
+      databaseBuilder.factory.buildCombinedCourseBlueprintShare();
+
+      await databaseBuilder.commit();
+
+      const expectedCombinedCourseBlueprint = await combinedCourseBluePrintRepository.findById({
+        id: blueprintShare.combinedCourseBlueprintId,
+      });
+
+      const expectedCombinedCourseBlueprint2 = await combinedCourseBluePrintRepository.findById({
+        id: blueprintShare2.combinedCourseBlueprintId,
+      });
+
+      //when
+      const result = await combinedCourseBluePrintRepository.findByOrganizationId({
+        organizationId: blueprintShare.organizationId,
+      });
+
+      //then
+      expect(result.length).to.equal(2);
+      expect(result[0]).to.deep.equal(expectedCombinedCourseBlueprint);
+      expect(result[1]).to.deep.equal(expectedCombinedCourseBlueprint2);
+    });
+    it('should return an empty array when the organization is not found', async function () {
+      const result = await combinedCourseBluePrintRepository.findByOrganizationId({ organizationId: 123 });
+
+      expect(result.length).to.equal(0);
+    });
+
+    it('should return an empty array when the organization has no shares', async function () {
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      await databaseBuilder.commit();
+
+      const result = await combinedCourseBluePrintRepository.findByOrganizationId({ organizationId });
+
+      expect(result.length).to.equal(0);
+    });
+  });
 });

--- a/api/tests/quest/integration/infrastructure/repositories/quest-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/quest-repository_test.js
@@ -5,7 +5,7 @@ import { databaseBuilder, expect, knex, sinon } from '../../../../test-helper.js
 
 describe('Quest | Integration | Repository | quest', function () {
   describe('#saveInBatch', function () {
-    it('should save quests', async function () {
+    it('should save quests and return their ids', async function () {
       const { id: rewardId } = databaseBuilder.factory.buildAttestation();
       const questInDatabase = databaseBuilder.factory.buildQuest({
         createdAt: new Date('2020-01-01T00:00:00Z'),
@@ -30,7 +30,7 @@ describe('Quest | Integration | Repository | quest', function () {
       });
 
       // when
-      await questRepository.saveInBatch({
+      const result = await questRepository.saveInBatch({
         quests: [expectedNewQuest, new Quest(questInDatabase)],
       });
 
@@ -53,6 +53,7 @@ describe('Quest | Integration | Repository | quest', function () {
           }),
         ),
       );
+      expect(result[0]).to.equal(thirdQuest.id);
     });
   });
 

--- a/api/tests/team/acceptance/application/prescriber-informations.controller.test.js
+++ b/api/tests/team/acceptance/application/prescriber-informations.controller.test.js
@@ -71,6 +71,11 @@ describe('Acceptance | Team | Application | Controller | prescriber-informations
                 related: `/api/organizations/${organization.id}/combined-courses`,
               },
             },
+            'combined-course-blueprints': {
+              links: {
+                related: `/api/organizations/${organization.id}/combined-course-blueprints`,
+              },
+            },
             divisions: {
               links: {
                 related: `/api/organizations/${organization.id}/divisions`,

--- a/api/tests/team/unit/infrastructure/serializers/jsonapi/prescriber-serializer_test.js
+++ b/api/tests/team/unit/infrastructure/serializers/jsonapi/prescriber-serializer_test.js
@@ -319,6 +319,11 @@ function createExpectedPrescriberSerializedWithOneMoreField({
               related: `/api/organizations/${organization.id}/combined-courses`,
             },
           },
+          'combined-course-blueprints': {
+            links: {
+              related: `/api/organizations/${organization.id}/combined-course-blueprints`,
+            },
+          },
         },
       },
       {
@@ -436,6 +441,11 @@ function createExpectedPrescriberSerialized({ prescriber, membership, userOrgaSe
           'combined-courses': {
             links: {
               related: `/api/organizations/${organization.id}/combined-courses`,
+            },
+          },
+          'combined-course-blueprints': {
+            links: {
+              related: `/api/organizations/${organization.id}/combined-course-blueprints`,
             },
           },
         },

--- a/orga/app/adapters/campaign.js
+++ b/orga/app/adapters/campaign.js
@@ -26,4 +26,18 @@ export default class CampaignAdapter extends ApplicationAdapter {
     const url = this.buildURL('campaign', model.id) + '/archive';
     return this.ajax(url, 'DELETE');
   }
+  createRecord(store, type, snapshot) {
+    const payload = this.serialize(snapshot);
+
+    if (payload.data.attributes.type === 'COMBINED_COURSE') {
+      payload.data.relationships['combined-course-blueprint'] = { data: { id: snapshot.record.targetProfile.id } };
+      const url = `${this.host}/${this.namespace}/combined-courses`;
+
+      return this.ajax(url, 'POST', { data: payload });
+    } else {
+      const url = `${this.host}/${this.namespace}/campaigns`;
+
+      return this.ajax(url, 'POST', { data: payload });
+    }
+  }
 }

--- a/orga/app/controllers/authenticated/campaigns/new.js
+++ b/orga/app/controllers/authenticated/campaigns/new.js
@@ -17,7 +17,6 @@ export default class NewController extends Controller {
   async createCampaign() {
     this.notifications.clearAll();
     this.errors = null;
-
     try {
       await this.model.campaign.save();
     } catch (errorResponse) {
@@ -30,7 +29,11 @@ export default class NewController extends Controller {
     }
 
     if (!this.errors) {
-      this.router.transitionTo('authenticated.campaigns.campaign.settings', this.model.campaign.id);
+      if (this.model.campaign.type === 'COMBINED_COURSE') {
+        this.router.transitionTo('authenticated.combined-course', this.model.campaign.id);
+      } else {
+        this.router.transitionTo('authenticated.campaigns.campaign.settings', this.model.campaign.id);
+      }
     }
   }
 

--- a/orga/app/models/campaign.js
+++ b/orga/app/models/campaign.js
@@ -35,6 +35,7 @@ export default class Campaign extends Model {
 
   @belongsTo('organization', { async: true, inverse: 'campaigns' }) organization;
   @belongsTo('target-profile', { async: true, inverse: null }) targetProfile;
+
   @belongsTo('campaign-collective-result', { async: true, inverse: null }) campaignCollectiveResult;
   @belongsTo('campaign-result-levels-per-tubes-and-competence', { async: true, inverse: null })
   campaignResultLevelsPerTubesAndCompetence;

--- a/orga/app/models/combined-course-blueprint.js
+++ b/orga/app/models/combined-course-blueprint.js
@@ -1,0 +1,5 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class CombinedCourseBlueprint extends Model {
+  @attr('string') name;
+}

--- a/orga/app/models/organization.js
+++ b/orga/app/models/organization.js
@@ -15,6 +15,7 @@ export default class Organization extends Model {
   @hasMany('combined-course', { async: true, inverse: null }) combinedCourses;
   @hasMany('campaign', { async: true, inverse: 'organization' }) campaigns;
   @hasMany('target-profile', { async: true, inverse: null }) targetProfiles;
+  @hasMany('combined-course-blueprint', { async: true, inverse: null }) combinedCourseBlueprints;
   @hasMany('organization-invitation', { async: true, inverse: 'organization' }) organizationInvitations;
   @hasMany('group', { async: true, inverse: null }) groups;
   @hasMany('division', { async: true, inverse: null }) divisions;

--- a/orga/app/routes/authenticated/campaigns/new.js
+++ b/orga/app/routes/authenticated/campaigns/new.js
@@ -24,6 +24,7 @@ export default class NewRoute extends Route {
   async model(params) {
     const organization = this.currentUser.organization;
     await organization.targetProfiles;
+    await organization.combinedCourseBlueprints;
     const membersSortedByFullName = await this.store.findAll('member-identity', {
       adapterOptions: { organizationId: organization.id },
     });
@@ -63,7 +64,8 @@ export default class NewRoute extends Route {
         ownerId: this.currentUser.prescriber.id,
         ...(campaignAttributes ?? campaignAttributes),
       }),
-      targetProfiles: organization.targetProfiles,
+      targetProfiles: organization.targetProfiles ?? undefined,
+      combinedCourseBlueprints: organization.combinedCourseBlueprints ?? undefined,
       membersSortedByFullName,
     });
   }

--- a/orga/app/templates/authenticated/campaigns/new.gjs
+++ b/orga/app/templates/authenticated/campaigns/new.gjs
@@ -16,5 +16,6 @@ import PageTitle from 'pix-orga/components/ui/page-title';
     @onSubmit={{@controller.createCampaign}}
     @onCancel={{@controller.cancel}}
     @membersSortedByFullName={{@model.membersSortedByFullName}}
+    @combinedCourseBlueprints={{@model.combinedCourseBlueprints}}
   />
 </template>

--- a/orga/mirage/config.js
+++ b/orga/mirage/config.js
@@ -375,6 +375,10 @@ function routes() {
     return schema.targetProfiles.all();
   });
 
+  this.get('/organizations/:id/combined-course-blueprints', (schema) => {
+    return schema.combinedCourseBlueprints.all();
+  });
+
   this.post('/campaigns', (schema, request) => {
     const body = JSON.parse(request.requestBody);
 
@@ -505,6 +509,17 @@ function routes() {
     };
   });
 
+  this.post('/combined-courses', (schema, request) => {
+    const body = JSON.parse(request.requestBody);
+
+    const campaign = {
+      ...body.data.attributes,
+      customLandingPageText: body.data.attributes['custom-landing-page-text'],
+      externalIdLabel: body.data.attributes['id-pix-label'],
+    };
+    const combinedCourseBlueprintId = body.data.relationships['combined-course-blueprint'].data.id;
+    return schema.campaigns.create({ ...campaign, combinedCourseBlueprintId });
+  });
   this.get('feature-toggles', (schema) => {
     return schema.featureToggles.findOrCreateBy({ id: 0 });
   });

--- a/orga/mirage/factories/combined-course-blueprint.js
+++ b/orga/mirage/factories/combined-course-blueprint.js
@@ -1,0 +1,8 @@
+import { faker } from '@faker-js/faker';
+import { Factory } from 'miragejs';
+
+export default Factory.extend({
+  name() {
+    return faker.lorem.sentence();
+  },
+});

--- a/orga/mirage/serializers/organization.js
+++ b/orga/mirage/serializers/organization.js
@@ -14,6 +14,9 @@ export default ApplicationSerializer.extend({
       targetProfiles: {
         related: `/api/organizations/${organization.id}/target-profiles`,
       },
+      combinedCourseBlueprints: {
+        related: `/api/organizations/${organization.id}/combined-course-blueprints`,
+      },
       memberships: {
         related: `/api/organizations/${organization.id}/memberships`,
       },

--- a/orga/tests/unit/controllers/authenticated/campaigns/new-test.js
+++ b/orga/tests/unit/controllers/authenticated/campaigns/new-test.js
@@ -63,4 +63,27 @@ module('Unit | Controller | authenticated/campaigns/new', function (hooks) {
       assert.true(controller.router.transitionTo.calledWith('authenticated.campaigns.campaign.settings', 1));
     });
   });
+  module('#action createCampaign when creating a combined course', function () {
+    test('it should call transitionTo with appropriate arguments', async function (assert) {
+      // given
+      controller.router = { transitionTo: sinon.stub() };
+      controller.notifications = {
+        clearAll: sinon.stub(),
+      };
+      controller.model = {
+        campaign: {
+          id: 1,
+          save: sinon.stub().resolves(),
+          setProperties: sinon.stub(),
+          type: 'COMBINED_COURSE',
+        },
+      };
+
+      // when
+      await controller.createCampaign({ name: 'ma campagne' });
+
+      // then
+      assert.true(controller.router.transitionTo.calledWith('authenticated.combined-course', 1));
+    });
+  });
 });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -765,6 +765,8 @@
         "create": "Create a campaign",
         "delete": "Delete"
       },
+      "combined-course-blueprints-label": "Select a combined course blueprint",
+      "combined-course-blueprints-list-label": "Select a combined course blueprint",
       "copy-of": "Copy of",
       "external-id-label": {
         "label": "external user ID label",
@@ -806,6 +808,7 @@
       "purpose": {
         "assessment": "Assess participants",
         "assessment-info": "An assessment campaign tests participants on specific topics.",
+        "combined-course": "Create a combined course",
         "exam": "Exam mode [beta]",
         "exam-info": "A ‘exam mode’ campaign enables participants to be tested on specific topics, without taking their user profile into account or having any impact on it. The campaign's questions are personalised for each participant, depending on how far they have progressed along the route.",
         "label": "What is the purpose of your campaign?",
@@ -1080,6 +1083,7 @@
         }
       }
     },
+    "combined-course-blueprints-list-label": "Sélectionnez un schéma de parcours",
     "combined-courses": {
       "empty-state": "No learning course available at the moment.",
       "table": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -753,6 +753,8 @@
         "create": "Créer la campagne",
         "delete": "Effacer"
       },
+      "combined-course-blueprints-label": "Sélectionner un schéma de parcours",
+      "combined-course-blueprints-list-label": "Sélectionnez un schéma de parcours",
       "copy-of": "Copie de",
       "external-id-label": {
         "label": "Libellé de l’identifiant",
@@ -794,6 +796,7 @@
       "purpose": {
         "assessment": "Évaluer les participants",
         "assessment-info": "Une campagne d’évaluation permet de tester les participants sur des sujets précis.",
+        "combined-course": "Créer un parcours combiné",
         "exam": "Mode interro [bêta]",
         "exam-info": "Une campagne de type “mode interro” permet de tester les participants sur des sujets précis, sans prendre en compte le profil utilisateur, et sans impacter celui-ci. Les épreuves proposées sont personnalisées pour chaque participant selon son avancement dans le parcours.",
         "label": "Quel est l'objectif de votre campagne ?",

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -752,6 +752,8 @@
         "create": "De campagne maken",
         "delete": "Wissen"
       },
+      "combined-course-blueprints-label": "Selecteer een gecombineerd cursusontwerp",
+      "combined-course-blueprints-list-label": "Selecteer een gecombineerd cursusontwerp",
       "copy-of": "Kopie van",
       "external-id-label": {
         "label": "Type externe user-ID",
@@ -793,6 +795,7 @@
       "purpose": {
         "assessment": "Deelnemers evalueren",
         "assessment-info": "Een beoordelingscampagne stelt deelnemers in staat om getest te worden op specifieke onderwerpen.",
+        "combined-course": "Maak een gecombineerde cursus",
         "exam": "Vraagmodus [beta]",
         "exam-info": "Met een campagne in de “quizmodus” kunnen deelnemers worden getest op specifieke onderwerpen, zonder rekening te houden met hun gebruikersprofiel of er invloed op te hebben. De aangeboden tests zijn gepersonaliseerd voor elke deelnemer, afhankelijk van hoe ver ze gevorderd zijn in het traject.",
         "label": "Wat is het doel van je campagne?",


### PR DESCRIPTION
## ❄️ Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->
Les prescripteurs ne peuvent pas créer de parcours combiné.
Cela oblige donc les admin (ie une équipe interne Pix) à créer et administrer ces parcours combinés pour eux.

## 🛷 Proposition

A l'image de ce qui existe pour la création de campagne d'évaluation ou de collecte de profil, on ajoute la possible de créer un parcours combiné depuis Pix Orga.

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## ☃️ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🧑‍🎄 Pour tester
Se connecter sur une organisation rattachée à un schéma de parcours combiné
Aller dans “Campagnes” → créer une campagne
Sélectionner l’objectif parcours apprenant
-> Le select “Que souhaitez-vous tester ?” doit contenir des options avec les blueprint partagés à l’organisation

→ On ne pose pas la question : de l’envoi multiple, de l’identifiant externe, du titre ni du texte de page d’accueil
-> En BDD, le combined_course est bien créé avec les infos attendues / sur PixOrga, le parcours apprenant remonte bien dans l’onglet “Parcours apprenant” des campagnes de l’organisation