### PR TITLE
[TECH] Ajouter minimumAnswersRequiredToValidateACertification dans les seeds certif (PIX-21685).

### DIFF
--- a/api/db/seeds/data/team-certification/shared/common-certification-versions.js
+++ b/api/db/seeds/data/team-certification/shared/common-certification-versions.js
@@ -140,6 +140,7 @@ export class CommonCertificationVersions {
         challengesConfiguration: JSON.stringify(CHALLENGES_CONFIGURATION),
         globalScoringConfiguration: JSON.stringify(GLOBAL_SCORING_CONFIGURATION),
         competencesScoringConfiguration: JSON.stringify(COMPETENCES_SCORING_CONFIGURATION),
+        minimumAnswersRequiredToValidateACertification: MINIMUM_ANSWERS_REQUIRED_TO_VALIDATE_A_CERTIFICATION,
       });
     await databaseBuilder.commit();
   }
@@ -231,6 +232,8 @@ export class CommonCertificationVersions {
     return currentVersionId;
   }
 }
+
+const MINIMUM_ANSWERS_REQUIRED_TO_VALIDATE_A_CERTIFICATION = 20;
 
 const CHALLENGES_CONFIGURATION = {
   maximumAssessmentLength: 32,


### PR DESCRIPTION
## 🥀 Problème

La colonne `minimumAnswersRequiredToValidateACertification` a été ajoutée à la table `certification_versions`.
Dans le repository `scoring-configuration-repository.js` on lève une erreur si cette valeur n'est pas définie.

Et malheureusement, on a oublié de modifier les seeds en conséquence 😕 

## 🏹 Proposition

Définir la propriété dans les seeds certif.

## ❤️‍🔥 Pour tester

✅ Lancer les seeds en local, tout devrait bien se passer !
