### PR TITLE
[FEATURE] Création d'un job de suppression des conversations avec le LLM âgées de plus de N jours (PIX-21105)

### DIFF
--- a/api/db/database-builder/factory/index.js
+++ b/api/db/database-builder/factory/index.js
@@ -6,6 +6,7 @@ import * as buildDataProtectionOfficer from './build-data-protection-officer.js'
 import * as campaignParticipationOverviewFactory from './campaign-participation-overview-factory.js';
 import * as knowledgeElementSnapshotFactory from './knowledge-elements-snapshot-factory.js';
 import * as learningContent from './learning-content/index.js';
+import * as llm from './llm/index.js';
 import * as poleEmploiSendingFactory from './pole-emploi-sending-factory.js';
 
 const path = dirname(fileURLToPath(import.meta.url));
@@ -49,4 +50,5 @@ export const factory = {
   poleEmploiSendingFactory,
   buildDataProtectionOfficer,
   learningContent,
+  llm,
 };

--- a/api/db/database-builder/factory/llm/build-chat-message.js
+++ b/api/db/database-builder/factory/llm/build-chat-message.js
@@ -1,4 +1,4 @@
-import { databaseBuffer } from '../database-buffer.js';
+import { databaseBuffer } from '../../database-buffer.js';
 import { buildChat } from './build-chat.js';
 
 const TABLE_NAME = 'chat_messages';

--- a/api/db/database-builder/factory/llm/build-chat.js
+++ b/api/db/database-builder/factory/llm/build-chat.js
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto';
 
-import { databaseBuffer } from '../database-buffer.js';
+import { databaseBuffer } from '../../database-buffer.js';
 
 const TABLE_NAME = 'chats';
 

--- a/api/db/database-builder/factory/llm/index.js
+++ b/api/db/database-builder/factory/llm/index.js
@@ -1,0 +1,2 @@
+export * from './build-chat.js';
+export * from './build-chat-message.js';

--- a/api/sample.env
+++ b/api/sample.env
@@ -464,6 +464,30 @@ LCMS_API_RELEASE_ID=
 ## default: none
 ## LLM_API_JWT_SECRET=
 
+# Chats deletion job's max chat lifespan (in days)
+# Chats that are older than this lifespan will be deleted.
+#
+# presence: required
+# type: Number
+# default: 80
+# LLM_DELETE_CHATS_JOB_LIFESPAN=
+
+# Chats deletion job's CRON expression
+# By default, launches every day at 7pm
+#
+# presence: required
+# type: String (CRON)
+# default: '0 19 * * *'
+# LLM_DELETE_CHATS_JOB_CRON=
+
+# Whether or not to run the chat deletion job in dry run mode
+# If true, no chats will actually be deleted.
+#
+# presence: required
+# type: Boolean
+# default: true
+# LLM_DELETE_CHATS_JOB_DRY_RUN=
+
 # =======
 # LOGGING
 # =======
@@ -1164,4 +1188,3 @@ EMAIL_VALIDATION_DEMAND_TEMPORARY_STORAGE_LIFESPAN=3d
 # type: Integer
 # default: 4
 DAY_BEFORE_RETRYING=
-

--- a/api/src/llm/application/jobs/delete-expired-chats-job-controller.js
+++ b/api/src/llm/application/jobs/delete-expired-chats-job-controller.js
@@ -1,0 +1,98 @@
+import { JobScheduleController } from '../../../shared/application/jobs/job-schedule-controller.js';
+import { config } from '../../../shared/config.js';
+import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
+import { child, SCOPES } from '../../../shared/infrastructure/utils/logger.js';
+
+const logger = child('llm:delete-expired-chats-job', { event: SCOPES.LLM });
+
+class DeleteExpiredChatsJobController extends JobScheduleController {
+  constructor() {
+    super('DeleteExpiredChatsJob', {
+      jobCron: config.llm.deleteChatsJob.cron,
+    });
+  }
+
+  async handle({ dependencies = { config, logger } }) {
+    const { lifespan, dryRun } = dependencies.config.llm.deleteChatsJob;
+
+    if (dryRun) {
+      dependencies.logger.info(
+        'DeleteExpiredChatsJobHandler - Starting script in dry run mode. No chats will actually be deleted.',
+      );
+    }
+
+    const today = new Date();
+    const cutoffDate = new Date();
+    cutoffDate.setDate(today.getDate() - lifespan);
+
+    dependencies.logger.info(`About to delete chats started before ${cutoffDate.toISOString()}`);
+
+    await DomainTransaction.execute(async () => {
+      const trx = DomainTransaction.getConnection();
+      try {
+        const [{ allChatsCount }] = await trx('chats').count('*', { as: 'allChatsCount' });
+        const chatsToBeDeleted = await trx('chats').where('startedAt', '<', cutoffDate);
+        const chatIdsToDelete = chatsToBeDeleted.map(({ id }) => id);
+
+        const [{ allChatMessagesCount }] = await trx('chat_messages').count('*', { as: 'allChatMessagesCount' });
+        const chatMessagesToBeDeleted = await trx('chat_messages').whereIn('chatId', chatIdsToDelete);
+
+        if (dryRun) {
+          logger.info(`${chatsToBeDeleted.length} chat(s) would have been deleted (out of ${allChatsCount})`);
+          logger.info(
+            `${chatMessagesToBeDeleted.length} chat message(s) would have been deleted (out of ${allChatMessagesCount})`,
+          );
+          throw new Error('dryRun is true');
+        }
+
+        const deletedChatMessages = await trx('chat_messages')
+          .whereIn('chatId', chatIdsToDelete)
+          .delete()
+          .returning('id');
+        const deletedChatMessageIds = deletedChatMessages.map(({ id }) => id);
+        logger.debug({
+          deletedChatMessageIds,
+          count: deletedChatMessages.length,
+        });
+
+        const expectedRemainingChatMessagesCount = allChatMessagesCount - chatMessagesToBeDeleted.length;
+        const actualRemaningChatMessagesCount = allChatMessagesCount - deletedChatMessages.length;
+        logger.info(`Number of expected remaining chat messages: ${expectedRemainingChatMessagesCount}`);
+        logger.info(`Number of remaining chat messages: ${actualRemaningChatMessagesCount}`);
+        if (expectedRemainingChatMessagesCount !== actualRemaningChatMessagesCount) {
+          const leftoverChatMessageIds = await trx('chats_messages').select('id').whereIn('chatId', chatIdsToDelete);
+          logger.error({
+            msg: `Number of actual remaining chats (${actualRemainingChatsCount}) does not match number of expected remaining chat (${expectedRemainingChatsCount}}).`,
+            leftoverChatMessageIds,
+            deletedChatMessageIds,
+          });
+        }
+
+        const deletedChats = await trx('chats').where('startedAt', '<', cutoffDate).delete().returning('id');
+        const deletedChatIds = deletedChats.map(({ id }) => id);
+        logger.debug({
+          deletedChatIds,
+          count: deletedChats.length,
+        });
+
+        const expectedRemainingChatsCount = allChatsCount - chatsToBeDeleted.length;
+        const actualRemainingChatsCount = allChatsCount - deletedChats.length;
+        logger.info(`Number of expected remaining chats: ${expectedRemainingChatsCount}`);
+        logger.info(`Number of actual remaining chats: ${actualRemainingChatsCount}`);
+        if (expectedRemainingChatsCount !== actualRemainingChatsCount) {
+          const leftoverChatIds = await trx('chats').select('id').where('startedAt', '<', cutoffDate);
+          logger.error({
+            msg: `Number of actual remaining chats (${actualRemainingChatsCount}) does not match number of expected remaining chat (${expectedRemainingChatsCount}}).`,
+            leftoverChatIds,
+            deletedChatIds,
+          });
+        }
+      } catch (error) {
+        logger.error({ err: error, msg: 'Error during job execution, starting rollback...' });
+        throw error;
+      }
+    });
+  }
+}
+
+export { DeleteExpiredChatsJobController };

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -19,6 +19,11 @@ function toBoolean(environmentVariable) {
   return environmentVariable === 'true';
 }
 
+/**
+ * @template T
+ * @param {string=} numberAsString
+ * @param {T} defaultValue
+ */
 function _getNumber(numberAsString, defaultValue) {
   const number = parseInt(numberAsString, 10);
   return isNaN(number) ? defaultValue : number;

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -144,6 +144,9 @@ const schema = Joi.object({
   LCMS_API_RELEASE_ID: Joi.any(),
   LLM_API_GET_CONFIGURATIONS_URL: Joi.string().optional(),
   LLM_CHAT_TEMPORARY_STORAGE_EXP_DELAY_SECONDS: Joi.string().optional(),
+  LLM_DELETE_CHATS_JOB_LIFESPAN: Joi.number().min(0).optional(),
+  LLM_DELETE_CHATS_JOB_DRY_RUN: Joi.string().optional().valid('true', 'false'),
+  LLM_DELETE_CHATS_JOB_CRON: Joi.string().optional(),
   LOG_ENABLED: Joi.string().required().valid('true', 'false'),
   LOG_FOR_HUMANS: Joi.string().optional().valid('true', 'false'),
   LOG_LEVEL: Joi.string().optional().valid('silent', 'fatal', 'error', 'warn', 'info', 'debug', 'trace'),
@@ -345,6 +348,11 @@ const configuration = (function () {
       getConfigurationUrl: _removeTrailingSlashFromUrl(process.env.LLM_API_GET_CONFIGURATIONS_URL ?? ''),
       postPromptUrl: _removeTrailingSlashFromUrl(process.env.LLM_API_POST_PROMPT_URL ?? ''),
       authSecret: process.env.LLM_API_JWT_SECRET,
+      deleteChatsJob: {
+        lifespan: _getNumber(process.env.LLM_DELETE_CHATS_JOB_LIFESPAN, 80),
+        cron: process.env.LLM_DELETE_CHATS_JOB_CRON || '0 19 * * *',
+        dryRun: toBoolean(process.env.LLM_DELETE_CHATS_JOB_DRY_RUN ?? true),
+      },
     },
     logging: {
       enabled: toBoolean(process.env.LOG_ENABLED),

--- a/api/src/shared/domain/DomainTransaction.js
+++ b/api/src/shared/domain/DomainTransaction.js
@@ -2,13 +2,28 @@ import { AsyncLocalStorage } from 'node:async_hooks';
 
 import { knex } from '../../../db/knex-database-connection.js';
 
+/**
+ * @typedef {import('knex').Knex} Knex
+ * @typedef {import('knex').Knex.Transaction} Transaction
+ * @typedef {import('knex').Knex.TransactionConfig} TransactionConfig
+ */
+
 const asyncLocalStorage = new AsyncLocalStorage();
 
 class DomainTransaction {
+  /**
+   * @param {Transaction} knexTransaction
+   */
   constructor(knexTransaction) {
     this.knexTransaction = knexTransaction;
   }
 
+  /**
+   * @template {Function} Lambda
+   * @param {Lambda} lambda
+   * @param {TransactionConfig=} transactionConfig
+   * @returns {ReturnType<Lambda> | Promise<ReturnType<Lambda>>}
+   */
   static execute(lambda, transactionConfig) {
     const existingConn = DomainTransaction.getConnection();
     if (existingConn.isTransaction) {
@@ -28,7 +43,7 @@ class DomainTransaction {
   }
 
   /**
-   * @returns {import('knex').Knex | import('knex').Knex.Transaction}
+   * @returns {Knex | Transaction}
    */
   static getConnection() {
     const store = asyncLocalStorage.getStore();
@@ -46,9 +61,9 @@ class DomainTransaction {
 }
 
 /**
- * @template F
+ * @template {Function} F
  * @param {F} func
- * @param {import('knex').Knex.TransactionConfig=} transactionConfig
+ * @param {TransactionConfig=} transactionConfig
  * @returns {F}
  */
 function withTransaction(func, transactionConfig) {

--- a/api/tests/devcomp/acceptance/application/passages/passage-controller_test.js
+++ b/api/tests/devcomp/acceptance/application/passages/passage-controller_test.js
@@ -391,7 +391,7 @@ describe('Acceptance | Controller | passage-controller', function () {
             configId: chatDTO.configurationId,
             configContent: chatDTO.configuration,
           };
-          await databaseBuilder.factory.buildChat(databaseChat);
+          await databaseBuilder.factory.llm.buildChat(databaseChat);
           await databaseBuilder.commit();
           const promptLlmScope = nock('https://llm-test.pix.fr/api')
             .post('/chat', {

--- a/api/tests/evaluation/acceptance/application/assessments/assessment-controller_test.js
+++ b/api/tests/evaluation/acceptance/application/assessments/assessment-controller_test.js
@@ -878,7 +878,7 @@ describe('Acceptance | Controller | assessment-controller', function () {
             configId: chatDTO.configurationId,
             configContent: chatDTO.configuration,
           };
-          await databaseBuilder.factory.buildChat(databaseChat);
+          await databaseBuilder.factory.llm.buildChat(databaseChat);
           await databaseBuilder.commit();
 
           const promptLlmScope = nock('https://llm-test.pix.fr/api')

--- a/api/tests/llm/acceptance/application/llm-preview-route_test.js
+++ b/api/tests/llm/acceptance/application/llm-preview-route_test.js
@@ -214,7 +214,7 @@ describe('Acceptance | Route | llm-preview', function () {
           },
           messages: [],
         };
-        await databaseBuilder.factory.buildChat(chat);
+        await databaseBuilder.factory.llm.buildChat(chat);
         await databaseBuilder.commit();
 
         // when
@@ -286,9 +286,9 @@ describe('Acceptance | Route | llm-preview', function () {
         totalInputTokens: 2_000,
         totalOutputTokens: 5_000,
       };
-      await databaseBuilder.factory.buildChat(chat);
+      await databaseBuilder.factory.llm.buildChat(chat);
       for (const message of messages) {
-        await databaseBuilder.factory.buildChatMessage(message);
+        await databaseBuilder.factory.llm.buildChatMessage(message);
       }
       await databaseBuilder.commit();
 
@@ -365,7 +365,7 @@ describe('Acceptance | Route | llm-preview', function () {
     context('when chat belongs to a user', function () {
       it('returns a 403 status code', async function () {
         // given
-        await databaseBuilder.factory.buildChat({
+        await databaseBuilder.factory.llm.buildChat({
           id: '123e4567-e89b-12d3-a456-426614174000',
           userId: 123,
           configId: 'some-config-id',
@@ -392,7 +392,7 @@ describe('Acceptance | Route | llm-preview', function () {
 
     it('returns LLM response as stream', async function () {
       // given
-      await databaseBuilder.factory.buildChat({
+      await databaseBuilder.factory.llm.buildChat({
         id: '123e4567-e89b-12d3-a456-426614174000',
         userId: null,
         configId: 'some-config-id',

--- a/api/tests/llm/integration/application/jobs/delete-expired-chats-job-controller_test.js
+++ b/api/tests/llm/integration/application/jobs/delete-expired-chats-job-controller_test.js
@@ -1,0 +1,140 @@
+import { randomUUID } from 'node:crypto';
+
+import { DeleteExpiredChatsJobController } from '../../../../../src/llm/application/jobs/delete-expired-chats-job-controller.js';
+import { JobGroup } from '../../../../../src/shared/application/jobs/job-controller.js';
+import { config } from '../../../../../src/shared/config.js';
+import { databaseBuilder, expect, knex } from '../../../../test-helper.js';
+
+describe('LLM | Integration | Application | Jobs | DeleteExpiredChatsJobController', function () {
+  /** @type {DeleteExpiredChatsJobController} */
+  let jobController;
+
+  beforeEach(function () {
+    jobController = new DeleteExpiredChatsJobController();
+  });
+
+  it('sets up the job controller configuration correctly', async function () {
+    expect(jobController.jobName).to.equal('DeleteExpiredChatsJob');
+    expect(jobController.jobGroup).to.equal(JobGroup.DEFAULT);
+  });
+
+  describe('when dryRun is true', function () {
+    beforeEach(function () {
+      config.llm.deleteChatsJob.dryRun = true;
+      config.llm.deleteChatsJob.lifespan = 10;
+    });
+
+    describe('when there are chats older than given days lifespan', function () {
+      it('should not delete any chats', async function () {
+        // given
+        const firstChatId = randomUUID();
+        databaseBuilder.factory.llm.buildChat({ id: firstChatId, startedAt: new Date('2020-01-01') });
+        databaseBuilder.factory.llm.buildChatMessage({ chatId: firstChatId });
+        await databaseBuilder.commit();
+
+        // when
+        await jobController.handle({});
+        const [{ count: chatsInDb }] = await knex('chats').count();
+        const [{ count: chatMessagesInDb }] = await knex('chat_messages').count();
+
+        // then
+        expect(chatsInDb).to.equal(1);
+        expect(chatMessagesInDb).to.equal(1);
+      });
+    });
+
+    describe('when there are no chats older than given lifespan', function () {
+      it('should not delete any chats', async function () {
+        // given
+        databaseBuilder.factory.llm.buildChatMessage();
+        await databaseBuilder.commit();
+
+        // when
+        await jobController.handle({});
+        const [{ count: chatsInDb }] = await knex('chats').count();
+        const [{ count: chatMessagesInDb }] = await knex('chat_messages').count();
+
+        // then
+        expect(chatsInDb).to.equal(1);
+        expect(chatMessagesInDb).to.equal(1);
+      });
+    });
+  });
+
+  describe('when dryRun is false', function () {
+    beforeEach(function () {
+      config.llm.deleteChatsJob.dryRun = false;
+      config.llm.deleteChatsJob.lifespan = 10;
+    });
+
+    describe('when there are chats older than given days lifespan', function () {
+      it('should delete chats older than that lifespan', async function () {
+        // given
+        const moldyChatId = randomUUID();
+        databaseBuilder.factory.llm.buildChat({ id: moldyChatId, startedAt: new Date('2020-01-01') });
+        databaseBuilder.factory.llm.buildChatMessage({ chatId: moldyChatId });
+
+        const expiredForSureChatId = randomUUID();
+        const expiredForSureChatDate = new Date();
+        expiredForSureChatDate.setDate(expiredForSureChatDate.getDate() - 15);
+        databaseBuilder.factory.llm.buildChat({ id: expiredForSureChatId, startedAt: expiredForSureChatDate });
+        databaseBuilder.factory.llm.buildChatMessage({ chatId: expiredForSureChatId });
+
+        const justExpiredChatId = randomUUID();
+        const justExpiredChatDate = new Date();
+        justExpiredChatDate.setDate(justExpiredChatDate.getDate() - 10);
+        databaseBuilder.factory.llm.buildChat({ id: justExpiredChatId, startedAt: justExpiredChatDate });
+        databaseBuilder.factory.llm.buildChatMessage({ chatId: justExpiredChatId });
+
+        const barelySavedChatId = randomUUID();
+        const barelySavedChatDate = new Date();
+        barelySavedChatDate.setDate(barelySavedChatDate.getDate() - 10);
+        barelySavedChatDate.setHours(barelySavedChatDate.getHours() + 1);
+        databaseBuilder.factory.llm.buildChat({ id: barelySavedChatId, startedAt: barelySavedChatDate });
+        databaseBuilder.factory.llm.buildChatMessage({ chatId: barelySavedChatId });
+
+        const recentChatId = randomUUID();
+        databaseBuilder.factory.llm.buildChat({ id: recentChatId, startedAt: new Date() });
+        databaseBuilder.factory.llm.buildChatMessage({ chatId: recentChatId });
+
+        await databaseBuilder.commit();
+
+        // when
+        await jobController.handle({});
+        const [{ count: chatsInDb }] = await knex('chats').count();
+        const [{ count: chatMessagesInDb }] = await knex('chat_messages').count();
+
+        // then
+        expect(chatsInDb).to.equal(2);
+        expect(chatMessagesInDb).to.equal(2);
+      });
+    });
+
+    describe('when there are no chats older than given lifespan', function () {
+      it('should not delete any chats', async function () {
+        // given
+        const barelySavedChatId = randomUUID();
+        const barelySavedChatDate = new Date();
+        barelySavedChatDate.setDate(barelySavedChatDate.getDate() - 10);
+        barelySavedChatDate.setHours(barelySavedChatDate.getHours() + 1);
+        databaseBuilder.factory.llm.buildChat({ id: barelySavedChatId, startedAt: barelySavedChatDate });
+        databaseBuilder.factory.llm.buildChatMessage({ chatId: barelySavedChatId });
+
+        const recentChatId = randomUUID();
+        databaseBuilder.factory.llm.buildChat({ id: recentChatId, startedAt: new Date() });
+        databaseBuilder.factory.llm.buildChatMessage({ chatId: recentChatId });
+
+        await databaseBuilder.commit();
+
+        // when
+        await jobController.handle({});
+        const [{ count: chatsInDb }] = await knex('chats').count();
+        const [{ count: chatMessagesInDb }] = await knex('chat_messages').count();
+
+        // then
+        expect(chatsInDb).to.equal(2);
+        expect(chatMessagesInDb).to.equal(2);
+      });
+    });
+  });
+});

--- a/api/tests/llm/integration/domain/usecases/prompt-chat_test.js
+++ b/api/tests/llm/integration/domain/usecases/prompt-chat_test.js
@@ -1839,13 +1839,13 @@ function buildBasicAssistantMessage(content, index) {
 }
 
 async function createChat(chatDTO) {
-  databaseBuilder.factory.buildChat({
+  databaseBuilder.factory.llm.buildChat({
     ...chatDTO,
     configId: chatDTO.configurationId,
     configContent: chatDTO.configuration,
   });
   for (const messageDTO of chatDTO.messages) {
-    databaseBuilder.factory.buildChatMessage({
+    databaseBuilder.factory.llm.buildChatMessage({
       ...messageDTO,
       chatId: chatDTO.id,
       wasModerated: messageDTO.wasModerated ?? null,

--- a/api/tests/llm/integration/infrastructure/repositories/chat-repository_test.js
+++ b/api/tests/llm/integration/infrastructure/repositories/chat-repository_test.js
@@ -113,7 +113,7 @@ describe('LLM | Integration | Infrastructure | Repositories | chat', function ()
       let databaseChat;
 
       beforeEach(async function () {
-        databaseChat = databaseBuilder.factory.buildChat();
+        databaseChat = databaseBuilder.factory.llm.buildChat();
         await databaseBuilder.commit();
       });
 
@@ -150,9 +150,9 @@ describe('LLM | Integration | Infrastructure | Repositories | chat', function ()
       let databaseChat, firstDatabaseChatMessage, secondDatabaseChatMessage;
 
       beforeEach(async function () {
-        databaseChat = databaseBuilder.factory.buildChat();
-        firstDatabaseChatMessage = databaseBuilder.factory.buildChatMessage({ chatId: databaseChat.id });
-        secondDatabaseChatMessage = databaseBuilder.factory.buildChatMessage({
+        databaseChat = databaseBuilder.factory.llm.buildChat();
+        firstDatabaseChatMessage = databaseBuilder.factory.llm.buildChatMessage({ chatId: databaseChat.id });
+        secondDatabaseChatMessage = databaseBuilder.factory.llm.buildChatMessage({
           chatId: databaseChat.id,
           index: 1,
           emitter: 'assistant',
@@ -218,7 +218,7 @@ describe('LLM | Integration | Infrastructure | Repositories | chat', function ()
 
     it('should return the Chat model when chat is found', async function () {
       // given
-      const chatId = databaseBuilder.factory.buildChat({
+      const chatId = databaseBuilder.factory.llm.buildChat({
         assessmentId: 123,
         userId: 456,
         challengeId: 'recCHallengeA',
@@ -241,7 +241,7 @@ describe('LLM | Integration | Infrastructure | Repositories | chat', function ()
         totalInputTokens: 1500,
         totalOutputTokens: 2500,
       }).id;
-      databaseBuilder.factory.buildChatMessage({
+      databaseBuilder.factory.llm.buildChatMessage({
         attachmentName: 'attachmentA',
         chatId,
         content: 'Voici le fichier :',
@@ -249,7 +249,7 @@ describe('LLM | Integration | Infrastructure | Repositories | chat', function ()
         index: 0,
         wasModerated: false,
       });
-      databaseBuilder.factory.buildChatMessage({
+      databaseBuilder.factory.llm.buildChatMessage({
         attachmentName: null,
         chatId,
         content: 'Les arc en ciels c super bo',
@@ -257,7 +257,7 @@ describe('LLM | Integration | Infrastructure | Repositories | chat', function ()
         index: 1,
         wasModerated: null,
       });
-      databaseBuilder.factory.buildChatMessage({ content: 'je ne fais pas partie du chat du test !! ' });
+      databaseBuilder.factory.llm.buildChatMessage({ content: 'je ne fais pas partie du chat du test !! ' });
       await databaseBuilder.commit();
 
       // when


### PR DESCRIPTION
## ❄️ Problème

Nous devons supprimer les `chats` et `chat_messages` après 3 mois.

## 🛷 Proposition

Création d'un job qui va, tous les jours, supprimer les conversations âgées de plus de _N_ (`lifespan`) jours.

## ☃️ Remarques

Par défaut, le script s'exécute en _dry run_, et ne supprimera donc rien.

## 🧑‍🎄 Pour tester

- Tests OK ✅
- Insérer des conversations ayant des dates de création (`chats.startedAt`) variées dans la base de données. 
<details>
<summary>Requêtes SQL</summary>

```sql
INSERT INTO chats ("id", "configContent", "startedAt")
VALUES ('a12452eb-e08d-4068-842b-dc901f2b97b0', '{}', '2020-01-01'::timestamptz),
  ('b12452eb-e08d-4068-842b-dc901f2b97b0', '{}', '2026-01-01'::timestamptz),
  ('c12452eb-e08d-4068-842b-dc901f2b97b0', '{}', '2026-01-20'::timestamptz),
  ('d12452eb-e08d-4068-842b-dc901f2b97b0', '{}', '2026-01-29'::timestamptz);
  
INSERT INTO chat_messages ("chatId", "index", "emitter")
VALUES ('a12452eb-e08d-4068-842b-dc901f2b97b0', 0, 'user'),
  ('b12452eb-e08d-4068-842b-dc901f2b97b0', 0, 'user'),
  ('c12452eb-e08d-4068-842b-dc901f2b97b0', 0, 'user'),
  ('d12452eb-e08d-4068-842b-dc901f2b97b0', 0, 'user');
```

</details>

- Renseigner la variable d'environnement `LLM_DELETE_CHATS_JOB_LIFESPAN`.
- Lancer le job manuellement, ou attendre son heure d'exécution programmée (`LLM_DELETE_CHATS_JOB_CRON`).
- Constater que les conversations ayant été créées il y a plus de `lifespan` jours.