### PR TITLE
[FEATURE] Supprimer le wording bêta des campagne de type exam (PIX-21658)

### DIFF
--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -296,7 +296,7 @@
         "ASSESSMENT": "Campaign of type assessment",
         "CAMPAIGN": "Campaign of type assessment",
         "COMBINED_COURSE": "Learning program",
-        "EXAM": "Exam mode [beta]",
+        "EXAM": "Exam mode",
         "FORMATION": "Training",
         "MODULE": "Module",
         "PROFILES_COLLECTION": "Campaign of type profiles collection"
@@ -305,7 +305,7 @@
         "ASSESSMENT": "Assessment",
         "CAMPAIGN": "Assessment",
         "COMBINED_COURSE": "Learning program",
-        "EXAM": "Exam mode [beta]",
+        "EXAM": "Exam mode",
         "FORMATION": "Training",
         "MODULE": "Module",
         "PROFILES_COLLECTION": "Profiles collection"
@@ -811,7 +811,7 @@
         "assessment": "Assess participants",
         "assessment-info": "An assessment campaign tests participants on specific topics.",
         "combined-course": "Create a combined course",
-        "exam": "Exam mode [beta]",
+        "exam": "Exam mode",
         "exam-info": "A ‘exam mode’ campaign enables participants to be tested on specific topics, without taking their user profile into account or having any impact on it. The campaign's questions are personalised for each participant, depending on how far they have progressed along the route.",
         "label": "What is the purpose of your campaign?",
         "profiles-collection": "Collect the participants' Pix profiles",
@@ -934,7 +934,7 @@
       },
       "campaign-type": {
         "assessment": "Assessment campaign",
-        "exam": "Questioning campaign [beta]",
+        "exam": "Questioning campaign",
         "profiles-collection": "Profiles collection campaign",
         "title": "Type of campaign"
       },

--- a/orga/translations/es.json
+++ b/orga/translations/es.json
@@ -296,7 +296,7 @@
         "ASSESSMENT": "Campaña de evaluación",
         "CAMPAIGN": "Campaña de evaluación",
         "COMBINED_COURSE": "Ruta de aprendizaje",
-        "EXAM": "Modo de consulta [beta]",
+        "EXAM": "Modo de consulta",
         "FORMATION": "Formación",
         "MODULE": "Módulo",
         "PROFILES_COLLECTION": "Campaña de recogida de perfiles"
@@ -305,7 +305,7 @@
         "ASSESSMENT": "Evaluación",
         "CAMPAIGN": "Evaluación",
         "COMBINED_COURSE": "Ruta de aprendizaje",
-        "EXAM": "Modo de consulta [beta]",
+        "EXAM": "Modo de consulta",
         "FORMATION": "Formación",
         "MODULE": "Módulo",
         "PROFILES_COLLECTION": "Colección de perfiles"
@@ -799,7 +799,7 @@
         "assessment": "Evaluación de los participantes",
         "assessment-info": "Una campaña de evaluación permite poner a prueba a los participantes sobre temas concretos.",
         "combined-course": "Crear una ruta combinada",
-        "exam": "Modo de consulta [beta]",
+        "exam": "Modo de consulta",
         "exam-info": "Una campaña en \"modo test\" permite examinar a los participantes sobre temas específicos, sin tener en cuenta su perfil de usuario ni influir en él. Los tests propuestos son personalizados para cada participante, en función de lo avanzado que esté en el curso.",
         "label": "¿Cuál es el objetivo de su campaña?",
         "profiles-collection": "Recoger los perfiles Pix de los participantes",
@@ -922,7 +922,7 @@
       },
       "campaign-type": {
         "assessment": "Campaña de evaluación",
-        "exam": "Campaña de concursos [beta]",
+        "exam": "Campaña de concursos",
         "profiles-collection": "Campaña de recogida de perfiles",
         "title": "Tipo de campaña"
       },

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -296,7 +296,7 @@
         "ASSESSMENT": "Campagne d'évaluation",
         "CAMPAIGN": "Campagne d'évaluation",
         "COMBINED_COURSE": "Parcours apprenant",
-        "EXAM": "Mode interro [bêta]",
+        "EXAM": "Mode interro",
         "FORMATION": "Formation",
         "MODULE": "Module",
         "PROFILES_COLLECTION": "Campagne de collecte de profil"
@@ -305,7 +305,7 @@
         "ASSESSMENT": "Évaluation",
         "CAMPAIGN": "Évaluation",
         "COMBINED_COURSE": "Parcours apprenant",
-        "EXAM": "Mode interro [bêta]",
+        "EXAM": "Mode interro",
         "FORMATION": "Formation",
         "MODULE": "Module",
         "PROFILES_COLLECTION": "Collecte de profil"
@@ -799,7 +799,7 @@
         "assessment": "Évaluer les participants",
         "assessment-info": "Une campagne d’évaluation permet de tester les participants sur des sujets précis.",
         "combined-course": "Créer un parcours combiné",
-        "exam": "Mode interro [bêta]",
+        "exam": "Mode interro",
         "exam-info": "Une campagne de type “mode interro” permet de tester les participants sur des sujets précis, sans prendre en compte le profil utilisateur, et sans impacter celui-ci. Les épreuves proposées sont personnalisées pour chaque participant selon son avancement dans le parcours.",
         "label": "Quel est l'objectif de votre campagne ?",
         "profiles-collection": "Collecter les profils Pix des participants",
@@ -922,7 +922,7 @@
       },
       "campaign-type": {
         "assessment": "Campagne d'évaluation",
-        "exam": "Campagne d'interro [bêta]",
+        "exam": "Campagne d'interro",
         "profiles-collection": "Campagne de collecte de profils",
         "title": "Type de la campagne"
       },

--- a/orga/translations/it.json
+++ b/orga/translations/it.json
@@ -296,7 +296,7 @@
         "ASSESSMENT": "Campagna di valutazione",
         "CAMPAIGN": "Campagna di valutazione",
         "COMBINED_COURSE": "Percorso di apprendimento",
-        "EXAM": "Modalità di interrogazione [beta]",
+        "EXAM": "Modalità di interrogazione",
         "FORMATION": "Formazione",
         "MODULE": "Modulo",
         "PROFILES_COLLECTION": "Campagna di raccolta profili"
@@ -305,7 +305,7 @@
         "ASSESSMENT": "Valutazione",
         "CAMPAIGN": "Valutazione",
         "COMBINED_COURSE": "Percorso di apprendimento",
-        "EXAM": "Modalità di interrogazione [beta]",
+        "EXAM": "Modalità di interrogazione",
         "FORMATION": "Formazione",
         "MODULE": "Modulo",
         "PROFILES_COLLECTION": "Collezione di profili"
@@ -799,7 +799,7 @@
         "assessment": "Valutazione dei partecipanti",
         "assessment-info": "Una campagna di valutazione consente ai partecipanti di essere testati su argomenti specifici.",
         "combined-course": "Creare un percorso combinato",
-        "exam": "Modalità di interrogazione [beta]",
+        "exam": "Modalità di interrogazione",
         "exam-info": "Una campagna in \"modalità quiz\" consente di sottoporre i partecipanti a test su argomenti specifici, senza tenere conto del loro profilo utente e senza influire su di esso. I test proposti sono personalizzati per ogni partecipante, a seconda del livello di avanzamento del corso.",
         "label": "Qual è l'obiettivo della vostra campagna?",
         "profiles-collection": "Raccogliere i profili Pix dei partecipanti",
@@ -922,7 +922,7 @@
       },
       "campaign-type": {
         "assessment": "Campagna di valutazione",
-        "exam": "Campagna Quiz [beta]",
+        "exam": "Campagna Quiz",
         "profiles-collection": "Campagna di raccolta profili",
         "title": "Tipo di campagna"
       },

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -296,7 +296,7 @@
       "explanation": {
         "ASSESSMENT": "Beoordelingscampagne",
         "COMBINED_COURSE": "Leerprogramma",
-        "EXAM": "Vraagmodus [beta]",
+        "EXAM": "Vraagmodus",
         "FORMATION": "Training",
         "MODULE": "Module",
         "PROFILES_COLLECTION": "Campagne profielenverzameling"
@@ -304,7 +304,7 @@
       "information": {
         "ASSESSMENT": "Beoordeling",
         "COMBINED_COURSE": "Leerprogramma",
-        "EXAM": "Vraagmodus [beta]",
+        "EXAM": "Vraagmodus",
         "FORMATION": "Training",
         "MODULE": "Module",
         "PROFILES_COLLECTION": "Profielverzameling"
@@ -798,7 +798,7 @@
         "assessment": "Deelnemers evalueren",
         "assessment-info": "Een beoordelingscampagne stelt deelnemers in staat om getest te worden op specifieke onderwerpen.",
         "combined-course": "Maak een gecombineerde cursus",
-        "exam": "Vraagmodus [beta]",
+        "exam": "Vraagmodus",
         "exam-info": "Met een campagne in de “quizmodus” kunnen deelnemers worden getest op specifieke onderwerpen, zonder rekening te houden met hun gebruikersprofiel of er invloed op te hebben. De aangeboden tests zijn gepersonaliseerd voor elke deelnemer, afhankelijk van hoe ver ze gevorderd zijn in het traject.",
         "label": "Wat is het doel van je campagne?",
         "profiles-collection": "Pix-profielen van deelnemers verzamelen",
@@ -921,7 +921,7 @@
       },
       "campaign-type": {
         "assessment": "Beoordelingscampagne",
-        "exam": "Quiz-campagne[beta]",
+        "exam": "Quiz-campagne",
         "profiles-collection": "Verzamelcampagne profielen",
         "title": "Soort campagne"
       },


### PR DESCRIPTION
## 🥀 Problème
Dans le formulaire de création de campagne, le mode interro est indiqué comme étant en mode bêta. 

## 🏹 Proposition
Supprimer le wording `beta`

## 💌 Remarques


## ❤️‍🔥 Pour tester
Sur PixOrga

- Créer une campagne dans l'orga PRO CLASSIC
- ne plus voir la mention béta dans le radio ni dans le texte d'info à droite

Participer à une campgne de type EXAM

Sur la liste des campagnes
- ne plus voir la mention beta dans le title du picto exam

Sur la page des participation d'un learner
- ne plus voir la mention béta à coté du picto mode interro 



