### PR TITLE
[TECH] Ajout id d'organisation dans le titre de l'onglet (PIX-21517)

### DIFF
--- a/admin/app/components/organizations/children.gjs
+++ b/admin/app/components/organizations/children.gjs
@@ -1,0 +1,34 @@
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import t from 'ember-intl/helpers/t';
+import ActionsSection from 'pix-admin/components/organizations/children/actions-section';
+import List from 'pix-admin/components/organizations/children/list';
+
+export default class OrganizationChildrenComponent extends Component {
+  @service accessControl;
+
+  @action
+  refreshOrganizationChildren() {
+    if (this.args.children && typeof this.args.children.reload === 'function') {
+      this.args.children.reload();
+    }
+  }
+
+  <template>
+    {{#if this.accessControl.hasAccessToOrganizationActionsScope}}
+      <ActionsSection @onAttachChildSubmitForm={{@onAttachChildSubmitForm}} @organization={{@organization}} />
+    {{/if}}
+
+    <section class="page-section">
+      <header class="page-section__header">
+        <h2 class="page-section__title">{{t "pages.organization-children.title"}}</h2>
+      </header>
+      {{#if @children}}
+        <List @childOrganizations={{@children}} @onRefreshOrganizationChildren={{this.refreshOrganizationChildren}} />
+      {{else}}
+        <p class="table__empty">{{t "pages.organization-children.empty-table"}}</p>
+      {{/if}}
+    </section>
+  </template>
+}

--- a/admin/app/templates/authenticated/organizations/get/children.gjs
+++ b/admin/app/templates/authenticated/organizations/get/children.gjs
@@ -1,40 +1,11 @@
-import { action } from '@ember/object';
-import Component from '@glimmer/component';
-import t from 'ember-intl/helpers/t';
 import pageTitle from 'ember-page-title/helpers/page-title';
-import ActionsSection from 'pix-admin/components/organizations/children/actions-section';
-import List from 'pix-admin/components/organizations/children/list';
+import Children from 'pix-admin/components/organizations/children';
 
-export default class Children extends Component {
-  @action
-  refreshOrganizationChildren() {
-    this.args.model.children.reload();
-  }
-
-  <template>
-    {{pageTitle "Children"}}
-    {{#if @controller.accessControl.hasAccessToOrganizationActionsScope}}
-
-      <ActionsSection
-        @onAttachChildSubmitForm={{@controller.handleFormSubmitted}}
-        @organization={{@model.organization}}
-      />
-    {{/if}}
-
-    <section class="page-section">
-      <header class="page-section__header">
-        <h2 class="page-section__title">{{t "pages.organization-children.title"}}</h2>
-      </header>
-      {{#if @model.children}}
-        <List
-          @childOrganizations={{@model.children}}
-          @onRefreshOrganizationChildren={{this.refreshOrganizationChildren}}
-        />
-
-      {{else}}
-        <p class="table__empty">{{t "pages.organization-children.empty-table"}}</p>
-      {{/if}}
-
-    </section>
-  </template>
-}
+<template>
+  {{pageTitle "Orga " @model.organization.id " | Organisations filles"}}
+  <Children
+    @organization={{@model.organization}}
+    @children={{@model.children}}
+    @onAttachChildSubmitForm={{@controller.handleFormSubmitted}}
+  />
+</template>

--- a/admin/app/templates/authenticated/organizations/get/target-profiles.gjs
+++ b/admin/app/templates/authenticated/organizations/get/target-profiles.gjs
@@ -1,7 +1,7 @@
 import pageTitle from 'ember-page-title/helpers/page-title';
 import TargetProfilesSection from 'pix-admin/components/organizations/target-profiles-section';
 <template>
-  {{pageTitle "Orga " @model.id " | Profils cibles"}}
+  {{pageTitle "Orga " @model.organization.id " | Profils cibles"}}
   <TargetProfilesSection
     @organization={{@model.organization}}
     @targetProfileSummaries={{@model.targetProfileSummaries}}

--- a/admin/tests/acceptance/authenticated/organizations/get-test.js
+++ b/admin/tests/acceptance/authenticated/organizations/get-test.js
@@ -245,6 +245,18 @@ module('Acceptance | Organizations | Get', function (hooks) {
           // then
           assert.strictEqual(currentURL(), `/organizations/${ORGANIZATION_ID}/target-profiles`);
         });
+
+        test('page title is set on target profiles page', async function (assert) {
+          // given
+          const orgId = ORGANIZATION_ID;
+          server.create('target-profile-summary', { id: 999, name: 'dummy' });
+
+          // when
+          await visit(`/organizations/${orgId}/target-profiles`);
+
+          const headScreen = within(document.head);
+          assert.ok(headScreen.getByText(`Orga ${orgId} | Profils cibles`, { selector: 'title' }));
+        });
       });
 
       module('Campaigns tab', function () {

--- a/admin/tests/acceptance/authenticated/organizations/get/children-test.js
+++ b/admin/tests/acceptance/authenticated/organizations/get/children-test.js
@@ -34,6 +34,8 @@ module('Acceptance | Organizations | Children', function (hooks) {
         // then
         assert.dom(screen.getByText('Aucune organisation fille')).exists();
         assert.dom(screen.getByRole('heading', { name: 'Organisations filles', level: 2 })).exists();
+        const headScreen = within(document.head);
+        assert.ok(headScreen.getByText(`Orga ${organizationId} | Organisations filles`, { selector: 'title' }));
       });
     });
 

--- a/admin/tests/integration/components/organizations/children-test.gjs
+++ b/admin/tests/integration/components/organizations/children-test.gjs
@@ -1,0 +1,104 @@
+import { render } from '@1024pix/ember-testing-library';
+import Service from '@ember/service';
+import { t } from 'ember-intl/test-support';
+import Children from 'pix-admin/components/organizations/children';
+import setupIntlRenderingTest from 'pix-admin/tests/helpers/setup-intl-rendering';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module('Integration | Component | organizations/children', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  module('when the admin member has access to organization scope', function (hooks) {
+    hooks.beforeEach(function () {
+      class AccessControlStub extends Service {
+        hasAccessToOrganizationActionsScope = true;
+      }
+      this.owner.register('service:access-control', AccessControlStub);
+    });
+
+    test('it should display children list and actions section', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const organization = store.createRecord('organization', { id: '1', name: 'Parent' });
+      const child1 = store.createRecord('organization', { id: '2', name: 'Child 1' });
+      const child2 = store.createRecord('organization', { id: '3', name: 'Child 2' });
+      const children = [child1, child2];
+
+      const onAttachChildSubmitFormStub = sinon.stub();
+
+      // when
+      const screen = await render(
+        <template>
+          <Children
+            @organization={{organization}}
+            @children={{children}}
+            @onAttachChildSubmitForm={{onAttachChildSubmitFormStub}}
+          />
+        </template>,
+      );
+
+      // then
+      assert.dom(screen.getByText('Child 1')).exists();
+      assert.dom(screen.getByText('Child 2')).exists();
+      assert.ok(
+        screen.getByRole('link', { name: t('components.organizations.children.create-child-organization-button') }),
+      );
+    });
+
+    test('it should display an empty message when no children', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const organization = store.createRecord('organization', { id: '1', name: 'Parent' });
+      const children = [];
+      const onAttachChildSubmitFormStub = sinon.stub();
+
+      // when
+      const screen = await render(
+        <template>
+          <Children
+            @organization={{organization}}
+            @children={{children}}
+            @onAttachChildSubmitForm={{onAttachChildSubmitFormStub}}
+          />
+        </template>,
+      );
+
+      // then
+      assert.dom(screen.getByText(t('pages.organization-children.empty-table'))).exists();
+    });
+  });
+
+  module('when the admin member does not have access to organization scope', function (hooks) {
+    hooks.beforeEach(function () {
+      class AccessControlStub extends Service {
+        hasAccessToOrganizationActionsScope = false;
+      }
+      this.owner.register('service:access-control', AccessControlStub);
+    });
+
+    test('it should not render the actions section', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const organization = store.createRecord('organization', { id: '1', name: 'Parent' });
+      const children = [];
+      const onAttachChildSubmitFormStub = sinon.stub();
+
+      // when
+      const screen = await render(
+        <template>
+          <Children
+            @organization={{organization}}
+            @children={{children}}
+            @onAttachChildSubmitForm={{onAttachChildSubmitFormStub}}
+          />
+        </template>,
+      );
+
+      // then
+      assert.notOk(
+        screen.queryByRole('link', { name: t('components.organizations.children.create-child-organization-button') }),
+      );
+    });
+  });
+});


### PR DESCRIPTION
## 🥀 Problème

Sur la page d’une orga, les titres des pages sur les onglets ne sont pas cohérents.

- Organisations filles

- Profils cibles

## 🏹 Proposition

Il faudrait s’aligner avec ce qui est indiqué sur la page de détail (Orga 108457 | Détails)

- Orga 108457 | Organisations filles

- Orga 108457 | Profils cibles



## ❤️‍🔥 Pour tester
- Sur pix-admin
- Aller sur la page organizations/ID_DE_L_ORGA/children
- Constater que le titre de l'onglet contient l'id de l'organisation
- Aller sur la page organizations/ID_DE_L_ORGA/target-profiles
- Constater que le titre de l'onglet contient l'id de l'organisation

