### PR TITLE
[BUGFIX] Permettre le rescoring lorsqu'une certification est terminée mais n'a pas d'assessment-result (PIX-21391)

### DIFF
--- a/admin/app/components/certifications/certification/informations/global-actions.gjs
+++ b/admin/app/components/certifications/certification/informations/global-actions.gjs
@@ -23,7 +23,9 @@ export default class CertificationInformationGlobalActions extends Component {
     return Boolean(
       !this.args.certification.isPublished &&
       this.args.session.finalizedAt &&
-      (this.args.certification.status === 'validated' || this.args.certification.status === 'error'),
+      (this.args.certification.status === 'validated' ||
+        this.args.certification.status === 'error' ||
+        !this.args.certification.status),
     );
   }
 

--- a/admin/tests/integration/components/certifications/certification/informations/global-actions-test.gjs
+++ b/admin/tests/integration/components/certifications/certification/informations/global-actions-test.gjs
@@ -98,6 +98,25 @@ module('Integration | Component | Certifications | Certification | Information |
             .exists();
         });
       });
+      module('when certification has no status, session is finalized and not published', function () {
+        test('should display a cancel button', async function (assert) {
+          // given
+          const certification = store.createRecord('certification', {
+            userId: 1,
+            status: null,
+            isPublished: false,
+          });
+          const session = createFinalizedSession();
+
+          // when
+          const screen = await renderGlobalActions(certification, session);
+
+          // then
+          assert
+            .dom(screen.getByRole('button', { name: t('components.certifications.global-actions.cancel.button') }))
+            .exists();
+        });
+      });
     });
 
     module('when should not display', function () {
@@ -438,6 +457,25 @@ module('Integration | Component | Certifications | Certification | Information |
             .exists();
         });
       });
+      module('when certification has no status, session is finalized and not published', function () {
+        test('should display a cancel button', async function (assert) {
+          // given
+          const certification = store.createRecord('certification', {
+            userId: 1,
+            status: null,
+            isPublished: false,
+          });
+          const session = createFinalizedSession();
+
+          // when
+          const screen = await renderGlobalActions(certification, session);
+
+          // then
+          assert
+            .dom(screen.getByRole('button', { name: t('components.certifications.global-actions.reject.button') }))
+            .exists();
+        });
+      });
     });
 
     module('when should not display', function () {
@@ -765,6 +803,25 @@ module('Integration | Component | Certifications | Certification | Information |
           const certification = store.createRecord('certification', {
             userId: 1,
             status: assessmentResultStatus.ERROR,
+            isPublished: false,
+          });
+          const session = createFinalizedSession();
+
+          // when
+          const screen = await renderGlobalActions(certification, session);
+
+          // then
+          assert
+            .dom(screen.getByRole('button', { name: t('components.certifications.global-actions.rescoring.button') }))
+            .exists();
+        });
+      });
+      module('when certification has no status, session is finalized and not published', function () {
+        test('should display a cancel button', async function (assert) {
+          // given
+          const certification = store.createRecord('certification', {
+            userId: 1,
+            status: null,
             isPublished: false,
           });
           const session = createFinalizedSession();

--- a/api/src/certification/evaluation/application/certification-rescoring-controller.js
+++ b/api/src/certification/evaluation/application/certification-rescoring-controller.js
@@ -18,6 +18,7 @@ const rescoreCertification = async function (
   const latestAssessmentResult = await dependencies.courseAssessmentResultRepository.getLatestAssessmentResult({
     certificationCourseId,
   });
+
   if (_isAssessmentResultNotRescorable(latestAssessmentResult)) {
     throw new CertificationRescoringNotAllowedError();
   }
@@ -38,10 +39,7 @@ const rescoreCertification = async function (
 };
 
 const _isAssessmentResultNotRescorable = (latestAssessmentResult) => {
-  return (
-    latestAssessmentResult &&
-    (latestAssessmentResult.status === 'cancelled' || latestAssessmentResult.status === 'rejected')
-  );
+  return latestAssessmentResult?.status === 'cancelled' || latestAssessmentResult?.status === 'rejected';
 };
 
 const certificationRescoringController = {

--- a/api/src/certification/session-management/domain/usecases/update-jury-comment.js
+++ b/api/src/certification/session-management/domain/usecases/update-jury-comment.js
@@ -5,7 +5,9 @@
  */
 
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
+import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { CompetenceMark } from '../../../shared/domain/models/CompetenceMark.js';
+
 /**
  * @param {object} params
  * @param {number} params.certificationCourseId
@@ -27,6 +29,9 @@ const updateJuryComment = async function ({
     const latestAssessmentResult = await courseAssessmentResultRepository.getLatestAssessmentResult({
       certificationCourseId,
     });
+    if (!latestAssessmentResult) {
+      throw new NotFoundError('No assessment result found');
+    }
 
     const updatedAssessmentResult = latestAssessmentResult.clone();
     updatedAssessmentResult.commentByJury = assessmentResultCommentByJury;

--- a/api/src/certification/session-management/infrastructure/repositories/course-assessment-result-repository.js
+++ b/api/src/certification/session-management/infrastructure/repositories/course-assessment-result-repository.js
@@ -1,7 +1,6 @@
 import _ from 'lodash';
 
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
-import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { AssessmentResult } from '../../../../shared/domain/models/AssessmentResult.js';
 import { CompetenceMark } from '../../../shared/domain/models/CompetenceMark.js';
 import { JuryComment, JuryCommentContexts } from '../../../shared/domain/models/JuryComment.js';
@@ -48,18 +47,17 @@ const getLatestAssessmentResult = async function ({ certificationCourseId }) {
     )
     .where({ certificationCourseId })
     .first();
+  if (latestAssessmentResult) {
+    const competencesMarksDTO = await knexConn('competence-marks').where({
+      assessmentResultId: latestAssessmentResult.id,
+    });
 
-  if (!latestAssessmentResult) {
-    throw new NotFoundError('No assessment result found');
+    return _toDomain({
+      assessmentResultDTO: latestAssessmentResult,
+      competencesMarksDTO,
+    });
   }
-  const competencesMarksDTO = await knexConn('competence-marks').where({
-    assessmentResultId: latestAssessmentResult.id,
-  });
-
-  return _toDomain({
-    assessmentResultDTO: latestAssessmentResult,
-    competencesMarksDTO,
-  });
+  return null;
 };
 
 export { getLatestAssessmentResult };

--- a/api/tests/certification/session-management/integration/infrastructure/repositories/course-assessment-result-repository_test.js
+++ b/api/tests/certification/session-management/integration/infrastructure/repositories/course-assessment-result-repository_test.js
@@ -1,8 +1,7 @@
 import * as courseAssessmentResultRepository from '../../../../../../src/certification/session-management/infrastructure/repositories/course-assessment-result-repository.js';
 import { AutoJuryCommentKeys } from '../../../../../../src/certification/shared/domain/models/JuryComment.js';
-import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
 import { AssessmentResult } from '../../../../../../src/shared/domain/models/AssessmentResult.js';
-import { catchErr, databaseBuilder, domainBuilder, expect } from '../../../../../test-helper.js';
+import { databaseBuilder, domainBuilder, expect } from '../../../../../test-helper.js';
 
 describe('Certification | Course | Integration | Repository | course-assessment-result', function () {
   describe('#getLatestAssessmentResult', function () {
@@ -99,7 +98,7 @@ describe('Certification | Course | Integration | Repository | course-assessment-
     });
 
     context('when no assessment result exists', function () {
-      it('should return a NotFound error', async function () {
+      it('should return undefined', async function () {
         // given
         const certificationCourseId = 1;
         databaseBuilder.factory.buildCertificationCourse({ id: certificationCourseId });
@@ -108,12 +107,12 @@ describe('Certification | Course | Integration | Repository | course-assessment-
         await databaseBuilder.commit();
 
         // when
-        const error = await catchErr(courseAssessmentResultRepository.getLatestAssessmentResult)({
+        const latestAssessmentResult = await courseAssessmentResultRepository.getLatestAssessmentResult({
           certificationCourseId,
         });
 
         // then
-        expect(error).to.deepEqualInstance(new NotFoundError('No assessment result found'));
+        expect(latestAssessmentResult).to.be.null;
       });
     });
   });

--- a/api/tests/certification/session-management/unit/domain/usecases/cancel_test.js
+++ b/api/tests/certification/session-management/unit/domain/usecases/cancel_test.js
@@ -3,8 +3,10 @@ import { AlgorithmEngineVersion } from '../../../../../../src/certification/shar
 import {
   CertificationCancelNotAllowedError,
   NotFinalizedSessionError,
+  NotFoundError,
 } from '../../../../../../src/shared/domain/errors.js';
 import CertificationCancelled from '../../../../../../src/shared/domain/events/CertificationCancelled.js';
+import { status as assessmentResultStatuses } from '../../../../../../src/shared/domain/models/AssessmentResult.js';
 import { catchErr, domainBuilder, expect, sinon } from '../../../../../test-helper.js';
 
 describe('Certification | Session-management | Unit | Domain | UseCases | cancel', function () {
@@ -37,7 +39,7 @@ describe('Certification | Session-management | Unit | Domain | UseCases | cancel
         certificationCourseRepository.get.withArgs({ id: 123 }).resolves(certificationCourse);
         certificationRescoringRepository.rescoreV2Certification.resolves();
         sessionRepository.isFinalized.withArgs({ id: certificationCourse.getSessionId() }).resolves(true);
-        courseAssessmentResultRepository.getLatestAssessmentResult.resolves(null);
+        courseAssessmentResultRepository.getLatestAssessmentResult.resolves(domainBuilder.buildAssessmentResult());
 
         // when
         await cancel({
@@ -83,7 +85,7 @@ describe('Certification | Session-management | Unit | Domain | UseCases | cancel
         };
         certificationCourseRepository.get.withArgs({ id: 123 }).resolves(certificationCourse);
         sessionRepository.isFinalized.withArgs({ id: certificationCourse.getSessionId() }).resolves(false);
-        courseAssessmentResultRepository.getLatestAssessmentResult.resolves(null);
+        courseAssessmentResultRepository.getLatestAssessmentResult.resolves(domainBuilder.buildAssessmentResult());
 
         // when
         const error = await catchErr(cancel)({
@@ -96,6 +98,49 @@ describe('Certification | Session-management | Unit | Domain | UseCases | cancel
 
         // then
         expect(error).to.be.instanceOf(NotFinalizedSessionError);
+      });
+    });
+    describe('when certification has no previous assessment result', function () {
+      it('should not cancel the certification', async function () {
+        // given
+        const juryId = 123;
+        const session = domainBuilder.certification.sessionManagement.buildSession({
+          finalizedAt: new Date('2020-01-01'),
+          version: AlgorithmEngineVersion.V2,
+        });
+        const certificationCourse = domainBuilder.buildCertificationCourse({
+          id: 123,
+          sessionId: session.id,
+          version: AlgorithmEngineVersion.V2,
+        });
+        const certificationCourseRepository = {
+          get: sinon.stub(),
+        };
+        const sessionRepository = {
+          isFinalized: sinon.stub(),
+        };
+        const certificationRescoringRepository = {
+          rescoreV2Certification: sinon.stub(),
+        };
+        const courseAssessmentResultRepository = {
+          getLatestAssessmentResult: sinon.stub(),
+        };
+        certificationCourseRepository.get.withArgs({ id: 123 }).resolves(certificationCourse);
+        certificationRescoringRepository.rescoreV2Certification.resolves();
+        sessionRepository.isFinalized.withArgs({ id: certificationCourse.getSessionId() }).resolves(true);
+        courseAssessmentResultRepository.getLatestAssessmentResult.resolves(null);
+
+        // when
+        const error = await catchErr(cancel)({
+          certificationCourseId: 123,
+          certificationCourseRepository,
+          sessionRepository,
+          juryId,
+          courseAssessmentResultRepository,
+        });
+
+        // then
+        expect(error).to.be.instanceOf(NotFoundError);
       });
     });
   });
@@ -129,7 +174,7 @@ describe('Certification | Session-management | Unit | Domain | UseCases | cancel
         certificationCourseRepository.get.withArgs({ id: 123 }).resolves(certificationCourse);
         certificationRescoringRepository.rescoreV3Certification.resolves();
         sessionRepository.isFinalized.withArgs({ id: certificationCourse.getSessionId() }).resolves(true);
-        courseAssessmentResultRepository.getLatestAssessmentResult.resolves(null);
+        courseAssessmentResultRepository.getLatestAssessmentResult.resolves(domainBuilder.buildAssessmentResult());
 
         // when
         await cancel({
@@ -191,6 +236,51 @@ describe('Certification | Session-management | Unit | Domain | UseCases | cancel
       });
     });
   });
+  describe('when certification has no previous assessment result', function () {
+    it('should not reject the certification and throw NotFoundError', async function () {
+      // given
+      const juryId = 123;
+      const session = domainBuilder.certification.sessionManagement.buildSession({
+        finalizedAt: new Date('2020-01-01'),
+        version: AlgorithmEngineVersion.V3,
+      });
+      const certificationCourse = domainBuilder.buildCertificationCourse({
+        id: 123,
+        sessionId: session.id,
+        version: AlgorithmEngineVersion.V3,
+      });
+      const certificationCourseRepository = {
+        get: sinon.stub(),
+      };
+      const sessionRepository = {
+        isFinalized: sinon.stub(),
+      };
+      const certificationRescoringRepository = {
+        rescoreV3Certification: sinon.stub(),
+      };
+      const courseAssessmentResultRepository = {
+        getLatestAssessmentResult: sinon.stub(),
+      };
+      certificationCourseRepository.get.withArgs({ id: 123 }).resolves(certificationCourse);
+      certificationRescoringRepository.rescoreV3Certification.resolves();
+      sessionRepository.isFinalized.withArgs({ id: certificationCourse.getSessionId() }).resolves(true);
+      courseAssessmentResultRepository.getLatestAssessmentResult.resolves(null);
+
+      // when
+      const error = await catchErr(cancel)({
+        certificationCourseId: 123,
+        juryId,
+        certificationCourseRepository,
+        sessionRepository,
+        certificationRescoringRepository,
+        courseAssessmentResultRepository,
+      });
+
+      // then
+      expect(error).to.be.instanceOf(NotFoundError);
+      expect(certificationRescoringRepository.rescoreV3Certification).to.not.have.been.called;
+    });
+  });
 
   describe('when certification is rejected', function () {
     it('should not cancel the certification and throw CertificationCancelNotAllowedError', async function () {
@@ -220,8 +310,9 @@ describe('Certification | Session-management | Unit | Domain | UseCases | cancel
 
       certificationCourseRepository.get.withArgs({ id: 123 }).resolves(certificationCourse);
       sessionRepository.isFinalized.withArgs({ id: certificationCourse.getSessionId() }).resolves(true);
-      courseAssessmentResultRepository.getLatestAssessmentResult.resolves({ status: 'rejected' });
-
+      courseAssessmentResultRepository.getLatestAssessmentResult.resolves(
+        domainBuilder.buildAssessmentResult({ status: assessmentResultStatuses.REJECTED }),
+      );
       // when
       const error = await catchErr(cancel)({
         certificationCourseId: 123,

--- a/api/tests/certification/session-management/unit/domain/usecases/reject-certification-course_test.js
+++ b/api/tests/certification/session-management/unit/domain/usecases/reject-certification-course_test.js
@@ -2,7 +2,8 @@ import { CertificationCourseRejected } from '../../../../../../src/certification
 import { rejectCertificationCourse } from '../../../../../../src/certification/session-management/domain/usecases/reject-certification-course.js';
 import { AlgorithmEngineVersion } from '../../../../../../src/certification/shared/domain/models/AlgorithmEngineVersion.js';
 import { CertificationCourse } from '../../../../../../src/certification/shared/domain/models/CertificationCourse.js';
-import { CertificationRejectNotAllowedError } from '../../../../../../src/shared/domain/errors.js';
+import { CertificationRejectNotAllowedError, NotFoundError } from '../../../../../../src/shared/domain/errors.js';
+import { status as assessmentResultStatuses } from '../../../../../../src/shared/domain/models/AssessmentResult.js';
 import { catchErr, domainBuilder, expect, sinon } from '../../../../../test-helper.js';
 
 describe('Unit | UseCase | reject-certification-course', function () {
@@ -25,7 +26,7 @@ describe('Unit | UseCase | reject-certification-course', function () {
       certificationCourseRepository.get.withArgs({ id: certificationCourseId }).resolves(certificationCourse);
       certificationCourseRepository.update.resolves();
       certificationRescoringRepository.rescoreV2Certification.resolves();
-      courseAssessmentResultRepository.getLatestAssessmentResult.resolves(null);
+      courseAssessmentResultRepository.getLatestAssessmentResult.resolves(domainBuilder.buildAssessmentResult());
 
       // when
       await rejectCertificationCourse({
@@ -51,6 +52,45 @@ describe('Unit | UseCase | reject-certification-course', function () {
         }),
       });
     });
+    describe('when certification has no previous assessment result', function () {
+      it('should not cancel the certification', async function () {
+        // given
+        const juryId = 123;
+        const session = domainBuilder.certification.sessionManagement.buildSession({
+          finalizedAt: null,
+          version: AlgorithmEngineVersion.V2,
+        });
+        const certificationCourse = domainBuilder.buildCertificationCourse({
+          id: 123,
+          sessionId: session.id,
+          version: AlgorithmEngineVersion.V2,
+        });
+        const certificationCourseRepository = {
+          get: sinon.stub(),
+        };
+        const sessionRepository = {
+          isFinalized: sinon.stub(),
+        };
+        const courseAssessmentResultRepository = {
+          getLatestAssessmentResult: sinon.stub(),
+        };
+        certificationCourseRepository.get.withArgs({ id: 123 }).resolves(certificationCourse);
+        sessionRepository.isFinalized.withArgs({ id: certificationCourse.getSessionId() }).resolves(false);
+        courseAssessmentResultRepository.getLatestAssessmentResult.resolves(null);
+
+        // when
+        const error = await catchErr(rejectCertificationCourse)({
+          certificationCourseId: 123,
+          certificationCourseRepository,
+          sessionRepository,
+          juryId,
+          courseAssessmentResultRepository,
+        });
+
+        // then
+        expect(error).to.be.instanceOf(NotFoundError);
+      });
+    });
   });
 
   describe('when certification is a V3', function () {
@@ -72,7 +112,7 @@ describe('Unit | UseCase | reject-certification-course', function () {
       certificationCourseRepository.get.withArgs({ id: certificationCourseId }).resolves(certificationCourse);
       certificationCourseRepository.update.resolves();
       certificationRescoringRepository.rescoreV3Certification.resolves();
-      courseAssessmentResultRepository.getLatestAssessmentResult.resolves(null);
+      courseAssessmentResultRepository.getLatestAssessmentResult.resolves(domainBuilder.buildAssessmentResult());
 
       // when
       await rejectCertificationCourse({
@@ -100,6 +140,39 @@ describe('Unit | UseCase | reject-certification-course', function () {
     });
   });
 
+  describe('when certification has no previous assessment result', function () {
+    it('should not reject the certification and throw NotFoundError', async function () {
+      // given
+      const certificationCourseRepository = { get: sinon.stub(), update: sinon.stub() };
+      const certificationRescoringRepository = { rescoreV3Certification: sinon.stub() };
+      const courseAssessmentResultRepository = { getLatestAssessmentResult: sinon.stub() };
+      const juryId = 123;
+
+      const dependencies = {
+        certificationCourseRepository,
+        certificationRescoringRepository,
+        courseAssessmentResultRepository,
+      };
+      const certificationCourse = domainBuilder.buildCertificationCourse({ version: AlgorithmEngineVersion.V3 });
+      const certificationCourseId = certificationCourse.getId();
+
+      certificationCourseRepository.get.withArgs({ id: certificationCourseId }).resolves(certificationCourse);
+      courseAssessmentResultRepository.getLatestAssessmentResult.resolves(null);
+
+      // when
+      const error = await catchErr(rejectCertificationCourse)({
+        ...dependencies,
+        juryId,
+        certificationCourseId: certificationCourseId,
+      });
+
+      // then
+      expect(error).to.be.instanceOf(NotFoundError);
+      expect(certificationCourseRepository.update).to.not.have.been.called;
+      expect(certificationRescoringRepository.rescoreV3Certification).to.not.have.been.called;
+    });
+  });
+
   describe('when certification is cancelled', function () {
     it('should not reject the certification and throw CertificationRejectNotAllowedError', async function () {
       // given
@@ -117,7 +190,9 @@ describe('Unit | UseCase | reject-certification-course', function () {
       const certificationCourseId = certificationCourse.getId();
 
       certificationCourseRepository.get.withArgs({ id: certificationCourseId }).resolves(certificationCourse);
-      courseAssessmentResultRepository.getLatestAssessmentResult.resolves({ status: 'cancelled' });
+      courseAssessmentResultRepository.getLatestAssessmentResult.resolves(
+        domainBuilder.buildAssessmentResult({ status: assessmentResultStatuses.CANCELLED }),
+      );
 
       // when
       const error = await catchErr(rejectCertificationCourse)({


### PR DESCRIPTION
## ❄️ Problème

Il peut arriver que le job de scoring ne fonctionne pas.

Et dans ce cas-là, si la certif devient terminée mais n’a pas de résultat (pas d'`assessment-result`), alors la certification n’a plus de statut et le bouton de rescoring ne s’affiche pas sur Admin.
De plus, côté API, on exige actuellement à ce qu'un `assessmentResult` existe pour réaliser un rescoring (alors qu'il n'est pas réellement nécessaire pour le calcul du scoring)

## 🛷 Proposition

Afin d'avoir une solution pour débloquer les certification se trouvant dans cette situation, on peut permettre, dans le front et le back, de rescorer une certification n'ayant pas d'`assessmentResult`.

## ☃️ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🧑‍🎄 Pour tester

### Reproduire le bug
- Passer une certification
- finaliser la session
- supprimer de la BDD l'assessmentResult, les competenceMarks et l'entrée dans la table certification-course-last-assessment-result

### Vérifier le bugfix
- la certification doit avoir ni statut, ni pixScore
- vérifier que les boutons (rescorer, annuler, rejeter) s'affiche sur la certification
- vérifier que déclencher le rescoring fonctionne et que la certification a ensuite un statut et un score
- Non régression sur les autres boutons (sur la certification "buguée" et les autres)