### PR TITLE
[TECH] Ajout de l'error.code et error.message dans un log (PIX-21715)

### DIFF
--- a/api/src/shared/infrastructure/http-agent.js
+++ b/api/src/shared/infrastructure/http-agent.js
@@ -98,8 +98,8 @@ const httpAgent = {
         code = httpErr.response.status;
         data = httpErr.response.data;
       } else {
-        code = '500';
-        data = null;
+        code = httpErr.code;
+        data = httpErr.message;
       }
 
       logger.error({

--- a/api/tests/shared/unit/infrastructure/http-agent_test.js
+++ b/api/tests/shared/unit/infrastructure/http-agent_test.js
@@ -206,13 +206,15 @@ describe('Shared | Unit | Infrastructure | http-agent', function () {
 
           const axiosError = {
             name: 'error name',
+            message: 'MESSAGE_ERROR',
+            code: 'CODE_ERROR',
           };
           sinon.stub(axios, 'get').withArgs(url, { data: payload, headers }).rejects(axiosError);
 
           const expectedResponse = {
             isSuccessful: false,
-            code: '500',
-            data: null,
+            code: 'CODE_ERROR',
+            data: 'MESSAGE_ERROR',
           };
 
           // when


### PR DESCRIPTION
## 🥀 Problème

Dans le challenge-repository lorsque que l'on charge des infos d'un webcmponent avec la fonction  `loadWebComponentInfo`. La gestion d'erreur manque d'info pour nous aider à débugger.

Exemple problème de certificat lorsque l'on à essayé de récupéré les infos d'un webcomponent, l'erreur ne remontait pas dans le logs.

## 🏹 Proposition

Ajouter le code erreur et le message d'erreur dans les log pour éviter de galérer comme la dernière fois.

## 💌 Remarques

RAS

## ❤️‍🔥 Pour tester

C'est compliqué, je ne sais pas trop comment forcer en ra/local une erreur de certificat.