### PR TITLE
[TECH] Ajouter des index sur les tables Passages et PassageEvents (PIX-21364)

### DIFF
--- a/api/db/migrations/20260205133246_add-passage-id-index-to-passage-events-table.js
+++ b/api/db/migrations/20260205133246_add-passage-id-index-to-passage-events-table.js
@@ -1,0 +1,20 @@
+const TABLE_NAME = 'passage-events';
+const COLUMN_NAME = 'passageId';
+
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.index(COLUMN_NAME);
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropIndex(COLUMN_NAME);
+  });
+};
+
+export { down, up };

--- a/api/db/migrations/20260205134706_add-user-id-module-id-index-in-passages-table.js
+++ b/api/db/migrations/20260205134706_add-user-id-module-id-index-in-passages-table.js
@@ -1,0 +1,24 @@
+const TABLE_NAME = 'passages';
+const COLUMN_NAMES = ['userId', 'moduleId'];
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.index(COLUMN_NAMES);
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAMES);
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## ❄️ Problème

Il manque des index sur les tables passages et passage-events : 
- sur la colonne passageId de la table passage-events . Une requête est faite sur cette colonne pour vérifier la cohérence des données avant l'insertion d'un nouvel élément.
- sur les colonnes moduleId et userId  de la table passages. Elles sont utilisées pour récupérer le statut des modules d'un utilisateur sur les parcours combinés

## 🛷 Proposition
Les ajouter

## ☃️ Remarques
RAS

## 🧑‍🎄 Pour tester
- En local, exécuter la commande `npm run db:migrate`
- Vérifier que les index ont bien été ajouté sur les tables passages et passage-events
- Exécuter 2 fois la commande` npm run db:rollback:latest`
- Constater que les index ont bien été supprimé.
