### PR TITLE
[FEATURE] Affichage du nombre de membres actifs dans la page d'une orga (PIX-20831).

### DIFF
--- a/admin/app/adapters/organization.js
+++ b/admin/app/adapters/organization.js
@@ -6,12 +6,14 @@ export default class OrganizationAdapter extends ApplicationAdapter {
   findHasMany(store, snapshot, url, relationship) {
     url = this.urlPrefix(url, this.buildURL(snapshot.modelName, snapshot.id, null, 'findHasMany'));
 
-    if (relationship.type === 'organization-membership' && snapshot.adapterOptions) {
+    if (relationship.type === 'organization-membership') {
       const params = new URLSearchParams();
-      for (const [key, value] of Object.entries(snapshot.adapterOptions)) {
-        if (value) params.append(key, value);
+      if (snapshot.adapterOptions) {
+        for (const [key, value] of Object.entries(snapshot.adapterOptions)) {
+          if (value) params.append(key, value);
+        }
       }
-      url = `${this.host}/${this.namespace}/organizations/${snapshot.id}/memberships?${params.toString()}`;
+      url = `${this.host}/${this.namespace}/organizations/${snapshot.id}/memberships${params.toString() ? '?' + params.toString() : ''}`;
     }
 
     return this.ajax(url, 'GET');

--- a/admin/app/templates/authenticated/organizations/get.gjs
+++ b/admin/app/templates/authenticated/organizations/get.gjs
@@ -22,6 +22,7 @@ import InformationSection from 'pix-admin/components/organizations/information-s
       {{#unless @model.isArchived}}
         <LinkTo @route="authenticated.organizations.get.team" @model={{@model}}>
           {{t "pages.organization.navbar.team"}}
+          ({{@model.organizationMemberships.length}})
         </LinkTo>
 
         <LinkTo @route="authenticated.organizations.get.invitations" @model={{@model}}>

--- a/admin/tests/acceptance/authenticated/organizations/get-test.js
+++ b/admin/tests/acceptance/authenticated/organizations/get-test.js
@@ -48,13 +48,17 @@ module('Acceptance | Organizations | Get', function (hooks) {
     module('Navigation tabs', function () {
       module('Team tab', function () {
         module('When organization is active', function () {
-          test('it should display team tab', async function (assert) {
+          test('it should display team tab with number of active members', async function (assert) {
+            // given
+            const user = this.server.create('user', { firstName: 'John', lastName: 'Doe', email: 'user@example.com' });
+            server.create('organization-membership', { user, organizationId: ORGANIZATION_ID });
+
             // when
             const screen = await visit(`/organizations/${ORGANIZATION_ID}`);
 
             // then
             const navigationTabs = screen.getByRole('navigation', { name: t('pages.organization.navbar.aria-label') });
-            assert.ok(within(navigationTabs).getByRole('link', { name: t('pages.organization.navbar.team') }));
+            assert.ok(within(navigationTabs).getByRole('link', { name: `${t('pages.organization.navbar.team')} (1)` }));
           });
 
           test('it should navigate to team page when clicking tab', async function (assert) {
@@ -65,7 +69,7 @@ module('Acceptance | Organizations | Get', function (hooks) {
             const navigationTabs = screen.getByRole('navigation', { name: t('pages.organization.navbar.aria-label') });
 
             const teamTab = within(navigationTabs).getByRole('link', {
-              name: t('pages.organization.navbar.team'),
+              name: `${t('pages.organization.navbar.team')} (0)`,
             });
             await click(teamTab);
 

--- a/admin/tests/acceptance/authenticated/organizations/memberships-management-test.js
+++ b/admin/tests/acceptance/authenticated/organizations/memberships-management-test.js
@@ -37,6 +37,18 @@ module('Acceptance | Organizations | Memberships management', function (hooks) {
   });
 
   module('listing members', function () {
+    test('it should display the number of active members', async function (assert) {
+      // given
+      const user = this.server.create('user', { firstName: 'John', lastName: 'Doe', email: 'user@example.com' });
+      this.server.create('organization-membership', { user, organization });
+
+      // when
+      const screen = await visit(`/organizations/${organization.id}/team`);
+
+      // then
+      assert.dom(screen.getByText('Équipe (1)')).exists();
+    });
+
     test('it should display the current filter when memberships are filtered by firstName', async function (assert) {
       // when
       const screen = await visit(`/organizations/${organization.id}/team?firstName=sav`);

--- a/admin/tests/unit/adapters/organization-test.js
+++ b/admin/tests/unit/adapters/organization-test.js
@@ -18,19 +18,41 @@ module('Unit | Adapters | organization', function (hooks) {
   });
 
   module('#findHasMany', function () {
-    test('should build url with query params when type is organization-membership', async function (assert) {
-      // given
-      const snapshot = { modelName: 'organization', id: '1', adapterOptions: { 'page[size]': 2 } };
-      const relationship = { type: 'organization-membership' };
-      const url = '/api/organizations/1/memberships';
+    module('when type is organization-membership', function () {
+      module('when there are no query params', function () {
+        test('builds the correct url', async function (assert) {
+          // given
+          const snapshot = { modelName: 'organization', id: '1' };
+          const relationship = { type: 'organization-membership' };
+          const url = '/api/organizations/1/memberships';
 
-      // when
-      await adapter.findHasMany({}, snapshot, url, relationship);
+          // when
+          await adapter.findHasMany({}, snapshot, url, relationship);
 
-      // then
-      assert.ok(
-        adapter.ajax.calledWith(`${ENV.APP.API_HOST}/api/admin/organizations/1/memberships?page%5Bsize%5D=2`, 'GET'),
-      );
+          // then
+          assert.ok(adapter.ajax.calledWith(`${ENV.APP.API_HOST}/api/admin/organizations/1/memberships`, 'GET'));
+        });
+      });
+
+      module('when there are query params', function () {
+        test('builds the correct url', async function (assert) {
+          // given
+          const snapshot = { modelName: 'organization', id: '1', adapterOptions: { 'page[size]': 2 } };
+          const relationship = { type: 'organization-membership' };
+          const url = '/api/organizations/1/memberships';
+
+          // when
+          await adapter.findHasMany({}, snapshot, url, relationship);
+
+          // then
+          assert.ok(
+            adapter.ajax.calledWith(
+              `${ENV.APP.API_HOST}/api/admin/organizations/1/memberships?page%5Bsize%5D=2`,
+              'GET',
+            ),
+          );
+        });
+      });
     });
 
     test('should build url without query params when type is not membership', async function (assert) {


### PR DESCRIPTION
## ❄️ Problème

Sur la page de détail d’une organisation, dans le nom de l’onglet “Equipe”, ajouter entre parenthèse le nombre de membres actifs (= qui n’ont pas été désactivés).

## 🛷 Proposition

Rajout du nombre dans l'onglet `Equipe` de la page de détails d'une organisation

## ☃️ Remarques

Nous ne gérons pas ici le problème posé par les filtres.
En effet, lorsque l'on applique un filtre, le nombre de membres actifs est mis à jour en temps réel.
Pour éviter cela, il nous faudrait remonter un nombre fixe du back, chose que nous ne faisons pas pour l'instant afin de garder une homogénéité dans le comportement des onglets. (mais sera possiblement amené à évoluer)

## 🧑‍🎄 Pour tester

Se connecter à Pix-Admin
Aller sur la page de détails d'une organisation
Vérifier que le nombre de membres actifs apparaît entre parenthèses sur l'onglet Equipe
