### PR TITLE
[TECH] Ajouter une méthode dans le knex-utils pour faire du "batch update"

### DIFF
--- a/api/db/database-builder/database-builder.js
+++ b/api/db/database-builder/database-builder.js
@@ -227,6 +227,7 @@ export class DatabaseBuilder {
         if (!tableName || tableName === '') return;
         if (tableName === 'pgboss.version') return;
         if (tableName === 'db_type_parsing_test') return;
+        if (tableName === 'batch_update_test') return;
 
         this.#dirtyTables.add(tableName);
       }

--- a/api/src/shared/infrastructure/utils/knex-utils.js
+++ b/api/src/shared/infrastructure/utils/knex-utils.js
@@ -1,6 +1,6 @@
 import { DomainTransaction } from '../../domain/DomainTransaction.js';
 
-const DEFAULT_PAGINATION = {
+export const DEFAULT_PAGINATION = {
   PAGE: 1,
   PAGE_SIZE: 10,
 };
@@ -14,11 +14,11 @@ const DEFAULT_PAGINATION = {
  * @param {Number} params.paginationParams.size - the size of the page
  * @param {object|null} params.countQueryBuilder - a knex query builder that counts the total number of rows, bypassing the default one
  */
-const fetchPage = async ({
+export async function fetchPage({
   queryBuilder,
   paginationParams: { number = DEFAULT_PAGINATION.PAGE, size = DEFAULT_PAGINATION.PAGE_SIZE } = {},
   countQueryBuilder = null,
-}) => {
+}) {
   const knexConn = DomainTransaction.getConnection();
   const page = number < 1 ? 1 : number;
   const offset = (page - 1) * size;
@@ -50,18 +50,116 @@ const fetchPage = async ({
       pageCount: Math.ceil(rowCount / size),
     },
   };
-};
+}
 
-function isUniqConstraintViolated(err) {
+export function isUniqConstraintViolated(err) {
   const PGSQL_UNIQ_CONSTRAINT = '23505';
 
   return err.code === PGSQL_UNIQ_CONSTRAINT;
 }
 
-function foreignKeyConstraintViolated(err) {
+export function foreignKeyConstraintViolated(err) {
   const PGSQL_FK_CONSTRAINT = '23503';
 
   return err.code === PGSQL_FK_CONSTRAINT;
 }
 
-export { DEFAULT_PAGINATION, fetchPage, foreignKeyConstraintViolated, isUniqConstraintViolated };
+/**
+ * Optimized batch update for PG, which result in a query similar as :
+ *
+ * UPDATE "users" AS t
+ * SET
+ *   "firstName" = data."firstName",
+ *   "lastName" = data."lastName"
+ * FROM (
+ *   VALUES
+ *     ($1::integer, $2::character varying(255), $3::character varying(255)),
+ *     ($4::integer, $5::character varying(255), $6::character varying(255)),
+ *     ($7::integer, $8::character varying(255), $9::character varying(255))
+ * ) AS data("id", "firstName", "lastName")
+ * WHERE t."id" = data."id";
+ *
+ * @param {object} params
+ * @param {string} params.tableName - example : 'users'
+ * @param {string} params.schema - example : 'public'
+ * @param {string} params.primaryKeyName - example : 'id'
+ * @param {Array<object>} params.rows - ⚠️objects must have the same keys. example : [{ id: 1, firstName: 'Lolo', lastName: 'Lapraline' }, { id: 2, firstName: 'Roro', lastName: 'Lapistache' }]
+ * @param {number} params.chunkSize - example : 500
+ */
+export async function batchUpdate({ schema = 'public', tableName, primaryKeyName, rows, chunkSize = 500 }) {
+  if (!rows || rows.length === 0) return;
+
+  const knexConn = DomainTransaction.getConnection();
+  const columnTypes = await getColumnTypes(knexConn, tableName, schema);
+  const columns = Object.keys(rows[0]);
+
+  for (const chunk of chunks(rows, chunkSize)) {
+    const values = [];
+    const bindings = [];
+
+    for (const row of chunk) {
+      const rowPlaceholders = columns.map((col) => `?::${columnTypes[col]}`).join(', ');
+      values.push(`(${rowPlaceholders})`);
+      bindings.push(...columns.map((col) => row[col]));
+    }
+
+    const setClause = columns
+      .filter((col) => col !== primaryKeyName)
+      .map((col) => `"${col}" = data."${col}"`)
+      .join(', ');
+
+    const sql = `UPDATE "${schema}"."${tableName}" AS t
+      SET ${setClause}
+      FROM (
+        VALUES ${values.join(', ')}
+      ) AS data(${columns.map((c) => `"${c}"`).join(', ')})
+      WHERE t."${primaryKeyName}" = data."${primaryKeyName}";
+    `;
+
+    // eslint-disable-next-line knex/avoid-injections
+    await knexConn.raw(sql, bindings);
+  }
+}
+
+function chunks(items, size) {
+  const chunks = [];
+  for (let i = 0; i < items.length; i += size) {
+    chunks.push(items.slice(i, i + size));
+  }
+  return chunks;
+}
+
+const tableColumnTypeCache = new Map();
+async function getColumnTypes(knex, tableName, schema = 'public') {
+  const cacheKey = `${schema}.${tableName}`;
+
+  if (tableColumnTypeCache.has(cacheKey)) {
+    return tableColumnTypeCache.get(cacheKey);
+  }
+
+  const result = await knex.raw(
+    `
+    SELECT
+      a.attname AS column_name,
+      format_type(a.atttypid, a.atttypmod) AS formatted_type
+    FROM pg_attribute a
+    JOIN pg_class c ON a.attrelid = c.oid
+    JOIN pg_namespace n ON c.relnamespace = n.oid
+    WHERE c.relname = ?
+      AND n.nspname = ?
+      AND a.attnum > 0
+      AND NOT a.attisdropped
+    `,
+    [tableName, schema],
+  );
+
+  const columnTypes = {};
+
+  for (const row of result.rows) {
+    columnTypes[row.column_name] = row.formatted_type;
+  }
+
+  tableColumnTypeCache.set(cacheKey, columnTypes);
+
+  return columnTypes;
+}

--- a/api/src/shared/infrastructure/utils/knex-utils.js
+++ b/api/src/shared/infrastructure/utils/knex-utils.js
@@ -65,7 +65,7 @@ export function foreignKeyConstraintViolated(err) {
 }
 
 /**
- * Optimized batch update for PG, which result in a query similar as :
+ * Optimized batch update for PG, which results in a query similar as :
  *
  * UPDATE "users" AS t
  * SET
@@ -100,7 +100,7 @@ export async function batchUpdate({ schema = 'public', tableName, primaryKeyName
     for (const row of chunk) {
       const rowPlaceholders = columns.map((col) => `?::${columnTypes[col]}`).join(', ');
       values.push(`(${rowPlaceholders})`);
-      bindings.push(...columns.map((col) => row[col]));
+      bindings.push(...columns.map((col) => row[col] ?? null));
     }
 
     const setClause = columns

--- a/api/tests/shared/integration/infrastructure/utils/knex-utils_test.js
+++ b/api/tests/shared/integration/infrastructure/utils/knex-utils_test.js
@@ -638,7 +638,7 @@ describe('Integration | Infrastructure | Utils | Knex utils', function () {
       ];
       await knex('batch_update_test').insert(insertRows);
 
-      // given
+      // when
       await batchUpdate({
         tableName: 'batch_update_test',
         primaryKeyName: 'id',
@@ -783,7 +783,7 @@ describe('Integration | Infrastructure | Utils | Knex utils', function () {
       ];
       await knex('batch_update_test').insert(insertRows);
 
-      // given
+      // when
       await batchUpdate({
         tableName: 'batch_update_test',
         primaryKeyName: 'id',

--- a/api/tests/shared/integration/infrastructure/utils/knex-utils_test.js
+++ b/api/tests/shared/integration/infrastructure/utils/knex-utils_test.js
@@ -675,7 +675,7 @@ describe('Integration | Infrastructure | Utils | Knex utils', function () {
             smallint_type: null,
             integer_type: null,
             biginteger_type: null,
-            numeric_type: null,
+            numeric_type: undefined,
             float_type: null,
             double_precision_type: null,
             boolean_type: null,

--- a/api/tests/shared/integration/infrastructure/utils/knex-utils_test.js
+++ b/api/tests/shared/integration/infrastructure/utils/knex-utils_test.js
@@ -1,7 +1,11 @@
 import _ from 'lodash';
 
 import { DomainTransaction } from '../../../../../src/shared/domain/DomainTransaction.js';
-import { DEFAULT_PAGINATION, fetchPage } from '../../../../../src/shared/infrastructure/utils/knex-utils.js';
+import {
+  batchUpdate,
+  DEFAULT_PAGINATION,
+  fetchPage,
+} from '../../../../../src/shared/infrastructure/utils/knex-utils.js';
 import { databaseBuilder, expect, knex } from '../../../../test-helper.js';
 
 describe('Integration | Infrastructure | Utils | Knex utils', function () {
@@ -512,6 +516,430 @@ describe('Integration | Infrastructure | Utils | Knex utils', function () {
           });
         }
       });
+    });
+  });
+
+  describe('batchUpdate', function () {
+    beforeEach(async function () {
+      await knex.raw(`
+        CREATE TYPE batch_status AS ENUM ('pending', 'running', 'done', 'failed');
+      `);
+
+      await knex.schema.createTable('batch_update_test', (table) => {
+        table.integer('id').primary();
+        table.string('string_type', 255);
+        table.text('text_type');
+        table.specificType('smallint_type', 'smallint');
+        table.integer('integer_type');
+        table.bigInteger('biginteger_type');
+        table.specificType('numeric_type', 'numeric(12,4)');
+        table.float('float_type');
+        table.specificType('double_precision_type', 'double precision');
+        table.boolean('boolean_type');
+        table.timestamp('timestamp_type', { useTz: false });
+        table.timestamp('timestamptz_type', { useTz: true });
+        table.date('date_type');
+        table.time('time_type');
+        table.specificType('interval_type', 'interval');
+        table.uuid('uuid_type');
+        table.json('json_type');
+        table.jsonb('jsonb_type');
+        table.specificType('array_text_type', 'text[]');
+        table.specificType('array_integer_type', 'integer[]');
+        table.specificType('enum_type', 'batch_status');
+        table.specificType('array_enum_type', 'batch_status[]');
+        table.binary('binary_type');
+      });
+    });
+
+    afterEach(async function () {
+      await knex.schema.dropTableIfExists('batch_update_test');
+      await knex.raw(`DROP TYPE IF EXISTS batch_status CASCADE`);
+    });
+
+    it('can update correctly for all types', async function () {
+      // given
+      const insertRows = [
+        {
+          id: 1,
+          string_type: 'row1_string_type',
+          text_type: 'row1_desc',
+          smallint_type: 1,
+          integer_type: 10,
+          biginteger_type: 100,
+          numeric_type: 1.1111,
+          float_type: 1.1,
+          double_precision_type: 1.11,
+          boolean_type: true,
+          timestamp_type: new Date('2024-01-01T01:00:00Z'),
+          timestamptz_type: new Date('2024-01-01T01:00:00Z'),
+          date_type: '1991-01-01',
+          time_type: '06:00:00',
+          interval_type: '1 hour',
+          uuid_type: '11111111-1111-1111-1111-111111111111',
+          json_type: { row: 1 },
+          jsonb_type: { meta: 1 },
+          array_text_type: ['r1a', 'r1b'],
+          array_integer_type: [1, 2],
+          enum_type: 'pending',
+          array_enum_type: ['pending'],
+          binary_type: Buffer.from('row1_raw'),
+        },
+        {
+          id: 2,
+          string_type: 'row2_string_type',
+          text_type: 'row2_desc',
+          smallint_type: 2,
+          integer_type: 20,
+          biginteger_type: 200,
+          numeric_type: 2.2222,
+          float_type: 2.2,
+          double_precision_type: 2.22,
+          boolean_type: false,
+          timestamp_type: new Date('2024-02-02T02:00:00Z'),
+          timestamptz_type: new Date('2024-02-02T02:00:00Z'),
+          date_type: '1992-02-02',
+          time_type: '07:00:00',
+          interval_type: '2 hours',
+          uuid_type: '22222222-2222-2222-2222-222222222222',
+          json_type: { row: 2 },
+          jsonb_type: { meta: 2 },
+          array_text_type: ['r2a', 'r2b'],
+          array_integer_type: [3, 4],
+          enum_type: 'running',
+          array_enum_type: ['running'],
+          binary_type: Buffer.from('row2_raw'),
+        },
+        {
+          id: 3,
+          string_type: 'row3_string_type',
+          text_type: 'row3_desc',
+          smallint_type: 3,
+          integer_type: 30,
+          biginteger_type: 300,
+          numeric_type: 3.3333,
+          float_type: 3.3,
+          double_precision_type: 3.33,
+          boolean_type: true,
+          timestamp_type: new Date('2024-03-03T03:00:00Z'),
+          timestamptz_type: new Date('2024-03-03T03:00:00Z'),
+          date_type: '1993-03-03',
+          time_type: '08:00:00',
+          interval_type: '3 hours',
+          uuid_type: '33333333-3333-3333-3333-333333333333',
+          json_type: { row: 3 },
+          jsonb_type: { meta: 3 },
+          array_text_type: ['r3a', 'r3b'],
+          array_integer_type: [5, 6],
+          enum_type: 'failed',
+          array_enum_type: ['failed'],
+          binary_type: Buffer.from('row3_raw'),
+        },
+      ];
+      await knex('batch_update_test').insert(insertRows);
+
+      // given
+      await batchUpdate({
+        tableName: 'batch_update_test',
+        primaryKeyName: 'id',
+        rows: [
+          {
+            id: 1,
+            string_type: 'row1_new',
+            text_type: 'row1_desc_new',
+            smallint_type: 11,
+            integer_type: 110,
+            biginteger_type: 1100,
+            numeric_type: 11.1111,
+            float_type: 11.1,
+            double_precision_type: 11.11,
+            boolean_type: false,
+            timestamp_type: new Date('2025-01-01T01:00:00Z'),
+            timestamptz_type: new Date('2025-01-01T01:00:00Z'),
+            date_type: '2001-01-01',
+            time_type: '09:00:00',
+            interval_type: '11 hours',
+            uuid_type: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+            json_type: { row: '1_updated' },
+            jsonb_type: { meta: '1_updated' },
+            array_text_type: ['r1_new'],
+            array_integer_type: [10, 11],
+            enum_type: 'done',
+            array_enum_type: ['running', 'done'],
+            binary_type: Buffer.from('row1_new_raw'),
+          },
+          {
+            id: 2,
+            string_type: null,
+            text_type: null,
+            smallint_type: null,
+            integer_type: null,
+            biginteger_type: null,
+            numeric_type: null,
+            float_type: null,
+            double_precision_type: null,
+            boolean_type: null,
+            timestamp_type: null,
+            timestamptz_type: null,
+            date_type: null,
+            time_type: null,
+            interval_type: null,
+            uuid_type: null,
+            json_type: null,
+            jsonb_type: null,
+            array_text_type: null,
+            array_integer_type: null,
+            enum_type: null,
+            array_enum_type: null,
+            binary_type: null,
+          },
+        ],
+      });
+
+      // then
+      const [r1, r2, r3] = await knex('batch_update_test').orderBy('id');
+      expect(r1).to.deep.include({
+        id: 1,
+        string_type: 'row1_new',
+        text_type: 'row1_desc_new',
+        smallint_type: 11,
+        integer_type: 110,
+        biginteger_type: 1100,
+        numeric_type: '11.1111',
+        float_type: 11.1,
+        double_precision_type: 11.11,
+        boolean_type: false,
+        uuid_type: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+        json_type: { row: '1_updated' },
+        jsonb_type: { meta: '1_updated' },
+        array_text_type: ['r1_new'],
+        array_integer_type: [10, 11],
+        enum_type: 'done',
+        array_enum_type: '{running,done}',
+        binary_type: Buffer.from('row1_new_raw'),
+      });
+
+      expect(r2).to.deep.include({
+        id: 2,
+        string_type: null,
+        text_type: null,
+        smallint_type: null,
+        integer_type: null,
+        biginteger_type: null,
+        numeric_type: null,
+        float_type: null,
+        double_precision_type: null,
+        boolean_type: null,
+        uuid_type: null,
+        json_type: null,
+        jsonb_type: null,
+        array_text_type: null,
+        array_integer_type: null,
+        enum_type: null,
+        array_enum_type: null,
+        binary_type: null,
+      });
+
+      expect(r3).to.deep.include({
+        id: 3,
+        string_type: 'row3_string_type',
+        text_type: 'row3_desc',
+        smallint_type: 3,
+        integer_type: 30,
+        biginteger_type: 300,
+        numeric_type: '3.3333',
+        float_type: 3.3,
+        double_precision_type: 3.33,
+        boolean_type: true,
+        uuid_type: '33333333-3333-3333-3333-333333333333',
+        json_type: { row: 3 },
+        jsonb_type: { meta: 3 },
+        array_text_type: ['r3a', 'r3b'],
+        array_integer_type: [5, 6],
+        enum_type: 'failed',
+        array_enum_type: '{failed}',
+        binary_type: Buffer.from('row3_raw'),
+      });
+    });
+
+    it('can partially update rows', async function () {
+      // given
+      const insertRows = [
+        {
+          id: 1,
+          string_type: 'row1_original',
+          integer_type: 10,
+        },
+        {
+          id: 2,
+          string_type: 'row2_original',
+          integer_type: 20,
+        },
+        {
+          id: 3,
+          string_type: 'row3_original',
+          integer_type: 30,
+        },
+      ];
+      await knex('batch_update_test').insert(insertRows);
+
+      // given
+      await batchUpdate({
+        tableName: 'batch_update_test',
+        primaryKeyName: 'id',
+        rows: [
+          {
+            id: 1,
+            integer_type: 110,
+          },
+          {
+            id: 2,
+            integer_type: null,
+          },
+        ],
+      });
+
+      // then
+      const [r1, r2, r3] = await knex('batch_update_test').orderBy('id');
+      expect(r1).to.deep.include({
+        id: 1,
+        string_type: 'row1_original',
+        text_type: null,
+        integer_type: 110,
+        smallint_type: null,
+        biginteger_type: null,
+        numeric_type: null,
+        float_type: null,
+        double_precision_type: null,
+        boolean_type: null,
+        uuid_type: null,
+        json_type: null,
+        jsonb_type: null,
+        array_text_type: null,
+        array_integer_type: null,
+        enum_type: null,
+        array_enum_type: null,
+        binary_type: null,
+      });
+
+      expect(r2).to.deep.include({
+        id: 2,
+        string_type: 'row2_original',
+        text_type: null,
+        smallint_type: null,
+        integer_type: null,
+        biginteger_type: null,
+        numeric_type: null,
+        float_type: null,
+        double_precision_type: null,
+        boolean_type: null,
+        uuid_type: null,
+        json_type: null,
+        jsonb_type: null,
+        array_text_type: null,
+        array_integer_type: null,
+        enum_type: null,
+        array_enum_type: null,
+        binary_type: null,
+      });
+
+      expect(r3).to.deep.include({
+        id: 3,
+        string_type: 'row3_original',
+        text_type: null,
+        smallint_type: null,
+        integer_type: 30,
+        biginteger_type: null,
+        numeric_type: null,
+        float_type: null,
+        double_precision_type: null,
+        boolean_type: null,
+        uuid_type: null,
+        json_type: null,
+        jsonb_type: null,
+        array_text_type: null,
+        array_integer_type: null,
+        enum_type: null,
+        array_enum_type: null,
+        binary_type: null,
+      });
+    });
+
+    it('does nothing when passing an empty array of rows', async function () {
+      const insertRows = [
+        {
+          id: 1,
+          string_type: 'row1_original',
+        },
+        {
+          id: 2,
+          string_type: 'row2_original',
+        },
+      ];
+      await knex('batch_update_test').insert(insertRows);
+
+      // when
+      await batchUpdate({
+        tableName: 'batch_update_test',
+        primaryKeyName: 'id',
+        rows: [],
+      });
+
+      // then
+      const [r1, r2] = await knex('batch_update_test').orderBy('id');
+      expect(r1).to.deep.include({
+        id: 1,
+        string_type: 'row1_original',
+      });
+
+      expect(r2).to.deep.include({
+        id: 2,
+        string_type: 'row2_original',
+      });
+    });
+
+    it('should chunk updates', async function () {
+      // given
+      const total = 100;
+      const rowsToInsert = [];
+      const rowsToUpdate = [];
+      for (let index = 0; index < total; index++) {
+        rowsToInsert.push({
+          id: index + 1,
+          string_type: `row${index}-original`,
+        });
+        if (index % 2 === 0) {
+          rowsToUpdate.push({
+            id: index + 1,
+            string_type: `row${index}-updated`,
+          });
+        }
+      }
+      await knex('batch_update_test').insert(rowsToInsert);
+      let updateQueryCount = 0;
+      function countUpdatesListener(query) {
+        if (query.sql.startsWith('UPDATE "public"."batch_update_test"')) {
+          updateQueryCount++;
+        }
+      }
+      knex.on('query', countUpdatesListener);
+
+      // when
+      try {
+        await batchUpdate({
+          tableName: 'batch_update_test',
+          primaryKeyName: 'id',
+          rows: rowsToUpdate,
+          chunkSize: 10,
+        });
+      } finally {
+        knex.off('query', countUpdatesListener);
+      }
+
+      // then
+      const countUpdated = await knex('batch_update_test').whereLike('string_type', '%-updated');
+      expect(countUpdated.length).to.equal(50);
+      expect(updateQueryCount).to.equal(5);
     });
   });
 });


### PR DESCRIPTION
## 🥀 Problème

Dans le code on retrouve parfois dans les repositories cette syntaxe :
```js
await knex('my_table').insert(someData).onConflict('id').merge();
```

Cela nous permet de faire :
- des upserts (très pratique, et même documenté dans PG pour faire cette manipulation)
- des batch update

Pour ce second cas, où le développeur **_sait_** que les enregistrements existent déjà, la syntaxe est peu expressive. De plus, l'opération pourrait être plus performante.

## 🏹 Proposition

Voici le genre de SQL généré avec la technique d'aujourd'hui, la stratégie `INSERT ON CONFLICT UPDATE` :

```sql
INSERT INTO "users" ("id", "firstName", "lastName")
VALUES
  ($1, $2, $3),
  ($4, $5, $6),
  ($7, $8, $9)
ON CONFLICT ("id") 
DO UPDATE SET
  "firstName" = EXCLUDED."firstName",
  "lastName" = EXCLUDED."lastName";
```

concrètement que va faire PG pour appliquer cette requête, pour chaque ligne :
- tenter de faire l'INSERT
- vérifier la contrainte d’unicité sur la colonne "id"
- détecter le conflit
- verrouiller la ligne en conflit
- faire l'UPDATE

On a donc un lock, du travail en plus et possiblement de la perte de performance liée à cette stratégie, ce qui est dommage particulièrement dans le cas où on **_sait_** qu'on veut update.

Je propose donc une méthode utilitaire dans le fichier `knex-utils.js` pour faire un `batchUpdate` qui va générer ce SQL équivalent à celui du dessus :

```sql
UPDATE "users" AS t
SET
  "firstName" = data."firstName",
  "lastName" = data."lastName"
FROM (
  VALUES
    ($1::integer, $2::character varying(255), $3::character varying(255)),
    ($4::integer, $5::character varying(255), $6::character varying(255)),
    ($7::integer, $8::character varying(255), $9::character varying(255))
) AS data("id", "firstName", "lastName")
WHERE t."id" = data."id";
```

qui va :
- construire une table temporaire en mémoire (VALUES)
- faire un `JOIN` via clé primaire
- mettre à jour les lignes correspondantes

On remarquera que c'est visuellement un peu moche, mais on n'a pas le choix : vu que la table temporaire n'a pas de colonnes typées, il faut caster pour chaque colonne mise à jour dans la table destination comme il faut. Le code le fait comme il faut car il va récupérer le vrai type de chaque colonne et le remettre dans la requête.

## 💌 Remarques

- Utilise la `DomainTransaction.getConnection()`
- Permet de définir une taille de chunk en cas de gros volumes

Lectures :
[https://www.postgresql.org/docs/current/sql-insert.html](https://www.postgresql.org/docs/current/sql-insert.html) particulièrement la section **ON CONFLICT Clause**


## ❤️‍🔥 Pour tester
Cette méthode n'est pas encore utilisée donc bon c'est surtout pour lancer la discussion
