### PR TITLE
[TECH] Placer la sélection sur le premier élément en erreur dans le formulaire de création d'organisation (PIX-21007)

### DIFF
--- a/admin/app/components/organizations/creation-form.gjs
+++ b/admin/app/components/organizations/creation-form.gjs
@@ -125,7 +125,7 @@ export default class OrganizationCreationForm extends Component {
 
           <div class="organization-creation-form__input--full">
             <PixInput
-              @id="organizationName"
+              @id="name"
               {{on "change" (fn this.handleInputChange "name")}}
               @requiredLabel={{t "common.fields.required-field"}}
               placeholder={{concat
@@ -142,6 +142,7 @@ export default class OrganizationCreationForm extends Component {
           </div>
 
           <PixSelect
+            @id="type"
             @onChange={{fn this.handleSelectChange "type"}}
             @options={{this.organizationTypes}}
             @placeholder={{t "components.organizations.creation.type.placeholder"}}
@@ -155,6 +156,7 @@ export default class OrganizationCreationForm extends Component {
           </PixSelect>
 
           <PixSelect
+            @id="administrationTeamId"
             @onChange={{fn this.handleSelectChange "administrationTeamId"}}
             @options={{this.administrationTeamsOptions}}
             @placeholder={{t "components.organizations.creation.administration-team.selector.placeholder"}}
@@ -170,6 +172,7 @@ export default class OrganizationCreationForm extends Component {
           </PixSelect>
 
           <PixSelect
+            @id="countryCode"
             @onChange={{fn this.handleSelectChange "countryCode"}}
             @options={{this.countriesOptions}}
             @placeholder={{t "components.organizations.creation.country.selector.placeholder"}}

--- a/admin/app/components/organizations/creation-form.gjs
+++ b/admin/app/components/organizations/creation-form.gjs
@@ -92,6 +92,12 @@ export default class OrganizationCreationForm extends Component {
     this.form = { ...this.form, [key]: value };
   };
 
+  focusOnFirstFieldInError = () => {
+    const fieldsInError = Object.keys(this.validator.errors);
+    const firstHtmlElementInError = document.getElementById(fieldsInError[0]);
+    firstHtmlElementInError.focus();
+  };
+
   handleSubmit = (event) => {
     event.preventDefault();
     const isFormValid = this.validator.validate(this.form);
@@ -99,6 +105,7 @@ export default class OrganizationCreationForm extends Component {
       this.pixToast.sendErrorNotification({
         message: this.intl.t('components.organizations.creation.error-messages.error-toast'),
       });
+      this.focusOnFirstFieldInError();
       return;
     }
     this.args.onSubmit(this.form);

--- a/admin/tests/integration/components/organizations/creation-form-test.gjs
+++ b/admin/tests/integration/components/organizations/creation-form-test.gjs
@@ -465,6 +465,43 @@ module('Integration | Component | organizations/creation-form', function (hooks)
         assert.notOk(screen.queryByText(t('components.organizations.creation.error-messages.country')));
         assert.notOk(screen.queryByText(t('components.organizations.creation.error-messages.dpo-email')));
       });
+
+      module('when first field in error is an input field', function () {
+        test('it should focus on it after submit', async function (assert) {
+          // given
+          const screen = await render(
+            <template><CreationForm @administrationTeams={{administrationTeams}} @countries={{countries}} /></template>,
+          );
+
+          // when
+          await click(screen.getByRole('button', { name: t('common.actions.add') }));
+
+          //then
+          const organizationNameInput = screen.getByRole('textbox', {
+            name: `${t('components.organizations.creation.name.label')} *`,
+          });
+          assert.strictEqual(document.activeElement, organizationNameInput);
+        });
+      });
+
+      module('when first field in error is a select field', function () {
+        test('it should focus on it after submit', async function (assert) {
+          // given
+          const screen = await render(
+            <template><CreationForm @administrationTeams={{administrationTeams}} @countries={{countries}} /></template>,
+          );
+
+          await fillByLabel(`${t('components.organizations.creation.name.label')} *`, 'Organisation de Test');
+
+          await click(screen.getByRole('button', { name: t('common.actions.add') }));
+
+          //then
+          const organizationTypeSelect = screen.getByRole('button', {
+            name: `${t('components.organizations.creation.type.label')} *`,
+          });
+          assert.strictEqual(document.activeElement, organizationTypeSelect);
+        });
+      });
     });
   });
 


### PR DESCRIPTION
## ❄️ Problème

Sur Pix Admin:
Actuellement, lorsqu'il ya des erreurs dans le formulaire de création d'organisation, le focus n'est placé nulle part. Or une bonne pratique d'accessibilité est de placer le focus sur le permier champ de formulaire en erreur.

[https://www.accede-web.com/notices/html-et-css/formulaires/integrer-les-messages-derreur-et-les-suggestions-de-correction-directement-dans-les-balises-label/](https://www.accede-web.com/notices/html-et-css/formulaires/integrer-les-messages-derreur-et-les-suggestions-de-correction-directement-dans-les-balises-label/)

## 🛷 Proposition

Déplacer le focus sur le premier champ de formulaire en erreur après la soumission du formulaire.

## ☃️ Remarques

On fait une suggestion optionnelle d'amélioration (dernier commit): placer le focus automatiquement sur le champ **Nom de l'organisation** au premier rendu de la page.

## 🧑‍🎄 Pour tester

Sur Pix Admin:
- accéder à la page de création d'organisation
- constater que le focus est sur le premier champ, **Nom de l'organisation**
- remplir le formulaire en commettant des erreurs (champs obligatoires non remplis, erreurs dans les urls, les adresses e-mail...)
- à la soumission du formulaire, constater que le focus est à chaque fois sur le premier champ en erreur
