### PR TITLE
[FEATURE] Utiliser un wording cohérent dans la création de parcours combiné (PIX-20325).

### DIFF
--- a/orga/tests/acceptance/campaign-creation-test.js
+++ b/orga/tests/acceptance/campaign-creation-test.js
@@ -37,7 +37,7 @@ module('Acceptance | Campaign Creation', function (hooks) {
 
     const screen = await visit('/campagnes/creation');
     await fillByLabel('Nom de la campagne *', 'Mon parcours combiné');
-    await clickByName('Créer un parcours combiné');
+    await clickByName('Développer les compétences des participants (parcours apprenants)');
 
     await click(screen.getByLabelText(`${t('pages.campaign-creation.combined-course-blueprints-list-label')} *`));
     await click(await screen.findByRole('option', { description: expectedCombinedCourseBlueprintName }));

--- a/orga/tests/integration/components/campaign/create-form-test.js
+++ b/orga/tests/integration/components/campaign/create-form-test.js
@@ -928,7 +928,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
       assert.dom(screen.queryByText(t('pages.campaign-creation.test-title.label'))).doesNotExist();
       assert.dom(screen.queryByText(t('pages.campaign-creation.target-profiles-list-label'))).doesNotExist();
       await fillByLabel('Nom de la campagne *', 'Mon parcours combiné');
-      await clickByName('Créer un parcours combiné');
+      await clickByName('Développer les compétences des participants (parcours apprenants)');
 
       await click(screen.getByLabelText(`${t('pages.campaign-creation.combined-course-blueprints-list-label')} *`));
       assert.ok(await screen.findByRole('option', { description: combinedCourseBlueprint.name }));

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -810,7 +810,7 @@
       "purpose": {
         "assessment": "Assess participants",
         "assessment-info": "An assessment campaign tests participants on specific topics.",
-        "combined-course": "Create a combined course",
+        "combined-course": "Developing participants' skills (learning courses)",
         "exam": "Exam mode",
         "exam-info": "A ‘exam mode’ campaign enables participants to be tested on specific topics, without taking their user profile into account or having any impact on it. The campaign's questions are personalised for each participant, depending on how far they have progressed along the route.",
         "label": "What is the purpose of your campaign?",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -798,7 +798,7 @@
       "purpose": {
         "assessment": "Évaluer les participants",
         "assessment-info": "Une campagne d’évaluation permet de tester les participants sur des sujets précis.",
-        "combined-course": "Créer un parcours combiné",
+        "combined-course": "Développer les compétences des participants (parcours apprenants)",
         "exam": "Mode interro",
         "exam-info": "Une campagne de type “mode interro” permet de tester les participants sur des sujets précis, sans prendre en compte le profil utilisateur, et sans impacter celui-ci. Les épreuves proposées sont personnalisées pour chaque participant selon son avancement dans le parcours.",
         "label": "Quel est l'objectif de votre campagne ?",

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -797,7 +797,7 @@
       "purpose": {
         "assessment": "Deelnemers evalueren",
         "assessment-info": "Een beoordelingscampagne stelt deelnemers in staat om getest te worden op specifieke onderwerpen.",
-        "combined-course": "Maak een gecombineerde cursus",
+        "combined-course": "De vaardigheden van de deelnemers ontwikkelen (leerprogramma)",
         "exam": "Vraagmodus",
         "exam-info": "Met een campagne in de “quizmodus” kunnen deelnemers worden getest op specifieke onderwerpen, zonder rekening te houden met hun gebruikersprofiel of er invloed op te hebben. De aangeboden tests zijn gepersonaliseerd voor elke deelnemer, afhankelijk van hoe ver ze gevorderd zijn in het traject.",
         "label": "Wat is het doel van je campagne?",


### PR DESCRIPTION
## 🥀 Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

La formulation dans la création de campagne de PixOrga n'est pas cohérente avec le reste de l'application.

## 🏹 Proposition

Pour garder le même type de formulation, on remplace dans le formulaire de création de campagne de PixOrga “Créer un parcours combiné” par “Développer les compétences des participants (parcours apprenants)”

flag: United Kingdom Developing participants' skills (learning courses)
flag: Netherlands De vaardigheden van de deelnemers ontwikkelen (leerprogramma)

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 💌 Remarques

RAS

<!-- Des infos supplémentaires, trucs et astuces ? -->

## ❤️‍🔥 Pour tester

Se connecter à Pix Orga (avec admin-orga@example.net par example).
Se rendre sur le formulaire de création de campagne.
Vérifier que la formulation de création de parcours apprenants est à jour.

<!--
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc.
- [ ] Documentation de la fonctionnalité (lien)
-->
