### PR TITLE
[TECH] Ajout de tests E2E sur un des cas d'anonymisation (PIX-21269)

### DIFF
--- a/high-level-tests/e2e-playwright/helpers/db-data.ts
+++ b/high-level-tests/e2e-playwright/helpers/db-data.ts
@@ -50,6 +50,15 @@ export const PIX_ORGA_MEMBER_DATA = {
   ],
 };
 
+export const PIX_ADMIN_SUPPORT_DATA = {
+  id: 1_000_008,
+  firstName: 'PixAdmin',
+  lastName: 'RoleSupport',
+  email: 'pix-admin_rolesupport@example.net',
+  rawPassword: 'pix123',
+  role: 'SUPPORT',
+};
+
 export const PIX_CERTIF_PRO_DATA = {
   id: 1_000_005,
   firstName: 'PixCertif',

--- a/high-level-tests/e2e-playwright/package.json
+++ b/high-level-tests/e2e-playwright/package.json
@@ -19,6 +19,8 @@
     "test": "playwright test",
     "test:snapshot": "UPDATE_SNAPSHOTS=true playwright test --grep @snapshot",
     "test:ui": "playwright test --ui",
+    "test:prescription": "playwright test --config playwright.config.prescription.ts",
+    "test:prescription:ui": "playwright test --config playwright.config.prescription.ts --ui",
     "test:certif": "playwright test --config playwright.config.certif.ts",
     "test:certif:testref": "ts-node scripts/recette-certif/run-by-test-ref.ts",
     "test:certif:snapshot": "UPDATE_SNAPSHOTS=true playwright test --config playwright.config.certif.ts --grep @snapshot",

--- a/high-level-tests/e2e-playwright/pages/pix-admin/HomePage.ts
+++ b/high-level-tests/e2e-playwright/pages/pix-admin/HomePage.ts
@@ -1,6 +1,7 @@
 import type { Page } from '@playwright/test';
 
-import { CertificationSessionsMainPage } from './index.ts';
+import { CertificationSessionsMainPage, OrganizationsListPage, UsersListPage } from './index.ts';
+
 export class HomePage {
   constructor(public readonly page: Page) {}
 
@@ -9,5 +10,19 @@ export class HomePage {
     await this.page.waitForURL(/\/sessions\/list\/with-required-action\?version=3$/);
 
     return new CertificationSessionsMainPage(this.page);
+  }
+
+  async goToUsersTab() {
+    await this.page.getByRole('link', { name: 'Utilisateurs', exact: true }).click();
+    await this.page.waitForURL(/\/users\/list$/);
+
+    return new UsersListPage(this.page);
+  }
+
+  async goToOrganizationsTab() {
+    await this.page.getByRole('link', { name: 'Organisations', exact: true }).click();
+    await this.page.waitForURL(/\/organizations\/list$/);
+
+    return new OrganizationsListPage(this.page);
   }
 }

--- a/high-level-tests/e2e-playwright/pages/pix-admin/OrganizationDetailsPage.ts
+++ b/high-level-tests/e2e-playwright/pages/pix-admin/OrganizationDetailsPage.ts
@@ -1,0 +1,12 @@
+import type { Page } from '@playwright/test';
+
+export class OrganizationDetailsPage {
+  constructor(public readonly page: Page) {}
+  async goToCampaign(campaignName: string) {
+    await this.page.getByRole('link', { name: 'Campagnes' }).click();
+    await this.page.waitForURL(/organizations\/\d+\/campaigns/);
+
+    await this.page.getByRole('link', { name: campaignName }).click();
+    await this.page.waitForURL(/campaigns\/\d+\/participations/);
+  }
+}

--- a/high-level-tests/e2e-playwright/pages/pix-admin/OrganizationsListPage.ts
+++ b/high-level-tests/e2e-playwright/pages/pix-admin/OrganizationsListPage.ts
@@ -1,0 +1,17 @@
+import type { Page } from '@playwright/test';
+
+import { OrganizationDetailsPage } from './index.ts';
+
+export class OrganizationsListPage {
+  constructor(public readonly page: Page) {}
+
+  async goToOrganizationDetails(organizationName: string) {
+    await this.page
+      .locator('table tbody tr', { has: this.page.getByText(organizationName) })
+      .getByRole('link')
+      .click();
+    await this.page.waitForURL(/organizations\/\d+\/team/);
+
+    return new OrganizationDetailsPage(this.page);
+  }
+}

--- a/high-level-tests/e2e-playwright/pages/pix-admin/UserDetailsPage.ts
+++ b/high-level-tests/e2e-playwright/pages/pix-admin/UserDetailsPage.ts
@@ -1,0 +1,9 @@
+import type { Page } from '@playwright/test';
+
+export class UserDetailsPage {
+  constructor(public readonly page: Page) {}
+  async anonymize() {
+    await this.page.getByRole('button', { name: 'Anonymiser cet utilisateur' }).click();
+    await this.page.getByRole('button', { name: 'Confirmer' }).click();
+  }
+}

--- a/high-level-tests/e2e-playwright/pages/pix-admin/UsersListPage.ts
+++ b/high-level-tests/e2e-playwright/pages/pix-admin/UsersListPage.ts
@@ -1,0 +1,22 @@
+import type { Page } from '@playwright/test';
+
+import { UserDetailsPage } from './UserDetailsPage.ts';
+
+export class UsersListPage {
+  constructor(public readonly page: Page) {}
+
+  async goToUserDetails(firstName: string, email: string) {
+    await this.page.getByLabel('Prénom').fill(firstName);
+    await this.page.getByRole('button', { name: 'Charger' }).click();
+
+    await this.page.getByText(email).waitFor({ state: 'visible' });
+
+    await this.page
+      .locator('table tbody tr', { has: this.page.getByText(firstName) })
+      .getByRole('link')
+      .click();
+    await this.page.waitForURL(/\/users\/\d+$/);
+
+    return new UserDetailsPage(this.page);
+  }
+}

--- a/high-level-tests/e2e-playwright/pages/pix-admin/index.ts
+++ b/high-level-tests/e2e-playwright/pages/pix-admin/index.ts
@@ -3,3 +3,7 @@ export * from './CertificationSessionPage.ts';
 export * from './CertificationSessionsMainPage.ts';
 export * from './HomePage.ts';
 export * from './LoginPage.ts';
+export * from './OrganizationDetailsPage.ts';
+export * from './OrganizationsListPage.ts';
+export * from './UserDetailsPage.ts';
+export * from './UsersListPage.ts';

--- a/high-level-tests/e2e-playwright/pages/pix-orga/HomePage.ts
+++ b/high-level-tests/e2e-playwright/pages/pix-orga/HomePage.ts
@@ -1,0 +1,14 @@
+import type { Page } from '@playwright/test';
+
+import { ParticipantsPage } from './index.ts';
+
+export class HomePage {
+  constructor(public readonly page: Page) {}
+
+  async goToParticipants() {
+    await this.page.getByRole('link', { name: 'Participants', exact: true }).click();
+    await this.page.getByText('Participant (1)').waitFor({ state: 'visible' });
+
+    return new ParticipantsPage(this.page);
+  }
+}

--- a/high-level-tests/e2e-playwright/pages/pix-orga/ParticipantsPage.ts
+++ b/high-level-tests/e2e-playwright/pages/pix-orga/ParticipantsPage.ts
@@ -1,0 +1,12 @@
+import type { Page } from '@playwright/test';
+export class ParticipantsPage {
+  constructor(public readonly page: Page) {}
+
+  async goToParticipant(firstName: string) {
+    await this.page
+      .locator('table tbody tr', { has: this.page.getByText(firstName) })
+      .getByRole('link')
+      .click();
+    await this.page.waitForURL(/\/participants\/\d+$/);
+  }
+}

--- a/high-level-tests/e2e-playwright/pages/pix-orga/index.ts
+++ b/high-level-tests/e2e-playwright/pages/pix-orga/index.ts
@@ -1,1 +1,3 @@
+export * from './HomePage.ts';
+export * from './ParticipantsPage.ts';
 export * from './PixOrgaPage.ts';

--- a/high-level-tests/e2e-playwright/playwright.config.prescription.ts
+++ b/high-level-tests/e2e-playwright/playwright.config.prescription.ts
@@ -1,0 +1,29 @@
+import { defineConfig } from '@playwright/test';
+
+import sharedConfig, { App, isCI, reuseExistingApps, setupWebServer } from './playwright.config.shared.ts';
+
+export default defineConfig({
+  ...sharedConfig,
+  projects: [
+    {
+      name: 'recette prescription - setup base data for anonymization',
+      testDir: 'tests/recette-prescription',
+      testMatch: '**/create-organization-learner.spec.ts',
+    },
+    {
+      name: 'recette prescription - anonymization scenarios',
+      testDir: 'tests/recette-prescription',
+      testMatch: '**/organization-learner-anonymisation/**/*.ts',
+      dependencies: ['recette prescription - setup base data for anonymization'],
+    },
+  ],
+
+  webServer: isCI
+    ? [setupWebServer(App.PIX_APP, true), setupWebServer(App.PIX_ORGA, true), setupWebServer(App.PIX_ADMIN, true)]
+    : [
+        setupWebServer(App.PIX_API, false),
+        setupWebServer(App.PIX_APP, reuseExistingApps),
+        setupWebServer(App.PIX_ORGA, reuseExistingApps),
+        setupWebServer(App.PIX_ADMIN, reuseExistingApps),
+      ],
+});

--- a/high-level-tests/e2e-playwright/tests/recette-prescription/create-organization-learner.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-prescription/create-organization-learner.spec.ts
@@ -1,0 +1,59 @@
+import { expect, test } from '../../helpers/fixtures.ts';
+import {
+  ChallengePage,
+  FinalCheckpointPage,
+  IntermediateCheckpointPage,
+  LoginPage,
+  StartCampaignPage,
+} from '../../pages/pix-app/index.ts';
+import { PixOrgaPage } from '../../pages/pix-orga/index.ts';
+
+test('set up base data for anonymization test : create an organization learner who has plays a campaign', async ({
+  page: pixAppPage,
+  pixOrgaMemberContext,
+}) => {
+  test.slow();
+  const pixOrgaPage = await pixOrgaMemberContext.newPage();
+  await pixOrgaPage.goto(process.env.PIX_ORGA_URL as string);
+  let campaignCode: string | null;
+  await test.step('creates the campaign', async () => {
+    await pixOrgaPage.getByRole('link', { name: 'Campagnes', exact: true }).click();
+    await pixOrgaPage.getByRole('link', { name: 'Créer une campagne' }).click();
+    const createCampaignPage = new PixOrgaPage(pixOrgaPage);
+    await createCampaignPage.createEvaluationCampaign({
+      campaignName: 'test playwright',
+      targetProfileName: 'petit Profile Cible',
+    });
+    campaignCode = await pixOrgaPage.locator('dd.campaign-header-title__campaign-code > span').textContent();
+  });
+
+  await pixAppPage.goto(process.env.PIX_APP_URL as string);
+  const loginPage = new LoginPage(pixAppPage);
+  await loginPage.signup('Jambon', 'Beurre', `jambon.beurre@example.net`, 'Coucoulesdevs44');
+  await test.step('plays the campaign', async () => {
+    await pixAppPage.getByRole('link', { name: "J'ai un code" }).click();
+    const startCampaignPage = new StartCampaignPage(pixAppPage);
+    await startCampaignPage.goToFirstChallenge(campaignCode as string);
+    await test.step(` answering right or wrong according to pattern`, async () => {
+      while (!pixAppPage.url().endsWith('/checkpoint?finalCheckpoint=true')) {
+        const challengePage = new ChallengePage(pixAppPage);
+        await challengePage.setRightOrWrongAnswer(true);
+        await challengePage.validateAnswer();
+
+        if (pixAppPage.url().includes('/checkpoint') && !pixAppPage.url().includes('finalCheckpoint=true')) {
+          const checkpointPage = new IntermediateCheckpointPage(pixAppPage);
+          await checkpointPage.goNext();
+        }
+      }
+    });
+
+    await test.step(`campaign results`, async () => {
+      const finalCheckpointPage = new FinalCheckpointPage(pixAppPage);
+      await finalCheckpointPage.goToResults();
+
+      await expect(
+        pixAppPage.getByRole('paragraph').filter({ hasText: 'Vos résultats ont été envoyés' }),
+      ).toBeVisible();
+    });
+  });
+});

--- a/high-level-tests/e2e-playwright/tests/recette-prescription/create-organization-learner.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-prescription/create-organization-learner.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '../../helpers/fixtures.ts';
+import { expect, test } from '../../fixtures/index.ts';
 import {
   ChallengePage,
   FinalCheckpointPage,

--- a/high-level-tests/e2e-playwright/tests/recette-prescription/organization-learner-anonymisation/user-anonymization.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-prescription/organization-learner-anonymisation/user-anonymization.spec.ts
@@ -1,5 +1,5 @@
+import { expect, test } from '../../../fixtures/index.ts';
 import { PIX_ADMIN_SUPPORT_DATA } from '../../../helpers/db-data.ts';
-import { expect, test } from '../../../helpers/fixtures.ts';
 import { LoginPage as AdminLoginPage } from '../../../pages/pix-admin/index.ts';
 import { LoginPage as AppLoginPage } from '../../../pages/pix-app/index.ts';
 import { HomePage as PixOrgaHomePage, ParticipantsPage } from '../../../pages/pix-orga/index.ts';

--- a/high-level-tests/e2e-playwright/tests/recette-prescription/organization-learner-anonymisation/user-anonymization.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-prescription/organization-learner-anonymisation/user-anonymization.spec.ts
@@ -1,0 +1,70 @@
+import { PIX_ADMIN_SUPPORT_DATA } from '../../../helpers/db-data.ts';
+import { expect, test } from '../../../helpers/fixtures.ts';
+import { LoginPage as AdminLoginPage } from '../../../pages/pix-admin/index.ts';
+import { LoginPage as AppLoginPage } from '../../../pages/pix-app/index.ts';
+import { HomePage as PixOrgaHomePage, ParticipantsPage } from '../../../pages/pix-orga/index.ts';
+
+test(`user is anonymized`, async ({ page: pixAppPage, pixSuperAdminContext, pixOrgaMemberContext }) => {
+  test.slow();
+
+  await test.step('User can access to their account on PixApp', async function () {
+    await pixAppPage.goto(process.env.PIX_APP_URL as string);
+    const loginPage = new AppLoginPage(pixAppPage);
+    await loginPage.login(`jambon.beurre@example.net`, 'Coucoulesdevs44');
+
+    await expect(pixAppPage.getByText('Bonjour Jambon')).toBeVisible();
+  });
+
+  const pixAdminPage = await pixSuperAdminContext.newPage();
+  await pixAdminPage.goto(process.env.PIX_ADMIN_URL as string);
+  const adminLoginPage = new AdminLoginPage(pixAdminPage);
+  const adminHomepage = await adminLoginPage.login(PIX_ADMIN_SUPPORT_DATA.email, PIX_ADMIN_SUPPORT_DATA.rawPassword);
+
+  await test.step('Anonymize user', async () => {
+    const userListPage = await adminHomepage.goToUsersTab();
+    const userDetailsPage = await userListPage.goToUserDetails('Jambon', 'jambon.beurre@example.net');
+    await userDetailsPage.anonymize();
+
+    await expect(
+      pixAdminPage.getByText(
+        `Utilisateur anonymisé par ${PIX_ADMIN_SUPPORT_DATA.firstName} ${PIX_ADMIN_SUPPORT_DATA.lastName}.`,
+      ),
+    ).toBeVisible();
+  });
+
+  // Impacts dans PixAdmin
+  await test.step('Admin can still access to campaign participation data', async function () {
+    const organizationsListPage = await adminHomepage.goToOrganizationsTab();
+    const organizationDetailsPage = await organizationsListPage.goToOrganizationDetails('Orga Pro');
+    await organizationDetailsPage.goToCampaign('test playwright');
+
+    await expect(
+      pixAdminPage.locator('table tbody tr', { has: pixAdminPage.getByText('Jambon Beurre') }).getByRole('link'),
+    ).not.toBeVisible();
+  });
+
+  // Impacts dans PixApp
+  // TODO: Retirer le skip une fois le ticket correctif implémenté côté Accès
+  await test.step.skip('User cannot access their account on PixApp anymore', async function () {
+    await pixAppPage.goto(process.env.PIX_APP_URL as string);
+    const loginPage = new AppLoginPage(pixAppPage);
+    await loginPage.login(`jambon.beurre@example.net`, 'Coucoulesdevs44');
+    await expect(
+      pixAppPage.getByText("L'adresse e-mail ou l'identifiant et/ou le mot de passe saisis sont incorrects."),
+    ).toBeVisible();
+  });
+
+  // Impacts dans PixOrga
+  await test.step('Organization learner related to user should not be altered', async function () {
+    const pixOrgaPage = await pixOrgaMemberContext.newPage();
+    await pixOrgaPage.goto(process.env.PIX_ORGA_URL as string);
+    const homePage = new PixOrgaHomePage(pixOrgaPage);
+
+    await homePage.goToParticipants();
+    await expect(pixOrgaPage.getByText('Jambon')).toBeVisible();
+
+    const participants = new ParticipantsPage(pixOrgaPage);
+    await participants.goToParticipant('Jambon');
+    await expect(pixOrgaPage.getByText('test playwright')).toBeVisible();
+  });
+});


### PR DESCRIPTION
## ❄️ Problème

L'anonymisation d'un utilisateur ne doit pas toucher les données de ses organization-learners associés
Nous souhaitons ne plus avoir à tester ce cas à la main
## 🛷 Proposition

Tester avec un test E2E playwright

## ☃️ Remarques

Avec application du POM
Un des tests est commenté car la team accès a encore un ticket ouvert pour traiter ce cas

## 🧑‍🎄 Pour tester

Tous les tests au vert