### PR TITLE
[TECH] Ajouter une condition sur l'organisation dans la récupération des parcours combiné (PIX-21369).

### DIFF
--- a/api/src/quest/infrastructure/repositories/combined-course-repository.js
+++ b/api/src/quest/infrastructure/repositories/combined-course-repository.js
@@ -65,6 +65,7 @@ const findByCampaignId = async ({ campaignId }) => {
       'questId',
     )
     .join('quests', 'quests.id', 'combined_courses.questId')
+    .where('combined_courses.organizationId', knexConn('campaigns').select('organizationId').where('id', campaignId))
     .whereJsonSupersetOf('quests.successRequirements', [{ data: { campaignId: { data: campaignId } } }]);
 
   return combinedCourses.map(_toDomain);

--- a/api/tests/prescription/target-profile/integration/infrastructure/repositories/target-profile-summary-for-admin-repository_test.js
+++ b/api/tests/prescription/target-profile/integration/infrastructure/repositories/target-profile-summary-for-admin-repository_test.js
@@ -357,11 +357,11 @@ describe('Integration | Repository | Target-profile-summary-for-admin', function
       const targetProfile1 = databaseBuilder.factory.buildTargetProfile();
       const targetProfile2 = databaseBuilder.factory.buildTargetProfile();
 
+      const organization = databaseBuilder.factory.buildOrganization();
       const campaignIdInCombinedCourse = databaseBuilder.factory.buildCampaign({
         targetProfileId: targetProfile1.id,
+        organizationId: organization.id,
       }).id;
-
-      const organization = databaseBuilder.factory.buildOrganization();
 
       databaseBuilder.factory.buildTargetProfileTraining({
         trainingId: training.id,

--- a/api/tests/quest/acceptance/application/api/combined-course-api_test.js
+++ b/api/tests/quest/acceptance/application/api/combined-course-api_test.js
@@ -43,8 +43,6 @@ describe('Acceptance | Quest | Application | combined-course-api', function () {
 
   it('should throw an error if multiple combined courses found', async function () {
     //given
-    const organizationId = databaseBuilder.factory.buildOrganization().id;
-
     databaseBuilder.factory.buildCombinedCourse({
       code: 'QWERTY123',
       name: combinedCourseName,

--- a/api/tests/quest/integration/infrastructure/repositories/combined-course-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/combined-course-repository_test.js
@@ -150,7 +150,7 @@ describe('Quest | Integration | Repository | combined-course', function () {
     });
   });
 
-  describe('#getByCampaignId', function () {
+  describe('#findByCampaignId', function () {
     let organizationId, combinedCourse, campaignId;
 
     beforeEach(async function () {


### PR DESCRIPTION
## ❄️ Problème

Une campagne ne peut pas être lié à d'autre organisation. il manque une condition pour les combined_course afin de faire un préfiltrage sur ceux appartenant à l'organisation

## 🛷 Proposition

Ajouter une condition sur l'organizationId permet de restreindre la récupération des parcours combiné ciblé à l'organisation lié à la campagne

## ☃️ Remarques
le résultat en local
```
Nouvelle Requête
Nested Loop  (cost=1.44..20.84 rows=1 width=90) (actual time=0.030..0.032 rows=1 loops=1)
  InitPlan 1 (returns $0)
    ->  Seq Scan on campaigns  (cost=0.00..1.29 rows=1 width=4) (actual time=0.004..0.004 rows=1 loops=1)
          Filter: (id = 6004)
          Rows Removed by Filter: 22
  ->  Seq Scan on quests  (cost=0.00..11.38 rows=1 width=4) (actual time=0.016..0.018 rows=1 loops=1)
        Filter: ("successRequirements" @> '[{"data": {"campaignId": {"data": 6004}}}]'::jsonb)
        Rows Removed by Filter: 7
  ->  Index Scan using combined_courses_questid_index on combined_courses  (cost=0.15..8.17 rows=1 width=90) (actual time=0.012..0.012 rows=1 loops=1)
        Index Cond: ("questId" = quests.id)
        Filter: ("organizationId" = $0)
Planning Time: 1.897 ms
Execution Time: 0.063 ms

Ancienne requête
Merge Join  (cost=11.54..14.58 rows=5 width=90) (actual time=0.110..0.111 rows=0 loops=1)
  Merge Cond: (combined_courses."questId" = quests.id)
  ->  Index Scan using combined_courses_questid_index on combined_courses  (cost=0.15..30.00 rows=590 width=90) (actual time=0.013..0.013 rows=1 loops=1)
  ->  Sort  (cost=11.38..11.39 rows=1 width=4) (actual time=0.050..0.050 rows=0 loops=1)
        Sort Key: quests.id
        Sort Method: quicksort  Memory: 25kB
        ->  Seq Scan on quests  (cost=0.00..11.38 rows=1 width=4) (actual time=0.039..0.040 rows=0 loops=1)
              Filter: ("successRequirements" @> '[{"data": {"campaignId": {"data": 1666360}}}]'::jsonb)
              Rows Removed by Filter: 8
Planning Time: 2.392 ms
Execution Time: 0.194 ms
```

## 🧑‍🎄 Pour tester

Vérifier que la page d'une campagne appartenant au parcours combiné s'affiche bien