### PR TITLE
[TECH] Ajout de tests autos pédagogiques pour mieux comprendre la gestion de la stack trace dans un contexte de promesses

### DIFF
--- a/api/tests/dev-educational/async-gotchas_test.js
+++ b/api/tests/dev-educational/async-gotchas_test.js
@@ -1,0 +1,161 @@
+import { expect } from '../test-helper.js';
+
+describe('Async gotchas – anti-patterns vs good patterns', function () {
+  function getStack(fn) {
+    return fn().catch((err) => err.stack);
+  }
+
+  context('error re-throw', function () {
+    context('❌ Anti-pattern: throw a new error and ignore the first error', function () {
+      it('resets the stack trace', async function () {
+        async function levelOne() {
+          throw new Error('boom');
+        }
+
+        async function levelTwo() {
+          try {
+            await levelOne();
+          } catch (err) {
+            throw new Error(err.message);
+          }
+        }
+
+        const stack = await getStack(() => levelTwo());
+        expect(stack).to.include('levelTwo').and.to.not.include('levelOne');
+      });
+    });
+
+    context('✅ Good pattern: let the first error bubble up', function () {
+      it('keeps the full stack trace', async function () {
+        async function levelOne() {
+          throw new Error('boom');
+        }
+
+        async function levelTwo() {
+          await levelOne();
+        }
+
+        const stack = await getStack(() => levelTwo());
+        expect(stack).to.include('levelTwo').and.to.include('levelOne');
+      });
+    });
+
+    context('✅ Good pattern: rethrow the same error', function () {
+      it('keeps the full stack trace', async function () {
+        async function levelOne() {
+          throw new Error('boom');
+        }
+
+        async function levelTwo() {
+          try {
+            await levelOne();
+          } catch (err) {
+            void 0; // let's pretend this piece of code does something super useful
+            throw err;
+          }
+        }
+
+        const stack = await getStack(() => levelTwo());
+        expect(stack).to.include('levelTwo').and.to.include('levelOne');
+      });
+    });
+  });
+
+  context('return vs return await in a function', function () {
+    context('❌ Anti-pattern: return a promise without awaiting it', function () {
+      it('loses the current function from the stack trace', async function () {
+        async function levelOne() {
+          await new Promise((resolve) => setTimeout(resolve, 10));
+          throw new Error('boom');
+        }
+
+        function levelTwo() {
+          return levelOne();
+        }
+
+        async function levelThree() {
+          try {
+            return await levelTwo();
+          } catch (err) {
+            void 0; // let's pretend this piece of code does something super useful
+            throw err;
+          }
+        }
+
+        const stack = await getStack(() => levelThree());
+        expect(stack).to.include('levelOne').and.to.include('levelThree').and.to.not.include('levelTwo');
+      });
+    });
+    context('✅ Good pattern: return a promise by awaiting it first', function () {
+      it('keeps the full stack trace', async function () {
+        async function levelOne() {
+          await new Promise((resolve) => setTimeout(resolve, 10));
+          throw new Error('boom');
+        }
+
+        async function levelTwo() {
+          return await levelOne();
+        }
+
+        async function levelThree() {
+          try {
+            return await levelTwo();
+          } catch (err) {
+            void 0; // let's pretend this piece of code does something super useful
+            throw err;
+          }
+        }
+
+        const stack = await getStack(() => levelThree());
+        expect(stack).to.include('levelOne').and.to.include('levelTwo').and.to.include('levelThree');
+      });
+    });
+  });
+
+  context('return vs return await in a try/catch block', function () {
+    context('❌ Anti-pattern: return a promise without awaiting it', function () {
+      it('loses the current function from the stack trace and never runs the catch block', async function () {
+        async function levelOne() {
+          await new Promise((resolve) => setTimeout(resolve, 10));
+          throw new Error('boom');
+        }
+
+        let catchBlockExecuted = false;
+        async function levelTwo() {
+          try {
+            return levelOne();
+          } catch (err) {
+            catchBlockExecuted = true;
+            throw err;
+          }
+        }
+
+        const stack = await getStack(() => levelTwo());
+        expect(stack).to.include('levelOne').and.to.not.include('levelTwo');
+        expect(catchBlockExecuted).to.be.false;
+      });
+    });
+    context('✅ Good pattern: return a promise by awaiting it first', function () {
+      it('keeps the full stack trace and run through the catch block', async function () {
+        async function levelOne() {
+          await new Promise((resolve) => setTimeout(resolve, 10));
+          throw new Error('boom');
+        }
+
+        let catchBlockExecuted = false;
+        async function levelTwo() {
+          try {
+            return await levelOne();
+          } catch (err) {
+            catchBlockExecuted = true;
+            throw err;
+          }
+        }
+
+        const stack = await getStack(() => levelTwo());
+        expect(stack).to.include('levelOne').and.to.include('levelTwo');
+        expect(catchBlockExecuted).to.be.true;
+      });
+    });
+  });
+});


### PR DESCRIPTION
## ❄️ Problème

En faisant ma petite veille (et pas petite vieille, merci) j'ai appris des petits trucs concernant la gestion de la stack trace en cas d'erreur dans un code asynchrone.

Si une fonction `fncA` appelle une autre fonction `fncB` asynchrone, et que `fncA` retourne directement la promesse sans attendre sa résolution, alors en cas d'erreur dans la promesse on perd une partie de l'historique réel de la stack trace : comme si `fncA` n'avait jamais été appelée 😮 

```js
async function fncB() {
  await new Promise((resolve) => setTimeout(resolve, 10));
  throw new Error('boom');
}

function fncA() {
  return fncB();
}

await fncA(); // BOOM
```

Stacktrace :
```
Error: boom
    at fncB (file:///some/file.js:1:17)
    at async Context.<anonymous> (file:///some/other/place.js)
```

alors qu'en attendant la résolution de la promesse dans la `fncA` elle s'ajoute alors à la pile des promesses et apparaît dans la stack trace en cas d'erreur : 

```js
async function fncB() {
  await new Promise((resolve) => setTimeout(resolve, 10));
  throw new Error('boom');
}

async function fncA() {
  return await fncB();
}

await fncA(); // BOOM
```

Stacktrace :
```
Error: boom
    at fncB (file:///some/file.js:1:17)
    at fncA (file:///some/file.js:6:17)
    at async Context.<anonymous> (file:///some/other/place.js)
```

## 🛷 Proposition

Pour documenter en ayant quelque chose de dynamique et actionnable en local, je me disais que c'était rigolo d'ajouter des tests pour illustrer tout cela.
Ce sont des tests unitaires donc ça me paraît indolore.

Aussi, même si pour les puristes de la perf ça peut sembler être un anti-pattern de mettre un `return await `systématiquement, de ce que j'ai compris : 
- le petit tick supplémentaire que cela induit me paraît pas grave en comparaison du gain de compréhension en debuggage
- ça reste une bonne pratique, en particulier pour le cas du try/catch, où là on ne parle pas seulement de perdre un bout de stack trace, mais de carrément by-passer le bloc du catch (je vous laisse découvrir de quoi il s'agit en allant lire le test associé)

## ☃️ Remarques

Si vous avez d'autres idées de où les mettre n'hésitez pas, et si vous avez appris quelque chose mettez un petit pouce 🤗 

## 🧑‍🎄 Pour tester

Lancer le fichier de test ajouté dans les tests unitaires. Si vous êtes curieux, décommentez les lignes de console.log() !
