### PR TITLE
[FEATURE] Afficher qu'il n'y a pas d'invitations en cours (PIX-20524)

### DIFF
--- a/orga/app/templates/authenticated/team/list/invitations.gjs
+++ b/orga/app/templates/authenticated/team/list/invitations.gjs
@@ -6,5 +6,7 @@ import InvitationsList from 'pix-orga/components/team/invitations-list';
 
   {{#if @model}}
     <InvitationsList @invitations={{@model}} />
+  {{else}}
+    <div class="table__empty">{{t "pages.team-invitations.empty-table"}}</div>
   {{/if}}
 </template>

--- a/orga/tests/acceptance/invitations-list-test.js
+++ b/orga/tests/acceptance/invitations-list-test.js
@@ -13,6 +13,24 @@ module('Acceptance | Invitations list', function (hooks) {
   setupMirage(hooks);
   setupIntl(hooks);
 
+  module('when there is no invitation', function () {
+    test('it should display an empty state', async function (assert) {
+      // given
+      const userAttributes = { lang: 'fr' };
+      const organizationAttributes = { id: 777, name: 'Collège Foufoufou' };
+      const organizationRole = 'ADMIN';
+
+      const user = createPrescriberForOrganization(userAttributes, organizationAttributes, organizationRole);
+      await authenticateSession(user.id);
+
+      // when
+      const screen = await visit('/equipe/invitations');
+
+      // then
+      assert.ok(screen.getByText(t('pages.team-invitations.empty-table')));
+    });
+  });
+
   test('it should be possible to cancel an invitation', async function (assert) {
     // given
     const userAttributes = { lang: 'fr' };

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -1924,6 +1924,7 @@
     },
     "team-invitations": {
       "cancel-invitation": "Delete this invitation",
+      "empty-table": "You have no pending invitations.",
       "invitation-cancelled-succeed-message": "The invitation has been deleted.",
       "invitation-resent-succeed-message": "The invitation has been resent.",
       "resend-invitation": "Resend the invitation",

--- a/orga/translations/es.json
+++ b/orga/translations/es.json
@@ -1911,6 +1911,7 @@
     },
     "team-invitations": {
       "cancel-invitation": "Borrar invitación",
+      "empty-table": "No hay invitaciones pendientes.",
       "invitation-cancelled-succeed-message": "La invitación ha sido eliminada.",
       "invitation-resent-succeed-message": "La invitación ha sido devuelta.",
       "resend-invitation": "Reenviar invitación",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -1911,6 +1911,7 @@
     },
     "team-invitations": {
       "cancel-invitation": "Supprimer l’invitation",
+      "empty-table": "Vous n’avez aucune invitation en attente.",
       "invitation-cancelled-succeed-message": "L’invitation a bien été supprimée.",
       "invitation-resent-succeed-message": "L'invitation a bien été renvoyée.",
       "resend-invitation": "Renvoyer l'invitation",

--- a/orga/translations/it.json
+++ b/orga/translations/it.json
@@ -1911,6 +1911,7 @@
     },
     "team-invitations": {
       "cancel-invitation": "Cancellare l'invito",
+      "empty-table": "Non ci sono inviti in attesa.",
       "invitation-cancelled-succeed-message": "L'invito è stato cancellato.",
       "invitation-resent-succeed-message": "L'invito è stato restituito.",
       "resend-invitation": "Reinvio dell'invito",

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -1905,6 +1905,7 @@
     },
     "team-invitations": {
       "cancel-invitation": "Uitnodiging verwijderen",
+      "empty-table": "Je hebt geen uitnodigingen in behandeling.",
       "invitation-cancelled-succeed-message": "De uitnodiging is verwijderd.",
       "invitation-resent-succeed-message": "De uitnodiging is opnieuw gestuurd.",
       "resend-invitation": "Uitnodiging opnieuw versturen",


### PR DESCRIPTION
## 🥀 Problème

Dans Pix Orga, dans l’onglet “Equipe”

s’il n’y a aucune invitation en attente, on affiche une page vide.

## 🏹 Proposition

Prévenir qu'il n'y a pas d'invitation en attente



## ❤️‍🔥 Pour tester
- Depuis pix-orga
- Sur une orga qui n'a pas d'invitation
- Constater qu'on affiche bien "Vous n’avez aucune invitation en attente."
