### PR TITLE
[TECH] Améliorer le script de traduction des fichiers de langues

### DIFF
--- a/api/knip.jsonc
+++ b/api/knip.jsonc
@@ -5,5 +5,6 @@
   "ignoreDependencies": [
     "mocha-junit-reporter", // used by .circleci/config.yml
     "pg-query-stream", // https://knexjs.org/guide/interfaces.html#streams
+    "json-autotranslate", // used by api/scripts/translate-language-files.js
   ],
 }

--- a/api/scripts/translate-language-files.js
+++ b/api/scripts/translate-language-files.js
@@ -93,6 +93,7 @@ export class TranslateLanguageFiles extends Script {
         'icu',
         '--type',
         'key-based',
+        '--decode-escapes',
         '--config',
         `${deeplKey},${formality},${batchSize}`,
       ];

--- a/api/scripts/translate-language-files.js
+++ b/api/scripts/translate-language-files.js
@@ -61,37 +61,52 @@ export class TranslateLanguageFiles extends Script {
     const sourcePath = path.join(dir, `${sourceLang}.json`);
     const targetPath = path.join(dir, `${targetLang}.json`);
 
-    const tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'json-autotranslate-'));
-    const tmpSourcePath = path.join(tmpDir, `${sourceLang}.json`);
-    const tmpTargetPath = path.join(tmpDir, `${targetLang}.json`);
-
-    const execute = 'npx';
-    const args = [
-      'json-autotranslate',
-      '-s',
-      'deepl-free',
-      '-i',
-      tmpDir,
-      '-l',
-      sourceLang,
-      '--directory-structure',
-      'ngx-translate',
-      '--type',
-      'key-based',
-      '--config',
-      `${deeplKey},${formality},${batchSize}`,
-    ];
-    const commandForLog = `${execute} ${args.join(' ')}`;
+    let tmpDir;
+    let tmpI18nDir;
+    let tmpSourcePath;
+    let tmpTargetPath;
 
     try {
-      logger.info(`Temp dir: ${tmpDir}`);
+      tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'json-autotranslate-'));
+      tmpI18nDir = path.join(tmpDir, 'i18n');
+
+      await fs.promises.mkdir(tmpI18nDir, { recursive: true });
+      logger.info(`Temp dir: ${tmpI18nDir}`);
+
+      tmpSourcePath = path.join(tmpI18nDir, `${sourceLang}.json`);
+      tmpTargetPath = path.join(tmpI18nDir, `${targetLang}.json`);
+
       logger.info(`Real source: ${sourcePath}`);
       logger.info(`Real target: ${targetPath}`);
+
+      const args = [
+        'json-autotranslate',
+        '-s',
+        'deepl-free',
+        '-i',
+        tmpI18nDir,
+        '-l',
+        sourceLang,
+        '--directory-structure',
+        'ngx-translate',
+        '--matcher',
+        'icu',
+        '--type',
+        'key-based',
+        '--config',
+        `${deeplKey},${formality},${batchSize}`,
+      ];
+
       if (dryRun) {
-        logger.info(`DryRun - will run: ${commandForLog}`);
+        logger.info('Dry run');
+        logger.info('Translator: deepl-free');
+        logger.info(`Languages: ${sourceLang} → ${targetLang}`);
+        logger.info(`Formality: ${formality}, batchSize: ${batchSize}`);
         return;
       }
+
       await fs.promises.copyFile(sourcePath, tmpSourcePath);
+
       try {
         await fs.promises.copyFile(targetPath, tmpTargetPath);
       } catch (err) {
@@ -102,16 +117,27 @@ export class TranslateLanguageFiles extends Script {
         }
       }
 
-      logger.info(`Running: ${commandForLog}`);
+      const execute = 'npx';
+      logger.info(`Running: npx json-autotranslate (deepl-free)`);
       await run(execute, args);
-      await fs.promises.copyFile(tmpTargetPath, targetPath);
+
+      let translatedContent;
+      try {
+        translatedContent = await fs.promises.readFile(tmpTargetPath, 'utf-8');
+      } catch (err) {
+        throw new Error(`Translation output not found at ${tmpTargetPath}.`, { cause: err });
+      }
+      await fs.promises.writeFile(targetPath, translatedContent, 'utf-8');
       logger.info(`Updated target: ${targetPath}`);
     } finally {
-      await fs.promises.rm(tmpDir, { recursive: true, force: true });
-      logger.info(`Temp dir deleted: ${tmpDir}`);
+      if (tmpDir) {
+        await fs.promises.rm(tmpDir, { recursive: true, force: true });
+        logger.info(`Temp dir deleted: ${tmpDir}`);
+      }
     }
   }
 }
+
 function run(cmd, args) {
   return new Promise((resolve, reject) => {
     const child = spawn(cmd, args, { stdio: 'inherit' });

--- a/api/scripts/translate-language-files.js
+++ b/api/scripts/translate-language-files.js
@@ -1,6 +1,3 @@
-// eslint-disable-next-line n/no-missing-import
-import 'json-autotranslate';
-
 import { spawn } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';


### PR DESCRIPTION
## 🥀 Problème
Avec l’internationalisation de nouvelles langues vont être ajoutée. Nous devons réaliser une première traduction des fichiers de l’API et des fronts (ex: fr.json => de.json) avant de les faire revoir par des traducteurs.

## 🏹 Proposition

Améliorer la lisibilité du fichier de traduction et éviter le remplacement des caractères spéciaux par des codes html.

## 💌 Remarques

ras

## ❤️‍🔥 Pour tester

Lire la documentation du script pour tester ("Script de traduction de fichier via une api de traduction"). Elle a été modifiée pour améliorer la gestion des tags html.
