### PR TITLE
[FEATURE] Amélioration de la gestion d'erreur du formulaire de création de lots de places (PIX-21301).

### DIFF
--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -815,6 +815,16 @@
         "no-last-connection-date-info": "Has not been connected since 03/2025"
       },
       "places": {
+        "creation": {
+          "error-messages": {
+            "activation-date": "Activation date is a mandatory field.",
+            "category": "Category is a mandatory field",
+            "count": "Count must be a positive integer.",
+            "expiration-date": "Expiration date is a mandatory field.",
+            "reference": "Reference is a mandatory field.",
+            "submit": "An error occured during places lot creation."
+          }
+        },
         "statistics": {
           "available-seats-count": {
             "title": "Seats available",

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -817,6 +817,16 @@
         "no-last-connection-date-info": "Non connecté depuis 03/2025"
       },
       "places": {
+        "creation": {
+          "error-messages": {
+            "activation-date": "La date d'activation est obligatoire.",
+            "category":  "La catégorie est obligatoire.",
+            "count": "Le nombre de places doit être un nombre entier positif.",
+            "expiration-date": "La date d'expiration est obligatoire.",
+            "reference": "La référence est obligatoire.",
+            "submit": "Erreur lors de la création du lot de place."
+          }
+        },
         "statistics": {
           "available-seats-count": {
             "title": "Places disponibles",


### PR DESCRIPTION
## ❄️ Problème

Les erreurs de saisie ne sont pas remontées sur le formulaire de création de lots de places, laissant l’utilisateur un peu pantois quant aux problèmes rencontrés.

## 🛷 Proposition

Renvoi d'erreurs avant l'appel http via une validation Joi (plus simple que ce qui est fait côté back, notamment à cause de l'absence du package @Joi/date que je n'ai pas voulu rajouter à l'application, et qui entrave un peu la gestion des erreurs côté front)

## ☃️ Remarques

N/A

## 🧑‍🎄 Pour tester

- Se connecter à Pix-Admin
- Essayer de créer un lot de places à une organisation en vérifiant que des erreurs sont remontées pour diverses raisons. (manque de référence, catégorie, date, nombre négatif ou absent)
