### PR TITLE
[TECH] Ajoute l'équipe Data dans le fichier `codeowner` pour leur signaler les changements de base de données

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -101,3 +101,6 @@
 /api/db/migrations/ @1024pix/team-captains
 /api/datamart/migrations/ @1024pix/team-captains
 
+# Directories that potentially concern Data's team
+/api/db/migrations/ @1024pix/team-data
+/api/datamart/migrations/ @1024pix/team-data


### PR DESCRIPTION
## ❄️ Problème

Parfois, nous, les équipes de développement, ne pensons pas à prévenir l'équipe Data de changements de schéma de base de donnée.


## 🛷 Proposition

Ajouter l'équipe Data au fichier `CODEOWNERS` . L'idée n'est pas de les désigner comme responsable de ce bout de code là, mais de faire en sorte que l'équipe soit informée des changements de schéma.

## ☃️ Remarques



## 🧑‍🎄 Pour tester
