### PR TITLE
[TECH] Réduire le nombre de requêtes SQL générées lors de l'inscription de plusieurs candidats d'un coup (PIX-21620)

### DIFF
--- a/api/src/certification/enrolment/application/attendance-sheet-route.js
+++ b/api/src/certification/enrolment/application/attendance-sheet-route.js
@@ -25,7 +25,7 @@ const register = async function (server) {
         tags: ['api', 'sessions'],
         notes: [
           '- **Cette route est restreinte aux utilisateurs appartenant à un centre de certification ayant créé la session**\n' +
-            '- Cette route permet de télécharger le pv de session pré-rempli au format ods',
+            "- Cette route permet de télécharger la feuille d'émargement pré-remplie au format PDF",
         ],
       },
     },

--- a/api/src/certification/enrolment/application/certification-candidate-route.js
+++ b/api/src/certification/enrolment/application/certification-candidate-route.js
@@ -52,6 +52,7 @@ const register = async function (server) {
                         .allow(null),
                     }),
                   )
+                  .required()
                   .min(1)
                   .max(2),
               },

--- a/api/src/certification/enrolment/domain/usecases/create-sessions.js
+++ b/api/src/certification/enrolment/domain/usecases/create-sessions.js
@@ -76,11 +76,6 @@ async function _deleteExistingCandidatesInSession({ candidateRepository, session
 }
 
 async function _saveCandidates({ candidates, sessionId, candidateRepository }) {
-  for (const candidateDTO of candidates) {
-    const candidate = new Candidate({ ...candidateDTO });
-    await candidateRepository.saveInSession({
-      sessionId,
-      candidate,
-    });
-  }
+  const candidatesToSave = candidates.map((candidate) => new Candidate({ ...candidate, sessionId }));
+  await candidateRepository.save({ candidates: candidatesToSave });
 }

--- a/api/src/certification/enrolment/domain/usecases/import-certification-candidates-from-candidates-import-sheet.js
+++ b/api/src/certification/enrolment/domain/usecases/import-certification-candidates-from-candidates-import-sheet.js
@@ -43,10 +43,7 @@ const importCertificationCandidatesFromCandidatesImportSheet = async function ({
 
   await DomainTransaction.execute(async () => {
     await candidateRepository.deleteBySessionId({ sessionId });
-
-    for (const candidate of candidates) {
-      await candidateRepository.saveInSession({ candidate, sessionId });
-    }
+    await candidateRepository.save({ candidates });
   });
 };
 

--- a/api/src/certification/enrolment/infrastructure/repositories/candidate-repository.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/candidate-repository.js
@@ -159,44 +159,6 @@ export async function deleteBySessionId({ sessionId }) {
 
 /**
  * @function
- * @param {object} params
- * @param {Candidate} params.candidate
- * @param {number} params.sessionId
- * @returns {Promise<number>} return saved candidate id
- */
-export async function saveInSession({ candidate, sessionId }) {
-  const candidateDataToSave = adaptModelToDb(candidate);
-  const knexConn = DomainTransaction.getConnection();
-
-  const [{ id: certificationCandidateId }] = await knexConn('certification-candidates')
-    .insert({ ...candidateDataToSave, sessionId })
-    .returning('id');
-
-  for (const subscription of candidate.subscriptions) {
-    if (subscription.type === SUBSCRIPTION_TYPES.CORE) {
-      await knexConn('certification-subscriptions').insert({
-        certificationCandidateId: certificationCandidateId,
-        type: subscription.type,
-        complementaryCertificationId: null,
-      });
-    } else {
-      const { id: complementaryCertificationId } = await knexConn('complementary-certifications')
-        .select('id')
-        .where({ key: subscription.complementaryCertificationKey })
-        .first();
-      await knexConn('certification-subscriptions').insert({
-        certificationCandidateId: certificationCandidateId,
-        type: subscription.type,
-        complementaryCertificationId: complementaryCertificationId,
-      });
-    }
-  }
-
-  return certificationCandidateId;
-}
-
-/**
- * @function
  * @param {Candidate[]} candidates
  * @returns {Promise<void>}
  */

--- a/api/tests/certification/enrolment/integration/infrastructure/repositories/candidate-repository_test.js
+++ b/api/tests/certification/enrolment/integration/infrastructure/repositories/candidate-repository_test.js
@@ -4,7 +4,7 @@ import * as candidateRepository from '../../../../../../src/certification/enrolm
 import { SUBSCRIPTION_TYPES } from '../../../../../../src/certification/shared/domain/constants.js';
 import { ComplementaryCertificationKeys } from '../../../../../../src/certification/shared/domain/models/ComplementaryCertificationKeys.js';
 import { _ } from '../../../../../../src/shared/infrastructure/utils/lodash-utils.js';
-import { catchErr, databaseBuilder, domainBuilder, expect, knex, sinon } from '../../../../../test-helper.js';
+import { catchErr, databaseBuilder, domainBuilder, expect, knex } from '../../../../../test-helper.js';
 
 describe('Integration | Certification | Enrolment | Repository | Candidate', function () {
   describe('#get', function () {
@@ -381,81 +381,6 @@ describe('Integration | Certification | Enrolment | Repository | Candidate', fun
           certificationCandidateId: candidateId,
           type: SUBSCRIPTION_TYPES.COMPLEMENTARY,
           complementaryCertificationId: 22,
-        },
-        ['createdAt'],
-      );
-      expect(savedSubscriptionsData[1]).to.deepEqualInstanceOmitting(
-        {
-          certificationCandidateId: candidateId,
-          type: SUBSCRIPTION_TYPES.CORE,
-          complementaryCertificationId: null,
-        },
-        ['createdAt'],
-      );
-    });
-  });
-
-  describe('#saveInSession', function () {
-    it("should insert session's candidate in DB with subscriptions", async function () {
-      // given
-      const complementaryCertificationId = databaseBuilder.factory.buildComplementaryCertification.clea({}).id;
-      const sessionId = databaseBuilder.factory.buildSession({}).id;
-      const aUserId = databaseBuilder.factory.buildUser().id;
-      await databaseBuilder.commit();
-      const candidate = domainBuilder.certification.enrolment.buildCandidate({
-        accessibilityAdjustmentNeeded: true,
-        userId: aUserId,
-        subscriptions: [
-          domainBuilder.certification.enrolment.buildCoreSubscription(),
-          domainBuilder.certification.enrolment.buildComplementarySubscription({
-            complementaryCertificationKey: ComplementaryCertificationKeys.CLEA,
-          }),
-        ],
-      });
-
-      // when
-      const candidateId = await candidateRepository.saveInSession({ candidate, sessionId });
-
-      // then
-      const savedCandidateData = await knex('certification-candidates').select('*').where({ id: candidateId }).first();
-      const savedSubscriptionsData = await knex('certification-subscriptions')
-        .select('*')
-        .where({ certificationCandidateId: candidateId })
-        .orderBy('type');
-
-      expect(_.omit(savedCandidateData, ['createdAt', 'extraTimePercentage'])).to.deep.equal({
-        id: candidateId,
-        firstName: candidate.firstName,
-        reconciledAt: null,
-        lastName: candidate.lastName,
-        birthCity: candidate.birthCity,
-        externalId: candidate.externalId,
-        birthdate: candidate.birthdate,
-        sessionId: sessionId,
-        birthProvinceCode: candidate.birthProvinceCode,
-        birthCountry: candidate.birthCountry,
-        userId: candidate.userId,
-        email: candidate.email,
-        resultRecipientEmail: candidate.resultRecipientEmail,
-        organizationLearnerId: candidate.organizationLearnerId,
-        birthPostalCode: candidate.birthPostalCode,
-        birthINSEECode: candidate.birthINSEECode,
-        sex: candidate.sex,
-        authorizedToStart: false,
-        billingMode: candidate.billingMode,
-        prepaymentCode: candidate.prepaymentCode,
-        hasSeenCertificationInstructions: false,
-        accessibilityAdjustmentNeeded: candidate.accessibilityAdjustmentNeeded,
-      });
-      expect(savedCandidateData.createdAt).to.be.instanceOf(Date);
-      expect(parseFloat(savedCandidateData.extraTimePercentage)).to.equal(candidate.extraTimePercentage);
-
-      expect(savedSubscriptionsData).to.have.lengthOf(2);
-      expect(savedSubscriptionsData[0]).to.deepEqualInstanceOmitting(
-        {
-          certificationCandidateId: candidateId,
-          type: SUBSCRIPTION_TYPES.COMPLEMENTARY,
-          complementaryCertificationId,
         },
         ['createdAt'],
       );

--- a/api/tests/certification/enrolment/integration/infrastructure/repositories/candidate-repository_test.js
+++ b/api/tests/certification/enrolment/integration/infrastructure/repositories/candidate-repository_test.js
@@ -4,7 +4,7 @@ import * as candidateRepository from '../../../../../../src/certification/enrolm
 import { SUBSCRIPTION_TYPES } from '../../../../../../src/certification/shared/domain/constants.js';
 import { ComplementaryCertificationKeys } from '../../../../../../src/certification/shared/domain/models/ComplementaryCertificationKeys.js';
 import { _ } from '../../../../../../src/shared/infrastructure/utils/lodash-utils.js';
-import { catchErr, databaseBuilder, domainBuilder, expect, knex } from '../../../../../test-helper.js';
+import { catchErr, databaseBuilder, domainBuilder, expect, knex, sinon } from '../../../../../test-helper.js';
 
 describe('Integration | Certification | Enrolment | Repository | Candidate', function () {
   describe('#get', function () {
@@ -464,6 +464,193 @@ describe('Integration | Certification | Enrolment | Repository | Candidate', fun
           certificationCandidateId: candidateId,
           type: SUBSCRIPTION_TYPES.CORE,
           complementaryCertificationId: null,
+        },
+        ['createdAt'],
+      );
+    });
+  });
+
+  describe('#save', function () {
+    it("should insert session's candidates in DB with their subscriptions", async function () {
+      // given
+      const cleaCertificationId = databaseBuilder.factory.buildComplementaryCertification.clea({}).id;
+      const droitCertificationId = databaseBuilder.factory.buildComplementaryCertification.droit({}).id;
+      const sessionId = databaseBuilder.factory.buildSession({}).id;
+      await databaseBuilder.commit();
+      const candidateA = domainBuilder.certification.enrolment.buildCandidate({
+        firstName: 'Lolo',
+        lastName: 'Lapraline',
+        accessibilityAdjustmentNeeded: true,
+        sessionId,
+        subscriptions: [
+          domainBuilder.certification.enrolment.buildCoreSubscription(),
+          domainBuilder.certification.enrolment.buildComplementarySubscription({
+            complementaryCertificationKey: ComplementaryCertificationKeys.CLEA,
+          }),
+        ],
+      });
+      const candidateB = domainBuilder.certification.enrolment.buildCandidate({
+        firstName: 'Geogeo',
+        lastName: 'Lenougat',
+        accessibilityAdjustmentNeeded: true,
+        sessionId,
+        subscriptions: [domainBuilder.certification.enrolment.buildCoreSubscription()],
+      });
+      const candidateC = domainBuilder.certification.enrolment.buildCandidate({
+        firstName: 'Loulou',
+        lastName: 'Lapistache',
+        sessionId,
+        accessibilityAdjustmentNeeded: false,
+        subscriptions: [
+          domainBuilder.certification.enrolment.buildComplementarySubscription({
+            complementaryCertificationKey: ComplementaryCertificationKeys.PIX_PLUS_DROIT,
+          }),
+        ],
+      });
+
+      // when
+      await candidateRepository.save({ candidates: [candidateA, candidateB, candidateC] });
+
+      // then
+      // Candidate A
+      const savedCandidateAData = await knex('certification-candidates')
+        .select('*')
+        .where({ firstName: 'Lolo' })
+        .first();
+      const savedSubscriptionsAData = await knex('certification-subscriptions')
+        .select('*')
+        .where({ certificationCandidateId: savedCandidateAData.id })
+        .orderBy('type');
+      expect(_.omit(savedCandidateAData, ['createdAt', 'extraTimePercentage'])).to.deep.equal({
+        id: savedCandidateAData.id,
+        firstName: candidateA.firstName,
+        reconciledAt: null,
+        lastName: candidateA.lastName,
+        birthCity: candidateA.birthCity,
+        externalId: candidateA.externalId,
+        birthdate: candidateA.birthdate,
+        sessionId: sessionId,
+        birthProvinceCode: candidateA.birthProvinceCode,
+        birthCountry: candidateA.birthCountry,
+        userId: null,
+        email: candidateA.email,
+        resultRecipientEmail: candidateA.resultRecipientEmail,
+        organizationLearnerId: candidateA.organizationLearnerId,
+        birthPostalCode: candidateA.birthPostalCode,
+        birthINSEECode: candidateA.birthINSEECode,
+        sex: candidateA.sex,
+        authorizedToStart: false,
+        billingMode: candidateA.billingMode,
+        prepaymentCode: candidateA.prepaymentCode,
+        hasSeenCertificationInstructions: false,
+        accessibilityAdjustmentNeeded: candidateA.accessibilityAdjustmentNeeded,
+      });
+      expect(savedCandidateAData.createdAt).to.be.instanceOf(Date);
+      expect(parseFloat(savedCandidateAData.extraTimePercentage)).to.equal(candidateA.extraTimePercentage);
+      expect(savedSubscriptionsAData).to.have.lengthOf(2);
+      expect(savedSubscriptionsAData[0]).to.deepEqualInstanceOmitting(
+        {
+          certificationCandidateId: savedCandidateAData.id,
+          type: SUBSCRIPTION_TYPES.COMPLEMENTARY,
+          complementaryCertificationId: cleaCertificationId,
+        },
+        ['createdAt'],
+      );
+      expect(savedSubscriptionsAData[1]).to.deepEqualInstanceOmitting(
+        {
+          certificationCandidateId: savedCandidateAData.id,
+          type: SUBSCRIPTION_TYPES.CORE,
+          complementaryCertificationId: null,
+        },
+        ['createdAt'],
+      );
+
+      // Candidate B
+      const savedCandidateBData = await knex('certification-candidates')
+        .select('*')
+        .where({ firstName: 'Geogeo' })
+        .first();
+      const savedSubscriptionsBData = await knex('certification-subscriptions')
+        .select('*')
+        .where({ certificationCandidateId: savedCandidateBData.id })
+        .orderBy('type');
+      expect(_.omit(savedCandidateBData, ['createdAt', 'extraTimePercentage'])).to.deep.equal({
+        id: savedCandidateBData.id,
+        firstName: candidateB.firstName,
+        reconciledAt: null,
+        lastName: candidateB.lastName,
+        birthCity: candidateB.birthCity,
+        externalId: candidateB.externalId,
+        birthdate: candidateB.birthdate,
+        sessionId: sessionId,
+        birthProvinceCode: candidateB.birthProvinceCode,
+        birthCountry: candidateB.birthCountry,
+        userId: null,
+        email: candidateB.email,
+        resultRecipientEmail: candidateB.resultRecipientEmail,
+        organizationLearnerId: candidateB.organizationLearnerId,
+        birthPostalCode: candidateB.birthPostalCode,
+        birthINSEECode: candidateB.birthINSEECode,
+        sex: candidateB.sex,
+        authorizedToStart: false,
+        billingMode: candidateB.billingMode,
+        prepaymentCode: candidateB.prepaymentCode,
+        hasSeenCertificationInstructions: false,
+        accessibilityAdjustmentNeeded: candidateB.accessibilityAdjustmentNeeded,
+      });
+      expect(savedCandidateBData.createdAt).to.be.instanceOf(Date);
+      expect(parseFloat(savedCandidateBData.extraTimePercentage)).to.equal(candidateB.extraTimePercentage);
+      expect(savedSubscriptionsBData).to.have.lengthOf(1);
+      expect(savedSubscriptionsBData[0]).to.deepEqualInstanceOmitting(
+        {
+          certificationCandidateId: savedCandidateBData.id,
+          type: SUBSCRIPTION_TYPES.CORE,
+          complementaryCertificationId: null,
+        },
+        ['createdAt'],
+      );
+
+      // Candidate C
+      const savedCandidateCData = await knex('certification-candidates')
+        .select('*')
+        .where({ firstName: 'Loulou' })
+        .first();
+      const savedSubscriptionsCData = await knex('certification-subscriptions')
+        .select('*')
+        .where({ certificationCandidateId: savedCandidateCData.id })
+        .orderBy('type');
+      expect(_.omit(savedCandidateCData, ['createdAt', 'extraTimePercentage'])).to.deep.equal({
+        id: savedCandidateCData.id,
+        firstName: candidateC.firstName,
+        reconciledAt: null,
+        lastName: candidateC.lastName,
+        birthCity: candidateC.birthCity,
+        externalId: candidateC.externalId,
+        birthdate: candidateC.birthdate,
+        sessionId: sessionId,
+        birthProvinceCode: candidateC.birthProvinceCode,
+        birthCountry: candidateC.birthCountry,
+        userId: null,
+        email: candidateC.email,
+        resultRecipientEmail: candidateC.resultRecipientEmail,
+        organizationLearnerId: candidateC.organizationLearnerId,
+        birthPostalCode: candidateC.birthPostalCode,
+        birthINSEECode: candidateC.birthINSEECode,
+        sex: candidateC.sex,
+        authorizedToStart: false,
+        billingMode: candidateC.billingMode,
+        prepaymentCode: candidateC.prepaymentCode,
+        hasSeenCertificationInstructions: false,
+        accessibilityAdjustmentNeeded: candidateC.accessibilityAdjustmentNeeded,
+      });
+      expect(savedCandidateCData.createdAt).to.be.instanceOf(Date);
+      expect(parseFloat(savedCandidateCData.extraTimePercentage)).to.equal(candidateC.extraTimePercentage);
+      expect(savedSubscriptionsCData).to.have.lengthOf(1);
+      expect(savedSubscriptionsCData[0]).to.deepEqualInstanceOmitting(
+        {
+          certificationCandidateId: savedCandidateCData.id,
+          type: SUBSCRIPTION_TYPES.COMPLEMENTARY,
+          complementaryCertificationId: droitCertificationId,
         },
         ['createdAt'],
       );

--- a/api/tests/certification/enrolment/unit/application/certification-candidate-route_test.js
+++ b/api/tests/certification/enrolment/unit/application/certification-candidate-route_test.js
@@ -119,6 +119,29 @@ describe('Unit | Application | Sessions | Routes', function () {
           expect(errors[0].detail).to.equals('"data.attributes.toto" is not allowed');
         });
       });
+
+      describe('when subscriptions in undefined', function () {
+        it('should return 400', async function () {
+          // given
+          sinon.stub(authorization, 'verifySessionAuthorization').returns(true);
+          sinon.stub(certificationCandidateController, 'addCandidate').returns('ok');
+          const httpTestServer = new HttpTestServer();
+          await httpTestServer.register(moduleUnderTest);
+
+          // when
+          const response = await httpTestServer.request('POST', '/api/sessions/1/certification-candidates', {
+            data: {
+              attributes: { ...correctAttributes, subscriptions: undefined },
+              type: 'certification-candidates',
+            },
+          });
+
+          // then
+          expect(response.statusCode).to.equal(400);
+          const { errors } = JSON.parse(response.payload);
+          expect(errors[0].detail).to.equals('"data.attributes.subscriptions" is required');
+        });
+      });
     });
   });
 

--- a/api/tests/certification/enrolment/unit/domain/usecases/create-sessions_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/create-sessions_test.js
@@ -15,7 +15,7 @@ describe('Unit | UseCase | sessions-mass-import | create-sessions', function () 
 
   beforeEach(function () {
     centerRepository = { getById: sinon.stub() };
-    candidateRepository = { deleteBySessionId: sinon.stub(), saveInSession: sinon.stub() };
+    candidateRepository = { deleteBySessionId: sinon.stub(), save: sinon.stub() };
     sessionRepository = { save: sinon.stub() };
     temporarySessionsStorageForMassImportService = {
       getByKeyAndUserId: sinon.stub(),
@@ -33,10 +33,9 @@ describe('Unit | UseCase | sessions-mass-import | create-sessions', function () 
       sessionId: undefined,
       subscriptions: [
         domainBuilder.certification.enrolment.buildCoreSubscription(),
-        domainBuilder.certification.shared.buildComplementaryCertification({
+        domainBuilder.certification.enrolment.buildComplementarySubscription({
           id: 1,
-          label: 'Pix+Droit',
-          key: ComplementaryCertificationKeys.PIX_PLUS_DROIT,
+          complementaryCertificationKey: ComplementaryCertificationKeys.PIX_PLUS_DROIT,
         }),
       ],
     };
@@ -101,7 +100,7 @@ describe('Unit | UseCase | sessions-mass-import | create-sessions', function () 
           // then
           const expectedSession = new SessionEnrolment({ ...temporaryCachedSessions[0], createdBy: sessionCreatorId });
           expect(sessionRepository.save).to.have.been.calledOnceWith({ session: expectedSession });
-          expect(candidateRepository.saveInSession).to.not.have.been.called;
+          expect(candidateRepository.save).to.not.have.been.called;
         });
       });
 
@@ -145,9 +144,8 @@ describe('Unit | UseCase | sessions-mass-import | create-sessions', function () 
           // then
           const expectedSession = new SessionEnrolment({ ...temporaryCachedSessions[0], createdBy: sessionCreatorId });
           expect(sessionRepository.save).to.have.been.calledOnceWith({ session: expectedSession });
-          expect(candidateRepository.saveInSession).to.have.been.calledOnceWith({
-            sessionId: 1234,
-            candidate,
+          expect(candidateRepository.save).to.have.been.calledOnceWith({
+            candidates: [domainBuilder.certification.enrolment.buildCandidate({ ...candidate, sessionId: 1234 })],
           });
         });
       });
@@ -182,9 +180,8 @@ describe('Unit | UseCase | sessions-mass-import | create-sessions', function () 
         expect(candidateRepository.deleteBySessionId).to.have.been.calledOnceWith({
           sessionId: 1234,
         });
-        expect(candidateRepository.saveInSession).to.have.been.calledOnceWith({
-          sessionId: 1234,
-          candidate,
+        expect(candidateRepository.save).to.have.been.calledOnceWith({
+          candidates: [domainBuilder.certification.enrolment.buildCandidate({ ...candidate, sessionId: 1234 })],
         });
       });
     });

--- a/api/tests/certification/enrolment/unit/domain/usecases/import-certification-candidates-from-candidates-import-sheet_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/import-certification-candidates-from-candidates-import-sheet_test.js
@@ -20,7 +20,7 @@ describe('Unit | UseCase | import-certification-candidates-from-attendance-sheet
     candidateRepository = {
       deleteBySessionId: sinon.stub(),
       findBySessionId: sinon.stub(),
-      saveInSession: sinon.stub(),
+      save: sinon.stub(),
     };
     sessionRepository = {
       get: sinon.stub(),
@@ -132,11 +132,8 @@ describe('Unit | UseCase | import-certification-candidates-from-attendance-sheet
           expect(candidateRepository.deleteBySessionId).to.have.been.calledWithExactly({
             sessionId,
           });
-          expect(candidateRepository.saveInSession).to.have.been.calledWithExactly({
-            candidate,
-            sessionId,
-          });
-          expect(candidateRepository.deleteBySessionId.calledBefore(candidateRepository.saveInSession)).to.be.true;
+          expect(candidateRepository.save).to.have.been.calledWithExactly({ candidates });
+          expect(candidateRepository.deleteBySessionId.calledBefore(candidateRepository.save)).to.be.true;
         });
       });
     });


### PR DESCRIPTION
## 🥀 Problème

On a un bugounet en prod qui fait qu'on peut trouver dans la BDD des candidats inscrits sans subscription.

On a essayé de vraiment trouver l'origine du bug, elle reste mystérieuse à ce jour. La seule piste lointaine qu'on ait, sans forme de justification, serait que lorsque le trafic est élevé et que côté BDD ça galère, on a parfois des loupés.

## 🏹 Proposition

Déjà, petite amélioration qui transforme une erreur 500 en 400 lors de l'ajout individuel de candidat.
Ensuite, on a modifié les usecases d'insertions groupés (import ODS + création de sessions en masse) pour batcher les insertions de candidats et de souscriptions en BDD.

## 💌 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## ❤️‍🔥 Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
