### PR TITLE
[FEATURE] Afficher la progression pour les campagnes de type exam (PIX-21457)

### DIFF
--- a/orga/app/components/participant/assessment/header.gjs
+++ b/orga/app/components/participant/assessment/header.gjs
@@ -80,9 +80,8 @@ export default class Header extends Component {
   }
 
   get displayProgression() {
-    const { participation, campaign } = this.args;
-
-    return !campaign.isTypeExam && !participation.isShared;
+    const { participation } = this.args;
+    return !participation.isShared;
   }
 
   get selectedParticipation() {

--- a/orga/tests/integration/components/participant/assessment/header-test.js
+++ b/orga/tests/integration/components/participant/assessment/header-test.js
@@ -160,7 +160,7 @@ module('Integration | Component | Participant::Assessment::Header', function (ho
 
   module('progression', function () {
     test('it displays campaign participation progression on type ASSESSMENT', async function (assert) {
-      this.participation = { progression: 0.75 };
+      this.participation = { progression: 0.75, isShared: false };
       this.campaign = { isTypeExam: false, isTypeAssessment: true };
 
       const screen = await render(
@@ -171,16 +171,16 @@ module('Integration | Component | Participant::Assessment::Header', function (ho
       assert.ok(screen.getByText('75 %'));
     });
 
-    test('it hide campaign participation progression on type EXAM', async function (assert) {
-      this.participation = { progression: 0.75 };
+    test('it displays campaign participation progression on type EXAM', async function (assert) {
+      this.participation = { progression: 0.75, isShared: false };
       this.campaign = { isTypeExam: true, isTypeAssessment: false };
 
       const screen = await render(
         hbs`<Participant::Assessment::Header @participation={{this.participation}} @campaign={{this.campaign}} />`,
       );
 
-      assert.notOk(screen.queryByText(t('pages.assessment-individual-results.progression')));
-      assert.notOk(screen.queryByText('75 %'));
+      assert.ok(screen.queryByText(t('pages.assessment-individual-results.progression')));
+      assert.ok(screen.queryByText('75 %'));
     });
   });
 
@@ -237,7 +237,7 @@ module('Integration | Component | Participant::Assessment::Header', function (ho
         );
       });
 
-      test('hides participant progression on campaign of type exam', async function (assert) {
+      test('show participant progression on campaign of type exam', async function (assert) {
         this.participation = {
           isShared: false,
           progression: 0.8,
@@ -251,8 +251,8 @@ module('Integration | Component | Participant::Assessment::Header', function (ho
           hbs`<Participant::Assessment::Header @participation={{this.participation}} @campaign={{this.campaign}} />`,
         );
 
-        assert.notOk(screen.queryByText(t('pages.assessment-individual-results.progression')));
-        assert.notOk(
+        assert.ok(screen.queryByText(t('pages.assessment-individual-results.progression')));
+        assert.ok(
           screen.queryByText(t('common.result.percentage', { value: 0.8 }), {
             normalizer: getDefaultNormalizer({ collapseWhitespace: false }),
           }),


### PR DESCRIPTION
## 🥀 Problème

Dans le cadre de l'industrialisation du mode EXAM, on souhaite afficher la progression pour faciliter le suivi des participations

## 🏹 Proposition

Dans PixOrga, on affiche la progression sur les participations à des campagnes de type EXAM/INTERRO

## 💌 Remarques



## ❤️‍🔥 Pour tester
- Créer une campagne en mode EXAM
- répondre à 2 questions de la campagne
- se connecter à pix orga 
- afficher la participations et voir la progression

