### PR TITLE
[BUGFIX] Réparer l'affichage du compteur de nombre de lettres dans le signalement (PIX-21245)

### DIFF
--- a/mon-pix/app/components/module/issue-report/issue-report-modal.gjs
+++ b/mon-pix/app/components/module/issue-report/issue-report-modal.gjs
@@ -166,6 +166,7 @@ export default class ModulixIssueReportModal extends Component {
                 <PixTextarea
                   class="issue-report-modal-form__comment"
                   @maxlength="200"
+                  @value={{this.comment}}
                   rows="5"
                   required
                   aria-required="true"


### PR DESCRIPTION
## ❄️ Problème
Actuellement, le compteur du nombre de lettres du textarea n'est pas mis à jour. En effet, lorsque la modale est femée, puis réouverte, la valeur du compteur du `textarea` est la même que celle avant la fermeture de la modale

## 🛷 Proposition
Suite au [fix](https://github.com/1024pix/pix-ui/pull/980) sur pix-ui, ajouter au composant `PixTextArea` un `@value` pour que le commentaire soit bien réinitialisé lorsqu'on ferme la modale.

## ☃️ Remarques
Le dernier commit permet de tester le fix sur Pix App. C'est bien sûr à supprimer avant le merge 😄 

## 🧑‍🎄 Pour tester

- Aller sur le module [galerie](https://app-pr14942.review.pix.fr/modules/b9414fc3/galerie)
- ouvrir une modale de signalement
- remplir le champs commentaires
- fermer la modale
- la réouvrir et constater que le compteur est remis à 0
