### PR TITLE
[BUGFIX] Corriger la mise à jour de la durée des contenus formatifs dans Pix Admin (PIX-21473)

### DIFF
--- a/admin/app/components/trainings/create-or-update-training-form.gjs
+++ b/admin/app/components/trainings/create-or-update-training-form.gjs
@@ -36,7 +36,7 @@ class Form {
     this.internalTitle = internalTitle || null;
     this.link = link || null;
     this.type = type || null;
-    this.duration = duration || { days: 0, hours: 0, minutes: 0 };
+    this.duration = duration ? { ...duration } : { days: 0, hours: 0, minutes: 0 };
     this.locale = locale || null;
     this.editorLogoUrl = editorLogoUrl || null;
     this.editorName = editorName || null;

--- a/admin/app/components/trainings/create-or-update-training-form.gjs
+++ b/admin/app/components/trainings/create-or-update-training-form.gjs
@@ -99,7 +99,7 @@ export default class CreateOrUpdateTrainingForm extends Component {
     if (this.form.type === MODULIX_TYPE) {
       if (key === 'link') {
         const selectedModule = this.modules.find((module) => module.link === value);
-        set(this.form, 'duration.minutes', selectedModule.duration);
+        this.form.duration = { days: 0, hours: 0, minutes: selectedModule.duration };
       }
 
       if (!this.form.editorLogoUrl) {


### PR DESCRIPTION
## 🥀 Problème

Sur le formulaire d'édition d'un contenu formatif sur Pix Admin, lorsqu'on met à jour la durée du C.F et qu'on annule ensuite, alors la durée affichée sur la page de détail est celle avant annulation.
Cela ne devrait pas être le cas 😛 

## 🏹 Proposition

Corriger cela en dupliquant le champ `duration` lors de la mise à jour.

## 💌 Remarques

On en profite pour aussi réinitialiser toutes les valeurs de l'objet duration lorsqu'on l'autocomplète avec un module existant

## ❤️‍🔥 Pour tester
- Aller sur la [page de détail d'un contenu formatif](https://admin-pr15241.review.pix.fr/trainings/8004/triggers)
- Cliquer sur modifier
- Modifier la valeur de chaque champ et cliquer sur `Annuler`
- Constater que les modifications n'ont pas été appliqué 😮‍💨 

### Test de l'autocomplétion des modules
- Aller sur la [page de détail d'un contenu formatif](https://admin-pr15241.review.pix.fr/trainings/8004/triggers)
- Cliquer sur modifier
- Mettre un type `webinaire` et une `duration` avec des jours, heures et minutes
- Changer le type en `modules` et sélectionner un module dans la liste proposée
- Constater que les champs `jours` et `heures` sont bien réinitialisés 🎉 
