### PR TITLE
[BUGFIX] Désactive le calcul de `isPartOfCombinedCourse`qui prend beaucoup de ressources.

### DIFF
--- a/api/src/prescription/target-profile/infrastructure/repositories/target-profile-summary-for-admin-repository.js
+++ b/api/src/prescription/target-profile/infrastructure/repositories/target-profile-summary-for-admin-repository.js
@@ -1,4 +1,3 @@
-import * as CombinedCourseRepository from '../../../../quest/infrastructure/repositories/combined-course-repository.js';
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { fetchPage } from '../../../../shared/infrastructure/utils/knex-utils.js';
 import { TargetProfileSummaryForAdmin } from '../../domain/models/TargetProfileSummaryForAdmin.js';
@@ -32,38 +31,13 @@ const findByTraining = async function ({ trainingId }) {
     .where({ trainingId })
     .orderBy('id', 'ASC');
 
-  const targetProfileIds = results.map((result) => result.id);
-  const campaignsByTargetProfile = await knexConn('campaigns')
-    .select('id', 'targetProfileId')
-    .whereIn('targetProfileId', targetProfileIds);
-
-  const campaignsMap = {};
-
-  for (const campaign of campaignsByTargetProfile) {
-    if (!campaignsMap[campaign.targetProfileId]) {
-      campaignsMap[campaign.targetProfileId] = [];
-    }
-    campaignsMap[campaign.targetProfileId].push(campaign.id);
-  }
-
-  const targetProfileSummaries = [];
-
-  for (const result of results) {
-    const relatedCampaignIds = campaignsMap[result.id] || [];
-    let isPartOfCombinedCourse = false;
-    for (const relatedCampaignId of relatedCampaignIds) {
-      const combinedCourse = await CombinedCourseRepository.findByCampaignId({ campaignId: relatedCampaignId });
-      isPartOfCombinedCourse = combinedCourse.length === 1;
-    }
-    targetProfileSummaries.push(
-      new TargetProfileSummaryForAdmin({
-        ...result,
-        isPartOfCombinedCourse,
-      }),
-    );
-  }
-
-  return targetProfileSummaries;
+  // FIXME: computing `isPartOfCombinedCourse` is quite heavy by now, we temporary set it  to false for every TargetProfileSummaryForAdmin
+  return results.map((result) => {
+    return new TargetProfileSummaryForAdmin({
+      ...result,
+      isPartOfCombinedCourse: false,
+    });
+  });
 };
 
 export { findByTraining, findPaginatedFiltered };

--- a/api/tests/prescription/target-profile/integration/infrastructure/repositories/target-profile-summary-for-admin-repository_test.js
+++ b/api/tests/prescription/target-profile/integration/infrastructure/repositories/target-profile-summary-for-admin-repository_test.js
@@ -350,7 +350,9 @@ describe('Integration | Repository | Target-profile-summary-for-admin', function
       expect(targetProfileSummaries).to.be.empty;
     });
 
-    it('should return a targetProfileSummary instance with correct attribute when target profile is used in a combined course', async function () {
+    // FIXME: computing `isPartOfCombinedCourse` is quite heavy by now, we temporary set it  to false for every TargetProfileSummaryForAdmin
+    // eslint-disable-next-line mocha/no-pending-tests
+    it.skip('should return a targetProfileSummary instance with correct attribute when target profile is used in a combined course', async function () {
       // given
       const training = databaseBuilder.factory.buildTraining();
 


### PR DESCRIPTION
## 🥀 Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

Suite à la PR https://github.com/1024pix/pix/pull/14357 et au grand nombre de Parcours Combinés créés récemment, on constate que le calcul de `isPartOfCombinedCourse` prend beaucoup de ressources, ce qui empêche d'afficher les Profils Cibles sur Pix Admin en production.

## 🏹 Proposition

On désactive temporairement le calcul, le temps de l'optimiser.

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 💌 Remarques

Cela a pour conséquence de ne plus afficher la modale de confirmation de détacher d'un profil cible qui est contenu dans un parcours combiné.

<!-- Des infos supplémentaires, trucs et astuces ? -->

## ❤️‍🔥 Pour tester

Afficher la liste des profils cibles depuis Pix Admin.
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
