### PR TITLE
[FEATURE] Création d'un onglet de détails sur la page d'une organisation (PIX-21196).

### DIFF
--- a/admin/app/components/organizations/archiving-confirmation-modal.gjs
+++ b/admin/app/components/organizations/archiving-confirmation-modal.gjs
@@ -11,19 +11,25 @@ import { t } from 'ember-intl';
   >
     <:content>
       <p>
-        Êtes-vous sûr de vouloir archiver cette organisation ?
+        {{t "components.organizations.information-section-view.archive-organization.confirmation"}}
       </p>
       <ul class="archiving-confirmation-modal__list">
-        <li class="archiving-confirmation-modal__information">Les membres actifs vont être désactivés</li>
-        <li class="archiving-confirmation-modal__information">Les invitations en attente vont être annulées</li>
-        <li class="archiving-confirmation-modal__information">Les campagnes actives vont être archivées</li>
+        <li class="archiving-confirmation-modal__information">{{t
+            "components.organizations.information-section-view.archive-organization.warnings.active-members"
+          }}</li>
+        <li class="archiving-confirmation-modal__information">{{t
+            "components.organizations.information-section-view.archive-organization.warnings.pending-invitations"
+          }}</li>
+        <li class="archiving-confirmation-modal__information">{{t
+            "components.organizations.information-section-view.archive-organization.warnings.active-campaigns"
+          }}</li>
         <li class="archiving-confirmation-modal__information">
-          Le rattachement et l'invitation de nouvelles personnes seront bloqués
+          {{t "components.organizations.information-section-view.archive-organization.warnings.linking"}}
         </li>
       </ul>
       <p>
         <strong>
-          Cette action est irréversible.
+          {{t "components.organizations.information-section-view.archive-organization.warnings.undone"}}
         </strong>
       </p>
     </:content>
@@ -33,7 +39,7 @@ import { t } from 'ember-intl';
         {{t "common.actions.cancel"}}
       </PixButton>
       <PixButton @type="submit" @size="small" {{on "click" @archiveOrganization}}>
-        Confirmer
+        {{t "common.actions.confirm"}}
       </PixButton>
     </:footer>
   </PixModal>

--- a/admin/app/components/organizations/head-information.gjs
+++ b/admin/app/components/organizations/head-information.gjs
@@ -1,0 +1,100 @@
+import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import PixTag from '@1024pix/pix-ui/components/pix-tag';
+import { on } from '@ember/modifier';
+import { action } from '@ember/object';
+import { LinkTo } from '@ember/routing';
+import Component from '@glimmer/component';
+import t from 'ember-intl/helpers/t';
+import ENV from 'pix-admin/config/environment';
+
+export default class HeadInformation extends Component {
+  @action
+  onLogoUpload(event) {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    const reader = new FileReader();
+    reader.onload = () => {
+      this.args.organization.logoUrl = reader.result;
+      this.args.onLogoUpdated();
+    };
+    reader.readAsDataURL(file);
+  }
+
+  get hasTags() {
+    const tags = this.args.organization.tags;
+    return tags?.length > 0;
+  }
+
+  get hasChildren() {
+    const children = this.args.organization.children;
+    return children?.length > 0;
+  }
+
+  get externalURL() {
+    const urlDashboardPrefix = ENV.APP.ORGANIZATION_DASHBOARD_URL;
+    return urlDashboardPrefix && urlDashboardPrefix + this.args.organization.id;
+  }
+
+  <template>
+    <div class="organization__header">
+      <div class="organization__logo">
+        <figure class="organization__logo-figure">
+          {{#if @organization.logoUrl}}
+            {{! template-lint-disable no-redundant-role }}
+            <img src={{@organization.logoUrl}} alt="" role="presentation" />
+          {{else}}
+            {{! template-lint-disable no-redundant-role }}
+            <img src="{{this.rootURL}}/logo-placeholder.png" alt="" role="presentation" />
+          {{/if}}
+
+          <label class="file-upload">
+            <input type="file" accept="image/*" hidden {{on "change" this.onLogoUpload}} />
+          </label>
+        </figure>
+      </div>
+
+      <div class="organization__title">
+        <h1 class="organization__name">{{@organization.name}}</h1>
+
+        <ul class="organization-tags-list">
+          {{#if this.hasChildren}}
+            <li>
+              <PixTag @color="success">
+                {{t "components.organizations.information-section-view.parent-organization"}}
+              </PixTag>
+            </li>
+          {{/if}}
+          {{#if @organization.parentOrganizationId}}
+            <li>
+              <PixTag class="organization__child-tag" @color="success">
+                {{t "components.organizations.information-section-view.child-organization"}}
+                <LinkTo @route="authenticated.organizations.get" @model={{@organization.parentOrganizationId}}>
+                  {{@organization.parentOrganizationName}}
+                </LinkTo>
+              </PixTag>
+            </li>
+          {{/if}}
+          {{#if this.hasTags}}
+            {{#each @organization.tags as |tag|}}
+              <li>
+                <PixTag @color="purple-light">{{tag.name}}</PixTag>
+              </li>
+            {{/each}}
+          {{/if}}
+        </ul>
+      </div>
+
+      <PixButtonLink
+        class="organization__dashboard-button"
+        @variant="secondary"
+        @href={{this.externalURL}}
+        @size="small"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Tableau de bord
+      </PixButtonLink>
+    </div>
+  </template>
+}

--- a/admin/app/components/organizations/head-information.gjs
+++ b/admin/app/components/organizations/head-information.gjs
@@ -61,14 +61,14 @@ export default class HeadInformation extends Component {
           {{#if this.hasChildren}}
             <li>
               <PixTag @color="success">
-                {{t "components.organizations.information-section-view.parent-organization"}}
+                {{t "components.organizations.head-information.parent-organization"}}
               </PixTag>
             </li>
           {{/if}}
           {{#if @organization.parentOrganizationId}}
             <li>
               <PixTag class="organization__child-tag" @color="success">
-                {{t "components.organizations.information-section-view.child-organization"}}
+                {{t "components.organizations.head-information.child-organization"}}
                 <LinkTo @route="authenticated.organizations.get" @model={{@organization.parentOrganizationId}}>
                   {{@organization.parentOrganizationName}}
                 </LinkTo>

--- a/admin/app/components/organizations/information-section-view.gjs
+++ b/admin/app/components/organizations/information-section-view.gjs
@@ -1,6 +1,5 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixIcon from '@1024pix/pix-ui/components/pix-icon';
-import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
 import { concat, get } from '@ember/helper';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
@@ -23,32 +22,20 @@ export default class OrganizationInformationSection extends Component {
 
   <template>
     <div class="organization__data">
-      {{#if @organization.isArchived}}
-        <PixNotificationAlert class="organization-information-section__archived-message" @type="warning">
-          {{t
-            "components.organizations.information-section-view.is-archived-warning"
-            archivedAt=@organization.archivedFormattedDate
-            archivedBy=@organization.archivistFullName
-          }}
-        </PixNotificationAlert>
-      {{/if}}
+      <OrganizationDescription @organization={{@organization}} />
 
-      <div>
-        <OrganizationDescription @organization={{@organization}} />
-
-        {{#if this.accessControl.hasAccessToOrganizationActionsScope}}
-          <div class="form-actions organization-information__actions">
-            <PixButton @variant="secondary" @size="small" @triggerAction={{@toggleEditMode}}>
-              {{t "common.actions.edit"}}
+      {{#if this.accessControl.hasAccessToOrganizationActionsScope}}
+        <div class="form-actions organization-information__actions">
+          <PixButton @variant="secondary" @size="small" @triggerAction={{@toggleEditMode}}>
+            {{t "common.actions.edit"}}
+          </PixButton>
+          {{#unless @organization.isArchived}}
+            <PixButton @variant="error" @size="small" @triggerAction={{@toggleArchivingConfirmationModal}}>
+              {{t "components.organizations.information-section-view.archive-organization.action"}}
             </PixButton>
-            {{#unless @organization.isArchived}}
-              <PixButton @variant="error" @size="small" @triggerAction={{@toggleArchivingConfirmationModal}}>
-                {{t "components.organizations.information-section-view.archive-organization.action"}}
-              </PixButton>
-            {{/unless}}
-          </div>
-        {{/if}}
-      </div>
+          {{/unless}}
+        </div>
+      {{/if}}
     </div>
   </template>
 }

--- a/admin/app/components/organizations/information-section-view.gjs
+++ b/admin/app/components/organizations/information-section-view.gjs
@@ -43,7 +43,7 @@ export default class OrganizationInformationSection extends Component {
             </PixButton>
             {{#unless @organization.isArchived}}
               <PixButton @variant="error" @size="small" @triggerAction={{@toggleArchivingConfirmationModal}}>
-                {{t "components.organizations.information-section-view.archive-organization"}}
+                {{t "components.organizations.information-section-view.archive-organization.action"}}
               </PixButton>
             {{/unless}}
           </div>

--- a/admin/app/components/organizations/information-section.gjs
+++ b/admin/app/components/organizations/information-section.gjs
@@ -1,13 +1,7 @@
-import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
-import PixTag from '@1024pix/pix-ui/components/pix-tag';
-import { on } from '@ember/modifier';
 import { action } from '@ember/object';
-import { LinkTo } from '@ember/routing';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { t } from 'ember-intl';
-import ENV from 'pix-admin/config/environment';
 
 import ArchivingConfirmationModal from './archiving-confirmation-modal';
 import InformationSectionEdit from './information-section-edit';
@@ -17,19 +11,6 @@ export default class OrganizationInformationSection extends Component {
   @service accessControl;
   @tracked isEditMode = false;
   @tracked showArchivingConfirmationModal = false;
-
-  @action
-  onLogoUpload(event) {
-    const file = event.target.files?.[0];
-    if (!file) return;
-
-    const reader = new FileReader();
-    reader.onload = () => {
-      this.args.organization.logoUrl = reader.result;
-      this.args.onLogoUpdated();
-    };
-    reader.readAsDataURL(file);
-  }
 
   @action
   toggleEditMode() {
@@ -47,83 +28,8 @@ export default class OrganizationInformationSection extends Component {
     this.args.archiveOrganization();
   }
 
-  get hasTags() {
-    const tags = this.args.organization.tags;
-    return tags?.length > 0;
-  }
-
-  get hasChildren() {
-    const children = this.args.organization.children;
-    return children?.length > 0;
-  }
-
-  get externalURL() {
-    const urlDashboardPrefix = ENV.APP.ORGANIZATION_DASHBOARD_URL;
-    return urlDashboardPrefix && urlDashboardPrefix + this.args.organization.id;
-  }
-
   <template>
     <section class="page-section">
-      <div class="organization__header">
-        <div class="organization__logo">
-          <figure class="organization__logo-figure">
-            {{#if @organization.logoUrl}}
-              {{! template-lint-disable no-redundant-role }}
-              <img src={{@organization.logoUrl}} alt="" role="presentation" />
-            {{else}}
-              {{! template-lint-disable no-redundant-role }}
-              <img src="{{this.rootURL}}/logo-placeholder.png" alt="" role="presentation" />
-            {{/if}}
-
-            <label class="file-upload">
-              <input type="file" accept="image/*" hidden {{on "change" this.onLogoUpload}} />
-            </label>
-          </figure>
-        </div>
-
-        <div class="organization__title">
-          <h1 class="organization__name">{{@organization.name}}</h1>
-
-          <ul class="organization-tags-list">
-            {{#if this.hasChildren}}
-              <li>
-                <PixTag @color="success">
-                  {{t "components.organizations.information-section-view.parent-organization"}}
-                </PixTag>
-              </li>
-            {{/if}}
-            {{#if @organization.parentOrganizationId}}
-              <li>
-                <PixTag class="organization__child-tag" @color="success">
-                  {{t "components.organizations.information-section-view.child-organization"}}
-                  <LinkTo @route="authenticated.organizations.get" @model={{@organization.parentOrganizationId}}>
-                    {{@organization.parentOrganizationName}}
-                  </LinkTo>
-                </PixTag>
-              </li>
-            {{/if}}
-            {{#if this.hasTags}}
-              {{#each @organization.tags as |tag|}}
-                <li>
-                  <PixTag @color="purple-light">{{tag.name}}</PixTag>
-                </li>
-              {{/each}}
-            {{/if}}
-          </ul>
-        </div>
-
-        <PixButtonLink
-          class="organization__dashboard-button"
-          @variant="secondary"
-          @href={{this.externalURL}}
-          @size="small"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Tableau de bord
-        </PixButtonLink>
-      </div>
-
       <div class="organization__information {{if this.isEditMode 'organization__information--editing'}}">
         {{#if this.isEditMode}}
           <InformationSectionEdit

--- a/admin/app/components/organizations/places.gjs
+++ b/admin/app/components/organizations/places.gjs
@@ -27,9 +27,7 @@ export default class Places extends Component {
 
   <template>
     <section class="page-section">
-      <header class="page-section__header">
-        <h2 class="page-section__title">Places</h2>
-      </header>
+      <h2 class="page-section__title page-section__title--sub">Places</h2>
       <Statistics @statistics={{@placesStatistics}} />
       <div class="places__resume">
         {{#if this.accessControl.hasAccessToOrganizationPlacesActionsScope}}

--- a/admin/app/components/organizations/target-profiles-section.gjs
+++ b/admin/app/components/organizations/target-profiles-section.gjs
@@ -139,9 +139,7 @@ export default class OrganizationTargetProfilesSectionComponent extends Componen
   <template>
     {{#if this.accessControl.hasAccessToOrganizationActionsScope}}
       <section class="page-section">
-        <header class="page-section__header">
-          <h2 class="page-section__title">Rattacher un ou plusieurs profil(s) cible(s)</h2>
-        </header>
+        <h2 class="page-section__title page-section__title--sub">Rattacher un ou plusieurs profil(s) cible(s)</h2>
         <div class="organization__forms-section">
           <form class="organization__sub-form form" {{on "submit" this.attachTargetProfiles}}>
             <PixInput

--- a/admin/app/controllers/authenticated/organizations/get.js
+++ b/admin/app/controllers/authenticated/organizations/get.js
@@ -1,61 +1,6 @@
 import Controller from '@ember/controller';
-import { action } from '@ember/object';
 import { service } from '@ember/service';
-import get from 'lodash/get';
 
 export default class GetController extends Controller {
-  @service pixToast;
-  @service router;
   @service accessControl;
-  @service intl;
-
-  @action
-  async updateOrganizationInformation() {
-    try {
-      await this.model.save();
-      this.pixToast.sendSuccessNotification({ message: "L'organisation a bien été modifiée." });
-      this.router.transitionTo('authenticated.organizations.get');
-    } catch (responseError) {
-      this.model.rollbackAttributes();
-      const error = get(responseError, 'errors[0]');
-      let message;
-      switch (error?.status) {
-        case '413':
-          message = this.intl.t(I18N_KEY_ERROR_MESSAGES[error?.status], {
-            maxSizeInMegaBytes: error?.meta?.maxSizeInMegaBytes,
-          });
-          break;
-        default:
-          message = this.intl.t(I18N_KEY_ERROR_MESSAGES['default']);
-      }
-      this.pixToast.sendErrorNotification({ message });
-    }
-  }
-
-  @action
-  async archiveOrganization() {
-    try {
-      await this.model.save({ adapterOptions: { archiveOrganization: true } });
-
-      this.pixToast.sendSuccessNotification({ message: 'Cette organisation a bien été archivée.' });
-      this.router.transitionTo('authenticated.organizations.get');
-    } catch (responseError) {
-      const status = get(responseError, 'errors[0].status');
-      const errorCode = get(responseError, 'errors[0].code');
-      if (errorCode === 'ARCHIVE_ORGANIZATION_ERROR') {
-        return this.pixToast.sendErrorNotification({
-          message: this.intl.t('pages.organization.get.archiving.notifications.active-places-lot-error'),
-        });
-      }
-      if (status === '422') {
-        return this.pixToast.sendErrorNotification({ message: "L'organisation n'a pas pu être archivée." });
-      }
-      this.pixToast.sendErrorNotification({ message: 'Une erreur est survenue.' });
-    }
-  }
 }
-
-const I18N_KEY_ERROR_MESSAGES = {
-  413: 'pages.organizations.notifications.errors.payload-too-large',
-  default: 'common.notifications.generic-error',
-};

--- a/admin/app/controllers/authenticated/organizations/get/details.js
+++ b/admin/app/controllers/authenticated/organizations/get/details.js
@@ -1,0 +1,61 @@
+import Controller from '@ember/controller';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import get from 'lodash/get';
+
+export default class DetailsController extends Controller {
+  @service pixToast;
+  @service router;
+  @service accessControl;
+  @service intl;
+
+  @action
+  async updateOrganizationInformation() {
+    try {
+      await this.model.save();
+      this.pixToast.sendSuccessNotification({ message: "L'organisation a bien été modifiée." });
+      this.router.transitionTo('authenticated.organizations.get');
+    } catch (responseError) {
+      this.model.rollbackAttributes();
+      const error = get(responseError, 'errors[0]');
+      let message;
+      switch (error?.status) {
+        case '413':
+          message = this.intl.t(I18N_KEY_ERROR_MESSAGES[error?.status], {
+            maxSizeInMegaBytes: error?.meta?.maxSizeInMegaBytes,
+          });
+          break;
+        default:
+          message = this.intl.t(I18N_KEY_ERROR_MESSAGES['default']);
+      }
+      this.pixToast.sendErrorNotification({ message });
+    }
+  }
+
+  @action
+  async archiveOrganization() {
+    try {
+      await this.model.save({ adapterOptions: { archiveOrganization: true } });
+
+      this.pixToast.sendSuccessNotification({ message: 'Cette organisation a bien été archivée.' });
+      this.router.transitionTo('authenticated.organizations.get');
+    } catch (responseError) {
+      const status = get(responseError, 'errors[0].status');
+      const errorCode = get(responseError, 'errors[0].code');
+      if (errorCode === 'ARCHIVE_ORGANIZATION_ERROR') {
+        return this.pixToast.sendErrorNotification({
+          message: this.intl.t('pages.organization.get.archiving.notifications.active-places-lot-error'),
+        });
+      }
+      if (status === '422') {
+        return this.pixToast.sendErrorNotification({ message: "L'organisation n'a pas pu être archivée." });
+      }
+      this.pixToast.sendErrorNotification({ message: 'Une erreur est survenue.' });
+    }
+  }
+}
+
+const I18N_KEY_ERROR_MESSAGES = {
+  413: 'pages.organizations.notifications.errors.payload-too-large',
+  default: 'common.notifications.generic-error',
+};

--- a/admin/app/controllers/authenticated/organizations/get/details.js
+++ b/admin/app/controllers/authenticated/organizations/get/details.js
@@ -13,7 +13,9 @@ export default class DetailsController extends Controller {
   async updateOrganizationInformation() {
     try {
       await this.model.save();
-      this.pixToast.sendSuccessNotification({ message: "L'organisation a bien été modifiée." });
+      this.pixToast.sendSuccessNotification({
+        message: this.intl.t('components.organizations.information-section-view.update.notifications.success'),
+      });
       this.router.transitionTo('authenticated.organizations.get');
     } catch (responseError) {
       this.model.rollbackAttributes();
@@ -37,7 +39,11 @@ export default class DetailsController extends Controller {
     try {
       await this.model.save({ adapterOptions: { archiveOrganization: true } });
 
-      this.pixToast.sendSuccessNotification({ message: 'Cette organisation a bien été archivée.' });
+      this.pixToast.sendSuccessNotification({
+        message: this.intl.t(
+          'components.organizations.information-section-view.archive-organization.notifications.success',
+        ),
+      });
       this.router.transitionTo('authenticated.organizations.get');
     } catch (responseError) {
       const status = get(responseError, 'errors[0].status');
@@ -48,9 +54,13 @@ export default class DetailsController extends Controller {
         });
       }
       if (status === '422') {
-        return this.pixToast.sendErrorNotification({ message: "L'organisation n'a pas pu être archivée." });
+        return this.pixToast.sendErrorNotification({
+          message: this.intl.t(
+            'components.organizations.information-section-view.archive-organization.notifications.error',
+          ),
+        });
       }
-      this.pixToast.sendErrorNotification({ message: 'Une erreur est survenue.' });
+      this.pixToast.sendErrorNotification({ message: this.intl.t('common.notifications.generic-error') });
     }
   }
 }

--- a/admin/app/router.js
+++ b/admin/app/router.js
@@ -40,6 +40,7 @@ Router.map(function () {
       this.route('new');
       this.route('list');
       this.route('get', { path: '/:organization_id' }, function () {
+        this.route('details');
         this.route('team');
         this.route('target-profiles');
         this.route('campaigns');

--- a/admin/app/routes/authenticated/organizations/get/index.js
+++ b/admin/app/routes/authenticated/organizations/get/index.js
@@ -5,6 +5,6 @@ export default class IndexRoute extends Route {
   @service router;
 
   beforeModel() {
-    this.router.replaceWith('authenticated.organizations.get.team');
+    this.router.replaceWith('authenticated.organizations.get.details');
   }
 }

--- a/admin/app/routes/authenticated/organizations/get/invitations.js
+++ b/admin/app/routes/authenticated/organizations/get/invitations.js
@@ -8,7 +8,7 @@ export default class InvitationsRoute extends Route {
   beforeModel() {
     const organization = this.modelFor('authenticated.organizations.get');
     if (organization.isArchived) {
-      return this.router.replaceWith('authenticated.organizations.get.target-profiles');
+      return this.router.replaceWith('authenticated.organizations.get.details');
     }
   }
 

--- a/admin/app/routes/authenticated/organizations/get/team.js
+++ b/admin/app/routes/authenticated/organizations/get/team.js
@@ -23,7 +23,7 @@ export default class OrganizationTeamRoute extends Route {
   beforeModel() {
     const organization = this.modelFor('authenticated.organizations.get');
     if (organization.isArchived) {
-      return this.router.replaceWith('authenticated.organizations.get.target-profiles');
+      return this.router.replaceWith('authenticated.organizations.get.details');
     }
   }
 

--- a/admin/app/styles/components/organization-information-section.scss
+++ b/admin/app/styles/components/organization-information-section.scss
@@ -4,7 +4,7 @@
 /* stylelint-disable color-no-hex */
 .organization-information-section {
   &__archived-message {
-    margin-top: var(--pix-spacing-3x);
+    margin-bottom: var(--pix-spacing-3x);
   }
 
   &__card {

--- a/admin/app/templates/authenticated/organizations/get.gjs
+++ b/admin/app/templates/authenticated/organizations/get.gjs
@@ -1,3 +1,4 @@
+import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
 import PixTabs from '@1024pix/pix-ui/components/pix-tabs';
 import { LinkTo } from '@ember/routing';
 import t from 'ember-intl/helpers/t';
@@ -11,6 +12,16 @@ import HeadInformation from 'pix-admin/components/organizations/head-information
 
   <main class="page-body" id="organizations-get-page">
     <HeadInformation @organization={{@model}} />
+
+    {{#if @model.isArchived}}
+      <PixNotificationAlert class="organization-information-section__archived-message" @type="warning">
+        {{t
+          "components.organizations.information-section-view.is-archived-warning"
+          archivedAt=@model.archivedFormattedDate
+          archivedBy=@model.archivistFullName
+        }}
+      </PixNotificationAlert>
+    {{/if}}
 
     <PixTabs @variant="primary" @ariaLabel={{t "pages.organization.navbar.aria-label"}} class="navigation">
 

--- a/admin/app/templates/authenticated/organizations/get.gjs
+++ b/admin/app/templates/authenticated/organizations/get.gjs
@@ -2,22 +2,21 @@ import PixTabs from '@1024pix/pix-ui/components/pix-tabs';
 import { LinkTo } from '@ember/routing';
 import t from 'ember-intl/helpers/t';
 import Breadcrumb from 'pix-admin/components/organizations/breadcrumb';
-import InformationSection from 'pix-admin/components/organizations/information-section';
+import HeadInformation from 'pix-admin/components/organizations/head-information';
+
 <template>
   <header class="page-header">
     <Breadcrumb @currentPageLabel={{@model.name}} />
   </header>
 
   <main class="page-body" id="organizations-get-page">
-
-    <InformationSection
-      @organization={{@model}}
-      @onLogoUpdated={{@controller.updateOrganizationInformation}}
-      @onSubmit={{@controller.updateOrganizationInformation}}
-      @archiveOrganization={{@controller.archiveOrganization}}
-    />
+    <HeadInformation @organization={{@model}} />
 
     <PixTabs @variant="primary" @ariaLabel={{t "pages.organization.navbar.aria-label"}} class="navigation">
+
+      <LinkTo @route="authenticated.organizations.get.details" @model={{@model}}>
+        {{t "pages.organization.navbar.details"}}
+      </LinkTo>
 
       {{#unless @model.isArchived}}
         <LinkTo @route="authenticated.organizations.get.team" @model={{@model}}>

--- a/admin/app/templates/authenticated/organizations/get/details.gjs
+++ b/admin/app/templates/authenticated/organizations/get/details.gjs
@@ -1,0 +1,12 @@
+import pageTitle from 'ember-page-title/helpers/page-title';
+import InformationSection from 'pix-admin/components/organizations/information-section';
+
+<template>
+  {{pageTitle "Orga " @model.id " | Détails"}}
+  <InformationSection
+    @organization={{@model}}
+    @onLogoUpdated={{@controller.updateOrganizationInformation}}
+    @onSubmit={{@controller.updateOrganizationInformation}}
+    @archiveOrganization={{@controller.archiveOrganization}}
+  />
+</template>

--- a/admin/tests/acceptance/authenticated/combined-course-blueprints/organizations-test.js
+++ b/admin/tests/acceptance/authenticated/combined-course-blueprints/organizations-test.js
@@ -96,7 +96,7 @@ module('Acceptance | combined course blueprint Organizations', function (hooks) 
         await click(screen.getByRole('link', { name: '456' }));
 
         // then
-        assert.deepEqual(currentURL(), '/organizations/456/team');
+        assert.deepEqual(currentURL(), '/organizations/456/details');
       });
 
       test('it should redirect to combined course blueprint details after detach', async function (assert) {

--- a/admin/tests/acceptance/authenticated/organizations/get-test.js
+++ b/admin/tests/acceptance/authenticated/organizations/get-test.js
@@ -45,6 +45,24 @@ module('Acceptance | Organizations | Get', function (hooks) {
       assert.strictEqual(currentURL(), `/organizations/${ORGANIZATION_ID}/details`);
     });
 
+    module('When organization is archived', function () {
+      test('it should display who archived it', async function (assert) {
+        // given
+        server.create('organization', {
+          id: ARCHIVED_ORGANIZATION_ID,
+          name: 'My Archived Organization',
+          archivedAt: new Date('2026-01-01'),
+          features: { PLACES_MANAGEMENT: { active: true } },
+          archivistFullName: 'Rob Lochon',
+        });
+        // when
+        const screen = await visit(`/organizations/${ARCHIVED_ORGANIZATION_ID}`);
+
+        // then
+        assert.dom(screen.getByText('Archivée le 01/01/2026 par Rob Lochon.')).exists();
+      });
+    });
+
     module('Navigation tabs', function () {
       module('Details tab', function () {
         module('When organization is active', function () {

--- a/admin/tests/acceptance/authenticated/organizations/information-management-test.js
+++ b/admin/tests/acceptance/authenticated/organizations/information-management-test.js
@@ -6,9 +6,12 @@ import { authenticateAdminMemberWithRole } from 'pix-admin/tests/helpers/test-in
 import { setupMirage } from 'pix-admin/tests/test-support/setup-mirage';
 import { module, test } from 'qunit';
 
+import setupIntl from '../../../helpers/setup-intl';
+
 module('Acceptance | Organizations | Information management', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
+  setupIntl(hooks);
 
   hooks.beforeEach(async function () {
     await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
@@ -36,20 +39,24 @@ module('Acceptance | Organizations | Information management', function (hooks) {
 
       const screen = await visit(`/organizations/${organization.id}`);
 
-      await clickByName('Modifier');
+      await clickByName(t('common.actions.edit'));
 
       // when
       await fillIn(screen.getByLabelText(/Nom \*/), 'newOrganizationName');
-      await fillByLabel('Prénom du DPO', 'Bru');
-      await fillByLabel('Nom du DPO', 'No');
-      await fillByLabel('Adresse e-mail du DPO', 'bru.no@example.net');
+      await fillByLabel(t('components.organizations.information-section-view.dpo-firstname'), 'Bru');
+      await fillByLabel(t('components.organizations.information-section-view.dpo-lastname'), 'No');
+      await fillByLabel(t('components.organizations.information-section-view.dpo-email'), 'bru.no@example.net');
 
-      await clickByName('Enregistrer');
+      await clickByName(t('common.actions.save'));
 
       // then
       assert.dom(screen.getByRole('heading', { name: 'newOrganizationName', level: 1 })).exists();
-      assert.dom(screen.getByText('Nom du DPO').nextElementSibling).hasText('Bru No');
-      assert.dom(screen.getByText('Adresse e-mail du DPO').nextElementSibling).hasText('bru.no@example.net');
+      assert
+        .dom(screen.getByText(t('components.organizations.information-section-view.dpo-lastname')).nextElementSibling)
+        .hasText('Bru No');
+      assert
+        .dom(screen.getByText(t('components.organizations.information-section-view.dpo-email')).nextElementSibling)
+        .hasText('bru.no@example.net');
     });
 
     test('should display an error toast if administration team is not filled in', async function (assert) {
@@ -73,10 +80,10 @@ module('Acceptance | Organizations | Information management', function (hooks) {
 
       const screen = await visit(`/organizations/${organization.id}`);
 
-      await clickByName('Modifier');
+      await clickByName(t('common.actions.edit'));
 
       // when
-      await clickByName('Enregistrer');
+      await clickByName(t('common.actions.save'));
 
       // then
       assert.dom(screen.getByText(t('components.organizations.editing.required-fields-error'))).exists();
@@ -113,7 +120,7 @@ module('Acceptance | Organizations | Information management', function (hooks) {
       const screen = await visit(`/organizations/${organization.id}/team`);
 
       // then
-      assert.dom(screen.queryByLabelText('Équipe', { selector: 'a' })).doesNotExist();
+      assert.dom(screen.queryByLabelText(t('pages.organization.navbar.team'), { selector: 'a' })).doesNotExist();
       assert.strictEqual(currentURL(), `/organizations/${organization.id}/target-profiles`);
     });
 
@@ -130,7 +137,7 @@ module('Acceptance | Organizations | Information management', function (hooks) {
       const screen = await visit(`/organizations/${organization.id}/invitations`);
 
       // then
-      assert.dom(screen.queryByLabelText('Invitations')).doesNotExist();
+      assert.dom(screen.queryByLabelText(t('pages.organization.navbar.invitations'))).doesNotExist();
       assert.strictEqual(currentURL(), `/organizations/${organization.id}/target-profiles`);
     });
   });
@@ -146,13 +153,17 @@ module('Acceptance | Organizations | Information management', function (hooks) {
         const screen = await visit(`/organizations/${organization.id}`);
 
         // when
-        await clickByName("Archiver l'organisation");
+        await clickByName(t('components.organizations.information-section-view.archive-organization.action'));
 
         await screen.findByRole('dialog');
 
         // then
         assert.dom(screen.getByRole('heading', { name: "Archiver l'organisation Aude Javel Company" })).exists();
-        assert.dom(screen.getByText('Êtes-vous sûr de vouloir archiver cette organisation ?')).exists();
+        assert
+          .dom(
+            screen.getByText(t('components.organizations.information-section-view.archive-organization.confirmation')),
+          )
+          .exists();
       });
 
       module('when user confirms archiving', function () {
@@ -163,14 +174,20 @@ module('Acceptance | Organizations | Information management', function (hooks) {
             features: { PLACES_MANAGEMENT: { active: true } },
           });
           const screen = await visit(`/organizations/${organization.id}`);
-          await clickByName("Archiver l'organisation");
-
+          await clickByName(t('components.organizations.information-section-view.archive-organization.action'));
           await screen.findByRole('dialog');
+
           // when
-          await clickByName('Confirmer');
+          await clickByName(t('common.actions.confirm'));
 
           // then
-          assert.dom(screen.getByText('Cette organisation a bien été archivée.')).exists();
+          assert
+            .dom(
+              screen.getByText(
+                t('components.organizations.information-section-view.archive-organization.notifications.success'),
+              ),
+            )
+            .exists();
           assert.dom(screen.getByText('Archivée le 02/02/2022 par Clément Tine.')).exists();
         });
 
@@ -194,11 +211,11 @@ module('Acceptance | Organizations | Information management', function (hooks) {
               422,
             );
             const screen = await visit(`/organizations/${organization.id}`);
-            await clickByName("Archiver l'organisation");
-
+            await clickByName(t('components.organizations.information-section-view.archive-organization.action'));
             await screen.findByRole('dialog');
+
             // when
-            await clickByName('Confirmer');
+            await clickByName(t('common.actions.confirm'));
 
             // then
             assert
@@ -226,14 +243,20 @@ module('Acceptance | Organizations | Information management', function (hooks) {
             422,
           );
           const screen = await visit(`/organizations/${organization.id}`);
-          await clickByName("Archiver l'organisation");
+          await clickByName(t('components.organizations.information-section-view.archive-organization.action'));
 
           await screen.findByRole('dialog');
           // when
-          await clickByName('Confirmer');
+          await clickByName(t('common.actions.confirm'));
 
           // then
-          assert.dom(screen.getByText("L'organisation n'a pas pu être archivée.")).exists();
+          assert
+            .dom(
+              screen.getByText(
+                t('components.organizations.information-section-view.archive-organization.notifications.error'),
+              ),
+            )
+            .exists();
           assert.dom(screen.queryByLabelText('Archivée le 02/02/2022 par Clément Tine.')).doesNotExist();
         });
 
@@ -255,14 +278,14 @@ module('Acceptance | Organizations | Information management', function (hooks) {
             500,
           );
           const screen = await visit(`/organizations/${organization.id}`);
-          await clickByName("Archiver l'organisation");
+          await clickByName(t('components.organizations.information-section-view.archive-organization.action'));
 
           await screen.findByRole('dialog');
           // when
-          await clickByName('Confirmer');
+          await clickByName(t('common.actions.confirm'));
 
           // then
-          assert.dom(screen.getByText('Une erreur est survenue.')).exists();
+          assert.dom(screen.getByText(t('common.notifications.generic-error'))).exists();
           assert.dom(screen.queryByLabelText('Archivée le 02/02/2022 par Clément Tine.')).doesNotExist();
         });
       });
@@ -275,12 +298,12 @@ module('Acceptance | Organizations | Information management', function (hooks) {
             features: { PLACES_MANAGEMENT: { active: true } },
           });
           const screen = await visit(`/organizations/${organization.id}`);
-          await clickByName("Archiver l'organisation");
+          await clickByName(t('components.organizations.information-section-view.archive-organization.action'));
 
           await screen.findByRole('dialog');
 
           // when
-          await clickByName('Annuler');
+          await clickByName(t('common.actions.cancel'));
 
           // then
           assert.dom(screen.queryByLabelText('Archivée le 02/02/2022 par Clément Tine.')).doesNotExist();
@@ -293,11 +316,11 @@ module('Acceptance | Organizations | Information management', function (hooks) {
             features: { PLACES_MANAGEMENT: { active: true } },
           });
           const screen = await visit(`/organizations/${organization.id}`);
-          await clickByName("Archiver l'organisation");
+          await clickByName(t('components.organizations.information-section-view.archive-organization.action'));
 
           await screen.findByRole('dialog');
           // when
-          await click(screen.getByRole('button', { name: 'Fermer' }));
+          await click(screen.getByRole('button', { name: t('common.actions.close') }));
 
           // then
           assert.dom(screen.queryByLabelText('Archivée le 02/02/2022 par Clément Tine.')).doesNotExist();

--- a/admin/tests/acceptance/authenticated/organizations/information-management-test.js
+++ b/admin/tests/acceptance/authenticated/organizations/information-management-test.js
@@ -121,7 +121,7 @@ module('Acceptance | Organizations | Information management', function (hooks) {
 
       // then
       assert.dom(screen.queryByLabelText(t('pages.organization.navbar.team'), { selector: 'a' })).doesNotExist();
-      assert.strictEqual(currentURL(), `/organizations/${organization.id}/target-profiles`);
+      assert.strictEqual(currentURL(), `/organizations/${organization.id}/details`);
     });
 
     test('should not allow user to access invitation page', async function (assert) {
@@ -138,7 +138,7 @@ module('Acceptance | Organizations | Information management', function (hooks) {
 
       // then
       assert.dom(screen.queryByLabelText(t('pages.organization.navbar.invitations'))).doesNotExist();
-      assert.strictEqual(currentURL(), `/organizations/${organization.id}/target-profiles`);
+      assert.strictEqual(currentURL(), `/organizations/${organization.id}/details`);
     });
   });
 

--- a/admin/tests/acceptance/authenticated/organizations/information-management-test.js
+++ b/admin/tests/acceptance/authenticated/organizations/information-management-test.js
@@ -84,7 +84,7 @@ module('Acceptance | Organizations | Information management', function (hooks) {
   });
 
   module('when organization is archived', function () {
-    test('should redirect to organization target profiles page', async function (assert) {
+    test('should redirect to organization details page', async function (assert) {
       // given
       const organization = this.server.create('organization', {
         name: 'oldOrganizationName',
@@ -97,7 +97,7 @@ module('Acceptance | Organizations | Information management', function (hooks) {
       await visit(`/organizations/${organization.id}`);
 
       // then
-      assert.strictEqual(currentURL(), `/organizations/${organization.id}/target-profiles`);
+      assert.strictEqual(currentURL(), `/organizations/${organization.id}/details`);
     });
 
     test('should not allow user to access team page', async function (assert) {

--- a/admin/tests/acceptance/authenticated/organizations/list-test.js
+++ b/admin/tests/acceptance/authenticated/organizations/list-test.js
@@ -131,7 +131,7 @@ module('Acceptance | Organizations | List', function (hooks) {
       await click(screen.getByRole('link', { name: '1' }));
 
       // then
-      assert.strictEqual(currentURL(), '/organizations/1/team');
+      assert.strictEqual(currentURL(), '/organizations/1/details');
     });
   });
 

--- a/admin/tests/acceptance/authenticated/organizations/memberships-management-test.js
+++ b/admin/tests/acceptance/authenticated/organizations/memberships-management-test.js
@@ -20,12 +20,12 @@ module('Acceptance | Organizations | Memberships management', function (hooks) {
     });
   });
 
-  test('should redirect to organization team page', async function (assert) {
+  test('should redirect to organization details page', async function (assert) {
     // when
     await visit(`/organizations/${organization.id}`);
 
     // then
-    assert.strictEqual(currentURL(), `/organizations/${organization.id}/team`);
+    assert.strictEqual(currentURL(), `/organizations/${organization.id}/details`);
   });
 
   test('it should set organizations menubar item active', async function (assert) {
@@ -129,7 +129,7 @@ module('Acceptance | Organizations | Memberships management', function (hooks) {
       this.server.create('user', { firstName: 'John', lastName: 'Doe', email: 'user@example.com' });
 
       // when
-      const screen = await visit(`/organizations/${organization.id}`);
+      const screen = await visit(`/organizations/${organization.id}/team`);
       await fillIn(
         screen.getByRole('textbox', { name: "Adresse e-mail de l'utilisateur à ajouter" }),
         'user@example.com',
@@ -153,7 +153,7 @@ module('Acceptance | Organizations | Memberships management', function (hooks) {
       this.server.create('organization-membership', { user, organization });
 
       // when
-      const screen = await visit(`/organizations/${organization.id}`);
+      const screen = await visit(`/organizations/${organization.id}/team`);
       await fillIn(
         screen.getByRole('textbox', { name: "Adresse e-mail de l'utilisateur à ajouter" }),
         'denise@example.com',
@@ -175,7 +175,7 @@ module('Acceptance | Organizations | Memberships management', function (hooks) {
       this.server.create('organization-membership', { user, organization });
 
       // when
-      const screen = await visit(`/organizations/${organization.id}`);
+      const screen = await visit(`/organizations/${organization.id}/team`);
       await fillIn(
         screen.getByRole('textbox', { name: "Adresse e-mail de l'utilisateur à ajouter" }),
         'unexisting@example.com',
@@ -201,7 +201,7 @@ module('Acceptance | Organizations | Memberships management', function (hooks) {
       });
 
       // when
-      const screen = await visit(`/organizations/${organization.id}`);
+      const screen = await visit(`/organizations/${organization.id}/team`);
 
       // then
       assert.dom(screen.queryByText('Ajouter un membre')).doesNotExist();

--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile/organizations-test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile/organizations-test.js
@@ -108,7 +108,7 @@ module('Acceptance | Target Profile Organizations', function (hooks) {
         await clickByName('456');
 
         // then
-        assert.deepEqual(currentURL(), '/organizations/456/team');
+        assert.deepEqual(currentURL(), '/organizations/456/details');
       });
 
       test('should be able to attach an organization with given target profile', async function (assert) {

--- a/admin/tests/integration/components/organizations/head-information-test.gjs
+++ b/admin/tests/integration/components/organizations/head-information-test.gjs
@@ -73,7 +73,7 @@ module('Integration | Component | organizations/header-information', function (h
         const screen = await render(<template><HeadInformation @organization={{organization}} /></template>);
 
         // then
-        assert.dom(screen.getByText(t('components.organizations.information-section-view.parent-organization'))).exists();
+        assert.dom(screen.getByText(t('components.organizations.head-information.parent-organization'))).exists();
       });
     });
 
@@ -95,7 +95,7 @@ module('Integration | Component | organizations/header-information', function (h
         const screen = await render(<template><HeadInformation @organization={{organization}} /></template>);
 
         // then
-        assert.dom(screen.getByText(t('components.organizations.information-section-view.child-organization'))).exists();
+        assert.dom(screen.getByText(t('components.organizations.head-information.child-organization'))).exists();
         assert.dom(screen.getByRole('link', { name: 'Shibusen' })).exists();
       });
     });
@@ -114,7 +114,7 @@ module('Integration | Component | organizations/header-information', function (h
 
         // then
         assert
-          .dom(screen.queryByText(t('components.organizations.information-section-view.parent-organization')))
+          .dom(screen.queryByText(t('components.organizations.head-information.parent-organization')))
           .doesNotExist();
       });
     });

--- a/admin/tests/integration/components/organizations/head-information-test.gjs
+++ b/admin/tests/integration/components/organizations/head-information-test.gjs
@@ -1,0 +1,122 @@
+import { render } from '@1024pix/ember-testing-library';
+import EmberObject from '@ember/object';
+import { t } from 'ember-intl/test-support';
+import HeadInformation from 'pix-admin/components/organizations/head-information';
+import ENV from 'pix-admin/config/environment';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | organizations/header-information', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  module('when displaying organization', function () {
+    test('it displays organization header information', async function (assert) {
+      // given
+      const organization = EmberObject.create({ id: 1, name: 'Organization SCO' });
+
+      // when
+      const screen = await render(<template><HeadInformation @organization={{organization}} /></template>);
+
+      // then
+      assert.dom(screen.getByRole('heading', { name: 'Organization SCO' })).exists();
+    });
+
+    test('it generates correct external dashboard URL', async function (assert) {
+      // given
+      ENV.APP.ORGANIZATION_DASHBOARD_URL = 'https://metabase.pix.fr/dashboard/137/?id=';
+      const organization = EmberObject.create({ id: 1, name: 'Test Organization' });
+
+      // when
+      const screen = await render(<template><HeadInformation @organization={{organization}} /></template>);
+
+      // then
+      const dashboardLink = screen.getByRole('link', { name: 'Tableau de bord' });
+      assert.dom(dashboardLink).hasAttribute('href', 'https://metabase.pix.fr/dashboard/137/?id=1');
+    });
+
+    module('when organization has tags', function () {
+      test('it should display tags', async function (assert) {
+        // given
+        const organization = EmberObject.create({
+          id: 1,
+          tags: [
+            { id: 1, name: 'CFA' },
+            { id: 2, name: 'PRIVE' },
+            { id: 3, name: 'AGRICULTURE' },
+          ],
+        });
+
+        // when
+        const screen = await render(<template><HeadInformation @organization={{organization}} /></template>);
+
+        // then
+        assert.dom(screen.getByText('CFA')).exists();
+        assert.dom(screen.getByText('PRIVE')).exists();
+        assert.dom(screen.getByText('AGRICULTURE')).exists();
+      });
+    });
+
+    module('when organization is parent', function () {
+      test('it should display parent label', async function (assert) {
+        //given
+        const store = this.owner.lookup('service:store');
+        const child = store.createRecord('organization', {
+          type: 'SCO',
+        });
+        const organization = store.createRecord('organization', {
+          type: 'SCO',
+          children: [child],
+        });
+
+        // when
+        const screen = await render(<template><HeadInformation @organization={{organization}} /></template>);
+
+        // then
+        assert.dom(screen.getByText(t('components.organizations.information-section-view.parent-organization'))).exists();
+      });
+    });
+
+    module('when organization is child', function () {
+      test('it displays child label and parent organization name', async function (assert) {
+        //given
+        const store = this.owner.lookup('service:store');
+        const parentOrganization = store.createRecord('organization', {
+          id: '5',
+          type: 'SCO',
+        });
+        const organization = store.createRecord('organization', {
+          type: 'SCO',
+          parentOrganizationId: parentOrganization.id,
+          parentOrganizationName: 'Shibusen',
+        });
+
+        // when
+        const screen = await render(<template><HeadInformation @organization={{organization}} /></template>);
+
+        // then
+        assert.dom(screen.getByText(t('components.organizations.information-section-view.child-organization'))).exists();
+        assert.dom(screen.getByRole('link', { name: 'Shibusen' })).exists();
+      });
+    });
+
+    module('when organization is neither parent nor children', function () {
+      test('it displays no organization network label', async function (assert) {
+        //given
+        const store = this.owner.lookup('service:store');
+        const organization = store.createRecord('organization', {
+          type: 'SCO',
+          name: 'notParent',
+        });
+
+        // when
+        const screen = await render(<template><HeadInformation @organization={{organization}} /></template>);
+
+        // then
+        assert
+          .dom(screen.queryByText(t('components.organizations.information-section-view.parent-organization')))
+          .doesNotExist();
+      });
+    });
+  });
+});

--- a/admin/tests/integration/components/organizations/information-section-test.gjs
+++ b/admin/tests/integration/components/organizations/information-section-test.gjs
@@ -4,7 +4,6 @@ import Service from '@ember/service';
 import { click, fillIn } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import InformationSection from 'pix-admin/components/organizations/information-section';
-import ENV from 'pix-admin/config/environment';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
@@ -35,120 +34,6 @@ module('Integration | Component | organizations/information-section', function (
         store.createRecord('country', { code: '99101', name: 'Danemark' }),
         store.createRecord('country', { code: '99100', name: 'France' }),
       ]);
-  });
-
-  module('when displaying organization', function () {
-    test('it displays organization header information', async function (assert) {
-      // given
-      const organization = EmberObject.create({ id: 1, name: 'Organization SCO' });
-
-      // when
-      const screen = await render(<template><InformationSection @organization={{organization}} /></template>);
-
-      // then
-      assert.dom(screen.getByRole('heading', { name: 'Organization SCO' })).exists();
-    });
-
-    test('it generates correct external dashboard URL', async function (assert) {
-      // given
-      ENV.APP.ORGANIZATION_DASHBOARD_URL = 'https://metabase.pix.fr/dashboard/137/?id=';
-      const organization = EmberObject.create({ id: 1, name: 'Test Organization' });
-
-      // when
-      const screen = await render(<template><InformationSection @organization={{organization}} /></template>);
-
-      // then
-      const dashboardLink = screen.getByRole('link', { name: 'Tableau de bord' });
-      assert.dom(dashboardLink).hasAttribute('href', 'https://metabase.pix.fr/dashboard/137/?id=1');
-    });
-
-    module('when organization has tags', function () {
-      test('it should display tags', async function (assert) {
-        // given
-        const organization = EmberObject.create({
-          id: 1,
-          tags: [
-            { id: 1, name: 'CFA' },
-            { id: 2, name: 'PRIVE' },
-            { id: 3, name: 'AGRICULTURE' },
-          ],
-        });
-
-        // when
-        const screen = await render(<template><InformationSection @organization={{organization}} /></template>);
-
-        // then
-        assert.dom(screen.getByText('CFA')).exists();
-        assert.dom(screen.getByText('PRIVE')).exists();
-        assert.dom(screen.getByText('AGRICULTURE')).exists();
-      });
-    });
-
-    module('when organization is parent', function () {
-      test('it should display parent label', async function (assert) {
-        //given
-        const store = this.owner.lookup('service:store');
-        const child = store.createRecord('organization', {
-          type: 'SCO',
-        });
-        const organization = store.createRecord('organization', {
-          type: 'SCO',
-          children: [child],
-        });
-
-        // when
-        const screen = await render(<template><InformationSection @organization={{organization}} /></template>);
-
-        // then
-        assert
-          .dom(screen.getByText(t('components.organizations.information-section-view.parent-organization')))
-          .exists();
-      });
-    });
-
-    module('when organization is child', function () {
-      test('it displays child label and parent organization name', async function (assert) {
-        //given
-        const store = this.owner.lookup('service:store');
-        const parentOrganization = store.createRecord('organization', {
-          id: '5',
-          type: 'SCO',
-        });
-        const organization = store.createRecord('organization', {
-          type: 'SCO',
-          parentOrganizationId: parentOrganization.id,
-          parentOrganizationName: 'Shibusen',
-        });
-
-        // when
-        const screen = await render(<template><InformationSection @organization={{organization}} /></template>);
-
-        // then
-        assert
-          .dom(screen.getByText(t('components.organizations.information-section-view.child-organization')))
-          .exists();
-        assert.dom(screen.getByRole('link', { name: 'Shibusen' })).exists();
-      });
-    });
-
-    module('when organization is neither parent nor children', function () {
-      test('it displays no organization network label', async function (assert) {
-        //given
-        const store = this.owner.lookup('service:store');
-        const organization = store.createRecord('organization', {
-          type: 'SCO',
-          name: 'notParent',
-        });
-
-        // when
-        const screen = await render(<template><InformationSection @organization={{organization}} /></template>);
-
-        // then
-        assert
-          .dom(screen.queryByText(t('components.organizations.information-section-view.parent-organization')))
-          .doesNotExist();
-      });
-    });
   });
 
   module('when editing organization', function () {
@@ -193,7 +78,6 @@ module('Integration | Component | organizations/information-section', function (
       await clickByName(t('common.actions.cancel'));
 
       // then
-      assert.ok(await screen.findByRole('heading', { name: 'Organization SCO' }));
       assert.ok(await screen.findByRole('button', { name: t('common.actions.edit') }));
     });
 
@@ -203,7 +87,6 @@ module('Integration | Component | organizations/information-section', function (
 
       await clickByName(t('common.actions.edit'));
 
-      await fillIn(screen.getByLabelText(`${t('components.organizations.editing.name.label')} *`), 'new name');
       await fillByLabel(t('components.organizations.information-section-view.external-id'), 'new externalId');
       await fillByLabel(t('components.organizations.editing.province-code.label'), 'new provinceCode');
       await clickByName(t('components.organizations.information-section-view.features.IS_MANAGING_STUDENTS'));
@@ -218,7 +101,6 @@ module('Integration | Component | organizations/information-section', function (
       await clickByName(t('common.actions.cancel'));
 
       // then
-      assert.dom(screen.getByRole('heading', { name: organization.name })).exists();
       assert
         .dom(screen.getByText(t('components.organizations.information-section-view.external-id')).nextElementSibling)
         .hasText(organization.externalId);
@@ -317,7 +199,6 @@ module('Integration | Component | organizations/information-section', function (
       await clickByName(t('common.actions.save'));
 
       // then
-      assert.dom(screen.getByRole('heading', { name: 'new name' })).exists();
       assert
         .dom(screen.getByText(t('components.organizations.information-section-view.external-id')).nextElementSibling)
         .hasText('new externalId');

--- a/admin/tests/integration/components/organizations/information-section-view-test.gjs
+++ b/admin/tests/integration/components/organizations/information-section-view-test.gjs
@@ -346,38 +346,6 @@ module('Integration | Component | organizations/information-section-view', funct
         .hasText(t('common.not-specified'));
     });
 
-    module('when organization is archived', function () {
-      test('it should display who archived it', async function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const archivedAt = new Date('2022-02-22');
-        const organization = store.createRecord('organization', { archivistFullName: 'Rob Lochon', archivedAt });
-
-        // when
-        const screen = await render(
-          <template>
-            <InformationSectionView
-              @organization={{organization}}
-              @toggleEditMode={{toggleEditMode}}
-              @toggleArchivingConfirmationModal={{toggleArchivingConfirmationModal}}
-            />
-          </template>,
-        );
-
-        // then
-        assert
-          .dom(
-            screen.getByText(
-              t('components.organizations.information-section-view.is-archived-warning', {
-                archivedAt: '22/02/2022',
-                archivedBy: 'Rob Lochon',
-              }),
-            ),
-          )
-          .exists();
-      });
-    });
-
     module('When organization is SCO or SUP', function () {
       const organization = EmberObject.create({ type: 'SCO', isOrganizationSCO: true });
 

--- a/admin/tests/integration/components/organizations/information-section-view-test.gjs
+++ b/admin/tests/integration/components/organizations/information-section-view-test.gjs
@@ -114,6 +114,7 @@ module('Integration | Component | organizations/information-section-view', funct
         .dom(screen.getByText(t('components.organizations.information-section-view.sso')).nextElementSibling)
         .hasText('super-sso');
     });
+
     test('it renders GAR identity provider correctly', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');
@@ -315,7 +316,7 @@ module('Integration | Component | organizations/information-section-view', funct
       assert
         .dom(
           screen.getByRole('button', {
-            name: t('components.organizations.information-section-view.archive-organization'),
+            name: t('components.organizations.information-section-view.archive-organization.action'),
           }),
         )
         .exists();
@@ -844,7 +845,7 @@ module('Integration | Component | organizations/information-section-view', funct
       assert
         .dom(
           screen.queryByRole('button', {
-            name: t('components.organizations.information-section-view.archive-organization'),
+            name: t('components.organizations.information-section-view.archive-organization.action'),
           }),
         )
         .doesNotExist();

--- a/admin/tests/unit/controllers/authenticated/organizations/get/details-test.js
+++ b/admin/tests/unit/controllers/authenticated/organizations/get/details-test.js
@@ -3,9 +3,9 @@ import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
-import setupIntl from '../../../../helpers/setup-intl';
+import setupIntl from '../../../../../helpers/setup-intl';
 
-module('Unit | Controller | authenticated/organizations/get', function (hooks) {
+module('Unit | Controller | authenticated/organizations/get/details', function (hooks) {
   setupTest(hooks);
   setupIntl(hooks);
 
@@ -13,7 +13,7 @@ module('Unit | Controller | authenticated/organizations/get', function (hooks) {
     module('when the size of the payload is lower than 2.5 Mo limit', function () {
       test('displays a success notification', async function (assert) {
         // Given
-        const controller = this.owner.lookup('controller:authenticated.organizations.get');
+        const controller = this.owner.lookup('controller:authenticated.organizations.get.details');
         controller.router = { transitionTo: sinon.stub() };
         controller.model = {
           id: 3,
@@ -40,7 +40,7 @@ module('Unit | Controller | authenticated/organizations/get', function (hooks) {
     module('when the size of the payload is greater than 2.5 Mo limit', function () {
       test('displays an error notification', async function (assert) {
         // Given
-        const controller = this.owner.lookup('controller:authenticated.organizations.get');
+        const controller = this.owner.lookup('controller:authenticated.organizations.get.details');
         controller.model = {
           id: 3,
           save: sinon.stub(),
@@ -70,7 +70,7 @@ module('Unit | Controller | authenticated/organizations/get', function (hooks) {
   module('#archiveOrganization', function () {
     test('it should update organization and redirect to get route', async function (assert) {
       // given
-      const controller = this.owner.lookup('controller:authenticated.organizations.get');
+      const controller = this.owner.lookup('controller:authenticated.organizations.get.details');
       controller.router = { transitionTo: sinon.stub() };
       controller.model = {
         id: 3,

--- a/admin/tests/unit/controllers/authenticated/organizations/get/details-test.js
+++ b/admin/tests/unit/controllers/authenticated/organizations/get/details-test.js
@@ -31,7 +31,7 @@ module('Unit | Controller | authenticated/organizations/get/details', function (
         // Then
         sinon.assert.calledOnce(controller.model.save);
         sinon.assert.calledWith(controller.pixToast.sendSuccessNotification, {
-          message: "L'organisation a bien été modifiée.",
+          message: t('components.organizations.information-section-view.update.notifications.success'),
         });
         assert.ok(true);
       });

--- a/admin/tests/unit/routes/authenticated/organizations/invitations-test.js
+++ b/admin/tests/unit/routes/authenticated/organizations/invitations-test.js
@@ -12,7 +12,7 @@ module('Unit | Route | authenticated/organizations/get/invitations', function (h
   });
 
   module('#beforeModel', function () {
-    test('it should transition to target-profiles route when organization is archived', async function (assert) {
+    test('it should transition to details route when organization is archived', async function (assert) {
       // given
       const organization = EmberObject.create({ isArchived: true });
       const route = this.owner.lookup('route:authenticated/organizations/get/invitations');
@@ -23,7 +23,7 @@ module('Unit | Route | authenticated/organizations/get/invitations', function (h
       await route.beforeModel();
 
       // then
-      assert.ok(route.router.replaceWith.calledWith('authenticated.organizations.get.target-profiles'));
+      assert.ok(route.router.replaceWith.calledWith('authenticated.organizations.get.details'));
     });
   });
 });

--- a/admin/tests/unit/routes/authenticated/organizations/team-test.js
+++ b/admin/tests/unit/routes/authenticated/organizations/team-test.js
@@ -12,7 +12,7 @@ module('Unit | Route | authenticated/organizations/get/team', function (hooks) {
   });
 
   module('#beforeModel', function () {
-    test('it should transition to target-profiles route when organization is archived', async function (assert) {
+    test('it should transition to details route when organization is archived', async function (assert) {
       // given
       const organization = EmberObject.create({ isArchived: true });
       const route = this.owner.lookup('route:authenticated/organizations/get/team');
@@ -23,7 +23,7 @@ module('Unit | Route | authenticated/organizations/get/team', function (hooks) {
       await route.beforeModel();
 
       // then
-      assert.ok(route.router.replaceWith.calledWith('authenticated.organizations.get.target-profiles'));
+      assert.ok(route.router.replaceWith.calledWith('authenticated.organizations.get.details'));
     });
   });
 });

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -1286,6 +1286,7 @@
         "aria-label": "Organization section navigation",
         "campaigns": "Campaigns",
         "children": "Children organisations",
+        "details": "Details",
         "invitations": "Invitations",
         "places": "Places",
         "tags": "Tags",

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -742,10 +742,27 @@
         },
         "required-fields-error": "Please fill in all required fields."
       },
+      "head-information": {
+        "child-organization": "Organisation fille de",
+        "parent-organization": "Organisation mère"
+      },
       "information-section-view": {
         "administration-team": "Administration team",
-        "archive-organization": "Archive organization",
-        "child-organization": "Child organization of",
+        "archive-organization":  {
+          "action": "Archive organisation",
+          "confirmation": "Do you really want to archive this organisation ?",
+          "notifications": {
+            "error": "The organisation could not be archived",
+            "success": "This organisation has successfully been archived"
+          },
+          "warnings": {
+            "active-campaigns": "Ongoing campaigns will be archived",
+            "active-members": "Active members will be deactivated",
+            "linking": "You are no longer allowed to attach new members or send invitations",
+            "pending-invitations": "Pending invitations will be cancelled",
+            "undone": "This action cannot be undone."
+          }
+        },
         "code": "Code",
         "country": {
           "label": "Country (INSEE code)",
@@ -793,11 +810,15 @@
           "title": "Features"
         },
         "is-archived-warning": "Archived at {archivedAt} by {archivedBy}.",
-        "parent-organization": "Parent organization",
         "province-code": "Province code",
         "sco-activation-email": "SCO activation e-mail address",
         "sso": "SSO",
-        "type": "Type"
+        "type": "Type",
+        "update": {
+          "notifications": {
+            "success": "The organisation has successfully been updated"
+          }
+        }
       },
       "invitations": {
         "table": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -744,10 +744,27 @@
         },
         "required-fields-error": "Veuillez remplir tous les champs obligatoires."
       },
+      "head-information": {
+        "child-organization": "Organisation fille de",
+        "parent-organization": "Organisation mère"
+      },
       "information-section-view": {
         "administration-team": "Équipe en charge",
-        "archive-organization": "Archiver l'organisation",
-        "child-organization": "Organisation fille de",
+        "archive-organization": {
+          "action": "Archiver l'organisation",
+          "confirmation": "Êtes-vous sûr de vouloir archiver cette organisation ?",
+          "notifications": {
+            "error": "L'organisation n'a pas pu être archivée.",
+            "success": "Cette organisation a bien été archivée."
+          },
+          "warnings": {
+            "active-campaigns": "Les campagnes actives vont être archivées",
+            "active-members": "Les membres actifs vont être désactivés",
+            "linking": "Le rattachement et l'invitation de nouvelles personnes seront bloqués",
+            "pending-invitations": "Les invitations en attente vont être annulées",
+            "undone": "Cette action est irréversible."
+          }
+        },
         "code": "Code",
         "country": {
           "label": "Pays (code INSEE)",
@@ -795,11 +812,15 @@
           "title": "Fonctionnalités"
         },
         "is-archived-warning": "Archivée le {archivedAt} par {archivedBy}.",
-        "parent-organization": "Organisation mère",
         "province-code": "Département",
         "sco-activation-email": "Adresse e-mail d'activation SCO",
         "sso": "SSO",
-        "type": "Type"
+        "type": "Type",
+        "update": {
+          "notifications": {
+            "success": "L'organisation a bien été modifiée."
+          }
+        }
       },
       "invitations": {
         "table": {
@@ -821,7 +842,7 @@
         "creation": {
           "error-messages": {
             "activation-date": "La date d'activation est obligatoire.",
-            "category":  "La catégorie est obligatoire.",
+            "category": "La catégorie est obligatoire.",
             "count": "Le nombre de places doit être un nombre entier positif.",
             "expiration-date": "La date d'expiration est obligatoire.",
             "reference": "La référence est obligatoire.",

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -1289,6 +1289,7 @@
         "aria-label": "Navigation de la section organisation",
         "campaigns": "Campagnes",
         "children": "Organisations filles",
+        "details": "Détails",
         "invitations": "Invitations",
         "places": "Places",
         "tags": "Tags",


### PR DESCRIPTION
## ❄️ Problème

La page de détails d'une organisation contient les détails d'une orga quel que soit l'onglet sur lequel on se trouve.
Un clic sur un des onglets de navigation en bas de page engendre un scroll en haut de page inutile et les détails de l'orga n'ont pas à être visibles sur chaque onglet

## 🛷 Proposition

On créée un nouvel onglet dédié aux détails de l'organisation

## ☃️ Remarques

Un peu de travail a été fait sur les traductions.
Tout n'est pas parfait ni fini mais c'est un début. 🤷🏻 

## 🧑‍🎄 Pour tester

Se connecter à Pix-Admin
Vérifier qu'un ouvel onglet Admin est dispo sur une page de détails d'une organisation
