### PR TITLE
[TECH] Envoie les jobs asynchrones après le succès de la transaction

### DIFF
--- a/api/src/certification/evaluation/domain/usecases/complete-certification-assessment.js
+++ b/api/src/certification/evaluation/domain/usecases/complete-certification-assessment.js
@@ -1,3 +1,4 @@
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { CertificationCompletedJob } from '../events/CertificationCompleted.js';
 
@@ -17,11 +18,13 @@ export const completeCertificationAssessment =
     if (assessmentSheet.isStarted) {
       assessmentSheet.complete();
       await assessmentSheetRepository.update(assessmentSheet);
-      await certificationCompletedJobRepository.performAsync(
-        new CertificationCompletedJob({
-          certificationCourseId,
-          locale,
-        }),
-      );
+      await DomainTransaction.addSuccessHandler(async () => {
+        await certificationCompletedJobRepository.performAsync(
+          new CertificationCompletedJob({
+            certificationCourseId,
+            locale,
+          }),
+        );
+      });
     }
   };

--- a/api/src/devcomp/domain/usecases/terminate-passage.js
+++ b/api/src/devcomp/domain/usecases/terminate-passage.js
@@ -1,23 +1,21 @@
-import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../shared/domain/errors.js';
 import { PassageDoesNotExistError, PassageTerminatedError } from '../errors.js';
 
 const terminatePassage = async function ({ passageId, passageRepository, updateCombinedCourseJobRepository }) {
-  const passage = await DomainTransaction.execute(async () => {
-    const passage = await _getPassage({ passageId, passageRepository });
-    if (passage.terminatedAt) {
-      throw new PassageTerminatedError();
-    }
-    passage.terminate();
-    return passageRepository.update({ passage });
-  });
-  if (passage.userId) {
+  const passage = await _getPassage({ passageId, passageRepository });
+  if (passage.terminatedAt) {
+    throw new PassageTerminatedError();
+  }
+  passage.terminate();
+  const terminatedPassage = await passageRepository.update({ passage });
+
+  if (terminatedPassage.userId) {
     await updateCombinedCourseJobRepository.performAsync({
-      userId: passage.userId,
-      moduleId: passage.moduleId,
+      userId: terminatedPassage.userId,
+      moduleId: terminatedPassage.moduleId,
     });
   }
-  return passage;
+  return terminatedPassage;
 };
 
 async function _getPassage({ passageId, passageRepository }) {

--- a/api/src/devcomp/domain/usecases/terminate-passage.js
+++ b/api/src/devcomp/domain/usecases/terminate-passage.js
@@ -1,28 +1,24 @@
-import { withTransaction } from '../../../shared/domain/DomainTransaction.js';
+import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../shared/domain/errors.js';
 import { PassageDoesNotExistError, PassageTerminatedError } from '../errors.js';
 
-const terminatePassage = withTransaction(async function ({
-  passageId,
-  passageRepository,
-  updateCombinedCourseJobRepository,
-}) {
-  const passage = await _getPassage({ passageId, passageRepository });
-  if (passage.terminatedAt) {
-    throw new PassageTerminatedError();
-  }
-  passage.terminate();
-  const terminatedPassage = await passageRepository.update({ passage });
-
+const terminatePassage = async function ({ passageId, passageRepository, updateCombinedCourseJobRepository }) {
+  const passage = await DomainTransaction.execute(async () => {
+    const passage = await _getPassage({ passageId, passageRepository });
+    if (passage.terminatedAt) {
+      throw new PassageTerminatedError();
+    }
+    passage.terminate();
+    return passageRepository.update({ passage });
+  });
   if (passage.userId) {
     await updateCombinedCourseJobRepository.performAsync({
       userId: passage.userId,
       moduleId: passage.moduleId,
     });
   }
-
-  return terminatedPassage;
-});
+  return passage;
+};
 
 async function _getPassage({ passageId, passageRepository }) {
   try {

--- a/api/src/evaluation/domain/usecases/save-and-correct-answer-for-campaign.js
+++ b/api/src/evaluation/domain/usecases/save-and-correct-answer-for-campaign.js
@@ -1,11 +1,11 @@
 import { AnswerJob } from '../../../quest/domain/models/AnwserJob.js';
-import { withTransaction } from '../../../shared/domain/DomainTransaction.js';
+import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { ChallengeAlreadyAnsweredError, ForbiddenAccess } from '../../../shared/domain/errors.js';
 import { ChallengeNotAskedError } from '../../../shared/domain/errors.js';
 import { KnowledgeElement } from '../../../shared/domain/models/KnowledgeElement.js';
 import { EmptyAnswerError } from '../errors.js';
 
-const saveAndCorrectAnswerForCampaign = withTransaction(async function ({
+const saveAndCorrectAnswerForCampaign = async function ({
   answer,
   userId,
   assessment,
@@ -22,85 +22,88 @@ const saveAndCorrectAnswerForCampaign = withTransaction(async function ({
   correctionService,
   campaignRepository,
 } = {}) {
-  if (assessment.userId !== userId) {
-    throw new ForbiddenAccess('User is not allowed to add an answer for this assessment.');
-  }
-  if (!assessment.campaignParticipationId) {
-    throw new ForbiddenAccess('Campaign does not accept any answer.');
-  }
-  if (assessment.answers.some((existingAnswer) => existingAnswer.challengeId === answer.challengeId)) {
-    throw new ChallengeAlreadyAnsweredError();
-  }
-  if (assessment.lastChallengeId && assessment.lastChallengeId !== answer.challengeId) {
-    throw new ChallengeNotAskedError();
-  }
-  if (!answer.hasValue && !answer.hasTimedOut) {
-    throw new EmptyAnswerError();
-  }
+  const savedAnswer = await DomainTransaction.execute(async () => {
+    if (assessment.userId !== userId) {
+      throw new ForbiddenAccess('User is not allowed to add an answer for this assessment.');
+    }
+    if (!assessment.campaignParticipationId) {
+      throw new ForbiddenAccess('Campaign does not accept any answer.');
+    }
+    if (assessment.answers.some((existingAnswer) => existingAnswer.challengeId === answer.challengeId)) {
+      throw new ChallengeAlreadyAnsweredError();
+    }
+    if (assessment.lastChallengeId && assessment.lastChallengeId !== answer.challengeId) {
+      throw new ChallengeNotAskedError();
+    }
+    if (!answer.hasValue && !answer.hasTimedOut) {
+      throw new EmptyAnswerError();
+    }
 
-  const challenge = await challengeRepository.get(answer.challengeId);
-  const correctedAnswer = correctionService.evaluateAnswer({
-    challenge,
-    answer,
-    assessment,
-    accessibilityAdjustmentNeeded: false,
-    forceOKAnswer,
-  });
-  const now = new Date();
-  const lastQuestionDate = assessment.lastQuestionDate || now;
-  correctedAnswer.setTimeSpentFrom({ now, lastQuestionDate });
+    const challenge = await challengeRepository.get(answer.challengeId);
+    const correctedAnswer = correctionService.evaluateAnswer({
+      challenge,
+      answer,
+      assessment,
+      accessibilityAdjustmentNeeded: false,
+      forceOKAnswer,
+    });
+    const now = new Date();
+    const lastQuestionDate = assessment.lastQuestionDate || now;
+    correctedAnswer.setTimeSpentFrom({ now, lastQuestionDate });
 
-  let answerSaved;
-  if (assessment.isSmartRandom()) {
-    const knowledgeElementsBefore =
-      await knowledgeElementForParticipationService.findUniqByUserOrCampaignParticipationId({
-        userId,
+    let answerToBeSaved;
+    if (assessment.isSmartRandom()) {
+      const knowledgeElementsBefore =
+        await knowledgeElementForParticipationService.findUniqByUserOrCampaignParticipationId({
+          userId,
+          campaignParticipationId: assessment.campaignParticipationId,
+        });
+
+      const targetSkills = await campaignRepository.findSkillsByCampaignParticipationId({
         campaignParticipationId: assessment.campaignParticipationId,
       });
-
-    const targetSkills = await campaignRepository.findSkillsByCampaignParticipationId({
-      campaignParticipationId: assessment.campaignParticipationId,
-    });
-    const campaignId = await campaignRepository.getCampaignIdByCampaignParticipationId(
-      assessment.campaignParticipationId,
-    );
-    const campaign = await campaignRepository.get(campaignId);
-    answerSaved = await answerRepository.save({ answer: correctedAnswer });
-    const knowledgeElementsToAdd = computeKnowledgeElements({
-      campaign,
-      assessment,
-      answer: answerSaved,
-      challenge,
-      targetSkills,
-      knowledgeElementsBefore,
-    });
-    await knowledgeElementForParticipationService.save({
-      knowledgeElements: knowledgeElementsToAdd,
-      campaignParticipationId: assessment.campaignParticipationId,
-    });
-    answerSaved.levelup = {};
-    if (!campaign.isExam) {
-      answerSaved.levelup = await computeLevelUpInformation({
-        answerSaved,
-        userId,
-        competenceId: challenge.competenceId,
-        locale,
+      const campaignId = await campaignRepository.getCampaignIdByCampaignParticipationId(
+        assessment.campaignParticipationId,
+      );
+      const campaign = await campaignRepository.get(campaignId);
+      answerToBeSaved = await answerRepository.save({ answer: correctedAnswer });
+      const knowledgeElementsToAdd = computeKnowledgeElements({
+        campaign,
+        assessment,
+        answer: answerToBeSaved,
+        challenge,
+        targetSkills,
         knowledgeElementsBefore,
-        knowledgeElementsAdded: knowledgeElementsToAdd,
-        scorecardService,
-        areaRepository,
-        competenceRepository,
-        competenceEvaluationRepository,
       });
+      await knowledgeElementForParticipationService.save({
+        knowledgeElements: knowledgeElementsToAdd,
+        campaignParticipationId: assessment.campaignParticipationId,
+      });
+      answerToBeSaved.levelup = {};
+      if (!campaign.isExam) {
+        answerToBeSaved.levelup = await computeLevelUpInformation({
+          answerSaved: answerToBeSaved,
+          userId,
+          competenceId: challenge.competenceId,
+          locale,
+          knowledgeElementsBefore,
+          knowledgeElementsAdded: knowledgeElementsToAdd,
+          scorecardService,
+          areaRepository,
+          competenceRepository,
+          competenceEvaluationRepository,
+        });
+      }
+      return answerToBeSaved;
     }
-  }
+  });
 
   if (userId) {
     await answerJobRepository.performAsync(new AnswerJob({ userId }));
   }
 
-  return answerSaved;
-});
+  return savedAnswer;
+};
 
 function computeKnowledgeElements({ campaign, assessment, answer, challenge, targetSkills, knowledgeElementsBefore }) {
   let knowledgeElements;

--- a/api/src/evaluation/domain/usecases/save-and-correct-answer-for-competence-evaluation.js
+++ b/api/src/evaluation/domain/usecases/save-and-correct-answer-for-competence-evaluation.js
@@ -1,5 +1,6 @@
 import { AnswerJob } from '../../../quest/domain/models/AnwserJob.js';
 import { withTransaction } from '../../../shared/domain/DomainTransaction.js';
+import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { ChallengeAlreadyAnsweredError, ForbiddenAccess } from '../../../shared/domain/errors.js';
 import { ChallengeNotAskedError } from '../../../shared/domain/errors.js';
 import { KnowledgeElement } from '../../../shared/domain/models/KnowledgeElement.js';
@@ -22,60 +23,63 @@ const saveAndCorrectAnswerForCompetenceEvaluation = withTransaction(async functi
   knowledgeElementRepository,
   correctionService,
 } = {}) {
-  if (assessment.userId !== userId) {
-    throw new ForbiddenAccess('User is not allowed to add an answer for this assessment.');
-  }
-  if (assessment.answers.some((existingAnswer) => existingAnswer.challengeId === answer.challengeId)) {
-    throw new ChallengeAlreadyAnsweredError();
-  }
-  if (assessment.lastChallengeId && assessment.lastChallengeId !== answer.challengeId) {
-    throw new ChallengeNotAskedError();
-  }
-  if (!answer.hasValue && !answer.hasTimedOut) {
-    throw new EmptyAnswerError();
-  }
+  const savedAnswer = await DomainTransaction.execute(async () => {
+    if (assessment.userId !== userId) {
+      throw new ForbiddenAccess('User is not allowed to add an answer for this assessment.');
+    }
+    if (assessment.answers.some((existingAnswer) => existingAnswer.challengeId === answer.challengeId)) {
+      throw new ChallengeAlreadyAnsweredError();
+    }
+    if (assessment.lastChallengeId && assessment.lastChallengeId !== answer.challengeId) {
+      throw new ChallengeNotAskedError();
+    }
+    if (!answer.hasValue && !answer.hasTimedOut) {
+      throw new EmptyAnswerError();
+    }
 
-  const challenge = await challengeRepository.get(answer.challengeId);
-  const correctedAnswer = correctionService.evaluateAnswer({
-    challenge,
-    answer,
-    assessment,
-    accessibilityAdjustmentNeeded: false,
-    forceOKAnswer,
-  });
-  const now = new Date();
-  const lastQuestionDate = assessment.lastQuestionDate || now;
-  correctedAnswer.setTimeSpentFrom({ now, lastQuestionDate });
+    const challenge = await challengeRepository.get(answer.challengeId);
+    const correctedAnswer = correctionService.evaluateAnswer({
+      challenge,
+      answer,
+      assessment,
+      accessibilityAdjustmentNeeded: false,
+      forceOKAnswer,
+    });
+    const now = new Date();
+    const lastQuestionDate = assessment.lastQuestionDate || now;
+    correctedAnswer.setTimeSpentFrom({ now, lastQuestionDate });
 
-  const targetSkills = await skillRepository.findActiveByCompetenceId(assessment.competenceId);
-  const knowledgeElementsBefore = await knowledgeElementRepository.findUniqByUserId({ userId });
-  const answerSaved = await answerRepository.save({ answer: correctedAnswer });
-  const knowledgeElementsToAdd = computeKnowledgeElements({
-    assessment,
-    answer: answerSaved,
-    challenge,
-    targetSkills,
-    knowledgeElementsBefore,
-  });
-  await knowledgeElementRepository.batchSave({ knowledgeElements: knowledgeElementsToAdd });
-  answerSaved.levelup = await computeLevelUpInformation({
-    answerSaved,
-    userId,
-    competenceId: challenge.competenceId,
-    locale,
-    knowledgeElementsBefore,
-    knowledgeElementsAdded: knowledgeElementsToAdd,
-    scorecardService,
-    areaRepository,
-    competenceRepository,
-    competenceEvaluationRepository,
+    const targetSkills = await skillRepository.findActiveByCompetenceId(assessment.competenceId);
+    const knowledgeElementsBefore = await knowledgeElementRepository.findUniqByUserId({ userId });
+    const answerToBeSaved = await answerRepository.save({ answer: correctedAnswer });
+    const knowledgeElementsToAdd = computeKnowledgeElements({
+      assessment,
+      answer: answerToBeSaved,
+      challenge,
+      targetSkills,
+      knowledgeElementsBefore,
+    });
+    await knowledgeElementRepository.batchSave({ knowledgeElements: knowledgeElementsToAdd });
+    answerToBeSaved.levelup = await computeLevelUpInformation({
+      answerSaved: answerToBeSaved,
+      userId,
+      competenceId: challenge.competenceId,
+      locale,
+      knowledgeElementsBefore,
+      knowledgeElementsAdded: knowledgeElementsToAdd,
+      scorecardService,
+      areaRepository,
+      competenceRepository,
+      competenceEvaluationRepository,
+    });
+    return answerToBeSaved;
   });
 
   if (userId) {
     await answerJobRepository.performAsync(new AnswerJob({ userId }));
   }
 
-  return answerSaved;
+  return savedAnswer;
 });
 
 function computeKnowledgeElements({ assessment, answer, challenge, targetSkills, knowledgeElementsBefore }) {

--- a/api/src/evaluation/infrastructure/repositories/answer-job-repository.js
+++ b/api/src/evaluation/infrastructure/repositories/answer-job-repository.js
@@ -1,5 +1,4 @@
 import { AnswerJob } from '../../../quest/domain/models/AnwserJob.js';
-import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { featureToggles } from '../../../shared/infrastructure/feature-toggles/index.js';
 import { temporaryStorage } from '../../../shared/infrastructure/key-value-storages/index.js';
 import { JobRepository } from '../../../shared/infrastructure/repositories/jobs/job-repository.js';

--- a/api/src/evaluation/infrastructure/repositories/answer-job-repository.js
+++ b/api/src/evaluation/infrastructure/repositories/answer-job-repository.js
@@ -22,17 +22,8 @@ export class AnswerJobRepository extends JobRepository {
     )
       return;
 
-    const knexConn = DomainTransaction.getConnection();
-
-    if (knexConn.isTransaction) {
-      await super.performAsync(job);
-      await this.#profileRewardTemporaryStorage.increment(job.userId);
-    } else {
-      await DomainTransaction.execute(async () => {
-        await super.performAsync(job);
-        await this.#profileRewardTemporaryStorage.increment(job.userId);
-      });
-    }
+    await super.performAsync(job);
+    await this.#profileRewardTemporaryStorage.increment(job.userId);
   }
 }
 

--- a/api/src/identity-access-management/application/anonymization/anonymization.admin.controller.js
+++ b/api/src/identity-access-management/application/anonymization/anonymization.admin.controller.js
@@ -1,4 +1,3 @@
-import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { generateCSVTemplate } from '../../../shared/infrastructure/serializers/csv/csv-template.js';
 import { GarAnonymizationParser } from '../../domain/services/GarAnonymizationParser.js';
 import { usecases } from '../../domain/usecases/index.js';
@@ -17,9 +16,7 @@ async function anonymizeGarData(request, h) {
 
   const userIds = await GarAnonymizationParser.getCsvData(filePath);
 
-  const result = await DomainTransaction.execute(async () => {
-    return await usecases.anonymizeGarAuthenticationMethods({ userIds, adminMemberId });
-  });
+  const result = await usecases.anonymizeGarAuthenticationMethods({ userIds, adminMemberId });
 
   return h.response(anonymizeGarResultSerializer.serialize(result)).code(200);
 }

--- a/api/src/identity-access-management/domain/usecases/anonymize-gar-authentication-methods.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/anonymize-gar-authentication-methods.usecase.js
@@ -2,6 +2,7 @@ import _ from 'lodash';
 
 import { PIX_ADMIN } from '../../../authorization/domain/constants.js';
 import { config } from '../../../shared/config.js';
+import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { EventLoggingJob } from '../../../shared/domain/models/jobs/EventLoggingJob.js';
 
 const USER_IDS_BATCH_SIZE = 1000;
@@ -25,22 +26,28 @@ export const anonymizeGarAuthenticationMethods = async function ({
 
   let garAnonymizedUserCount = 0;
 
-  for (const userIdsBatch of userIdBatches) {
-    const { garAnonymizedUserIds } = await authenticationMethodRepository.anonymizeByUserIds({ userIds: userIdsBatch });
-    garAnonymizedUserCount += garAnonymizedUserIds.length;
-
-    if (config.auditLogger.isEnabled && garAnonymizedUserIds?.length > 0) {
-      await eventLoggingJobRepository.performAsync(
-        EventLoggingJob.forUsers({
-          client: 'PIX_ADMIN',
-          action: 'ANONYMIZATION_GAR',
-          userIds: garAnonymizedUserIds,
-          updatedByUserId: adminMemberId,
-          role: PIX_ADMIN.ROLES.SUPER_ADMIN,
-        }),
-      );
+  const eventLoggingJobs = [];
+  await DomainTransaction.execute(async () => {
+    for (const userIdsBatch of userIdBatches) {
+      const { garAnonymizedUserIds } = await authenticationMethodRepository.anonymizeByUserIds({
+        userIds: userIdsBatch,
+      });
+      garAnonymizedUserCount += garAnonymizedUserIds.length;
+      if (config.auditLogger.isEnabled && garAnonymizedUserIds?.length > 0) {
+        eventLoggingJobs.push(
+          EventLoggingJob.forUsers({
+            client: 'PIX_ADMIN',
+            action: 'ANONYMIZATION_GAR',
+            userIds: garAnonymizedUserIds,
+            updatedByUserId: adminMemberId,
+            role: PIX_ADMIN.ROLES.SUPER_ADMIN,
+          }),
+        );
+      }
     }
+  });
+  for (const eventLoggingJob of eventLoggingJobs) {
+    await eventLoggingJobRepository.performAsync(eventLoggingJob);
   }
-
   return { garAnonymizedUserCount, total: userIds.length };
 };

--- a/api/src/identity-access-management/domain/usecases/create-user.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/create-user.usecase.js
@@ -1,4 +1,4 @@
-import { withTransaction } from '../../../shared/domain/DomainTransaction.js';
+import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { EntityValidationError } from '../../../shared/domain/errors.js';
 import { createAccountCreationEmail } from '../emails/create-account-creation.email.js';
 import { InvalidOrAlreadyUsedEmailError } from '../errors.js';
@@ -20,7 +20,7 @@ import { InvalidOrAlreadyUsedEmailError } from '../errors.js';
  * @property {import('../../../shared/domain/validators').PasswordValidator} passwordValidator
  * @return {Promise<User|undefined>}
  */
-const createUser = withTransaction(async function ({
+const createUser = async function ({
   locale,
   password,
   user,
@@ -42,7 +42,6 @@ const createUser = withTransaction(async function ({
     userValidator,
     passwordValidator,
   });
-
   const userHasValidatedPixTermsOfService = user.cgu === true;
   if (userHasValidatedPixTermsOfService) {
     user.lastTermsOfServiceValidatedAt = new Date();
@@ -50,15 +49,19 @@ const createUser = withTransaction(async function ({
 
   const hashedPassword = await cryptoService.hashPassword(password);
 
-  const savedUser = await userService.createUserWithPassword({
-    user,
-    locale,
-    hashedPassword,
-    userToCreateRepository,
-    authenticationMethodRepository,
-  });
+  const { savedUser, token } = await DomainTransaction.execute(async () => {
+    const savedUser = await userService.createUserWithPassword({
+      user,
+      locale,
+      hashedPassword,
+      userToCreateRepository,
+      authenticationMethodRepository,
+    });
 
-  const token = await emailValidationDemandRepository.save(savedUser.id);
+    const token = await emailValidationDemandRepository.save(savedUser.id);
+
+    return { savedUser, token };
+  });
 
   await emailRepository.sendEmailAsync(
     createAccountCreationEmail({
@@ -71,7 +74,7 @@ const createUser = withTransaction(async function ({
   );
 
   return savedUser;
-});
+};
 
 export { createUser };
 

--- a/api/src/identity-access-management/domain/usecases/upgrade-to-real-user.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/upgrade-to-real-user.usecase.js
@@ -1,11 +1,11 @@
 import { AlreadyRegisteredEmailError } from '../../../../src/shared/domain/errors.js';
 import { UnauthorizedError } from '../../../shared/application/http-errors.js';
-import { withTransaction } from '../../../shared/domain/DomainTransaction.js';
+import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { NON_OIDC_IDENTITY_PROVIDERS } from '../constants/identity-providers.js';
 import { createAccountCreationEmail } from '../emails/create-account-creation.email.js';
 import { AuthenticationMethod } from '../models/AuthenticationMethod.js';
 
-const upgradeToRealUser = withTransaction(async function ({
+const upgradeToRealUser = async function ({
   userId,
   userAttributes,
   password,
@@ -33,21 +33,26 @@ const upgradeToRealUser = withTransaction(async function ({
     throw new UnauthorizedError('Anonymous token is invalid', 'INVALID_ANONYMOUS_TOKEN');
   }
 
-  const realUser = anonymousUser.convertAnonymousToRealUser(userAttributes);
-  await userRepository.update(realUser.mapToDatabaseDto());
+  const { realUser, token } = await DomainTransaction.execute(async () => {
+    const realUser = anonymousUser.convertAnonymousToRealUser(userAttributes);
+    await userRepository.update(realUser.mapToDatabaseDto());
 
-  const hashedPassword = await cryptoService.hashPassword(password);
-  const authenticationMethod = new AuthenticationMethod({
-    userId,
-    identityProvider: NON_OIDC_IDENTITY_PROVIDERS.PIX.code,
-    authenticationComplement: new AuthenticationMethod.PixAuthenticationComplement({
-      password: hashedPassword,
-      shouldChangePassword: false,
-    }),
+    const hashedPassword = await cryptoService.hashPassword(password);
+    const authenticationMethod = new AuthenticationMethod({
+      userId,
+      identityProvider: NON_OIDC_IDENTITY_PROVIDERS.PIX.code,
+      authenticationComplement: new AuthenticationMethod.PixAuthenticationComplement({
+        password: hashedPassword,
+        shouldChangePassword: false,
+      }),
+    });
+    await authenticationMethodRepository.create({ authenticationMethod });
+
+    const token = await emailValidationDemandRepository.save(realUser.id);
+
+    return { realUser, token };
   });
-  await authenticationMethodRepository.create({ authenticationMethod });
 
-  const token = await emailValidationDemandRepository.save(realUser.id);
   await emailRepository.sendEmailAsync(
     createAccountCreationEmail({
       locale,
@@ -57,6 +62,6 @@ const upgradeToRealUser = withTransaction(async function ({
     }),
   );
   return realUser;
-});
+};
 
 export { upgradeToRealUser };

--- a/api/src/prescription/campaign-participation/domain/usecases/delete-campaign-participation.js
+++ b/api/src/prescription/campaign-participation/domain/usecases/delete-campaign-participation.js
@@ -1,7 +1,7 @@
-import { withTransaction } from '../../../../shared/domain/DomainTransaction.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { EventLoggingJob } from '../../../../shared/domain/models/jobs/EventLoggingJob.js';
 
-const deleteCampaignParticipation = withTransaction(async function ({
+const deleteCampaignParticipation = async function ({
   userId,
   campaignId,
   campaignParticipationId,
@@ -21,32 +21,40 @@ const deleteCampaignParticipation = withTransaction(async function ({
       keepPreviousDeleted,
     });
 
-  for (const campaignParticipation of campaignParticipations) {
-    campaignParticipation.delete(userId);
-    await campaignParticipationRepository.remove(campaignParticipation.dataToUpdateOnDeletion);
+  const eventLoggingJobs = [];
 
-    await eventLoggingJobRepository.performAsync(
-      EventLoggingJob.forUser({
-        client,
-        action: campaignParticipation.loggerContext,
-        role: userRole,
-        userId: campaignParticipation.id,
-        updatedByUserId: userId,
-        data: {},
-      }),
+  await DomainTransaction.execute(async () => {
+    for (const campaignParticipation of campaignParticipations) {
+      campaignParticipation.delete(userId);
+      await campaignParticipationRepository.remove(campaignParticipation.dataToUpdateOnDeletion);
+
+      eventLoggingJobs.push(
+        EventLoggingJob.forUser({
+          client,
+          action: campaignParticipation.loggerContext,
+          role: userRole,
+          userId: campaignParticipation.id,
+          updatedByUserId: userId,
+          data: {},
+        }),
+      );
+    }
+    const campaignParticipationIds = campaignParticipations.map(({ id }) => id);
+    await badgeAcquisitionRepository.deleteUserIdOnNonCertifiableBadgesForCampaignParticipations(
+      campaignParticipationIds,
     );
-  }
-  const campaignParticipationIds = campaignParticipations.map(({ id }) => id);
-  await badgeAcquisitionRepository.deleteUserIdOnNonCertifiableBadgesForCampaignParticipations(
-    campaignParticipationIds,
-  );
-  await userRecommendedTrainingRepository.deleteCampaignParticipationIds({ campaignParticipationIds });
+    await userRecommendedTrainingRepository.deleteCampaignParticipationIds({ campaignParticipationIds });
 
-  const assessments = await assessmentRepository.getByCampaignParticipationIds(campaignParticipationIds);
-  for (const assessment of assessments) {
-    assessment.detachCampaignParticipation();
-    await assessmentRepository.updateCampaignParticipationId(assessment);
+    const assessments = await assessmentRepository.getByCampaignParticipationIds(campaignParticipationIds);
+    for (const assessment of assessments) {
+      assessment.detachCampaignParticipation();
+      await assessmentRepository.updateCampaignParticipationId(assessment);
+    }
+  });
+
+  for (const eventLoggingJob of eventLoggingJobs) {
+    await eventLoggingJobRepository.performAsync(eventLoggingJob);
   }
-});
+};
 
 export { deleteCampaignParticipation };

--- a/api/src/prescription/campaign-participation/domain/usecases/start-campaign-participation.js
+++ b/api/src/prescription/campaign-participation/domain/usecases/start-campaign-participation.js
@@ -1,29 +1,29 @@
-import { withTransaction } from '../../../../shared/domain/DomainTransaction.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { KnowledgeElement } from '../../../../shared/domain/models/KnowledgeElement.js';
 import { ParticipationStartedJob } from '../models/ParticipationStartedJob.js';
 
-export const startCampaignParticipation = withTransaction(
-  async ({
-    campaignParticipation,
+export const startCampaignParticipation = async ({
+  campaignParticipation,
+  userId,
+  campaignRepository,
+  assessmentRepository,
+  knowledgeElementRepository,
+  campaignParticipantRepository,
+  campaignParticipationRepository,
+  competenceEvaluationRepository,
+  participationStartedJobRepository,
+}) => {
+  const campaignParticipant = await campaignParticipantRepository.get({
     userId,
-    campaignRepository,
-    assessmentRepository,
-    knowledgeElementRepository,
-    campaignParticipantRepository,
-    campaignParticipationRepository,
-    competenceEvaluationRepository,
-    participationStartedJobRepository,
-  }) => {
-    const campaignParticipant = await campaignParticipantRepository.get({
-      userId,
-      campaignId: campaignParticipation.campaignId,
-    });
+    campaignId: campaignParticipation.campaignId,
+  });
 
-    campaignParticipant.start({
-      participantExternalId: campaignParticipation.participantExternalId,
-      isReset: campaignParticipation.isReset,
-    });
+  campaignParticipant.start({
+    participantExternalId: campaignParticipation.participantExternalId,
+    isReset: campaignParticipation.isReset,
+  });
 
+  const createdCampaignParticipation = await DomainTransaction.execute(async () => {
     const campaignParticipationId = await campaignParticipantRepository.save({ campaignParticipant });
 
     const createdCampaignParticipation = await campaignParticipationRepository.get(campaignParticipationId);
@@ -42,13 +42,16 @@ export const startCampaignParticipation = withTransaction(
         knowledgeElementRepository,
       });
     }
+    return createdCampaignParticipation;
+  });
 
-    await participationStartedJobRepository.performAsync(new ParticipationStartedJob({ campaignParticipationId }));
-    return {
-      campaignParticipation: createdCampaignParticipation,
-    };
-  },
-);
+  await participationStartedJobRepository.performAsync(
+    new ParticipationStartedJob({ campaignParticipationId: createdCampaignParticipation.id }),
+  );
+  return {
+    campaignParticipation: createdCampaignParticipation,
+  };
+};
 
 async function _resetCampaignParticipation({
   campaignParticipation,

--- a/api/src/prescription/campaign/domain/usecases/delete-campaigns.js
+++ b/api/src/prescription/campaign/domain/usecases/delete-campaigns.js
@@ -1,65 +1,67 @@
 import { CLIENTS, PIX_ORGA } from '../../../../authorization/domain/constants.js';
 import * as CombinedCourseRepository from '../../../../quest/infrastructure/repositories/combined-course-repository.js';
-import { withTransaction } from '../../../../shared/domain/DomainTransaction.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { EventLoggingJob } from '../../../../shared/domain/models/jobs/EventLoggingJob.js';
 import { CampaignBelongsToCombinedCourseError } from '../errors.js';
 import { CampaignsDestructor } from '../models/CampaignsDestructor.js';
 
-const deleteCampaigns = withTransaction(
-  async ({
+const deleteCampaigns = async ({
+  userId,
+  organizationId,
+  campaignIds,
+  adminMemberRepository,
+  assessmentRepository,
+  badgeAcquisitionRepository,
+  organizationMembershipRepository,
+  campaignAdministrationRepository,
+  campaignParticipationRepository,
+  userRecommendedTrainingRepository,
+  eventLoggingJobRepository,
+  client,
+  userRole,
+  keepPreviousDeletion = false,
+  isPartOfDeletingCombinedCourse = false,
+}) => {
+  let membership;
+  let pixAdminRole = userRole;
+
+  if (!pixAdminRole) {
+    const pixAdminMember = await adminMemberRepository.get({ userId });
+    pixAdminRole = pixAdminMember?.role;
+    if (!pixAdminRole) {
+      membership = await organizationMembershipRepository.getByUserIdAndOrganizationId({ userId, organizationId });
+    }
+  }
+
+  for (const campaignId of campaignIds) {
+    const combinedCourses = await CombinedCourseRepository.findByCampaignId({ campaignId });
+    if (combinedCourses.length > 0 && !isPartOfDeletingCombinedCourse) {
+      throw new CampaignBelongsToCombinedCourseError();
+    }
+  }
+
+  const campaignsToDelete = await campaignAdministrationRepository.findByIds(campaignIds);
+  const campaignParticipationsToDelete = await campaignParticipationRepository.getByCampaignIds(campaignIds, {
+    withDeletedParticipation: keepPreviousDeletion,
+  });
+
+  const campaignDestructor = new CampaignsDestructor({
+    campaignsToDelete,
+    campaignParticipationsToDelete,
     userId,
     organizationId,
-    campaignIds,
-    adminMemberRepository,
-    assessmentRepository,
-    badgeAcquisitionRepository,
-    organizationMembershipRepository,
-    campaignAdministrationRepository,
-    campaignParticipationRepository,
-    userRecommendedTrainingRepository,
-    eventLoggingJobRepository,
-    client,
-    userRole,
-    keepPreviousDeletion = false,
-    isPartOfDeletingCombinedCourse = false,
-  }) => {
-    let membership;
-    let pixAdminRole = userRole;
+    membership,
+    pixAdminRole,
+  });
+  campaignDestructor.delete({ keepPreviousDeletion });
 
-    if (!pixAdminRole) {
-      const pixAdminMember = await adminMemberRepository.get({ userId });
-      pixAdminRole = pixAdminMember?.role;
-      if (!pixAdminRole) {
-        membership = await organizationMembershipRepository.getByUserIdAndOrganizationId({ userId, organizationId });
-      }
-    }
+  const eventLoggingJobs = [];
 
-    for (const campaignId of campaignIds) {
-      const combinedCourses = await CombinedCourseRepository.findByCampaignId({ campaignId });
-      if (combinedCourses.length > 0 && !isPartOfDeletingCombinedCourse) {
-        throw new CampaignBelongsToCombinedCourseError();
-      }
-    }
-
-    const campaignsToDelete = await campaignAdministrationRepository.findByIds(campaignIds);
-    const campaignParticipationsToDelete = await campaignParticipationRepository.getByCampaignIds(campaignIds, {
-      withDeletedParticipation: keepPreviousDeletion,
-    });
-
-    const campaignDestructor = new CampaignsDestructor({
-      campaignsToDelete,
-      campaignParticipationsToDelete,
-      userId,
-      organizationId,
-      membership,
-      pixAdminRole,
-    });
-    campaignDestructor.delete({ keepPreviousDeletion });
-
+  await DomainTransaction.execute(async () => {
     for (const campaignParticipation of campaignDestructor.campaignParticipations) {
       await campaignParticipationRepository.update(campaignParticipation);
 
-      await eventLoggingJobRepository.performAsync(
+      eventLoggingJobs.push(
         EventLoggingJob.forUser({
           client: client ?? CLIENTS.ORGA,
           action: campaignParticipation.loggerContext,
@@ -90,7 +92,11 @@ const deleteCampaigns = withTransaction(
     await campaignAdministrationRepository.deleteExternalIdLabelFromCampaigns(campaignIdsToDelete);
 
     await campaignAdministrationRepository.remove(campaignsToDelete);
-  },
-);
+  });
+
+  for (const eventLoggingJob of eventLoggingJobs) {
+    await eventLoggingJobRepository.performAsync(eventLoggingJob);
+  }
+};
 
 export { deleteCampaigns };

--- a/api/src/prescription/learner-management/domain/usecases/delete-organization-learners.js
+++ b/api/src/prescription/learner-management/domain/usecases/delete-organization-learners.js
@@ -1,8 +1,8 @@
-import { withTransaction } from '../../../../shared/domain/DomainTransaction.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { EventLoggingJob } from '../../../../shared/domain/models/jobs/EventLoggingJob.js';
 import { OrganizationLearnerList } from '../models/OrganizationLearnerList.js';
 
-const deleteOrganizationLearners = withTransaction(async function ({
+const deleteOrganizationLearners = async function ({
   organizationLearnerIds,
   userId,
   organizationId,
@@ -40,62 +40,70 @@ const deleteOrganizationLearners = withTransaction(async function ({
 
   const organizationProfileRewards = await organizationsProfileRewardRepository.getByOrganizationId({ organizationId });
 
-  for (const organizationLearner of organizationLearnersToDelete) {
-    const organizationLearnerRewards = organizationProfileRewards.filter(
-      (organizationProfileReward) => organizationProfileReward.userId === organizationLearner.userId,
-    );
-    organizationLearner.delete(userId, { keepPreviousDeletion });
-    await organizationLearnerRepository.remove(organizationLearner.dataToUpdateOnDeletion);
+  const eventLoggingJobs = [];
 
-    for (const organizationLearnerReward of organizationLearnerRewards) {
-      await organizationsProfileRewardRepository.remove(organizationLearnerReward);
-    }
+  await DomainTransaction.execute(async () => {
+    for (const organizationLearner of organizationLearnersToDelete) {
+      const organizationLearnerRewards = organizationProfileRewards.filter(
+        (organizationProfileReward) => organizationProfileReward.userId === organizationLearner.userId,
+      );
+      organizationLearner.delete(userId, { keepPreviousDeletion });
+      await organizationLearnerRepository.remove(organizationLearner.dataToUpdateOnDeletion);
 
-    await eventLoggingJobRepository.performAsync(
-      EventLoggingJob.forUser({
-        client,
-        action: organizationLearner.loggerContext,
-        role: userRole,
-        userId: organizationLearner.id,
-        updatedByUserId: userId,
-        data: {},
-      }),
-    );
+      for (const organizationLearnerReward of organizationLearnerRewards) {
+        await organizationsProfileRewardRepository.remove(organizationLearnerReward);
+      }
 
-    const campaignParticipations =
-      await campaignParticipationRepositoryFromBC.getAllCampaignParticipationsForOrganizationLearner({
-        organizationLearnerId: organizationLearner.id,
-        withDeletedParticipation: keepPreviousDeletion,
-      });
-
-    for (const campaignParticipation of campaignParticipations) {
-      campaignParticipation.delete(userId);
-      await campaignParticipationRepositoryFromBC.remove(campaignParticipation.dataToUpdateOnDeletion);
-
-      await eventLoggingJobRepository.performAsync(
+      eventLoggingJobs.push(
         EventLoggingJob.forUser({
           client,
-          action: campaignParticipation.loggerContext,
+          action: organizationLearner.loggerContext,
           role: userRole,
-          userId: campaignParticipation.id,
+          userId: organizationLearner.id,
           updatedByUserId: userId,
           data: {},
         }),
       );
-    }
 
-    const campaignParticipationIds = campaignParticipations.map(({ id }) => id);
-    await badgeAcquisitionRepository.deleteUserIdOnNonCertifiableBadgesForCampaignParticipations(
-      campaignParticipationIds,
-    );
-    const assessments = await assessmentRepository.getByCampaignParticipationIds(campaignParticipationIds);
-    for (const assessment of assessments) {
-      assessment.detachCampaignParticipation();
-      await assessmentRepository.updateCampaignParticipationId(assessment);
-    }
+      const campaignParticipations =
+        await campaignParticipationRepositoryFromBC.getAllCampaignParticipationsForOrganizationLearner({
+          organizationLearnerId: organizationLearner.id,
+          withDeletedParticipation: keepPreviousDeletion,
+        });
 
-    await userRecommendedTrainingRepository.deleteCampaignParticipationIds({ campaignParticipationIds });
+      for (const campaignParticipation of campaignParticipations) {
+        campaignParticipation.delete(userId);
+        await campaignParticipationRepositoryFromBC.remove(campaignParticipation.dataToUpdateOnDeletion);
+
+        eventLoggingJobs.push(
+          EventLoggingJob.forUser({
+            client,
+            action: campaignParticipation.loggerContext,
+            role: userRole,
+            userId: campaignParticipation.id,
+            updatedByUserId: userId,
+            data: {},
+          }),
+        );
+      }
+
+      const campaignParticipationIds = campaignParticipations.map(({ id }) => id);
+      await badgeAcquisitionRepository.deleteUserIdOnNonCertifiableBadgesForCampaignParticipations(
+        campaignParticipationIds,
+      );
+      const assessments = await assessmentRepository.getByCampaignParticipationIds(campaignParticipationIds);
+      for (const assessment of assessments) {
+        assessment.detachCampaignParticipation();
+        await assessmentRepository.updateCampaignParticipationId(assessment);
+      }
+
+      await userRecommendedTrainingRepository.deleteCampaignParticipationIds({ campaignParticipationIds });
+    }
+  });
+
+  for (const eventLoggingJob of eventLoggingJobs) {
+    await eventLoggingJobRepository.performAsync(eventLoggingJob);
   }
-});
+};
 
 export { deleteOrganizationLearners };

--- a/api/src/prescription/learner-management/domain/usecases/upload-csv-file.js
+++ b/api/src/prescription/learner-management/domain/usecases/upload-csv-file.js
@@ -1,8 +1,8 @@
-import { withTransaction } from '../../../../shared/domain/DomainTransaction.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { OrganizationImportStatus } from '../models/OrganizationImportStatus.js';
 import { ValidateCsvOrganizationImportFileJob } from '../models/ValidateCsvOrganizationImportFileJob.js';
 
-const uploadCsvFile = withTransaction(async function ({
+const uploadCsvFile = async function ({
   payload,
   userId,
   organizationId,
@@ -13,40 +13,39 @@ const uploadCsvFile = withTransaction(async function ({
   importStorage,
   Parser,
 }) {
-  const organizationImportInstance = OrganizationImportStatus.create({ organizationId, createdBy: userId });
-  await organizationImportRepository.save(organizationImportInstance);
+  const organizationImportId = await DomainTransaction.execute(async () => {
+    const organizationImportInstance = OrganizationImportStatus.create({ organizationId, createdBy: userId });
+    await organizationImportRepository.save(organizationImportInstance);
 
-  const organizationImport = await organizationImportRepository.getLastByOrganizationId(organizationId);
+    const organizationImport = await organizationImportRepository.getLastByOrganizationId(organizationId);
 
-  let filename;
-  let encoding;
-  const errors = [];
+    let filename;
+    let encoding;
+    const errors = [];
 
-  // Sending File
-  try {
-    filename = await importStorage.sendFile({ filepath: payload.path });
+    try {
+      filename = await importStorage.sendFile({ filepath: payload.path });
 
-    const parserEncoding = await importStorage.getParser({ Parser, filename }, organizationId, i18n);
-    encoding = parserEncoding.getFileEncoding();
+      const parserEncoding = await importStorage.getParser({ Parser, filename }, organizationId, i18n);
+      encoding = parserEncoding.getFileEncoding();
 
-    if (type) {
-      await validateCsvOrganizationImportFileJobRepository.performAsync(
-        new ValidateCsvOrganizationImportFileJob({
-          organizationImportId: organizationImport.id,
-          type,
-          locale: i18n.getLocale(),
-        }),
-      );
+      return organizationImport.id;
+    } catch (error) {
+      errors.push(error);
+      throw error;
+    } finally {
+      organizationImport.upload({ filename, encoding, errors });
+      await organizationImportRepository.save(organizationImport);
     }
+  });
 
-    return organizationImport.id;
-  } catch (error) {
-    errors.push(error);
-    throw error;
-  } finally {
-    organizationImport.upload({ filename, encoding, errors });
-    await organizationImportRepository.save(organizationImport);
-  }
-});
+  await validateCsvOrganizationImportFileJobRepository.performAsync(
+    new ValidateCsvOrganizationImportFileJob({
+      organizationImportId,
+      type,
+      locale: i18n.getLocale(),
+    }),
+  );
+};
 
 export { uploadCsvFile };

--- a/api/src/prescription/learner-management/domain/usecases/upload-siecle-file.js
+++ b/api/src/prescription/learner-management/domain/usecases/upload-siecle-file.js
@@ -20,7 +20,7 @@ const uploadSiecleFile = async function ({
   },
   dependencies = { logger },
 }) {
-  await DomainTransaction.execute(async () => {
+  const organizationImport = await DomainTransaction.execute(async () => {
     let organizationImport = OrganizationImportStatus.create({ organizationId, createdBy: userId });
 
     await organizationImportRepository.save(organizationImport);
@@ -41,9 +41,7 @@ const uploadSiecleFile = async function ({
           dependencies.logger.error(rmError);
         }
       }
-      await validateOrganizationImportFileJobRepository.performAsync(
-        new ValidateOrganizationImportFileJob({ organizationImportId: organizationImport.id }),
-      );
+      return organizationImport;
     } catch (error) {
       errors.push(error);
 
@@ -53,6 +51,10 @@ const uploadSiecleFile = async function ({
       await organizationImportRepository.save(organizationImport);
     }
   });
+
+  await validateOrganizationImportFileJobRepository.performAsync(
+    new ValidateOrganizationImportFileJob({ organizationImportId: organizationImport.id }),
+  );
 };
 
 export { uploadSiecleFile };

--- a/api/src/prescription/learner-management/domain/usecases/validate-siecle-xml-file.js
+++ b/api/src/prescription/learner-management/domain/usecases/validate-siecle-xml-file.js
@@ -21,7 +21,7 @@ const validateSiecleXmlFile = async function ({
   importStorage,
   importOrganizationLearnersJobRepository,
 }) {
-  await DomainTransaction.execute(async () => {
+  const organizationImport = await DomainTransaction.execute(async () => {
     const organizationImport = await organizationImportRepository.get(organizationImportId);
 
     const organization = await organizationRepository.get(organizationImport.organizationId);
@@ -44,10 +44,7 @@ const validateSiecleXmlFile = async function ({
       if (isEmpty(organizationLearnerData)) {
         throw new SiecleXmlImportError(ERRORS.EMPTY);
       }
-
-      await importOrganizationLearnersJobRepository.performAsync(
-        new ImportOrganizationLearnersJob({ organizationImportId: organizationImport.id }),
-      );
+      return organizationImport;
     } catch (error) {
       if (error instanceof AggregateImportError) {
         errors.push(...error.meta);
@@ -63,6 +60,10 @@ const validateSiecleXmlFile = async function ({
       await organizationImportRepository.save(organizationImport);
     }
   });
+
+  await importOrganizationLearnersJobRepository.performAsync(
+    new ImportOrganizationLearnersJob({ organizationImportId: organizationImport.id }),
+  );
 };
 
 export { validateSiecleXmlFile };

--- a/api/src/privacy/domain/usecases/anonymize-user.usecase.js
+++ b/api/src/privacy/domain/usecases/anonymize-user.usecase.js
@@ -1,5 +1,5 @@
 import { config } from '../../../shared/config.js';
-import { withTransaction } from '../../../shared/domain/DomainTransaction.js';
+import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { EventLoggingJob } from '../../../shared/domain/models/jobs/EventLoggingJob.js';
 import { anonymizeGeneralizeDate } from '../../../shared/infrastructure/utils/date-utils.js';
 
@@ -21,7 +21,7 @@ import { anonymizeGeneralizeDate } from '../../../shared/infrastructure/utils/da
  * @param{EventLoggingJobRepository} params.eventLoggingJobRepository
  * @returns {Promise<void>}
  */
-const anonymizeUser = withTransaction(async function ({
+const anonymizeUser = async function ({
   userId,
   anonymizedByUserId,
   anonymizedByUserRole,
@@ -38,36 +38,38 @@ const anonymizeUser = withTransaction(async function ({
   userAcceptanceRepository,
   learnersApiRepository,
 }) {
-  const user = await userRepository.get(userId);
+  await DomainTransaction.execute(async () => {
+    const user = await userRepository.get(userId);
 
-  await userRepository.get(anonymizedByUserId);
+    await userRepository.get(anonymizedByUserId);
 
-  await authenticationMethodRepository.removeAllAuthenticationMethodsByUserId({ userId });
+    await authenticationMethodRepository.removeAllAuthenticationMethodsByUserId({ userId });
 
-  await refreshTokenRepository.revokeAllByUserId({ userId });
+    await refreshTokenRepository.revokeAllByUserId({ userId });
 
-  if (user.email) {
-    await resetPasswordDemandRepository.removeAllByEmail(user.email);
-  }
+    if (user.email) {
+      await resetPasswordDemandRepository.removeAllByEmail(user.email);
+    }
 
-  await _anonymizeOrganizationLearner({
-    userId,
-    learnersApiRepository,
+    await _anonymizeOrganizationLearner({
+      userId,
+      learnersApiRepository,
+    });
+
+    await _anonymizeMemberships({ membershipRepository, userId, updatedByUserId: anonymizedByUserId });
+
+    await _anonymizeLastUserApplicationConnections(lastUserApplicationConnectionsRepository, userId);
+
+    await _anonymizeCertificationCenterMemberships(certificationCenterMembershipRepository, userId, anonymizedByUserId);
+
+    await _anonymizeLastUserApplicationConnections(lastUserApplicationConnectionsRepository, userId);
+
+    await userAcceptanceRepository.removeAllByUserId(userId);
+
+    await _anonymizeUserLogin({ userId, userLoginRepository });
+
+    await _anonymizeUser({ user, anonymizedByUserId, userRepository });
   });
-
-  await _anonymizeMemberships({ membershipRepository, userId, updatedByUserId: anonymizedByUserId });
-
-  await _anonymizeLastUserApplicationConnections(lastUserApplicationConnectionsRepository, userId);
-
-  await _anonymizeCertificationCenterMemberships(certificationCenterMembershipRepository, userId, anonymizedByUserId);
-
-  await _anonymizeLastUserApplicationConnections(lastUserApplicationConnectionsRepository, userId);
-
-  await userAcceptanceRepository.removeAllByUserId(userId);
-
-  await _anonymizeUserLogin({ userId, userLoginRepository });
-
-  await _anonymizeUser({ user, anonymizedByUserId, userRepository });
 
   if (config.auditLogger.isEnabled) {
     await eventLoggingJobRepository.performAsync(
@@ -80,7 +82,7 @@ const anonymizeUser = withTransaction(async function ({
       }),
     );
   }
-});
+};
 
 async function _anonymizeMemberships({ userId, anonymizedByUserId, membershipRepository }) {
   // Anonymize last accessed at

--- a/api/tests/devcomp/unit/domain/usecases/terminate-passage_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/terminate-passage_test.js
@@ -108,6 +108,8 @@ describe('Unit | Devcomp | Domain | UseCases | terminate-passage', function () {
 
         const updatedPassage = {
           id: passageId,
+          userId: passage.userId,
+          moduleId: passage.moduleId,
           terminatedAt: new Date('2025-03-04'),
         };
         passageRepository.update.withArgs({ passage }).resolves(updatedPassage);

--- a/api/tests/evaluation/unit/infrastructure/repositories/answer-job-repository_test.js
+++ b/api/tests/evaluation/unit/infrastructure/repositories/answer-job-repository_test.js
@@ -76,47 +76,5 @@ describe('Evaluation | Unit | Infrastructure | Repositories | AnswerJobRepositor
       // then
       expect(profileRewardTemporaryStorageStub.increment).to.have.been.calledWith(userId);
     });
-
-    describe('should use transaction in all cases', function () {
-      it('should use existing transaction', async function () {
-        // given
-        const profileRewardTemporaryStorageStub = { increment: sinon.stub() };
-        const knexStub = { batchInsert: sinon.stub().resolves([]), isTransaction: true };
-        sinon.stub(DomainTransaction, 'getConnection').returns(knexStub);
-        sinon.stub(DomainTransaction, 'execute').callsFake((callback) => {
-          return callback();
-        });
-        const userId = Symbol('userId');
-        const answerJobRepository = new AnswerJobRepository({
-          dependencies: { profileRewardTemporaryStorage: profileRewardTemporaryStorageStub },
-        });
-
-        // when
-        await answerJobRepository.performAsync({ userId });
-
-        // then
-        expect(DomainTransaction.execute).to.have.not.been.called;
-      });
-
-      it('should create new transaction', async function () {
-        // given
-        const profileRewardTemporaryStorageStub = { increment: sinon.stub() };
-        const knexStub = { batchInsert: sinon.stub().resolves([]), isTransaction: false };
-        sinon.stub(DomainTransaction, 'getConnection').returns(knexStub);
-        sinon.stub(DomainTransaction, 'execute').callsFake((callback) => {
-          return callback();
-        });
-        const userId = Symbol('userId');
-        const answerJobRepository = new AnswerJobRepository({
-          dependencies: { profileRewardTemporaryStorage: profileRewardTemporaryStorageStub },
-        });
-
-        // when
-        await answerJobRepository.performAsync({ userId });
-
-        // then
-        expect(DomainTransaction.execute).to.have.been.called;
-      });
-    });
   });
 });

--- a/api/tests/prescription/campaign-participation/unit/domain/usecases/start-campaign-participation_test.js
+++ b/api/tests/prescription/campaign-participation/unit/domain/usecases/start-campaign-participation_test.js
@@ -137,7 +137,7 @@ describe('Unit | UseCase | start-campaign-participation', function () {
       campaignParticipantRepository.save
         .withArgs({ campaignParticipant: sinon.match(campaignParticipant) })
         .resolves(12);
-      campaignParticipationRepository.get.withArgs(12).resolves();
+      campaignParticipationRepository.get.withArgs(12).resolves({ id: 'campaignParticipationId' });
     });
 
     context('when campaign is resettable', function () {

--- a/api/tests/prescription/learner-management/unit/domain/usecases/upload-csv-file_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/usecases/upload-csv-file_test.js
@@ -1,6 +1,7 @@
 import iconv from 'iconv-lite';
 
 import { OrganizationImportStatus } from '../../../../../../src/prescription/learner-management/domain/models/OrganizationImportStatus.js';
+import { ValidateCsvOrganizationImportFileJob } from '../../../../../../src/prescription/learner-management/domain/models/ValidateCsvOrganizationImportFileJob.js';
 import { uploadCsvFile } from '../../../../../../src/prescription/learner-management/domain/usecases/upload-csv-file.js';
 import { SupOrganizationLearnerImportHeader } from '../../../../../../src/prescription/learner-management/infrastructure/serializers/csv/sup-organization-learner-import-header.js';
 import { SupOrganizationLearnerParser } from '../../../../../../src/prescription/learner-management/infrastructure/serializers/csv/sup-organization-learner-parser.js';
@@ -20,12 +21,13 @@ describe('Unit | UseCase | uploadCsvFile', function () {
   let timer,
     fakeDate,
     organizationImportRepositoryStub,
-    validateCsvOrganizationImportFileJobRepositoryStub,
     importStorageStub,
     payload,
     filepath,
     s3Filename,
     csvContent,
+    importType,
+    validateCsvOrganizationImportFileJobRepositoryStub,
     organizationImportStub,
     organizationImportSavedStub,
     organizationImportId;
@@ -36,7 +38,7 @@ describe('Unit | UseCase | uploadCsvFile', function () {
     });
 
     organizationImportId = Symbol('organizationImportId');
-
+    importType = Symbol('FREGATA');
     s3Filename = Symbol('filename');
     csvContent = iconv.encode(
       `${supOrganizationLearnerImportHeader}
@@ -57,8 +59,6 @@ describe('Unit | UseCase | uploadCsvFile', function () {
       getParser: sinon.stub(),
     };
 
-    validateCsvOrganizationImportFileJobRepositoryStub = { performAsync: sinon.stub() };
-
     organizationImportStub = { upload: sinon.stub() };
 
     organizationImportSavedStub = { id: organizationImportId, upload: sinon.stub() };
@@ -75,6 +75,10 @@ describe('Unit | UseCase | uploadCsvFile', function () {
     organizationImportRepositoryStub.getLastByOrganizationId
       .withArgs(organizationId)
       .resolves(organizationImportSavedStub);
+
+    validateCsvOrganizationImportFileJobRepositoryStub = {
+      performAsync: sinon.stub(),
+    };
   });
 
   afterEach(async function () {
@@ -92,14 +96,16 @@ describe('Unit | UseCase | uploadCsvFile', function () {
         .resolves(SupOrganizationLearnerParser.buildParser(csvContent, organizationId, i18n));
 
       // when
-      const result = await uploadCsvFile({
+      await uploadCsvFile({
         Parser: SupOrganizationLearnerParser,
         payload,
         userId,
         organizationId,
         i18n,
+        type: importType,
         organizationImportRepository: organizationImportRepositoryStub,
         importStorage: importStorageStub,
+        validateCsvOrganizationImportFileJobRepository: validateCsvOrganizationImportFileJobRepositoryStub,
       });
 
       // then
@@ -107,7 +113,13 @@ describe('Unit | UseCase | uploadCsvFile', function () {
       expect(organizationImportRepositoryStub.save.getCall(1)).to.have.been.calledWithExactly(
         organizationImportSavedStub,
       );
-      expect(result).to.be.equals(organizationImportId);
+      expect(validateCsvOrganizationImportFileJobRepositoryStub.performAsync).to.have.been.calledWithExactly(
+        new ValidateCsvOrganizationImportFileJob({
+          organizationImportId,
+          type: importType,
+          locale: i18n.getLocale(),
+        }),
+      );
     });
   });
 
@@ -138,43 +150,6 @@ describe('Unit | UseCase | uploadCsvFile', function () {
         encoding: undefined,
         errors: [errorS3],
       });
-    });
-
-    it('should save organization import with error when save job fails', async function () {
-      //given
-      const expectedError = new Error('jobFails');
-      const parserStub = { getFileEncoding: sinon.stub() };
-      const encoding = Symbol('encoding');
-
-      validateCsvOrganizationImportFileJobRepositoryStub.performAsync.rejects(expectedError);
-
-      importStorageStub.sendFile.withArgs({ filepath: payload.path }).resolves(s3Filename);
-      importStorageStub.getParser
-        .withArgs({ Parser: SupOrganizationLearnerParser, filename: s3Filename }, organizationId, i18n)
-        .resolves(parserStub);
-
-      parserStub.getFileEncoding.returns(encoding);
-
-      // when
-      await catchErr(uploadCsvFile)({
-        Parser: SupOrganizationLearnerParser,
-        payload,
-        userId,
-        organizationId,
-        i18n,
-        type: Symbol('type'),
-        organizationImportRepository: organizationImportRepositoryStub,
-        importStorage: importStorageStub,
-        validateCsvOrganizationImportFileJobRepository: validateCsvOrganizationImportFileJobRepositoryStub,
-      });
-
-      //then
-      expect(organizationImportSavedStub.upload).to.have.been.calledWithExactly({
-        filename: s3Filename,
-        encoding,
-        errors: [expectedError],
-      });
-      expect(organizationImportRepositoryStub.save).to.have.been.calledWithExactly(organizationImportSavedStub);
     });
   });
 });

--- a/api/tests/prescription/learner-management/unit/domain/usecases/upload-siecle-file_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/usecases/upload-siecle-file_test.js
@@ -232,31 +232,6 @@ describe('Unit | UseCase | upload-siecle-file', function () {
         expect(organizationImportRepositoryStub.save).to.have.been.calledWithExactly(organizationImportSavedStub);
         expect(validateOrganizationImportFileJobRepositoryStub.performAsync).not.called;
       });
-
-      it('should save organization import with error when save job fails', async function () {
-        //given
-        const expectedError = new Error('jobFails');
-        validateOrganizationImportFileJobRepositoryStub.performAsync.rejects(expectedError);
-
-        // when
-        await catchErr(uploadSiecleFile)({
-          userId,
-          organizationId,
-          payload,
-          organizationImportRepository: organizationImportRepositoryStub,
-          siecleService: siecleServiceStub,
-          importStorage: importStorageStub,
-          validateOrganizationImportFileJobRepository: validateOrganizationImportFileJobRepositoryStub,
-        });
-
-        //then
-        expect(organizationImportSavedStub.upload).to.have.been.calledWithExactly({
-          filename: s3filename,
-          encoding,
-          errors: [expectedError],
-        });
-        expect(organizationImportRepositoryStub.save).to.have.been.calledWithExactly(organizationImportSavedStub);
-      });
     });
   });
 });

--- a/api/tests/prescription/learner-management/unit/domain/usecases/upload-siecle-file_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/usecases/upload-siecle-file_test.js
@@ -178,6 +178,7 @@ describe('Unit | UseCase | upload-siecle-file', function () {
           errors: [error],
         });
         expect(organizationImportRepositoryStub.save).to.have.been.calledWithExactly(organizationImportSavedStub);
+        expect(validateOrganizationImportFileJobRepositoryStub.performAsync).not.called;
       });
 
       it('should save organizationImport if zip is invalid', async function () {
@@ -203,6 +204,7 @@ describe('Unit | UseCase | upload-siecle-file', function () {
           errors: [zipError],
         });
         expect(organizationImportRepositoryStub.save).to.have.been.calledWithExactly(organizationImportSavedStub);
+        expect(validateOrganizationImportFileJobRepositoryStub.performAsync).not.called;
       });
 
       it('should save organizationImport if there is detectEncoding fails', async function () {
@@ -228,6 +230,7 @@ describe('Unit | UseCase | upload-siecle-file', function () {
           errors: [encodingError],
         });
         expect(organizationImportRepositoryStub.save).to.have.been.calledWithExactly(organizationImportSavedStub);
+        expect(validateOrganizationImportFileJobRepositoryStub.performAsync).not.called;
       });
 
       it('should save organization import with error when save job fails', async function () {

--- a/api/tests/prescription/learner-management/unit/domain/usecases/validate-siecle-xml-file_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/usecases/validate-siecle-xml-file_test.js
@@ -52,6 +52,7 @@ describe('Unit | UseCase | validate-siecle-xml-file', function () {
       get: sinon.stub().withArgs(organizationId).returns({ externalId: externalIdSymbol }),
     };
 
+    readableSymbol = Symbol('readable');
     importStorageStub = {
       deleteFile: sinon.stub(),
       readFile: sinon.stub().withArgs({ filename: organizationImportStub.filename }).resolves(readableSymbol),
@@ -102,6 +103,7 @@ describe('Unit | UseCase | validate-siecle-xml-file', function () {
           filename: organizationImportStub.filename,
         });
         expect(organizationImportRepositoryStub.save).to.have.been.calledWithExactly(organizationImportStub);
+        expect(importOrganizationLearnersJobRepositoryStub.performAsync).not.called;
       });
 
       it('should save error when there is an error deleting file from S3', async function () {
@@ -120,26 +122,8 @@ describe('Unit | UseCase | validate-siecle-xml-file', function () {
           filename: organizationImportStub.filename,
         });
         expect(organizationImportRepositoryStub.save).to.have.been.calledWithExactly(organizationImportStub);
+        expect(importOrganizationLearnersJobRepositoryStub.performAsync).not.called;
       });
-    });
-
-    it('should save error when there is an error publishing event', async function () {
-      const publishError = new Error('ERROR');
-
-      importOrganizationLearnersJobRepositoryStub.performAsync.rejects(publishError);
-
-      await catchErr(validateSiecleXmlFile)({
-        organizationImportId,
-        organizationImportRepository: organizationImportRepositoryStub,
-        organizationRepository: organizationRepositoryStub,
-        importStorage: importStorageStub,
-        importOrganizationLearnersJobRepository: importOrganizationLearnersJobRepositoryStub,
-      });
-      expect(organizationImportStub.validate).to.have.been.calledWith({ errors: [publishError] });
-      expect(importStorageStub.deleteFile).to.have.been.calledWithExactly({
-        filename: organizationImportStub.filename,
-      });
-      expect(organizationImportRepositoryStub.save).to.have.been.calledWithExactly(organizationImportStub);
     });
 
     context('when there is validation errors', function () {
@@ -159,6 +143,7 @@ describe('Unit | UseCase | validate-siecle-xml-file', function () {
         expect(error).to.be.instanceof(AggregateImportError);
         expect(organizationImportStub.validate).to.have.been.calledWith({ errors: parsingErrors });
         expect(organizationImportRepositoryStub.save).to.have.been.calledWithExactly(organizationImportStub);
+        expect(importOrganizationLearnersJobRepositoryStub.performAsync).not.called;
       });
 
       it('should save empty learner error', async function () {
@@ -180,6 +165,7 @@ describe('Unit | UseCase | validate-siecle-xml-file', function () {
           true,
         );
         expect(organizationImportRepositoryStub.save).to.have.been.calledWithExactly(organizationImportStub);
+        expect(importOrganizationLearnersJobRepositoryStub.performAsync).not.called;
       });
     });
   });


### PR DESCRIPTION
## 🥀 Problème

Les jobs asynchrones sont planifiés en insérant une ligne dans une table spécifique du schéma `pgboss`.
On fait cette insertion en utilisant la transaction courante, ce qui a pour effet de ne pas commiter cette insertion (et donc ne pas planifier le job) en cas d'échec de la transation englobante.
Dans le cadre de notre migration vers la version la plus récente de pgboss, nous voulons utiliser l'API de pgboss plutôt que de faire une insertion manuelle.
Dans la situation actuelle, cela aurait pour conséquence de lancer le job malgré un échec des autres parties du usecase.

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

## 🏹 Proposition

Avec l'introduction du successHandler de la DomainTransaction, nous sommes désormais outillés pour planifier le job uniquement en cas de succès de la transaction.

On fait donc une passe sur l'ensemble des appels à `performAsync`.

Nous avons choisi d'utiliser prioritairement `DomainTransaction.execute` suivi de `asyncJobRepositoryXX.performAsync`.
Lorsque cela n'était pas possible, nous avons utilisé le `successHandler` de la `DomainTransaction`.

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 💌 Remarques

`answer-job-repository` testait si la connexion courante est une transaction ou pas.
Cela est désormais inutile car `DomainTransaction.execute` le fait également.

`upload-csv-file` et `upload-siecle-file` stockent une erreur éventuelle levée par la fonction `performAsync`.
En exécutant `performAsync` en dehors de la transaction, on ne peut plus stocker l'erreur de cette fonction dans la base de données.
Cela ne semble pas primordial, une erreur de `performAsync` étant une erreur d'infrastructure au niveau de pgboss (à confirmer par @1024pix/team-prescription).

<!-- Des infos supplémentaires, trucs et astuces ? -->

## ❤️‍🔥 Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
