### PR TITLE
[TECH] Mutualiser ABORT_REASON dans une constante partagée

### DIFF
--- a/api/db/seeds/data/team-certification/tools/publish-session-with-validated-certification.js
+++ b/api/db/seeds/data/team-certification/tools/publish-session-with-validated-certification.js
@@ -6,7 +6,7 @@ import { usecases as evaluationUseCases } from '../../../../../src/certification
 import { usecases as flashUseCases } from '../../../../../src/certification/evaluation/domain/usecases/index.js';
 import { usecases as scoringUseCases } from '../../../../../src/certification/scoring/domain/usecases/index.js';
 import { usecases as sessionManagementUseCases } from '../../../../../src/certification/session-management/domain/usecases/index.js';
-import { ABORT_REASONS } from '../../../../../src/certification/shared/domain/models/CertificationCourse.js';
+import { ABORT_REASONS } from '../../../../../src/certification/shared/domain/constants/abort-reasons.js';
 import { CertificationReport } from '../../../../../src/certification/shared/domain/models/CertificationReport.js';
 import { pickAnswerStatusService } from '../../../../../src/certification/shared/domain/services/pick-answer-status-service.js';
 import { FRENCH_SPOKEN } from '../../../../../src/shared/domain/services/locale-service.js';

--- a/api/src/certification/evaluation/domain/models/AssessmentSheet.js
+++ b/api/src/certification/evaluation/domain/models/AssessmentSheet.js
@@ -6,11 +6,7 @@ import Joi from 'joi';
 
 import { Answer } from '../../../../evaluation/domain/models/Answer.js';
 import { EntityValidationError } from '../../../../shared/domain/errors.js';
-
-export const ABORT_REASONS = {
-  CANDIDATE: 'candidate',
-  TECHNICAL: 'technical',
-};
+import { ABORT_REASONS } from '../../../shared/domain/constants/abort-reasons.js';
 
 export class AssessmentSheet {
   /**

--- a/api/src/certification/evaluation/domain/models/CertificationAssessmentScoreV3.js
+++ b/api/src/certification/evaluation/domain/models/CertificationAssessmentScoreV3.js
@@ -12,7 +12,7 @@ import { COMPETENCES_COUNT, PIX_COUNT_BY_LEVEL } from '../../../../shared/domain
 import { status as CertificationStatus } from '../../../../shared/domain/models/AssessmentResult.js';
 import { meshConfiguration } from '../../../results/domain/models/v3/MeshConfiguration.js';
 import { Intervals } from '../../../scoring/domain/models/Intervals.js';
-import { ABORT_REASONS } from '../../../shared/domain/models/CertificationCourse.js';
+import { ABORT_REASONS } from '../../../shared/domain/constants/abort-reasons.js';
 
 export class CertificationAssessmentScoreV3 {
   /**

--- a/api/src/certification/session-management/application/certification-report-route.js
+++ b/api/src/certification/session-management/application/certification-report-route.js
@@ -3,7 +3,7 @@ import Joi from 'joi';
 import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
 import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
 import { authorization } from '../../shared/application/pre-handlers/authorization.js';
-import { ABORT_REASONS } from '../../shared/domain/models/CertificationCourse.js';
+import { ABORT_REASONS } from '../../shared/domain/constants/abort-reasons.js';
 import { certificationReportController } from './certification-report-controller.js';
 
 const register = async function (server) {

--- a/api/src/certification/shared/domain/constants/abort-reasons.js
+++ b/api/src/certification/shared/domain/constants/abort-reasons.js
@@ -1,0 +1,4 @@
+export const ABORT_REASONS = {
+  CANDIDATE: 'candidate',
+  TECHNICAL: 'technical',
+};

--- a/api/src/certification/shared/domain/models/CertificationCourse.js
+++ b/api/src/certification/shared/domain/models/CertificationCourse.js
@@ -10,14 +10,10 @@ import BaseJoi from 'joi';
 import _ from 'lodash';
 
 import { EntityValidationError } from '../../../../shared/domain/errors.js';
+import { ABORT_REASONS } from '../constants/abort-reasons.js';
 import { AlgorithmEngineVersion } from './AlgorithmEngineVersion.js';
 
 const Joi = BaseJoi.extend(JoiDate);
-
-export const ABORT_REASONS = {
-  CANDIDATE: 'candidate',
-  TECHNICAL: 'technical',
-};
 
 const V3_CERTIFICATION_AVAILABLE_LANGUAGES = ['fr', 'en'];
 

--- a/api/tests/certification/evaluation/unit/domain/models/AssessmentSheet_test.js
+++ b/api/tests/certification/evaluation/unit/domain/models/AssessmentSheet_test.js
@@ -1,4 +1,4 @@
-import { ABORT_REASONS } from '../../../../../../src/certification/evaluation/domain/models/AssessmentSheet.js';
+import { ABORT_REASONS } from '../../../../../../src/certification/shared/domain/constants/abort-reasons.js';
 import { domainBuilder, expect } from '../../../../../test-helper.js';
 
 describe('Unit | Certification | Evaluation | Domain | Models | AssessmentSheet', function () {

--- a/api/tests/certification/evaluation/unit/domain/services/scoring/scoring-v2_test.js
+++ b/api/tests/certification/evaluation/unit/domain/services/scoring/scoring-v2_test.js
@@ -8,8 +8,8 @@ import {
   handleV2CertificationScoring,
 } from '../../../../../../../src/certification/evaluation/domain/services/scoring/scoring-v2.js';
 import { CertificationAssessment } from '../../../../../../../src/certification/session-management/domain/models/CertificationAssessment.js';
+import { ABORT_REASONS } from '../../../../../../../src/certification/shared/domain/constants/abort-reasons.js';
 import { AlgorithmEngineVersion } from '../../../../../../../src/certification/shared/domain/models/AlgorithmEngineVersion.js';
-import { ABORT_REASONS } from '../../../../../../../src/certification/shared/domain/models/CertificationCourse.js';
 import { AutoJuryCommentKeys } from '../../../../../../../src/certification/shared/domain/models/JuryComment.js';
 import * as scoringService from '../../../../../../../src/evaluation/domain/services/scoring/scoring-service.js';
 import CertificationCancelled from '../../../../../../../src/shared/domain/events/CertificationCancelled.js';

--- a/api/tests/certification/session-management/integration/domain/usecases/finalize-session_test.js
+++ b/api/tests/certification/session-management/integration/domain/usecases/finalize-session_test.js
@@ -1,6 +1,6 @@
 import { SessionWithAbortReasonOnCompletedCertificationCourseError } from '../../../../../../src/certification/session-management/domain/errors.js';
 import { usecases } from '../../../../../../src/certification/session-management/domain/usecases/index.js';
-import { ABORT_REASONS } from '../../../../../../src/certification/shared/domain/models/CertificationCourse.js';
+import { ABORT_REASONS } from '../../../../../../src/certification/shared/domain/constants/abort-reasons.js';
 import { DomainTransaction } from '../../../../../../src/shared/domain/DomainTransaction.js';
 import { catchErr, databaseBuilder, domainBuilder, expect, knex } from '../../../../../test-helper.js';
 

--- a/api/tests/certification/session-management/integration/infrastructure/repositories/v3-certification-course-details-for-administration-repository_test.js
+++ b/api/tests/certification/session-management/integration/infrastructure/repositories/v3-certification-course-details-for-administration-repository_test.js
@@ -1,5 +1,5 @@
 import * as v3CertificationCourseDetailsForAdministrationRepository from '../../../../../../src/certification/session-management/infrastructure/repositories/v3-certification-course-details-for-administration-repository.js';
-import { ABORT_REASONS } from '../../../../../../src/certification/shared/domain/models/CertificationCourse.js';
+import { ABORT_REASONS } from '../../../../../../src/certification/shared/domain/constants/abort-reasons.js';
 import {
   CertificationIssueReportCategory,
   CertificationIssueReportSubcategories,

--- a/api/tests/certification/session-management/unit/application/certification-report-route_test.js
+++ b/api/tests/certification/session-management/unit/application/certification-report-route_test.js
@@ -1,7 +1,7 @@
 import { certificationReportController } from '../../../../../src/certification/session-management/application/certification-report-controller.js';
 import * as moduleUnderTest from '../../../../../src/certification/session-management/application/certification-report-route.js';
 import { authorization } from '../../../../../src/certification/shared/application/pre-handlers/authorization.js';
-import { ABORT_REASONS } from '../../../../../src/certification/shared/domain/models/CertificationCourse.js';
+import { ABORT_REASONS } from '../../../../../src/certification/shared/domain/constants/abort-reasons.js';
 import { NotFoundError } from '../../../../../src/shared/application/http-errors.js';
 import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
 import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';

--- a/api/tests/certification/session-management/unit/domain/usecases/process-auto-jury_test.js
+++ b/api/tests/certification/session-management/unit/domain/usecases/process-auto-jury_test.js
@@ -1,8 +1,8 @@
 import { CertificationJuryDone } from '../../../../../../src/certification/session-management/domain/events/CertificationJuryDone.js';
 import { SessionFinalized } from '../../../../../../src/certification/session-management/domain/read-models/SessionFinalized.js';
 import { processAutoJury } from '../../../../../../src/certification/session-management/domain/usecases/process-auto-jury.js';
+import { ABORT_REASONS } from '../../../../../../src/certification/shared/domain/constants/abort-reasons.js';
 import { AlgorithmEngineVersion } from '../../../../../../src/certification/shared/domain/models/AlgorithmEngineVersion.js';
-import { ABORT_REASONS } from '../../../../../../src/certification/shared/domain/models/CertificationCourse.js';
 import {
   CertificationIssueReportCategory,
   CertificationIssueReportSubcategories,

--- a/api/tests/certification/session-management/unit/infrastructure/serializers/v3-certification-course-details-for-administration-serializer_test.js
+++ b/api/tests/certification/session-management/unit/infrastructure/serializers/v3-certification-course-details-for-administration-serializer_test.js
@@ -2,7 +2,7 @@ import { V3CertificationChallengeForAdministration } from '../../../../../../src
 import { V3CertificationChallengeLiveAlertForAdministration } from '../../../../../../src/certification/session-management/domain/models/V3CertificationChallengeLiveAlertForAdministration.js';
 import { V3CertificationCourseDetailsForAdministration } from '../../../../../../src/certification/session-management/domain/models/V3CertificationCourseDetailsForAdministration.js';
 import * as serializer from '../../../../../../src/certification/session-management/infrastructure/serializers/v3-certification-course-details-for-administration-serializer.js';
-import { ABORT_REASONS } from '../../../../../../src/certification/shared/domain/models/CertificationCourse.js';
+import { ABORT_REASONS } from '../../../../../../src/certification/shared/domain/constants/abort-reasons.js';
 import { AnswerStatus } from '../../../../../../src/shared/domain/models/AnswerStatus.js';
 import { Assessment } from '../../../../../../src/shared/domain/models/Assessment.js';
 import { AssessmentResult } from '../../../../../../src/shared/domain/models/AssessmentResult.js';

--- a/api/tests/evaluation/unit/domain/models/CertificationAssessmentScoreV3_test.js
+++ b/api/tests/evaluation/unit/domain/models/CertificationAssessmentScoreV3_test.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 
 import { CertificationAssessmentScoreV3 } from '../../../../../src/certification/evaluation/domain/models/CertificationAssessmentScoreV3.js';
-import { ABORT_REASONS } from '../../../../../src/certification/shared/domain/models/CertificationCourse.js';
+import { ABORT_REASONS } from '../../../../../src/certification/shared/domain/constants/abort-reasons.js';
 import { config } from '../../../../../src/shared/config.js';
 import { AnswerStatus } from '../../../../../src/shared/domain/models/AnswerStatus.js';
 import { status } from '../../../../../src/shared/domain/models/AssessmentResult.js';


### PR DESCRIPTION
## ❄️ Problème

La constante `ABORT_REASON` était définie utilisé à plusieurs endroit du code et défini dans deux modèle différents

## 🛷 Proposition

Créer une constante dans le dossier partagé de certification

## ☃️ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🧑‍🎄 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
