### PR TITLE
[FEATURE] Afficher la progression sur les exports des campagnes de type EXAM (PIX-21458).

### DIFF
--- a/api/src/prescription/campaign/infrastructure/exports/campaigns/campaign-assessment-result-line.js
+++ b/api/src/prescription/campaign/infrastructure/exports/campaigns/campaign-assessment-result-line.js
@@ -121,15 +121,11 @@ class CampaignAssessmentResultLine {
       ...this._group,
       ...this._studentNumber,
       ...(this.campaign.externalIdLabel ? [this.campaignParticipationInfo.participantExternalId] : []),
-      ...(this.campaign.isAssessment
-        ? [
-            this.campaignParticipationService.progress(
-              this.campaignParticipationInfo.isCompleted,
-              this.targetedKnowledgeElementsCount,
-              this.learningContent.skills.length,
-            ),
-          ]
-        : []),
+      this.campaignParticipationService.progress(
+        this.campaignParticipationInfo.isCompleted,
+        this.targetedKnowledgeElementsCount,
+        this.learningContent.skills.length,
+      ),
       dayjs.utc(this.campaignParticipationInfo.createdAt).tz('Europe/Paris').format('DD/MM/YYYY HH:mm'),
       this._makeYesNoColumns(this.campaignParticipationInfo.isShared),
       this.campaignParticipationInfo.isShared

--- a/api/src/prescription/campaign/infrastructure/serializers/csv/campaign-assessment-export.js
+++ b/api/src/prescription/campaign/infrastructure/serializers/csv/campaign-assessment-export.js
@@ -122,7 +122,7 @@ class CampaignAssessmentExport {
       ...(forSupStudents ? [this.i18n.__('campaign-export.common.participant-student-number')] : []),
       ...(this.campaign.externalIdLabel ? [this.campaign.externalIdLabel] : []),
 
-      ...(this.campaign.isAssessment ? [this.i18n.__('campaign-export.assessment.progress')] : []),
+      this.i18n.__('campaign-export.assessment.progress'),
       this.i18n.__('campaign-export.assessment.started-on'),
       this.i18n.__('campaign-export.assessment.is-shared'),
       this.i18n.__('campaign-export.assessment.shared-on'),

--- a/api/tests/prescription/campaign/unit/infrastructure/exports/campaigns/campaign-assessment-result-line_test.js
+++ b/api/tests/prescription/campaign/unit/infrastructure/exports/campaigns/campaign-assessment-result-line_test.js
@@ -65,6 +65,7 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentResultLine', functio
             `"${targetProfile.name}";` +
             `"${campaignParticipationInfo.participantLastName}";` +
             `"${campaignParticipationInfo.participantFirstName}";` +
+            '1;' +
             `"${createdAtFormated}";` +
             '"Oui";' +
             `"${sharedAtFormated}";` +
@@ -115,6 +116,7 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentResultLine', functio
             `"${targetProfile.name}";` +
             `"${campaignParticipationInfo.participantLastName}";` +
             `"${campaignParticipationInfo.participantFirstName}";` +
+            '0;' +
             `"${createdAtFormated}";` +
             '"Non";' +
             '"NA";' +

--- a/api/tests/prescription/campaign/unit/infrastructure/serializers/csv/campaign-assessment-export_test.js
+++ b/api/tests/prescription/campaign/unit/infrastructure/serializers/csv/campaign-assessment-export_test.js
@@ -86,43 +86,6 @@ describe('Unit | Serializer | CSV | campaign-assessment-export', function () {
       expect(csv).to.equal(expectedHeader);
     });
 
-    it('should hide progression header on campaign of type Exam', async function () {
-      //given
-      const campaignProfile = new CampaignAssessmentExport({
-        outputStream,
-        organization,
-        campaign: domainBuilder.prescription.campaign.buildCampaign.ofTypeExam({ externalIdLabel: null }),
-        competences,
-        targetProfile,
-        learningContent,
-        stageCollection,
-        translate,
-      });
-
-      const expectedHeader =
-        '\uFEFF"Nom de l\'organisation";' +
-        '"ID Campagne";' +
-        '"Code";' +
-        '"Nom de la campagne";' +
-        '"Parcours";' +
-        '"Nom du Participant";' +
-        '"Prénom du Participant";' +
-        '"Date et heure de début (Europe/Paris)";' +
-        '"Partage (O/N)";' +
-        '"Date et heure du partage (Europe/Paris)";' +
-        '"% maitrise de l\'ensemble des acquis du profil"' +
-        '\n';
-      //when
-      await campaignProfile.export({});
-
-      outputStream.end();
-
-      const csv = await csvPromise;
-
-      // then
-      expect(csv).to.equal(expectedHeader);
-    });
-
     it('should display additional header on generic import', async function () {
       //given
       const campaignProfile = new CampaignAssessmentExport({


### PR DESCRIPTION
## 🥀 Problème

Suite à l'industrialisation des campagnes de type EXAM, il nous manque quelque fonctionnalité. 

## 🏹 Proposition

Comme la correction de la progression a été corrigé dans une précedente PR. l'activation de la progression des types EXAM s'en trouvent simplifié

Ajouter dans l'export csv des participations à une camapagne d'exam/interro  le % de leur avancement.

## 💌 Remarques

RAS

## ❤️‍🔥 Pour tester

Faire une campagne de type exam (code: VEMVNN235) et vérifier la progression en cours dans le CSV d'export
Faire une campagne de type assessment (code: VEMVNN235)  et vérifier que la progression n'est pas cassée comme nolwenn