### PR TITLE
[TECH] Remplace le groupBy de lodash par le Object.groupBy() natif de JS

### DIFF
--- a/api/src/certification/results/domain/read-models/CertifiedBadge.js
+++ b/api/src/certification/results/domain/read-models/CertifiedBadge.js
@@ -10,9 +10,10 @@ class CertifiedBadge {
   }
 
   static fromComplementaryCertificationCourseResults(complementaryCertificationCourseResults) {
-    const complementaryCertificationCourseResultsByComplementaryCertificationCourseId = _.groupBy(
+    const complementaryCertificationCourseResultsByComplementaryCertificationCourseId = Object.groupBy(
       complementaryCertificationCourseResults,
-      'complementaryCertificationCourseId',
+      (complementaryCertificationCourseResult) =>
+        complementaryCertificationCourseResult.complementaryCertificationCourseId,
     );
 
     return Object.values(complementaryCertificationCourseResultsByComplementaryCertificationCourseId)

--- a/api/src/certification/results/infrastructure/repositories/certificate-repository.js
+++ b/api/src/certification/results/infrastructure/repositories/certificate-repository.js
@@ -236,7 +236,7 @@ function _checkOrganizationIsScoIsManagingStudents(qb) {
 }
 
 function _filterMostRecentCertificationCoursePerOrganizationLearner(DTOs) {
-  const groupedByOrganizationLearner = _.groupBy(DTOs, 'organizationLearnerId');
+  const groupedByOrganizationLearner = Object.groupBy(DTOs, (DTO) => DTO.organizationLearnerId);
 
   const mostRecent = [];
   for (const certificationsForOneOrganizationLearner of Object.values(groupedByOrganizationLearner)) {

--- a/api/src/certification/results/infrastructure/repositories/certified-profile-repository.js
+++ b/api/src/certification/results/infrastructure/repositories/certified-profile-repository.js
@@ -1,5 +1,3 @@
-import _ from 'lodash';
-
 import { knex } from '../../../../../db/knex-database-connection.js';
 import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { FRENCH_SPOKEN } from '../../../../shared/domain/services/locale-service.js';
@@ -75,8 +73,8 @@ async function _createCertifiedSkills(skillIds, askedSkillIds) {
 }
 
 async function _createCertifiedTubes(certifiedSkills) {
-  const certifiedSkillsByTube = _.groupBy(certifiedSkills, 'tubeId');
-  const tubes = await tubeRepository.findByRecordIds(Object.keys(certifiedSkillsByTube), FRENCH_SPOKEN);
+  const tubeIds = [...new Set(certifiedSkills.map((certifiedSkill) => certifiedSkill.tubeId))];
+  const tubes = await tubeRepository.findByRecordIds(tubeIds, FRENCH_SPOKEN);
   return tubes.map((tube) => {
     const name = tube.practicalTitle;
     return new CertifiedTube({
@@ -88,9 +86,9 @@ async function _createCertifiedTubes(certifiedSkills) {
 }
 
 async function _createCertifiedCompetences(certifiedTubes) {
-  const certifiedTubesByCompetence = _.groupBy(certifiedTubes, 'competenceId');
+  const competenceIds = [...new Set(certifiedTubes.map((certifiedTube) => certifiedTube.competenceId))];
   const competences = await competenceRepository.findByRecordIds({
-    competenceIds: Object.keys(certifiedTubesByCompetence),
+    competenceIds,
     locale: FRENCH_SPOKEN,
   });
   return competences.map((competence) => {
@@ -105,9 +103,9 @@ async function _createCertifiedCompetences(certifiedTubes) {
 }
 
 async function _createCertifiedAreas(certifiedCompetences) {
-  const certifiedCompetencesByArea = _.groupBy(certifiedCompetences, 'areaId');
+  const areaIds = [...new Set(certifiedCompetences.map((certifiedCompetence) => certifiedCompetence.areaId))];
   const areas = await areaRepository.findByRecordIds({
-    areaIds: Object.keys(certifiedCompetencesByArea),
+    areaIds,
     locale: FRENCH_SPOKEN,
   });
   return areas.map((area) => {

--- a/api/src/devcomp/domain/usecases/find-tutorials.js
+++ b/api/src/devcomp/domain/usecases/find-tutorials.js
@@ -66,7 +66,7 @@ function _getEasiestSkills(skillsGroupByTube) {
 }
 
 function _getSkillsGroupedByTube(failedSkills) {
-  const sortedSkills = [...failedSkills].sort((a, b) => a.difficulty - b.difficulty);
+  const sortedSkills = failedSkills.toSorted((a, b) => a.difficulty - b.difficulty);
 
   const uniqueSkills = Array.from(new Set(sortedSkills));
 

--- a/api/src/devcomp/domain/usecases/find-tutorials.js
+++ b/api/src/devcomp/domain/usecases/find-tutorials.js
@@ -70,7 +70,7 @@ function _getSkillsGroupedByTube(failedSkills) {
 
   const uniqueSkills = Array.from(new Set(sortedSkills));
 
-  return Object.groupBy(uniqueSkills, (skill) => skill.tubeName);
+  return Object.groupBy(uniqueSkills, (uniqueSkill) => uniqueSkill.tubeName);
 }
 
 function _getFailedSkills(skills, invalidatedDirectKnowledgeElements) {

--- a/api/src/devcomp/domain/usecases/find-tutorials.js
+++ b/api/src/devcomp/domain/usecases/find-tutorials.js
@@ -66,7 +66,11 @@ function _getEasiestSkills(skillsGroupByTube) {
 }
 
 function _getSkillsGroupedByTube(failedSkills) {
-  return _.groupBy(_(_.orderBy(failedSkills, 'difficulty')).uniq().value(), 'tubeName');
+  const sortedSkills = [...failedSkills].sort((a, b) => a.difficulty - b.difficulty);
+
+  const uniqueSkills = Array.from(new Set(sortedSkills));
+
+  return Object.groupBy(uniqueSkills, (skill) => skill.tubeName);
 }
 
 function _getFailedSkills(skills, invalidatedDirectKnowledgeElements) {

--- a/api/src/devcomp/infrastructure/repositories/training-trigger-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/training-trigger-repository.js
@@ -1,5 +1,3 @@
-import _ from 'lodash';
-
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../shared/domain/errors.js';
 import * as areaRepository from '../../../shared/infrastructure/repositories/area-repository.js';
@@ -162,13 +160,13 @@ async function _toDomainForAdmin({ trainingTrigger, triggerTubes }) {
 }
 
 async function _getLearningContent(tubes, locale = 'fr-fr') {
-  const thematicIds = _.keys(_.groupBy(tubes, 'thematicId'));
+  const thematicIds = [...new Set(tubes.map((t) => t.thematicId))];
   const thematics = await thematicRepository.findByRecordIds(thematicIds, locale);
 
-  const competenceIds = _.keys(_.groupBy(thematics, 'competenceId'));
+  const competenceIds = [...new Set(thematics.map((t) => t.competenceId))];
   const competences = await competenceRepository.findByRecordIds({ competenceIds, locale });
 
-  const areaIds = _.keys(_.groupBy(competences, 'areaId'));
+  const areaIds = [...new Set(competences.map((c) => c.areaId))];
   const areas = await areaRepository.findByRecordIds({ areaIds, locale });
 
   return {

--- a/api/src/evaluation/infrastructure/repositories/competence-evaluation-repository.js
+++ b/api/src/evaluation/infrastructure/repositories/competence-evaluation-repository.js
@@ -138,7 +138,10 @@ async function _getByCompetenceIdAndUserId({ competenceId, userId, forUpdate = f
 }
 
 function _selectOnlyOneCompetenceEvaluationByCompetence(competenceEvaluations) {
-  const assessmentsGroupedByCompetence = _.groupBy(competenceEvaluations, 'competenceId');
+  const assessmentsGroupedByCompetence = Object.groupBy(
+    competenceEvaluations,
+    (competenceEvaluation) => competenceEvaluation.competenceId,
+  );
   return _.map(assessmentsGroupedByCompetence, _.head);
 }
 

--- a/api/src/prescription/campaign/domain/read-models/CampaignAnalysis.js
+++ b/api/src/prescription/campaign/domain/read-models/CampaignAnalysis.js
@@ -72,7 +72,7 @@ class CampaignTubeRecommendation {
   }
 
   add({ knowledgeElements = [] }) {
-    const knowledgeElementsByParticipant = Object.values(Object.groupBy(knowledgeElements, (ke) => ke.userId));
+    const knowledgeElementsByParticipant = Object.values(Object.groupBy(knowledgeElements, (knowledgeElement) => knowledgeElement.userId));
     this._computeCumulativeScore(knowledgeElementsByParticipant);
     this.cumulativeParticipantCount += knowledgeElementsByParticipant.length;
   }

--- a/api/src/prescription/campaign/domain/read-models/CampaignAnalysis.js
+++ b/api/src/prescription/campaign/domain/read-models/CampaignAnalysis.js
@@ -72,7 +72,9 @@ class CampaignTubeRecommendation {
   }
 
   add({ knowledgeElements = [] }) {
-    const knowledgeElementsByParticipant = Object.values(Object.groupBy(knowledgeElements, (knowledgeElement) => knowledgeElement.userId));
+    const knowledgeElementsByParticipant = Object.values(
+      Object.groupBy(knowledgeElements, (knowledgeElement) => knowledgeElement.userId),
+    );
     this._computeCumulativeScore(knowledgeElementsByParticipant);
     this.cumulativeParticipantCount += knowledgeElementsByParticipant.length;
   }

--- a/api/src/prescription/campaign/domain/read-models/CampaignAnalysis.js
+++ b/api/src/prescription/campaign/domain/read-models/CampaignAnalysis.js
@@ -72,7 +72,7 @@ class CampaignTubeRecommendation {
   }
 
   add({ knowledgeElements = [] }) {
-    const knowledgeElementsByParticipant = _.toArray(_.groupBy(knowledgeElements, 'userId'));
+    const knowledgeElementsByParticipant = Object.values(Object.groupBy(knowledgeElements, (ke) => ke.userId));
     this._computeCumulativeScore(knowledgeElementsByParticipant);
     this.cumulativeParticipantCount += knowledgeElementsByParticipant.length;
   }

--- a/api/src/prescription/learner-management/infrastructure/repositories/student-repository.js
+++ b/api/src/prescription/learner-management/infrastructure/repositories/student-repository.js
@@ -5,7 +5,7 @@ import { Student } from '../../../../shared/domain/models/Student.js';
 
 const _toStudents = function (results) {
   const students = [];
-  const resultsGroupedByNatId = _.groupBy(results, 'nationalStudentId');
+  const resultsGroupedByNatId = Object.groupBy(results, (result) => result.nationalStudentId);
   for (const [nationalStudentId, accounts] of Object.entries(resultsGroupedByNatId)) {
     const mostRelevantAccount = _.orderBy(accounts, ['certificationCount', 'updatedAt'], ['desc', 'desc'])[0];
     students.push(

--- a/api/src/prescription/target-profile/infrastructure/repositories/target-profile-administration-repository.js
+++ b/api/src/prescription/target-profile/infrastructure/repositories/target-profile-administration-repository.js
@@ -17,6 +17,7 @@ import * as tubeRepository from '../../../../shared/infrastructure/repositories/
 import { logger } from '../../../../shared/infrastructure/utils/logger.js';
 import { StageCollection } from '../../domain/models/StageCollection.js';
 import { TargetProfileSummaryForAdmin } from '../../domain/models/TargetProfileSummaryForAdmin.js';
+
 const TARGET_PROFILE_TABLE = 'target-profiles';
 
 const get = async function ({ id, locale = FRENCH_FRANCE }) {
@@ -181,13 +182,13 @@ async function _getLearningContent(targetProfileId, tubesData, locale) {
     );
   }
 
-  const thematicIds = _.keys(_.groupBy(tubes, 'thematicId'));
+  const thematicIds = [...new Set(tubes.map((t) => t.thematicId))];
   const thematics = await thematicRepository.findByRecordIds(thematicIds, locale);
 
-  const competenceIds = _.keys(_.groupBy(thematics, 'competenceId'));
+  const competenceIds = [...new Set(thematics.map((t) => t.competenceId))];
   const competences = await competenceRepository.findByRecordIds({ competenceIds, locale });
 
-  const areaIds = _.keys(_.groupBy(competences, 'areaId'));
+  const areaIds = [...new Set(competences.map((c) => c.areaId))];
   const areas = await areaRepository.findByRecordIds({ areaIds, locale });
 
   for (const tube of tubes) {

--- a/api/src/school/infrastructure/repositories/mission-assessment-repository.js
+++ b/api/src/school/infrastructure/repositories/mission-assessment-repository.js
@@ -1,5 +1,3 @@
-import _ from 'lodash';
-
 import { knex } from '../../../../db/knex-database-connection.js';
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { Assessment } from '../../../shared/domain/models/Assessment.js';
@@ -52,8 +50,12 @@ async function _getMissionAssessmentsByLearnerId(missionId, organizationLearnerI
     .join('assessments', 'assessments.id', 'mission-assessments.assessmentId')
     .where({ missionId })
     .whereIn('mission-assessments.organizationLearnerId', organizationLearnerIds);
-
-  return Object.entries(_.groupBy(organizationLearnerAssessments, 'organizationLearnerId'));
+  return Object.entries(
+    Object.groupBy(
+      organizationLearnerAssessments,
+      (organizationLearnerAssessment) => organizationLearnerAssessment.organizationLearnerId,
+    ),
+  );
 }
 
 const _byDescendingCreatedAt = (assessmentA, assessmentB) => assessmentB.createdAt - assessmentA.createdAt;
@@ -70,7 +72,10 @@ const getStatusesForLearners = async function (missionId, organizationLearners) 
   });
 
   const decoratedMissionLearners = [];
-  const lastRelevantAssessmentByLearnerId = _.groupBy(lastRelevantAssessments, 'organizationLearnerId');
+  const lastRelevantAssessmentByLearnerId = Object.groupBy(
+    lastRelevantAssessments,
+    (lastRelevantAssessment) => lastRelevantAssessment.organizationLearnerId,
+  );
 
   for (const organizationLearner of organizationLearners) {
     const [organizationLearnerInfo] = lastRelevantAssessmentByLearnerId[`${organizationLearner.id}`] ?? [];

--- a/api/src/shared/domain/models/KnowledgeElement.js
+++ b/api/src/shared/domain/models/KnowledgeElement.js
@@ -145,7 +145,10 @@ function _enrichDirectKnowledgeElementWithInferredKnowledgeElements({
   targetSkills,
   userId,
 }) {
-  const targetSkillsGroupedByTubeName = _.groupBy(targetSkills, (skill) => skill.tubeNameWithoutPrefix);
+  const targetSkillsGroupedByTubeName = Object.groupBy(
+    targetSkills,
+    (targetSkill) => targetSkill.tubeNameWithoutPrefix,
+  );
   const status = answer.isOk() ? statuses.VALIDATED : statuses.INVALIDATED;
 
   if (directKnowledgeElement) {

--- a/api/src/shared/infrastructure/repositories/assessment-repository.js
+++ b/api/src/shared/infrastructure/repositories/assessment-repository.js
@@ -5,7 +5,7 @@ import { DomainTransaction } from '../../domain/DomainTransaction.js';
 import { NotFoundError } from '../../domain/errors.js';
 import { Assessment } from '../../domain/models/Assessment.js';
 
-const { groupBy, map, head, uniqBy, omit } = lodash;
+const { uniqBy, omit } = lodash;
 
 const getWithAnswers = async function (id) {
   const knexConn = DomainTransaction.getConnection();
@@ -49,7 +49,7 @@ const findLastCompletedAssessmentsForEachCompetenceByUser = async function (user
     .where('assessment-results.createdAt', '<', limitDate)
     .where('assessments.state', '=', 'completed')
     .orderBy('assessments.createdAt', 'desc');
-  return _selectLastAssessmentForEachCompetence(lastCompletedAssessments).map(
+  return _selectMostRecentAssessmentForEachCompetence(lastCompletedAssessments).map(
     (assessment) => new Assessment(assessment),
   );
 };
@@ -221,9 +221,9 @@ export {
   updateWhenNewChallengeIsAsked,
 };
 
-function _selectLastAssessmentForEachCompetence(assessments) {
-  const assessmentsGroupedByCompetence = groupBy(assessments, (assessment) => assessment.competenceId);
-  return map(assessmentsGroupedByCompetence, head);
+function _selectMostRecentAssessmentForEachCompetence(assessments) {
+  const groupedByCompetence = Object.groupBy(assessments, (a) => a.competenceId);
+  return Object.values(groupedByCompetence).map((group) => group[0]);
 }
 
 function _adaptModelToDb(assessment) {

--- a/api/src/shared/infrastructure/repositories/assessment-repository.js
+++ b/api/src/shared/infrastructure/repositories/assessment-repository.js
@@ -222,8 +222,8 @@ export {
 };
 
 function _selectMostRecentAssessmentForEachCompetence(assessments) {
-  const groupedByCompetence = Object.groupBy(assessments, (a) => a.competenceId);
-  return Object.values(groupedByCompetence).map((group) => group[0]);
+  const assessmentsGroupedByCompetence = Object.groupBy(assessments, (assessment) => assessment.competenceId);
+  return Object.values(assessmentsGroupedByCompetence).map((group) => group[0]);
 }
 
 function _adaptModelToDb(assessment) {

--- a/api/src/shared/infrastructure/repositories/badge-for-calculation-repository.js
+++ b/api/src/shared/infrastructure/repositories/badge-for-calculation-repository.js
@@ -23,13 +23,13 @@ const findByCampaignParticipationId = async function ({ campaignParticipationId 
     .select(['id', 'threshold', 'badgeId', 'scope', 'cappedTubes'])
     .whereIn('badgeId', badgeIds)
     .orderBy('badge-criteria.id');
-  const badgeCriteriaDTOByBadge = _.groupBy(badgeCriteriaDTO, 'badgeId');
+  const badgeCriteriaDTOByBadge = Object.groupBy(badgeCriteriaDTO, (badgeCriterionDTO) => badgeCriterionDTO.badgeId);
 
   const campaignSkills = await campaignRepository.findSkillsByCampaignParticipationId({
     campaignParticipationId,
   });
   const campaignSkillIds = campaignSkills.map(({ id }) => id);
-  const campaignSkillsByTube = _.groupBy(campaignSkills, 'tubeId');
+  const campaignSkillsByTube = Object.groupBy(campaignSkills, (campaignSkill) => campaignSkill.tubeId);
 
   const badges = [];
   for (const badgeDTO of badgesDTO) {
@@ -59,13 +59,13 @@ const findByCampaignId = async function ({ campaignId }) {
     .select(['id', 'threshold', 'badgeId', 'scope', 'cappedTubes'])
     .whereIn('badgeId', badgeIds)
     .orderBy('badge-criteria.id');
-  const badgeCriteriaDTOByBadge = _.groupBy(badgeCriteriaDTO, 'badgeId');
+  const badgeCriteriaDTOByBadge = Object.groupBy(badgeCriteriaDTO, (badgeCriterionDTO) => badgeCriterionDTO.badgeId);
 
   const campaignSkills = await campaignRepository.findSkills({
     campaignId,
   });
   const campaignSkillIds = campaignSkills.map(({ id }) => id);
-  const campaignSkillsByTube = _.groupBy(campaignSkills, 'tubeId');
+  const campaignSkillsByTube = Object.groupBy(campaignSkills, (campaignSkill) => campaignSkill.tubeId);
 
   const badges = [];
   for (const badgeDTO of badgesDTO) {
@@ -104,7 +104,7 @@ const getByCertifiableBadgeAcquisition = async function ({ certifiableBadgeAcqui
     campaignId,
   });
   const campaignSkillIds = campaignSkills.map(({ id }) => id);
-  const campaignSkillsByTube = _.groupBy(campaignSkills, 'tubeId');
+  const campaignSkillsByTube = Object.groupBy(campaignSkills, (campaignSkill) => campaignSkill.tubeId);
 
   return _buildBadge(knexConn, campaignSkillsByTube, campaignSkillIds, badgeCriteriaDTO, badgeDTO);
 };

--- a/api/src/shared/infrastructure/repositories/knowledge-element-repository.js
+++ b/api/src/shared/infrastructure/repositories/knowledge-element-repository.js
@@ -70,7 +70,7 @@ const findUniqByUserIdAndCompetenceId = async function ({ userId, competenceId }
 
 const findUniqByUserIdGroupedByCompetenceId = async function ({ userId, limitDate }) {
   const knowledgeElements = await findUniqByUserId({ userId, limitDate });
-  return Object.groupBy(knowledgeElements, (ke) => ke.competenceId);
+  return Object.groupBy(knowledgeElements, (knowledgeElement) => knowledgeElement.competenceId);
 };
 
 const findInvalidatedAndDirectByUserId = async function ({ userId }) {

--- a/api/src/shared/infrastructure/repositories/knowledge-element-repository.js
+++ b/api/src/shared/infrastructure/repositories/knowledge-element-repository.js
@@ -1,5 +1,3 @@
-import _ from 'lodash';
-
 import { KnowledgeElementCollection } from '../../../prescription/shared/domain/models/KnowledgeElementCollection.js';
 import { DomainTransaction } from '../../domain/DomainTransaction.js';
 import { KnowledgeElement } from '../../domain/models/KnowledgeElement.js';
@@ -72,7 +70,7 @@ const findUniqByUserIdAndCompetenceId = async function ({ userId, competenceId }
 
 const findUniqByUserIdGroupedByCompetenceId = async function ({ userId, limitDate }) {
   const knowledgeElements = await findUniqByUserId({ userId, limitDate });
-  return _.groupBy(knowledgeElements, 'competenceId');
+  return Object.groupBy(knowledgeElements, (ke) => ke.competenceId);
 };
 
 const findInvalidatedAndDirectByUserId = async function ({ userId }) {


### PR DESCRIPTION
## ❄️ Problème

JS intègre de plus en plus de fonctions natives qui permettent de retirer des usages de lodash.

## 🛷 Proposition
Retrait des `_.groupBy()` au profit de `Object.groupBy()`

## ☃️ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🧑‍🎄 Pour tester

Tests CI OK
