### PR TITLE
Mettre en import absolu les imports relatifs de l'environment (mon-pix)

### DIFF
--- a/mon-pix/app/router.js
+++ b/mon-pix/app/router.js
@@ -1,6 +1,5 @@
 import EmberRouter from '@ember/routing/router';
-
-import config from './config/environment';
+import config from 'mon-pix/config/environment';
 
 export default class Router extends EmberRouter {
   location = config.locationType;

--- a/mon-pix/app/services/ajax.js
+++ b/mon-pix/app/services/ajax.js
@@ -1,6 +1,5 @@
 import AjaxService from 'ember-ajax/services/ajax';
-
-import config from '../config/environment';
+import config from 'mon-pix/config/environment';
 
 export default AjaxService.extend({
   host: config.APP.API_HOST,


### PR DESCRIPTION
## 🥀 Problème

Des imports du fichier config/environment utilisent des chemins relatifs (./config/environment, ../config/environment).
Or:
    • Les imports absolus sont la convention recommandée dans les applications Ember.
    • Ils sont plus robustes, car indépendants de la position des fichiers dans l’arborescence.
    • Cette approche homogénéise le projet.
    • Elle permet également d’aliaser l’accès à la configuration afin d’y injecter des valeurs spécifiques à écri+

## 🏹 Proposition

Remplacer les imports relatifs par des imports absolus.

## 💌 Remarques

Seuls 2 fichiers sont concernés dans le code source de mon-pix (hors tests) et font exception par rapport au reste du code.

## ❤️‍🔥 Pour tester

Lancer les tests de l'application.
Ce changement ne doit avoir aucun effet sur les tests de l'application mon-pix.