### PR TITLE
[FEATURE] Afficher le nombre de profils cibles sur la page de détail d'une organisation (PIX-20833)

### DIFF
--- a/admin/app/templates/authenticated/organizations/get.gjs
+++ b/admin/app/templates/authenticated/organizations/get.gjs
@@ -17,7 +17,7 @@ import InformationSection from 'pix-admin/components/organizations/information-s
       @archiveOrganization={{@controller.archiveOrganization}}
     />
 
-    <PixTabs @variant="primary" @ariaLabel="Navigation de la section organisation" class="navigation">
+    <PixTabs @variant="primary" @ariaLabel={{t "pages.organization.navbar.aria-label"}} class="navigation">
 
       {{#unless @model.isArchived}}
         <LinkTo @route="authenticated.organizations.get.team" @model={{@model}}>

--- a/admin/app/templates/authenticated/organizations/get.gjs
+++ b/admin/app/templates/authenticated/organizations/get.gjs
@@ -31,6 +31,7 @@ import InformationSection from 'pix-admin/components/organizations/information-s
 
       <LinkTo @route="authenticated.organizations.get.target-profiles" @model={{@model}}>
         {{t "pages.organization.navbar.target-profiles"}}
+        ({{@model.targetProfileSummaries.length}})
       </LinkTo>
 
       <LinkTo @route="authenticated.organizations.get.campaigns" @model={{@model}}>

--- a/admin/tests/acceptance/authenticated/organizations/get-test.js
+++ b/admin/tests/acceptance/authenticated/organizations/get-test.js
@@ -1,0 +1,319 @@
+import { visit, within } from '@1024pix/ember-testing-library';
+import { click, currentURL } from '@ember/test-helpers';
+import { t } from 'ember-intl/test-support';
+import { setupApplicationTest } from 'ember-qunit';
+import { authenticateAdminMemberWithRole } from 'pix-admin/tests/helpers/test-init';
+import { setupMirage } from 'pix-admin/tests/test-support/setup-mirage';
+import { module, test } from 'qunit';
+
+import setupIntl from '../../../helpers/setup-intl';
+
+module('Acceptance | Organizations | Get', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+  setupIntl(hooks);
+
+  module('When user is not logged in', function () {
+    test('organization details page should not be accessible by an unauthenticated user', async function (assert) {
+      // when
+      await visit('/organizations/1');
+
+      // then
+      assert.strictEqual(currentURL(), '/login');
+    });
+  });
+
+  module('When user is authenticated as Super Admin', function (hooks) {
+    const ORGANIZATION_ID = 1;
+    const ARCHIVED_ORGANIZATION_ID = 2;
+    const ORGANIZATION_WITHOUT_PLACES_MANAGEMENT_ID = 3;
+
+    hooks.beforeEach(async () => {
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+      server.create('organization', {
+        id: ORGANIZATION_ID,
+        name: 'My Organization',
+        features: { PLACES_MANAGEMENT: { active: true } },
+      });
+    });
+
+    test('it should be accessible for an authenticated user and redirect to team tab', async function (assert) {
+      // when
+      await visit(`/organizations/${ORGANIZATION_ID}`);
+
+      // then
+      assert.strictEqual(currentURL(), `/organizations/${ORGANIZATION_ID}/team`);
+    });
+
+    module('Navigation tabs', function () {
+      module('Team tab', function () {
+        module('When organization is active', function () {
+          test('it should display team tab', async function (assert) {
+            // when
+            const screen = await visit(`/organizations/${ORGANIZATION_ID}`);
+
+            // then
+            const navigationTabs = screen.getByRole('navigation', { name: t('pages.organization.navbar.aria-label') });
+            assert.ok(within(navigationTabs).getByRole('link', { name: t('pages.organization.navbar.team') }));
+          });
+
+          test('it should navigate to team page when clicking tab', async function (assert) {
+            // given
+            const screen = await visit(`/organizations/${ORGANIZATION_ID}`);
+
+            // when
+            const navigationTabs = screen.getByRole('navigation', { name: t('pages.organization.navbar.aria-label') });
+
+            const teamTab = within(navigationTabs).getByRole('link', {
+              name: t('pages.organization.navbar.team'),
+            });
+            await click(teamTab);
+
+            // then
+            assert.strictEqual(currentURL(), `/organizations/${ORGANIZATION_ID}/team`);
+          });
+        });
+
+        module('When organization is archived', function () {
+          test('it should not display team tab', async function (assert) {
+            // given
+            server.create('organization', {
+              id: ARCHIVED_ORGANIZATION_ID,
+              name: 'My Archived Organization',
+              archivedAt: new Date('2026-01-01'),
+              features: { PLACES_MANAGEMENT: { active: true } },
+            });
+
+            // when
+            const screen = await visit(`/organizations/${ARCHIVED_ORGANIZATION_ID}`);
+
+            // then
+            const navigationTabs = screen.getByRole('navigation', { name: t('pages.organization.navbar.aria-label') });
+            assert.notOk(within(navigationTabs).queryByRole('link', { name: t('pages.organization.navbar.team') }));
+          });
+        });
+      });
+
+      module('Invitations tab', function () {
+        test('it should display invitations tab', async function (assert) {
+          // when
+          const screen = await visit(`/organizations/${ORGANIZATION_ID}`);
+
+          // then
+          const navigationTabs = screen.getByRole('navigation', { name: t('pages.organization.navbar.aria-label') });
+          assert.ok(within(navigationTabs).getByRole('link', { name: t('pages.organization.navbar.invitations') }));
+        });
+
+        test('it should navigate to invitations page when clicking tab', async function (assert) {
+          // given
+          const screen = await visit(`/organizations/${ORGANIZATION_ID}`);
+
+          // when
+          const navigationTabs = screen.getByRole('navigation', { name: t('pages.organization.navbar.aria-label') });
+
+          const invitationsTab = within(navigationTabs).getByRole('link', {
+            name: t('pages.organization.navbar.invitations'),
+          });
+          await click(invitationsTab);
+
+          // then
+          assert.strictEqual(currentURL(), `/organizations/${ORGANIZATION_ID}/invitations`);
+        });
+
+        module('When organization is archived', function () {
+          test('it should not display team tab', async function (assert) {
+            // given
+            server.create('organization', {
+              id: ARCHIVED_ORGANIZATION_ID,
+              name: 'My Archived Organization',
+              archivedAt: new Date('2026-01-01'),
+              features: { PLACES_MANAGEMENT: { active: true } },
+            });
+            // when
+            const screen = await visit(`/organizations/${ARCHIVED_ORGANIZATION_ID}`);
+
+            // then
+            const navigationTabs = screen.getByRole('navigation', { name: t('pages.organization.navbar.aria-label') });
+            assert.notOk(within(navigationTabs).queryByRole('link', { name: t('pages.organization.navbar.team') }));
+          });
+        });
+      });
+
+      module('Target profiles tab', function () {
+        test('it should display target-profiles tab, with number of target-profiles', async function (assert) {
+          // given
+          server.create('target-profile-summary', { id: 123, name: 'Mon super profil cible' });
+
+          // when
+          const screen = await visit(`/organizations/${ORGANIZATION_ID}`);
+
+          // then
+          const navigationTabs = screen.getByRole('navigation', { name: t('pages.organization.navbar.aria-label') });
+          assert.ok(
+            within(navigationTabs).getByRole('link', { name: `${t('pages.organization.navbar.target-profiles')} (1)` }),
+          );
+        });
+
+        test('it should navigate to target profiles page when clicking tab', async function (assert) {
+          // given
+          const screen = await visit(`/organizations/${ORGANIZATION_ID}`);
+
+          // when
+          const navigationTabs = screen.getByRole('navigation', { name: t('pages.organization.navbar.aria-label') });
+
+          const targetProfilesTab = within(navigationTabs).getByRole('link', {
+            name: `${t('pages.organization.navbar.target-profiles')} (0)`,
+          });
+          await click(targetProfilesTab);
+
+          // then
+          assert.strictEqual(currentURL(), `/organizations/${ORGANIZATION_ID}/target-profiles`);
+        });
+      });
+
+      module('Campaigns tab', function () {
+        test('it should display campaigns tab', async function (assert) {
+          // given
+          server.create('campaign');
+
+          // when
+          const screen = await visit(`/organizations/${ORGANIZATION_ID}`);
+
+          // then
+          const navigationTabs = screen.getByRole('navigation', { name: t('pages.organization.navbar.aria-label') });
+          assert.ok(within(navigationTabs).getByRole('link', { name: t('pages.organization.navbar.campaigns') }));
+        });
+      });
+
+      module('Places tab', function () {
+        module('when PLACES_MANAGEMENT feature is enabled', function () {
+          test('it should display places tab', async function (assert) {
+            // when
+            const screen = await visit(`/organizations/${ORGANIZATION_ID}`);
+
+            // then
+            const navigationTabs = screen.getByRole('navigation', { name: t('pages.organization.navbar.aria-label') });
+            assert.ok(within(navigationTabs).getByRole('link', { name: t('pages.organization.navbar.places') }));
+          });
+
+          test('it should navigate to places page when clicking tab', async function (assert) {
+            // given
+            const screen = await visit(`/organizations/${ORGANIZATION_ID}`);
+
+            // when
+            const navigationTabs = screen.getByRole('navigation', { name: t('pages.organization.navbar.aria-label') });
+
+            const placesTab = within(navigationTabs).getByRole('link', {
+              name: t('pages.organization.navbar.places'),
+            });
+            await click(placesTab);
+
+            // then
+            assert.strictEqual(currentURL(), `/organizations/${ORGANIZATION_ID}/places`);
+          });
+        });
+
+        module('when PLACES_MANAGEMENT feature is disabled', function () {
+          test('it should not display places tab', async function (assert) {
+            // given
+            server.create('organization', {
+              id: ORGANIZATION_WITHOUT_PLACES_MANAGEMENT_ID,
+              name: 'My Organization Without PLACES_MANAGEMENT',
+              features: { PLACES_MANAGEMENT: { active: false } },
+            });
+
+            // when
+            const screen = await visit(`/organizations/${ORGANIZATION_WITHOUT_PLACES_MANAGEMENT_ID}`);
+
+            // then
+            const navigationTabs = screen.getByRole('navigation', { name: t('pages.organization.navbar.aria-label') });
+            assert.notOk(within(navigationTabs).queryByRole('link', { name: t('pages.organization.navbar.places') }));
+          });
+        });
+      });
+
+      module('Tags tab', function () {
+        test('it should display tags tab', async function (assert) {
+          // when
+          const screen = await visit(`/organizations/${ORGANIZATION_ID}`);
+
+          // then
+          const navigationTabs = screen.getByRole('navigation', { name: t('pages.organization.navbar.aria-label') });
+          assert.ok(within(navigationTabs).getByRole('link', { name: t('pages.organization.navbar.tags') }));
+        });
+
+        test('it should navigate to tags page when clicking tab', async function (assert) {
+          // given
+          const screen = await visit(`/organizations/${ORGANIZATION_ID}`);
+
+          // when
+          const navigationTabs = screen.getByRole('navigation', { name: t('pages.organization.navbar.aria-label') });
+
+          const tagsTab = within(navigationTabs).getByRole('link', {
+            name: t('pages.organization.navbar.tags'),
+          });
+          await click(tagsTab);
+
+          // then
+          assert.strictEqual(currentURL(), `/organizations/${ORGANIZATION_ID}/all-tags`);
+        });
+      });
+
+      module('Child organizations tab', function () {
+        test('it should display child organizations tab, with number of child organizations', async function (assert) {
+          // given
+          server.create('organization', {
+            parentOrganizationId: 1,
+            name: 'Child of My Organization',
+            features: { PLACES_MANAGEMENT: { active: false } },
+          });
+
+          // when
+          const screen = await visit('/organizations/1');
+
+          // then
+          const navigationTabs = screen.getByRole('navigation', { name: t('pages.organization.navbar.aria-label') });
+          assert.ok(
+            within(navigationTabs).getByRole('link', { name: `${t('pages.organization.navbar.children')} (1)` }),
+          );
+        });
+
+        test('it should navigate to child organizations page when clicking tab', async function (assert) {
+          // given
+          const screen = await visit(`/organizations/${ORGANIZATION_ID}`);
+
+          // when
+          const navigationTabs = screen.getByRole('navigation', { name: t('pages.organization.navbar.aria-label') });
+
+          const targetProfilesTab = within(navigationTabs).getByRole('link', {
+            name: `${t('pages.organization.navbar.children')} (0)`,
+          });
+          await click(targetProfilesTab);
+
+          // then
+          assert.strictEqual(currentURL(), `/organizations/${ORGANIZATION_ID}/children`);
+        });
+      });
+    });
+  });
+
+  module('When user is authenticated as Certif Admin', function (hooks) {
+    hooks.beforeEach(async () => {
+      await authenticateAdminMemberWithRole({ isCertif: true })(server);
+      server.create('organization', {
+        id: 1,
+        name: 'My Organization',
+        features: { PLACES_MANAGEMENT: { active: true } },
+      });
+    });
+
+    test('it should not display tags tab', async function (assert) {
+      // when
+      const screen = await visit('/organizations/1');
+
+      // then
+      const navigationTabs = screen.getByRole('navigation', { name: t('pages.organization.navbar.aria-label') });
+      assert.notOk(within(navigationTabs).queryByRole('link', { name: t('pages.organization.navbar.tags') }));
+    });
+  });
+});

--- a/admin/tests/acceptance/authenticated/organizations/get/children-test.js
+++ b/admin/tests/acceptance/authenticated/organizations/get/children-test.js
@@ -19,42 +19,6 @@ module('Acceptance | Organizations | Children', function (hooks) {
       await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
     });
 
-    test('"Organisations filles" tab exists', async function (assert) {
-      // given
-      const organizationId = this.server.create('organization', {
-        name: 'Orga name',
-        features: { PLACES_MANAGEMENT: { active: true } },
-      }).id;
-
-      // when
-      const screen = await visit(`/organizations/${organizationId}/children`);
-
-      // then
-      assert.strictEqual(currentURL(), `/organizations/${organizationId}/children`);
-      assert.dom(screen.getByRole('link', { name: 'Organisations filles (0)' })).hasClass('active');
-    });
-
-    test('Displays the number of child organisations in tab name', async function (assert) {
-      // given
-      const parentOrganizationId = this.server.create('organization', {
-        id: 1,
-        name: 'Orga name',
-        features: { PLACES_MANAGEMENT: { active: true } },
-      }).id;
-      this.server.create('organization', {
-        id: 2,
-        parentOrganizationId: 1,
-        name: 'Child',
-        features: { PLACES_MANAGEMENT: { active: true } },
-      });
-
-      // when
-      const screen = await visit(`/organizations/${parentOrganizationId}/children`);
-
-      // then
-      assert.dom(screen.getByRole('link', { name: 'Organisations filles (1)' })).hasClass('active');
-    });
-
     module('when there is no child organization', function () {
       test('displays a message', async function (assert) {
         // given

--- a/admin/tests/acceptance/authenticated/organizations/information-management-test.js
+++ b/admin/tests/acceptance/authenticated/organizations/information-management-test.js
@@ -83,42 +83,6 @@ module('Acceptance | Organizations | Information management', function (hooks) {
     });
   });
 
-  module('when PLACES_MANAGEMENT feature is enabled', function () {
-    test('should display Places menu item', async function (assert) {
-      // given
-      const organization = this.server.create('organization', {
-        name: 'organizationName',
-        features: {
-          PLACES_MANAGEMENT: { active: true },
-        },
-      });
-
-      // when
-      const screen = await visit(`/organizations/${organization.id}`);
-
-      // then
-      assert.dom(screen.getByRole('link', { name: t('pages.organization.navbar.places') })).exists();
-    });
-  });
-
-  module('when PLACES_MANAGEMENT feature is disabled', function () {
-    test('should not display Places menu item', async function (assert) {
-      // given
-      const organization = this.server.create('organization', {
-        name: 'organizationName',
-        features: {
-          PLACES_MANAGEMENT: { active: false },
-        },
-      });
-
-      // when
-      const screen = await visit(`/organizations/${organization.id}`);
-
-      // then
-      assert.dom(screen.queryByRole('link', { name: t('pages.organization.navbar.places') })).doesNotExist();
-    });
-  });
-
   module('when organization is archived', function () {
     test('should redirect to organization target profiles page', async function (assert) {
       // given

--- a/admin/tests/acceptance/authenticated/organizations/target-profiles-management-test.js
+++ b/admin/tests/acceptance/authenticated/organizations/target-profiles-management-test.js
@@ -25,7 +25,6 @@ module('Acceptance | Organizations | Target profiles management', function (hook
     const screen = await visit(`/organizations/${ownerOrganizationId}/target-profiles`);
 
     // then
-    assert.dom(screen.getByRole('link', { name: 'Tags' })).exists();
     const table = screen.getByRole('table', {
       name: t('components.organizations.target-profiles-section.table.caption'),
     });

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -1283,6 +1283,7 @@
         }
       },
       "navbar": {
+        "aria-label": "Organization section navigation",
         "campaigns": "Campaigns",
         "children": "Children organisations",
         "invitations": "Invitations",

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -1286,6 +1286,7 @@
         }
       },
       "navbar": {
+        "aria-label": "Navigation de la section organisation",
         "campaigns": "Campagnes",
         "children": "Organisations filles",
         "invitations": "Invitations",


### PR DESCRIPTION
## ❄️ Problème

Dans Pix Admin, sur la page de détail d'une organisation, on veut pouvoir rapidement visualiser le nombre de profils cibles rattachés à cette organisation.

## 🛷 Proposition

Ajouter le nombre de profils cibles rattachés entre parenthèses dans le nom de l'onglet de navigation.

## ☃️ Remarques

L'affichage de la barre de navigation et ses différents onglets n'étaient pas testés. On a rajouté un fichier de test pour couvrir l'affichage des onglets selon les différentes conditions (rôle, archivage de l'orga, activation de fonctionnalités...)

## 🧑‍🎄 Pour tester

Sur la page de détail d'une organisation:
- constater que l'onglet **Profils cibles** affiche le nombre entre parenthèses
- rattacher de nouveaux profils et en supprimer afin de constater la mise à jour en direct de l'affichage
