### PR TITLE
[FEATURE] Claims additionnels optionels pour l'auth OIDC

### DIFF
--- a/api/src/identity-access-management/domain/models/AuthenticationMethod.js
+++ b/api/src/identity-access-management/domain/models/AuthenticationMethod.js
@@ -22,7 +22,7 @@ class PixAuthenticationComplement {
 
 class OidcAuthenticationComplement {
   constructor(properties) {
-    validateEntity(Joi.object().required().min(1), properties);
+    validateEntity(Joi.object().required(), properties);
 
     Object.entries(properties).forEach(([key, value]) => {
       this[key] = value;

--- a/api/tests/unit/domain/models/AuthenticationMethod_test.js
+++ b/api/tests/unit/domain/models/AuthenticationMethod_test.js
@@ -218,10 +218,9 @@ describe('Unit | Domain | Models | AuthenticationMethod', function () {
     });
 
     context('OidcAuthenticationComplement', function () {
-      it('cannot be created without properties', function () {
+      it('cannot be created without object', function () {
         // when
         expect(() => new AuthenticationMethod.OidcAuthenticationComplement()).to.throw(ObjectValidationError);
-        expect(() => new AuthenticationMethod.OidcAuthenticationComplement({})).to.throw(ObjectValidationError);
       });
 
       it('can hold any properties', function () {


### PR DESCRIPTION
## 🥀 Problème

Dans le cadre de certains fournisseurs d'identité OIDC, les claims additionnels ne sont pas nécessairement renseignés. Mais dans le code, on empêche la connexion / création de compte, si au moins 1 des claims additionnels n'est pas renseigné.

## 🏹 Proposition

Cette vérification est étrange car on ne vérifie pas qu'ils sont tous obligatoires, mais que seulement 1 est obligatoire. ([condition ici dans le code](https://github.com/1024pix/pix/blob/ad4b94ce0f0224a959d15bc9c11c06c33c857bd0/api/src/identity-access-management/domain/models/AuthenticationMethod.js#L25))

Supprimer cette vérification: le `min(1)`, ce qui veut dire que les additionnels claims n'empêcheront pas la connexion s'ils sont absents.

Cela a plus de sens car on ne devrait pas empêcher un utilisateur de se connecter si des claims additionnels ne sont pas fournis car ils ne sont pas nécessaires pour le bon fonctionnement de l'app. Les seuls claims obligatoires sont le sub, nom et prénom pour le bon fonctionnement.

**⚠️ À valider avec l'équipe avant de merger**

## 💌 Remarques

N/A

## ❤️‍🔥 Pour tester

S'inscrire sur PixApp avec un oidc provider qui a des `claimsToStore` de défini.