### PR TITLE
[FEATURE] Empêcher l'accès aux parcours combinés supprimés (PIX-21506)

### DIFF
--- a/api/db/database-builder/factory/build-combined-course.js
+++ b/api/db/database-builder/factory/build-combined-course.js
@@ -16,6 +16,8 @@ const buildCombinedCourse = function ({
   createdAt = new Date(),
   updatedAt,
   combinedCourseBlueprintId,
+  deletedAt = null,
+  deletedBy = null,
 } = {}) {
   organizationId = isUndefined(organizationId) ? buildOrganization().id : organizationId;
 
@@ -38,6 +40,8 @@ const buildCombinedCourse = function ({
     updatedAt: updatedAt ?? createdAt,
     questId,
     combinedCourseBlueprintId,
+    deletedAt,
+    deletedBy,
   };
 
   return databaseBuffer.pushInsertable({

--- a/api/db/seeds/data/team-prescription/build-combined-courses.js
+++ b/api/db/seeds/data/team-prescription/build-combined-courses.js
@@ -42,6 +42,8 @@ const buildCombinixQuest = (databaseBuilder, combinedCourseData) => {
   const { id: combinedCourseId } = buildCombinedCourse({
     ...combinedCourseData.quest,
     organizationId: combinedCourseData.organizationId,
+    deletedAt: combinedCourseData.deletedAt,
+    deletedBy: combinedCourseData.deletedBy,
   });
 
   // Build target profile if needed

--- a/api/src/quest/application/usecases/check-authorization-to-access-combined-course.js
+++ b/api/src/quest/application/usecases/check-authorization-to-access-combined-course.js
@@ -3,9 +3,16 @@ import { ORGANIZATION_FEATURE } from '../../../shared/domain/constants.js';
 import * as organizationFeatureRepository from '../../../shared/infrastructure/repositories/organization-feature-repository.js';
 import * as combinedCourseParticipantRepository from '../../infrastructure/repositories/combined-course-participant-repository.js';
 import * as combinedCourseRepository from '../../infrastructure/repositories/combined-course-repository.js';
+import * as checkDeletedOfCombinedCourse from './check-deleted-of-combined-course.js';
 
 const execute = async function ({ userId, code }) {
   const { organizationId } = await combinedCourseRepository.getByCode({ code });
+
+  const authorized = await checkDeletedOfCombinedCourse.execute({ code });
+
+  if (!authorized) {
+    return false;
+  }
 
   const hasImportFeature = await organizationFeatureRepository.isFeatureEnabledForOrganization({
     organizationId,

--- a/api/src/quest/application/usecases/check-deleted-of-combined-course.js
+++ b/api/src/quest/application/usecases/check-deleted-of-combined-course.js
@@ -1,0 +1,11 @@
+import * as combinedCourseRepository from '../../infrastructure/repositories/combined-course-repository.js';
+
+const execute = async function ({ code, id, dependencies = { combinedCourseRepository } }) {
+  const { deletedAt } = id
+    ? await dependencies.combinedCourseRepository.getById({ id })
+    : await dependencies.combinedCourseRepository.getByCode({ code });
+
+  return !deletedAt;
+};
+
+export { execute };

--- a/api/src/quest/application/usecases/check-user-can-manage-combined-course.js
+++ b/api/src/quest/application/usecases/check-user-can-manage-combined-course.js
@@ -1,5 +1,6 @@
 import * as membershipRepository from '../../../shared/infrastructure/repositories/membership-repository.js';
 import * as combinedCourseRepository from '../../infrastructure/repositories/combined-course-repository.js';
+import * as checkDeletedOfCombinedCourse from './check-deleted-of-combined-course.js';
 
 const execute = async function ({
   userId,
@@ -7,6 +8,11 @@ const execute = async function ({
   dependencies = { membershipRepository, combinedCourseRepository },
 }) {
   const { organizationId } = await dependencies.combinedCourseRepository.getById({ id: combinedCourseId });
+  const authorized = await checkDeletedOfCombinedCourse.execute({ id: combinedCourseId });
+
+  if (!authorized) {
+    return false;
+  }
   const memberships = await dependencies.membershipRepository.findByUserIdAndOrganizationId({
     userId,
     organizationId,

--- a/api/src/quest/domain/models/CombinedCourse.js
+++ b/api/src/quest/domain/models/CombinedCourse.js
@@ -23,7 +23,19 @@ export class CombinedCourse {
   #quest;
 
   constructor(
-    { id, code, organizationId, name, description, illustration, participations = [], questId, blueprintId } = {},
+    {
+      id,
+      code,
+      organizationId,
+      name,
+      description,
+      illustration,
+      participations = [],
+      questId,
+      blueprintId,
+      deletedAt = null,
+      deletedBy = null,
+    } = {},
     quest,
   ) {
     this.id = id;
@@ -35,6 +47,8 @@ export class CombinedCourse {
     this.participations = participations;
     this.questId = questId;
     this.blueprintId = blueprintId;
+    this.deletedAt = deletedAt;
+    this.deletedBy = deletedBy;
 
     this.#validate({ id, code, organizationId, name, description, illustration });
 

--- a/api/src/quest/infrastructure/repositories/combined-course-repository.js
+++ b/api/src/quest/infrastructure/repositories/combined-course-repository.js
@@ -7,7 +7,7 @@ const getByCode = async ({ code }) => {
   const knexConn = DomainTransaction.getConnection();
 
   const combinedCourse = await knexConn('combined_courses')
-    .select('id', 'organizationId', 'code', 'name', 'description', 'illustration', 'questId')
+    .select('id', 'organizationId', 'code', 'name', 'description', 'illustration', 'questId', 'deletedAt', 'deletedBy')
     .where('code', code)
     .first();
   if (!combinedCourse) {
@@ -21,7 +21,7 @@ const getById = async ({ id }) => {
   const knexConn = DomainTransaction.getConnection();
 
   const combinedCourse = await knexConn('combined_courses')
-    .select('id', 'organizationId', 'code', 'name', 'description', 'illustration', 'questId')
+    .select('id', 'organizationId', 'code', 'name', 'description', 'illustration', 'questId', 'deletedAt', 'deletedBy')
     .where('id', id)
     .whereNotNull('organizationId')
     .whereNotNull('code')
@@ -159,6 +159,8 @@ const _toDomain = ({
   illustration,
   questId,
   combinedCourseBlueprintId,
+  deletedAt,
+  deletedBy,
 }) => {
   return new CombinedCourse({
     id,
@@ -169,6 +171,8 @@ const _toDomain = ({
     illustration,
     questId,
     blueprintId: combinedCourseBlueprintId,
+    deletedAt,
+    deletedBy,
   });
 };
 

--- a/api/src/shared/application/security-pre-handlers.js
+++ b/api/src/shared/application/security-pre-handlers.js
@@ -679,12 +679,12 @@ async function checkAuthorizationToAccessCombinedCourse(
   const userId = request.auth.credentials.userId;
   const code = request.query?.filter?.code || request.params.code;
 
-  const belongsToOrganization = await dependencies.checkAuthorizationToAccessCombinedCourseUsecase.execute({
+  const canAccessCombinedCourse = await dependencies.checkAuthorizationToAccessCombinedCourseUsecase.execute({
     userId,
     code,
   });
 
-  if (belongsToOrganization) return h.response(true);
+  if (canAccessCombinedCourse) return h.response(true);
   return _replyForbiddenError(h);
 }
 

--- a/api/tests/quest/integration/domain/usecases/find-combined-course-by-module-id-and-user-id_test.js
+++ b/api/tests/quest/integration/domain/usecases/find-combined-course-by-module-id-and-user-id_test.js
@@ -67,6 +67,8 @@ describe('Integration | Quest | Domain | UseCases | find-combined-course-by-modu
         participations: [],
         questId: combinedCourse1.questId,
         blueprintId: null,
+        deletedAt: null,
+        deletedBy: null,
       },
       {
         id: combinedCourse2.id,
@@ -78,6 +80,8 @@ describe('Integration | Quest | Domain | UseCases | find-combined-course-by-modu
         participations: [],
         questId: combinedCourse2.questId,
         blueprintId: null,
+        deletedAt: null,
+        deletedBy: null,
       },
     ]);
   });

--- a/api/tests/quest/integration/infrastructure/repositories/combined-course-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/combined-course-repository_test.js
@@ -522,6 +522,8 @@ describe('Quest | Integration | Repository | combined-course', function () {
           participations: [],
           questId: combinedCourseWithModule.questId,
           blueprintId: null,
+          deletedAt: null,
+          deletedBy: null,
         },
         {
           id: otherCombinedCourseWithModule.id,
@@ -533,6 +535,8 @@ describe('Quest | Integration | Repository | combined-course', function () {
           participations: [],
           questId: otherCombinedCourseWithModule.questId,
           blueprintId: null,
+          deletedAt: null,
+          deletedBy: null,
         },
       ]);
     });
@@ -587,6 +591,8 @@ describe('Quest | Integration | Repository | combined-course', function () {
           participations: [],
           questId: combinedCourseWithModule.questId,
           blueprintId: null,
+          deletedAt: null,
+          deletedBy: null,
         },
         {
           id: combinedCourseWithModuleAndOtherOrga.id,
@@ -598,6 +604,8 @@ describe('Quest | Integration | Repository | combined-course', function () {
           participations: [],
           questId: combinedCourseWithModuleAndOtherOrga.questId,
           blueprintId: null,
+          deletedAt: null,
+          deletedBy: null,
         },
       ]);
     });

--- a/api/tests/unit/domain/usecases/check-deleted-of-combined-course_test.js
+++ b/api/tests/unit/domain/usecases/check-deleted-of-combined-course_test.js
@@ -1,0 +1,28 @@
+import * as checkDeletedOfCombinedCourse from '../../../../src/quest/application/usecases/check-deleted-of-combined-course.js';
+import { expect, sinon } from '../../../test-helper.js';
+
+describe('Unit | UseCase | check-deleted-of-combined-course', function () {
+  let combinedCourseRepositoryStub;
+
+  beforeEach(function () {
+    combinedCourseRepositoryStub = {
+      getById: sinon.stub().resolves({ deletedAt: null }),
+      getByCode: sinon.stub().resolves({ deletedAt: null }),
+    };
+  });
+
+  it('should call getByCode if code is given into parameters', async function () {
+    await checkDeletedOfCombinedCourse.execute({
+      code: 'RANDOM',
+      dependencies: { combinedCourseRepository: combinedCourseRepositoryStub },
+    });
+    expect(combinedCourseRepositoryStub.getByCode).to.be.calledWithExactly({ code: 'RANDOM' });
+  });
+  it('should call getById if id is given into parameters', async function () {
+    await checkDeletedOfCombinedCourse.execute({
+      id: 1,
+      dependencies: { combinedCourseRepository: combinedCourseRepositoryStub },
+    });
+    expect(combinedCourseRepositoryStub.getById).to.be.calledWithExactly({ id: 1 });
+  });
+});

--- a/mon-pix/app/routes/combined-courses/presentation.js
+++ b/mon-pix/app/routes/combined-courses/presentation.js
@@ -25,9 +25,17 @@ export default class CombinedCoursePresentationRoute extends Route {
   }
 
   async model() {
-    const { code } = this.paramsFor('combined-courses');
-    await this.store.adapterFor('combined-course').reassessStatus(code);
-    return this.store.queryRecord('combined-course', { filter: { code } });
+    try {
+      const { code } = this.paramsFor('combined-courses');
+      await this.store.adapterFor('combined-course').reassessStatus(code);
+      return this.store.queryRecord('combined-course', { filter: { code } });
+    } catch (err) {
+      if (err.errors[0].code === 403) {
+        this.router.replaceWith('campaigns.archived-error');
+      } else {
+        throw err;
+      }
+    }
   }
 
   afterModel(combinedCourse) {


### PR DESCRIPTION
## 🥀 Problème
On veut que les parcours supprimés logiquement (c'est-à-dire flaggés "DeletedAt" ou "DeletedBy") ne soient pas accessibles par les utilisateurs.

## 🏹 Proposition
On crée une condition qui throw une erreur de type ForbiddenAccess si le parcours combiné a une date dans "deletedAt".
On a créé un seed à part pour pouvoir tester cette nouvelle condition.

## 💌 Remarques
Dans l'accès aux campagnes, cette erreur est levée également mais plus tard. Elle renvoie aussi vers l'écran "Oups".
Ici, on a choisi de lancer une erreur de type "Forbidden Access", donc l'erreur apparaît en rouge en dessous du champ code.

## ❤️‍🔥 Pour tester
Flagger un combinedCourse avec un deletedAt/deletedBy avec une requête SQL
Entrer le code du parcours combiné
Voir l’erreur “Oups ! nous ne parvenons pas à vous trouver. Vérifiez vos informations afin de continuer ou prévenez l’organisateur.”
Aller voir dans la console → Réseau/Network → l’erreur sur combined-courses/filter? doit être de statut 403 et le message doit être "Vous n'êtes pas autorisé à rejoindre le parcours combiné".