### PR TITLE
[TECH] :recycle: Remplace l'utilisation de la fonction `cloneDeep` de la librairie ` lodash`

### DIFF
--- a/api/src/certification/enrolment/infrastructure/utils/ods/write-ods-utils.js
+++ b/api/src/certification/enrolment/infrastructure/utils/ods/write-ods-utils.js
@@ -17,7 +17,7 @@ class OdsUtilsBuilder {
   }
 
   withData(dataToInject, templateValues) {
-    const intermediateXmlDom = _.cloneDeep(this.xmlDom);
+    const intermediateXmlDom = structuredClone(this.xmlDom);
     for (const { placeholder, propertyName } of templateValues) {
       const targetXmlDomElement = _getXmlDomElementByText(intermediateXmlDom, placeholder);
       if (targetXmlDomElement) {
@@ -32,7 +32,7 @@ class OdsUtilsBuilder {
   }
 
   headersTranslation({ headersValues, translate }) {
-    const intermediateXmlDom = _.cloneDeep(this.xmlDom);
+    const intermediateXmlDom = structuredClone(this.xmlDom);
     for (const propertyName of headersValues) {
       const targetXmlDomElement = _getXmlDomElementByText(intermediateXmlDom, propertyName);
       if (targetXmlDomElement) {
@@ -481,7 +481,7 @@ function updateXmlSparseValues({ stringifiedXml, templateValues, dataToInject })
 }
 
 function _updateXmlDomWithData(parsedXmlDom, dataToInject, templateValues) {
-  const parsedXmlDomUpdated = _.cloneDeep(parsedXmlDom);
+  const parsedXmlDomUpdated = structuredClone(parsedXmlDom);
   for (const { placeholder, propertyName } of templateValues) {
     const targetXmlDomElement = _getXmlDomElementByText(parsedXmlDomUpdated, placeholder);
     if (targetXmlDomElement) {

--- a/api/src/certification/session-management/domain/read-models/CertificationDetails.js
+++ b/api/src/certification/session-management/domain/read-models/CertificationDetails.js
@@ -60,8 +60,8 @@ class CertificationDetails {
       status: this.status,
       totalScore: this.totalScore,
       percentageCorrectAnswers: this.percentageCorrectAnswers,
-      competencesWithMark: _.cloneDeep(this.competencesWithMark),
-      listChallengesAndAnswers: _.cloneDeep(this.listChallengesAndAnswers),
+      competencesWithMark: structuredClone(this.competencesWithMark),
+      listChallengesAndAnswers: structuredClone(this.listChallengesAndAnswers),
     };
   }
 }

--- a/api/src/certification/session-management/infrastructure/serializers/session-for-supervising-serializer.js
+++ b/api/src/certification/session-management/infrastructure/serializers/session-for-supervising-serializer.js
@@ -1,12 +1,11 @@
 import jsonapiSerializer from 'jsonapi-serializer';
-import _ from 'lodash';
 
 const { Serializer } = jsonapiSerializer;
 
 const serialize = function (sessions) {
   return new Serializer('sessionForSupervising', {
     transform(currentSessionForSupervising) {
-      const cloneSession = _.cloneDeep(currentSessionForSupervising);
+      const cloneSession = structuredClone(currentSessionForSupervising);
 
       cloneSession.certificationCandidates.forEach((candidate) => {
         candidate.enrolledComplementaryCertificationLabel = candidate.enrolledComplementaryCertification?.label ?? null;

--- a/api/src/certification/session-management/infrastructure/serializers/session-for-supervising-serializer.js
+++ b/api/src/certification/session-management/infrastructure/serializers/session-for-supervising-serializer.js
@@ -5,14 +5,12 @@ const { Serializer } = jsonapiSerializer;
 const serialize = function (sessions) {
   return new Serializer('sessionForSupervising', {
     transform(currentSessionForSupervising) {
-      const cloneSession = structuredClone(currentSessionForSupervising);
-
-      cloneSession.certificationCandidates.forEach((candidate) => {
+      currentSessionForSupervising.certificationCandidates.forEach((candidate) => {
         candidate.enrolledComplementaryCertificationLabel = candidate.enrolledComplementaryCertification?.label ?? null;
         candidate.enrolledDoubleCertificationLabel = candidate.enrolledDoubleCertification?.label ?? null;
       });
 
-      return cloneSession;
+      return currentSessionForSupervising;
     },
     attributes: ['room', 'examiner', 'accessCode', 'date', 'time', 'certificationCandidates', 'address'],
     typeForAttribute: (attribute) =>

--- a/api/tests/certification/enrolment/integration/infrastructure/ods/write-ods-utils_test.js
+++ b/api/tests/certification/enrolment/integration/infrastructure/ods/write-ods-utils_test.js
@@ -1,9 +1,4 @@
 import fs from 'node:fs';
-
-const { promises } = fs;
-
-const { writeFile, unlink } = promises;
-
 import * as url from 'node:url';
 
 import { AddedCellOption } from '../../../../../../src/certification/enrolment/infrastructure/utils/ods/added-cell-option.js';
@@ -15,9 +10,13 @@ import {
   incrementRowsColumnSpan,
   makeUpdatedOdsByContentXml,
   updateXmlRows,
-  updateXmlSparseValues,
 } from '../../../../../../src/certification/enrolment/infrastructure/utils/ods/write-ods-utils.js';
 import { expect } from '../../../../../test-helper.js';
+
+const { promises } = fs;
+
+const { writeFile, unlink } = promises;
+
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
 
 describe('Integration | Shared | Infrastructure | Utils | Ods | write-ods-utils', function () {
@@ -45,60 +44,6 @@ describe('Integration | Shared | Infrastructure | Utils | Ods | write-ods-utils'
 
     afterEach(async function () {
       await unlink(updatedOdsFilePath);
-    });
-  });
-
-  describe('#updateXmlSparseValues', function () {
-    const templateValues = [
-      {
-        placeholder: 'PLACEHOLDER_1',
-        propertyName: 'name',
-      },
-      {
-        placeholder: 'PLACEHOLDER_2',
-        propertyName: 'age',
-      },
-    ];
-
-    const dataToInject = {
-      name: 'Dummy name',
-      age: 'Dummy age',
-    };
-
-    const stringifiedXml =
-      '<xml xmlns:some="some namespace" xmlns:text="text namespace">' +
-      '<some:element>' +
-      '<text:p>PLACEHOLDER_1</text:p>' +
-      '<text:p>Some value</text:p>' +
-      '<some:block>' +
-      '<text:p>PLACEHOLDER_2</text:p>' +
-      '</some:block>' +
-      '</some:element>' +
-      '<text:p>Some other value</text:p>' +
-      '</xml>';
-
-    const updatedStringifiedXml =
-      '<xml xmlns:some="some namespace" xmlns:text="text namespace">' +
-      '<some:element>' +
-      '<text:p>Dummy name</text:p>' +
-      '<text:p>Some value</text:p>' +
-      '<some:block>' +
-      '<text:p>Dummy age</text:p>' +
-      '</some:block>' +
-      '</some:element>' +
-      '<text:p>Some other value</text:p>' +
-      '</xml>';
-
-    it('should transform an xml by replacing templatized cells and data to inject', function () {
-      // when
-      const result = updateXmlSparseValues({
-        stringifiedXml,
-        templateValues,
-        dataToInject,
-      });
-
-      // then
-      expect(result).to.deep.equal(updatedStringifiedXml);
     });
   });
 

--- a/api/tests/certification/evaluation/unit/domain/services/scoring/scoring-v2_test.js
+++ b/api/tests/certification/evaluation/unit/domain/services/scoring/scoring-v2_test.js
@@ -1345,12 +1345,9 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V2', f
       });
 
       context('when reproducibility rate is between 50% and 80%', function () {
-        beforeEach(function () {
-          certificationAssessment.certificationAnswersByDate = answersWithReproducibilityRateLessThan80();
-        });
-
         it('should return list of competences with certifiedLevel less or equal to estimatedLevel', async function () {
           // given
+          certificationAssessment.certificationAnswersByDate = await answersWithReproducibilityRateLessThan80();
           const malusForFalseAnswer = 8;
           const expectedCertifiedCompetences = [
             domainBuilder.buildCompetenceMark({
@@ -1386,7 +1383,10 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V2', f
 
         it('should return the percentage of correct answers', async function () {
           // given
-          const certificationAssessmentWithNeutralizedChallenge = _.cloneDeep(certificationAssessment);
+          const certificationAssessmentWithNeutralizedChallenge = structuredClone(certificationAssessment);
+          certificationAssessmentWithNeutralizedChallenge.certificationAnswersByDate =
+            answersWithReproducibilityRateLessThan80();
+          certificationAssessmentWithNeutralizedChallenge.certificationChallenges[0].isNeutralized = true;
           certificationAssessmentWithNeutralizedChallenge.certificationChallenges[0].isNeutralized = true;
 
           // when
@@ -1407,6 +1407,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V2', f
 
           context('with one OK, one KO and one QROCM-dep OK', function () {
             it('should return level obtained equal to level positioned minus one', async function () {
+              certificationAssessment.certificationAnswersByDate = await answersWithReproducibilityRateLessThan80();
               // Given
               const positionedLevel = 2;
               const positionedScore = 20;
@@ -1939,7 +1940,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V2', f
       context('when certification has enough non neutralized challenges to be trusted', function () {
         it('should return a CertificationAssessmentScore which hasEnoughNonNeutralizedChallengesToBeTrusted is true', async function () {
           // given
-          const certificationAssessmentWithNeutralizedChallenge = _.cloneDeep(certificationAssessment);
+          const certificationAssessmentWithNeutralizedChallenge = certificationAssessment;
           certificationAssessmentWithNeutralizedChallenge.certificationChallenges[0].isNeutralized = true;
           certificationAssessmentWithNeutralizedChallenge.certificationChallenges[1].isNeutralized = true;
           certificationAssessmentWithNeutralizedChallenge.certificationChallenges[2].isNeutralized = true;
@@ -1962,7 +1963,8 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V2', f
       context('when certification has not enough non neutralized challenges to be trusted', function () {
         it('should return a CertificationAssessmentScore which hasEnoughNonNeutralizedChallengesToBeTrusted is false', async function () {
           // given
-          const certificationAssessmentWithNeutralizedChallenge = _.cloneDeep(certificationAssessment);
+
+          const certificationAssessmentWithNeutralizedChallenge = certificationAssessment;
           certificationAssessmentWithNeutralizedChallenge.certificationChallenges[0].isNeutralized = true;
           certificationAssessmentWithNeutralizedChallenge.certificationChallenges[1].isNeutralized = true;
           certificationAssessmentWithNeutralizedChallenge.certificationChallenges[2].isNeutralized = true;

--- a/api/tests/evaluation/acceptance/application/feedbacks/feedback-controller_test.js
+++ b/api/tests/evaluation/acceptance/application/feedbacks/feedback-controller_test.js
@@ -1,9 +1,5 @@
-import lodash from 'lodash';
-
 import { createServer, databaseBuilder, expect, knex } from '../../../../test-helper.js';
 import { domainBuilder } from '../../../../tooling/domain-builder/domain-builder.js';
-
-const { cloneDeep } = lodash;
 
 describe('Acceptance | Controller | feedback-controller', function () {
   let server;
@@ -64,7 +60,7 @@ describe('Acceptance | Controller | feedback-controller', function () {
 
     it('should return 201 HTTP status code with empty content', function () {
       // when
-      const optionsWithEmptyContent = cloneDeep(options);
+      const optionsWithEmptyContent = structuredClone(options);
       optionsWithEmptyContent.payload.data.attributes.content = '';
       const promise = server.inject(options);
 

--- a/api/tests/evaluation/integration/application/badges/index_test.js
+++ b/api/tests/evaluation/integration/application/badges/index_test.js
@@ -98,7 +98,7 @@ describe('Integration | Application | Badges | Routes', function () {
           await httpTestServer.register(badgesRouter);
 
           // when
-          const payloadCopy = _.cloneDeep(payload);
+          const payloadCopy = structuredClone(payload);
           payloadCopy.data.attributes['capped-tubes-criteria'] = [
             {
               cappedTubes: [
@@ -126,7 +126,7 @@ describe('Integration | Application | Badges | Routes', function () {
           await httpTestServer.register(badgesRouter);
 
           // when
-          const payloadCopy = _.cloneDeep(payload);
+          const payloadCopy = structuredClone(payload);
           payloadCopy.data.attributes['capped-tubes-criteria'] = [
             {
               threshold: '20',

--- a/api/tests/evaluation/unit/domain/services/smart-random/smart-random_test.js
+++ b/api/tests/evaluation/unit/domain/services/smart-random/smart-random_test.js
@@ -1,5 +1,3 @@
-import _ from 'lodash';
-
 import * as SmartRandom from '../../../../../../src/evaluation/domain/services/algorithm-methods/smart-random.js';
 import { AnswerStatus } from '../../../../../../src/shared/domain/models/AnswerStatus.js';
 import { domainBuilder, expect } from '../../../../../test-helper.js';
@@ -8,17 +6,6 @@ const KNOWLEDGE_ELEMENT_STATUS = {
   VALIDATED: 'validated',
   INVALIDATED: 'invalidated',
 };
-
-const ONE_MINUTE = 60;
-
-function turnIntoTimedChallenge(challenge) {
-  return _.assign(structuredClone(challenge), { timer: ONE_MINUTE });
-}
-
-function duplicateChallengeOfSameDifficulty(challenge) {
-  const challengeId = parseInt(challenge.id[0]) + 1;
-  return _.assign(structuredClone(challenge), { id: 'rec' + challengeId });
-}
 
 describe('Integration | Domain | Algorithm-methods | SmartRandom', function () {
   let challenges,
@@ -143,9 +130,13 @@ describe('Integration | Domain | Algorithm-methods | SmartRandom', function () {
         // given
         lastAnswer = domainBuilder.buildAnswer({ timeout: 50 });
         targetSkills = [url2, web1];
-        const challenge_defaultLevel_Timed = turnIntoTimedChallenge(challengeUrl_2);
-        const challenge_notDefaultLevel_Untimed = _.assign(structuredClone(challengeWeb_1));
-        challenges = [challenge_defaultLevel_Timed, challenge_notDefaultLevel_Untimed];
+        const challenge_defaultLevel_Timed = domainBuilder.buildChallenge({
+          id: 'recurl2',
+          skill: url2,
+          locales: ['fr'],
+          timer: 60,
+        });
+        challenges = [challenge_defaultLevel_Timed, challengeWeb_1];
 
         // when
         const { possibleSkillsForNextChallenge } = SmartRandom.getPossibleSkillsForNextChallenge({
@@ -214,7 +205,12 @@ describe('Integration | Domain | Algorithm-methods | SmartRandom', function () {
       it('should start with a timed challenge anyway when no untimed challenges were found', function () {
         // given
         targetSkills = [web3];
-        const challenge_AnyLevel_Timed = turnIntoTimedChallenge(challengeWeb_3);
+        const challenge_AnyLevel_Timed = domainBuilder.buildChallenge({
+          id: 'recweb3',
+          skill: web3,
+          locales: ['fr'],
+          timer: 60,
+        });
         challenges = [challenge_AnyLevel_Timed];
 
         // when
@@ -527,7 +523,12 @@ describe('Integration | Domain | Algorithm-methods | SmartRandom', function () {
       it('should end the test if the next challenges wont provide any additional knowledge on the user', function () {
         // given
         targetSkills = [web1, web2];
-        challenges = [challengeWeb_1, challengeWeb_2, duplicateChallengeOfSameDifficulty(challengeWeb_2)];
+        const challengeWeb_2_duplicate = domainBuilder.buildChallenge({
+          id: 'recweb2_duplicate',
+          skill: web2,
+          locales: ['fr'],
+        });
+        challenges = [challengeWeb_1, challengeWeb_2, challengeWeb_2_duplicate];
         lastAnswer = domainBuilder.buildAnswer({ challengeId: challengeWeb_2.id, result: AnswerStatus.OK });
         allAnswers = [lastAnswer];
         knowledgeElements = [

--- a/api/tests/evaluation/unit/domain/services/smart-random/smart-random_test.js
+++ b/api/tests/evaluation/unit/domain/services/smart-random/smart-random_test.js
@@ -12,12 +12,12 @@ const KNOWLEDGE_ELEMENT_STATUS = {
 const ONE_MINUTE = 60;
 
 function turnIntoTimedChallenge(challenge) {
-  return _.assign(_.cloneDeep(challenge), { timer: ONE_MINUTE });
+  return _.assign(structuredClone(challenge), { timer: ONE_MINUTE });
 }
 
 function duplicateChallengeOfSameDifficulty(challenge) {
   const challengeId = parseInt(challenge.id[0]) + 1;
-  return _.assign(_.cloneDeep(challenge), { id: 'rec' + challengeId });
+  return _.assign(structuredClone(challenge), { id: 'rec' + challengeId });
 }
 
 describe('Integration | Domain | Algorithm-methods | SmartRandom', function () {
@@ -144,7 +144,7 @@ describe('Integration | Domain | Algorithm-methods | SmartRandom', function () {
         lastAnswer = domainBuilder.buildAnswer({ timeout: 50 });
         targetSkills = [url2, web1];
         const challenge_defaultLevel_Timed = turnIntoTimedChallenge(challengeUrl_2);
-        const challenge_notDefaultLevel_Untimed = _.assign(_.cloneDeep(challengeWeb_1));
+        const challenge_notDefaultLevel_Untimed = _.assign(structuredClone(challengeWeb_1));
         challenges = [challenge_defaultLevel_Timed, challenge_notDefaultLevel_Untimed];
 
         // when


### PR DESCRIPTION
## 🥀 Problème

Nous avons une forme de dépendance à la librairie Lodash alors que pour certaines opérations, nous pourrions  le faire en utilisant  JavaScript natif.

## 🏹 Proposition

Remplacer l'utilisation de la fonction `cloneDeep`  de `Lodash` par `structuredClone` de  JavaScript

## 💌 Remarques

https://developer.mozilla.org/en-US/docs/Web/API/Window/structuredClone
https://github.com/you-dont-need/You-Dont-Need-Lodash-Underscore?tab=readme-ov-file#_clonedeep

## ❤️‍🔥 Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
