### PR TITLE
[FEATURE] Rend l'item courant d'un parcours apprenant plus visible (PIX-21784).

### DIFF
--- a/mon-pix/app/components/combined-course/combined-course-item.gjs
+++ b/mon-pix/app/components/combined-course/combined-course-item.gjs
@@ -55,7 +55,9 @@ const Content = <template>
           class="combined-course-item__indicator--completed
             {{if @hasYellowBorder 'combined-course-item__indicator--yellow'}}"
         >
-          <span class="combined-course-item__completion-field">{{t "pages.combined-courses.items.completed"}}</span>
+          {{#unless @isCampaignType}}
+            <span class="combined-course-item__completion-field">{{t "pages.combined-courses.items.completed"}}</span>
+          {{/unless}}
           <PixIcon
             @name="checkCircle"
             @plainIcon={{true}}
@@ -100,13 +102,7 @@ const Duration = <template>
 </template>;
 
 function hasWhiteBackground(item) {
-  if (!item.isCompleted && !item.isLocked) {
-    return true;
-  } else if (item.type === CombinedCourseItemTypes.MODULE && item.isCompleted) {
-    return true;
-  } else {
-    return false;
-  }
+  return item.isCompleted || !item.isLocked;
 }
 
 <template>

--- a/mon-pix/app/styles/components/_combined-courses.scss
+++ b/mon-pix/app/styles/components/_combined-courses.scss
@@ -72,10 +72,10 @@
       color: var(--pix-secondary-900);
 
       &__title {
-            margin-bottom: var(--pix-spacing-2x);
-            font-size: 18px;
+        margin-bottom: var(--pix-spacing-2x);
+        font-size: 1.125rem;
 
-            @extend %pix-title-l;
+        @extend %pix-title-l;
       }
 
       &__description {
@@ -112,25 +112,30 @@
   gap: var(--pix-spacing-4x);
   align-items: center;
   justify-content: space-between;
-  width: 100%;
+  width: calc(100% - var(--pix-spacing-4x) * 2);
   margin-bottom: var(--pix-spacing-4x);
+  margin-left: var(--pix-spacing-4x);
   padding: var(--pix-spacing-4x) var(--pix-spacing-6x);
   background: rgb(var(--pix-primary-100-inline), 0.2);
   border: 1px solid var(--pix-primary-100);
   border-radius: var(--pix-spacing-4x);
 
+  @include breakpoints.device-is('tablet') {
+    width: 100%;
+    margin-left: 0;
+  }
+
   &--isCampaignType {
     flex-wrap: wrap;
 
-    &__indicator--completed{
+    &__indicator--completed {
       order: 1;
     }
 
-     @include breakpoints.device-is('tablet') {
+    @include breakpoints.device-is('tablet') {
       flex-basis: none;
       flex-wrap: nowrap;
     }
-
   }
 
   &--formation {
@@ -150,6 +155,11 @@
     flex-basis: auto;
     gap: var(--pix-spacing-4x);
     align-items: center;
+
+    .combined-course-item__icon {
+      max-width: var(--pix-spacing-8x);
+      max-height: var(--pix-spacing-8x);
+    }
   }
 
   &__icon {
@@ -157,8 +167,13 @@
     align-items: center;
     justify-content: center;
 
-     &--yellow {
-          color: var(--pix-secondary-500);
+    svg {
+      width: 100%;
+      height: 100%;
+    }
+
+    &--yellow {
+      color: var(--pix-secondary-500);
     }
   }
 
@@ -178,12 +193,12 @@
   &__completion-field {
     @extend .sr-only;
 
-     @include breakpoints.device-is('tablet') {
+    @include breakpoints.device-is('tablet') {
       position: static;
       display: flex;
       width: max-content;
       width: auto;
-      width:100%;
+      width: 100%;
       height: auto;
       margin: 0;
       overflow: visible;
@@ -192,7 +207,7 @@
   }
 
   &--campaign {
-   display:flex;
+    display: flex;
   }
 
   &__campaign-indicators {
@@ -201,13 +216,17 @@
     color: var(--pix-primary-500);
     font-weight: var(--pix-font-bold);
 
-    @include breakpoints.device-is('tablet') {
-        flex-basis: auto;
-        order: 1;
-        margin-left: auto;
-     }
-  }
+    img {
+      min-width: var(--pix-spacing-8x);
+      min-height: var(--pix-spacing-8x);
+    }
 
+    @include breakpoints.device-is('tablet') {
+      flex-basis: auto;
+      order: 1;
+      margin-left: auto;
+    }
+  }
 
   &__indicator {
     order: 2;
@@ -227,22 +246,21 @@
       @extend %pix-body-m;
 
       display: flex;
-      gap: var(--pix-spacing-2x);
+      gap: var(--pix-spacing-4x);
       align-items: center;
       height: 24px;
       color: var(--pix-primary-500);
       font-weight: var(--pix-font-bold);
 
       .combined-course-item__icon {
-         @include breakpoints.device-is('tablet') {
-       width: var(--pix-spacing-8x);
-        height: var(--pix-spacing-8x);
+        @include breakpoints.device-is('tablet') {
+          min-width: var(--pix-spacing-8x);
+          min-height: var(--pix-spacing-8x);
 
-        &--yellow {
-          color: var(--pix-secondary-500);
+          &--yellow {
+            color: var(--pix-secondary-500);
+          }
         }
-    }
-
       }
     }
 
@@ -255,12 +273,32 @@
     display: flex;
     flex-direction: column;
     align-items: start;
-    border: 6px solid var(--pix-primary-300);
+    width: 100%;
+    margin-left: 0;
+    border: 6px solid var(--pix-primary-500);
+    box-shadow:
+      0 2px 5px 0 rgb(var(--pix-primary-500-inline), 25%),
+      0 -2px 5px 0 rgb(var(--pix-primary-500-inline), 15%) inset,
+      0 1px 1px 0 rgb(var(--pix-neutral-0-inline), 10%) inset,
+      0 3px 4px 0 rgb(var(--pix-primary-10-inline), 10%) inset;
+
+    .combined-course-item__title {
+      @extend %pix-title-xs;
+    }
+
+    .combined-course-item__icon {
+      min-width: var(--pix-spacing-12x);
+      max-width: var(--pix-spacing-12x);
+      min-height: var(--pix-spacing-12x);
+      max-height: var(--pix-spacing-12x);
+    }
 
     @include breakpoints.device-is('tablet') {
-    flex-direction: row;
-    align-items: center;
-  }
+      flex-direction: row;
+      align-items: center;
+      width: calc(100% + var(--pix-spacing-6x) * 2);
+      margin-left: calc(var(--pix-spacing-6x) * -1);
+    }
 
     .combined-course-item__tag {
       display: flex;
@@ -285,12 +323,10 @@
     }
   }
 
-
- &__stars {
-  height: 24px;
-  margin-right: var(--pix-spacing-6x);
-  margin-left: var(--pix-spacing-4x);
-}
+  &__stars {
+    height: 24px;
+    margin-left: var(--pix-spacing-4x);
+  }
 
   .combined-course-item__text {
     display: flex;


### PR DESCRIPTION
## 🥀 Problème

L'item courant d'un parcours apprenant n'est pas suffisamment mis en avant et cela cause des incompréhensions des utilisateurs.

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

## 🏹 Proposition

Suite au redesign de la page du parcours apprenant, on prend en compte les différents changements : 

 - [x] Changement de fond des diagnostics en neutral-o
 - [x] Suppression du texte "Complété" sur le diag
 
**Item passé ou à venir :**
 - [x] Réduction de la taille des icônes d'item à 40px
 - [x] Titre item token title-xxs

**Item en cours :**
 - [x] Augmentation de la largeur de l'item à
 - [x] Augmentation taille de l'icône à 56px
 - [x] Titre item token title-xs
 - [x] Shadow default (création du token côté DS)
 - [x] border en primary-500

Les changements liés aux textes n'ont pas été faits car ils nécessitent de retravailler les données d'un parcours apprenant pour déterminer les étapes.

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 💌 Remarques

Les nouveaux styles n'ont pas encore été ajoutés au Design System, nous le ferons après validation en panel.

<!-- Des infos supplémentaires, trucs et astuces ? -->

## ❤️‍🔥 Pour tester

Se rendre dans Pix APP.
Saisir le code COMBINIX1.

Voir que le style de l'item courant respecte le design Figma.
Avancer dans le parcours apprenant pour vérifier les styles des étapes à venir et passées.

<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
