### PR TITLE
[TECH] Limiter la flakyness des tests de certif E2E

### DIFF
--- a/high-level-tests/e2e-playwright/helpers/utils.ts
+++ b/high-level-tests/e2e-playwright/helpers/utils.ts
@@ -1,4 +1,4 @@
-import { Page } from '@playwright/test';
+import { Locator, Page } from '@playwright/test';
 
 export function* rightWrongAnswerCycle({ numRight = 1, numWrong = 1 }) {
   const answers: boolean[] = [];
@@ -74,4 +74,28 @@ export function normalizeWhitespace(str: string): string {
 
 export function sanitizeFilename(name: string) {
   return name.replace(/[^a-z0-9_\-.]/gi, '_');
+}
+
+export async function waitForVisibleWithReload(
+  page: Page,
+  locator: Locator,
+  options?: {
+    timeout?: number;
+    interval?: number;
+  },
+) {
+  const timeout = options?.timeout ?? 60_000;
+  const interval = options?.interval ?? 2_000;
+
+  const start = Date.now();
+
+  while (Date.now() - start < timeout) {
+    await page.reload();
+
+    if (await locator.isVisible()) return;
+
+    await page.waitForTimeout(interval);
+  }
+
+  throw new Error('Element did not appear before timeout');
 }

--- a/high-level-tests/e2e-playwright/pages/pix-admin/CertificationSessionsMainPage.ts
+++ b/high-level-tests/e2e-playwright/pages/pix-admin/CertificationSessionsMainPage.ts
@@ -1,5 +1,6 @@
 import type { Page } from '@playwright/test';
 
+import { waitForVisibleWithReload } from '../../helpers/utils.ts';
 import { CertificationSessionPage } from './index.ts';
 
 export class CertificationSessionsMainPage {
@@ -9,7 +10,13 @@ export class CertificationSessionsMainPage {
     await this.page.getByRole('link', { name: /V3 — Sessions à publier/ }).click();
     await this.page.waitForURL(/\/sessions\/list\/to-be-published\?version=3$/);
 
-    await this.page.getByRole('link', { name: sessionNumber, exact: true }).click();
+    const locatorToWaitFor = this.page.getByRole('link', {
+      name: sessionNumber,
+      exact: true,
+    });
+    await waitForVisibleWithReload(this.page, locatorToWaitFor);
+
+    await locatorToWaitFor.click();
     await this.page.waitForURL(/\/sessions\/\d+$/);
 
     return new CertificationSessionPage(this.page);

--- a/high-level-tests/e2e-playwright/pages/pix-certif/SessionFinalizationPage.ts
+++ b/high-level-tests/e2e-playwright/pages/pix-certif/SessionFinalizationPage.ts
@@ -12,8 +12,6 @@ export class SessionFinalizationPage {
       .getByText('Les informations de la session ont été transmises avec succès.')
       .waitFor({ state: 'visible' });
 
-    await this.page.waitForTimeout(2000); // BEURK, attendre que le scoring soit bien passé
-
     return new SessionManagementPage(this.page);
   }
 

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/clea/PRO_CLEA_0OK-32KO.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/clea/PRO_CLEA_0OK-32KO.spec.ts
@@ -52,7 +52,6 @@ test(
         'Vos résultats, en attente de validation par les équipes Pix, seront bientôt disponibles sur votre compte Pix',
       );
     });
-    await pixAppCertifiablePage.waitForTimeout(2000); // BEURK, attendre que le scoring soit bien passé
 
     await test.step('Finalization and scoring', async () => {
       const sessionManagementPage = new SessionManagementPage(pixCertifProPage);

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/clea/PRO_CLEA_32OK-0KO.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/clea/PRO_CLEA_32OK-0KO.spec.ts
@@ -53,7 +53,6 @@ test(
         'Vos résultats, en attente de validation par les équipes Pix, seront bientôt disponibles sur votre compte Pix',
       );
     });
-    await pixAppCertifiablePage.waitForTimeout(2000); // BEURK, attendre que le scoring soit bien passé
 
     await test.step('Finalization and scoring', async () => {
       const sessionManagementPage = new SessionManagementPage(pixCertifProPage);

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/clea/PRO_CLEA_32OK-0KO_Rescore.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/clea/PRO_CLEA_32OK-0KO_Rescore.spec.ts
@@ -54,7 +54,6 @@ test(
         'Vos résultats, en attente de validation par les équipes Pix, seront bientôt disponibles sur votre compte Pix',
       );
     });
-    await pixAppCertifiablePage.waitForTimeout(2000); // BEURK, attendre que le scoring soit bien passé
 
     await test.step('Finalization and scoring', async () => {
       const sessionManagementPage = new SessionManagementPage(pixCertifProPage);

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/core/PRO_CORE_0OK-32KO.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/core/PRO_CORE_0OK-32KO.spec.ts
@@ -50,7 +50,6 @@ test(
         'Vos résultats, en attente de validation par les équipes Pix, seront bientôt disponibles sur votre compte Pix',
       );
     });
-    await pixAppCertifiablePage.waitForTimeout(2000); // BEURK, attendre que le scoring soit bien passé
 
     await test.step('Finalization and scoring', async () => {
       const sessionManagementPage = new SessionManagementPage(pixCertifProPage);

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/core/PRO_CORE_32OK-0KO.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/core/PRO_CORE_32OK-0KO.spec.ts
@@ -51,7 +51,6 @@ test(
         'Vos résultats, en attente de validation par les équipes Pix, seront bientôt disponibles sur votre compte Pix',
       );
     });
-    await pixAppCertifiablePage.waitForTimeout(2000); // BEURK, attendre que le scoring soit bien passé
 
     await test.step('Finalization and scoring', async () => {
       const sessionManagementPage = new SessionManagementPage(pixCertifProPage);

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/core/PRO_CORE_32OK-0KO_Rescore.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/core/PRO_CORE_32OK-0KO_Rescore.spec.ts
@@ -52,7 +52,6 @@ test(
         'Vos résultats, en attente de validation par les équipes Pix, seront bientôt disponibles sur votre compte Pix',
       );
     });
-    await pixAppCertifiablePage.waitForTimeout(2000); // BEURK, attendre que le scoring soit bien passé
 
     await test.step('Finalization and scoring', async () => {
       const sessionManagementPage = new SessionManagementPage(pixCertifProPage);

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/core/PRO_CORE_32OK-0KO_Uncancelled.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/core/PRO_CORE_32OK-0KO_Uncancelled.spec.ts
@@ -52,7 +52,6 @@ test(
         'Vos résultats, en attente de validation par les équipes Pix, seront bientôt disponibles sur votre compte Pix',
       );
     });
-    await pixAppCertifiablePage.waitForTimeout(2000); // BEURK, attendre que le scoring soit bien passé
 
     await test.step('Finalization and scoring', async () => {
       const sessionManagementPage = new SessionManagementPage(pixCertifProPage);

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/core/PRO_CORE_32OK-0KO_Unrejected.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/core/PRO_CORE_32OK-0KO_Unrejected.spec.ts
@@ -52,7 +52,6 @@ test(
         'Vos résultats, en attente de validation par les équipes Pix, seront bientôt disponibles sur votre compte Pix',
       );
     });
-    await pixAppCertifiablePage.waitForTimeout(2000); // BEURK, attendre que le scoring soit bien passé
 
     await test.step('Finalization and scoring', async () => {
       const sessionManagementPage = new SessionManagementPage(pixCertifProPage);


### PR DESCRIPTION
## 🥀 Problème

Tests flakys, notamment au moment de cliquer sur la session dans la liste des sessions à publier

## 🏹 Proposition

Je soupçonne le job de scoring qui traine parfois à se déclencher. Le problème est que lorsqu'on arrive sur la page des sessions à publier sur PixAdmin, la session ne va jamais apparaître par magie à moins de recharger la page de temps en temps.

C'est ce que je propose de faire plutôt que d'attendre arbitrairement à la fin de chaque test de certif deux secondes
## 💌 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## ❤️‍🔥 Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
