### PR TITLE
[FEATURE] Ajouter l'italien sur Pix App et Pix Orga (PIX-21502)

### DIFF
--- a/admin/app/services/locale.js
+++ b/admin/app/services/locale.js
@@ -16,13 +16,13 @@ export const ENGLISH_INTERNATIONAL_LOCALE = 'en';
 
 const DEFAULT_LANGUAGE = new Intl.Locale(DEFAULT_LOCALE).language;
 
-const PIX_LOCALES = ['en', 'es', 'es-419', 'fr', 'nl', 'fr-BE', 'fr-FR', 'nl-BE'];
+const PIX_LOCALES = ['en', 'es', 'es-419', 'fr', 'nl', 'fr-BE', 'fr-FR', 'nl-BE', 'it'];
 
 // Currently the challenge locales are not in canonical locales, thus the "fr-fr" value.
 // This cannot be changed without migrating the challenges content.
 const PIX_CHALLENGE_LOCALES = ['en', 'fr', 'fr-fr', 'nl', 'es', 'es-419', 'it', 'de'];
 
-const PIX_LANGUAGES = ['fr', 'en', 'nl', 'es'];
+const PIX_LANGUAGES = ['fr', 'en', 'nl', 'es', 'it'];
 
 const COOKIE_LOCALE = 'locale';
 

--- a/admin/app/services/url-base.js
+++ b/admin/app/services/url-base.js
@@ -56,6 +56,7 @@ export const PIX_WEBSITE_ROOT_URLS = {
   en: 'https://pix.org/en',
   es: 'https://pix.org/en',
   'es-419': 'https://pix.org/en',
+  it: 'https://pix.org/en',
   fr: 'https://pix.org/fr',
 };
 
@@ -69,6 +70,7 @@ export const PIX_WEBSITE_PATHS = {
     en: 'terms-and-conditions',
     es: 'terms-and-conditions',
     'es-419': 'terms-and-conditions',
+    it: 'terms-and-conditions',
     fr: 'conditions-generales-d-utilisation',
   },
   LEGAL_NOTICE: {
@@ -79,6 +81,7 @@ export const PIX_WEBSITE_PATHS = {
     en: 'legal-notice',
     es: 'legal-notice',
     'es-419': 'legal-notice',
+    it: 'legal-notice',
     fr: 'mentions-legales',
   },
   DATA_PROTECTION_POLICY: {
@@ -89,6 +92,7 @@ export const PIX_WEBSITE_PATHS = {
     en: 'personal-data-protection-policy',
     es: 'personal-data-protection-policy',
     'es-419': 'personal-data-protection-policy',
+    it: 'personal-data-protection-policy',
     fr: 'politique-protection-donnees-personnelles-app',
   },
   ACCESSIBILITY: {
@@ -99,6 +103,7 @@ export const PIX_WEBSITE_PATHS = {
     en: 'accessibility',
     es: 'accessibility',
     'es-419': 'accessibility',
+    it: 'accessibility',
     fr: 'accessibilite',
   },
   ACCESSIBILITY_ORGA: {
@@ -109,6 +114,7 @@ export const PIX_WEBSITE_PATHS = {
     en: 'accessibility-pix-orga',
     es: 'accessibility-pix-orga',
     'es-419': 'accessibility-pix-orga',
+    it: 'accessibility-pix-orga',
     fr: 'accessibilite-pix-orga',
   },
   ACCESSIBILITY_CERTIF: {
@@ -119,6 +125,7 @@ export const PIX_WEBSITE_PATHS = {
     en: 'accessibility-pix-certif',
     es: 'accessibility-pix-certif',
     'es-419': 'accessibility-pix-certif',
+    it: 'accessibility-pix-certif',
     fr: 'accessibilite-pix-certif',
   },
   SUPPORT: {
@@ -129,6 +136,7 @@ export const PIX_WEBSITE_PATHS = {
     en: 'support',
     es: 'support',
     'es-419': 'support',
+    it: 'support',
     fr: 'support',
   },
   CERTIFICATION_RESULTS_EXPLANATION: {
@@ -139,6 +147,18 @@ export const PIX_WEBSITE_PATHS = {
     en: 'understand-certification-results',
     es: 'understand-certification-results',
     'es-419': 'understand-certification-results',
+    it: 'understand-certification-results',
     fr: 'certification-comprendre-score-niveau',
+  },
+  CERTIFICATION_HOW_TO: {
+    'fr-FR': 'se-certifier',
+    'fr-BE': 'se-certifier',
+    'nl-BE': 'mijn-digitale-vaardigheden-certificeren',
+    nl: 'mijn-digitale-vaardigheden-certificeren',
+    en: 'certify-my-digital-skills',
+    es: 'certify-my-digital-skills',
+    'es-419': 'certify-my-digital-skills',
+    it: 'certify-my-digital-skills',
+    fr: 'se-certifier',
   },
 };

--- a/admin/tests/unit/services/locale-test.js
+++ b/admin/tests/unit/services/locale-test.js
@@ -71,7 +71,7 @@ module('Unit | Services | locale', function (hooks) {
       const pixLocales = localeService.pixLocales;
 
       // then
-      assert.deepEqual(pixLocales, ['en', 'es', 'es-419', 'fr', 'nl', 'fr-BE', 'fr-FR', 'nl-BE']);
+      assert.deepEqual(pixLocales, ['en', 'es', 'es-419', 'fr', 'nl', 'fr-BE', 'fr-FR', 'nl-BE', 'it']);
     });
   });
 
@@ -81,7 +81,7 @@ module('Unit | Services | locale', function (hooks) {
       const pixLanguages = localeService.pixLanguages;
 
       // then
-      assert.deepEqual(pixLanguages, ['fr', 'en', 'nl', 'es']);
+      assert.deepEqual(pixLanguages, ['fr', 'en', 'nl', 'es', 'it']);
     });
   });
 

--- a/api/src/shared/domain/services/locale-service.js
+++ b/api/src/shared/domain/services/locale-service.js
@@ -7,7 +7,7 @@ const DEFAULT_CHALLENGE_LOCALE = 'fr-fr';
 const CHALLENGE_LOCALES = ['en', 'fr', 'fr-fr', 'nl', 'es', 'es-419', 'it', 'de'];
 
 const DEFAULT_LOCALE = 'fr';
-const SUPPORTED_LOCALES = ['en', 'es', 'es-419', 'fr', 'nl', 'fr-BE', 'fr-FR', 'nl-BE'];
+const SUPPORTED_LOCALES = ['en', 'es', 'es-419', 'fr', 'nl', 'fr-BE', 'fr-FR', 'nl-BE', 'it'];
 
 const SUPPORTED_LANGUAGES = Array.from(new Set(SUPPORTED_LOCALES.map((locale) => new Intl.Locale(locale).language)));
 

--- a/api/src/shared/domain/services/url-service.js
+++ b/api/src/shared/domain/services/url-service.js
@@ -16,6 +16,7 @@ export const PIX_WEBSITE_ROOT_URLS = {
   nl: `${PIX_WEBSITE_DOMAIN_ORG}/nl-be`,
   en: `${PIX_WEBSITE_DOMAIN_ORG}/en`,
   es: `${PIX_WEBSITE_DOMAIN_ORG}/en`,
+  it: `${PIX_WEBSITE_DOMAIN_ORG}/en`,
   'es-419': `${PIX_WEBSITE_DOMAIN_ORG}/en`,
   fr: `${PIX_WEBSITE_DOMAIN_ORG}/fr`,
 };
@@ -124,6 +125,7 @@ export const PIX_WEBSITE_PATHS = {
     en: 'support',
     es: 'support',
     'es-419': 'support',
+    it: 'support',
     fr: 'support',
   },
 };

--- a/api/src/shared/infrastructure/i18n/i18n.js
+++ b/api/src/shared/infrastructure/i18n/i18n.js
@@ -10,8 +10,8 @@ const __dirname = import.meta.dirname;
 const translationsFolder = path.resolve(path.join(__dirname, '../../../../translations'));
 
 export const defaultSettings = {
-  locales: ['en', 'fr', 'es', 'es-419', 'nl'],
-  fallbacks: { 'en-*': 'en', 'fr-*': 'fr', 'es-*': 'es', 'nl-*': 'nl' },
+  locales: ['en', 'fr', 'es', 'es-419', 'nl', 'it'],
+  fallbacks: { 'en-*': 'en', 'fr-*': 'fr', 'es-*': 'es', 'nl-*': 'nl', 'it-*': 'it' },
   defaultLocale: 'fr', // default locale must match an existing translation file (fr => fr.json)
   directory: translationsFolder,
   objectNotation: true,

--- a/api/tests/organizational-entities/integration/domain/usecases/create-organizations-with-tags-and-target-profiles.usecase.test.js
+++ b/api/tests/organizational-entities/integration/domain/usecases/create-organizations-with-tags-and-target-profiles.usecase.test.js
@@ -123,7 +123,8 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
           },
           {
             attribute: 'locale',
-            message: "La locale doit avoir l'une des valeurs suivantes : en, es, es-419, fr, nl, fr-be, fr-fr, nl-be",
+            message:
+              "La locale doit avoir l'une des valeurs suivantes : en, es, es-419, fr, nl, fr-be, fr-fr, nl-be, it",
           },
           {
             attribute: 'locale',

--- a/api/tests/organizational-entities/integration/domain/validators/organization-with-tags-and-target-profiles.test.js
+++ b/api/tests/organizational-entities/integration/domain/validators/organization-with-tags-and-target-profiles.test.js
@@ -107,7 +107,7 @@ describe('Unit | Domain | Validators | organization-with-tags-and-target-profile
         expect(error.message).to.equal(`Échec de validation de l'entité.`);
         expect(error.invalidAttributes).to.deep.include({
           attribute: 'locale',
-          message: `La locale doit avoir l'une des valeurs suivantes : en, es, es-419, fr, nl, fr-be, fr-fr, nl-be`,
+          message: `La locale doit avoir l'une des valeurs suivantes : en, es, es-419, fr, nl, fr-be, fr-fr, nl-be, it`,
         });
       });
     });

--- a/api/tests/shared/unit/domain/services/locale-service.test.js
+++ b/api/tests/shared/unit/domain/services/locale-service.test.js
@@ -8,7 +8,7 @@ describe('Unit | Shared | Domain | Service | Locale', function () {
       const result = localeService.getSupportedLanguages();
 
       // then
-      expect(result).to.deep.equal(['en', 'es', 'fr', 'nl']);
+      expect(result).to.deep.equal(['en', 'es', 'fr', 'nl', 'it']);
     });
   });
 

--- a/api/translations/it.json
+++ b/api/translations/it.json
@@ -1,0 +1,550 @@
+{
+  "account-recovery-email": {
+    "params": {
+      "choosePassword": "Scegliere una password",
+      "context": "Avete richiesto il recupero del vostro conto Pix.",
+      "doNotAnswer": "Questa è un'e-mail automatica, non rispondete.",
+      "instruction": "Scegliere una password per completare la procedura.",
+      "linkValidFor": "Questo link è valido per 24 ore. Se non siete l'autore della richiesta, ignorate questa e-mail.",
+      "moreOn": "Per saperne di più",
+      "pixPresentation": "Pix è il servizio pubblico online per valutare, sviluppare e certificare le vostre competenze digitali.",
+      "signing": "- Il team Pix"
+    }
+  },
+  "attendance-sheet": {
+    "certification-information": {
+      "date": "Data :",
+      "local-time": "Ora locale (inizio) :",
+      "location-name": "Nome del sito :",
+      "number": "N°",
+      "room-name": "Nome della sede :",
+      "session": "La sessione di certificazione"
+    },
+    "examiner-information": {
+      "invigilated-by": "Monitorato da :",
+      "signature": "Firma(e) :",
+      "title": "Il/i supervisore/i"
+    },
+    "file-name": "scheda di registrazione-sessione-",
+    "header": {
+      "page": "Pagina",
+      "title": "Foglio presenze"
+    },
+    "table": {
+      "birth-name": "Nome di nascita",
+      "date-of-birth": {
+        "example": "(gg/mm/aaaa)",
+        "label": "Data di nascita"
+      },
+      "division": "Classe",
+      "external-id": "Identificatore locale",
+      "first-name": "Nome",
+      "signature": "Firma",
+      "title": "Elenco dei candidati"
+    }
+  },
+  "campaign-export": {
+    "assessment": {
+      "competence-area": {
+        "items-successfully-completed": "Competenze acquisite sul campo {name}",
+        "mastery-percentage": "% di padronanza della conoscenza del dominio {name}",
+        "total-items": "Numero di realizzazioni del profilo di destinazione del dominio {name}"
+      },
+      "is-shared": "Condivisione (S/N)",
+      "mastery-percentage-target-profile": "% di padronanza di tutte le competenze del profilo",
+      "progress": "Aumento %",
+      "shared-on": "Data e ora della condivisione (Europa/Parigi)",
+      "skill": {
+        "items-successfully-completed": "Abilità padroneggiate nell'abilità {name}",
+        "mastery-percentage": "% di padronanza delle competenze acquisite {name}",
+        "total-items": "Numero di risultati ottenuti dal profilo di destinazione nell'abilità {name}."
+      },
+      "started-on": "Data e ora di inizio (Europa/Parigi)",
+      "status": {
+        "ko": "KO",
+        "not-tested": "Non testato",
+        "ok": "OK"
+      },
+      "success-rate": "Cuscinetto ottenuto (/{value})",
+      "target-profile-name": "Corso",
+      "thematic-result-name": "{name} ottenuto (S/N)"
+    },
+    "common": {
+      "campaign-code": "Codice",
+      "campaign-id": "ID Campagne",
+      "campaign-name": "Nome della campagna",
+      "file-name": "Risultati-{name}-{id}-{date}.csv",
+      "no": "No",
+      "not-available": "NA",
+      "organization-name": "Nome dell'organizzazione",
+      "participant-division": "Classe",
+      "participant-firstname": "Nome del partecipante",
+      "participant-group": "Gruppo",
+      "participant-lastname": "Nome del partecipante",
+      "participant-student-number": "Numero dello studente",
+      "yes": "Sì"
+    },
+    "profiles-collection": {
+      "certifiable-skills": "Numero di competenze certificabili",
+      "is-certifiable": "Certificabile (S/N)",
+      "is-sent": "Inviare (S/N)",
+      "pix-score": "Numero totale di pixel",
+      "sent-on": "Data e ora di spedizione (Europa/Parigi)",
+      "skill-level": "Livello per l'abilità {name}",
+      "skill-ranking": "Numero di pixel per l'abilità {name}"
+    }
+  },
+  "candidate-list-template": {
+    "billing-mode": {
+      "free": "Gratuito",
+      "paid": "Pagare",
+      "prepaid": "Prepagato"
+    },
+    "certification": "Certificazione",
+    "complementary": "complementare",
+    "filename": "elenco-candidati-sessione-",
+    "headers": {
+      "birth-date": "* Data di nascita (formato: gg/mm/aaaa)",
+      "birthcity": "Nome del comune",
+      "birthcity-inseecode": "Codice Insee",
+      "birthcity-postcode": "Codice postale",
+      "birthcountry": "Paese",
+      "birthname": "* Nome di nascita",
+      "birthplace": "* Luogo di nascita",
+      "birthplace-instructions": "Istruzioni per la compilazione del luogo di nascita :",
+      "birthplace-instructions-abroad": "- Candidato nato all'estero: compilare le colonne \"Paese\" e \"Nome del comune\" e",
+      "birthplace-instructions-abroad-insee": "       inserire 99 nella colonna \"Codice Insee\".",
+      "birthplace-instructions-france": "- Candidato nato in Francia: inserire Francia nella colonna \"Paese\".",
+      "birthplace-instructions-france-insee": "    - Se codice Insee: compilare solo la colonna \"Codice Insee\".",
+      "birthplace-instructions-france-postal": "    - Se codice postale: compilare le colonne \"Codice postale\" e \"Nome del comune\".",
+      "born-abroad": "Candidato nato all'estero: codice Insee 99 E nome del comune",
+      "born-in-france": "Candidato nato in Francia: codice Insee O codice postale e nome del comune",
+      "candidates": "Partecipanti",
+      "candidates-list": "Elenco dei candidati",
+      "date": "Data",
+      "email-convocation": "Invito via e-mail",
+      "email-results": "Indirizzo e-mail del destinatario dei risultati (formatore, insegnante, ecc.)",
+      "externalid": "Identificatore locale",
+      "extra-time": "Tempo di bonus?",
+      "firstname": "* Nome",
+      "gender": "* Sesso (M o F)",
+      "locale-time": "Ora locale (inizio)",
+      "room-name": "Nome della stanza",
+      "session-certification": "La sessione di certificazione",
+      "session-invigilates-by": "Sessione supervisionata da :",
+      "session-invigilators": "Firma del/i supervisore/i :",
+      "session-number": "Numero della sessione",
+      "site-name": "Nome del sito"
+    },
+    "one-per-candidate": "(solo uno per candidato)",
+    "options": "Possibili opzioni:",
+    "prepayment": "Codice di pagamento anticipato",
+    "pricing": "Prezzi",
+    "pricing-pix": "Prezzo dell'azione Pix",
+    "tooltip-line-1": "(Richiesto in particolare per l'acquisto di crediti combinati)",
+    "tooltip-line-2": "Deve includere il numero SIRET dell'organizzazione e il numero della fattura. Es: 12345678912345/FACT12345",
+    "tooltip-line-3": "Se non si dispone di una fattura, è necessario stabilire un codice di pagamento anticipato con Pix.",
+    "tooltips": {
+      "date-format": "Utilizzare il formato data gg/mm/aaaa",
+      "email-format": "L'e-mail deve contenere una '@' e un '. ,\n Esempio: nom@exemple.fr Questo campo è facoltativo,\n viene utilizzato per facilitare l'invito dei candidati.",
+      "email-results": "Indirizzo e-mail del destinatario dei risultati (formatore, insegnante, ecc.),\n Se il campo non viene compilato, i risultati non verranno inviati via e-mail ai candidati interessati,\n I risultati del candidato saranno visualizzati direttamente sul suo account Pix.",
+      "extra-time": "Campo obbligatorio se il candidato ha diritto a un tempo supplementare per completare la certificazione.\n È previsto un numero intero compreso tra 1 e 99% espresso in percentuale (ad es. 33%).",
+      "gender-format": "M=Maschio F=Femmina"
+    },
+    "yes": "Sì",
+    "yes-or-empty": "(\"sì\" o lasciare in bianco)"
+  },
+  "certification": {
+    "certificate": {
+      "file-metadata": {
+        "title": "Certificazione/i Pix"
+      },
+      "file-name": "certificazione-pix-{deliveredAt}.pdf",
+      "v2": {
+        "competences-content": {
+          "level": "Livello",
+          "title": "Competenze certificate (livelli su {maxReachableLevelOnCertificationDate})"
+        },
+        "complementary-certification-title": "Altre certificazioni ottenute",
+        "description": "Questo documento certifica che Pix",
+        "main-content": {
+          "birth": "Data e luogo di nascita :",
+          "certification-center": "Centro di certificazione :",
+          "delivered-at": "Rilasciato il :",
+          "first-and-last-names": "Nome e cognome :",
+          "from-birthplace": " à",
+          "professionalizing-certification-message": "Il certificato Pix è riconosciuto come qualifica professionale da France Compétences una volta raggiunto un punteggio minimo di 120 PIX."
+        },
+        "not-a-certificate": "Questo documento non è un certificato",
+        "qr-code-content": {
+          "link": {
+            "description": "Utilizzate questo codice sul sito web :",
+            "label": "app.pix.fr/certificato di verifica",
+            "url": "https://app.pix.fr/verification-certificat"
+          },
+          "title": "Verificare l'autenticità della certificazione",
+          "verification-code": "Codice di verifica"
+        },
+        "score-content": {
+          "absolute-max-level-indication": "Quando sono disponibili gli 8 livelli del repository Pix, il numero massimo sarà di 1024 pixel.",
+          "max-reachable-level-indication": "* Alla data di ottenimento di questa certificazione, il numero massimo di pix raggiungibile era { maxReachableScore }, corrispondente al livello { maxReachableLevelOnCertificationDate }."
+        },
+        "signature": "Benjamin Marteau, Direttore di GIP Pix",
+        "title": "Certificato"
+      },
+      "v3": {
+        "complementary-content": {
+          "title": "Certificazione complementare ottenuta :"
+        },
+        "main-content": {
+          "birth": "nato il: {birthdate} a {birthplace}",
+          "certification-center": "Centro di certificazione: {certificationCenter}",
+          "delivered-at": {
+            "date": "il {deliveredAt}",
+            "label": "rilasciato a"
+          },
+          "signature": "Benjamin Marteau, Direttore di GIP Pix",
+          "title": "Certificazione Pix"
+        },
+        "qr-code-content": {
+          "explanation": "Per verificare l'autenticità di questo certificato, utilizzare questo codice all'indirizzo",
+          "link": {
+            "label": "app.pix.fr/certificato di verifica",
+            "url": "https://app.pix.fr/verification-certificat"
+          }
+        },
+        "score-content": {
+          "global-level": "Livello complessivo",
+          "level-explanation": "Il vostro livello significa che :"
+        }
+      }
+    },
+    "global": {
+      "meshlevel": {
+        "LEVEL_ADVANCED_5": {
+          "description": "Siete in grado di utilizzare strumenti specialistici per cercare informazioni in modo affidabile, gestire i social network e modificare immagini e video. Siete in grado di produrre analisi dei dati e rappresentazioni grafiche adeguate. Sapete come impostare un ambiente digitale (installazione e configurazione). Conoscete le problematiche legate al tracciamento e alla raccolta dei dati. Comprendete l'impatto ambientale e sociale dell'uso del digitale e sapete come adattare le vostre pratiche.",
+          "label": "Avanzato 1",
+          "summary": "Avete competenze digitali avanzate e conoscenze solide che vi permettono di affrontare autonomamente nuove situazioni. Siete in grado di aiutare altre persone."
+        },
+        "LEVEL_ADVANCED_6": {
+          "description": "Avete il pieno controllo del vostro ambiente digitale per poter creare e distribuire contenuti, comunicare e collaborare. Sapete come gestire la vostra presenza online e scegliere le impostazioni giuste per le vostre trasmissioni. Siete in grado di programmare e automatizzare alcune attività (elaborazione dei dati, backup, aggiornamento, ecc.). Siete in grado di aiutare gli altri a rendere sicure le loro pratiche e, in particolare, a limitare il loro impatto sull'ambiente e sulla salute.",
+          "label": "Avanzato 2",
+          "summary": "Avete competenze digitali avanzate e conoscenze approfondite che potete mettere a frutto, per voi stessi o per altri, in modo creativo e sicuro. Potete aiutare altre persone a sviluppare le loro competenze."
+        },
+        "LEVEL_BEGINNER_1": {
+          "description": "È in grado di orientarsi nelle interfacce degli strumenti digitali già utilizzati (telefono, tablet, computer). Con un supporto occasionale, è possibile visitare un sito web, leggere e rispondere ai messaggi (SMS, e-mail, ecc.), utilizzare semplici applicazioni sul telefono o sul tablet e accedere ai servizi online.",
+          "label": "Novizio 1",
+          "summary": "Avete pratiche digitali semplici e spesso avete bisogno di aiuto"
+        },
+        "LEVEL_BEGINNER_2": {
+          "description": "Nel vostro ambiente digitale abituale, sapete come cercare informazioni sul web, scaricare un file e ritrovarlo, consultare e inviare messaggi elettronici e collegare i vostri dispositivi a Internet (computer, tablet, telefoni). Sapete inserire un testo con una semplice formattazione e salvarlo. Sa che alcune informazioni pubblicate online sono false e che è importante proteggere i propri account con password sicure.",
+          "label": "Novizio 2",
+          "summary": "Avete a disposizione pratiche digitali semplici, con un aiuto quando il gioco si fa duro."
+        },
+        "LEVEL_EXPERT_7": {
+          "description": "Sarete in grado di analizzare un'esigenza, di consultare la documentazione, anche tecnica, e di valutare le soluzioni digitali per implementare la soluzione più ottimale, o addirittura di sviluppare voi stessi degli strumenti. Comprenderete le questioni economiche, sociali ed etiche associate alle tecnologie digitali e sarete in grado di riflettere criticamente sulle vostre pratiche digitali. Sarete in grado di formarvi su nuove tecniche e di avere una buona conoscenza dei più recenti progressi tecnologici, come quelli resi possibili dall'intelligenza artificiale.",
+          "label": "Esperto 1",
+          "summary": "Disponete di pratiche digitali ottimizzate e di conoscenze specialistiche che vi consentono di affrontare con metodo situazioni complesse e nuove."
+        },
+        "LEVEL_EXPERT_8": {
+          "label": "Esperto 2",
+          "summary": "Siete in grado di documentare le vostre soluzioni a problemi nuovi e specifici in modo da poterle condividere."
+        },
+        "LEVEL_INDEPENDENT_3": {
+          "description": "Sapete navigare in rete per effettuare ricerche approfondite utilizzando informazioni pertinenti. Sapete partecipare ad attività collaborative (e-mail, agenda condivisa, videoritrovi, documenti condivisi). Sapete utilizzare le funzioni più comuni dei software standard (elaborazione testi e fogli di calcolo). Siete consapevoli dei rischi associati alle vostre pratiche digitali e della necessità di proteggerle, nonché dell'impatto ambientale dei vostri usi digitali. Sapete come risolvere i problemi più comuni (password, connessione).",
+          "label": "Indipendente 1",
+          "summary": "Sarete in grado di svolgere autonomamente semplici compiti digitali nella maggior parte delle situazioni quotidiane."
+        },
+        "LEVEL_INDEPENDENT_4": {
+          "description": "Sapete impostare una strategia di ricerca di informazioni sul web e sui social network e verificare l'affidabilità delle informazioni trovate. Siete in grado di utilizzare le principali funzioni degli strumenti di collaborazione e di creare documenti utilizzando diversi software (elaborazione testi, fogli di calcolo, presentazioni, immagini). È possibile attuare pratiche sicure in termini di protezione dei dati personali e dei dispositivi. Potete adattare le vostre pratiche digitali per limitare il loro impatto sull'ambiente e sulla vostra salute.",
+          "label": "Indipendente 2",
+          "summary": "Siete a vostro agio in tutte le situazioni digitali più comuni e avete una buona padronanza del vocabolario associato alle tecnologie digitali."
+        }
+      }
+    }
+  },
+  "certification-center-invitation-email": {
+    "params": {
+      "acceptInvitation": "Accettare l'invito",
+      "doNotAnswer": "Questa è un'e-mail automatica, non rispondete.",
+      "here": "qui",
+      "moreAbout": "Per saperne di più",
+      "needHelp": "Hai bisogno di aiuto? Contattaci",
+      "oneTimeLink": "Questo link è solo per uso singolo",
+      "pixCertifPresentation": "Lo spazio Pix Certif è uno strumento dedicato all'organizzazione di sessioni di certificazione.",
+      "title": "Invito a partecipare allo spazio",
+      "yourCertificationCenter": "Il vostro centro di certificazione"
+    },
+    "subject": "Invito a partecipare a Pix Certif"
+  },
+  "certification-result-email": {
+    "params": {
+      "doNotReply": "Questa è un'e-mail automatica, non rispondete.",
+      "download": "Scarica i risultati",
+      "emailValidFor": "Questo link è valido per 30 giorni.",
+      "findOutMore": "Per saperne di più",
+      "findOutMoreFranceSuffix": " (Francia) o",
+      "findOutMoreInternationalSuffix": " (Internazionale)",
+      "guidelines": "Le segnalazioni del centro di certificazione sono state prese in considerazione, se del caso, dalla giuria Pix. Qui potete trovare informazioni su come interpretare questi risultati.",
+      "guidelinesLinkName": "Interpretazione dei risultati di prescrizione",
+      "overviewText": "Salve, ecco i risultati delle certificazioni che avete prescritto al vostro pubblico",
+      "resultsAvailable": "Sono disponibili i risultati delle certificazioni Pix prescritte al pubblico.",
+      "subject": "[Sessione di certificazione",
+      "viewResultsInProfile": "I candidati possono visualizzare i loro risultati nel loro profilo Pix."
+    },
+    "title": "Vedere i risultati della sessione di certificazione n. {sessionId}!"
+  },
+  "certification-results-csv": {
+    "filenames": {
+      "DIVISION_CERTIFICATION_RESULTS_FILENAME": "{dateWithTime}_results_{division}.csv",
+      "SESSION_CERTIFICATION_RESULTS_FILENAME": "{dateWithTime}_session_results{sessionId}.csv"
+    },
+    "headers": {
+      "BIRTHDATE": "Data di nascita",
+      "BIRTHPLACE": "Luogo di nascita",
+      "CERTIFICATION_CENTER": "Centro di certificazione",
+      "CERTIFICATION_DATE": "Data della certificazione",
+      "CERTIFICATION_LABEL": "Certificazione {label}",
+      "CERTIFICATION_NUMBER": "Numero di certificazione",
+      "EXTERNAL_ID": "Identificatore esterno",
+      "FIRSTNAME": "Nome",
+      "JURY_COMMENT_FOR_ORGANIZATION": "Commenti della giuria sull'organizzazione",
+      "LASTNAME": "Nome",
+      "PIX_SCORE": "Numero di pixel",
+      "REGISTRATION_STATUS": "Stato della registrazione",
+      "SESSION_ID": "Sessione",
+      "SKILL_LABEL": "{skillIndex}",
+      "STATUS": "Stato"
+    },
+    "values": {
+      "CERTIFICATION_CANCELLED": "Annullato",
+      "CERTIFICATION_IN_ERROR": "In errore",
+      "CERTIFICATION_REJECTED": "Rifiutato",
+      "CERTIFICATION_STARTED": "Avviato",
+      "CERTIFICATION_VALIDATED": "Convalidato",
+      "COMPLEMENTARY_CERTIFICATION_CANCELLED": "Annullato",
+      "COMPLEMENTARY_CERTIFICATION_NOT_DONE": "Non superato",
+      "COMPLEMENTARY_CERTIFICATION_REJECTED": "Rifiutato",
+      "COMPLEMENTARY_CERTIFICATION_VALIDATED": "Convalidato",
+      "REJECTED_AUTOMATICALLY_COMMENT": "Il candidato ha risposto in modo errato a più del 50% delle domande, invalidando l'intera certificazione e ottenendo un punteggio di 0 pix."
+    }
+  },
+  "common": {
+    "email": {
+      "contactUs": "contattaci qui",
+      "doNotAnswer": "Questa è un'e-mail automatica, non rispondete.",
+      "moreOn": "Per saperne di più",
+      "pixPresentation": "Pix è il servizio pubblico online per valutare, sviluppare e certificare le vostre competenze digitali."
+    }
+  },
+  "csv-import-values": {
+    "sup-organization-learner": {
+      "diplomas": {
+        "bts": "BTS a controllo statale",
+        "classe-preparatoire": "Classe preparatoria controllata dallo Stato",
+        "dcg ": "DCG a controllo statale",
+        "deust": "DEUSTO controllato dallo Stato",
+        "dma ": "DMA a controllo di stato",
+        "dnmade": "DNMADE a controllo statale",
+        "doctorat": "Diploma di dottorato nazionale controllato dallo Stato",
+        "dts": "SDR a controllo statale",
+        "dut": "DUT a controllo di stato",
+        "etat-controle": "Diploma a controllo statale",
+        "ingenieur": "Laurea in ingegneria a controllo statale",
+        "license": "Laurea nazionale controllata dallo Stato",
+        "license-grade": "Titolo di studio statale che conferisce il grado di licenza",
+        "master": "Diploma di Master nazionale a controllo statale",
+        "master-grade": "Master a controllo statale",
+        "other": "Altro",
+        "vise": "Diploma a controllo statale"
+      },
+      "study-schemes": {
+        "continuous-training": "Formazione continua",
+        "initial-training": "Formazione iniziale, escluso l'apprendistato",
+        "other": "Altro",
+        "training": "Apprendimento"
+      },
+      "unknown": "Non riconosciuto"
+    }
+  },
+  "csv-template": {
+    "organization-learners": {
+      "birth-city": "Nome del comune di nascita** (in francese)",
+      "birth-city-code": "Codice del luogo di nascita** (comune)",
+      "birth-country-code": "Codice del paese di nascita",
+      "birth-province-code": "Codice reparto nascita",
+      "birthdate": "Data di nascita (gg/mm/aaaa)* (se applicabile)",
+      "division": "Divisione",
+      "first-name": "Nome",
+      "last-name": "Cognome* (nome)",
+      "mef-code": "Codice MEF*",
+      "middle-name": "Secondo nome",
+      "national-identifier": "Identificatore univoco",
+      "preferred-last-name": "Nome in uso",
+      "sex": "Codice del sesso",
+      "status": "Stato",
+      "third-name": "Terzo nome"
+    },
+    "sup-organization-learners": {
+      "birthdate": "Data di nascita (gg/mm/aaaa)",
+      "department": "Componente",
+      "diploma": "Diploma",
+      "educational-team": "Team di insegnanti",
+      "email": "Email",
+      "first-name": "Nome",
+      "group": "Gruppo",
+      "last-name": "Nome della famiglia",
+      "middle-name": "Secondo nome",
+      "preferred-lastname": "Nome in uso",
+      "student-number": "Numero dello studente",
+      "study-scheme": "Dieta",
+      "third-name": "Terzo nome"
+    },
+    "template-name": "modello di importazione"
+  },
+  "email-sender-name": {
+    "pix-app": "PIX - Non rispondere",
+    "pix-certif": "Pix Certif - Non rispondere",
+    "pix-orga": "Pix Orga - Non rispondere"
+  },
+  "entity-validation-errors": {
+    "ACCEPT_CGU": "Per creare un account è necessario accettare le condizioni d'uso di Pix.",
+    "ALREADY_REGISTERED_EMAIL": "Questo indirizzo e-mail è già registrato, si prega di effettuare il login.",
+    "CUSTOM_RESULT_PAGE_BUTTON_TEXT_IS_REQUIRED_WHEN_CUSTOM_RESULT_PAGE_BUTTON_URL_IS_FILLED": "Viene inserito un URL per il pulsante: è richiesto anche un testo.",
+    "CUSTOM_RESULT_PAGE_BUTTON_URL_IS_REQUIRED_WHEN_CUSTOM_RESULT_PAGE_BUTTON_TEXT_IS_FILLED": "Viene inserito un testo per il pulsante: è richiesto anche un URL.",
+    "CUSTOM_RESULT_PAGE_BUTTON_URL_MUST_BE_A_URL": "L'URL del pulsante deve essere un URL completo e valido.",
+    "EMPTY_EMAIL": "L'indirizzo e-mail non è stato inserito.",
+    "EMPTY_FIRST_NAME": "Il nome non è compilato.",
+    "EMPTY_INPUT": "Nessun campo è compilato.",
+    "EMPTY_LAST_NAME": "Il vostro nome non è stato inserito.",
+    "EMPTY_USERNAME": "Il nome utente non è stato inserito.",
+    "FILL_USERNAME_OR_EMAIL": "È necessario inserire un indirizzo e-mail e/o un nome utente.",
+    "MAX_SIZE_EMAIL": "L'indirizzo e-mail non deve superare i 255 caratteri.",
+    "MAX_SIZE_FIRST_NAME": "Il nome non deve superare i 255 caratteri.",
+    "MAX_SIZE_LAST_NAME": "Il nome non deve superare i 255 caratteri.",
+    "STAGE_TARGET_PROFILE_IS_REQUIRED": "Il profilo di destinazione è obbligatorio",
+    "STAGE_THRESHOLD_IS_REQUIRED": "La soglia di atterraggio è obbligatoria",
+    "STAGE_TITLE_IS_REQUIRED": "Il titolo del livello è obbligatorio",
+    "WRONG_EMAIL_FORMAT": "Il formato dell'indirizzo e-mail non è corretto."
+  },
+  "jury": {
+    "comment": {
+      "CANCELLED_DUE_TO_LACK_OF_ANSWERS_FOR_TECHNICAL_REASON": {
+        "candidate": "Uno o più problemi tecnici segnalati all'invigilatore durante la sessione di certificazione hanno compromesso la qualità del test di certificazione. Purtroppo, a causa dell'elevato numero di domande a cui non è stato possibile rispondere correttamente, non siamo in grado di calcolare un punteggio affidabile e di rilasciare un certificato. La certificazione sarà annullata e il prescrittore della vostra certificazione (se applicabile) ne sarà informato.",
+        "organization": "Uno o più problemi tecnici, segnalati dal candidato al supervisore della sessione di certificazione, hanno compromesso il regolare svolgimento del test di certificazione. Non siamo in grado di certificare il candidato e la sua certificazione è pertanto annullata. Questa informazione deve essere presa in considerazione e può indurre a proporre una nuova sessione di certificazione per questo candidato."
+      },
+      "CANCELLED_DUE_TO_NEUTRALIZATION": {
+        "candidate": "Uno o più problemi tecnici segnalati all'invigilatore durante la sessione di certificazione hanno compromesso la qualità del test di certificazione. Poiché non è stato possibile rispondere a un numero eccessivo di domande, non è possibile rilasciare la certificazione. La vostra certificazione sarà annullata e il prescrittore della vostra certificazione (se applicabile) ne sarà informato.",
+        "organization": "Uno o più problemi tecnici hanno compromesso il test di certificazione. Non siamo in grado di rilasciare la certificazione, che viene pertanto annullata. Questa informazione può indurre a proporre una nuova sessione di certificazione per questo candidato."
+      },
+      "FRAUD": {
+        "candidate": "Poiché le condizioni in cui avete sostenuto il test di certificazione non sono state rispettate e siete stati denunciati per frode, la vostra certificazione è stata di conseguenza invalidata.",
+        "organization": "È stata rilevata una situazione di frode: dopo l'analisi, abbiamo deciso di rifiutare la certificazione."
+      },
+      "LOWER_LEVEL_COMPLEMENTARY_CERTIFICATION_ACQUIRED": {
+        "candidate": "Congratulazioni, il vostro punteggio vi ha permesso di convalidare la vostra certificazione complementare! Il livello ottenuto corrisponde al livello inferiore a quello per il quale si aveva diritto.",
+        "organization": "Il punteggio del candidato non è stato sufficiente per convalidare la sua certificazione complementare al livello per cui era idoneo. Tuttavia, ha convalidato il livello immediatamente inferiore a questa certificazione complementare. Pertanto, è certificato."
+      },
+      "REJECTED_DUE_TO_INSUFFICIENT_CORRECT_ANSWERS": {
+        "candidate": "Avete risposto in modo errato a più del 50% delle domande, invalidando l'intera certificazione e ottenendo un punteggio di 0 pix.",
+        "organization": "Il candidato ha risposto in modo errato a più del 50% delle domande, invalidando l'intera certificazione e ottenendo un punteggio di 0 pix."
+      },
+      "REJECTED_DUE_TO_LACK_OF_ANSWERS": {
+        "candidate": "Il numero di domande risposte durante il test di certificazione è insufficiente per il rilascio della certificazione Pix.",
+        "organization": "Il numero di domande a cui il candidato ha risposto durante il test di certificazione è insufficiente per il rilascio della certificazione Pix."
+      },
+      "REJECTED_DUE_TO_ZERO_PIX_SCORE": {
+        "candidate": "I risultati ottenuti non consentono ancora di ottenere la certificazione Pix. È necessario progredire per acquisire maggiore dimestichezza con l'ambiente digitale ed essere in grado di promuovere le proprie competenze.",
+        "organization": "I risultati ottenuti da questo candidato non consentono di ottenere la certificazione Pix. Il candidato deve fare ulteriori progressi per essere più a suo agio con l'ambiente digitale ed essere in grado di promuovere le proprie competenze."
+      }
+    }
+  },
+  "jury-certification-summary": {
+    "comment": {
+      "CORE": "Certificazione Pix",
+      "DOUBLE_CORE_CLEA": "Certificazione Dual Pix/CléA Numérique"
+    }
+  },
+  "organization-invitation-email": {
+    "params": {
+      "acceptInvitation": "Accettare l'invito",
+      "doNotAnswer": "Questa è un'e-mail automatica, non rispondete.",
+      "here": "qui",
+      "moreAbout": "Per saperne di più",
+      "needHelp": "Hai bisogno di aiuto? Contattaci",
+      "oneTimeLink": "Questo link è solo per uso singolo",
+      "pixPresentation": "Pix è il servizio pubblico online per valutare, sviluppare e certificare le vostre competenze digitali.",
+      "subtitle": "La piattaforma Pix Orga consente di creare e gestire campagne di test e di monitorare i progressi dei partecipanti.",
+      "title": "Siete invitati a unirvi a Pix Orga",
+      "yourOrganization": "La vostra organizzazione"
+    },
+    "subject": "Invito a partecipare a Pix Orga"
+  },
+  "pix-account-creation-email": {
+    "params": {
+      "askForHelp": "Hai bisogno di aiuto? Contattaci",
+      "disclaimer": "Se non avete creato l'account, potete chiederne la cancellazione.",
+      "doNotAnswer": "Questa è un'e-mail automatica, non rispondete.",
+      "goToPix": "Controlla il mio indirizzo e-mail",
+      "helpdeskLinkLabel": "qui",
+      "moreOn": "Per saperne di più",
+      "pixPresentation": "Pix è il servizio pubblico online per valutare, sviluppare e certificare le vostre competenze digitali.",
+      "subtitle": "Grazie per aver creato il vostro account. Manca ancora un passo per proteggere il vostro account verificando il vostro indirizzo e-mail.",
+      "subtitleDescription": "È molto semplice, basta cliccare sul pulsante qui sotto e accedere al proprio account Pix.",
+      "title": "Ciao {firstName},"
+    },
+    "subject": "Il vostro account Pix è stato creato"
+  },
+  "reset-password-demand-email": {
+    "params": {
+      "clickOnTheButton": "Fare clic sul pulsante sottostante per scegliere una nuova password.",
+      "contactUs": "contattaci qui",
+      "doNotAnswer": "Questa è un'e-mail automatica, non rispondete. Abbiamo bisogno del vostro aiuto,",
+      "linkValidFor": "Questo link è valido per 24 ore. Se non siete l'autore della richiesta, ignorate questa e-mail.",
+      "moreOn": "Per saperne di più",
+      "pixPresentation": "Pix è il servizio pubblico online per valutare, sviluppare e certificare le vostre competenze digitali.",
+      "resetMyPassword": "Impostare una nuova password",
+      "title": "Ripristino della password",
+      "weCannotSendYourPassword": "Salve, per motivi di sicurezza non inviamo la password via e-mail."
+    },
+    "subject": "Richiesta di reimpostazione della password Pix"
+  },
+  "self-account-deletion-email": {
+    "params": {
+      "contactUs": "contattaci qui",
+      "hello": "Ciao {firstName},",
+      "requestConfirmation": "A seguito della vostra richiesta, confermeremo la cancellazione del vostro account Pix e dei vostri dati personali.",
+      "seeYouSoon": "Ci auguriamo di vedervi presto per nuove avventure digitali.",
+      "signing": "Il team Pix",
+      "title": "Eliminazione dell'account",
+      "warning": "Se non siete la fonte di questa richiesta, contattate l'assistenza."
+    },
+    "subject": "Eliminazione dell'account"
+  },
+  "verification-code-email": {
+    "body": {
+      "context": "Desidera modificare l'indirizzo e-mail del suo account. Per continuare, inserire il seguente codice in Pix :",
+      "doNotAnswer": "Questa è un'e-mail automatica, non rispondete.",
+      "greeting": "Salve,",
+      "moreOn": "Per saperne di più",
+      "pixPresentation": "Pix è il servizio pubblico online per valutare, sviluppare e certificare le vostre competenze digitali.",
+      "seeYouSoon": "Ci vediamo presto su Pix.",
+      "signing": "- Il team Pix",
+      "warningMessage": "Se non è stato lei, la preghiamo di reimpostare la password il prima possibile per garantire la sicurezza del suo account."
+    },
+    "subject": "Il codice Pix è {code}."
+  },
+  "warning-connection-email": {
+    "params": {
+      "context": "Abbiamo notato una nuova connessione al vostro account Pix dopo un periodo di inattività di 12 mesi o più.",
+      "disclaimer": "Se la connessione proviene dall'utente, non è necessario intervenire.",
+      "hello": "Ciao {firstName},",
+      "resetMyPassword": "Impostare una nuova password",
+      "signing": "Il team Pix",
+      "supportContact": "In caso di dubbi o domande, il nostro team di assistenza sarà lieto di aiutarvi.",
+      "thanks": "Grazie per la vostra vigilanza,",
+      "warningMessage": "In caso contrario, vi invitiamo a modificare immediatamente la password per proteggere il vostro account facendo clic sul pulsante sottostante:"
+    },
+    "subject": "Attività recenti sul tuo account Pix"
+  }
+}

--- a/certif/app/services/locale.js
+++ b/certif/app/services/locale.js
@@ -16,13 +16,13 @@ export const ENGLISH_INTERNATIONAL_LOCALE = 'en';
 
 const DEFAULT_LANGUAGE = new Intl.Locale(DEFAULT_LOCALE).language;
 
-const PIX_LOCALES = ['en', 'es', 'es-419', 'fr', 'nl', 'fr-BE', 'fr-FR', 'nl-BE'];
+const PIX_LOCALES = ['en', 'es', 'es-419', 'fr', 'nl', 'fr-BE', 'fr-FR', 'nl-BE', 'it'];
 
 // Currently the challenge locales are not in canonical locales, thus the "fr-fr" value.
 // This cannot be changed without migrating the challenges content.
 const PIX_CHALLENGE_LOCALES = ['en', 'fr', 'fr-fr', 'nl', 'es', 'es-419', 'it', 'de'];
 
-const PIX_LANGUAGES = ['fr', 'en', 'nl', 'es'];
+const PIX_LANGUAGES = ['fr', 'en', 'nl', 'es', 'it'];
 
 const COOKIE_LOCALE = 'locale';
 

--- a/certif/app/services/url-base.js
+++ b/certif/app/services/url-base.js
@@ -56,6 +56,7 @@ export const PIX_WEBSITE_ROOT_URLS = {
   en: 'https://pix.org/en',
   es: 'https://pix.org/en',
   'es-419': 'https://pix.org/en',
+  it: 'https://pix.org/en',
   fr: 'https://pix.org/fr',
 };
 
@@ -69,6 +70,7 @@ export const PIX_WEBSITE_PATHS = {
     en: 'terms-and-conditions',
     es: 'terms-and-conditions',
     'es-419': 'terms-and-conditions',
+    it: 'terms-and-conditions',
     fr: 'conditions-generales-d-utilisation',
   },
   LEGAL_NOTICE: {
@@ -79,6 +81,7 @@ export const PIX_WEBSITE_PATHS = {
     en: 'legal-notice',
     es: 'legal-notice',
     'es-419': 'legal-notice',
+    it: 'legal-notice',
     fr: 'mentions-legales',
   },
   DATA_PROTECTION_POLICY: {
@@ -89,6 +92,7 @@ export const PIX_WEBSITE_PATHS = {
     en: 'personal-data-protection-policy',
     es: 'personal-data-protection-policy',
     'es-419': 'personal-data-protection-policy',
+    it: 'personal-data-protection-policy',
     fr: 'politique-protection-donnees-personnelles-app',
   },
   ACCESSIBILITY: {
@@ -99,6 +103,7 @@ export const PIX_WEBSITE_PATHS = {
     en: 'accessibility',
     es: 'accessibility',
     'es-419': 'accessibility',
+    it: 'accessibility',
     fr: 'accessibilite',
   },
   ACCESSIBILITY_ORGA: {
@@ -109,6 +114,7 @@ export const PIX_WEBSITE_PATHS = {
     en: 'accessibility-pix-orga',
     es: 'accessibility-pix-orga',
     'es-419': 'accessibility-pix-orga',
+    it: 'accessibility-pix-orga',
     fr: 'accessibilite-pix-orga',
   },
   ACCESSIBILITY_CERTIF: {
@@ -119,6 +125,7 @@ export const PIX_WEBSITE_PATHS = {
     en: 'accessibility-pix-certif',
     es: 'accessibility-pix-certif',
     'es-419': 'accessibility-pix-certif',
+    it: 'accessibility-pix-certif',
     fr: 'accessibilite-pix-certif',
   },
   SUPPORT: {
@@ -129,6 +136,7 @@ export const PIX_WEBSITE_PATHS = {
     en: 'support',
     es: 'support',
     'es-419': 'support',
+    it: 'support',
     fr: 'support',
   },
   CERTIFICATION_RESULTS_EXPLANATION: {
@@ -139,6 +147,18 @@ export const PIX_WEBSITE_PATHS = {
     en: 'understand-certification-results',
     es: 'understand-certification-results',
     'es-419': 'understand-certification-results',
+    it: 'understand-certification-results',
     fr: 'certification-comprendre-score-niveau',
+  },
+  CERTIFICATION_HOW_TO: {
+    'fr-FR': 'se-certifier',
+    'fr-BE': 'se-certifier',
+    'nl-BE': 'mijn-digitale-vaardigheden-certificeren',
+    nl: 'mijn-digitale-vaardigheden-certificeren',
+    en: 'certify-my-digital-skills',
+    es: 'certify-my-digital-skills',
+    'es-419': 'certify-my-digital-skills',
+    it: 'certify-my-digital-skills',
+    fr: 'se-certifier',
   },
 };

--- a/certif/tests/unit/services/locale-test.js
+++ b/certif/tests/unit/services/locale-test.js
@@ -71,7 +71,7 @@ module('Unit | Services | locale', function (hooks) {
       const pixLocales = localeService.pixLocales;
 
       // then
-      assert.deepEqual(pixLocales, ['en', 'es', 'es-419', 'fr', 'nl', 'fr-BE', 'fr-FR', 'nl-BE']);
+      assert.deepEqual(pixLocales, ['en', 'es', 'es-419', 'fr', 'nl', 'fr-BE', 'fr-FR', 'nl-BE', 'it']);
     });
   });
 
@@ -81,7 +81,7 @@ module('Unit | Services | locale', function (hooks) {
       const pixLanguages = localeService.pixLanguages;
 
       // then
-      assert.deepEqual(pixLanguages, ['fr', 'en', 'nl', 'es']);
+      assert.deepEqual(pixLanguages, ['fr', 'en', 'nl', 'es', 'it']);
     });
   });
 

--- a/mon-pix/app/services/locale.js
+++ b/mon-pix/app/services/locale.js
@@ -16,13 +16,13 @@ export const ENGLISH_INTERNATIONAL_LOCALE = 'en';
 
 const DEFAULT_LANGUAGE = new Intl.Locale(DEFAULT_LOCALE).language;
 
-const PIX_LOCALES = ['en', 'es', 'es-419', 'fr', 'nl', 'fr-BE', 'fr-FR', 'nl-BE'];
+const PIX_LOCALES = ['en', 'es', 'es-419', 'fr', 'nl', 'fr-BE', 'fr-FR', 'nl-BE', 'it'];
 
 // Currently the challenge locales are not in canonical locales, thus the "fr-fr" value.
 // This cannot be changed without migrating the challenges content.
 const PIX_CHALLENGE_LOCALES = ['en', 'fr', 'fr-fr', 'nl', 'es', 'es-419', 'it', 'de'];
 
-const PIX_LANGUAGES = ['fr', 'en', 'nl', 'es'];
+const PIX_LANGUAGES = ['fr', 'en', 'nl', 'es', 'it'];
 
 const COOKIE_LOCALE = 'locale';
 

--- a/mon-pix/app/services/url-base.js
+++ b/mon-pix/app/services/url-base.js
@@ -56,6 +56,7 @@ export const PIX_WEBSITE_ROOT_URLS = {
   en: 'https://pix.org/en',
   es: 'https://pix.org/en',
   'es-419': 'https://pix.org/en',
+  it: 'https://pix.org/en',
   fr: 'https://pix.org/fr',
 };
 
@@ -69,6 +70,7 @@ export const PIX_WEBSITE_PATHS = {
     en: 'terms-and-conditions',
     es: 'terms-and-conditions',
     'es-419': 'terms-and-conditions',
+    it: 'terms-and-conditions',
     fr: 'conditions-generales-d-utilisation',
   },
   LEGAL_NOTICE: {
@@ -79,6 +81,7 @@ export const PIX_WEBSITE_PATHS = {
     en: 'legal-notice',
     es: 'legal-notice',
     'es-419': 'legal-notice',
+    it: 'legal-notice',
     fr: 'mentions-legales',
   },
   DATA_PROTECTION_POLICY: {
@@ -89,6 +92,7 @@ export const PIX_WEBSITE_PATHS = {
     en: 'personal-data-protection-policy',
     es: 'personal-data-protection-policy',
     'es-419': 'personal-data-protection-policy',
+    it: 'personal-data-protection-policy',
     fr: 'politique-protection-donnees-personnelles-app',
   },
   ACCESSIBILITY: {
@@ -99,6 +103,7 @@ export const PIX_WEBSITE_PATHS = {
     en: 'accessibility',
     es: 'accessibility',
     'es-419': 'accessibility',
+    it: 'accessibility',
     fr: 'accessibilite',
   },
   ACCESSIBILITY_ORGA: {
@@ -109,6 +114,7 @@ export const PIX_WEBSITE_PATHS = {
     en: 'accessibility-pix-orga',
     es: 'accessibility-pix-orga',
     'es-419': 'accessibility-pix-orga',
+    it: 'accessibility-pix-orga',
     fr: 'accessibilite-pix-orga',
   },
   ACCESSIBILITY_CERTIF: {
@@ -119,6 +125,7 @@ export const PIX_WEBSITE_PATHS = {
     en: 'accessibility-pix-certif',
     es: 'accessibility-pix-certif',
     'es-419': 'accessibility-pix-certif',
+    it: 'accessibility-pix-certif',
     fr: 'accessibilite-pix-certif',
   },
   SUPPORT: {
@@ -129,6 +136,7 @@ export const PIX_WEBSITE_PATHS = {
     en: 'support',
     es: 'support',
     'es-419': 'support',
+    it: 'support',
     fr: 'support',
   },
   CERTIFICATION_RESULTS_EXPLANATION: {
@@ -139,6 +147,7 @@ export const PIX_WEBSITE_PATHS = {
     en: 'understand-certification-results',
     es: 'understand-certification-results',
     'es-419': 'understand-certification-results',
+    it: 'understand-certification-results',
     fr: 'certification-comprendre-score-niveau',
   },
   CERTIFICATION_HOW_TO: {
@@ -149,6 +158,7 @@ export const PIX_WEBSITE_PATHS = {
     en: 'certify-my-digital-skills',
     es: 'certify-my-digital-skills',
     'es-419': 'certify-my-digital-skills',
+    it: 'certify-my-digital-skills',
     fr: 'se-certifier',
   },
 };

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -41,6 +41,7 @@ module.exports = function (environment) {
       SUPPORTED_LOCALES: [
         { value: 'en', nativeName: 'English', displayedInSwitcher: true },
         { value: 'es', nativeName: 'Español', displayedInSwitcher: false },
+        { value: 'it', nativeName: 'Italiano', displayedInSwitcher: true },
         { value: 'es-419', nativeName: 'Español (Latinoamérica y el Caribe)', displayedInSwitcher: true },
         { value: 'fr', nativeName: 'Français', displayedInSwitcher: true },
         { value: 'fr-FR', nativeName: 'Français (France)', displayedInSwitcher: false },

--- a/mon-pix/tests/unit/services/locale-test.js
+++ b/mon-pix/tests/unit/services/locale-test.js
@@ -71,7 +71,7 @@ module('Unit | Services | locale', function (hooks) {
       const pixLocales = localeService.pixLocales;
 
       // then
-      assert.deepEqual(pixLocales, ['en', 'es', 'es-419', 'fr', 'nl', 'fr-BE', 'fr-FR', 'nl-BE']);
+      assert.deepEqual(pixLocales, ['en', 'es', 'es-419', 'fr', 'nl', 'fr-BE', 'fr-FR', 'nl-BE', 'it']);
     });
   });
 
@@ -81,7 +81,7 @@ module('Unit | Services | locale', function (hooks) {
       const pixLanguages = localeService.pixLanguages;
 
       // then
-      assert.deepEqual(pixLanguages, ['fr', 'en', 'nl', 'es']);
+      assert.deepEqual(pixLanguages, ['fr', 'en', 'nl', 'es', 'it']);
     });
   });
 
@@ -286,6 +286,10 @@ module('Unit | Services | locale', function (hooks) {
         {
           label: 'Français (Belgique)',
           value: 'fr-BE',
+        },
+        {
+          label: 'Italiano',
+          value: 'it',
         },
         {
           label: 'Nederlands (België)',

--- a/mon-pix/translations/it.json
+++ b/mon-pix/translations/it.json
@@ -1,0 +1,2421 @@
+{
+  "api-error-messages": {
+    "join-error": {
+      "r11": "Hai già un account Pix con l'indirizzo e-mail '<br>'{valore }'<br><br>'Per continuare, accedi a questo account o chiedi aiuto a un insegnante.'<br><br>' (Per l'insegnante: vedi il 'Kit di risoluzione dei problemi' in Pix Orga > Documentation - Code R11).",
+      "r12": "Si dispone già di un account Pix utilizzato con l'identificativo nella forma nome.cognome seguito da 4 cifre:'<br>'{valore }'<br><br>'Per continuare, accedere a questo account o chiedere aiuto a un insegnante.'<br><br>'(Per l'insegnante: vedere il 'Kit per la risoluzione dei problemi' in Pix Orga &gt Documentation - Code R12)",
+      "r13": "Hai già un account Pix tramite l'ENT di un'altra scuola.'<br><br>'Per continuare, contatta un insegnante che può darti accesso a questo account usando Pix Orga. '<br><br>' (Per l'insegnante: vedi il 'Kit per la risoluzione dei problemi' in Pix Orga &gt Documentazione - Codice R13)",
+      "r31": "Hai già un account Pix con l'indirizzo e-mail'<br>'{valore }'<br><br>'Per continuare, accedi a questo account o chiedi aiuto a un insegnante.'<br><br>' (Per l'insegnante: vedi il 'Kit per la risoluzione dei problemi' nella Documentazione di Pix Orga &gt - Codice R31)",
+      "r32": "Si dispone già di un account Pix utilizzato con l'identificativo nella forma nome.cognome seguito da 4 cifre:'<br>'{valore }'<br><br>'Per continuare, accedere a questo account o chiedere aiuto a un insegnante.'<br><br>'(Per l'insegnante: vedere il 'Kit di risoluzione dei problemi' in Pix Orga &gt Documentation - Code R32)",
+      "r33": "Avete già un account Pix tramite ENT. Utilizzatelo per iscrivervi al corso.",
+      "r70": "Si è verificato un errore. Esci e riprova.",
+      "r90": {
+        "account-belonging-to-another-user": "Sembra che uno studente stia già utilizzando questo account.",
+        "details": {
+          "code": "(specificando il codice R90)",
+          "contact-support": {
+            "link-text": " contattare l'assistenza",
+            "link-url": "https://support.pix.org/fr/support/tickets/new"
+          },
+          "disconnect-user": "In caso contrario, effettuare il logout e partecipare alla campagna dal proprio account.",
+          "if-account-belonging-to-user": "Se il conto appartiene a voi,"
+        }
+      }
+    },
+    "register-error": {
+      "s50": "Questo identificatore esiste già",
+      "s51": "Hai già un account Pix con l'indirizzo e-mail '<br>'{valore }'<br><br>'Per continuare, accedi a questo account o chiedi aiuto a un insegnante.'<br><br>' (Per l'insegnante: vedi il 'Kit per la risoluzione dei problemi' in Pix Orga > Documentation - Code R51).",
+      "s52": "Hai già un account Pix utilizzato con l'identificativo nella forma nome.cognome seguito da 4 cifre:'<br>'{valore }'<br><br>'Per continuare, accedi a questo account o chiedi aiuto a un insegnante.'<br><br>'(Per l'insegnante: vedi il 'Kit per la risoluzione dei problemi' in Pix Orga > Documentation - Code R52)",
+      "s53": "Hai già un account Pix tramite ENT.'<br> 'Usalo per iscriverti al corso.",
+      "s61": "Hai già un account Pix con l'indirizzo e-mail '<br>'{valore }'<br><br>'Per continuare, accedi a questo account o chiedi aiuto a un insegnante.'<br><br>' (Per l'insegnante: vedi il 'Kit per la risoluzione dei problemi' in Pix Orga > Documentation - Code R61).",
+      "s62": "Si dispone già di un account Pix utilizzato con l'identificativo nella forma nome.cognome seguito da 4 cifre:'<br>'{valore }'<br><br>'Per continuare, accedere a questo account o chiedere aiuto a un insegnante.'<br><br>'(Per l'insegnante: vedere il 'Kit per la risoluzione dei problemi' in Pix Orga > Documentation - Code R62)",
+      "s63": "Hai già un account Pix tramite l'ENT di un'altra scuola.'<br><br>'Per continuare, contatta un insegnante che può darti accesso a questo account usando Pix Orga. '<br><br>' (Per l'insegnante: vedi il 'Kit di risoluzione dei problemi' in Pix Orga > Documentazione - Codice R63)"
+    }
+  },
+  "application": {
+    "description": "Pix è una piattaforma online per la valutazione e la certificazione delle competenze digitali dei cittadini francofoni (alunni, studenti, diplomati, persone in cerca di lavoro, anziani)."
+  },
+  "common": {
+    "actions": {
+      "back": "Torna a",
+      "cancel": "Annullamento",
+      "close": "Chiudere",
+      "confirm": "Confermare",
+      "continue": "Continua",
+      "download": "Scaricare",
+      "lets-go": "Si parte!",
+      "login": "Accesso a Pix",
+      "quit": "Lasciare",
+      "refresh-page": "Aggiorna la pagina",
+      "send": "Inviare",
+      "show-less": "Mostra meno",
+      "show-more": "Vedi di più",
+      "sign-out": "Disconnessione",
+      "stay": "Soggiorno",
+      "validate": "Confermare"
+    },
+    "api-error-messages": {
+      "bad-request-error": "I dati inviati non sono nel formato corretto.",
+      "gateway-timeout-error": "Il servizio sta subendo dei rallentamenti. Si prega di riprovare più tardi.",
+      "internal-server-error": "Si è verificato un errore interno. I nostri team stanno risolvendo il problema. Si prega di riprovare più tardi.",
+      "login-unauthorized-error": "L'indirizzo e-mail o il nome utente e/o la password inseriti non sono corretti.",
+      "login-unauthorized-remaining-attempts-error": "Attenzione: avete ancora {remainingAttempts, plural, =0 {0 tentativi} =1 {1 tentativo} other {# tentativi}} prima che il vostro account Pix venga bloccato definitivamente.",
+      "login-unauthorized-remaining-attempts-with-user-name-error": "Attenzione: hai ancora {remainingAttempts, plural, =0 {0 tentativi} =1 {1 tentativo} other {# tentativi}} prima che il tuo account Pix venga bloccato in modo permanente.'<br>'In caso di dimenticanza, '<strong>'contatta il tuo insegnante'</strong>' per reimpostare la password e/o recuperare l'accesso.",
+      "login-unauthorized-with-user-name-error": "Il nome utente e/o la password inseriti non sono corretti.'<br>'In caso di dimenticanza, '<strong>'contatta il tuo insegnante'</strong>' per reimpostare la password e/o recuperare il nome utente.",
+      "login-unexpected-error": "Impossibile connettersi. Riprovare tra qualche istante. Se il problema persiste, '<'a href=\"{supportHomeUrl}\" target=\"blank\"'>'contattateci tramite il centro assistenza'</a>'.",
+      "login-user-blocked-error": "Il suo account è bloccato perché ha effettuato troppi tentativi di connessione. Per sbloccarlo, '<'a href=\"{url}\"'>'contattaci'</a>'.",
+      "login-user-temporary-blocked-error": "Hai effettuato troppi tentativi di accesso, il tuo account Pix è temporaneamente bloccato per {blockingDurationMinutes} minuti. Riprova più tardi o clicca su '<'a href=\"{url}\"'>'password dimenticata'</a>' per resettarla.",
+      "login-user-temporary-blocked-with-username-error": "Hai effettuato troppi tentativi di accesso, il tuo account Pix è temporaneamente bloccato per {blockingDurationMinutes} minuti.'<br>'In caso di dimenticanza, '<strong>'contatta il tuo insegnante'</strong>' per reimpostare la password e/o recuperare l'accesso."
+    },
+    "cgu": {
+      "cgu": "condizioni di utilizzo",
+      "data-protection-policy": "Informativa sulla privacy",
+      "error": "Per creare un account è necessario accettare le condizioni d'uso e l'informativa sulla privacy di Pix.",
+      "label": "Accetto le condizioni d'uso e l'informativa sulla privacy di Pix",
+      "message": "Accetto le '<'a href=\"{cguUrl}\" class=\"link\" target=\"_blank\" rel=\"noreferrer\"'>'condizioni di utilizzo'</a>' e le '<'a href=\"{dataProtectionPolicyUrl}\" class=\"link\" target=\"_blank\" rel=\"noreferrer\"'>'norme sulla privacy'</a>' di Pix",
+      "read-message": "Leggere le '<'a href=\"{cguUrl}\" class=\"link\" target=\"_blank\" rel=\"noreferrer\"'>'condizioni d'uso'</a>' e le '<'a href=\"{dataProtectionPolicyUrl}\" class=\"link\" target=\"_blank\" rel=\"noreferrer\"'>'norme sulla privacy'</a>'."
+    },
+    "companion": {
+      "check": {
+        "detected": {
+          "description": "Estensione Pix Companion{version}<br />installata e attivata.",
+          "version": " (versione {version})"
+        },
+        "not-detected": {
+          "description": "Estensione Pix Companion non installata/attivata o in una versione obsoleta,<br /> che non è più supportata per l'accesso alla sessione di certificazione.",
+          "link": "Accedere alla documentazione"
+        }
+      },
+      "install-documentation-url": "https://cloud.pix.fr/s/g76RwDwsZmZPZZ6",
+      "not-detected": {
+        "description": "L'estensione potrebbe non essere installata o attivata. Consultare il seguente documento per riprendere la sessione di certificazione. Se necessario, contattare il supervisore.",
+        "link": "Accedere alla documentazione",
+        "title": "L'estensione Pix Companion<br />non è stata rilevata"
+      }
+    },
+    "data-protection-policy-information-banner": {
+      "title": "La nostra politica sulla privacy è cambiata. Vi invitiamo a leggerla:",
+      "url-label": "Politica di protezione dei dati."
+    },
+    "display": {
+      "percentage": "{value, number, ::percent}"
+    },
+    "error": "Si è verificato un errore. Riprovare o contattare l'assistenza.",
+    "form": {
+      "error": "errore",
+      "invisible-password": "nascondere la password",
+      "mandatory": "obbligatorio",
+      "mandatory-all-fields": "Tutti i campi sono obbligatori.",
+      "mandatory-fields": "I campi contrassegnati da '<abbr title=\"mandatory\" class=\"mandatory-mark\">'*'</abbr>' sono obbligatori.",
+      "success": "corretto",
+      "visible-password": "Visualizzazione della password"
+    },
+    "french-education-ministry": "Ministero dell'Istruzione e della Gioventù. Libertà uguaglianza fraternità",
+    "french-republic": "Repubblica francese. Libertà, uguaglianza, fraternità.",
+    "languages": {
+      "en": "Inglese",
+      "fr": "Francese",
+      "nl": "Olandese"
+    },
+    "level": "livello",
+    "loading": {
+      "default": "Caricamento in corso",
+      "results": "Preparazione dei risultati",
+      "test": "Il test è in fase di caricamento"
+    },
+    "new-information-banner": {
+      "close-label": "Chiudere il banner"
+    },
+    "no-level": "Nessun livello",
+    "or": "o",
+    "pagination": {
+      "action": {
+        "next": "Vai alla pagina successiva",
+        "previous": "Vai alla pagina precedente",
+        "select-page-size": "Numero di elementi da visualizzare per pagina"
+      },
+      "page-info": "{start, number}-{end, number} su {total, plural, =0 {0 elementi} =1 {1 elemento} other {{total, number} elementi}}",
+      "page-number": "Pagina {current, number} / {total, number}",
+      "page-results": "{total, plural, =0 {0 elementi} =1 {1 elemento} other {{total, number} elementi}}",
+      "result-by-page": "Vedi"
+    },
+    "password": "Password",
+    "pix": "pix",
+    "skip-links": {
+      "skip-to-content": "Vai al contenuto",
+      "skip-to-footer": "Vai a fondo pagina"
+    },
+    "validation": {
+      "password": {
+        "error": "È stata inserita una password errata. La password deve essere più lunga di 8 caratteri e contenere almeno un numero, una lettera minuscola e una lettera maiuscola.",
+        "rules": {
+          "contains-digit": "una cifra minima",
+          "contains-lowercase": "un minimo",
+          "contains-uppercase": "almeno una lettera maiuscola",
+          "min-length": "8 caratteri minimo"
+        }
+      }
+    }
+  },
+  "components": {
+    "attestations": {
+      "obtainedAt": "Data di emissione: {date}",
+      "title": {
+        "numeric-sensivity": "Certificato di consapevolezza digitale"
+      }
+    },
+    "authentication": {
+      "authentication-identity-providers": {
+        "login": {
+          "heading": "Altri mezzi di connessione",
+          "login-with-featured-identity-provider-link": "Connettersi con {featuredIdentityProvider}"
+        },
+        "select-another-organization-link": "Scegliere un'altra organizzazione",
+        "signup": {
+          "heading": "Altri mezzi di registrazione",
+          "signup-with-featured-identity-provider-link": "Registrazione con {featuredIdentityProvider}"
+        }
+      },
+      "login-form": {
+        "fields": {
+          "login": {
+            "error": "L'indirizzo e-mail o il nome utente non sono stati inseriti."
+          },
+          "password": {
+            "error": "La password non è stata inserita."
+          }
+        }
+      },
+      "new-password-input": {
+        "completed-message": "{ rulesCompleted } su { rulesCount } completato.",
+        "instructions-label": "La password deve essere conforme alle seguenti regole:",
+        "label": "Password"
+      },
+      "oidc-provider-selector": {
+        "label": "Ricerca di un'organizzazione",
+        "placeholder": "Selezionare un'organizzazione",
+        "searchLabel": "Ricerca per parole chiave"
+      },
+      "password-reset-demand-form": {
+        "actions": {
+          "receive-reset-button": "Ricevere un link di ripristino"
+        },
+        "contact-us-link": {
+          "link-text": "Consultare il centro di assistenza"
+        },
+        "fields": {
+          "email": {
+            "error-message-invalid": "L'indirizzo e-mail non è valido.",
+            "label": "Indirizzo e-mail",
+            "placeholder": "Ad esempio, jean.dupont@email.com"
+          }
+        },
+        "no-email-question": "Problemi di connessione a Pix?",
+        "rule": "Tutti i campi sono obbligatori."
+      },
+      "password-reset-demand-received-info": {
+        "heading": "Controllare la posta elettronica",
+        "message": "Se il vostro indirizzo è associato a un account Pix, vi sono state inviate per e-mail le istruzioni per reimpostare la password.",
+        "no-email-received-question": "Non hai ricevuto un'e-mail?",
+        "try-again": "Fare un'altra richiesta"
+      },
+      "password-reset-form": {
+        "actions": {
+          "login": "Voglio connettermi",
+          "submit": "Reimpostare la password"
+        },
+        "errors": {
+          "expired-demand": "Siamo spiacenti, ma la richiesta di reimpostazione della password è già stata utilizzata o è scaduta. Si prega di riprovare.",
+          "forbidden": "Si è verificato un errore, contattare l'assistenza."
+        },
+        "fields": {
+          "password": {
+            "label": "Inserire la nuova password"
+          }
+        },
+        "success-info": {
+          "message": "La password è stata reimpostata."
+        }
+      },
+      "signup-form": {
+        "actions": {
+          "submit": "Desidero registrarmi"
+        },
+        "errors": {
+          "invalid-or-already-used-email": "Indirizzo e-mail non valido o già utilizzato"
+        },
+        "fields": {
+          "email": {
+            "error": "L'indirizzo e-mail non è valido.",
+            "label": "Indirizzo e-mail",
+            "placeholder": "Ad esempio, jean.dupont@email.com"
+          },
+          "firstname": {
+            "error": "Il nome non è compilato.",
+            "label": "Nome",
+            "placeholder": "ex: Jean"
+          },
+          "lastname": {
+            "error": "Il vostro nome non è stato inserito.",
+            "label": "Nome",
+            "placeholder": "ad esempio Dupont"
+          },
+          "legend": "Informazioni necessarie per la registrazione."
+        }
+      },
+      "sso-selection-form": {
+        "should-display-account-recovery-banner": "Sei uno studente? Se non l'avete ancora fatto, '<'a href=\"{url}\"'>'andate alla pagina per recuperare il vostro account Pix'</a>' e salvate i vostri progressi."
+      }
+    },
+    "campaigns": {
+      "attestation-result": {
+        "computing": "Certificato in corso di calcolo",
+        "computing-description": "Un problema tecnico ci ha impedito di informarvi sui vostri risultati. Vi preghiamo di effettuare nuovamente il login domani su Pix, nella sezione \"Il mio corso\", per controllare i vostri risultati. Ci scusiamo per il disagio causato.",
+        "not-obtained": "Certificato non ottenuto :",
+        "obtained": "Certificato ottenuto",
+        "title": {
+          "EDUCOLLAB": "Comunicare collaborare",
+          "EDUCULTURENUM": "Cultura digitale",
+          "EDUDOC": "Adattare i documenti",
+          "EDUIA": "Dati, algoritmi e IA",
+          "EDUINCONTOURNABLES": "I must-have",
+          "EDURESSOURCES": "Gestione e condivisione delle risorse",
+          "EDUSECU": "Sicurezza digitale",
+          "EDUSUPPORT": "Creazione di supporti didattici",
+          "EDUVEILLE": "Monitoraggio",
+          "MAIRIEBUREAU": "Mairie de Paris - Ufficio di base",
+          "MINARM": "Base digitale",
+          "PARENTHOOD": "Consapevolezza digitale",
+          "SIXTH_GRADE": "Consapevolezza digitale"
+        }
+      },
+      "results-loader": {
+        "steps": {
+          "competences": "Calcolo dei punteggi per competenze",
+          "rewards": "Cerimonia di premiazione",
+          "trainings": "Individuare i corsi di formazione utili"
+        },
+        "subtitle": "Solo un momento, per favore! Sarò il più veloce possibile.",
+        "title": "Calcolo del punteggio attuale..."
+      },
+      "start-landing-page": {
+        "steps": {
+          "step1": {
+            "description": "Rispondere a domande adeguate al proprio livello",
+            "title": "Valuta te stesso"
+          },
+          "step2": {
+            "description": "Analizzare i propri punti di forza e le aree di miglioramento",
+            "title": "Scoprite il vostro punteggio"
+          },
+          "step3": {
+            "description": "Accesso a una formazione personalizzata in base ai vostri risultati",
+            "title": "Progredire"
+          }
+        }
+      }
+    },
+    "invited": {
+      "reconciliation": {
+        "error-message": {
+          "date-field": "Si prega di utilizzare il formato gg/mm/aaaa quando si inserisce il campo {fieldName}.",
+          "invalid-reconciliation-error": "Controllare le informazioni ({fields}) o contattare un insegnante.",
+          "mandatory-field": "Compilare il campo {fieldName}."
+        },
+        "field": {
+          "birthdate": "Data di nascita",
+          "firstname": "Nome",
+          "lastname": "Nome",
+          "sub-label": {
+            "date": "In formato (gg/mm/aaaa), ad esempio: {dateFormat}"
+          }
+        },
+        "title": "Aderire all'organizzazione { organizationName }"
+      }
+    },
+    "locale-switcher": {
+      "label": "Selezionare una lingua"
+    }
+  },
+  "navigation": {
+    "back-to-homepage": "Torna alla pagina iniziale",
+    "back-to-profile": "Torna alle competenze",
+    "copyrights": "©",
+    "error": "Errore",
+    "external-link-title": "Aprire in una nuova finestra",
+    "footer": {
+      "a11y": "Accessibilità: parzialmente conforme",
+      "data-protection-policy": "Politica di protezione dei dati",
+      "eula": "Termini e condizioni d'uso",
+      "help-center": "Centro assistenza",
+      "label": "Menu a piè di pagina",
+      "legal-notice": "Informazioni legali",
+      "server-status": "Stato del servizio",
+      "sitemap": "Mappa del sito",
+      "student-data-protection-policy": "Politica di protezione dei dati degli studenti",
+      "student-data-protection-policy-url": "https://pix.fr/politique-protection-donnees-personnelles-app-eleves"
+    },
+    "homepage": "Pagina iniziale di Pix",
+    "main": {
+      "attestations": "I miei certificati",
+      "code": "Ho un codice",
+      "dashboard": "Casa",
+      "help": "Aiuto",
+      "label": "Menu principale",
+      "link-help": "https://pix.fr/support",
+      "skills": "Competenze",
+      "start-certification": "Certificazione",
+      "trainings": "I miei corsi di formazione",
+      "tutorials": "I miei tutorial"
+    },
+    "mobile-button-title": "Aprire il menu",
+    "nav-bar": {
+      "aria-label": "navigazione principale",
+      "close": "Chiudere la navigazione",
+      "open": "Aprire la navigazione"
+    },
+    "not-logged": {
+      "sign-in": "Accedi",
+      "sign-up": "Iscriviti"
+    },
+    "pix": "Pix",
+    "showcase-homepage": "Pix home page { tld }",
+    "user": {
+      "account": "Il mio account",
+      "certifications": "Le mie certificazioni",
+      "sign-out": "Disconnessione",
+      "tests": "I miei percorsi di carriera"
+    },
+    "user-logged-menu": {
+      "details": "Visualizza le mie informazioni"
+    }
+  },
+  "pages": {
+    "account-recovery": {
+      "errors": {
+        "account-exists": "Esiste già un account con questo indirizzo e-mail.",
+        "key-expired": "Il link di recupero è scaduto,",
+        "key-expired-renew-demand-link": "rinnovare la richiesta qui.",
+        "key-invalid": "Il collegamento di recupero non esiste.",
+        "key-used": "Questo conto è già stato recuperato.",
+        "title": "Ops, c'è stato un errore!"
+      },
+      "find-sco-record": {
+        "backup-email-confirmation": {
+          "ask-for-new-email-message": "o fornirne uno nuovo",
+          "email-already-exist-for-account-message": "L'indirizzo e-mail sotto riportato è già associato al vostro account:",
+          "email-is-needed-message": "{ firstName }, ci serve il suo indirizzo e-mail",
+          "email-is-valid-message": "Se valido,",
+          "email-reset-message": "reimpostare la password",
+          "email-sent-to-choose-password-message": "Vi invieremo un'e-mail per scegliere la password.",
+          "form": {
+            "actions": {
+              "cancel": "Annullamento",
+              "submit": "Ecco a voi"
+            },
+            "email": "Il vostro indirizzo e-mail",
+            "error": {
+              "email-already-exist": {
+                "existing-email": "Questo indirizzo e-mail è già in vostro possesso. Se è valido,",
+                "init-password": " reimpostare la password",
+                "new-email": "In caso contrario, inserirne uno nuovo."
+              },
+              "empty-email": "Il campo dell'indirizzo e-mail è obbligatorio.",
+              "invalid-or-already-used-email": "Indirizzo e-mail non valido o già utilizzato",
+              "new-backup-email": "Inserisci un indirizzo e-mail valido per recuperare il tuo account.",
+              "new-email-already-exist": "Questo indirizzo e-mail è già in uso",
+              "wrong-email-format": "L'indirizzo e-mail non è valido."
+            }
+          }
+        },
+        "confirmation-step": {
+          "buttons": {
+            "cancel": "Annullamento",
+            "confirm": "Posso confermare"
+          },
+          "certify-account": "Certifico sul mio onore che il conto associato a questi dati mi appartiene.",
+          "contact-support": "Se notate un errore o se questi dati non sono vostri,",
+          "fields": {
+            "first-name": "Il vostro nome di battesimo",
+            "last-name": "Il tuo nome",
+            "latest-organization-name": "Il vostro ultimo stabilimento",
+            "username": "Il tuo login"
+          },
+          "found-account": "Abbiamo trovato il suo account:",
+          "good-news": "Buone notizie { firstName }!"
+        },
+        "conflict": {
+          "found-you-but": "{ firstName }, ti abbiamo trovato ma...",
+          "title": "Conflitto",
+          "warning": "Per precauzione, dobbiamo verificare insieme i vostri dati."
+        },
+        "contact-support": {
+          "link-text": "contattare l'assistenza.",
+          "link-url": "https://pix.fr/support/form/aide-recuperer-mon-compte"
+        },
+        "send-email-confirmation": {
+          "check-spam": "Se non vedete questa e-mail, controllate la cartella spam.",
+          "return": "Torna a Pix",
+          "send-email": "Le abbiamo appena inviato un'e-mail per consentirle di scegliere una password. Ora può controllare la sua casella di posta elettronica.",
+          "title": "Recupero dell'account Pix"
+        },
+        "student-information": {
+          "errors": {
+            "empty-first-name": "Il campo del nome è obbligatorio.",
+            "empty-ine-ina": "Il campo INE è obbligatorio.",
+            "empty-last-name": "Il campo del nome è obbligatorio.",
+            "invalid-ine-ina-format": "Il campo INE è nel formato sbagliato.",
+            "not-found": "Pix non riconosce i vostri dati. Verificate che siano corretti, altrimenti"
+          },
+          "form": {
+            "birthdate": "Data di nascita",
+            "first-name": "Nome",
+            "ine-ina": "INE (Identifiant National Élève)",
+            "label": {
+              "birth-day": "giorno di nascita",
+              "birth-month": "mese di nascita",
+              "birth-year": "anno di nascita"
+            },
+            "last-name": "Nome",
+            "placeholder": {
+              "birth-day": "JJ",
+              "birth-month": "MM",
+              "birth-year": "AAAA"
+            },
+            "submit": "Venite a trovarmi!",
+            "tooltip": "<strong>Dove posso trovare il mio INE? </strong> <p>Questo identificatore si trova di solito sulla pagella scolastica, altrimenti la scuola precedente può fornirlo per voi.</p>"
+          },
+          "mandatory-all-fields": "Tutti i campi sono obbligatori.",
+          "subtitle": {
+            "link": "reimpostare la password qui.",
+            "text": "Se si dispone di un account con un indirizzo e-mail valido,"
+          },
+          "title": "Avete lasciato il sistema scolastico e volete riottenere l'accesso al sistema Pix."
+        },
+        "title": "Recuperare il mio account"
+      },
+      "support": {
+        "recover": " per l'assistenza.",
+        "url": "https://support.pix.org/fr/support/tickets/new",
+        "url-text": "Contatta l'assistenza"
+      },
+      "update-sco-record": {
+        "fill-password": "Inserisci la tua password e Pix è tuo!",
+        "form": {
+          "authentication-methods-removal-notice": "Dopo questo passaggio, non sarà più possibile connettersi con { connections }.",
+          "choose-password": "Scegliere una password per continuare a godere di Pix.",
+          "email-label": "Indirizzo e-mail",
+          "errors": {
+            "empty-password": "Il campo della password è obbligatorio.",
+            "invalid-password": "La password deve essere lunga almeno 8 caratteri e contenere almeno una lettera maiuscola, una lettera minuscola e un numero."
+          },
+          "login-button": "Voglio connettermi",
+          "new-connection-info": "Non preoccupatevi, per accedere nuovamente è sufficiente utilizzare il vostro indirizzo e-mail e la password che avete impostato qui.",
+          "password-label": "Password",
+          "sco-connections": {
+            "gar": "il Mediacentro",
+            "username": "il vostro tesserino scolastico Pix"
+          }
+        },
+        "welcome-message": "Bentornato { firstName }!"
+      }
+    },
+    "assessment-banner": {
+      "modal": {
+        "actions": {
+          "quit": {
+            "extra-information": "Uscire dalla prova e tornare alla pagina iniziale"
+          }
+        },
+        "content": "Tutti i vostri progressi vengono registrati. Potete riprendere da dove avete lasciato.",
+        "title": "Avete bisogno di una pausa?"
+      },
+      "title": "Test di valutazione :"
+    },
+    "assessment-results": {
+      "actions": {
+        "continue-pix-experience": "Continua la mia esperienza Pix",
+        "return-to-homepage": "Torna alla pagina iniziale"
+      },
+      "answers": {
+        "header": "Le vostre risposte"
+      },
+      "title": "Fine del test"
+    },
+    "attestations": {
+      "subtitle": "Accedere e scaricare tutti i certificati Pix.",
+      "title": "I miei certificati"
+    },
+    "authentication": {
+      "login": {
+        "signup-button": "Iscriviti"
+      },
+      "sso-selection": {
+        "login": {
+          "button": "Voglio connettermi",
+          "message": "Verrete reindirizzati alla pagina di login \"{providerName}\" per identificarvi su Pix."
+        },
+        "signup": {
+          "button": "Desidero registrarmi",
+          "link": "Registrati su",
+          "title": "Non avete un account?"
+        },
+        "title": "Scegliete la vostra organizzazione"
+      }
+    },
+    "autonomous-course": {
+      "landing-page": {
+        "actions": {
+          "sign-in": "Ho già un account, accedo",
+          "start-anonymously": "Inizio senza un account Pix",
+          "start-connected": "Inizio"
+        },
+        "texts": {
+          "first-course": "È il vostro primo tour Pix?",
+          "legal-informations": "Indipendentemente dal fatto che abbiate o meno un account Pix, le informazioni sui vostri progressi ci verranno inviate.'<br>'Queste informazioni vengono utilizzate da Pix per migliorare il servizio.",
+          "title": "Iniziare il corso:"
+        }
+      }
+    },
+    "campaign": {
+      "errors": {
+        "existing-participation": "Il corso non è accessibile a voi.",
+        "existing-participation-info": "Contattate il vostro insegnante per farvi togliere la partecipazione a Pix Orga.",
+        "existing-participation-user-info": "Esiste già una voce associata al nome {lastName} {firstName}",
+        "no-longer-accessible": "Ops, la pagina richiesta non è più accessibile.",
+        "not-accessible": "Ops, la pagina richiesta non è accessibile."
+      }
+    },
+    "campaign-landing": {
+      "assessment": {
+        "action": "Inizio",
+        "announcement": "Registratevi o accedete alla piattaforma Pix e iniziate il vostro test.",
+        "certify": {
+          "description": "A seconda della vostra situazione e a determinate condizioni, potete accedere alla certificazione Pix, riconosciuta dal mondo professionale e che vi permette di migliorare le vostre competenze digitali. Per ulteriori informazioni, contattare l'organizzatore del corso.",
+          "title": "Le risposte convalidate in questo corso contribuiranno al vostro profilo personale di competenze digitali su Pix."
+        },
+        "details": "Durante questo corso, avrete l'opportunità di :",
+        "develop": {
+          "description": "Ogni 5 domande, si vedono le risposte corrette e si ricevono consigli e raccomandazioni personalizzate di esercitazioni per sviluppare le proprie competenze.",
+          "title": "Scoprite i vostri risultati man mano che il test procede e consultate i suggerimenti su come migliorare."
+        },
+        "evaluate": {
+          "description": "Dovrete effettuare ricerche su Internet, utilizzare il vostro ambiente di lavoro digitale, testare le vostre conoscenze, ecc.",
+          "title": "Misurate le vostre competenze digitali con sfide di apprendimento divertenti che si adattano al vostro livello di competenza (utilizzando un algoritmo adattivo)."
+        },
+        "legal": "Cliccando su \"Sto iniziando\", le informazioni sui vostri progressi nel corso saranno inviate all'organizzatore del corso in modo che possa supportarvi. Al termine del corso, i risultati saranno inviati automaticamente all'organizzatore.",
+        "title": "Inizia il tuo viaggio Pix",
+        "title-with-username": "'<span>'{userFirstName}'</span>','<br>' pronti a valutare le vostre competenze digitali?"
+      },
+      "profiles-collection": {
+        "action": "Si parte!",
+        "announcement": "Registratevi o accedete alla piattaforma Pix e inviate il vostro profilo all'organizzazione destinataria.",
+        "legal": "Le informazioni relative al vostro profilo PIX saranno inviate all'organizzatore per consentirgli di accompagnarvi. Saranno trasmesse solo con il vostro consenso.",
+        "title": "Invia il tuo profilo",
+        "title-with-username": "'<span>'{userFirstName}'</span>','<br>' invia il tuo profilo"
+      },
+      "title": "Presentazione",
+      "warning-message": "Non sei { firstName } { lastName }?",
+      "warning-message-logout": "Disconnessione"
+    },
+    "campaign-participation": {
+      "title": "Corso"
+    },
+    "campaign-participation-overview": {
+      "card": {
+        "finished-at": "Completato su {date}",
+        "results": "{result, number, ::percent} di successo",
+        "resume": {
+          "extra-information": "Riprendere il percorso {campaignTitle}.",
+          "information": "Il curriculum"
+        },
+        "retry": "Migliorare me stesso",
+        "see-more": "Vedi dettagli",
+        "stages": "{count} { count, plural, =0 {stella} =1 {stella} other {stella} } su {total}",
+        "started-at": "Avviato su {date}",
+        "tag": {
+          "deleted": "Inattivo",
+          "disabled": "Inattivo",
+          "finished": "Completato",
+          "started": "In corso"
+        },
+        "text-deleted": "Percorso disattivato dalla propria organizzazione.'<br> 'Non è più possibile agire su questo percorso.",
+        "text-disabled": "Corso disattivato dalla propria organizzazione.'<br> 'Non è più possibile inviare i risultati."
+      },
+      "title": "Corso"
+    },
+    "certificate": {
+      "actions": {
+        "download-attestation": "Scarica il mio certificato",
+        "download-certificate": "Scarica il mio certificato"
+      },
+      "back-link": "Torniamo alle mie certificazioni",
+      "candidate": "Candidato :",
+      "candidate-birth": "Nato il {birthdate}",
+      "candidate-birth-complete": "Nato su {birthdate} in {birthplace}.",
+      "certification-center": "Centro di certificazione :",
+      "certification-date": "Data della visita :",
+      "certification-value": {
+        "paragraphs": {
+          "1": "Riconosciuta ufficialmente, la Certificazione Pix attesta la vostra padronanza delle competenze digitali. Entrerete a far parte di una comunità di milioni di utenti certificati. Congratulazioni per questa pietra miliare della vostra carriera!",
+          "2": "Il vostro punteggio certificato è stato calcolato sulla base delle vostre risposte durante il processo di certificazione. Può quindi differire dal numero di pixel indicato nel vostro profilo.",
+          "3": "Il giorno della certificazione è stato possibile raggiungere il livello 7 e un massimo di 895 pix (livello Expert 1)."
+        }
+      },
+      "competences": {
+        "information": "Il vostro punteggio certificato è stato calcolato sulla base delle vostre risposte durante il processo di certificazione. Può quindi differire dal numero di Pix visualizzato nel vostro profilo. Il giorno della certificazione era possibile raggiungere il livello {maxReachableLevelOnCertificationDate} di competenze e {maxReachablePixCountOnCertificationDate} pix al massimo."
+      },
+      "complementary": {
+        "alternative": "Certificazione complementare",
+        "clea": "Certificazione CléA Numérique di Pix",
+        "title": "Altre certificazioni ottenute"
+      },
+      "congratulations": "Congratulazioni!",
+      "delivered-at": "Data di emissione :",
+      "details": {
+        "competences": {
+          "description": "Il punteggio Pix fornisce una stima del vostro livello nelle 16 abilità numeriche.",
+          "title": "Il vostro profilo di competenze digitali"
+        }
+      },
+      "exam-date": "Data della visita :",
+      "global": {
+        "explanation": {
+          "default": "Avete raggiunto il livello {globalLevelLabel} della Certificazione Pix!",
+          "pre-beginner-level": "Avete completato il test di certificazione Pix, ma i vostri risultati non vi consentono di ottenere il primo livello."
+        },
+        "labels": {
+          "advanced": "Avanzato",
+          "beginner": "Novizio",
+          "expert": "Esperto",
+          "independent": "Indipendente",
+          "level": "Il vostro livello"
+        },
+        "progress-bar-explanation": {
+          "default": "Barra di avanzamento che mostra il livello raggiunto ({level}, o livello {globalLevelLabel}) su un livello massimo raggiungibile di 7 (livello Esperto 1).",
+          "pre-beginner-level": "Barra di avanzamento che indica il livello massimo che può essere raggiunto nella certificazione (ad es. 7 o Expert 1 livello)"
+        }
+      },
+      "hexagon-score": {
+        "certified": "certificato"
+      },
+      "issued-on": "Rilasciato il",
+      "jury-info": "Le osservazioni della giuria non vengono condivise nella pagina di verifica del certificato.",
+      "jury-title": "Commenti della giuria",
+      "learn-about-certification-results": "Come vanno interpretati i risultati?",
+      "professionalizing-warning": "Il certificato Pix è riconosciuto come qualifica professionale da France Compétences una volta raggiunto un punteggio minimo di 120 pix.",
+      "title": "Certificato Pix",
+      "verification-code": {
+        "alt": "Copia",
+        "copied": "Codice copiato!",
+        "copy": "Copiare il codice",
+        "information": "Il vostro codice di verifica univoco",
+        "share": "Condividi il tuo certificato",
+        "title": "Codice di verifica",
+        "tooltip": "Fornite questo codice per consentire a terzi di verificare l'autenticità del vostro certificato."
+      }
+    },
+    "certification-ender": {
+      "candidate": {
+        "disconnect": "Esci dal mio account",
+        "disconnect-tip": "Se non si tratta del vostro computer, ricordatevi di disconnettervi.",
+        "ended-by-invigilator": "L'esaminatore ha interrotto il test di certificazione. Non è possibile continuare a rispondere alle domande.",
+        "ended-due-to-finalization": "La sessione è stata conclusa dal centro di certificazione. Non è più possibile continuare a rispondere alle domande.",
+        "remote-certification": "Se si sta eseguendo la certificazione Pix in remoto, assicurarsi di disconnettersi dallo strumento di monitoraggio una volta completato il test.",
+        "title": "Test completato!"
+      },
+      "results": {
+        "disclaimer": "I risultati, in attesa della convalida da parte dei team Pix, saranno presto disponibili sul vostro account Pix.",
+        "step-1": "Accedere al proprio account Pix e trovare i risultati nella sezione \"Le mie certificazioni\" (accessibile cliccando sul proprio nome nell'angolo in alto a destra dello schermo).",
+        "step-2": "Potete scaricare il vostro certificato e condividerlo, oppure inviarci il codice di verifica da utilizzare sul sito web di Pix.",
+        "title": "Come posso visualizzare e condividere i risultati della mia certificazione?"
+      }
+    },
+    "certification-instructions": {
+      "buttons": {
+        "continuous": {
+          "aria-label": "Continuare con la schermata successiva",
+          "label": "Continua",
+          "last-page": {
+            "aria-label": "Proseguire con la pagina di inserimento della certificazione"
+          }
+        },
+        "previous": {
+          "aria-label": "Ritorno alla schermata precedente",
+          "label": "Precedente"
+        }
+      },
+      "steps": {
+        "1": {
+          "paragraphs": {
+            "1": "La certificazione {certificationName} è un test \"<strong>adattivo\"</strong> per valutare il vostro livello nel \"<strong>quadro di riferimento delle 16 competenze digitali del Pix\"</strong>.",
+            "2": "La \"<strong>difficoltà delle domande si adatta in tempo reale\"</strong> in base alle risposte fornite.",
+            "3": "Se alcune domande sembrano difficili, è perché il test di certificazione cerca di misurare il vostro livello massimo. Se non siete in grado di rispondere a una domanda, avete la possibilità di \"saltarla\": non verrà riproposta durante la certificazione e non sarà convalidata.",
+            "4": "Per ottenere un punteggio il più vicino possibile alle proprie capacità \"<strong>è necessario arrivare alla fine del test\"</strong>.",
+            "pix-plus-1": "La certificazione {certificationName} è un '<strong>'test adattivo'</strong>' per valutare il livello del candidato sull’'<strong>'insieme di competenze del quadro di riferimento della certificazione {certificationName}'</strong>'."
+          },
+          "question": "Come funziona il test?",
+          "title": "Benvenuti alla certificazione {certificationName}."
+        },
+        "2": {
+          "legend": {
+            "strong-text": "32 DOMANDE"
+          },
+          "paragraphs": {
+            "1": "Il test di certificazione consiste in \"<strong>32 domande\"</strong>\".",
+            "2": "Avete un massimo di '<strong>'{durata}'</strong>' per rispondere*.",
+            "3": "*escluso il tempo supplementare",
+            "4": "Se si completano '<strong>'meno di 20 domande, non sarà possibile assegnare un punteggio'</strong>'."
+          },
+          "title": "Come funziona il test di certificazione?"
+        },
+        "3": {
+          "images": {
+            "focus-challenge": "Modalità di messa a fuoco",
+            "regular-challenge": "Modalità libera"
+          },
+          "paragraphs": {
+            "1": {
+              "text": "Per le domande in '<strong>'modalità libera'</strong>' contrassegnate da un'icona verde: sarà possibile effettuare ricerche sul web e utilizzare l'ambiente digitale disponibile.'<br>'Tuttavia, '<strong>'alcuni siti non saranno accessibili nella certificazione'</strong>'.",
+              "title": "Modalità libera :"
+            },
+            "2": {
+              "text": "Per le domande in \"<strong>modalità focus\"</strong>, indicate da un'icona gialla: non sarà possibile lasciare la pagina e cercare.",
+              "title": "Modalità di messa a fuoco :"
+            }
+          },
+          "title": "Due tipi di domande"
+        },
+        "4": {
+          "list": {
+            "1": "Andare in fondo alla pagina",
+            "2": "Selezionare \"Segnala un problema con la domanda\".",
+            "3": "Fare clic su \"Sì, sono sicuro\".",
+            "4": "Chiamate il supervisore che interverrà per aiutarvi."
+          },
+          "text": "'<strong>'In caso di problemi tecnici'</strong> (ad esempio, l'immagine si rifiuta di essere visualizzata), seguire questi passaggi:",
+          "title": "Cosa fare in caso di problemi?"
+        },
+        "5": {
+          "checkbox-label": "Selezionando questa casella, dichiaro di aver letto il presente regolamento e mi impegno a rispettarlo.",
+          "list": {
+            "1": "'<strong>'Comunicare con qualcun altro'</strong>', all'interno o all'esterno della stanza, con mezzi fisici o elettronici.",
+            "2": "'<strong>'Utilizzare un telefono cellulare o qualsiasi dispositivo elettronico collegato'</strong>' (diverso dal computer su cui si sta prendendo la certificazione).",
+            "3": "'<strong>'Utilizzare un sistema di intelligenza artificiale'</strong>' o un chatbot.",
+            "4": "'<strong>'Consultare un forum di auto-aiuto'</strong>' fornendo direttamente la risposta a una domanda.",
+            "5": "'<strong>'Mobilitare qualsiasi altro mezzo che fornisca direttamente la risposta alla domanda'</strong>', senza aver svolto il lavoro richiesto dall'istruzione.",
+            "6": "'<strong>'Usa un browser diverso'</strong>' rispetto a quello su cui si sta eseguendo il test di certificazione {certificationName}.",
+            "7": "'<strong>'Impersonare'</strong>' un'altra persona."
+          },
+          "pix-companion": "L'accesso a determinati siti è vietato nell'ambito del test di certificazione, grazie a un'estensione installata sul browser. Qualsiasi frode accertata (tentativo di aggirare l'estensione o mancato rispetto dei comportamenti sopra elencati) può comportare l'invalidazione della certificazione.",
+          "text": "Nella certificazione è vietato :",
+          "title": "Regole da rispettare"
+        }
+      },
+      "title": "Spiegazione della certificazione",
+      "vocal-step-identifier": "Pagina {pageId} su {pageCount}."
+    },
+    "certification-joiner": {
+      "congratulation-banner": {
+        "double-certification": {
+          "eligible": "È inoltre possibile ottenere una certificazione complementare:",
+          "outdated": "<strong>Non sei più eleggibile per la certificazione {doubleCertificationName} in seguito alla sua evoluzione.</strong><br />Contatta la tua scuola o l'organizzazione che ti ha offerto il corso per riprendere una campagna e tornare così eleggibile. I tuoi progressi sono stati conservati e non devi fare altro che giocare ai nuovi eventi, che dovrebbero essere veloci."
+        },
+        "link": {
+          "text": "Come si ottiene la certificazione?"
+        },
+        "message": "Congratulazioni {fullName}, il vostro profilo Pix è certificabile."
+      },
+      "error-messages": {
+        "generic": {
+          "check-personal-info": "Verificare con il supervisore che i propri dati personali corrispondano a quelli riportati sul foglio di registrazione.",
+          "check-session-number": "Controllare il numero della sessione.",
+          "disclaimer": "Le informazioni inserite non corrispondono a nessun candidato iscritto alla sessione."
+        },
+        "language-not-supported": "La certificazione Pix non è ancora disponibile in {userLanguage}. '<br>' Le lingue attualmente disponibili per ottenere la certificazione sono: {availableLanguages}. '<br>' È possibile scegliere un'altra lingua dalla pagina",
+        "language-not-supported-link": "Il mio account",
+        "missing-center-habilitation": "Non è possibile partecipare alla sessione. Il centro di certificazione non è autorizzato a rilasciare questa certificazione.",
+        "session-not-accessible": "La sessione a cui si sta cercando di accedere non è più accessibile.",
+        "wrong-account": "Le informazioni inserite corrispondono a un candidato registrato per la sessione e già loggato con un altro account. Verificare di aver effettuato l'accesso con l'account che ha avviato la certificazione.",
+        "wrong-account-sco": "Si sta utilizzando un account non collegato alla propria scuola.\nAccedete all'account con cui avete completato i corsi o chiedete aiuto al vostro supervisore.",
+        "wrong-account-sco-link": {
+          "label": "Come faccio a trovare il conto collegato allo stabilimento?",
+          "url": "https://pix.fr/support/enseignement-scolaire/enseignant-ou-personnel-de-direction/que-faire-si-une-eleve-ne-parvient-pas-rejoindre-sa-session-de-certification"
+        },
+        "wrong-domain-for-pix-plus": "Poiché al momento le certificazioni Pix+ sono disponibili solo in francese, non sono disponibili su https://pix.org.<br/>Si prega di effettuare il logout e di accedere nuovamente tramite '<a href=\"https://app.pix.fr/connexion\">questo link.</a>'."
+      },
+      "first-title": "Partecipare a una sessione",
+      "form": {
+        "actions": {
+          "submit": "Continua"
+        },
+        "fields": {
+          "birth-date": "Data di nascita",
+          "birth-day": "giorno di nascita (DD)",
+          "birth-month": "mese di nascita (MM)",
+          "birth-name": "Nome di nascita",
+          "birth-year": "anno di nascita (YYYY)",
+          "first-name": "Nome",
+          "session-number": "Numero della sessione",
+          "session-number-information": "Comunicata solo dall'invigilatore all'inizio della sessione."
+        },
+        "fields-validation": {
+          "session-number-error": "Il numero di sessione è composto solo da numeri."
+        },
+        "placeholders": {
+          "birth-day": "JJ",
+          "birth-month": "MM",
+          "birth-name": "ad esempio Dupont",
+          "birth-year": "AAAA",
+          "first-name": "ex: Jean",
+          "session-number": "ex: 123456"
+        }
+      },
+      "title": "Partecipare a una sessione di certificazione"
+    },
+    "certification-not-certifiable": {
+      "action": {
+        "back": "Torna alla pagina iniziale"
+      },
+      "text": "Per ottenere la certificazione del proprio profilo, è necessario aver raggiunto un livello superiore a 0 in almeno 5 competenze.",
+      "title": "Il vostro profilo non è ancora certificabile."
+    },
+    "certification-results": {
+      "action": {
+        "confirm": "Posso confermare",
+        "logout": "Disconnessione"
+      },
+      "finished": {
+        "description": "I risultati saranno presto disponibili nel vostro account.",
+        "title": "Bravo, è finita!",
+        "warning-text": "Se non si tratta del vostro computer, ricordatevi di disconnettervi."
+      },
+      "flag-alt": "Bandiera",
+      "title": "Test completato"
+    },
+    "certification-start": {
+      "access-code": "Codice di accesso fornito dal supervisore",
+      "actions": {
+        "submit": "Avviare il test"
+      },
+      "cgu": {
+        "contact": {
+          "email": "dpo@pix.fr",
+          "info": "Ai sensi della legge francese sulla protezione dei dati, potete esercitare il diritto di accesso e rettifica dei vostri dati personali inviando un'e-mail a"
+        },
+        "info": "Cliccando su \"Inizia il mio test\", accetto che i miei dati di identità, il numero di certificazione e le circostanze del test, così come sono stati inseriti dall'invigilatore, vengano trasmessi a Pix. Pix utilizzerà queste informazioni durante le deliberazioni della giuria per produrre e archiviare i miei risultati e per rilasciare il mio certificato. Se questa certificazione è stata prescritta da un'organizzazione, accetto che Pix possa comunicare i miei risultati a quest'ultima."
+      },
+      "core-and-complementary-subscriptions": "Oltre alla certificazione Pix, siete iscritti alle seguenti certificazioni complementari:",
+      "error-messages": {
+        "access-code-error": "Questo codice non esiste o non è più valido.",
+        "candidate-not-authorized-to-resume": "Si prega di contattare il proprio assistente per autorizzare la ripresa della prova.",
+        "candidate-not-authorized-to-start": "L'esaminatore non ha confermato la vostra presenza nell'aula d'esame. Pertanto, non è ancora possibile iniziare il test di certificazione. Si prega di informare l'esaminatore.",
+        "generic": "Si è appena verificato un errore inatteso del server.",
+        "missing-code": "Il codice di accesso non è stato inserito.",
+        "session-not-accessible": "La sessione di certificazione non è più accessibile.",
+        "unknown": {
+          "summary-label": "Visualizza altri dettagli:"
+        }
+      },
+      "first-title": "State per iniziare il test di certificazione",
+      "link-to-user-certification": "Vedi le mie certificazioni",
+      "non-eligible-subscription": "Non si ha diritto a {complementarySubscriptionLabel}. È tuttavia possibile ottenere la certificazione Pix.",
+      "title": "Partecipare a una sessione di certificazione"
+    },
+    "certifications-list": {
+      "buttons": {
+        "details": "Vedi dettagli",
+        "download-attestation": "Scarica il certificato",
+        "download-certificate": "Scarica il certificato"
+      },
+      "comment": "Commento:",
+      "description": "Accedi a tutte le tue certificazioni Pix. Visualizza i dettagli e scarica i tuoi certificati.",
+      "information": {
+        "certification-center": "Centro di certificazione :",
+        "date": "Data della visita :"
+      },
+      "no-certification": {
+        "text": "Non si dispone ancora della certificazione Pix"
+      },
+      "statuses": {
+        "cancelled": "Annullato",
+        "not-published": "In attesa dei risultati",
+        "rejected": "Non ottenuto",
+        "validated": "Ottenuto"
+      },
+      "title": "Le mie certificazioni"
+    },
+    "challenge": {
+      "actions": {
+        "continue": "Continua",
+        "continue-go-to-next": "Passo alla prossima domanda",
+        "skip": "Passo",
+        "skip-go-to-next": "Passo alla prossima domanda",
+        "validate": "Convalido",
+        "validate-go-to-next": "Convalido e passo alla domanda successiva",
+        "wait-for-invigilator": "Le azioni sono sospese fino all'arrivo del supervisore."
+      },
+      "already-answered": "Avete già risposto a questa domanda",
+      "answer-input": {
+        "numbered-label": "Risposta {number}"
+      },
+      "certification": {
+        "banner": {
+          "certification-number": "Numero di certificazione"
+        },
+        "title": "Certificazione {certificationNumber}"
+      },
+      "certification-feedback-panel": {
+        "actions": {
+          "no-send-feedback": "No, torno al test...",
+          "open-close": "Segnalare un problema con la domanda",
+          "send-feedback": "Sì, sono sicuro"
+        },
+        "description": "Siete sicuri di voler segnalare un problema?",
+        "information": "Quando si segnala un problema, la certificazione viene messa in pausa finché il supervisore non interviene per convalidare o invalidare la segnalazione."
+      },
+      "embed-simulator": {
+        "actions": {
+          "launch": "Inizio",
+          "launch-label": "Avvio della simulazione",
+          "reset": "Reset",
+          "reset-label": "Azzeramento della simulazione"
+        },
+        "placeholder": "Caricamento dell'applicazione corrente"
+      },
+      "feedback-panel": {
+        "actions": {
+          "open-close": "Segnalare un problema con la domanda"
+        },
+        "description": "Pix è sempre desideroso di ascoltare i vostri commenti su come migliorare i test offerti!",
+        "form": {
+          "actions": {
+            "submit": "Inviare",
+            "submit-aria-label": "Invia il mio messaggio"
+          },
+          "fields": {
+            "category-selection": {
+              "label": "Ho un problema con",
+              "options": {
+                "accessibility": "Accessibilità del test",
+                "answer": "La risposta",
+                "download": "Il file da scaricare",
+                "embed": "Il simulatore/applicazione",
+                "link": "Il link indicato nella domanda",
+                "other": "Altro",
+                "picture": "L'immagine",
+                "question": "La domanda",
+                "tutorial": "Il tutorial"
+              }
+            },
+            "detail-selection": {
+              "add-comment": "Aggiungi un commento",
+              "aria-first": "Ho un problema con",
+              "aria-secondary": "Selezionare un'opzione per specificare il problema",
+              "label": "Selezionare un'opzione per specificare il problema",
+              "options": {
+                "answer-not-accepted": "La mia risposta è corretta, ma non è stata convalidata.",
+                "answer-not-agreed": "Non sono d'accordo con la risposta",
+                "download": {
+                  "edit-failure": {
+                    "label": "Non riesco a modificare il",
+                    "solution": "Il file è probabilmente aperto in \"sola lettura\" o in \"modalità protetta\". '<br>'Fare clic su \"Abilita modifica\" o \"Modifica documento\" nel banner in cima al file, se appare. '<br>'Altrimenti salvare il file con un altro nome e aprire questo nuovo file."
+                  },
+                  "lost": {
+                    "label": "Non riesco a trovare il file scaricato",
+                    "solution": "Per impostazione predefinita, un file scaricato viene salvato nella cartella \"Download\". Può anche essere scaricato nella stessa posizione dell'ultimo download..."
+                  },
+                  "open-failure": {
+                    "label": "Non riesco ad aprire il file su un computer",
+                    "solution": "Se non si riesce ad aprire un file, consultare '<a href=\"https://pix.org/fr/aide-ouvrir-modifier-retrouver-un-fichier-telecharge-depuis-une-question-pix\">'la guida situata sotto il pulsante \"Download\"'</a>'. Lì troverete il software o gli strumenti online consigliati."
+                  },
+                  "other": "Ho un altro problema con il"
+                },
+                "embed-displayed-on-desktop-with-problems": {
+                  "label": "Su un computer, il simulatore viene visualizzato ma presenta un problema",
+                  "solution": "Facciamo del nostro meglio per garantire che i simulatori funzionino su tutti i dispositivi, tutti i sistemi operativi e tutti i browser, ma è possibile che stiate utilizzando un sistema particolare. Potete fermarvi qui e ricominciare da un computer.'<br>'Specificate il vostro problema indicando il browser e il sistema operativo."
+                },
+                "embed-displayed-on-mobile-devices-with-problems": {
+                  "label": "Su un telefono o un tablet, il simulatore viene visualizzato ma presenta un problema",
+                  "solution": "Facciamo del nostro meglio per garantire che i simulatori funzionino su tutti i dispositivi, tutti i sistemi operativi e tutti i browser, ma è possibile che stiate utilizzando un sistema particolare.'<br>'Specificate il vostro problema indicando il tipo di dispositivo (smartphone, tablet...), il sistema operativo e il browser."
+                },
+                "embed-not-displayed": {
+                  "label": "Il simulatore/applicazione non viene visualizzato",
+                  "solution": "La connessione Internet potrebbe essere troppo debole.'<br>'Ricaricare la pagina premendo il pulsante di aggiornamento '<img class=\"tuto-icon\" src=\"/images/icons/icon-reload.svg\" alt=\"\" />' accanto alla barra degli indirizzi. Attendere un attimo e il simulatore potrebbe apparire. '<br><br>'In caso contrario, potete riprovare in un altro momento o da un'altra postazione con una connessione migliore?"
+                },
+                "embed-other": "Il simulatore/applicazione presenta un altro problema",
+                "link-other": "Il link non funziona o presenta un altro problema",
+                "link-unauthorized": {
+                  "label": "Il link è bloccato dalla mia organizzazione/istituzione...",
+                  "solution": "Potreste appartenere a un'organizzazione (scuole, università, aziende, dipartimenti governativi, associazioni, ecc.) che protegge i propri utenti e le proprie apparecchiature limitando le pagine Internet a cui avete accesso.'<br>'"
+                },
+                "other-challenge-proposal": "Ho un'idea (brillante) per un test da suggerire",
+                "other-difficulty": "Ho un altro problema",
+                "other-site-improvement": "Ho un suggerimento per migliorare la piattaforma",
+                "picture-not-displayed": {
+                  "label": "L'immagine non viene visualizzata",
+                  "solution": "La connessione a Internet potrebbe essere troppo debole.'<br>'Ricaricare la pagina premendo il pulsante di aggiornamento '<img class=\"tuto-icon\" src=\"/images/icons/icon-reload.svg\" alt=\"\" />' accanto alla barra degli indirizzi. Attendere un attimo e l'immagine potrebbe apparire. '<br><br>'In caso contrario, potete riprovare in un altro momento o da un'altra postazione con una connessione migliore?"
+                },
+                "picture-other": "L'immagine presenta un altro problema",
+                "question-improvement": "Vorrei proporre un miglioramento alla domanda",
+                "question-not-understood": "Non capisco la domanda",
+                "tutorial-link-error": "Il link al tutorial porta a un'altra pagina o a una pagina di errore.",
+                "tutorial-not-accepted": "Il tutorial non è adatto",
+                "tutorial-proposal": "Ho un tutorial per voi"
+              },
+              "problem-suggestion-description": "Descrivete il vostro problema o suggerimento"
+            }
+          },
+          "status": {
+            "error": {
+              "empty-message": "È necessario inserire un messaggio.",
+              "max-characters": "Il messaggio è limitato a 10.000 caratteri."
+            },
+            "success": "'<p>'Il tuo commento è stato trasmesso al team del progetto Pix.'</p><p>'Mercix!'</p>'"
+          }
+        },
+        "information": {
+          "data-usage": "'<p>'Pix tratta i dati in quest'area per gestire e analizzare le difficoltà riscontrate e per beneficiare del vostro feedback. Avete dei diritti sui vostri dati che possono essere esercitati contattando: <strong>dpo@pix.fr</strong>.'</p><p><a href=\"https://pix.fr/dp-formulaire-signalement-epreuve\" target=\"_blank\" class=\"link\">'Scopri di più sulla protezione dei dati e sui tuoi diritti.'</a></p>'",
+          "guidance": "'<p>'* Fate attenzione a ciò che scrivete in quest'area: rimanete oggettivi e fattuali, a beneficio vostro e degli altri.'</p><p>'In particolare, non inserite informazioni, che riguardino voi stessi o terzi, su salute, religione, opinioni politiche, sindacali o filosofiche, origini etniche, o su sanzioni o condanne.'</p>'"
+        },
+        "modal": {
+          "content": "'<p><strong>'Sei sicuro di voler segnalare questo problema?'</strong></p><p>'Grazie per la tua segnalazione, che sarà esaminata attentamente dal team Pix. Prendiamo in considerazione tutti i tuoi commenti per migliorare continuamente i nostri servizi e la nostra esperienza utente. Non saremo in grado di fornirle una risposta personalizzata. Grazie per la collaborazione.'</p>'",
+          "title": "Conferma della segnalazione"
+        }
+      },
+      "has-focused-out-of-window": {
+        "certification": "Abbiamo rilevato un cambio di pagina. La risposta sarà considerata errata. Se siete stati costretti a cambiare pagina, informate il vostro supervisore e rispondete alla domanda in sua presenza.",
+        "default": "Abbiamo rilevato un cambio di pagina. Nella certificazione, la sua risposta non sarebbe stata convalidata.",
+        "v3-accessible-certification": "È stato rilevato un cambio di pagina. Se si è dovuto cambiare pagina per utilizzare uno strumento di accessibilità digitale (come uno screen reader o una tastiera virtuale), rispondere comunque alla domanda.",
+        "v3-certification": "Abbiamo rilevato un cambio di pagina. La risposta sarà considerata errata. Se siete stati costretti a cambiare pagina, informate il vostro supervisore in modo che possa vedere la modifica e segnalarla direttamente dall'\"Area del supervisore\"."
+      },
+      "illustration": {
+        "placeholder": "Caricamento dell'immagine corrente"
+      },
+      "is-focused-challenge": {
+        "info-alert": {
+          "adjusted-course-title": "Rispondete a questa domanda senza utilizzare Internet o altre applicazioni.",
+          "subtitle": "Nella certificazione, se si cambia pagina, la risposta non sarà convalidata.",
+          "title": "Provate a rispondere a questa domanda senza utilizzare Internet o altre applicazioni."
+        }
+      },
+      "live-alerts": {
+        "challenge": {
+          "message": "Avvisare il proprio supervisore affinché possa identificare il problema e risolverlo direttamente nell'interfaccia \"Area supervisore\"."
+        },
+        "companion": {
+          "message": "Contattare il proprio supervisore per confermare la presenza dell'estensione."
+        },
+        "refresh": "Aggiorna la pagina",
+        "waiting-information": "In attesa del supervisore..."
+      },
+      "parts": {
+        "answer-input": "La tua risposta",
+        "answer-instructions": {
+          "qcm": "Selezionare diverse risposte.",
+          "qcu": "Selezionare una sola risposta."
+        },
+        "feedback": "Segnala un problema",
+        "feedback-v3": "Segnalare un problema con la domanda",
+        "instruction": "Istruzioni per il test",
+        "progress": "I vostri progressi",
+        "validation": "Convalidare o superare il test"
+      },
+      "progress-bar": {
+        "label": "Domanda"
+      },
+      "skip-error-message": {
+        "qcm": "Per convalidare, selezionare almeno due risposte. In caso contrario, saltare.",
+        "qcu": "Per confermare, selezionare una risposta. Altrimenti, saltare.",
+        "qroc": "Per convalidare, compilare il campo di testo. Altrimenti, saltare.",
+        "qroc-auto-reply": "Quando il test viene superato, viene visualizzato \"È possibile convalidare\". Riprovare o superare il test.",
+        "qroc-positive-number": "Per convalidare, inserire un numero maggiore o uguale a 0, altrimenti saltare.",
+        "qrocm": "Per convalidare, compilare tutti i campi delle risposte. In caso contrario, saltare."
+      },
+      "statement": {
+        "alternative-instruction": {
+          "actions": {
+            "display": "Visualizzare l'alternativa di testo",
+            "hide": "Nascondi testo alternativo"
+          }
+        },
+        "file-download": {
+          "actions": {
+            "choose-type": "Scegliere il tipo di file da utilizzare",
+            "download": "Scaricare"
+          },
+          "description": "Pix consente di scegliere il formato di file da scaricare. Se non sapete quale opzione scegliere, mantenete quella predefinita. Questo è il formato di file supportato dal maggior numero di applicazioni software.",
+          "file-type": "file .{fileExtension}",
+          "help": "Hai bisogno di aiuto con '<a href=\"https://pix.org/fr/aide-ouvrir-modifier-retrouver-un-fichier-telecharge-depuis-une-question-pix\" class=\"challenge-statement__action-help--link\" target=\"_blank\" aria-label=\"apri, modifica o trova questo file (apri in una nuova finestra)\">'apri, modifica o trova questo file'</a>'?"
+        },
+        "sr-only": {
+          "alternative-instruction": "Questa prova contiene un'illustrazione con un testo alternativo.",
+          "embed": "Questo test comprende un simulatore."
+        },
+        "text-to-speech": {
+          "activate": "Attivare la vocalizzazione",
+          "deactivate": "Disattivare la vocalizzazione",
+          "play": "Leggere le istruzioni ad alta voce",
+          "stop": "Smettere di leggere le istruzioni"
+        },
+        "tooltip": {
+          "aria-label": "Visualizzare l'indicazione sulla prova.",
+          "close": "Capisco",
+          "focused": {
+            "content": "'<strong class=\"tooltip-tag-information__title--focused\">'Cerca di rimanere su questa pagina per rispondere!'</strong><br/>' Questa domanda non richiede internet o applicazioni.",
+            "title": "Modalità di messa a fuoco"
+          },
+          "other": {
+            "content": "Siete liberi di utilizzare Internet o le applicazioni per rispondere a questa domanda.",
+            "title": "Modalità libera"
+          }
+        }
+      },
+      "timed": {
+        "cannot-answer": "Il tempo limite è scaduto. La risposta non sarà convalidata."
+      },
+      "title": {
+        "default": "Modalità libera - Domanda {stepNumber} su {totalChallengeNumber}.",
+        "focused": "Modalità di messa a fuoco - Domanda {stepNumber} su {totalChallengeNumber}.",
+        "focused-out": "Fallito - Modalità di messa a fuoco - Domanda {stepNumber} su {totalChallengeNumber}.",
+        "timed-out": "Tempo trascorso - Domanda {stepNumber} su {totalChallengeNumber}"
+      }
+    },
+    "checkpoint": {
+      "actions": {
+        "next-page": {
+          "continue": "Continua",
+          "results": "Vedi i miei risultati"
+        }
+      },
+      "answers": {
+        "already-finished": {
+          "explanation": "Avete già risposto a queste domande nei test precedenti: potete accedere direttamente ai vostri risultati.\n\nVolete migliorare il vostro punteggio? Cliccate su \"Vedi i miei risultati\" per ripetere il test.",
+          "info": "Hai già risposto!"
+        },
+        "header": "le vostre risposte"
+      },
+      "completion-percentage": {
+        "caption": "progressi lungo il percorso",
+        "label": "'<p class=\"sr-only\">'Hai completato '</p>'{completionPercentage}%'<p class=\"sr-only\">' del tuo viaggio.'</p>'"
+      },
+      "sharing-results": {
+        "information-banner": "Cliccando sul pulsante \"Vedi i miei risultati\", i vostri risultati saranno inviati all'organizzatore."
+      },
+      "title": {
+        "assessment-progress": "Avanzamento",
+        "end-of-assessment": "Fine della valutazione"
+      }
+    },
+    "combined-courses": {
+      "completed": {
+        "description": "Ben fatto! Avete compiuto un passo importante nella navigazione del mondo digitale.",
+        "retry-text": "Volete ripassare? Siete liberi di rivedere tutti i moduli!",
+        "survey-button": "Rispondere al questionario",
+        "survey-button-description": "Compilate il questionario per dare la vostra opinione sul percorso",
+        "title": "Congratulazioni! Avete finito!"
+      },
+      "content": {
+        "resume-button": "Continua il mio viaggio",
+        "start-button": "Iniziare il mio viaggio",
+        "step": "Passo {stepNumber}"
+      },
+      "items": {
+        "aria-label-completed-campaign": "Questo elemento viene completato con una percentuale di successo di {value, number, ::percent}.",
+        "aria-label-completed-campaign-with-stages": "Hai ottenuto {acquired, plural, =0 {no stelle} =1 {# stelle} other {# stelle}} su {total}.",
+        "aria-label-duration": "Durata stimata: {duration} minuti",
+        "completed": "Completato!",
+        "duration": "≈ {duration} min",
+        "formation": {
+          "description": "Completate la vostra diagnosi per sbloccare un programma di moduli su misura per i vostri risultati!",
+          "title": "Programma personalizzato di moduli"
+        },
+        "tagText": "Ecco dove siete!"
+      },
+      "process-custom-passages": {
+        "description": "Analizziamo i vostri risultati e costruiamo il vostro piano di allenamento personalizzato.",
+        "list": {
+          "generate-personalize-course": "Generate il vostro percorso personalizzato.",
+          "results-analysis": "Analisi dei risultati.",
+          "select-passages": "Selezione di corsi di formazione adeguati."
+        },
+        "title": "Calcolo del proseguimento del percorso attuale."
+      }
+    },
+    "comparison-window": {
+      "results": {
+        "a11y": {
+          "good-answer": "La risposta data è valida",
+          "skipped-answer": "Domanda passata",
+          "the-answer-was": "La risposta corretta è",
+          "timedout": "Si è superato il limite di tempo",
+          "wrong-answer": "La risposta data è sbagliata"
+        },
+        "aband": {
+          "title": "Non avete dato una risposta",
+          "tooltip": "Nessuna risposta"
+        },
+        "abandAutoReply": {
+          "title": "Avete superato il test",
+          "tooltip": "Test passato"
+        },
+        "default": {
+          "title": "Risposta",
+          "tooltip": "Correzione automatica in fase di sviluppo ;)"
+        },
+        "feedback": {
+          "correct": "Risposta corretta",
+          "wrong": "Risposta errata. '<br>La risposta corretta è :"
+        },
+        "focusedOut": {
+          "title": "Avete superato la prova",
+          "tooltip": "Test fallito"
+        },
+        "ko": {
+          "title": "Non avete la risposta giusta",
+          "tooltip": "Risposta errata"
+        },
+        "koAutoReply": {
+          "title": "Non avete superato il test",
+          "tooltip": "Test non riuscito"
+        },
+        "ok": {
+          "title": "Hai la risposta giusta!",
+          "tooltip": "Risposta corretta"
+        },
+        "okAutoReply": {
+          "title": "Avete superato il test",
+          "tooltip": "Test riuscito"
+        },
+        "solutions": {
+          "end": "o...",
+          "or": "o"
+        },
+        "timedout": {
+          "title": "Si è superato il limite di tempo",
+          "tooltip": "Time out"
+        },
+        "tips": {
+          "other-proposition": "Altra proposta",
+          "your-answer": "La tua risposta"
+        }
+      },
+      "upcoming-tutorials": "Qui troverete presto dei tutorial che vi aiuteranno a superare questo tipo di test."
+    },
+    "competence-details": {
+      "actions": {
+        "continue": {
+          "extra-information": "Abilità del curriculum {competenceName}",
+          "label": "Il curriculum"
+        },
+        "improve": {
+          "description": {
+            "countdown": "{ daysBeforeImproving, plural, =0 { giorni.} =1 { giorni.} other {# giorni.} }",
+            "waiting-text": "Provate il livello successivo in"
+          },
+          "improvingText": "Cercate di raggiungere il livello successivo!",
+          "label": "Ritentore"
+        },
+        "reset": {
+          "description": "Reset disponibile in { daysBeforeReset, plural, =0 {0 giorni.} =1 { giorno.} other {# giorni.} }",
+          "label": "Azzeramento",
+          "modal": {
+            "important-message": "Il tuo { earnedPix } Pix sarà rimosso dall'abilità: { scoreCardName }.",
+            "important-message-above-level-one": "I livelli { level } e { earnedPix } Pix saranno rimossi dall'abilità: { scoreCardName }.",
+            "title": "Azzeramento delle competenze",
+            "warning": {
+              "certification": "se desiderate far certificare il vostro profilo e i vostri vari risultati, questo potrebbe influire sulla vostra certificazione.",
+              "header": "Si prega di notare:",
+              "ongoing-assessment": "se è in corso un corso di valutazione, è possibile che vi vengano riproposte alcune domande."
+            }
+          }
+        },
+        "start": {
+          "extra-information": "Avviare l'abilità {competenceName}",
+          "label": "Inizio"
+        }
+      },
+      "for-competence": "l'abilità {competence}",
+      "next-level-info": "{ remainingPixToNextLevel } pix prima del livello { level }",
+      "title": "Competenza",
+      "tutorials": {
+        "description": "Ecco una selezione di tutorial per aiutarvi a guadagnare Pix.",
+        "title": "Coltivare le proprie competenze"
+      }
+    },
+    "competence-result": {
+      "header": {
+        "congratulations": "Congratulazioni!",
+        "not-bad": "Non male, ma non eccezionale!",
+        "not-bad-subtitle": "Ancora un piccolo sforzo e avrete raggiunto il primo livello.",
+        "too-bad": "Tante foto!",
+        "too-bad-subtitle": "Ovviamente non è la tua giornata, ma la prossima volta farai meglio.",
+        "you-have-earned": "Avete",
+        "you-have-reached-level": "Avete raggiunto"
+      },
+      "title": "Risultati della vostra abilità"
+    },
+    "complementary-certification-names": {
+      "DROIT": "Pix+ Destra",
+      "EDU_1ER_DEGRE": "Pix+ Édu 1° livello",
+      "EDU_2ND_DEGRE": "Pix+ Edu 2° livello",
+      "EDU_CPE": "Pix+ Edu CPE",
+      "PRO_SANTE": "Pix+ Professionisti della salute"
+    },
+    "course": {
+      "errors": {
+        "not-accessible": "Ops, la pagina richiesta non è accessibile."
+      }
+    },
+    "dashboard": {
+      "campaigns": {
+        "resume": {
+          "action": "Continua",
+          "text": "<h2>Non dimenticate di completare l'invio del vostro profilo! </h2>"
+        },
+        "subtitle": "Continuare il test in corso o inviare i risultati",
+        "tests-link": "Tutti i miei percorsi di carriera",
+        "title": "I miei percorsi di carriera"
+      },
+      "empty-dashboard": {
+        "link-to-competences": "Vedi le mie competenze",
+        "message": "<h2>Bravo, hai completato le abilità consigliate! </h2> <p>Per andare avanti continua a esercitarti provando le abilità. </p>"
+      },
+      "improvable-competences": {
+        "extra-information": "Accedere a tutte le abilità per riprovare",
+        "profile-link": "Tutte le competenze",
+        "subtitle": "Siete pronti a passare al livello successivo?",
+        "title": "Riprovare un'abilità"
+      },
+      "presentation": {
+        "link": {
+          "text": "Per saperne di più",
+          "url": "https://pix.fr/actualites/decouvrez-votre-nouveau-tableau-de-bord"
+        },
+        "message": "<h2>Ciao, scopri la tua dashboard.</h2><p>Accedi rapidamente e facilmente ai tuoi corsi e ai test di competenze già iniziati.<br/>Scopri come procede il tuo punteggio Pix e controlla se il tuo profilo è pronto per la certificazione Pix.</p>"
+      },
+      "recommended-competences": {
+        "extra-information": "Accesso a tutte le competenze consigliate",
+        "profile-link": "Tutte le competenze",
+        "subtitle": "Esplorate le competenze consigliate per voi.",
+        "title": "Competenze consigliate"
+      },
+      "score": {
+        "profile-link": "Vedi le mie competenze"
+      },
+      "started-competences": {
+        "subtitle": "Continuate con i vostri test di abilità, trovate gli ultimi qui.",
+        "title": "Riprendere in mano un'abilità"
+      },
+      "title": "Casa",
+      "welcome": "Ciao { firstName }."
+    },
+    "download-session-results": {
+      "button": {
+        "label": "Scarica i risultati"
+      },
+      "errors": {
+        "invalid-token": "Il link per il download dei risultati della sessione non è valido."
+      },
+      "title": "Scarica i risultati della sessione"
+    },
+    "error": {
+      "content-text": "'<p>'La invitiamo a ricaricare questa pagina o a tornare alla home page.'</p><p>'Può anche contattarci tramite '<a href=\"https://support.pix.fr/support/tickets/new\">'il modulo del centro assistenza'</a>' specificando il codice di errore sotto nella descrizione.'</p><p>'Ci scusiamo per l'inconveniente.'</p><p>'Il team Pix.'</p>'",
+      "first-title": "Ops, c'è stato un errore!"
+    },
+    "evaluation-results": {
+      "quit-results": {
+        "leave-without-signup-modal": {
+          "actions": {
+            "cancel": "Annullamento",
+            "leave": "Sì, lasciare il corso"
+          },
+          "content-information": "Se si abbandona il corso senza registrarsi, non sarà possibile mantenere i propri progressi.",
+          "content-instruction": "Vuole continuare?",
+          "title": "Lasciare e tornare su pix.fr?"
+        }
+      }
+    },
+    "fill-in-campaign-code": {
+      "description": "Questo codice è composto da 9 numeri e/o lettere. Viene inviato dalla vostra scuola/organizzazione e serve per iniziare un corso o inviare il vostro profilo.",
+      "errors": {
+        "forbidden": "Oops! Non riusciamo a trovarti. Si prega di controllare i propri dati per continuare o di informare l'organizzatore.",
+        "missing-code": "Inserire un codice.",
+        "not-found": "Il codice è errato, verificare il formato (ad esempio, ABCDEF234) o contattare l'organizzatore."
+      },
+      "first-title-connected": "{ firstName }, inserire il codice",
+      "first-title-not-connected": "Inserisci il tuo codice",
+      "label": "Inserisci il tuo codice per iniziare",
+      "mediacentre-start-campaign-modal": {
+        "actions": {
+          "continue": "Continua",
+          "quit": "Lasciare"
+        },
+        "message": "Per accedere al corso :",
+        "message-footer": "Collegatevi a Pix tramite il vostro Mediacentre",
+        "organised-by": "proposto da",
+        "title": "Accesso al corso tramite Mediacentre"
+      },
+      "start": "Accesso al corso",
+      "title": "Ho un codice",
+      "warning-message": "Non sei { firstName } { lastName }?",
+      "warning-message-logout": "Disconnessione"
+    },
+    "fill-in-certificate-verification-code": {
+      "description": "La certificazione Pix attesta un livello di competenza digitale: inserire il \"codice di verifica\" del certificato Pix che si desidera controllare qui sotto.",
+      "errors": {
+        "missing-code": "Inserire il codice di verifica.",
+        "not-found": "Non esiste un certificato Pix corrispondente.",
+        "unallowed-access": "Inserire il codice di verifica nel formato P-XXXXXXXX nel campo qui sopra.",
+        "wrong-format": "Controllare il formato del codice (P-XXXXXXXX)."
+      },
+      "first-title": "Verifica di un certificato Pix",
+      "label": "Codice di verifica",
+      "sub-label": "Esempio: P-XXXXXXXX",
+      "title": "Verifica di un certificato Pix",
+      "verify": "Controllare il certificato"
+    },
+    "fill-in-participant-external-id": {
+      "announcement": "L'organizzatore ha bisogno delle seguenti informazioni per potervi accompagnare:",
+      "buttons": {
+        "cancel": "Annullamento",
+        "continue": "Continua"
+      },
+      "errors": {
+        "invalid-external-id": "Il vostro { externalIdLabel } non è valido.",
+        "invalid-external-id-email": "L'indirizzo e-mail non è valido.",
+        "max-length-external-id": "Il vostro { externalIdLabel } non deve superare i 255 caratteri.",
+        "missing-external-id": "Inserire il proprio { externalIdLabel }."
+      },
+      "first-title": "Prima di iniziare",
+      "title": "Inserire il mio login"
+    },
+    "focused-certification-challenge-instructions": {
+      "action": "Sono pronto a partire",
+      "description": "Per la domanda o le domande successive, non sarà possibile lasciare la pagina.",
+      "title": "Modalità di messa a fuoco"
+    },
+    "join": {
+      "button": "Si parte!",
+      "fields": {
+        "birthdate": {
+          "day-error": "Il giorno di nascita non è valido.",
+          "day-format": "JJ",
+          "day-label": "giorno di nascita",
+          "label": "Data di nascita",
+          "month-error": "Il mese di nascita non è valido.",
+          "month-format": "MM",
+          "month-label": "mese di nascita",
+          "year-error": "L'anno di nascita non è valido.",
+          "year-format": "AAAA",
+          "year-label": "anno di nascita"
+        },
+        "firstname": {
+          "error": "Il nome non è compilato.",
+          "label": "Nome"
+        },
+        "lastname": {
+          "error": "Il vostro nome non è stato inserito.",
+          "label": "Nome"
+        }
+      },
+      "rgpd-legal-notice": "Per sapere come vengono trattati i vostri dati e quali sono i vostri diritti, potete leggere il documento",
+      "rgpd-legal-notice-link": "Informazioni.",
+      "rgpd-legal-notice-url": "https://pix.fr/politique-protection-donnees-personnelles-app-eleves",
+      "sco": {
+        "associate": "Associato",
+        "continue-with-pix": "Continua con il mio account Pix",
+        "error-not-found": "Sei uno studente? '<br>' Controlla i tuoi dati (nome, cognome e data di nascita) o contatta un insegnante.'<br><br>' Sei un insegnante? '<br>' L'accesso a un corso non è al momento disponibile.",
+        "first-title": "Aderire all'organizzazione { organizationName }",
+        "invalid-reconciliation-error": "Si è verificato un errore. Contattare l'assistenza.",
+        "login-information-message": "L'account Pix '<b>'{ connectionMethod }'</b>' sarà associato allo studente: '<b>'{ firstName } { lastName }'</b>'.'<br><br>'Se siete voi, fate clic su \"Associa\", altrimenti uscite.",
+        "login-information-title": "Informazioni sulla connessione",
+        "subtitle": "Compilare le informazioni mancanti"
+      },
+      "sup": {
+        "error": "Controllare le informazioni inserite o, se si dispone già di un account Pix, effettuare il login.",
+        "fields": {
+          "student-number": {
+            "error": "Il vostro numero di studente non è stato inserito.",
+            "label": "Numero dello studente",
+            "modify": "Cambiare il numero dello studente",
+            "not-existing": "Non ho un numero di matricola"
+          }
+        },
+        "message": "Per accedere al test e inviare i risultati, immettere le informazioni così come appaiono sulla carta dello studente. Pix se ne ricorderà la prossima volta.",
+        "title": "Registrate il vostro account Pix con {organizationName}."
+      },
+      "title": "Contatto"
+    },
+    "learning-more": {
+      "info": "Questi link alle esercitazioni sono stati suggeriti dagli utenti di Pix.",
+      "title": "Per saperne di più"
+    },
+    "levelup-notif": {
+      "obtained-level": "Il livello { level } ha vinto!"
+    },
+    "llm-preview": {
+      "iframe-title": "ChatPix",
+      "title": "Anteprima di ChatPix"
+    },
+    "modulix": {
+      "beta-banner": "Questo modulo è in versione beta. È possibile che vengano apportate modifiche nel tempo.",
+      "buttons": {
+        "activity": {
+          "retry": "Riprova",
+          "verify": "Controlla la mia risposta"
+        },
+        "element": {
+          "alternativeText": "Visualizzare l'alternativa di testo",
+          "transcription": "Visualizza la trascrizione"
+        },
+        "embed": {
+          "start": {
+            "ariaLabel": "Avviare il simulatore",
+            "name": "Inizio"
+          }
+        },
+        "flashcards": {
+          "answers": {
+            "almost": "Quasi",
+            "no": "Per niente",
+            "yes": "Sì!"
+          },
+          "nextCard": "Avanti",
+          "retry": "Riprova",
+          "seeAgain": "Rivedere la domanda",
+          "seeAnswer": "Vedi la risposta",
+          "start": "Inizio"
+        },
+        "grain": {
+          "continue": "Continua",
+          "skip": "Vai a",
+          "skipActivity": "Saltare l'attività",
+          "terminate": "Finitura"
+        },
+        "interactive-element": {
+          "reset": {
+            "ariaLabel": "Resettare il simulatore",
+            "name": "Reset"
+          }
+        },
+        "stepper": {
+          "controls": {
+            "next": {
+              "ariaLabel": "Passo successivo"
+            },
+            "previous": {
+              "ariaLabel": "Stadio precedente"
+            }
+          },
+          "next": {
+            "ariaLabel": "Passare alla fase successiva",
+            "horizontal": {
+              "name": "Avanti"
+            },
+            "vertical": {
+              "name": "Per saperne di più"
+            }
+          }
+        }
+      },
+      "details": {
+        "duration": "Durata",
+        "durationValue": "'<span aria-hidden=\"true\">'≈'</span><span class=\"screen-reader-only\">'Circa '</span>'{duration} min",
+        "level": "Livello",
+        "levels": {
+          "advanced": "Avanzato",
+          "expert": "Esperto",
+          "independent": "Indipendente",
+          "novice": "Novizio"
+        },
+        "objectives": "Obiettivi",
+        "smallScreenModal": {
+          "cancel": "Torna ai dettagli",
+          "description": "Alcune attività di questo modulo potrebbero essere difficili da eseguire su uno schermo di piccole dimensioni. Per un'esperienza ottimale, si consiglia di utilizzare un computer.",
+          "startModule": "Inizio",
+          "title": "Sembra che tu stia usando uno schermo piccolo"
+        },
+        "startModule": "Avviare il modulo"
+      },
+      "download": {
+        "button": "Scaricare",
+        "description": "Scegliere il formato in base al software in uso. Se non siete sicuri, scegliete il primo file, che è compatibile con la maggior parte dei software.",
+        "documentationLinkHref": "https://pix.org/fr/aide-ouvrir-modifier-retrouver-un-fichier-telecharge-depuis-une-question-pix",
+        "documentationLinkLabel": "Come posso aprire, modificare o recuperare questo file?",
+        "format": "Formato {format}",
+        "intro": "Scegliere il formato di file che si desidera utilizzare.",
+        "label": "Scaricare il file in formato {format}."
+      },
+      "flashcards": {
+        "answerDirection": "Avevi la risposta?",
+        "completed": "Completato",
+        "counters": {
+          "almost": "Quasi: {totalAlmost}",
+          "no": "Per niente: {totalNo}",
+          "yes": "Sì! : {totalYes}"
+        },
+        "direction": "Cercare la risposta e girare la carta",
+        "navigation": {
+          "longCurrentStep": "Passare da {current} a {total}.",
+          "shortCurrentStep": "{current}/{total}"
+        },
+        "position": "Scheda {currentCardPosition}/{totalCards}"
+      },
+      "grain": {
+        "tag": {
+          "activity": "Attività"
+        },
+        "title": {
+          "lesson": "Lezione",
+          "summary": "Sintesi"
+        }
+      },
+      "interactiveElement": {
+        "label": "Elemento interattivo"
+      },
+      "issue-report": {
+        "aria-label": "Invia un problema o un suggerimento",
+        "button": "Rapporto",
+        "error-messages": {
+          "missing-comment": "Inserire un commento."
+        },
+        "modal": {
+          "categories": {
+            "custom-and-embed": {
+              "embed-not-working": "Il simulatore/applicazione non funziona",
+              "instruction-issue": "Non capisco le istruzioni"
+            },
+            "default": {
+              "accessibility-issue": "Problemi di accessibilità",
+              "other": "Altro"
+            },
+            "feedback": {
+              "improvement": "Vorrei suggerire un miglioramento",
+              "question-issue": "Non capisco la domanda",
+              "response-issue": "Non sono d'accordo con la risposta"
+            }
+          },
+          "confirmation-message": {
+            "error": {
+              "info": "Si è verificato un errore durante l'invio del commento.",
+              "retry": "Riprovare più tardi."
+            },
+            "success": "Grazie per il suo commento."
+          },
+          "legend": "Informazioni necessarie per inviare un avviso",
+          "select-label": "Motivo della segnalazione",
+          "textarea-label": "Commento",
+          "textarea-placeholder": "Ci parli del suo problema o del suo suggerimento",
+          "title": "Rapporto"
+        }
+      },
+      "modals": {
+        "alternativeText": {
+          "title": "Alternativa di testo"
+        },
+        "transcription": {
+          "title": "Trascrizione"
+        }
+      },
+      "navigation": {
+        "buttons": {
+          "aria-label": {
+            "disabled": "Non disponibile. Terminare il passo precedente",
+            "enabled": "Passare al passo {sectionTitle}.",
+            "steps": "Passare da {indexSection} a {totalSections}."
+          }
+        },
+        "tooltip": {
+          "disabled": "Da continuare: {sectionTitle}"
+        }
+      },
+      "preview": {
+        "showJson": "Visualizzare JSON",
+        "stepper": "Anteprima: stepper {direction}",
+        "textarea-label": "Contenuto del modulo"
+      },
+      "qab": {
+        "correct-answer": "Ottima risposta!",
+        "incorrect-answer": "Risposta sbagliata.",
+        "retry": "Riprova",
+        "score": {
+          "title": "Serie conclusa",
+          "yourScore": "Il tuo punteggio: {score}/{total}"
+        }
+      },
+      "qcm": {
+        "direction": "Selezionare diverse risposte."
+      },
+      "qcu": {
+        "direction": "Selezionare una sola risposta."
+      },
+      "qcuDeclarative": {
+        "complementaryInstruction": "Non esiste una risposta giusta o sbagliata.",
+        "direction": "Selezionare una sola risposta."
+      },
+      "qcuDiscovery": {
+        "direction": "Selezionare la risposta che sembra più accurata."
+      },
+      "qrocm": {
+        "direction": "Compilare {count, plural, =1 { il campo} other { i campi}}."
+      },
+      "recap": {
+        "backToModuleDetails": "Lasciare",
+        "goToHomepage": "Continua",
+        "subtitle": "Avete lavorato sui seguenti obiettivi:",
+        "title": "Modulo completato!"
+      },
+      "section": {
+        "explore-to-understand": "Esplorare per capire",
+        "go-further": "Andare oltre",
+        "practise": "Pratica",
+        "question-yourself": "Fare domande",
+        "retain-the-essentials": "Mantenere l'essenziale"
+      },
+      "sidebar": {
+        "button": "Visualizzare le fasi del modulo"
+      },
+      "stepper": {
+        "aria-role-description": "sequenza di passi",
+        "step": {
+          "aria-label": "{currentStep} su {totalSteps}.",
+          "aria-role-description": "palcoscenico"
+        }
+      },
+      "verification-precondition-failed-alert": {
+        "qcm": "Per confermare, selezionare almeno due risposte.",
+        "qcu": "Per confermare, selezionare una risposta.",
+        "qrocm": "Per convalidare, compilare tutti i campi di risposta."
+      }
+    },
+    "not-connected": {
+      "message": "Sei proprio fuori dal mondo.'<br>'Grazie, a presto.",
+      "title": "Disconnesso"
+    },
+    "oidc-reconciliation": {
+      "authentication-method-to-add": "Connessione aggiunta :",
+      "confirm": "Continua",
+      "current-authentication-methods": "I miei metodi di connessione attuali:",
+      "email": "Indirizzo e-mail",
+      "external-connection": "Collegamento esterno",
+      "external-connection-via": "Connessione tramite",
+      "information": "Poiché la valutazione delle competenze è personalizzata, il vostro account deve rimanere strettamente personale.",
+      "return": "Torna a",
+      "sub-title": "Un nuovo metodo di accesso sta per essere aggiunto al vostro account Pix.",
+      "switch-account": "Cambia conto",
+      "title": "Attenzione!",
+      "username": "Identificatore"
+    },
+    "oidc-signup-or-login": {
+      "error": {
+        "account-conflict": "Questo account è già associato a questa organizzazione. Accedere con un altro account o contattare l'assistenza.",
+        "data-sharing-refused": "La informiamo che la trasmissione dei suoi dati, specificati nella pagina precedente, è indispensabile per poter accedere e utilizzare il servizio.",
+        "error-message": "È necessario accettare le condizioni d'uso di Pix.",
+        "expired-authentication-key": "La richiesta di autenticazione è scaduta.",
+        "invalid-email": "L'indirizzo e-mail non è valido.",
+        "login-unauthorized-error": "L'indirizzo e-mail e/o la password inseriti non sono corretti.",
+        "password-reset-token-invalid-or-expired": "È passato troppo tempo per convalidare la nuova password. Tornare alla pagina di accesso per inserire nuovamente il nome utente e la password temporanea."
+      },
+      "login-form": {
+        "button": "Voglio connettermi",
+        "description": "Effettuate il login per collegare il vostro account esistente e recuperare le competenze precedentemente valutate.",
+        "email": "Indirizzo e-mail",
+        "password": "Password",
+        "title": "Ho già un account Pix"
+      },
+      "signup-form": {
+        "button": "Creo il mio account",
+        "claims": {
+          "FrEduFonctAdm": "Funzione amministrativa",
+          "FrEduNumenHash": "Identificatore tecnico",
+          "discipline": "Disciplina",
+          "employeeNumber": "Numero di dipendenti",
+          "population": "Popolazione",
+          "rne": "Luogo di lavoro",
+          "title": "Funzione"
+        },
+        "description": "Verrà creato un account utilizzando le informazioni fornite dall'organizzazione.",
+        "error": "Non siamo riusciti a recuperare le informazioni sulla vostra identità dal servizio utilizzato. Si prega di contattare l'assistenza informatica dell'organizzazione.",
+        "first-name-label-and-value": "Nome: {firstName}",
+        "last-name-label-and-value": "Nome: {lastName}",
+        "title": "Non ho un account Pix"
+      },
+      "title": "Crea il tuo account Pix"
+    },
+    "password-reset-demand": {
+      "title": "Avete dimenticato la password?"
+    },
+    "profile": {
+      "accessibility": {
+        "title": "Il vostro profilo Pix",
+        "user-score": "Il vostro numero di Pix",
+        "user-skills": "Le vostre capacità di Pix"
+      },
+      "competence-card": {
+        "congrats": "Ben fatto!",
+        "details": "dettagli",
+        "image-info": {
+          "first-level": "Il primo livello è in corso, completato al {percentageAheadOfNextLevel}%.",
+          "level": "Livello attuale: {currentLevel}. Il livello successivo viene completato al {percentageAheadOfNextLevel}%.",
+          "no-level": "Abilità non avviata"
+        }
+      },
+      "description": "Mettetevi alla prova con il vostro ritmo in 16 abilità digitali. Scegliete una competenza e iniziate a guadagnare pix.",
+      "first-title": "Avete 16 abilità da testare. Concentratevi e partite!",
+      "resume-campaign-banner": {
+        "accessibility": {
+          "resume": "Continua il tuo viaggio",
+          "share": "Condividere i risultati del viaggio"
+        },
+        "actions": {
+          "continue": "Continua",
+          "resume": "Il curriculum"
+        },
+        "reminder-continue-campaign": "Non avete completato il corso",
+        "reminder-continue-campaign-with-title": "Non è stato completato il percorso \"{title}\".",
+        "reminder-send-campaign": "Non dimenticate di finalizzare la spedizione!",
+        "reminder-send-campaign-with-title": "Percorso \"{title}\" completato. Non dimenticate di finalizzare la spedizione!"
+      },
+      "title": "Competenze",
+      "total-score-helper": {
+        "explanation": "'<p>'Questo è il numero massimo di pix che saremo in grado di raggiungere quando tutti gli 8 livelli del repository Pix saranno disponibili.'</p><p>'Oggi,'<span class=\"hexagon-score-information__--strong\">'il massimo è {maxReachablePixScore} pix'</span>', corrispondente al livello {maxReachableLevel}.'</p>'",
+        "icon": "Informazioni su pix",
+        "label": "Aprire il tooltip",
+        "title": "Perché 1024 pixel?"
+      }
+    },
+    "profile-already-shared": {
+      "actions": {
+        "continue": "Continua la tua esperienza Pix"
+      },
+      "explanation": "Avete già inviato il profilo sottostante all'organizzazione {organization}'<br>'{date} a {hour,time,hhmm}.",
+      "first-title": "Non tutto va secondo i piani",
+      "retry": {
+        "button": "Invia di nuovo il mio profilo",
+        "message": "{organization} invita a restituire il proprio profilo per misurare i propri progressi."
+      },
+      "title": "Profilo già inviato"
+    },
+    "reset-password": {
+      "error": {
+        "expired-demand": "Siamo spiacenti, ma la richiesta di reimpostazione della password è già stata utilizzata o è scaduta. Si prega di riprovare."
+      },
+      "first-title": "Reimpostare la password",
+      "title": "Cambiare la password"
+    },
+    "result-item": {
+      "aband": "Nessuna risposta",
+      "actions": {
+        "see-answers-and-tutorials": {
+          "label": "Risposte e tutorial"
+        }
+      },
+      "ko": "Risposta errata",
+      "ok": "Risposta corretta",
+      "timedout": "Time out"
+    },
+    "sco-signup-or-login": {
+      "invitation": "{ organizationName } vi invita ad unirvi a Pix",
+      "login-form": {
+        "button": "Accedi",
+        "fields": {
+          "login": {
+            "label": "Indirizzo e-mail o login"
+          },
+          "password": {
+            "label": "Password"
+          }
+        },
+        "forgotten-password": {
+          "email": "Un indirizzo e-mail :",
+          "instruction": "Hai dimenticato la password? Avete un account Pix con :",
+          "other-identity": "Un login : Contattare l'insegnante per ripristinarlo",
+          "reset-link": "Fare clic qui per ripristinarlo"
+        },
+        "title": "Ho già un account Pix",
+        "unexpected-user-account-error": "L'indirizzo e-mail o il nome utente non sono corretti. Per continuare, è necessario accedere al proprio account, che si presenta sotto forma di :"
+      },
+      "signup-form": {
+        "button": "Iscriviti",
+        "button-form": "Desidero registrarmi",
+        "fields": {
+          "birthdate": {
+            "day": {
+              "error": "Il giorno di nascita non è valido.",
+              "label": "Giorno di nascita",
+              "placeholder": "JJ"
+            },
+            "label": "Data di nascita (GG/MM/AAAA)",
+            "month": {
+              "error": "Il mese di nascita non è valido.",
+              "label": "Mese di nascita",
+              "placeholder": "MM"
+            },
+            "year": {
+              "error": "L'anno di nascita non è valido.",
+              "label": "Anno di nascita",
+              "placeholder": "AAAA"
+            }
+          },
+          "cgu": "Accetto le '<a href=\"https://pix.fr/conditions-generales-d-utilisation\" class=\"link\" target=\"_blank\" rel=\"noopener noreferrer\">'condizioni d'uso di Pix'</a>'",
+          "email": {
+            "error": "L'e-mail non è valida.",
+            "help": "(ad esempio nom@exemple.fr)",
+            "label": "Indirizzo e-mail"
+          },
+          "firstname": {
+            "error": "Il nome non è compilato.",
+            "label": "Nome"
+          },
+          "lastname": {
+            "error": "Il vostro nome non è stato inserito.",
+            "label": "Nome"
+          },
+          "password": {
+            "error": "La password deve essere lunga almeno 8 caratteri e contenere almeno una lettera maiuscola, una lettera minuscola e un numero.",
+            "help": "(minimo 8 caratteri, di cui uno maiuscolo, uno minuscolo e un numero)",
+            "label": "Password",
+            "show-button": "rendere leggibile la password"
+          },
+          "username": {
+            "label": "Il mio login"
+          }
+        },
+        "not-me": "Non sono io",
+        "options": {
+          "email": "Il mio indirizzo e-mail",
+          "text": "Vorrei registrarmi con :",
+          "username": "Il mio login"
+        },
+        "rgpd-legal-notice": "Per sapere come vengono trattati i vostri dati e quali sono i vostri diritti, potete leggere il documento",
+        "rgpd-legal-notice-link": "Informazioni.",
+        "rgpd-legal-notice-url": "https://pix.fr/politique-protection-donnees-personnelles-app-eleves",
+        "title": "Vorrei registrarmi con Pix"
+      },
+      "title": "Collegarsi a Pix"
+    },
+    "send-profile": {
+      "disabled-share": "Questo corso è stato disattivato dall'organizzatore. Non è più possibile inviare i risultati.",
+      "errors": {
+        "archived": "Non è più possibile inviare il proprio profilo poiché l'organizzatore ha archiviato la raccolta dei profili."
+      },
+      "first-title": "Invio del profilo Pix",
+      "form": {
+        "continue": "Continua la tua esperienza Pix",
+        "recipient": "Destinatario: {recipient}",
+        "send": "Invio il mio profilo",
+        "shared": "Grazie, il tuo profilo è stato inviato!"
+      },
+      "instructions": "Trasmetterete il punteggio e i livelli di abilità del vostro profilo Pix. Eventuali modifiche al profilo dopo l'invio di queste informazioni non saranno trasmesse. Ricordati di controllare prima di inviare!",
+      "title": "Invia il mio profilo"
+    },
+    "shared-certification": {
+      "back-link": "Torniamo all'inserimento del codice di verifica",
+      "title": "Condivisione del certificato"
+    },
+    "sign-in": {
+      "actions": {
+        "submit": "Voglio connettermi"
+      },
+      "fields": {
+        "legend": "Informazioni necessarie per l'accesso.",
+        "login": {
+          "label": "Indirizzo e-mail o login",
+          "placeholder": "Ad esempio, jean.dupont@email.com"
+        },
+        "password": {
+          "label": "Password"
+        }
+      },
+      "first-title": "Accedere a",
+      "forgotten-password": "Avete dimenticato la password?",
+      "title": "Connessione"
+    },
+    "signup": {
+      "actions": {
+        "login": "Accedi",
+        "sign-up-on-pix": "Registrati con Pix",
+        "submit": "Desidero registrarmi"
+      },
+      "fields": {
+        "email": {
+          "help": "(ad esempio nom@exemple.fr)"
+        }
+      },
+      "first-title": "Registrati su",
+      "save-progress-message": "Per tenere traccia dei vostri progressi e continuare a valutarvi, registratevi con Pix!",
+      "title": "Registrazione"
+    },
+    "sitemap": {
+      "accessibility": {
+        "help": "Aiuto per le domande sull'accessibilità in Pix",
+        "title": "Accessibilità"
+      },
+      "cgu": {
+        "policy": "Politica di protezione dei dati",
+        "subcontractors": "Elenco dei subappaltatori"
+      },
+      "resources": "Risorse",
+      "title": "Mappa del sito"
+    },
+    "skill-review": {
+      "abstract": "Hai acquisito la padronanza di '<strong>'{rate, number, ::percent}'</strong><br>'delle abilità testate.",
+      "abstract-title": "Il risultato per questo percorso",
+      "actions": {
+        "back-to-pix": "Partenza e ritorno a Pix",
+        "continue": "Continua la tua esperienza Pix"
+      },
+      "already-shared": "Grazie, i risultati sono stati inviati!",
+      "badge-card": {
+        "acquired": "Ottenuto",
+        "acquired-full": "Distintivo ottenuto",
+        "certifiable": "Certificare",
+        "not-acquired": "Non ottenuto",
+        "not-acquired-full": "Distintivo non ottenuto",
+        "progress-bar-label": "Percentuale di passaggi di badge"
+      },
+      "badges-title": "I vostri badge",
+      "details": {
+        "caption": "Dettagli sui risultati ottenuti in termini percentuali in base alle competenze",
+        "header-result": "Risultati",
+        "header-skill": "Competenze testate",
+        "percentage": "{rate, number, ::percent}",
+        "progress-bar-label": "Percentuale di successo dell'abilità",
+        "result": "Risultato complessivo",
+        "title": "I risultati per abilità"
+      },
+      "error": "Ops, c'è stato un errore!",
+      "hero": {
+        "acquired-badges-title": "Premi vinti",
+        "explanations": {
+          "trainings": "Per aiutarvi a progredire, date un'occhiata ai nostri corsi di formazione consigliati e trovate quelli più adatti a voi."
+        },
+        "mastery-rate": "di successo nelle domande",
+        "retry": {
+          "actions": {
+            "reset": "Resettare e riprovare",
+            "retry": "Riproduzione del mio viaggio"
+          },
+          "description": "Il vostro organizzatore vi chiederà di ripetere il corso.",
+          "retryIn": "Non è ancora possibile rigiocare questo percorso, tornare a {duration}.",
+          "title": "Migliorare i risultati"
+        },
+        "see-trainings": "Vedere i corsi",
+        "shared-message": "I risultati sono stati inviati da {date} a {time}.",
+        "thanks": "Grazie {name} per la vostra partecipazione!"
+      },
+      "improve": {
+        "description": "È possibile riprovare alcune delle domande",
+        "title": "Volete migliorare i vostri risultati?"
+      },
+      "information": "Se avete già completato un percorso Pix, non vi verranno riproposte le stesse domande. Tuttavia, i risultati qui riportati tengono conto di tutte le vostre risposte.",
+      "net-promoter-score": {
+        "link": {
+          "href": "https://pix.fr",
+          "label": "Esprimo la mia opinione"
+        },
+        "text": "Prendetevi qualche minuto per dirci cosa ne pensate di questo test e aiutarci a migliorarlo.",
+        "title": "La vostra opinione conta!"
+      },
+      "not-finished": "Non è ancora possibile inviare i risultati, quindi abbiamo ancora alcune domande per voi.",
+      "reset": {
+        "button": "Resettare e riprovare",
+        "modal": {
+          "text": "Stai per azzerare il tuo corso <strong>{targetProfileName}</strong>, nel tentativo di migliorare il tuo livello. Alla fine del corso, potrai inviare nuovamente i tuoi risultati.",
+          "warning-text": "I Pix, i livelli e le certificazioni ottenuti durante questo corso saranno cancellati."
+        },
+        "notification": "Azzerare per riprovare. L'organizzatore continuerà ad avere accesso ai risultati inviati in precedenza."
+      },
+      "retry": {
+        "button": "Riproduzione del mio viaggio",
+        "message": "{organizationName} vi invita a frequentare nuovamente questo corso per migliorare il vostro risultato e continuare a progredire.",
+        "notification": "Ripetere le domande fallite per migliorare il proprio risultato e continuare a progredire. L'organizzatore continuerà ad avere accesso ai risultati precedentemente inviati."
+      },
+      "retry-and-reset": {
+        "notification": "Riprodurre le domande fallite o azzerarle per riprovare. L'organizzatore continuerà ad avere accesso ai risultati inviati in precedenza."
+      },
+      "send-status": {
+        "in-progress": "Invio"
+      },
+      "stage": {
+        "caption": "I dettagli dei vostri risultati sotto forma di percentuali e stelle in base alle competenze",
+        "masteryPercentage": "{rate, number, ::percent} di successo",
+        "starsAcquired": "{acquired, plural, =0 {nessuna stella acquisita} =1 {# stelle acquisite} other {# stelle acquisite}} su {total}.",
+        "title": "Dettagli sulle competenze"
+      },
+      "tabs": {
+        "aria-label": "3 schede con i dettagli dei risultati",
+        "results-details": {
+          "description": "Scoprite le vostre competenze in dettaglio, organizzate per aree specifiche, per comprendere meglio i vostri punti di forza e le aree di miglioramento. Identificate i vostri punti di forza e le aree in cui potete concentrare i vostri sforzi per fare ulteriori progressi.",
+          "tab-label": "Dettagli",
+          "title": "Dettagli dei risultati"
+        },
+        "rewards": {
+          "description": "Questa sezione evidenzia i riconoscimenti ricevuti e le aspettative dell'organizzatore del corso. Scoprite come è stata valutata la vostra prestazione e identificate le aree di miglioramento delle vostre competenze.",
+          "tab-label": "Premi",
+          "title": "Premi e aspettative dell'organizzatore"
+        },
+        "trainings": {
+          "description": "Ricevete consigli di allenamento personalizzati per continuare a progredire e alimentate la vostra curiosità per aiutarvi a raggiungere il vostro pieno potenziale.",
+          "tab-label": "Formazione",
+          "title": "Volete saperne di più?"
+        }
+      },
+      "title": "Risultati",
+      "trainings": {
+        "description": "Scoprite i corsi di formazione consigliati per voi, in base ai vostri risultati, per aiutarvi a progredire!",
+        "title": "Volete saperne di più?"
+      }
+    },
+    "terms-of-service": {
+      "cgu": "Accetto i '<a href=\"https://pix.fr/conditions-generales-d-utilisation\" class=\"link\" target=\"_blank\">'termini e condizioni d'uso di Pix'</a>'.",
+      "form": {
+        "button": "Continuo",
+        "error-message": "È necessario accettare le condizioni d'uso di Pix."
+      },
+      "message": "Abbiamo aggiornato le nostre condizioni d'uso. Vi preghiamo di accettarle per continuare la vostra esperienza su Pix.",
+      "title": "Termini e condizioni d'uso"
+    },
+    "timed-challenge-instructions": {
+      "action": "Inizio",
+      "primary": "Avrete '<span class=\"timed-challenge-instructions__time\">'{time}'</span>' per passare alla domanda successiva.",
+      "secondary": "È possibile continuare a rispondere anche in seguito, ma la domanda non sarà considerata come riuscita.",
+      "time": {
+        "and": " e",
+        "minutes": "{minutes, plural, =0 {} =1 {# minuti} other {# minuti}}",
+        "seconds": "{seconds, plural, =0 {} =1 {# secondi} other {# secondi}}."
+      }
+    },
+    "training": {
+      "editor": "Contenuti formativi proposti da",
+      "type": {
+        "autoformation": "Corsi di autoformazione",
+        "e-learning": "Formazione a distanza",
+        "hybrid-training": "Formazione ibrida",
+        "in-person-training": "Formazione faccia a faccia",
+        "modulix": "Modulo Pix (Beta)",
+        "webinaire": "Webinar"
+      }
+    },
+    "tutorial": {
+      "dot-action-description": "Andare al passo {stepNumber} su {stepsCount}.",
+      "dot-action-title": "Passare da {stepNumber} a {stepsCount}.",
+      "dots-nav-label": "Passi del tutorial",
+      "next": "Avanti",
+      "next-title": "Mostra il passo successivo",
+      "pages": {
+        "page0": {
+          "explanation": "Se non conoscete la risposta\nprobabilmente si trova su Internet.",
+          "title": "Potete cercare su Internet ..."
+        },
+        "page1": {
+          "explanation": "Se viene visualizzata questa immagine, utilizzare solo ciò che si conosce!\n Non dovete usare Internet o il vostro software.",
+          "title": "... tranne che per alcune domande"
+        },
+        "page2": {
+          "explanation": "Prendete tutto il tempo necessario per completare il corso.\nSe una domanda è a tempo, ciò sarà indicato.",
+          "title": "Senza limiti di tempo!"
+        },
+        "page3": {
+          "explanation": "Accedere alle esercitazioni per saperne di più\nper saperne di più su ogni domanda e progredire.",
+          "title": "Tutorial per l'apprendimento"
+        },
+        "page4": {
+          "explanation": "In base alle vostre risposte,\nPix adatta la difficoltà delle domande.",
+          "title": "Il giusto livello di difficoltà"
+        }
+      },
+      "pass": "Ignorare",
+      "pass-title": "Salta il tutorial e inizia il mio viaggio",
+      "start": "Iniziare il mio viaggio",
+      "title": "Tutorial della campagna"
+    },
+    "tutorial-panel": {
+      "info": "Questi link alle esercitazioni sono stati suggeriti dagli utenti di Pix.",
+      "title": "Per avere successo la prossima volta"
+    },
+    "update-expired-password": {
+      "button": "Reset",
+      "fields": {
+        "error": "La password deve essere lunga almeno 8 caratteri e contenere almeno una lettera maiuscola, una lettera minuscola e un numero.",
+        "help": "(minimo 8 caratteri, di cui uno maiuscolo, uno minuscolo e un numero)",
+        "label": "Password"
+      },
+      "first-title": "Reimpostare la password",
+      "go-to-login": "Voglio connettermi",
+      "subtitle": "Scegliere una nuova password per continuare",
+      "title": "Cambiare la password",
+      "validation": "La password è stata aggiornata."
+    },
+    "user-account": {
+      "account-update-email": {
+        "email-information": "Questo indirizzo e-mail deve essere valido nel caso in cui si dimentichi la password. Questo sarà il vostro nuovo indirizzo di accesso.",
+        "fields": {
+          "errors": {
+            "empty-password": "La password non può essere vuota.",
+            "invalid-password": "La password inserita non è valida.",
+            "mismatching-email": "I due indirizzi e-mail non sono identici. Si prega di controllare la propria iscrizione.",
+            "new-email-already-exist": "Questo indirizzo e-mail è già in uso.",
+            "unknown-error": "Si è verificato un errore. Riprovare o contattare l'assistenza.",
+            "wrong-email-format": "L'indirizzo e-mail non è valido."
+          },
+          "new-email": {
+            "label": "Nuovo indirizzo e-mail"
+          },
+          "new-email-confirmation": {
+            "label": "Conferma dell'indirizzo e-mail"
+          },
+          "password": {
+            "label": "Password"
+          }
+        },
+        "password-information": "Inserire la password per confermare",
+        "save-button": "Confermare",
+        "title": "Modifica dell'indirizzo e-mail"
+      },
+      "account-update-email-with-validation": {
+        "fields": {
+          "errors": {
+            "empty-password": "La password non può essere vuota.",
+            "invalid-email": "L'indirizzo e-mail non è valido.",
+            "invalid-or-already-used-email": "Indirizzo e-mail non valido o già utilizzato",
+            "invalid-password": "La password inserita non è valida.",
+            "new-email-already-exist": "Questo indirizzo e-mail è già in uso."
+          },
+          "new-email": {
+            "label": "Nuovo indirizzo e-mail"
+          },
+          "password": {
+            "label": "Password",
+            "security-information": "La sicurezza dei vostri dati personali è fondamentale. Per questo motivo verifichiamo che siate l'autore della richiesta. Inserite la vostra password per ricevere un codice di verifica."
+          }
+        },
+        "save-button": "Ricevere un codice di verifica",
+        "title": "Modifica dell'indirizzo e-mail"
+      },
+      "connexion-methods": {
+        "authentication-methods": {
+          "gar": "via ENT/Mediacentre",
+          "label": "Collegamento esterno",
+          "via": "via {identityProviderOrganizationName}"
+        },
+        "edit-button": "Modificare",
+        "email": "Indirizzo e-mail",
+        "menu-link-title": "I miei metodi di connessione",
+        "username": "Identificatore"
+      },
+      "delete-account": {
+        "actions": {
+          "delete": "Cancellare il mio account"
+        },
+        "menu-link-title": "Cancellare il mio account",
+        "modal": {
+          "error-403": "Non è possibile eliminare il proprio account. Contattare l'assistenza Pix.",
+          "question": "Sei sicuro di voler cancellare il tuo account?",
+          "title": "State per cancellare il vostro account",
+          "warning-1": "Si noti che l'account non può essere recuperato dopo l'eliminazione.",
+          "warning-2": "Non appena confermate, verrete automaticamente disconnessi e la vostra richiesta verrà immediatamente elaborata."
+        },
+        "more-information": "Per ulteriori informazioni,",
+        "more-information-contact-support": "è possibile contattare l'assistenza.",
+        "title": "Cancellare definitivamente il mio account",
+        "warning-email": "Questa azione è irreversibile. Tutte le competenze, i corsi e i {pixScore} pix ottenuti saranno eliminati definitivamente per l'account PIX che utilizza l'indirizzo e-mail <strong>{email}</strong>.",
+        "warning-other": "Questa azione è irreversibile. Tutte le competenze, i corsi e i {pixScore} pix ottenuti saranno eliminati definitivamente per l'account PIX <strong>{firstName} {lastName}</strong>."
+      },
+      "email-confirmed": "Indirizzo e-mail verificato.",
+      "email-verification": {
+        "code-explanation-of-use": "Per spostarsi da un campo all'altro, utilizzare la tabulazione o le frecce destra e sinistra della tastiera. Per compilare un campo, inserire i numeri da 1 a 9 o utilizzare le frecce su e giù della tastiera.",
+        "code-label": "Campo",
+        "code-legend": "Inserire il codice di verifica inviato per e-mail",
+        "confirmation-message": "E-mail inviata!",
+        "description": "Inserire il codice di verifica ricevuto all'indirizzo e-mail :",
+        "did-not-receive": "Non ho ricevuto nulla,",
+        "errors": {
+          "email-modification-demand-expired": "Questo codice è scaduto. Si prega di rinnovare la richiesta.",
+          "incorrect-code": "Il codice inserito non è corretto.",
+          "new-email-already-exist": "Questo indirizzo e-mail è già in uso.",
+          "unknown-error": "Si è verificato un errore. Riprovare o contattare l'assistenza."
+        },
+        "send-back-the-code": "inviami il codice",
+        "time-code-validation": "Il codice ricevuto è valido per 10 minuti",
+        "title": "Controllo dell'indirizzo e-mail",
+        "update-successful": "Il tuo indirizzo e-mail è stato modificato!"
+      },
+      "language": {
+        "lang": "Lingua",
+        "menu-link-title": "Scegliete la vostra lingua",
+        "update-successful": "La vostra lingua è stata cambiata!"
+      },
+      "personal-information": {
+        "first-name": "Nome",
+        "last-name": "Nome",
+        "menu-link-title": "I miei dati personali"
+      },
+      "title": "Il mio account"
+    },
+    "user-tests": {
+      "anonymised-participations": {
+        "course": "Corso",
+        "states": {
+          "completed": "completato",
+          "started": "iniziato"
+        },
+        "title": "Corsi per disabili"
+      },
+      "description": "Trovate i vostri percorsi Pix, seguite i vostri progressi e riprendete semplicemente da dove avete lasciato.",
+      "title": "I miei percorsi di carriera"
+    },
+    "user-trainings": {
+      "description": "Continuare a progredire grazie ai corsi di formazione consigliati al termine della valutazione.",
+      "title": "I miei corsi di formazione"
+    },
+    "user-tutorials": {
+      "description": "Migliorate le vostre competenze digitali con esercitazioni adatte al vostro livello.",
+      "empty-list-info": {
+        "description": {
+          "part1": "Durante lo svolgimento dei test, vi verranno suggerite delle esercitazioni: fate clic sull'icona del segnalibro",
+          "part2": "per registrare quelli che volete trovare qui!"
+        },
+        "image-link": "images/illustrations/user-tutorials/illustration-en.svg",
+        "title": "Non avete ancora registrato nulla"
+      },
+      "filter": "Filtro",
+      "label": "tutorial",
+      "list": {
+        "title": "La mia lista",
+        "tutorial": {
+          "actions": {
+            "evaluate": {
+              "extra-information": "Contrassegnare questa esercitazione come utile",
+              "label": "Non considera più utile questo tutorial"
+            },
+            "remove": {
+              "label": "Rimuovere dal mio elenco di tutorial"
+            },
+            "save": {
+              "label": "Aggiungi al mio elenco di tutorial"
+            }
+          },
+          "source": "Da"
+        }
+      },
+      "recommended": "Consigliato",
+      "recommended-empty": {
+        "description": "Per consigliare le esercitazioni adatte al vostro livello, è necessario avviare un test delle competenze.",
+        "link": "Inizio",
+        "title": "{firstName}, trovate i vostri tutorial preferiti qui"
+      },
+      "saved": "Registrato",
+      "saved-empty": {
+        "description": "È necessario registrare un'esercitazione consigliata per farla apparire qui.",
+        "title": "Non ci sono ancora esercitazioni registrate"
+      },
+      "sidebar": {
+        "reset": "Reset",
+        "reset-aria-label": "Azzeramento e deselezione di tutti i filtri",
+        "see-results": "Guarda i risultati"
+      },
+      "title": "I miei tutorial"
+    }
+  }
+}

--- a/orga/app/services/locale.js
+++ b/orga/app/services/locale.js
@@ -16,13 +16,13 @@ export const ENGLISH_INTERNATIONAL_LOCALE = 'en';
 
 const DEFAULT_LANGUAGE = new Intl.Locale(DEFAULT_LOCALE).language;
 
-const PIX_LOCALES = ['en', 'es', 'es-419', 'fr', 'nl', 'fr-BE', 'fr-FR', 'nl-BE'];
+const PIX_LOCALES = ['en', 'es', 'es-419', 'fr', 'nl', 'fr-BE', 'fr-FR', 'nl-BE', 'it'];
 
 // Currently the challenge locales are not in canonical locales, thus the "fr-fr" value.
 // This cannot be changed without migrating the challenges content.
 const PIX_CHALLENGE_LOCALES = ['en', 'fr', 'fr-fr', 'nl', 'es', 'es-419', 'it', 'de'];
 
-const PIX_LANGUAGES = ['fr', 'en', 'nl', 'es'];
+const PIX_LANGUAGES = ['fr', 'en', 'nl', 'es', 'it'];
 
 const COOKIE_LOCALE = 'locale';
 

--- a/orga/app/services/url-base.js
+++ b/orga/app/services/url-base.js
@@ -56,6 +56,7 @@ export const PIX_WEBSITE_ROOT_URLS = {
   en: 'https://pix.org/en',
   es: 'https://pix.org/en',
   'es-419': 'https://pix.org/en',
+  it: 'https://pix.org/en',
   fr: 'https://pix.org/fr',
 };
 
@@ -69,6 +70,7 @@ export const PIX_WEBSITE_PATHS = {
     en: 'terms-and-conditions',
     es: 'terms-and-conditions',
     'es-419': 'terms-and-conditions',
+    it: 'terms-and-conditions',
     fr: 'conditions-generales-d-utilisation',
   },
   LEGAL_NOTICE: {
@@ -79,6 +81,7 @@ export const PIX_WEBSITE_PATHS = {
     en: 'legal-notice',
     es: 'legal-notice',
     'es-419': 'legal-notice',
+    it: 'legal-notice',
     fr: 'mentions-legales',
   },
   DATA_PROTECTION_POLICY: {
@@ -89,6 +92,7 @@ export const PIX_WEBSITE_PATHS = {
     en: 'personal-data-protection-policy',
     es: 'personal-data-protection-policy',
     'es-419': 'personal-data-protection-policy',
+    it: 'personal-data-protection-policy',
     fr: 'politique-protection-donnees-personnelles-app',
   },
   ACCESSIBILITY: {
@@ -99,6 +103,7 @@ export const PIX_WEBSITE_PATHS = {
     en: 'accessibility',
     es: 'accessibility',
     'es-419': 'accessibility',
+    it: 'accessibility',
     fr: 'accessibilite',
   },
   ACCESSIBILITY_ORGA: {
@@ -109,6 +114,7 @@ export const PIX_WEBSITE_PATHS = {
     en: 'accessibility-pix-orga',
     es: 'accessibility-pix-orga',
     'es-419': 'accessibility-pix-orga',
+    it: 'accessibility-pix-orga',
     fr: 'accessibilite-pix-orga',
   },
   ACCESSIBILITY_CERTIF: {
@@ -119,6 +125,7 @@ export const PIX_WEBSITE_PATHS = {
     en: 'accessibility-pix-certif',
     es: 'accessibility-pix-certif',
     'es-419': 'accessibility-pix-certif',
+    it: 'accessibility-pix-certif',
     fr: 'accessibilite-pix-certif',
   },
   SUPPORT: {
@@ -129,6 +136,7 @@ export const PIX_WEBSITE_PATHS = {
     en: 'support',
     es: 'support',
     'es-419': 'support',
+    it: 'support',
     fr: 'support',
   },
   CERTIFICATION_RESULTS_EXPLANATION: {
@@ -139,6 +147,18 @@ export const PIX_WEBSITE_PATHS = {
     en: 'understand-certification-results',
     es: 'understand-certification-results',
     'es-419': 'understand-certification-results',
+    it: 'understand-certification-results',
     fr: 'certification-comprendre-score-niveau',
+  },
+  CERTIFICATION_HOW_TO: {
+    'fr-FR': 'se-certifier',
+    'fr-BE': 'se-certifier',
+    'nl-BE': 'mijn-digitale-vaardigheden-certificeren',
+    nl: 'mijn-digitale-vaardigheden-certificeren',
+    en: 'certify-my-digital-skills',
+    es: 'certify-my-digital-skills',
+    'es-419': 'certify-my-digital-skills',
+    it: 'certify-my-digital-skills',
+    fr: 'se-certifier',
   },
 };

--- a/orga/config/environment.js
+++ b/orga/config/environment.js
@@ -39,6 +39,7 @@ module.exports = function (environment) {
         { value: 'fr-BE', nativeName: 'Français (Belgique)', displayedInSwitcher: true },
         { value: 'en', nativeName: 'English', displayedInSwitcher: true },
         { value: 'nl', nativeName: 'Nederlands', displayedInSwitcher: false },
+        { value: 'it', nativeName: 'Italiano', displayedInSwitcher: true },
         { value: 'nl-BE', nativeName: 'Nederlands (België)', displayedInSwitcher: true },
       ],
       BANNER_CONTENT: process.env.BANNER_CONTENT || '',

--- a/orga/tests/unit/services/locale-test.js
+++ b/orga/tests/unit/services/locale-test.js
@@ -71,7 +71,7 @@ module('Unit | Services | locale', function (hooks) {
       const pixLocales = localeService.pixLocales;
 
       // then
-      assert.deepEqual(pixLocales, ['en', 'es', 'es-419', 'fr', 'nl', 'fr-BE', 'fr-FR', 'nl-BE']);
+      assert.deepEqual(pixLocales, ['en', 'es', 'es-419', 'fr', 'nl', 'fr-BE', 'fr-FR', 'nl-BE', 'it']);
     });
   });
 
@@ -81,7 +81,7 @@ module('Unit | Services | locale', function (hooks) {
       const pixLanguages = localeService.pixLanguages;
 
       // then
-      assert.deepEqual(pixLanguages, ['fr', 'en', 'nl', 'es']);
+      assert.deepEqual(pixLanguages, ['fr', 'en', 'nl', 'es', 'it']);
     });
   });
 
@@ -282,6 +282,10 @@ module('Unit | Services | locale', function (hooks) {
         {
           label: 'Français (Belgique)',
           value: 'fr-BE',
+        },
+        {
+          label: 'Italiano',
+          value: 'it',
         },
         {
           label: 'Nederlands (België)',

--- a/orga/translations/it.json
+++ b/orga/translations/it.json
@@ -1,0 +1,2024 @@
+{
+  "api-error-messages": {
+    "campaign-creation": {
+      "custom-landing-page_too_long": "Il testo di presentazione della campagna è troppo lungo.",
+      "external-user-id-required": "Si prega di specificare la formulazione del campo che i partecipanti dovranno compilare all'inizio del corso.",
+      "id-pix-type-required": "Selezionare un tipo di identificatore esterno.",
+      "name-required": "Date un nome alla vostra campagna.",
+      "owner_not_in_organization": "Il proprietario non fa parte dell'organizzazione.",
+      "purpose-required": "Scegliete l'obiettivo della vostra campagna: valutazione o raccolta di profili.",
+      "target-profile-required": "Selezionare un percorso per la propria campagna.",
+      "title_too_long": "Il titolo della campagna è troppo lungo."
+    },
+    "csv-import": {
+      "property-not-uniq": "Riga {line}: il campo \"{field}\" deve essere unico all'interno del file."
+    },
+    "default": "Il servizio non è temporaneamente disponibile. Si prega di riprovare più tardi.",
+    "edit-student-number": {
+      "student-number-exists": "Il numero di studente inserito è già utilizzato dallo studente {firstName} {lastName}"
+    },
+    "global": "Si è verificato un errore. Riprovare più tardi.",
+    "or-separator": " o",
+    "student-csv-import": {
+      "bad-csv-format": "Il file deve essere in formato csv con un separatore di virgole o punti.",
+      "encoding-not-supported": "Codifica del file non supportata.",
+      "field-bad-values": "Riga {line}: Il campo \"{field}\" deve essere \"{valids}\".",
+      "field-date-format": "Riga {line}: il campo \"{field}\" deve essere in formato \"{acceptedFormat}\".",
+      "field-email-format": "Riga {line}: Il campo \"{field}\" deve essere un indirizzo e-mail valido.",
+      "field-length": "Riga {line}: il campo \"{field}\" deve essere lungo {limit} caratteri.",
+      "field-max-length": "Riga {line}: il campo \"{field}\" deve essere inferiore a {limit} caratteri.",
+      "field-min-length": "Riga {line}: il campo \"{field}\" deve essere lungo almeno {limit} caratteri.",
+      "field-required": "Riga {line}: il campo \"{field}\" è obbligatorio.",
+      "header-required": "La colonna \"{field}\" è obbligatoria.",
+      "header-unknown": "Le intestazioni delle colonne devono essere identiche a quelle del modello.",
+      "identifier-unique": "Riga {line}: il campo \"{field}\" in questa riga ricorre più volte nel file.",
+      "insee-code-invalid": "Riga {line}: il campo \"{field}\" non è in formato INSEE.",
+      "payload-too-large": "La dimensione del file deve essere inferiore a {maxSize}MB.",
+      "student-number-format": "Riga {line}: il campo \"{field}\" non deve contenere caratteri speciali.",
+      "student-number-unique": "Riga {line}: il campo \"{field}\" deve essere unico all'interno del file."
+    },
+    "student-password-reset": {
+      "organization-learner-does-not-belong-to-organization-error": "Alcuni degli studenti selezionati non sono più presenti in questa organizzazione.",
+      "organization-learner-without-username-error": "Alcuni studenti selezionati non hanno più il login. Si prega di aggiornare la pagina.",
+      "user-does-not-belong-to-organization-error": "Non si dispone più dei diritti per questa organizzazione."
+    },
+    "student-xml-import": {
+      "birth-city-code-required-for-french-student": "Un alunno con INE {nationalStudentId} non ha il campo del codice del comune di nascita compilato. È obbligatorio per ogni alunno nato in Francia.",
+      "birthdate-required": "L'alunno con l'INE {nationalStudentId} non ha il campo della data di nascita compilato. È obbligatorio per ogni alunno.",
+      "empty": "Gli studenti devono avere un INE e una classe.",
+      "encoding-not-supported": "Codifica del file non supportata.",
+      "first-name-required": "L'alunno con INE {nationalStudentId} non ha il campo nome compilato. È obbligatorio per ogni alunno.",
+      "ine-required": "Il campo INE è obbligatorio per ogni studente.",
+      "ine-unique": "L'INE {nationalStudentId} è presente più volte nel file per diversi alunni.",
+      "invalid-birthdate-format": "Uno studente con un INE di {nationalStudentId} non ha il formato corretto della data di nascita. Deve essere in formato 'GG/MM/AAAA'.",
+      "invalid-file": "Il file non è conforme.",
+      "invalid-file-extension": "Estensione {fileExtension} non supportata.",
+      "last-name-required": "L'alunno con INE {nationalStudentId} non ha il campo Cognome compilato. È obbligatorio per ogni alunno.",
+      "payload-too-large": "La dimensione del file deve essere inferiore a {maxSize}MB.",
+      "sex-code-required": "Uno studente con un INE di {nationalStudentId} non ha il campo sesso compilato. È obbligatorio per ogni alunno.",
+      "uai-mismatched": "L'UAI del file SIECLE non corrisponde a quello del vostro stabilimento."
+    }
+  },
+  "application": {
+    "description": "La piattaforma dedicata alla valutazione e al monitoraggio educativo. Il vostro spazio Pix Orga vi permette di lanciare una campagna di valutazione o di raccogliere i profili Pix, di seguire i progressi dei vostri studenti o allievi in una campagna o di accedere ai loro risultati."
+  },
+  "banners": {
+    "certification": {
+      "message": "'<strong>'Certificazioni:'</strong>' non dimenticate di '<'a href={documentationLink} class=\"{linkClasses}\" target=\"_blank\" rel=\"noopener noreferrer\"'>'finalizzare le sessioni in Pix Certif'</a>' e poi scaricare i certificati tramite la scheda \"Certificazioni\" prima dell'inizio del nuovo anno scolastico {year}."
+    },
+    "ia": {
+      "message": "I nuovi percorsi di apprendimento Pix sull'IA sono disponibili nel vostro spazio Pix Orga! Sono obbligatori per gli alunni delle 4e, 2de (generale e tecnologica) e del 1° anno del PAC, con un'implementazione graduale negli anni scolastici 2025-2026 e 2026-2027.",
+      "step1": "Consultate '<'a href='https://cloud.pix.fr/s/rrkLPMS5dYGKRQ9' title='AI Deployment Kit' class='link--banner link--bold link--underlined' '>'the deployment kit'</a>'",
+      "step2": "Registratevi per il '<'a href='https://app.livestorm.co/pix-1/parcours-intelligence-artificielle-enseignement-scolaire?utm_source=pixorga' class='link-banner link--bold link--underlined' '>'webinar'</a>'."
+    },
+    "import": {
+      "message": "Fasi chiave dell'anno scolastico :",
+      "step1a": "Implementare : '<'a href='https://cloud.pix.fr/s/WjTnkSbFs9TDcSC' title='Guida scarica risultati' class='link--banner link- grassetto link--sottolineato' '>'scarica risultati'</a>' certificazione e",
+      "step1b": "Importazione",
+      "step1c": "database degli studenti (admin)",
+      "step2": "'<'a href='https://cloud.pix.fr/s/RaPpKjFHNX2kSR4' title='Guide Lancer les parcours de rentrée' class='link--banner link- grassetto link--sottolineato' '>'Créer les campagnes'</a>' (corsi rentrée, 6e, tematici, disciplinari, mirati...).",
+      "step3": "Certificare gli studenti. '<'a href='https://cloud.pix.fr/s/opiFxfjygR76S8y' title='Guida Preparazione e organizzazione della certificazione degli studenti' class='link--banner link- grassetto link--sottolineato' '>'Per saperne di più sulla certificazione'</a>'."
+    },
+    "last-places-lot-available": {
+      "message": "I biglietti scadono tra {days, number} giorni."
+    },
+    "maximum-places-exceeded": {
+      "message": "<b>La tua organizzazione non ha più posti disponibili!</b><br />Per beneficiare di tutte le funzionalità, ti preghiamo di liberare posti, di metterti in contatto con il tuo rappresentante Pix o di '<'a href='https://pix.fr/support/form/professionnel-le' title='contact-us(France)' class=\"{linkClasses}\"'>contattarci tramite questo modulo</a>'. <br />Se siete un'organizzazione al di fuori della Francia '<'a href='https://pix.org/fr/support/form/contactez-le-support-pix' title='contact us (outside France)' class=\"{linkClasses}\" '>contattateci tramite questo modulo</a>'."
+    },
+    "over-capacity": {
+      "message": "Si noti che si sta utilizzando un numero di posti superiore alla capacità totale."
+    },
+    "survey": {
+      "message": "Aiutate Pix a far evolvere Pix Orga rispondendo a questo breve sondaggio su come utilizzate le campagne! '<'a href={documentationLink} class=\"{linkClasses}\" target=\"_blank\" rel=\"noopener noreferrer\"'>'Accedi al sondaggio'</a>'"
+    }
+  },
+  "cards": {
+    "available-seats-count": {
+      "title": "Posti disponibili",
+      "value": "/{total} posti"
+    },
+    "badges-acquisitions": {
+      "information": "Qui troverete il numero di badge ottenuti dai vostri partecipanti a questa campagna, nonché la percentuale ottenuta.",
+      "obtained": "ottenuto",
+      "title": "Distintivi"
+    },
+    "occupied-seats-count": {
+      "anonymous": "incluso {count, plural, =1 {1 posto} other {{count, number} posti}} con accesso senza account",
+      "title": "Posti occupati",
+      "value": "/{total} posti"
+    },
+    "participants-average-results": {
+      "information": "Qui troverete i risultati medi della vostra campagna. Questo numero comprende tutti i partecipanti che hanno completato il corso e inviato i risultati.",
+      "title": "Risultato medio"
+    },
+    "participants-average-stages": {
+      "information": "Qui potete vedere il numero medio di partecipanti alla vostra campagna. Questo numero comprende tutti i partecipanti che hanno completato il corso e inviato i risultati.",
+      "title": "Cuscinetto medio"
+    },
+    "participants-count": {
+      "information": "Qui troverete il numero totale di partecipanti alla vostra campagna. Questo numero comprende tutti i partecipanti che hanno inserito il codice e hanno iniziato il loro viaggio o inviato il loro profilo.",
+      "loader": "Caricamento del numero totale di partecipanti",
+      "title": "Numero totale di partecipanti"
+    },
+    "place-info": {
+      "with-account": {
+        "heading": "'<strong>'Il partecipante ha un conto Pix:'</strong>'",
+        "message-description": "È possibile liberare posti eliminando i partecipanti dalla scheda Partecipanti.",
+        "message-main": "1 partecipante con almeno una partecipazione a una campagna = 1 posto occupato."
+      },
+      "without-account": {
+        "heading": "'<strong>'Il partecipante non ha un account Pix'</strong>' (campagna con accesso senza account):",
+        "message-description": "È possibile liberare questi spazi eliminando le voci della campagna senza accesso all'account interessato o cancellando la campagna.",
+        "message-main": "1 partecipazione senza conto = 1 posto occupato."
+      }
+    },
+    "submitted-count": {
+      "loader": "Caricamento dei risultati o dei profili ricevuti",
+      "title": "Partecipazioni completate"
+    }
+  },
+  "charts": {
+    "participants-by-day": {
+      "captions": {
+        "shared": "Iscrizioni completate al giorno",
+        "started": "Numero totale di partecipanti al giorno"
+      },
+      "labels-a11y": {
+        "date": "Data",
+        "shared": "Partecipazioni completate",
+        "started": "Numero totale di partecipanti"
+      },
+      "labels-legend": {
+        "shared": "Partecipazioni completate",
+        "started": "Numero totale di partecipanti"
+      },
+      "loader": "Caricamento dell'attività dei partecipanti",
+      "title": "Attività dei partecipanti"
+    },
+    "participants-by-mastery-percentage": {
+      "label-a11y": "Da {from, number, ::percent} a {to, number, ::percent}: {count, plural, =0 {0 partecipanti} =1 {1 partecipante} other {{count, number} partecipanti}}.",
+      "loader": "Caricamento della ripartizione dei partecipanti per risultato",
+      "title": "Ripartizione dei partecipanti per risultato",
+      "tooltip": {
+        "label": "Numero di partecipanti: {count}",
+        "legend": "{from, number, ::percent} - {to, number, ::percent}",
+        "title": "Risultati {legend}"
+      }
+    },
+    "participants-by-stage": {
+      "loader": "Caricamento della ripartizione dei partecipanti per livelli",
+      "participants": "{count, plural, =0 {0 partecipanti} =1 { 1 partecipante} other {{count, number} partecipanti}}",
+      "title": "Ripartizione dei partecipanti per livello"
+    },
+    "participants-by-status": {
+      "a11y-title": "Ripartizione per stato",
+      "labels-a11y": {
+        "shared": "{count, plural, =0 {0 partecipanti} =1 {1 partecipanti} other {{count, number} partecipanti}} che hanno inviato i loro risultati",
+        "started": "{count, plural, =0 {0 partecipanti} =1 {1 partecipante} other {{count, number} partecipanti}} in fase di sperimentazione"
+      },
+      "labels-legend": {
+        "shared": "Voci chiuse ({count})",
+        "started": "In corso ({count})"
+      },
+      "labels-tooltip": {
+        "shared": "Iscrizioni chiuse: {percentage, number, ::percent .0}",
+        "started": "In corso: {percentage, number, ::percent .0}"
+      },
+      "loader": "Proporzioni di carico per stato",
+      "title": "Statuto"
+    }
+  },
+  "common": {
+    "actions": {
+      "back": "Torna a",
+      "cancel": "Annullamento",
+      "close": "Chiudere",
+      "confirm": "Confermare",
+      "global": "Azioni",
+      "link-to-participant": "Visualizza tutte le attività dei partecipanti",
+      "save": "Registro"
+    },
+    "api-error-messages": {
+      "account-conflict": "Questo account è già associato a questa organizzazione. Accedere con un altro account o contattare l'assistenza.",
+      "bad-request-error": "I dati inviati non sono nel formato corretto.",
+      "default": "Si è verificato un errore. Riprovare o contattare l'assistenza.",
+      "expired-authentication-key": "La richiesta di autenticazione è scaduta.",
+      "internal-server-error": "Si è verificato un errore interno. I nostri team stanno risolvendo il problema. Si prega di riprovare più tardi.",
+      "login-unauthorized-error": "L'indirizzo e-mail o il nome utente e/o la password inseriti non sono corretti.",
+      "login-unauthorized-remaining-attempts-error": "Attenzione: avete ancora {remainingAttempts, plural, =0 {0 tentativi} =1 {1 tentativo} other {# tentativi}} prima che il vostro account Pix venga bloccato definitivamente.",
+      "login-unauthorized-remaining-attempts-with-user-name-error": "Attenzione: hai ancora {remainingAttempts, plural, =0 {0 tentativi} =1 {1 tentativo} other {# tentativi}} prima che il tuo account Pix venga definitivamente bloccato.'<br>'Se lo dimentichi, '<strong>'contatta il tuo insegnante'</strong>' per reimpostare la password e/o recuperare il tuo login.",
+      "login-unauthorized-with-user-name-error": "Il nome utente e/o la password inseriti non sono corretti.'<br>'In caso di dimenticanza, '<strong>'contatta il tuo insegnante'</strong>' per reimpostare la password e/o recuperare il nome utente.",
+      "login-unexpected-error": "Impossibile connettersi. Riprovare tra qualche istante. Se il problema persiste, '<'a href=\"{supportHomeUrl}\" target=\"blank\"'>'contattateci tramite il centro assistenza'</a>'.",
+      "login-user-blocked-error": "Il suo account è bloccato perché ha effettuato troppi tentativi di connessione. Per sbloccarlo, '<'a href=\"{url}\"'>'contattaci'</a>'.",
+      "login-user-temporary-blocked-error": "Hai effettuato troppi tentativi di accesso, il tuo account Pix è temporaneamente bloccato per {blockingDurationMinutes} minuti. Riprova più tardi o clicca su '<'a href=\"{url}\"'>'password dimenticata'</a>' per resettarla.",
+      "login-user-temporary-blocked-with-username-error": "Hai effettuato troppi tentativi di accesso, il tuo account Pix è temporaneamente bloccato per {blockingDurationMinutes} minuti.'<br>'In caso di dimenticanza, '<strong>'contatta il tuo insegnante'</strong>' per reimpostare la password e/o recuperare l'accesso."
+    },
+    "breadcrumb": "Percorso a briciole di pane",
+    "cgu": {
+      "error": "Per creare un account è necessario accettare le condizioni d'uso e l'informativa sulla privacy di Pix.",
+      "label": "Accetto le condizioni d'uso e l'informativa sulla privacy di Pix",
+      "read-message": "Leggere le '<'a href=\"{cguUrl}\" class=\"link\" target=\"_blank\" rel=\"noreferrer\"'>'condizioni d'uso'</a>' e le '<'a href=\"{dataProtectionPolicyUrl}\" class=\"link\" target=\"_blank\" rel=\"noreferrer\"'>'norme sulla privacy'</a>'."
+    },
+    "filters": {
+      "actions": {
+        "clear": "Eliminare i filtri"
+      },
+      "divisions": {
+        "empty": "Nessuna classe",
+        "label": "Ricerca per classe",
+        "placeholder": "Le classi"
+      },
+      "fullname": {
+        "label": "Ricerca per nome e cognome",
+        "placeholder": "Cognome, nome"
+      },
+      "groups": {
+        "empty": "Nessun gruppo",
+        "label": "Ricerca per gruppo",
+        "placeholder": "Gruppi"
+      },
+      "loading": "Caricamento...",
+      "placeholder": "-- Seleziona...",
+      "title": "Filtri"
+    },
+    "form": {
+      "mandatory-all-fields": "Tutti i campi sono obbligatori.",
+      "mandatory-fields": "indica un campo obbligatorio",
+      "mandatory-fields-title": "obbligatorio"
+    },
+    "fullname": "{firstName} {lastName}",
+    "help-form": "https://support.pix.fr/support/tickets/new",
+    "home-page": "Pagina iniziale di Pix Orga",
+    "import": {
+      "field": {
+        "birthdate": "Data di nascita",
+        "division": "Classe",
+        "oralization": "Leggere le istruzioni"
+      }
+    },
+    "loading": "Caricamento in corso",
+    "no-content": "Nessun contenuto",
+    "result": {
+      "accessibility-description": "Risultato ottenuto = {percentage, number, ::percent}, cioè il cuscinetto {stage} su {totalStage}.",
+      "percentage": "{value, number, ::percent}",
+      "stages": "{count, plural, =0 {0 stelle} =1 {1 stella} other {{count, number} stelle}} su {total}"
+    },
+    "target-profile-details": {
+      "results": {
+        "common": "Risultati visualizzati in",
+        "percent": "percentuale",
+        "star": "stella"
+      },
+      "simplified-access": {
+        "with-account": "Accesso al conto",
+        "without-account": "Accesso senza account"
+      },
+      "subjects": "Argomenti : {value, number}",
+      "thematic-results": "Distintivi: {value, number}"
+    },
+    "validation": {
+      "password": {
+        "error": "È stata inserita una password errata. La password deve essere più lunga di 8 caratteri e contenere almeno un numero, una lettera minuscola e una lettera maiuscola.",
+        "rules": {
+          "contains-digit": "una cifra minima",
+          "contains-lowercase": "un minimo",
+          "contains-uppercase": "almeno una lettera maiuscola",
+          "min-length": "8 caratteri minimo"
+        }
+      }
+    }
+  },
+  "components": {
+    "activity-type": {
+      "explanation": {
+        "ASSESSMENT": "Campagna di valutazione",
+        "CAMPAIGN": "Campagna di valutazione",
+        "COMBINED_COURSE": "Percorso di apprendimento",
+        "EXAM": "Modalità di interrogazione [beta]",
+        "FORMATION": "Formazione",
+        "MODULE": "Modulo",
+        "PROFILES_COLLECTION": "Campagna di raccolta profili"
+      },
+      "information": {
+        "ASSESSMENT": "Valutazione",
+        "CAMPAIGN": "Valutazione",
+        "COMBINED_COURSE": "Percorso di apprendimento",
+        "EXAM": "Modalità di interrogazione [beta]",
+        "FORMATION": "Formazione",
+        "MODULE": "Modulo",
+        "PROFILES_COLLECTION": "Collezione di profili"
+      }
+    },
+    "analysis-per-competence": {
+      "cover-rate-gauge-label": "{count, plural, =1 { Sulla competenza il partecipante ha raggiunto un livello di {reachedLevel} su un livello massimo raggiungibile di {maxLevel}.} other {Sulla competenza i partecipanti hanno raggiunto un livello di {reachedLevel} su un livello massimo raggiungibile di {maxLevel}.}}.",
+      "description": "{count, plural, =1 {Di seguito, si trovano le competenze della campagna e le loro descrizioni, nonché il posizionamento dei partecipanti.} other {Di seguito, si trovano le competenze della campagna e le loro descrizioni, nonché il posizionamento dei partecipanti.}}",
+      "table": {
+        "caption": "Competenze",
+        "column": {
+          "competences": "Nome e descrizione dell'abilità",
+          "level": "Livello",
+          "positioning": "Posizionamento"
+        }
+      }
+    },
+    "analysis-per-tube": {
+      "cover-rate-gauge-label": "{count, plural, =1 {Sull'argomento i partecipanti hanno raggiunto un livello di {reachedLevel} su un livello massimo raggiungibile di {maxLevel}.} other {Sull'argomento i partecipanti hanno raggiunto un livello di {reachedLevel} su un livello massimo raggiungibile di {maxLevel}.}}.",
+      "description": "{count, plural, =1 {Di seguito, i temi della campagna e le loro descrizioni, nonché il posizionamento dei partecipanti.} other {Di seguito, i temi della campagna e le loro descrizioni, nonché il posizionamento dei partecipanti.}}",
+      "table": {
+        "caption": "{index} - {name}",
+        "column": {
+          "level": "Livello",
+          "positioning": "Posizionamento",
+          "tubes": "Nome e descrizione del soggetto"
+        }
+      }
+    },
+    "analysis-per-tube-or-competence": {
+      "title": "Posizionamento dettagliato",
+      "toggle": {
+        "label": "Visualizzato da :",
+        "label-competences": "Competenze",
+        "label-tubes": "Soggetti"
+      }
+    },
+    "authentication": {
+      "authentication-identity-providers": {
+        "select-another-organization-link": "Scegliere un altro metodo di connessione",
+        "spacer": {
+          "or": "o"
+        }
+      },
+      "oidc-association-confirmation": {
+        "authentication-method-to-add": "Aggiunta di una connessione",
+        "confirm": "Continua",
+        "current-authentication-methods": "I miei metodi di connessione attuali",
+        "email": "Indirizzo e-mail",
+        "external-connection": "Collegamento esterno",
+        "external-connection-via": "Connessione tramite",
+        "return": "Torna a",
+        "title": "Un nuovo metodo di accesso sta per essere aggiunto al vostro account Pix.",
+        "username": "Identificatore"
+      },
+      "oidc-provider-selector": {
+        "label": "Ricerca di un metodo di connessione",
+        "placeholder": "Selezionare un metodo di connessione",
+        "searchLabel": "Ricerca per parole chiave"
+      }
+    },
+    "certificability": {
+      "placeholder-select": "Certificabile / Non certificabile"
+    },
+    "certificability-tooltip": {
+      "aria-label": "Spiegazione della certificabilità",
+      "content": "La certificabilità significa che il partecipante ha raggiunto il livello 1 in almeno 5 competenze diverse.",
+      "from-collect-notice": "Le informazioni provengono dalle campagne di raccolta dei profili effettuate dal partecipante. Se il partecipante ha già inviato il proprio profilo, vengono visualizzati la data e lo stato dell'ultimo invio.",
+      "from-compute-certificability": "Questo stato viene aggiornato automaticamente (ogni 24 ore) e durante le campagne di raccolta dei profili."
+    },
+    "cover-rate-gauge": {
+      "label": "In questa campagna, i partecipanti hanno raggiunto un livello di {reachedLevel} su un livello massimo raggiungibile di {maxLevel}."
+    },
+    "date": {
+      "no-date": "Non c'è ancora una data"
+    },
+    "global-positioning": {
+      "description": "Il posizionamento complessivo è il livello medio raggiunto dai partecipanti (barra viola) rispetto al massimo che avrebbero potuto raggiungere in questa campagna (barra bianca).",
+      "gauge-label": "Durante questa campagna, i vostri partecipanti hanno raggiunto un livello medio di {reachedLevel} su un livello massimo raggiungibile di {maxLevel}.",
+      "title": "Posizionamento globale"
+    },
+    "group": {
+      "SCO": "Classe",
+      "SUP": "Gruppo"
+    },
+    "import-information-banner": {
+      "error": "Importazione fallita",
+      "error-link": "(vedere la pagina di importazione).",
+      "in-progress": "È in corso un'importazione",
+      "in-progress-link": "(controllare lo stato di importazione).",
+      "success": "I partecipanti sono stati effettivamente importati su {date} da {firstname} {lastname}."
+    },
+    "index": {
+      "action-cards": {
+        "classic": {
+          "create-campaign": {
+            "buttonText": "Nuova campagna",
+            "description": "Scegliete il corso su cui volete valutare i vostri partecipanti o raccogliere il loro profilo Pix.",
+            "title": "Creare una campagna"
+          },
+          "follow-activity": {
+            "buttonText": "Vedi le mie campagne",
+            "description": "Visualizzare lo stato e i risultati dei partecipanti.",
+            "title": "Tracciamento dell'attività"
+          }
+        },
+        "missions": {
+          "extend-session": {
+            "buttonText": "Estendere la sessione"
+          },
+          "follow-activity": {
+            "buttonText": "Vedere le missioni",
+            "description": "Visualizzare lo stato e i risultati dei partecipanti.",
+            "title": "Tracciamento dell'attività"
+          },
+          "launch-session": {
+            "buttonText": "Attivare la sessione",
+            "description": "La sessione consente agli studenti di accedere a Pix Junior per 4 ore. Una volta attivata, la sessione può essere prolungata.",
+            "title": "Gestione di una sessione"
+          }
+        },
+        "title": "Cosa ti piacerebbe fare?"
+      },
+      "organization-information": {
+        "label": "Nome dell'organizzazione",
+        "title": "Informazioni sulla vostra organizzazione"
+      },
+      "participation-statistics": {
+        "completed-participations": {
+          "description": "Partecipazioni completate negli ultimi 30 giorni.",
+          "info": "Il numero di partecipazioni completate negli ultimi 30 giorni comprende le campagne attive di cui si è proprietari.",
+          "no-completed-participations": "Nessuna iscrizione completata negli ultimi 30 giorni.",
+          "title": "Partecipazioni completate"
+        },
+        "completion-rate": {
+          "description": "{completed} voci completate su {started} voci avviate.",
+          "info": "Il tasso di completamento viene calcolato in base alle campagne attive di cui si è titolari.",
+          "no-activity": "Nessuna attività al momento",
+          "title": "Tasso di completamento"
+        }
+      },
+      "welcome": {
+        "description": {
+          "classic": "Benvenuti nella vostra piattaforma di valutazione e sviluppo delle competenze digitali! Create e distribuite campagne ai vostri partecipanti. Tracciate i loro progressi e analizzate i loro risultati in modo da poter offrire loro un supporto su misura per le loro esigenze.",
+          "missions": "Benvenuti nella vostra piattaforma per il monitoraggio delle competenze digitali dei vostri alunni! Selezionate i compiti e seguite i loro progressi."
+        },
+        "title": "Ciao {name},"
+      }
+    },
+    "locale-switcher": {
+      "label": "Selezionare una lingua"
+    },
+    "organization-participants-header": {
+      "default": {
+        "title": "{count, plural, =0 {Partecipanti} =1 {Partecipanti ({count})} other {Partecipanti ({count})}}"
+      },
+      "import-button": "Importazione",
+      "sco": {
+        "title": "{count, plural, =0 {Studenti} =1 {Studenti ({count})} other {Studenti ({count})}}"
+      },
+      "sco-title": "{count, plural, =0 {Studenti} =1 {Studente ({count})} other {Studenti ({count})}}",
+      "title": "{count, plural, =0 {Partecipanti} =1 {Partecipanti ({count})} other {Partecipanti ({count})}}"
+    },
+    "participation-status": {
+      "COMPLETED": "Completato",
+      "LOCKED": "Per sbloccare",
+      "NOT_STARTED": "Per fare",
+      "SHARED": "Completato",
+      "STARTED": "In corso"
+    },
+    "terms-of-service": {
+      "actions": {
+        "accept": "Accettare e continuare",
+        "document-link": "Leggere le condizioni di utilizzo",
+        "reject": "Rifiuto e uscita"
+      },
+      "message": {
+        "requested": "Per continuare a utilizzare Pix, leggere e accettare i nostri Termini e condizioni d'uso.",
+        "update-requested": "Abbiamo aggiornato i nostri T&C. Si prega di controllare le modifiche e di accettarle per continuare."
+      },
+      "title": {
+        "requested": "Si prega di accettare le nostre Condizioni Generali d'Uso (CGU).",
+        "update-requested": "Importante aggiornamento delle Condizioni generali d'uso (GTCU)"
+      }
+    },
+    "ui": {
+      "deletion-modal": {
+        "confirm-deletion": "Sì, sto cancellando",
+        "confirmation-checkbox": "Confermo di aver compreso appieno l'impatto delle {count} cancellazioni."
+      },
+      "edit-participant-name-modal": {
+        "error-messages": {
+          "first-name": "Il nome dell'utente non può essere vuoto.",
+          "last-name": "Il nome utente non può essere vuoto."
+        },
+        "fields": {
+          "first-name": "Nome",
+          "last-name": "Nome"
+        },
+        "label": "Modifica del nome utente",
+        "success-message": "Nome aggiornato con successo"
+      }
+    }
+  },
+  "navigation": {
+    "assessment-individual-results": {
+      "aria-label": "Navigazione nella sezione dei risultati della valutazione individuale"
+    },
+    "campaign-page": {
+      "aria-label": "Navigazione nella sezione dei dettagli della campagna"
+    },
+    "credits": {
+      "number": "{count, plural, =0 {0 crediti} =1 { 1 credito} other {{count, number} crediti}}",
+      "tooltip-text": "Il numero di crediti visualizzato corrisponde al numero di crediti acquisiti dall'organizzazione e attualmente validi (indipendentemente dalla loro attivazione). Per ulteriori informazioni, contattateci all'indirizzo '<a href=mailto:pro@pix.fr>'pro@pix.fr'</a>'."
+    },
+    "external-link-title": "Aprire in una nuova finestra",
+    "footer": {
+      "a11y": "Accessibilità: parzialmente conforme",
+      "aria-label": "Navigazione a piè di pagina",
+      "copyrights": "©",
+      "help-center": "Centro assistenza",
+      "legal-notice": "Informazioni legali",
+      "pix": "Pix",
+      "server-status": "Stato del dipartimento"
+    },
+    "main": {
+      "aria-label": "Navigazione principale",
+      "attestations": "Certificati",
+      "campaigns": "Campagne",
+      "certifications": "Certificazioni",
+      "close": "Chiudere la navigazione",
+      "combined-courses": "Percorsi di apprendimento",
+      "documentation": "Documentazione",
+      "home": "Casa",
+      "missions": "Missioni",
+      "open": "Aprire la navigazione",
+      "organization-participants": "Partecipanti",
+      "places": "Luoghi",
+      "sco-organization-participants": "Studenti",
+      "statistics": "Statistiche",
+      "sup-organization-participants": "Studenti",
+      "support": "Centro assistenza",
+      "team": "Squadra"
+    },
+    "places": {
+      "link": "vedi dettagli",
+      "number": "{count, plural, =0 {0 posti disponibili} =1 { 1 posto disponibile} other {{count} posti disponibili}}"
+    },
+    "school-sessions": {
+      "activate-button": "Attivare la sessione",
+      "extend-button": "Estendere la sessione",
+      "status": {
+        "active-label": "Sessione attiva fino a {sessionExpirationDate}.",
+        "aria-label": "Spiegazione della sessione",
+        "code-label": "Codice della scuola",
+        "inactive-label": "Sessione inattiva",
+        "info-text": "Gli studenti possono accedere alle missioni solo quando la sessione è attiva.'<br>' Al termine della sessione, gli studenti nel bel mezzo di una missione non verranno disconnessi.",
+        "title": "Stato della sessione"
+      }
+    },
+    "team-members": {
+      "aria-label": "Navigazione nella sezione del team"
+    },
+    "user-logged-menu": {
+      "button": "Cambiamento dell'organizzazione",
+      "logout": "Disconnessione"
+    }
+  },
+  "pages": {
+    "assessment-individual-results": {
+      "badges": "Distintivi",
+      "breadcrumb-current-page-label": "Partecipazione di {firstName} {lastName}",
+      "participation-label": "Partecipazione #{participationNumber}",
+      "participation-not-shared": "Risultati non inviati",
+      "participation-selector": "Scegliere un paletto",
+      "participation-shared": "Risultati inviati",
+      "progression": "Avanzamento",
+      "result": "Risultati",
+      "tab": {
+        "results": "Risultati",
+        "review": "Analisi"
+      },
+      "table": {
+        "column": {
+          "competences": "Abilità ({count, plural, =0 {-} other {{count}}})",
+          "results": {
+            "label": "Risultati",
+            "tooltip": "'<span class=\"screen-reader-only\">'Questo partecipante ha convalidato'</span>' {result, number, ::percent} '<span class=\"screen-reader-only\">'di abilità {competence}.'</span>'"
+          }
+        },
+        "empty": "In attesa dei risultati",
+        "title": "Risultati per abilità"
+      },
+      "title": "Risultati da {firstName} {lastName}"
+    },
+    "attestations": {
+      "EDUCOLLAB": "Pix+Edu - Comunicare e collaborare",
+      "EDUCULTURENUM": "Pix+Edu - Alfabetizzazione digitale",
+      "EDUDOC": "Pix+Edu - Adattare i documenti",
+      "EDUIA": "Pix+Edu - Dati, algoritmi e AI",
+      "EDUINCONTOURNABLES": "Pix+Edu - L'essenziale",
+      "EDURESSOURCES": "Pix+Edu - Gestione e condivisione delle risorse",
+      "EDUSECU": "Pix+Edu - Sicurezza digitale",
+      "EDUSUPPORT": "Pix+Edu - Creare materiale didattico",
+      "EDUVEILLE": "Pix+Edu - Tenere d'occhio",
+      "MAIRIEBUREAU": "Mairie de Paris - Ufficio di base",
+      "MINARM": "Base digitale",
+      "PARENTHOOD": "Certificato di consapevolezza digitale",
+      "SIXTH_GRADE": "Certificato di consapevolezza digitale",
+      "basic-description": "Esportazione di tutti i certificati",
+      "download-attestations-button": "Scarica (.pdf)",
+      "no-attestations": "Nessun certificato disponibile per la vostra selezione",
+      "section": {
+        "download": "Scaricare",
+        "list": "Follow-up: {attestationName}"
+      },
+      "select-divisions-label": "Selezionare i certificati per una o più classi",
+      "select-label": "Certificato",
+      "table": {
+        "column": {
+          "division": "Classe",
+          "first-name": "Nome",
+          "last-name": "Nome",
+          "status": "Ottenere"
+        },
+        "filter": {
+          "divisions": {
+            "empty-option": "Classe",
+            "label": "Classe"
+          },
+          "legend": "Filtri per la tabella dei certificati: i campi di input possono essere utilizzati per filtrare la tabella in base al nome o al cognome dell'alunno e alla classe. I pulsanti possono essere utilizzati per filtrare o meno i certificati ottenuti.",
+          "results": "{total, plural, =0 {0 risultati} =1 { 1 risultato} other {{total, number} risultati}}",
+          "status": {
+            "empty-option": "Ottenuto / Non ottenuto",
+            "label": "Ottenere",
+            "not-obtained": "Non ottenuto",
+            "obtained": "Ottenuto"
+          }
+        },
+        "status": {
+          "not-obtained": "Non ottenuto",
+          "obtained": "Ottenuto su {date}"
+        }
+      },
+      "title": "Certificati"
+    },
+    "campaign": {
+      "actions": {
+        "export-results": "Esportazione dei risultati (.csv)",
+        "unarchive": "Disarchiviazione della campagna"
+      },
+      "archived": "Campagna archiviata",
+      "code": "Codice",
+      "copy": {
+        "code": {
+          "default": "Copiare il codice",
+          "success": "Ricevuto!"
+        },
+        "link": {
+          "default": "Copiare il link diretto",
+          "success": "Ricevuto!"
+        }
+      },
+      "created-by": "Proprietario",
+      "created-on": "Creato il",
+      "empty-state": "Nessun partecipante per ora!",
+      "empty-state-with-copy-link": "Non ci sono ancora partecipanti! Inviate loro il seguente link per aderire alla campagna.",
+      "included-in-combined-course": "Questa campagna di valutazione è inclusa nel percorso di apprendimento.",
+      "included-in-combined-course-end": ".",
+      "multiple-sendings": {
+        "status": {
+          "disabled": "No",
+          "enabled": "Sì"
+        },
+        "title": "Invio multiplo"
+      },
+      "name": "Nome della campagna",
+      "tab": {
+        "activity": "Attività",
+        "combined-courses": "Percorsi di apprendimento",
+        "results": "Risultati ({count, number})",
+        "review": "Analisi",
+        "settings": "Parametri"
+      }
+    },
+    "campaign-activity": {
+      "actions": {
+        "delete": "Cancellare"
+      },
+      "delete-participation-modal": {
+        "actions": {
+          "cancel": "No",
+          "confirmation": "Sì, sto cancellando"
+        },
+        "error": "Si è verificato un problema durante l'eliminazione della voce.",
+        "success": "La puntata è stata ritirata con successo.",
+        "text": "Se si sta per eliminare una voce, questa non sarà più visibile né inclusa nelle statistiche della campagna.",
+        "title": "Eliminare la partecipazione di <strong>{firstName} {lastName}</strong>?",
+        "warning": {
+          "assessment-campaign-participation": {
+            "shared-participation": "Il partecipante non potrà più accedere ai risultati di questa campagna.",
+            "started-participation": "Il partecipante non potrà più partecipare."
+          },
+          "profiles-collection-campaign-participation": {
+            "shared-participation": "Il partecipante non potrà più partecipare a questa raccolta di profili."
+          }
+        }
+      },
+      "table": {
+        "column": {
+          "delete": "Eliminare la partecipazione agli utili",
+          "first-name": "Nome",
+          "last-name": "Nome",
+          "participationCount": "Numero di voci",
+          "status": "Stato"
+        },
+        "delete-button-label": "Eliminare la partecipazione agli utili",
+        "empty": "Nessun partecipante",
+        "see-results": "Visualizza i risultati per {firstName} {lastName}",
+        "title": "Elenco dei partecipanti"
+      },
+      "title": "Attività"
+    },
+    "campaign-analysis": {
+      "description": {
+        "explanation": "{count, plural, =1 { Il posizionamento riflette il livello medio raggiunto dal partecipante, rispetto al livello massimo raggiungibile in questa campagna.} other { Il posizionamento riflette il livello medio raggiunto dai partecipanti, rispetto al livello massimo raggiungibile in questa campagna.}}",
+        "nota-bene": "{count, plural, =1 {Tutti i dati presentati provengono dalla partecipazione selezionata.} other {Tutti i dati presentati provengono da partecipazioni condivise e non cancellate da campagne di valutazione e vengono aggiornati ad ogni visita.}}",
+        "resume": "{count, plural, =1 {Analizzare per abilità o per materia, il posizionamento del partecipante a questa campagna che copre una selezione di argomenti del quadro di riferimento Pix.} other {Analizzare per abilità o per materia, il posizionamento dei vostri partecipanti a questa campagna che copre una selezione di argomenti del quadro di riferimento Pix.}}"
+      },
+      "levels-correspondence": {
+        "infos": {
+          "link": "https://pix.fr/score-et-niveaux",
+          "text": "Per saperne di più sui livelli."
+        },
+        "levels": {
+          "advanced": "5 o 6: Avanzato",
+          "beginner": "1 o 2: Novizio",
+          "expert": "7 o 8: Esperto",
+          "independent": "3 o 4: Lavoratore autonomo"
+        },
+        "title": "Corrispondenza tra i livelli"
+      },
+      "title": "Analisi"
+    },
+    "campaign-creation": {
+      "actions": {
+        "create": "Creare la campagna",
+        "delete": "Cancellare"
+      },
+      "combined-course-blueprints-label": "Selezionare un piano di percorso",
+      "combined-course-blueprints-list-label": "Selezionare un piano di percorso",
+      "copy-of": "Copia di",
+      "external-id-label": {
+        "label": "Formulazione dell'identificatore",
+        "question-label": "Desiderate richiedere un identificatore esterno?",
+        "required": "L'id esterno è obbligatorio",
+        "suggestion": "Esempio: \"Numero dello studente\" o \"Indirizzo e-mail professionale\" *."
+      },
+      "external-id-type": {
+        "question-label": "Qual è il tipo di identificatore esterno?"
+      },
+      "landing-page-text": {
+        "label": "Testo della pagina iniziale",
+        "sublabel": "Questo campo verrà visualizzato dai partecipanti alla campagna."
+      },
+      "legal-warning": "* In conformità con la legge francese sulla protezione dei dati, e in qualità di responsabile del trattamento dei dati, si prega di fare attenzione a non chiedere dati particolarmente identificativi o significativi, a meno che non siano assolutamente indispensabili. Il numero di previdenza sociale (NIR) deve essere evitato, così come qualsiasi altro dato sensibile.",
+      "multiple-sendings": {
+        "assessments": {
+          "info": "Se si sceglie di inviare la campagna più volte, il partecipante potrà ripetere la campagna più volte, inserendo nuovamente il codice. Avrete accesso a tutti i risultati.",
+          "question-label": "Volete consentire ai partecipanti di inviare i loro risultati più di una volta?"
+        },
+        "info-title": "Invio multiplo",
+        "knowledge-elements-resettable": "Nell'ambito del corso, i partecipanti possono cercare di migliorare i propri risultati ripetendo tutte le domande del corso.",
+        "profiles": {
+          "info": "Se si sceglie di inviare più profili, i partecipanti potranno inviare il proprio profilo più volte inserendo nuovamente il codice della campagna. All'interno di Pix Orga, si troverà l'ultimo profilo inviato.",
+          "question-label": "Volete consentire ai partecipanti di inviare il loro profilo più volte?"
+        }
+      },
+      "name": {
+        "label": "Nome della campagna"
+      },
+      "no": "No",
+      "owner": {
+        "info": "Il proprietario della campagna e gli amministratori di questa organizzazione sono le uniche persone che possono modificare o archiviare questa campagna.",
+        "label": "Proprietario della campagna",
+        "placeholder": "Nome e cognome del proprietario",
+        "search-placeholder": "Trovare un proprietario",
+        "title": "Proprietario della campagna"
+      },
+      "purpose": {
+        "assessment": "Valutazione dei partecipanti",
+        "assessment-info": "Una campagna di valutazione consente ai partecipanti di essere testati su argomenti specifici.",
+        "combined-course": "Creare un percorso combinato",
+        "exam": "Modalità di interrogazione [beta]",
+        "exam-info": "Una campagna in \"modalità quiz\" consente di sottoporre i partecipanti a test su argomenti specifici, senza tenere conto del loro profilo utente e senza influire su di esso. I test proposti sono personalizzati per ogni partecipante, a seconda del livello di avanzamento del corso.",
+        "label": "Qual è l'obiettivo della vostra campagna?",
+        "profiles-collection": "Raccogliere i profili Pix dei partecipanti",
+        "profiles-collection-info": "Una campagna di raccolta di profili viene utilizzata per recuperare il profilo dei partecipanti: livelli per abilità e punteggio pix.",
+        "profiles-collection-info-certificability-calculation": "Lo stato di certificabilità viene aggiornato automaticamente nella scheda '<'a href=\"/eleves\" class=\"{linkClasses}\"'>'Studenti'</a>'."
+      },
+      "tags": {
+        "BACK_TO_SCHOOL": "Corso di ritorno a scuola / 6e",
+        "COMPETENCES": "Le 16 competenze",
+        "CUSTOM": "Corsi su misura",
+        "DISCIPLINE": "Disciplinare",
+        "OTHER": "Altro",
+        "PIX_PLUS": "Pix+",
+        "PREDEFINED": "Percorsi predefiniti",
+        "SUBJECT": "Temi",
+        "TARGETED": "Corsi mirati"
+      },
+      "tags-title": "Filtrare la ricerca :",
+      "target-profiles-category-label": "Filtrare i percorsi per categoria",
+      "target-profiles-category-placeholder": "Categorie",
+      "target-profiles-label": "Selezionare un percorso",
+      "target-profiles-list-label": "Cosa vorresti testare?",
+      "target-profiles-search-placeholder": "Ricerca per nome",
+      "test-title": {
+        "label": "Titolo del corso",
+        "sublabel": "Questo campo verrà visualizzato dai partecipanti alla campagna."
+      },
+      "title": "Creare una campagna",
+      "yes": "Sì"
+    },
+    "campaign-individual-results": {
+      "shared-date": "Inviato su",
+      "start-date": "Iniziato il"
+    },
+    "campaign-individual-review": {
+      "title": "Analisi per {firstName} {lastName}"
+    },
+    "campaign-modification": {
+      "actions": {
+        "edit": "Modificare"
+      },
+      "campaign-modification-success-message": "Le modifiche sono state salvate.",
+      "campaign-name": "Nome della campagna",
+      "landing-page-text": {
+        "label": "Testo della pagina iniziale",
+        "sublabel": "Questo campo verrà visualizzato dai partecipanti alla campagna."
+      },
+      "owner": {
+        "info": "Il proprietario della campagna e gli amministratori di questa organizzazione sono le uniche persone che possono modificare e archiviare questa campagna.",
+        "label": "Proprietario della campagna",
+        "placeholder": "Nome e cognome del proprietario",
+        "title": "Proprietario della campagna"
+      },
+      "personalised-test-title": {
+        "label": "Titolo del corso",
+        "sublabel": "Questo campo verrà visualizzato dai partecipanti alla campagna."
+      },
+      "title": "Modifica di una campagna"
+    },
+    "campaign-results": {
+      "average": "Risultati medi",
+      "filters": {
+        "aria-label": "Filtri sulle partecipazioni",
+        "participations-count": "{count, plural, =0 {0 partecipanti} =1 {1 partecipante} other {{count} partecipanti}}",
+        "type": {
+          "badges": "Distintivi ottenuti",
+          "groups": {
+            "empty": "Nessun gruppo",
+            "title": "Gruppi"
+          },
+          "stages": "Cuscinetti",
+          "status": {
+            "empty": "Tutte le voci",
+            "title": "Stato"
+          },
+          "unacquired-badges": "Distintivi non ottenuti"
+        }
+      },
+      "result": "Risultati",
+      "table": {
+        "badge-tooltip": {
+          "acquired": "Acquisito",
+          "unacquired": "Non acquisito"
+        },
+        "caption": "Questa tabella elenca i partecipanti che hanno condiviso i loro risultati. Per ogni partecipante sono indicati il cognome, il nome e i risultati.",
+        "column": {
+          "ariaSharedResultCount": "Numero di risultati inviati",
+          "badges": "Distintivi",
+          "evolution": "L'evoluzione",
+          "first-name": "Nome",
+          "last-name": "Nome",
+          "results": {
+            "label": "Risultati",
+            "on-hold": " In attesa di spedizione",
+            "under-test": "Attualmente in fase di test"
+          },
+          "sharedResultCount": "Numero di risultati inviati"
+        },
+        "empty": "Nessuna partecipazione",
+        "evolution": {
+          "decrease": "In declino",
+          "increase": "In crescita",
+          "stable": "Costante",
+          "unavailable": "Non disponibile"
+        },
+        "evolution-tooltip": {
+          "content": "Progressi del partecipante tra gli ultimi due risultati condivisi."
+        },
+        "title": "Elenco dei risultati ricevuti"
+      },
+      "tested-items": "Attività valutate",
+      "title": "Risultati",
+      "validated-items": "Risultati convalidati"
+    },
+    "campaign-settings": {
+      "actions": {
+        "archive": "Archivio",
+        "duplicate": "Duplicato",
+        "edit": "Modificare"
+      },
+      "campaign-type": {
+        "assessment": "Campagna di valutazione",
+        "exam": "Campagna Quiz [beta]",
+        "profiles-collection": "Campagna di raccolta profili",
+        "title": "Tipo di campagna"
+      },
+      "direct-link": "Collegamento diretto",
+      "external-user-id-label": "Formulazione dell'identificatore",
+      "external-user-id-types": {
+        "email": "Email",
+        "string": "Altro"
+      },
+      "landing-page-text": "Testo della pagina iniziale",
+      "multiple-sendings": {
+        "status": {
+          "disabled": "No",
+          "enabled": "Sì"
+        },
+        "title": "Invio multiplo",
+        "tooltip": {
+          "aria-label": "Descrizione dell'invio multiplo",
+          "text": "Se sono attivati gli invii multipli, i partecipanti possono inviare i loro elaborati più volte inserendo nuovamente il codice della campagna."
+        }
+      },
+      "personalised-test-title": "Titolo del corso",
+      "reset-to-zero": {
+        "status": {
+          "disabled": "No",
+          "enabled": "Sì"
+        },
+        "title": "Azzeramento",
+        "tooltip": {
+          "aria-label": "Descrizione di Reset",
+          "text": "Se la funzione di reset è attivata, il partecipante può ripetere l'intero corso e inviare i propri risultati, più volte, inserendo nuovamente il codice della campagna."
+        }
+      },
+      "target-profile": {
+        "title": "Corso",
+        "tooltip": "Descrizione del corso"
+      },
+      "title": "Parametri"
+    },
+    "campaigns-list": {
+      "action": {
+        "campaign": {
+          "archived": "Archiviato",
+          "label": "Visualizzare le campagne attive o archiviate",
+          "ongoing": "Attivo"
+        },
+        "create": "Creare una campagna"
+      },
+      "action-bar": {
+        "delete-button": "Cancellare",
+        "error-message": "{count, plural, =1 {Si è verificato un errore, la campagna non è stata rimossa dall'elenco.} other {Si è verificato un errore, le {count} campagne selezionate non sono state rimosse dall'elenco.}}",
+        "information": "{count, plural, =1 {{count} campagna selezionata} other {{count} campagne selezionate}}",
+        "success-message": "{count, plural, =1 {La campagna (insieme ai suoi risultati) è stata effettivamente rimossa dall'elenco.} other {Le {count} campagne selezionate (insieme ai loro risultati) sono state effettivamente rimosse dall'elenco.}}"
+      },
+      "deletion-modal": {
+        "confirmation-checkbox": "Confermo di aver compreso appieno l'impatto delle {count} cancellazioni.",
+        "content": {
+          "footer": "Si noti che questa azione è irreversibile.",
+          "header": "{count, plural, =1 {Questa campagna non sarà più visibile} other {Queste campagne non saranno più visibili}} in Pix Orga.",
+          "main-participation-prevent": "Tutte le voci di {count, plural, =1 {questa campagna} other {queste campagne}} e i relativi risultati saranno eliminati."
+        },
+        "title": "{count, plural, =1 {Sicuro di voler cancellare la campagna selezionata? } other {Sicuro di voler cancellare le campagne '<strong>'{count}'</strong>' selezionate? }}"
+      },
+      "filter": {
+        "by-name": "Ricerca di una campagna",
+        "by-owner": "Trovare un proprietario",
+        "legend": "Filtri per la tabella delle campagne: i campi di input possono essere utilizzati per filtrare la tabella in base al nome della campagna e al nome del proprietario. I pulsanti possono essere utilizzati per filtrare le campagne attive e archiviate.",
+        "results": "{total, plural, =0 {0 campagne} =1 {1 campagna} other {{total, number} campagne}}"
+      },
+      "navigation": "Navigazione nella sezione Campagne",
+      "no-campaign": "Nessuna campagna, per iniziare fare clic sul pulsante \"Crea una campagna\".",
+      "table": {
+        "column": {
+          "code": "Codice",
+          "created-by": "Proprietario",
+          "created-on": "Creato il",
+          "mainCheckbox": "Selezionare/deselezionare l'intera colonna",
+          "name": "Nome della campagna",
+          "participants": "Partecipanti",
+          "results": "Risultati ricevuti"
+        },
+        "description-all-campaigns": "Questa tabella elenca tutte le campagne create nel vostro spazio Pix Orga. Per ogni campagna sono indicati il codice, il proprietario, la data di creazione, il numero di partecipanti e il numero di risultati ricevuti.",
+        "description-my-campaigns": "Questa tabella elenca le campagne di cui si è proprietari. Per ogni campagna sono indicati il codice, la data di creazione, il numero di partecipanti e il numero di risultati ricevuti.",
+        "empty": "Nessuna campagna"
+      },
+      "tabs": {
+        "all-campaigns": "Tutte le campagne",
+        "my-campaigns": "Le mie campagne"
+      },
+      "title": "Campagne"
+    },
+    "certifications": {
+      "description": "Selezionare la classe per la quale si desidera esportare i risultati della certificazione (.csv) o scaricare i certificati (.pdf).\n È possibile filtrare questo elenco inserendo il nome della classe direttamente nel campo.",
+      "documentation-link": "https://cloud.pix.fr/s/oqnYJWHoSXz8LJk",
+      "documentation-link-label": "Interpretazione dei risultati",
+      "documentation-link-notice": "Seguite questo link per scoprire come interpretare i risultati:",
+      "download-attestations-button": "Scarica i certificati",
+      "download-button": "Esportazione dei risultati",
+      "errors": {
+        "invalid-division": "La classe {selectedDivision} non esiste.",
+        "no-certificates": "Nessun certificato per la classe {selectedDivision}.",
+        "no-results": "Nessun risultato di certificazione per la classe {selectedDivision}."
+      },
+      "no-students-imported-yet": "In questa scheda si trovano i risultati e i certificati degli studenti. Per prima cosa, è necessario importare il database degli studenti della scuola.",
+      "select-label": "Classe",
+      "title": "Risultati della certificazione"
+    },
+    "combined-course": {
+      "campaigns": "{count, plural, =1 {Vedi i dettagli della campagna} other {Vedi i dettagli della campagna #{index}}}",
+      "filters": {
+        "by-status": "Ricerca per stato di partecipazione",
+        "status": {
+          "COMPLETED": "Completato",
+          "STARTED": "In corso",
+          "placeholder": "Tutti gli stati"
+        }
+      },
+      "introduction": "I percorsi di apprendimento combinano valutazioni e moduli di apprendimento personalizzati, consentendo di adattare l'apprendimento al livello di ciascun partecipante.",
+      "participation-detail": {
+        "breadcrumb": "Partecipazione di {firstName} {lastName}",
+        "column": {
+          "campaign": "Campagna",
+          "module": "Modulo",
+          "status": "Stato"
+        },
+        "formation-locked": "Sbloccato al termine della campagna",
+        "step-label": "Passo {number}"
+      },
+      "statistics": {
+        "completed-participations": "Partecipazioni completate",
+        "total-participations": "Totale partecipazioni"
+      },
+      "table": {
+        "campaign-completion": "{nbItemsCompleted, plural, =0 {Nessuna campagna completata su {nbItems}} =1 {Una campagna completata su {nbItems}} other {{nbItemsCompleted} campagne completate su {nbItems}}}.",
+        "column": {
+          "campaigns": "Campagne",
+          "first-name": "Nome",
+          "last-name": "Nome",
+          "modules": "Moduli",
+          "status": "Stato"
+        },
+        "description": "Elenco dei partecipanti",
+        "module-completion": "{nbItemsCompleted, plural, =0 { Nessun modulo completato su {nbItems}} =1 {Un modulo completato su {nbItems}} other {{nbItemsCompleted} moduli completati su {nbItems}}}.",
+        "no-module": "Nessun modulo consigliato.",
+        "tooltip": {
+          "campaigns-column": "x / y\" indica i progressi del partecipante: ha completato x campagne su un totale di y. Ad esempio, 1/2 significa che il partecipante ha completato 1 campagna su 2.",
+          "modules-column": "x / y\" indica lo stato di avanzamento del partecipante: ha completato x moduli su un totale di y. Il numero totale di moduli varia per ogni partecipante, a seconda delle raccomandazioni personalizzate."
+        }
+      }
+    },
+    "combined-courses": {
+      "empty-state": "Al momento non è disponibile un percorso per studenti.",
+      "table": {
+        "caption": "Elenco dei percorsi di apprendimento",
+        "column": {
+          "code": "Codice",
+          "completed": "I partecipanti che hanno completato",
+          "name": "Nome del corso",
+          "participants": "Partecipanti"
+        }
+      }
+    },
+    "index": {
+      "title": "Casa"
+    },
+    "join": {
+      "signup": {
+        "errors": {
+          "invalid-or-already-used-email": "Indirizzo e-mail non valido o già utilizzato"
+        },
+        "fields": {
+          "email": {
+            "error": "L'indirizzo e-mail non è valido.",
+            "label": "Indirizzo e-mail",
+            "placeholder": "Ad esempio, jean.dupont@email.com"
+          },
+          "firstname": {
+            "error": "Il nome non è compilato.",
+            "label": "Nome",
+            "placeholder": "ex: Jean"
+          },
+          "lastname": {
+            "error": "Il vostro nome non è stato inserito.",
+            "label": "Nome",
+            "placeholder": "ad esempio Dupont"
+          },
+          "legend": "Informazioni necessarie per la registrazione.",
+          "password": {
+            "completed-message": "{ rulesCompleted } su { rulesCount } completato.",
+            "instructions-label": "La password deve essere conforme alle seguenti regole:",
+            "label": "Password"
+          }
+        },
+        "submit": "Desidero registrarmi",
+        "subtitle": "per accedere allo spazio Pix Orga",
+        "title": "Iscriviti a Pix"
+      }
+    },
+    "join-request-form": {
+      "firstname": "Il vostro nome di battesimo",
+      "lastname": "Il tuo nome",
+      "legal-information": {
+        "link-text": "Per saperne di più sui miei diritti.",
+        "link-url": "https://pix.fr/dp-formulaire-recuperation-pixorga-sco",
+        "text": "Le informazioni raccolte in questo modulo vengono registrate in un file elaborato da GIP Pix per conto del Ministero dell'Educazione Nazionale, in qualità di responsabile del trattamento dei dati, per consentire alla vostra scuola di accedere al suo spazio Pix Orga, inviandole un invito a entrare in questo spazio."
+      },
+      "organization-code": "UAI/RNE dello stabilimento"
+    },
+    "login": {
+      "join-invitation": "Siete invitati a partecipare: {organizationName}",
+      "signup": {
+        "label": "Registrati con Pix"
+      },
+      "title": "Accedere a",
+      "with-pix-account": "con il tuo account Pix"
+    },
+    "login-form": {
+      "active-or-retrieve": "Attivate o diventate amministratori dello spazio Pix Orga della vostra scuola.",
+      "admin-role-question": "Siete un dirigente o un insegnante?",
+      "associate-account": "Collegare il mio account",
+      "email": {
+        "label": "Indirizzo e-mail",
+        "placeholder": "Ad esempio, jean.dupont@email.com"
+      },
+      "errors": {
+        "access-not-allowed": "L'accesso a Pix Orga è limitato ai membri invitati. Ogni area è gestita da un amministratore di Pix Orga specifico per l'organizzazione che la utilizza. Contattatelo per invitarvi.",
+        "empty-email": "L'indirizzo e-mail non è stato inserito.",
+        "empty-password": "La password non è stata inserita.",
+        "invalid-email": "L'indirizzo e-mail non è valido.",
+        "status": {
+          "404": "L'indirizzo e-mail e/o la password inseriti non sono corretti.",
+          "409": "Questo invito è già stato accettato o annullato."
+        }
+      },
+      "forgot-password": "Avete dimenticato la password?",
+      "invitation-already-accepted": "Questo invito è già stato accettato. Si prega di effettuare il login o di contattare l'amministratore del proprio spazio Pix Orga.",
+      "invitation-not-found": "Questo invito non è stato trovato. Contattare l'amministratore del proprio spazio Pix Orga.",
+      "invitation-was-cancelled": "Questo invito non è più valido. Contattare l'amministratore del proprio spazio Pix Orga.",
+      "login": "Voglio connettermi",
+      "password": "Password"
+    },
+    "login-or-register": {
+      "login-form": {
+        "button": "Accedi",
+        "title": "Ho già un account PIX"
+      },
+      "register-form": {
+        "button": "Iscriviti",
+        "errors": {
+          "default": "Il servizio non è temporaneamente disponibile. Si prega di riprovare più tardi.",
+          "email-already-exists": "Questo indirizzo e-mail è già registrato, si prega di effettuare il login.",
+          "invalid-or-already-used-email": "Indirizzo e-mail non valido o già utilizzato"
+        },
+        "fields": {
+          "button": {
+            "label": "Desidero registrarmi"
+          },
+          "cgu": {
+            "accept": "Accetto il",
+            "and": "e il",
+            "aria-label": "Accettare le condizioni d'uso di Pix",
+            "data-protection-policy": "Informativa sulla privacy",
+            "error": "Per creare un account è necessario accettare le condizioni d'uso e l'informativa sulla privacy di Pix.",
+            "terms-of-use": "termini e condizioni di utilizzo di Pix"
+          },
+          "email": {
+            "error": "L'indirizzo e-mail non è valido.",
+            "label": "Indirizzo e-mail"
+          },
+          "first-name": {
+            "error": "Il nome non è compilato.",
+            "label": "Nome"
+          },
+          "last-name": {
+            "error": "Il vostro nome non è stato inserito.",
+            "label": "Nome"
+          },
+          "password": {
+            "error": "La password deve essere lunga almeno 8 caratteri e contenere almeno una lettera maiuscola, una lettera minuscola e un numero.",
+            "label": "Password"
+          }
+        },
+        "title": "Desidero registrarmi"
+      },
+      "title": "Siete invitati a unirvi all'organizzazione {organizationName}."
+    },
+    "missions": {
+      "list": {
+        "actions": {
+          "see-mission-details": "Vedi dettagli"
+        },
+        "aria-label": "Missione",
+        "banner": {
+          "copypaste-container": {
+            "abstract": "Iniziate le prime missioni con i vostri studenti attivando la sessione tramite il pulsante qui sopra e utilizzando il tasto",
+            "button": {
+              "success": "copiato!",
+              "tooltip": "copiare il codice"
+            }
+          },
+          "hint": "Non esitate ad aggiungerlo ai vostri preferiti.",
+          "import-text": "link alla scuola",
+          "step1": {
+            "admin": {
+              "head": "Fase 1: <b>Per favore</b>.",
+              "link": "importare il database degli studenti",
+              "tail": "<b>Da Onde</b> (file esportabile nel menu Elenchi & documenti > Estrazioni > Alunni o loro supervisori <b>selezionando solo gli alunni del 3° ciclo</b>)."
+            },
+            "non-admin": "Passo 1: <b>Richiedere all'amministratore</b> Pix Orga del proprio spazio per importare gli studenti."
+          },
+          "step2": {
+            "option1": "utilizzare <b>il link</b> '<'a href=\"{pixJuniorUrl}\"'>'junior.pix.fr'</a>'. Vi verrà richiesto il codice della scuola a ogni accesso.",
+            "option2": {
+              "body": "o utilizzare il link diretto '<'a href=\"{pixJuniorUrl}\" target=_blank >junior.pix.fr/schools/{code}'</a>'",
+              "hint": "È possibile salvare questo preferito sui computer."
+            },
+            "title": "Fase 2: Per consentire agli studenti di accedere allo spazio Pix Junior della scuola, è possibile :"
+          },
+          "step3": "Fase 3: <b>Attivare la sessione Pix Junior</b> tramite il pulsante nella barra laterale. <b>Questa azione deve essere eseguita prima di ogni sessione con gli studenti</b>.",
+          "welcome": "Per iniziare a usare Pix Junior :"
+        },
+        "caption": "Elenco delle missioni",
+        "empty-state": "Non ci sono missioni",
+        "headers": {
+          "actions": "Azioni",
+          "competences": "Competenze CRCN lavorate",
+          "name": "Missione",
+          "started-by": "Iniziato da"
+        },
+        "no-division": "Nessuna classe",
+        "non-admin": {
+          "abstract": "Per iniziare, chiedere all'amministratore di importare gli studenti."
+        }
+      },
+      "mission": {
+        "details": {
+          "button-label": "Vedi la scheda didattica",
+          "competence": {
+            "title": "Competenza CRCN lavorata su :"
+          },
+          "objective": {
+            "title": "Obiettivi della missione :"
+          }
+        },
+        "table": {
+          "activities": {
+            "aria-label": "Studente",
+            "caption": "Tabella degli studenti con la loro partecipazione alla missione {missionName}",
+            "filters": {
+              "aria-label": "Filtro per studenti",
+              "learners-count": "{count, plural, =0 { Nessun alunno} =1 { 1 alunno} other {{count} alunni}}",
+              "status": {
+                "label": "Stato della missione"
+              }
+            },
+            "headers": {
+              "division": "Classe",
+              "first-name": "Nome",
+              "last-name": "Nome",
+              "status": "Stato della missione"
+            },
+            "mission-status": {
+              "completed": "Completato",
+              "not-started": "Non iniziato",
+              "started": "In corso"
+            },
+            "no-data": "Non ci sono partecipanti"
+          },
+          "result": {
+            "aria-label": "Studente",
+            "caption": "Tabella degli studenti con il risultato della loro partecipazione alla missione {missionName}",
+            "filters": {
+              "aria-label": "Filtro per studenti",
+              "global-result": {
+                "label": "Valutazione della missione",
+                "options": {
+                  "exceeded": "Superato",
+                  "no-result": "Nessuna valutazione",
+                  "not-reached": "Non raggiunto",
+                  "partially-reached": "Parzialmente raggiunto",
+                  "reached": "Raggiunto"
+                }
+              },
+              "learners-count": "{count, plural, =0 { Nessun alunno} =1 { 1 alunno} other {{count} alunni}}"
+            },
+            "headers": {
+              "dare-challenge": "Sfida",
+              "division": "Classe",
+              "first-name": "Nome",
+              "last-name": "Nome",
+              "result": "Valutazione della missione",
+              "step": "Passo {number}"
+            },
+            "mission-dare-result": {
+              "not-reached": "NA",
+              "reached": "A",
+              "undefined": "-"
+            },
+            "mission-result": {
+              "exceeded": "Superato",
+              "not-reached": "Non raggiunto",
+              "partially-reached": "Parzialmente raggiunto",
+              "reached": "Raggiunto",
+              "undefined": "-"
+            },
+            "no-data": "Non ci sono partecipanti",
+            "step-result": {
+              "not-reached": "NA",
+              "partially-reached": "PA",
+              "reached": "A",
+              "undefined": "-"
+            }
+          }
+        },
+        "tabs": {
+          "activities": "Attività",
+          "aria-label": "Navigazione tra le attività o i risultati della missione",
+          "results": "Risultati"
+        },
+        "title": "Dettagli di una missione"
+      },
+      "title": "Missioni"
+    },
+    "oidc": {
+      "login": {
+        "signup-button": "Non ho un account, mi registro con la mia organizzazione",
+        "sub-title": "per collegarlo al nuovo metodo di connessione",
+        "title": "Utilizza il tuo account Pix"
+      },
+      "signup": {
+        "claims": {
+          "FrEduFonctAdm": "Funzione amministrativa",
+          "FrEduNumenHash": "Identificatore tecnico",
+          "discipline": "Disciplina",
+          "employeeNumber": "Numero di dipendenti",
+          "first-name-label": "Nome :",
+          "last-name-label": "Nome :",
+          "population": "Popolazione",
+          "rne": "Luogo di lavoro",
+          "title": "Funzione"
+        },
+        "description": "Verrà creato un account utilizzando le informazioni fornite dall'organizzazione.",
+        "error": {
+          "cgu": "Per creare un account è necessario accettare le condizioni d'uso e l'informativa sulla privacy di Pix.",
+          "claims": "Non siamo riusciti a recuperare le informazioni sulla vostra identità dal servizio utilizzato. Si prega di contattare il supporto informatico dell'organizzazione."
+        },
+        "login-button": "Ho già un account Pix, vorrei effettuare il login",
+        "signup-button": "Desidero iscrivermi a Pix",
+        "sub-title": "per accedere allo spazio Pix Orga",
+        "title": "Iscriviti a Pix"
+      }
+    },
+    "organization-learner": {
+      "activity": {
+        "assessment-summary": "Sintesi della partecipazione alle campagne di valutazione",
+        "cards": {
+          "shared": "Inviato: {count}",
+          "started": "In corso: {count}",
+          "title": {
+            "assessment": "Valutazioni",
+            "profiles-collection": "Collezione di profili"
+          }
+        },
+        "empty-state": "Nessuna attività al momento! Inviare una campagna a {organizationLearnerFirstName} {organizationLearnerLastName} e iniziare a seguirne i progressi.",
+        "participation-list": {
+          "table": {
+            "column": {
+              "campaign-name": "Campagna",
+              "campaign-type": "Tipo",
+              "created-at": "Data di inizio",
+              "participation-count": "Numero di voci",
+              "shared-at": "Data di invio",
+              "status": "Stato"
+            }
+          }
+        },
+        "participations-title": "Elenco di tutte le voci",
+        "profile-collection-summary": "Sintesi della partecipazione alle campagne di raccolta dei profili",
+        "title": "Attività"
+      },
+      "header": {
+        "aria-label-title": "Pagina di dettaglio per {firstName} {lastName}"
+      }
+    },
+    "organization-participant-activity": {
+      "title": "Attività dei partecipanti"
+    },
+    "organization-participants": {
+      "action-bar": {
+        "delete-button": "Cancellare",
+        "error-message": "{count, plural, =1 {Si è verificato un errore, {firstname} {lastname} non è stato rimosso dall'elenco dei partecipanti.} other {Si è verificato un errore, i {count} partecipanti selezionati non sono stati rimossi dall'elenco.}}",
+        "information": "{count, plural, =1 {{count} partecipante selezionato} other {{count} partecipanti selezionati}}",
+        "success-message": "{count, plural, =1 {{firstname} {lastname} è stato rimosso dall'elenco dei partecipanti.} other { I {count} partecipanti selezionati sono stati rimossi dall'elenco.}}"
+      },
+      "deletion-modal": {
+        "confirmation-checkbox": "Confermo di aver compreso appieno l'impatto delle {count} cancellazioni.",
+        "content": {
+          "footer": "Si noti che questa azione è irreversibile.",
+          "header": "{count, plural, =1 {Questo partecipante non sarà più visibile} other {Questi partecipanti non saranno più visibili}} in Pix Orga.",
+          "main-campaign-prevent": "Questo avrà quindi un impatto sui risultati e sulle analisi delle campagne che {count, plural, =1 {ha} other {hanno}} realizzato.",
+          "main-participation-prevent": "Tutte le voci della {count, plural, =1 {sua} other {sua}} campagna saranno eliminate."
+        },
+        "title": "{count, plural, =1 {Cancella '<strong>'{firstname} {lastname}'</strong>' dai tuoi} other {Sei sicuro di voler cancellare '<strong>'{count}'</strong>'}} partecipanti?"
+      },
+      "empty-state": {
+        "action": "Vedi le mie campagne",
+        "call-to-action": "Invitateli a partecipare a una campagna o a crearne una nuova.",
+        "message": "Nessun partecipante per ora!"
+      },
+      "filters": {
+        "aria-label": "Filtri per i partecipanti",
+        "participations-count": "{count, plural, =0 {0 partecipanti} =1 {1 partecipante} other {{count} partecipanti}}",
+        "students-count": "{count, plural, =0 {0 alunni} =1 { 1 alunno} other {{count} alunni}}",
+        "type": {
+          "certificability": {
+            "label": "Ricerca per certificabilità",
+            "placeholder": "Certificazione"
+          }
+        }
+      },
+      "page-title": "Partecipanti",
+      "table": {
+        "actions": {
+          "disable-oralization": "Disattivare la lettura del setpoint",
+          "enable-oralization": "Attivare la lettura del setpoint"
+        },
+        "column": {
+          "checkbox": "Selezionare/Deselezionare {firstname} {lastname}",
+          "first-name": "Nome",
+          "is-certifiable": {
+            "label": "Certificazione"
+          },
+          "last-name": {
+            "ariaLabelDefaultSort": "La tabella non è attualmente ordinata per nome. Fare clic per ordinare in ordine alfabetico.",
+            "ariaLabelSortDown": "La tabella è ordinata per nome, in ordine alfabetico inverso. Fare clic per ordinare in ordine alfabetico.",
+            "ariaLabelSortUp": "La tabella è ordinata alfabeticamente per nome. Fare clic per ordinare in ordine alfabetico inverso.",
+            "label": "Nome"
+          },
+          "latest-participation": {
+            "ariaLabelDefaultSort": "La tabella non è attualmente ordinata per data di partecipazione. Fare clic per ordinare in ordine crescente.",
+            "ariaLabelSortDown": "La tabella è ordinata per data di partecipazione decrescente. Fare clic per ordinare in ordine crescente.",
+            "ariaLabelSortUp": "La tabella è ordinata per data di partecipazione in ordine crescente. Fare clic per ordinare in ordine decrescente.",
+            "label": "Ultima partecipazione"
+          },
+          "mainCheckbox": "Selezionare/deselezionare l'intera colonna",
+          "participation-count": {
+            "ariaLabelDefaultSort": "La tabella non è attualmente ordinata per numero di voci. Fare clic per ordinare in ordine crescente.",
+            "ariaLabelSortDown": "La tabella è ordinata per numero decrescente di voci. Fare clic per ordinare in ordine crescente.",
+            "ariaLabelSortUp": "La tabella è ordinata per numero crescente di voci. Fare clic per ordinare in ordine decrescente.",
+            "label": "Numero di voci"
+          }
+        },
+        "description": "Tabella dei partecipanti ordinati per nome.",
+        "empty": "Nessun partecipante",
+        "oralization-header-tooltip": "Attivando \"leggi le istruzioni\", lo studente riceverà una trascrizione parlata.",
+        "row-value": {
+          "oralization": {
+            "false": "Spento",
+            "true": "Attivato"
+          }
+        }
+      }
+    },
+    "organization-participants-import": {
+      "actions": {
+        "add-sup": {
+          "details": "Consente di aggiungere un elenco di studenti all'elenco già importato e/o di modificare le informazioni degli studenti già importati.",
+          "label": "Aggiungi studenti",
+          "title": "Aggiungere / modificare"
+        },
+        "participants": {
+          "details": "Questa azione consente di :",
+          "details-add": "aggiungere nuovi partecipanti",
+          "details-disable": "disattivare gli ex partecipanti",
+          "details-update": "modificare i partecipanti già importati",
+          "label": "Elenco delle importazioni",
+          "title": "Importare l'elenco dei partecipanti"
+        },
+        "replace": {
+          "details": "Si usa per importare un nuovo elenco di studenti al posto di quello esistente.",
+          "label": "Importare un nuovo elenco",
+          "title": "Sostituire"
+        }
+      },
+      "banner": {
+        "anchor-error": "Vedere l'elenco degli errori",
+        "fix-error-text": "Correggere gli errori e importare nuovamente il file.",
+        "import-error": "L'importazione dei partecipanti è fallita.",
+        "import-in-progress": "Il contenuto del file è stato convalidato e i partecipanti sono in fase di importazione.",
+        "in-progress-text": "Si prega di aggiornare questa pagina tra qualche istante per verificare lo stato del file.",
+        "retry-error-text": "Si è verificato un errore, si prega di importare più tardi o di scrivere al supporto Pix.",
+        "upload-completed": "Il file è stato importato su {date} da {firstName} {lastName}.",
+        "upload-error": "Non è stato possibile importare il file.",
+        "upload-in-progress": "L'importazione del file potrebbe richiedere alcuni minuti. Non lasciare questa pagina.",
+        "validation-error": "Il contenuto del file contiene errori.",
+        "validation-in-progress": "Il contenuto del file è in corso di convalida.",
+        "warning-banner": "Alcuni valori non sono stati riconosciuti. Sono stati sostituiti da \"Non riconosciuto\". Se ritenete che manchino dei valori nell'elenco restrittivo, contattateci all'indirizzo '<a href=\"mailto:sup@pix.fr\">'sup@pix.fr'</a></div>'."
+      },
+      "error-panel": {
+        "error-wrapper": "Non è stato importato alcun partecipante. Modificare il file e importarlo nuovamente.",
+        "global-error": "Non sono stati importati partecipanti. Si prega di riprovare o di contattarci tramite '<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://support.pix.fr/support/tickets/new\">'il modulo del centro assistenza'</a>'.",
+        "title": "Errori nell'ultimo file importato :"
+      },
+      "file-type-separator": ",",
+      "global-success": "Ultimo file importato con successo su {date} da {firstName} {lastName}.",
+      "sco": {
+        "title": "Importazione di studenti"
+      },
+      "sup": {
+        "title": "Importazione di studenti"
+      },
+      "supported-formats": "(formati supportati: {types})",
+      "title": "Importazione",
+      "warnings": {
+        "diploma": "Diplomi non riconosciuti: {diplomas};",
+        "study-scheme": "Piani non riconosciuti: {studySchemes};"
+      }
+    },
+    "participants-list": {
+      "latest-participation-information-tooltip": {
+        "aria-label": "Informazioni sull'ultima partecipazione",
+        "campaign-ASSESSMENT-type": "Valutazione",
+        "campaign-PROFILES_COLLECTION-type": "Collezione di profili",
+        "campaign-name": "Campagna :",
+        "campaign-status": "Stato :",
+        "campaign-type": "Tipo :",
+        "participation-SHARED-status": "Ricevuto",
+        "participation-STARTED-status": "In corso"
+      }
+    },
+    "places": {
+      "before-date": "a",
+      "places-lots": {
+        "statuses": {
+          "active": "Attività",
+          "expired": "Scaduto",
+          "pending": "Prossimamente"
+        },
+        "table": {
+          "caption": "Tabella che elenca gli acquisti di biglietti della vostra organizzazione. Per ogni acquisto sono indicati: il numero di posti, la data di attivazione, la data di scadenza e lo stato (attivo, in arrivo o scaduto). È ordinata in base allo stato degli acquisti e alla loro data di scadenza.",
+          "empty-state": "Al momento non c'è posto!",
+          "headers": {
+            "activation-date": "Data di attivazione",
+            "count": "Numero di posti",
+            "expiration-date": "Data di scadenza",
+            "status": "Stato"
+          },
+          "title": "Cronologia dell'acquisto dei biglietti"
+        }
+      },
+      "title": "Luoghi"
+    },
+    "preselect-target-profile": {
+      "download": "Scaricare la selezione di argomenti ({ numberOfTubesSelected }) (JSON, { fileSize }ko)",
+      "download-filename": "selection-subjects-{ organizationName }-{ date }.json",
+      "no-tube-selected": "Scaricare la selezione di argomenti (JSON, { fileSize }ko)",
+      "table": {
+        "caption": "Selezione dei soggetti",
+        "column": {
+          "mobile": "Compatibile con gli smartphone",
+          "name": "Nome del soggetto",
+          "tablet": "Compatibile con i tablet",
+          "theme-name": "Nome del tema"
+        },
+        "is-responsive": "sì",
+        "not-responsive": "no",
+        "row-title": "Oggetto"
+      },
+      "title": "Selezione dei soggetti"
+    },
+    "profiles-individual-results": {
+      "breadcrumb-current-page-label": "Partecipazione di {firstName} {lastName}",
+      "certifiable": "Certificabile",
+      "competences-certifiables": "COMP. CERTIFICABILE",
+      "pix": "PIX",
+      "pix-score": "{score, number}",
+      "table": {
+        "column": {
+          "level": "Livello",
+          "pix-score": "Punteggio Pix",
+          "skill": "Competenza"
+        },
+        "empty": "In attesa dei risultati",
+        "title": "Risultati per abilità"
+      },
+      "title": "Profilo di {firstName} {lastName}"
+    },
+    "profiles-list": {
+      "table": {
+        "caption": "Questa tabella contiene l'elenco dei partecipanti che hanno condiviso il proprio profilo. Per ogni partecipante sono indicati il cognome, il nome, la data di invio, il punteggio Pix, l'evoluzione, lo stato di certificabilità e il numero di competenze certificabili.",
+        "column": {
+          "ariaSharedProfileCount": "Numero di azioni del profilo",
+          "certifiable": "Certificabile",
+          "certifiable-tag": "Certificabile",
+          "competences-certifiables": "Comp. certificabile",
+          "evolution": "L'evoluzione",
+          "first-name": "Nome",
+          "last-name": "Nome",
+          "pix-score": {
+            "label": "Punteggio Pix",
+            "value": "{score, number}"
+          },
+          "sending-date": {
+            "label": "Data di invio",
+            "on-hold": "In attesa di spedizione"
+          },
+          "sharedProfileCount": "Numero di azioni del profilo"
+        },
+        "empty": "In attesa di profili",
+        "evolution": {
+          "decrease": "In declino",
+          "increase": "In crescita",
+          "stable": "Costante",
+          "unavailable": "Non disponibile"
+        },
+        "evolution-tooltip": {
+          "content": "Variazione del punteggio pix tra le ultime due condivisioni del profilo."
+        },
+        "title": "Elenco dei profili ricevuti"
+      },
+      "title": "Profili ricevuti"
+    },
+    "sco-organization-participant-activity": {
+      "title": "Attività degli studenti"
+    },
+    "sco-organization-participants": {
+      "action-bar": {
+        "generate-username-password-button": "Generare login e/o password per gli studenti selezionati.",
+        "information": "{count, plural, =1 {{count} studente selezionato} other {{count} studente selezionato}}",
+        "reset-password-button": "Reimpostare le password degli studenti selezionati"
+      },
+      "actions": {
+        "manage-account": "Gestisci il tuo account",
+        "show-actions": "Azioni di visualizzazione"
+      },
+      "connection-types": {
+        "email": "Indirizzo e-mail",
+        "empty": "-",
+        "identifiant": "Identificatore",
+        "mediacentre": "Mediacentre",
+        "none": "No",
+        "without-mediacentre": "Senza Mediacentre"
+      },
+      "filter": {
+        "aria-label": "Filtri per studenti",
+        "certificability": {
+          "label": "Ricerca per certificabilità",
+          "placeholder": "Certificazione"
+        },
+        "division": {
+          "empty": "Nessuna classe",
+          "label": "Ricerca per classe"
+        },
+        "first-name": {
+          "label": "Ricerca per nome"
+        },
+        "last-name": {
+          "label": "Ricerca per nome"
+        },
+        "login-method": {
+          "empty-option": "Metodo di connessione",
+          "label": "Ricerca per metodo di connessione"
+        },
+        "students-count": "{count, plural, =0 {0 alunni} =1 { 1 alunno} other {{count} alunni}}"
+      },
+      "generate-username-password-modal": {
+        "content-message-1": "Gli studenti che non hanno ancora un metodo di accesso devono seguire una campagna presso la scuola per creare il loro account PIX.",
+        "content-message-2": "Verrà generato un file CSV contenente i login e le password uniche.",
+        "content-message-3": "Condividete queste nuove password una tantum con i vostri studenti. Quando accederanno con questa password, Pix chiederà loro di inserirne una nuova.",
+        "title": "Generare login e/o password per gli studenti selezionati.",
+        "warning-message": "Per gli studenti che hanno accesso al Mediacentre e/o un indirizzo e-mail verranno generati un login e una password. Gli studenti che hanno già un login dovranno reimpostare la loro password."
+      },
+      "manage-authentication-method-modal": {
+        "authentication-methods": "Metodi di connessione",
+        "copied": "Ricevuto!",
+        "error": {
+          "default": "Si è verificato un errore interno. I nostri team stanno risolvendo il problema. Si prega di riprovare più tardi.",
+          "unexpected": "Qualcosa è andato storto. Riprovare."
+        },
+        "section": {
+          "add-username": {
+            "button": "Aggiungere un identificatore",
+            "label": "Aggiungere una connessione con un login"
+          },
+          "email": {
+            "copy": "Copiare l'indirizzo e-mail",
+            "label": "Indirizzo e-mail"
+          },
+          "mediacentre": {
+            "label": "Mediacentre"
+          },
+          "password": {
+            "copy": "Copiare la password unica",
+            "label": "Nuova password unica",
+            "warning-1": "Consegnate allo studente la nuova password.",
+            "warning-2": "Lo studente accede con questa password unica.",
+            "warning-3": "Pix gli chiede di sceglierne uno nuovo."
+          },
+          "reset-password": {
+            "button": "Reimpostare la password",
+            "warning": "Reset cancella la password corrente dello studente."
+          },
+          "username": {
+            "copy": "Identificatore di copia",
+            "label": "Identificatore"
+          }
+        },
+        "title": "Gestione dell'account Pix dello studente"
+      },
+      "messages": {
+        "password-reset-success": "Le password degli studenti selezionati sono state reimpostate."
+      },
+      "no-participants": "Nessun studente per ora!",
+      "no-participants-action": "L'amministratore deve importare il database degli studenti facendo clic sul pulsante Importa.",
+      "page-title": "Studenti",
+      "reset-password-modal": {
+        "content-message-1": "Su {totalSelectedStudents, plural, =1 {<strong>{totalSelectedStudents} studente</strong> selezionato} other {<strong>{totalSelectedStudents} studente</strong> selezionato}}, {totalAffectedStudents, plural, =0 {<strong>nessuna password</strong> verrà resettata} =1 { la <strong>{totalAffectedStudents} password dello studente</strong> sarà resettata} other { le password degli <strong>{totalAffectedStudents} studenti</strong> saranno resettate}}.",
+        "content-message-2": "Verrà generato un file CSV contenente i login e le password uniche.",
+        "content-message-3": "Consegnare queste nuove password una tantum agli studenti. Quando accederanno con questa password, Pix chiederà loro di inserirne una nuova.",
+        "title": "Ripristino delle <strong>password</strong> degli studenti con <strong>identificatore</strong>.",
+        "warning-message": "È possibile reimpostare solo le password di accesso. L'accesso tramite indirizzo e-mail e Mediacentre non sono interessati."
+      },
+      "table": {
+        "column": {
+          "checkbox": "Selezionare/Deselezionare {firstname} {lastname}",
+          "date-of-birth": "Data di nascita",
+          "division": {
+            "ariaLabelDefaultSort": "La tabella non è attualmente ordinata per classe. Fare clic per ordinare alfanumericamente.",
+            "ariaLabelSortDown": "La tabella è ordinata per classe, in ordine alfanumerico inverso. Fare clic per ordinare per ordine alfanumerico.",
+            "ariaLabelSortUp": "La tabella è ordinata per classe, in ordine alfanumerico. Fare clic per ordinare in ordine alfanumerico inverso.",
+            "label": "Classe"
+          },
+          "first-name": "Nome",
+          "is-certifiable": {
+            "eligible": "Certificabile",
+            "label": "Certificazione",
+            "non-eligible": "Non certificabile",
+            "not-available": "Non comunicato"
+          },
+          "last-name": {
+            "ariaLabelDefaultSort": "La tabella non è attualmente ordinata per nome. Fare clic per ordinare in ordine alfabetico.",
+            "ariaLabelSortDown": "La tabella è ordinata per nome, in ordine alfabetico inverso. Fare clic per ordinare in ordine alfabetico.",
+            "ariaLabelSortUp": "La tabella è ordinata alfabeticamente per nome. Fare clic per ordinare in ordine alfabetico inverso.",
+            "label": "Nome"
+          },
+          "last-participation-date": "Ultima partecipazione",
+          "login-method": "Metodo/i di connessione",
+          "mainCheckbox": "Selezionare/deselezionare l'intera colonna",
+          "participation-count": {
+            "ariaLabelDefaultSort": "La tabella non è attualmente ordinata per numero di voci. Fare clic per ordinare in ordine crescente.",
+            "ariaLabelSortDown": "La tabella è ordinata per numero decrescente di voci. Fare clic per ordinare in ordine crescente.",
+            "ariaLabelSortUp": "La tabella è ordinata per numero crescente di voci. Fare clic per ordinare in ordine decrescente.",
+            "label": "Numero di voci"
+          }
+        },
+        "description": "Tabella degli studenti ordinata per nome. Per gli studenti che hanno fornito un metodo di connessione, è possibile utilizzare un menu nella colonna 'Azioni' per gestire i metodi di connessione autorizzati e reimpostare la password dello studente.",
+        "empty": "Nessun studente."
+      },
+      "title": "{count, plural, =0 {Studenti} =1 {Studente ({count})} other {Studenti ({count})}}"
+    },
+    "sso-selection": {
+      "login": {
+        "button": "Voglio connettermi",
+        "message": "Verrete reindirizzati alla pagina di login \"{providerName}\" per identificarvi su Pix."
+      },
+      "signup": {
+        "button": "Desidero registrarmi"
+      },
+      "title": "Scegliere il metodo di connessione"
+    },
+    "statistics": {
+      "before-date": "a",
+      "description": "La tabella seguente consente di visualizzare il posizionamento dei partecipanti per argomento.'<br>' Il posizionamento riflette il livello medio dei partecipanti rispetto al livello massimo che avrebbero potuto raggiungere.'<br>' Questi dati tengono conto di tutte le partecipazioni condivise nell'ambito delle campagne di valutazione della vostra organizzazione che non sono state cancellate.",
+      "empty-state": "Nessun dato disponibile",
+      "level": {
+        "advanced": "Avanzato",
+        "expert": "Esperto",
+        "independent": "Indipendente",
+        "novice": "Novizio"
+      },
+      "select-label": "Dominio",
+      "table": {
+        "caption": "Questa tabella mostra i risultati di tutti i partecipanti per argomento. Per ogni riga sono indicati l'abilità, il soggetto, il tasso di copertura e il livello raggiunto.",
+        "headers": {
+          "competences": "Competenze",
+          "positioning": "Posizionamento",
+          "reached-level": "Livello raggiunto",
+          "topics": "Soggetti"
+        }
+      },
+      "title": "Statistiche"
+    },
+    "sup-organization-participant-activity": {
+      "title": "Attività degli studenti"
+    },
+    "sup-organization-participants": {
+      "action-bar": {
+        "delete-button": "Cancellare",
+        "error-message": "{count, plural, =1 {Si è verificato un errore, {firstname} {lastname} non è stato rimosso dall'elenco degli studenti.} other {Si è verificato un errore, gli {count} studenti selezionati non sono stati rimossi dall'elenco.}}",
+        "information": "{count, plural, =1 {{count} studente selezionato} other {{count} studente selezionato}}",
+        "success-message": "{count, plural, =1 {{firstname} {lastname} è stato rimosso con successo dall'elenco degli studenti.} other { Gli {count} studenti selezionati sono stati rimossi con successo dall'elenco.}}"
+      },
+      "actions": {
+        "download-template": "Scarica il modello",
+        "edit-student-number": "Modifica del numero di studente",
+        "show-actions": "Azioni di visualizzazione"
+      },
+      "deletion-modal": {
+        "content": {
+          "footer": "Si noti che questa azione è irreversibile.",
+          "header": "{count, plural, =1 {Questo studente non sarà più visibile} other {Questi studenti non saranno più visibili}} in Pix Orga.",
+          "main-campaign-prevent": "Questo avrà quindi un impatto sui risultati e sulle analisi delle campagne che {count, plural, =1 {ha} other {hanno}} realizzato.",
+          "main-participation-prevent": "Tutte le voci della {count, plural, =1 {sua} other {sua}} campagna saranno eliminate."
+        },
+        "title": "{count, plural, =1 {Cancella '<strong>'{firstname} {lastname}'</strong>' dai tuoi} other {Sei sicuro di voler cancellare '<strong>'{count}'</strong>'}} studenti?"
+      },
+      "edit-student-number-modal": {
+        "actions": {
+          "update": "Aggiornamento"
+        },
+        "form": {
+          "error": "Il numero dello studente non deve essere vuoto.",
+          "new-student-number-label": "Numero del nuovo studente",
+          "student-number": "L'attuale numero di studenti di {firstName} {lastName} è :",
+          "success": "La modifica del numero di studente da {firstName} a {lastName} è stata effettuata con successo."
+        },
+        "title": "Redazione del numero degli studenti"
+      },
+      "empty-state": {
+        "no-participants": "Non ci sono ancora studenti!",
+        "no-participants-action": "L'amministratore deve importare gli studenti facendo clic sul pulsante Importa."
+      },
+      "filter": {
+        "aria-label": "Filtrare gli studenti",
+        "certificability": {
+          "label": "Ricerca per certificabilità",
+          "placeholder": "Certificazione"
+        },
+        "group": {
+          "empty": "Nessun gruppo",
+          "label": "Inserire un gruppo",
+          "placeholder": "Ricerca per gruppo"
+        },
+        "student-number": {
+          "label": "Inserire un numero di studente",
+          "placeholder": "1234658P"
+        },
+        "students-count": "{count, plural, =0 {0 studenti} =1 { 1 studente} other {{count} studenti}}"
+      },
+      "page-title": "Studenti",
+      "replace-students-modal": {
+        "confirm": "Sì, sto sostituendo",
+        "confirmation-checkbox": "Confermo di aver compreso appieno l'impatto",
+        "footer-content": "Gli studenti esistenti nell'applicazione e presenti nella nuova importazione non saranno cancellati e saranno aggiornati se necessario.",
+        "last-warning": "Si noti che questa azione è irreversibile. Gli studenti non presenti nella nuova importazione saranno cancellati da Pix Orga.",
+        "main-content": "Tutti i loro contributi alle campagne saranno cancellati. Questo avrà un impatto sui risultati e sulle analisi delle campagne che hanno realizzato. Non potranno più partecipare alle campagne a cui hanno preso parte in passato. Tuttavia, potranno partecipare a nuove campagne.",
+        "title": "Siete sicuri di voler sostituire gli studenti esistenti?"
+      },
+      "table": {
+        "column": {
+          "date-of-birth": "Data di nascita",
+          "first-name": "Nome",
+          "group": "Gruppi",
+          "is-certifiable": {
+            "label": "Certificazione"
+          },
+          "last-name": {
+            "ariaLabelDefaultSort": "La tabella non è attualmente ordinata per nome. Fare clic per ordinare in ordine alfabetico.",
+            "ariaLabelSortDown": "La tabella è ordinata per nome, in ordine alfabetico inverso. Fare clic per ordinare in ordine alfabetico.",
+            "ariaLabelSortUp": "La tabella è ordinata alfabeticamente per nome. Fare clic per ordinare in ordine alfabetico inverso.",
+            "label": "Nome"
+          },
+          "last-participation-date": "Ultima partecipazione",
+          "participation-count": {
+            "ariaLabelDefaultSort": "La tabella non è attualmente ordinata per numero di voci. Fare clic per ordinare in ordine crescente.",
+            "ariaLabelSortDown": "La tabella è ordinata per numero decrescente di voci. Fare clic per ordinare in ordine crescente.",
+            "ariaLabelSortUp": "La tabella è ordinata per numero crescente di voci. Fare clic per ordinare in ordine decrescente.",
+            "label": "Numero di voci"
+          },
+          "student-number": "Numero dello studente"
+        },
+        "description": "Tabella degli studenti ordinati per nome. È possibile utilizzare un menu in una colonna aggiuntiva per cambiare il numero di studente.",
+        "empty": "Nessun studente."
+      },
+      "title": "{count, plural, =0 {Studenti} =1 {Studente ({count})} other {Studenti ({count})}}"
+    },
+    "team-invitations": {
+      "cancel-invitation": "Cancellare l'invito",
+      "invitation-cancelled-succeed-message": "L'invito è stato cancellato.",
+      "invitation-resent-succeed-message": "L'invito è stato restituito.",
+      "resend-invitation": "Reinvio dell'invito",
+      "table": {
+        "column": {
+          "email-address": "Indirizzo e-mail",
+          "pending-invitation": "Data dell'ultimo invio"
+        },
+        "row": {
+          "aria-label": "Invito in attesa di risposta"
+        }
+      },
+      "title": "Inviti"
+    },
+    "team-list": {
+      "add-member-button": "Invita un membro",
+      "tabs": {
+        "invitation": "Inviti ({count, plural, =0 {-} other {{count}}})",
+        "member": "Membri ({count, plural, =0 {-} other {{count}}})"
+      },
+      "title": "Squadra"
+    },
+    "team-members": {
+      "actions": {
+        "edit-organization-membership-role": "Modificare il ruolo",
+        "leave-organization": "Lasciando quest'area Pix Orga",
+        "manage": "Gestire",
+        "remove-membership": "Cancellare",
+        "save": "Registro",
+        "select-role": {
+          "label": "Selezionare un ruolo",
+          "options": {
+            "admin": "Direttore",
+            "member": "Membro"
+          }
+        }
+      },
+      "modals": {
+        "leave-organization": {
+          "message": "Sei sicuro di voler lasciare questo spazio Pix Orga? Non avrai più accesso a <strong>{organizationName}</strong>.<br/><br/>Le tue campagne resteranno accessibili al resto del team, non saranno archiviate.<br/><br/>Il tuo accesso agli altri spazi Pix Orga non subirà conseguenze.<br/><br/>Sarai disconnesso.",
+          "title": "Lasciando quest'area Pix Orga"
+        }
+      },
+      "notifications": {
+        "change-member-role": {
+          "error": "Si è verificato un errore durante la modifica del ruolo del membro.",
+          "success": "Il ruolo è stato cambiato."
+        },
+        "leave-organization": {
+          "error": "Si è verificato un errore durante la disattivazione del membro.",
+          "success": "Sei stato rimosso con successo dall'organizzazione {organizationName}. Sarai disconnesso da Pix Orga..."
+        },
+        "remove-membership": {
+          "error": "Si è verificato un errore durante la disattivazione del membro.",
+          "success": "{memberFirstName} {memberLastName} è stato rimosso con successo dalla tua squadra Pix Orga."
+        }
+      },
+      "remove-membership-modal": {
+        "actions": {
+          "remove": "Sì, eliminare il membro"
+        },
+        "message": "{memberFirstName} {memberLastName} non avrà più accesso a questo spazio Pix Orga.'<br>'Le sue campagne rimangono accessibili al resto della squadra.",
+        "title": "Stai confermando la cancellazione?"
+      },
+      "table": {
+        "column": {
+          "first-name": "Nome",
+          "last-name": "Nome",
+          "organization-membership-role": "Ruolo"
+        },
+        "empty": "In attesa dei membri"
+      },
+      "title": "Membri"
+    },
+    "team-new": {
+      "email-requirement": "Inserire qui l'indirizzo e-mail del membro che si desidera invitare.",
+      "errors": {
+        "default": "Il servizio non è temporaneamente disponibile. Si prega di riprovare più tardi.",
+        "invalid-input": "I dati inviati non sono nel formato corretto",
+        "mandatory-email-field": "Questo campo è obbligatorio",
+        "sending-email-to-invalid-email-address": "L'invio dell'e-mail per l'indirizzo {email} non è riuscito. Il server di invio ha risposto \"{errorMessage}\".",
+        "status": {
+          "400": "Il formato dell'indirizzo e-mail non è corretto.",
+          "404": "Questa e-mail non appartiene a nessun utente.",
+          "412": "Questo membro è già stato aggiunto.",
+          "500": "Qualcosa è andato storto. Riprovare."
+        }
+      },
+      "invite-form-modal": {
+        "confirm": "Confermare",
+        "question": "Vuole continuare?",
+        "title": "Confermare l'aggiunta di nuovi membri del team",
+        "warning": "I membri aggiunti avranno accesso ai risultati dei partecipanti e all'analisi della campagna."
+      },
+      "invited-members": "Al ricevimento dell'e-mail, gli ospiti potranno scegliere se creare un account Pix o accedere con un account Pix esistente.",
+      "several-email-requirement": "È possibile invitare più membri separando gli indirizzi e-mail con delle virgole.",
+      "success": {
+        "invitation": "È stato effettivamente inviato un invito all'indirizzo e-mail {email}.",
+        "multiple-invitations": "È stato inviato un invito agli indirizzi e-mail elencati."
+      },
+      "title": "Invita un membro",
+      "warning": "I membri aggiunti di seguito avranno accesso ai risultati dei partecipanti e all'analisi della campagna. Assicuratevi che le persone invitate siano membri della vostra organizzazione."
+    },
+    "team-new-item": {
+      "input-label": "Indirizzo/i e-mail",
+      "invite-button": "Invito"
+    },
+    "terms-of-service": {
+      "accept": "Accetto le condizioni di utilizzo",
+      "title": "Termini e condizioni d'uso"
+    }
+  }
+}


### PR DESCRIPTION
## 🥀 Problème

Il faut ajouter l'italien dans pix Orga et pix App

## 🏹 Proposition

Traduire les fichiers de langues de l'API, Pix Orga, Pix App et modifier les services et configurations pour afficher ces fronts en italien

## 💌 Remarques

ras

## ❤️‍🔥 Pour tester
Aucune locale n'est `disabled` sur cette RA 
- Sur Pix App et Pix Orga vérifiez que l'italien est proposé dans le locale switcher et sélectionnable.
- Promenez-vous sur ces deux sites pour vérifier l'affichage en italien
- Sur Pix Certif et Pix Admin vérifiez que les sites ne peuvent pas s'afficher en italien et/ou que l'italien n'est pas proposé dans le locale switcher (pour Pix Certif)
