### PR TITLE
[BUGFIX] Ajout d'une condition supplémentaire sur l'upsert de organization_learner_participations

### DIFF
--- a/api/src/quest/infrastructure/repositories/organization-learner-participation-repository.js
+++ b/api/src/quest/infrastructure/repositories/organization-learner-participation-repository.js
@@ -32,14 +32,13 @@ export const synchronize = async ({ organizationLearnerId, moduleIds, modulesApi
 
   const learnerParticipationsByModule = await knexConn('organization_learner_participations')
     .select('organization_learner_participations.id', 'referenceId')
-    .select('organization_learner_participations.id', 'referenceId')
     .whereNull('deletedAt')
+    .where('organizationLearnerId', organizationLearnerId)
     .whereIn('referenceId', moduleIds);
 
   for (const modulePassage of modulePassages) {
     const learnerParticipationModule = learnerParticipationsByModule.find(
-      (learnerParticipation) =>
-        learnerParticipation.moduleId === modulePassage.id || learnerParticipation.referenceId === modulePassage.id,
+      (learnerParticipation) => learnerParticipation.referenceId === modulePassage.id,
     );
 
     const { id: organizationLearnerParticipationId, ...organizationLearnerPassageParticipation } =

--- a/api/tests/quest/integration/infrastructure/repositories/organization-learner-participation-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/organization-learner-participation-repository_test.js
@@ -177,6 +177,10 @@ describe('Quest | Integration | Infrastructure | repositories | organization lea
     });
 
     it('should update passage when participation already exists', async function () {
+      databaseBuilder.factory.buildOrganizationLearnerParticipation({
+        moduleId: '1234-abcdef',
+        status: 'STARTED',
+      });
       const learnerParticipationId = databaseBuilder.factory.buildOrganizationLearnerParticipation({
         status: 'STARTED',
         organizationLearnerId: organizationLearner.id,


### PR DESCRIPTION
## 🥀 Problème
[Lien vers logs Datadog
](https://app.datadoghq.eu/dashboard/rkh-gvk-6qj?fromUser=false&refresh_mode=sliding&tpl_var_service%5B0%5D=pix-orga-production&tpl_var_service%5B1%5D=pix-api-production&from_ts=1771254158958&to_ts=1771426958958&live=true)

## 🏹 Proposition
Comme la contrainte d'unicité organizationLearnerId/moduleId casse au reassess-status, on a supposé que soit le learner n'était pas passé correctement, soit le moduleId.
Il s'est avéré qu'on ne filtrait pas sur la requête pour récupérer les participations d'un learner à un module donné (on récupérait toutes les participations pour un moduleId).

## ❤️‍🔥 Pour tester
Tirer la branche en local

Commenter le  .where('organizationLearnerId', organizationLearnerId) dans : 

```
const learnerParticipationsByModule = await knexConn('organization_learner_participations')
    .select('organization_learner_participations.id', 'referenceId')
    .whereNull('deletedAt')
    .where('organizationLearnerId', organizationLearnerId)
    .whereIn('referenceId', moduleIds);
```

Et vérifier que le test correspondant au synchronize casse.
Remettre le code dans son état initial et vérifier que les tests sont au vert.