### PR TITLE
[TECH] :broom: Réduit l'utilisation de la  librairie `lodash`

### DIFF
--- a/api/src/certification/enrolment/domain/read-models/EnrolledCandidate.js
+++ b/api/src/certification/enrolment/domain/read-models/EnrolledCandidate.js
@@ -2,8 +2,6 @@
  * @typedef {import('../models/Subscription.js').Subscription} Subscription
  * @typedef {import('../models/Candidate.js').Candidate} Candidate
  */
-import _ from 'lodash';
-
 import { SUBSCRIPTION_TYPES } from '../../../shared/domain/constants.js';
 
 /**
@@ -54,7 +52,7 @@ export class EnrolledCandidate {
     this.resultRecipientEmail = resultRecipientEmail;
     this.externalId = externalId;
     this.birthdate = birthdate;
-    this.extraTimePercentage = !_.isNil(extraTimePercentage) ? parseFloat(extraTimePercentage) : null;
+    this.extraTimePercentage = extraTimePercentage != null ? parseFloat(extraTimePercentage) : null;
     this.isLinked = Boolean(userId);
     this.userId = userId;
     this.sessionId = sessionId;

--- a/api/src/certification/enrolment/infrastructure/utils/sessions-import.js
+++ b/api/src/certification/enrolment/infrastructure/utils/sessions-import.js
@@ -1,9 +1,5 @@
 import { Parser } from '@json2csv/plainjs';
 
-const { omit } = lodash;
-
-import lodash from 'lodash';
-
 import {
   COMPLEMENTARY_CERTIFICATION_SUFFIX,
   headers,
@@ -26,9 +22,9 @@ function _getComplementaryCertificationsHeaders(habilitationLabels) {
 }
 
 function _getHeadersAsArray(complementaryCertificationsHeaders = [], shouldDisplayBillingModeColumns) {
-  const certificationCenterCsvHeaders = shouldDisplayBillingModeColumns
-    ? headers
-    : omit(headers, ['billingMode', 'prepaymentCode']);
+  // eslint-disable-next-line no-unused-vars
+  const { billingMode, prepaymentCode, ...headersWithoutBillingMode } = headers;
+  const certificationCenterCsvHeaders = shouldDisplayBillingModeColumns ? headers : headersWithoutBillingMode;
 
   const csvHeaders = Object.keys(certificationCenterCsvHeaders).reduce((arr, key) => [...arr, headers[key]], []);
   return [...csvHeaders, ...complementaryCertificationsHeaders];

--- a/api/src/certification/session-management/infrastructure/repositories/jury-certification-summary-repository.js
+++ b/api/src/certification/session-management/infrastructure/repositories/jury-certification-summary-repository.js
@@ -13,7 +13,7 @@ const findBySessionId = async function ({ sessionId }) {
 
   const juryCertificationSummaryDTOs = await _getJuryCertificationSummaries(orderResults);
 
-  return _.map(juryCertificationSummaryDTOs, _toDomain);
+  return juryCertificationSummaryDTOs.map(_toDomain);
 };
 
 const findBySessionIdPaginated = async function ({ page, sessionId }) {
@@ -28,7 +28,7 @@ const findBySessionIdPaginated = async function ({ page, sessionId }) {
   const orderedResults = await _getByCertificationCourseIds(orderedCertificationCourseIds);
 
   const juryCertificationSummaryDTOs = await _getJuryCertificationSummaries(orderedResults);
-  const juryCertificationSummaries = _.map(juryCertificationSummaryDTOs, _toDomain);
+  const juryCertificationSummaries = juryCertificationSummaryDTOs.map(_toDomain);
   return {
     pagination,
     juryCertificationSummaries,

--- a/api/src/certification/session-management/infrastructure/serializers/jury-certification-summary-serializer.js
+++ b/api/src/certification/session-management/infrastructure/serializers/jury-certification-summary-serializer.js
@@ -2,14 +2,15 @@ import lodash from 'lodash';
 
 const { Serializer } = jsonapiSerializer;
 
-const { omit, get } = lodash;
+const { get } = lodash;
 
 import jsonapiSerializer from 'jsonapi-serializer';
 
 const serialize = function (juryCertificationSummary, meta, { translate }) {
   return new Serializer('jury-certification-summary', {
     transform(juryCertificationSummary) {
-      const result = omit(juryCertificationSummary, 'certificationIssueReports');
+      // eslint-disable-next-line no-unused-vars
+      const { certificationIssueReports, ...result } = juryCertificationSummary;
       result.certificationObtained = juryCertificationSummary.getCertificationLabel(translate);
       result.examinerComment = get(juryCertificationSummary, 'certificationIssueReports[0].description');
       result.numberOfCertificationIssueReports = juryCertificationSummary.certificationIssueReports.length;

--- a/api/tests/certification/enrolment/integration/infrastructure/repositories/certification-candidate-repository_test.js
+++ b/api/tests/certification/enrolment/integration/infrastructure/repositories/certification-candidate-repository_test.js
@@ -1,5 +1,3 @@
-import _ from 'lodash';
-
 import { SUBSCRIPTION_TYPES } from '../../../../../../src/certification/shared/domain/constants.js';
 import { ComplementaryCertification } from '../../../../../../src/certification/shared/domain/models/ComplementaryCertification.js';
 import { ComplementaryCertificationKeys } from '../../../../../../src/certification/shared/domain/models/ComplementaryCertificationKeys.js';
@@ -20,20 +18,23 @@ describe('Integration | Repository | CertificationCandidate', function () {
     beforeEach(async function () {
       // given
       const anotherSessionId = databaseBuilder.factory.buildSession().id;
-      _.each(
-        [
-          { lastName: 'Rine', firstName: 'Lena', sessionId },
-          { lastName: 'Pafromage', firstName: 'Lara', sessionId },
-          { lastName: 'Mate', firstName: 'Otto', sessionId },
-          { lastName: 'Attrak', firstName: 'Pat', sessionId: anotherSessionId },
-          { lastName: 'Registre', firstName: 'Jean', sessionId: anotherSessionId },
-          { lastName: 'Damant', firstName: 'Evy', sessionId },
-        ],
-        (candidate) => {
-          const aCandidate = databaseBuilder.factory.buildCertificationCandidate(candidate);
-          databaseBuilder.factory.buildCoreSubscription({ certificationCandidateId: aCandidate.id });
+      [
+        { lastName: 'Rine', firstName: 'Lena', sessionId },
+        { lastName: 'Pafromage', firstName: 'Lara', sessionId },
+        { lastName: 'Mate', firstName: 'Otto', sessionId },
+        { lastName: 'Attrak', firstName: 'Pat', sessionId: anotherSessionId },
+        {
+          lastName: 'Registre',
+          firstName: 'Jean',
+          sessionId: anotherSessionId,
         },
-      );
+        { lastName: 'Damant', firstName: 'Evy', sessionId },
+      ].forEach((candidate) => {
+        const aCandidate = databaseBuilder.factory.buildCertificationCandidate(candidate);
+        databaseBuilder.factory.buildCoreSubscription({
+          certificationCandidateId: aCandidate.id,
+        });
+      });
 
       await databaseBuilder.commit();
     });
@@ -65,19 +66,25 @@ describe('Integration | Repository | CertificationCandidate', function () {
           firstName: 'Otto',
           sessionId,
         });
-        databaseBuilder.factory.buildCoreSubscription({ certificationCandidateId: ottoMate.id });
+        databaseBuilder.factory.buildCoreSubscription({
+          certificationCandidateId: ottoMate.id,
+        });
         const patAttrak = databaseBuilder.factory.buildCertificationCandidate({
           lastName: 'Attrak',
           firstName: 'Pat',
           sessionId,
         });
-        databaseBuilder.factory.buildCoreSubscription({ certificationCandidateId: patAttrak.id });
+        databaseBuilder.factory.buildCoreSubscription({
+          certificationCandidateId: patAttrak.id,
+        });
         const evyDamant = databaseBuilder.factory.buildCertificationCandidate({
           lastName: 'Damant',
           firstName: 'Evy',
           sessionId,
         });
-        databaseBuilder.factory.buildCoreSubscription({ certificationCandidateId: evyDamant.id });
+        databaseBuilder.factory.buildCoreSubscription({
+          certificationCandidateId: evyDamant.id,
+        });
 
         databaseBuilder.factory.buildComplementaryCertificationSubscription({
           complementaryCertificationId: rockCertification.id,
@@ -157,7 +164,9 @@ describe('Integration | Repository | CertificationCandidate', function () {
         reconciledAt,
       }).id;
 
-      databaseBuilder.factory.buildCoreSubscription({ certificationCandidateId });
+      databaseBuilder.factory.buildCoreSubscription({
+        certificationCandidateId,
+      });
 
       databaseBuilder.factory.buildComplementaryCertificationSubscription({
         complementaryCertificationId: complementaryCertification.id,
@@ -170,10 +179,15 @@ describe('Integration | Repository | CertificationCandidate', function () {
     context('when there is one certification candidate with the given session id and user id', function () {
       it('should fetch the candidate', async function () {
         // when
-        const result = await certificationCandidateRepository.getBySessionIdAndUserId({ sessionId, userId });
+        const result = await certificationCandidateRepository.getBySessionIdAndUserId({
+          sessionId,
+          userId,
+        });
 
         // then
-        const actualCandidate = _.omit(result, 'subscriptions');
+        // eslint-disable-next-line no-unused-vars
+        const { subscriptions, ...actualCandidate } = result;
+
         expect(actualCandidate).to.deep.equal({
           accessibilityAdjustmentNeeded: false,
           authorizedToStart: false,
@@ -263,7 +277,9 @@ describe('Integration | Repository | CertificationCandidate', function () {
           id: 456,
           lastName: 'last-name',
         });
-        databaseBuilder.factory.buildCoreSubscription({ certificationCandidateId: certificationCandidate.id });
+        databaseBuilder.factory.buildCoreSubscription({
+          certificationCandidateId: certificationCandidate.id,
+        });
         await databaseBuilder.commit();
 
         // when
@@ -301,7 +317,9 @@ describe('Integration | Repository | CertificationCandidate', function () {
           id: 456,
           lastName: 'last-name',
         });
-        databaseBuilder.factory.buildCoreSubscription({ certificationCandidateId: candidate.id });
+        databaseBuilder.factory.buildCoreSubscription({
+          certificationCandidateId: candidate.id,
+        });
 
         await databaseBuilder.commit();
         const wrongCandidateId = 1298;
@@ -325,8 +343,12 @@ describe('Integration | Repository | CertificationCandidate', function () {
     context('when certification candidate is not found', function () {
       it('should throw NotFound error', async function () {
         // given
-        const candidate = databaseBuilder.factory.buildCertificationCandidate({ id: 1 });
-        databaseBuilder.factory.buildCoreSubscription({ certificationCandidateId: candidate.id });
+        const candidate = databaseBuilder.factory.buildCertificationCandidate({
+          id: 1,
+        });
+        databaseBuilder.factory.buildCoreSubscription({
+          certificationCandidateId: candidate.id,
+        });
         const wrongCandidateId = 99;
         await databaseBuilder.commit();
 
@@ -344,7 +366,9 @@ describe('Integration | Repository | CertificationCandidate', function () {
       it('should return the candidate with empty complementary certification', async function () {
         // given
         const certificationCandidate = databaseBuilder.factory.buildCertificationCandidate();
-        databaseBuilder.factory.buildCoreSubscription({ certificationCandidateId: certificationCandidate.id });
+        databaseBuilder.factory.buildCoreSubscription({
+          certificationCandidateId: certificationCandidate.id,
+        });
         await databaseBuilder.commit();
 
         // when
@@ -406,7 +430,9 @@ describe('Integration | Repository | CertificationCandidate', function () {
       it('should return the candidate with his complementary certification', async function () {
         // given
         const certificationCandidate = databaseBuilder.factory.buildCertificationCandidate();
-        databaseBuilder.factory.buildCoreSubscription({ certificationCandidateId: certificationCandidate.id });
+        databaseBuilder.factory.buildCoreSubscription({
+          certificationCandidateId: certificationCandidate.id,
+        });
         const complementaryCertification = databaseBuilder.factory.buildComplementaryCertification({
           label: 'Complementary certification 2',
         });
@@ -423,7 +449,13 @@ describe('Integration | Repository | CertificationCandidate', function () {
         });
 
         // then
-        const certificationCandidateWithComplementaryCertification = _.omit(result, 'subscriptions');
+
+        const {
+          // eslint-disable-next-line no-unused-vars
+          subscriptions,
+          ...certificationCandidateWithComplementaryCertification
+        } = result;
+
         expect(certificationCandidateWithComplementaryCertification).to.deep.equal({
           accessibilityAdjustmentNeeded: certificationCandidate.accessibilityAdjustmentNeeded,
           authorizedToStart: certificationCandidate.authorizedToStart,


### PR DESCRIPTION
## 🥀 Problème

Nous utilisons la librairie externe `lodash`. Cela cré une forme de dépendance externe et un vecteur possible d'attaque.

## 🏹 Proposition

Utilisé du JavaScript simple au lieu des fonctions lodash

## 💌 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## ❤️‍🔥 Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
