### PR TITLE
[TECH] Réduit le nombre de requêtes SQL généré par les repositories du scope "Certification" (PIX-21725)

### DIFF
--- a/api/src/certification/configuration/infrastructure/repositories/framework-challenges-repository.js
+++ b/api/src/certification/configuration/infrastructure/repositories/framework-challenges-repository.js
@@ -31,6 +31,7 @@ export async function getByVersionId({ versionId }) {
 export async function update(challenges) {
   const knexConn = DomainTransaction.getConnection();
 
+  // Note: cannot do onConflict.merge here because ['versionId', 'challengeId'] has no composite index
   for (const { versionId, discriminant, difficulty, challengeId } of challenges) {
     await knexConn('certification-frameworks-challenges')
       .update({

--- a/api/src/certification/enrolment/domain/usecases/delete-session.js
+++ b/api/src/certification/enrolment/domain/usecases/delete-session.js
@@ -1,4 +1,4 @@
-import { withTransaction } from '../../../../shared/domain/DomainTransaction.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { SessionStartedDeletionError } from '../errors.js';
 
 /**
@@ -11,12 +11,14 @@ import { SessionStartedDeletionError } from '../errors.js';
  * @param {SessionRepository} params.sessionRepository
  * @param {SessionManagementRepository} params.sessionManagementRepository
  */
-const deleteSession = withTransaction(async ({ sessionId, sessionRepository, sessionManagementRepository }) => {
+const deleteSession = async ({ sessionId, sessionRepository, sessionManagementRepository }) => {
   if (!(await sessionManagementRepository.hasNoStartedCertification({ id: sessionId }))) {
     throw new SessionStartedDeletionError();
   }
 
-  await sessionRepository.remove({ id: sessionId });
-});
+  await DomainTransaction.execute(async () => {
+    await sessionRepository.remove({ id: sessionId });
+  });
+};
 
 export { deleteSession };

--- a/api/src/certification/evaluation/infrastructure/repositories/session-repository.js
+++ b/api/src/certification/evaluation/infrastructure/repositories/session-repository.js
@@ -18,16 +18,20 @@ export const get = async ({ id }) => {
 
 export const getByCertificationCourseId = async ({ certificationCourseId }) => {
   const knexConn = DomainTransaction.getConnection();
-  const certificationCourseDTO = await knexConn('certification-courses').where('id', certificationCourseId).first();
+  const sessionDTO = await knexConn('sessions')
+    .select({
+      id: 'sessions.id',
+      accessCode: 'sessions.accessCode',
+      finalizedAt: 'sessions.finalizedAt',
+      publishedAt: 'sessions.publishedAt',
+    })
+    .join('certification-courses', 'certification-courses.sessionId', 'sessions.id')
+    .where('certification-courses.id', certificationCourseId)
+    .first();
 
-  if (!certificationCourseDTO) {
+  if (!sessionDTO) {
     throw new NotFoundError('Certification course does not exist');
   }
-
-  const sessionDTO = await knexConn('sessions')
-    .select('id', 'accessCode', 'finalizedAt', 'publishedAt')
-    .where('id', certificationCourseDTO.sessionId)
-    .first();
 
   return _toDomain(sessionDTO);
 };

--- a/api/src/certification/session-management/infrastructure/repositories/certification-repository.js
+++ b/api/src/certification/session-management/infrastructure/repositories/certification-repository.js
@@ -31,7 +31,6 @@ const publishCertificationCourses = async function (certificationStatuses) {
   }));
 
   const knexConn = DomainTransaction.getConnection();
-  // Trick to .batchUpdate(), which does not exist in knex per say
   await knexConn('certification-courses')
     .insert(certificationDataToUpdate)
     .onConflict('id')

--- a/api/src/certification/shared/domain/models/CertificationReport.js
+++ b/api/src/certification/shared/domain/models/CertificationReport.js
@@ -53,18 +53,6 @@ class CertificationReport {
     }
   }
 
-  static fromCertificationCourse(certificationCourse) {
-    const certificationCourseDTO = certificationCourse.toDTO();
-    return new CertificationReport({
-      certificationCourseId: certificationCourseDTO.id,
-      firstName: certificationCourseDTO.firstName,
-      lastName: certificationCourseDTO.lastName,
-      certificationIssueReports: certificationCourseDTO.certificationIssueReports,
-      isCompleted: certificationCourseDTO.assessment.isCompleted(),
-      abortReason: certificationCourseDTO.abortReason,
-    });
-  }
-
   static idFromCertificationCourseId(certificationCourseId) {
     return `CertificationReport-${certificationCourseId}`;
   }

--- a/api/tests/certification/configuration/integration/infrastucture/repositories/complementary-certification-badge-repository_test.js
+++ b/api/tests/certification/configuration/integration/infrastucture/repositories/complementary-certification-badge-repository_test.js
@@ -1,6 +1,6 @@
 import lodash from 'lodash';
 
-import { databaseBuilder, domainBuilder, expect, knex, sinon } from '../../../../../test-helper.js';
+import { databaseBuilder, domainBuilder, expect, knex } from '../../../../../test-helper.js';
 
 const { omit } = lodash;
 import * as complementaryCertificationBadgeRepository from '../../../../../../src/certification/configuration/infrastructure/repositories/complementary-certification-badge-repository.js';
@@ -102,17 +102,6 @@ describe('Integration | Infrastructure | Repository | Certification | Complement
   });
 
   context('#attach', function () {
-    let clock;
-    const createdAt = new Date('2023-09-19T01:02:03Z');
-
-    beforeEach(function () {
-      clock = sinon.useFakeTimers({ now: createdAt, toFake: ['Date'] });
-    });
-
-    afterEach(async function () {
-      clock.restore();
-    });
-
     it('should attach the complementary certification badges', async function () {
       // given
       const userId = databaseBuilder.factory.buildUser().id;
@@ -158,14 +147,13 @@ describe('Integration | Infrastructure | Repository | Certification | Complement
         complementaryCertificationId,
       });
 
-      const results = complementaryCertificationBadges.map((badge) => omit(badge, ['id']));
+      const results = complementaryCertificationBadges.map((badge) => omit(badge, ['id', 'createdAt']));
       expect(results).to.deep.equal([
         {
           badgeId: badgeId1,
           certificateMessage: null,
           temporaryCertificateMessage: null,
           createdBy: userId,
-          createdAt,
           detachedAt: null,
           complementaryCertificationId,
           level: 1,
@@ -179,7 +167,6 @@ describe('Integration | Infrastructure | Repository | Certification | Complement
           certificateMessage: null,
           temporaryCertificateMessage: null,
           createdBy: userId,
-          createdAt,
           detachedAt: null,
           complementaryCertificationId,
           level: 2,

--- a/api/tests/certification/enrolment/integration/infrastructure/repositories/certification-candidate-repository_test.js
+++ b/api/tests/certification/enrolment/integration/infrastructure/repositories/certification-candidate-repository_test.js
@@ -5,7 +5,7 @@ import * as certificationCandidateRepository from '../../../../../../src/certifi
 import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
 import { catchErr, databaseBuilder, domainBuilder, expect, knex } from '../../../../../test-helper.js';
 
-describe('Integration | Repository | CertificationCandidate', function () {
+describe('Certification | Shared | Integration | Repository | CertificationCandidate', function () {
   let sessionId;
 
   beforeEach(async function () {

--- a/api/tests/certification/enrolment/integration/infrastructure/repositories/session-repository_test.js
+++ b/api/tests/certification/enrolment/integration/infrastructure/repositories/session-repository_test.js
@@ -138,7 +138,7 @@ describe('Integration | Repository | certification | enrolment | SessionEnrolmen
     });
   });
 
-  describe('#delete', function () {
+  describe('#remove', function () {
     context('when session exists', function () {
       context('when the session has candidates', function () {
         it('should remove candidates and delete the session', async function () {

--- a/api/tests/certification/shared/integration/infrastructure/repositories/certification-center-repository_test.js
+++ b/api/tests/certification/shared/integration/infrastructure/repositories/certification-center-repository_test.js
@@ -3,7 +3,7 @@ import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
 import { CertificationCenter } from '../../../../../../src/shared/domain/models/CertificationCenter.js';
 import { catchErr, databaseBuilder, domainBuilder, expect, sinon } from '../../../../../test-helper.js';
 
-describe('Integration | Repository | Certification Center', function () {
+describe('Certification | Shared | Integration | Repository | Certification Center', function () {
   let clock, now;
 
   beforeEach(function () {

--- a/api/tests/certification/shared/unit/domain/models/CertificationReport_test.js
+++ b/api/tests/certification/shared/unit/domain/models/CertificationReport_test.js
@@ -2,7 +2,6 @@ import lodash from 'lodash';
 
 import { InvalidCertificationReportForFinalization } from '../../../../../../src/certification/shared/domain/errors.js';
 import { CertificationReport } from '../../../../../../src/certification/shared/domain/models/CertificationReport.js';
-import { Assessment } from '../../../../../../src/shared/domain/models/Assessment.js';
 import { catchErr, domainBuilder, EMPTY_BLANK_AND_NULL, expect } from '../../../../../test-helper.js';
 const { keys } = lodash;
 
@@ -75,55 +74,6 @@ describe('Unit | Domain | Models | CertificationReport', function () {
       // then
       expect(error).to.be.instanceOf(InvalidCertificationReportForFinalization);
       expect(error.message).to.equal('Abort reason is required if certificationReport is not completed');
-    });
-  });
-
-  describe('#fromCertificationCourse', function () {
-    it('should return a certificationReport from a certificationCourse', function () {
-      // given
-      const certificationCourse = domainBuilder.buildCertificationCourse();
-      const certificationCourseDTO = certificationCourse.toDTO();
-      const expectedCertificationReport = domainBuilder.buildCertificationReport({
-        id: `CertificationReport:${certificationCourseDTO.id}`,
-        certificationCourseId: certificationCourseDTO.id,
-        examinerComment: null,
-        certificationIssueReports: certificationCourseDTO.certificationIssueReports,
-        firstName: certificationCourseDTO.firstName,
-        isCompleted: true,
-        lastName: certificationCourseDTO.lastName,
-      });
-
-      // when
-      const certificationReport = CertificationReport.fromCertificationCourse(certificationCourse);
-
-      // then
-      expect(certificationReport).to.deepEqualInstance(expectedCertificationReport);
-    });
-
-    it('should return a certificationReport from a uncompleted certificationCourse', function () {
-      // given
-      const certificationCourse = domainBuilder.buildCertificationCourse({
-        assessment: domainBuilder.buildAssessment({ state: Assessment.states.STARTED }),
-      });
-
-      // when
-      const { isCompleted } = CertificationReport.fromCertificationCourse(certificationCourse);
-
-      // then
-      expect(isCompleted).to.be.false;
-    });
-
-    it('should return a certificationReport from a completed certificationCourse', function () {
-      // given
-      const certificationCourse = domainBuilder.buildCertificationCourse({
-        assessment: domainBuilder.buildAssessment({ state: Assessment.states.COMPLETED }),
-      });
-
-      // when
-      const { isCompleted } = CertificationReport.fromCertificationCourse(certificationCourse);
-
-      // then
-      expect(isCompleted).to.be.true;
     });
   });
 });


### PR DESCRIPTION
## 🥀 Problème

Certains repositories effectuent plusieurs requêtes SQL dont le résultat peut être obtenu en moins de requêtes pas plus consommatrices.
Petit tour du propriétaire des repositories du scope Certification

## 🏹 Proposition

Réduire le nombre de requêtes en compactant certains appels

## 💌 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## ❤️‍🔥 Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
