### PR TITLE
[FEATURE] Ne plus mettre zéro crédit par défault lors de la création en masse d'organisations (PIX-21580)

### DIFF
--- a/api/src/organizational-entities/domain/models/OrganizationForAdmin.js
+++ b/api/src/organizational-entities/domain/models/OrganizationForAdmin.js
@@ -5,7 +5,6 @@ import isEmpty from 'lodash/isEmpty.js';
 import { ORGANIZATION_FEATURE } from '../../../shared/domain/constants.js';
 import { DataProtectionOfficer } from './DataProtectionOfficer.js';
 
-const CREDIT_DEFAULT_VALUE = 0;
 const PAD_TARGET_LENGTH = 3;
 const PAD_STRING = '0';
 
@@ -27,7 +26,7 @@ class OrganizationForAdmin {
     externalId,
     provinceCode,
     isManagingStudents,
-    credit = CREDIT_DEFAULT_VALUE,
+    credit = null,
     email,
     documentationUrl,
     createdBy,

--- a/api/src/organizational-entities/domain/validators/organization-with-tags-and-target-profiles.js
+++ b/api/src/organizational-entities/domain/validators/organization-with-tags-and-target-profiles.js
@@ -31,8 +31,9 @@ const schema = Joi.object({
     }),
   identityProviderForCampaigns: Joi.string().allow(null),
   provinceCode: Joi.string().allow('', null),
-  credit: Joi.number().default(0).messages({
+  credit: Joi.number().min(0).allow(null).messages({
     'number.base': 'Le crédit doit être un entier.',
+    'number.min': 'Le crédit doit être un nombre entier positif.',
   }),
   emailInvitations: Joi.string().email().allow('', null).messages({
     'string.email': "L'email fourni n'est pas valide.",

--- a/api/src/shared/infrastructure/serializers/csv/csv-serializer.js
+++ b/api/src/shared/infrastructure/serializers/csv/csv-serializer.js
@@ -149,7 +149,8 @@ async function deserializeForOrganizationsImport(file) {
           columnName === 'parentOrganizationId' ||
           columnName === 'administrationTeamId' ||
           columnName === 'countryCode' ||
-          columnName === 'organizationLearnerTypeId'
+          columnName === 'organizationLearnerTypeId' ||
+          columnName === 'credit'
         ) {
           value = parseInt(value, 10);
         }
@@ -157,9 +158,6 @@ async function deserializeForOrganizationsImport(file) {
           value = value.replaceAll(' ', '').toLowerCase();
         }
       } else {
-        if (columnName === 'credit') {
-          value = 0;
-        }
         if (
           columnName === 'identityProviderForCampaigns' ||
           columnName === 'DPOFirstName' ||
@@ -170,7 +168,8 @@ async function deserializeForOrganizationsImport(file) {
           columnName === 'emailForSCOActivation' ||
           columnName === 'administrationTeamId' ||
           columnName === 'countryCode' ||
-          columnName === 'organizationLearnerTypeId'
+          columnName === 'organizationLearnerTypeId' ||
+          columnName === 'credit'
         ) {
           value = null;
         }

--- a/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
@@ -74,7 +74,7 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
 
       const buffer =
         'type,externalId,name,provinceCode,credit,createdBy,documentationUrl,identityProviderForCampaigns,isManagingStudents,emailForSCOActivation,DPOFirstName,DPOLastName,DPOEmail,emailInvitations,organizationInvitationRole,locale,tags,targetProfiles,administrationTeamId,parentOrganizationId,countryCode,organizationLearnerTypeId\n' +
-        `SCO,ANNEGRAELLE,Orga des Anne-Graelle,33700,666,${superAdminUserId},url.com,,true,,Anne,Graelle,anne-graelle@example.net,,ADMIN,fr,GRAS_GARGOUILLE,${targetProfileId},1234,,99100,${organizationLearnerTypeId}\n` +
+        `SCO,ANNEGRAELLE,Orga des Anne-Graelle,33700,,${superAdminUserId},url.com,,true,,Anne,Graelle,anne-graelle@example.net,,ADMIN,fr,GRAS_GARGOUILLE,${targetProfileId},1234,,99100,${organizationLearnerTypeId}\n` +
         `PRO,ANNEGARBURE,Orga des Anne-Garbure,33700,999,${superAdminUserId},,,,,Anne,Garbure,anne-garbure@example.net,,ADMIN,fr,GARBURE,${targetProfileId},1234,${parentOrganizationId},99100,${organizationLearnerTypeId}`;
 
       // when
@@ -99,7 +99,7 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
         externalId: 'ANNEGRAELLE',
         name: 'Orga des Anne-Graelle',
         provinceCode: '33700',
-        credit: 666,
+        credit: null,
         createdBy: superAdminUserId,
         documentationUrl: 'url.com',
         identityProviderForCampaigns: null,

--- a/api/tests/organizational-entities/integration/domain/validators/organization-with-tags-and-target-profiles.test.js
+++ b/api/tests/organizational-entities/integration/domain/validators/organization-with-tags-and-target-profiles.test.js
@@ -65,6 +65,20 @@ describe('Unit | Domain | Validators | organization-with-tags-and-target-profile
         });
       });
     });
+
+    it('should allow null for credit', function () {
+      // given
+      const organization = {
+        ...DEFAULT_ORGANIZATION,
+        credit: null,
+      };
+
+      // when
+      const result = validate(organization);
+
+      // then
+      expect(result).to.be.true;
+    });
   });
 
   context('error', function () {
@@ -306,6 +320,46 @@ describe('Unit | Domain | Validators | organization-with-tags-and-target-profile
         expect(error.invalidAttributes).to.deep.include({
           attribute: 'organizationLearnerTypeId',
           message: "L'id du public prescrit n'est pas un nombre",
+        });
+      });
+    });
+
+    context('credit validation', function () {
+      it('returns an EntityValidation error when credit is neither a number nor null', function () {
+        // given
+        const organization = {
+          ...DEFAULT_ORGANIZATION,
+          credit: 'String credit',
+        };
+
+        // when
+        const error = catchErrSync(validate)(organization);
+
+        // then
+        expect(error).to.be.instanceOf(EntityValidationError);
+        expect(error.message).to.equal(`Échec de validation de l'entité.`);
+        expect(error.invalidAttributes).to.deep.include({
+          attribute: 'credit',
+          message: 'Le crédit doit être un entier.',
+        });
+      });
+
+      it('returns an EntityValidation error when credit is not a positive number', function () {
+        // given
+        const organization = {
+          ...DEFAULT_ORGANIZATION,
+          credit: -1,
+        };
+
+        // when
+        const error = catchErrSync(validate)(organization);
+
+        // then
+        expect(error).to.be.instanceOf(EntityValidationError);
+        expect(error.message).to.equal(`Échec de validation de l'entité.`);
+        expect(error.invalidAttributes).to.deep.include({
+          attribute: 'credit',
+          message: 'Le crédit doit être un nombre entier positif.',
         });
       });
     });

--- a/api/tests/organizational-entities/unit/domain/models/OrganizationForAdmin_test.js
+++ b/api/tests/organizational-entities/unit/domain/models/OrganizationForAdmin_test.js
@@ -25,6 +25,16 @@ describe('Unit | Organizational Entities | Domain | Model | OrganizationForAdmin
         expect(organization.documentationUrl).to.be.null;
       });
     });
+
+    context('when credit is undefined', function () {
+      it('should set credit to null', function () {
+        // when
+        const organization = new OrganizationForAdmin({ credit: undefined });
+
+        // then
+        expect(organization.credit).to.be.null;
+      });
+    });
   });
 
   describe('features', function () {


### PR DESCRIPTION
## 🥀 Problème

Lors d'une création d'orgas en masse, si les crédits ne sont pas renseignés, on met leur valeur par défaut à zéro. Or ce n'est plus le comportement qu'on veut. On va progressivement se débarasser de l'utilisation des crédits donc on ne veut pas mettre de vraie valeur par défaut (zéro étant une véritable valeur et pas une absence de valeur dans notre cas).

## 🏹 Proposition

S'aligner avec la création unitaire (la possibilité de mettre des crédits a déjà carrément disparu) et mettre une valeur null si aucun crédit n'est renseigné.

## 💌 Remarques
RAS

## ❤️‍🔥 Pour tester

Sur Pix Admin:
- Aller sur l'onglet Administration -> Déploiement -> Création d'organisations en masse
- télécharger un template de CSV 
- le remplir sans renseigner de crédits
- constater sur l'organisation créée l'absence de valeur sur le champ "Crédits" et pas 0