### PR TITLE
[TECH] Mettre un FT pour activer ou désactiver la transaction autour du usecase de get next challenge

### DIFF
--- a/api/config/feature-toggles-config.js
+++ b/api/config/feature-toggles-config.js
@@ -87,4 +87,10 @@ export default {
     defaultValue: [],
     tags: ['team-acces', 'i18n', 'frontend'],
   },
+  enableTransactionForGetNext: {
+    type: 'boolean',
+    description: 'Enable wrapping the get next challenge usecase in a transaction',
+    defaultValue: true,
+    tags: ['captain', 'backend', 'db', 'pool'],
+  },
 };


### PR DESCRIPTION
## ❄️ Problème

La prod est en souffrance et on se demande si les containers n'ont pas tout simplement à gérer trop de transactions

## 🛷 Proposition

Mettre sous FT le fait de wrapper ou pas le usecase de get next challenge dans une transaction

## ☃️ Remarques

nom du FT : enableTransactionForGetNext
true par défaut

## 🧑‍🎄 Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
