### PR TITLE
[FEATURE] Ajouter la possibilité d'exporter en NL le PDF d'un PC dans Admin (PIX-21627)

### DIFF
--- a/admin/app/components/target-profiles/pdf-parameters-modal.gjs
+++ b/admin/app/components/target-profiles/pdf-parameters-modal.gjs
@@ -15,6 +15,7 @@ export default class PdfParametersModal extends Component {
     this.options = [
       { value: 'fr', label: 'Français' },
       { value: 'en', label: 'Anglais' },
+      { value: 'nl', label: 'Néerlandais' },
     ];
     this.language = 'fr';
   }
@@ -49,7 +50,7 @@ export default class PdfParametersModal extends Component {
           @hideDefaultOption={{true}}
           class="pdf-modal--select"
         >
-          <:label>Langue du référentiel (français ou anglais) :</:label>
+          <:label>Langue du référentiel (français, anglais ou néerlandais) :</:label>
         </PixSelect>
       </:content>
       <:footer>

--- a/api/src/prescription/target-profile/application/admin-target-profile-route.js
+++ b/api/src/prescription/target-profile/application/admin-target-profile-route.js
@@ -226,7 +226,7 @@ const register = async function (server) {
             id: identifiersType.targetProfileId,
           }),
           query: Joi.object({
-            language: Joi.string().valid('fr', 'en').required(),
+            language: Joi.string().valid('fr', 'en', 'nl').required(),
           }),
         },
         handler: targetProfileController.getLearningContentAsPdf,

--- a/api/src/prescription/target-profile/application/presenter/pdf/drawer/CoverPageLegalMentionText.js
+++ b/api/src/prescription/target-profile/application/presenter/pdf/drawer/CoverPageLegalMentionText.js
@@ -6,8 +6,8 @@ import { Text } from './Text.js';
 const textByLang = {
   en: 'This is a working document, updated regularly. Its distribution is restricted and its use limited to Pix Orga members in the context of the implementation of the support of their users.',
   fr: "Ceci est un document de travail. Il évolue régulièrement. Sa diffusion est restreinte et son usage limité aux utilisateurs de Pix Orga dans le cadre de la mise en oeuvre de l'accompagnement de leurs publics.",
+  nl: 'Dit is een werkdocument. Het wordt regelmatig bijgewerkt. De verspreiding ervan is beperkt en het gebruik ervan is voorbehouden aan gebruikers van Pix Orga in het kader van de begeleiding van hun publiek.',
 };
-
 class CoverPageLegaLMentionText extends Text {
   constructor({ language }) {
     const text = textByLang[language];

--- a/api/src/prescription/target-profile/application/presenter/pdf/drawer/CoverPageVersionText.js
+++ b/api/src/prescription/target-profile/application/presenter/pdf/drawer/CoverPageVersionText.js
@@ -9,6 +9,7 @@ import { Text } from './Text.js';
 const textByLang = {
   en: 'Version {date}',
   fr: 'Version du {date}',
+  nl: 'Versie van {date}',
 };
 
 class CoverPageVersionText extends Text {

--- a/api/src/prescription/target-profile/application/presenter/pdf/drawer/LegalMentionText.js
+++ b/api/src/prescription/target-profile/application/presenter/pdf/drawer/LegalMentionText.js
@@ -8,6 +8,7 @@ import { Text } from './Text.js';
 const textByLang = {
   en: 'This is a working document, updated regularly. Its distribution is restricted and its use limited to Pix Orga members in the context of the implementation of the support of their users. - Version {date}',
   fr: "Ceci est un document de travail. Il évolue régulièrement. Sa diffusion est restreinte et son usage limité aux utilisateurs de Pix Orga dans le cadre de la mise en oeuvre de l'accompagnement de leurs publics. - Version du {date}",
+  nl: 'Dit is een werkdocument. Het wordt regelmatig bijgewerkt. De verspreiding ervan is beperkt en het gebruik ervan is voorbehouden aan gebruikers van Pix Orga in het kader van de begeleiding van hun publiek. - Versie van {date}',
 };
 
 class LegalMentionText extends Text {

--- a/api/src/prescription/target-profile/application/presenter/pdf/learning-content-pdf-presenter.js
+++ b/api/src/prescription/target-profile/application/presenter/pdf/learning-content-pdf-presenter.js
@@ -1,4 +1,6 @@
 import 'dayjs/locale/fr.js';
+import 'dayjs/locale/en.js';
+import 'dayjs/locale/nl.js';
 
 import { PDFDocument } from 'pdf-lib';
 

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -74,7 +74,7 @@ function getSeedsConfig() {
     context,
     learningContent: {
       frameworks,
-      locales: process.env.SEEDS_LEARNING_CONTENT_LOCALES?.split(',') ?? ['fr-fr', 'en'],
+      locales: process.env.SEEDS_LEARNING_CONTENT_LOCALES?.split(',') ?? ['fr-fr', 'en', 'nl', 'nl-BE'],
     },
   };
 }

--- a/api/tests/prescription/target-profile/unit/application/admin-target-profiles-route_test.js
+++ b/api/tests/prescription/target-profile/unit/application/admin-target-profiles-route_test.js
@@ -571,7 +571,7 @@ describe('Unit | Application | Admin Target Profiles | Routes', function () {
         expect(error).to.deep.equal({
           status: '400',
           title: 'Bad Request',
-          detail: '"language" must be one of [fr, en]',
+          detail: '"language" must be one of [fr, en, nl]',
         });
         expect(targetProfileController.getLearningContentAsPdf).to.not.have.been.called;
       });


### PR DESCRIPTION
## 🥀 Problème

Les équipes déploiement ne peuvent pas exporter les PDF de PC en Néerlandais. 

## 🏹 Proposition

Ajouter la possibilité de télécharger les PDF en Néerlandais. 

## 💌 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## ❤️‍🔥 Pour tester
- aller sur admin 
- aller sur un PC  
- télécharger le PDF 
- vérifier que le PDF est en Néerlandais 
PS : le titre du PC n'est pas traduit en anglais et néerlandais donc c'est normal que ça ne soit pas traduit 👍 