### PR TITLE
[TECH] Utiliser les DomainTransaction dans les repository de devcomp (PIX-21418)

### DIFF
--- a/api/src/devcomp/infrastructure/repositories/tutorial-evaluation-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/tutorial-evaluation-repository.js
@@ -1,10 +1,12 @@
 import { knex } from '../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { TutorialEvaluation } from '../../domain/models/TutorialEvaluation.js';
 
 const TABLE_NAME = 'tutorial-evaluations';
 
 const createOrUpdate = async function ({ userId, tutorialId, status }) {
-  const tutorialEvaluation = await knex(TABLE_NAME)
+  const knexConn = DomainTransaction.getConnection();
+  const tutorialEvaluation = await knexConn(TABLE_NAME)
     .insert({
       userId,
       tutorialId,
@@ -20,7 +22,8 @@ const createOrUpdate = async function ({ userId, tutorialId, status }) {
 };
 
 const find = async function ({ userId }) {
-  const tutorialEvaluation = await knex(TABLE_NAME).where({ userId });
+  const knexConn = DomainTransaction.getConnection();
+  const tutorialEvaluation = await knexConn(TABLE_NAME).where({ userId });
   return tutorialEvaluation.map(_toDomain);
 };
 

--- a/api/src/devcomp/infrastructure/repositories/user-saved-tutorial-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/user-saved-tutorial-repository.js
@@ -1,24 +1,27 @@
-import { knex } from '../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { UserSavedTutorial } from '../../domain/models/UserSavedTutorial.js';
 
 const TABLE_NAME = 'user-saved-tutorials';
 
 const addTutorial = async function ({ userId, tutorialId, skillId }) {
-  const userSavedTutorials = await knex(TABLE_NAME).where({ userId, tutorialId });
+  const knexConn = DomainTransaction.getConnection();
+  const userSavedTutorials = await knexConn(TABLE_NAME).where({ userId, tutorialId });
   if (userSavedTutorials.length) {
     return _toDomain(userSavedTutorials[0]);
   }
-  const savedUserSavedTutorials = await knex(TABLE_NAME).insert({ userId, tutorialId, skillId }).returning('*');
+  const savedUserSavedTutorials = await knexConn(TABLE_NAME).insert({ userId, tutorialId, skillId }).returning('*');
   return _toDomain(savedUserSavedTutorials[0]);
 };
 
 const find = async function ({ userId }) {
-  const userSavedTutorials = await knex(TABLE_NAME).where({ userId }).orderBy('createdAt', 'desc');
+  const knexConn = DomainTransaction.getConnection();
+  const userSavedTutorials = await knexConn(TABLE_NAME).where({ userId }).orderBy('createdAt', 'desc');
   return userSavedTutorials.map(_toDomain);
 };
 
 const removeFromUser = async function (userSavedTutorial) {
-  return knex(TABLE_NAME).where(userSavedTutorial).delete();
+  const knexConn = DomainTransaction.getConnection();
+  return knexConn(TABLE_NAME).where(userSavedTutorial).delete();
 };
 
 export { addTutorial, find, removeFromUser };


### PR DESCRIPTION
## ❄️ Problème
Actuellement, dans les repository, il arrive qu'on n'utilise pas la connexion ouverte par les transactions. Cela utilse alors une nouvelle connexion pour effectuer les requêtes, ce qui cause des pb de file d'attente pour les requêtes entrantes, et des timeout quand la bdd est surchargée.

## 🛷 Proposition
Récupérer la connexion ouverte par les transactions, et l'utiliser.

## ☃️ Remarques
Tests effectués en mettant la variable `DATABASE_CONNECTION_POOL_MAX_SIZE=1` . Sur le path `api/tests/devcomp`
- tests d'acceptance ✅ 
- test d'integration ✅ 

Aucun problème de `timeout` détecté.

Même si on parle de transaction, à aucun moment il n'est question d'argent ici.

## 🧑‍🎄 Pour tester
La CI est 🍏 
