### PR TITLE
[FEATURE] Ajout de l'organizationTypeLearnerId lors de la création d'une organisation (PIX-21329).

### DIFF
--- a/api/src/organizational-entities/domain/validators/organization-creation-validator.js
+++ b/api/src/organizational-entities/domain/validators/organization-creation-validator.js
@@ -27,6 +27,15 @@ const organizationValidationJoiSchema = Joi.object({
     'number.min': 'Le code pays doit être un nombre entier compris entre 99000 et 99999.',
     'number.max': 'Le code pays doit être un nombre entier compris entre 99000 et 99999.',
   }),
+
+  organizationLearnerType: Joi.object({
+    id: Joi.number(),
+    name: Joi.string(),
+  })
+    .required()
+    .messages({
+      'any.required': "Le public prescrit n'est pas renseigné.",
+    }),
 });
 
 const validate = function (organizationCreationParams) {

--- a/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
@@ -215,9 +215,14 @@ const save = async function ({ organization }) {
     'administrationTeamId',
     'parentOrganizationId',
     'countryCode',
-    'organizationLearnerTypeId',
   ]);
-  const [organizationCreated] = await knexConn(ORGANIZATIONS_TABLE_NAME).returning('*').insert(data);
+  // TODO: supprimer l'optional chaining quand organizationLearnerTypeId sera not-nullable à la fin de l'epix PIX-19561
+  const [organizationCreated] = await knexConn(ORGANIZATIONS_TABLE_NAME)
+    .returning('*')
+    .insert({
+      ...data,
+      organizationLearnerTypeId: organization.organizationLearnerType?.id,
+    });
   const savedOrganization = _toDomain(organizationCreated);
 
   if (!_.isEmpty(savedOrganization.features)) {

--- a/api/tests/organizational-entities/integration/domain/usecases/create-organization_test.js
+++ b/api/tests/organizational-entities/integration/domain/usecases/create-organization_test.js
@@ -1,10 +1,12 @@
 import {
   AdministrationTeamNotFound,
   CountryNotFoundError,
+  OrganizationLearnerTypeNotFound,
   UnableToAttachChildOrganizationToParentOrganizationError,
 } from '../../../../../src/organizational-entities/domain/errors.js';
 import { Organization } from '../../../../../src/organizational-entities/domain/models/Organization.js';
 import { OrganizationForAdmin } from '../../../../../src/organizational-entities/domain/models/OrganizationForAdmin.js';
+import { OrganizationLearnerType } from '../../../../../src/organizational-entities/domain/models/OrganizationLearnerType.js';
 import { usecases } from '../../../../../src/organizational-entities/domain/usecases/index.js';
 import { EntityValidationError, NotFoundError } from '../../../../../src/shared/domain/errors.js';
 import {
@@ -42,6 +44,9 @@ describe('Integration | UseCases | create-organization', function () {
       countryCode: 99100,
       externalId: 'My external Id',
       provinceCode: '078',
+      organizationLearnerType: new OrganizationLearnerType({
+        id: undefined,
+      }),
     });
 
     // when
@@ -135,6 +140,9 @@ describe('Integration | UseCases | create-organization', function () {
           createdBy: superAdminUserId,
           administrationTeamId: 9999,
           countryCode: 99100,
+          organizationLearnerType: new OrganizationLearnerType({
+            id: undefined,
+          }),
         });
 
         // when
@@ -144,6 +152,38 @@ describe('Integration | UseCases | create-organization', function () {
         expect(error).to.deep.equal(
           new AdministrationTeamNotFound({
             meta: { administrationTeamId: organization.administrationTeamId },
+          }),
+        );
+      });
+    });
+
+    describe('when organization learner type does not exist', function () {
+      it('throws OrganizationLearnerTypeNotFound error', async function () {
+        // given
+        const organization = new OrganizationForAdmin({
+          name: 'ACME',
+          type: 'PRO',
+          documentationUrl: 'https://pix.fr',
+          createdBy: superAdminUserId,
+          administrationTeamId: 1234,
+          countryCode: 99100,
+          organizationLearnerType: new OrganizationLearnerType({
+            id: 5678,
+          }),
+        });
+
+        // when
+        const error = await catchErr(usecases.createOrganization)({
+          organization,
+        });
+
+        // then
+        expect(error).to.deep.equal(
+          new OrganizationLearnerTypeNotFound({
+            meta: {
+              organizationLearnerTypeId: organization.organizationLearnerType.id,
+            },
+            message: `Organization learner type not found for id ${organization.organizationLearnerType.id}`,
           }),
         );
       });
@@ -159,6 +199,9 @@ describe('Integration | UseCases | create-organization', function () {
           createdBy: superAdminUserId,
           administrationTeamId: 1234,
           countryCode: 99999,
+          organizationLearnerType: new OrganizationLearnerType({
+            id: undefined,
+          }),
         });
 
         // when
@@ -202,6 +245,9 @@ describe('Integration | UseCases | create-organization', function () {
         createdBy: superAdminUserId,
         administrationTeamId: 1234,
         countryCode: 99100,
+        organizationLearnerType: new OrganizationLearnerType({
+          id: undefined,
+        }),
       });
 
       // when

--- a/api/tests/organizational-entities/integration/domain/usecases/create-organization_test.js
+++ b/api/tests/organizational-entities/integration/domain/usecases/create-organization_test.js
@@ -85,45 +85,43 @@ describe('Integration | UseCases | create-organization', function () {
       });
 
       describe('when parent organization is a child organization', function () {
-        ('throws UnableToAttachChildOrganizationToParentOrganizationError',
-          async function () {
-            // given
-            const parentOrganizationId = databaseBuilder.factory.buildOrganization().id;
-            const childOrganizationId = databaseBuilder.factory.buildOrganization({
-              id: 2000,
-              name: 'Parent Org',
-              type: Organization.types.SCO1D,
-              parentOrganizationId,
-            }).id;
+        it('throws UnableToAttachChildOrganizationToParentOrganizationError', async function () {
+          // given
+          const parentOrganizationId = databaseBuilder.factory.buildOrganization().id;
+          const childOrganizationId = databaseBuilder.factory.buildOrganization({
+            id: 2000,
+            name: 'Parent Org',
+            type: Organization.types.SCO1D,
+            parentOrganizationId,
+          }).id;
 
-            await databaseBuilder.commit();
+          await databaseBuilder.commit();
 
-            const organization = new OrganizationForAdmin({
-              name: 'ACME',
-              type: 'PRO',
-              documentationUrl: 'https://pix.fr',
-              createdBy: superAdminUserId,
-              administrationTeamId: 1234,
-              parentOrganizationId: childOrganizationId,
-              countryCode: 99100,
-            });
-
-            // when
-            const error = await catchErr(usecases.createOrganization)({ organization });
-
-            // then
-            expect(error).to.deep.equal(
-              new UnableToAttachChildOrganizationToParentOrganizationError({
-                code: 'UNABLE_TO_ATTACH_CHILD_ORGANIZATION_TO_ANOTHER_CHILD_ORGANIZATION',
-                message:
-                  'Unable to attach child organization to parent organization which is also a child organization',
-                meta: {
-                  grandParentOrganizationId: parentOrganizationId,
-                  parentOrganizationId: childOrganizationId,
-                },
-              }),
-            );
+          const organization = new OrganizationForAdmin({
+            name: 'ACME',
+            type: 'PRO',
+            documentationUrl: 'https://pix.fr',
+            createdBy: superAdminUserId,
+            administrationTeamId: 1234,
+            parentOrganizationId: childOrganizationId,
+            countryCode: 99100,
           });
+
+          // when
+          const error = await catchErr(usecases.createOrganization)({ organization });
+
+          // then
+          expect(error).to.deep.equal(
+            new UnableToAttachChildOrganizationToParentOrganizationError({
+              code: 'UNABLE_TO_ATTACH_CHILD_ORGANIZATION_TO_ANOTHER_CHILD_ORGANIZATION',
+              message: 'Unable to attach child organization to parent organization which is also a child organization',
+              meta: {
+                grandParentOrganizationId: parentOrganizationId,
+                parentOrganizationId: childOrganizationId,
+              },
+            }),
+          );
+        });
       });
     });
 

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/organization-for-admin.repository.test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/organization-for-admin.repository.test.js
@@ -1209,6 +1209,10 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
         createdBy: superAdminUserId,
         administrationTeamId: administrationTeam.id,
         countryCode: 99100,
+        organizationLearnerType: new OrganizationLearnerType({
+          id: organizationLearnerType.id,
+          name: organizationLearnerType.name,
+        }),
       });
 
       // when
@@ -1220,6 +1224,8 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
       expect(savedOrganization.type).to.equal('SCO');
       expect(savedOrganization.createdBy).to.equal(superAdminUserId);
       expect(savedOrganization.countryCode).to.equal(99100);
+      expect(savedOrganization.organizationLearnerType).to.be.instanceOf(OrganizationLearnerType);
+      expect(savedOrganization.organizationLearnerType.id).to.equal(organizationLearnerType.id);
     });
 
     context('when the organization type is SCO-1D', function () {

--- a/api/tests/organizational-entities/unit/domain/validators/organization-creation-validator_test.js
+++ b/api/tests/organizational-entities/unit/domain/validators/organization-creation-validator_test.js
@@ -21,6 +21,7 @@ describe('Unit | Domain | Validators | organization-validator', function () {
           documentationUrl: 'https://kingArthur.com',
           administrationTeamId: 1234,
           countryCode: 99123,
+          organizationLearnerType: {},
         };
 
         // when/then
@@ -41,6 +42,7 @@ describe('Unit | Domain | Validators | organization-validator', function () {
             type: 'PRO',
             administrationTeamId: 1234,
             countryCode: 99123,
+            organizationLearnerType: {},
           };
 
           try {
@@ -73,6 +75,7 @@ describe('Unit | Domain | Validators | organization-validator', function () {
             type: MISSING_VALUE,
             administrationTeamId: 1234,
             countryCode: 99123,
+            organizationLearnerType: {},
           };
 
           try {
@@ -97,6 +100,7 @@ describe('Unit | Domain | Validators | organization-validator', function () {
             type: 'PTT',
             administrationTeamId: 1234,
             countryCode: 99123,
+            organizationLearnerType: {},
           };
 
           try {
@@ -112,7 +116,13 @@ describe('Unit | Domain | Validators | organization-validator', function () {
         ['SUP', 'SCO', 'PRO', 'SCO-1D'].forEach((type) => {
           it(`should not throw with ${type} as type`, function () {
             // given
-            const organizationCreationParams = { name: 'ACME', type, administrationTeamId: 1234, countryCode: 99123 };
+            const organizationCreationParams = {
+              name: 'ACME',
+              type,
+              administrationTeamId: 1234,
+              countryCode: 99123,
+              organizationLearnerType: {},
+            };
 
             // when/then
             return expect(() => organizationCreationValidator.validate(organizationCreationParams)).to.not.throw();
@@ -129,6 +139,7 @@ describe('Unit | Domain | Validators | organization-validator', function () {
             documentationUrl: 'invalidUrl',
             administrationTeamId: 1234,
             countryCode: 99123,
+            organizationLearnerType: {},
           };
           const error = await catchErr(organizationCreationValidator.validate)(organizationCreationParams);
 
@@ -150,6 +161,7 @@ describe('Unit | Domain | Validators | organization-validator', function () {
             type: 'PRO',
             countryCode: 99123,
             administrationTeamId: undefined,
+            organizationLearnerType: {},
           };
 
           try {
@@ -175,6 +187,7 @@ describe('Unit | Domain | Validators | organization-validator', function () {
             type: 'PRO',
             administrationTeamId: 1234,
             countryCode: undefined,
+            organizationLearnerType: {},
           };
 
           try {
@@ -198,6 +211,7 @@ describe('Unit | Domain | Validators | organization-validator', function () {
             type: 'PRO',
             administrationTeamId: 1234,
             countryCode: 98999,
+            organizationLearnerType: {},
           };
 
           try {
@@ -221,6 +235,32 @@ describe('Unit | Domain | Validators | organization-validator', function () {
             type: 'PRO',
             administrationTeamId: 1234,
             countryCode: 100000,
+            organizationLearnerType: {},
+          };
+
+          try {
+            // when
+            organizationCreationValidator.validate(organizationCreationParams);
+            expect.fail('should have thrown an error');
+          } catch (errors) {
+            // then
+            _assertErrorMatchesWithExpectedOne(errors, expectedError);
+          }
+        });
+      });
+
+      context('on organizationLearnerType attribute', function () {
+        it('should reject with error when organizationLearnerType is missing', function () {
+          // given
+          const expectedError = {
+            attribute: 'organizationLearnerType',
+            message: "Le public prescrit n'est pas renseigné.",
+          };
+          const organizationCreationParams = {
+            name: 'ACME',
+            type: 'PRO',
+            administrationTeamId: 1234,
+            countryCode: 99998,
           };
 
           try {
@@ -241,6 +281,7 @@ describe('Unit | Domain | Validators | organization-validator', function () {
           type: MISSING_VALUE,
           administrationTeamId: MISSING_VALUE,
           countryCode: MISSING_VALUE,
+          organizationLearnerType: {},
         };
 
         try {


### PR DESCRIPTION
## 🥀 Problème

L'organizationLearnerTypeId n'est pas inclus lors de la création unitaire d'une organisation.

## 🏹 Proposition

On rajoute le paramètre lors de la création unitaire d'une organisation.

## 💌 Remarques

Seul le repository est impacté.
Toute la déserialisation de la requête créant l'objet OrganizationLearnerType a été effectuée dans la PR 
Le paramètre n'est pas encore obligatoire (d'où la présence d'optional chaining), il le deviendra une fois toutes les que toutes les possibilités pour la création d'une organisation auront été retravaillées.

## ❤️‍🔥 Pour tester

- Se connecter à Pix-Admin et récupérer un token
- Effectuer la requête curl suivante :

```
curl https://admin-pr15131.review.pix.fr/api/admin/organizations \
    -H "Authorization: Bearer <TOKEN>" \
    -H "Content-Type: application/json" \
    -H "Accept-language: fr-fr" \
    -d '{"data": {"attributes": { "name": "Test", "type": "SCO", "administration-team-id": 8000, "country-code": 99100, "organization-learner-type-id":  8101 }, "type": "organizations"}}' \
    -X POST
```

- vérifier que l'organisation a bien été créée avec le bon organizationLearnerTypeId
- vérifier qu'il n'y ait pas de régression via la création unitaire par l'IHM