### PR TITLE
[TECH] Augmente les capacités de l'exécuteur `admin_lint` pour éviter les problèmes mémoire lors de la CI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -826,7 +826,7 @@ jobs:
 
   admin_lint:
     executor:
-      name: node-docker
+      name: node-docker-medium
     working_directory: ~/pix/admin
     steps:
       - attach_workspace:


### PR DESCRIPTION
## 🥀 Problème

La tâche `admin_lint` de la CI échoue très régulièrement par manque de mémoire.

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

## 🏹 Proposition

En attendant de consommer moins de mémoire pour cette tâche et afin de débloquer notre CI, on passe à la classe `medium` pour cette tâche.

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 💌 Remarques

RAS

<!-- Des infos supplémentaires, trucs et astuces ? -->

## ❤️‍🔥 Pour tester

CI verte, du premier coup
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
