### PR TITLE
[BUGFIX] (Problèmes de la production) Correction dans le scope Accès de la transactions d’un usecase read-only et de Promise.all (PIX-21455)

### DIFF
--- a/api/src/identity-access-management/application/oidc-provider/oidc-provider.admin.controller.js
+++ b/api/src/identity-access-management/application/oidc-provider/oidc-provider.admin.controller.js
@@ -9,7 +9,9 @@ import { getForwardedOrigin, RequestedApplication } from '../../infrastructure/u
  */
 async function createInBatch(request, h) {
   const oidcProviders = request.payload;
-  await Promise.all(oidcProviders.map((oidcProvider) => usecases.addOidcProvider({ ...oidcProvider })));
+  for (const oidcProvider of oidcProviders) {
+    await usecases.addOidcProvider(oidcProvider);
+  }
   return h.response().code(204);
 }
 

--- a/api/src/identity-access-management/application/oidc-provider/oidc-provider.admin.controller.js
+++ b/api/src/identity-access-management/application/oidc-provider/oidc-provider.admin.controller.js
@@ -1,4 +1,3 @@
-import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { oidcAuthenticationServiceRegistry, usecases } from '../../domain/usecases/index.js';
 import * as oidcProviderSerializer from '../../infrastructure/serializers/jsonapi/oidc-identity-providers.serializer.js';
 import { getForwardedOrigin, RequestedApplication } from '../../infrastructure/utils/network.js';
@@ -10,11 +9,7 @@ import { getForwardedOrigin, RequestedApplication } from '../../infrastructure/u
  */
 async function createInBatch(request, h) {
   const oidcProviders = request.payload;
-
-  await DomainTransaction.execute(() => {
-    return Promise.all(oidcProviders.map((oidcProvider) => usecases.addOidcProvider({ ...oidcProvider })));
-  });
-
+  await Promise.all(oidcProviders.map((oidcProvider) => usecases.addOidcProvider({ ...oidcProvider })));
   return h.response().code(204);
 }
 

--- a/api/src/identity-access-management/domain/usecases/add-oidc-provider.js
+++ b/api/src/identity-access-management/domain/usecases/add-oidc-provider.js
@@ -1,3 +1,5 @@
+import { withTransaction } from '../../../shared/domain/DomainTransaction.js';
+
 /**
  * @typedef {import ('../usecases/index.js').OidcProviderRepository} OidcProviderRepository
  */
@@ -31,7 +33,7 @@
  * @param {CryptoService} params.cryptoService
  * @returns {Promise<void>}
  */
-const addOidcProvider = async function ({
+export const addOidcProvider = withTransaction(async function ({
   accessTokenLifespan,
   additionalRequiredProperties,
   application,
@@ -92,6 +94,4 @@ const addOidcProvider = async function ({
   const propertiesWithEncryptedClientSecret = { encryptedClientSecret, ...propertiesWithoutClientSecret };
 
   await oidcProviderRepository.create(propertiesWithEncryptedClientSecret);
-};
-
-export { addOidcProvider };
+});

--- a/api/src/identity-access-management/domain/usecases/get-current-user.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/get-current-user.usecase.js
@@ -1,4 +1,3 @@
-import { withTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { UserWithActivity } from '../read-models/UserWithActivity.js';
 
 /**
@@ -10,7 +9,7 @@ import { UserWithActivity } from '../read-models/UserWithActivity.js';
  * }} params
  * @return {Promise<UserWithActivity>}
  */
-export const getCurrentUser = withTransaction(async function ({
+export const getCurrentUser = async function ({
   authenticatedUserId,
   userRepository,
   campaignParticipationRepository,
@@ -39,4 +38,4 @@ export const getCurrentUser = withTransaction(async function ({
     shouldSeeDataProtectionPolicyInformationBanner,
     anonymousUserToken,
   });
-});
+};

--- a/api/src/identity-access-management/domain/usecases/get-current-user.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/get-current-user.usecase.js
@@ -16,11 +16,15 @@ export const getCurrentUser = async function ({
   userRecommendedTrainingRepository,
   anonymousUserTokenRepository,
 }) {
-  const [hasAssessmentParticipations, codeForLastProfileToShare, hasRecommendedTrainings] = await Promise.all([
-    campaignParticipationRepository.hasAssessmentParticipations(authenticatedUserId),
-    campaignParticipationRepository.getCodeOfLastParticipationToProfilesCollectionCampaignForUser(authenticatedUserId),
-    userRecommendedTrainingRepository.hasRecommendedTrainings({ userId: authenticatedUserId }),
-  ]);
+  const hasAssessmentParticipations =
+    await campaignParticipationRepository.hasAssessmentParticipations(authenticatedUserId);
+  const codeForLastProfileToShare =
+    await campaignParticipationRepository.getCodeOfLastParticipationToProfilesCollectionCampaignForUser(
+      authenticatedUserId,
+    );
+  const hasRecommendedTrainings = await userRecommendedTrainingRepository.hasRecommendedTrainings({
+    userId: authenticatedUserId,
+  });
 
   const user = await userRepository.get(authenticatedUserId);
   const shouldSeeDataProtectionPolicyInformationBanner = user.shouldSeeDataProtectionPolicyInformationBanner;

--- a/api/src/identity-access-management/infrastructure/repositories/authentication-method.repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/authentication-method.repository.js
@@ -237,16 +237,14 @@ const update = async function ({ id, authenticationComplement }) {
     .update({ authenticationComplement, updatedAt: new Date() });
 };
 
-const batchUpsertPasswordThatShouldBeChanged = function ({ usersToUpdateWithNewPassword }) {
-  return Promise.all(
-    usersToUpdateWithNewPassword.map(async ({ userId, hashedPassword }) => {
-      if (await hasIdentityProviderPIX({ userId })) {
-        return updatePassword({ userId, hashedPassword, shouldChangePassword: true });
-      } else {
-        return createPasswordThatShouldBeChanged({ userId, hashedPassword });
-      }
-    }),
-  );
+const batchUpsertPasswordThatShouldBeChanged = async function ({ usersToUpdateWithNewPassword }) {
+  for (const { userId, hashedPassword } of usersToUpdateWithNewPassword) {
+    if (await hasIdentityProviderPIX({ userId })) {
+      await updatePassword({ userId, hashedPassword, shouldChangePassword: true });
+    } else {
+      await createPasswordThatShouldBeChanged({ userId, hashedPassword });
+    }
+  }
 };
 
 /**


### PR DESCRIPTION
## 🥀 Problème

Dans Pix API, dans le scope Accès, nous avons identifié des mauvaises utilisations de transactions et de `Promise.all`.

## 🏹 Proposition

* Supprimer l’utilisation des transactions dans les usecases read-only car elles sont inutiles
* Remplacer l’utiliser de `Promise.all` par `for...of` pour les appels en BDD pour éviter des requêtes en parallèle inutiles et impactant les autres requêtes

## 💌 Remarques

RAS

## ❤️‍🔥 Pour tester

* Pour tester le usecase getCurrentUser, tester une connexion simple d’un utilisateur et une déconnexion
* Pour tester ce qui touche au chargement des Identity Providers, tester une connexion par SSO
* Pour tester le chargement de nouveaux OIDC Providers dans Pix Admin, aller dans Pix Admin et charger le fichier `api/OIDC_PROVIDERS.example.json` 
* Pour tester le bon fonctionnement de `batchUpsertPasswordThatShouldBeChanged`, aller dans Pix Orga, dans une Orga SCO, sélectionnez tous les élèves et cliquez sur "Réinitialiser les mots de passe des élèves sélectionnés". 