### PR TITLE
[TECH] Améliorer les performances de la page des parcours apprenants sur PixOrga (PIX-21487)

### DIFF
--- a/api/db/seeds/data/team-prescription/fixtures/pro-complete-combined-course.js
+++ b/api/db/seeds/data/team-prescription/fixtures/pro-complete-combined-course.js
@@ -288,13 +288,14 @@ export const MAXI_COMBINED_COURSE = {
       },
     ],
   },
-  participations: [
-    {
-      firstName: faker.person.firstName(),
-      lastName: faker.person.lastName(),
-      email: 'maxi-combined@example.net',
-      status: OrganizationLearnerParticipationStatuses.STARTED,
-      campaignStatus: CampaignParticipationStatuses.SHARED,
-    },
-  ],
+  participations: Array.from({ length: 100 }).map((_, index) => ({
+    firstName: faker.person.firstName(),
+    lastName: faker.person.lastName(),
+    email: `${index}maxi-combined@example.net`,
+    status:
+      Math.random() > 0.5
+        ? OrganizationLearnerParticipationStatuses.STARTED
+        : OrganizationLearnerParticipationStatuses.COMPLETED,
+    campaignStatus: CampaignParticipationStatuses.SHARED,
+  })),
 };

--- a/api/src/prescription/organization-learner/application/api/organization-learners-with-participations-api.js
+++ b/api/src/prescription/organization-learner/application/api/organization-learners-with-participations-api.js
@@ -81,8 +81,8 @@ export async function find({ userIds }) {
 }
 
 export async function findByOrganizationAndOrganizationLearnerId({ organizationLearnerId, organizationId }) {
-  const organizationLearnerWithParticipation = await getOrganizationLearnerWithParticipations({
-    organizationLearnerId,
+  const organizationLearnerWithParticipations = await getOrganizationLearnerWithParticipations({
+    organizationLearnerIds: [organizationLearnerId],
     organizationId,
     organizationLearnerRepository,
     organizationRepository,
@@ -92,5 +92,26 @@ export async function findByOrganizationAndOrganizationLearnerId({ organizationL
     stageAcquisitionRepository,
     stageAcquisitionComparisonService,
   });
-  return new OrganizationLearnerWithParticipations(organizationLearnerWithParticipation);
+  return new OrganizationLearnerWithParticipations(organizationLearnerWithParticipations.get(organizationLearnerId));
+}
+
+export async function findByOrganizationAndOrganizationLearnerIds({ organizationLearnerIds, organizationId }) {
+  const organizationLearnerWithParticipations = await getOrganizationLearnerWithParticipations({
+    organizationLearnerIds,
+    organizationId,
+    organizationLearnerRepository,
+    organizationRepository,
+    tagRepository,
+    campaignParticipationOverviewRepository,
+    stageRepository,
+    stageAcquisitionRepository,
+    stageAcquisitionComparisonService,
+  });
+  for (const [key, organizationLearnerWithParticipation] of organizationLearnerWithParticipations) {
+    organizationLearnerWithParticipations.set(
+      key,
+      new OrganizationLearnerWithParticipations(organizationLearnerWithParticipation),
+    );
+  }
+  return organizationLearnerWithParticipations;
 }

--- a/api/src/quest/domain/services/combined-course-details-service.js
+++ b/api/src/quest/domain/services/combined-course-details-service.js
@@ -46,7 +46,7 @@ async function getCombinedCourseDetails({
   eligibilityRepository,
   recommendedModuleRepository,
 }) {
-  const participation = await combinedCourseParticipationRepository.findMostRecentByLearnerId({
+  const participation = await combinedCourseParticipationRepository.findByLearnerId({
     organizationLearnerId,
     combinedCourseId: combinedCourseDetails.id,
   });

--- a/api/src/quest/domain/services/combined-course-details-service.js
+++ b/api/src/quest/domain/services/combined-course-details-service.js
@@ -82,4 +82,87 @@ async function getCombinedCourseDetails({
   return combinedCourseDetails;
 }
 
-export default { instantiateCombinedCourseDetails, getCombinedCourseDetails };
+async function getCombinedCourseDetailsForMultipleLearners({
+  combinedCourseDetails,
+  organizationLearnerIds,
+  combinedCourseParticipationRepository,
+  eligibilityRepository,
+  recommendedModuleRepository,
+}) {
+  const participations = await combinedCourseParticipationRepository.findByLearnerIds({
+    organizationLearnerIds,
+    combinedCourseId: combinedCourseDetails.id,
+  });
+
+  const learnerIdsWithParticipation = organizationLearnerIds.filter((organizationLearnerId) =>
+    participations.some((participation) => participation.organizationLearnerId === organizationLearnerId),
+  );
+
+  let eligibilitiesByLearnerId = new Map();
+
+  if (learnerIdsWithParticipation.length > 0) {
+    eligibilitiesByLearnerId = await eligibilityRepository.findByOrganizationAndOrganizationLearnerIds({
+      organizationLearnerIds: learnerIdsWithParticipation,
+      organizationId: combinedCourseDetails.organizationId,
+      moduleIds: combinedCourseDetails.moduleIds,
+    });
+  }
+
+  const dataForQuestByLearnerId = new Map();
+  const recommendedModulesByLearnerId = new Map();
+
+  for (const learnerId of learnerIdsWithParticipation) {
+    const eligibility = eligibilitiesByLearnerId.get(learnerId);
+    if (!eligibility) continue;
+
+    const dataForQuest = new DataForQuest({ eligibility });
+    dataForQuestByLearnerId.set(learnerId, dataForQuest);
+
+    const campaignParticipationIds =
+      combinedCourseDetails.quest.findCampaignParticipationIdsContributingToQuest(dataForQuest);
+
+    if (campaignParticipationIds.length > 0) {
+      const recommendedModules = await recommendedModuleRepository.findIdsByCampaignParticipationIds({
+        campaignParticipationIds,
+      });
+      recommendedModulesByLearnerId.set(learnerId, recommendedModules);
+    }
+  }
+
+  const resultsByLearnerId = new Map();
+
+  for (const organizationLearnerId of organizationLearnerIds) {
+    const participation = participations.find(
+      (participation) => participation.organizationLearnerId === organizationLearnerId,
+    );
+    const dataForQuest = dataForQuestByLearnerId.get(organizationLearnerId);
+    const recommendedModuleIdsForUser = recommendedModulesByLearnerId.get(organizationLearnerId) ?? [];
+
+    combinedCourseDetails.generateItems({
+      participation,
+      recommendedModuleIdsForUser,
+      dataForQuest,
+    });
+
+    const state = {
+      id: combinedCourseDetails.id,
+      status: combinedCourseDetails.status,
+      participation: combinedCourseDetails.participation,
+      items: combinedCourseDetails.items,
+    };
+
+    if (participation) {
+      state.participationDetails = combinedCourseDetails.participationDetails;
+    }
+
+    resultsByLearnerId.set(organizationLearnerId, state);
+  }
+
+  return resultsByLearnerId;
+}
+
+export default {
+  instantiateCombinedCourseDetails,
+  getCombinedCourseDetails,
+  getCombinedCourseDetailsForMultipleLearners,
+};

--- a/api/src/quest/domain/usecases/find-combined-course-participations.js
+++ b/api/src/quest/domain/usecases/find-combined-course-participations.js
@@ -1,5 +1,3 @@
-import { PromiseUtils } from '../../../shared/infrastructure/utils/promise-utils.js';
-
 export const findCombinedCourseParticipations = async ({
   combinedCourseId,
   page,
@@ -17,19 +15,17 @@ export const findCombinedCourseParticipations = async ({
   const combinedCourseDetails = await combinedCourseDetailsService.instantiateCombinedCourseDetails({
     combinedCourseId,
   });
-  const combinedCourseParticipations = await PromiseUtils.mapSeries(
+
+  const resultsByLearnerId = await combinedCourseDetailsService.getCombinedCourseDetailsForMultipleLearners({
     organizationLearnerIds,
-    async (organizationLearnerId) => {
-      const combinedCourseDetail = await combinedCourseDetailsService.getCombinedCourseDetails({
-        organizationLearnerId,
-        combinedCourseDetails,
-      });
-      return combinedCourseDetail.participationDetails;
-    },
-  );
+    combinedCourseDetails,
+  });
 
   return {
-    combinedCourseParticipations,
+    combinedCourseParticipations: resultsByLearnerId
+      .values()
+      .toArray()
+      .map(({ participationDetails }) => participationDetails),
     meta,
   };
 };

--- a/api/src/quest/infrastructure/repositories/combined-course-participation-repository.js
+++ b/api/src/quest/infrastructure/repositories/combined-course-participation-repository.js
@@ -108,8 +108,8 @@ export const getByUserId = async function ({ userId, combinedCourseId }) {
   return new CombinedCourseParticipation(combinedCourseParticipations[0]);
 };
 
-export const findMostRecentByLearnerId = async function ({ organizationLearnerId, combinedCourseId }) {
   const knexConnection = DomainTransaction.getConnection();
+export const findByLearnerId = async function ({ organizationLearnerId, combinedCourseId }) {
 
   const combinedCourseParticipation = await knexConnection('organization_learner_participations')
     .select(

--- a/api/src/quest/infrastructure/repositories/combined-course-participation-repository.js
+++ b/api/src/quest/infrastructure/repositories/combined-course-participation-repository.js
@@ -108,10 +108,18 @@ export const getByUserId = async function ({ userId, combinedCourseId }) {
   return new CombinedCourseParticipation(combinedCourseParticipations[0]);
 };
 
-  const knexConnection = DomainTransaction.getConnection();
 export const findByLearnerId = async function ({ organizationLearnerId, combinedCourseId }) {
+  const participation = await findByLearnerIds({
+    organizationLearnerIds: [organizationLearnerId],
+    combinedCourseId,
+  });
+  if (participation.length > 0) return participation[0];
+  return null;
+};
 
-  const combinedCourseParticipation = await knexConnection('organization_learner_participations')
+export const findByLearnerIds = async function ({ organizationLearnerIds, combinedCourseId }) {
+  const knexConnection = DomainTransaction.getConnection();
+  const results = await knexConnection('organization_learner_participations')
     .select(
       'organization_learner_participations.id',
       'organizationLearnerId',
@@ -130,18 +138,15 @@ export const findByLearnerId = async function ({ organizationLearnerId, combined
       '=',
       'organization_learner_participations.organizationLearnerId',
     )
+    .whereIn('view-active-organization-learners.id', organizationLearnerIds)
     .where({
-      'view-active-organization-learners.id': organizationLearnerId,
       'organization_learner_participations.referenceId': combinedCourseId.toString(),
       'organization_learner_participations.type': OrganizationLearnerParticipationTypes.COMBINED_COURSE,
     })
     .whereNull('organization_learner_participations.deletedAt')
-    .orderBy('organization_learner_participations.createdAt', 'DESC')
-    .first();
+    .orderBy([{ column: 'organization_learner_participations.createdAt', order: 'desc' }]);
 
-  if (!combinedCourseParticipation) return null;
-
-  return new CombinedCourseParticipation(combinedCourseParticipation);
+  return results.map((row) => new CombinedCourseParticipation(row));
 };
 
 export const findPaginatedCombinedCourseParticipationById = async function ({ combinedCourseId, page, filters }) {

--- a/api/src/quest/infrastructure/repositories/eligibility-repository.js
+++ b/api/src/quest/infrastructure/repositories/eligibility-repository.js
@@ -24,4 +24,33 @@ export const findByOrganizationAndOrganizationLearnerId = async ({
   return toDomain({ ...result, passages });
 };
 
+export const findByOrganizationAndOrganizationLearnerIds = async ({
+  organizationLearnerIds,
+  organizationId,
+  organizationLearnerWithParticipationApi,
+  organizationLearnerParticipationRepository = questOrganizationLearnerParticipationRepository,
+  moduleIds = [],
+}) => {
+  const passagesByLearnerId = await organizationLearnerParticipationRepository.findByOrganizationLearnerIdsAndModuleIds(
+    {
+      organizationLearnerIds,
+      moduleIds,
+    },
+  );
+  const resultsByLearnerId = await organizationLearnerWithParticipationApi.findByOrganizationAndOrganizationLearnerIds({
+    organizationLearnerIds,
+    organizationId,
+  });
+
+  const eligibilitiesByLearnerId = new Map();
+  for (const organizationLearnerId of organizationLearnerIds) {
+    const result = resultsByLearnerId.get(organizationLearnerId);
+    const passages = passagesByLearnerId.get(organizationLearnerId) ?? [];
+    if (result) {
+      eligibilitiesByLearnerId.set(organizationLearnerId, toDomain({ ...result, passages }));
+    }
+  }
+  return eligibilitiesByLearnerId;
+};
+
 const toDomain = (organizationLearnersWithParticipations) => new Eligibility(organizationLearnersWithParticipations);

--- a/api/tests/quest/integration/domain/usecases/find-combined-course-participations_test.js
+++ b/api/tests/quest/integration/domain/usecases/find-combined-course-participations_test.js
@@ -183,4 +183,19 @@ describe('Quest | Integration | Domain | Usecases | findCombinedCourseParticipat
     expect(combinedCourseParticipations).lengthOf(1);
     expect(combinedCourseParticipations[0].id).equal(participation2.id);
   });
+
+  it('should include all paginated learners in the result even when they have no campaign or module participations', async function () {
+    // when
+    const { combinedCourseParticipations } = await usecases.findCombinedCourseParticipations({
+      combinedCourseId,
+      filters: { fullName: 'Paul' },
+    });
+
+    // then
+    expect(combinedCourseParticipations).lengthOf(1);
+    expect(combinedCourseParticipations[0]).instanceOf(CombinedCourseParticipationDetails);
+    expect(combinedCourseParticipations[0].id).to.equal(participation1.id);
+    expect(combinedCourseParticipations[0].nbCampaignsCompleted).to.equal(0);
+    expect(combinedCourseParticipations[0].nbModulesCompleted).to.equal(0);
+  });
 });

--- a/api/tests/quest/integration/infrastructure/repositories/combined-course-participation-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/combined-course-participation-repository_test.js
@@ -327,6 +327,102 @@ describe('Quest | Integration | Infrastructure | repositories | Combined-Course-
     });
   });
 
+  describe('#findByLearnerIds', function () {
+    it('should return most recent combinedCourse participation for given learnerIds and combinedCourse ids', async function () {
+      // given
+      const firstLearner = databaseBuilder.factory.buildOrganizationLearner();
+      const secondLearner = databaseBuilder.factory.buildOrganizationLearner();
+
+      const { id: combinedCourseId } = databaseBuilder.factory.buildCombinedCourse({
+        organizationId: firstLearner.organizationId,
+        code: 'COMBINIX1',
+      });
+      const expectedCombinedCourseParticipation = databaseBuilder.factory.buildOrganizationLearnerParticipation({
+        organizationLearnerId: firstLearner.id,
+        status: OrganizationLearnerParticipationStatuses.COMPLETED,
+        type: OrganizationLearnerParticipationTypes.COMBINED_COURSE,
+        createdAt: new Date('2025-01-01'),
+        combinedCourseId,
+      });
+      databaseBuilder.factory.buildOrganizationLearnerParticipation({
+        organizationLearnerId: firstLearner.id,
+        status: OrganizationLearnerParticipationStatuses.COMPLETED,
+        type: OrganizationLearnerParticipationTypes.COMBINED_COURSE,
+        createdAt: new Date('2024-01-01'),
+        combinedCourseId,
+      });
+
+      const secondCombinedCourseParticipation = databaseBuilder.factory.buildOrganizationLearnerParticipation({
+        organizationLearnerId: secondLearner.id,
+        status: OrganizationLearnerParticipationStatuses.COMPLETED,
+        type: OrganizationLearnerParticipationTypes.COMBINED_COURSE,
+        createdAt: new Date('2025-01-01'),
+        combinedCourseId,
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const result = await combinedCourseParticipationRepository.findByLearnerIds({
+        organizationLearnerIds: [firstLearner.id, secondLearner.id],
+        combinedCourseId,
+      });
+
+      // then
+      const combinedCourseParticipationForFirstLearner = result.find(
+        (participation) => participation.organizationLearnerId === firstLearner.id,
+      );
+
+      expect(combinedCourseParticipationForFirstLearner).instanceOf(CombinedCourseParticipation);
+
+      expect(combinedCourseParticipationForFirstLearner).to.deep.equal({
+        id: expectedCombinedCourseParticipation.id,
+        combinedCourseId,
+        organizationLearnerId: firstLearner.id,
+        division: firstLearner.division,
+        group: firstLearner.group,
+        firstName: firstLearner.firstName,
+        lastName: firstLearner.lastName,
+        status: OrganizationLearnerParticipationStatuses.COMPLETED,
+        createdAt: expectedCombinedCourseParticipation.createdAt,
+        updatedAt: expectedCombinedCourseParticipation.updatedAt,
+      });
+
+      const combinedCourseParticipationForSecondLearner = result.find(
+        (participation) => participation.organizationLearnerId === secondLearner.id,
+      );
+
+      expect(combinedCourseParticipationForSecondLearner).instanceOf(CombinedCourseParticipation);
+      expect(combinedCourseParticipationForSecondLearner).to.deep.equal({
+        id: secondCombinedCourseParticipation.id,
+        combinedCourseId,
+        organizationLearnerId: secondLearner.id,
+        division: secondLearner.division,
+        group: secondLearner.group,
+        firstName: secondLearner.firstName,
+        lastName: secondLearner.lastName,
+        status: OrganizationLearnerParticipationStatuses.COMPLETED,
+        createdAt: secondCombinedCourseParticipation.createdAt,
+        updatedAt: secondCombinedCourseParticipation.updatedAt,
+      });
+    });
+
+    it('should return an empty array when there are no participation', async function () {
+      // given
+      const organizationLearnerId = 1;
+      const combinedCourseId = 2;
+
+      // when
+      const result = await combinedCourseParticipationRepository.findByLearnerIds({
+        organizationLearnerIds: [organizationLearnerId],
+        combinedCourseId,
+      });
+
+      // then
+      expect(result).empty;
+    });
+  });
+
   describe('#findPaginatedCombinedCourseParticipationById', function () {
     let combinedCourseId;
     let organizationLearner1, organizationLearner2, organizationLearner3;

--- a/api/tests/quest/integration/infrastructure/repositories/combined-course-participation-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/combined-course-participation-repository_test.js
@@ -270,8 +270,8 @@ describe('Quest | Integration | Infrastructure | repositories | Combined-Course-
     });
   });
 
-  describe('#findMostRecentByLearnerId', function () {
-    it('should return most recent combinedCourse participation for given learnerId and combinedCourse ids', async function () {
+  describe('#findByLearnerId', function () {
+    it('should return combinedCourse participation for given learnerId and combinedCourse ids', async function () {
       // given
       const {
         firstName,
@@ -288,7 +288,6 @@ describe('Quest | Integration | Infrastructure | repositories | Combined-Course-
         combinedCourseId,
       });
       databaseBuilder.factory.buildOrganizationLearnerParticipation({
-        organizationLearnerId,
         status: OrganizationLearnerParticipationStatuses.COMPLETED,
         type: OrganizationLearnerParticipationTypes.COMBINED_COURSE,
         createdAt: new Date('2024-01-01'),
@@ -297,7 +296,7 @@ describe('Quest | Integration | Infrastructure | repositories | Combined-Course-
       await databaseBuilder.commit();
 
       // when
-      const result = await combinedCourseParticipationRepository.findMostRecentByLearnerId({
+      const result = await combinedCourseParticipationRepository.findByLearnerId({
         organizationLearnerId,
         combinedCourseId,
       });
@@ -318,7 +317,7 @@ describe('Quest | Integration | Infrastructure | repositories | Combined-Course-
       const combinedCourseId = 2;
 
       // when
-      const result = await combinedCourseParticipationRepository.findMostRecentByLearnerId({
+      const result = await combinedCourseParticipationRepository.findByLearnerId({
         organizationLearnerId,
         combinedCourseId,
       });


### PR DESCRIPTION
## 🍄‍🟫 Problème

La page des participations d'un parcours combiné effectuait des requêtes SQL en N+1 : pour chaque apprenant paginé, une série de requêtes individuelles était lancée pour récupérer son éligibilité, ses participations aux campagnes et ses passages de modules.

Avec 100 apprenants par page, cela générait des centaines de requêtes par chargement de page, rendant la page inutilisable en conditions réelles.

## 🐦‍⬛ Proposition

Refactoring de la couche repository et service pour traiter tous les apprenants en batch :

- Les repositories acceptent désormais une liste d'IDs apprenants avec de nouvelles méthodes.
getCombinedCourseDetailsForMultipleLearners` retourne une `Map<learnerId, {status, participation, items}>` permettant d'enrichir chaque apprenant indépendamment
- Ajout de tests d'intégration vérifiant le comportement multi-apprenants

## 🫑 Remarques

On ajoute 100 participants dans les seeds du MAXICOMBI par défaut pour tester plus facilement cette page.
On a toujours un problème de query N+1 pour les modules recommandes, ce sera l'objet d'une prochaine PR.

## ⚾ Pour tester

### Pix Orga
- Aller sur la page de détail du parcours MAXICOMBI
- Voir la liste des participants qui s'affiche
- Tester ses fonctionnalités pour voir que tout marche bien (augmenter la limite d'affichage, filtrer, accéder à un participant ...)
- Vérifier les participations aux campagnes
