### PR TITLE
[FEATURE] Tracker les clics sur les boutons de campagne depuis un parcours apprenant (PIX-21663)

### DIFF
--- a/orga/app/components/combined-course/header.gjs
+++ b/orga/app/components/combined-course/header.gjs
@@ -1,5 +1,7 @@
 import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
 import PixIndicatorCard from '@1024pix/pix-ui/components/pix-indicator-card';
+import { on } from '@ember/modifier';
+import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
@@ -7,9 +9,11 @@ import ActivityType from 'pix-orga/components/activity-type';
 import CopyPasteButton from 'pix-orga/components/copy-paste-button';
 import Breadcrumb from 'pix-orga/components/ui/breadcrumb';
 import PageTitle from 'pix-orga/components/ui/page-title';
+import { EVENT_NAME } from 'pix-orga/helpers/metrics-event-name';
 
 export default class CombinedCourseHeader extends Component {
   @service intl;
+  @service pixMetrics;
 
   get breadcrumbLinks() {
     return [
@@ -31,6 +35,11 @@ export default class CombinedCourseHeader extends Component {
     return index + 1;
   }
 
+  @action
+  trackCampaignClick() {
+    this.pixMetrics.trackEvent(EVENT_NAME.COMBINED_COURSE.VIEW_CAMPAIGN_CLICK);
+  }
+
   <template>
     <PageTitle>
       <:breadcrumb>
@@ -46,7 +55,12 @@ export default class CombinedCourseHeader extends Component {
           {{#if @campaignIds.length}}
             <div class="combined-course-page__campaigns">
               {{#each @campaignIds as |campaignId index|}}
-                <PixButtonLink @route="authenticated.campaigns.campaign" @model={{campaignId}} @variant="primary">
+                <PixButtonLink
+                  {{on "click" this.trackCampaignClick}}
+                  @route="authenticated.campaigns.campaign"
+                  @model={{campaignId}}
+                  @variant="primary"
+                >
                   {{t "pages.combined-course.campaigns" count=@campaignIds.length index=(this.getCampaignIndex index)}}
                 </PixButtonLink>
               {{/each}}

--- a/orga/app/helpers/metrics-event-name.js
+++ b/orga/app/helpers/metrics-event-name.js
@@ -6,4 +6,7 @@ export const EVENT_NAME = {
   CAMPAIGN: {
     EXPORT_DATA_CLICK: 'campaignExportDataResultClick',
   },
+  COMBINED_COURSE: {
+    VIEW_CAMPAIGN_CLICK: 'combinedCourseViewCampaignClick',
+  },
 };


### PR DESCRIPTION
## 🦆 Problème

Il n'est pas possible de mesurer combien d'utilisateurs consultent une campagne depuis la page d'un parcours apprenant dans Pix Orga.

## 🎯 Proposition

Ajout d'un événement Plausible \`combinedCourseViewCampaignClick\` lors du clic sur un bouton de consultation d'une campagne depuis la page d'un parcours apprenant.

## 🔍 Pour tester
- Se connecter à Pix Orga et naviguer vers un parcours apprenant
- Cliquer sur un bouton de consultation d'une campagne
- Vérifier dans Plausible que l'événement `combinedCourseViewCampaignClick`  est bien envoyé et que le funnel fonctionne, je l'ai ajoute a la review également. 

Test en review app:
<img width="994" height="646" alt="image" src="https://github.com/user-attachments/assets/02e58bb6-a23e-4029-a575-3e2581084534" />
