### PR TITLE
[TECH] Créer une table de faits fct_structures (PIX-21293)

### DIFF
--- a/api/db/migrations/20260303135206_create-structures-fact-table.js
+++ b/api/db/migrations/20260303135206_create-structures-fact-table.js
@@ -1,0 +1,32 @@
+const TABLE_NAME = 'fct_structures';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.createTable(TABLE_NAME, function (table) {
+    table.comment('This fact table contains the links between structures, networks and organizations.');
+    table.integer('structure_id').notNullable().comment('References the ID of the structure.');
+    table.integer('network_id').nullable().comment('References the ID of the network if any.');
+    table.integer('parent_structure_id').nullable().comment('References the ID of the parent structure if any.');
+    table.integer('child_structure_id').nullable().comment('References the ID of the child structure if any.');
+    table.integer('organization_id').nullable().comment('References the ID of the organization if any.');
+
+    table.foreign('structure_id').references('structures.id');
+    table.foreign('network_id').references('networks.id');
+    table.foreign('parent_structure_id').references('structures.id');
+    table.foreign('child_structure_id').references('structures.id');
+    table.foreign('organization_id').references('organizations.id');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.dropTable(TABLE_NAME);
+};
+
+export { down, up };


### PR DESCRIPTION
## 🥀 Problème
Cette PR s'inscrit dans le cadre de la mise en place d'un système de réseaux d'organisation. 
Maintenant que les tables `networks` (https://github.com/1024pix/pix/pull/15327) et `structures` (https://github.com/1024pix/pix/pull/15332) sont créées, il faut définir les relations entre elles et entre les organisations.

## 🏹 Proposition

Plutôt que de rajouter des clés étrangères dans les tables concernées, on propose de créer une table de faits qui référencera nos différentes tables de dimensions (https://waytolearnx.com/2018/08/difference-entre-table-des-faits-et-table-de-dimension.html). Cette table va nous permettre pour chaque structure de définir:
- le réseau auquel elle appartient
- sa place dans la hiérarchie (parent et enfants)
- son organisation rattachée

## 💌 Remarques

Cette table est dépendante des tables `network` et `structures`

## ❤️‍🔥 Pour tester
Éxectuer la migration et la rollback sans encombre.
