### PR TITLE
[BUGFIX] Limiter à 1 seule connexion simultanée à la base de données pour le job `CertificationCompletedJobController`.

### DIFF
--- a/api/src/certification/enrolment/domain/usecases/reconcile-candidate.js
+++ b/api/src/certification/enrolment/domain/usecases/reconcile-candidate.js
@@ -3,6 +3,8 @@
  * @typedef {import ('../models/Candidate.js').Candidate} Candidate
  */
 
+import { withTransaction } from '../../../../shared/domain/DomainTransaction.js';
+
 /**
  * @param {object} params
  * @param {Candidate} params.candidate
@@ -11,8 +13,8 @@
  *
  * @returns {Promise<Candidate>}
  */
-export async function reconcileCandidate({ userId, candidate, candidateRepository }) {
+export const reconcileCandidate = withTransaction(async ({ userId, candidate, candidateRepository }) => {
   candidate.reconcile(userId);
   await candidateRepository.update(candidate);
   return candidate;
-}
+});

--- a/api/src/certification/enrolment/domain/usecases/verify-candidate-identity.js
+++ b/api/src/certification/enrolment/domain/usecases/verify-candidate-identity.js
@@ -6,6 +6,7 @@
  * @typedef {import ('../models/Candidate.js').Candidate} Candidate
  */
 
+import { withTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import {
   CertificationCandidateByPersonalInfoNotFoundError,
   CertificationCandidateByPersonalInfoTooManyMatchesError,
@@ -24,61 +25,63 @@ import { CertificationCourse } from '../../../shared/domain/models/Certification
  * @param {UserRepository} params.userRepository
  * @returns {Promise<Candidate>}
  */
-export const verifyCandidateIdentity = async ({
-  userId,
-  sessionId,
-  firstName,
-  lastName,
-  birthdate,
-  candidateRepository,
-  centerRepository,
-  sessionRepository,
-  userRepository,
-  normalizeStringFnc,
-}) => {
-  const user = await userRepository.get({ id: userId });
-
-  const isUserLanguageValid = CertificationCourse.isLanguageAvailableForV3Certification(user.lang);
-  if (!isUserLanguageValid) {
-    throw new LanguageNotSupportedError(user.lang);
-  }
-
-  const session = await sessionRepository.get({ id: sessionId });
-
-  const candidatesInSession = await candidateRepository.findBySessionId({ sessionId: session.id });
-
-  const candidate = findMatchingEnrolledCandidate({
-    session,
-    candidatesInSession,
+export const verifyCandidateIdentity = withTransaction(
+  async ({
+    userId,
+    sessionId,
     firstName,
     lastName,
     birthdate,
+    candidateRepository,
+    centerRepository,
+    sessionRepository,
+    userRepository,
     normalizeStringFnc,
-  });
+  }) => {
+    const user = await userRepository.get({ id: userId });
 
-  if (candidate.isReconciled()) {
-    if (candidate.isReconciledTo(userId)) {
-      return candidate;
+    const isUserLanguageValid = CertificationCourse.isLanguageAvailableForV3Certification(user.lang);
+    if (!isUserLanguageValid) {
+      throw new LanguageNotSupportedError(user.lang);
     }
-    throw new UnexpectedUserAccountError({});
-  }
 
-  if (session.hasReconciledCandidateTo({ candidates: candidatesInSession, userId })) {
-    throw new UserAlreadyLinkedToCandidateInSessionError(
-      'The user is already linked to a candidate with different personal info in the given session',
-    );
-  }
+    const session = await sessionRepository.get({ id: sessionId });
 
-  const center = await centerRepository.getById({ id: session.certificationCenterId });
+    const candidatesInSession = await candidateRepository.findBySessionId({ sessionId: session.id });
 
-  if (center.isMatchingOrganizationScoAndManagingStudents) {
-    if (!user.has({ organizationLearnerId: candidate.organizationLearnerId })) {
-      throw new MatchingReconciledStudentNotFoundError();
+    const candidate = findMatchingEnrolledCandidate({
+      session,
+      candidatesInSession,
+      firstName,
+      lastName,
+      birthdate,
+      normalizeStringFnc,
+    });
+
+    if (candidate.isReconciled()) {
+      if (candidate.isReconciledTo(userId)) {
+        return candidate;
+      }
+      throw new UnexpectedUserAccountError({});
     }
-  }
 
-  return candidate;
-};
+    if (session.hasReconciledCandidateTo({ candidates: candidatesInSession, userId })) {
+      throw new UserAlreadyLinkedToCandidateInSessionError(
+        'The user is already linked to a candidate with different personal info in the given session',
+      );
+    }
+
+    const center = await centerRepository.getById({ id: session.certificationCenterId });
+
+    if (center.isMatchingOrganizationScoAndManagingStudents) {
+      if (!user.has({ organizationLearnerId: candidate.organizationLearnerId })) {
+        throw new MatchingReconciledStudentNotFoundError();
+      }
+    }
+
+    return candidate;
+  },
+);
 
 /**
  * @param {object} params

--- a/api/src/certification/enrolment/domain/usecases/verify-candidate-reconciliation-requirements.js
+++ b/api/src/certification/enrolment/domain/usecases/verify-candidate-reconciliation-requirements.js
@@ -4,6 +4,7 @@
  * @typedef {import ('./index.js').CertificationCenterRepository} CertificationCenterRepository
  */
 
+import { withTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { UserNotAuthorizedToCertifyError } from '../../../../shared/domain/errors.js';
 import { CenterHabilitationError } from '../../../shared/domain/errors.js';
 
@@ -17,27 +18,27 @@ import { CenterHabilitationError } from '../../../shared/domain/errors.js';
  * @returns {Promise<void>} if candidate is deemed eligible
  * @throws {UserNotAuthorizedToCertifyError} candidate is not certifiable for CORE
  */
-export async function verifyCandidateReconciliationRequirements({
-  candidate,
-  sessionId,
-  placementProfileService,
-  certificationCenterRepository,
-}) {
-  const placementProfile = await placementProfileService.getPlacementProfile({
-    userId: candidate.userId,
-    limitDate: candidate.reconciledAt,
-  });
-
-  if (!placementProfile.isCertifiable()) {
+export const verifyCandidateReconciliationRequirements = withTransaction(
+  async ({ candidate, sessionId, placementProfileService, certificationCenterRepository }) => {
     throw new UserNotAuthorizedToCertifyError();
-  }
+    const placementProfile = await placementProfileService.getPlacementProfile({
+      userId: candidate.userId,
+      limitDate: candidate.reconciledAt,
+    });
+    console.log(placementProfile);
 
-  if (candidate.hasComplementarySubscription()) {
-    const complementarySubscription = candidate.getComplementarySubscription();
-    const certificationCenter = await certificationCenterRepository.getBySessionId({ sessionId });
-
-    if (!certificationCenter.isHabilitated(complementarySubscription.complementaryCertificationKey)) {
-      throw new CenterHabilitationError();
+    if (!placementProfile.isCertifiable()) {
+      console.log('Will throw');
+      throw new UserNotAuthorizedToCertifyError();
     }
-  }
-}
+
+    if (candidate.hasComplementarySubscription()) {
+      const complementarySubscription = candidate.getComplementarySubscription();
+      const certificationCenter = await certificationCenterRepository.getBySessionId({ sessionId });
+
+      if (!certificationCenter.isHabilitated(complementarySubscription.complementaryCertificationKey)) {
+        throw new CenterHabilitationError();
+      }
+    }
+  },
+);

--- a/api/src/certification/enrolment/infrastructure/repositories/candidate-repository.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/candidate-repository.js
@@ -34,7 +34,9 @@ export async function get({ certificationCandidateId }) {
  * @returns {Promise<Array<Candidate>>}
  */
 export async function findBySessionId({ sessionId }) {
-  const candidatesData = await buildBaseReadQuery(knex)
+  const knexConn = DomainTransaction.getConnection();
+
+  const candidatesData = await buildBaseReadQuery(knexConn)
     .where({ 'certification-candidates.sessionId': sessionId })
     .orderBy('certification-candidates.id');
 

--- a/api/src/certification/enrolment/infrastructure/repositories/session-repository.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/session-repository.js
@@ -42,7 +42,9 @@ export async function save({ session }) {
  * @throws {NotFoundError}
  */
 export async function get({ id }) {
-  const foundSession = await knex
+  const knexConn = DomainTransaction.getConnection();
+
+  const foundSession = await knexConn
     .select('sessions.*')
     .select({ certificationCenterType: 'certification-centers.type' })
     .from('sessions')
@@ -110,10 +112,10 @@ export async function update(session) {
  */
 export async function remove({ id }) {
   await knex.transaction(async (trx) => {
-    const certificationCandidateIdsInSession = await knex('certification-candidates')
+    const certificationCandidateIdsInSession = await trx('certification-candidates')
       .where({ sessionId: id })
       .pluck('id');
-    const invigilatorAccessIds = await knex('invigilator_accesses').where({ sessionId: id }).pluck('id');
+    const invigilatorAccessIds = await trx('invigilator_accesses').where({ sessionId: id }).pluck('id');
 
     if (invigilatorAccessIds) {
       await trx('invigilator_accesses').whereIn('id', invigilatorAccessIds).del();

--- a/api/src/certification/shared/infrastructure/repositories/certification-candidate-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/certification-candidate-repository.js
@@ -1,4 +1,5 @@
 import { knex } from '../../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { Subscription } from '../../../enrolment/domain/models/Subscription.js';
 import { CertificationCandidate } from '../../../shared/domain/models/CertificationCandidate.js';
@@ -75,6 +76,7 @@ function _toDomain({ candidateData, subscriptionData }) {
 }
 
 function _candidateBaseQuery() {
+  const knex = DomainTransaction.getConnection();
   return knex
     .select({
       certificationCandidate: 'certification-candidates.*',
@@ -97,6 +99,7 @@ function _candidateBaseQuery() {
 }
 
 async function _getSubscriptions(candidateId) {
+  const knex = DomainTransaction.getConnection();
   return knex
     .select(
       'certification-subscriptions.complementaryCertificationId',


### PR DESCRIPTION
## 🥀 Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

Quand on lance le test du job CertificationCompletedJob en limitant le nombre de connexion à 1, on voit que ceux-ci échouent.
Cela signifie donc que plusieurs connexions sont ouvertes, ce qui est potentiellement problématique en cas de fort trafic lié au passage de certification.

## 🏹 Proposition

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

On passe sur tous les usecases et repositories utilisés par le job pour utiliser la DomainTransaction partout et donc utiliser la transaction ouverte le cas échéant.

## 💌 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

RAS

## ❤️‍🔥 Pour tester

Lancer la commande

```
DATABASE_CONNECTION_POOL_MAX_SIZE=1 npm run test:api:path -- tests/certification/evaluation/integration/application/jobs/certification-completed-job-controller_test.js
```

Constater que les tests sont en succès.

<!--
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc.
- [ ] Documentation de la fonctionnalité (lien)
-->
