### PR TITLE
[TECH] Avoir la possibilité de désactiver le parsing des types JSON et JSONB dans knex via un flag dans la knex config

### DIFF
--- a/api/datawarehouse/knexfile.js
+++ b/api/datawarehouse/knexfile.js
@@ -8,6 +8,7 @@ const baseConfiguration = {
   connection: {
     connectionString: process.env.DATAWAREHOUSE_DATABASE_URL,
   },
+  disableJsonTypesParsing: true,
 };
 
 const environments = {

--- a/api/db/database-connection.js
+++ b/api/db/database-connection.js
@@ -22,7 +22,7 @@ export class DatabaseConnection {
   constructor(knexConfig) {
     this.#hasConnection = Boolean(knexConfig?.connection?.connectionString);
     if (this.#hasConnection) {
-      if (knexConfig.name === 'datawarehouse') {
+      if (knexConfig?.customFlags?.disableJsonTypesParsing) {
         disableTypeCastingForJsonTypes(knexConfig);
       }
       this.knex = Knex(knexConfig);

--- a/api/db/utils/build-postgres-environment.js
+++ b/api/db/utils/build-postgres-environment.js
@@ -1,4 +1,11 @@
-export function buildPostgresEnvironment({ connection, pool, migrationsDirectory, seedsDirectory, name }) {
+export function buildPostgresEnvironment({
+  connection,
+  pool,
+  migrationsDirectory,
+  seedsDirectory,
+  name,
+  disableJsonTypesParsing = false,
+}) {
   return {
     name,
     client: 'postgresql',
@@ -17,5 +24,8 @@ export function buildPostgresEnvironment({ connection, pool, migrationsDirectory
       loadExtensions: ['.js'],
     },
     asyncStackTraces: process.env.KNEX_ASYNC_STACKTRACE_ENABLED !== 'false',
+    customFlags: {
+      disableJsonTypesParsing,
+    },
   };
 }


### PR DESCRIPTION
## 🥀 Problème

Pour la PR concernant le fait de ne pas parser les types JSON et JSONB, on avait besoin de faire un traitement exceptionnel pour le client knex de la base datawarehouse. Pour rapidement livrer, on a mis en dur une valeur pour vérifier qu'il s'agissait bien de la connexion vers le datawarehouse

## 🏹 Proposition

Avoir la possibilité de définir un flag disableJsonTypesParsing à true au niveau de la config du knexfile pour permettre la désactivation du parsing des types JSON et JSONB

## 💌 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## ❤️‍🔥 Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
