### PR TITLE
[BUGFIX] Corriger la jauge de progression dans le cadre d'un participation à un campagne (PIX-21388).

### DIFF
--- a/api/src/evaluation/domain/services/algorithm-methods/data-fetcher.js
+++ b/api/src/evaluation/domain/services/algorithm-methods/data-fetcher.js
@@ -24,7 +24,8 @@ async function fetchForCampaigns({
   const knowledgeElements = await _fetchKnowledgeElements({
     assessment,
     isRetrying,
-    keepRecentOrValidated: true,
+    isFromCampaign: true,
+    isImproving: true,
     campaignParticipationRepository,
     knowledgeElementForParticipationService,
     knowledgeElementRepository,
@@ -44,7 +45,8 @@ async function fetchForCampaigns({
 async function _fetchKnowledgeElements({
   assessment,
   isRetrying = false,
-  keepRecentOrValidated = false,
+  isFromCampaign = false,
+  isImproving = false,
   knowledgeElementForParticipationService,
   knowledgeElementRepository,
   improvementService,
@@ -58,11 +60,13 @@ async function _fetchKnowledgeElements({
   } else {
     knowledgeElements = await knowledgeElementRepository.findUniqByUserId({ userId: assessment.userId });
   }
-  return improvementService.filterKnowledgeElementsIfImproving({
+
+  return improvementService.filterKnowledgeElements({
     knowledgeElements,
-    assessment,
+    isFromCampaign,
     isRetrying,
-    keepRecentOrValidated,
+    isImproving: isImproving ?? assessment.isImproving,
+    createdAt: assessment.createdAt,
   });
 }
 

--- a/api/src/evaluation/domain/services/improvement-service.js
+++ b/api/src/evaluation/domain/services/improvement-service.js
@@ -2,8 +2,8 @@ import dayjs from 'dayjs';
 
 import { constants } from '../../../shared/domain/constants.js';
 
-function _keepKnowledgeElementsRecentOrValidated({ currentUserKnowledgeElements, assessment, minimumDelayInDays }) {
-  const startedDateOfAssessment = assessment.createdAt;
+function keepKnowledgeElementsRecentOrValidated({ currentUserKnowledgeElements, createdAt, minimumDelayInDays }) {
+  const startedDateOfAssessment = createdAt;
 
   return currentUserKnowledgeElements.filter((knowledgeElement) => {
     const isNotOldEnoughToBeImproved =
@@ -12,25 +12,26 @@ function _keepKnowledgeElementsRecentOrValidated({ currentUserKnowledgeElements,
   });
 }
 
-function filterKnowledgeElementsIfImproving({
+function filterKnowledgeElements({
   knowledgeElements,
-  assessment,
+  createdAt,
   isRetrying = false,
-  keepRecentOrValidated = false,
+  isImproving = false,
+  isFromCampaign = false,
 }) {
-  const minimumDelayInDays =
-    isRetrying || keepRecentOrValidated
+  const isFromCampaignImprovingOrRetrying = isFromCampaign && (isImproving || isRetrying);
+  if (isFromCampaignImprovingOrRetrying || isImproving) {
+    const minimumDelayInDays = isFromCampaignImprovingOrRetrying
       ? constants.MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING
       : constants.MINIMUM_DELAY_IN_DAYS_BEFORE_IMPROVING;
 
-  if (keepRecentOrValidated || assessment.isImproving) {
-    return _keepKnowledgeElementsRecentOrValidated({
+    return keepKnowledgeElementsRecentOrValidated({
       currentUserKnowledgeElements: knowledgeElements,
-      assessment,
+      createdAt,
       minimumDelayInDays,
     });
   }
   return knowledgeElements;
 }
 
-export { filterKnowledgeElementsIfImproving };
+export { filterKnowledgeElements };

--- a/api/src/evaluation/domain/usecases/get-progression.js
+++ b/api/src/evaluation/domain/usecases/get-progression.js
@@ -31,10 +31,12 @@ const getProgression = async function ({
       campaignParticipationId: assessment.campaignParticipationId,
     });
 
-    const knowledgeElementsForProgression = await improvementService.filterKnowledgeElementsIfImproving({
+    const knowledgeElementsForProgression = improvementService.filterKnowledgeElements({
       knowledgeElements: knowledgeElementsBeforeSharedDate,
-      assessment,
+      createdAt: assessment.createdAt,
       isRetrying,
+      isFromCampaign: true,
+      isImproving: true,
     });
 
     progression = new Progression({
@@ -47,13 +49,13 @@ const getProgression = async function ({
 
   if (assessment.isCompetenceEvaluation()) {
     const competenceEvaluation = await competenceEvaluationRepository.getByAssessmentId(assessmentId);
-    const [skills, knowledgeElements] = await Promise.all([
-      skillRepository.findActiveByCompetenceId(competenceEvaluation.competenceId),
-      knowledgeElementRepository.findUniqByUserId({ userId }),
-    ]);
-    const knowledgeElementsForProgression = await improvementService.filterKnowledgeElementsIfImproving({
+    const skills = await skillRepository.findActiveByCompetenceId(competenceEvaluation.competenceId);
+    const knowledgeElements = await knowledgeElementRepository.findUniqByUserId({ userId });
+
+    const knowledgeElementsForProgression = improvementService.filterKnowledgeElements({
       knowledgeElements,
-      assessment,
+      isImproving: assessment.isImproving,
+      createdAt: assessment.createdAt,
     });
 
     progression = new Progression({

--- a/api/tests/evaluation/integration/domain/usecases/get-progression_test.js
+++ b/api/tests/evaluation/integration/domain/usecases/get-progression_test.js
@@ -1,0 +1,348 @@
+import dayjs from 'dayjs';
+
+import { evaluationUsecases } from '../../../../../src/evaluation/domain/usecases/index.js';
+import {
+  CampaignParticipationStatuses,
+  CampaignTypes,
+} from '../../../../../src/prescription/shared/domain/constants.js';
+import { ForbiddenAccess } from '../../../../../src/shared/domain/errors.js';
+import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
+import { KnowledgeElement } from '../../../../../src/shared/domain/models/KnowledgeElement.js';
+import { catchErr, databaseBuilder, expect } from '../../../../test-helper.js';
+
+describe('Integration | Domain | UseCases | get-progression', function () {
+  describe('when the assessment is link to a campaign participation', function () {
+    describe('campaign cases', function () {
+      let campaign, assessmentId, userId, assessmentCreatedDate, organizationLearner;
+
+      beforeEach(async function () {
+        campaign = databaseBuilder.factory.buildCampaign({ type: CampaignTypes.ASSESSMENT });
+        assessmentCreatedDate = new Date('2024-01-01');
+
+        const skillDatas = [
+          {
+            id: 'skillId0Perime',
+            status: 'périmé',
+          },
+          {
+            id: 'skillId1Archive',
+            status: 'archivé',
+          },
+          {
+            id: 'skillId2Actif',
+            status: 'actif',
+          },
+        ];
+
+        skillDatas.forEach((skillData) => {
+          const skill = databaseBuilder.factory.learningContent.buildSkill(skillData);
+
+          databaseBuilder.factory.buildCampaignSkill({ campaignId: campaign.id, skillId: skill.id });
+        });
+
+        organizationLearner = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId: campaign.organizationId,
+        });
+
+        await databaseBuilder.commit();
+      });
+
+      describe('When participation has been anonymized', function () {
+        it('should throw Forbidden Access', async function () {
+          //given
+          const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
+            campaignId: campaign.id,
+            userId: null,
+            organizationLearnerId: organizationLearner.id,
+            createdAt: assessmentCreatedDate,
+            status: CampaignParticipationStatuses.STARTED,
+            sharedAt: null,
+            deletedAt: new Date(),
+          });
+
+          assessmentId = databaseBuilder.factory.buildAssessment({
+            campaignParticipationId: null,
+            userId: campaignParticipation.userId,
+            type: Assessment.types.CAMPAIGN,
+            state: Assessment.states.STARTED,
+            createdAt: assessmentCreatedDate,
+          }).id;
+
+          await databaseBuilder.commit();
+
+          const error = await catchErr(evaluationUsecases.getProgression)({
+            progressionId: `progression-${assessmentId}`,
+            userId: campaignParticipation.userId,
+          });
+
+          expect(error).instanceOf(ForbiddenAccess);
+        });
+      });
+
+      describe('When participation is active', function () {
+        beforeEach(async function () {
+          const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
+            campaignId: campaign.id,
+            userId: organizationLearner.userId,
+            organizationLearnerId: organizationLearner.id,
+            createdAt: assessmentCreatedDate,
+            status: CampaignParticipationStatuses.STARTED,
+            sharedAt: null,
+          });
+
+          userId = campaignParticipation.userId;
+          assessmentId = databaseBuilder.factory.buildAssessment({
+            campaignParticipationId: campaignParticipation.id,
+            userId: campaignParticipation.userId,
+            type: Assessment.types.CAMPAIGN,
+            state: Assessment.states.STARTED,
+            createdAt: assessmentCreatedDate,
+          }).id;
+
+          await databaseBuilder.commit();
+        });
+
+        it('rate to 0, on user without any knowledge elements', async function () {
+          // given
+
+          // when
+          const result = await evaluationUsecases.getProgression({
+            progressionId: `progression-${assessmentId}`,
+            userId,
+          });
+
+          // then
+          expect(result.completionRate).equal(0);
+          expect(result).to.deep.equal({
+            id: `progression-${assessmentId}`,
+            isProfileCompleted: false,
+            knowledgeElements: [],
+            skillIds: ['skillId1Archive', 'skillId2Actif'],
+            targetedKnowledgeElements: [],
+          });
+        });
+
+        it('rate to 0, on user failed all knowledge element from previous assessment', async function () {
+          // given
+          databaseBuilder.factory.buildKnowledgeElement({
+            skillId: 'skillId1Archive',
+            userId,
+            status: KnowledgeElement.StatusType.INVALIDATED,
+            createdAt: dayjs(assessmentCreatedDate).subtract(10, 'day').toDate(),
+          });
+          databaseBuilder.factory.buildKnowledgeElement({
+            skillId: 'skillId2Actif',
+            userId,
+            status: KnowledgeElement.StatusType.INVALIDATED,
+            createdAt: dayjs(assessmentCreatedDate).subtract(10, 'day').toDate(),
+          });
+
+          await databaseBuilder.commit();
+
+          // when
+          const result = await evaluationUsecases.getProgression({
+            progressionId: `progression-${assessmentId}`,
+            userId,
+          });
+
+          // then
+          expect(result.completionRate).equal(0);
+          expect(result).to.deep.equal({
+            id: `progression-${assessmentId}`,
+            isProfileCompleted: false,
+            knowledgeElements: [],
+            skillIds: ['skillId1Archive', 'skillId2Actif'],
+            targetedKnowledgeElements: [],
+          });
+        });
+
+        it('rate to 0, on user reset all previous knowledge element from previous assessment', async function () {
+          // given
+          databaseBuilder.factory.buildKnowledgeElement({
+            skillId: 'skillId1Archive',
+            userId,
+            status: KnowledgeElement.StatusType.VALIDATED,
+            createdAt: dayjs(assessmentCreatedDate).subtract(20, 'day').toDate(),
+          });
+          databaseBuilder.factory.buildKnowledgeElement({
+            skillId: 'skillId2Actif',
+            userId,
+            status: KnowledgeElement.StatusType.VALIDATED,
+            createdAt: dayjs(assessmentCreatedDate).subtract(20, 'day').toDate(),
+          });
+          databaseBuilder.factory.buildKnowledgeElement({
+            skillId: 'skillId1Archive',
+            userId,
+            status: KnowledgeElement.StatusType.RESET,
+            createdAt: dayjs(assessmentCreatedDate).subtract(10, 'day').toDate(),
+          });
+
+          databaseBuilder.factory.buildKnowledgeElement({
+            skillId: 'skillId2Actif',
+            userId,
+            status: KnowledgeElement.StatusType.RESET,
+            createdAt: dayjs(assessmentCreatedDate).subtract(10, 'day').toDate(),
+          });
+
+          await databaseBuilder.commit();
+
+          // when
+          const result = await evaluationUsecases.getProgression({
+            progressionId: `progression-${assessmentId}`,
+            userId,
+          });
+
+          // then
+          expect(result.completionRate).equal(0);
+          expect(result).to.deep.equal({
+            id: `progression-${assessmentId}`,
+            isProfileCompleted: false,
+            knowledgeElements: [],
+            skillIds: ['skillId1Archive', 'skillId2Actif'],
+            targetedKnowledgeElements: [],
+          });
+        });
+
+        it('rate to 1, on user succeed all knowledge element from previous assessment', async function () {
+          // given
+          const ke1 = databaseBuilder.factory.buildKnowledgeElement({
+            skillId: 'skillId1Archive',
+            userId,
+            status: KnowledgeElement.StatusType.VALIDATED,
+            createdAt: dayjs(assessmentCreatedDate).subtract(10, 'day').toDate(),
+          });
+          const ke2 = databaseBuilder.factory.buildKnowledgeElement({
+            skillId: 'skillId2Actif',
+            userId,
+            status: KnowledgeElement.StatusType.VALIDATED,
+            createdAt: dayjs(assessmentCreatedDate).subtract(20, 'day').toDate(),
+          });
+
+          await databaseBuilder.commit();
+
+          // when
+          const result = await evaluationUsecases.getProgression({
+            progressionId: `progression-${assessmentId}`,
+            userId,
+          });
+
+          // then
+          expect(result.completionRate).equal(1);
+          expect(result).to.deep.equal({
+            id: `progression-${assessmentId}`,
+            isProfileCompleted: false,
+            knowledgeElements: [ke1, ke2],
+            skillIds: ['skillId1Archive', 'skillId2Actif'],
+            targetedKnowledgeElements: [ke1, ke2],
+          });
+        });
+
+        it('rate to 1, on user succeed all knowledge element from current assessment', async function () {
+          // given
+          const ke1 = databaseBuilder.factory.buildKnowledgeElement({
+            skillId: 'skillId1Archive',
+            userId,
+            assessmentId,
+            status: KnowledgeElement.StatusType.VALIDATED,
+            createdAt: dayjs(assessmentCreatedDate).add(1, 'hour').toDate(),
+          });
+          const ke2 = databaseBuilder.factory.buildKnowledgeElement({
+            skillId: 'skillId2Actif',
+            userId,
+            assessmentId,
+            status: KnowledgeElement.StatusType.VALIDATED,
+            createdAt: dayjs(assessmentCreatedDate).add(1, 'hour').toDate(),
+          });
+
+          await databaseBuilder.commit();
+
+          // when
+          const result = await evaluationUsecases.getProgression({
+            progressionId: `progression-${assessmentId}`,
+            userId,
+          });
+
+          // then
+          expect(result.completionRate).equal(1);
+          expect(result).to.deep.equal({
+            id: `progression-${assessmentId}`,
+            isProfileCompleted: false,
+            knowledgeElements: [ke1, ke2],
+            skillIds: ['skillId1Archive', 'skillId2Actif'],
+            targetedKnowledgeElements: [ke1, ke2],
+          });
+        });
+
+        it('rate to 1, on user missed some knowledge element from current assessment', async function () {
+          // given
+          const ke1 = databaseBuilder.factory.buildKnowledgeElement({
+            skillId: 'skillId1Archive',
+            userId,
+            assessmentId,
+            status: KnowledgeElement.StatusType.VALIDATED,
+            createdAt: dayjs(assessmentCreatedDate).add(1, 'hour').toDate(),
+          });
+          const ke2 = databaseBuilder.factory.buildKnowledgeElement({
+            skillId: 'skillId2Actif',
+            userId,
+            assessmentId,
+            status: KnowledgeElement.StatusType.INVALIDATED,
+            createdAt: dayjs(assessmentCreatedDate).add(1, 'hour').toDate(),
+          });
+
+          await databaseBuilder.commit();
+
+          // when
+          const result = await evaluationUsecases.getProgression({
+            progressionId: `progression-${assessmentId}`,
+            userId,
+          });
+
+          // then
+          expect(result.completionRate).equal(1);
+          expect(result).to.deep.equal({
+            id: `progression-${assessmentId}`,
+            isProfileCompleted: false,
+            knowledgeElements: [ke1, ke2],
+            skillIds: ['skillId1Archive', 'skillId2Actif'],
+            targetedKnowledgeElements: [ke1, ke2],
+          });
+        });
+
+        it('rate to 0.5, on user missed some knowledge element from previous assessment', async function () {
+          // given
+          const ke1 = databaseBuilder.factory.buildKnowledgeElement({
+            skillId: 'skillId1Archive',
+            userId,
+            status: KnowledgeElement.StatusType.VALIDATED,
+            createdAt: dayjs(assessmentCreatedDate).subtract(10, 'day').toDate(),
+          });
+          databaseBuilder.factory.buildKnowledgeElement({
+            skillId: 'skillId2Actif',
+            userId,
+            status: KnowledgeElement.StatusType.INVALIDATED,
+            createdAt: dayjs(assessmentCreatedDate).subtract(10, 'day').toDate(),
+          });
+
+          await databaseBuilder.commit();
+
+          // when
+          const result = await evaluationUsecases.getProgression({
+            progressionId: `progression-${assessmentId}`,
+            userId,
+          });
+
+          // then
+          expect(result.completionRate).equal(0.5);
+          expect(result).to.deep.equal({
+            id: `progression-${assessmentId}`,
+            isProfileCompleted: false,
+            knowledgeElements: [ke1],
+            skillIds: ['skillId1Archive', 'skillId2Actif'],
+            targetedKnowledgeElements: [ke1],
+          });
+        });
+      });
+    });
+  });
+});

--- a/api/tests/evaluation/unit/domain/services/smart-random/data-fetcher_test.js
+++ b/api/tests/evaluation/unit/domain/services/smart-random/data-fetcher_test.js
@@ -31,7 +31,7 @@ describe('Unit | Domain | services | smart-random | dataFetcher', function () {
         isRetrying: sinon.stub(),
       };
       improvementService = {
-        filterKnowledgeElementsIfImproving: sinon.stub(),
+        filterKnowledgeElements: sinon.stub(),
       };
     });
 
@@ -61,8 +61,14 @@ describe('Unit | Domain | services | smart-random | dataFetcher', function () {
       campaignParticipationRepository.isRetrying
         .withArgs({ campaignParticipationId: assessment.campaignParticipationId })
         .resolves(isRetrying);
-      improvementService.filterKnowledgeElementsIfImproving
-        .withArgs({ knowledgeElements, assessment, isRetrying, keepRecentOrValidated: true })
+      improvementService.filterKnowledgeElements
+        .withArgs({
+          knowledgeElements,
+          isRetrying,
+          isImproving: true,
+          createdAt: assessment.createdAt,
+          isFromCampaign: true,
+        })
         .resolves(filteredKnowledgeElements);
 
       // when
@@ -111,8 +117,14 @@ describe('Unit | Domain | services | smart-random | dataFetcher', function () {
       campaignParticipationRepository.isRetrying
         .withArgs({ campaignParticipationId: assessment.campaignParticipationId })
         .resolves(isRetrying);
-      improvementService.filterKnowledgeElementsIfImproving
-        .withArgs({ knowledgeElements, assessment, isRetrying, keepRecentOrValidated: true })
+      improvementService.filterKnowledgeElements
+        .withArgs({
+          knowledgeElements,
+          isFromCampaign: true,
+          isRetrying,
+          createdAt: assessment.createdAt,
+          isImproving: true,
+        })
         .resolves(filteredKnowledgeElements);
 
       // when
@@ -163,7 +175,7 @@ describe('Unit | Domain | services | smart-random | dataFetcher', function () {
         findActiveByCompetenceId: sinon.stub(),
       };
       improvementService = {
-        filterKnowledgeElementsIfImproving: sinon.stub(),
+        filterKnowledgeElements: sinon.stub(),
       };
 
       answer = domainBuilder.buildAnswer();
@@ -177,8 +189,14 @@ describe('Unit | Domain | services | smart-random | dataFetcher', function () {
       skillRepository.findActiveByCompetenceId.withArgs(assessment.competenceId).resolves(skills);
       challengeRepository.findValidatedByCompetenceId.withArgs(assessment.competenceId).resolves(challenges);
       knowledgeElementRepository.findUniqByUserId.withArgs({ userId: assessment.userId }).resolves(knowledgeElements);
-      improvementService.filterKnowledgeElementsIfImproving
-        .withArgs({ knowledgeElements, assessment, isRetrying: false, keepRecentOrValidated: false })
+      improvementService.filterKnowledgeElements
+        .withArgs({
+          knowledgeElements,
+          isRetrying: false,
+          isFromCampaign: false,
+          isImproving: assessment.isImproving,
+          createdAt: assessment.createdAt,
+        })
         .resolves(filteredKnowledgeElements);
 
       // when
@@ -194,7 +212,7 @@ describe('Unit | Domain | services | smart-random | dataFetcher', function () {
 
     it('filter knowledge elements if assessment is an improving one', async function () {
       // then
-      expect(improvementService.filterKnowledgeElementsIfImproving).to.be.called;
+      expect(improvementService.filterKnowledgeElements).to.be.called;
     });
 
     it('fetches answers, targetsSkills challenges and knowledgeElements', async function () {


### PR DESCRIPTION
## ❄️ Problème

Suite à la possibilité de repasser les acquis invalidés par défaut, il est arrivé un petit souci à la jauge de progression qui, elle, les prenait toujours en compte. 
Un utilisateur voyait 100% de progression mais un bouton "continuer." l'impression d'une spirale infernale pour engloutir toutes les connaissance de Pix

## 🛷 Proposition

Utiliser le boolean que nous avions mis en place sur le dataFetcher pour exclure les acquis invalidés lors du choix de la prochaine question.

## ☃️ Remarques

Ce bug est apparu car le usecase de progression était testé en unitaire. sans réel donnée pour valider le comportement du métier. 
Transformation d'une partie du usecase ( celui impactant les campagnes en test d'integration afin d'avoir les cas possibles testés dans des conditions proches du réel )

## 🧑‍🎄 Pour tester
Ci au vert. 
Créer un PC sur un domaine cappé au MAX
Créer une campagne avec ce parcours.
Se positionner d'abord en autonomie et tout rater
Participer à la campagne et répondre une question sur deux pour avoir le checkpoint. 
Vérifier qu'au checkpoint vous n'avez pas 100% mais un pourcentage cohérent avec la réalité de la vie 

