### PR TITLE
[TECH] Déplacer la logique de target-profiles-section dans sa route (PIX-16662)

### DIFF
--- a/admin/app/components/organizations/target-profiles-section.gjs
+++ b/admin/app/components/organizations/target-profiles-section.gjs
@@ -19,10 +19,8 @@ export default class OrganizationTargetProfilesSectionComponent extends Componen
   @tracked targetProfileToDetach;
 
   @service accessControl;
-  @service pixToast;
-  @service router;
-  @service store;
   @service intl;
+  @service pixToast;
 
   get isDisabled() {
     return this.targetProfilesToAttach === '';
@@ -40,64 +38,18 @@ export default class OrganizationTargetProfilesSectionComponent extends Componen
   @action
   async attachTargetProfiles(e) {
     e.preventDefault();
-    if (this.isDisabled) return;
-
-    const organization = this.args.organization;
-    const targetProfileSummaries = this.args.targetProfileSummaries;
-
-    try {
-      const targetProfileIdsBefore = targetProfileSummaries.map(({ id }) => id);
-      const targetProfileIdsToAttach = this._getUniqueTargetProfileIds();
-      const adapter = this.store.adapterFor('organization');
-
-      await adapter.attachTargetProfile({
-        organizationId: organization.id,
-        targetProfileIds: targetProfileIdsToAttach,
-      });
-      await targetProfileSummaries.reload();
-      const targetProfileIdsAfter = targetProfileSummaries.map(({ id }) => id);
-      const attachedIds = targetProfileIdsAfter.filter((id) => !targetProfileIdsBefore.includes(id));
-      const duplicatedIds = targetProfileIdsBefore.filter((id) => targetProfileIdsToAttach.includes(id));
-      const hasInserted = attachedIds.length > 0;
-      const hasDuplicated = duplicatedIds.length > 0;
-      const message = [];
-      if (hasInserted) {
-        message.push('Profil(s) cible(s) rattaché(s) avec succès.');
-      }
-      if (hasInserted && hasDuplicated) {
-        message.push('<br/>');
-      }
-      if (hasDuplicated) {
-        message.push(
-          `Le(s) profil(s) cible(s) suivant(s) étai(en)t déjà rattaché(s) à cette organisation : ${duplicatedIds.join(
-            ', ',
-          )}.`,
-        );
-      }
-      this.targetProfilesToAttach = '';
-      return this.pixToast.sendSuccessNotification({ message: message.join('') });
-    } catch (responseError) {
-      this._handleResponseError(responseError);
+    if (this.isDisabled) {
+      return;
     }
+
+    await this.args.onAttachTargetProfiles(this.getUniqueTargetProfileIds());
+    this.targetProfilesToAttach = '';
   }
 
   @action
-  goToTargetProfilePage(targetProfileId) {
-    this.router.transitionTo('authenticated.target-profiles.target-profile', targetProfileId);
-  }
-
-  @action
-  async detachTargetProfile(targetProfilId) {
-    const adapter = this.store.adapterFor('target-profile');
-
-    try {
-      await adapter.detachOrganizations(targetProfilId, [this.args.organization.id]);
-      this.closeModal();
-      await this.args.organization.get('targetProfileSummaries').reload();
-      return this.pixToast.sendSuccessNotification({ message: 'Profil cible détaché avec succès.' });
-    } catch (responseError) {
-      this._handleResponseError(responseError);
-    }
+  async detachTargetProfile(targetProfileId) {
+    await this.args.onDetachTargetProfile(targetProfileId);
+    this.closeModal();
   }
 
   @action
@@ -112,21 +64,7 @@ export default class OrganizationTargetProfilesSectionComponent extends Componen
     this.targetProfileToDetach = null;
   }
 
-  _handleResponseError({ errors }) {
-    const genericErrorMessage = this.intl.t('common.notifications.generic-error');
-
-    if (!errors) {
-      return this.pixToast.sendErrorNotification({ message: genericErrorMessage });
-    }
-    errors.forEach((error) => {
-      if (['404', '412'].includes(error.status)) {
-        return this.pixToast.sendErrorNotification({ message: error.detail });
-      }
-      return this.pixToast.sendErrorNotification({ message: genericErrorMessage });
-    });
-  }
-
-  _getUniqueTargetProfileIds() {
+  getUniqueTargetProfileIds() {
     const targetProfileIds = this.targetProfilesToAttach.split(',').map((targetProfileId) => targetProfileId.trim());
     return uniq(targetProfileIds);
   }

--- a/admin/app/routes/authenticated/organizations/get/target-profiles.js
+++ b/admin/app/routes/authenticated/organizations/get/target-profiles.js
@@ -1,12 +1,80 @@
 import Route from '@ember/routing/route';
-import RSVP from 'rsvp';
+import { service } from '@ember/service';
 
 export default class OrganizationTargetProfilesRoute extends Route {
+  @service intl;
+  @service pixToast;
+  @service store;
+
   async model() {
     const organization = this.modelFor('authenticated.organizations.get');
-    return RSVP.hash({
-      organization: organization,
-      targetProfileSummaries: organization.targetProfileSummaries,
+    const targetProfileSummaries = await organization.hasMany('targetProfileSummaries').reload();
+
+    return {
+      organization,
+      targetProfileSummaries,
+      onAttachTargetProfiles: this.attachTargetProfiles.bind(this),
+      onDetachTargetProfile: this.detachTargetProfile.bind(this),
+    };
+  }
+
+  async attachTargetProfiles(targetProfileIds) {
+    const { organization, targetProfileSummaries } = this.currentModel;
+    const currentIds = targetProfileSummaries.map(({ id }) => id);
+    const attachedIds = targetProfileIds.filter((id) => !currentIds.includes(id));
+    const duplicatedIds = currentIds.filter((id) => targetProfileIds.includes(id));
+    const hasInserted = attachedIds.length > 0;
+
+    try {
+      const adapter = this.store.adapterFor('organization');
+      await adapter.attachTargetProfile({ organizationId: organization.id, targetProfileIds });
+
+      if (hasInserted) {
+        const successMessage =
+          attachedIds.length === 1
+            ? `Le profil cible ${attachedIds[0]} a été rattaché avec succès.`
+            : `Les profils cibles suivants ont été rattachés avec succès : ${attachedIds.join(', ')}.`;
+        this.pixToast.sendSuccessNotification({ message: successMessage });
+      }
+      if (duplicatedIds.length > 0) {
+        const warningMessage =
+          duplicatedIds.length === 1
+            ? `Le profil cible ${duplicatedIds[0]} est déjà rattaché à cette organisation.`
+            : `Les profils cibles suivants sont déjà rattachés à cette organisation : ${duplicatedIds.join(', ')}.`;
+        this.pixToast.sendWarningNotification({ message: warningMessage });
+      }
+      this.refresh();
+    } catch (responseError) {
+      this.handleResponseError(responseError);
+    }
+  }
+
+  async detachTargetProfile(targetProfileId) {
+    const { organization } = this.currentModel;
+
+    try {
+      const adapter = this.store.adapterFor('target-profile');
+      await adapter.detachOrganizations(targetProfileId, [organization.id]);
+      this.pixToast.sendSuccessNotification({ message: `Profil cible ${targetProfileId} détaché avec succès.` });
+      this.refresh();
+    } catch (responseError) {
+      this.handleResponseError(responseError);
+    }
+  }
+
+  handleResponseError({ errors }) {
+    const genericErrorMessage = this.intl.t('common.notifications.generic-error');
+
+    if (!errors) {
+      this.pixToast.sendErrorNotification({ message: genericErrorMessage });
+      return;
+    }
+    errors.forEach((error) => {
+      if (['404', '412'].includes(error.status)) {
+        this.pixToast.sendErrorNotification({ message: error.detail });
+      } else {
+        this.pixToast.sendErrorNotification({ message: genericErrorMessage });
+      }
     });
   }
 }

--- a/admin/app/templates/authenticated/organizations/get/target-profiles.gjs
+++ b/admin/app/templates/authenticated/organizations/get/target-profiles.gjs
@@ -5,5 +5,7 @@ import TargetProfilesSection from 'pix-admin/components/organizations/target-pro
   <TargetProfilesSection
     @organization={{@model.organization}}
     @targetProfileSummaries={{@model.targetProfileSummaries}}
+    @onAttachTargetProfiles={{@model.onAttachTargetProfiles}}
+    @onDetachTargetProfile={{@model.onDetachTargetProfile}}
   />
 </template>

--- a/admin/tests/integration/components/organizations/target-profiles-section-test.gjs
+++ b/admin/tests/integration/components/organizations/target-profiles-section-test.gjs
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+import { waitForDialogClose } from '../../../helpers/wait-for';
 
 module('Integration | Component | organizations/target-profiles-section', function (hooks) {
   setupIntlRenderingTest(hooks);
@@ -36,14 +37,9 @@ module('Integration | Component | organizations/target-profiles-section', functi
       assert.dom(screen.getByRole('button', { name: 'Valider' })).hasAttribute('aria-disabled');
     });
 
-    test('it calls the organization action when the input is not empty and user clicks on button', async function (assert) {
+    test('it calls onAttachTargetProfiles with parsed IDs when input is not empty and user clicks on button', async function (assert) {
       // given
-      class NotificationsStub extends Service {
-        sendSuccessNotification = sinon.stub();
-      }
-      const adapter = store.adapterFor('organization');
-      const attachTargetProfileStub = sinon.stub(adapter, 'attachTargetProfile').resolves();
-      this.owner.register('service:pixToast', NotificationsStub);
+      const onAttachTargetProfiles = sinon.stub().resolves();
       const targetProfileSummary = store.createRecord('target-profile-summary', {
         id: '666',
         internalName: 'Number of The Beast',
@@ -52,21 +48,23 @@ module('Integration | Component | organizations/target-profiles-section', functi
         id: '1',
         targetProfiles: [],
       });
-
       const targetProfileSummaries = [targetProfileSummary];
-      targetProfileSummaries.reload = sinon.stub();
 
       // when
       await render(
         <template>
-          <TargetProfilesSection @organization={{organization}} @targetProfileSummaries={{targetProfileSummaries}} />
+          <TargetProfilesSection
+            @organization={{organization}}
+            @targetProfileSummaries={{targetProfileSummaries}}
+            @onAttachTargetProfiles={{onAttachTargetProfiles}}
+          />
         </template>,
       );
-      await fillByLabel('ID du ou des profil(s) cible(s)', '1');
+      await fillByLabel('ID du ou des profil(s) cible(s)', '1, 12,   1000 ');
       await clickByName('Valider');
 
       // then
-      assert.ok(attachTargetProfileStub.calledWith({ organizationId: '1', targetProfileIds: ['1'] }));
+      assert.ok(onAttachTargetProfiles.calledWith(['1', '12', '1000']));
     });
 
     test('it should have a link to redirect on target profile page', async function (assert) {
@@ -145,14 +143,9 @@ module('Integration | Component | organizations/target-profiles-section', functi
         assert.ok(screen.getByRole('heading', { name: "Détacher le profil cible de l'organisation" }));
       });
 
-      test('it should detach a target profile when click on "Confirmer" button', async function (assert) {
+      test('it should call onDetachTargetProfile with the target profile id when click on "Confirmer" button', async function (assert) {
         // given
-
-        const notificationService = this.owner.lookup('service:pixToast');
-        sinon.stub(notificationService, 'sendSuccessNotification');
-
-        const adapter = store.adapterFor('target-profile');
-        const detachOrganizationsTargetProfileStub = sinon.stub(adapter, 'detachOrganizations').resolves();
+        const onDetachTargetProfile = sinon.stub().resolves();
         const targetProfileSummary = store.createRecord('target-profile-summary', {
           id: '666',
           internalName: 'Number of The Beast',
@@ -160,57 +153,59 @@ module('Integration | Component | organizations/target-profiles-section', functi
         const organization = store.createRecord('organization', {
           id: '1',
           targetProfiles: [],
-          get: sinon.stub().returns({ reload: sinon.stub() }),
         });
         const targetProfileSummaries = [targetProfileSummary];
 
         //when
         const screen = await render(
           <template>
-            <TargetProfilesSection @organization={{organization}} @targetProfileSummaries={{targetProfileSummaries}} />
+            <TargetProfilesSection
+              @organization={{organization}}
+              @targetProfileSummaries={{targetProfileSummaries}}
+              @onDetachTargetProfile={{onDetachTargetProfile}}
+            />
           </template>,
         );
         const detachButton = screen.getByRole('button', { name: 'Détacher' });
         await click(detachButton);
         const confirmButton = await screen.findByRole('button', { name: 'Confirmer' });
         await click(confirmButton);
+
         // then
-        assert.true(detachOrganizationsTargetProfileStub.calledOnceWith(targetProfileSummary.id));
+        assert.true(onDetachTargetProfile.calledOnceWith(targetProfileSummary.id));
       });
 
-      test('it should show a notification on success', async function (assert) {
+      test('it should close the modal after successful detach', async function (assert) {
         // given
-        const notificationService = this.owner.lookup('service:pixToast');
-        const notificationSuccessStub = sinon.stub(notificationService, 'sendSuccessNotification');
-
-        const adapter = store.adapterFor('target-profile');
-        sinon.stub(adapter, 'detachOrganizations').resolves();
-
+        const onDetachTargetProfile = sinon.stub().resolves();
+        const targetProfileSummary = store.createRecord('target-profile-summary', {
+          id: '666',
+          internalName: 'Number of The Beast',
+        });
         const organization = store.createRecord('organization', {
           id: '1',
           targetProfiles: [],
         });
-        const targetProfileSummaries = [
-          store.createRecord('target-profile-summary', {
-            id: '666',
-            internalName: 'Number of The Beast',
-          }),
-        ];
-        targetProfileSummaries.reload = sinon.stub();
+        const targetProfileSummaries = [targetProfileSummary];
 
         // when
         const screen = await render(
           <template>
-            <TargetProfilesSection @organization={{organization}} @targetProfileSummaries={{targetProfileSummaries}} />
+            <TargetProfilesSection
+              @organization={{organization}}
+              @targetProfileSummaries={{targetProfileSummaries}}
+              @onDetachTargetProfile={{onDetachTargetProfile}}
+            />
           </template>,
         );
         const detachButton = screen.getByRole('button', { name: 'Détacher' });
         await click(detachButton);
         const confirmButton = await screen.findByRole('button', { name: 'Confirmer' });
         await click(confirmButton);
+        await waitForDialogClose();
 
         // then
-        assert.ok(notificationSuccessStub.calledOnceWithExactly({ message: 'Profil cible détaché avec succès.' }));
+        assert.dom(screen.queryByRole('dialog')).doesNotExist();
       });
     });
   });

--- a/admin/tests/unit/routes/authenticated/organizations/get/target-profiles-test.js
+++ b/admin/tests/unit/routes/authenticated/organizations/get/target-profiles-test.js
@@ -1,0 +1,233 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module('Unit | Route | authenticated/organizations/get/target-profiles', function (hooks) {
+  setupTest(hooks);
+
+  let route;
+
+  hooks.beforeEach(function () {
+    route = this.owner.lookup('route:authenticated/organizations/get/target-profiles');
+
+    route.pixToast = {
+      sendSuccessNotification: sinon.stub(),
+      sendWarningNotification: sinon.stub(),
+      sendErrorNotification: sinon.stub(),
+    };
+    route.intl = { t: sinon.stub().returns('Une erreur est survenue.') };
+  });
+
+  module('#attachTargetProfiles', function () {
+    test('it attaches target profiles and refreshes the model', async function (assert) {
+      // given
+      const adapter = this.owner.lookup('service:store').adapterFor('organization');
+      const attachTargetProfileStub = sinon.stub(adapter, 'attachTargetProfile').resolves();
+      const refreshStub = sinon.stub(route, 'refresh');
+
+      route.currentModel = {
+        organization: { id: '1' },
+        targetProfileSummaries: [],
+      };
+
+      // when
+      await route.attachTargetProfiles(['42']);
+
+      // then
+      assert.ok(attachTargetProfileStub.calledWith({ organizationId: '1', targetProfileIds: ['42'] }));
+      assert.ok(refreshStub.calledOnce);
+    });
+
+    test('it shows a singular success notification when one profile is new', async function (assert) {
+      // given
+      const adapter = this.owner.lookup('service:store').adapterFor('organization');
+      sinon.stub(adapter, 'attachTargetProfile').resolves();
+      sinon.stub(route, 'refresh');
+
+      route.currentModel = {
+        organization: { id: '1' },
+        targetProfileSummaries: [],
+      };
+
+      // when
+      await route.attachTargetProfiles(['42']);
+
+      // then
+      assert.ok(
+        route.pixToast.sendSuccessNotification.calledWith({
+          message: 'Le profil cible 42 a été rattaché avec succès.',
+        }),
+      );
+    });
+
+    test('it shows a plural success notification when multiple profiles are new', async function (assert) {
+      // given
+      const adapter = this.owner.lookup('service:store').adapterFor('organization');
+      sinon.stub(adapter, 'attachTargetProfile').resolves();
+      sinon.stub(route, 'refresh');
+
+      route.currentModel = {
+        organization: { id: '1' },
+        targetProfileSummaries: [],
+      };
+
+      // when
+      await route.attachTargetProfiles(['42', '43']);
+
+      // then
+      assert.ok(
+        route.pixToast.sendSuccessNotification.calledWith({
+          message: 'Les profils cibles suivants ont été rattachés avec succès : 42, 43.',
+        }),
+      );
+    });
+
+    test('it shows a singular warning notification when one profile is already attached', async function (assert) {
+      // given
+      const adapter = this.owner.lookup('service:store').adapterFor('organization');
+      sinon.stub(adapter, 'attachTargetProfile').resolves();
+      sinon.stub(route, 'refresh');
+
+      route.currentModel = {
+        organization: { id: '1' },
+        targetProfileSummaries: [{ id: '42' }],
+      };
+
+      // when
+      await route.attachTargetProfiles(['42']);
+
+      // then
+      assert.ok(
+        route.pixToast.sendWarningNotification.calledWith({
+          message: 'Le profil cible 42 est déjà rattaché à cette organisation.',
+        }),
+      );
+    });
+
+    test('it shows a plural warning notification when multiple profiles are already attached', async function (assert) {
+      // given
+      const adapter = this.owner.lookup('service:store').adapterFor('organization');
+      sinon.stub(adapter, 'attachTargetProfile').resolves();
+      sinon.stub(route, 'refresh');
+
+      route.currentModel = {
+        organization: { id: '1' },
+        targetProfileSummaries: [{ id: '42' }, { id: '43' }],
+      };
+
+      // when
+      await route.attachTargetProfiles(['42', '43']);
+
+      // then
+      assert.ok(
+        route.pixToast.sendWarningNotification.calledWith({
+          message: 'Les profils cibles suivants sont déjà rattachés à cette organisation : 42, 43.',
+        }),
+      );
+    });
+
+    test('it shows both success and warning notifications when some profiles are new and some are duplicates', async function (assert) {
+      // given
+      const adapter = this.owner.lookup('service:store').adapterFor('organization');
+      sinon.stub(adapter, 'attachTargetProfile').resolves();
+      sinon.stub(route, 'refresh');
+
+      route.currentModel = {
+        organization: { id: '1' },
+        targetProfileSummaries: [{ id: '10' }],
+      };
+
+      // when
+      await route.attachTargetProfiles(['10', '42']);
+
+      // then
+      assert.ok(
+        route.pixToast.sendSuccessNotification.calledWith({
+          message: 'Le profil cible 42 a été rattaché avec succès.',
+        }),
+      );
+      assert.ok(
+        route.pixToast.sendWarningNotification.calledWith({
+          message: 'Le profil cible 10 est déjà rattaché à cette organisation.',
+        }),
+      );
+    });
+
+    test('it shows an error notification when the request fails', async function (assert) {
+      // given
+      const adapter = this.owner.lookup('service:store').adapterFor('organization');
+      sinon
+        .stub(adapter, 'attachTargetProfile')
+        .callsFake(() => Promise.reject({ errors: [{ status: '404', detail: 'Not found' }] }));
+      sinon.stub(route, 'refresh');
+
+      route.currentModel = {
+        organization: { id: '1' },
+        targetProfileSummaries: [],
+      };
+
+      await route.attachTargetProfiles(['99']);
+
+      // then
+      assert.ok(route.pixToast.sendErrorNotification.calledOnce);
+      assert.ok(route.refresh.notCalled);
+    });
+  });
+
+  module('#detachTargetProfile', function () {
+    test('it detaches a target profile and refreshes the model', async function (assert) {
+      // given
+      const adapter = this.owner.lookup('service:store').adapterFor('target-profile');
+      const detachOrganizationsStub = sinon.stub(adapter, 'detachOrganizations').resolves();
+      sinon.stub(route, 'refresh');
+
+      route.currentModel = {
+        organization: { id: '1' },
+      };
+
+      // when
+      await route.detachTargetProfile('42');
+
+      // then
+      assert.ok(detachOrganizationsStub.calledWith('42', ['1']));
+      assert.ok(route.refresh.calledOnce);
+    });
+
+    test('it shows a success notification with the target profile id', async function (assert) {
+      // given
+      const adapter = this.owner.lookup('service:store').adapterFor('target-profile');
+      sinon.stub(adapter, 'detachOrganizations').resolves();
+      sinon.stub(route, 'refresh');
+
+      route.currentModel = {
+        organization: { id: '1' },
+      };
+
+      // when
+      await route.detachTargetProfile('42');
+
+      // then
+      assert.ok(route.pixToast.sendSuccessNotification.calledWith({ message: 'Profil cible 42 détaché avec succès.' }));
+    });
+
+    test('it shows an error notification when the request fails', async function (assert) {
+      // given
+      const adapter = this.owner.lookup('service:store').adapterFor('target-profile');
+      sinon
+        .stub(adapter, 'detachOrganizations')
+        .callsFake(() => Promise.reject({ errors: [{ status: '412', detail: 'Conflict' }] }));
+      sinon.stub(route, 'refresh');
+
+      route.currentModel = {
+        organization: { id: '1' },
+      };
+
+      // when
+      await route.detachTargetProfile('42');
+
+      // then
+      assert.ok(route.pixToast.sendErrorNotification.calledWith({ message: 'Conflict' }));
+      assert.ok(route.refresh.notCalled);
+    });
+  });
+});


### PR DESCRIPTION
## 🥀 Problème

Le composant `organizations/target-profiles-section` portait lui-même les appels API (attach/detach de profils cibles) et rafraîchissait les données via `.reload()` sur les collections Ember Data. Cette logique métier n'a pas sa place dans un composant.

## 🏹 Proposition

- Déplacement des appels adapter et de la logique de notification dans la route `authenticated/organizations/get/target-profiles`
- Utilisation de `this.refresh()` (via `organization.hasMany('targetProfileSummaries').reload()` dans le hook `model()`) pour rafraîchir les données après chaque opération
- Les actions de la route sont exposées au composant via le modèle (`onAttachTargetProfiles`, `onDetachTargetProfile`)
- Le composant ne conserve que l'état UI (valeur de l'input, état de la modale)
- Suppression du code mort (`goToTargetProfilePage`, `@service router`)
- Amélioration des messages de notification : singulier/pluriel, et avertissement distinct pour les doublons (`sendWarningNotification`)

## 💌 Remarques

Le `<br/>` présent dans l'ancien message de notification ne fonctionnait pas — remplacé par deux notifications séparées.

## ❤️‍🔥 Pour tester

Depuis une organisation sur PixAdmin:

- [x] Rattacher un profil cible à une organisation -> notification de succès, liste rafraîchie
- [x] Rattacher un profil déjà rattaché -> notification d'avertissement
- [x] Rattacher un mix de nouveaux et doublons -> les deux notifications
- [x] Détacher un profil cible -> confirmation modale, notification de succès avec l'ID, liste rafraîchie
- [x] Attacher un profil cible inexistant -> notification d'erreur
- [x] Rouler votre visage sur le clavier pour remplir le champ -> notification d'erreur