### PR TITLE
[TECH] Relier la table "organization_learner_type" à la table "organizations" (PIX-21215) 

### DIFF
--- a/api/db/migrations/20260129143947_add-organizationLearnerTypeId-relationship-to-organizations.js
+++ b/api/db/migrations/20260129143947_add-organizationLearnerTypeId-relationship-to-organizations.js
@@ -1,0 +1,29 @@
+const TABLE_NAME = 'organizations';
+const COLUMN_NAME = 'organizationLearnerTypeId';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table
+      .integer(COLUMN_NAME)
+      .defaultTo(null)
+      .nullable()
+      .references('organization_learner_types.id')
+      .comment("Reference to the organization's organization learner type.");
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+export { down, up };

--- a/api/tests/team/integration/infrastructure/repositories/user-orga-settings-repository_test.js
+++ b/api/tests/team/integration/infrastructure/repositories/user-orga-settings-repository_test.js
@@ -118,7 +118,10 @@ describe('Integration | Team | Infrastructure | Repository | UserOrgaSettings', 
       expect(updatedUserOrgaSettings.id).to.equal(userOrgaSettings.id);
       expect(updatedUserOrgaSettings.updatedAt).to.deep.equal(now);
       expect(updatedUserOrgaSettings.user).to.deep.include(user);
-      expect(updatedUserOrgaSettings.currentOrganization).to.deep.equal(newOrganization);
+      // TODO: remove omit when epix https://1024pix.atlassian.net/browse/PIX-19561 is completed
+      expect(_.omit(updatedUserOrgaSettings.currentOrganization, 'organizationLearnerTypeId')).to.deep.equal(
+        newOrganization,
+      );
     });
   });
 


### PR DESCRIPTION
## ❄️ Problème

Maintenant que la table `organization_learner_types` est créée, il faut établir une relation one-to-many avec la table organizations.

## 🛷 Proposition

Ajouter une clé étrangère `organizationLearnerTypeId` dans la table organizations, faisant référence à l'ID d'un enregistrement de la table "organization_learner_type"

## ☃️ Remarques

Un test qui utilise le builder d'organizations a été modifié provisoirement pour qu'il passe. Il est prévu de créer le database builder des Types de prescrits et de modifier celui des organizations dans une future PR. Une fois que ce sera fait, il faudra annuler les changements faits sur ce fichier de test.

## 🧑‍🎄 Pour tester
Tests au vert
