### PR TITLE
[TECH] Ajout de la colonne minimumAnswersRequiredToValidateACertification dans la table certification_versions (PIX-21280)

### DIFF
--- a/api/db/migrations/20260128171331_add_minimum_answer_required_column_to_certification_versions.js
+++ b/api/db/migrations/20260128171331_add_minimum_answer_required_column_to_certification_versions.js
@@ -1,0 +1,28 @@
+const TABLE_NAME = 'certification_versions';
+const COLUMN_NAME = 'minimumAnswersRequiredToValidateACertification';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table
+      .integer(COLUMN_NAME)
+      .comment(
+        'Minimum number of answers required to validate a certification. Any certification finalized with less answers than specified would be cancelled or rejected (depending on abort reason)',
+      );
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## ❄️ Problème

Actuellement, le paramètre `minimumAnswersRequiredToValidateACertification`, qui correspond au nombre de réponses minimum nécessaire pour pouvoir valider une certification, se trouve dans le fichier `config.js`. Or, dans le cadre de l'historisation de version de certification, et d'autant plus dans celui du scoring des Pix plus, pour lesquels il est possible que cette valeur ne soit pas la même que pour Pix Cœur, il est nécessaire d'historiser ce paramètre en le faisant entrer dans la notion de version de certification.

## 🛷 Proposition

Ajouter une colonne `minimumAnswersRequiredToValidateACertification` sur la table `certification_versions`.

## ☃️ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🧑‍🎄 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
