### PR TITLE
[BUGFIX] Corriger la fermeture impossible de la modale de rest de password en masse (PIX-21486).

### DIFF
--- a/orga/app/components/sco-organization-participant/list.gjs
+++ b/orga/app/components/sco-organization-participant/list.gjs
@@ -262,7 +262,7 @@ export default class ScoList extends Component {
             @totalAffectedStudents={{this.affectedStudents.length}}
             @onTriggerAction={{fn this.generateUsernamePasswordForStudents this.affectedStudents reset}}
             @showResetPasswordModal={{this.showResetPasswordModal}}
-            @onCloseResetPassworModal={{this.closeResetPasswordModal}}
+            @onCloseResetPasswordModal={{this.closeResetPasswordModal}}
             @showGeneratePasswordModal={{this.showGenerateUsernamePasswordModal}}
             @onCloseGeneratePasswordModal={{this.closeGenerateUsernamePasswordModal}}
           />

--- a/orga/tests/integration/components/sco-organization-participant/reset-password-modal-test.gjs
+++ b/orga/tests/integration/components/sco-organization-participant/reset-password-modal-test.gjs
@@ -1,0 +1,71 @@
+import { clickByName, render } from '@1024pix/ember-testing-library';
+import { t } from 'ember-intl/test-support';
+import ResetPasswordModal from 'pix-orga/components/sco-organization-participant/reset-password-modal';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | ScoOrganizationParticipant::ResetPasswordModal', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('renders the modal', async function (assert) {
+    // given
+    const onCloseModal = sinon.spy();
+    const onTriggerAction = sinon.spy();
+    const totalAffectedStudents = 3;
+    const totalSelectedStudents = 3;
+
+    const screen = await render(
+      <template>
+        <ResetPasswordModal
+          @showModal={{true}}
+          @totalSelectedStudents={{totalSelectedStudents}}
+          @totalAffectedStudents={{totalAffectedStudents}}
+          @onTriggerAction={{onTriggerAction}}
+          @onCloseModal={{onCloseModal}}
+        />
+      </template>,
+    );
+
+    assert
+      .dom(
+        screen.getByRole('heading', {
+          name: 'Réinitialisation des mots de passe des élèves avec identifiant',
+        }),
+      )
+      .exists();
+
+    // when
+    await clickByName(t('common.actions.confirm'));
+
+    // then
+    assert.ok(onTriggerAction.calledOnce);
+  });
+
+  test('closes the modal', async function (assert) {
+    // given
+    const onCloseModal = sinon.spy();
+    const onTriggerAction = sinon.spy();
+    const totalAffectedStudents = 3;
+    const totalSelectedStudents = 3;
+
+    await render(
+      <template>
+        <ResetPasswordModal
+          @showModal={{true}}
+          @totalSelectedStudents={{totalSelectedStudents}}
+          @totalAffectedStudents={{totalAffectedStudents}}
+          @onTriggerAction={{onTriggerAction}}
+          @onCloseModal={{onCloseModal}}
+        />
+      </template>,
+    );
+
+    // when
+    await clickByName(t('common.actions.cancel'));
+
+    // then
+    assert.ok(onCloseModal.calledOnce);
+  });
+});


### PR DESCRIPTION
## 🥀 Problème
Sur Pix Orga, quand un enseignant veut mettre à jour les mots de passe de plusieurs de ses élèves, une modale de confirmation s’affiche, mais l’enseignant ne peut que confirmer la mise à jour (le bouton “annuler” et l’icône de fermeture (X ) ne fonctionnent pas.

## 🏹 Proposition
Permettre la fermeture de la modale via le bouton annuler et le bouton de fermeture de la modale.

## ❤️‍🔥 Pour tester
- Se connecter avec le compte orgacces@example.net
- Aller sur l'onglet Eleves
- Sélectionner plusieurs élèves puis appuyer sur le bouton de réinitialisation de mot de passe.
- Constater qu'on peut fermer la modale via les boutons Fermer et Annuler.
