### PR TITLE
[BUGFIX] Corrige un bug empêchant de créer des parcours combiné avec deux campagnes depuis PixOrga (PIX-21738).

### DIFF
--- a/api/src/quest/domain/usecases/create-combined-course.js
+++ b/api/src/quest/domain/usecases/create-combined-course.js
@@ -33,7 +33,7 @@ export const createCombinedCourse = async ({
   const targetProfiles = await targetProfileRepository.findByIds({ ids: targetProfileIds });
   const campaignsToCreate = [];
   const recommendableModules = await recommendedModuleRepository.findIdsByTargetProfileIds({
-    targetProfileIds: [targetProfileIds],
+    targetProfileIds,
   });
 
   for (const targetProfile of targetProfiles) {
@@ -42,7 +42,9 @@ export const createCombinedCourse = async ({
       targetProfile,
       creatorId,
       combinedCourseCode,
-      recommendableModules,
+      recommendableModules: recommendableModules.filter((recommendableModule) =>
+        recommendableModule.targetProfileIds.includes(targetProfile.id),
+      ),
       modules,
     });
     campaignsToCreate.push(campaignForCombinedCourse);

--- a/api/tests/quest/integration/domain/usecases/create-combined-course_test.js
+++ b/api/tests/quest/integration/domain/usecases/create-combined-course_test.js
@@ -13,9 +13,9 @@ describe('Integration | Combined course | Domain | UseCases | create-combined-co
     const userId = databaseBuilder.factory.buildUser().id;
     const organizationId = databaseBuilder.factory.buildOrganization().id;
 
-    const targetProfile = databaseBuilder.factory.buildTargetProfile();
-
     const targetProfileWithTraining = databaseBuilder.factory.buildTargetProfile();
+    const otherTargetProfile = databaseBuilder.factory.buildTargetProfile();
+
     const trainingId = databaseBuilder.factory.buildTraining({
       type: 'modulix',
       title: 'Demo combinix 1',
@@ -34,9 +34,10 @@ describe('Integration | Combined course | Domain | UseCases | create-combined-co
       illustration,
     } = databaseBuilder.factory.buildCombinedCourseBlueprint({
       content: [
-        { type: 'evaluation', value: targetProfile.id },
+        { type: 'evaluation', value: targetProfileWithTraining.id },
         { type: 'module', value: '27d6ca4f' },
         { type: 'module', value: 'df82ec66' },
+        { type: 'evaluation', value: otherTargetProfile.id },
       ],
     });
 
@@ -52,9 +53,9 @@ describe('Integration | Combined course | Domain | UseCases | create-combined-co
       organizationId,
     });
 
-    const [createdCampaign] = await knex('campaigns')
+    const campaigns = await knex('campaigns')
       .where({ organizationId })
-      .whereIn('targetProfileId', [targetProfile.id, targetProfileWithTraining.id])
+      .whereIn('targetProfileId', [otherTargetProfile.id, targetProfileWithTraining.id])
       .orderBy('id');
 
     const expectedModules = [
@@ -100,7 +101,7 @@ describe('Integration | Combined course | Domain | UseCases | create-combined-co
           comparison: REQUIREMENT_COMPARISONS.ALL,
           data: {
             campaignId: {
-              data: createdCampaign.id,
+              data: campaigns[0].id,
               comparison: CRITERION_COMPARISONS.EQUAL,
             },
             status: {
@@ -110,6 +111,20 @@ describe('Integration | Combined course | Domain | UseCases | create-combined-co
           },
         },
         ...expectedModules,
+        {
+          requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
+          comparison: REQUIREMENT_COMPARISONS.ALL,
+          data: {
+            campaignId: {
+              data: campaigns[1].id,
+              comparison: CRITERION_COMPARISONS.EQUAL,
+            },
+            status: {
+              data: CampaignParticipationStatuses.SHARED,
+              comparison: CRITERION_COMPARISONS.EQUAL,
+            },
+          },
+        },
       ],
       description,
       illustration,
@@ -130,9 +145,14 @@ describe('Integration | Combined course | Domain | UseCases | create-combined-co
     expect(createdQuest.illustration).to.equal(expectedCreatedQuest.illustration);
 
     //Campaign 1
-    expect(createdCampaign.name).to.equal(targetProfile.internalName);
-    expect(createdCampaign.title).to.equal(targetProfile.name);
-    expect(createdCampaign.customResultPageButtonUrl.includes('/chargement')).false;
-    expect(createdCampaign.customResultPageButtonText).to.equal('Continuer');
+    expect(campaigns[0].name).to.equal(targetProfileWithTraining.internalName);
+    expect(campaigns[0].title).to.equal(targetProfileWithTraining.name);
+    expect(campaigns[0].customResultPageButtonUrl.includes('/chargement')).true;
+    expect(campaigns[0].customResultPageButtonText).to.equal('Continuer');
+
+    expect(campaigns[1].name).to.equal(otherTargetProfile.internalName);
+    expect(campaigns[1].title).to.equal(otherTargetProfile.name);
+    expect(campaigns[1].customResultPageButtonUrl.includes('/chargement')).false;
+    expect(campaigns[1].customResultPageButtonText).to.equal('Continuer');
   });
 });


### PR DESCRIPTION
## 🥀 Problème

En utilisant un schéma de parcours combiné contenant deux campagnes, la création de parcours combiné produit une erreur 500. Il s'avère qu'on passe un tableau de tableau d'id de profil cibles qui re respecte pas la signature de l'API interne.

## 🏹 Proposition

Corriger l'appel de la méthode.

## 💌 Remarques

Au passage, il y avait un second bug qui faisait que toutes les campagnes présentes dans le parcours combiné passait par l'écran de chargement de fin de diagnostique si un diagnostique était présent dans le schéma. On filtre maintenant correctement au moment de la création de la campagne.

## ❤️‍🔥 Pour tester
- Créer un parcours combiné à partir d'un schéma contenant au moins deux campagnes
- Créer un parcours combiné à partir d'un schéma contenant une campagne de diagnostique (avec un module recommandable) et une campagne d'évaluation. Vérifier qu'à la fin de la campagne de diagnostique on a bien l'écran de chargement et vérifier qu'à la fin de la campagne d'évaluation on est bien redirigé vers la page principale du parcours combiné.