### PR TITLE
[TECH] Ajouter un script pour rattacher les ownerOrganizationId au profile cible dans la table dédié (PIX-21603).

### DIFF
--- a/api/src/prescription/scripts/add-target-profile-share-for-owner-organisation-id.js
+++ b/api/src/prescription/scripts/add-target-profile-share-for-owner-organisation-id.js
@@ -1,0 +1,55 @@
+import { Script } from '../../shared/application/scripts/script.js';
+import { ScriptRunner } from '../../shared/application/scripts/script-runner.js';
+import { DomainTransaction } from '../../shared/domain/DomainTransaction.js';
+
+const options = {
+  dryRun: {
+    type: 'boolean',
+    describe: 'Run the script without making any database changes',
+    default: true,
+  },
+};
+
+export class AddTargetProfileShareOnOwnerOrganizationId extends Script {
+  constructor() {
+    super({
+      description:
+        'Add target profile shares on owner organization Id column in order to delete target-profiles.ownerOrganizationId',
+      permanent: false,
+      options,
+    });
+  }
+
+  async handle({ logger, options }) {
+    await DomainTransaction.execute(async () => {
+      const knexConn = DomainTransaction.getConnection();
+
+      logger.info('BEGIN: AddTargetProfileShareOnOwnerOrganizationId');
+
+      const targetProfileShareToInsert = await knexConn('target-profiles')
+        .select(['id as targetProfileId', 'ownerOrganizationId as organizationId'])
+        .whereNotNull('ownerOrganizationId');
+
+      logger.info(`Try to add ${targetProfileShareToInsert.length} organization link`);
+
+      const res = await knexConn('target-profile-shares')
+        .insert(targetProfileShareToInsert)
+        .onConflict(['targetProfileId', 'organizationId'])
+        .ignore()
+        .returning('id');
+
+      logger.info(`Add ${res.length} organization link`);
+
+      if (options.dryRun) {
+        await knexConn.rollback();
+        logger.info('ROLLBACK: AddTargetProfileShareOnOwnerOrganizationId (dry run mode)');
+        logger.info('Use --dryRun=false to persist changes');
+        return;
+      }
+
+      logger.info('COMMIT: AddTargetProfileShareOnOwnerOrganizationId');
+    });
+  }
+}
+
+await ScriptRunner.execute(import.meta.url, AddTargetProfileShareOnOwnerOrganizationId);

--- a/api/tests/prescription/integration/scripts/add-target-profile-share-for-owner-organisation-id.test.js
+++ b/api/tests/prescription/integration/scripts/add-target-profile-share-for-owner-organisation-id.test.js
@@ -1,0 +1,153 @@
+import { AddTargetProfileShareOnOwnerOrganizationId } from '../../../../src/prescription/scripts/add-target-profile-share-for-owner-organisation-id.js';
+import { databaseBuilder, expect, knex, sinon } from '../../../test-helper.js';
+
+const { buildTargetProfile, buildTargetProfileShare, buildOrganization } = databaseBuilder.factory;
+
+describe('Integration | Prescription | Scripts | add-target-profile-share-for-owner-organisation-id', function () {
+  let script;
+  let logger;
+
+  beforeEach(function () {
+    script = new AddTargetProfileShareOnOwnerOrganizationId();
+    logger = {
+      info: sinon.stub(),
+      debug: sinon.stub(),
+      warn: sinon.stub(),
+      error: sinon.stub(),
+    };
+  });
+
+  describe('options', function () {
+    it('should have the correct options', function () {
+      const { options } = script.metaInfo;
+
+      expect(options.dryRun).to.deep.include({
+        type: 'boolean',
+        describe: 'Run the script without making any database changes',
+        default: true,
+      });
+    });
+  });
+
+  describe('#handle', function () {
+    describe('when target profile does not have ownerOrganizationId', function () {
+      it('should do nothing', async function () {
+        // given
+        const targetProfileId = buildTargetProfile({ ownerOrganizationId: null }).id;
+        await databaseBuilder.commit();
+
+        const options = {
+          dryRun: false,
+        };
+
+        // when
+        await script.handle({ logger, options });
+
+        // then
+        const targetProfileShares = await knex('target-profile-shares').where({ targetProfileId });
+        expect(targetProfileShares).lengthOf(0);
+      });
+
+      it('should not remove older target profile shares', async function () {
+        // given
+        const organizationId = buildOrganization().id;
+        const targetProfileId = buildTargetProfile({ ownerOrganizationId: null }).id;
+
+        buildTargetProfileShare({ organizationId, targetProfileId });
+        await databaseBuilder.commit();
+
+        const options = {
+          dryRun: false,
+        };
+
+        // when
+        await script.handle({ logger, options });
+
+        // then
+        const targetProfileShares = await knex('target-profile-shares').where({ targetProfileId, organizationId });
+        expect(targetProfileShares).lengthOf(1);
+      });
+    });
+
+    describe('when target profile have ownerOrganizationId', function () {
+      it('should not insert data on dryRun true', async function () {
+        // given
+        const organizationId = buildOrganization().id;
+        const targetProfileId = buildTargetProfile({ ownerOrganizationId: organizationId }).id;
+        await databaseBuilder.commit();
+
+        const options = {
+          dryRun: true,
+        };
+
+        // when
+        await script.handle({ logger, options });
+
+        // then
+        const targetProfileShares = await knex('target-profile-shares').where({ targetProfileId, organizationId });
+        expect(targetProfileShares).lengthOf(0);
+      });
+
+      it('should insert ownerOrganizationId targetProfileShare line', async function () {
+        // given
+        const organizationId = buildOrganization().id;
+        const targetProfileId = buildTargetProfile({ ownerOrganizationId: organizationId }).id;
+        await databaseBuilder.commit();
+
+        const options = {
+          dryRun: false,
+        };
+
+        // when
+        await script.handle({ logger, options });
+
+        // then
+        const targetProfileShares = await knex('target-profile-shares').where({ targetProfileId, organizationId });
+        expect(targetProfileShares).lengthOf(1);
+      });
+
+      it('should do nothing if ownerOrganization is already registered ', async function () {
+        // given
+        const organizationId = buildOrganization().id;
+        const targetProfileId = buildTargetProfile({ ownerOrganizationId: organizationId }).id;
+
+        buildTargetProfileShare({ organizationId, targetProfileId });
+        await databaseBuilder.commit();
+
+        const options = {
+          dryRun: false,
+        };
+
+        // when
+        await script.handle({ logger, options });
+
+        // then
+        const targetProfileShares = await knex('target-profile-shares').where({ targetProfileId, organizationId });
+        expect(targetProfileShares).lengthOf(1);
+      });
+
+      it('should not insert organizationId on another targetProfile', async function () {
+        // given
+        const organizationId = buildOrganization().id;
+        const targetProfileId = buildTargetProfile({ ownerOrganizationId: organizationId }).id;
+        const otherTargetProfileId = buildTargetProfile({ ownerOrganizationId: null }).id;
+
+        buildTargetProfileShare({ organizationId, targetProfileId });
+        await databaseBuilder.commit();
+
+        const options = {
+          dryRun: false,
+        };
+
+        // when
+        await script.handle({ logger, options });
+
+        // then
+        const targetProfileShares = await knex('target-profile-shares').where({
+          targetProfileId: otherTargetProfileId,
+        });
+        expect(targetProfileShares).lengthOf(0);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## 🥀 Problème

On déprécie la colonne ownerOrganizationId en vue d'une suppression, celle-ci pose problème pour plusieurs raisons.
- Si l'organisation ne veut plus du PC.
- Pour retrouver les PC d'une organisation, plusieurs infos dans des endroits différents
- 
## 🏹 Proposition

Rappatrier l'information de la disponibilité du Pc dans la table dédiée target-profile-shares

## 💌 Remarques

il y a < 6k profil cible en prod. l'insert me semble pas déconnant comme solution. 

## ❤️‍🔥 Pour tester
Lancer le script sur la RA et vérifier que tout les PC ont bien des rattachements dans target profile shares