### PR TITLE
[FEATURE] Cache des routes banner, feature-toggles et oidc-providers

### DIFF
--- a/api/src/banner/application/banner-route.js
+++ b/api/src/banner/application/banner-route.js
@@ -1,5 +1,3 @@
-import ms from 'ms';
-
 import { bannerController } from './banner-controller.js';
 
 const register = async function (server) {
@@ -11,8 +9,7 @@ const register = async function (server) {
         auth: false,
         handler: bannerController.getInformationBanner,
         cache: {
-          expiresIn: ms('1 Year'),
-          privacy: 'public',
+          otherwise: 'public, max-age=0, s-maxage=86400, must-revalidate',
         },
       },
     },

--- a/api/src/banner/application/banner-route.js
+++ b/api/src/banner/application/banner-route.js
@@ -1,3 +1,5 @@
+import ms from 'ms';
+
 import { bannerController } from './banner-controller.js';
 
 const register = async function (server) {
@@ -8,7 +10,10 @@ const register = async function (server) {
       options: {
         auth: false,
         handler: bannerController.getInformationBanner,
-        cache: false,
+        cache: {
+          expiresIn: ms('1 Year'),
+          privacy: 'public',
+        },
       },
     },
   ]);

--- a/api/src/identity-access-management/application/oidc-provider/oidc-provider.route.js
+++ b/api/src/identity-access-management/application/oidc-provider/oidc-provider.route.js
@@ -1,5 +1,4 @@
 import Joi from 'joi';
-import ms from 'ms';
 
 import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
 import { oidcProviderController } from './oidc-provider.controller.js';
@@ -11,8 +10,7 @@ export const oidcProviderRoutes = [
     options: {
       auth: false,
       cache: {
-        expiresIn: ms('1 Day'),
-        privacy: 'public',
+        otherwise: 'public, max-age=0, s-maxage=86400, must-revalidate',
       },
       handler: (request, h) => oidcProviderController.getIdentityProviders(request, h),
       notes: [

--- a/api/src/identity-access-management/application/oidc-provider/oidc-provider.route.js
+++ b/api/src/identity-access-management/application/oidc-provider/oidc-provider.route.js
@@ -1,4 +1,5 @@
 import Joi from 'joi';
+import ms from 'ms';
 
 import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
 import { oidcProviderController } from './oidc-provider.controller.js';
@@ -9,7 +10,10 @@ export const oidcProviderRoutes = [
     path: '/api/oidc/identity-providers/{any*}',
     options: {
       auth: false,
-      cache: false,
+      cache: {
+        expiresIn: ms('1 Day'),
+        privacy: 'public',
+      },
       handler: (request, h) => oidcProviderController.getIdentityProviders(request, h),
       notes: [
         'Cette route renvoie une liste contenant les informations requises par le front pour les partenaires OIDC',

--- a/api/src/shared/application/feature-toggles/index.js
+++ b/api/src/shared/application/feature-toggles/index.js
@@ -1,3 +1,5 @@
+import ms from 'ms';
+
 import { featureToggleController } from './feature-toggle-controller.js';
 
 const register = async function (server) {
@@ -9,7 +11,10 @@ const register = async function (server) {
         auth: false,
         handler: featureToggleController.getActiveFeatures,
         tags: ['api'],
-        cache: false,
+        cache: {
+          expiresIn: ms('5 Minutes'),
+          privacy: 'public',
+        },
       },
     },
   ]);

--- a/api/src/shared/application/feature-toggles/index.js
+++ b/api/src/shared/application/feature-toggles/index.js
@@ -1,5 +1,3 @@
-import ms from 'ms';
-
 import { featureToggleController } from './feature-toggle-controller.js';
 
 const register = async function (server) {
@@ -12,8 +10,7 @@ const register = async function (server) {
         handler: featureToggleController.getActiveFeatures,
         tags: ['api'],
         cache: {
-          expiresIn: ms('5 Minutes'),
-          privacy: 'public',
+          otherwise: 'public, max-age=0, s-maxage=86400, must-revalidate',
         },
       },
     },


### PR DESCRIPTION
## 🥀 Problème

Depuis le changement de CDN, certaines des routes cachées avec l'ancien CDN ne sont plus en cache : information-banners, feature-toggles et oidc-providers.

## 🏹 Proposition

Le nouveau CDN permet de mettre en cache les ressources avec `Cache-Control: public`.

Ajouter ce header et l'expiration associées directement au niveau de la configuration HAPI pour les routes : 
- `/api/information-banners/{target}`: 1 an
- `/api/feature-toggles`: 5 minutes
- `/api/oidc/identity-providers/{any*}`: 1 jour

Il sera nécessaire d'invalider le cache dans Pix Exploit pour les routes suivantes :
- Ajout / suppression de banner : invalider le cache `/api/information-banners/{target}`
- Changement de FT : invalider le cache `/api/feature-toggles`

## 💌 Remarques

N/A

## ❤️‍🔥 Pour tester

Vérifier les headers du cache de ces requêtes.