### PR TITLE
[FEATURE] Ajoute deux colonnes dans la BDD pour la suppression - anonymisation des parcours combinés (PIX-21453)

### DIFF
--- a/api/db/migrations/20260210104635_add-deleted-at-deleted-by-on-combined_courses.js
+++ b/api/db/migrations/20260210104635_add-deleted-at-deleted-by-on-combined_courses.js
@@ -1,0 +1,29 @@
+const TABLE_NAME = 'combined_courses';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dateTime('deletedAt').defaultTo(null).comment('Deletion date of combined course');
+    table
+      .bigInteger('deletedBy')
+      .references('users.id')
+      .defaultTo(null)
+      .comment('Id of the user triggering the deletion');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn('deletedAt');
+    table.dropColumn('deletedBy');
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## 🥀 Problème
On veut pouvoir supprimer ou anonymiser des parcours combinés.

## 🏹 Proposition
A l'image de ce qui se fait sur les campagnes, on veut pouvoir ajouter une date dans une colonne deletedAt et savoir qui a lancé la suppression du parcours.

## ❤️‍🔥 Pour tester
Connexion à Postgres sur la RA + \d combined_courses.
Vérifier la présence des colonnes, des types ainsi que de la clé étrangère.
