### PR TITLE
[TECH] Réparer les seeds certif

### DIFF
--- a/api/db/seeds/data/team-certification/tools/publish-session-with-validated-certification.js
+++ b/api/db/seeds/data/team-certification/tools/publish-session-with-validated-certification.js
@@ -120,9 +120,9 @@ export default async function publishSessionWithValidatedCertification({
     certificationReports: reports,
   });
 
-  await sessionManagementUseCases.processAutoJury({ sessionId: sessionFinalized.sessionId });
+  await sessionManagementUseCases.processAutoJury({ session: sessionFinalized });
 
-  await sessionManagementUseCases.registerPublishableSession({ sessionFinalized });
+  await sessionManagementUseCases.registerPublishableSession({ session: sessionFinalized });
 
   await databaseBuilder.commit();
 


### PR DESCRIPTION
## 🥀 Problème

```shell
Error while executing "1024pix/pix/api/db/seeds/seed.js" seed: Cannot read properties of undefined (reading 'certificationCourses') 
Error: Error while executing "1024pix/pix/api/db/seeds/seed.js" seed: Cannot read properties of undefined (reading 'certificationCourses') 
   at Seeder._waterfallBatch (1024pix/pix/api/node_modules/knex/lib/migrations/seed/Seeder.js:118:23) 
TypeError: Cannot read properties of undefined (reading 'certificationCourses') 
   at processAutoJury (file://1024pix/pix/api/src/certification/session-management/domain/usecases/process-auto-jury.js:31:45) 
   at Object.processAutoJury (file://1024pix/pix/api/src/shared/infrastructure/utils/dependency-injection.js:4:20) 
   at publishSessionWithValidatedCertification (file://1024pix/pix/api/db/seeds/data/team-certification/tools/publish-session-with-validated-certification.js:123:35) 
   at process.processTicksAndRejections (node:internal/process/task_queues:103:5) 
   at async ProSeed.create (file://1024pix/pix/api/db/seeds/data/team-certification/cases/simple-pro-certification.js:67:5) 
   at async teamCertificationDataBuilder (file://1024pix/pix/api/db/seeds/data/team-certification/data-builder.js:16:5) 
   at async Module.seed (file://1024pix/pix/api/db/seeds/seed.js:69:5) 
   at async Seeder._waterfallBatch (1024pix/pix/api/node_modules/knex/lib/migrations/seed/Seeder.js:115:9)
```

## 🏹 Proposition

Réparer le fichier de seeds problématique

## ❤️‍🔥 Pour tester

Lancer les seeds en local ✅ 
