### PR TITLE
[TECH] Ajout le domaine des routes dans les logs

### DIFF
--- a/api/src/banner/application/banner-route.js
+++ b/api/src/banner/application/banner-route.js
@@ -14,5 +14,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'src-banners-api';
+const name = 'banner/banner-api';
 export { name, register };

--- a/api/src/certification/configuration/application/attach-target-profile-route.js
+++ b/api/src/certification/configuration/application/attach-target-profile-route.js
@@ -76,5 +76,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'attach-target-profile-api';
+const name = 'certification/configuration/attach-target-profile-api';
 export { name, register };

--- a/api/src/certification/configuration/application/certification-framework-route.js
+++ b/api/src/certification/configuration/application/certification-framework-route.js
@@ -133,5 +133,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'certification-frameworks-api';
+const name = 'certification/configuration/certification-frameworks-api';
 export { name, register };

--- a/api/src/certification/configuration/application/certification-version-route.js
+++ b/api/src/certification/configuration/application/certification-version-route.js
@@ -110,5 +110,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'certification-versions-api';
+const name = 'certification/configuration/certification-versions-api';
 export { name, register };

--- a/api/src/certification/configuration/application/complementary-certification-route.js
+++ b/api/src/certification/configuration/application/complementary-certification-route.js
@@ -125,5 +125,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'complementary-certifications-api';
+const name = 'certification/configuration/complementary-certifications-api';
 export { name, register };

--- a/api/src/certification/configuration/application/sco-blocked-access-dates-route.js
+++ b/api/src/certification/configuration/application/sco-blocked-access-dates-route.js
@@ -66,5 +66,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'sco-blocked-access-dates-api';
+const name = 'certification/configuration/sco-blocked-access-dates-api';
 export { name, register };

--- a/api/src/certification/configuration/application/sco-whitelist-route.js
+++ b/api/src/certification/configuration/application/sco-whitelist-route.js
@@ -60,5 +60,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'sco-whitelist-api';
+const name = 'certification/configuration/sco-whitelist-api';
 export { name, register };

--- a/api/src/certification/enrolment/application/attendance-sheet-route.js
+++ b/api/src/certification/enrolment/application/attendance-sheet-route.js
@@ -32,5 +32,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'attendance-sheet-api';
+const name = 'certification/enrolment/attendance-sheet-api';
 export { name, register };

--- a/api/src/certification/enrolment/application/certification-candidate-route.js
+++ b/api/src/certification/enrolment/application/certification-candidate-route.js
@@ -258,5 +258,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'certification-candidate';
+const name = 'certification/enrolment/certification-candidate-api';
 export { name, register };

--- a/api/src/certification/enrolment/application/certification-center-route.js
+++ b/api/src/certification/enrolment/application/certification-center-route.js
@@ -42,5 +42,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'certification-centers-session-students-api';
+const name = 'certification/enrolment/certification-centers-session-students-api';
 export { name, register };

--- a/api/src/certification/enrolment/application/certification-centers-get-divisions-route.js
+++ b/api/src/certification/enrolment/application/certification-centers-get-divisions-route.js
@@ -32,5 +32,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'certification-centers-get-divisions-api';
+const name = 'certification/enrolment/certification-centers-get-divisions-api';
 export { name, register };

--- a/api/src/certification/enrolment/application/enrolment-route.js
+++ b/api/src/certification/enrolment/application/enrolment-route.js
@@ -83,5 +83,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'enrolment-api';
+const name = 'certification/enrolment/enrolment-api';
 export { name, register };

--- a/api/src/certification/enrolment/application/session-mass-import-route.js
+++ b/api/src/certification/enrolment/application/session-mass-import-route.js
@@ -95,5 +95,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'session-mass-import-api';
+const name = 'certification/enrolment/session-mass-import-api';
 export { name, register };

--- a/api/src/certification/enrolment/application/session-route.js
+++ b/api/src/certification/enrolment/application/session-route.js
@@ -134,5 +134,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'certification-enrollment-api';
+const name = 'certification/enrolment/certification-enrollment-api';
 export { name, register };

--- a/api/src/certification/enrolment/application/subscription-route.js
+++ b/api/src/certification/enrolment/application/subscription-route.js
@@ -25,5 +25,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'subscription-api';
+const name = 'certification/enrolment/subscription-api';
 export { name, register };

--- a/api/src/certification/enrolment/application/user-route.js
+++ b/api/src/certification/enrolment/application/user-route.js
@@ -33,5 +33,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'certification-enrolment-certification-eligibility-api';
+const name = 'certification/enrolment/certification-enrolment-certification-eligibility-api';
 export { name, register };

--- a/api/src/certification/evaluation/application/certification-admin-route.js
+++ b/api/src/certification/evaluation/application/certification-admin-route.js
@@ -67,5 +67,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'evaluation-certification-api';
+const name = 'certification/evaluation/evaluation-certification-api';
 export { name, register };

--- a/api/src/certification/evaluation/application/certification-course-route.js
+++ b/api/src/certification/evaluation/application/certification-course-route.js
@@ -57,5 +57,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'certification-courses-api';
+const name = 'certification/evaluation/certification-courses-api';
 export { name, register };

--- a/api/src/certification/evaluation/application/certification-rescoring-route.js
+++ b/api/src/certification/evaluation/application/certification-rescoring-route.js
@@ -34,5 +34,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'certification-rescoring-api';
+const name = 'certification/evaluation/certification-rescoring-api';
 export { name, register };

--- a/api/src/certification/evaluation/application/companion-alert-route.js
+++ b/api/src/certification/evaluation/application/companion-alert-route.js
@@ -29,5 +29,5 @@ const register = async function (server) {
   server.route(routes);
 };
 
-const name = 'evaluation-companion-alert-api';
+const name = 'certification/evaluation/evaluation-companion-alert-api';
 export { name, register };

--- a/api/src/certification/evaluation/application/scenario-simulator-route.js
+++ b/api/src/certification/evaluation/application/scenario-simulator-route.js
@@ -48,5 +48,5 @@ const register = async (server) => {
   ]);
 };
 
-const name = 'scenario-simulator-api';
+const name = 'certification/evaluation/scenario-simulator-api';
 export { name, register };

--- a/api/src/certification/results/application/certificate-route.js
+++ b/api/src/certification/results/application/certificate-route.js
@@ -157,5 +157,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'certificate-api';
+const name = 'certification/results/certificate-api';
 export { name, register };

--- a/api/src/certification/results/application/certification-reports-route.js
+++ b/api/src/certification/results/application/certification-reports-route.js
@@ -32,5 +32,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'certification-reports';
+const name = 'certification/results/certification-reports';
 export { name, register };

--- a/api/src/certification/results/application/certification-results-route.js
+++ b/api/src/certification/results/application/certification-results-route.js
@@ -128,5 +128,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'certification-results-api';
+const name = 'certification/results/certification-results-api';
 export { name, register };

--- a/api/src/certification/results/application/livret-scolaire-route.js
+++ b/api/src/certification/results/application/livret-scolaire-route.js
@@ -46,5 +46,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'livret-scolaire-api';
+const name = 'certification/results/livret-scolaire-api';
 export { name, register };

--- a/api/src/certification/results/application/organization-route.js
+++ b/api/src/certification/results/application/organization-route.js
@@ -36,5 +36,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'organization';
+const name = 'certification/results/organization-api';
 export { name, register };

--- a/api/src/certification/results/application/parcoursup-route.js
+++ b/api/src/certification/results/application/parcoursup-route.js
@@ -91,5 +91,5 @@ const register = async function (server) {
     },
   ]);
 };
-const name = 'parcoursup-api';
+const name = 'certification/results/parcoursup-api';
 export { name, register };

--- a/api/src/certification/results/application/user-route.js
+++ b/api/src/certification/results/application/user-route.js
@@ -38,5 +38,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'certification-results-user-api';
+const name = 'certification/results/certification-results-user-api';
 export { name, register };

--- a/api/src/certification/scoring/application/scoring-and-capacity-simulator-route.js
+++ b/api/src/certification/scoring/application/scoring-and-capacity-simulator-route.js
@@ -34,6 +34,6 @@ const register = async (server) => {
   ]);
 };
 
-const name = 'scoring-and-capacity-simulator';
+const name = 'certification/scoring/scoring-and-capacity-simulator-api';
 
 export { name, register };

--- a/api/src/certification/scoring/application/scoring-configuration-route.js
+++ b/api/src/certification/scoring/application/scoring-configuration-route.js
@@ -77,6 +77,6 @@ const register = async (server) => {
   ]);
 };
 
-const name = 'scoring-configuration';
+const name = 'certification/scoring/scoring-configuration-api';
 
 export { name, register };

--- a/api/src/certification/session-management/application/cancellation-route.js
+++ b/api/src/certification/session-management/application/cancellation-route.js
@@ -57,5 +57,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'cancellation-api';
+const name = 'certification/session-management/cancellation-api';
 export { name, register };

--- a/api/src/certification/session-management/application/certification-candidate-route.js
+++ b/api/src/certification/session-management/application/certification-candidate-route.js
@@ -80,5 +80,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'certification-candidate-api';
+const name = 'certification/session-management/certification-candidate-api';
 export { name, register };

--- a/api/src/certification/session-management/application/certification-centers-session-summaries-route.js
+++ b/api/src/certification/session-management/application/certification-centers-session-summaries-route.js
@@ -31,5 +31,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'session-summaries-api';
+const name = 'certification/session-management/session-summaries-api';
 export { name, register };

--- a/api/src/certification/session-management/application/certification-course-route.js
+++ b/api/src/certification/session-management/application/certification-course-route.js
@@ -146,5 +146,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'certification-course-api';
+const name = 'certification/session-management/certification-course-api';
 export { name, register };

--- a/api/src/certification/session-management/application/certification-details-route.js
+++ b/api/src/certification/session-management/application/certification-details-route.js
@@ -39,5 +39,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'certification-details-api';
+const name = 'certification/session-management/certification-details-api';
 export { name, register };

--- a/api/src/certification/session-management/application/certification-issue-report-route.js
+++ b/api/src/certification/session-management/application/certification-issue-report-route.js
@@ -65,5 +65,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'certification-issue-reports-api';
+const name = 'certification/session-management/certification-issue-reports-api';
 export { name, register };

--- a/api/src/certification/session-management/application/certification-officer-route.js
+++ b/api/src/certification/session-management/application/certification-officer-route.js
@@ -39,6 +39,6 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'session-certification-officer-api';
+const name = 'certification/session-management/session-certification-officer-api';
 
 export { name, register };

--- a/api/src/certification/session-management/application/certification-report-route.js
+++ b/api/src/certification/session-management/application/certification-report-route.js
@@ -60,5 +60,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'certification-reports-api';
+const name = 'certification/session-management/certification-reports-api';
 export { name, register };

--- a/api/src/certification/session-management/application/companion-alert-route.js
+++ b/api/src/certification/session-management/application/companion-alert-route.js
@@ -48,4 +48,4 @@ export function register(server) {
   ]);
 }
 
-export const name = 'session-management-companion-alert-api';
+export const name = 'certification/session-management/session-management-companion-alert-api';

--- a/api/src/certification/session-management/application/complementary-certification-course-results-route.js
+++ b/api/src/certification/session-management/application/complementary-certification-course-results-route.js
@@ -48,5 +48,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'complementary-certification-course-results-api';
+const name = 'certification/session-management/complementary-certification-course-results-api';
 export { name, register };

--- a/api/src/certification/session-management/application/finalize-route.js
+++ b/api/src/certification/session-management/application/finalize-route.js
@@ -44,5 +44,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'finalization-api';
+const name = 'certification/session-management/finalization-api';
 export { name, register };

--- a/api/src/certification/session-management/application/finalized-session-route.js
+++ b/api/src/certification/session-management/application/finalized-session-route.js
@@ -62,5 +62,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'finalized-session-api';
+const name = 'certification/session-management/finalized-session-api';
 export { name, register };

--- a/api/src/certification/session-management/application/invigilator-kit-route.js
+++ b/api/src/certification/session-management/application/invigilator-kit-route.js
@@ -37,5 +37,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'invigilator-kit-api';
+const name = 'certification/session-management/invigilator-kit-api';
 export { name, register };

--- a/api/src/certification/session-management/application/jury-certification-route.js
+++ b/api/src/certification/session-management/application/jury-certification-route.js
@@ -34,5 +34,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'jury-certification-api';
+const name = 'certification/session-management/jury-certification-api';
 export { name, register };

--- a/api/src/certification/session-management/application/jury-certification-summaries-route.js
+++ b/api/src/certification/session-management/application/jury-certification-summaries-route.js
@@ -40,5 +40,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'sessions-api';
+const name = 'certification/session-management/sessions-api';
 export { name, register };

--- a/api/src/certification/session-management/application/jury-comment-route.js
+++ b/api/src/certification/session-management/application/jury-comment-route.js
@@ -67,5 +67,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'jury-comment-api';
+const name = 'certification/session-management/jury-comment-api';
 export { name, register };

--- a/api/src/certification/session-management/application/session-for-supervising-route.js
+++ b/api/src/certification/session-management/application/session-for-supervising-route.js
@@ -34,5 +34,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'session-for-supervising-api';
+const name = 'certification/session-management/session-for-supervising-api';
 export { name, register };

--- a/api/src/certification/session-management/application/session-live-alert-route.js
+++ b/api/src/certification/session-management/application/session-live-alert-route.js
@@ -88,5 +88,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'session-live-alert-api';
+const name = 'certification/session-management/session-live-alert-api';
 export { name, register };

--- a/api/src/certification/session-management/application/session-publication-route.js
+++ b/api/src/certification/session-management/application/session-publication-route.js
@@ -97,5 +97,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'session-publication-api';
+const name = 'certification/session-management/session-publication-api';
 export { name, register };

--- a/api/src/certification/session-management/application/session-route.js
+++ b/api/src/certification/session-management/application/session-route.js
@@ -89,5 +89,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'session-get-api';
+const name = 'certification/session-management/session-get-api';
 export { name, register };

--- a/api/src/certification/session-management/application/supervise-route.js
+++ b/api/src/certification/session-management/application/supervise-route.js
@@ -39,5 +39,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'session-supervise-api';
+const name = 'certification/session-management/session-supervise-api';
 export { name, register };

--- a/api/src/certification/session-management/application/unfinalize-route.js
+++ b/api/src/certification/session-management/application/unfinalize-route.js
@@ -35,5 +35,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'unfinalize-api';
+const name = 'certification/session-management/unfinalize-api';
 export { name, register };

--- a/api/src/certification/session-management/application/update-cpf-import-status-route.js
+++ b/api/src/certification/session-management/application/update-cpf-import-status-route.js
@@ -39,5 +39,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'update-cpf-import-status-api';
+const name = 'certification/session-management/update-cpf-import-status-api';
 export { name, register };

--- a/api/src/devcomp/application/campaign-participations/campaign-participation-route.js
+++ b/api/src/devcomp/application/campaign-participations/campaign-participation-route.js
@@ -25,5 +25,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'old-campaign-participations-api';
+const name = 'devcomp/old-campaign-participations-api';
 export { name, register };

--- a/api/src/devcomp/application/module-issue-report/module-issue-report-route.js
+++ b/api/src/devcomp/application/module-issue-report/module-issue-report-route.js
@@ -34,5 +34,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'module-issue-report-api';
+const name = 'devcomp/module-issue-report-api';
 export { name, register };

--- a/api/src/devcomp/application/modules-metadata/module-metadata-route.js
+++ b/api/src/devcomp/application/modules-metadata/module-metadata-route.js
@@ -24,5 +24,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'modules-metadata-api';
+const name = 'devcomp/modules-metadata-api';
 export { name, register };

--- a/api/src/devcomp/application/modules/module-route.js
+++ b/api/src/devcomp/application/modules/module-route.js
@@ -50,5 +50,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'modules-api';
+const name = 'devcomp/modules-api';
 export { name, register };

--- a/api/src/devcomp/application/passage-events/passage-event-route.js
+++ b/api/src/devcomp/application/passage-events/passage-event-route.js
@@ -38,5 +38,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'passage-events-api';
+const name = 'devcomp/passage-events-api';
 export { name, register };

--- a/api/src/devcomp/application/passages/passage-route.js
+++ b/api/src/devcomp/application/passages/passage-route.js
@@ -137,5 +137,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'passages-api';
+const name = 'devcomp/passages-api';
 export { name, register };

--- a/api/src/devcomp/application/trainings/training-route.js
+++ b/api/src/devcomp/application/trainings/training-route.js
@@ -396,5 +396,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'trainings-api';
+const name = 'devcomp/trainings-api';
 export { name, register };

--- a/api/src/devcomp/application/tutorial-evaluations/tutorial-evaluations-route.js
+++ b/api/src/devcomp/application/tutorial-evaluations/tutorial-evaluations-route.js
@@ -37,5 +37,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'tutorial-evaluations-api';
+const name = 'devcomp/tutorial-evaluations-api';
 export { name, register };

--- a/api/src/devcomp/application/user-trainings/user-trainings-route.js
+++ b/api/src/devcomp/application/user-trainings/user-trainings-route.js
@@ -32,5 +32,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'users-api';
+const name = 'devcomp/users-api';
 export { name, register };

--- a/api/src/devcomp/application/user-tutorials/user-tutorials-route.js
+++ b/api/src/devcomp/application/user-tutorials/user-tutorials-route.js
@@ -87,5 +87,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'tutorials-api';
+const name = 'devcomp/tutorials-api';
 export { name, register };

--- a/api/src/evaluation/application/answers/index.js
+++ b/api/src/evaluation/application/answers/index.js
@@ -109,5 +109,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'answers-api';
+const name = 'evaluation/answers-api';
 export { name, register };

--- a/api/src/evaluation/application/assessments/assessment-routes.js
+++ b/api/src/evaluation/application/assessments/assessment-routes.js
@@ -87,5 +87,5 @@ const register = async function (server) {
   server.route(routes);
 };
 
-const name = 'evaluation-assessments-api';
+const name = 'evaluation/evaluation-assessments-api';
 export { name, register };

--- a/api/src/evaluation/application/autonomous-courses/index.js
+++ b/api/src/evaluation/application/autonomous-courses/index.js
@@ -166,5 +166,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'autonomous-courses-api';
+const name = 'evaluation/autonomous-courses-api';
 export { name, register };

--- a/api/src/evaluation/application/badge-criteria/index.js
+++ b/api/src/evaluation/application/badge-criteria/index.js
@@ -65,5 +65,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'badge-criteria-api';
+const name = 'evaluation/badge-criteria-api';
 export { name, register };

--- a/api/src/evaluation/application/badges/index.js
+++ b/api/src/evaluation/application/badges/index.js
@@ -135,5 +135,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'badges-api';
+const name = 'evaluation/badges-api';
 export { name, register };

--- a/api/src/evaluation/application/competence-evaluations/index.js
+++ b/api/src/evaluation/application/competence-evaluations/index.js
@@ -42,5 +42,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'competence-evaluations-api';
+const name = 'evaluation/competence-evaluations-api';
 export { name, register };

--- a/api/src/evaluation/application/courses/course-route.js
+++ b/api/src/evaluation/application/courses/course-route.js
@@ -22,5 +22,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'courses-api';
+const name = 'evaluation/courses-api';
 export { name, register };

--- a/api/src/evaluation/application/feedbacks/index.js
+++ b/api/src/evaluation/application/feedbacks/index.js
@@ -49,5 +49,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'feedbacks-api';
+const name = 'evaluation/feedbacks-api';
 export { name, register };

--- a/api/src/evaluation/application/progressions/index.js
+++ b/api/src/evaluation/application/progressions/index.js
@@ -17,5 +17,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'progressions-api';
+const name = 'evaluation/progressions-api';
 export { name, register };

--- a/api/src/evaluation/application/scorecards/index.js
+++ b/api/src/evaluation/application/scorecards/index.js
@@ -61,5 +61,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'scorecards-api';
+const name = 'evaluation/scorecards-api';
 export { name, register };

--- a/api/src/evaluation/application/smart-random-simulator/index.js
+++ b/api/src/evaluation/application/smart-random-simulator/index.js
@@ -127,5 +127,5 @@ const register = async function (server) {
   server.route([getNextChallengeRoute, getCampaignParametersRoute]);
 };
 
-const name = 'smart-random-simulator-api';
+const name = 'evaluation/smart-random-simulator-api';
 export { name, register };

--- a/api/src/evaluation/application/stage-collections/index.js
+++ b/api/src/evaluation/application/stage-collections/index.js
@@ -57,5 +57,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'stage-collections-api';
+const name = 'evaluation/stage-collections-api';
 export { name, register };

--- a/api/src/evaluation/application/stages/index.js
+++ b/api/src/evaluation/application/stages/index.js
@@ -52,5 +52,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'stage-api';
+const name = 'evaluation/stage-api';
 export { name, register };

--- a/api/src/evaluation/application/users/index.js
+++ b/api/src/evaluation/application/users/index.js
@@ -59,5 +59,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'evaluation-users-api';
+const name = 'evaluation/evaluation-users-api';
 export { name, register };

--- a/api/src/identity-access-management/application/routes.js
+++ b/api/src/identity-access-management/application/routes.js
@@ -36,6 +36,6 @@ function register(server, { routes = allRoutes, tags }) {
   server.route(filteredRoutes);
 }
 
-const name = 'identity-access-management-api';
+const name = 'identity-access-management/identity-access-management-api';
 
 export const identityAccessManagementRoutes = [{ register, name }];

--- a/api/src/learning-content/application/frameworks-route.js
+++ b/api/src/learning-content/application/frameworks-route.js
@@ -74,5 +74,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'frameworks-api';
+const name = 'learning-content/frameworks-api';
 export { name, register };

--- a/api/src/learning-content/application/learning-content-route.js
+++ b/api/src/learning-content/application/learning-content-route.js
@@ -83,4 +83,4 @@ export async function register(server) {
   ]);
 }
 
-export const name = 'lcms-api';
+export const name = 'learning-content/lcms-api';

--- a/api/src/llm/application/llm-preview-route.js
+++ b/api/src/llm/application/llm-preview-route.js
@@ -89,4 +89,4 @@ export async function register(server) {
   ]);
 }
 
-export const name = 'llm-preview-api';
+export const name = 'llm/llm-preview-api';

--- a/api/src/maddo/application/campaigns-routes.js
+++ b/api/src/maddo/application/campaigns-routes.js
@@ -120,5 +120,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'maddo-campaigns-api';
+const name = 'maddo/maddo-campaigns-api';
 export { name, register };

--- a/api/src/maddo/application/organizations-routes.js
+++ b/api/src/maddo/application/organizations-routes.js
@@ -120,5 +120,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'maddo-meta-api';
+const name = 'maddo/maddo-meta-api';
 export { name, register };

--- a/api/src/maddo/application/replications-routes.js
+++ b/api/src/maddo/application/replications-routes.js
@@ -29,5 +29,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'maddo-replications-api';
+const name = 'maddo/maddo-replications-api';
 export { name, register };

--- a/api/src/organizational-entities/application/administration-team/administration-team.admin.route.js
+++ b/api/src/organizational-entities/application/administration-team/administration-team.admin.route.js
@@ -30,6 +30,6 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'administration-teams-admin-api';
+const name = 'organizational-entities/administration-team-admin-api';
 
 export { name, register };

--- a/api/src/organizational-entities/application/certification-center/certification-center.admin.route.js
+++ b/api/src/organizational-entities/application/certification-center/certification-center.admin.route.js
@@ -212,5 +212,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'certification-centers-admin';
+const name = 'organizational-entities/certification-center-admin';
 export { name, register };

--- a/api/src/organizational-entities/application/organization-learner-type/organization-learner-type.admin.route.js
+++ b/api/src/organizational-entities/application/organization-learner-type/organization-learner-type.admin.route.js
@@ -29,6 +29,6 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'organization-learner-types-admin-api';
+const name = 'organizational-entities/organization-learner-type-admin-api';
 
 export { name, register };

--- a/api/src/organizational-entities/application/organization/organization.admin.route.js
+++ b/api/src/organizational-entities/application/organization/organization.admin.route.js
@@ -526,6 +526,6 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'organizational-entities-api';
+const name = 'organizational-entities/organization-admin-api';
 
 export { name, register };

--- a/api/src/organizational-entities/application/tag/tag.admin.route.js
+++ b/api/src/organizational-entities/application/tag/tag.admin.route.js
@@ -92,6 +92,6 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'tags-admin-api';
+const name = 'organizational-entities/tag-admin-api';
 
 export { name, register };

--- a/api/src/prescription/campaign-participation/application/admin-campaign-participation-route.js
+++ b/api/src/prescription/campaign-participation/application/admin-campaign-participation-route.js
@@ -34,5 +34,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'admin-campaign-participation-api';
+const name = 'prescription/campaign-participation/admin-campaign-participation-api';
 export { name, register };

--- a/api/src/prescription/campaign-participation/application/campaign-participation-route.js
+++ b/api/src/prescription/campaign-participation/application/campaign-participation-route.js
@@ -356,5 +356,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'campaign-participation-api';
+const name = 'prescription/campaign-participation/campaign-participation-api';
 export { name, register };

--- a/api/src/prescription/campaign-participation/application/learner-participation-route.js
+++ b/api/src/prescription/campaign-participation/application/learner-participation-route.js
@@ -78,5 +78,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'learner-participation-api';
+const name = 'prescription/campaign-participation/learner-participation-api';
 export { name, register };

--- a/api/src/prescription/campaign-participation/application/pole-emploi-route.js
+++ b/api/src/prescription/campaign-participation/application/pole-emploi-route.js
@@ -60,5 +60,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'pole-emploi-api';
+const name = 'prescription/campaign-participation/pole-emploi-api';
 export { name, register };

--- a/api/src/prescription/campaign/application/campaign-administration-route.js
+++ b/api/src/prescription/campaign/application/campaign-administration-route.js
@@ -360,5 +360,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'campaigns-administration-api';
+const name = 'prescription/campaign/campaign-administration-api';
 export { name, register };

--- a/api/src/prescription/campaign/application/campaign-detail-route.js
+++ b/api/src/prescription/campaign/application/campaign-detail-route.js
@@ -203,5 +203,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'campaigns-detail-api';
+const name = 'prescription/campaign/campaigns-detail-api';
 export { name, register };

--- a/api/src/prescription/campaign/application/campaign-results-route.js
+++ b/api/src/prescription/campaign/application/campaign-results-route.js
@@ -103,5 +103,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'campaigns-participation-api';
+const name = 'prescription/campaign/campaign-results-api';
 export { name, register };

--- a/api/src/prescription/campaign/application/campaign-route.js
+++ b/api/src/prescription/campaign/application/campaign-route.js
@@ -75,5 +75,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'campaign-api';
+const name = 'prescription/campaign/campaign-api';
 export { name, register };

--- a/api/src/prescription/campaign/application/campaign-stats-route.js
+++ b/api/src/prescription/campaign/application/campaign-stats-route.js
@@ -83,5 +83,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'campaigns-statistics-api';
+const name = 'prescription/campaign/campaign-stats-api';
 export { name, register };

--- a/api/src/prescription/learner-management/application/organization-import-route.js
+++ b/api/src/prescription/learner-management/application/organization-import-route.js
@@ -81,6 +81,6 @@ const register = async (server) => {
   ]);
 };
 
-const name = 'organization-import-api';
+const name = 'prescription/learner-management/organization-import-api';
 
 export { name, register };

--- a/api/src/prescription/learner-management/application/organization-learners-route.js
+++ b/api/src/prescription/learner-management/application/organization-learners-route.js
@@ -234,6 +234,6 @@ const register = async (server) => {
   ]);
 };
 
-const name = 'organization-learners-management-api';
+const name = 'prescription/learner-management/organization-learners-api';
 
 export { name, register };

--- a/api/src/prescription/learner-management/application/sco-organization-management-route.js
+++ b/api/src/prescription/learner-management/application/sco-organization-management-route.js
@@ -85,6 +85,6 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'sco-organization-management';
+const name = 'prescription/learner-management/sco-organization-management-api';
 
 export { name, register };

--- a/api/src/prescription/learner-management/application/sup-organization-management-route.js
+++ b/api/src/prescription/learner-management/application/sup-organization-management-route.js
@@ -184,5 +184,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'sup-organization-management';
+const name = 'prescription/learner-management/sup-organization-management-api';
 export { name, register };

--- a/api/src/prescription/organization-learner-feature/application/organization-learner-features-route.js
+++ b/api/src/prescription/organization-learner-feature/application/organization-learner-features-route.js
@@ -80,5 +80,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'organization-learner-feature-route';
+const name = 'prescription/organization-learner-feature/organization-learner-features-api';
 export { name, register };

--- a/api/src/prescription/organization-learner/application/learner-activity-route.js
+++ b/api/src/prescription/organization-learner/application/learner-activity-route.js
@@ -56,6 +56,6 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'learner-activity-api';
+const name = 'prescription/organization-learner/learner-activity-api';
 
 export { name, register };

--- a/api/src/prescription/organization-learner/application/learner-list-route.js
+++ b/api/src/prescription/organization-learner/application/learner-list-route.js
@@ -71,6 +71,6 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'learner-list-api';
+const name = 'prescription/organization-learner/learner-list-api';
 
 export { name, register };

--- a/api/src/prescription/organization-learner/application/organization-learners-route.js
+++ b/api/src/prescription/organization-learner/application/organization-learners-route.js
@@ -115,5 +115,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'organization-learners-route';
+const name = 'prescription/organization-learner/organization-learners-api';
 export { name, register };

--- a/api/src/prescription/organization-learner/application/organization-to-join-route.js
+++ b/api/src/prescription/organization-learner/application/organization-to-join-route.js
@@ -27,5 +27,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'organization-to-join';
+const name = 'prescription/organization-learner/organization-to-join-api';
 export { name, register };

--- a/api/src/prescription/organization-learner/application/registration-organization-learner-route.js
+++ b/api/src/prescription/organization-learner/application/registration-organization-learner-route.js
@@ -27,6 +27,6 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'registration-organization-learner-api';
+const name = 'prescription/organization-learner/registration-organization-learner-api';
 
 export { name, register };

--- a/api/src/prescription/organization-learner/application/sco-organization-learner-route.js
+++ b/api/src/prescription/organization-learner/application/sco-organization-learner-route.js
@@ -219,5 +219,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'sco-organization-learner-route';
+const name = 'prescription/organization-learner/sco-organization-learner-api';
 export { name, register };

--- a/api/src/prescription/organization-learner/application/sup-learner-list-route.js
+++ b/api/src/prescription/organization-learner/application/sup-learner-list-route.js
@@ -68,6 +68,6 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'sup-learner-list-api';
+const name = 'prescription/organization-learner/sup-learner-list-api';
 
 export { name, register };

--- a/api/src/prescription/organization-place/application/organization-place-route.js
+++ b/api/src/prescription/organization-place/application/organization-place-route.js
@@ -180,6 +180,6 @@ const register = async (server) => {
   ]);
 };
 
-const name = 'organization-place-api';
+const name = 'prescription/organization-place/organization-place-api';
 
 export { name, register };

--- a/api/src/prescription/target-profile/application/admin-target-profile-route.js
+++ b/api/src/prescription/target-profile/application/admin-target-profile-route.js
@@ -488,5 +488,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'admin-target-profiles-api';
+const name = 'prescription/target-profile/admin-target-profiles-api';
 export { name, register };

--- a/api/src/prescription/target-profile/application/target-profile-route.js
+++ b/api/src/prescription/target-profile/application/target-profile-route.js
@@ -50,5 +50,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'orga-target-profiles-api';
+const name = 'prescription/target-profile/target-profile-api';
 export { name, register };

--- a/api/src/profile/application/attestation-route.js
+++ b/api/src/profile/application/attestation-route.js
@@ -60,5 +60,5 @@ const register = async function (server) {
   server.route([...userRoutes]);
 };
 
-const name = 'attestation-api';
+const name = 'profile/attestation-api';
 export { name, register };

--- a/api/src/profile/application/profile-route.js
+++ b/api/src/profile/application/profile-route.js
@@ -65,5 +65,5 @@ const register = async function (server) {
   server.route([...adminRoutes, ...userRoutes]);
 };
 
-const name = 'profile-api';
+const name = 'profile/profile-api';
 export { name, register };

--- a/api/src/quest/application/combined-course-blueprint-route.js
+++ b/api/src/quest/application/combined-course-blueprint-route.js
@@ -168,5 +168,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'combined-course-blueprints-api';
+const name = 'quest/combined-course-blueprints-api';
 export { name, register };

--- a/api/src/quest/application/combined-course-route.js
+++ b/api/src/quest/application/combined-course-route.js
@@ -259,5 +259,5 @@ const register = async function (server) {
     },
   ]);
 };
-const name = 'combined-courses-api';
+const name = 'quest/combined-courses-api';
 export { name, register };

--- a/api/src/quest/application/quest-route.js
+++ b/api/src/quest/application/quest-route.js
@@ -112,5 +112,5 @@ const register = async function (server) {
     },
   ]);
 };
-const name = 'quest-api';
+const name = 'quest/quest-api';
 export { name, register };

--- a/api/src/quest/application/verified-code-route.js
+++ b/api/src/quest/application/verified-code-route.js
@@ -23,5 +23,5 @@ const register = async function (server) {
     },
   ]);
 };
-const name = 'verified-codes-api';
+const name = 'quest/verified-codes-api';
 export { name, register };

--- a/api/src/school/application/activity-answer-route.js
+++ b/api/src/school/application/activity-answer-route.js
@@ -47,5 +47,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'activity-answers-api';
+const name = 'school/activity-answers-api';
 export { name, register };

--- a/api/src/school/application/assessment-route.js
+++ b/api/src/school/application/assessment-route.js
@@ -75,5 +75,5 @@ const register = async function (server) {
     },
   ]);
 };
-const name = 'assessment-pix1d-api';
+const name = 'school/assessment-pix1d-api';
 export { name, register };

--- a/api/src/school/application/challenge-route.js
+++ b/api/src/school/application/challenge-route.js
@@ -22,5 +22,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'school-challenges-api';
+const name = 'school/school-challenges-api';
 export { name, register };

--- a/api/src/school/application/mission-learner-route.js
+++ b/api/src/school/application/mission-learner-route.js
@@ -40,5 +40,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'mission-learners-api';
+const name = 'school/mission-learners-api';
 export { name, register };

--- a/api/src/school/application/mission-route.js
+++ b/api/src/school/application/mission-route.js
@@ -71,5 +71,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'mission-api';
+const name = 'school/mission-api';
 export { name, register };

--- a/api/src/school/application/organization-learner-route.js
+++ b/api/src/school/application/organization-learner-route.js
@@ -26,5 +26,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'school-organization-learners-api';
+const name = 'school/school-organization-learners-api';
 export { name, register };

--- a/api/src/school/application/school-route.js
+++ b/api/src/school/application/school-route.js
@@ -58,5 +58,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'school-api';
+const name = 'school/school-api';
 export { name, register };

--- a/api/src/shared/application/assessments/index.js
+++ b/api/src/shared/application/assessments/index.js
@@ -162,5 +162,5 @@ const register = async function (server) {
   server.route(routes);
 };
 
-const name = 'assessments-api';
+const name = 'shared/assessments-api';
 export { name, register };

--- a/api/src/shared/application/challenges/index.js
+++ b/api/src/shared/application/challenges/index.js
@@ -22,5 +22,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'challenges-api';
+const name = 'shared/challenges-api';
 export { name, register };

--- a/api/src/shared/application/country/country-route.js
+++ b/api/src/shared/application/country/country-route.js
@@ -17,5 +17,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'certification-cpf-countries';
+const name = 'shared/certification-cpf-countries-api';
 export { name, register };

--- a/api/src/shared/application/feature-toggles/index.js
+++ b/api/src/shared/application/feature-toggles/index.js
@@ -15,5 +15,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'feature-toggles-api';
+const name = 'shared/feature-toggles-api';
 export { name, register };

--- a/api/src/shared/application/healthcheck/index.js
+++ b/api/src/shared/application/healthcheck/index.js
@@ -42,5 +42,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'healthcheck-api';
+const name = 'shared/healthcheck-api';
 export { name, register };

--- a/api/src/shared/infrastructure/plugins/pino.js
+++ b/api/src/shared/infrastructure/plugins/pino.js
@@ -39,6 +39,7 @@ function requestSerializer(req) {
     user_id: monitoringTools.extractUserIdFromRequest(req),
     metrics: context?.metrics,
     route: context?.request?.route?.path,
+    routeDomain: context?.request?.route?.realm?.plugin,
   };
 }
 
@@ -69,13 +70,7 @@ const plugin = {
         return;
       }
       if (event.error) {
-        logger.error(
-          {
-            tags: event.tags,
-            err: event.error,
-          },
-          'request error',
-        );
+        logger.error({ tags: event.tags, err: event.error }, 'request error');
       }
     });
 

--- a/api/src/team/application/routes.js
+++ b/api/src/team/application/routes.js
@@ -28,6 +28,6 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'team-api';
+const name = 'team/team-api';
 
 export const teamRoutes = [{ register, name }];


### PR DESCRIPTION
## 🥀 Problème

Dans notre monitoring, il n'est pas possible de différencier les routes par domaine métier, afin de faciliter le suivi (perf, erreurs...) par les équipes.

## 🏹 Proposition

Ajouter l'attribut `routeDomain` dans les logs qui est déterminé grâce au nom défini pour les routes au moment de l'enregistrement dans HAPI.

```js
// ‎api/src/certification/configuration/application/attach-target-profile-route.js
// ...
const name = 'certification/configuration/attach-target-profile-api';
export { name, register };

// api/src/shared/infrastructure/plugins/pino.js
// ...
// permet de récupérer le nom de la route
routeDomain: context?.request?.route?.realm?.plugin,
// ...
```

Dans le monitoring, on pourra filtrer les requêtes des web conteneurs par domaine. Par exemple :
- `routeDomain:certification*`
- `routeDomain:certification/configuration*`

## 💌 Remarques

À voir avec les captains pour traiter cet attribut dans notre outil de monitoring.

## ❤️‍🔥 Pour tester

Tous les test doivent passer.
