### PR TITLE
[FEATURE] Pouvoir modifier le public prescrit d'une organisation (PIX-21248)

### DIFF
--- a/admin/app/adapters/organization-learner-type.js
+++ b/admin/app/adapters/organization-learner-type.js
@@ -1,0 +1,5 @@
+import ApplicationAdapter from './application';
+
+export default class OrganizationLearnerTypeAdapter extends ApplicationAdapter {
+  namespace = 'api/admin';
+}

--- a/admin/app/components/organizations/information-section-edit.gjs
+++ b/admin/app/components/organizations/information-section-edit.gjs
@@ -31,6 +31,7 @@ export default class OrganizationInformationSectionEditionMode extends Component
   @tracked showArchivingConfirmationModal = false;
   @tracked toggleLockPlaces = false;
   @tracked administrationTeams = [];
+  @tracked organizationLearnerTypes = [];
   @tracked countries = [];
 
   noIdentityProviderOption = { label: this.intl.t('common.words.none'), value: 'None' };
@@ -47,6 +48,7 @@ export default class OrganizationInformationSectionEditionMode extends Component
 
   async #loadAsyncData() {
     this.administrationTeams = await this.store.findAll('administration-team');
+    this.organizationLearnerTypes = await this.store.findAll('organization-learner-type');
     this.countries = await this.store.findAll('country');
   }
 
@@ -68,6 +70,9 @@ export default class OrganizationInformationSectionEditionMode extends Component
         ? `${this.args.organization.administrationTeamId}`
         : null,
       countryCode: this.args.organization.countryCode ? `${this.args.organization.countryCode}` : null,
+      organizationLearnerTypeName: this.args.organization.organizationLearnerTypeName
+        ? this.args.organization.organizationLearnerTypeName
+        : null,
     };
   }
 
@@ -92,6 +97,14 @@ export default class OrganizationInformationSectionEditionMode extends Component
       label: administrationTeam.name,
     }));
 
+    return options;
+  }
+
+  get organizationLearnerTypeOptions() {
+    const options = this.organizationLearnerTypes.map((organizationLearnerType) => ({
+      value: organizationLearnerType.name,
+      label: organizationLearnerType.name,
+    }));
     return options;
   }
 
@@ -170,6 +183,7 @@ export default class OrganizationInformationSectionEditionMode extends Component
     this.args.organization.set('administrationTeamName', administrationTeamName);
     this.args.organization.set('countryCode', this.form.countryCode);
     this.args.organization.set('countryName', countryName ?? null);
+    this.args.organization.set('organizationLearnerTypeName', this.form.organizationLearnerTypeName);
 
     this.closeAndResetForm();
     return this.args.onSubmit();
@@ -216,6 +230,25 @@ export default class OrganizationInformationSectionEditionMode extends Component
             @isFullWidth={{true}}
           >
             <:label>{{t "components.organizations.editing.administration-team.selector.label"}}</:label>
+          </PixSelect>
+
+          <PixSelect
+            required
+            @aria-required={{true}}
+            @requiredLabel={{t "common.forms.mandatory"}}
+            @errorMessage={{if
+              this.validator.errors.organizationLearnerTypeName
+              (t this.validator.errors.organizationLearnerTypeName)
+            }}
+            @validationStatus={{if this.validator.errors.organizationLearnerTypeName "error"}}
+            @options={{this.organizationLearnerTypeOptions}}
+            @value={{this.form.organizationLearnerTypeName}}
+            @onChange={{fn this.updateValue "organizationLearnerTypeName"}}
+            @hideDefaultOption={{true}}
+            @isFullWidth={{true}}
+            @placeholder={{t "components.organizations.editing.organization-learner-type.selector.placeholder"}}
+          >
+            <:label>{{t "components.organizations.editing.organization-learner-type.selector.label"}}</:label>
           </PixSelect>
 
           <PixSelect
@@ -420,6 +453,10 @@ const ORGANIZATION_FORM_VALIDATION_SCHEMA = Joi.object({
   countryCode: Joi.string().empty(['', null]).required().messages({
     'any.required': 'components.organizations.editing.country.selector.error-message',
     'string.empty': 'components.organizations.editing.country.selector.error-message',
+  }),
+  organizationLearnerTypeName: Joi.string().empty(['', null]).required().messages({
+    'any.required': 'components.organizations.editing.organization-learner-type.selector.error-message',
+    'string.empty': 'components.organizations.editing.organization-learner-type.selector.error-message',
   }),
   identityProviderForCampaigns: Joi.string().empty(['', null]),
 });

--- a/admin/app/models/organization-learner-type.js
+++ b/admin/app/models/organization-learner-type.js
@@ -1,0 +1,5 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class OrganizationLearnerType extends Model {
+  @attr('string') name;
+}

--- a/admin/tests/acceptance/authenticated/organizations/information-management-test.js
+++ b/admin/tests/acceptance/authenticated/organizations/information-management-test.js
@@ -34,6 +34,7 @@ module('Acceptance | Organizations | Information management', function (hooks) {
         },
         administrationTeamId: 456,
         countryCode: 99100,
+        organizationLearnerTypeName: 'Student',
       });
       this.server.create('organization', { id: '1234', features: { PLACES_MANAGEMENT: { active: true } } });
 

--- a/admin/tests/integration/components/organizations/information-section-edit-test.gjs
+++ b/admin/tests/integration/components/organizations/information-section-edit-test.gjs
@@ -29,6 +29,13 @@ module('Integration | Component | organizations/information-section-edit', funct
         store.createRecord('country', { code: '99101', name: 'Danemark' }),
         store.createRecord('country', { code: '99100', name: 'France' }),
       ]);
+
+    findAllStub
+      .withArgs('organization-learner-type')
+      .resolves([
+        store.createRecord('organization-learner-type', { id: '789', name: 'Student' }),
+        store.createRecord('organization-learner-type', { id: '987', name: 'Teacher' }),
+      ]);
   });
 
   module('organization validation', function (hooks) {
@@ -259,6 +266,36 @@ module('Integration | Component | organizations/information-section-edit', funct
 
       // then
       assert.ok(countryCodeErrorMessage);
+    });
+
+    test('it should show error message if organization learner type is empty', async function (assert) {
+      const organizationWithoutOrganizationLearnerType = EmberObject.create({
+        id: 1,
+        name: 'Organization SCO',
+        externalId: 'VELIT',
+        provinceCode: 'h50',
+        email: 'sco.generic.account@example.net',
+        isOrganizationSCO: true,
+        credit: 0,
+        documentationUrl: 'https://pix.fr/',
+        features: {},
+        administrationTeamId: 123,
+        countryCode: '99100',
+        organizationLearnerTypeName: null,
+      });
+
+      // when
+      const screen = await render(
+        <template><InformationSectionEdit @organization={{organizationWithoutOrganizationLearnerType}} /></template>,
+      );
+      await click(screen.getByRole('button', { name: t('common.actions.save') }));
+
+      const organizationLearnerTypeErrorMessage = screen.getByText(
+        t('components.organizations.editing.organization-learner-type.selector.error-message'),
+      );
+
+      // then
+      assert.ok(organizationLearnerTypeErrorMessage);
     });
 
     module('#features', function () {
@@ -536,6 +573,96 @@ module('Integration | Component | organizations/information-section-edit', funct
       );
     });
   });
+
+  module('organization learner type select', function () {
+    test('it should display select with options loaded', async function (assert) {
+      // given
+      const organization = EmberObject.create({
+        id: 1,
+        name: 'Organization SCO',
+        externalId: 'VELIT',
+        provinceCode: 'h50',
+        email: 'sco.generic.account@example.net',
+        isOrganizationSCO: true,
+        credit: 0,
+        documentationUrl: 'https://pix.fr/',
+        features: {},
+        administrationTeamId: 123,
+        countryCode: 99100,
+      });
+
+      //when
+      const screen = await render(<template><InformationSectionEdit @organization={{organization}} /></template>);
+      await click(
+        screen.getByRole('button', {
+          name: `${t('components.organizations.editing.organization-learner-type.selector.label')} *`,
+        }),
+      );
+      const listbox = await screen.findByRole('listbox');
+
+      //then
+      assert.ok(within(listbox).getByRole('option', { name: 'Student' }));
+      assert.ok(within(listbox).getByRole('option', { name: 'Teacher' }));
+    });
+
+    test('it should display current organization-learner-type as pre-selected option if organization has one', async function (assert) {
+      // given
+      const organization = EmberObject.create({
+        id: 1,
+        name: 'Organization SCO',
+        externalId: 'VELIT',
+        provinceCode: 'h50',
+        email: 'sco.generic.account@example.net',
+        isOrganizationSCO: true,
+        credit: 0,
+        features: {},
+        documentationUrl: 'https://pix.fr/',
+        administrationTeamId: 123,
+        countryCode: 99100,
+        organizationLearnerTypeName: 'Student',
+      });
+      const screen = await render(<template><InformationSectionEdit @organization={{organization}} /></template>);
+
+      // then
+      assert.ok(
+        within(
+          screen.getByRole('button', {
+            name: `${t('components.organizations.editing.organization-learner-type.selector.label')} *`,
+          }),
+        ).getByText('Student'),
+      );
+    });
+
+    test('it should display the placeholder if organization does not have a organization-learner-type', async function (assert) {
+      // given
+      const organization = EmberObject.create({
+        id: 1,
+        name: 'Organization SCO',
+        externalId: 'VELIT',
+        provinceCode: 'h50',
+        email: 'sco.generic.account@example.net',
+        isOrganizationSCO: true,
+        credit: 0,
+        documentationUrl: 'https://pix.fr/',
+        features: {},
+        administrationTeamId: 123,
+        countryCode: 99100,
+        organizationLearnerTypeName: null,
+      });
+
+      //when
+      const screen = await render(<template><InformationSectionEdit @organization={{organization}} /></template>);
+
+      // then
+      assert.ok(
+        within(
+          screen.getByRole('button', {
+            name: `${t('components.organizations.editing.organization-learner-type.selector.label')} *`,
+          }),
+        ).getByText(t('components.organizations.editing.organization-learner-type.selector.placeholder')),
+      );
+    });
+  });
 });
 
 module('Rendering', function (hooks) {
@@ -556,6 +683,13 @@ module('Rendering', function (hooks) {
       .resolves([
         store.createRecord('country', { code: '99101', name: 'Danemark' }),
         store.createRecord('country', { code: '99100', name: 'France' }),
+      ]);
+
+    findAllStub
+      .withArgs('organization-learner-type')
+      .resolves([
+        store.createRecord('organization-learner-type', { id: '789', name: 'Student' }),
+        store.createRecord('organization-learner-type', { id: '987', name: 'Teacher' }),
       ]);
 
     class AccessControlStub extends Service {

--- a/admin/tests/integration/components/organizations/information-section-test.gjs
+++ b/admin/tests/integration/components/organizations/information-section-test.gjs
@@ -34,6 +34,13 @@ module('Integration | Component | organizations/information-section', function (
         store.createRecord('country', { code: '99101', name: 'Danemark' }),
         store.createRecord('country', { code: '99100', name: 'France' }),
       ]);
+
+    findAllStub
+      .withArgs('organization-learner-type')
+      .resolves([
+        store.createRecord('organization-learner-type', { id: '789', name: 'Student' }),
+        store.createRecord('organization-learner-type', { id: '987', name: 'Teacher' }),
+      ]);
   });
 
   module('when editing organization', function () {
@@ -49,6 +56,7 @@ module('Integration | Component | organizations/information-section', function (
       features: {},
       administrationTeamId: 123,
       countryCode: 99100,
+      organizationLearnerTypeName: 'Student',
     });
 
     test('it should toggle edition mode on click to edit button', async function (assert) {

--- a/admin/tests/mirage/routes.js
+++ b/admin/tests/mirage/routes.js
@@ -682,6 +682,27 @@ export default function routes() {
     };
   });
 
+  this.get('/admin/organization-learner-types', async () => {
+    return {
+      data: [
+        {
+          type: 'organization-learner-type',
+          id: '2',
+          attributes: {
+            name: 'Student',
+          },
+        },
+        {
+          type: 'organization-learner-type',
+          id: '1',
+          attributes: {
+            name: 'Teacher',
+          },
+        },
+      ],
+    };
+  });
+
   this.get('/admin/oidc/identity-providers', () => {
     return {
       data: [

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -741,6 +741,13 @@
         "name": {
           "label": "Name"
         },
+        "organization-learner-type": {
+          "selector": {
+            "error-message": "Organization learner type is required",
+            "label": "Organization learner type",
+            "placeholder": "Choose an organization learner type"
+          }
+        },
         "province-code": {
           "label": "Province code (3 digits)"
         },

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -743,6 +743,13 @@
         "name": {
           "label": "Nom"
         },
+        "organization-learner-type": {
+          "selector": {
+            "error-message": "Le public prescrit est requis",
+            "label": "Public prescrit",
+            "placeholder": "Sélectionner un public prescrit"
+          }
+        },
         "province-code": {
           "label": "Département (en 3 chiffres)"
         },

--- a/api/src/organizational-entities/domain/usecases/update-organization-information.usecase.js
+++ b/api/src/organizational-entities/domain/usecases/update-organization-information.usecase.js
@@ -13,7 +13,7 @@ const updateOrganizationInformation = withTransaction(async function ({
   const existingOrganization = await organizationForAdminRepository.get({ organizationId: organization.id });
 
   let organizationLearnerType;
-  if (organization.organizationLearnerType) {
+  if (organization.organizationLearnerType?.name) {
     try {
       organizationLearnerType = await organizationLearnerTypeRepository.getByName(
         organization.organizationLearnerType.name,

--- a/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
@@ -191,16 +191,6 @@ const get = async function ({ organizationId }) {
     return new Tag(tag);
   });
 
-  // TODO: supprimer la condition quand organizationLearnerTypeId sera not-nullable à la fin de l'epix PIX-19561
-  if (organization.organizationLearnerTypeId) {
-    organization.organizationLearnerType = new OrganizationLearnerType({
-      id: organization.organizationLearnerTypeId,
-      name: organization.organizationLearnerTypeName,
-    });
-  } else {
-    organization.organizationLearnerType = null;
-  }
-
   return _toDomain(organization);
 };
 
@@ -489,10 +479,25 @@ function _toDomain(rawOrganization) {
     administrationTeamId: rawOrganization.administrationTeamId,
     administrationTeamName: rawOrganization.administrationTeamName,
     countryCode: rawOrganization.countryCode,
-    organizationLearnerType: rawOrganization.organizationLearnerType,
+    organizationLearnerType: _createOrganizationLearnerType(
+      rawOrganization.organizationLearnerTypeId,
+      rawOrganization.organizationLearnerTypeName,
+    ),
   });
 
   return organization;
+}
+
+function _createOrganizationLearnerType(organizationLearnerTypeId, organizationLearnerTypeName) {
+  // TODO: supprimer la condition quand organizationLearnerTypeId sera not-nullable à la fin de l'epix PIX-19561
+  if (organizationLearnerTypeId) {
+    return new OrganizationLearnerType({
+      id: organizationLearnerTypeId,
+      name: organizationLearnerTypeName,
+    });
+  } else {
+    return null;
+  }
 }
 
 export const organizationForAdminRepository = {

--- a/api/src/organizational-entities/infrastructure/serializers/jsonapi/organization-learner-type/organization-learner-type-serializer.js
+++ b/api/src/organizational-entities/infrastructure/serializers/jsonapi/organization-learner-type/organization-learner-type-serializer.js
@@ -4,11 +4,6 @@ const { Serializer } = jsonapiSerializer;
 
 const serialize = function (organizationLearnerType) {
   return new Serializer('organization-learner-types', {
-    transform(record) {
-      return {
-        name: record.name,
-      };
-    },
     attributes: ['name'],
   }).serialize(organizationLearnerType);
 };

--- a/api/src/organizational-entities/infrastructure/serializers/jsonapi/organizations-administration/organization-for-admin.serializer.js
+++ b/api/src/organizational-entities/infrastructure/serializers/jsonapi/organizations-administration/organization-for-admin.serializer.js
@@ -2,6 +2,7 @@ import { Serializer } from 'jsonapi-serializer';
 import _ from 'lodash';
 
 import { OrganizationForAdmin } from '../../../../domain/models/OrganizationForAdmin.js';
+import { OrganizationLearnerType } from '../../../../domain/models/OrganizationLearnerType.js';
 
 const serialize = function (organizations, meta) {
   return new Serializer('organizations', {
@@ -140,6 +141,10 @@ const deserialize = function (json) {
     features: attributes.features,
     tagIds,
     countryCode: attributes['country-code'] && parseInt(attributes['country-code']),
+    organizationLearnerType: new OrganizationLearnerType({
+      id: undefined,
+      name: attributes['organization-learner-type-name'],
+    }),
   });
   return organization;
 };

--- a/api/tests/organizational-entities/acceptance/application/organization-learner-type/organization-learner-type.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/organization-learner-type/organization-learner-type.admin.route.test.js
@@ -11,8 +11,14 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
     it('returns a list of organization learner types with 200 HTTP status code', async function () {
       // given
       const server = await createServer();
-      const organizationLearnerType1 = databaseBuilder.factory.buildOrganizationLearnerType({ name: 'Public 1' });
-      const organizationLearnerType2 = databaseBuilder.factory.buildOrganizationLearnerType({ name: 'Public 2' });
+      const organizationLearnerType1 = databaseBuilder.factory.buildOrganizationLearnerType({
+        id: 123,
+        name: 'Public 1',
+      });
+      const organizationLearnerType2 = databaseBuilder.factory.buildOrganizationLearnerType({
+        id: 456,
+        name: 'Public 2',
+      });
       await databaseBuilder.commit();
       const userId = (await insertUserWithRoleSuperAdmin()).id;
       const options = {
@@ -25,12 +31,14 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
           attributes: {
             name: organizationLearnerType1.name,
           },
+          id: '123',
           type: 'organization-learner-types',
         },
         {
           attributes: {
             name: organizationLearnerType2.name,
           },
+          id: '456',
           type: 'organization-learner-types',
         },
       ];

--- a/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
@@ -1,9 +1,9 @@
-import iconv from "iconv-lite";
-import lodash from "lodash";
+import iconv from 'iconv-lite';
+import lodash from 'lodash';
 
-import { PIX_ADMIN } from "../../../../../src/authorization/domain/constants.js";
-import { ORGANIZATION_FEATURE } from "../../../../../src/shared/domain/constants.js";
-import { Membership } from "../../../../../src/shared/domain/models/Membership.js";
+import { PIX_ADMIN } from '../../../../../src/authorization/domain/constants.js';
+import { ORGANIZATION_FEATURE } from '../../../../../src/shared/domain/constants.js';
+import { Membership } from '../../../../../src/shared/domain/models/Membership.js';
 import {
   createServer,
   databaseBuilder,
@@ -12,12 +12,12 @@ import {
   insertMultipleSendingFeatureForNewOrganization,
   insertUserWithRoleSuperAdmin,
   knex,
-} from "../../../../test-helper.js";
+} from '../../../../test-helper.js';
 
 const { ROLES } = PIX_ADMIN;
 const { map: _map } = lodash;
 
-describe("Acceptance | Organizational Entities | Application | Route | Admin | Organization", function () {
+describe('Acceptance | Organizational Entities | Application | Route | Admin | Organization', function () {
   let superAdmin;
   let server;
 
@@ -29,15 +29,15 @@ describe("Acceptance | Organizational Entities | Application | Route | Admin | O
     server = await createServer();
   });
 
-  describe("GET /api/admin/organizations/import-csv/template", function () {
-    it("responds with a 200", async function () {
+  describe('GET /api/admin/organizations/import-csv/template', function () {
+    it('responds with a 200', async function () {
       // given
       const options = {
-        method: "GET",
+        method: 'GET',
         headers: generateAuthenticatedUserRequestHeaders({
           userId: superAdmin.id,
         }),
-        url: "/api/admin/organizations/import-csv/template",
+        url: '/api/admin/organizations/import-csv/template',
       };
 
       // when
@@ -48,38 +48,35 @@ describe("Acceptance | Organizational Entities | Application | Route | Admin | O
     });
   });
 
-  describe("POST /api/admin/organizations/import-csv", function () {
-    it("create organizations for the given csv file", async function () {
+  describe('POST /api/admin/organizations/import-csv', function () {
+    it('create organizations for the given csv file', async function () {
       // given
       const superAdminUserId = databaseBuilder.factory.buildUser.withRole().id;
-      databaseBuilder.factory.buildTag({ name: "GRAS" });
-      databaseBuilder.factory.buildTag({ name: "GARGOUILLE" });
-      databaseBuilder.factory.buildTag({ name: "GARBURE" });
-      databaseBuilder.factory.buildFeature(
-        ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY,
-      );
+      databaseBuilder.factory.buildTag({ name: 'GRAS' });
+      databaseBuilder.factory.buildTag({ name: 'GARGOUILLE' });
+      databaseBuilder.factory.buildTag({ name: 'GARBURE' });
+      databaseBuilder.factory.buildFeature(ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY);
       databaseBuilder.factory.buildAdministrationTeam({ id: 1234 });
       databaseBuilder.factory.buildCertificationCpfCountry({
         code: 99100,
-        commonName: "France",
-        originalName: "France",
+        commonName: 'France',
+        originalName: 'France',
       });
       const organizationId = databaseBuilder.factory.buildOrganization().id;
-      const parentOrganizationId =
-        databaseBuilder.factory.buildOrganization().id;
+      const parentOrganizationId = databaseBuilder.factory.buildOrganization().id;
       const targetProfileId = databaseBuilder.factory.buildTargetProfile({
         ownerOrganizationId: organizationId,
       }).id;
       await databaseBuilder.commit();
 
       const buffer =
-        "type,externalId,name,provinceCode,credit,createdBy,documentationUrl,identityProviderForCampaigns,isManagingStudents,emailForSCOActivation,DPOFirstName,DPOLastName,DPOEmail,emailInvitations,organizationInvitationRole,locale,tags,targetProfiles,administrationTeamId,parentOrganizationId,countryCode\n" +
+        'type,externalId,name,provinceCode,credit,createdBy,documentationUrl,identityProviderForCampaigns,isManagingStudents,emailForSCOActivation,DPOFirstName,DPOLastName,DPOEmail,emailInvitations,organizationInvitationRole,locale,tags,targetProfiles,administrationTeamId,parentOrganizationId,countryCode\n' +
         `SCO,ANNEGRAELLE,Orga des Anne-Graelle,33700,666,${superAdminUserId},url.com,,true,,Anne,Graelle,anne-graelle@example.net,,ADMIN,fr,GRAS_GARGOUILLE,${targetProfileId},1234,,99100\n` +
         `PRO,ANNEGARBURE,Orga des Anne-Garbure,33700,999,${superAdminUserId},,,,,Anne,Garbure,anne-garbure@example.net,,ADMIN,fr,GARBURE,${targetProfileId},1234,${parentOrganizationId},99100`;
 
       // when
       const response = await server.inject({
-        method: "POST",
+        method: 'POST',
         url: `/api/admin/organizations/import-csv`,
         headers: generateAuthenticatedUserRequestHeaders({
           userId: superAdminUserId,
@@ -90,34 +87,30 @@ describe("Acceptance | Organizational Entities | Application | Route | Admin | O
       // then
       expect(response.statusCode).to.equal(201);
 
-      const organizations = await knex("organizations");
+      const organizations = await knex('organizations');
       expect(organizations).to.have.lengthOf(4);
 
-      const firstOrganizationCreated = organizations.find(
-        (organization) => organization.externalId === "ANNEGRAELLE",
-      );
+      const firstOrganizationCreated = organizations.find((organization) => organization.externalId === 'ANNEGRAELLE');
       expect(firstOrganizationCreated).to.deep.include({
-        type: "SCO",
-        externalId: "ANNEGRAELLE",
-        name: "Orga des Anne-Graelle",
-        provinceCode: "33700",
+        type: 'SCO',
+        externalId: 'ANNEGRAELLE',
+        name: 'Orga des Anne-Graelle',
+        provinceCode: '33700',
         credit: 666,
         createdBy: superAdminUserId,
-        documentationUrl: "url.com",
+        documentationUrl: 'url.com',
         identityProviderForCampaigns: null,
         isManagingStudents: true,
         parentOrganizationId: null,
         countryCode: 99100,
       });
 
-      const secondOrganizationCreated = organizations.find(
-        (organization) => organization.externalId === "ANNEGARBURE",
-      );
+      const secondOrganizationCreated = organizations.find((organization) => organization.externalId === 'ANNEGARBURE');
       expect(secondOrganizationCreated).to.deep.include({
-        type: "PRO",
-        externalId: "ANNEGARBURE",
-        name: "Orga des Anne-Garbure",
-        provinceCode: "33700",
+        type: 'PRO',
+        externalId: 'ANNEGARBURE',
+        name: 'Orga des Anne-Garbure',
+        provinceCode: '33700',
         credit: 999,
         createdBy: superAdminUserId,
         identityProviderForCampaigns: null,
@@ -126,40 +119,39 @@ describe("Acceptance | Organizational Entities | Application | Route | Admin | O
         countryCode: 99100,
       });
 
-      const dataProtectionOfficers = await knex("data-protection-officers");
+      const dataProtectionOfficers = await knex('data-protection-officers');
       expect(dataProtectionOfficers).to.have.lengthOf(2);
 
-      const targetProfileShares = await knex("target-profile-shares");
+      const targetProfileShares = await knex('target-profile-shares');
       expect(targetProfileShares).to.have.lengthOf(2);
 
       const firstTargetProfileShare = targetProfileShares.find(
-        (targetProfileShare) =>
-          targetProfileShare.organizationId === firstOrganizationCreated.id,
+        (targetProfileShare) => targetProfileShare.organizationId === firstOrganizationCreated.id,
       );
       expect(firstTargetProfileShare).to.deep.include({
         organizationId: firstOrganizationCreated.id,
         targetProfileId,
       });
 
-      const firstOrganizationTags = await knex("organization-tags").where({
+      const firstOrganizationTags = await knex('organization-tags').where({
         organizationId: firstOrganizationCreated.id,
       });
       expect(firstOrganizationTags).to.have.lengthOf(2);
     });
   });
 
-  describe("GET /api/admin/organizations/{organizationId}/children", function () {
-    context("error cases", function () {
-      context("when organization does not exist", function () {
-        it("returns a 404 HTTP status code with an error message", async function () {
+  describe('GET /api/admin/organizations/{organizationId}/children', function () {
+    context('error cases', function () {
+      context('when organization does not exist', function () {
+        it('returns a 404 HTTP status code with an error message', async function () {
           // given
           const userId = databaseBuilder.factory.buildUser.withRole().id;
 
           await databaseBuilder.commit();
 
           const request = {
-            method: "GET",
-            url: "/api/admin/organizations/986532/children",
+            method: 'GET',
+            url: '/api/admin/organizations/986532/children',
             headers: generateAuthenticatedUserRequestHeaders({ userId }),
           };
 
@@ -168,63 +160,56 @@ describe("Acceptance | Organizational Entities | Application | Route | Admin | O
 
           // then
           expect(response.statusCode).to.equal(404);
-          expect(response.result.errors[0].detail).to.equal(
-            "Organization with ID (986532) not found",
-          );
+          expect(response.result.errors[0].detail).to.equal('Organization with ID (986532) not found');
         });
       });
 
-      context(
-        "when the user does not have access to the resource",
-        function () {
-          it("returns a 403 HTTP status code with an error message", async function () {
-            // given
-            const userId = databaseBuilder.factory.buildUser().id;
-            const organizationId =
-              databaseBuilder.factory.buildOrganization().id;
+      context('when the user does not have access to the resource', function () {
+        it('returns a 403 HTTP status code with an error message', async function () {
+          // given
+          const userId = databaseBuilder.factory.buildUser().id;
+          const organizationId = databaseBuilder.factory.buildOrganization().id;
 
-            await databaseBuilder.commit();
+          await databaseBuilder.commit();
 
-            const request = {
-              method: "GET",
-              url: `/api/admin/organizations/${organizationId}/children`,
-              headers: generateAuthenticatedUserRequestHeaders({ userId }),
-            };
+          const request = {
+            method: 'GET',
+            url: `/api/admin/organizations/${organizationId}/children`,
+            headers: generateAuthenticatedUserRequestHeaders({ userId }),
+          };
 
-            // when
-            const response = await server.inject(request);
+          // when
+          const response = await server.inject(request);
 
-            // then
-            expect(response.statusCode).to.equal(403);
-          });
-        },
-      );
+          // then
+          expect(response.statusCode).to.equal(403);
+        });
+      });
     });
 
-    context("success cases", function () {
+    context('success cases', function () {
       Object.keys(ROLES).forEach((role) => {
         context(`when user has role ${role}`, function () {
-          it("returns child organizations list with a 200 HTTP status code", async function () {
+          it('returns child organizations list with a 200 HTTP status code', async function () {
             // given
             const userId = databaseBuilder.factory.buildUser.withRole({
               role,
             }).id;
-            const parentOrganizationId =
-              databaseBuilder.factory.buildOrganization().id;
+            const parentOrganizationId = databaseBuilder.factory.buildOrganization().id;
 
             const firstChildId =
               databaseBuilder.factory.buildOrganization({
                 parentOrganizationId,
-              }).id + "";
+              }).id + '';
             const secondChildId =
               databaseBuilder.factory.buildOrganization({
                 parentOrganizationId,
-              }).id + "";
+              }).id + '';
 
             await databaseBuilder.commit();
 
             const request = {
-              method: "GET",
+              method: 'GET',
               url: `/api/admin/organizations/${parentOrganizationId}/children`,
               headers: generateAuthenticatedUserRequestHeaders({ userId }),
             };
@@ -234,45 +219,40 @@ describe("Acceptance | Organizational Entities | Application | Route | Admin | O
             // then
             expect(response.statusCode).to.equal(200);
             expect(response.result.data).to.have.lengthOf(2);
-            expect(_map(response.result.data, "id")).to.have.members([
-              firstChildId,
-              secondChildId,
-            ]);
+            expect(_map(response.result.data, 'id')).to.have.members([firstChildId, secondChildId]);
           });
         });
       });
     });
   });
 
-  describe("GET /api/admin/organizations", function () {
+  describe('GET /api/admin/organizations', function () {
     let options;
 
     beforeEach(async function () {
       const userSuperAdmin = databaseBuilder.factory.buildUser.withRole();
 
-      const administrationTeamId1 =
-        databaseBuilder.factory.buildAdministrationTeam({ id: 56789 }).id;
-      const administrationTeamId2 =
-        databaseBuilder.factory.buildAdministrationTeam({ id: 1234 }).id;
+      const administrationTeamId1 = databaseBuilder.factory.buildAdministrationTeam({ id: 56789 }).id;
+      const administrationTeamId2 = databaseBuilder.factory.buildAdministrationTeam({ id: 1234 }).id;
 
       databaseBuilder.factory.buildOrganization({
         id: 1,
-        name: "The name of the organization",
-        type: "SUP",
-        externalId: "1234567A",
+        name: 'The name of the organization',
+        type: 'SUP',
+        externalId: '1234567A',
         administrationTeamId: administrationTeamId1,
       });
       databaseBuilder.factory.buildOrganization({
         id: 2,
-        name: "Organization of the night",
-        type: "PRO",
-        externalId: "1234568A",
+        name: 'Organization of the night',
+        type: 'PRO',
+        externalId: '1234568A',
         administrationTeamId: administrationTeamId2,
       });
 
       options = {
-        method: "GET",
-        url: "/api/admin/organizations",
+        method: 'GET',
+        url: '/api/admin/organizations',
         payload: {},
         headers: generateAuthenticatedUserRequestHeaders({
           userId: userSuperAdmin.id,
@@ -282,10 +262,10 @@ describe("Acceptance | Organizational Entities | Application | Route | Admin | O
       return databaseBuilder.commit();
     });
 
-    describe("Resource access management", function () {
-      it("should respond with a 401 - unauthorized access - if user is not authenticated", async function () {
+    describe('Resource access management', function () {
+      it('should respond with a 401 - unauthorized access - if user is not authenticated', async function () {
         // given
-        options.headers.authorization = "invalid.access.token";
+        options.headers.authorization = 'invalid.access.token';
 
         // when
         const response = await server.inject(options);
@@ -294,7 +274,7 @@ describe("Acceptance | Organizational Entities | Application | Route | Admin | O
         expect(response.statusCode).to.equal(401);
       });
 
-      it("should respond with a 403 - forbidden access - if user has not role Super Admin", async function () {
+      it('should respond with a 403 - forbidden access - if user has not role Super Admin', async function () {
         // given
         const nonSuperAdminUserId = 9999;
         options.headers = generateAuthenticatedUserRequestHeaders({
@@ -309,18 +289,18 @@ describe("Acceptance | Organizational Entities | Application | Route | Admin | O
       });
     });
 
-    describe("Success case", function () {
-      it("should return a 200 status code response with JSON API serialized", async function () {
+    describe('Success case', function () {
+      it('should return a 200 status code response with JSON API serialized', async function () {
         // when
         const response = await server.inject(options);
 
         // then
         expect(response.statusCode).to.equal(200);
         expect(response.result.data).to.have.lengthOf(2);
-        expect(response.result.data[0].type).to.equal("organizations");
+        expect(response.result.data[0].type).to.equal('organizations');
       });
 
-      it("should return pagination meta data", async function () {
+      it('should return pagination meta data', async function () {
         // given
         const expectedMetaData = {
           page: 1,
@@ -336,10 +316,9 @@ describe("Acceptance | Organizational Entities | Application | Route | Admin | O
         expect(response.result.meta).to.deep.equal(expectedMetaData);
       });
 
-      it("should return a 200 status code with paginated and filtered data", async function () {
+      it('should return a 200 status code with paginated and filtered data', async function () {
         // given
-        options.url =
-          "/api/admin/organizations?filter[name]=orga&filter[externalId]=A&page[number]=2&page[size]=1";
+        options.url = '/api/admin/organizations?filter[name]=orga&filter[externalId]=A&page[number]=2&page[size]=1';
         const expectedMetaData = {
           page: 2,
           pageSize: 1,
@@ -354,13 +333,13 @@ describe("Acceptance | Organizational Entities | Application | Route | Admin | O
         expect(response.statusCode).to.equal(200);
         expect(response.result.meta).to.deep.equal(expectedMetaData);
         expect(response.result.data).to.have.lengthOf(1);
-        expect(response.result.data[0].type).to.equal("organizations");
+        expect(response.result.data[0].type).to.equal('organizations');
       });
 
-      it("should return a 200 status code with filtered data", async function () {
+      it('should return a 200 status code with filtered data', async function () {
         // given
         options.url =
-          "/api/admin/organizations?filter[name]=Organization of the night&filter[externalId]=1234568A&filter[administrationTeamId]=1234&page[number]=1&page[size]=2";
+          '/api/admin/organizations?filter[name]=Organization of the night&filter[externalId]=1234568A&filter[administrationTeamId]=1234&page[number]=1&page[size]=2';
         const expectedMetaData = {
           page: 1,
           pageSize: 2,
@@ -375,14 +354,14 @@ describe("Acceptance | Organizational Entities | Application | Route | Admin | O
         expect(response.statusCode).to.equal(200);
         expect(response.result.meta).to.deep.equal(expectedMetaData);
         expect(response.result.data).to.have.lengthOf(1);
-        expect(response.result.data[0].type).to.equal("organizations");
-        expect(response.result.data[0].id).to.equal("2");
+        expect(response.result.data[0].type).to.equal('organizations');
+        expect(response.result.data[0].id).to.equal('2');
       });
 
-      it("should return a 200 status code with empty result", async function () {
+      it('should return a 200 status code with empty result', async function () {
         // given
         options.url =
-          "/api/admin/organizations?filter[name]=orga&filter[type]=sco&filter[externalId]=B&page[number]=1&page[size]=1";
+          '/api/admin/organizations?filter[name]=orga&filter[type]=sco&filter[externalId]=B&page[number]=1&page[size]=1';
         const expectedMetaData = {
           page: 1,
           pageSize: 1,
@@ -401,62 +380,61 @@ describe("Acceptance | Organizational Entities | Application | Route | Admin | O
     });
   });
 
-  describe("POST /api/admin/organizations", function () {
+  describe('POST /api/admin/organizations', function () {
     let payload;
     let options;
 
     beforeEach(function () {
       payload = {
         data: {
-          type: "organizations",
+          type: 'organizations',
           attributes: {
-            name: "The name of the organization",
-            type: "PRO",
-            "documentation-url": "https://kingArthur.com",
+            name: 'The name of the organization',
+            type: 'PRO',
+            'documentation-url': 'https://kingArthur.com',
           },
         },
       };
       options = {
-        method: "POST",
-        url: "/api/admin/organizations",
+        method: 'POST',
+        url: '/api/admin/organizations',
         payload,
         headers: generateAuthenticatedUserRequestHeaders(),
       };
     });
 
-    describe("Success case", function () {
-      context("when no parent organization id is provided", function () {
-        it("returns 200 HTTP status code with the created organization", async function () {
+    describe('Success case', function () {
+      context('when no parent organization id is provided', function () {
+        it('returns 200 HTTP status code with the created organization', async function () {
           // given
-          const superAdminUserId =
-            databaseBuilder.factory.buildUser.withRole().id;
+          const superAdminUserId = databaseBuilder.factory.buildUser.withRole().id;
           databaseBuilder.factory.buildAdministrationTeam({
             id: 1234,
-            name: "Équipe 1",
+            name: 'Équipe 1',
           });
           databaseBuilder.factory.buildCertificationCpfCountry({
             code: 99100,
-            commonName: "France",
-            originalName: "France",
+            commonName: 'France',
+            originalName: 'France',
           });
           await databaseBuilder.commit();
 
           // when
           const { result, statusCode } = await server.inject({
-            method: "POST",
-            url: "/api/admin/organizations",
+            method: 'POST',
+            url: '/api/admin/organizations',
             payload: {
               data: {
-                type: "organizations",
+                type: 'organizations',
                 attributes: {
-                  name: "The name of the organization",
-                  type: "PRO",
-                  "documentation-url": "https://kingArthur.com",
-                  "data-protection-officer-email": "justin.ptipeu@example.net",
-                  "administration-team-id": 1234,
-                  "country-code": 99100,
-                  "external-id": "My external Id",
-                  "province-code": "078",
+                  name: 'The name of the organization',
+                  type: 'PRO',
+                  'documentation-url': 'https://kingArthur.com',
+                  'data-protection-officer-email': 'justin.ptipeu@example.net',
+                  'administration-team-id': 1234,
+                  'country-code': 99100,
+                  'external-id': 'My external Id',
+                  'province-code': '078',
                 },
               },
             },
@@ -469,56 +447,48 @@ describe("Acceptance | Organizational Entities | Application | Route | Admin | O
           const createdOrganization = result.data.attributes;
 
           expect(statusCode).to.equal(200);
-          expect(createdOrganization.name).to.equal(
-            "The name of the organization",
-          );
-          expect(createdOrganization.type).to.equal("PRO");
-          expect(createdOrganization["documentation-url"]).to.equal(
-            "https://kingArthur.com",
-          );
-          expect(createdOrganization["data-protection-officer-email"]).to.equal(
-            "justin.ptipeu@example.net",
-          );
-          expect(createdOrganization["created-by"]).to.equal(superAdminUserId);
-          expect(createdOrganization["country-code"]).to.equal(99100);
-          expect(createdOrganization["external-id"]).to.equal("My external Id");
-          expect(createdOrganization["province-code"]).to.equal("078");
+          expect(createdOrganization.name).to.equal('The name of the organization');
+          expect(createdOrganization.type).to.equal('PRO');
+          expect(createdOrganization['documentation-url']).to.equal('https://kingArthur.com');
+          expect(createdOrganization['data-protection-officer-email']).to.equal('justin.ptipeu@example.net');
+          expect(createdOrganization['created-by']).to.equal(superAdminUserId);
+          expect(createdOrganization['country-code']).to.equal(99100);
+          expect(createdOrganization['external-id']).to.equal('My external Id');
+          expect(createdOrganization['province-code']).to.equal('078');
         });
       });
 
-      context("when a parent organization id is provided", function () {
-        it("returns 200 HTTP status code with the created child organization", async function () {
+      context('when a parent organization id is provided', function () {
+        it('returns 200 HTTP status code with the created child organization', async function () {
           // given
-          const superAdminUserId =
-            databaseBuilder.factory.buildUser.withRole().id;
+          const superAdminUserId = databaseBuilder.factory.buildUser.withRole().id;
           databaseBuilder.factory.buildAdministrationTeam({
             id: 1234,
-            name: "Équipe 1",
+            name: 'Équipe 1',
           });
           databaseBuilder.factory.buildCertificationCpfCountry({
             code: 99100,
-            commonName: "France",
-            originalName: "France",
+            commonName: 'France',
+            originalName: 'France',
           });
-          const parentOrganizationId =
-            databaseBuilder.factory.buildOrganization().id;
+          const parentOrganizationId = databaseBuilder.factory.buildOrganization().id;
           await databaseBuilder.commit();
 
           // when
           const { result, statusCode } = await server.inject({
-            method: "POST",
+            method: 'POST',
             url: `/api/admin/organizations`,
             payload: {
               data: {
-                type: "organizations",
+                type: 'organizations',
                 attributes: {
-                  name: "The name of the organization",
-                  type: "PRO",
-                  "documentation-url": "https://kingArthur.com",
-                  "data-protection-officer-email": "justin.ptipeu@example.net",
-                  "administration-team-id": 1234,
-                  "parent-organization-id": parentOrganizationId,
-                  "country-code": 99100,
+                  name: 'The name of the organization',
+                  type: 'PRO',
+                  'documentation-url': 'https://kingArthur.com',
+                  'data-protection-officer-email': 'justin.ptipeu@example.net',
+                  'administration-team-id': 1234,
+                  'parent-organization-id': parentOrganizationId,
+                  'country-code': 99100,
                 },
               },
             },
@@ -531,28 +501,20 @@ describe("Acceptance | Organizational Entities | Application | Route | Admin | O
           const createdOrganization = result.data.attributes;
 
           expect(statusCode).to.equal(200);
-          expect(createdOrganization.name).to.equal(
-            "The name of the organization",
-          );
-          expect(createdOrganization.type).to.equal("PRO");
-          expect(createdOrganization["documentation-url"]).to.equal(
-            "https://kingArthur.com",
-          );
-          expect(createdOrganization["data-protection-officer-email"]).to.equal(
-            "justin.ptipeu@example.net",
-          );
-          expect(createdOrganization["created-by"]).to.equal(superAdminUserId);
-          expect(createdOrganization["parent-organization-id"]).to.equal(
-            parentOrganizationId,
-          );
+          expect(createdOrganization.name).to.equal('The name of the organization');
+          expect(createdOrganization.type).to.equal('PRO');
+          expect(createdOrganization['documentation-url']).to.equal('https://kingArthur.com');
+          expect(createdOrganization['data-protection-officer-email']).to.equal('justin.ptipeu@example.net');
+          expect(createdOrganization['created-by']).to.equal(superAdminUserId);
+          expect(createdOrganization['parent-organization-id']).to.equal(parentOrganizationId);
         });
       });
     });
 
-    describe("when creating with a wrong payload (ex: organization type is wrong)", function () {
-      it("should return 422 HTTP status code", async function () {
+    describe('when creating with a wrong payload (ex: organization type is wrong)', function () {
+      it('should return 422 HTTP status code', async function () {
         // given
-        payload.data.attributes.type = "FAK";
+        payload.data.attributes.type = 'FAK';
 
         // then
         const response = await server.inject(options);
@@ -561,17 +523,17 @@ describe("Acceptance | Organizational Entities | Application | Route | Admin | O
         expect(response.statusCode).to.equal(422);
       });
 
-      it("should not keep the user in the database", async function () {
+      it('should not keep the user in the database', async function () {
         // given
-        payload.data.attributes.type = "FAK";
+        payload.data.attributes.type = 'FAK';
 
         // then
         const creatingOrganizationOnFailure = server.inject(options);
 
         // then
         return creatingOrganizationOnFailure.then(() => {
-          return knex("users")
-            .count("id as id")
+          return knex('users')
+            .count('id as id')
             .then((count) => {
               expect(parseInt(count[0].id, 10)).to.equal(1);
             });
@@ -579,10 +541,10 @@ describe("Acceptance | Organizational Entities | Application | Route | Admin | O
       });
     });
 
-    describe("Resource access management", function () {
-      it("should respond with a 401 - unauthorized access - if user is not authenticated", function () {
+    describe('Resource access management', function () {
+      it('should respond with a 401 - unauthorized access - if user is not authenticated', function () {
         // given
-        options.headers.authorization = "invalid.access.token";
+        options.headers.authorization = 'invalid.access.token';
 
         // when
         const promise = server.inject(options);
@@ -593,7 +555,7 @@ describe("Acceptance | Organizational Entities | Application | Route | Admin | O
         });
       });
 
-      it("should respond with a 403 - forbidden access - if user has not role Super Admin", function () {
+      it('should respond with a 403 - forbidden access - if user has not role Super Admin', function () {
         // given
         const nonSuperAdminUserId = 9999;
         options.headers = generateAuthenticatedUserRequestHeaders({
@@ -611,61 +573,57 @@ describe("Acceptance | Organizational Entities | Application | Route | Admin | O
     });
   });
 
-  describe("GET /api/admin/organizations/{organizationId}", function () {
-    context("Expected output", function () {
-      it("should return the matching organization as JSON API", async function () {
+  describe('GET /api/admin/organizations/{organizationId}', function () {
+    context('Expected output', function () {
+      it('should return the matching organization as JSON API', async function () {
         // given
         const superAdminUserId = databaseBuilder.factory.buildUser.withRole({
           id: 983733,
-          firstName: "Tom",
-          lastName: "Dereck",
+          firstName: 'Tom',
+          lastName: 'Dereck',
         }).id;
 
         const archivist = databaseBuilder.factory.buildUser({
-          firstName: "Jean",
-          lastName: "Bonneau",
+          firstName: 'Jean',
+          lastName: 'Bonneau',
         });
-        const archivedAt = new Date("2019-04-28T02:42:00Z");
-        const createdAt = new Date("2019-04-28T02:42:00Z");
+        const archivedAt = new Date('2019-04-28T02:42:00Z');
+        const createdAt = new Date('2019-04-28T02:42:00Z');
 
-        const administrationTeam =
-          databaseBuilder.factory.buildAdministrationTeam();
+        const administrationTeam = databaseBuilder.factory.buildAdministrationTeam();
 
         const country = databaseBuilder.factory.buildCertificationCpfCountry({
           code: 99100,
-          commonName: "France",
-          originalName: "France",
+          commonName: 'France',
+          originalName: 'France',
         });
 
         const organization = databaseBuilder.factory.buildOrganization({
-          type: "SCO",
-          name: "Organization catalina",
-          logoUrl: "some logo url",
-          externalId: "ABC123",
-          provinceCode: "45",
+          type: 'SCO',
+          name: 'Organization catalina',
+          logoUrl: 'some logo url',
+          externalId: 'ABC123',
+          provinceCode: '45',
           isManagingStudents: true,
           credit: 666,
-          email: "sco.generic.account@example.net",
+          email: 'sco.generic.account@example.net',
           createdBy: superAdminUserId,
-          documentationUrl: "https://pix.fr/",
+          documentationUrl: 'https://pix.fr/',
           archivedBy: archivist.id,
           archivedAt,
           createdAt,
           administrationTeamId: administrationTeam.id,
           countryCode: country.code,
         });
-        const dataProtectionOfficer =
-          databaseBuilder.factory.buildDataProtectionOfficer.withOrganizationId(
-            {
-              firstName: "Justin",
-              lastName: "Ptipeu",
-              email: "justin.ptipeu@example.net",
-              organizationId: organization.id,
-              createdAt,
-              updatedAt: createdAt,
-            },
-          );
-        const tag = databaseBuilder.factory.buildTag({ id: 7, name: "AEFE" });
+        const dataProtectionOfficer = databaseBuilder.factory.buildDataProtectionOfficer.withOrganizationId({
+          firstName: 'Justin',
+          lastName: 'Ptipeu',
+          email: 'justin.ptipeu@example.net',
+          organizationId: organization.id,
+          createdAt,
+          updatedAt: createdAt,
+        });
+        const tag = databaseBuilder.factory.buildTag({ id: 7, name: 'AEFE' });
         databaseBuilder.factory.buildOrganizationTag({
           tagId: tag.id,
           organizationId: organization.id,
@@ -674,7 +632,7 @@ describe("Acceptance | Organizational Entities | Application | Route | Admin | O
 
         // when
         const response = await server.inject({
-          method: "GET",
+          method: 'GET',
           url: `/api/admin/organizations/${organization.id}`,
           headers: generateAuthenticatedUserRequestHeaders({
             userId: superAdmin.id,
@@ -687,42 +645,39 @@ describe("Acceptance | Organizational Entities | Application | Route | Admin | O
             attributes: {
               name: organization.name,
               type: organization.type,
-              "logo-url": organization.logoUrl,
-              "external-id": organization.externalId,
-              "parent-organization-id": organization.parentOrganizationId,
-              "parent-organization-name": null,
-              "province-code": "045",
-              "is-managing-students": organization.isManagingStudents,
+              'logo-url': organization.logoUrl,
+              'external-id': organization.externalId,
+              'parent-organization-id': organization.parentOrganizationId,
+              'parent-organization-name': null,
+              'province-code': '045',
+              'is-managing-students': organization.isManagingStudents,
               credit: organization.credit,
               email: organization.email,
-              "created-by": superAdminUserId,
-              "created-at": createdAt,
-              "documentation-url": organization.documentationUrl,
-              "show-nps": organization.showNPS,
-              "form-nps-url": organization.formNPSUrl,
-              "show-skills": false,
-              "archivist-full-name": "Jean Bonneau",
+              'created-by': superAdminUserId,
+              'created-at': createdAt,
+              'documentation-url': organization.documentationUrl,
+              'show-nps': organization.showNPS,
+              'form-nps-url': organization.formNPSUrl,
+              'show-skills': false,
+              'archivist-full-name': 'Jean Bonneau',
               code: undefined,
-              "data-protection-officer-first-name":
-                dataProtectionOfficer.firstName,
-              "data-protection-officer-last-name":
-                dataProtectionOfficer.lastName,
-              "data-protection-officer-email": dataProtectionOfficer.email,
-              "archived-at": archivedAt,
-              "creator-full-name": "Tom Dereck",
-              "identity-provider-for-campaigns": null,
-              "administration-team-id": administrationTeam.id,
-              "administration-team-name": administrationTeam.name,
-              "country-code": country.code,
-              "country-name": country.commonName,
-              "organization-learner-type-name": `Type pour organisation ${organization.id}`,
+              'data-protection-officer-first-name': dataProtectionOfficer.firstName,
+              'data-protection-officer-last-name': dataProtectionOfficer.lastName,
+              'data-protection-officer-email': dataProtectionOfficer.email,
+              'archived-at': archivedAt,
+              'creator-full-name': 'Tom Dereck',
+              'identity-provider-for-campaigns': null,
+              'administration-team-id': administrationTeam.id,
+              'administration-team-name': administrationTeam.name,
+              'country-code': country.code,
+              'country-name': country.commonName,
+              'organization-learner-type-name': `Type pour organisation ${organization.id}`,
               features: {
                 [ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key]: {
                   active: false,
                   params: null,
                 },
-                [ORGANIZATION_FEATURE
-                  .COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key]: {
+                [ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key]: {
                   active: true,
                   params: null,
                 },
@@ -747,7 +702,7 @@ describe("Acceptance | Organizational Entities | Application | Route | Admin | O
                   related: `/api/admin/organizations/${organization.id}/children`,
                 },
               },
-              "organization-memberships": {
+              'organization-memberships': {
                 links: {
                   related: `/api/organizations/${organization.id}/memberships`,
                 },
@@ -756,22 +711,22 @@ describe("Acceptance | Organizational Entities | Application | Route | Admin | O
                 data: [
                   {
                     id: tag.id.toString(),
-                    type: "tags",
+                    type: 'tags',
                   },
                 ],
               },
-              "target-profile-summaries": {
+              'target-profile-summaries': {
                 links: {
                   related: `/api/admin/organizations/${organization.id}/target-profile-summaries`,
                 },
               },
-              "organization-invitations": {
+              'organization-invitations': {
                 links: {
                   related: `/api/admin/organizations/${organization.id}/invitations`,
                 },
               },
             },
-            type: "organizations",
+            type: 'organizations',
           },
           included: [
             {
@@ -780,16 +735,16 @@ describe("Acceptance | Organizational Entities | Application | Route | Admin | O
                 name: tag.name,
               },
               id: tag.id.toString(),
-              type: "tags",
+              type: 'tags',
             },
           ],
         });
       });
 
-      it("should return a 404 error when organization was not found", async function () {
+      it('should return a 404 error when organization was not found', async function () {
         // when
         const response = await server.inject({
-          method: "GET",
+          method: 'GET',
           url: `/api/admin/organizations/999`,
           headers: generateAuthenticatedUserRequestHeaders({
             userId: superAdmin.id,
@@ -800,22 +755,22 @@ describe("Acceptance | Organizational Entities | Application | Route | Admin | O
         expect(response.result).to.deep.equal({
           errors: [
             {
-              status: "404",
-              detail: "Not found organization for ID 999",
-              title: "Not Found",
+              status: '404',
+              detail: 'Not found organization for ID 999',
+              title: 'Not Found',
             },
           ],
         });
       });
     });
 
-    describe("Resource access management", function () {
-      it("should respond with a 401 - unauthorized access - if user is not authenticated", function () {
+    describe('Resource access management', function () {
+      it('should respond with a 401 - unauthorized access - if user is not authenticated', function () {
         // given & when
         const promise = server.inject({
-          method: "GET",
+          method: 'GET',
           url: `/api/admin/organizations/999`,
-          headers: { authorization: "invalid.access.token" },
+          headers: { authorization: 'invalid.access.token' },
         });
 
         // then
@@ -824,13 +779,13 @@ describe("Acceptance | Organizational Entities | Application | Route | Admin | O
         });
       });
 
-      it("should respond with a 403 - forbidden access - if user has not role Super Admin", function () {
+      it('should respond with a 403 - forbidden access - if user has not role Super Admin', function () {
         // given
         const nonSuperAdminUserId = 9999;
 
         // when
         const promise = server.inject({
-          method: "GET",
+          method: 'GET',
           url: `/api/admin/organizations/999`,
           headers: generateAuthenticatedUserRequestHeaders({
             userId: nonSuperAdminUserId,
@@ -845,26 +800,24 @@ describe("Acceptance | Organizational Entities | Application | Route | Admin | O
     });
   });
 
-  describe("PATCH /api/admin/organizations/{organizationId}", function () {
-    it("should return the updated organization and status code 200", async function () {
+  describe('PATCH /api/admin/organizations/{organizationId}', function () {
+    it('should return the updated organization and status code 200', async function () {
       // given
-      const administrationTeamId =
-        databaseBuilder.factory.buildAdministrationTeam().id;
+      const administrationTeamId = databaseBuilder.factory.buildAdministrationTeam().id;
 
       const country = databaseBuilder.factory.buildCertificationCpfCountry({
-        code: "99102",
-        commonName: "Islande",
-        originalName: "Islande",
+        code: '99102',
+        commonName: 'Islande',
+        originalName: 'Islande',
       });
-      const newOrganizationLearnerType =
-        databaseBuilder.factory.buildOrganizationLearnerType({
-          name: "New Learner Type",
-        });
+      const newOrganizationLearnerType = databaseBuilder.factory.buildOrganizationLearnerType({
+        name: 'New Learner Type',
+      });
 
       const organizationAttributes = {
-        externalId: "0446758F",
-        provinceCode: "044",
-        email: "sco.generic.newaccount@example.net",
+        externalId: '0446758F',
+        provinceCode: '044',
+        email: 'sco.generic.newaccount@example.net',
         credit: 50,
       };
 
@@ -875,22 +828,22 @@ describe("Acceptance | Organizational Entities | Application | Route | Admin | O
 
       const payload = {
         data: {
-          type: "organizations",
+          type: 'organizations',
           id: organization.id,
           attributes: {
-            "external-id": organizationAttributes.externalId,
-            "province-code": organizationAttributes.provinceCode,
+            'external-id': organizationAttributes.externalId,
+            'province-code': organizationAttributes.provinceCode,
             email: organizationAttributes.email,
             credit: organizationAttributes.credit,
-            "administration-team-id": administrationTeamId,
-            "country-code": country.code,
-            "organization-learner-type-name": newOrganizationLearnerType.name,
+            'administration-team-id': administrationTeamId,
+            'country-code': country.code,
+            'organization-learner-type-name': newOrganizationLearnerType.name,
           },
         },
       };
 
       const options = {
-        method: "PATCH",
+        method: 'PATCH',
         url: `/api/admin/organizations/${organization.id}`,
         payload,
         headers: generateAuthenticatedUserRequestHeaders(),
@@ -901,21 +854,19 @@ describe("Acceptance | Organizational Entities | Application | Route | Admin | O
 
       // then
       expect(response.statusCode).to.equal(200);
-      expect(response.result.data["external-id"]).not.to.equal(
-        organization.externalId,
-      );
+      expect(response.result.data['external-id']).not.to.equal(organization.externalId);
     });
   });
 
-  describe("POST /api/admin/organizations/{id}/archive", function () {
-    it("returns the archived organization", async function () {
+  describe('POST /api/admin/organizations/{id}/archive', function () {
+    it('returns the archived organization', async function () {
       // given
       const organizationId = databaseBuilder.factory.buildOrganization().id;
       await databaseBuilder.commit();
 
       // when
       const response = await server.inject({
-        method: "POST",
+        method: 'POST',
         url: `/api/admin/organizations/${organizationId}/archive`,
         headers: generateAuthenticatedUserRequestHeaders({
           userId: superAdmin.id,
@@ -925,12 +876,10 @@ describe("Acceptance | Organizational Entities | Application | Route | Admin | O
       // then
       expect(response.statusCode).to.equal(200);
       const archivedOrganization = response.result.data.attributes;
-      expect(archivedOrganization["archivist-full-name"]).to.equal(
-        `${superAdmin.firstName} ${superAdmin.lastName}`,
-      );
+      expect(archivedOrganization['archivist-full-name']).to.equal(`${superAdmin.firstName} ${superAdmin.lastName}`);
     });
 
-    it("is forbidden for role certif", async function () {
+    it('is forbidden for role certif', async function () {
       // given
       const certifUser = databaseBuilder.factory.buildUser.withRole({
         role: ROLES.CERTIF,
@@ -940,7 +889,7 @@ describe("Acceptance | Organizational Entities | Application | Route | Admin | O
 
       // when
       const response = await server.inject({
-        method: "POST",
+        method: 'POST',
         url: `/api/admin/organizations/${organizationId}/archive`,
         headers: generateAuthenticatedUserRequestHeaders({
           userId: certifUser.id,
@@ -952,15 +901,15 @@ describe("Acceptance | Organizational Entities | Application | Route | Admin | O
     });
   });
 
-  describe("GET /api/admin/organizations/batch-archive/template", function () {
-    it("responds with a 200", async function () {
+  describe('GET /api/admin/organizations/batch-archive/template', function () {
+    it('responds with a 200', async function () {
       // given
       const options = {
-        method: "GET",
+        method: 'GET',
         headers: generateAuthenticatedUserRequestHeaders({
           userId: superAdmin.id,
         }),
-        url: "/api/admin/organizations/batch-archive/template",
+        url: '/api/admin/organizations/batch-archive/template',
       };
 
       // when
@@ -971,9 +920,9 @@ describe("Acceptance | Organizational Entities | Application | Route | Admin | O
     });
   });
 
-  describe("POST /api/admin/organizations/batch-archive", function () {
-    context("success case", function () {
-      it("returns a 204 http request", async function () {
+  describe('POST /api/admin/organizations/batch-archive', function () {
+    context('success case', function () {
+      it('returns a 204 http request', async function () {
         const adminMember = databaseBuilder.factory.buildUser.withRole();
         const organizationId1 = databaseBuilder.factory.buildOrganization({
           archivedAt: null,
@@ -987,13 +936,13 @@ describe("Acceptance | Organizational Entities | Application | Route | Admin | O
 
         const csvData = `ID de l'organisation\n${organizationId1}\n${organizationId2}\n`;
 
-        const boundary = "simple-boundary-12345";
+        const boundary = 'simple-boundary-12345';
 
         const payloadBuffer = _createMultipartPayload({
           boundary,
-          filename: "organizations.csv",
-          fieldName: "file",
-          contentType: "text/csv",
+          filename: 'organizations.csv',
+          fieldName: 'file',
+          contentType: 'text/csv',
           content: csvData,
         });
 
@@ -1001,11 +950,11 @@ describe("Acceptance | Organizational Entities | Application | Route | Admin | O
           ...generateAuthenticatedUserRequestHeaders({
             userId: adminMember.id,
           }),
-          "Content-Type": `multipart/form-data; boundary=${boundary}`,
+          'Content-Type': `multipart/form-data; boundary=${boundary}`,
         };
 
         const response = await server.inject({
-          method: "POST",
+          method: 'POST',
           url: `/api/admin/organizations/batch-archive`,
           headers,
           payload: payloadBuffer,
@@ -1013,12 +962,8 @@ describe("Acceptance | Organizational Entities | Application | Route | Admin | O
 
         expect(response.statusCode).to.equal(204);
 
-        const archivedOrganization1 = await knex("organizations")
-          .where({ id: organizationId1 })
-          .first();
-        const archivedOrganization2 = await knex("organizations")
-          .where({ id: organizationId2 })
-          .first();
+        const archivedOrganization1 = await knex('organizations').where({ id: organizationId1 }).first();
+        const archivedOrganization2 = await knex('organizations').where({ id: organizationId2 }).first();
 
         expect(archivedOrganization1.archivedBy).to.deep.equal(adminMember.id);
         expect(archivedOrganization2.archivedBy).to.deep.equal(adminMember.id);
@@ -1027,8 +972,8 @@ describe("Acceptance | Organizational Entities | Application | Route | Admin | O
       });
     });
 
-    context("error cases", function () {
-      it("returns an error with meta info", async function () {
+    context('error cases', function () {
+      it('returns an error with meta info', async function () {
         // given
         const adminMember = databaseBuilder.factory.buildUser.withRole();
         const organizationId1 = databaseBuilder.factory.buildOrganization({
@@ -1052,13 +997,13 @@ describe("Acceptance | Organizational Entities | Application | Route | Admin | O
           `${nonExistingOrganizationId1}\n` +
           `${nonExistingOrganizationId2}\n`;
 
-        const boundary = "simple-boundary-12345";
+        const boundary = 'simple-boundary-12345';
 
         const payloadBuffer = _createMultipartPayload({
           boundary,
-          filename: "organizations.csv",
-          fieldName: "file",
-          contentType: "text/csv",
+          filename: 'organizations.csv',
+          fieldName: 'file',
+          contentType: 'text/csv',
           content: csvData,
         });
 
@@ -1066,29 +1011,23 @@ describe("Acceptance | Organizational Entities | Application | Route | Admin | O
           ...generateAuthenticatedUserRequestHeaders({
             userId: adminMember.id,
           }),
-          "Content-Type": `multipart/form-data; boundary=${boundary}`,
+          'Content-Type': `multipart/form-data; boundary=${boundary}`,
         };
 
         // when
         const response = await server.inject({
-          method: "POST",
+          method: 'POST',
           url: `/api/admin/organizations/batch-archive`,
           headers,
           payload: payloadBuffer,
         });
 
         // then
-        const archivedOrganization1 = await knex("organizations")
-          .where({ id: organizationId1 })
-          .first();
-        const archivedOrganization2 = await knex("organizations")
-          .where({ id: organizationId2 })
-          .first();
+        const archivedOrganization1 = await knex('organizations').where({ id: organizationId1 }).first();
+        const archivedOrganization2 = await knex('organizations').where({ id: organizationId2 }).first();
 
         expect(response.statusCode).to.equal(422);
-        expect(response.result.errors[0].code).to.deep.equal(
-          "ARCHIVE_ORGANIZATIONS_IN_BATCH_ERROR",
-        );
+        expect(response.result.errors[0].code).to.deep.equal('ARCHIVE_ORGANIZATIONS_IN_BATCH_ERROR');
         expect(response.result.errors[0].meta).to.deep.equal({
           currentLine: 3,
           totalLines: 4,
@@ -1099,13 +1038,13 @@ describe("Acceptance | Organizational Entities | Application | Route | Admin | O
         expect(archivedOrganization2.archivedAt).not.to.be.null;
       });
 
-      it("fails when the file payload is too large", async function () {
-        const buffer = Buffer.alloc(1048576 * 22, "B"); // > 10 Mo buffer
+      it('fails when the file payload is too large', async function () {
+        const buffer = Buffer.alloc(1048576 * 22, 'B'); // > 10 Mo buffer
         const adminMember = databaseBuilder.factory.buildUser.withRole();
 
         const options = {
-          method: "POST",
-          url: "/api/admin/organizations/batch-archive",
+          method: 'POST',
+          url: '/api/admin/organizations/batch-archive',
           headers: generateAuthenticatedUserRequestHeaders({
             userId: adminMember.id,
           }),
@@ -1114,21 +1053,21 @@ describe("Acceptance | Organizational Entities | Application | Route | Admin | O
 
         const response = await server.inject(options);
         expect(response.statusCode).to.equal(413);
-        expect(response.result.errors[0].code).to.equal("PAYLOAD_TOO_LARGE");
-        expect(response.result.errors[0].meta.maxSize).to.equal("20");
+        expect(response.result.errors[0].code).to.equal('PAYLOAD_TOO_LARGE');
+        expect(response.result.errors[0].meta.maxSize).to.equal('20');
       });
     });
   });
 
-  describe("GET /api/admin/organizations/add-organization-features/template", function () {
-    it("responds with a 200", async function () {
+  describe('GET /api/admin/organizations/add-organization-features/template', function () {
+    it('responds with a 200', async function () {
       // given
       const options = {
-        method: "GET",
+        method: 'GET',
         headers: generateAuthenticatedUserRequestHeaders({
           userId: superAdmin.id,
         }),
-        url: "/api/admin/organizations/add-organization-features/template",
+        url: '/api/admin/organizations/add-organization-features/template',
       };
 
       // when
@@ -1139,40 +1078,40 @@ describe("Acceptance | Organizational Entities | Application | Route | Admin | O
     });
   });
 
-  describe("POST /api/admin/organizations/add-organization-features", function () {
-    context("When a CSV file is loaded", function () {
+  describe('POST /api/admin/organizations/add-organization-features', function () {
+    context('When a CSV file is loaded', function () {
       let feature, firstOrganization, otherOrganization;
 
       beforeEach(async function () {
         feature = databaseBuilder.factory.buildFeature({
           key: ORGANIZATION_FEATURE.COVER_RATE.key,
-          description: " best feature ever",
+          description: ' best feature ever',
         });
         firstOrganization = databaseBuilder.factory.buildOrganization({
-          name: "first organization",
-          type: "PRO",
+          name: 'first organization',
+          type: 'PRO',
         });
         otherOrganization = databaseBuilder.factory.buildOrganization({
-          name: "other organization",
-          type: "PRO",
+          name: 'other organization',
+          type: 'PRO',
         });
 
         await databaseBuilder.commit();
       });
 
-      it("responds with a 204 - no content", async function () {
+      it('responds with a 204 - no content', async function () {
         // given
         const input = `Feature Name;Organization ID;Params
       ${feature.key};${firstOrganization.id};
       ${feature.key};${otherOrganization.id};`;
 
         const options = {
-          method: "POST",
+          method: 'POST',
           headers: generateAuthenticatedUserRequestHeaders({
             userId: superAdmin.id,
           }),
-          url: "/api/admin/organizations/add-organization-features",
-          payload: iconv.encode(input, "UTF-8"),
+          url: '/api/admin/organizations/add-organization-features',
+          payload: iconv.encode(input, 'UTF-8'),
         };
 
         // when
@@ -1184,33 +1123,33 @@ describe("Acceptance | Organizational Entities | Application | Route | Admin | O
     });
   });
 
-  describe("POST /api/admin/organizations/{organizationId}/attach-child-organization", function () {
-    context("success cases", function () {
+  describe('POST /api/admin/organizations/{organizationId}/attach-child-organization', function () {
+    context('success cases', function () {
       let parentOrganizationId;
       let firstChildOrganization;
       let secondChildOrganization;
 
       beforeEach(async function () {
         parentOrganizationId = databaseBuilder.factory.buildOrganization({
-          name: "Parent Organization",
-          type: "SCO",
+          name: 'Parent Organization',
+          type: 'SCO',
         }).id;
         firstChildOrganization = databaseBuilder.factory.buildOrganization({
-          name: "child Organization",
-          type: "SCO",
+          name: 'child Organization',
+          type: 'SCO',
         });
         secondChildOrganization = databaseBuilder.factory.buildOrganization({
-          name: "child Organization",
-          type: "SCO",
+          name: 'child Organization',
+          type: 'SCO',
         });
         await databaseBuilder.commit();
       });
 
       context('when user has "SUPER_ADMIN" role', function () {
-        it("attach child organization", async function () {
+        it('attach child organization', async function () {
           // given
           const options = {
-            method: "POST",
+            method: 'POST',
             url: `/api/admin/organizations/${parentOrganizationId}/attach-child-organization`,
             headers: generateAuthenticatedUserRequestHeaders({
               userId: superAdmin.id,
@@ -1224,73 +1163,41 @@ describe("Acceptance | Organizational Entities | Application | Route | Admin | O
           const response = await server.inject(options);
 
           // then
-          const updatedFirstChildOrganization = await knex("organizations")
+          const updatedFirstChildOrganization = await knex('organizations')
             .where({ id: firstChildOrganization.id })
             .first();
-          const updatedSecondChildOrganization = await knex("organizations")
+          const updatedSecondChildOrganization = await knex('organizations')
             .where({ id: secondChildOrganization.id })
             .first();
           expect(response.statusCode).to.equal(204);
-          expect(updatedFirstChildOrganization.parentOrganizationId).to.equal(
-            parentOrganizationId,
-          );
-          expect(updatedSecondChildOrganization.parentOrganizationId).to.equal(
-            parentOrganizationId,
-          );
+          expect(updatedFirstChildOrganization.parentOrganizationId).to.equal(parentOrganizationId);
+          expect(updatedSecondChildOrganization.parentOrganizationId).to.equal(parentOrganizationId);
         });
       });
     });
 
-    context("error cases", function () {
-      context(
-        "when user is not authorized to access the resource",
-        function () {
-          let parentOrganizationId;
-          let childOrganizationId;
+    context('error cases', function () {
+      context('when user is not authorized to access the resource', function () {
+        let parentOrganizationId;
+        let childOrganizationId;
 
-          beforeEach(async function () {
-            parentOrganizationId =
-              databaseBuilder.factory.buildOrganization().id;
-            childOrganizationId =
-              databaseBuilder.factory.buildOrganization().id;
-            await databaseBuilder.commit();
-          });
+        beforeEach(async function () {
+          parentOrganizationId = databaseBuilder.factory.buildOrganization().id;
+          childOrganizationId = databaseBuilder.factory.buildOrganization().id;
+          await databaseBuilder.commit();
+        });
 
-          [ROLES.CERTIF, ROLES.SUPPORT, ROLES.METIER].forEach((role) => {
-            context(`when user has "${role}" role`, function () {
-              it("returns a 403 HTTP status code", async function () {
-                // given
-                const userId = databaseBuilder.factory.buildUser.withRole({
-                  role,
-                }).id;
-                await databaseBuilder.commit();
-
-                const options = {
-                  method: "POST",
-                  url: `/api/admin/organizations/${parentOrganizationId}/attach-child-organization`,
-                  headers: generateAuthenticatedUserRequestHeaders({ userId }),
-                  payload: {
-                    childOrganizationIds: `${childOrganizationId}`,
-                  },
-                };
-
-                // when
-                const response = await server.inject(options);
-
-                // then
-                expect(response.statusCode).to.equal(403);
-              });
-            });
-          });
-
-          context("when user has no role", function () {
-            it("returns a 403 HTTP status code", async function () {
+        [ROLES.CERTIF, ROLES.SUPPORT, ROLES.METIER].forEach((role) => {
+          context(`when user has "${role}" role`, function () {
+            it('returns a 403 HTTP status code', async function () {
               // given
-              const userId = databaseBuilder.factory.buildUser().id;
+              const userId = databaseBuilder.factory.buildUser.withRole({
+                role,
+              }).id;
               await databaseBuilder.commit();
 
               const options = {
-                method: "POST",
+                method: 'POST',
                 url: `/api/admin/organizations/${parentOrganizationId}/attach-child-organization`,
                 headers: generateAuthenticatedUserRequestHeaders({ userId }),
                 payload: {
@@ -1305,10 +1212,33 @@ describe("Acceptance | Organizational Entities | Application | Route | Admin | O
               expect(response.statusCode).to.equal(403);
             });
           });
-        },
-      );
+        });
 
-      context("when request have invalid data", function () {
+        context('when user has no role', function () {
+          it('returns a 403 HTTP status code', async function () {
+            // given
+            const userId = databaseBuilder.factory.buildUser().id;
+            await databaseBuilder.commit();
+
+            const options = {
+              method: 'POST',
+              url: `/api/admin/organizations/${parentOrganizationId}/attach-child-organization`,
+              headers: generateAuthenticatedUserRequestHeaders({ userId }),
+              payload: {
+                childOrganizationIds: `${childOrganizationId}`,
+              },
+            };
+
+            // when
+            const response = await server.inject(options);
+
+            // then
+            expect(response.statusCode).to.equal(403);
+          });
+        });
+      });
+
+      context('when request have invalid data', function () {
         let parentOrganizationId;
         let childOrganizationId;
 
@@ -1318,14 +1248,14 @@ describe("Acceptance | Organizational Entities | Application | Route | Admin | O
           await databaseBuilder.commit();
         });
 
-        context("when parent organization id does not exist", function () {
-          it("returns a 404 HTTP status code", async function () {
+        context('when parent organization id does not exist', function () {
+          it('returns a 404 HTTP status code', async function () {
             // given
             const userId = databaseBuilder.factory.buildUser.withRole().id;
             await databaseBuilder.commit();
 
             const options = {
-              method: "POST",
+              method: 'POST',
               url: `/api/admin/organizations/985421/attach-child-organization`,
               headers: generateAuthenticatedUserRequestHeaders({ userId }),
               payload: {
@@ -1341,17 +1271,17 @@ describe("Acceptance | Organizational Entities | Application | Route | Admin | O
           });
         });
 
-        context("when child organization id does not exist", function () {
-          it("returns a 404 HTTP status code", async function () {
+        context('when child organization id does not exist', function () {
+          it('returns a 404 HTTP status code', async function () {
             // given
             const options = {
-              method: "POST",
+              method: 'POST',
               url: `/api/admin/organizations/${parentOrganizationId}/attach-child-organization`,
               headers: generateAuthenticatedUserRequestHeaders({
                 userId: superAdmin.id,
               }),
               payload: {
-                childOrganizationIds: "984512",
+                childOrganizationIds: '984512',
               },
             };
 
@@ -1364,15 +1294,14 @@ describe("Acceptance | Organizational Entities | Application | Route | Admin | O
         });
       });
 
-      context("when attaching child organization to itself", function () {
-        it("returns a 409 HTTP status code with detailed error info", async function () {
+      context('when attaching child organization to itself', function () {
+        it('returns a 409 HTTP status code with detailed error info', async function () {
           // given
-          const parentOrganizationId =
-            databaseBuilder.factory.buildOrganization().id;
+          const parentOrganizationId = databaseBuilder.factory.buildOrganization().id;
           await databaseBuilder.commit();
 
           const options = {
-            method: "POST",
+            method: 'POST',
             url: `/api/admin/organizations/${parentOrganizationId}/attach-child-organization`,
             headers: generateAuthenticatedUserRequestHeaders({
               userId: superAdmin.id,
@@ -1389,10 +1318,10 @@ describe("Acceptance | Organizational Entities | Application | Route | Admin | O
           const error = result.errors[0];
           expect(statusCode).to.equal(409);
           expect(error).to.deep.equal({
-            status: "409",
-            code: "UNABLE_TO_ATTACH_CHILD_ORGANIZATION_TO_ITSELF",
-            title: "Conflict",
-            detail: "Unable to attach child organization to itself",
+            status: '409',
+            code: 'UNABLE_TO_ATTACH_CHILD_ORGANIZATION_TO_ITSELF',
+            title: 'Conflict',
+            detail: 'Unable to attach child organization to itself',
             meta: {
               childOrganizationId: parentOrganizationId,
               parentOrganizationId,
@@ -1401,152 +1330,18 @@ describe("Acceptance | Organizational Entities | Application | Route | Admin | O
         });
       });
 
-      context(
-        "when attaching an already attached child organization",
-        function () {
-          it("returns a 409 HTTP status code with detailed error info", async function () {
-            // given
-            const parentOrganizationId =
-              databaseBuilder.factory.buildOrganization().id;
-            const anotherParentOrganizationId =
-              databaseBuilder.factory.buildOrganization().id;
-            const childOrganizationId =
-              databaseBuilder.factory.buildOrganization({
-                parentOrganizationId: anotherParentOrganizationId,
-              }).id;
-            await databaseBuilder.commit();
-
-            const options = {
-              method: "POST",
-              url: `/api/admin/organizations/${parentOrganizationId}/attach-child-organization`,
-              headers: generateAuthenticatedUserRequestHeaders({
-                userId: superAdmin.id,
-              }),
-              payload: {
-                childOrganizationIds: `${childOrganizationId}`,
-              },
-            };
-
-            // when
-            const { result, statusCode } = await server.inject(options);
-
-            // then
-            const error = result.errors[0];
-            expect(statusCode).to.equal(409);
-            expect(error).to.deep.equal({
-              status: "409",
-              code: "UNABLE_TO_ATTACH_ALREADY_ATTACHED_CHILD_ORGANIZATION",
-              title: "Conflict",
-              detail: "Unable to attach already attached child organization",
-              meta: { childOrganizationId },
-            });
-          });
-        },
-      );
-
-      context(
-        "when parent organization is already child of an organization",
-        function () {
-          it("returns a 409 HTTP status code with detailed error info", async function () {
-            // given
-            const anotherParentOrganizationId =
-              databaseBuilder.factory.buildOrganization().id;
-            const parentOrganizationId =
-              databaseBuilder.factory.buildOrganization({
-                parentOrganizationId: anotherParentOrganizationId,
-              }).id;
-            const childOrganizationId =
-              databaseBuilder.factory.buildOrganization().id;
-            await databaseBuilder.commit();
-
-            const options = {
-              method: "POST",
-              url: `/api/admin/organizations/${parentOrganizationId}/attach-child-organization`,
-              headers: generateAuthenticatedUserRequestHeaders({
-                userId: superAdmin.id,
-              }),
-              payload: {
-                childOrganizationIds: `${childOrganizationId}`,
-              },
-            };
-
-            // when
-            const { result, statusCode } = await server.inject(options);
-
-            // then
-            const error = result.errors[0];
-            expect(statusCode).to.equal(409);
-            expect(error).to.deep.equal({
-              status: "409",
-              code: "UNABLE_TO_ATTACH_CHILD_ORGANIZATION_TO_ANOTHER_CHILD_ORGANIZATION",
-              title: "Conflict",
-              detail:
-                "Unable to attach child organization to parent organization which is also a child organization",
-              meta: {
-                grandParentOrganizationId: anotherParentOrganizationId,
-                parentOrganizationId,
-              },
-            });
-          });
-        },
-      );
-
-      context(
-        "when attaching child organization without the same type as parent organization",
-        function () {
-          it("returns a 409 HTTP status code with detailed error info", async function () {
-            // given
-            const parentOrganizationId =
-              databaseBuilder.factory.buildOrganization({ type: "SCO" }).id;
-            await databaseBuilder.commit();
-
-            const options = {
-              method: "POST",
-              url: `/api/admin/organizations/${parentOrganizationId}/attach-child-organization`,
-              headers: generateAuthenticatedUserRequestHeaders({
-                userId: superAdmin.id,
-              }),
-              payload: {
-                childOrganizationIds: `${parentOrganizationId}`,
-              },
-            };
-
-            // when
-            const { result, statusCode } = await server.inject(options);
-
-            // then
-            const error = result.errors[0];
-            expect(statusCode).to.equal(409);
-            expect(error).to.deep.equal({
-              status: "409",
-              code: "UNABLE_TO_ATTACH_CHILD_ORGANIZATION_TO_ITSELF",
-              title: "Conflict",
-              detail: "Unable to attach child organization to itself",
-              meta: {
-                childOrganizationId: parentOrganizationId,
-                parentOrganizationId,
-              },
-            });
-          });
-        },
-      );
-
-      context("when child organization is already parent", function () {
-        it("returns a 409 HTTP status code with detailed error info", async function () {
+      context('when attaching an already attached child organization', function () {
+        it('returns a 409 HTTP status code with detailed error info', async function () {
           // given
-          const parentOrganizationId =
-            databaseBuilder.factory.buildOrganization({ type: "PRO" }).id;
-          const childOrganizationId = databaseBuilder.factory.buildOrganization(
-            { type: "PRO" },
-          ).id;
-          databaseBuilder.factory.buildOrganization({
-            type: "PRO",
-            parentOrganizationId: childOrganizationId,
-          });
+          const parentOrganizationId = databaseBuilder.factory.buildOrganization().id;
+          const anotherParentOrganizationId = databaseBuilder.factory.buildOrganization().id;
+          const childOrganizationId = databaseBuilder.factory.buildOrganization({
+            parentOrganizationId: anotherParentOrganizationId,
+          }).id;
           await databaseBuilder.commit();
 
           const options = {
-            method: "POST",
+            method: 'POST',
             url: `/api/admin/organizations/${parentOrganizationId}/attach-child-organization`,
             headers: generateAuthenticatedUserRequestHeaders({
               userId: superAdmin.id,
@@ -1563,11 +1358,124 @@ describe("Acceptance | Organizational Entities | Application | Route | Admin | O
           const error = result.errors[0];
           expect(statusCode).to.equal(409);
           expect(error).to.deep.equal({
-            status: "409",
-            code: "UNABLE_TO_ATTACH_PARENT_ORGANIZATION_AS_CHILD_ORGANIZATION",
-            title: "Conflict",
-            detail:
-              "Unable to attach child organization because it is already parent of organizations",
+            status: '409',
+            code: 'UNABLE_TO_ATTACH_ALREADY_ATTACHED_CHILD_ORGANIZATION',
+            title: 'Conflict',
+            detail: 'Unable to attach already attached child organization',
+            meta: { childOrganizationId },
+          });
+        });
+      });
+
+      context('when parent organization is already child of an organization', function () {
+        it('returns a 409 HTTP status code with detailed error info', async function () {
+          // given
+          const anotherParentOrganizationId = databaseBuilder.factory.buildOrganization().id;
+          const parentOrganizationId = databaseBuilder.factory.buildOrganization({
+            parentOrganizationId: anotherParentOrganizationId,
+          }).id;
+          const childOrganizationId = databaseBuilder.factory.buildOrganization().id;
+          await databaseBuilder.commit();
+
+          const options = {
+            method: 'POST',
+            url: `/api/admin/organizations/${parentOrganizationId}/attach-child-organization`,
+            headers: generateAuthenticatedUserRequestHeaders({
+              userId: superAdmin.id,
+            }),
+            payload: {
+              childOrganizationIds: `${childOrganizationId}`,
+            },
+          };
+
+          // when
+          const { result, statusCode } = await server.inject(options);
+
+          // then
+          const error = result.errors[0];
+          expect(statusCode).to.equal(409);
+          expect(error).to.deep.equal({
+            status: '409',
+            code: 'UNABLE_TO_ATTACH_CHILD_ORGANIZATION_TO_ANOTHER_CHILD_ORGANIZATION',
+            title: 'Conflict',
+            detail: 'Unable to attach child organization to parent organization which is also a child organization',
+            meta: {
+              grandParentOrganizationId: anotherParentOrganizationId,
+              parentOrganizationId,
+            },
+          });
+        });
+      });
+
+      context('when attaching child organization without the same type as parent organization', function () {
+        it('returns a 409 HTTP status code with detailed error info', async function () {
+          // given
+          const parentOrganizationId = databaseBuilder.factory.buildOrganization({ type: 'SCO' }).id;
+          await databaseBuilder.commit();
+
+          const options = {
+            method: 'POST',
+            url: `/api/admin/organizations/${parentOrganizationId}/attach-child-organization`,
+            headers: generateAuthenticatedUserRequestHeaders({
+              userId: superAdmin.id,
+            }),
+            payload: {
+              childOrganizationIds: `${parentOrganizationId}`,
+            },
+          };
+
+          // when
+          const { result, statusCode } = await server.inject(options);
+
+          // then
+          const error = result.errors[0];
+          expect(statusCode).to.equal(409);
+          expect(error).to.deep.equal({
+            status: '409',
+            code: 'UNABLE_TO_ATTACH_CHILD_ORGANIZATION_TO_ITSELF',
+            title: 'Conflict',
+            detail: 'Unable to attach child organization to itself',
+            meta: {
+              childOrganizationId: parentOrganizationId,
+              parentOrganizationId,
+            },
+          });
+        });
+      });
+
+      context('when child organization is already parent', function () {
+        it('returns a 409 HTTP status code with detailed error info', async function () {
+          // given
+          const parentOrganizationId = databaseBuilder.factory.buildOrganization({ type: 'PRO' }).id;
+          const childOrganizationId = databaseBuilder.factory.buildOrganization({ type: 'PRO' }).id;
+          databaseBuilder.factory.buildOrganization({
+            type: 'PRO',
+            parentOrganizationId: childOrganizationId,
+          });
+          await databaseBuilder.commit();
+
+          const options = {
+            method: 'POST',
+            url: `/api/admin/organizations/${parentOrganizationId}/attach-child-organization`,
+            headers: generateAuthenticatedUserRequestHeaders({
+              userId: superAdmin.id,
+            }),
+            payload: {
+              childOrganizationIds: `${childOrganizationId}`,
+            },
+          };
+
+          // when
+          const { result, statusCode } = await server.inject(options);
+
+          // then
+          const error = result.errors[0];
+          expect(statusCode).to.equal(409);
+          expect(error).to.deep.equal({
+            status: '409',
+            code: 'UNABLE_TO_ATTACH_PARENT_ORGANIZATION_AS_CHILD_ORGANIZATION',
+            title: 'Conflict',
+            detail: 'Unable to attach child organization because it is already parent of organizations',
             meta: {
               childOrganizationId,
             },
@@ -1577,27 +1485,27 @@ describe("Acceptance | Organizational Entities | Application | Route | Admin | O
     });
   });
 
-  describe("POST /api/admin/organizations/{childOrganizationId}/detach-parent-organization", function () {
-    context("success cases", function () {
+  describe('POST /api/admin/organizations/{childOrganizationId}/detach-parent-organization', function () {
+    context('success cases', function () {
       let parentOrganization;
       let childOrganization;
 
       beforeEach(async function () {
         parentOrganization = databaseBuilder.factory.buildOrganization({
-          name: "Parent Organization",
+          name: 'Parent Organization',
         });
         childOrganization = databaseBuilder.factory.buildOrganization({
-          name: "Child Organization",
+          name: 'Child Organization',
           parentOrganizationId: parentOrganization.id,
         });
         await databaseBuilder.commit();
       });
 
       context('when user has role "SUPER_ADMIN', function () {
-        it("should detach child organization from its parent", async function () {
+        it('should detach child organization from its parent', async function () {
           // given
           const options = {
-            method: "POST",
+            method: 'POST',
             url: `/api/admin/organizations/${childOrganization.id}/detach-parent-organization`,
             headers: generateAuthenticatedUserRequestHeaders({
               userId: superAdmin.id,
@@ -1608,9 +1516,7 @@ describe("Acceptance | Organizational Entities | Application | Route | Admin | O
           const response = await server.inject(options);
 
           // then
-          const updatedChildOrganization = await knex("organizations")
-            .where({ id: childOrganization.id })
-            .first();
+          const updatedChildOrganization = await knex('organizations').where({ id: childOrganization.id }).first();
 
           expect(response.statusCode).to.equal(204);
           expect(updatedChildOrganization.parentOrganizationId).to.be.null;
@@ -1619,15 +1525,15 @@ describe("Acceptance | Organizational Entities | Application | Route | Admin | O
     });
   });
 
-  describe("GET /api/admin/organizations/update-organizations/template", function () {
-    it("responds with a 200", async function () {
+  describe('GET /api/admin/organizations/update-organizations/template', function () {
+    it('responds with a 200', async function () {
       // given
       const options = {
-        method: "GET",
+        method: 'GET',
         headers: generateAuthenticatedUserRequestHeaders({
           userId: superAdmin.id,
         }),
-        url: "/api/admin/organizations/update-organizations/template",
+        url: '/api/admin/organizations/update-organizations/template',
       };
 
       // when
@@ -1638,44 +1544,44 @@ describe("Acceptance | Organizational Entities | Application | Route | Admin | O
     });
   });
 
-  describe("POST /api/admin/organizations/update-organizations", function () {
-    context("when a CSV file is loaded", function () {
+  describe('POST /api/admin/organizations/update-organizations', function () {
+    context('when a CSV file is loaded', function () {
       let firstOrganization, otherOrganization;
 
       beforeEach(async function () {
         databaseBuilder.factory.buildCertificationCpfCountry({
           code: 99500,
-          commonName: "LALALAND",
-          originalName: "LALALAND",
+          commonName: 'LALALAND',
+          originalName: 'LALALAND',
         });
         databaseBuilder.factory.buildAdministrationTeam({ id: 1234 });
         firstOrganization = databaseBuilder.factory.buildOrganization({
-          name: "first organization",
-          type: "PRO",
+          name: 'first organization',
+          type: 'PRO',
           countryCode: 99100,
         });
         otherOrganization = databaseBuilder.factory.buildOrganization({
-          name: "other organization",
-          type: "PRO",
+          name: 'other organization',
+          type: 'PRO',
           countryCode: 99100,
         });
 
         await databaseBuilder.commit();
       });
 
-      it("responds with a 204 - no content", async function () {
+      it('responds with a 204 - no content', async function () {
         // given
         const input = `Organization ID;Organization Name;Organization External ID;Organization Parent ID;Organization Identity Provider Code;Organization Documentation URL;Organization Province Code;DPO Last Name;DPO First Name;DPO E-mail;Administration Team ID;Country Code
       ${firstOrganization.id};MSFT;12;;OIDC_EXAMPLE_NET;https://doc.url;;Troisjour;Adam;;1234;99500
       ${otherOrganization.id};APPL;;;;;;;Cali;;1234;99500`;
 
         const options = {
-          method: "POST",
+          method: 'POST',
           headers: generateAuthenticatedUserRequestHeaders({
             userId: superAdmin.id,
           }),
-          url: "/api/admin/organizations/update-organizations",
-          payload: iconv.encode(input, "UTF-8"),
+          url: '/api/admin/organizations/update-organizations',
+          payload: iconv.encode(input, 'UTF-8'),
         };
 
         // when
@@ -1686,12 +1592,12 @@ describe("Acceptance | Organizational Entities | Application | Route | Admin | O
       });
     });
 
-    context("when user is not authorized to access the resource", function () {
+    context('when user is not authorized to access the resource', function () {
       const input = `Organization ID;Organization Name;Organization External ID;Organization Parent ID;Organization Identity Provider Code;Organization Documentation URL;Organization Province Code;DPO Last Name;DPO First Name;DPO E-mail`;
 
       [ROLES.CERTIF, ROLES.SUPPORT, ROLES.METIER].forEach((role) => {
         context(`when user has "${role}" role`, function () {
-          it("returns a 403 HTTP status code", async function () {
+          it('returns a 403 HTTP status code', async function () {
             // given
             const userId = databaseBuilder.factory.buildUser.withRole({
               role,
@@ -1699,10 +1605,10 @@ describe("Acceptance | Organizational Entities | Application | Route | Admin | O
             await databaseBuilder.commit();
 
             const options = {
-              method: "POST",
+              method: 'POST',
               url: `/api/admin/organizations/update-organizations`,
               headers: generateAuthenticatedUserRequestHeaders({ userId }),
-              payload: iconv.encode(input, "UTF-8"),
+              payload: iconv.encode(input, 'UTF-8'),
             };
 
             // when
@@ -1714,17 +1620,17 @@ describe("Acceptance | Organizational Entities | Application | Route | Admin | O
         });
       });
 
-      context("when user has no role", function () {
-        it("returns a 403 HTTP status code", async function () {
+      context('when user has no role', function () {
+        it('returns a 403 HTTP status code', async function () {
           // given
           const userId = databaseBuilder.factory.buildUser().id;
           await databaseBuilder.commit();
 
           const options = {
-            method: "POST",
+            method: 'POST',
             url: `/api/admin/organizations/update-organizations`,
             headers: generateAuthenticatedUserRequestHeaders({ userId }),
-            payload: iconv.encode(input, "UTF-8"),
+            payload: iconv.encode(input, 'UTF-8'),
           };
 
           // when
@@ -1737,15 +1643,15 @@ describe("Acceptance | Organizational Entities | Application | Route | Admin | O
     });
   });
 
-  describe("GET /api/admin/organizations/import-tags-csv/template", function () {
-    it("responds with a 200", async function () {
+  describe('GET /api/admin/organizations/import-tags-csv/template', function () {
+    it('responds with a 200', async function () {
       // given
       const options = {
-        method: "GET",
+        method: 'GET',
         headers: generateAuthenticatedUserRequestHeaders({
           userId: superAdmin.id,
         }),
-        url: "/api/admin/organizations/import-tags-csv/template",
+        url: '/api/admin/organizations/import-tags-csv/template',
       };
 
       // when
@@ -1756,8 +1662,8 @@ describe("Acceptance | Organizational Entities | Application | Route | Admin | O
     });
   });
 
-  describe("POST /api/admin/organizations/import-tags-csv", function () {
-    context("When a CSV file is loaded", function () {
+  describe('POST /api/admin/organizations/import-tags-csv', function () {
+    context('When a CSV file is loaded', function () {
       let firstTag;
       let secondTag;
       let thirdTag;
@@ -1765,9 +1671,9 @@ describe("Acceptance | Organizational Entities | Application | Route | Admin | O
       let secondOrganizationId;
 
       beforeEach(async function () {
-        firstTag = databaseBuilder.factory.buildTag({ name: "tag1" });
-        secondTag = databaseBuilder.factory.buildTag({ name: "tag2" });
-        thirdTag = databaseBuilder.factory.buildTag({ name: "tag3" });
+        firstTag = databaseBuilder.factory.buildTag({ name: 'tag1' });
+        secondTag = databaseBuilder.factory.buildTag({ name: 'tag2' });
+        thirdTag = databaseBuilder.factory.buildTag({ name: 'tag3' });
 
         firstOrganizationId = databaseBuilder.factory.buildOrganization().id;
         secondOrganizationId = databaseBuilder.factory.buildOrganization().id;
@@ -1775,9 +1681,9 @@ describe("Acceptance | Organizational Entities | Application | Route | Admin | O
         return databaseBuilder.commit();
       });
 
-      it("responds with a 204 - no content", async function () {
+      it('responds with a 204 - no content', async function () {
         // given
-        const csvHeader = "Organization ID,Tag name";
+        const csvHeader = 'Organization ID,Tag name';
         const input = `${csvHeader}
         ${firstOrganizationId},${firstTag.name}
         ${secondOrganizationId},${secondTag.name}
@@ -1785,12 +1691,12 @@ describe("Acceptance | Organizational Entities | Application | Route | Admin | O
         `;
 
         const options = {
-          method: "POST",
+          method: 'POST',
           headers: generateAuthenticatedUserRequestHeaders({
             userId: superAdmin.id,
           }),
-          url: "/api/admin/organizations/import-tags-csv",
-          payload: iconv.encode(input, "UTF-8"),
+          url: '/api/admin/organizations/import-tags-csv',
+          payload: iconv.encode(input, 'UTF-8'),
         };
 
         // when
@@ -1802,15 +1708,14 @@ describe("Acceptance | Organizational Entities | Application | Route | Admin | O
     });
   });
 
-  describe("GET /api/organizations/{id}/places-statistics", function () {
-    it("should return statistics of organization places and http code 200", async function () {
+  describe('GET /api/organizations/{id}/places-statistics', function () {
+    it('should return statistics of organization places and http code 200', async function () {
       // given
       const server = await createServer();
 
-      const { userId, organizationId } =
-        databaseBuilder.factory.buildMembership({
-          organizationRole: Membership.roles.ADMIN,
-        });
+      const { userId, organizationId } = databaseBuilder.factory.buildMembership({
+        organizationRole: Membership.roles.ADMIN,
+      });
       const placesManagementFeatureId = databaseBuilder.factory.buildFeature({
         key: ORGANIZATION_FEATURE.PLACES_MANAGEMENT.key,
       }).id;
@@ -1821,15 +1726,15 @@ describe("Acceptance | Organizational Entities | Application | Route | Admin | O
       databaseBuilder.factory.buildOrganizationPlace({
         organizationId,
         count: 10,
-        activationDate: new Date("2023-01-01"),
-        expirationDate: new Date("2023-12-12"),
-        category: "T0",
+        activationDate: new Date('2023-01-01'),
+        expirationDate: new Date('2023-12-12'),
+        category: 'T0',
         createdBy: userId,
       });
       await databaseBuilder.commit();
 
       const options = {
-        method: "GET",
+        method: 'GET',
         url: `/api/admin/organizations/${organizationId}/places-statistics`,
         headers: generateAuthenticatedUserRequestHeaders({ superAdmin }),
       };
@@ -1839,30 +1744,22 @@ describe("Acceptance | Organizational Entities | Application | Route | Admin | O
 
       // then
       expect(response.statusCode).to.equal(200);
-      expect(response.result.data.type).to.equal(
-        "organization-places-statistics",
-      );
+      expect(response.result.data.type).to.equal('organization-places-statistics');
     });
   });
 });
 
-function _createMultipartPayload({
-  boundary,
-  filename,
-  fieldName,
-  contentType,
-  content,
-}) {
+function _createMultipartPayload({ boundary, filename, fieldName, contentType, content }) {
   return Buffer.from(
     [
       `--${boundary}`,
       `Content-Disposition: form-data; name="${fieldName}"; filename="${filename}"`,
       `Content-Type: ${contentType}`,
-      "",
+      '',
       content,
       `--${boundary}--`,
-      "",
-    ].join("\r\n"),
-    "utf-8",
+      '',
+    ].join('\r\n'),
+    'utf-8',
   );
 }

--- a/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
@@ -1,9 +1,9 @@
-import iconv from 'iconv-lite';
-import lodash from 'lodash';
+import iconv from "iconv-lite";
+import lodash from "lodash";
 
-import { PIX_ADMIN } from '../../../../../src/authorization/domain/constants.js';
-import { ORGANIZATION_FEATURE } from '../../../../../src/shared/domain/constants.js';
-import { Membership } from '../../../../../src/shared/domain/models/Membership.js';
+import { PIX_ADMIN } from "../../../../../src/authorization/domain/constants.js";
+import { ORGANIZATION_FEATURE } from "../../../../../src/shared/domain/constants.js";
+import { Membership } from "../../../../../src/shared/domain/models/Membership.js";
 import {
   createServer,
   databaseBuilder,
@@ -12,12 +12,12 @@ import {
   insertMultipleSendingFeatureForNewOrganization,
   insertUserWithRoleSuperAdmin,
   knex,
-} from '../../../../test-helper.js';
+} from "../../../../test-helper.js";
 
 const { ROLES } = PIX_ADMIN;
 const { map: _map } = lodash;
 
-describe('Acceptance | Organizational Entities | Application | Route | Admin | Organization', function () {
+describe("Acceptance | Organizational Entities | Application | Route | Admin | Organization", function () {
   let superAdmin;
   let server;
 
@@ -29,13 +29,15 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
     server = await createServer();
   });
 
-  describe('GET /api/admin/organizations/import-csv/template', function () {
-    it('responds with a 200', async function () {
+  describe("GET /api/admin/organizations/import-csv/template", function () {
+    it("responds with a 200", async function () {
       // given
       const options = {
-        method: 'GET',
-        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
-        url: '/api/admin/organizations/import-csv/template',
+        method: "GET",
+        headers: generateAuthenticatedUserRequestHeaders({
+          userId: superAdmin.id,
+        }),
+        url: "/api/admin/organizations/import-csv/template",
       };
 
       // when
@@ -46,65 +48,76 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
     });
   });
 
-  describe('POST /api/admin/organizations/import-csv', function () {
-    it('create organizations for the given csv file', async function () {
+  describe("POST /api/admin/organizations/import-csv", function () {
+    it("create organizations for the given csv file", async function () {
       // given
       const superAdminUserId = databaseBuilder.factory.buildUser.withRole().id;
-      databaseBuilder.factory.buildTag({ name: 'GRAS' });
-      databaseBuilder.factory.buildTag({ name: 'GARGOUILLE' });
-      databaseBuilder.factory.buildTag({ name: 'GARBURE' });
-      databaseBuilder.factory.buildFeature(ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY);
+      databaseBuilder.factory.buildTag({ name: "GRAS" });
+      databaseBuilder.factory.buildTag({ name: "GARGOUILLE" });
+      databaseBuilder.factory.buildTag({ name: "GARBURE" });
+      databaseBuilder.factory.buildFeature(
+        ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY,
+      );
       databaseBuilder.factory.buildAdministrationTeam({ id: 1234 });
       databaseBuilder.factory.buildCertificationCpfCountry({
         code: 99100,
-        commonName: 'France',
-        originalName: 'France',
+        commonName: "France",
+        originalName: "France",
       });
       const organizationId = databaseBuilder.factory.buildOrganization().id;
-      const parentOrganizationId = databaseBuilder.factory.buildOrganization().id;
-      const targetProfileId = databaseBuilder.factory.buildTargetProfile({ ownerOrganizationId: organizationId }).id;
+      const parentOrganizationId =
+        databaseBuilder.factory.buildOrganization().id;
+      const targetProfileId = databaseBuilder.factory.buildTargetProfile({
+        ownerOrganizationId: organizationId,
+      }).id;
       await databaseBuilder.commit();
 
       const buffer =
-        'type,externalId,name,provinceCode,credit,createdBy,documentationUrl,identityProviderForCampaigns,isManagingStudents,emailForSCOActivation,DPOFirstName,DPOLastName,DPOEmail,emailInvitations,organizationInvitationRole,locale,tags,targetProfiles,administrationTeamId,parentOrganizationId,countryCode\n' +
+        "type,externalId,name,provinceCode,credit,createdBy,documentationUrl,identityProviderForCampaigns,isManagingStudents,emailForSCOActivation,DPOFirstName,DPOLastName,DPOEmail,emailInvitations,organizationInvitationRole,locale,tags,targetProfiles,administrationTeamId,parentOrganizationId,countryCode\n" +
         `SCO,ANNEGRAELLE,Orga des Anne-Graelle,33700,666,${superAdminUserId},url.com,,true,,Anne,Graelle,anne-graelle@example.net,,ADMIN,fr,GRAS_GARGOUILLE,${targetProfileId},1234,,99100\n` +
         `PRO,ANNEGARBURE,Orga des Anne-Garbure,33700,999,${superAdminUserId},,,,,Anne,Garbure,anne-garbure@example.net,,ADMIN,fr,GARBURE,${targetProfileId},1234,${parentOrganizationId},99100`;
 
       // when
       const response = await server.inject({
-        method: 'POST',
+        method: "POST",
         url: `/api/admin/organizations/import-csv`,
-        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdminUserId }),
+        headers: generateAuthenticatedUserRequestHeaders({
+          userId: superAdminUserId,
+        }),
         payload: buffer,
       });
 
       // then
       expect(response.statusCode).to.equal(201);
 
-      const organizations = await knex('organizations');
+      const organizations = await knex("organizations");
       expect(organizations).to.have.lengthOf(4);
 
-      const firstOrganizationCreated = organizations.find((organization) => organization.externalId === 'ANNEGRAELLE');
+      const firstOrganizationCreated = organizations.find(
+        (organization) => organization.externalId === "ANNEGRAELLE",
+      );
       expect(firstOrganizationCreated).to.deep.include({
-        type: 'SCO',
-        externalId: 'ANNEGRAELLE',
-        name: 'Orga des Anne-Graelle',
-        provinceCode: '33700',
+        type: "SCO",
+        externalId: "ANNEGRAELLE",
+        name: "Orga des Anne-Graelle",
+        provinceCode: "33700",
         credit: 666,
         createdBy: superAdminUserId,
-        documentationUrl: 'url.com',
+        documentationUrl: "url.com",
         identityProviderForCampaigns: null,
         isManagingStudents: true,
         parentOrganizationId: null,
         countryCode: 99100,
       });
 
-      const secondOrganizationCreated = organizations.find((organization) => organization.externalId === 'ANNEGARBURE');
+      const secondOrganizationCreated = organizations.find(
+        (organization) => organization.externalId === "ANNEGARBURE",
+      );
       expect(secondOrganizationCreated).to.deep.include({
-        type: 'PRO',
-        externalId: 'ANNEGARBURE',
-        name: 'Orga des Anne-Garbure',
-        provinceCode: '33700',
+        type: "PRO",
+        externalId: "ANNEGARBURE",
+        name: "Orga des Anne-Garbure",
+        provinceCode: "33700",
         credit: 999,
         createdBy: superAdminUserId,
         identityProviderForCampaigns: null,
@@ -113,39 +126,40 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
         countryCode: 99100,
       });
 
-      const dataProtectionOfficers = await knex('data-protection-officers');
+      const dataProtectionOfficers = await knex("data-protection-officers");
       expect(dataProtectionOfficers).to.have.lengthOf(2);
 
-      const targetProfileShares = await knex('target-profile-shares');
+      const targetProfileShares = await knex("target-profile-shares");
       expect(targetProfileShares).to.have.lengthOf(2);
 
       const firstTargetProfileShare = targetProfileShares.find(
-        (targetProfileShare) => targetProfileShare.organizationId === firstOrganizationCreated.id,
+        (targetProfileShare) =>
+          targetProfileShare.organizationId === firstOrganizationCreated.id,
       );
       expect(firstTargetProfileShare).to.deep.include({
         organizationId: firstOrganizationCreated.id,
         targetProfileId,
       });
 
-      const firstOrganizationTags = await knex('organization-tags').where({
+      const firstOrganizationTags = await knex("organization-tags").where({
         organizationId: firstOrganizationCreated.id,
       });
       expect(firstOrganizationTags).to.have.lengthOf(2);
     });
   });
 
-  describe('GET /api/admin/organizations/{organizationId}/children', function () {
-    context('error cases', function () {
-      context('when organization does not exist', function () {
-        it('returns a 404 HTTP status code with an error message', async function () {
+  describe("GET /api/admin/organizations/{organizationId}/children", function () {
+    context("error cases", function () {
+      context("when organization does not exist", function () {
+        it("returns a 404 HTTP status code with an error message", async function () {
           // given
           const userId = databaseBuilder.factory.buildUser.withRole().id;
 
           await databaseBuilder.commit();
 
           const request = {
-            method: 'GET',
-            url: '/api/admin/organizations/986532/children',
+            method: "GET",
+            url: "/api/admin/organizations/986532/children",
             headers: generateAuthenticatedUserRequestHeaders({ userId }),
           };
 
@@ -154,48 +168,63 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
 
           // then
           expect(response.statusCode).to.equal(404);
-          expect(response.result.errors[0].detail).to.equal('Organization with ID (986532) not found');
+          expect(response.result.errors[0].detail).to.equal(
+            "Organization with ID (986532) not found",
+          );
         });
       });
 
-      context('when the user does not have access to the resource', function () {
-        it('returns a 403 HTTP status code with an error message', async function () {
-          // given
-          const userId = databaseBuilder.factory.buildUser().id;
-          const organizationId = databaseBuilder.factory.buildOrganization().id;
-
-          await databaseBuilder.commit();
-
-          const request = {
-            method: 'GET',
-            url: `/api/admin/organizations/${organizationId}/children`,
-            headers: generateAuthenticatedUserRequestHeaders({ userId }),
-          };
-
-          // when
-          const response = await server.inject(request);
-
-          // then
-          expect(response.statusCode).to.equal(403);
-        });
-      });
-    });
-
-    context('success cases', function () {
-      Object.keys(ROLES).forEach((role) => {
-        context(`when user has role ${role}`, function () {
-          it('returns child organizations list with a 200 HTTP status code', async function () {
+      context(
+        "when the user does not have access to the resource",
+        function () {
+          it("returns a 403 HTTP status code with an error message", async function () {
             // given
-            const userId = databaseBuilder.factory.buildUser.withRole({ role }).id;
-            const parentOrganizationId = databaseBuilder.factory.buildOrganization().id;
-
-            const firstChildId = databaseBuilder.factory.buildOrganization({ parentOrganizationId }).id + '';
-            const secondChildId = databaseBuilder.factory.buildOrganization({ parentOrganizationId }).id + '';
+            const userId = databaseBuilder.factory.buildUser().id;
+            const organizationId =
+              databaseBuilder.factory.buildOrganization().id;
 
             await databaseBuilder.commit();
 
             const request = {
-              method: 'GET',
+              method: "GET",
+              url: `/api/admin/organizations/${organizationId}/children`,
+              headers: generateAuthenticatedUserRequestHeaders({ userId }),
+            };
+
+            // when
+            const response = await server.inject(request);
+
+            // then
+            expect(response.statusCode).to.equal(403);
+          });
+        },
+      );
+    });
+
+    context("success cases", function () {
+      Object.keys(ROLES).forEach((role) => {
+        context(`when user has role ${role}`, function () {
+          it("returns child organizations list with a 200 HTTP status code", async function () {
+            // given
+            const userId = databaseBuilder.factory.buildUser.withRole({
+              role,
+            }).id;
+            const parentOrganizationId =
+              databaseBuilder.factory.buildOrganization().id;
+
+            const firstChildId =
+              databaseBuilder.factory.buildOrganization({
+                parentOrganizationId,
+              }).id + "";
+            const secondChildId =
+              databaseBuilder.factory.buildOrganization({
+                parentOrganizationId,
+              }).id + "";
+
+            await databaseBuilder.commit();
+
+            const request = {
+              method: "GET",
               url: `/api/admin/organizations/${parentOrganizationId}/children`,
               headers: generateAuthenticatedUserRequestHeaders({ userId }),
             };
@@ -205,51 +234,58 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
             // then
             expect(response.statusCode).to.equal(200);
             expect(response.result.data).to.have.lengthOf(2);
-            expect(_map(response.result.data, 'id')).to.have.members([firstChildId, secondChildId]);
+            expect(_map(response.result.data, "id")).to.have.members([
+              firstChildId,
+              secondChildId,
+            ]);
           });
         });
       });
     });
   });
 
-  describe('GET /api/admin/organizations', function () {
+  describe("GET /api/admin/organizations", function () {
     let options;
 
     beforeEach(async function () {
       const userSuperAdmin = databaseBuilder.factory.buildUser.withRole();
 
-      const administrationTeamId1 = databaseBuilder.factory.buildAdministrationTeam({ id: 56789 }).id;
-      const administrationTeamId2 = databaseBuilder.factory.buildAdministrationTeam({ id: 1234 }).id;
+      const administrationTeamId1 =
+        databaseBuilder.factory.buildAdministrationTeam({ id: 56789 }).id;
+      const administrationTeamId2 =
+        databaseBuilder.factory.buildAdministrationTeam({ id: 1234 }).id;
 
       databaseBuilder.factory.buildOrganization({
         id: 1,
-        name: 'The name of the organization',
-        type: 'SUP',
-        externalId: '1234567A',
+        name: "The name of the organization",
+        type: "SUP",
+        externalId: "1234567A",
         administrationTeamId: administrationTeamId1,
       });
       databaseBuilder.factory.buildOrganization({
         id: 2,
-        name: 'Organization of the night',
-        type: 'PRO',
-        externalId: '1234568A',
+        name: "Organization of the night",
+        type: "PRO",
+        externalId: "1234568A",
         administrationTeamId: administrationTeamId2,
       });
 
       options = {
-        method: 'GET',
-        url: '/api/admin/organizations',
+        method: "GET",
+        url: "/api/admin/organizations",
         payload: {},
-        headers: generateAuthenticatedUserRequestHeaders({ userId: userSuperAdmin.id }),
+        headers: generateAuthenticatedUserRequestHeaders({
+          userId: userSuperAdmin.id,
+        }),
       };
 
       return databaseBuilder.commit();
     });
 
-    describe('Resource access management', function () {
-      it('should respond with a 401 - unauthorized access - if user is not authenticated', async function () {
+    describe("Resource access management", function () {
+      it("should respond with a 401 - unauthorized access - if user is not authenticated", async function () {
         // given
-        options.headers.authorization = 'invalid.access.token';
+        options.headers.authorization = "invalid.access.token";
 
         // when
         const response = await server.inject(options);
@@ -258,10 +294,12 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
         expect(response.statusCode).to.equal(401);
       });
 
-      it('should respond with a 403 - forbidden access - if user has not role Super Admin', async function () {
+      it("should respond with a 403 - forbidden access - if user has not role Super Admin", async function () {
         // given
         const nonSuperAdminUserId = 9999;
-        options.headers = generateAuthenticatedUserRequestHeaders({ userId: nonSuperAdminUserId });
+        options.headers = generateAuthenticatedUserRequestHeaders({
+          userId: nonSuperAdminUserId,
+        });
 
         // when
         const response = await server.inject(options);
@@ -271,20 +309,25 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
       });
     });
 
-    describe('Success case', function () {
-      it('should return a 200 status code response with JSON API serialized', async function () {
+    describe("Success case", function () {
+      it("should return a 200 status code response with JSON API serialized", async function () {
         // when
         const response = await server.inject(options);
 
         // then
         expect(response.statusCode).to.equal(200);
         expect(response.result.data).to.have.lengthOf(2);
-        expect(response.result.data[0].type).to.equal('organizations');
+        expect(response.result.data[0].type).to.equal("organizations");
       });
 
-      it('should return pagination meta data', async function () {
+      it("should return pagination meta data", async function () {
         // given
-        const expectedMetaData = { page: 1, pageSize: 10, rowCount: 2, pageCount: 1 };
+        const expectedMetaData = {
+          page: 1,
+          pageSize: 10,
+          rowCount: 2,
+          pageCount: 1,
+        };
 
         // when
         const response = await server.inject(options);
@@ -293,10 +336,16 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
         expect(response.result.meta).to.deep.equal(expectedMetaData);
       });
 
-      it('should return a 200 status code with paginated and filtered data', async function () {
+      it("should return a 200 status code with paginated and filtered data", async function () {
         // given
-        options.url = '/api/admin/organizations?filter[name]=orga&filter[externalId]=A&page[number]=2&page[size]=1';
-        const expectedMetaData = { page: 2, pageSize: 1, rowCount: 2, pageCount: 2 };
+        options.url =
+          "/api/admin/organizations?filter[name]=orga&filter[externalId]=A&page[number]=2&page[size]=1";
+        const expectedMetaData = {
+          page: 2,
+          pageSize: 1,
+          rowCount: 2,
+          pageCount: 2,
+        };
 
         // when
         const response = await server.inject(options);
@@ -305,14 +354,19 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
         expect(response.statusCode).to.equal(200);
         expect(response.result.meta).to.deep.equal(expectedMetaData);
         expect(response.result.data).to.have.lengthOf(1);
-        expect(response.result.data[0].type).to.equal('organizations');
+        expect(response.result.data[0].type).to.equal("organizations");
       });
 
-      it('should return a 200 status code with filtered data', async function () {
+      it("should return a 200 status code with filtered data", async function () {
         // given
         options.url =
-          '/api/admin/organizations?filter[name]=Organization of the night&filter[externalId]=1234568A&filter[administrationTeamId]=1234&page[number]=1&page[size]=2';
-        const expectedMetaData = { page: 1, pageSize: 2, rowCount: 1, pageCount: 1 };
+          "/api/admin/organizations?filter[name]=Organization of the night&filter[externalId]=1234568A&filter[administrationTeamId]=1234&page[number]=1&page[size]=2";
+        const expectedMetaData = {
+          page: 1,
+          pageSize: 2,
+          rowCount: 1,
+          pageCount: 1,
+        };
 
         // when
         const response = await server.inject(options);
@@ -321,15 +375,20 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
         expect(response.statusCode).to.equal(200);
         expect(response.result.meta).to.deep.equal(expectedMetaData);
         expect(response.result.data).to.have.lengthOf(1);
-        expect(response.result.data[0].type).to.equal('organizations');
-        expect(response.result.data[0].id).to.equal('2');
+        expect(response.result.data[0].type).to.equal("organizations");
+        expect(response.result.data[0].id).to.equal("2");
       });
 
-      it('should return a 200 status code with empty result', async function () {
+      it("should return a 200 status code with empty result", async function () {
         // given
         options.url =
-          '/api/admin/organizations?filter[name]=orga&filter[type]=sco&filter[externalId]=B&page[number]=1&page[size]=1';
-        const expectedMetaData = { page: 1, pageSize: 1, rowCount: 0, pageCount: 0 };
+          "/api/admin/organizations?filter[name]=orga&filter[type]=sco&filter[externalId]=B&page[number]=1&page[size]=1";
+        const expectedMetaData = {
+          page: 1,
+          pageSize: 1,
+          rowCount: 0,
+          pageCount: 0,
+        };
 
         // when
         const response = await server.inject(options);
@@ -342,131 +401,158 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
     });
   });
 
-  describe('POST /api/admin/organizations', function () {
+  describe("POST /api/admin/organizations", function () {
     let payload;
     let options;
 
     beforeEach(function () {
       payload = {
         data: {
-          type: 'organizations',
+          type: "organizations",
           attributes: {
-            name: 'The name of the organization',
-            type: 'PRO',
-            'documentation-url': 'https://kingArthur.com',
+            name: "The name of the organization",
+            type: "PRO",
+            "documentation-url": "https://kingArthur.com",
           },
         },
       };
       options = {
-        method: 'POST',
-        url: '/api/admin/organizations',
+        method: "POST",
+        url: "/api/admin/organizations",
         payload,
         headers: generateAuthenticatedUserRequestHeaders(),
       };
     });
 
-    describe('Success case', function () {
-      context('when no parent organization id is provided', function () {
-        it('returns 200 HTTP status code with the created organization', async function () {
+    describe("Success case", function () {
+      context("when no parent organization id is provided", function () {
+        it("returns 200 HTTP status code with the created organization", async function () {
           // given
-          const superAdminUserId = databaseBuilder.factory.buildUser.withRole().id;
-          databaseBuilder.factory.buildAdministrationTeam({ id: 1234, name: 'Équipe 1' });
+          const superAdminUserId =
+            databaseBuilder.factory.buildUser.withRole().id;
+          databaseBuilder.factory.buildAdministrationTeam({
+            id: 1234,
+            name: "Équipe 1",
+          });
           databaseBuilder.factory.buildCertificationCpfCountry({
             code: 99100,
-            commonName: 'France',
-            originalName: 'France',
+            commonName: "France",
+            originalName: "France",
           });
           await databaseBuilder.commit();
 
           // when
           const { result, statusCode } = await server.inject({
-            method: 'POST',
-            url: '/api/admin/organizations',
+            method: "POST",
+            url: "/api/admin/organizations",
             payload: {
               data: {
-                type: 'organizations',
+                type: "organizations",
                 attributes: {
-                  name: 'The name of the organization',
-                  type: 'PRO',
-                  'documentation-url': 'https://kingArthur.com',
-                  'data-protection-officer-email': 'justin.ptipeu@example.net',
-                  'administration-team-id': 1234,
-                  'country-code': 99100,
-                  'external-id': 'My external Id',
-                  'province-code': '078',
+                  name: "The name of the organization",
+                  type: "PRO",
+                  "documentation-url": "https://kingArthur.com",
+                  "data-protection-officer-email": "justin.ptipeu@example.net",
+                  "administration-team-id": 1234,
+                  "country-code": 99100,
+                  "external-id": "My external Id",
+                  "province-code": "078",
                 },
               },
             },
-            headers: generateAuthenticatedUserRequestHeaders({ userId: superAdminUserId }),
+            headers: generateAuthenticatedUserRequestHeaders({
+              userId: superAdminUserId,
+            }),
           });
 
           // then
           const createdOrganization = result.data.attributes;
 
           expect(statusCode).to.equal(200);
-          expect(createdOrganization.name).to.equal('The name of the organization');
-          expect(createdOrganization.type).to.equal('PRO');
-          expect(createdOrganization['documentation-url']).to.equal('https://kingArthur.com');
-          expect(createdOrganization['data-protection-officer-email']).to.equal('justin.ptipeu@example.net');
-          expect(createdOrganization['created-by']).to.equal(superAdminUserId);
-          expect(createdOrganization['country-code']).to.equal(99100);
-          expect(createdOrganization['external-id']).to.equal('My external Id');
-          expect(createdOrganization['province-code']).to.equal('078');
+          expect(createdOrganization.name).to.equal(
+            "The name of the organization",
+          );
+          expect(createdOrganization.type).to.equal("PRO");
+          expect(createdOrganization["documentation-url"]).to.equal(
+            "https://kingArthur.com",
+          );
+          expect(createdOrganization["data-protection-officer-email"]).to.equal(
+            "justin.ptipeu@example.net",
+          );
+          expect(createdOrganization["created-by"]).to.equal(superAdminUserId);
+          expect(createdOrganization["country-code"]).to.equal(99100);
+          expect(createdOrganization["external-id"]).to.equal("My external Id");
+          expect(createdOrganization["province-code"]).to.equal("078");
         });
       });
 
-      context('when a parent organization id is provided', function () {
-        it('returns 200 HTTP status code with the created child organization', async function () {
+      context("when a parent organization id is provided", function () {
+        it("returns 200 HTTP status code with the created child organization", async function () {
           // given
-          const superAdminUserId = databaseBuilder.factory.buildUser.withRole().id;
-          databaseBuilder.factory.buildAdministrationTeam({ id: 1234, name: 'Équipe 1' });
+          const superAdminUserId =
+            databaseBuilder.factory.buildUser.withRole().id;
+          databaseBuilder.factory.buildAdministrationTeam({
+            id: 1234,
+            name: "Équipe 1",
+          });
           databaseBuilder.factory.buildCertificationCpfCountry({
             code: 99100,
-            commonName: 'France',
-            originalName: 'France',
+            commonName: "France",
+            originalName: "France",
           });
-          const parentOrganizationId = databaseBuilder.factory.buildOrganization().id;
+          const parentOrganizationId =
+            databaseBuilder.factory.buildOrganization().id;
           await databaseBuilder.commit();
 
           // when
           const { result, statusCode } = await server.inject({
-            method: 'POST',
+            method: "POST",
             url: `/api/admin/organizations`,
             payload: {
               data: {
-                type: 'organizations',
+                type: "organizations",
                 attributes: {
-                  name: 'The name of the organization',
-                  type: 'PRO',
-                  'documentation-url': 'https://kingArthur.com',
-                  'data-protection-officer-email': 'justin.ptipeu@example.net',
-                  'administration-team-id': 1234,
-                  'parent-organization-id': parentOrganizationId,
-                  'country-code': 99100,
+                  name: "The name of the organization",
+                  type: "PRO",
+                  "documentation-url": "https://kingArthur.com",
+                  "data-protection-officer-email": "justin.ptipeu@example.net",
+                  "administration-team-id": 1234,
+                  "parent-organization-id": parentOrganizationId,
+                  "country-code": 99100,
                 },
               },
             },
-            headers: generateAuthenticatedUserRequestHeaders({ userId: superAdminUserId }),
+            headers: generateAuthenticatedUserRequestHeaders({
+              userId: superAdminUserId,
+            }),
           });
 
           // then
           const createdOrganization = result.data.attributes;
 
           expect(statusCode).to.equal(200);
-          expect(createdOrganization.name).to.equal('The name of the organization');
-          expect(createdOrganization.type).to.equal('PRO');
-          expect(createdOrganization['documentation-url']).to.equal('https://kingArthur.com');
-          expect(createdOrganization['data-protection-officer-email']).to.equal('justin.ptipeu@example.net');
-          expect(createdOrganization['created-by']).to.equal(superAdminUserId);
-          expect(createdOrganization['parent-organization-id']).to.equal(parentOrganizationId);
+          expect(createdOrganization.name).to.equal(
+            "The name of the organization",
+          );
+          expect(createdOrganization.type).to.equal("PRO");
+          expect(createdOrganization["documentation-url"]).to.equal(
+            "https://kingArthur.com",
+          );
+          expect(createdOrganization["data-protection-officer-email"]).to.equal(
+            "justin.ptipeu@example.net",
+          );
+          expect(createdOrganization["created-by"]).to.equal(superAdminUserId);
+          expect(createdOrganization["parent-organization-id"]).to.equal(
+            parentOrganizationId,
+          );
         });
       });
     });
 
-    describe('when creating with a wrong payload (ex: organization type is wrong)', function () {
-      it('should return 422 HTTP status code', async function () {
+    describe("when creating with a wrong payload (ex: organization type is wrong)", function () {
+      it("should return 422 HTTP status code", async function () {
         // given
-        payload.data.attributes.type = 'FAK';
+        payload.data.attributes.type = "FAK";
 
         // then
         const response = await server.inject(options);
@@ -475,17 +561,17 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
         expect(response.statusCode).to.equal(422);
       });
 
-      it('should not keep the user in the database', async function () {
+      it("should not keep the user in the database", async function () {
         // given
-        payload.data.attributes.type = 'FAK';
+        payload.data.attributes.type = "FAK";
 
         // then
         const creatingOrganizationOnFailure = server.inject(options);
 
         // then
         return creatingOrganizationOnFailure.then(() => {
-          return knex('users')
-            .count('id as id')
+          return knex("users")
+            .count("id as id")
             .then((count) => {
               expect(parseInt(count[0].id, 10)).to.equal(1);
             });
@@ -493,10 +579,10 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
       });
     });
 
-    describe('Resource access management', function () {
-      it('should respond with a 401 - unauthorized access - if user is not authenticated', function () {
+    describe("Resource access management", function () {
+      it("should respond with a 401 - unauthorized access - if user is not authenticated", function () {
         // given
-        options.headers.authorization = 'invalid.access.token';
+        options.headers.authorization = "invalid.access.token";
 
         // when
         const promise = server.inject(options);
@@ -507,10 +593,12 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
         });
       });
 
-      it('should respond with a 403 - forbidden access - if user has not role Super Admin', function () {
+      it("should respond with a 403 - forbidden access - if user has not role Super Admin", function () {
         // given
         const nonSuperAdminUserId = 9999;
-        options.headers = generateAuthenticatedUserRequestHeaders({ userId: nonSuperAdminUserId });
+        options.headers = generateAuthenticatedUserRequestHeaders({
+          userId: nonSuperAdminUserId,
+        });
 
         // when
         const promise = server.inject(options);
@@ -523,65 +611,74 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
     });
   });
 
-  describe('GET /api/admin/organizations/{organizationId}', function () {
-    context('Expected output', function () {
-      it('should return the matching organization as JSON API', async function () {
+  describe("GET /api/admin/organizations/{organizationId}", function () {
+    context("Expected output", function () {
+      it("should return the matching organization as JSON API", async function () {
         // given
         const superAdminUserId = databaseBuilder.factory.buildUser.withRole({
           id: 983733,
-          firstName: 'Tom',
-          lastName: 'Dereck',
+          firstName: "Tom",
+          lastName: "Dereck",
         }).id;
 
         const archivist = databaseBuilder.factory.buildUser({
-          firstName: 'Jean',
-          lastName: 'Bonneau',
+          firstName: "Jean",
+          lastName: "Bonneau",
         });
-        const archivedAt = new Date('2019-04-28T02:42:00Z');
-        const createdAt = new Date('2019-04-28T02:42:00Z');
+        const archivedAt = new Date("2019-04-28T02:42:00Z");
+        const createdAt = new Date("2019-04-28T02:42:00Z");
 
-        const administrationTeam = databaseBuilder.factory.buildAdministrationTeam();
+        const administrationTeam =
+          databaseBuilder.factory.buildAdministrationTeam();
 
         const country = databaseBuilder.factory.buildCertificationCpfCountry({
           code: 99100,
-          commonName: 'France',
-          originalName: 'France',
+          commonName: "France",
+          originalName: "France",
         });
 
         const organization = databaseBuilder.factory.buildOrganization({
-          type: 'SCO',
-          name: 'Organization catalina',
-          logoUrl: 'some logo url',
-          externalId: 'ABC123',
-          provinceCode: '45',
+          type: "SCO",
+          name: "Organization catalina",
+          logoUrl: "some logo url",
+          externalId: "ABC123",
+          provinceCode: "45",
           isManagingStudents: true,
           credit: 666,
-          email: 'sco.generic.account@example.net',
+          email: "sco.generic.account@example.net",
           createdBy: superAdminUserId,
-          documentationUrl: 'https://pix.fr/',
+          documentationUrl: "https://pix.fr/",
           archivedBy: archivist.id,
           archivedAt,
           createdAt,
           administrationTeamId: administrationTeam.id,
           countryCode: country.code,
         });
-        const dataProtectionOfficer = databaseBuilder.factory.buildDataProtectionOfficer.withOrganizationId({
-          firstName: 'Justin',
-          lastName: 'Ptipeu',
-          email: 'justin.ptipeu@example.net',
+        const dataProtectionOfficer =
+          databaseBuilder.factory.buildDataProtectionOfficer.withOrganizationId(
+            {
+              firstName: "Justin",
+              lastName: "Ptipeu",
+              email: "justin.ptipeu@example.net",
+              organizationId: organization.id,
+              createdAt,
+              updatedAt: createdAt,
+            },
+          );
+        const tag = databaseBuilder.factory.buildTag({ id: 7, name: "AEFE" });
+        databaseBuilder.factory.buildOrganizationTag({
+          tagId: tag.id,
           organizationId: organization.id,
-          createdAt,
-          updatedAt: createdAt,
         });
-        const tag = databaseBuilder.factory.buildTag({ id: 7, name: 'AEFE' });
-        databaseBuilder.factory.buildOrganizationTag({ tagId: tag.id, organizationId: organization.id });
         await databaseBuilder.commit();
 
         // when
         const response = await server.inject({
-          method: 'GET',
+          method: "GET",
           url: `/api/admin/organizations/${organization.id}`,
-          headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
+          headers: generateAuthenticatedUserRequestHeaders({
+            userId: superAdmin.id,
+          }),
         });
 
         // then
@@ -590,39 +687,57 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
             attributes: {
               name: organization.name,
               type: organization.type,
-              'logo-url': organization.logoUrl,
-              'external-id': organization.externalId,
-              'parent-organization-id': organization.parentOrganizationId,
-              'parent-organization-name': null,
-              'province-code': '045',
-              'is-managing-students': organization.isManagingStudents,
+              "logo-url": organization.logoUrl,
+              "external-id": organization.externalId,
+              "parent-organization-id": organization.parentOrganizationId,
+              "parent-organization-name": null,
+              "province-code": "045",
+              "is-managing-students": organization.isManagingStudents,
               credit: organization.credit,
               email: organization.email,
-              'created-by': superAdminUserId,
-              'created-at': createdAt,
-              'documentation-url': organization.documentationUrl,
-              'show-nps': organization.showNPS,
-              'form-nps-url': organization.formNPSUrl,
-              'show-skills': false,
-              'archivist-full-name': 'Jean Bonneau',
+              "created-by": superAdminUserId,
+              "created-at": createdAt,
+              "documentation-url": organization.documentationUrl,
+              "show-nps": organization.showNPS,
+              "form-nps-url": organization.formNPSUrl,
+              "show-skills": false,
+              "archivist-full-name": "Jean Bonneau",
               code: undefined,
-              'data-protection-officer-first-name': dataProtectionOfficer.firstName,
-              'data-protection-officer-last-name': dataProtectionOfficer.lastName,
-              'data-protection-officer-email': dataProtectionOfficer.email,
-              'archived-at': archivedAt,
-              'creator-full-name': 'Tom Dereck',
-              'identity-provider-for-campaigns': null,
-              'administration-team-id': administrationTeam.id,
-              'administration-team-name': administrationTeam.name,
-              'country-code': country.code,
-              'country-name': country.commonName,
-              'organization-learner-type-name': `Type pour organisation ${organization.id}`,
+              "data-protection-officer-first-name":
+                dataProtectionOfficer.firstName,
+              "data-protection-officer-last-name":
+                dataProtectionOfficer.lastName,
+              "data-protection-officer-email": dataProtectionOfficer.email,
+              "archived-at": archivedAt,
+              "creator-full-name": "Tom Dereck",
+              "identity-provider-for-campaigns": null,
+              "administration-team-id": administrationTeam.id,
+              "administration-team-name": administrationTeam.name,
+              "country-code": country.code,
+              "country-name": country.commonName,
+              "organization-learner-type-name": `Type pour organisation ${organization.id}`,
               features: {
-                [ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key]: { active: false, params: null },
-                [ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key]: { active: true, params: null },
-                [ORGANIZATION_FEATURE.SHOW_SKILLS.key]: { active: false, params: null },
-                [ORGANIZATION_FEATURE.IS_MANAGING_STUDENTS.key]: { active: true, params: null },
-                [ORGANIZATION_FEATURE.SHOW_NPS.key]: { active: false, params: null },
+                [ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key]: {
+                  active: false,
+                  params: null,
+                },
+                [ORGANIZATION_FEATURE
+                  .COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key]: {
+                  active: true,
+                  params: null,
+                },
+                [ORGANIZATION_FEATURE.SHOW_SKILLS.key]: {
+                  active: false,
+                  params: null,
+                },
+                [ORGANIZATION_FEATURE.IS_MANAGING_STUDENTS.key]: {
+                  active: true,
+                  params: null,
+                },
+                [ORGANIZATION_FEATURE.SHOW_NPS.key]: {
+                  active: false,
+                  params: null,
+                },
               },
             },
             id: organization.id.toString(),
@@ -632,7 +747,7 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
                   related: `/api/admin/organizations/${organization.id}/children`,
                 },
               },
-              'organization-memberships': {
+              "organization-memberships": {
                 links: {
                   related: `/api/organizations/${organization.id}/memberships`,
                 },
@@ -641,22 +756,22 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
                 data: [
                   {
                     id: tag.id.toString(),
-                    type: 'tags',
+                    type: "tags",
                   },
                 ],
               },
-              'target-profile-summaries': {
+              "target-profile-summaries": {
                 links: {
                   related: `/api/admin/organizations/${organization.id}/target-profile-summaries`,
                 },
               },
-              'organization-invitations': {
+              "organization-invitations": {
                 links: {
                   related: `/api/admin/organizations/${organization.id}/invitations`,
                 },
               },
             },
-            type: 'organizations',
+            type: "organizations",
           },
           included: [
             {
@@ -665,40 +780,42 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
                 name: tag.name,
               },
               id: tag.id.toString(),
-              type: 'tags',
+              type: "tags",
             },
           ],
         });
       });
 
-      it('should return a 404 error when organization was not found', async function () {
+      it("should return a 404 error when organization was not found", async function () {
         // when
         const response = await server.inject({
-          method: 'GET',
+          method: "GET",
           url: `/api/admin/organizations/999`,
-          headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
+          headers: generateAuthenticatedUserRequestHeaders({
+            userId: superAdmin.id,
+          }),
         });
 
         // then
         expect(response.result).to.deep.equal({
           errors: [
             {
-              status: '404',
-              detail: 'Not found organization for ID 999',
-              title: 'Not Found',
+              status: "404",
+              detail: "Not found organization for ID 999",
+              title: "Not Found",
             },
           ],
         });
       });
     });
 
-    describe('Resource access management', function () {
-      it('should respond with a 401 - unauthorized access - if user is not authenticated', function () {
+    describe("Resource access management", function () {
+      it("should respond with a 401 - unauthorized access - if user is not authenticated", function () {
         // given & when
         const promise = server.inject({
-          method: 'GET',
+          method: "GET",
           url: `/api/admin/organizations/999`,
-          headers: { authorization: 'invalid.access.token' },
+          headers: { authorization: "invalid.access.token" },
         });
 
         // then
@@ -707,15 +824,17 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
         });
       });
 
-      it('should respond with a 403 - forbidden access - if user has not role Super Admin', function () {
+      it("should respond with a 403 - forbidden access - if user has not role Super Admin", function () {
         // given
         const nonSuperAdminUserId = 9999;
 
         // when
         const promise = server.inject({
-          method: 'GET',
+          method: "GET",
           url: `/api/admin/organizations/999`,
-          headers: generateAuthenticatedUserRequestHeaders({ userId: nonSuperAdminUserId }),
+          headers: generateAuthenticatedUserRequestHeaders({
+            userId: nonSuperAdminUserId,
+          }),
         });
 
         // then
@@ -726,46 +845,52 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
     });
   });
 
-  describe('PATCH /api/admin/organizations/{organizationId}', function () {
-    it('should return the updated organization and status code 200', async function () {
+  describe("PATCH /api/admin/organizations/{organizationId}", function () {
+    it("should return the updated organization and status code 200", async function () {
       // given
-      const administrationTeamId = databaseBuilder.factory.buildAdministrationTeam().id;
+      const administrationTeamId =
+        databaseBuilder.factory.buildAdministrationTeam().id;
 
       const country = databaseBuilder.factory.buildCertificationCpfCountry({
-        code: '99102',
-        commonName: 'Islande',
-        originalName: 'Islande',
+        code: "99102",
+        commonName: "Islande",
+        originalName: "Islande",
       });
-      const newOrganizationLearnerType = databaseBuilder.factory.buildOrganizationLearnerType();
+      const newOrganizationLearnerType =
+        databaseBuilder.factory.buildOrganizationLearnerType({
+          name: "New Learner Type",
+        });
 
       const organizationAttributes = {
-        externalId: '0446758F',
-        provinceCode: '044',
-        email: 'sco.generic.newaccount@example.net',
+        externalId: "0446758F",
+        provinceCode: "044",
+        email: "sco.generic.newaccount@example.net",
         credit: 50,
       };
 
-      const organization = databaseBuilder.factory.buildOrganization({ ...organizationAttributes });
+      const organization = databaseBuilder.factory.buildOrganization({
+        ...organizationAttributes,
+      });
       await databaseBuilder.commit();
 
       const payload = {
         data: {
-          type: 'organizations',
+          type: "organizations",
           id: organization.id,
           attributes: {
-            'external-id': organizationAttributes.externalId,
-            'province-code': organizationAttributes.provinceCode,
+            "external-id": organizationAttributes.externalId,
+            "province-code": organizationAttributes.provinceCode,
             email: organizationAttributes.email,
             credit: organizationAttributes.credit,
-            'administration-team-id': administrationTeamId,
-            'country-code': country.code,
-            'organization-learner-type-name': newOrganizationLearnerType.name,
+            "administration-team-id": administrationTeamId,
+            "country-code": country.code,
+            "organization-learner-type-name": newOrganizationLearnerType.name,
           },
         },
       };
 
       const options = {
-        method: 'PATCH',
+        method: "PATCH",
         url: `/api/admin/organizations/${organization.id}`,
         payload,
         headers: generateAuthenticatedUserRequestHeaders(),
@@ -776,44 +901,50 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
 
       // then
       expect(response.statusCode).to.equal(200);
-      expect(response.result.data['external-id']).not.to.equal(organization.externalId);
-      const formerOrganizationLearnerType = await knex('organization_learner_types').where({
-        id: organization.organizationLearnerTypeId,
-      });
-      expect(response.result.data['organization-learner-type-name']).to.equal(formerOrganizationLearnerType.name);
+      expect(response.result.data["external-id"]).not.to.equal(
+        organization.externalId,
+      );
     });
   });
 
-  describe('POST /api/admin/organizations/{id}/archive', function () {
-    it('returns the archived organization', async function () {
+  describe("POST /api/admin/organizations/{id}/archive", function () {
+    it("returns the archived organization", async function () {
       // given
       const organizationId = databaseBuilder.factory.buildOrganization().id;
       await databaseBuilder.commit();
 
       // when
       const response = await server.inject({
-        method: 'POST',
+        method: "POST",
         url: `/api/admin/organizations/${organizationId}/archive`,
-        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
+        headers: generateAuthenticatedUserRequestHeaders({
+          userId: superAdmin.id,
+        }),
       });
 
       // then
       expect(response.statusCode).to.equal(200);
       const archivedOrganization = response.result.data.attributes;
-      expect(archivedOrganization['archivist-full-name']).to.equal(`${superAdmin.firstName} ${superAdmin.lastName}`);
+      expect(archivedOrganization["archivist-full-name"]).to.equal(
+        `${superAdmin.firstName} ${superAdmin.lastName}`,
+      );
     });
 
-    it('is forbidden for role certif', async function () {
+    it("is forbidden for role certif", async function () {
       // given
-      const certifUser = databaseBuilder.factory.buildUser.withRole({ role: ROLES.CERTIF });
+      const certifUser = databaseBuilder.factory.buildUser.withRole({
+        role: ROLES.CERTIF,
+      });
       const organizationId = databaseBuilder.factory.buildOrganization().id;
       await databaseBuilder.commit();
 
       // when
       const response = await server.inject({
-        method: 'POST',
+        method: "POST",
         url: `/api/admin/organizations/${organizationId}/archive`,
-        headers: generateAuthenticatedUserRequestHeaders({ userId: certifUser.id }),
+        headers: generateAuthenticatedUserRequestHeaders({
+          userId: certifUser.id,
+        }),
       });
 
       // then
@@ -821,13 +952,15 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
     });
   });
 
-  describe('GET /api/admin/organizations/batch-archive/template', function () {
-    it('responds with a 200', async function () {
+  describe("GET /api/admin/organizations/batch-archive/template", function () {
+    it("responds with a 200", async function () {
       // given
       const options = {
-        method: 'GET',
-        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
-        url: '/api/admin/organizations/batch-archive/template',
+        method: "GET",
+        headers: generateAuthenticatedUserRequestHeaders({
+          userId: superAdmin.id,
+        }),
+        url: "/api/admin/organizations/batch-archive/template",
       };
 
       // when
@@ -838,33 +971,41 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
     });
   });
 
-  describe('POST /api/admin/organizations/batch-archive', function () {
-    context('success case', function () {
-      it('returns a 204 http request', async function () {
+  describe("POST /api/admin/organizations/batch-archive", function () {
+    context("success case", function () {
+      it("returns a 204 http request", async function () {
         const adminMember = databaseBuilder.factory.buildUser.withRole();
-        const organizationId1 = databaseBuilder.factory.buildOrganization({ archivedAt: null, archivedBy: null }).id;
-        const organizationId2 = databaseBuilder.factory.buildOrganization({ archivedAt: null, archivedBy: null }).id;
+        const organizationId1 = databaseBuilder.factory.buildOrganization({
+          archivedAt: null,
+          archivedBy: null,
+        }).id;
+        const organizationId2 = databaseBuilder.factory.buildOrganization({
+          archivedAt: null,
+          archivedBy: null,
+        }).id;
         await databaseBuilder.commit();
 
         const csvData = `ID de l'organisation\n${organizationId1}\n${organizationId2}\n`;
 
-        const boundary = 'simple-boundary-12345';
+        const boundary = "simple-boundary-12345";
 
         const payloadBuffer = _createMultipartPayload({
           boundary,
-          filename: 'organizations.csv',
-          fieldName: 'file',
-          contentType: 'text/csv',
+          filename: "organizations.csv",
+          fieldName: "file",
+          contentType: "text/csv",
           content: csvData,
         });
 
         const headers = {
-          ...generateAuthenticatedUserRequestHeaders({ userId: adminMember.id }),
-          'Content-Type': `multipart/form-data; boundary=${boundary}`,
+          ...generateAuthenticatedUserRequestHeaders({
+            userId: adminMember.id,
+          }),
+          "Content-Type": `multipart/form-data; boundary=${boundary}`,
         };
 
         const response = await server.inject({
-          method: 'POST',
+          method: "POST",
           url: `/api/admin/organizations/batch-archive`,
           headers,
           payload: payloadBuffer,
@@ -872,8 +1013,12 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
 
         expect(response.statusCode).to.equal(204);
 
-        const archivedOrganization1 = await knex('organizations').where({ id: organizationId1 }).first();
-        const archivedOrganization2 = await knex('organizations').where({ id: organizationId2 }).first();
+        const archivedOrganization1 = await knex("organizations")
+          .where({ id: organizationId1 })
+          .first();
+        const archivedOrganization2 = await knex("organizations")
+          .where({ id: organizationId2 })
+          .first();
 
         expect(archivedOrganization1.archivedBy).to.deep.equal(adminMember.id);
         expect(archivedOrganization2.archivedBy).to.deep.equal(adminMember.id);
@@ -882,8 +1027,8 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
       });
     });
 
-    context('error cases', function () {
-      it('returns an error with meta info', async function () {
+    context("error cases", function () {
+      it("returns an error with meta info", async function () {
         // given
         const adminMember = databaseBuilder.factory.buildUser.withRole();
         const organizationId1 = databaseBuilder.factory.buildOrganization({
@@ -907,35 +1052,43 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
           `${nonExistingOrganizationId1}\n` +
           `${nonExistingOrganizationId2}\n`;
 
-        const boundary = 'simple-boundary-12345';
+        const boundary = "simple-boundary-12345";
 
         const payloadBuffer = _createMultipartPayload({
           boundary,
-          filename: 'organizations.csv',
-          fieldName: 'file',
-          contentType: 'text/csv',
+          filename: "organizations.csv",
+          fieldName: "file",
+          contentType: "text/csv",
           content: csvData,
         });
 
         const headers = {
-          ...generateAuthenticatedUserRequestHeaders({ userId: adminMember.id }),
-          'Content-Type': `multipart/form-data; boundary=${boundary}`,
+          ...generateAuthenticatedUserRequestHeaders({
+            userId: adminMember.id,
+          }),
+          "Content-Type": `multipart/form-data; boundary=${boundary}`,
         };
 
         // when
         const response = await server.inject({
-          method: 'POST',
+          method: "POST",
           url: `/api/admin/organizations/batch-archive`,
           headers,
           payload: payloadBuffer,
         });
 
         // then
-        const archivedOrganization1 = await knex('organizations').where({ id: organizationId1 }).first();
-        const archivedOrganization2 = await knex('organizations').where({ id: organizationId2 }).first();
+        const archivedOrganization1 = await knex("organizations")
+          .where({ id: organizationId1 })
+          .first();
+        const archivedOrganization2 = await knex("organizations")
+          .where({ id: organizationId2 })
+          .first();
 
         expect(response.statusCode).to.equal(422);
-        expect(response.result.errors[0].code).to.deep.equal('ARCHIVE_ORGANIZATIONS_IN_BATCH_ERROR');
+        expect(response.result.errors[0].code).to.deep.equal(
+          "ARCHIVE_ORGANIZATIONS_IN_BATCH_ERROR",
+        );
         expect(response.result.errors[0].meta).to.deep.equal({
           currentLine: 3,
           totalLines: 4,
@@ -946,32 +1099,36 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
         expect(archivedOrganization2.archivedAt).not.to.be.null;
       });
 
-      it('fails when the file payload is too large', async function () {
-        const buffer = Buffer.alloc(1048576 * 22, 'B'); // > 10 Mo buffer
+      it("fails when the file payload is too large", async function () {
+        const buffer = Buffer.alloc(1048576 * 22, "B"); // > 10 Mo buffer
         const adminMember = databaseBuilder.factory.buildUser.withRole();
 
         const options = {
-          method: 'POST',
-          url: '/api/admin/organizations/batch-archive',
-          headers: generateAuthenticatedUserRequestHeaders({ userId: adminMember.id }),
+          method: "POST",
+          url: "/api/admin/organizations/batch-archive",
+          headers: generateAuthenticatedUserRequestHeaders({
+            userId: adminMember.id,
+          }),
           payload: buffer,
         };
 
         const response = await server.inject(options);
         expect(response.statusCode).to.equal(413);
-        expect(response.result.errors[0].code).to.equal('PAYLOAD_TOO_LARGE');
-        expect(response.result.errors[0].meta.maxSize).to.equal('20');
+        expect(response.result.errors[0].code).to.equal("PAYLOAD_TOO_LARGE");
+        expect(response.result.errors[0].meta.maxSize).to.equal("20");
       });
     });
   });
 
-  describe('GET /api/admin/organizations/add-organization-features/template', function () {
-    it('responds with a 200', async function () {
+  describe("GET /api/admin/organizations/add-organization-features/template", function () {
+    it("responds with a 200", async function () {
       // given
       const options = {
-        method: 'GET',
-        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
-        url: '/api/admin/organizations/add-organization-features/template',
+        method: "GET",
+        headers: generateAuthenticatedUserRequestHeaders({
+          userId: superAdmin.id,
+        }),
+        url: "/api/admin/organizations/add-organization-features/template",
       };
 
       // when
@@ -982,32 +1139,40 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
     });
   });
 
-  describe('POST /api/admin/organizations/add-organization-features', function () {
-    context('When a CSV file is loaded', function () {
+  describe("POST /api/admin/organizations/add-organization-features", function () {
+    context("When a CSV file is loaded", function () {
       let feature, firstOrganization, otherOrganization;
 
       beforeEach(async function () {
         feature = databaseBuilder.factory.buildFeature({
           key: ORGANIZATION_FEATURE.COVER_RATE.key,
-          description: ' best feature ever',
+          description: " best feature ever",
         });
-        firstOrganization = databaseBuilder.factory.buildOrganization({ name: 'first organization', type: 'PRO' });
-        otherOrganization = databaseBuilder.factory.buildOrganization({ name: 'other organization', type: 'PRO' });
+        firstOrganization = databaseBuilder.factory.buildOrganization({
+          name: "first organization",
+          type: "PRO",
+        });
+        otherOrganization = databaseBuilder.factory.buildOrganization({
+          name: "other organization",
+          type: "PRO",
+        });
 
         await databaseBuilder.commit();
       });
 
-      it('responds with a 204 - no content', async function () {
+      it("responds with a 204 - no content", async function () {
         // given
         const input = `Feature Name;Organization ID;Params
       ${feature.key};${firstOrganization.id};
       ${feature.key};${otherOrganization.id};`;
 
         const options = {
-          method: 'POST',
-          headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
-          url: '/api/admin/organizations/add-organization-features',
-          payload: iconv.encode(input, 'UTF-8'),
+          method: "POST",
+          headers: generateAuthenticatedUserRequestHeaders({
+            userId: superAdmin.id,
+          }),
+          url: "/api/admin/organizations/add-organization-features",
+          payload: iconv.encode(input, "UTF-8"),
         };
 
         // when
@@ -1019,35 +1184,37 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
     });
   });
 
-  describe('POST /api/admin/organizations/{organizationId}/attach-child-organization', function () {
-    context('success cases', function () {
+  describe("POST /api/admin/organizations/{organizationId}/attach-child-organization", function () {
+    context("success cases", function () {
       let parentOrganizationId;
       let firstChildOrganization;
       let secondChildOrganization;
 
       beforeEach(async function () {
         parentOrganizationId = databaseBuilder.factory.buildOrganization({
-          name: 'Parent Organization',
-          type: 'SCO',
+          name: "Parent Organization",
+          type: "SCO",
         }).id;
         firstChildOrganization = databaseBuilder.factory.buildOrganization({
-          name: 'child Organization',
-          type: 'SCO',
+          name: "child Organization",
+          type: "SCO",
         });
         secondChildOrganization = databaseBuilder.factory.buildOrganization({
-          name: 'child Organization',
-          type: 'SCO',
+          name: "child Organization",
+          type: "SCO",
         });
         await databaseBuilder.commit();
       });
 
       context('when user has "SUPER_ADMIN" role', function () {
-        it('attach child organization', async function () {
+        it("attach child organization", async function () {
           // given
           const options = {
-            method: 'POST',
+            method: "POST",
             url: `/api/admin/organizations/${parentOrganizationId}/attach-child-organization`,
-            headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
+            headers: generateAuthenticatedUserRequestHeaders({
+              userId: superAdmin.id,
+            }),
             payload: {
               childOrganizationIds: `${firstChildOrganization.id},${secondChildOrganization.id}`,
             },
@@ -1057,39 +1224,73 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
           const response = await server.inject(options);
 
           // then
-          const updatedFirstChildOrganization = await knex('organizations')
+          const updatedFirstChildOrganization = await knex("organizations")
             .where({ id: firstChildOrganization.id })
             .first();
-          const updatedSecondChildOrganization = await knex('organizations')
+          const updatedSecondChildOrganization = await knex("organizations")
             .where({ id: secondChildOrganization.id })
             .first();
           expect(response.statusCode).to.equal(204);
-          expect(updatedFirstChildOrganization.parentOrganizationId).to.equal(parentOrganizationId);
-          expect(updatedSecondChildOrganization.parentOrganizationId).to.equal(parentOrganizationId);
+          expect(updatedFirstChildOrganization.parentOrganizationId).to.equal(
+            parentOrganizationId,
+          );
+          expect(updatedSecondChildOrganization.parentOrganizationId).to.equal(
+            parentOrganizationId,
+          );
         });
       });
     });
 
-    context('error cases', function () {
-      context('when user is not authorized to access the resource', function () {
-        let parentOrganizationId;
-        let childOrganizationId;
+    context("error cases", function () {
+      context(
+        "when user is not authorized to access the resource",
+        function () {
+          let parentOrganizationId;
+          let childOrganizationId;
 
-        beforeEach(async function () {
-          parentOrganizationId = databaseBuilder.factory.buildOrganization().id;
-          childOrganizationId = databaseBuilder.factory.buildOrganization().id;
-          await databaseBuilder.commit();
-        });
+          beforeEach(async function () {
+            parentOrganizationId =
+              databaseBuilder.factory.buildOrganization().id;
+            childOrganizationId =
+              databaseBuilder.factory.buildOrganization().id;
+            await databaseBuilder.commit();
+          });
 
-        [ROLES.CERTIF, ROLES.SUPPORT, ROLES.METIER].forEach((role) => {
-          context(`when user has "${role}" role`, function () {
-            it('returns a 403 HTTP status code', async function () {
+          [ROLES.CERTIF, ROLES.SUPPORT, ROLES.METIER].forEach((role) => {
+            context(`when user has "${role}" role`, function () {
+              it("returns a 403 HTTP status code", async function () {
+                // given
+                const userId = databaseBuilder.factory.buildUser.withRole({
+                  role,
+                }).id;
+                await databaseBuilder.commit();
+
+                const options = {
+                  method: "POST",
+                  url: `/api/admin/organizations/${parentOrganizationId}/attach-child-organization`,
+                  headers: generateAuthenticatedUserRequestHeaders({ userId }),
+                  payload: {
+                    childOrganizationIds: `${childOrganizationId}`,
+                  },
+                };
+
+                // when
+                const response = await server.inject(options);
+
+                // then
+                expect(response.statusCode).to.equal(403);
+              });
+            });
+          });
+
+          context("when user has no role", function () {
+            it("returns a 403 HTTP status code", async function () {
               // given
-              const userId = databaseBuilder.factory.buildUser.withRole({ role }).id;
+              const userId = databaseBuilder.factory.buildUser().id;
               await databaseBuilder.commit();
 
               const options = {
-                method: 'POST',
+                method: "POST",
                 url: `/api/admin/organizations/${parentOrganizationId}/attach-child-organization`,
                 headers: generateAuthenticatedUserRequestHeaders({ userId }),
                 payload: {
@@ -1104,33 +1305,10 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
               expect(response.statusCode).to.equal(403);
             });
           });
-        });
+        },
+      );
 
-        context('when user has no role', function () {
-          it('returns a 403 HTTP status code', async function () {
-            // given
-            const userId = databaseBuilder.factory.buildUser().id;
-            await databaseBuilder.commit();
-
-            const options = {
-              method: 'POST',
-              url: `/api/admin/organizations/${parentOrganizationId}/attach-child-organization`,
-              headers: generateAuthenticatedUserRequestHeaders({ userId }),
-              payload: {
-                childOrganizationIds: `${childOrganizationId}`,
-              },
-            };
-
-            // when
-            const response = await server.inject(options);
-
-            // then
-            expect(response.statusCode).to.equal(403);
-          });
-        });
-      });
-
-      context('when request have invalid data', function () {
+      context("when request have invalid data", function () {
         let parentOrganizationId;
         let childOrganizationId;
 
@@ -1140,14 +1318,14 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
           await databaseBuilder.commit();
         });
 
-        context('when parent organization id does not exist', function () {
-          it('returns a 404 HTTP status code', async function () {
+        context("when parent organization id does not exist", function () {
+          it("returns a 404 HTTP status code", async function () {
             // given
             const userId = databaseBuilder.factory.buildUser.withRole().id;
             await databaseBuilder.commit();
 
             const options = {
-              method: 'POST',
+              method: "POST",
               url: `/api/admin/organizations/985421/attach-child-organization`,
               headers: generateAuthenticatedUserRequestHeaders({ userId }),
               payload: {
@@ -1163,15 +1341,17 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
           });
         });
 
-        context('when child organization id does not exist', function () {
-          it('returns a 404 HTTP status code', async function () {
+        context("when child organization id does not exist", function () {
+          it("returns a 404 HTTP status code", async function () {
             // given
             const options = {
-              method: 'POST',
+              method: "POST",
               url: `/api/admin/organizations/${parentOrganizationId}/attach-child-organization`,
-              headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
+              headers: generateAuthenticatedUserRequestHeaders({
+                userId: superAdmin.id,
+              }),
               payload: {
-                childOrganizationIds: '984512',
+                childOrganizationIds: "984512",
               },
             };
 
@@ -1184,16 +1364,19 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
         });
       });
 
-      context('when attaching child organization to itself', function () {
-        it('returns a 409 HTTP status code with detailed error info', async function () {
+      context("when attaching child organization to itself", function () {
+        it("returns a 409 HTTP status code with detailed error info", async function () {
           // given
-          const parentOrganizationId = databaseBuilder.factory.buildOrganization().id;
+          const parentOrganizationId =
+            databaseBuilder.factory.buildOrganization().id;
           await databaseBuilder.commit();
 
           const options = {
-            method: 'POST',
+            method: "POST",
             url: `/api/admin/organizations/${parentOrganizationId}/attach-child-organization`,
-            headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
+            headers: generateAuthenticatedUserRequestHeaders({
+              userId: superAdmin.id,
+            }),
             payload: {
               childOrganizationIds: `${parentOrganizationId}`,
             },
@@ -1206,111 +1389,10 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
           const error = result.errors[0];
           expect(statusCode).to.equal(409);
           expect(error).to.deep.equal({
-            status: '409',
-            code: 'UNABLE_TO_ATTACH_CHILD_ORGANIZATION_TO_ITSELF',
-            title: 'Conflict',
-            detail: 'Unable to attach child organization to itself',
-            meta: { childOrganizationId: parentOrganizationId, parentOrganizationId },
-          });
-        });
-      });
-
-      context('when attaching an already attached child organization', function () {
-        it('returns a 409 HTTP status code with detailed error info', async function () {
-          // given
-          const parentOrganizationId = databaseBuilder.factory.buildOrganization().id;
-          const anotherParentOrganizationId = databaseBuilder.factory.buildOrganization().id;
-          const childOrganizationId = databaseBuilder.factory.buildOrganization({
-            parentOrganizationId: anotherParentOrganizationId,
-          }).id;
-          await databaseBuilder.commit();
-
-          const options = {
-            method: 'POST',
-            url: `/api/admin/organizations/${parentOrganizationId}/attach-child-organization`,
-            headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
-            payload: {
-              childOrganizationIds: `${childOrganizationId}`,
-            },
-          };
-
-          // when
-          const { result, statusCode } = await server.inject(options);
-
-          // then
-          const error = result.errors[0];
-          expect(statusCode).to.equal(409);
-          expect(error).to.deep.equal({
-            status: '409',
-            code: 'UNABLE_TO_ATTACH_ALREADY_ATTACHED_CHILD_ORGANIZATION',
-            title: 'Conflict',
-            detail: 'Unable to attach already attached child organization',
-            meta: { childOrganizationId },
-          });
-        });
-      });
-
-      context('when parent organization is already child of an organization', function () {
-        it('returns a 409 HTTP status code with detailed error info', async function () {
-          // given
-          const anotherParentOrganizationId = databaseBuilder.factory.buildOrganization().id;
-          const parentOrganizationId = databaseBuilder.factory.buildOrganization({
-            parentOrganizationId: anotherParentOrganizationId,
-          }).id;
-          const childOrganizationId = databaseBuilder.factory.buildOrganization().id;
-          await databaseBuilder.commit();
-
-          const options = {
-            method: 'POST',
-            url: `/api/admin/organizations/${parentOrganizationId}/attach-child-organization`,
-            headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
-            payload: {
-              childOrganizationIds: `${childOrganizationId}`,
-            },
-          };
-
-          // when
-          const { result, statusCode } = await server.inject(options);
-
-          // then
-          const error = result.errors[0];
-          expect(statusCode).to.equal(409);
-          expect(error).to.deep.equal({
-            status: '409',
-            code: 'UNABLE_TO_ATTACH_CHILD_ORGANIZATION_TO_ANOTHER_CHILD_ORGANIZATION',
-            title: 'Conflict',
-            detail: 'Unable to attach child organization to parent organization which is also a child organization',
-            meta: { grandParentOrganizationId: anotherParentOrganizationId, parentOrganizationId },
-          });
-        });
-      });
-
-      context('when attaching child organization without the same type as parent organization', function () {
-        it('returns a 409 HTTP status code with detailed error info', async function () {
-          // given
-          const parentOrganizationId = databaseBuilder.factory.buildOrganization({ type: 'SCO' }).id;
-          await databaseBuilder.commit();
-
-          const options = {
-            method: 'POST',
-            url: `/api/admin/organizations/${parentOrganizationId}/attach-child-organization`,
-            headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
-            payload: {
-              childOrganizationIds: `${parentOrganizationId}`,
-            },
-          };
-
-          // when
-          const { result, statusCode } = await server.inject(options);
-
-          // then
-          const error = result.errors[0];
-          expect(statusCode).to.equal(409);
-          expect(error).to.deep.equal({
-            status: '409',
-            code: 'UNABLE_TO_ATTACH_CHILD_ORGANIZATION_TO_ITSELF',
-            title: 'Conflict',
-            detail: 'Unable to attach child organization to itself',
+            status: "409",
+            code: "UNABLE_TO_ATTACH_CHILD_ORGANIZATION_TO_ITSELF",
+            title: "Conflict",
+            detail: "Unable to attach child organization to itself",
             meta: {
               childOrganizationId: parentOrganizationId,
               parentOrganizationId,
@@ -1319,18 +1401,156 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
         });
       });
 
-      context('when child organization is already parent', function () {
-        it('returns a 409 HTTP status code with detailed error info', async function () {
+      context(
+        "when attaching an already attached child organization",
+        function () {
+          it("returns a 409 HTTP status code with detailed error info", async function () {
+            // given
+            const parentOrganizationId =
+              databaseBuilder.factory.buildOrganization().id;
+            const anotherParentOrganizationId =
+              databaseBuilder.factory.buildOrganization().id;
+            const childOrganizationId =
+              databaseBuilder.factory.buildOrganization({
+                parentOrganizationId: anotherParentOrganizationId,
+              }).id;
+            await databaseBuilder.commit();
+
+            const options = {
+              method: "POST",
+              url: `/api/admin/organizations/${parentOrganizationId}/attach-child-organization`,
+              headers: generateAuthenticatedUserRequestHeaders({
+                userId: superAdmin.id,
+              }),
+              payload: {
+                childOrganizationIds: `${childOrganizationId}`,
+              },
+            };
+
+            // when
+            const { result, statusCode } = await server.inject(options);
+
+            // then
+            const error = result.errors[0];
+            expect(statusCode).to.equal(409);
+            expect(error).to.deep.equal({
+              status: "409",
+              code: "UNABLE_TO_ATTACH_ALREADY_ATTACHED_CHILD_ORGANIZATION",
+              title: "Conflict",
+              detail: "Unable to attach already attached child organization",
+              meta: { childOrganizationId },
+            });
+          });
+        },
+      );
+
+      context(
+        "when parent organization is already child of an organization",
+        function () {
+          it("returns a 409 HTTP status code with detailed error info", async function () {
+            // given
+            const anotherParentOrganizationId =
+              databaseBuilder.factory.buildOrganization().id;
+            const parentOrganizationId =
+              databaseBuilder.factory.buildOrganization({
+                parentOrganizationId: anotherParentOrganizationId,
+              }).id;
+            const childOrganizationId =
+              databaseBuilder.factory.buildOrganization().id;
+            await databaseBuilder.commit();
+
+            const options = {
+              method: "POST",
+              url: `/api/admin/organizations/${parentOrganizationId}/attach-child-organization`,
+              headers: generateAuthenticatedUserRequestHeaders({
+                userId: superAdmin.id,
+              }),
+              payload: {
+                childOrganizationIds: `${childOrganizationId}`,
+              },
+            };
+
+            // when
+            const { result, statusCode } = await server.inject(options);
+
+            // then
+            const error = result.errors[0];
+            expect(statusCode).to.equal(409);
+            expect(error).to.deep.equal({
+              status: "409",
+              code: "UNABLE_TO_ATTACH_CHILD_ORGANIZATION_TO_ANOTHER_CHILD_ORGANIZATION",
+              title: "Conflict",
+              detail:
+                "Unable to attach child organization to parent organization which is also a child organization",
+              meta: {
+                grandParentOrganizationId: anotherParentOrganizationId,
+                parentOrganizationId,
+              },
+            });
+          });
+        },
+      );
+
+      context(
+        "when attaching child organization without the same type as parent organization",
+        function () {
+          it("returns a 409 HTTP status code with detailed error info", async function () {
+            // given
+            const parentOrganizationId =
+              databaseBuilder.factory.buildOrganization({ type: "SCO" }).id;
+            await databaseBuilder.commit();
+
+            const options = {
+              method: "POST",
+              url: `/api/admin/organizations/${parentOrganizationId}/attach-child-organization`,
+              headers: generateAuthenticatedUserRequestHeaders({
+                userId: superAdmin.id,
+              }),
+              payload: {
+                childOrganizationIds: `${parentOrganizationId}`,
+              },
+            };
+
+            // when
+            const { result, statusCode } = await server.inject(options);
+
+            // then
+            const error = result.errors[0];
+            expect(statusCode).to.equal(409);
+            expect(error).to.deep.equal({
+              status: "409",
+              code: "UNABLE_TO_ATTACH_CHILD_ORGANIZATION_TO_ITSELF",
+              title: "Conflict",
+              detail: "Unable to attach child organization to itself",
+              meta: {
+                childOrganizationId: parentOrganizationId,
+                parentOrganizationId,
+              },
+            });
+          });
+        },
+      );
+
+      context("when child organization is already parent", function () {
+        it("returns a 409 HTTP status code with detailed error info", async function () {
           // given
-          const parentOrganizationId = databaseBuilder.factory.buildOrganization({ type: 'PRO' }).id;
-          const childOrganizationId = databaseBuilder.factory.buildOrganization({ type: 'PRO' }).id;
-          databaseBuilder.factory.buildOrganization({ type: 'PRO', parentOrganizationId: childOrganizationId });
+          const parentOrganizationId =
+            databaseBuilder.factory.buildOrganization({ type: "PRO" }).id;
+          const childOrganizationId = databaseBuilder.factory.buildOrganization(
+            { type: "PRO" },
+          ).id;
+          databaseBuilder.factory.buildOrganization({
+            type: "PRO",
+            parentOrganizationId: childOrganizationId,
+          });
           await databaseBuilder.commit();
 
           const options = {
-            method: 'POST',
+            method: "POST",
             url: `/api/admin/organizations/${parentOrganizationId}/attach-child-organization`,
-            headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
+            headers: generateAuthenticatedUserRequestHeaders({
+              userId: superAdmin.id,
+            }),
             payload: {
               childOrganizationIds: `${childOrganizationId}`,
             },
@@ -1343,10 +1563,11 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
           const error = result.errors[0];
           expect(statusCode).to.equal(409);
           expect(error).to.deep.equal({
-            status: '409',
-            code: 'UNABLE_TO_ATTACH_PARENT_ORGANIZATION_AS_CHILD_ORGANIZATION',
-            title: 'Conflict',
-            detail: 'Unable to attach child organization because it is already parent of organizations',
+            status: "409",
+            code: "UNABLE_TO_ATTACH_PARENT_ORGANIZATION_AS_CHILD_ORGANIZATION",
+            title: "Conflict",
+            detail:
+              "Unable to attach child organization because it is already parent of organizations",
             meta: {
               childOrganizationId,
             },
@@ -1356,34 +1577,40 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
     });
   });
 
-  describe('POST /api/admin/organizations/{childOrganizationId}/detach-parent-organization', function () {
-    context('success cases', function () {
+  describe("POST /api/admin/organizations/{childOrganizationId}/detach-parent-organization", function () {
+    context("success cases", function () {
       let parentOrganization;
       let childOrganization;
 
       beforeEach(async function () {
-        parentOrganization = databaseBuilder.factory.buildOrganization({ name: 'Parent Organization' });
+        parentOrganization = databaseBuilder.factory.buildOrganization({
+          name: "Parent Organization",
+        });
         childOrganization = databaseBuilder.factory.buildOrganization({
-          name: 'Child Organization',
+          name: "Child Organization",
           parentOrganizationId: parentOrganization.id,
         });
         await databaseBuilder.commit();
       });
 
       context('when user has role "SUPER_ADMIN', function () {
-        it('should detach child organization from its parent', async function () {
+        it("should detach child organization from its parent", async function () {
           // given
           const options = {
-            method: 'POST',
+            method: "POST",
             url: `/api/admin/organizations/${childOrganization.id}/detach-parent-organization`,
-            headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
+            headers: generateAuthenticatedUserRequestHeaders({
+              userId: superAdmin.id,
+            }),
           };
 
           // when
           const response = await server.inject(options);
 
           // then
-          const updatedChildOrganization = await knex('organizations').where({ id: childOrganization.id }).first();
+          const updatedChildOrganization = await knex("organizations")
+            .where({ id: childOrganization.id })
+            .first();
 
           expect(response.statusCode).to.equal(204);
           expect(updatedChildOrganization.parentOrganizationId).to.be.null;
@@ -1392,13 +1619,15 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
     });
   });
 
-  describe('GET /api/admin/organizations/update-organizations/template', function () {
-    it('responds with a 200', async function () {
+  describe("GET /api/admin/organizations/update-organizations/template", function () {
+    it("responds with a 200", async function () {
       // given
       const options = {
-        method: 'GET',
-        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
-        url: '/api/admin/organizations/update-organizations/template',
+        method: "GET",
+        headers: generateAuthenticatedUserRequestHeaders({
+          userId: superAdmin.id,
+        }),
+        url: "/api/admin/organizations/update-organizations/template",
       };
 
       // when
@@ -1409,42 +1638,44 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
     });
   });
 
-  describe('POST /api/admin/organizations/update-organizations', function () {
-    context('when a CSV file is loaded', function () {
+  describe("POST /api/admin/organizations/update-organizations", function () {
+    context("when a CSV file is loaded", function () {
       let firstOrganization, otherOrganization;
 
       beforeEach(async function () {
         databaseBuilder.factory.buildCertificationCpfCountry({
           code: 99500,
-          commonName: 'LALALAND',
-          originalName: 'LALALAND',
+          commonName: "LALALAND",
+          originalName: "LALALAND",
         });
         databaseBuilder.factory.buildAdministrationTeam({ id: 1234 });
         firstOrganization = databaseBuilder.factory.buildOrganization({
-          name: 'first organization',
-          type: 'PRO',
+          name: "first organization",
+          type: "PRO",
           countryCode: 99100,
         });
         otherOrganization = databaseBuilder.factory.buildOrganization({
-          name: 'other organization',
-          type: 'PRO',
+          name: "other organization",
+          type: "PRO",
           countryCode: 99100,
         });
 
         await databaseBuilder.commit();
       });
 
-      it('responds with a 204 - no content', async function () {
+      it("responds with a 204 - no content", async function () {
         // given
         const input = `Organization ID;Organization Name;Organization External ID;Organization Parent ID;Organization Identity Provider Code;Organization Documentation URL;Organization Province Code;DPO Last Name;DPO First Name;DPO E-mail;Administration Team ID;Country Code
       ${firstOrganization.id};MSFT;12;;OIDC_EXAMPLE_NET;https://doc.url;;Troisjour;Adam;;1234;99500
       ${otherOrganization.id};APPL;;;;;;;Cali;;1234;99500`;
 
         const options = {
-          method: 'POST',
-          headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
-          url: '/api/admin/organizations/update-organizations',
-          payload: iconv.encode(input, 'UTF-8'),
+          method: "POST",
+          headers: generateAuthenticatedUserRequestHeaders({
+            userId: superAdmin.id,
+          }),
+          url: "/api/admin/organizations/update-organizations",
+          payload: iconv.encode(input, "UTF-8"),
         };
 
         // when
@@ -1455,21 +1686,23 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
       });
     });
 
-    context('when user is not authorized to access the resource', function () {
+    context("when user is not authorized to access the resource", function () {
       const input = `Organization ID;Organization Name;Organization External ID;Organization Parent ID;Organization Identity Provider Code;Organization Documentation URL;Organization Province Code;DPO Last Name;DPO First Name;DPO E-mail`;
 
       [ROLES.CERTIF, ROLES.SUPPORT, ROLES.METIER].forEach((role) => {
         context(`when user has "${role}" role`, function () {
-          it('returns a 403 HTTP status code', async function () {
+          it("returns a 403 HTTP status code", async function () {
             // given
-            const userId = databaseBuilder.factory.buildUser.withRole({ role }).id;
+            const userId = databaseBuilder.factory.buildUser.withRole({
+              role,
+            }).id;
             await databaseBuilder.commit();
 
             const options = {
-              method: 'POST',
+              method: "POST",
               url: `/api/admin/organizations/update-organizations`,
               headers: generateAuthenticatedUserRequestHeaders({ userId }),
-              payload: iconv.encode(input, 'UTF-8'),
+              payload: iconv.encode(input, "UTF-8"),
             };
 
             // when
@@ -1481,17 +1714,17 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
         });
       });
 
-      context('when user has no role', function () {
-        it('returns a 403 HTTP status code', async function () {
+      context("when user has no role", function () {
+        it("returns a 403 HTTP status code", async function () {
           // given
           const userId = databaseBuilder.factory.buildUser().id;
           await databaseBuilder.commit();
 
           const options = {
-            method: 'POST',
+            method: "POST",
             url: `/api/admin/organizations/update-organizations`,
             headers: generateAuthenticatedUserRequestHeaders({ userId }),
-            payload: iconv.encode(input, 'UTF-8'),
+            payload: iconv.encode(input, "UTF-8"),
           };
 
           // when
@@ -1504,13 +1737,15 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
     });
   });
 
-  describe('GET /api/admin/organizations/import-tags-csv/template', function () {
-    it('responds with a 200', async function () {
+  describe("GET /api/admin/organizations/import-tags-csv/template", function () {
+    it("responds with a 200", async function () {
       // given
       const options = {
-        method: 'GET',
-        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
-        url: '/api/admin/organizations/import-tags-csv/template',
+        method: "GET",
+        headers: generateAuthenticatedUserRequestHeaders({
+          userId: superAdmin.id,
+        }),
+        url: "/api/admin/organizations/import-tags-csv/template",
       };
 
       // when
@@ -1521,8 +1756,8 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
     });
   });
 
-  describe('POST /api/admin/organizations/import-tags-csv', function () {
-    context('When a CSV file is loaded', function () {
+  describe("POST /api/admin/organizations/import-tags-csv", function () {
+    context("When a CSV file is loaded", function () {
       let firstTag;
       let secondTag;
       let thirdTag;
@@ -1530,9 +1765,9 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
       let secondOrganizationId;
 
       beforeEach(async function () {
-        firstTag = databaseBuilder.factory.buildTag({ name: 'tag1' });
-        secondTag = databaseBuilder.factory.buildTag({ name: 'tag2' });
-        thirdTag = databaseBuilder.factory.buildTag({ name: 'tag3' });
+        firstTag = databaseBuilder.factory.buildTag({ name: "tag1" });
+        secondTag = databaseBuilder.factory.buildTag({ name: "tag2" });
+        thirdTag = databaseBuilder.factory.buildTag({ name: "tag3" });
 
         firstOrganizationId = databaseBuilder.factory.buildOrganization().id;
         secondOrganizationId = databaseBuilder.factory.buildOrganization().id;
@@ -1540,9 +1775,9 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
         return databaseBuilder.commit();
       });
 
-      it('responds with a 204 - no content', async function () {
+      it("responds with a 204 - no content", async function () {
         // given
-        const csvHeader = 'Organization ID,Tag name';
+        const csvHeader = "Organization ID,Tag name";
         const input = `${csvHeader}
         ${firstOrganizationId},${firstTag.name}
         ${secondOrganizationId},${secondTag.name}
@@ -1550,10 +1785,12 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
         `;
 
         const options = {
-          method: 'POST',
-          headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
-          url: '/api/admin/organizations/import-tags-csv',
-          payload: iconv.encode(input, 'UTF-8'),
+          method: "POST",
+          headers: generateAuthenticatedUserRequestHeaders({
+            userId: superAdmin.id,
+          }),
+          url: "/api/admin/organizations/import-tags-csv",
+          payload: iconv.encode(input, "UTF-8"),
         };
 
         // when
@@ -1565,14 +1802,15 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
     });
   });
 
-  describe('GET /api/organizations/{id}/places-statistics', function () {
-    it('should return statistics of organization places and http code 200', async function () {
+  describe("GET /api/organizations/{id}/places-statistics", function () {
+    it("should return statistics of organization places and http code 200", async function () {
       // given
       const server = await createServer();
 
-      const { userId, organizationId } = databaseBuilder.factory.buildMembership({
-        organizationRole: Membership.roles.ADMIN,
-      });
+      const { userId, organizationId } =
+        databaseBuilder.factory.buildMembership({
+          organizationRole: Membership.roles.ADMIN,
+        });
       const placesManagementFeatureId = databaseBuilder.factory.buildFeature({
         key: ORGANIZATION_FEATURE.PLACES_MANAGEMENT.key,
       }).id;
@@ -1583,15 +1821,15 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
       databaseBuilder.factory.buildOrganizationPlace({
         organizationId,
         count: 10,
-        activationDate: new Date('2023-01-01'),
-        expirationDate: new Date('2023-12-12'),
-        category: 'T0',
+        activationDate: new Date("2023-01-01"),
+        expirationDate: new Date("2023-12-12"),
+        category: "T0",
         createdBy: userId,
       });
       await databaseBuilder.commit();
 
       const options = {
-        method: 'GET',
+        method: "GET",
         url: `/api/admin/organizations/${organizationId}/places-statistics`,
         headers: generateAuthenticatedUserRequestHeaders({ superAdmin }),
       };
@@ -1601,22 +1839,30 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
 
       // then
       expect(response.statusCode).to.equal(200);
-      expect(response.result.data.type).to.equal('organization-places-statistics');
+      expect(response.result.data.type).to.equal(
+        "organization-places-statistics",
+      );
     });
   });
 });
 
-function _createMultipartPayload({ boundary, filename, fieldName, contentType, content }) {
+function _createMultipartPayload({
+  boundary,
+  filename,
+  fieldName,
+  contentType,
+  content,
+}) {
   return Buffer.from(
     [
       `--${boundary}`,
       `Content-Disposition: form-data; name="${fieldName}"; filename="${filename}"`,
       `Content-Type: ${contentType}`,
-      '',
+      "",
       content,
       `--${boundary}--`,
-      '',
-    ].join('\r\n'),
-    'utf-8',
+      "",
+    ].join("\r\n"),
+    "utf-8",
   );
 }

--- a/api/tests/organizational-entities/integration/domain/usecases/find-children-organizations.usecase.test.js
+++ b/api/tests/organizational-entities/integration/domain/usecases/find-children-organizations.usecase.test.js
@@ -1,26 +1,36 @@
 import { OrganizationForAdmin } from '../../../../../src/organizational-entities/domain/models/OrganizationForAdmin.js';
+import { OrganizationLearnerType } from '../../../../../src/organizational-entities/domain/models/OrganizationLearnerType.js';
 import { usecases } from '../../../../../src/organizational-entities/domain/usecases/index.js';
 import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
 import { catchErr, databaseBuilder, expect } from '../../../../test-helper.js';
 
 describe('Integration | Organizational Entities | Domain | UseCase | findChildrenOrganizations', function () {
-  it('returns a list of child organizations', async function () {
+  it('returns a list of children organizations', async function () {
     // given
+    const organizationLearnerType = databaseBuilder.factory.buildOrganizationLearnerType();
     const parentOrganizationId = databaseBuilder.factory.buildOrganization({
       name: 'name_ok_1',
       type: 'SCO',
       externalId: '1234567A',
+      organizationLearnerTypeId: organizationLearnerType.id,
     }).id;
 
     const childOrganization = databaseBuilder.factory.buildOrganization({
       name: 'First Child',
       type: 'SCO',
       parentOrganizationId,
+      organizationLearnerTypeId: organizationLearnerType.id,
     });
 
     await databaseBuilder.commit();
 
-    const expectedChildOrganizations = new OrganizationForAdmin(childOrganization);
+    const expectedChildOrganizations = new OrganizationForAdmin({
+      ...childOrganization,
+      organizationLearnerType: new OrganizationLearnerType({
+        id: organizationLearnerType.id,
+        name: undefined,
+      }),
+    });
 
     // when
     const childOrganizations = await usecases.findChildrenOrganizations({

--- a/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/organization-for-admin.serializer.test.js
+++ b/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/organization-for-admin.serializer.test.js
@@ -1,6 +1,7 @@
 import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../../../../src/identity-access-management/domain/constants/identity-providers.js';
 import { Organization } from '../../../../../../src/organizational-entities/domain/models/Organization.js';
 import { OrganizationForAdmin } from '../../../../../../src/organizational-entities/domain/models/OrganizationForAdmin.js';
+import { OrganizationLearnerType } from '../../../../../../src/organizational-entities/domain/models/OrganizationLearnerType.js';
 import { organizationForAdminSerializer } from '../../../../../../src/organizational-entities/infrastructure/serializers/jsonapi/organizations-administration/organization-for-admin.serializer.js';
 import { ORGANIZATION_FEATURE } from '../../../../../../src/shared/domain/constants.js';
 import { domainBuilder, expect } from '../../../../../test-helper.js';
@@ -187,6 +188,7 @@ describe('Unit | Serializer | organization-for-admin-serializer', function () {
           [ORGANIZATION_FEATURE.SHOW_SKILLS.key]: { active: true },
         },
         countryCode: '99100',
+        organizationLearnerTypeName: 'Teacher',
       };
 
       // when
@@ -211,6 +213,7 @@ describe('Unit | Serializer | organization-for-admin-serializer', function () {
             'administration-team-id': organizationAttributes.administrationTeamId,
             features: organizationAttributes.features,
             'country-code': organizationAttributes.countryCode,
+            'organization-learner-type-name': organizationAttributes.organizationLearnerTypeName,
           },
         },
       });
@@ -244,6 +247,10 @@ describe('Unit | Serializer | organization-for-admin-serializer', function () {
           },
         },
         countryCode: 99100,
+        organizationLearnerType: new OrganizationLearnerType({
+          id: undefined,
+          name: organizationAttributes.organizationLearnerTypeName,
+        }),
       });
       expect(organization).to.be.instanceOf(OrganizationForAdmin);
       expect(organization).to.deep.equal(expectedOrganization);

--- a/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/organization-learner-type-serializer_test.js
+++ b/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/organization-learner-type-serializer_test.js
@@ -5,7 +5,10 @@ describe('Unit | Serializer | organization-learner-type-serializer', function ()
   describe('#serialize', function () {
     it('should return a JSON API serialized organization learner type', function () {
       // given
-      const organizationLearnerType = domainBuilder.acquisition.buildOrganizationLearnerType();
+      const organizationLearnerType = domainBuilder.acquisition.buildOrganizationLearnerType({
+        id: 123,
+        name: 'Student',
+      });
 
       // when
       const serializedOrganizationLearnerType = organizationLearnerTypeSerializer.serialize(organizationLearnerType);
@@ -13,9 +16,10 @@ describe('Unit | Serializer | organization-learner-type-serializer', function ()
       // then
       expect(serializedOrganizationLearnerType).to.deep.equal({
         data: {
+          id: '123',
           type: 'organization-learner-types',
           attributes: {
-            name: organizationLearnerType.name,
+            name: 'Student',
           },
         },
       });


### PR DESCRIPTION
## 🥀 Problème

Suite à cette PR https://github.com/1024pix/pix/pull/15091 on veut pouvoir modifier le public prescrit dans e formulaire d'édition d'une organisation sur Pix Admin.

## 🏹 Proposition

Ajouter un select contenant les publics prescrits possibles sur la page d'édition d'une orga.

## 💌 Remarques

On a choisit de rendre ce champ obligatoire côté front, avant que cela le soit côté back afin de faciliter la transition.

## ❤️‍🔥 Pour tester
Sur Pix Admin
- aller sur la page d'une organisation avec public prescrit
- cliquer sur Modifier
- tenter de modifier le public prescrit
- constater que ça fonctionne

- créer une nouvelle orga sans public prescrit
- cliquer sur Modifier
- constater que le select de public prescrit n'est pas rempli
- tenter de soumettre le formulaire
- constater qu'on n'est pas autorisé tant que le champ n'est pas rempli
