### PR TITLE
[BUGFIX] Ne pas afficher le blur sur une question focus déjà répondue (PIX-18636).

### DIFF
--- a/mon-pix/app/controllers/assessments/challenge.js
+++ b/mon-pix/app/controllers/assessments/challenge.js
@@ -76,7 +76,7 @@ export default class ChallengeController extends Controller {
   }
 
   get shouldBlurBanner() {
-    return this.model.challenge.focused && !this.hasConfirmedFocusChallengeWarningScreen;
+    return !this.model.answer && this.model.challenge.focused && !this.hasConfirmedFocusChallengeWarningScreen;
   }
 
   get isFocusedChallenge() {

--- a/mon-pix/tests/unit/controllers/assessments/challenge-test.js
+++ b/mon-pix/tests/unit/controllers/assessments/challenge-test.js
@@ -111,6 +111,61 @@ module('Unit | Controller | Assessments | Challenge', function (hooks) {
     });
   });
 
+  module('#shouldBlurBanner', function () {
+    [
+      {
+        answer: null,
+        focused: true,
+        hasConfirmed: false,
+        expectedResult: true,
+      },
+      {
+        answer: 'some-answer',
+        focused: true,
+        hasConfirmed: false,
+        expectedResult: false,
+      },
+      {
+        answer: null,
+        focused: false,
+        hasConfirmed: false,
+        expectedResult: false,
+      },
+      {
+        answer: null,
+        focused: true,
+        hasConfirmed: true,
+        expectedResult: false,
+      },
+    ].forEach(({ answer, focused, hasConfirmed, expectedResult }) => {
+      const _hasAnswer = answer ? 'answer exists' : 'no answer';
+      const _isFocused = focused ? 'challenge is focused' : 'challenge is not focused';
+      const _hasConfirmed = hasConfirmed
+        ? 'focus warning screen is confirmed'
+        : 'focus warning screen is not confirmed';
+
+      test(`should be ${expectedResult} when ${_hasAnswer}, ${_isFocused} and ${_hasConfirmed}`, function (assert) {
+        // given
+        const focusedCertificationChallengeWarningManager = this.owner.lookup(
+          'service:focused-certification-challenge-warning-manager',
+        );
+        focusedCertificationChallengeWarningManager._hasConfirmedFocusChallengeScreen = hasConfirmed;
+
+        controller.model = {
+          answer,
+          challenge: { focused },
+          assessment: {},
+        };
+
+        // when
+        const result = controller.shouldBlurBanner;
+
+        // then
+        assert.strictEqual(result, expectedResult);
+      });
+    });
+  });
+
   module('#displayChallenge', function () {
     module('when challenge is focused and assessment is of type certification', function () {
       [
@@ -163,6 +218,7 @@ module('Unit | Controller | Assessments | Challenge', function (hooks) {
         });
       });
     });
+
     module('when challenge is not focused and has no timer', function () {
       [
         { answer: undefined, hasUserConfirmedTimedChallengeWarning: false, expectedResult: true },


### PR DESCRIPTION
## 🥀 Problème

- En test de certification, j'arrive sur une épreuve focus.
- Je valide l'écran intermédiaire m'indiquant que ça va être une question focus (un boolean est rajouté dans le local storage)
- Je réponds ou passe
- J'arrive (à un moment) sur une épreuve NON focus (le boolean est retiré du local storage)
- Je reviens en arrière (bouton retour du navigateur) jusqu'à mon épreuve focus.
- L'écran intermédiaire ne s'affiche pas à nouveau () mais la classe .blur-banner est appliquée et on ne voit pas le header quand on est sur l'épreuve ().

<img width="1024" height="437" alt="image" src="https://github.com/user-attachments/assets/2ab39914-2594-4737-ad1d-48e30c6491b4" />


## 🏹 Proposition

Ne pas appliquer le blur quand on revient sur une question déjà répondue.

## ❤️‍🔥 Pour tester

Trust me.
