### PR TITLE
[TECH] Fix admin flaky (PIX-21772)

### DIFF
--- a/admin/app/components/target-profiles/organizations.gjs
+++ b/admin/app/components/target-profiles/organizations.gjs
@@ -69,7 +69,7 @@ export default class Organizations extends Component {
 
   @action
   async reloadCurrentPage() {
-    return this.router.refresh();
+    return this.router.replaceWith('authenticated.target-profiles.target-profile.organizations');
   }
 
   @action

--- a/admin/app/controllers/authenticated/target-profiles/target-profile/organizations.js
+++ b/admin/app/controllers/authenticated/target-profiles/target-profile/organizations.js
@@ -1,0 +1,11 @@
+import Controller from '@ember/controller';
+import { tracked } from '@glimmer/tracking';
+
+const DEFAULT_PAGE_NUMBER = 1;
+
+export default class TargetProfileOrganizationsController extends Controller {
+  queryParams = ['pageNumber', 'pageSize'];
+
+  @tracked pageNumber = DEFAULT_PAGE_NUMBER;
+  @tracked pageSize = 10;
+}

--- a/admin/tests/integration/components/target-profiles/organizations-test.gjs
+++ b/admin/tests/integration/components/target-profiles/organizations-test.gjs
@@ -310,7 +310,7 @@ module('Integration | Component | target-profiles | Organizations', function (ho
           data: { attributes: { 'duplicated-ids': [], 'attached-ids': [1, 2] } },
         });
         const router = this.owner.lookup('service:router');
-        const refreshStub = sinon.stub(router, 'refresh');
+        const refreshStub = sinon.stub(router, 'replaceWith');
 
         // when
         await render(


### PR DESCRIPTION
## 🗡️  Problème

[Flaky](https://app.circleci.com/pipelines/github/1024pix/pix/158411/workflows/6a185373-7193-405d-90d9-cbdaabe10bae/jobs/1784735/tests)

## 🩸  Proposition

### Ok bon... 

Après BEAUCOUP trop d'investigations je suis a 70% convaincu que le flaky a été introduit par cette modification: 
[https://github.com/1024pix/pix/pull/14873](https://github.com/1024pix/pix/pull/14873/changes#diff-c10aa1b5afb0031c99eae319929cd5573b329218f7e248a362b1131125339358L57)

Qu'est ce qui me fait penser ça ?
1) Le merge de cette PR ( fin Janvier ) correspond a peu prés a la date d'apparition du bug ( début Février )
2) Il existe aussi un test d'acceptance sur les blueprints qui lui n'est jamais remonte en flaky, hors les mécanismes sont les mêmes, la seule différence fondamentale c'est `refresh` vs  `replaceWith`

### Ok intéressant, mais pourquoi ?

C'est la que ça devient boueux. 
De ce que j'en ai compris, les tests utilisent [ce truc](https://github.com/emberjs/ember-test-helpers/blob/66981f7178323fad37e5bffcfcafb04628441fa8/addon/src/settled.ts#L185) pour attendre un état stable avant de faire des expects. 
Et apparemment `refresh` et `replaceWith` n'appellent pas exactement les memes fonctions internes d'ember donc on peut avoir un décalage dans les comportements. 
Apres on part dans de sombres histoires de `_routerMicrolib`, de backburner.js, de mirage et de next tick. Franchement j'en suis ressorti triste et désabusé. 
Ma théorie c'est qu'il est possible que `hasPendingTransitions` retourne `false` alors que toutes les données ne sont pas rechargées.
 
### Ok mais tu peux le prouver ?

Sur la vie de moi j'ai pas réussi a reproduire. J'ai tout fait, lancer les commandes comme en CI, ralentir Mirage, réduire la vitesse de mes processeurs ( j'avais l'impression d’être revenu en 2002 ) mais pas. une. seule. fois. Donc j'ai beau mettre des logs partout, je peux pas le prouver.
C'est pour ça que j'ajoute le controller et le `replaceWith` pour tester ma théorie. 

### Ok mais pourquoi le fix c'est pas juste d'utiliser `replaceWith` ?

Parce que sans controller et ses queryParams `tracked`, ça marche pas. Ember voit que c'est la même route, même params, il fait rien, pas bête le hamster.
 
### Ok du coup il faut faire des controllers ?

Je suis convaincu que non, je pense que c'est une évolution bienvenue, j'imagine que le problème ici se situe plutôt du cote de Mirage et compagnie. Je pense que la vraie solution ici est de garder le refresh, supprimer le controller et remplacer les tests d'acceptance par du end to end si on y tient vraiment.

### Ok autre chose ?

On peut utiliser `refresh()` plus finement avec un argument.
Dans notre cas:

`this.route.refresh()`
<img width="454" height="163" alt="Pasted image 20260225152722" src="https://github.com/user-attachments/assets/9326c8fb-f681-487d-b1f1-604daf1a95fb" />

VS

`this.router.refresh('authenticated.target-profiles.target-profile.organizations');`
<img width="449" height="110" alt="Pasted image 20260225153006" src="https://github.com/user-attachments/assets/37a265ae-8d0f-4aa4-84b2-38712a912013" />

Big up a [Ember assistant](https://chatgpt.com/g/g-NlX2z2g6H-ember-assistant) qui en a marre de moi

## 🤞🏼  Pour tester

No flaky pliiizz 😿 
