### PR TITLE
[TECH] Utiliser les domaines transaction dans les repo certification

### DIFF
--- a/api/src/certification/session-management/infrastructure/repositories/certification-candidate-for-supervising-repository.js
+++ b/api/src/certification/session-management/infrastructure/repositories/certification-candidate-for-supervising-repository.js
@@ -1,9 +1,11 @@
-import { knex } from '../../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { CertificationCandidateNotFoundError } from '../../../../shared/domain/errors.js';
 import { CertificationCandidateForSupervising } from '../../domain/models/CertificationCandidateForSupervising.js';
 
 const get = async function ({ certificationCandidateId }) {
-  const result = await knex('certification-candidates')
+  const knexConn = DomainTransaction.getConnection();
+
+  const result = await knexConn('certification-candidates')
     .select(
       'certification-candidates.*',
       'assessments.state AS assessmentStatus',
@@ -25,7 +27,9 @@ const get = async function ({ certificationCandidateId }) {
 };
 
 const update = async function (certificationCandidateForSupervising) {
-  const result = await knex('certification-candidates')
+  const knexConn = DomainTransaction.getConnection();
+
+  const result = await knexConn('certification-candidates')
     .where({
       id: certificationCandidateForSupervising.id,
     })

--- a/api/src/certification/session-management/infrastructure/repositories/certification-officer-repository.js
+++ b/api/src/certification/session-management/infrastructure/repositories/certification-officer-repository.js
@@ -1,9 +1,11 @@
-import { knex } from '../../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { UserNotFoundError } from '../../../../shared/domain/errors.js';
 import { CertificationOfficer } from '../../domain/models/CertificationOfficer.js';
 
 const get = async function ({ userId }) {
-  const certificationOfficer = await knex('users')
+  const knexConn = DomainTransaction.getConnection();
+
+  const certificationOfficer = await knexConn('users')
     .select(['id', 'firstName', 'lastName'])
     .where({ id: userId })
     .first();

--- a/api/src/certification/session-management/infrastructure/repositories/certification-repository.js
+++ b/api/src/certification/session-management/infrastructure/repositories/certification-repository.js
@@ -1,4 +1,3 @@
-import { knex } from '../../../../../db/knex-database-connection.js';
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 
 const getStatusesBySessionId = async function (sessionId) {
@@ -40,7 +39,8 @@ const publishCertificationCourses = async function (certificationStatuses) {
 };
 
 const unpublishCertificationCoursesBySessionId = async function ({ sessionId }) {
-  await knex('certification-courses').where({ sessionId }).update({ isPublished: false, updatedAt: new Date() });
+  const knexConn = DomainTransaction.getConnection();
+  await knexConn('certification-courses').where({ sessionId }).update({ isPublished: false, updatedAt: new Date() });
 };
 
 export { getStatusesBySessionId, publishCertificationCourses, unpublishCertificationCoursesBySessionId };


### PR DESCRIPTION
## 🥀 Problème

Dans le contexte Certification, sur certains repository, on utilise toujours `knex` au lieu de `DomainTransaction.getConnection`.

## 🏹 Proposition

Déplacer une transaction près des écritures, dans :
- `sco-certification-candidate-repository`

Utiliser le `DomainTransaction.getConnection` dans :
- `certification-candidate-for-supervising-repository`
- `certification-officer-repository`
- `certification-repository`
- `cpf-certification-result-repository`

## 💌 Remarques

N/A

## ❤️‍🔥 Pour tester

Les tests auto sont suffisants ?
