### PR TITLE
[BUGFIX]:  utiliser https agent

### DIFF
--- a/api/src/shared/infrastructure/metrics/pushgateway.js
+++ b/api/src/shared/infrastructure/metrics/pushgateway.js
@@ -1,4 +1,4 @@
-import http from 'node:http';
+import https from 'node:https';
 
 import { Pushgateway } from 'prom-client';
 
@@ -23,7 +23,7 @@ const pushgateway = new Pushgateway(
   {
     headers,
     timeout: config.metrics.prometheus.pushgateway.timeout,
-    agent: new http.Agent({
+    agent: new https.Agent({
       keepAlive: true,
       keepAliveMsec: config.metrics.prometheus.pushgateway.keepAlive,
       maxSockets: 1,


### PR DESCRIPTION
## 🥀 Problème

l'agent pour pushgateway a été défini en http ce qui crée un erreur

## 🏹 Proposition

utiliser https

## 💌 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## ❤️‍🔥 Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
