### PR TITLE
[TECH] Mise en place de timeouts divers, à la fois niveau serveur et niveau client BDD, afin de ne pas laisser de l'activité orpheline dans le cas où le client a fermé la connexion

### DIFF
--- a/api/datamart/knexfile.js
+++ b/api/datamart/knexfile.js
@@ -7,13 +7,21 @@ const baseConfiguration = {
   name: 'datamart',
   migrationsDirectory: './migrations/',
   seedsDirectory: './seeds/',
-  databaseUrl: process.env.DATAMART_DATABASE_URL,
+  connection: {
+    connectionString: process.env.DATAMART_DATABASE_URL,
+  },
 };
 
 const environments = {
   development: buildPostgresEnvironment(baseConfiguration),
 
-  test: buildPostgresEnvironment({ ...baseConfiguration, databaseUrl: process.env.TEST_DATAMART_DATABASE_URL }),
+  test: buildPostgresEnvironment({
+    ...baseConfiguration,
+    connection: {
+      ...baseConfiguration.connection,
+      connectionString: process.env.TEST_DATAMART_DATABASE_URL,
+    },
+  }),
 
   production: buildPostgresEnvironment(baseConfiguration),
 };

--- a/api/datawarehouse/knexfile.js
+++ b/api/datawarehouse/knexfile.js
@@ -5,13 +5,21 @@ loadEnvFileIfExists();
 
 const baseConfiguration = {
   name: 'datawarehouse',
-  databaseUrl: process.env.DATAWAREHOUSE_DATABASE_URL,
+  connection: {
+    connectionString: process.env.DATAWAREHOUSE_DATABASE_URL,
+  },
 };
 
 const environments = {
   development: buildPostgresEnvironment(baseConfiguration),
 
-  test: buildPostgresEnvironment({ ...baseConfiguration, databaseUrl: process.env.TEST_DATAWAREHOUSE_DATABASE_URL }),
+  test: buildPostgresEnvironment({
+    ...baseConfiguration,
+    connection: {
+      ...baseConfiguration.connection,
+      connectionString: process.env.TEST_DATAWAREHOUSE_DATABASE_URL,
+    },
+  }),
 
   production: buildPostgresEnvironment(baseConfiguration),
 };

--- a/api/db/database-builder/database-builder.js
+++ b/api/db/database-builder/database-builder.js
@@ -1,6 +1,7 @@
 /* eslint-disable knex/avoid-injections */
 import _ from 'lodash';
 
+import { DatabaseConnection } from '../database-connection.js';
 import { databaseBuffer as defaultDatabaseBuffer } from './database-buffer.js';
 import * as databaseHelpers from './database-helpers.js';
 import { factory } from './factory/index.js';
@@ -118,7 +119,11 @@ export class DatabaseBuilder {
   }
 
   async #getDirtyTablesSequencesInfo() {
-    const database = this.knex.client.database();
+    // TODO: find a better way to do it
+    const knexConfig = this.knex.context.client.config;
+    const url = DatabaseConnection.databaseUrlFromConfig(knexConfig);
+    this.knex.__pix__database = url.pathname.slice(1);
+    const database = this.knex.__pix__database;
 
     const rawSequencesInfo = await this.knex
       .from('information_schema.columns')

--- a/api/db/knexfile.js
+++ b/api/db/knexfile.js
@@ -7,10 +7,18 @@ const baseConfiguration = {
   name: 'live',
   migrationsDirectory: './migrations/',
   seedsDirectory: './seeds/',
-  databaseUrl: process.env.DATABASE_URL,
+  connection: {
+    connectionString: process.env.DATABASE_URL,
+    statement_timeout: parseInt(process.env.DATABASE_STATEMENT_TIMEOUT_MS, 10) || undefined,
+    query_timeout: parseInt(process.env.DATABASE_QUERY_TIMEOUT_MS, 10) || undefined,
+    idle_in_transaction_session_timeout:
+      parseInt(process.env.DATABASE_IDLE_IN_TRANSACTION_SESSION_TIMEOUT_MS, 10) || undefined,
+    connectionTimeoutMillis: parseInt(process.env.DATABASE_CONNECTION_TIMEOUT_MS, 10) || undefined,
+  },
   pool: {
     min: parseInt(process.env.DATABASE_CONNECTION_POOL_MIN_SIZE, 10),
     max: parseInt(process.env.DATABASE_CONNECTION_POOL_MAX_SIZE, 10),
+    idleTimeoutMillis: parseInt(process.env.DATABASE_IDLE_TIMEOUT_MS, 10) || 10_000,
   },
 };
 
@@ -19,7 +27,10 @@ export default {
 
   test: buildPostgresEnvironment({
     ...baseConfiguration,
-    databaseUrl: process.env.TEST_DATABASE_URL,
+    connection: {
+      ...baseConfiguration.connection,
+      connectionString: process.env.TEST_DATABASE_URL,
+    },
   }),
 
   production: buildPostgresEnvironment(baseConfiguration),

--- a/api/db/utils/build-postgres-environment.js
+++ b/api/db/utils/build-postgres-environment.js
@@ -1,8 +1,8 @@
-export function buildPostgresEnvironment({ databaseUrl, pool, migrationsDirectory, seedsDirectory, name }) {
+export function buildPostgresEnvironment({ connection, pool, migrationsDirectory, seedsDirectory, name }) {
   return {
     name,
     client: 'postgresql',
-    connection: databaseUrl,
+    connection,
     pool: {
       min: pool?.min || 1,
       max: pool?.max || 4,

--- a/api/sample.env
+++ b/api/sample.env
@@ -1165,3 +1165,55 @@ EMAIL_VALIDATION_DEMAND_TEMPORARY_STORAGE_LIFESPAN=3d
 # default: 4
 DAY_BEFORE_RETRYING=
 
+# =====
+# TIMEOUTS
+# =====
+
+# Response timeout in milliseconds. Sets the maximum time allowed for the server to respond to an incoming
+# request before giving up and responding with a Service Unavailable (503) error response.
+# Put 0 to set no timeout at all.
+#
+# presence: optional
+# type: Integer
+# default: 0
+HTTP_SERVER_RESPONSE_TIMEOUT_MS=
+
+# Response timeout in milliseconds. Sets the maximum time allowed before a statement in query will time out.
+# Put 0 to set no timeout at all.
+#
+# presence: optional
+# type: Integer
+# default: 0
+DATABASE_STATEMENT_TIMEOUT_MS=
+
+# Response timeout in milliseconds. Sets the maximum time allowed before a query will time out.
+# Put 0 to set no timeout at all.
+#
+# presence: optional
+# type: Integer
+# default: 0
+DATABASE_QUERY_TIMEOUT_MS=
+
+# Response timeout in milliseconds. Sets the maximum time allowed before terminating any session with an open idle transaction.
+# Put 0 to set no timeout at all.
+#
+# presence: optional
+# type: Integer
+# default: 0
+DATABASE_IDLE_IN_TRANSACTION_SESSION_TIMEOUT_MS=
+
+# Response timeout in milliseconds. Sets the maximum time allowed to wait for a connection before timeout.
+# Put 0 to set no timeout at all.
+#
+# presence: optional
+# type: Integer
+# default: 0
+DATABASE_CONNECTION_TIMEOUT_MS=
+
+# Response timeout in milliseconds. Help me Benjamin I am not sure about this one.
+# Put 0 to set no timeout at all.
+#
+# presence: optional
+# type: Integer
+# default: 10000
+DATABASE_IDLE_TIMEOUT_MS=

--- a/api/server.js
+++ b/api/server.js
@@ -71,7 +71,7 @@ installHapiHook();
 
 const { logOpsMetrics, port, logging } = config;
 const createServer = async () => {
-  const server = createBareServer();
+  const server = await createBareServer();
 
   // initialisation of Datadog link for metrics publication
   const metrics = new Metrics({ config });
@@ -97,7 +97,8 @@ const createServer = async () => {
   return server;
 };
 
-const createBareServer = function () {
+const createBareServer = async function () {
+  const serverResponseTimeout = config.timeouts.server;
   const serverConfiguration = {
     compression: false,
     debug: { request: false, log: false },
@@ -111,6 +112,9 @@ const createBareServer = function () {
       },
       response: {
         emptyStatusCode: 204,
+      },
+      timeout: {
+        server: serverResponseTimeout === 0 ? false : serverResponseTimeout,
       },
     },
     port,

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -157,6 +157,7 @@ const schema = Joi.object({
   TLD_FR: Joi.string().optional(),
   TLD_ORG: Joi.string().optional(),
   APIM_URL: Joi.string().optional(),
+  HTTP_SERVER_RESPONSE_TIMEOUT_MS: Joi.number().integer().min(0).optional(),
 }).options({ allowUnknown: true });
 
 const configuration = (function () {
@@ -475,6 +476,9 @@ const configuration = (function () {
     },
     temporaryStorageForAnonymousUserTokens: {
       expirationDelaySeconds: ms(process.env.ANONYMOUS_USER_TOKEN_TEMPORARY_STORAGE_LIFESPAN || '1d') / 1000,
+    },
+    timeouts: {
+      server: parseInt(process.env.HTTP_SERVER_RESPONSE_TIMEOUT_MS, 10) || 0,
     },
     v3Certification: {
       scoring: {

--- a/api/tests/integration/infrastructure/database-connection_test.js
+++ b/api/tests/integration/infrastructure/database-connection_test.js
@@ -70,7 +70,9 @@ describe('Integration | Infrastructure | database-connection', function () {
       const databaseConnection = new DatabaseConnection({
         name: 'not-existing-pg',
         client: 'postgresql',
-        connection: undefined,
+        connection: {
+          connectionString: undefined,
+        },
         pool: {
           min: 1,
           max: 2,


### PR DESCRIPTION
## ❄️ Problème

Les requêtes formulées par les fronts ends auprès de l'API sont proxy par un NGinx. 
Lorsque la prod s'emballe, les requêtes clients s'accumulent. NGinx est configuré pour fermer la connexion au bout de 60 secondes.
Le problème c'est que côté API ça continue de travailler alors que le client est parti

## 🛷 Proposition

Ajouter des variables d'env pour ajuster des timeouts au niveau :
- HapiJS
- Knex pour les divers cas : acquérir une connexion, attendre une exécution de query, etc...

## ☃️ Remarques

De plus au début on partait pour du feature toggle histoire d'être bien flex pendant la prod, mais ce n'est pas possible puisque ce sont des valeurs utilisées lors du boot.

Questions : faut-il le faire pour maddo, le serveur timeout ? + vérifier qu'on n'affecte pas le job de replication

## 🧑‍🎄 Pour tester
On a testé en local pour la variable pour le serveur, ca marche bien Hapi renvoie bien 503 au bout du temps donné.
Les autres pas testés encore
