### PR TITLE
[BUGFIX] Corriger la progression dans le téléchargement des csv sur PixOrga (PIX-21433).

### DIFF
--- a/api/src/prescription/campaign/domain/usecases/index.js
+++ b/api/src/prescription/campaign/domain/usecases/index.js
@@ -1,5 +1,6 @@
 import * as tutorialRepository from '../../../../devcomp/infrastructure/repositories/tutorial-repository.js';
 import * as userRecommendedTrainingRepository from '../../../../devcomp/infrastructure/repositories/user-recommended-training-repository.js';
+import * as improvementService from '../../../../evaluation/domain/services/improvement-service.js';
 import * as badgeAcquisitionRepository from '../../../../evaluation/infrastructure/repositories/badge-acquisition-repository.js';
 import * as badgeRepository from '../../../../evaluation/infrastructure/repositories/badge-repository.js';
 import * as stageAcquisitionRepository from '../../../../evaluation/infrastructure/repositories/stage-acquisition-repository.js';
@@ -22,6 +23,7 @@ import * as membershipRepository from '../../../../team/infrastructure/repositor
 import * as campaignAnalysisRepository from '../../../campaign-participation/infrastructure/repositories/campaign-analysis-repository.js';
 import * as campaignParticipationRepository from '../../../campaign-participation/infrastructure/repositories/campaign-participation-repository.js';
 import * as organizationLearnerImportFormatRepository from '../../../learner-management/infrastructure/repositories/organization-learner-import-format-repository.js';
+import knowledgeElementForParticipationService from '../../../shared/domain/services/knowledge-element-for-participation-service.js';
 import * as learningContentRepository from '../../../shared/infrastructure/repositories/learning-content-repository.js';
 import * as campaignAdministrationRepository from '../../infrastructure/repositories/campaign-administration-repository.js';
 import * as campaignAssessmentParticipationResultListRepository from '../../infrastructure/repositories/campaign-assessment-participation-result-list-repository.js';
@@ -43,6 +45,7 @@ import * as stageCollectionRepository from '../../infrastructure/repositories/st
 import * as campaignUpdateValidator from '../validators/campaign-update-validator.js';
 
 const dependencies = {
+  knowledgeElementForParticipationService,
   assessmentRepository,
   adminMemberRepository,
   badgeForCalculationRepository,
@@ -65,6 +68,7 @@ const dependencies = {
   campaignUpdateValidator,
   codeGenerator,
   competenceRepository,
+  improvementService,
   divisionRepository,
   eventLoggingJobRepository,
   featureToggles,

--- a/api/src/prescription/campaign/domain/usecases/start-writing-campaign-assessment-results-to-stream.js
+++ b/api/src/prescription/campaign/domain/usecases/start-writing-campaign-assessment-results-to-stream.js
@@ -48,7 +48,6 @@ const startWritingCampaignAssessmentResultsToStream = async function ({
   campaignRepository,
   campaignParticipationInfoRepository,
   organizationRepository,
-  knowledgeElementSnapshotRepository,
   knowledgeElementForParticipationService,
   badgeAcquisitionRepository,
   targetProfileRepository,
@@ -66,9 +65,13 @@ const startWritingCampaignAssessmentResultsToStream = async function ({
     throw new CampaignTypeError();
   }
 
-  const targetProfile = await targetProfileRepository.getByCampaignId({ campaignId: campaign.id });
+  const targetProfile = await targetProfileRepository.getByCampaignId({
+    campaignId: campaign.id,
+  });
   const learningContent = await learningContentRepository.findByCampaignId(campaign.id, locale);
-  const stageCollection = await stageCollectionRepository.findStageCollection({ campaignId });
+  const stageCollection = await stageCollectionRepository.findStageCollection({
+    campaignId,
+  });
 
   const organization = await organizationRepository.get(campaign.organizationId);
   const campaignParticipationInfos = await campaignParticipationInfoRepository.findByCampaignId(campaign.id);
@@ -100,7 +103,6 @@ const startWritingCampaignAssessmentResultsToStream = async function ({
       knowledgeElementForParticipationService,
       badgeAcquisitionRepository,
       stageAcquisitionRepository,
-      knowledgeElementSnapshotRepository,
       improvementService,
     })
     .then(() => {

--- a/api/src/prescription/campaign/domain/usecases/start-writing-campaign-assessment-results-to-stream.js
+++ b/api/src/prescription/campaign/domain/usecases/start-writing-campaign-assessment-results-to-stream.js
@@ -49,7 +49,7 @@ const startWritingCampaignAssessmentResultsToStream = async function ({
   campaignParticipationInfoRepository,
   organizationRepository,
   knowledgeElementSnapshotRepository,
-  knowledgeElementRepository,
+  knowledgeElementForParticipationService,
   badgeAcquisitionRepository,
   targetProfileRepository,
   learningContentRepository,
@@ -57,6 +57,7 @@ const startWritingCampaignAssessmentResultsToStream = async function ({
   organizationFeatureApi,
   organizationLearnerImportFormatRepository,
   stageAcquisitionRepository,
+  improvementService,
 }) {
   let additionalHeaders = [];
   const campaign = await campaignRepository.get(campaignId);
@@ -94,13 +95,14 @@ const startWritingCampaignAssessmentResultsToStream = async function ({
   // function, node will keep all the data in memory until the end of the
   // complete operation.
   campaignAssessment
-    .export(
+    .export({
       campaignParticipationInfos,
-      knowledgeElementRepository,
+      knowledgeElementForParticipationService,
       badgeAcquisitionRepository,
       stageAcquisitionRepository,
       knowledgeElementSnapshotRepository,
-    )
+      improvementService,
+    })
     .then(() => {
       writableStream.end();
     })

--- a/api/src/prescription/campaign/infrastructure/repositories/knowledge-element-snapshot-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/knowledge-element-snapshot-repository.js
@@ -34,7 +34,7 @@ export async function findCampaignParticipationKnowledgeElementSnapshots(campaig
   return campaignParticipationIds.map(
     (campaignParticipationId) =>
       new CampaignParticipationKnowledgeElementSnapshots({
-        knowledgeElements: knowledgeElementsByCampaignParticipation[campaignParticipationId],
+        knowledgeElements: knowledgeElementsByCampaignParticipation[campaignParticipationId] ?? [],
         campaignParticipationId: campaignParticipationId,
       }),
   );

--- a/api/src/prescription/campaign/infrastructure/serializers/csv/campaign-assessment-export.js
+++ b/api/src/prescription/campaign/infrastructure/serializers/csv/campaign-assessment-export.js
@@ -41,7 +41,6 @@ class CampaignAssessmentExport {
       knowledgeElementForParticipationService,
       badgeAcquisitionRepository,
       stageAcquisitionRepository,
-      knowledgeElementSnapshotRepository,
     },
     constants = {
       CHUNK_SIZE_CAMPAIGN_RESULT_PROCESSING,
@@ -68,9 +67,12 @@ class CampaignAssessmentExport {
         });
 
         const sharedKnowledgeElementsByUserIdAndCompetenceId =
-          await knowledgeElementSnapshotRepository.findCampaignParticipationKnowledgeElementSnapshots(
-            sharedParticipations.map(({ campaignParticipationId }) => campaignParticipationId),
-          );
+          await knowledgeElementForParticipationService.findUniqByUsersOrCampaignParticipationIds({
+            participationInfos: sharedParticipations.map(({ campaignParticipationId }) => {
+              return { campaignParticipationId };
+            }),
+            fetchFromSnapshot: true,
+          });
 
         const startedParticipations = campaignParticipationInfoChunk.filter(
           ({ isShared, isCompleted }) => !isShared && !isCompleted,
@@ -126,11 +128,17 @@ class CampaignAssessmentExport {
       this.i18n.__('campaign-export.assessment.shared-on'),
 
       ...(this.stageCollection.hasStage
-        ? [this.i18n.__('campaign-export.assessment.success-rate', { value: this.stageCollection.totalStages - 1 })]
+        ? [
+            this.i18n.__('campaign-export.assessment.success-rate', {
+              value: this.stageCollection.totalStages - 1,
+            }),
+          ]
         : []),
 
       ..._.flatMap(this.targetProfile.badges, (badge) => [
-        this.i18n.__('campaign-export.assessment.thematic-result-name', { name: badge.title }),
+        this.i18n.__('campaign-export.assessment.thematic-result-name', {
+          name: badge.title,
+        }),
       ]),
 
       this.i18n.__('campaign-export.assessment.mastery-percentage-target-profile'),
@@ -149,8 +157,12 @@ class CampaignAssessmentExport {
 
   #competenceColumnHeaders() {
     return _.flatMap(this.competences, (competence) => [
-      this.i18n.__('campaign-export.assessment.skill.mastery-percentage', { name: competence.name }),
-      this.i18n.__('campaign-export.assessment.skill.total-items', { name: competence.name }),
+      this.i18n.__('campaign-export.assessment.skill.mastery-percentage', {
+        name: competence.name,
+      }),
+      this.i18n.__('campaign-export.assessment.skill.total-items', {
+        name: competence.name,
+      }),
       this.i18n.__('campaign-export.assessment.skill.items-successfully-completed', { name: competence.name }),
     ]);
   }
@@ -158,7 +170,9 @@ class CampaignAssessmentExport {
   #areaColumnHeaders() {
     return _.flatMap(this.areas, (area) => [
       this.i18n.__('campaign-export.assessment.competence-area.mastery-percentage', { name: area.title }),
-      this.i18n.__('campaign-export.assessment.competence-area.total-items', { name: area.title }),
+      this.i18n.__('campaign-export.assessment.competence-area.total-items', {
+        name: area.title,
+      }),
       this.i18n.__('campaign-export.assessment.competence-area.items-successfully-completed', { name: area.title }),
     ]);
   }

--- a/api/src/prescription/shared/domain/models/KnowledgeElementCollection.js
+++ b/api/src/prescription/shared/domain/models/KnowledgeElementCollection.js
@@ -1,5 +1,3 @@
-import _ from 'lodash';
-
 import { KnowledgeElement } from '../../../../shared/domain/models/KnowledgeElement.js';
 
 class KnowledgeElementCollection {
@@ -8,17 +6,24 @@ class KnowledgeElementCollection {
   }
 
   get latestUniqNonResetKnowledgeElements() {
-    return _(this.knowledgeElements)
-      .orderBy('createdAt', 'desc')
-      .uniqBy('skillId')
-      .reject({ status: KnowledgeElement.StatusType.RESET })
-      .value();
+    const seen = new Set();
+
+    return this.knowledgeElements
+      .toSorted((a, b) => new Date(b.createdAt) - new Date(a.createdAt))
+      .filter((el) => {
+        if (seen.has(el.skillId)) return false;
+        seen.add(el.skillId);
+        return true;
+      })
+      .filter((el) => el.status !== KnowledgeElement.StatusType.RESET);
   }
 
   toSnapshot() {
     return JSON.stringify(
-      this.latestUniqNonResetKnowledgeElements.map((ke) =>
-        _.pick(ke, ['createdAt', 'source', 'status', 'earnedPix', 'skillId', 'competenceId']),
+      this.latestUniqNonResetKnowledgeElements.map(
+        ({ createdAt, source, status, earnedPix, skillId, competenceId }) => {
+          return { createdAt, source, status, earnedPix, skillId, competenceId };
+        },
       ),
     );
   }

--- a/api/src/prescription/shared/domain/services/knowledge-element-for-participation-service.js
+++ b/api/src/prescription/shared/domain/services/knowledge-element-for-participation-service.js
@@ -75,6 +75,18 @@ class KnowledgeElementForParticipationService {
 
     throw new Error(`find knowledge-elements for campaign of type ${campaign.type} not implemented`);
   }
+
+  async findUniqByUsersOrCampaignParticipationIds({ participationInfos, fetchFromSnapshot }) {
+    if (!fetchFromSnapshot) {
+      return await this.knowledgeElementRepository.findUniqByUserIds({
+        userIds: participationInfos.map(({ userId }) => userId),
+      });
+    }
+
+    return await this.knowledgeElementSnapshotRepository.findCampaignParticipationKnowledgeElementSnapshots(
+      participationInfos.map(({ campaignParticipationId }) => campaignParticipationId),
+    );
+  }
 }
 
 const knowledgeElementService = new KnowledgeElementForParticipationService();

--- a/api/tests/prescription/campaign/integration/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
@@ -592,6 +592,7 @@ describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-r
               userId: participant.id,
               state: Assessment.states.STARTED,
               type: Assessment.types.CAMPAIGN,
+              createdAt,
             });
 
             databaseBuilder.factory.buildKnowledgeElement({
@@ -599,6 +600,7 @@ describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-r
               skillId: 'recSkillWeb1',
               competenceId: 'recCompetence1',
               userId: participant.id,
+              createdAt,
             });
 
             // anonymized learner
@@ -631,6 +633,7 @@ describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-r
               skillId: 'recSkillWeb1',
               competenceId: 'recCompetence1',
               userId: anonymizedUser.id,
+              createdAt: new Date('2018-01-01'),
             });
 
             await databaseBuilder.commit();

--- a/api/tests/prescription/campaign/unit/infrastructure/serializers/csv/campaign-assessment-export_test.js
+++ b/api/tests/prescription/campaign/unit/infrastructure/serializers/csv/campaign-assessment-export_test.js
@@ -76,7 +76,7 @@ describe('Unit | Serializer | CSV | campaign-assessment-export', function () {
         '"% maitrise de l\'ensemble des acquis du profil"' +
         '\n';
       //when
-      await campaignProfile.export();
+      await campaignProfile.export({});
 
       outputStream.end();
 
@@ -113,7 +113,7 @@ describe('Unit | Serializer | CSV | campaign-assessment-export', function () {
         '"% maitrise de l\'ensemble des acquis du profil"' +
         '\n';
       //when
-      await campaignProfile.export();
+      await campaignProfile.export({});
 
       outputStream.end();
 
@@ -154,7 +154,7 @@ describe('Unit | Serializer | CSV | campaign-assessment-export', function () {
         '"% maitrise de l\'ensemble des acquis du profil"' +
         '\n';
       //when
-      await campaignProfile.export();
+      await campaignProfile.export({});
 
       outputStream.end();
 
@@ -196,7 +196,7 @@ describe('Unit | Serializer | CSV | campaign-assessment-export', function () {
         '"% maitrise de l\'ensemble des acquis du profil"' +
         '\n';
       //when
-      await campaignProfile.export();
+      await campaignProfile.export({});
 
       outputStream.end();
 
@@ -240,7 +240,7 @@ describe('Unit | Serializer | CSV | campaign-assessment-export', function () {
         '"% maitrise de l\'ensemble des acquis du profil"' +
         '\n';
       //when
-      await campaignProfile.export();
+      await campaignProfile.export({});
 
       outputStream.end();
 
@@ -283,7 +283,7 @@ describe('Unit | Serializer | CSV | campaign-assessment-export', function () {
         '\n';
 
       //when
-      await campaignProfile.export();
+      await campaignProfile.export({});
 
       outputStream.end();
 
@@ -327,7 +327,7 @@ describe('Unit | Serializer | CSV | campaign-assessment-export', function () {
         '\n';
 
       //when
-      await campaignProfile.export();
+      await campaignProfile.export({});
 
       outputStream.end();
 
@@ -368,7 +368,7 @@ describe('Unit | Serializer | CSV | campaign-assessment-export', function () {
         '\n';
 
       //when
-      await campaignProfile.export();
+      await campaignProfile.export({});
 
       outputStream.end();
 
@@ -412,7 +412,7 @@ describe('Unit | Serializer | CSV | campaign-assessment-export', function () {
         '\n';
 
       //when
-      await campaignProfile.export();
+      await campaignProfile.export({});
 
       outputStream.end();
 


### PR DESCRIPTION
## 🥀 Problème

Le pourcentage d'avancement sur le CSV des résultats sur PixOrga.

## 🏹 Proposition

Utiliser le service qui permet de filtrer les Ke n'appartenant pas à la campagne en cours pour refleter le bon pourcentage.

## 💌 Remarques

RAS

## ❤️‍🔥 Pour tester
