### PR TITLE
[TECH] Supprime la condition peu performante sur hasAssessmentParticipations (PIX-21367)

### DIFF
--- a/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-repository.js
@@ -1,6 +1,5 @@
 import lodash from 'lodash';
 
-import { knex } from '../../../../../db/knex-database-connection.js';
 import { OrganizationLearnerParticipationTypes } from '../../../../quest/domain/models/OrganizationLearnerParticipation.js';
 import { constants } from '../../../../shared/domain/constants.js';
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
@@ -241,17 +240,6 @@ const hasAssessmentParticipations = async function (userId) {
     .leftJoin('campaigns', 'campaigns.id', 'campaignId')
     .where('assessments.type', '=', Assessment.types.CAMPAIGN)
     .where({ 'assessments.userId': userId })
-    .whereNotExists(function () {
-      this.select(knex.raw('1'))
-        .from('quests')
-        .join('combined_courses', 'combined_courses.questId', 'quests.id')
-        .whereIn('combined_courses.organizationId', function () {
-          this.select('organizationId').from('organization-learners').where('userId', userId);
-        })
-        .crossJoin(knex.raw('jsonb_array_elements("successRequirements") as success_elem'))
-        .whereNotNull('quests.successRequirements')
-        .andWhereRaw("(success_elem->'data'->'campaignId'->>'data')::integer = \"campaigns\".\"id\"");
-    })
     .where(function () {
       this.whereNot('campaigns.organizationId', constants.AUTONOMOUS_COURSES_ORGANIZATION_ID).orWhereNull(
         'campaigns.organizationId',


### PR DESCRIPTION
## ❄️ Problème

La condition qui exclue les participations a des campagnes incluses dans des parcours combinés est peu performante et impacte négativement la production.

## 🛷 Proposition

Après réflexion cette condition n'est pas pertinente parce que dans la même fonction on vérifie si l'utilisateur a une participation à des parcours combinés. Donc on a pas besoin d'exclure ces participations. Cela semble être un reliquat de la période de construction des parcours combinés qu'on a oublié d'enlever.

## ☃️ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🧑‍🎄 Pour tester

Les tests sont au vert 🍏 
