### PR TITLE
[TECH] Refactor la durée d'un certif course dans PixAdmin

### DIFF
--- a/admin/app/models/v3-certification-course-details-for-administration.js
+++ b/admin/app/models/v3-certification-course-details-for-administration.js
@@ -39,10 +39,6 @@ export default class V3CertificationCourseDetailsForAdministration extends Model
     return this.assessmentState === assessmentStates.ENDED_BY_INVIGILATOR;
   }
 
-  get wasCompleted() {
-    return this.assessmentState === assessmentStates.COMPLETED;
-  }
-
   get numberOfOkAnswers() {
     const certificationChallengesForAdministration = this.hasMany('certificationChallengesForAdministration').value();
     if (!certificationChallengesForAdministration) return 0;
@@ -69,7 +65,7 @@ export default class V3CertificationCourseDetailsForAdministration extends Model
 
   get duration() {
     const start = new Date(this.createdAt);
-    const end = this.wasCompleted ? new Date(this.completedAt) : new Date(this.endedAt);
+    const end = new Date(this.completedAt || this.endedAt);
     return end - start;
   }
 


### PR DESCRIPTION
## 🥀 Problème

On a constaté des problèmes d'affichage de la durée sur PixAdmin.

## 🏹 Proposition

Un certif-course en état `completed` a forcément un `completedAt`, sinon, il a un `endedAt`.
Pas besoin de faire une vérification de l'état de l'assessment pour le calcul de la durée.

## ❤️‍🔥 Pour tester

✅ Tests verts
