### PR TITLE
[BUGFIX] Garder une connexion knex pour sauvegarder l'état de l'import (PIX-21368).

### DIFF
--- a/api/src/prescription/learner-management/infrastructure/repositories/organization-import-repository.js
+++ b/api/src/prescription/learner-management/infrastructure/repositories/organization-import-repository.js
@@ -1,3 +1,4 @@
+import { knex } from '../../../../../db/knex-database-connection.js';
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { OrganizationImportStatus } from '../../domain/models/OrganizationImportStatus.js';
 import { OrganizationImportDetail } from '../../domain/read-models/OrganizationImportDetail.js';
@@ -50,14 +51,13 @@ function _stringifyErrors(errors) {
 }
 
 const save = async function (organizationImport) {
-  const knexConn = DomainTransaction.getConnection();
   const attributes = { ...organizationImport, errors: _stringifyErrors(organizationImport.errors) };
 
   if (organizationImport.id) {
-    const updatedRows = await knexConn('organization-imports').update(attributes).where({ id: organizationImport.id });
+    const updatedRows = await knex('organization-imports').update(attributes).where({ id: organizationImport.id });
     if (updatedRows === 0) throw new Error();
   } else {
-    await knexConn('organization-imports').insert(attributes);
+    await knex('organization-imports').insert(attributes);
   }
 };
 


### PR DESCRIPTION
## 🥀 Problème

Les job d'import ne change plus de status. le finally sauvegarde en BDD. mais comme on est récupère une transaction. on ne sauvegarde pas l'état de l'import

## 🏹 Proposition

Utiliser knex avec parcimonie seulement sur le save de l'organisation import

## 💌 Remarques

RAS, peut être que c'est pas la meilleurs solution mais ca va débloquer le peu d'import qui le nécessite

## ❤️‍🔥 Pour tester
