### PR TITLE
[TECH] Ajoute des handlers de succès dans la DomainTransaction.

### DIFF
--- a/api/config/feature-toggles-config.js
+++ b/api/config/feature-toggles-config.js
@@ -93,4 +93,11 @@ export default {
     defaultValue: true,
     tags: ['captain', 'backend', 'db', 'pool'],
   },
+  successHandlersForDomainTransaction: {
+    type: 'boolean',
+    description: 'Enable success handlers for DomainTransaction',
+    defaultValue: true,
+    devDefaultValues: { test: true, reviewApp: true },
+    tags: ['captain', 'backend', 'transactions'],
+  },
 };

--- a/api/src/prescription/campaign-participation/domain/usecases/share-campaign-result.js
+++ b/api/src/prescription/campaign-participation/domain/usecases/share-campaign-result.js
@@ -1,3 +1,4 @@
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { UserNotAuthorizedToAccessEntityError } from '../../../../shared/domain/errors.js';
 import { ParticipationResultCalculationJob } from '../models/ParticipationResultCalculationJob.js';
 import { ParticipationSharedJob } from '../models/ParticipationSharedJob.js';
@@ -16,14 +17,16 @@ const shareCampaignResult = async function ({
   campaignParticipation.share();
   await campaignParticipationRepository.updateWithSnapshot(campaignParticipation);
 
-  await participationResultCalculationJobRepository.performAsync(
-    new ParticipationResultCalculationJob({ campaignParticipationId }),
-  );
-  await participationSharedJobRepository.performAsync(
-    new ParticipationSharedJob({
-      campaignParticipationId,
-    }),
-  );
+  await DomainTransaction.addSuccessHandler(async () => {
+    await participationResultCalculationJobRepository.performAsync(
+      new ParticipationResultCalculationJob({ campaignParticipationId }),
+    );
+    await participationSharedJobRepository.performAsync(
+      new ParticipationSharedJob({
+        campaignParticipationId,
+      }),
+    );
+  });
 };
 
 export { shareCampaignResult };

--- a/api/src/shared/domain/DomainTransaction.js
+++ b/api/src/shared/domain/DomainTransaction.js
@@ -1,6 +1,7 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
 
 import { knex } from '../../../db/knex-database-connection.js';
+import { featureToggles } from '../infrastructure/feature-toggles/index.js';
 
 const asyncLocalStorage = new AsyncLocalStorage();
 
@@ -31,8 +32,9 @@ class DomainTransaction {
 
   static async addSuccessHandler(handler) {
     const store = asyncLocalStorage.getStore();
+    const isSuccessHandlerEnabled = await featureToggles.get('successHandlersForDomainTransaction');
 
-    if (store?.transaction) {
+    if (store?.transaction && isSuccessHandlerEnabled) {
       store.transaction.successHandlers.push(handler);
     } else {
       await handler();

--- a/api/src/shared/domain/DomainTransaction.js
+++ b/api/src/shared/domain/DomainTransaction.js
@@ -30,6 +30,23 @@ class DomainTransaction {
       });
   }
 
+  /**
+   *
+   * @param {Function} handler : handler executed after transaction is successful
+   *
+   * @description Important notice: success handlers shall not be massively used
+   * You should be able to declare code to be exectuted after transaction success in a better way
+   * i.e declaring code **after** DomainTransaction.execture call :
+   *  -- myUsecase.js
+   *  function myUsecase() {
+   *    await DomainTransaction.execute(() => {
+   *      -- transactional code
+   *    });
+   *
+   *    -- sending job after transaction is successful
+   *    await myJob.performAsync(payload);
+   *  }
+   */
   static async addSuccessHandler(handler) {
     const store = asyncLocalStorage.getStore();
     const isSuccessHandlerEnabled = await featureToggles.get('successHandlersForDomainTransaction');

--- a/api/src/shared/domain/DomainTransaction.js
+++ b/api/src/shared/domain/DomainTransaction.js
@@ -7,6 +7,7 @@ const asyncLocalStorage = new AsyncLocalStorage();
 class DomainTransaction {
   constructor(knexTransaction) {
     this.knexTransaction = knexTransaction;
+    this.successHandlers = [];
   }
 
   static execute(lambda, transactionConfig) {
@@ -14,17 +15,28 @@ class DomainTransaction {
     if (existingConn.isTransaction) {
       return lambda();
     }
-    return (
-      knex
-        .transaction((trx) => {
-          const domainTransaction = new DomainTransaction(trx);
-          return asyncLocalStorage.run({ transaction: domainTransaction }, lambda, domainTransaction);
-        }, transactionConfig)
-        // Need to re-throw otherwise the error goes silent
-        .catch((err) => {
-          throw err;
-        })
-    );
+    let domainTransaction;
+    return knex
+      .transaction((trx) => {
+        domainTransaction = new DomainTransaction(trx);
+        return asyncLocalStorage.run({ transaction: domainTransaction }, lambda, domainTransaction);
+      }, transactionConfig)
+      .then(async (result) => {
+        for (const handler of domainTransaction.successHandlers) {
+          await handler();
+        }
+        return result;
+      });
+  }
+
+  static async addSuccessHandler(handler) {
+    const store = asyncLocalStorage.getStore();
+
+    if (store?.transaction) {
+      store.transaction.successHandlers.push(handler);
+    } else {
+      await handler();
+    }
   }
 
   /**

--- a/api/src/shared/domain/DomainTransaction.js
+++ b/api/src/shared/domain/DomainTransaction.js
@@ -27,6 +27,9 @@ class DomainTransaction {
           await handler();
         }
         return result;
+      })
+      .finally(() => {
+        domainTransaction.successHandlers = [];
       });
   }
 

--- a/api/tests/shared/integration/domain/DomainTransaction_test.js
+++ b/api/tests/shared/integration/domain/DomainTransaction_test.js
@@ -1,5 +1,5 @@
 import { DomainTransaction, withTransaction } from '../../../../src/shared/domain/DomainTransaction.js';
-import { catchErr, expect, knex } from '../../../../tests/test-helper.js';
+import { catchErr, expect, knex, sinon } from '../../../../tests/test-helper.js';
 
 describe('Shared | Integration | Domain | DomainTransaction', function () {
   context('behaviour when nesting', function () {
@@ -284,6 +284,54 @@ describe('Shared | Integration | Domain | DomainTransaction', function () {
         expect(err.message).to.equal("Let's rollback !");
         const { count } = await knex('features').count('id').first();
         expect(count).to.equal(0);
+      });
+    });
+  });
+
+  context.only('onSuccess management', function () {
+    context('when transaction is committed', function () {
+      it('executes onSuccess handlers after transaction is committed', async function () {
+        const afterSuccessHandler = sinon.stub().resolves();
+        const successHandler1 = sinon.stub().resolves();
+        const successHandler2 = sinon.stub().resolves();
+
+        const result = await DomainTransaction.execute(async () => {
+          await DomainTransaction.addSuccessHandler(successHandler1);
+          await afterSuccessHandler();
+          await DomainTransaction.addSuccessHandler(successHandler2);
+          return 'result';
+        });
+
+        expect(successHandler1.calledAfter(afterSuccessHandler)).to.be.true;
+        expect(successHandler2.calledAfter(successHandler1)).to.be.true;
+        expect(result).to.equal('result');
+      });
+    });
+    context('when transaction is rollbacked', function () {
+      it('does not execute onSuccess handlers after transaction is rollbacked', async function () {
+        const afterSuccessHandler = sinon.stub().rejects(new Error('Error during transaction'));
+        const successHandler = sinon.stub().resolves();
+
+        await expect(
+          DomainTransaction.execute(async () => {
+            await DomainTransaction.addSuccessHandler(successHandler);
+            await afterSuccessHandler();
+            return 'result';
+          }),
+        ).to.be.rejectedWith(Error);
+
+        expect(successHandler).to.not.have.been.called;
+      });
+    });
+    context('when there is no transactions', function () {
+      it('executes onSuccess handlers immediately', async function () {
+        const afterSuccessHandler = sinon.stub().resolves();
+        const successHandler = sinon.stub().resolves();
+
+        await DomainTransaction.addSuccessHandler(successHandler);
+        await afterSuccessHandler();
+
+        expect(successHandler.calledBefore(afterSuccessHandler)).to.be.true;
       });
     });
   });

--- a/api/tests/shared/integration/domain/DomainTransaction_test.js
+++ b/api/tests/shared/integration/domain/DomainTransaction_test.js
@@ -338,6 +338,35 @@ describe('Shared | Integration | Domain | DomainTransaction', function () {
       });
     });
 
+    context('when success handlers are defined in deeper functions', function () {
+      it('executes onSuccess handlers after transaction is committed', async function () {
+        const firstCallProcess = sinon.stub().resolves();
+        const secondCallProcess = sinon.stub().resolves();
+        const firstCallSuccessHandler = sinon.stub().resolves();
+        const secondCallSuccessHandler = sinon.stub().resolves();
+
+        async function firstCall() {
+          await DomainTransaction.addSuccessHandler(firstCallSuccessHandler);
+          await firstCallProcess();
+        }
+        async function secondCall() {
+          await DomainTransaction.addSuccessHandler(secondCallSuccessHandler);
+          await secondCallProcess();
+        }
+
+        const myTransaction = withTransaction(async () => {
+          await firstCall();
+          await secondCall();
+        });
+        await myTransaction();
+
+        expect(secondCallProcess.calledAfter(firstCallProcess)).to.be.true;
+        expect(firstCallSuccessHandler.calledAfter(secondCallProcess)).to.be.true;
+        expect(secondCallSuccessHandler.calledAfter(secondCallProcess)).to.be.true;
+        expect(secondCallSuccessHandler.calledAfter(firstCallSuccessHandler)).to.be.true;
+      });
+    });
+
     context('when successHandlersForDomainTransaction feature toggle is disabled', function () {
       it('executes onSuccess handlers immediately', async function () {
         await featureToggles.set('successHandlersForDomainTransaction', false);

--- a/api/tests/shared/integration/domain/DomainTransaction_test.js
+++ b/api/tests/shared/integration/domain/DomainTransaction_test.js
@@ -1,4 +1,5 @@
 import { DomainTransaction, withTransaction } from '../../../../src/shared/domain/DomainTransaction.js';
+import { featureToggles } from '../../../../src/shared/infrastructure/feature-toggles/index.js';
 import { catchErr, expect, knex, sinon } from '../../../../tests/test-helper.js';
 
 describe('Shared | Integration | Domain | DomainTransaction', function () {
@@ -288,7 +289,7 @@ describe('Shared | Integration | Domain | DomainTransaction', function () {
     });
   });
 
-  context.only('onSuccess management', function () {
+  context('onSuccess management', function () {
     context('when transaction is committed', function () {
       it('executes onSuccess handlers after transaction is committed', async function () {
         const afterSuccessHandler = sinon.stub().resolves();
@@ -307,6 +308,7 @@ describe('Shared | Integration | Domain | DomainTransaction', function () {
         expect(result).to.equal('result');
       });
     });
+
     context('when transaction is rollbacked', function () {
       it('does not execute onSuccess handlers after transaction is rollbacked', async function () {
         const afterSuccessHandler = sinon.stub().rejects(new Error('Error during transaction'));
@@ -323,6 +325,7 @@ describe('Shared | Integration | Domain | DomainTransaction', function () {
         expect(successHandler).to.not.have.been.called;
       });
     });
+
     context('when there is no transactions', function () {
       it('executes onSuccess handlers immediately', async function () {
         const afterSuccessHandler = sinon.stub().resolves();
@@ -332,6 +335,27 @@ describe('Shared | Integration | Domain | DomainTransaction', function () {
         await afterSuccessHandler();
 
         expect(successHandler.calledBefore(afterSuccessHandler)).to.be.true;
+      });
+    });
+
+    context('when successHandlersForDomainTransaction feature toggle is disabled', function () {
+      it('executes onSuccess handlers immediately', async function () {
+        await featureToggles.set('successHandlersForDomainTransaction', false);
+
+        const inTransactionFunction = sinon.stub().resolves();
+        const successHandler1 = sinon.stub().resolves();
+        const successHandler2 = sinon.stub().resolves();
+
+        const result = await DomainTransaction.execute(async () => {
+          await DomainTransaction.addSuccessHandler(successHandler1);
+          await inTransactionFunction();
+          await DomainTransaction.addSuccessHandler(successHandler2);
+          return 'result';
+        });
+
+        expect(successHandler1.calledBefore(inTransactionFunction)).to.be.true;
+        expect(inTransactionFunction.calledBefore(successHandler2)).to.be.true;
+        expect(result).to.equal('result');
       });
     });
   });

--- a/api/tests/shared/unit/domain/DomainTransaction_test.js
+++ b/api/tests/shared/unit/domain/DomainTransaction_test.js
@@ -89,7 +89,7 @@ describe('Unit | Infrastructure | DomainTransaction', function () {
       sinon.stub(knex, 'transaction');
       knex.transaction.callsFake(async (fn) => fn(transactionStub));
 
-      const myUseCase = withTransaction(function () {
+      const myUseCase = withTransaction(async function () {
         // Something
       });
       await myUseCase();

--- a/api/tests/shared/unit/domain/DomainTransaction_test.js
+++ b/api/tests/shared/unit/domain/DomainTransaction_test.js
@@ -73,8 +73,8 @@ describe('Unit | Infrastructure | DomainTransaction', function () {
     it('should get transaction from store', async function () {
       const transactionStub = { commit: sinon.stub() };
       sinon.stub(knex, 'transaction');
-      knex.transaction.callsFake(async () => transactionStub);
-      const myUseCase = withTransaction(() => {
+      knex.transaction.callsFake(async (fn) => fn(transactionStub));
+      const myUseCase = withTransaction(async () => {
         return DomainTransaction.getConnection();
       });
       const connection = await myUseCase();


### PR DESCRIPTION
## 🥀 Problème

Actuellement, l'envoi des jobs PGBoss est transactionnel, il réutilise la transaction en cours afin d'annuler leur envoi en cas d'erreur dans la transaction.

Ce comportement nous empêche de migrer vers la version 12 de PGBoss ainsi que d'utiliser une base dédiée pour les jobs PGBoss (ce qui permettrait de décharger la BDD).

## 🏹 Proposition

Le comportement attendu est de pouvoir exécuter des traitements (envoie de job) quand la transaction s'est terminée avec succès. 

Dans la plupart des cas, il est déjà possible et recommandé de lancer le job après la transaction (à noter qu'il ne faut pas utiliser `withTransaction`) : 
```js
// myUsecase.js
function myUsecase() {
  await DomainTransaction.execute(() => {
    // mon code transactionnel...
  });

  // envoi du job après que la transaction soit commitée
  await myJob.performAsync(payload);
}
```

Mais actuellement certains choix de design nous empêchent de se placer après la transaction. Par exemple, l'utilisation de `withTransaction` qui englobe toute la fonction ou les usecases nestés (utilisation d'API internes...)

Nous proposons la notion des `success handlers` sur le `DomainTransaction`. Ils permettent d'enregistrer des fonctions à tout moment dans une transaction (même dans les cas de nesting) et seront exécutés à la fin.

```js
// myUsecase.js
function myUsecase() {
  await DomainTransaction.execute(() => {
    // mon code transactionnel...
    
    await myRepoOrApi.doWhatever();
    
    // mon code transactionnel...
  });
}

// myRepoOrApi.js
async function doWhatever() {
  // mon code transactionnel...

  // Ajout du job dans le success handler
  await DomainTransaction.addSuccessHandler(async () => {
    await myJob.performAsync(payload);
  });

  // mon code transactionnel...
}
```

Ici le job sera lancé quand tout le traitement transactionnel est exécuté correctement. Si une erreur est lancée, la transaction est rollback et le job n'est pas lancé.


## 💌 Remarques

Cette nouvelle fonctionnalité est activable par le feature toggle `successHandlersForDomainTransaction`. S'il est désactivé, on conserve le comportement actuel.

⚠️ **Il y a un risque de "Memory leak",** si on ajoute des milliers de handlers dans une transaction. 
- Il faut toujours préféré l'exemple 1 : faire les traitements après la transaction.
- Il faut utiliser `DomainTransaction.addSuccessHandler` uniquement si on a besoin qu'il soit conditionné par une transaction réussie.
- Ne pas utiliser `DomainTransaction.addSuccessHandler` si des centaines ou milliers de handlers seront enregistrés (dans une boucle for par exemple).
- **QUESTION : Faut-il ajouter une limite max de handler pour s'en prémunir (en jetant une exception à l'ajout des handlers) ?**

## ❤️‍🔥 Pour tester

1. Activer le FT `successHandlersForDomainTransaction`
2. Faire une participation à une campagne et la partager.
3. Vérifier qu'il n'y a pas d'erreur et que les jobs ont bien été exécutés.
