### PR TITLE
[BUGFIX] Changement de condition pour déclarer reuseExistingApps

### DIFF
--- a/high-level-tests/e2e-playwright/playwright.config.shared.ts
+++ b/high-level-tests/e2e-playwright/playwright.config.shared.ts
@@ -7,7 +7,7 @@ const playwrightFolder = './node_modules/.playwright';
 
 export const isCI = Boolean(process.env.CI);
 if (!isCI) dotenv.config({ path: path.resolve(import.meta.dirname, '.env.e2e') });
-export const reuseExistingApps = Boolean(process.env.REUSE_EXISTING_APPS);
+export const reuseExistingApps = process.env.REUSE_EXISTING_APPS === 'true';
 
 // See https://playwright.dev/docs/test-configuration
 export default defineConfig({


### PR DESCRIPTION
## ❄️ Problème

La ligne suivante affecte systématiquement la valeur `true`à la variable `reuseExistingApps` dans le fichier de configuration shared de playwright : 
`export const reuseExistingApps = Boolean(process.env.REUSE_EXISTING_APPS);`

## 🛷 Proposition

Modifier la condition de déclaration.

## 🧑‍🎄 Pour tester

Localement, les tests e2e se lancent.
