### PR TITLE
[TECH] Utilise la connexion ouverte pour transaction, le cas échéant, dans les repositories des Bounded Contexts de certification

### DIFF
--- a/api/src/certification/complementary-certification/infrastructure/repositories/complementary-certification-badge-repository.js
+++ b/api/src/certification/complementary-certification/infrastructure/repositories/complementary-certification-badge-repository.js
@@ -1,4 +1,3 @@
-import { knex } from '../../../../../db/knex-database-connection.js';
 import { Badge } from '../../../../evaluation/domain/models/Badge.js';
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 
@@ -36,12 +35,13 @@ const attach = async function ({ complementaryCertificationBadges }) {
 };
 
 const findAttachableBadgesByIds = async function ({ ids }) {
-  const badges = await knex
+  const knexConn = DomainTransaction.getConnection();
+  const badges = await knexConn
     .from('badges')
     .whereIn('badges.id', ids)
     .andWhere('badges.isCertifiable', true)
     .whereNotExists(
-      knex
+      knexConn
         .select(1)
         .from('complementary-certification-badges')
         .whereRaw('"complementary-certification-badges"."badgeId" = "badges"."id"'),

--- a/api/src/certification/complementary-certification/infrastructure/repositories/organization-repository.js
+++ b/api/src/certification/complementary-certification/infrastructure/repositories/organization-repository.js
@@ -1,7 +1,9 @@
-import { knex } from '../../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 
 const getOrganizationUserEmailByCampaignTargetProfileId = async function (targetProfileId) {
-  return knex('campaigns')
+  const knexConn = DomainTransaction.getConnection();
+
+  return knexConn('campaigns')
     .innerJoin('organizations', 'campaigns.organizationId', 'organizations.id')
     .innerJoin('memberships', 'organizations.id', 'memberships.organizationId')
     .innerJoin('users', 'users.id', 'memberships.userId')

--- a/api/src/certification/configuration/infrastructure/repositories/attachable-target-profiles-repository.js
+++ b/api/src/certification/configuration/infrastructure/repositories/attachable-target-profiles-repository.js
@@ -1,5 +1,5 @@
 // @ts-check
-import { knex } from '../../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { isBlank } from '../../../../shared/infrastructure/utils/lodash-utils.js';
 import { AttachableTargetProfile } from '../../domain/models/AttachableTargetProfile.js';
 
@@ -9,7 +9,8 @@ import { AttachableTargetProfile } from '../../domain/models/AttachableTargetPro
  * @returns {Promise<Array<AttachableTargetProfile>>}
  */
 const find = async function ({ searchTerm } = {}) {
-  const targetProfiles = await knex('target-profiles')
+  const knexConn = DomainTransaction.getConnection();
+  const targetProfiles = await knexConn('target-profiles')
     .select('target-profiles.id', 'target-profiles.name')
     .distinct()
     .leftJoin('badges', 'target-profiles.id', 'badges.targetProfileId')

--- a/api/src/certification/configuration/infrastructure/repositories/complementary-certification-for-target-profile-attachment-repository.js
+++ b/api/src/certification/configuration/infrastructure/repositories/complementary-certification-for-target-profile-attachment-repository.js
@@ -1,4 +1,4 @@
-import { knex } from '../../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { ComplementaryCertificationForTargetProfileAttachment } from '../../domain/models/ComplementaryCertificationForTargetProfileAttachment.js';
 
@@ -7,7 +7,8 @@ function _toDomain(row) {
 }
 
 const getById = async function ({ complementaryCertificationId }) {
-  const complementaryCertification = await knex
+  const knexConn = DomainTransaction.getConnection();
+  const complementaryCertification = await knexConn
     .from('complementary-certifications')
     .where({ id: complementaryCertificationId })
     .first();
@@ -28,7 +29,8 @@ const getById = async function ({ complementaryCertificationId }) {
  * @throws {NotFoundError}
  */
 const getByKey = async function ({ complementaryCertificationKey }) {
-  const complementaryCertification = await knex
+  const knexConn = DomainTransaction.getConnection();
+  const complementaryCertification = await knexConn
     .from('complementary-certifications')
     .where({ key: complementaryCertificationKey })
     .first();

--- a/api/src/certification/configuration/infrastructure/repositories/complementary-certification-repository.js
+++ b/api/src/certification/configuration/infrastructure/repositories/complementary-certification-repository.js
@@ -3,7 +3,6 @@
  * @typedef {import ('../../../shared/domain/models/ComplementaryCertificationKeys.js').ComplementaryCertificationKeys} ComplementaryCertificationKeys
  */
 
-import { knex } from '../../../../../db/knex-database-connection.js';
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { ComplementaryCertification } from '../../../complementary-certification/domain/models/ComplementaryCertification.js';
@@ -25,7 +24,8 @@ function _toDomain(row) {
  * @returns {Promise<Array<ComplementaryCertification>>}
  */
 const findAll = async function () {
-  const result = await knex.from('complementary-certifications').select('id', 'label', 'key').orderBy('id', 'asc');
+  const knexConn = DomainTransaction.getConnection();
+  const result = await knexConn.from('complementary-certifications').select('id', 'label', 'key').orderBy('id', 'asc');
 
   return result.map(_toDomain);
 };
@@ -51,7 +51,8 @@ const getByKey = async function (key) {
  * @returns {Promise<ComplementaryCertification>}
  */
 const getById = async function ({ id }) {
-  const complementaryCertification = await knex.from('complementary-certifications').where({ id }).first();
+  const knexConn = DomainTransaction.getConnection();
+  const complementaryCertification = await knexConn.from('complementary-certifications').where({ id }).first();
 
   if (!complementaryCertification) {
     throw new NotFoundError('Complementary certification does not exist');

--- a/api/src/certification/configuration/infrastructure/repositories/versions-repository.js
+++ b/api/src/certification/configuration/infrastructure/repositories/versions-repository.js
@@ -3,7 +3,6 @@
  * @typedef {import('../../../shared/domain/models/Scopes.js').SCOPES} SCOPES
  * @typedef {import('../../../../shared/domain/models/Challenge.js').Challenge} Challenge
  */
-import { knex } from '../../../../../db/knex-database-connection.js';
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { FlashAssessmentAlgorithmConfiguration } from '../../../shared/domain/models/FlashAssessmentAlgorithmConfiguration.js';
@@ -99,12 +98,9 @@ export async function create({ version, challenges }) {
     versionId: id,
   }));
 
-  const batchInsertQuery = knex.batchInsert('certification-frameworks-challenges', challengesDTO);
-
-  if (knexConn.isTransaction) {
-    batchInsertQuery.transacting(/** @type {import('knex').Knex.Transaction} */ (knexConn));
-  }
-  await batchInsertQuery;
+  await knexConn
+    .batchInsert('certification-frameworks-challenges', challengesDTO)
+    .transacting(knexConn.isTransaction ? knexConn : null);
 
   return id;
 }

--- a/api/src/certification/enrolment/domain/usecases/delete-session.js
+++ b/api/src/certification/enrolment/domain/usecases/delete-session.js
@@ -1,3 +1,4 @@
+import { withTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { SessionStartedDeletionError } from '../errors.js';
 
 /**
@@ -10,12 +11,12 @@ import { SessionStartedDeletionError } from '../errors.js';
  * @param {SessionRepository} params.sessionRepository
  * @param {SessionManagementRepository} params.sessionManagementRepository
  */
-const deleteSession = async function ({ sessionId, sessionRepository, sessionManagementRepository }) {
+const deleteSession = withTransaction(async ({ sessionId, sessionRepository, sessionManagementRepository }) => {
   if (!(await sessionManagementRepository.hasNoStartedCertification({ id: sessionId }))) {
     throw new SessionStartedDeletionError();
   }
 
   await sessionRepository.remove({ id: sessionId });
-};
+});
 
 export { deleteSession };

--- a/api/src/certification/enrolment/domain/usecases/delete-unlinked-certification-candidate.js
+++ b/api/src/certification/enrolment/domain/usecases/delete-unlinked-certification-candidate.js
@@ -2,6 +2,7 @@
  * @typedef {import('./index.js').CandidateRepository} CandidateRepository
  */
 
+import { withTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { CertificationCandidateForbiddenDeletionError } from '../errors.js';
 
@@ -9,7 +10,7 @@ import { CertificationCandidateForbiddenDeletionError } from '../errors.js';
  * @param {object} params
  * @param {CandidateRepository} params.candidateRepository
  */
-const deleteUnlinkedCertificationCandidate = async function ({ candidateId, candidateRepository }) {
+const deleteUnlinkedCertificationCandidate = withTransaction(async ({ candidateId, candidateRepository }) => {
   const candidate = await candidateRepository.get({ certificationCandidateId: candidateId });
 
   if (!candidate) {
@@ -21,6 +22,6 @@ const deleteUnlinkedCertificationCandidate = async function ({ candidateId, cand
   }
 
   throw new CertificationCandidateForbiddenDeletionError();
-};
+});
 
 export { deleteUnlinkedCertificationCandidate };

--- a/api/src/certification/enrolment/infrastructure/repositories/certification-cpf-city-repository.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/certification-cpf-city-repository.js
@@ -1,5 +1,5 @@
 // @ts-check
-import { knex } from '../../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { CertificationCpfCity } from '../../../shared/domain/models/CertificationCpfCity.js';
 
 const COLUMNS = ['id', 'name', 'postalCode', 'INSEECode', 'isActualName'];
@@ -11,7 +11,8 @@ const COLUMNS = ['id', 'name', 'postalCode', 'INSEECode', 'isActualName'];
  * @returns {Promise<Array<CertificationCpfCity>> }
  */
 const findByINSEECode = async function ({ INSEECode }) {
-  const result = await knex
+  const knexConn = DomainTransaction.getConnection();
+  const result = await knexConn
     .select(COLUMNS)
     .from('certification-cpf-cities')
     .where({ INSEECode })
@@ -28,7 +29,8 @@ const findByINSEECode = async function ({ INSEECode }) {
  * @returns {Promise<Array<CertificationCpfCity>> }
  */
 const findByPostalCode = async function ({ postalCode }) {
-  const result = await knex
+  const knexConn = DomainTransaction.getConnection();
+  const result = await knexConn
     .select(COLUMNS)
     .from('certification-cpf-cities')
     .where({ postalCode })

--- a/api/src/certification/enrolment/infrastructure/repositories/certification-cpf-country-repository.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/certification-cpf-country-repository.js
@@ -1,5 +1,5 @@
 // @ts-check
-import { knex } from '../../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { CertificationCpfCountry } from '../../../shared/domain/models/CertificationCpfCountry.js';
 
 /**
@@ -9,9 +9,10 @@ import { CertificationCpfCountry } from '../../../shared/domain/models/Certifica
  * @returns {Promise<CertificationCpfCountry | null> }
  */
 const getByMatcher = async function ({ matcher }) {
+  const knexConn = DomainTransaction.getConnection();
   const COLUMNS = ['id', 'code', 'commonName', 'originalName', 'matcher'];
 
-  const result = await knex.select(COLUMNS).from('certification-cpf-countries').where({ matcher }).first();
+  const result = await knexConn.select(COLUMNS).from('certification-cpf-countries').where({ matcher }).first();
 
   if (!result) {
     return null;

--- a/api/src/certification/enrolment/infrastructure/repositories/complementary-certification-badge-with-offset-version-repository.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/complementary-certification-badge-with-offset-version-repository.js
@@ -1,5 +1,5 @@
 // @ts-check
-import { knex } from '../../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { ComplementaryCertificationBadgeWithOffsetVersion } from '../../domain/models/ComplementaryCertificationBadge.js';
 
 /**
@@ -9,7 +9,8 @@ import { ComplementaryCertificationBadgeWithOffsetVersion } from '../../domain/m
  * @returns {Promise<Array<ComplementaryCertificationBadgeWithOffsetVersion>>}
  */
 export async function getAllWithSameTargetProfile({ complementaryCertificationBadgeId }) {
-  const results = await knex('complementary-certification-badges')
+  const knexConn = DomainTransaction.getConnection();
+  const results = await knexConn('complementary-certification-badges')
     .select(
       'complementary-certification-badges.id',
       'complementary-certification-badges.minimumEarnedPix',
@@ -17,7 +18,7 @@ export async function getAllWithSameTargetProfile({ complementaryCertificationBa
       'complementary-certification-badges.label',
       'complementary-certification-badges.imageUrl',
       'complementary-certification-badges.detachedAt',
-      knex.raw(
+      knexConn.raw(
         '(rank() over (partition by "complementaryCertificationId", "level" ORDER BY "detachedAt" DESC NULLS FIRST)) - 1 as "offsetVersion"',
       ),
     )
@@ -25,7 +26,7 @@ export async function getAllWithSameTargetProfile({ complementaryCertificationBa
     .where(
       'badges.targetProfileId',
       '=',
-      knex('complementary-certification-badges')
+      knexConn('complementary-certification-badges')
         .select('target-profiles.id')
         .join('badges', 'badges.id', '=', 'complementary-certification-badges.badgeId')
         .join('target-profiles', 'target-profiles.id', '=', 'badges.targetProfileId')

--- a/api/src/certification/enrolment/infrastructure/repositories/complementary-certification-course-repository.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/complementary-certification-course-repository.js
@@ -1,4 +1,4 @@
-import { knex } from '../../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { ComplementaryCertificationCourseWithResults } from '../../domain/models/ComplementaryCertificationCourseWithResults.js';
 
 /**
@@ -8,12 +8,13 @@ import { ComplementaryCertificationCourseWithResults } from '../../domain/models
  * @returns {Promise<Array<ComplementaryCertificationCourseWithResults>>}
  */
 const findByUserId = async function ({ userId }) {
-  const results = await knex
+  const knexConn = DomainTransaction.getConnection();
+  const results = await knexConn
     .select({
       id: 'complementary-certification-courses.id',
       hasExternalJury: 'complementary-certifications.hasExternalJury',
       complementaryCertificationBadgeId: 'targetedBadge.id',
-      results: knex.raw(
+      results: knexConn.raw(
         `array_agg(json_build_object(
         'id', "complementary-certification-course-results".id,
         'acquired', "complementary-certification-course-results".acquired,

--- a/api/src/certification/enrolment/infrastructure/repositories/complementary-certification-repository.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/complementary-certification-repository.js
@@ -2,7 +2,7 @@
 /**
  * @typedef {import ('../../../shared/domain/models/ComplementaryCertificationKeys.js').ComplementaryCertificationKeys} ComplementaryCertificationKeys
  */
-import { knex } from '../../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { ComplementaryCertification } from '../../../shared/domain/models/ComplementaryCertification.js';
 
 /**
@@ -10,7 +10,8 @@ import { ComplementaryCertification } from '../../../shared/domain/models/Comple
  * @returns {Promise<Array<ComplementaryCertification>>}
  */
 const findAll = async function () {
-  const result = await knex.from('complementary-certifications').select('id', 'label', 'key').orderBy('id', 'asc');
+  const knexConn = DomainTransaction.getConnection();
+  const result = await knexConn.from('complementary-certifications').select('id', 'label', 'key').orderBy('id', 'asc');
 
   return result.map(_toDomain);
 };

--- a/api/src/certification/enrolment/infrastructure/repositories/sco-certification-candidate-repository.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/sco-certification-candidate-repository.js
@@ -6,6 +6,8 @@
 import { knex } from '../../../../../db/knex-database-connection.js';
 import { Subscription } from '../../domain/models/Subscription.js';
 
+// I LET IT THAT WAY. THE TRANSACTION IS CONTAINED HERE IN THE USECASE THAT USES IT
+// USECASE IS A SEMI-LONG RUNNING WORK (enroll a lot of students at once)
 /**
  * @function
  * @param {object} params

--- a/api/src/certification/enrolment/infrastructure/repositories/sco-certification-candidate-repository.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/sco-certification-candidate-repository.js
@@ -6,8 +6,8 @@
 import { knex } from '../../../../../db/knex-database-connection.js';
 import { Subscription } from '../../domain/models/Subscription.js';
 
-// I LET IT THAT WAY. THE TRANSACTION IS CONTAINED HERE IN THE USECASE THAT USES IT
-// USECASE IS A SEMI-LONG RUNNING WORK (enroll a lot of students at once)
+// We voluntarily let the transaction contained in the repository as the usecase initiate a lengthy treatment
+
 /**
  * @function
  * @param {object} params

--- a/api/src/certification/enrolment/infrastructure/repositories/session-for-attendance-sheet-repository.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/session-for-attendance-sheet-repository.js
@@ -1,4 +1,4 @@
-import { knex } from '../../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { CertificationCandidateForAttendanceSheet } from '../../domain/read-models/CertificationCandidateForAttendanceSheet.js';
 import { SessionForAttendanceSheet } from '../../domain/read-models/SessionForAttendanceSheet.js';
@@ -11,7 +11,8 @@ import { SessionForAttendanceSheet } from '../../domain/read-models/SessionForAt
  * @throws {NotFoundError}
  */
 const getWithCertificationCandidates = async function ({ id }) {
-  const results = await knex
+  const knexConn = DomainTransaction.getConnection();
+  const results = await knexConn
     .select(
       'sessions.id',
       'sessions.date',
@@ -24,7 +25,7 @@ const getWithCertificationCandidates = async function ({ id }) {
       'organizations.isManagingStudents',
     )
     .select({
-      certificationCandidates: knex.raw(`
+      certificationCandidates: knexConn.raw(`
       json_agg(json_build_object(
       'firstName', "certification-candidates"."firstName",
       'lastName', "certification-candidates"."lastName",

--- a/api/src/certification/results/infrastructure/repositories/certification-version-repository.js
+++ b/api/src/certification/results/infrastructure/repositories/certification-version-repository.js
@@ -1,7 +1,8 @@
-import { knex } from '../../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 
 const getByCertificationCourseId = async function ({ certificationCourseId }) {
-  const { version } = await knex
+  const knexConn = DomainTransaction.getConnection();
+  const { version } = await knexConn
     .select('version')
     .from('certification-courses')
     .where({ id: certificationCourseId })

--- a/api/src/certification/results/infrastructure/repositories/certified-profile-repository.js
+++ b/api/src/certification/results/infrastructure/repositories/certified-profile-repository.js
@@ -1,4 +1,4 @@
-import { knex } from '../../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { FRENCH_SPOKEN } from '../../../../shared/domain/services/locale-service.js';
 import * as areaRepository from '../../../../shared/infrastructure/repositories/area-repository.js';
@@ -15,7 +15,8 @@ import {
 } from '../../domain/read-models/CertifiedProfile.js';
 
 const get = async function (certificationCourseId) {
-  const certificationDatas = await knex
+  const knexConn = DomainTransaction.getConnection();
+  const certificationDatas = await knexConn
     .select({
       userId: 'certification-courses.userId',
       createdAt: 'certification-courses.createdAt',

--- a/api/src/certification/results/infrastructure/repositories/clea-certified-candidate-repository.js
+++ b/api/src/certification/results/infrastructure/repositories/clea-certified-candidate-repository.js
@@ -1,9 +1,10 @@
-import { knex } from '../../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { ComplementaryCertificationKeys } from '../../../shared/domain/models/ComplementaryCertificationKeys.js';
 import { CleaCertifiedCandidate } from '../../domain/read-models/CleaCertifiedCandidate.js';
 
 const getBySessionId = async function (sessionId) {
-  const results = await knex
+  const knexConn = DomainTransaction.getConnection();
+  const results = await knexConn
     .from('certification-courses')
     .select(
       'certification-courses.firstName',

--- a/api/src/certification/results/infrastructure/repositories/competence-tree-repository.js
+++ b/api/src/certification/results/infrastructure/repositories/competence-tree-repository.js
@@ -1,4 +1,4 @@
-import { CompetenceTree } from '../../../../../src/shared/domain/models/CompetenceTree.js';
+import { CompetenceTree } from '../../../../shared/domain/models/CompetenceTree.js';
 import * as areaRepository from '../../../../shared/infrastructure/repositories/area-repository.js';
 
 const get = async function ({ locale, dependencies = { areaRepository } } = {}) {

--- a/api/src/certification/results/infrastructure/repositories/sco-certification-candidate-repository.js
+++ b/api/src/certification/results/infrastructure/repositories/sco-certification-candidate-repository.js
@@ -1,4 +1,4 @@
-import { knex } from '../../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 
 /**
  * @param {object} params
@@ -7,10 +7,11 @@ import { knex } from '../../../../../db/knex-database-connection.js';
  * @returns {Promise<Array<number>>} candidates identifiers of active students participants to certification sessions within given division
  */
 const findIdsByOrganizationIdAndDivision = function ({ organizationId, division }) {
-  const uniqLastCandidatesByOrganizationLearners = knex
+  const knexConn = DomainTransaction.getConnection();
+  const uniqLastCandidatesByOrganizationLearners = knexConn
     .select(
       'certification-candidates.id',
-      knex.raw(
+      knexConn.raw(
         `row_number() OVER (
           PARTITION BY "certification-candidates"."organizationLearnerId"
           ORDER BY "certification-courses"."createdAt" DESC
@@ -36,7 +37,7 @@ const findIdsByOrganizationIdAndDivision = function ({ organizationId, division 
     .orderBy('certification-candidates.firstName', 'ASC')
     .as('uniqLastCandidatesByOrganizationLearners');
 
-  return knex
+  return knexConn
     .pluck('id')
     .from(uniqLastCandidatesByOrganizationLearners)
     .where('uniqLastCandidatesByOrganizationLearners.session_number', 1);

--- a/api/src/certification/session-management/infrastructure/repositories/competence-mark-repository.js
+++ b/api/src/certification/session-management/infrastructure/repositories/competence-mark-repository.js
@@ -1,8 +1,9 @@
-import { knex } from '../../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { CompetenceMark } from '../../../shared/domain/models/CompetenceMark.js';
 
 const findByCertificationCourseId = async function ({ certificationCourseId }) {
-  const competenceMarks = await knex
+  const knexConn = DomainTransaction.getConnection();
+  const competenceMarks = await knexConn
     .select(
       'competence-marks.id',
       'competence-marks.area_code',

--- a/api/src/certification/session-management/infrastructure/repositories/complementary-certification-course-result-repository.js
+++ b/api/src/certification/session-management/infrastructure/repositories/complementary-certification-course-result-repository.js
@@ -1,4 +1,4 @@
-import { knex } from '../../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 
 const save = async function ({
   complementaryCertificationCourseId,
@@ -6,7 +6,8 @@ const save = async function ({
   acquired,
   source,
 }) {
-  return knex('complementary-certification-course-results')
+  const knexConn = DomainTransaction.getConnection();
+  return knexConn('complementary-certification-course-results')
     .insert({ complementaryCertificationBadgeId, acquired, complementaryCertificationCourseId, source })
     .onConflict(['complementaryCertificationCourseId', 'source'])
     .merge();

--- a/api/src/certification/session-management/infrastructure/repositories/cpf-export-repository.js
+++ b/api/src/certification/session-management/infrastructure/repositories/cpf-export-repository.js
@@ -1,7 +1,11 @@
-import { knex } from '../../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 
 const findFileNamesByStatus = async function ({ cpfImportStatus }) {
-  return knex('certification-courses-cpf-infos').where({ importStatus: cpfImportStatus }).pluck('filename').distinct();
+  const knexConn = DomainTransaction.getConnection();
+  return knexConn('certification-courses-cpf-infos')
+    .where({ importStatus: cpfImportStatus })
+    .pluck('filename')
+    .distinct();
 };
 
 export { findFileNamesByStatus };

--- a/api/src/certification/session-management/infrastructure/repositories/finalized-session-repository.js
+++ b/api/src/certification/session-management/infrastructure/repositories/finalized-session-repository.js
@@ -1,6 +1,5 @@
 import _ from 'lodash';
 
-import { knex } from '../../../../../db/knex-database-connection.js';
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { FinalizedSession } from '../../domain/models/FinalizedSession.js';
@@ -28,8 +27,9 @@ const get = async function ({ sessionId }) {
 };
 
 const findFinalizedSessionsToPublish = async function ({ version } = {}) {
+  const knexConn = DomainTransaction.getConnection();
   const versionFilter = version ? { 'sessions.version': version } : {};
-  const publishableFinalizedSessions = await knex('finalized-sessions')
+  const publishableFinalizedSessions = await knexConn('finalized-sessions')
     .innerJoin('sessions', 'finalized-sessions.sessionId', 'sessions.id')
     .where({
       ...versionFilter,
@@ -44,8 +44,9 @@ const findFinalizedSessionsToPublish = async function ({ version } = {}) {
 };
 
 const findFinalizedSessionsWithRequiredAction = async function ({ version } = {}) {
+  const knexConn = DomainTransaction.getConnection();
   const versionFilter = version ? { 'sessions.version': version } : {};
-  const publishableFinalizedSessions = await knex('finalized-sessions')
+  const publishableFinalizedSessions = await knexConn('finalized-sessions')
     .innerJoin('sessions', 'finalized-sessions.sessionId', 'sessions.id')
     .where({
       ...versionFilter,

--- a/api/src/certification/session-management/infrastructure/repositories/session-for-invigilator-kit-repository.js
+++ b/api/src/certification/session-management/infrastructure/repositories/session-for-invigilator-kit-repository.js
@@ -1,8 +1,9 @@
-import { knex } from '../../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { SessionForInvigilatorKit } from '../../domain/read-models/SessionForInvigilatorKit.js';
 
 const get = async function ({ id }) {
-  const results = await knex
+  const knexConn = DomainTransaction.getConnection();
+  const results = await knexConn
     .select(
       'sessions.id',
       'sessions.date',

--- a/api/src/certification/session-management/infrastructure/repositories/session-for-supervising-repository.js
+++ b/api/src/certification/session-management/infrastructure/repositories/session-for-supervising-repository.js
@@ -1,4 +1,4 @@
-import { knex } from '../../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { CertificationChallengeLiveAlertStatus } from '../../../shared/domain/models/CertificationChallengeLiveAlert.js';
 import { CertificationCompanionLiveAlertStatus } from '../../../shared/domain/models/CertificationCompanionLiveAlert.js';
@@ -8,7 +8,8 @@ import { ComplementaryCertificationForSupervising } from '../../domain/models/Co
 import { SessionForSupervising } from '../../domain/read-models/SessionForSupervising.js';
 
 const get = async function ({ id }) {
-  const results = await knex
+  const knexConn = DomainTransaction.getConnection();
+  const results = await knexConn
     .select({
       id: 'sessions.id',
       date: 'sessions.date',
@@ -17,7 +18,7 @@ const get = async function ({ id }) {
       examiner: 'sessions.examiner',
       accessCode: 'sessions.accessCode',
       address: 'sessions.address',
-      certificationCandidates: knex.raw(`
+      certificationCandidates: knexConn.raw(`
         json_agg(json_build_object(
           'userId', "certification-candidates"."userId",
           'firstName', "certification-candidates"."firstName",

--- a/api/src/certification/session-management/infrastructure/repositories/session-jury-comment-repository.js
+++ b/api/src/certification/session-management/infrastructure/repositories/session-jury-comment-repository.js
@@ -1,9 +1,10 @@
-import { knex } from '../../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { SessionJuryComment } from '../../domain/models/SessionJuryComment.js';
 
 const get = async function ({ id }) {
-  const result = await knex
+  const knexConn = DomainTransaction.getConnection();
+  const result = await knexConn
     .select({
       id: 'id',
       comment: 'juryComment',
@@ -42,7 +43,8 @@ const remove = async function ({ id }) {
 export { get, remove, save };
 
 async function _persist(sessionId, columnsToSave) {
-  const updatedSessionIds = await knex('sessions').update(columnsToSave).where({ id: sessionId }).returning('id');
+  const knexConn = DomainTransaction.getConnection();
+  const updatedSessionIds = await knexConn('sessions').update(columnsToSave).where({ id: sessionId }).returning('id');
 
   if (updatedSessionIds.length === 0) {
     throw new NotFoundError(`La session ${sessionId} n'existe pas ou son accès est restreint.`);

--- a/api/src/certification/session-management/infrastructure/repositories/session-summary-repository.js
+++ b/api/src/certification/session-management/infrastructure/repositories/session-summary-repository.js
@@ -1,9 +1,10 @@
-import { knex } from '../../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { fetchPage } from '../../../../shared/infrastructure/utils/knex-utils.js';
 import { SessionSummary } from '../../domain/read-models/SessionSummary.js';
 
 const findPaginatedByCertificationCenterId = async function ({ certificationCenterId, page }) {
-  const query = knex('sessions')
+  const knexConn = DomainTransaction.getConnection();
+  const query = knexConn('sessions')
     .select({
       id: 'sessions.id',
       address: 'sessions.address',
@@ -16,8 +17,8 @@ const findPaginatedByCertificationCenterId = async function ({ certificationCent
       createdAt: 'sessions.createdAt',
     })
     .select(
-      knex.raw('COUNT("certification-candidates"."id") AS "enrolledCandidatesCount"'),
-      knex.raw('COUNT("certification-courses"."id") AS "effectiveCandidatesCount"'),
+      knexConn.raw('COUNT("certification-candidates"."id") AS "enrolledCandidatesCount"'),
+      knexConn.raw('COUNT("certification-courses"."id") AS "effectiveCandidatesCount"'),
     )
     .leftJoin('certification-candidates', 'certification-candidates.sessionId', 'sessions.id')
     .leftJoin('certification-courses', function () {
@@ -32,7 +33,7 @@ const findPaginatedByCertificationCenterId = async function ({ certificationCent
     .orderBy('sessions.time', 'DESC')
     .orderBy('sessions.id', 'ASC');
 
-  const countQuery = knex('sessions').count('*', { as: 'row_count' }).where({ certificationCenterId });
+  const countQuery = knexConn('sessions').count('*', { as: 'row_count' }).where({ certificationCenterId });
 
   const { results, pagination } = await fetchPage({
     queryBuilder: query,

--- a/api/src/certification/session-management/infrastructure/repositories/v3-certification-course-details-for-administration-repository.js
+++ b/api/src/certification/session-management/infrastructure/repositories/v3-certification-course-details-for-administration-repository.js
@@ -1,4 +1,4 @@
-import { knex } from '../../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { AnswerStatus } from '../../../../shared/domain/models/AnswerStatus.js';
 import { CertificationChallengeLiveAlertStatus } from '../../../shared/domain/models/CertificationChallengeLiveAlert.js';
 import { V3CertificationChallengeForAdministration } from '../../domain/models/V3CertificationChallengeForAdministration.js';
@@ -6,7 +6,8 @@ import { V3CertificationChallengeLiveAlertForAdministration } from '../../domain
 import { V3CertificationCourseDetailsForAdministration } from '../../domain/models/V3CertificationCourseDetailsForAdministration.js';
 
 const getV3DetailsByCertificationCourseId = async function ({ certificationCourseId }) {
-  const liveAlertsDTO = await knex('certification-challenge-live-alerts')
+  const knexConn = DomainTransaction.getConnection();
+  const liveAlertsDTO = await knexConn('certification-challenge-live-alerts')
     .select({
       id: 'certification-challenge-live-alerts.id',
       challengeId: 'certification-challenge-live-alerts.challengeId',
@@ -26,7 +27,7 @@ const getV3DetailsByCertificationCourseId = async function ({ certificationCours
     .where('certification-challenge-live-alerts.status', CertificationChallengeLiveAlertStatus.VALIDATED)
     .orderBy('certification-challenge-live-alerts.createdAt', 'ASC');
 
-  const certificationCourseDTO = await knex
+  const certificationCourseDTO = await knexConn
     .select({
       isRejectedForFraud: 'certification-courses.isRejectedForFraud',
       certificationCourseId: 'certification-courses.id',
@@ -55,7 +56,7 @@ const getV3DetailsByCertificationCourseId = async function ({ certificationCours
     })
     .first();
 
-  const certificationChallengesDetailsDTO = await knex
+  const certificationChallengesDetailsDTO = await knexConn
     .select({
       challengeId: 'certification-challenges.challengeId',
       answerStatus: 'answers.result',

--- a/api/src/certification/shared/infrastructure/repositories/certifiable-badge-acquisition-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/certifiable-badge-acquisition-repository.js
@@ -1,6 +1,5 @@
 import _ from 'lodash';
 
-import { knex } from '../../../../../db/knex-database-connection.js';
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { CertifiableBadgeAcquisition } from '../../domain/models/CertifiableBadgeAcquisition.js';
 
@@ -56,7 +55,7 @@ const findHighestCertifiable = async function ({ userId, limitDate = new Date() 
     .join('complementary-certifications', 'complementary-certifications.id', 'user-badges.complementaryCertificationId')
     .join('campaign-participations', 'campaign-participations.id', 'user-badges.campaignParticipationId')
     .where({
-      'user-badges.acquiredAt': knex('latest-acquiredAt-badges')
+      'user-badges.acquiredAt': knexConn('latest-acquiredAt-badges')
         .select('acquiredAt')
         .whereRaw(
           '"latest-acquiredAt-badges"."complementaryCertificationId" = "user-badges"."complementaryCertificationId"',

--- a/api/src/certification/shared/infrastructure/repositories/certification-candidate-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/certification-candidate-repository.js
@@ -1,8 +1,7 @@
-import { knex } from '../../../../../db/knex-database-connection.js';
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { Subscription } from '../../../enrolment/domain/models/Subscription.js';
-import { CertificationCandidate } from '../../../shared/domain/models/CertificationCandidate.js';
+import { CertificationCandidate } from '../../domain/models/CertificationCandidate.js';
 import { ComplementaryCertification } from '../../domain/models/ComplementaryCertification.js';
 
 /**
@@ -37,7 +36,8 @@ const findBySessionId = async function (sessionId) {
 };
 
 const update = async function (certificationCandidate) {
-  const result = await knex('certification-candidates')
+  const knexConn = DomainTransaction.getConnection();
+  const result = await knexConn('certification-candidates')
     .where({ id: certificationCandidate.id })
     .update({ authorizedToStart: certificationCandidate.authorizedToStart });
 
@@ -76,8 +76,8 @@ function _toDomain({ candidateData, subscriptionData }) {
 }
 
 function _candidateBaseQuery() {
-  const knex = DomainTransaction.getConnection();
-  return knex
+  const knexConn = DomainTransaction.getConnection();
+  return knexConn
     .select({
       certificationCandidate: 'certification-candidates.*',
       complementaryCertificationId: 'complementary-certifications.id',
@@ -99,8 +99,8 @@ function _candidateBaseQuery() {
 }
 
 async function _getSubscriptions(candidateId) {
-  const knex = DomainTransaction.getConnection();
-  return knex
+  const knexConn = DomainTransaction.getConnection();
+  return knexConn
     .select(
       'certification-subscriptions.complementaryCertificationId',
       'certification-subscriptions.certificationCandidateId',

--- a/api/src/certification/shared/infrastructure/repositories/certification-center-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/certification-center-repository.js
@@ -1,7 +1,7 @@
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { CertificationCenter } from '../../../../shared/domain/models/CertificationCenter.js';
-import { ComplementaryCertification } from '../../../shared/domain/models/ComplementaryCertification.js';
+import { ComplementaryCertification } from '../../domain/models/ComplementaryCertification.js';
 
 const getComplementaryCertifications = async (knexConnection, certificationCenter) =>
   await knexConnection('complementary-certifications')

--- a/api/src/certification/shared/infrastructure/repositories/certification-course-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/certification-course-repository.js
@@ -30,15 +30,15 @@ async function save({ certificationCourse }) {
   return get({ id: certificationCourseId });
 }
 
-const _findCertificationCourse = async function (id, knexConn = knex) {
+const _findCertificationCourse = async function (id, knexConn) {
   return knexConn('certification-courses').where({ id }).first();
 };
 
-const _findAssessment = async function (certificationCourseId, knexConn = knex) {
+const _findAssessment = async function (certificationCourseId, knexConn) {
   return knexConn('assessments').where({ certificationCourseId }).first();
 };
 
-const _findAllChallenges = async function (certificationCourseId, knexConn = knex) {
+const _findAllChallenges = async function (certificationCourseId, knexConn) {
   return knexConn('certification-challenges').where({ courseId: certificationCourseId });
 };
 
@@ -167,6 +167,7 @@ async function findAllByUserId({ userId }) {
   });
 }
 
+// TODO revoir plus tard la pertinence ou pas
 async function update({ certificationCourse, noTransaction = false }) {
   const knexConn = noTransaction ? knex : DomainTransaction.getConnection();
 
@@ -180,7 +181,7 @@ async function update({ certificationCourse, noTransaction = false }) {
     throw new NotFoundError(`No rows updated for certification course of id ${certificationCourse.getId()}.`);
   }
 
-  return get({ id: certificationCourseData.id });
+  return get({ id: certificationCourseData.id }); // should have pass it noTransaction as well ?
 }
 
 async function isVerificationCodeAvailable({ verificationCode }) {

--- a/api/src/certification/shared/infrastructure/repositories/complementary-certification-badge-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/complementary-certification-badge-repository.js
@@ -1,15 +1,16 @@
-import { knex } from '../../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { ComplementaryCertificationBadge } from '../../domain/models/ComplementaryCertificationBadge.js';
 
 export const getAllWithSameTargetProfile = async (complementaryCertificationBadgeId) => {
-  const complementaryCertificationBadges = await knex('complementary-certification-badges')
+  const knexConn = DomainTransaction.getConnection();
+  const complementaryCertificationBadges = await knexConn('complementary-certification-badges')
     .select('complementary-certification-badges.*')
     .join('badges', 'badges.id', '=', 'complementary-certification-badges.badgeId')
     .where(
       'badges.targetProfileId',
       '=',
-      knex('complementary-certification-badges')
+      knexConn('complementary-certification-badges')
         .select('target-profiles.id')
         .join('badges', 'badges.id', '=', 'complementary-certification-badges.badgeId')
         .join('target-profiles', 'target-profiles.id', '=', 'badges.targetProfileId')

--- a/api/src/certification/shared/infrastructure/repositories/complementary-certification-course-result-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/complementary-certification-course-result-repository.js
@@ -1,9 +1,9 @@
-import { knex } from '../../../../../db/knex-database-connection.js';
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { ComplementaryCertificationCourseResult } from '../../domain/models/ComplementaryCertificationCourseResult.js';
 
 const getPixSourceResultByComplementaryCertificationCourseId = async function ({ complementaryCertificationCourseId }) {
-  const result = await knex
+  const knexConn = DomainTransaction.getConnection();
+  const result = await knexConn
     .select('*')
     .from('complementary-certification-course-results')
     .where({ complementaryCertificationCourseId, source: ComplementaryCertificationCourseResult.sources.PIX })
@@ -17,14 +17,15 @@ const getPixSourceResultByComplementaryCertificationCourseId = async function ({
 const getAllowedJuryLevelIdsByComplementaryCertificationBadgeId = async function ({
   complementaryCertificationBadgeId,
 }) {
-  return knex
+  const knexConn = DomainTransaction.getConnection();
+  return knexConn
     .pluck('complementary-certification-badges.id')
     .from('badges')
     .innerJoin('complementary-certification-badges', 'badges.id', 'complementary-certification-badges.badgeId')
     .where(
       'targetProfileId',
       '=',
-      knex('badges')
+      knexConn('badges')
         .select('targetProfileId')
         .innerJoin('complementary-certification-badges', 'badges.id', 'complementary-certification-badges.badgeId')
         .where({ 'complementary-certification-badges.id': complementaryCertificationBadgeId })
@@ -34,7 +35,8 @@ const getAllowedJuryLevelIdsByComplementaryCertificationBadgeId = async function
 };
 
 const removeExternalJuryResult = async function ({ complementaryCertificationCourseId }) {
-  await knex('complementary-certification-course-results')
+  const knexConn = DomainTransaction.getConnection();
+  await knexConn('complementary-certification-course-results')
     .where({ complementaryCertificationCourseId, source: ComplementaryCertificationCourseResult.sources.EXTERNAL })
     .delete();
 };

--- a/api/src/certification/shared/infrastructure/repositories/issue-report-category-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/issue-report-category-repository.js
@@ -1,4 +1,4 @@
-import { knex } from '../../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { CertificationIssueReportCategory } from '../../domain/read-models/CertificationIssueReportCategory.js';
 
@@ -7,7 +7,8 @@ function _toDomain(issueReportCategoryModel) {
 }
 
 const get = async function ({ name }) {
-  const issueReportCategory = await knex('issue-report-categories').where({ name }).first();
+  const knexConn = DomainTransaction.getConnection();
+  const issueReportCategory = await knexConn('issue-report-categories').where({ name }).first();
 
   if (!issueReportCategory) {
     throw new NotFoundError('The issue report category name does not exist');

--- a/api/src/certification/shared/infrastructure/repositories/session-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/session-repository.js
@@ -1,9 +1,8 @@
-import { knex } from '../../../../../db/knex-database-connection.js';
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { SessionManagement } from '../../../session-management/domain/models/SessionManagement.js';
-import { CertificationCandidate } from '../../../shared/domain/models/CertificationCandidate.js';
-import { ComplementaryCertification } from '../../../shared/domain/models/ComplementaryCertification.js';
+import { CertificationCandidate } from '../../domain/models/CertificationCandidate.js';
+import { ComplementaryCertification } from '../../domain/models/ComplementaryCertification.js';
 
 const getWithCertificationCandidates = async function ({ id }) {
   const knexConn = DomainTransaction.getConnection();
@@ -13,7 +12,7 @@ const getWithCertificationCandidates = async function ({ id }) {
     throw new NotFoundError("La session n'existe pas ou son accès est restreint");
   }
 
-  const certificationCandidates = await knex
+  const certificationCandidates = await knexConn
     .select({
       certificationCandidate: 'certification-candidates.*',
       complementaryCertificationId: 'complementary-certifications.id',

--- a/api/src/certification/shared/infrastructure/repositories/target-profile-history-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/target-profile-history-repository.js
@@ -1,4 +1,4 @@
-import { knex } from '../../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { TargetProfileHistoryForAdmin } from '../../../../shared/domain/models/TargetProfileHistoryForAdmin.js';
 import { PromiseUtils } from '../../../../shared/infrastructure/utils/promise-utils.js';
 import { ComplementaryCertificationBadgeForAdmin } from '../../domain/models/ComplementaryCertificationBadgeForAdmin.js';
@@ -6,7 +6,8 @@ import { ComplementaryCertificationBadgeForAdmin } from '../../domain/models/Com
 const getCurrentTargetProfilesHistoryWithBadgesByComplementaryCertificationId = async function ({
   complementaryCertificationId,
 }) {
-  const currentTargetProfiles = await knex('complementary-certification-badges')
+  const knexConn = DomainTransaction.getConnection();
+  const currentTargetProfiles = await knexConn('complementary-certification-badges')
     .select({
       id: 'target-profiles.id',
       name: 'target-profiles.name',
@@ -29,7 +30,8 @@ const getCurrentTargetProfilesHistoryWithBadgesByComplementaryCertificationId = 
 const getDetachedTargetProfilesHistoryByComplementaryCertificationId = async function ({
   complementaryCertificationId,
 }) {
-  const detachedTargetProfiles = await knex('complementary-certification-badges')
+  const knexConn = DomainTransaction.getConnection();
+  const detachedTargetProfiles = await knexConn('complementary-certification-badges')
     .select({
       id: 'target-profiles.id',
       name: 'target-profiles.name',
@@ -60,7 +62,8 @@ export {
 };
 
 async function _getTargetProfileComplementaryCertificationBadges({ targetProfile }) {
-  const badgesDTO = await knex('badges')
+  const knexConn = DomainTransaction.getConnection();
+  const badgesDTO = await knexConn('badges')
     .select({
       id: 'badges.id',
       complementaryCertificationBadgeId: 'complementary-certification-badges.id',

--- a/api/src/certification/shared/infrastructure/repositories/user-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/user-repository.js
@@ -1,6 +1,5 @@
 import _ from 'lodash';
 
-import { knex } from '../../../../../db/knex-database-connection.js';
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { User } from '../../../enrolment/domain/models/User.js';
 
@@ -10,7 +9,7 @@ export async function get({ id }) {
     .select({
       id: 'users.id',
       lang: 'users.lang',
-      organizationLearnerIds: knex.raw(
+      organizationLearnerIds: knexConn.raw(
         `array_agg("view-active-organization-learners".id order by "view-active-organization-learners".id)`,
       ),
     })

--- a/api/tests/certification/enrolment/unit/domain/usecases/delete-session_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/delete-session_test.js
@@ -1,8 +1,12 @@
 import { SessionStartedDeletionError } from '../../../../../../src/certification/enrolment/domain/errors.js';
 import { deleteSession } from '../../../../../../src/certification/enrolment/domain/usecases/delete-session.js';
+import { DomainTransaction } from '../../../../../../src/shared/domain/DomainTransaction.js';
 import { catchErr, expect, sinon } from '../../../../../test-helper.js';
 
 describe('Unit | UseCase | delete-session', function () {
+  beforeEach(async function () {
+    sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => lambda());
+  });
   context('when there are no certification courses', function () {
     it('should delete the session', async function () {
       // given

--- a/api/tests/certification/session-management/unit/domain/usecases/delete-unlinked-certification-candidate_test.js
+++ b/api/tests/certification/session-management/unit/domain/usecases/delete-unlinked-certification-candidate_test.js
@@ -1,5 +1,6 @@
 import { CertificationCandidateForbiddenDeletionError } from '../../../../../../src/certification/enrolment/domain/errors.js';
 import { deleteUnlinkedCertificationCandidate } from '../../../../../../src/certification/enrolment/domain/usecases/delete-unlinked-certification-candidate.js';
+import { DomainTransaction } from '../../../../../../src/shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
 import { catchErr, domainBuilder, expect, sinon } from '../../../../../test-helper.js';
 
@@ -14,6 +15,7 @@ describe('Unit | UseCase | delete-unlinked-certification-candidate', function ()
       remove: sinon.stub(),
     };
     candidateRepository.remove.withArgs({ id: candidateId }).resolves(true);
+    sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => lambda());
   });
 
   context('When the certification candidate is not linked to a user', function () {


### PR DESCRIPTION
## 🥀 Problème

Dans le cas de uscase sous transaction, si ce usecase utilise des repositories qui ne prennent pas la peine de récupérer la connexion courante, alors il en demande un autre au pool.
Dans un contexte de fort traffic cela peut fortement impacter la plateforme.

## 🏹 Proposition

Rendre (presque) tous les repositories DomainTransaction compliant sur les bounded contexts de certif

## 💌 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## ❤️‍🔥 Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
