### PR TITLE
[FEATURE] Enregistrer un passage-event quand on clique sur Réessayer ou Réinitialiser (PIX-21197)

### DIFF
--- a/api/src/devcomp/domain/factories/passage-event-factory.js
+++ b/api/src/devcomp/domain/factories/passage-event-factory.js
@@ -27,7 +27,7 @@ import {
 } from '../models/passage-events/flashcard-events.js';
 import { GrainContinuedEvent, GrainSkippedEvent } from '../models/passage-events/grain-events.js';
 import { PassageStartedEvent, PassageTerminatedEvent } from '../models/passage-events/passage-events.js';
-import { QABCardAnsweredEvent, QABCardRetriedEvent } from '../models/passage-events/qab-events.js';
+import { QABCardAnsweredEvent, QABRetriedEvent } from '../models/passage-events/qab-events.js';
 import { StepperNextStepEvent } from '../models/passage-events/stepper-events.js';
 
 class PassageEventFactory {
@@ -69,8 +69,8 @@ class PassageEventFactory {
         return new PassageTerminatedEvent(eventData);
       case 'QAB_CARD_ANSWERED':
         return new QABCardAnsweredEvent(eventData);
-      case 'QAB_CARD_RETRIED':
-        return new QABCardRetriedEvent(eventData);
+      case 'QAB_RETRIED':
+        return new QABRetriedEvent(eventData);
       case 'QROCM_ANSWERED':
         return new QROCMAnsweredEvent(eventData);
       case 'QCM_ANSWERED':

--- a/api/src/devcomp/domain/factories/passage-event-factory.js
+++ b/api/src/devcomp/domain/factories/passage-event-factory.js
@@ -5,6 +5,7 @@ import {
   QCUAnsweredEvent,
   QCUDeclarativeAnsweredEvent,
   QCUDiscoveryAnsweredEvent,
+  QCURetriedEvent,
   QROCMAnsweredEvent,
 } from '../models/passage-events/answerable-element-events.js';
 import {
@@ -77,6 +78,8 @@ class PassageEventFactory {
         return new QCMAnsweredEvent(eventData);
       case 'QCU_ANSWERED':
         return new QCUAnsweredEvent(eventData);
+      case 'QCU_RETRIED':
+        return new QCURetriedEvent(eventData);
       case 'QCU_DECLARATIVE_ANSWERED':
         return new QCUDeclarativeAnsweredEvent(eventData);
       case 'QCU_DISCOVERY_ANSWERED':

--- a/api/src/devcomp/domain/factories/passage-event-factory.js
+++ b/api/src/devcomp/domain/factories/passage-event-factory.js
@@ -1,5 +1,6 @@
 import { DomainError } from '../../../shared/domain/errors.js';
 import {
+  CustomDraftRetriedEvent,
   CustomRetriedEvent,
   EmbedAnsweredEvent,
   EmbedRetriedEvent,
@@ -42,6 +43,8 @@ class PassageEventFactory {
         return new AudioTranscriptionOpenedEvent(eventData);
       case 'AUDIO_PLAYED':
         return new AudioPlayedEvent(eventData);
+      case 'CUSTOM_DRAFT_RETRIED':
+        return new CustomDraftRetriedEvent(eventData);
       case 'CUSTOM_RETRIED':
         return new CustomRetriedEvent(eventData);
       case 'EMBED_ANSWERED':

--- a/api/src/devcomp/domain/factories/passage-event-factory.js
+++ b/api/src/devcomp/domain/factories/passage-event-factory.js
@@ -2,6 +2,7 @@ import { DomainError } from '../../../shared/domain/errors.js';
 import {
   EmbedAnsweredEvent,
   QCMAnsweredEvent,
+  QCMRetriedEvent,
   QCUAnsweredEvent,
   QCUDeclarativeAnsweredEvent,
   QCUDiscoveryAnsweredEvent,
@@ -76,6 +77,8 @@ class PassageEventFactory {
         return new QROCMAnsweredEvent(eventData);
       case 'QCM_ANSWERED':
         return new QCMAnsweredEvent(eventData);
+      case 'QCM_RETRIED':
+        return new QCMRetriedEvent(eventData);
       case 'QCU_ANSWERED':
         return new QCUAnsweredEvent(eventData);
       case 'QCU_RETRIED':

--- a/api/src/devcomp/domain/factories/passage-event-factory.js
+++ b/api/src/devcomp/domain/factories/passage-event-factory.js
@@ -1,6 +1,7 @@
 import { DomainError } from '../../../shared/domain/errors.js';
 import {
   EmbedAnsweredEvent,
+  EmbedRetriedEvent,
   QCMAnsweredEvent,
   QCMRetriedEvent,
   QCUAnsweredEvent,
@@ -42,6 +43,8 @@ class PassageEventFactory {
         return new AudioPlayedEvent(eventData);
       case 'EMBED_ANSWERED':
         return new EmbedAnsweredEvent(eventData);
+      case 'EMBED_RETRIED':
+        return new EmbedRetriedEvent(eventData);
       case 'EXPAND_OPENED':
         return new ExpandOpenedEvent(eventData);
       case 'EXPAND_CLOSED':

--- a/api/src/devcomp/domain/factories/passage-event-factory.js
+++ b/api/src/devcomp/domain/factories/passage-event-factory.js
@@ -1,5 +1,6 @@
 import { DomainError } from '../../../shared/domain/errors.js';
 import {
+  CustomRetriedEvent,
   EmbedAnsweredEvent,
   EmbedRetriedEvent,
   QCMAnsweredEvent,
@@ -41,6 +42,8 @@ class PassageEventFactory {
         return new AudioTranscriptionOpenedEvent(eventData);
       case 'AUDIO_PLAYED':
         return new AudioPlayedEvent(eventData);
+      case 'CUSTOM_RETRIED':
+        return new CustomRetriedEvent(eventData);
       case 'EMBED_ANSWERED':
         return new EmbedAnsweredEvent(eventData);
       case 'EMBED_RETRIED':

--- a/api/src/devcomp/domain/factories/passage-event-factory.js
+++ b/api/src/devcomp/domain/factories/passage-event-factory.js
@@ -8,6 +8,7 @@ import {
   QCUDiscoveryAnsweredEvent,
   QCURetriedEvent,
   QROCMAnsweredEvent,
+  QROCMRetriedEvent,
 } from '../models/passage-events/answerable-element-events.js';
 import {
   AudioPlayedEvent,
@@ -87,6 +88,8 @@ class PassageEventFactory {
         return new QCUDeclarativeAnsweredEvent(eventData);
       case 'QCU_DISCOVERY_ANSWERED':
         return new QCUDiscoveryAnsweredEvent(eventData);
+      case 'QROCM_RETRIED':
+        return new QROCMRetriedEvent(eventData);
       case 'SHORT_VIDEO_TRANSCRIPTION_OPENED':
         return new ShortVideoTranscriptionOpenedEvent(eventData);
       case 'VIDEO_TRANSCRIPTION_OPENED':

--- a/api/src/devcomp/domain/models/passage-events/answerable-element-events.js
+++ b/api/src/devcomp/domain/models/passage-events/answerable-element-events.js
@@ -50,6 +50,20 @@ class QCUAnsweredEvent extends PassageEventWithElementAnswered {
   }
 }
 
+class QCURetriedEvent extends PassageEventWithElement {
+  constructor({ id, occurredAt, createdAt, passageId, sequenceNumber, elementId }) {
+    super({
+      type: 'QCU_RETRIED',
+      id,
+      occurredAt,
+      createdAt,
+      passageId,
+      sequenceNumber,
+      elementId,
+    });
+  }
+}
+
 class QCUDeclarativeAnsweredEvent extends PassageEventWithElement {
   constructor({ id, occurredAt, createdAt, passageId, sequenceNumber, elementId, answer }) {
     super({
@@ -105,5 +119,6 @@ export {
   QCUAnsweredEvent,
   QCUDeclarativeAnsweredEvent,
   QCUDiscoveryAnsweredEvent,
+  QCURetriedEvent,
   QROCMAnsweredEvent,
 };

--- a/api/src/devcomp/domain/models/passage-events/answerable-element-events.js
+++ b/api/src/devcomp/domain/models/passage-events/answerable-element-events.js
@@ -2,6 +2,20 @@ import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asser
 import { PassageEventWithElement } from './PassageEventWithElement.js';
 import { PassageEventWithElementAnswered } from './PassageEventWithElementAnswered.js';
 
+class CustomDraftRetriedEvent extends PassageEventWithElement {
+  constructor({ id, occurredAt, createdAt, passageId, sequenceNumber, elementId }) {
+    super({
+      type: 'CUSTOM_DRAFT_RETRIED',
+      id,
+      occurredAt,
+      createdAt,
+      passageId,
+      sequenceNumber,
+      elementId,
+    });
+  }
+}
+
 class CustomRetriedEvent extends PassageEventWithElement {
   constructor({ id, occurredAt, createdAt, passageId, sequenceNumber, elementId }) {
     super({
@@ -170,6 +184,7 @@ class QROCMRetriedEvent extends PassageEventWithElement {
 }
 
 export {
+  CustomDraftRetriedEvent,
   CustomRetriedEvent,
   EmbedAnsweredEvent,
   EmbedRetriedEvent,

--- a/api/src/devcomp/domain/models/passage-events/answerable-element-events.js
+++ b/api/src/devcomp/domain/models/passage-events/answerable-element-events.js
@@ -18,6 +18,20 @@ class EmbedAnsweredEvent extends PassageEventWithElementAnswered {
   }
 }
 
+class EmbedRetriedEvent extends PassageEventWithElement {
+  constructor({ id, occurredAt, createdAt, passageId, sequenceNumber, elementId }) {
+    super({
+      type: 'EMBED_RETRIED',
+      id,
+      occurredAt,
+      createdAt,
+      passageId,
+      sequenceNumber,
+      elementId,
+    });
+  }
+}
+
 class QCMAnsweredEvent extends PassageEventWithElementAnswered {
   constructor({ id, occurredAt, createdAt, passageId, sequenceNumber, elementId, answer, status }) {
     super({
@@ -143,6 +157,7 @@ class QROCMRetriedEvent extends PassageEventWithElement {
 
 export {
   EmbedAnsweredEvent,
+  EmbedRetriedEvent,
   QCMAnsweredEvent,
   QCMRetriedEvent,
   QCUAnsweredEvent,

--- a/api/src/devcomp/domain/models/passage-events/answerable-element-events.js
+++ b/api/src/devcomp/domain/models/passage-events/answerable-element-events.js
@@ -127,6 +127,20 @@ class QROCMAnsweredEvent extends PassageEventWithElementAnswered {
   }
 }
 
+class QROCMRetriedEvent extends PassageEventWithElement {
+  constructor({ id, occurredAt, createdAt, passageId, sequenceNumber, elementId }) {
+    super({
+      type: 'QROCM_RETRIED',
+      id,
+      occurredAt,
+      createdAt,
+      passageId,
+      sequenceNumber,
+      elementId,
+    });
+  }
+}
+
 export {
   EmbedAnsweredEvent,
   QCMAnsweredEvent,
@@ -136,4 +150,5 @@ export {
   QCUDiscoveryAnsweredEvent,
   QCURetriedEvent,
   QROCMAnsweredEvent,
+  QROCMRetriedEvent,
 };

--- a/api/src/devcomp/domain/models/passage-events/answerable-element-events.js
+++ b/api/src/devcomp/domain/models/passage-events/answerable-element-events.js
@@ -34,6 +34,20 @@ class QCMAnsweredEvent extends PassageEventWithElementAnswered {
   }
 }
 
+class QCMRetriedEvent extends PassageEventWithElement {
+  constructor({ id, occurredAt, createdAt, passageId, sequenceNumber, elementId }) {
+    super({
+      type: 'QCM_RETRIED',
+      id,
+      occurredAt,
+      createdAt,
+      passageId,
+      sequenceNumber,
+      elementId,
+    });
+  }
+}
+
 class QCUAnsweredEvent extends PassageEventWithElementAnswered {
   constructor({ id, occurredAt, createdAt, passageId, sequenceNumber, elementId, answer, status }) {
     super({
@@ -116,6 +130,7 @@ class QROCMAnsweredEvent extends PassageEventWithElementAnswered {
 export {
   EmbedAnsweredEvent,
   QCMAnsweredEvent,
+  QCMRetriedEvent,
   QCUAnsweredEvent,
   QCUDeclarativeAnsweredEvent,
   QCUDiscoveryAnsweredEvent,

--- a/api/src/devcomp/domain/models/passage-events/answerable-element-events.js
+++ b/api/src/devcomp/domain/models/passage-events/answerable-element-events.js
@@ -2,6 +2,20 @@ import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asser
 import { PassageEventWithElement } from './PassageEventWithElement.js';
 import { PassageEventWithElementAnswered } from './PassageEventWithElementAnswered.js';
 
+class CustomRetriedEvent extends PassageEventWithElement {
+  constructor({ id, occurredAt, createdAt, passageId, sequenceNumber, elementId }) {
+    super({
+      type: 'CUSTOM_RETRIED',
+      id,
+      occurredAt,
+      createdAt,
+      passageId,
+      sequenceNumber,
+      elementId,
+    });
+  }
+}
+
 class EmbedAnsweredEvent extends PassageEventWithElementAnswered {
   constructor({ id, occurredAt, createdAt, passageId, sequenceNumber, elementId, answer, status }) {
     super({
@@ -156,6 +170,7 @@ class QROCMRetriedEvent extends PassageEventWithElement {
 }
 
 export {
+  CustomRetriedEvent,
   EmbedAnsweredEvent,
   EmbedRetriedEvent,
   QCMAnsweredEvent,

--- a/api/src/devcomp/domain/models/passage-events/qab-events.js
+++ b/api/src/devcomp/domain/models/passage-events/qab-events.js
@@ -21,10 +21,10 @@ class QABCardAnsweredEvent extends PassageEventWithElementAnswered {
   }
 }
 
-class QABCardRetriedEvent extends PassageEventWithElement {
+class QABRetriedEvent extends PassageEventWithElement {
   constructor({ id, occurredAt, createdAt, passageId, sequenceNumber, elementId }) {
-    super({ id, type: 'QAB_CARD_RETRIED', occurredAt, createdAt, passageId, sequenceNumber, elementId });
+    super({ id, type: 'QAB_RETRIED', occurredAt, createdAt, passageId, sequenceNumber, elementId });
   }
 }
 
-export { QABCardAnsweredEvent, QABCardRetriedEvent };
+export { QABCardAnsweredEvent, QABRetriedEvent };

--- a/api/tests/devcomp/integration/domain/models/flashcard-events/answerable-element-events_test.js
+++ b/api/tests/devcomp/integration/domain/models/flashcard-events/answerable-element-events_test.js
@@ -1,6 +1,7 @@
 import {
   EmbedAnsweredEvent,
   QCMAnsweredEvent,
+  QCMRetriedEvent,
   QCUAnsweredEvent,
   QCUDeclarativeAnsweredEvent,
   QCUDiscoveryAnsweredEvent,
@@ -145,6 +146,37 @@ describe('Integration | Devcomp | Domain | Models | passage-events | answerable-
       expect(qcuRetriedEvent.passageId).to.equal(passageId);
       expect(qcuRetriedEvent.sequenceNumber).to.equal(sequenceNumber);
       expect(qcuRetriedEvent.data).to.deep.equal({ elementId });
+    });
+  });
+
+  describe('#QCMRetriedEvent', function () {
+    it('should init and keep attributes', function () {
+      // given
+      const id = Symbol('id');
+      const occurredAt = new Date();
+      const createdAt = new Date();
+      const passageId = 2;
+      const sequenceNumber = 3;
+      const elementId = '05112f63-0b47-4774-b638-6669c4e3a26d';
+
+      // when
+      const qcmRetriedEvent = new QCMRetriedEvent({
+        id,
+        occurredAt,
+        createdAt,
+        passageId,
+        sequenceNumber,
+        elementId,
+      });
+
+      // then
+      expect(qcmRetriedEvent.id).to.equal(id);
+      expect(qcmRetriedEvent.type).to.equal('QCM_RETRIED');
+      expect(qcmRetriedEvent.occurredAt).to.equal(occurredAt);
+      expect(qcmRetriedEvent.createdAt).to.equal(createdAt);
+      expect(qcmRetriedEvent.passageId).to.equal(passageId);
+      expect(qcmRetriedEvent.sequenceNumber).to.equal(sequenceNumber);
+      expect(qcmRetriedEvent.data).to.deep.equal({ elementId });
     });
   });
 

--- a/api/tests/devcomp/integration/domain/models/flashcard-events/answerable-element-events_test.js
+++ b/api/tests/devcomp/integration/domain/models/flashcard-events/answerable-element-events_test.js
@@ -4,8 +4,10 @@ import {
   QCUAnsweredEvent,
   QCUDeclarativeAnsweredEvent,
   QCUDiscoveryAnsweredEvent,
+  QCURetriedEvent,
   QROCMAnsweredEvent,
 } from '../../../../../../src/devcomp/domain/models/passage-events/answerable-element-events.js';
+import { QABRetriedEvent } from '../../../../../../src/devcomp/domain/models/passage-events/qab-events.js';
 import { DomainError } from '../../../../../../src/shared/domain/errors.js';
 import { catchErrSync, expect } from '../../../../../test-helper.js';
 
@@ -112,6 +114,37 @@ describe('Integration | Devcomp | Domain | Models | passage-events | answerable-
       expect(qcuAnsweredEvent.passageId).to.equal(passageId);
       expect(qcuAnsweredEvent.sequenceNumber).to.equal(sequenceNumber);
       expect(qcuAnsweredEvent.data).to.deep.equal({ elementId, answer, status });
+    });
+  });
+
+  describe('#QCURetriedEvent', function () {
+    it('should init and keep attributes', function () {
+      // given
+      const id = Symbol('id');
+      const occurredAt = new Date();
+      const createdAt = new Date();
+      const passageId = 2;
+      const sequenceNumber = 3;
+      const elementId = '05112f63-0b47-4774-b638-6669c4e3a26d';
+
+      // when
+      const qcuRetriedEvent = new QCURetriedEvent({
+        id,
+        occurredAt,
+        createdAt,
+        passageId,
+        sequenceNumber,
+        elementId,
+      });
+
+      // then
+      expect(qcuRetriedEvent.id).to.equal(id);
+      expect(qcuRetriedEvent.type).to.equal('QCU_RETRIED');
+      expect(qcuRetriedEvent.occurredAt).to.equal(occurredAt);
+      expect(qcuRetriedEvent.createdAt).to.equal(createdAt);
+      expect(qcuRetriedEvent.passageId).to.equal(passageId);
+      expect(qcuRetriedEvent.sequenceNumber).to.equal(sequenceNumber);
+      expect(qcuRetriedEvent.data).to.deep.equal({ elementId });
     });
   });
 

--- a/api/tests/devcomp/integration/domain/models/flashcard-events/answerable-element-events_test.js
+++ b/api/tests/devcomp/integration/domain/models/flashcard-events/answerable-element-events_test.js
@@ -7,8 +7,8 @@ import {
   QCUDiscoveryAnsweredEvent,
   QCURetriedEvent,
   QROCMAnsweredEvent,
+  QROCMRetriedEvent,
 } from '../../../../../../src/devcomp/domain/models/passage-events/answerable-element-events.js';
-import { QABRetriedEvent } from '../../../../../../src/devcomp/domain/models/passage-events/qab-events.js';
 import { DomainError } from '../../../../../../src/shared/domain/errors.js';
 import { catchErrSync, expect } from '../../../../../test-helper.js';
 
@@ -177,6 +177,37 @@ describe('Integration | Devcomp | Domain | Models | passage-events | answerable-
       expect(qcmRetriedEvent.passageId).to.equal(passageId);
       expect(qcmRetriedEvent.sequenceNumber).to.equal(sequenceNumber);
       expect(qcmRetriedEvent.data).to.deep.equal({ elementId });
+    });
+  });
+
+  describe('#QROCMRetriedEvent', function () {
+    it('should init and keep attributes', function () {
+      // given
+      const id = Symbol('id');
+      const occurredAt = new Date();
+      const createdAt = new Date();
+      const passageId = 2;
+      const sequenceNumber = 3;
+      const elementId = '05112f63-0b47-4774-b638-6669c4e3a26d';
+
+      // when
+      const qrocmRetriedEvent = new QROCMRetriedEvent({
+        id,
+        occurredAt,
+        createdAt,
+        passageId,
+        sequenceNumber,
+        elementId,
+      });
+
+      // then
+      expect(qrocmRetriedEvent.id).to.equal(id);
+      expect(qrocmRetriedEvent.type).to.equal('QROCM_RETRIED');
+      expect(qrocmRetriedEvent.occurredAt).to.equal(occurredAt);
+      expect(qrocmRetriedEvent.createdAt).to.equal(createdAt);
+      expect(qrocmRetriedEvent.passageId).to.equal(passageId);
+      expect(qrocmRetriedEvent.sequenceNumber).to.equal(sequenceNumber);
+      expect(qrocmRetriedEvent.data).to.deep.equal({ elementId });
     });
   });
 

--- a/api/tests/devcomp/integration/domain/models/flashcard-events/answerable-element-events_test.js
+++ b/api/tests/devcomp/integration/domain/models/flashcard-events/answerable-element-events_test.js
@@ -1,5 +1,6 @@
 import {
   EmbedAnsweredEvent,
+  EmbedRetriedEvent,
   QCMAnsweredEvent,
   QCMRetriedEvent,
   QCUAnsweredEvent,
@@ -45,6 +46,37 @@ describe('Integration | Devcomp | Domain | Models | passage-events | answerable-
       expect(embedAnsweredEvent.passageId).to.equal(passageId);
       expect(embedAnsweredEvent.sequenceNumber).to.equal(sequenceNumber);
       expect(embedAnsweredEvent.data).to.deep.equal({ elementId, answer, status });
+    });
+  });
+
+  describe('#EmbedRetriedEvent', function () {
+    it('should init and keep attributes', function () {
+      // given
+      const id = Symbol('id');
+      const occurredAt = new Date();
+      const createdAt = new Date();
+      const passageId = 2;
+      const sequenceNumber = 3;
+      const elementId = '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095';
+
+      // when
+      const embedRetriedEvent = new EmbedRetriedEvent({
+        id,
+        occurredAt,
+        createdAt,
+        passageId,
+        sequenceNumber,
+        elementId,
+      });
+
+      // then
+      expect(embedRetriedEvent.id).to.equal(id);
+      expect(embedRetriedEvent.type).to.equal('EMBED_RETRIED');
+      expect(embedRetriedEvent.occurredAt).to.equal(occurredAt);
+      expect(embedRetriedEvent.createdAt).to.equal(createdAt);
+      expect(embedRetriedEvent.passageId).to.equal(passageId);
+      expect(embedRetriedEvent.sequenceNumber).to.equal(sequenceNumber);
+      expect(embedRetriedEvent.data).to.deep.equal({ elementId });
     });
   });
 

--- a/api/tests/devcomp/integration/domain/models/flashcard-events/answerable-element-events_test.js
+++ b/api/tests/devcomp/integration/domain/models/flashcard-events/answerable-element-events_test.js
@@ -1,4 +1,5 @@
 import {
+  CustomRetriedEvent,
   EmbedAnsweredEvent,
   EmbedRetriedEvent,
   QCMAnsweredEvent,
@@ -14,6 +15,37 @@ import { DomainError } from '../../../../../../src/shared/domain/errors.js';
 import { catchErrSync, expect } from '../../../../../test-helper.js';
 
 describe('Integration | Devcomp | Domain | Models | passage-events | answerable-element-events', function () {
+  describe('#CustomRetriedEvent', function () {
+    it('should init and keep attributes', function () {
+      // given
+      const id = Symbol('id');
+      const occurredAt = new Date();
+      const createdAt = new Date();
+      const passageId = 2;
+      const sequenceNumber = 3;
+      const elementId = '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095';
+
+      // when
+      const customRetriedEvent = new CustomRetriedEvent({
+        id,
+        occurredAt,
+        createdAt,
+        passageId,
+        sequenceNumber,
+        elementId,
+      });
+
+      // then
+      expect(customRetriedEvent.id).to.equal(id);
+      expect(customRetriedEvent.type).to.equal('CUSTOM_RETRIED');
+      expect(customRetriedEvent.occurredAt).to.equal(occurredAt);
+      expect(customRetriedEvent.createdAt).to.equal(createdAt);
+      expect(customRetriedEvent.passageId).to.equal(passageId);
+      expect(customRetriedEvent.sequenceNumber).to.equal(sequenceNumber);
+      expect(customRetriedEvent.data).to.deep.equal({ elementId });
+    });
+  });
+
   describe('#EmbedAnsweredEvent', function () {
     it('should init and keep attributes', function () {
       // given

--- a/api/tests/devcomp/integration/domain/models/flashcard-events/answerable-element-events_test.js
+++ b/api/tests/devcomp/integration/domain/models/flashcard-events/answerable-element-events_test.js
@@ -1,4 +1,5 @@
 import {
+  CustomDraftRetriedEvent,
   CustomRetriedEvent,
   EmbedAnsweredEvent,
   EmbedRetriedEvent,
@@ -15,6 +16,37 @@ import { DomainError } from '../../../../../../src/shared/domain/errors.js';
 import { catchErrSync, expect } from '../../../../../test-helper.js';
 
 describe('Integration | Devcomp | Domain | Models | passage-events | answerable-element-events', function () {
+  describe('#CustomDraftRetriedEvent', function () {
+    it('should init and keep attributes', function () {
+      // given
+      const id = Symbol('id');
+      const occurredAt = new Date();
+      const createdAt = new Date();
+      const passageId = 2;
+      const sequenceNumber = 3;
+      const elementId = '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095';
+
+      // when
+      const customDraftRetriedEvent = new CustomDraftRetriedEvent({
+        id,
+        occurredAt,
+        createdAt,
+        passageId,
+        sequenceNumber,
+        elementId,
+      });
+
+      // then
+      expect(customDraftRetriedEvent.id).to.equal(id);
+      expect(customDraftRetriedEvent.type).to.equal('CUSTOM_DRAFT_RETRIED');
+      expect(customDraftRetriedEvent.occurredAt).to.equal(occurredAt);
+      expect(customDraftRetriedEvent.createdAt).to.equal(createdAt);
+      expect(customDraftRetriedEvent.passageId).to.equal(passageId);
+      expect(customDraftRetriedEvent.sequenceNumber).to.equal(sequenceNumber);
+      expect(customDraftRetriedEvent.data).to.deep.equal({ elementId });
+    });
+  });
+
   describe('#CustomRetriedEvent', function () {
     it('should init and keep attributes', function () {
       // given

--- a/api/tests/devcomp/integration/domain/models/passage-events/qab-events_test.js
+++ b/api/tests/devcomp/integration/domain/models/passage-events/qab-events_test.js
@@ -1,6 +1,6 @@
 import {
   QABCardAnsweredEvent,
-  QABCardRetriedEvent,
+  QABRetriedEvent,
 } from '../../../../../../src/devcomp/domain/models/passage-events/qab-events.js';
 import { DomainError } from '../../../../../../src/shared/domain/errors.js';
 import { catchErrSync, expect } from '../../../../../test-helper.js';
@@ -76,7 +76,7 @@ describe('Integration | Devcomp | Domain | Models | passage-events | qab-events'
     });
   });
 
-  describe('#QABCardRetriedEvent', function () {
+  describe('#QABRetriedEvent', function () {
     it('should init and keep attributes', function () {
       // given
       const id = Symbol('id');
@@ -87,7 +87,7 @@ describe('Integration | Devcomp | Domain | Models | passage-events | qab-events'
       const elementId = '05112f63-0b47-4774-b638-6669c4e3a26d';
 
       // when
-      const qabCardAnsweredEvent = new QABCardRetriedEvent({
+      const qabRetriedEvent = new QABRetriedEvent({
         id,
         occurredAt,
         createdAt,
@@ -97,13 +97,13 @@ describe('Integration | Devcomp | Domain | Models | passage-events | qab-events'
       });
 
       // then
-      expect(qabCardAnsweredEvent.id).to.equal(id);
-      expect(qabCardAnsweredEvent.type).to.equal('QAB_CARD_RETRIED');
-      expect(qabCardAnsweredEvent.occurredAt).to.equal(occurredAt);
-      expect(qabCardAnsweredEvent.createdAt).to.equal(createdAt);
-      expect(qabCardAnsweredEvent.passageId).to.equal(passageId);
-      expect(qabCardAnsweredEvent.sequenceNumber).to.equal(sequenceNumber);
-      expect(qabCardAnsweredEvent.data).to.deep.equal({ elementId });
+      expect(qabRetriedEvent.id).to.equal(id);
+      expect(qabRetriedEvent.type).to.equal('QAB_RETRIED');
+      expect(qabRetriedEvent.occurredAt).to.equal(occurredAt);
+      expect(qabRetriedEvent.createdAt).to.equal(createdAt);
+      expect(qabRetriedEvent.passageId).to.equal(passageId);
+      expect(qabRetriedEvent.sequenceNumber).to.equal(sequenceNumber);
+      expect(qabRetriedEvent.data).to.deep.equal({ elementId });
     });
   });
 });

--- a/api/tests/devcomp/unit/domain/factories/passage-event-factory_test.js
+++ b/api/tests/devcomp/unit/domain/factories/passage-event-factory_test.js
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 
 import { PassageEventFactory } from '../../../../../src/devcomp/domain/factories/passage-event-factory.js';
 import {
+  CustomDraftRetriedEvent,
   CustomRetriedEvent,
   EmbedAnsweredEvent,
   EmbedRetriedEvent,
@@ -105,6 +106,25 @@ describe('Unit | Devcomp | Domain | Models | Block | BlockInput', function () {
 
         // then
         expect(builtEvent).to.be.instanceOf(AudioTranscriptionOpenedEvent);
+      });
+    });
+
+    describe('when given a CUSTOM_DRAFT_RETRIED event', function () {
+      it('should return a CustomDraftRetriedEvent instance', function () {
+        // given
+        const rawEvent = {
+          occurredAt: new Date(),
+          passageId: 2,
+          sequenceNumber: 3,
+          elementId: 'c505e7c9-327e-4be5-9c62-ce4627b85f98',
+          type: 'CUSTOM_DRAFT_RETRIED',
+        };
+
+        // when
+        const builtEvent = PassageEventFactory.build(rawEvent);
+
+        // then
+        expect(builtEvent).to.be.instanceOf(CustomDraftRetriedEvent);
       });
     });
 

--- a/api/tests/devcomp/unit/domain/factories/passage-event-factory_test.js
+++ b/api/tests/devcomp/unit/domain/factories/passage-event-factory_test.js
@@ -7,6 +7,7 @@ import {
   QCUAnsweredEvent,
   QCUDeclarativeAnsweredEvent,
   QCUDiscoveryAnsweredEvent,
+  QCURetriedEvent,
   QROCMAnsweredEvent,
 } from '../../../../../src/devcomp/domain/models/passage-events/answerable-element-events.js';
 import {
@@ -407,6 +408,24 @@ describe('Unit | Devcomp | Domain | Models | Block | BlockInput', function () {
 
         // then
         expect(builtEvent).to.be.instanceOf(QCUAnsweredEvent);
+      });
+    });
+
+    describe('when given a QCU_RETRIED event', function () {
+      it('should return a QcuRetriedEvent instance', function () {
+        // given
+        const rawEvent = {
+          occurredAt: new Date(),
+          passageId: 2,
+          sequenceNumber: 3,
+          elementId: 'c505e7c9-327e-4be5-9c62-ce4627b85f98',
+          type: 'QCU_RETRIED',
+        };
+        // when
+        const builtEvent = PassageEventFactory.build(rawEvent);
+
+        // then
+        expect(builtEvent).to.be.instanceOf(QCURetriedEvent);
       });
     });
 

--- a/api/tests/devcomp/unit/domain/factories/passage-event-factory_test.js
+++ b/api/tests/devcomp/unit/domain/factories/passage-event-factory_test.js
@@ -37,7 +37,7 @@ import {
 } from '../../../../../src/devcomp/domain/models/passage-events/passage-events.js';
 import {
   QABCardAnsweredEvent,
-  QABCardRetriedEvent,
+  QABRetriedEvent,
 } from '../../../../../src/devcomp/domain/models/passage-events/qab-events.js';
 import { StepperNextStepEvent } from '../../../../../src/devcomp/domain/models/passage-events/stepper-events.js';
 import { DomainError } from '../../../../../src/shared/domain/errors.js';
@@ -352,21 +352,21 @@ describe('Unit | Devcomp | Domain | Models | Block | BlockInput', function () {
       });
     });
 
-    describe('when given a QAB_CARD_RETRIED event', function () {
-      it('should return a QabCardAnsweredEvent instance', function () {
+    describe('when given a QAB_RETRIED event', function () {
+      it('should return a QabRetriedEvent instance', function () {
         // given
         const rawEvent = {
           occurredAt: new Date(),
           passageId: 2,
           sequenceNumber: 3,
           elementId: 'c505e7c9-327e-4be5-9c62-ce4627b85f98',
-          type: 'QAB_CARD_RETRIED',
+          type: 'QAB_RETRIED',
         };
         // when
         const builtEvent = PassageEventFactory.build(rawEvent);
 
         // then
-        expect(builtEvent).to.be.instanceOf(QABCardRetriedEvent);
+        expect(builtEvent).to.be.instanceOf(QABRetriedEvent);
       });
     });
 

--- a/api/tests/devcomp/unit/domain/factories/passage-event-factory_test.js
+++ b/api/tests/devcomp/unit/domain/factories/passage-event-factory_test.js
@@ -10,6 +10,7 @@ import {
   QCUDiscoveryAnsweredEvent,
   QCURetriedEvent,
   QROCMAnsweredEvent,
+  QROCMRetriedEvent,
 } from '../../../../../src/devcomp/domain/models/passage-events/answerable-element-events.js';
 import {
   AudioPlayedEvent,
@@ -445,6 +446,24 @@ describe('Unit | Devcomp | Domain | Models | Block | BlockInput', function () {
 
         // then
         expect(builtEvent).to.be.instanceOf(QCMRetriedEvent);
+      });
+    });
+
+    describe('when given a QROCM_RETRIED event', function () {
+      it('should return a QrocmRetriedEvent instance', function () {
+        // given
+        const rawEvent = {
+          occurredAt: new Date(),
+          passageId: 2,
+          sequenceNumber: 3,
+          elementId: 'c505e7c9-327e-4be5-9c62-ce4627b85f98',
+          type: 'QROCM_RETRIED',
+        };
+        // when
+        const builtEvent = PassageEventFactory.build(rawEvent);
+
+        // then
+        expect(builtEvent).to.be.instanceOf(QROCMRetriedEvent);
       });
     });
 

--- a/api/tests/devcomp/unit/domain/factories/passage-event-factory_test.js
+++ b/api/tests/devcomp/unit/domain/factories/passage-event-factory_test.js
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 
 import { PassageEventFactory } from '../../../../../src/devcomp/domain/factories/passage-event-factory.js';
 import {
+  CustomRetriedEvent,
   EmbedAnsweredEvent,
   EmbedRetriedEvent,
   QCMAnsweredEvent,
@@ -104,6 +105,25 @@ describe('Unit | Devcomp | Domain | Models | Block | BlockInput', function () {
 
         // then
         expect(builtEvent).to.be.instanceOf(AudioTranscriptionOpenedEvent);
+      });
+    });
+
+    describe('when given an CUSTOM_RETRIED event', function () {
+      it('should return a CustomRetriedEvent instance', function () {
+        // given
+        const rawEvent = {
+          occurredAt: new Date(),
+          passageId: 2,
+          sequenceNumber: 3,
+          elementId: 'c505e7c9-327e-4be5-9c62-ce4627b85f98',
+          type: 'CUSTOM_RETRIED',
+        };
+
+        // when
+        const builtEvent = PassageEventFactory.build(rawEvent);
+
+        // then
+        expect(builtEvent).to.be.instanceOf(CustomRetriedEvent);
       });
     });
 

--- a/api/tests/devcomp/unit/domain/factories/passage-event-factory_test.js
+++ b/api/tests/devcomp/unit/domain/factories/passage-event-factory_test.js
@@ -4,6 +4,7 @@ import { PassageEventFactory } from '../../../../../src/devcomp/domain/factories
 import {
   EmbedAnsweredEvent,
   QCMAnsweredEvent,
+  QCMRetriedEvent,
   QCUAnsweredEvent,
   QCUDeclarativeAnsweredEvent,
   QCUDiscoveryAnsweredEvent,
@@ -426,6 +427,24 @@ describe('Unit | Devcomp | Domain | Models | Block | BlockInput', function () {
 
         // then
         expect(builtEvent).to.be.instanceOf(QCURetriedEvent);
+      });
+    });
+
+    describe('when given a QCM_RETRIED event', function () {
+      it('should return a QcmRetriedEvent instance', function () {
+        // given
+        const rawEvent = {
+          occurredAt: new Date(),
+          passageId: 2,
+          sequenceNumber: 3,
+          elementId: 'c505e7c9-327e-4be5-9c62-ce4627b85f98',
+          type: 'QCM_RETRIED',
+        };
+        // when
+        const builtEvent = PassageEventFactory.build(rawEvent);
+
+        // then
+        expect(builtEvent).to.be.instanceOf(QCMRetriedEvent);
       });
     });
 

--- a/api/tests/devcomp/unit/domain/factories/passage-event-factory_test.js
+++ b/api/tests/devcomp/unit/domain/factories/passage-event-factory_test.js
@@ -3,6 +3,7 @@ import { expect } from 'chai';
 import { PassageEventFactory } from '../../../../../src/devcomp/domain/factories/passage-event-factory.js';
 import {
   EmbedAnsweredEvent,
+  EmbedRetriedEvent,
   QCMAnsweredEvent,
   QCMRetriedEvent,
   QCUAnsweredEvent,
@@ -142,6 +143,25 @@ describe('Unit | Devcomp | Domain | Models | Block | BlockInput', function () {
 
         // then
         expect(builtEvent).to.be.instanceOf(EmbedAnsweredEvent);
+      });
+    });
+
+    describe('when given an EMBED_RETRIED event', function () {
+      it('should return a EmbedRetriedEvent instance', function () {
+        // given
+        const rawEvent = {
+          occurredAt: new Date(),
+          passageId: 2,
+          sequenceNumber: 3,
+          elementId: 'c505e7c9-327e-4be5-9c62-ce4627b85f98',
+          type: 'EMBED_RETRIED',
+        };
+
+        // when
+        const builtEvent = PassageEventFactory.build(rawEvent);
+
+        // then
+        expect(builtEvent).to.be.instanceOf(EmbedRetriedEvent);
       });
     });
 

--- a/mon-pix/app/components/module/component/element.gjs
+++ b/mon-pix/app/components/module/component/element.gjs
@@ -54,7 +54,7 @@ export default class ModulixElement extends Component {
     {{else if (eq @element.type "separator")}}
       <SeparatorElement />
     {{else if (eq @element.type "flashcards")}}
-      <FlashcardsElement @flashcards={{@element}} @onAnswer={{@onElementAnswer}} />
+      <FlashcardsElement @flashcards={{@element}} @onAnswer={{@onElementAnswer}} @onRetry={{@onElementRetry}} />
     {{else if (eq @element.type "qcu")}}
       <QcuElement
         @element={{@element}}

--- a/mon-pix/app/components/module/component/element.gjs
+++ b/mon-pix/app/components/module/component/element.gjs
@@ -82,7 +82,7 @@ export default class ModulixElement extends Component {
         @correction={{this.getLastCorrectionForElement @element}}
       />
     {{else if (eq @element.type "qab")}}
-      <QabElement @element={{@element}} @onAnswer={{@onElementAnswer}} />
+      <QabElement @element={{@element}} @onAnswer={{@onElementAnswer}} @onRetry={{@onElementRetry}} />
     {{/if}}
   </template>
 }

--- a/mon-pix/app/components/module/element/custom-draft.gjs
+++ b/mon-pix/app/components/module/element/custom-draft.gjs
@@ -1,6 +1,7 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixIcon from '@1024pix/pix-ui/components/pix-icon';
 import { action } from '@ember/object';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 
@@ -11,6 +12,8 @@ import ModuleElement from './module-element';
 
 export default class ModulixCustomDraft extends ModuleElement {
   @tracked reportInfo = {};
+
+  @service passageEvents;
 
   constructor(...args) {
     super(...args);
@@ -33,6 +36,11 @@ export default class ModulixCustomDraft extends ModuleElement {
 
   @action
   resetEmbed() {
+    this.passageEvents.record({
+      type: 'CUSTOM_DRAFT_RETRIED',
+      data: { elementId: this.args.customDraft.id },
+    });
+
     this.iframe.setAttribute('src', this.args.customDraft.url);
     this.iframe.focus();
   }

--- a/mon-pix/app/components/module/element/custom-element.gjs
+++ b/mon-pix/app/components/module/element/custom-element.gjs
@@ -2,6 +2,7 @@ import { metadata } from '@1024pix/epreuves-components/metadata';
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixIcon from '@1024pix/pix-ui/components/pix-icon';
 import { action } from '@ember/object';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 import htmlUnsafe from 'mon-pix/helpers/html-unsafe';
@@ -18,6 +19,8 @@ export default class ModulixCustomElement extends ModuleElement {
 
   @tracked
   resetButtonDisplayed = false;
+
+  @service passageEvents;
 
   @action
   mountCustomElement(container) {
@@ -36,6 +39,13 @@ export default class ModulixCustomElement extends ModuleElement {
   @action
   resetCustomElement() {
     this.customElement.reset();
+
+    this.passageEvents.record({
+      type: 'CUSTOM_RETRIED',
+      data: {
+        elementId: this.args.component.id,
+      },
+    });
   }
 
   get isInteractive() {

--- a/mon-pix/app/components/module/element/embed.gjs
+++ b/mon-pix/app/components/module/element/embed.gjs
@@ -58,6 +58,13 @@ export default class ModulixEmbed extends ModuleElement {
   resetEmbed() {
     this.iframe.setAttribute('src', this.args.embed.url);
     this.iframe.focus();
+
+    this.passageEvents.record({
+      type: 'EMBED_RETRIED',
+      data: {
+        elementId: this.args.embed.id,
+      },
+    });
   }
 
   get heightStyle() {

--- a/mon-pix/app/components/module/element/flashcards/flashcards.gjs
+++ b/mon-pix/app/components/module/element/flashcards/flashcards.gjs
@@ -71,6 +71,7 @@ export default class ModulixFlashcards extends Component {
 
   @action
   retry() {
+    this.args.onRetry({ element: this.args.flashcards });
     this.currentStep = 'intro';
     this.currentCardIndex = 0;
     this.displayedSideName = 'recto';

--- a/mon-pix/app/components/module/element/qab/qab.gjs
+++ b/mon-pix/app/components/module/element/qab/qab.gjs
@@ -121,7 +121,7 @@ export default class ModuleQab extends ModuleElement {
     this.score = 0;
 
     this.passageEvents.record({
-      type: 'QAB_CARD_RETRIED',
+      type: 'QAB_RETRIED',
       data: {
         elementId: this.element.id,
       },

--- a/mon-pix/app/components/module/element/qab/qab.gjs
+++ b/mon-pix/app/components/module/element/qab/qab.gjs
@@ -114,6 +114,7 @@ export default class ModuleQab extends ModuleElement {
 
   @action
   onRetry() {
+    this.args.onRetry({ element: this.element });
     this.currentStep = 'cards';
     this.removedCards.clear();
     this.cardStatuses.clear();

--- a/mon-pix/app/components/module/element/qcm.gjs
+++ b/mon-pix/app/components/module/element/qcm.gjs
@@ -115,6 +115,16 @@ export default class ModuleQcm extends ModuleElement {
     });
   }
 
+  @action
+  retry(event) {
+    super.retry(event);
+
+    this.passageEvents.record({
+      type: 'QCM_RETRIED',
+      data: { elementId: this.element.id },
+    });
+  }
+
   waitFor(duration) {
     return new Promise((resolve) => setTimeout(resolve, duration));
   }

--- a/mon-pix/app/components/module/element/qcu.gjs
+++ b/mon-pix/app/components/module/element/qcu.gjs
@@ -114,6 +114,10 @@ export default class ModuleQcu extends ModuleElement {
     super.retry(event);
     this.currentCorrection = null;
     this.displayFeedbackState = false;
+    this.passageEvents.record({
+      type: 'QCU_RETRIED',
+      data: { elementId: this.element.id },
+    });
   }
 
   get selectedProposalFeedback() {

--- a/mon-pix/app/components/module/element/qrocm.gjs
+++ b/mon-pix/app/components/module/element/qrocm.gjs
@@ -124,6 +124,16 @@ export default class ModuleQrocm extends ModuleElement {
     this.isVerifying = false;
   }
 
+  @action
+  retry(event) {
+    super.retry(event);
+
+    this.passageEvents.record({
+      type: 'QROCM_RETRIED',
+      data: { elementId: this.element.id },
+    });
+  }
+
   #waitFor(duration) {
     return new Promise((resolve) => setTimeout(resolve, duration));
   }

--- a/mon-pix/tests/integration/components/module/embed_test.gjs
+++ b/mon-pix/tests/integration/components/module/embed_test.gjs
@@ -549,6 +549,31 @@ module('Integration | Component | Module | Embed', function (hooks) {
       const iframe = screen.getByTitle(embed.title);
       assert.strictEqual(document.activeElement, iframe);
     });
+
+    test('should send an event', async function (assert) {
+      // given
+      const embed = {
+        id: 'id',
+        title: 'title',
+        isCompletionRequired: false,
+        url: 'https://example.org',
+        height: 800,
+      };
+      await render(<template><ModulixEmbed @embed={{embed}} /></template>);
+
+      // when
+      await clickByName(t('pages.modulix.buttons.embed.start.ariaLabel'));
+      await clickByName(t('pages.modulix.buttons.interactive-element.reset.ariaLabel'));
+
+      // then
+      sinon.assert.calledWithExactly(passageEventRecordStub, {
+        type: 'EMBED_RETRIED',
+        data: {
+          elementId: embed.id,
+        },
+      });
+      assert.ok(true);
+    });
   });
 
   module('when user copy pastes', function () {

--- a/mon-pix/tests/integration/components/module/flashcards_test.gjs
+++ b/mon-pix/tests/integration/components/module/flashcards_test.gjs
@@ -316,10 +316,13 @@ module('Integration | Component | Module | Flashcards', function (hooks) {
       const { flashcards } = _getFlashcards();
 
       const onAnswerStub = sinon.stub();
+      const onRetrySpy = sinon.spy();
 
       // when
       const screen = await render(
-        <template><ModulixFlashcards @flashcards={{flashcards}} @onAnswer={{onAnswerStub}} /></template>,
+        <template>
+          <ModulixFlashcards @flashcards={{flashcards}} @onAnswer={{onAnswerStub}} @onRetry={{onRetrySpy}} />
+        </template>,
       );
       await clickByName(t('pages.modulix.buttons.flashcards.start'));
       await clickByName(t('pages.modulix.buttons.flashcards.seeAnswer'));
@@ -330,10 +333,11 @@ module('Integration | Component | Module | Flashcards', function (hooks) {
 
       // then
       assert.dom(screen.getByRole('button', { name: t('pages.modulix.buttons.flashcards.start') })).exists();
+      assert.ok(onRetrySpy.calledOnceWithExactly({ element: flashcards }));
       assert.ok(
-        passageEventsService.record.calledWith({
+        passageEventsService.record.calledWithExactly({
           type: 'FLASHCARDS_RETRIED',
-          data: { elementId: '71de6394-ff88-4de3-8834-a40057a50ff4' },
+          data: { elementId: flashcards.id },
         }),
       );
     });
@@ -344,10 +348,13 @@ module('Integration | Component | Module | Flashcards', function (hooks) {
         const { flashcards, firstCard } = _getFlashcards();
 
         const onAnswerStub = sinon.stub();
+        const onRetryStub = sinon.stub();
 
         // when
         const screen = await render(
-          <template><ModulixFlashcards @flashcards={{flashcards}} @onAnswer={{onAnswerStub}} /></template>,
+          <template>
+            <ModulixFlashcards @flashcards={{flashcards}} @onAnswer={{onAnswerStub}} @onRetry={{onRetryStub}} />
+          </template>,
         );
         await clickByName(t('pages.modulix.buttons.flashcards.start'));
         await clickByName(t('pages.modulix.buttons.flashcards.seeAnswer'));

--- a/mon-pix/tests/integration/components/module/qab_test.gjs
+++ b/mon-pix/tests/integration/components/module/qab_test.gjs
@@ -195,10 +195,13 @@ module('Integration | Component | Module | QAB', function (hooks) {
           // given
           const qabElement = _getQabElement();
           const onAnswerStub = sinon.stub();
+          const onRetrySpy = sinon.spy();
 
           // when
           const screen = await render(
-            <template><ModuleQabElement @element={{qabElement}} @onAnswer={{onAnswerStub}} /></template>,
+            <template>
+              <ModuleQabElement @element={{qabElement}} @onAnswer={{onAnswerStub}} @onRetry={{onRetrySpy}} />
+            </template>,
           );
           await click(screen.getByRole('button', { name: 'Option A: Vrai' }));
           await clock.tickAsync(NEXT_CARD_DELAY);
@@ -207,12 +210,12 @@ module('Integration | Component | Module | QAB', function (hooks) {
           await click(screen.getByRole('button', { name: 'Réessayer' }));
 
           // then
-
           assert.dom(screen.getByText('Les chiens ne transpirent pas.')).exists();
           assert.dom(screen.getByText('Maintenant, entraînez-vous sur des exemples concrets !')).exists();
           assert.dom(screen.getByText('Les boules de pétanques sont creuses.')).exists();
 
           const recordQabCardRetriedCall = passageEventRecordStub.getCall(2);
+          sinon.assert.calledWith(onRetrySpy, { element: qabElement });
           assert.deepEqual(recordQabCardRetriedCall.args, [
             {
               type: 'QAB_RETRIED',

--- a/mon-pix/tests/integration/components/module/qab_test.gjs
+++ b/mon-pix/tests/integration/components/module/qab_test.gjs
@@ -215,7 +215,7 @@ module('Integration | Component | Module | QAB', function (hooks) {
           const recordQabCardRetriedCall = passageEventRecordStub.getCall(2);
           assert.deepEqual(recordQabCardRetriedCall.args, [
             {
-              type: 'QAB_CARD_RETRIED',
+              type: 'QAB_RETRIED',
               data: {
                 elementId: qabElement.id,
               },

--- a/mon-pix/tests/integration/components/module/qcu_test.gjs
+++ b/mon-pix/tests/integration/components/module/qcu_test.gjs
@@ -226,6 +226,38 @@ module('Integration | Component | Module | QCU', function (hooks) {
     assert.dom(screen.queryByRole('button', { name: 'Réessayer' })).doesNotExist();
   });
 
+  module('when user click on retry button', function () {
+    test('should call action and send an event', async function (assert) {
+      // given
+      const qcuElement = _getQcuElement();
+      const answeredProposal = qcuElement.proposals[1];
+      const onAnswerStub = sinon.stub();
+      const onRetrySpy = sinon.spy();
+
+      // when
+      const screen = await render(
+        <template><ModulixQcu @element={{qcuElement}} @onAnswer={{onAnswerStub}} @onRetry={{onRetrySpy}} /></template>,
+      );
+      await click(screen.getByLabelText(answeredProposal.content));
+
+      const verifyButton = screen.queryByRole('button', { name: 'Vérifier ma réponse' });
+      await click(verifyButton);
+      await clock.tickAsync(VERIFY_RESPONSE_DELAY);
+      const retryButton = screen.getByRole('button', { name: 'Réessayer' });
+      await click(retryButton);
+
+      // then
+      sinon.assert.calledWith(onRetrySpy, { element: qcuElement });
+      sinon.assert.calledWithExactly(passageEventRecordStub, {
+        type: 'QCU_RETRIED',
+        data: {
+          elementId: qcuElement.id,
+        },
+      });
+      assert.ok(true);
+    });
+  });
+
   module('when preview mode is enabled', function () {
     test('should display all feedbacks, without answering', async function (assert) {
       // given


### PR DESCRIPTION
## ❄️ Problème

Dans les passage-events, on ne trace pas le fait qu'un utilisateur clique sur le boutons "Réessayer" des questions, ou le bouton "Réinitialiser" des POI et embed.

## 🛷 Proposition

Ajouter l'enregistrement de cet événement dans la table passage-events.

## ☃️ Remarques

- Les éléments qcu déclaratif et qcu découverte n'ont pas de bouton "réessayer"
- Renommage de l'event "QAB_CARD_RETRIED" en "QAB_RETRIED" car c'est tout le deck qui est remis à zéro. Il faudrait créer un script pour remettre les données actuelles avec le bon nom en DB.
- Appel de la fonction `onRetry` de `passage.gjs` dans les éléments QAB et Flashcards, afin d'enregistrer des metrics dans Plausible.


## 🧑‍🎄 Pour tester

- Ouvrir la [galerie](https://app-pr14979.review.pix.fr/modules/galerie)
- Essayer d'appuyer sur le bouton _Réessayer_, en vérifiant qu'un appel pour créer un passage-events a été fait, pour les éléments suivants : 
   - QCU
   - QCM
   - QROCM
   - QAB
   - Flashcards
  
- Essayer d'appuyer sur le bouton _Réinitialiser_, en vérifiant qu'un appel pour créer un passage-events a été fait, pour les éléments suivants : 
  - Embed
  - Custom
  - Custom-draft
