### PR TITLE
[TECH] Permettre l'ajout d'une info bulle aux champs de Modulix Editor via la description JOI (PIX-21636).

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/conversion/joi-to-json-schema.js
+++ b/api/src/devcomp/infrastructure/datasources/conversion/joi-to-json-schema.js
@@ -36,9 +36,13 @@ function convertBoolean() {
 }
 
 function convertString(joiStringDescribedSchema) {
-  const jsonSchema = { type: 'string', format: null };
+  const jsonSchema = { type: 'string', format: null, options: null };
 
   const rules = joiStringDescribedSchema.rules;
+
+  if (hasFlag(joiStringDescribedSchema.flags, 'description')) {
+    jsonSchema.options = { infoText: joiStringDescribedSchema.flags['description'] };
+  }
 
   const emailRule = findRule(rules, 'email');
   if (emailRule !== undefined) {
@@ -277,7 +281,12 @@ function findRule(rules, ruleName) {
 
 function hasFlag(flags, flagName, flagValue) {
   if (flags !== undefined) {
-    return Object.entries(flags).some(([name, value]) => flagName === name && flagValue === value);
+    return Object.entries(flags).some(([name, value]) => {
+      if (!flagValue) {
+        return flagName === name;
+      }
+      return flagName === name && flagValue === value;
+    });
   }
   return false;
 }

--- a/api/src/devcomp/infrastructure/datasources/conversion/joi-to-json-schema.js
+++ b/api/src/devcomp/infrastructure/datasources/conversion/joi-to-json-schema.js
@@ -107,8 +107,12 @@ function handleNonStandardStringProperties(joiStringDescribedSchema, jsonSchema)
 }
 
 function convertNumber(joiNumberDescribedSchema) {
-  const jsonSchema = { type: 'number' };
+  const jsonSchema = { type: 'number', options: null };
   const rules = joiNumberDescribedSchema.rules;
+
+  if (hasFlag(joiNumberDescribedSchema.flags, 'description')) {
+    jsonSchema.options = { infoText: joiNumberDescribedSchema.flags['description'] };
+  }
 
   const integerRule = findRule(rules, 'integer');
   if (integerRule !== undefined) {

--- a/api/src/devcomp/infrastructure/datasources/conversion/joi-to-json-schema.js
+++ b/api/src/devcomp/infrastructure/datasources/conversion/joi-to-json-schema.js
@@ -138,8 +138,12 @@ function convertNumber(joiNumberDescribedSchema) {
 }
 
 function convertArray(joiArrayDescribedSchema, key = '') {
-  const jsonSchema = { type: 'array' };
+  const jsonSchema = { type: 'array', options: null };
   const rules = joiArrayDescribedSchema.rules;
+
+  if (hasFlag(joiArrayDescribedSchema.flags, 'description')) {
+    jsonSchema.options = { infoText: joiArrayDescribedSchema.flags['description'] };
+  }
 
   const minRule = findRule(rules, 'min');
   if (minRule !== undefined) {
@@ -163,7 +167,7 @@ function convertArray(joiArrayDescribedSchema, key = '') {
 
         // Add headerTemplate for JSON Editor lib
         // See {@link https://github.com/json-editor/json-editor#dynamic-headers}
-        // for further informations
+        // for further information
         jsonSchema.items.headerTemplate = `${itemTitle} {{i0}}`;
       }
     }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/validation/element/qrocm-schema.js
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/validation/element/qrocm-schema.js
@@ -4,38 +4,89 @@ import { htmlNotAllowedSchema, htmlSchema, proposalIdSchema, uuidSchema } from '
 import { feedbackSchema } from './feedback-schema.js';
 
 const blockInputSchema = Joi.object({
-  input: htmlNotAllowedSchema.required(),
-  type: Joi.string().valid('input').required(),
-  inputType: Joi.string().valid('text', 'number').required(),
-  size: Joi.number().positive().required(),
-  display: Joi.string().valid('inline', 'block').required(),
-  placeholder: htmlNotAllowedSchema.allow('').required(),
-  ariaLabel: htmlNotAllowedSchema.required(),
+  input: htmlNotAllowedSchema.required().description('Identifiant unique obligatoire (non visible dans le module)'),
+  type: Joi.string()
+    .valid('input')
+    .required()
+    .description("Le type input permet d'afficher un champ éditable par l'utilisateur."),
+  inputType: Joi.string()
+    .valid('text', 'number')
+    .required()
+    .description(
+      "Le type number affiche un champ qui n'accepte que les chiffres. Le type text affiche un champ textuel classique.",
+    ),
+  size: Joi.number()
+    .positive()
+    .required()
+    .description('Largeur du champ. Indiquez une valeur correspondant au nombre de caractères attendu.'),
+  display: Joi.string()
+    .valid('inline', 'block')
+    .required()
+    .description(
+      "Type d'affichage du champ. En inline, le champ apparaîtra sur la même ligne que les autres propositions. En block, il se mettra à la ligne suivante.",
+    ),
+  placeholder: htmlNotAllowedSchema
+    .allow('')
+    .required()
+    .description("Texte de substitution qui s'affiche dans le champ avant qu'il soit édité."),
+  ariaLabel: htmlNotAllowedSchema
+    .required()
+    .description(
+      "Description du champ nécessaire à l’accessibilité (non visible dans le module, lu par les lecteurs d'écran).",
+    ),
   tolerances: Joi.array()
     .unique()
     .items(Joi.string().valid('t1', 't2', 't3'))
-    .required(),
+    .required()
+    .description(
+      "Les tolérances permettent de valider une réponse malgré les erreurs. (T1 - Espaces, casse & accents, T2 - Ponctuation et T3 - Distance d'édition).",
+    ),
   solutions: Joi.array()
-    .items(Joi.alternatives(Joi.string().min(1).required(), Joi.number().min(1).required()))
-    .required(),
+    .items(
+      Joi.alternatives(
+        Joi.string().min(1).required().description('Contenu (type texte) de la solution.'),
+        Joi.number().min(1).required().description('Contenu (type nombre) de la solution.'),
+      ),
+    )
+    .required()
+    .description('Solution(s) du champ.'),
 }).required();
 
 const blockSelectSchema = Joi.object({
-  input: htmlNotAllowedSchema.required(),
-  type: Joi.string().valid('select').required(),
-  display: Joi.string().valid('inline', 'block').required(),
-  placeholder: htmlNotAllowedSchema.allow('').required(),
-  ariaLabel: htmlNotAllowedSchema.required(),
-  tolerances: Joi.array().empty().required(),
+  type: Joi.string()
+    .valid('select')
+    .required()
+    .description("Le type select permet d'afficher un sélecteur avec plusieurs options."),
+  input: htmlNotAllowedSchema.required().description('Identifiant unique obligatoire (non visible dans le module)'),
+  display: Joi.string()
+    .valid('inline', 'block')
+    .required()
+    .description(
+      "Type d'affichage du champ. En inline, le champ apparaîtra sur la même ligne que les autres propositions. En block, il se mettra à la ligne suivante.",
+    ),
+  placeholder: htmlNotAllowedSchema
+    .allow('')
+    .required()
+    .description("Texte de substitution qui s'affiche dans le champ lorsqu’aucune option n'est sélectionnée."),
+  ariaLabel: htmlNotAllowedSchema
+    .required()
+    .description(
+      "Description du champ nécessaire à l’accessibilité (non visible dans le module, lu par les lecteurs d'écran).",
+    ),
+  tolerances: Joi.array().empty().required().description('Les tolérances ne concernent que les QROCm de type input.'),
   options: Joi.array()
     .items(
       Joi.object({
-        id: proposalIdSchema,
-        content: htmlNotAllowedSchema.required(),
+        id: proposalIdSchema.description("Identifiant de l'option. Caractères autorisés : tout chiffre (0 à 9)."),
+        content: htmlNotAllowedSchema.required().description("Contenu de l'option."),
       }),
     )
-    .required(),
-  solutions: Joi.array().items(proposalIdSchema).required(),
+    .required()
+    .description('Options du champ.'),
+  solutions: Joi.array()
+    .items(proposalIdSchema.description("Coller ici l'dentifiant (id) de l'option"))
+    .required()
+    .description('Solution(s) du champ.'),
 }).required();
 
 const blockTextSchema = Joi.object({
@@ -46,7 +97,7 @@ const blockTextSchema = Joi.object({
 const qrocmElementSchema = Joi.object({
   id: uuidSchema,
   type: Joi.string().valid('qrocm').required(),
-  instruction: htmlSchema.required(),
+  instruction: htmlSchema.required().description('Consigne du QROCm'),
   proposals: Joi.array()
     .items(
       Joi.alternatives().conditional('.type', {
@@ -57,7 +108,10 @@ const qrocmElementSchema = Joi.object({
         ],
       }),
     )
-    .required(),
+    .required()
+    .description(
+      'Propositions qui vont s’afficher les unes à la suite des autres dans le module (dans l’ordre de contribution)',
+    ),
   feedbacks: Joi.object({
     valid: feedbackSchema,
     invalid: feedbackSchema,

--- a/api/src/devcomp/infrastructure/datasources/learning-content/validation/module-schema.js
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/validation/module-schema.js
@@ -51,7 +51,12 @@ const moduleDetailsSchema = Joi.object({
       'Image qui s’affiche dans l’en-tête du module. Exemple: https://assets.pix.org/modules/placeholder-details.svg.',
     ),
   description: htmlSchema.required().description('Texte d’introduction en dessous du titre du module.'),
-  duration: Joi.number().integer().min(0).max(120).required(),
+  duration: Joi.number()
+    .integer()
+    .min(0)
+    .max(120)
+    .required()
+    .description('Durée du module (en minutes). Valeur acceptée: entre 0 et 120. Ne pas inclure l’unité.'),
   level: Joi.string().valid('novice', 'independent', 'advanced', 'expert').required().description('Niveau du module.'),
   objectives: Joi.array()
     .items(htmlSchema)

--- a/api/src/devcomp/infrastructure/datasources/learning-content/validation/module-schema.js
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/validation/module-schema.js
@@ -53,7 +53,11 @@ const moduleDetailsSchema = Joi.object({
   description: htmlSchema.required().description('Texte d’introduction en dessous du titre du module.'),
   duration: Joi.number().integer().min(0).max(120).required(),
   level: Joi.string().valid('novice', 'independent', 'advanced', 'expert').required().description('Niveau du module.'),
-  objectives: Joi.array().items(htmlSchema).min(1).required(),
+  objectives: Joi.array()
+    .items(htmlSchema)
+    .min(1)
+    .required()
+    .description('Un objectif minimum. Ils s’affichent dans l’ordre contribué.'),
   tabletSupport: Joi.string()
     .valid('comfortable', 'inconvenient', 'obstructed')
     .required()

--- a/api/src/devcomp/infrastructure/datasources/learning-content/validation/module-schema.js
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/validation/module-schema.js
@@ -44,12 +44,22 @@ const ALLOWED_ELEMENTS_SCHEMA = [
 const ELEMENTS_FORBIDDEN_IN_STEPPER = ['flashcards', 'qab'];
 
 const moduleDetailsSchema = Joi.object({
-  image: Joi.string().uri().required(),
-  description: htmlSchema.required(),
+  image: Joi.string()
+    .uri()
+    .required()
+    .description(
+      'Image qui s’affiche dans l’en-tête du module. Exemple: https://assets.pix.org/modules/placeholder-details.svg.',
+    ),
+  description: htmlSchema.required().description('Texte d’introduction en dessous du titre du module.'),
   duration: Joi.number().integer().min(0).max(120).required(),
-  level: Joi.string().valid('novice', 'independent', 'advanced', 'expert').required(),
+  level: Joi.string().valid('novice', 'independent', 'advanced', 'expert').required().description('Niveau du module.'),
   objectives: Joi.array().items(htmlSchema).min(1).required(),
-  tabletSupport: Joi.string().valid('comfortable', 'inconvenient', 'obstructed').required(),
+  tabletSupport: Joi.string()
+    .valid('comfortable', 'inconvenient', 'obstructed')
+    .required()
+    .description(
+      "Si la valeur est inconvenient ou obstructed, on indiquera à l'utilisateur que le module peut être difficile à réaliser sur un petit écran.",
+    ),
 });
 
 const elementSchema = Joi.alternatives().conditional('.type', {
@@ -82,7 +92,10 @@ const grainSchema = Joi.object({
   type: Joi.string()
     .valid('short-lesson', 'discovery', 'activity', 'challenge', 'lesson', 'summary', 'transition')
     .required(),
-  title: htmlNotAllowedSchema.required().allow(''),
+  title: htmlNotAllowedSchema
+    .required()
+    .allow('')
+    .description('Titre du grain. Usage interne pour faciliter la navigation sur Modulix Editor.'),
   components: Joi.array()
     .items(
       Joi.alternatives().conditional('.type', {
@@ -123,14 +136,22 @@ const moduleSectionSchema = Joi.object({
 });
 
 const moduleSchema = Joi.object({
-  id: uuidSchema,
-  shortId: Joi.string().length(8).required(),
+  id: uuidSchema.description('Identifiant universel unique (uuid) du module.'),
+  shortId: Joi.string().length(8).required().description("Identifiant court unique du module, présent dans l'url."),
   slug: Joi.string()
     .regex(/^[a-z0-9-]+$/)
-    .required(),
-  title: htmlNotAllowedSchema.required(),
+    .required()
+    .description(
+      "Identifiant texte unique du module, présent dans l'url. Caractères autorisés : Tout caractère entre a et z (minuscules), tout chiffre (0 à 9) et le trait d'union (-).",
+    ),
+  title: htmlNotAllowedSchema.required().description('Titre du module.'),
   isBeta: Joi.boolean().required(),
-  visibility: Joi.string().valid('private', 'public').required(),
+  visibility: Joi.string()
+    .valid('private', 'public')
+    .required()
+    .description(
+      'Valeurs acceptées : private, public. Si vous indiquez "public", le module pourra être sélectionné à la création d’un contenu formatif dans Pix Admin.',
+    ),
   details: moduleDetailsSchema.required(),
   sections: Joi.array().items(moduleSectionSchema).required(),
 }).required();

--- a/api/tests/devcomp/unit/infrastructure/datasources/conversion/joi-to-json-schema_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/conversion/joi-to-json-schema_test.js
@@ -170,19 +170,19 @@ describe('Unit | Infrastructure | Datasources | Conversion | joi-to-json-schema'
     it('should convert Joi.array to JSON Schema', function () {
       const joiSchema = Joi.array();
       const jsonSchema = convertJoiToJsonSchema(joiSchema);
-      expect(jsonSchema).to.deep.equal({ type: 'array' });
+      expect(jsonSchema).to.deep.equal({ type: 'array', options: null });
     });
 
     it('should convert Joi.array.min to JSON Schema with minItems', function () {
       const joiSchema = Joi.array().min(3);
       const jsonSchema = convertJoiToJsonSchema(joiSchema);
-      expect(jsonSchema).to.deep.equal({ type: 'array', minItems: 3 });
+      expect(jsonSchema).to.deep.equal({ type: 'array', minItems: 3, options: null });
     });
 
     it('should convert Joi.array.unique to JSON Schema with uniqueItems', function () {
       const joiSchema = Joi.array().unique();
       const jsonSchema = convertJoiToJsonSchema(joiSchema);
-      expect(jsonSchema).to.deep.equal({ type: 'array', uniqueItems: true });
+      expect(jsonSchema).to.deep.equal({ type: 'array', uniqueItems: true, options: null });
     });
 
     describe('items', function () {
@@ -191,26 +191,33 @@ describe('Unit | Infrastructure | Datasources | Conversion | joi-to-json-schema'
         const jsonSchema = convertJoiToJsonSchema(joiSchema);
         expect(jsonSchema).to.deep.equal({
           type: 'array',
-          items: { type: 'string', format: null },
+          items: { type: 'string', format: null, options: null },
+          options: null,
         });
       });
 
       it('should convert Joi.array.items(number) to JSON Schema with items number', function () {
         const joiSchema = Joi.array().items(Joi.number());
         const jsonSchema = convertJoiToJsonSchema(joiSchema);
-        expect(jsonSchema).to.deep.equal({ type: 'array', items: { type: 'number' } });
+        expect(jsonSchema).to.deep.equal({ type: 'array', items: { type: 'number' }, options: null });
       });
 
       it('should convert Joi.array.items(object) to JSON Schema with items object', function () {
         const joiSchema = Joi.array().items(Joi.object());
         const jsonSchema = convertJoiToJsonSchema(joiSchema);
-        expect(jsonSchema).to.deep.equal({ type: 'array', items: { type: 'object' } });
+        expect(jsonSchema).to.deep.equal({ type: 'array', items: { type: 'object' }, options: null });
       });
 
       it('should convert Joi.array.items(array) to JSON Schema with items array', function () {
         const joiSchema = Joi.array().items(Joi.array());
         const jsonSchema = convertJoiToJsonSchema(joiSchema);
-        expect(jsonSchema).to.deep.equal({ type: 'array', items: { type: 'array' } });
+        expect(jsonSchema).to.deep.equal({ type: 'array', items: { type: 'array', options: null }, options: null });
+      });
+
+      it('should convert Joi.array.description to JSON Schema with options infoText', function () {
+        const joiSchema = Joi.array().description('cool gang');
+        const jsonSchema = convertJoiToJsonSchema(joiSchema);
+        expect(jsonSchema).to.deep.equal({ type: 'array', options: { infoText: 'cool gang' } });
       });
     });
   });
@@ -304,6 +311,7 @@ describe('Unit | Infrastructure | Datasources | Conversion | joi-to-json-schema'
         properties: {
           proposals: {
             type: 'array',
+            options: null,
             items: {
               title: 'proposal',
               headerTemplate: 'proposal {{i0}}',

--- a/api/tests/devcomp/unit/infrastructure/datasources/conversion/joi-to-json-schema_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/conversion/joi-to-json-schema_test.js
@@ -22,62 +22,68 @@ describe('Unit | Infrastructure | Datasources | Conversion | joi-to-json-schema'
     it('should convert Joi.string to JSON Schema', function () {
       const joiSchema = Joi.string();
       const jsonSchema = convertJoiToJsonSchema(joiSchema);
-      expect(jsonSchema).to.deep.equal({ type: 'string', format: null });
+      expect(jsonSchema).to.deep.equal({ type: 'string', format: null, options: null });
     });
 
     it('should convert Joi.string.min to JSON Schema with minLength', function () {
       const joiSchema = Joi.string().min(8);
       const jsonSchema = convertJoiToJsonSchema(joiSchema);
-      expect(jsonSchema).to.deep.equal({ type: 'string', format: null, minLength: 8 });
+      expect(jsonSchema).to.deep.equal({ type: 'string', format: null, minLength: 8, options: null });
     });
 
     it('should convert Joi.string.max to JSON Schema with maxLength', function () {
       const joiSchema = Joi.string().max(32);
       const jsonSchema = convertJoiToJsonSchema(joiSchema);
-      expect(jsonSchema).to.deep.equal({ type: 'string', format: null, maxLength: 32 });
+      expect(jsonSchema).to.deep.equal({ type: 'string', format: null, maxLength: 32, options: null });
     });
 
     it('should convert Joi.string.email to JSON Schema with format email', function () {
       const joiSchema = Joi.string().email();
       const jsonSchema = convertJoiToJsonSchema(joiSchema);
-      expect(jsonSchema).to.deep.equal({ type: 'string', format: 'email' });
+      expect(jsonSchema).to.deep.equal({ type: 'string', format: 'email', options: null });
     });
 
     it('should convert Joi.string.isoDate to JSON Schema with format date', function () {
       const joiSchema = Joi.string().isoDate();
       const jsonSchema = convertJoiToJsonSchema(joiSchema);
-      expect(jsonSchema).to.deep.equal({ type: 'string', format: 'date' });
+      expect(jsonSchema).to.deep.equal({ type: 'string', format: 'date', options: null });
     });
 
     it('should convert Joi.string.uri to JSON Schema with format uri', function () {
       const joiSchema = Joi.string().uri();
       const jsonSchema = convertJoiToJsonSchema(joiSchema);
-      expect(jsonSchema).to.deep.equal({ type: 'string', format: 'uri' });
+      expect(jsonSchema).to.deep.equal({ type: 'string', format: 'uri', options: null });
     });
 
     it('should convert Joi.string.guid to JSON Schema with format uuid', function () {
       const joiSchema = Joi.string().guid({ version: 'uuidv4' });
       const jsonSchema = convertJoiToJsonSchema(joiSchema);
-      expect(jsonSchema).to.deep.equal({ type: 'string', format: 'uuid' });
+      expect(jsonSchema).to.deep.equal({ type: 'string', format: 'uuid', options: null });
+    });
+
+    it('should convert Joi.string.description to JSON Schema with options infoText', function () {
+      const joiSchema = Joi.string().description('cool gang');
+      const jsonSchema = convertJoiToJsonSchema(joiSchema);
+      expect(jsonSchema).to.deep.equal({ type: 'string', options: { infoText: 'cool gang' }, format: null });
     });
 
     describe('regex', function () {
       it('should convert Joi.string.regex(d) to JSON Schema with converted pattern', function () {
         const joiSchema = Joi.string().regex(/^\d+$/);
         const jsonSchema = convertJoiToJsonSchema(joiSchema);
-        expect(jsonSchema).to.deep.equal({ type: 'string', format: null, pattern: '^[0-9]+$' });
+        expect(jsonSchema).to.deep.equal({ type: 'string', format: null, pattern: '^[0-9]+$', options: null });
       });
 
       it('should convert Joi.string.regex(*) to JSON Schema with given pattern', function () {
         const joiSchema = Joi.string().regex(/^[a-z0-9-]+$/);
         const jsonSchema = convertJoiToJsonSchema(joiSchema);
-        expect(jsonSchema).to.deep.equal({ type: 'string', format: null, pattern: '^[a-z0-9-]+$' });
+        expect(jsonSchema).to.deep.equal({ type: 'string', format: null, pattern: '^[a-z0-9-]+$', options: null });
       });
 
       it('should convert Joi.string.regex(*, invert) to JSON Schema with no pattern', function () {
         const joiSchema = Joi.string().regex(/<.*?>/, { invert: true });
         const jsonSchema = convertJoiToJsonSchema(joiSchema);
-        expect(jsonSchema).to.deep.equal({ type: 'string', format: null });
+        expect(jsonSchema).to.deep.equal({ type: 'string', format: null, options: null });
       });
 
       it('should convert Joi.string.regex.message to JSON Schema with errorMessage', function () {
@@ -88,6 +94,7 @@ describe('Unit | Infrastructure | Datasources | Conversion | joi-to-json-schema'
           pattern: 'abc',
           format: null,
           errorMessage: '{{:#label}} failed custom validation',
+          options: null,
         });
       });
     });
@@ -96,13 +103,13 @@ describe('Unit | Infrastructure | Datasources | Conversion | joi-to-json-schema'
       it('should convert Joi.string.allow(empty) to JSON Schema with no enum', function () {
         const joiSchema = Joi.string().allow('');
         const jsonSchema = convertJoiToJsonSchema(joiSchema);
-        expect(jsonSchema).to.deep.equal({ type: 'string', format: null });
+        expect(jsonSchema).to.deep.equal({ type: 'string', format: null, options: null });
       });
 
       it('should convert Joi.string.allow(*) to JSON Schema with enum', function () {
         const joiSchema = Joi.string().allow('Hello');
         const jsonSchema = convertJoiToJsonSchema(joiSchema);
-        expect(jsonSchema).to.deep.equal({ type: 'string', format: null, enum: ['Hello'] });
+        expect(jsonSchema).to.deep.equal({ type: 'string', format: null, enum: ['Hello'], options: null });
       });
     });
 
@@ -115,7 +122,7 @@ describe('Unit | Infrastructure | Datasources | Conversion | joi-to-json-schema'
 
           const jsonSchema = convertJoiToJsonSchema(joiSchema);
 
-          expect(jsonSchema).to.deep.equal({ type: 'string', format: 'jodit' });
+          expect(jsonSchema).to.deep.equal({ type: 'string', format: 'jodit', options: null });
         });
       });
     });
@@ -239,7 +246,7 @@ describe('Unit | Infrastructure | Datasources | Conversion | joi-to-json-schema'
       expect(jsonSchema).to.deep.equal({
         type: 'object',
         properties: {
-          name: { type: 'string', format: null },
+          name: { type: 'string', format: null, options: null },
           age: { type: 'number' },
         },
         additionalProperties: false,
@@ -255,7 +262,7 @@ describe('Unit | Infrastructure | Datasources | Conversion | joi-to-json-schema'
       expect(jsonSchema).to.deep.equal({
         type: 'object',
         properties: {
-          name: { type: 'string', format: null },
+          name: { type: 'string', format: null, options: null },
           age: { type: 'number' },
         },
         required: ['name'],
@@ -277,8 +284,8 @@ describe('Unit | Infrastructure | Datasources | Conversion | joi-to-json-schema'
           address: {
             type: 'object',
             properties: {
-              street: { type: 'string', format: null },
-              city: { type: 'string', format: null },
+              street: { type: 'string', format: null, options: null },
+              city: { type: 'string', format: null, options: null },
             },
             additionalProperties: false,
           },
@@ -302,6 +309,7 @@ describe('Unit | Infrastructure | Datasources | Conversion | joi-to-json-schema'
               headerTemplate: 'proposal {{i0}}',
               type: 'string',
               format: null,
+              options: null,
             },
           },
         },
@@ -318,7 +326,9 @@ describe('Unit | Infrastructure | Datasources | Conversion | joi-to-json-schema'
 
       expect(joiSchema.validate('string').error).to.be.undefined;
       expect(joiSchema.validate(123).error).to.be.undefined;
-      expect(jsonSchema).to.deep.equal({ oneOf: [{ type: 'string', format: null }, { type: 'number' }] });
+      expect(jsonSchema).to.deep.equal({
+        oneOf: [{ type: 'string', format: null, options: null }, { type: 'number' }],
+      });
     });
 
     describe('Joi.alternatives.conditional', function () {
@@ -355,10 +365,12 @@ describe('Unit | Infrastructure | Datasources | Conversion | joi-to-json-schema'
                   enum: ['handball'],
                   type: 'string',
                   format: null,
+                  options: null,
                 },
                 value: {
                   type: 'string',
                   format: null,
+                  options: null,
                 },
               },
               required: ['sport', 'value'],
@@ -372,6 +384,7 @@ describe('Unit | Infrastructure | Datasources | Conversion | joi-to-json-schema'
                   enum: ['volleyball'],
                   type: 'string',
                   format: null,
+                  options: null,
                 },
                 value: {
                   type: 'number',
@@ -419,10 +432,12 @@ describe('Unit | Infrastructure | Datasources | Conversion | joi-to-json-schema'
                   enum: ['handball'],
                   type: 'string',
                   format: null,
+                  options: null,
                 },
                 value: {
                   type: 'string',
                   format: null,
+                  options: null,
                 },
               },
               required: ['type', 'value'],
@@ -436,6 +451,7 @@ describe('Unit | Infrastructure | Datasources | Conversion | joi-to-json-schema'
                   enum: ['volleyball'],
                   type: 'string',
                   format: null,
+                  options: null,
                 },
                 value: {
                   type: 'number',
@@ -487,6 +503,7 @@ describe('Unit | Infrastructure | Datasources | Conversion | joi-to-json-schema'
                       enum: ['a'],
                       type: 'string',
                       format: null,
+                      options: null,
                     },
                   },
                   required: ['a'],
@@ -500,6 +517,7 @@ describe('Unit | Infrastructure | Datasources | Conversion | joi-to-json-schema'
                       enum: ['b'],
                       type: 'string',
                       format: null,
+                      options: null,
                     },
                   },
                   required: ['b'],
@@ -512,6 +530,7 @@ describe('Unit | Infrastructure | Datasources | Conversion | joi-to-json-schema'
               enum: ['handball', 'volleyball'],
               type: 'string',
               format: null,
+              options: null,
             },
           },
           required: ['sport', 'data'],
@@ -547,10 +566,12 @@ describe('Unit | Infrastructure | Datasources | Conversion | joi-to-json-schema'
                 enum: ['qcu'],
                 format: null,
                 type: 'string',
+                options: null,
               },
               value: {
                 format: null,
                 type: 'string',
+                options: null,
               },
             },
             required: ['type'],
@@ -560,6 +581,7 @@ describe('Unit | Infrastructure | Datasources | Conversion | joi-to-json-schema'
                   enum: ['qcu'],
                   format: null,
                   type: 'string',
+                  options: null,
                 },
                 value: {
                   type: 'number',

--- a/api/tests/devcomp/unit/infrastructure/datasources/conversion/joi-to-json-schema_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/conversion/joi-to-json-schema_test.js
@@ -132,37 +132,43 @@ describe('Unit | Infrastructure | Datasources | Conversion | joi-to-json-schema'
     it('should convert Joi.number to JSON Schema', function () {
       const joiSchema = Joi.number();
       const jsonSchema = convertJoiToJsonSchema(joiSchema);
-      expect(jsonSchema).to.deep.equal({ type: 'number' });
+      expect(jsonSchema).to.deep.equal({ type: 'number', options: null });
     });
 
     it('should convert Joi.number.integer to JSON Schema with type integer', function () {
       const joiSchema = Joi.number().integer();
       const jsonSchema = convertJoiToJsonSchema(joiSchema);
-      expect(jsonSchema).to.deep.equal({ type: 'integer' });
+      expect(jsonSchema).to.deep.equal({ type: 'integer', options: null });
     });
 
     it('should convert Joi.number.positive to JSON Schema with minimum 1', function () {
       const joiSchema = Joi.number().positive();
       const jsonSchema = convertJoiToJsonSchema(joiSchema);
-      expect(jsonSchema).to.deep.equal({ type: 'number', minimum: 1 });
+      expect(jsonSchema).to.deep.equal({ type: 'number', minimum: 1, options: null });
     });
 
     it('should convert Joi.number.negative to JSON Schema with maximum -1', function () {
       const joiSchema = Joi.number().negative();
       const jsonSchema = convertJoiToJsonSchema(joiSchema);
-      expect(jsonSchema).to.deep.equal({ type: 'number', maximum: -1 });
+      expect(jsonSchema).to.deep.equal({ type: 'number', maximum: -1, options: null });
     });
 
     it('should convert Joi.number.min to JSON Schema with minimum', function () {
       const joiSchema = Joi.number().min(0);
       const jsonSchema = convertJoiToJsonSchema(joiSchema);
-      expect(jsonSchema).to.deep.equal({ type: 'number', minimum: 0 });
+      expect(jsonSchema).to.deep.equal({ type: 'number', minimum: 0, options: null });
     });
 
     it('should convert Joi.number.max to JSON Schema with maximum', function () {
       const joiSchema = Joi.number().max(150);
       const jsonSchema = convertJoiToJsonSchema(joiSchema);
-      expect(jsonSchema).to.deep.equal({ type: 'number', maximum: 150 });
+      expect(jsonSchema).to.deep.equal({ type: 'number', maximum: 150, options: null });
+    });
+
+    it('should convert Joi.number.description to JSON Schema with options infoText', function () {
+      const joiSchema = Joi.number().description('cool gang');
+      const jsonSchema = convertJoiToJsonSchema(joiSchema);
+      expect(jsonSchema).to.deep.equal({ type: 'number', options: { infoText: 'cool gang' } });
     });
   });
 
@@ -199,7 +205,7 @@ describe('Unit | Infrastructure | Datasources | Conversion | joi-to-json-schema'
       it('should convert Joi.array.items(number) to JSON Schema with items number', function () {
         const joiSchema = Joi.array().items(Joi.number());
         const jsonSchema = convertJoiToJsonSchema(joiSchema);
-        expect(jsonSchema).to.deep.equal({ type: 'array', items: { type: 'number' }, options: null });
+        expect(jsonSchema).to.deep.equal({ type: 'array', items: { type: 'number', options: null }, options: null });
       });
 
       it('should convert Joi.array.items(object) to JSON Schema with items object', function () {
@@ -254,7 +260,7 @@ describe('Unit | Infrastructure | Datasources | Conversion | joi-to-json-schema'
         type: 'object',
         properties: {
           name: { type: 'string', format: null, options: null },
-          age: { type: 'number' },
+          age: { type: 'number', options: null },
         },
         additionalProperties: false,
       });
@@ -270,7 +276,7 @@ describe('Unit | Infrastructure | Datasources | Conversion | joi-to-json-schema'
         type: 'object',
         properties: {
           name: { type: 'string', format: null, options: null },
-          age: { type: 'number' },
+          age: { type: 'number', options: null },
         },
         required: ['name'],
         additionalProperties: false,
@@ -335,7 +341,10 @@ describe('Unit | Infrastructure | Datasources | Conversion | joi-to-json-schema'
       expect(joiSchema.validate('string').error).to.be.undefined;
       expect(joiSchema.validate(123).error).to.be.undefined;
       expect(jsonSchema).to.deep.equal({
-        oneOf: [{ type: 'string', format: null, options: null }, { type: 'number' }],
+        oneOf: [
+          { type: 'string', format: null, options: null },
+          { type: 'number', options: null },
+        ],
       });
     });
 
@@ -396,6 +405,7 @@ describe('Unit | Infrastructure | Datasources | Conversion | joi-to-json-schema'
                 },
                 value: {
                   type: 'number',
+                  options: null,
                 },
               },
               required: ['sport', 'value'],
@@ -463,6 +473,7 @@ describe('Unit | Infrastructure | Datasources | Conversion | joi-to-json-schema'
                 },
                 value: {
                   type: 'number',
+                  options: null,
                 },
               },
               required: ['type', 'value'],
@@ -593,6 +604,7 @@ describe('Unit | Infrastructure | Datasources | Conversion | joi-to-json-schema'
                 },
                 value: {
                   type: 'number',
+                  options: null,
                 },
               },
             },


### PR DESCRIPTION
## 🥀 Problème

Sur Modulix Editor, le métier doit renseigner beaucoup de champs avec des validations différentes.
Une documentation existe pour les accompagner mais il est est verbeuse et il est fastidieux pour eux de passer d'un doc à Modulix Editor.

## 🏹 Proposition

JSON Editor propose une proprité github.com/json-editor/json-editor#infotext permettant d'inclure une info bulle sur les champs.
Notre validation passant par `Joi`, nous nous servirons du paramètre `description` pour renseigner cette propriété `infotext`.

## 💌 Remarques

J'ai renseigné quelques champs en fonction de la doc Confluence et de la validation Joi (explication de patterns regex, les min/max...)

## ❤️‍🔥 Pour tester

- Dans Modulix Editor en local :
  - https://github.com/1024pix/modulix-editor/blob/f5b966cd28bc847e1aa2f542678d641740bf6111/index.html#L122-L122 => ajouter l'API ici (`https://api-pr15272.review.pix.fr/api/...`)
  - Lancer Modulix Editor
  - Voir les info bulles près des champs suivants : slug, objectives...

<img width="556" height="112" alt="Capture d’écran 2026-02-25 à 14 16 11" src="https://github.com/user-attachments/assets/ac461762-4f6c-450d-b559-a4e5d31115ba" />

Le métier a explicitement demandé à "info buller" le QROCM, vérifiez le contenu des info bulle pour lui :)

 
<img width="769" height="860" alt="Capture d’écran 2026-02-25 à 18 31 45" src="https://github.com/user-attachments/assets/82d94b5e-4382-4425-ac38-9b8ca1954231" />
