### PR TITLE
[FEATURE] Pouvoir renseigner le public prescrit lors de la création d'organisation en masse (PIX-21331)

### DIFF
--- a/api/src/organizational-entities/domain/validators/organization-with-tags-and-target-profiles.js
+++ b/api/src/organizational-entities/domain/validators/organization-with-tags-and-target-profiles.js
@@ -49,15 +49,15 @@ const schema = Joi.object({
     .messages({
       'any.only': "Le rôle fourni doit avoir l'une des valeurs suivantes : ADMIN ou MEMBER",
     }),
-  createdBy: Joi.number().empty('').required().messages({
+  createdBy: Joi.number().empty(null).required().messages({
     'any.required': "L'id du créateur est manquant",
     'number.base': "L'id du créateur n'est pas un nombre",
   }),
-  administrationTeamId: Joi.number().empty('').required().messages({
+  administrationTeamId: Joi.number().empty(null).required().messages({
     'any.required': "L'id de l'équipe en charge est manquant",
     'number.base': "L'id de l'équipe en charge n'est pas un nombre",
   }),
-  countryCode: Joi.number().min(99000).max(99999).integer().required().messages({
+  countryCode: Joi.number().min(99000).max(99999).empty(null).integer().required().messages({
     'any.required': 'Le code pays n’est pas renseigné.',
     'number.min': 'Le code pays doit être un nombre entier compris entre 99000 et 99999.',
     'number.max': 'Le code pays doit être un nombre entier compris entre 99000 et 99999.',

--- a/api/src/organizational-entities/domain/validators/organization-with-tags-and-target-profiles.js
+++ b/api/src/organizational-entities/domain/validators/organization-with-tags-and-target-profiles.js
@@ -49,16 +49,17 @@ const schema = Joi.object({
     .messages({
       'any.only': "Le rôle fourni doit avoir l'une des valeurs suivantes : ADMIN ou MEMBER",
     }),
-  createdBy: Joi.number().empty(null).required().messages({
+  createdBy: Joi.number().empty(null).strict().required().messages({
     'any.required': "L'id du créateur est manquant",
     'number.base': "L'id du créateur n'est pas un nombre",
   }),
-  administrationTeamId: Joi.number().empty(null).required().messages({
+  administrationTeamId: Joi.number().empty(null).strict().required().messages({
     'any.required': "L'id de l'équipe en charge est manquant",
     'number.base': "L'id de l'équipe en charge n'est pas un nombre",
   }),
-  countryCode: Joi.number().min(99000).max(99999).empty(null).integer().required().messages({
+  countryCode: Joi.number().min(99000).max(99999).empty(null).integer().strict().required().messages({
     'any.required': 'Le code pays n’est pas renseigné.',
+    'number.base': "Le code pays n'est pas un nombre",
     'number.min': 'Le code pays doit être un nombre entier compris entre 99000 et 99999.',
     'number.max': 'Le code pays doit être un nombre entier compris entre 99000 et 99999.',
   }),

--- a/api/src/organizational-entities/domain/validators/organization-with-tags-and-target-profiles.js
+++ b/api/src/organizational-entities/domain/validators/organization-with-tags-and-target-profiles.js
@@ -63,6 +63,10 @@ const schema = Joi.object({
     'number.min': 'Le code pays doit être un nombre entier compris entre 99000 et 99999.',
     'number.max': 'Le code pays doit être un nombre entier compris entre 99000 et 99999.',
   }),
+  organizationLearnerTypeId: Joi.number().strict().empty(null).required().messages({
+    'any.required': "L'id du public prescrit est manquant",
+    'number.base': "L'id du public prescrit n'est pas un nombre",
+  }),
 });
 
 const validate = function (organization) {

--- a/api/src/shared/infrastructure/serializers/csv/csv-serializer.js
+++ b/api/src/shared/infrastructure/serializers/csv/csv-serializer.js
@@ -164,18 +164,14 @@ async function deserializeForOrganizationsImport(file) {
           columnName === 'DPOEmail' ||
           columnName === 'parentOrganizationId' ||
           columnName === 'provinceCode' ||
-          columnName === 'emailForSCOActivation'
+          columnName === 'emailForSCOActivation' ||
+          columnName === 'administrationTeamId' ||
+          columnName === 'countryCode'
         ) {
           value = null;
         }
         if (columnName === 'locale') {
           value = 'fr-fr';
-        }
-        if (columnName === 'adminstrationTeamId') {
-          value = parseInt(value, 10);
-        }
-        if (columnName === 'countryCode') {
-          value = parseInt(value, 10);
         }
       }
       return value;

--- a/api/src/shared/infrastructure/serializers/csv/csv-serializer.js
+++ b/api/src/shared/infrastructure/serializers/csv/csv-serializer.js
@@ -121,6 +121,7 @@ const requiredFieldNamesForOrganizationsImport = [
   'administrationTeamId',
   'parentOrganizationId',
   'countryCode',
+  'organizationLearnerTypeId',
 ];
 
 async function deserializeForOrganizationsImport(file) {
@@ -147,7 +148,8 @@ async function deserializeForOrganizationsImport(file) {
           columnName === 'createdBy' ||
           columnName === 'parentOrganizationId' ||
           columnName === 'administrationTeamId' ||
-          columnName === 'countryCode'
+          columnName === 'countryCode' ||
+          columnName === 'organizationLearnerTypeId'
         ) {
           value = parseInt(value, 10);
         }
@@ -167,7 +169,8 @@ async function deserializeForOrganizationsImport(file) {
           columnName === 'provinceCode' ||
           columnName === 'emailForSCOActivation' ||
           columnName === 'administrationTeamId' ||
-          columnName === 'countryCode'
+          columnName === 'countryCode' ||
+          columnName === 'organizationLearnerTypeId'
         ) {
           value = null;
         }

--- a/api/src/shared/infrastructure/serializers/csv/csv-serializer.js
+++ b/api/src/shared/infrastructure/serializers/csv/csv-serializer.js
@@ -143,15 +143,16 @@ async function deserializeForOrganizationsImport(file) {
         ) {
           value = value.toUpperCase();
         }
-        if (columnName === 'createdBy') {
+        if (
+          columnName === 'createdBy' ||
+          columnName === 'parentOrganizationId' ||
+          columnName === 'administrationTeamId' ||
+          columnName === 'countryCode'
+        ) {
           value = parseInt(value, 10);
         }
         if (columnName === 'emailInvitations' || columnName === 'emailForSCOActivation' || columnName === 'DPOEmail') {
           value = value.replaceAll(' ', '').toLowerCase();
-        }
-
-        if (columnName === 'parentOrganizationId') {
-          value = parseInt(value, 10);
         }
       } else {
         if (columnName === 'credit') {

--- a/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
@@ -68,12 +68,14 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
       const targetProfileId = databaseBuilder.factory.buildTargetProfile({
         ownerOrganizationId: organizationId,
       }).id;
+      const organizationLearnerTypeId = databaseBuilder.factory.buildOrganizationLearnerType().id;
+
       await databaseBuilder.commit();
 
       const buffer =
-        'type,externalId,name,provinceCode,credit,createdBy,documentationUrl,identityProviderForCampaigns,isManagingStudents,emailForSCOActivation,DPOFirstName,DPOLastName,DPOEmail,emailInvitations,organizationInvitationRole,locale,tags,targetProfiles,administrationTeamId,parentOrganizationId,countryCode\n' +
-        `SCO,ANNEGRAELLE,Orga des Anne-Graelle,33700,666,${superAdminUserId},url.com,,true,,Anne,Graelle,anne-graelle@example.net,,ADMIN,fr,GRAS_GARGOUILLE,${targetProfileId},1234,,99100\n` +
-        `PRO,ANNEGARBURE,Orga des Anne-Garbure,33700,999,${superAdminUserId},,,,,Anne,Garbure,anne-garbure@example.net,,ADMIN,fr,GARBURE,${targetProfileId},1234,${parentOrganizationId},99100`;
+        'type,externalId,name,provinceCode,credit,createdBy,documentationUrl,identityProviderForCampaigns,isManagingStudents,emailForSCOActivation,DPOFirstName,DPOLastName,DPOEmail,emailInvitations,organizationInvitationRole,locale,tags,targetProfiles,administrationTeamId,parentOrganizationId,countryCode,organizationLearnerTypeId\n' +
+        `SCO,ANNEGRAELLE,Orga des Anne-Graelle,33700,666,${superAdminUserId},url.com,,true,,Anne,Graelle,anne-graelle@example.net,,ADMIN,fr,GRAS_GARGOUILLE,${targetProfileId},1234,,99100,${organizationLearnerTypeId}\n` +
+        `PRO,ANNEGARBURE,Orga des Anne-Garbure,33700,999,${superAdminUserId},,,,,Anne,Garbure,anne-garbure@example.net,,ADMIN,fr,GARBURE,${targetProfileId},1234,${parentOrganizationId},99100,${organizationLearnerTypeId}`;
 
       // when
       const response = await server.inject({
@@ -104,6 +106,7 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
         isManagingStudents: true,
         parentOrganizationId: null,
         countryCode: 99100,
+        organizationLearnerTypeId,
       });
 
       const secondOrganizationCreated = organizations.find((organization) => organization.externalId === 'ANNEGARBURE');
@@ -118,6 +121,7 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
         isManagingStudents: false,
         parentOrganizationId,
         countryCode: 99100,
+        organizationLearnerTypeId,
       });
 
       const dataProtectionOfficers = await knex('data-protection-officers');

--- a/api/tests/organizational-entities/integration/domain/usecases/create-organizations-with-tags-and-target-profiles.usecase.test.js
+++ b/api/tests/organizational-entities/integration/domain/usecases/create-organizations-with-tags-and-target-profiles.usecase.test.js
@@ -3,6 +3,7 @@ import lodash from 'lodash';
 import {
   AdministrationTeamNotFound,
   CountryNotFoundError,
+  OrganizationLearnerTypeNotFound,
   UnableToAttachChildOrganizationToParentOrganizationError,
 } from '../../../../../src/organizational-entities/domain/errors.js';
 import { usecases } from '../../../../../src/organizational-entities/domain/usecases/index.js';
@@ -33,7 +34,8 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
     userId,
     byDefaultFeatureId,
     administrationTeamId,
-    countryCode;
+    countryCode,
+    organizationLearnerTypeId;
 
   beforeEach(async function () {
     databaseBuilder.factory.buildFeature(ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY);
@@ -46,6 +48,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
       originalName: 'Lalaland',
       commonName: 'Lalaland',
     }).code;
+    organizationLearnerTypeId = databaseBuilder.factory.buildOrganizationLearnerType({ id: 1234 }).id;
     ondeImportFormat = databaseBuilder.factory.buildOrganizationLearnerImportFormat({
       name: ORGANIZATION_FEATURE.LEARNER_IMPORT.FORMAT.ONDE,
     });
@@ -90,6 +93,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
             organizationInvitationRole: '',
             administrationTeamId: null,
             countryCode: null,
+            organizationLearnerTypeId: null,
           },
         ];
 
@@ -138,6 +142,10 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
             message: "L'id de l'équipe en charge est manquant",
           },
           { attribute: 'countryCode', message: 'Le code pays n’est pas renseigné.' },
+          {
+            attribute: 'organizationLearnerTypeId',
+            message: "L'id du public prescrit est manquant",
+          },
         ]);
       });
     });
@@ -161,6 +169,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
             organizationInvitationRole: 'ADMIN',
             administrationTeamId,
             countryCode,
+            organizationLearnerTypeId,
           },
           {
             type: 'PRO',
@@ -177,6 +186,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
             organizationInvitationRole: 'ADMIN',
             administrationTeamId,
             countryCode,
+            organizationLearnerTypeId,
           },
           {
             type: 'PRO',
@@ -193,6 +203,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
             organizationInvitationRole: 'ADMIN',
             administrationTeamId,
             countryCode,
+            organizationLearnerTypeId,
           },
         ];
 
@@ -234,6 +245,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
             organizationInvitationRole: 'ADMIN',
             administrationTeamId,
             countryCode,
+            organizationLearnerTypeId,
           },
           {
             type: 'PRO',
@@ -250,6 +262,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
             organizationInvitationRole: 'MEMBER',
             administrationTeamId,
             countryCode,
+            organizationLearnerTypeId,
           },
           {
             type: 'PRO',
@@ -266,6 +279,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
             organizationInvitationRole: 'ADMIN',
             administrationTeamId,
             countryCode,
+            organizationLearnerTypeId,
           },
         ];
 
@@ -310,6 +324,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
           organizationInvitationRole: 'ADMIN',
           administrationTeamId,
           countryCode,
+          organizationLearnerTypeId,
         },
         {
           type: 'PRO',
@@ -326,6 +341,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
           organizationInvitationRole: 'ADMIN',
           administrationTeamId,
           countryCode,
+          organizationLearnerTypeId,
         },
         {
           type: 'PRO',
@@ -342,6 +358,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
           organizationInvitationRole: 'ADMIN',
           administrationTeamId,
           countryCode,
+          organizationLearnerTypeId,
         },
       ];
 
@@ -373,6 +390,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
             'targetProfiles',
             'administrationTeamId',
             'countryCode',
+            'organizationLearnerTypeId',
           ),
         );
 
@@ -407,6 +425,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
           organizationInvitationRole: 'ADMIN',
           administrationTeamId,
           countryCode,
+          organizationLearnerTypeId,
         },
         {
           type: 'PRO',
@@ -423,6 +442,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
           organizationInvitationRole: 'MEMBER',
           administrationTeamId,
           countryCode,
+          organizationLearnerTypeId,
         },
         {
           type: 'PRO',
@@ -439,6 +459,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
           organizationInvitationRole: 'ADMIN',
           administrationTeamId,
           countryCode,
+          organizationLearnerTypeId,
         },
       ];
 
@@ -476,6 +497,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
           organizationInvitationRole: 'ADMIN',
           administrationTeamId,
           countryCode,
+          organizationLearnerTypeId,
         },
         {
           type: 'PRO',
@@ -492,6 +514,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
           organizationInvitationRole: 'MEMBER',
           administrationTeamId: 9999,
           countryCode,
+          organizationLearnerTypeId,
         },
       ];
 
@@ -532,6 +555,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
           organizationInvitationRole: 'ADMIN',
           administrationTeamId,
           countryCode,
+          organizationLearnerTypeId,
         },
         {
           type: 'PRO',
@@ -548,6 +572,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
           organizationInvitationRole: 'MEMBER',
           administrationTeamId: anotherAdministrationTeamId,
           countryCode,
+          organizationLearnerTypeId,
         },
       ];
 
@@ -584,6 +609,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
           organizationInvitationRole: 'ADMIN',
           administrationTeamId,
           countryCode: invalidCountryCode,
+          organizationLearnerTypeId,
         },
       ];
 
@@ -621,6 +647,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
           organizationInvitationRole: 'ADMIN',
           administrationTeamId,
           countryCode,
+          organizationLearnerTypeId,
         },
       ];
 
@@ -633,6 +660,116 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
       const organizationsInDB = await knex('organizations').select();
       expect(organizationsInDB).to.have.lengthOf(1);
       expect(organizationsInDB[0].countryCode).to.equal(Number(countryCode));
+    });
+  });
+
+  describe('when one provided organization learner type id is not found in database', function () {
+    it('should rollback', async function () {
+      // given
+      const nonExistingOrganizationLearnerTypeId = 5678;
+
+      const organizationsWithOneNonExistingOrganizationLearnerType = [
+        {
+          type: 'SCO',
+          externalId: 'a100',
+          name: 'Collège Bob',
+          provinceCode: '044',
+          credit: 1,
+          emailInvitations: '',
+          locale: 'fr-fr',
+          tags: '',
+          targetProfiles: '',
+          createdBy: userId,
+          documentationUrl: 'http://www.pix.fr',
+          organizationInvitationRole: 'ADMIN',
+          administrationTeamId,
+          countryCode,
+          organizationLearnerTypeId,
+        },
+        {
+          type: 'PRO',
+          externalId: 'a200',
+          name: 'Thomas Transports',
+          provinceCode: '044',
+          credit: 1,
+          emailInvitations: '',
+          locale: 'fr-fr',
+          tags: '',
+          targetProfiles: '',
+          createdBy: userId,
+          documentationUrl: 'http://www.pix.fr',
+          organizationInvitationRole: 'MEMBER',
+          administrationTeamId,
+          countryCode,
+          organizationLearnerTypeId: nonExistingOrganizationLearnerTypeId,
+        },
+      ];
+
+      // when
+      const error = await catchErr(usecases.createOrganizationsWithTagsAndTargetProfiles)({
+        organizations: organizationsWithOneNonExistingOrganizationLearnerType,
+      });
+
+      // then
+      expect(error).to.be.instanceOf(OrganizationLearnerTypeNotFound);
+      expect(error.meta).to.deep.equal({
+        organizationLearnerTypeId: nonExistingOrganizationLearnerTypeId,
+      });
+      const organizationsInDB = await knex('organizations').select();
+      expect(organizationsInDB).to.have.lengthOf(0);
+    });
+  });
+
+  describe('when provided organizationLearnerTypeId is found in database', function () {
+    it('should save the organizations', async function () {
+      // given
+      const organizationsWithExistingOrganizationLearnerType = [
+        {
+          type: 'PRO',
+          externalId: 'a200',
+          name: 'Thomas Transports',
+          provinceCode: '044',
+          credit: 1,
+          emailInvitations: '',
+          locale: 'fr-fr',
+          tags: '',
+          targetProfiles: '',
+          createdBy: userId,
+          documentationUrl: 'http://www.pix.fr',
+          organizationInvitationRole: 'MEMBER',
+          administrationTeamId,
+          countryCode,
+          organizationLearnerTypeId,
+        },
+        {
+          type: 'PRO',
+          externalId: 'a300',
+          name: "Les boulangeries de l'ouest",
+          provinceCode: '056',
+          credit: 15,
+          emailInvitations: '',
+          locale: 'fr-fr',
+          tags: '',
+          targetProfiles: '',
+          createdBy: userId,
+          documentationUrl: 'http://www.pix.fr',
+          organizationInvitationRole: 'ADMIN',
+          administrationTeamId,
+          countryCode,
+          organizationLearnerTypeId,
+        },
+      ];
+
+      // when
+      await usecases.createOrganizationsWithTagsAndTargetProfiles({
+        organizations: organizationsWithExistingOrganizationLearnerType,
+      });
+
+      // then
+      const organizationsInDB = await knex('organizations').select();
+      expect(organizationsInDB).to.have.lengthOf(2);
+      expect(organizationsInDB[0].organizationLearnerTypeId).to.equal(organizationLearnerTypeId);
+      expect(organizationsInDB[1].organizationLearnerTypeId).to.equal(organizationLearnerTypeId);
     });
   });
 
@@ -661,6 +798,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
           organizationInvitationRole: 'ADMIN',
           administrationTeamId,
           countryCode,
+          organizationLearnerTypeId,
         },
         {
           type: 'PRO',
@@ -677,6 +815,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
           organizationInvitationRole: 'ADMIN',
           administrationTeamId,
           countryCode,
+          organizationLearnerTypeId,
         },
         {
           type: 'PRO',
@@ -693,6 +832,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
           organizationInvitationRole: 'ADMIN',
           administrationTeamId,
           countryCode,
+          organizationLearnerTypeId,
         },
       ];
 
@@ -724,6 +864,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
             'targetProfiles',
             'administrationTeamId',
             'countryCode',
+            'organizationLearnerTypeId',
           ),
         );
 
@@ -760,6 +901,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
           documentationUrl: 'http://www.pix.fr',
           administrationTeamId,
           countryCode,
+          organizationLearnerTypeId,
         },
         {
           type: 'PRO',
@@ -776,6 +918,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
           documentationUrl: 'http://www.pix.fr',
           administrationTeamId,
           countryCode,
+          organizationLearnerTypeId,
         },
       ];
 
@@ -817,6 +960,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
           documentationUrl: 'http://www.pix.fr',
           administrationTeamId,
           countryCode,
+          organizationLearnerTypeId,
         },
       ];
 
@@ -870,6 +1014,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
           documentationUrl: 'http://www.pix.fr',
           administrationTeamId,
           countryCode,
+          organizationLearnerTypeId,
         },
         {
           type: 'PRO',
@@ -885,6 +1030,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
           documentationUrl: 'http://www.pix.fr',
           administrationTeamId,
           countryCode,
+          organizationLearnerTypeId,
         },
       ];
 
@@ -928,6 +1074,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
           provinceCode: '123',
           administrationTeamId,
           countryCode,
+          organizationLearnerTypeId,
         },
         {
           type: 'SCO-1D',
@@ -941,6 +1088,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
           provinceCode: '123',
           administrationTeamId,
           countryCode,
+          organizationLearnerTypeId,
         },
       ];
 
@@ -977,6 +1125,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
             administrationTeamId,
             parentOrganizationId,
             countryCode,
+            organizationLearnerTypeId,
           },
         ];
 
@@ -1003,6 +1152,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
             administrationTeamId,
             parentOrganizationId: 12345,
             countryCode,
+            organizationLearnerTypeId,
           },
         ];
 
@@ -1035,6 +1185,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
             administrationTeamId,
             parentOrganizationId,
             countryCode,
+            organizationLearnerTypeId,
           },
         ];
 

--- a/api/tests/organizational-entities/integration/domain/usecases/create-organizations-with-tags-and-target-profiles.usecase.test.js
+++ b/api/tests/organizational-entities/integration/domain/usecases/create-organizations-with-tags-and-target-profiles.usecase.test.js
@@ -42,6 +42,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
     importStudentsFeature = databaseBuilder.factory.buildFeature(ORGANIZATION_FEATURE.LEARNER_IMPORT);
     administrationTeamId = databaseBuilder.factory.buildAdministrationTeam().id;
     countryCode = databaseBuilder.factory.buildCertificationCpfCountry({
+      code: 99997,
       originalName: 'Lalaland',
       commonName: 'Lalaland',
     }).code;

--- a/api/tests/organizational-entities/integration/domain/usecases/create-organizations-with-tags-and-target-profiles.usecase.test.js
+++ b/api/tests/organizational-entities/integration/domain/usecases/create-organizations-with-tags-and-target-profiles.usecase.test.js
@@ -83,12 +83,12 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
             credit: '',
             locale: '',
             tags: '',
-            createdBy: '',
+            createdBy: null,
             documentationUrl: '',
             targetProfiles: '',
             organizationInvitationRole: '',
-            administrationTeamId: '',
-            countryCode: undefined,
+            administrationTeamId: null,
+            countryCode: null,
           },
         ];
 

--- a/api/tests/organizational-entities/integration/domain/validators/organization-with-tags-and-target-profiles.test.js
+++ b/api/tests/organizational-entities/integration/domain/validators/organization-with-tags-and-target-profiles.test.js
@@ -129,6 +129,25 @@ describe('Unit | Domain | Validators | organization-with-tags-and-target-profile
         });
       });
 
+      it('returns an EntityValidation error when countryCode is not a number', function () {
+        // given
+        const organization = {
+          ...DEFAULT_ORGANIZATION,
+          countryCode: '99100',
+        };
+
+        // when
+        const error = catchErrSync(validate)(organization);
+
+        // then
+        expect(error).to.be.instanceOf(EntityValidationError);
+        expect(error.message).to.equal(`Échec de validation de l'entité.`);
+        expect(error.invalidAttributes).to.deep.include({
+          attribute: 'countryCode',
+          message: "Le code pays n'est pas un nombre",
+        });
+      });
+
       it('returns an EntityValidation error when country code is below minimum value', function () {
         // given
         const organization = {
@@ -187,6 +206,25 @@ describe('Unit | Domain | Validators | organization-with-tags-and-target-profile
           message: "L'id du créateur est manquant",
         });
       });
+
+      it('returns an EntityValidation error when createdBy is not a number', function () {
+        // given
+        const organization = {
+          ...DEFAULT_ORGANIZATION,
+          createdBy: '123456',
+        };
+
+        // when
+        const error = catchErrSync(validate)(organization);
+
+        // then
+        expect(error).to.be.instanceOf(EntityValidationError);
+        expect(error.message).to.equal(`Échec de validation de l'entité.`);
+        expect(error.invalidAttributes).to.deep.include({
+          attribute: 'createdBy',
+          message: "L'id du créateur n'est pas un nombre",
+        });
+      });
     });
 
     context('administrationTeamId validation', function () {
@@ -206,6 +244,25 @@ describe('Unit | Domain | Validators | organization-with-tags-and-target-profile
         expect(error.invalidAttributes).to.deep.include({
           attribute: 'administrationTeamId',
           message: "L'id de l'équipe en charge est manquant",
+        });
+      });
+
+      it('returns an EntityValidation error when administrationTeamId is not a number', function () {
+        // given
+        const organization = {
+          ...DEFAULT_ORGANIZATION,
+          administrationTeamId: '8001',
+        };
+
+        // when
+        const error = catchErrSync(validate)(organization);
+
+        // then
+        expect(error).to.be.instanceOf(EntityValidationError);
+        expect(error.message).to.equal(`Échec de validation de l'entité.`);
+        expect(error.invalidAttributes).to.deep.include({
+          attribute: 'administrationTeamId',
+          message: "L'id de l'équipe en charge n'est pas un nombre",
         });
       });
     });

--- a/api/tests/organizational-entities/integration/domain/validators/organization-with-tags-and-target-profiles.test.js
+++ b/api/tests/organizational-entities/integration/domain/validators/organization-with-tags-and-target-profiles.test.js
@@ -19,6 +19,7 @@ describe('Unit | Domain | Validators | organization-with-tags-and-target-profile
     type: 'SCO',
     administrationTeamId: 1,
     countryCode: 99123,
+    organizationLearnerTypeId: 456,
   };
 
   context('success', function () {
@@ -52,6 +53,7 @@ describe('Unit | Domain | Validators | organization-with-tags-and-target-profile
               createdBy: 0,
               administrationTeamId: 1,
               countryCode: 99123,
+              organizationLearnerTypeId: 456,
             };
 
             // when
@@ -84,6 +86,7 @@ describe('Unit | Domain | Validators | organization-with-tags-and-target-profile
           { attribute: 'createdBy', message: "L'id du créateur est manquant" },
           { attribute: 'administrationTeamId', message: "L'id de l'équipe en charge est manquant" },
           { attribute: 'countryCode', message: 'Le code pays n’est pas renseigné.' },
+          { attribute: 'organizationLearnerTypeId', message: "L'id du public prescrit est manquant" },
         ]);
       });
     });
@@ -263,6 +266,46 @@ describe('Unit | Domain | Validators | organization-with-tags-and-target-profile
         expect(error.invalidAttributes).to.deep.include({
           attribute: 'administrationTeamId',
           message: "L'id de l'équipe en charge n'est pas un nombre",
+        });
+      });
+    });
+
+    context('organizationLearnerTypeId validation', function () {
+      it('returns a required error when organizationLearnerTypeId is null', function () {
+        // given
+        const organization = {
+          ...DEFAULT_ORGANIZATION,
+          organizationLearnerTypeId: null,
+        };
+
+        // when
+        const error = catchErrSync(validate)(organization);
+
+        // then
+        expect(error).to.be.instanceOf(EntityValidationError);
+        expect(error.message).to.equal(`Échec de validation de l'entité.`);
+        expect(error.invalidAttributes).to.deep.include({
+          attribute: 'organizationLearnerTypeId',
+          message: "L'id du public prescrit est manquant",
+        });
+      });
+
+      it('returns an EntityValidation error when organizationLearnerTypeId is not a number', function () {
+        // given
+        const organization = {
+          ...DEFAULT_ORGANIZATION,
+          organizationLearnerTypeId: '100025',
+        };
+
+        // when
+        const error = catchErrSync(validate)(organization);
+
+        // then
+        expect(error).to.be.instanceOf(EntityValidationError);
+        expect(error.message).to.equal(`Échec de validation de l'entité.`);
+        expect(error.invalidAttributes).to.deep.include({
+          attribute: 'organizationLearnerTypeId',
+          message: "L'id du public prescrit n'est pas un nombre",
         });
       });
     });

--- a/api/tests/organizational-entities/integration/domain/validators/organization-with-tags-and-target-profiles.test.js
+++ b/api/tests/organizational-entities/integration/domain/validators/organization-with-tags-and-target-profiles.test.js
@@ -109,8 +109,27 @@ describe('Unit | Domain | Validators | organization-with-tags-and-target-profile
       });
     });
 
-    context('when country code is below minimum value', function () {
-      it('returns an EntityValidation error', function () {
+    context('countryCode validation', function () {
+      it('returns a required error when countryCode is null', function () {
+        // given
+        const organization = {
+          ...DEFAULT_ORGANIZATION,
+          countryCode: null,
+        };
+
+        // when
+        const error = catchErrSync(validate)(organization);
+
+        // then
+        expect(error).to.be.instanceOf(EntityValidationError);
+        expect(error.message).to.equal(`Échec de validation de l'entité.`);
+        expect(error.invalidAttributes).to.deep.include({
+          attribute: 'countryCode',
+          message: 'Le code pays n’est pas renseigné.',
+        });
+      });
+
+      it('returns an EntityValidation error when country code is below minimum value', function () {
         // given
         const organization = {
           ...DEFAULT_ORGANIZATION,
@@ -128,10 +147,8 @@ describe('Unit | Domain | Validators | organization-with-tags-and-target-profile
           message: 'Le code pays doit être un nombre entier compris entre 99000 et 99999.',
         });
       });
-    });
 
-    context('when country code is above maximum value', function () {
-      it('returns an EntityValidation error', function () {
+      it('returns an EntityValidation error when country code is above maximum value', function () {
         // given
         const organization = {
           ...DEFAULT_ORGANIZATION,
@@ -147,6 +164,48 @@ describe('Unit | Domain | Validators | organization-with-tags-and-target-profile
         expect(error.invalidAttributes).to.deep.include({
           attribute: 'countryCode',
           message: 'Le code pays doit être un nombre entier compris entre 99000 et 99999.',
+        });
+      });
+    });
+
+    context('createdBy validation', function () {
+      it('returns a required error when createdBy is null', function () {
+        // given
+        const organization = {
+          ...DEFAULT_ORGANIZATION,
+          createdBy: null,
+        };
+
+        // when
+        const error = catchErrSync(validate)(organization);
+
+        // then
+        expect(error).to.be.instanceOf(EntityValidationError);
+        expect(error.message).to.equal(`Échec de validation de l'entité.`);
+        expect(error.invalidAttributes).to.deep.include({
+          attribute: 'createdBy',
+          message: "L'id du créateur est manquant",
+        });
+      });
+    });
+
+    context('administrationTeamId validation', function () {
+      it('returns a required error when administrationTeamId is null', function () {
+        // given
+        const organization = {
+          ...DEFAULT_ORGANIZATION,
+          administrationTeamId: null,
+        };
+
+        // when
+        const error = catchErrSync(validate)(organization);
+
+        // then
+        expect(error).to.be.instanceOf(EntityValidationError);
+        expect(error.message).to.equal(`Échec de validation de l'entité.`);
+        expect(error.invalidAttributes).to.deep.include({
+          attribute: 'administrationTeamId',
+          message: "L'id de l'équipe en charge est manquant",
         });
       });
     });


### PR DESCRIPTION
## 🥀 Problème

Depuis l'ajout du champ Public prescrit (organization learner Type), on veut pouvoir le resneigner lors de la création d'organisations en masse.

## 🏹 Proposition

Rajouter la colonne _organizationLearnerTypeId_ dans le fichier CSV et implémenter l'ajout de ce champ sur les organisations.

## 💌 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## ❤️‍🔥 Pour tester
SUr Pix Admin, aller sur l'onglet Administratif -> Déploiement -> Création en masse
- télécharger le template
- constater la nouvelle colonne organizationLearnerTypeId
- remplir le fichier
- l'uploader et constater la création des orgas avec le public prescrit renseigné
- faire des erreurs (ne pas renseigner ce champ ou renseigner un id faux) et constater les messages d'erreurs
