### PR TITLE
[TECH] Résoudre le problème des tests en timeout qui font échouer la CI

### DIFF
--- a/api/tests/certification/evaluation/integration/application/api/select-next-certification-challenge-api_test.js
+++ b/api/tests/certification/evaluation/integration/application/api/select-next-certification-challenge-api_test.js
@@ -47,7 +47,11 @@ describe('Integration | Application | Certification | Evaluation | API', functio
         // In the middle of the selectNextCertificationChallenge transaction, lock is not available
         // Any attempt to concurrently lock will timeout
         // @see {https://github.com/knex/knex/blob/b6507a7129d2b9fafebf5f831494431e64c6a8a0/test/integration2/query/select/selects.spec.js#L953}
-        await knex('assessments').where({ id: originalAssessment.id }).forUpdate().first().timeout(100);
+        await knex('assessments')
+          .where({ id: originalAssessment.id })
+          .forUpdate()
+          .first()
+          .timeout(100, { cancel: true });
       });
 
       // when
@@ -67,7 +71,7 @@ describe('Integration | Application | Certification | Evaluation | API', functio
         .where({ id: originalAssessment.id })
         .forUpdate()
         .first()
-        .timeout(100);
+        .timeout(100, { cancel: true });
       return expect(assessmentAfterLock.id).to.equal(originalAssessment.id);
     });
   });

--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -364,7 +364,9 @@ describe('Integration | Repository | Campaign Participation', function () {
       const error = await catchErr(DomainTransaction.execute)(async () => {
         await campaignParticipationRepository.getLocked(participation.id);
         // we mimick a concurrent call on the campaign-participations table on the same row
-        return knex('campaign-participations').where({ id: participation.id }).first().forUpdate().timeout(100);
+        return knex('campaign-participations').where({ id: participation.id }).first().forUpdate().timeout(100, {
+          cancel: true,
+        });
       });
       expect(error).instanceOf(Error);
       expect(error.message).to.equal('Defined query timeout of 100ms exceeded when running query.');


### PR DESCRIPTION
## ❄️ Problème
Sur la CI, on a régulièrement l'erreur suivante sur le job des tests d'intégration de l'api : 

`"after each/all" hook in "{root}"
Error: Timeout of 2000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.`

Cela survient régulièrement, et fait échouer la CI, ce qui rend laborieux le merge des PR.

Le problème semble être causé par l'utilisation de la méthode `timeout()` de knex, lorsqu'on fait des requêtes `forUpdate` pour simuler le lock d'un enregistrement. 

## 🛷 Proposition
Ajouter un cancel des requêtes knex qui utilisent la méthode `timeout`, comme mentionné dans la doc https://knexjs.org/guide/query-builder#timeout

## ☃️ Remarques
Cela résout les pb en local, j'ose espérer qu'il en sera de même sur le long terme sur la CI, et qu'il n'y a pas d'autre cause au pb de timeout 

## 🧑‍🎄 Pour tester
CI verte à moultes reprises
