### PR TITLE
[FEATURE] Mettre à jour les liens anglais de doc dans PixCertif (PIX-21509).

### DIFF
--- a/certif/tests/unit/services/url-test.js
+++ b/certif/tests/unit/services/url-test.js
@@ -179,7 +179,7 @@ module('Unit | Service | url', function (hooks) {
       const urlToDownloadSessionIssueReportSheet = service.urlToDownloadSessionIssueReportSheet;
 
       // then
-      assert.strictEqual(urlToDownloadSessionIssueReportSheet, 'https://cloud.pix.fr/s/ro7jHtsZZbY5SCX/download');
+      assert.strictEqual(urlToDownloadSessionIssueReportSheet, 'https://cloud.pix.fr/s/B6egBZnbjJFSiaN');
     });
   });
 
@@ -204,7 +204,7 @@ module('Unit | Service | url', function (hooks) {
       const urlToDownloadSessionV3IssueReportSheet = service.urlToDownloadSessionV3IssueReportSheet;
 
       // then
-      assert.strictEqual(urlToDownloadSessionV3IssueReportSheet, 'https://cloud.pix.fr/s/ro7jHtsZZbY5SCX/download');
+      assert.strictEqual(urlToDownloadSessionV3IssueReportSheet, 'https://cloud.pix.fr/s/B6egBZnbjJFSiaN');
     });
   });
 });

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -189,12 +189,12 @@
     },
     "urls": {
       "documentation": {
-        "other": "https://cloud.pix.fr/s/WPcbosgLjnWLQJ4",
-        "sco-managing-students": "https://cloud.pix.fr/s/WPcbosgLjnWLQJ4"
+        "other": "https://cloud.pix.fr/s/c6SmQ8iM6nGbrzw",
+        "sco-managing-students": "https://cloud.pix.fr/s/c6SmQ8iM6nGbrzw"
       },
-      "fraud": "https://cloud.pix.fr/s/9A598pR5ksp6jss/download",
-      "session-issue-report-sheet": "https://cloud.pix.fr/s/ro7jHtsZZbY5SCX/download",
-      "session-v3-issue-report-sheet": "https://cloud.pix.fr/s/ro7jHtsZZbY5SCX/download"
+      "fraud": "https://cloud.pix.fr/s/zka5JJqpbgWZLPr",
+      "session-issue-report-sheet": "https://cloud.pix.fr/s/B6egBZnbjJFSiaN",
+      "session-v3-issue-report-sheet": "https://cloud.pix.fr/s/B6egBZnbjJFSiaN"
     }
   },
   "components": {


### PR DESCRIPTION
## 🥀 Problème

Suite à notre incident sur le cloud on a quelques fichiers qui ont disparus.

## 🏹 Proposition

Remplacer 3 liens : 

- Onglet “Documentation”: https://cloud.pix.fr/s/c6SmQ8iM6nGbrzw
- Page de détail d’une session : https://cloud.pix.fr/s/B6egBZnbjJFSiaN
- Page de détail d’une session : https://cloud.pix.fr/s/zka5JJqpbgWZLPr

## ❤️‍🔥 Pour tester

Tester les liens [en RA](https://certif-pr15126.review.pix.org/?lang=en).
