### PR TITLE
[FEATURE] Ajoute une colonne questId sur combined course blueprint 

### DIFF
--- a/api/db/migrations/20260223084910_adds-questId-on-combined-course-blueprint.js
+++ b/api/db/migrations/20260223084910_adds-questId-on-combined-course-blueprint.js
@@ -1,0 +1,28 @@
+const TABLE_NAME = 'combined_course_blueprints';
+const COLUMN_NAME = 'questId';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table
+      .integer(COLUMN_NAME)
+      .defaultTo(null)
+      .references('quests.id')
+      .comment('The id of the quest used to attribute rewards - optional');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## 🥀 Problème
On souhaite pouvoir créer des quêtes au moment de la création du blueprint de parcours combiné afin de renseigner une attestation sur un blueprint.

## 🏹 Proposition
On ajoute une colonne questId sur la table des combined course blueprints.

## ❤️‍🔥 Pour tester
Vérifier que la colonne est bien présente en faisant \d combined_course_blueprints.