### PR TITLE
[BUGFIX] Enlève le crossJoin d'une requête sur les campaignParticipation pour pouvoir utiliser un index

### DIFF
--- a/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-overview-repository.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-overview-repository.js
@@ -19,9 +19,8 @@ const findByUserIdWithFilters = async function ({ userId, states }) {
         .whereIn('combined_courses.organizationId', function () {
           this.select('organizationId').from('organization-learners').where('userId', userId);
         })
-        .crossJoin(knex.raw('jsonb_array_elements("successRequirements") as success_elem'))
-        .whereNotNull('successRequirements')
-        .andWhereRaw("(success_elem->'data'->'campaignId'->>'data')::integer = \"campaigns\".\"id\"");
+        .andWhereRaw(`"quests"."successRequirements" @> jsonb_build_array(jsonb_build_object('data', jsonb_build_object('campaignId', jsonb_build_object('data',"campaignId"))))
+`);
     });
   });
 

--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-overview-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-overview-repository_test.js
@@ -950,6 +950,7 @@ describe('Integration | Repository | Campaign Participation Overview', function 
 
         // then
         expect(campaignParticipationOverviews).to.have.lengthOf(1);
+        expect(campaignParticipationOverviews[0].campaignId).to.be.equal(campaign.id);
       });
     });
 


### PR DESCRIPTION
## ❄️ Problème

Dans findByUserIdWithFilters sur le repositiory campaign-participation-overviews, on ajoute un crossJoin pour pouvoir exclure les participations aux campagnes appartenant à des parcours combinés : 

`.crossJoin(knex.raw('jsonb_array_elements("successRequirements") as success_elem'))
`

Or, sur un crossJoin, on ne peut pas indexer.

## 🛷 Proposition

On enlève le crossJoin en passant par du sql raw pour aller chercher les campaignIds qui nous intéressent.

## ☃️ Remarques

Il faudra ajouter un index pour gagner en performance.

## 🧑‍🎄 Pour tester

Se connecter sur attestation-blank@example.net.
Commencer une participation sur un parcours combiné.

Aller sur la page d'accueil et vérifier qu'une seule carte est présente (celle qui correspond au parcours apprenant).