### PR TITLE
[TECH] Amélioration de requête SQL de récupération de places (PIX-21590).

### DIFF
--- a/api/src/prescription/organization-learner/infrastructure/repositories/organization-learner-repository.js
+++ b/api/src/prescription/organization-learner/infrastructure/repositories/organization-learner-repository.js
@@ -494,18 +494,16 @@ const findAllLearnerWithAtLeastOneParticipationByOrganizationId = async function
 const findAllLearnerWithAtLeastOneParticipationByOrganizationIds = async function (organizationIds) {
   const knexConn = DomainTransaction.getConnection();
   const results = await knexConn
-    .select('users.isAnonymous', 'view-active-organization-learners.organizationId')
-    .distinct('view-active-organization-learners.id')
-    .from('view-active-organization-learners')
-    .join('users', 'users.id', 'view-active-organization-learners.userId')
-    .join('campaign-participations', function () {
-      this.on('campaign-participations.organizationLearnerId', 'view-active-organization-learners.id').andOnVal(
-        'campaign-participations.deletedAt',
-        knexConn.raw('IS'),
-        knexConn.raw('NULL'),
-      );
-    })
-    .whereIn('organizationId', organizationIds);
+    .select('users.isAnonymous', 'vaol.organizationId')
+    .from(knexConn.raw('unnest(?::int[]) AS organization(id)', [organizationIds]))
+    .join('view-active-organization-learners as vaol', 'vaol.organizationId', 'organization.id')
+    .join('users', 'users.id', 'vaol.userId')
+    .whereExists(function () {
+      this.select(1)
+        .from('campaign-participations')
+        .whereRaw('"campaign-participations"."organizationLearnerId" = vaol.id')
+        .whereNull('campaign-participations.deletedAt');
+    });
 
   const resultByOrganization = {};
 


### PR DESCRIPTION
## 🥀 Problème

Une requête liée à la récupération des places d'un organization-learner met trop de temps à s'exécuter.
Cette requête, dans la méthode `findAllLearnerWithAtLeastOneParticipationByOrganizationIds` de `api/src/prescription/organization-learner/infrastructure/repositories/organization-learner-repository.js` fait planter le setup de l'environnement `pix-api-to-pg` à cause de ces timeouts à répétition.
On voudrait donc la retoucher un peu. 🧑‍🏭 

Un `EXPLAIN ANALYZE` sur la requête initiale donne le résultat suivant : 

```
QUERY PLAN
Unique  (cost=1108817.12..1394669.48 rows=2214028 width=9) (actual time=988.077..1115.725 rows=98613 loops=1)
  ->  Gather Merge  (cost=1108817.12..1378064.27 rows=2214028 width=9) (actual time=988.076..1106.729 rows=98613 loops=1)
        Workers Planned: 4
        Workers Launched: 4
        ->  Unique  (cost=1107817.06..1113352.13 rows=553507 width=9) (actual time=961.602..967.765 rows=19723 loops=5)
              ->  Sort  (cost=1107817.06..1109200.83 rows=553507 width=9) (actual time=961.600..964.093 rows=50097 loops=5)
"                    Sort Key: u.""isAnonymous"", ""organization-learners"".""organizationId"", ""organization-learners"".id"
                    Sort Method: quicksort  Memory: 5794kB
                    Worker 0:  Sort Method: quicksort  Memory: 3378kB
                    Worker 1:  Sort Method: quicksort  Memory: 3103kB
                    Worker 2:  Sort Method: quicksort  Memory: 3380kB
                    Worker 3:  Sort Method: quicksort  Memory: 3348kB
                    ->  Nested Loop  (cost=11994.89..1049611.36 rows=553507 width=9) (actual time=275.527..939.490 rows=50097 loops=5)
                          ->  Nested Loop  (cost=11994.33..704312.37 rows=263417 width=9) (actual time=275.441..652.185 rows=32339 loops=5)
"                                ->  Parallel Bitmap Heap Scan on ""organization-learners""  (cost=11993.89..484503.78 rows=315280 width=12) (actual time=275.357..475.449 rows=32405 loops=5)"
"                                      Recheck Cond: (""organizationId"" = ANY ('{<LISTE_DES_757_IDS_TROUVÉS_EN_PRODUCTION>}'::integer[]))"
                                      Rows Removed by Index Recheck: 773913
"                                      Filter: ((""deletedAt"" IS NULL) AND (""deletedBy"" IS NULL))"
                                      Rows Removed by Filter: 16756
                                      Heap Blocks: exact=22850 lossy=18738
                                      ->  Bitmap Index Scan on organization_learners_organizationid_division_index  (cost=0.00..11676.72 rows=1318137 width=0) (actual time=45.578..45.579 rows=245806 loops=1)
"                                            Index Cond: (""organizationId"" = ANY ('{<LISTE_DES_757_IDS_TROUVÉS_EN_PRODUCTION>}'::integer[]))"
                                ->  Index Scan using users_pkey on users u  (cost=0.44..0.70 rows=1 width=5) (actual time=0.005..0.005 rows=1 loops=162026)
"                                      Index Cond: (id = ""organization-learners"".""userId"")"
"                          ->  Index Scan using campaign_participations_organizationlearnerid_index on ""campaign-participations"" cp  (cost=0.56..1.24 rows=7 width=4) (actual time=0.006..0.009 rows=2 loops=161695)"
"                                Index Cond: (""organizationLearnerId"" = ""organization-learners"".id)"
"                                Filter: (""deletedAt"" IS NULL)"
                                Rows Removed by Filter: 1
Planning Time: 1.348 ms
JIT:
  Functions: 86
"  Options: Inlining true, Optimization true, Expressions true, Deforming true"
"  Timing: Generation 6.073 ms, Inlining 220.914 ms, Optimization 583.569 ms, Emission 364.206 ms, Total 1174.761 ms"
Execution Time: 1120.785 ms
```

Problème n°1: TRI MASSIF

```
Unique
 -> Gather Merge
   -> Unique
     -> Sort
```
Deux niveaux de `Unique` et `Sort` obligatoire

Cause:  Beaucoup de doublons sont créés à cause du `JOIN campaign-participations` (1 learner → N participations), qui doivent ensuite être éliminés par PG à posteriori.

Problème n°2: `Nested Loop` sur un gros jeu de données

```
Nested Loop (actual time=275..939 ms)
  loops=5
  rows=50k par worker
```

```
Index Scan on users
  loops=162026

Index Scan on campaign-participations
  loops=161695
```

- 160 000 index scans sur `users` et `campaign-participations`

Problème n°3: Bitmap Heap Scan 

```
Bitmap Heap Scan on organization-learners
  Heap Blocks: exact=22850 lossy=18738
  Rows Removed by Index Recheck: 773913
```

- L’index sur organizationId renvoie énormément de TIDs
- PG doit relire les pages heap, rechecker chaque ligne et jeter ~774k lignes après coup

Cause probable : 

- `WHERE organizationId IN (...)` avec une liste trop importante

## 🏹 Proposition

Nous réécrivons la requête en : 
- remplaçant la jointure à `campaign-participations` par un `IF EXISTS` 
- utilisant `UNNEST` en lieu et place du `WHERE organizationId IN (...)` 

## 💌 Remarques

⚠️ Analyse et proposition d'amélioration réalisées en collaboration avec l'IA.
Malgré ce qui semble être un QUERY PLAN (ci-dessous) de moins bonne facture, notamment à cause du `Parallel Seq Scan` sur `users` 💥 , la requête s'exécute systématiquement avant le timeout. 🤷🏻 

```
QUERY PLAN
Gather  (cost=469119.68..1052887.43 rows=352805 width=5) (actual time=450.618..2244.297 rows=98613 loops=1)
  Workers Planned: 4
  Workers Launched: 4
  ->  Nested Loop Semi Join  (cost=468119.68..1016606.93 rows=88201 width=5) (actual time=782.305..2100.075 rows=19723 loops=5)
        ->  Hash Join  (cost=468119.12..830796.73 rows=310367 width=9) (actual time=782.211..1901.796 rows=32339 loops=5)
"              Hash Cond: (users.id = ""organization-learners"".""userId"")"
              ->  Parallel Seq Scan on users  (cost=0.00..301140.33 rows=4426032 width=5) (actual time=207.097..648.733 rows=3540826 loops=5)
              ->  Hash  (cost=442289.39..442289.39 rows=1485898 width=12) (actual time=572.545..572.547 rows=161695 loops=5)
                    Buckets: 524288  Batches: 8  Memory Usage: 4958kB
                    ->  Nested Loop  (cost=0.44..442289.39 rows=1485898 width=12) (actual time=0.133..543.295 rows=162026 loops=5)
                          ->  Function Scan on unnest organization  (cost=0.00..7.57 rows=757 width=4) (actual time=0.061..0.200 rows=757 loops=5)
"                          ->  Index Scan using organization_learners_organizationid_division_index on ""organization-learners""  (cost=0.44..564.63 rows=1963 width=12) (actual time=0.008..0.696 rows=214 loops=3785)"
"                                Index Cond: (""organizationId"" = organization.id)"
"                                Filter: ((""deletedAt"" IS NULL) AND (""deletedBy"" IS NULL))"
                                Rows Removed by Filter: 111
"        ->  Index Scan using campaign_participations_organizationlearnerid_index on ""campaign-participations""  (cost=0.56..0.74 rows=7 width=4) (actual time=0.006..0.006 rows=1 loops=161695)"
"              Index Cond: (""organizationLearnerId"" = ""organization-learners"".id)"
"              Filter: (""deletedAt"" IS NULL)"
              Rows Removed by Filter: 1
Planning Time: 0.742 ms
JIT:
  Functions: 110
"  Options: Inlining true, Optimization true, Expressions true, Deforming true"
"  Timing: Generation 5.600 ms, Inlining 193.698 ms, Optimization 499.541 ms, Emission 342.455 ms, Total 1041.293 ms"
Execution Time: 2250.060 ms

```

## ❤️‍🔥 Pour tester

- Tester les deux requêtes (ancienne version et nouvelle) sur la production/datawarehouse
- Obtenir un temps de réponse plus rapide pour la nouvelle version

Récupération des organizationIds à insérer dans les requêtes: 

```sql
select o.id from organizations o 
join "organization-features" of 
on of."organizationId" = o.id
and of."featureId" = 35
where o."archivedAt" is null;
```

Ancienne version : 
```sql
SELECT DISTINCT
  u."isAnonymous",
  voal."organizationId",
  voal."id"
FROM "view-active-organization-learners" AS voal
JOIN "users" AS u
  ON u."id" = voal."userId"
JOIN "campaign-participations" AS cp
  ON cp."organizationLearnerId" = voal."id"
 AND cp."deletedAt" IS NULL
WHERE voal."organizationId" IN (<ORGANIZATION_IDS>);
```

Nouvelle version : 
```sql
SELECT 
    "users"."isAnonymous", 
    "vaol"."organizationId"
FROM 
    unnest(ARRAY[<ORGANIZATION_IDS>]::int[]) AS organization(id)
INNER JOIN 
    "view-active-organization-learners" AS "vaol" 
    ON "vaol"."organizationId" = "organization"."id"
INNER JOIN 
    "users" 
    ON "users"."id" = "vaol"."userId"
WHERE 
    EXISTS (
        SELECT 1 
        FROM "campaign-participations" 
        WHERE "campaign-participations"."organizationLearnerId" = "vaol"."id"
          AND "campaign-participations"."deletedAt" IS NULL
    );
```