### PR TITLE
[TECH] Améliore l'usage du pool de connexions à la BDD via un refacto sur le usecase d'inscription de candidats de certification dans le SCO 

### DIFF
--- a/api/src/certification/enrolment/infrastructure/repositories/sco-certification-candidate-repository.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/sco-certification-candidate-repository.js
@@ -19,19 +19,19 @@ const addNonEnrolledCandidatesToSession = async function ({ sessionId, scoCertif
   await knex.transaction(async (trx) => {
     const organizationLearnerIds = scoCertificationCandidates.map((candidate) => candidate.organizationLearnerId);
 
-    const alreadyEnrolledCandidate = await trx
+    const alreadyEnrolledCandidates = await trx
       .select(['organizationLearnerId'])
       .from('certification-candidates')
       .whereIn('organizationLearnerId', organizationLearnerIds)
       .where({ sessionId });
 
-    const alreadyEnrolledCandidateOrganizationLearnerIds = alreadyEnrolledCandidate.map(
-      (candidate) => candidate.organizationLearnerId,
+    const alreadyEnrolledCandidateOrganizationLearnerIds = new Set(
+      alreadyEnrolledCandidates.map((c) => c.organizationLearnerId),
     );
 
     const scoCandidateToDTO = _scoCandidateToDTOForSession(sessionId);
     const candidatesToBeEnrolledDTOs = scoCertificationCandidates
-      .filter((candidate) => !alreadyEnrolledCandidateOrganizationLearnerIds.includes(candidate.organizationLearnerId))
+      .filter((c) => !alreadyEnrolledCandidateOrganizationLearnerIds.has(c.organizationLearnerId))
       .map((candidate) => scoCandidateToDTO(candidate));
 
     for (const candidateDTO of candidatesToBeEnrolledDTOs) {

--- a/api/src/certification/enrolment/infrastructure/repositories/sco-certification-candidate-repository.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/sco-certification-candidate-repository.js
@@ -6,7 +6,7 @@
 import { knex } from '../../../../../db/knex-database-connection.js';
 import { SUBSCRIPTION_TYPES } from '../../../shared/domain/constants.js';
 
-// We voluntarily let the transaction contained in the repository as the usecase initiate a lengthy treatment
+// We voluntarily keep the transaction contained in the repository as the usecase initiate a lengthy treatment
 
 /**
  * @function

--- a/api/src/certification/enrolment/infrastructure/repositories/sco-certification-candidate-repository.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/sco-certification-candidate-repository.js
@@ -4,7 +4,7 @@
  */
 
 import { knex } from '../../../../../db/knex-database-connection.js';
-import { Subscription } from '../../domain/models/Subscription.js';
+import { SUBSCRIPTION_TYPES } from '../../../shared/domain/constants.js';
 
 // We voluntarily let the transaction contained in the repository as the usecase initiate a lengthy treatment
 
@@ -30,21 +30,19 @@ const addNonEnrolledCandidatesToSession = async function ({ sessionId, scoCertif
     );
 
     const scoCandidateToDTO = _scoCandidateToDTOForSession(sessionId);
-    const candidatesToBeEnrolledDTOs = scoCertificationCandidates
-      .filter((c) => !alreadyEnrolledCandidateOrganizationLearnerIds.has(c.organizationLearnerId))
-      .map((candidate) => scoCandidateToDTO(candidate));
+    const candidateDTOs = scoCertificationCandidates
+      .filter((candidate) => !alreadyEnrolledCandidateOrganizationLearnerIds.has(candidate.organizationLearnerId))
+      .map(scoCandidateToDTO);
 
-    for (const candidateDTO of candidatesToBeEnrolledDTOs) {
-      const { subscriptions, ...candidateToInsert } = candidateDTO;
+    if (candidateDTOs.length === 0) return;
 
-      const [{ id }] = await trx('certification-candidates').insert(candidateToInsert).returning('id');
+    const insertedCandidateDTOs = await trx('certification-candidates').insert(candidateDTOs).returning(['id']);
 
-      subscriptions[0].certificationCandidateId = id;
-      // eslint-disable-next-line no-unused-vars
-      const { complementaryCertificationKey, ...subscriptionToInsert } = subscriptions[0];
-
-      await trx('certification-subscriptions').insert(subscriptionToInsert);
-    }
+    const subscriptionDTOs = insertedCandidateDTOs.map((insertedCandidateDTO) => ({
+      certificationCandidateId: insertedCandidateDTO.id,
+      type: SUBSCRIPTION_TYPES.CORE,
+    }));
+    await trx('certification-subscriptions').insert(subscriptionDTOs);
   });
 };
 
@@ -61,7 +59,6 @@ export { addNonEnrolledCandidatesToSession };
  * @property {string} birthCity
  * @property {string} birthCountry
  * @property {number} sessionId
- * @property {Array<Subscription>} subscriptions
  */
 
 /**
@@ -70,18 +67,15 @@ export { addNonEnrolledCandidatesToSession };
  * @returns {function(SCOCertificationCandidate): SCOCertificationCandidateDTO}
  */
 function _scoCandidateToDTOForSession(sessionId) {
-  return (scoCandidate) => {
-    return {
-      firstName: scoCandidate.firstName,
-      lastName: scoCandidate.lastName,
-      birthdate: scoCandidate.birthdate,
-      organizationLearnerId: scoCandidate.organizationLearnerId,
-      sex: scoCandidate.sex,
-      birthINSEECode: scoCandidate.birthINSEECode,
-      birthCity: scoCandidate.birthCity,
-      birthCountry: scoCandidate.birthCountry,
-      sessionId,
-      subscriptions: [Subscription.buildCore({ certificationCandidateId: null })],
-    };
-  };
+  return (scoCandidate) => ({
+    firstName: scoCandidate.firstName,
+    lastName: scoCandidate.lastName,
+    birthdate: scoCandidate.birthdate,
+    organizationLearnerId: scoCandidate.organizationLearnerId,
+    sex: scoCandidate.sex,
+    birthINSEECode: scoCandidate.birthINSEECode,
+    birthCity: scoCandidate.birthCity,
+    birthCountry: scoCandidate.birthCountry,
+    sessionId,
+  });
 }


### PR DESCRIPTION
## 🥀 Problème

Il existe des petits pas qui provoquent des effets de géant concernant la BDD.
Deux caveats :
- Une boucle (ou pire des boucles imbriquées) pour faire des opérations en BDD
- Le PromiseAll

## 🏹 Proposition

Sur ce usecase, réduction du nombre de requêtes pour inscrire des candidats SCO en certification.

### La boucle
Soit N candidats inscrits 
AVANT : 
=> N requête d'insertion batchée pour les candidats + N requêtes de subscriptions

APRES :
=> 1 requête d'insertion batchée pour les candidats + 1 requête d'insertion batchée de subscriptions

Exemple pour 25 candidats : 50 requêtes avant contre 2 aujourd'hui

### Le Promise.all
Récupération des infos CPF dans le cas où les candidats ont été inscrits avec un code de ville de naissance.
Sur 25 candidats, 5 sont inscrits avec un code de ville de naissance : 5 requêtes en parallèle pour récupérer les infos sur la ville (mauvais voisin pour les autres requêtes clients du même container). Il faut savoir que la taille du pool aujourd'hui est de 10 par container. Ce usecase peut prendre toutes les connexions du pool à lui tout seul

Solution : casser le promise.all et faire un mapSeries

## 💌 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## ❤️‍🔥 Pour tester
tests verts
