### PR TITLE
[BUGFIX] Exclure les learner supprimés de la réconciliation auto (PIX-21729)

### DIFF
--- a/api/src/prescription/learner-management/domain/usecases/reconcile-sco-organization-learner-automatically.js
+++ b/api/src/prescription/learner-management/domain/usecases/reconcile-sco-organization-learner-automatically.js
@@ -15,6 +15,10 @@ const reconcileScoOrganizationLearnerAutomatically = async function ({
   const nationalStudentIdForReconcile = _.orderBy(studentOrganizationLearners, 'updatedAt', 'desc')[0]
     .nationalStudentId;
 
+  if (!nationalStudentIdForReconcile) {
+    throw new UserCouldNotBeReconciledError();
+  }
+
   return organizationLearnerRepository.reconcileUserByNationalStudentIdAndOrganizationId({
     userId,
     nationalStudentId: nationalStudentIdForReconcile,

--- a/api/src/prescription/learner-management/infrastructure/repositories/organization-learner-repository.js
+++ b/api/src/prescription/learner-management/infrastructure/repositories/organization-learner-repository.js
@@ -250,6 +250,8 @@ const reconcileUserByNationalStudentIdAndOrganizationId = async function ({
         nationalStudentId,
         isDisabled: false,
       })
+      .whereNull('deletedAt')
+      .whereNotNull('nationalStudentId')
       .update({ userId, updatedAt: knexConn.fn.now() })
       .returning('*');
 

--- a/api/tests/prescription/learner-management/integration/domain/usecases/reconcile-sco-organization-learner-automatically_test.js
+++ b/api/tests/prescription/learner-management/integration/domain/usecases/reconcile-sco-organization-learner-automatically_test.js
@@ -1,0 +1,43 @@
+import { usecases } from '../../../../../../src/prescription/learner-management/domain/usecases/index.js';
+import { UserCouldNotBeReconciledError } from '../../../../../../src/shared/domain/errors.js';
+import { catchErr, databaseBuilder, expect } from '../../../../../test-helper.js';
+
+describe('Integration | UseCases | reconcile-sco-organization-learner-automatically', function () {
+  context('When user has no nationalStudentId', function () {
+    it('should throw a UserCouldNotBeReconciledError code error', async function () {
+      // when
+      const organization = databaseBuilder.factory.buildOrganization();
+      const user = databaseBuilder.factory.buildUser();
+
+      databaseBuilder.factory.buildOrganizationLearner({
+        userId: user.id,
+        nationalStudentId: null,
+        firstName: 'old-learner-in-orga-without-import',
+      });
+
+      databaseBuilder.factory.buildOrganizationLearner({
+        organizationId: organization.id,
+        userId: null,
+        nationalStudentId: '1234',
+        firstName: 'new-learner-in-sco-with-import',
+      });
+      databaseBuilder.factory.buildOrganizationLearner({
+        organizationId: organization.id,
+        userId: null,
+        nationalStudentId: null,
+        firstName: '(anonymised)',
+        deletedAt: new Date(),
+      });
+
+      await databaseBuilder.commit();
+
+      const error = await catchErr(usecases.reconcileScoOrganizationLearnerAutomatically)({
+        organizationId: organization.id,
+        userId: user.id,
+      });
+
+      // then
+      expect(error).to.be.instanceof(UserCouldNotBeReconciledError);
+    });
+  });
+});

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/organization-learner-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/organization-learner-repository_test.js
@@ -1760,6 +1760,7 @@ describe('Integration | Repository | Organization Learner Management | Organizat
           firstName: 'Steeve',
           lastName: 'Roger',
           isDisabled: false,
+          nationalStudentId: 'INE123456',
         });
         user = databaseBuilder.factory.buildUser({ firstName: 'Steeve', lastName: 'Roger' });
         await databaseBuilder.commit();
@@ -1824,6 +1825,80 @@ describe('Integration | Repository | Organization Learner Management | Organizat
         expect(error).to.be.instanceof(UserCouldNotBeReconciledError);
       });
     });
+    context('when the organizationLearner has no national Student Id and there is anonymised learner', function () {
+      it('should return an error', async function () {
+        const { id: organizationId } = databaseBuilder.factory.buildOrganization();
+        const { id: userId } = databaseBuilder.factory.buildUser({ firstName: 'Natasha', lastName: 'Romanoff' });
+
+        databaseBuilder.factory.buildOrganizationLearner({
+          organizationId,
+          userId: null,
+          nationalStudentId: '123456789',
+          firstName: 'Natasha',
+          lastName: 'Romanoff',
+          isDisabled: false,
+        });
+
+        databaseBuilder.factory.buildOrganizationLearner({
+          organizationId,
+          userId: null,
+          firstName: '(anonymised)',
+          lastName: '(anonymised)',
+          nationalStudentId: null,
+          isDisabled: false,
+          deletedAt: new Date(),
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const error = await catchErr(reconcileUserByNationalStudentIdAndOrganizationId)({
+          userId,
+          nationalStudentId: null,
+          organizationId,
+        });
+
+        // then
+        expect(error).to.be.instanceof(UserCouldNotBeReconciledError);
+      });
+    });
+
+    context('when the organizationLearner has no national Student Id', function () {
+      it('should return an error', async function () {
+        const { id: organizationId } = databaseBuilder.factory.buildOrganization();
+        const { id: userId } = databaseBuilder.factory.buildUser({ firstName: 'Natasha', lastName: 'Romanoff' });
+
+        databaseBuilder.factory.buildOrganizationLearner({
+          organizationId,
+          userId: null,
+          nationalStudentId: '123456789',
+          firstName: 'Natasha',
+          lastName: 'Romanoff',
+          isDisabled: false,
+        });
+
+        databaseBuilder.factory.buildOrganizationLearner({
+          organizationId,
+          userId: null,
+          firstName: '(anonymised)',
+          lastName: '(anonymised)',
+          nationalStudentId: null,
+          isDisabled: false,
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const error = await catchErr(reconcileUserByNationalStudentIdAndOrganizationId)({
+          userId,
+          nationalStudentId: null,
+          organizationId,
+        });
+
+        // then
+        expect(error).to.be.instanceof(UserCouldNotBeReconciledError);
+      });
+    });
 
     context('when the organizationLearner is disabled', function () {
       it('should return an error', async function () {
@@ -1836,6 +1911,7 @@ describe('Integration | Repository | Organization Learner Management | Organizat
           lastName: 'Romanoff',
           isDisabled: true,
         });
+        await databaseBuilder.commit();
         // when
         const error = await catchErr(reconcileUserByNationalStudentIdAndOrganizationId)({
           userId,


### PR DESCRIPTION

## 🥀 Problème
Dans le cas ou une orga a des learner supprimé et qu'un lerner tente de se réconcilier, on associe l'utilisateur à un learner supprimé.
Ca génère une erreur au moment de créer la participation.

## 🏹 Proposition

Ne pas prendre en compte les learner supprimé lors de la réconciliation

## 💌 Remarques

On a rajouté la sécurité au niveau du usecase (en ne tentant pas de réconciliation si le learner précédent n'a pas de `nationalStudentId`)
On exclu les learner supprimés des learners ciblé par la réconciliation auto.

## ❤️‍🔥 Pour tester

- Créer une campagne de collecte de profil dans l'orga Sco Agri ( FREGATA )
- Faire un import de learner SCO Agri ( FREGATA ) 
- Depuis pixAdmin, supprimer le learner importer 
- Ré-importer le fichier pour avoir un nouveau learner
- Démarrer une participation sur PROASSMUL avec le compte member-orga@example.net 
- Se déconnecter 
- Tenter de participer à la campagne de collecte de profil
- Voir le formulaire de réconciliation