### PR TITLE
[FEATURE] Les radio button des QCU ne sont plus visibles dans les modules (PIX-21644).

### DIFF
--- a/mon-pix/app/components/module/element/_qcm.scss
+++ b/mon-pix/app/components/module/element/_qcm.scss
@@ -15,31 +15,6 @@
 
   &__proposals, &__short-proposals, &__3-short-proposals {
     margin: var(--pix-spacing-4x) 0;
-
-    @media (not (prefers-reduced-motion: reduce)) {
-      .pix-label-wrapped--state-success,
-      .pix-label-wrapped--state-error {
-        transition:
-          border 0.25s 0.25s,
-          color 0.25s 0.25s;
-      }
-    }
-
-    .pix-checkbox .pix-label-wrapped--state-error {
-      color: var(--pix-warning-700);
-      background-color: var(--state-background-color);
-      border-color: var(--pix-warning-700);
-
-      --state-background-color: var(--pix-warning-50);
-    }
-
-    .pix-checkbox .pix-label-wrapped--state-success {
-      color: var(--pix-success-700);
-      background-color: var(--state-background-color);
-      border-color: var(--pix-success-700);
-
-      --state-background-color: var(--pix-success-50);
-    }
   }
 
   &__short-proposals, &__3-short-proposals {

--- a/mon-pix/app/components/module/element/_qcu.scss
+++ b/mon-pix/app/components/module/element/_qcu.scss
@@ -15,31 +15,6 @@
 
   &__proposals, &__short-proposals, &__3-short-proposals {
     margin: var(--pix-spacing-4x) 0;
-
-    @media (not (prefers-reduced-motion: reduce)) {
-      .pix-label-wrapped--state-success,
-      .pix-label-wrapped--state-error {
-        transition:
-          border 0.25s 0.25s,
-          color 0.25s 0.25s;
-      }
-    }
-
-    .pix-radio-button .pix-label-wrapped--state-error {
-      color: var(--pix-warning-700);
-      background-color: var(--state-background-color);
-      border-color: var(--pix-warning-700);
-
-      --state-background-color: var(--pix-warning-50);
-    }
-
-    .pix-radio-button .pix-label-wrapped--state-success {
-      color: var(--pix-success-700);
-      background-color: var(--state-background-color);
-      border-color: var(--pix-success-700);
-
-      --state-background-color: var(--pix-success-50);
-    }
   }
 
   &__short-proposals, &__3-short-proposals {

--- a/mon-pix/app/components/module/element/qcm.gjs
+++ b/mon-pix/app/components/module/element/qcm.gjs
@@ -162,7 +162,7 @@ export default class ModuleQcm extends ModuleElement {
               name={{this.element.id}}
               @isDisabled={{this.disableInput}}
               @state={{this.getProposalState proposal.id}}
-              @variant="tile"
+              @variant="modulix"
               {{on "click" (fn this.checkboxSelected proposal.id)}}
             >
               <:label>{{htmlUnsafe proposal.content}}</:label>

--- a/mon-pix/app/components/module/element/qcu.gjs
+++ b/mon-pix/app/components/module/element/qcu.gjs
@@ -146,7 +146,7 @@ export default class ModuleQcu extends ModuleElement {
               @value={{proposal.id}}
               @isDisabled={{this.disableInput}}
               @state={{this.getProposalState proposal.id}}
-              @variant="tile"
+              @variant="modulix"
               {{on "click" (fn this.radioClicked proposal.id)}}
             >
               <:label>

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -14,7 +14,7 @@
         "@1024pix/ember-testing-library": "^3.0.27",
         "@1024pix/epreuves-components": "^2.8.1",
         "@1024pix/eslint-plugin": "^2.1.17",
-        "@1024pix/pix-ui": "^58.4.9",
+        "@1024pix/pix-ui": "github:1024pix/pix-ui#PIX-21644-hide-radio-button-on-radio-button-tile",
         "@1024pix/stylelint-config": "^5.1.37",
         "@babel/eslint-parser": "^7.25.1",
         "@babel/plugin-proposal-decorators": "^7.24.7",
@@ -844,15 +844,14 @@
       }
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "58.4.9",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-58.4.9.tgz",
-      "integrity": "sha512-sK/F8C/TPKQmkdr0V0wCA782khKwCmNxJhzZ1TjFuLleawGNwbnRALx463wkf/wMpWcaVmmxFl+cXcGsBYjryw==",
+      "version": "59.0.0",
+      "resolved": "git+ssh://git@github.com/1024pix/pix-ui.git#0272d02523d0a949be8a5963c7d4e62a22eacee5",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.2",
-        "@formatjs/intl": "^3.0.0",
+        "@formatjs/intl": "^4.0.0",
         "check-engine": "^1.14.0",
         "ember-auto-import": "^2.7.4",
         "ember-cli-babel": "^8.2.0",
@@ -868,84 +867,6 @@
       },
       "engines": {
         "node": "^20 || ^22 || ^24"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/@formatjs/ecma402-abstract": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.6.tgz",
-      "integrity": "sha512-HJnTFeRM2kVFVr5gr5kH1XP6K0JcJtE7Lzvtr3FS/so5f1kpsqqqxy5JF+FRaO6H2qmcMfAUIox7AJteieRtVw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@formatjs/fast-memoize": "2.2.7",
-        "@formatjs/intl-localematcher": "0.6.2",
-        "decimal.js": "^10.4.3",
-        "tslib": "^2.8.0"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/@formatjs/fast-memoize": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.7.tgz",
-      "integrity": "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/@formatjs/icu-messageformat-parser": {
-      "version": "2.11.4",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.4.tgz",
-      "integrity": "sha512-7kR78cRrPNB4fjGFZg3Rmj5aah8rQj9KPzuLsmcSn4ipLXQvC04keycTI1F7kJYDwIXtT2+7IDEto842CfZBtw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "2.3.6",
-        "@formatjs/icu-skeleton-parser": "1.8.16",
-        "tslib": "^2.8.0"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/@formatjs/icu-skeleton-parser": {
-      "version": "1.8.16",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.16.tgz",
-      "integrity": "sha512-H13E9Xl+PxBd8D5/6TVUluSpxGNvFSlN/b3coUp0e0JpuWXXnQDiavIpY3NnvSp4xhEMoXyyBvVfdFX8jglOHQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "2.3.6",
-        "tslib": "^2.8.0"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/@formatjs/intl": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl/-/intl-3.1.8.tgz",
-      "integrity": "sha512-LWXgwI5zTMatvR8w8kCNh/priDTOF/ZssokMBHJ7ZWXFoYLVOYo0EJERD9Eajv+xsfQO1QkuAt77KWQ1OI4mOQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "2.3.6",
-        "@formatjs/fast-memoize": "2.2.7",
-        "@formatjs/icu-messageformat-parser": "2.11.4",
-        "intl-messageformat": "10.7.18",
-        "tslib": "^2.8.0"
-      },
-      "peerDependencies": {
-        "typescript": "^5.6.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/@formatjs/intl-localematcher": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.2.tgz",
-      "integrity": "sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.8.0"
       }
     },
     "node_modules/@1024pix/pix-ui/node_modules/ember-cli-htmlbars": {
@@ -972,19 +893,6 @@
       },
       "engines": {
         "node": "12.* || 14.* || >= 16"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/intl-messageformat": {
-      "version": "10.7.18",
-      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.18.tgz",
-      "integrity": "sha512-m3Ofv/X/tV8Y3tHXLohcuVuhWKo7BBq62cqY15etqmLxg2DZ34AGGgQDeR+SCta2+zICb1NX83af0GJmbQ1++g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "2.3.6",
-        "@formatjs/fast-memoize": "2.2.7",
-        "@formatjs/icu-messageformat-parser": "2.11.4",
-        "tslib": "^2.8.0"
       }
     },
     "node_modules/@1024pix/pix-ui/node_modules/semver": {

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -47,7 +47,7 @@
     "@1024pix/ember-testing-library": "^3.0.27",
     "@1024pix/epreuves-components": "^2.8.1",
     "@1024pix/eslint-plugin": "^2.1.17",
-    "@1024pix/pix-ui": "^58.4.9",
+    "@1024pix/pix-ui": "github:1024pix/pix-ui#PIX-21644-hide-radio-button-on-radio-button-tile",
     "@1024pix/stylelint-config": "^5.1.37",
     "@babel/eslint-parser": "^7.25.1",
     "@babel/plugin-proposal-decorators": "^7.24.7",


### PR DESCRIPTION
## 🥀 Problème

La nouvelle feature des "réponses courtes" dans les modules apporte une modification importante dans les QCU. On ne veut plus voir les radio button, afin que les réponses ressemblent visuellement aux QCU déclaratifs et découverte.

## 🏹 Proposition

Les modifications ont été effectués sur Pix UI pour modifier le composant PixRadioButton dont on se sert dans le QCU.
On applique le nouveau variant modulix et on supprime la gestion de la couleur, désormais géré dans Pix UI

## 💌 Remarques

> [!CAUTION]
>  Cette PR dépend de Pix UI, elle ne peut être mergé sans : https://github.com/1024pix/pix-ui/pull/987 

## ❤️‍🔥 Pour tester
https://app-pr15199.review.pix.fr/modules/6a68bf32/bac-a-sable/details

Non régression du comportement des QCM (couleur/focus etc...)
Pour les QCU : 
- pas de radio button ( vérifier sur plusieurs navigateurs )
- Bons comportement couleurs
- Bons comportement clavier
- Comme le radio button n'existe plus, c'est le contour qui reste visible quand on clique sur une réponse avant de valider.