### PR TITLE
[TECH] Ajouter la propriété headerTemplate lors de la génération du schéma JSON des modules (PIX-21544)

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/conversion/joi-to-json-schema.js
+++ b/api/src/devcomp/infrastructure/datasources/conversion/joi-to-json-schema.js
@@ -156,6 +156,11 @@ function convertArray(joiArrayDescribedSchema, key = '') {
       jsonSchema.items = convertFromType(item);
       if (itemTitle) {
         jsonSchema.items.title = itemTitle;
+
+        // Add headerTemplate for JSON Editor lib
+        // See {@link https://github.com/json-editor/json-editor#dynamic-headers}
+        // for further informations
+        jsonSchema.items.headerTemplate = `${itemTitle} {{i0}}`;
       }
     }
   }

--- a/api/tests/devcomp/unit/infrastructure/datasources/conversion/joi-to-json-schema_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/conversion/joi-to-json-schema_test.js
@@ -297,7 +297,12 @@ describe('Unit | Infrastructure | Datasources | Conversion | joi-to-json-schema'
         properties: {
           proposals: {
             type: 'array',
-            items: { title: 'proposal', type: 'string', format: null },
+            items: {
+              title: 'proposal',
+              headerTemplate: 'proposal {{i0}}',
+              type: 'string',
+              format: null,
+            },
           },
         },
         additionalProperties: false,


### PR DESCRIPTION
## 🥀 Problème

La numérotation sur les applications utilisant JSON Editor et consommant le schéma des modules commence à 1.
Nous voulons que cela commence à 0 pour garder une cohérence avec les erreurs Joi en cas de problème de validation.

## 🏹 Proposition

Ajouter une propriété `headerTemplate` lors de la génération des types array pour gérer cela. ([doc JSON Editor](https://github.com/json-editor/json-editor#dynamic-headers)  pour plus d'infos)

## 💌 Remarques

RAS

## ❤️‍🔥 Pour tester
CI ✅ 