### PR TITLE
[TECH] Utiliser la DomainTransaction dans les repositories du domaine Acquisition (PIX-21420).

### DIFF
--- a/api/src/certification/enrolment/infrastructure/repositories/center-repository.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/center-repository.js
@@ -2,7 +2,6 @@
 /**
  * @typedef {import ('../../../shared/domain/models/ComplementaryCertificationKeys.js').ComplementaryCertificationKeys} ComplementaryCertificationKeys
  */
-import { knex } from '../../../../../db/knex-database-connection.js';
 import { Organization } from '../../../../organizational-entities/domain/models/Organization.js';
 import { CERTIFICATION_CENTER_TYPES } from '../../../../shared/domain/constants.js';
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
@@ -55,7 +54,7 @@ export async function getById({ id }) {
   }
   let matchingOrganization = null;
   if (center.type === CERTIFICATION_CENTER_TYPES.SCO) {
-    const organizationDB = await knex('organizations')
+    const organizationDB = await knexConn('organizations')
       .where({ type: Organization.types.SCO })
       .whereRaw('LOWER("externalId") = ?', center.externalId?.toLowerCase() ?? '')
       .first();

--- a/api/src/organizational-entities/infrastructure/repositories/administration-team-repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/administration-team-repository.js
@@ -1,14 +1,16 @@
-import { knex } from '../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { AdministrationTeam } from '../../domain/models/AdministrationTeam.js';
 
 const findAll = async function () {
-  const administrationTeams = await knex.select('id', 'name').from('administration_teams').orderBy('name', 'asc');
+  const knexConn = DomainTransaction.getConnection();
+  const administrationTeams = await knexConn.select('id', 'name').from('administration_teams').orderBy('name', 'asc');
 
   return administrationTeams.map(_toDomain);
 };
 
 const getById = async function (id) {
-  const administrationTeam = await knex.select('id', 'name').from('administration_teams').where({ id }).first();
+  const knexConn = DomainTransaction.getConnection();
+  const administrationTeam = await knexConn.select('id', 'name').from('administration_teams').where({ id }).first();
 
   if (!administrationTeam) {
     return null;

--- a/api/src/organizational-entities/infrastructure/repositories/data-protection-officer.repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/data-protection-officer.repository.js
@@ -1,4 +1,3 @@
-import { knex } from '../../../../db/knex-database-connection.js';
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { DataProtectionOfficer } from '../../domain/models/DataProtectionOfficer.js';
 
@@ -6,7 +5,7 @@ const DATA_PROTECTION_OFFICERS_TABLE_NAME = 'data-protection-officers';
 
 async function batchAddDataProtectionOfficerToOrganization(organizationDataProtectionOfficer) {
   const knexConn = DomainTransaction.getConnection();
-  await knex
+  await knexConn
     .batchInsert(DATA_PROTECTION_OFFICERS_TABLE_NAME, organizationDataProtectionOfficer)
     .transacting(knexConn.isTransaction ? knexConn : null);
 }

--- a/api/src/organizational-entities/infrastructure/repositories/organization-learner.repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/organization-learner.repository.js
@@ -1,4 +1,3 @@
-import { knex } from '../../../../db/knex-database-connection.js';
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { ParticipantRepartition } from '../../domain/models/ParticipantRepartition.js';
 
@@ -20,8 +19,8 @@ const findAllLearnerWithAtLeastOneParticipationByOrganizationId = async function
     .join('campaign-participations', function () {
       this.on('campaign-participations.organizationLearnerId', 'view-active-organization-learners.id').andOnVal(
         'campaign-participations.deletedAt',
-        knex.raw('IS'),
-        knex.raw('NULL'),
+        knexConn.raw('IS'),
+        knexConn.raw('NULL'),
       );
     })
     .where({ organizationId });

--- a/api/src/organizational-entities/infrastructure/repositories/organization-places-lot.repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/organization-places-lot.repository.js
@@ -1,4 +1,3 @@
-import { knex } from '../../../../db/knex-database-connection.js';
 import { PlacesLot } from '../../../organizational-entities/domain/read-models/PlacesLot.js';
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 
@@ -22,17 +21,17 @@ const baseQuery = ({ organizationIds, callOrderByAndRemoveDeleted = false }) => 
     .whereIn('organization-places.organizationId', organizationIds);
 
   if (callOrderByAndRemoveDeleted) {
-    query = orderByAndRemoveDeleted(query);
+    query = orderByAndRemoveDeleted(query, knexConn);
   }
 
   return query;
 };
 
-const orderByAndRemoveDeleted = (query) => {
+const orderByAndRemoveDeleted = (query, knexConn) => {
   return query
     .whereNull('organization-places.deletedAt')
     .orderBy(
-      knex.raw(
+      knexConn.raw(
         'CASE WHEN "organization-places"."activationDate" <= now() AND "organization-places"."expirationDate" >= now() THEN 1 WHEN "organization-places"."activationDate" > now() THEN 2 ELSE 3 END',
       ),
       'asc',

--- a/api/src/organizational-entities/infrastructure/repositories/tag.repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/tag.repository.js
@@ -1,6 +1,5 @@
 import lodash from 'lodash';
 
-import { knex } from '../../../../db/knex-database-connection.js';
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { AlreadyExistingEntityError } from '../../../shared/domain/errors.js';
 import * as knexUtils from '../../../shared/infrastructure/utils/knex-utils.js';
@@ -9,9 +8,10 @@ import { Tag } from '../../domain/models/Tag.js';
 const { omit } = lodash;
 
 const create = async function (tag) {
+  const knexConn = DomainTransaction.getConnection();
   try {
     const tagToCreate = omit(tag, 'id');
-    const [row] = await knex('tags').insert(tagToCreate).returning('*');
+    const [row] = await knexConn('tags').insert(tagToCreate).returning('*');
     return new Tag(row);
   } catch (error) {
     if (knexUtils.isUniqConstraintViolated(error)) {
@@ -22,7 +22,8 @@ const create = async function (tag) {
 };
 
 const findByName = async function ({ name }) {
-  const row = await knex('tags').where({ name }).first();
+  const knexConn = DomainTransaction.getConnection();
+  const row = await knexConn('tags').where({ name }).first();
   if (!row) {
     return null;
   }
@@ -30,7 +31,8 @@ const findByName = async function ({ name }) {
 };
 
 const findAll = async function () {
-  const rows = await knex('tags');
+  const knexConn = DomainTransaction.getConnection();
+  const rows = await knexConn('tags');
   return rows.map((row) => new Tag(row));
 };
 

--- a/api/src/organizational-entities/infrastructure/repositories/target-profile-share-repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/target-profile-share-repository.js
@@ -1,9 +1,8 @@
-import { knex } from '../../../../db/knex-database-connection.js';
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 
 const batchAddTargetProfilesToOrganization = async function (organizationTargetProfiles) {
   const knexConn = DomainTransaction.getConnection();
-  await knex
+  await knexConn
     .batchInsert('target-profile-shares', organizationTargetProfiles)
     .transacting(knexConn.isTransaction ? knexConn : null);
 };

--- a/api/src/school/infrastructure/repositories/school-repository.js
+++ b/api/src/school/infrastructure/repositories/school-repository.js
@@ -1,4 +1,3 @@
-import { knex } from '../../../../db/knex-database-connection.js';
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { Division } from '../../domain/models/Division.js';
 import { School } from '../../domain/models/School.js';
@@ -10,11 +9,13 @@ const save = async function ({ organizationId, code }) {
 };
 
 const isCodeAvailable = async function ({ code }) {
-  return !(await knex('schools').first('id').where({ code }));
+  const knexConn = DomainTransaction.getConnection();
+  return !(await knexConn('schools').first('id').where({ code }));
 };
 
 const getByCode = async function ({ code }) {
-  const data = await knex('schools')
+  const knexConn = DomainTransaction.getConnection();
+  const data = await knexConn('schools')
     .select('organizations.id', 'name', 'code')
     .join('organizations', 'organizations.id', 'organizationId')
     .where({ code })
@@ -28,12 +29,14 @@ const getByCode = async function ({ code }) {
 };
 
 const getById = async function ({ organizationId }) {
-  const result = await knex('schools').first('code').where({ organizationId });
+  const knexConn = DomainTransaction.getConnection();
+  const result = await knexConn('schools').first('code').where({ organizationId });
   return result.code;
 };
 
 const updateSessionExpirationDate = async function ({ organizationId, sessionExpirationDate }) {
-  await knex('schools').where({ organizationId }).update({ sessionExpirationDate });
+  const knexConn = DomainTransaction.getConnection();
+  await knexConn('schools').where({ organizationId }).update({ sessionExpirationDate });
 };
 
 const getDivisions = async function ({ organizationId, organizationLearnerApi }) {
@@ -45,7 +48,8 @@ const getDivisions = async function ({ organizationId, organizationLearnerApi })
 };
 
 const getSessionExpirationDate = async function ({ code }) {
-  const [sessionExpirationDate] = await knex('schools')
+  const knexConn = DomainTransaction.getConnection();
+  const [sessionExpirationDate] = await knexConn('schools')
     .select('sessionExpirationDate')
     .where({ code })
     .pluck('sessionExpirationDate');

--- a/api/src/shared/infrastructure/repositories/admin-member.repository.js
+++ b/api/src/shared/infrastructure/repositories/admin-member.repository.js
@@ -1,11 +1,12 @@
-import { knex } from '../../../../db/knex-database-connection.js';
 import { AdminMemberError } from '../../../authorization/domain/errors.js';
 import { AdminMember } from '../../../team/domain/models/AdminMember.js';
+import { DomainTransaction } from '../../domain/DomainTransaction.js';
 
 const TABLE_NAME = 'pix-admin-roles';
 
 const findAll = async function () {
-  const members = await knex
+  const knexConn = DomainTransaction.getConnection();
+  const members = await knexConn
     .select(`${TABLE_NAME}.id`, 'users.id as userId', 'firstName', 'lastName', 'email', 'role')
     .from(TABLE_NAME)
     .where({ disabledAt: null })
@@ -16,7 +17,8 @@ const findAll = async function () {
 };
 
 const getById = async function (id) {
-  const adminMember = await knex
+  const knexConn = DomainTransaction.getConnection();
+  const adminMember = await knexConn
     .select(`${TABLE_NAME}.id`, 'users.id as userId', 'firstName', 'lastName', 'email', 'role', 'disabledAt')
     .from(TABLE_NAME)
     .where({ 'pix-admin-roles.id': id })
@@ -27,7 +29,8 @@ const getById = async function (id) {
 };
 
 const get = async function ({ userId }) {
-  const adminMember = await knex
+  const knexConn = DomainTransaction.getConnection();
+  const adminMember = await knexConn
     .select(`${TABLE_NAME}.id`, 'users.id as userId', 'firstName', 'lastName', 'email', 'role', 'disabledAt')
     .from(TABLE_NAME)
     .where({ userId })
@@ -38,8 +41,9 @@ const get = async function ({ userId }) {
 };
 
 const update = async function ({ id, attributesToUpdate }) {
+  const knexConn = DomainTransaction.getConnection();
   const now = new Date();
-  const [updatedAdminMember] = await knex
+  const [updatedAdminMember] = await knexConn
     .from(TABLE_NAME)
     .where({ id })
     .update({ ...attributesToUpdate, updatedAt: now })
@@ -56,13 +60,15 @@ const update = async function ({ id, attributesToUpdate }) {
 };
 
 const save = async function (pixAdminRole) {
-  const [savedAdminMember] = await knex(TABLE_NAME).insert(pixAdminRole).returning('*');
+  const knexConn = DomainTransaction.getConnection();
+  const [savedAdminMember] = await knexConn(TABLE_NAME).insert(pixAdminRole).returning('*');
   return new AdminMember(savedAdminMember);
 };
 
 const deactivate = async function ({ id }) {
+  const knexConn = DomainTransaction.getConnection();
   const now = new Date();
-  const [deactivateddAdminMember] = await knex
+  const [deactivateddAdminMember] = await knexConn
     .from('pix-admin-roles')
     .where({ id })
     .whereRaw('"disabledAt" IS NULL')

--- a/api/src/shared/infrastructure/repositories/country-repository.js
+++ b/api/src/shared/infrastructure/repositories/country-repository.js
@@ -1,23 +1,25 @@
-import { knex } from '../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../domain/DomainTransaction.js';
 import { NotFoundError } from '../../domain/errors.js';
 import { Country } from '../../domain/read-models/Country.js';
 
 const findAll = async function () {
-  const result = await knex
+  const knexConn = DomainTransaction.getConnection();
+  const result = await knexConn
     .from('certification-cpf-countries')
     .select('commonName', 'code', 'matcher')
-    .where('commonName', '=', knex.ref('originalName'))
+    .where('commonName', '=', knexConn.ref('originalName'))
     .orderBy('commonName', 'asc');
 
   return result.map(_toDomain);
 };
 
 const getByCode = async function (code) {
-  const result = await knex
+  const knexConn = DomainTransaction.getConnection();
+  const result = await knexConn
     .from('certification-cpf-countries')
     .select('commonName', 'code', 'matcher')
     .where({ code })
-    .where('commonName', '=', knex.ref('originalName'))
+    .where('commonName', '=', knexConn.ref('originalName'))
     .first();
 
   if (!result) {

--- a/api/src/shared/infrastructure/repositories/organization-repository.js
+++ b/api/src/shared/infrastructure/repositories/organization-repository.js
@@ -1,4 +1,3 @@
-import { knex } from '../../../../db/knex-database-connection.js';
 import { Organization } from '../../../organizational-entities/domain/models/Organization.js';
 import { Tag } from '../../../organizational-entities/domain/models/Tag.js';
 import { ORGANIZATION_FEATURE } from '../../../shared/domain/constants.js';
@@ -51,7 +50,9 @@ const get = async function (id) {
 };
 
 const getIdByCertificationCenterId = async function (certificationCenterId) {
-  const organizationIds = await knex
+  const knexConn = DomainTransaction.getConnection();
+
+  const organizationIds = await knexConn
     .pluck('organizations.id')
     .from(ORGANIZATIONS_TABLE_NAME)
     .innerJoin('certification-centers', function () {
@@ -68,7 +69,8 @@ const getIdByCertificationCenterId = async function (certificationCenterId) {
 };
 
 const findActiveScoOrganizationsByExternalId = async function (externalId) {
-  const organizationsDB = await knex(ORGANIZATIONS_TABLE_NAME)
+  const knexConn = DomainTransaction.getConnection();
+  const organizationsDB = await knexConn(ORGANIZATIONS_TABLE_NAME)
     .where({ archivedAt: null })
     .whereIn('type', [Organization.types.SCO, Organization.types.SCO1D])
     .whereRaw('LOWER("externalId") = ?', `${externalId.toLowerCase()}`);


### PR DESCRIPTION
## ❄️ Problème

Certains repositories utilisent knex en direct alors qu'ils peuvent être utilisés dans un usecase nécessitant une transaction. ce qui ouvre deux pool à la db au lieu d'une.

## 🛷 Proposition

Utiliser DomainTransaction dans les repo du folder `organizational-entities`.

## ☃️ Remarques

On a modifié quelques repos d'autres domaines qui sont encore importés dans le domaine `organizational-entities`.
D'autres PR liées à de la migration/ API internes viendront dans le futur.

## 🧑‍🎄 Pour tester

CI ✅ 