### PR TITLE
[FEATURE] Modifier le wording des champs pour le QROCM (PIX-21200)

### DIFF
--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1747,7 +1747,7 @@
         "direction": "Select the answer that you think is most accurate."
       },
       "qrocm": {
-        "direction": "Fill in the {count, plural, =1 {blank} other {blanks}}."
+        "direction": "Fill in the {count, plural, =1 {field} other {fields}}."
       },
       "recap": {
         "backToModuleDetails": "Quit",

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1743,7 +1743,7 @@
         "direction": "Seleccione la respuesta que le parezca más adecuada."
       },
       "qrocm": {
-        "direction": "Rellena {count, plural, =1 {le champ vide} other {les champs vides}}."
+        "direction": "Rellena {count, plural, =1 {el campo} other {los campos}}."
       },
       "recap": {
         "backToModuleDetails": "Deje de",

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1736,8 +1736,8 @@
         "direction": "Seleccione una sola respuesta."
       },
       "qcuDeclarative": {
-        "complementaryInstruction": "Seleccione una sola respuesta.",
-        "direction": "There is no right or wrong answer."
+        "complementaryInstruction": "No hay respuestas correctas o incorrectas.",
+        "direction": "Seleccione una sola respuesta."
       },
       "qcuDiscovery": {
         "direction": "Seleccione la respuesta que le parezca más adecuada."

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1755,7 +1755,7 @@
         "direction": "Sélectionnez la réponse qui vous semble la plus juste."
       },
       "qrocm": {
-        "direction": "Remplissez {count, plural, =1 {le champ vide} other {les champs vides}}."
+        "direction": "Remplissez {count, plural, =1 {le champ} other {les champs}}."
       },
       "recap": {
         "backToModuleDetails": "Quitter",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1741,7 +1741,7 @@
       },
       "qcuDeclarative": {
         "complementaryInstruction": "Kies één antwoord",
-        "direction": "There is no right or wrong answer."
+        "direction": "Selecteer één antwoord."
       },
       "qcuDiscovery": {
         "direction": "Selecteer het antwoord dat u het meest juist lijkt."

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1747,7 +1747,7 @@
         "direction": "Selecteer het antwoord dat u het meest juist lijkt."
       },
       "qrocm": {
-        "direction": "Vul de lege velden in."
+        "direction": "Vul {count, plural, =1 {het veld} other {de velden}} in."
       },
       "recap": {
         "backToModuleDetails": "Stoppen met",


### PR DESCRIPTION
## ❄️ Problème

y'a pas de problème, que des solutions :)

## 🛷 Proposition

Modifier le wording, tout simplement.

## ☃️ Remarques

J'ai spot des trads pas faites ailleurs, j'ai fixé ça

## 🧑‍🎄 Pour tester

- Voir le wording sur un qrocm
- Lancez vos modules en espagnol et en néerlandais pour check un peu le squelette modulix. Si vous trouvez un truc, je le modifierais ici.

<img width="866" height="365" alt="Capture d’écran 2026-01-28 à 15 50 24" src="https://github.com/user-attachments/assets/89d2f9c5-0050-4f72-b8d7-89758be8f528" />
<img width="875" height="331" alt="Capture d’écran 2026-01-28 à 15 51 13" src="https://github.com/user-attachments/assets/53ffcc74-36a2-4f06-8a6b-ee86305793f9" />
