### PR TITLE
[FEATURE] Révoquer les tokens des utilisateurs OIDC lors de la déconnexion (PIX-20688).

### DIFF
--- a/admin/app/authenticators/oidc.js
+++ b/admin/app/authenticators/oidc.js
@@ -7,6 +7,7 @@ import ENV from 'pix-admin/config/environment';
 export default class OidcAuthenticator extends BaseAuthenticator {
   @service session;
   @service oidcIdentityProviders;
+  @service requestManager;
 
   async authenticate({ code, state, iss, authenticationKey, email, identityProviderSlug }) {
     const identityProvider = this.oidcIdentityProviders.list.find((provider) => provider.id === identityProviderSlug);
@@ -65,5 +66,26 @@ export default class OidcAuthenticator extends BaseAuthenticator {
       }
       reject();
     });
+  }
+
+  /**
+   * @param {Object} data - The current authenticated session data
+   */
+  async invalidate(data) {
+    const { identityProviderCode, logoutUrlUuid } = data || {};
+
+    const response = await this.requestManager.request({
+      url: `${ENV.APP.API_HOST}/api/oidc/logout`,
+      method: 'POST',
+      body: JSON.stringify({
+        identity_provider: identityProviderCode,
+        logout_url_uuid: logoutUrlUuid,
+      }),
+    });
+
+    const { redirectLogoutUrl } = await response.content;
+    if (!redirectLogoutUrl) return;
+
+    this.session.alternativeRootURL = redirectLogoutUrl;
   }
 }

--- a/admin/tests/mirage/routes.js
+++ b/admin/tests/mirage/routes.js
@@ -737,6 +737,11 @@ export default function routes() {
     };
   });
 
+  this.post('/oidc/logout', () => {
+    const redirectLogoutUrl = undefined; // because shouldCloseSession == false
+    return { redirectLogoutUrl };
+  });
+
   this.get('/admin/combined-course-blueprints');
   this.post('/admin/combined-course-blueprints');
   this.post(

--- a/admin/tests/unit/authenticators/oidc-test.js
+++ b/admin/tests/unit/authenticators/oidc-test.js
@@ -143,4 +143,67 @@ module('Unit | Authenticator | oidc', function (hooks) {
       });
     });
   });
+
+  module('#invalidate', function () {
+    module('when user has no logout_url_uuid in their session (because shouldCloseSession is false)', function () {
+      test('does not set alternativeRootURL', async function (assert) {
+        // given
+        const sessionStub = Service.create({
+          isAuthenticated: true,
+        });
+        const authenticator = this.owner.lookup('authenticator:oidc');
+        authenticator.session = sessionStub;
+
+        const redirectLogoutUrl = undefined;
+        const requestManager = this.owner.lookup('service:request-manager');
+        sinon.stub(requestManager, 'request').resolves({
+          content: {
+            redirectLogoutUrl,
+          },
+        });
+
+        // when
+        await authenticator.invalidate({
+          identityProviderCode: 'OIDC_PARTNER',
+        });
+
+        // then
+        assert.strictEqual(authenticator.session.alternativeRootURL, undefined);
+      });
+    });
+
+    module('when user has a logout_url_uuid in their session (because shouldCloseSession is true)', function () {
+      test('sets alternativeRootURL with the redirectLogoutUrl', async function (assert) {
+        // given
+        const sessionStub = Service.create({
+          isAuthenticated: true,
+          data: {
+            authenticated: {
+              logout_url_uuid: 'uuid',
+            },
+          },
+        });
+        const authenticator = this.owner.lookup('authenticator:oidc');
+        authenticator.session = sessionStub;
+
+        const redirectLogoutUrl =
+          'https://oidc.example.net/ea5ac20c-5076-4806-860a-b0aeb01645d4/oauth2/v2.0/logout?client_id=client';
+        const requestManager = this.owner.lookup('service:request-manager');
+        sinon.stub(requestManager, 'request').resolves({
+          content: {
+            redirectLogoutUrl,
+          },
+        });
+
+        // when
+        await authenticator.invalidate({
+          identityProviderCode: 'OIDC_PARTNER',
+          logoutUrlUuid: 'uuid',
+        });
+
+        // then
+        assert.strictEqual(authenticator.session.alternativeRootURL, redirectLogoutUrl);
+      });
+    });
+  });
 });

--- a/api/src/identity-access-management/application/oidc-provider/oidc-provider.controller.js
+++ b/api/src/identity-access-management/application/oidc-provider/oidc-provider.controller.js
@@ -182,6 +182,29 @@ async function reconcileUser(request, h) {
 }
 
 /**
+ * @typedef {function} logout
+ * @param request
+ * @param h
+ * @return {Promise<{redirectLogoutUrl: string}>}
+ */
+async function logout(request, h) {
+  const userId = request.auth.credentials.userId;
+  const { identity_provider: identityProvider, logout_url_uuid: logoutUrlUUID } = request.payload;
+
+  const origin = getForwardedOrigin(request.headers);
+  const requestedApplication = RequestedApplication.fromOrigin(origin);
+
+  const redirectLogoutUrl = await usecases.logoutOidcUser({
+    identityProvider,
+    userId,
+    logoutUrlUUID,
+    requestedApplication,
+  });
+
+  return h.response({ redirectLogoutUrl }).code(200);
+}
+
+/**
  * @typedef {Object} OidcProviderController
  * @property {authenticateOidcUser} authenticateOidcUser
  * @property {findUserForReconciliation} findUserForReconciliation
@@ -189,6 +212,7 @@ async function reconcileUser(request, h) {
  * @property {getIdentityProviders} getIdentityProviders
  * @property {getRedirectLogoutUrl} getRedirectLogoutUrl
  * @property {reconcileUser} reconcileUser
+ * @property {logout} logout
  */
 export const oidcProviderController = {
   authenticateOidcUser,
@@ -198,4 +222,5 @@ export const oidcProviderController = {
   getIdentityProviders,
   getRedirectLogoutUrl,
   reconcileUser,
+  logout,
 };

--- a/api/src/identity-access-management/application/oidc-provider/oidc-provider.route.js
+++ b/api/src/identity-access-management/application/oidc-provider/oidc-provider.route.js
@@ -1,6 +1,6 @@
 import Joi from 'joi';
 
-import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
 import { oidcProviderController } from './oidc-provider.controller.js';
 
 export const oidcProviderRoutes = [
@@ -152,6 +152,21 @@ export const oidcProviderRoutes = [
           '- Elle retourne un access token et une uri de déconnexion',
       ],
       tags: ['identity-access-management', 'api', 'oidc'],
+    },
+  },
+  {
+    method: 'POST',
+    path: '/api/oidc/logout',
+    config: {
+      validate: {
+        payload: Joi.object({
+          identity_provider: Joi.string().required(),
+          logout_url_uuid: Joi.string().optional(),
+        }).required(),
+      },
+      handler: (request, h) => oidcProviderController.logout(request, h),
+      notes: ['- Cette route permet de déconnecter un utilisateur OIDC et de supprimer/révoquer ses tokens'],
+      tags: ['identity-access-management', 'api', 'token', 'oidc'],
     },
   },
 ];

--- a/api/src/identity-access-management/domain/usecases/index.js
+++ b/api/src/identity-access-management/domain/usecases/index.js
@@ -147,6 +147,7 @@ import { getUserByResetPasswordDemand } from './get-user-by-reset-password-deman
 import { getUserDetailsForAdmin } from './get-user-details-for-admin.usecase.js';
 import { importUserLastLoggedAt } from './import-user-last-logged-at.usecase.js';
 import { listLtiPublicKeys } from './list-lti-public-keys.usecase.js';
+import { logoutOidcUser } from './logout-oidc-user.usecase.js';
 import { markAssessmentInstructionsInfoAsSeen } from './mark-assessment-instructions-info-as-seen.usecase.js';
 import { markUserHasSeenNewDashboardInfo } from './mark-user-has-seen-new-dashboard-info.usecase.js';
 import { reassignAuthenticationMethodToAnotherUser } from './reassign-authentication-method-to-another-user.usecase.js';
@@ -206,6 +207,7 @@ const usecasesWithoutInjectedDependencies = {
   getUserDetailsForAdmin,
   importUserLastLoggedAt,
   listLtiPublicKeys,
+  logoutOidcUser,
   markAssessmentInstructionsInfoAsSeen,
   markUserHasSeenNewDashboardInfo,
   reassignAuthenticationMethodToAnotherUser,

--- a/api/src/identity-access-management/domain/usecases/logout-oidc-user.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/logout-oidc-user.usecase.js
@@ -1,0 +1,44 @@
+/**
+ * @typedef {function} logoutOidcUser
+ * @param {Object} params
+ * @param {string} params.userId
+ * @param {string} params.identityProvider
+ * @param {string} params.requestedApplication
+ * @param {OidcAuthenticationServiceRegistry} params.oidcAuthenticationServiceRegistry
+ * @param {refreshTokenRepository} params.refreshTokenRepository
+ * @return {Promise<string>}
+ */
+async function logoutOidcUser({
+  userId,
+  identityProvider,
+  requestedApplication,
+  logoutUrlUUID,
+  oidcAuthenticationServiceRegistry,
+  revokedUserAccessRepository,
+  refreshTokenRepository,
+}) {
+  // Revoke user AccessToken
+  await revokedUserAccessRepository.saveForUser({
+    userId,
+    revokeUntil: new Date(),
+  });
+
+  // Revoke user RefreshToken
+  await refreshTokenRepository.revokeAllByUserId({ userId });
+
+  const oidcAuthenticationService = await oidcAuthenticationServiceRegistry.getOidcProviderServiceByCode({
+    identityProviderCode: identityProvider,
+    requestedApplication,
+  });
+
+  if (!oidcAuthenticationService.shouldCloseSession) return;
+
+  const redirectLogoutUrl = await oidcAuthenticationService.getRedirectLogoutUrl({
+    logoutUrlUUID,
+    userId,
+  });
+
+  return redirectLogoutUrl;
+}
+
+export { logoutOidcUser };

--- a/api/src/identity-access-management/domain/usecases/revoke-access-for-users.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/revoke-access-for-users.usecase.js
@@ -13,10 +13,10 @@ export const revokeAccessForUsers = async function ({
   authenticationMethodRepository,
 }) {
   for (const userId of userIds) {
-    // Revoke user access for access token
+    // Revoke user AccessToken
     await revokedUserAccessRepository.saveForUser({ userId, revokeUntil: new Date() });
 
-    // Revoke user access for refresh token
+    // Revoke user RefreshToken
     await refreshTokenRepository.revokeAllByUserId({ userId });
 
     // Revoke current user password

--- a/api/tests/identity-access-management/acceptance/application/oidc-provider.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/oidc-provider.route.test.js
@@ -3,6 +3,8 @@ import querystring from 'node:querystring';
 import jsonwebtoken from 'jsonwebtoken';
 
 import { authenticationSessionService } from '../../../../src/identity-access-management/domain/services/authentication-session.service.js';
+import { refreshTokenRepository } from '../../../../src/identity-access-management/infrastructure/repositories/refresh-token.repository.js';
+import { revokedUserAccessRepository } from '../../../../src/identity-access-management/infrastructure/repositories/revoked-user-access.repository.js';
 import { AuthenticationSessionContent } from '../../../../src/shared/domain/models/AuthenticationSessionContent.js';
 import { tokenService } from '../../../../src/shared/domain/services/token-service.js';
 import {
@@ -584,6 +586,44 @@ describe('Acceptance | Identity Access Management | Application | Route | oidc-p
     });
   });
 
+  describe('POST /api/oidc/logout', function () {
+    beforeEach(async function () {
+      await createServerWithMockedTestOidcProvider({
+        application: 'app',
+        applicationTld: '.org',
+        postLogoutRedirectUri: `https://app.dev.pix.fr/post-logout-redirect-uri`,
+      });
+    });
+
+    it('returns an object which contains the post logout url with an HTTP status code 200 and revokes access and refresh tokens', async function () {
+      // given
+      const userId = 1992;
+      const options = {
+        method: 'POST',
+        url: '/api/oidc/logout',
+        payload: {
+          identity_provider: 'OIDC_EXAMPLE_NET',
+          logout_url_uuid: '86e1338f-304c-41a8-9472-89fe1b9748a1',
+        },
+        headers: generateAuthenticatedUserRequestHeaders({ userId }),
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result.redirectLogoutUrl).to.equal(
+        'https://oidc.example.net/ea5ac20c-5076-4806-860a-b0aeb01645d4/oauth2/v2.0/logout?client_id=client',
+      );
+
+      const revokedUserAccess = await revokedUserAccessRepository.findByUserId(userId);
+      expect(revokedUserAccess.revokeTimeStamp).to.be.a('number');
+      const refreshTokens = await refreshTokenRepository.findAllByUserId(userId);
+      expect(refreshTokens).to.have.lengthOf(0);
+    });
+  });
+
   context('when the OIDC provider has a connectionMethodCode', function () {
     describe('POST /api/oidc/token', function () {
       let payload, cookies;
@@ -850,12 +890,14 @@ describe('Acceptance | Identity Access Management | Application | Route | oidc-p
     applicationTld,
     identityProvider,
     connectionMethodCode,
+    postLogoutRedirectUri,
   }) {
     openidClientMock = await createMockedTestOidcProvider({
       application,
       applicationTld,
       identityProvider,
       connectionMethodCode,
+      postLogoutRedirectUri,
     });
     server = await createServer();
   }

--- a/api/tests/identity-access-management/integration/application/oidc-provider.route.test.js
+++ b/api/tests/identity-access-management/integration/application/oidc-provider.route.test.js
@@ -13,7 +13,14 @@ import {
 } from '../../../../src/identity-access-management/domain/usecases/index.js';
 import { UserNotFoundError } from '../../../../src/shared/domain/errors.js';
 import * as serverSideCookieSession from '../../../../src/shared/infrastructure/plugins/yar.js';
-import { databaseBuilder, expect, HttpTestServer, sinon } from '../../../test-helper.js';
+import {
+  databaseBuilder,
+  expect,
+  generateAuthenticatedUserRequestHeaders,
+  HttpTestServer,
+  sinon,
+} from '../../../test-helper.js';
+import { createMockedTestOidcProvider } from '../../../tooling/openid-client/openid-client-mocks.js';
 
 const routesUnderTest = identityAccessManagementRoutes[0];
 
@@ -23,6 +30,7 @@ describe('Integration | Identity Access Management | Application | Route | oidc-
   beforeEach(async function () {
     httpTestServer = new HttpTestServer();
     httpTestServer.setupDeserialization();
+    httpTestServer.setupAuthentication();
     await httpTestServer.register(serverSideCookieSession);
     await httpTestServer.register(routesUnderTest);
   });
@@ -240,6 +248,36 @@ describe('Integration | Identity Access Management | Application | Route | oidc-
         expect(response.result.errors[0].detail).to.equal(
           "La valeur de l'externalIdentifier de la méthode de connexion ne correspond pas à celui reçu par le partenaire.",
         );
+      });
+    });
+  });
+
+  describe('POST /api/oidc/logout', function () {
+    context('when the url UUID is invalid', function () {
+      it(`returns an error and does not revoke tokens`, async function () {
+        // given
+        const headers = generateAuthenticatedUserRequestHeaders({ userId: 1234, audience: 'https://orga.pix.org' });
+        //const auth = { credentials: { userId: 1234 }, strategy: {} };
+        const payload = {
+          identity_provider: 'OIDC_LOGOUT_EXAMPLE_NET',
+          logout_url_uuid: 'invalid',
+        };
+
+        const identityProvider = 'OIDC_LOGOUT_EXAMPLE_NET';
+        const openIdClientMock = await createMockedTestOidcProvider({
+          application: 'orga',
+          applicationTld: '.org',
+          identityProvider,
+        });
+
+        openIdClientMock.buildEndSessionUrl.throws(new Error('Client Error: Wrong token hint'));
+
+        // when
+        const response = await httpTestServer.request('POST', '/api/oidc/logout', payload, null, headers);
+
+        // then
+        expect(response.statusCode).to.equal(422);
+        expect(response.result.errors[0].code).to.equal('OIDC_GENERIC_ERROR');
       });
     });
   });

--- a/api/tests/tooling/openid-client/openid-client-mocks.js
+++ b/api/tests/tooling/openid-client/openid-client-mocks.js
@@ -55,6 +55,7 @@ async function createMockedTestOidcProvider({
   applicationTld,
   connectionMethodCode,
   identityProvider = 'OIDC_EXAMPLE_NET',
+  postLogoutRedirectUri,
 }) {
   const openidClientMock = createOpenIdClientMock(openIdConfigurationResponse);
 
@@ -85,6 +86,7 @@ async function createMockedTestOidcProvider({
         redirectUri,
         slug: 'oidc-example-net',
         source: 'oidcexamplenet',
+        postLogoutRedirectUri,
       },
       { openidClient: openidClientMock },
     ),

--- a/mon-pix/app/authenticators/oidc.js
+++ b/mon-pix/app/authenticators/oidc.js
@@ -8,6 +8,7 @@ export default class OidcAuthenticator extends BaseAuthenticator {
   @service oidcIdentityProviders;
   @service session;
   @service locale;
+  @service requestManager;
 
   async authenticate({ code, state, iss, identityProviderSlug, authenticationKey, hostSlug }) {
     const request = {
@@ -74,20 +75,19 @@ export default class OidcAuthenticator extends BaseAuthenticator {
    * @param {Object} data - The current authenticated session data
    */
   async invalidate(data) {
-    const { access_token, shouldCloseSession, identityProviderCode, logoutUrlUuid } = data || {};
-    if (!shouldCloseSession) {
-      return;
-    }
+    const { identityProviderCode, logoutUrlUuid } = data || {};
 
-    const response = await fetch(
-      `${ENV.APP.API_HOST}/api/oidc/redirect-logout-url?identity_provider=${identityProviderCode}&logout_url_uuid=${logoutUrlUuid}`,
-      {
-        headers: {
-          Authorization: `Bearer ${access_token}`,
-        },
-      },
-    );
-    const { redirectLogoutUrl } = await response.json();
+    const response = await this.requestManager.request({
+      url: `${ENV.APP.API_HOST}/api/oidc/logout`,
+      method: 'POST',
+      body: JSON.stringify({
+        identity_provider: identityProviderCode,
+        logout_url_uuid: logoutUrlUuid,
+      }),
+    });
+
+    const { redirectLogoutUrl } = await response.content;
+    if (!redirectLogoutUrl) return;
 
     this.session.alternativeRootURL = redirectLogoutUrl;
   }

--- a/mon-pix/mirage/routes/authentication/oidc/index.js
+++ b/mon-pix/mirage/routes/authentication/oidc/index.js
@@ -82,13 +82,6 @@ export default function (config) {
     };
   });
 
-  config.get('/oidc/redirect-logout-url', () => {
-    return {
-      redirectLogoutUrl:
-        'http://identity_provider_base_url/deconnexion?id_token_hint=ID_TOKEN&redirect_uri=http%3A%2F%2Flocalhost.fr%3A4200%2Fconnexion',
-    };
-  });
-
   config.post(
     '/oidc/user/check-reconciliation',
     {
@@ -103,4 +96,9 @@ export default function (config) {
     },
     200,
   );
+
+  config.post('/oidc/logout', () => {
+    const redirectLogoutUrl = undefined; // because shouldCloseSession == false
+    return { redirectLogoutUrl };
+  });
 }

--- a/mon-pix/tests/unit/authenticators/oidc-test.js
+++ b/mon-pix/tests/unit/authenticators/oidc-test.js
@@ -162,8 +162,35 @@ module('Unit | Authenticator | oidc', function (hooks) {
   });
 
   module('#invalidate', function () {
-    module('when user has logout url in their session', function () {
-      test('should set alternativeRootURL with the redirect logout url', async function (assert) {
+    module('when user has no logout_url_uuid in their session (because shouldCloseSession is false)', function () {
+      test('does not set alternativeRootURL', async function (assert) {
+        // given
+        const sessionStub = Service.create({
+          isAuthenticated: true,
+        });
+        const authenticator = this.owner.lookup('authenticator:oidc');
+        authenticator.session = sessionStub;
+
+        const redirectLogoutUrl = undefined;
+        const requestManager = this.owner.lookup('service:request-manager');
+        sinon.stub(requestManager, 'request').resolves({
+          content: {
+            redirectLogoutUrl,
+          },
+        });
+
+        // when
+        await authenticator.invalidate({
+          identityProviderCode: 'OIDC_PARTNER',
+        });
+
+        // then
+        assert.strictEqual(authenticator.session.alternativeRootURL, undefined);
+      });
+    });
+
+    module('when user has a logout_url_uuid in their session (because shouldCloseSession is true)', function () {
+      test('sets alternativeRootURL with the redirectLogoutUrl', async function (assert) {
         // given
         const sessionStub = Service.create({
           isAuthenticated: true,
@@ -175,22 +202,24 @@ module('Unit | Authenticator | oidc', function (hooks) {
         });
         const authenticator = this.owner.lookup('authenticator:oidc');
         authenticator.session = sessionStub;
+
         const redirectLogoutUrl =
-          'http://identity_provider_base_url/deconnexion?id_token_hint=ID_TOKEN&redirect_uri=http%3A%2F%2Flocalhost.fr%3A4200%2Fconnexion';
-        sinon.stub(window, 'fetch').resolves({
-          json: sinon.stub().resolves({ redirectLogoutUrl }),
+          'https://oidc.example.net/ea5ac20c-5076-4806-860a-b0aeb01645d4/oauth2/v2.0/logout?client_id=client';
+        const requestManager = this.owner.lookup('service:request-manager');
+        sinon.stub(requestManager, 'request').resolves({
+          content: {
+            redirectLogoutUrl,
+          },
         });
 
         // when
         await authenticator.invalidate({
-          shouldCloseSession: true,
           identityProviderCode: 'OIDC_PARTNER',
           logoutUrlUuid: 'uuid',
         });
 
         // then
         assert.strictEqual(authenticator.session.alternativeRootURL, redirectLogoutUrl);
-        sinon.restore();
       });
     });
   });

--- a/orga/app/authenticators/oidc.js
+++ b/orga/app/authenticators/oidc.js
@@ -8,6 +8,7 @@ export default class OidcAuthenticator extends BaseAuthenticator {
   @service oidcIdentityProviders;
   @service session;
   @service locale;
+  @service requestManager;
 
   async authenticate({ code, state, iss, identityProviderSlug, authenticationKey, hostSlug }) {
     const request = {
@@ -74,20 +75,22 @@ export default class OidcAuthenticator extends BaseAuthenticator {
    * @param {Object} data - The current authenticated session data
    */
   async invalidate(data) {
-    const { access_token, shouldCloseSession, identityProviderCode, logoutUrlUuid } = data || {};
-    if (!shouldCloseSession || this.session.routeAfterInvalidation) {
+    const { identityProviderCode, logoutUrlUuid } = data || {};
+    if (this.session.routeAfterInvalidation) {
       return;
     }
 
-    const response = await fetch(
-      `${ENV.APP.API_HOST}/api/oidc/redirect-logout-url?identity_provider=${identityProviderCode}&logout_url_uuid=${logoutUrlUuid}`,
-      {
-        headers: {
-          Authorization: `Bearer ${access_token}`,
-        },
-      },
-    );
-    const { redirectLogoutUrl } = await response.json();
+    const response = await this.requestManager.request({
+      url: `${ENV.APP.API_HOST}/api/oidc/logout`,
+      method: 'POST',
+      body: JSON.stringify({
+        identity_provider: identityProviderCode,
+        logout_url_uuid: logoutUrlUuid,
+      }),
+    });
+
+    const { redirectLogoutUrl } = await response.content;
+    if (!redirectLogoutUrl) return;
 
     this.session.routeAfterInvalidation = redirectLogoutUrl;
   }

--- a/orga/app/services/request-manager-handlers/app-info-handler.js
+++ b/orga/app/services/request-manager-handlers/app-info-handler.js
@@ -1,0 +1,15 @@
+import ENV from 'pix-orga/config/environment';
+
+/**
+ * Request manager handler adding application info in request headers.
+ * See: https://github.com/emberjs/data/blob/main/guides/requests/examples/1-auth.md
+ */
+export default class AppInfoHandler {
+  request(context, next) {
+    const headers = new Headers(context.request.headers);
+
+    headers.append('X-App-Version', ENV.APP.APP_VERSION);
+
+    return next(Object.assign({}, context.request, { headers }));
+  }
+}

--- a/orga/app/services/request-manager-handlers/auth-handler.js
+++ b/orga/app/services/request-manager-handlers/auth-handler.js
@@ -1,0 +1,20 @@
+import { service } from '@ember/service';
+
+/**
+ * Request manager handler adding authentication credentials in the request.
+ * See: https://github.com/emberjs/data/blob/main/guides/requests/examples/1-auth.md
+ */
+export default class AuthHandler {
+  @service session;
+
+  request(context, next) {
+    const headers = new Headers(context.request.headers);
+
+    const { isAuthenticated, data } = this.session;
+    if (isAuthenticated) {
+      headers.append('Authorization', `Bearer ${data.authenticated.access_token}`);
+    }
+
+    return next(Object.assign({}, context.request, { headers }));
+  }
+}

--- a/orga/app/services/request-manager-handlers/json-handler.js
+++ b/orga/app/services/request-manager-handlers/json-handler.js
@@ -1,0 +1,17 @@
+/**
+ * Request manager handler to manage JSON request.
+ * See: https://github.com/emberjs/data/blob/main/guides/requests/examples/1-auth.md
+ */
+export default class JsonHandler {
+  request(context, next) {
+    const headers = new Headers(context.request.headers);
+
+    headers.append('Accept', 'application/json');
+
+    if (!(context.request.body instanceof FormData)) {
+      headers.set('Content-Type', 'application/json');
+    }
+
+    return next(Object.assign({}, context.request, { headers }));
+  }
+}

--- a/orga/app/services/request-manager-handlers/locale-handler.js
+++ b/orga/app/services/request-manager-handlers/locale-handler.js
@@ -1,0 +1,16 @@
+import { service } from '@ember/service';
+
+/**
+ * Request manager handler adding user locale in request header.
+ * See: https://github.com/emberjs/data/blob/main/guides/requests/examples/1-auth.md
+ */
+export default class LocaleHandler {
+  @service locale;
+
+  request(context, next) {
+    const headers = new Headers(context.request.headers);
+    headers.append('Accept-Language', this.locale.acceptLanguageHeader);
+
+    return next(Object.assign({}, context.request, { headers }));
+  }
+}

--- a/orga/app/services/request-manager.js
+++ b/orga/app/services/request-manager.js
@@ -1,0 +1,32 @@
+import { getOwner, setOwner } from '@ember/application';
+import RequestManager from '@ember-data/request';
+import Fetch from '@ember-data/request/fetch';
+
+import AppInfoHandler from './request-manager-handlers/app-info-handler.js';
+import AuthHandler from './request-manager-handlers/auth-handler.js';
+import JsonHandler from './request-manager-handlers/json-handler.js';
+import LocaleHandler from './request-manager-handlers/locale-handler.js';
+
+/**
+ * Request manager preconfigured for authenticated or not HTTP requests.
+ * see: https://api.emberjs.com/ember-data/release/modules/@ember-data%2Frequest
+ */
+export default class RequestManagerService extends RequestManager {
+  constructor(createArgs) {
+    super(createArgs);
+
+    const authHandler = new AuthHandler();
+    setOwner(authHandler, getOwner(this));
+
+    const localHandler = new LocaleHandler();
+    setOwner(localHandler, getOwner(this));
+
+    const appInfoHandler = new AppInfoHandler();
+    setOwner(appInfoHandler, getOwner(this));
+
+    const jsonHandler = new JsonHandler();
+    setOwner(jsonHandler, getOwner(this));
+
+    this.use([authHandler, localHandler, appInfoHandler, jsonHandler, Fetch]);
+  }
+}

--- a/orga/mirage/config.js
+++ b/orga/mirage/config.js
@@ -789,13 +789,6 @@ function routes() {
     };
   });
 
-  this.get('/oidc/redirect-logout-url', () => {
-    return {
-      redirectLogoutUrl:
-        'http://identity_provider_base_url/deconnexion?id_token_hint=ID_TOKEN&redirect_uri=http%3A%2F%2Flocalhost.fr%3A4200%2Fconnexion',
-    };
-  });
-
   this.post(
     '/oidc/user/check-reconciliation',
     {
@@ -824,5 +817,10 @@ function routes() {
         '.bbb',
       logout_url_uuid: null,
     };
+  });
+
+  this.post('/oidc/logout', () => {
+    const redirectLogoutUrl = undefined; // because shouldCloseSession == false
+    return { redirectLogoutUrl };
   });
 }

--- a/orga/tests/unit/authenticators/oidc-test.js
+++ b/orga/tests/unit/authenticators/oidc-test.js
@@ -164,9 +164,69 @@ module('Unit | Authenticator | oidc', function (hooks) {
   });
 
   module('#invalidate', function () {
-    module('when user has logout url in their session', function () {
-      module('when user has no routeAfterInvalidation in their session', function () {
-        test('sets routeAfterInvalidation with the redirect logout url', async function (assert) {
+    module('when user has already a routeAfterInvalidation in their session', function () {
+      test('does not change the routeAfterInvalidation', async function (assert) {
+        // given
+        const sessionStub = Service.create({
+          isAuthenticated: true,
+          data: {
+            authenticated: {
+              logout_url_uuid: 'uuid',
+            },
+          },
+          routeAfterInvalidation: '/connexion?error=USER_HAS_NO_ORGANIZATION_MEMBERSHIP',
+        });
+        const authenticator = this.owner.lookup('authenticator:oidc');
+        authenticator.session = sessionStub;
+        sinon.stub(window, 'fetch');
+
+        // when
+        await authenticator.invalidate({
+          shouldCloseSession: true,
+          identityProviderCode: 'OIDC_PARTNER',
+          logoutUrlUuid: 'uuid',
+        });
+
+        // then
+        assert.strictEqual(
+          authenticator.session.routeAfterInvalidation,
+          '/connexion?error=USER_HAS_NO_ORGANIZATION_MEMBERSHIP',
+        );
+        sinon.assert.notCalled(window.fetch);
+        sinon.restore();
+      });
+    });
+
+    module('when user has no routeAfterInvalidation in their session', function () {
+      module('when user has no logout_url_uuid in their session (because shouldCloseSession is false)', function () {
+        test('does not set routeAfterInvalidation', async function (assert) {
+          // given
+          const sessionStub = Service.create({
+            isAuthenticated: true,
+          });
+          const authenticator = this.owner.lookup('authenticator:oidc');
+          authenticator.session = sessionStub;
+
+          const redirectLogoutUrl = undefined;
+          const requestManager = this.owner.lookup('service:request-manager');
+          sinon.stub(requestManager, 'request').resolves({
+            content: {
+              redirectLogoutUrl,
+            },
+          });
+
+          // when
+          await authenticator.invalidate({
+            identityProviderCode: 'OIDC_PARTNER',
+          });
+
+          // then
+          assert.strictEqual(authenticator.session.routeAfterInvalidation, undefined);
+        });
+      });
+
+      module('when user has a logout_url_uuid in their session (because shouldCloseSession is true)', function () {
+        test('sets routeAfterInvalidation with the redirectLogoutUrl', async function (assert) {
           // given
           const sessionStub = Service.create({
             isAuthenticated: true,
@@ -178,55 +238,24 @@ module('Unit | Authenticator | oidc', function (hooks) {
           });
           const authenticator = this.owner.lookup('authenticator:oidc');
           authenticator.session = sessionStub;
+
           const redirectLogoutUrl =
-            'http://identity_provider_base_url/deconnexion?id_token_hint=ID_TOKEN&redirect_uri=http%3A%2F%2Flocalhost.fr%3A4200%2Fconnexion';
-          sinon.stub(window, 'fetch').resolves({
-            json: sinon.stub().resolves({ redirectLogoutUrl }),
+            'https://oidc.example.net/ea5ac20c-5076-4806-860a-b0aeb01645d4/oauth2/v2.0/logout?client_id=client';
+          const requestManager = this.owner.lookup('service:request-manager');
+          sinon.stub(requestManager, 'request').resolves({
+            content: {
+              redirectLogoutUrl,
+            },
           });
 
           // when
           await authenticator.invalidate({
-            shouldCloseSession: true,
             identityProviderCode: 'OIDC_PARTNER',
             logoutUrlUuid: 'uuid',
           });
 
           // then
           assert.strictEqual(authenticator.session.routeAfterInvalidation, redirectLogoutUrl);
-          sinon.restore();
-        });
-      });
-
-      module('when user has already a routeAfterInvalidation in their session', function () {
-        test('does not change the routeAfterInvalidation', async function (assert) {
-          // given
-          const sessionStub = Service.create({
-            isAuthenticated: true,
-            data: {
-              authenticated: {
-                logout_url_uuid: 'uuid',
-              },
-            },
-            routeAfterInvalidation: '/connexion?error=USER_HAS_NO_ORGANIZATION_MEMBERSHIP',
-          });
-          const authenticator = this.owner.lookup('authenticator:oidc');
-          authenticator.session = sessionStub;
-          sinon.stub(window, 'fetch');
-
-          // when
-          await authenticator.invalidate({
-            shouldCloseSession: true,
-            identityProviderCode: 'OIDC_PARTNER',
-            logoutUrlUuid: 'uuid',
-          });
-
-          // then
-          assert.strictEqual(
-            authenticator.session.routeAfterInvalidation,
-            '/connexion?error=USER_HAS_NO_ORGANIZATION_MEMBERSHIP',
-          );
-          sinon.assert.notCalled(window.fetch);
-          sinon.restore();
         });
       });
     });

--- a/orga/tests/unit/services/request-manager-test.js
+++ b/orga/tests/unit/services/request-manager-test.js
@@ -1,0 +1,85 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module('Unit | Service | request-manager', function (hooks) {
+  setupTest(hooks);
+  let requestManagerService;
+  let sessionService;
+  let currentDomainService;
+  let localeService;
+
+  hooks.beforeEach(function () {
+    sinon.stub(window, 'fetch');
+
+    requestManagerService = this.owner.lookup('service:requestManager');
+
+    sessionService = this.owner.lookup('service:session');
+    sinon.stub(sessionService, 'isAuthenticated').value(false);
+    sinon.stub(sessionService, 'data').value(null);
+
+    currentDomainService = this.owner.lookup('service:currentDomain');
+    sinon.stub(currentDomainService, 'isFranceDomain').value(false);
+
+    localeService = this.owner.lookup('service:locale');
+    sinon.stub(localeService, 'acceptLanguageHeader').value('fr');
+  });
+
+  hooks.afterEach(function () {
+    sinon.restore();
+  });
+
+  module('request()', function () {
+    test('it requests successfully with default headers', async function (assert) {
+      // given
+      window.fetch.resolves(responseMock({ status: 200, data: { foo: 'bar' } }));
+
+      // when
+      const result = await requestManagerService.request({ url: '/test', method: 'GET' });
+
+      // then
+      assert.strictEqual(result.response.status, 200);
+      assert.deepEqual(result.content, { foo: 'bar' });
+
+      const [url, { headers }] = window.fetch.getCall(0).args;
+      assert.strictEqual(url, '/test');
+      assert.strictEqual(headers.get('Accept-Language'), 'fr');
+      assert.strictEqual(headers.get('X-App-Version'), 'development');
+      assert.strictEqual(headers.get('Accept'), 'application/json');
+      assert.strictEqual(headers.get('Content-Type'), 'application/json');
+    });
+
+    module('when user is authenticated', function () {
+      test('it sets the Authorization header with the access token', async function (assert) {
+        // given
+        window.fetch.resolves(responseMock({ status: 200, data: { foo: 'bar' } }));
+        sinon.stub(sessionService, 'isAuthenticated').value(true);
+        sinon.stub(sessionService, 'data').value({ authenticated: { access_token: 'baz' } });
+
+        // when
+        await requestManagerService.request({ url: '/test', method: 'GET' });
+
+        // then
+        const [url, { headers }] = window.fetch.getCall(0).args;
+        assert.strictEqual(url, '/test');
+        assert.strictEqual(headers.get('Authorization'), 'Bearer baz');
+      });
+    });
+
+    module('when an error occured on HTTP call', function () {
+      test('it throws an exception with error details', async function (assert) {
+        // given
+        window.fetch.resolves(responseMock({ status: 400, data: { error: 'KO' } }));
+
+        // when
+        assert.rejects(requestManagerService.request({ url: '/test', method: 'GET' }), function (err) {
+          return err.status === 400 && err.content.error === 'KO';
+        });
+      });
+    });
+  });
+});
+
+function responseMock({ status, data }) {
+  return new window.Response(JSON.stringify(data), { status });
+}


### PR DESCRIPTION
## 🥀 Problème
Lors du logout d’un Front d’un utilisateur s’étant authentifié par SSO, l’AccessToken de Pix API n’est pas révoqué et le RefreshToken de Pix n’est pas supprimé.

## 🏹 Proposition
Créer une nouvelle route de déconnexion OIDC qui se chargera de révoquer l’AccessToken et de supprimer le RefreshToken et de retourner l'URL de redirection post-déconnexion.

:information_source: On ne supprime pas encore la route `/api/oidc/redirect-logout-url` car elle est encore utilisée par les différents Fronts en production. Cette route sera supprimée prochainement dans une autre PR.

## ❤️‍🔥 Pour tester
- Sur _Pix App_, _Pix Orga_ et _Pix Admin_, se connecter à l'aide d'un SSO OIDC dans toutes les configurations possibles suivantes (dans la limite des différents SSO disponibles pour chaque frontal bien sûr) :
   - utiliser un SSO OIDC avec `shouldCloseSession` et avec `postLogoutRedirectUri`
   - utiliser un SSO OIDC avec `shouldCloseSession` et sans `postLogoutRedirectUri`
   - utiliser un SSO OIDC avec `shouldCloseSession` et avec `additionalRequiredProperties.logoutUrl`
   - utiliser un SSO OIDC sans `shouldCloseSession`
- Se déconnecter de l'application et constater qu'on est redirigé sur la bonne page de connexion
- Depuis l'interface développeur Réseau du navigateur, rejouer une requête authentifiée (par exemple pour Pix App `/api/users/me`, et pour Pix Orga `/api/prescription/prescribers/xxxxx`) qui devra renvoyer une erreur `Unauthorized`

Et voici des cas de tests particuliers pour Pix Orga dans la PR #14869