### PR TITLE
[FEATURE] Ne pas afficher la page d'analyse pour une participation en cours (PIX-21468)

### DIFF
--- a/api/src/prescription/campaign-participation/domain/usecases/get-campaign-assessment-participation-result.js
+++ b/api/src/prescription/campaign-participation/domain/usecases/get-campaign-assessment-participation-result.js
@@ -6,10 +6,16 @@ const getCampaignAssessmentParticipationResult = async function ({
   campaignParticipationId,
   campaignRepository,
   campaignAssessmentParticipationResultRepository,
+  campaignParticipationRepository,
   locale,
 } = {}) {
   if (!(await campaignRepository.checkIfUserOrganizationHasAccessToCampaign(campaignId, userId))) {
     throw new UserNotAuthorizedToAccessEntityError('User does not belong to the organization that owns the campaign');
+  }
+
+  const participation = await campaignParticipationRepository.get(campaignParticipationId);
+  if (!participation.isShared) {
+    throw new UserNotAuthorizedToAccessEntityError('Campaign participation is not shared yet');
   }
 
   return campaignAssessmentParticipationResultRepository.getByCampaignIdAndCampaignParticipationId({

--- a/api/src/prescription/campaign-participation/domain/usecases/get-result-levels-per-tubes-and-competences.js
+++ b/api/src/prescription/campaign-participation/domain/usecases/get-result-levels-per-tubes-and-competences.js
@@ -1,11 +1,19 @@
+import { UserNotAuthorizedToAccessEntityError } from '../../../../shared/domain/errors.js';
 import { CampaignResultLevelsPerTubesAndCompetences } from '../../../campaign/domain/models/CampaignResultLevelsPerTubesAndCompetences.js';
 
 const getResultLevelsPerTubesAndCompetences = async ({
   campaignParticipationId,
   locale,
+  campaignParticipationRepository,
   learningContentRepository,
   knowledgeElementSnapshotRepository,
 }) => {
+  const participation = await campaignParticipationRepository.get(campaignParticipationId);
+
+  if (!participation.isShared) {
+    throw new UserNotAuthorizedToAccessEntityError('Campaign participation is not shared yet');
+  }
+
   const learningContent = await learningContentRepository.findByCampaignParticipationId(
     campaignParticipationId,
     locale,

--- a/api/tests/prescription/campaign-participation/integration/domain/usecases/get-result-levels-per-tubes-and-competences_test.js
+++ b/api/tests/prescription/campaign-participation/integration/domain/usecases/get-result-levels-per-tubes-and-competences_test.js
@@ -7,9 +7,10 @@ import {
   CampaignTypes,
 } from '../../../../../../src/prescription/shared/domain/constants.js';
 import { KnowledgeElementCollection } from '../../../../../../src/prescription/shared/domain/models/KnowledgeElementCollection.js';
+import { UserNotAuthorizedToAccessEntityError } from '../../../../../../src/shared/domain/errors.js';
 import { KnowledgeElement } from '../../../../../../src/shared/domain/models/KnowledgeElement.js';
 import { FRENCH_SPOKEN } from '../../../../../../src/shared/domain/services/locale-service.js';
-import { databaseBuilder, expect } from '../../../../../test-helper.js';
+import { catchErr, databaseBuilder, expect } from '../../../../../test-helper.js';
 
 describe('Integration | Prescription | Campaign participation | Usecase | get-result-levels-per-tubes-and-competences', function () {
   let campaignParticipation;
@@ -116,5 +117,22 @@ describe('Integration | Prescription | Campaign participation | Usecase | get-re
         title: 'Tube 1 fr title',
       },
     ]);
+  });
+
+  context('when participation is not shared', function () {
+    it('should throw UserNotAuthorizedToAccessEntityError', async function () {
+      const notSharedParticipation = databaseBuilder.factory.buildCampaignParticipation({
+        campaignId: campaignParticipation.campaignId,
+        status: CampaignParticipationStatuses.STARTED,
+      });
+      await databaseBuilder.commit();
+
+      const error = await catchErr(usecases.getResultLevelsPerTubesAndCompetences)({
+        campaignParticipationId: notSharedParticipation.id,
+        locale: FRENCH_SPOKEN,
+      });
+
+      expect(error).to.be.instanceOf(UserNotAuthorizedToAccessEntityError);
+    });
   });
 });

--- a/api/tests/prescription/campaign-participation/unit/domain/usecases/get-campaign-assessment-participation-result_test.js
+++ b/api/tests/prescription/campaign-participation/unit/domain/usecases/get-campaign-assessment-participation-result_test.js
@@ -3,7 +3,7 @@ import { UserNotAuthorizedToAccessEntityError } from '../../../../../../src/shar
 import { catchErr, domainBuilder, expect, sinon } from '../../../../../test-helper.js';
 
 describe('Unit | UseCase | get-campaign-assessment-participation-result', function () {
-  let campaignRepository, campaignAssessmentParticipationResultRepository;
+  let campaignRepository, campaignAssessmentParticipationResultRepository, campaignParticipationRepository;
   let userId, campaignId, campaign, campaignParticipationId;
   const locale = 'fr';
 
@@ -13,6 +13,9 @@ describe('Unit | UseCase | get-campaign-assessment-participation-result', functi
     };
     campaignAssessmentParticipationResultRepository = {
       getByCampaignIdAndCampaignParticipationId: sinon.stub(),
+    };
+    campaignParticipationRepository = {
+      get: sinon.stub(),
     };
   });
 
@@ -25,25 +28,50 @@ describe('Unit | UseCase | get-campaign-assessment-participation-result', functi
       campaignRepository.checkIfUserOrganizationHasAccessToCampaign.withArgs(campaignId, userId).resolves(true);
     });
 
-    it('should get the campaignAssessmentParticipationResult', async function () {
-      // given
-      const expectedResult = Symbol('Result');
-      campaignAssessmentParticipationResultRepository.getByCampaignIdAndCampaignParticipationId
-        .withArgs({ campaignId, campaignParticipationId, locale })
-        .resolves(expectedResult);
+    context('when participation is shared', function () {
+      it('should get the campaignAssessmentParticipationResult', async function () {
+        // given
+        const expectedResult = Symbol('Result');
+        campaignParticipationRepository.get.withArgs(campaignParticipationId).resolves({ isShared: true });
+        campaignAssessmentParticipationResultRepository.getByCampaignIdAndCampaignParticipationId
+          .withArgs({ campaignId, campaignParticipationId, locale })
+          .resolves(expectedResult);
 
-      // when
-      const result = await getCampaignAssessmentParticipationResult({
-        userId,
-        campaignId,
-        campaignParticipationId,
-        campaignRepository,
-        campaignAssessmentParticipationResultRepository,
-        locale,
+        // when
+        const result = await getCampaignAssessmentParticipationResult({
+          userId,
+          campaignId,
+          campaignParticipationId,
+          campaignRepository,
+          campaignAssessmentParticipationResultRepository,
+          campaignParticipationRepository,
+          locale,
+        });
+
+        // then
+        expect(result).to.equal(expectedResult);
       });
+    });
 
-      // then
-      expect(result).to.equal(expectedResult);
+    context('when participation is not shared', function () {
+      it('should throw UserNotAuthorizedToAccessEntityError', async function () {
+        // given
+        campaignParticipationRepository.get.withArgs(campaignParticipationId).resolves({ isShared: false });
+
+        // when
+        const result = await catchErr(getCampaignAssessmentParticipationResult)({
+          userId,
+          campaignId,
+          campaignParticipationId,
+          campaignRepository,
+          campaignAssessmentParticipationResultRepository,
+          campaignParticipationRepository,
+          locale,
+        });
+
+        // then
+        expect(result).to.be.instanceOf(UserNotAuthorizedToAccessEntityError);
+      });
     });
   });
 
@@ -64,6 +92,7 @@ describe('Unit | UseCase | get-campaign-assessment-participation-result', functi
         campaignParticipationId,
         campaignRepository,
         campaignAssessmentParticipationResultRepository,
+        campaignParticipationRepository,
         locale,
       });
 

--- a/orga/app/components/participant/assessment/results.gjs
+++ b/orga/app/components/participant/assessment/results.gjs
@@ -4,6 +4,7 @@ import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
 import { t } from 'ember-intl';
 
 import multiply from '../../../helpers/multiply';
+import EmptyState from '../../ui/empty-state';
 
 function sortedCompetenceResults(results) {
   return results.sort((a, b) => {
@@ -20,7 +21,7 @@ function competenceCount(results) {
 }
 
 <template>
-  <section>
+  {{#if (displayResults @results)}}
     <PixTable
       @variant="orga"
       @caption={{t "pages.assessment-individual-results.table.title"}}
@@ -59,8 +60,7 @@ function competenceCount(results) {
       </:columns>
     </PixTable>
 
-    {{#unless (displayResults @results)}}
-      <p class="table__empty content-text">{{t "pages.assessment-individual-results.table.empty"}}</p>
-    {{/unless}}
-  </section>
+  {{else}}
+    <EmptyState @infoText={{t "pages.assessment-individual-results.table.empty"}} />
+  {{/if}}
 </template>

--- a/orga/app/routes/authenticated/campaigns/participant-assessment/analysis.js
+++ b/orga/app/routes/authenticated/campaigns/participant-assessment/analysis.js
@@ -25,7 +25,11 @@ export default class AnalysisRoute extends Route {
 
   async model() {
     const { campaignAssessmentParticipation } = this.modelFor('authenticated.campaigns.participant-assessment');
+
+    if (!campaignAssessmentParticipation.isShared) {
+      return { analysisData: null, isAnalysisAvailable: false, isForParticipant: true };
+    }
     const analysisData = await campaignAssessmentParticipation.campaignParticipationLevelsPerTubesAndCompetence;
-    return { analysisData, isForParticipant: true };
+    return { analysisData, isAnalysisAvailable: true, isForParticipant: true };
   }
 }

--- a/orga/app/routes/authenticated/campaigns/participant-assessment/results.js
+++ b/orga/app/routes/authenticated/campaigns/participant-assessment/results.js
@@ -15,6 +15,9 @@ export default class ResultsRoute extends Route {
 
   async model() {
     const { campaignAssessmentParticipation } = this.modelFor('authenticated.campaigns.participant-assessment');
+    if (!campaignAssessmentParticipation.isShared) {
+      return [];
+    }
     const campaignAssessmentParticipationResult =
       await campaignAssessmentParticipation.campaignAssessmentParticipationResult;
     const competenceResults = await campaignAssessmentParticipationResult.competenceResults;

--- a/orga/app/templates/authenticated/campaigns/participant-assessment/analysis.gjs
+++ b/orga/app/templates/authenticated/campaigns/participant-assessment/analysis.gjs
@@ -1,6 +1,13 @@
+import { t } from 'ember-intl';
 import AnalysisHeader from 'pix-orga/components/analysis/analysis-header';
 
+import EmptyState from '../../../../components/ui/empty-state';
+
 <template>
-  <AnalysisHeader @model={{@model}} />
-  {{outlet}}
+  {{#if @model.isAnalysisAvailable}}
+    <AnalysisHeader @model={{@model}} />
+    {{outlet}}
+  {{else}}
+    <EmptyState @infoText={{t "pages.assessment-individual-results.table.empty"}} />
+  {{/if}}
 </template>

--- a/orga/tests/acceptance/campaign-participants-individual-results-test.js
+++ b/orga/tests/acceptance/campaign-participants-individual-results-test.js
@@ -99,13 +99,22 @@ module('Acceptance | Campaign Participants Individual Results', function (hooks)
       'withCompetenceResults',
       { id: 1, campaignId: 1 },
     );
-    server.create('campaign-assessment-participation', { id: 1, campaignId: 1, campaignAssessmentParticipationResult });
+    server.create('campaign-assessment-participation', {
+      id: 1,
+      campaignId: 1,
+      isShared: true,
+      masteryRate: 0.5,
+      campaignAssessmentParticipationResult,
+    });
 
     // when
     const screen = await visit('/campagnes/1/evaluations/1');
 
     // then
-    assert.dom(screen.getByText('Compétences (2)')).exists();
+
+    assert
+      .dom(screen.getByText(t('pages.assessment-individual-results.table.column.competences', { count: 2 })))
+      .exists();
   });
 
   test('it should not display individual results when competence results are empty', async function (assert) {
@@ -121,6 +130,22 @@ module('Acceptance | Campaign Participants Individual Results', function (hooks)
     const screen = await visit('/campagnes/1/evaluations/1');
 
     // then
-    assert.dom(screen.getByText('Compétences (-)')).exists();
+    assert.dom(screen.getByText(t('pages.assessment-individual-results.table.empty'))).exists();
+  });
+
+  test('it should not display individual results when participation is not shared', async function (assert) {
+    // given
+    const campaignAssessmentParticipationResult = server.create(
+      'campaign-assessment-participation-result',
+      'withCompetenceResults',
+      { id: 1, campaignId: 1, isShared: false },
+    );
+    server.create('campaign-assessment-participation', { id: 1, campaignId: 1, campaignAssessmentParticipationResult });
+
+    // when
+    const screen = await visit('/campagnes/1/evaluations/1');
+
+    // then
+    assert.dom(screen.getByText(t('pages.assessment-individual-results.table.empty'))).exists();
   });
 });

--- a/orga/tests/integration/components/participant/assessment/results-test.js
+++ b/orga/tests/integration/components/participant/assessment/results-test.js
@@ -14,7 +14,7 @@ module('Integration | Component | Participant::Assessment::Results', function (h
     store = this.owner.lookup('service:store');
   });
 
-  test('it should display a sentence when displayResults is false', async function (assert) {
+  test('it should hide table when there is no results', async function (assert) {
     // when
     const competenceResults = [];
 
@@ -25,7 +25,7 @@ module('Integration | Component | Participant::Assessment::Results', function (h
     assert.dom(screen.getByText(t('pages.assessment-individual-results.table.empty'))).exists();
   });
 
-  test('it should display results when displayResults is true', async function (assert) {
+  test('it should display results when there are results', async function (assert) {
     // given
     const competenceResult = store.createRecord('campaign-assessment-participation-competence-result', {
       name: 'Compétence 1',

--- a/orga/tests/integration/components/participant/assessment/tabs-test.gjs
+++ b/orga/tests/integration/components/participant/assessment/tabs-test.gjs
@@ -1,5 +1,5 @@
-import { render as renderScreen } from '@1024pix/ember-testing-library';
-import { hbs } from 'ember-cli-htmlbars';
+import { render } from '@1024pix/ember-testing-library';
+import Tabs from 'pix-orga/components/participant/assessment/tabs';
 import { module, test } from 'qunit';
 
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
@@ -13,12 +13,12 @@ module('Integration | Component | Participant::Assessment::Tabs', function (hook
 
   test('it should display navigation links for results and analysis pages', async function (assert) {
     // given
-    this.campaignId = 1;
-    this.participationId = 2;
+    const campaignId = 1;
+    const participationId = 2;
 
     // when
-    const screen = await renderScreen(
-      hbs`<Participant::Assessment::Tabs @campaignId={{this.campaignId}} @participationId={{this.participationId}} />`,
+    const screen = await render(
+      <template><Tabs @campaignId={{campaignId}} @participationId={{participationId}} /></template>,
     );
 
     // then
@@ -28,12 +28,12 @@ module('Integration | Component | Participant::Assessment::Tabs', function (hook
 
   test('[A11Y] it should contain accessibility aria-label nav', async function (assert) {
     // given
-    this.campaignId = 1;
-    this.participationId = 2;
+    const campaignId = 1;
+    const participationId = 2;
 
     // when
-    const screen = await renderScreen(
-      hbs`<Participant::Assessment::Tabs @campaignId={{this.campaignId}} @participationId={{this.participationId}} />`,
+    const screen = await render(
+      <template><Tabs @campaignId={{campaignId}} @participationId={{participationId}} /></template>,
     );
 
     // then

--- a/orga/tests/integration/templates/authenticated/campaigns/participant-assessments/analysis_test.gjs
+++ b/orga/tests/integration/templates/authenticated/campaigns/participant-assessments/analysis_test.gjs
@@ -10,6 +10,7 @@ module('Integration | Template | Authenticated | Campaigns | Participant Assessm
   setupIntlRenderingTest(hooks);
   const model = {
     isForParticipant: true,
+    isAnalysisAvailable: true,
   };
 
   module('display analysis', function () {
@@ -29,6 +30,20 @@ module('Integration | Template | Authenticated | Campaigns | Participant Assessm
       assert.ok(screen.getByText(t('pages.campaign-analysis.levels-correspondence.levels.advanced')));
       assert.ok(screen.getByText(t('pages.campaign-analysis.levels-correspondence.levels.expert')));
       assert.ok(screen.getByRole('link', { name: t('pages.campaign-analysis.levels-correspondence.infos.text') }));
+    });
+  });
+
+  module('hide analysis', function () {
+    test('it should hide content', async function (assert) {
+      // given
+      model.isAnalysisAvailable = false;
+      const router = this.owner.lookup('service:router');
+      sinon.stub(router, 'currentRouteName').value('');
+
+      const screen = await render(<template><Analysis @model={{model}} /></template>);
+
+      // then
+      assert.ok(screen.getByText(t('pages.assessment-individual-results.table.empty')));
     });
   });
 });

--- a/orga/tests/unit/routes/authenticated/campaigns/participant-assessment/analysis-test.js
+++ b/orga/tests/unit/routes/authenticated/campaigns/participant-assessment/analysis-test.js
@@ -7,11 +7,11 @@ module(
   function (hooks) {
     setupTest(hooks);
 
-    module('before model', function (hooks) {
-      hooks.afterEach(function () {
-        sinon.restore();
-      });
+    hooks.afterEach(function () {
+      sinon.restore();
+    });
 
+    module('before model', function () {
       module('When places limit is reached', function () {
         test('should redirect on main campaign page', function (assert) {
           //given
@@ -92,6 +92,62 @@ module(
 
           //then
           assert.ok(replaceWithStub.calledWithExactly('authenticated.campaigns.participant-assessment.analysis.tubes'));
+        });
+      });
+    });
+
+    module('model', function () {
+      module('campaignAssessmentParticipation is shared', function (hooks) {
+        let route;
+        hooks.beforeEach(function () {
+          route = this.owner.lookup('route:authenticated/campaigns/participant-assessment/analysis');
+          sinon
+            .stub(route, 'modelFor')
+            .withArgs('authenticated.campaigns.participant-assessment')
+            .returns({
+              campaignAssessmentParticipation: {
+                isShared: true,
+                campaignParticipationLevelsPerTubesAndCompetence: Promise.resolve({}),
+              },
+            });
+        });
+        test('it should return model', async function (assert) {
+          const result = await route.model();
+          assert.ok(result.analysisData);
+        });
+        test('it should return isAnalysisAvailable to true', async function (assert) {
+          const result = await route.model();
+          assert.true(result.isAnalysisAvailable);
+        });
+        test('it should return isForParticipant to true', async function (assert) {
+          const result = await route.model();
+          assert.true(result.isForParticipant);
+        });
+      });
+      module('campaignAssessmentParticipation is not shared', function (hooks) {
+        let route;
+        hooks.beforeEach(function () {
+          route = this.owner.lookup('route:authenticated/campaigns/participant-assessment/analysis');
+          sinon
+            .stub(route, 'modelFor')
+            .withArgs('authenticated.campaigns.participant-assessment')
+            .returns({
+              campaignAssessmentParticipation: {
+                isShared: false,
+              },
+            });
+        });
+        test('it should return null analysisData', async function (assert) {
+          const result = await route.model();
+          assert.strictEqual(result.analysisData, null);
+        });
+        test('it should return isAnalysisAvailable to false', async function (assert) {
+          const result = await route.model();
+          assert.false(result.isAnalysisAvailable);
+        });
+        test('it should return isForParticipant to true', async function (assert) {
+          const result = await route.model();
+          assert.true(result.isForParticipant);
         });
       });
     });

--- a/orga/tests/unit/routes/authenticated/campaigns/participant-assessment/results-test.js
+++ b/orga/tests/unit/routes/authenticated/campaigns/participant-assessment/results-test.js
@@ -7,11 +7,11 @@ module(
   function (hooks) {
     setupTest(hooks);
 
-    module('Before model', function (hooks) {
-      hooks.afterEach(function () {
-        sinon.restore();
-      });
+    hooks.afterEach(function () {
+      sinon.restore();
+    });
 
+    module('Before model', function () {
       module('When places limit is reached', function () {
         test('should redirect on main campaign page', function (assert) {
           //given
@@ -47,6 +47,56 @@ module(
 
           //then
           assert.notOk(replaceWithStub.called);
+        });
+      });
+    });
+
+    module('model', function () {
+      module('when participation is not shared', function () {
+        test('it should return an empty array without calling the API', async function (assert) {
+          //given
+          const route = this.owner.lookup('route:authenticated/campaigns/participant-assessment/results');
+
+          sinon
+            .stub(route, 'modelFor')
+            .withArgs('authenticated.campaigns.participant-assessment')
+            .returns({
+              campaignAssessmentParticipation: {
+                isShared: false,
+              },
+            });
+
+          //when
+          const result = await route.model();
+
+          //then
+          assert.deepEqual(result, []);
+        });
+      });
+
+      module('when participation is shared', function () {
+        test('it should return competence results', async function (assert) {
+          //given
+          const route = this.owner.lookup('route:authenticated/campaigns/participant-assessment/results');
+          const competenceResults = [Symbol('result1'), Symbol('result2')];
+
+          sinon
+            .stub(route, 'modelFor')
+            .withArgs('authenticated.campaigns.participant-assessment')
+            .returns({
+              campaignAssessmentParticipation: {
+                isShared: true,
+                campaignAssessmentParticipationResult: Promise.resolve({
+                  competenceResults: Promise.resolve(competenceResults),
+                }),
+              },
+            });
+
+          //when
+          const result = await route.model();
+
+          //then
+          assert.deepEqual(result, competenceResults);
         });
       });
     });


### PR DESCRIPTION
## 🦊 Problème

Lorsqu'une participation à une campagne d'évaluation n'est pas terminée (statut \`STARTED\` ou \`TO_SHARE\` 😃 ), il était possible d'accéder à la page d'analyse dans Pix Orga et d'afficher les statistiques par tube et compétence. En mode interro, ces stats étaient même affichées en live via le snapshot de KE.

## 🦩 Proposition

**API** :
- Le usecase \`getResultLevelsPerTubesAndCompetences\` lève une \`UserNotAuthorizedToAccessEntityError\` (403) si la participation n'est pas partagée.
- Le usecase \`getCampaignAssessmentParticipationResult\` lève désormais également une \`UserNotAuthorizedToAccessEntityError\` (403) si la participation n'est pas partagée.

**Orga** :
- La page d'analyse affiche « En attente de résultats » si la participation n'est pas partagée (aucun appel API effectué).
- La page de résultats affiche également « En attente de résultats » si la participation n'est pas partagée (aucun appel API effectué).

## 🐙 Pour tester

- [ ] Vérifier que le contenu des onglets « Résultats » et « Analyse » est disponible pour une [participation partagée](https://orga-pr15269.review.pix.fr/campagnes/1000001/evaluations/140447/resultats)
- [ ] Vérifier que les onglets « Résultats » et « Analyse » sont bien visibles pour une [participation non partagée](https://orga-pr15269.review.pix.fr/campagnes/1000001/evaluations/140448/resultats)
- [ ] Vérifier que les deux onglets affichent « En attente de résultats » pour une participation non partagée
Bonus
- [ ] Appeler directement les routes pour une participation non partagée → 403