### PR TITLE
[FEATURE] Permettre de supprimer et anonymiser les participations d'un prescrit sur un parcours combiné précis (PIX-21505)

### DIFF
--- a/api/scripts/prod/delete-and-anonymize-organization-learner-participations-from-combined-courses.js
+++ b/api/scripts/prod/delete-and-anonymize-organization-learner-participations-from-combined-courses.js
@@ -1,0 +1,68 @@
+import { usecases } from '../../src/quest/domain/usecases/index.js';
+import { Script } from '../../src/shared/application/scripts/script.js';
+import { ScriptRunner } from '../../src/shared/application/scripts/script-runner.js';
+import { DomainTransaction } from '../../src/shared/domain/DomainTransaction.js';
+
+// Définition du script
+export class DeleteAndAnonymizeOrganizationLearnerParticipationsScript extends Script {
+  constructor() {
+    super({
+      description:
+        'Deletes all types of participations (from a combined course, campaign, and passages) for a given organization learner id and combined course id',
+      permanent: true,
+      options: {
+        combinedCourseId: {
+          type: 'number',
+          describe: 'a single combined course id',
+          demandOption: true,
+        },
+        organizationLearnerId: {
+          type: 'number',
+          describe: 'a single organization learner id',
+          demandOption: true,
+        },
+        dryRun: {
+          type: 'boolean',
+          default: true,
+        },
+      },
+    });
+  }
+
+  async handle({ options, logger, dependencies = usecases }) {
+    logger.info(
+      { event: 'DeleteAndAnonymizeOrganizationLearnerParticipations' },
+      `Deletes and anonymizes all participations linked to combined course ${options.combinedCourseId} for learner ${options.organizationLearnerId}`,
+    );
+    await DomainTransaction.execute(async () => {
+      const knexConn = DomainTransaction.getConnection();
+
+      const engineeringUserId = process.env.ENGINEERING_USER_ID;
+
+      try {
+        await dependencies.deleteAndAnonymizeParticipationsForALearnerId({
+          combinedCourseId: options.combinedCourseId,
+          organizationLearnerId: options.organizationLearnerId,
+          userId: engineeringUserId,
+        });
+
+        if (options.dryRun) {
+          await knexConn.rollback();
+          logger.info(`ROLLBACK due to dryRun`);
+          logger.info(`--dryRun true to persist changes`);
+          return;
+        }
+
+        logger.info(
+          { event: 'DeleteAndAnonymizeCombinedCoursesScript' },
+          `COMMIT: Successfully deleted and anonymized all participations linked to combined course ${options.combinedCourseId[0]} for learner ${options.organizationLearnerId[0]}`,
+        );
+      } catch (error) {
+        await knexConn.rollback();
+        logger.error({ event: 'DeleteAndAnonymizeCombinedCoursesScript' }, `ROLLBACK: An error has occured, ${error}`);
+        throw error;
+      }
+    });
+  }
+}
+await ScriptRunner.execute(import.meta.url, DeleteAndAnonymizeOrganizationLearnerParticipationsScript);

--- a/api/src/prescription/campaign-participation/application/api/campaign-participations-api.js
+++ b/api/src/prescription/campaign-participation/application/api/campaign-participations-api.js
@@ -18,7 +18,7 @@ export const getCampaignParticipationsByLearnerIdAndCampaignId = async ({ organi
   });
 };
 
-export const deleteCampaignParticipationsInCombinedCourse = async ({
+export const deleteCampaignParticipations = async ({
   userId,
   campaignParticipationIds,
   campaignId,

--- a/api/src/prescription/campaign-participation/application/api/campaign-participations-api.js
+++ b/api/src/prescription/campaign-participation/application/api/campaign-participations-api.js
@@ -10,3 +10,30 @@ import { usecases } from '../../domain/usecases/index.js';
 export const hasCampaignParticipations = async ({ userId }) => {
   return usecases.hasCampaignParticipations({ userId });
 };
+
+export const getCampaignParticipationsByLearnerIdAndCampaignId = async ({ organizationLearnerId, campaignId }) => {
+  return usecases.getCampaignParticipationsForOrganizationLearner({
+    organizationLearnerId,
+    campaignId,
+  });
+};
+
+export const deleteCampaignParticipationsInCombinedCourse = async ({
+  userId,
+  campaignParticipationIds,
+  campaignId,
+  keepPreviousDeletion,
+  userRole,
+  client,
+}) => {
+  for (const campaignParticipationId of campaignParticipationIds) {
+    await usecases.deleteCampaignParticipation({
+      userId,
+      campaignId,
+      campaignParticipationId,
+      userRole,
+      client,
+      keepPreviousDeleted: keepPreviousDeletion,
+    });
+  }
+};

--- a/api/src/quest/domain/models/CampaignParticipation.js
+++ b/api/src/quest/domain/models/CampaignParticipation.js
@@ -1,0 +1,9 @@
+class CampaignParticipation {
+  constructor({ id, sharedAt, status }) {
+    this.id = id;
+    this.sharedAt = sharedAt;
+    this.status = status;
+  }
+}
+
+export { CampaignParticipation };

--- a/api/src/quest/domain/usecases/delete-and-anonymise-participations-for-a-learner-id.js
+++ b/api/src/quest/domain/usecases/delete-and-anonymise-participations-for-a-learner-id.js
@@ -38,7 +38,7 @@ export const deleteAndAnonymizeParticipationsForALearnerId = withTransaction(
           campaignId,
         });
       const campaignParticipationIds = campaignParticipations.map((campaignParticipation) => campaignParticipation.id);
-      await campaignParticipationRepository.deleteCampaignParticipationsInCombinedCourse({
+      await campaignParticipationRepository.deleteCampaignParticipations({
         userId,
         campaignId: campaignId,
         campaignParticipationIds,

--- a/api/src/quest/domain/usecases/delete-and-anonymise-participations-for-a-learner-id.js
+++ b/api/src/quest/domain/usecases/delete-and-anonymise-participations-for-a-learner-id.js
@@ -1,0 +1,50 @@
+import { CLIENTS, PIX_ADMIN } from '../../../authorization/domain/constants.js';
+import { withTransaction } from '../../../shared/domain/DomainTransaction.js';
+
+export const deleteAndAnonymizeParticipationsForALearnerId = withTransaction(
+  async ({
+    organizationLearnerParticipationRepository,
+    campaignRepository,
+    combinedCourseId,
+    userId,
+    organizationLearnerId,
+    combinedCourseDetailsService,
+    campaignParticipationRepository,
+  }) => {
+    await organizationLearnerParticipationRepository.deleteCombinedCourseParticipationByCombinedCourseIdAndOrganizationLearnerId(
+      { combinedCourseId, userId, organizationLearnerId },
+    );
+    const campaignIds = await campaignRepository.getCampaignIdsByCombinedCourseIds({
+      combinedCourseIds: [combinedCourseId],
+    });
+
+    const modulesIdsToDelete = [];
+
+    const { modules } = await combinedCourseDetailsService.instantiateCombinedCourseDetails({
+      combinedCourseId,
+    });
+    modulesIdsToDelete.push(...modules.map((module) => module.id));
+
+    await organizationLearnerParticipationRepository.deletePassagesByModuleIdsAndOrganizationLearnerId({
+      moduleIds: modulesIdsToDelete,
+      organizationLearnerId,
+      userId,
+    });
+
+    for (const campaignId of campaignIds) {
+      const campaignParticipations =
+        await campaignParticipationRepository.getCampaignParticipationsByLearnerIdAndCampaignId({
+          organizationLearnerId,
+          campaignId,
+        });
+      const campaignParticipationIds = campaignParticipations.map((campaignParticipation) => campaignParticipation.id);
+      await campaignParticipationRepository.deleteCampaignParticipationsInCombinedCourse({
+        userId,
+        campaignId: campaignId,
+        campaignParticipationIds,
+        userRole: PIX_ADMIN.ROLES.SUPER_ADMIN,
+        client: CLIENTS.SCRIPT,
+      });
+    }
+  },
+);

--- a/api/src/quest/domain/usecases/index.js
+++ b/api/src/quest/domain/usecases/index.js
@@ -39,6 +39,7 @@ const dependencies = {
   organizationLearnerRepository,
   organizationLearnerPrescriptionRepository,
   combinedCourseBlueprintRepository,
+  campaignParticipationRepository: repositories.campaignParticipationRepository,
   codeGenerator,
   logger,
 };
@@ -49,6 +50,7 @@ import { createCombinedCourse } from './create-combined-course.js';
 import { createCombinedCourseBlueprint } from './create-combined-course-blueprint.js';
 import { createCombinedCourses } from './create-combined-courses.js';
 import { createOrUpdateQuestsInBatch } from './create-or-update-quests-in-batch.js';
+import { deleteAndAnonymizeParticipationsForALearnerId } from './delete-and-anonymise-participations-for-a-learner-id.js';
 import { detachOrganizationFromCombinedCourseBlueprint } from './detach-organization-from-combined-course-blueprint.js';
 import { findByOrganizationId } from './find-by-organization-id.js';
 import { findCombinedCourseBlueprints } from './find-combined-course-blueprints.js';
@@ -91,6 +93,7 @@ const usecasesWithoutInjectedDependencies = {
   createCombinedCourseBlueprint,
   createCombinedCourse,
   findByOrganizationId,
+  deleteAndAnonymizeParticipationsForALearnerId,
 };
 
 const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);

--- a/api/src/quest/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/src/quest/infrastructure/repositories/campaign-participation-repository.js
@@ -1,4 +1,4 @@
-export async function deleteCampaignParticipationsInCombinedCourse({
+export async function deleteCampaignParticipations({
   userId,
   campaignId,
   campaignParticipationIds,
@@ -7,7 +7,7 @@ export async function deleteCampaignParticipationsInCombinedCourse({
   campaignParticipationsApi,
   keepPreviousDeletion,
 }) {
-  return campaignParticipationsApi.deleteCampaignParticipationsInCombinedCourse({
+  return campaignParticipationsApi.deleteCampaignParticipations({
     userId,
     campaignParticipationIds,
     campaignId,

--- a/api/src/quest/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/src/quest/infrastructure/repositories/campaign-participation-repository.js
@@ -1,0 +1,29 @@
+export async function deleteCampaignParticipationsInCombinedCourse({
+  userId,
+  campaignId,
+  campaignParticipationIds,
+  userRole,
+  client,
+  campaignParticipationsApi,
+  keepPreviousDeletion,
+}) {
+  return campaignParticipationsApi.deleteCampaignParticipationsInCombinedCourse({
+    userId,
+    campaignParticipationIds,
+    campaignId,
+    keepPreviousDeletion,
+    userRole,
+    client,
+  });
+}
+
+export async function getCampaignParticipationsByLearnerIdAndCampaignId({
+  organizationLearnerId,
+  campaignId,
+  campaignParticipationsApi,
+}) {
+  return campaignParticipationsApi.getCampaignParticipationsByLearnerIdAndCampaignId({
+    organizationLearnerId,
+    campaignId,
+  });
+}

--- a/api/src/quest/infrastructure/repositories/index.js
+++ b/api/src/quest/infrastructure/repositories/index.js
@@ -4,6 +4,7 @@ import * as knowledgeElementsApi from '../../../evaluation/application/api/knowl
 import * as userApi from '../../../identity-access-management/application/api/users-api.js';
 import * as skillsApi from '../../../learning-content/application/api/skills-api.js';
 import * as campaignsApi from '../../../prescription/campaign/application/api/campaigns-api.js';
+import * as campaignParticipationsApi from '../../../prescription/campaign-participation/application/api/campaign-participations-api.js';
 import * as organizationLearnerApi from '../../../prescription/organization-learner/application/api/organization-learners-api.js';
 import * as organizationLearnerWithParticipationApi from '../../../prescription/organization-learner/application/api/organization-learners-with-participations-api.js';
 import * as targetProfilesApi from '../../../prescription/target-profile/application/api/target-profile-api.js';
@@ -12,6 +13,7 @@ import * as rewardApi from '../../../profile/application/api/reward-api.js';
 import { temporaryStorage } from '../../../shared/infrastructure/key-value-storages/index.js';
 import * as accessCodeRepository from '../../../shared/infrastructure/repositories/access-code-repository.js';
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
+import * as campaignParticipationRepository from './campaign-participation-repository.js';
 import * as campaignRepository from './campaign-repository.js';
 import * as combinedCourseDetailsRepository from './combined-course-details-repository.js';
 import * as combinedCourseParticipantRepository from './combined-course-participant-repository.js';
@@ -45,12 +47,14 @@ const repositoriesWithoutInjectedDependencies = {
   userRepository,
   recommendedModuleRepository,
   targetProfileRepository,
+  campaignParticipationRepository,
 };
 
 const dependencies = {
   organizationLearnerWithParticipationApi,
   knowledgeElementsApi,
   campaignsApi,
+  campaignParticipationsApi,
   organizationLearnerApi,
   skillsApi,
   profileRewardApi,

--- a/api/src/quest/infrastructure/repositories/organization-learner-participation-repository.js
+++ b/api/src/quest/infrastructure/repositories/organization-learner-participation-repository.js
@@ -9,10 +9,7 @@ export const findByOrganizationLearnerIdAndModuleIds = async ({ organizationLear
 
   const organizationLearnerParticipations = await knexConn('organization_learner_participations')
     .select('organization_learner_participations.*')
-    .where({
-      organizationLearnerId,
-      type: OrganizationLearnerParticipationTypes.PASSAGE,
-    })
+    .where({ organizationLearnerId, type: OrganizationLearnerParticipationTypes.PASSAGE })
     .whereIn('referenceId', moduleIds)
     .whereNull('deletedAt');
 
@@ -31,17 +28,11 @@ export const synchronize = async ({ organizationLearnerId, moduleIds, modulesApi
   const knexConn = DomainTransaction.getConnection();
 
   const learner = await organizationLearnerApi.get(organizationLearnerId);
-  const modulePassages = await modulesApi.getUserModuleStatuses({
-    userId: learner.userId,
-    moduleIds,
-  });
+  const modulePassages = await modulesApi.getUserModuleStatuses({ userId: learner.userId, moduleIds });
 
   const learnerParticipationsByModule = await knexConn('organization_learner_participations')
     .select('organization_learner_participations.id', 'referenceId')
-    .where({
-      organizationLearnerId,
-      type: OrganizationLearnerParticipationTypes.PASSAGE,
-    })
+    .select('organization_learner_participations.id', 'referenceId')
     .whereNull('deletedAt')
     .whereIn('referenceId', moduleIds);
 

--- a/api/tests/quest/integration/domain/usecases/delete-and-anonymise-participations-for-a-learner-id_test.js
+++ b/api/tests/quest/integration/domain/usecases/delete-and-anonymise-participations-for-a-learner-id_test.js
@@ -1,0 +1,120 @@
+import { CampaignParticipation } from '../../../../../src/quest/domain/models/CampaignParticipation.js';
+import {
+  OrganizationLearnerParticipationStatuses,
+  OrganizationLearnerParticipationTypes,
+} from '../../../../../src/quest/domain/models/OrganizationLearnerParticipation.js';
+import { usecases } from '../../../../../src/quest/domain/usecases/index.js';
+import { Membership } from '../../../../../src/shared/domain/models/Membership.js';
+import { databaseBuilder, expect, knex, sinon } from '../../../../test-helper.js';
+
+describe('Integration | Quest | Domain | UseCases | delete-and-anonymise-participations-for-a-learner-id', function () {
+  let campaign,
+    organization,
+    combinedCourse,
+    organizationLearnerId,
+    otherOrganizationLearnerId,
+    campaignParticipationId,
+    campaignParticipationsApiStub;
+  const moduleId = '01151659-77c1-41cc-8724-89091357af3d';
+
+  beforeEach(async function () {
+    campaignParticipationsApiStub = {
+      getCampaignParticipationsByLearnerIdAndCampaignId: sinon.stub(),
+      deleteCampaignsParticipationsInCombinedCourse: sinon.stub(),
+    };
+
+    organization = databaseBuilder.factory.buildOrganization();
+    organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({
+      organizationId: organization.id,
+    }).id;
+    otherOrganizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({
+      organizationId: organization.id,
+    }).id;
+    campaign = databaseBuilder.factory.buildCampaign({
+      organizationId: organization.id,
+    });
+
+    combinedCourse = databaseBuilder.factory.buildCombinedCourse({
+      combinedCourseContents: [{ campaignId: campaign.id }, { moduleId }],
+      code: 'RANDOM',
+    });
+
+    campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
+      campaignId: campaign.id,
+      organizationLearnerId,
+    }).id;
+    databaseBuilder.factory.buildCampaignParticipation({
+      campaignId: campaign.id,
+      organizationLearnerId: otherOrganizationLearnerId,
+    });
+
+    databaseBuilder.factory.buildOrganizationLearnerParticipation({
+      combinedCourseId: combinedCourse.id.toString(),
+      type: OrganizationLearnerParticipationTypes.COMBINED_COURSE,
+      organizationLearnerId,
+      status: OrganizationLearnerParticipationStatuses.COMPLETED,
+    });
+
+    databaseBuilder.factory.buildOrganizationLearnerParticipation({
+      combinedCourseId: combinedCourse.id.toString(),
+      type: OrganizationLearnerParticipationTypes.COMBINED_COURSE,
+      organizationLearnerId,
+      status: OrganizationLearnerParticipationStatuses.COMPLETED,
+    });
+
+    databaseBuilder.factory.buildOrganizationLearnerParticipation({
+      moduleId,
+      organizationLearnerId: otherOrganizationLearnerId,
+      type: OrganizationLearnerParticipationTypes.COMBINED_COURSE,
+      status: OrganizationLearnerParticipationStatuses.COMPLETED,
+    });
+
+    await databaseBuilder.commit();
+  });
+
+  it('flags organization_learner_participations and campaign_participations linked to combined Course with deletedBy/deletedAt attributes', async function () {
+    //given
+    const { userId } = databaseBuilder.factory.buildMembership({
+      organizationId: organization.id,
+      organizationRole: Membership.roles.ADMIN,
+    });
+
+    campaignParticipationsApiStub.getCampaignParticipationsByLearnerIdAndCampaignId
+      .withArgs({ organizationLearnerId, campaignId: campaign.id })
+      .resolves(new CampaignParticipation({ id: campaignParticipationId }));
+    campaignParticipationsApiStub.deleteCampaignsParticipationsInCombinedCourse
+      .withArgs({ userId, campaignParticipationIds: [campaignParticipationId] })
+      .resolves();
+
+    await databaseBuilder.commit();
+
+    //when
+    await usecases.deleteAndAnonymizeParticipationsForALearnerId({
+      combinedCourseId: combinedCourse.id,
+      userId,
+      organizationLearnerId,
+      campaignParticipationsApi: campaignParticipationsApiStub,
+    });
+
+    const deletedCombinedCourseParticipations = await knex('organization_learner_participations').where(
+      'organizationLearnerId',
+      organizationLearnerId,
+    );
+
+    const remainingCombinedCourseParticipations = await knex('organization_learner_participations').where(
+      'organizationLearnerId',
+      otherOrganizationLearnerId,
+    );
+
+    //then
+    expect(deletedCombinedCourseParticipations).to.have.lengthOf(2);
+    expect(deletedCombinedCourseParticipations[0].deletedBy).to.equal(userId);
+    expect(deletedCombinedCourseParticipations[0].deletedAt).to.not.be.null;
+    expect(deletedCombinedCourseParticipations[1].deletedBy).to.equal(userId);
+    expect(deletedCombinedCourseParticipations[1].deletedAt).to.not.be.null;
+
+    expect(remainingCombinedCourseParticipations.length).to.equal(1);
+    expect(remainingCombinedCourseParticipations[0].deletedBy).to.be.null;
+    expect(remainingCombinedCourseParticipations[0].deletedAt).to.be.null;
+  });
+});

--- a/api/tests/quest/integration/infrastructure/repositories/campaign-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/campaign-repository_test.js
@@ -1,0 +1,31 @@
+import * as campaignRepository from '../../../../../src/quest/infrastructure/repositories/campaign-repository.js';
+import { databaseBuilder, expect } from '../../../../test-helper.js';
+
+describe('Quest | Integration | Repository | combined-course-blueprint', function () {
+  describe('#getCampaignIdsByCombinedCourseIds', function () {
+    it('should return correct campaign ids', async function () {
+      const { id: campaignId } = databaseBuilder.factory.buildCampaign();
+      const { id: otherCampaignId } = databaseBuilder.factory.buildCampaign();
+
+      const { id: combinedCourseId1 } = databaseBuilder.factory.buildCombinedCourse({
+        code: 'RANDOM',
+        combinedCourseContents: [{ campaignId }],
+      });
+      const { id: combinedCourseId2 } = databaseBuilder.factory.buildCombinedCourse({ code: 'LKJHG' });
+      databaseBuilder.factory.buildCombinedCourse({
+        combinedCourseContents: [{ campaignId: otherCampaignId }],
+      });
+
+      await databaseBuilder.commit();
+
+      //when
+      const campaignIds = await campaignRepository.getCampaignIdsByCombinedCourseIds({
+        combinedCourseIds: [combinedCourseId1, combinedCourseId2],
+      });
+
+      // then
+      expect(campaignIds).to.have.lengthOf(1);
+      expect(campaignIds[0]).to.deep.equal(campaignId);
+    });
+  });
+});

--- a/api/tests/quest/unit/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/quest/unit/infrastructure/repositories/campaign-participation-repository_test.js
@@ -1,0 +1,72 @@
+import { CampaignParticipationStatuses } from '../../../../../src/prescription/shared/domain/constants.js';
+import { CampaignParticipation } from '../../../../../src/quest/domain/models/CampaignParticipation.js';
+import * as campaignParticipationRepository from '../../../../../src/quest/infrastructure/repositories/campaign-participation-repository.js';
+import { expect, sinon } from '../../../../test-helper.js';
+
+describe('Quest | Unit | Infrastructure | Repositories | campaign-participation', function () {
+  let expectedResult, campaignParticipationsApiStub;
+  const organizationLearnerId = 1;
+  const campaignId = 1;
+
+  beforeEach(async function () {
+    expectedResult = {
+      id: 1,
+      sharedAt: null,
+      status: CampaignParticipationStatuses.SHARED,
+    };
+
+    campaignParticipationsApiStub = {
+      getCampaignParticipationsByLearnerIdAndCampaignId: sinon.stub(),
+      deleteCampaignParticipationsInCombinedCourse: sinon.stub(),
+    };
+    campaignParticipationsApiStub.getCampaignParticipationsByLearnerIdAndCampaignId
+      .withArgs({ organizationLearnerId, campaignId })
+      .resolves(new CampaignParticipation(expectedResult));
+  });
+  describe('#getCampaignParticipationsByLearnerIdAndCampaignId', function () {
+    it('should call getCampaignParticipationsByLearnerIdAndCampaignId method from campaignParticipationsApi', async function () {
+      // when
+      const result = await campaignParticipationRepository.getCampaignParticipationsByLearnerIdAndCampaignId({
+        organizationLearnerId,
+        campaignId,
+        campaignParticipationsApi: campaignParticipationsApiStub,
+      });
+
+      // then
+      expect(result).to.be.an.instanceof(CampaignParticipation);
+      expect(result).to.deep.equal(expectedResult);
+    });
+  });
+  describe('#deleteCampaignParticipationInCombinedCourse', function () {
+    it('should call deleteCampaignParticipationInCombinedCourse method from campaignParticipationsApi', async function () {
+      //given
+      const userId = Symbol(1);
+      const campaignId = Symbol(1);
+      const campaignParticipationIds = Symbol(1);
+      const userRole = Symbol('admin');
+      const client = Symbol('client');
+      const keepPreviousDeletion = Symbol('true');
+
+      // when
+      await campaignParticipationRepository.deleteCampaignParticipationsInCombinedCourse({
+        userId,
+        campaignId,
+        campaignParticipationIds,
+        userRole,
+        client,
+        campaignParticipationsApi: campaignParticipationsApiStub,
+        keepPreviousDeletion,
+      });
+
+      // then
+      expect(campaignParticipationsApiStub.deleteCampaignParticipationsInCombinedCourse).to.be.calledWithExactly({
+        userId,
+        campaignParticipationIds,
+        campaignId,
+        keepPreviousDeletion,
+        userRole,
+        client,
+      });
+    });
+  });
+});

--- a/api/tests/quest/unit/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/quest/unit/infrastructure/repositories/campaign-participation-repository_test.js
@@ -17,7 +17,7 @@ describe('Quest | Unit | Infrastructure | Repositories | campaign-participation'
 
     campaignParticipationsApiStub = {
       getCampaignParticipationsByLearnerIdAndCampaignId: sinon.stub(),
-      deleteCampaignParticipationsInCombinedCourse: sinon.stub(),
+      deleteCampaignParticipations: sinon.stub(),
     };
     campaignParticipationsApiStub.getCampaignParticipationsByLearnerIdAndCampaignId
       .withArgs({ organizationLearnerId, campaignId })
@@ -48,7 +48,7 @@ describe('Quest | Unit | Infrastructure | Repositories | campaign-participation'
       const keepPreviousDeletion = Symbol('true');
 
       // when
-      await campaignParticipationRepository.deleteCampaignParticipationsInCombinedCourse({
+      await campaignParticipationRepository.deleteCampaignParticipations({
         userId,
         campaignId,
         campaignParticipationIds,
@@ -59,7 +59,7 @@ describe('Quest | Unit | Infrastructure | Repositories | campaign-participation'
       });
 
       // then
-      expect(campaignParticipationsApiStub.deleteCampaignParticipationsInCombinedCourse).to.be.calledWithExactly({
+      expect(campaignParticipationsApiStub.deleteCampaignParticipations).to.be.calledWithExactly({
         userId,
         campaignParticipationIds,
         campaignId,

--- a/api/tests/unit/scripts/delete-and-anonymize-organization-learner-participations-from-combined-courses_test.js
+++ b/api/tests/unit/scripts/delete-and-anonymize-organization-learner-participations-from-combined-courses_test.js
@@ -1,0 +1,85 @@
+import { DeleteAndAnonymizeOrganizationLearnerParticipationsScript } from '../../../scripts/prod/delete-and-anonymize-organization-learner-participations-from-combined-courses.js';
+import { DomainTransaction } from '../../../src/shared/domain/DomainTransaction.js';
+import { catchErr, expect, sinon } from '../../test-helper.js';
+
+describe('DeleteAndAnonymizeOrganizationLearnerParticipationsScript', function () {
+  let script, logger;
+  describe('Options', function () {
+    it('has the correct options', function () {
+      script = new DeleteAndAnonymizeOrganizationLearnerParticipationsScript();
+      const { options } = script.metaInfo;
+      logger = { info: sinon.stub(), error: sinon.stub() };
+
+      expect(options.combinedCourseId).to.deep.include({
+        type: 'number',
+        describe: 'a single combined course id',
+        demandOption: true,
+      });
+      expect(options.organizationLearnerId).to.deep.include({
+        type: 'number',
+        describe: 'a single organization learner id',
+        demandOption: true,
+      });
+    });
+  });
+
+  describe('Handle', function () {
+    let usecasesStub, domainTransactionStub;
+    const combinedCourseId = '1';
+    const organizationLearnerId = '2';
+
+    const ENGINEERING_USER_ID = 99999;
+
+    beforeEach(async function () {
+      logger = { info: sinon.spy(), error: sinon.spy() };
+      sinon.stub(process, 'env').value({ ENGINEERING_USER_ID });
+      script = new DeleteAndAnonymizeOrganizationLearnerParticipationsScript();
+      usecasesStub = {
+        deleteAndAnonymizeParticipationsForALearnerId: sinon.stub(),
+      };
+      domainTransactionStub = Symbol('domainTransaction');
+      sinon.stub(DomainTransaction, 'execute').callsFake((fn) => fn(domainTransactionStub));
+      sinon.stub(DomainTransaction, 'getConnection').returns({ rollback: sinon.stub() });
+    });
+
+    it('should call usecase with correct arguments and log accordingly if usecase resolves', async function () {
+      //given&when
+      await script.handle({
+        options: { combinedCourseId, organizationLearnerId, dryRun: false },
+        logger,
+        dependencies: usecasesStub,
+      });
+
+      //then
+      expect(usecasesStub.deleteAndAnonymizeParticipationsForALearnerId).to.be.calledWithExactly({
+        combinedCourseId,
+        organizationLearnerId,
+        userId: ENGINEERING_USER_ID,
+      });
+
+      expect(logger.info).to.have.been.calledWithExactly(
+        { event: 'DeleteAndAnonymizeCombinedCoursesScript' },
+        `COMMIT: Successfully deleted and anonymized all participations linked to combined course ${combinedCourseId} for learner ${organizationLearnerId}`,
+      );
+    });
+    it('should rollback and log accordingly if usecase fail', async function () {
+      //given&when
+      usecasesStub.deleteAndAnonymizeParticipationsForALearnerId
+        .withArgs({
+          combinedCourseId,
+          organizationLearnerId,
+          userId: ENGINEERING_USER_ID,
+        })
+        .rejects(new Error('message'));
+
+      await catchErr(script.handle)({
+        options: { combinedCourseId, organizationLearnerId, dryRun: false },
+        logger,
+        dependencies: usecasesStub,
+      });
+
+      //then
+      expect(logger.error).to.have.been.called;
+    });
+  });
+});


### PR DESCRIPTION
## 🥀 Problème
On veut pouvoir répondre rapidement, avec un script testé, à des demandes de suppression / anonymisation des prescrits qui auraient participé à un parcours combiné.

## 🏹 Proposition
On écrit un script qui  les participations aux parcours combinés (organization_learner_participation de type combined_course), aux modules (organization_learner_participation de type passage) et aux campagnes, comme supprimés avec une valeur dans deletedAt et deletedBy.
Le script prend trois arguments : combinedCourseId, organizationLearnerId, et un booléen dryRun.

## ❤️‍🔥 Pour tester
Se connecter sur PixApp avec le compte attestation-blank@example.net.
Entrer MAXICOMBI dans j'ai un code -> participer à la campagne et au premier module. Relever l'id de la campagne, du prescrit connecté et du parcours combiné.

Lancer la commande sur un one-off : 
```
scalingo -a pix-api-review-pr15127 run node ./scripts/prod/delete-and-anonymize-organization-learner-participations-from-combined-courses --dryRun=false --combinedCourseId=idDuMaxiCombi organizationLearnerId=idDuPrescritQuiAParticipé
```

Vérifier que les parcours combinés, les campagnes associées et les participations sont bien flaggées
`SELECT * FROM "campaigns" WHERE "deletedAt" IS NOT NULL` -> 1 participation doit apparaître avec le bon id
`SELECT * FROM "organization_learner_participations" WHERE "deletedAt" IS NOT NULL` -> plusieurs participations doivent apparaître, avec le type (passages ou parcours combiné) et l'id correct 
