### PR TITLE
[FEATURE] Retravailler le design du header de la page d'une organisation (PIX-21349)

### DIFF
--- a/admin/app/components/organizations/head-information.gjs
+++ b/admin/app/components/organizations/head-information.gjs
@@ -5,6 +5,7 @@ import { action } from '@ember/object';
 import { LinkTo } from '@ember/routing';
 import Component from '@glimmer/component';
 import t from 'ember-intl/helpers/t';
+import CopyButton from 'pix-admin/components/ui/copy-button';
 import ENV from 'pix-admin/config/environment';
 
 export default class HeadInformation extends Component {
@@ -37,7 +38,7 @@ export default class HeadInformation extends Component {
   }
 
   <template>
-    <div class="organization__header">
+    <div class="organization__head-information">
       <div class="organization__logo">
         <figure class="organization__logo-figure">
           {{#if @organization.logoUrl}}
@@ -55,7 +56,18 @@ export default class HeadInformation extends Component {
       </div>
 
       <div class="organization__title">
-        <h1 class="organization__name">{{@organization.name}}</h1>
+        <div>
+          <h1 class="organization__name">{{@organization.name}}</h1>
+          <div class="organization__id">
+            <p>ID : <span>{{@organization.id}}</span></p>
+            <CopyButton
+              @id="copy-organization-id"
+              @value={{@organization.id}}
+              @tooltip={{t "components.organizations.head-information.copy-id"}}
+              @label={{t "components.organizations.head-information.copy-id"}}
+            />
+          </div>
+        </div>
 
         <ul class="organization-tags-list">
           {{#if this.hasChildren}}

--- a/admin/app/components/organizations/head-information.scss
+++ b/admin/app/components/organizations/head-information.scss
@@ -1,0 +1,91 @@
+@use 'pix-design-tokens/typography';
+
+.organization__head-information {
+  display: flex;
+  gap: var(--pix-spacing-4x);
+  align-items: center;
+  max-width: 1400px;
+  padding: var(--pix-spacing-4x) var(--pix-spacing-6x);
+  color: var(--pix-neutral-900);
+  background-color: var(--pix-neutral-0);
+
+  // TODO: replace border and shadow by new shadow design-token once available
+  border: 1.2px var(--pix-neutral-100) solid;
+  border-radius: var(--pix-spacing-4x);
+  box-shadow: 5px 4px 10px 2px rgb(0 0 0 / 10%);
+
+  .organization__logo {
+    width: 83px;
+    height: 83px;
+
+    .organization__logo-figure {
+      position: relative;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      width: 75px;
+      height: 75px;
+      margin: 0;
+      border: 2px solid var(--pix-neutral-100);
+      border-radius: 3px;
+
+      > img {
+        max-width: 100%;
+        max-height: 100%;
+      }
+
+      > .file-upload {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background: transparent;
+        cursor: pointer;
+      }
+    }
+  }
+
+  .organization__title {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+    gap: var(--pix-spacing-2x);
+
+    .organization__name {
+      @extend %pix-title-s;
+    }
+
+    .organization__id {
+      @extend %pix-title-xxs;
+
+      display: flex;
+      gap: var(--pix-spacing-2x);
+      align-items: center;
+
+      span {
+        font-weight: normal;
+      }
+    }
+
+    .organization-tags-list {
+      display: flex;
+      flex-wrap: wrap;
+      gap: var(--pix-spacing-2x);
+      padding: 0;
+      list-style: none;
+    }
+
+    .organization__child-tag {
+      a {
+        color: var(--pix-success-700);
+        text-decoration: underline;
+      }
+    }
+  }
+
+  .organization__dashboard-button {
+    align-self: center;
+  }
+}

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -111,3 +111,4 @@
 @use 'certification-centers/membership-item' as *;
 @use 'certification-centers/invitations-action' as *;
 @use 'organizations/creation-form' as *;
+@use 'organizations/head-information' as *;

--- a/admin/app/styles/authenticated/organizations/get.scss
+++ b/admin/app/styles/authenticated/organizations/get.scss
@@ -1,76 +1,11 @@
 /* stylelint-disable selector-class-pattern */
 #organizations-get-page {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pix-spacing-6x);
 
-  .organization__header {
-    display: flex;
-    align-items: flex-start;
-    max-width: 1400px;
-    margin-bottom: var(--pix-spacing-3x);
-    margin-left: 0;
-
-    .organization__logo {
-      margin-right: 20px;
-
-      .organization__logo-figure {
-        position: relative;
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        justify-content: center;
-        width: 80px;
-        height: 80px;
-        margin: 0;
-        border: 2px solid var(--pix-neutral-20);
-        border-radius: var(--pix-spacing-1x);
-
-        > img {
-          max-width: 100%;
-          max-height: 100%;
-        }
-
-        > .file-upload {
-          position: absolute;
-          top: 0;
-          left: 0;
-          width: 100%;
-          height: 100%;
-          background: transparent;
-          cursor: pointer;
-        }
-      }
-    }
-
-
-    .organization__title {
-      display: flex;
-      flex-direction: column;
-      flex-grow: 1;
-      gap: var(--pix-spacing-2x);
-
-      .organization__name {
-        font-weight: 600;
-        font-size: 1.5rem;
-      }
-
-      .organization-tags-list {
-        display: flex;
-        flex-wrap: wrap;
-        gap: var(--pix-spacing-2x);
-        padding: 0;
-        list-style: none;
-      }
-
-      .organization__child-tag{
-        a {
-          color: var(--pix-success-700);
-          text-decoration: underline;
-        }
-      }
-    }
-
-    .organization__dashboard-button {
-      align-self: center;
-    }
+  .organization__navigation {
+    margin: 0;
   }
 
   .organization__information {

--- a/admin/app/styles/components/organization-information-section.scss
+++ b/admin/app/styles/components/organization-information-section.scss
@@ -3,10 +3,6 @@
 
 /* stylelint-disable color-no-hex */
 .organization-information-section {
-  &__archived-message {
-    margin-bottom: var(--pix-spacing-3x);
-  }
-
   &__card {
     &--general {
       .card__content {

--- a/admin/app/templates/authenticated/organizations/get.gjs
+++ b/admin/app/templates/authenticated/organizations/get.gjs
@@ -14,7 +14,7 @@ import HeadInformation from 'pix-admin/components/organizations/head-information
     <HeadInformation @organization={{@model}} />
 
     {{#if @model.isArchived}}
-      <PixNotificationAlert class="organization-information-section__archived-message" @type="warning">
+      <PixNotificationAlert @type="warning">
         {{t
           "components.organizations.information-section-view.is-archived-warning"
           archivedAt=@model.archivedFormattedDate
@@ -23,7 +23,11 @@ import HeadInformation from 'pix-admin/components/organizations/head-information
       </PixNotificationAlert>
     {{/if}}
 
-    <PixTabs @variant="primary" @ariaLabel={{t "pages.organization.navbar.aria-label"}} class="navigation">
+    <PixTabs
+      @variant="primary"
+      @ariaLabel={{t "pages.organization.navbar.aria-label"}}
+      class="navigation organization__navigation"
+    >
 
       <LinkTo @route="authenticated.organizations.get.details" @model={{@model}}>
         {{t "pages.organization.navbar.details"}}

--- a/admin/tests/integration/components/organizations/head-information-test.gjs
+++ b/admin/tests/integration/components/organizations/head-information-test.gjs
@@ -20,6 +20,8 @@ module('Integration | Component | organizations/header-information', function (h
 
       // then
       assert.dom(screen.getByRole('heading', { name: 'Organization SCO' })).exists();
+      assert.dom(screen.getByText((_, element) => element.textContent === 'ID : 1')).exists();
+      assert.dom(screen.getByRole('button', { name: t('components.organizations.head-information.copy-id') })).exists();
     });
 
     test('it generates correct external dashboard URL', async function (assert) {

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -761,8 +761,9 @@
         "required-fields-error": "Please fill in all required fields."
       },
       "head-information": {
-        "child-organization": "Organisation fille de",
-        "parent-organization": "Organisation mère"
+        "child-organization": "Child organization of",
+        "copy-id": "Copy ID",
+        "parent-organization": "Parent organization"
       },
       "information-section-view": {
         "administration-team": "Administration team",

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -764,6 +764,7 @@
       },
       "head-information": {
         "child-organization": "Organisation fille de",
+        "copy-id": "Copier l'ID",
         "parent-organization": "Organisation mère"
       },
       "information-section-view": {


### PR DESCRIPTION
## 🥀 Problème

Dans le cadre de la refonte des pages d'organisations sur Pix Admin, on voudrait revoir le header de la page de détail pour coller à la nouvelle maquette (https://www.figma.com/design/YOD6plwy3EfJLmC2Let0zV/Pix-Admin?node-id=3754-6397&p=f&m=dev)

## 🏹 Proposition
 Make it shiny

## 💌 Remarques

- les ombres utilisées ne collent pas à la maquette car on est en attente de nouveaux designs-token
- l'ID et la liste de tags ont été inversés dans un soucis de cohérence (toutes les orgas n'ont pas de tags)
- la présence de l'ID vient d'une demande métier qui en a besoin pour le reporter dans divers documents. Un bouton de copie dans le presse-papier a donc été ajouté pour faciliter cette tâche 
- un bug sur la mise à jour du logo a été détecté. Il fera l'objet d'une future PR

## ❤️‍🔥 Pour tester
Sur Pix Admin
- aller sur Organisations -> cliquer sur une organisation
- constater le nouveau design
- essayer la fonctionnalité de copie d'ID
- tenter d'archiver une orga pour voir l'affichage de la bannière