### PR TITLE
[FEATURE] Sauvegarder la capacité, l'index de maille et l'id de version lors du scoring (PIX-21698).

### DIFF
--- a/api/db/database-builder/factory/build-assessment-result.js
+++ b/api/db/database-builder/factory/build-assessment-result.js
@@ -21,6 +21,9 @@ function buildAssessmentResult({
   assessmentId,
   createdAt = new Date('2020-01-01'),
   certificationCourseId,
+  capacity,
+  reachedMeshIndex,
+  versionId,
 } = {}) {
   assessmentId = _.isUndefined(assessmentId) ? buildAssessment({ certificationCourseId }).id : assessmentId;
   juryId = _.isUndefined(juryId) ? buildUser().id : juryId;
@@ -39,6 +42,9 @@ function buildAssessmentResult({
     juryId,
     assessmentId,
     createdAt,
+    capacity,
+    reachedMeshIndex,
+    versionId,
   };
   return databaseBuffer.pushInsertable({
     tableName: 'assessment-results',
@@ -63,6 +69,9 @@ buildAssessmentResult.last = function ({
   juryId,
   assessmentId,
   createdAt,
+  capacity,
+  reachedMeshIndex,
+  versionId,
 }) {
   const assessmentResult = buildAssessmentResult({
     id,
@@ -79,6 +88,9 @@ buildAssessmentResult.last = function ({
     assessmentId,
     createdAt,
     certificationCourseId,
+    capacity,
+    reachedMeshIndex,
+    versionId,
   });
 
   buildCertificationCourseLastAssessmentResult({

--- a/api/src/certification/evaluation/domain/models/ScoringV3Algorithm.js
+++ b/api/src/certification/evaluation/domain/models/ScoringV3Algorithm.js
@@ -100,6 +100,17 @@ export class ScoringV3Algorithm {
   /**
    *  @param {object} params
    *  @param {number} params.capacity
+   *  @returns {number} reachedMeshIndex
+   */
+  computeReachedMeshIndex({ capacity }) {
+    const certificationScoringIntervals = this.v3CertificationScoring.intervals;
+    const scoringIntervals = new Intervals({ intervals: certificationScoringIntervals });
+    return scoringIntervals.findIntervalIndexFromCapacity(capacity);
+  }
+
+  /**
+   *  @param {object} params
+   *  @param {number} params.capacity
    *  @returns {CompetenceMark[]} competenceMarks
    */
   computeCompetenceMarks({ capacity }) {

--- a/api/src/certification/evaluation/domain/models/V3CertificationScoring.js
+++ b/api/src/certification/evaluation/domain/models/V3CertificationScoring.js
@@ -5,10 +5,12 @@ export class V3CertificationScoring {
     competencesForScoring,
     certificationScoringConfiguration,
     minimumAnswersRequiredToValidateACertification,
+    versionId,
   }) {
     this._competencesForScoring = competencesForScoring;
     this._certificationScoringConfiguration = certificationScoringConfiguration;
     this.minimumAnswersRequiredToValidateACertification = minimumAnswersRequiredToValidateACertification;
+    this.versionId = versionId;
   }
 
   getCompetencesScore(capacity) {
@@ -33,6 +35,7 @@ export class V3CertificationScoring {
     allAreas,
     competenceList,
     minimumAnswersRequiredToValidateACertification,
+    versionId,
   }) {
     const competencesForScoring =
       competenceForScoringConfiguration?.map(({ competence: competenceCode, values }) => {
@@ -50,6 +53,7 @@ export class V3CertificationScoring {
       competencesForScoring,
       certificationScoringConfiguration,
       minimumAnswersRequiredToValidateACertification,
+      versionId,
     });
   }
 }

--- a/api/src/certification/evaluation/domain/models/factories/AssessmentResultFactory.js
+++ b/api/src/certification/evaluation/domain/models/factories/AssessmentResultFactory.js
@@ -11,6 +11,7 @@ export class AssessmentResultFactory {
     juryId,
     competenceMarks,
     capacity,
+    reachedMeshIndex,
     versionId,
   }) {
     const commentForCandidate = new JuryComment({
@@ -33,6 +34,7 @@ export class AssessmentResultFactory {
       juryId,
       competenceMarks,
       capacity,
+      reachedMeshIndex,
       versionId,
     });
   }
@@ -56,6 +58,7 @@ export class AssessmentResultFactory {
     juryId,
     competenceMarks,
     capacity,
+    reachedMeshIndex,
     versionId,
   }) {
     return new AssessmentResult({
@@ -66,6 +69,7 @@ export class AssessmentResultFactory {
       juryId,
       competenceMarks,
       capacity,
+      reachedMeshIndex,
       versionId,
     });
   }
@@ -78,6 +82,7 @@ export class AssessmentResultFactory {
     juryId,
     competenceMarks,
     capacity,
+    reachedMeshIndex,
     versionId,
   }) {
     return new AssessmentResult({
@@ -88,6 +93,7 @@ export class AssessmentResultFactory {
       juryId,
       competenceMarks,
       capacity,
+      reachedMeshIndex,
       versionId,
     });
   }
@@ -99,6 +105,7 @@ export class AssessmentResultFactory {
     juryId,
     competenceMarks,
     capacity,
+    reachedMeshIndex,
     versionId,
   }) {
     return this.#buildWithAutoJuryComment({
@@ -110,11 +117,21 @@ export class AssessmentResultFactory {
       juryId,
       competenceMarks,
       capacity,
+      reachedMeshIndex,
       versionId,
     });
   }
 
-  static buildFraud({ pixScore, reproducibilityRate, assessmentId, juryId, competenceMarks, capacity, versionId }) {
+  static buildFraud({
+    pixScore,
+    reproducibilityRate,
+    assessmentId,
+    juryId,
+    competenceMarks,
+    capacity,
+    reachedMeshIndex,
+    versionId,
+  }) {
     return this.#buildWithAutoJuryComment({
       autoJuryCommentKey: AutoJuryCommentKeys.FRAUD,
       status: AssessmentResult.status.REJECTED,
@@ -124,6 +141,7 @@ export class AssessmentResultFactory {
       juryId,
       competenceMarks,
       capacity,
+      reachedMeshIndex,
       versionId,
     });
   }
@@ -136,6 +154,7 @@ export class AssessmentResultFactory {
     juryId,
     competenceMarks,
     capacity,
+    reachedMeshIndex,
     versionId,
   }) {
     return this.#buildWithAutoJuryComment({
@@ -147,6 +166,7 @@ export class AssessmentResultFactory {
       juryId,
       competenceMarks,
       capacity,
+      reachedMeshIndex,
       versionId,
     });
   }
@@ -158,6 +178,7 @@ export class AssessmentResultFactory {
     juryId,
     competenceMarks,
     capacity,
+    reachedMeshIndex,
     versionId,
   }) {
     return this.#buildWithAutoJuryComment({
@@ -169,6 +190,7 @@ export class AssessmentResultFactory {
       juryId,
       competenceMarks,
       capacity,
+      reachedMeshIndex,
       versionId,
     });
   }
@@ -178,8 +200,8 @@ export class AssessmentResultFactory {
     reproducibilityRate,
     assessmentId,
     juryId,
-    competenceMarks,
     capacity,
+    reachedMeshIndex,
     versionId,
   }) {
     return this.#buildWithAutoJuryComment({
@@ -189,8 +211,8 @@ export class AssessmentResultFactory {
       reproducibilityRate,
       assessmentId,
       juryId,
-      competenceMarks,
       capacity,
+      reachedMeshIndex,
       versionId,
     });
   }
@@ -202,6 +224,7 @@ export class AssessmentResultFactory {
     juryId,
     competenceMarks,
     capacity,
+    reachedMeshIndex,
     versionId,
   }) {
     return this.#buildWithAutoJuryComment({
@@ -213,6 +236,7 @@ export class AssessmentResultFactory {
       juryId,
       competenceMarks,
       capacity,
+      reachedMeshIndex,
       versionId,
     });
   }

--- a/api/src/certification/evaluation/domain/models/factories/AssessmentResultFactory.js
+++ b/api/src/certification/evaluation/domain/models/factories/AssessmentResultFactory.js
@@ -2,6 +2,37 @@ import { AssessmentResult } from '../../../../../shared/domain/models/Assessment
 import { AutoJuryCommentKeys, JuryComment, JuryCommentContexts } from '../../../../shared/domain/models/JuryComment.js';
 
 export class AssessmentResultFactory {
+  static #buildWithAutoJuryComment({
+    autoJuryCommentKey,
+    status,
+    pixScore,
+    reproducibilityRate,
+    assessmentId,
+    juryId,
+    competenceMarks,
+  }) {
+    const commentForCandidate = new JuryComment({
+      context: JuryCommentContexts.CANDIDATE,
+      commentByAutoJury: autoJuryCommentKey,
+    });
+
+    const commentForOrganization = new JuryComment({
+      context: JuryCommentContexts.ORGANIZATION,
+      commentByAutoJury: autoJuryCommentKey,
+    });
+
+    return new AssessmentResult({
+      commentForCandidate,
+      commentForOrganization,
+      pixScore,
+      reproducibilityRate,
+      status,
+      assessmentId,
+      juryId,
+      competenceMarks,
+    });
+  }
+
   static buildAlgoErrorResult({ error, assessmentId, juryId }) {
     return new AssessmentResult({
       commentByJury: error.message,
@@ -34,44 +65,22 @@ export class AssessmentResultFactory {
   }
 
   static buildNotTrustableAssessmentResult({ pixScore, reproducibilityRate, assessmentId, juryId }) {
-    const commentForCandidate = new JuryComment({
-      context: JuryCommentContexts.CANDIDATE,
-      commentByAutoJury: AutoJuryCommentKeys.CANCELLED_DUE_TO_NEUTRALIZATION,
-    });
-
-    const commentForOrganization = new JuryComment({
-      context: JuryCommentContexts.ORGANIZATION,
-      commentByAutoJury: AutoJuryCommentKeys.CANCELLED_DUE_TO_NEUTRALIZATION,
-    });
-
-    return new AssessmentResult({
-      commentForCandidate,
-      commentForOrganization,
+    return this.#buildWithAutoJuryComment({
+      autoJuryCommentKey: AutoJuryCommentKeys.CANCELLED_DUE_TO_NEUTRALIZATION,
+      status: AssessmentResult.status.CANCELLED,
       pixScore,
       reproducibilityRate,
-      status: AssessmentResult.status.CANCELLED,
       assessmentId,
       juryId,
     });
   }
 
   static buildFraud({ pixScore, reproducibilityRate, assessmentId, juryId, competenceMarks }) {
-    const commentForCandidate = new JuryComment({
-      context: JuryCommentContexts.CANDIDATE,
-      commentByAutoJury: AutoJuryCommentKeys.FRAUD,
-    });
-
-    const commentForOrganization = new JuryComment({
-      context: JuryCommentContexts.ORGANIZATION,
-      commentByAutoJury: AutoJuryCommentKeys.FRAUD,
-    });
-
-    return new AssessmentResult({
-      commentForCandidate,
-      commentForOrganization,
+    return this.#buildWithAutoJuryComment({
+      autoJuryCommentKey: AutoJuryCommentKeys.FRAUD,
+      status: AssessmentResult.status.REJECTED,
       pixScore,
       reproducibilityRate,
-      status: AssessmentResult.status.REJECTED,
       assessmentId,
       juryId,
       competenceMarks,
@@ -79,25 +88,14 @@ export class AssessmentResultFactory {
   }
 
   static buildLackOfAnswers({ pixScore, reproducibilityRate, status, assessmentId, juryId, competenceMarks }) {
-    const commentForCandidate = new JuryComment({
-      context: JuryCommentContexts.CANDIDATE,
-      commentByAutoJury: AutoJuryCommentKeys.REJECTED_DUE_TO_LACK_OF_ANSWERS,
-    });
-
-    const commentForOrganization = new JuryComment({
-      context: JuryCommentContexts.ORGANIZATION,
-      commentByAutoJury: AutoJuryCommentKeys.REJECTED_DUE_TO_LACK_OF_ANSWERS,
-    });
-
-    return new AssessmentResult({
+    return this.#buildWithAutoJuryComment({
+      autoJuryCommentKey: AutoJuryCommentKeys.REJECTED_DUE_TO_LACK_OF_ANSWERS,
+      status,
       pixScore,
       reproducibilityRate,
-      status,
       assessmentId,
       juryId,
       competenceMarks,
-      commentForCandidate,
-      commentForOrganization,
     });
   }
 
@@ -108,67 +106,34 @@ export class AssessmentResultFactory {
     juryId,
     competenceMarks,
   }) {
-    const commentForCandidate = new JuryComment({
-      context: JuryCommentContexts.CANDIDATE,
-      commentByAutoJury: AutoJuryCommentKeys.CANCELLED_DUE_TO_LACK_OF_ANSWERS_FOR_TECHNICAL_REASON,
-    });
-
-    const commentForOrganization = new JuryComment({
-      context: JuryCommentContexts.ORGANIZATION,
-      commentByAutoJury: AutoJuryCommentKeys.CANCELLED_DUE_TO_LACK_OF_ANSWERS_FOR_TECHNICAL_REASON,
-    });
-
-    return new AssessmentResult({
+    return this.#buildWithAutoJuryComment({
+      autoJuryCommentKey: AutoJuryCommentKeys.CANCELLED_DUE_TO_LACK_OF_ANSWERS_FOR_TECHNICAL_REASON,
+      status: AssessmentResult.status.CANCELLED,
       pixScore,
       reproducibilityRate,
-      status: AssessmentResult.status.CANCELLED,
       assessmentId,
       juryId,
       competenceMarks,
-      commentForCandidate,
-      commentForOrganization,
     });
   }
 
   static buildInsufficientCorrectAnswers({ pixScore, reproducibilityRate, assessmentId, juryId }) {
-    const commentForCandidate = new JuryComment({
-      context: JuryCommentContexts.CANDIDATE,
-      commentByAutoJury: AutoJuryCommentKeys.REJECTED_DUE_TO_INSUFFICIENT_CORRECT_ANSWERS,
-    });
-
-    const commentForOrganization = new JuryComment({
-      context: JuryCommentContexts.ORGANIZATION,
-      commentByAutoJury: AutoJuryCommentKeys.REJECTED_DUE_TO_INSUFFICIENT_CORRECT_ANSWERS,
-    });
-
-    return new AssessmentResult({
-      commentForCandidate,
-      commentForOrganization,
+    return this.#buildWithAutoJuryComment({
+      autoJuryCommentKey: AutoJuryCommentKeys.REJECTED_DUE_TO_INSUFFICIENT_CORRECT_ANSWERS,
+      status: AssessmentResult.status.REJECTED,
       pixScore,
       reproducibilityRate,
-      status: AssessmentResult.status.REJECTED,
       assessmentId,
       juryId,
     });
   }
 
   static buildRejectedDueToZeroPixScore({ pixScore, reproducibilityRate, assessmentId, juryId, competenceMarks }) {
-    const commentForCandidate = new JuryComment({
-      context: JuryCommentContexts.CANDIDATE,
-      commentByAutoJury: AutoJuryCommentKeys.REJECTED_DUE_TO_ZERO_PIX_SCORE,
-    });
-
-    const commentForOrganization = new JuryComment({
-      context: JuryCommentContexts.ORGANIZATION,
-      commentByAutoJury: AutoJuryCommentKeys.REJECTED_DUE_TO_ZERO_PIX_SCORE,
-    });
-
-    return new AssessmentResult({
-      commentForCandidate,
-      commentForOrganization,
+    return this.#buildWithAutoJuryComment({
+      autoJuryCommentKey: AutoJuryCommentKeys.REJECTED_DUE_TO_ZERO_PIX_SCORE,
+      status: AssessmentResult.status.REJECTED,
       pixScore,
       reproducibilityRate,
-      status: AssessmentResult.status.REJECTED,
       assessmentId,
       juryId,
       competenceMarks,

--- a/api/src/certification/evaluation/domain/models/factories/AssessmentResultFactory.js
+++ b/api/src/certification/evaluation/domain/models/factories/AssessmentResultFactory.js
@@ -10,6 +10,7 @@ export class AssessmentResultFactory {
     assessmentId,
     juryId,
     competenceMarks,
+    capacity,
   }) {
     const commentForCandidate = new JuryComment({
       context: JuryCommentContexts.CANDIDATE,
@@ -30,6 +31,7 @@ export class AssessmentResultFactory {
       assessmentId,
       juryId,
       competenceMarks,
+      capacity,
     });
   }
 
@@ -45,7 +47,14 @@ export class AssessmentResultFactory {
     });
   }
 
-  static buildCancelledAssessmentResult({ pixScore, reproducibilityRate, assessmentId, juryId, competenceMarks }) {
+  static buildCancelledAssessmentResult({
+    pixScore,
+    reproducibilityRate,
+    assessmentId,
+    juryId,
+    competenceMarks,
+    capacity,
+  }) {
     return new AssessmentResult({
       pixScore,
       reproducibilityRate,
@@ -53,6 +62,7 @@ export class AssessmentResultFactory {
       assessmentId,
       juryId,
       competenceMarks,
+      capacity,
     });
   }
 
@@ -63,6 +73,7 @@ export class AssessmentResultFactory {
     assessmentId,
     juryId,
     competenceMarks,
+    capacity,
   }) {
     return new AssessmentResult({
       pixScore,
@@ -71,10 +82,18 @@ export class AssessmentResultFactory {
       assessmentId,
       juryId,
       competenceMarks,
+      capacity,
     });
   }
 
-  static buildNotTrustableAssessmentResult({ pixScore, reproducibilityRate, assessmentId, juryId, competenceMarks }) {
+  static buildNotTrustableAssessmentResult({
+    pixScore,
+    reproducibilityRate,
+    assessmentId,
+    juryId,
+    competenceMarks,
+    capacity,
+  }) {
     return this.#buildWithAutoJuryComment({
       autoJuryCommentKey: AutoJuryCommentKeys.CANCELLED_DUE_TO_NEUTRALIZATION,
       status: AssessmentResult.status.CANCELLED,
@@ -83,10 +102,11 @@ export class AssessmentResultFactory {
       assessmentId,
       juryId,
       competenceMarks,
+      capacity,
     });
   }
 
-  static buildFraud({ pixScore, reproducibilityRate, assessmentId, juryId, competenceMarks }) {
+  static buildFraud({ pixScore, reproducibilityRate, assessmentId, juryId, competenceMarks, capacity }) {
     return this.#buildWithAutoJuryComment({
       autoJuryCommentKey: AutoJuryCommentKeys.FRAUD,
       status: AssessmentResult.status.REJECTED,
@@ -95,10 +115,19 @@ export class AssessmentResultFactory {
       assessmentId,
       juryId,
       competenceMarks,
+      capacity,
     });
   }
 
-  static buildLackOfAnswers({ pixScore, reproducibilityRate, status, assessmentId, juryId, competenceMarks }) {
+  static buildLackOfAnswers({
+    pixScore,
+    reproducibilityRate,
+    status,
+    assessmentId,
+    juryId,
+    competenceMarks,
+    capacity,
+  }) {
     return this.#buildWithAutoJuryComment({
       autoJuryCommentKey: AutoJuryCommentKeys.REJECTED_DUE_TO_LACK_OF_ANSWERS,
       status,
@@ -107,6 +136,7 @@ export class AssessmentResultFactory {
       assessmentId,
       juryId,
       competenceMarks,
+      capacity,
     });
   }
 
@@ -116,6 +146,7 @@ export class AssessmentResultFactory {
     assessmentId,
     juryId,
     competenceMarks,
+    capacity,
   }) {
     return this.#buildWithAutoJuryComment({
       autoJuryCommentKey: AutoJuryCommentKeys.CANCELLED_DUE_TO_LACK_OF_ANSWERS_FOR_TECHNICAL_REASON,
@@ -125,10 +156,18 @@ export class AssessmentResultFactory {
       assessmentId,
       juryId,
       competenceMarks,
+      capacity,
     });
   }
 
-  static buildInsufficientCorrectAnswers({ pixScore, reproducibilityRate, assessmentId, juryId, competenceMarks }) {
+  static buildInsufficientCorrectAnswers({
+    pixScore,
+    reproducibilityRate,
+    assessmentId,
+    juryId,
+    competenceMarks,
+    capacity,
+  }) {
     return this.#buildWithAutoJuryComment({
       autoJuryCommentKey: AutoJuryCommentKeys.REJECTED_DUE_TO_INSUFFICIENT_CORRECT_ANSWERS,
       status: AssessmentResult.status.REJECTED,
@@ -137,10 +176,18 @@ export class AssessmentResultFactory {
       assessmentId,
       juryId,
       competenceMarks,
+      capacity,
     });
   }
 
-  static buildRejectedDueToZeroPixScore({ pixScore, reproducibilityRate, assessmentId, juryId, competenceMarks }) {
+  static buildRejectedDueToZeroPixScore({
+    pixScore,
+    reproducibilityRate,
+    assessmentId,
+    juryId,
+    competenceMarks,
+    capacity,
+  }) {
     return this.#buildWithAutoJuryComment({
       autoJuryCommentKey: AutoJuryCommentKeys.REJECTED_DUE_TO_ZERO_PIX_SCORE,
       status: AssessmentResult.status.REJECTED,
@@ -149,6 +196,7 @@ export class AssessmentResultFactory {
       assessmentId,
       juryId,
       competenceMarks,
+      capacity,
     });
   }
 }

--- a/api/src/certification/evaluation/domain/models/factories/AssessmentResultFactory.js
+++ b/api/src/certification/evaluation/domain/models/factories/AssessmentResultFactory.js
@@ -41,30 +41,40 @@ export class AssessmentResultFactory {
       status: AssessmentResult.status.ERROR,
       assessmentId,
       juryId,
+      competenceMarks: [],
     });
   }
 
-  static buildCancelledAssessmentResult({ pixScore, reproducibilityRate, assessmentId, juryId }) {
+  static buildCancelledAssessmentResult({ pixScore, reproducibilityRate, assessmentId, juryId, competenceMarks }) {
     return new AssessmentResult({
       pixScore,
       reproducibilityRate,
       status: AssessmentResult.status.CANCELLED,
       assessmentId,
       juryId,
+      competenceMarks,
     });
   }
 
-  static buildStandardAssessmentResult({ pixScore, reproducibilityRate, status, assessmentId, juryId }) {
+  static buildStandardAssessmentResult({
+    pixScore,
+    reproducibilityRate,
+    status,
+    assessmentId,
+    juryId,
+    competenceMarks,
+  }) {
     return new AssessmentResult({
       pixScore,
       reproducibilityRate,
       status,
       assessmentId,
       juryId,
+      competenceMarks,
     });
   }
 
-  static buildNotTrustableAssessmentResult({ pixScore, reproducibilityRate, assessmentId, juryId }) {
+  static buildNotTrustableAssessmentResult({ pixScore, reproducibilityRate, assessmentId, juryId, competenceMarks }) {
     return this.#buildWithAutoJuryComment({
       autoJuryCommentKey: AutoJuryCommentKeys.CANCELLED_DUE_TO_NEUTRALIZATION,
       status: AssessmentResult.status.CANCELLED,
@@ -72,6 +82,7 @@ export class AssessmentResultFactory {
       reproducibilityRate,
       assessmentId,
       juryId,
+      competenceMarks,
     });
   }
 
@@ -117,7 +128,7 @@ export class AssessmentResultFactory {
     });
   }
 
-  static buildInsufficientCorrectAnswers({ pixScore, reproducibilityRate, assessmentId, juryId }) {
+  static buildInsufficientCorrectAnswers({ pixScore, reproducibilityRate, assessmentId, juryId, competenceMarks }) {
     return this.#buildWithAutoJuryComment({
       autoJuryCommentKey: AutoJuryCommentKeys.REJECTED_DUE_TO_INSUFFICIENT_CORRECT_ANSWERS,
       status: AssessmentResult.status.REJECTED,
@@ -125,6 +136,7 @@ export class AssessmentResultFactory {
       reproducibilityRate,
       assessmentId,
       juryId,
+      competenceMarks,
     });
   }
 

--- a/api/src/certification/evaluation/domain/models/factories/AssessmentResultFactory.js
+++ b/api/src/certification/evaluation/domain/models/factories/AssessmentResultFactory.js
@@ -11,6 +11,7 @@ export class AssessmentResultFactory {
     juryId,
     competenceMarks,
     capacity,
+    versionId,
   }) {
     const commentForCandidate = new JuryComment({
       context: JuryCommentContexts.CANDIDATE,
@@ -32,6 +33,7 @@ export class AssessmentResultFactory {
       juryId,
       competenceMarks,
       capacity,
+      versionId,
     });
   }
 
@@ -54,6 +56,7 @@ export class AssessmentResultFactory {
     juryId,
     competenceMarks,
     capacity,
+    versionId,
   }) {
     return new AssessmentResult({
       pixScore,
@@ -63,6 +66,7 @@ export class AssessmentResultFactory {
       juryId,
       competenceMarks,
       capacity,
+      versionId,
     });
   }
 
@@ -74,6 +78,7 @@ export class AssessmentResultFactory {
     juryId,
     competenceMarks,
     capacity,
+    versionId,
   }) {
     return new AssessmentResult({
       pixScore,
@@ -83,6 +88,7 @@ export class AssessmentResultFactory {
       juryId,
       competenceMarks,
       capacity,
+      versionId,
     });
   }
 
@@ -93,6 +99,7 @@ export class AssessmentResultFactory {
     juryId,
     competenceMarks,
     capacity,
+    versionId,
   }) {
     return this.#buildWithAutoJuryComment({
       autoJuryCommentKey: AutoJuryCommentKeys.CANCELLED_DUE_TO_NEUTRALIZATION,
@@ -103,10 +110,11 @@ export class AssessmentResultFactory {
       juryId,
       competenceMarks,
       capacity,
+      versionId,
     });
   }
 
-  static buildFraud({ pixScore, reproducibilityRate, assessmentId, juryId, competenceMarks, capacity }) {
+  static buildFraud({ pixScore, reproducibilityRate, assessmentId, juryId, competenceMarks, capacity, versionId }) {
     return this.#buildWithAutoJuryComment({
       autoJuryCommentKey: AutoJuryCommentKeys.FRAUD,
       status: AssessmentResult.status.REJECTED,
@@ -116,6 +124,7 @@ export class AssessmentResultFactory {
       juryId,
       competenceMarks,
       capacity,
+      versionId,
     });
   }
 
@@ -127,6 +136,7 @@ export class AssessmentResultFactory {
     juryId,
     competenceMarks,
     capacity,
+    versionId,
   }) {
     return this.#buildWithAutoJuryComment({
       autoJuryCommentKey: AutoJuryCommentKeys.REJECTED_DUE_TO_LACK_OF_ANSWERS,
@@ -137,6 +147,7 @@ export class AssessmentResultFactory {
       juryId,
       competenceMarks,
       capacity,
+      versionId,
     });
   }
 
@@ -147,6 +158,7 @@ export class AssessmentResultFactory {
     juryId,
     competenceMarks,
     capacity,
+    versionId,
   }) {
     return this.#buildWithAutoJuryComment({
       autoJuryCommentKey: AutoJuryCommentKeys.CANCELLED_DUE_TO_LACK_OF_ANSWERS_FOR_TECHNICAL_REASON,
@@ -157,6 +169,7 @@ export class AssessmentResultFactory {
       juryId,
       competenceMarks,
       capacity,
+      versionId,
     });
   }
 
@@ -167,6 +180,7 @@ export class AssessmentResultFactory {
     juryId,
     competenceMarks,
     capacity,
+    versionId,
   }) {
     return this.#buildWithAutoJuryComment({
       autoJuryCommentKey: AutoJuryCommentKeys.REJECTED_DUE_TO_INSUFFICIENT_CORRECT_ANSWERS,
@@ -177,6 +191,7 @@ export class AssessmentResultFactory {
       juryId,
       competenceMarks,
       capacity,
+      versionId,
     });
   }
 
@@ -187,6 +202,7 @@ export class AssessmentResultFactory {
     juryId,
     competenceMarks,
     capacity,
+    versionId,
   }) {
     return this.#buildWithAutoJuryComment({
       autoJuryCommentKey: AutoJuryCommentKeys.REJECTED_DUE_TO_ZERO_PIX_SCORE,
@@ -197,6 +213,7 @@ export class AssessmentResultFactory {
       juryId,
       competenceMarks,
       capacity,
+      versionId,
     });
   }
 }

--- a/api/src/certification/evaluation/domain/services/scoring/create-v3-assessment-result.js
+++ b/api/src/certification/evaluation/domain/services/scoring/create-v3-assessment-result.js
@@ -5,6 +5,7 @@ export function createV3AssessmentResult({
   allAnswers,
   assessmentId,
   pixScore,
+  capacity,
   status,
   competenceMarks,
   isRejectedForFraud,
@@ -18,6 +19,7 @@ export function createV3AssessmentResult({
       pixScore,
       assessmentId,
       competenceMarks,
+      capacity,
     });
   }
   if (isRejectedForFraud) {
@@ -26,6 +28,7 @@ export function createV3AssessmentResult({
       assessmentId,
       juryId,
       competenceMarks,
+      capacity,
     });
   }
 
@@ -38,6 +41,7 @@ export function createV3AssessmentResult({
         assessmentId,
         juryId,
         competenceMarks,
+        capacity,
       });
     } else {
       return AssessmentResultFactory.buildLackOfAnswers({
@@ -46,6 +50,7 @@ export function createV3AssessmentResult({
         assessmentId,
         juryId,
         competenceMarks,
+        capacity,
       });
     }
   }
@@ -56,6 +61,7 @@ export function createV3AssessmentResult({
       assessmentId,
       juryId,
       competenceMarks,
+      capacity,
     });
   }
 
@@ -65,6 +71,7 @@ export function createV3AssessmentResult({
     assessmentId,
     juryId,
     competenceMarks,
+    capacity,
   });
 }
 

--- a/api/src/certification/evaluation/domain/services/scoring/create-v3-assessment-result.js
+++ b/api/src/certification/evaluation/domain/services/scoring/create-v3-assessment-result.js
@@ -6,6 +6,7 @@ export function createV3AssessmentResult({
   assessmentId,
   pixScore,
   capacity,
+  versionId,
   status,
   competenceMarks,
   isRejectedForFraud,
@@ -20,6 +21,7 @@ export function createV3AssessmentResult({
       assessmentId,
       competenceMarks,
       capacity,
+      versionId,
     });
   }
   if (isRejectedForFraud) {
@@ -29,6 +31,7 @@ export function createV3AssessmentResult({
       juryId,
       competenceMarks,
       capacity,
+      versionId,
     });
   }
 
@@ -42,6 +45,7 @@ export function createV3AssessmentResult({
         juryId,
         competenceMarks,
         capacity,
+        versionId,
       });
     } else {
       return AssessmentResultFactory.buildLackOfAnswers({
@@ -51,6 +55,7 @@ export function createV3AssessmentResult({
         juryId,
         competenceMarks,
         capacity,
+        versionId,
       });
     }
   }
@@ -62,6 +67,7 @@ export function createV3AssessmentResult({
       juryId,
       competenceMarks,
       capacity,
+      versionId,
     });
   }
 
@@ -72,6 +78,7 @@ export function createV3AssessmentResult({
     juryId,
     competenceMarks,
     capacity,
+    versionId,
   });
 }
 

--- a/api/src/certification/evaluation/domain/services/scoring/create-v3-assessment-result.js
+++ b/api/src/certification/evaluation/domain/services/scoring/create-v3-assessment-result.js
@@ -17,6 +17,7 @@ export function createV3AssessmentResult({
       juryId,
       pixScore,
       assessmentId,
+      competenceMarks,
     });
   }
   if (isRejectedForFraud) {
@@ -24,6 +25,7 @@ export function createV3AssessmentResult({
       pixScore,
       assessmentId,
       juryId,
+      competenceMarks,
     });
   }
 
@@ -35,6 +37,7 @@ export function createV3AssessmentResult({
         pixScore,
         assessmentId,
         juryId,
+        competenceMarks,
       });
     } else {
       return AssessmentResultFactory.buildLackOfAnswers({
@@ -42,6 +45,7 @@ export function createV3AssessmentResult({
         status,
         assessmentId,
         juryId,
+        competenceMarks,
       });
     }
   }
@@ -60,6 +64,7 @@ export function createV3AssessmentResult({
     status,
     assessmentId,
     juryId,
+    competenceMarks,
   });
 }
 

--- a/api/src/certification/evaluation/domain/services/scoring/create-v3-assessment-result.js
+++ b/api/src/certification/evaluation/domain/services/scoring/create-v3-assessment-result.js
@@ -6,6 +6,7 @@ export function createV3AssessmentResult({
   assessmentId,
   pixScore,
   capacity,
+  reachedMeshIndex,
   versionId,
   status,
   competenceMarks,
@@ -21,6 +22,7 @@ export function createV3AssessmentResult({
       assessmentId,
       competenceMarks,
       capacity,
+      reachedMeshIndex,
       versionId,
     });
   }
@@ -31,6 +33,7 @@ export function createV3AssessmentResult({
       juryId,
       competenceMarks,
       capacity,
+      reachedMeshIndex,
       versionId,
     });
   }
@@ -45,6 +48,7 @@ export function createV3AssessmentResult({
         juryId,
         competenceMarks,
         capacity,
+        reachedMeshIndex,
         versionId,
       });
     } else {
@@ -55,6 +59,7 @@ export function createV3AssessmentResult({
         juryId,
         competenceMarks,
         capacity,
+        reachedMeshIndex,
         versionId,
       });
     }
@@ -65,8 +70,8 @@ export function createV3AssessmentResult({
       pixScore,
       assessmentId,
       juryId,
-      competenceMarks,
       capacity,
+      reachedMeshIndex,
       versionId,
     });
   }
@@ -78,6 +83,7 @@ export function createV3AssessmentResult({
     juryId,
     competenceMarks,
     capacity,
+    reachedMeshIndex,
     versionId,
   });
 }

--- a/api/src/certification/evaluation/domain/services/scoring/scoring-v3.js
+++ b/api/src/certification/evaluation/domain/services/scoring/scoring-v3.js
@@ -47,6 +47,7 @@ export function handleV3CertificationScoring({
   v3CertificationScoring,
   cleaScoringCriteria,
   scoringDegradationService,
+  versionId,
 }) {
   if (candidate.hasPixPlusSubscription) {
     return {
@@ -71,6 +72,7 @@ export function handleV3CertificationScoring({
     maximumAssessmentLength,
     minimumAnswersRequiredToValidateACertification:
       v3CertificationScoring.minimumAnswersRequiredToValidateACertification,
+    versionId,
   });
 
   let doubleCertificationScoring = null;
@@ -103,6 +105,7 @@ function scoreCertification({
   assessmentSheet,
   maximumAssessmentLength,
   minimumAnswersRequiredToValidateACertification,
+  versionId,
 }) {
   const downgradeCapacity = shouldDowngradeCapacity({
     maximumAssessmentLength,
@@ -129,6 +132,7 @@ function scoreCertification({
     assessmentId: assessmentSheet.assessmentId,
     pixScore,
     capacity,
+    versionId,
     status,
     competenceMarks,
     isRejectedForFraud: assessmentSheet.isRejectedForFraud,

--- a/api/src/certification/evaluation/domain/services/scoring/scoring-v3.js
+++ b/api/src/certification/evaluation/domain/services/scoring/scoring-v3.js
@@ -116,6 +116,7 @@ function scoreCertification({
 
   const capacity = scoringV3Algorithm.computeCapacity({ shouldDowngradeCapacity: downgradeCapacity });
   const pixScore = scoringV3Algorithm.computePixScoreFromCapacity({ capacity });
+  const reachedMeshIndex = scoringV3Algorithm.computeReachedMeshIndex({ capacity });
   const competenceMarks = scoringV3Algorithm.computeCompetenceMarks({ capacity });
   const status = isCertificationRejected({
     answers: assessmentSheet.answers,
@@ -132,6 +133,7 @@ function scoreCertification({
     assessmentId: assessmentSheet.assessmentId,
     pixScore,
     capacity,
+    reachedMeshIndex,
     versionId,
     status,
     competenceMarks,

--- a/api/src/certification/evaluation/domain/services/scoring/scoring-v3.js
+++ b/api/src/certification/evaluation/domain/services/scoring/scoring-v3.js
@@ -47,7 +47,6 @@ export function handleV3CertificationScoring({
   v3CertificationScoring,
   cleaScoringCriteria,
   scoringDegradationService,
-  versionId,
 }) {
   if (candidate.hasPixPlusSubscription) {
     return {
@@ -72,7 +71,7 @@ export function handleV3CertificationScoring({
     maximumAssessmentLength,
     minimumAnswersRequiredToValidateACertification:
       v3CertificationScoring.minimumAnswersRequiredToValidateACertification,
-    versionId,
+    versionId: v3CertificationScoring.versionId,
   });
 
   let doubleCertificationScoring = null;

--- a/api/src/certification/evaluation/domain/services/scoring/scoring-v3.js
+++ b/api/src/certification/evaluation/domain/services/scoring/scoring-v3.js
@@ -128,6 +128,7 @@ function scoreCertification({
     allAnswers: assessmentSheet.answers,
     assessmentId: assessmentSheet.assessmentId,
     pixScore,
+    capacity,
     status,
     competenceMarks,
     isRejectedForFraud: assessmentSheet.isRejectedForFraud,

--- a/api/src/certification/evaluation/domain/services/scoring/scoring-v3.js
+++ b/api/src/certification/evaluation/domain/services/scoring/scoring-v3.js
@@ -35,7 +35,7 @@ import { createV3AssessmentResult } from './create-v3-assessment-result.js';
  * @param {ComplementaryCertificationScoringCriteria} params.cleaScoringCriteria
  * @param {ScoringDegradationService} params.scoringDegradationService
  *
- * @return {Object<Object<AssessmentResult, CompetenceMark[]>, DoubleCertificationScoring>}
+ * @return {Object<AssessmentResult, DoubleCertificationScoring>}
  */
 export function handleV3CertificationScoring({
   event,
@@ -50,7 +50,7 @@ export function handleV3CertificationScoring({
 }) {
   if (candidate.hasPixPlusSubscription) {
     return {
-      coreScoring: null,
+      coreAssessmentResult: null,
       doubleCertificationScoring: null,
     }; // WIP : will be done in the future
   }
@@ -64,7 +64,7 @@ export function handleV3CertificationScoring({
     downgradeCapacityFunction: scoringDegradationService.downgradeCapacity,
   });
   const maximumAssessmentLength = algorithm.getConfiguration().maximumAssessmentLength;
-  const { assessmentResult, competenceMarks } = scoreCertification({
+  const assessmentResult = scoreCertification({
     event,
     scoringV3Algorithm,
     assessmentSheet,
@@ -82,7 +82,7 @@ export function handleV3CertificationScoring({
     });
   }
   return {
-    coreScoring: { assessmentResult, competenceMarks },
+    coreAssessmentResult: assessmentResult,
     doubleCertificationScoring,
   };
 }
@@ -95,7 +95,7 @@ export function handleV3CertificationScoring({
  * @param {number} params.maximumAssessmentLength
  * @param {number} params.minimumAnswersRequiredToValidateACertification
  *
- * @returns {Object<AssessmentResult, CompetenceMark[]>}
+ * @returns {AssessmentResult}
  */
 function scoreCertification({
   event,
@@ -135,7 +135,7 @@ function scoreCertification({
     juryId: event?.juryId,
     minimumAnswersRequiredToValidateACertification,
   });
-  return { competenceMarks, assessmentResult };
+  return assessmentResult;
 }
 
 /**

--- a/api/src/certification/evaluation/domain/usecases/score-v3-certification.js
+++ b/api/src/certification/evaluation/domain/usecases/score-v3-certification.js
@@ -16,7 +16,6 @@
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { NotFinalizedSessionError, NotFoundError } from '../../../../shared/domain/errors.js';
 import { SessionAlreadyPublishedError } from '../../../session-management/domain/errors.js';
-import { CompetenceMark } from '../../../shared/domain/models/CompetenceMark.js';
 import { ComplementaryCertificationCourseResult } from '../../../shared/domain/models/ComplementaryCertificationCourseResult.js';
 import { CertificationAssessmentHistory } from '../models/CertificationAssessmentHistory.js';
 import { FlashAssessmentAlgorithm } from '../models/FlashAssessmentAlgorithm.js';
@@ -94,7 +93,7 @@ export async function scoreV3Certification({
     certificationCourseId: assessmentSheet.certificationCourseId,
   });
 
-  const { coreScoring, doubleCertificationScoring } = services.handleV3CertificationScoring({
+  const { coreAssessmentResult, doubleCertificationScoring } = services.handleV3CertificationScoring({
     event,
     candidate,
     assessmentSheet,
@@ -115,11 +114,10 @@ export async function scoreV3Certification({
   await DomainTransaction.execute(async () => {
     await certificationAssessmentHistoryRepository.save(certificationAssessmentHistory);
 
-    if (coreScoring) {
+    if (coreAssessmentResult) {
       await _saveV3Result({
-        assessmentResult: coreScoring.assessmentResult,
+        assessmentResult: coreAssessmentResult,
         certificationCourseId: assessmentSheet.certificationCourseId,
-        competenceMarks: coreScoring.competenceMarks,
         assessmentResultRepository,
         sharedCompetenceMarkRepository,
         certificationCourseRepository,
@@ -178,7 +176,6 @@ const _verifyCertificationIsScorable = async ({
 async function _saveV3Result({
   assessmentResult,
   certificationCourseId,
-  competenceMarks,
   assessmentResultRepository,
   sharedCompetenceMarkRepository,
   certificationCourseRepository,
@@ -188,12 +185,9 @@ async function _saveV3Result({
     assessmentResult,
   });
 
-  for (const competenceMark of competenceMarks) {
-    const competenceMarkDomain = new CompetenceMark({
-      ...competenceMark,
-      assessmentResultId: newAssessmentResult.id,
-    });
-    await sharedCompetenceMarkRepository.save(competenceMarkDomain);
+  for (const competenceMark of assessmentResult.competenceMarks) {
+    competenceMark.assessmentResultId = newAssessmentResult.id;
+    await sharedCompetenceMarkRepository.save(competenceMark);
   }
 
   const certificationCourse = await certificationCourseRepository.get({ id: certificationCourseId });

--- a/api/src/certification/evaluation/domain/usecases/score-v3-certification.js
+++ b/api/src/certification/evaluation/domain/usecases/score-v3-certification.js
@@ -103,7 +103,6 @@ export async function scoreV3Certification({
     algorithm,
     v3CertificationScoring,
     cleaScoringCriteria,
-    versionId: version.id,
   });
 
   const certificationAssessmentHistory = CertificationAssessmentHistory.fromChallengesAndAnswers({

--- a/api/src/certification/evaluation/domain/usecases/score-v3-certification.js
+++ b/api/src/certification/evaluation/domain/usecases/score-v3-certification.js
@@ -102,6 +102,7 @@ export async function scoreV3Certification({
     algorithm,
     v3CertificationScoring,
     cleaScoringCriteria,
+    versionId: version.id,
   });
 
   const certificationAssessmentHistory = CertificationAssessmentHistory.fromChallengesAndAnswers({

--- a/api/src/certification/evaluation/domain/usecases/score-v3-certification.js
+++ b/api/src/certification/evaluation/domain/usecases/score-v3-certification.js
@@ -16,6 +16,7 @@
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { NotFinalizedSessionError, NotFoundError } from '../../../../shared/domain/errors.js';
 import { SessionAlreadyPublishedError } from '../../../session-management/domain/errors.js';
+import { CompetenceMark } from '../../../shared/domain/models/CompetenceMark.js';
 import { ComplementaryCertificationCourseResult } from '../../../shared/domain/models/ComplementaryCertificationCourseResult.js';
 import { CertificationAssessmentHistory } from '../models/CertificationAssessmentHistory.js';
 import { FlashAssessmentAlgorithm } from '../models/FlashAssessmentAlgorithm.js';
@@ -170,9 +171,9 @@ const _verifyCertificationIsScorable = async ({
  * @param {object} params
  * @param {AssessmentResult} params.assessmentResult
  * @param {number} params.certificationCourseId
- * @param {CompetenceMark} params.competenceMarks
  * @param {AssessmentResultRepository} params.assessmentResultRepository
- * @param {sharedCompetenceMarkRepository} params.sharedCompetenceMarkRepository
+ * @param {SharedCompetenceMarkRepository} params.sharedCompetenceMarkRepository
+ * @param {CertificationCourseRepository} params.certificationCourseRepository
  */
 async function _saveV3Result({
   assessmentResult,
@@ -186,10 +187,13 @@ async function _saveV3Result({
     assessmentResult,
   });
 
-  for (const competenceMark of assessmentResult.competenceMarks) {
-    competenceMark.assessmentResultId = newAssessmentResult.id;
-    await sharedCompetenceMarkRepository.save(competenceMark);
-  }
+  const competenceMarksToSave = assessmentResult.competenceMarks.map(
+    (competenceMark) => new CompetenceMark({ ...competenceMark, assessmentResultId: newAssessmentResult.id }),
+  );
+
+  await sharedCompetenceMarkRepository.saveMany({
+    competenceMarks: competenceMarksToSave,
+  });
 
   const certificationCourse = await certificationCourseRepository.get({ id: certificationCourseId });
   certificationCourse.complete({ now: new Date() });

--- a/api/src/certification/evaluation/infrastructure/repositories/scoring-configuration-repository.js
+++ b/api/src/certification/evaluation/infrastructure/repositories/scoring-configuration-repository.js
@@ -10,7 +10,7 @@ export const getLatestByDateAndLocale = async ({ locale, date }) => {
   // NOTE : only works for certification of core competencies
   const competenceList = await competenceRepository.listPixCompetencesOnly({ locale });
 
-  const configuration = await knexConn('certification_versions')
+  const certificationVersion = await knexConn('certification_versions')
     .select(
       'id',
       'globalScoringConfiguration',
@@ -24,19 +24,20 @@ export const getLatestByDateAndLocale = async ({ locale, date }) => {
     .first();
 
   if (
-    !configuration?.competencesScoringConfiguration ||
-    !configuration?.globalScoringConfiguration ||
-    !configuration?.minimumAnswersRequiredToValidateACertification
+    !certificationVersion?.competencesScoringConfiguration ||
+    !certificationVersion?.globalScoringConfiguration ||
+    !certificationVersion?.minimumAnswersRequiredToValidateACertification
   ) {
     throw new NotFoundError(`No certification scoring configuration found for date ${date.toISOString()}`);
   }
 
   return V3CertificationScoring.fromConfigurations({
-    competenceForScoringConfiguration: configuration.competencesScoringConfiguration,
-    certificationScoringConfiguration: configuration.globalScoringConfiguration,
+    competenceForScoringConfiguration: certificationVersion.competencesScoringConfiguration,
+    certificationScoringConfiguration: certificationVersion.globalScoringConfiguration,
     allAreas,
     competenceList,
-    minimumAnswersRequiredToValidateACertification: configuration.minimumAnswersRequiredToValidateACertification,
+    minimumAnswersRequiredToValidateACertification: certificationVersion.minimumAnswersRequiredToValidateACertification,
+    versionId: certificationVersion.id,
   });
 };
 
@@ -66,6 +67,7 @@ export const getLatestByVersion = async ({ version }) => {
     allAreas,
     competenceList,
     minimumAnswersRequiredToValidateACertification,
+    versionId: version.id,
   });
 };
 

--- a/api/src/certification/session-management/infrastructure/repositories/course-assessment-result-repository.js
+++ b/api/src/certification/session-management/infrastructure/repositories/course-assessment-result-repository.js
@@ -32,6 +32,9 @@ function _toDomain({ assessmentResultDTO, competencesMarksDTO }) {
     commentForOrganization,
     reproducibilityRate: reproducibilityRateAsNumber,
     competenceMarks: competenceMarks,
+    capacity: assessmentResultDTO.capacity,
+    reachedMeshIndex: assessmentResultDTO.reachedMeshIndex,
+    versionId: assessmentResultDTO.versionId,
   });
 }
 
@@ -51,6 +54,9 @@ const getLatestAssessmentResult = async function ({ certificationCourseId }) {
       juryId: 'assessment-results.juryId',
       pixScore: 'assessment-results.pixScore',
       reproducibilityRate: 'assessment-results.reproducibilityRate',
+      capacity: 'assessment-results.capacity',
+      reachedMeshIndex: 'assessment-results.reachedMeshIndex',
+      versionId: 'assessment-results.versionId',
       competenceMarkId: 'competence-marks.id',
       competenceMarkAreaCode: 'competence-marks.area_code',
       competenceMarkCompetenceCode: 'competence-marks.competence_code',

--- a/api/src/certification/shared/infrastructure/repositories/competence-mark-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/competence-mark-repository.js
@@ -13,4 +13,18 @@ const save = async function (competenceMark) {
   return new CompetenceMark(savedCompetenceMark);
 };
 
-export { save };
+/**
+ * @param {object} params
+ * @param {CompetenceMark[]} params.competenceMarks
+ * @returns {Promise<CompetenceMark[]>}
+ */
+const saveMany = async function ({ competenceMarks }) {
+  await Promise.all(competenceMarks.map((competenceMark) => competenceMark.validate()));
+
+  const knexConn = DomainTransaction.getConnection();
+  const savedCompetenceMarks = await knexConn('competence-marks').insert(competenceMarks).returning('*');
+
+  return savedCompetenceMarks.map((competenceMark) => new CompetenceMark(competenceMark));
+};
+
+export { save, saveMany };

--- a/api/src/shared/domain/models/AssessmentResult.js
+++ b/api/src/shared/domain/models/AssessmentResult.js
@@ -30,6 +30,7 @@ class AssessmentResult {
    * @param {number} assessmentId
    * @param {number} juryId
    * @param {number} capacity
+   * @param {number} reachedMeshIndex
    * @param {number} versionId
    */
   constructor({
@@ -45,6 +46,7 @@ class AssessmentResult {
     assessmentId,
     juryId,
     capacity = null,
+    reachedMeshIndex = null,
     versionId = null,
   } = {}) {
     this.id = id;
@@ -59,6 +61,7 @@ class AssessmentResult {
     this.assessmentId = assessmentId;
     this.juryId = juryId;
     this.capacity = capacity;
+    this.reachedMeshIndex = reachedMeshIndex;
     this.versionId = versionId;
   }
 
@@ -89,6 +92,7 @@ class AssessmentResult {
       assessmentId: this.assessmentId,
       juryId: this.juryId,
       capacity: this.capacity,
+      reachedMeshIndex: this.reachedMeshIndex,
       versionId: this.versionId,
     });
   }

--- a/api/src/shared/domain/models/AssessmentResult.js
+++ b/api/src/shared/domain/models/AssessmentResult.js
@@ -30,6 +30,7 @@ class AssessmentResult {
    * @param {number} assessmentId
    * @param {number} juryId
    * @param {number} capacity
+   * @param {number} versionId
    */
   constructor({
     id,
@@ -44,6 +45,7 @@ class AssessmentResult {
     assessmentId,
     juryId,
     capacity = null,
+    versionId = null,
   } = {}) {
     this.id = id;
     this.commentForCandidate = commentForCandidate;
@@ -57,6 +59,7 @@ class AssessmentResult {
     this.assessmentId = assessmentId;
     this.juryId = juryId;
     this.capacity = capacity;
+    this.versionId = versionId;
   }
 
   /**
@@ -86,6 +89,7 @@ class AssessmentResult {
       assessmentId: this.assessmentId,
       juryId: this.juryId,
       capacity: this.capacity,
+      versionId: this.versionId,
     });
   }
 

--- a/api/src/shared/domain/models/AssessmentResult.js
+++ b/api/src/shared/domain/models/AssessmentResult.js
@@ -29,6 +29,7 @@ class AssessmentResult {
    * @param {Array<CompetenceMark>} competenceMarks
    * @param {number} assessmentId
    * @param {number} juryId
+   * @param {number} capacity
    */
   constructor({
     id,
@@ -42,6 +43,7 @@ class AssessmentResult {
     competenceMarks = [],
     assessmentId,
     juryId,
+    capacity = null,
   } = {}) {
     this.id = id;
     this.commentForCandidate = commentForCandidate;
@@ -54,6 +56,7 @@ class AssessmentResult {
     this.competenceMarks = competenceMarks;
     this.assessmentId = assessmentId;
     this.juryId = juryId;
+    this.capacity = capacity;
   }
 
   /**
@@ -82,6 +85,7 @@ class AssessmentResult {
       competenceMarks: this.competenceMarks,
       assessmentId: this.assessmentId,
       juryId: this.juryId,
+      capacity: this.capacity,
     });
   }
 

--- a/api/src/shared/infrastructure/repositories/assessment-result-repository.js
+++ b/api/src/shared/infrastructure/repositories/assessment-result-repository.js
@@ -36,13 +36,24 @@ function _toDomain({ assessmentResultDTO, competencesMarksDTO }) {
     reproducibilityRate: reproducibilityRateAsNumber,
     competenceMarks: competenceMarks,
     capacity: assessmentResultDTO.capacity,
+    reachedMeshIndex: assessmentResultDTO.reachedMeshIndex,
     versionId: assessmentResultDTO.versionId,
   });
 }
 
 const save = async function ({ certificationCourseId, assessmentResult }) {
-  const { pixScore, reproducibilityRate, status, commentByJury, id, juryId, assessmentId, capacity, versionId } =
-    assessmentResult;
+  const {
+    pixScore,
+    reproducibilityRate,
+    status,
+    commentByJury,
+    id,
+    juryId,
+    assessmentId,
+    capacity,
+    reachedMeshIndex,
+    versionId,
+  } = assessmentResult;
   const commentByAutoJury = _getCommentByAutoJury(assessmentResult);
 
   if (_.isNil(assessmentId)) {
@@ -60,6 +71,7 @@ const save = async function ({ certificationCourseId, assessmentResult }) {
       juryId,
       assessmentId,
       capacity,
+      reachedMeshIndex,
       versionId,
       commentForCandidate: assessmentResult.commentForCandidate?.fallbackComment,
       commentForOrganization: assessmentResult.commentForOrganization?.fallbackComment,

--- a/api/src/shared/infrastructure/repositories/assessment-result-repository.js
+++ b/api/src/shared/infrastructure/repositories/assessment-result-repository.js
@@ -35,11 +35,12 @@ function _toDomain({ assessmentResultDTO, competencesMarksDTO }) {
     pixScore: assessmentResultDTO.pixScore,
     reproducibilityRate: reproducibilityRateAsNumber,
     competenceMarks: competenceMarks,
+    capacity: assessmentResultDTO.capacity,
   });
 }
 
 const save = async function ({ certificationCourseId, assessmentResult }) {
-  const { pixScore, reproducibilityRate, status, commentByJury, id, juryId, assessmentId } = assessmentResult;
+  const { pixScore, reproducibilityRate, status, commentByJury, id, juryId, assessmentId, capacity } = assessmentResult;
   const commentByAutoJury = _getCommentByAutoJury(assessmentResult);
 
   if (_.isNil(assessmentId)) {
@@ -56,6 +57,7 @@ const save = async function ({ certificationCourseId, assessmentResult }) {
       id,
       juryId,
       assessmentId,
+      capacity,
       commentForCandidate: assessmentResult.commentForCandidate?.fallbackComment,
       commentForOrganization: assessmentResult.commentForOrganization?.fallbackComment,
       commentByAutoJury,

--- a/api/src/shared/infrastructure/repositories/assessment-result-repository.js
+++ b/api/src/shared/infrastructure/repositories/assessment-result-repository.js
@@ -36,11 +36,13 @@ function _toDomain({ assessmentResultDTO, competencesMarksDTO }) {
     reproducibilityRate: reproducibilityRateAsNumber,
     competenceMarks: competenceMarks,
     capacity: assessmentResultDTO.capacity,
+    versionId: assessmentResultDTO.versionId,
   });
 }
 
 const save = async function ({ certificationCourseId, assessmentResult }) {
-  const { pixScore, reproducibilityRate, status, commentByJury, id, juryId, assessmentId, capacity } = assessmentResult;
+  const { pixScore, reproducibilityRate, status, commentByJury, id, juryId, assessmentId, capacity, versionId } =
+    assessmentResult;
   const commentByAutoJury = _getCommentByAutoJury(assessmentResult);
 
   if (_.isNil(assessmentId)) {
@@ -58,6 +60,7 @@ const save = async function ({ certificationCourseId, assessmentResult }) {
       juryId,
       assessmentId,
       capacity,
+      versionId,
       commentForCandidate: assessmentResult.commentForCandidate?.fallbackComment,
       commentForOrganization: assessmentResult.commentForOrganization?.fallbackComment,
       commentByAutoJury,

--- a/api/tests/certification/evaluation/acceptance/application/certification-rescoring-route_test.js
+++ b/api/tests/certification/evaluation/acceptance/application/certification-rescoring-route_test.js
@@ -68,6 +68,10 @@ describe('Certification | Evaluation | Acceptance | Application |  certification
         const currentVersion = databaseBuilder.factory.buildCertificationVersion({
           startDate: new Date('2010-02-01'),
           expirationDate: null,
+          globalScoringConfiguration: [
+            { bounds: { max: -4, min: -8 }, meshLevel: 0 },
+            { bounds: { max: 8, min: -4 }, meshLevel: 1 },
+          ],
           minimumAnswersRequiredToValidateACertification: 1,
         });
 
@@ -137,8 +141,9 @@ describe('Certification | Evaluation | Acceptance | Application |  certification
         const descOrderedAssessmentResults = await knex('assessment-results').orderBy('createdAt', 'DESC');
         expect(descOrderedAssessmentResults).to.have.length(2);
         const [lastAssessmentResult] = descOrderedAssessmentResults;
-        expect(lastAssessmentResult.pixScore).to.be.equal(48);
+        expect(lastAssessmentResult.pixScore).to.be.equal(69);
         expect(lastAssessmentResult.capacity).to.be.equal(-3);
+        expect(lastAssessmentResult.reachedMeshIndex).to.be.equal(1);
         expect(lastAssessmentResult.juryId).to.be.equal(user.id);
         expect(lastAssessmentResult.versionId).to.be.equal(currentVersion.id);
       });
@@ -201,6 +206,10 @@ describe('Certification | Evaluation | Acceptance | Application |  certification
             maximumAssessmentLength: 1,
             defaultCandidateCapacity: -3,
           }),
+          globalScoringConfiguration: [
+            { bounds: { max: -4, min: -8 }, meshLevel: 0 },
+            { bounds: { max: 8, min: -4 }, meshLevel: 1 },
+          ],
           minimumAnswersRequiredToValidateACertification: 1,
         });
 
@@ -281,8 +290,9 @@ describe('Certification | Evaluation | Acceptance | Application |  certification
         const descOrderedAssessmentResults = await knex('assessment-results').orderBy('createdAt', 'DESC');
         expect(descOrderedAssessmentResults).to.have.length(2);
         const [lastAssessmentResult] = descOrderedAssessmentResults;
-        expect(lastAssessmentResult.pixScore).to.be.equal(48);
+        expect(lastAssessmentResult.pixScore).to.be.equal(69);
         expect(lastAssessmentResult.capacity).to.be.equal(-3);
+        expect(lastAssessmentResult.reachedMeshIndex).to.be.equal(1);
         expect(lastAssessmentResult.juryId).to.be.equal(user.id);
         expect(lastAssessmentResult.versionId).to.be.equal(archivedVersion.id);
       });

--- a/api/tests/certification/evaluation/acceptance/application/certification-rescoring-route_test.js
+++ b/api/tests/certification/evaluation/acceptance/application/certification-rescoring-route_test.js
@@ -65,7 +65,7 @@ describe('Certification | Evaluation | Acceptance | Application |  certification
           competencesScoringConfiguration: null,
           minimumAnswersRequiredToValidateACertification: 1,
         });
-        databaseBuilder.factory.buildCertificationVersion({
+        const currentVersion = databaseBuilder.factory.buildCertificationVersion({
           startDate: new Date('2010-02-01'),
           expirationDate: null,
           minimumAnswersRequiredToValidateACertification: 1,
@@ -138,7 +138,9 @@ describe('Certification | Evaluation | Acceptance | Application |  certification
         expect(descOrderedAssessmentResults).to.have.length(2);
         const [lastAssessmentResult] = descOrderedAssessmentResults;
         expect(lastAssessmentResult.pixScore).to.be.equal(48);
+        expect(lastAssessmentResult.capacity).to.be.equal(-3);
         expect(lastAssessmentResult.juryId).to.be.equal(user.id);
+        expect(lastAssessmentResult.versionId).to.be.equal(currentVersion.id);
       });
     });
 
@@ -192,7 +194,7 @@ describe('Certification | Evaluation | Acceptance | Application |  certification
           delta: 4.4,
         });
 
-        databaseBuilder.factory.buildCertificationVersion({
+        const archivedVersion = databaseBuilder.factory.buildCertificationVersion({
           startDate: new Date('2010-02-01'),
           expirationDate: new Date('2024-02-01'),
           challengesConfiguration: domainBuilder.buildFlashAlgorithmConfiguration({
@@ -280,7 +282,9 @@ describe('Certification | Evaluation | Acceptance | Application |  certification
         expect(descOrderedAssessmentResults).to.have.length(2);
         const [lastAssessmentResult] = descOrderedAssessmentResults;
         expect(lastAssessmentResult.pixScore).to.be.equal(48);
+        expect(lastAssessmentResult.capacity).to.be.equal(-3);
         expect(lastAssessmentResult.juryId).to.be.equal(user.id);
+        expect(lastAssessmentResult.versionId).to.be.equal(archivedVersion.id);
       });
     });
   });

--- a/api/tests/certification/evaluation/integration/infrastructure/repositories/scoring-configuration-repository_test.js
+++ b/api/tests/certification/evaluation/integration/infrastructure/repositories/scoring-configuration-repository_test.js
@@ -93,6 +93,7 @@ describe('Certification | Evaluation | Integration | Repositories | scoring-conf
 
       // then
       expect(result).to.be.instanceOf(V3CertificationScoring);
+      expect(result.versionId).to.be.a('number');
       expect(result._competencesForScoring[0].competenceId).to.be.equal(`${PIX_ORIGIN}Competence`);
       expect(result._competencesForScoring[0].intervals.length).not.to.be.equal(0);
       expect(result._certificationScoringConfiguration[0].bounds.min).to.be.equal(-8);
@@ -128,6 +129,7 @@ describe('Certification | Evaluation | Integration | Repositories | scoring-conf
 
       // then
       expect(result).to.be.instanceOf(V3CertificationScoring);
+      expect(result.versionId).to.equal(1);
       expect(result._competencesForScoring[0].competenceId).to.be.equal(`${PIX_ORIGIN}Competence`);
       expect(result._competencesForScoring[0].intervals.length).not.to.be.equal(0);
     });

--- a/api/tests/certification/evaluation/unit/domain/models/V3CertificationScoring_test.js
+++ b/api/tests/certification/evaluation/unit/domain/models/V3CertificationScoring_test.js
@@ -48,6 +48,18 @@ describe('Certification | Evaluation | Unit | Domain | Models | V3CertificationS
     });
   });
 
+  describe('#versionId', function () {
+    it('should return the versionId', function () {
+      const v3CertificationScoring = new V3CertificationScoring({
+        competencesForScoring: [],
+        certificationScoringConfiguration: [],
+        versionId: 42,
+      });
+
+      expect(v3CertificationScoring.versionId).to.equal(42);
+    });
+  });
+
   describe('#fromConfigurations', function () {
     it('should return a valid V3CertificationScoring', function () {
       const area = domainBuilder.buildArea();
@@ -73,8 +85,10 @@ describe('Certification | Evaluation | Unit | Domain | Models | V3CertificationS
         certificationScoringConfiguration: {},
         allAreas: [area],
         competenceList: [competence],
+        versionId: 99,
       });
 
+      expect(v3CertificationScoring.versionId).to.equal(99);
       expect(v3CertificationScoring.getCompetencesScore(0.5)).to.deep.equal([
         domainBuilder.buildCompetenceMark({
           competenceId: competence.id,

--- a/api/tests/certification/evaluation/unit/domain/models/factories/AssessmentResultFactory_test.js
+++ b/api/tests/certification/evaluation/unit/domain/models/factories/AssessmentResultFactory_test.js
@@ -28,6 +28,7 @@ describe('Certification | Evaluation | Unit | Domain | Factories | AssessmentRes
         reproducibilityRate: 0,
         competenceMarks: [],
         capacity: null,
+        versionId: null,
       });
       expectedAssessmentResult.id = undefined;
       expectedAssessmentResult.commentForCandidate = undefined;
@@ -51,6 +52,7 @@ describe('Certification | Evaluation | Unit | Domain | Factories | AssessmentRes
         juryId: 456,
         competenceMarks,
         capacity: 1.7,
+        versionId: 10,
       });
 
       // then
@@ -62,6 +64,7 @@ describe('Certification | Evaluation | Unit | Domain | Factories | AssessmentRes
         reproducibilityRate: 90,
         competenceMarks,
         capacity: 1.7,
+        versionId: 10,
       });
       expectedAssessmentResult.id = undefined;
       expectedAssessmentResult.commentForCandidate = undefined;
@@ -84,6 +87,7 @@ describe('Certification | Evaluation | Unit | Domain | Factories | AssessmentRes
         juryId: 456,
         competenceMarks,
         capacity: 0.84,
+        versionId: 10,
       });
 
       // then
@@ -95,6 +99,7 @@ describe('Certification | Evaluation | Unit | Domain | Factories | AssessmentRes
         reproducibilityRate: 50.25,
         competenceMarks,
         capacity: 0.84,
+        versionId: 10,
       });
       expectedAssessmentResult.id = undefined;
       expectedAssessmentResult.createdAt = undefined;
@@ -115,6 +120,7 @@ describe('Certification | Evaluation | Unit | Domain | Factories | AssessmentRes
         juryId: 456,
         competenceMarks,
         capacity: 2.13,
+        versionId: 10,
       });
 
       // then
@@ -126,6 +132,7 @@ describe('Certification | Evaluation | Unit | Domain | Factories | AssessmentRes
         reproducibilityRate: 50.25,
         competenceMarks,
         capacity: 2.13,
+        versionId: 10,
         commentForCandidate: domainBuilder.certification.shared.buildJuryComment.candidate({
           commentByAutoJury: AutoJuryCommentKeys.CANCELLED_DUE_TO_NEUTRALIZATION,
         }),
@@ -152,6 +159,7 @@ describe('Certification | Evaluation | Unit | Domain | Factories | AssessmentRes
         juryId: 456,
         competenceMarks,
         capacity: 3.21,
+        versionId: 10,
       });
 
       // then
@@ -163,6 +171,7 @@ describe('Certification | Evaluation | Unit | Domain | Factories | AssessmentRes
         reproducibilityRate: 50.25,
         competenceMarks,
         capacity: 3.21,
+        versionId: 10,
         commentForCandidate: domainBuilder.certification.shared.buildJuryComment.candidate({
           commentByAutoJury: AutoJuryCommentKeys.FRAUD,
         }),
@@ -190,6 +199,7 @@ describe('Certification | Evaluation | Unit | Domain | Factories | AssessmentRes
         juryId: 456,
         competenceMarks,
         capacity: -1.52,
+        versionId: 10,
       });
 
       // then
@@ -201,6 +211,7 @@ describe('Certification | Evaluation | Unit | Domain | Factories | AssessmentRes
         juryId: 456,
         competenceMarks,
         capacity: -1.52,
+        versionId: 10,
         commentForCandidate: domainBuilder.certification.shared.buildJuryComment.candidate({
           commentByAutoJury: AutoJuryCommentKeys.REJECTED_DUE_TO_INSUFFICIENT_CORRECT_ANSWERS,
         }),
@@ -227,6 +238,7 @@ describe('Certification | Evaluation | Unit | Domain | Factories | AssessmentRes
         juryId: 456,
         competenceMarks,
         capacity: -3.94,
+        versionId: 10,
       });
 
       // then
@@ -238,6 +250,7 @@ describe('Certification | Evaluation | Unit | Domain | Factories | AssessmentRes
         juryId: 456,
         competenceMarks,
         capacity: -3.94,
+        versionId: 10,
         commentForCandidate: domainBuilder.certification.shared.buildJuryComment.candidate({
           commentByAutoJury: AutoJuryCommentKeys.REJECTED_DUE_TO_ZERO_PIX_SCORE,
         }),
@@ -264,6 +277,7 @@ describe('Certification | Evaluation | Unit | Domain | Factories | AssessmentRes
         juryId: 456,
         competenceMarks,
         capacity: -0.67,
+        versionId: 10,
       });
 
       // then
@@ -275,6 +289,7 @@ describe('Certification | Evaluation | Unit | Domain | Factories | AssessmentRes
         juryId: 456,
         competenceMarks,
         capacity: -0.67,
+        versionId: 10,
         commentForCandidate: domainBuilder.certification.shared.buildJuryComment.candidate({
           commentByAutoJury: AutoJuryCommentKeys.CANCELLED_DUE_TO_LACK_OF_ANSWERS_FOR_TECHNICAL_REASON,
         }),

--- a/api/tests/certification/evaluation/unit/domain/models/factories/AssessmentResultFactory_test.js
+++ b/api/tests/certification/evaluation/unit/domain/models/factories/AssessmentResultFactory_test.js
@@ -28,6 +28,7 @@ describe('Certification | Evaluation | Unit | Domain | Factories | AssessmentRes
         reproducibilityRate: 0,
         competenceMarks: [],
         capacity: null,
+        reachedMeshIndex: null,
         versionId: null,
       });
       expectedAssessmentResult.id = undefined;
@@ -52,6 +53,7 @@ describe('Certification | Evaluation | Unit | Domain | Factories | AssessmentRes
         juryId: 456,
         competenceMarks,
         capacity: 1.7,
+        reachedMeshIndex: 4,
         versionId: 10,
       });
 
@@ -64,6 +66,7 @@ describe('Certification | Evaluation | Unit | Domain | Factories | AssessmentRes
         reproducibilityRate: 90,
         competenceMarks,
         capacity: 1.7,
+        reachedMeshIndex: 4,
         versionId: 10,
       });
       expectedAssessmentResult.id = undefined;
@@ -87,6 +90,7 @@ describe('Certification | Evaluation | Unit | Domain | Factories | AssessmentRes
         juryId: 456,
         competenceMarks,
         capacity: 0.84,
+        reachedMeshIndex: 4,
         versionId: 10,
       });
 
@@ -99,6 +103,7 @@ describe('Certification | Evaluation | Unit | Domain | Factories | AssessmentRes
         reproducibilityRate: 50.25,
         competenceMarks,
         capacity: 0.84,
+        reachedMeshIndex: 4,
         versionId: 10,
       });
       expectedAssessmentResult.id = undefined;
@@ -120,6 +125,7 @@ describe('Certification | Evaluation | Unit | Domain | Factories | AssessmentRes
         juryId: 456,
         competenceMarks,
         capacity: 2.13,
+        reachedMeshIndex: 4,
         versionId: 10,
       });
 
@@ -132,6 +138,7 @@ describe('Certification | Evaluation | Unit | Domain | Factories | AssessmentRes
         reproducibilityRate: 50.25,
         competenceMarks,
         capacity: 2.13,
+        reachedMeshIndex: 4,
         versionId: 10,
         commentForCandidate: domainBuilder.certification.shared.buildJuryComment.candidate({
           commentByAutoJury: AutoJuryCommentKeys.CANCELLED_DUE_TO_NEUTRALIZATION,
@@ -159,6 +166,7 @@ describe('Certification | Evaluation | Unit | Domain | Factories | AssessmentRes
         juryId: 456,
         competenceMarks,
         capacity: 3.21,
+        reachedMeshIndex: 4,
         versionId: 10,
       });
 
@@ -171,6 +179,7 @@ describe('Certification | Evaluation | Unit | Domain | Factories | AssessmentRes
         reproducibilityRate: 50.25,
         competenceMarks,
         capacity: 3.21,
+        reachedMeshIndex: 4,
         versionId: 10,
         commentForCandidate: domainBuilder.certification.shared.buildJuryComment.candidate({
           commentByAutoJury: AutoJuryCommentKeys.FRAUD,
@@ -187,9 +196,6 @@ describe('Certification | Evaluation | Unit | Domain | Factories | AssessmentRes
 
   describe('#buildInsufficientCorrectAnswers', function () {
     it('should return an insufficient correct answers AssessmentResult', function () {
-      // given
-      const competenceMarks = [domainBuilder.buildCompetenceMark()];
-
       // when
       const actualAssessmentResult = AssessmentResultFactory.buildInsufficientCorrectAnswers({
         pixScore: 0,
@@ -197,8 +203,8 @@ describe('Certification | Evaluation | Unit | Domain | Factories | AssessmentRes
         assessmentId: 123,
         status: AssessmentResult.status.REJECTED,
         juryId: 456,
-        competenceMarks,
         capacity: -1.52,
+        reachedMeshIndex: 0,
         versionId: 10,
       });
 
@@ -209,8 +215,8 @@ describe('Certification | Evaluation | Unit | Domain | Factories | AssessmentRes
         reproducibilityRate: 49,
         assessmentId: 123,
         juryId: 456,
-        competenceMarks,
         capacity: -1.52,
+        reachedMeshIndex: 0,
         versionId: 10,
         commentForCandidate: domainBuilder.certification.shared.buildJuryComment.candidate({
           commentByAutoJury: AutoJuryCommentKeys.REJECTED_DUE_TO_INSUFFICIENT_CORRECT_ANSWERS,
@@ -238,6 +244,7 @@ describe('Certification | Evaluation | Unit | Domain | Factories | AssessmentRes
         juryId: 456,
         competenceMarks,
         capacity: -3.94,
+        reachedMeshIndex: 0,
         versionId: 10,
       });
 
@@ -250,6 +257,7 @@ describe('Certification | Evaluation | Unit | Domain | Factories | AssessmentRes
         juryId: 456,
         competenceMarks,
         capacity: -3.94,
+        reachedMeshIndex: 0,
         versionId: 10,
         commentForCandidate: domainBuilder.certification.shared.buildJuryComment.candidate({
           commentByAutoJury: AutoJuryCommentKeys.REJECTED_DUE_TO_ZERO_PIX_SCORE,
@@ -277,6 +285,7 @@ describe('Certification | Evaluation | Unit | Domain | Factories | AssessmentRes
         juryId: 456,
         competenceMarks,
         capacity: -0.67,
+        reachedMeshIndex: 1,
         versionId: 10,
       });
 
@@ -289,6 +298,7 @@ describe('Certification | Evaluation | Unit | Domain | Factories | AssessmentRes
         juryId: 456,
         competenceMarks,
         capacity: -0.67,
+        reachedMeshIndex: 1,
         versionId: 10,
         commentForCandidate: domainBuilder.certification.shared.buildJuryComment.candidate({
           commentByAutoJury: AutoJuryCommentKeys.CANCELLED_DUE_TO_LACK_OF_ANSWERS_FOR_TECHNICAL_REASON,

--- a/api/tests/certification/evaluation/unit/domain/models/factories/AssessmentResultFactory_test.js
+++ b/api/tests/certification/evaluation/unit/domain/models/factories/AssessmentResultFactory_test.js
@@ -38,6 +38,9 @@ describe('Certification | Evaluation | Unit | Domain | Factories | AssessmentRes
 
   describe('#buildStandardAssessmentResult', function () {
     it('should return a standard AssessmentResult', function () {
+      // given
+      const competenceMarks = [domainBuilder.buildCompetenceMark()];
+
       // when
       const actualAssessmentResult = AssessmentResultFactory.buildStandardAssessmentResult({
         pixScore: 55,
@@ -45,6 +48,7 @@ describe('Certification | Evaluation | Unit | Domain | Factories | AssessmentRes
         status: AssessmentResult.status.VALIDATED,
         assessmentId: 123,
         juryId: 456,
+        competenceMarks,
       });
 
       // then
@@ -54,7 +58,7 @@ describe('Certification | Evaluation | Unit | Domain | Factories | AssessmentRes
         status: AssessmentResult.status.VALIDATED,
         pixScore: 55,
         reproducibilityRate: 90,
-        competenceMarks: [],
+        competenceMarks,
       });
       expectedAssessmentResult.id = undefined;
       expectedAssessmentResult.commentForCandidate = undefined;
@@ -66,12 +70,16 @@ describe('Certification | Evaluation | Unit | Domain | Factories | AssessmentRes
 
   describe('#buildCancelled', function () {
     it('should return a cancelled AssessmentResult', function () {
+      // given
+      const competenceMarks = [domainBuilder.buildCompetenceMark()];
+
       // when
       const actualAssessmentResult = AssessmentResultFactory.buildCancelledAssessmentResult({
         pixScore: 55,
         reproducibilityRate: 50.25,
         assessmentId: 123,
         juryId: 456,
+        competenceMarks,
       });
 
       // then
@@ -81,6 +89,7 @@ describe('Certification | Evaluation | Unit | Domain | Factories | AssessmentRes
         status: AssessmentResult.status.CANCELLED,
         pixScore: 55,
         reproducibilityRate: 50.25,
+        competenceMarks,
       });
       expectedAssessmentResult.id = undefined;
       expectedAssessmentResult.createdAt = undefined;
@@ -90,12 +99,16 @@ describe('Certification | Evaluation | Unit | Domain | Factories | AssessmentRes
 
   describe('#buildNotTrustableAssessmentResult', function () {
     it('should return a not trustable AssessmentResult', function () {
+      // given
+      const competenceMarks = [domainBuilder.buildCompetenceMark()];
+
       // when
       const actualAssessmentResult = AssessmentResultFactory.buildNotTrustableAssessmentResult({
         pixScore: 55,
         reproducibilityRate: 50.25,
         assessmentId: 123,
         juryId: 456,
+        competenceMarks,
       });
 
       // then
@@ -105,7 +118,7 @@ describe('Certification | Evaluation | Unit | Domain | Factories | AssessmentRes
         status: AssessmentResult.status.CANCELLED,
         pixScore: 55,
         reproducibilityRate: 50.25,
-        competenceMarks: [],
+        competenceMarks,
         commentForCandidate: domainBuilder.certification.shared.buildJuryComment.candidate({
           commentByAutoJury: AutoJuryCommentKeys.CANCELLED_DUE_TO_NEUTRALIZATION,
         }),
@@ -156,6 +169,9 @@ describe('Certification | Evaluation | Unit | Domain | Factories | AssessmentRes
 
   describe('#buildInsufficientCorrectAnswers', function () {
     it('should return an insufficient correct answers AssessmentResult', function () {
+      // given
+      const competenceMarks = [domainBuilder.buildCompetenceMark()];
+
       // when
       const actualAssessmentResult = AssessmentResultFactory.buildInsufficientCorrectAnswers({
         pixScore: 0,
@@ -163,6 +179,7 @@ describe('Certification | Evaluation | Unit | Domain | Factories | AssessmentRes
         assessmentId: 123,
         status: AssessmentResult.status.REJECTED,
         juryId: 456,
+        competenceMarks,
       });
 
       // then
@@ -172,6 +189,7 @@ describe('Certification | Evaluation | Unit | Domain | Factories | AssessmentRes
         reproducibilityRate: 49,
         assessmentId: 123,
         juryId: 456,
+        competenceMarks,
         commentForCandidate: domainBuilder.certification.shared.buildJuryComment.candidate({
           commentByAutoJury: AutoJuryCommentKeys.REJECTED_DUE_TO_INSUFFICIENT_CORRECT_ANSWERS,
         }),
@@ -222,12 +240,16 @@ describe('Certification | Evaluation | Unit | Domain | Factories | AssessmentRes
 
   describe('#buildLackOfAnswersForTechnicalReason', function () {
     it('should return a cancelled AssessmentResult', function () {
+      // given
+      const competenceMarks = [domainBuilder.buildCompetenceMark()];
+
       // when
       const actualAssessmentResult = AssessmentResultFactory.buildLackOfAnswersForTechnicalReason({
         pixScore: 0,
         reproducibilityRate: 49,
         assessmentId: 123,
         juryId: 456,
+        competenceMarks,
       });
 
       // then
@@ -237,6 +259,7 @@ describe('Certification | Evaluation | Unit | Domain | Factories | AssessmentRes
         reproducibilityRate: 49,
         assessmentId: 123,
         juryId: 456,
+        competenceMarks,
         commentForCandidate: domainBuilder.certification.shared.buildJuryComment.candidate({
           commentByAutoJury: AutoJuryCommentKeys.CANCELLED_DUE_TO_LACK_OF_ANSWERS_FOR_TECHNICAL_REASON,
         }),

--- a/api/tests/certification/evaluation/unit/domain/models/factories/AssessmentResultFactory_test.js
+++ b/api/tests/certification/evaluation/unit/domain/models/factories/AssessmentResultFactory_test.js
@@ -27,6 +27,7 @@ describe('Certification | Evaluation | Unit | Domain | Factories | AssessmentRes
         pixScore: 0,
         reproducibilityRate: 0,
         competenceMarks: [],
+        capacity: null,
       });
       expectedAssessmentResult.id = undefined;
       expectedAssessmentResult.commentForCandidate = undefined;
@@ -49,6 +50,7 @@ describe('Certification | Evaluation | Unit | Domain | Factories | AssessmentRes
         assessmentId: 123,
         juryId: 456,
         competenceMarks,
+        capacity: 1.7,
       });
 
       // then
@@ -59,6 +61,7 @@ describe('Certification | Evaluation | Unit | Domain | Factories | AssessmentRes
         pixScore: 55,
         reproducibilityRate: 90,
         competenceMarks,
+        capacity: 1.7,
       });
       expectedAssessmentResult.id = undefined;
       expectedAssessmentResult.commentForCandidate = undefined;
@@ -80,6 +83,7 @@ describe('Certification | Evaluation | Unit | Domain | Factories | AssessmentRes
         assessmentId: 123,
         juryId: 456,
         competenceMarks,
+        capacity: 0.84,
       });
 
       // then
@@ -90,6 +94,7 @@ describe('Certification | Evaluation | Unit | Domain | Factories | AssessmentRes
         pixScore: 55,
         reproducibilityRate: 50.25,
         competenceMarks,
+        capacity: 0.84,
       });
       expectedAssessmentResult.id = undefined;
       expectedAssessmentResult.createdAt = undefined;
@@ -109,6 +114,7 @@ describe('Certification | Evaluation | Unit | Domain | Factories | AssessmentRes
         assessmentId: 123,
         juryId: 456,
         competenceMarks,
+        capacity: 2.13,
       });
 
       // then
@@ -119,6 +125,7 @@ describe('Certification | Evaluation | Unit | Domain | Factories | AssessmentRes
         pixScore: 55,
         reproducibilityRate: 50.25,
         competenceMarks,
+        capacity: 2.13,
         commentForCandidate: domainBuilder.certification.shared.buildJuryComment.candidate({
           commentByAutoJury: AutoJuryCommentKeys.CANCELLED_DUE_TO_NEUTRALIZATION,
         }),
@@ -144,6 +151,7 @@ describe('Certification | Evaluation | Unit | Domain | Factories | AssessmentRes
         assessmentId: 123,
         juryId: 456,
         competenceMarks,
+        capacity: 3.21,
       });
 
       // then
@@ -154,6 +162,7 @@ describe('Certification | Evaluation | Unit | Domain | Factories | AssessmentRes
         pixScore: 55,
         reproducibilityRate: 50.25,
         competenceMarks,
+        capacity: 3.21,
         commentForCandidate: domainBuilder.certification.shared.buildJuryComment.candidate({
           commentByAutoJury: AutoJuryCommentKeys.FRAUD,
         }),
@@ -180,6 +189,7 @@ describe('Certification | Evaluation | Unit | Domain | Factories | AssessmentRes
         status: AssessmentResult.status.REJECTED,
         juryId: 456,
         competenceMarks,
+        capacity: -1.52,
       });
 
       // then
@@ -190,6 +200,7 @@ describe('Certification | Evaluation | Unit | Domain | Factories | AssessmentRes
         assessmentId: 123,
         juryId: 456,
         competenceMarks,
+        capacity: -1.52,
         commentForCandidate: domainBuilder.certification.shared.buildJuryComment.candidate({
           commentByAutoJury: AutoJuryCommentKeys.REJECTED_DUE_TO_INSUFFICIENT_CORRECT_ANSWERS,
         }),
@@ -215,6 +226,7 @@ describe('Certification | Evaluation | Unit | Domain | Factories | AssessmentRes
         assessmentId: 123,
         juryId: 456,
         competenceMarks,
+        capacity: -3.94,
       });
 
       // then
@@ -225,6 +237,7 @@ describe('Certification | Evaluation | Unit | Domain | Factories | AssessmentRes
         assessmentId: 123,
         juryId: 456,
         competenceMarks,
+        capacity: -3.94,
         commentForCandidate: domainBuilder.certification.shared.buildJuryComment.candidate({
           commentByAutoJury: AutoJuryCommentKeys.REJECTED_DUE_TO_ZERO_PIX_SCORE,
         }),
@@ -250,6 +263,7 @@ describe('Certification | Evaluation | Unit | Domain | Factories | AssessmentRes
         assessmentId: 123,
         juryId: 456,
         competenceMarks,
+        capacity: -0.67,
       });
 
       // then
@@ -260,6 +274,7 @@ describe('Certification | Evaluation | Unit | Domain | Factories | AssessmentRes
         assessmentId: 123,
         juryId: 456,
         competenceMarks,
+        capacity: -0.67,
         commentForCandidate: domainBuilder.certification.shared.buildJuryComment.candidate({
           commentByAutoJury: AutoJuryCommentKeys.CANCELLED_DUE_TO_LACK_OF_ANSWERS_FOR_TECHNICAL_REASON,
         }),

--- a/api/tests/certification/evaluation/unit/domain/services/scoring/create-v3-assessment-result_test.js
+++ b/api/tests/certification/evaluation/unit/domain/services/scoring/create-v3-assessment-result_test.js
@@ -9,6 +9,8 @@ const minimumAnswersRequiredToValidateACertification = 20;
 describe('Unit | Certification | Evaluation | Domain | Services | Create V3 Assessment Result', function () {
   const competenceMarks = Symbol('someCompetenceMarks');
   const pixScore = 456;
+  const capacity = 2.45;
+
   describe('createV3AssessmentResult', function () {
     it('it should return cancelled AssessmentResult if toBeCancelled is true', function () {
       //when
@@ -17,6 +19,7 @@ describe('Unit | Certification | Evaluation | Domain | Services | Create V3 Asse
         allAnswers: [],
         assessmentId: 123,
         pixScore,
+        capacity,
         status: AssessmentResult.status.CANCELLED,
         competenceMarks,
         isRejectedForFraud: false,
@@ -29,6 +32,7 @@ describe('Unit | Certification | Evaluation | Domain | Services | Create V3 Asse
       expect(assessmentResult.status).to.equal(AssessmentResult.status.CANCELLED);
       expect(assessmentResult.pixScore).to.equal(pixScore);
       expect(assessmentResult.competenceMarks).to.deep.equal(competenceMarks);
+      expect(assessmentResult.capacity).to.equal(capacity);
     });
 
     it('it should return a rejected for fraud AssessmentResult if isRejectedForFraud is true', function () {
@@ -37,6 +41,7 @@ describe('Unit | Certification | Evaluation | Domain | Services | Create V3 Asse
         toBeCancelled: false,
         allAnswers: [],
         pixScore,
+        capacity,
         status: AssessmentResult.status.REJECTED,
         competenceMarks,
         assessmentId: 123,
@@ -54,6 +59,7 @@ describe('Unit | Certification | Evaluation | Domain | Services | Create V3 Asse
       expect(assessmentResult.commentForOrganization).to.deep.equal(juryComment);
       expect(assessmentResult.pixScore).to.equal(pixScore);
       expect(assessmentResult.competenceMarks).to.deep.equal(competenceMarks);
+      expect(assessmentResult.capacity).to.equal(capacity);
     });
 
     context('when there is an insuffisant number of answer', function () {
@@ -64,6 +70,7 @@ describe('Unit | Certification | Evaluation | Domain | Services | Create V3 Asse
           allAnswers: [],
           assessmentId: 123,
           pixScore,
+          capacity,
           status: AssessmentResult.status.VALIDATED,
           competenceMarks,
           isRejectedForFraud: false,
@@ -80,6 +87,7 @@ describe('Unit | Certification | Evaluation | Domain | Services | Create V3 Asse
         expect(assessmentResult.commentForOrganization).to.deep.equal(juryComment);
         expect(assessmentResult.pixScore).to.equal(pixScore);
         expect(assessmentResult.competenceMarks).to.deep.equal(competenceMarks);
+        expect(assessmentResult.capacity).to.equal(capacity);
       });
 
       it('should return a rejected AssessmentResult if the cause is not technical', function () {
@@ -89,6 +97,7 @@ describe('Unit | Certification | Evaluation | Domain | Services | Create V3 Asse
           allAnswers: [],
           assessmentId: 123,
           pixScore,
+          capacity,
           status: AssessmentResult.status.REJECTED,
           competenceMarks,
           isRejectedForFraud: false,
@@ -105,6 +114,7 @@ describe('Unit | Certification | Evaluation | Domain | Services | Create V3 Asse
         expect(assessmentResult.commentForOrganization).to.deep.equal(juryComment);
         expect(assessmentResult.pixScore).to.equal(pixScore);
         expect(assessmentResult.competenceMarks).to.deep.equal(competenceMarks);
+        expect(assessmentResult.capacity).to.equal(capacity);
       });
     });
     context('when there is a sufficient number of answers', function () {
@@ -123,6 +133,7 @@ describe('Unit | Certification | Evaluation | Domain | Services | Create V3 Asse
           allAnswers: answers,
           assessmentId: 123,
           pixScore: 0,
+          capacity,
           status: AssessmentResult.status.VALIDATED,
           competenceMarks,
           isRejectedForFraud: false,
@@ -139,6 +150,7 @@ describe('Unit | Certification | Evaluation | Domain | Services | Create V3 Asse
         expect(assessmentResult.commentForOrganization).to.deep.equal(juryComment);
         expect(assessmentResult.pixScore).to.equal(0);
         expect(assessmentResult.competenceMarks).to.deep.equal([]);
+        expect(assessmentResult.capacity).to.equal(capacity);
       });
 
       it('should return a standard AssessmentResult if pix score is not 0', function () {
@@ -148,6 +160,7 @@ describe('Unit | Certification | Evaluation | Domain | Services | Create V3 Asse
           allAnswers: answers,
           assessmentId: 123,
           pixScore,
+          capacity,
           status: AssessmentResult.status.VALIDATED,
           competenceMarks,
           isRejectedForFraud: false,
@@ -160,6 +173,7 @@ describe('Unit | Certification | Evaluation | Domain | Services | Create V3 Asse
         expect(assessmentResult.status).to.equal(AssessmentResult.status.VALIDATED);
         expect(assessmentResult.pixScore).to.equal(pixScore);
         expect(assessmentResult.competenceMarks).to.deep.equal(competenceMarks);
+        expect(assessmentResult.capacity).to.equal(capacity);
       });
     });
   });

--- a/api/tests/certification/evaluation/unit/domain/services/scoring/create-v3-assessment-result_test.js
+++ b/api/tests/certification/evaluation/unit/domain/services/scoring/create-v3-assessment-result_test.js
@@ -10,6 +10,7 @@ describe('Unit | Certification | Evaluation | Domain | Services | Create V3 Asse
   const competenceMarks = Symbol('someCompetenceMarks');
   const pixScore = 456;
   const capacity = 2.45;
+  const reachedMeshIndex = 5;
   const versionId = 7;
 
   describe('createV3AssessmentResult', function () {
@@ -21,6 +22,7 @@ describe('Unit | Certification | Evaluation | Domain | Services | Create V3 Asse
         assessmentId: 123,
         pixScore,
         capacity,
+        reachedMeshIndex,
         versionId,
         status: AssessmentResult.status.CANCELLED,
         competenceMarks,
@@ -35,6 +37,7 @@ describe('Unit | Certification | Evaluation | Domain | Services | Create V3 Asse
       expect(assessmentResult.pixScore).to.equal(pixScore);
       expect(assessmentResult.competenceMarks).to.deep.equal(competenceMarks);
       expect(assessmentResult.capacity).to.equal(capacity);
+      expect(assessmentResult.reachedMeshIndex).to.equal(reachedMeshIndex);
       expect(assessmentResult.versionId).to.equal(versionId);
     });
 
@@ -45,6 +48,7 @@ describe('Unit | Certification | Evaluation | Domain | Services | Create V3 Asse
         allAnswers: [],
         pixScore,
         capacity,
+        reachedMeshIndex,
         versionId,
         status: AssessmentResult.status.REJECTED,
         competenceMarks,
@@ -64,6 +68,7 @@ describe('Unit | Certification | Evaluation | Domain | Services | Create V3 Asse
       expect(assessmentResult.pixScore).to.equal(pixScore);
       expect(assessmentResult.competenceMarks).to.deep.equal(competenceMarks);
       expect(assessmentResult.capacity).to.equal(capacity);
+      expect(assessmentResult.reachedMeshIndex).to.equal(reachedMeshIndex);
       expect(assessmentResult.versionId).to.equal(versionId);
     });
 
@@ -76,6 +81,7 @@ describe('Unit | Certification | Evaluation | Domain | Services | Create V3 Asse
           assessmentId: 123,
           pixScore,
           capacity,
+          reachedMeshIndex,
           versionId,
           status: AssessmentResult.status.VALIDATED,
           competenceMarks,
@@ -94,6 +100,7 @@ describe('Unit | Certification | Evaluation | Domain | Services | Create V3 Asse
         expect(assessmentResult.pixScore).to.equal(pixScore);
         expect(assessmentResult.competenceMarks).to.deep.equal(competenceMarks);
         expect(assessmentResult.capacity).to.equal(capacity);
+        expect(assessmentResult.reachedMeshIndex).to.equal(reachedMeshIndex);
         expect(assessmentResult.versionId).to.equal(versionId);
       });
 
@@ -105,6 +112,7 @@ describe('Unit | Certification | Evaluation | Domain | Services | Create V3 Asse
           assessmentId: 123,
           pixScore,
           capacity,
+          reachedMeshIndex,
           versionId,
           status: AssessmentResult.status.REJECTED,
           competenceMarks,
@@ -123,6 +131,7 @@ describe('Unit | Certification | Evaluation | Domain | Services | Create V3 Asse
         expect(assessmentResult.pixScore).to.equal(pixScore);
         expect(assessmentResult.competenceMarks).to.deep.equal(competenceMarks);
         expect(assessmentResult.capacity).to.equal(capacity);
+        expect(assessmentResult.reachedMeshIndex).to.equal(reachedMeshIndex);
         expect(assessmentResult.versionId).to.equal(versionId);
       });
     });
@@ -143,6 +152,7 @@ describe('Unit | Certification | Evaluation | Domain | Services | Create V3 Asse
           assessmentId: 123,
           pixScore: 0,
           capacity,
+          reachedMeshIndex,
           versionId,
           status: AssessmentResult.status.VALIDATED,
           competenceMarks,
@@ -161,6 +171,7 @@ describe('Unit | Certification | Evaluation | Domain | Services | Create V3 Asse
         expect(assessmentResult.pixScore).to.equal(0);
         expect(assessmentResult.competenceMarks).to.deep.equal([]);
         expect(assessmentResult.capacity).to.equal(capacity);
+        expect(assessmentResult.reachedMeshIndex).to.equal(reachedMeshIndex);
         expect(assessmentResult.versionId).to.equal(versionId);
       });
 
@@ -172,6 +183,7 @@ describe('Unit | Certification | Evaluation | Domain | Services | Create V3 Asse
           assessmentId: 123,
           pixScore,
           capacity,
+          reachedMeshIndex,
           versionId,
           status: AssessmentResult.status.VALIDATED,
           competenceMarks,
@@ -186,6 +198,7 @@ describe('Unit | Certification | Evaluation | Domain | Services | Create V3 Asse
         expect(assessmentResult.pixScore).to.equal(pixScore);
         expect(assessmentResult.competenceMarks).to.deep.equal(competenceMarks);
         expect(assessmentResult.capacity).to.equal(capacity);
+        expect(assessmentResult.reachedMeshIndex).to.equal(reachedMeshIndex);
         expect(assessmentResult.versionId).to.equal(versionId);
       });
     });

--- a/api/tests/certification/evaluation/unit/domain/services/scoring/create-v3-assessment-result_test.js
+++ b/api/tests/certification/evaluation/unit/domain/services/scoring/create-v3-assessment-result_test.js
@@ -28,7 +28,7 @@ describe('Unit | Certification | Evaluation | Domain | Services | Create V3 Asse
       //then
       expect(assessmentResult.status).to.equal(AssessmentResult.status.CANCELLED);
       expect(assessmentResult.pixScore).to.equal(pixScore);
-      expect(assessmentResult.competenceMarks).to.deep.equal([]);
+      expect(assessmentResult.competenceMarks).to.deep.equal(competenceMarks);
     });
 
     it('it should return a rejected for fraud AssessmentResult if isRejectedForFraud is true', function () {
@@ -53,7 +53,7 @@ describe('Unit | Certification | Evaluation | Domain | Services | Create V3 Asse
       expect(assessmentResult.status).to.equal(AssessmentResult.status.REJECTED);
       expect(assessmentResult.commentForOrganization).to.deep.equal(juryComment);
       expect(assessmentResult.pixScore).to.equal(pixScore);
-      expect(assessmentResult.competenceMarks).to.deep.equal([]);
+      expect(assessmentResult.competenceMarks).to.deep.equal(competenceMarks);
     });
 
     context('when there is an insuffisant number of answer', function () {
@@ -79,7 +79,7 @@ describe('Unit | Certification | Evaluation | Domain | Services | Create V3 Asse
         expect(assessmentResult.status).to.equal(AssessmentResult.status.CANCELLED);
         expect(assessmentResult.commentForOrganization).to.deep.equal(juryComment);
         expect(assessmentResult.pixScore).to.equal(pixScore);
-        expect(assessmentResult.competenceMarks).to.deep.equal([]);
+        expect(assessmentResult.competenceMarks).to.deep.equal(competenceMarks);
       });
 
       it('should return a rejected AssessmentResult if the cause is not technical', function () {
@@ -104,7 +104,7 @@ describe('Unit | Certification | Evaluation | Domain | Services | Create V3 Asse
         expect(assessmentResult.status).to.equal(AssessmentResult.status.REJECTED);
         expect(assessmentResult.commentForOrganization).to.deep.equal(juryComment);
         expect(assessmentResult.pixScore).to.equal(pixScore);
-        expect(assessmentResult.competenceMarks).to.deep.equal([]);
+        expect(assessmentResult.competenceMarks).to.deep.equal(competenceMarks);
       });
     });
     context('when there is a sufficient number of answers', function () {
@@ -138,7 +138,7 @@ describe('Unit | Certification | Evaluation | Domain | Services | Create V3 Asse
         expect(assessmentResult.status).to.equal(AssessmentResult.status.REJECTED);
         expect(assessmentResult.commentForOrganization).to.deep.equal(juryComment);
         expect(assessmentResult.pixScore).to.equal(0);
-        expect(assessmentResult.competenceMarks).to.deep.equal(competenceMarks);
+        expect(assessmentResult.competenceMarks).to.deep.equal([]);
       });
 
       it('should return a standard AssessmentResult if pix score is not 0', function () {
@@ -159,7 +159,7 @@ describe('Unit | Certification | Evaluation | Domain | Services | Create V3 Asse
         //then
         expect(assessmentResult.status).to.equal(AssessmentResult.status.VALIDATED);
         expect(assessmentResult.pixScore).to.equal(pixScore);
-        expect(assessmentResult.competenceMarks).to.deep.equal([]);
+        expect(assessmentResult.competenceMarks).to.deep.equal(competenceMarks);
       });
     });
   });

--- a/api/tests/certification/evaluation/unit/domain/services/scoring/create-v3-assessment-result_test.js
+++ b/api/tests/certification/evaluation/unit/domain/services/scoring/create-v3-assessment-result_test.js
@@ -10,6 +10,7 @@ describe('Unit | Certification | Evaluation | Domain | Services | Create V3 Asse
   const competenceMarks = Symbol('someCompetenceMarks');
   const pixScore = 456;
   const capacity = 2.45;
+  const versionId = 7;
 
   describe('createV3AssessmentResult', function () {
     it('it should return cancelled AssessmentResult if toBeCancelled is true', function () {
@@ -20,6 +21,7 @@ describe('Unit | Certification | Evaluation | Domain | Services | Create V3 Asse
         assessmentId: 123,
         pixScore,
         capacity,
+        versionId,
         status: AssessmentResult.status.CANCELLED,
         competenceMarks,
         isRejectedForFraud: false,
@@ -33,6 +35,7 @@ describe('Unit | Certification | Evaluation | Domain | Services | Create V3 Asse
       expect(assessmentResult.pixScore).to.equal(pixScore);
       expect(assessmentResult.competenceMarks).to.deep.equal(competenceMarks);
       expect(assessmentResult.capacity).to.equal(capacity);
+      expect(assessmentResult.versionId).to.equal(versionId);
     });
 
     it('it should return a rejected for fraud AssessmentResult if isRejectedForFraud is true', function () {
@@ -42,6 +45,7 @@ describe('Unit | Certification | Evaluation | Domain | Services | Create V3 Asse
         allAnswers: [],
         pixScore,
         capacity,
+        versionId,
         status: AssessmentResult.status.REJECTED,
         competenceMarks,
         assessmentId: 123,
@@ -60,6 +64,7 @@ describe('Unit | Certification | Evaluation | Domain | Services | Create V3 Asse
       expect(assessmentResult.pixScore).to.equal(pixScore);
       expect(assessmentResult.competenceMarks).to.deep.equal(competenceMarks);
       expect(assessmentResult.capacity).to.equal(capacity);
+      expect(assessmentResult.versionId).to.equal(versionId);
     });
 
     context('when there is an insuffisant number of answer', function () {
@@ -71,6 +76,7 @@ describe('Unit | Certification | Evaluation | Domain | Services | Create V3 Asse
           assessmentId: 123,
           pixScore,
           capacity,
+          versionId,
           status: AssessmentResult.status.VALIDATED,
           competenceMarks,
           isRejectedForFraud: false,
@@ -88,6 +94,7 @@ describe('Unit | Certification | Evaluation | Domain | Services | Create V3 Asse
         expect(assessmentResult.pixScore).to.equal(pixScore);
         expect(assessmentResult.competenceMarks).to.deep.equal(competenceMarks);
         expect(assessmentResult.capacity).to.equal(capacity);
+        expect(assessmentResult.versionId).to.equal(versionId);
       });
 
       it('should return a rejected AssessmentResult if the cause is not technical', function () {
@@ -98,6 +105,7 @@ describe('Unit | Certification | Evaluation | Domain | Services | Create V3 Asse
           assessmentId: 123,
           pixScore,
           capacity,
+          versionId,
           status: AssessmentResult.status.REJECTED,
           competenceMarks,
           isRejectedForFraud: false,
@@ -115,6 +123,7 @@ describe('Unit | Certification | Evaluation | Domain | Services | Create V3 Asse
         expect(assessmentResult.pixScore).to.equal(pixScore);
         expect(assessmentResult.competenceMarks).to.deep.equal(competenceMarks);
         expect(assessmentResult.capacity).to.equal(capacity);
+        expect(assessmentResult.versionId).to.equal(versionId);
       });
     });
     context('when there is a sufficient number of answers', function () {
@@ -134,6 +143,7 @@ describe('Unit | Certification | Evaluation | Domain | Services | Create V3 Asse
           assessmentId: 123,
           pixScore: 0,
           capacity,
+          versionId,
           status: AssessmentResult.status.VALIDATED,
           competenceMarks,
           isRejectedForFraud: false,
@@ -151,6 +161,7 @@ describe('Unit | Certification | Evaluation | Domain | Services | Create V3 Asse
         expect(assessmentResult.pixScore).to.equal(0);
         expect(assessmentResult.competenceMarks).to.deep.equal([]);
         expect(assessmentResult.capacity).to.equal(capacity);
+        expect(assessmentResult.versionId).to.equal(versionId);
       });
 
       it('should return a standard AssessmentResult if pix score is not 0', function () {
@@ -161,6 +172,7 @@ describe('Unit | Certification | Evaluation | Domain | Services | Create V3 Asse
           assessmentId: 123,
           pixScore,
           capacity,
+          versionId,
           status: AssessmentResult.status.VALIDATED,
           competenceMarks,
           isRejectedForFraud: false,
@@ -174,6 +186,7 @@ describe('Unit | Certification | Evaluation | Domain | Services | Create V3 Asse
         expect(assessmentResult.pixScore).to.equal(pixScore);
         expect(assessmentResult.competenceMarks).to.deep.equal(competenceMarks);
         expect(assessmentResult.capacity).to.equal(capacity);
+        expect(assessmentResult.versionId).to.equal(versionId);
       });
     });
   });

--- a/api/tests/certification/evaluation/unit/domain/services/scoring/scoring-v3_test.js
+++ b/api/tests/certification/evaluation/unit/domain/services/scoring/scoring-v3_test.js
@@ -82,8 +82,8 @@ describe('Unit | Certification | Evaluation | Domain | Services | Scoring V3', f
         });
 
         // then
-        expect(score.coreScoring.competenceMarks[0]).to.be.instanceOf(CompetenceMark);
-        expect(score.coreScoring.assessmentResult).to.be.instanceOf(AssessmentResult);
+        expect(score.coreAssessmentResult.competenceMarks[0]).to.be.instanceOf(CompetenceMark);
+        expect(score.coreAssessmentResult).to.be.instanceOf(AssessmentResult);
         expect(score.doubleCertificationScoring).to.be.null;
       });
     });
@@ -131,8 +131,8 @@ describe('Unit | Certification | Evaluation | Domain | Services | Scoring V3', f
           scoringDegradationService,
         });
 
-        expect(score.coreScoring.competenceMarks[0]).to.be.instanceOf(CompetenceMark);
-        expect(score.coreScoring.assessmentResult).to.be.instanceOf(AssessmentResult);
+        expect(score.coreAssessmentResult.competenceMarks[0]).to.be.instanceOf(CompetenceMark);
+        expect(score.coreAssessmentResult).to.be.instanceOf(AssessmentResult);
         expect(score.doubleCertificationScoring).to.be.instanceOf(DoubleCertificationScoring);
       });
     });
@@ -149,7 +149,7 @@ describe('Unit | Certification | Evaluation | Domain | Services | Scoring V3', f
         });
 
         expect(hasScored).to.deep.equal({
-          coreScoring: null,
+          coreAssessmentResult: null,
           doubleCertificationScoring: null,
         });
       });

--- a/api/tests/certification/evaluation/unit/domain/usecases/score-v3-certification_test.js
+++ b/api/tests/certification/evaluation/unit/domain/usecases/score-v3-certification_test.js
@@ -98,7 +98,7 @@ describe('Unit | Certification | Evaluation | Domain | UseCase | Score V3 Certif
 
         expect(dependencies.certificationAssessmentHistoryRepository.save).to.have.been.called;
         expect(dependencies.assessmentResultRepository.save).not.to.have.been.called;
-        expect(dependencies.sharedCompetenceMarkRepository.save).not.to.have.been.called;
+        expect(dependencies.sharedCompetenceMarkRepository.saveMany).not.to.have.been.called;
         expect(dependencies.certificationCourseRepository.update).not.to.have.been.called;
         expect(dependencies.complementaryCertificationCourseResultRepository.save).not.to.have.been.called;
       });
@@ -233,7 +233,7 @@ function stubCertificationCourseRepository() {
 
 function stubSharedCompetenceMarkRepository() {
   const sharedCompetenceMarkRepository = {
-    save: sinon.stub(),
+    saveMany: sinon.stub(),
   };
   return sharedCompetenceMarkRepository;
 }

--- a/api/tests/certification/evaluation/unit/domain/usecases/score-v3-certification_test.js
+++ b/api/tests/certification/evaluation/unit/domain/usecases/score-v3-certification_test.js
@@ -178,11 +178,11 @@ function stubServices({ hasPixPlusSubscription = false } = {}) {
   const assessmentResultId = 123;
 
   const scoringObject = {
-    coreScoring: !hasPixPlusSubscription
-      ? {
+    coreAssessmentResult: !hasPixPlusSubscription
+      ? domainBuilder.buildAssessmentResult({
+          id: assessmentResultId,
           competenceMarks: [domainBuilder.buildCompetenceMark(assessmentResultId)],
-          assessmentResult: domainBuilder.buildAssessmentResult({ id: assessmentResultId }),
-        }
+        })
       : null,
     doubleCertificationScoring: null,
   };

--- a/api/tests/certification/session-management/acceptance/application/finalize-route_test.js
+++ b/api/tests/certification/session-management/acceptance/application/finalize-route_test.js
@@ -391,9 +391,13 @@ describe('Certification | Session Management | Acceptance | Application | Route 
       });
 
       context('when session is v3', function () {
+        let certificationVersionId;
+
         beforeEach(async function () {
           ({ options, session } = await _createSession({ version: 3 }));
-          databaseBuilder.factory.buildCertificationVersion({ minimumAnswersRequiredToValidateACertification: 1 });
+          certificationVersionId = databaseBuilder.factory.buildCertificationVersion({
+            minimumAnswersRequiredToValidateACertification: 1,
+          }).id;
           await databaseBuilder.commit();
         });
 
@@ -505,7 +509,7 @@ describe('Certification | Session Management | Acceptance | Application | Route 
           expect(finalizedSession.isPublishable).to.be.true;
         });
 
-        it('should mark the assessment as ended due to finalization', async function () {
+        it('should score and mark the assessment as ended due to finalization', async function () {
           // given
           const abortReason = 'candidate';
           const userId = databaseBuilder.factory.buildUser().id;
@@ -591,8 +595,21 @@ describe('Certification | Session Management | Acceptance | Application | Route 
 
           // then
           expect(response.statusCode).to.equal(200);
+
           const assessment = await knex('assessments').where({ certificationCourseId }).first();
           expect(assessment.state).to.equal('endedDueToFinalization');
+
+          const lastAssessmentResult = await knex('assessment-results')
+            .where({ assessmentId })
+            .orderBy('createdAt', 'desc')
+            .first();
+          expect(lastAssessmentResult).to.deep.include({
+            pixScore: 48,
+            capacity: -3,
+            reachedMeshIndex: 0,
+            status: AssessmentResult.status.VALIDATED,
+            versionId: certificationVersionId,
+          });
         });
 
         context('when certification is a double certification', function () {
@@ -713,6 +730,13 @@ describe('Certification | Session Management | Acceptance | Application | Route 
 
             const pixCoreResults = await knex('assessment-results').where({ assessmentId });
             expect(pixCoreResults).to.have.lengthOf(1);
+            expect(pixCoreResults[0]).to.deep.include({
+              pixScore: 48,
+              capacity: -3,
+              reachedMeshIndex: 0,
+              status: AssessmentResult.status.VALIDATED,
+              versionId: certificationVersionId,
+            });
 
             const cleaResult = await knex('complementary-certification-course-results').where({
               complementaryCertificationCourseId,
@@ -763,10 +787,13 @@ describe('Certification | Session Management | Acceptance | Application | Route 
 
           // then
           expect(response.statusCode).to.equal(200);
+
           const finalizedSession = await knex('finalized-sessions').where({ sessionId: session.id }).first();
           expect(finalizedSession.isPublishable).to.be.true;
+
           const assessmentResult = await knex('assessment-results').where({ assessmentId }).first();
           expect(assessmentResult.status).to.equal(AssessmentResult.status.CANCELLED);
+
           const assessment = await knex('assessments').where({ certificationCourseId }).first();
           expect(assessment.state).to.equal('endedDueToFinalization');
         });

--- a/api/tests/certification/session-management/integration/infrastructure/repositories/course-assessment-result-repository_test.js
+++ b/api/tests/certification/session-management/integration/infrastructure/repositories/course-assessment-result-repository_test.js
@@ -8,6 +8,7 @@ describe('Certification | Course | Integration | Repository | course-assessment-
     context('when assessment result exists', function () {
       it('should return the assessment result', async function () {
         // given
+        const versionId = databaseBuilder.factory.buildCertificationVersion().id;
         const juryId = databaseBuilder.factory.buildUser().id;
         const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({ id: 1 }).id;
         databaseBuilder.factory.buildAssessment({ id: 2, certificationCourseId: 1 });
@@ -58,6 +59,9 @@ describe('Certification | Course | Integration | Repository | course-assessment-
           juryId,
           assessmentId: 2,
           competenceMarks: [competenceMark1, competenceMark2],
+          capacity: -1,
+          reachedMeshIndex: 1,
+          versionId,
         });
         const olderAssessmentResult = domainBuilder.buildAssessmentResult({
           id: 6543,
@@ -71,6 +75,9 @@ describe('Certification | Course | Integration | Repository | course-assessment-
           juryId,
           assessmentId: 2,
           competenceMarks: [competenceMark3],
+          capacity: -1,
+          reachedMeshIndex: 1,
+          versionId,
         });
         const lastAssessmentResultId = databaseBuilder.factory.buildAssessmentResult({
           ...expectedAssessmentResult,

--- a/api/tests/certification/shared/integration/infrastructure/repositories/competence-mark-repository_test.js
+++ b/api/tests/certification/shared/integration/infrastructure/repositories/competence-mark-repository_test.js
@@ -47,4 +47,28 @@ describe('Integration | Repository | CompetenceMark', function () {
       expect(savedMark).to.have.property('id').and.not.to.be.null;
     });
   });
+
+  describe('#saveMany', function () {
+    it('should persist competence marks in db and return them', async function () {
+      // given
+      const assessmentResultId = await databaseBuilder.factory.buildAssessmentResult().id;
+      await databaseBuilder.commit();
+
+      const competenceMarks = [
+        domainBuilder.buildCompetenceMark({ assessmentResultId }),
+        domainBuilder.buildCompetenceMark({ assessmentResultId }),
+        domainBuilder.buildCompetenceMark({ assessmentResultId }),
+      ];
+
+      // when
+      const savedMarks = await competenceMarkRepository.saveMany({ competenceMarks });
+
+      // then
+      const marks = await knex('competence-marks').select();
+      expect(marks).to.have.lengthOf(3);
+
+      expect(savedMarks[1]).to.be.an.instanceOf(CompetenceMark);
+      expect(savedMarks[1]).to.have.property('id').and.not.to.be.null;
+    });
+  });
 });

--- a/api/tests/evaluation/unit/domain/models/ScoringV3Algorithm_test.js
+++ b/api/tests/evaluation/unit/domain/models/ScoringV3Algorithm_test.js
@@ -92,4 +92,12 @@ describe('Certification | Evaluation | Unit | Domain | Models | ScoringV3Algorit
       });
     });
   });
+
+  context('#computeReachedMeshIndex', function () {
+    it('should return the interval index for a given capacity', function () {
+      const reachedMeshIndex = scoringV3Algorithm.computeReachedMeshIndex({ capacity: 2 });
+
+      expect(reachedMeshIndex).to.equal(4);
+    });
+  });
 });

--- a/api/tests/shared/integration/infrastructure/repositories/assessment-result-repository_test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/assessment-result-repository_test.js
@@ -34,6 +34,7 @@ describe('Integration | Repository | AssessmentResult', function () {
           assessmentId: assessment.id,
           competenceMarks: [],
           capacity: 3.56,
+          reachedMeshIndex: 3,
           versionId: certificationVersion.id,
         });
         assessmentResultToSave.id = undefined;
@@ -72,6 +73,7 @@ describe('Integration | Repository | AssessmentResult', function () {
           juryId: 100,
           assessmentId: assessment.id,
           competenceMarks: [],
+          reachedMeshIndex: 3,
           versionId: certificationVersion.id,
         });
         assessmentResultToSave.id = undefined;
@@ -335,6 +337,7 @@ describe('Integration | Repository | AssessmentResult', function () {
     context('when certification course has one assessment result', function () {
       it('should return the assessment result', async function () {
         // given
+        const version = databaseBuilder.factory.buildCertificationVersion();
         databaseBuilder.factory.buildCertificationCourse({ id: 1 });
         databaseBuilder.factory.buildUser({ id: 100 });
         databaseBuilder.factory.buildAssessment({ id: 2, certificationCourseId: 1 });
@@ -372,8 +375,9 @@ describe('Integration | Repository | AssessmentResult', function () {
           juryId: 100,
           assessmentId: 2,
           competenceMarks: [competenceMark1, competenceMark2],
-          capacity: null,
-          versionId: null,
+          capacity: 3,
+          reachedMeshIndex: 5,
+          versionId: version.id,
         });
         databaseBuilder.factory.buildAssessmentResult({
           ...expectedAssessmentResult,
@@ -444,6 +448,7 @@ describe('Integration | Repository | AssessmentResult', function () {
           assessmentId: 2,
           competenceMarks: [competenceMark1, competenceMark3],
           capacity: null,
+          reachedMeshIndex: null,
           versionId: null,
         });
         databaseBuilder.factory.buildAssessmentResult({
@@ -497,6 +502,7 @@ describe('Integration | Repository | AssessmentResult', function () {
           status: Assessment.states.STARTED,
           competenceMarks: [],
           capacity: null,
+          reachedMeshIndex: null,
           versionId: null,
         });
         expectedAssessmentResult.id = undefined;
@@ -527,6 +533,7 @@ describe('Integration | Repository | AssessmentResult', function () {
           status: Assessment.states.STARTED,
           competenceMarks: [],
           capacity: null,
+          reachedMeshIndex: null,
           versionId: null,
         });
         expectedAssessmentResult.id = undefined;

--- a/api/tests/shared/integration/infrastructure/repositories/assessment-result-repository_test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/assessment-result-repository_test.js
@@ -10,10 +10,12 @@ describe('Integration | Repository | AssessmentResult', function () {
     context('when save is successful', function () {
       it('should return the saved assessment result', async function () {
         // given
-        databaseBuilder.factory.buildCertificationCourse({ id: 1 });
+        const certificationVersion = databaseBuilder.factory.buildCertificationVersion();
+        const certificationCourse = databaseBuilder.factory.buildCertificationCourse();
         databaseBuilder.factory.buildUser({ id: 100 });
-        databaseBuilder.factory.buildAssessment({ id: 2, certificationCourseId: 1 });
+        const assessment = databaseBuilder.factory.buildAssessment({ certificationCourseId: certificationCourse.id });
         await databaseBuilder.commit();
+
         const assessmentResultToSave = domainBuilder.buildAssessmentResult({
           pixScore: 33,
           reproducibilityRate: 29.1,
@@ -29,15 +31,16 @@ describe('Integration | Repository | AssessmentResult', function () {
           }),
           createdAt: new Date('2021-10-29T03:06:00Z'),
           juryId: 100,
-          assessmentId: 2,
+          assessmentId: assessment.id,
           competenceMarks: [],
           capacity: 3.56,
+          versionId: certificationVersion.id,
         });
         assessmentResultToSave.id = undefined;
 
         // when
         const savedAssessmentResult = await assessmentResultRepository.save({
-          certificationCourseId: 1,
+          certificationCourseId: certificationCourse.id,
           assessmentResult: assessmentResultToSave,
         });
 
@@ -47,9 +50,10 @@ describe('Integration | Repository | AssessmentResult', function () {
 
       it('should persist the assessment result in DB', async function () {
         // given
-        databaseBuilder.factory.buildCertificationCourse({ id: 1 });
+        const certificationVersion = databaseBuilder.factory.buildCertificationVersion();
+        const certificationCourse = databaseBuilder.factory.buildCertificationCourse({ id: 3 });
         databaseBuilder.factory.buildUser({ id: 100 });
-        databaseBuilder.factory.buildAssessment({ id: 2, certificationCourseId: 1 });
+        const assessment = databaseBuilder.factory.buildAssessment({ certificationCourseId: certificationCourse.id });
         await databaseBuilder.commit();
         const assessmentResultToSave = domainBuilder.buildAssessmentResult({
           pixScore: 33,
@@ -66,17 +70,21 @@ describe('Integration | Repository | AssessmentResult', function () {
           }),
           createdAt: new Date('2021-10-29T03:06:00Z'),
           juryId: 100,
-          assessmentId: 2,
+          assessmentId: assessment.id,
           competenceMarks: [],
+          versionId: certificationVersion.id,
         });
         assessmentResultToSave.id = undefined;
 
         // when
-        await assessmentResultRepository.save({ certificationCourseId: 1, assessmentResult: assessmentResultToSave });
+        await assessmentResultRepository.save({
+          certificationCourseId: certificationCourse.id,
+          assessmentResult: assessmentResultToSave,
+        });
 
         // then
         const actualAssessmentResult = await assessmentResultRepository.getByCertificationCourseId({
-          certificationCourseId: 1,
+          certificationCourseId: certificationCourse.id,
         });
         expect(actualAssessmentResult).to.deepEqualInstanceOmitting(assessmentResultToSave, ['id', 'createdAt']);
         expect(actualAssessmentResult.id).to.exist;
@@ -86,10 +94,12 @@ describe('Integration | Repository | AssessmentResult', function () {
       context('when there is no assessment result for the certification course yet', function () {
         it('should persist the link between the assessment result and the certification course in DB', async function () {
           // given
-          databaseBuilder.factory.buildCertificationCourse({ id: 1 });
+          const certificationVersion = databaseBuilder.factory.buildCertificationVersion();
+          const certificationCourse = databaseBuilder.factory.buildCertificationCourse();
           databaseBuilder.factory.buildUser({ id: 100 });
-          databaseBuilder.factory.buildAssessment({ id: 2, certificationCourseId: 1 });
+          const assessment = databaseBuilder.factory.buildAssessment({ certificationCourseId: certificationCourse.id });
           await databaseBuilder.commit();
+
           const assessmentResultToSave = domainBuilder.buildAssessmentResult({
             pixScore: 33,
             reproducibilityRate: 29.1,
@@ -103,35 +113,40 @@ describe('Integration | Repository | AssessmentResult', function () {
             }),
             createdAt: new Date('2021-10-29T03:06:00Z'),
             juryId: 100,
-            assessmentId: 2,
+            assessmentId: assessment.id,
             competenceMarks: [],
+            versionId: certificationVersion.id,
           });
           assessmentResultToSave.id = undefined;
 
           // when
           const assessmentResult = await assessmentResultRepository.save({
-            certificationCourseId: 1,
+            certificationCourseId: certificationCourse.id,
             assessmentResult: assessmentResultToSave,
           });
 
           // then
           const result = await knex('certification-courses-last-assessment-results').select('*');
-          expect(result).to.deep.equal([{ lastAssessmentResultId: assessmentResult.id, certificationCourseId: 1 }]);
+          expect(result).to.deep.equal([
+            { lastAssessmentResultId: assessmentResult.id, certificationCourseId: certificationCourse.id },
+          ]);
         });
       });
 
       context('when there is already an assessment result for the certification course', function () {
         it('should update the link between the assessment result and the certification course in DB', async function () {
           // given
-          databaseBuilder.factory.buildCertificationCourse({ id: 1 });
+          const certificationVersion = databaseBuilder.factory.buildCertificationVersion();
+          const certificationCourse = databaseBuilder.factory.buildCertificationCourse();
           databaseBuilder.factory.buildUser({ id: 100 });
-          databaseBuilder.factory.buildAssessment({ id: 2, certificationCourseId: 1 });
-          databaseBuilder.factory.buildAssessmentResult({ id: 99, assessmentId: 2 });
+          const assessment = databaseBuilder.factory.buildAssessment({ certificationCourseId: certificationCourse.id });
+          databaseBuilder.factory.buildAssessmentResult({ id: 99, assessmentId: assessment.id });
           databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
-            certificationCourseId: 1,
+            certificationCourseId: certificationCourse.id,
             lastAssessmentResultId: 99,
           });
           await databaseBuilder.commit();
+
           const assessmentResultToSave = domainBuilder.buildAssessmentResult({
             pixScore: 33,
             reproducibilityRate: 29.1,
@@ -145,20 +160,23 @@ describe('Integration | Repository | AssessmentResult', function () {
             }),
             createdAt: new Date('2021-10-29T03:06:00Z'),
             juryId: 100,
-            assessmentId: 2,
+            assessmentId: assessment.id,
             competenceMarks: [],
+            versionId: certificationVersion.id,
           });
           assessmentResultToSave.id = undefined;
 
           // when
           const assessmentResult = await assessmentResultRepository.save({
-            certificationCourseId: 1,
+            certificationCourseId: certificationCourse.id,
             assessmentResult: assessmentResultToSave,
           });
 
           // then
           const result = await knex('certification-courses-last-assessment-results').select('*');
-          expect(result).to.deep.equal([{ lastAssessmentResultId: assessmentResult.id, certificationCourseId: 1 }]);
+          expect(result).to.deep.equal([
+            { lastAssessmentResultId: assessmentResult.id, certificationCourseId: certificationCourse.id },
+          ]);
         });
       });
     });
@@ -166,10 +184,11 @@ describe('Integration | Repository | AssessmentResult', function () {
     context('when assessmentId attribute is not valid', function () {
       it('should throw a MissingAssessmentId error', async function () {
         // given
-        databaseBuilder.factory.buildCertificationCourse({ id: 1 });
+        const certificationCourse = databaseBuilder.factory.buildCertificationCourse();
         databaseBuilder.factory.buildUser({ id: 100 });
-        databaseBuilder.factory.buildAssessment({ id: 2, certificationCourseId: 1 });
+        databaseBuilder.factory.buildAssessment({ id: 2, certificationCourseId: certificationCourse.id });
         await databaseBuilder.commit();
+
         const assessmentResultToSave = domainBuilder.buildAssessmentResult({
           pixScore: 33,
           reproducibilityRate: 29.1,
@@ -354,6 +373,7 @@ describe('Integration | Repository | AssessmentResult', function () {
           assessmentId: 2,
           competenceMarks: [competenceMark1, competenceMark2],
           capacity: null,
+          versionId: null,
         });
         databaseBuilder.factory.buildAssessmentResult({
           ...expectedAssessmentResult,
@@ -424,6 +444,7 @@ describe('Integration | Repository | AssessmentResult', function () {
           assessmentId: 2,
           competenceMarks: [competenceMark1, competenceMark3],
           capacity: null,
+          versionId: null,
         });
         databaseBuilder.factory.buildAssessmentResult({
           ...expectedAssessmentResult,
@@ -476,6 +497,7 @@ describe('Integration | Repository | AssessmentResult', function () {
           status: Assessment.states.STARTED,
           competenceMarks: [],
           capacity: null,
+          versionId: null,
         });
         expectedAssessmentResult.id = undefined;
         expectedAssessmentResult.commentByJury = undefined;
@@ -505,6 +527,7 @@ describe('Integration | Repository | AssessmentResult', function () {
           status: Assessment.states.STARTED,
           competenceMarks: [],
           capacity: null,
+          versionId: null,
         });
         expectedAssessmentResult.id = undefined;
         expectedAssessmentResult.commentByJury = undefined;
@@ -521,9 +544,10 @@ describe('Integration | Repository | AssessmentResult', function () {
     context('when the assessment result exists', function () {
       it('should update the assessment result', async function () {
         // given
+        const certificationVersion = databaseBuilder.factory.buildCertificationVersion();
         databaseBuilder.factory.buildCertificationCourse({ id: 1 });
         databaseBuilder.factory.buildUser({ id: 100 });
-        databaseBuilder.factory.buildAssessment({ id: 2, certificationCourseId: 1 });
+        const assessment = databaseBuilder.factory.buildAssessment({ certificationCourseId: 1 });
         const competenceMark1 = domainBuilder.buildCompetenceMark({
           id: 200,
           level: 3,
@@ -549,8 +573,9 @@ describe('Integration | Repository | AssessmentResult', function () {
           status: AssessmentResult.status.VALIDATED,
           createdAt: new Date('2021-10-29T03:06:00Z'),
           juryId: 100,
-          assessmentId: 2,
+          assessmentId: assessment.id,
           competenceMarks: [competenceMark1, competenceMark2],
+          versionId: certificationVersion.id,
         });
         databaseBuilder.factory.buildAssessmentResult(assessmentResult);
         databaseBuilder.factory.buildCompetenceMark(competenceMark1);

--- a/api/tests/shared/integration/infrastructure/repositories/assessment-result-repository_test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/assessment-result-repository_test.js
@@ -31,6 +31,7 @@ describe('Integration | Repository | AssessmentResult', function () {
           juryId: 100,
           assessmentId: 2,
           competenceMarks: [],
+          capacity: 3.56,
         });
         assessmentResultToSave.id = undefined;
 
@@ -352,6 +353,7 @@ describe('Integration | Repository | AssessmentResult', function () {
           juryId: 100,
           assessmentId: 2,
           competenceMarks: [competenceMark1, competenceMark2],
+          capacity: null,
         });
         databaseBuilder.factory.buildAssessmentResult({
           ...expectedAssessmentResult,
@@ -421,6 +423,7 @@ describe('Integration | Repository | AssessmentResult', function () {
           juryId: 100,
           assessmentId: 2,
           competenceMarks: [competenceMark1, competenceMark3],
+          capacity: null,
         });
         databaseBuilder.factory.buildAssessmentResult({
           ...expectedAssessmentResult,
@@ -472,6 +475,7 @@ describe('Integration | Repository | AssessmentResult', function () {
           assessmentId: 2,
           status: Assessment.states.STARTED,
           competenceMarks: [],
+          capacity: null,
         });
         expectedAssessmentResult.id = undefined;
         expectedAssessmentResult.commentByJury = undefined;
@@ -500,6 +504,7 @@ describe('Integration | Repository | AssessmentResult', function () {
           assessmentId: null,
           status: Assessment.states.STARTED,
           competenceMarks: [],
+          capacity: null,
         });
         expectedAssessmentResult.id = undefined;
         expectedAssessmentResult.commentByJury = undefined;

--- a/api/tests/shared/unit/domain/models/AssessmentResult_test.js
+++ b/api/tests/shared/unit/domain/models/AssessmentResult_test.js
@@ -14,6 +14,7 @@ describe('Unit | Domain | Models | AssessmentResult', function () {
         status: Assessment.states.STARTED,
         competenceMarks: [],
         capacity: null,
+        reachedMeshIndex: null,
         versionId: null,
       });
       expectedAssessmentResult.id = undefined;

--- a/api/tests/shared/unit/domain/models/AssessmentResult_test.js
+++ b/api/tests/shared/unit/domain/models/AssessmentResult_test.js
@@ -14,6 +14,7 @@ describe('Unit | Domain | Models | AssessmentResult', function () {
         status: Assessment.states.STARTED,
         competenceMarks: [],
         capacity: null,
+        versionId: null,
       });
       expectedAssessmentResult.id = undefined;
       expectedAssessmentResult.commentForCandidate = undefined;

--- a/api/tests/shared/unit/domain/models/AssessmentResult_test.js
+++ b/api/tests/shared/unit/domain/models/AssessmentResult_test.js
@@ -13,6 +13,7 @@ describe('Unit | Domain | Models | AssessmentResult', function () {
         assessmentId: 123,
         status: Assessment.states.STARTED,
         competenceMarks: [],
+        capacity: null,
       });
       expectedAssessmentResult.id = undefined;
       expectedAssessmentResult.commentForCandidate = undefined;

--- a/api/tests/tooling/domain-builder/factory/build-assessment-result.js
+++ b/api/tests/tooling/domain-builder/factory/build-assessment-result.js
@@ -16,6 +16,7 @@ const buildAssessmentResult = function ({
   juryId = 1,
   assessmentId = 456,
   competenceMarks = [],
+  capacity = 1.2567,
 } = {}) {
   return new AssessmentResult({
     pixScore,
@@ -29,6 +30,7 @@ const buildAssessmentResult = function ({
     juryId,
     assessmentId,
     competenceMarks,
+    capacity,
   });
 };
 

--- a/api/tests/tooling/domain-builder/factory/build-assessment-result.js
+++ b/api/tests/tooling/domain-builder/factory/build-assessment-result.js
@@ -17,6 +17,7 @@ const buildAssessmentResult = function ({
   assessmentId = 456,
   competenceMarks = [],
   capacity = 1.2567,
+  reachedMeshIndex = 2,
   versionId = 42,
 } = {}) {
   return new AssessmentResult({
@@ -32,6 +33,7 @@ const buildAssessmentResult = function ({
     assessmentId,
     competenceMarks,
     capacity,
+    reachedMeshIndex,
     versionId,
   });
 };
@@ -47,6 +49,9 @@ buildAssessmentResult.validated = function ({
   juryId,
   assessmentId,
   competenceMarks,
+  capacity,
+  reachedMeshIndex,
+  versionId,
 } = {}) {
   return buildAssessmentResult({
     id,
@@ -60,6 +65,9 @@ buildAssessmentResult.validated = function ({
     juryId,
     assessmentId,
     competenceMarks,
+    capacity,
+    reachedMeshIndex,
+    versionId,
   });
 };
 
@@ -74,6 +82,9 @@ buildAssessmentResult.rejected = function ({
   juryId,
   assessmentId,
   competenceMarks,
+  capacity,
+  reachedMeshIndex,
+  versionId,
 } = {}) {
   return buildAssessmentResult({
     id,
@@ -87,6 +98,9 @@ buildAssessmentResult.rejected = function ({
     juryId,
     assessmentId,
     competenceMarks,
+    capacity,
+    reachedMeshIndex,
+    versionId,
   });
 };
 
@@ -100,6 +114,9 @@ buildAssessmentResult.error = function ({
   juryId,
   assessmentId,
   competenceMarks,
+  capacity,
+  reachedMeshIndex,
+  versionId,
 } = {}) {
   return buildAssessmentResult({
     id,
@@ -113,6 +130,9 @@ buildAssessmentResult.error = function ({
     juryId,
     assessmentId,
     competenceMarks,
+    capacity,
+    reachedMeshIndex,
+    versionId,
   });
 };
 
@@ -126,6 +146,9 @@ buildAssessmentResult.started = function ({
   juryId,
   assessmentId,
   competenceMarks,
+  capacity,
+  reachedMeshIndex,
+  versionId,
 } = {}) {
   return buildAssessmentResult({
     id,
@@ -139,6 +162,9 @@ buildAssessmentResult.started = function ({
     juryId,
     assessmentId,
     competenceMarks,
+    capacity,
+    reachedMeshIndex,
+    versionId,
   });
 };
 

--- a/api/tests/tooling/domain-builder/factory/build-assessment-result.js
+++ b/api/tests/tooling/domain-builder/factory/build-assessment-result.js
@@ -17,6 +17,7 @@ const buildAssessmentResult = function ({
   assessmentId = 456,
   competenceMarks = [],
   capacity = 1.2567,
+  versionId = 42,
 } = {}) {
   return new AssessmentResult({
     pixScore,
@@ -31,6 +32,7 @@ const buildAssessmentResult = function ({
     assessmentId,
     competenceMarks,
     capacity,
+    versionId,
   });
 };
 

--- a/api/tests/tooling/domain-builder/factory/certification/shared/build-v3-certification-scoring.js
+++ b/api/tests/tooling/domain-builder/factory/certification/shared/build-v3-certification-scoring.js
@@ -13,10 +13,12 @@ export const buildV3CertificationScoring = ({
     { bounds: { max: 6.56789, min: 4.90123 }, meshLevel: 7 },
   ],
   minimumAnswersRequiredToValidateACertification = 20,
+  versionId = 1,
 } = {}) => {
   return new V3CertificationScoring({
     competencesForScoring,
     certificationScoringConfiguration,
     minimumAnswersRequiredToValidateACertification,
+    versionId,
   });
 };


### PR DESCRIPTION
## 🥀 Problème

Aujourd'hui, le résultat du scoring est stocké dans `assessment-results`. Pour la v3 à ce jour la seule valeur stockée est le `pixScore`.
Le problème c'est que lorsqu'il va s'agir de scorer des certifications pix plus, lesquelles ne requièrent pas de calcul de `pixScore`, il nous faut stocker une information pour pouvoir déterminer le niveau atteint par le candidat.
En somme, les données de scoring stockées aujourd'hui sont insuffisantes pour les pix plus.

## 🏹 Proposition

La migration de BDD a été effectuée ici : https://github.com/1024pix/pix/pull/15240.

Nous venons maintenant remplir les colonnes `capacity`, `reachedMeshIndex` et `versionId` de la table `assessment-results` lors du scoring.

## ❤️‍🔥 Pour tester

### Non régression, tout devrait toujours bien se passer
- Lancer les tests E2E de certif en local ✅ 

### Fonctionnel
- Terminer une certification
- Vérifier que les colonnes sont bien remplies en BDD

<img width="485" height="457" alt="image" src="https://github.com/user-attachments/assets/4612c959-e4d7-4ea7-b5ed-2cbae772d559" />

