### PR TITLE
[TECH] Mettre à jour la stack des RA et la version de l'addon PG

### DIFF
--- a/admin/scalingo.json
+++ b/admin/scalingo.json
@@ -19,7 +19,7 @@
   "stack": "scalingo-24",
   "addons": [
     {
-      "plan": "postgresql:postgresql-sandbox"
+      "plan": "postgresql:postgresql-starter-512"
     }
   ]
 }

--- a/admin/scalingo.json
+++ b/admin/scalingo.json
@@ -16,7 +16,7 @@
       "size": "S"
     }
   },
-  "stack": "scalingo-22",
+  "stack": "scalingo-24",
   "addons": [
     {
       "plan": "postgresql:postgresql-sandbox"

--- a/api/scalingo.json
+++ b/api/scalingo.json
@@ -31,7 +31,7 @@
   },
   "addons": [
     {
-      "plan": "postgresql:postgresql-sandbox",
+      "plan": "postgresql:postgresql-starter-512",
       "options": {
         "version": "16.9"
       }

--- a/api/scalingo.json
+++ b/api/scalingo.json
@@ -49,5 +49,5 @@
       "size": "S"
     }
   },
-  "stack": "scalingo-22"
+  "stack": "scalingo-24"
 }

--- a/audit-logger/scalingo.json
+++ b/audit-logger/scalingo.json
@@ -31,7 +31,7 @@
   },
   "addons": [
     {
-      "plan": "postgresql:postgresql-sandbox",
+      "plan": "postgresql:postgresql-starter-512",
       "options": {
         "version": "16.9"
       }

--- a/audit-logger/scalingo.json
+++ b/audit-logger/scalingo.json
@@ -43,5 +43,5 @@
       "size": "S"
     }
   },
-  "stack": "scalingo-22"
+  "stack": "scalingo-24"
 }

--- a/certif/scalingo.json
+++ b/certif/scalingo.json
@@ -19,7 +19,7 @@
   "stack": "scalingo-24",
   "addons": [
     {
-      "plan": "postgresql:postgresql-sandbox"
+      "plan": "postgresql:postgresql-starter-512"
     }
   ]
 }

--- a/certif/scalingo.json
+++ b/certif/scalingo.json
@@ -16,7 +16,7 @@
       "size": "S"
     }
   },
-  "stack": "scalingo-22",
+  "stack": "scalingo-24",
   "addons": [
     {
       "plan": "postgresql:postgresql-sandbox"

--- a/junior/scalingo.json
+++ b/junior/scalingo.json
@@ -12,7 +12,7 @@
       "size": "S"
     }
   },
-  "stack": "scalingo-22",
+  "stack": "scalingo-24",
   "addons": [
     {
       "plan": "postgresql:postgresql-sandbox"

--- a/junior/scalingo.json
+++ b/junior/scalingo.json
@@ -15,7 +15,7 @@
   "stack": "scalingo-24",
   "addons": [
     {
-      "plan": "postgresql:postgresql-sandbox"
+      "plan": "postgresql:postgresql-starter-512"
     }
   ]
 }

--- a/mon-pix/scalingo.json
+++ b/mon-pix/scalingo.json
@@ -12,7 +12,7 @@
       "size": "S"
     }
   },
-  "stack": "scalingo-22",
+  "stack": "scalingo-24",
   "addons": [
     {
       "plan": "postgresql:postgresql-sandbox"

--- a/mon-pix/scalingo.json
+++ b/mon-pix/scalingo.json
@@ -15,7 +15,7 @@
   "stack": "scalingo-24",
   "addons": [
     {
-      "plan": "postgresql:postgresql-sandbox"
+      "plan": "postgresql:postgresql-starter-512"
     }
   ]
 }

--- a/orga/scalingo.json
+++ b/orga/scalingo.json
@@ -19,7 +19,7 @@
   "stack": "scalingo-24",
   "addons": [
     {
-      "plan": "postgresql:postgresql-sandbox"
+      "plan": "postgresql:postgresql-starter-512"
     }
   ]
 }

--- a/orga/scalingo.json
+++ b/orga/scalingo.json
@@ -16,7 +16,7 @@
       "size": "S"
     }
   },
-  "stack": "scalingo-22",
+  "stack": "scalingo-24",
   "addons": [
     {
       "plan": "postgresql:postgresql-sandbox"

--- a/scalingo.json
+++ b/scalingo.json
@@ -35,5 +35,5 @@
       "size": "S"
     }
   },
-  "stack": "scalingo-22"
+  "stack": "scalingo-24"
 }


### PR DESCRIPTION
## 🥀 Problème
Une nouvelle [stack](https://scalingo.com/fr/blog/nouvelle-stack-scalingo-24) Scalingo est disponible depuis quelques mois et elle est devenu la stack par défaut. De plus, Scalingo arrête ses plans sandbox pour les bases de données PG et toute nouvelle RA est donc créée sur le plan starter-512. Cependant, notre configuration scalingo.json n'est pas à jour.

## 🏹 Proposition
- Mettre à jour la stack en scalingo-24
- Mettre à jour l'addon pg en starter-512

## ❤️‍🔥 Pour tester
Les RA se déploient
