### PR TITLE
[BUGFIX] Autoriser momentanément la désynchro des passages et des organization-learner-participations

### DIFF
--- a/admin/config/deploy.js
+++ b/admin/config/deploy.js
@@ -1,4 +1,3 @@
-/* eslint-env node */
 'use strict';
 
 module.exports = function (deployTarget) {

--- a/api/src/quest/application/jobs/update-combined-course-job-controller.js
+++ b/api/src/quest/application/jobs/update-combined-course-job-controller.js
@@ -1,4 +1,5 @@
 import { JobController } from '../../../shared/application/jobs/job-controller.js';
+import { config } from '../../../shared/config.js';
 import { UpdateCombineCourseJob } from '../../domain/models/UpdateCombinedCourseJob.js';
 import { usecases } from '../../domain/usecases/index.js';
 
@@ -6,6 +7,11 @@ class UpdateCombinedCourseJobController extends JobController {
   constructor() {
     super(UpdateCombineCourseJob.name);
   }
+
+  get isJobEnabled() {
+    return config.pgBoss.updateCombinedCourseJobEnabled;
+  }
+
   async handle({ data }) {
     const { userId, moduleId } = data;
 

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -435,6 +435,9 @@ const configuration = (function () {
       exportSenderJobEnabled: process.env.PGBOSS_EXPORT_SENDER_JOB_ENABLED
         ? toBoolean(process.env.PGBOSS_EXPORT_SENDER_JOB_ENABLED)
         : true,
+      updateCombinedCourseJobEnabled: process.env.PGBOSS_UPDATE_COMBINED_COURSE_JOB_ENABLED
+        ? toBoolean(process.env.PGBOSS_UPDATE_COMBINED_COURSE_JOB_ENABLED)
+        : true,
     },
     poleEmploi: {
       clientId: process.env.POLE_EMPLOI_CLIENT_ID,


### PR DESCRIPTION
## ❄️ Problème
UpdateCombinedCourseJob semble peu performant. La même opération est réalisée deux fois pour synchroniser les données entre la table passages et la table organization_learner_participations.

## 🛷 Proposition
On ajoute un getter isJobEnabled pour pouvoir désactiver momentanément la synchronisation des passages de modules hors parcours combiné avec les modules passés à l'intérieur d'un parcours.

## ☃️ Remarques
On doit ajouter une variable pgboss updateCombinedCourseJobEnabled et la set à TRUE.
