### PR TITLE
[BUMP] Mise à jour de @1024pix/epreuves-components à 2.8.0

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -80,7 +80,7 @@
         "yargs": "^18.0.0"
       },
       "devDependencies": {
-        "@1024pix/epreuves-components": "^2.7.0",
+        "@1024pix/epreuves-components": "^2.8.0",
         "@1024pix/eslint-plugin": "^2.1.17",
         "@eslint/compat": "^2.0.1",
         "@ls-lint/ls-lint": "^2.3.1",
@@ -116,9 +116,9 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-2.7.0.tgz",
-      "integrity": "sha512-qeT8Hky2BcJA9fV+RXa5AP2+3qU/sHKpeq7AL8ZVG26PhtNqWLARXKghjpOD2nBWr3Yo6NmSppW5UBI41cpuKQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-2.8.0.tgz",
+      "integrity": "sha512-aDKfMyzA7hfv39/MkHvsrIp0jEM3gTBH9xmVnmTSdJt3rOPS9DV1d7EoLczAhdBXFL+YV6maG1vWylPRcBIS8w==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {

--- a/api/package.json
+++ b/api/package.json
@@ -160,7 +160,7 @@
     "yargs": "^18.0.0"
   },
   "devDependencies": {
-    "@1024pix/epreuves-components": "^2.7.0",
+    "@1024pix/epreuves-components": "^2.8.0",
     "@1024pix/eslint-plugin": "^2.1.17",
     "@eslint/compat": "^2.0.1",
     "@ls-lint/ls-lint": "^2.3.1",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-epreuves-components.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-epreuves-components.json
@@ -1496,6 +1496,88 @@
               }
             }
           ]
+        },
+        {
+          "id": "1eca59cb-c125-4a15-98b7-1980df9dfced",
+          "type": "discovery",
+          "title": "template-mail",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "6554ce8c-d968-4921-9980-19cf8b63db0c",
+                "type": "text",
+                "content": "<p>Template mail</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "0fbcbe62-2fbe-4254-ad09-7c3a7c49321b",
+                "type": "custom",
+                "instruction": "",
+                "tagName": "template-mail",
+                "props": {
+                  "subject": "Votre facture #A‑91382",
+                  "mailAddress": "billing@micros0ft.com",
+                  "avatarColor": "#f24645",
+                  "expeditor": "Micr0sofot",
+                  "time": {
+                    "days": -2,
+                    "minutes": -5
+                  },
+                  "content": "salut [monsieur/madame]<br> ceci est un lien <a href='http://www.test.com'>link Fake</a><br> cho'",
+                  "previousMail": {
+                    "time": {
+                      "days": -5,
+                      "minutes": -10
+                    },
+                    "content": "[Madame, / Monsieur,]<br><br>Nous vous remercions sincèrement pour votre message et l’intérêt que vous portez à [Nom de votre entreprise] ainsi qu’à nos services.Nous répondrons à votre message dans les plus brefs délais et restons à votre disposition pour toute demande supplémentaire, y compris une rencontre personnelle si vous le souhaitez. D’ici là, vous pouvez obtenir des informations complémentaires sur nos [Produits/Services] en consultant, par exemple, nos réseaux sociaux sur [Lien vers les réseaux sociaux, par exemple, YouTube] ou en téléchargeant notre [Lien de téléchargement, tel qu’une présentation d’entreprise ou un document technique].<br>Chaleureusement,<br>L’équipe de [Nom de votre entreprise]",
+                    "name": "Alex"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        {
+          "id": "e50c0a21-55ef-42b8-8f73-0c6994858de1",
+          "type": "discovery",
+          "title": "test-top-mdp",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "9f2b4dd1-9120-45cc-847e-37a7d944bbd4",
+                "type": "text",
+                "content": "<p>test top mdp</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "a5231820-3946-4deb-9c39-3ac5e0ac9dd3",
+                "type": "custom",
+                "instruction": "",
+                "tagName": "test-top-mdp",
+                "props": {
+                  "passwords": [
+                    "123456",
+                    "123456789",
+                    "azerty",
+                    "1234561",
+                    "qwerty",
+                    "marseille",
+                    "000000",
+                    "1234567891",
+                    "doudou",
+                    "12345"
+                  ],
+                  "expectedPassword": "marseille"
+                }
+              }
+            }
+          ]
         }
       ]
     }

--- a/junior/package-lock.json
+++ b/junior/package-lock.json
@@ -11,7 +11,7 @@
       "license": "AGPL-3.0",
       "devDependencies": {
         "@1024pix/ember-testing-library": "^3.0.27",
-        "@1024pix/epreuves-components": "^2.7.0",
+        "@1024pix/epreuves-components": "^2.8.0",
         "@1024pix/eslint-plugin": "^2.1.17",
         "@1024pix/pix-ui": "^58.4.11",
         "@1024pix/stylelint-config": "^5.1.37",
@@ -180,9 +180,9 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-2.7.0.tgz",
-      "integrity": "sha512-qeT8Hky2BcJA9fV+RXa5AP2+3qU/sHKpeq7AL8ZVG26PhtNqWLARXKghjpOD2nBWr3Yo6NmSppW5UBI41cpuKQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-2.8.0.tgz",
+      "integrity": "sha512-aDKfMyzA7hfv39/MkHvsrIp0jEM3gTBH9xmVnmTSdJt3rOPS9DV1d7EoLczAhdBXFL+YV6maG1vWylPRcBIS8w==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {

--- a/junior/package.json
+++ b/junior/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^3.0.27",
-    "@1024pix/epreuves-components": "^2.7.0",
+    "@1024pix/epreuves-components": "^2.8.0",
     "@1024pix/eslint-plugin": "^2.1.17",
     "@1024pix/pix-ui": "^58.4.11",
     "@1024pix/stylelint-config": "^5.1.37",

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -12,7 +12,7 @@
       "devDependencies": {
         "@1024pix/ember-api-actions": "^1.1.0",
         "@1024pix/ember-testing-library": "^3.0.27",
-        "@1024pix/epreuves-components": "^2.7.0",
+        "@1024pix/epreuves-components": "^2.8.0",
         "@1024pix/eslint-plugin": "^2.1.17",
         "@1024pix/pix-ui": "^58.4.9",
         "@1024pix/stylelint-config": "^5.1.37",
@@ -817,9 +817,9 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-2.7.0.tgz",
-      "integrity": "sha512-qeT8Hky2BcJA9fV+RXa5AP2+3qU/sHKpeq7AL8ZVG26PhtNqWLARXKghjpOD2nBWr3Yo6NmSppW5UBI41cpuKQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-2.8.0.tgz",
+      "integrity": "sha512-aDKfMyzA7hfv39/MkHvsrIp0jEM3gTBH9xmVnmTSdJt3rOPS9DV1d7EoLczAhdBXFL+YV6maG1vWylPRcBIS8w==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@1024pix/ember-api-actions": "^1.1.0",
     "@1024pix/ember-testing-library": "^3.0.27",
-    "@1024pix/epreuves-components": "^2.7.0",
+    "@1024pix/epreuves-components": "^2.8.0",
     "@1024pix/eslint-plugin": "^2.1.17",
     "@1024pix/pix-ui": "^58.4.9",
     "@1024pix/stylelint-config": "^5.1.37",


### PR DESCRIPTION
## 🥀 Problème

Il manque des objets interactifs qui ont été créés dans pix épreuves.

## 🏹 Proposition
Mettre à jour le package pour rendre disponibles les nouveaux objets interactifs :
- test-top-mdp
- template-mail


## 💌 Remarques
RAS

## ❤️‍🔥 Pour tester

Aller sur la page de démo des composants et vérifier que tout roule.
Tests au vert.
