### PR TITLE
[FEATURE] Permettre l'affichage des réponses courtes en cas de QCU déclaratif ou découverte sur Pix App (PIX-21287).

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
@@ -435,6 +435,70 @@
           ]
         },
         {
+          "id": "12be4923-0130-45bf-9171-fcb38bb5d065",
+          "type": "challenge",
+          "title": "qcu-declarative short proposals (2 et 3)",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "dddddd7c-0bdd-447a-8958-84b50e0e2558",
+                "type": "qcu-declarative",
+                "instruction": "<p>Qui arrive en premier dans le bol : le lait ou les céréales ?</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "Le lait 🥛",
+                    "feedback": {
+                      "diagnosis": "<p>...Intéressant. Tu chauffes ton lait aussi ? 👀</p>"
+                    }
+                  },
+                  {
+                    "id": "2",
+                    "content": "Les céréales 🌾",
+                    "feedback": {
+                      "diagnosis": "<p>Meilleure stratégie ! Ça fait plus de céréales dans le bol 🥣</p>"
+                    }
+                  }
+                ],
+                "hasShortProposals": true
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "82eaf7ce-02f7-44e8-8c51-3d07ba29e400",
+                "type": "qcu-declarative",
+                "instruction": "<p>Toto et Tata sont sur un bâton 🛶, qui tombe à l'eau?</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "Toto",
+                    "feedback": {
+                      "diagnosis": "<p>Ah bon ?</p>"
+                    }
+                  },
+                  {
+                    "id": "2",
+                    "content": "Tata",
+                    "feedback": {
+                      "diagnosis": "<p>Tu est sûr ?</p>"
+                    }
+                  },
+                  {
+                    "id": "3",
+                    "content": "Toto et Tata",
+                    "feedback": {
+                      "diagnosis": "<p>Pas facile de tenir sur un bâton oui 😏</p>"
+                    }
+                  }
+                ],
+                "hasShortProposals": true
+              }
+            }
+          ]
+        },
+        {
           "id": "f1738f85-e272-43d3-aee2-f4190be54c34",
           "type": "summary",
           "title": "test table",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
@@ -340,6 +340,101 @@
           ]
         },
         {
+          "id": "1122aced-5885-4a5d-afed-99c7a9dff009",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "488e3984-6ed6-4245-8c94-da188a2fd13c",
+                "type": "text",
+                "content": "<p>Section <strong>Réponses Courtes</strong> (QCU découverte et déclaratif)</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "d8678f8a-902e-43c2-8c41-2c09e32905e1",
+          "type": "discovery",
+          "title": "qcu-discovery short proposals (4 et 3)",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "c3bc4466-2825-488e-ad5f-275ace4b19a8",
+                "type": "qcu-discovery",
+                "instruction": "<p>Quelle est la meilleure crêpe ?</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "Nutella 🍫",
+                    "feedback": {
+                      "diagnosis": "<p>Les meilleures c'est clair !</p>"
+                    }
+                  },
+                  {
+                    "id": "2",
+                    "content": "Nature 🌱",
+                    "feedback": {
+                      "diagnosis": "<p>Si la pâte est bien faite, pas besoin de plus parfois !</p>"
+                    }
+                  },
+                  {
+                    "id": "3",
+                    "content": "Beurre/sucre 🥞",
+                    "feedback": {
+                      "diagnosis": "<p>Pardon ?</p>"
+                    }
+                  },
+                  {
+                    "id": "4",
+                    "content": "Complète avec poulet",
+                    "feedback": {
+                      "diagnosis": "<p>Galette, pas crêpe ! Avec la sauce biggy 🤤</p>"
+                    }
+                  }
+                ],
+                "solution": "1",
+                "hasShortProposals": true
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "81eaa0ab-6b2d-4748-94dc-9504732eabc5",
+                "type": "qcu-discovery",
+                "instruction": "<p>Combien de chiens/chats dans l'équipe ?</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "3🐶/3😺",
+                    "feedback": {
+                      "diagnosis": "<p>Non 😔</p>"
+                    }
+                  },
+                  {
+                    "id": "2",
+                    "content": "2🐶/2😺",
+                    "feedback": {
+                      "diagnosis": "<p>Ouiiii ! 🐶😺</p>"
+                    }
+                  },
+                  {
+                    "id": "3",
+                    "content": "2🐶/3😺",
+                    "feedback": {
+                      "diagnosis": "<p>Non, un certain E.LLM n'a pas adopté de chat encore 😛</p>"
+                    }
+                  }
+                ],
+                "solution": "2",
+                "hasShortProposals": true
+              }
+            }
+          ]
+        },
+        {
           "id": "f1738f85-e272-43d3-aee2-f4190be54c34",
           "type": "summary",
           "title": "test table",

--- a/api/src/devcomp/infrastructure/factories/module-factory.js
+++ b/api/src/devcomp/infrastructure/factories/module-factory.js
@@ -331,6 +331,7 @@ export class ModuleFactory {
 
   static #buildQCUDiscovery(element) {
     return new QCUDiscovery({
+      hasShortProposals: element.hasShortProposals,
       id: element.id,
       instruction: element.instruction,
       proposals: element.proposals.map((proposal) => {

--- a/api/src/devcomp/infrastructure/factories/module-factory.js
+++ b/api/src/devcomp/infrastructure/factories/module-factory.js
@@ -317,6 +317,7 @@ export class ModuleFactory {
 
   static #buildQCUDeclarative(element) {
     return new QCUDeclarative({
+      hasShortProposals: element.hasShortProposals,
       id: element.id,
       instruction: element.instruction,
       proposals: element.proposals.map((proposal) => {

--- a/api/tests/devcomp/integration/infrastructure/factories/module-factory_test.js
+++ b/api/tests/devcomp/integration/infrastructure/factories/module-factory_test.js
@@ -1028,6 +1028,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
                     {
                       type: 'element',
                       element: {
+                        hasShortProposals: true,
                         id: '6a6944be-a8a3-4138-b5dc-af664cf40b07',
                         type: 'qcu-discovery',
                         instruction: '<p>Quel est le dessert classique idéal lors d’un goûter&nbsp;?</p>',

--- a/api/tests/devcomp/integration/infrastructure/factories/module-factory_test.js
+++ b/api/tests/devcomp/integration/infrastructure/factories/module-factory_test.js
@@ -576,6 +576,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
         // then
         expect(module.sections[0].grains[0].components[0].element).to.be.an.instanceOf(Text);
       });
+
       it('should instantiate a Module with a ComponentElement which contains a Audio Element', async function () {
         // given
         const moduleData = {
@@ -956,6 +957,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
                     {
                       type: 'element',
                       element: {
+                        hasShortProposals: false,
                         id: '6a6944be-a8a3-4138-b5dc-af664cf40b07',
                         type: 'qcu-declarative',
                         instruction: '<p>Quand faut-il mouiller sa brosse à dents ?</p>',
@@ -1982,6 +1984,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
                         {
                           elements: [
                             {
+                              hasShortProposals: true,
                               id: '6a6944be-a8a3-4138-b5dc-af664cf40b07',
                               type: 'qcu-declarative',
                               instruction: '<p>Quand faut-il mouiller sa brosse à dents ?</p>',

--- a/mon-pix/app/components/module/component/_proposal-button.scss
+++ b/mon-pix/app/components/module/component/_proposal-button.scss
@@ -45,15 +45,15 @@
 .proposal-button--variant-discovery {
   &:hover,
   &:active {
-    background: rgb(var(--pix-orga-50-inline), 0.5);
+    background: rgb(var(--pix-info-100-inline), 0.5);
   }
 
   &.proposal-button--selected {
-    background: var(--pix-orga-50);
+    background: var(--pix-info-100);
     border-color: var(--pix-neutral-500);
 
     &:hover {
-      background: var(--pix-orga-50);
+      background: var(--pix-info-100);
     }
   }
 

--- a/mon-pix/app/components/module/element/_qcu-declarative.scss
+++ b/mon-pix/app/components/module/element/_qcu-declarative.scss
@@ -1,4 +1,5 @@
 @use 'pix-design-tokens/typography';
+@use 'pix-design-tokens/breakpoints';
 
 .element-qcu-declarative {
   width: 100%;
@@ -20,11 +21,31 @@
     color: var(--pix-neutral-800);
   }
 
-  &__proposals {
-    display:flex;
-    flex-direction: column;
+  &__short-proposals, &__proposals, &__3-short-proposals {
     gap: var(--pix-spacing-3x);
     margin-top: var(--pix-spacing-4x);
+  }
+
+  &__proposals {
+    display: flex;
+    flex-direction: column;
+  }
+
+  &__short-proposals {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  &__3-short-proposals {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+  }
+
+  @include breakpoints.device-is('mobile') {
+    &__short-proposals, &__3-short-proposals {
+      display: flex;
+      flex-direction: column;
+    }
   }
 
   &__feedback {

--- a/mon-pix/app/components/module/element/_qcu-discovery.scss
+++ b/mon-pix/app/components/module/element/_qcu-discovery.scss
@@ -1,4 +1,5 @@
 @use 'pix-design-tokens/typography';
+@use 'pix-design-tokens/breakpoints';
 
 .element-qcu-discovery {
   &__instruction {
@@ -12,10 +13,30 @@
     color: var(--pix-neutral-500);
   }
 
+  &__short-proposals, &__proposals, &__3-short-proposals {
+    gap: var(--pix-spacing-3x);
+    margin: var(--pix-spacing-4x) 0;
+  }
+
   &__proposals {
     display: flex;
     flex-direction: column;
-    gap: var(--pix-spacing-3x);
-    margin: var(--pix-spacing-4x) 0;
+  }
+
+  &__short-proposals {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  &__3-short-proposals {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+  }
+
+  @include breakpoints.device-is('mobile') {
+    &__short-proposals, &__3-short-proposals {
+      display: flex;
+      flex-direction: column;
+    }
   }
 }

--- a/mon-pix/app/components/module/element/module-element.gjs
+++ b/mon-pix/app/components/module/element/module-element.gjs
@@ -41,6 +41,14 @@ export default class ModuleElement extends Component {
     throw new Error('ModuleElement.canValidateElement not implemented');
   }
 
+  get hasShortProposals() {
+    if (!this.element.hasShortProposals) {
+      return 'proposals';
+    }
+    const isNumberOfProposalsOdd = this.element.proposals.length === 3;
+    return isNumberOfProposalsOdd ? '3-short-proposals' : 'short-proposals';
+  }
+
   resetAnswers() {
     throw new Error('ModuleElement.resetAnswers not implemented');
   }

--- a/mon-pix/app/components/module/element/module-element.gjs
+++ b/mon-pix/app/components/module/element/module-element.gjs
@@ -1,8 +1,11 @@
 import { action } from '@ember/object';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
 export default class ModuleElement extends Component {
+  @service modulixPreviewMode;
+
   @tracked shouldDisplayRequiredMessage = false;
   @tracked isOnRetryMode = false;
 
@@ -42,7 +45,7 @@ export default class ModuleElement extends Component {
   }
 
   get hasShortProposals() {
-    if (!this.element.hasShortProposals) {
+    if (!this.element.hasShortProposals || this.modulixPreviewMode.isEnabled) {
       return 'proposals';
     }
     const isNumberOfProposalsOdd = this.element.proposals.length === 3;

--- a/mon-pix/app/components/module/element/qcu-declarative.gjs
+++ b/mon-pix/app/components/module/element/qcu-declarative.gjs
@@ -72,7 +72,7 @@ export default class ModuleQcuDeclarative extends ModuleElement {
         <p class="element-qcu-declarative__complementary-instruction">
           {{t "pages.modulix.qcuDeclarative.complementaryInstruction"}}
         </p>
-        <div class="element-qcu-declarative__proposals">
+        <div class="element-qcu-declarative__{{this.hasShortProposals}}">
           {{#each this.element.proposals as |proposal|}}
             <ProposalButton
               @proposal={{proposal}}

--- a/mon-pix/app/components/module/element/qcu-discovery.gjs
+++ b/mon-pix/app/components/module/element/qcu-discovery.gjs
@@ -73,7 +73,7 @@ export default class ModuleQcuDiscovery extends ModuleElement {
         <p class="element-qcu-discovery__direction">
           {{t "pages.modulix.qcuDiscovery.direction"}}
         </p>
-        <div class="element-qcu-discovery__proposals">
+        <div class="element-qcu-discovery__{{this.hasShortProposals}}">
           {{#each this.element.proposals as |proposal|}}
             <ProposalButton
               @proposal={{proposal}}


### PR DESCRIPTION
## 🥀 Problème

Nous avons désormais la possibilité de créer des éléments de type "réponses courtes" dans les modules.
Mais coté front, rien n'a été fait.

## 🏹 Proposition

Permettre l'affichage des réponses courtes en cas de QCU déclaratif ou découverte sur Pix App.

## 💌 Remarques

En preview : Pour un affichage "propre" des feedbacks, j'ai appliqué le `display flex` des **réponses longues** mais à voir avec le métier s'ils souhaitent voir l'affichage des **réponses courtes** correctement quand ils sont en preview.

Seulement ça va demander du dev plus important parce que s'ils veulent un affichage "**réponses courtes**" en preview, en l'état avec mon code ça donne ça 

<img width="568" height="370" alt="Capture d’écran 2026-02-16 à 17 09 28" src="https://github.com/user-attachments/assets/a885d175-51b3-46f5-83fc-8467feffe67a" />

Pas hyper propre quoi.

(j'ai volontairement caviardé le contenu pour pas se faire spoil par le nouveau contenu dans bac-a-sable)
## ❤️‍🔥 Pour tester

- Aller dans [bac-a-sable](https://app-pr15136.review.pix.fr/modules/6a68bf32/bac-a-sable/)
- Passer les activités jusqu'à arriver à la section `Réponses courtes`
- Voir les 2 QCU déclaratif et 2 QCU découverte 
  - Si 2 proposals = cote à cote sur une ligne
  - Si 3 proposals = cote à cote sur une ligne
  - Si 4 proposals = 2 par ligne
- Checker les comportements (desktop, mobile = chaque proposal à la ligne)


