### PR TITLE
[TECH] Fixe le minimum de connexions à maintenir dans le pool knex à 1 et retire le wrapping transactionnel d'un usecase qui fait uniquement des lectures lourdes

### DIFF
--- a/api/db/utils/build-postgres-environment.js
+++ b/api/db/utils/build-postgres-environment.js
@@ -4,7 +4,7 @@ export function buildPostgresEnvironment({ connection, pool, migrationsDirectory
     client: 'postgresql',
     connection,
     pool: {
-      min: pool?.min || 1,
+      min: pool?.min || 0,
       max: pool?.max || 4,
     },
     migrations: {

--- a/api/src/prescription/campaign/domain/usecases/find-paginated-campaign-participant-activities.js
+++ b/api/src/prescription/campaign/domain/usecases/find-paginated-campaign-participant-activities.js
@@ -1,7 +1,6 @@
-import { withTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { UserNotAuthorizedToAccessEntityError } from '../../../../shared/domain/errors.js';
 
-const findPaginatedCampaignParticipantActivities = withTransaction(async function ({
+const findPaginatedCampaignParticipantActivities = async function ({
   userId,
   campaignId,
   page,
@@ -15,7 +14,7 @@ const findPaginatedCampaignParticipantActivities = withTransaction(async functio
     campaignId,
     filters,
   });
-});
+};
 
 export { findPaginatedCampaignParticipantActivities };
 

--- a/api/tests/integration/infrastructure/database-connection_test.js
+++ b/api/tests/integration/infrastructure/database-connection_test.js
@@ -59,7 +59,7 @@ describe('Integration | Infrastructure | database-connection', function () {
           free: 0,
           pendingAcquires: 0,
           pendingCreates: 0,
-          min: 1,
+          min: 0,
           max: 4,
         },
       });


### PR DESCRIPTION
## 🥀 Problème

La [doc Knex](https://knexjs.org/guide/#pool) invite fortement à fixer le `min pool size` à 0 afin de forcer les connexions idle à mourir et ne pas réserver une connexion pour rien. De plus, il arrive que des connexions conservées se retrouvent dans des états en erreur et malheureusement c'est lors de sa réutilisation qu'on s'aperçoit qu'elle n'est pas fonctionnelle.

Aussi, on réalise qu'on a probablement été trop aggressifs sur la mise en place de transaction. On va préparer un nouveau document de recommandation sur ce sujet là mais en tout cas, vu le traffic que Pix est supposé recevoir, pour les usecases qui sont purement de lecture, l'usage de transaction ne sera plus recommandé.

## 🏹 Proposition

Fixer le min pool size par défaut à 0
Retirer le `withTransaction` autour du usecase `findPaginatedCampaignParticipantActivities`

## 💌 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## ❤️‍🔥 Pour tester
tests verts
