### PR TITLE
[FEATURE] Remplir les champs de la page de création d'un contenu formatif lorsqu'il concerne un module sur Pix Admin (PIX-21237)

### DIFF
--- a/admin/app/components/trainings/create-or-update-training-form.gjs
+++ b/admin/app/components/trainings/create-or-update-training-form.gjs
@@ -44,6 +44,9 @@ class Form {
   }
 }
 
+const MODULIX_TYPE = 'modulix';
+const MODULIX_EDITOR_LOGO_URL = 'https://assets.pix.org/contenu-formatif/editeur/pix-logo.svg';
+
 export default class CreateOrUpdateTrainingForm extends Component {
   @service featureToggles;
   @service store;
@@ -86,6 +89,17 @@ export default class CreateOrUpdateTrainingForm extends Component {
   @action
   updateSelect(key, value) {
     set(this.form, key, value);
+
+    this.fillInputsForModulixTraining();
+  }
+
+  @action
+  fillInputsForModulixTraining() {
+    if (this.form.type === MODULIX_TYPE) {
+      if (!this.form.editorLogoUrl) {
+        set(this.form, 'editorLogoUrl', MODULIX_EDITOR_LOGO_URL);
+      }
+    }
   }
 
   @action

--- a/admin/app/components/trainings/create-or-update-training-form.gjs
+++ b/admin/app/components/trainings/create-or-update-training-form.gjs
@@ -175,7 +175,7 @@ export default class CreateOrUpdateTrainingForm extends Component {
           </PixSelect>
 
           {{#if this.form.type}}
-            {{#if (eq this.form.type "modulix")}}
+            {{#if (eq this.form.type MODULIX_TYPE)}}
               <PixSelect
                 @id="trainingModule"
                 @placeholder="-- Sélectionnez un module --"
@@ -253,7 +253,7 @@ export default class CreateOrUpdateTrainingForm extends Component {
           </PixSelect>
           <PixInput
             @id="trainingEditorLogoUrl"
-            @subLabel="Exemple : https://assets.pix.org/contenu-formatif/editeur/pix-logo.svg"
+            @subLabel="Exemple : {{MODULIX_EDITOR_LOGO_URL}}"
             required={{true}}
             aria-required={{true}}
             @value={{this.form.editorLogoUrl}}

--- a/admin/app/components/trainings/create-or-update-training-form.gjs
+++ b/admin/app/components/trainings/create-or-update-training-form.gjs
@@ -46,6 +46,7 @@ class Form {
 
 const MODULIX_TYPE = 'modulix';
 const MODULIX_EDITOR_LOGO_URL = 'https://assets.pix.org/contenu-formatif/editeur/pix-logo.svg';
+const MODULIX_EDITOR_NAME = 'Pix';
 
 export default class CreateOrUpdateTrainingForm extends Component {
   @service featureToggles;
@@ -98,6 +99,10 @@ export default class CreateOrUpdateTrainingForm extends Component {
     if (this.form.type === MODULIX_TYPE) {
       if (!this.form.editorLogoUrl) {
         set(this.form, 'editorLogoUrl', MODULIX_EDITOR_LOGO_URL);
+      }
+
+      if (!this.form.editorName) {
+        set(this.form, 'editorName', MODULIX_EDITOR_NAME);
       }
     }
   }

--- a/admin/app/components/trainings/create-or-update-training-form.gjs
+++ b/admin/app/components/trainings/create-or-update-training-form.gjs
@@ -91,12 +91,17 @@ export default class CreateOrUpdateTrainingForm extends Component {
   updateSelect(key, value) {
     set(this.form, key, value);
 
-    this.fillInputsForModulixTraining();
+    this.fillInputsForModulixTraining(key, value);
   }
 
   @action
-  fillInputsForModulixTraining() {
+  fillInputsForModulixTraining(key, value) {
     if (this.form.type === MODULIX_TYPE) {
+      if (key === 'link') {
+        const selectedModule = this.modules.find((module) => module.link === value);
+        set(this.form, 'duration.minutes', selectedModule.duration);
+      }
+
       if (!this.form.editorLogoUrl) {
         set(this.form, 'editorLogoUrl', MODULIX_EDITOR_LOGO_URL);
       }

--- a/admin/app/components/trainings/create-or-update-training-form.gjs
+++ b/admin/app/components/trainings/create-or-update-training-form.gjs
@@ -274,7 +274,6 @@ export default class CreateOrUpdateTrainingForm extends Component {
             @subLabel="Exemple: Ministère de l'Éducation nationale et de la Jeunesse. Liberté égalité fraternité"
             required={{true}}
             aria-required={{true}}
-            placeholder="Ministère de l'Éducation nationale et de la Jeunesse. Liberté égalité fraternité."
             @value={{this.form.editorName}}
             {{on "change" (fn this.updateForm "editorName")}}
           >

--- a/admin/app/models/module-metadata.js
+++ b/admin/app/models/module-metadata.js
@@ -3,4 +3,5 @@ import Model, { attr } from '@ember-data/model';
 export default class ModuleMetadata extends Model {
   @attr('string') title;
   @attr('string') link;
+  @attr('string') duration;
 }

--- a/admin/tests/integration/components/trainings/create-or-update-training-form-test.gjs
+++ b/admin/tests/integration/components/trainings/create-or-update-training-form-test.gjs
@@ -261,6 +261,50 @@ module('Integration | Component | trainings | CreateOrUpdateTrainingForm', funct
       });
     });
 
+    test('it should auto fill the editor name', async function (assert) {
+      // given
+      // when
+      const screen = await render(
+      <template><CreateOrUpdateTrainingForm @onSubmit={{onSubmit}} @onCancel={{onCancel}} /></template>,
+      );
+
+      await click(screen.getByRole('button', { name: 'Format' }));
+      await screen.findByRole('listbox');
+      await click(screen.getByRole('option', { name: 'Module Pix' }));
+
+      // then
+      assert
+        .dom(
+          screen.getByLabelText(
+            "Nom de l'éditeur Exemple: Ministère de l'Éducation nationale et de la Jeunesse. Liberté égalité fraternité",
+          ),
+        )
+        .hasValue('Pix');
+    });
+
+    module('when editor name was already provided', function () {
+      test('it should not auto fill the editor name', async function (assert) {
+        // given
+        const editorNameValue = 'Super éditeur !';
+
+        // when
+        const screen = await render(
+        <template><CreateOrUpdateTrainingForm @onSubmit={{onSubmit}} @onCancel={{onCancel}} /></template>,
+        );
+        const editorNameInput = screen.getByLabelText(
+          "Nom de l'éditeur Exemple: Ministère de l'Éducation nationale et de la Jeunesse. Liberté égalité fraternité",
+        );
+
+        await fillIn(editorNameInput, editorNameValue);
+        await click(screen.getByRole('button', { name: 'Format' }));
+        await screen.findByRole('listbox');
+        await click(screen.getByRole('option', { name: 'Module Pix' }));
+
+        // then
+        assert.dom(editorNameInput).hasValue(editorNameValue);
+      });
+    });
+
     module('when model is provided', function () {
       test('it should display correct module on editing form', async function (assert) {
         // given & when

--- a/admin/tests/integration/components/trainings/create-or-update-training-form-test.gjs
+++ b/admin/tests/integration/components/trainings/create-or-update-training-form-test.gjs
@@ -16,8 +16,16 @@ module('Integration | Component | trainings | CreateOrUpdateTrainingForm', funct
 
   hooks.beforeEach(async function () {
     const store = this.owner.lookup('service:store');
-    store.createRecord('module-metadata', { title: 'Faire un clic droit', link: '/modules/r2d2droi/clic-droit' });
-    store.createRecord('module-metadata', { title: 'Utiliser un LLM', link: '/modules/k2000tro/use-llm' });
+    store.createRecord('module-metadata', {
+      title: 'Faire un clic droit',
+      link: '/modules/r2d2droi/clic-droit',
+      duration: 30,
+    });
+    store.createRecord('module-metadata', {
+      title: 'Utiliser un LLM',
+      link: '/modules/k2000tro/use-llm',
+      duration: 10,
+    });
   });
 
   test('it should display the items', async function (assert) {
@@ -265,7 +273,7 @@ module('Integration | Component | trainings | CreateOrUpdateTrainingForm', funct
       // given
       // when
       const screen = await render(
-      <template><CreateOrUpdateTrainingForm @onSubmit={{onSubmit}} @onCancel={{onCancel}} /></template>,
+        <template><CreateOrUpdateTrainingForm @onSubmit={{onSubmit}} @onCancel={{onCancel}} /></template>,
       );
 
       await click(screen.getByRole('button', { name: 'Format' }));
@@ -289,7 +297,7 @@ module('Integration | Component | trainings | CreateOrUpdateTrainingForm', funct
 
         // when
         const screen = await render(
-        <template><CreateOrUpdateTrainingForm @onSubmit={{onSubmit}} @onCancel={{onCancel}} /></template>,
+          <template><CreateOrUpdateTrainingForm @onSubmit={{onSubmit}} @onCancel={{onCancel}} /></template>,
         );
         const editorNameInput = screen.getByLabelText(
           "Nom de l'éditeur Exemple: Ministère de l'Éducation nationale et de la Jeunesse. Liberté égalité fraternité",
@@ -303,6 +311,24 @@ module('Integration | Component | trainings | CreateOrUpdateTrainingForm', funct
         // then
         assert.dom(editorNameInput).hasValue(editorNameValue);
       });
+    });
+
+    test('it should auto fill the duration', async function (assert) {
+      // given
+      // when
+      const screen = await render(
+        <template><CreateOrUpdateTrainingForm @onSubmit={{onSubmit}} @onCancel={{onCancel}} /></template>,
+      );
+
+      await click(screen.getByRole('button', { name: 'Format' }));
+      await screen.findByRole('listbox');
+      await click(screen.getByRole('option', { name: 'Module Pix' }));
+      await click(screen.getByRole('button', { name: 'Module' }));
+      await screen.findByRole('listbox');
+      await click(await screen.findByRole('option', { name: 'Utiliser un LLM' }));
+
+      // then
+      assert.dom(screen.getByRole('spinbutton', { name: 'Minutes (MM)' })).hasValue('10');
     });
 
     module('when model is provided', function () {

--- a/admin/tests/integration/components/trainings/create-or-update-training-form-test.gjs
+++ b/admin/tests/integration/components/trainings/create-or-update-training-form-test.gjs
@@ -217,6 +217,50 @@ module('Integration | Component | trainings | CreateOrUpdateTrainingForm', funct
       assert.dom(screen.getByRole('button', { name: 'Module' })).exists();
     });
 
+    test('it should auto fill the editor logo url', async function (assert) {
+      // given
+      // when
+      const screen = await render(
+        <template><CreateOrUpdateTrainingForm @onSubmit={{onSubmit}} @onCancel={{onCancel}} /></template>,
+      );
+
+      await click(screen.getByRole('button', { name: 'Format' }));
+      await screen.findByRole('listbox');
+      await click(screen.getByRole('option', { name: 'Module Pix' }));
+
+      // then
+      assert
+        .dom(
+          screen.getByRole('textbox', {
+            name: "Url du logo de l'éditeur (.svg) Exemple : https://assets.pix.org/contenu-formatif/editeur/pix-logo.svg",
+          }),
+        )
+        .hasValue('https://assets.pix.org/contenu-formatif/editeur/pix-logo.svg');
+    });
+
+    module('when editor logo url was already provided', function () {
+      test('it should not auto fill the editor logo url', async function (assert) {
+        // given
+        const editorLogoUrlValue = 'https://assets.pix.org/contenu-formatif/editeur/hello.svg';
+
+        // when
+        const screen = await render(
+          <template><CreateOrUpdateTrainingForm @onSubmit={{onSubmit}} @onCancel={{onCancel}} /></template>,
+        );
+        const editorLogoUrl = screen.getByRole('textbox', {
+          name: "Url du logo de l'éditeur (.svg) Exemple : https://assets.pix.org/contenu-formatif/editeur/pix-logo.svg",
+        });
+
+        await fillIn(editorLogoUrl, editorLogoUrlValue);
+        await click(screen.getByRole('button', { name: 'Format' }));
+        await screen.findByRole('listbox');
+        await click(screen.getByRole('option', { name: 'Module Pix' }));
+
+        // then
+        assert.dom(editorLogoUrl).hasValue(editorLogoUrlValue);
+      });
+    });
+
     module('when model is provided', function () {
       test('it should display correct module on editing form', async function (assert) {
         // given & when


### PR DESCRIPTION
## 🥀 Problème

Le métier est amené à créer des contenu formatif concernant les modules et dans le formulaire, on attend des valeurs dans les champs qui sont en soit déjà stockées dans les données des modules (duration).
Le logo de l'éditeur et son nom sont également systématiquement les mêmes.

Le métier aimerait que ces champs soient automatiquement remplis.

## 🏹 Proposition

Remplir automatiquement les champs lorsqu'un CF modulix est créé ou mis à jour, c'est à dire : 

- la durée
- le logo de l'éditeur ( on veut toujours https://assets.pix.org/contenu-formatif/editeur/pix-logo.svg)
- le nom de l'éditeur ( on veut toujours Pix )

## 💌 Remarques

J'ai constaté que la duration max d'un module était de 30 min. A cela j'ai volontairement modifié uniquement l'input des minutes dans le formulaire.

Est-ce que je traite ici la possibilité qu'il puisse durer 1 heure ou plus ou on le fera en temps voulu ?

## ❤️‍🔥 Pour tester

Testez avec ces 3 modules, ils ont des durations différentes 

<img width="398" height="130" alt="Capture d’écran 2026-02-10 à 15 27 05" src="https://github.com/user-attachments/assets/bac98337-13a0-484f-9c37-adc1198984d3" />
<img width="495" height="127" alt="Capture d’écran 2026-02-10 à 15 28 26" src="https://github.com/user-attachments/assets/30e29435-9c83-43e2-b882-59a8c4857465" />
<img width="358" height="127" alt="Capture d’écran 2026-02-10 à 15 29 10" src="https://github.com/user-attachments/assets/9dba2179-06f5-4df1-9113-9ba675f982c8" />


Lors de la création d'un contenu formatif : 
Constater que les champs sont remplis quand le module est sélectionné



https://github.com/user-attachments/assets/7fc23c8c-578d-4a1f-8d24-01a22f8f9506

---

A la modification d'un contenu formatif : 

- Si je clique sur un autre module avec une durée différente, le champ "Minutes MM" se met à jour.


- Si je remplace "Pix" dans le champ "Nom de l'éditeur" et l'url, puis que je change le type (pour ex `webinaire`) et que je remet type `Module`, le logo url et le nom de l'éditeur ne sont pas modifiés.