### PR TITLE
[TECH] Ajout d'une colonne contenant la configuration de scoring sur les tables permettant la remontée Parcoursup du Datamart (PIX-21422)

### DIFF
--- a/api/datamart/migrations/20260206095838_add-column-configuration-to-certification-result-tables.js
+++ b/api/datamart/migrations/20260206095838_add-column-configuration-to-certification-result-tables.js
@@ -1,0 +1,31 @@
+const TABLE_NAME_1 = 'sco_certification_results';
+const TABLE_NAME_2 = 'certification_results';
+const COLUMN_NAME = 'configuration';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME_1, function (table) {
+    table.jsonb(COLUMN_NAME).defaultTo(null).comment('Configuration of scoring for certification');
+  });
+  await knex.schema.table(TABLE_NAME_2, function (table) {
+    table.jsonb(COLUMN_NAME).defaultTo(null).comment('Configuration of scoring for certification');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME_1, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+  await knex.schema.table(TABLE_NAME_2, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## ❄️ Problème

Actuellement, on ne récupère pas la configuration de scoring lorsqu'on construit les CertificationResults de Parcoursup. Or, dans le but de versionner la notion du "niveau maximum atteignable" (MAX_REACHABLE_LEVEL, actuellement 7), on calcule à présent cette valeur depuis la configuration de scoring et elle est nécessaire pour construire les  CertificationResults de Parcoursup. 

## 🛷 Proposition

Ajouter une colonne "configuration" aux tables `sco_certification_results` et `certification_results` du datamart dans le but d'ensuite remonter dans la réplication la colonne du même nom des tables `data_export_parcoursup_certif_result_code_validation` et `data_export_parcoursup_certif_result` du datawarehouse

## ☃️ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🧑‍🎄 Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
