### PR TITLE
[TECH] Retirer les équipes qui n'existent plus des code-owners (PIX-21374)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -30,22 +30,11 @@
 /api/src/certification/ @1024pix/team-certification
 /api/tests/certification/ @1024pix/team-certification
 
-# Directories maintained by team Evaluation
-/api/db/seeds/data/team-evaluation/ @1024pix/team-evaluation
-/api/src/evaluation/ @1024pix/team-evaluation
-/api/tests/evaluation/ @1024pix/team-evaluation
-
 
 # Directories maintained by team Prescription
 /api/db/seeds/data/team-prescription/ @1024pix/team-prescription
 /api/src/prescription/ @1024pix/team-prescription
 /api/tests/prescription/ @1024pix/team-prescription
-
-
-# Directories maintained by team Junior
-/api/db/seeds/data/team-1d/ @1024pix/team-junior
-/api/src/school/ @1024pix/team-junior
-/api/tests/school/ @1024pix/team-junior
 
 
 # Directories maintained by team Accès


### PR DESCRIPTION
## ❄️ Problème

On suggère des équipes inexistantes pour réaliser des reviews

## 🛷 Proposition

Retirer ces équipes des code-owners

## ☃️ Remarques

Suite à la re-répartition des fonctionnalités, il y aura besoin d'améliorer ces code-owners pour proposer les bonnes équipes au bon moment cependant cela demanderait une plus grande discussions.
## 🧑‍🎄 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
