### PR TITLE
[BUGFIX] Ne pas arrêter le polling vers le endpoint de supervision de session sur l'espace surveillant lorsque il y a des erreurs sur les appels (PIX-21732)

### DIFF
--- a/certif/app/routes/session-supervising.js
+++ b/certif/app/routes/session-supervising.js
@@ -21,12 +21,13 @@ export default class SessionSupervisingRoute extends Route {
       try {
         await this.store.queryRecord('session-for-supervising', { sessionId: model.id });
       } catch (response) {
-        this.#stopPolling();
         if (response?.errors?.[0]?.status === '401') {
+          this.#stopPolling();
           this.router.replaceWith('login-session-invigilator');
         }
 
         if (response.message === NO_INTERNET_MESSAGE) {
+          this.#stopPolling();
           this.pixToast.sendErrorNotification({
             message: this.intl.t('pages.session-supervising-error.no-internet-error'),
           });


### PR DESCRIPTION
## 🥀 Problème

Dans le code, lorsque l'appel vers sessions/:id/supervising est en erreur, le polling est interrompu mais n'est jamais repris, en particulier lorsque les erreurs se sont pas du fait de l'utilisateur (API qui rame etc...)

## 🏹 Proposition

Interrompre le polling seulement dans les cas pertinents, à savoir :
- Lorsque l'utilisateur n 'est pas authentifié et est redirigé
- Lorsque l'utilisateur ne semble pas avoir de connexion internet

## 💌 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## ❤️‍🔥 Pour tester
On l'a fait !

on s'est connecté sur l'espace surveillant, observer le polling, couper l'api, observer les erreurs de polling, relancer api, constater les appels verts de polling
