### PR TITLE
Déplacer les accès aux services du constructeur vers activate() dans ApplicationRoute

### DIFF
--- a/mon-pix/app/routes/application.js
+++ b/mon-pix/app/routes/application.js
@@ -17,8 +17,8 @@ export default class ApplicationRoute extends Route {
   @service currentUser;
   @service locale;
 
-  constructor() {
-    super(...arguments);
+  activate() {
+    this.splash.hide();
 
     const trackRouteChange = (transition) => {
       if (!transition.to || transition.to.metadata?.doNotTrackPage) {
@@ -27,10 +27,6 @@ export default class ApplicationRoute extends Route {
       this.pixMetrics.trackPage();
     };
     this.router.on('routeDidChange', trackRouteChange);
-  }
-
-  activate() {
-    this.splash.hide();
   }
 
   async beforeModel(transition) {


### PR DESCRIPTION
## 🥀 Problème

Fichier modifié :
mon-pix/app/routes/application.js

Problème identifié :
Dans les classes Ember natives (Octane), les services déclarés avec @service ne sont pas encore disponibles dans le constructor().
Le code initial plaçait l’initialisation du listener routeDidChange (suivi des changements de route) dans le constructeur, ce qui pouvait entraîner un accès prématuré à des propriétés injectées.

## 🏹 Proposition

    • Déplacement de l’écouteur this.router.on('routeDidChange', ...) du constructor() vers le hook de cycle de vie activate().
    • Fusion de l’appel this.splash.hide() (déjà présent dans activate()) dans ce même hook.
    • Suppression du constructor(), devenu inutile.

## 💌 Remarques

Le hook activate() est exécuté après l’initialisation complète de la route, garantissant la disponibilité des services injectés.
Le comportement fonctionnel reste inchangé, mais la robustesse du code est améliorée.

## ❤️‍🔥 Pour tester

Les tests de l'application ne doivent pas être impactés par ce changement.
