### PR TITLE
[TECH] Utiliser la DomainTransaction dans les repository des Bounded Context Accès (PIX-21408).

### DIFF
--- a/api/src/identity-access-management/infrastructure/repositories/client-application.repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/client-application.repository.js
@@ -1,6 +1,5 @@
 import Joi from 'joi';
 
-import { knex } from '../../../../db/knex-database-connection.js';
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { ClientApplication } from '../../domain/models/ClientApplication.js';
 
@@ -8,13 +7,15 @@ const TABLE_NAME = 'client_applications';
 
 export const clientApplicationRepository = {
   async findByClientId(clientId) {
-    const dto = await knex.select().from(TABLE_NAME).where({ clientId }).first();
+    const knexConn = DomainTransaction.getConnection();
+    const dto = await knexConn.select().from(TABLE_NAME).where({ clientId }).first();
     if (!dto) return undefined;
     return toDomain(dto);
   },
 
   async list() {
-    const dtos = await knex.select().from(TABLE_NAME).orderBy('name');
+    const knexConn = DomainTransaction.getConnection();
+    const dtos = await knexConn.select().from(TABLE_NAME).orderBy('name');
     return dtos.map((dto) => {
       const clientApplication = toDomain(dto);
       // eslint-disable-next-line no-unused-vars -- extract clientSecret so that it's not returned/displayed
@@ -38,20 +39,22 @@ export const clientApplicationRepository = {
     if (jurisdiction) {
       await jurisdictionSchema.validateAsync(jurisdiction);
     }
-    await knex.insert({ name, clientId, clientSecret, scopes, jurisdiction }).into(TABLE_NAME);
+    const knexConn = DomainTransaction.getConnection();
+    await knexConn.insert({ name, clientId, clientSecret, scopes, jurisdiction }).into(TABLE_NAME);
   },
 
   async save(clientApplication) {
     const knexConn = DomainTransaction.getConnection();
     const updated = await knexConn('client_applications')
-      .update({ ...toDto(clientApplication), updatedAt: knex.fn.now() })
+      .update({ ...toDto(clientApplication), updatedAt: knexConn.fn.now() })
       .where('id', clientApplication.id);
 
     return updated === 1;
   },
 
   async removeByClientId(clientId) {
-    const rows = await knex.delete().from(TABLE_NAME).where({ clientId });
+    const knexConn = DomainTransaction.getConnection();
+    const rows = await knexConn.delete().from(TABLE_NAME).where({ clientId });
     return rows === 1;
   },
 };

--- a/api/src/identity-access-management/infrastructure/repositories/lti-platform-registration.repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/lti-platform-registration.repository.js
@@ -1,9 +1,10 @@
-import { knex } from '../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { LtiPlatformRegistration } from '../../domain/models/LtiPlatformRegistration.js';
 
 export const ltiPlatformRegistrationRepository = {
   async findByClientId(clientId) {
-    const ltiPlatformRegistrationDTO = await knex
+    const knexConn = DomainTransaction.getConnection();
+    const ltiPlatformRegistrationDTO = await knexConn
       .select('*')
       .from('lti_platform_registrations')
       .where('clientId', clientId)
@@ -17,7 +18,8 @@ export const ltiPlatformRegistrationRepository = {
   },
 
   async listActivePublicKeys() {
-    return knex.select('publicKey').from('lti_platform_registrations').where('status', 'active').pluck('publicKey');
+    const knexConn = DomainTransaction.getConnection();
+    return knexConn.select('publicKey').from('lti_platform_registrations').where('status', 'active').pluck('publicKey');
   },
 
   async save({
@@ -29,7 +31,8 @@ export const ltiPlatformRegistrationRepository = {
     publicKey,
     platformOpenIdConfigUrl,
   }) {
-    return knex('lti_platform_registrations').insert({
+    const knexConn = DomainTransaction.getConnection();
+    return knexConn('lti_platform_registrations').insert({
       clientId,
       platformOrigin,
       status,

--- a/api/src/identity-access-management/infrastructure/repositories/oidc-provider-repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/oidc-provider-repository.js
@@ -1,4 +1,3 @@
-import { knex } from '../../../../db/knex-database-connection.js';
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { AlreadyExistingEntityError } from '../../../shared/domain/errors.js';
 import * as knexUtils from '../../../shared/infrastructure/utils/knex-utils.js';
@@ -55,7 +54,8 @@ const create = async function (oidcProviderProperties) {
  * @return {Promise<Array<OidcProvider>>}
  */
 const findAllOidcProviders = async function () {
-  const result = await knex.select().from(OIDC_PROVIDERS_TABLE_NAME);
+  const knexConn = DomainTransaction.getConnection();
+  const result = await knexConn.select().from(OIDC_PROVIDERS_TABLE_NAME);
   return result.map(_toDomain);
 };
 

--- a/api/src/identity-access-management/infrastructure/repositories/organization-learner-identity.repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/organization-learner-identity.repository.js
@@ -1,4 +1,4 @@
-import { knex } from '../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { OrganizationLearnerIdentityNotFoundError } from '../../domain/errors.js';
 import { OrganizationLearnerIdentity } from '../../domain/models/OrganizationLearnerIdentity.js';
 
@@ -6,7 +6,8 @@ const USER_TABLE_NAME = 'users';
 const VIEW_ORGANIZATION_LEARNERS_TABLE_NAME = 'view-active-organization-learners';
 
 async function getByIds(ids) {
-  const results = await knex({
+  const knexConn = DomainTransaction.getConnection();
+  const results = await knexConn({
     viewOrganizationLearners: VIEW_ORGANIZATION_LEARNERS_TABLE_NAME,
   })
     .join({ users: USER_TABLE_NAME }, 'users.id', 'viewOrganizationLearners.userId')

--- a/api/src/team/infrastructure/repositories/user-organizations-for-admin.repository.js
+++ b/api/src/team/infrastructure/repositories/user-organizations-for-admin.repository.js
@@ -1,8 +1,9 @@
-import { knex } from '../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { UserOrganizationForAdmin } from '../../domain/read-models/UserOrganizationForAdmin.js';
 
 const findByUserId = async function (userId) {
-  const organizations = await knex('memberships')
+  const knexConn = DomainTransaction.getConnection();
+  const organizations = await knexConn('memberships')
     .select({
       id: 'memberships.id',
       organizationRole: 'memberships.organizationRole',


### PR DESCRIPTION
## ❄️ Problème
Des problèmes de performance liés aux disponibilités des lectures/écritures de BDD ont été constatés. Un de axes d'amélioration est d'appeler DOmainTransaction.getConnection pour obtenir une éventuelle connexion déjà ouverte avant d'en ouvrir une nouvelle. 

Travail réalisé sur les dossiers Identity Access Management et Team. Reste à venir.

## 🛷 Proposition
Utiliser les domain transactions sur les repositories Identity Access Management et Team.


## 🧑‍🎄 Pour tester
