### PR TITLE
[TECH] Ajoute une stratégie d'authentification de routes API qui permet un usage non authentifié tout en validant l'authentification si elle est fournie.

### DIFF
--- a/api/server.js
+++ b/api/server.js
@@ -214,7 +214,9 @@ const setupDeserialization = function (server) {
 };
 
 const setupAuthentication = function (server) {
-  server.auth.scheme(serverAuthentication.schemes.jwt.name, serverAuthentication.schemes.jwt.scheme);
+  Object.values(serverAuthentication.schemes).forEach((scheme) => {
+    server.auth.scheme(scheme.name, scheme.scheme);
+  });
   Object.values(serverAuthentication.strategies).forEach((strategy) => {
     server.auth.strategy(strategy.name, strategy.schemeName, strategy.configuration);
   });

--- a/api/src/identity-access-management/infrastructure/server-authentication.js
+++ b/api/src/identity-access-management/infrastructure/server-authentication.js
@@ -4,6 +4,7 @@ import { config } from '../../shared/config.js';
 import { tokenService } from '../../shared/domain/services/token-service.js';
 import {
   jwtApplicationAuthenticationStrategyName,
+  jwtOptionalUserAuthenticationStrategyName,
   jwtUserAuthenticationStrategyName,
 } from '../../shared/infrastructure/authentication-strategy-names.js';
 import { logger } from '../../shared/infrastructure/utils/logger.js';
@@ -19,12 +20,30 @@ const schemes = {
       };
     },
   },
+  optionalJwt: {
+    name: 'jwt-optional-scheme',
+    scheme(_, strategyConfiguration) {
+      return {
+        authenticate: authenticateOptionalJWT(strategyConfiguration),
+      };
+    },
+  },
 };
 
 const strategies = {
   jwtUser: {
     name: jwtUserAuthenticationStrategyName,
     schemeName: schemes.jwt.name,
+    configuration: {
+      key: config.authentication.secret,
+      validate: (decodedAccessToken, options) =>
+        validateUser(decodedAccessToken, { ...options, revokedUserAccessRepository }),
+    },
+  },
+
+  jwtOptionalUser: {
+    name: jwtOptionalUserAuthenticationStrategyName,
+    schemeName: schemes.optionalJwt.name,
     configuration: {
       key: config.authentication.secret,
       validate: (decodedAccessToken, options) =>
@@ -89,6 +108,17 @@ async function validateClientApplication(decodedAccessToken) {
       scope: decodedAccessToken.scope.split(/\s/g),
       source: decodedAccessToken.source,
     },
+  };
+}
+
+function authenticateOptionalJWT({ key, validate }) {
+  return async (request, h) => {
+    const authorizationHeader = request.headers.authorization;
+    if (!authorizationHeader) {
+      return h.authenticated({ credentials: { userId: null } });
+    }
+
+    return authenticateJWT({ key, validate })(request, h);
   };
 }
 

--- a/api/src/identity-access-management/infrastructure/server-authentication.js
+++ b/api/src/identity-access-management/infrastructure/server-authentication.js
@@ -37,7 +37,7 @@ const strategies = {
     configuration: {
       key: config.authentication.secret,
       validate: (decodedAccessToken, options) =>
-        validateUser(decodedAccessToken, { ...options, revokedUserAccessRepository }),
+        validateUserAccessToken(decodedAccessToken, { ...options, revokedUserAccessRepository }),
     },
   },
 
@@ -47,7 +47,7 @@ const strategies = {
     configuration: {
       key: config.authentication.secret,
       validate: (decodedAccessToken, options) =>
-        validateUser(decodedAccessToken, { ...options, revokedUserAccessRepository }),
+        validateUserAccessToken(decodedAccessToken, { ...options, revokedUserAccessRepository }),
     },
   },
 
@@ -56,12 +56,12 @@ const strategies = {
     schemeName: schemes.jwt.name,
     configuration: {
       key: config.authentication.secret,
-      validate: validateClientApplication,
+      validate: validateClientApplicationAccessToken,
     },
   },
 };
 
-async function validateUser(decodedAccessToken, { request, revokedUserAccessRepository }) {
+async function validateUserAccessToken(decodedAccessToken, { request, revokedUserAccessRepository }) {
   const userId = decodedAccessToken.user_id;
   if (!userId) {
     return { isValid: false };
@@ -91,7 +91,7 @@ async function validateUser(decodedAccessToken, { request, revokedUserAccessRepo
   return { isValid: true, credentials: { userId: decodedAccessToken.user_id } };
 }
 
-async function validateClientApplication(decodedAccessToken) {
+async function validateClientApplicationAccessToken(decodedAccessToken) {
   if (!decodedAccessToken.client_id) {
     logger.warn({
       message: 'decodedAccessToken has no client_id',
@@ -164,4 +164,4 @@ function authenticateJWT({ key, validate }) {
   };
 }
 
-export { schemes, strategies, validateClientApplication, validateUser };
+export { schemes, strategies, validateClientApplicationAccessToken, validateUserAccessToken };

--- a/api/src/quest/application/combined-course-route.js
+++ b/api/src/quest/application/combined-course-route.js
@@ -9,6 +9,7 @@ import { PayloadTooLargeError, sendJsonApiError } from '../../shared/application
 import { securityPreHandlers } from '../../shared/application/security-pre-handlers.js';
 import { MAX_FILE_SIZE_UPLOAD } from '../../shared/domain/constants.js';
 import { identifiersType } from '../../shared/domain/types/identifiers-type.js';
+import { jwtOptionalUserAuthenticationStrategyName } from '../../shared/infrastructure/authentication-strategy-names.js';
 import { combinedCourseController } from './combined-course-controller.js';
 
 const register = async function (server) {
@@ -17,6 +18,9 @@ const register = async function (server) {
       method: 'GET',
       path: '/api/combined-courses',
       config: {
+        auth: {
+          strategy: jwtOptionalUserAuthenticationStrategyName,
+        },
         pre: [
           {
             method: securityPreHandlers.checkAuthorizationToAccessCombinedCourse,

--- a/api/src/shared/infrastructure/authentication-strategy-names.js
+++ b/api/src/shared/infrastructure/authentication-strategy-names.js
@@ -1,2 +1,3 @@
 export const jwtUserAuthenticationStrategyName = 'jwt-user';
+export const jwtOptionalUserAuthenticationStrategyName = 'jwt-optional-user';
 export const jwtApplicationAuthenticationStrategyName = 'jwt-application';

--- a/api/tests/identity-access-management/unit/infrastructure/server-authentication.test.js
+++ b/api/tests/identity-access-management/unit/infrastructure/server-authentication.test.js
@@ -2,8 +2,8 @@ import { RevokedUserAccess } from '../../../../src/identity-access-management/do
 import { revokedUserAccessRepository } from '../../../../src/identity-access-management/infrastructure/repositories/revoked-user-access.repository.js';
 import {
   schemes,
-  validateClientApplication,
-  validateUser,
+  validateClientApplicationAccessToken,
+  validateUserAccessToken,
 } from '../../../../src/identity-access-management/infrastructure/server-authentication.js';
 import { ForwardedOriginError } from '../../../../src/identity-access-management/infrastructure/utils/network.js';
 import { tokenService } from '../../../../src/shared/domain/services/token-service.js';
@@ -88,7 +88,7 @@ describe('Unit | Identity Access Management | Infrastructure | serverAuthenticat
     });
   });
 
-  describe('#validateUser', function () {
+  describe('#validateUserAccessToken', function () {
     describe('when there is no user Id', function () {
       it('should throw an error', async function () {
         // given
@@ -109,7 +109,7 @@ describe('Unit | Identity Access Management | Infrastructure | serverAuthenticat
         const { authenticate } = schemes.jwt.scheme(undefined, {
           key: 'dummy-secret',
           validate: (decodedAccessToken, options) =>
-            validateUser(decodedAccessToken, {
+            validateUserAccessToken(decodedAccessToken, {
               ...options,
               revokedUserAccessRepository,
             }),
@@ -147,7 +147,7 @@ describe('Unit | Identity Access Management | Infrastructure | serverAuthenticat
           const { authenticate } = schemes.jwt.scheme(undefined, {
             key: 'dummy-secret',
             validate: (decodedAccessToken, options) =>
-              validateUser(decodedAccessToken, {
+              validateUserAccessToken(decodedAccessToken, {
                 ...options,
                 revokedUserAccessRepository,
               }),
@@ -189,7 +189,7 @@ describe('Unit | Identity Access Management | Infrastructure | serverAuthenticat
           const { authenticate } = schemes.jwt.scheme(undefined, {
             key: 'dummy-secret',
             validate: (decodedAccessToken, options) =>
-              validateUser(decodedAccessToken, {
+              validateUserAccessToken(decodedAccessToken, {
                 ...options,
                 revokedUserAccessRepository,
               }),
@@ -226,7 +226,7 @@ describe('Unit | Identity Access Management | Infrastructure | serverAuthenticat
           const { authenticate } = schemes.jwt.scheme(undefined, {
             key: 'dummy-secret',
             validate: (decodedAccessToken, options) =>
-              validateUser(decodedAccessToken, {
+              validateUserAccessToken(decodedAccessToken, {
                 ...options,
                 revokedUserAccessRepository,
               }),
@@ -256,7 +256,7 @@ describe('Unit | Identity Access Management | Infrastructure | serverAuthenticat
           const { authenticate } = schemes.jwt.scheme(undefined, {
             key: 'dummy-secret',
             validate: (decodedAccessToken, options) =>
-              validateUser(decodedAccessToken, {
+              validateUserAccessToken(decodedAccessToken, {
                 ...options,
                 revokedUserAccessRepository,
               }),
@@ -270,7 +270,7 @@ describe('Unit | Identity Access Management | Infrastructure | serverAuthenticat
     });
   });
 
-  describe('#validateClientApplication', function () {
+  describe('#validateClientApplicationAccessToken', function () {
     describe('when there is a clientId', function () {
       it('should call h.authenticated with credentials', async function () {
         const request = { headers: { authorization: 'Bearer token' } };
@@ -291,7 +291,7 @@ describe('Unit | Identity Access Management | Infrastructure | serverAuthenticat
 
         const { authenticate } = schemes.jwt.scheme(undefined, {
           key: 'dummy-secret',
-          validate: validateClientApplication,
+          validate: validateClientApplicationAccessToken,
         });
         await authenticate(request, h);
 
@@ -313,7 +313,7 @@ describe('Unit | Identity Access Management | Infrastructure | serverAuthenticat
 
         const { authenticate } = schemes.jwt.scheme(undefined, {
           key: 'dummy-secret',
-          validate: validateClientApplication,
+          validate: validateClientApplicationAccessToken,
         });
         const response = await authenticate(request, h);
 

--- a/api/tests/quest/unit/application/combined-course-route_test.js
+++ b/api/tests/quest/unit/application/combined-course-route_test.js
@@ -2,7 +2,7 @@ import { combinedCourseController } from '../../../../src/quest/application/comb
 import * as combinedCourseRoute from '../../../../src/quest/application/combined-course-route.js';
 import { OrganizationLearnerParticipationStatuses } from '../../../../src/quest/domain/models/OrganizationLearnerParticipation.js';
 import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
-import { expect, HttpTestServer, sinon } from '../../../test-helper.js';
+import { expect, generateAuthenticatedUserRequestHeaders, HttpTestServer, sinon } from '../../../test-helper.js';
 
 describe('Quest | Unit | Routes | combined-course-route', function () {
   describe('GET /api/combined-course', function () {
@@ -12,6 +12,7 @@ describe('Quest | Unit | Routes | combined-course-route', function () {
       sinon.stub(combinedCourseController, 'getByCode').callsFake((_, h) => h.response());
 
       const httpTestServer = new HttpTestServer();
+      httpTestServer.setupAuthentication();
       await httpTestServer.register(combinedCourseRoute);
 
       // when
@@ -29,10 +30,17 @@ describe('Quest | Unit | Routes | combined-course-route', function () {
       sinon.stub(combinedCourseController, 'getById').callsFake((_, h) => h.response());
 
       const httpTestServer = new HttpTestServer();
+      httpTestServer.setupAuthentication();
       await httpTestServer.register(combinedCourseRoute);
 
       // when
-      await httpTestServer.request('GET', '/api/combined-courses/123');
+      await httpTestServer.request(
+        'GET',
+        '/api/combined-courses/123',
+        null,
+        null,
+        generateAuthenticatedUserRequestHeaders({ userId: 123 }),
+      );
 
       // then
       expect(securityPreHandlers.checkUserCanManageCombinedCourse).to.have.been.called;
@@ -46,10 +54,17 @@ describe('Quest | Unit | Routes | combined-course-route', function () {
       sinon.stub(combinedCourseController, 'getStatistics').callsFake((_, h) => h.response());
 
       const httpTestServer = new HttpTestServer();
+      httpTestServer.setupAuthentication();
       await httpTestServer.register(combinedCourseRoute);
 
       // when
-      await httpTestServer.request('GET', '/api/combined-courses/123/statistics');
+      await httpTestServer.request(
+        'GET',
+        '/api/combined-courses/123/statistics',
+        null,
+        null,
+        generateAuthenticatedUserRequestHeaders({ userId: 123 }),
+      );
 
       // then
       expect(securityPreHandlers.checkUserCanManageCombinedCourse).to.have.been.called;
@@ -63,6 +78,7 @@ describe('Quest | Unit | Routes | combined-course-route', function () {
       sinon.stub(combinedCourseController, 'findParticipations').callsFake((_, h) => h.response());
 
       const httpTestServer = new HttpTestServer();
+      httpTestServer.setupAuthentication();
       await httpTestServer.register(combinedCourseRoute);
 
       // when
@@ -75,6 +91,9 @@ describe('Quest | Unit | Routes | combined-course-route', function () {
           `&filters[statuses][]=${OrganizationLearnerParticipationStatuses.STARTED}` +
           '&filters[divisions][]=6eme' +
           '&filters[groups][]=A',
+        null,
+        null,
+        generateAuthenticatedUserRequestHeaders({ userId: 123 }),
       );
 
       // then
@@ -90,10 +109,17 @@ describe('Quest | Unit | Routes | combined-course-route', function () {
       sinon.stub(combinedCourseController, 'getCombinedCourseParticipationById').callsFake((_, h) => h.response());
 
       const httpTestServer = new HttpTestServer();
+      httpTestServer.setupAuthentication();
       await httpTestServer.register(combinedCourseRoute);
 
       // when
-      await httpTestServer.request('GET', '/api/combined-courses/123/participations/456');
+      await httpTestServer.request(
+        'GET',
+        '/api/combined-courses/123/participations/456',
+        null,
+        null,
+        generateAuthenticatedUserRequestHeaders({ userId: 123 }),
+      );
 
       // then
       expect(securityPreHandlers.checkUserCanManageCombinedCourse).to.have.been.called;
@@ -108,10 +134,17 @@ describe('Quest | Unit | Routes | combined-course-route', function () {
       sinon.stub(combinedCourseController, 'start').callsFake((_, h) => h.response());
 
       const httpTestServer = new HttpTestServer();
+      httpTestServer.setupAuthentication();
       await httpTestServer.register(combinedCourseRoute);
 
       // when
-      await httpTestServer.request('PUT', '/api/combined-courses/ABC/start');
+      await httpTestServer.request(
+        'PUT',
+        '/api/combined-courses/ABC/start',
+        null,
+        null,
+        generateAuthenticatedUserRequestHeaders({ userId: 123 }),
+      );
 
       // then
       expect(securityPreHandlers.checkAuthorizationToAccessCombinedCourse).to.have.been.called;
@@ -125,10 +158,17 @@ describe('Quest | Unit | Routes | combined-course-route', function () {
       sinon.stub(combinedCourseController, 'reassessStatus').callsFake((_, h) => h.response());
 
       const httpTestServer = new HttpTestServer();
+      httpTestServer.setupAuthentication();
       await httpTestServer.register(combinedCourseRoute);
 
       // when
-      await httpTestServer.request('PATCH', '/api/combined-courses/ABC/reassess-status');
+      await httpTestServer.request(
+        'PATCH',
+        '/api/combined-courses/ABC/reassess-status',
+        null,
+        null,
+        generateAuthenticatedUserRequestHeaders({ userId: 123 }),
+      );
 
       // then
       expect(securityPreHandlers.checkAuthorizationToAccessCombinedCourse).to.have.been.called;
@@ -142,10 +182,17 @@ describe('Quest | Unit | Routes | combined-course-route', function () {
       sinon.stub(combinedCourseController, 'getByOrganizationId').callsFake((_, h) => h.response());
 
       const httpTestServer = new HttpTestServer();
+      httpTestServer.setupAuthentication();
       await httpTestServer.register(combinedCourseRoute);
 
       // when
-      await httpTestServer.request('GET', '/api/organizations/123/combined-courses');
+      await httpTestServer.request(
+        'GET',
+        '/api/organizations/123/combined-courses',
+        null,
+        null,
+        generateAuthenticatedUserRequestHeaders({ userId: 123 }),
+      );
 
       // then
       expect(securityPreHandlers.checkUserBelongsToOrganization).to.have.been.called;

--- a/api/tests/tooling/server/http-test-server.js
+++ b/api/tests/tooling/server/http-test-server.js
@@ -55,7 +55,9 @@ class HttpTestServer {
   }
 
   setupAuthentication() {
-    this.hapiServer.auth.scheme(serverAuthentication.schemes.jwt.name, serverAuthentication.schemes.jwt.scheme);
+    Object.values(serverAuthentication.schemes).forEach((scheme) => {
+      this.hapiServer.auth.scheme(scheme.name, scheme.scheme);
+    });
     Object.values(serverAuthentication.strategies).forEach((strategy) =>
       this.hapiServer.auth.strategy(strategy.name, strategy.schemeName, strategy.configuration),
     );


### PR DESCRIPTION
## 🥀 Problème

Actuellement, il est possible de définir une route comme n'ayant pas d'authentification avec `auth: false` dans sa configuration.
Malheureusement, ce faisant, si un token d'authentification est fourni dans l'appel d'API, celui-ci n'est pas validé et le `userId` n'est pas rendu disponible dans l'objet `request.credentials.userId`.
Cela est particulièrement gênant pour les routes qui veulent un comportement différent selon que l'utilisateur est connecté ou non. (Par exemple `GET /api/combined-courses`).

## 🏹 Proposition

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

On crée un nouveau schéma d'authentification appelé `jwtOptional` qui permet d'appeler une route sans token.
Si un token est passé, alors celui-ci est validé comme avec le schéma `jwt`.

On crée une stratégie d'authentification qui permet d'utiliser ce schéma.

## 💌 Remarques

RAS
<!-- Des infos supplémentaires, trucs et astuces ? -->

## ❤️‍🔥 Pour tester

Ce schéma est mis en place dans la route `GET /api/combined-courses`.
Cela permet de vérifier son bon fonctionnement en rejoignant un parcours combiné.

Pour cela, en n'étant pas connecté, se rendre sur la route `/campagnes`.
Saisir le code `COMBINIX1`.
Vérifier que l'on est bien redirigé vers l'écran d'inscription.
Se connecter avec l'utilisateur `attestation-blank@example.net`
Vérifier que l'on arrive bien sur l'écran de démarrage du parcours combiné.

En étant connecté avec un autre compte, se rendre sur la route `/campagnes`.
Saisir le code `COMBINIX1`.
Vérifier que l'on est bien redirigé l'écran de démarrage du parcours combiné.

<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
