### PR TITLE
[TECH] Assurer l'usage d'une seule connexion à la base de données lors de l'usage de la route POST /api/answers.

### DIFF
--- a/api/db/knexfile.js
+++ b/api/db/knexfile.js
@@ -8,6 +8,10 @@ const baseConfiguration = {
   migrationsDirectory: './migrations/',
   seedsDirectory: './seeds/',
   databaseUrl: process.env.DATABASE_URL,
+  pool: {
+    min: parseInt(process.env.DATABASE_CONNECTION_POOL_MIN_SIZE, 10),
+    max: parseInt(process.env.DATABASE_CONNECTION_POOL_MAX_SIZE, 10),
+  },
 };
 
 export default {
@@ -18,11 +22,5 @@ export default {
     databaseUrl: process.env.TEST_DATABASE_URL,
   }),
 
-  production: buildPostgresEnvironment({
-    ...baseConfiguration,
-    pool: {
-      min: parseInt(process.env.DATABASE_CONNECTION_POOL_MIN_SIZE, 10),
-      max: parseInt(process.env.DATABASE_CONNECTION_POOL_MAX_SIZE, 10),
-    },
-  }),
+  production: buildPostgresEnvironment(baseConfiguration),
 };

--- a/api/src/certification/evaluation/infrastructure/repositories/certification-candidate-repository.js
+++ b/api/src/certification/evaluation/infrastructure/repositories/certification-candidate-repository.js
@@ -1,5 +1,5 @@
 // @ts-check
-import { knex } from '../../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { CertificationCandidateNotFoundError } from '../../../../shared/domain/errors.js';
 import { Candidate } from '../../../evaluation/domain/models/Candidate.js';
 import { ComplementaryCertificationKeys } from '../../../shared/domain/models/ComplementaryCertificationKeys.js';
@@ -20,7 +20,9 @@ import { SCOPES } from '../../../shared/domain/models/Scopes.js';
  * @throws {CertificationCandidateNotFoundError}
  */
 export const findByAssessmentId = async function ({ assessmentId }) {
-  const result = await knex('certification-candidates')
+  const knexConn = DomainTransaction.getConnection();
+
+  const result = await knexConn('certification-candidates')
     .select('certification-candidates.accessibilityAdjustmentNeeded', 'certification-candidates.reconciledAt', {
       complementaryCertificationKey: 'complementary-certifications.key',
     })

--- a/api/src/certification/shared/infrastructure/repositories/certification-challenge-live-alert-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/certification-challenge-live-alert-repository.js
@@ -70,7 +70,8 @@ const getOngoingByChallengeIdAndAssessmentId = async ({ challengeId, assessmentI
 };
 
 const getOngoingOrValidatedByChallengeIdAndAssessmentId = async ({ challengeId, assessmentId }) => {
-  const certificationChallengeLiveAlertDto = await knex('certification-challenge-live-alerts')
+  const knexConn = DomainTransaction.getConnection();
+  const certificationChallengeLiveAlertDto = await knexConn('certification-challenge-live-alerts')
     .where({
       'certification-challenge-live-alerts.challengeId': challengeId,
       'certification-challenge-live-alerts.assessmentId': assessmentId,

--- a/api/src/shared/infrastructure/repositories/knowledge-element-repository.js
+++ b/api/src/shared/infrastructure/repositories/knowledge-element-repository.js
@@ -1,6 +1,5 @@
 import _ from 'lodash';
 
-import { knex } from '../../../../db/knex-database-connection.js';
 import { KnowledgeElementCollection } from '../../../prescription/shared/domain/models/KnowledgeElementCollection.js';
 import { DomainTransaction } from '../../domain/DomainTransaction.js';
 import { KnowledgeElement } from '../../domain/models/KnowledgeElement.js';
@@ -45,7 +44,7 @@ const batchSave = async function ({ knowledgeElements }) {
   const knexConn = DomainTransaction.getConnection();
   // eslint-disable-next-line no-unused-vars
   const knowledgeElementsToSave = knowledgeElements.map(({ id, createdAt, ...ke }) => ke);
-  const savedKnowledgeElements = await knex
+  const savedKnowledgeElements = await knexConn
     .batchInsert(tableName, knowledgeElementsToSave)
     .transacting(knexConn.isTransaction ? knexConn : null)
     .returning('*');


### PR DESCRIPTION
## ❄️ Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

Suite aux récents soucis de production, nous avons constaté un usage excessif des connexions à la base de données.
Cela se traduit par un pool de connexions saturés entrainant des blocages des transactions et requêtes ouvertes.

## 🛷 Proposition

Dans cette PR, on se concentre sur la route `POST /api/answers` qui est une des routes les plus utilisées de l'application.
Pour cela, on permet de configurer le pool de connexions sur tous les environnements (notamment en test).
Ensuite on lance les tests d'acceptance et intégration liées à la route `POST /api/answers` en limitant le maximum de connections à 1.
On constate alors des tests en timeout, montrant les repositories / usecases exécutant des requêtes hors transactions.

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## ☃️ Remarques

On devra faire ce travail sur toutes les routes.

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🧑‍🎄 Pour tester

CI verte et vérifier le bon fonctionnement de l'application lors de la réponse à des questions.

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
