### PR TITLE
[TECH] Gérer l'utilisation du if/then/otherwise de Joi dans le script to conversion vers json-schema (PIX-21466)

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/conversion/joi-to-json-schema.js
+++ b/api/src/devcomp/infrastructure/datasources/conversion/joi-to-json-schema.js
@@ -189,7 +189,31 @@ function convertObject(joiObjectDescribedSchema) {
   return jsonSchema;
 }
 
+function generateIfThenOtherwiseSchema(match) {
+  const baseSchema = convertFromType(match.otherwise);
+
+  const conditionalKeyName = Object.keys(match.is.keys)[0];
+  const schemaProperties = {
+    [conditionalKeyName]: {
+      const: match.is.keys[conditionalKeyName].allow[0].override,
+    },
+  };
+
+  return {
+    ...baseSchema,
+    title: match.otherwise.keys.type.allow[0],
+    if: { properties: schemaProperties },
+    then: { properties: convertFromType(match.then).properties },
+  };
+}
+
 function convertAlternatives(joiAlternativesDescribedSchema) {
+  const match = joiAlternativesDescribedSchema.matches[0];
+
+  if (Object.keys(match).includes('is')) {
+    return generateIfThenOtherwiseSchema(match);
+  }
+
   const oneOf = joiAlternativesDescribedSchema.matches.flatMap((match) => {
     if (match.ref !== undefined) {
       if (match.switch !== undefined) {

--- a/api/src/devcomp/infrastructure/datasources/conversion/joi-to-json-schema.js
+++ b/api/src/devcomp/infrastructure/datasources/conversion/joi-to-json-schema.js
@@ -34,7 +34,8 @@ function convertBoolean() {
 }
 
 function convertString(joiStringDescribedSchema) {
-  const jsonSchema = { type: 'string' };
+  const jsonSchema = { type: 'string', format: null };
+
   const rules = joiStringDescribedSchema.rules;
 
   const emailRule = findRule(rules, 'email');

--- a/api/tests/devcomp/unit/infrastructure/datasources/conversion/joi-to-json-schema_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/conversion/joi-to-json-schema_test.js
@@ -2,7 +2,6 @@ import Joi from 'joi';
 
 import { convertJoiToJsonSchema } from '../../../../../../src/devcomp/infrastructure/datasources/conversion/joi-to-json-schema.js';
 import { catchErrSync, expect } from '../../../../../test-helper.js';
-import { qcmElementSchema } from '../learning-content/validation/element/qcm-schema.js';
 
 describe('Unit | Infrastructure | Datasources | Conversion | joi-to-json-schema', function () {
   it('should throw if not Joi', function () {
@@ -518,193 +517,52 @@ describe('Unit | Infrastructure | Datasources | Conversion | joi-to-json-schema'
       describe('if then otherwise statement', function () {
         it('should convert simple schema to json schema', function () {
           // given
-          const joiSchema = qcmElementSchema;
+          const joiSchema = Joi.alternatives().conditional(Joi.object({ isNumber: true }).unknown(), {
+            then: Joi.object({
+              type: Joi.string().valid('qcu').required(),
+              value: Joi.number(),
+            }),
+            otherwise: Joi.object({
+              type: Joi.string().valid('qcu').required(),
+              value: Joi.string(),
+            }),
+          });
 
           const expectedJsonSchema = {
-            type: 'object',
-            properties: {
-              id: {
-                type: 'string',
-                format: 'uuid',
-              },
-              type: {
-                type: 'string',
-                enum: ['qcm'],
-                format: null,
-              },
-              instruction: {
-                type: 'string',
-                format: 'jodit',
-              },
-              hasShortProposals: {
-                type: 'boolean',
-              },
-              proposals: {
-                type: 'array',
-                minItems: 3,
-                items: {
-                  type: 'object',
-                  properties: {
-                    id: {
-                      type: 'string',
-                      pattern: '^[0-9]+$',
-                      format: null,
-                    },
-                    content: {
-                      type: 'string',
-                      format: 'jodit',
-                    },
-                  },
-                  required: ['id', 'content'],
-                  additionalProperties: false,
-                  title: 'proposal',
-                },
-              },
-              feedbacks: {
-                type: 'object',
-                properties: {
-                  valid: {
-                    type: 'object',
-                    properties: {
-                      state: {
-                        type: 'string',
-                        format: 'jodit',
-                      },
-                      diagnosis: {
-                        type: 'string',
-                        format: 'jodit',
-                      },
-                    },
-                    required: ['state', 'diagnosis'],
-                    additionalProperties: false,
-                  },
-                  invalid: {
-                    type: 'object',
-                    properties: {
-                      state: {
-                        type: 'string',
-                        format: 'jodit',
-                      },
-                      diagnosis: {
-                        type: 'string',
-                        format: 'jodit',
-                      },
-                    },
-                    required: ['state', 'diagnosis'],
-                    additionalProperties: false,
-                  },
-                },
-                additionalProperties: false,
-              },
-              solutions: {
-                type: 'array',
-                minItems: 2,
-                items: {
-                  type: 'string',
-                  pattern: '^[0-9]+$',
-                  title: 'solution',
-                  format: null,
-                },
-              },
-            },
-            required: ['id', 'type', 'instruction', 'hasShortProposals', 'proposals', 'feedbacks', 'solutions'],
             additionalProperties: false,
-            title: 'qcm',
             if: {
               properties: {
-                hasShortProposals: {
+                isNumber: {
                   const: true,
                 },
               },
             },
+            properties: {
+              type: {
+                enum: ['qcu'],
+                format: null,
+                type: 'string',
+              },
+              value: {
+                format: null,
+                type: 'string',
+              },
+            },
+            required: ['type'],
             then: {
               properties: {
-                id: {
-                  type: 'string',
-                  format: 'uuid',
-                },
                 type: {
-                  type: 'string',
-                  enum: ['qcm'],
+                  enum: ['qcu'],
                   format: null,
-                },
-                instruction: {
                   type: 'string',
-                  format: 'jodit',
                 },
-                hasShortProposals: {
-                  type: 'boolean',
-                },
-                proposals: {
-                  type: 'array',
-                  minItems: 3,
-                  items: {
-                    type: 'object',
-                    properties: {
-                      id: {
-                        type: 'string',
-                        pattern: '^[0-9]+$',
-                        format: null,
-                      },
-                      content: {
-                        type: 'string',
-                        maxLength: 20,
-                        format: null,
-                      },
-                    },
-                    required: ['id', 'content'],
-                    additionalProperties: false,
-                    title: 'proposal',
-                  },
-                },
-                feedbacks: {
-                  type: 'object',
-                  properties: {
-                    valid: {
-                      type: 'object',
-                      properties: {
-                        state: {
-                          type: 'string',
-                          format: 'jodit',
-                        },
-                        diagnosis: {
-                          type: 'string',
-                          format: 'jodit',
-                        },
-                      },
-                      required: ['state', 'diagnosis'],
-                      additionalProperties: false,
-                    },
-                    invalid: {
-                      type: 'object',
-                      properties: {
-                        state: {
-                          type: 'string',
-                          format: 'jodit',
-                        },
-                        diagnosis: {
-                          type: 'string',
-                          format: 'jodit',
-                        },
-                      },
-                      required: ['state', 'diagnosis'],
-                      additionalProperties: false,
-                    },
-                  },
-                  additionalProperties: false,
-                },
-                solutions: {
-                  type: 'array',
-                  minItems: 2,
-                  items: {
-                    type: 'string',
-                    pattern: '^[0-9]+$',
-                    title: 'solution',
-                    format: null,
-                  },
+                value: {
+                  type: 'number',
                 },
               },
             },
+            title: 'qcu',
+            type: 'object',
           };
 
           // when

--- a/api/tests/devcomp/unit/infrastructure/datasources/conversion/joi-to-json-schema_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/conversion/joi-to-json-schema_test.js
@@ -2,6 +2,7 @@ import Joi from 'joi';
 
 import { convertJoiToJsonSchema } from '../../../../../../src/devcomp/infrastructure/datasources/conversion/joi-to-json-schema.js';
 import { catchErrSync, expect } from '../../../../../test-helper.js';
+import { qcmElementSchema } from '../learning-content/validation/element/qcm-schema.js';
 
 describe('Unit | Infrastructure | Datasources | Conversion | joi-to-json-schema', function () {
   it('should throw if not Joi', function () {
@@ -498,6 +499,199 @@ describe('Unit | Infrastructure | Datasources | Conversion | joi-to-json-schema'
           },
           required: ['sport', 'data'],
           type: 'object',
+        });
+      });
+
+      describe('if then otherwise statement', function () {
+        it('should convert simple schema to json schema', function () {
+          // given
+          const joiSchema = qcmElementSchema;
+
+          const expectedJsonSchema = {
+            type: 'object',
+            properties: {
+              id: {
+                type: 'string',
+                format: 'uuid',
+              },
+              type: {
+                type: 'string',
+                enum: ['qcm'],
+              },
+              instruction: {
+                type: 'string',
+                format: 'jodit',
+              },
+              hasShortProposals: {
+                type: 'boolean',
+              },
+              proposals: {
+                type: 'array',
+                minItems: 3,
+                items: {
+                  type: 'object',
+                  properties: {
+                    id: {
+                      type: 'string',
+                      pattern: '^[0-9]+$',
+                    },
+                    content: {
+                      type: 'string',
+                      format: 'jodit',
+                    },
+                  },
+                  required: ['id', 'content'],
+                  additionalProperties: false,
+                  title: 'proposal',
+                },
+              },
+              feedbacks: {
+                type: 'object',
+                properties: {
+                  valid: {
+                    type: 'object',
+                    properties: {
+                      state: {
+                        type: 'string',
+                        format: 'jodit',
+                      },
+                      diagnosis: {
+                        type: 'string',
+                        format: 'jodit',
+                      },
+                    },
+                    required: ['state', 'diagnosis'],
+                    additionalProperties: false,
+                  },
+                  invalid: {
+                    type: 'object',
+                    properties: {
+                      state: {
+                        type: 'string',
+                        format: 'jodit',
+                      },
+                      diagnosis: {
+                        type: 'string',
+                        format: 'jodit',
+                      },
+                    },
+                    required: ['state', 'diagnosis'],
+                    additionalProperties: false,
+                  },
+                },
+                additionalProperties: false,
+              },
+              solutions: {
+                type: 'array',
+                minItems: 2,
+                items: {
+                  type: 'string',
+                  pattern: '^[0-9]+$',
+                  title: 'solution',
+                },
+              },
+            },
+            required: ['id', 'type', 'instruction', 'hasShortProposals', 'proposals', 'feedbacks', 'solutions'],
+            additionalProperties: false,
+            title: 'qcm',
+            if: {
+              properties: {
+                hasShortProposals: {
+                  const: true,
+                },
+              },
+            },
+            then: {
+              properties: {
+                id: {
+                  type: 'string',
+                  format: 'uuid',
+                },
+                type: {
+                  type: 'string',
+                  enum: ['qcm'],
+                },
+                instruction: {
+                  type: 'string',
+                  format: 'jodit',
+                },
+                hasShortProposals: {
+                  type: 'boolean',
+                },
+                proposals: {
+                  type: 'array',
+                  minItems: 3,
+                  items: {
+                    type: 'object',
+                    properties: {
+                      id: {
+                        type: 'string',
+                        pattern: '^[0-9]+$',
+                      },
+                      content: {
+                        type: 'string',
+                        maxLength: 20,
+                      },
+                    },
+                    required: ['id', 'content'],
+                    additionalProperties: false,
+                    title: 'proposal',
+                  },
+                },
+                feedbacks: {
+                  type: 'object',
+                  properties: {
+                    valid: {
+                      type: 'object',
+                      properties: {
+                        state: {
+                          type: 'string',
+                          format: 'jodit',
+                        },
+                        diagnosis: {
+                          type: 'string',
+                          format: 'jodit',
+                        },
+                      },
+                      required: ['state', 'diagnosis'],
+                      additionalProperties: false,
+                    },
+                    invalid: {
+                      type: 'object',
+                      properties: {
+                        state: {
+                          type: 'string',
+                          format: 'jodit',
+                        },
+                        diagnosis: {
+                          type: 'string',
+                          format: 'jodit',
+                        },
+                      },
+                      required: ['state', 'diagnosis'],
+                      additionalProperties: false,
+                    },
+                  },
+                  additionalProperties: false,
+                },
+                solutions: {
+                  type: 'array',
+                  minItems: 2,
+                  items: {
+                    type: 'string',
+                    pattern: '^[0-9]+$',
+                    title: 'solution',
+                  },
+                },
+              },
+            },
+          };
+
+          // when
+          const jsonSchema = convertJoiToJsonSchema(joiSchema);
+
+          // expect
+          expect(jsonSchema).to.deep.equal(expectedJsonSchema);
         });
       });
     });

--- a/api/tests/devcomp/unit/infrastructure/datasources/conversion/joi-to-json-schema_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/conversion/joi-to-json-schema_test.js
@@ -23,19 +23,19 @@ describe('Unit | Infrastructure | Datasources | Conversion | joi-to-json-schema'
     it('should convert Joi.string to JSON Schema', function () {
       const joiSchema = Joi.string();
       const jsonSchema = convertJoiToJsonSchema(joiSchema);
-      expect(jsonSchema).to.deep.equal({ type: 'string' });
+      expect(jsonSchema).to.deep.equal({ type: 'string', format: null });
     });
 
     it('should convert Joi.string.min to JSON Schema with minLength', function () {
       const joiSchema = Joi.string().min(8);
       const jsonSchema = convertJoiToJsonSchema(joiSchema);
-      expect(jsonSchema).to.deep.equal({ type: 'string', minLength: 8 });
+      expect(jsonSchema).to.deep.equal({ type: 'string', format: null, minLength: 8 });
     });
 
     it('should convert Joi.string.max to JSON Schema with maxLength', function () {
       const joiSchema = Joi.string().max(32);
       const jsonSchema = convertJoiToJsonSchema(joiSchema);
-      expect(jsonSchema).to.deep.equal({ type: 'string', maxLength: 32 });
+      expect(jsonSchema).to.deep.equal({ type: 'string', format: null, maxLength: 32 });
     });
 
     it('should convert Joi.string.email to JSON Schema with format email', function () {
@@ -66,19 +66,19 @@ describe('Unit | Infrastructure | Datasources | Conversion | joi-to-json-schema'
       it('should convert Joi.string.regex(d) to JSON Schema with converted pattern', function () {
         const joiSchema = Joi.string().regex(/^\d+$/);
         const jsonSchema = convertJoiToJsonSchema(joiSchema);
-        expect(jsonSchema).to.deep.equal({ type: 'string', pattern: '^[0-9]+$' });
+        expect(jsonSchema).to.deep.equal({ type: 'string', format: null, pattern: '^[0-9]+$' });
       });
 
       it('should convert Joi.string.regex(*) to JSON Schema with given pattern', function () {
         const joiSchema = Joi.string().regex(/^[a-z0-9-]+$/);
         const jsonSchema = convertJoiToJsonSchema(joiSchema);
-        expect(jsonSchema).to.deep.equal({ type: 'string', pattern: '^[a-z0-9-]+$' });
+        expect(jsonSchema).to.deep.equal({ type: 'string', format: null, pattern: '^[a-z0-9-]+$' });
       });
 
       it('should convert Joi.string.regex(*, invert) to JSON Schema with no pattern', function () {
         const joiSchema = Joi.string().regex(/<.*?>/, { invert: true });
         const jsonSchema = convertJoiToJsonSchema(joiSchema);
-        expect(jsonSchema).to.deep.equal({ type: 'string' });
+        expect(jsonSchema).to.deep.equal({ type: 'string', format: null });
       });
 
       it('should convert Joi.string.regex.message to JSON Schema with errorMessage', function () {
@@ -87,6 +87,7 @@ describe('Unit | Infrastructure | Datasources | Conversion | joi-to-json-schema'
         expect(jsonSchema).to.deep.equal({
           type: 'string',
           pattern: 'abc',
+          format: null,
           errorMessage: '{{:#label}} failed custom validation',
         });
       });
@@ -96,13 +97,13 @@ describe('Unit | Infrastructure | Datasources | Conversion | joi-to-json-schema'
       it('should convert Joi.string.allow(empty) to JSON Schema with no enum', function () {
         const joiSchema = Joi.string().allow('');
         const jsonSchema = convertJoiToJsonSchema(joiSchema);
-        expect(jsonSchema).to.deep.equal({ type: 'string' });
+        expect(jsonSchema).to.deep.equal({ type: 'string', format: null });
       });
 
       it('should convert Joi.string.allow(*) to JSON Schema with enum', function () {
         const joiSchema = Joi.string().allow('Hello');
         const jsonSchema = convertJoiToJsonSchema(joiSchema);
-        expect(jsonSchema).to.deep.equal({ type: 'string', enum: ['Hello'] });
+        expect(jsonSchema).to.deep.equal({ type: 'string', format: null, enum: ['Hello'] });
       });
     });
 
@@ -182,7 +183,10 @@ describe('Unit | Infrastructure | Datasources | Conversion | joi-to-json-schema'
       it('should convert Joi.array.items(string) to JSON Schema with items string', function () {
         const joiSchema = Joi.array().items(Joi.string());
         const jsonSchema = convertJoiToJsonSchema(joiSchema);
-        expect(jsonSchema).to.deep.equal({ type: 'array', items: { type: 'string' } });
+        expect(jsonSchema).to.deep.equal({
+          type: 'array',
+          items: { type: 'string', format: null },
+        });
       });
 
       it('should convert Joi.array.items(number) to JSON Schema with items number', function () {
@@ -236,7 +240,7 @@ describe('Unit | Infrastructure | Datasources | Conversion | joi-to-json-schema'
       expect(jsonSchema).to.deep.equal({
         type: 'object',
         properties: {
-          name: { type: 'string' },
+          name: { type: 'string', format: null },
           age: { type: 'number' },
         },
         additionalProperties: false,
@@ -252,7 +256,7 @@ describe('Unit | Infrastructure | Datasources | Conversion | joi-to-json-schema'
       expect(jsonSchema).to.deep.equal({
         type: 'object',
         properties: {
-          name: { type: 'string' },
+          name: { type: 'string', format: null },
           age: { type: 'number' },
         },
         required: ['name'],
@@ -274,8 +278,8 @@ describe('Unit | Infrastructure | Datasources | Conversion | joi-to-json-schema'
           address: {
             type: 'object',
             properties: {
-              street: { type: 'string' },
-              city: { type: 'string' },
+              street: { type: 'string', format: null },
+              city: { type: 'string', format: null },
             },
             additionalProperties: false,
           },
@@ -294,7 +298,7 @@ describe('Unit | Infrastructure | Datasources | Conversion | joi-to-json-schema'
         properties: {
           proposals: {
             type: 'array',
-            items: { title: 'proposal', type: 'string' },
+            items: { title: 'proposal', type: 'string', format: null },
           },
         },
         additionalProperties: false,
@@ -310,7 +314,7 @@ describe('Unit | Infrastructure | Datasources | Conversion | joi-to-json-schema'
 
       expect(joiSchema.validate('string').error).to.be.undefined;
       expect(joiSchema.validate(123).error).to.be.undefined;
-      expect(jsonSchema).to.deep.equal({ oneOf: [{ type: 'string' }, { type: 'number' }] });
+      expect(jsonSchema).to.deep.equal({ oneOf: [{ type: 'string', format: null }, { type: 'number' }] });
     });
 
     describe('Joi.alternatives.conditional', function () {
@@ -346,9 +350,11 @@ describe('Unit | Infrastructure | Datasources | Conversion | joi-to-json-schema'
                 sport: {
                   enum: ['handball'],
                   type: 'string',
+                  format: null,
                 },
                 value: {
                   type: 'string',
+                  format: null,
                 },
               },
               required: ['sport', 'value'],
@@ -361,6 +367,7 @@ describe('Unit | Infrastructure | Datasources | Conversion | joi-to-json-schema'
                 sport: {
                   enum: ['volleyball'],
                   type: 'string',
+                  format: null,
                 },
                 value: {
                   type: 'number',
@@ -407,9 +414,11 @@ describe('Unit | Infrastructure | Datasources | Conversion | joi-to-json-schema'
                 type: {
                   enum: ['handball'],
                   type: 'string',
+                  format: null,
                 },
                 value: {
                   type: 'string',
+                  format: null,
                 },
               },
               required: ['type', 'value'],
@@ -422,6 +431,7 @@ describe('Unit | Infrastructure | Datasources | Conversion | joi-to-json-schema'
                 type: {
                   enum: ['volleyball'],
                   type: 'string',
+                  format: null,
                 },
                 value: {
                   type: 'number',
@@ -472,6 +482,7 @@ describe('Unit | Infrastructure | Datasources | Conversion | joi-to-json-schema'
                     a: {
                       enum: ['a'],
                       type: 'string',
+                      format: null,
                     },
                   },
                   required: ['a'],
@@ -484,6 +495,7 @@ describe('Unit | Infrastructure | Datasources | Conversion | joi-to-json-schema'
                     b: {
                       enum: ['b'],
                       type: 'string',
+                      format: null,
                     },
                   },
                   required: ['b'],
@@ -495,6 +507,7 @@ describe('Unit | Infrastructure | Datasources | Conversion | joi-to-json-schema'
             sport: {
               enum: ['handball', 'volleyball'],
               type: 'string',
+              format: null,
             },
           },
           required: ['sport', 'data'],
@@ -517,6 +530,7 @@ describe('Unit | Infrastructure | Datasources | Conversion | joi-to-json-schema'
               type: {
                 type: 'string',
                 enum: ['qcm'],
+                format: null,
               },
               instruction: {
                 type: 'string',
@@ -534,6 +548,7 @@ describe('Unit | Infrastructure | Datasources | Conversion | joi-to-json-schema'
                     id: {
                       type: 'string',
                       pattern: '^[0-9]+$',
+                      format: null,
                     },
                     content: {
                       type: 'string',
@@ -588,6 +603,7 @@ describe('Unit | Infrastructure | Datasources | Conversion | joi-to-json-schema'
                   type: 'string',
                   pattern: '^[0-9]+$',
                   title: 'solution',
+                  format: null,
                 },
               },
             },
@@ -610,6 +626,7 @@ describe('Unit | Infrastructure | Datasources | Conversion | joi-to-json-schema'
                 type: {
                   type: 'string',
                   enum: ['qcm'],
+                  format: null,
                 },
                 instruction: {
                   type: 'string',
@@ -627,10 +644,12 @@ describe('Unit | Infrastructure | Datasources | Conversion | joi-to-json-schema'
                       id: {
                         type: 'string',
                         pattern: '^[0-9]+$',
+                        format: null,
                       },
                       content: {
                         type: 'string',
                         maxLength: 20,
+                        format: null,
                       },
                     },
                     required: ['id', 'content'],
@@ -681,6 +700,7 @@ describe('Unit | Infrastructure | Datasources | Conversion | joi-to-json-schema'
                     type: 'string',
                     pattern: '^[0-9]+$',
                     title: 'solution',
+                    format: null,
                   },
                 },
               },

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/proposal-content-schema.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/proposal-content-schema.js
@@ -1,9 +1,5 @@
-import Joi from 'joi';
-
 import { htmlNotAllowedSchema, htmlSchema } from '../utils.js';
 
-export const proposalContentSchema = Joi.when(Joi.ref('....hasShortProposals'), {
-  is: true,
-  then: htmlNotAllowedSchema.required().max(20),
-  otherwise: htmlSchema.required(),
-});
+export const shortProposalContentSchema = htmlNotAllowedSchema.max(20);
+
+export const proposalContentSchema = htmlSchema;

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qcm-schema.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qcm-schema.js
@@ -5,29 +5,18 @@ import { feedbackSchema } from './feedback-schema.js';
 import { proposalContentSchema, shortProposalContentSchema } from './proposal-content-schema.js';
 
 const qcmElementSchema = Joi.alternatives().conditional(Joi.object({ hasShortProposals: true }).unknown(), {
-  then: Joi.object({
+  then: _getQcmElementSchemaWithProposalContentSchema(shortProposalContentSchema),
+  otherwise: _getQcmElementSchemaWithProposalContentSchema(proposalContentSchema),
+});
+
+export { qcmElementSchema };
+
+function _getQcmElementSchemaWithProposalContentSchema(proposalContentSchema) {
+  return Joi.object({
     id: uuidSchema,
     type: Joi.string().valid('qcm').required(),
     instruction: htmlSchema.required(),
     hasShortProposals: Joi.boolean().optional().default(false).required(),
-    proposals: Joi.array()
-      .items({
-        id: proposalIdSchema.required(),
-        content: shortProposalContentSchema.required(),
-      })
-      .min(3)
-      .required(),
-    feedbacks: Joi.object({
-      valid: feedbackSchema,
-      invalid: feedbackSchema,
-    }).required(),
-    solutions: Joi.array().items(proposalIdSchema).min(2).required(),
-  }).required(),
-  otherwise: Joi.object({
-    id: uuidSchema,
-    type: Joi.string().valid('qcm').required(),
-    instruction: htmlSchema.required(),
-    hasShortProposals: Joi.boolean().required().default(false).required(),
     proposals: Joi.array()
       .items({
         id: proposalIdSchema.required(),
@@ -40,7 +29,5 @@ const qcmElementSchema = Joi.alternatives().conditional(Joi.object({ hasShortPro
       invalid: feedbackSchema,
     }).required(),
     solutions: Joi.array().items(proposalIdSchema).min(2).required(),
-  }).required(),
-});
-
-export { qcmElementSchema };
+  }).required();
+}

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qcm-schema.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qcm-schema.js
@@ -2,25 +2,45 @@ import Joi from 'joi';
 
 import { htmlSchema, proposalIdSchema, uuidSchema } from '../utils.js';
 import { feedbackSchema } from './feedback-schema.js';
-import { proposalContentSchema } from './proposal-content-schema.js';
+import { proposalContentSchema, shortProposalContentSchema } from './proposal-content-schema.js';
 
-const qcmElementSchema = Joi.object({
-  id: uuidSchema,
-  type: Joi.string().valid('qcm').required(),
-  instruction: htmlSchema.required(),
-  proposals: Joi.array()
-    .items({
-      id: proposalIdSchema,
-      content: proposalContentSchema,
-    })
-    .min(3)
-    .required(),
-  feedbacks: Joi.object({
-    valid: feedbackSchema,
-    invalid: feedbackSchema,
+const qcmElementSchema = Joi.alternatives().conditional(Joi.object({ hasShortProposals: true }).unknown(), {
+  then: Joi.object({
+    id: uuidSchema,
+    type: Joi.string().valid('qcm').required(),
+    instruction: htmlSchema.required(),
+    hasShortProposals: Joi.boolean().optional().default(false).required(),
+    proposals: Joi.array()
+      .items({
+        id: proposalIdSchema.required(),
+        content: shortProposalContentSchema.required(),
+      })
+      .min(3)
+      .required(),
+    feedbacks: Joi.object({
+      valid: feedbackSchema,
+      invalid: feedbackSchema,
+    }).required(),
+    solutions: Joi.array().items(proposalIdSchema).min(2).required(),
   }).required(),
-  solutions: Joi.array().items(proposalIdSchema).min(2).required(),
-  hasShortProposals: Joi.boolean().required().default(false),
-}).required();
+  otherwise: Joi.object({
+    id: uuidSchema,
+    type: Joi.string().valid('qcm').required(),
+    instruction: htmlSchema.required(),
+    hasShortProposals: Joi.boolean().required().default(false).required(),
+    proposals: Joi.array()
+      .items({
+        id: proposalIdSchema.required(),
+        content: proposalContentSchema.required(),
+      })
+      .min(3)
+      .required(),
+    feedbacks: Joi.object({
+      valid: feedbackSchema,
+      invalid: feedbackSchema,
+    }).required(),
+    solutions: Joi.array().items(proposalIdSchema).min(2).required(),
+  }).required(),
+});
 
 export { qcmElementSchema };

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qcu-declarative-schema.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qcu-declarative-schema.js
@@ -5,7 +5,14 @@ import { feedbackNeutralSchema } from './feedback-neutral-schema.js';
 import { proposalContentSchema, shortProposalContentSchema } from './proposal-content-schema.js';
 
 const qcuDeclarativeElementSchema = Joi.alternatives().conditional(Joi.object({ hasShortProposals: true }).unknown(), {
-  then: Joi.object({
+  then: _getQcuDeclarativeSchemaWithProposalContentSchema(shortProposalContentSchema),
+  otherwise: _getQcuDeclarativeSchemaWithProposalContentSchema(proposalContentSchema),
+});
+
+export { qcuDeclarativeElementSchema };
+
+function _getQcuDeclarativeSchemaWithProposalContentSchema(proposalContentSchema) {
+  return Joi.object({
     id: uuidSchema,
     type: Joi.string().valid('qcu-declarative').required(),
     instruction: htmlSchema.required(),
@@ -13,24 +20,9 @@ const qcuDeclarativeElementSchema = Joi.alternatives().conditional(Joi.object({ 
     proposals: Joi.array()
       .items({
         id: proposalIdSchema.required(),
-        content: shortProposalContentSchema.required(),
-        feedback: feedbackNeutralSchema.required(),
-      })
-      .required(),
-  }),
-  otherwise: Joi.object({
-    id: uuidSchema,
-    type: Joi.string().valid('qcu-declarative').required(),
-    instruction: htmlSchema.required(),
-    hasShortProposals: Joi.boolean().required().default(false).required(),
-    proposals: Joi.array()
-      .items({
-        id: proposalIdSchema.required(),
         content: proposalContentSchema.required(),
         feedback: feedbackNeutralSchema.required(),
       })
       .required(),
-  }),
-});
-
-export { qcuDeclarativeElementSchema };
+  });
+}

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qcu-declarative-schema.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qcu-declarative-schema.js
@@ -2,20 +2,35 @@ import Joi from 'joi';
 
 import { htmlSchema, proposalIdSchema, uuidSchema } from '../utils.js';
 import { feedbackNeutralSchema } from './feedback-neutral-schema.js';
-import { proposalContentSchema } from './proposal-content-schema.js';
+import { proposalContentSchema, shortProposalContentSchema } from './proposal-content-schema.js';
 
-const qcuDeclarativeElementSchema = Joi.object({
-  id: uuidSchema,
-  type: Joi.string().valid('qcu-declarative').required(),
-  instruction: htmlSchema.required(),
-  proposals: Joi.array()
-    .items({
-      id: proposalIdSchema.required(),
-      content: proposalContentSchema,
-      feedback: feedbackNeutralSchema.required(),
-    })
-    .required(),
-  hasShortProposals: Joi.boolean().required().default(false),
+const qcuDeclarativeElementSchema = Joi.alternatives().conditional(Joi.object({ hasShortProposals: true }).unknown(), {
+  then: Joi.object({
+    id: uuidSchema,
+    type: Joi.string().valid('qcu-declarative').required(),
+    instruction: htmlSchema.required(),
+    hasShortProposals: Joi.boolean().optional().default(false).required(),
+    proposals: Joi.array()
+      .items({
+        id: proposalIdSchema.required(),
+        content: shortProposalContentSchema.required(),
+        feedback: feedbackNeutralSchema.required(),
+      })
+      .required(),
+  }),
+  otherwise: Joi.object({
+    id: uuidSchema,
+    type: Joi.string().valid('qcu-declarative').required(),
+    instruction: htmlSchema.required(),
+    hasShortProposals: Joi.boolean().required().default(false).required(),
+    proposals: Joi.array()
+      .items({
+        id: proposalIdSchema.required(),
+        content: proposalContentSchema.required(),
+        feedback: feedbackNeutralSchema.required(),
+      })
+      .required(),
+  }),
 });
 
 export { qcuDeclarativeElementSchema };

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qcu-discovery-schema.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qcu-discovery-schema.js
@@ -2,20 +2,37 @@ import Joi from 'joi';
 
 import { htmlSchema, proposalIdSchema, uuidSchema } from '../utils.js';
 import { feedbackNeutralSchema } from './feedback-neutral-schema.js';
+import { proposalContentSchema, shortProposalContentSchema } from './proposal-content-schema.js';
 
-const qcuDiscoveryElementSchema = Joi.object({
-  id: uuidSchema,
-  type: Joi.string().valid('qcu-discovery').required(),
-  instruction: htmlSchema.required(),
-  proposals: Joi.array()
-    .items({
-      id: proposalIdSchema.required(),
-      content: htmlSchema.required(),
-      feedback: feedbackNeutralSchema.required(),
-    })
-    .required(),
-  solution: proposalIdSchema.required(),
-  hasShortProposals: Joi.boolean().required().default(false),
+const qcuDiscoveryElementSchema = Joi.alternatives().conditional(Joi.object({ hasShortProposals: true }).unknown(), {
+  then: Joi.object({
+    id: uuidSchema,
+    type: Joi.string().valid('qcu-discovery').required(),
+    instruction: htmlSchema.required(),
+    hasShortProposals: Joi.boolean().optional().default(false).required(),
+    proposals: Joi.array()
+      .items({
+        id: proposalIdSchema.required(),
+        content: shortProposalContentSchema.required(),
+        feedback: feedbackNeutralSchema.required(),
+      })
+      .required(),
+    solution: proposalIdSchema.required(),
+  }),
+  otherwise: Joi.object({
+    id: uuidSchema,
+    type: Joi.string().valid('qcu-discovery').required(),
+    instruction: htmlSchema.required(),
+    hasShortProposals: Joi.boolean().required().default(false).required(),
+    proposals: Joi.array()
+      .items({
+        id: proposalIdSchema.required(),
+        content: proposalContentSchema.required(),
+        feedback: feedbackNeutralSchema.required(),
+      })
+      .required(),
+    solution: proposalIdSchema.required(),
+  }),
 });
 
 export { qcuDiscoveryElementSchema };

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qcu-discovery-schema.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qcu-discovery-schema.js
@@ -5,25 +5,16 @@ import { feedbackNeutralSchema } from './feedback-neutral-schema.js';
 import { proposalContentSchema, shortProposalContentSchema } from './proposal-content-schema.js';
 
 const qcuDiscoveryElementSchema = Joi.alternatives().conditional(Joi.object({ hasShortProposals: true }).unknown(), {
-  then: Joi.object({
+  then: _getQcuDiscoverySchemaWithProposalContentSchema(shortProposalContentSchema),
+  otherwise: _getQcuDiscoverySchemaWithProposalContentSchema(proposalContentSchema),
+});
+
+function _getQcuDiscoverySchemaWithProposalContentSchema(proposalContentSchema) {
+  return Joi.object({
     id: uuidSchema,
     type: Joi.string().valid('qcu-discovery').required(),
     instruction: htmlSchema.required(),
     hasShortProposals: Joi.boolean().optional().default(false).required(),
-    proposals: Joi.array()
-      .items({
-        id: proposalIdSchema.required(),
-        content: shortProposalContentSchema.required(),
-        feedback: feedbackNeutralSchema.required(),
-      })
-      .required(),
-    solution: proposalIdSchema.required(),
-  }),
-  otherwise: Joi.object({
-    id: uuidSchema,
-    type: Joi.string().valid('qcu-discovery').required(),
-    instruction: htmlSchema.required(),
-    hasShortProposals: Joi.boolean().required().default(false).required(),
     proposals: Joi.array()
       .items({
         id: proposalIdSchema.required(),
@@ -32,7 +23,6 @@ const qcuDiscoveryElementSchema = Joi.alternatives().conditional(Joi.object({ ha
       })
       .required(),
     solution: proposalIdSchema.required(),
-  }),
-});
-
+  });
+}
 export { qcuDiscoveryElementSchema };

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qcu-schema.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qcu-schema.js
@@ -2,21 +2,37 @@ import Joi from 'joi';
 
 import { htmlSchema, proposalIdSchema, uuidSchema } from '../utils.js';
 import { feedbackSchema } from './feedback-schema.js';
-import { proposalContentSchema } from './proposal-content-schema.js';
+import { proposalContentSchema, shortProposalContentSchema } from './proposal-content-schema.js';
 
-const qcuElementSchema = Joi.object({
-  id: uuidSchema,
-  type: Joi.string().valid('qcu').required(),
-  instruction: htmlSchema.required(),
-  proposals: Joi.array()
-    .items({
-      id: proposalIdSchema.required(),
-      content: proposalContentSchema,
-      feedback: feedbackSchema.required(),
-    })
-    .required(),
-  solution: proposalIdSchema.required(),
-  hasShortProposals: Joi.boolean().required().default(false),
+const qcuElementSchema = Joi.alternatives().conditional(Joi.object({ hasShortProposals: true }).unknown(), {
+  then: Joi.object({
+    id: uuidSchema,
+    type: Joi.string().valid('qcu').required(),
+    instruction: htmlSchema.required(),
+    hasShortProposals: Joi.boolean().optional().default(false).required(),
+    proposals: Joi.array()
+      .items({
+        id: proposalIdSchema.required(),
+        content: shortProposalContentSchema.required(),
+        feedback: feedbackSchema.required(),
+      })
+      .required(),
+    solution: proposalIdSchema.required(),
+  }),
+  otherwise: Joi.object({
+    id: uuidSchema,
+    type: Joi.string().valid('qcu').required(),
+    instruction: htmlSchema.required(),
+    hasShortProposals: Joi.boolean().required().default(false).required(),
+    proposals: Joi.array()
+      .items({
+        id: proposalIdSchema.required(),
+        content: proposalContentSchema.required(),
+        feedback: feedbackSchema.required(),
+      })
+      .required(),
+    solution: proposalIdSchema.required(),
+  }),
 });
 
 export { qcuElementSchema };

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qcu-schema.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qcu-schema.js
@@ -5,25 +5,18 @@ import { feedbackSchema } from './feedback-schema.js';
 import { proposalContentSchema, shortProposalContentSchema } from './proposal-content-schema.js';
 
 const qcuElementSchema = Joi.alternatives().conditional(Joi.object({ hasShortProposals: true }).unknown(), {
-  then: Joi.object({
+  then: _getQcuSchemaWithProposalContentSchema(shortProposalContentSchema),
+  otherwise: _getQcuSchemaWithProposalContentSchema(proposalContentSchema),
+});
+
+export { qcuElementSchema };
+
+function _getQcuSchemaWithProposalContentSchema(proposalContentSchema) {
+  return Joi.object({
     id: uuidSchema,
     type: Joi.string().valid('qcu').required(),
     instruction: htmlSchema.required(),
     hasShortProposals: Joi.boolean().optional().default(false).required(),
-    proposals: Joi.array()
-      .items({
-        id: proposalIdSchema.required(),
-        content: shortProposalContentSchema.required(),
-        feedback: feedbackSchema.required(),
-      })
-      .required(),
-    solution: proposalIdSchema.required(),
-  }),
-  otherwise: Joi.object({
-    id: uuidSchema,
-    type: Joi.string().valid('qcu').required(),
-    instruction: htmlSchema.required(),
-    hasShortProposals: Joi.boolean().required().default(false).required(),
     proposals: Joi.array()
       .items({
         id: proposalIdSchema.required(),
@@ -32,7 +25,5 @@ const qcuElementSchema = Joi.alternatives().conditional(Joi.object({ hasShortPro
       })
       .required(),
     solution: proposalIdSchema.required(),
-  }),
-});
-
-export { qcuElementSchema };
+  });
+}


### PR DESCRIPTION
## 🥀 Problème
Actuellement, le script qui génère le json schema sur lequel se base modulix editor, ne supporte pas la fonctionnalité `if/then/otherwise` de Joi.

## 🏹 Proposition
Faire la mise à jour du script pour prendre en compte cette compatibilité.

## 💌 Remarques
Il a également été ajouté le fait de mettre un format de string à null quand ce n'est pas du texte qui inclu du html. Cela permet dans modulix editor d'afficher un champs texte basique, sans le wysiwyg jodit.

Une fois la PR mergée, il faudra effectuer une mise à jour du json schema dans modulix-editor

## ❤️‍🔥 Pour tester
Les tests sont verts