### PR TITLE
[FEATURE] Permettre de voir les apprenants qui n'ont pas encore participé à une campagne en filtrant la liste (PIX-17952)

### DIFF
--- a/api/src/prescription/campaign/application/campaign-detail-controller.js
+++ b/api/src/prescription/campaign/application/campaign-detail-controller.js
@@ -1,7 +1,6 @@
 import stream from 'node:stream';
 
 import { escapeFileName, getUserLocale } from '../../../shared/infrastructure/utils/request-response-utils.js';
-import { CampaignParticipationStatuses } from '../../shared/domain/constants.js';
 import { usecases } from '../domain/usecases/index.js';
 import * as campaignDetailsManagementSerializer from '../infrastructure/serializers/jsonapi/campaign-management-serializer.js';
 import * as campaignParticipantsActivitySerializer from '../infrastructure/serializers/jsonapi/campaign-participant-activity-serializer.js';
@@ -9,7 +8,6 @@ import * as campaignReportSerializer from '../infrastructure/serializers/jsonapi
 import * as campaignToJoinSerializer from '../infrastructure/serializers/jsonapi/campaign-to-join-serializer.js';
 import * as targetProfileSerializer from '../infrastructure/serializers/jsonapi/target-profile-serializer.js';
 
-const { TO_SHARE, STARTED, SHARED } = CampaignParticipationStatuses;
 const { PassThrough } = stream;
 
 const getByCode = async function (
@@ -126,15 +124,13 @@ const findParticipantsActivity = async function (
   const { campaignId } = request.params;
 
   const { page, filter: filters } = request.query;
+
+  // TODO Migrate this filters logic in ParticipantActivityFilters model
   if (filters.divisions && !Array.isArray(filters.divisions)) {
     filters.divisions = [filters.divisions];
   }
   if (filters.groups && !Array.isArray(filters.groups)) {
     filters.groups = [filters.groups];
-  }
-  // TODO Remove TO_SHARE status once it's no longer used
-  if (filters.status) {
-    filters.status = filters.status === STARTED ? [STARTED, TO_SHARE] : [SHARED];
   }
 
   const { userId } = request.auth.credentials;

--- a/api/src/prescription/campaign/application/campaign-detail-controller.js
+++ b/api/src/prescription/campaign/application/campaign-detail-controller.js
@@ -138,7 +138,7 @@ const findParticipantsActivity = async function (
   }
 
   const { userId } = request.auth.credentials;
-  const paginatedParticipations = await usecases.findPaginatedCampaignParticipantsActivities({
+  const paginatedParticipations = await usecases.findPaginatedCampaignParticipantActivities({
     userId,
     campaignId,
     page,

--- a/api/src/prescription/campaign/application/campaign-detail-route.js
+++ b/api/src/prescription/campaign/application/campaign-detail-route.js
@@ -185,7 +185,7 @@ const register = async function (server) {
             filter: Joi.object({
               divisions: Joi.array().items(Joi.string()),
               status: Joi.string()
-                .valid(...campaignParticipationStatuses)
+                .valid(...campaignParticipationStatuses, 'NOT_STARTED')
                 .empty(''),
               groups: [Joi.string(), Joi.array().items(Joi.string())],
               search: Joi.string().empty(''),

--- a/api/src/prescription/campaign/domain/read-models/CampaignParticipantActivity.js
+++ b/api/src/prescription/campaign/domain/read-models/CampaignParticipantActivity.js
@@ -2,25 +2,21 @@ import { CampaignParticipationStatuses } from '../../../shared/domain/constants.
 
 class CampaignParticipantActivity {
   constructor({
+    organizationLearnerId,
     campaignParticipationId,
-    userId,
     firstName,
     lastName,
     participantExternalId,
-    sharedAt,
     status,
-    lastCampaignParticipationId,
     participationCount,
   } = {}) {
-    this.campaignParticipationId = campaignParticipationId;
-    this.userId = userId;
+    this.organizationLearnerId = organizationLearnerId;
     this.firstName = firstName;
     this.lastName = lastName;
     this.participantExternalId = participantExternalId;
-    this.sharedAt = sharedAt;
     // TODO Remove TO_SHARE status once it's no longer used
     this.status = status === CampaignParticipationStatuses.TO_SHARE ? CampaignParticipationStatuses.STARTED : status;
-    this.lastCampaignParticipationId = lastCampaignParticipationId || campaignParticipationId;
+    this.lastCampaignParticipationId = campaignParticipationId;
     this.participationCount = participationCount || 0;
   }
 }

--- a/api/src/prescription/campaign/domain/usecases/find-paginated-campaign-participant-activities.js
+++ b/api/src/prescription/campaign/domain/usecases/find-paginated-campaign-participant-activities.js
@@ -1,6 +1,7 @@
+import { withTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { UserNotAuthorizedToAccessEntityError } from '../../../../shared/domain/errors.js';
 
-const findPaginatedCampaignParticipantsActivities = async function ({
+const findPaginatedCampaignParticipantActivities = withTransaction(async function ({
   userId,
   campaignId,
   page,
@@ -9,11 +10,14 @@ const findPaginatedCampaignParticipantsActivities = async function ({
   campaignParticipantActivityRepository,
 }) {
   await _checkUserAccessToCampaign(campaignId, userId, campaignRepository);
+  return campaignParticipantActivityRepository.findPaginatedByCampaignId({
+    page,
+    campaignId,
+    filters,
+  });
+});
 
-  return campaignParticipantActivityRepository.findPaginatedByCampaignId({ page, campaignId, filters });
-};
-
-export { findPaginatedCampaignParticipantsActivities };
+export { findPaginatedCampaignParticipantActivities };
 
 async function _checkUserAccessToCampaign(campaignId, userId, campaignRepository) {
   const hasAccess = await campaignRepository.checkIfUserOrganizationHasAccessToCampaign(campaignId, userId);

--- a/api/src/prescription/campaign/domain/usecases/index.js
+++ b/api/src/prescription/campaign/domain/usecases/index.js
@@ -99,7 +99,7 @@ import { findAssessmentParticipationResultList } from './find-assessment-partici
 import { findCampaignProfilesCollectionParticipationSummaries } from './find-campaign-profiles-collection-participation-summaries.js';
 import { findCampaignSkillIdsForCampaignParticipations } from './find-campaign-skill-ids-for-campaign-participations.js';
 import { findPaginatedCampaignManagements } from './find-paginated-campaign-managements.js';
-import { findPaginatedCampaignParticipantsActivities } from './find-paginated-campaign-participants-activities.js';
+import { findPaginatedCampaignParticipantActivities } from './find-paginated-campaign-participant-activities.js';
 import { findPaginatedFilteredOrganizationCampaigns } from './find-paginated-filtered-organization-campaigns.js';
 import { getCampaign } from './get-campaign.js';
 import { getCampaignByCode } from './get-campaign-by-code.js';
@@ -136,7 +136,7 @@ const usecasesWithoutInjectedDependencies = {
   findCampaignProfilesCollectionParticipationSummaries,
   findCampaignSkillIdsForCampaignParticipations,
   findPaginatedCampaignManagements,
-  findPaginatedCampaignParticipantsActivities,
+  findPaginatedCampaignParticipantActivities,
   findPaginatedFilteredOrganizationCampaigns,
   getCampaignByCode,
   getCampaignManagement,

--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-participant-activity-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-participant-activity-repository.js
@@ -1,28 +1,68 @@
 import { knex } from '../../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { filterByFullName } from '../../../../shared/infrastructure/utils/filter-utils.js';
 import { fetchPage } from '../../../../shared/infrastructure/utils/knex-utils.js';
+import { CampaignParticipationStatuses } from '../../../shared/domain/constants.js';
 import { CampaignParticipantActivity } from '../../domain/read-models/CampaignParticipantActivity.js';
+
+// TODO move to its own model
+export class ParticipantActivityFilters {
+  /** @type string */
+  #status;
+  /** @type string[] */
+  #groups;
+  /** @type string[] */
+  #divisions;
+
+  constructor({ status = null, search = null, groups = [], divisions = [] }) {
+    this.#status = status;
+    this.search = search;
+    this.#groups = groups;
+    this.#divisions = divisions;
+  }
+
+  get participationStatus() {
+    if (this.#status === CampaignParticipationStatuses.STARTED)
+      return [CampaignParticipationStatuses.STARTED, CampaignParticipationStatuses.TO_SHARE];
+
+    if (!this.#status)
+      return [
+        CampaignParticipationStatuses.SHARED,
+        CampaignParticipationStatuses.STARTED,
+        CampaignParticipationStatuses.TO_SHARE,
+      ];
+
+    return [this.#status];
+  }
+
+  get groups() {
+    if (this.#groups.length === 0) return null;
+    return this.#groups?.map((group) => group.toLowerCase().trim());
+  }
+
+  get divisions() {
+    if (this.#divisions.length === 0) return null;
+    return this.#divisions?.map((division) => division.toLowerCase().trim());
+  }
+
+  get showNotStarted() {
+    return this.#status === 'NOT_STARTED';
+  }
+}
 
 const campaignParticipantActivityRepository = {
   async findPaginatedByCampaignId({ page = { size: 25 }, campaignId, filters = {} }) {
-    const query = knex
+    const knexConn = DomainTransaction.getConnection();
+    const activityFilters = new ParticipantActivityFilters(filters);
+
+    const query = knexConn('view-active-organization-learners')
       .select(
-        'campaign-participations.id AS campaignParticipationId',
-        'campaign-participations.userId',
+        'view-active-organization-learners.id AS organizationLearnerId',
         'view-active-organization-learners.firstName',
         'view-active-organization-learners.lastName',
+        'campaign-participations.id AS campaignParticipationId',
         'campaign-participations.participantExternalId',
-        'campaign-participations.sharedAt',
         'campaign-participations.status',
-        'campaigns.type AS campaignType',
-        knex('campaign-participations')
-          .select('id')
-          .whereRaw('"organizationLearnerId" = "view-active-organization-learners"."id"')
-          .and.whereNull('campaign-participations.deletedAt')
-          .and.where('campaignId', campaignId)
-          .orderBy('createdAt', 'desc')
-          .limit(1)
-          .as('lastCampaignParticipationId'),
         knex('campaign-participations')
           .whereRaw('"organizationLearnerId" = "view-active-organization-learners"."id"')
           .and.whereNull('campaign-participations.deletedAt')
@@ -30,21 +70,22 @@ const campaignParticipantActivityRepository = {
           .count('id')
           .as('participationCount'),
       )
-      .from('campaign-participations')
-      .join('campaigns', 'campaigns.id', 'campaign-participations.campaignId')
-      .join(
-        'view-active-organization-learners',
-        'view-active-organization-learners.id',
-        'campaign-participations.organizationLearnerId',
+      .leftJoin('campaign-participations', function () {
+        this.on('campaign-participations.organizationLearnerId', 'view-active-organization-learners.id')
+          .andOnVal('campaign-participations.campaignId', campaignId)
+          .andOnVal('isImproved', false)
+          .andOnNull('campaign-participations.deletedAt');
+      })
+      .where(
+        'view-active-organization-learners.organizationId',
+        knex('campaigns').select('organizationId').where('id', campaignId),
       )
-      .modify(_filterParticipations, filters, campaignId)
+      .modify(filterParticipations, activityFilters)
       .orderByRaw('LOWER(??) ASC, LOWER(??) ASC', ['lastName', 'firstName']);
 
     const { results, pagination } = await fetchPage({ queryBuilder: query, paginationParams: page });
 
-    const campaignParticipantsActivities = results.map((result) => {
-      return new CampaignParticipantActivity(result);
-    });
+    const campaignParticipantsActivities = results.map((result) => new CampaignParticipantActivity(result));
 
     return {
       campaignParticipantsActivities,
@@ -53,18 +94,15 @@ const campaignParticipantActivityRepository = {
   },
 };
 
-function _filterParticipations(queryBuilder, filters, campaignId) {
+function filterParticipations(queryBuilder, filters) {
   queryBuilder
-    .where('campaign-participations.campaignId', '=', campaignId)
-    .where('campaign-participations.isImproved', '=', false)
-    .whereNull('campaign-participations.deletedAt')
-    .modify(_filterByDivisions, filters)
-    .modify(_filterByStatus, filters)
-    .modify(_filterByGroup, filters)
-    .modify(_filterBySearch, filters);
+    .modify(filterByDivisions, filters)
+    .modify(filterByStatus, filters)
+    .modify(filterByGroup, filters)
+    .modify(filterBySearch, filters);
 }
 
-function _filterBySearch(queryBuilder, filters) {
+function filterBySearch(queryBuilder, filters) {
   if (filters.search) {
     filterByFullName(
       queryBuilder,
@@ -75,25 +113,23 @@ function _filterBySearch(queryBuilder, filters) {
   }
 }
 
-function _filterByDivisions(queryBuilder, filters) {
+function filterByDivisions(queryBuilder, filters) {
   if (filters.divisions) {
-    const divisionsLowerCase = filters.divisions.map((division) => division.toLowerCase());
-    queryBuilder.whereRaw('LOWER("view-active-organization-learners"."division") = ANY(:divisionsLowerCase)', {
-      divisionsLowerCase,
-    });
+    queryBuilder.whereIn(knex.raw('LOWER("view-active-organization-learners"."division")'), filters.divisions);
   }
 }
 
-function _filterByStatus(queryBuilder, filters) {
-  if (filters.status) {
-    queryBuilder.whereIn('campaign-participations.status', filters.status);
+function filterByStatus(queryBuilder, filters) {
+  if (filters.showNotStarted) {
+    queryBuilder.whereNull('campaign-participations.campaignId');
+  } else {
+    queryBuilder.whereIn('campaign-participations.status', filters.participationStatus);
   }
 }
 
-function _filterByGroup(queryBuilder, filters) {
+function filterByGroup(queryBuilder, filters) {
   if (filters.groups) {
-    const groupsLowerCase = filters.groups.map((group) => group.toLowerCase());
-    queryBuilder.whereIn(knex.raw('LOWER("view-active-organization-learners"."group")'), groupsLowerCase);
+    queryBuilder.whereIn(knex.raw('LOWER("view-active-organization-learners"."group")'), filters.groups);
   }
 }
 

--- a/api/src/prescription/campaign/infrastructure/serializers/jsonapi/campaign-participant-activity-serializer.js
+++ b/api/src/prescription/campaign/infrastructure/serializers/jsonapi/campaign-participant-activity-serializer.js
@@ -4,13 +4,12 @@ const { Serializer } = jsonapiSerializer;
 
 const serialize = function ({ campaignParticipantsActivities, pagination }) {
   return new Serializer('campaign-participant-activity', {
-    id: 'campaignParticipationId',
+    id: 'organizationLearnerId',
     attributes: [
       'firstName',
       'lastName',
       'participantExternalId',
       'status',
-      'progression',
       'lastCampaignParticipationId',
       'participationCount',
     ],

--- a/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-participant-activity-repository_test.js
+++ b/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-participant-activity-repository_test.js
@@ -336,9 +336,11 @@ describe('Integration | Repository | Campaign Participant activity', function ()
     });
 
     context('when there is a filter on the firstname and lastname', function () {
-      it('returns all participants if the filter is empty', async function () {
+      let campaign;
+
+      beforeEach(async function () {
         // given
-        campaign = databaseBuilder.factory.buildCampaign({});
+        campaign = databaseBuilder.factory.buildCampaign();
 
         databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
           { organizationId: campaign.organizationId, firstName: 'Choupette', lastName: 'Eurasier' },
@@ -351,7 +353,9 @@ describe('Integration | Repository | Campaign Participant activity', function ()
         );
 
         await databaseBuilder.commit();
+      });
 
+      it('returns all participants if the filter is empty', async function () {
         // when
         const { pagination } = await campaignParticipantActivityRepository.findPaginatedByCampaignId({
           campaignId: campaign.id,
@@ -363,21 +367,6 @@ describe('Integration | Repository | Campaign Participant activity', function ()
       });
 
       it('return Choupette participant when we search part its firstname', async function () {
-        // given
-        campaign = databaseBuilder.factory.buildCampaign({});
-
-        databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
-          { organizationId: campaign.organizationId, firstName: 'Choupette', lastName: 'Eurasier' },
-          { campaignId: campaign.id },
-        );
-
-        databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
-          { organizationId: campaign.organizationId, firstName: 'Salto', lastName: 'Irish terrier' },
-          { campaignId: campaign.id },
-        );
-
-        await databaseBuilder.commit();
-
         // when
         const { campaignParticipantsActivities, pagination } =
           await campaignParticipantActivityRepository.findPaginatedByCampaignId({
@@ -391,21 +380,6 @@ describe('Integration | Repository | Campaign Participant activity', function ()
       });
 
       it('return Choupette participant when we search contains a space before', async function () {
-        // given
-        campaign = databaseBuilder.factory.buildCampaign({});
-
-        databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
-          { organizationId: campaign.organizationId, firstName: 'Choupette', lastName: 'Eurasier' },
-          { campaignId: campaign.id },
-        );
-
-        databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
-          { organizationId: campaign.organizationId, firstName: 'Salto', lastName: 'Irish terrier' },
-          { campaignId: campaign.id },
-        );
-
-        await databaseBuilder.commit();
-
         // when
         const { campaignParticipantsActivities, pagination } =
           await campaignParticipantActivityRepository.findPaginatedByCampaignId({
@@ -419,21 +393,6 @@ describe('Integration | Repository | Campaign Participant activity', function ()
       });
 
       it('return Choupette participant when we search contains a space after', async function () {
-        // given
-        campaign = databaseBuilder.factory.buildCampaign({});
-
-        databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
-          { organizationId: campaign.organizationId, firstName: 'Choupette', lastName: 'Eurasier' },
-          { campaignId: campaign.id },
-        );
-
-        databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
-          { organizationId: campaign.organizationId, firstName: 'Salto', lastName: 'Irish terrier' },
-          { campaignId: campaign.id },
-        );
-
-        await databaseBuilder.commit();
-
         // when
         const { campaignParticipantsActivities, pagination } =
           await campaignParticipantActivityRepository.findPaginatedByCampaignId({
@@ -447,21 +406,6 @@ describe('Integration | Repository | Campaign Participant activity', function ()
       });
 
       it('return Choupette participant when we search part its lastname', async function () {
-        // given
-        campaign = databaseBuilder.factory.buildCampaign({});
-
-        databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
-          { organizationId: campaign.organizationId, firstName: 'Choupette', lastName: 'Eurasier' },
-          { campaignId: campaign.id },
-        );
-
-        databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
-          { organizationId: campaign.organizationId, firstName: 'Salto', lastName: 'Irish terrier' },
-          { campaignId: campaign.id },
-        );
-
-        await databaseBuilder.commit();
-
         // when
         const { campaignParticipantsActivities, pagination } =
           await campaignParticipantActivityRepository.findPaginatedByCampaignId({
@@ -475,21 +419,6 @@ describe('Integration | Repository | Campaign Participant activity', function ()
       });
 
       it('return Choupette participant when we search part its fullname', async function () {
-        // given
-        campaign = databaseBuilder.factory.buildCampaign({});
-
-        databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
-          { organizationId: campaign.organizationId, firstName: 'Choupette', lastName: 'Eurasier' },
-          { campaignId: campaign.id },
-        );
-
-        databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
-          { organizationId: campaign.organizationId, firstName: 'Salto', lastName: 'Irish terrier' },
-          { campaignId: campaign.id },
-        );
-
-        await databaseBuilder.commit();
-
         // when
         const { campaignParticipantsActivities, pagination } =
           await campaignParticipantActivityRepository.findPaginatedByCampaignId({
@@ -504,13 +433,7 @@ describe('Integration | Repository | Campaign Participant activity', function ()
 
       it('return Choupette participant only for the involved campaign when we search part of its full name', async function () {
         // given
-        campaign = databaseBuilder.factory.buildCampaign({});
-        const otherCampaign = databaseBuilder.factory.buildCampaign({});
-
-        databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
-          { organizationId: campaign.organizationId, firstName: 'Choupette', lastName: 'Right' },
-          { campaignId: campaign.id },
-        );
+        const otherCampaign = databaseBuilder.factory.buildCampaign();
 
         databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
           { organizationId: campaign.organizationId, firstName: 'Choupette', lastName: 'Wrong' },
@@ -528,20 +451,13 @@ describe('Integration | Repository | Campaign Participant activity', function ()
 
         // then
         expect(pagination.rowCount).to.equal(1);
-        expect(campaignParticipantsActivities[0].lastName).to.equal('Right');
+        expect(campaignParticipantsActivities[0].lastName).to.equal('Eurasier');
       });
 
       it('return all participants when we search similar part of firstname', async function () {
         // given
-        campaign = databaseBuilder.factory.buildCampaign({});
-
         databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
           { organizationId: campaign.organizationId, firstName: 'Saphira', lastName: 'Eurasier' },
-          { campaignId: campaign.id },
-        );
-
-        databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
-          { organizationId: campaign.organizationId, firstName: 'Salto', lastName: 'Irish terrier' },
           { campaignId: campaign.id },
         );
 
@@ -564,7 +480,7 @@ describe('Integration | Repository | Campaign Participant activity', function ()
     context('when there is a filter on group', function () {
       it('returns participants which have the correct group', async function () {
         // given
-        campaign = databaseBuilder.factory.buildCampaign();
+        const campaign = databaseBuilder.factory.buildCampaign();
 
         databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
           { organizationId: campaign.organizationId, group: 'L1' },

--- a/api/tests/prescription/campaign/unit/application/campaign-detail-controller_test.js
+++ b/api/tests/prescription/campaign/unit/application/campaign-detail-controller_test.js
@@ -331,7 +331,7 @@ describe('Unit | Application | Controller | Campaign detail', function () {
   describe('#findParticipantsActivity', function () {
     let serializedParticipantsActivities;
     let participantsActivities;
-    const filters = { status: ['SHARED'], groups: ['L1'], search: 'Choupette' };
+    const filters = { status: 'SHARED', groups: ['L1'], search: 'Choupette' };
 
     const campaignId = 1;
     const userId = 1;
@@ -362,7 +362,6 @@ describe('Unit | Application | Controller | Campaign detail', function () {
           auth: {
             credentials: { userId },
           },
-
           query: {
             page: { number: 3 },
             filter: {

--- a/api/tests/prescription/campaign/unit/application/campaign-detail-controller_test.js
+++ b/api/tests/prescription/campaign/unit/application/campaign-detail-controller_test.js
@@ -340,7 +340,7 @@ describe('Unit | Application | Controller | Campaign detail', function () {
     beforeEach(function () {
       participantsActivities = Symbol('participants activities');
       serializedParticipantsActivities = Symbol('serialized participants activities');
-      sinon.stub(usecases, 'findPaginatedCampaignParticipantsActivities');
+      sinon.stub(usecases, 'findPaginatedCampaignParticipantActivities');
       campaignParticipantsActivitySerializerStub = {
         serialize: sinon.stub(),
       };
@@ -348,7 +348,7 @@ describe('Unit | Application | Controller | Campaign detail', function () {
 
     it('should return the participants activities properly serialized', async function () {
       // given
-      usecases.findPaginatedCampaignParticipantsActivities
+      usecases.findPaginatedCampaignParticipantActivities
         .withArgs({ campaignId, userId, page: { number: 3 }, filters })
         .resolves(participantsActivities);
       campaignParticipantsActivitySerializerStub.serialize

--- a/api/tests/prescription/campaign/unit/domain/read-models/CampaignParticipantActivity_test.js
+++ b/api/tests/prescription/campaign/unit/domain/read-models/CampaignParticipantActivity_test.js
@@ -5,48 +5,25 @@ import { expect } from '../../../../../test-helper.js';
 describe('Unit | Domain | Read-Models | CampaignResults | CampaignParticipantActivity', function () {
   describe('constructor', function () {
     it('should correctly initialize the information about campaign participant activity', function () {
-      const sharedAt = new Date();
-
       const campaignParticipantActivity = new CampaignParticipantActivity({
+        organizationLearnerId: 12,
         campaignParticipationId: 45,
         firstName: 'Lidia',
         lastName: 'Aguilar',
-        userId: 123,
         participantExternalId: 'Alba67',
-        sharedAt,
         status: CampaignParticipationStatuses.TO_SHARE,
-        lastCampaignParticipationId: null,
         participationCount: null,
       });
 
       expect(campaignParticipantActivity).to.deep.equal({
-        campaignParticipationId: 45,
+        organizationLearnerId: 12,
         firstName: 'Lidia',
         lastName: 'Aguilar',
-        userId: 123,
         participantExternalId: 'Alba67',
-        sharedAt,
-        status: CampaignParticipationStatuses.STARTED,
+        status: 'STARTED',
         lastCampaignParticipationId: 45,
         participationCount: 0,
       });
-    });
-
-    it('should use lastCampaignParticipationId if provided', function () {
-      const lastCampaignParticipationId = 42;
-
-      const campaignParticipantActivity = new CampaignParticipantActivity({
-        campaignParticipationId: 45,
-        firstName: 'Lidia',
-        lastName: 'Aguilar',
-        userId: 123,
-        participantExternalId: 'Alba67',
-        sharedAt: new Date(),
-        status: CampaignParticipationStatuses.SHARED,
-        lastCampaignParticipationId: lastCampaignParticipationId,
-      });
-
-      expect(campaignParticipantActivity.lastCampaignParticipationId).to.deep.equal(lastCampaignParticipationId);
     });
   });
 });

--- a/api/tests/prescription/campaign/unit/infrastructure/serializers/jsonapi/campaign-participant-activity-serializer_test.js
+++ b/api/tests/prescription/campaign/unit/infrastructure/serializers/jsonapi/campaign-participant-activity-serializer_test.js
@@ -11,8 +11,8 @@ describe('Unit | Serializer | JSONAPI | campaign-participant-activity-serializer
       // given
       const campaignParticipantsActivities = [
         new CampaignParticipantActivity({
-          userId: 1,
-          campaignParticipationId: '1',
+          organizationLearnerId: 1,
+          campaignParticipationId: 3,
           firstName: 'Karam',
           lastName: 'Habibi',
           participantExternalId: 'Dev',
@@ -20,13 +20,13 @@ describe('Unit | Serializer | JSONAPI | campaign-participant-activity-serializer
           participationCount: 1,
         }),
         new CampaignParticipantActivity({
-          userId: 2,
-          campaignParticipationId: '2',
+          organizationLearnerId: 2,
+          campaignParticipationId: 2,
           firstName: 'Dimitri',
           lastName: 'Payet',
           participantExternalId: 'Footballer',
           status: STARTED,
-          sharedAt: null,
+          participationCount: 2,
         }),
       ];
       const pagination = {
@@ -48,7 +48,7 @@ describe('Unit | Serializer | JSONAPI | campaign-participant-activity-serializer
               'last-name': 'Habibi',
               'participant-external-id': 'Dev',
               status: SHARED,
-              'last-campaign-participation-id': '1',
+              'last-campaign-participation-id': 3,
               'participation-count': 1,
             },
           },
@@ -60,8 +60,8 @@ describe('Unit | Serializer | JSONAPI | campaign-participant-activity-serializer
               'last-name': 'Payet',
               'participant-external-id': 'Footballer',
               status: STARTED,
-              'last-campaign-participation-id': '2',
-              'participation-count': 0,
+              'last-campaign-participation-id': 2,
+              'participation-count': 2,
             },
           },
         ],

--- a/orga/app/components/campaign/filter/participation-filters.gjs
+++ b/orga/app/components/campaign/filter/participation-filters.gjs
@@ -123,7 +123,7 @@ export default class ParticipationFilters extends Component {
   }
 
   get statusOptions() {
-    const statuses = ['STARTED', 'SHARED'];
+    const statuses = ['STARTED', 'SHARED', 'NOT_STARTED'];
     return statuses.map((status) => {
       const label = this.intl.t(`components.participation-status.${status}`);
       return { value: status, label };

--- a/orga/app/components/campaign/filter/participation-filters.gjs
+++ b/orga/app/components/campaign/filter/participation-filters.gjs
@@ -123,7 +123,10 @@ export default class ParticipationFilters extends Component {
   }
 
   get statusOptions() {
-    const statuses = ['STARTED', 'SHARED', 'NOT_STARTED'];
+    const statuses = ['STARTED', 'SHARED'];
+
+    if (this.currentUser.hasImportFeature) statuses.push('NOT_STARTED');
+
     return statuses.map((status) => {
       const label = this.intl.t(`components.participation-status.${status}`);
       return { value: status, label };

--- a/orga/app/components/ui/participation-status.gjs
+++ b/orga/app/components/ui/participation-status.gjs
@@ -12,7 +12,7 @@ export default class ParticipationStatus extends Component {
 
   get label() {
     const { status } = this.args;
-    return this.intl.t(`components.participation-status.${status}`);
+    return this.intl.t(`components.participation-status.${status ?? 'NOT_STARTED'}`);
   }
 
   <template>

--- a/orga/app/services/current-user.js
+++ b/orga/app/services/current-user.js
@@ -18,10 +18,11 @@ export default class CurrentUserService extends Service {
   @tracked combinedCourses;
 
   get canAccessImportPage() {
-    return Boolean(
-      (this.isSCOManagingStudents || this.isSUPManagingStudents || this.hasLearnerImportFeature) &&
-      this.isAdminInOrganization,
-    );
+    return Boolean(this.hasImportFeature && this.isAdminInOrganization);
+  }
+
+  get hasImportFeature() {
+    return this.organization.isManagingStudents || this.hasLearnerImportFeature;
   }
 
   get canAccessAttestationsPage() {
@@ -53,7 +54,7 @@ export default class CurrentUserService extends Service {
   }
 
   get canEditLearnerName() {
-    return this.isAdminInOrganization && !this.hasLearnerImportFeature && !this.organization.isManagingStudents;
+    return this.isAdminInOrganization && !this.hasImportFeature;
   }
 
   get placeStatistics() {

--- a/orga/tests/integration/components/campaign/activity/participants-list-test.js
+++ b/orga/tests/integration/components/campaign/activity/participants-list-test.js
@@ -156,6 +156,7 @@ module('Integration | Component | Campaign::Activity::ParticipantsList', functio
   test('it should hide participation column when showParticipationCount is false', async function (assert) {
     class CurrentUserStub extends Service {
       isAdminInOrganization = true;
+      organization = { isManagingStudents: false };
     }
     this.owner.register('service:current-user', CurrentUserStub);
     this.set('campaign', { id: '100', externalIdLabel: 'id', type: 'ASSESSMENT' });
@@ -184,6 +185,11 @@ module('Integration | Component | Campaign::Activity::ParticipantsList', functio
   });
 
   test('[A11Y] it should have an aria label', async function (assert) {
+    class CurrentUserStub extends Service {
+      isAdminInOrganization = true;
+      organization = { isManagingStudents: false };
+    }
+    this.owner.register('service:current-user', CurrentUserStub);
     this.set('campaign', { externalIdLabel: 'id', type: 'ASSESSMENT' });
 
     this.set('participations', [

--- a/orga/tests/integration/components/campaign/filter/participation-filters-test.gjs
+++ b/orga/tests/integration/components/campaign/filter/participation-filters-test.gjs
@@ -877,6 +877,7 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
           t('pages.campaign-results.filters.type.status.empty'),
           t('components.participation-status.STARTED'),
           t('components.participation-status.SHARED'),
+          t('components.participation-status.NOT_STARTED'),
         ],
       );
     });

--- a/orga/tests/integration/components/campaign/filter/participation-filters-test.gjs
+++ b/orga/tests/integration/components/campaign/filter/participation-filters-test.gjs
@@ -18,7 +18,14 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
     store = this.owner.lookup('service:store');
   });
 
-  module('Basic Filter State', function () {
+  module('Basic Filter State', function (hooks) {
+    hooks.beforeEach(function () {
+      class CurrentUserStub extends Service {
+        hasImportFeature = false;
+      }
+      this.owner.register('service:current-user', CurrentUserStub);
+    });
+
     test('it should display one filtered participant', async function (assert) {
       // given
       const campaign = store.createRecord('campaign', {
@@ -228,7 +235,13 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
     });
   });
 
-  module('stages', function () {
+  module('stages', function (hooks) {
+    hooks.beforeEach(function () {
+      class CurrentUserStub extends Service {
+        hasImportFeature = false;
+      }
+      this.owner.register('service:current-user', CurrentUserStub);
+    });
     module('when campaign has no stages', function () {
       test('should not displays the stage filter', async function (assert) {
         // given
@@ -475,7 +488,13 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
     });
   });
 
-  module('badges', function () {
+  module('badges', function (hooks) {
+    hooks.beforeEach(function () {
+      class CurrentUserStub extends Service {
+        hasImportFeature = false;
+      }
+      this.owner.register('service:current-user', CurrentUserStub);
+    });
     module('when campaign has badges and has type ASSESSMENT', function () {
       test('it displays the badge filters', async function (assert) {
         // given
@@ -798,6 +817,10 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
 
   module('status', function () {
     test('it triggers the filter when a status is selected', async function (assert) {
+      class CurrentUserStub extends Service {
+        hasImportFeature = false;
+      }
+      this.owner.register('service:current-user', CurrentUserStub);
       // given
       const campaign = store.createRecord('campaign', {
         id: campaignId,
@@ -825,6 +848,10 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
     });
 
     test('it select the option passed as selectedStatus args', async function (assert) {
+      class CurrentUserStub extends Service {
+        hasImportFeature = false;
+      }
+      this.owner.register('service:current-user', CurrentUserStub);
       // given
       const campaign = store.createRecord('campaign', {
         id: campaignId,
@@ -853,7 +880,43 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
         .exists();
     });
 
-    test('it should display statuses', async function (assert) {
+    test('it should hide not started status without import feature', async function (assert) {
+      class CurrentUserStub extends Service {
+        hasImportFeature = false;
+      }
+      this.owner.register('service:current-user', CurrentUserStub);
+      // given
+      const campaign = store.createRecord('campaign', {
+        id: campaignId,
+        name: 'campagne 1',
+        type: 'ASSESSMENT',
+        targetProfileHasStage: false,
+        stages: [],
+      });
+
+      // when
+      const screen = await render(
+        <template><ParticipationFilters @campaign={{campaign}} @onFilter={{noop}} /></template>,
+      );
+
+      // then
+      await click(screen.getByLabelText(t('pages.campaign-results.filters.type.status.title')));
+      const options = await screen.findAllByRole('option');
+      assert.deepEqual(
+        options.map((option) => option.innerText),
+        [
+          t('pages.campaign-results.filters.type.status.empty'),
+          t('components.participation-status.STARTED'),
+          t('components.participation-status.SHARED'),
+        ],
+      );
+    });
+
+    test('it should display not started status with import feature', async function (assert) {
+      class CurrentUserStub extends Service {
+        hasImportFeature = true;
+      }
+      this.owner.register('service:current-user', CurrentUserStub);
       // given
       const campaign = store.createRecord('campaign', {
         id: campaignId,
@@ -883,7 +946,13 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
     });
   });
 
-  module('search', function () {
+  module('search', function (hooks) {
+    hooks.beforeEach(function () {
+      class CurrentUserStub extends Service {
+        hasImportFeature = false;
+      }
+      this.owner.register('service:current-user', CurrentUserStub);
+    });
     test('that in the fullname search input we will have the value that we put', async function (assert) {
       const campaign = store.createRecord('campaign', {
         id: '1',
@@ -931,7 +1000,14 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
     });
   });
 
-  module('certificability', function () {
+  module('certificability', function (hooks) {
+    hooks.beforeEach(function () {
+      class CurrentUserStub extends Service {
+        hasImportFeature = false;
+      }
+      this.owner.register('service:current-user', CurrentUserStub);
+    });
+
     test('display certificability filter', async function (assert) {
       const campaign = store.createRecord('campaign', {
         id: '1',

--- a/orga/tests/integration/components/ui/participation-status-test.gjs
+++ b/orga/tests/integration/components/ui/participation-status-test.gjs
@@ -10,6 +10,7 @@ module('Integration | Component | Ui | ParticipationStatus', function (hooks) {
 
   module('label', function () {
     test('it should display formatted label', async function (assert) {
+      // given
       const status = 'SHARED';
 
       // when
@@ -17,6 +18,16 @@ module('Integration | Component | Ui | ParticipationStatus', function (hooks) {
 
       // then
       assert.ok(screen.getByText(t('components.participation-status.SHARED')));
+    });
+    test('it should display not started label if status is null', async function (assert) {
+      // given
+      const status = null;
+
+      // when
+      const screen = await render(<template><ParticipationStatus @status={{status}} /></template>);
+
+      // then
+      assert.ok(screen.getByText(t('components.participation-status.NOT_STARTED')));
     });
   });
 });

--- a/orga/tests/unit/services/current-user-test.js
+++ b/orga/tests/unit/services/current-user-test.js
@@ -301,6 +301,35 @@ module('Unit | Service | current-user', function (hooks) {
       });
     });
 
+    module('#hasImportFeature', function () {
+      test('should return true if organization has feature import activated', function (assert) {
+        currentUserService.prescriber = {
+          hasOrganizationLearnerImport: true,
+        };
+        currentUserService.organization = { isManagingStudents: false };
+
+        assert.true(currentUserService.hasImportFeature);
+      });
+
+      test('should return true if organization is managing student', function (assert) {
+        currentUserService.prescriber = {
+          hasOrganizationLearnerImport: false,
+        };
+        currentUserService.organization = { isManagingStudents: true };
+
+        assert.true(currentUserService.hasImportFeature);
+      });
+
+      test('should return false if organization is not managing student without learner import feature', function (assert) {
+        currentUserService.prescriber = {
+          hasOrganizationLearnerImport: false,
+        };
+        currentUserService.organization = { isManagingStudents: false };
+
+        assert.false(currentUserService.hasImportFeature);
+      });
+    });
+
     module('#canAccessPlacesPage', function () {
       test('should return true if user is admin and organization has feature activated', function (assert) {
         currentUserService.isAdminInOrganization = true;
@@ -401,36 +430,24 @@ module('Unit | Service | current-user', function (hooks) {
       });
 
       module('when is admin of the organization', function () {
-        test('should return false if organization is not sco managing student', function (assert) {
+        test('should return false if organization is not managing student', function (assert) {
           currentUserService.isAdminInOrganization = true;
-          currentUserService.isSCOManagingStudents = false;
+          currentUserService.organization = { isManagingStudents: false };
 
           assert.false(currentUserService.canAccessImportPage);
         });
 
-        test('should return true if organization is sco managing student', function (assert) {
+        test('should return true if organization is managing student', function (assert) {
           currentUserService.isAdminInOrganization = true;
-          currentUserService.isSCOManagingStudents = true;
-
-          assert.true(currentUserService.canAccessImportPage);
-        });
-
-        test('should return false if organization not sup managing student', function (assert) {
-          currentUserService.isAdminInOrganization = true;
-          currentUserService.isSUPManagingStudents = false;
-
-          assert.false(currentUserService.canAccessImportPage);
-        });
-
-        test('should return true if organization is sup managing student', function (assert) {
-          currentUserService.isAdminInOrganization = true;
-          currentUserService.isSUPManagingStudents = true;
+          currentUserService.organization = { isManagingStudents: true };
 
           assert.true(currentUserService.canAccessImportPage);
         });
 
         test('should return true if user can use import learner feature', function (assert) {
           currentUserService.isAdminInOrganization = true;
+          currentUserService.organization = { isManagingStudents: false };
+
           currentUserService.prescriber = { hasOrganizationLearnerImport: true };
 
           assert.true(currentUserService.canAccessImportPage);
@@ -438,36 +455,23 @@ module('Unit | Service | current-user', function (hooks) {
       });
 
       module('when is not admin of the organization', function () {
-        test('should return false if organization is not sco managing student', function (assert) {
+        test('should return false if organization is not managing student', function (assert) {
           currentUserService.isAdminInOrganization = false;
-          currentUserService.isSCOManagingStudents = false;
+          currentUserService.organization = { isManagingStudents: false };
 
           assert.false(currentUserService.canAccessImportPage);
         });
 
-        test('should return false if organization is sco managing student', function (assert) {
+        test('should return false if organization is managing student', function (assert) {
           currentUserService.isAdminInOrganization = false;
-          currentUserService.isSCOManagingStudents = true;
-
-          assert.false(currentUserService.canAccessImportPage);
-        });
-
-        test('should return false if organization not sup managing student', function (assert) {
-          currentUserService.isAdminInOrganization = false;
-          currentUserService.isSUPManagingStudents = false;
-
-          assert.false(currentUserService.canAccessImportPage);
-        });
-
-        test('should return false if organization is sup managing student', function (assert) {
-          currentUserService.isAdminInOrganization = false;
-          currentUserService.isSUPManagingStudents = true;
+          currentUserService.organization = { isManagingStudents: true };
 
           assert.false(currentUserService.canAccessImportPage);
         });
 
         test('should return false if user can use import learner feature', function (assert) {
           currentUserService.isAdminInOrganization = false;
+          currentUserService.organization = { isManagingStudents: false };
           currentUserService.prescriber = { hasOrganizationLearnerImport: true };
 
           assert.false(currentUserService.canAccessImportPage);

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -878,7 +878,7 @@
           },
           "stages": "Success rate",
           "status": {
-            "empty": "All statuses",
+            "empty": "All participations",
             "title": "Status"
           },
           "unacquired-badges": "Unacquired badges"

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -866,7 +866,7 @@
           },
           "stages": "Paliers",
           "status": {
-            "empty": "Tous les statuts",
+            "empty": "Toutes les participations",
             "title": "Statut"
           },
           "unacquired-badges": "Badges non obtenus"

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -865,7 +865,7 @@
           },
           "stages": "Succesratio",
           "status": {
-            "empty": "Alle statussen",
+            "empty": "Alle deelnames",
             "title": "Status"
           },
           "unacquired-badges": "Thema's niet verkregen"


### PR DESCRIPTION
## ❄️ Problème

Il est parfois difficile pour nos prescripteurs de savoir qui n'a pas encore commencé sa campagne.

## 🛷 Proposition

Ajouter un statut "A faire" au filtre sur le statut de la participation, qui permet d'afficher les apprenants n'ayant pas encore de participation associée à la campagne. 
Tous les autres filtres seront fonctionnels afin d'affiner sa recherche par classe / division ou  nom / prénom.

## ☃️ Remarques

On se base désormais sur les organization learners pour récupérer les données (avec ou sans participation).

Nous avons créé une class `ParticipantActivityFilters` qui à terme fera office de model à part pour les filtres afin d'avoir une harmonisation sur les différents usages des filtres dans les routes mise à disposition de nos prescripteurs.

Le filtre sur les classes / divisions continue de récupérer uniquement les classes associées aux learners ayant participé à la campagne. Si aucun learner d'une classe n'a pas participé à une campagne, cette classe n'apparaîtra pas sur le filtre.

## 🧑‍🎄 Pour tester

Ci au vert bien entendu. 
Faire un tour sur soi même et le cas échéant sur PixOrga.
Créer une campagne sur une orga SCO / SUP. 
Aller sur la page des participants à cette campagne.
Modifier le filtre pour afficher les apprenants sans participations. 
Vérifier que vous avez bien la liste intégrale de vos participants. 

Merci,
Bonne journée