### PR TITLE
[TECH] Remplacer le hack JSON.parse(JSON.stringify()) par la fonction native structuredClone pour dupliquer un objet

### DIFF
--- a/api/src/devcomp/infrastructure/serializers/jsonapi/training-serializer.js
+++ b/api/src/devcomp/infrastructure/serializers/jsonapi/training-serializer.js
@@ -10,7 +10,7 @@ const serializeForAdmin = function (training = {}, meta) {
       duration.hours = duration.hours || 0;
       duration.minutes = duration.minutes || 0;
 
-      return JSON.parse(JSON.stringify({ ...record, isRecommendable: record.isRecommendable }));
+      return structuredClone({ ...record, isRecommendable: record.isRecommendable });
     },
     attributes: [
       'id',

--- a/api/src/devcomp/infrastructure/serializers/jsonapi/training-trigger-serializer.js
+++ b/api/src/devcomp/infrastructure/serializers/jsonapi/training-trigger-serializer.js
@@ -5,7 +5,7 @@ const { Serializer, Deserializer } = jsonapiSerializer;
 const serialize = function (trainingTrigger = {}, meta) {
   return new Serializer('training-triggers', {
     transform(record) {
-      return JSON.parse(JSON.stringify(record));
+      return structuredClone(record);
     },
     attributes: ['id', 'trainingId', 'type', 'threshold', 'areas', 'tubesCount'],
     areas: {


### PR DESCRIPTION
## ❄️ Problème

Pour cloner rapidement un objet, pendant longtemps le trick qui marchait bien c'était :
```js
JSON.parse(JSON.stringify(myObj))
```

Depuis quelques temps déjà a été introduit une fonction native qui fait mieux le travail ! `structuredClone(myObj)`

## 🛷 Proposition

Remplacer le vieux hack JSON par la fonction native.

## ☃️ Remarques

C'est mieux car :
- Plus de data types sont gérés : `Map`, `Set`, `Date`, `RegExp`, les références circulaires...
- La fonction est native donc optimisée et surtout pensée exprès pour cet usage !

Attention cela dit elle ne fait pas encore le café ! Elle ne permet pas de cloner une instance de classe où plus généralement tout objet héritant de comportements provenant d'un prototype

## 🧑‍🎄 Pour tester

Tests autos ok
