### PR TITLE
[BUGFIX] Ignorer l'erreur lors d'un conflit d'unicité pendant de la création d'un membership (PIX-21467).

### DIFF
--- a/api/src/team/infrastructure/repositories/organization-invited-user.repository.js
+++ b/api/src/team/infrastructure/repositories/organization-invited-user.repository.js
@@ -51,7 +51,9 @@ const save = async function ({ organizationInvitedUser }) {
         organizationId: organizationInvitedUser.invitation.organizationId,
         userId: organizationInvitedUser.userId,
       })
-      .returning('id');
+      .returning('id')
+      .onConflict(['organizationId', 'userId'])
+      .ignore();
 
     organizationInvitedUser.currentMembershipId = membershipId;
   }


### PR DESCRIPTION
## 🥀 Problème
Des erreurs 500 ont été constatés sur la route /api/organization-invitations/{id}/response. Ces erreurs 500 semblent provenir de conflits liés à des contraintes d'unicité entre userId et organizationId lors de l'acceptation d'une invitation.

## 🏹 Proposition
Ignorer l'erreur lancée par un conflit d'unicité du couple organizationId/userId utilisé pour un membershipId. En cas d'erreur, le membership ne sera pas créé.

## 💌 Remarques
Pas réussi à reproduire en local

## ❤️‍🔥 Pour tester
- ?
