### PR TITLE
[TECH] Réparer un flaky sur Pix Admin

### DIFF
--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile/organizations-test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile/organizations-test.js
@@ -118,7 +118,7 @@ module('Acceptance | Target Profile Organizations', function (hooks) {
         await fillByLabel("Rattacher les organisations d'un profil cible existant", '43');
         await clickByName('Valider le rattachement à partir de ce profil cible');
 
-        assert.dom(await screen.findByRole('cell', { name: 'Organization for target profile 43' })).exists();
+        assert.ok(await screen.findByRole('cell', { name: 'Organization for target profile 43' }));
       });
     });
   });


### PR DESCRIPTION
## 🥀 Problème
On a un flaky sur un test Acceptance | Target Profile Organizations côté admin.

## 🏹 Proposition
On remplace le .exists par .isVisible : je l'ai déjà fait dans une PR précédente pour fixer un autre flaky du même style. C'est lié à la librairie qunit.
https://github.com/1024pix/pix/pull/14953

