### PR TITLE
[TECH] Retirer la colonne ownerOrganizationId sur la table des profils cibles (PIX-21605).

### DIFF
--- a/api/db/migrations/20260302095048_remove-owner-organization-id-from-target-profile.js
+++ b/api/db/migrations/20260302095048_remove-owner-organization-id-from-target-profile.js
@@ -1,0 +1,21 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.table('target-profiles', function (table) {
+    table.dropColumn('ownerOrganizationId');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.table('target-profiles', function (table) {
+    table.integer('ownerOrganizationId').nullable().defaultTo(null).references('organizations.id');
+  });
+};
+
+export { down, up };

--- a/api/tests/prescription/organization-learner/integration/domain/usecases/get-organization-learner-with-participations_test.js
+++ b/api/tests/prescription/organization-learner/integration/domain/usecases/get-organization-learner-with-participations_test.js
@@ -169,7 +169,7 @@ describe('Integration | UseCases | get-organization-learner-with-participations'
         organizationId: organization.id,
       });
 
-      const targetProfileId = databaseBuilder.factory.buildTargetProfile({ ownerOrganizationId: organization.id }).id;
+      const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
       const campaign = databaseBuilder.factory.buildCampaign({ targetProfileId });
 
       databaseBuilder.factory.buildCampaignParticipation({

--- a/high-level-tests/e2e-playwright/helpers/db.ts
+++ b/high-level-tests/e2e-playwright/helpers/db.ts
@@ -412,7 +412,6 @@ export async function createTargetProfileInDB(name: string) {
   const [{ id }] = await knex('target-profiles')
     .insert({
       name,
-      ownerOrganizationId: null,
       internalName: name,
       imageUrl: null,
       isSimplifiedAccess: false,

--- a/high-level-tests/e2e/cypress/fixtures/target-profile-shares.json
+++ b/high-level-tests/e2e/cypress/fixtures/target-profile-shares.json
@@ -1,0 +1,7 @@
+[
+  {
+    "targetProfileId": 1,
+    "organizationId": 1,
+    "id": 1
+  }
+]

--- a/high-level-tests/e2e/cypress/fixtures/target-profiles.json
+++ b/high-level-tests/e2e/cypress/fixtures/target-profiles.json
@@ -2,7 +2,6 @@
   {
     "id": 1,
     "name": "Compétences pour un Mestre",
-    "internalName": "Nom interne pour un Mestre",
-    "ownerOrganizationId": 1
+    "internalName": "Nom interne pour un Mestre"
   }
 ]

--- a/high-level-tests/e2e/cypress/integration/pix-app/a11y-authenticated-1.test.js
+++ b/high-level-tests/e2e/cypress/integration/pix-app/a11y-authenticated-1.test.js
@@ -14,6 +14,7 @@ describe("a11y", () => {
     cy.task("db:fixture", "organization-invitations");
     cy.task("db:fixture", "user-orga-settings");
     cy.task("db:fixture", "target-profiles");
+    cy.task("db:fixture", "target-profile-shares");
     cy.task("db:fixture", "target-profile_tubes");
     cy.task("db:fixture", "campaigns");
     cy.task("db:fixture", "campaign_skills");

--- a/high-level-tests/e2e/cypress/integration/pix-app/a11y-authenticated-2.test.js
+++ b/high-level-tests/e2e/cypress/integration/pix-app/a11y-authenticated-2.test.js
@@ -14,6 +14,7 @@ describe("a11y", () => {
     cy.task("db:fixture", "organization-invitations");
     cy.task("db:fixture", "user-orga-settings");
     cy.task("db:fixture", "target-profiles");
+    cy.task("db:fixture", "target-profile-shares");
     cy.task("db:fixture", "target-profile_tubes");
     cy.task("db:fixture", "campaigns");
     cy.task("db:fixture", "campaign_skills");

--- a/high-level-tests/e2e/cypress/integration/pix-app/a11y-not-authenticated.test.js
+++ b/high-level-tests/e2e/cypress/integration/pix-app/a11y-not-authenticated.test.js
@@ -9,6 +9,7 @@ describe("a11y", () => {
     cy.task("db:fixture", "organization-invitations");
     cy.task("db:fixture", "user-orga-settings");
     cy.task("db:fixture", "target-profiles");
+    cy.task("db:fixture", "target-profile-shares");
     cy.task("db:fixture", "target-profile_tubes");
     cy.task("db:fixture", "campaigns");
     cy.task("db:fixture", "campaign_skills");

--- a/high-level-tests/e2e/cypress/support/step_definitions/index.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/index.js
@@ -14,6 +14,7 @@ Given("les données de test sont chargées", () => {
   cy.task("db:fixture", "organization-invitations");
   cy.task("db:fixture", "user-orga-settings");
   cy.task("db:fixture", "target-profiles");
+  cy.task("db:fixture", "target-profile-shares");
   cy.task("db:fixture", "target-profile_tubes");
   cy.task("db:fixture", "campaigns");
   cy.task("db:fixture", "campaign_skills");


### PR DESCRIPTION
## 🥀 Problème

Ce champs n'est plus utilisé dans le code, mais il existe toujours en bdd

## 🏹 Proposition

Supprimer cette colonne

## 💌 Remarques

RAS

## ❤️‍🔥 Pour tester
Vérifier que la base de données ne contient plus la colonne sur la table 'target-profiles'