### PR TITLE
[FEATURE] Modification design des feedbacks dans les modules sur Pix App (PIX-21136).

### DIFF
--- a/mon-pix/app/components/module/_feedback.scss
+++ b/mon-pix/app/components/module/_feedback.scss
@@ -1,50 +1,4 @@
 .feedback {
-  position: relative;
-  height: 100%;
-  padding: var(--pix-spacing-4x) var(--pix-spacing-6x);
-  border-radius: var(--pix-spacing-4x);
-
-  > p {
-    color: var(--modulix-feedback-state-color);
-  }
-
-  &--success {
-    --modulix-feedback-state-color: var(--pix-success-700);
-    --modulix-feedback-hover-color: var(--pix-success-500);
-    --modulix-feedback-focus-color: var(--pix-success-900);
-
-    background-color: var(--pix-success-50);
-  }
-
-  &--error {
-    --modulix-feedback-state-color: var(--pix-warning-700);
-    --modulix-feedback-hover-color: var(--pix-warning-500);
-    --modulix-feedback-focus-color: var(--pix-warning-900);
-
-    background-color: var(--pix-warning-50);
-  }
-
-  &__state {
-    font-weight: var(--pix-font-bold);
-  }
-
-  &__report-button {
-    display: flex;
-    justify-content: flex-end;
-
-    button:not([aria-disabled="true"]) {
-      color: var(--modulix-feedback-state-color);
-
-      &:hover {
-        color: var(--modulix-feedback-hover-color);
-      }
-
-      &:focus, &:active {
-        color: var(--modulix-feedback-focus-color);
-      }
-    }
-  }
-
   @media (not (prefers-reduced-motion: reduce)) {
     animation: 0.75s zoom-in-zoom-out ease;
 
@@ -62,5 +16,39 @@
         scale: 100%;
       }
     }
+  }
+
+  &--success {
+    --modulix-feedback-background-color: var(--pix-success-100);
+    --modulix-feedback-state-color: var(--pix-success-900);
+  }
+
+  &--error {
+    --modulix-feedback-background-color: var(--pix-warning-100);
+    --modulix-feedback-state-color: var(--pix-warning-900);
+  }
+
+  &__content {
+    position: relative;
+    height: 100%;
+    padding: var(--pix-spacing-4x) var(--pix-spacing-6x);
+    border-radius: var(--pix-spacing-4x);
+    background-color: var(--modulix-feedback-background-color);
+
+    > p {
+      color: var(--modulix-feedback-state-color);
+    }
+  }
+
+  &__buttons {
+    display: flex;
+    gap: var(--pix-spacing-4x);
+    justify-content: flex-end;
+  }
+}
+
+.feedback-content {
+  &__state {
+    font-weight: var(--pix-font-bold);
   }
 }

--- a/mon-pix/app/components/module/_feedback.scss
+++ b/mon-pix/app/components/module/_feedback.scss
@@ -26,17 +26,25 @@
   &--error {
     --modulix-feedback-background-color: var(--pix-warning-100);
     --modulix-feedback-state-color: var(--pix-warning-900);
+    --modulix-feedback-retry-content-color: var(--pix-warning-900);
+    --modulix-feedback-retry-background-color: var(--pix-warning-300-inline);
+    --modulix-feedback-hover-retry-background-color: var(--pix-warning-500-inline);
+    --modulix-feedback-focus-retry-content-color: var(--pix-warning-500);
   }
 
   &__content {
     position: relative;
     height: 100%;
     padding: var(--pix-spacing-4x) var(--pix-spacing-6x);
-    border-radius: var(--pix-spacing-4x);
     background-color: var(--modulix-feedback-background-color);
+    border-radius: var(--pix-spacing-4x);
 
     > p {
       color: var(--modulix-feedback-state-color);
+    }
+
+    &--with-retry-button {
+      border-bottom-right-radius: 0;
     }
   }
 
@@ -44,6 +52,26 @@
     display: flex;
     gap: var(--pix-spacing-4x);
     justify-content: flex-end;
+  }
+}
+
+.feedback-buttons {
+  &__retry {
+    padding: var(--pix-spacing-1x) var(--pix-spacing-4x);
+    color: var(--modulix-feedback-retry-content-color);
+    background-color: rgb(var(--modulix-feedback-retry-background-color), 0.8);
+    border-radius: 0 0 8px 8px;
+
+    &:not([aria-disabled="true"]) {
+      &:hover {
+        color: var(--modulix-feedback-retry-content-color);
+        background-color: rgb(var(--modulix-feedback-hover-retry-background-color), 0.8);
+      }
+
+      &:focus, &:active {
+        color: var(--modulix-feedback-focus-retry-content-color);
+      }
+    }
   }
 }
 

--- a/mon-pix/app/components/module/_feedback.scss
+++ b/mon-pix/app/components/module/_feedback.scss
@@ -32,6 +32,15 @@
     --modulix-feedback-focus-retry-content-color: var(--pix-warning-500);
   }
 
+  &--info {
+    --modulix-feedback-background-color: var(--pix-info-100);
+    --modulix-feedback-state-color: var(--pix-info-700);
+    --modulix-feedback-retry-content-color: var(--pix-info-900);
+    --modulix-feedback-retry-background-color: var(--pix-info-300-inline);
+    --modulix-feedback-hover-retry-background-color: var(--pix-info-500-inline);
+    --modulix-feedback-focus-retry-content-color: var(--pix-info-500);
+  }
+
   &__content {
     position: relative;
     height: 100%;

--- a/mon-pix/app/components/module/_feedback.scss
+++ b/mon-pix/app/components/module/_feedback.scss
@@ -4,6 +4,10 @@
   padding: var(--pix-spacing-4x) var(--pix-spacing-6x);
   border-radius: var(--pix-spacing-4x);
 
+  > p {
+    color: var(--modulix-feedback-state-color);
+  }
+
   &--success {
     --modulix-feedback-state-color: var(--pix-success-700);
     --modulix-feedback-hover-color: var(--pix-success-500);
@@ -21,7 +25,6 @@
   }
 
   &__state {
-    color: var(--modulix-feedback-state-color);
     font-weight: var(--pix-font-bold);
   }
 

--- a/mon-pix/app/components/module/element/_custom-draft.scss
+++ b/mon-pix/app/components/module/element/_custom-draft.scss
@@ -13,13 +13,14 @@
 
   &__buttons {
     display: flex;
-    justify-content: space-between;
+    gap: var(--pix-spacing-4x);
+    justify-content: flex-end;
   }
 
   &__container {
     padding: var(--pix-spacing-2x);
     border: 2px dashed var(--pix-primary-700);
-    border-radius: 8px 8px 8px 0;
+    border-radius: 8px 8px 0;
   }
 }
 

--- a/mon-pix/app/components/module/element/_custom-element.scss
+++ b/mon-pix/app/components/module/element/_custom-element.scss
@@ -28,7 +28,8 @@ message-conversation::part(conversation) {
 
   &__buttons {
     display: flex;
-    justify-content: space-between;
+    gap: var(--pix-spacing-4x);
+    justify-content: flex-end;
   }
 
   &__button {
@@ -38,11 +39,11 @@ message-conversation::part(conversation) {
 
   &--reset-state{
     background-color: var(--pix-primary-10);
-    border-radius: 16px 16px 16px 0;
+    border-radius: 16px 16px 0;
   }
 
   &--reset-interactive-state{
-    border-radius: 16px 16px 16px 0;
+    border-radius: 16px 16px 0;
   }
 }
 

--- a/mon-pix/app/components/module/element/_qcm.scss
+++ b/mon-pix/app/components/module/element/_qcm.scss
@@ -48,8 +48,4 @@
   &__required-field-missing {
     margin-bottom: var(--pix-spacing-4x);
   }
-
-  &__feedback {
-    margin-bottom: var(--pix-spacing-4x);
-  }
 }

--- a/mon-pix/app/components/module/element/_qcu-declarative.scss
+++ b/mon-pix/app/components/module/element/_qcu-declarative.scss
@@ -28,13 +28,6 @@
   }
 
   &__feedback {
-    @extend %pix-body-l;
-
-    padding: var(--pix-spacing-6x);
-    color: var(--pix-neutral-0);
-    background: var(--pix-neutral-800);
-    border-radius: 0 0 var(--pix-spacing-4x) var(--pix-spacing-4x);
-
     @media (not (prefers-reduced-motion: reduce)) {
       animation: 0.75s zoom-in-zoom-out ease;
 
@@ -57,20 +50,18 @@
 }
 
 .element-qcu-declarative-feedback {
+
+  &__content {
+    @extend %pix-body-l;
+
+    padding: var(--pix-spacing-6x);
+    color: var(--pix-neutral-0);
+    background: var(--pix-neutral-800);
+    border-radius: 0 0 var(--pix-spacing-4x) var(--pix-spacing-4x);
+  }
+
   &__report-button {
     display: flex;
     justify-content: flex-end;
-
-    button:not([aria-disabled="true"]) {
-      color: var(--pix-neutral-0);
-
-      &:hover {
-        color: var(--pix-neutral-100);
-      }
-
-      &:focus, &:active {
-        color: var(--pix-neutral-0);
-      }
-    }
   }
 }

--- a/mon-pix/app/components/module/element/_qcu-discovery.scss
+++ b/mon-pix/app/components/module/element/_qcu-discovery.scss
@@ -18,47 +18,4 @@
     gap: var(--pix-spacing-3x);
     margin: var(--pix-spacing-4x) 0;
   }
-
-  &__feedback {
-    color: var(--pix-neutral-800);
-    background: var(--pix-info-100);
-
-    @media (not (prefers-reduced-motion: reduce)) {
-      animation: 0.75s zoom-in-zoom-out ease;
-
-      @keyframes zoom-in-zoom-out {
-        0% {
-          scale: 100%;
-          overflow: hidden;
-        }
-
-        50% {
-          scale: 110%;
-        }
-
-        100% {
-          scale: 100%;
-        }
-      }
-    }
-  }
-}
-
-.element-qcu-discovery-feedback {
-  &__report-button {
-    display: flex;
-    justify-content: flex-end;
-
-    button:not([aria-disabled="true"]) {
-      color: var(--pix-info-700);
-
-      &:hover {
-        color: var(--pix-info-500);
-      }
-
-      &:focus, &:active {
-        color: var(--pix-info-900);
-      }
-    }
-  }
 }

--- a/mon-pix/app/components/module/element/_qcu.scss
+++ b/mon-pix/app/components/module/element/_qcu.scss
@@ -48,9 +48,4 @@
   &__required-field-missing {
     margin-bottom: var(--pix-spacing-4x);
   }
-
-  &__feedback {
-    margin-top: var(--pix-spacing-1x);
-    margin-bottom: var(--pix-spacing-4x);
-  }
 }

--- a/mon-pix/app/components/module/element/_qrocm.scss
+++ b/mon-pix/app/components/module/element/_qrocm.scss
@@ -19,10 +19,6 @@
   &__required-field-missing {
     margin-bottom: var(--pix-spacing-4x);
   }
-
-  &__feedback {
-    margin-bottom: var(--pix-spacing-4x);
-  }
 }
 
 .element-qrocm-proposals {

--- a/mon-pix/app/components/module/element/custom-draft.gjs
+++ b/mon-pix/app/components/module/element/custom-draft.gjs
@@ -61,6 +61,8 @@ export default class ModulixCustomDraft extends ModuleElement {
       </fieldset>
 
       <div class="element-custom-draft__buttons">
+        <ModulixIssueReportBlock @reportInfo={{this.reportInfo}} />
+
         <PixButton
           class="element-custom-draft-buttons__reset"
           @iconBefore="refresh"
@@ -68,8 +70,6 @@ export default class ModulixCustomDraft extends ModuleElement {
           @triggerAction={{this.resetEmbed}}
           aria-label="{{t 'pages.modulix.buttons.interactive-element.reset.ariaLabel'}}"
         >{{t "pages.modulix.buttons.interactive-element.reset.name"}}</PixButton>
-
-        <ModulixIssueReportBlock @reportInfo={{this.reportInfo}} />
       </div>
     </div>
   </template>

--- a/mon-pix/app/components/module/element/custom-element.gjs
+++ b/mon-pix/app/components/module/element/custom-element.gjs
@@ -77,6 +77,8 @@ export default class ModulixCustomElement extends ModuleElement {
       {{/if}}
 
       <div class={{if this.resetButtonDisplayed "element-custom__buttons" "element-custom__button"}}>
+        <ModulixIssueReportBlock @reportInfo={{this.reportInfo}} />
+
         {{#if this.resetButtonDisplayed}}
           <PixButton
             class="element-custom-buttons__reset"
@@ -86,8 +88,6 @@ export default class ModulixCustomElement extends ModuleElement {
             aria-label="{{t 'pages.modulix.buttons.interactive-element.reset.ariaLabel'}}"
           >{{t "pages.modulix.buttons.interactive-element.reset.name"}}</PixButton>
         {{/if}}
-
-        <ModulixIssueReportBlock @reportInfo={{this.reportInfo}} />
       </div>
     </div>
   </template>

--- a/mon-pix/app/components/module/element/qab/_qab.scss
+++ b/mon-pix/app/components/module/element/qab/_qab.scss
@@ -21,13 +21,11 @@
     justify-items: center;
   }
 
-  &__feedback {
-    color: var(--pix-neutral-800);
-    background: var(--pix-info-100);
-  }
-
   &__retry-button {
-    margin-bottom: var(--pix-spacing-2x);
+    display: flex;
+    justify-content: flex-end;
+    max-width: 560px;
+    margin: 0 auto;
   }
 
   &__proposals {
@@ -44,23 +42,6 @@
     &--empty {
       height: 0;
       margin-top: 0;
-    }
-  }
-
-  &__report-button {
-    display: flex;
-    justify-content: flex-end;
-
-    button:not([aria-disabled="true"]) {
-      color: var(--pix-info-700);
-
-      &:hover {
-        color: var(--pix-info-500);
-      }
-
-      &:focus, &:active {
-        color: var(--pix-info-900);
-      }
     }
   }
 }

--- a/mon-pix/app/components/module/element/qab/qab.gjs
+++ b/mon-pix/app/components/module/element/qab/qab.gjs
@@ -6,10 +6,10 @@ import { t } from 'ember-intl';
 import QabProposalButton from 'mon-pix/components/module/element/qab/proposal-button';
 import QabCard from 'mon-pix/components/module/element/qab/qab-card';
 import QabScoreCard from 'mon-pix/components/module/element/qab/qab-score-card';
+import ModulixFeedback from 'mon-pix/components/module/feedback';
 import { TrackedArray, TrackedMap } from 'tracked-built-ins';
 
 import { htmlUnsafe } from '../../../../helpers/html-unsafe';
-import ModulixIssueReportBlock from '../../issue-report/issue-report-block';
 import ModuleElement from '../module-element';
 
 const NEXT_CARD_REMOVE_DELAY = 400;
@@ -40,10 +40,6 @@ export default class ModuleQab extends ModuleElement {
 
   get currentCard() {
     return this.displayedCards[0];
-  }
-
-  get feedback() {
-    return this.element.feedback.diagnosis;
   }
 
   get shouldDisplayFeedback() {
@@ -186,26 +182,22 @@ export default class ModuleQab extends ModuleElement {
         </div>
       </fieldset>
     </form>
-    {{#if this.shouldDisplayFeedback}}
-      <div class="feedback element-qab__feedback" role="status" tabindex="-1">
-        {{htmlUnsafe this.feedback}}
 
-        <div class="element-qab__report-button">
-          <ModulixIssueReportBlock @reportInfo={{this.reportInfo}} />
+    {{#if this.shouldDisplayFeedback}}
+      <ModulixFeedback
+        @feedback={{this.element.feedback}}
+        @reportInfo={{this.reportInfo}}
+        @shouldDisplayRetryButton={{this.shouldDisplayScore}}
+        @retry={{this.onRetry}}
+      />
+    {{else}}
+      {{#if this.shouldDisplayScore}}
+        <div class="element-qab__retry-button">
+          <PixButton @variant="tertiary" @triggerAction={{this.onRetry}} @iconAfter="refresh">
+            {{t "pages.modulix.qab.retry"}}
+          </PixButton>
         </div>
-      </div>
-    {{/if}}
-    {{#if this.shouldDisplayScore}}
-      <PixButton
-        class="element-qab__retry-button"
-        @variant="tertiary"
-        @size="small"
-        @type="button"
-        @triggerAction={{this.onRetry}}
-        @iconAfter="refresh"
-      >
-        {{t "pages.modulix.qab.retry"}}
-      </PixButton>
+      {{/if}}
     {{/if}}
   </template>
 }

--- a/mon-pix/app/components/module/element/qcm.gjs
+++ b/mon-pix/app/components/module/element/qcm.gjs
@@ -179,24 +179,18 @@ export default class ModuleQcm extends ModuleElement {
         </PixButton>
       {{/unless}}
 
-      <div class="element-qcm__feedback" role="status" tabindex="-1">
-        {{#if this.shouldDisplayFeedback}}
-          <ModulixFeedback
-            @answerIsValid={{this.answerIsValid}}
-            @feedback={{this.correction.feedback}}
-            @reportInfo={{this.reportInfo}}
-          />
-        {{/if}}
-      </div>
+      {{#if this.shouldDisplayFeedback}}
+        <ModulixFeedback
+          @answerIsValid={{this.answerIsValid}}
+          @feedback={{this.correction.feedback}}
+          @reportInfo={{this.reportInfo}}
+        />
+      {{/if}}
 
       {{#if this.modulixPreviewMode.isEnabled}}
-        <div role="status" tabindex="-1">
-          {{#each this.previewFeedbacks as |feedback|}}
-            <div class="element-qcm__feedback">
-              <ModulixFeedback @answerIsValid={{this.isValidFeedbackForPreview feedback}} @feedback={{feedback}} />
-            </div>
-          {{/each}}
-        </div>
+        {{#each this.previewFeedbacks as |feedback|}}
+          <ModulixFeedback @answerIsValid={{this.isValidFeedbackForPreview feedback}} @feedback={{feedback}} />
+        {{/each}}
       {{/if}}
 
       {{#if this.shouldDisplayRetryButton}}

--- a/mon-pix/app/components/module/element/qcm.gjs
+++ b/mon-pix/app/components/module/element/qcm.gjs
@@ -184,6 +184,8 @@ export default class ModuleQcm extends ModuleElement {
           @answerIsValid={{this.answerIsValid}}
           @feedback={{this.correction.feedback}}
           @reportInfo={{this.reportInfo}}
+          @shouldDisplayRetryButton={{this.shouldDisplayRetryButton}}
+          @retry={{this.retry}}
         />
       {{/if}}
 
@@ -191,19 +193,6 @@ export default class ModuleQcm extends ModuleElement {
         {{#each this.previewFeedbacks as |feedback|}}
           <ModulixFeedback @answerIsValid={{this.isValidFeedbackForPreview feedback}} @feedback={{feedback}} />
         {{/each}}
-      {{/if}}
-
-      {{#if this.shouldDisplayRetryButton}}
-        <PixButton
-          class="element-qcm__retry-button"
-          @variant="tertiary"
-          @size="small"
-          @type="button"
-          @triggerAction={{this.retry}}
-          @iconBefore="refresh"
-        >
-          {{t "pages.modulix.buttons.activity.retry"}}
-        </PixButton>
       {{/if}}
     </form>
   </template>

--- a/mon-pix/app/components/module/element/qcu-declarative.gjs
+++ b/mon-pix/app/components/module/element/qcu-declarative.gjs
@@ -81,7 +81,9 @@ export default class ModuleQcuDeclarative extends ModuleElement {
             />
             {{#if this.modulixPreviewMode.isEnabled}}
               <div class="element-qcu-declarative__feedback" role="status" tabindex="-1">
-                {{htmlUnsafe proposal.feedback.diagnosis}}
+                <div class="element-qcu-declarative-feedback__content">
+                  {{htmlUnsafe proposal.feedback.diagnosis}}
+                </div>
               </div>
             {{/if}}
           {{/each}}
@@ -90,8 +92,9 @@ export default class ModuleQcuDeclarative extends ModuleElement {
     </form>
     {{#if this.shouldDisplayFeedback}}
       <div class="element-qcu-declarative__feedback" role="status" tabindex="-1">
-        {{htmlUnsafe this.selectedProposalFeedback}}
-
+        <div class="element-qcu-declarative-feedback__content">
+          {{htmlUnsafe this.selectedProposalFeedback}}
+        </div>
         <div class="element-qcu-declarative-feedback__report-button">
           <ModulixIssueReportBlock @reportInfo={{this.reportInfo}} />
         </div>

--- a/mon-pix/app/components/module/element/qcu-discovery.gjs
+++ b/mon-pix/app/components/module/element/qcu-discovery.gjs
@@ -3,10 +3,10 @@ import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 import ProposalButton from 'mon-pix/components/module/component/proposal-button';
+import ModulixFeedback from 'mon-pix/components/module/feedback';
 
 import { htmlUnsafe } from '../../../helpers/html-unsafe';
 import { VERIFY_RESPONSE_DELAY } from '../component/element';
-import ModulixIssueReportBlock from '../issue-report/issue-report-block';
 import ModuleElement from './module-element';
 
 export default class ModuleQcuDiscovery extends ModuleElement {
@@ -18,7 +18,7 @@ export default class ModuleQcuDiscovery extends ModuleElement {
   @service modulixPreviewMode;
 
   get selectedProposalFeedback() {
-    return this.element.proposals.find((proposal) => proposal.id === this.selectedProposalId).feedback.diagnosis;
+    return this.element.proposals.find((proposal) => proposal.id === this.selectedProposalId).feedback;
   }
 
   get selectedProposalAnswer() {
@@ -82,22 +82,15 @@ export default class ModuleQcuDiscovery extends ModuleElement {
               @isDiscoveryVariant={{true}}
             />
             {{#if this.modulixPreviewMode.isEnabled}}
-              <div class="element-qcu-discovery__feedback" role="status" tabindex="-1">
-                {{htmlUnsafe proposal.feedback.diagnosis}}
-              </div>
+              <ModulixFeedback @feedback={{proposal.feedback}} />
             {{/if}}
           {{/each}}
         </div>
       </fieldset>
     </form>
-    {{#if this.shouldDisplayFeedback}}
-      <div class="feedback element-qcu-discovery__feedback" role="status" tabindex="-1">
-        {{htmlUnsafe this.selectedProposalFeedback}}
 
-        <div class="element-qcu-discovery-feedback__report-button">
-          <ModulixIssueReportBlock @reportInfo={{this.reportInfo}} />
-        </div>
-      </div>
+    {{#if this.shouldDisplayFeedback}}
+      <ModulixFeedback @feedback={{this.selectedProposalFeedback}} @reportInfo={{this.reportInfo}} />
     {{/if}}
   </template>
 }

--- a/mon-pix/app/components/module/element/qcu.gjs
+++ b/mon-pix/app/components/module/element/qcu.gjs
@@ -184,20 +184,9 @@ export default class ModuleQcu extends ModuleElement {
           @answerIsValid={{this.answerIsValid}}
           @feedback={{this.correction.feedback}}
           @reportInfo={{this.reportInfo}}
+          @shouldDisplayRetryButton={{this.shouldDisplayRetryButton}}
+          @retry={{this.retry}}
         />
-      {{/if}}
-
-      {{#if this.shouldDisplayRetryButton}}
-        <PixButton
-          class="element-qcu__retry-button"
-          @variant="tertiary"
-          @size="small"
-          @type="button"
-          @triggerAction={{this.retry}}
-          @iconBefore="refresh"
-        >
-          {{t "pages.modulix.buttons.activity.retry"}}
-        </PixButton>
       {{/if}}
     </form>
   </template>

--- a/mon-pix/app/components/module/element/qcu.gjs
+++ b/mon-pix/app/components/module/element/qcu.gjs
@@ -151,12 +151,10 @@ export default class ModuleQcu extends ModuleElement {
             </PixRadioButton>
 
             {{#if this.modulixPreviewMode.isEnabled}}
-              <div class="element-qcu__feedback" role="status" tabindex="-1">
-                <ModulixFeedback
-                  @answerIsValid={{this.isValidFeedbackForPreview proposal.id}}
-                  @feedback={{proposal.feedback}}
-                />
-              </div>
+              <ModulixFeedback
+                @answerIsValid={{this.isValidFeedbackForPreview proposal.id}}
+                @feedback={{proposal.feedback}}
+              />
             {{/if}}
           {{/each}}
         </div>
@@ -181,15 +179,13 @@ export default class ModuleQcu extends ModuleElement {
         </PixButton>
       {{/unless}}
 
-      <div class="element-qcu__feedback" role="status" tabindex="-1">
-        {{#if this.shouldDisplayFeedback}}
-          <ModulixFeedback
-            @answerIsValid={{this.answerIsValid}}
-            @feedback={{this.correction.feedback}}
-            @reportInfo={{this.reportInfo}}
-          />
-        {{/if}}
-      </div>
+      {{#if this.shouldDisplayFeedback}}
+        <ModulixFeedback
+          @answerIsValid={{this.answerIsValid}}
+          @feedback={{this.correction.feedback}}
+          @reportInfo={{this.reportInfo}}
+        />
+      {{/if}}
 
       {{#if this.shouldDisplayRetryButton}}
         <PixButton

--- a/mon-pix/app/components/module/element/qrocm.gjs
+++ b/mon-pix/app/components/module/element/qrocm.gjs
@@ -246,24 +246,18 @@ export default class ModuleQrocm extends ModuleElement {
         </PixButton>
       {{/unless}}
 
-      <div class="element-qrocm__feedback" role="status" tabindex="-1">
-        {{#if this.shouldDisplayFeedback}}
-          <ModulixFeedback
-            @answerIsValid={{this.answerIsValid}}
-            @feedback={{this.correction.feedback}}
-            @reportInfo={{this.reportInfo}}
-          />
-        {{/if}}
-      </div>
+      {{#if this.shouldDisplayFeedback}}
+        <ModulixFeedback
+          @answerIsValid={{this.answerIsValid}}
+          @feedback={{this.correction.feedback}}
+          @reportInfo={{this.reportInfo}}
+        />
+      {{/if}}
 
       {{#if this.modulixPreviewMode.isEnabled}}
-        <div role="status" tabindex="-1">
-          {{#each this.previewFeedbacks as |feedback|}}
-            <div class="element-qrocm__feedback">
-              <ModulixFeedback @answerIsValid={{this.isValidFeedbackForPreview feedback}} @feedback={{feedback}} />
-            </div>
-          {{/each}}
-        </div>
+        {{#each this.previewFeedbacks as |feedback|}}
+          <ModulixFeedback @answerIsValid={{this.isValidFeedbackForPreview feedback}} @feedback={{feedback}} />
+        {{/each}}
       {{/if}}
 
       {{#if this.shouldDisplayRetryButton}}

--- a/mon-pix/app/components/module/element/qrocm.gjs
+++ b/mon-pix/app/components/module/element/qrocm.gjs
@@ -251,6 +251,8 @@ export default class ModuleQrocm extends ModuleElement {
           @answerIsValid={{this.answerIsValid}}
           @feedback={{this.correction.feedback}}
           @reportInfo={{this.reportInfo}}
+          @shouldDisplayRetryButton={{this.shouldDisplayRetryButton}}
+          @retry={{this.retry}}
         />
       {{/if}}
 
@@ -258,19 +260,6 @@ export default class ModuleQrocm extends ModuleElement {
         {{#each this.previewFeedbacks as |feedback|}}
           <ModulixFeedback @answerIsValid={{this.isValidFeedbackForPreview feedback}} @feedback={{feedback}} />
         {{/each}}
-      {{/if}}
-
-      {{#if this.shouldDisplayRetryButton}}
-        <PixButton
-          class="element-qrocm__retry-button"
-          @variant="tertiary"
-          @size="small"
-          @type="button"
-          @triggerAction={{this.retry}}
-          @iconBefore="refresh"
-        >
-          {{t "pages.modulix.buttons.activity.retry"}}
-        </PixButton>
       {{/if}}
     </form>
   </template>

--- a/mon-pix/app/components/module/feedback.gjs
+++ b/mon-pix/app/components/module/feedback.gjs
@@ -11,7 +11,7 @@ export default class ModulixFeedback extends Component {
   }
 
   <template>
-    <div class="feedback feedback-{{this.type}}">
+    <div class="feedback feedback--{{this.type}}" role="status" tabindex="-1">
       <div class="feedback__content">
         {{#if @feedback.state}}
           <p class="feedback-content__state">{{htmlUnsafe @feedback.state}}</p>

--- a/mon-pix/app/components/module/feedback.gjs
+++ b/mon-pix/app/components/module/feedback.gjs
@@ -1,4 +1,6 @@
+import PixButton from '@1024pix/pix-ui/components/pix-button';
 import Component from '@glimmer/component';
+import { t } from 'ember-intl';
 
 import { htmlUnsafe } from '../../helpers/html-unsafe';
 import ModulixIssueReportBlock from './issue-report/issue-report-block';
@@ -9,13 +11,15 @@ export default class ModulixFeedback extends Component {
   }
 
   <template>
-    <div class="feedback feedback--{{this.type}}">
-      {{#if @feedback.state}}
-        <p class="feedback__state">{{htmlUnsafe @feedback.state}}</p>
-      {{/if}}
-      {{htmlUnsafe @feedback.diagnosis}}
+    <div class="feedback feedback-{{this.type}}">
+      <div class="feedback__content">
+        {{#if @feedback.state}}
+          <p class="feedback-content__state">{{htmlUnsafe @feedback.state}}</p>
+        {{/if}}
+        {{htmlUnsafe @feedback.diagnosis}}
 
-      <div class="feedback__report-button">
+      </div>
+      <div class="feedback__buttons">
         <ModulixIssueReportBlock @reportInfo={{@reportInfo}} />
       </div>
     </div>

--- a/mon-pix/app/components/module/feedback.gjs
+++ b/mon-pix/app/components/module/feedback.gjs
@@ -23,7 +23,9 @@ export default class ModulixFeedback extends Component {
 
       </div>
       <div class="feedback__buttons">
-        <ModulixIssueReportBlock @reportInfo={{@reportInfo}} />
+        {{#if @reportInfo}}
+          <ModulixIssueReportBlock @reportInfo={{@reportInfo}} />
+        {{/if}}
         {{#if @shouldDisplayRetryButton}}
           <PixButton
             class="feedback-buttons__retry"

--- a/mon-pix/app/components/module/feedback.gjs
+++ b/mon-pix/app/components/module/feedback.gjs
@@ -7,6 +7,9 @@ import ModulixIssueReportBlock from './issue-report/issue-report-block';
 
 export default class ModulixFeedback extends Component {
   get type() {
+    if (this.args.answerIsValid === undefined) {
+      return 'info';
+    }
     return this.args.answerIsValid ? 'success' : 'error';
   }
 

--- a/mon-pix/app/components/module/feedback.gjs
+++ b/mon-pix/app/components/module/feedback.gjs
@@ -11,7 +11,7 @@ export default class ModulixFeedback extends Component {
   <template>
     <div class="feedback feedback--{{this.type}}">
       {{#if @feedback.state}}
-        <div class="feedback__state">{{htmlUnsafe @feedback.state}}</div>
+        <p class="feedback__state">{{htmlUnsafe @feedback.state}}</p>
       {{/if}}
       {{htmlUnsafe @feedback.diagnosis}}
 

--- a/mon-pix/app/components/module/feedback.gjs
+++ b/mon-pix/app/components/module/feedback.gjs
@@ -12,7 +12,7 @@ export default class ModulixFeedback extends Component {
 
   <template>
     <div class="feedback feedback--{{this.type}}" role="status" tabindex="-1">
-      <div class="feedback__content">
+      <div class="feedback__content {{if @shouldDisplayRetryButton 'feedback__content--with-retry-button'}}">
         {{#if @feedback.state}}
           <p class="feedback-content__state">{{htmlUnsafe @feedback.state}}</p>
         {{/if}}
@@ -21,6 +21,16 @@ export default class ModulixFeedback extends Component {
       </div>
       <div class="feedback__buttons">
         <ModulixIssueReportBlock @reportInfo={{@reportInfo}} />
+        {{#if @shouldDisplayRetryButton}}
+          <PixButton
+            class="feedback-buttons__retry"
+            @variant="tertiary"
+            @triggerAction={{@retry}}
+            @iconBefore="refresh"
+          >
+            {{t "pages.modulix.buttons.activity.retry"}}
+          </PixButton>
+        {{/if}}
       </div>
     </div>
   </template>

--- a/mon-pix/tests/acceptance/module/retry-qcm_test.js
+++ b/mon-pix/tests/acceptance/module/retry-qcm_test.js
@@ -75,7 +75,6 @@ module('Acceptance | Module | Routes | retryQcm', function (hooks) {
     await click(retryButton);
 
     // then
-    assert.strictEqual(screen.queryByRole('status').innerText, '');
     assert.false(qcmForm.disabled);
     assert.false(wrongAnswerCheckbox.checked);
     assert.false(rightAnswerCheckbox.checked);
@@ -155,7 +154,6 @@ module('Acceptance | Module | Routes | retryQcm', function (hooks) {
     await click(retryButton);
 
     // then
-    assert.strictEqual(screen.queryByRole('status').innerText, '');
     assert.false(qcmForm.disabled);
     assert.false(wrongAnswerCheckbox.checked);
     assert.false(rightAnswerCheckbox.checked);

--- a/mon-pix/tests/acceptance/module/retry-qcu_test.js
+++ b/mon-pix/tests/acceptance/module/retry-qcu_test.js
@@ -83,7 +83,6 @@ module('Acceptance | Module | Routes | retryQcu', function (hooks) {
     await click(retryButton);
 
     // then
-    assert.strictEqual(feedback.innerText, '');
     assert.false(firstQcuForm.disabled);
     assert.false(wrongAnswerRadio.checked);
     assert.false(rightAnswerRadio.checked);
@@ -171,14 +170,11 @@ module('Acceptance | Module | Routes | retryQcu', function (hooks) {
     await click(wrongAnswerRadio);
     await click(firstQcuVerifyButton);
 
-    const feedback = await screen.findByRole('status');
-
     // when
     const retryButton = await screen.findByRole('button', { name: 'Réessayer' });
     await click(retryButton);
 
     // then
-    assert.strictEqual(feedback.innerText, '');
     assert.false(firstQcuForm.disabled);
     assert.false(wrongAnswerRadio.checked);
     assert.false(rightAnswerRadio.checked);

--- a/mon-pix/tests/acceptance/module/retry-qrocm_test.js
+++ b/mon-pix/tests/acceptance/module/retry-qrocm_test.js
@@ -101,7 +101,6 @@ module('Acceptance | Module | Routes | retryQrocm', function (hooks) {
     await click(retryButton);
 
     // then
-    assert.strictEqual(screen.queryByRole('status').innerText, '');
     assert.false(qrocmForm.disabled);
     await clickByName('Réponse 1');
     await screen.findByRole('listbox');

--- a/mon-pix/tests/integration/components/module/feedback_test.gjs
+++ b/mon-pix/tests/integration/components/module/feedback_test.gjs
@@ -81,4 +81,23 @@ module('Integration | Component | Module | Feedback', function (hooks) {
       assert.dom(screen.getByRole('heading', { name: t('pages.modulix.issue-report.modal.title'), level: 1 })).exists();
     });
   });
+
+  test('should display retry button', async function (assert) {
+    // given
+    const feedback = {
+      state: 'Correct !',
+      diagnosis: "<p>C'est la bonne réponse !</p>",
+    };
+    const shouldDisplayRetryButton = true;
+
+    // when
+    const screen = await render(
+      <template>
+        <ModulixFeedback @feedback={{feedback}} @shouldDisplayRetryButton={{shouldDisplayRetryButton}} />
+      </template>,
+    );
+
+    // then
+    assert.dom(screen.getByRole('button', { name: t('pages.modulix.buttons.activity.retry') })).exists();
+  });
 });

--- a/mon-pix/tests/integration/components/module/feedback_test.gjs
+++ b/mon-pix/tests/integration/components/module/feedback_test.gjs
@@ -48,10 +48,13 @@ module('Integration | Component | Module | Feedback', function (hooks) {
       state: 'Correct !',
       diagnosis: "<p>C'est la bonne réponse !</p>",
     };
+    const reportInfo = { answer: 1, elementId: 123 };
 
     // when
     const screen = await render(
-      <template><ModulixFeedback @answerIsValid={{true}} @feedback={{feedback}} /></template>,
+      <template>
+        <ModulixFeedback @answerIsValid={{true}} @feedback={{feedback}} @reportInfo={{reportInfo}} />
+      </template>,
     );
 
     // then
@@ -65,12 +68,13 @@ module('Integration | Component | Module | Feedback', function (hooks) {
         state: 'Correct !',
         diagnosis: "<p>C'est la bonne réponse !</p>",
       };
+      const reportInfo = { answer: 1, elementId: 123 };
 
       // when
       const screen = await render(
         <template>
           <div id="modal-container"></div>
-          <ModulixFeedback @answerIsValid={{true}} @feedback={{feedback}} />
+          <ModulixFeedback @answerIsValid={{true}} @feedback={{feedback}} @reportInfo={{reportInfo}} />
         </template>,
       );
       await click(screen.getByRole('button', { name: t('pages.modulix.issue-report.aria-label') }));

--- a/mon-pix/tests/integration/components/module/feedback_test.gjs
+++ b/mon-pix/tests/integration/components/module/feedback_test.gjs
@@ -22,6 +22,7 @@ module('Integration | Component | Module | Feedback', function (hooks) {
     );
 
     // then
+    assert.dom(screen.getByRole('status')).exists();
     assert.dom(screen.getByText('Correct !')).exists();
     assert.dom(screen.getByText("C'est la bonne réponse !")).exists();
   });


### PR DESCRIPTION
## ❄️ Problème

La team design a amélioré les feedbacks dans les modules. Disposition des différents boutons, couleurs, etc..

## 🛷 Proposition

Appliquer les modifications dans les différents éléments : 
- QAB (report button extrait du feedback, le retry button à sa droite)
- QCU (report button extrait du feedback, le retry button à sa droite)
- QCM (report button extrait du feedback, le retry button à sa droite)
- QROCM (report button extrait du feedback, le retry button à sa droite)
- QCU-déclaratif (report button extrait du feedback)
- QCU-découverte (report button extrait du feedback)
- POI (inversion des bouton retry et report, collé sur la droite avec un gap 4x)

## 🧑‍🎄 Pour tester

Faites une comparaison avec un autre environnement : 

- https://app-pr14934.review.pix.fr/modules/6a68bf32/bac-a-sable/details

Passer le module en entier pour voir afficher les feedbacks : 
- en succès, en erreur, en info

### QAB
> [!NOTE]
> focus 
<img width="637" height="431" alt="Capture d’écran 2026-01-30 à 15 54 56" src="https://github.com/user-attachments/assets/6774b877-86d5-4db5-a832-cc119092ad24" />

> [!NOTE]
> hover
<img width="637" height="431" alt="Capture d’écran 2026-01-30 à 15 54 52" src="https://github.com/user-attachments/assets/1eb3cb6f-9a79-4b84-a51e-ef68c19b5a80" />

> [!NOTE]
> neutre
<img width="637" height="431" alt="Capture d’écran 2026-01-30 à 15 54 50" src="https://github.com/user-attachments/assets/0aff487d-c881-46f3-bc9f-f67f35d16065" />

----

DANS https://app-pr14934.review.pix.fr/modules/a23e9d63/ia-deepfakes-alt/details

Si le QAB n'a pas de feedback, le bouton pour réessayer apparaît toujours

<img width="619" height="533" alt="Capture d’écran 2026-01-30 à 15 59 25" src="https://github.com/user-attachments/assets/2b4eb299-9c44-4c52-a80f-0472753ff3d5" />

----

### POI

<img width="616" height="530" alt="Capture d’écran 2026-01-30 à 16 01 47" src="https://github.com/user-attachments/assets/83605469-da84-4845-b5f3-da87c37621d3" />

----

### QCU/QCM/QROCM

<img width="816" height="290" alt="Capture d’écran 2026-01-30 à 17 40 07" src="https://github.com/user-attachments/assets/5bd588f2-828d-4506-a750-7c29ebcb4ad8" />


> [!NOTE]
> focus
<img width="816" height="290" alt="Capture d’écran 2026-01-30 à 17 39 55" src="https://github.com/user-attachments/assets/28ffef3a-35d1-4ded-9775-8f43f4ca5aa6" />


> [!NOTE]
> hover
<img width="816" height="290" alt="Capture d’écran 2026-01-30 à 17 39 52" src="https://github.com/user-attachments/assets/f7721b04-6259-4220-9c82-25cfea84c659" />


> [!NOTE]
> neutre
<img width="816" height="290" alt="Capture d’écran 2026-01-30 à 17 39 49" src="https://github.com/user-attachments/assets/40986fbf-92f3-4fb8-8939-3d6dd8223027" />


----

### QCU DISCOVERY

<img width="819" height="303" alt="Capture d’écran 2026-01-30 à 17 42 29" src="https://github.com/user-attachments/assets/ea506c12-1896-4c71-885d-936c1f177f23" />

----

### QCU DECLARATIF

<img width="819" height="369" alt="Capture d’écran 2026-01-30 à 17 43 24" src="https://github.com/user-attachments/assets/501c59e2-b268-4202-8ba2-5e1d9f03ad88" />
