### PR TITLE
[FEATURE] Augmenter le nombre de retry de 4 à 10 pour les appels réseau en échec de openid-client  (PIX-21302)

### DIFF
--- a/api/src/identity-access-management/domain/helpers/openid-client-with-retry.js
+++ b/api/src/identity-access-management/domain/helpers/openid-client-with-retry.js
@@ -10,10 +10,11 @@ export class OpenidClientWithRetry {
   #maxRetryCount;
   #waitDurationInMs;
 
-  constructor({ openidClient, maxRetryCount, durationInMs } = {}) {
+  constructor({ identityProvider, openidClient, maxRetryCount, durationInMs } = {}) {
     this.#openidClient = openidClient ?? originalOpenidClient;
     this.#maxRetryCount = maxRetryCount ?? MAX_RETRY_COUNT;
     this.#waitDurationInMs = durationInMs ?? WAIT_DURATION_IN_MS;
+    this.identityProvider = identityProvider;
   }
 
   /**
@@ -59,7 +60,7 @@ export class OpenidClientWithRetry {
         throw error;
       }
 
-      _monitorError(error, f, retryCount);
+      _monitorError(this.identityProvider, error, f, retryCount);
 
       await new Promise((resolve) => setTimeout(() => resolve(), this.#waitDurationInMs));
 
@@ -68,9 +69,9 @@ export class OpenidClientWithRetry {
   }
 }
 
-function _monitorError(error, f, retryCount) {
+function _monitorError(identityProvider, error, f, retryCount) {
   const monitoringData = {
-    message: `Error executing ${f.name}, retry = ${retryCount}`,
+    message: `Error for identityProvider ${identityProvider} executing ${f.name}, retry = ${retryCount}`,
     context: 'oidc',
     team: 'acces',
   };
@@ -85,5 +86,3 @@ function _monitorError(error, f, retryCount) {
 
   logger.info(monitoringData);
 }
-
-export const openidClientWithRetry = new OpenidClientWithRetry();

--- a/api/src/identity-access-management/domain/helpers/openid-client-with-retry.js
+++ b/api/src/identity-access-management/domain/helpers/openid-client-with-retry.js
@@ -2,7 +2,7 @@ import * as originalOpenidClient from 'openid-client';
 
 import { logger } from '../../../shared/infrastructure/utils/logger.js';
 
-const MAX_RETRY_COUNT = 4;
+const MAX_RETRY_COUNT = 10;
 const WAIT_DURATION_IN_MS = 2000;
 
 export class OpenidClientWithRetry {

--- a/api/src/identity-access-management/domain/services/oidc-authentication-service.js
+++ b/api/src/identity-access-management/domain/services/oidc-authentication-service.js
@@ -12,7 +12,7 @@ import { AuthenticationSessionContent } from '../../../shared/domain/models/Auth
 import { temporaryStorage } from '../../../shared/infrastructure/key-value-storages/index.js';
 import { logger } from '../../../shared/infrastructure/utils/logger.js';
 import { DEFAULT_CLAIM_MAPPING } from '../constants/oidc-identity-providers.js';
-import { openidClientWithRetry } from '../helpers/openid-client-with-retry.js';
+import { OpenidClientWithRetry } from '../helpers/openid-client-with-retry.js';
 import { AuthenticationMethod } from '../models/AuthenticationMethod.js';
 import { ClaimManager } from '../models/ClaimManager.js';
 
@@ -52,7 +52,7 @@ export class OidcAuthenticationService {
       isVisible = true,
       claimMapping,
     },
-    { sessionTemporaryStorage = defaultSessionTemporaryStorage, openidClient = openidClientWithRetry } = {},
+    { sessionTemporaryStorage = defaultSessionTemporaryStorage, openidClient } = {},
   ) {
     this.accessTokenLifespanMs = ms(accessTokenLifespan);
     this.additionalRequiredProperties = additionalRequiredProperties;
@@ -76,7 +76,7 @@ export class OidcAuthenticationService {
     this.slug = slug;
     this.source = source;
     this.isVisible = isVisible;
-    this.#openidClient = openidClient;
+    this.#openidClient = openidClient ?? new OpenidClientWithRetry({ identityProvider });
 
     claimMapping = claimMapping || DEFAULT_CLAIM_MAPPING;
 

--- a/api/tests/identity-access-management/unit/helpers/openid-client-with-retry.test.js
+++ b/api/tests/identity-access-management/unit/helpers/openid-client-with-retry.test.js
@@ -65,8 +65,8 @@ describe('Unit | Identity Access Management | Domain | Helper | openid-client-wi
         }
 
         // then
-        expect(openidClient.discovery.callCount).to.equal(5);
-        expect(logger.info.callCount).to.equal(4);
+        expect(openidClient.discovery.callCount).to.equal(11);
+        expect(logger.info.callCount).to.equal(10);
       });
     });
   });
@@ -123,8 +123,8 @@ describe('Unit | Identity Access Management | Domain | Helper | openid-client-wi
         }
 
         // then
-        expect(openidClient.authorizationCodeGrant.callCount).to.equal(5);
-        expect(logger.info.callCount).to.equal(4);
+        expect(openidClient.authorizationCodeGrant.callCount).to.equal(11);
+        expect(logger.info.callCount).to.equal(10);
       });
     });
   });
@@ -181,8 +181,8 @@ describe('Unit | Identity Access Management | Domain | Helper | openid-client-wi
         }
 
         // then
-        expect(openidClient.fetchUserInfo.callCount).to.equal(5);
-        expect(logger.info.callCount).to.equal(4);
+        expect(openidClient.fetchUserInfo.callCount).to.equal(11);
+        expect(logger.info.callCount).to.equal(10);
       });
     });
   });


### PR DESCRIPTION
## ❄️ Problème

La PR  #14793 a ajouté du retry sur les appels réseau en échec de openid-client, mais même si cela a permis que certaines actions qui auraient avant fini en échec pour l’utilisateur aient fini en réussite, dans une majorité de cas 4 retries ne sont pas suffisants.

## 🛷 Proposition

1. Augmenter le nombre de retry de 4 à 10 pour les appels réseau en échec de openid-client
2. Ajouter explicitement le code de l’`identityProvider` dans les logs de monitoring pour faciliter l’analyse des logs

## ☃️ Remarques

RAS

## 🧑‍🎄 Pour tester

À tester en local.

### Test du fonctionnement sans erreur

* Tester la connexion par SSO sur Pix App `.fr`
* Tester la connexion par SSO sur Pix App `.org`
* Tester la connexion par SSO sur Pix Orga : 
   * Suivre une invitation en choisissant une autre méthode de connexion et en créant un compte
   * Suivre une invitation en choisissant une autre méthode de connexion et en associant un compte
   * Avec un compte déjà associé par SSO et avec des droits dans Pix Orga se connecter par SSO

### Test du fonctionnement sur erreur avec retry et délais

Modifier le code de `api/src/identity-access-management/domain/helpers/openid-client-with-retry.js` comme suit :
```javascript
  async #executeWithRetry(f, params, retryCount = 0) {
    try {
      // Start of code block to add for test purpose
      if (retryCount <= 2) {
        throw new Error('Error from test');
      }
      // End of code block to add for test purpose

      return await f.apply(this.#openidClient, params);
    } catch (error) {
      if (retryCount >= this.#maxRetryCount) {
        throw error;
      }

      _monitorError(this.identityProvider, error, f, retryCount);

      await new Promise((resolve) => setTimeout(() => resolve(), this.#waitDurationInMs));

      return this.#executeWithRetry(f, params, retryCount + 1);
    }
  }
```

1. Aller sur n’importe quelle application Pix Front et actionner le bouton pour démarrer une connexion par SSO,
3. Constater dans la console où Pix API s’exécute les 3 logs de monitoring apparaissant à 2 secondes d’intervale.

