### PR TITLE
[BUGFIX] Empêcher les bugs de récupération de missions lorsqu'il existe plusieurs assessments commencés pour une même mission

### DIFF
--- a/api/src/school/infrastructure/repositories/mission-assessment-repository.js
+++ b/api/src/school/infrastructure/repositories/mission-assessment-repository.js
@@ -65,10 +65,10 @@ const getStatusesForLearners = async function (missionId, organizationLearners) 
   const missionAssessmentsByLearnerId = await _getMissionAssessmentsByLearnerId(missionId, organizationLearnerIds);
 
   const lastRelevantAssessments = missionAssessmentsByLearnerId.map(([_organizationLearnerId, assessments]) => {
-    if (assessments.length > 1) {
-      return assessments.filter((assessment) => assessment.status === 'completed').sort(_byDescendingCreatedAt)[0];
-    }
-    return assessments[0];
+    const sortedAssessments = assessments.sort(_byDescendingCreatedAt);
+    const mostRecentCompletedAssessment = sortedAssessments.find((assessment) => assessment.status === 'completed');
+    if (mostRecentCompletedAssessment) return mostRecentCompletedAssessment;
+    return sortedAssessments[0];
   });
 
   const decoratedMissionLearners = [];

--- a/api/tests/school/integration/infrastructure/repositories/mission-assessment-repository_test.js
+++ b/api/tests/school/integration/infrastructure/repositories/mission-assessment-repository_test.js
@@ -200,7 +200,7 @@ describe('Integration | Repository | mission-assessment-repository', function ()
   describe('#getStatusesForLearners', function () {
     it('should return references or last assessment started and completed', async function () {
       const organizationLearnerWithCompletedAssessment = databaseBuilder.factory.buildOrganizationLearner();
-      const organizationLearnerWithStartedAssessment = databaseBuilder.factory.buildOrganizationLearner();
+      const organizationLearnerWithStartedAndAbortedAssessment = databaseBuilder.factory.buildOrganizationLearner();
       const organizationLearnerWithoutAssessment = databaseBuilder.factory.buildOrganizationLearner();
       const organizationLearnerWhoRetriedMission = databaseBuilder.factory.buildOrganizationLearner();
       const organizationLearnerWhoRetriedAndCompletedMissions = databaseBuilder.factory.buildOrganizationLearner();
@@ -209,9 +209,17 @@ describe('Integration | Repository | mission-assessment-repository', function ()
 
       const startedMissionAssessment = databaseBuilder.factory.buildMissionAssessment({
         missionId,
-        organizationLearnerId: organizationLearnerWithStartedAssessment.id,
+        organizationLearnerId: organizationLearnerWithStartedAndAbortedAssessment.id,
         state: Assessment.states.STARTED,
         createdAt: new Date('2023-10-10'),
+        result: null,
+      });
+
+      databaseBuilder.factory.buildMissionAssessment({
+        missionId,
+        organizationLearnerId: organizationLearnerWithStartedAndAbortedAssessment.id,
+        state: Assessment.states.ABORTED,
+        createdAt: new Date('2023-05-05'),
         result: null,
       });
 
@@ -270,7 +278,7 @@ describe('Integration | Repository | mission-assessment-repository', function ()
       const organizationLearners = [
         organizationLearnerWithCompletedAssessment,
         organizationLearnerWithoutAssessment,
-        organizationLearnerWithStartedAssessment,
+        organizationLearnerWithStartedAndAbortedAssessment,
         organizationLearnerWhoRetriedMission,
         organizationLearnerWhoRetriedAndCompletedMissions,
       ];
@@ -284,7 +292,7 @@ describe('Integration | Repository | mission-assessment-repository', function ()
         }),
         new MissionLearner({ ...organizationLearnerWithoutAssessment, missionStatus: 'not-started' }),
         new MissionLearner({
-          ...organizationLearnerWithStartedAssessment,
+          ...organizationLearnerWithStartedAndAbortedAssessment,
           missionStatus: 'started',
           result: startedMissionAssessment.result,
         }),


### PR DESCRIPTION
## 🥀 Problème

Dans le cas oú pour une mission donnée l'utilisateur a au moins deux assessments et aucun d'eux n 'est completed, y'a un truc qui pète

## 🏹 Proposition

Lodash faisait le travail de nettoyage des valeurs undefined dans un groupBy, pas le natif, donc il faut nettoyer si y'a risque d'en avoir avant de passer la collection à `Object.groupBy()`

La résolution consiste à garantir le fait de retourner un assessment dans la callback du map

## 💌 Remarques

Je suis repassée sur tous les `Object.groupBy()` que j'ai remplacé récemment, aucun autre ne présentait, à mon sens, un risque de valeur non définie dans la collection

## ❤️‍🔥 Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
