### PR TITLE
[TECH] Ajouter une contrainte not-null sur le champ organizationLearnerTypeId de la table organizations (PIX-21334)

### DIFF
--- a/api/db/migrations/20260224133749_add-not-nullable-constraint-on-organizationLearnerTypeId-in-organizations-table.js
+++ b/api/db/migrations/20260224133749_add-not-nullable-constraint-on-organizationLearnerTypeId-in-organizations-table.js
@@ -1,0 +1,24 @@
+const TABLE_NAME = 'organizations';
+const COLUMN_NAME = 'organizationLearnerTypeId';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.integer(COLUMN_NAME).notNullable().alter();
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.integer(COLUMN_NAME).nullable().alter();
+  });
+};
+
+export { down, up };

--- a/high-level-tests/e2e-playwright/helpers/db.ts
+++ b/high-level-tests/e2e-playwright/helpers/db.ts
@@ -348,6 +348,13 @@ export async function createOrganizationInDB({
     .returning('id')
     .then((rows) => rows[0].id);
 
+  const organizationLearnerTypeId = await knex('organization_learner_types')
+    .insert({
+      name: `Type for ${externalId}`,
+    })
+    .returning('id')
+    .then((rows) => rows[0].id);
+
   const [{ id }] = await knex('organizations')
     .insert({
       type,
@@ -371,6 +378,7 @@ export async function createOrganizationInDB({
       parentOrganizationId: null,
       administrationTeamId,
       countryCode: 99100,
+      organizationLearnerTypeId,
     })
     .returning('id');
   return id;

--- a/high-level-tests/e2e/cypress/fixtures/organization_learner_types.json
+++ b/high-level-tests/e2e/cypress/fixtures/organization_learner_types.json
@@ -1,0 +1,10 @@
+[
+  {
+  "id": 1,
+  "name": "Students"
+  },
+  {
+  "id": 2,
+  "name": "Professionnal"
+  }
+]

--- a/high-level-tests/e2e/cypress/fixtures/organizations.json
+++ b/high-level-tests/e2e/cypress/fixtures/organizations.json
@@ -4,7 +4,8 @@
     "type": "PRO",
     "name": "Dragon & Co",
     "administrationTeamId": 1,
-    "countryCode": 99100
+    "countryCode": 99100,
+    "organizationLearnerTypeId": 2
   },
   {
     "id": 2,
@@ -12,7 +13,8 @@
     "name": "The Night Watch",
     "isManagingStudents": true,
     "administrationTeamId": 2,
-    "countryCode": 99100
+    "countryCode": 99100,
+    "organizationLearnerTypeId": 1
   },
   {
     "id": 3,
@@ -20,6 +22,7 @@
     "name": "The Order of Maesters",
     "isManagingStudents": true,
     "administrationTeamId": 1,
-    "countryCode": 99100
+    "countryCode": 99100,
+    "organizationLearnerTypeId": 1
   }
 ]

--- a/high-level-tests/e2e/cypress/integration/pix-app/a11y-authenticated-1.test.js
+++ b/high-level-tests/e2e/cypress/integration/pix-app/a11y-authenticated-1.test.js
@@ -8,6 +8,7 @@ describe("a11y", () => {
     cy.task("db:fixture", "users");
     cy.task("db:fixture", "authentication-methods");
     cy.task("db:fixture", "administration_teams");
+    cy.task('db:fixture', "organization_learner_types");
     cy.task("db:fixture", "organizations");
     cy.task("db:fixture", "memberships");
     cy.task("db:fixture", "organization-invitations");

--- a/high-level-tests/e2e/cypress/integration/pix-app/a11y-authenticated-2.test.js
+++ b/high-level-tests/e2e/cypress/integration/pix-app/a11y-authenticated-2.test.js
@@ -8,6 +8,7 @@ describe("a11y", () => {
     cy.task("db:fixture", "users");
     cy.task("db:fixture", "authentication-methods");
     cy.task("db:fixture", "administration_teams");
+    cy.task('db:fixture', "organization_learner_types");
     cy.task("db:fixture", "organizations");
     cy.task("db:fixture", "memberships");
     cy.task("db:fixture", "organization-invitations");

--- a/high-level-tests/e2e/cypress/integration/pix-app/a11y-not-authenticated.test.js
+++ b/high-level-tests/e2e/cypress/integration/pix-app/a11y-not-authenticated.test.js
@@ -3,6 +3,7 @@ describe("a11y", () => {
     cy.task("db:fixture", "users");
     cy.task("db:fixture", "authentication-methods");
     cy.task("db:fixture", "administration_teams");
+    cy.task('db:fixture', "organization_learner_types");
     cy.task("db:fixture", "organizations");
     cy.task("db:fixture", "memberships");
     cy.task("db:fixture", "organization-invitations");

--- a/high-level-tests/e2e/cypress/support/step_definitions/index.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/index.js
@@ -8,6 +8,7 @@ Given("les données de test sont chargées", () => {
   cy.task("db:fixture", "users");
   cy.task("db:fixture", "authentication-methods");
   cy.task("db:fixture", "administration_teams");
+  cy.task("db:fixture", "organization_learner_types");
   cy.task("db:fixture", "organizations");
   cy.task("db:fixture", "memberships");
   cy.task("db:fixture", "organization-invitations");


### PR DESCRIPTION
## 🥀 Problème

Le champs Public prescrit (`organizationLearnerTypeId`) sur la table `organizations `doit maintenant être obligatoire.

## 🏹 Proposition
Ajouter une migration qui altere la table `organizations` afin d'ajouter une contrainte `not-null` sur ce champ.

## 💌 Remarques

- aucune organization n'a ce champ à null en integration
- aucune organization n'a ce champ à null en recette
- aucune organization n'a ce champ à null en prod

## ❤️‍🔥 Pour tester

Seeds et tests ok
