### PR TITLE
[BUGFIX] Correction d'une régression sur les `qcu_image` et `qcm_image` de Pix Junior (PIX-21518)

### DIFF
--- a/junior/app/components/challenge/content/embedded-web-component.gjs
+++ b/junior/app/components/challenge/content/embedded-web-component.gjs
@@ -5,7 +5,7 @@ import didRender from '../../../modifiers/did-render';
 
 export default class EmbeddedWebComponent extends Component {
   #customElement;
-  #handleAnswer = (event) => this.args.setAnswerValue(event.detail[0]);
+  #handleAnswer = (event) => this.args.setAnswerValue(event.detail[0]?.answer);
 
   @action
   mountCustomElement(container) {


### PR DESCRIPTION
## 🥀 Problème

La [mise à jour](https://github.com/1024pix/pix/pull/15004) de la librairie `@1024pix/epreuves-components` en 2.7.0 a introduit une régression sur la validation des `qcm_image` et `qcu_image` dans Pix Junior.

## 🏹 Proposition

Prendre en compte le nouveau format d'évènements envoyés par les webcomponents (`{ answer: 'patate' }` au lieu de `'patate'`)

## 💌 Remarques

Un test d'acceptance est à écrire, et sera implémenté dans le cadre d'une autre PR.
