### PR TITLE
[FEATURE] Ajouter la propriété hasShortProposals dans le schéma des QCU, QCM et QCU Découverte et QCU Déclaratif (PIX-21284)

### DIFF
--- a/api/src/devcomp/domain/models/element/QCM.js
+++ b/api/src/devcomp/domain/models/element/QCM.js
@@ -4,7 +4,7 @@ import { Feedbacks } from '../Feedbacks.js';
 import { Element } from './Element.js';
 
 class QCM extends Element {
-  constructor({ id, instruction, locales, proposals, feedbacks, solutions }) {
+  constructor({ id, instruction, locales, proposals, feedbacks, solutions, hasShortProposals = false } = {}) {
     super({ id, type: 'qcm' });
 
     assertNotNullOrUndefined(instruction, 'The instruction is required for a QCM');
@@ -19,6 +19,7 @@ class QCM extends Element {
     this.locales = locales;
     this.proposals = proposals;
     this.isAnswerable = true;
+    this.hasShortProposals = Boolean(hasShortProposals);
 
     this.feedbacks = new Feedbacks(feedbacks);
     this.solutions = solutions;

--- a/api/src/devcomp/domain/models/element/QCU-declarative.js
+++ b/api/src/devcomp/domain/models/element/QCU-declarative.js
@@ -3,7 +3,7 @@ import { ModuleInstantiationError } from '../../errors.js';
 import { Element } from './Element.js';
 
 class QCUDeclarative extends Element {
-  constructor({ id, instruction, proposals }) {
+  constructor({ id, instruction, proposals, hasShortProposals = false } = {}) {
     super({ id, type: 'qcu-declarative' });
 
     assertNotNullOrUndefined(instruction, 'The instruction is required for a QCU declarative');
@@ -13,6 +13,7 @@ class QCUDeclarative extends Element {
     this.instruction = instruction;
     this.proposals = proposals;
     this.isAnswerable = true;
+    this.hasShortProposals = Boolean(hasShortProposals);
   }
 
   #assertProposalsAreNotEmpty(proposals) {

--- a/api/src/devcomp/domain/models/element/QCU-discovery.js
+++ b/api/src/devcomp/domain/models/element/QCU-discovery.js
@@ -1,9 +1,10 @@
 import { QCU } from './QCU.js';
 
 class QCUDiscovery extends QCU {
-  constructor({ id, instruction, proposals, solution }) {
+  constructor({ id, instruction, proposals, solution, hasShortProposals = false } = {}) {
     super({ id, instruction, proposals, solution, type: 'qcu-discovery' });
 
+    this.hasShortProposals = Boolean(hasShortProposals);
     this.solution = solution;
   }
 }

--- a/api/src/devcomp/domain/models/element/QCU.js
+++ b/api/src/devcomp/domain/models/element/QCU.js
@@ -3,7 +3,7 @@ import { ModuleInstantiationError } from '../../errors.js';
 import { Element } from './Element.js';
 
 class QCU extends Element {
-  constructor({ id, instruction, locales, proposals, solution, type = 'qcu' }) {
+  constructor({ id, instruction, locales, proposals, solution, type = 'qcu', hasShortProposals = false } = {}) {
     super({ id, type });
 
     assertNotNullOrUndefined(instruction, 'The instruction is required for a QCU');
@@ -16,6 +16,7 @@ class QCU extends Element {
     this.proposals = proposals;
     this.solution = solution;
     this.isAnswerable = true;
+    this.hasShortProposals = Boolean(hasShortProposals);
   }
 
   #assertProposalsAreNotEmpty(proposals) {

--- a/api/tests/devcomp/unit/domain/models/element/QCM_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/QCM_test.js
@@ -20,6 +20,7 @@ describe('Unit | Devcomp | Domain | Models | Element | QCM', function () {
         proposals: [proposal1, proposal2],
         feedbacks,
         solutions,
+        hasShortProposals: true,
       });
 
       // Then
@@ -30,6 +31,8 @@ describe('Unit | Devcomp | Domain | Models | Element | QCM', function () {
       expect(qcm.proposals).deep.equal([proposal1, proposal2]);
       expect(qcm.feedbacks).deep.equal(feedbacks);
       expect(qcm.solutions).deep.equal(solutions);
+      expect(qcm.isAnswerable).to.be.true;
+      expect(qcm.hasShortProposals).to.be.true;
     });
   });
 

--- a/api/tests/devcomp/unit/domain/models/element/QCU-declarative_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/QCU-declarative_test.js
@@ -20,6 +20,8 @@ describe('Unit | Devcomp | Domain | Models | Element | QCU-declarative', functio
       expect(qcu.instruction).equal('instruction');
       expect(qcu.type).equal('qcu-declarative');
       expect(qcu.proposals).deep.equal([proposal1, proposal2]);
+      expect(qcu.isAnswerable).to.be.true;
+      expect(qcu.hasShortProposals).to.be.false;
     });
   });
 });

--- a/api/tests/devcomp/unit/domain/models/element/QCU-discovery_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/QCU-discovery_test.js
@@ -17,6 +17,7 @@ describe('Unit | Devcomp | Domain | Models | Element | QCU-discovery', function 
         instruction: 'instruction',
         proposals: [proposal1, proposal2],
         solution: '1',
+        hasShortProposals: true,
       });
 
       // Then
@@ -25,6 +26,8 @@ describe('Unit | Devcomp | Domain | Models | Element | QCU-discovery', function 
       expect(qcu.type).equal('qcu-discovery');
       expect(qcu.proposals).deep.equal([proposal1, proposal2]);
       expect(qcu.solution).equal('1');
+      expect(qcu.isAnswerable).to.be.true;
+      expect(qcu.hasShortProposals).to.be.true;
     });
   });
 

--- a/api/tests/devcomp/unit/domain/models/element/QCU_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/QCU_test.js
@@ -17,6 +17,7 @@ describe('Unit | Devcomp | Domain | Models | Element | QCU', function () {
         locales: ['fr-FR'],
         proposals: [proposal1, proposal2],
         solution: 'proposal1',
+        hasShortProposals: true,
       });
 
       // Then
@@ -26,6 +27,8 @@ describe('Unit | Devcomp | Domain | Models | Element | QCU', function () {
       expect(qcu.locales).deep.equal(['fr-FR']);
       expect(qcu.proposals).deep.equal([proposal1, proposal2]);
       expect(qcu.solution).deep.equal('proposal1');
+      expect(qcu.isAnswerable).to.be.true;
+      expect(qcu.hasShortProposals).to.be.true;
       expect(qcu.feedbacks).to.be.undefined;
     });
   });

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/proposal-content-schema.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/proposal-content-schema.js
@@ -1,0 +1,9 @@
+import Joi from 'joi';
+
+import { htmlNotAllowedSchema, htmlSchema } from '../utils.js';
+
+export const proposalContentSchema = Joi.when(Joi.ref('....hasShortProposals'), {
+  is: true,
+  then: htmlNotAllowedSchema.required().max(20),
+  otherwise: htmlSchema.required(),
+});

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qcm-schema.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qcm-schema.js
@@ -2,6 +2,7 @@ import Joi from 'joi';
 
 import { htmlSchema, proposalIdSchema, uuidSchema } from '../utils.js';
 import { feedbackSchema } from './feedback-schema.js';
+import { proposalContentSchema } from './proposal-content-schema.js';
 
 const qcmElementSchema = Joi.object({
   id: uuidSchema,
@@ -10,7 +11,7 @@ const qcmElementSchema = Joi.object({
   proposals: Joi.array()
     .items({
       id: proposalIdSchema,
-      content: htmlSchema,
+      content: proposalContentSchema,
     })
     .min(3)
     .required(),
@@ -19,6 +20,7 @@ const qcmElementSchema = Joi.object({
     invalid: feedbackSchema,
   }).required(),
   solutions: Joi.array().items(proposalIdSchema).min(2).required(),
+  hasShortProposals: Joi.boolean().required().default(false),
 }).required();
 
 export { qcmElementSchema };

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qcm-schema.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qcm-schema.js
@@ -20,7 +20,7 @@ const qcmElementSchema = Joi.object({
     invalid: feedbackSchema,
   }).required(),
   solutions: Joi.array().items(proposalIdSchema).min(2).required(),
-  hasShortProposals: Joi.boolean().required().default(false),
+  hasShortProposals: Joi.boolean().optional().default(false),
 }).required();
 
 export { qcmElementSchema };

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qcu-declarative-schema.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qcu-declarative-schema.js
@@ -2,6 +2,7 @@ import Joi from 'joi';
 
 import { htmlSchema, proposalIdSchema, uuidSchema } from '../utils.js';
 import { feedbackNeutralSchema } from './feedback-neutral-schema.js';
+import { proposalContentSchema } from './proposal-content-schema.js';
 
 const qcuDeclarativeElementSchema = Joi.object({
   id: uuidSchema,
@@ -10,10 +11,11 @@ const qcuDeclarativeElementSchema = Joi.object({
   proposals: Joi.array()
     .items({
       id: proposalIdSchema.required(),
-      content: htmlSchema.required(),
+      content: proposalContentSchema,
       feedback: feedbackNeutralSchema.required(),
     })
     .required(),
+  hasShortProposals: Joi.boolean().required().default(false),
 });
 
 export { qcuDeclarativeElementSchema };

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qcu-declarative-schema.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qcu-declarative-schema.js
@@ -15,7 +15,7 @@ const qcuDeclarativeElementSchema = Joi.object({
       feedback: feedbackNeutralSchema.required(),
     })
     .required(),
-  hasShortProposals: Joi.boolean().required().default(false),
+  hasShortProposals: Joi.boolean().optional().default(false),
 });
 
 export { qcuDeclarativeElementSchema };

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qcu-discovery-schema.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qcu-discovery-schema.js
@@ -15,6 +15,7 @@ const qcuDiscoveryElementSchema = Joi.object({
     })
     .required(),
   solution: proposalIdSchema.required(),
+  hasShortProposals: Joi.boolean().required().default(false),
 });
 
 export { qcuDiscoveryElementSchema };

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qcu-discovery-schema.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qcu-discovery-schema.js
@@ -15,7 +15,7 @@ const qcuDiscoveryElementSchema = Joi.object({
     })
     .required(),
   solution: proposalIdSchema.required(),
-  hasShortProposals: Joi.boolean().required().default(false),
+  hasShortProposals: Joi.boolean().optional().default(false),
 });
 
 export { qcuDiscoveryElementSchema };

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qcu-schema.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qcu-schema.js
@@ -1,6 +1,6 @@
 import Joi from 'joi';
 
-import { htmlSchema, proposalIdSchema, uuidSchema } from '../utils.js';
+import { htmlNotAllowedSchema, htmlSchema, proposalIdSchema, uuidSchema } from '../utils.js';
 import { feedbackSchema } from './feedback-schema.js';
 
 const qcuElementSchema = Joi.object({
@@ -10,11 +10,16 @@ const qcuElementSchema = Joi.object({
   proposals: Joi.array()
     .items({
       id: proposalIdSchema.required(),
-      content: htmlSchema.required(),
+      content: Joi.when(Joi.ref('....hasShortProposals'), {
+        is: true,
+        then: htmlNotAllowedSchema.required().max(20),
+        otherwise: htmlSchema.required(),
+      }),
       feedback: feedbackSchema.required(),
     })
     .required(),
   solution: proposalIdSchema.required(),
+  hasShortProposals: Joi.boolean().required().default(false),
 });
 
 export { qcuElementSchema };

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qcu-schema.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qcu-schema.js
@@ -1,7 +1,8 @@
 import Joi from 'joi';
 
-import { htmlNotAllowedSchema, htmlSchema, proposalIdSchema, uuidSchema } from '../utils.js';
+import { htmlSchema, proposalIdSchema, uuidSchema } from '../utils.js';
 import { feedbackSchema } from './feedback-schema.js';
+import { proposalContentSchema } from './proposal-content-schema.js';
 
 const qcuElementSchema = Joi.object({
   id: uuidSchema,
@@ -10,11 +11,7 @@ const qcuElementSchema = Joi.object({
   proposals: Joi.array()
     .items({
       id: proposalIdSchema.required(),
-      content: Joi.when(Joi.ref('....hasShortProposals'), {
-        is: true,
-        then: htmlNotAllowedSchema.required().max(20),
-        otherwise: htmlSchema.required(),
-      }),
+      content: proposalContentSchema,
       feedback: feedbackSchema.required(),
     })
     .required(),

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qcu-schema.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qcu-schema.js
@@ -16,7 +16,7 @@ const qcuElementSchema = Joi.object({
     })
     .required(),
   solution: proposalIdSchema.required(),
-  hasShortProposals: Joi.boolean().required().default(false),
+  hasShortProposals: Joi.boolean().optional().default(false),
 });
 
 export { qcuElementSchema };

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js
@@ -322,6 +322,7 @@ describe('Unit | Infrastructure | Datasources | Learning Content | Module Dataso
             feedback: { state: 'Correct !', diagnosis: `<p>${i + 1}</p>` },
           })),
           solution: '1',
+          hasShortProposals: false,
         };
 
         await qcuElementSchema.validateAsync(sample, {
@@ -771,68 +772,34 @@ describe('Unit | Infrastructure | Datasources | Learning Content | Module Dataso
     describe('when element requires short answers', function () {
       it('should throw an error when an answer is long', async function () {
         // given
-        const moduleWithInvalidShortAnswer = {
-          id: 'b9a8e4f8-07cb-4448-9007-bb296f91e355',
-          shortId: '378523fb',
-          slug: 'reponses-courtes',
-          title: 'Réponses courtes',
-          isBeta: false,
-          visibility: 'public',
-          details: {
-            image: 'https://assets.pix.org/modules/placeholder-details.svg',
-            description: 'Module de test pour les réponses courtes',
-            duration: 0,
-            level: 'novice',
-            objectives: ['Tester les réponses courtes'],
-            tabletSupport: 'comfortable',
-          },
-          sections: [
+        const moduleWithTooLongShortAnswer = _createModuleWithElement({
+          id: 'ff22d014-ac30-4159-8b49-02a227766151',
+          type: 'qcu',
+          instruction: 'Hello',
+          hasShortProposals: true,
+          proposals: [
             {
-              id: '711c3c8a-b761-43a4-a841-588bfcaed6e8',
-              type: 'question-yourself',
-              grains: [
-                {
-                  id: '94b2eaed-ccc8-41a1-a7d9-875376cd73e8',
-                  type: 'short-lesson',
-                  title: '',
-                  components: [
-                    {
-                      type: 'element',
-                      element: {
-                        id: 'ff22d014-ac30-4159-8b49-02a227766151',
-                        type: 'qcu',
-                        instruction: 'Hello',
-                        hasShortProposals: true,
-                        proposals: [
-                          {
-                            id: '1',
-                            content: 'Une réponse bien',
-                            feedback: {
-                              state: '',
-                              diagnosis: 'Oui',
-                            },
-                          },
-                          {
-                            id: '2',
-                            content: 'Une réponse bien trop longue',
-                            feedback: {
-                              state: '',
-                              diagnosis: 'Non',
-                            },
-                          },
-                        ],
-                        solution: '1',
-                      },
-                    },
-                  ],
-                },
-              ],
+              id: '1',
+              content: 'Une réponse bien',
+              feedback: {
+                state: '',
+                diagnosis: 'Oui',
+              },
+            },
+            {
+              id: '2',
+              content: 'Une réponse bien trop longue',
+              feedback: {
+                state: '',
+                diagnosis: 'Non',
+              },
             },
           ],
-        };
+          solution: '1',
+        });
 
         try {
-          await moduleSchema.validateAsync(moduleWithInvalidShortAnswer, { abortEarly: false });
+          await moduleSchema.validateAsync(moduleWithTooLongShortAnswer, { abortEarly: false });
           throw new Error('Joi validation should have thrown');
         } catch (joiError) {
           expect(joiError.message).to.deep.equal(
@@ -843,68 +810,34 @@ describe('Unit | Infrastructure | Datasources | Learning Content | Module Dataso
 
       it('should throw an error when an answer short but contains HTML', async function () {
         // given
-        const moduleWithInvalidShortAnswer = {
-          id: 'b9a8e4f8-07cb-4448-9007-bb296f91e355',
-          shortId: '378523fb',
-          slug: 'reponses-courtes',
-          title: 'Réponses courtes',
-          isBeta: false,
-          visibility: 'public',
-          details: {
-            image: 'https://assets.pix.org/modules/placeholder-details.svg',
-            description: 'Module de test pour les réponses courtes',
-            duration: 0,
-            level: 'novice',
-            objectives: ['Tester les réponses courtes'],
-            tabletSupport: 'comfortable',
-          },
-          sections: [
+        const moduleWithShortAnswerContainingHTML = _createModuleWithElement({
+          id: 'ff22d014-ac30-4159-8b49-02a227766151',
+          type: 'qcu',
+          instruction: 'Hello',
+          hasShortProposals: true,
+          proposals: [
             {
-              id: '711c3c8a-b761-43a4-a841-588bfcaed6e8',
-              type: 'question-yourself',
-              grains: [
-                {
-                  id: '94b2eaed-ccc8-41a1-a7d9-875376cd73e8',
-                  type: 'short-lesson',
-                  title: '',
-                  components: [
-                    {
-                      type: 'element',
-                      element: {
-                        id: 'ff22d014-ac30-4159-8b49-02a227766151',
-                        type: 'qcu',
-                        instruction: 'Hello',
-                        hasShortProposals: true,
-                        proposals: [
-                          {
-                            id: '1',
-                            content: 'Une réponse bien',
-                            feedback: {
-                              state: '',
-                              diagnosis: 'Oui',
-                            },
-                          },
-                          {
-                            id: '2',
-                            content: '<blink>!</blink>',
-                            feedback: {
-                              state: '',
-                              diagnosis: 'Non',
-                            },
-                          },
-                        ],
-                        solution: '1',
-                      },
-                    },
-                  ],
-                },
-              ],
+              id: '1',
+              content: 'Une réponse bien',
+              feedback: {
+                state: '',
+                diagnosis: 'Oui',
+              },
+            },
+            {
+              id: '2',
+              content: '<blink>!</blink>',
+              feedback: {
+                state: '',
+                diagnosis: 'Non',
+              },
             },
           ],
-        };
+          solution: '1',
+        });
 
         try {
-          await moduleSchema.validateAsync(moduleWithInvalidShortAnswer, { abortEarly: false });
+          await moduleSchema.validateAsync(moduleWithShortAnswerContainingHTML, { abortEarly: false });
           throw new Error('Joi validation should have thrown');
         } catch (joiError) {
           expect(joiError.message).to.deep.equal(
@@ -917,68 +850,34 @@ describe('Unit | Infrastructure | Datasources | Learning Content | Module Dataso
     describe('when element allows long answers', function () {
       it('should not throw an error when an answer is long', async function () {
         // given
-        const moduleWithInvalidShortAnswer = {
-          id: 'b9a8e4f8-07cb-4448-9007-bb296f91e355',
-          shortId: '378523fb',
-          slug: 'reponses-courtes',
-          title: 'Réponses courtes',
-          isBeta: false,
-          visibility: 'public',
-          details: {
-            image: 'https://assets.pix.org/modules/placeholder-details.svg',
-            description: 'Module de test pour les réponses courtes',
-            duration: 0,
-            level: 'novice',
-            objectives: ['Tester les réponses courtes'],
-            tabletSupport: 'comfortable',
-          },
-          sections: [
+        const moduleWithValidLongAnswer = _createModuleWithElement({
+          id: 'ff22d014-ac30-4159-8b49-02a227766151',
+          type: 'qcu',
+          instruction: 'Hello',
+          hasShortProposals: false,
+          proposals: [
             {
-              id: '711c3c8a-b761-43a4-a841-588bfcaed6e8',
-              type: 'question-yourself',
-              grains: [
-                {
-                  id: '94b2eaed-ccc8-41a1-a7d9-875376cd73e8',
-                  type: 'short-lesson',
-                  title: '',
-                  components: [
-                    {
-                      type: 'element',
-                      element: {
-                        id: 'ff22d014-ac30-4159-8b49-02a227766151',
-                        type: 'qcu',
-                        instruction: 'Hello',
-                        hasShortProposals: false,
-                        proposals: [
-                          {
-                            id: '1',
-                            content: 'Une réponse bien',
-                            feedback: {
-                              state: '',
-                              diagnosis: 'Oui',
-                            },
-                          },
-                          {
-                            id: '2',
-                            content: 'Une réponse bien trop longue',
-                            feedback: {
-                              state: '',
-                              diagnosis: 'Non',
-                            },
-                          },
-                        ],
-                        solution: '1',
-                      },
-                    },
-                  ],
-                },
-              ],
+              id: '1',
+              content: 'Une réponse bien',
+              feedback: {
+                state: '',
+                diagnosis: 'Oui',
+              },
+            },
+            {
+              id: '2',
+              content: 'Une réponse bien trop longue',
+              feedback: {
+                state: '',
+                diagnosis: 'Non',
+              },
             },
           ],
-        };
+          solution: '1',
+        });
 
         try {
-          await moduleSchema.validateAsync(moduleWithInvalidShortAnswer, { abortEarly: false });
+          await moduleSchema.validateAsync(moduleWithValidLongAnswer, { abortEarly: false });
         } catch (joiError) {
           const formattedError = joiErrorParser.format(joiError);
           expect(joiError).to.equal(undefined, formattedError);
@@ -987,3 +886,36 @@ describe('Unit | Infrastructure | Datasources | Learning Content | Module Dataso
     });
   });
 });
+
+function _createModuleWithElement(element) {
+  return {
+    id: 'b9a8e4f8-07cb-4448-9007-bb296f91e355',
+    shortId: '378523fb',
+    slug: 'test-module',
+    title: 'Test module',
+    isBeta: false,
+    visibility: 'public',
+    details: {
+      image: 'https://assets.pix.org/modules/placeholder-details.svg',
+      description: 'Module de test',
+      duration: 0,
+      level: 'novice',
+      objectives: ['Tester les modules'],
+      tabletSupport: 'comfortable',
+    },
+    sections: [
+      {
+        id: '711c3c8a-b761-43a4-a841-588bfcaed6e8',
+        type: 'question-yourself',
+        grains: [
+          {
+            id: '94b2eaed-ccc8-41a1-a7d9-875376cd73e8',
+            type: 'short-lesson',
+            title: '',
+            components: [{ type: 'element', element }],
+          },
+        ],
+      },
+    ],
+  };
+}

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js
@@ -766,4 +766,224 @@ describe('Unit | Infrastructure | Datasources | Learning Content | Module Dataso
       }
     });
   });
+
+  describe('For elements that support short answers', function () {
+    describe('when element requires short answers', function () {
+      it('should throw an error when an answer is long', async function () {
+        // given
+        const moduleWithInvalidShortAnswer = {
+          id: 'b9a8e4f8-07cb-4448-9007-bb296f91e355',
+          shortId: '378523fb',
+          slug: 'reponses-courtes',
+          title: 'Réponses courtes',
+          isBeta: false,
+          visibility: 'public',
+          details: {
+            image: 'https://assets.pix.org/modules/placeholder-details.svg',
+            description: 'Module de test pour les réponses courtes',
+            duration: 0,
+            level: 'novice',
+            objectives: ['Tester les réponses courtes'],
+            tabletSupport: 'comfortable',
+          },
+          sections: [
+            {
+              id: '711c3c8a-b761-43a4-a841-588bfcaed6e8',
+              type: 'question-yourself',
+              grains: [
+                {
+                  id: '94b2eaed-ccc8-41a1-a7d9-875376cd73e8',
+                  type: 'short-lesson',
+                  title: '',
+                  components: [
+                    {
+                      type: 'element',
+                      element: {
+                        id: 'ff22d014-ac30-4159-8b49-02a227766151',
+                        type: 'qcu',
+                        instruction: 'Hello',
+                        hasShortProposals: true,
+                        proposals: [
+                          {
+                            id: '1',
+                            content: 'Une réponse bien',
+                            feedback: {
+                              state: '',
+                              diagnosis: 'Oui',
+                            },
+                          },
+                          {
+                            id: '2',
+                            content: 'Une réponse bien trop longue',
+                            feedback: {
+                              state: '',
+                              diagnosis: 'Non',
+                            },
+                          },
+                        ],
+                        solution: '1',
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        };
+
+        try {
+          await moduleSchema.validateAsync(moduleWithInvalidShortAnswer, { abortEarly: false });
+          throw new Error('Joi validation should have thrown');
+        } catch (joiError) {
+          expect(joiError.message).to.deep.equal(
+            '"sections[0].grains[0].components[0].element.proposals[1].content" length must be less than or equal to 20 characters long. "sections[0].grains" does not contain 1 required value(s)',
+          );
+        }
+      });
+
+      it('should throw an error when an answer short but contains HTML', async function () {
+        // given
+        const moduleWithInvalidShortAnswer = {
+          id: 'b9a8e4f8-07cb-4448-9007-bb296f91e355',
+          shortId: '378523fb',
+          slug: 'reponses-courtes',
+          title: 'Réponses courtes',
+          isBeta: false,
+          visibility: 'public',
+          details: {
+            image: 'https://assets.pix.org/modules/placeholder-details.svg',
+            description: 'Module de test pour les réponses courtes',
+            duration: 0,
+            level: 'novice',
+            objectives: ['Tester les réponses courtes'],
+            tabletSupport: 'comfortable',
+          },
+          sections: [
+            {
+              id: '711c3c8a-b761-43a4-a841-588bfcaed6e8',
+              type: 'question-yourself',
+              grains: [
+                {
+                  id: '94b2eaed-ccc8-41a1-a7d9-875376cd73e8',
+                  type: 'short-lesson',
+                  title: '',
+                  components: [
+                    {
+                      type: 'element',
+                      element: {
+                        id: 'ff22d014-ac30-4159-8b49-02a227766151',
+                        type: 'qcu',
+                        instruction: 'Hello',
+                        hasShortProposals: true,
+                        proposals: [
+                          {
+                            id: '1',
+                            content: 'Une réponse bien',
+                            feedback: {
+                              state: '',
+                              diagnosis: 'Oui',
+                            },
+                          },
+                          {
+                            id: '2',
+                            content: '<blink>!</blink>',
+                            feedback: {
+                              state: '',
+                              diagnosis: 'Non',
+                            },
+                          },
+                        ],
+                        solution: '1',
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        };
+
+        try {
+          await moduleSchema.validateAsync(moduleWithInvalidShortAnswer, { abortEarly: false });
+          throw new Error('Joi validation should have thrown');
+        } catch (joiError) {
+          expect(joiError.message).to.deep.equal(
+            '"sections[0].grains[0].components[0].element.proposals[1].content" failed custom validation because HTML is not allowed in this field. "sections[0].grains" does not contain 1 required value(s)',
+          );
+        }
+      });
+    });
+
+    describe('when element allows long answers', function () {
+      it('should not throw an error when an answer is long', async function () {
+        // given
+        const moduleWithInvalidShortAnswer = {
+          id: 'b9a8e4f8-07cb-4448-9007-bb296f91e355',
+          shortId: '378523fb',
+          slug: 'reponses-courtes',
+          title: 'Réponses courtes',
+          isBeta: false,
+          visibility: 'public',
+          details: {
+            image: 'https://assets.pix.org/modules/placeholder-details.svg',
+            description: 'Module de test pour les réponses courtes',
+            duration: 0,
+            level: 'novice',
+            objectives: ['Tester les réponses courtes'],
+            tabletSupport: 'comfortable',
+          },
+          sections: [
+            {
+              id: '711c3c8a-b761-43a4-a841-588bfcaed6e8',
+              type: 'question-yourself',
+              grains: [
+                {
+                  id: '94b2eaed-ccc8-41a1-a7d9-875376cd73e8',
+                  type: 'short-lesson',
+                  title: '',
+                  components: [
+                    {
+                      type: 'element',
+                      element: {
+                        id: 'ff22d014-ac30-4159-8b49-02a227766151',
+                        type: 'qcu',
+                        instruction: 'Hello',
+                        hasShortProposals: false,
+                        proposals: [
+                          {
+                            id: '1',
+                            content: 'Une réponse bien',
+                            feedback: {
+                              state: '',
+                              diagnosis: 'Oui',
+                            },
+                          },
+                          {
+                            id: '2',
+                            content: 'Une réponse bien trop longue',
+                            feedback: {
+                              state: '',
+                              diagnosis: 'Non',
+                            },
+                          },
+                        ],
+                        solution: '1',
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        };
+
+        try {
+          await moduleSchema.validateAsync(moduleWithInvalidShortAnswer, { abortEarly: false });
+        } catch (joiError) {
+          const formattedError = joiErrorParser.format(joiError);
+          expect(joiError).to.equal(undefined, formattedError);
+        }
+      });
+    });
+  });
 });

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
@@ -625,6 +625,7 @@ function getAttributesComponents() {
         ],
         feedbacks: { valid: { state: 'valid' }, invalid: { state: 'invalid' } },
         solutions: ['1', '2'],
+        hasShortProposals: false,
         type: 'qcm',
       },
     },

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
@@ -565,6 +565,7 @@ function getAttributesComponents() {
         instruction: 'hello',
         isAnswerable: true,
         locales: undefined,
+        hasShortProposals: false,
         proposals: [
           {
             content: 'toto',

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
@@ -583,6 +583,7 @@ function getAttributesComponents() {
         id: 'af447a7b-6790-4b3b-b83e-296e6618ca31',
         instruction: 'question declarative',
         isAnswerable: true,
+        hasShortProposals: false,
         proposals: [
           {
             content: 'plop',


### PR DESCRIPTION
## ❄️ Problème

Nous avons besoin d'une propriété permettant que les éléments QCU, QCM et QCU Découverte et QCU Déclaratif puissent être configuré pour afficher des réponses courtes.

## 🛷 Proposition

- Ajouter la propriété `hasShortProposals` à ces quatre éléments
- Ajouter les règles de validation Joi si `hasShortProposals` est `true`
	- la proposition doit faire 20 caractères ou moins
	- la proposition ne doit pas contenir de HTML

### TODO

- [x] QCU
- [x] QCM
- [x] QCU Découverte
- [x] QCU Déclaratif

## ☃️ Remarques

La propriété `hasShortProposals` est pour l'instant optionnelle en attendant que les modules soient mis à jour dans un prochain ticket.

## 🧑‍🎄 Pour tester

Pas de test fonctionnel.