### PR TITLE
[BUGFIX] Afficher les données qui proviennent rééllement de la base de donnée (PIX-21368).

### DIFF
--- a/api/src/organizational-entities/domain/models/OrganizationForAdmin.js
+++ b/api/src/organizational-entities/domain/models/OrganizationForAdmin.js
@@ -114,20 +114,31 @@ class OrganizationForAdmin {
         params: null,
       };
     }
+
     if (this.type === 'SCO' && this.isManagingStudents) {
       this.features[ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key] = {
         active: true,
         params: null,
       };
     }
+
     if (this.type === 'SCO-1D') {
-      this.features[ORGANIZATION_FEATURE.MISSIONS_MANAGEMENT.key] = { active: true, params: null };
-      this.features[ORGANIZATION_FEATURE.ORALIZATION_MANAGED_BY_PRESCRIBER.key] = { active: true, params: null };
-      this.features[ORGANIZATION_FEATURE.LEARNER_IMPORT.key] = {
-        active: true,
-        params: { name: ORGANIZATION_FEATURE.LEARNER_IMPORT.FORMAT.ONDE },
-      };
+      if (this.features[ORGANIZATION_FEATURE.MISSIONS_MANAGEMENT.key] === undefined) {
+        this.features[ORGANIZATION_FEATURE.MISSIONS_MANAGEMENT.key] = { active: true, params: null };
+      }
+
+      if (this.features[ORGANIZATION_FEATURE.ORALIZATION_MANAGED_BY_PRESCRIBER.key] === undefined) {
+        this.features[ORGANIZATION_FEATURE.ORALIZATION_MANAGED_BY_PRESCRIBER.key] = { active: true, params: null };
+      }
+
+      if (this.features[ORGANIZATION_FEATURE.LEARNER_IMPORT.key] === undefined) {
+        this.features[ORGANIZATION_FEATURE.LEARNER_IMPORT.key] = {
+          active: true,
+          params: { name: ORGANIZATION_FEATURE.LEARNER_IMPORT.FORMAT.ONDE },
+        };
+      }
     }
+
     this.tagsToAdd = [];
     this.tagsToRemove = [];
     this.code = code;


### PR DESCRIPTION
## ❄️ Problème

Pour une mise à jour de format d'organization SCO-1D, l'affichage sur PixAdmin est biaisé par le model 

## 🛷 Proposition

Ne pas écraser les données provenant de la base de donnée à l'affichage, merci bisous. 

## ☃️ Remarques

Il y aura un refacto à faire pour ce model afin de gérer mieux les features que l'on souhaite activé. ( dans une base de donnée de config par exemple ? plutôt que dans le model ? ) 

## 🧑‍🎄 Pour tester

Mettre à jour le format ONDE par celui de la FWB sur l'orga 9001, et vérifier que le nom change bien sur PixAdmin
sur scalingo éxecuter cette requete :

`update "organization-features" set params = '{"organizationLearnerImportFormatId":1002}' where id = 108613`

```
scalingo -a pix-api-review-pr14954 pgsql-console
```
```sql
-- set GENERIC
update "organization-features" set params = '{"organizationLearnerImportFormatId":1002}' where id = 109049;
```
```sql
-- set ONDE
update "organization-features" set params = '{"organizationLearnerImportFormatId":1001}' where id = 109049;
```