### PR TITLE
[FEATURE] Ajout du choix obligatoire de public prescrit dans la création d'organisation (PIX-21330).

### DIFF
--- a/admin/app/components/organizations/creation-form.gjs
+++ b/admin/app/components/organizations/creation-form.gjs
@@ -51,6 +51,15 @@ export default class OrganizationCreationForm extends Component {
     return options;
   }
 
+  get organizationLearnerTypesOptions() {
+    const options = this.args.organizationLearnerTypes.map((organizationLearnerType) => ({
+      value: organizationLearnerType.id,
+      label: organizationLearnerType.name,
+    }));
+
+    return options;
+  }
+
   get submitButtonText() {
     return this.args.parentOrganization?.name
       ? 'components.organizations.creation.actions.add-child-organization'
@@ -182,7 +191,24 @@ export default class OrganizationCreationForm extends Component {
           </PixSelect>
 
           <PixSelect
+            @id="organizationLearnerTypeId"
+            @onChange={{fn this.handleSelectChange "organizationLearnerTypeId"}}
+            @options={{this.organizationLearnerTypesOptions}}
+            @placeholder={{t "components.organizations.creation.organization-learner-type.selector.placeholder"}}
+            @hideDefaultOption={{true}}
+            @value={{this.form.organizationLearnerTypeId}}
+            @requiredLabel={{t "common.fields.required-field"}}
+            @errorMessage={{if
+              this.validator.errors.organizationLearnerTypeId
+              (t this.validator.errors.organizationLearnerTypeId)
+            }}
+            @isFullWidth={{true}}
+          >
+            <:label>{{t "components.organizations.creation.organization-learner-type.selector.label"}}</:label>
+          </PixSelect>
+          <PixSelect
             @id="countryCode"
+            class="organization-creation-form__field--force-grid-start"
             @onChange={{fn this.handleSelectChange "countryCode"}}
             @options={{this.countriesOptions}}
             @placeholder={{t "components.organizations.creation.country.selector.placeholder"}}
@@ -304,6 +330,10 @@ const ORGANIZATION_CREATION_FORM_VALIDATION_SCHEMA = Joi.object({
   administrationTeamId: Joi.string().empty(['', null]).required().messages({
     'any.required': 'components.organizations.creation.error-messages.administration-team',
     'string.empty': 'components.organizations.creation.error-messages.administration-team',
+  }),
+  organizationLearnerTypeId: Joi.string().empty(['', null]).required().messages({
+    'any.required': 'components.organizations.creation.error-messages.organization-learner-type',
+    'string.empty': 'components.organizations.creation.error-messages.organization-learner-type',
   }),
   countryCode: Joi.string().empty(['', null]).required().messages({
     'any.required': 'components.organizations.creation.error-messages.country',

--- a/admin/app/components/organizations/creation-form.scss
+++ b/admin/app/components/organizations/creation-form.scss
@@ -26,4 +26,8 @@
   &__parent-name--full {
     grid-column: 1 / span 2;
   }
+
+  &__field--force-grid-start {
+    grid-column-start: 1;
+  }
 }

--- a/admin/app/routes/authenticated/organizations/new.js
+++ b/admin/app/routes/authenticated/organizations/new.js
@@ -18,6 +18,7 @@ export default class NewRoute extends Route {
   async model(_, transition) {
     const administrationTeams = await this.store.findAll('administration-team');
     const countries = await this.store.findAll('country');
+    const organizationLearnerTypes = await this.store.findAll('organization-learner-type');
     let parentOrganization = null;
     const { parentOrganizationId } = transition.to.queryParams;
     if (parentOrganizationId) {
@@ -27,6 +28,7 @@ export default class NewRoute extends Route {
       administrationTeams,
       countries,
       parentOrganization,
+      organizationLearnerTypes,
     });
   }
 

--- a/admin/app/templates/authenticated/organizations/new.gjs
+++ b/admin/app/templates/authenticated/organizations/new.gjs
@@ -17,6 +17,7 @@ import CreationForm from 'pix-admin/components/organizations/creation-form';
     <CreationForm
       @administrationTeams={{@model.administrationTeams}}
       @countries={{@model.countries}}
+      @organizationLearnerTypes={{@model.organizationLearnerTypes}}
       @onSubmit={{@controller.addOrganization}}
       @onCancel={{@controller.redirectOnCancel}}
       @parentOrganization={{@model.parentOrganization}}

--- a/admin/tests/acceptance/authenticated/organizations/create-organization-test.js
+++ b/admin/tests/acceptance/authenticated/organizations/create-organization-test.js
@@ -118,6 +118,14 @@ module('Acceptance | Organizations | Create', function (hooks) {
 
       await click(
         screen.getByRole('button', {
+          name: `${t('components.organizations.creation.organization-learner-type.selector.label')} *`,
+        }),
+      );
+      await screen.findByRole('listbox');
+      await click(screen.getByText('Teacher'));
+
+      await click(
+        screen.getByRole('button', {
           name: `${t('components.organizations.creation.country.selector.label')} *`,
         }),
       );

--- a/admin/tests/integration/components/organizations/creation-form-test.gjs
+++ b/admin/tests/integration/components/organizations/creation-form-test.gjs
@@ -25,6 +25,11 @@ module('Integration | Component | organizations/creation-form', function (hooks)
     { id: 'team-2', name: 'Équipe 2' },
   ];
 
+  const organizationLearnerTypes = [
+    { id: '123', name: 'Student' },
+    { id: '456', name: 'Teacher' },
+  ];
+
   hooks.beforeEach(function () {
     store = this.owner.lookup('service:store');
 
@@ -42,6 +47,7 @@ module('Integration | Component | organizations/creation-form', function (hooks)
         <template>
           <CreationForm
             @administrationTeams={{administrationTeams}}
+            @organizationLearnerTypes={{organizationLearnerTypes}}
             @countries={{countries}}
             @onSubmit={{onSubmit}}
             @onCancel={{onCancel}}
@@ -53,6 +59,9 @@ module('Integration | Component | organizations/creation-form', function (hooks)
       assert.ok(screen.getByRole('textbox', { name: `${t('components.organizations.creation.name.label')} *` }));
       assert.ok(screen.getByLabelText(`${t('components.organizations.creation.type.label')} *`));
       assert.ok(screen.getByText(t('components.organizations.creation.administration-team.selector.placeholder')));
+      assert.ok(
+        screen.getByLabelText(`${t('components.organizations.creation.organization-learner-type.selector.label')} *`),
+      );
       assert.ok(screen.getByLabelText(`${t('components.organizations.creation.country.selector.label')} *`));
       assert.ok(screen.getByRole('textbox', { name: t('components.organizations.creation.province-code') }));
       assert.ok(screen.getByRole('textbox', { name: t('components.organizations.creation.external-id.label') }));
@@ -73,6 +82,7 @@ module('Integration | Component | organizations/creation-form', function (hooks)
           <CreationForm
             @organization={{organization}}
             @administrationTeams={{administrationTeams}}
+            @organizationLearnerTypes={{organizationLearnerTypes}}
             @countries={{countries}}
             @onSubmit={{onSubmit}}
             @onCancel={{onCancel}}
@@ -95,6 +105,38 @@ module('Integration | Component | organizations/creation-form', function (hooks)
       assert.strictEqual(options[1].title, 'Danemark (99101)');
     });
 
+    test('should render learner types options in list', async function (assert) {
+      // given
+      const organization = store.createRecord('organization', { type: '' });
+
+      const screen = await render(
+        <template>
+          <CreationForm
+            @organization={{organization}}
+            @administrationTeams={{administrationTeams}}
+            @organizationLearnerTypes={{organizationLearnerTypes}}
+            @countries={{countries}}
+            @onSubmit={{onSubmit}}
+            @onCancel={{onCancel}}
+          />
+        </template>,
+      );
+
+      // when
+      await click(
+        screen.getByRole('button', {
+          name: `${t('components.organizations.creation.organization-learner-type.selector.label')} *`,
+        }),
+      );
+      await screen.findByRole('listbox');
+      const options = await screen.getAllByRole('option');
+
+      // then
+      assert.strictEqual(options.length, 2);
+      assert.strictEqual(options[0].title, 'Student');
+      assert.strictEqual(options[1].title, 'Teacher');
+    });
+
     module('when there is a parent organization', function () {
       test("it prefills the administration team selector with its parent's", async function (assert) {
         // given - when
@@ -105,6 +147,7 @@ module('Integration | Component | organizations/creation-form', function (hooks)
             <CreationForm
               @parentOrganization={{organization}}
               @administrationTeams={{administrationTeams}}
+              @organizationLearnerTypes={{organizationLearnerTypes}}
               @countries={{countries}}
               @onSubmit={{onSubmit}}
               @onCancel={{onCancel}}
@@ -125,6 +168,7 @@ module('Integration | Component | organizations/creation-form', function (hooks)
             <CreationForm
               @parentOrganization={{organization}}
               @administrationTeams={{administrationTeams}}
+              @organizationLearnerTypes={{organizationLearnerTypes}}
               @countries={{countries}}
               @onSubmit={{onSubmit}}
               @onCancel={{onCancel}}
@@ -148,6 +192,7 @@ module('Integration | Component | organizations/creation-form', function (hooks)
             <CreationForm
               @parentOrganization={{organization}}
               @administrationTeams={{administrationTeams}}
+              @organizationLearnerTypes={{organizationLearnerTypes}}
               @countries={{countries}}
               @onSubmit={{onSubmit}}
               @onCancel={{onCancel}}
@@ -173,6 +218,7 @@ module('Integration | Component | organizations/creation-form', function (hooks)
             <CreationForm
               @parentOrganization={{organization}}
               @administrationTeams={{administrationTeams}}
+              @organizationLearnerTypes={{organizationLearnerTypes}}
               @countries={{countries}}
               @onSubmit={{onSubmit}}
               @onCancel={{onCancel}}
@@ -195,6 +241,7 @@ module('Integration | Component | organizations/creation-form', function (hooks)
             <CreationForm
               @parentOrganization={{null}}
               @administrationTeams={{administrationTeams}}
+              @organizationLearnerTypes={{organizationLearnerTypes}}
               @countries={{countries}}
               @onSubmit={{onSubmit}}
               @onCancel={{onCancel}}
@@ -216,6 +263,7 @@ module('Integration | Component | organizations/creation-form', function (hooks)
             <CreationForm
               @parentOrganization={{null}}
               @administrationTeams={{administrationTeams}}
+              @organizationLearnerTypes={{organizationLearnerTypes}}
               @countries={{countries}}
               @onSubmit={{onSubmit}}
               @onCancel={{onCancel}}
@@ -237,6 +285,7 @@ module('Integration | Component | organizations/creation-form', function (hooks)
             <CreationForm
               @parentOrganization={{null}}
               @administrationTeams={{administrationTeams}}
+              @organizationLearnerTypes={{organizationLearnerTypes}}
               @countries={{countries}}
               @onSubmit={{onSubmit}}
               @onCancel={{onCancel}}
@@ -258,6 +307,7 @@ module('Integration | Component | organizations/creation-form', function (hooks)
             <CreationForm
               @parentOrganization={{null}}
               @administrationTeams={{administrationTeams}}
+              @organizationLearnerTypes={{organizationLearnerTypes}}
               @countries={{countries}}
               @onSubmit={{onSubmit}}
               @onCancel={{onCancel}}
@@ -284,6 +334,7 @@ module('Integration | Component | organizations/creation-form', function (hooks)
         <template>
           <CreationForm
             @administrationTeams={{administrationTeams}}
+            @organizationLearnerTypes={{organizationLearnerTypes}}
             @countries={{countries}}
             @onSubmit={{handleSubmitStub}}
             @onCancel={{onCancel}}
@@ -306,6 +357,14 @@ module('Integration | Component | organizations/creation-form', function (hooks)
       );
       await screen.findByRole('listbox');
       click(await screen.findByRole('option', { name: 'Équipe 2' }));
+
+      click(
+        screen.getByRole('button', {
+          name: `${t('components.organizations.creation.organization-learner-type.selector.label')} *`,
+        }),
+      );
+      await screen.findByRole('listbox');
+      click(await screen.findByRole('option', { name: 'Student' }));
 
       await fillByLabel(t('components.organizations.creation.province-code'), '78');
 
@@ -332,6 +391,7 @@ module('Integration | Component | organizations/creation-form', function (hooks)
         type: 'SCO',
         externalId: 'Mon identifiant externe',
         administrationTeamId: 'team-2',
+        organizationLearnerTypeId: '123',
         provinceCode: '78',
         countryCode: '99100',
         documentationUrl: 'https://www.documentation.fr',
@@ -353,6 +413,7 @@ module('Integration | Component | organizations/creation-form', function (hooks)
             <template>
               <CreationForm
                 @administrationTeams={{administrationTeams}}
+                @organizationLearnerTypes={{organizationLearnerTypes}}
                 @countries={{countries}}
                 @onSubmit={{handleSubmitStub}}
               />
@@ -369,7 +430,13 @@ module('Integration | Component | organizations/creation-form', function (hooks)
         test('should display error toast and display specific error messages on required fields', async function (assert) {
           // given
           const screen = await render(
-            <template><CreationForm @administrationTeams={{administrationTeams}} @countries={{countries}} /></template>,
+            <template>
+              <CreationForm
+                @administrationTeams={{administrationTeams}}
+                @organizationLearnerTypes={{organizationLearnerTypes}}
+                @countries={{countries}}
+              />
+            </template>,
           );
 
           // when
@@ -381,11 +448,15 @@ module('Integration | Component | organizations/creation-form', function (hooks)
           const administrationTeamErrorMessage = screen.getByText(
             t('components.organizations.creation.error-messages.administration-team'),
           );
+          const organizationLearnerTypeErrorMessage = screen.getByText(
+            t('components.organizations.creation.error-messages.organization-learner-type'),
+          );
           const countryErrorMessage = screen.getByText(t('components.organizations.creation.error-messages.country'));
 
           assert.ok(nameErrorMessage);
           assert.ok(typeErrorMessage);
           assert.ok(administrationTeamErrorMessage);
+          assert.ok(organizationLearnerTypeErrorMessage);
           assert.ok(countryErrorMessage);
           assert.ok(
             errorNotificationStub.calledWithExactly({
@@ -399,7 +470,13 @@ module('Integration | Component | organizations/creation-form', function (hooks)
         test('should display specific error if documentation link or DPO email are not valid', async function (assert) {
           // given
           const screen = await render(
-            <template><CreationForm @administrationTeams={{administrationTeams}} @countries={{countries}} /></template>,
+            <template>
+              <CreationForm
+                @administrationTeams={{administrationTeams}}
+                @organizationLearnerTypes={{organizationLearnerTypes}}
+                @countries={{countries}}
+              />
+            </template>,
           );
 
           await fillByLabel(t('components.organizations.creation.documentation-link'), 'non-valid-documentation-url');
@@ -425,7 +502,13 @@ module('Integration | Component | organizations/creation-form', function (hooks)
       test('should make error messages disappear when updating fields in error with correct values', async function (assert) {
         // given
         const screen = await render(
-          <template><CreationForm @administrationTeams={{administrationTeams}} @countries={{countries}} /></template>,
+          <template>
+            <CreationForm
+              @administrationTeams={{administrationTeams}}
+              @organizationLearnerTypes={{organizationLearnerTypes}}
+              @countries={{countries}}
+            />
+          </template>,
         );
 
         await fillByLabel(`${t('components.organizations.creation.name.label')} *`, 'Organisation de Test');
@@ -470,7 +553,13 @@ module('Integration | Component | organizations/creation-form', function (hooks)
         test('it should focus on it after submit', async function (assert) {
           // given
           const screen = await render(
-            <template><CreationForm @administrationTeams={{administrationTeams}} @countries={{countries}} /></template>,
+            <template>
+              <CreationForm
+                @administrationTeams={{administrationTeams}}
+                @organizationLearnerTypes={{organizationLearnerTypes}}
+                @countries={{countries}}
+              />
+            </template>,
           );
 
           // when
@@ -488,7 +577,13 @@ module('Integration | Component | organizations/creation-form', function (hooks)
         test('it should focus on it after submit', async function (assert) {
           // given
           const screen = await render(
-            <template><CreationForm @administrationTeams={{administrationTeams}} @countries={{countries}} /></template>,
+            <template>
+              <CreationForm
+                @administrationTeams={{administrationTeams}}
+                @organizationLearnerTypes={{organizationLearnerTypes}}
+                @countries={{countries}}
+              />
+            </template>,
           );
 
           await fillByLabel(`${t('components.organizations.creation.name.label')} *`, 'Organisation de Test');
@@ -510,7 +605,12 @@ module('Integration | Component | organizations/creation-form', function (hooks)
       // given
       const screen = await render(
         <template>
-          <CreationForm @administrationTeams={{administrationTeams}} @countries={{countries}} @onCancel={{onCancel}} />
+          <CreationForm
+            @administrationTeams={{administrationTeams}}
+            @organizationLearnerTypes={{organizationLearnerTypes}}
+            @countries={{countries}}
+            @onCancel={{onCancel}}
+          />
         </template>,
       );
 

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -704,6 +704,7 @@
           "dpo-email": "The email adress is not in the correct format",
           "error-toast": "Please correct the fields with errors.",
           "name": "Name is required",
+          "organization-learner-type": "Learner type is required",
           "type": "Organization type is required"
         },
         "external-id": {
@@ -715,6 +716,12 @@
         "name": {
           "label": "Name of the organization",
           "placeholder": "My new organization"
+        },
+        "organization-learner-type": {
+          "selector": {
+            "label": "Learner Type",
+            "placeholder": "Select one learner type"
+          }
         },
         "parent-organization-name": "Parent organization: {parentOrganizationName}",
         "province-code": "Province code (3 digits)",

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -706,6 +706,7 @@
           "dpo-email": "L'adresse e-mail n'est pas au bon format",
           "error-toast": "Veuillez corriger les champs en erreur.",
           "name": "Le nom est requis",
+          "organization-learner-type": "Le public prescrit est requis",
           "type": "Le type d'organisation est requis"
         },
         "external-id": {
@@ -717,6 +718,12 @@
         "name": {
           "label": "Nom de l'organisation",
           "placeholder": "Ma nouvelle organisation"
+        },
+        "organization-learner-type": {
+          "selector": {
+            "label": "Public prescrit",
+            "placeholder": "Sélectionner un public prescrit"
+          }
         },
         "parent-organization-name": "Organisation mère : {parentOrganizationName}",
         "province-code": "Département (en 3 chiffres)",

--- a/api/src/organizational-entities/domain/validators/organization-creation-validator.js
+++ b/api/src/organizational-entities/domain/validators/organization-creation-validator.js
@@ -30,7 +30,7 @@ const organizationValidationJoiSchema = Joi.object({
 
   organizationLearnerType: Joi.object({
     id: Joi.number(),
-    name: Joi.string(),
+    name: Joi.string().allow(null),
   })
     .required()
     .messages({

--- a/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
@@ -413,6 +413,7 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
             id: 1234,
             name: 'Équipe 1',
           });
+          databaseBuilder.factory.buildOrganizationLearnerType({ id: 123 });
           databaseBuilder.factory.buildCertificationCpfCountry({
             code: 99100,
             commonName: 'France',
@@ -436,6 +437,8 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
                   'country-code': 99100,
                   'external-id': 'My external Id',
                   'province-code': '078',
+                  'organization-learner-type-id': 123,
+                  'organization-learner-type-name': null,
                 },
               },
             },


### PR DESCRIPTION
## 🥀 Problème

Il n'est pas encore possible dans Pix-Admin de sélectionner le public prescrit lors de la création unitaire d'une organisation.

## 🏹 Proposition

Ajout du sélecteur permettant d'inclure le public prescrit à la requête de création unitaire d'organisation.

## 💌 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## ❤️‍🔥 Pour tester

- Se connecter à Pix-Admin
- Créer une nouvelle organisation
- Vérifier que le type de public prescrit est ajouté