### PR TITLE
[BUGFIX] Le scoring ne marche pas quand le candidat a un score de 0 pix (PIX-21760)

### DIFF
--- a/api/src/certification/shared/infrastructure/repositories/competence-mark-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/competence-mark-repository.js
@@ -16,15 +16,13 @@ const save = async function (competenceMark) {
 /**
  * @param {object} params
  * @param {CompetenceMark[]} params.competenceMarks
- * @returns {Promise<CompetenceMark[]>}
+ * @returns {Promise<void>}
  */
 const saveMany = async function ({ competenceMarks }) {
   await Promise.all(competenceMarks.map((competenceMark) => competenceMark.validate()));
 
   const knexConn = DomainTransaction.getConnection();
-  const savedCompetenceMarks = await knexConn('competence-marks').insert(competenceMarks).returning('*');
-
-  return savedCompetenceMarks.map((competenceMark) => new CompetenceMark(competenceMark));
+  await knexConn('competence-marks').insert(competenceMarks).returning('*');
 };
 
 export { save, saveMany };

--- a/api/tests/certification/evaluation/integration/domain/usecases/score-v3-certification_test.js
+++ b/api/tests/certification/evaluation/integration/domain/usecases/score-v3-certification_test.js
@@ -112,6 +112,27 @@ describe('Certification | Evaluation | Integration | Domain | Usecases | Score v
               },
             ],
           },
+          {
+            id: 'recCompetence4',
+            index: '1.5',
+            tubes: [
+              {
+                id: 'recTube4_0',
+                skills: [
+                  {
+                    id: 'recSkill4_0',
+                    nom: '@recSkill4_0',
+                    challenges: [{ id: 'recChallenge4_0_0', ...challengeParams }],
+                  },
+                  {
+                    id: 'recSkill4_1',
+                    nom: '@recSkill4_1',
+                    challenges: [{ id: 'recChallenge4_1_0', ...challengeParams }],
+                  },
+                ],
+              },
+            ],
+          },
         ],
       },
     ];
@@ -119,7 +140,8 @@ describe('Certification | Evaluation | Integration | Domain | Usecases | Score v
     await mockLearningContent(learningContentObjects);
 
     certificationVersionId = databaseBuilder.factory.buildCertificationVersion({
-      challengesConfiguration: { maximumAssessmentLength: 8 },
+      challengesConfiguration: { maximumAssessmentLength: 10 },
+      minimumAnswersRequiredToValidateACertification: 10,
     }).id;
 
     await databaseBuilder.commit();
@@ -165,52 +187,117 @@ describe('Certification | Evaluation | Integration | Domain | Usecases | Score v
       await databaseBuilder.commit();
     });
 
-    it('should score the certification', async function () {
-      // given
-      const event = new CertificationCompletedJob({
-        certificationCourseId,
-        locale: FRENCH_SPOKEN,
-      });
+    context('when pix score is not 0 (so competence marks are created)', function () {
+      it('should score the certification', async function () {
+        // given
+        _buildValidAnswersAndCertificationChallenges({
+          assessmentId: completedCertificationAssessmentId,
+          certificationCourseId,
+          versionId: certificationVersionId,
+        });
+        await databaseBuilder.commit();
+        const event = new CertificationCompletedJob({
+          certificationCourseId,
+          locale: FRENCH_SPOKEN,
+        });
 
-      // when
-      await usecases.scoreV3Certification({ certificationCourseId, event });
+        // when
+        await usecases.scoreV3Certification({ certificationCourseId, event });
 
-      // then
-      const results = await knex('assessment-results').where({ assessmentId: completedCertificationAssessmentId });
-      expect(results).to.have.lengthOf(1);
+        // then
+        const results = await knex('assessment-results').where({ assessmentId: completedCertificationAssessmentId });
+        expect(results).to.have.lengthOf(1);
 
-      const linkToCertifCourse = await knex('certification-courses-last-assessment-results')
-        .where({
+        const linkToCertifCourse = await knex('certification-courses-last-assessment-results')
+          .where({
+            lastAssessmentResultId: results[0].id,
+            certificationCourseId: certificationCourseId,
+          })
+          .first();
+        expect(linkToCertifCourse).to.deep.equal({
           lastAssessmentResultId: results[0].id,
           certificationCourseId: certificationCourseId,
-        })
-        .first();
-      expect(linkToCertifCourse).to.deep.equal({
-        lastAssessmentResultId: results[0].id,
-        certificationCourseId: certificationCourseId,
+        });
+
+        const certifCourseCompletedAt = await knex('certification-courses')
+          .select('completedAt')
+          .where({
+            id: certificationCourseId,
+          })
+          .first();
+
+        expect(certifCourseCompletedAt).not.to.be.null;
+        const competenceMarks = await knex('competence-marks').where({ assessmentResultId: results[0].id });
+        expect(competenceMarks).to.have.lengthOf(1);
+        expect(competenceMarks[0].assessmentResultId).to.equal(results[0].id);
+
+        const certificationChallengeCapacities = await knex('certification-challenge-capacities').whereIn(
+          'certificationChallengeId',
+          knex('certification-challenges').select('id').where({ courseId: certificationCourseId }),
+        );
+        expect(certificationChallengeCapacities).to.have.lengthOf(10);
       });
+    });
 
-      const certifCourseCompletedAt = await knex('certification-courses')
-        .select('completedAt')
-        .where({
-          id: certificationCourseId,
-        })
-        .first();
+    context('when pix score is 0, thus creating no competence mark', function () {
+      it('should score a certification without competence marks when pixScore is 0', async function () {
+        // given
+        _buildInvalidAnswersAndCertificationChallenges({
+          assessmentId: completedCertificationAssessmentId,
+          certificationCourseId,
+          versionId: certificationVersionId,
+        });
+        await databaseBuilder.commit();
+        const event = new CertificationCompletedJob({
+          certificationCourseId,
+          locale: FRENCH_SPOKEN,
+        });
 
-      expect(certifCourseCompletedAt).not.to.be.null;
-      const competenceMarks = await knex('competence-marks').where({ assessmentResultId: results[0].id });
-      expect(competenceMarks).to.have.lengthOf(1);
-      expect(competenceMarks[0].assessmentResultId).to.equal(results[0].id);
+        // when
+        await usecases.scoreV3Certification({ certificationCourseId, event });
 
-      const certificationChallengeCapacities = await knex('certification-challenge-capacities').whereIn(
-        'certificationChallengeId',
-        knex('certification-challenges').select('id').where({ courseId: certificationCourseId }),
-      );
-      expect(certificationChallengeCapacities).to.have.lengthOf(8);
+        // then
+        const results = await knex('assessment-results').where({ assessmentId: completedCertificationAssessmentId });
+        expect(results).to.have.lengthOf(1);
+
+        const linkToCertifCourse = await knex('certification-courses-last-assessment-results')
+          .where({
+            lastAssessmentResultId: results[0].id,
+            certificationCourseId: certificationCourseId,
+          })
+          .first();
+        expect(linkToCertifCourse).to.deep.equal({
+          lastAssessmentResultId: results[0].id,
+          certificationCourseId: certificationCourseId,
+        });
+
+        const certifCourseCompletedAt = await knex('certification-courses')
+          .select('completedAt')
+          .where({
+            id: certificationCourseId,
+          })
+          .first();
+
+        expect(certifCourseCompletedAt).not.to.be.null;
+        const competenceMarks = await knex('competence-marks').where({ assessmentResultId: results[0].id });
+        expect(competenceMarks).to.have.lengthOf(0);
+
+        const certificationChallengeCapacities = await knex('certification-challenge-capacities').whereIn(
+          'certificationChallengeId',
+          knex('certification-challenges').select('id').where({ courseId: certificationCourseId }),
+        );
+        expect(certificationChallengeCapacities).to.have.lengthOf(10);
+      });
     });
 
     it('should rollback scoring if any error happens', async function () {
       // given
+      _buildValidAnswersAndCertificationChallenges({
+        assessmentId: completedCertificationAssessmentId,
+        certificationCourseId,
+        versionId: certificationVersionId,
+      });
+      await databaseBuilder.commit();
       const event = new CertificationCompletedJob({
         certificationCourseId,
         locale: FRENCH_SPOKEN,
@@ -363,7 +450,7 @@ describe('Certification | Evaluation | Integration | Domain | Usecases | Score v
         'certificationChallengeId',
         knex('certification-challenges').select('id').where({ courseId: certificationCourseId }),
       );
-      expect(certificationChallengeCapacities).to.have.lengthOf(8);
+      expect(certificationChallengeCapacities).to.have.lengthOf(10);
 
       const complementaryResults = await knex('complementary-certification-course-results').where({
         complementaryCertificationCourseId,
@@ -435,7 +522,7 @@ describe('Certification | Evaluation | Integration | Domain | Usecases | Score v
 });
 
 function _buildValidAnswersAndCertificationChallenges({ certificationCourseId, assessmentId, versionId }) {
-  for (let iCompetence = 0; iCompetence < 4; iCompetence++) {
+  for (let iCompetence = 0; iCompetence < 5; iCompetence++) {
     for (let i = 0; i < 2; ++i) {
       databaseBuilder.factory.buildCertificationFrameworksChallenge({
         challengeId: `recChallenge${iCompetence}_${i}_0`,
@@ -446,6 +533,30 @@ function _buildValidAnswersAndCertificationChallenges({ certificationCourseId, a
       databaseBuilder.factory.buildAnswer({
         challengeId: `recChallenge${iCompetence}_${i}_0`,
         result: 'ok',
+        assessmentId: assessmentId,
+      });
+      databaseBuilder.factory.buildCertificationChallenge({
+        challengeId: `recChallenge${iCompetence}_${i}_0`,
+        courseId: certificationCourseId,
+        discriminant: challengeParams.delta,
+        difficulty: challengeParams.alpha,
+      });
+    }
+  }
+}
+
+function _buildInvalidAnswersAndCertificationChallenges({ assessmentId, certificationCourseId, versionId }) {
+  for (let iCompetence = 0; iCompetence < 5; iCompetence++) {
+    for (let i = 0; i < 2; ++i) {
+      databaseBuilder.factory.buildCertificationFrameworksChallenge({
+        challengeId: `recChallenge${iCompetence}_${i}_0`,
+        versionId,
+        discriminant: -8,
+        difficulty: -8,
+      });
+      databaseBuilder.factory.buildAnswer({
+        challengeId: `recChallenge${iCompetence}_${i}_0`,
+        result: 'ko',
         assessmentId: assessmentId,
       });
       databaseBuilder.factory.buildCertificationChallenge({

--- a/api/tests/certification/shared/integration/infrastructure/repositories/competence-mark-repository_test.js
+++ b/api/tests/certification/shared/integration/infrastructure/repositories/competence-mark-repository_test.js
@@ -49,7 +49,7 @@ describe('Integration | Repository | CompetenceMark', function () {
   });
 
   describe('#saveMany', function () {
-    it('should persist competence marks in db and return them', async function () {
+    it('should persist competence marks in db', async function () {
       // given
       const assessmentResultId = await databaseBuilder.factory.buildAssessmentResult().id;
       await databaseBuilder.commit();
@@ -61,14 +61,11 @@ describe('Integration | Repository | CompetenceMark', function () {
       ];
 
       // when
-      const savedMarks = await competenceMarkRepository.saveMany({ competenceMarks });
+      await competenceMarkRepository.saveMany({ competenceMarks });
 
       // then
       const marks = await knex('competence-marks').select();
       expect(marks).to.have.lengthOf(3);
-
-      expect(savedMarks[1]).to.be.an.instanceOf(CompetenceMark);
-      expect(savedMarks[1]).to.have.property('id').and.not.to.be.null;
     });
   });
 });

--- a/high-level-tests/e2e-playwright/fixtures/certification/certif-setup.ts
+++ b/high-level-tests/e2e-playwright/fixtures/certification/certif-setup.ts
@@ -42,6 +42,12 @@ type PassManyCertificationExamsParams = {
 
 type PassCertificationExamResult = {
   invigilatorOverviewPage: InvigilatorOverviewPage;
+  certificationNumber: string;
+};
+
+type PassManyCertificationExamsResults = {
+  invigilatorOverviewPage: InvigilatorOverviewPage;
+  certificationNumbers: string[];
 };
 
 type EnrollCandidateAndPassExamParams = {
@@ -54,14 +60,14 @@ type EnrollCandidateAndPassExamParams = {
 
 type EnrollCandidateAndPassExamResult = {
   sessionNumber: string;
+  certificationNumber: string;
   invigilatorOverviewPage: InvigilatorOverviewPage;
 };
 
-// todo renomme moi
 export const certifSetupFixtures = baseCertifTest.extend<{
   enrollCandidate: (args: EnrollCandidateParams) => Promise<EnrollCandidateResult>;
   passCertificationExam: (args: PassCertificationExamParams) => Promise<PassCertificationExamResult>;
-  passManyCertificationExams: (args: PassManyCertificationExamsParams) => Promise<PassCertificationExamResult>;
+  passManyCertificationExams: (args: PassManyCertificationExamsParams) => Promise<PassManyCertificationExamsResults>;
   enrollCandidateAndPassExam: (args: EnrollCandidateAndPassExamParams) => Promise<EnrollCandidateAndPassExamResult>;
 }>({
   enrollCandidate: async ({ pixCertifProPage }, use) => {
@@ -122,6 +128,7 @@ export const certifSetupFixtures = baseCertifTest.extend<{
       rightWrongAnswersSequence,
       pixAppPage,
     }: PassCertificationExamParams) => {
+      let certificationNumber: string = '';
       const invigilatorOverviewPage = await certifSetupFixtures.step('Evaluation', async () => {
         await pixAppPage.goto(process.env.PIX_APP_URL!);
 
@@ -152,6 +159,7 @@ export const certifSetupFixtures = baseCertifTest.extend<{
 
         await certifSetupFixtures.step('Candidate takes the test', async () => {
           const challengePage = await certificationAccessCodePage.fillAccessCodeAndStartCertificationTest(accessCode);
+          certificationNumber = await challengePage.getCertificationNumber();
           for (const [i, shouldAnswerCorrectly] of rightWrongAnswersSequence.entries()) {
             const challengeImprint = await challengePage.getChallengeImprint();
             snapshotHandler.push('challenge imprint to have value', challengeImprint);
@@ -165,6 +173,7 @@ export const certifSetupFixtures = baseCertifTest.extend<{
 
       return {
         invigilatorOverviewPage,
+        certificationNumber,
       };
     };
     await use(passCertificationExam);
@@ -176,6 +185,7 @@ export const certifSetupFixtures = baseCertifTest.extend<{
       accessCode,
       invigilatorCode,
     }: PassManyCertificationExamsParams) => {
+      const certificationNumbers: string[] = [];
       const invigilatorOverviewPage = await certifSetupFixtures.step('Evaluation', async () => {
         const reachAccessCodePagePromises = examsData.map(async (examData) => {
           await examData.pixAppPage.goto(process.env.PIX_APP_URL!);
@@ -224,6 +234,8 @@ export const certifSetupFixtures = baseCertifTest.extend<{
             `Candidate ${examData.certifiableUserData.firstName} takes the test`,
             async () => {
               const challengePage = await accessCodePage.fillAccessCodeAndStartCertificationTest(accessCode);
+              const certificationNumber = await challengePage.getCertificationNumber();
+              certificationNumbers.push(certificationNumber);
               for (const [i, shouldAnswerCorrectly] of examData.rightWrongAnswersSequence.entries()) {
                 await expect(examData.pixAppPage.getByLabel('Votre progression')).toContainText(`${i + 1} / 32`);
                 await challengePage.setRightOrWrongAnswer(shouldAnswerCorrectly);
@@ -241,6 +253,7 @@ export const certifSetupFixtures = baseCertifTest.extend<{
 
       return {
         invigilatorOverviewPage,
+        certificationNumbers,
       };
     };
     await use(passManyCertificationExams);
@@ -258,7 +271,7 @@ export const certifSetupFixtures = baseCertifTest.extend<{
         certificationKey,
         certifiableUserData,
       });
-      const { invigilatorOverviewPage } = await passCertificationExam({
+      const { invigilatorOverviewPage, certificationNumber } = await passCertificationExam({
         certifiableUserData,
         sessionNumber,
         accessCode,
@@ -268,7 +281,7 @@ export const certifSetupFixtures = baseCertifTest.extend<{
         pixAppPage,
       });
 
-      return { sessionNumber, invigilatorOverviewPage };
+      return { sessionNumber, invigilatorOverviewPage, certificationNumber };
     };
     await use(enrollCandidateAndPassExam);
   },

--- a/high-level-tests/e2e-playwright/fixtures/certification/certif-setup.ts
+++ b/high-level-tests/e2e-playwright/fixtures/certification/certif-setup.ts
@@ -1,6 +1,7 @@
 import { Page } from '@playwright/test';
 
 import { PixCertifiableUserData } from '../../helpers/certification/builders/types.ts';
+import { knex } from '../../helpers/db.ts';
 import { CERTIFICATIONS_DATA } from '../../helpers/db-data.ts';
 import { HomePage } from '../../pages/pix-app/index.ts';
 import { InvigilatorLoginPage, InvigilatorOverviewPage, SessionListPage } from '../../pages/pix-certif/index.ts';
@@ -69,6 +70,7 @@ export const certifSetupFixtures = baseCertifTest.extend<{
   passCertificationExam: (args: PassCertificationExamParams) => Promise<PassCertificationExamResult>;
   passManyCertificationExams: (args: PassManyCertificationExamsParams) => Promise<PassManyCertificationExamsResults>;
   enrollCandidateAndPassExam: (args: EnrollCandidateAndPassExamParams) => Promise<EnrollCandidateAndPassExamResult>;
+  waitForScoringJobToBeCompleted: (args: string) => Promise<void>;
 }>({
   enrollCandidate: async ({ pixCertifProPage }, use) => {
     const enrollCandidate = async ({
@@ -284,6 +286,30 @@ export const certifSetupFixtures = baseCertifTest.extend<{
       return { sessionNumber, invigilatorOverviewPage, certificationNumber };
     };
     await use(enrollCandidateAndPassExam);
+  },
+  // eslint-disable-next-line no-empty-pattern
+  waitForScoringJobToBeCompleted: async ({}, use) => {
+    const waitForScoringJobToBeCompleted = async (certificationNumber: string) => {
+      const start = Date.now();
+
+      while (Date.now() - start < 10_000) {
+        const job = await knex('pgboss.job')
+          .where({
+            name: 'CertificationCompletedJob',
+          })
+          .whereRaw(`data @> ?::jsonb`, [JSON.stringify({ certificationCourseId: parseInt(certificationNumber) })])
+          .first();
+
+        if (job?.state === 'completed') {
+          return;
+        }
+
+        await new Promise((r) => setTimeout(r, 1_000));
+      }
+
+      throw new Error('Certification job did not reach completed state in time or never existed');
+    };
+    await use(waitForScoringJobToBeCompleted);
   },
 });
 

--- a/high-level-tests/e2e-playwright/fixtures/certification/logged-pages.ts
+++ b/high-level-tests/e2e-playwright/fixtures/certification/logged-pages.ts
@@ -333,7 +333,7 @@ export const loggedPagesFixtures = sharedTest.extend<
           await pixApp.getByRole('link', { name: "J'ai un code" }).click();
           const startCampaignPage = new StartCampaignPage(pixApp);
           await startCampaignPage.goToFirstChallenge(campaignCode as string);
-          while (!pixApp.url().endsWith('/checkpoint?finalCheckpoint=true')) {
+          while (!pixApp.url().includes('finalCheckpoint=true')) {
             const challengePage = new ChallengePage(pixApp);
             await challengePage.setRightOrWrongAnswer(true);
             await challengePage.validateAnswer();

--- a/high-level-tests/e2e-playwright/helpers/utils.ts
+++ b/high-level-tests/e2e-playwright/helpers/utils.ts
@@ -1,4 +1,4 @@
-import { Locator, Page } from '@playwright/test';
+import { expect, Locator, Page } from '@playwright/test';
 
 export function* rightWrongAnswerCycle({ numRight = 1, numWrong = 1 }) {
   const answers: boolean[] = [];
@@ -91,10 +91,14 @@ export async function waitForVisibleWithReload(
 
   while (Date.now() - start < timeout) {
     await page.reload();
+    await page.waitForLoadState('domcontentloaded');
 
-    if (await locator.isVisible()) return;
-
-    await page.waitForTimeout(interval);
+    try {
+      await expect(locator).toBeVisible({ timeout: interval });
+      return;
+    } catch {
+      // element not here yet, reloading...
+    }
   }
 
   throw new Error('Element did not appear before timeout');

--- a/high-level-tests/e2e-playwright/pages/pix-app/ChallengePage.ts
+++ b/high-level-tests/e2e-playwright/pages/pix-app/ChallengePage.ts
@@ -65,4 +65,8 @@ export class ChallengePage {
     await this.page.getByRole('button', { name: 'Quitter' }).click();
     await this.page.getByRole('link', { name: "Quitter l'épreuve et retourner à la page d'accueil" }).click();
   }
+
+  async getCertificationNumber() {
+    return await this.page.locator('.certification-number__value').innerText();
+  }
 }

--- a/high-level-tests/e2e-playwright/pages/pix-app/ChallengePage.ts
+++ b/high-level-tests/e2e-playwright/pages/pix-app/ChallengePage.ts
@@ -1,4 +1,4 @@
-import type { Page } from '@playwright/test';
+import { Page } from '@playwright/test';
 export class ChallengePage {
   constructor(public readonly page: Page) {}
 
@@ -16,31 +16,39 @@ export class ChallengePage {
   }
 
   async skip() {
+    const previousUrl = this.page.url();
     const challengeNumber = await this.getChallengeImprint();
     const validateAnswerButton = this.page.getByRole('button', {
       name: 'Je passe et je vais à la prochaine question',
     });
     // Forces to wait until next challenge is loaded
     const selector = `p:has-text("ninaimprint ${challengeNumber}")`;
-    await Promise.all([validateAnswerButton.click(), this.page.waitForSelector(selector, { state: 'detached' })]);
+    await validateAnswerButton.click();
+    await this.page.waitForSelector(selector, { state: 'detached' });
     const hasLoader = await this.page.locator('.app-loader').isVisible();
     if (hasLoader) {
       await this.page.waitForSelector('.app-loader', { state: 'detached' });
     }
+    await this.page.waitForURL((url) => url.toString() !== previousUrl);
+    await this.page.waitForLoadState('domcontentloaded');
   }
 
   async validateAnswer() {
+    const previousUrl = this.page.url();
     const challengeNumber = await this.getChallengeImprint();
     const validateAnswerButton = this.page.getByRole('button', {
       name: 'Je valide et je vais à la prochaine question',
     });
     // Forces to wait until next challenge is loaded
     const selector = `p:has-text("ninaimprint ${challengeNumber}")`;
-    await Promise.all([validateAnswerButton.click(), this.page.waitForSelector(selector, { state: 'detached' })]);
+    await validateAnswerButton.click();
+    await this.page.waitForSelector(selector, { state: 'detached' });
     const hasLoader = await this.page.locator('.app-loader').isVisible();
     if (hasLoader) {
       await this.page.waitForSelector('.app-loader', { state: 'detached' });
     }
+    await this.page.waitForURL((url) => url.toString() !== previousUrl);
+    await this.page.waitForLoadState('domcontentloaded');
   }
 
   async hasUserLeveledUp() {

--- a/high-level-tests/e2e-playwright/playwright.config.certif.ts
+++ b/high-level-tests/e2e-playwright/playwright.config.certif.ts
@@ -4,7 +4,7 @@ import sharedConfig, { App, isCI, reuseExistingApps, setupWebServer } from './pl
 
 export default defineConfig({
   ...sharedConfig,
-  timeout: 70_000,
+  timeout: 80_000,
   projects: [
     {
       name: 'Recette',

--- a/high-level-tests/e2e-playwright/tests/assessments/campaign-evaluation.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/assessments/campaign-evaluation.spec.ts
@@ -67,7 +67,7 @@ test(
       const startCampaignPage = new StartCampaignPage(pixAppPage);
       await startCampaignPage.goToFirstChallenge(campaignCode as string);
       await test.step(` answering right or wrong according to pattern`, async () => {
-        while (!pixAppPage.url().endsWith('/checkpoint?finalCheckpoint=true')) {
+        while (!pixAppPage.url().includes('finalCheckpoint=true')) {
           const challengePage = new ChallengePage(pixAppPage);
           const challengeImprint = await challengePage.getChallengeImprint();
           snapshotHandler.push('challenge imprint to have value', challengeImprint);

--- a/high-level-tests/e2e-playwright/tests/assessments/competence-evaluation.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/assessments/competence-evaluation.spec.ts
@@ -60,7 +60,7 @@ test(
         await page.getByRole('link', { name: 'Commencer' }).click();
 
         await test.step(`"${competenceTitle}" answering right or wrong according to pattern`, async () => {
-          while (!page.url().endsWith('/checkpoint?finalCheckpoint=true')) {
+          while (!page.url().includes('finalCheckpoint=true')) {
             const challengePage = new ChallengePage(page);
             const challengeImprint = await challengePage.getChallengeImprint();
             snapshotHandler.push('challenge imprint to have value', challengeImprint);

--- a/high-level-tests/e2e-playwright/tests/pix-orga/assessment-campaign.test.ts
+++ b/high-level-tests/e2e-playwright/tests/pix-orga/assessment-campaign.test.ts
@@ -57,7 +57,7 @@ test('Assessment campaign', async ({ page }) => {
     await startCampaignPage.goToFirstChallenge(campaignCode);
 
     await test.step(`answering right or wrong according to pattern`, async () => {
-      while (!page.url().endsWith('/checkpoint?finalCheckpoint=true')) {
+      while (!page.url().includes('finalCheckpoint=true')) {
         const challengePage = new ChallengePage(page);
         await challengePage.setRightOrWrongAnswer(rightWrongAnswerCycleIter.next().value as boolean);
         await challengePage.validateAnswer();

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/clea/PRO_CLEA_0OK-32KO.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/clea/PRO_CLEA_0OK-32KO.spec.ts
@@ -37,14 +37,13 @@ test(
   }) => {
     const certifiableUserData = await getCertifiableUserData(0);
     const pixAppCertifiablePage = await pixAppCertifiableUserPage(certifiableUserData);
-    const { sessionNumber } = await enrollCandidateAndPassExam({
+    const { sessionNumber, certificationNumber } = await enrollCandidateAndPassExam({
       testRef,
       rightWrongAnswersSequence: Array(32).fill(false),
       certificationKey: CERTIFICATIONS_DATA.CLEA.key,
       pixAppPage: pixAppCertifiablePage,
       certifiableUserData,
     });
-    let certificationNumber = '';
 
     await test.step(`reaches end of certification test`, async () => {
       await expect(pixAppCertifiablePage.locator('h1')).toContainText('Test terminé !');
@@ -98,7 +97,6 @@ test(
         const certificationInformationPage = await certificationListPage.goToCertificationInfoPage(
           certifiableUserData.firstName,
         );
-        certificationNumber = certificationInformationPage.getCertificationNumber();
         await checkCertificationGeneralInformationAndExpectSuccess(certificationInformationPage, {
           sessionNumber,
           status: 'Rejetée',

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/clea/PRO_CLEA_0OK-32KO.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/clea/PRO_CLEA_0OK-32KO.spec.ts
@@ -33,6 +33,7 @@ test(
     enrollCandidateAndPassExam,
     pixAdminRoleCertifPage,
     pixAppCertifiableUserPage,
+    waitForScoringJobToBeCompleted,
     snapshotHandler,
   }) => {
     const certifiableUserData = await getCertifiableUserData(0);
@@ -50,6 +51,7 @@ test(
       await expect(pixAppCertifiablePage.locator('h2')).toContainText(
         'Vos résultats, en attente de validation par les équipes Pix, seront bientôt disponibles sur votre compte Pix',
       );
+      await waitForScoringJobToBeCompleted(certificationNumber);
     });
 
     await test.step('Finalization and scoring', async () => {

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/clea/PRO_CLEA_1OK-0KO_EndedByFinalization_Abandonment.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/clea/PRO_CLEA_1OK-0KO_EndedByFinalization_Abandonment.spec.ts
@@ -37,14 +37,13 @@ test(
   }) => {
     const certifiableUserData = await getCertifiableUserData(0);
     const pixAppCertifiablePage = await pixAppCertifiableUserPage(certifiableUserData);
-    const { sessionNumber } = await enrollCandidateAndPassExam({
+    const { sessionNumber, certificationNumber } = await enrollCandidateAndPassExam({
       testRef,
       rightWrongAnswersSequence: [true],
       certificationKey: CERTIFICATIONS_DATA.CLEA.key,
       pixAppPage: pixAppCertifiablePage,
       certifiableUserData,
     });
-    let certificationNumber = '';
 
     await test.step('user stops at second challenge', async () => {
       await expect(pixAppCertifiablePage.getByLabel('Votre progression')).toContainText('2 / 32');
@@ -95,7 +94,6 @@ test(
         const certificationInformationPage = await certificationListPage.goToCertificationInfoPage(
           certifiableUserData.firstName,
         );
-        certificationNumber = certificationInformationPage.getCertificationNumber();
         await checkCertificationGeneralInformationAndExpectSuccess(certificationInformationPage, {
           sessionNumber,
           status: 'Rejetée',

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/clea/PRO_CLEA_1OK-0KO_EndedByFinalization_TechnicalIssue.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/clea/PRO_CLEA_1OK-0KO_EndedByFinalization_TechnicalIssue.spec.ts
@@ -37,14 +37,13 @@ test(
   }) => {
     const certifiableUserData = await getCertifiableUserData(0);
     const pixAppCertifiablePage = await pixAppCertifiableUserPage(certifiableUserData);
-    const { sessionNumber } = await enrollCandidateAndPassExam({
+    const { sessionNumber, certificationNumber } = await enrollCandidateAndPassExam({
       testRef,
       rightWrongAnswersSequence: [true],
       certificationKey: CERTIFICATIONS_DATA.CLEA.key,
       pixAppPage: pixAppCertifiablePage,
       certifiableUserData,
     });
-    let certificationNumber = '';
 
     await test.step('user stops at second challenge', async () => {
       await expect(pixAppCertifiablePage.getByLabel('Votre progression')).toContainText('2 / 32');
@@ -95,7 +94,6 @@ test(
         const certificationInformationPage = await certificationListPage.goToCertificationInfoPage(
           certifiableUserData.firstName,
         );
-        certificationNumber = certificationInformationPage.getCertificationNumber();
         await checkCertificationGeneralInformationAndExpectSuccess(certificationInformationPage, {
           sessionNumber,
           status: 'Annulée',

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/clea/PRO_CLEA_1OK-0KO_EndedByInvigilator_Abandonment.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/clea/PRO_CLEA_1OK-0KO_EndedByInvigilator_Abandonment.spec.ts
@@ -37,14 +37,13 @@ test(
   }) => {
     const certifiableUserData = await getCertifiableUserData(0);
     const pixAppCertifiablePage = await pixAppCertifiableUserPage(certifiableUserData);
-    const { sessionNumber, invigilatorOverviewPage } = await enrollCandidateAndPassExam({
+    const { sessionNumber, invigilatorOverviewPage, certificationNumber } = await enrollCandidateAndPassExam({
       testRef,
       rightWrongAnswersSequence: [true],
       certificationKey: CERTIFICATIONS_DATA.CLEA.key,
       pixAppPage: pixAppCertifiablePage,
       certifiableUserData,
     });
-    let certificationNumber = '';
 
     await test.step('user stops at second challenge', async () => {
       await expect(pixAppCertifiablePage.getByLabel('Votre progression')).toContainText('2 / 32');
@@ -99,7 +98,6 @@ test(
         const certificationInformationPage = await certificationListPage.goToCertificationInfoPage(
           certifiableUserData.firstName,
         );
-        certificationNumber = certificationInformationPage.getCertificationNumber();
         await checkCertificationGeneralInformationAndExpectSuccess(certificationInformationPage, {
           sessionNumber,
           status: 'Rejetée',

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/clea/PRO_CLEA_1OK-0KO_EndedByInvigilator_TechnicalIssue.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/clea/PRO_CLEA_1OK-0KO_EndedByInvigilator_TechnicalIssue.spec.ts
@@ -37,14 +37,13 @@ test(
   }) => {
     const certifiableUserData = await getCertifiableUserData(0);
     const pixAppCertifiablePage = await pixAppCertifiableUserPage(certifiableUserData);
-    const { sessionNumber, invigilatorOverviewPage } = await enrollCandidateAndPassExam({
+    const { sessionNumber, invigilatorOverviewPage, certificationNumber } = await enrollCandidateAndPassExam({
       testRef,
       rightWrongAnswersSequence: [true],
       certificationKey: CERTIFICATIONS_DATA.CLEA.key,
       pixAppPage: pixAppCertifiablePage,
       certifiableUserData,
     });
-    let certificationNumber = '';
 
     await test.step('user stops at second challenge', async () => {
       await expect(pixAppCertifiablePage.getByLabel('Votre progression')).toContainText('2 / 32');
@@ -99,7 +98,6 @@ test(
         const certificationInformationPage = await certificationListPage.goToCertificationInfoPage(
           certifiableUserData.firstName,
         );
-        certificationNumber = certificationInformationPage.getCertificationNumber();
         await checkCertificationGeneralInformationAndExpectSuccess(certificationInformationPage, {
           sessionNumber,
           status: 'Annulée',

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/clea/PRO_CLEA_32OK-0KO.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/clea/PRO_CLEA_32OK-0KO.spec.ts
@@ -38,14 +38,13 @@ test(
   }) => {
     const certifiableUserData = await getCertifiableUserData(0);
     const pixAppCertifiablePage = await pixAppCertifiableUserPage(certifiableUserData);
-    const { sessionNumber } = await enrollCandidateAndPassExam({
+    const { sessionNumber, certificationNumber } = await enrollCandidateAndPassExam({
       testRef,
       rightWrongAnswersSequence: Array(32).fill(true),
       certificationKey: CERTIFICATIONS_DATA.CLEA.key,
       pixAppPage: pixAppCertifiablePage,
       certifiableUserData,
     });
-    let certificationNumber = '';
 
     await test.step(`reaches end of certification test`, async () => {
       await expect(pixAppCertifiablePage.locator('h1')).toContainText('Test terminé !');
@@ -99,7 +98,6 @@ test(
         const certificationInformationPage = await certificationListPage.goToCertificationInfoPage(
           certifiableUserData.firstName,
         );
-        certificationNumber = certificationInformationPage.getCertificationNumber();
         await checkCertificationGeneralInformationAndExpectSuccess(certificationInformationPage, {
           sessionNumber,
           status: 'Validée',

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/clea/PRO_CLEA_32OK-0KO.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/clea/PRO_CLEA_32OK-0KO.spec.ts
@@ -34,6 +34,7 @@ test(
     enrollCandidateAndPassExam,
     pixAdminRoleCertifPage,
     getCertifiableUserData,
+    waitForScoringJobToBeCompleted,
     snapshotHandler,
   }) => {
     const certifiableUserData = await getCertifiableUserData(0);
@@ -51,6 +52,7 @@ test(
       await expect(pixAppCertifiablePage.locator('h2')).toContainText(
         'Vos résultats, en attente de validation par les équipes Pix, seront bientôt disponibles sur votre compte Pix',
       );
+      await waitForScoringJobToBeCompleted(certificationNumber);
     });
 
     await test.step('Finalization and scoring', async () => {

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/clea/PRO_CLEA_32OK-0KO_Rescore.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/clea/PRO_CLEA_32OK-0KO_Rescore.spec.ts
@@ -39,14 +39,13 @@ test(
   }) => {
     const certifiableUserData = await getCertifiableUserData(0);
     const pixAppCertifiablePage = await pixAppCertifiableUserPage(certifiableUserData);
-    const { sessionNumber } = await enrollCandidateAndPassExam({
+    const { sessionNumber, certificationNumber } = await enrollCandidateAndPassExam({
       testRef,
       rightWrongAnswersSequence: Array(32).fill(true),
       certificationKey: CERTIFICATIONS_DATA.CLEA.key,
       pixAppPage: pixAppCertifiablePage,
       certifiableUserData,
     });
-    let certificationNumber = '';
 
     await test.step(`reaches end of certification test`, async () => {
       await expect(pixAppCertifiablePage.locator('h1')).toContainText('Test terminé !');
@@ -100,7 +99,6 @@ test(
         const certificationInformationPage = await certificationListPage.goToCertificationInfoPage(
           certifiableUserData.firstName,
         );
-        certificationNumber = certificationInformationPage.getCertificationNumber();
         await checkCertificationGeneralInformationAndExpectSuccess(certificationInformationPage, {
           sessionNumber,
           status: 'Validée',

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/clea/PRO_CLEA_32OK-0KO_Rescore.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/clea/PRO_CLEA_32OK-0KO_Rescore.spec.ts
@@ -35,6 +35,7 @@ test(
     enrollCandidateAndPassExam,
     pixAdminRoleCertifPage,
     getCertifiableUserData,
+    waitForScoringJobToBeCompleted,
     snapshotHandler,
   }) => {
     const certifiableUserData = await getCertifiableUserData(0);
@@ -52,6 +53,7 @@ test(
       await expect(pixAppCertifiablePage.locator('h2')).toContainText(
         'Vos résultats, en attente de validation par les équipes Pix, seront bientôt disponibles sur votre compte Pix',
       );
+      await waitForScoringJobToBeCompleted(certificationNumber);
     });
 
     await test.step('Finalization and scoring', async () => {

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/core/PRO_CORE_0OK-32KO.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/core/PRO_CORE_0OK-32KO.spec.ts
@@ -32,6 +32,7 @@ test(
     enrollCandidateAndPassExam,
     pixAdminRoleCertifPage,
     getCertifiableUserData,
+    waitForScoringJobToBeCompleted,
     snapshotHandler,
   }) => {
     const certifiableUserData = await getCertifiableUserData(0);
@@ -48,6 +49,7 @@ test(
       await expect(pixAppCertifiablePage.locator('h2')).toContainText(
         'Vos résultats, en attente de validation par les équipes Pix, seront bientôt disponibles sur votre compte Pix',
       );
+      await waitForScoringJobToBeCompleted(certificationNumber);
     });
 
     await test.step('Finalization and scoring', async () => {

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/core/PRO_CORE_0OK-32KO.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/core/PRO_CORE_0OK-32KO.spec.ts
@@ -36,13 +36,12 @@ test(
   }) => {
     const certifiableUserData = await getCertifiableUserData(0);
     const pixAppCertifiablePage = await pixAppCertifiableUserPage(certifiableUserData);
-    const { sessionNumber } = await enrollCandidateAndPassExam({
+    const { sessionNumber, certificationNumber } = await enrollCandidateAndPassExam({
       testRef,
       rightWrongAnswersSequence: Array(32).fill(false),
       pixAppPage: pixAppCertifiablePage,
       certifiableUserData,
     });
-    let certificationNumber = '';
 
     await test.step(`reaches end of certification test`, async () => {
       await expect(pixAppCertifiablePage.locator('h1')).toContainText('Test terminé !');
@@ -96,7 +95,6 @@ test(
         const certificationInformationPage = await certificationListPage.goToCertificationInfoPage(
           certifiableUserData.firstName,
         );
-        certificationNumber = certificationInformationPage.getCertificationNumber();
         await checkCertificationGeneralInformationAndExpectSuccess(certificationInformationPage, {
           sessionNumber,
           status: 'Rejetée',

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/core/PRO_CORE_1OK-0KO_EndedByFinalization_Abandonment.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/core/PRO_CORE_1OK-0KO_EndedByFinalization_Abandonment.spec.ts
@@ -36,13 +36,12 @@ test(
   }) => {
     const certifiableUserData = await getCertifiableUserData(0);
     const pixAppCertifiablePage = await pixAppCertifiableUserPage(certifiableUserData);
-    const { sessionNumber } = await enrollCandidateAndPassExam({
+    const { sessionNumber, certificationNumber } = await enrollCandidateAndPassExam({
       testRef,
       rightWrongAnswersSequence: [true],
       pixAppPage: pixAppCertifiablePage,
       certifiableUserData,
     });
-    let certificationNumber = '';
 
     await test.step('user stops at second challenge', async () => {
       await expect(pixAppCertifiablePage.getByLabel('Votre progression')).toContainText('2 / 32');
@@ -93,7 +92,6 @@ test(
         const certificationInformationPage = await certificationListPage.goToCertificationInfoPage(
           certifiableUserData.firstName,
         );
-        certificationNumber = certificationInformationPage.getCertificationNumber();
         await checkCertificationGeneralInformationAndExpectSuccess(certificationInformationPage, {
           sessionNumber,
           status: 'Rejetée',

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/core/PRO_CORE_1OK-0KO_EndedByFinalization_TechnicalIssue.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/core/PRO_CORE_1OK-0KO_EndedByFinalization_TechnicalIssue.spec.ts
@@ -36,13 +36,12 @@ test(
   }) => {
     const certifiableUserData = await getCertifiableUserData(0);
     const pixAppCertifiablePage = await pixAppCertifiableUserPage(certifiableUserData);
-    const { sessionNumber } = await enrollCandidateAndPassExam({
+    const { sessionNumber, certificationNumber } = await enrollCandidateAndPassExam({
       testRef,
       rightWrongAnswersSequence: [true],
       pixAppPage: pixAppCertifiablePage,
       certifiableUserData,
     });
-    let certificationNumber = '';
 
     await test.step('user stops at second challenge', async () => {
       await expect(pixAppCertifiablePage.getByLabel('Votre progression')).toContainText('2 / 32');
@@ -93,7 +92,6 @@ test(
         const certificationInformationPage = await certificationListPage.goToCertificationInfoPage(
           certifiableUserData.firstName,
         );
-        certificationNumber = certificationInformationPage.getCertificationNumber();
         await checkCertificationGeneralInformationAndExpectSuccess(certificationInformationPage, {
           sessionNumber,
           status: 'Annulée',

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/core/PRO_CORE_1OK-0KO_EndedByInvigilator_Abandonment.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/core/PRO_CORE_1OK-0KO_EndedByInvigilator_Abandonment.spec.ts
@@ -36,13 +36,12 @@ test(
   }) => {
     const certifiableUserData = await getCertifiableUserData(0);
     const pixAppCertifiablePage = await pixAppCertifiableUserPage(certifiableUserData);
-    const { sessionNumber, invigilatorOverviewPage } = await enrollCandidateAndPassExam({
+    const { sessionNumber, invigilatorOverviewPage, certificationNumber } = await enrollCandidateAndPassExam({
       testRef,
       rightWrongAnswersSequence: [true],
       pixAppPage: pixAppCertifiablePage,
       certifiableUserData,
     });
-    let certificationNumber = '';
 
     await test.step('user stops at second challenge', async () => {
       await expect(pixAppCertifiablePage.getByLabel('Votre progression')).toContainText('2 / 32');
@@ -97,7 +96,6 @@ test(
         const certificationInformationPage = await certificationListPage.goToCertificationInfoPage(
           certifiableUserData.firstName,
         );
-        certificationNumber = certificationInformationPage.getCertificationNumber();
         await checkCertificationGeneralInformationAndExpectSuccess(certificationInformationPage, {
           sessionNumber,
           status: 'Rejetée',

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/core/PRO_CORE_1OK-0KO_EndedByInvigilator_TechnicalIssue.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/core/PRO_CORE_1OK-0KO_EndedByInvigilator_TechnicalIssue.spec.ts
@@ -36,13 +36,12 @@ test(
   }) => {
     const certifiableUserData = await getCertifiableUserData(0);
     const pixAppCertifiablePage = await pixAppCertifiableUserPage(certifiableUserData);
-    const { sessionNumber, invigilatorOverviewPage } = await enrollCandidateAndPassExam({
+    const { sessionNumber, invigilatorOverviewPage, certificationNumber } = await enrollCandidateAndPassExam({
       testRef,
       rightWrongAnswersSequence: [true],
       pixAppPage: pixAppCertifiablePage,
       certifiableUserData,
     });
-    let certificationNumber = '';
 
     await test.step('user stops at second challenge', async () => {
       await expect(pixAppCertifiablePage.getByLabel('Votre progression')).toContainText('2 / 32');
@@ -97,7 +96,6 @@ test(
         const certificationInformationPage = await certificationListPage.goToCertificationInfoPage(
           certifiableUserData.firstName,
         );
-        certificationNumber = certificationInformationPage.getCertificationNumber();
         await checkCertificationGeneralInformationAndExpectSuccess(certificationInformationPage, {
           sessionNumber,
           status: 'Annulée',

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/core/PRO_CORE_24OK-0KO_EndedByFinalization_Abandonment.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/core/PRO_CORE_24OK-0KO_EndedByFinalization_Abandonment.spec.ts
@@ -37,13 +37,12 @@ test(
   }) => {
     const certifiableUserData = await getCertifiableUserData(0);
     const pixAppCertifiablePage = await pixAppCertifiableUserPage(certifiableUserData);
-    const { sessionNumber } = await enrollCandidateAndPassExam({
+    const { sessionNumber, certificationNumber } = await enrollCandidateAndPassExam({
       testRef,
       rightWrongAnswersSequence: Array(24).fill(true),
       pixAppPage: pixAppCertifiablePage,
       certifiableUserData,
     });
-    let certificationNumber = '';
 
     await test.step('user stops at 25th challenge', async () => {
       await expect(pixAppCertifiablePage.getByLabel('Votre progression')).toContainText('25 / 32');
@@ -94,7 +93,6 @@ test(
         const certificationInformationPage = await certificationListPage.goToCertificationInfoPage(
           certifiableUserData.firstName,
         );
-        certificationNumber = certificationInformationPage.getCertificationNumber();
         await checkCertificationGeneralInformationAndExpectSuccess(certificationInformationPage, {
           sessionNumber,
           status: 'Validée',

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/core/PRO_CORE_24OK-0KO_EndedByFinalization_TechnicalIssue.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/core/PRO_CORE_24OK-0KO_EndedByFinalization_TechnicalIssue.spec.ts
@@ -37,13 +37,12 @@ test(
   }) => {
     const certifiableUserData = await getCertifiableUserData(0);
     const pixAppCertifiablePage = await pixAppCertifiableUserPage(certifiableUserData);
-    const { sessionNumber } = await enrollCandidateAndPassExam({
+    const { sessionNumber, certificationNumber } = await enrollCandidateAndPassExam({
       testRef,
       rightWrongAnswersSequence: Array(24).fill(true),
       pixAppPage: pixAppCertifiablePage,
       certifiableUserData,
     });
-    let certificationNumber = '';
 
     await test.step('user stops at 25th challenge', async () => {
       await expect(pixAppCertifiablePage.getByLabel('Votre progression')).toContainText('25 / 32');
@@ -94,7 +93,6 @@ test(
         const certificationInformationPage = await certificationListPage.goToCertificationInfoPage(
           certifiableUserData.firstName,
         );
-        certificationNumber = certificationInformationPage.getCertificationNumber();
         await checkCertificationGeneralInformationAndExpectSuccess(certificationInformationPage, {
           sessionNumber,
           status: 'Validée',

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/core/PRO_CORE_24OK-0KO_EndedByInvigilator_Abandonment.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/core/PRO_CORE_24OK-0KO_EndedByInvigilator_Abandonment.spec.ts
@@ -37,13 +37,12 @@ test(
   }) => {
     const certifiableUserData = await getCertifiableUserData(0);
     const pixAppCertifiablePage = await pixAppCertifiableUserPage(certifiableUserData);
-    const { sessionNumber, invigilatorOverviewPage } = await enrollCandidateAndPassExam({
+    const { sessionNumber, invigilatorOverviewPage, certificationNumber } = await enrollCandidateAndPassExam({
       testRef,
       rightWrongAnswersSequence: Array(24).fill(true),
       pixAppPage: pixAppCertifiablePage,
       certifiableUserData,
     });
-    let certificationNumber = '';
 
     await test.step('user stops at 25th challenge', async () => {
       await expect(pixAppCertifiablePage.getByLabel('Votre progression')).toContainText('25 / 32');
@@ -98,7 +97,6 @@ test(
         const certificationInformationPage = await certificationListPage.goToCertificationInfoPage(
           certifiableUserData.firstName,
         );
-        certificationNumber = certificationInformationPage.getCertificationNumber();
         await checkCertificationGeneralInformationAndExpectSuccess(certificationInformationPage, {
           sessionNumber,
           status: 'Validée',

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/core/PRO_CORE_24OK-0KO_EndedByInvigilator_TechnicalIssue.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/core/PRO_CORE_24OK-0KO_EndedByInvigilator_TechnicalIssue.spec.ts
@@ -37,13 +37,12 @@ test(
   }) => {
     const certifiableUserData = await getCertifiableUserData(0);
     const pixAppCertifiablePage = await pixAppCertifiableUserPage(certifiableUserData);
-    const { sessionNumber, invigilatorOverviewPage } = await enrollCandidateAndPassExam({
+    const { sessionNumber, invigilatorOverviewPage, certificationNumber } = await enrollCandidateAndPassExam({
       testRef,
       rightWrongAnswersSequence: Array(24).fill(true),
       pixAppPage: pixAppCertifiablePage,
       certifiableUserData,
     });
-    let certificationNumber = '';
 
     await test.step('user stops at 25th challenge', async () => {
       await expect(pixAppCertifiablePage.getByLabel('Votre progression')).toContainText('25 / 32');
@@ -98,7 +97,6 @@ test(
         const certificationInformationPage = await certificationListPage.goToCertificationInfoPage(
           certifiableUserData.firstName,
         );
-        certificationNumber = certificationInformationPage.getCertificationNumber();
         await checkCertificationGeneralInformationAndExpectSuccess(certificationInformationPage, {
           sessionNumber,
           status: 'Validée',

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/core/PRO_CORE_32OK-0KO.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/core/PRO_CORE_32OK-0KO.spec.ts
@@ -37,13 +37,12 @@ test(
   }) => {
     const certifiableUserData = await getCertifiableUserData(0);
     const pixAppCertifiablePage = await pixAppCertifiableUserPage(certifiableUserData);
-    const { sessionNumber } = await enrollCandidateAndPassExam({
+    const { sessionNumber, certificationNumber } = await enrollCandidateAndPassExam({
       testRef,
       rightWrongAnswersSequence: Array(32).fill(true),
       pixAppPage: pixAppCertifiablePage,
       certifiableUserData,
     });
-    let certificationNumber = '';
 
     await test.step(`reaches end of certification test`, async () => {
       await expect(pixAppCertifiablePage.locator('h1')).toContainText('Test terminé !');
@@ -97,7 +96,6 @@ test(
         const certificationInformationPage = await certificationListPage.goToCertificationInfoPage(
           certifiableUserData.firstName,
         );
-        certificationNumber = certificationInformationPage.getCertificationNumber();
         await checkCertificationGeneralInformationAndExpectSuccess(certificationInformationPage, {
           sessionNumber,
           status: 'Validée',

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/core/PRO_CORE_32OK-0KO.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/core/PRO_CORE_32OK-0KO.spec.ts
@@ -33,6 +33,7 @@ test(
     enrollCandidateAndPassExam,
     pixAdminRoleCertifPage,
     getCertifiableUserData,
+    waitForScoringJobToBeCompleted,
     snapshotHandler,
   }) => {
     const certifiableUserData = await getCertifiableUserData(0);
@@ -49,6 +50,7 @@ test(
       await expect(pixAppCertifiablePage.locator('h2')).toContainText(
         'Vos résultats, en attente de validation par les équipes Pix, seront bientôt disponibles sur votre compte Pix',
       );
+      await waitForScoringJobToBeCompleted(certificationNumber);
     });
 
     await test.step('Finalization and scoring', async () => {

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/core/PRO_CORE_32OK-0KO_Rescore.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/core/PRO_CORE_32OK-0KO_Rescore.spec.ts
@@ -34,6 +34,7 @@ test(
     enrollCandidateAndPassExam,
     pixAdminRoleCertifPage,
     getCertifiableUserData,
+    waitForScoringJobToBeCompleted,
     snapshotHandler,
   }) => {
     const certifiableUserData = await getCertifiableUserData(0);
@@ -50,6 +51,7 @@ test(
       await expect(pixAppCertifiablePage.locator('h2')).toContainText(
         'Vos résultats, en attente de validation par les équipes Pix, seront bientôt disponibles sur votre compte Pix',
       );
+      await waitForScoringJobToBeCompleted(certificationNumber);
     });
 
     await test.step('Finalization and scoring', async () => {

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/core/PRO_CORE_32OK-0KO_Rescore.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/core/PRO_CORE_32OK-0KO_Rescore.spec.ts
@@ -38,13 +38,12 @@ test(
   }) => {
     const certifiableUserData = await getCertifiableUserData(0);
     const pixAppCertifiablePage = await pixAppCertifiableUserPage(certifiableUserData);
-    const { sessionNumber } = await enrollCandidateAndPassExam({
+    const { sessionNumber, certificationNumber } = await enrollCandidateAndPassExam({
       testRef,
       rightWrongAnswersSequence: Array(32).fill(true),
       pixAppPage: pixAppCertifiablePage,
       certifiableUserData,
     });
-    let certificationNumber = '';
 
     await test.step(`reaches end of certification test`, async () => {
       await expect(pixAppCertifiablePage.locator('h1')).toContainText('Test terminé !');
@@ -98,7 +97,6 @@ test(
         const certificationInformationPage = await certificationListPage.goToCertificationInfoPage(
           certifiableUserData.firstName,
         );
-        certificationNumber = certificationInformationPage.getCertificationNumber();
         await checkCertificationGeneralInformationAndExpectSuccess(certificationInformationPage, {
           sessionNumber,
           status: 'Validée',

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/core/PRO_CORE_32OK-0KO_Uncancelled.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/core/PRO_CORE_32OK-0KO_Uncancelled.spec.ts
@@ -34,6 +34,7 @@ test(
     enrollCandidateAndPassExam,
     pixAdminRoleCertifPage,
     getCertifiableUserData,
+    waitForScoringJobToBeCompleted,
     snapshotHandler,
   }) => {
     const certifiableUserData = await getCertifiableUserData(0);
@@ -50,6 +51,7 @@ test(
       await expect(pixAppCertifiablePage.locator('h2')).toContainText(
         'Vos résultats, en attente de validation par les équipes Pix, seront bientôt disponibles sur votre compte Pix',
       );
+      await waitForScoringJobToBeCompleted(certificationNumber);
     });
 
     await test.step('Finalization and scoring', async () => {

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/core/PRO_CORE_32OK-0KO_Uncancelled.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/core/PRO_CORE_32OK-0KO_Uncancelled.spec.ts
@@ -38,13 +38,12 @@ test(
   }) => {
     const certifiableUserData = await getCertifiableUserData(0);
     const pixAppCertifiablePage = await pixAppCertifiableUserPage(certifiableUserData);
-    const { sessionNumber } = await enrollCandidateAndPassExam({
+    const { sessionNumber, certificationNumber } = await enrollCandidateAndPassExam({
       testRef,
       rightWrongAnswersSequence: Array(32).fill(true),
       pixAppPage: pixAppCertifiablePage,
       certifiableUserData,
     });
-    let certificationNumber = '';
 
     await test.step(`reaches end of certification test`, async () => {
       await expect(pixAppCertifiablePage.locator('h1')).toContainText('Test terminé !');
@@ -98,7 +97,6 @@ test(
         const certificationInformationPage = await certificationListPage.goToCertificationInfoPage(
           certifiableUserData.firstName,
         );
-        certificationNumber = certificationInformationPage.getCertificationNumber();
         await checkCertificationGeneralInformationAndExpectSuccess(certificationInformationPage, {
           sessionNumber,
           status: 'Validée',

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/core/PRO_CORE_32OK-0KO_Unrejected.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/core/PRO_CORE_32OK-0KO_Unrejected.spec.ts
@@ -34,6 +34,7 @@ test(
     enrollCandidateAndPassExam,
     pixAdminRoleCertifPage,
     getCertifiableUserData,
+    waitForScoringJobToBeCompleted,
     snapshotHandler,
   }) => {
     const certifiableUserData = await getCertifiableUserData(0);
@@ -50,6 +51,7 @@ test(
       await expect(pixAppCertifiablePage.locator('h2')).toContainText(
         'Vos résultats, en attente de validation par les équipes Pix, seront bientôt disponibles sur votre compte Pix',
       );
+      await waitForScoringJobToBeCompleted(certificationNumber);
     });
 
     await test.step('Finalization and scoring', async () => {

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/core/PRO_CORE_32OK-0KO_Unrejected.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/core/PRO_CORE_32OK-0KO_Unrejected.spec.ts
@@ -38,13 +38,12 @@ test(
   }) => {
     const certifiableUserData = await getCertifiableUserData(0);
     const pixAppCertifiablePage = await pixAppCertifiableUserPage(certifiableUserData);
-    const { sessionNumber } = await enrollCandidateAndPassExam({
+    const { sessionNumber, certificationNumber } = await enrollCandidateAndPassExam({
       testRef,
       rightWrongAnswersSequence: Array(32).fill(true),
       pixAppPage: pixAppCertifiablePage,
       certifiableUserData,
     });
-    let certificationNumber = '';
 
     await test.step(`reaches end of certification test`, async () => {
       await expect(pixAppCertifiablePage.locator('h1')).toContainText('Test terminé !');
@@ -98,7 +97,6 @@ test(
         const certificationInformationPage = await certificationListPage.goToCertificationInfoPage(
           certifiableUserData.firstName,
         );
-        certificationNumber = certificationInformationPage.getCertificationNumber();
         await checkCertificationGeneralInformationAndExpectSuccess(certificationInformationPage, {
           sessionNumber,
           status: 'Validée',

--- a/high-level-tests/e2e-playwright/tests/recette-prescription/create-organization-learner.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-prescription/create-organization-learner.spec.ts
@@ -35,7 +35,7 @@ test('set up base data for anonymization test : create an organization learner w
     const startCampaignPage = new StartCampaignPage(pixAppPage);
     await startCampaignPage.goToFirstChallenge(campaignCode as string);
     await test.step(` answering right or wrong according to pattern`, async () => {
-      while (!pixAppPage.url().endsWith('/checkpoint?finalCheckpoint=true')) {
+      while (!pixAppPage.url().includes('finalCheckpoint=true')) {
         const challengePage = new ChallengePage(pixAppPage);
         await challengePage.setRightOrWrongAnswer(true);
         await challengePage.validateAnswer();


### PR DESCRIPTION
## 🥀 Problème

Dans le cas où le candidat a un score de 0 pix après avoir répondu à toutes les questions, le scoring est KO

## 🏹 Proposition

Le code pour créer les competence marks ne marchait pas quand il y en avait 0 à créer (surtout la partie qui retourne les competences marks créés).

Solution : ne rien retourner après l'insertion en masse

## 💌 Remarques

Correction de flakyness au passage sur les e2e

## ❤️‍🔥 Pour tester
E2E OK