### PR TITLE
[TECH] Ignorer le contenu des modules dans le check de format API (PIX-21599)

### DIFF
--- a/api/.oxfmtrc.json
+++ b/api/.oxfmtrc.json
@@ -2,5 +2,5 @@
   "$schema": "./node_modules/oxfmt/configuration_schema.json",
   "printWidth": 120,
   "singleQuote": true,
-  "ignorePatterns": ["**/not-a-json.json"]
+  "ignorePatterns": ["**/not-a-json.json", "src/devcomp/infrastructure/datasources/learning-content/modules/**.json"]
 }


### PR DESCRIPTION
## 🥀 Problème

Depuis la mise en place du nouveau formatter oxfmt côté API, les PR de la contribution Modulix ont leur CI KO car celles-ci ne respectent pas les règles de format.

## 🏹 Proposition

Lors du check du format des fichiers API par Oxfmt, ignorer les fichiers de la contribution Modulix.
Ceux-ci sont systématiquement stockés dans le dossier : `api/src/devcomp/infrastructure/datasources/learning-content/modules`

## 💌 Remarques

RAS

## ❤️‍🔥 Pour tester
- Récupérer la branche localement
- Modifier un fichier dans le dossier `api/src/devcomp/infrastructure/datasources/learning-content/modules`, qui devraient en tant normal lancer une erreur de format
- Lancer la commande `npm run lint:format`
- Constater qu'il n'y a aucune erreur remontée