### PR TITLE
[FEATURE] Alerter l'utilisateur qui supprime un profil cible attaché à un parcours combiné (PIX-21472).

### DIFF
--- a/api/src/quest/infrastructure/repositories/combined-course-repository.js
+++ b/api/src/quest/infrastructure/repositories/combined-course-repository.js
@@ -71,6 +71,20 @@ const findByCampaignId = async ({ campaignId }) => {
   return combinedCourses.map(_toDomain);
 };
 
+const targetProfileIdsPartOfAnyCombinedCourse = async ({ targetProfileIds }) => {
+  const knexConn = DomainTransaction.getConnection();
+  return knexConn('campaigns')
+    .select('campaigns.targetProfileId')
+    .whereIn('campaigns.targetProfileId', targetProfileIds)
+    .whereIn(
+      'campaigns.id',
+      knexConn('quests').select(
+        knexConn.raw('jsonb_path_query("successRequirements", \'$.data.campaignId.data\')::integer'),
+      ),
+    )
+    .pluck('campaigns.targetProfileId');
+};
+
 const saveInBatch = async ({ combinedCourses, questRepository }) => {
   const knexConn = DomainTransaction.getConnection();
   const combinedCoursesToSave = combinedCourses.map(_toDTO);
@@ -154,4 +168,5 @@ export {
   getById,
   save,
   saveInBatch,
+  targetProfileIdsPartOfAnyCombinedCourse,
 };

--- a/api/tests/prescription/target-profile/integration/infrastructure/repositories/target-profile-summary-for-admin-repository_test.js
+++ b/api/tests/prescription/target-profile/integration/infrastructure/repositories/target-profile-summary-for-admin-repository_test.js
@@ -350,9 +350,7 @@ describe('Integration | Repository | Target-profile-summary-for-admin', function
       expect(targetProfileSummaries).to.be.empty;
     });
 
-    // FIXME: computing `isPartOfCombinedCourse` is quite heavy by now, we temporary set it  to false for every TargetProfileSummaryForAdmin
-    // eslint-disable-next-line mocha/no-pending-tests
-    it.skip('should return a targetProfileSummary instance with correct attribute when target profile is used in a combined course', async function () {
+    it('should return a targetProfileSummary instance with correct attribute when target profile is used in a combined course', async function () {
       // given
       const training = databaseBuilder.factory.buildTraining();
 

--- a/api/tests/quest/integration/infrastructure/repositories/combined-course-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/combined-course-repository_test.js
@@ -198,6 +198,64 @@ describe('Quest | Integration | Repository | combined-course', function () {
     });
   });
 
+  describe('targetProfileIdsPartOfAnyCombinedCourse', function () {
+    it('should return an array containing only targetProfileIds contained in a combinedCourse', async function () {
+      // given
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      const campaign = databaseBuilder.factory.buildCampaign({
+        organizationId,
+      });
+      const campaignIdNotInQuest = databaseBuilder.factory.buildCampaign({
+        organizationId,
+      });
+      databaseBuilder.factory.buildCombinedCourse({
+        code: 'ABCDE1234',
+        name: 'Mon parcours Combiné',
+        organizationId,
+        description: 'Le but de ma quête',
+        illustration: 'images/illustration.svg',
+        combinedCourseContents: [{ campaignId: campaign.id }],
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const targetProfileIdsPartOfAnyCombinedCourse =
+        await combinedCourseRepository.targetProfileIdsPartOfAnyCombinedCourse({
+          targetProfileIds: [campaignIdNotInQuest.targetProfileId, campaign.targetProfileId],
+        });
+
+      // then
+      expect(targetProfileIdsPartOfAnyCombinedCourse).deep.equal([campaign.targetProfileId]);
+    });
+
+    it('should return an empty array when target profiles are part of no combined courses', async function () {
+      // given
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      const code = 'ABCDE1234';
+      const name = 'Mon parcours Combiné';
+      const description = 'Le but de ma quête';
+      const illustration = 'images/illustration.svg';
+      databaseBuilder.factory.buildCombinedCourse({
+        code,
+        name,
+        organizationId,
+        description,
+        illustration,
+        combinedCourseContents: [],
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const targetProfileIdsPartOfAnyCombinedCourse =
+        await combinedCourseRepository.targetProfileIdsPartOfAnyCombinedCourse({
+          targetProfileIds: [123],
+        });
+
+      // then
+      expect(targetProfileIdsPartOfAnyCombinedCourse).deep.equal([]);
+    });
+  });
+
   describe('#saveInBatch', function () {
     it('should create quests related to given combined courses', async function () {
       // given


### PR DESCRIPTION
## 🥀 Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

Suite à des soucis de performances nous avons supprimé le calcul de `isPartOfCombinedCourse` permettant d'informer un utilisateur Pix Admin qui souhaite supprimer un profil cible que celui-ci est attaché à un parcours combiné.

(voir https://github.com/1024pix/pix/pull/15086)

## 🏹 Proposition

On a revu le besoin et simplifier la query SQL pour déterminer uniquement si un profil cible est attaché à un parcours combiné.

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 💌 Remarques

On a regardé le plan d'analyse et celui-ci est beaucoup plus simple.
Nous avons également joué la requête sur la production via Metabase pour 25000 profil cibles simultanés et celle-ci s'exécute en moins de 200ms ce qui paraît acceptable.

<!-- Des infos supplémentaires, trucs et astuces ? -->

## ❤️‍🔥 Pour tester

Se rendre sur Pix Admin et tenter de détacher un Profil Cible qui fait parti d'un Parcours Combiné.

<!--
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc.
- [ ] Documentation de la fonctionnalité (lien)
-->
