### PR TITLE
[FEATURE] Créer une route pour faire remonter la liste de public préscrit (PIX-21247)

### DIFF
--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -810,7 +810,7 @@
           "title": "Features"
         },
         "is-archived-warning": "Archived at {archivedAt} by {archivedBy}.",
-        "organization-learner-type": "Organization learner type",
+        "organization-learner-type": "Learner type",
         "province-code": "Province code",
         "sco-activation-email": "SCO activation e-mail address",
         "sso": "SSO",

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -812,7 +812,7 @@
           "title": "Fonctionnalités"
         },
         "is-archived-warning": "Archivée le {archivedAt} par {archivedBy}.",
-        "organization-learner-type": "Typologie de prescrits",
+        "organization-learner-type": "Public prescrit",
         "province-code": "Département",
         "sco-activation-email": "Adresse e-mail d'activation SCO",
         "sso": "SSO",

--- a/api/src/organizational-entities/application/organization-learner-type/organization-learner-type.admin.controller.js
+++ b/api/src/organizational-entities/application/organization-learner-type/organization-learner-type.admin.controller.js
@@ -1,0 +1,15 @@
+import { usecases } from '../../domain/usecases/index.js';
+import * as organizationLearnerTypeSerializer from '../../infrastructure/serializers/jsonapi/organization-learner-type/organization-learner-type-serializer.js';
+
+const findAllOrganizationLearnerTypes = async function (
+  request,
+  h,
+  dependencies = { organizationLearnerTypeSerializer },
+) {
+  const organizationLearnerTypes = await usecases.findAllOrganizationLearnerTypes();
+  return dependencies.organizationLearnerTypeSerializer.serialize(organizationLearnerTypes);
+};
+
+const organizationLearnerTypesController = { findAllOrganizationLearnerTypes };
+
+export { organizationLearnerTypesController };

--- a/api/src/organizational-entities/application/organization-learner-type/organization-learner-type.admin.route.js
+++ b/api/src/organizational-entities/application/organization-learner-type/organization-learner-type.admin.route.js
@@ -1,0 +1,34 @@
+import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
+import { organizationLearnerTypesController } from './organization-learner-type.admin.controller.js';
+
+const register = async function (server) {
+  server.route([
+    {
+      method: 'GET',
+      path: '/api/admin/organization-learner-types',
+      config: {
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.hasAtLeastOneAccessOf([
+                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+                securityPreHandlers.checkAdminMemberHasRoleSupport,
+                securityPreHandlers.checkAdminMemberHasRoleMetier,
+              ])(request, h),
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        handler: (request, h) => organizationLearnerTypesController.findAllOrganizationLearnerTypes(request, h),
+        notes: [
+          "- **Cette route est restreinte aux utilisateurs authentifiés ayant les droits d'accès**\n" +
+            '- Renvoie tous les publics prescrits.',
+        ],
+        tags: ['api', 'organization-learner-types'],
+      },
+    },
+  ]);
+};
+
+const name = 'organization-learner-types-admin-api';
+
+export { name, register };

--- a/api/src/organizational-entities/application/routes.js
+++ b/api/src/organizational-entities/application/routes.js
@@ -1,12 +1,14 @@
 import * as administrationTeamAdminRoutes from './administration-team/administration-team.admin.route.js';
 import * as certificationCenterAdminRoutes from './certification-center/certification-center.admin.route.js';
 import * as organizationAdminRoutes from './organization/organization.admin.route.js';
+import * as organizationLearnerTypeAdminRoutes from './organization-learner-type/organization-learner-type.admin.route.js';
 import * as tagAdminRoutes from './tag/tag.admin.route.js';
 
 const organizationalEntitiesRoutes = [
   certificationCenterAdminRoutes,
   organizationAdminRoutes,
   administrationTeamAdminRoutes,
+  organizationLearnerTypeAdminRoutes,
   tagAdminRoutes,
 ];
 

--- a/api/src/organizational-entities/domain/models/OrganizationLearnerType.js
+++ b/api/src/organizational-entities/domain/models/OrganizationLearnerType.js
@@ -1,0 +1,11 @@
+class OrganizationLearnerType {
+  /**
+   * @param {object} params
+   * @param {string} params.name
+   */
+  constructor({ name }) {
+    this.name = name;
+  }
+}
+
+export { OrganizationLearnerType };

--- a/api/src/organizational-entities/domain/usecases/find-all-organization-learner-types.refactor.js
+++ b/api/src/organizational-entities/domain/usecases/find-all-organization-learner-types.refactor.js
@@ -1,0 +1,9 @@
+/**
+ * @function
+ * @returns {Promise<Array<OrganizationLearnerType>>}
+ */
+const findAllOrganizationLearnerTypes = async function ({ organizationLearnerTypeRepository }) {
+  return organizationLearnerTypeRepository.findAll();
+};
+
+export { findAllOrganizationLearnerTypes };

--- a/api/src/organizational-entities/domain/usecases/index.js
+++ b/api/src/organizational-entities/domain/usecases/index.js
@@ -16,6 +16,7 @@ import * as dataProtectionOfficerRepository from '../../infrastructure/repositor
 import { repositories as organizationalEntitiesRepositories } from '../../infrastructure/repositories/index.js';
 import * as organizationFeatureRepository from '../../infrastructure/repositories/organization-feature-repository.js';
 import * as organizationLearnerRepository from '../../infrastructure/repositories/organization-learner.repository.js';
+import * as organizationLearnerTypeRepository from '../../infrastructure/repositories/organization-learner-type-repository.js';
 import * as organizationPlacesLotRepository from '../../infrastructure/repositories/organization-places-lot.repository.js';
 import * as organizationTagRepository from '../../infrastructure/repositories/organization-tag.repository.js';
 import { tagRepository } from '../../infrastructure/repositories/tag.repository.js';
@@ -35,6 +36,7 @@ import * as organizationValidator from '../validators/organization-with-tags-and
  * @typedef {import ('../../infrastructure/repositories/organization-feature-repository.js')} OrganizationFeatureRepository
  * @typedef {import ('../../infrastructure/repositories/organization-places-lot.repository.js')} OrganizationPlacesLotRepository
  * @typedef {import ('../../infrastructure/repositories/organization-learner.repository.js')} OrganizationLearnerRepository
+ * @typedef {import ('../../infrastructure/repositories/organization-learner-type-repository.js')} OrganizationLearnerTypeRepository
  * @typedef {import ('../../infrastructure/repositories/organization-for-admin.repository.js')} OrganizationForAdminRepository
  * @typedef {import ('../../infrastructure/repositories/tag.repository.js')} TagRepository
  * @typedef {import ('../../infrastructure/repositories/target-profile-share-repository.js')} TargetProfileShareRepository
@@ -62,6 +64,7 @@ const repositories = {
   organizationForAdminRepository: organizationalEntitiesRepositories.organizationForAdminRepository,
   organizationFeatureRepository,
   organizationLearnerRepository,
+  organizationLearnerTypeRepository,
   organizationPlacesLotRepository,
   schoolRepository,
   learnersApi,
@@ -86,6 +89,7 @@ import { createOrganizationsWithTagsAndTargetProfiles } from './create-organizat
 import { createTag } from './create-tag.js';
 import { detachParentOrganizationFromOrganization } from './detach-parent-organization-from-organization.usecase.js';
 import { findAllAdministrationTeams } from './find-all-administration-teams.usecase.js';
+import { findAllOrganizationLearnerTypes } from './find-all-organization-learner-types.refactor.js';
 import { findAllTags } from './find-all-tags.usecase.js';
 import { findChildrenOrganizations } from './find-children-organizations.usecase.js';
 import { findOrganizationFeatures } from './find-organization-features.js';
@@ -120,6 +124,7 @@ const usecasesWithoutInjectedDependencies = {
   findPaginatedFilteredCertificationCenters,
   findPaginatedFilteredOrganizations,
   findAllAdministrationTeams,
+  findAllOrganizationLearnerTypes,
   getCenterForAdmin,
   getOrganizationById,
   getOrganizationDetails,

--- a/api/src/organizational-entities/infrastructure/repositories/organization-learner-type-repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/organization-learner-type-repository.js
@@ -1,0 +1,24 @@
+import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
+import { OrganizationLearnerType } from '../../domain/models/OrganizationLearnerType.js';
+
+/**
+ * @function
+ * @returns {Promise<Array<OrganizationLearnerType>>}
+ */
+const findAll = async function () {
+  const knexConn = DomainTransaction.getConnection();
+  const organizationLearnerTypes = await knexConn
+    .select('name')
+    .from('organization_learner_types')
+    .orderBy('name', 'asc');
+
+  return organizationLearnerTypes.map(_toDomain);
+};
+
+const _toDomain = function (organizationLearnerTypeDTO) {
+  return new OrganizationLearnerType({
+    name: organizationLearnerTypeDTO.name,
+  });
+};
+
+export { findAll };

--- a/api/src/organizational-entities/infrastructure/serializers/jsonapi/organization-learner-type/organization-learner-type-serializer.js
+++ b/api/src/organizational-entities/infrastructure/serializers/jsonapi/organization-learner-type/organization-learner-type-serializer.js
@@ -1,0 +1,11 @@
+import jsonapiSerializer from 'jsonapi-serializer';
+
+const { Serializer } = jsonapiSerializer;
+
+const serialize = function (organizationLearnerType) {
+  return new Serializer('organization-learner-type', {
+    attributes: ['name'],
+  }).serialize(organizationLearnerType);
+};
+
+export { serialize };

--- a/api/tests/organizational-entities/acceptance/application/organization-learner-type/organization-learner-type.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/organization-learner-type/organization-learner-type.admin.route.test.js
@@ -1,0 +1,46 @@
+import {
+  createServer,
+  databaseBuilder,
+  expect,
+  generateAuthenticatedUserRequestHeaders,
+  insertUserWithRoleSuperAdmin,
+} from '../../../../test-helper.js';
+
+describe('Acceptance | Organizational Entities | Application | Route | Admin | OrganizationLearnerTypes', function () {
+  describe('GET /api/admin/organization-learner-types', function () {
+    it('returns a list of organization learner types with 200 HTTP status code', async function () {
+      // given
+      const server = await createServer();
+      const organizationLearnerType1 = databaseBuilder.factory.buildOrganizationLearnerType({ name: 'Public 1' });
+      const organizationLearnerType2 = databaseBuilder.factory.buildOrganizationLearnerType({ name: 'Public 2' });
+      await databaseBuilder.commit();
+      const userId = (await insertUserWithRoleSuperAdmin()).id;
+      const options = {
+        method: 'GET',
+        url: '/api/admin/organization-learner-types',
+        headers: generateAuthenticatedUserRequestHeaders({ userId }),
+      };
+      const expectedOrganizationLearnerTypes = [
+        {
+          attributes: {
+            name: organizationLearnerType1.name,
+          },
+          type: 'organization-learner-types',
+        },
+        {
+          attributes: {
+            name: organizationLearnerType2.name,
+          },
+          type: 'organization-learner-types',
+        },
+      ];
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result.data).to.deep.equal(expectedOrganizationLearnerTypes);
+    });
+  });
+});

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/organization-learner-type-repository_test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/organization-learner-type-repository_test.js
@@ -1,0 +1,38 @@
+import * as organizationLearnerTypeRepository from '../../../../../src/organizational-entities/infrastructure/repositories/organization-learner-type-repository.js';
+import { databaseBuilder, domainBuilder, expect } from '../../../../test-helper.js';
+
+describe('Integration | Repository | organization-learner-type-repository', function () {
+  describe('#findAll', function () {
+    it('should return all organization learner types ordered by name', async function () {
+      // given
+      const firstOrganizationLearnerType = databaseBuilder.factory.buildOrganizationLearnerType({
+        name: 'Type B',
+        createdAt: new Date('2020-01-01'),
+      });
+      const secondOrganizationLearnerType = databaseBuilder.factory.buildOrganizationLearnerType({
+        name: 'Type A',
+        createdAt: new Date('2021-01-02'),
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const result = await organizationLearnerTypeRepository.findAll();
+
+      // then
+      expect(result).to.have.deep.members([
+        domainBuilder.acquisition.buildOrganizationLearnerType({
+          name: secondOrganizationLearnerType.name,
+        }),
+        domainBuilder.acquisition.buildOrganizationLearnerType({ name: firstOrganizationLearnerType.name }),
+      ]);
+    });
+
+    it('should return an empty array if there is no organization learner type', async function () {
+      // when
+      const result = await organizationLearnerTypeRepository.findAll();
+
+      // then
+      expect(result).to.deep.equal([]);
+    });
+  });
+});

--- a/api/tests/organizational-entities/unit/application/organization-learner-type/organization-learner-type.admin.controller.test.js
+++ b/api/tests/organizational-entities/unit/application/organization-learner-type/organization-learner-type.admin.controller.test.js
@@ -1,0 +1,25 @@
+import { organizationLearnerTypesController } from '../../../../../src/organizational-entities/application/organization-learner-type/organization-learner-type.admin.controller.js';
+import { usecases } from '../../../../../src/organizational-entities/domain/usecases/index.js';
+import { domainBuilder, expect, hFake, sinon } from '../../../../test-helper.js';
+
+describe('Unit | Organizational Entities | Application | Controller | Admin | OrganizationLearnerType', function () {
+  describe('#findAllOrganizationLearnerTypes', function () {
+    it('calls findAllOrganizationLearnerTypes usecase and OrganizationLearnerType serializer', async function () {
+      // given
+      const organizationLearnerType1 = domainBuilder.acquisition.buildOrganizationLearnerType({ name: 'Public 1' });
+      const organizationLearnerType2 = domainBuilder.acquisition.buildOrganizationLearnerType({ name: 'Public 2' });
+      const organizationLearnerTypes = [organizationLearnerType1, organizationLearnerType2];
+      sinon.stub(usecases, 'findAllOrganizationLearnerTypes').resolves(organizationLearnerTypes);
+      const organizationLearnerTypeSerializer = { serialize: sinon.stub() };
+
+      // when
+      await organizationLearnerTypesController.findAllOrganizationLearnerTypes({}, hFake, {
+        organizationLearnerTypeSerializer,
+      });
+
+      // then
+      expect(usecases.findAllOrganizationLearnerTypes).to.have.been.calledOnce;
+      expect(organizationLearnerTypeSerializer.serialize).to.have.been.calledWithExactly(organizationLearnerTypes);
+    });
+  });
+});

--- a/api/tests/tooling/domain-builder/factory/acquisition/build-organization-learner-type.js
+++ b/api/tests/tooling/domain-builder/factory/acquisition/build-organization-learner-type.js
@@ -1,0 +1,7 @@
+import { OrganizationLearnerType } from '../../../../../src/organizational-entities/domain/models/OrganizationLearnerType.js';
+
+const buildOrganizationLearnerType = function ({ name = 'Élève' } = {}) {
+  return new OrganizationLearnerType({ name });
+};
+
+export { buildOrganizationLearnerType };

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -1,5 +1,6 @@
 import { buildCertificate } from '../factory/certification/results/build-v3-certification-attestation.js';
 import { buildPassage } from '../factory/devcomp/build-passage.js';
+import { buildOrganizationLearnerType } from './acquisition/build-organization-learner-type.js';
 import { buildEmptyInformationBanner, buildInformationBanner } from './banner/build-banner-information.js';
 import { buildAccountRecoveryDemand } from './build-account-recovery-demand.js';
 import { buildActivity } from './build-activity.js';
@@ -239,6 +240,10 @@ import { buildOrganizationToJoin } from './prescription/organization-learner/bui
 import { buildStageCollection as buildStageCollectionForTargetProfileManagement } from './target-profile-management/build-stage-collection.js';
 import { buildStageCollection as buildStageCollectionForUserCampaignResults } from './user-campaign-results/build-stage-collection.js';
 
+const acquisition = {
+  buildOrganizationLearnerType,
+};
+
 const banner = {
   buildEmptyInformationBanner,
   buildInformationBanner,
@@ -358,6 +363,7 @@ const llm = {
 };
 
 export {
+  acquisition,
   banner,
   buildAccountRecoveryDemand,
   buildActivity,


### PR DESCRIPTION
## 🥀 Problème

Dans le formulaire de création d'une organisation, on a besoin d'afficher une liste de public prescrit

## 🏹 Proposition

Créer un endpoint GET admin/organization-learner-types pour charger la liste des publics prescrits


## ❤️‍🔥 Pour tester

- Se connecter à pix-admin
- Récupérer le TOKEN
- Lancer la commande suivante

```
curl https://admin-pr15038.review.pix.fr/api/admin/organization-learner-types \
    -H "Authorization: Bearer $TOKEN" \
    -H "Content-Type: application/json" \
    -H "Accept-language: fr-fr" \
    -X GET \

```

- Constater que l'on récupère bien une liste de public prescrit