### PR TITLE
[FEATURE] Ne pas calculer les levelup en mode exam (PIX-21731)

### DIFF
--- a/api/src/evaluation/domain/usecases/save-and-correct-answer-for-campaign.js
+++ b/api/src/evaluation/domain/usecases/save-and-correct-answer-for-campaign.js
@@ -78,18 +78,21 @@ const saveAndCorrectAnswerForCampaign = withTransaction(async function ({
       knowledgeElements: knowledgeElementsToAdd,
       campaignParticipationId: assessment.campaignParticipationId,
     });
-    answerSaved.levelup = await computeLevelUpInformation({
-      answerSaved,
-      userId,
-      competenceId: challenge.competenceId,
-      locale,
-      knowledgeElementsBefore,
-      knowledgeElementsAdded: knowledgeElementsToAdd,
-      scorecardService,
-      areaRepository,
-      competenceRepository,
-      competenceEvaluationRepository,
-    });
+    answerSaved.levelup = {};
+    if (!campaign.isExam) {
+      answerSaved.levelup = await computeLevelUpInformation({
+        answerSaved,
+        userId,
+        competenceId: challenge.competenceId,
+        locale,
+        knowledgeElementsBefore,
+        knowledgeElementsAdded: knowledgeElementsToAdd,
+        scorecardService,
+        areaRepository,
+        competenceRepository,
+        competenceEvaluationRepository,
+      });
+    }
   }
 
   if (userId) {

--- a/api/tests/evaluation/integration/domain/usecases/save-and-correct-answer-for-campaign_test.js
+++ b/api/tests/evaluation/integration/domain/usecases/save-and-correct-answer-for-campaign_test.js
@@ -341,11 +341,7 @@ describe('Evaluation | Integration | Usecase | Save and correct answer for campa
       sinon.assert.match(savedAnswer, {
         id: sinon.match.number,
         result: AnswerStatus.OK,
-        levelup: {
-          id: savedAnswer.id,
-          competenceName: 'nom de la compétence',
-          level: 3,
-        },
+        levelup: {},
       });
       expect(savedAnswer).to.be.instanceOf(Answer);
     });


### PR DESCRIPTION
## 🥀 Problème
En mode interro l’URL affiche le token de levelUP alors qu’on ne gagne pas de niveau dans ce mode.
<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

## 🏹 Proposition
Soit ne pas calculer le levelUp, pour ne pas l’afficher dans l’URL.
<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 💌 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## ❤️‍🔥 Pour tester
Creer 2 campagnes avec le même PC 
- une campagne exam
- une campagne d'eval

Se connecter avec orga-member et faire la campagne d'eval 
- voir la montée de niveau

Se connecter avec admin-member et faire la campagne exam
- ne pas voir les infos de levelup dans l'url

<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
