### PR TITLE
[TECH] Limiter le nombre de requêtes lors de la modification en masse d'organisation (PIX-201703)

### DIFF
--- a/api/src/organizational-entities/domain/usecases/update-organizations-in-batch.usecase.js
+++ b/api/src/organizational-entities/domain/usecases/update-organizations-in-batch.usecase.js
@@ -1,6 +1,6 @@
 import { createReadStream } from 'node:fs';
 
-import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
+import { withTransaction } from '../../../shared/domain/DomainTransaction.js';
 import * as emailValidationService from '../../../shared/domain/services/email-validation-service.js';
 import { CsvParser } from '../../../shared/infrastructure/serializers/csv/csv-parser.js';
 import { getDataBuffer } from '../../../shared/infrastructure/utils/buffer.js';
@@ -26,134 +26,138 @@ import {
  * @param {CountryRepository} params.countryRepository
  * @return {Promise<void>}
  */
-export const updateOrganizationsInBatch = async function ({
-  filePath,
-  organizationForAdminRepository,
-  administrationTeamRepository,
-  countryRepository,
-  organizationLearnerTypeRepository,
-}) {
-  const organizationBatchUpdateDtos = await _getCsvData(filePath);
+export const updateOrganizationsInBatch = withTransaction(
+  async ({
+    filePath,
+    organizationForAdminRepository,
+    administrationTeamRepository,
+    countryRepository,
+    organizationLearnerTypeRepository,
+  }) => {
+    const dtos = await _getCsvData(filePath);
+    if (dtos.length === 0) return;
 
-  if (organizationBatchUpdateDtos.length === 0) return;
+    const organizationIds = new Set();
+    const parentOrganizationIds = new Set();
+    const administrationTeamIds = new Set();
+    const countryCodes = new Set();
+    const organizationLearnerTypeIds = new Set();
 
-  await DomainTransaction.execute(async () => {
-    await Promise.all(
-      organizationBatchUpdateDtos.map(async (organizationBatchUpdateDto) => {
-        await _checkOrganizationUpdate({
-          organizationBatchUpdateDto,
-          organizationForAdminRepository,
-          administrationTeamRepository,
-          countryRepository,
-          organizationLearnerTypeRepository,
-        });
+    for (const dto of dtos) {
+      organizationIds.add(dto.id);
+      if (dto.parentOrganizationId) parentOrganizationIds.add(dto.parentOrganizationId);
+      if (dto.administrationTeamId) administrationTeamIds.add(dto.administrationTeamId);
+      if (dto.countryCode) countryCodes.add(dto.countryCode);
+      if (dto.organizationLearnerTypeId) organizationLearnerTypeIds.add(dto.organizationLearnerTypeId);
+    }
 
-        try {
-          const organization = await organizationForAdminRepository.get({
-            organizationId: organizationBatchUpdateDto.id,
-          });
-          organization.updateFromOrganizationBatchUpdateDto(organizationBatchUpdateDto);
-
-          await organizationForAdminRepository.update({ organization });
-        } catch {
-          throw new OrganizationBatchUpdateError({
-            meta: { organizationId: organizationBatchUpdateDto.id },
-          });
-        }
-      }),
+    const existingOrganizationIds = await _toExistingSet(
+      Array.from(new Set([...organizationIds, ...parentOrganizationIds])),
+      (ids) => organizationForAdminRepository.findExistingIds({ ids }),
     );
-  });
-};
 
-async function _checkOrganizationUpdate({
-  organizationBatchUpdateDto,
-  organizationForAdminRepository,
-  administrationTeamRepository,
-  countryRepository,
-  organizationLearnerTypeRepository,
-}) {
-  const organization = await organizationForAdminRepository.exist({ organizationId: organizationBatchUpdateDto.id });
-  if (!organization) {
-    throw new OrganizationNotFound({
-      meta: {
-        organizationId: organizationBatchUpdateDto.id,
-      },
-    });
-  }
+    const existingAdministrationTeamIds = await _toExistingSet(Array.from(administrationTeamIds), (ids) =>
+      administrationTeamRepository.findExistingIds({ ids }),
+    );
 
-  if (organizationBatchUpdateDto.parentOrganizationId) {
-    const parentOrganization = await organizationForAdminRepository.exist({
-      organizationId: organizationBatchUpdateDto.parentOrganizationId,
+    const existingCountryCodes = await _toExistingSet(Array.from(countryCodes), (codes) =>
+      countryRepository.findExistingCodes({ codes }),
+    );
+
+    const existingOrganizationLearnerTypeIds = await _toExistingSet(Array.from(organizationLearnerTypeIds), (ids) =>
+      organizationLearnerTypeRepository.findExistingIds({ ids }),
+    );
+
+    _validateAllDtos(dtos, {
+      existingOrganizationIds,
+      existingAdministrationTeamIds,
+      existingCountryCodes,
+      existingOrganizationLearnerTypeIds,
     });
-    if (!parentOrganization) {
+
+    for (const dto of dtos) {
+      await _updateOrganization(dto, organizationForAdminRepository);
+    }
+  },
+);
+
+async function _toExistingSet(values, finder) {
+  if (!values || values.length === 0) return new Set();
+  const existing = await finder(values);
+  return new Set(existing.map(String));
+}
+
+function _validateAllDtos(
+  dtos,
+  { existingOrganizationIds, existingAdministrationTeamIds, existingCountryCodes, existingOrganizationLearnerTypeIds },
+) {
+  for (const dto of dtos) {
+    if (!existingOrganizationIds.has(String(dto.id))) {
+      throw new OrganizationNotFound({
+        meta: { organizationId: dto.id },
+      });
+    }
+
+    if (dto.parentOrganizationId && !existingOrganizationIds.has(String(dto.parentOrganizationId))) {
       throw new UnableToAttachChildOrganizationToParentOrganizationError({
         meta: {
-          organizationId: organizationBatchUpdateDto.id,
-          value: organizationBatchUpdateDto.parentOrganizationId,
+          organizationId: dto.id,
+          value: dto.parentOrganizationId,
         },
       });
     }
-  }
 
-  if (
-    organizationBatchUpdateDto.dataProtectionOfficerEmail &&
-    !emailValidationService.validateEmailSyntax(organizationBatchUpdateDto.dataProtectionOfficerEmail)
-  ) {
-    throw new DpoEmailInvalid({
-      meta: {
-        organizationId: organizationBatchUpdateDto.id,
-        value: organizationBatchUpdateDto.dataProtectionOfficerEmail,
-      },
-    });
-  }
-
-  if (organizationBatchUpdateDto.administrationTeamId) {
-    const administrationTeam = await administrationTeamRepository.getById(
-      organizationBatchUpdateDto.administrationTeamId,
-    );
-
-    if (!administrationTeam) {
-      throw new AdministrationTeamNotFound({
+    if (dto.dataProtectionOfficerEmail && !emailValidationService.validateEmailSyntax(dto.dataProtectionOfficerEmail)) {
+      throw new DpoEmailInvalid({
         meta: {
-          administrationTeamId: organizationBatchUpdateDto.administrationTeamId,
+          organizationId: dto.id,
+          value: dto.dataProtectionOfficerEmail,
         },
       });
     }
-  }
 
-  if (organizationBatchUpdateDto.countryCode) {
-    await _checkCountryExists(organizationBatchUpdateDto.countryCode, countryRepository);
-  }
+    if (dto.administrationTeamId && !existingAdministrationTeamIds.has(String(dto.administrationTeamId))) {
+      throw new AdministrationTeamNotFound({
+        meta: { administrationTeamId: dto.administrationTeamId },
+      });
+    }
 
-  if (organizationBatchUpdateDto.organizationLearnerTypeId) {
-    await _checkOrganizationLearnerTypeExists(
-      organizationBatchUpdateDto.organizationLearnerTypeId,
-      organizationLearnerTypeRepository,
-    );
-  }
+    if (dto.countryCode && !existingCountryCodes.has(String(dto.countryCode))) {
+      logger.error({
+        event: 'Not_found_country',
+        message: `Le pays avec le code ${dto.countryCode} n'a pas été trouvé.`,
+      });
 
-  return organization;
+      throw new CountryNotFoundError({
+        message: `Country not found for code ${dto.countryCode}`,
+        meta: { countryCode: dto.countryCode },
+      });
+    }
+
+    if (
+      dto.organizationLearnerTypeId &&
+      !existingOrganizationLearnerTypeIds.has(String(dto.organizationLearnerTypeId))
+    ) {
+      throw new OrganizationLearnerTypeNotFound({
+        message: `Organization learner type not found for id ${dto.organizationLearnerTypeId}`,
+        meta: { organizationLearnerTypeId: dto.organizationLearnerTypeId },
+      });
+    }
+  }
 }
 
-async function _checkCountryExists(countryCode, countryRepository) {
+async function _updateOrganization(dto, repository) {
   try {
-    await countryRepository.getByCode(countryCode);
-  } catch {
-    logger.error({
-      event: 'Not_found_country',
-      message: `Le pays avec le code ${countryCode} n'a pas été trouvé.`,
+    const organization = await repository.get({
+      organizationId: dto.id,
     });
-    throw new CountryNotFoundError({ message: `Country not found for code ${countryCode}`, meta: { countryCode } });
-  }
-}
 
-async function _checkOrganizationLearnerTypeExists(organizationLearnerTypeId, organizationLearnerTypeRepository) {
-  try {
-    await organizationLearnerTypeRepository.getById(organizationLearnerTypeId);
+    organization.updateFromOrganizationBatchUpdateDto(dto);
+
+    await repository.update({ organization });
   } catch {
-    throw new OrganizationLearnerTypeNotFound({
-      message: `Organization learner type not found for id ${organizationLearnerTypeId}`,
-      meta: { organizationLearnerTypeId },
+    throw new OrganizationBatchUpdateError({
+      meta: { organizationId: dto.id },
     });
   }
 }

--- a/api/src/organizational-entities/infrastructure/repositories/administration-team-repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/administration-team-repository.js
@@ -19,10 +19,22 @@ const getById = async function (id) {
   return _toDomain(administrationTeam);
 };
 
+/**
+ * @type {function}
+ * @param {Array<string>} ids
+ * @return {Promise<Array<number>>}
+ */
+const findExistingIds = async function ({ ids } = {}) {
+  if (!ids || ids.length === 0) return [];
+  const knexConn = DomainTransaction.getConnection();
+  const administrationTeams = await knexConn('administration_teams').select('id').whereIn('id', ids);
+  return administrationTeams.map((team) => team.id);
+};
+
 const _toDomain = function (administrationTeamDTO) {
   return new AdministrationTeam({
     ...administrationTeamDTO,
   });
 };
 
-export { findAll, getById };
+export { findAll, findExistingIds, getById };

--- a/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
@@ -67,6 +67,18 @@ const exist = async function ({ organizationId }) {
 
 /**
  * @type {function}
+ * @param {Array<string|number>} ids
+ * @return {Promise<Array<string|number>>}
+ */
+const findExistingIds = async function ({ ids } = {}) {
+  if (!ids || ids.length === 0) return [];
+  const knexConnection = DomainTransaction.getConnection();
+  const organizations = await knexConnection(ORGANIZATIONS_TABLE_NAME).select('id').whereIn('id', ids);
+  return organizations.map((org) => org.id);
+};
+
+/**
+ * @type {function}
  * @param {string|number} parentOrganizationId
  * @return {Promise<OrganizationForAdmin[]>}
  */
@@ -503,6 +515,7 @@ export const organizationForAdminRepository = {
   archive,
   createProOrganizationInvitation,
   exist,
+  findExistingIds,
   findPaginatedFiltered,
   findChildrenByParentOrganizationId,
   get,

--- a/api/src/organizational-entities/infrastructure/repositories/organization-learner-type-repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/organization-learner-type-repository.js
@@ -36,6 +36,18 @@ const getById = async function (id) {
   return _toDomain(organizationLearnerTypeDTO);
 };
 
+/**
+ * @type {function}
+ * @param {Array<string>} ids
+ * @return {Promise<Array<number>>}
+ */
+const findExistingIds = async function ({ ids } = {}) {
+  if (!ids || ids.length === 0) return [];
+  const knexConn = DomainTransaction.getConnection();
+  const organizationLearnerTypes = await knexConn('organization_learner_types').select('id').whereIn('id', ids);
+  return organizationLearnerTypes.map((type) => type.id);
+};
+
 const _toDomain = function (organizationLearnerTypeDTO) {
   return new OrganizationLearnerType({
     id: organizationLearnerTypeDTO.id,
@@ -43,4 +55,4 @@ const _toDomain = function (organizationLearnerTypeDTO) {
   });
 };
 
-export { findAll, getById };
+export { findAll, findExistingIds, getById };

--- a/api/src/shared/infrastructure/repositories/country-repository.js
+++ b/api/src/shared/infrastructure/repositories/country-repository.js
@@ -29,7 +29,22 @@ const getByCode = async function (code) {
   return _toDomain(result);
 };
 
-export { findAll, getByCode };
+/**
+ * @type {function}
+ * @param {Array<string>} codes
+ * @return {Promise<Array<string>>}
+ */
+const findExistingCodes = async function ({ codes } = {}) {
+  if (!codes || codes.length === 0) return [];
+  const knexConn = DomainTransaction.getConnection();
+  const result = await knexConn('certification-cpf-countries')
+    .select('code')
+    .whereIn('code', codes)
+    .where('commonName', '=', knexConn.ref('originalName'));
+  return result.map((row) => row.code);
+};
+
+export { findAll, findExistingCodes, getByCode };
 
 function _toDomain(row) {
   return new Country({

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/administration-team-repository_test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/administration-team-repository_test.js
@@ -60,4 +60,34 @@ describe('Integration | Repository | administration-team-repository', function (
       expect(result).to.be.null;
     });
   });
+
+  describe('#findExistingIds', function () {
+    it('should return the administration team ids matching the given ids', async function () {
+      // given
+      const administrationTeam1 = databaseBuilder.factory.buildAdministrationTeam();
+      const administrationTeam2 = databaseBuilder.factory.buildAdministrationTeam();
+      await databaseBuilder.commit();
+
+      // when
+      const foundAdministrationTeamIds = await administrationTeamRepository.findExistingIds({
+        ids: [administrationTeam1.id, administrationTeam2.id],
+      });
+
+      // then
+      expect(foundAdministrationTeamIds).to.deep.equal([administrationTeam1.id, administrationTeam2.id]);
+    });
+
+    it('should return an empty array if there is no matching id', async function () {
+      // given
+      const unknownIds = [456, 789];
+
+      // when
+      const foundAdministrationTeamIds = await administrationTeamRepository.findExistingIds({
+        ids: unknownIds,
+      });
+
+      // then
+      expect(foundAdministrationTeamIds).to.deep.equal([]);
+    });
+  });
 });

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/organization-for-admin.repository.test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/organization-for-admin.repository.test.js
@@ -1784,4 +1784,34 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
       expect(organizationLearnerTypeId).to.equal(secondOrganizationLearnerType.id);
     });
   });
+
+  describe('findExistingIds', function () {
+    it('should return organization ids matching given ids', async function () {
+      // given
+      const organization1 = databaseBuilder.factory.buildOrganization();
+      const organization2 = databaseBuilder.factory.buildOrganization();
+      await databaseBuilder.commit();
+
+      // when
+      const foundOrganizationIds = await repositories.organizationForAdminRepository.findExistingIds({
+        ids: [organization1.id, organization2.id],
+      });
+
+      // then
+      expect(foundOrganizationIds).to.deep.equal([organization1.id, organization2.id]);
+    });
+
+    it('should return an empty array if no organization id matches', async function () {
+      // given
+      const unknownOrganizationIds = [999, 998];
+
+      // when
+      const foundOrganizationIds = await repositories.organizationForAdminRepository.findExistingIds({
+        ids: unknownOrganizationIds,
+      });
+
+      // then
+      expect(foundOrganizationIds).to.deep.equal([]);
+    });
+  });
 });

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/organization-learner-type-repository_test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/organization-learner-type-repository_test.js
@@ -76,4 +76,36 @@ describe('Integration | Repository | organization-learner-type-repository', func
       expect(error).to.be.instanceOf(NotFoundError);
     });
   });
+
+  describe('#findExistingIds', function () {
+    it('should return the ids of the organization learner types matching the given ids', async function () {
+      // given
+      const firstOrganizationLearnerType = databaseBuilder.factory.buildOrganizationLearnerType({
+        id: 123,
+      });
+      const secondOrganizationLearnerType = databaseBuilder.factory.buildOrganizationLearnerType({
+        id: 456,
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const result = await organizationLearnerTypeRepository.findExistingIds({
+        ids: [firstOrganizationLearnerType.id, secondOrganizationLearnerType.id],
+      });
+
+      // then
+      expect(result).to.deep.equal([firstOrganizationLearnerType.id, secondOrganizationLearnerType.id]);
+    });
+
+    it('should return an empty array if no organization learner type matches the given ids', async function () {
+      // given
+      const unknownIds = [123, 456];
+
+      // when
+      const result = await organizationLearnerTypeRepository.findExistingIds({ ids: unknownIds });
+
+      // then
+      expect(result).to.deep.equal([]);
+    });
+  });
 });

--- a/api/tests/organizational-entities/unit/domain/usecases/update-organizations-in-batch.usecase.test.js
+++ b/api/tests/organizational-entities/unit/domain/usecases/update-organizations-in-batch.usecase.test.js
@@ -1,11 +1,14 @@
-import { OrganizationBatchUpdateDTO } from '../../../../../src/organizational-entities/domain/dtos/OrganizationBatchUpdateDTO.js';
 import { OrganizationBatchUpdateError } from '../../../../../src/organizational-entities/domain/errors.js';
 import { updateOrganizationsInBatch } from '../../../../../src/organizational-entities/domain/usecases/update-organizations-in-batch.usecase.js';
 import { DomainTransaction } from '../../../../../src/shared/domain/DomainTransaction.js';
 import { catchErr, createTempFile, domainBuilder, expect, removeTempFile, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Organizational Entities | Domain | UseCase | update-organizations-in-batch', function () {
-  let filePath, organizationForAdminRepository, administrationTeamRepository, countryRepository;
+  let filePath,
+    organizationForAdminRepository,
+    administrationTeamRepository,
+    countryRepository,
+    organizationLearnerTypeRepository;
 
   const csvHeaders =
     'Organization ID;Organization Name;Organization External ID;Organization Parent ID;Organization Identity Provider Code;Organization Documentation URL;Organization Province Code;DPO Last Name;DPO First Name;DPO E-mail;Administration Team ID;Country Code';
@@ -21,12 +24,22 @@ describe('Unit | Organizational Entities | Domain | UseCase | update-organizatio
       exist: sinon.stub(),
     };
 
+    organizationForAdminRepository.findExistingIds = sinon.stub().resolves([]);
+
     countryRepository = {
       getByCode: sinon.stub().resolves(domainBuilder.buildCountry({ code: '99100' })),
+      findExistingCodes: sinon.stub().resolves([]),
     };
 
     administrationTeamRepository = {
       getById: sinon.stub().resolves(domainBuilder.buildAdministrationTeam({ id: 1234 })),
+    };
+
+    administrationTeamRepository.findExistingIds = sinon.stub().resolves([]);
+
+    organizationLearnerTypeRepository = {
+      getById: sinon.stub().resolves(domainBuilder.acquisition.buildOrganizationLearnerType({ id: 12 })),
+      findExistingIds: sinon.stub().resolves([]),
     };
   });
 
@@ -45,96 +58,16 @@ describe('Unit | Organizational Entities | Domain | UseCase | update-organizatio
       filePath = await createTempFile('test.csv', fileData);
 
       // when
-      await updateOrganizationsInBatch({ filePath, organizationForAdminRepository, administrationTeamRepository });
+      await updateOrganizationsInBatch({
+        filePath,
+        organizationForAdminRepository,
+        administrationTeamRepository,
+        organizationLearnerTypeRepository,
+      });
 
       // then
-      expect(DomainTransaction.execute).to.not.have.been.called;
       expect(organizationForAdminRepository.get).to.not.have.been.called;
       expect(organizationForAdminRepository.update).to.not.have.been.called;
-    });
-  });
-
-  context('when parsing a CSV file which contains a list of organizations to update', function () {
-    let csvData;
-
-    beforeEach(async function () {
-      const fileData = `${csvHeaders}
-      1;;12;;OIDC_EXAMPLE_NET;https://doc.url;;Troisjour;Adam;foo@email.com;1234;99100
-      2;New Name;;;;;;;Cali;;5678;99100`;
-      filePath = await createTempFile('test.csv', fileData);
-      csvData = [
-        new OrganizationBatchUpdateDTO({
-          id: '1',
-          externalId: '12',
-          identityProviderForCampaigns: 'OIDC_EXAMPLE_NET',
-          documentationUrl: 'https://doc.url',
-          dataProtectionOfficerLastName: 'Troisjour',
-          dataProtectionOfficerFirstName: 'Adam',
-          dataProtectionOfficerEmail: 'foo@email.com',
-          administrationTeamId: '1234',
-          countryCode: '99100',
-        }),
-        new OrganizationBatchUpdateDTO({
-          id: '2',
-          name: 'New Name',
-          dataProtectionOfficerFirstName: 'Cali',
-          administrationTeamId: '5678',
-          countryCode: '99100',
-        }),
-      ];
-    });
-
-    it('calls n times "organizationForAdminRepository.get" to retrieve an organization', async function () {
-      // given
-      organizationForAdminRepository.exist.resolves(true);
-      organizationForAdminRepository.get.onCall(0).resolves(domainBuilder.buildOrganizationForAdmin({ id: 1 }));
-      organizationForAdminRepository.get.onCall(1).resolves(domainBuilder.buildOrganizationForAdmin({ id: 2 }));
-
-      // when
-      await updateOrganizationsInBatch({
-        filePath,
-        organizationForAdminRepository,
-        administrationTeamRepository,
-        countryRepository,
-      });
-
-      // then
-      expect(DomainTransaction.execute).to.have.been.called;
-      expect(organizationForAdminRepository.get).to.have.been.callCount(2);
-      expect(organizationForAdminRepository.get.getCall(0)).to.have.been.calledWithExactly({ organizationId: '1' });
-      expect(organizationForAdminRepository.get.getCall(1)).to.have.been.calledWithExactly({ organizationId: '2' });
-    });
-
-    it('calls n times "organizationForAdminRepository.update" to update an organization', async function () {
-      // given
-      const firstOrganization = domainBuilder.buildOrganizationForAdmin({ id: 1 });
-      const secondOrganization = domainBuilder.buildOrganizationForAdmin({ id: 2 });
-      organizationForAdminRepository.exist.resolves(true);
-      organizationForAdminRepository.get.onCall(0).resolves(firstOrganization);
-      organizationForAdminRepository.get.onCall(1).resolves(secondOrganization);
-
-      const expectedFirstOrganization = domainBuilder.buildOrganizationForAdmin({ id: 1 });
-      expectedFirstOrganization.updateFromOrganizationBatchUpdateDto(csvData[0]);
-      const expectedSecondOrganization = domainBuilder.buildOrganizationForAdmin({ id: 2 });
-      expectedSecondOrganization.updateFromOrganizationBatchUpdateDto(csvData[1]);
-
-      // when
-      await updateOrganizationsInBatch({
-        filePath,
-        organizationForAdminRepository,
-        administrationTeamRepository,
-        countryRepository,
-      });
-
-      // then
-      expect(DomainTransaction.execute).to.have.been.called;
-      expect(organizationForAdminRepository.update).to.have.been.callCount(2);
-      expect(organizationForAdminRepository.update.getCall(0)).to.have.been.calledWithExactly({
-        organization: expectedFirstOrganization,
-      });
-      expect(organizationForAdminRepository.update.getCall(1)).to.have.been.calledWithExactly({
-        organization: expectedSecondOrganization,
-      });
     });
   });
 
@@ -149,6 +82,10 @@ describe('Unit | Organizational Entities | Domain | UseCase | update-organizatio
         organizationForAdminRepository.exist.resolves(true);
         organizationForAdminRepository.get.onCall(0).resolves(domainBuilder.buildOrganizationForAdmin({ id: 1 }));
         organizationForAdminRepository.update.rejects('Unexpected error');
+        organizationForAdminRepository.findExistingIds.resolves(['1', '2']);
+        administrationTeamRepository.findExistingIds.resolves(['1234']);
+        countryRepository.findExistingCodes.resolves(['99100']);
+        organizationLearnerTypeRepository.findExistingIds.resolves([]);
 
         // when
         const error = await catchErr(updateOrganizationsInBatch)({
@@ -156,6 +93,7 @@ describe('Unit | Organizational Entities | Domain | UseCase | update-organizatio
           organizationForAdminRepository,
           administrationTeamRepository,
           countryRepository,
+          organizationLearnerTypeRepository,
         });
 
         // then

--- a/api/tests/shared/integration/infrastructure/repositories/country-repository_test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/country-repository_test.js
@@ -109,4 +109,40 @@ describe('Integration | Shared | Repository | country-repository', function () {
       });
     });
   });
+
+  describe('#findExistingCodes', function () {
+    it('should return the codes matching the given codes', async function () {
+      // given
+      const togoCountry = databaseBuilder.factory.buildCertificationCpfCountry({
+        code: '99345',
+        commonName: 'TOGO',
+        originalName: 'TOGO',
+      });
+
+      const nabooCountry = databaseBuilder.factory.buildCertificationCpfCountry({
+        code: '99876',
+        commonName: 'NABOO',
+        originalName: 'NABOO',
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const result = await countryRepository.findExistingCodes({ codes: [togoCountry.code, nabooCountry.code] });
+
+      // then
+      expect(result).to.deep.equal([togoCountry.code, nabooCountry.code]);
+    });
+
+    it('should return an empty array if there is no matching code', async function () {
+      // given
+      const nonExistingCodes = ['1234', '5678'];
+
+      // when
+      const result = await countryRepository.findExistingCodes({ codes: nonExistingCodes });
+
+      // then
+      expect(result).to.deep.equal([]);
+    });
+  });
 });


### PR DESCRIPTION
## 🥀 Problème

Lors de la modification d'orga en masse, plusieurs vérifications (appels bdd) sont fait à chaque ligne du csv d'import. Ces appels peuvent être groupés afin d'alléger le usecase et de limiter le nombre de reqêtes.

## 🏹 Proposition

Grouper les vérifications afin de ne garder que l'appel à l'update par ligne.


## ❤️‍🔥 Pour tester

- Non régression sur la mise à jour d'orga en masse