### PR TITLE
[FEATURE] Ne pas réconcilier un candidat Pix+ sur pix.org (PIX-21361).

### DIFF
--- a/api/src/certification/enrolment/application/http-error-mapper-configuration.js
+++ b/api/src/certification/enrolment/application/http-error-mapper-configuration.js
@@ -6,6 +6,7 @@ import {
   InvalidCertificationCandidate,
   SessionStartedDeletionError,
   UnknownCountryForStudentEnrolmentError,
+  WrongDomainExtensionForPixPlusError,
 } from '../domain/errors.js';
 
 const enrolmentDomainErrorMappingConfiguration = [
@@ -25,6 +26,10 @@ const enrolmentDomainErrorMappingConfiguration = [
   {
     name: InvalidCertificationCandidate.name,
     httpErrorFn: (error) => new HttpErrors.UnprocessableEntityError(error.message),
+  },
+  {
+    name: WrongDomainExtensionForPixPlusError.name,
+    httpErrorFn: (error) => new HttpErrors.ForbiddenError(error.message, error.code),
   },
 ].map((domainErrorMappingConfiguration) => new DomainErrorMappingConfiguration(domainErrorMappingConfiguration));
 

--- a/api/src/certification/enrolment/application/session-controller.js
+++ b/api/src/certification/enrolment/application/session-controller.js
@@ -47,12 +47,16 @@ const createCandidateParticipation = async function (request, h) {
   const lastName = trim(request.payload.data.attributes['last-name']);
   const birthdate = request.payload.data.attributes['birthdate'];
 
+  const origin = request.headers.origin || request.headers.referer;
+  const isFrenchDomainExtension = origin ? new URL(origin).hostname.endsWith('.fr') : false;
+
   const candidate = await services.registerCandidateParticipation({
     userId,
     sessionId,
     firstName,
     lastName,
     birthdate,
+    isFrenchDomainExtension,
     normalizeStringFnc: normalize,
   });
 

--- a/api/src/certification/enrolment/domain/errors.js
+++ b/api/src/certification/enrolment/domain/errors.js
@@ -90,10 +90,18 @@ class InvalidCertificationCandidate extends DomainError {
   }
 }
 
+class WrongDomainExtensionForPixPlusError extends DomainError {
+  constructor(message = 'Pix Plus candidate is not on french domain') {
+    super(message);
+    this.code = 'WRONG_PIX_PLUS_CANDIDATE_DOMAIN';
+  }
+}
+
 export {
   CertificationCandidateForbiddenDeletionError,
   CertificationCandidateNotFoundError,
   InvalidCertificationCandidate,
   SessionStartedDeletionError,
   UnknownCountryForStudentEnrolmentError,
+  WrongDomainExtensionForPixPlusError,
 };

--- a/api/tests/certification/enrolment/acceptance/application/session-route_test.js
+++ b/api/tests/certification/enrolment/acceptance/application/session-route_test.js
@@ -387,7 +387,10 @@ describe('Certification | Enrolment | Acceptance | Routes | session-route', func
               },
             },
           },
-          headers: generateAuthenticatedUserRequestHeaders({ userId }),
+          headers: {
+            ...generateAuthenticatedUserRequestHeaders({ userId }),
+            origin: 'https://app.pix.fr',
+          },
         };
 
         return databaseBuilder.commit();
@@ -511,7 +514,10 @@ describe('Certification | Enrolment | Acceptance | Routes | session-route', func
               },
             },
           },
-          headers: generateAuthenticatedUserRequestHeaders({ userId }),
+          headers: {
+            ...generateAuthenticatedUserRequestHeaders({ userId }),
+            origin: 'https://app.pix.org',
+          },
         };
 
         return databaseBuilder.commit();

--- a/api/tests/certification/enrolment/integration/domain/services/register-candidate-participation-service_test.js
+++ b/api/tests/certification/enrolment/integration/domain/services/register-candidate-participation-service_test.js
@@ -46,6 +46,7 @@ describe('Integration | Application | Service | register-candidate-participation
         firstName: certificationCandidate.firstName,
         lastName: certificationCandidate.lastName,
         birthdate: certificationCandidate.birthdate,
+        isFrenchDomainExtension: true,
         normalizeStringFnc: normalize,
       });
 

--- a/api/tests/certification/enrolment/unit/application/session-controller_test.js
+++ b/api/tests/certification/enrolment/unit/application/session-controller_test.js
@@ -206,6 +206,7 @@ describe('Certification | Enrolment | Unit | Application | Controller | session-
         },
         auth: { credentials: { userId } },
         params: { sessionId },
+        headers: { origin: 'https://app.pix.fr' },
       };
       const candidate = {
         firstName,
@@ -223,6 +224,7 @@ describe('Certification | Enrolment | Unit | Application | Controller | session-
           firstName,
           lastName,
           birthdate,
+          isFrenchDomainExtension: true,
           normalizeStringFnc: normalize,
         })
         .resolves(candidate);

--- a/mon-pix/app/components/certification-joiner.gjs
+++ b/mon-pix/app/components/certification-joiner.gjs
@@ -33,6 +33,10 @@ function _isLanguageNotSupported(error) {
   return error.code === 'LANGUAGE_NOT_SUPPORTED';
 }
 
+function _isWrongDomainForPixPlus(error) {
+  return error.code === 'WRONG_PIX_PLUS_CANDIDATE_DOMAIN';
+}
+
 function _isCenterHasHabilitationToHoldTheSession(error) {
   return error.status === '403' && error.code === 'CENTER_HABILITATION_ERROR';
 }
@@ -284,6 +288,10 @@ export default class CertificationJoiner extends Component {
         this.errorMessage = this.intl.t('pages.certification-joiner.error-messages.session-not-accessible');
       } else if (_isCenterHasHabilitationToHoldTheSession(errorDetails)) {
         this.errorMessage = this.intl.t('pages.certification-joiner.error-messages.missing-center-habilitation');
+      } else if (_isWrongDomainForPixPlus(errorDetails)) {
+        this.errorMessage = this.intl.t('pages.certification-joiner.error-messages.wrong-domain-for-pix-plus', {
+          htmlSafe: true,
+        });
       } else {
         this.errorMessage = this.intl.t('pages.certification-joiner.error-messages.generic.disclaimer');
         this.errorDetailList = [

--- a/mon-pix/tests/integration/components/certification-joiner-test.js
+++ b/mon-pix/tests/integration/components/certification-joiner-test.js
@@ -277,6 +277,31 @@ module('Integration | Component | certification-joiner', function (hooks) {
         assert.ok(screen.getByText(t('pages.certification-joiner.error-messages.missing-center-habilitation')));
       });
     });
+
+    module('when candidate has a complementary subscription and is on wrong domain', function () {
+      test('should display an error message', async function (assert) {
+        // given
+        this.set('onStepChange', sinon.stub());
+        const screen = await render(hbs`<CertificationJoiner @onStepChange={{this.onStepChange}} />`);
+
+        await _fillInputsToJoinSession({ screen, t });
+
+        const store = this.owner.lookup('service:store');
+        const saveStub = sinon.stub();
+        saveStub
+          .withArgs({ adapterOptions: { joinSession: true, sessionId: '123456' } })
+          .throws({ errors: [{ status: '403', code: 'WRONG_PIX_PLUS_CANDIDATE_DOMAIN' }] });
+        const createRecordMock = sinon.mock();
+        createRecordMock.returns({ save: saveStub, deleteRecord: function () {} });
+        store.createRecord = createRecordMock;
+
+        // when
+        await click(screen.getByRole('button', { name: t('pages.certification-joiner.form.actions.submit') }));
+
+        // then
+        assert.ok(screen.getByText("Les certifications Pix+ n'étant disponibles qu'en français", { exact: false }));
+      });
+    });
   });
 
   test('should display hint on session number input', async function (assert) {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -839,7 +839,8 @@
         "wrong-account-sco-link": {
           "label": "How to find the account linked to the school/organisation ?",
           "url": "https://pix.fr/support/enseignement-scolaire/enseignant-ou-personnel-de-direction/que-faire-si-une-eleve-ne-parvient-pas-rejoindre-sa-session-de-certification"
-        }
+        },
+        "wrong-domain-for-pix-plus": "Pix+ certifications are only available in French for now, so they are not available on <b>https://pix.org</b>.<br/>Please log out and log back in via '<a href=\"https://app.pix.fr/connexion\">this link.</a>'"
       },
       "first-title": "Join a session",
       "form": {

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -835,7 +835,8 @@
         "wrong-account-sco-link": {
           "label": "¿Cómo encuentro la cuenta vinculada al establecimiento?",
           "url": "https://pix.fr/support/enseignement-scolaire/enseignant-ou-personnel-de-direction/que-faire-si-une-eleve-ne-parvient-pas-rejoindre-sa-session-de-certification"
-        }
+        },
+        "wrong-domain-for-pix-plus": "Las certificaciones Pix+ solo están disponibles en francés por el momento, por lo que no están disponibles en <b>https://pix.org</b>.<br/>Por favor, cierra sesión y vuelve a conectarte a través de '<a href=\"https://app.pix.fr/connexion\">este enlace.</a>'"
       },
       "first-title": "Unirse a una sesión",
       "form": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -840,7 +840,8 @@
         "wrong-account-sco-link": {
           "label": "Comment trouver le compte lié à l'établissement ?",
           "url": "https://pix.fr/support/enseignement-scolaire/enseignant-ou-personnel-de-direction/que-faire-si-une-eleve-ne-parvient-pas-rejoindre-sa-session-de-certification"
-        }
+        },
+        "wrong-domain-for-pix-plus": "Les certifications Pix+ n'étant disponibles qu'en français pour le moment, elles ne sont pas disponibles sur https://pix.org.<br/>Merci de vous déconnecter puis de vous reconnecter via '<a href=\"https://app.pix.fr/connexion\">ce lien.</a>'"
       },
       "first-title": "Rejoindre une session",
       "form": {

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -839,7 +839,8 @@
         "wrong-account-sco-link": {
           "label": "Hoe vind ik de rekening die aan de vestiging is gekoppeld?",
           "url": "https://pix.fr/support/enseignement-scolaire/enseignant-ou-personnel-de-direction/que-faire-si-une-eleve-ne-parvient-pas-rejoindre-sa-session-de-certification"
-        }
+        },
+        "wrong-domain-for-pix-plus": "Pix+ certificeringen zijn momenteel alleen beschikbaar in het Frans, dus ze zijn niet beschikbaar op <b>https://pix.org</b>.<br/>Gelieve uit te loggen en opnieuw in te loggen via '<a href=\"https://app.pix.fr/connexion\">deze link.</a>'"
       },
       "first-title": "Deelnemen aan een sessie",
       "form": {


### PR DESCRIPTION
## ❄️ Problème

Si un candidat tente de rejoindre une certification Pix+ en se connectant via [pix.org](https://app.pix.org/connexion), aucun blocage ne se présente à lui. En revanche, la certification Pix+ se termine avant qu’il ou elle n’ait atteint les 32 questions de l'épreuve. Le candidat est alors dans l’incapacité de terminer sa certification Pix+.

## 🛷 Proposition

Afficher une erreur spécifique si un candidat à une certif Pix+ tente de se réconcilier depuis .org

## 🧑‍🎄 Pour tester

- Créer une session Pix+
- Ajouter un candidat
- Aller sur [PixApp .org](https://app-pr14969.review.pix.org/)
- Tenter de se réconcilier avec ce candidat
- ✅ L'erreur spécifique devrait s'afficher
- Sur [PixApp .fr](https://app-pr14969.review.pix.fr/), la réconciliation devrait se faire sans encombre
