### PR TITLE
[TECH] Mutualisation de la logique de vérification d'infos pour une organisation (PIX-20805).

### DIFF
--- a/api/src/organizational-entities/domain/services/organization-verification.service.js
+++ b/api/src/organizational-entities/domain/services/organization-verification.service.js
@@ -1,0 +1,16 @@
+import { logger } from '../../../shared/infrastructure/utils/logger.js';
+import { CountryNotFoundError } from '../errors.js';
+
+const checkCountryExists = async (countryCode, countryRepository) => {
+  try {
+    await countryRepository.getByCode(countryCode);
+  } catch {
+    logger.error({
+      event: 'Not_found_country',
+      message: `Le pays avec le code ${countryCode} n'a pas été trouvé.`,
+    });
+    throw new CountryNotFoundError({ message: `Country not found for code ${countryCode}`, meta: { countryCode } });
+  }
+};
+
+export { checkCountryExists };

--- a/api/src/organizational-entities/domain/services/organization-verification.service.js
+++ b/api/src/organizational-entities/domain/services/organization-verification.service.js
@@ -1,5 +1,5 @@
 import { logger } from '../../../shared/infrastructure/utils/logger.js';
-import { CountryNotFoundError, OrganizationLearnerTypeNotFound } from '../errors.js';
+import { AdministrationTeamNotFound, CountryNotFoundError, OrganizationLearnerTypeNotFound } from '../errors.js';
 
 const checkCountryExists = async (countryCode, countryRepository) => {
   try {
@@ -26,4 +26,16 @@ const checkOrganizationLearnerTypeExists = async (organizationLearnerTypeId, org
   }
 };
 
-export { checkCountryExists, checkOrganizationLearnerTypeExists };
+async function checkAdministrationTeamExists(administrationTeamId, administrationTeamRepository) {
+  const existingAdministrationTeam = await administrationTeamRepository.getById(administrationTeamId);
+
+  if (!existingAdministrationTeam) {
+    throw new AdministrationTeamNotFound({
+      meta: {
+        administrationTeamId: administrationTeamId,
+      },
+    });
+  }
+}
+
+export { checkAdministrationTeamExists, checkCountryExists, checkOrganizationLearnerTypeExists };

--- a/api/src/organizational-entities/domain/services/organization-verification.service.js
+++ b/api/src/organizational-entities/domain/services/organization-verification.service.js
@@ -1,5 +1,5 @@
 import { logger } from '../../../shared/infrastructure/utils/logger.js';
-import { CountryNotFoundError } from '../errors.js';
+import { CountryNotFoundError, OrganizationLearnerTypeNotFound } from '../errors.js';
 
 const checkCountryExists = async (countryCode, countryRepository) => {
   try {
@@ -13,4 +13,17 @@ const checkCountryExists = async (countryCode, countryRepository) => {
   }
 };
 
-export { checkCountryExists };
+const checkOrganizationLearnerTypeExists = async (organizationLearnerTypeId, organizationLearnerTypeRepository) => {
+  if (organizationLearnerTypeId) {
+    try {
+      return await organizationLearnerTypeRepository.getById(organizationLearnerTypeId);
+    } catch {
+      throw new OrganizationLearnerTypeNotFound({
+        message: `Organization learner type not found for id ${organizationLearnerTypeId}`,
+        meta: { organizationLearnerTypeId },
+      });
+    }
+  }
+};
+
+export { checkCountryExists, checkOrganizationLearnerTypeExists };

--- a/api/src/organizational-entities/domain/usecases/create-organization.js
+++ b/api/src/organizational-entities/domain/usecases/create-organization.js
@@ -1,7 +1,5 @@
-import { logger } from '../../../shared/infrastructure/utils/logger.js';
 import {
   AdministrationTeamNotFound,
-  CountryNotFoundError,
   OrganizationLearnerTypeNotFound,
   UnableToAttachChildOrganizationToParentOrganizationError,
 } from '../errors.js';
@@ -17,6 +15,7 @@ const createOrganization = async function ({
   organizationCreationValidator,
   schoolRepository,
   codeGenerator,
+  organizationVerificationService,
 }) {
   if (organization.parentOrganizationId) {
     const parentOrganization = await organizationForAdminRepository.get({
@@ -30,7 +29,7 @@ const createOrganization = async function ({
 
   await _checkOrganizationLearnerTypeExists(organization.organizationLearnerType.id, organizationLearnerTypeRepository);
 
-  await _checkCountryExists(organization.countryCode, countryRepository);
+  await organizationVerificationService.checkCountryExists(organization.countryCode, countryRepository);
 
   const administrationTeam = await administrationTeamRepository.getById(organization.administrationTeamId);
 
@@ -42,7 +41,9 @@ const createOrganization = async function ({
     });
   }
 
-  const savedOrganization = await organizationForAdminRepository.save({ organization });
+  const savedOrganization = await organizationForAdminRepository.save({
+    organization,
+  });
 
   await dataProtectionOfficerRepository.create({
     organizationId: savedOrganization.id,
@@ -55,7 +56,9 @@ const createOrganization = async function ({
     const code = await codeGenerator.generate(schoolRepository);
     await schoolRepository.save({ organizationId: savedOrganization.id, code });
   }
-  return await organizationForAdminRepository.get({ organizationId: savedOrganization.id });
+  return await organizationForAdminRepository.get({
+    organizationId: savedOrganization.id,
+  });
 };
 
 export { createOrganization };
@@ -83,17 +86,5 @@ async function _checkOrganizationLearnerTypeExists(organizationLearnerTypeId, or
         meta: { organizationLearnerTypeId },
       });
     }
-  }
-}
-
-async function _checkCountryExists(countryCode, countryRepository) {
-  try {
-    await countryRepository.getByCode(countryCode);
-  } catch {
-    logger.error({
-      event: 'Not_found_country',
-      message: `Le pays avec le code ${countryCode} n'a pas été trouvé.`,
-    });
-    throw new CountryNotFoundError({ message: `Country not found for code ${countryCode}`, meta: { countryCode } });
   }
 }

--- a/api/src/organizational-entities/domain/usecases/create-organization.js
+++ b/api/src/organizational-entities/domain/usecases/create-organization.js
@@ -1,8 +1,4 @@
-import {
-  AdministrationTeamNotFound,
-  OrganizationLearnerTypeNotFound,
-  UnableToAttachChildOrganizationToParentOrganizationError,
-} from '../errors.js';
+import { AdministrationTeamNotFound, UnableToAttachChildOrganizationToParentOrganizationError } from '../errors.js';
 import { Organization } from '../models/Organization.js';
 
 const createOrganization = async function ({
@@ -27,7 +23,10 @@ const createOrganization = async function ({
 
   organizationCreationValidator.validate(organization);
 
-  await _checkOrganizationLearnerTypeExists(organization.organizationLearnerType.id, organizationLearnerTypeRepository);
+  await organizationVerificationService.checkOrganizationLearnerTypeExists(
+    organization.organizationLearnerType.id,
+    organizationLearnerTypeRepository,
+  );
 
   await organizationVerificationService.checkCountryExists(organization.countryCode, countryRepository);
 
@@ -73,18 +72,5 @@ function _assertParentOrganizationIsNotChildOrganization(parentOrganization) {
         parentOrganizationId: parentOrganization.id,
       },
     });
-  }
-}
-
-async function _checkOrganizationLearnerTypeExists(organizationLearnerTypeId, organizationLearnerTypeRepository) {
-  if (organizationLearnerTypeId) {
-    try {
-      await organizationLearnerTypeRepository.getById(organizationLearnerTypeId);
-    } catch {
-      throw new OrganizationLearnerTypeNotFound({
-        message: `Organization learner type not found for id ${organizationLearnerTypeId}`,
-        meta: { organizationLearnerTypeId },
-      });
-    }
   }
 }

--- a/api/src/organizational-entities/domain/usecases/create-organization.js
+++ b/api/src/organizational-entities/domain/usecases/create-organization.js
@@ -1,4 +1,4 @@
-import { AdministrationTeamNotFound, UnableToAttachChildOrganizationToParentOrganizationError } from '../errors.js';
+import { UnableToAttachChildOrganizationToParentOrganizationError } from '../errors.js';
 import { Organization } from '../models/Organization.js';
 
 const createOrganization = async function ({
@@ -30,15 +30,10 @@ const createOrganization = async function ({
 
   await organizationVerificationService.checkCountryExists(organization.countryCode, countryRepository);
 
-  const administrationTeam = await administrationTeamRepository.getById(organization.administrationTeamId);
-
-  if (!administrationTeam) {
-    throw new AdministrationTeamNotFound({
-      meta: {
-        administrationTeamId: organization.administrationTeamId,
-      },
-    });
-  }
+  await organizationVerificationService.checkAdministrationTeamExists(
+    organization.administrationTeamId,
+    administrationTeamRepository,
+  );
 
   const savedOrganization = await organizationForAdminRepository.save({
     organization,

--- a/api/src/organizational-entities/domain/usecases/create-organizations-with-tags-and-target-profiles.usecase.js
+++ b/api/src/organizational-entities/domain/usecases/create-organizations-with-tags-and-target-profiles.usecase.js
@@ -14,7 +14,7 @@ import * as codeGenerator from '../../../shared/domain/services/code-generator.j
 import { CONCURRENCY_HEAVY_OPERATIONS } from '../../../shared/infrastructure/constants.js';
 import { logger } from '../../../shared/infrastructure/utils/logger.js';
 import { PromiseUtils } from '../../../shared/infrastructure/utils/promise-utils.js';
-import { AdministrationTeamNotFound, UnableToAttachChildOrganizationToParentOrganizationError } from '../errors.js';
+import { UnableToAttachChildOrganizationToParentOrganizationError } from '../errors.js';
 import { Organization } from '../models/Organization.js';
 import { OrganizationForAdmin } from '../models/OrganizationForAdmin.js';
 import { OrganizationLearnerType } from '../models/OrganizationLearnerType.js';
@@ -105,15 +105,11 @@ async function _createOrganizations({
   return PromiseUtils.mapSeries(transformedOrganizationsData, async (organizationToCreate) => {
     const { administrationTeamId, parentOrganizationId, countryCode, organizationLearnerType } =
       organizationToCreate.organization;
-    const administrationTeam = await administrationTeamRepository.getById(administrationTeamId);
 
-    if (!administrationTeam) {
-      throw new AdministrationTeamNotFound({
-        meta: {
-          administrationTeamId,
-        },
-      });
-    }
+    await organizationVerificationService.checkAdministrationTeamExists(
+      administrationTeamId,
+      administrationTeamRepository,
+    );
 
     if (parentOrganizationId) {
       const organization = await organizationForAdminRepository.get({

--- a/api/src/organizational-entities/domain/usecases/create-organizations-with-tags-and-target-profiles.usecase.js
+++ b/api/src/organizational-entities/domain/usecases/create-organizations-with-tags-and-target-profiles.usecase.js
@@ -16,7 +16,6 @@ import { logger } from '../../../shared/infrastructure/utils/logger.js';
 import { PromiseUtils } from '../../../shared/infrastructure/utils/promise-utils.js';
 import {
   AdministrationTeamNotFound,
-  CountryNotFoundError,
   OrganizationLearnerTypeNotFound,
   UnableToAttachChildOrganizationToParentOrganizationError,
 } from '../errors.js';
@@ -44,6 +43,7 @@ const createOrganizationsWithTagsAndTargetProfiles = async function ({
   organizationValidator,
   countryRepository,
   organizationLearnerTypeRepository,
+  organizationVerificationService,
 }) {
   if (isEmpty(organizations)) {
     throw new ObjectValidationError('Les organisations ne sont pas renseignées.');
@@ -65,6 +65,7 @@ const createOrganizationsWithTagsAndTargetProfiles = async function ({
       transformedOrganizationsData,
       countryRepository,
       organizationLearnerTypeRepository,
+      organizationVerificationService,
     });
 
     await _addDataProtectionOfficers({
@@ -103,6 +104,7 @@ async function _createOrganizations({
   organizationForAdminRepository,
   countryRepository,
   organizationLearnerTypeRepository,
+  organizationVerificationService,
 }) {
   return PromiseUtils.mapSeries(transformedOrganizationsData, async (organizationToCreate) => {
     const { administrationTeamId, parentOrganizationId, countryCode, organizationLearnerType } =
@@ -125,7 +127,7 @@ async function _createOrganizations({
       _assertOrganizationIsNotChildOrganization(organization);
     }
 
-    await _checkCountryExists(countryCode, countryRepository);
+    await organizationVerificationService.checkCountryExists(countryCode, countryRepository);
 
     await _checkOrganizationLearnerTypeExists(organizationLearnerType.id, organizationLearnerTypeRepository);
 
@@ -309,14 +311,6 @@ async function _addTargetProfiles({ createdOrganizations, targetProfileShareRepo
     }
 
     throw new DomainError(error.message);
-  }
-}
-
-async function _checkCountryExists(countryCode, countryRepository) {
-  try {
-    await countryRepository.getByCode(countryCode);
-  } catch {
-    throw new CountryNotFoundError({ message: `Country not found for code ${countryCode}`, meta: { countryCode } });
   }
 }
 

--- a/api/src/organizational-entities/domain/usecases/create-organizations-with-tags-and-target-profiles.usecase.js
+++ b/api/src/organizational-entities/domain/usecases/create-organizations-with-tags-and-target-profiles.usecase.js
@@ -14,11 +14,7 @@ import * as codeGenerator from '../../../shared/domain/services/code-generator.j
 import { CONCURRENCY_HEAVY_OPERATIONS } from '../../../shared/infrastructure/constants.js';
 import { logger } from '../../../shared/infrastructure/utils/logger.js';
 import { PromiseUtils } from '../../../shared/infrastructure/utils/promise-utils.js';
-import {
-  AdministrationTeamNotFound,
-  OrganizationLearnerTypeNotFound,
-  UnableToAttachChildOrganizationToParentOrganizationError,
-} from '../errors.js';
+import { AdministrationTeamNotFound, UnableToAttachChildOrganizationToParentOrganizationError } from '../errors.js';
 import { Organization } from '../models/Organization.js';
 import { OrganizationForAdmin } from '../models/OrganizationForAdmin.js';
 import { OrganizationLearnerType } from '../models/OrganizationLearnerType.js';
@@ -129,7 +125,10 @@ async function _createOrganizations({
 
     await organizationVerificationService.checkCountryExists(countryCode, countryRepository);
 
-    await _checkOrganizationLearnerTypeExists(organizationLearnerType.id, organizationLearnerTypeRepository);
+    await organizationVerificationService.checkOrganizationLearnerTypeExists(
+      organizationLearnerType.id,
+      organizationLearnerTypeRepository,
+    );
 
     try {
       const createdOrganization = await organizationForAdminRepository.save({
@@ -311,17 +310,6 @@ async function _addTargetProfiles({ createdOrganizations, targetProfileShareRepo
     }
 
     throw new DomainError(error.message);
-  }
-}
-
-async function _checkOrganizationLearnerTypeExists(organizationLearnerTypeId, organizationLearnerTypeRepository) {
-  try {
-    await organizationLearnerTypeRepository.getById(organizationLearnerTypeId);
-  } catch {
-    throw new OrganizationLearnerTypeNotFound({
-      message: `Organization learner type not found for id ${organizationLearnerTypeId}`,
-      meta: { organizationLearnerTypeId },
-    });
   }
 }
 

--- a/api/src/organizational-entities/domain/usecases/index.js
+++ b/api/src/organizational-entities/domain/usecases/index.js
@@ -21,6 +21,7 @@ import * as organizationPlacesLotRepository from '../../infrastructure/repositor
 import * as organizationTagRepository from '../../infrastructure/repositories/organization-tag.repository.js';
 import { tagRepository } from '../../infrastructure/repositories/tag.repository.js';
 import * as targetProfileShareRepository from '../../infrastructure/repositories/target-profile-share-repository.js';
+import * as organizationVerificationService from '../services/organization-verification.service.js';
 import * as organizationCreationValidator from '../validators/organization-creation-validator.js';
 import * as organizationValidator from '../validators/organization-with-tags-and-target-profiles.js';
 
@@ -45,9 +46,10 @@ import * as organizationValidator from '../validators/organization-with-tags-and
  * @typedef {import ('../../../school/infrastructure/repositories/school-repository.js')} SchoolRepository
  * @typedef {import ('../validators/organization-creation-validator.js')} OrganizationCreationValidator
  * @typedef {import ('../../../shared/infrastructure/repositories/country-repository.js')} CountryRepository
+ * @typedef {import ('../services/organization-verification.service.js')} OrganizationVerificationService
  */
 
-const repositories = {
+const dependenciesToInject = {
   administrationTeamRepository,
   adminMemberRepository,
   organizationValidator,
@@ -72,9 +74,10 @@ const repositories = {
   organizationTagRepository,
   tagRepository,
   targetProfileShareRepository,
+  organizationVerificationService,
 };
 
-const dependencies = Object.assign({}, repositories);
+const dependencies = Object.assign({}, dependenciesToInject);
 
 import { addOrganizationFeatureInBatch } from './add-organization-feature-in-batch.usecase.js';
 import { addTagsToOrganizations } from './add-tags-to-organizations.usecase.js';

--- a/api/src/organizational-entities/domain/usecases/update-organization-information.usecase.js
+++ b/api/src/organizational-entities/domain/usecases/update-organization-information.usecase.js
@@ -1,5 +1,4 @@
 import { withTransaction } from '../../../shared/domain/DomainTransaction.js';
-import { AdministrationTeamNotFound } from '../errors.js';
 
 const updateOrganizationInformation = withTransaction(async function ({
   organization,
@@ -25,7 +24,10 @@ const updateOrganizationInformation = withTransaction(async function ({
 
   const tagsToUpdate = await tagRepository.findByIds(organization.tagIds);
 
-  await _checkAdministrationTeamExists(organization.administrationTeamId, administrationTeamRepository);
+  await organizationVerificationService.checkAdministrationTeamExists(
+    organization.administrationTeamId,
+    administrationTeamRepository,
+  );
 
   if (organization.countryCode) {
     await organizationVerificationService.checkCountryExists(organization.countryCode, countryRepository);
@@ -45,17 +47,5 @@ const updateOrganizationInformation = withTransaction(async function ({
     organizationId: organization.id,
   });
 });
-
-async function _checkAdministrationTeamExists(administrationTeamId, administrationTeamRepository) {
-  const existingAdministrationTeam = await administrationTeamRepository.getById(administrationTeamId);
-
-  if (!existingAdministrationTeam) {
-    throw new AdministrationTeamNotFound({
-      meta: {
-        administrationTeamId: administrationTeamId,
-      },
-    });
-  }
-}
 
 export { updateOrganizationInformation };

--- a/api/src/organizational-entities/domain/usecases/update-organization-information.usecase.js
+++ b/api/src/organizational-entities/domain/usecases/update-organization-information.usecase.js
@@ -1,6 +1,5 @@
 import { withTransaction } from '../../../shared/domain/DomainTransaction.js';
-import { logger } from '../../../shared/infrastructure/utils/logger.js';
-import { AdministrationTeamNotFound, CountryNotFoundError, OrganizationLearnerTypeNotFound } from '../errors.js';
+import { AdministrationTeamNotFound, OrganizationLearnerTypeNotFound } from '../errors.js';
 
 const updateOrganizationInformation = withTransaction(async function ({
   organization,
@@ -8,9 +7,12 @@ const updateOrganizationInformation = withTransaction(async function ({
   tagRepository,
   administrationTeamRepository,
   organizationLearnerTypeRepository,
+  organizationVerificationService,
   countryRepository,
 }) {
-  const existingOrganization = await organizationForAdminRepository.get({ organizationId: organization.id });
+  const existingOrganization = await organizationForAdminRepository.get({
+    organizationId: organization.id,
+  });
 
   let organizationLearnerType;
   if (organization.organizationLearnerType.id) {
@@ -33,7 +35,7 @@ const updateOrganizationInformation = withTransaction(async function ({
   await _checkAdministrationTeamExists(organization.administrationTeamId, administrationTeamRepository);
 
   if (organization.countryCode) {
-    await _checkCountryExists(organization.countryCode, countryRepository);
+    await organizationVerificationService.checkCountryExists(organization.countryCode, countryRepository);
   }
 
   existingOrganization.updateWithDataProtectionOfficerAndTags(
@@ -42,9 +44,13 @@ const updateOrganizationInformation = withTransaction(async function ({
     tagsToUpdate,
   );
 
-  await organizationForAdminRepository.update({ organization: existingOrganization });
+  await organizationForAdminRepository.update({
+    organization: existingOrganization,
+  });
 
-  return organizationForAdminRepository.get({ organizationId: organization.id });
+  return organizationForAdminRepository.get({
+    organizationId: organization.id,
+  });
 });
 
 async function _checkAdministrationTeamExists(administrationTeamId, administrationTeamRepository) {
@@ -56,18 +62,6 @@ async function _checkAdministrationTeamExists(administrationTeamId, administrati
         administrationTeamId: administrationTeamId,
       },
     });
-  }
-}
-
-async function _checkCountryExists(countryCode, countryRepository) {
-  try {
-    await countryRepository.getByCode(countryCode);
-  } catch {
-    logger.error({
-      event: 'Not_found_country',
-      message: `Le pays avec le code ${countryCode} n'a pas été trouvé.`,
-    });
-    throw new CountryNotFoundError({ message: `Country not found for code ${countryCode}`, meta: { countryCode } });
   }
 }
 

--- a/api/src/organizational-entities/domain/usecases/update-organization-information.usecase.js
+++ b/api/src/organizational-entities/domain/usecases/update-organization-information.usecase.js
@@ -1,5 +1,5 @@
 import { withTransaction } from '../../../shared/domain/DomainTransaction.js';
-import { AdministrationTeamNotFound, OrganizationLearnerTypeNotFound } from '../errors.js';
+import { AdministrationTeamNotFound } from '../errors.js';
 
 const updateOrganizationInformation = withTransaction(async function ({
   organization,
@@ -16,18 +16,11 @@ const updateOrganizationInformation = withTransaction(async function ({
 
   let organizationLearnerType;
   if (organization.organizationLearnerType.id) {
-    try {
-      organizationLearnerType = await organizationLearnerTypeRepository.getById(
-        organization.organizationLearnerType.id,
-      );
-      organization.organizationLearnerType = organizationLearnerType;
-    } catch {
-      throw new OrganizationLearnerTypeNotFound({
-        meta: {
-          organizationLearnerTypeId: organization.organizationLearnerType.id,
-        },
-      });
-    }
+    organizationLearnerType = await organizationVerificationService.checkOrganizationLearnerTypeExists(
+      organization.organizationLearnerType.id,
+      organizationLearnerTypeRepository,
+    );
+    organization.organizationLearnerType = organizationLearnerType;
   }
 
   const tagsToUpdate = await tagRepository.findByIds(organization.tagIds);

--- a/api/tests/organizational-entities/integration/domain/services/organization-verification.service.test.js
+++ b/api/tests/organizational-entities/integration/domain/services/organization-verification.service.test.js
@@ -1,5 +1,9 @@
-import { CountryNotFoundError } from '../../../../../src/organizational-entities/domain/errors.js';
+import {
+  CountryNotFoundError,
+  OrganizationLearnerTypeNotFound,
+} from '../../../../../src/organizational-entities/domain/errors.js';
 import * as organizationVerificationService from '../../../../../src/organizational-entities/domain/services/organization-verification.service.js';
+import * as organizationLearnerTypeRepository from '../../../../../src/organizational-entities/infrastructure/repositories/organization-learner-type-repository.js';
 import * as countryRepository from '../../../../../src/shared/infrastructure/repositories/country-repository.js';
 import { catchErr, databaseBuilder, expect } from '../../../../test-helper.js';
 
@@ -37,6 +41,49 @@ describe('Integration | Organizational Entities | Domain | Services | organizati
           new CountryNotFoundError({
             message: `Country not found for code ${unknownCountryCode}`,
             meta: { countryCode: unknownCountryCode },
+          }),
+        );
+      });
+    });
+  });
+
+  describe('#checkOrganizationLearnerTypeExists', function () {
+    describe('when the organization learner exists', function () {
+      it('does not throw an error', async function () {
+        // given
+        const organizationLearnerType = databaseBuilder.factory.buildOrganizationLearnerType({
+          id: 123,
+        });
+        await databaseBuilder.commit();
+
+        // then
+        await expect(
+          organizationVerificationService.checkOrganizationLearnerTypeExists(
+            organizationLearnerType.id,
+            organizationLearnerTypeRepository,
+          ),
+        ).not.to.be.rejected;
+      });
+    });
+
+    describe('when the organization learner type does not exist', function () {
+      it('throws an error', async function () {
+        // given
+        const unknownOrganizationLearnerTypeId = 99000;
+
+        // when
+        const error = await catchErr(organizationVerificationService.checkOrganizationLearnerTypeExists)(
+          unknownOrganizationLearnerTypeId,
+          organizationLearnerTypeRepository,
+        );
+
+        // then
+        expect(error).to.deepEqualInstance(
+          new OrganizationLearnerTypeNotFound({
+            message: `Organization learner type not found for id ${unknownOrganizationLearnerTypeId}`,
+            meta: {
+              organizationLearnerTypeId: unknownOrganizationLearnerTypeId,
+            },
           }),
         );
       });

--- a/api/tests/organizational-entities/integration/domain/services/organization-verification.service.test.js
+++ b/api/tests/organizational-entities/integration/domain/services/organization-verification.service.test.js
@@ -1,0 +1,45 @@
+import { CountryNotFoundError } from '../../../../../src/organizational-entities/domain/errors.js';
+import * as organizationVerificationService from '../../../../../src/organizational-entities/domain/services/organization-verification.service.js';
+import * as countryRepository from '../../../../../src/shared/infrastructure/repositories/country-repository.js';
+import { catchErr, databaseBuilder, expect } from '../../../../test-helper.js';
+
+describe('Integration | Organizational Entities | Domain | Services | organization-verification', function () {
+  describe('#checkCountryExists', function () {
+    describe('when the country exists', function () {
+      it('does not throw an error', async function () {
+        // given
+        const country = databaseBuilder.factory.buildCertificationCpfCountry({
+          code: '99425',
+          commonName: 'COUNTRY',
+          originalName: 'COUNTRY',
+        });
+        await databaseBuilder.commit();
+
+        // then
+        await expect(organizationVerificationService.checkCountryExists(country.code, countryRepository)).not.to.be
+          .rejected;
+      });
+    });
+
+    describe('when the country does not exist', function () {
+      it('throws an error', async function () {
+        // given
+        const unknownCountryCode = 99000;
+
+        // when
+        const error = await catchErr(organizationVerificationService.checkCountryExists)(
+          unknownCountryCode,
+          countryRepository,
+        );
+
+        // then
+        expect(error).to.deepEqualInstance(
+          new CountryNotFoundError({
+            message: `Country not found for code ${unknownCountryCode}`,
+            meta: { countryCode: unknownCountryCode },
+          }),
+        );
+      });
+    });
+  });
+});

--- a/api/tests/organizational-entities/integration/domain/services/organization-verification.service.test.js
+++ b/api/tests/organizational-entities/integration/domain/services/organization-verification.service.test.js
@@ -1,8 +1,11 @@
+import { ADMINISTRATION_TEAM_ROCKET_ID } from '../../../../../db/seeds/data/team-acquisition/constants.js';
 import {
+  AdministrationTeamNotFound,
   CountryNotFoundError,
   OrganizationLearnerTypeNotFound,
 } from '../../../../../src/organizational-entities/domain/errors.js';
 import * as organizationVerificationService from '../../../../../src/organizational-entities/domain/services/organization-verification.service.js';
+import * as administrationTeamRepository from '../../../../../src/organizational-entities/infrastructure/repositories/administration-team-repository.js';
 import * as organizationLearnerTypeRepository from '../../../../../src/organizational-entities/infrastructure/repositories/organization-learner-type-repository.js';
 import * as countryRepository from '../../../../../src/shared/infrastructure/repositories/country-repository.js';
 import { catchErr, databaseBuilder, expect } from '../../../../test-helper.js';
@@ -83,6 +86,49 @@ describe('Integration | Organizational Entities | Domain | Services | organizati
             message: `Organization learner type not found for id ${unknownOrganizationLearnerTypeId}`,
             meta: {
               organizationLearnerTypeId: unknownOrganizationLearnerTypeId,
+            },
+          }),
+        );
+      });
+    });
+  });
+
+  describe('#checkAdministrationTeamExists', function () {
+    describe('when the administration team exists', function () {
+      it('does not throw an error', async function () {
+        // given
+        const administrationTeam = databaseBuilder.factory.buildAdministrationTeam({
+          id: ADMINISTRATION_TEAM_ROCKET_ID,
+          name: 'Team Rocket',
+        });
+        await databaseBuilder.commit();
+
+        // then
+        await expect(
+          organizationVerificationService.checkAdministrationTeamExists(
+            administrationTeam.id,
+            administrationTeamRepository,
+          ),
+        ).not.to.be.rejected;
+      });
+    });
+
+    describe('when the administration team does not exist', function () {
+      it('throws an error', async function () {
+        // given
+        const unknownAdministrationTeamId = 99000;
+
+        // when
+        const error = await catchErr(organizationVerificationService.checkAdministrationTeamExists)(
+          unknownAdministrationTeamId,
+          administrationTeamRepository,
+        );
+
+        // then
+        expect(error).to.deepEqualInstance(
+          new AdministrationTeamNotFound({
+            meta: {
+              administrationTeamId: unknownAdministrationTeamId,
             },
           }),
         );


### PR DESCRIPTION
## 🥀 Problème

Il y a beaucoup de duplication de code métier au niveau de la création/mise à jour d'organisations, notamment en ce qui concerne la vérification d'informations.

## 🏹 Proposition

On mutualise le tout dans un service appelé par les différents usecases.

## 💌 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## ❤️‍🔥 Pour tester

Pas de régression sur la création/mise à jour d'organisations.
