### PR TITLE
[FEATURE] Centrer les légendes des éléments images (PIX-21199)

### DIFF
--- a/mon-pix/app/components/module/element/_image.scss
+++ b/mon-pix/app/components/module/element/_image.scss
@@ -20,6 +20,7 @@
 
     margin-top: var(--pix-spacing-1x);
     color: rgb(var(--pix-neutral-800-inline), 0.9);
+    text-align: center;
   }
 
   &__licence {


### PR DESCRIPTION
## ❄️ Problème
Les légendes des éléments de type `image` des modules sont alignées à gauche. Or, nous souhaitons les centrer.

## 🛷 Proposition
Le faire.

## ☃️ Remarques
Une légende à gauche peut être reçue sur le podcast du même nom, mais cela force l'oxymore.

## 🧑‍🎄 Pour tester
- aller sur [la galerie](https://app-pr14921.review.pix.fr/modules/galerie)
- aller sur l'élément image (cliquer 8 fois sur "Continuer", et 1 fois sur "Passer l'activité")
- vérifier que sur tous les formats (desktop, tablette, mobile), le texte est bien centré.
