### PR TITLE
[TECH] Création des tables `networks`, `structures` et `fct_structures`  (PIX-21291).

### DIFF
--- a/api/db/migrations/20260302135529_create-networks-table.js
+++ b/api/db/migrations/20260302135529_create-networks-table.js
@@ -1,0 +1,25 @@
+const TABLE_NAME = 'networks';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.createTable(TABLE_NAME, function (table) {
+    table.comment('This table contains all networks.');
+    table.increments('id').primary();
+    table.string('name', 50).notNullable().comment('Name of the network');
+    table.dateTime('created_at').notNullable().defaultTo(knex.fn.now());
+    table.dateTime('updated_at').defaultTo(knex.fn.now());
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.dropTable(TABLE_NAME);
+};
+
+export { down, up };

--- a/api/db/migrations/20260302142338_create-structures-table.js
+++ b/api/db/migrations/20260302142338_create-structures-table.js
@@ -1,0 +1,24 @@
+const TABLE_NAME = 'structures';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.createTable(TABLE_NAME, function (table) {
+    table.comment('This table contains all structures.');
+    table.increments('id').primary();
+    table.dateTime('created_at').notNullable().defaultTo(knex.fn.now());
+    table.dateTime('updated_at').defaultTo(knex.fn.now());
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.dropTable(TABLE_NAME);
+};
+
+export { down, up };

--- a/api/db/migrations/20260303135206_create-structures-fact-table.js
+++ b/api/db/migrations/20260303135206_create-structures-fact-table.js
@@ -1,0 +1,32 @@
+const TABLE_NAME = 'fct_structures';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.createTable(TABLE_NAME, function (table) {
+    table.comment('This fact table contains the links between structures, networks and organizations.');
+    table.integer('structure_id').notNullable().comment('References the ID of the structure.');
+    table.integer('network_id').nullable().comment('References the ID of the network if any.');
+    table.integer('parent_structure_id').nullable().comment('References the ID of the parent structure if any.');
+    table.integer('child_structure_id').nullable().comment('References the ID of the child structure if any.');
+    table.integer('organization_id').nullable().comment('References the ID of the organization if any.');
+
+    table.foreign('structure_id').references('structures.id');
+    table.foreign('network_id').references('networks.id');
+    table.foreign('parent_structure_id').references('structures.id');
+    table.foreign('child_structure_id').references('structures.id');
+    table.foreign('organization_id').references('organizations.id');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.dropTable(TABLE_NAME);
+};
+
+export { down, up };


### PR DESCRIPTION
## 🥀 Problème

Nous lançons l'epix des réseaux qui a pour objectifs de :
- Hiérarchiser des centres de certifications et organisations dans un réseau
- Créer un lien fort entre un centre de certification et une organisation

Ces besoins nécessitent que l'on enregistre diverses données (`networks` et `structures`)

## 🏹 Proposition

Création de nouvelles tables `networks` et `structures`.
Pour ce qui va être de la hiérarchisation des structures, et plutôt que de rajouter des clés étrangères dans les tables concernées (`certification-centers`, `organisations`, et `structures` pour le niveau dans la hiérarchie), nous optons pour un schéma de données basé sur des [tables de dimensions et une table de faits](https://waytolearnx.com/2018/08/difference-entre-table-des-faits-et-table-de-dimension.html). Cette table va nous permettre pour chaque structure de définir:

- le réseau auquel elle appartient
- sa place dans la hiérarchie (parent et enfants)
- son organisation rattachée

## 💌 Remarques

Ci-dessous le schéma de données prévu pour le MVP des réseaux, tel que co-construit avec @sandalfon 
Légende:

- En ![#1589F0](https://placehold.co/15x15/1589F0/1589F0.png) Table de dimensions
- En ![#f03c15](https://placehold.co/15x15/f03c15/f03c15.png) Table de faits

<img width="720" height="570" alt="Capture d’écran 2026-03-04 à 10 57 47" src="https://github.com/user-attachments/assets/10059920-d86d-44fc-a949-d480f56de5f4" />

## ❤️‍🔥 Pour tester

Exécuter l'entièreté des migrations et rollbacks.
Vérifier qu'il n'y ait pas d'erreur.
