### PR TITLE
[FEATURE] Afficher le nb d'orgas qui ont été archivés (PIX-21350)

### DIFF
--- a/admin/app/components/administration/deployment/organizations-batch-archive.gjs
+++ b/admin/app/components/administration/deployment/organizations-batch-archive.gjs
@@ -24,6 +24,8 @@ export default class OrganizationsBatchArchive extends Component {
     const formData = new FormData();
     formData.append('file', files[0]);
 
+    const numberOfDataLines = await _getCsvDataLinesCount(files);
+
     try {
       await this.requestManager.request({
         url: `${ENV.APP.API_HOST}/api/admin/organizations/batch-archive`,
@@ -32,7 +34,9 @@ export default class OrganizationsBatchArchive extends Component {
       });
 
       this.pixToast.sendSuccessNotification({
-        message: this.intl.t('components.administration.organizations-batch-archive.notifications.success'),
+        message: this.intl.t('components.administration.organizations-batch-archive.notifications.success', {
+          count: numberOfDataLines,
+        }),
       });
     } catch (errorResponse) {
       const errors = errorResponse.errors;
@@ -82,4 +86,22 @@ export default class OrganizationsBatchArchive extends Component {
       </DownloadTemplate>
     </AdministrationBlockLayout>
   </template>
+}
+
+async function _getCsvDataLinesCount(files) {
+  const file = files[0];
+
+  const text = await file.text();
+
+  const lines = text.split(/\r?\n/);
+
+  const filtered = _filterEmptyLines(lines);
+
+  const numberOfDataLines = filtered.length - 1;
+  return numberOfDataLines;
+}
+
+function _filterEmptyLines(lines) {
+  const filtered = lines.filter((line) => line.trim() !== '');
+  return filtered;
 }

--- a/admin/tests/integration/components/administration/deployment/organizations-batch-archive-test.gjs
+++ b/admin/tests/integration/components/administration/deployment/organizations-batch-archive-test.gjs
@@ -22,24 +22,35 @@ module('Integration | Component | administration/organizations-batch-archive', f
   });
 
   module('when batch archive succeeds', function () {
-    test('it displays a success notification', async function (assert) {
+    test('it displays the correct number of archived organizations in success notification', async function (assert) {
       // given
-      const file = new Blob(['foo'], { type: `valid-file` });
+      const csvContent = `id
+                          1,
+                          2,
+                          3,`;
+
+      const file = new File([csvContent], 'test.csv', { type: 'text/csv' });
 
       requestManagerService.request.resolves({ response: { ok: true, status: 204 } });
 
-      // when
       const screen = await render(
         <template><OrganizationsBatchArchive /><PixToastContainer @closeButtonAriaLabel="Close" /></template>,
       );
+
       const input = await screen.findByLabelText(
         t('components.administration.organizations-batch-archive.upload-button'),
       );
+
+      // when
       await triggerEvent(input, 'change', { files: [file] });
 
       // then
       assert.ok(
-        await screen.findByText(t('components.administration.organizations-batch-archive.notifications.success')),
+        await screen.findByText(
+          t('components.administration.organizations-batch-archive.notifications.success', {
+            count: 3,
+          }),
+        ),
       );
     });
   });

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -190,7 +190,7 @@
           "errors": {
             "error-in-batch": "The organizations archiving has failed. The organization ID line n°{currentLine} failed, out of {totalLines} lines."
           },
-          "success": "The organizations have been archived."
+          "success": "{ count, plural, one {One organization has been successfully archived.} other {{ count } organizations have been successfully archived.}}"
         },
         "title": "Archiving of organizations in batch",
         "upload-button": "Import a CSV file"

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -191,7 +191,7 @@
           "errors": {
             "error-in-batch": "L'archivage d'une des organisations a échoué. L'organization concernée est à la ligne {currentLine} du fichier comportant {totalLines} lignes. Corrigez la ligne concernée et ré-importez le fichier."
           },
-          "success": "Les organisations ont bien été archivées."
+          "success": "{ count, plural, one {Une organisation a bien été archivée.} other {{ count } organisations ont bien été archivées.}}"
         },
         "title": "Archivage des organisations en masse",
         "upload-button": "Importer un fichier CSV"


### PR DESCRIPTION
## 🥀 Problème

Lors de l'archivage en masse, la notification affichée n'indique pas le nb de lignes traitées

## 🏹 Proposition

Afficher le nb d'organisations archivées


## ❤️‍🔥 Pour tester
- Depuis pix-admin
- Archiver en masse des organisations
- Vérifier que la notification de succès indique le nombre d'organisations archivées
