### PR TITLE
[BUGFIX] Logger et ne plus cacher les erreurs liés au manque d'épreuve de get-next-challenge de certif (PIX-21514).

### DIFF
--- a/api/src/certification/evaluation/application/api/select-next-certification-challenge-api.js
+++ b/api/src/certification/evaluation/application/api/select-next-certification-challenge-api.js
@@ -1,5 +1,6 @@
 /**
  * @typedef {import ('../../../../shared/domain/errors.js').AssessmentEndedError} AssessmentEndedError
+ * @typedef {import ('../../../../shared/domain/errors.js').AssessmentLackOfChallengesError} AssessmentLackOfChallengesError
  * @typedef {import ('../../../../shared/domain/models/Challenge.js').Challenge} Challenge
  * @typedef {import ('./models/CertificationAssessmentIdentifier.js').CertificationAssessmentIdentifier} CertificationAssessmentIdentifier
  */
@@ -17,7 +18,7 @@ import * as assessmentRepository from '../../infrastructure/repositories/assessm
  *
  * @returns {Challenge}
  * @throws {AssessmentEndedError} test ended or no next challenge available
- * @throws {RangeError} illegal V3 certification algorithm state
+ * @throws {AssessmentLackOfChallengesError} no eligible challenges remaining before reaching maximum assessment length
  */
 export const selectNextCertificationChallenge = withTransaction(
   async ({

--- a/api/src/certification/evaluation/domain/models/FlashAssessmentAlgorithm.js
+++ b/api/src/certification/evaluation/domain/models/FlashAssessmentAlgorithm.js
@@ -5,6 +5,7 @@
  * @typedef {import('../services/algorithm-methods/flash.js')} FlashAlgorithmImplementation
  */
 
+import { AssessmentLackOfChallengesError } from '../../../../shared/domain/errors.js';
 import { FlashAssessmentAlgorithmChallengesBetweenCompetencesRule } from './FlashAssessmentAlgorithmChallengesBetweenCompetencesRule.js';
 import { FlashAssessmentAlgorithmNonAnsweredSkillsRule } from './FlashAssessmentAlgorithmNonAnsweredSkillsRule.js';
 import { FlashAssessmentAlgorithmOneQuestionPerTubeRule } from './FlashAssessmentAlgorithmOneQuestionPerTubeRule.js';
@@ -65,7 +66,10 @@ class FlashAssessmentAlgorithm {
     const challengesAfterRulesApplication = this.#applyChallengeSelectionRules(assessmentAnswers, challenges);
 
     if (challengesAfterRulesApplication?.length === 0) {
-      throw new RangeError('No eligible challenges in referential');
+      throw new AssessmentLackOfChallengesError({
+        numberOfAnswers: assessmentAnswers?.length,
+        maximumAssessmentLength,
+      });
     }
 
     return this.flashAlgorithmImplementation.getPossibleNextChallenges({

--- a/api/src/shared/domain/errors.js
+++ b/api/src/shared/domain/errors.js
@@ -40,9 +40,7 @@ class AssessmentEndedError extends DomainError {
 
 class AssessmentLackOfChallengesError extends AssessmentEndedError {
   constructor({ numberOfAnswers, maximumAssessmentLength } = {}) {
-    super(
-      `No eligible challenges remaining. ${numberOfAnswers} answers (maximum was ${maximumAssessmentLength})`,
-    );
+    super(`No eligible challenges remaining. ${numberOfAnswers} answers (maximum was ${maximumAssessmentLength})`);
     this.numberOfAnswers = numberOfAnswers;
     this.maximumAssessmentLength = maximumAssessmentLength;
   }

--- a/api/src/shared/domain/errors.js
+++ b/api/src/shared/domain/errors.js
@@ -38,6 +38,16 @@ class AssessmentEndedError extends DomainError {
   }
 }
 
+class AssessmentLackOfChallengesError extends AssessmentEndedError {
+  constructor({ numberOfAnswers, maximumAssessmentLength } = {}) {
+    super(
+      `No eligible challenges remaining. ${numberOfAnswers} answers (maximum was ${maximumAssessmentLength})`,
+    );
+    this.numberOfAnswers = numberOfAnswers;
+    this.maximumAssessmentLength = maximumAssessmentLength;
+  }
+}
+
 class AssessmentResultNotCreatedError extends DomainError {
   constructor(message = "L'assessment result n'a pas pu être généré.") {
     super(message);
@@ -1021,6 +1031,7 @@ export {
   ApplicationScopeNotAllowedError,
   ApplicationWithInvalidCredentialsError,
   AssessmentEndedError,
+  AssessmentLackOfChallengesError,
   AssessmentNotCompletedError,
   AssessmentResultNotCreatedError,
   AuditLoggerApiError,

--- a/api/src/shared/domain/usecases/update-assessment-with-next-challenge.js
+++ b/api/src/shared/domain/usecases/update-assessment-with-next-challenge.js
@@ -41,7 +41,11 @@ export async function updateAssessmentWithNextChallenge({
   } catch (error) {
     if (error instanceof AssessmentLackOfChallengesError) {
       logger.warn(
-        { assessmentId: assessment.id, numberOfAnswers: error.numberOfAnswers, maximumAssessmentLength: error.maximumAssessmentLength },
+        {
+          assessmentId: assessment.id,
+          numberOfAnswers: error.numberOfAnswers,
+          maximumAssessmentLength: error.maximumAssessmentLength,
+        },
         'Assessment ended prematurely: no challenge remaining before reaching maximum assessment length',
       );
       nextChallenge = null;

--- a/api/tests/certification/shared/unit/domain/models/FlashAssessmentAlgorithm_test.js
+++ b/api/tests/certification/shared/unit/domain/models/FlashAssessmentAlgorithm_test.js
@@ -1,5 +1,6 @@
 import { FlashAssessmentAlgorithm } from '../../../../../../src/certification/evaluation/domain/models/FlashAssessmentAlgorithm.js';
 import { FlashAssessmentAlgorithmConfiguration } from '../../../../../../src/certification/shared/domain/models/FlashAssessmentAlgorithmConfiguration.js';
+import { AssessmentLackOfChallengesError } from '../../../../../../src/shared/domain/errors.js';
 import { catchErrSync, domainBuilder, expect, sinon } from '../../../../../test-helper.js';
 
 const baseFlashAssessmentAlgorithmConfig = {
@@ -236,6 +237,58 @@ describe('Unit | Domain | Models | FlashAssessmentAlgorithm', function () {
             expectedChallenges,
           );
         });
+      });
+    });
+
+    context('when all challenges are eliminated by rules', function () {
+      it('should throw an AssessmentLackOfChallengesError', function () {
+        // given
+        const initialCapacity = baseFlashAssessmentAlgorithmConfig.defaultCandidateCapacity;
+        const computedCapacity = 2;
+        const algorithm = new FlashAssessmentAlgorithm({
+          flashAlgorithmImplementation,
+          configuration: _getAlgorithmConfig({
+            maximumAssessmentLength: 32,
+            limitToOneQuestionPerTube: true,
+          }),
+        });
+
+        const skill1 = domainBuilder.buildSkill({ id: 'skill1', tubeId: 'tube1' });
+        const skill2 = domainBuilder.buildSkill({ id: 'skill2', tubeId: 'tube1' });
+
+        const answeredChallenge = domainBuilder.buildChallenge({
+          id: 'answeredChallenge',
+          skill: skill1,
+        });
+        const remainingChallenge = domainBuilder.buildChallenge({
+          id: 'remainingChallenge',
+          skill: skill2,
+        });
+
+        const assessmentAnswers = [
+          domainBuilder.buildAnswer({ challengeId: answeredChallenge.id }),
+        ];
+        const challenges = [answeredChallenge, remainingChallenge];
+
+        flashAlgorithmImplementation.getCapacityAndErrorRate
+          .withArgs(
+            _getCapacityAndErrorRateParams({
+              allAnswers: assessmentAnswers,
+              challenges,
+              capacity: initialCapacity,
+            }),
+          )
+          .returns({ capacity: computedCapacity });
+
+        // when
+        const error = catchErrSync(({ assessmentAnswers, challenges }) =>
+          algorithm.getPossibleNextChallenges({ assessmentAnswers, challenges }),
+        )({ assessmentAnswers, challenges });
+
+        // then
+        expect(error).to.be.instanceOf(AssessmentLackOfChallengesError);
+        expect(error.numberOfAnswers).to.equal(1);
+        expect(error.maximumAssessmentLength).to.equal(32);
       });
     });
   });

--- a/api/tests/certification/shared/unit/domain/models/FlashAssessmentAlgorithm_test.js
+++ b/api/tests/certification/shared/unit/domain/models/FlashAssessmentAlgorithm_test.js
@@ -265,9 +265,7 @@ describe('Unit | Domain | Models | FlashAssessmentAlgorithm', function () {
           skill: skill2,
         });
 
-        const assessmentAnswers = [
-          domainBuilder.buildAnswer({ challengeId: answeredChallenge.id }),
-        ];
+        const assessmentAnswers = [domainBuilder.buildAnswer({ challengeId: answeredChallenge.id })];
         const challenges = [answeredChallenge, remainingChallenge];
 
         flashAlgorithmImplementation.getCapacityAndErrorRate

--- a/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-for-certification_test.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-for-certification_test.js
@@ -202,7 +202,7 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-certif
           lastChallengeId: firstChallengeId,
           userId,
           lastQuestionDate: new Date('2020-01-20'),
-          state: 'started',
+          state: Assessment.states.COMPLETED,
         });
         databaseBuilder.factory.buildCertificationChallengeLiveAlert({
           assessmentId: assessment.id,

--- a/api/tests/shared/acceptance/application/assessments/assessment-controller-get_test.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-controller-get_test.js
@@ -26,7 +26,7 @@ describe('Acceptance | API | assessment-controller-get', function () {
         const assessmentId = databaseBuilder.factory.buildAssessment({
           userId,
           courseId,
-          state: Assessment.states.STARTED,
+          state: Assessment.states.COMPLETED,
           type: Assessment.types.CERTIFICATION,
           certificationCourseId,
         }).id;
@@ -46,7 +46,7 @@ describe('Acceptance | API | assessment-controller-get', function () {
           type: 'assessments',
           id: assessmentId.toString(),
           attributes: {
-            state: Assessment.states.STARTED,
+            state: Assessment.states.COMPLETED,
             title: certificationCourseId,
             type: Assessment.types.CERTIFICATION,
             'certification-number': certificationCourseId,
@@ -267,7 +267,7 @@ describe('Acceptance | API | assessment-controller-get', function () {
         const assessmentId = databaseBuilder.factory.buildAssessment({
           userId: null,
           courseId,
-          state: Assessment.states.STARTED,
+          state: Assessment.states.COMPLETED,
           type: Assessment.types.DEMO,
         }).id;
         await databaseBuilder.commit();
@@ -285,7 +285,7 @@ describe('Acceptance | API | assessment-controller-get', function () {
           type: 'assessments',
           id: assessmentId.toString(),
           attributes: {
-            state: Assessment.states.STARTED,
+            state: Assessment.states.COMPLETED,
             title: courseName,
             type: Assessment.types.DEMO,
             'has-ongoing-challenge-live-alert': false,

--- a/api/tests/shared/unit/domain/usecases/update-assessment-with-next-challenge_test.js
+++ b/api/tests/shared/unit/domain/usecases/update-assessment-with-next-challenge_test.js
@@ -285,6 +285,20 @@ describe('Shared | Unit | Domain | Use Cases | get-next-challenge', function () 
             expect(assessmentWithoutChallenge.nextChallenge).to.be.null;
           });
         });
+
+        context('when an unexpected error occurs', function () {
+          it('should propagate the error', async function () {
+            // given
+            const unexpectedError = new Error('Some unexpected error');
+            certificationEvaluationRepository_selectNextCertificationChallengeStub.rejects(unexpectedError);
+
+            // when
+            const promise = updateAssessmentWithNextChallenge({ assessment, ...dependencies });
+
+            // then
+            await expect(promise).to.be.rejectedWith(unexpectedError);
+          });
+        });
       });
 
       context('for assessment of type unknown', function () {

--- a/api/tests/shared/unit/domain/usecases/update-assessment-with-next-challenge_test.js
+++ b/api/tests/shared/unit/domain/usecases/update-assessment-with-next-challenge_test.js
@@ -1,4 +1,4 @@
-import { AssessmentEndedError } from '../../../../../src/shared/domain/errors.js';
+import { AssessmentEndedError, AssessmentLackOfChallengesError } from '../../../../../src/shared/domain/errors.js';
 import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
 import { updateAssessmentWithNextChallenge } from '../../../../../src/shared/domain/usecases/update-assessment-with-next-challenge.js';
 import { domainBuilder, expect, preventStubsToBeCalledUnexpectedly, sinon } from '../../../../test-helper.js';
@@ -281,6 +281,21 @@ describe('Shared | Unit | Domain | Use Cases | get-next-challenge', function () 
 
             // when
             const assessmentWithoutChallenge = await updateAssessmentWithNextChallenge({ assessment, ...dependencies });
+            // then
+            expect(assessmentWithoutChallenge.nextChallenge).to.be.null;
+          });
+        });
+
+        context('when the referential is exhausted before reaching maximum assessment length', function () {
+          it('should return an assessment with no nextChallenge', async function () {
+            // given
+            certificationEvaluationRepository_selectNextCertificationChallengeStub.rejects(
+              new AssessmentLackOfChallengesError({ numberOfAnswers: 27, maximumAssessmentLength: 32 }),
+            );
+
+            // when
+            const assessmentWithoutChallenge = await updateAssessmentWithNextChallenge({ assessment, ...dependencies });
+
             // then
             expect(assessmentWithoutChallenge.nextChallenge).to.be.null;
           });


### PR DESCRIPTION
## 🥀 Problème

Suite à des problèmes de certifications ne proposant pas assez d'épreuve, sans raison, nous nous sommes rendus compte que le `get-next-challenge` ne loggait aucune information nous permettant de pouvoir connaître les conditions amenant à ce problème.

## 🏹 Proposition

Ajouter des logs lorsque la fin de certif se fait avant la fin prévue initialement.

## ❤️‍🔥 Pour tester

Tests verts ✅ 