### PR TITLE
[TECH] Utiliser DomainTransaction dans les repo de Shared

### DIFF
--- a/api/src/shared/infrastructure/repositories/access-code-repository.js
+++ b/api/src/shared/infrastructure/repositories/access-code-repository.js
@@ -1,10 +1,11 @@
-import { knex } from '../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../domain/DomainTransaction.js';
 
 export const isCodeAvailable = async function (code) {
-  const isCodeExistsInCampaigns = await knex('campaigns').first('id').where({ code });
+  const knexConn = DomainTransaction.getConnection();
+  const isCodeExistsInCampaigns = await knexConn('campaigns').first('id').where({ code });
   if (isCodeExistsInCampaigns) {
     return false;
   }
-  const isCodeExistsInCombinedCourse = await knex('combined_courses').first('id').where({ code });
+  const isCodeExistsInCombinedCourse = await knexConn('combined_courses').first('id').where({ code });
   return !isCodeExistsInCombinedCourse;
 };

--- a/api/src/shared/infrastructure/repositories/assessment-result-repository.js
+++ b/api/src/shared/infrastructure/repositories/assessment-result-repository.js
@@ -1,6 +1,5 @@
 import _ from 'lodash';
 
-import { knex } from '../../../../db/knex-database-connection.js';
 import { CompetenceMark } from '../../../certification/shared/domain/models/CompetenceMark.js';
 import {
   AutoJuryCommentKeys,
@@ -72,7 +71,8 @@ const save = async function ({ certificationCourseId, assessmentResult }) {
 };
 
 const findLatestLevelAndPixScoreByAssessmentId = async function ({ assessmentId, limitDate }) {
-  const result = await knex('assessment-results')
+  const knexConn = DomainTransaction.getConnection();
+  const result = await knexConn('assessment-results')
     .select('level', 'pixScore')
     .where((qb) => {
       qb.where({ assessmentId });
@@ -122,7 +122,8 @@ const getByCertificationCourseId = async function ({ certificationCourseId }) {
 };
 
 const updateToAcquiredLowerLevelComplementaryCertification = async function ({ id }) {
-  const updatedAssessmentResult = await knex('assessment-results')
+  const knexConn = DomainTransaction.getConnection();
+  const updatedAssessmentResult = await knexConn('assessment-results')
     .where({ id })
     .update({ commentByAutoJury: AutoJuryCommentKeys.LOWER_LEVEL_COMPLEMENTARY_CERTIFICATION_ACQUIRED });
 

--- a/api/src/shared/infrastructure/repositories/badge-for-calculation-repository.js
+++ b/api/src/shared/infrastructure/repositories/badge-for-calculation-repository.js
@@ -34,7 +34,6 @@ const findByCampaignParticipationId = async function ({ campaignParticipationId 
   const badges = [];
   for (const badgeDTO of badgesDTO) {
     const badge = await _buildBadge(
-      knexConn,
       campaignSkillsByTube,
       campaignSkillIds,
       badgeCriteriaDTOByBadge[badgeDTO.id],
@@ -70,7 +69,6 @@ const findByCampaignId = async function ({ campaignId }) {
   const badges = [];
   for (const badgeDTO of badgesDTO) {
     const badge = await _buildBadge(
-      knexConn,
       campaignSkillsByTube,
       campaignSkillIds,
       badgeCriteriaDTOByBadge[badgeDTO.id],
@@ -106,10 +104,10 @@ const getByCertifiableBadgeAcquisition = async function ({ certifiableBadgeAcqui
   const campaignSkillIds = campaignSkills.map(({ id }) => id);
   const campaignSkillsByTube = Object.groupBy(campaignSkills, (campaignSkill) => campaignSkill.tubeId);
 
-  return _buildBadge(knexConn, campaignSkillsByTube, campaignSkillIds, badgeCriteriaDTO, badgeDTO);
+  return _buildBadge(campaignSkillsByTube, campaignSkillIds, badgeCriteriaDTO, badgeDTO);
 };
 
-async function _buildBadge(knex, campaignSkillsByTube, campaignSkillIds, badgeCriteriaDTO, badgeDTO) {
+async function _buildBadge(campaignSkillsByTube, campaignSkillIds, badgeCriteriaDTO, badgeDTO) {
   const badgeCriteria = [];
   for (const badgeCriterionDTO of badgeCriteriaDTO) {
     if (badgeCriterionDTO.scope === SCOPES.CAMPAIGN_PARTICIPATION) {

--- a/api/src/shared/infrastructure/repositories/organization-feature-repository.js
+++ b/api/src/shared/infrastructure/repositories/organization-feature-repository.js
@@ -1,7 +1,8 @@
-import { knex } from '../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../domain/DomainTransaction.js';
 
 const isFeatureEnabledForOrganization = async function ({ organizationId, featureKey }) {
-  const organizationFeature = await knex('organization-features')
+  const knexConn = DomainTransaction.getConnection();
+  const organizationFeature = await knexConn('organization-features')
     .join('features', function () {
       this.on('features.id', 'organization-features.featureId').andOnVal('features.key', featureKey);
     })

--- a/api/src/shared/infrastructure/repositories/prescriber-role-repository.js
+++ b/api/src/shared/infrastructure/repositories/prescriber-role-repository.js
@@ -1,5 +1,5 @@
-import { knex } from '../../../../db/knex-database-connection.js';
 import { prescriberRoles } from '../../application/pre-handlers/CampaignAuthorization.js';
+import { DomainTransaction } from '../../domain/DomainTransaction.js';
 
 const getForCampaign = async function ({ userId, campaignId }) {
   const result = await _getCampaignAccess({ userId, campaignId });
@@ -16,12 +16,13 @@ const getForCampaign = async function ({ userId, campaignId }) {
 export { getForCampaign };
 
 function _getCampaignAccess({ campaignId, userId }) {
-  return knex('campaigns')
+  const knexConn = DomainTransaction.getConnection();
+  return knexConn('campaigns')
     .select('ownerId', 'memberships.organizationRole')
     .join('memberships', function () {
       this.on('memberships.organizationId', 'campaigns.organizationId')
         .andOnVal('userId', userId)
-        .andOnVal('disabledAt', knex.raw('IS'), knex.raw('NULL'));
+        .andOnVal('disabledAt', knexConn.raw('IS'), knexConn.raw('NULL'));
     })
     .where('campaigns.id', campaignId)
     .first();

--- a/api/src/shared/infrastructure/repositories/skill-repository.js
+++ b/api/src/shared/infrastructure/repositories/skill-repository.js
@@ -1,4 +1,4 @@
-import { knex } from '../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../domain/DomainTransaction.js';
 import { NotFoundError } from '../../domain/errors.js';
 import { Skill } from '../../domain/models/Skill.js';
 import { getTranslatedKey } from '../../domain/services/get-translated-text.js';
@@ -59,7 +59,8 @@ export async function findOperativeByCompetenceId(competenceId) {
 }
 
 export async function findOperativeByCompetenceIds(competenceIds) {
-  const ids = await knex
+  const knexConn = DomainTransaction.getConnection();
+  const ids = await knexConn
     .pluck('id')
     .from(TABLE_NAME)
     .whereIn('competenceId', competenceIds)

--- a/api/src/shared/infrastructure/repositories/tube-repository.js
+++ b/api/src/shared/infrastructure/repositories/tube-repository.js
@@ -1,4 +1,4 @@
-import { knex } from '../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../domain/DomainTransaction.js';
 import { LearningContentResourceNotFound } from '../../domain/errors.js';
 import { Tube } from '../../domain/models/Tube.js';
 import { getTranslatedKey } from '../../domain/services/get-translated-text.js';
@@ -30,7 +30,8 @@ export async function findByNames({ tubeNames, locale }) {
   if (!tubeNames) {
     return [];
   }
-  const ids = await knex.pluck('id').from(TABLE_NAME).whereIn('name', tubeNames).orderBy('name');
+  const knexConn = DomainTransaction.getConnection();
+  const ids = await knexConn.pluck('id').from(TABLE_NAME).whereIn('name', tubeNames).orderBy('name');
   const tubeDtos = await getInstance().loadMany(ids);
   return toDomainList(tubeDtos, locale);
 }
@@ -44,7 +45,8 @@ export async function findByRecordIds(ids, locale) {
 }
 
 export async function findActiveByRecordIds(ids, locale) {
-  const activeTubeIds = await knex
+  const knexConn = DomainTransaction.getConnection();
+  const activeTubeIds = await knexConn
     .pluck('tubeId')
     .distinct()
     .from('learningcontent.skills')

--- a/api/src/shared/infrastructure/repositories/user-login-repository.js
+++ b/api/src/shared/infrastructure/repositories/user-login-repository.js
@@ -1,4 +1,3 @@
-import { knex } from '../../../../db/knex-database-connection.js';
 import { UserLogin } from '../../../identity-access-management/domain/models/UserLogin.js';
 import { NotFoundError } from '../../../shared/domain/errors.js';
 import { DomainTransaction } from '../../domain/DomainTransaction.js';
@@ -34,7 +33,8 @@ const getByUserId = async function (userId) {
 };
 
 const create = async function (userLogin) {
-  const [userLoginDTO] = await knex(USER_LOGINS_TABLE_NAME).insert(userLogin).returning('*');
+  const knexConn = DomainTransaction.getConnection();
+  const [userLoginDTO] = await knexConn(USER_LOGINS_TABLE_NAME).insert(userLogin).returning('*');
   return _toDomain(userLoginDTO);
 };
 
@@ -53,7 +53,8 @@ const update = async function (userLogin, { preventUpdatedAt } = {}) {
 };
 
 const findByUsername = async function (username) {
-  const userLoginDTO = await knex
+  const knexConn = DomainTransaction.getConnection();
+  const userLoginDTO = await knexConn
     .select('user-logins.*')
     .from(USER_LOGINS_TABLE_NAME)
     .where('users.email', username.toLowerCase())
@@ -67,7 +68,8 @@ const findByUsername = async function (username) {
 const updateLastLoggedAt = async function ({ userId }) {
   const now = new Date();
 
-  await knex(USER_LOGINS_TABLE_NAME)
+  const knexConn = DomainTransaction.getConnection();
+  await knexConn(USER_LOGINS_TABLE_NAME)
     .insert({
       userId,
       lastLoggedAt: now,


### PR DESCRIPTION
## 🥀 Problème

Dans le contexte Shared, sur certains repository, on utilise toujours `knex` au lieu de `DomainTransaction.getConnection`.

## 🏹 Proposition

Utiliser le `DomainTransaction.getConnection` dans :
- `access-code-repository.js`
- `assessment-result-repository.js`
- `organization-feature-repository.js`
- `prescriber-role-repository.js`
- `skill-repository.js`
- `tube-repository.js`
- `user-login-repository.js`

## 💌 Remarques

[scout] Supprimer un argument non utilisé dans une fonction de `badge-for-calculation-repository.js`

## ❤️‍🔥 Pour tester

Les tests auto sont suffisants ?
