### PR TITLE
[TECH] Ecrire un script pour remplir les trois nouvelles colonnes "capacity", "meshIndex" et "versionId" de la table "assessment-results"

### DIFF
--- a/api/scripts/certification/fill-capacity-meshindex-versionid-columns-in-assessment-results-table.js
+++ b/api/scripts/certification/fill-capacity-meshindex-versionid-columns-in-assessment-results-table.js
@@ -132,7 +132,7 @@ async function processCertifications(certificationsData, coreScoringConfiguratio
   let latestCertificationIdProcessed;
   const assessmentResultsToUpdate = [];
   logger.info(
-    `Processing certification from ${certificationsData[0].certificationCourseId} to ${certificationsData.at(-1).id}...`,
+    `Processing certification from ${certificationsData[0].certificationCourseId} to ${certificationsData.at(-1).certificationCourseId}...`,
   );
   for (const certificationData of certificationsData) {
     try {

--- a/api/scripts/certification/fill-capacity-meshindex-versionid-columns-in-assessment-results-table.js
+++ b/api/scripts/certification/fill-capacity-meshindex-versionid-columns-in-assessment-results-table.js
@@ -192,7 +192,7 @@ function findCorrespondingCoreScoringConfiguration(v3CertificationScorings, reco
   for (const v3CertificationScoring of v3CertificationScorings) {
     if (
       reconciledAt >= v3CertificationScoring.startDate &&
-      (v3CertificationScoring.expirationDate === null || reconciledAt < v3CertificationScoring.startDate)
+      (v3CertificationScoring.expirationDate === null || reconciledAt < v3CertificationScoring.expirationDate)
     ) {
       return v3CertificationScoring;
     }

--- a/api/scripts/certification/fill-capacity-meshindex-versionid-columns-in-assessment-results-table.js
+++ b/api/scripts/certification/fill-capacity-meshindex-versionid-columns-in-assessment-results-table.js
@@ -12,7 +12,7 @@ export class FillCapacityMeshindexVersionidColumnsInAssessmentResultsTable exten
   constructor() {
     super({
       description:
-        'Capacity, meshIndex and versionId are three new columns recently added in assessment-results table. This script fills those columns',
+        'Capacity, reachedMeshIndex and versionId are three new columns recently added in assessment-results table. This script fills those columns',
       permanent: false,
       options: {
         dryRun: {
@@ -41,7 +41,7 @@ export class FillCapacityMeshindexVersionidColumnsInAssessmentResultsTable exten
     const coreScoringConfigurations = await getCoreScoringConfigurations();
 
     let currentStartId = startId;
-    let certificationsData = await selectCertificationsToProcess(coreScoringConfigurations, currentStartId, chunkSize);
+    let certificationsData = await selectCertificationsToProcess(currentStartId, chunkSize);
     while (certificationsData.length > 0) {
       const { assessmentResultsToUpdate, latestCertificationIdProcessed } = await processCertifications(
         certificationsData,
@@ -55,14 +55,16 @@ export class FillCapacityMeshindexVersionidColumnsInAssessmentResultsTable exten
         logger.info(`Certifications up until ID ${latestCertificationIdProcessed} DONE`);
         if (dryRun) {
           await trx.rollback();
+        } else {
+          await trx.commit();
         }
       } catch (error) {
         await trx.rollback();
         throw error;
       }
 
-      currentStartId = latestCertificationIdProcessed;
-      certificationsData = await selectCertificationsToProcess(coreScoringConfigurations, currentStartId, chunkSize);
+      currentStartId = latestCertificationIdProcessed + 1;
+      certificationsData = await selectCertificationsToProcess(currentStartId, chunkSize);
     }
 
     logger.info('No more certifications to process youpi');
@@ -105,10 +107,10 @@ async function getCoreScoringConfigurations() {
     v3CertificationScorings.push(data);
   }
 
-  return v3CertificationScorings.sort();
+  return v3CertificationScorings;
 }
 
-async function selectCertificationsToProcess(coreScoringConfigurations, startId, chunkSize) {
+async function selectCertificationsToProcess(startId, chunkSize) {
   return await knex
     .select({
       certificationCourseId: 'certification-courses.id',
@@ -129,10 +131,12 @@ async function selectCertificationsToProcess(coreScoringConfigurations, startId,
 async function processCertifications(certificationsData, coreScoringConfigurations, logger) {
   let latestCertificationIdProcessed;
   const assessmentResultsToUpdate = [];
-  logger.info(`Processing certification from ${certificationsData[0].id} to ${certificationsData.at(-1).id}...`);
+  logger.info(
+    `Processing certification from ${certificationsData[0].certificationCourseId} to ${certificationsData.at(-1).id}...`,
+  );
   for (const certificationData of certificationsData) {
     try {
-      latestCertificationIdProcessed = certificationData.id;
+      latestCertificationIdProcessed = certificationData.certificationCourseId;
       const assessmentResultData = await processCertification(coreScoringConfigurations, certificationData);
       assessmentResultsToUpdate.push(assessmentResultData);
     } catch (error) {
@@ -169,14 +173,17 @@ async function processCertification(v3CertificationScorings, certificationData) 
     return null;
   }
 
-  const capacity = computeCapacityFromPixScore(assessmentResultData.pixScore, coreScoringConfiguration);
-  const meshIndex = computeMeshIndexFromCapacity(capacity, coreScoringConfiguration);
+  const capacity = computeCapacityFromPixScore(
+    assessmentResultData.pixScore,
+    coreScoringConfiguration.scoringConfiguration,
+  );
+  const reachedMeshIndex = computeMeshIndexFromCapacity(capacity, coreScoringConfiguration.scoringConfiguration);
   const versionId = coreScoringConfiguration.id;
 
   return {
     ...assessmentResultData,
     capacity,
-    meshIndex,
+    reachedMeshIndex,
     versionId,
   };
 }
@@ -197,13 +204,12 @@ function findCorrespondingCoreScoringConfiguration(v3CertificationScorings, reco
 function computeCapacityFromPixScore(pixScore, scoringConfiguration) {
   const certificationScoringIntervals = scoringConfiguration.intervals;
   const maxReachableLevel = scoringConfiguration.maxReachableLevel;
-
   return CapacitySimulator.compute({
     score: pixScore,
     certificationScoringIntervals,
     competencesForScoring: scoringConfiguration.competencesForScoring,
     maxReachableLevel,
-  });
+  }).capacity;
 }
 
 function computeMeshIndexFromCapacity(capacity, scoringConfiguration) {

--- a/api/scripts/certification/fill-capacity-meshindex-versionid-columns-in-assessment-results-table.js
+++ b/api/scripts/certification/fill-capacity-meshindex-versionid-columns-in-assessment-results-table.js
@@ -1,0 +1,215 @@
+import { knex } from '../../db/knex-database-connection.js';
+import { Frameworks } from '../../src/certification/configuration/domain/models/Frameworks.js';
+import { CapacitySimulator } from '../../src/certification/evaluation/domain/models/CapacitySimulator.js';
+import { Intervals } from '../../src/certification/evaluation/domain/models/Intervals.js';
+import { V3CertificationScoring } from '../../src/certification/evaluation/domain/models/V3CertificationScoring.js';
+import { Script } from '../../src/shared/application/scripts/script.js';
+import { ScriptRunner } from '../../src/shared/application/scripts/script-runner.js';
+import * as areaRepository from '../../src/shared/infrastructure/repositories/area-repository.js';
+import * as competenceRepository from '../../src/shared/infrastructure/repositories/competence-repository.js';
+
+export class FillCapacityMeshindexVersionidColumnsInAssessmentResultsTable extends Script {
+  constructor() {
+    super({
+      description:
+        'Capacity, meshIndex and versionId are three new columns recently added in assessment-results table. This script fills those columns',
+      permanent: false,
+      options: {
+        dryRun: {
+          type: 'boolean',
+          describe: 'Run the script without making any database changes',
+          default: true,
+        },
+        startId: {
+          type: 'number',
+          describe: 'Define the id of the certification-courses from which we start doing the process',
+          default: 5906059,
+        },
+        chunkSize: {
+          type: 'number',
+          describe:
+            'Define the number of certifications processed in a chunk (chunks determined how many certifications are updated and committed at the same time)',
+          default: 1000,
+        },
+      },
+    });
+  }
+
+  async handle({ logger, options }) {
+    const { dryRun, startId, chunkSize } = options;
+    logger.info('Script execution started');
+    const coreScoringConfigurations = await getCoreScoringConfigurations();
+
+    let currentStartId = startId;
+    let certificationsData = await selectCertificationsToProcess(coreScoringConfigurations, currentStartId, chunkSize);
+    while (certificationsData.length > 0) {
+      const { assessmentResultsToUpdate, latestCertificationIdProcessed } = await processCertifications(
+        certificationsData,
+        coreScoringConfigurations,
+        logger,
+      );
+
+      const trx = await knex.transaction();
+      try {
+        await trx('assessment-results').insert(assessmentResultsToUpdate).onConflict('id').merge();
+        logger.info(`Certifications up until ID ${latestCertificationIdProcessed} DONE`);
+        if (dryRun) {
+          await trx.rollback();
+        }
+      } catch (error) {
+        await trx.rollback();
+        throw error;
+      }
+
+      currentStartId = latestCertificationIdProcessed;
+      certificationsData = await selectCertificationsToProcess(coreScoringConfigurations, currentStartId, chunkSize);
+    }
+
+    logger.info('No more certifications to process youpi');
+  }
+}
+
+async function getCoreScoringConfigurations() {
+  const allAreas = await areaRepository.list();
+  const competenceList = await competenceRepository.listPixCompetencesOnly();
+
+  const versionsData = await knex('certification_versions')
+    .select(
+      'id',
+      'startDate',
+      'expirationDate',
+      'globalScoringConfiguration',
+      'competencesScoringConfiguration',
+      'minimumAnswersRequiredToValidateACertification',
+    )
+    .where({
+      scope: Frameworks.CORE,
+    })
+    .orderByRaw('"expirationDate" ASC NULLS LAST');
+
+  const v3CertificationScorings = [];
+  for (const versionData of versionsData) {
+    const scoringConfiguration = V3CertificationScoring.fromConfigurations({
+      competenceForScoringConfiguration: versionData.competencesScoringConfiguration,
+      certificationScoringConfiguration: versionData.globalScoringConfiguration,
+      allAreas,
+      competenceList,
+      minimumAnswersRequiredToValidateACertification: versionData.minimumAnswersRequiredToValidateACertification,
+    });
+    const data = {
+      id: versionData.id,
+      startDate: versionData.startDate,
+      expirationDate: versionData.expirationDate,
+      scoringConfiguration,
+    };
+    v3CertificationScorings.push(data);
+  }
+
+  return v3CertificationScorings.sort();
+}
+
+async function selectCertificationsToProcess(coreScoringConfigurations, startId, chunkSize) {
+  return await knex
+    .select({
+      certificationCourseId: 'certification-courses.id',
+      reconciledAt: 'certification-candidates.reconciledAt',
+    })
+    .from('certification-courses')
+    .join('certification-candidates', function () {
+      this.on({ 'certification-candidates.sessionId': 'certification-courses.sessionId' }).andOn({
+        'certification-candidates.userId': 'certification-courses.userId',
+      });
+    })
+    .where('certification-courses.version', 3)
+    .where('certification-courses.id', '>=', startId)
+    .orderBy('certification-courses.id', 'asc')
+    .limit(chunkSize);
+}
+
+async function processCertifications(certificationsData, coreScoringConfigurations, logger) {
+  let latestCertificationIdProcessed;
+  const assessmentResultsToUpdate = [];
+  logger.info(`Processing certification from ${certificationsData[0].id} to ${certificationsData.at(-1).id}...`);
+  for (const certificationData of certificationsData) {
+    try {
+      latestCertificationIdProcessed = certificationData.id;
+      const assessmentResultData = await processCertification(coreScoringConfigurations, certificationData);
+      assessmentResultsToUpdate.push(assessmentResultData);
+    } catch (error) {
+      logger.error(error, `Certification ID ${latestCertificationIdProcessed} encountered an error`);
+      throw error;
+    }
+  }
+  return {
+    assessmentResultsToUpdate: assessmentResultsToUpdate.filter((ar) => !!ar),
+    latestCertificationIdProcessed,
+  };
+}
+
+async function processCertification(v3CertificationScorings, certificationData) {
+  const coreScoringConfiguration = findCorrespondingCoreScoringConfiguration(
+    v3CertificationScorings,
+    certificationData.reconciledAt,
+  );
+
+  const assessmentResultData = await knex
+    .select('assessment-results.*')
+    .from('assessment-results')
+    .join(
+      'certification-courses-last-assessment-results',
+      'certification-courses-last-assessment-results.lastAssessmentResultId',
+      'assessment-results.id',
+    )
+    .where(
+      'certification-courses-last-assessment-results.certificationCourseId',
+      certificationData.certificationCourseId,
+    )
+    .first();
+  if (!assessmentResultData) {
+    return null;
+  }
+
+  const capacity = computeCapacityFromPixScore(assessmentResultData.pixScore, coreScoringConfiguration);
+  const meshIndex = computeMeshIndexFromCapacity(capacity, coreScoringConfiguration);
+  const versionId = coreScoringConfiguration.id;
+
+  return {
+    ...assessmentResultData,
+    capacity,
+    meshIndex,
+    versionId,
+  };
+}
+
+function findCorrespondingCoreScoringConfiguration(v3CertificationScorings, reconciledAt) {
+  for (const v3CertificationScoring of v3CertificationScorings) {
+    if (
+      reconciledAt >= v3CertificationScoring.startDate &&
+      (v3CertificationScoring.expirationDate === null || reconciledAt < v3CertificationScoring.startDate)
+    ) {
+      return v3CertificationScoring;
+    }
+  }
+
+  throw new Error(`No Certification Scoring found for ${reconciledAt} date.`);
+}
+
+function computeCapacityFromPixScore(pixScore, scoringConfiguration) {
+  const certificationScoringIntervals = scoringConfiguration.intervals;
+  const maxReachableLevel = scoringConfiguration.maxReachableLevel;
+
+  return CapacitySimulator.compute({
+    score: pixScore,
+    certificationScoringIntervals,
+    competencesForScoring: scoringConfiguration.competencesForScoring,
+    maxReachableLevel,
+  });
+}
+
+function computeMeshIndexFromCapacity(capacity, scoringConfiguration) {
+  const certificationScoringIntervals = scoringConfiguration.intervals;
+  const scoringIntervals = new Intervals({ intervals: certificationScoringIntervals });
+  return scoringIntervals.findIntervalIndexFromCapacity(capacity);
+}
+
+await ScriptRunner.execute(import.meta.url, FillCapacityMeshindexVersionidColumnsInAssessmentResultsTable);

--- a/api/tests/certification/scripts/integration/fill-capacity-meshindex-versionid-columns-in-assessment-results-table_test.js
+++ b/api/tests/certification/scripts/integration/fill-capacity-meshindex-versionid-columns-in-assessment-results-table_test.js
@@ -27,9 +27,74 @@ describe.only('Integration | Certification | Scripts | Fill capacity, meshindex,
     await mockLearningContent(learningContent);
   });
 
-  it('should fill capacity, meshindex and versionid in assessment results', async function () {
+  it('should not commit if dryRun', async function () {
     const startDate = new Date('2025-10-01');
     const expirationDate = null;
+
+    databaseBuilder.factory.buildCertificationVersion({
+      startDate,
+      expirationDate,
+    }).id;
+
+    const pixScores = [0, 895];
+
+    const firstCertificationCourseId = _createBatchAssessmentResults({
+      reconciledAt: new Date('2025-12-23'),
+      pixScores,
+    });
+
+    await databaseBuilder.commit();
+
+    const assessmentResultDataBefore = await knex('assessment-results').orderBy('id');
+
+    await script.handle({ options: { dryRun: true, startId: firstCertificationCourseId, chunkSize: 1 }, logger });
+
+    const assessmentResultData = await knex('assessment-results').orderBy('id');
+    expect(assessmentResultData).to.deep.equal(assessmentResultDataBefore);
+  });
+
+  it('should fill capacity, meshindex and versionid in assessment results for current version', async function () {
+    const startDate = new Date('2025-10-01');
+    const expirationDate = null;
+
+    const versionId = databaseBuilder.factory.buildCertificationVersion({
+      startDate,
+      expirationDate,
+    }).id;
+
+    const pixScores = [0, 895];
+
+    const firstCertificationCourseId = _createBatchAssessmentResults({
+      reconciledAt: new Date('2025-12-23'),
+      pixScores,
+    });
+
+    await databaseBuilder.commit();
+
+    const assessmentResultDataBefore = await knex('assessment-results').orderBy('id');
+    expect(assessmentResultDataBefore).to.have.lengthOf(pixScores.length);
+    expect(assessmentResultDataBefore[0].capacity).to.be.null;
+    expect(assessmentResultDataBefore[0].reachedMeshIndex).to.be.null;
+    expect(assessmentResultDataBefore[0].versionId).to.be.null;
+    expect(assessmentResultDataBefore[1].capacity).to.be.null;
+    expect(assessmentResultDataBefore[1].reachedMeshIndex).to.be.null;
+    expect(assessmentResultDataBefore[1].versionId).to.be.null;
+
+    await script.handle({ options: { dryRun: false, startId: firstCertificationCourseId, chunkSize: 1 }, logger });
+
+    const assessmentResultData = await knex('assessment-results').orderBy('id');
+    expect(assessmentResultData).to.have.lengthOf(pixScores.length);
+    expect(Math.ceil(assessmentResultData[0].capacity)).to.equal(-8);
+    expect(assessmentResultData[0].reachedMeshIndex).to.equal(0);
+    expect(assessmentResultData[0].versionId).to.equal(versionId);
+    expect(Math.ceil(assessmentResultData[1].capacity)).to.equal(8);
+    expect(assessmentResultData[1].reachedMeshIndex).to.equal(7);
+    expect(assessmentResultData[1].versionId).to.equal(versionId);
+  });
+
+  it('should fill capacity, meshindex and versionid in assessment results for expired version', async function () {
+    const startDate = new Date('2025-10-01');
+    const expirationDate = new Date('2026-01-01');
 
     const versionId = databaseBuilder.factory.buildCertificationVersion({
       startDate,

--- a/api/tests/certification/scripts/integration/fill-capacity-meshindex-versionid-columns-in-assessment-results-table_test.js
+++ b/api/tests/certification/scripts/integration/fill-capacity-meshindex-versionid-columns-in-assessment-results-table_test.js
@@ -1,0 +1,90 @@
+import { FillCapacityMeshindexVersionidColumnsInAssessmentResultsTable } from '../../../../scripts/certification/fill-capacity-meshindex-versionid-columns-in-assessment-results-table.js';
+import { AlgorithmEngineVersion } from '../../../../src/certification/shared/domain/models/AlgorithmEngineVersion.js';
+import { databaseBuilder, expect, knex, mockLearningContent, sinon } from '../../../test-helper.js';
+
+describe.only('Integration | Certification | Scripts | Fill capacity, meshindex, versionid columns in assessment results', function () {
+  let logger, script;
+
+  const learningContent = {
+    areas: [{ id: 'recArea1', competenceIds: ['recCompetence1'] }],
+    competences: [
+      {
+        id: 'recCompetence1',
+        index: '1.1',
+        areaId: 'recArea1',
+        origin: 'Pix',
+        name_i18n: {
+          fr: 'Nom de la competence FR',
+          en: 'Nom de la competence EN',
+        },
+      },
+    ],
+  };
+
+  beforeEach(async function () {
+    logger = { info: sinon.stub(), error: sinon.stub() };
+    script = new FillCapacityMeshindexVersionidColumnsInAssessmentResultsTable();
+    await mockLearningContent(learningContent);
+  });
+
+  it('should fill capacity, meshindex and versionid in assessment results', async function () {
+    const startDate = new Date('2025-10-01');
+    const expirationDate = null;
+
+    const versionId = databaseBuilder.factory.buildCertificationVersion({
+      startDate,
+      expirationDate,
+    }).id;
+
+    const pixScores = [0, 895];
+
+    const firstCertificationCourseId = _createBatchAssessmentResults({
+      reconciledAt: new Date('2025-12-23'),
+      pixScores,
+    });
+
+    await databaseBuilder.commit();
+
+    const assessmentResultDataBefore = await knex('assessment-results').orderBy('id');
+    expect(assessmentResultDataBefore).to.have.lengthOf(pixScores.length);
+    expect(assessmentResultDataBefore[0].capacity).to.be.null;
+    expect(assessmentResultDataBefore[0].reachedMeshIndex).to.be.null;
+    expect(assessmentResultDataBefore[0].versionId).to.be.null;
+    expect(assessmentResultDataBefore[1].capacity).to.be.null;
+    expect(assessmentResultDataBefore[1].reachedMeshIndex).to.be.null;
+    expect(assessmentResultDataBefore[1].versionId).to.be.null;
+
+    await script.handle({ options: { dryRun: false, startId: firstCertificationCourseId, chunkSize: 1 }, logger });
+
+    const assessmentResultData = await knex('assessment-results').orderBy('id');
+    expect(assessmentResultData).to.have.lengthOf(pixScores.length);
+    expect(Math.ceil(assessmentResultData[0].capacity)).to.equal(-8);
+    expect(assessmentResultData[0].reachedMeshIndex).to.equal(0);
+    expect(assessmentResultData[0].versionId).to.equal(versionId);
+    expect(Math.ceil(assessmentResultData[1].capacity)).to.equal(8);
+    expect(assessmentResultData[1].reachedMeshIndex).to.equal(7);
+    expect(assessmentResultData[1].versionId).to.equal(versionId);
+  });
+});
+
+function _createBatchAssessmentResults({ reconciledAt, pixScores }) {
+  let firstCertificationCourseId;
+  for (const pixScore of pixScores) {
+    const sessionId = databaseBuilder.factory.buildSession().id;
+    const userId = databaseBuilder.factory.buildUser().id;
+    databaseBuilder.factory.buildCertificationCandidate({ sessionId, reconciledAt: reconciledAt, userId });
+    const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
+      sessionId,
+      userId,
+      version: AlgorithmEngineVersion.V3,
+    }).id;
+    firstCertificationCourseId = firstCertificationCourseId || certificationCourseId;
+    const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId }).id;
+    const lastAssessmentResultId = databaseBuilder.factory.buildAssessmentResult({ assessmentId, pixScore }).id;
+    databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
+      certificationCourseId,
+      lastAssessmentResultId,
+    });
+  }
+  return firstCertificationCourseId;
+}

--- a/api/tests/certification/scripts/integration/fill-capacity-meshindex-versionid-columns-in-assessment-results-table_test.js
+++ b/api/tests/certification/scripts/integration/fill-capacity-meshindex-versionid-columns-in-assessment-results-table_test.js
@@ -1,8 +1,8 @@
 import { FillCapacityMeshindexVersionidColumnsInAssessmentResultsTable } from '../../../../scripts/certification/fill-capacity-meshindex-versionid-columns-in-assessment-results-table.js';
 import { AlgorithmEngineVersion } from '../../../../src/certification/shared/domain/models/AlgorithmEngineVersion.js';
-import { databaseBuilder, expect, knex, mockLearningContent, sinon } from '../../../test-helper.js';
+import { catchErr, databaseBuilder, expect, knex, mockLearningContent, sinon } from '../../../test-helper.js';
 
-describe.only('Integration | Certification | Scripts | Fill capacity, meshindex, versionid columns in assessment results', function () {
+describe('Integration | Certification | Scripts | Fill capacity, meshindex, versionid columns in assessment results', function () {
   let logger, script;
 
   const learningContent = {
@@ -38,16 +38,18 @@ describe.only('Integration | Certification | Scripts | Fill capacity, meshindex,
 
     const pixScores = [0, 895];
 
-    const firstCertificationCourseId = _createBatchAssessmentResults({
+    const certificationCourseIds = [];
+    _createBatchAssessmentResults({
       reconciledAt: new Date('2025-12-23'),
       pixScores,
+      certificationCourseIds,
     });
 
     await databaseBuilder.commit();
 
     const assessmentResultDataBefore = await knex('assessment-results').orderBy('id');
 
-    await script.handle({ options: { dryRun: true, startId: firstCertificationCourseId, chunkSize: 1 }, logger });
+    await script.handle({ options: { dryRun: true, startId: certificationCourseIds[0], chunkSize: 1 }, logger });
 
     const assessmentResultData = await knex('assessment-results').orderBy('id');
     expect(assessmentResultData).to.deep.equal(assessmentResultDataBefore);
@@ -64,9 +66,11 @@ describe.only('Integration | Certification | Scripts | Fill capacity, meshindex,
 
     const pixScores = [0, 895];
 
-    const firstCertificationCourseId = _createBatchAssessmentResults({
+    const certificationCourseIds = [];
+    _createBatchAssessmentResults({
       reconciledAt: new Date('2025-12-23'),
       pixScores,
+      certificationCourseIds,
     });
 
     await databaseBuilder.commit();
@@ -80,7 +84,7 @@ describe.only('Integration | Certification | Scripts | Fill capacity, meshindex,
     expect(assessmentResultDataBefore[1].reachedMeshIndex).to.be.null;
     expect(assessmentResultDataBefore[1].versionId).to.be.null;
 
-    await script.handle({ options: { dryRun: false, startId: firstCertificationCourseId, chunkSize: 1 }, logger });
+    await script.handle({ options: { dryRun: false, startId: certificationCourseIds[0], chunkSize: 1 }, logger });
 
     const assessmentResultData = await knex('assessment-results').orderBy('id');
     expect(assessmentResultData).to.have.lengthOf(pixScores.length);
@@ -103,9 +107,11 @@ describe.only('Integration | Certification | Scripts | Fill capacity, meshindex,
 
     const pixScores = [0, 895];
 
-    const firstCertificationCourseId = _createBatchAssessmentResults({
+    const certificationCourseIds = [];
+    _createBatchAssessmentResults({
       reconciledAt: new Date('2025-12-23'),
       pixScores,
+      certificationCourseIds,
     });
 
     await databaseBuilder.commit();
@@ -119,7 +125,7 @@ describe.only('Integration | Certification | Scripts | Fill capacity, meshindex,
     expect(assessmentResultDataBefore[1].reachedMeshIndex).to.be.null;
     expect(assessmentResultDataBefore[1].versionId).to.be.null;
 
-    await script.handle({ options: { dryRun: false, startId: firstCertificationCourseId, chunkSize: 1 }, logger });
+    await script.handle({ options: { dryRun: false, startId: certificationCourseIds[0], chunkSize: 1 }, logger });
 
     const assessmentResultData = await knex('assessment-results').orderBy('id');
     expect(assessmentResultData).to.have.lengthOf(pixScores.length);
@@ -130,10 +136,123 @@ describe.only('Integration | Certification | Scripts | Fill capacity, meshindex,
     expect(assessmentResultData[1].reachedMeshIndex).to.equal(7);
     expect(assessmentResultData[1].versionId).to.equal(versionId);
   });
+
+  it('should correctly process certification from two different versions with appropriate logger informations', async function () {
+    const startDateArchivedVersion = new Date('2025-01-01');
+    const expirationDateArchivedVersion = new Date('2026-01-01');
+    const startDateCurrentVersion = expirationDateArchivedVersion;
+    const expirationDateCurrentVersion = null;
+    const pixScores = [0, 450, 895];
+    const certificationCourseIds = [];
+
+    const versionIdArchivedVersion = databaseBuilder.factory.buildCertificationVersion({
+      startDate: startDateArchivedVersion,
+      expirationDate: expirationDateArchivedVersion,
+    }).id;
+
+    _createBatchAssessmentResults({
+      reconciledAt: new Date('2025-12-23'),
+      pixScores,
+      certificationCourseIds,
+    });
+
+    const versionIdCurrentVersion = databaseBuilder.factory.buildCertificationVersion({
+      startDate: startDateCurrentVersion,
+      expirationDate: expirationDateCurrentVersion,
+    }).id;
+
+    _createBatchAssessmentResults({
+      reconciledAt: new Date('2026-01-10'),
+      pixScores,
+      certificationCourseIds,
+    });
+
+    await databaseBuilder.commit();
+
+    await script.handle({ options: { dryRun: false, startId: certificationCourseIds[0], chunkSize: 2 }, logger });
+
+    const assessmentResultData = await knex('assessment-results').orderBy('id');
+    expect(assessmentResultData).to.have.lengthOf(6);
+    expect(assessmentResultData[0].versionId).to.equal(versionIdArchivedVersion);
+    expect(assessmentResultData[3].versionId).to.equal(versionIdCurrentVersion);
+    expect(logger.info.getCall(0)).to.have.been.calledWithExactly('Script execution started');
+    expect(logger.info.getCall(1)).to.have.been.calledWithExactly(
+      `Processing certification from ${certificationCourseIds[0]} to ${certificationCourseIds[1]}...`,
+    );
+    expect(logger.info.getCall(2)).to.have.been.calledWithExactly(
+      `Certifications up until ID ${certificationCourseIds[1]} DONE`,
+    );
+    expect(logger.info.getCall(3)).to.have.been.calledWithExactly(
+      `Processing certification from ${certificationCourseIds[2]} to ${certificationCourseIds[3]}...`,
+    );
+    expect(logger.info.getCall(4)).to.have.been.calledWithExactly(
+      `Certifications up until ID ${certificationCourseIds[3]} DONE`,
+    );
+    expect(logger.info.getCall(5)).to.have.been.calledWithExactly(
+      `Processing certification from ${certificationCourseIds[4]} to ${certificationCourseIds[5]}...`,
+    );
+    expect(logger.info.getCall(6)).to.have.been.calledWithExactly(
+      `Certifications up until ID ${certificationCourseIds[5]} DONE`,
+    );
+    expect(logger.info.getCall(7)).to.have.been.calledWithExactly('No more certifications to process youpi');
+  });
+
+  it('should throw an error when no matching version to reconciledAt date is found, and rollback chunk', async function () {
+    const startDate = new Date('2025-10-01');
+    const expirationDate = new Date('2026-01-01');
+    const certificationCourseIds = [];
+
+    const versionId = databaseBuilder.factory.buildCertificationVersion({
+      startDate,
+      expirationDate,
+    }).id;
+
+    const pixScores = [0, 450, 895];
+
+    _createBatchAssessmentResults({
+      reconciledAt: new Date('2025-12-23'),
+      pixScores,
+      certificationCourseIds,
+    });
+
+    const reconciledAt = new Date();
+    _createBatchAssessmentResults({
+      reconciledAt,
+      pixScores: [500],
+      certificationCourseIds,
+    });
+
+    await databaseBuilder.commit();
+
+    const err = await catchErr(script.handle)({
+      options: { dryRun: false, startId: certificationCourseIds[0], chunkSize: 2 },
+      logger,
+    });
+
+    const assessmentResultData = await knex('assessment-results').orderBy('id');
+    expect(assessmentResultData).to.have.lengthOf(4);
+    expect(assessmentResultData[0].versionId).to.equal(versionId);
+    expect(assessmentResultData[2].versionId).to.equal(null);
+    expect(logger.info.getCall(0)).to.have.been.calledWithExactly('Script execution started');
+    expect(logger.info.getCall(1)).to.have.been.calledWithExactly(
+      `Processing certification from ${certificationCourseIds[0]} to ${certificationCourseIds[1]}...`,
+    );
+    expect(logger.info.getCall(2)).to.have.been.calledWithExactly(
+      `Certifications up until ID ${certificationCourseIds[1]} DONE`,
+    );
+    expect(logger.info.getCall(3)).to.have.been.calledWithExactly(
+      `Processing certification from ${certificationCourseIds[2]} to ${certificationCourseIds[3]}...`,
+    );
+    expect(err).to.be.instanceOf(Error);
+    expect(err).to.have.property('message', `No Certification Scoring found for ${reconciledAt} date.`);
+    expect(logger.error).to.have.been.calledWithExactly(
+      err,
+      `Certification ID ${certificationCourseIds[3]} encountered an error`,
+    );
+  });
 });
 
-function _createBatchAssessmentResults({ reconciledAt, pixScores }) {
-  let firstCertificationCourseId;
+function _createBatchAssessmentResults({ reconciledAt, pixScores, certificationCourseIds }) {
   for (const pixScore of pixScores) {
     const sessionId = databaseBuilder.factory.buildSession().id;
     const userId = databaseBuilder.factory.buildUser().id;
@@ -143,7 +262,7 @@ function _createBatchAssessmentResults({ reconciledAt, pixScores }) {
       userId,
       version: AlgorithmEngineVersion.V3,
     }).id;
-    firstCertificationCourseId = firstCertificationCourseId || certificationCourseId;
+    certificationCourseIds.push(certificationCourseId);
     const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId }).id;
     const lastAssessmentResultId = databaseBuilder.factory.buildAssessmentResult({ assessmentId, pixScore }).id;
     databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
@@ -151,5 +270,4 @@ function _createBatchAssessmentResults({ reconciledAt, pixScores }) {
       lastAssessmentResultId,
     });
   }
-  return firstCertificationCourseId;
 }


### PR DESCRIPTION
## 🥀 Problème

Dans le cadre de l'ajout du scoring des Pix Plus V3, nous avons choisi d'étoffer les objets assessmentResult pour qu'ils contiennent la capacité finale, l'index du "mesh" atteint et l'id de la version du référentiel de certification. Il faut remplir ses champs rétro activement pour l'ensemble des certif v3

## 🏹 Proposition

Rédaction d'un script utilisant notamment le simulateur score vers capacité 

## 💌 Remarques

Paramètres du script : 
- dryRun (défaut `true`)
- startId: id du premier certification course à traiter (défaut `5906059`)
- chunkSize (défaut `1000`)

## ❤️‍🔥 Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
