### PR TITLE
[TECH] Utiliser la DomainTransaction dans les repository des Bounded Context Prescription (PIX-21411).

### DIFF
--- a/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-assessment-participation-result-repository.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-assessment-participation-result-repository.js
@@ -1,4 +1,4 @@
-import { knex } from '../../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../../shared/domain/errors.js';
 import * as knowledgeElementSnapshotRepository from '../../../campaign/infrastructure/repositories/knowledge-element-snapshot-repository.js';
 import * as learningContentRepository from '../../../shared/infrastructure/repositories/learning-content-repository.js';
@@ -20,7 +20,9 @@ async function _fetchCampaignAssessmentParticipationResultAttributesFromCampaign
   campaignId,
   campaignParticipationId,
 ) {
-  const [campaignAssessmentParticipationResult] = await knex
+  const knexConn = DomainTransaction.getConnection();
+
+  const [campaignAssessmentParticipationResult] = await knexConn
     .with('campaignAssessmentParticipationResult', (qb) => {
       qb.select([
         'users.id AS userId',

--- a/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participant-repository.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participant-repository.js
@@ -1,6 +1,5 @@
 import pick from 'lodash/pick.js';
 
-import { knex } from '../../../../../db/knex-database-connection.js';
 import * as campaignRepository from '../../../../../src/prescription/campaign/infrastructure/repositories/campaign-repository.js';
 import { CAMPAIGN_FEATURES } from '../../../../shared/domain/constants.js';
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
@@ -214,8 +213,8 @@ async function _getOrganizationLearner(campaignId, userId) {
       function () {
         this.on('campaign-participations.organizationLearnerId', 'view-active-organization-learners.id');
         this.on('campaign-participations.campaignId', 'campaigns.id');
-        this.on('campaign-participations.deletedAt', knex.raw('IS'), knex.raw('NULL'));
-        this.on('campaign-participations.isImproved', knex.raw('false'));
+        this.on('campaign-participations.deletedAt', knexConnection.raw('IS'), knexConnection.raw('NULL'));
+        this.on('campaign-participations.isImproved', knexConnection.raw('false'));
         this.on('campaign-participations.userId', '!=', 'view-active-organization-learners.userId');
       },
       'view-active-organization-learners.id',

--- a/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-profile-repository.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-profile-repository.js
@@ -1,4 +1,4 @@
-import { knex } from '../../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../../shared/domain/errors.js';
 import * as placementProfileService from '../../../../shared/domain/services/placement-profile-service.js';
 import * as areaRepository from '../../../../shared/infrastructure/repositories/area-repository.js';
@@ -24,7 +24,9 @@ const findProfile = async function ({ campaignId, campaignParticipationId, local
 export { findProfile };
 
 async function _fetchCampaignProfileAttributesFromCampaignParticipation(campaignId, campaignParticipationId) {
-  const [profile] = await knex
+  const knexConn = DomainTransaction.getConnection();
+
+  const [profile] = await knexConn
     .with('campaignProfile', (qb) => {
       qb.select([
         'campaign-participations.userId',

--- a/api/src/prescription/campaign-participation/infrastructure/repositories/participant-results-shared-repository.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/participant-results-shared-repository.js
@@ -1,5 +1,5 @@
-import { knex } from '../../../../../db/knex-database-connection.js';
 import * as campaignRepository from '../../../../../src/prescription/campaign/infrastructure/repositories/campaign-repository.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import * as placementProfileService from '../../../../shared/domain/services/placement-profile-service.js';
 import * as competenceRepository from '../../../../shared/infrastructure/repositories/competence-repository.js';
 import * as knowledgeElementSnapshotRepository from '../../../campaign/infrastructure/repositories/knowledge-element-snapshot-repository.js';
@@ -8,7 +8,9 @@ import * as campaignParticipationRepository from './campaign-participation-repos
 
 const participantResultsSharedRepository = {
   async save(participantResultShared) {
-    await knex('campaign-participations').update(participantResultShared).where({ id: participantResultShared.id });
+    const knexConn = DomainTransaction.getConnection();
+
+    await knexConn('campaign-participations').update(participantResultShared).where({ id: participantResultShared.id });
   },
 
   async get(campaignParticipationId) {

--- a/api/src/prescription/campaign-participation/infrastructure/repositories/participations-for-campaign-management-repository.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/participations-for-campaign-management-repository.js
@@ -1,10 +1,12 @@
-import { knex } from '../../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { fetchPage } from '../../../../shared/infrastructure/utils/knex-utils.js';
 import { ParticipationForCampaignManagement } from '../../domain/models/ParticipationForCampaignManagement.js';
 
 const updateParticipantExternalId = async function ({ campaignParticipationId, participantExternalId }) {
-  const updatedRows = await knex('campaign-participations')
+  const knexConn = DomainTransaction.getConnection();
+
+  const updatedRows = await knexConn('campaign-participations')
     .where('id', campaignParticipationId)
     .update({ participantExternalId });
 
@@ -14,7 +16,9 @@ const updateParticipantExternalId = async function ({ campaignParticipationId, p
 };
 
 const findPaginatedParticipationsForCampaignManagement = async function ({ campaignId, page }) {
-  const query = knex('campaign-participations')
+  const knexConn = DomainTransaction.getConnection();
+
+  const query = knexConn('campaign-participations')
     .select({
       id: 'campaign-participations.id',
       lastName: 'view-active-organization-learners.lastName',
@@ -23,7 +27,7 @@ const findPaginatedParticipationsForCampaignManagement = async function ({ campa
       userFirstName: 'users.firstName',
       userLastName: 'users.lastName',
       participantExternalId: 'campaign-participations.participantExternalId',
-      status: knex.raw(
+      status: knexConn.raw(
         `CASE WHEN "campaign-participations"."status" = 'TO_SHARE' THEN 'STARTED' ELSE "campaign-participations"."status" END`, // TODO: stop casting TO_SHARE once the migration is done
       ),
       createdAt: 'campaign-participations.createdAt',

--- a/api/src/prescription/campaign-participation/infrastructure/repositories/participations-for-user-management-repository.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/participations-for-user-management-repository.js
@@ -1,4 +1,3 @@
-import { knex } from '../../../../../db/knex-database-connection.js';
 import * as combinedCourseApi from '../../../../quest/application/api/combined-course-api.js';
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { Assessment } from '../../../../shared/domain/models/Assessment.js';
@@ -16,12 +15,12 @@ const findByUserId = async function (userId) {
         .select({
           campaignParticipationId: 'campaign-participations.id',
           participantExternalId: 'campaign-participations.participantExternalId',
-          status: knex.raw(
+          status: knexConnection.raw(
             `CASE WHEN "campaign-participations"."status" = 'TO_SHARE' THEN 'STARTED' ELSE "campaign-participations"."status" END`, // TODO: stop casting TO_SHARE once the migration is done
           ),
           campaignId: 'campaigns.id',
           campaignCode: 'campaigns.code',
-          createdAt: knex.raw('COALESCE("campaign-participations"."createdAt", assessments."createdAt")'),
+          createdAt: knexConnection.raw('COALESCE("campaign-participations"."createdAt", assessments."createdAt")'),
           sharedAt: 'campaign-participations.sharedAt',
           deletedAt: 'campaign-participations.deletedAt',
           updatedAt: 'assessments.updatedAt',
@@ -43,7 +42,7 @@ const findByUserId = async function (userId) {
           this.select({
             campaignParticipationId: 'campaign-participations.id',
             participantExternalId: 'campaign-participations.participantExternalId',
-            status: knex.raw(
+            status: knexConnection.raw(
               `CASE WHEN "campaign-participations"."status" = 'TO_SHARE' THEN 'STARTED' ELSE "campaign-participations"."status" END`,
             ),
             campaignId: 'campaigns.id',

--- a/api/src/prescription/campaign-participation/infrastructure/repositories/pole-emploi-sending-repository.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/pole-emploi-sending-repository.js
@@ -1,15 +1,19 @@
-import { knex } from '../../../../../db/knex-database-connection.js';
 import * as OidcIdentityProviders from '../../../../identity-access-management/domain/constants/oidc-identity-providers.js';
 import { config } from '../../../../shared/config.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 
 const create = function ({ poleEmploiSending }) {
-  return knex('pole-emploi-sendings').insert({ ...poleEmploiSending });
+  const knexConn = DomainTransaction.getConnection();
+
+  return knexConn('pole-emploi-sendings').insert({ ...poleEmploiSending });
 };
 
 const find = async function (sending, filters) {
+  const knexConn = DomainTransaction.getConnection();
+
   const POLE_EMPLOI_SENDINGS_LIMIT = config.poleEmploi.poleEmploiSendingsLimit;
 
-  const rawSendings = await knex('pole-emploi-sendings')
+  const rawSendings = await knexConn('pole-emploi-sendings')
     .select(
       'pole-emploi-sendings.id AS idEnvoi',
       'pole-emploi-sendings.createdAt AS dateEnvoi',

--- a/api/src/prescription/campaign/domain/usecases/swap-campaign-code.js
+++ b/api/src/prescription/campaign/domain/usecases/swap-campaign-code.js
@@ -1,6 +1,11 @@
+import { withTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { SwapCampaignMismatchOrganizationError } from '../errors.js';
 
-const swapCampaignCodes = async function ({ firstCampaignId, secondCampaignId, campaignAdministrationRepository }) {
+const swapCampaignCodes = withTransaction(async function ({
+  firstCampaignId,
+  secondCampaignId,
+  campaignAdministrationRepository,
+}) {
   const isFromSameOrganization = await campaignAdministrationRepository.isFromSameOrganization({
     firstCampaignId,
     secondCampaignId,
@@ -11,6 +16,6 @@ const swapCampaignCodes = async function ({ firstCampaignId, secondCampaignId, c
   }
 
   return campaignAdministrationRepository.swapCampaignCodes({ firstCampaignId, secondCampaignId });
-};
+});
 
 export { swapCampaignCodes };

--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-collective-result-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-collective-result-repository.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 
-import { knex } from '../../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { CHUNK_SIZE_CAMPAIGN_RESULT_PROCESSING } from '../../../../shared/infrastructure/constants.js';
 import { CampaignParticipationStatuses } from '../../../shared/domain/constants.js';
 import { CampaignCollectiveResult } from '../../domain/read-models/CampaignCollectiveResult.js';
@@ -32,7 +32,8 @@ const getCampaignCollectiveResult = async function (campaignId, campaignLearning
 export { getCampaignCollectiveResult };
 
 async function _getChunksSharedParticipations(campaignId) {
-  const results = await knex
+  const knexConn = DomainTransaction.getConnection();
+  const results = await knexConn
     .from('campaign-participations')
     .max('id')
     .where({ campaignId, status: SHARED, deletedAt: null })

--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-participation-info-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-participation-info-repository.js
@@ -1,4 +1,3 @@
-import { knex } from '../../../../../db/knex-database-connection.js';
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { Assessment } from '../../../../shared/domain/models/Assessment.js';
 import { CampaignParticipationInfo } from '../../domain/read-models/CampaignParticipationInfo.js';
@@ -11,7 +10,7 @@ const findByCampaignId = async function (campaignId) {
       qb.select([
         'campaign-participations.*',
         'assessments.state',
-        _assessmentRankByCreationDate(),
+        _assessmentRankByCreationDate(knexConn),
         'view-active-organization-learners.firstName',
         'view-active-organization-learners.lastName',
         'view-active-organization-learners.studentNumber',
@@ -39,8 +38,8 @@ const findByCampaignId = async function (campaignId) {
 
 export { findByCampaignId };
 
-function _assessmentRankByCreationDate() {
-  return knex.raw('ROW_NUMBER() OVER (PARTITION BY ?? ORDER BY ?? DESC) AS rank', [
+function _assessmentRankByCreationDate(knexConn) {
+  return knexConn.raw('ROW_NUMBER() OVER (PARTITION BY ?? ORDER BY ?? DESC) AS rank', [
     'assessments.campaignParticipationId',
     'assessments.createdAt',
   ]);

--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-to-join-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-to-join-repository.js
@@ -1,10 +1,12 @@
-import { knex } from '../../../../../db/knex-database-connection.js';
 import { CAMPAIGN_FEATURES } from '../../../../shared/domain/constants.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { CampaignToJoin } from '../../domain/read-models/CampaignToJoin.js';
 
 const getByCode = async function ({ code, organizationFeatureAPI }) {
-  const result = await knex('campaigns')
+  const knexConn = DomainTransaction.getConnection();
+
+  const result = await knexConn('campaigns')
     .select('campaigns.*')
     .select({
       organizationId: 'organizations.id',
@@ -28,7 +30,7 @@ const getByCode = async function ({ code, organizationFeatureAPI }) {
     throw new NotFoundError(`La campagne au code ${code} n'existe pas ou son accès est restreint`);
   }
 
-  const externalIdFeature = await knex('campaign-features')
+  const externalIdFeature = await knexConn('campaign-features')
     .select('params')
     .join('features', 'features.id', 'featureId')
     .where({ campaignId: result.id, 'features.key': CAMPAIGN_FEATURES.EXTERNAL_ID.key })

--- a/api/src/prescription/campaign/infrastructure/repositories/division-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/division-repository.js
@@ -1,8 +1,10 @@
-import { knex } from '../../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { Division } from '../../domain/models/Division.js';
 
 async function findByCampaignId(campaignId) {
-  const divisions = await knex('view-active-organization-learners')
+  const knexConn = DomainTransaction.getConnection();
+
+  const divisions = await knexConn('view-active-organization-learners')
     .where({ campaignId })
     .whereNotNull('division')
     .where({ 'campaign-participations.deletedAt': null })
@@ -18,7 +20,9 @@ async function findByCampaignId(campaignId) {
 }
 
 async function findByOrganizationIdForCurrentSchoolYear({ organizationId }) {
-  const divisionRows = await knex('view-active-organization-learners')
+  const knexConn = DomainTransaction.getConnection();
+
+  const divisionRows = await knexConn('view-active-organization-learners')
     .distinct('division')
     .where({ organizationId, isDisabled: false })
     .whereNotNull('division')

--- a/api/src/prescription/campaign/infrastructure/repositories/group-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/group-repository.js
@@ -1,8 +1,9 @@
-import { knex } from '../../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { Group } from '../../domain/models/Group.js';
 
 async function findByCampaignId(campaignId) {
-  const groups = await knex('view-active-organization-learners')
+  const knexConn = DomainTransaction.getConnection();
+  const groups = await knexConn('view-active-organization-learners')
     .where({ campaignId })
     .where({ 'campaign-participations.deletedAt': null })
     .distinct('group')
@@ -18,7 +19,9 @@ async function findByCampaignId(campaignId) {
 }
 
 async function findByOrganizationId({ organizationId }) {
-  const groupRows = await knex('view-active-organization-learners')
+  const knexConn = DomainTransaction.getConnection();
+
+  const groupRows = await knexConn('view-active-organization-learners')
     .distinct('group')
     .where({ organizationId, isDisabled: false })
     .whereNotNull('group')

--- a/api/src/prescription/learner-management/infrastructure/repositories/organization-import-repository.js
+++ b/api/src/prescription/learner-management/infrastructure/repositories/organization-import-repository.js
@@ -1,4 +1,3 @@
-import { knex } from '../../../../../db/knex-database-connection.js';
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { OrganizationImportStatus } from '../../domain/models/OrganizationImportStatus.js';
 import { OrganizationImportDetail } from '../../domain/read-models/OrganizationImportDetail.js';
@@ -17,7 +16,9 @@ const getLastByOrganizationId = async function (organizationId) {
 };
 
 const getLastImportDetailForOrganization = async function (organizationId) {
-  const result = await knex('organization-imports')
+  const knexConn = DomainTransaction.getConnection();
+
+  const result = await knexConn('organization-imports')
     .select('organization-imports.*', 'users.firstName', 'users.lastName')
     .join('users', 'users.id', 'organization-imports.createdBy')
     .where({ organizationId })
@@ -31,6 +32,7 @@ const getLastImportDetailForOrganization = async function (organizationId) {
 
 const get = async function (id) {
   const knexConn = DomainTransaction.getConnection();
+
   const result = await knexConn('organization-imports').where({ id }).first();
 
   if (!result) return null;
@@ -48,13 +50,14 @@ function _stringifyErrors(errors) {
 }
 
 const save = async function (organizationImport) {
+  const knexConn = DomainTransaction.getConnection();
   const attributes = { ...organizationImport, errors: _stringifyErrors(organizationImport.errors) };
 
   if (organizationImport.id) {
-    const updatedRows = await knex('organization-imports').update(attributes).where({ id: organizationImport.id });
+    const updatedRows = await knexConn('organization-imports').update(attributes).where({ id: organizationImport.id });
     if (updatedRows === 0) throw new Error();
   } else {
-    await knex('organization-imports').insert(attributes);
+    await knexConn('organization-imports').insert(attributes);
   }
 };
 

--- a/api/src/prescription/organization-learner/infrastructure/repositories/organization-learner-activity-repository.js
+++ b/api/src/prescription/organization-learner/infrastructure/repositories/organization-learner-activity-repository.js
@@ -1,9 +1,11 @@
-import { knex } from '../../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { OrganizationLearnerActivity } from '../../domain/read-models/OrganizationLearnerActivity.js';
 import { OrganizationLearnerParticipation } from '../../domain/read-models/OrganizationLearnerParticipation.js';
 
 async function get(organizationLearnerId) {
-  const organizationLearnerParticipations = await knex('campaign-participations')
+  const knexConn = DomainTransaction.getConnection();
+
+  const organizationLearnerParticipations = await knexConn('campaign-participations')
     .select(
       'campaign-participations.id',
       'campaign-participations.createdAt',
@@ -12,14 +14,14 @@ async function get(organizationLearnerId) {
       'campaign-participations.status',
       'campaigns.name',
       'campaigns.type',
-      knex('campaign-participations')
+      knexConn('campaign-participations')
         .whereRaw('"campaignId" = "campaigns"."id"')
         .where('organizationLearnerId', organizationLearnerId)
         .whereNull('deletedAt')
         .groupBy('campaignId')
         .count()
         .as('participationsCount'),
-      knex('campaign-participations')
+      knexConn('campaign-participations')
         .select('campaign-participations.id')
         .whereRaw('"campaignId" = "campaigns"."id"')
         .where('organizationLearnerId', organizationLearnerId)

--- a/api/src/prescription/shared/infrastructure/repositories/learning-content-repository.js
+++ b/api/src/prescription/shared/infrastructure/repositories/learning-content-repository.js
@@ -1,8 +1,8 @@
 import _ from 'lodash';
 
-import { knex } from '../../../../../db/knex-database-connection.js';
 import * as learningContentConversionService from '../../../../../lib/domain/services/learning-content/learning-content-conversion-service.js';
 import * as campaignRepository from '../../../../prescription/campaign/infrastructure/repositories/campaign-repository.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { NoSkillsInCampaignError, NotFoundError } from '../../../../shared/domain/errors.js';
 import { CampaignLearningContent } from '../../../../shared/domain/models/CampaignLearningContent.js';
 import { LearningContent } from '../../../../shared/domain/models/LearningContent.js';
@@ -22,7 +22,9 @@ async function findByCampaignId(campaignId, locale) {
 }
 
 async function findByTargetProfileId(targetProfileId, locale) {
-  const cappedTubesDTO = await knex('target-profile_tubes')
+  const knexConn = DomainTransaction.getConnection();
+
+  const cappedTubesDTO = await knexConn('target-profile_tubes')
     .select({
       id: 'tubeId',
       level: 'level',

--- a/api/src/prescription/target-profile/infrastructure/repositories/organizations-to-attach-to-target-profile-repository.js
+++ b/api/src/prescription/target-profile/infrastructure/repositories/organizations-to-attach-to-target-profile-repository.js
@@ -1,4 +1,4 @@
-import { knex } from '../../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { foreignKeyConstraintViolated } from '../../../../shared/infrastructure/utils/knex-utils.js';
 
@@ -21,18 +21,21 @@ const attachOrganizations = async function (targetProfile) {
 };
 
 const addTargetProfilesToOrganization = async function ({ organizationId, targetProfileIdList }) {
+  const knexConn = DomainTransaction.getConnection();
   const targetProfileShareToAdd = targetProfileIdList.map((targetProfileId) => {
     return { organizationId, targetProfileId };
   });
-  await knex('target-profile-shares')
+  await knexConn('target-profile-shares')
     .insert(targetProfileShareToAdd)
     .onConflict(['targetProfileId', 'organizationId'])
     .ignore();
 };
 
 async function _createTargetProfileShares(targetProfileShares) {
+  const knexConn = DomainTransaction.getConnection();
+
   try {
-    const insertedTargetProfileShares = await knex('target-profile-shares')
+    const insertedTargetProfileShares = await knexConn('target-profile-shares')
       .insert(targetProfileShares)
       .onConflict(['targetProfileId', 'organizationId'])
       .ignore()

--- a/api/src/prescription/target-profile/infrastructure/repositories/target-profile-bond-repository.js
+++ b/api/src/prescription/target-profile/infrastructure/repositories/target-profile-bond-repository.js
@@ -1,7 +1,9 @@
-import { knex } from '../../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 
 const update = async function (targetProfile) {
-  const results = await knex('target-profile-shares')
+  const knexConn = DomainTransaction.getConnection();
+
+  const results = await knexConn('target-profile-shares')
     .where('targetProfileId', targetProfile.id)
     .whereIn('organizationId', targetProfile.organizationIdsToDetach)
     .del()

--- a/api/src/prescription/target-profile/infrastructure/repositories/target-profile-for-specifier-repository.js
+++ b/api/src/prescription/target-profile/infrastructure/repositories/target-profile-for-specifier-repository.js
@@ -1,4 +1,4 @@
-import { knex } from '../../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { PromiseUtils } from '../../../../shared/infrastructure/utils/promise-utils.js';
 import { TargetProfileForSpecifier } from '../../domain/read-models/TargetProfileForSpecifier.js';
 
@@ -9,11 +9,12 @@ async function availableForOrganization(organizationId) {
 }
 
 function _fetchTargetProfiles(organizationId) {
-  const selectTargetProfileSharesIdsBelongToOrganization = knex
+  const knexConn = DomainTransaction.getConnection();
+  const selectTargetProfileSharesIdsBelongToOrganization = knexConn
     .select('targetProfileId')
     .from('target-profile-shares')
     .where({ organizationId });
-  return knex('target-profiles')
+  return knexConn('target-profiles')
     .select([
       'target-profiles.id',
       'target-profiles.name',
@@ -21,9 +22,9 @@ function _fetchTargetProfiles(organizationId) {
       'target-profiles.category',
       'target-profiles.areKnowledgeElementsResettable',
       'target-profiles.isSimplifiedAccess',
-      knex.count('id').from('badges').whereRaw('badges."targetProfileId"="target-profiles".id').as('countBadges'),
-      knex.count('id').from('stages').whereRaw('stages."targetProfileId"="target-profiles".id').as('countStages'),
-      knex
+      knexConn.count('id').from('badges').whereRaw('badges."targetProfileId"="target-profiles".id').as('countBadges'),
+      knexConn.count('id').from('stages').whereRaw('stages."targetProfileId"="target-profiles".id').as('countStages'),
+      knexConn
         .count('tubeId')
         .from('target-profile_tubes')
         .whereRaw('"target-profile_tubes"."targetProfileId"="target-profiles".id')

--- a/api/src/prescription/target-profile/infrastructure/repositories/target-profile-repository.js
+++ b/api/src/prescription/target-profile/infrastructure/repositories/target-profile-repository.js
@@ -1,4 +1,3 @@
-import { knex } from '../../../../../db/knex-database-connection.js';
 import { Badge } from '../../../../evaluation/domain/models/Badge.js';
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../../shared/domain/errors.js';
@@ -21,19 +20,22 @@ const get = async function (id) {
 };
 
 const findByIds = async function (targetProfileIds) {
-  const targetProfiles = await knex('target-profiles').whereIn('id', targetProfileIds);
+  const knexConn = DomainTransaction.getConnection();
+
+  const targetProfiles = await knexConn('target-profiles').whereIn('id', targetProfileIds);
   return targetProfiles.map((targetProfile) => {
     return new TargetProfile(targetProfile);
   });
 };
 
 const findOrganizationIds = async function (targetProfileId) {
-  const targetProfile = await knex(TARGET_PROFILE_TABLE).select('id').where({ id: targetProfileId }).first();
+  const knexConn = DomainTransaction.getConnection();
+  const targetProfile = await knexConn(TARGET_PROFILE_TABLE).select('id').where({ id: targetProfileId }).first();
   if (!targetProfile) {
     throw new NotFoundError(`No target profile for ID ${targetProfileId}`);
   }
 
-  const targetProfileShares = await knex('target-profile-shares')
+  const targetProfileShares = await knexConn('target-profile-shares')
     .select('organizationId')
     .where({ 'target-profile-shares.targetProfileId': targetProfileId });
   return targetProfileShares.map((targetProfileShare) => targetProfileShare.organizationId);

--- a/api/src/prescription/target-profile/infrastructure/repositories/target-profile-summary-for-admin-repository.js
+++ b/api/src/prescription/target-profile/infrastructure/repositories/target-profile-summary-for-admin-repository.js
@@ -1,11 +1,12 @@
-import { knex } from '../../../../../db/knex-database-connection.js';
 import * as CombinedCourseRepository from '../../../../quest/infrastructure/repositories/combined-course-repository.js';
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { fetchPage } from '../../../../shared/infrastructure/utils/knex-utils.js';
 import { TargetProfileSummaryForAdmin } from '../../domain/models/TargetProfileSummaryForAdmin.js';
 
 const findPaginatedFiltered = async function ({ filter, page }) {
-  const query = knex('target-profiles')
+  const knexConn = DomainTransaction.getConnection();
+
+  const query = knexConn('target-profiles')
     .select('id', 'internalName', 'outdated', 'category', 'createdAt')
     .orderBy('outdated', 'ASC')
     .orderBy('internalName', 'ASC')

--- a/api/tests/prescription/campaign/unit/domain/usecases/swap-campaign-code_test.js
+++ b/api/tests/prescription/campaign/unit/domain/usecases/swap-campaign-code_test.js
@@ -1,5 +1,6 @@
 import { SwapCampaignMismatchOrganizationError } from '../../../../../../src/prescription/campaign/domain/errors.js';
 import { swapCampaignCodes } from '../../../../../../src/prescription/campaign/domain/usecases/swap-campaign-code.js';
+import { DomainTransaction } from '../../../../../../src/shared/domain/DomainTransaction.js';
 import { catchErr, expect, sinon } from '../../../../../test-helper.js';
 
 describe('Unit | UseCase | swap-campaign-code', function () {
@@ -7,6 +8,8 @@ describe('Unit | UseCase | swap-campaign-code', function () {
 
   beforeEach(function () {
     campaignAdministrationRepository = { swapCampaignCodes: sinon.stub(), isFromSameOrganization: sinon.stub() };
+    sinon.stub(DomainTransaction, 'execute');
+    DomainTransaction.execute.callsFake((callback) => callback());
   });
 
   it('should swap the codes', async function () {


### PR DESCRIPTION
## ❄️ Problème

Certains repository utilise knex en direct alors qu'ils peuvent être utilisé dans un usecase necessitant une trasnaction. ce qui ouvre deux pool à la db au lieu d'une.

## 🛷 Proposition

Utiliser DomainTransaction dans les repo du folder prescription .

## ☃️ Remarques

Un seul knex perdure, c'est celui de datamart. qui est une BDD à part. 

## 🧑‍🎄 Pour tester

Ci au vert