### PR TITLE
[BUGFIX] Corriger la possibilité de reprendre une compétence evaluation (PIX-21501).

### DIFF
--- a/api/src/evaluation/domain/services/algorithm-methods/data-fetcher.js
+++ b/api/src/evaluation/domain/services/algorithm-methods/data-fetcher.js
@@ -31,7 +31,11 @@ async function fetchForCampaigns({
     knowledgeElementRepository,
     improvementService,
   });
-  const [skills, challenges] = await _fetchSkillsAndChallenges({ campaignSkills, challengeRepository, locale });
+  const [skills, challenges] = await _fetchSkillsAndChallenges({
+    campaignSkills,
+    challengeRepository,
+    locale,
+  });
 
   return {
     allAnswers,
@@ -58,14 +62,16 @@ async function _fetchKnowledgeElements({
       campaignParticipationId: assessment.campaignParticipationId,
     });
   } else {
-    knowledgeElements = await knowledgeElementRepository.findUniqByUserId({ userId: assessment.userId });
+    knowledgeElements = await knowledgeElementRepository.findUniqByUserId({
+      userId: assessment.userId,
+    });
   }
 
   return improvementService.filterKnowledgeElements({
     knowledgeElements,
     isFromCampaign,
     isRetrying,
-    isImproving: isImproving ?? assessment.isImproving,
+    isImproving: isImproving || assessment.isImproving,
     createdAt: assessment.createdAt,
   });
 }

--- a/api/tests/evaluation/unit/domain/services/smart-random/data-fetcher_test.js
+++ b/api/tests/evaluation/unit/domain/services/smart-random/data-fetcher_test.js
@@ -52,14 +52,21 @@ describe('Unit | Domain | services | smart-random | dataFetcher', function () {
 
       answerRepository.findByAssessment.withArgs(assessment.id).resolves([answer]);
       campaignRepository.findSkillsByCampaignParticipationId
-        .withArgs({ campaignParticipationId: assessment.campaignParticipationId })
+        .withArgs({
+          campaignParticipationId: assessment.campaignParticipationId,
+        })
         .resolves(skills);
       challengeRepository.findOperativeBySkills.withArgs(skills).resolves(challenges);
       knowledgeElementForParticipationService.findUniqByUserOrCampaignParticipationId
-        .withArgs({ userId: assessment.userId, campaignParticipationId: assessment.campaignParticipationId })
+        .withArgs({
+          userId: assessment.userId,
+          campaignParticipationId: assessment.campaignParticipationId,
+        })
         .resolves(knowledgeElements);
       campaignParticipationRepository.isRetrying
-        .withArgs({ campaignParticipationId: assessment.campaignParticipationId })
+        .withArgs({
+          campaignParticipationId: assessment.campaignParticipationId,
+        })
         .resolves(isRetrying);
       improvementService.filterKnowledgeElements
         .withArgs({
@@ -108,14 +115,21 @@ describe('Unit | Domain | services | smart-random | dataFetcher', function () {
 
       answerRepository.findByAssessment.withArgs(assessment.id).resolves([answer]);
       campaignRepository.findSkillsByCampaignParticipationId
-        .withArgs({ campaignParticipationId: assessment.campaignParticipationId })
+        .withArgs({
+          campaignParticipationId: assessment.campaignParticipationId,
+        })
         .resolves(skills);
       challengeRepository.findOperativeBySkills.withArgs(skills).resolves(challenges);
       knowledgeElementForParticipationService.findUniqByUserOrCampaignParticipationId
-        .withArgs({ userId: assessment.userId, campaignParticipationId: assessment.campaignParticipationId })
+        .withArgs({
+          userId: assessment.userId,
+          campaignParticipationId: assessment.campaignParticipationId,
+        })
         .resolves(knowledgeElements);
       campaignParticipationRepository.isRetrying
-        .withArgs({ campaignParticipationId: assessment.campaignParticipationId })
+        .withArgs({
+          campaignParticipationId: assessment.campaignParticipationId,
+        })
         .resolves(isRetrying);
       improvementService.filterKnowledgeElements
         .withArgs({
@@ -182,7 +196,9 @@ describe('Unit | Domain | services | smart-random | dataFetcher', function () {
       challenges = [domainBuilder.buildChallenge()];
       knowledgeElements = [domainBuilder.buildKnowledgeElement()];
       skills = [domainBuilder.buildSkill()];
-      const assessment = domainBuilder.buildAssessment.ofTypeCompetenceEvaluation();
+      const assessment = domainBuilder.buildAssessment.ofTypeCompetenceEvaluation({
+        isImproving: true,
+      });
       filteredKnowledgeElements = Symbol('filteredKnowledgeElements');
 
       answerRepository.findByAssessment.withArgs(assessment.id).resolves([answer]);


### PR DESCRIPTION
## 🥀 Problème

Erreur de débutant sur un coallesce qui est passé inapercue en revue. 

## 🏹 Proposition

Changer la condition en OU . sachant que pour une campagne IsImproving est toujours à true. 

## 💌 Remarques

Correction du tests unitaire qui ne tester pas correctement le isImproving

Ce service meriterait des tests d'integration à ce noter dans un ticket pour plus tard

## ❤️‍🔥 Pour tester
Faire une compétence evaluation . tout rater. 
Retenter la compétence évaluation et vérifier qu'on vous pose  à nouveau des questions sans être coincé dans une boucle infini. 