### PR TITLE
[TECH] Uniformise les tâches CI de lint des fronts.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -593,14 +593,26 @@ jobs:
 
   mon_pix_lint:
     executor:
-      name: node-docker-medium
+      name: node-docker
     working_directory: ~/pix/mon-pix
     steps:
       - attach_workspace:
           at: ~/pix
       - run:
-          name: Lint
-          command: npm run lint
+          name: Lint templates
+          command: npm run lint:hbs
+          when: always
+      - run:
+          name: Lint JS
+          command: npm run lint:js
+          when: always
+      - run:
+          name: Lint SCSS
+          command: npm run lint:scss
+          when: always
+      - run:
+          name: Lint translations
+          command: npm run lint:translations
           when: always
 
   mon_pix_test:
@@ -659,8 +671,20 @@ jobs:
       - attach_workspace:
           at: ~/pix
       - run:
-          name: Lint
-          command: npm run lint
+          name: Lint templates
+          command: npm run lint:hbs
+          when: always
+      - run:
+          name: Lint JS
+          command: npm run lint:js
+          when: always
+      - run:
+          name: Lint SCSS
+          command: npm run lint:scss
+          when: always
+      - run:
+          name: Lint translations
+          command: npm run lint:translations
           when: always
 
   orga_test:
@@ -712,8 +736,20 @@ jobs:
       - attach_workspace:
           at: ~/pix
       - run:
-          name: Lint
-          command: npm run lint
+          name: Lint templates
+          command: npm run lint:hbs
+          when: always
+      - run:
+          name: Lint JS
+          command: npm run lint:js
+          when: always
+      - run:
+          name: Lint SCSS
+          command: npm run lint:scss
+          when: always
+      - run:
+          name: Lint translations
+          command: npm run lint:translations
           when: always
 
   junior_test:
@@ -772,8 +808,20 @@ jobs:
       - attach_workspace:
           at: ~/pix
       - run:
-          name: Lint
-          command: npm run lint
+          name: Lint templates
+          command: npm run lint:hbs
+          when: always
+      - run:
+          name: Lint JS
+          command: npm run lint:js
+          when: always
+      - run:
+          name: Lint SCSS
+          command: npm run lint:scss
+          when: always
+      - run:
+          name: Lint translations
+          command: npm run lint:translations
           when: always
 
   certif_test:

--- a/certif/package.json
+++ b/certif/package.json
@@ -22,8 +22,8 @@
   "scripts": {
     "build": "ember build --environment $BUILD_ENVIRONMENT",
     "clean": "rm -rf tmp dist node_modules",
-    "lint": "run-p --continue-on-error 'lint:!(fix)'",
-    "lint:fix": "run-p --continue-on-error lint:*:fix",
+    "lint": "run-s -clns 'lint:(hbs|js|scss|translations)'",
+    "lint:fix": "run-s -clns 'lint:(hbs|js|scss|translations):fix'",
     "lint:hbs": "ember-template-lint .",
     "lint:hbs:fix": "ember-template-lint . --fix",
     "lint:js": "eslint . --cache --cache-strategy content",

--- a/junior/package.json
+++ b/junior/package.json
@@ -19,8 +19,8 @@
   "files": [],
   "scripts": {
     "build": "ember build --environment=production",
-    "lint": "run-p --continue-on-error 'lint:!(fix)'",
-    "lint:fix": "run-p --continue-on-error lint:*:fix",
+    "lint": "run-s -clns 'lint:(hbs|js|scss|translations)'",
+    "lint:fix": "run-s -clns 'lint:(hbs|js|scss|translations):fix'",
     "lint:hbs": "ember-template-lint .",
     "lint:hbs:fix": "ember-template-lint . --fix",
     "lint:js": "eslint . --cache --cache-strategy content",

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -22,8 +22,8 @@
   "files": [],
   "scripts": {
     "clean": "rm -rf tmp dist node_modules",
-    "lint": "run-p --continue-on-error 'lint:!(fix)'",
-    "lint:fix": "run-p --continue-on-error 'lint:*:fix'",
+    "lint": "run-s -clns 'lint:(hbs|js|scss|translations)'",
+    "lint:fix": "run-s -clns 'lint:(hbs|js|scss|translations):fix'",
     "lint:hbs": "ember-template-lint .",
     "lint:hbs:fix": "ember-template-lint . --fix",
     "lint:js": "eslint . --cache --cache-strategy content",

--- a/orga/package.json
+++ b/orga/package.json
@@ -23,8 +23,8 @@
   "scripts": {
     "build": "ember build --environment $BUILD_ENVIRONMENT",
     "clean": "rm -rf tmp dist node_modules",
-    "lint": "run-p --continue-on-error 'lint:!(fix)'",
-    "lint:fix": "run-p --continue-on-error 'lint:*:fix'",
+    "lint": "run-s -clns 'lint:(hbs|js|scss|translations)'",
+    "lint:fix": "run-s -clns 'lint:(hbs|js|scss|translations):fix'",
     "lint:hbs": "ember-template-lint .",
     "lint:hbs:fix": "ember-template-lint . --fix",
     "lint:js": "eslint . --cache --cache-strategy content",


### PR DESCRIPTION
## 🥀 Problème

Suite à la PR https://github.com/1024pix/pix/pull/15143, on se rend compte que les tâches de lint ne sont pas cohérentes entre les différents front.
<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

## 🏹 Proposition

On prend comme référence la tâche `admin_lint` qui lance les lint en série et permet de consommer moins de mémoire.
On en profite pour utiliser un éxecuteur de classe `small` sur toutes ces tâches.

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 💌 Remarques

Il faudra faire le ménage dans nos configurations et éventuellement mettre en place `knip` pour linter nos dépendances.
<!-- Des infos supplémentaires, trucs et astuces ? -->

## ❤️‍🔥 Pour tester

Vérifier que les tâches `xxx_lint` se déroulent en série avec un job par étape de lint, et ce pour tous les fronts.
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
