### PR TITLE
[BUGFIX] les textes des feedbacks sans balises <p> ne se colorent pas (PIX-21417).

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
@@ -58,7 +58,7 @@
                           "content": "Vrai",
                           "feedback": {
                             "state": "Correct&#8239;!",
-                            "diagnosis": "<p> Ces 16 compétences sont rangées dans 5 domaines.</p>"
+                            "diagnosis": "Ces 16 compétences sont rangées dans 5 domaines."
                           }
                         },
                         {

--- a/mon-pix/app/components/module/_feedback.scss
+++ b/mon-pix/app/components/module/_feedback.scss
@@ -45,12 +45,9 @@
     position: relative;
     height: 100%;
     padding: var(--pix-spacing-4x) var(--pix-spacing-6x);
+    color: var(--modulix-feedback-state-color);
     background-color: var(--modulix-feedback-background-color);
     border-radius: var(--pix-spacing-4x);
-
-    > p {
-      color: var(--modulix-feedback-state-color);
-    }
 
     &--with-retry-button {
       border-bottom-right-radius: 0;


### PR DESCRIPTION
## 🥀 Problème

On constate que de nombreux modules possèdent des feedbacks avec un texte noir, alors que l'on attend de la couleur depuis le re-design des feedbacks.

## 🏹 Proposition

Retirer une ligne coté css qui appliquait la couleur uniquement sur les balises `<p>`

En effet des balises HTML sont inclus un peu partout dans les modules, notamment dans les `diagnosis` des feedbacks. Seulement les manipulations métiers, les règles changeantes font que bcp de `diagnosis` n'ont pas de balises `<p>`? C'est celles-ci qui avait un texte en noir.
 
## ❤️‍🔥 Pour tester


https://app-pr15024.review.pix.fr/modules/preview/bac-a-sable

J'ai volontairement retiré la balise `<p>` du premier feedback pour voir un cas de feedback sans balise comme on peut avoir dans d'autres modules.

<img width="946" height="676" alt="Capture d’écran 2026-02-10 à 14 23 15" src="https://github.com/user-attachments/assets/b5b05000-43a9-42d0-b28d-cda2cc559604" />

---

Constater que dans les modules signalés par le métier, les feedbacks sont traités 

- https://app-pr15024.review.pix.fr/modules/preview/iagenbiais-avance
- https://app-pr15024.review.pix.fr/modules/preview/cyber-virus-nov
- https://app-pr15024.review.pix.fr/modules/preview/cyber-proteger-mdp/
