### PR TITLE
[BUGFIX] Exclure les apprenants desactivé sur la page des activités d'une organisation (PIX-21377).

### DIFF
--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-participant-activity-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-participant-activity-repository.js
@@ -80,6 +80,7 @@ const campaignParticipantActivityRepository = {
         'view-active-organization-learners.organizationId',
         knex('campaigns').select('organizationId').where('id', campaignId),
       )
+      .where('view-active-organization-learners.isDisabled', false)
       .modify(filterParticipations, activityFilters)
       .orderByRaw('LOWER(??) ASC, LOWER(??) ASC', ['lastName', 'firstName']);
 

--- a/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-participant-activity-repository_test.js
+++ b/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-participant-activity-repository_test.js
@@ -300,6 +300,32 @@ describe('Integration | Repository | Campaign Participant activity', function ()
           expect(campaignParticipantsActivities).lengthOf(2);
         });
       });
+
+      context('When the learner is disabled', function () {
+        it('should return empty list', async function () {
+          // given
+          const campaign = databaseBuilder.factory.buildCampaign();
+
+          databaseBuilder.factory.buildOrganizationLearner({
+            firstName: 'nonParticipant',
+            organizationId: campaign.organizationId,
+            isDisabled: true,
+          });
+
+          await databaseBuilder.commit();
+
+          // when
+          const { campaignParticipantsActivities } =
+            await campaignParticipantActivityRepository.findPaginatedByCampaignId({
+              campaignId: campaign.id,
+
+              filters: { status: 'NOT_STARTED' },
+            });
+
+          // then
+          expect(campaignParticipantsActivities).lengthOf(0);
+        });
+      });
     });
 
     context('order', function () {


### PR DESCRIPTION
## ❄️ Problème

On ne prend pas en compte les apprenants desactivé, ce qui remonte une liste plus importante que prévu

## 🛷 Proposition

Ajouter cette condition 

## ☃️ Remarques

RAS

## 🧑‍🎄 Pour tester

Faire un import sur PixOrga pour desactiver les anciens learner et vérifier qu'il n'apparaissent plus dans la liste de la campagne