### PR TITLE
[FEATURE] Pouvoir supprimer un parcours combiné et anonymiser ses participations (PIX-21503)

### DIFF
--- a/api/scripts/prod/delete-and-anonymise-combined-courses.js
+++ b/api/scripts/prod/delete-and-anonymise-combined-courses.js
@@ -1,0 +1,63 @@
+import { usecases } from '../../src/quest/domain/usecases/index.js';
+import { commaSeparatedNumberParser } from '../../src/shared/application/scripts/parsers.js';
+import { Script } from '../../src/shared/application/scripts/script.js';
+import { ScriptRunner } from '../../src/shared/application/scripts/script-runner.js';
+import { DomainTransaction } from '../../src/shared/domain/DomainTransaction.js';
+
+// Définition du script
+export class DeleteAndAnonymiseCombinedCoursesScript extends Script {
+  constructor() {
+    super({
+      description: 'Deletes combined courses and anonymize possible existing participations of learners',
+      permanent: true,
+      options: {
+        combinedCourseIds: {
+          type: 'string',
+          describe: 'a list of comma separated combined course ids',
+          demandOption: true,
+          coerce: commaSeparatedNumberParser(),
+        },
+        dryRun: {
+          type: 'boolean',
+          default: true,
+        },
+      },
+    });
+  }
+
+  async handle({ options, logger, dependencies = usecases }) {
+    logger.info(
+      { event: 'DeleteAndAnonymizeCombinedCoursesScript' },
+      `Deletes ${options.combinedCourseIds.length} combined courses and anonymize possible existing participations`,
+    );
+    await DomainTransaction.execute(async () => {
+      const knexConn = DomainTransaction.getConnection();
+
+      const engineeringUserId = process.env.ENGINEERING_USER_ID;
+
+      try {
+        await dependencies.deleteAndAnonymizeCombinedCourses({
+          combinedCourseIds: options.combinedCourseIds,
+          userId: engineeringUserId,
+        });
+
+        if (options.dryRun) {
+          await knexConn.rollback();
+          logger.info(`ROLLBACK due to dryRun`);
+          logger.info(`--dryRun true to persist changes`);
+          return;
+        }
+
+        logger.info(
+          { event: 'DeleteAndAnonymizeCombinedCoursesScript' },
+          `COMMIT: Successfully deleted ${options.combinedCourseIds.length} combined courses and anonymized their participations`,
+        );
+      } catch (error) {
+        await knexConn.rollback();
+        logger.error({ event: 'DeleteAndAnonymizeCombinedCoursesScript' }, `ROLLBACK: An error has occured, ${error}`);
+        throw error;
+      }
+    });
+  }
+}
+await ScriptRunner.execute(import.meta.url, DeleteAndAnonymiseCombinedCoursesScript);

--- a/api/src/prescription/campaign/application/api/campaigns-api.js
+++ b/api/src/prescription/campaign/application/api/campaigns-api.js
@@ -76,7 +76,9 @@ export const save = async (campaigns, options) => {
  */
 export const get = async (campaignId) => {
   const getCampaign = await usecases.getCampaign({ campaignId });
-  return new Campaign(getCampaign);
+  const campaign = new Campaign(getCampaign);
+  campaign.setOrganizationId(getCampaign.organizationId);
+  return campaign;
 };
 
 /**
@@ -241,3 +243,22 @@ export const deleteActiveCampaigns = withTransaction(async ({ userId, organizati
   const campaignIdsToDelete = await usecases.findActiveCampaignIdsByOrganization({ organizationId });
   await usecases.deleteCampaigns({ userId, organizationId, campaignIds: campaignIdsToDelete });
 });
+
+export const deleteCampaignsInCombinedCourses = async ({
+  userId,
+  organizationId,
+  campaignIds,
+  keepPreviousDeletion,
+  userRole,
+  client,
+}) => {
+  await usecases.deleteCampaigns({
+    userId,
+    organizationId,
+    campaignIds,
+    keepPreviousDeletion,
+    userRole,
+    client,
+    isPartOfDeletingCombinedCourse: true,
+  });
+};

--- a/api/src/prescription/campaign/application/api/models/Campaign.js
+++ b/api/src/prescription/campaign/application/api/models/Campaign.js
@@ -24,4 +24,8 @@ export class Campaign {
     this.isProfilesCollection = isProfilesCollection;
     this.targetProfileId = targetProfileId;
   }
+
+  setOrganizationId(id) {
+    this.organizationId = id;
+  }
 }

--- a/api/src/prescription/campaign/domain/read-models/CampaignReport.js
+++ b/api/src/prescription/campaign/domain/read-models/CampaignReport.js
@@ -25,6 +25,7 @@ class CampaignReport {
     stages = [],
     multipleSendings,
     targetProfileName,
+    organizationId,
   } = {}) {
     this.targetProfileName = targetProfileName;
     this.id = id;
@@ -49,6 +50,7 @@ class CampaignReport {
     this.stages = stages;
     this.multipleSendings = multipleSendings;
     this.tubes = this.canComputeCoverRate ? undefined : null;
+    this.organizationId = organizationId;
   }
 
   get isAssessment() {

--- a/api/src/prescription/campaign/domain/usecases/delete-campaigns.js
+++ b/api/src/prescription/campaign/domain/usecases/delete-campaigns.js
@@ -21,6 +21,7 @@ const deleteCampaigns = withTransaction(
     client,
     userRole,
     keepPreviousDeletion = false,
+    isPartOfDeletingCombinedCourse = false,
   }) => {
     let membership;
     let pixAdminRole = userRole;
@@ -35,7 +36,7 @@ const deleteCampaigns = withTransaction(
 
     for (const campaignId of campaignIds) {
       const combinedCourses = await CombinedCourseRepository.findByCampaignId({ campaignId });
-      if (combinedCourses.length > 0) {
+      if (combinedCourses.length > 0 && !isPartOfDeletingCombinedCourse) {
         throw new CampaignBelongsToCombinedCourseError();
       }
     }

--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-report-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-report-repository.js
@@ -34,6 +34,7 @@ const get = async function (id) {
       targetProfileName: 'target-profiles.name',
       multipleSendings: 'campaigns.multipleSendings',
       areKnowledgeElementsResettable: 'target-profiles.areKnowledgeElementsResettable',
+      organizationId: 'campaigns.organizationId',
     })
     .select(
       knexConn.raw('ARRAY_AGG("badges"."id")  AS "badgeIds"'),

--- a/api/src/quest/domain/usecases/delete-and-anonymize-combined-courses.js
+++ b/api/src/quest/domain/usecases/delete-and-anonymize-combined-courses.js
@@ -1,0 +1,50 @@
+import { CLIENTS, PIX_ADMIN } from '../../../authorization/domain/constants.js';
+import { withTransaction } from '../../../shared/domain/DomainTransaction.js';
+
+export const deleteAndAnonymizeCombinedCourses = withTransaction(
+  async ({
+    combinedCourseRepository,
+    organizationLearnerParticipationRepository,
+    campaignRepository,
+    combinedCourseIds,
+    userId,
+    combinedCourseDetailsService,
+  }) => {
+    await combinedCourseRepository.deleteCombinedCourses({
+      combinedCourseIds,
+      deletedBy: userId,
+    });
+    await organizationLearnerParticipationRepository.deleteCombinedCourseParticipations({ combinedCourseIds, userId });
+    const campaignIds = await campaignRepository.getCampaignIdsByCombinedCourseIds({
+      combinedCourseIds,
+    });
+
+    const modulesIdsToDelete = [];
+
+    for (const combinedCourseId of combinedCourseIds) {
+      const { modules } = await combinedCourseDetailsService.instantiateCombinedCourseDetails({
+        combinedCourseId: combinedCourseId,
+      });
+      modulesIdsToDelete.push(...modules.map((module) => module.id));
+    }
+
+    await organizationLearnerParticipationRepository.deletePassagesByModuleIds({
+      moduleIds: modulesIdsToDelete,
+      userId,
+    });
+
+    for (const campaignId of campaignIds) {
+      const campaign = await campaignRepository.get({
+        id: campaignId,
+      });
+      await campaignRepository.deleteCampaignsInCombinedCourses({
+        userId,
+        organizationId: campaign.organizationId,
+        campaignIds: [campaign.id],
+        keepPreviousDeletion: true,
+        userRole: PIX_ADMIN.ROLES.SUPER_ADMIN,
+        client: CLIENTS.SCRIPT,
+      });
+    }
+  },
+);

--- a/api/src/quest/domain/usecases/index.js
+++ b/api/src/quest/domain/usecases/index.js
@@ -51,6 +51,7 @@ import { createCombinedCourseBlueprint } from './create-combined-course-blueprin
 import { createCombinedCourses } from './create-combined-courses.js';
 import { createOrUpdateQuestsInBatch } from './create-or-update-quests-in-batch.js';
 import { deleteAndAnonymizeParticipationsForALearnerId } from './delete-and-anonymise-participations-for-a-learner-id.js';
+import { deleteAndAnonymizeCombinedCourses } from './delete-and-anonymize-combined-courses.js';
 import { detachOrganizationFromCombinedCourseBlueprint } from './detach-organization-from-combined-course-blueprint.js';
 import { findByOrganizationId } from './find-by-organization-id.js';
 import { findCombinedCourseBlueprints } from './find-combined-course-blueprints.js';
@@ -74,6 +75,7 @@ const usecasesWithoutInjectedDependencies = {
   checkUserQuest,
   createOrUpdateQuestsInBatch,
   detachOrganizationFromCombinedCourseBlueprint,
+  deleteAndAnonymizeCombinedCourses,
   findCombinedCourseByCampaignId,
   findCombinedCourseByModuleIdAndUserId,
   getCombinedCourseByCode,

--- a/api/src/quest/infrastructure/repositories/campaign-repository.js
+++ b/api/src/quest/infrastructure/repositories/campaign-repository.js
@@ -11,6 +11,25 @@ export const get = async function ({ id, campaignsApi }) {
   return new Campaign(campaign);
 };
 
+export const deleteCampaignsInCombinedCourses = async function ({
+  userId,
+  organizationId,
+  campaignIds,
+  keepPreviousDeletion,
+  userRole,
+  client,
+  campaignsApi,
+}) {
+  return campaignsApi.deleteCampaignsInCombinedCourses({
+    userId,
+    organizationId,
+    campaignIds,
+    keepPreviousDeletion,
+    userRole,
+    client,
+  });
+};
+
 export const getCampaignIdsByCombinedCourseIds = async function ({ combinedCourseIds }) {
   const knexConn = DomainTransaction.getConnection();
 
@@ -31,7 +50,9 @@ export const getCampaignIdsByCombinedCourseIds = async function ({ combinedCours
 
 export const save = async function ({ campaigns, campaignsApi }) {
   const campaignToCreate = campaigns.map(_toDTO);
-  const createdCampaigns = await campaignsApi.save(campaignToCreate, { allowCreationWithoutTargetProfileShare: true });
+  const createdCampaigns = await campaignsApi.save(campaignToCreate, {
+    allowCreationWithoutTargetProfileShare: true,
+  });
   return createdCampaigns.map((campaign) => new Campaign(campaign));
 };
 

--- a/api/src/quest/infrastructure/repositories/combined-course-repository.js
+++ b/api/src/quest/infrastructure/repositories/combined-course-repository.js
@@ -138,6 +138,13 @@ const findByModuleIdAndOrganizationIds = async ({ moduleId, organizationIds }) =
   return combinedCourses.map(_toDomain);
 };
 
+const deleteCombinedCourses = async ({ combinedCourseIds, deletedBy }) => {
+  const knexConn = DomainTransaction.getConnection();
+  await knexConn('combined_courses')
+    .update({ deletedAt: knexConn.fn.now(), deletedBy, updatedAt: knexConn.fn.now() })
+    .whereIn('id', combinedCourseIds);
+};
+
 const _toDomain = ({
   id,
   organizationId,
@@ -161,6 +168,7 @@ const _toDomain = ({
 };
 
 export {
+  deleteCombinedCourses,
   findByCampaignId,
   findByModuleIdAndOrganizationIds,
   findByOrganizationId,

--- a/api/src/quest/infrastructure/repositories/organization-learner-participation-repository.js
+++ b/api/src/quest/infrastructure/repositories/organization-learner-participation-repository.js
@@ -96,3 +96,19 @@ export const deletePassagesByModuleIdsAndOrganizationLearnerId = async ({
     .whereIn('referenceId', moduleIds)
     .andWhere('organizationLearnerId', organizationLearnerId);
 };
+export const deleteCombinedCourseParticipations = async ({ combinedCourseIds, userId }) => {
+  const knexConn = DomainTransaction.getConnection();
+
+  const stringifiedCombinedCourseIds = combinedCourseIds.map((id) => id.toString());
+  await knexConn('organization_learner_participations')
+    .update({ deletedAt: knexConn.fn.now(), deletedBy: userId, updatedAt: knexConn.fn.now() })
+    .whereIn('organization_learner_participations.referenceId', stringifiedCombinedCourseIds);
+};
+
+export const deletePassagesByModuleIds = async ({ moduleIds, userId }) => {
+  const knexConn = DomainTransaction.getConnection();
+
+  await knexConn('organization_learner_participations')
+    .update({ deletedAt: knexConn.fn.now(), deletedBy: userId, updatedAt: knexConn.fn.now() })
+    .whereIn('organization_learner_participations.referenceId', moduleIds);
+}

--- a/api/src/quest/infrastructure/repositories/organization-learner-participation-repository.js
+++ b/api/src/quest/infrastructure/repositories/organization-learner-participation-repository.js
@@ -70,12 +70,7 @@ export const deleteCombinedCourseParticipationByCombinedCourseIdAndOrganizationL
 }) => {
   const knexConn = DomainTransaction.getConnection();
 
-  await knexConn('organization_learner_participations')
-    .update({
-      deletedAt: knexConn.fn.now(),
-      deletedBy: userId,
-      updatedAt: knexConn.fn.now(),
-    })
+  await baseUpdateQuery(knexConn, userId)
     .where('organizationLearnerId', organizationLearnerId)
     .andWhere('referenceId', combinedCourseId.toString());
 };
@@ -87,12 +82,7 @@ export const deletePassagesByModuleIdsAndOrganizationLearnerId = async ({
 }) => {
   const knexConn = DomainTransaction.getConnection();
 
-  await knexConn('organization_learner_participations')
-    .update({
-      deletedAt: knexConn.fn.now(),
-      deletedBy: userId,
-      updatedAt: knexConn.fn.now(),
-    })
+  await baseUpdateQuery(knexConn, userId)
     .whereIn('referenceId', moduleIds)
     .andWhere('organizationLearnerId', organizationLearnerId);
 };
@@ -100,15 +90,22 @@ export const deleteCombinedCourseParticipations = async ({ combinedCourseIds, us
   const knexConn = DomainTransaction.getConnection();
 
   const stringifiedCombinedCourseIds = combinedCourseIds.map((id) => id.toString());
-  await knexConn('organization_learner_participations')
-    .update({ deletedAt: knexConn.fn.now(), deletedBy: userId, updatedAt: knexConn.fn.now() })
-    .whereIn('organization_learner_participations.referenceId', stringifiedCombinedCourseIds);
+  await baseUpdateQuery(knexConn, userId).whereIn(
+    'organization_learner_participations.referenceId',
+    stringifiedCombinedCourseIds,
+  );
 };
 
 export const deletePassagesByModuleIds = async ({ moduleIds, userId }) => {
   const knexConn = DomainTransaction.getConnection();
 
-  await knexConn('organization_learner_participations')
-    .update({ deletedAt: knexConn.fn.now(), deletedBy: userId, updatedAt: knexConn.fn.now() })
-    .whereIn('organization_learner_participations.referenceId', moduleIds);
+  await baseUpdateQuery(knexConn, userId).whereIn('organization_learner_participations.referenceId', moduleIds);
+};
+
+function baseUpdateQuery(knexConn, userId) {
+  return knexConn('organization_learner_participations').update({
+    deletedAt: knexConn.fn.now(),
+    deletedBy: userId,
+    updatedAt: knexConn.fn.now(),
+  });
 }

--- a/api/tests/quest/integration/domain/usecases/delete-and-anonymize-combined-courses_test.js
+++ b/api/tests/quest/integration/domain/usecases/delete-and-anonymize-combined-courses_test.js
@@ -1,0 +1,113 @@
+import { expect } from 'chai';
+
+import {
+  OrganizationLearnerParticipationStatuses,
+  OrganizationLearnerParticipationTypes,
+} from '../../../../../src/quest/domain/models/OrganizationLearnerParticipation.js';
+import { usecases } from '../../../../../src/quest/domain/usecases/index.js';
+import { Membership } from '../../../../../src/shared/domain/models/Membership.js';
+import { databaseBuilder, knex, sinon } from '../../../../test-helper.js';
+
+describe('Integration | Combined course | Domain | UseCases | delete-and-anonymize-combined-courses', function () {
+  let campaign, organization, combinedCourse, otherCombinedCourse, campaignsApiStub;
+  const moduleId = "01151659-77c1-41cc-8724-89091357af3d";
+
+  beforeEach(async function () {
+    campaignsApiStub = {
+      get: sinon.stub(),
+      deleteCampaignsInCombinedCourses: sinon.stub(),
+    };
+
+    organization = databaseBuilder.factory.buildOrganization();
+    campaign = databaseBuilder.factory.buildCampaign({ organizationId: organization.id });
+    const combinedCourseBlueprint = databaseBuilder.factory.buildCombinedCourseBlueprint({
+      content: [{ type: 'EVALUATION', value: campaign.targetProfileId }],
+    });
+
+    combinedCourse = databaseBuilder.factory.buildCombinedCourse({
+      combinedCourseContents: [{ campaignId: campaign.id }, { moduleId }],
+      combinedCourseBlueprintId: combinedCourseBlueprint.id,
+      code: 'RANDOM',
+    });
+
+    databaseBuilder.factory.buildOrganizationLearnerParticipation({
+      combinedCourseId: combinedCourse.id.toString(),
+      type: OrganizationLearnerParticipationTypes.COMBINED_COURSE,
+      status: OrganizationLearnerParticipationStatuses.COMPLETED,
+    });
+
+    databaseBuilder.factory.buildOrganizationLearnerParticipation({
+      combinedCourseId: combinedCourse.id.toString(),
+      type: OrganizationLearnerParticipationTypes.COMBINED_COURSE,
+      status: OrganizationLearnerParticipationStatuses.COMPLETED,
+    });
+
+    databaseBuilder.factory.buildOrganizationLearnerParticipation({
+      moduleId,
+      type: OrganizationLearnerParticipationTypes.COMBINED_COURSE,
+      status: OrganizationLearnerParticipationStatuses.COMPLETED,
+    });
+
+    otherCombinedCourse = databaseBuilder.factory.buildCombinedCourse({ organizationId: organization.id });
+    databaseBuilder.factory.buildOrganizationLearnerParticipation({
+      organizationId: organization.id,
+      status: OrganizationLearnerParticipationStatuses.COMPLETED,
+    });
+    databaseBuilder.factory.buildOrganizationLearnerParticipation({
+      combinedCourseId: otherCombinedCourse.id.toString(),
+      type: OrganizationLearnerParticipationTypes.COMBINED_COURSE,
+      status: OrganizationLearnerParticipationStatuses.COMPLETED,
+    });
+
+    await databaseBuilder.commit();
+  });
+
+  it('flags combined course, campaign linked to combined course, and organization_learner_participations linked to combined Course', async function () {
+    //given
+    const { userId } = databaseBuilder.factory.buildMembership({
+      organizationId: organization.id,
+      organizationRole: Membership.roles.ADMIN,
+    });
+
+    campaignsApiStub.get.withArgs(campaign.id).resolves(campaign);
+    campaignsApiStub.deleteCampaignsInCombinedCourses.withArgs(campaign.id).resolves();
+
+    await databaseBuilder.commit();
+
+    //when
+    await usecases.deleteAndAnonymizeCombinedCourses({
+      combinedCourseIds: [combinedCourse.id],
+      userId,
+      campaignsApi: campaignsApiStub,
+    });
+
+    const deletedCombinedCourses = await knex('combined_courses').where('id', combinedCourse.id);
+    const deletedCombinedCourseParticipations = await knex('organization_learner_participations').where(
+      'referenceId',
+      combinedCourse.id,
+    );
+     const deletedCombinedCoursePassage = await knex('organization_learner_participations').where(
+      'referenceId',
+      moduleId,
+    );
+
+    const remainingCombinedCourses = await knex('combined_courses').where('id', otherCombinedCourse.id);
+    const remainingCombinedCourseParticipations = await knex('organization_learner_participations').where(
+      'referenceId',
+      otherCombinedCourse.id,
+    );
+
+    //then
+    expect(deletedCombinedCourses[0].deletedBy).to.equal(userId);
+    expect(deletedCombinedCourses[0].deletedAt).to.not.be.null;
+    expect(deletedCombinedCourseParticipations[0].deletedBy).to.equal(userId);
+    expect(deletedCombinedCourseParticipations[0].deletedAt).to.not.be.null;
+    expect(deletedCombinedCoursePassage[0].deletedBy).to.equal(userId);
+    expect(deletedCombinedCoursePassage[0].deletedAt).to.not.be.null;
+
+    expect(remainingCombinedCourses[0].deletedAt).to.be.null;
+    expect(remainingCombinedCourses[0].deletedBy).to.be.null;
+    expect(remainingCombinedCourseParticipations[0].deletedAt).to.be.null;
+    expect(remainingCombinedCourseParticipations[0].deletedBy).to.be.null;
+  });
+});

--- a/api/tests/quest/integration/domain/usecases/delete-and-anonymize-combined-courses_test.js
+++ b/api/tests/quest/integration/domain/usecases/delete-and-anonymize-combined-courses_test.js
@@ -10,7 +10,7 @@ import { databaseBuilder, knex, sinon } from '../../../../test-helper.js';
 
 describe('Integration | Combined course | Domain | UseCases | delete-and-anonymize-combined-courses', function () {
   let campaign, organization, combinedCourse, otherCombinedCourse, campaignsApiStub;
-  const moduleId = "01151659-77c1-41cc-8724-89091357af3d";
+  const moduleId = '01151659-77c1-41cc-8724-89091357af3d';
 
   beforeEach(async function () {
     campaignsApiStub = {
@@ -86,7 +86,7 @@ describe('Integration | Combined course | Domain | UseCases | delete-and-anonymi
       'referenceId',
       combinedCourse.id,
     );
-     const deletedCombinedCoursePassage = await knex('organization_learner_participations').where(
+    const deletedCombinedCoursePassage = await knex('organization_learner_participations').where(
       'referenceId',
       moduleId,
     );

--- a/api/tests/quest/integration/infrastructure/repositories/organization-learner-participation-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/organization-learner-participation-repository_test.js
@@ -446,8 +446,8 @@ describe('Quest | Integration | Infrastructure | repositories | organization lea
   describe('#deletePassagesByModuleIds', function () {
     it('should delete the exact passage', async function () {
       //given
-      const moduleId = "01151659-77c1-41cc-8724-89091357af3d";
-      const otherModuleId = "f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d";
+      const moduleId = '01151659-77c1-41cc-8724-89091357af3d';
+      const otherModuleId = 'f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d';
 
       const { userId } = await databaseBuilder.factory.buildMembership();
 
@@ -485,5 +485,4 @@ describe('Quest | Integration | Infrastructure | repositories | organization lea
       expect(remainingPassage[0].deletedBy).to.be.null;
     });
   });
-
 });

--- a/api/tests/unit/scripts/delete-and-anonymise-combined-courses_test.js
+++ b/api/tests/unit/scripts/delete-and-anonymise-combined-courses_test.js
@@ -1,0 +1,75 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { DeleteAndAnonymiseCombinedCoursesScript } from '../../../scripts/prod/delete-and-anonymise-combined-courses.js';
+import { DomainTransaction } from '../../../src/shared/domain/DomainTransaction.js';
+import { catchErr } from '../../test-helper.js';
+
+describe('DeleteAndAnonymiseCombinedCoursesScript', function () {
+  let script, logger;
+  describe('Options', function () {
+    it('has the correct options', function () {
+      script = new DeleteAndAnonymiseCombinedCoursesScript();
+      const { options } = script.metaInfo;
+
+      expect(options.combinedCourseIds).to.deep.include({
+        type: 'string',
+        describe: 'a list of comma separated combined course ids',
+        demandOption: true,
+      });
+    });
+  });
+
+  describe('Handle', function () {
+    let usecasesStub, domainTransactionStub;
+    const combinedCourseId = Symbol('1');
+    const ENGINEERING_USER_ID = 99999;
+
+    beforeEach(async function () {
+      script = new DeleteAndAnonymiseCombinedCoursesScript();
+      logger = { info: sinon.spy(), error: sinon.spy() };
+      sinon.stub(process, 'env').value({ ENGINEERING_USER_ID });
+
+      usecasesStub = {
+        deleteAndAnonymizeCombinedCourses: sinon.stub(),
+      };
+      domainTransactionStub = Symbol('domainTransaction');
+      sinon.stub(DomainTransaction, 'execute').callsFake((fn) => fn(domainTransactionStub));
+      sinon.stub(DomainTransaction, 'getConnection').returns({ rollback: sinon.stub() });
+    });
+
+    it('should call usecase with correct arguments and log accordingly if usecase resolves', async function () {
+      //given&when
+      await script.handle({ options: { combinedCourseIds: [combinedCourseId] }, logger, dependencies: usecasesStub });
+
+      //then
+      expect(usecasesStub.deleteAndAnonymizeCombinedCourses).to.be.calledWithExactly({
+        combinedCourseIds: [combinedCourseId],
+        userId: ENGINEERING_USER_ID,
+      });
+
+      expect(logger.info).to.have.been.calledWithExactly(
+        { event: 'DeleteAndAnonymizeCombinedCoursesScript' },
+        `COMMIT: Successfully deleted ${[combinedCourseId].length} combined courses and anonymized their participations`,
+      );
+    });
+    it('should rollback and log accordingly if usecase fail', async function () {
+      //given&when
+      usecasesStub.deleteAndAnonymizeCombinedCourses
+        .withArgs({
+          combinedCourseIds: [combinedCourseId],
+          userId: ENGINEERING_USER_ID,
+        })
+        .rejects();
+
+      await catchErr(script.handle)({
+        options: { combinedCourseIds: [combinedCourseId] },
+        logger,
+        dependencies: usecasesStub,
+      });
+
+      //then
+      expect(logger.error).to.have.been.called;
+    });
+  });
+});


### PR DESCRIPTION
## 🥀 Problème
On fait suite au premier script de la PR https://github.com/1024pix/pix/pull/15127

## 🏹 Proposition
On écrit un script qui : 
- marque les parcours combinés, les participations aux parcours combinés (organization_learner_participation de type combined_course), aux modules (organization_learner_participation de type passage) et aux campagnes, comme supprimés avec une valeur dans deletedAt et deletedBy
- supprime les campagnes liées aux parcours combinés.

Le script prend deux arguments : combinedCourseIds sous la forme d'une chaîne de caractères (les ids sont séparés par des virgules) et un booléen dryRun.

## ❤️‍🔥 Pour tester
Se connecter sur PixApp sur attestation-blank@example.net
Entrer MAXICOMBI dans j'ai un code -> participer à la campagne et au premier module. Relever l'id du parcours combiné
Entrer COMBINIX1 dans j'ai un code -> participer à la campagne et au premier module. Relever l'id du parcours combiné

Lancer la commande en RA (bash): node ./scripts/prod/delete-and-anonymise-combined-courses --dryRun=false --combinedCourseIds=id1, id2...

Vérifier que les parcours combinés, les campagnes associées et les participations sont bien flaggées
SELECT * FROM "combined_courses" WHERE "deletedAt" IS NOT NULL. 2 résultats doivent apparaître.
