### PR TITLE
[FEATURE] Afficher l'id des éléments sur la preview d'un module (PIX-21512).

### DIFF
--- a/mon-pix/app/components/module/component/element.gjs
+++ b/mon-pix/app/components/module/component/element.gjs
@@ -1,4 +1,6 @@
+import PixTag from '@1024pix/pix-ui/components/pix-tag';
 import { action } from '@ember/object';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { eq } from 'ember-truth-helpers';
 import AudioElement from 'mon-pix/components/module/element/audio';
@@ -24,6 +26,8 @@ import ENV from 'mon-pix/config/environment';
 export const VERIFY_RESPONSE_DELAY = ENV.APP.MODULIX_VERIFICATION_RESPONSE_DELAY;
 
 export default class ModulixElement extends Component {
+  @service modulixPreviewMode;
+
   // @deprecated to remove due to function not being used anymore on qcu, qcm and qrocm element
   @action
   getLastCorrectionForElement() {
@@ -31,6 +35,12 @@ export default class ModulixElement extends Component {
   }
 
   <template>
+    {{#if this.modulixPreviewMode.isPreviewAndElementsIdButtonEnabled}}
+      <PixTag @color="yellow" class="modulix-preview__elements-id-tag">
+        {{! template-lint-disable "no-bare-strings" }}
+        <p>element-id: {{@element.id}}</p>
+      </PixTag>
+    {{/if}}
     {{#if (eq @element.type "text")}}
       <TextElement @text={{@element}} />
     {{else if (eq @element.type "image")}}

--- a/mon-pix/app/components/module/preview.gjs
+++ b/mon-pix/app/components/module/preview.gjs
@@ -13,6 +13,8 @@ import { notEq } from 'ember-truth-helpers';
 import ModulixGrain from 'mon-pix/components/module/grain/grain';
 import ModulixSectionTitle from 'mon-pix/components/module/section-title';
 
+import didInsert from '../../modifiers/modifier-did-insert';
+
 export default class ModulixPreview extends Component {
   @service store;
   @service modulixPreviewMode;
@@ -155,6 +157,15 @@ export default class ModulixPreview extends Component {
     this.moduleCodeDisplayed = !this.moduleCodeDisplayed;
   }
 
+  @action
+  setHTMLElementOffset(htmlElement) {
+    const bannerElement = document.getElementById('pix-layout-banner-container');
+    if (!bannerElement) return;
+    const distanceBetweenNavigationAndBanner = 8;
+    const top = bannerElement.getBoundingClientRect().height + distanceBetweenNavigationAndBanner;
+    htmlElement.style.setProperty('top', `${top}px `);
+  }
+
   <template>
     {{pageTitle this.formattedModule.title}}
 
@@ -175,7 +186,7 @@ export default class ModulixPreview extends Component {
       </div>
     {{/unless}}
 
-    <div class="modulix-preview__elements-id-button">
+    <div class="modulix-preview__elements-id-button" {{didInsert this.setHTMLElementOffset}}>
       <PixSegmentedControl @onChange={{this.enableElementsIdButton}} @variant="primary" @toggled={{true}}>
         <:label>{{t "pages.modulix.preview.elements-id-button.label"}}</:label>
         <:viewA>{{t "pages.modulix.preview.elements-id-button.choices.yes"}}</:viewA>

--- a/mon-pix/app/components/module/preview.gjs
+++ b/mon-pix/app/components/module/preview.gjs
@@ -1,5 +1,6 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import PixSegmentedControl from '@1024pix/pix-ui/components/pix-segmented-control';
 import PixTextarea from '@1024pix/pix-ui/components/pix-textarea';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
@@ -131,6 +132,11 @@ export default class ModulixPreview extends Component {
   noop() {}
 
   @action
+  enableElementsIdButton() {
+    this.modulixPreviewMode.enableElementsIdButton();
+  }
+
+  @action
   updateModule(event) {
     try {
       this.errorMessage = null;
@@ -168,6 +174,14 @@ export default class ModulixPreview extends Component {
         </PixButtonLink>
       </div>
     {{/unless}}
+
+    <div class="modulix-preview__elements-id-button">
+      <PixSegmentedControl @onChange={{this.enableElementsIdButton}} @variant="primary" @toggled={{true}}>
+        <:label>{{t "pages.modulix.preview.elements-id-button.label"}}</:label>
+        <:viewA>{{t "pages.modulix.preview.elements-id-button.choices.yes"}}</:viewA>
+        <:viewB>{{t "pages.modulix.preview.elements-id-button.choices.no"}}</:viewB>
+      </PixSegmentedControl>
+    </div>
 
     <div class="module-preview {{if this.moduleCodeDisplayed 'module-preview--with-editor'}}">
       <aside class="module-preview__passage module-passage">

--- a/mon-pix/app/components/module/preview.gjs
+++ b/mon-pix/app/components/module/preview.gjs
@@ -164,8 +164,7 @@ export default class ModulixPreview extends Component {
           @size="small"
           target="_blank"
         >
-          {{! template-lint-disable "no-bare-strings" }}
-          Modulix Editor
+          {{t "pages.modulix.preview.modulix-editor"}}
         </PixButtonLink>
       </div>
     {{/unless}}

--- a/mon-pix/app/services/modulix-preview-mode.js
+++ b/mon-pix/app/services/modulix-preview-mode.js
@@ -1,9 +1,20 @@
+import { action } from '@ember/object';
 import Service from '@ember/service';
+import { tracked } from '@glimmer/tracking';
 
 export default class ModulixPreviewModeService extends Service {
   isEnabled = false;
+  @tracked isElementsIdButtonEnabled = false;
 
   enable() {
     this.isEnabled = true;
+  }
+
+  get isPreviewAndElementsIdButtonEnabled() {
+    return this.isEnabled && this.isElementsIdButtonEnabled;
+  }
+
+  @action enableElementsIdButton() {
+    this.isElementsIdButtonEnabled = !this.isElementsIdButtonEnabled;
   }
 }

--- a/mon-pix/app/styles/components/llm/preview.scss
+++ b/mon-pix/app/styles/components/llm/preview.scss
@@ -16,4 +16,8 @@
     border: 2px solid var(--pix-primary-100);
     border-radius: 4px;
   }
+
+  &__elements-id-tag {
+    margin: var(--pix-spacing-2x) 0;
+  }
 }

--- a/mon-pix/app/styles/components/llm/preview.scss
+++ b/mon-pix/app/styles/components/llm/preview.scss
@@ -3,3 +3,17 @@
   height: 600px;
   border: none;
 }
+
+.modulix-preview {
+  &__elements-id-button {
+    position: sticky;
+    top: var(--pix-spacing-6x);
+    z-index: 200;
+    display: inline-block;
+    margin-left: var(--pix-spacing-6x);
+    padding: var(--pix-spacing-4x);
+    background-color: var(--pix-neutral-0);
+    border: 2px solid var(--pix-primary-100);
+    border-radius: 4px;
+  }
+}

--- a/mon-pix/tests/integration/components/module/component/element_test.gjs
+++ b/mon-pix/tests/integration/components/module/component/element_test.gjs
@@ -1,4 +1,5 @@
 import { render } from '@1024pix/ember-testing-library';
+import Service from '@ember/service';
 import { findAll } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import ModulixElement from 'mon-pix/components/module/component/element';
@@ -457,5 +458,40 @@ module('Integration | Component | Module | Element', function (hooks) {
 
     // then
     assert.dom(screen.getByRole('button', { name: 'Option A: Vrai' })).exists();
+  });
+
+  module('when preview mode is enabled and elements id button clicked', function () {
+    test('should display a tag with element Id', async function (assert) {
+      // given
+      class PreviewModeServiceStub extends Service {
+        isPreviewAndElementsIdButtonEnabled = true;
+      }
+      this.owner.register('service:modulixPreviewMode', PreviewModeServiceStub);
+
+      const element = {
+        id: 'ed795d29-5f04-499c-a9c8-4019125c5cb1',
+        type: 'qab',
+        instruction: '<p>Hello.</p>',
+        cards: [
+          {
+            id: 'e222b060-7c18-4ee2-afe2-2ae27c28946a',
+            image: {
+              url: 'https://assets.pix.org/modules/bac-a-sable/boules-de-petanque.jpg',
+              altText: '',
+            },
+            text: 'Les boules de pétanques sont creuses.',
+            proposalA: 'Vrai',
+            proposalB: 'Faux',
+            solution: 'A',
+          },
+        ],
+      };
+
+      // when
+      const screen = await render(<template><ModulixElement @element={{element}} /></template>);
+
+      // then
+      assert.dom(screen.getByText('element-id: ed795d29-5f04-499c-a9c8-4019125c5cb1')).exists();
+    });
   });
 });

--- a/mon-pix/tests/integration/components/module/preview_test.gjs
+++ b/mon-pix/tests/integration/components/module/preview_test.gjs
@@ -132,4 +132,15 @@ module('Integration | Component | Module | Preview', function (hooks) {
       });
     });
   });
+
+  test('should display a button display elements id', async function (assert) {
+    // given
+    //  when
+    const screen = await render(<template><ModulixPreview /></template>);
+
+    // then
+    assert.dom(screen.getByRole('radiogroup', { name: t('pages.modulix.preview.elements-id-button.label') })).exists();
+    assert.dom(screen.getByRole('radio', { name: t('pages.modulix.preview.elements-id-button.choices.yes') })).exists();
+    assert.dom(screen.getByRole('radio', { name: t('pages.modulix.preview.elements-id-button.choices.no') })).exists();
+  });
 });

--- a/mon-pix/tests/unit/services/modulix-preview-mode-test.js
+++ b/mon-pix/tests/unit/services/modulix-preview-mode-test.js
@@ -22,4 +22,67 @@ module('Unit | Service | modulix-preview-mode', function (hooks) {
     // then
     assert.true(previewMode.isEnabled);
   });
+
+  module('isElementsIdButtonEnabled', function () {
+    test('it should be disabled by default', function (assert) {
+      // when
+      const previewMode = this.owner.lookup('service:modulix-preview-mode');
+
+      // then
+      assert.false(previewMode.isElementsIdButtonEnabled);
+    });
+
+    test('it enables elements id button', function (assert) {
+      // given
+      const previewMode = this.owner.lookup('service:modulix-preview-mode');
+
+      // when
+      previewMode.enableElementsIdButton();
+
+      // then
+      assert.true(previewMode.isElementsIdButtonEnabled);
+    });
+
+    module('get isPreviewAndElementsIdButtonEnabled', function () {
+      module('when preview mode is not enabled', function () {
+        test('it returns false', function (assert) {
+          // given
+          const previewMode = this.owner.lookup('service:modulix-preview-mode');
+
+          // when
+          previewMode.enableElementsIdButton();
+
+          // then
+          assert.false(previewMode.isPreviewAndElementsIdButtonEnabled);
+        });
+      });
+
+      module('when elements id button is not enabled', function () {
+        test('it returns false', function (assert) {
+          // given
+          const previewMode = this.owner.lookup('service:modulix-preview-mode');
+
+          // when
+          previewMode.enable();
+
+          // then
+          assert.false(previewMode.isPreviewAndElementsIdButtonEnabled);
+        });
+      });
+
+      module('when both are enabled', function () {
+        test('it returns true', function (assert) {
+          // given
+          const previewMode = this.owner.lookup('service:modulix-preview-mode');
+
+          // when
+          previewMode.enable();
+          previewMode.enableElementsIdButton();
+
+          // then
+          assert.true(previewMode.isPreviewAndElementsIdButtonEnabled);
+        });
+      });
+    });
+  });
 });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1722,6 +1722,7 @@
         }
       },
       "preview": {
+        "modulix-editor": "Modulix Editor",
         "showJson": "Show JSON",
         "stepper": "Preview : stepper {direction}",
         "textarea-label": "Module content"

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1722,6 +1722,13 @@
         }
       },
       "preview": {
+        "elements-id-button": {
+          "choices": {
+            "no": "No",
+            "yes": "Yes"
+          },
+          "label": "Display elements ID"
+        },
         "modulix-editor": "Modulix Editor",
         "showJson": "Show JSON",
         "stepper": "Preview : stepper {direction}",

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1718,6 +1718,7 @@
         }
       },
       "preview": {
+        "modulix-editor": "Modulix Editor",
         "showJson": "Show JSON",
         "stepper": "Preview : stepper {direction}",
         "textarea-label": "Contenido del módulo"

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1718,6 +1718,13 @@
         }
       },
       "preview": {
+        "elements-id-button": {
+          "choices": {
+            "no": "No",
+            "yes": "Si"
+          },
+          "label": "Mostrar ID de los elementos"
+        },
         "modulix-editor": "Modulix Editor",
         "showJson": "Show JSON",
         "stepper": "Preview : stepper {direction}",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1730,6 +1730,13 @@
         }
       },
       "preview": {
+        "elements-id-button": {
+          "choices": {
+            "no": "Non",
+            "yes": "Oui"
+          },
+          "label": "Afficher l'ID des éléments"
+        },
         "modulix-editor": "Modulix Editor",
         "showJson": "Afficher le JSON",
         "stepper": "Preview : stepper {direction}",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1730,6 +1730,7 @@
         }
       },
       "preview": {
+        "modulix-editor": "Modulix Editor",
         "showJson": "Afficher le JSON",
         "stepper": "Preview : stepper {direction}",
         "textarea-label": "Contenu du Module"

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1722,6 +1722,13 @@
         }
       },
       "preview": {
+        "elements-id-button": {
+          "choices": {
+            "no": "Nee",
+            "yes": "Ja"
+          },
+          "label": "De ID's van de elementen weergeven"
+        },
         "modulix-editor": "Modulix Editor",
         "showJson": "Show JSON",
         "stepper": "Preview : stepper {direction}",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1722,6 +1722,7 @@
         }
       },
       "preview": {
+        "modulix-editor": "Modulix Editor",
         "showJson": "Show JSON",
         "stepper": "Preview : stepper {direction}",
         "textarea-label": "Inhoud module"


### PR DESCRIPTION
## 🥀 Problème
Le métier veut pouvoir traiter les signalements efficacement, et un des cas de figure qu’ils rencontrent c’est de pouvoir identifier les elementIds concernés par les signalement sur Pix App.

## 🏹 Proposition

En preview uniquement, afficher un bouton permettant de montrer les elementIds ou de les masquer

## 💌 Remarques

Pourquoi ces choix design : 

- le `sticky`, le bouton est disponible lorsque le métier déroule un module.
  - Pourquoi à gauche ? Parce qu'en version affichage JSON, le JSON apparaît à droite. Ça perturberait la lecture.
- le tag en jaune. Choix perso, je trouve qu'il ressort bien mais je me rangerais aux préférences du métier.

Pourquoi le service `previewMode` : 

- Sinon je suis obligé de traverser tous les components.
- Je trouve ce service plutôt adéquat puisque qu'il concerne la preview.

## ❤️‍🔥 Pour tester

On a deux usages coté métier : 

https://app-pr15114.review.pix.fr/modules/preview/bac-a-sable/
=> voir le comportement du bouton et l'affichage des tags


https://app-pr15114.review.pix.fr/modules/preview/
=> (C'est la vue avec JSON) voir le comportement du bouton et l'affichage des tags

---

https://app-pr15114.review.pix.fr/modules/bac-a-sable
=> s'assurer que le bouton n'apparaît pas pour l'utilisateur
