### PR TITLE
[TECH] :truck: Déplace le modèle `ComplementaryCertification` dans le contexte de configuration

### DIFF
--- a/api/src/certification/configuration/domain/models/ComplementaryCertification.js
+++ b/api/src/certification/configuration/domain/models/ComplementaryCertification.js
@@ -1,6 +1,6 @@
 import { ComplementaryCertificationKeys } from '../../../shared/domain/models/ComplementaryCertificationKeys.js';
 
-class ComplementaryCertification {
+export class ComplementaryCertification {
   constructor({ id, label, key }) {
     this.id = id;
     this.label = label;
@@ -8,5 +8,3 @@ class ComplementaryCertification {
     this.hasComplementaryReferential = key !== ComplementaryCertificationKeys.CLEA;
   }
 }
-
-export { ComplementaryCertification };

--- a/api/src/certification/configuration/infrastructure/repositories/complementary-certification-repository.js
+++ b/api/src/certification/configuration/infrastructure/repositories/complementary-certification-repository.js
@@ -5,7 +5,7 @@
 
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../../shared/domain/errors.js';
-import { ComplementaryCertification } from '../../../complementary-certification/domain/models/ComplementaryCertification.js';
+import { ComplementaryCertification } from '../../domain/models/ComplementaryCertification.js';
 
 /**
  * @param {object} row

--- a/api/tests/tooling/domain-builder/factory/certification/complementary-certification/build-complementary-certification.js
+++ b/api/tests/tooling/domain-builder/factory/certification/complementary-certification/build-complementary-certification.js
@@ -1,4 +1,4 @@
-import { ComplementaryCertification } from '../../../../../../src/certification/complementary-certification/domain/models/ComplementaryCertification.js';
+import { ComplementaryCertification } from '../../../../../../src/certification/configuration/domain/models/ComplementaryCertification.js';
 import { ComplementaryCertificationKeys } from '../../../../../../src/certification/shared/domain/models/ComplementaryCertificationKeys.js';
 
 const buildComplementaryCertification = function ({


### PR DESCRIPTION

## 🥀 Problème

Le sous domaine `complementary-certification` est un raccourci que nous avions pris. 
Le modèle `ComplementaryCertification` n'est utilisé que dans le contexte `configuration`

## 🏹 Proposition

Déplacer le modèle `ComplementaryCertification` vers le contexte `configuration`

## 💌 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## ❤️‍🔥 Pour tester

