### PR TITLE
[BUGFIX] Ajouter le feature toggle disabledLocalesInFrontend dans toutes les applications front

### DIFF
--- a/admin/app/models/feature-toggle.js
+++ b/admin/app/models/feature-toggle.js
@@ -1,3 +1,5 @@
-import Model from '@ember-data/model';
+import Model, { attr } from '@ember-data/model';
 
-export default class FeatureToggle extends Model {}
+export default class FeatureToggle extends Model {
+  @attr('array') disabledLocalesInFrontend;
+}

--- a/certif/app/models/feature-toggle.js
+++ b/certif/app/models/feature-toggle.js
@@ -2,4 +2,5 @@ import Model, { attr } from '@ember-data/model';
 
 export default class FeatureToggle extends Model {
   @attr('boolean') isPixPlusCandidateA11yEnabled;
+  @attr('array') disabledLocalesInFrontend;
 }

--- a/certif/app/transforms/array.js
+++ b/certif/app/transforms/array.js
@@ -1,0 +1,11 @@
+import Transform from '@ember-data/serializer/transform';
+
+export default class Array extends Transform {
+  deserialize(serialized) {
+    return serialized;
+  }
+
+  serialize(deserialized) {
+    return deserialized;
+  }
+}

--- a/orga/app/models/feature-toggle.js
+++ b/orga/app/models/feature-toggle.js
@@ -2,4 +2,5 @@ import Model, { attr } from '@ember-data/model';
 
 export default class FeatureToggle extends Model {
   @attr('boolean') displayIaCampaignBanner;
+  @attr('array') disabledLocalesInFrontend;
 }

--- a/orga/app/transforms/array.js
+++ b/orga/app/transforms/array.js
@@ -1,0 +1,11 @@
+import Transform from '@ember-data/serializer/transform';
+
+export default class Array extends Transform {
+  deserialize(serialized) {
+    return serialized;
+  }
+
+  serialize(deserialized) {
+    return deserialized;
+  }
+}


### PR DESCRIPTION
## 🥀 Problème

On souhaite pouvoir utiliser le feature toggle `disabledLocalesInFrontend` dans tous les frontaux pour pouvoir travailler sur ces locales sans qu'elles soient immédiatement utilisables par les utilisateurs.

Or la désactivation de certaines locales mise en place avec #14907 par ne fonctionne pas sur les frontaux autres que Pix App.

## 🏹 Proposition

Compléter le modèle et si nécessaire la conversion de l'attribut 'array' dans les trois applications.

## 💌 Remarques

RAS

## ❤️‍🔥 Pour tester

#### Définir une seule locale à désactiver

```shell
npm run toggles -- --key disabledLocalesInFrontend --value 'fr-BE'
```
```shell
npm run toggles -- --list
```

#### Définir plusieurs locales à désactiver

```shell
npm run toggles -- --key disabledLocalesInFrontend --value 'es,fr-BE'
```
```shell
npm run toggles -- --list
```

#### Définir qu’aucune locale n’est désactivée

```shell
npm run toggles -- --key disabledLocalesInFrontend --value ''
```
```shell
npm run toggles -- --list
```

### Tester tous les frontaux

1. Modifier le FT `disabledLocalesInFrontend` en utilisant différentes valeurs possibles,
2. Constater que les changements de valeur du FT `disabledLocalesInFrontend` font que certaines locales ne sont pas affichées dans les localeSwitchers des frontaux Pix App, Pix Certif et Pix Orga,
3. Tester globalement tous les frontaux Pix App, Pix Certif, Pix Orga et Pix Admin sur les différentes pages mettant en jeu des locales pour vérifier que globalement il n’y a pas de régression.
