### PR TITLE
[FEATURE] Rajouter un wording avant de démarrer une campagne exam (PIX-21707)

### DIFF
--- a/mon-pix/app/components/campaign-start-block.gjs
+++ b/mon-pix/app/components/campaign-start-block.gjs
@@ -31,6 +31,11 @@ export default class CampaignStartBlock extends Component {
           {{#unless this.session.isAuthenticated}}
             <h2 class="campaign-landing-page-start__subtitle">{{this.announcementText}}</h2>
           {{/unless}}
+          {{#if this.showExamCampaignInfo}}
+            <p class="campaign-landing-page-detail__exam-notice">{{t
+                "pages.campaign-landing.assessment.exam-notice"
+              }}</p>
+          {{/if}}
           <PixButton
             @type="submit"
             class="campaign-landing-page__start-button"
@@ -72,6 +77,10 @@ export default class CampaignStartBlock extends Component {
 
   get campaignType() {
     return this.args.campaign.isAssessment || this.args.campaign.isExam ? 'assessment' : 'profiles-collection';
+  }
+
+  get showExamCampaignInfo() {
+    return this.args.campaign.isExam;
   }
 
   get titleText() {

--- a/mon-pix/app/styles/components/campaigns/assessment/start-landing-page/campaign-landing-page-details.scss
+++ b/mon-pix/app/styles/components/campaigns/assessment/start-landing-page/campaign-landing-page-details.scss
@@ -1,5 +1,11 @@
+@use 'pix-design-tokens/typography';
+
 .campaign-landing-page-details {
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
+}
+
+.campaign-landing-page-detail__exam-notice {
+  @extend %pix-body-m;
 }

--- a/mon-pix/tests/integration/components/campaign-start-block-test.js
+++ b/mon-pix/tests/integration/components/campaign-start-block-test.js
@@ -205,6 +205,7 @@ module('Integration | Component | campaign-start-block', function (hooks) {
             }),
           )
           .exists();
+        assert.dom(screen.getByText(t('pages.campaign-landing.assessment.exam-notice'))).exists();
         assert.dom(screen.getByText(t('pages.campaign-landing.assessment.legal'))).exists();
       });
 

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -602,6 +602,7 @@
           "description": "You will have to carry out searches online, use your digital working environment, test your knowledge, etc.",
           "title": "Measure your digital skills with fun and educational challenges that adapt to your level of proficiency  (through an adaptive algorithm)."
         },
+        "exam-notice": "During this customised test, your competences profile will not be taken into account or modified. Your answers will not affect your skills levels or your overall Pix score.",
         "legal": "By clicking on “Begin your test“, information about your progress will be shared with the organiser so they can assist you if necessary. At the end of your test, your results will be automatically shared with your organisation.",
         "title": "Begin your customised test",
         "title-with-username": "'<span>'{userFirstName}'</span>','<br>' ready to assess your digital skills?"

--- a/mon-pix/translations/es-419.json
+++ b/mon-pix/translations/es-419.json
@@ -1,5 +1,10 @@
 {
   "pages": {
+    "campaign-landing": {
+      "assessment": {
+        "exam-notice": "Durante este test, su perfil de competencias no será tomado en cuenta ni modificado. Sus respuestas no afectarán sus niveles de habilidades ni su puntaje global de Pix."
+      }
+    },
     "sign-in": {
       "first-title": "Accede a tu cuenta"
     }

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -602,6 +602,7 @@
           "description": "Deberás realizar búsquedas en internet, utilizar tu entorno de trabajo digital, poner a prueba tus conocimientos, etc.",
           "title": "Medir tus competencias digitales con retos lúdicos y de aprendizaje que se adaptan a tu nivel de competencia (mediante un algoritmo adaptativo)."
         },
+        "exam-notice": "Durante la realización de este test, su perfil de competencias no será tomado en cuenta ni modificado. Sus respuestas no tendrán ningún impacto en sus niveles de habilidades ni en su puntuación global de Pix.",
         "legal": "Al hacer clic en «Empiezo» te conectarás a la plataforma y se enviará la información sobre tu progreso en el test al organizador del mismo para que pueda ayudarte si es necesario. Al final del test, sus resultados se enviarán automáticamente al organizador.",
         "title": "Empieza tu test Pix",
         "title-with-username": "'<span>'¿{userFirstName}'</span>','<br>' Listo para evaluar tus habilidades?"

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -602,6 +602,7 @@
           "description": "Vous serez amené à effectuer des recherches sur internet, utiliser votre environnement numérique de travail, tester vos connaissances, etc.",
           "title": "Mesurer vos compétences numériques avec des défis ludiques et apprenants qui s'adaptent à votre niveau de maîtrise (via un algorithme adaptatif)."
         },
+        "exam-notice": "Lors de ce parcours, votre profil de compétences ne sera pas pris en compte, ni modifié. Vos réponses n'auront pas d'impact sur vos niveaux, ni sur votre score Pix global.",
         "legal": "En cliquant sur “Je commence”, les informations relatives à votre avancée dans le parcours seront transmises à l’organisateur du parcours pour lui permettre de vous accompagner. À la fin du parcours, vos résultats seront transmis automatiquement à l’organisateur.",
         "title": "Commencez votre parcours Pix",
         "title-with-username": "'<span>'{userFirstName}'</span>','<br>' prêt à évaluer vos compétences numériques ?"

--- a/mon-pix/translations/it.json
+++ b/mon-pix/translations/it.json
@@ -602,6 +602,7 @@
           "description": "Dovrete effettuare ricerche su Internet, utilizzare il vostro ambiente di lavoro digitale, testare le vostre conoscenze, ecc.",
           "title": "Misurate le vostre competenze digitali con sfide di apprendimento divertenti che si adattano al vostro livello di competenza (utilizzando un algoritmo adattivo)."
         },
+        "exam-notice": "Durante questo percorso, il Suo profilo di competenze non verrà preso in considerazione né modificato. Le Sue risposte non avranno alcun impatto sui Suoi livelli di competenze né sul Suo punteggio globale Pix.",
         "legal": "Cliccando su \"Sto iniziando\", le informazioni sui vostri progressi nel corso saranno inviate all'organizzatore del corso in modo che possa supportarvi. Al termine del corso, i risultati saranno inviati automaticamente all'organizzatore.",
         "title": "Inizia il tuo viaggio Pix",
         "title-with-username": "'<span>'{userFirstName}'</span>','<br>' pronti a valutare le vostre competenze digitali?"

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -602,6 +602,7 @@
           "description": "Je zult internetopzoekingen moeten doen, je digitale werkomgeving moeten gebruiken, je kennis moeten testen, enz.",
           "title": "Meet je digitale vaardigheden met leuke leeruitdagingen die zich aanpassen aan je vaardigheidsniveau (met behulp van een adaptief algoritme)."
         },
+        "exam-notice": "Tijdens dit test wordt je vaardigheidsprofiel niet in aanmerking genomen of gewijzigd. Je antwoorden hebben geen invloed op je huidige niveaus, noch op je globale Pix-score.",
         "legal": "Door op \"Ik begin\" te klikken, wordt informatie over je voortgang tijdens de cursus naar de cursusorganisator gestuurd zodat zij je kunnen ondersteunen. Aan het einde van je test worden je resultaten automatisch gedeeld met je organisatie.",
         "title": "Begin je Pix-reis",
         "title-with-username": "'<span>'{userFirstName}'</span>','<br>' ben je klaar om je vaardigheden te testen?"


### PR DESCRIPTION
## 🥀 Problème

En démarrant un parcours en mode interro sans avoir l’information que le fonctionnement est différent d’un parcours d’évaluation classique, les prescrits risquent de s’inquiéter de ne pas voir leur progression prise en compte. (aka écrire en panique à leur prescripteur ou au support)

## 🏹 Proposition

On propose d’ajouter la mention suivante sur la page de début de campagne type EXAM/ mode interro avant le bouton “Je commence” : 

> Lors de ce parcours, votre profil de compétences ne sera pas pris en compte, ni modifié. Vos réponses n'auront pas d'impact sur vos niveaux, ni sur votre score Pix global.


## 💌 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## ❤️‍🔥 Pour tester
- Démarrer une campagne de type EXAM
- Voir le wording
