### PR TITLE
[BUGFIX] Ne pas afficher l'indicateur de focus sur le stepper lorsqu'il n'est pas le premier composant d'un grain (PIX-21232)

### DIFF
--- a/mon-pix/app/components/module/component/step.gjs
+++ b/mon-pix/app/components/module/component/step.gjs
@@ -33,7 +33,7 @@ export default class ModulixStep extends Component {
 
   @action
   focusAndScroll(htmlElement) {
-    if (!this.args.isActive || this.args.preventScrollAndFocus) {
+    if (!this.args.isActive || this.args.preventFocusAndScroll) {
       return;
     }
 

--- a/mon-pix/app/components/module/component/stepper.gjs
+++ b/mon-pix/app/components/module/component/stepper.gjs
@@ -13,6 +13,7 @@ import ModuleGrain from 'mon-pix/components/module/grain/grain';
 import htmlUnsafe from 'mon-pix/helpers/html-unsafe';
 import { inc } from 'mon-pix/helpers/inc';
 import { TrackedSet } from 'tracked-built-ins';
+import { localCopy } from 'tracked-toolbox';
 
 import didInsert from '../../../modifiers/modifier-did-insert';
 import { VERIFY_RESPONSE_DELAY } from './element';
@@ -33,8 +34,7 @@ export default class ModulixStepper extends Component {
 
   @tracked displayedStepIndex = 0;
 
-  @tracked
-  preventScrollAndFocus = false;
+  @localCopy('args.preventInitialScrollAndFocus', false) preventScrollAndFocus;
 
   @tracked shouldAppearToRight = false;
   @tracked shouldDisplayHorizontalNextButton = this.shouldDisplayNextButton;

--- a/mon-pix/app/components/module/component/stepper.gjs
+++ b/mon-pix/app/components/module/component/stepper.gjs
@@ -291,6 +291,7 @@ export default class ModulixStepper extends Component {
               @onExpandToggle={{@onExpandToggle}}
               @onNextButtonClick={{this.displayNextStep}}
               @shouldDisplayNextButton={{this.shouldDisplayVerticalNextButton index}}
+              @preventScrollAndFocus={{this.preventScrollAndFocus}}
               @updateSkipButton={{@updateSkipButton}}
               @nextButtonName={{t "pages.modulix.buttons.stepper.next.vertical.name"}}
               @lastDisplayedStepIndex={{index}}

--- a/mon-pix/app/components/module/component/stepper.gjs
+++ b/mon-pix/app/components/module/component/stepper.gjs
@@ -34,7 +34,7 @@ export default class ModulixStepper extends Component {
 
   @tracked displayedStepIndex = 0;
 
-  @localCopy('args.preventInitialScrollAndFocus', false) preventScrollAndFocus;
+  @localCopy('args.preventInitialFocusAndScroll', false) preventFocusAndScroll;
 
   @tracked shouldAppearToRight = false;
   @tracked shouldDisplayHorizontalNextButton = this.shouldDisplayNextButton;
@@ -79,7 +79,7 @@ export default class ModulixStepper extends Component {
     }
 
     this.displayedStepIndex -= 1;
-    this.preventScrollAndFocus = true;
+    this.preventFocusAndScroll = true;
   }
 
   @action
@@ -96,7 +96,7 @@ export default class ModulixStepper extends Component {
 
     this.args.onStepperNextStep(currentStepPosition);
     this.displayedStepIndex = currentStepPosition;
-    this.preventScrollAndFocus = false;
+    this.preventFocusAndScroll = false;
 
     if (!this.userPrefersReducedMotion) {
       this.shouldAppearToRight = true;
@@ -113,7 +113,7 @@ export default class ModulixStepper extends Component {
     }
 
     this.displayedStepIndex++;
-    this.preventScrollAndFocus = true;
+    this.preventFocusAndScroll = true;
   }
 
   get lastDisplayedStepIndex() {
@@ -264,7 +264,7 @@ export default class ModulixStepper extends Component {
                 @onExpandToggle={{@onExpandToggle}}
                 @onNextButtonClick={{this.displayNextStep}}
                 @shouldDisplayNextButton={{this.shouldDisplayHorizontalNextButton}}
-                @preventScrollAndFocus={{this.preventScrollAndFocus}}
+                @preventFocusAndScroll={{this.preventFocusAndScroll}}
                 @shouldAppearToRight={{this.shouldAppearToRight}}
                 @updateSkipButton={{@updateSkipButton}}
                 @nextButtonName={{t "pages.modulix.buttons.stepper.next.horizontal.name"}}
@@ -291,7 +291,7 @@ export default class ModulixStepper extends Component {
               @onExpandToggle={{@onExpandToggle}}
               @onNextButtonClick={{this.displayNextStep}}
               @shouldDisplayNextButton={{this.shouldDisplayVerticalNextButton index}}
-              @preventScrollAndFocus={{this.preventScrollAndFocus}}
+              @preventFocusAndScroll={{this.preventFocusAndScroll}}
               @updateSkipButton={{@updateSkipButton}}
               @nextButtonName={{t "pages.modulix.buttons.stepper.next.vertical.name"}}
               @lastDisplayedStepIndex={{index}}

--- a/mon-pix/app/components/module/grain/grain.gjs
+++ b/mon-pix/app/components/module/grain/grain.gjs
@@ -259,6 +259,11 @@ export default class ModuleGrain extends Component {
       : this.intl.t('pages.modulix.buttons.grain.skip');
   }
 
+  @action
+  preventStepperInitialScrollAndFocus(index) {
+    return index !== 0;
+  }
+
   <template>
     <article
       id={{this.elementId}}
@@ -282,8 +287,8 @@ export default class ModuleGrain extends Component {
             {{this.grainTitle}}</h3>
         {{/if}}
         <div class="grain-card__content">
-          <!-- eslint-disable-next-line no-unused-vars -->
-          {{#each this.displayableComponents as |component|}}
+
+          {{#each this.displayableComponents as |component index|}}
             {{#if (eq component.type "element")}}
               <div class="grain-card-content__element">
                 <Element
@@ -313,6 +318,7 @@ export default class ModuleGrain extends Component {
                   @onVideoTranscriptionOpen={{@onVideoTranscriptionOpen}}
                   @onFileDownload={{@onFileDownload}}
                   @onExpandToggle={{@onExpandToggle}}
+                  @preventInitialScrollAndFocus={{this.preventStepperInitialScrollAndFocus index}}
                   @direction={{this.stepperDirection}}
                   @updateSkipButton={{this.updateSkipButton}}
                 />

--- a/mon-pix/app/components/module/grain/grain.gjs
+++ b/mon-pix/app/components/module/grain/grain.gjs
@@ -318,7 +318,7 @@ export default class ModuleGrain extends Component {
                   @onVideoTranscriptionOpen={{@onVideoTranscriptionOpen}}
                   @onFileDownload={{@onFileDownload}}
                   @onExpandToggle={{@onExpandToggle}}
-                  @preventInitialScrollAndFocus={{this.preventStepperInitialScrollAndFocus index}}
+                  @preventInitialFocusAndScroll={{this.preventStepperInitialScrollAndFocus index}}
                   @direction={{this.stepperDirection}}
                   @updateSkipButton={{this.updateSkipButton}}
                 />

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -98,6 +98,7 @@
         "stylelint": "^17.0.0",
         "stylelint-order": "^7.0.0",
         "tracked-built-ins": "^4.0.0",
+        "tracked-toolbox": "^2.2.0",
         "webpack": "^5.95.0",
         "xss": "^1.0.13"
       },

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -131,6 +131,7 @@
     "stylelint": "^17.0.0",
     "stylelint-order": "^7.0.0",
     "tracked-built-ins": "^4.0.0",
+    "tracked-toolbox": "^2.2.0",
     "webpack": "^5.95.0",
     "xss": "^1.0.13"
   },

--- a/mon-pix/tests/integration/components/module/grain_test.gjs
+++ b/mon-pix/tests/integration/components/module/grain_test.gjs
@@ -1111,6 +1111,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
         const verifyButton = screen.getByRole('button', { name: 'Vérifier ma réponse' });
         await click(verifyButton);
         await clock.tickAsync(VERIFY_RESPONSE_DELAY);
+
         await click(screen.getByRole('button', { name: t('pages.modulix.buttons.activity.retry') }));
         sinon.assert.calledOnce(onElementRetryStub);
         assert.ok(true);

--- a/mon-pix/tests/integration/components/module/stepper_test.gjs
+++ b/mon-pix/tests/integration/components/module/stepper_test.gjs
@@ -2497,4 +2497,111 @@ module('Integration | Component | Module | Stepper', function (hooks) {
       });
     });
   });
+
+  module('focusAndScroll', function (hooks) {
+    let focusAndScrollStub;
+
+    hooks.beforeEach(async function () {
+      const modulixAutoScrollService = this.owner.lookup('service:modulixAutoScroll');
+      focusAndScrollStub = sinon.stub(modulixAutoScrollService, 'focusAndScroll');
+    });
+
+    hooks.afterEach(async function () {
+      focusAndScrollStub.restore();
+    });
+
+    module('when preventInitialFocusAndScroll is true', function () {
+      test("it should not call 'modulixAutoScroll.focusAndScroll' function when rendering component", async function (assert) {
+        // given
+        const steps = [
+          {
+            elements: [
+              {
+                id: '342183f7-af51-4e4e-ab4c-ebed1e195063',
+                type: 'text',
+                content: '<p>Text 1</p>',
+              },
+            ],
+          },
+          {
+            elements: [
+              {
+                id: '768441a5-a7d6-4987-ada9-7253adafd842',
+                type: 'text',
+                content: '<p>Text 2</p>',
+              },
+            ],
+          },
+        ];
+
+        function stepperIsFinished() {}
+
+        function onStepperNextStepStub() {}
+
+        // when
+        await render(
+          <template>
+            <ModulixStepper
+              @direction="horizontal"
+              @preventInitialScrollAndFocus={{true}}
+              @steps={{steps}}
+              @stepperIsFinished={{stepperIsFinished}}
+              @onStepperNextStep={{onStepperNextStepStub}}
+            />
+          </template>,
+        );
+
+        // then
+        sinon.assert.notCalled(focusAndScrollStub);
+        assert.ok(true);
+      });
+    });
+
+    module('when preventInitialFocusAndScroll is false', function () {
+      test("it should call 'modulixAutoScroll.focusAndScroll' function when rendering component", async function (assert) {
+        // given
+        const steps = [
+          {
+            elements: [
+              {
+                id: '342183f7-af51-4e4e-ab4c-ebed1e195063',
+                type: 'text',
+                content: '<p>Text 1</p>',
+              },
+            ],
+          },
+          {
+            elements: [
+              {
+                id: '768441a5-a7d6-4987-ada9-7253adafd842',
+                type: 'text',
+                content: '<p>Text 2</p>',
+              },
+            ],
+          },
+        ];
+
+        function stepperIsFinished() {}
+
+        function onStepperNextStepStub() {}
+
+        // when
+        await render(
+          <template>
+            <ModulixStepper
+              @direction="horizontal"
+              @preventInitialScrollAndFocus={{false}}
+              @steps={{steps}}
+              @stepperIsFinished={{stepperIsFinished}}
+              @onStepperNextStep={{onStepperNextStepStub}}
+            />
+          </template>,
+        );
+
+        // then
+        sinon.assert.calledOnce(focusAndScrollStub);
+        assert.ok(true);
+      });
+    });
+  });
 });

--- a/mon-pix/tests/integration/components/module/stepper_test.gjs
+++ b/mon-pix/tests/integration/components/module/stepper_test.gjs
@@ -2510,8 +2510,8 @@ module('Integration | Component | Module | Stepper', function (hooks) {
       focusAndScrollStub.restore();
     });
 
-    module('when preventInitialFocusAndScroll is true', function () {
-      test("it should not call 'modulixAutoScroll.focusAndScroll' function when rendering component", async function (assert) {
+    module('when preventInitialScrollAndFocus is true', function () {
+      test("it prevents scroll and focus on stepper when rendering component", async function (assert) {
         // given
         const steps = [
           {
@@ -2557,8 +2557,8 @@ module('Integration | Component | Module | Stepper', function (hooks) {
       });
     });
 
-    module('when preventInitialFocusAndScroll is false', function () {
-      test("it should call 'modulixAutoScroll.focusAndScroll' function when rendering component", async function (assert) {
+    module('when preventInitialScrollAndFocus is false', function () {
+      test("it prevents scroll and focus on stepper when rendering component", async function (assert) {
         // given
         const steps = [
           {

--- a/mon-pix/tests/integration/components/module/stepper_test.gjs
+++ b/mon-pix/tests/integration/components/module/stepper_test.gjs
@@ -2510,8 +2510,8 @@ module('Integration | Component | Module | Stepper', function (hooks) {
       focusAndScrollStub.restore();
     });
 
-    module('when preventInitialScrollAndFocus is true', function () {
-      test("it prevents scroll and focus on stepper when rendering component", async function (assert) {
+    module('when preventInitialFocusAndScroll is true', function () {
+      test('it prevents scroll and focus on stepper when rendering component', async function (assert) {
         // given
         const steps = [
           {
@@ -2543,7 +2543,7 @@ module('Integration | Component | Module | Stepper', function (hooks) {
           <template>
             <ModulixStepper
               @direction="horizontal"
-              @preventInitialScrollAndFocus={{true}}
+              @preventInitialFocusAndScroll={{true}}
               @steps={{steps}}
               @stepperIsFinished={{stepperIsFinished}}
               @onStepperNextStep={{onStepperNextStepStub}}
@@ -2557,8 +2557,8 @@ module('Integration | Component | Module | Stepper', function (hooks) {
       });
     });
 
-    module('when preventInitialScrollAndFocus is false', function () {
-      test("it prevents scroll and focus on stepper when rendering component", async function (assert) {
+    module('when preventInitialFocusAndScroll is false', function () {
+      test('it prevents scroll and focus on stepper when rendering component', async function (assert) {
         // given
         const steps = [
           {
@@ -2590,7 +2590,7 @@ module('Integration | Component | Module | Stepper', function (hooks) {
           <template>
             <ModulixStepper
               @direction="horizontal"
-              @preventInitialScrollAndFocus={{false}}
+              @preventInitialFocusAndScroll={{false}}
               @steps={{steps}}
               @stepperIsFinished={{stepperIsFinished}}
               @onStepperNextStep={{onStepperNextStepStub}}


### PR DESCRIPTION
## 🥀 Problème

Lorsqu'on a un grain avec plusieurs éléments et un stepper, alors l'indicateur de focus va automatiquement se positionner sur le stepper quelque soit son emplacement dans le grain. Il faudrait qu'il se mette plutôt sur le premier élément / composant du grain.

## 🏹 Proposition

Corriger ce comportement en ne mettant pas d'indicateur de focus si le stepper n'est pas le premier composant du grain.

## 💌 Remarques

On utilise actuellement : 
- `focusAndScroll` sur les actions / fonction du service ModulixAutoScroll
- `scrollAndFocus` sur les arguments passés aux composants. 

Cette PR aligne les nommages pour garder uniquement focusAndScroll 😄 

## ❤️‍🔥 Pour tester
- Aller sur le module [bac-a-sable](https://app-pr15159.review.pix.fr/modules/6a68bf32/bac-a-sable/passage)
- Vérifier que l'indicateur de focus ne se met plus automatiquement sur le stepper dans le premier grain 🎉 