### PR TITLE
[FEATURE] Rétropédalage 🚴 → contour POI non interactif sans bordure (PIX-21089)

### DIFF
--- a/mon-pix/app/components/module/element/custom-element.gjs
+++ b/mon-pix/app/components/module/element/custom-element.gjs
@@ -71,7 +71,7 @@ export default class ModulixCustomElement extends ModuleElement {
         </fieldset>
       {{else}}
         <div
-          class="element-custom__container {{if this.resetButtonDisplayed 'element-custom--reset-state'}}"
+          class={{if this.resetButtonDisplayed "element-custom--reset-state"}}
           {{didInsert this.mountCustomElement}}
         />
       {{/if}}


### PR DESCRIPTION
## ❄️ Problème

On ne veut plus de bordure pour les POI non interactifs (snifi)

## 🛷 Proposition

Enlever la bordure. Ca donne cela : 

<img width="850" height="334" alt="image" src="https://github.com/user-attachments/assets/f141e331-a296-4ea7-99f1-8c950cd34666" />

## ☃️ Remarques

Le nom de la branche est plus long que la ligne de code enlevée.

## 🧑‍🎄 Pour tester

- Ouvrir le module [cyber-message-arnaque](https://app-pr14950.review.pix.fr/modules/975d25d1/cyber-message-arnaque)
- Afficher un POI de conversation (pas interactif). Constater qu'il n'y a pas de bordure
- Afficher un POI interactif (le téléphone). Il doit y avoir une bordure en pointillés.
