### PR TITLE
[FEATURE] Ajouter le feature toggle multipleLocalesForTrainingsEnabled (PIX-21773).

### DIFF
--- a/admin/app/models/feature-toggle.js
+++ b/admin/app/models/feature-toggle.js
@@ -2,4 +2,5 @@ import Model, { attr } from '@ember-data/model';
 
 export default class FeatureToggle extends Model {
   @attr('array') disabledLocalesInFrontend;
+  @attr('boolean') multipleLocalesForTrainingsEnabled;
 }

--- a/api/config/feature-toggles-config.js
+++ b/api/config/feature-toggles-config.js
@@ -100,4 +100,11 @@ export default {
     devDefaultValues: { test: true, reviewApp: true },
     tags: ['captain', 'backend', 'transactions'],
   },
+  multipleLocalesForTrainingsEnabled: {
+    type: 'boolean',
+    description: 'Enable trainings with multiple locales',
+    defaultValue: false,
+    devDefaultValues: { test: false, reviewApp: true },
+    tags: ['team-devcomp', 'pix-api', 'pix-admin', 'frontend', 'backend'],
+  },
 };

--- a/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
+++ b/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
@@ -31,6 +31,7 @@ describe('Acceptance | Shared | Application | Controller | feature-toggle', func
             'use-pix-orga-new-auth-design': false,
             'is-pix-plus-candidate-a11y-enabled': false,
             'are-module-short-id-urls-enabled': false,
+            'multiple-locales-for-trainings-enabled': false,
           },
         },
       };


### PR DESCRIPTION
## 🥀 Problème

Nous avons besoin de mettre en place plusieurs locales pour un même contenu formatif.
Aujourd'hui le métier se retrouve à dupliquer un contenuF pour mettre les deux locales (langues) FR et FR-FR.

## 🏹 Proposition

Création d'un FT pour lancer le chantier


## ❤️‍🔥 Pour tester

-  Lancer Admin
- Voir l'API retourner true sur `multipleLocalesForTrainingsEnabled`
- Changer la valeur du FT =>  `scalingo -a pix-api-review-pr15328 run "npm run toggles -- --key=multipleLocalesForTrainingsEnabled --value=false"`

<img width="1461" height="603" alt="Capture d’écran 2026-03-02 à 16 50 33" src="https://github.com/user-attachments/assets/a0a0df9a-61a9-4edf-8921-b0a3aff19d48" />
