### PR TITLE
[TECH] Ajout de colonnes dans la table "assessment-results" pour permettre le stockage du scoring des pix plus et faciliter son interprétation (PIX-21697)

### DIFF
--- a/api/db/migrations/20260224093720_add-scoring-columns-on-table-assessment-results.js
+++ b/api/db/migrations/20260224093720_add-scoring-columns-on-table-assessment-results.js
@@ -1,0 +1,55 @@
+// Make sure you properly test your migration, especially DDL (Data Definition Language)
+// ! If the target table is large, and the migration take more than 20 minutes, the deployment will fail !
+
+// You can design and test your migration to avoid this by following this guide
+// https://1024pix.atlassian.net/wiki/spaces/EDTDT/pages/3849323922/Cr+er+une+migration
+
+// If your migrations target :
+//
+// `answers`
+// `knowledge-elements`
+// `knowledge-element-snapshots`
+//
+// contact @team-captains, because automatic migrations are not active on `pix-datawarehouse-production`
+// this may prevent data replication to succeed the day after your migration is deployed on `pix-api-production`
+const TABLE_NAME = 'assessment-results';
+const COLUMN_CAPACITY_NAME = 'capacity';
+const COLUMN_REACHED_MESH_INDEX_NAME = 'reachedMeshIndex';
+const COLUMN_VERSION_ID_NAME = 'versionId';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.float(COLUMN_CAPACITY_NAME).nullable().defaultTo(null).comment('Computed final capacity');
+    table
+      .smallint(COLUMN_REACHED_MESH_INDEX_NAME)
+      .nullable()
+      .defaultTo(null)
+      .comment(
+        'Mesh index reached by the candidate, corresponding to meshes in certification_versions.globalScoringConfiguration',
+      );
+    table
+      .integer(COLUMN_VERSION_ID_NAME)
+      .nullable()
+      .defaultTo(null)
+      .references('certification_versions.id')
+      .comment('Fetch related certification version more easily, thus avoiding many joins');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_CAPACITY_NAME);
+    table.dropColumn(COLUMN_REACHED_MESH_INDEX_NAME);
+    table.dropColumn(COLUMN_VERSION_ID_NAME);
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## 🥀 Problème

Aujourd'hui, le résultat du scoring est stocké dans `assessment-results`. Pour la v3 à ce jour la seule valeur stockée est le `pixScore`.
Le problème c'est que lorsqu'il va s'agir de scorer des certifications pix plus, lesquelles ne requièrent pas de calcul de `pixScore`, il nous faut stocker une information pour pouvoir déterminer le niveau atteint par le candidat.
En somme, les données de scoring stockées aujourd'hui sont insuffisantes pour les pix plus.

## 🏹 Proposition

La donnée originelle et qui permet de calculer toutes les sous-interprétations du niveau du candidat est la capacité. Donc on décide de l'inscrire dans l'assessment-result.
De plus, vu la petite taille de la donnée, on se dit que c'est également intéressant de stocker le meshIndex dans lequel se trouve le candidat : le résultat de ce calcul est fixe lorsque le scoring est fini. Pour éviter d'avoir à recalculer le niveau atteint à chaque fois, on se dit que c'est bien de le stocker.
Logiquement, pour interpréter correctement ce meshIndex au regard des mailles du référentiel de certification passée par le candidat, on s'est également dit que ça serait pratique d'avoir sous la main une information pour récupérer facilement la configuration correspondante, donc on ajoute une colonne en référence à la table `certification_versions`.

## 💌 Remarques

Toutes les colonnes sont nullable car :
- assessment-results contient des résultats de certification sur des versions de l'algorithme de certification antérieure à la v3
- le rétro-remplissage des colonnes pour les assessment-results concernés se fera dans un deuxième temps

## ❤️‍🔥 Pour tester
```
npm run db:migrate
npm run db:rollback:latest
```

```
+------------------------+--------------------------+--------------------------------------------------------------------+
| Column                 | Type                     | Modifiers                                                          |
|------------------------+--------------------------+--------------------------------------------------------------------|
| id                     | integer                  |  not null default nextval('"assessment-results_id_seq"'::regclass) |
| createdAt              | timestamp with time zone |  not null default CURRENT_TIMESTAMP                                |
| level                  | integer                  |                                                                    |
| pixScore               | integer                  |                                                                    |
| emitter                | text                     |                                                                    |
| commentByJury          | text                     |                                                                    |
| commentForOrganization | text                     |                                                                    |
| commentForCandidate    | text                     |                                                                    |
| status                 | text                     |  not null                                                          |
| juryId                 | integer                  |                                                                    |
| assessmentId           | integer                  |                                                                    |
| reproducibilityRate    | numeric(5,2)             |  default NULL::numeric                                             |
| commentByAutoJury      | text                     |                                                                    |
| capacity               | real                     |                                                                    |
| reachedMeshIndex       | smallint                 |                                                                    |
| versionId              | integer                  |                                                                    |
+------------------------+--------------------------+--------------------------------------------------------------------+
```
