### PR TITLE
[FEATURE] Fix de deux requêtes sur les participations aux campagnes et sur les assessments

### DIFF
--- a/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-repository.js
@@ -244,6 +244,10 @@ const hasAssessmentParticipations = async function (userId) {
     .whereNotExists(function () {
       this.select(knex.raw('1'))
         .from('quests')
+        .join('combined_courses', 'combined_courses.questId', 'quests.id')
+        .whereIn('combined_courses.organizationId', function () {
+          this.select('organizationId').from('organization-learners').where('userId', userId);
+        })
         .crossJoin(knex.raw('jsonb_array_elements("successRequirements") as success_elem'))
         .whereNotNull('quests.successRequirements')
         .andWhereRaw("(success_elem->'data'->'campaignId'->>'data')::integer = \"campaigns\".\"id\"");

--- a/api/tests/prescription/campaign-participation/acceptance/application/campaign-participation-route_test.js
+++ b/api/tests/prescription/campaign-participation/acceptance/application/campaign-participation-route_test.js
@@ -858,16 +858,18 @@ describe('Acceptance | API | Campaign Participations', function () {
     });
 
     it('should not return participation related to combined course', async function () {
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      const organizationLearner = databaseBuilder.factory.buildOrganizationLearner({ organizationId, userId });
       // given
       sinon.stub(constants, 'AUTONOMOUS_COURSES_ORGANIZATION_ID').value(777);
 
-      const campaignInCombinedCourse = databaseBuilder.factory.buildCampaign();
+      const campaignInCombinedCourse = databaseBuilder.factory.buildCampaign({ organizationId });
       databaseBuilder.factory.buildCombinedCourse({
         name: 'Combinix',
         rewardType: null,
         rewardId: null,
         code: 'COMBINIX1',
-        organizationId: campaignInCombinedCourse.organizationId,
+        organizationId,
         combinedCourseContents: [
           { campaignId: campaignInCombinedCourse.id },
           { moduleId: 'eeeb4951-6f38-4467-a4ba-0c85ed71321a' },
@@ -878,10 +880,12 @@ describe('Acceptance | API | Campaign Participations', function () {
       databaseBuilder.factory.campaignParticipationOverviewFactory.build({
         userId,
         campaignId: campaignInCombinedCourse.id,
+        organizationLearner: organizationLearner.id,
       });
       const sharableCampaignParticipation = databaseBuilder.factory.campaignParticipationOverviewFactory.buildOnGoing({
         userId,
         campaignSkills: ['recSkillId1'],
+        organizationLearnerId: organizationLearner.id,
       });
       await databaseBuilder.commit();
 

--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-overview-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-overview-repository_test.js
@@ -913,15 +913,20 @@ describe('Integration | Repository | Campaign Participation Overview', function 
 
     context('when campaign is related to combined-course', function () {
       it('should not return them', async function () {
-        const campaign = databaseBuilder.factory.buildCampaign();
+        const organization = databaseBuilder.factory.buildOrganization();
+        databaseBuilder.factory.buildOrganizationLearner({
+          organizationId: organization.id,
+          userId,
+        });
+        const campaign = databaseBuilder.factory.buildCampaign({ organizationId: organization.id });
 
-        const campaignInCombinedCourse = databaseBuilder.factory.buildCampaign();
+        const campaignInCombinedCourse = databaseBuilder.factory.buildCampaign({ organizationId: organization.id });
         databaseBuilder.factory.buildCombinedCourse({
           name: 'Combinix',
           rewardType: null,
           rewardId: null,
           code: 'COMBINIX1',
-          organizationId: campaignInCombinedCourse.organizationId,
+          organizationId: organization.id,
           combinedCourseContents: [
             { campaignId: campaignInCombinedCourse.id },
             { moduleId: 'eeeb4951-6f38-4467-a4ba-0c85ed71321a' },

--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -1389,13 +1389,14 @@ describe('Integration | Repository | Campaign Participation', function () {
   });
 
   describe('#hasAssessmentParticipations', function () {
-    let userId, organizationLearnerId;
+    let userId, organizationLearnerId, organizationId;
 
     beforeEach(async function () {
       sinon.stub(constants, 'AUTONOMOUS_COURSES_ORGANIZATION_ID').value(777);
 
       userId = databaseBuilder.factory.buildUser().id;
-      organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({ userId }).id;
+      organizationId = databaseBuilder.factory.buildOrganization().id;
+      organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({ userId, organizationId }).id;
       await databaseBuilder.commit();
     });
 
@@ -1548,14 +1549,14 @@ describe('Integration | Repository | Campaign Participation', function () {
     });
 
     it('should return true user linked to a combined course', async function () {
-      const campaignInCombinedCourse = databaseBuilder.factory.buildCampaign();
+      const campaignInCombinedCourse = databaseBuilder.factory.buildCampaign({ organizationId });
 
       const combinedCourse = databaseBuilder.factory.buildCombinedCourse({
         name: 'Combinix',
         rewardType: null,
         rewardId: null,
         code: 'COMBINIX1',
-        organizationId: campaignInCombinedCourse.organizationId,
+        organizationId,
         combinedCourseContents: [
           { campaignId: campaignInCombinedCourse.id },
           { moduleId: 'eeeb4951-6f38-4467-a4ba-0c85ed71321a' },
@@ -1578,21 +1579,17 @@ describe('Integration | Repository | Campaign Participation', function () {
     });
 
     it('should return true if at least one assessment is not linked to a combined course', async function () {
-      const campaign = databaseBuilder.factory.buildCampaign();
+      const campaign = databaseBuilder.factory.buildCampaign({ organizationId });
 
-      const campaignInCombinedCourse = databaseBuilder.factory.buildCampaign();
+      const campaignInCombinedCourse = databaseBuilder.factory.buildCampaign({ organizationId });
 
-      const participationInCombinedCourse = databaseBuilder.factory.buildCampaignParticipation({
-        campaignId: campaignInCombinedCourse.id,
-        organizationLearnerId,
-        userId,
-      });
       const participation = databaseBuilder.factory.buildCampaignParticipation({
         campaignId: campaign.id,
         organizationLearnerId,
         userId,
       });
       databaseBuilder.factory.buildCombinedCourse({
+        organizationId,
         combinedCourseContents: [{ campaignId: campaignInCombinedCourse.id }],
       });
 
@@ -1600,13 +1597,6 @@ describe('Integration | Repository | Campaign Participation', function () {
         campaignParticipationId: participation.id,
         type: Assessment.types.CAMPAIGN,
         createdAt: participation.createdAt,
-        userId,
-      });
-
-      databaseBuilder.factory.buildAssessment({
-        campaignParticipationId: participationInCombinedCourse.id,
-        type: Assessment.types.CAMPAIGN,
-        createdAt: participationInCombinedCourse.createdAt,
         userId,
       });
 


### PR DESCRIPTION
## ❄️ Problème
Deux requêtes sont très lentes en production : 
campaignParticipationRepository.hasAssessmentParticipations
campaignParticipationOverviews.findByUserIdWithFilters

## 🛷 Proposition
Au lieu d'aller chercher dans toutes les quêtes qui ont successRequirements à null la participation d'un user,
on propose de limiter aux quêtes qui ont un lien avec un éventuel organization learner de l'utilisateur

## ☃️ Remarques

## 🧑‍🎄 Pour tester
