### PR TITLE
[TECH] Améliore le monitoring sur l'état du pool de connexions de Knex

### DIFF
--- a/api/server.js
+++ b/api/server.js
@@ -161,6 +161,11 @@ const enableOpsMetrics = async function (server, metrics) {
     });
     metrics.addMetricPoint({
       type: 'gauge',
+      name: 'captain.api.knex.db_connections_pending_acquire',
+      value: pool.numPendingAcquires(),
+    });
+    metrics.addMetricPoint({
+      type: 'gauge',
       name: 'captain.api.knex.db_connections_pending_destroy',
       value: pool.pendingDestroys.length,
     });

--- a/api/server.js
+++ b/api/server.js
@@ -174,10 +174,7 @@ const enableOpsMetrics = async function (server, metrics) {
   const client = knex.client;
   gaugeConnections(client.pool)();
 
-  client.pool.on('createSuccess', gaugeConnections(client.pool));
-  client.pool.on('acquireSuccess', gaugeConnections(client.pool));
-  client.pool.on('release', gaugeConnections(client.pool));
-  client.pool.on('destroySuccess', gaugeConnections(client.pool));
+  setInterval(gaugeConnections(client.pool), 10_000);
 
   server.events.on('response', (request) => {
     const info = request.info;


### PR DESCRIPTION
## ❄️ Problème

La mesure n'est envoyée à Datadog que lors d'events sur le pool (nouvelle connexion acquise, connexion détruite, etc...)
Le problème c'est que si on est en train d'expérimenter un freeze de pool (car toutes les connexions sont idle in transaction par exemple), et bien plus aucune info ne remonte sur Datadog

## 🛷 Proposition

- Remplacer le branchement aux events à un envoi périodique de 10 secondes
- Ajouter la mesure du nombre de requêtes en attente de connexion

## ☃️ Remarques
source : https://github.com/vincit/tarn.js/

## 🧑‍🎄 Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
