### PR TITLE
[FEATURE] Ajouter une Banner pour la campagne IA sur PixOrga (PIX-21344).

### DIFF
--- a/api/config/feature-toggles-config.js
+++ b/api/config/feature-toggles-config.js
@@ -17,6 +17,12 @@ export default {
     defaultValue: false,
     tags: ['team-prescription', 'frontend'],
   },
+  displayIaCampaignBanner: {
+    type: 'boolean',
+    description: 'Use to activate IA banner on PixOrga',
+    defaultValue: false,
+    tags: ['team-prescription', 'frontend', 'orga'],
+  },
   isQuestEnabled: {
     type: 'boolean',
     description: 'Used to enable quests feature',

--- a/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
+++ b/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
@@ -21,6 +21,7 @@ describe('Acceptance | Shared | Application | Controller | feature-toggle', func
           type: 'feature-toggles',
           attributes: {
             'dynamic-feature-toggle-system': false,
+            'display-ia-campaign-banner': false,
             'is-async-quest-rewarding-calculation-enabled': false,
             'is-survey-enabled-for-combined-courses': true,
             'is-quest-enabled': true,

--- a/orga/app/components/banner/sco-communication.gjs
+++ b/orga/app/components/banner/sco-communication.gjs
@@ -1,28 +1,39 @@
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import ScoBanner from 'pix-orga/components/banner/sco-banner';
+import ScoIABanner from 'pix-orga/components/banner/sco-ia-banner';
 
 export default class ScommunicationBanner extends Component {
   @service currentUser;
   @service router;
+  @service featureToggles;
 
   get shouldDisplayBanner() {
-    return (
+    const isValidRoute =
+      this.args.forceDisplayBanner ||
       [
         'authenticated.campaigns.list.my-campaigns',
         'authenticated.campaigns.list.all-campaigns',
         'authenticated.team.list.members',
         'authenticated.sco-organization-participants.list',
-      ].includes(this.router.currentRouteName) && this.currentUser.isSCOManagingStudents
-    );
+      ].includes(this.router.currentRouteName);
+    return isValidRoute && this.currentUser.isSCOManagingStudents;
   }
   get importParticipantUrl() {
     return this.router.urlFor('authenticated.import-organization-participants');
   }
 
+  get displayIaBanner() {
+    return this.featureToggles.featureToggles?.displayIaCampaignBanner ?? false;
+  }
+
   <template>
     {{#if this.shouldDisplayBanner}}
-      <ScoBanner />
+      {{#if this.displayIaBanner}}
+        <ScoIABanner />
+      {{else}}
+        <ScoBanner />
+      {{/if}}
     {{/if}}
   </template>
 }

--- a/orga/app/components/banner/sco-ia-banner.gjs
+++ b/orga/app/components/banner/sco-ia-banner.gjs
@@ -1,0 +1,12 @@
+import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
+import { t } from 'ember-intl';
+
+<template>
+  <PixNotificationAlert @type="communication-orga" @withIcon={{true}}>
+    <p>{{t "banners.ia.message"}}</p>
+    <ol class="banner-list">
+      <li>{{t "banners.ia.step1" htmlSafe=true}}</li>
+      <li>{{t "banners.ia.step2" htmlSafe=true}}</li>
+    </ol>
+  </PixNotificationAlert>
+</template>

--- a/orga/app/components/index/welcome.gjs
+++ b/orga/app/components/index/welcome.gjs
@@ -1,5 +1,5 @@
 import { t } from 'ember-intl';
-import ScoBanner from 'pix-orga/components/banner/sco-banner';
+import ScoCommunication from 'pix-orga/components/banner/sco-communication';
 import PageTitle from 'pix-orga/components/ui/page-title';
 
 <template>
@@ -13,7 +13,7 @@ import PageTitle from 'pix-orga/components/ui/page-title';
     </:subtitle>
 
     <:notificationAlert>
-      <ScoBanner />
+      <ScoCommunication @forceDisplayBanner={{true}} />
     </:notificationAlert>
   </PageTitle>
 </template>

--- a/orga/app/models/feature-toggle.js
+++ b/orga/app/models/feature-toggle.js
@@ -1,3 +1,5 @@
-import Model from '@ember-data/model';
+import Model, { attr } from '@ember-data/model';
 
-export default class FeatureToggle extends Model {}
+export default class FeatureToggle extends Model {
+  @attr('boolean') displayIaCampaignBanner;
+}

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -66,6 +66,11 @@
     "certification": {
       "message": "'<strong>'Certifications :'</strong>' Please don't forget to '<'a href={documentationLink} class=\"{linkClasses}\" target=\"_blank\" rel=\"noopener noreferrer\"'>'to finalize your sessions in Pix Certif'</a>' and to download the certificates via the \"Certifications\" tab before the start of the {year} academic year."
     },
+    "ia": {
+      "message": "The new Pix learning pathways on AI are available in your Pix Orga space! They are compulsory for pupils in Year 9, Year 12 (general and technological) and Year 11 (CAP), with gradual implementation over the 2025-2026 and 2026-2027 school years.",
+      "step1": "See '<'a href='https://cloud.pix.fr/s/rrkLPMS5dYGKRQ9' class='link link--banner link--bold link--underlined' '>'the deployment kit'</a>'",
+      "step2": "Register for the '<'a href='https://app.livestorm.co/pix-1/parcours-intelligence-artificielle-enseignement-scolaire?utm_source=pixorga' class='link link--banner link--bold link--underlined' '>'webinar'</a>'"
+    },
     "import": {
       "message": "The main stages of the school year :",
       "step1a": " Setting up&nbsp;: '<'a href='https://cloud.pix.fr/s/WjTnkSbFs9TDcSC' title='Downloading results how-to' class='link link--banner link--bold link--underlined' '>'downloading certification results'</a>' and",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -66,6 +66,11 @@
     "certification": {
       "message": "'<strong>'Certifications :'</strong>' n’oubliez pas de '<'a href={documentationLink} class=\"{linkClasses}\" target=\"_blank\" rel=\"noopener noreferrer\"'>'finaliser les sessions dans Pix Certif'</a>' puis de télécharger les certificats via l'onglet “Certifications” avant la rentrée {year}."
     },
+    "ia": {
+      "message": "Les nouveaux parcours apprenant Pix sur l’IA sont disponibles dans votre espace Pix Orga ! Ils sont obligatoires pour les élèves de 4e, de 2de (générale et technologique) et de 1re année de CAP, avec une mise en œuvre progressive sur les années scolaires 2025-2026 et 2026-2027",
+      "step1": "Consultez '<'a href='https://cloud.pix.fr/s/rrkLPMS5dYGKRQ9' title='Kit de déploiement IA' class='link link--banner link--bold link--underlined' '>'le kit de déploiement'</a>'",
+      "step2": "S'inscrire au '<'a href='https://app.livestorm.co/pix-1/parcours-intelligence-artificielle-enseignement-scolaire?utm_source=pixorga' class='link link--banner link--bold link--underlined' '>'webinaire'</a>'"
+    },
     "import": {
       "message": "Les grandes étapes de l’année dans l’enseignement scolaire :",
       "step1a": "Mettre en place&nbsp;: '<'a href='https://cloud.pix.fr/s/WjTnkSbFs9TDcSC' title='Guide télécharger les résultats' class='link link--banner link--bold link--underlined' '>'télécharger les résultats'</a>' de certification et",

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -66,6 +66,11 @@
     "certification": {
       "message": "'<strong>'Certificaten:'</strong>' Vergeet niet om '<'a href={documentationLink} class=\"{linkClasses}\" target=\"_blank\" rel=\"noopener noreferrer\"'>'de sessies af te ronden in Pix Certif'</a>' en de certificaten hier te downloaden via het tabblad \"Certificaten\" voor de start van het schooljaar {year}."
     },
+    "ia": {
+      "message": "De nieuwe Pix-leertrajecten over AI zijn beschikbaar in uw Pix Orga-ruimte! Ze zijn verplicht voor leerlingen van het 4e, 2e (algemeen en technologisch) en 1e jaar van het CAP, met een geleidelijke invoering in de schooljaren 2025-2026 en 2026-2027.",
+      "step1": "Raadpleeg '<'a href='https://cloud.pix.fr/s/rrkLPMS5dYGKRQ9' title='Kit de déploiement IA' class='link link--banner link--bold link--underlined' '>'de implementatiekit'</a>'",
+      "step2": "Aanmelden voor het '<'a href='https://app.livestorm.co/pix-1/parcours-intelligence-artificielle-enseignement-scolaire?utm_source=pixorga' class='link link--banner link--bold link--underlined' '>'webinar'</a>'"
+    },
     "import": {
       "message": "Belangrijke fasen in het schooljaar :",
       "step1a": "Implement&nbsp;: '<'a href='https://cloud.pix.fr/s/WjTnkSbFs9TDcSC' title='Gids download resultaten' class='link link--banner link--bold link--underlined''>'download resultaten'</a>' certificering en",


### PR DESCRIPTION
## ❄️ Problème

Y'a pas de problème, c'est un nouveau besoin

## 🛷 Proposition

Afficher une bannière pour inciter les prescripteurs à instancier les campagnes IA 

## ☃️ Remarques

RAS

## 🧑‍🎄 Pour tester

Activer le feature toggle et vérifier le bon affichage de la banner
voir les feature toggle
```
scalingo -a pix-api-review-pr14944 run "npm run toggles"
```
Passer le toggle à true
```
scalingo -a pix-api-review-pr14944 run "npm run toggles -- -k displayIaCampaignBanner -v true"
```