### PR TITLE
[BUGFIX] Ne pas parser les données de type JSON et JSONB en provenance de datawarehouse

### DIFF
--- a/api/db/database-builder/database-builder.js
+++ b/api/db/database-builder/database-builder.js
@@ -226,6 +226,7 @@ export class DatabaseBuilder {
 
         if (!tableName || tableName === '') return;
         if (tableName === 'pgboss.version') return;
+        if (tableName === 'db_type_parsing_test') return;
 
         this.#dirtyTables.add(tableName);
       }

--- a/api/db/database-connection.js
+++ b/api/db/database-connection.js
@@ -6,7 +6,7 @@ import _ from 'lodash';
 import { config } from '../src/shared/config.js';
 import { monitoringTools } from '../src/shared/infrastructure/monitoring-tools.js';
 import { logger } from '../src/shared/infrastructure/utils/logger.js';
-import { configureConnectionExtension } from './knex-extensions.js';
+import { configureConnectionExtension, disableTypeCastingForJsonTypes } from './knex-extensions.js';
 
 const { logging } = config;
 
@@ -22,6 +22,9 @@ export class DatabaseConnection {
   constructor(knexConfig) {
     this.#hasConnection = Boolean(knexConfig?.connection?.connectionString);
     if (this.#hasConnection) {
+      if (knexConfig.name === 'datawarehouse') {
+        disableTypeCastingForJsonTypes(knexConfig);
+      }
       this.knex = Knex(knexConfig);
       this.#name = knexConfig.name;
       const url = DatabaseConnection.databaseUrlFromConfig(knexConfig);

--- a/api/db/knex-extensions.js
+++ b/api/db/knex-extensions.js
@@ -49,3 +49,24 @@ export function configureConnectionExtension(knex) {
     }
   }
 }
+
+export function disableTypeCastingForJsonTypes(knexConfig) {
+  const JSON_OID = types.builtins.JSON;
+  const JSONB_OID = types.builtins.JSONB;
+
+  const originalAfterCreate = knexConfig.pool?.afterCreate;
+
+  knexConfig.pool = {
+    ...knexConfig.pool,
+    afterCreate: (conn, done) => {
+      conn.setTypeParser(JSON_OID, (val) => val);
+      conn.setTypeParser(JSONB_OID, (val) => val);
+
+      if (originalAfterCreate) {
+        return originalAfterCreate(conn, done);
+      }
+
+      done(null, conn);
+    },
+  };
+}

--- a/api/tests/integration/db/db-type-parsing_test.js
+++ b/api/tests/integration/db/db-type-parsing_test.js
@@ -1,0 +1,51 @@
+import { datamartKnex, datawarehouseKnex, expect, knex } from '../../test-helper.js';
+
+describe('Integration | DB | db-type-parsing', function () {
+  describe('JSON and JSONB parsing', function () {
+    [
+      { knexClient: datamartKnex, name: 'datamartKnex' },
+      { knexClient: datawarehouseKnex, name: 'datawarehouseKnex' },
+      { knexClient: knex, name: 'knex' },
+    ].forEach(({ knexClient, name }) => {
+      beforeEach(async function () {
+        await knexClient.raw(`
+          CREATE TABLE db_type_parsing_test (
+            id SERIAL PRIMARY KEY,
+            column_of_type_json JSON NOT NULL,
+            column_of_type_jsonb JSONB NOT NULL
+          );
+        `);
+        await knexClient('db_type_parsing_test').insert({
+          column_of_type_json: '[{"foo": "bar"}]',
+          column_of_type_jsonb: '[{"foob": "barb"}]',
+        });
+      });
+
+      if (name === 'datawarehouseKnex') {
+        it(`should not cast json and jsonb types when reading data from table in base ${name}`, async function () {
+          const res = await knexClient
+            .select(['column_of_type_json', 'column_of_type_jsonb'])
+            .from('db_type_parsing_test')
+            .first();
+
+          expect(res.column_of_type_json).to.equal('[{"foo": "bar"}]');
+          expect(res.column_of_type_jsonb).to.equal('[{"foob": "barb"}]');
+        });
+      } else {
+        it(`should cast json and jsonb types when reading data from table ${name}`, async function () {
+          const res = await knexClient
+            .select(['column_of_type_json', 'column_of_type_jsonb'])
+            .from('db_type_parsing_test')
+            .first();
+
+          expect(res.column_of_type_json).to.deep.equal([{ foo: 'bar' }]);
+          expect(res.column_of_type_jsonb).to.deep.equal([{ foob: 'barb' }]);
+        });
+      }
+
+      afterEach(async function () {
+        await knexClient.raw(`DROP TABLE IF EXISTS db_type_parsing_test;`);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## 🥀 Problème

Un des tâches de l'API Maddo consiste à déplacer des données du datawarehouse de Data vers le Datamart.
Depuis hier / avant-hier, les jobs de remplissage des tables `sco_certification_results` et `certification_results` sont en erreur. Pour cause, les insertions dans ces tables sont en échec car une donnée supposée être du JSON est détectée comme invalide.

Ce qui est fait par Maddo :
```
SELECT id, ..., configuration FROM data_export_parcoursup_certif_result; // depuis datawarehouse

INSERT INTO certification_results(columns) VALUES (les valeurs select au dessus); // vers datamart
```

Cette opération est réalisée en stream, et on utilise le client `knex` pour la réaliser.
Le problème c'est que `knex`, et plus précisément la dépendance [https://github.com/brianc/node-pg-types](node-pg), pour certains types de colonnes fait du parsing. En l'occurrence pour les types JSON-like, knex nous retourne la donnée sélectionnée castée en objet Javascript.

Cela posait donc une erreur lorsque cette donnée (préalablement transformée par knex donc) était directement ré-insérée car il aurait fallu la repasser en chaîne de caractères.

## 🏹 Proposition

Puisque seul Maddo se connecte au datawarehouse, principalement dans le but de transférer des données, nous décidons de désactiver tout parsing JSON et JSONB sur le client knex du datawarehouse.

Puisque cette désactivation est ciblée, on ne peut pas le faire au global pour tout le monde ( comme on le fait pour le type DATE par exemple ici api/db/knex-extensions.js:10

Une manière de le faire et de surcharger chaque nouvelle connexion dans le pool du knex du datawarehouse et avant de la rendre disponible la customiser pour empêcher le parsing des types JSON et JSONB.

## 💌 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## ❤️‍🔥 Pour tester
On a ajouté un test pour vérifier que cette désactivation n'a bien effet que pour le client knex de datawarehouse
