### PR TITLE
[FEATURE] Déplacer le bouton Réessayer à droite pour les embed (PIX-21429)

### DIFF
--- a/mon-pix/app/components/module/element/_embed.scss
+++ b/mon-pix/app/components/module/element/_embed.scss
@@ -9,7 +9,7 @@
     border: 2px dashed var(--pix-primary-700);
 
     &--with-retry-button {
-      border-radius: 8px 8px 8px 0;
+      border-radius: 8px 8px 0;
     }
 
     &--without-retry-button {
@@ -24,7 +24,8 @@
 
   &__buttons {
     display: flex;
-    justify-content: space-between;
+    gap: var(--pix-spacing-4x);
+    justify-content: flex-end;
   }
 
   &__button {

--- a/mon-pix/app/components/module/element/embed.gjs
+++ b/mon-pix/app/components/module/element/embed.gjs
@@ -200,6 +200,8 @@ export default class ModulixEmbed extends ModuleElement {
       </div>
 
       <div class={{if this.resetButtonDisplayed "element-embed__buttons" "element-embed__button"}}>
+        <ModulixIssueReportBlock @reportInfo={{this.reportInfo}} />
+
         {{#if this.resetButtonDisplayed}}
           <PixButton
             class="element-embed-buttons__retry"
@@ -209,8 +211,6 @@ export default class ModulixEmbed extends ModuleElement {
             aria-label="{{t 'pages.modulix.buttons.interactive-element.reset.ariaLabel'}}"
           >{{t "pages.modulix.buttons.interactive-element.reset.name"}}</PixButton>
         {{/if}}
-
-        <ModulixIssueReportBlock @reportInfo={{this.reportInfo}} />
       </div>
     </div>
   </template>


### PR DESCRIPTION
## 🥀 Problème

Le bouton Embed a  son bouton Réinitiliaser conforme aux anciennes maquettes.

## 🏹 Proposition

Le déplacer à droite, comme pour les custom-element, ce qui avait été fait dans cette PR : https://github.com/1024pix/pix/pull/14934/changes/8fa5525f549222b85bbc26bbbc2788253d0c023c

## 💌 Remarques

C'est beau.

## ❤️‍🔥 Pour tester
- Ouvrir le [bac-a-sable](https://app-pr15105.review.pix.fr/modules/6a68bf32/bac-a-sable/details)
- Défiler jusqu'au grain contenant l'embed visioconférence
- Commencer l'embed
- Vérifier que le bouton "Réinitialiser" s'affiche bien à droite, à côté du bouton "Signaler"
