### PR TITLE
[FEATURE] Créer la table "organization_learner_types" (PIX-21213)

### DIFF
--- a/api/db/migrations/20260129133349_create-organization-learner-types-table.js
+++ b/api/db/migrations/20260129133349_create-organization-learner-types-table.js
@@ -1,0 +1,22 @@
+const TABLE_NAME = 'organization_learner_types';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.createTable(TABLE_NAME, function (table) {
+    table.increments('id').primary();
+    table.string('name').notNullable().comment("Name of the organization learner's type");
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.dropTable(TABLE_NAME);
+};
+
+export { down, up };


### PR DESCRIPTION
## ❄️ Problème

Sur chaque organisation, on souhaite pouvoir ajouter l'information du type de public prescrit (Élèves, Ensignants, Salariés...).

## 🛷 Proposition

Dans un premier temps, créer une nouvelle table en base de données contenant les différents types de public prescrit possibles. On pourra y faire référence plus tard.

## ☃️ Remarques
RAS