### PR TITLE
[BUGFIX]  Réalignement de l'image des carte de mission avant lancement d'une mission (PIX-21602)

### DIFF
--- a/junior/app/styles/components/mission-card/card.scss
+++ b/junior/app/styles/components/mission-card/card.scss
@@ -11,7 +11,9 @@
     font-style: normal;
     background-color: var(--pix-neutral-0);
     border-radius: 16px;
-    box-shadow: 2px 4px 6px 0 rgb(70 77 98 / 20%), 0 0 2px 0 rgb(70 77 98 / 32%);
+    box-shadow:
+      2px 4px 6px 0 rgb(70 77 98 / 20%),
+      0 0 2px 0 rgb(70 77 98 / 32%);
 
     .area-code-1 {
       color: var(--pix-information-dark);
@@ -118,6 +120,7 @@
       top: 85px;
       right: 0;
       left: 0;
+      text-align: center;
 
       .icon {
         width: 121px;


### PR DESCRIPTION
## 🥀 Problème

<img width="726" height="682" alt="image" src="https://github.com/user-attachments/assets/ffc6d6df-cfe2-41d7-83b2-f39044fad778" />

## 🏹 Proposition

<img width="726" height="682" alt="image" src="https://github.com/user-attachments/assets/511c5118-eaf4-42b0-9f38-bc8f63ceaced" />

## 💌 Remarques

RAS

## ❤️‍🔥 Pour tester

 1 - codeEcole: `MINIPIXOU`
 2 - choisir un user
 3 - lien : https://junior-pr15157.review.pix.fr/missions/7


Voir qu'au lancement d'une mission l'image est bien aligné.