### PR TITLE
[FEATURE] Utiliser des Mutex Locks natifs pour certaines sections de code de OidcAuthenticationServiceRegistry

### DIFF
--- a/api/src/identity-access-management/domain/services/oidc-authentication-service-registry.js
+++ b/api/src/identity-access-management/domain/services/oidc-authentication-service-registry.js
@@ -1,3 +1,5 @@
+import { locks } from 'node:worker_threads';
+
 import { InvalidIdentityProviderError } from '../../../shared/domain/errors.js';
 import { cryptoService } from '../../../shared/domain/services/crypto-service.js';
 import { PromiseUtils } from '../../../shared/infrastructure/utils/promise-utils.js';
@@ -53,45 +55,65 @@ export class OidcAuthenticationServiceRegistry {
     }
   }
 
-  async #configureReadyOidcProviderServiceByCode(oidcProviderServiceCode) {
-    const oidcProviderService = this.#allOidcProviderServices?.find(
-      (oidcProviderService) => oidcProviderService.code === oidcProviderServiceCode,
-    );
+  async #configureReadyOidcProviderServiceByCode(identityProviderCode) {
+    const lockName = `configureReadyOidcProviderServiceByCode-${identityProviderCode}`;
+    await locks.request(lockName, async () => {
+      // The lock has been acquired.
+      // eslint-disable-next-line no-console
+      console.log(`lock ${lockName} has been acquired↑↑↑`);
+      const oidcProviderService = this.#allOidcProviderServices?.find(
+        (oidcProviderService) => oidcProviderService.code === identityProviderCode,
+      );
 
-    if (!oidcProviderService) return;
+      if (!oidcProviderService) return;
 
-    await oidcProviderService.initializeClientConfig();
+      await oidcProviderService.initializeClientConfig();
+    });
+    // The lock has been released here.
+    // eslint-disable-next-line no-console
+    console.log(`lock ${lockName} has been released↓↓↓`);
   }
 
   async #loadAllOidcProviderServices(oidcProviderServices) {
-    if (this.#allOidcProviderServices) {
-      return;
-    }
+    const lockName = 'loadAllOidcProviderServices';
+    await locks.request(lockName, async () => {
+      // The lock has been acquired.
+      // eslint-disable-next-line no-console
+      console.log(`lock ${lockName} has been acquired↑↑↑`);
 
-    if (!oidcProviderServices) {
-      const oidcProviders = await this.oidcProviderRepository.findAllOidcProviders();
+      if (this.#allOidcProviderServices) {
+        return;
+      }
 
-      oidcProviderServices = await PromiseUtils.mapSeries(oidcProviders, async (oidcProvider) => {
-        await oidcProvider.decryptClientSecret(cryptoService);
-        switch (oidcProvider.identityProvider) {
-          case 'FWB':
-            return new FwbOidcAuthenticationService(oidcProvider);
-          case 'POLE_EMPLOI':
-            return new PoleEmploiOidcAuthenticationService(oidcProvider);
-          default:
-            return new OidcAuthenticationService(oidcProvider);
-        }
-      });
-    }
+      if (!oidcProviderServices) {
+        const oidcProviders = await this.oidcProviderRepository.findAllOidcProviders();
 
-    this.#allOidcProviderServices = oidcProviderServices;
+        oidcProviderServices = await PromiseUtils.mapSeries(oidcProviders, async (oidcProvider) => {
+          await oidcProvider.decryptClientSecret(cryptoService);
+          switch (oidcProvider.identityProvider) {
+            case 'FWB':
+              return new FwbOidcAuthenticationService(oidcProvider);
+            case 'POLE_EMPLOI':
+              return new PoleEmploiOidcAuthenticationService(oidcProvider);
+            default:
+              return new OidcAuthenticationService(oidcProvider);
+          }
+        });
+      }
 
-    this.#readyOidcProviderServicesByRequestedApplications = Object.groupBy(
-      this.#allOidcProviderServices.filter(
-        (oidcProviderService) => oidcProviderService.isReady || oidcProviderService.isReadyForPixAdmin,
-      ),
-      (oidcProviderService) => generateGroupByKey(oidcProviderService.application, oidcProviderService.applicationTld),
-    );
+      this.#allOidcProviderServices = oidcProviderServices;
+
+      this.#readyOidcProviderServicesByRequestedApplications = Object.groupBy(
+        this.#allOidcProviderServices.filter(
+          (oidcProviderService) => oidcProviderService.isReady || oidcProviderService.isReadyForPixAdmin,
+        ),
+        (oidcProviderService) =>
+          generateGroupByKey(oidcProviderService.application, oidcProviderService.applicationTld),
+      );
+    });
+    // The lock has been released here.
+    // eslint-disable-next-line no-console
+    console.log(`lock ${lockName} has been released↓↓↓`);
   }
 }
 


### PR DESCRIPTION
## 🥀 Problème

L’`oidcAuthenticationServiceRegistry` réalise certaines opérations lourdes, sur la route `/api/oidc/identity-providers` et sur la route `/api/oidc/authorization-url`, qui ne devraient pas être réalisées de manière concurrente. Les opérations concurrentes de ce type chargent inutilement la base de données et les services OIDC de nos partenaires.

On a donc besoin de verrouiller la ressource au sein même d’un même container. Contrairement à des locks qui servent à verrouiller des ressources entre plusieurs conteneurs, qui est un autre type de besoin.

## 🏹 Proposition

Utiliser l’API _LockManager_ qui est disponible depuis Node.js v24.5.0 : 
* https://developer.mozilla.org/en-US/docs/Web/API/LockManager
* https://nodejs.org/docs/latest/api/worker_threads.html#class-lockmanager

:information_source: L’implémentation du LockManager est en état _Experimental_ dans Node.js. Mais l’API Web LockManager étant très simple et l’implémentation dans Node.js reprenant exactement cette Web API il est très improbable que l’API change dans Node.js. Par contre on peut imaginer une implémentation avec des fuites mémoire potentielles que seule une utilisation prolongée sans redémarrage pourra valider.

**:warning: Cette PR va recevoir des modifications suite à sa présentation en MeJ. Prévoir quelques semaines de délai, pour des raisons d’indisponibilité, avant qu’elle soit finalisée et reproposée à la revue**.

:warning: Ne pas mettre en production avant validation des captains et de @bpetetot.

## 💌 Remarques

Il y a des `console.log` qui sont présents pour faciliter la compréhension quand on teste. Ce sera à enlever avant le merge si la PR est validée.

## ❤️‍🔥 Pour tester

### Test de charge

:information_source: Pour que le test de charge proposé soit pertinent il faut impérativement redémarrer Pix API avant le démarrage de chaque test.

Démarrer Pix API et la soumettre à une forte charge, par exemple avec la commande `siege`[*] : 

```shell
siege --concurrent=255 --reps=3 --delay=0 https://app.dev.pix.fr/api/oidc/identity-providers/fr
```

Comparer en exécutant la même chose sur la branche `dev` et constater que sur `dev` le serveur est incapable de supporter la même charge et qu’il faut plutôt mettre l’option `--concurrent=5`.

:information_source: Siege, logiciel libre : https://download.joedog.org/siege/ et dans les dépôts APT

### Test fonctionnel

En local, se connecter à Pix App, Pix Orga et Pix Admin avec différents SSO, se déconnecter, et constater que tout est fonctionnel comme attendu sans régression.
