### PR TITLE
[BUGFIX] Corriger l'alignement du texte de la consigne sur un QCM (PIX-21401).

### DIFF
--- a/junior/app/styles/app.scss
+++ b/junior/app/styles/app.scss
@@ -43,7 +43,6 @@ body {
   color: var(--pix-neutral-900);
   font-weight: 600;
   font-family: $font-nunito;
-  text-align: center;
   background: rgb(236 242 251 / 20%);
 }
 

--- a/junior/app/styles/pages/school.scss
+++ b/junior/app/styles/pages/school.scss
@@ -40,6 +40,7 @@
     height: 190px;
     margin: 12px;
     color: var(--pix-neutral-900);
+    text-align: center;
     background-color: var(--pix-neutral-0);
     background-image: url('/images/division.svg');
     background-repeat: no-repeat;


### PR DESCRIPTION
## 🥀 Problème

L'alignement du texte de consigne est centré alors qu'il devrait être aligné à gauche.

<img width="1219" height="459" alt="image" src="https://github.com/user-attachments/assets/9efa483a-c21a-43cf-898e-c6167b3a28b9" />


## 🏹 Proposition

Retirer la règle css de la balise body.


## 💌 Remarques

Une régression à été corrigé pour la page divisions. 

## ❤️‍🔥 Pour tester

Se connecter sur l'app junior.
code école: `MINIPIXOU`
aller sur la route : `/challenges/Challenge2x44XNGGjUbyD0/preview`

Observer que l'alignement de la consigne est bien  à gauche