### PR TITLE
[TECH] supprime la sortie de log dans les tests

### DIFF
--- a/api/tests/integration/scripts/client-applications_test.js
+++ b/api/tests/integration/scripts/client-applications_test.js
@@ -152,7 +152,7 @@ describe('ClientApplicationsScript', function () {
     describe('list', function () {
       it('should list existing client applications', async function () {
         // given
-        const consoleTableSpy = sinon.spy(console, 'table');
+        const consoleTableSpy = sinon.stub(console, 'table');
         const clientApp = domainBuilder.buildClientApplication();
         databaseBuilder.factory.buildClientApplication(clientApp);
         await databaseBuilder.commit();


### PR DESCRIPTION
## ❄️ Problème

Un log vient polluer la sortie standard quand on lance les tests

## 🛷 Proposition

Remplacer l'utilisation du spy par un stub pour éviter d'appeler la méthode originale.

## ☃️ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🧑‍🎄 Pour tester

Lancer les tests en local et valider qu'on a plus de log dans la sortie standard
