### PR TITLE
[FEATURE] Autoriser des custom-draft stockés dans pix-epreuves-externe (PIX-21705)

### DIFF
--- a/api/src/devcomp/domain/models/element/CustomDraft.js
+++ b/api/src/devcomp/domain/models/element/CustomDraft.js
@@ -3,7 +3,10 @@ import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asser
 import { Element } from './Element.js';
 
 class CustomDraft extends Element {
-  static #VALID_URL_PREFIX = 'https://1024pix.github.io/atelier-contenus';
+  static #VALID_URL_PREFIX = {
+    ATELIER_CONTENUS: 'https://1024pix.github.io/atelier-contenus',
+    PIX_EPREUVES_EXTERNES: 'https://1024pix.github.io/pix-epreuves-externes',
+  };
 
   constructor({ id, title, url, instruction, height }) {
     super({ id, type: 'custom-draft' });
@@ -21,8 +24,13 @@ class CustomDraft extends Element {
     this.instruction = instruction;
     this.height = height;
 
-    if (!URL.parse(url).href.startsWith(CustomDraft.#VALID_URL_PREFIX)) {
-      throw new DomainError('The custom-draft URL must be from "1024pix.github.io/atelier-contenus"');
+    if (
+      !URL.parse(url).href.startsWith(CustomDraft.#VALID_URL_PREFIX.ATELIER_CONTENUS) &&
+      !URL.parse(url).href.startsWith(CustomDraft.#VALID_URL_PREFIX.PIX_EPREUVES_EXTERNES)
+    ) {
+      throw new DomainError(
+        'The custom-draft URL must be from "1024pix.github.io/atelier-contenus" or "1024pix.github.io/pix-epreuves-externes"',
+      );
     }
   }
 }

--- a/api/tests/devcomp/unit/domain/models/element/CustomDraft_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/CustomDraft_test.js
@@ -4,7 +4,7 @@ import { catchErrSync, expect } from '../../../../../test-helper.js';
 
 describe('Unit | Devcomp | Domain | Models | Element | CustomDraft', function () {
   describe('#constructor', function () {
-    it('should instanciate a CustomDraft with right properties', function () {
+    it('should instantiate a CustomDraft with right properties', function () {
       // Given
       const props = {
         id: 'id',
@@ -24,6 +24,23 @@ describe('Unit | Devcomp | Domain | Models | Element | CustomDraft', function ()
       expect(customDraft.url).to.equal('https://1024pix.github.io/atelier-contenus/custom-draft.html');
       expect(customDraft.instruction).to.equal('<p>instruction</p>');
       expect(customDraft.height).to.equal(400);
+    });
+
+    it('should allow a CustomDraft with an url from pix-epreuves-externes', function () {
+      // Given
+      const props = {
+        id: 'id',
+        title: 'title',
+        url: 'https://1024pix.github.io/pix-epreuves-externes/custom-draft.html',
+        instruction: '<p>instruction</p>',
+        height: 400,
+      };
+
+      // When
+      const customDraft = new CustomDraft(props);
+
+      // Then
+      expect(customDraft.url).to.equal('https://1024pix.github.io/pix-epreuves-externes/custom-draft.html');
     });
   });
 
@@ -53,7 +70,7 @@ describe('Unit | Devcomp | Domain | Models | Element | CustomDraft', function ()
     });
   });
 
-  describe('When custom-draft URL is not from 1024pix.github.io/atelier-contenus', function () {
+  describe('When custom-draft URL is not from 1024pix.github.io/atelier-contenus nor 1024pix.github.io/pix-epreuves-externes', function () {
     it('should throw an error', function () {
       // given & when
       const error = catchErrSync(
@@ -69,7 +86,9 @@ describe('Unit | Devcomp | Domain | Models | Element | CustomDraft', function ()
 
       // then
       expect(error).to.be.instanceOf(DomainError);
-      expect(error.message).to.equal('The custom-draft URL must be from "1024pix.github.io/atelier-contenus"');
+      expect(error.message).to.equal(
+        'The custom-draft URL must be from "1024pix.github.io/atelier-contenus" or "1024pix.github.io/pix-epreuves-externes"',
+      );
     });
   });
 });


### PR DESCRIPTION
## 🥀 Problème

Le métier veut ajouter des custom-draft qui sont hébergés dans `pix-epreuves-externes` au lieu de `atelier-contenus`.
C'est le cas dans cette PR : https://github.com/1024pix/pix/pull/15211/changes

## 🏹 Proposition

Dans l'API, autoriser la création d'un custom-draft qui a une url commençant par `https://1024pix.github.io/pix-epreuves-externes`

## 💌 Remarques

Il faudra vérifier que la PR de Philomène ne remonte plus d'erreur.

## ❤️‍🔥 Pour tester
CI au vert
