### PR TITLE
[FEATURE] Mettre à jour les évènements QAB_CARD_RETRIED de la table passage-events (PIX-21427)

### DIFF
--- a/api/scripts/modulix/modify-type-label-passage-event-qab-card-retried.js
+++ b/api/scripts/modulix/modify-type-label-passage-event-qab-card-retried.js
@@ -1,0 +1,60 @@
+import { knex } from '../../db/knex-database-connection.js';
+import { Script } from '../../src/shared/application/scripts/script.js';
+import { ScriptRunner } from '../../src/shared/application/scripts/script-runner.js';
+
+const OLD_TYPE_LABEL = 'QAB_CARD_RETRIED';
+const NEW_LABEL_TYPE = 'QAB_RETRIED';
+
+export class ModifyTypeLabelPassageEventQabCardRetried extends Script {
+  constructor() {
+    super({
+      description: 'Rename type label of passage events recorded when a QAB has been retried',
+      permanent: false,
+      options: {
+        dryRun: {
+          type: 'boolean',
+          describe: 'Run the script without making any database changes',
+          default: false,
+        },
+      },
+    });
+  }
+
+  async handle({ logger, options }) {
+    const { dryRun } = options;
+    logger.info('Script execution started');
+
+    const trx = await knex.transaction();
+    try {
+      const passageEventsTypeLabelToBeUpdated = await trx('passage-events').where('type', `${OLD_TYPE_LABEL}`);
+      logger.info(
+        `Number of passage event with the old type QAB_CARD_RETRIED : ${passageEventsTypeLabelToBeUpdated.length}`,
+      );
+
+      for (const passageEvent of passageEventsTypeLabelToBeUpdated) {
+        await trx('passage-events').update({ type: NEW_LABEL_TYPE }).where({ id: passageEvent.id });
+      }
+
+      if (dryRun) {
+        const passageEventsTypeLabel = await trx('passage-events').select('type').where('type', `${OLD_TYPE_LABEL}`);
+        const passageEventsTypeLabelUpdated = passageEventsTypeLabel.map((item) => item.type);
+
+        logger.info(
+          `List of passage events with old type label ‘QAB_CARD_RETRIED‘ left after update : ${passageEventsTypeLabelUpdated}`,
+        );
+
+        await trx.rollback();
+        return;
+      }
+
+      await trx.commit();
+      logger.info(`${passageEventsTypeLabelToBeUpdated.length} passage events have been successfully updated.`);
+      return;
+    } catch (error) {
+      await trx.rollback();
+      throw error;
+    }
+  }
+}
+
+await ScriptRunner.execute(import.meta.url, ModifyTypeLabelPassageEventQabCardRetried);

--- a/api/tests/integration/scripts/modulix/modify-type-label-passage-event-qab-card-retried_test.js
+++ b/api/tests/integration/scripts/modulix/modify-type-label-passage-event-qab-card-retried_test.js
@@ -1,0 +1,89 @@
+import { ModifyTypeLabelPassageEventQabCardRetried } from '../../../../scripts/modulix/modify-type-label-passage-event-qab-card-retried.js';
+import { databaseBuilder, expect, knex, sinon } from '../../../test-helper.js';
+
+const OLD_TYPE_LABEL = 'QAB_CARD_RETRIED';
+const NEW_LABEL_TYPE = 'QAB_RETRIED';
+
+describe('Integration | modulix | scripts | modify-type-label-passage-event-qab-card-retried.js', function () {
+  describe('#handle', function () {
+    let file;
+    let logger;
+    let script;
+
+    beforeEach(function () {
+      script = new ModifyTypeLabelPassageEventQabCardRetried();
+      logger = { info: sinon.spy(), error: sinon.spy() };
+    });
+
+    it('runs the script with dryRun', async function () {
+      // given
+      const passage = databaseBuilder.factory.buildPassage();
+      databaseBuilder.factory.buildPassageEvent({
+        type: `${OLD_TYPE_LABEL}`,
+        passageId: passage.id,
+        sequenceNumber: 1,
+      });
+      databaseBuilder.factory.buildPassageEvent({
+        type: `${OLD_TYPE_LABEL}`,
+        passageId: passage.id,
+        sequenceNumber: 2,
+      });
+      databaseBuilder.factory.buildPassageEvent({
+        type: 'PASSAGE_TERMINATED',
+        passageId: passage.id,
+        sequenceNumber: 3,
+      });
+      await databaseBuilder.commit();
+
+      // when
+      await script.handle({
+        options: { file, dryRun: true },
+        logger,
+      });
+
+      // then
+      expect(logger.info).to.have.been.calledWith(
+        'List of passage events with old type label ‘QAB_CARD_RETRIED‘ left after update : ',
+      );
+      const passageEvents = await knex('passage-events').orderBy('id');
+      expect(passageEvents[0].type).to.equal(OLD_TYPE_LABEL);
+      expect(passageEvents[1].type).to.equal(OLD_TYPE_LABEL);
+      expect(passageEvents[2].type).to.equal('PASSAGE_TERMINATED');
+    });
+
+    it('runs the script without dryRun', async function () {
+      // given
+      const passage = databaseBuilder.factory.buildPassage();
+      databaseBuilder.factory.buildPassageEvent({
+        type: `${OLD_TYPE_LABEL}`,
+        passageId: passage.id,
+        sequenceNumber: 1,
+      });
+      databaseBuilder.factory.buildPassageEvent({
+        type: `${OLD_TYPE_LABEL}`,
+        passageId: passage.id,
+        sequenceNumber: 2,
+      });
+      databaseBuilder.factory.buildPassageEvent({
+        type: 'PASSAGE_TERMINATED',
+        passageId: passage.id,
+        sequenceNumber: 3,
+      });
+      await databaseBuilder.commit();
+
+      // when
+      await script.handle({
+        options: { file },
+        logger,
+      });
+
+      // then
+      const passageEvents = await knex('passage-events').orderBy('id');
+      expect(passageEvents[0].type).to.equal(NEW_LABEL_TYPE);
+      expect(passageEvents[1].type).to.equal(NEW_LABEL_TYPE);
+      expect(passageEvents[2].type).to.equal('PASSAGE_TERMINATED');
+
+      expect(logger.info).to.have.been.calledWith('Number of passage event with the old type QAB_CARD_RETRIED : 2');
+    });
+  });
+});


### PR DESCRIPTION
## 🥀 Problème

Un renommage de l'évènement QAB_CARD_RETRIED en QAB_RETRIED à été fait (dans le ticket  https://1024pix.atlassian.net/browse/PIX-21197 )

Il faut donc faire une reprise de données sur la table pour tous les évènements qui ont ce nom là.

## 🏹 Proposition

Créer un script pour renommer ces passage-events en `QAB_RETRIED`

## 💌 Remarques
- Option `dryRun` disponible
- Il faudra contacter les captains pour faire tourner le script en prod
- Il faudra, une fois exécuté en Prod, supprimer le script du repo

## ❤️‍🔥 Pour tester
- Récupérer la branche localement
- S'assurer qu'on a des passage-events avec le type `QAB_CARD_RETRIED` dans sa DB locale
- Lancer le script, depuis le dossier `/pix/api`, avec la commande suivante (mode `dryRun`) : `node --env-file-if-exists=.env scripts/modulix/modify-type-label-passage-event-qab-card-retried.js --dryRun`
- Vérifier qu'en sortie, on a bien : ` List of passage events with old type label ‘QAB_CARD_RETRIED‘ left after update :`