### PR TITLE
[BUGFIX] Ajouter --env-file-if-exists=.env manquant pour exécution locale du script npm start:job

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -66,7 +66,7 @@
     "start": "node --env-file-if-exists=.env index.js",
     "start:maddo": "MADDO=true node --env-file-if-exists=.env index.maddo.js",
     "start:watch": "npm run dev",
-    "start:job": "node worker.js",
+    "start:job": "node --env-file-if-exists=.env worker.js",
     "start:job:fast": "node --env-file-if-exists=.env worker.js fast",
     "start:job:watch": "nodemon --env-file-if-exists=.env worker.js",
     "start:job:fast:watch": "nodemon --env-file-if-exists=.env worker.js fast",


### PR DESCRIPTION
## 🥀 Problème

En local, quand on exécute la commande `npm run start:job` les variables d’environnement du fichier `.env` ne sont pas prises en compte. On peut s’en rendre compte facilement car : 
* la commande `npm run start:job` ne produit aucun log dans le terminal dans laquelle elle a été lancée
* la var d’env `PIX_AUDIT_LOGGER_BASE_URL` n’étant pas définie les envois vers l’AuditLogger sont tous en échec

Peu de dev ont dû remarquer ce problème car la commande `npm run start:job` est surtout exécutée en production, d’autres alternatives plus pratiques à utiliser en local pour les développeurs étant disponibles. Néanmoins cet état de fait est perturbant et donc autant y remédier.

## 🏹 Proposition

Ajouter l’option `--env-file-if-exists=.env` à la commande `node worker.js` exécutée par le script `npm start:job`.

## 💌 Remarques

RAS

## ❤️‍🔥 Pour tester

Dans Pix API, exécuter la commande `npm run start:job` et vérifier que des logs s’affichent maintenant bien dans la console.
