### PR TITLE
[BUMP] Mise à jour de @1024pix/epreuves-components à 2.7.0

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -79,7 +79,7 @@
         "yargs": "^18.0.0"
       },
       "devDependencies": {
-        "@1024pix/epreuves-components": "^2.6.0",
+        "@1024pix/epreuves-components": "^2.7.0",
         "@1024pix/eslint-plugin": "^2.1.17",
         "@eslint/compat": "^2.0.1",
         "@ls-lint/ls-lint": "^2.3.1",
@@ -117,9 +117,9 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-2.6.0.tgz",
-      "integrity": "sha512-2P6Co2MQ7ImUHMzJK6DdbyZjuWF4Vs+5Tq5IC2aK8Mgv9GnQTsUVllAkUH5VQkLVtRQ0PLMHcc+SgBvwp6X2ww==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-2.7.0.tgz",
+      "integrity": "sha512-qeT8Hky2BcJA9fV+RXa5AP2+3qU/sHKpeq7AL8ZVG26PhtNqWLARXKghjpOD2nBWr3Yo6NmSppW5UBI41cpuKQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {

--- a/api/package.json
+++ b/api/package.json
@@ -85,7 +85,7 @@
     "yargs": "^18.0.0"
   },
   "devDependencies": {
-    "@1024pix/epreuves-components": "^2.6.0",
+    "@1024pix/epreuves-components": "^2.7.0",
     "@1024pix/eslint-plugin": "^2.1.17",
     "@eslint/compat": "^2.0.1",
     "@ls-lint/ls-lint": "^2.3.1",

--- a/api/src/devcomp/infrastructure/datasources/conversion/joi-to-json-schema.js
+++ b/api/src/devcomp/infrastructure/datasources/conversion/joi-to-json-schema.js
@@ -47,6 +47,11 @@ function convertString(joiStringDescribedSchema) {
     jsonSchema.format = 'uuid';
   }
 
+  const isoDateRule = findRule(rules, 'isoDate');
+  if (isoDateRule !== undefined) {
+    jsonSchema.format = 'date';
+  }
+
   const uriRule = findRule(rules, 'uri');
   if (uriRule !== undefined) {
     jsonSchema.format = 'uri';

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-epreuves-components.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-epreuves-components.json
@@ -1374,6 +1374,79 @@
           ]
         },
         {
+          "id": "629ce2a5-1e2d-4214-a3d7-313888fcdf9d",
+          "type": "discovery",
+          "title": "quiz-stepper",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "390b1adb-f3fe-4099-8431-99f798c779df",
+                "type": "text",
+                "content": "<p>quiz-stepper</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "1645e692-6fb8-473d-a317-243c3b518d29",
+                "type": "custom",
+                "instruction": "",
+                "tagName": "quiz-stepper",
+                "props": {
+                  "titleLevel": 2,
+                  "steps": [
+                    {
+                      "question": "Quelle version de ce message vous inciterait le plus à réagir ?",
+                      "feedback": {
+                        "success": "Effectivement, même si les deux messages transmettent la même idée, le second message crée un sentiment d’urgence et de menace. C’est un biais de cadrage : la manière dont l’information est présentée influence notre réaction.",
+                        "failed": "Ici, même si les deux messages transmettent la même idée, le second message crée un sentiment d’urgence et de menace. C’est un biais de cadrage : la manière dont l’information est présentée influence notre réaction."
+                      },
+                      "choice1": {
+                        "title": "Message 1",
+                        "content": "Bonjour, \n une facture est arrivée à échéance. Merci de la régler dans les plus brefs délais."
+                      },
+                      "choice2": {
+                        "title": "Message 2",
+                        "content": "⚠ URGENT : Si vous ne réglez pas cette facture sous 24h, votre compte sera suspendu et des pénalités financières s’appliqueront.",
+                        "isGoodAnswer": true
+                      }
+                    },
+                    {
+                      "question": "Quelle belle deuxième question que voila ?",
+                      "feedback": {
+                        "success": "Bravo !",
+                        "failed": "Dommage :("
+                      },
+                      "choice1": {
+                        "content": "CONTENT: Réponse 1 sans titre!"
+                      },
+                      "choice2": {
+                        "content": "CONTENT: Réponse 2 sans titre!",
+                        "isGoodAnswer": true
+                      }
+                    },
+                    {
+                      "question": "Quelle belle troisième non-question !",
+                      "feedback": {
+                        "success": "Bravo2 !",
+                        "failed": "Dommage2 :("
+                      },
+                      "choice1": {
+                        "title": "TITLE : Bonne réponse",
+                        "isGoodAnswer": true
+                      },
+                      "choice2": {
+                        "title": "TITLE: Mauvaise réponse"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        {
           "id": "45928ed8-83c9-4dfe-b5fb-07f83e60477e",
           "type": "discovery",
           "title": "select-conversation",

--- a/api/tests/devcomp/unit/infrastructure/datasources/conversion/joi-to-json-schema_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/conversion/joi-to-json-schema_test.js
@@ -43,6 +43,12 @@ describe('Unit | Infrastructure | Datasources | Conversion | joi-to-json-schema'
       expect(jsonSchema).to.deep.equal({ type: 'string', format: 'email' });
     });
 
+    it('should convert Joi.string.isoDate to JSON Schema with format date', function () {
+      const joiSchema = Joi.string().isoDate();
+      const jsonSchema = convertJoiToJsonSchema(joiSchema);
+      expect(jsonSchema).to.deep.equal({ type: 'string', format: 'date' });
+    });
+
     it('should convert Joi.string.uri to JSON Schema with format uri', function () {
       const joiSchema = Joi.string().uri();
       const jsonSchema = convertJoiToJsonSchema(joiSchema);

--- a/junior/package-lock.json
+++ b/junior/package-lock.json
@@ -11,7 +11,7 @@
       "license": "AGPL-3.0",
       "devDependencies": {
         "@1024pix/ember-testing-library": "^3.0.27",
-        "@1024pix/epreuves-components": "^2.6.0",
+        "@1024pix/epreuves-components": "^2.7.0",
         "@1024pix/eslint-plugin": "^2.1.17",
         "@1024pix/pix-ui": "^58.4.2",
         "@1024pix/stylelint-config": "^5.1.37",
@@ -180,9 +180,9 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-2.6.0.tgz",
-      "integrity": "sha512-2P6Co2MQ7ImUHMzJK6DdbyZjuWF4Vs+5Tq5IC2aK8Mgv9GnQTsUVllAkUH5VQkLVtRQ0PLMHcc+SgBvwp6X2ww==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-2.7.0.tgz",
+      "integrity": "sha512-qeT8Hky2BcJA9fV+RXa5AP2+3qU/sHKpeq7AL8ZVG26PhtNqWLARXKghjpOD2nBWr3Yo6NmSppW5UBI41cpuKQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {

--- a/junior/package.json
+++ b/junior/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^3.0.27",
-    "@1024pix/epreuves-components": "^2.6.0",
+    "@1024pix/epreuves-components": "^2.7.0",
     "@1024pix/eslint-plugin": "^2.1.17",
     "@1024pix/pix-ui": "^58.4.2",
     "@1024pix/stylelint-config": "^5.1.37",

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -12,7 +12,7 @@
       "devDependencies": {
         "@1024pix/ember-api-actions": "^1.1.0",
         "@1024pix/ember-testing-library": "^3.0.27",
-        "@1024pix/epreuves-components": "^2.6.0",
+        "@1024pix/epreuves-components": "^2.7.0",
         "@1024pix/eslint-plugin": "^2.1.17",
         "@1024pix/pix-ui": "^58.4.7",
         "@1024pix/stylelint-config": "^5.1.37",
@@ -900,9 +900,9 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-2.6.0.tgz",
-      "integrity": "sha512-2P6Co2MQ7ImUHMzJK6DdbyZjuWF4Vs+5Tq5IC2aK8Mgv9GnQTsUVllAkUH5VQkLVtRQ0PLMHcc+SgBvwp6X2ww==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-2.7.0.tgz",
+      "integrity": "sha512-qeT8Hky2BcJA9fV+RXa5AP2+3qU/sHKpeq7AL8ZVG26PhtNqWLARXKghjpOD2nBWr3Yo6NmSppW5UBI41cpuKQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@1024pix/ember-api-actions": "^1.1.0",
     "@1024pix/ember-testing-library": "^3.0.27",
-    "@1024pix/epreuves-components": "^2.6.0",
+    "@1024pix/epreuves-components": "^2.7.0",
     "@1024pix/eslint-plugin": "^2.1.17",
     "@1024pix/pix-ui": "^58.4.7",
     "@1024pix/stylelint-config": "^5.1.37",


### PR DESCRIPTION
## ❄️ Problème
Il manque des objets interactifs qui ont été créés dans pix épreuves.

## 🛷 Proposition
Mettre à jour le package pour rendre disponibles les nouveaux objets interactifs :
- Nouvel objet `quiz-stepper`
- Suppression du titre de `phishing-message`
- Suppression du bouton de réinitialisation sur `capacity-calculation`
- Amélioration de l'accessibilité sur `flip-cards`
- Émettre les informations de validation pour `image-quiz`

## ☃️ Remarques
- Prise en charge de `Joi.string().isoDate()` dans le script de conversion des schémas Joi en JSON schema.

## 🧑‍🎄 Pour tester
Aller sur la page de démo des composants et vérifier que tout roule.
Tests au vert.