### PR TITLE
[FEATURE] Pouvoir modifier le public prescrit d'une organisation lors de la modification en masse (PIX-21327)

### DIFF
--- a/admin/app/components/organizations/information-section-edit.gjs
+++ b/admin/app/components/organizations/information-section-edit.gjs
@@ -70,8 +70,8 @@ export default class OrganizationInformationSectionEditionMode extends Component
         ? `${this.args.organization.administrationTeamId}`
         : null,
       countryCode: this.args.organization.countryCode ? `${this.args.organization.countryCode}` : null,
-      organizationLearnerTypeName: this.args.organization.organizationLearnerTypeName
-        ? this.args.organization.organizationLearnerTypeName
+      organizationLearnerTypeId: this.args.organization.organizationLearnerTypeId
+        ? `${this.args.organization.organizationLearnerTypeId}`
         : null,
     };
   }
@@ -102,7 +102,7 @@ export default class OrganizationInformationSectionEditionMode extends Component
 
   get organizationLearnerTypeOptions() {
     const options = this.organizationLearnerTypes.map((organizationLearnerType) => ({
-      value: organizationLearnerType.name,
+      value: organizationLearnerType.id,
       label: organizationLearnerType.name,
     }));
     return options;
@@ -166,6 +166,10 @@ export default class OrganizationInformationSectionEditionMode extends Component
       (team) => team.id === this.form.administrationTeamId,
     )?.name;
 
+    const organizationLearnerTypeName = this.organizationLearnerTypes.find(
+      (organizationLearnerType) => organizationLearnerType.id === this.form.organizationLearnerTypeId,
+    )?.name;
+
     const countryName = this.countries.find((country) => country.code === this.form.countryCode)?.name;
 
     this.args.organization.set('name', this.form.name);
@@ -183,7 +187,8 @@ export default class OrganizationInformationSectionEditionMode extends Component
     this.args.organization.set('administrationTeamName', administrationTeamName);
     this.args.organization.set('countryCode', this.form.countryCode);
     this.args.organization.set('countryName', countryName ?? null);
-    this.args.organization.set('organizationLearnerTypeName', this.form.organizationLearnerTypeName);
+    this.args.organization.set('organizationLearnerTypeId', this.form.organizationLearnerTypeId);
+    this.args.organization.set('organizationLearnerTypeName', organizationLearnerTypeName);
 
     this.closeAndResetForm();
     return this.args.onSubmit();
@@ -237,13 +242,13 @@ export default class OrganizationInformationSectionEditionMode extends Component
             @aria-required={{true}}
             @requiredLabel={{t "common.forms.mandatory"}}
             @errorMessage={{if
-              this.validator.errors.organizationLearnerTypeName
-              (t this.validator.errors.organizationLearnerTypeName)
+              this.validator.errors.organizationLearnerTypeId
+              (t this.validator.errors.organizationLearnerTypeId)
             }}
-            @validationStatus={{if this.validator.errors.organizationLearnerTypeName "error"}}
+            @validationStatus={{if this.validator.errors.organizationLearnerTypeId "error"}}
             @options={{this.organizationLearnerTypeOptions}}
-            @value={{this.form.organizationLearnerTypeName}}
-            @onChange={{fn this.updateValue "organizationLearnerTypeName"}}
+            @value={{this.form.organizationLearnerTypeId}}
+            @onChange={{fn this.updateValue "organizationLearnerTypeId"}}
             @hideDefaultOption={{true}}
             @isFullWidth={{true}}
             @placeholder={{t "components.organizations.editing.organization-learner-type.selector.placeholder"}}
@@ -454,7 +459,7 @@ const ORGANIZATION_FORM_VALIDATION_SCHEMA = Joi.object({
     'any.required': 'components.organizations.editing.country.selector.error-message',
     'string.empty': 'components.organizations.editing.country.selector.error-message',
   }),
-  organizationLearnerTypeName: Joi.string().empty(['', null]).required().messages({
+  organizationLearnerTypeId: Joi.string().empty(['', null]).required().messages({
     'any.required': 'components.organizations.editing.organization-learner-type.selector.error-message',
     'string.empty': 'components.organizations.editing.organization-learner-type.selector.error-message',
   }),

--- a/admin/app/models/organization.js
+++ b/admin/app/models/organization.js
@@ -30,6 +30,7 @@ export default class Organization extends Model {
   @attr('string') administrationTeamName;
   @attr('number') countryCode;
   @attr('string') countryName;
+  @attr() organizationLearnerTypeId;
   @attr('string') organizationLearnerTypeName;
 
   @hasMany('organization-membership', { async: true, inverse: 'organization' }) organizationMemberships;

--- a/admin/tests/acceptance/authenticated/organizations/information-management-test.js
+++ b/admin/tests/acceptance/authenticated/organizations/information-management-test.js
@@ -35,6 +35,7 @@ module('Acceptance | Organizations | Information management', function (hooks) {
         administrationTeamId: 456,
         countryCode: 99100,
         organizationLearnerTypeName: 'Student',
+        organizationLearnerTypeId: 2,
       });
       this.server.create('organization', { id: '1234', features: { PLACES_MANAGEMENT: { active: true } } });
 

--- a/admin/tests/integration/components/organizations/information-section-edit-test.gjs
+++ b/admin/tests/integration/components/organizations/information-section-edit-test.gjs
@@ -620,6 +620,7 @@ module('Integration | Component | organizations/information-section-edit', funct
         administrationTeamId: 123,
         countryCode: 99100,
         organizationLearnerTypeName: 'Student',
+        organizationLearnerTypeId: 789,
       });
       const screen = await render(<template><InformationSectionEdit @organization={{organization}} /></template>);
 

--- a/admin/tests/integration/components/organizations/information-section-test.gjs
+++ b/admin/tests/integration/components/organizations/information-section-test.gjs
@@ -57,6 +57,7 @@ module('Integration | Component | organizations/information-section', function (
       administrationTeamId: 123,
       countryCode: 99100,
       organizationLearnerTypeName: 'Student',
+      organizationLearnerTypeId: 789,
     });
 
     test('it should toggle edition mode on click to edit button', async function (assert) {

--- a/api/src/organizational-entities/domain/constants.js
+++ b/api/src/organizational-entities/domain/constants.js
@@ -51,6 +51,10 @@ export const ORGANIZATIONS_UPDATE_HEADER = {
       name: 'Country Code',
       property: 'countryCode',
     }),
+    new CsvColumn({
+      name: 'Organization Learner Type ID',
+      property: 'organizationLearnerTypeId',
+    }),
   ],
 };
 

--- a/api/src/organizational-entities/domain/dtos/OrganizationBatchUpdateDTO.js
+++ b/api/src/organizational-entities/domain/dtos/OrganizationBatchUpdateDTO.js
@@ -13,6 +13,7 @@ export class OrganizationBatchUpdateDTO {
    * @param {string|undefined} data.dataProtectionOfficerEmail
    * @param {string|undefined} data.administrationTeamId
    * @param {string|undefined} data.countryCode
+   * @param {string|undefined} data.organizationLearnerTypeId
    */
   constructor(data) {
     this.id = data.id;
@@ -27,5 +28,6 @@ export class OrganizationBatchUpdateDTO {
     this.dataProtectionOfficerEmail = data.dataProtectionOfficerEmail ?? '';
     this.administrationTeamId = data.administrationTeamId ?? '';
     this.countryCode = data.countryCode ?? '';
+    this.organizationLearnerTypeId = data.organizationLearnerTypeId ?? '';
   }
 }

--- a/api/src/organizational-entities/domain/models/OrganizationForAdmin.js
+++ b/api/src/organizational-entities/domain/models/OrganizationForAdmin.js
@@ -205,6 +205,10 @@ class OrganizationForAdmin {
     if (organizationBatchUpdateDto.administrationTeamId)
       this.administrationTeamId = organizationBatchUpdateDto.administrationTeamId;
     if (organizationBatchUpdateDto.countryCode) this.countryCode = organizationBatchUpdateDto.countryCode;
+    if (organizationBatchUpdateDto.organizationLearnerTypeId) {
+      this.organizationLearnerType.id = organizationBatchUpdateDto.organizationLearnerTypeId;
+      this.organizationLearnerType.name = undefined;
+    }
   }
 
   updateParentOrganizationId(parentOrganizationId) {

--- a/api/src/organizational-entities/domain/usecases/update-organization-information.usecase.js
+++ b/api/src/organizational-entities/domain/usecases/update-organization-information.usecase.js
@@ -13,16 +13,16 @@ const updateOrganizationInformation = withTransaction(async function ({
   const existingOrganization = await organizationForAdminRepository.get({ organizationId: organization.id });
 
   let organizationLearnerType;
-  if (organization.organizationLearnerType?.name) {
+  if (organization.organizationLearnerType?.id) {
     try {
-      organizationLearnerType = await organizationLearnerTypeRepository.getByName(
-        organization.organizationLearnerType.name,
+      organizationLearnerType = await organizationLearnerTypeRepository.getById(
+        organization.organizationLearnerType.id,
       );
       organization.organizationLearnerType = organizationLearnerType;
     } catch {
       throw new OrganizationLearnerTypeNotFound({
         meta: {
-          organizationLearnerTypeName: organization.organizationLearnerType.name,
+          organizationLearnerTypeId: organization.organizationLearnerType.id,
         },
       });
     }

--- a/api/src/organizational-entities/infrastructure/repositories/organization-learner-type-repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/organization-learner-type-repository.js
@@ -17,16 +17,16 @@ const findAll = async function () {
 };
 
 /**
- * @param {*} name
+ * @param {*} id
  * @returns {Promise<OrganizationLearnerType>}
  * @throws {NotFoundError}
  */
-const getByName = async function (name) {
+const getById = async function (id) {
   const knexConn = DomainTransaction.getConnection();
   const organizationLearnerTypeDTO = await knexConn
     .select('name', 'id')
     .from('organization_learner_types')
-    .where({ name })
+    .where({ id })
     .first();
 
   if (!organizationLearnerTypeDTO) {
@@ -43,4 +43,4 @@ const _toDomain = function (organizationLearnerTypeDTO) {
   });
 };
 
-export { findAll, getByName };
+export { findAll, getById };

--- a/api/src/organizational-entities/infrastructure/serializers/jsonapi/organizations-administration/organization-for-admin.serializer.js
+++ b/api/src/organizational-entities/infrastructure/serializers/jsonapi/organizations-administration/organization-for-admin.serializer.js
@@ -10,8 +10,10 @@ const serialize = function (organizations, meta) {
       const dataProtectionOfficer = record.dataProtectionOfficer;
 
       const organizationLearnerTypeName = record?.organizationLearnerType?.name;
-      if (organizationLearnerTypeName) {
+      const organizationLearnerTypeId = record?.organizationLearnerType?.id;
+      if (organizationLearnerTypeId) {
         record.organizationLearnerTypeName = organizationLearnerTypeName;
+        record.organizationLearnerTypeId = organizationLearnerTypeId;
       }
 
       if (dataProtectionOfficer) {
@@ -57,6 +59,7 @@ const serialize = function (organizations, meta) {
       'administrationTeamName',
       'countryCode',
       'countryName',
+      'organizationLearnerTypeId',
       'organizationLearnerTypeName',
     ],
     organizationMemberships: {
@@ -142,7 +145,7 @@ const deserialize = function (json) {
     tagIds,
     countryCode: attributes['country-code'] && parseInt(attributes['country-code']),
     organizationLearnerType: new OrganizationLearnerType({
-      id: undefined,
+      id: attributes['organization-learner-type-id'],
       name: attributes['organization-learner-type-name'],
     }),
   });

--- a/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
@@ -2,6 +2,7 @@ import iconv from 'iconv-lite';
 import lodash from 'lodash';
 
 import { PIX_ADMIN } from '../../../../../src/authorization/domain/constants.js';
+import { ORGANIZATIONS_UPDATE_HEADER } from '../../../../../src/organizational-entities/domain/constants.js';
 import { ORGANIZATION_FEATURE } from '../../../../../src/shared/domain/constants.js';
 import { Membership } from '../../../../../src/shared/domain/models/Membership.js';
 import {
@@ -1575,9 +1576,9 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
 
       it('responds with a 204 - no content', async function () {
         // given
-        const input = `Organization ID;Organization Name;Organization External ID;Organization Parent ID;Organization Identity Provider Code;Organization Documentation URL;Organization Province Code;DPO Last Name;DPO First Name;DPO E-mail;Administration Team ID;Country Code
-      ${firstOrganization.id};MSFT;12;;OIDC_EXAMPLE_NET;https://doc.url;;Troisjour;Adam;;1234;99500
-      ${otherOrganization.id};APPL;;;;;;;Cali;;1234;99500`;
+        const input = `${ORGANIZATIONS_UPDATE_HEADER.columns.map(({ name }) => name).join(';')}
+      ${firstOrganization.id};MSFT;12;;OIDC_EXAMPLE_NET;https://doc.url;;Troisjour;Adam;;1234;99500;
+      ${otherOrganization.id};APPL;;;;;;;Cali;;1234;99500;`;
 
         const options = {
           method: 'POST',

--- a/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
@@ -598,6 +598,8 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
           originalName: 'France',
         });
 
+        const organizationLearnerType = databaseBuilder.factory.buildOrganizationLearnerType();
+
         const organization = databaseBuilder.factory.buildOrganization({
           type: 'SCO',
           name: 'Organization catalina',
@@ -614,6 +616,7 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
           createdAt,
           administrationTeamId: administrationTeam.id,
           countryCode: country.code,
+          organizationLearnerTypeId: organizationLearnerType.id,
         });
         const dataProtectionOfficer = databaseBuilder.factory.buildDataProtectionOfficer.withOrganizationId({
           firstName: 'Justin',
@@ -671,7 +674,8 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
               'administration-team-name': administrationTeam.name,
               'country-code': country.code,
               'country-name': country.commonName,
-              'organization-learner-type-name': `Type pour organisation ${organization.id}`,
+              'organization-learner-type-name': organizationLearnerType.name,
+              'organization-learner-type-id': organizationLearnerType.id,
               features: {
                 [ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key]: {
                   active: false,

--- a/api/tests/organizational-entities/integration/domain/usecases/update-organization-information.usecase_test.js
+++ b/api/tests/organizational-entities/integration/domain/usecases/update-organization-information.usecase_test.js
@@ -43,8 +43,8 @@ describe('Integration | Organizational Entities | Domain | UseCases | update-org
       administrationTeamId: newAdministrationTeamId,
       countryCode: newCountry.code,
       organizationLearnerType: domainBuilder.acquisition.buildOrganizationLearnerType({
-        id: null,
-        name: newOrganizationLearnerType.name,
+        id: newOrganizationLearnerType.id,
+        name: undefined,
       }),
     });
 
@@ -58,7 +58,7 @@ describe('Integration | Organizational Entities | Domain | UseCases | update-org
     expect(updatedOrganization.name).to.equal("Nouveau nom d'organization");
     expect(updatedOrganization.administrationTeamId).to.equal(newAdministrationTeamId);
     expect(updatedOrganization.countryCode).to.equal(99102);
-    expect(updatedOrganization.organizationLearnerType.id).to.equal(newOrganizationLearnerType.id);
+    expect(updatedOrganization.organizationLearnerType.name).to.equal(newOrganizationLearnerType.name);
   });
 
   context('when organization learner type does not exist', function () {
@@ -71,7 +71,8 @@ describe('Integration | Organizational Entities | Domain | UseCases | update-org
       const organizationNewInformations = domainBuilder.buildOrganizationForAdmin({
         id: organizationId,
         organizationLearnerType: domainBuilder.acquisition.buildOrganizationLearnerType({
-          name: 'Student',
+          id: 123,
+          name: undefined,
         }),
       });
 
@@ -82,7 +83,7 @@ describe('Integration | Organizational Entities | Domain | UseCases | update-org
 
       // then
       expect(error).to.be.instanceOf(OrganizationLearnerTypeNotFound);
-      expect(error.meta.organizationLearnerTypeName).to.equal(organizationNewInformations.organizationLearnerType.name);
+      expect(error.meta.organizationLearnerTypeId).to.equal(organizationNewInformations.organizationLearnerType.id);
     });
   });
 

--- a/api/tests/organizational-entities/integration/domain/usecases/update-organizations-in-batch.usecase.test.js
+++ b/api/tests/organizational-entities/integration/domain/usecases/update-organizations-in-batch.usecase.test.js
@@ -3,6 +3,7 @@ import {
   AdministrationTeamNotFound,
   CountryNotFoundError,
   DpoEmailInvalid,
+  OrganizationLearnerTypeNotFound,
   OrganizationNotFound,
   UnableToAttachChildOrganizationToParentOrganizationError,
 } from '../../../../../src/organizational-entities/domain/errors.js';
@@ -46,6 +47,9 @@ describe('Integration | Organizational Entities | Domain | UseCase | update-orga
       databaseBuilder.factory.buildAdministrationTeam({ id: 1234 });
       databaseBuilder.factory.buildAdministrationTeam({ id: 5678 });
 
+      databaseBuilder.factory.buildOrganizationLearnerType({ id: 12 });
+      databaseBuilder.factory.buildOrganizationLearnerType({ id: 34 });
+
       databaseBuilder.factory.buildCertificationCpfCountry({
         code: '99100',
         commonName: 'France',
@@ -74,8 +78,8 @@ describe('Integration | Organizational Entities | Domain | UseCase | update-orga
       // given
       const headers = ORGANIZATIONS_UPDATE_HEADER.columns.map(({ name }) => name).join(';');
       const fileData = `${headers}
-      ${organization1.id};;12;;OIDC_EXAMPLE_NET;https://doc.url;;Troisjour;Adam;foo@email.com;1234;99100
-      ${organization2.id};New Name;;;;;;;Cali;;5678;99100`;
+      ${organization1.id};;12;;OIDC_EXAMPLE_NET;https://doc.url;;Troisjour;Adam;foo@email.com;1234;99100;12
+      ${organization2.id};New Name;;;;;;;Cali;;5678;99100;34`;
       filePath = await createTempFile('test.csv', fileData);
 
       // when
@@ -88,6 +92,7 @@ describe('Integration | Organizational Entities | Domain | UseCase | update-orga
       expect(updatedOrganization1.documentationUrl).to.equal('https://doc.url');
       expect(updatedOrganization1.administrationTeamId).to.equal(1234);
       expect(updatedOrganization1.countryCode).to.equal(99100);
+      expect(updatedOrganization1.organizationLearnerTypeId).to.equal(12);
 
       const dpo1 = await knex('data-protection-officers').where({ organizationId: organization1.id }).first();
       expect(dpo1.firstName).to.equal('Adam');
@@ -98,6 +103,7 @@ describe('Integration | Organizational Entities | Domain | UseCase | update-orga
       expect(updatedOrganization2.name).to.equal('New Name');
       expect(updatedOrganization2.administrationTeamId).to.equal(5678);
       expect(updatedOrganization2.countryCode).to.equal(99100);
+      expect(updatedOrganization2.organizationLearnerTypeId).to.equal(34);
     });
   });
 
@@ -112,7 +118,7 @@ describe('Integration | Organizational Entities | Domain | UseCase | update-orga
       // given
       const headers = ORGANIZATIONS_UPDATE_HEADER.columns.map(({ name }) => name).join(';');
       const fileData = `${headers}
-      999999;;12;;OIDC_EXAMPLE_NET;https://doc.url;;Troisjour;Adam;;1234;`;
+      999999;;12;;OIDC_EXAMPLE_NET;https://doc.url;;Troisjour;Adam;;1234;;`;
       filePath = await createTempFile('test.csv', fileData);
 
       // when
@@ -130,7 +136,7 @@ describe('Integration | Organizational Entities | Domain | UseCase | update-orga
 
       const headers = ORGANIZATIONS_UPDATE_HEADER.columns.map(({ name }) => name).join(';');
       const fileData = `${headers}
-      ${organization.id};;12;;OIDC_EXAMPLE_NET;https://doc.url;;Troisjour;Adam;;1234;`;
+      ${organization.id};;12;;OIDC_EXAMPLE_NET;https://doc.url;;Troisjour;Adam;;1234;;`;
       filePath = await createTempFile('test.csv', fileData);
 
       // when
@@ -148,7 +154,7 @@ describe('Integration | Organizational Entities | Domain | UseCase | update-orga
 
       const headers = ORGANIZATIONS_UPDATE_HEADER.columns.map(({ name }) => name).join(';');
       const fileData = `${headers}
-      ${organization.id};;12;;OIDC_EXAMPLE_NET;https://doc.url;;Troisjour;Adam;;;99999`;
+      ${organization.id};;12;;OIDC_EXAMPLE_NET;https://doc.url;;Troisjour;Adam;;;99999;`;
       filePath = await createTempFile('test.csv', fileData);
 
       // when
@@ -167,7 +173,7 @@ describe('Integration | Organizational Entities | Domain | UseCase | update-orga
 
         const headers = ORGANIZATIONS_UPDATE_HEADER.columns.map(({ name }) => name).join(';');
         const fileData = `${headers}
-        ${organization.id};;12;;OIDC_EXAMPLE_NET;https://doc.url;;Troisjour;Adam;;;`;
+        ${organization.id};;12;;OIDC_EXAMPLE_NET;https://doc.url;;Troisjour;Adam;;;;`;
         filePath = await createTempFile('test.csv', fileData);
 
         // when
@@ -187,7 +193,7 @@ describe('Integration | Organizational Entities | Domain | UseCase | update-orga
 
         const headers = ORGANIZATIONS_UPDATE_HEADER.columns.map(({ name }) => name).join(';');
         const fileData = `${headers}
-        ${organization.id};;12;;OIDC_EXAMPLE_NET;https://doc.url;;Troisjour;Adam;foo@email.com;;`;
+        ${organization.id};;12;;OIDC_EXAMPLE_NET;https://doc.url;;Troisjour;Adam;foo@email.com;;;`;
         filePath = await createTempFile('test.csv', fileData);
 
         // when
@@ -209,7 +215,7 @@ describe('Integration | Organizational Entities | Domain | UseCase | update-orga
 
         const headers = ORGANIZATIONS_UPDATE_HEADER.columns.map(({ name }) => name).join(';');
         const fileData = `${headers}
-        ${organization.id};;12;999999;OIDC_EXAMPLE_NET;https://doc.url;;Troisjour;Adam;;1234;`;
+        ${organization.id};;12;999999;OIDC_EXAMPLE_NET;https://doc.url;;Troisjour;Adam;;1234;;`;
         filePath = await createTempFile('test.csv', fileData);
 
         // when
@@ -229,7 +235,7 @@ describe('Integration | Organizational Entities | Domain | UseCase | update-orga
 
         const headers = ORGANIZATIONS_UPDATE_HEADER.columns.map(({ name }) => name).join(';');
         const fileData = `${headers}
-        ${organization.id};;12;;OIDC_EXAMPLE_NET;https://doc.url;;Troisjour;Adam;foo;;`;
+        ${organization.id};;12;;OIDC_EXAMPLE_NET;https://doc.url;;Troisjour;Adam;foo;;;`;
         filePath = await createTempFile('test.csv', fileData);
 
         // when
@@ -239,6 +245,30 @@ describe('Integration | Organizational Entities | Domain | UseCase | update-orga
         expect(error).to.be.instanceOf(DpoEmailInvalid);
         expect(error.meta.organizationId).to.equal(`${organization.id}`);
       });
+    });
+
+    it('throws a OrganizationLearnerTypeNotFound error when organization learner type does not exist', async function () {
+      // given
+      const organizationLearnerType = databaseBuilder.factory.buildOrganizationLearnerType({ id: 1234 });
+      const organization = databaseBuilder.factory.buildOrganization({
+        externalId: 999,
+        organizationLearnerTypeId: organizationLearnerType.id,
+      });
+      await databaseBuilder.commit();
+
+      const headers = ORGANIZATIONS_UPDATE_HEADER.columns.map(({ name }) => name).join(';');
+      const fileData = `${headers}
+      ${organization.id};;12;;OIDC_EXAMPLE_NET;https://doc.url;;Troisjour;Adam;;;;5678`;
+      filePath = await createTempFile('test.csv', fileData);
+
+      // when
+      const error = await catchErr(usecases.updateOrganizationsInBatch)({
+        filePath,
+      });
+
+      // then
+      expect(error).to.be.instanceOf(OrganizationLearnerTypeNotFound);
+      expect(error.meta.organizationLearnerTypeId).to.equal('5678');
     });
   });
 });

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/organization-learner-type-repository_test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/organization-learner-type-repository_test.js
@@ -41,16 +41,20 @@ describe('Integration | Repository | organization-learner-type-repository', func
     });
   });
 
-  describe('#getByName', function () {
-    it('should return the organization learner type with the given name', async function () {
+  describe('#getById', function () {
+    it('should return the organization learner type with the given id', async function () {
       // given
       const organizationLearnerType = databaseBuilder.factory.buildOrganizationLearnerType({
-        name: 'Type A',
+        id: 123,
+      });
+
+      databaseBuilder.factory.buildOrganizationLearnerType({
+        id: 456,
       });
       await databaseBuilder.commit();
 
       // when
-      const result = await organizationLearnerTypeRepository.getByName(organizationLearnerType.name);
+      const result = await organizationLearnerTypeRepository.getById(organizationLearnerType.id);
 
       // then
       expect(result).to.deep.equal(
@@ -62,8 +66,11 @@ describe('Integration | Repository | organization-learner-type-repository', func
     });
 
     it('should throw if there is no organization learner type with the given name', async function () {
+      // given
+      const unknownId = 123;
+
       // when
-      const error = await catchErr(organizationLearnerTypeRepository.getByName)('Unknown name');
+      const error = await catchErr(organizationLearnerTypeRepository.getById)(unknownId);
 
       // then
       expect(error).to.be.instanceOf(NotFoundError);

--- a/api/tests/organizational-entities/unit/application/http-error-mapper-configuration_test.js
+++ b/api/tests/organizational-entities/unit/application/http-error-mapper-configuration_test.js
@@ -82,7 +82,7 @@ describe('Unit | Organizational Entities | Application | HttpErrorMapperConfigur
         (httpErrorMapper) => httpErrorMapper.name === OrganizationLearnerTypeNotFound.name,
       );
 
-      const meta = { organizationLearnerTypeName: 'Student' };
+      const meta = { organizationLearnerTypeId: 123 };
 
       // when
       const error = httpErrorMapper.httpErrorFn(new OrganizationLearnerTypeNotFound({ meta }));

--- a/api/tests/organizational-entities/unit/domain/dtos/OrganizationBatchUpdateDTO.test.js
+++ b/api/tests/organizational-entities/unit/domain/dtos/OrganizationBatchUpdateDTO.test.js
@@ -31,6 +31,7 @@ describe('Unit | Organizational Entities | Domain | DTO | OrganizationBatchUpdat
         dataProtectionOfficerEmail: 'adam.troisjour@example.net',
         administrationTeamId: '1234',
         countryCode: '99100',
+        organizationLearnerTypeId: '',
       });
     });
   });

--- a/api/tests/organizational-entities/unit/domain/models/OrganizationForAdmin_test.js
+++ b/api/tests/organizational-entities/unit/domain/models/OrganizationForAdmin_test.js
@@ -1007,6 +1007,26 @@ describe('Unit | Organizational Entities | Domain | Model | OrganizationForAdmin
       expect(organizationToUpdate.countryCode).to.equal(countryCode);
       expect(organizationToUpdate).to.deep.equal(expectedOrganization);
     });
+
+    it('updates the organization learner type id', function () {
+      // given
+      const organizationLearnerType = domainBuilder.acquisition.buildOrganizationLearnerType({
+        id: 1234,
+      });
+
+      const organizationToUpdate = domainBuilder.buildOrganizationForAdmin({
+        organizationLearnerType,
+      });
+
+      // when
+      organizationToUpdate.updateFromOrganizationBatchUpdateDto(
+        new OrganizationBatchUpdateDTO({ id: '1', organizationLearnerTypeId: 5678 }),
+      );
+
+      // then
+      expect(organizationToUpdate.organizationLearnerType.id).to.equal(5678);
+      expect(organizationToUpdate.organizationLearnerType.name).to.equal(undefined);
+    });
   });
 
   context('#setCountryName', function () {

--- a/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/organization-for-admin.serializer.test.js
+++ b/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/organization-for-admin.serializer.test.js
@@ -15,7 +15,10 @@ describe('Unit | Serializer | organization-for-admin-serializer', function () {
         domainBuilder.buildTag({ id: 7, name: 'AEFE' }),
         domainBuilder.buildTag({ id: 44, name: 'PUBLIC' }),
       ];
-      const organizationLearnerType = domainBuilder.acquisition.buildOrganizationLearnerType();
+      const organizationLearnerType = domainBuilder.acquisition.buildOrganizationLearnerType({
+        id: 123,
+        name: 'Student',
+      });
 
       const parentOrganization = domainBuilder.buildOrganizationForAdmin({
         email: 'motherSco.generic.account@example.net',
@@ -102,6 +105,7 @@ describe('Unit | Serializer | organization-for-admin-serializer', function () {
             'country-code': organization.countryCode,
             'country-name': organization.countryName,
             'organization-learner-type-name': organization.organizationLearnerType.name,
+            'organization-learner-type-id': organization.organizationLearnerType.id,
           },
           relationships: {
             'organization-memberships': {
@@ -189,6 +193,7 @@ describe('Unit | Serializer | organization-for-admin-serializer', function () {
         },
         countryCode: '99100',
         organizationLearnerTypeName: 'Teacher',
+        organizationLearnerTypeId: 123,
       };
 
       // when
@@ -213,6 +218,7 @@ describe('Unit | Serializer | organization-for-admin-serializer', function () {
             'administration-team-id': organizationAttributes.administrationTeamId,
             features: organizationAttributes.features,
             'country-code': organizationAttributes.countryCode,
+            'organization-learner-type-id': organizationAttributes.organizationLearnerTypeId,
             'organization-learner-type-name': organizationAttributes.organizationLearnerTypeName,
           },
         },
@@ -248,8 +254,8 @@ describe('Unit | Serializer | organization-for-admin-serializer', function () {
         },
         countryCode: 99100,
         organizationLearnerType: new OrganizationLearnerType({
-          id: undefined,
-          name: organizationAttributes.organizationLearnerTypeName,
+          id: 123,
+          name: 'Teacher',
         }),
       });
       expect(organization).to.be.instanceOf(OrganizationForAdmin);


### PR DESCRIPTION
## 🥀 Problème

La mise à jour du public prescrit n'est pas disponible via l'import d'un fichier CSV pour la modification en masse d'organisation.

## 🏹 Proposition

Ajouter une colonne Organization Learner Type dans le CSV de modification en masse, et gérer la mise à jour,

## 💌 Remarques

Le premier commit propose de modifier une partie de ce qui a été fait précédemment sur la modification unitaire, afin de se baser sur l'ID du learner type et non le nom.

## ❤️‍🔥 Pour tester
Sur Pix Admin:
- dans l'onglet Administration -> Déploiement -> Modification des organisations en masse
- télécharger le template du fichier CSV
- constater la nouvelle colonne Organization Learner Type
- remplir le CSV avec un ID d'orga et un ID d'Organization Learner Type
- uploader le fichier ainsi modifié
- constater la modification du public prescrit pour les orgas concernées

Cas d'erreur
- tester un mauvais format CSV
- tester un ID de public prescrit non existant
