### PR TITLE
[FEATURE] Changer des textes et labels de bouton sur la mire de connexion Pix Orga (PIX-20585).

### DIFF
--- a/orga/app/components/authentication/login-form.gjs
+++ b/orga/app/components/authentication/login-form.gjs
@@ -78,6 +78,10 @@ export default class LoginForm extends Component {
     return url.toString();
   }
 
+  get connectionButtonLabel() {
+    return this.args.submitFormButtonLabel || this.intl.t('pages.login-form.login');
+  }
+
   @action
   updatePassword(event) {
     this.password = event.target.value?.trim();
@@ -140,7 +144,7 @@ export default class LoginForm extends Component {
       </div>
 
       <PixButton @type="submit" @isLoading={{this.isLoading}}>
-        {{t "pages.login-form.login"}}
+        {{this.connectionButtonLabel}}
       </PixButton>
     </form>
   </template>

--- a/orga/app/styles/pages/authentication/login.scss
+++ b/orga/app/styles/pages/authentication/login.scss
@@ -14,9 +14,5 @@
     &__question {
       font-weight: var(--pix-font-bold);
     }
-
-    &__message {
-      color: var(--pix-neutral-500);
-    }
   }
 }

--- a/orga/app/templates/authentication/login.gjs
+++ b/orga/app/templates/authentication/login.gjs
@@ -30,9 +30,6 @@ import AuthenticationLayout from 'pix-orga/components/authentication-layout/inde
           <LinkTo class="link link--black link--underlined" @route="join-request">
             {{t "pages.login-form.active-or-retrieve"}}
           </LinkTo>
-          <div class="authentication-login__recover-access__message">
-            ({{t "pages.login-form.only-for-admin"}})
-          </div>
         </div>
       {{/if}}
 

--- a/orga/app/templates/authentication/oidc/login.gjs
+++ b/orga/app/templates/authentication/oidc/login.gjs
@@ -33,7 +33,10 @@ import InvitationBanner from 'pix-orga/components/banner/invitation-banner';
         <h3 class="pix-body-l">{{t "pages.oidc.login.sub-title"}}</h3>
       </div>
 
-      <LoginForm @onSubmit={{@controller.redirectToAssociationConfirmation}} />
+      <LoginForm
+        @onSubmit={{@controller.redirectToAssociationConfirmation}}
+        @submitFormButtonLabel={{t "pages.login-form.associate-account"}}
+      />
 
       {{#if @controller.currentInvitation}}
         <PixButtonLink

--- a/orga/tests/acceptance/oidc/oidc-authentication-flow-test.js
+++ b/orga/tests/acceptance/oidc/oidc-authentication-flow-test.js
@@ -119,7 +119,7 @@ module('Acceptance | OIDC | authentication flow', function (hooks) {
             // when
             await fillIn(await screen.getByRole('textbox', { name: t('pages.login-form.email.label') }), user.email);
             await fillIn(await screen.getByLabelText(t('pages.login-form.password')), 'pix123');
-            const loginButton = screen.getByRole('button', { name: t('pages.login-form.login') });
+            const loginButton = screen.getByRole('button', { name: t('pages.login-form.associate-account') });
             await click(loginButton);
 
             // then
@@ -173,7 +173,7 @@ module('Acceptance | OIDC | authentication flow', function (hooks) {
             );
             await fillIn(screen.getByLabelText(t('pages.login-form.password')), 'incorrect-password');
 
-            await click(screen.getByRole('button', { name: t('pages.login-form.login') }));
+            await click(screen.getByRole('button', { name: t('pages.login-form.associate-account') }));
             // eslint-disable-next-line ember/no-settled-after-test-helper
             await settled();
 
@@ -197,7 +197,7 @@ module('Acceptance | OIDC | authentication flow', function (hooks) {
             );
             await fillIn(screen.getByLabelText(t('pages.login-form.password')), 'incorrect-password');
 
-            await click(screen.getByRole('button', { name: t('pages.login-form.login') }));
+            await click(screen.getByRole('button', { name: t('pages.login-form.associate-account') }));
             // eslint-disable-next-line ember/no-settled-after-test-helper
             await settled();
 
@@ -216,7 +216,7 @@ module('Acceptance | OIDC | authentication flow', function (hooks) {
               'harry@cover.com',
             );
             await fillIn(await screen.getByLabelText(t('pages.login-form.password')), 'pix123');
-            await click(await screen.getByRole('button', { name: 'Je me connecte' }));
+            await click(await screen.getByRole('button', { name: t('pages.login-form.associate-account') }));
           }
 
           module('when the user has already accepted Pix Orga terms of service', function () {

--- a/orga/tests/integration/components/authentication/login-form-test.gjs
+++ b/orga/tests/integration/components/authentication/login-form-test.gjs
@@ -51,4 +51,26 @@ module('Integration | Component | LoginForm', function (hooks) {
       assert.dom(screen.getByText('This is an error')).exists();
     });
   });
+
+  module('when the login form is used for an account association', function () {
+    test('it displays associate account button label', async function (assert) {
+      // given & when
+      const screen = await render(
+        <template><LoginForm @submitFormButtonLabel={{t "pages.login-form.associate-account"}} /></template>,
+      );
+
+      // then
+      assert.dom(screen.getByRole('button', { name: t('pages.login-form.associate-account') })).exists();
+    });
+  });
+
+  module('when the login form is not used for an account association', function () {
+    test('it displays associate account button label', async function (assert) {
+      // given & when
+      const screen = await render(<template><LoginForm /></template>);
+
+      // then
+      assert.dom(screen.getByRole('button', { name: t('pages.login-form.login') })).exists();
+    });
+  });
 });

--- a/orga/tests/integration/templates/authentication/login-test.gjs
+++ b/orga/tests/integration/templates/authentication/login-test.gjs
@@ -26,7 +26,6 @@ module('Integration | Template | Authentication | login', function (hooks) {
       // then
       assert.dom('.authentication-login-form__recover-access__question').doesNotExist();
       assert.dom('.authentication-login-form__recover-access .link--underlined').doesNotExist();
-      assert.dom('.authentication-login-form__recover-access__message').doesNotExist();
     });
   });
 
@@ -42,7 +41,6 @@ module('Integration | Template | Authentication | login', function (hooks) {
       // then
       assert.dom('.authentication-login__recover-access__question').exists();
       assert.dom('.authentication-login__recover-access .link--underlined').exists();
-      assert.dom('.authentication-login__recover-access__message').exists();
     });
   });
 });

--- a/orga/tests/integration/templates/authentication/oidc/login-test.gjs
+++ b/orga/tests/integration/templates/authentication/oidc/login-test.gjs
@@ -52,7 +52,7 @@ module('Integration | Template | Authentication | OIDC | login', function (hooks
         .exists();
       assert.dom(screen.getByRole('textbox', { name: t('pages.login-form.email.label') })).exists();
       assert.dom(screen.getByLabelText(t('pages.login-form.password'))).exists();
-      assert.dom(screen.getByRole('button', { name: t('pages.login-form.login') })).exists();
+      assert.dom(screen.getByRole('button', { name: t('pages.login-form.associate-account') })).exists();
       assert.dom(screen.getByRole('link', { name: t('pages.oidc.login.signup-button') })).exists();
     });
   });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -1168,7 +1168,6 @@
       "invitation-not-found": "This invitation was not found. Please contact the administrator of your Pix Orga space.",
       "invitation-was-cancelled": "This invitation is no longer valid. Please contact the administrator of your Pix Orga space.",
       "login": "Log in",
-      "only-for-admin": "only for school administrations",
       "password": "Password"
     },
     "login-or-register": {

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -1149,6 +1149,7 @@
     "login-form": {
       "active-or-retrieve": "Activate or become the administrator of your school's Pix Orga space",
       "admin-role-question": "Are you a headteacher?",
+      "associate-account": "Associate my account",
       "email": {
         "label": "Email address",
         "placeholder": "e.g. john.smith@email.com"

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -1137,6 +1137,7 @@
     "login-form": {
       "active-or-retrieve": "Activez ou devenez l'administrateur de l'espace Pix Orga de votre établissement scolaire",
       "admin-role-question": "Vous êtes personnel de direction ou directeur d'école ?",
+      "associate-account": "Associer mon compte",
       "email": {
         "label": "Adresse e-mail",
         "placeholder": "ex: jean.dupont@email.com"

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -1156,7 +1156,6 @@
       "invitation-not-found": "Cette invitation n'a pas été trouvée. Contactez l’administrateur de votre espace Pix Orga.",
       "invitation-was-cancelled": "Cette invitation n’est plus valide. Contactez l’administrateur de votre espace Pix Orga.",
       "login": "Je me connecte",
-      "only-for-admin": "Réservé aux personnels de direction des établissements scolaires publics et privés sous contrat.",
       "password": "Mot de passe"
     },
     "login-or-register": {

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -1131,6 +1131,7 @@
     "login-form": {
       "active-or-retrieve": "Activeer of word beheerder van de Pix Orga-ruimte van uw school.",
       "admin-role-question": "Bent u een schoolhoofd?",
+      "associate-account": "Mijn account koppelen",
       "email": {
         "label": "E-mailadres",
         "placeholder": "b.v. jan.jansen@email.com"

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -1150,7 +1150,6 @@
       "invitation-not-found": "Deze uitnodiging is niet gevonden. Neem contact op met de beheerder van je Pix Orga-ruimte.",
       "invitation-was-cancelled": "Deze uitnodiging is niet langer geldig. Neem contact op met de beheerder van je Pix Orga-ruimte.",
       "login": "Ik log in",
-      "only-for-admin": "Gereserveerd voor directiepersoneel van openbare en privéscholen onder contract.",
       "password": "Wachtwoord"
     },
     "login-or-register": {


### PR DESCRIPTION
## ❄️ Problème
Suite à la mise en prod de la connexion SSO sur Pix Orga, on réalise des ajustements sur les écrans.

## 🛷 Proposition
Sur la mire de connexion, supprimer la phrase :
"Réservé aux personnels de direction des établissements scolaires publics et privés sous contrat"

À la place de “Je me connecte” mettre “J’associe mon compte” sur la page d'association de compte

## 🧑‍🎄 Pour tester
- Lancer Pix Orga `.fr` et constater sur la page de connexion l'absence de la mention "Réservé aux personnels de direction des établissements scolaires publics et privés sous contrat"
- Se connecter via ProConnect et constater que la page d'association de compte au retour du fournisseur d'accès affiche le bouton "Associer mon compte" au lieu de "Me connecter"
