### PR TITLE
[TECH] Ajouter une barre de progression dans le script de migration des statuts des participations (PIX-21362)

### DIFF
--- a/api/tests/prescription/integration/scripts/revert-campaign-participations-to-started_test.js
+++ b/api/tests/prescription/integration/scripts/revert-campaign-participations-to-started_test.js
@@ -13,6 +13,7 @@ describe('Integration | Prescription | Scripts | revert-campaign-participations-
     script = new RevertCampaignParticipationsToStartedScript();
     logger = {
       info: sinon.stub(),
+      debug: sinon.stub(),
       warn: sinon.stub(),
       error: sinon.stub(),
     };
@@ -276,7 +277,7 @@ describe('Integration | Prescription | Scripts | revert-campaign-participations-
             await script.handle({ logger, options });
 
             // then
-            expect(logger.info).to.have.been.calledWith(
+            expect(logger.debug).to.have.been.calledWith(
               'Participation is of type PROFILES_COLLECTION, skipping assessment update',
             );
           });
@@ -305,7 +306,7 @@ describe('Integration | Prescription | Scripts | revert-campaign-participations-
             await script.handle({ logger, options });
 
             // then
-            expect(logger.info).to.have.been.calledWith('Participation has been deleted, skipping assessment update');
+            expect(logger.debug).to.have.been.calledWith('Participation has been deleted, skipping assessment update');
           });
         });
       });


### PR DESCRIPTION
## ❄️ Problème

Le script de migration `revert-campaign-participations-to-started.js` ne fournissait pas de feedback visuel sur sa progression lors du traitement des participations aux campagnes, ce qui rendait difficile l'estimation du temps restant et le suivi de l'avancement.

## 🛷 Proposition

Ajout d'une barre de progression visuelle qui affiche :
- Le nombre de participations traitées / total
- Le pourcentage d'avancement
- Une représentation visuelle sous forme de barre `[###...] 45/100 (45%)`

## 🧑‍🎄 Pour tester

```bash
node --env-file=.env src/prescription/scripts/revert-campaign-participations-to-started.js --startDate=2024-01-01 --endDate=2024-01-31 --dryRun=true
```

Vérifier:
- La magnificence de la barre de progression
