### PR TITLE
[FEATURE] Mise à jour du public prescrit d'une organisation (PIX-21314).

### DIFF
--- a/api/src/organizational-entities/application/http-error-mapper-configuration.js
+++ b/api/src/organizational-entities/application/http-error-mapper-configuration.js
@@ -9,6 +9,7 @@ import {
   FeatureNotFound,
   FeatureParamsNotProcessable,
   OrganizationBatchUpdateError,
+  OrganizationLearnerTypeNotFound,
   OrganizationNotFound,
   TagNotFoundError,
   UnableToAttachChildOrganizationToParentOrganizationError,
@@ -26,6 +27,10 @@ const organizationalEntitiesDomainErrorMappingConfiguration = [
   },
   {
     name: OrganizationNotFound.name,
+    httpErrorFn: (error) => new HttpErrors.UnprocessableEntityError(error.message, error.code, error.meta),
+  },
+  {
+    name: OrganizationLearnerTypeNotFound.name,
     httpErrorFn: (error) => new HttpErrors.UnprocessableEntityError(error.message, error.code, error.meta),
   },
   {

--- a/api/src/organizational-entities/application/organization/organization.admin.controller.js
+++ b/api/src/organizational-entities/application/organization/organization.admin.controller.js
@@ -1,4 +1,3 @@
-import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import * as csvSerializer from '../../../shared/infrastructure/serializers/csv/csv-serializer.js';
 import { generateCSVTemplate } from '../../../shared/infrastructure/serializers/csv/csv-template.js';
 import { extractUserIdFromRequest } from '../../../shared/infrastructure/utils/request-response-utils.js';
@@ -161,11 +160,8 @@ const updateOrganizationInformation = async function (
 ) {
   const organizationDeserialized = dependencies.organizationForAdminSerializer.deserialize(request.payload);
 
-  const organizationUpdated = await DomainTransaction.execute(function (domainTransaction) {
-    return usecases.updateOrganizationInformation({
-      organization: organizationDeserialized,
-      domainTransaction,
-    });
+  const organizationUpdated = await usecases.updateOrganizationInformation({
+    organization: organizationDeserialized,
   });
   return h.response(dependencies.organizationForAdminSerializer.serialize(organizationUpdated));
 };

--- a/api/src/organizational-entities/domain/errors.js
+++ b/api/src/organizational-entities/domain/errors.js
@@ -98,6 +98,18 @@ class FeatureParamsNotProcessable extends DomainError {
   }
 }
 
+class OrganizationLearnerTypeNotFound extends DomainError {
+  constructor({
+    code = 'ORGANIZATION_LEARNER_TYPE_NOT_FOUND',
+    message = 'Organization learner type does not exist',
+    meta,
+  } = {}) {
+    super(message);
+    this.code = code;
+    this.meta = meta;
+  }
+}
+
 class UnableToDetachParentOrganizationFromChildOrganization extends DomainError {
   constructor({
     code = 'UNABLE_TO_DETACH_PARENT_ORGANIZATION_FROM_CHILD_ORGANIZATION',
@@ -120,6 +132,7 @@ export {
   FeatureNotFound,
   FeatureParamsNotProcessable,
   OrganizationBatchUpdateError,
+  OrganizationLearnerTypeNotFound,
   OrganizationNotFound,
   TagNotFoundError,
   UnableToAttachChildOrganizationToParentOrganizationError,

--- a/api/src/organizational-entities/domain/models/OrganizationForAdmin.js
+++ b/api/src/organizational-entities/domain/models/OrganizationForAdmin.js
@@ -54,7 +54,7 @@ class OrganizationForAdmin {
     administrationTeamName,
     countryCode,
     countryName,
-    organizationLearnerTypeName,
+    organizationLearnerType,
   } = {}) {
     this.id = id;
     this.name = name;
@@ -85,7 +85,7 @@ class OrganizationForAdmin {
     this.tagIds = tagIds;
     this.administrationTeamId = administrationTeamId;
     this.administrationTeamName = administrationTeamName;
-    this.organizationLearnerTypeName = organizationLearnerTypeName;
+    this.organizationLearnerType = organizationLearnerType;
 
     // @deprecated you should use value stored in features property
     this.isManagingStudents = isManagingStudents;
@@ -244,6 +244,9 @@ class OrganizationForAdmin {
     this.tagsToRemove = differenceBy(this.tags, tags, 'id').map(({ id }) => ({ tagId: id, organizationId: this.id }));
     if (organization.administrationTeamId) this.administrationTeamId = organization.administrationTeamId;
     if (organization.countryCode) this.countryCode = organization.countryCode;
+    if (organization.organizationLearnerType) {
+      this.organizationLearnerType = organization.organizationLearnerType;
+    }
   }
 
   setCountryName(countryName) {

--- a/api/src/organizational-entities/domain/models/OrganizationLearnerType.js
+++ b/api/src/organizational-entities/domain/models/OrganizationLearnerType.js
@@ -1,9 +1,11 @@
 class OrganizationLearnerType {
   /**
    * @param {object} params
+   * @param {number} params.id
    * @param {string} params.name
    */
-  constructor({ name }) {
+  constructor({ id, name }) {
+    this.id = id;
     this.name = name;
   }
 }

--- a/api/src/organizational-entities/domain/usecases/update-organization-information.usecase.js
+++ b/api/src/organizational-entities/domain/usecases/update-organization-information.usecase.js
@@ -1,6 +1,6 @@
 import { withTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { logger } from '../../../shared/infrastructure/utils/logger.js';
-import { AdministrationTeamNotFound, CountryNotFoundError } from '../errors.js';
+import { AdministrationTeamNotFound, CountryNotFoundError, OrganizationLearnerTypeNotFound } from '../errors.js';
 
 const updateOrganizationInformation = withTransaction(async function ({
   organization,
@@ -14,10 +14,18 @@ const updateOrganizationInformation = withTransaction(async function ({
 
   let organizationLearnerType;
   if (organization.organizationLearnerType) {
-    organizationLearnerType = await organizationLearnerTypeRepository.getByName(
-      organization.organizationLearnerType.name,
-    );
-    organization.organizationLearnerType = organizationLearnerType;
+    try {
+      organizationLearnerType = await organizationLearnerTypeRepository.getByName(
+        organization.organizationLearnerType.name,
+      );
+      organization.organizationLearnerType = organizationLearnerType;
+    } catch {
+      throw new OrganizationLearnerTypeNotFound({
+        meta: {
+          organizationLearnerTypeName: organization.organizationLearnerType.name,
+        },
+      });
+    }
   }
 
   const tagsToUpdate = await tagRepository.findByIds(organization.tagIds);

--- a/api/src/organizational-entities/domain/usecases/update-organization-information.usecase.js
+++ b/api/src/organizational-entities/domain/usecases/update-organization-information.usecase.js
@@ -7,9 +7,19 @@ const updateOrganizationInformation = withTransaction(async function ({
   organizationForAdminRepository,
   tagRepository,
   administrationTeamRepository,
+  organizationLearnerTypeRepository,
   countryRepository,
 }) {
   const existingOrganization = await organizationForAdminRepository.get({ organizationId: organization.id });
+
+  let organizationLearnerType;
+  if (organization.organizationLearnerType) {
+    organizationLearnerType = await organizationLearnerTypeRepository.getByName(
+      organization.organizationLearnerType.name,
+    );
+    organization.organizationLearnerType = organizationLearnerType;
+  }
+
   const tagsToUpdate = await tagRepository.findByIds(organization.tagIds);
 
   await _checkAdministrationTeamExists(organization.administrationTeamId, administrationTeamRepository);

--- a/api/src/organizational-entities/infrastructure/repositories/organization-learner-type-repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/organization-learner-type-repository.js
@@ -1,4 +1,5 @@
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
+import { NotFoundError } from '../../../shared/domain/errors.js';
 import { OrganizationLearnerType } from '../../domain/models/OrganizationLearnerType.js';
 
 /**
@@ -15,6 +16,26 @@ const findAll = async function () {
   return organizationLearnerTypes.map(_toDomain);
 };
 
+/**
+ * @param {*} name
+ * @returns {Promise<OrganizationLearnerType>}
+ * @throws {NotFoundError}
+ */
+const getByName = async function (name) {
+  const knexConn = DomainTransaction.getConnection();
+  const organizationLearnerTypeDTO = await knexConn
+    .select('name', 'id')
+    .from('organization_learner_types')
+    .where({ name })
+    .first();
+
+  if (!organizationLearnerTypeDTO) {
+    throw new NotFoundError();
+  }
+
+  return _toDomain(organizationLearnerTypeDTO);
+};
+
 const _toDomain = function (organizationLearnerTypeDTO) {
   return new OrganizationLearnerType({
     id: organizationLearnerTypeDTO.id,
@@ -22,4 +43,4 @@ const _toDomain = function (organizationLearnerTypeDTO) {
   });
 };
 
-export { findAll };
+export { findAll, getByName };

--- a/api/src/organizational-entities/infrastructure/repositories/organization-learner-type-repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/organization-learner-type-repository.js
@@ -8,7 +8,7 @@ import { OrganizationLearnerType } from '../../domain/models/OrganizationLearner
 const findAll = async function () {
   const knexConn = DomainTransaction.getConnection();
   const organizationLearnerTypes = await knexConn
-    .select('name')
+    .select('name', 'id')
     .from('organization_learner_types')
     .orderBy('name', 'asc');
 
@@ -17,6 +17,7 @@ const findAll = async function () {
 
 const _toDomain = function (organizationLearnerTypeDTO) {
   return new OrganizationLearnerType({
+    id: organizationLearnerTypeDTO.id,
     name: organizationLearnerTypeDTO.name,
   });
 };

--- a/api/src/organizational-entities/infrastructure/serializers/jsonapi/organization-learner-type/organization-learner-type-serializer.js
+++ b/api/src/organizational-entities/infrastructure/serializers/jsonapi/organization-learner-type/organization-learner-type-serializer.js
@@ -3,7 +3,12 @@ import jsonapiSerializer from 'jsonapi-serializer';
 const { Serializer } = jsonapiSerializer;
 
 const serialize = function (organizationLearnerType) {
-  return new Serializer('organization-learner-type', {
+  return new Serializer('organization-learner-types', {
+    transform(record) {
+      return {
+        name: record.name,
+      };
+    },
     attributes: ['name'],
   }).serialize(organizationLearnerType);
 };

--- a/api/src/organizational-entities/infrastructure/serializers/jsonapi/organizations-administration/organization-for-admin.serializer.js
+++ b/api/src/organizational-entities/infrastructure/serializers/jsonapi/organizations-administration/organization-for-admin.serializer.js
@@ -8,6 +8,11 @@ const serialize = function (organizations, meta) {
     transform(record) {
       const dataProtectionOfficer = record.dataProtectionOfficer;
 
+      const organizationLearnerTypeName = record?.organizationLearnerType?.name;
+      if (organizationLearnerTypeName) {
+        record.organizationLearnerTypeName = organizationLearnerTypeName;
+      }
+
       if (dataProtectionOfficer) {
         record.dataProtectionOfficerFirstName = dataProtectionOfficer.firstName;
         record.dataProtectionOfficerLastName = dataProtectionOfficer.lastName;

--- a/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
@@ -774,6 +774,7 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
 
       // then
       expect(response.statusCode).to.equal(200);
+      expect(response.result.data['external-id']).not.to.equal(organization.externalId);
     });
   });
 

--- a/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
@@ -736,6 +736,7 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
         commonName: 'Islande',
         originalName: 'Islande',
       });
+      const newOrganizationLearnerType = databaseBuilder.factory.buildOrganizationLearnerType();
 
       const organizationAttributes = {
         externalId: '0446758F',
@@ -758,6 +759,7 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
             credit: organizationAttributes.credit,
             'administration-team-id': administrationTeamId,
             'country-code': country.code,
+            'organization-learner-type-name': newOrganizationLearnerType.name,
           },
         },
       };
@@ -775,6 +777,10 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
       // then
       expect(response.statusCode).to.equal(200);
       expect(response.result.data['external-id']).not.to.equal(organization.externalId);
+      const formerOrganizationLearnerType = await knex('organization_learner_types').where({
+        id: organization.organizationLearnerTypeId,
+      });
+      expect(response.result.data['organization-learner-type-name']).to.equal(formerOrganizationLearnerType.name);
     });
   });
 

--- a/api/tests/organizational-entities/integration/domain/usecases/update-organization-information.usecase_test.js
+++ b/api/tests/organizational-entities/integration/domain/usecases/update-organization-information.usecase_test.js
@@ -1,6 +1,7 @@
 import {
   AdministrationTeamNotFound,
   CountryNotFoundError,
+  OrganizationLearnerTypeNotFound,
 } from '../../../../../src/organizational-entities/domain/errors.js';
 import { OrganizationForAdmin } from '../../../../../src/organizational-entities/domain/models/OrganizationForAdmin.js';
 import { usecases } from '../../../../../src/organizational-entities/domain/usecases/index.js';
@@ -58,6 +59,31 @@ describe('Integration | Organizational Entities | Domain | UseCases | update-org
     expect(updatedOrganization.administrationTeamId).to.equal(newAdministrationTeamId);
     expect(updatedOrganization.countryCode).to.equal(99102);
     expect(updatedOrganization.organizationLearnerType.id).to.equal(newOrganizationLearnerType.id);
+  });
+
+  context('when organization learner type does not exist', function () {
+    it('throws an OrganizationLearnerTypeNotFound error', async function () {
+      // given
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+
+      await databaseBuilder.commit();
+
+      const organizationNewInformations = domainBuilder.buildOrganizationForAdmin({
+        id: organizationId,
+        organizationLearnerType: domainBuilder.acquisition.buildOrganizationLearnerType({
+          name: 'Student',
+        }),
+      });
+
+      // when
+      const error = await catchErr(usecases.updateOrganizationInformation)({
+        organization: organizationNewInformations,
+      });
+
+      // then
+      expect(error).to.be.instanceOf(OrganizationLearnerTypeNotFound);
+      expect(error.meta.organizationLearnerTypeName).to.equal(organizationNewInformations.organizationLearnerType.name);
+    });
   });
 
   context('when administration team does not exist', function () {

--- a/api/tests/organizational-entities/integration/domain/usecases/update-organization-information.usecase_test.js
+++ b/api/tests/organizational-entities/integration/domain/usecases/update-organization-information.usecase_test.js
@@ -23,6 +23,11 @@ describe('Integration | Organizational Entities | Domain | UseCases | update-org
 
     const newAdministrationTeamId = databaseBuilder.factory.buildAdministrationTeam().id;
 
+    const newOrganizationLearnerType = databaseBuilder.factory.buildOrganizationLearnerType({
+      id: 1,
+      name: 'New Type',
+    });
+
     const newCountry = databaseBuilder.factory.buildCertificationCpfCountry({
       code: 99102,
       originalName: 'Islande',
@@ -31,16 +36,20 @@ describe('Integration | Organizational Entities | Domain | UseCases | update-org
 
     await databaseBuilder.commit();
 
-    const organizationNewInformations = domainBuilder.buildOrganizationForAdmin({
+    const organizationNewInformation = domainBuilder.buildOrganizationForAdmin({
       id: organizationId,
       name: "Nouveau nom d'organization",
       administrationTeamId: newAdministrationTeamId,
       countryCode: newCountry.code,
+      organizationLearnerType: domainBuilder.acquisition.buildOrganizationLearnerType({
+        id: null,
+        name: newOrganizationLearnerType.name,
+      }),
     });
 
     // when
     const updatedOrganization = await usecases.updateOrganizationInformation({
-      organization: organizationNewInformations,
+      organization: organizationNewInformation,
     });
 
     // then
@@ -48,6 +57,7 @@ describe('Integration | Organizational Entities | Domain | UseCases | update-org
     expect(updatedOrganization.name).to.equal("Nouveau nom d'organization");
     expect(updatedOrganization.administrationTeamId).to.equal(newAdministrationTeamId);
     expect(updatedOrganization.countryCode).to.equal(99102);
+    expect(updatedOrganization.organizationLearnerType.id).to.equal(newOrganizationLearnerType.id);
   });
 
   context('when administration team does not exist', function () {

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/organization-learner-type-repository_test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/organization-learner-type-repository_test.js
@@ -1,5 +1,6 @@
 import * as organizationLearnerTypeRepository from '../../../../../src/organizational-entities/infrastructure/repositories/organization-learner-type-repository.js';
-import { databaseBuilder, domainBuilder, expect } from '../../../../test-helper.js';
+import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
+import { catchErr, databaseBuilder, domainBuilder, expect } from '../../../../test-helper.js';
 
 describe('Integration | Repository | organization-learner-type-repository', function () {
   describe('#findAll', function () {
@@ -37,6 +38,35 @@ describe('Integration | Repository | organization-learner-type-repository', func
 
       // then
       expect(result).to.deep.equal([]);
+    });
+  });
+
+  describe('#getByName', function () {
+    it('should return the organization learner type with the given name', async function () {
+      // given
+      const organizationLearnerType = databaseBuilder.factory.buildOrganizationLearnerType({
+        name: 'Type A',
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const result = await organizationLearnerTypeRepository.getByName(organizationLearnerType.name);
+
+      // then
+      expect(result).to.deep.equal(
+        domainBuilder.acquisition.buildOrganizationLearnerType({
+          id: organizationLearnerType.id,
+          name: organizationLearnerType.name,
+        }),
+      );
+    });
+
+    it('should throw if there is no organization learner type with the given name', async function () {
+      // when
+      const error = await catchErr(organizationLearnerTypeRepository.getByName)('Unknown name');
+
+      // then
+      expect(error).to.be.instanceOf(NotFoundError);
     });
   });
 });

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/organization-learner-type-repository_test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/organization-learner-type-repository_test.js
@@ -21,9 +21,13 @@ describe('Integration | Repository | organization-learner-type-repository', func
       // then
       expect(result).to.have.deep.members([
         domainBuilder.acquisition.buildOrganizationLearnerType({
+          id: secondOrganizationLearnerType.id,
           name: secondOrganizationLearnerType.name,
         }),
-        domainBuilder.acquisition.buildOrganizationLearnerType({ name: firstOrganizationLearnerType.name }),
+        domainBuilder.acquisition.buildOrganizationLearnerType({
+          id: firstOrganizationLearnerType.id,
+          name: firstOrganizationLearnerType.name,
+        }),
       ]);
     });
 

--- a/api/tests/organizational-entities/unit/application/http-error-mapper-configuration_test.js
+++ b/api/tests/organizational-entities/unit/application/http-error-mapper-configuration_test.js
@@ -4,6 +4,7 @@ import {
   TagNotFoundError,
   UnableToDetachParentOrganizationFromChildOrganization,
 } from '../../../../src/organizational-entities/domain/errors.js';
+import { OrganizationLearnerTypeNotFound } from '../../../../src/organizational-entities/domain/errors.js';
 import { HttpErrors } from '../../../../src/shared/application/http-errors.js';
 import { DomainErrorMappingConfiguration } from '../../../../src/shared/application/models/domain-error-mapping-configuration.js';
 import { expect } from '../../../test-helper.js';
@@ -70,6 +71,25 @@ describe('Unit | Organizational Entities | Application | HttpErrorMapperConfigur
       // then
       expect(error).to.be.instanceOf(HttpErrors.NotFoundError);
       expect(error.message).to.equal('Country not found');
+      expect(error.meta).to.equal(meta);
+    });
+  });
+
+  context('when mapping "OrganizationLearnerTypeNotFound"', function () {
+    it('should return a UnprocessableEntityError Http Error', function () {
+      // given
+      const httpErrorMapper = organizationalEntitiesDomainErrorMappingConfiguration.find(
+        (httpErrorMapper) => httpErrorMapper.name === OrganizationLearnerTypeNotFound.name,
+      );
+
+      const meta = { organizationLearnerTypeName: 'Student' };
+
+      // when
+      const error = httpErrorMapper.httpErrorFn(new OrganizationLearnerTypeNotFound({ meta }));
+
+      // then
+      expect(error).to.be.instanceOf(HttpErrors.UnprocessableEntityError);
+      expect(error.message).to.equal('Organization learner type does not exist');
       expect(error.meta).to.equal(meta);
     });
   });

--- a/api/tests/organizational-entities/unit/application/organization/organization.admin.controller.test.js
+++ b/api/tests/organizational-entities/unit/application/organization/organization.admin.controller.test.js
@@ -1,6 +1,5 @@
 import { organizationAdminController } from '../../../../../src/organizational-entities/application/organization/organization.admin.controller.js';
 import { usecases } from '../../../../../src/organizational-entities/domain/usecases/index.js';
-import { DomainTransaction } from '../../../../../src/shared/domain/DomainTransaction.js';
 import {
   domainBuilder,
   expect,
@@ -179,16 +178,12 @@ describe('Unit | Organizational Entities | Application | Controller | Admin | or
       const dependencies = {
         organizationForAdminSerializer: organizationForAdminSerializerStub,
       };
-      const domainTransaction = Symbol('domainTransaction');
-      sinon.stub(DomainTransaction, 'execute').callsFake((callback) => {
-        return callback(domainTransaction);
-      });
 
       dependencies.organizationForAdminSerializer.deserialize
         .withArgs(request.payload)
         .returns(organizationDeserialized);
       usecases.updateOrganizationInformation
-        .withArgs({ organization: organizationDeserialized, domainTransaction })
+        .withArgs({ organization: organizationDeserialized })
         .resolves(updatedOrganization);
       dependencies.organizationForAdminSerializer.serialize
         .withArgs(updatedOrganization)

--- a/api/tests/organizational-entities/unit/domain/models/OrganizationForAdmin_test.js
+++ b/api/tests/organizational-entities/unit/domain/models/OrganizationForAdmin_test.js
@@ -1,5 +1,6 @@
 import { OrganizationBatchUpdateDTO } from '../../../../../src/organizational-entities/domain/dtos/OrganizationBatchUpdateDTO.js';
 import { OrganizationForAdmin } from '../../../../../src/organizational-entities/domain/models/OrganizationForAdmin.js';
+import { OrganizationLearnerType } from '../../../../../src/organizational-entities/domain/models/OrganizationLearnerType.js';
 import { ORGANIZATION_FEATURE } from '../../../../../src/shared/domain/constants.js';
 import { domainBuilder, expect } from '../../../../test-helper.js';
 
@@ -747,6 +748,42 @@ describe('Unit | Organizational Entities | Domain | Model | OrganizationForAdmin
       expect(givenOrganization.features).to.deep.includes({
         [ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key]: { active: false },
       });
+    });
+
+    it('updates organization learner type', function () {
+      // given
+      const formerOrganizationLearnerType = new OrganizationLearnerType({ id: 1, name: 'Student' });
+      const newOrganizationLearnerType = new OrganizationLearnerType({ id: 2, name: 'Professional' });
+      const givenOrganization = new OrganizationForAdmin({
+        organizationLearnerType: formerOrganizationLearnerType,
+      });
+
+      // when
+      givenOrganization.updateWithDataProtectionOfficerAndTags({
+        organizationLearnerType: newOrganizationLearnerType,
+        features,
+      });
+
+      // then
+      expect(givenOrganization.organizationLearnerType).to.deep.equal(newOrganizationLearnerType);
+    });
+
+    it('does not update organization learner type to undefined', function () {
+      // given
+      const formerOrganizationLearnerType = new OrganizationLearnerType({ id: 1, name: 'Student' });
+      const newOrganizationLearnerType = undefined;
+      const givenOrganization = new OrganizationForAdmin({
+        organizationLearnerType: formerOrganizationLearnerType,
+      });
+
+      // when
+      givenOrganization.updateWithDataProtectionOfficerAndTags({
+        organizationLearnerType: newOrganizationLearnerType,
+        features,
+      });
+
+      // then
+      expect(givenOrganization.organizationLearnerType).to.deep.equal(formerOrganizationLearnerType);
     });
   });
 

--- a/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/organization-for-admin.serializer.test.js
+++ b/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/organization-for-admin.serializer.test.js
@@ -14,6 +14,8 @@ describe('Unit | Serializer | organization-for-admin-serializer', function () {
         domainBuilder.buildTag({ id: 7, name: 'AEFE' }),
         domainBuilder.buildTag({ id: 44, name: 'PUBLIC' }),
       ];
+      const organizationLearnerType = domainBuilder.acquisition.buildOrganizationLearnerType();
+
       const parentOrganization = domainBuilder.buildOrganizationForAdmin({
         email: 'motherSco.generic.account@example.net',
         tags,
@@ -32,8 +34,9 @@ describe('Unit | Serializer | organization-for-admin-serializer', function () {
         name: 'motherSco',
         countryCode: 99100,
         countryName: 'France',
-        organizationLearnerTypeName: 'Learner type',
+        organizationLearnerType: organizationLearnerType,
       });
+
       const organization = domainBuilder.buildOrganizationForAdmin({
         email: 'sco.generic.account@example.net',
         tags,
@@ -55,7 +58,7 @@ describe('Unit | Serializer | organization-for-admin-serializer', function () {
         administrationTeamName: administrationTeam.name,
         countryCode: 99100,
         countryName: 'France',
-        organizationLearnerTypeName: 'Learner type',
+        organizationLearnerType: organizationLearnerType,
       });
       const meta = { some: 'meta' };
 
@@ -97,7 +100,7 @@ describe('Unit | Serializer | organization-for-admin-serializer', function () {
             features: organization.features,
             'country-code': organization.countryCode,
             'country-name': organization.countryName,
-            'organization-learner-type-name': organization.organizationLearnerTypeName,
+            'organization-learner-type-name': organization.organizationLearnerType.name,
           },
           relationships: {
             'organization-memberships': {

--- a/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/organization-learner-type-serializer_test.js
+++ b/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/organization-learner-type-serializer_test.js
@@ -1,0 +1,24 @@
+import * as organizationLearnerTypeSerializer from '../../../../../../src/organizational-entities/infrastructure/serializers/jsonapi/organization-learner-type/organization-learner-type-serializer.js';
+import { domainBuilder, expect } from '../../../../../test-helper.js';
+
+describe('Unit | Serializer | organization-learner-type-serializer', function () {
+  describe('#serialize', function () {
+    it('should return a JSON API serialized organization learner type', function () {
+      // given
+      const organizationLearnerType = domainBuilder.acquisition.buildOrganizationLearnerType();
+
+      // when
+      const serializedOrganizationLearnerType = organizationLearnerTypeSerializer.serialize(organizationLearnerType);
+
+      // then
+      expect(serializedOrganizationLearnerType).to.deep.equal({
+        data: {
+          type: 'organization-learner-types',
+          attributes: {
+            name: organizationLearnerType.name,
+          },
+        },
+      });
+    });
+  });
+});

--- a/api/tests/tooling/domain-builder/factory/acquisition/build-organization-learner-type.js
+++ b/api/tests/tooling/domain-builder/factory/acquisition/build-organization-learner-type.js
@@ -1,7 +1,7 @@
 import { OrganizationLearnerType } from '../../../../../src/organizational-entities/domain/models/OrganizationLearnerType.js';
 
-const buildOrganizationLearnerType = function ({ name = 'Élève' } = {}) {
-  return new OrganizationLearnerType({ name });
+const buildOrganizationLearnerType = function ({ id = 1234, name = 'Élève' } = {}) {
+  return new OrganizationLearnerType({ id, name });
 };
 
 export { buildOrganizationLearnerType };

--- a/api/tests/tooling/domain-builder/factory/build-organization-for-admin.js
+++ b/api/tests/tooling/domain-builder/factory/build-organization-for-admin.js
@@ -33,7 +33,7 @@ function buildOrganizationForAdmin({
   administrationTeamName = null,
   countryCode = null,
   countryName = null,
-  organizationLearnerTypeName = null,
+  organizationLearnerType = null,
 } = {}) {
   return new OrganizationForAdmin({
     id,
@@ -68,7 +68,7 @@ function buildOrganizationForAdmin({
     administrationTeamName,
     countryCode,
     countryName,
-    organizationLearnerTypeName,
+    organizationLearnerType,
   });
 }
 


### PR DESCRIPTION
## 🥀 Problème

Il n'est pas possible de modifier le public prescrit d'une organisation

## 🏹 Proposition

Pouvoir modifier le public prescrit d'une organisation (uniquement côté back pour l'instant)

## 💌 Remarques

Pour le moment, on ne modifie pas le public prescrit, ce sera fait lorsqu'on fera le côté front.

## ❤️‍🔥 Pour tester

- Se connecter à Pix-Admin
- Aller sur la page de détails d'une orga avec un public prescrit
- Modifier un champ
- Vérifier que rien ne casse et que l'update se fait

- Réitérer avec une orga sans public prescrit

- Pour vérifier que la MAJ se fait malgré l'absence de select côté front, utiliser ce curl en allant chercher un token valide
```
curl https://admin-pr15091.review.pix.fr/api/admin/organizations/8001 \
    -H "Authorization: Bearer <TOKEN>" \
    -H "Content-Type: application/json" \
    -H "Accept-language: fr-fr" \
    -d '{
  "data": {
    "id": 8001,
    "attributes": {
    "administration-team-id": 8000,
      "organization-learner-type-name":  "Student
    },
    "type": "organizations"
  }
}' \
    -X PATCH
```