### PR TITLE
[FEATURE] Remonter le type de prescrit dans le détail d'une organisation (PIX-21244).

### DIFF
--- a/admin/app/components/organizations/information-section-view.gjs
+++ b/admin/app/components/organizations/information-section-view.gjs
@@ -112,6 +112,12 @@ class OrganizationDescription extends Component {
         </div>
         <div class="organization-information-section__right-block">
           <div class="organization-information-section__field">
+            <span class="organization-information-section__label">
+              {{t "components.organizations.information-section-view.organization-learner-type"}}
+            </span>
+            <span class="organization-information-section__value">{{@organization.organizationLearnerTypeName}}</span>
+          </div>
+          <div class="organization-information-section__field">
             <span class="organization-information-section__label">{{t
                 "components.organizations.information-section-view.country.label"
               }}</span>

--- a/admin/app/models/organization.js
+++ b/admin/app/models/organization.js
@@ -30,6 +30,7 @@ export default class Organization extends Model {
   @attr('string') administrationTeamName;
   @attr('number') countryCode;
   @attr('string') countryName;
+  @attr('string') organizationLearnerTypeName;
 
   @hasMany('organization-membership', { async: true, inverse: 'organization' }) organizationMemberships;
   @hasMany('target-profile-summary', { async: true, inverse: null }) targetProfileSummaries;

--- a/admin/tests/integration/components/organizations/information-section-view-test.gjs
+++ b/admin/tests/integration/components/organizations/information-section-view-test.gjs
@@ -54,6 +54,7 @@ module('Integration | Component | organizations/information-section-view', funct
         administrationTeamName: 'team Rocket',
         countryCode: 99100,
         countryName: 'France',
+        organizationLearnerTypeName: 'super-type-de-prescrit',
       };
 
       // when
@@ -113,6 +114,12 @@ module('Integration | Component | organizations/information-section-view', funct
       assert
         .dom(screen.getByText(t('components.organizations.information-section-view.sso')).nextElementSibling)
         .hasText('super-sso');
+      assert
+        .dom(
+          screen.getByText(t('components.organizations.information-section-view.organization-learner-type'))
+            .nextElementSibling,
+        )
+        .hasText('super-type-de-prescrit');
     });
 
     test('it renders GAR identity provider correctly', async function (assert) {

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -810,6 +810,7 @@
           "title": "Features"
         },
         "is-archived-warning": "Archived at {archivedAt} by {archivedBy}.",
+        "organization-learner-type": "Organization learner type",
         "province-code": "Province code",
         "sco-activation-email": "SCO activation e-mail address",
         "sso": "SSO",

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -812,6 +812,7 @@
           "title": "Fonctionnalités"
         },
         "is-archived-warning": "Archivée le {archivedAt} par {archivedBy}.",
+        "organization-learner-type": "Typologie de prescrits",
         "province-code": "Département",
         "sco-activation-email": "Adresse e-mail d'activation SCO",
         "sso": "SSO",

--- a/api/src/organizational-entities/domain/models/OrganizationForAdmin.js
+++ b/api/src/organizational-entities/domain/models/OrganizationForAdmin.js
@@ -54,6 +54,7 @@ class OrganizationForAdmin {
     administrationTeamName,
     countryCode,
     countryName,
+    organizationLearnerTypeName,
   } = {}) {
     this.id = id;
     this.name = name;
@@ -84,6 +85,7 @@ class OrganizationForAdmin {
     this.tagIds = tagIds;
     this.administrationTeamId = administrationTeamId;
     this.administrationTeamName = administrationTeamName;
+    this.organizationLearnerTypeName = organizationLearnerTypeName;
 
     // @deprecated you should use value stored in features property
     this.isManagingStudents = isManagingStudents;

--- a/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
@@ -115,6 +115,7 @@ const get = async function ({ organizationId }) {
       administrationTeamId: 'organizations.administrationTeamId',
       administrationTeamName: 'administrationTeams.name',
       countryCode: 'organizations.countryCode',
+      organizationLearnerTypeName: 'organization_learner_types.name',
     })
     .leftJoin('users AS archivists', 'archivists.id', 'organizations.archivedBy')
     .leftJoin(
@@ -122,6 +123,7 @@ const get = async function ({ organizationId }) {
       'administrationTeams.id',
       'organizations.administrationTeamId',
     )
+    .leftJoin('organization_learner_types', 'organization_learner_types.id', 'organizations.organizationLearnerTypeId')
     .leftJoin('users AS creators', 'creators.id', 'organizations.createdBy')
     .leftJoin(
       'data-protection-officers AS dataProtectionOfficers',
@@ -471,6 +473,7 @@ function _toDomain(rawOrganization) {
     administrationTeamId: rawOrganization.administrationTeamId,
     administrationTeamName: rawOrganization.administrationTeamName,
     countryCode: rawOrganization.countryCode,
+    organizationLearnerTypeName: rawOrganization.organizationLearnerTypeName,
   });
 
   return organization;

--- a/api/src/organizational-entities/infrastructure/serializers/jsonapi/organizations-administration/organization-for-admin.serializer.js
+++ b/api/src/organizational-entities/infrastructure/serializers/jsonapi/organizations-administration/organization-for-admin.serializer.js
@@ -51,6 +51,7 @@ const serialize = function (organizations, meta) {
       'administrationTeamName',
       'countryCode',
       'countryName',
+      'organizationLearnerTypeName',
     ],
     organizationMemberships: {
       ref: 'id',

--- a/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
@@ -616,6 +616,7 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
               'administration-team-name': administrationTeam.name,
               'country-code': country.code,
               'country-name': country.commonName,
+              'organization-learner-type-name': `Type pour organisation ${organization.id}`,
               features: {
                 [ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key]: { active: false, params: null },
                 [ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key]: { active: true, params: null },

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/organization-for-admin.repository.test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/organization-for-admin.repository.test.js
@@ -761,6 +761,7 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
     it('returns an organization for admin by provided id', async function () {
       // given
       const superAdminUser = databaseBuilder.factory.buildUser({ firstName: 'Cécile', lastName: 'Encieux' });
+      const organizationLearnerType = databaseBuilder.factory.buildOrganizationLearnerType({ name: 'Type Toto' });
       const parentOrganization = databaseBuilder.factory.buildOrganization({
         type: 'SCO',
         name: 'Mother Of Dark Side',
@@ -772,6 +773,7 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
         email: 'sco.generic.account@example.net',
         createdBy: superAdminUser.id,
         documentationUrl: 'https://pix.fr/',
+        organizationLearnerTypeId: organizationLearnerType.id,
       });
       const organization = databaseBuilder.factory.buildOrganization({
         type: 'SCO',
@@ -792,6 +794,7 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
         parentOrganizationId: parentOrganization.id,
         administrationTeamId: administrationTeam.id,
         countryCode: 99100,
+        organizationLearnerTypeId: organizationLearnerType.id,
       });
 
       databaseBuilder.factory.buildDataProtectionOfficer.withOrganizationId({
@@ -851,6 +854,7 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
         identityProviderForCampaigns: 'genericOidcProviderCode',
         administrationTeamId: administrationTeam.id,
         administrationTeamName: administrationTeam.name,
+        organizationLearnerTypeName: organizationLearnerType.name,
         features: {
           [ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key]: { active: false },
           [ORGANIZATION_FEATURE.LEARNER_IMPORT.key]: { active: true, params: { name: 'BIDON' } },
@@ -956,6 +960,7 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
           administrationTeamId: administrationTeam.id,
           administrationTeamName: administrationTeam.name,
           countryCode: 99100,
+          organizationLearnerTypeName: `Type pour organisation ${organization.id}`,
         });
         expect(foundOrganizationForAdmin).to.deep.equal(expectedOrganizationForAdmin);
       });
@@ -1066,6 +1071,7 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
           administrationTeamId: administrationTeam.id,
           administrationTeamName: administrationTeam.name,
           countryCode: 99100,
+          organizationLearnerTypeName: `Type pour organisation ${organization.id}`,
         });
         expect(foundOrganizationForAdmin).to.deep.equal(expectedOrganizationForAdmin);
       });
@@ -1171,6 +1177,7 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
           administrationTeamId: administrationTeam.id,
           administrationTeamName: administrationTeam.name,
           countryCode: 99100,
+          organizationLearnerTypeName: `Type pour organisation ${insertedOrganization.id}`,
         });
         expect(foundOrganizationForAdmin).to.deepEqualInstance(expectedOrganizationForAdmin);
       });

--- a/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/organization-for-admin.serializer.test.js
+++ b/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/organization-for-admin.serializer.test.js
@@ -32,6 +32,7 @@ describe('Unit | Serializer | organization-for-admin-serializer', function () {
         name: 'motherSco',
         countryCode: 99100,
         countryName: 'France',
+        organizationLearnerTypeName: 'Learner type',
       });
       const organization = domainBuilder.buildOrganizationForAdmin({
         email: 'sco.generic.account@example.net',
@@ -54,6 +55,7 @@ describe('Unit | Serializer | organization-for-admin-serializer', function () {
         administrationTeamName: administrationTeam.name,
         countryCode: 99100,
         countryName: 'France',
+        organizationLearnerTypeName: 'Learner type',
       });
       const meta = { some: 'meta' };
 
@@ -95,6 +97,7 @@ describe('Unit | Serializer | organization-for-admin-serializer', function () {
             features: organization.features,
             'country-code': organization.countryCode,
             'country-name': organization.countryName,
+            'organization-learner-type-name': organization.organizationLearnerTypeName,
           },
           relationships: {
             'organization-memberships': {

--- a/api/tests/tooling/domain-builder/factory/build-organization-for-admin.js
+++ b/api/tests/tooling/domain-builder/factory/build-organization-for-admin.js
@@ -33,6 +33,7 @@ function buildOrganizationForAdmin({
   administrationTeamName = null,
   countryCode = null,
   countryName = null,
+  organizationLearnerTypeName = null,
 } = {}) {
   return new OrganizationForAdmin({
     id,
@@ -67,6 +68,7 @@ function buildOrganizationForAdmin({
     administrationTeamName,
     countryCode,
     countryName,
+    organizationLearnerTypeName,
   });
 }
 


### PR DESCRIPTION
## 🥀 Problème

Nous ne savons quel type de prescrit est géré par une organisation.

## 🏹 Proposition

On remonte l'information dans la page de détails d'une organisation.

## 💌 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## ❤️‍🔥 Pour tester

- Se connecter à Pix-Admin
- Aller sur la page de détails d'une organisation
- Vérifier que la typologie de prescrit d'une organisation est bien affichée dans les informations générales
