### PR TITLE
[TECH] Supprime un index inutile dans la table "sessions" sur la colonne "accessCode"

### DIFF
--- a/api/db/migrations/20260208165256_drop-index-on-column-access-code-in-table-sessions.js
+++ b/api/db/migrations/20260208165256_drop-index-on-column-access-code-in-table-sessions.js
@@ -7,7 +7,7 @@ const COLUMN_NAME = 'accessCode';
  * @returns { Promise<void> }
  */
 const up = async function (knex) {
-  await knex.raw(`DROP INDEX IF EXISTS ??;`, [INDEX_NAME]);
+  await knex.raw(`DROP INDEX CONCURRENTLY IF EXISTS ??;`, [INDEX_NAME]);
 };
 
 /**
@@ -20,4 +20,7 @@ const down = async function (knex) {
   });
 };
 
-export { down, up };
+// DROP INDEX CONCURRENTLY cannot run inside a transaction block
+const config = { transaction: false };
+
+export { config, down, up };

--- a/api/db/migrations/20260208165256_drop-index-on-column-access-code-in-table-sessions.js
+++ b/api/db/migrations/20260208165256_drop-index-on-column-access-code-in-table-sessions.js
@@ -1,0 +1,23 @@
+const TABLE_NAME = 'sessions';
+const INDEX_NAME = 'sessions_accesscode_index';
+const COLUMN_NAME = 'accessCode';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.raw(`DROP INDEX IF EXISTS ??;`, [INDEX_NAME]);
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.alterTable(TABLE_NAME, (table) => {
+    table.index(COLUMN_NAME, INDEX_NAME);
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## 🥀 Problème
Identification via Metabase d'un index non utilisé sur la colonne `accessCode` de la table `sessions`

## 🏹 Proposition

Drop l'index avec la migration rollback pour le remettre.

Contrôles effectués avant suppression :
- Metabase indique 0 usage de l'index
- Aucune requête existantes aujourd'hui dans le code n'est susceptible de l'utiliser (pas de jointures, pas de where, pas de order by)

## 💌 Remarques
C'est une table à ~600k lignes. À cet effet, je me suis permis d'ajouter CONCURRENTLY dans la requête pour que ce soit plus prod friendly. Ca devrait largement passer dans un contexte de MEP à midi.
Par contre il faut préciser que la migration est hors transaction (on peut pas concurrently pendant une transaction)

## ❤️‍🔥 Pour tester

migration + rollback testé
