### PR TITLE
[TECH] Mise à jour de liens cassés sur Pix Certif (PIX-21279)

### DIFF
--- a/certif/app/services/url.js
+++ b/certif/app/services/url.js
@@ -29,10 +29,10 @@ export default class Url extends UrlBaseService {
 
   get joiningIssueSheetUrl() {
     if (this.locale.currentLanguage === 'fr') {
-      return 'https://cloud.pix.fr/s/b8BFXX94Ys2WGxM/download/Probl%C3%A8mes%20d%27acc%C3%A8s%20en%20session.pdf';
+      return 'https://cloud.pix.fr/s/QcKnpcTya5iWF5C';
     }
 
-    return 'https://cloud.pix.fr/s/JmBn2q5rpzgrjxN/download';
+    return 'https://cloud.pix.fr/s/aZRMYipSLREiBXP';
   }
 
   get documentationUrl() {
@@ -59,6 +59,10 @@ export default class Url extends UrlBaseService {
   }
 
   get invigilatorDocumentationUrl() {
-    return 'https://cloud.pix.fr/s/s4H9x4PD4eKokqX';
+    if (this.locale.currentLanguage === 'fr') {
+      return 'https://cloud.pix.fr/s/8xB82zdPKYSZzaM';
+    }
+
+    return 'https://cloud.pix.fr/s/Mfd2ggwGHwmprA4';
   }
 }

--- a/certif/tests/integration/components/session-supervising/header-test.js
+++ b/certif/tests/integration/components/session-supervising/header-test.js
@@ -179,6 +179,6 @@ module('Integration | Component | SessionSupervising::Header', function (hooks) 
           name: 'Documentation sur la gestion des signalements Ouverture dans une nouvelle fenêtre',
         }),
       )
-      .hasAttribute('href', 'https://cloud.pix.fr/s/s4H9x4PD4eKokqX');
+      .hasAttribute('href', 'https://cloud.pix.fr/s/8xB82zdPKYSZzaM');
   });
 });

--- a/certif/tests/unit/services/url-test.js
+++ b/certif/tests/unit/services/url-test.js
@@ -141,7 +141,7 @@ module('Unit | Service | url', function (hooks) {
       const invigilatorDocumentationUrl = service.invigilatorDocumentationUrl;
 
       // then
-      assert.strictEqual(invigilatorDocumentationUrl, 'https://cloud.pix.fr/s/s4H9x4PD4eKokqX');
+      assert.strictEqual(invigilatorDocumentationUrl, 'https://cloud.pix.fr/s/8xB82zdPKYSZzaM');
     });
   });
 


### PR DESCRIPTION
## ❄️ Problème

Suite à notre incident sur le cloud on a quelques fichiers qui ont disparus.

Deux nouveaux fichiers ont disparu : 
- “Documentation sur la gestion des signalements” dans le bandeau bleu de l’espace surveillant
- Le document pour aider à résoudre les problèmes de connexion disponible dans l'étape de finalisation d’une session dans Pix Certif, lorsqu'on coche "Un ou plusieurs candidats étaient présents en session de certification mais n'ont pas pu rejoindre la session."

## 🛷 Proposition

Mettre à jour ces liens avec de nouveaux liens fournis par le métier

## ☃️ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🧑‍🎄 Pour tester

Créer une session, vérifier que le lien dans l'espace surveillant fonctionne, puis finaliser, cocher "Un ou plusieurs candidats étaient présents en session de certification mais n'ont pas pu rejoindre la session." et tester le lien de la documentation.
