### PR TITLE
[TECH] Désactive rewardUser au niveau de la réponse à une question

### DIFF
--- a/api/src/evaluation/application/answers/answer-controller.js
+++ b/api/src/evaluation/application/answers/answer-controller.js
@@ -1,5 +1,5 @@
-import { usecases as questUsecases } from '../../../quest/domain/usecases/index.js';
-import { featureToggles } from '../../../shared/infrastructure/feature-toggles/index.js';
+// import { usecases as questUsecases } from '../../../quest/domain/usecases/index.js';
+// import { featureToggles } from '../../../shared/infrastructure/feature-toggles/index.js';
 import * as assessmentRepository from '../../../shared/infrastructure/repositories/assessment-repository.js';
 import {
   extractUserIdFromRequest,

--- a/api/src/evaluation/application/answers/answer-controller.js
+++ b/api/src/evaluation/application/answers/answer-controller.js
@@ -39,13 +39,14 @@ const save = async function (request, h, dependencies = { answerSerializer, asse
       locale,
     });
   }
-  if (
-    userId &&
-    !(await featureToggles.get('isAsyncQuestRewardingCalculationEnabled')) &&
-    (await featureToggles.get('isQuestEnabled'))
-  ) {
-    await questUsecases.rewardUser({ userId });
-  }
+  // INFO: On désactive temporairement ce code pour vérifier un problème de production
+  // if (
+  //   userId &&
+  //   !(await featureToggles.get('isAsyncQuestRewardingCalculationEnabled')) &&
+  //   (await featureToggles.get('isQuestEnabled'))
+  // ) {
+  //   await questUsecases.rewardUser({ userId });
+  // }
 
   return h.response(dependencies.answerSerializer.serialize(correctedAnswer)).created();
 };

--- a/api/tests/evaluation/unit/application/answers/answer-controller_test.js
+++ b/api/tests/evaluation/unit/application/answers/answer-controller_test.js
@@ -280,7 +280,7 @@ describe('Unit | Controller | answer-controller', function () {
           expect(questUsecases.rewardUser).to.have.not.been.called;
         });
 
-        it('should call rewardUser if async is not enabled', async function () {
+        it.skip('should call rewardUser if async is not enabled', async function () {
           // given
           await featureToggles.set('isQuestEnabled', true);
           await featureToggles.set('isAsyncQuestRewardingCalculationEnabled', false);

--- a/api/tests/evaluation/unit/application/answers/answer-controller_test.js
+++ b/api/tests/evaluation/unit/application/answers/answer-controller_test.js
@@ -280,20 +280,20 @@ describe('Unit | Controller | answer-controller', function () {
           expect(questUsecases.rewardUser).to.have.not.been.called;
         });
 
-        it.skip('should call rewardUser if async is not enabled', async function () {
-          // given
-          await featureToggles.set('isQuestEnabled', true);
-          await featureToggles.set('isAsyncQuestRewardingCalculationEnabled', false);
+        // it('should call rewardUser if async is not enabled', async function () {
+        //   // given
+        //   await featureToggles.set('isQuestEnabled', true);
+        //   await featureToggles.set('isAsyncQuestRewardingCalculationEnabled', false);
 
-          // when
-          await answerController.save(request, hFake, {
-            answerSerializer: answerSerializerStub,
-            assessmentRepository,
-          });
+        //   // when
+        //   await answerController.save(request, hFake, {
+        //     answerSerializer: answerSerializerStub,
+        //     assessmentRepository,
+        //   });
 
-          // then
-          expect(questUsecases.rewardUser).to.have.been.calledWith({ userId });
-        });
+        //   // then
+        //   expect(questUsecases.rewardUser).to.have.been.calledWith({ userId });
+        // });
 
         it('should not call the reward user usecase if userId is not provided', async function () {
           // given


### PR DESCRIPTION
## ❄️ Problème

Nous avons actuellement des instabilités en production.

## 🛷 Proposition

On essaye de désactiver la délivrance de récompense via les quêtes au niveau de la réponse à une question.

## ☃️ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🧑‍🎄 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
