### PR TITLE
[TECH] Supprimer l'usage du promise.all dans le scope prescription (PIX-21410)

### DIFF
--- a/api/src/prescription/campaign-participation/domain/usecases/find-user-campaign-participation-overviews.js
+++ b/api/src/prescription/campaign-participation/domain/usecases/find-user-campaign-participation-overviews.js
@@ -22,10 +22,8 @@ const findUserCampaignParticipationOverviews = async function ({
   ];
   const campaignParticipationIds = campaignParticipationOverviews.map(({ id }) => id);
 
-  const [stages, acquiredStages] = await Promise.all([
-    stageRepository.getByTargetProfileIds(targetProfileIds),
-    stageAcquisitionRepository.getByCampaignParticipations(campaignParticipationIds),
-  ]);
+  const stages = await stageRepository.getByTargetProfileIds(targetProfileIds);
+  const acquiredStages = await stageAcquisitionRepository.getByCampaignParticipations(campaignParticipationIds);
 
   const campaignParticipationOverviewsWithStages = campaignParticipationOverviews.map(
     (campaignParticipationOverview) => {

--- a/api/src/prescription/campaign-participation/domain/usecases/get-shared-campaign-participation-profile.js
+++ b/api/src/prescription/campaign-participation/domain/usecases/get-shared-campaign-participation-profile.js
@@ -22,18 +22,15 @@ const getSharedCampaignParticipationProfile = async function ({
     throw new NoCampaignParticipationForUserAndCampaign();
   }
 
-  const [
-    { multipleSendings: campaignAllowsRetry },
-    isOrganizationLearnerActive,
-    knowledgeElementsGroupedByCompetenceId,
-  ] = await Promise.all([
-    campaignRepository.get(campaignId),
-    organizationLearnerRepository.isActive({ campaignId, userId }),
-    knowledgeElementRepository.findUniqByUserIdGroupedByCompetenceId({
+  const { multipleSendings: campaignAllowsRetry } = await campaignRepository.get(campaignId);
+  const isOrganizationLearnerActive = await organizationLearnerRepository.isActive({ campaignId, userId });
+  const knowledgeElementsGroupedByCompetenceId = await knowledgeElementRepository.findUniqByUserIdGroupedByCompetenceId(
+    {
       userId,
       limitDate: campaignParticipation.sharedAt,
-    }),
-  ]);
+    },
+  );
+
   const competences = await competenceRepository.listPixCompetencesOnly({ locale });
   const allAreas = await areaRepository.list({ locale });
   const maxReachableLevel = constants.MAX_REACHABLE_LEVEL;

--- a/api/src/prescription/campaign-participation/domain/usecases/get-user-campaign-assessment-result.js
+++ b/api/src/prescription/campaign-participation/domain/usecases/get-user-campaign-assessment-result.js
@@ -24,18 +24,18 @@ const getUserCampaignAssessmentResult = async function ({
     throw new NoCampaignParticipationForUserAndCampaign();
   }
   try {
-    const [badges, knowledgeElements] = await Promise.all([
-      badgeRepository.findByCampaignId(campaignId),
-      knowledgeElementForParticipationService.findUniqByUserOrCampaignParticipationId({
-        userId,
-        campaignParticipationId: campaignParticipation.id,
-      }),
-    ]);
+    const badges = await badgeRepository.findByCampaignId(campaignId);
+    const knowledgeElements = await knowledgeElementForParticipationService.findUniqByUserOrCampaignParticipationId({
+      userId,
+      campaignParticipationId: campaignParticipation.id,
+    });
+
     const stillValidBadgeIds = await checkStillValidBadges(
       campaignId,
       knowledgeElements,
       badgeForCalculationRepository,
     );
+
     const badgeWithAcquisitionPercentage = await getBadgeAcquisitionPercentage(
       campaignId,
       knowledgeElements,
@@ -50,10 +50,8 @@ const getUserCampaignAssessmentResult = async function ({
       ).acquisitionPercentage,
     }));
 
-    const [stages, acquiredStages] = await Promise.all([
-      stageRepository.getByCampaignId(campaignId),
-      stageAcquisitionRepository.getByCampaignParticipation(campaignParticipation.id),
-    ]);
+    const stages = await stageRepository.getByCampaignId(campaignId);
+    const acquiredStages = await stageAcquisitionRepository.getByCampaignParticipation(campaignParticipation.id);
 
     const stagesAndAcquiredStagesComparison = compareStagesAndAcquiredStages.compare(stages, acquiredStages);
 

--- a/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-result-repository.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-result-repository.js
@@ -11,12 +11,11 @@ const campaignParticipationResultRepository = {
   async getByParticipationId(campaignParticipationId) {
     const campaignParticipation = await campaignParticipationRepository.get(campaignParticipationId);
 
-    const [skillIds, competences, assessment, knowledgeElements] = await Promise.all([
-      campaignRepository.findSkillIds({ campaignId: campaignParticipation.campaignId }),
-      competenceRepository.list(),
-      assessmentRepository.get(campaignParticipation.lastAssessment.id),
-      getKnowledgeElements(campaignParticipation),
-    ]);
+    const skillIds = await campaignRepository.findSkillIds({ campaignId: campaignParticipation.campaignId });
+    const competences = await competenceRepository.list();
+    const assessment = await assessmentRepository.get(campaignParticipation.lastAssessment.id);
+    const knowledgeElements = await getKnowledgeElements(campaignParticipation);
+
     const allAreas = await areaRepository.list();
 
     return CampaignParticipationResult.buildFrom({

--- a/api/src/prescription/campaign/domain/usecases/get-campaign.js
+++ b/api/src/prescription/campaign/domain/usecases/get-campaign.js
@@ -17,11 +17,9 @@ const getCampaign = async function ({
   }
 
   if (campaignReport.isAssessment || campaignReport.isExam) {
-    const [badges, stageCollection, masteryRates] = await Promise.all([
-      badgeRepository.findByCampaignId(campaignId),
-      stageCollectionRepository.findStageCollection({ campaignId }),
-      campaignReportRepository.findMasteryRates(campaignId),
-    ]);
+    const badges = await badgeRepository.findByCampaignId(campaignId);
+    const stageCollection = await stageCollectionRepository.findStageCollection({ campaignId });
+    const masteryRates = await campaignReportRepository.findMasteryRates(campaignId);
 
     campaignReport.setBadges(badges);
     campaignReport.computeAverageResult(masteryRates);

--- a/api/src/prescription/campaign/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream.js
+++ b/api/src/prescription/campaign/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream.js
@@ -34,14 +34,12 @@ const startWritingCampaignProfilesCollectionResultsToStream = async function ({
     additionalHeaders = importFormat.exportableColumns;
   }
 
-  const [allPixCompetences, organization, { models: campaignParticipationResultDatas }] = await Promise.all([
-    competenceRepository.listPixCompetencesOnly({ locale: i18n.getLocale() }),
-    organizationRepository.get(campaign.organizationId),
-    campaignParticipationRepository.findInfoByCampaignId({
-      campaignId: campaign.id,
-      page: { size: 1000000, number: 1 },
-    }),
-  ]);
+  const allPixCompetences = await competenceRepository.listPixCompetencesOnly({ locale: i18n.getLocale() });
+  const organization = await organizationRepository.get(campaign.organizationId);
+  const { models: campaignParticipationResultDatas } = await campaignParticipationRepository.findInfoByCampaignId({
+    campaignId: campaign.id,
+    page: { size: 1000000, number: 1 },
+  });
 
   const campaignProfilesCollectionExport = new CampaignProfilesCollectionExport({
     outputStream: writableStream,

--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-participations-stats-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-participations-stats-repository.js
@@ -5,10 +5,8 @@ import { getLatestParticipationSharedForOneLearner } from './helpers/get-latest-
 const { TO_SHARE, SHARED, STARTED } = CampaignParticipationStatuses;
 
 const getParticipationsActivityByDate = async function (campaignId) {
-  const [startedParticipations, sharedParticipations] = await Promise.all([
-    _getCumulativeParticipationCountsByDay(campaignId, 'createdAt'),
-    _getCumulativeParticipationCountsByDay(campaignId, 'sharedAt'),
-  ]);
+  const startedParticipations = await _getCumulativeParticipationCountsByDay(campaignId, 'createdAt');
+  const sharedParticipations = await _getCumulativeParticipationCountsByDay(campaignId, 'sharedAt');
   return { startedParticipations, sharedParticipations };
 };
 

--- a/api/src/prescription/campaign/infrastructure/serializers/csv/campaign-assessment-export.js
+++ b/api/src/prescription/campaign/infrastructure/serializers/csv/campaign-assessment-export.js
@@ -76,19 +76,17 @@ class CampaignAssessmentExport {
           userIds: startedParticipations.map(({ userId }) => userId),
         });
 
-        const csvLines = await Promise.all(
-          campaignParticipationInfoChunk.map((campaignParticipationInfo) =>
-            this.#buildCSVLineForParticipation({
-              acquiredBadges,
-              acquiredStages,
-              campaignParticipationInfo,
-              campaignParticipationInfoChunk,
-              knowledgeElementRepository,
-              knowledgeElementSnapshotRepository,
-              sharedKnowledgeElementsByUserIdAndCompetenceId,
-              startedKnowledgeElementsByUserIdAndCompetenceId,
-            }),
-          ),
+        const csvLines = campaignParticipationInfoChunk.map((campaignParticipationInfo) =>
+          this.#buildCSVLineForParticipation({
+            acquiredBadges,
+            acquiredStages,
+            campaignParticipationInfo,
+            campaignParticipationInfoChunk,
+            knowledgeElementRepository,
+            knowledgeElementSnapshotRepository,
+            sharedKnowledgeElementsByUserIdAndCompetenceId,
+            startedKnowledgeElementsByUserIdAndCompetenceId,
+          }),
         );
         this.stream.write(csvLines.join(''));
       },
@@ -159,7 +157,7 @@ class CampaignAssessmentExport {
     ]);
   }
 
-  async #buildCSVLineForParticipation({
+  #buildCSVLineForParticipation({
     campaignParticipationInfo,
     acquiredStages,
     acquiredBadges,
@@ -176,7 +174,7 @@ class CampaignAssessmentExport {
       areas: this.areas,
       competences: this.competences,
       stageCollection: this.stageCollection,
-      participantKnowledgeElementsByCompetenceId: await this.#getParticipantKnowledgeElementsByCompetenceId({
+      participantKnowledgeElementsByCompetenceId: this.#getParticipantKnowledgeElementsByCompetenceId({
         campaignParticipationInfo,
         sharedKnowledgeElementsByUserIdAndCompetenceId,
         startedKnowledgeElementsByUserIdAndCompetenceId,
@@ -194,7 +192,7 @@ class CampaignAssessmentExport {
     }).toCsvLine();
   }
 
-  async #getParticipantKnowledgeElementsByCompetenceId({
+  #getParticipantKnowledgeElementsByCompetenceId({
     campaignParticipationInfo,
     sharedKnowledgeElementsByUserIdAndCompetenceId,
     startedKnowledgeElementsByUserIdAndCompetenceId,

--- a/api/src/prescription/learner-management/infrastructure/repositories/organization-learner-repository.js
+++ b/api/src/prescription/learner-management/infrastructure/repositories/organization-learner-repository.js
@@ -162,20 +162,16 @@ function _shouldStudentToImportBeReconciled(
   return isFromSameOrganization || isFromDifferentOrganizationWithSameBirthday;
 }
 
-const saveCommonOrganizationLearners = function (learners) {
-  const knex = DomainTransaction.getConnection();
-
-  return Promise.all(
-    learners.map((learner) => {
-      return knex('organization-learners').insert(learner).onConflict('id').merge({
-        firstName: learner.firstName,
-        lastName: learner.lastName,
-        attributes: learner.attributes,
-        isDisabled: false,
-        updatedAt: new Date(),
-      });
-    }),
-  );
+const saveCommonOrganizationLearners = async function (learners) {
+  const knexConn = DomainTransaction.getConnection();
+  const now = new Date();
+  learners.forEach((learner) => {
+    learner.updatedAt = now;
+  });
+  await knexConn('organization-learners')
+    .insert(learners)
+    .onConflict('id')
+    .merge(['firstName', 'lastName', 'attributes', 'isDisabled', 'updatedAt']);
 };
 
 const disableCommonOrganizationLearnersFromOrganizationId = function ({

--- a/api/src/prescription/organization-learner/domain/usecases/get-organization-learner-with-participations.js
+++ b/api/src/prescription/organization-learner/domain/usecases/get-organization-learner-with-participations.js
@@ -27,10 +27,8 @@ export const getOrganizationLearnerWithParticipations = async function ({
 
   const targetProfileIds = [...targetProfileIdsSet];
 
-  const [stages, acquiredStages] = await Promise.all([
-    stageRepository.getByTargetProfileIds(targetProfileIds),
-    stageAcquisitionRepository.getByCampaignParticipations(campaignParticipationIds),
-  ]);
+  const stages = await stageRepository.getByTargetProfileIds(targetProfileIds);
+  const acquiredStages = await stageAcquisitionRepository.getByCampaignParticipations(campaignParticipationIds);
 
   const campaignParticipationOverviewsWithStages = campaignParticipationOverviews.map(
     (campaignParticipationOverview) => {

--- a/api/src/prescription/target-profile/application/admin-target-profile-controller.js
+++ b/api/src/prescription/target-profile/application/admin-target-profile-controller.js
@@ -143,16 +143,15 @@ const copyTargetProfile = withTransaction(async (request) => {
   const copiedTargetProfileId = await prescriptionTargetProfileUsecases.copyTargetProfile({
     targetProfileId: targetProfileIdToCopy,
   });
-  await Promise.all([
-    await evaluationUsecases.copyTargetProfileBadges({
-      originTargetProfileId: targetProfileIdToCopy,
-      destinationTargetProfileId: copiedTargetProfileId,
-    }),
-    await evaluationUsecases.copyTargetProfileStages({
-      originTargetProfileId: targetProfileIdToCopy,
-      destinationTargetProfileId: copiedTargetProfileId,
-    }),
-  ]);
+
+  await evaluationUsecases.copyTargetProfileBadges({
+    originTargetProfileId: targetProfileIdToCopy,
+    destinationTargetProfileId: copiedTargetProfileId,
+  });
+  await evaluationUsecases.copyTargetProfileStages({
+    originTargetProfileId: targetProfileIdToCopy,
+    destinationTargetProfileId: copiedTargetProfileId,
+  });
 
   return copiedTargetProfileId;
 });

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/organization-learner-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/organization-learner-repository_test.js
@@ -1251,6 +1251,18 @@ describe('Integration | Repository | Organization Learner Management | Organizat
             INE: '234567890',
           },
         });
+        const organizationLearner2 = databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner(
+          {
+            firstName: 'Pikachu',
+            lastName: 'PikaPika',
+            organizationId,
+            isDisabled: false,
+            updatedAt: new Date('2020-01-01'),
+            attributes: {
+              INE: '234567800',
+            },
+          },
+        );
 
         await databaseBuilder.commit();
 
@@ -1262,16 +1274,31 @@ describe('Integration | Repository | Organization Learner Management | Organizat
           INE: '12345',
         });
 
-        await saveCommonOrganizationLearners([learnerData]);
+        const learner2Data = new CommonOrganizationLearner({
+          id: organizationLearner2.id,
+          firstName: 'Raichu',
+          lastName: 'Pika',
+          organizationId,
+          INE: '12345',
+        });
 
-        const [updatedOrganizationLearner] = await knex.from('organization-learners');
+        await saveCommonOrganizationLearners([learnerData, learner2Data]);
 
-        expect(updatedOrganizationLearner.firstName).to.equal(learnerData.firstName);
-        expect(updatedOrganizationLearner.lastName).to.equal(learnerData.lastName);
-        expect(updatedOrganizationLearner.organizationId).to.equal(learnerData.organizationId);
-        expect(updatedOrganizationLearner.attributes).to.deep.equal(learnerData.attributes);
-        expect(updatedOrganizationLearner.isDisabled).to.be.false;
-        expect(updatedOrganizationLearner.updatedAt).to.be.deep.equal(new Date('2023-02-02'));
+        const updatedOrganizationLearners = await knex.from('organization-learners');
+
+        expect(updatedOrganizationLearners[0].firstName).to.equal(learnerData.firstName);
+        expect(updatedOrganizationLearners[0].lastName).to.equal(learnerData.lastName);
+        expect(updatedOrganizationLearners[0].organizationId).to.equal(learnerData.organizationId);
+        expect(updatedOrganizationLearners[0].attributes).to.deep.equal(learnerData.attributes);
+        expect(updatedOrganizationLearners[0].isDisabled).to.be.false;
+        expect(updatedOrganizationLearners[0].updatedAt).to.be.deep.equal(new Date('2023-02-02'));
+
+        expect(updatedOrganizationLearners[1].firstName).to.equal(learner2Data.firstName);
+        expect(updatedOrganizationLearners[1].lastName).to.equal(learner2Data.lastName);
+        expect(updatedOrganizationLearners[1].organizationId).to.equal(learner2Data.organizationId);
+        expect(updatedOrganizationLearners[1].attributes).to.deep.equal(learner2Data.attributes);
+        expect(updatedOrganizationLearners[1].isDisabled).to.be.false;
+        expect(updatedOrganizationLearners[1].updatedAt).to.be.deep.equal(new Date('2023-02-02'));
       });
     });
   });


### PR DESCRIPTION
## ❄️ Problème

On a des problèmes de poll de connection saturé en prod

## 🛷 Proposition

Limiter les utilisations de Promise.all qui lance des requètes en parallèle.

## ☃️ Remarques

RAS

## 🧑‍🎄 Pour tester
Comme c'est du refactor, ras
Sinon test de non reg sur tout les usecases

<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
