### PR TITLE
[TECH] Relier une organisation à une structure (PIX-21293)

### DIFF
--- a/api/db/migrations/20260302135529_create-networks-table.js
+++ b/api/db/migrations/20260302135529_create-networks-table.js
@@ -1,0 +1,24 @@
+const TABLE_NAME = 'networks';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.createTable(TABLE_NAME, function (table) {
+    table.comment('This table contains all networks.');
+    table.increments('id').primary();
+    table.string('name', 50).notNullable().comment('Name of the network');
+    table.dateTime('createdAt').notNullable().defaultTo(knex.fn.now());
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.dropTable(TABLE_NAME);
+};
+
+export { down, up };

--- a/api/db/migrations/20260302142338_create-structures-table.js
+++ b/api/db/migrations/20260302142338_create-structures-table.js
@@ -1,0 +1,30 @@
+const TABLE_NAME = 'structures';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.createTable(TABLE_NAME, function (table) {
+    table.increments('id').primary();
+    table.integer('level').notNullable().defaultTo(0);
+    table.integer('network_id').unsigned().nullable();
+    table.foreign('network_id').references('id').inTable('networks');
+    table.integer('parent_structure_id').unsigned().nullable();
+    table.foreign('parent_structure_id').references('id').inTable(TABLE_NAME);
+    table.dateTime('createdAt').notNullable().defaultTo(knex.fn.now());
+    table.dateTime('updatedAt').defaultTo(knex.fn.now());
+
+    table.index('parent_structure_id');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.dropTable(TABLE_NAME);
+};
+
+export { down, up };

--- a/api/db/migrations/20260302155633_add-structureId-relationship-to-organizations.js
+++ b/api/db/migrations/20260302155633_add-structureId-relationship-to-organizations.js
@@ -1,0 +1,29 @@
+const TABLE_NAME = 'organizations';
+const COLUMN_NAME = 'structureId';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table
+      .integer(COLUMN_NAME)
+      .defaultTo(null)
+      .nullable()
+      .references('structures.id')
+      .comment("Reference to the organization's structure id.");
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## 🥀 Problème

On a créé les réseaux et les structures. Il faut désormais les relier aux organisations pour indiquer si celles-ci font partie d'un réseau.

## 🏹 Proposition

Ajouter une clé étrangère `structureId` sur la table `organization`.

## 💌 Remarques

On a gardé le camelCase `structureId` dans un soucis de cohérence avec le reste des colonnes de cette table.

## ❤️‍🔥 Pour tester
Exécuter la migration et la rollback
