### PR TITLE
[TECH] Corrige l'épuisement du pool dans le endpoint GET /assessments/{id} et dans l'util "fetchPage" pour récupérer des résultats paginés

### DIFF
--- a/api/src/certification/evaluation/infrastructure/repositories/certification-candidate-repository.js
+++ b/api/src/certification/evaluation/infrastructure/repositories/certification-candidate-repository.js
@@ -1,9 +1,9 @@
 // @ts-check
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { CertificationCandidateNotFoundError } from '../../../../shared/domain/errors.js';
-import { Candidate } from '../../../evaluation/domain/models/Candidate.js';
 import { ComplementaryCertificationKeys } from '../../../shared/domain/models/ComplementaryCertificationKeys.js';
 import { SCOPES } from '../../../shared/domain/models/Scopes.js';
+import { Candidate } from '../../domain/models/Candidate.js';
 
 /**
  * @typedef {object} RawCertificationCandidateResult

--- a/api/src/certification/shared/infrastructure/repositories/certification-challenge-live-alert-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/certification-challenge-live-alert-repository.js
@@ -1,6 +1,5 @@
 import _ from 'lodash';
 
-import { knex } from '../../../../../db/knex-database-connection.js';
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import {
   CertificationChallengeLiveAlert,
@@ -8,14 +7,16 @@ import {
 } from '../../domain/models/CertificationChallengeLiveAlert.js';
 
 const save = async function ({ certificationChallengeLiveAlert }) {
-  return knex('certification-challenge-live-alerts')
-    .insert({ ..._toDTO(certificationChallengeLiveAlert), updatedAt: new Date() })
+  const knexConn = DomainTransaction.getConnection();
+  return knexConn('certification-challenge-live-alerts')
+    .insert({ ..._toDTO(certificationChallengeLiveAlert), updatedAt: knexConn.fn.now() })
     .onConflict(['id'])
     .merge();
 };
 
 const getByAssessmentId = async ({ assessmentId }) => {
-  const certificationChallengeLiveAlertsDto = await knex('certification-challenge-live-alerts').where({
+  const knexConn = DomainTransaction.getConnection();
+  const certificationChallengeLiveAlertsDto = await knexConn('certification-challenge-live-alerts').where({
     assessmentId,
   });
 
@@ -40,7 +41,8 @@ const getLiveAlertValidatedChallengeIdsByAssessmentId = async ({ assessmentId })
 };
 
 const getOngoingBySessionIdAndUserId = async ({ sessionId, userId }) => {
-  const certificationChallengeLiveAlertDto = await knex('certification-courses')
+  const knexConn = DomainTransaction.getConnection();
+  const certificationChallengeLiveAlertDto = await knexConn('certification-courses')
     .leftJoin('assessments', 'certification-courses.id', 'assessments.certificationCourseId')
     .leftJoin(
       'certification-challenge-live-alerts',
@@ -58,7 +60,8 @@ const getOngoingBySessionIdAndUserId = async ({ sessionId, userId }) => {
 };
 
 const getOngoingByChallengeIdAndAssessmentId = async ({ challengeId, assessmentId }) => {
-  const certificationChallengeLiveAlertDto = await knex('certification-challenge-live-alerts')
+  const knexConn = DomainTransaction.getConnection();
+  const certificationChallengeLiveAlertDto = await knexConn('certification-challenge-live-alerts')
     .where({
       'certification-challenge-live-alerts.challengeId': challengeId,
       'certification-challenge-live-alerts.assessmentId': assessmentId,

--- a/api/src/certification/shared/infrastructure/repositories/certification-challenge-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/certification-challenge-repository.js
@@ -1,4 +1,3 @@
-import { knex } from '../../../../../db/knex-database-connection.js';
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { logger } from '../../../../shared/infrastructure/utils/logger.js';
 import { CertificationChallenge } from '../../domain/models/CertificationChallenge.js';
@@ -28,7 +27,8 @@ const save = async function ({ certificationChallenge }) {
 };
 
 const getNextChallengeByCourseId = async function (courseId, ignoredChallengeIds) {
-  const certificationChallenge = await knex('certification-challenges')
+  const knexConn = DomainTransaction.getConnection();
+  const certificationChallenge = await knexConn('certification-challenges')
     .where({ courseId })
     .whereNotIn('challengeId', ignoredChallengeIds)
     .orderBy('id', 'asc')

--- a/api/src/certification/shared/infrastructure/repositories/certification-companion-alert-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/certification-companion-alert-repository.js
@@ -1,8 +1,9 @@
-import { knex } from '../../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { CertificationCompanionLiveAlert } from '../../domain/models/CertificationCompanionLiveAlert.js';
 
 export const getAllByAssessmentId = async ({ assessmentId }) => {
-  const certificationCompanionLiveAlertsDto = await knex('certification-companion-live-alerts')
+  const knexConn = DomainTransaction.getConnection();
+  const certificationCompanionLiveAlertsDto = await knexConn('certification-companion-live-alerts')
     .select('id', 'assessmentId', 'status')
     .where({
       assessmentId,

--- a/api/src/evaluation/domain/services/algorithm-methods/data-fetcher.js
+++ b/api/src/evaluation/domain/services/algorithm-methods/data-fetcher.js
@@ -82,12 +82,14 @@ async function fetchForCompetenceEvaluations({
   improvementService,
   locale,
 }) {
-  const [allAnswers, targetSkills, challenges, knowledgeElements] = await Promise.all([
-    answerRepository.findByAssessment(assessment.id),
-    skillRepository.findActiveByCompetenceId(assessment.competenceId),
-    challengeRepository.findValidatedByCompetenceId(assessment.competenceId, locale),
-    _fetchKnowledgeElements({ assessment, knowledgeElementRepository, improvementService }),
-  ]);
+  const allAnswers = await answerRepository.findByAssessment(assessment.id);
+  const targetSkills = await skillRepository.findActiveByCompetenceId(assessment.competenceId);
+  const challenges = await challengeRepository.findValidatedByCompetenceId(assessment.competenceId, locale);
+  const knowledgeElements = await _fetchKnowledgeElements({
+    assessment,
+    knowledgeElementRepository,
+    improvementService,
+  });
 
   return {
     allAnswers,

--- a/api/src/evaluation/domain/services/algorithm-methods/data-fetcher.js
+++ b/api/src/evaluation/domain/services/algorithm-methods/data-fetcher.js
@@ -20,19 +20,17 @@ async function fetchForCampaigns({
     campaignParticipationId: assessment.campaignParticipationId,
   });
 
-  const [allAnswers, knowledgeElements, [skills, challenges]] = await Promise.all([
-    answerRepository.findByAssessment(assessment.id),
-    _fetchKnowledgeElements({
-      assessment,
-      isRetrying,
-      keepRecentOrValidated: true,
-      campaignParticipationRepository,
-      knowledgeElementForParticipationService,
-      knowledgeElementRepository,
-      improvementService,
-    }),
-    _fetchSkillsAndChallenges({ campaignSkills, challengeRepository, locale }),
-  ]);
+  const allAnswers = await answerRepository.findByAssessment(assessment.id);
+  const knowledgeElements = await _fetchKnowledgeElements({
+    assessment,
+    isRetrying,
+    keepRecentOrValidated: true,
+    campaignParticipationRepository,
+    knowledgeElementForParticipationService,
+    knowledgeElementRepository,
+    improvementService,
+  });
+  const [skills, challenges] = await _fetchSkillsAndChallenges({ campaignSkills, challengeRepository, locale });
 
   return {
     allAnswers,

--- a/api/src/evaluation/domain/usecases/get-next-challenge-for-preview.js
+++ b/api/src/evaluation/domain/usecases/get-next-challenge-for-preview.js
@@ -1,4 +1,4 @@
-import { AssessmentEndedError } from '../../../../src/shared/domain/errors.js';
+import { AssessmentEndedError } from '../../../shared/domain/errors.js';
 
 const getNextChallengeForPreview = function () {
   return Promise.reject(new AssessmentEndedError());

--- a/api/src/shared/application/assessments/index.js
+++ b/api/src/shared/application/assessments/index.js
@@ -1,9 +1,9 @@
 import Joi from 'joi';
 
 import { assessmentAuthorization } from '../../../evaluation/application/pre-handlers/assessment-authorization.js';
-import { securityPreHandlers } from '../../application/security-pre-handlers.js';
 import { config } from '../../config.js';
 import { identifiersType } from '../../domain/types/identifiers-type.js';
+import { securityPreHandlers } from '../security-pre-handlers.js';
 import { assessmentController } from './assessment-controller.js';
 
 const { featureToggles } = config;

--- a/api/src/shared/infrastructure/repositories/assessment-repository.js
+++ b/api/src/shared/infrastructure/repositories/assessment-repository.js
@@ -151,7 +151,7 @@ const updateLastQuestionDate = async function ({ id, lastQuestionDate }) {
   const knexConn = DomainTransaction.getConnection();
   const [assessmentUpdated] = await knexConn('assessments')
     .where({ id })
-    .update({ lastQuestionDate, updatedAt: new Date() })
+    .update({ lastQuestionDate, updatedAt: knexConn.fn.now() })
     .returning('*');
   if (!assessmentUpdated) return null;
 };


### PR DESCRIPTION
## ❄️ Problème

Nous expérimentons des problèmes d'épuisement de pool de connexions. Cela est notamment dû à la non utilisation de la transaction en cours ouverte par un usecase dans certains repositories utilisés au sein de ce usecase.

## 🛷 Proposition

- Intervention sur une des routes les plus utilisées : `GET /assessments/{id}`
- Intervention sur un utilitaire qui permet de récupérer des résultats paginés, et qui est souvent utilisé sur de la grosse requête : `knexUtils.fetchPage()`

## ☃️ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🧑‍🎄 Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
