### PR TITLE
[FEATURE] Ajout de description dans le schéma Joi de custom-element (PIX-21762)

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/validation/element/custom-element-schema.js
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/validation/element/custom-element-schema.js
@@ -6,9 +6,15 @@ import { htmlSchema, uuidSchema } from '../utils.js';
 const commonProps = {
   id: uuidSchema,
   type: Joi.string().valid('custom').required(),
-  title: Joi.string().allow('').required(),
-  instruction: htmlSchema.allow('').required(),
-  functionalInstruction: htmlSchema.allow('').required(),
+  title: Joi.string().allow('').required().description("Titre de l'élément interactif ou dynamique. Champ facultatif"),
+  instruction: htmlSchema
+    .allow('')
+    .required()
+    .description("Consigne pédagogique de l'élément interactif ou dynamique. Champ facultatif"),
+  functionalInstruction: htmlSchema
+    .allow('')
+    .required()
+    .description("Consigne fonctionnelle de l'élément interactif ou dynamique. Champ facultatif"),
 };
 
 export const customElementSchema = Joi.alternatives().conditional('.tagName', {


### PR DESCRIPTION
## 🥀 Problème

On a ajouté des nouveaux champs dans le custom-element, mais il est bon d'avoir des infos dispo dans Modulix-editor.

## 🏹 Proposition

Ajouter `.description()` dans custom-element-schema pour les champs `title, instruction` et `functionalInsruction`.

## 💌 Remarques

RAS

## ❤️‍🔥 Pour tester

Dans Modulix Editor en local :
- https://github.com/1024pix/modulix-editor/blob/f5b966cd28bc847e1aa2f542678d641740bf6111/index.html#L122-L122 => ajouter l'API ici (https://api-pr15322.review.pix.fr/api/...)
- Lancer Modulix Editor
- Voir les info bulles près des champs suivants : custom-element > title, inscrution, functionalInstruction

