### PR TITLE
[BUGFIX] Fix d'un flaky sur les profils cibles côté Admin

### DIFF
--- a/admin/tests/acceptance/authenticated/combined-course-blueprints/attach-organizations-form-test.js
+++ b/admin/tests/acceptance/authenticated/combined-course-blueprints/attach-organizations-form-test.js
@@ -14,16 +14,14 @@ module('Acceptance | Attach organizations form', function (hooks) {
 
   hooks.beforeEach(async function () {
     await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
-
-    combinedCourseBlueprintId = 1;
-    server.create('combined-course-blueprint', { id: combinedCourseBlueprintId, internalName: 'toto' });
-
-    await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
   });
 
   //then
-  test('should be able to add new organization to the target profile', async function (assert) {
+  test('should be able to add new organization to the combined course blueprint', async function (assert) {
     // given
+    combinedCourseBlueprintId = 1;
+    server.create('combined-course-blueprint', { id: combinedCourseBlueprintId, internalName: 'toto' });
+
     const screen = await visit(`/combined-course-blueprints/${combinedCourseBlueprintId}/organizations`);
 
     // when
@@ -31,6 +29,27 @@ module('Acceptance | Attach organizations form', function (hooks) {
     await clickByName('Valider le rattachement');
 
     // then
-    assert.dom(await screen.findByRole('cell', { name: 'Organization 42' })).exists();
+    assert.dom(await screen.findByRole('cell', { name: 'Organization 42' })).isVisible();
+  });
+
+  test('should be able to add new organization to the target profile', async function (assert) {
+    server.create('organization', {
+      id: 456,
+      name: 'My organization',
+      features: { PLACES_MANAGEMENT: { active: false } },
+    });
+
+    server.create('target-profile', { id: 1, ownerOrganizationId: 456, name: 'Mon super profil cible' });
+
+    // given
+    const screen = await visit('/target-profiles/1');
+    await clickByName('Organisations du profil cible');
+
+    // when
+    await fillByLabel('Rattacher une ou plusieurs organisation(s)', '42');
+    await clickByName('Valider le rattachement');
+
+    // then
+    assert.dom(await screen.findByRole('cell', { name: 'Organization 42' })).isVisible();
   });
 });

--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile/organizations-test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile/organizations-test.js
@@ -111,19 +111,6 @@ module('Acceptance | Target Profile Organizations', function (hooks) {
         assert.deepEqual(currentURL(), '/organizations/456/team');
       });
 
-      test('should be able to add new organization to the target profile', async function (assert) {
-        // given
-        const screen = await visit('/target-profiles/1');
-        await clickByName('Organisations du profil cible');
-
-        // when
-        await fillByLabel('Rattacher une ou plusieurs organisation(s)', '42');
-        await clickByName('Valider le rattachement');
-
-        // then
-        assert.dom(await screen.findByRole('cell', { name: 'Organization 42' })).exists();
-      });
-
       test('should be able to attach an organization with given target profile', async function (assert) {
         const screen = await visit('/target-profiles/1');
         await clickByName('Organisations du profil cible');


### PR DESCRIPTION
## ❄️ Problème
Un flaky nous a été remonté 
<img width="1198" height="395" alt="image" src="https://github.com/user-attachments/assets/6d6b60fa-4101-41fd-8b66-e0fe0bbdebbe" />

Or la logique qui est testée ici appartient désormais à un composant commun AttachOrganizationsForm.

## 🛷 Proposition
On n'arrive pas à voir pourquoi ce flaky nous pose problème en CI (pas reproductible en local).
On a un test d'acceptance sur le composant, qui va venir tester la même logique côté parcours combiné.

Dans un but de refactorisation, on déplace donc le test vers le test du composant.
Dans une optique de "réparation" du flaky, je propose de passer à .isVisible() au lieu de .ok() dans l'assertion car ce genre de bug a été remonté sur le Github de Qunit et les développeurs de la librairie ont répondu à l'issue https://github.com/mainmatter/qunit-dom/issues/245

## 🧑‍🎄 Pour tester
Ci au vert