### PR TITLE
[TECH] Déflakyser les tests de recette E2E de certification

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,6 +91,23 @@ executors:
         environment:
           - initialBuckets=pix-import-test
     resource_class: medium
+  node-redis-postgres-s3-docker-large:
+    parameters:
+      node-version:
+        # renovate datasource=node-version depName=node
+        default: 24.11.1
+        type: string
+    docker:
+      - image: cimg/node:<<parameters.node-version>>
+      - image: postgres:16.9-alpine
+        environment:
+          POSTGRES_USER: circleci
+          POSTGRES_HOST_AUTH_METHOD: trust
+      - image: redis:7.2.11-alpine
+      - image: adobe/s3mock:4.11.0
+        environment:
+          - initialBuckets=pix-import-test
+    resource_class: large
   node-browsers-docker:
     parameters:
       node-version:
@@ -1200,7 +1217,7 @@ jobs:
 
   e2e_playwright_test_recette_certif:
     executor:
-      name: node-redis-postgres-s3-docker-medium
+      name: node-redis-postgres-s3-docker-large
     working_directory: ~/pix/high-level-tests/e2e-playwright
     parallelism: 4
     steps:

--- a/high-level-tests/e2e-playwright/playwright.config.certif.ts
+++ b/high-level-tests/e2e-playwright/playwright.config.certif.ts
@@ -4,7 +4,7 @@ import sharedConfig, { App, isCI, reuseExistingApps, setupWebServer } from './pl
 
 export default defineConfig({
   ...sharedConfig,
-  timeout: 40_000,
+  timeout: 70_000,
   projects: [
     {
       name: 'Recette',


### PR DESCRIPTION
## 🥀 Problème

C'est flaky

## 🏹 Proposition

Augmenter le timeout et tester avec une machine "large" de chez CircleCI pendant un mois voir si c'est bien

## 💌 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## ❤️‍🔥 Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
