### PR TITLE
[FEATURE] Permettre l'affichage des réponses courtes en cas de QCU et QCM sur Pix App (PIX-21288).

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
@@ -349,7 +349,7 @@
               "element": {
                 "id": "488e3984-6ed6-4245-8c94-da188a2fd13c",
                 "type": "text",
-                "content": "<p>Section <strong>Réponses Courtes</strong> (QCU découverte et déclaratif)</p>"
+                "content": "<p>Section <strong>Réponses Courtes</strong> (QCM, QCU (+ découverte et déclaratif))</p>"
               }
             }
           ]
@@ -364,7 +364,7 @@
               "element": {
                 "id": "c3bc4466-2825-488e-ad5f-275ace4b19a8",
                 "type": "qcu-discovery",
-                "instruction": "<p>Quelle est la meilleure crêpe ?</p>",
+                "instruction": "<p>Quelle est la meilleure crêpe 🥞 ?</p>",
                 "proposals": [
                   {
                     "id": "1",
@@ -382,7 +382,7 @@
                   },
                   {
                     "id": "3",
-                    "content": "Beurre/sucre 🥞",
+                    "content": "Citron/sucre 🍋",
                     "feedback": {
                       "diagnosis": "<p>Pardon ?</p>"
                     }
@@ -580,6 +580,51 @@
                   }
                 ],
                 "solution": "2",
+                "hasShortProposals": true
+              }
+            }
+          ]
+        },
+        {
+          "id": "aa40e5bb-fe1e-41df-9318-a00aaca6dbe8",
+          "type": "challenge",
+          "title": "qcm short proposals (3 et 4)",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "e48f8ce7-cd94-40d3-bb62-bbee4116951c",
+                "type": "qcm",
+                "instruction": "<p>Dans ces propositions, lesquels sont des palindromes?</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "De la salade"
+                  },
+                  {
+                    "id": "2",
+                    "content": "KEYAK"
+                  },
+                  {
+                    "id": "3",
+                    "content": "10/02/2001"
+                  },
+                  {
+                    "id": "4",
+                    "content": "Réifier"
+                  }
+                ],
+                "feedbacks": {
+                  "valid": {
+                    "state": "Correct&#8239;!",
+                    "diagnosis": "<p>On trouve ici un palindrome classique par lecture des lettres, un palindrome de forme numérique et un palindrome syllabique.</p>"
+                  },
+                  "invalid": {
+                    "state": "Et non&#8239;!",
+                    "diagnosis": "<p>Essayez encore 🦀</p>"
+                  }
+                },
+                "solutions": ["1", "3", "4"],
                 "hasShortProposals": true
               }
             }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
@@ -499,6 +499,93 @@
           ]
         },
         {
+          "id": "e2b88606-c4aa-4ac2-9505-1ac691df3d67",
+          "type": "challenge",
+          "title": "qcu short proposals (3 et 4)",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "19525c84-e8e7-4852-868b-e1857f21daae",
+                "type": "qcu",
+                "instruction": "<p>Quel émoji utilise-t-on chez devcomp quand on ne participe pas au mob ?</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "🔥",
+                    "feedback": {
+                      "state": "🔥🔥🔥",
+                      "diagnosis": "<p> Non, cet émoji n'est pas disponible en autocollant sur le huddle de travail.</p>"
+                    }
+                  },
+                  {
+                    "id": "2",
+                    "content": "☕️",
+                    "feedback": {
+                      "state": "What else ? ☕️",
+                      "diagnosis": "<p>Non, mais cet émoji est bien présent comme autocollant sur le huddle.<br> Il nous permet d'indiquer que l'on s'absente un moment.</p>"
+                    }
+                  },
+                  {
+                    "id": "3",
+                    "content": "👎",
+                    "feedback": {
+                      "state": "👍 !",
+                      "diagnosis": "<p>Tout à fait ! Cet émoji, présent comme autocollant sur le huddle, nous permet d'indiquer cette information au reste de l'équipe.</p>"
+                    }
+                  }
+                ],
+                "solution": "3",
+                "hasShortProposals": true
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "b671a789-1aff-4941-b49b-ac8a1634e9eb",
+                "type": "qcu",
+                "instruction": "<p>Quel émoji utilise-t-on chez devcomp quand on commit une feature ?</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "🦀",
+                    "feedback": {
+                      "state": "Alors non...",
+                      "diagnosis": "<p>Cet émoji fait partie de la DA de l'équipe, mais rien à voir avec nos standards de commit.</p>"
+                    }
+                  },
+                  {
+                    "id": "2",
+                    "content": "⚡️",
+                    "feedback": {
+                      "state": "Oui !",
+                      "diagnosis": "<p>Pure décision de l'équipe, <strong>Gitmoji</strong> le recommandant normalement pour les améliorations de performance. <br> C'est juste qu'il est COOL 😎</p>"
+                    }
+                  },
+                  {
+                    "id": "3",
+                    "content": "✨",
+                    "feedback": {
+                      "state": "🤖INCORRECT🤖",
+                      "diagnosis": "<p>Il s'agit effectivement de l'émoji recommandé par <strong>Gitmoji</strong> mais nous avons changé depuis peu car il est devenu le symbole non officiel de l’IA.</p>"
+                    }
+                  },
+                  {
+                    "id": "4",
+                    "content": "🔥",
+                    "feedback": {
+                      "state": "🔥🔥🔥",
+                      "diagnosis": "<p>Celui-ci indique que l'on supprime du code ! il nous vient du guide <strong>Gitmoji</strong>.</p>"
+                    }
+                  }
+                ],
+                "solution": "2",
+                "hasShortProposals": true
+              }
+            }
+          ]
+        },
+        {
           "id": "f1738f85-e272-43d3-aee2-f4190be54c34",
           "type": "summary",
           "title": "test table",

--- a/api/src/devcomp/infrastructure/factories/module-factory.js
+++ b/api/src/devcomp/infrastructure/factories/module-factory.js
@@ -301,6 +301,7 @@ export class ModuleFactory {
 
   static #buildQCU(element) {
     return new QCU({
+      hasShortProposals: element.hasShortProposals,
       id: element.id,
       instruction: element.instruction,
       locales: element.locales,

--- a/api/src/devcomp/infrastructure/factories/module-factory.js
+++ b/api/src/devcomp/infrastructure/factories/module-factory.js
@@ -285,6 +285,7 @@ export class ModuleFactory {
 
   static #buildQCM(element) {
     return new QCM({
+      hasShortProposals: element.hasShortProposals,
       id: element.id,
       instruction: element.instruction,
       locales: element.locales,

--- a/api/tests/devcomp/integration/infrastructure/factories/module-factory_test.js
+++ b/api/tests/devcomp/integration/infrastructure/factories/module-factory_test.js
@@ -894,6 +894,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
                     {
                       type: 'element',
                       element: {
+                        hasShortProposals: true,
                         id: 'ba78dead-a806-4954-b408-e8ef28d28fab',
                         type: 'qcu',
                         instruction: '<p>L’adresse mail M3g4Cool1415@gmail.com est correctement écrite ?</p>',
@@ -1912,6 +1913,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
                         {
                           elements: [
                             {
+                              hasShortProposals: true,
                               id: '71de6394-ff88-4de3-8834-a40057a50ff4',
                               type: 'qcu',
                               instruction: '<p>Pix évalue 16 compétences numériques différentes.</p>',

--- a/api/tests/devcomp/integration/infrastructure/factories/module-factory_test.js
+++ b/api/tests/devcomp/integration/infrastructure/factories/module-factory_test.js
@@ -1116,6 +1116,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
                     {
                       type: 'element',
                       element: {
+                        hasShortProposals: true,
                         id: '30701e93-1b4d-4da4-b018-fa756c07d53f',
                         type: 'qcm',
                         instruction: '<p>Quels sont les 3 piliers de Pix ?</p>',
@@ -2067,6 +2068,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
                         {
                           elements: [
                             {
+                              hasShortProposals: true,
                               id: '30701e93-1b4d-4da4-b018-fa756c07d53f',
                               type: 'qcm',
                               instruction: '<p>Quels sont les 3 piliers de Pix&#8239;?</p>',

--- a/mon-pix/app/components/module/element/_qcm.scss
+++ b/mon-pix/app/components/module/element/_qcm.scss
@@ -24,7 +24,7 @@
       }
     }
 
-    .pix-label-wrapped--variant-tile.pix-label-wrapped--disabled.pix-label-wrapped--state-error {
+    .pix-checkbox .pix-label-wrapped--state-error {
       color: var(--pix-warning-700);
       background-color: var(--state-background-color);
       border-color: var(--pix-warning-700);
@@ -32,16 +32,12 @@
       --state-background-color: var(--pix-warning-50);
     }
 
-    .pix-label-wrapped--variant-tile.pix-label-wrapped--disabled.pix-label-wrapped--state-success {
+    .pix-checkbox .pix-label-wrapped--state-success {
       color: var(--pix-success-700);
       background-color: var(--state-background-color);
       border-color: var(--pix-success-700);
 
       --state-background-color: var(--pix-success-50);
-    }
-
-    .pix-label-wrapped--variant-tile.pix-label-wrapped--disabled .pix-label-wrapped__state-icon {
-      background-color: var(--state-background-color);
     }
   }
 

--- a/mon-pix/app/components/module/element/_qcm.scss
+++ b/mon-pix/app/components/module/element/_qcm.scss
@@ -1,4 +1,5 @@
 @use 'pix-design-tokens/typography';
+@use 'pix-design-tokens/breakpoints';
 
 .element-qcm {
   &__instruction {
@@ -12,7 +13,7 @@
     color: var(--pix-neutral-500);
   }
 
-  &__proposals {
+  &__proposals, &__short-proposals, &__3-short-proposals {
     margin: var(--pix-spacing-4x) 0;
 
     @media (not (prefers-reduced-motion: reduce)) {
@@ -38,6 +39,30 @@
       border-color: var(--pix-success-700);
 
       --state-background-color: var(--pix-success-50);
+    }
+  }
+
+  &__short-proposals, &__3-short-proposals {
+    display: grid;
+    gap: var(--pix-spacing-3x);
+
+    .pix-checkbox + .pix-checkbox {
+      margin: 0;
+    }
+  }
+
+  &__short-proposals {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  &__3-short-proposals {
+    grid-template-columns: repeat(3, 1fr);
+  }
+
+  @include breakpoints.device-is('mobile') {
+    &__short-proposals, &__3-short-proposals {
+      display: flex;
+      flex-direction: column;
     }
   }
 

--- a/mon-pix/app/components/module/element/_qcm.scss
+++ b/mon-pix/app/components/module/element/_qcm.scss
@@ -61,8 +61,7 @@
 
   @include breakpoints.device-is('mobile') {
     &__short-proposals, &__3-short-proposals {
-      display: flex;
-      flex-direction: column;
+      grid-template-columns: 1fr;
     }
   }
 

--- a/mon-pix/app/components/module/element/_qcu-declarative.scss
+++ b/mon-pix/app/components/module/element/_qcu-declarative.scss
@@ -43,8 +43,7 @@
 
   @include breakpoints.device-is('mobile') {
     &__short-proposals, &__3-short-proposals {
-      display: flex;
-      flex-direction: column;
+      grid-template-columns: 1fr;
     }
   }
 

--- a/mon-pix/app/components/module/element/_qcu-discovery.scss
+++ b/mon-pix/app/components/module/element/_qcu-discovery.scss
@@ -35,8 +35,7 @@
 
   @include breakpoints.device-is('mobile') {
     &__short-proposals, &__3-short-proposals {
-      display: flex;
-      flex-direction: column;
+      grid-template-columns: 1fr;
     }
   }
 }

--- a/mon-pix/app/components/module/element/_qcu.scss
+++ b/mon-pix/app/components/module/element/_qcu.scss
@@ -1,4 +1,5 @@
 @use 'pix-design-tokens/typography';
+@use 'pix-design-tokens/breakpoints';
 
 .element-qcu {
   &__instruction {
@@ -12,7 +13,7 @@
     color: var(--pix-neutral-500);
   }
 
-  &__proposals {
+  &__proposals, &__short-proposals, &__3-short-proposals {
     margin: var(--pix-spacing-4x) 0;
 
     @media (not (prefers-reduced-motion: reduce)) {
@@ -38,6 +39,30 @@
       border-color: var(--pix-success-700);
 
       --state-background-color: var(--pix-success-50);
+    }
+  }
+
+  &__short-proposals, &__3-short-proposals {
+    display: grid;
+    gap: var(--pix-spacing-3x);
+
+    .pix-radio-button + .pix-radio-button {
+      margin: 0;
+    }
+  }
+
+  &__short-proposals {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  &__3-short-proposals {
+    grid-template-columns: repeat(3, 1fr);
+  }
+
+  @include breakpoints.device-is('mobile') {
+    &__short-proposals, &__3-short-proposals {
+      display: flex;
+      flex-direction: column;
     }
   }
 

--- a/mon-pix/app/components/module/element/_qcu.scss
+++ b/mon-pix/app/components/module/element/_qcu.scss
@@ -61,8 +61,7 @@
 
   @include breakpoints.device-is('mobile') {
     &__short-proposals, &__3-short-proposals {
-      display: flex;
-      flex-direction: column;
+      grid-template-columns: 1fr;
     }
   }
 

--- a/mon-pix/app/components/module/element/_qcu.scss
+++ b/mon-pix/app/components/module/element/_qcu.scss
@@ -24,7 +24,7 @@
       }
     }
 
-    .pix-label-wrapped--variant-tile.pix-label-wrapped--disabled.pix-label-wrapped--state-error {
+    .pix-radio-button .pix-label-wrapped--state-error {
       color: var(--pix-warning-700);
       background-color: var(--state-background-color);
       border-color: var(--pix-warning-700);
@@ -32,16 +32,12 @@
       --state-background-color: var(--pix-warning-50);
     }
 
-    .pix-label-wrapped--variant-tile.pix-label-wrapped--disabled.pix-label-wrapped--state-success {
+    .pix-radio-button .pix-label-wrapped--state-success {
       color: var(--pix-success-700);
       background-color: var(--state-background-color);
       border-color: var(--pix-success-700);
 
       --state-background-color: var(--pix-success-50);
-    }
-
-    .pix-label-wrapped--variant-tile.pix-label-wrapped--disabled .pix-label-wrapped__state-icon {
-      background-color: var(--state-background-color);
     }
   }
 

--- a/mon-pix/app/components/module/element/module-element.gjs
+++ b/mon-pix/app/components/module/element/module-element.gjs
@@ -44,7 +44,7 @@ export default class ModuleElement extends Component {
     throw new Error('ModuleElement.canValidateElement not implemented');
   }
 
-  get hasShortProposals() {
+  get proposalsStyle() {
     if (!this.element.hasShortProposals || this.modulixPreviewMode.isEnabled) {
       return 'proposals';
     }

--- a/mon-pix/app/components/module/element/qcm.gjs
+++ b/mon-pix/app/components/module/element/qcm.gjs
@@ -156,7 +156,7 @@ export default class ModuleQcm extends ModuleElement {
           {{t "pages.modulix.qcm.direction"}}
         </p>
 
-        <div class="element-qcm__proposals">
+        <div class="element-qcm__{{this.proposalsStyle}}">
           {{#each this.element.proposals as |proposal|}}
             <PixCheckbox
               name={{this.element.id}}

--- a/mon-pix/app/components/module/element/qcu-declarative.gjs
+++ b/mon-pix/app/components/module/element/qcu-declarative.gjs
@@ -72,7 +72,7 @@ export default class ModuleQcuDeclarative extends ModuleElement {
         <p class="element-qcu-declarative__complementary-instruction">
           {{t "pages.modulix.qcuDeclarative.complementaryInstruction"}}
         </p>
-        <div class="element-qcu-declarative__{{this.hasShortProposals}}">
+        <div class="element-qcu-declarative__{{this.proposalsStyle}}">
           {{#each this.element.proposals as |proposal|}}
             <ProposalButton
               @proposal={{proposal}}

--- a/mon-pix/app/components/module/element/qcu-discovery.gjs
+++ b/mon-pix/app/components/module/element/qcu-discovery.gjs
@@ -73,7 +73,7 @@ export default class ModuleQcuDiscovery extends ModuleElement {
         <p class="element-qcu-discovery__direction">
           {{t "pages.modulix.qcuDiscovery.direction"}}
         </p>
-        <div class="element-qcu-discovery__{{this.hasShortProposals}}">
+        <div class="element-qcu-discovery__{{this.proposalsStyle}}">
           {{#each this.element.proposals as |proposal|}}
             <ProposalButton
               @proposal={{proposal}}

--- a/mon-pix/app/components/module/element/qcu.gjs
+++ b/mon-pix/app/components/module/element/qcu.gjs
@@ -139,7 +139,7 @@ export default class ModuleQcu extends ModuleElement {
           {{t "pages.modulix.qcu.direction"}}
         </p>
 
-        <div class="element-qcu__proposals">
+        <div class="element-qcu__{{this.proposalsStyle}}">
           {{#each this.element.proposals as |proposal|}}
             <PixRadioButton
               name={{this.element.id}}

--- a/mon-pix/tests/integration/components/module/qcm_test.gjs
+++ b/mon-pix/tests/integration/components/module/qcm_test.gjs
@@ -434,4 +434,41 @@ module('Integration | Component | Module | QCM', function (hooks) {
       assert.dom(screen.getByText('Too Bad!')).exists();
     });
   });
+
+  module('when QCM has short proposals', function () {
+    test('should display proposals in a grid', async function (assert) {
+      // given
+      const hasShortProposals = true;
+      const qcmElementWithShortProposals = {
+        hasShortProposals,
+        id: 'a2638f8e-05ee-42e0-9820-13a9977cf5dc',
+        instruction: 'Instruction',
+        proposals: [
+          { id: '1', content: 'checkbox1' },
+          { id: '2', content: 'checkbox2' },
+          { id: '3', content: 'checkbox3' },
+        ],
+        feedbacks: {
+          valid: {
+            state: 'Correct!',
+            diagnosis: '<p>Good job!</p>',
+          },
+          invalid: {
+            state: 'Wrong!',
+            diagnosis: '<p>Too Bad!</p>',
+          },
+        },
+        solutions: ['1', '2'],
+        type: 'qcm',
+      };
+
+      // when
+      const screen = await render(<template><ModulixQcm @element={{qcmElementWithShortProposals}} /></template>);
+
+      // then
+      assert
+        .dom(screen.getByRole('checkbox', { name: 'checkbox1' }).parentElement.parentElement.parentElement)
+        .hasClass('element-qcm__3-short-proposals');
+    });
+  });
 });

--- a/mon-pix/tests/integration/components/module/qcu-declarative_test.gjs
+++ b/mon-pix/tests/integration/components/module/qcu-declarative_test.gjs
@@ -167,9 +167,28 @@ module('Integration | Component | Module | QCUDeclarative', function (hooks) {
       assert.dom(screen.getByRole('heading', { name: t('pages.modulix.issue-report.modal.title'), level: 1 })).exists();
     });
   });
+
+  module('when qcu declarative has short proposals', function () {
+    test('should display proposals in a grid', async function (assert) {
+      // given
+      const hasShortProposals = true;
+      const qcuDeclarativeElementWithShortProposals = _getQcuDeclarativeElement(hasShortProposals);
+      const { proposals } = qcuDeclarativeElementWithShortProposals;
+
+      // when
+      const screen = await render(
+        <template><ModuleQcuDeclarative @element={{qcuDeclarativeElementWithShortProposals}} /></template>,
+      );
+
+      // then
+      assert
+        .dom(screen.getByRole('button', { name: proposals[0].content }).parentElement)
+        .hasClass('element-qcu-declarative__3-short-proposals');
+    });
+  });
 });
 
-function _getQcuDeclarativeElement() {
+function _getQcuDeclarativeElement(hasShortProposals = false) {
   const instruction = '<p>De quoi le ‘oui‘ a-t-il besoin pour gagner ?</p>';
   const complementaryInstruction = 'Il n’y a pas de bonne ou de mauvaise réponse.';
 
@@ -197,5 +216,5 @@ function _getQcuDeclarativeElement() {
     },
   ];
 
-  return { instruction, complementaryInstruction, proposals };
+  return { instruction, hasShortProposals, complementaryInstruction, proposals };
 }

--- a/mon-pix/tests/integration/components/module/qcu-discovery_test.gjs
+++ b/mon-pix/tests/integration/components/module/qcu-discovery_test.gjs
@@ -188,9 +188,28 @@ module('Integration | Component | Module | QCUDiscovery', function (hooks) {
       assert.dom(screen.getByRole('heading', { name: t('pages.modulix.issue-report.modal.title'), level: 1 })).exists();
     });
   });
+
+  module('when qcu discovery has short proposals', function () {
+    test('should display proposals in a grid', async function (assert) {
+      // given
+      const hasShortProposals = true;
+      const qcuDiscoveryElementWithShortProposals = _getQcuDiscoveryElement(hasShortProposals);
+      const { proposals } = qcuDiscoveryElementWithShortProposals;
+
+      // when
+      const screen = await render(
+        <template><ModuleQcuDiscovery @element={{qcuDiscoveryElementWithShortProposals}} /></template>,
+      );
+
+      // then
+      assert
+        .dom(screen.getByRole('button', { name: proposals[0].content }).parentElement)
+        .hasClass('element-qcu-discovery__short-proposals');
+    });
+  });
 });
 
-function _getQcuDiscoveryElement() {
+function _getQcuDiscoveryElement(hasShortProposals = false) {
   const instruction = '<p>Quel est le dessert classique idéal lors d’un goûter&nbsp;?</p>';
   const solution = '1';
 
@@ -226,5 +245,5 @@ function _getQcuDiscoveryElement() {
     },
   ];
 
-  return { id: '0c397035-a940-441f-8936-050db7f997af', instruction, proposals, solution };
+  return { id: '0c397035-a940-441f-8936-050db7f997af', hasShortProposals, instruction, proposals, solution };
 }

--- a/mon-pix/tests/integration/components/module/qcu_test.gjs
+++ b/mon-pix/tests/integration/components/module/qcu_test.gjs
@@ -277,10 +277,27 @@ module('Integration | Component | Module | QCU', function (hooks) {
       assert.dom(screen.getByText('Try again!')).exists();
     });
   });
+
+  module('when qcu has short proposals', function () {
+    test('should display proposals in a grid', async function (assert) {
+      // given
+      const hasShortProposals = true;
+      const qcuElementWithShortProposals = _getQcuElement(hasShortProposals);
+
+      // when
+      const screen = await render(<template><ModulixQcu @element={{qcuElementWithShortProposals}} /></template>);
+
+      // then
+      assert
+        .dom(screen.getByRole('radio', { name: 'radio1' }).parentElement.parentElement.parentElement)
+        .hasClass('element-qcu__short-proposals');
+    });
+  });
 });
 
-function _getQcuElement() {
-  const qcuElement = {
+function _getQcuElement(hasShortProposals = false) {
+  return {
+    hasShortProposals,
     id: 'd0690f26-978c-41c3-9a21-da931857739c',
     instruction: 'Instruction',
     proposals: [
@@ -290,6 +307,4 @@ function _getQcuElement() {
     solution: '1',
     type: 'qcu',
   };
-
-  return qcuElement;
 }


### PR DESCRIPTION
## 🥀 Problème

Nous avons désormais la possibilité de créer des éléments de type "réponses courtes" dans les modules.
Mais coté front, rien n'a été fait.

## 🏹 Proposition

Permettre l'affichage des réponses courtes en cas de QCU et QCM sur Pix App.

## 💌 Remarques

Des tests ont été ajoutés sur le QCU découverte et déclaratif

## ❤️‍🔥 Pour tester

https://app-pr15151.review.pix.fr/modules/6a68bf32/bac-a-sable/details

Vérifier le comportement des 2 QCU réponses courtes et 1 QCM ajouté dans cette PR
  - Le placement (2 ou 4 proposals = 2 à la suite / 3 proposals = 3 alignés à la suite)
  - Le rendu des boutons lorsqu'on les sélectionne et qu'on valide la réponse (non régression avec le comportement habituel de ces éléments)
  - Le placement en mobile (même comportement que les versions réponses longues)
  - Le placement en preview (même comportement que les versions réponses longues)