### PR TITLE
[TECH] Correction de balises HTML dans les modules pour les textes à trous (PIX-21233).

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYPhishing_IND.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYPhishing_IND.json
@@ -596,13 +596,13 @@
                   },
                   {
                     "type": "text",
-                    "content": "<p>pour vous voler de l’argent ou escroquer vos proches.</p>"
+                    "content": "<span>pour vous voler de l’argent ou escroquer vos proches.</span>"
                   }
                 ],
                 "feedbacks": {
                   "valid": {
                     "state": "<p>Bonne réponse !</p>",
-                    "diagnosis": "<p>Vous avez correctement  identifié les caractéristiques des messages de phishing.</p>"
+                    "diagnosis": "<p>Vous avez correctement identifié les caractéristiques des messages de phishing.</p>"
                   },
                   "invalid": {
                     "state": "<p>Mauvaise réponse.</p>",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IADefinition_IND.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IADefinition_IND.json
@@ -795,7 +795,7 @@
                 "proposals": [
                   {
                     "type": "text",
-                    "content": "<p><strong>\"L’ail des ours peut se manger en ____\" </strong></p>"
+                    "content": "<span><strong>\"L’ail des ours peut se manger en ____\" </strong></span>"
                   },
                   {
                     "input": "627e8063-9059-4bd6-9492-396cfb983c48",
@@ -820,7 +820,7 @@
                   },
                   {
                     "type": "text",
-                    "content": "<p><strong>Salade</strong><br></p>"
+                    "content": "<span><strong>Salade</strong></span>"
                   },
                   {
                     "input": "1c91ad6e-adfd-432b-9aa1-0ce28a06dda0",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/NR-Datacenter-NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/NR-Datacenter-NOV.json
@@ -822,7 +822,7 @@
                 "proposals": [
                   {
                     "type": "text",
-                    "content": "<p>La demande d’information part&nbsp;</p>"
+                    "content": "<span>La demande d’information part&nbsp;</span>"
                   },
                   {
                     "input": "a",
@@ -851,7 +851,7 @@
                   },
                   {
                     "type": "text",
-                    "content": "<p>pour aller dans&nbsp;</p>"
+                    "content": "<span>pour aller dans&nbsp;</span>"
                   },
                   {
                     "input": "b",
@@ -880,7 +880,7 @@
                   },
                   {
                     "type": "text",
-                    "content": "<p>où se trouvent des&nbsp;</p>"
+                    "content": "<span>où se trouvent des&nbsp;</span>"
                   },
                   {
                     "input": "c",
@@ -909,7 +909,7 @@
                   },
                   {
                     "type": "text",
-                    "content": "<p>. Une fois la demande traitée, la réponse revient vers&nbsp;</p>"
+                    "content": "<span>. Une fois la demande traitée, la réponse revient vers&nbsp;</span>"
                   },
                   {
                     "input": "d",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/NR_Evaluation_IND.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/NR_Evaluation_IND.json
@@ -671,7 +671,7 @@
                 "proposals": [
                   {
                     "type": "text",
-                    "content": "<p>Pour évaluer les impacts environnementaux du numérique, on utilise une méthode appelée&nbsp;</p>"
+                    "content": "<span>Pour évaluer les impacts environnementaux du numérique, on utilise une méthode appelée&nbsp;</span>"
                   },
                   {
                     "input": "a",
@@ -702,7 +702,7 @@
                   },
                   {
                     "type": "text",
-                    "content": "<p>. Cette méthode consiste à analyser&nbsp;</p>"
+                    "content": "<span>. Cette méthode consiste à analyser&nbsp;</span>"
                   },
                   {
                     "input": "b",
@@ -731,7 +731,7 @@
                   },
                   {
                     "type": "text",
-                    "content": "<p>d’un équipement. Les résultats dépendent du&nbsp;</p>"
+                    "content": "<span>d’un équipement. Les résultats dépendent du&nbsp;</span>"
                   },
                   {
                     "input": "c",
@@ -760,7 +760,7 @@
                   },
                   {
                     "type": "text",
-                    "content": "<p>et de l’&nbsp;</p>"
+                    "content": "<span>et de l’&nbsp;</span>"
                   },
                   {
                     "input": "d",
@@ -789,7 +789,7 @@
                   },
                   {
                     "type": "text",
-                    "content": "<p>. C’est pourquoi un chiffre sur l’impact du numérique doit toujours être&nbsp;</p>"
+                    "content": "<span>. C’est pourquoi un chiffre sur l’impact du numérique doit toujours être&nbsp;</span>"
                   },
                   {
                     "input": "e",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/galerie.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/galerie.json
@@ -636,7 +636,7 @@
                   },
                   {
                     "type": "text",
-                    "content": "<p><span>d'intérêt public qui a été créé en</span></p>"
+                    "content": "<span>d'intérêt public qui a été créé en</span>"
                   },
                   {
                     "input": "pix-birth",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/tri-multicritere-tableau.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/tri-multicritere-tableau.json
@@ -328,7 +328,7 @@
                 "proposals": [
                   {
                     "type": "text",
-                    "content": "<p>Le deuxième au classement est</p>"
+                    "content": "<span>Le deuxième au classement est</span>"
                   },
                   {
                     "input": "prenom-activite",
@@ -347,7 +347,7 @@
                   },
                   {
                     "type": "text",
-                    "content": "<p>Les vainqueurs remportent une</p>"
+                    "content": "<span>. Les vainqueurs remportent une</span>"
                   },
                   {
                     "input": "lot-activite",
@@ -529,7 +529,7 @@
                 "proposals": [
                   {
                     "type": "text",
-                    "content": "<p>Le prénom du deuxième est :</p>"
+                    "content": "<span>Le prénom du deuxième est :</span>"
                   },
                   {
                     "input": "prenom-boss",
@@ -548,7 +548,7 @@
                   },
                   {
                     "type": "text",
-                    "content": "<p>Le contenu du trésor est :</p>"
+                    "content": "<span>. Le contenu du trésor est :</span>"
                   },
                   {
                     "input": "tresor-boss",


### PR DESCRIPTION
## ❄️ Problème

Des balises `<p>` étaient automatiquement ajouté dans les modules lors de leur création ou mise à jour. (traité ici https://github.com/1024pix/modulix-editor/pull/31). Cela a une incidence sur les elements avec texte à trous.

Les élément textes à trous portent un paramètre `display:"inline"` pour ne pas que les champs reviennent à la la ligne. Mais les `<p>` imposent pas définition un retour à la ligne.

## 🛷 Proposition

Nettoyer les quelques modules ayant dans leurs éléments des balises `<p>` alors que les champs sont en display: "inline".

## 🧑‍🎄 Pour tester

Texte à trous en échec : 

| https://app.integration.pix.fr/modules/preview/centre-de-donnee-novice | https://app-pr14993.review.pix.fr/modules/preview/centre-de-donnee-novice |
|--------|--------|
| <img width="423" height="288" alt="Capture d’écran 2026-02-05 à 11 39 33" src="https://github.com/user-attachments/assets/4a64d897-66c7-4d7d-9b1d-123c09c28dc7" /> | <img width="637" height="247" alt="Capture d’écran 2026-02-05 à 11 41 10" src="https://github.com/user-attachments/assets/77b43cd5-7a61-4d4b-9aab-4fe2bff42ad2" /> |


| https://app.integration.pix.fr/modules/preview/anatomie-message-arnaque | https://app-pr14993.review.pix.fr/modules/preview/anatomie-message-arnaque |
|--------|--------|
| <img width="769" height="241" alt="Capture d’écran 2026-02-05 à 17 46 46" src="https://github.com/user-attachments/assets/980aa949-30cb-46d8-b1c3-60e49976fc0a" /> | <img width="799" height="248" alt="Capture d’écran 2026-02-05 à 17 47 08" src="https://github.com/user-attachments/assets/00791ab2-94ed-4fd3-b711-7996fde3c98b" /> |

| https://app.integration.pix.fr/modules/preview/evaluation-impacts-environnementaux-numerique | https://app-pr14993.review.pix.fr/modules/preview/evaluation-impacts-environnementaux-numerique |
|--------|--------|
 | <img width="727" height="498" alt="Capture d’écran 2026-02-05 à 17 48 20" src="https://github.com/user-attachments/assets/84bf5f80-71e2-40cf-924a-1d763bfdb7eb" />  | <img width="783" height="353" alt="Capture d’écran 2026-02-05 à 17 48 37" src="https://github.com/user-attachments/assets/5f381385-3a64-412e-bc15-3830029fd111" />  |


| https://app.integration.pix.fr/modules/preview/tri-multicritere-tableau | https://app-pr14993.review.pix.fr/modules/preview/tri-multicritere-tableau |
|--------|--------|
| <img width="491" height="222" alt="Capture d’écran 2026-02-05 à 17 50 55" src="https://github.com/user-attachments/assets/69cc195d-f991-4c5e-97ab-df243a73c58d" /> | <img width="764" height="134" alt="Capture d’écran 2026-02-05 à 17 52 01" src="https://github.com/user-attachments/assets/97263fb9-80dd-401b-a26c-f84322116f99" /> |
| <img width="475" height="252" alt="Capture d’écran 2026-02-05 à 17 51 04" src="https://github.com/user-attachments/assets/6ee15fa2-469c-4299-b2bc-a6ce7098307e" /> | <img width="788" height="160" alt="Capture d’écran 2026-02-05 à 17 52 21" src="https://github.com/user-attachments/assets/c98444b8-47e2-4275-bd82-63aaa264b916" /> |


| https://app.integration.pix.fr/modules/preview/ia-def-ind | https://app-pr14993.review.pix.fr/modules/preview/ia-def-ind |
|--------|--------|
 | <img width="297" height="163" alt="Capture d’écran 2026-02-05 à 17 55 40" src="https://github.com/user-attachments/assets/7f485f01-2fb5-4d39-b8dc-fbc46b005996" />  |   |
