### PR TITLE
[FEATURE] Scripte une modification de nom de parcours combinés (PIX-21504)

### DIFF
--- a/api/scripts/prod/update-name-of-combined-courses.js
+++ b/api/scripts/prod/update-name-of-combined-courses.js
@@ -1,0 +1,65 @@
+import { usecases } from '../../src/quest/domain/usecases/index.js';
+import { commaSeparatedNumberParser } from '../../src/shared/application/scripts/parsers.js';
+import { Script } from '../../src/shared/application/scripts/script.js';
+import { ScriptRunner } from '../../src/shared/application/scripts/script-runner.js';
+import { DomainTransaction } from '../../src/shared/domain/DomainTransaction.js';
+
+export class UpdateCombinedCoursesNameScript extends Script {
+  constructor() {
+    super({
+      description: 'Updates the name of a single or several combined courses',
+      permanent: true,
+      options: {
+        combinedCourseIds: {
+          type: 'string',
+          describe: 'a list of comma separated combined course ids',
+          demandOption: true,
+          coerce: commaSeparatedNumberParser(),
+        },
+        newName: {
+          type: 'string',
+          describe: 'a single name that will apply to every combined course id given in argument',
+          demandOption: true,
+        },
+        dryRun: {
+          type: 'boolean',
+          default: true,
+        },
+      },
+    });
+  }
+
+  async handle({ options, logger, dependencies = usecases }) {
+    logger.info(
+      { event: 'UpdateCombinedCoursesNameScript' },
+      `Updates the name attribute for ${options.combinedCourseIds.length} combined courses`,
+    );
+    await DomainTransaction.execute(async () => {
+      const knexConn = DomainTransaction.getConnection();
+
+      try {
+        await dependencies.updateCombinedCourses({
+          combinedCourseIds: options.combinedCourseIds,
+          name: options.newName,
+        });
+
+        if (options.dryRun) {
+          await knexConn.rollback();
+          logger.info(`ROLLBACK due to dryRun`);
+          logger.info(`--dryRun true to persist changes`);
+          return;
+        }
+
+        logger.info(
+          { event: 'UpdateCombinedCoursesNameScript' },
+          `COMMIT: Successfully updated names for ${options.combinedCourseIds.length} combined courses.`,
+        );
+      } catch (error) {
+        await knexConn.rollback();
+        logger.error({ event: 'UpdateCombinedCoursesNameScript' }, `ROLLBACK: An error has occured, ${error}`);
+        throw error;
+      }
+    });
+  }
+}
+await ScriptRunner.execute(import.meta.url, UpdateCombinedCoursesNameScript);

--- a/api/src/quest/domain/usecases/index.js
+++ b/api/src/quest/domain/usecases/index.js
@@ -69,6 +69,7 @@ import { getVerifiedCode } from './get-verified-code.js';
 import { rewardUser } from './reward-user.js';
 import { startCombinedCourse } from './start-combined-course.js';
 import { updateCombinedCourse } from './update-combined-course.js';
+import { updateCombinedCourses } from './update-combined-courses.js';
 
 const usecasesWithoutInjectedDependencies = {
   attachOrganizationsToCombinedCourseBlueprint,
@@ -96,6 +97,7 @@ const usecasesWithoutInjectedDependencies = {
   createCombinedCourse,
   findByOrganizationId,
   deleteAndAnonymizeParticipationsForALearnerId,
+  updateCombinedCourses,
 };
 
 const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);

--- a/api/src/quest/domain/usecases/update-combined-courses.js
+++ b/api/src/quest/domain/usecases/update-combined-courses.js
@@ -1,0 +1,3 @@
+export async function updateCombinedCourses({ combinedCourseIds, name, combinedCourseRepository }) {
+  await combinedCourseRepository.updateCombinedCourses({ combinedCourseIds, name });
+}

--- a/api/src/quest/infrastructure/repositories/combined-course-repository.js
+++ b/api/src/quest/infrastructure/repositories/combined-course-repository.js
@@ -145,6 +145,11 @@ const deleteCombinedCourses = async ({ combinedCourseIds, deletedBy }) => {
     .whereIn('id', combinedCourseIds);
 };
 
+const updateCombinedCourses = async ({ combinedCourseIds, name }) => {
+  const knexConn = DomainTransaction.getConnection();
+  await knexConn('combined_courses').update({ name, updatedAt: knexConn.fn.now() }).whereIn('id', combinedCourseIds);
+};
+
 const _toDomain = ({
   id,
   organizationId,
@@ -177,4 +182,5 @@ export {
   save,
   saveInBatch,
   targetProfileIdsPartOfAnyCombinedCourse,
+  updateCombinedCourses,
 };

--- a/api/tests/quest/integration/domain/usecases/update-combined-courses_test.js
+++ b/api/tests/quest/integration/domain/usecases/update-combined-courses_test.js
@@ -1,0 +1,46 @@
+import { usecases } from '../../../../../src/quest/domain/usecases/index.js';
+import { databaseBuilder, expect, knex } from '../../../../test-helper.js';
+
+describe('Integration | Quest | Domain | UseCases | update-combined-courses', function () {
+  const lastUpdatedAt = new Date('2025-07-07');
+
+  it('should update names and updatedAt of combined courses with corresponding ids', async function () {
+    //given
+    const firstCombinedCourse = await databaseBuilder.factory.buildCombinedCourse({
+      code: 'FIRST',
+      updatedAt: lastUpdatedAt,
+    });
+    const secondCombinedCourse = await databaseBuilder.factory.buildCombinedCourse({
+      code: 'SECOND',
+      updatedAt: lastUpdatedAt,
+    });
+
+    const otherCombinedCourse = await databaseBuilder.factory.buildCombinedCourse({
+      updatedAt: lastUpdatedAt,
+    });
+
+    await databaseBuilder.commit();
+
+    //then
+    await usecases.updateCombinedCourses({
+      combinedCourseIds: [firstCombinedCourse.id, secondCombinedCourse.id],
+      name: 'new-name',
+    });
+
+    const updatedCombinedCourses = await knex('combined_courses').whereIn('id', [
+      firstCombinedCourse.id,
+      secondCombinedCourse.id,
+    ]);
+
+    const notUpdatedCombinedCourse = await knex('combined_courses').where('id', otherCombinedCourse.id).first();
+
+    expect(updatedCombinedCourses[0].name).to.equal('new-name');
+    expect(updatedCombinedCourses[0].updatedAt).to.be.above(lastUpdatedAt);
+
+    expect(updatedCombinedCourses[1].name).to.equal('new-name');
+    expect(updatedCombinedCourses[1].updatedAt).to.be.above(lastUpdatedAt);
+
+    expect(notUpdatedCombinedCourse.name).to.equal(otherCombinedCourse.name);
+    expect(notUpdatedCombinedCourse.updatedAt).not.to.be.above(lastUpdatedAt);
+  });
+});

--- a/api/tests/quest/integration/infrastructure/repositories/combined-course-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/combined-course-repository_test.js
@@ -658,4 +658,48 @@ describe('Quest | Integration | Repository | combined-course', function () {
       expect(deletedCombinedCourse.deletedBy).to.equal(userId);
     });
   });
+
+  describe('#updateCombinedCourses', function () {
+    let lastUpdatedAt;
+
+    beforeEach(async function () {
+      lastUpdatedAt = new Date('2023-01-01');
+    });
+
+    it('should update name for given combined courses ids', async function () {
+      //given
+      const combinedCourse = databaseBuilder.factory.buildCombinedCourse({
+        code: 'QWERTY123',
+        name: 'name1',
+        combinedCourseContents: [],
+        updatedAt: lastUpdatedAt,
+      });
+
+      const otherCombinedCourse = databaseBuilder.factory.buildCombinedCourse({
+        code: 'AZERTY123',
+        name: 'name2',
+        combinedCourseContents: [],
+        updatedAt: lastUpdatedAt,
+      });
+
+      await databaseBuilder.commit();
+
+      //when
+      await combinedCourseRepository.updateCombinedCourses({
+        combinedCourseIds: [combinedCourse.id],
+        name: 'new-name',
+      });
+
+      const allCombinedCourses = await knex('combined_courses');
+      const notUpdatedCombinedCourse = await knex('combined_courses').where('id', otherCombinedCourse.id).first();
+      const updatedCombinedCourse = await knex('combined_courses').where('id', combinedCourse.id).first();
+
+      //then
+      expect(allCombinedCourses).to.have.lengthOf(2);
+      expect(notUpdatedCombinedCourse.updatedAt).to.not.be.above(lastUpdatedAt);
+      expect(notUpdatedCombinedCourse.name).to.equal(otherCombinedCourse.name);
+      expect(updatedCombinedCourse.updatedAt).to.be.above(lastUpdatedAt);
+      expect(updatedCombinedCourse.name).to.equal('new-name');
+    });
+  });
 });

--- a/api/tests/unit/scripts/update-name-of-combined-courses_test.js
+++ b/api/tests/unit/scripts/update-name-of-combined-courses_test.js
@@ -1,0 +1,64 @@
+import { UpdateCombinedCoursesNameScript } from '../../../scripts/prod/update-name-of-combined-courses.js';
+import { DomainTransaction } from '../../../src/shared/domain/DomainTransaction.js';
+import { catchErr, expect, sinon } from '../../test-helper.js';
+
+describe('UpdateNameOfCombinedCoursesScript', function () {
+  let usecasesStub, logger, domainTransactionStub;
+
+  const script = new UpdateCombinedCoursesNameScript();
+
+  beforeEach(function () {
+    usecasesStub = {
+      updateCombinedCourses: sinon.stub().resolves(),
+    };
+    logger = { info: sinon.stub(), error: sinon.stub() };
+    domainTransactionStub = Symbol('domainTransaction');
+    sinon.stub(DomainTransaction, 'execute').callsFake((fn) => fn(domainTransactionStub));
+    sinon.stub(DomainTransaction, 'getConnection').returns({ rollback: sinon.stub() });
+  });
+
+  context('when dry run is true', function () {
+    it('should not update name of combined course', async function () {
+      await script.handle({
+        options: { dryRun: true, combinedCourseIds: [1, 2], newName: 'new-name' },
+        logger,
+        dependencies: usecasesStub,
+      });
+
+      expect(logger.info).to.have.been.calledWith('ROLLBACK due to dryRun');
+    });
+  });
+  context('when dry run is false', function () {
+    it('should call update combined course usecase', async function () {
+      await script.handle({
+        options: { dryRun: false, combinedCourseIds: [1, 2], newName: 'new-name' },
+        logger,
+        dependencies: usecasesStub,
+      });
+
+      expect(usecasesStub.updateCombinedCourses).to.have.been.calledWithExactly({
+        combinedCourseIds: [1, 2],
+        name: 'new-name',
+      });
+    });
+    it('should log accordingly if usecase fails', async function () {
+      //given
+      usecasesStub.updateCombinedCourses
+        .withArgs({
+          combinedCourseIds: [1, 2],
+          name: 'new-name',
+        })
+        .rejects();
+
+      //when
+      await catchErr(script.handle)({
+        options: { combinedCourseIds: [1, 2], newName: 'new-name' },
+        logger,
+        dependencies: usecasesStub,
+      });
+
+      //then
+      expect(logger.error).to.have.been.called;
+    });
+  });
+});


### PR DESCRIPTION
## 🥀 Problème

A partir de janvier 26, nous généralisons les parcours IA dans les établissements scolaires et nous déployons plus largement dans les autres orgas. 

Nous avons facilité la création des blueprints et parcours apprenants mais nous n’avons pas encore attaqué la partie modification.

Pour gérer les demandes urgentes, on trouvait ça intéressant d’avoir quelques requêtes / scripts à dispo pour réagir rapidement. 


## 🏹 Proposition
On écrit un script pour permettre de modifier des noms de parcours combinés à partir d'une liste de parcours combinés donnés.

## ❤️‍🔥 Pour tester
`node ./scripts/prod/update-name-of-combined-courses.js --dryRun=false  --combinedCourseIds='108173, 108234' --newName='nouveau-nom'`
Vérifier que les deux parcours ont bien pris le nom 'nouveau-nom'