### PR TITLE
[BUGFIX] Utiliser la DomainConnection dans tous les repositories `shared`, `school` et `maddo`.

### DIFF
--- a/api/src/devcomp/infrastructure/repositories/tutorial-evaluation-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/tutorial-evaluation-repository.js
@@ -1,4 +1,3 @@
-import { knex } from '../../../../db/knex-database-connection.js';
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { TutorialEvaluation } from '../../domain/models/TutorialEvaluation.js';
 
@@ -15,7 +14,7 @@ const createOrUpdate = async function ({ userId, tutorialId, status }) {
     .onConflict(['userId', 'tutorialId'])
     .merge({
       status,
-      updatedAt: knex.fn.now(),
+      updatedAt: knexConn.fn.now(),
     })
     .returning('*');
   return _toDomain(tutorialEvaluation[0]);

--- a/api/src/evaluation/infrastructure/repositories/badge-criteria-repository.js
+++ b/api/src/evaluation/infrastructure/repositories/badge-criteria-repository.js
@@ -1,4 +1,3 @@
-import { knex } from '../../../../db/knex-database-connection.js';
 import { BadRequestError } from '../../../shared/application/http-errors.js';
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../shared/domain/errors.js';
@@ -29,11 +28,13 @@ const saveAll = async function (badgeCriteria) {
 };
 
 const updateCriterion = async function (id, attributesToUpdate) {
+  const knexConn = DomainTransaction.getConnection();
+
   if (Object.keys(attributesToUpdate).length === 0) {
     throw new BadRequestError("Erreur, aucune propriété n'est à mettre à jour");
   }
 
-  const [updatedCriterion] = await knex(TABLE_NAME).update(attributesToUpdate).where({ id }).returning('*');
+  const [updatedCriterion] = await knexConn(TABLE_NAME).update(attributesToUpdate).where({ id }).returning('*');
 
   if (!updatedCriterion) {
     throw new NotFoundError('Erreur, critère de badge introuvable');

--- a/api/src/evaluation/infrastructure/repositories/feedback-repository.js
+++ b/api/src/evaluation/infrastructure/repositories/feedback-repository.js
@@ -1,12 +1,13 @@
 import omit from 'lodash/omit.js';
 
-import { knex } from '../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { Feedback } from '../../domain/models/Feedback.js';
 
 export const save = async function (feedback) {
+  const knexConn = DomainTransaction.getConnection();
   const dataToInsert = omit(feedback, ['id']);
 
-  const result = await knex('feedbacks').insert(dataToInsert).returning('*');
+  const result = await knexConn('feedbacks').insert(dataToInsert).returning('*');
 
   return new Feedback(result[0]);
 };

--- a/api/src/maddo/infrastructure/repositories/campaign-repository.js
+++ b/api/src/maddo/infrastructure/repositories/campaign-repository.js
@@ -1,5 +1,5 @@
-import { knex } from '../../../../db/knex-database-connection.js';
 import * as campaignAPI from '../../../prescription/campaign/application/api/campaigns-api.js';
+import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { Campaign } from '../../domain/models/Campaign.js';
 
 export async function findByOrganizationId(organizationId, page, locale) {
@@ -16,7 +16,9 @@ export async function findByOrganizationId(organizationId, page, locale) {
 }
 
 export async function getOrganizationId(campaignId) {
-  const [organizationId] = await knex.pluck('organizationId').from('campaigns').where('id', campaignId);
+  const knexConn = DomainTransaction.getConnection();
+
+  const [organizationId] = await knexConn.pluck('organizationId').from('campaigns').where('id', campaignId);
   return organizationId;
 }
 

--- a/api/src/maddo/infrastructure/repositories/client-application-repository.js
+++ b/api/src/maddo/infrastructure/repositories/client-application-repository.js
@@ -1,6 +1,8 @@
-import { knex } from '../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 
 export async function getJurisdiction(clientId) {
-  const clientApplication = await knex('client_applications').select('jurisdiction').where({ clientId }).first();
+  const knexConn = DomainTransaction.getConnection();
+
+  const clientApplication = await knexConn('client_applications').select('jurisdiction').where({ clientId }).first();
   return clientApplication.jurisdiction;
 }

--- a/api/src/maddo/infrastructure/repositories/organization-repository.js
+++ b/api/src/maddo/infrastructure/repositories/organization-repository.js
@@ -1,8 +1,10 @@
-import { knex } from '../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { Organization } from '../../domain/models/Organization.js';
 
 export async function findIdsByTagNames(tagNames) {
-  return knex
+  const knexConn = DomainTransaction.getConnection();
+
+  return knexConn
     .pluck('organization-tags.organizationId')
     .from('organization-tags')
     .join('tags', 'tags.id', 'organization-tags.tagId')
@@ -13,7 +15,9 @@ export async function findIdsByTagNames(tagNames) {
 }
 
 export async function findIdentityProviderForCampaignsByCampaignId(campaignId) {
-  const { identityProviderForCampaigns } = await knex
+  const knexConn = DomainTransaction.getConnection();
+
+  const { identityProviderForCampaigns } = await knexConn
     .select('organizations.identityProviderForCampaigns')
     .from('organizations')
     .join('campaigns', 'campaigns.organizationId', 'organizations.id')
@@ -24,7 +28,9 @@ export async function findIdentityProviderForCampaignsByCampaignId(campaignId) {
 }
 
 export async function findByIds(organizationIds) {
-  const rawOrganizations = await knex
+  const knexConn = DomainTransaction.getConnection();
+
+  const rawOrganizations = await knexConn
     .select('id', 'name', 'externalId')
     .from('organizations')
     .whereIn('id', organizationIds)

--- a/api/src/school/infrastructure/repositories/mission-assessment-repository.js
+++ b/api/src/school/infrastructure/repositories/mission-assessment-repository.js
@@ -1,4 +1,3 @@
-import { knex } from '../../../../db/knex-database-connection.js';
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { Assessment } from '../../../shared/domain/models/Assessment.js';
 import { MissionLearner } from '../../domain/models/MissionLearner.js';
@@ -25,7 +24,8 @@ const getByAssessmentId = async function (assessmentId) {
 };
 
 const getCurrent = async function (missionId, organizationLearnerId) {
-  const rawAssessmentMission = await knex('mission-assessments')
+  const knexConn = DomainTransaction.getConnection();
+  const rawAssessmentMission = await knexConn('mission-assessments')
     .join('assessments', 'assessments.id', 'mission-assessments.assessmentId')
     .where({ missionId, organizationLearnerId, state: Assessment.states.STARTED })
     .first();
@@ -38,7 +38,8 @@ const getCurrent = async function (missionId, organizationLearnerId) {
 };
 
 async function _getMissionAssessmentsByLearnerId(missionId, organizationLearnerIds) {
-  const organizationLearnerAssessments = await knex
+  const knexConn = DomainTransaction.getConnection();
+  const organizationLearnerAssessments = await knexConn
     .select(
       'mission-assessments.organizationLearnerId',
       'assessments.state as status',
@@ -90,11 +91,12 @@ const getStatusesForLearners = async function (missionId, organizationLearners) 
 };
 
 const getMissionIdsByState = async function (organizationLearnerId) {
-  const missionAssessments = await knex('mission-assessments')
+  const knexConn = DomainTransaction.getConnection();
+  const missionAssessments = await knexConn('mission-assessments')
     .select('mission-assessments.missionId', 'assessments.state', 'mission-assessments.createdAt')
     .join('assessments', 'assessments.id', 'mission-assessments.assessmentId')
     .join(
-      knex
+      knexConn
         .select('organizationLearnerId as learnerId', 'missionId')
         .max('createdAt', { as: 'date' })
         .from('mission-assessments')

--- a/api/src/school/infrastructure/repositories/organization-learner-repository.js
+++ b/api/src/school/infrastructure/repositories/organization-learner-repository.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 
-import { knex } from '../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { OrganizationLearner } from '../../domain/models/OrganizationLearner.js';
 
 const getStudentsByOrganizationId = async function ({ organizationId, organizationLearnerApi }) {
@@ -18,11 +18,13 @@ const getById = async function ({ organizationLearnerId, organizationLearnerApi 
 };
 
 async function getDivisionsWhichStartedMission({ missionId, organizationId, organizationLearnerApi }) {
+  const knexConn = DomainTransaction.getConnection();
+
   const { organizationLearners } = await organizationLearnerApi.find({
     organizationId,
   });
 
-  const startedOrganizationLearnersIds = await knex
+  const startedOrganizationLearnersIds = await knexConn
     .select('organizationLearnerId')
     .from('mission-assessments')
     .where({ missionId })


### PR DESCRIPTION
## 🥀 Problème

Dans le cas de uscase sous transaction, si ce usecase utilise des repositories qui ne prennent pas la peine de récupérer la connexion courante, alors il en demande un autre au pool.
Dans un contexte de fort traffic cela peut fortement impacter la plateforme.

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

## 🏹 Proposition

Rendre (presque) tous les repositories DomainTransaction compliant sur les bounded contexts shared, maddo et school

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 💌 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## ❤️‍🔥 Pour tester

<!--
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc.
- [ ] Documentation de la fonctionnalité (lien)
-->
