### PR TITLE
[TECH] Pousser l'erreur dans un objet pour être identifier dans le logger.

### DIFF
--- a/api/scripts/prod/delete-and-anonymise-previous-participations.js
+++ b/api/scripts/prod/delete-and-anonymise-previous-participations.js
@@ -97,8 +97,8 @@ export class DeleteAndAnonymisePreviousCampaignParticipationsScript extends Scri
       } catch (error) {
         await knexConn.rollback();
         logger.error(
+          { error },
           `ERROR: anonymise deleted participations... not related to archived organization before  or deleted learner`,
-          error,
         );
         throw error;
       }


### PR DESCRIPTION
## 🥀 Problème

Lors de l'execution du script, une erreur est retourné mais rien n'est montré dans les logs du à un mésusage du logger

## 🏹 Proposition

Utiliser le logger correctement afin de mettre l'objet en erreur en premier parametre

## 💌 Remarques

RAS