### PR TITLE
[BUGFIX] Ne pas échouer si la valeur de scoring_configuration est nulle

### DIFF
--- a/api/src/certification/results/infrastructure/repositories/certification-parcoursup-repository.js
+++ b/api/src/certification/results/infrastructure/repositories/certification-parcoursup-repository.js
@@ -118,7 +118,7 @@ const _toDomain = (certificationResultDto) => {
       pixScore: certificationResult.pix_score,
       certificationDate: certificationResult.certification_date,
       competences: Array.from(uniqCompetences.values()),
-      maxReachableLevel: certificationResult.scoring_configuration.length - 1,
+      maxReachableLevel: certificationResult.scoring_configuration?.length - 1,
     });
   });
 };


### PR DESCRIPTION
## 🥀 Problème
Nous avons des erreurs 500 sur des appels parcoursup depuis la MEP: https://app.datadoghq.eu/logs?query=service%3Apix-api-maddo-production&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&context_event=AZyPXitsAADZ6nNh96WiFwAE&event=AwAAAZyPZJWbFPCP0AAAABhBWnlQWkpZOEFBQ3lpRGZib2dqM29nQUYAAAAkZjE5YzhmNjQtOTY2NS00YjEzLTg0MDktNGQ0YWNkZGM0NmNlAAAAAw&messageDisplay=inline&refresh_mode=sliding&screenId=rkh-gvk-6qj&storage=hot&stream_sort=time%2Cdesc&tpl_var_service%5B0%5D=pix-orga-production&tpl_var_service%5B1%5D=pix-admin-production&viz=&from_ts=1771930973075&to_ts=1771931873075&live=true

## 🏹 Proposition
Ne pas échouer si la valeur de scoring_configuration est nulle