### PR TITLE
[FEATURE] Les textes à trous configurées en inline appliquent le paramètre aux balises autour (PIX-21476).

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
@@ -84,7 +84,7 @@
                       "proposals": [
                         {
                           "type": "text",
-                          "content": "<span>Pix est un</span>"
+                          "content": "<h1>Pix est un</h1>"
                         },
                         {
                           "input": "pix-name",
@@ -99,7 +99,7 @@
                         },
                         {
                           "type": "text",
-                          "content": "<span>d'intérêt public qui a été créée en</span>"
+                          "content": "<p>d'intérêt public qui a été créée en</p>"
                         },
                         {
                           "input": "pix-birth",

--- a/mon-pix/app/components/module/element/_qrocm.scss
+++ b/mon-pix/app/components/module/element/_qrocm.scss
@@ -29,9 +29,9 @@
       display: block;
       width: fit-content;
     }
-
-    &--inline {
-      display: inline-block;
-    }
   }
+}
+
+.element-qrocm__proposals > *:not(.element-qrocm-proposals__input--block, span) {
+  display: inline-block;
 }

--- a/mon-pix/app/components/module/element/qrocm.gjs
+++ b/mon-pix/app/components/module/element/qrocm.gjs
@@ -190,33 +190,18 @@ export default class ModuleQrocm extends ModuleElement {
             {{/if}}
             {{#if (eq block.type "input")}}
               <div class="element-qrocm-proposals__input element-qrocm-proposals__input--{{block.display}}">
-                {{#if (eq block.inputType "text")}}
-                  <PixInput
-                    @type="text"
-                    @value={{get this.selectedValues block.input}}
-                    @id={{block.input}}
-                    placeholder={{block.placeholder}}
-                    @screenReaderOnly={{true}}
-                    {{on "change" (fn this.onInputChanged block)}}
-                    size={{block.size}}
-                    readonly={{this.disableInput}}
-                  >
-                    <:label>{{block.ariaLabel}}</:label>
-                  </PixInput>
-                {{else if (eq block.inputType "number")}}
-                  <PixInput
-                    type="number"
-                    @value={{get this.selectedValues block.input}}
-                    @id={{block.input}}
-                    placeholder={{block.placeholder}}
-                    @screenReaderOnly={{true}}
-                    {{on "change" (fn this.onInputChanged block)}}
-                    size={{block.size}}
-                    readonly={{this.disableInput}}
-                  >
-                    <:label>{{block.ariaLabel}}</:label>
-                  </PixInput>
-                {{/if}}
+                <PixInput
+                  type={{block.inputType}}
+                  @value={{get this.selectedValues block.input}}
+                  @id={{block.input}}
+                  placeholder={{block.placeholder}}
+                  @screenReaderOnly={{true}}
+                  {{on "change" (fn this.onInputChanged block)}}
+                  size={{block.size}}
+                  readonly={{this.disableInput}}
+                >
+                  <:label>{{block.ariaLabel}}</:label>
+                </PixInput>
               </div>
             {{else if (eq block.type "select")}}
               <div class="element-qrocm-proposals__input element-qrocm-proposals__input--{{block.display}}">

--- a/mon-pix/app/components/module/element/qrocm.gjs
+++ b/mon-pix/app/components/module/element/qrocm.gjs
@@ -189,7 +189,10 @@ export default class ModuleQrocm extends ModuleElement {
               {{htmlUnsafe block.content}}
             {{/if}}
             {{#if (eq block.type "input")}}
-              <div class="element-qrocm-proposals__input element-qrocm-proposals__input--{{block.display}}">
+              <div
+                class="element-qrocm-proposals__input
+                  {{if (eq block.display 'block') 'element-qrocm-proposals__input--block'}}"
+              >
                 <PixInput
                   type={{block.inputType}}
                   @value={{get this.selectedValues block.input}}
@@ -204,7 +207,10 @@ export default class ModuleQrocm extends ModuleElement {
                 </PixInput>
               </div>
             {{else if (eq block.type "select")}}
-              <div class="element-qrocm-proposals__input element-qrocm-proposals__input--{{block.display}}">
+              <div
+                class="element-qrocm-proposals__input
+                  {{if (eq block.display 'block') 'element-qrocm-proposals__input--block'}}"
+              >
                 <PixSelect
                   @value={{get this.selectedValues block.input}}
                   @placeholder={{block.placeholder}}

--- a/mon-pix/tests/integration/components/module/qrocm_test.gjs
+++ b/mon-pix/tests/integration/components/module/qrocm_test.gjs
@@ -133,9 +133,9 @@ module('Integration | Component | Module | QROCM', function (hooks) {
       }),
     );
     assert.dom(screen.getByText('Ma première proposition')).exists({ count: 1 });
-    assert.ok(screen.queryByRole('spinbutton', { name: 'input-aria' }));
-    assert.ok(screen.queryByText("l'identifiant"));
-    assert.dom('.element-qrocm-proposals__input--inline').exists({ count: 2 });
+    assert.ok(screen.getByRole('spinbutton', { name: 'input-aria' }));
+    assert.ok(screen.getByText("l'identifiant"));
+    assert.dom('.element-qrocm-proposals__input--block').doesNotExist();
   });
 
   test('should be able to select an option', async function (assert) {


### PR DESCRIPTION
## 🥀 Problème

Les textes à trous dans les modules (qrocm) possèdent un paramètre `display:inline` permettant de tenir sur une ligne.
Ce paramètre ne s'applique que sur le champ `input` et pas sur le reste.

Si le texte, suivant ou précédent un champ en `display:inline`, possède une balise de type `block` (comme le p, les headings... [liste ici](http://web.simmons.edu/~grovesd/comm244/notes/week4/block-inline)) alors le texte à trous en ligne ne s'applique pas.

## 🏹 Proposition

Dans le component QROCM, si la classe inline du champ s'applique, faire en sorte que les balises html proches appliquent aussi un `display:inline`.

Le [:has()](https://developer.mozilla.org/fr/docs/Web/CSS/Reference/Selectors/:has) on oublie, on part sur un traitement du parent qui va appliquer display inline partout sauf (avec usage du :not()) les inputs portant la classe du block et les span.

Le `*` permet de ne pas avoir à spécifier une balise HTML en particulier. Comme on a pas la main dessus, et que le métier peut aussi bien mettre un `<p>`, un `<h1>` ou une liste `<ol>`.

## 💌 Remarques

Nous avions au début appliqué une modification coté modulix Editor pour supprimer les balises `p` qui s'ajoutaient automatiquement et qui n'était pas systématiquement souhaité par le métier.
Mais des effets secondaires nous oblige à revert cette modification.

## ❤️‍🔥 Pour tester

https://app-pr15089.review.pix.fr/modules/preview/bac-a-sable

Dans bac-a-sable, j'ai volontairement mis un `h1 `et un `p` dans les textes précédant et suivant les champs.
Vérifier que le inline s'applique bien.

Vérifier que les autres textes à trous se comportent bien

- https://app-pr15089.review.pix.fr/modules/preview/centre-de-donnee-novice
- https://app-pr15089.review.pix.fr/modules/preview/anatomie-message-arnaque
- https://app-pr15089.review.pix.fr/modules/preview/evaluation-impacts-environnementaux-numerique
- https://app-pr15089.review.pix.fr/modules/preview/tri-multicritere-tableau
- https://app-pr15089.review.pix.fr/modules/preview/ia-def-ind 