### PR TITLE
[BUGFIX] Supprimer l'effet de clignotement du feedback sur les QCM (PIX-21365)

### DIFF
--- a/mon-pix/app/components/module/element/qcm.gjs
+++ b/mon-pix/app/components/module/element/qcm.gjs
@@ -50,6 +50,7 @@ export default class ModuleQcm extends ModuleElement {
   }
 
   resetAnswers() {
+    this.currentCorrection = null;
     this.selectedAnswerIds = new Set();
   }
 


### PR DESCRIPTION
## ❄️ Problème
Actuellement, quand on réessaye de répondre à un qcm après avoir échoué, il y a un phénomène bizarre : 

https://github.com/user-attachments/assets/4b9c6783-6d56-408c-97df-7007d5b1bef5



## 🛷 Proposition
Le réparer.

## ☃️ Remarques


## 🧑‍🎄 Pour tester
- aller sur la galerie
- répondre faux au qcm
- clicker sur réessayer
- bien répondre au QCM
- constater qu'il n'y a plus de clignotement
