### PR TITLE
[TECH] Remettre certaines dependences de l'API

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -60,10 +60,10 @@
         "papaparse": "^5.3.2",
         "pdf-lib": "^1.17.1",
         "pdfkit": "^0.17.0",
-        "pg": "^8.7.3",
+        "pg": "^8.16.3",
         "pg-boss": "^9.0.0",
         "pg-query-stream": "^4.7.3",
-        "pino": "^10.0.0",
+        "pino": "^10.1.0",
         "pino-pretty": "^13.0.0",
         "prom-client": "^15.1.3",
         "randomstring": "^1.2.2",
@@ -1279,32 +1279,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/Borewit"
       }
-    },
-    "node_modules/@datadog/datadog-api-client": {
-      "version": "1.51.0",
-      "resolved": "https://registry.npmjs.org/@datadog/datadog-api-client/-/datadog-api-client-1.51.0.tgz",
-      "integrity": "sha512-y8Qh9TJCj1KFXqc/E7379LBAdybUqDlYA5+O+/CmR5RTi+5Ct5orX2QWwVZYlSsnUrFTbcJd31e1UDurkvlfIQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/buffer-from": "^1.1.0",
-        "@types/node": "*",
-        "@types/pako": "^1.0.3",
-        "buffer-from": "^1.1.2",
-        "cross-fetch": "^3.1.5",
-        "es6-promise": "^4.2.8",
-        "form-data": "^4.0.4",
-        "loglevel": "^1.8.1",
-        "pako": "^2.0.4"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@datadog/datadog-api-client/node_modules/pako": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
-      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
-      "license": "(MIT AND Zlib)"
     },
     "node_modules/@electric-sql/pglite": {
       "version": "0.3.15",
@@ -5043,6 +5017,32 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/datadog-metrics/node_modules/@datadog/datadog-api-client": {
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/@datadog/datadog-api-client/-/datadog-api-client-1.49.0.tgz",
+      "integrity": "sha512-ybHGk8nZoxxFShk+VQOvPVOk232afe4Qf3dRIXkDhYqUTrIJQsaOphwMVTmi02b3t/ST2TkdOq0WlIJpvFj5Tw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/buffer-from": "^1.1.0",
+        "@types/node": "*",
+        "@types/pako": "^1.0.3",
+        "buffer-from": "^1.1.2",
+        "cross-fetch": "^3.1.5",
+        "es6-promise": "^4.2.8",
+        "form-data": "^4.0.4",
+        "loglevel": "^1.8.1",
+        "pako": "^2.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/datadog-metrics/node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/dataloader": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.2.3.tgz",
@@ -6000,6 +6000,39 @@
       "engines": {
         "node": ">=16.0.0"
       }
+    },
+    "node_modules/extract-pg-schema/node_modules/pg": {
+      "version": "8.17.2",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.17.2.tgz",
+      "integrity": "sha512-vjbKdiBJRqzcYw1fNU5KuHyYvdJ1qpcQg1CeBrHFqV1pWgHeVR6j/+kX0E1AAXfyuLUGY1ICrN2ELKA/z2HWzw==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.10.1",
+        "pg-pool": "^3.11.0",
+        "pg-protocol": "^1.11.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.3.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/extract-pg-schema/node_modules/pg-connection-string": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.10.1.tgz",
+      "integrity": "sha512-iNzslsoeSH2/gmDDKiyMqF64DATUCWj3YJ0wP14kqcsf2TUklwimd+66yYojKwZCA7h2yRNLGug71hCBA2a4sw==",
+      "license": "MIT"
     },
     "node_modules/fast-copy": {
       "version": "4.0.2",
@@ -9114,15 +9147,15 @@
       }
     },
     "node_modules/pg": {
-      "version": "8.17.2",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-8.17.2.tgz",
-      "integrity": "sha512-vjbKdiBJRqzcYw1fNU5KuHyYvdJ1qpcQg1CeBrHFqV1pWgHeVR6j/+kX0E1AAXfyuLUGY1ICrN2ELKA/z2HWzw==",
+      "version": "8.16.3",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
+      "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "pg-connection-string": "^2.10.1",
-        "pg-pool": "^3.11.0",
-        "pg-protocol": "^1.11.0",
+        "pg-connection-string": "^2.9.1",
+        "pg-pool": "^3.10.1",
+        "pg-protocol": "^1.10.3",
         "pg-types": "2.2.0",
         "pgpass": "1.0.5"
       },
@@ -9130,7 +9163,7 @@
         "node": ">= 16.0.0"
       },
       "optionalDependencies": {
-        "pg-cloudflare": "^1.3.0"
+        "pg-cloudflare": "^1.2.7"
       },
       "peerDependencies": {
         "pg-native": ">=3.0.1"
@@ -9300,22 +9333,22 @@
       }
     },
     "node_modules/pino": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-10.2.1.tgz",
-      "integrity": "sha512-Tjyv76gdUe2460dEhtcnA4fU/+HhGq2Kr7OWlo2R/Xxbmn/ZNKWavNWTD2k97IE+s755iVU7WcaOEIl+H3cq8w==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-10.1.0.tgz",
+      "integrity": "sha512-0zZC2ygfdqvqK8zJIr1e+wT1T/L+LF6qvqvbzEQ6tiMAoTqEVK9a1K3YRu8HEUvGEvNqZyPJTtb2sNIoTkB83w==",
       "license": "MIT",
       "dependencies": {
         "@pinojs/redact": "^0.4.0",
         "atomic-sleep": "^1.0.0",
         "on-exit-leak-free": "^2.1.0",
-        "pino-abstract-transport": "^3.0.0",
+        "pino-abstract-transport": "^2.0.0",
         "pino-std-serializers": "^7.0.0",
         "process-warning": "^5.0.0",
         "quick-format-unescaped": "^4.0.3",
         "real-require": "^0.2.0",
         "safe-stable-stringify": "^2.3.1",
         "sonic-boom": "^4.0.1",
-        "thread-stream": "^4.0.0"
+        "thread-stream": "^3.0.0"
       },
       "bin": {
         "pino": "bin.js"
@@ -9371,6 +9404,15 @@
       "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
       "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
       "license": "MIT"
+    },
+    "node_modules/pino/node_modules/pino-abstract-transport": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
     },
     "node_modules/plur": {
       "version": "2.1.2",
@@ -10867,15 +10909,12 @@
       "license": "MIT"
     },
     "node_modules/thread-stream": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.0.0.tgz",
-      "integrity": "sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
+      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
       "license": "MIT",
       "dependencies": {
         "real-require": "^0.2.0"
-      },
-      "engines": {
-        "node": ">=20"
       }
     },
     "node_modules/tildify": {

--- a/api/package.json
+++ b/api/package.json
@@ -66,10 +66,10 @@
     "papaparse": "^5.3.2",
     "pdf-lib": "^1.17.1",
     "pdfkit": "^0.17.0",
-    "pg": "^8.7.3",
+    "pg": "^8.16.3",
     "pg-boss": "^9.0.0",
     "pg-query-stream": "^4.7.3",
-    "pino": "^10.0.0",
+    "pino": "^10.1.0",
     "pino-pretty": "^13.0.0",
     "prom-client": "^15.1.3",
     "randomstring": "^1.2.2",
@@ -119,7 +119,8 @@
     "stream-to-promise": "^3.0.0"
   },
   "overrides": {
-    "chai": "^6.0.0"
+    "chai": "^6.0.0",
+    "@datadog/datadog-api-client": "1.49.0"
   },
   "scripts": {
     "clean": "rm -rf node_modules",


### PR DESCRIPTION
### Problème

Suite à la mise à jour du package lock par renovate, on a des dépendances mise à jour qui peuvent poser des soucis en prod.

### Changement

Revert leur mise à jour pour voir si ça corrige : 
- `"pg":  "^8.17.2" => "^8.16.3"`
- `"pino": "^10.2.1" => "^10.1.0"`

Override de `"@datadog/datadog-api-client": "1.49.0"` au lieu de `1.51.0`

**Les modifications sont visibles dans le `package-lock.json`**