### PR TITLE
[FEATURE] Pouvoir désactiver certaines locales dans les applications Frontend (PIX-19702)

### DIFF
--- a/admin/app/routes/application.js
+++ b/admin/app/routes/application.js
@@ -10,11 +10,12 @@ export default class ApplicationRoute extends Route {
   @service intl;
 
   async beforeModel(transition) {
+    await this.featureToggles.load();
+
     const queryParams = transition?.to?.queryParams;
     this.intl.setFormats(formats);
     this.locale.setBestLocale({ queryParams });
     await this.session.setup();
-    await this.featureToggles.load();
     await this.currentUser.load();
   }
 }

--- a/admin/app/services/locale.js
+++ b/admin/app/services/locale.js
@@ -87,15 +87,6 @@ export default class LocaleService extends Service {
       .sort((a, b) => a.label.localeCompare(b.label));
   }
 
-  isSupportedLocale(locale) {
-    try {
-      const localeCanonicalName = Intl.getCanonicalLocales(locale)?.[0];
-      return this.availableLocales.some((availableLocale) => localeCanonicalName == availableLocale);
-    } catch {
-      return false;
-    }
-  }
-
   setCurrentLocale(locale) {
     const nearestLocale = this.#getNearestSupportedLocale(locale);
     this.#setCookieLocale(nearestLocale);

--- a/admin/tests/unit/services/locale-test.js
+++ b/admin/tests/unit/services/locale-test.js
@@ -115,60 +115,6 @@ module('Unit | Services | locale', function (hooks) {
     });
   });
 
-  module('isSupportedLocale', function () {
-    module('when locale is supported', function () {
-      test('returns true', function (assert) {
-        // given
-        const locale = 'nl-BE';
-
-        // when
-        const result = localeService.isSupportedLocale(locale);
-
-        // then
-        assert.true(result);
-      });
-    });
-
-    module('when locale is supported but not given in canonical form', function () {
-      test('returns true', function (assert) {
-        // given
-        const locale = 'nl-be';
-
-        // when
-        const result = localeService.isSupportedLocale(locale);
-
-        // then
-        assert.true(result);
-      });
-    });
-
-    module('when locale is valid but not supported', function () {
-      test('returns false', function (assert) {
-        // given
-        const locale = 'ko';
-
-        // when
-        const result = localeService.isSupportedLocale(locale);
-
-        // then
-        assert.false(result);
-      });
-    });
-
-    module('when locale is invalid', function () {
-      test('returns false', function (assert) {
-        // given
-        const locale = 'invalid_locale_in_bad_format';
-
-        // when
-        const result = localeService.isSupportedLocale(locale);
-
-        // then
-        assert.false(result);
-      });
-    });
-  });
-
   module('setCurrentLocale', function () {
     test('set app locale in the cookies', function (assert) {
       // given

--- a/admin/tests/unit/services/locale-test.js
+++ b/admin/tests/unit/services/locale-test.js
@@ -22,7 +22,7 @@ module('Unit | Services | locale', function (hooks) {
 
   hooks.beforeEach(function () {
     localeService = this.owner.lookup('service:locale');
-    sinon.stub(localeService, 'supportedLocales').value(['en', 'es', 'fr', 'nl', 'fr-BE', 'fr-FR', 'nl-BE']);
+    sinon.stub(localeService, 'availableLocales').value(['en', 'es', 'fr', 'nl', 'fr-BE', 'fr-FR', 'nl-BE']);
 
     currentDomainService = this.owner.lookup('service:currentDomain');
     sinon.stub(currentDomainService, 'getExtension');

--- a/api/config/feature-toggles-config.js
+++ b/api/config/feature-toggles-config.js
@@ -81,4 +81,10 @@ export default {
     devDefaultValues: { test: false, reviewApp: true },
     tags: ['frontend', 'team-devcomp', 'modulix', 'pix-app'],
   },
+  disabledLocalesInFrontend: {
+    type: 'array',
+    description: 'Disable the specified locales',
+    defaultValue: [],
+    tags: ['team-acces', 'i18n', 'frontend'],
+  },
 };

--- a/api/src/shared/domain/services/locale-service.js
+++ b/api/src/shared/domain/services/locale-service.js
@@ -1,8 +1,6 @@
 const ENGLISH_SPOKEN = 'en';
 const FRENCH_FRANCE = 'fr-fr';
 const FRENCH_SPOKEN = 'fr';
-const DUTCH_SPOKEN = 'nl';
-const SPANISH_SPOKEN = 'es';
 const FRENCH_FRANCE_LOCALE = 'fr-FR';
 
 const DEFAULT_CHALLENGE_LOCALE = 'fr-fr';
@@ -131,7 +129,6 @@ function getNearestChallengeLocale(locale) {
 
 export {
   coerceLanguage,
-  DUTCH_SPOKEN,
   ENGLISH_SPOKEN,
   FRENCH_FRANCE,
   FRENCH_SPOKEN,
@@ -144,5 +141,4 @@ export {
   getSupportedLanguages,
   getSupportedLocales,
   isFranceLocale,
-  SPANISH_SPOKEN,
 };

--- a/api/src/shared/infrastructure/feature-toggles/feature-toggles-client.js
+++ b/api/src/shared/infrastructure/feature-toggles/feature-toggles-client.js
@@ -4,7 +4,7 @@ const ConfigSchema = Joi.object().pattern(
   Joi.string(),
   Joi.object({
     description: Joi.string().required(),
-    type: Joi.string().valid('boolean', 'number', 'string').required(),
+    type: Joi.string().valid('boolean', 'number', 'string', 'array').required(),
     defaultValue: Joi.any().required(),
     devDefaultValues: Joi.object({
       test: Joi.any().optional(),
@@ -86,6 +86,7 @@ export class FeatureTogglesClient {
     if (!featureToggle) {
       throw new FeatureToggleNotFoundError(key);
     }
+
     await this.storage.save({ key, value });
   }
 

--- a/api/src/shared/infrastructure/feature-toggles/feature-toggles-script.js
+++ b/api/src/shared/infrastructure/feature-toggles/feature-toggles-script.js
@@ -51,6 +51,8 @@ export class FeatureToggleScript extends Script {
         convertedValue = value === 'true';
       } else if (featureToggle.type === 'number') {
         convertedValue = Number(value);
+      } else if (featureToggle.type === 'array') {
+        convertedValue = value.split(',').filter((element) => element != '');
       } else {
         convertedValue = value;
       }

--- a/api/src/shared/infrastructure/feature-toggles/feature-toggles-script.js
+++ b/api/src/shared/infrastructure/feature-toggles/feature-toggles-script.js
@@ -46,13 +46,16 @@ export class FeatureToggleScript extends Script {
     }
 
     if (value !== undefined) {
+      let convertedValue;
       if (featureToggle.type === 'boolean') {
-        await featureTogglesClient.set(key, value === 'true');
+        convertedValue = value === 'true';
       } else if (featureToggle.type === 'number') {
-        await featureTogglesClient.set(key, Number(value));
+        convertedValue = Number(value);
       } else {
-        await featureTogglesClient.set(key, value);
+        convertedValue = value;
       }
+
+      await featureTogglesClient.set(key, convertedValue);
     }
 
     // Get a feature toggle

--- a/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
+++ b/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
@@ -22,6 +22,7 @@ describe('Acceptance | Shared | Application | Controller | feature-toggle', func
           attributes: {
             'dynamic-feature-toggle-system': false,
             'display-ia-campaign-banner': false,
+            'disabled-locales-in-frontend': [],
             'is-async-quest-rewarding-calculation-enabled': false,
             'is-survey-enabled-for-combined-courses': true,
             'is-quest-enabled': true,

--- a/api/tests/shared/unit/domain/services/mail-service_test.js
+++ b/api/tests/shared/unit/domain/services/mail-service_test.js
@@ -1,9 +1,7 @@
 import {
-  DUTCH_SPOKEN,
   ENGLISH_SPOKEN,
   FRENCH_FRANCE,
   FRENCH_SPOKEN,
-  SPANISH_SPOKEN,
 } from '../../../../../src/shared/domain/services/locale-service.js';
 import * as mailService from '../../../../../src/shared/domain/services/mail-service.js';
 import { getI18n } from '../../../../../src/shared/infrastructure/i18n/i18n.js';
@@ -540,9 +538,9 @@ describe('Unit | Service | MailService', function () {
       });
     });
 
-    it(`calls sendEmail with from, to, template, tags and locale ${DUTCH_SPOKEN}`, async function () {
+    it('calls sendEmail with from, to, template, tags and locale nl', async function () {
       // given
-      const locale = DUTCH_SPOKEN;
+      const locale = 'nl';
       const i18n = getI18n(locale);
       const userEmail = 'user@example.net';
       const code = '999999';
@@ -571,9 +569,9 @@ describe('Unit | Service | MailService', function () {
       });
     });
 
-    it(`calls sendEmail with from, to, template, tags and locale ${SPANISH_SPOKEN}`, async function () {
+    it('calls sendEmail with from, to, template, tags and locale es', async function () {
       // given
-      const locale = SPANISH_SPOKEN;
+      const locale = 'es';
       const i18n = getI18n(locale);
       const userEmail = 'user@example.net';
       const code = '999999';

--- a/api/tests/shared/unit/infrastructure/feature-toggles/feature-toggles.script.test.js
+++ b/api/tests/shared/unit/infrastructure/feature-toggles/feature-toggles.script.test.js
@@ -1,0 +1,66 @@
+import { FeatureToggleScript } from '../../../../../src/shared/infrastructure/feature-toggles/feature-toggles-script.js';
+import { expect, sinon } from '../../../../test-helper.js';
+
+describe('Unit | Shared | Scripts | FeatureToggleScript', function () {
+  let script;
+  let featureTogglesClient;
+  let logger;
+
+  beforeEach(function () {
+    script = new FeatureToggleScript();
+    featureTogglesClient = {
+      config: {},
+      set: sinon.stub(),
+      get: sinon.stub(),
+    };
+    logger = {
+      warn: sinon.stub(),
+    };
+  });
+
+  describe('#handle', function () {
+    context('when featureToggle.type is boolean', function () {
+      context('when the value is the string "true"', function () {
+        it('sets boolean true in the featureTogglesClient', async function () {
+          // given
+          sinon.stub(featureTogglesClient, 'config').value({ aFeatureToggle: { type: 'boolean' } });
+          const options = { key: 'aFeatureToggle', value: 'true' };
+
+          // when
+          await script.handle({ options, logger, featureTogglesClient });
+
+          // then
+          expect(featureTogglesClient.set).to.have.been.calledOnceWithExactly('aFeatureToggle', true);
+        });
+      });
+
+      context('when the value is the string "false"', function () {
+        it('sets boolean false in the featureTogglesClient', async function () {
+          // given
+          sinon.stub(featureTogglesClient, 'config').value({ aFeatureToggle: { type: 'boolean' } });
+          const options = { key: 'aFeatureToggle', value: 'false' };
+
+          // when
+          await script.handle({ options, logger, featureTogglesClient });
+
+          // then
+          expect(featureTogglesClient.set).to.have.been.calledOnceWithExactly('aFeatureToggle', false);
+        });
+      });
+    });
+
+    context('when featureToggle.type is number', function () {
+      it('sets an empty list in the featureTogglesClient', async function () {
+        // given
+        sinon.stub(featureTogglesClient, 'config').value({ aFeatureToggle: { type: 'number' } });
+        const options = { key: 'aFeatureToggle', value: '98765' };
+
+        // when
+        await script.handle({ options, logger, featureTogglesClient });
+
+        // then
+        expect(featureTogglesClient.set).to.have.been.calledOnceWithExactly('aFeatureToggle', 98765);
+      });
+    });
+  });
+});

--- a/api/tests/shared/unit/infrastructure/feature-toggles/feature-toggles.script.test.js
+++ b/api/tests/shared/unit/infrastructure/feature-toggles/feature-toggles.script.test.js
@@ -62,5 +62,35 @@ describe('Unit | Shared | Scripts | FeatureToggleScript', function () {
         expect(featureTogglesClient.set).to.have.been.calledOnceWithExactly('aFeatureToggle', 98765);
       });
     });
+
+    context('when featureToggle.type is array', function () {
+      context('when the value is an empty string', function () {
+        it('sets an empty list in the featureTogglesClient', async function () {
+          // given
+          sinon.stub(featureTogglesClient, 'config').value({ aFeatureToggle: { type: 'array' } });
+          const options = { key: 'aFeatureToggle', value: '' };
+
+          // when
+          await script.handle({ options, logger, featureTogglesClient });
+
+          // then
+          expect(featureTogglesClient.set).to.have.been.calledOnceWithExactly('aFeatureToggle', []);
+        });
+      });
+
+      context('when disabledLocalesInFrontend value is a comma-separated list of values', function () {
+        it('sets a populated list in the featureTogglesClient', async function () {
+          // given
+          sinon.stub(featureTogglesClient, 'config').value({ aFeatureToggle: { type: 'array' } });
+          const options = { key: 'aFeatureToggle', value: 'value1,value2' };
+
+          // when
+          await script.handle({ options, logger, featureTogglesClient });
+
+          // then
+          expect(featureTogglesClient.set).to.have.been.calledOnceWithExactly('aFeatureToggle', ['value1', 'value2']);
+        });
+      });
+    });
   });
 });

--- a/certif/app/helpers/text-with-multiple-lang.js
+++ b/certif/app/helpers/text-with-multiple-lang.js
@@ -11,7 +11,7 @@ export default class textWithMultipleLang extends Helper {
       text = text.toString();
     }
     const lang = this.locale.currentLanguage;
-    const listOfLocales = this.locale.supportedLocales;
+    const listOfLocales = this.locale.availableLocales;
     let outputText = _clean(text, listOfLocales);
 
     if (text && listOfLocales.includes(lang)) {

--- a/certif/app/routes/application.js
+++ b/certif/app/routes/application.js
@@ -14,11 +14,12 @@ export default class ApplicationRoute extends Route {
   @service intl;
 
   async beforeModel(transition) {
+    await this.featureToggles.load();
+
     const queryParams = transition?.to?.queryParams;
     this.intl.setFormats(formats);
     this.locale.setBestLocale({ queryParams });
     await this.session.setup();
-    await this.featureToggles.load();
     await this.currentUser.load();
   }
 

--- a/certif/app/services/locale.js
+++ b/certif/app/services/locale.js
@@ -87,15 +87,6 @@ export default class LocaleService extends Service {
       .sort((a, b) => a.label.localeCompare(b.label));
   }
 
-  isSupportedLocale(locale) {
-    try {
-      const localeCanonicalName = Intl.getCanonicalLocales(locale)?.[0];
-      return this.availableLocales.some((availableLocale) => localeCanonicalName == availableLocale);
-    } catch {
-      return false;
-    }
-  }
-
   setCurrentLocale(locale) {
     const nearestLocale = this.#getNearestSupportedLocale(locale);
     this.#setCookieLocale(nearestLocale);

--- a/certif/tests/helpers/service-stubs.js
+++ b/certif/tests/helpers/service-stubs.js
@@ -1,0 +1,28 @@
+import Service from '@ember/service';
+
+/**
+ * @param {Object} owner - The owner object.
+ * @returns {Service} The stubbed featureToggles service.
+ */
+export function stubFeatureTogglesService(owner, featureToggles) {
+  class FeatureTogglesServiceServiceStub extends Service {
+    #featureToggles;
+
+    constructor() {
+      super();
+      this.#featureToggles = featureToggles ?? {};
+    }
+
+    load() {
+      return Promise.resolve();
+    }
+
+    get featureToggles() {
+      return this.#featureToggles;
+    }
+  }
+
+  owner.unregister('service:featureToggles');
+  owner.register('service:featureToggles', FeatureTogglesServiceServiceStub);
+  return owner.lookup('service:featureToggles');
+}

--- a/certif/tests/integration/components/sessions/session-details/enrolled-candidates/index-test.gjs
+++ b/certif/tests/integration/components/sessions/session-details/enrolled-candidates/index-test.gjs
@@ -7,6 +7,7 @@ import { COMPLEMENTARY_KEYS, SUBSCRIPTION_TYPES } from 'pix-certif/models/subscr
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
+import { stubFeatureTogglesService } from '../../../../../helpers/service-stubs';
 import setupIntlRenderingTest from '../../../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | Sessions | SessionDetails | EnrolledCandidates', function (hooks) {
@@ -17,10 +18,7 @@ module('Integration | Component | Sessions | SessionDetails | EnrolledCandidates
   hooks.beforeEach(async function () {
     store = this.owner.lookup('service:store');
 
-    class FeatureTogglesStub extends Service {
-      featureToggles = { isPixPlusCandidateA11yEnabled: false };
-    }
-    this.owner.register('service:featureToggles', FeatureTogglesStub);
+    stubFeatureTogglesService(this.owner, { isPixPlusCandidateA11yEnabled: false });
 
     const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
       id: '123',
@@ -568,10 +566,7 @@ module('Integration | Component | Sessions | SessionDetails | EnrolledCandidates
     module('when feature toggle disables Pix+ candidate edition', function () {
       test('it should display edit button only for CORE candidates when feature is disabled', async function (assert) {
         // given
-        class FeatureTogglesStub extends Service {
-          featureToggles = { isPixPlusCandidateA11yEnabled: false };
-        }
-        this.owner.register('service:featureToggles', FeatureTogglesStub);
+        stubFeatureTogglesService(this.owner, { isPixPlusCandidateA11yEnabled: false });
 
         const localCertificationCandidates = certificationCandidates;
         const localCountries = countries;
@@ -597,10 +592,7 @@ module('Integration | Component | Sessions | SessionDetails | EnrolledCandidates
     module('when feature toggle enables Pix+ candidate edition', function () {
       test('it should display edit button for all candidates when feature is enabled', async function (assert) {
         // given
-        class FeatureTogglesStub extends Service {
-          featureToggles = { isPixPlusCandidateA11yEnabled: true };
-        }
-        this.owner.register('service:featureToggles', FeatureTogglesStub);
+        stubFeatureTogglesService(this.owner, { isPixPlusCandidateA11yEnabled: true });
 
         const localCertificationCandidates = certificationCandidates;
         const localCountries = countries;

--- a/certif/tests/unit/helpers/text-with-multiple-lang-test.js
+++ b/certif/tests/unit/helpers/text-with-multiple-lang-test.js
@@ -7,7 +7,7 @@ module('Unit | Helper | text with multiple lang', function (hooks) {
 
   hooks.beforeEach(function () {
     textWithMultipleLangHelper = new textWithMultipleLang();
-    textWithMultipleLangHelper.locale = { supportedLocales: ['fr', 'en'] };
+    textWithMultipleLangHelper.locale = { availableLocales: ['fr', 'en'] };
   });
   [
     { text: 'des mots', lang: 'fr', outputText: 'des mots' },

--- a/certif/tests/unit/services/locale-test.js
+++ b/certif/tests/unit/services/locale-test.js
@@ -115,60 +115,6 @@ module('Unit | Services | locale', function (hooks) {
     });
   });
 
-  module('isSupportedLocale', function () {
-    module('when locale is supported', function () {
-      test('returns true', function (assert) {
-        // given
-        const locale = 'nl-BE';
-
-        // when
-        const result = localeService.isSupportedLocale(locale);
-
-        // then
-        assert.true(result);
-      });
-    });
-
-    module('when locale is supported but not given in canonical form', function () {
-      test('returns true', function (assert) {
-        // given
-        const locale = 'nl-be';
-
-        // when
-        const result = localeService.isSupportedLocale(locale);
-
-        // then
-        assert.true(result);
-      });
-    });
-
-    module('when locale is valid but not supported', function () {
-      test('returns false', function (assert) {
-        // given
-        const locale = 'ko';
-
-        // when
-        const result = localeService.isSupportedLocale(locale);
-
-        // then
-        assert.false(result);
-      });
-    });
-
-    module('when locale is invalid', function () {
-      test('returns false', function (assert) {
-        // given
-        const locale = 'invalid_locale_in_bad_format';
-
-        // when
-        const result = localeService.isSupportedLocale(locale);
-
-        // then
-        assert.false(result);
-      });
-    });
-  });
-
   module('setCurrentLocale', function () {
     test('set app locale in the cookies', function (assert) {
       // given

--- a/certif/tests/unit/services/locale-test.js
+++ b/certif/tests/unit/services/locale-test.js
@@ -22,7 +22,7 @@ module('Unit | Services | locale', function (hooks) {
 
   hooks.beforeEach(function () {
     localeService = this.owner.lookup('service:locale');
-    sinon.stub(localeService, 'supportedLocales').value(['en', 'es', 'fr', 'nl', 'fr-BE', 'fr-FR', 'nl-BE']);
+    sinon.stub(localeService, 'availableLocales').value(['en', 'es', 'fr', 'nl', 'fr-BE', 'fr-FR', 'nl-BE']);
 
     currentDomainService = this.owner.lookup('service:currentDomain');
     sinon.stub(currentDomainService, 'getExtension');

--- a/mon-pix/app/helpers/text-with-multiple-lang.js
+++ b/mon-pix/app/helpers/text-with-multiple-lang.js
@@ -12,7 +12,7 @@ export default class textWithMultipleLang extends Helper {
       text = text.toString();
     }
     const lang = this.locale.currentLanguage;
-    const listOfLocales = this.locale.supportedLocales;
+    const listOfLocales = this.locale.availableLocales;
     let outputText = _clean(text, listOfLocales);
     if (text && listOfLocales.includes(lang)) {
       const regex = new RegExp(`(\\[${lang}\\]){1}(.|\n)*?(\\[\\/${lang}\\]){1}`);

--- a/mon-pix/app/models/feature-toggle.js
+++ b/mon-pix/app/models/feature-toggle.js
@@ -5,4 +5,5 @@ export default class FeatureToggle extends Model {
   @attr('boolean') isQuestEnabled;
   @attr('boolean') isSurveyEnabledForCombinedCourses;
   @attr('boolean') areModuleShortIdUrlsEnabled;
+  @attr('array') disabledLocalesInFrontend;
 }

--- a/mon-pix/app/routes/application.js
+++ b/mon-pix/app/routes/application.js
@@ -34,11 +34,12 @@ export default class ApplicationRoute extends Route {
   }
 
   async beforeModel(transition) {
+    await this.featureToggles.load().catch();
+
     const queryParams = transition?.to?.queryParams;
     this.intl.setFormats(formats);
     this.locale.setBestLocale({ queryParams });
     await this.session.setup();
-    await this.featureToggles.load().catch();
     await this.oidcIdentityProviders.load().catch();
     await this.authentication.handleAnonymousAuthentication(transition);
     await this.currentUser.load();

--- a/mon-pix/app/services/locale.js
+++ b/mon-pix/app/services/locale.js
@@ -87,15 +87,6 @@ export default class LocaleService extends Service {
       .sort((a, b) => a.label.localeCompare(b.label));
   }
 
-  isSupportedLocale(locale) {
-    try {
-      const localeCanonicalName = Intl.getCanonicalLocales(locale)?.[0];
-      return this.availableLocales.some((availableLocale) => localeCanonicalName == availableLocale);
-    } catch {
-      return false;
-    }
-  }
-
   setCurrentLocale(locale) {
     const nearestLocale = this.#getNearestSupportedLocale(locale);
     this.#setCookieLocale(nearestLocale);

--- a/mon-pix/tests/unit/helpers/text-with-multiple-lang-test.js
+++ b/mon-pix/tests/unit/helpers/text-with-multiple-lang-test.js
@@ -7,7 +7,7 @@ module('Unit | Helper | text with multiple lang', function (hooks) {
 
   hooks.beforeEach(function () {
     textWithMultipleLangHelper = new textWithMultipleLang();
-    textWithMultipleLangHelper.locale = { supportedLocales: ['fr', 'en'] };
+    textWithMultipleLangHelper.locale = { availableLocales: ['fr', 'en'] };
   });
   [
     { text: 'des mots', lang: 'fr', outputText: 'des mots' },

--- a/mon-pix/tests/unit/services/locale-test.js
+++ b/mon-pix/tests/unit/services/locale-test.js
@@ -115,60 +115,6 @@ module('Unit | Services | locale', function (hooks) {
     });
   });
 
-  module('isSupportedLocale', function () {
-    module('when locale is supported', function () {
-      test('returns true', function (assert) {
-        // given
-        const locale = 'nl-BE';
-
-        // when
-        const result = localeService.isSupportedLocale(locale);
-
-        // then
-        assert.true(result);
-      });
-    });
-
-    module('when locale is supported but not given in canonical form', function () {
-      test('returns true', function (assert) {
-        // given
-        const locale = 'nl-be';
-
-        // when
-        const result = localeService.isSupportedLocale(locale);
-
-        // then
-        assert.true(result);
-      });
-    });
-
-    module('when locale is valid but not supported', function () {
-      test('returns false', function (assert) {
-        // given
-        const locale = 'ko';
-
-        // when
-        const result = localeService.isSupportedLocale(locale);
-
-        // then
-        assert.false(result);
-      });
-    });
-
-    module('when locale is invalid', function () {
-      test('returns false', function (assert) {
-        // given
-        const locale = 'invalid_locale_in_bad_format';
-
-        // when
-        const result = localeService.isSupportedLocale(locale);
-
-        // then
-        assert.false(result);
-      });
-    });
-  });
-
   module('setCurrentLocale', function () {
     test('set app locale in the cookies', function (assert) {
       // given

--- a/mon-pix/tests/unit/services/locale-test.js
+++ b/mon-pix/tests/unit/services/locale-test.js
@@ -22,7 +22,7 @@ module('Unit | Services | locale', function (hooks) {
 
   hooks.beforeEach(function () {
     localeService = this.owner.lookup('service:locale');
-    sinon.stub(localeService, 'supportedLocales').value(['en', 'es', 'fr', 'nl', 'fr-BE', 'fr-FR', 'nl-BE']);
+    sinon.stub(localeService, 'availableLocales').value(['en', 'es', 'fr', 'nl', 'fr-BE', 'fr-FR', 'nl-BE']);
 
     currentDomainService = this.owner.lookup('service:currentDomain');
     sinon.stub(currentDomainService, 'getExtension');

--- a/orga/app/helpers/text-with-multiple-lang.js
+++ b/orga/app/helpers/text-with-multiple-lang.js
@@ -11,7 +11,7 @@ export default class textWithMultipleLang extends Helper {
       text = text.toString();
     }
     const lang = this.locale.currentLanguage;
-    const listOfLocales = this.locale.supportedLocales;
+    const listOfLocales = this.locale.availableLocales;
     let outputText = _clean(text, listOfLocales);
 
     if (text && listOfLocales.includes(lang)) {

--- a/orga/app/routes/application.js
+++ b/orga/app/routes/application.js
@@ -28,11 +28,12 @@ export default class ApplicationRoute extends Route {
   }
 
   async beforeModel(transition) {
+    await this.featureToggles.load();
+
     const queryParams = transition?.to?.queryParams;
     this.intl.setFormats(formats);
     this.locale.setBestLocale({ queryParams });
     await this.session.setup();
-    await this.featureToggles.load();
     await this.oidcIdentityProviders.load().catch();
   }
 

--- a/orga/app/services/locale.js
+++ b/orga/app/services/locale.js
@@ -87,15 +87,6 @@ export default class LocaleService extends Service {
       .sort((a, b) => a.label.localeCompare(b.label));
   }
 
-  isSupportedLocale(locale) {
-    try {
-      const localeCanonicalName = Intl.getCanonicalLocales(locale)?.[0];
-      return this.availableLocales.some((availableLocale) => localeCanonicalName == availableLocale);
-    } catch {
-      return false;
-    }
-  }
-
   setCurrentLocale(locale) {
     const nearestLocale = this.#getNearestSupportedLocale(locale);
     this.#setCookieLocale(nearestLocale);

--- a/orga/tests/unit/helpers/text-with-multiple-lang-test.js
+++ b/orga/tests/unit/helpers/text-with-multiple-lang-test.js
@@ -6,7 +6,7 @@ module('Unit | Helper | TextWithMultipleLang', function (hooks) {
   let helper;
   hooks.beforeEach(function () {
     helper = new textWithMultipleLang();
-    helper.locale = { supportedLocales: ['fr', 'en'] };
+    helper.locale = { availableLocales: ['fr', 'en'] };
   });
 
   [

--- a/orga/tests/unit/services/locale-test.js
+++ b/orga/tests/unit/services/locale-test.js
@@ -115,60 +115,6 @@ module('Unit | Services | locale', function (hooks) {
     });
   });
 
-  module('isSupportedLocale', function () {
-    module('when locale is supported', function () {
-      test('returns true', function (assert) {
-        // given
-        const locale = 'nl-BE';
-
-        // when
-        const result = localeService.isSupportedLocale(locale);
-
-        // then
-        assert.true(result);
-      });
-    });
-
-    module('when locale is supported but not given in canonical form', function () {
-      test('returns true', function (assert) {
-        // given
-        const locale = 'nl-be';
-
-        // when
-        const result = localeService.isSupportedLocale(locale);
-
-        // then
-        assert.true(result);
-      });
-    });
-
-    module('when locale is valid but not supported', function () {
-      test('returns false', function (assert) {
-        // given
-        const locale = 'ko';
-
-        // when
-        const result = localeService.isSupportedLocale(locale);
-
-        // then
-        assert.false(result);
-      });
-    });
-
-    module('when locale is invalid', function () {
-      test('returns false', function (assert) {
-        // given
-        const locale = 'invalid_locale_in_bad_format';
-
-        // when
-        const result = localeService.isSupportedLocale(locale);
-
-        // then
-        assert.false(result);
-      });
-    });
-  });
-
   module('setCurrentLocale', function () {
     test('set app locale in the cookies', function (assert) {
       // given

--- a/orga/tests/unit/services/locale-test.js
+++ b/orga/tests/unit/services/locale-test.js
@@ -22,7 +22,7 @@ module('Unit | Services | locale', function (hooks) {
 
   hooks.beforeEach(function () {
     localeService = this.owner.lookup('service:locale');
-    sinon.stub(localeService, 'supportedLocales').value(['en', 'es', 'fr', 'nl', 'fr-BE', 'fr-FR', 'nl-BE']);
+    sinon.stub(localeService, 'availableLocales').value(['en', 'es', 'fr', 'nl', 'fr-BE', 'fr-FR', 'nl-BE']);
 
     currentDomainService = this.owner.lookup('service:currentDomain');
     sinon.stub(currentDomainService, 'getExtension');


### PR DESCRIPTION
## ❄️ Problème

On souhaite pouvoir ajouter progressivement de nouvelles locales et éviter qu’elles soient tout de suite utilisables par les utilisateurs pendant qu’on travaille dessus. Par exemple, on configure l’italien sans avoir commencé à tout traduire ou bien validé toutes les traductions.

## 🛷 Proposition

La solution consiste à pouvoir désactiver certaines locales **uniquement au niveau des Fronts** en utilisant pour cela le mécanisme des Feature Toggles.

Les traitements au niveau du Back ne sont pas absolument pas impactés.

La solution nécessite l’ajout du nouveau type de Feature Toggle `array`.

Utilisation du script des Feature Toggles pour configurer une liste de locales à désactiver (l’exécution de ce script remplace toute valeur précédente, cela n’ajoute pas de nouvelles locales à désactiver) :
```shell
npm run toggles -- --key disabledLocalesInFrontend --value <LISTE_DE_LOCALES>
```

## ☃️ Remarques

Il a été nécessaire de modifier un fichier de tests de Pix Certif en créant pour l’occasion une nouvelle fonction helper `stubFeatureTogglesService` qui effectue aussi des `owner.unregister('service:featureToggles')`, sans cela certains tests ne passaient plus.

## 🧑‍🎄 Pour tester

### Tester la modification du FT `disabledLocalesInFrontend`

#### Définir une seule locale à désactiver

```shell
npm run toggles -- --key disabledLocalesInFrontend --value 'fr-BE'
```
```shell
npm run toggles -- --list
```

#### Définir plusieurs locales à désactiver

```shell
npm run toggles -- --key disabledLocalesInFrontend --value 'es,fr-BE'
```
```shell
npm run toggles -- --list
```

#### Définir qu’aucune locale n’est désactivée

```shell
npm run toggles -- --key disabledLocalesInFrontend --value ''
```
```shell
npm run toggles -- --list
```

### Tester tous les frontaux

1. Modifier le FT `disabledLocalesInFrontend` en utilisant différentes valeurs possibles,
2. Constater que les changements de valeur du FT `disabledLocalesInFrontend` font que certaines locales ne sont pas affichées dans les localeSwitchers des frontaux Pix App, Pix Certif et Pix Orga,
3. Tester globalement tous les frontaux Pix App, Pix Certif, Pix Orga et Pix Admin sur les différentes pages mettant en jeu des locales pour vérifier que globalement il n’y a pas de régression.

### Tester que le nouveau type de Feature Toggle `array` ne casse pas Pix Exploit

<img width="1733" height="1251" alt="Screenshot-Liste_des_fonctionnalités_disponibles_Pix_exploit" src="https://github.com/user-attachments/assets/b5eb00db-79ff-4b0e-8f45-760dd2bf9ac8" />

:information_source: Avec le code actuel de Pix Exploit les FT de type `array` comme le FT `disabledLocalesInFrontend` ne sont pas modifiables. Il y a bien toujours une action _« Modifier la valeur »_ mais elle ne produit pas d’effet. Une autre PR est prête qui fait fonctionner cette fonctionnalité à être réalisée si la PR présente est validée.