### PR TITLE
[TECH] Gérer les URLs dans le service dédié (PIX-21807).

### DIFF
--- a/certif/app/services/url.js
+++ b/certif/app/services/url.js
@@ -36,18 +36,27 @@ export default class Url extends UrlBaseService {
   }
 
   get documentationUrl() {
-    if (this.currentUser.currentAllowedCertificationCenterAccess.isScoManagingStudents) {
-      return this.intl.t('common.urls.documentation.sco-managing-students');
+    if (this.locale.currentLanguage === 'fr') {
+      if (this.currentUser.currentAllowedCertificationCenterAccess.isScoManagingStudents) {
+        return 'https://cloud.pix.fr/s/opiFxfjygR76S8y';
+      }
+      return 'https://cloud.pix.fr/s/ypq3K7GmgpEdwop';
     }
-    return this.intl.t('common.urls.documentation.other');
+    return 'https://cloud.pix.fr/s/c6SmQ8iM6nGbrzw';
   }
 
   get urlToDownloadSessionIssueReportSheet() {
-    return this.intl.t('common.urls.session-issue-report-sheet');
+    if (this.locale.currentLanguage === 'fr') {
+      return 'https://cloud.pix.fr/s/B76yA8ip9Radej9/download';
+    }
+    return 'https://cloud.pix.fr/s/B6egBZnbjJFSiaN';
   }
 
   get urlToDownloadSessionV3IssueReportSheet() {
-    return this.intl.t('common.urls.session-v3-issue-report-sheet');
+    if (this.locale.currentLanguage === 'fr') {
+      return 'https://cloud.pix.fr/s/ff8sYPWPyCo3MrN/download';
+    }
+    return 'https://cloud.pix.fr/s/B6egBZnbjJFSiaN';
   }
 
   get fraudFormUrl() {
@@ -55,7 +64,10 @@ export default class Url extends UrlBaseService {
   }
 
   get fraudReportUrl() {
-    return this.intl.t('common.urls.fraud');
+    if (this.locale.currentLanguage === 'fr') {
+      return 'https://cloud.pix.fr/s/AgDytb8yHxrmjFk/download';
+    }
+    return 'https://cloud.pix.fr/s/zka5JJqpbgWZLPr';
   }
 
   get invigilatorDocumentationUrl() {

--- a/certif/tests/integration/components/layout/sidebar_test.gjs
+++ b/certif/tests/integration/components/layout/sidebar_test.gjs
@@ -245,7 +245,7 @@ module('Integration | Component | Layout | Sidebar', function (hooks) {
         // then
         assert
           .dom(screen.getByRole('link', { name: t('navigation.sidebar.documentation') }))
-          .hasAttribute('href', t('common.urls.documentation.sco-managing-students'));
+          .hasAttribute('href', 'https://cloud.pix.fr/s/opiFxfjygR76S8y');
       });
     });
 
@@ -277,7 +277,7 @@ module('Integration | Component | Layout | Sidebar', function (hooks) {
         // then
         assert
           .dom(screen.getByRole('link', { name: t('navigation.sidebar.documentation') }))
-          .hasAttribute('href', t('common.urls.documentation.other'));
+          .hasAttribute('href', 'https://cloud.pix.fr/s/ypq3K7GmgpEdwop');
       });
     });
   });

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -186,15 +186,6 @@
       },
       "candidates": "Candidates",
       "invigilator": "Invigilator"
-    },
-    "urls": {
-      "documentation": {
-        "other": "https://cloud.pix.fr/s/c6SmQ8iM6nGbrzw",
-        "sco-managing-students": "https://cloud.pix.fr/s/c6SmQ8iM6nGbrzw"
-      },
-      "fraud": "https://cloud.pix.fr/s/zka5JJqpbgWZLPr",
-      "session-issue-report-sheet": "https://cloud.pix.fr/s/B6egBZnbjJFSiaN",
-      "session-v3-issue-report-sheet": "https://cloud.pix.fr/s/B6egBZnbjJFSiaN"
     }
   },
   "components": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -186,15 +186,6 @@
       },
       "candidates": "Candidats",
       "invigilator": "Surveillant"
-    },
-    "urls": {
-      "documentation": {
-        "other": "https://cloud.pix.fr/s/ypq3K7GmgpEdwop",
-        "sco-managing-students": "https://cloud.pix.fr/s/opiFxfjygR76S8y"
-      },
-      "fraud": "https://cloud.pix.fr/s/AgDytb8yHxrmjFk/download",
-      "session-issue-report-sheet": "https://cloud.pix.fr/s/B76yA8ip9Radej9/download",
-      "session-v3-issue-report-sheet": "https://cloud.pix.fr/s/ff8sYPWPyCo3MrN/download"
     }
   },
   "components": {


### PR DESCRIPTION
## 🥀 Problème

On ne souhaite pas gérer les URLs dans les fichiers de traduction. 

(Voir les [explications complémentaires](https://1024pix.atlassian.net/wiki/spaces/DA/pages/5862719492/Comment+bien+g+rer+les+URL+des+liens+avec+un+urlService)).

## 🏹 Proposition

Ne plus avoir d’URLs dans les fichiers de traduction.
Les centraliser dans le service URL dédié.

## ❤️‍🔥 Pour tester

Tests verts ✅ 
