### PR TITLE
[FEATURE] Ne pas afficher le formulaire d'inscription si l'utilisateur se connecte sans invitation (PIX-21275)

### DIFF
--- a/orga/app/controllers/authentication/oidc/login.js
+++ b/orga/app/controllers/authentication/oidc/login.js
@@ -61,4 +61,10 @@ export default class OidcLoginController extends Controller {
   goToOidcProviderLoginPage() {
     this.oidcIdentityProviders.isOidcProviderAuthenticationInProgress = true;
   }
+
+  @action
+  goBack() {
+    oidcUserAuthenticationStorage.remove();
+    return this.router.transitionTo('authentication.login');
+  }
 }

--- a/orga/app/routes/authentication/oidc/flow.js
+++ b/orga/app/routes/authentication/oidc/flow.js
@@ -13,6 +13,7 @@ export default class LoginOidcRoute extends Route {
   @service oidcIdentityProviders;
   @service router;
   @service session;
+  @service joinInvitation;
 
   async beforeModel(transition) {
     const queryParams = transition.to.queryParams;
@@ -55,7 +56,11 @@ export default class LoginOidcRoute extends Route {
     const { identityProviderSlug, shouldCreateUserAccount } = model;
 
     if (shouldCreateUserAccount) {
-      this.router.transitionTo('authentication.oidc.signup', identityProviderSlug);
+      if (this.joinInvitation.invitation) {
+        this.router.transitionTo('authentication.oidc.signup', identityProviderSlug);
+      } else {
+        this.router.transitionTo('authentication.oidc.login', identityProviderSlug);
+      }
     }
   }
 

--- a/orga/app/styles/pages/sign-form.scss
+++ b/orga/app/styles/pages/sign-form.scss
@@ -4,3 +4,8 @@
   gap: var(--pix-spacing-4x);
   padding-top: var(--pix-spacing-6x);
 }
+
+.back-button {
+  align-self: flex-end;
+  width: fit-content;
+}

--- a/orga/app/templates/authentication/oidc/login.gjs
+++ b/orga/app/templates/authentication/oidc/login.gjs
@@ -1,3 +1,4 @@
+import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
 import t from 'ember-intl/helpers/t';
 import pageTitle from 'ember-page-title/helpers/page-title';
@@ -10,6 +11,16 @@ import InvitationBanner from 'pix-orga/components/banner/invitation-banner';
 
   <AuthenticationLayout class="signin-page-layout">
     <:header>
+      {{#unless @controller.currentInvitation}}
+        <PixButton
+          class="back-button"
+          @variant="secondary"
+          @triggerAction={{@controller.goBack}}
+          @iconBefore="arrowLeft"
+        >
+          {{t "common.actions.back"}}
+        </PixButton>
+      {{/unless}}
     </:header>
 
     <:content>
@@ -33,7 +44,6 @@ import InvitationBanner from 'pix-orga/components/banner/invitation-banner';
           {{t "pages.oidc.login.signup-button"}}
         </PixButtonLink>
       {{/if}}
-
     </:content>
   </AuthenticationLayout>
 </template>

--- a/orga/app/templates/authentication/oidc/login.gjs
+++ b/orga/app/templates/authentication/oidc/login.gjs
@@ -24,9 +24,15 @@ import InvitationBanner from 'pix-orga/components/banner/invitation-banner';
 
       <LoginForm @onSubmit={{@controller.redirectToAssociationConfirmation}} />
 
-      <PixButtonLink @variant="secondary" @route="authentication.oidc.signup" @model={{@model.identity_provider_slug}}>
-        {{t "pages.oidc.login.signup-button"}}
-      </PixButtonLink>
+      {{#if @controller.currentInvitation}}
+        <PixButtonLink
+          @variant="secondary"
+          @route="authentication.oidc.signup"
+          @model={{@model.identity_provider_slug}}
+        >
+          {{t "pages.oidc.login.signup-button"}}
+        </PixButtonLink>
+      {{/if}}
 
     </:content>
   </AuthenticationLayout>

--- a/orga/tests/integration/templates/authentication/oidc/login-test.gjs
+++ b/orga/tests/integration/templates/authentication/oidc/login-test.gjs
@@ -8,45 +8,77 @@ import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 module('Integration | Template | Authentication | OIDC | login', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('it displays the login template with invitation banner and form component', async function (assert) {
-    // given
-    const controller = {
-      currentInvitation: {
-        invitationId: 1,
-        code: 'ABC123',
-        organizationName: 'Organisation OIDC',
-      },
-    };
+  const model = {
+    identity_provider_slug: 'oidc-test-slug',
+  };
 
-    // when
-    const screen = await render(<template><Login @controller={{controller}} /></template>);
+  module('When user is invited', function () {
+    test('it displays the login template with invitation banner, login form component and link to signup form', async function (assert) {
+      // given
+      const controller = {
+        currentInvitation: {
+          invitationId: 1,
+          code: 'ABC123',
+          organizationName: 'Test Organization',
+        },
+      };
 
-    // then
-    assert
-      .dom(
-        screen.getByText(
-          t('pages.login.join-invitation', {
-            organizationName: controller.currentInvitation.organizationName,
+      // when
+      const screen = await render(<template><Login @controller={{controller}} @model={{model}} /></template>);
+
+      // then
+      assert
+        .dom(
+          screen.getByText(
+            t('pages.login.join-invitation', {
+              organizationName: controller.currentInvitation.organizationName,
+            }),
+          ),
+        )
+        .exists();
+      assert
+        .dom(
+          screen.getByRole('heading', {
+            name: `${t('pages.oidc.login.title')}`,
           }),
-        ),
-      )
-      .exists();
-    assert
-      .dom(
-        screen.getByRole('heading', {
-          name: `${t('pages.oidc.login.title')}`,
-        }),
-      )
-      .exists();
-    assert
-      .dom(
-        screen.getByRole('heading', {
-          name: `${t('pages.oidc.login.sub-title')}`,
-        }),
-      )
-      .exists();
-    assert.dom(screen.getByRole('textbox', { name: t('pages.login-form.email.label') })).exists();
-    assert.dom(screen.getByLabelText(t('pages.login-form.password'))).exists();
-    assert.dom(screen.getByRole('button', { name: t('pages.login-form.login') })).exists();
+        )
+        .exists();
+      assert
+        .dom(
+          screen.getByRole('heading', {
+            name: `${t('pages.oidc.login.sub-title')}`,
+          }),
+        )
+        .exists();
+      assert.dom(screen.getByRole('textbox', { name: t('pages.login-form.email.label') })).exists();
+      assert.dom(screen.getByLabelText(t('pages.login-form.password'))).exists();
+      assert.dom(screen.getByRole('button', { name: t('pages.login-form.login') })).exists();
+      assert.dom(screen.getByRole('link', { name: t('pages.oidc.login.signup-button') })).exists();
+    });
+  });
+
+  module('When user is not invited', function () {
+    test('it displays the login template with login form component but no invitation banner and no link to signup form', async function (assert) {
+      // when
+      const screen = await render(<template><Login />@model={{model}}</template>);
+
+      // then
+      assert
+        .dom(
+          screen.getByRole('heading', {
+            name: `${t('pages.oidc.login.title')}`,
+          }),
+        )
+        .exists();
+      assert
+        .dom(
+          screen.getByRole('heading', {
+            name: `${t('pages.oidc.login.sub-title')}`,
+          }),
+        )
+        .exists();
+      assert.dom('.invitation-banner').doesNotExist();
+      assert.dom(screen.queryByRole('link', { name: t('pages.oidc.login.signup-button') })).doesNotExist();
+    });
   });
 });

--- a/orga/tests/integration/templates/authentication/oidc/login-test.gjs
+++ b/orga/tests/integration/templates/authentication/oidc/login-test.gjs
@@ -13,7 +13,7 @@ module('Integration | Template | Authentication | OIDC | login', function (hooks
   };
 
   module('When user is invited', function () {
-    test('it displays the login template with invitation banner, login form component and link to signup form', async function (assert) {
+    test('it displays the login template with an invitation banner, a login form component and a link to signup form', async function (assert) {
       // given
       const controller = {
         currentInvitation: {
@@ -58,7 +58,7 @@ module('Integration | Template | Authentication | OIDC | login', function (hooks
   });
 
   module('When user is not invited', function () {
-    test('it displays the login template with login form component but no invitation banner and no link to signup form', async function (assert) {
+    test('it displays the login template with a login form component, no invitation banner, and a link to authentication/login instead of the signup form link', async function (assert) {
       // when
       const screen = await render(<template><Login />@model={{model}}</template>);
 
@@ -79,6 +79,7 @@ module('Integration | Template | Authentication | OIDC | login', function (hooks
         .exists();
       assert.dom('.invitation-banner').doesNotExist();
       assert.dom(screen.queryByRole('link', { name: t('pages.oidc.login.signup-button') })).doesNotExist();
+      assert.dom(screen.queryByRole('button', { name: t('common.actions.back') })).exists();
     });
   });
 });


### PR DESCRIPTION
## ❄️ Problème

Quand un utilisateur tente de se connecter via SSO (sans invitation) et qu’on ne trouve aucun compte Pix associé (via son sub), actuellement, on propose directement de créer un compte ou via le bouton “J’ai déjà un compte Pix….” pour associer le SSO à un compte Pix (login/mdp) existant.
Or on doit proposer l’inscription uniquement si l’utilisateur a une invitation valide.

## 🛷 Proposition

1. Après sa connexion SSO (sans invitation) et son compte non trouvé via le sub, on affiche directement la page d’association :
<img width="1024" height="538" alt="image" src="https://github.com/user-attachments/assets/60c82716-5453-4984-bb11-331866022e78" />

2.  le lien “Je n’ai pas de compte…” n’est pas à afficher ici. Si l’utilisateur n’a pas d’invitation on ne veut pas afficher ce bouton. [On peut remplacer ce bouton par un bouton “Retour” pour lui permettre de revenir sur la page de login.]

## ☃️ Remarques

Faut-il tester le bouton "Retour" ?
Si oui faut-il / comment vérifier que le sessionStorage est vide ?

## 🧑‍🎄 Pour tester

Les tests sont à faire en local :

1. Sans invitation, connectez-vous via un SSO sur Pix Orga (le sub ne doit pas être connu chez Pix)
3. Vérifiez que le retour du fournisseur d'identité se fait bien sur `https://orga.dev.pix.fr/connexion/:identity_provider_slug/login` et non sur `https://orga.dev.pix.fr/connexion//:identity_provider_slug/signup`
Ouvrez la console et vérifiez la présence en session de l'oidcUserAuthentication
4. Vérifiez que le bouton "Je n'ai pas de compte, je m'inscris avec mon organisation" n'apparaît pas.
5. Vérifiez la présence du bouton "Retour"
6. Cliquez sur le bouton "Retour" et vérifiez que vous êtes redirigé vers `https://orga.dev.pix.fr/connexion/login` et que l'`oidcUserAuthentication` a été effacé du session storage
7. [NON REGRESSION] Refaites le parcours avec une invitation. 
- Vérifiez que vous êtes redirigé vers  `https://orga.dev.pix.fr/connexion//:identity_provider_slug/signup` après l'authentification par le fournisseur d'identité
- Vérifiez que le bouton "J'ai déjà un compte Pix, je m'inscris avec mon organisation" est présent et fonctionnel.
