### PR TITLE
[TECH] Mettre à jour le plan de l'addon redis en starter-256

### DIFF
--- a/api/scalingo.json
+++ b/api/scalingo.json
@@ -37,7 +37,7 @@
       }
     },
     {
-      "plan": "redis:redis-sandbox",
+      "plan": "redis:redis-starter-256",
       "options": {
         "version": "7.2.11"
       }


### PR DESCRIPTION
## 🥀 Problème
Scalingo arrête ses plans sandbox pour les bases de données Redis et toute nouvelle RA est donc créée sur le plan starter-256. Cependant, notre configuration scalingo.json n'est pas à jour.

## 🏹 Proposition
Mettre à jour le plan de l'addon redis en starter-256

## ❤️‍🔥 Pour tester
L'API se déploie
