### PR TITLE
[BUGFIX] Mettre à jour les liens et l'icône du bandeau SCO (PIX-21630)

### DIFF
--- a/orga/tests/integration/components/banner/sco-communication-test.gjs
+++ b/orga/tests/integration/components/banner/sco-communication-test.gjs
@@ -43,7 +43,7 @@ module('Integration | Component | Banner::Sco-communication', function (hooks) {
             assert.ok(screen.getByText(this.intl.t('banners.import.message')));
 
             const downloadLink = screen.getByRole('link', { name: 'télécharger les résultats' });
-            assert.strictEqual(downloadLink.href, 'https://cloud.pix.fr/s/WjTnkSbFs9TDcSC');
+            assert.strictEqual(downloadLink.href, 'https://cloud.pix.fr/s/TBF97QzSni7SWpc');
 
             const importLink = screen.queryByRole('link', { name: 'importer' });
             assert.ok(importLink.href.endsWith('/import-participants'));
@@ -52,7 +52,7 @@ module('Integration | Component | Banner::Sco-communication', function (hooks) {
             assert.strictEqual(createCampaignLink.href, 'https://cloud.pix.fr/s/d7MCSCq2RsSy5Pt');
 
             const certifLink = screen.queryByRole('link', { name: 'En savoir plus sur la certification' });
-            assert.strictEqual(certifLink.href, 'https://cloud.pix.fr/s/opiFxfjygR76S8y');
+            assert.strictEqual(certifLink.href, 'https://cloud.pix.fr/s/nkEoMj9BtHX9EzE');
           });
 
           test('should render the ia sco banner', async function (assert) {

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -72,13 +72,13 @@
       "step2": "Register for the '<'a href='https://app.livestorm.co/pix-1/parcours-intelligence-artificielle-enseignement-scolaire?utm_source=pixorga' class='link link--banner link--bold link--underlined' '>'webinar'</a>'"
     },
     "import": {
-      "ia-message": "📢 '<'a href='https://cloud.pix.fr/s/rrkLPMS5dYGKRQ9' class='link link--banner link--bold link--underlined' '>'New: discover the AI learner journey deployment kit'</a>'",
+      "ia-message": "🚀 '<'a href='https://cloud.pix.fr/s/rrkLPMS5dYGKRQ9' class='link link--banner link--bold link--underlined' '>'New: discover the AI learner journey deployment kit'</a>'",
       "message": "The main stages of the school year :",
-      "step1a": " Setting up&nbsp;: '<'a href='https://cloud.pix.fr/s/WjTnkSbFs9TDcSC' title='Downloading results how-to' class='link link--banner link--bold link--underlined' '>'downloading certification results'</a>' and",
+      "step1a": " Setting up&nbsp;: '<'a href='https://cloud.pix.fr/s/TBF97QzSni7SWpc' title='Downloading results how-to' class='link link--banner link--bold link--underlined' '>'downloading certification results'</a>' and",
       "step1b": "importing",
       "step1c": "the student database (admin)",
       "step2": "'<'a href='https://cloud.pix.fr/s/d7MCSCq2RsSy5Pt' title='Back-to-school how-to' class='link link--banner link--bold link--underlined' '>'Create campaigns'</a>' (back-to-school, 6th grade, thematic, subject-based, targeted courses, etc.).",
-      "step3": "Certify learners. '<'a href='https://cloud.pix.fr/s/opiFxfjygR76S8y' title='Preparing and organising student certification how-to' class='link link--banner link--bold link--underlined' '>'Find out more about the certification'</a>'."
+      "step3": "Certify learners. '<'a href='https://cloud.pix.fr/s/nkEoMj9BtHX9EzE' title='Preparing and organising student certification how-to' class='link link--banner link--bold link--underlined' '>'Find out more about the certification'</a>'."
     },
     "last-places-lot-available": {
       "message": "Please note that your seats will expire in {days, number} days."

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -72,13 +72,13 @@
       "step2": "S'inscrire au '<'a href='https://app.livestorm.co/pix-1/parcours-intelligence-artificielle-enseignement-scolaire?utm_source=pixorga' class='link link--banner link--bold link--underlined' '>'webinaire'</a>'"
     },
     "import": {
-      "ia-message": "📢 '<'a href='https://cloud.pix.fr/s/rrkLPMS5dYGKRQ9' class='link link--banner link--bold link--underlined' '>'Nouveau : découvrez le kit de déploiement des parcours apprenants IA'</a>'",
+      "ia-message": "🚀 '<'a href='https://cloud.pix.fr/s/rrkLPMS5dYGKRQ9' class='link link--banner link--bold link--underlined' '>'Nouveau : découvrez le kit de déploiement des parcours apprenants IA'</a>'",
       "message": "Les grandes étapes de l’année dans l’enseignement scolaire :",
-      "step1a": "Mettre en place&nbsp;: '<'a href='https://cloud.pix.fr/s/WjTnkSbFs9TDcSC' title='Guide télécharger les résultats' class='link link--banner link--bold link--underlined' '>'télécharger les résultats'</a>' de certification et",
+      "step1a": "Mettre en place&nbsp;: '<'a href='https://cloud.pix.fr/s/TBF97QzSni7SWpc' title='Guide télécharger les résultats' class='link link--banner link--bold link--underlined' '>'télécharger les résultats'</a>' de certification et",
       "step1b": "importer",
       "step1c": "la base élèves (admin)",
       "step2": "'<'a href='https://cloud.pix.fr/s/d7MCSCq2RsSy5Pt' title='Guide Lancer les parcours de rentrée' class='link link--banner link--bold link--underlined' '>'Créer les campagnes'</a>' (parcours rentrée, 6e, thématiques, disciplinaires, ciblés…).",
-      "step3": "Certifier les apprenants. '<'a href='https://cloud.pix.fr/s/opiFxfjygR76S8y' title='Guide Préparer et organiser la certification des élèves' class='link link--banner link--bold link--underlined' '>'En savoir plus sur la certification'</a>'."
+      "step3": "Certifier les apprenants. '<'a href='https://cloud.pix.fr/s/nkEoMj9BtHX9EzE' title='Guide Préparer et organiser la certification des élèves' class='link link--banner link--bold link--underlined' '>'En savoir plus sur la certification'</a>'."
     },
     "last-places-lot-available": {
       "message": "Attention, vos places arrivent à échéance dans {days, number} jours."

--- a/orga/translations/it.json
+++ b/orga/translations/it.json
@@ -72,13 +72,13 @@
       "step2": "Registratevi per il '<'a href='https://app.livestorm.co/pix-1/parcours-intelligence-artificielle-enseignement-scolaire?utm_source=pixorga' class='link link--banner link--bold link--underlined' '>'webinar'</a>'."
     },
     "import": {
-      "ia-message": "📢 '<'a href='https://cloud.pix.fr/s/rrkLPMS5dYGKRQ9' class='link link--banner link--bold link--underlined' '>'Novità: scoprite il kit di implementazione dei percorsi di apprendimento IA'</a>'",
+      "ia-message": "🚀 '<'a href='https://cloud.pix.fr/s/rrkLPMS5dYGKRQ9' class='link link--banner link--bold link--underlined' '>'Nuovo: scopri il kit di implementazione dei percorsi di apprendimento IA'</a>'",
       "message": "Fasi chiave dell'anno scolastico :",
-      "step1a": "Implementare : '<'a href='https://cloud.pix.fr/s/WjTnkSbFs9TDcSC' title='Guida scarica risultati' class='link link--banner link--bold link--underlined' '>'scarica risultati'</a>' certificazione e",
+      "step1a": "Implementare : '<'a href='https://cloud.pix.fr/s/TBF97QzSni7SWpc' title='Guida scarica risultati' class='link link--banner link--bold link--underlined' '>'scarica risultati'</a>' certificazione e",
       "step1b": "Importazione",
       "step1c": "database degli studenti (admin)",
       "step2": "'<'a href='https://cloud.pix.fr/s/RaPpKjFHNX2kSR4' title='guida Avviare percorsi di rientro scolastico' class='link link--banner link--bold link--underlined' '>'Creare campagne'</a>' (ritorno a scuola, prima media, corsi tematici, corsi specifici per materia, corsi mirati, ecc.).",
-      "step3": "Certificare gli studenti. '<'a href='https://cloud.pix.fr/s/opiFxfjygR76S8y' title='Guida Preparazione e organizzazione della certificazione degli studenti' class='link link--banner link--bold link--underlined' '>'Per saperne di più sulla certificazione'</a>'."
+      "step3": "Certificare gli studenti. '<'a href='https://cloud.pix.fr/s/nkEoMj9BtHX9EzE' title='Guida Preparazione e organizzazione della certificazione degli studenti' class='link link--banner link--bold link--underlined' '>'Per saperne di più sulla certificazione'</a>'."
     },
     "last-places-lot-available": {
       "message": "I biglietti scadono tra {days, number} giorni."

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -72,13 +72,13 @@
       "step2": "Aanmelden voor het '<'a href='https://app.livestorm.co/pix-1/parcours-intelligence-artificielle-enseignement-scolaire?utm_source=pixorga' class='link link--banner link--bold link--underlined' '>'webinar'</a>'"
     },
     "import": {
-      "ia-message": "📢 '<'a href='https://cloud.pix.fr/s/rrkLPMS5dYGKRQ9' class='link link--banner link--bold link--underlined' '>'Nieuw: ontdek de implementatiekit voor AI-leertrajecten'</a>'",
+      "ia-message": "🚀 '<'a href='https://cloud.pix.fr/s/rrkLPMS5dYGKRQ9' class='link link--banner link--bold link--underlined' '>'Nieuw: ontdek de implementatiekit voor AI-leertrajecten'</a>'",
       "message": "Belangrijke fasen in het schooljaar:",
-      "step1a": "Implement&nbsp;: '<'a href='https://cloud.pix.fr/s/WjTnkSbFs9TDcSC' title='Gids download resultaten' class='link link--banner link--bold link--underlined''>'download resultaten'</a>' certificering en",
+      "step1a": "Implement&nbsp;: '<'a href='https://cloud.pix.fr/s/TBF97QzSni7SWpc' title='Gids download resultaten' class='link link--banner link--bold link--underlined''>'download resultaten'</a>' certificering en",
       "step1b": "Importeren",
       "step1c": "studentendatabase (admin)",
       "step2": "'<'a href='https://cloud.pix.fr/s/d7MCSCq2RsSy5Pt' title='Gids voor het lanceren van back-to-school cursussen' class='link- banner link-old link--underlined' '>'Campagnes maken'</a>' (cursussen rentrée, 6e, thematisch, disciplinair, gericht...).",
-      "step3": "Certificering van studenten. '<'a href='https://cloud.pix.fr/s/opiFxfjygR76S8y' title='Gids Certificering van lerenden voorbereiden en organiseren' class='link link--banner link--bold link--underlined' '>'Lees meer over de certificering'</a>'."
+      "step3": "Certificering van studenten. '<'a href='https://cloud.pix.fr/s/nkEoMj9BtHX9EzE' title='Gids Certificering van lerenden voorbereiden en organiseren' class='link link--banner link--bold link--underlined' '>'Lees meer over de certificering'</a>'."
     },
     "last-places-lot-available": {
       "message": "{days, number} Houd er rekening mee dat je tickets over enkele dagen verlopen."


### PR DESCRIPTION
## 🥀 Problème

Les liens du bandeau SCO dans Pix Orga ne sont plus à jour.

## 🏹 Proposition

Mise à jour dans les 4 fichiers de traduction (fr, en, nl, it) :
- Lien « télécharger les résultats » → nouveau lien
- Lien « en savoir plus sur la certification » → nouveau lien
- Remplacement de l'icône 📢 par 🚀 dans le message IA (pour éviter le double mégaphone)
- Ajout de la traduction italienne du message IA (clé `ia-message` absente jusqu'ici)

## 💌 Remarques

Prévenir dans [#C66CN9STX](https://1024pix.slack.com/archives/C66CN9STX/p1771431947524529) quand c'est mergé.

## ❤️‍🔥 Pour tester

- [ ] Connectez-vous avec un compte prescripteur SCO
- [ ] Vérifier que le bandeau affiche les nouveaux liens et l'icône 🚀 in tutte le lingue