### PR TITLE
[TECH] Utiliser les domaines transaction dans les repo Team

### DIFF
--- a/api/src/privacy/domain/usecases/anonymize-user.usecase.js
+++ b/api/src/privacy/domain/usecases/anonymize-user.usecase.js
@@ -50,11 +50,6 @@ const anonymizeUser = withTransaction(async function ({
     await resetPasswordDemandRepository.removeAllByEmail(user.email);
   }
 
-  await certificationCenterMembershipRepository.disableMembershipsByUserId({
-    updatedByUserId: anonymizedByUserId,
-    userId,
-  });
-
   await _anonymizeOrganizationLearner({
     userId,
     learnersApiRepository,
@@ -64,7 +59,7 @@ const anonymizeUser = withTransaction(async function ({
 
   await _anonymizeLastUserApplicationConnections(lastUserApplicationConnectionsRepository, userId);
 
-  await _anonymizeCertificationCenterMembershipsLastAccessedAt(certificationCenterMembershipRepository, userId);
+  await _anonymizeCertificationCenterMemberships(certificationCenterMembershipRepository, userId, anonymizedByUserId);
 
   await _anonymizeLastUserApplicationConnections(lastUserApplicationConnectionsRepository, userId);
 
@@ -103,7 +98,11 @@ async function _anonymizeMemberships({ userId, anonymizedByUserId, membershipRep
   await membershipRepository.disableMembershipsByUserId({ userId, updatedByUserId: anonymizedByUserId });
 }
 
-async function _anonymizeCertificationCenterMembershipsLastAccessedAt(certificationCenterMembershipRepository, userId) {
+async function _anonymizeCertificationCenterMemberships(
+  certificationCenterMembershipRepository,
+  userId,
+  anonymizedByUserId,
+) {
   const userCertificationCenterMemberships = await certificationCenterMembershipRepository.findByUserId(userId);
 
   for (const certificationCenterMembership of userCertificationCenterMemberships) {
@@ -115,6 +114,11 @@ async function _anonymizeCertificationCenterMembershipsLastAccessedAt(certificat
       lastAccessedAt: anonymizedCertificationCenterMembershipLastAccessedAt,
     });
   }
+
+  await certificationCenterMembershipRepository.disableMembershipsByUserId({
+    updatedByUserId: anonymizedByUserId,
+    userId,
+  });
 }
 
 async function _anonymizeLastUserApplicationConnections(lastUserApplicationConnectionsRepository, userId) {

--- a/api/src/team/infrastructure/repositories/organization-invitation.repository.js
+++ b/api/src/team/infrastructure/repositories/organization-invitation.repository.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 
-import { knex } from '../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../shared/domain/errors.js';
 import { OrganizationInvitation } from '../../domain/models/OrganizationInvitation.js';
 
@@ -14,8 +14,9 @@ import { OrganizationInvitation } from '../../domain/models/OrganizationInvitati
  * @returns {Promise<OrganizationInvitation>}
  */
 const create = async function ({ organizationId, email, code, role, locale }) {
+  const knexConn = DomainTransaction.getConnection();
   const status = OrganizationInvitation.StatusType.PENDING;
-  const [organizationInvitationCreated] = await knex('organization-invitations')
+  const [organizationInvitationCreated] = await knexConn('organization-invitations')
     .insert({ organizationId, email, status, code, role, locale })
     .returning('*');
 
@@ -27,7 +28,8 @@ const create = async function ({ organizationId, email, code, role, locale }) {
  * @returns {Promise<OrganizationInvitation>}
  */
 const get = async function (id) {
-  const organizationInvitation = await knex('organization-invitations').where('id', id).first();
+  const knexConn = DomainTransaction.getConnection();
+  const organizationInvitation = await knexConn('organization-invitations').where('id', id).first();
   if (!organizationInvitation) throw new NotFoundError(`Not found organization-invitation for ID ${id}`);
   return new OrganizationInvitation(organizationInvitation);
 };
@@ -39,7 +41,8 @@ const get = async function (id) {
  * @returns {Promise<OrganizationInvitation>}
  */
 const getByIdAndCode = async function ({ id, code }) {
-  const organizationInvitation = await knex('organization-invitations').where({ id, code }).first();
+  const knexConn = DomainTransaction.getConnection();
+  const organizationInvitation = await knexConn('organization-invitations').where({ id, code }).first();
   if (!organizationInvitation)
     throw new NotFoundError(`Not found organization-invitation for ID ${id} and code ${code}`);
   return new OrganizationInvitation(organizationInvitation);
@@ -52,7 +55,8 @@ const getByIdAndCode = async function ({ id, code }) {
 const markAsAccepted = async function (id) {
   const status = OrganizationInvitation.StatusType.ACCEPTED;
 
-  const [organizationInvitationAccepted] = await knex('organization-invitations')
+  const knexConn = DomainTransaction.getConnection();
+  const [organizationInvitationAccepted] = await knexConn('organization-invitations')
     .where({ id })
     .update({ status, updatedAt: new Date() })
     .returning('*');
@@ -66,7 +70,8 @@ const markAsAccepted = async function (id) {
  * @returns {Promise<OrganizationInvitation>}
  */
 const markAsCancelled = async function ({ id }) {
-  const [organizationInvitation] = await knex('organization-invitations')
+  const knexConn = DomainTransaction.getConnection();
+  const [organizationInvitation] = await knexConn('organization-invitations')
     .where({ id })
     .update({
       status: OrganizationInvitation.StatusType.CANCELLED,
@@ -86,7 +91,8 @@ const markAsCancelled = async function ({ id }) {
  * @returns {Promise<OrganizationInvitation>}
  */
 const findPendingByOrganizationId = async function ({ organizationId }) {
-  const pendingOrganizationInvitations = await knex('organization-invitations')
+  const knexConn = DomainTransaction.getConnection();
+  const pendingOrganizationInvitations = await knexConn('organization-invitations')
     .where({ organizationId, status: OrganizationInvitation.StatusType.PENDING })
     .orderBy('updatedAt', 'desc');
   return pendingOrganizationInvitations.map((pendingOrganizationInvitation) => {
@@ -101,7 +107,8 @@ const findPendingByOrganizationId = async function ({ organizationId }) {
  * @returns {Promise<OrganizationInvitation>}
  */
 const findOnePendingByOrganizationIdAndEmail = async function ({ organizationId, email }) {
-  const pendingOrganizationInvitation = await knex('organization-invitations')
+  const knexConn = DomainTransaction.getConnection();
+  const pendingOrganizationInvitation = await knexConn('organization-invitations')
     .where({ organizationId, status: OrganizationInvitation.StatusType.PENDING })
     .whereRaw('LOWER("email") = ?', `${email.toLowerCase()}`)
     .first();
@@ -114,7 +121,8 @@ const findOnePendingByOrganizationIdAndEmail = async function ({ organizationId,
  * @returns {Promise<OrganizationInvitation>}
  */
 const updateModificationDate = async function (id) {
-  const organizationInvitation = await knex('organization-invitations')
+  const knexConn = DomainTransaction.getConnection();
+  const organizationInvitation = await knexConn('organization-invitations')
     .where({ id })
     .update({ updatedAt: new Date() })
     .returning('*')
@@ -131,7 +139,8 @@ const updateModificationDate = async function (id) {
  * @returns {Promise<OrganizationInvitation>}
  */
 const update = async function (organizationInvitation) {
-  const [updatedOrganizationInvitation] = await knex('organization-invitations')
+  const knexConn = DomainTransaction.getConnection();
+  const [updatedOrganizationInvitation] = await knexConn('organization-invitations')
     .where({ id: organizationInvitation.id })
     .update({
       ...organizationInvitation,

--- a/api/src/team/infrastructure/repositories/organization-member-identity.repository.js
+++ b/api/src/team/infrastructure/repositories/organization-member-identity.repository.js
@@ -1,8 +1,10 @@
-import { knex } from '../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { OrganizationMemberIdentity } from '../../domain/models/OrganizationMemberIdentity.js';
 
 const findAllByOrganizationId = async function ({ organizationId }) {
-  const sortedMembers = await knex('users')
+  const knexConn = DomainTransaction.getConnection();
+
+  const sortedMembers = await knexConn('users')
     .select('users.id', 'users.firstName', 'users.lastName')
     .join('memberships', 'memberships.userId', 'users.id')
     .where({ disabledAt: null, organizationId })


### PR DESCRIPTION
## 🥀 Problème

Dans le contexte Team, sur certains repository, on utilise toujours `knex` au lieu de `DomainTransaction.getConnection`.

## 🏹 Proposition

Utiliser le `DomainTransaction.getConnection` dans :
- certification-center-invitation-repository.js
- certification-center-invited-user.repository.js
- certification-center-membership.repository.js
- organization-invitation.repository.js
- organization-invited-user.repository.js
- organization-member-identity.repository.js
- prescriber-repository.js

## 💌 Remarques

À noter, que correctement réutiliser la transaction a permis de corriger un bug dans l'anonymisation. On désactivait les memberships dans de centres de certif dans une transaction différente de l'anonymisation de ces centres. La transaction ne se basait pas sur des données à jour pour mettre à jour en centre de certification.
=> Voir le dernier commit 37b81c28e94b454342c38ed51d9c6b4e30c0593a

## ❤️‍🔥 Pour tester

Les tests auto sont suffisants ?
