### PR TITLE
[TECH] Supprime un index inutile dans la table "certification-center-memberships" sur la colonne "updatedByUserId"

### DIFF
--- a/api/db/migrations/20260208163652_drop-index-on-column-updated-by-user-id-in-table-certification-center-memberships.js
+++ b/api/db/migrations/20260208163652_drop-index-on-column-updated-by-user-id-in-table-certification-center-memberships.js
@@ -1,0 +1,23 @@
+const TABLE_NAME = 'certification-center-memberships';
+const INDEX_NAME = 'certification_center_memberships_updatedbyuserid_index';
+const COLUMN_NAME = 'updatedByUserId';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.raw(`DROP INDEX IF EXISTS ??;`, [INDEX_NAME]);
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.alterTable(TABLE_NAME, (table) => {
+    table.index(COLUMN_NAME, INDEX_NAME);
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## 🥀 Problème
Identification via Metabase d'un index non utilisé sur la colonne `updatedByUserId` de la table `certification-center-memberships`

## 🏹 Proposition

Drop l'index avec la migration rollback pour le remettre.

Contrôles effectués avant suppression :
- Metabase indique 0 usage de l'index
- Aucune requête existantes aujourd'hui dans le code n'est susceptible de l'utiliser (pas de jointures, pas de where, pas de order by)

## 💌 Remarques
Cette migration peut être jouée en Prod lors de la MEP, c'est une petite table (~100k lignes) pas consultée sur les gros endpoints

## ❤️‍🔥 Pour tester

migration + rollback testé
