### PR TITLE
[TECH] Clarification des variables d'environnement utilisées dans le contexte `llm` (PIX-21177)

### DIFF
--- a/api/sample.env
+++ b/api/sample.env
@@ -436,33 +436,43 @@ LCMS_API_RELEASE_ID=
 # default: 200
 # sample: LLM_LOCK_CHAT_EXPIRATION_DELAY_SECONDS=
 
-# LLM API URL to get a configuration by id
+# LLM CONFIGURATION EDITOR API URL to get a configuration by id
 #
-# If not present, embed with LLM will not work
-#
-# presence: required
-# type: String
-# default: none
-# LLM_API_GET_CONFIGURATIONS_URL=
-
-# LLM API URL to post a prompt
-#
-# If not present, embed with LLM will not work
+# If not present, embeds with LLM will not work
 #
 # presence: required
 # type: String
 # default: none
-# LLM_API_POST_PROMPT_URL=
+# LLM_CONFIGURATION_EDITOR_API_GET_CONFIGURATION_URL=
 
-## LLM API SECRET (temporary) Secret salt value used in JWT token generation for LLM.
-## For dev purposes, put the same secret as your selfhosted LLM API
+# LLM INFERENCE API URL to post a prompt
+#
+# If not present, embeds with LLM will not work
+#
+# presence: required
+# type: String
+# default: none
+# LLM_INFERENCE_API_POST_PROMPT_URL=
+
+## LLM CONFIGURATION EDITOR API SECRET (temporary) Secret salt value used in JWT token generation for LLM.
+## For dev purposes, put the same secret as your selfhosted LLM CONFIGURATION EDITOR API
 ##
-## If not present, embed with LLM will not work
+## If not present, embeds with LLM will not work
 ##
 ## presence: required
 ## type: String
 ## default: none
-## LLM_API_JWT_SECRET=
+## LLM_CONFIGURATION_EDITOR_API_JWT_SECRET=
+
+## LLM INFERENCE API SECRET (temporary) Secret salt value used in JWT token generation for LLM.
+## For dev purposes, put the same secret as your selfhosted LLM INFERENCE API
+##
+## If not present, embeds with LLM will not work
+##
+## presence: required
+## type: String
+## default: none
+## LLM_INFERENCE_API_JWT_SECRET=
 
 # =======
 # LOGGING

--- a/api/src/llm/infrastructure/repositories/configuration-repository.js
+++ b/api/src/llm/infrastructure/repositories/configuration-repository.js
@@ -16,12 +16,12 @@ export async function get(id) {
     throw new ConfigurationNotFoundError(id);
   }
 
-  const url = config.llm.getConfigurationUrl + '/' + id;
+  const url = config.llm.configurationEditorApi.getConfigurationUrl + '/' + id;
   let response;
   try {
     response = await fetch(url, {
       headers: {
-        authorization: `Bearer ${jwt.sign('foo', config.llm.authSecret)}`,
+        authorization: `Bearer ${jwt.sign('foo', config.llm.configurationEditorApi.authSecret)}`,
       },
     });
   } catch (err) {

--- a/api/src/llm/infrastructure/repositories/prompt-repository.js
+++ b/api/src/llm/infrastructure/repositories/prompt-repository.js
@@ -36,7 +36,7 @@ export async function prompt({ messages, configuration, chatId }) {
     configuration: configurationDTO,
     history: messages,
   });
-  const url = config.llm.postPromptUrl;
+  const url = config.llm.inferenceApi.postPromptUrl;
 
   let response;
   let currentRetryCount = 0;
@@ -54,7 +54,7 @@ export async function prompt({ messages, configuration, chatId }) {
               client_id: 'pix-api',
               scope: 'api',
             },
-            config.llm.authSecret,
+            config.llm.inferenceApi.authSecret,
           )}`,
         },
         body: payload,

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -137,8 +137,11 @@ const schema = Joi.object({
   LCMS_API_KEY: Joi.string().requiredForApi(),
   LCMS_API_URL: Joi.string().uri().requiredForApi(),
   LCMS_API_RELEASE_ID: Joi.any(),
-  LLM_API_GET_CONFIGURATIONS_URL: Joi.string().optional(),
   LLM_CHAT_TEMPORARY_STORAGE_EXP_DELAY_SECONDS: Joi.string().optional(),
+  LLM_CONFIGURATION_EDITOR_API_GET_CONFIGURATION_URL: Joi.string().optional(),
+  LLM_CONFIGURATION_EDITOR_API_JWT_SECRET: Joi.string().optional(),
+  LLM_INFERENCE_API_POST_PROMPT_URL: Joi.string().optional(),
+  LLM_INFERENCE_API_JWT_SECRET: Joi.string().optional(),
   LOG_ENABLED: Joi.string().required().valid('true', 'false'),
   LOG_FOR_HUMANS: Joi.string().optional().valid('true', 'false'),
   LOG_LEVEL: Joi.string().optional().valid('silent', 'fatal', 'error', 'warn', 'info', 'debug', 'trace'),
@@ -350,9 +353,16 @@ const configuration = (function () {
         expirationDelaySeconds: ms(process.env.LLM_CHAT_TEMPORARY_STORAGE_EXP_DELAY_SECONDS ?? '12h'),
       },
       lockChatExpirationDelayMilliseconds: (process.env.LLM_LOCK_CHAT_EXPIRATION_DELAY_SECONDS ?? 200) * 1000,
-      getConfigurationUrl: _removeTrailingSlashFromUrl(process.env.LLM_API_GET_CONFIGURATIONS_URL ?? ''),
-      postPromptUrl: _removeTrailingSlashFromUrl(process.env.LLM_API_POST_PROMPT_URL ?? ''),
-      authSecret: process.env.LLM_API_JWT_SECRET,
+      inferenceApi: {
+        postPromptUrl: _removeTrailingSlashFromUrl(process.env.LLM_INFERENCE_API_POST_PROMPT_URL ?? ''),
+        authSecret: process.env.LLM_INFERENCE_API_JWT_SECRET,
+      },
+      configurationEditorApi: {
+        getConfigurationUrl: _removeTrailingSlashFromUrl(
+          process.env.LLM_CONFIGURATION_EDITOR_API_GET_CONFIGURATION_URL ?? '',
+        ),
+        authSecret: process.env.LLM_CONFIGURATION_EDITOR_API_JWT_SECRET,
+      },
     },
     logging: {
       enabled: toBoolean(process.env.LOG_ENABLED),
@@ -538,10 +548,11 @@ const configuration = (function () {
     config.lcms.apiKey = 'test-api-key';
     config.lcms.url = 'https://lcms-test.pix.fr/api';
 
-    config.llm.getConfigurationUrl = 'https://llm-test.pix.fr/api/configurations';
-    config.llm.postPromptUrl = 'https://llm-test.pix.fr/api/chat';
+    config.llm.configurationEditorApi.getConfigurationUrl = 'https://llm-test.pix.fr/api/configurations';
+    config.llm.inferenceApi.postPromptUrl = 'https://llm-test.pix.fr/api/chat';
     config.llm.temporaryStorage.expirationDelaySeconds = 1;
-    config.llm.authSecret = 'Le secret dans les tests';
+    config.llm.configurationEditorApi.authSecret = 'Le secret dans les tests';
+    config.llm.inferenceApi.authSecret = 'Le secret dans les tests';
 
     config.domain.tldFr = '.fr';
     config.domain.tldOrg = '.org';


### PR DESCRIPTION
## ❄️ Problème

Les variables d'environnement `LLM_API_GET_CONFIGURATIONS_URL` et `LLM_API_POST_PROMPT_URL` sont trompeuses, car il y a en réalité 2 APIs différentes qui se cachent sous le nom de `LLM_API`.

## 🛷 Proposition

Expliciter la distinction entre les deux APIs utilisées : 
- `LLM_API_GET_CONFIGURATIONS_URL` ➡️ `LLM_CONFIGURATION_EDITOR_API_GET_CONFIGURATION_URL`
- `LLM_API_POST_PROMPT_URL` ➡️ `LLM_INFERENCE_API_POST_PROMPT_URL`

De même, séparer `LLM_API_JWT_SECRET` en deux variables distinctes.

## 🧑‍🎄 Pour tester

Modifier les variables d'environnement et constater que l'API LLM fonctionne encore 😉