### PR TITLE
[TECH] Supprimer le paramètre variant tile pour les PixCheckbox de Pix Admin

### DIFF
--- a/admin/app/components/badges/badge.gjs
+++ b/admin/app/components/badges/badge.gjs
@@ -166,14 +166,12 @@ export default class Badge extends Component {
             <div class="badge-edit-form__checkboxes">
               <PixCheckbox
                 @checked={{this.form.isCertifiable}}
-                @variant="tile"
                 {{on "change" (this.onFormCheckToggle "isCertifiable")}}
               ><:label>Certifiable</:label></PixCheckbox>
               <div>
                 <PixCheckbox
                   @type="checkbox"
                   @checked={{this.form.isAlwaysVisible}}
-                  @variant="tile"
                   {{on "change" (this.onFormCheckToggle "isAlwaysVisible")}}
                 ><:label>Lacunes</:label></PixCheckbox>
               </div>


### PR DESCRIPTION
## 🥀 Problème

Une montée de version de Pix UI incluait [le renommage d'un variant coté PixCheckbox et PixRadioButton](https://github.com/1024pix/pix-ui/pull/987).

Cette montée de version a été effectué sur Admin sans gérer cette modification. 

## 🏹 Proposition

Le variant tile a été renommé en modulix, car il a été pensé pour les besoins d'un module. 
L'usage sur Pix Admin n'a pas d'intérêt.

On supprime donc l'usage du variant.


## ❤️‍🔥 Pour tester

- Aller sur Pix Admin
- Aller sur un profil cible lié à cléA
- Voir les clés de lecture associés (badges)
- Modifier un badge existant
- Constater que les checkbox "Certifiable" et "Lacunes" sont fonctionnelles
- (le formulaire est moche mais ça ça ne concerne pas le scope de cette PR :) )
