### PR TITLE
[TECH] Utiliser l'attribut isFullWidth dans les pages de création et modification d'orga (PIX-21491)

### DIFF
--- a/admin/app/components/organizations/creation-form.gjs
+++ b/admin/app/components/organizations/creation-form.gjs
@@ -143,6 +143,7 @@ export default class OrganizationCreationForm extends Component {
               required={{false}}
               @validationStatus={{if this.validator.errors.name "error"}}
               @errorMessage={{if this.validator.errors.name (t this.validator.errors.name)}}
+              @isFullWidth={{true}}
             >
               <:label>{{t "components.organizations.creation.name.label"}}</:label>
             </PixInput>
@@ -157,6 +158,7 @@ export default class OrganizationCreationForm extends Component {
             @value={{this.form.type}}
             @requiredLabel={{t "common.fields.required-field"}}
             @errorMessage={{if this.validator.errors.type (t this.validator.errors.type)}}
+            @isFullWidth={{true}}
           >
             <:label>{{t "components.organizations.creation.type.label"}}</:label>
             <:default as |organizationType|>{{organizationType.label}}</:default>
@@ -174,6 +176,7 @@ export default class OrganizationCreationForm extends Component {
               this.validator.errors.administrationTeamId
               (t this.validator.errors.administrationTeamId)
             }}
+            @isFullWidth={{true}}
           >
             <:label>{{t "components.organizations.creation.administration-team.selector.label"}}</:label>
           </PixSelect>
@@ -189,6 +192,7 @@ export default class OrganizationCreationForm extends Component {
             @isSearchable={{true}}
             @locale={{this.locale.currentLocale}}
             @errorMessage={{if this.validator.errors.countryCode (t this.validator.errors.countryCode)}}
+            @isFullWidth={{true}}
           >
             <:label>{{t "components.organizations.creation.country.selector.label"}}</:label>
           </PixSelect>
@@ -206,6 +210,7 @@ export default class OrganizationCreationForm extends Component {
               @id="externalId"
               {{on "change" (fn this.handleInputChange "externalId")}}
               placeholder={{t "components.organizations.creation.external-id.placeholder"}}
+              @isFullWidth={{true}}
             >
               <:label>{{t "components.organizations.creation.external-id.label"}}</:label>
             </PixInput>
@@ -224,6 +229,7 @@ export default class OrganizationCreationForm extends Component {
               @value="{{this.form.documentationUrl}}"
               @validationStatus={{if this.validator.errors.documentationUrl "error"}}
               @errorMessage={{if this.validator.errors.documentationUrl (t this.validator.errors.documentationUrl)}}
+              @isFullWidth={{true}}
             >
               <:label>{{t "components.organizations.creation.documentation-link"}}</:label>
             </PixInput>
@@ -263,6 +269,7 @@ export default class OrganizationCreationForm extends Component {
                 this.validator.errors.dataProtectionOfficerEmail
                 (t this.validator.errors.dataProtectionOfficerEmail)
               }}
+              @isFullWidth={{true}}
             >
               <:label>{{t "components.organizations.creation.dpo.email"}}
                 <abbr title={{t "components.organizations.creation.dpo.definition"}}>{{t

--- a/admin/app/components/organizations/creation-form.scss
+++ b/admin/app/components/organizations/creation-form.scss
@@ -5,16 +5,11 @@
     .card__content {
       display: grid;
       grid-template-columns: 1fr 1fr;
-      column-gap: var(--pix-spacing-6x);
-      row-gap: var(--pix-spacing-6x);
+      gap: var(--pix-spacing-6x) var(--pix-spacing-6x);
     }
 
     .card__content > * + * {
-      margin-top: 0px;
-    }
-
-    .pix-select {
-      width: 100%;
+      margin-top: 0;
     }
 
     .pix-input__input {
@@ -25,10 +20,6 @@
   &__input {
     &--full {
       grid-column: 1 / span 2;
-
-      .pix-input {
-        width: 100%;
-      }
     }
   }
 

--- a/admin/app/components/organizations/information-section-edit.gjs
+++ b/admin/app/components/organizations/information-section-edit.gjs
@@ -192,6 +192,7 @@ export default class OrganizationInformationSectionEditionMode extends Component
               @errorMessage={{this.validator.errors.name}}
               @validationStatus={{if this.validator.errors.name "error"}}
               @value={{this.form.name}}
+              @isFullWidth={{true}}
               {{on "input" (fn this.updateFormValue "name")}}
             ><:label>
                 {{t "components.organizations.editing.name.label"}}
@@ -211,8 +212,8 @@ export default class OrganizationInformationSectionEditionMode extends Component
             @value={{this.form.administrationTeamId}}
             @onChange={{fn this.updateValue "administrationTeamId"}}
             @hideDefaultOption={{true}}
-            class="admin-form__select"
             @placeholder={{t "components.organizations.editing.administration-team.selector.placeholder"}}
+            @isFullWidth={{true}}
           >
             <:label>{{t "components.organizations.editing.administration-team.selector.label"}}</:label>
           </PixSelect>
@@ -229,8 +230,8 @@ export default class OrganizationInformationSectionEditionMode extends Component
             @hideDefaultOption={{true}}
             @isSearchable={{true}}
             @locale={{this.locale.currentLocale}}
-            class="admin-form__select"
             @placeholder={{t "components.organizations.editing.country.selector.placeholder"}}
+            @isFullWidth={{true}}
           >
             <:label>{{t "components.organizations.editing.country.selector.label"}}</:label>
           </PixSelect>
@@ -247,6 +248,7 @@ export default class OrganizationInformationSectionEditionMode extends Component
               @errorMessage={{this.validator.errors.externalId}}
               @validationStatus={{if this.validator.errors.externalId "error"}}
               @value={{this.form.externalId}}
+              @isFullWidth={{true}}
               {{on "input" (fn this.updateFormValue "externalId")}}
             ><:label>{{t "components.organizations.information-section-view.external-id"}}</:label></PixInput>
           </div>
@@ -261,6 +263,7 @@ export default class OrganizationInformationSectionEditionMode extends Component
               @errorMessage={{this.validator.errors.documentationUrl}}
               @validationStatus={{if this.validator.errors.documentationUrl "error"}}
               @value={{this.form.documentationUrl}}
+              @isFullWidth={{true}}
               {{on "input" (fn this.updateFormValue "documentationUrl")}}
             ><:label>{{t "components.organizations.information-section-view.documentation-link"}}</:label></PixInput>
           </div>
@@ -270,7 +273,7 @@ export default class OrganizationInformationSectionEditionMode extends Component
             @value={{this.form.identityProviderForCampaigns}}
             @onChange={{fn this.updateValue "identityProviderForCampaigns"}}
             @hideDefaultOption={{true}}
-            class="admin-form__select"
+            @isFullWidth={{true}}
           >
             <:label>{{t "components.organizations.information-section-view.sso"}}</:label>
           </PixSelect>
@@ -323,6 +326,7 @@ export default class OrganizationInformationSectionEditionMode extends Component
               @errorMessage={{this.validator.errors.dataProtectionOfficerEmail}}
               @validationStatus={{if this.validator.errors.dataProtectionOfficerEmail "error"}}
               @value={{this.form.dataProtectionOfficerEmail}}
+              @isFullWidth={{true}}
               {{on "input" (fn this.updateFormValue "dataProtectionOfficerEmail")}}
             ><:label>{{t "components.organizations.information-section-view.dpo-email"}}</:label></PixInput>
           </div>

--- a/admin/app/components/organizations/places-lot-creation-form.gjs
+++ b/admin/app/components/organizations/places-lot-creation-form.gjs
@@ -77,7 +77,7 @@ export default class PlacesLotCreationForm extends Component {
     <section class="page-section">
       <div class="places__add-form">
         <form class="form" {{on "submit" this.onSubmit}}>
-          <span class="form__instructions">
+          <span class="admin-form__mandatory-text">
             {{t "common.forms.mandatory-fields" htmlSafe=true}}
           </span>
           <div class="form-field">

--- a/admin/app/styles/authenticated/organizations/get.scss
+++ b/admin/app/styles/authenticated/organizations/get.scss
@@ -83,10 +83,6 @@
 
     .organization__edit-form {
       width: 500px;
-
-      & .pix-input {
-        width: 100%;
-      }
     }
   }
 

--- a/admin/app/styles/globals/form.scss
+++ b/admin/app/styles/globals/form.scss
@@ -148,7 +148,3 @@
   gap: var(--pix-spacing-4x);
   margin-top: var(--pix-spacing-6x);
 }
-
-.admin-form__select {
-  width: 100%;
-}


### PR DESCRIPTION
## 🥀 Problème

On a récemment ajouté un attribut isFullWidth dans PixUI aux composants PixInput et PixSelect, mais on ne l'utilise pas encore dans les apps.

## 🏹 Proposition

Utiliser cet attribut pour notamment ne plus aller sélectionner l'input par sa classe `pix-input` ou `pix-select` (qui sont des classes PIX-UI et qui pourraient changer de nom). On se limite au scope Acquisition et aux endroits où une refonte Design a été effectuée: page de création d'orga et page d'édition.

## 💌 Remarques

On propose aussi dans le deuxième commit d'utiliser la nouvelle classe pour l'instruction du formulaire sur le formulaire d'ajouts de places (se référer au TODO ligne 9 dans `admin/app/styles/globals/form.scss`).

## ❤️‍🔥 Pour tester

Sur Pix Admin, sur les pages de création et de modification d'organisation, constater que le style n'a pas bougé (comparer avec l'intégration)
