### PR TITLE
[TECH] Mettre à jour le script api qui remonte les infos modules pour pix-db-replication (PIX-21624)

### DIFF
--- a/api/scripts/modulix/list-modules-for-db-replication.js
+++ b/api/scripts/modulix/list-modules-for-db-replication.js
@@ -8,7 +8,18 @@ async function listModulesForDBReplication() {
   const imports = await moduleDatasource.list();
   console.log('--- List of modules for DB replication ---');
   const moduleInformation = imports.map((module) => {
-    return { id: module.id, shortId: module.shortId, slug: module.slug, title: module.title };
+    const moduleObjectivesInline = module.details.objectives.join(', ');
+    return {
+      id: module.id,
+      shortId: module.shortId,
+      slug: module.slug,
+      title: module.title,
+      level: module.details.level,
+      duration: module.details.duration,
+      objectives: moduleObjectivesInline,
+      isBeta: module.isBeta,
+      visibility: module.visibility,
+    };
   });
   console.log(JSON.stringify(moduleInformation, null, 2).replace(/"([^"]+)": "([^"]+)"/g, "$1: '$2'"));
 }

--- a/api/scripts/modulix/list-modules-for-db-replication.js
+++ b/api/scripts/modulix/list-modules-for-db-replication.js
@@ -26,8 +26,11 @@ async function listModulesForMetabaseFilter() {
 }
 
 async function main() {
+  if (process.argv[2] === 'metabase-filter') {
+    await listModulesForMetabaseFilter();
+    return;
+  }
   await listModulesForDBReplication();
-  await listModulesForMetabaseFilter();
 }
 
 await main();

--- a/api/scripts/modulix/list-modules-for-db-replication.js
+++ b/api/scripts/modulix/list-modules-for-db-replication.js
@@ -5,7 +5,7 @@ import moduleDatasource from '../../src/devcomp/infrastructure/datasources/learn
  * @returns {Promise<void>}
  */
 async function listModulesForDBReplication() {
-  const imports = await moduleDatasource.list();
+  const imports = await moduleDatasource.listModulesWithFilename();
   console.log('--- List of modules for DB replication ---');
   const moduleInformation = imports.map((module) => {
     const moduleObjectivesInline = module.details.objectives.join(', ');
@@ -14,6 +14,7 @@ async function listModulesForDBReplication() {
       shortId: module.shortId,
       slug: module.slug,
       title: module.title,
+      filename: module.filename,
       level: module.details.level,
       duration: module.details.duration,
       objectives: moduleObjectivesInline,

--- a/api/src/devcomp/infrastructure/datasources/learning-content/module-datasource.js
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/module-datasource.js
@@ -62,14 +62,25 @@ const moduleDatasource = {
   list: async () => {
     return referential.modules;
   },
+  listModulesWithFilename: async () => {
+    const modulesWithFilename = { modules: [] };
+
+    const { files, path } = await readModuleFiles();
+
+    for (const file of files) {
+      const fileURL = pathToFileURL(join(path, file.name));
+      const module = await import(fileURL, { with: { type: 'json' } });
+      modulesWithFilename.modules.push({ ...module.default, filename: file.name });
+    }
+
+    return modulesWithFilename.modules;
+  },
 };
 
 async function importModules() {
   const imports = { modules: [] };
 
-  const __dirname = dirname(fileURLToPath(import.meta.url));
-  const path = join(__dirname, './modules');
-  const files = await readdir(path, { withFileTypes: true });
+  const { files, path } = await readModuleFiles();
 
   for (const file of files) {
     const fileURL = pathToFileURL(join(path, file.name));
@@ -78,6 +89,13 @@ async function importModules() {
   }
 
   return imports;
+}
+
+async function readModuleFiles() {
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+  const path = join(__dirname, './modules');
+  const files = await readdir(path, { withFileTypes: true });
+  return { files, path };
 }
 
 export default moduleDatasource;

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/module-datasource_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/module-datasource_test.js
@@ -165,4 +165,14 @@ describe('Unit | Infrastructure | Datasources | Learning Content | ModuleDatasou
       });
     });
   });
+
+  describe('#listModulesWithFilename', function () {
+    it('should return a list of modules with their filename', async function () {
+      // when
+      const modules = await moduleDatasource.listModulesWithFilename();
+
+      expect(modules[0].filename).to.exist;
+      expect(modules[0].filename).to.be.a('string');
+    });
+  });
 });


### PR DESCRIPTION
## 🏹 Proposition

Suite aux points régulier avec Alice L. sur la data Modulix, il est suggéré d'ajouter des infos dans ce qui est disponible dans la table `modules`.
Ces infos sont listées grâce à un script de l'API, appelé `list-modules-for-db-replication`.
Il faut donc ajouter les infos demandées dans ce script : durée, niveau, isBeta, visibilité, nom du fichier json et objectifs du module.

## 💌 Remarques

- Ajout d'une méthode pour récupérer, depuis le repo, les modules avec leur filename
- Un autre ticket existe pour la MAJ de pix-db-replication.
- Ajout d'une option pour lancer uniquement le listing des modules, sans le listing adapté au filtre `Modules`de Metabase. Pour l'utiliser, lancer `node list-modules-for-db-replication.js metabase-filter`; seule la liste des modules pour les filtres Metabase s'affichera.

## ❤️‍🔥 Pour tester
- Récupérer le branche localement
- Lancer le script avec la commande `node list-modules-for-db-replication.js`
- Dans la console, constater qu'on a la liste des modules avec les nouvelles infos ajoutées