### PR TITLE
[TECH] Vérifier l'unicité des shortIds lors des tests des modules (PIX21816)

### DIFF
--- a/api/tests/devcomp/integration/repositories/module-repository_test.js
+++ b/api/tests/devcomp/integration/repositories/module-repository_test.js
@@ -288,12 +288,21 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
         it('should result an empty array of duplicated IDs ', async function () {
           const modules = await moduleDatasource.list();
           const ids = [];
+          const shortIds = [];
+
           const duplicateIds = new Set();
+          const duplicateShortIds = new Set();
+
           for (const module of modules) {
             if (ids.includes(module.id)) {
               duplicateIds.add(module.id);
             }
             ids.push(module.id);
+
+            if (shortIds.includes(module.shortId)) {
+              duplicateShortIds.add(module.shortId);
+            }
+            shortIds.push(module.shortId);
 
             for (const section of module.sections) {
               if (ids.includes(section.id)) {
@@ -348,6 +357,7 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
           }
 
           expect([...duplicateIds]).to.deep.equal([]);
+          expect([...duplicateShortIds]).to.deep.equal([]);
         });
       });
     });


### PR DESCRIPTION
## 🥀 Problème
Actuellement, lors d’une contribution métier modulix, aucune validation n’est effectuée sur l’unicité des shortIds.

## 🏹 Proposition
L'ajouter

## 💌 Remarques
Même si les champs de shortIds ne sont pas éditables, cela permet de se prémunir d'une mauvaise manipulation, ou d'un mauvais copier/coller.

## ❤️‍🔥 Pour tester
- récupérer la branche en local
- copier/coller un `shortId` d'un module dans un autre pour créer un doublon
- lancer le test `api/tests/devcomp/integration/repositories/module-repository_test.js`
- vérifier que le test ne passe pas, et remonte le shortId dans le message d'erreur