### PR TITLE
[FEATURE] Bloquer l'accès à une campagne archivée (PIX-21652)

### DIFF
--- a/api/src/evaluation/domain/usecases/save-and-correct-answer-for-campaign.js
+++ b/api/src/evaluation/domain/usecases/save-and-correct-answer-for-campaign.js
@@ -26,7 +26,7 @@ const saveAndCorrectAnswerForCampaign = async function ({
     if (assessment.userId !== userId) {
       throw new ForbiddenAccess('User is not allowed to add an answer for this assessment.');
     }
-    if (!assessment.campaignParticipationId) {
+    if (!assessment.isCampaignParticipationAvailable() || !assessment?.campaign.isAccessible) {
       throw new ForbiddenAccess('Campaign does not accept any answer.');
     }
     if (assessment.answers.some((existingAnswer) => existingAnswer.challengeId === answer.challengeId)) {

--- a/api/tests/evaluation/integration/domain/usecases/save-and-correct-answer-for-campaign_test.js
+++ b/api/tests/evaluation/integration/domain/usecases/save-and-correct-answer-for-campaign_test.js
@@ -20,12 +20,9 @@ describe('Evaluation | Integration | Usecase | Save and correct answer for campa
       const userId = databaseBuilder.factory.buildUser().id;
       const assessmentDB = databaseBuilder.factory.buildAssessment({
         userId,
+        // campaignParticipationId are nullify when campaign is deleted
         campaignParticipationId: null,
         type: Assessment.types.CAMPAIGN,
-      });
-      databaseBuilder.factory.buildCompetenceEvaluation({
-        userId,
-        status: CompetenceEvaluation.statuses.STARTED,
       });
       databaseBuilder.factory.learningContent.buildArea({
         id: 'monAreaId',
@@ -92,6 +89,95 @@ describe('Evaluation | Integration | Usecase | Save and correct answer for campa
     });
   });
 
+  context('for archived campaign', function () {
+    it('should throw a ForbiddenAccess', async function () {
+      // given
+      const locale = 'fr';
+      const userId = databaseBuilder.factory.buildUser().id;
+      const learner = databaseBuilder.factory.buildOrganizationLearner({ userId });
+      const campaign = databaseBuilder.factory.buildCampaign({
+        code: 'PILIPILIX',
+        archivedAt: new Date(),
+        organizationId: learner.organizationId,
+      });
+      const participation = databaseBuilder.factory.buildCampaignParticipation({
+        userId: userId,
+        organizationLearnerId: learner.id,
+        campaignId: campaign.id,
+      });
+      const assessmentDB = databaseBuilder.factory.buildAssessment({
+        userId,
+        campaignParticipationId: participation.id,
+        type: Assessment.types.CAMPAIGN,
+      });
+      databaseBuilder.factory.learningContent.buildArea({
+        id: 'monAreaId',
+      });
+      databaseBuilder.factory.learningContent.buildCompetence({
+        id: 'maCompetenceId',
+        areaId: 'monAreaId',
+        name_i18n: {
+          fr: 'nom de la compétence',
+        },
+      });
+      databaseBuilder.factory.learningContent.buildChallenge({
+        id: 'monEpreuveId',
+        skillId: skillIds[2],
+        competenceId: 'maCompetenceId',
+        locales: [locale],
+        status: 'validé',
+        solution: 'correct',
+        proposals: '${a}',
+        type: 'QROC',
+      });
+      skillIds.map((id, index) =>
+        databaseBuilder.factory.learningContent.buildSkill({
+          id,
+          competenceId: 'maCompetenceId',
+          pixValue: PIX_COUNT_BY_LEVEL,
+          status: 'actif',
+          tubeId: 'monTubeId',
+          level: index + 1,
+        }),
+      );
+      const someAnswerId = databaseBuilder.factory.buildAnswer().id;
+      const someOtherAssessmentId = databaseBuilder.factory.buildAssessment({ userId }).id;
+      databaseBuilder.factory.buildKnowledgeElement({
+        skillId: skillIds[0],
+        earnedPix: PIX_COUNT_BY_LEVEL,
+        userId,
+        assessmentId: someOtherAssessmentId,
+        answerId: someAnswerId,
+        status: KnowledgeElement.StatusType.VALIDATED,
+        source: KnowledgeElement.SourceType.DIRECT,
+        competenceId: 'maCompetenceId',
+        createdAt: new Date('2020-01-01'),
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const assessment = domainBuilder.buildAssessment({
+        ...assessmentDB,
+        campaign: domainBuilder.buildCampaign(campaign),
+      });
+      const answer = new Answer({
+        value: 'correct',
+        challengeId: 'monEpreuveId',
+        assessmentId: assessment.id,
+      });
+      const error = await catchErr(evaluationUsecases.saveAndCorrectAnswerForCampaign)({
+        answer,
+        userId,
+        assessment,
+        locale,
+        forceOKAnswer: false,
+      });
+
+      // then
+      expect(error).to.be.instanceOf(ForbiddenAccess);
+    });
+  });
+
   context('for campaign of type assessment with method smart_random', function () {
     it('should correct answer and save both answer and knowledge-elements', async function () {
       // given
@@ -99,6 +185,7 @@ describe('Evaluation | Integration | Usecase | Save and correct answer for campa
       const userId = databaseBuilder.factory.buildUser().id;
       const campaignId = databaseBuilder.factory.buildCampaign({
         type: CampaignTypes.ASSESSMENT,
+        code: 'PILIPILIX',
       }).id;
       skillIds.map((skillId) =>
         databaseBuilder.factory.buildCampaignSkill({
@@ -149,6 +236,7 @@ describe('Evaluation | Integration | Usecase | Save and correct answer for campa
           level: index + 1,
         }),
       );
+
       const someAnswerId = databaseBuilder.factory.buildAnswer().id;
       const someOtherAssessmentId = databaseBuilder.factory.buildAssessment({ userId }).id;
       databaseBuilder.factory.buildKnowledgeElement({
@@ -171,6 +259,7 @@ describe('Evaluation | Integration | Usecase | Save and correct answer for campa
         challengeId: 'monEpreuveId',
         assessmentId: assessment.id,
       });
+
       const savedAnswer = await evaluationUsecases.saveAndCorrectAnswerForCampaign({
         answer,
         userId,

--- a/api/tests/evaluation/unit/domain/usecases/save-and-correct-answer-for-campaign_test.js
+++ b/api/tests/evaluation/unit/domain/usecases/save-and-correct-answer-for-campaign_test.js
@@ -16,6 +16,7 @@ describe('Unit | Evaluation | Domain | Use Cases | save-and-correct-answer-for-c
   const userId = 1;
   let assessment;
   let challenge;
+  let campaign;
   let solution;
   let validator;
   let correctAnswerValue;
@@ -45,6 +46,7 @@ describe('Unit | Evaluation | Domain | Use Cases | save-and-correct-answer-for-c
     answerRepository = { save: sinon.stub() };
     challengeRepository = { get: sinon.stub() };
     scorecardService = { computeLevelUpInformation: sinon.stub() };
+    campaign = domainBuilder.buildCampaign({ id: campaignId });
     campaignRepository = {
       findSkillsByCampaignParticipationId: sinon.stub(),
       get: sinon.stub(),
@@ -74,11 +76,12 @@ describe('Unit | Evaluation | Domain | Use Cases | save-and-correct-answer-for-c
       method: Assessment.methods.SMART_RANDOM,
       campaignParticipationId,
       answers: [],
+      campaign,
     });
     campaignRepository.getCampaignIdByCampaignParticipationId
       .withArgs(assessment.campaignParticipationId)
       .resolves(campaignId);
-    campaignRepository.get.withArgs(campaignId).resolves(domainBuilder.buildCampaign({ id: campaignId }));
+    campaignRepository.get.withArgs(campaignId).resolves(campaign);
     answer = domainBuilder.buildAnswer({ assessmentId: assessment.id, value: correctAnswerValue, challengeId });
     answer.id = undefined;
     answer.result = undefined;
@@ -184,6 +187,7 @@ describe('Unit | Evaluation | Domain | Use Cases | save-and-correct-answer-for-c
         lastQuestionDate: new Date('2021-03-11T11:00:00Z'),
         type: Assessment.types.CAMPAIGN,
         answers: [],
+        campaign,
       });
 
       // when
@@ -219,9 +223,10 @@ describe('Unit | Evaluation | Domain | Use Cases | save-and-correct-answer-for-c
       assessment = domainBuilder.buildAssessment({
         userId,
         lastQuestionDate: new Date('2021-03-11T11:00:00Z'),
-        type: Assessment.types.COMPETENCE_EVALUATION,
+        type: Assessment.types.CAMPAIGN,
         campaignParticipationId,
         answers: [],
+        campaign,
       });
       const answerSaved = domainBuilder.buildAnswer(emptyAnswer);
       answerRepository.save.resolves(answerSaved);
@@ -361,6 +366,7 @@ describe('Unit | Evaluation | Domain | Use Cases | save-and-correct-answer-for-c
         method: Assessment.methods.SMART_RANDOM,
         campaignParticipationId,
         answers: [],
+        campaign,
       });
       answerSaved = domainBuilder.buildAnswer(answer);
       answerSaved.timeSpent = 5;

--- a/mon-pix/app/routes/assessments/challenge.js
+++ b/mon-pix/app/routes/assessments/challenge.js
@@ -58,6 +58,14 @@ export default class ChallengeRoute extends Route {
     });
   }
 
+  async afterModel({ assessment }) {
+    const campaign = await assessment.campaign;
+    if (assessment.isForCampaign && !campaign.isAccessible) {
+      this.router.replaceWith('campaigns.archived-error', campaign.code);
+      return;
+    }
+  }
+
   serialize(model) {
     return {
       assessment_id: model.assessment.id,

--- a/mon-pix/app/routes/campaigns/entry-point.js
+++ b/mon-pix/app/routes/campaigns/entry-point.js
@@ -70,7 +70,7 @@ export default class EntryPoint extends Route {
     }
 
     const isAutonomousCourse = campaign.organizationId === ENV.APP.AUTONOMOUS_COURSES_ORGANIZATION_ID;
-    if (!campaign.isAccessible && !hasParticipated) {
+    if (!campaign.isAccessible) {
       this.router.replaceWith('campaigns.archived-error', campaign.code);
     } else if (hasParticipated && !isAutonomousCourse) {
       this.router.replaceWith('campaigns.entrance', campaign.code);

--- a/mon-pix/mirage/routes/assessments/get-assessment.js
+++ b/mon-pix/mirage/routes/assessments/get-assessment.js
@@ -18,6 +18,7 @@ export default function (schema, request) {
       break;
     case 'CAMPAIGN':
       challengeIdStartsWith = 'recSMARPLA';
+      assessment.campaign = schema.campaigns.findBy({ code: assessment.codeCampaign });
       break;
   }
   const answers = schema.answers.where({ assessmentId: assessment.id }).models;

--- a/mon-pix/mirage/serializers/assessment.js
+++ b/mon-pix/mirage/serializers/assessment.js
@@ -1,5 +1,5 @@
 import ApplicationSerializer from './application';
 
 export default ApplicationSerializer.extend({
-  include: ['answers', 'certificationCourse', 'progression', 'nextChallenge'],
+  include: ['answers', 'certificationCourse', 'progression', 'nextChallenge', 'campaign'],
 });

--- a/mon-pix/tests/acceptance/footer-test.js
+++ b/mon-pix/tests/acceptance/footer-test.js
@@ -49,7 +49,6 @@ module('Acceptance | Footer', function (hooks) {
 
     // when
     await resumeCampaignOfTypeAssessmentByCode(campaign.code, false);
-
     // then
     assert.dom('#footer').doesNotExist();
   });

--- a/mon-pix/tests/unit/routes/assessments/challenge-test.js
+++ b/mon-pix/tests/unit/routes/assessments/challenge-test.js
@@ -170,4 +170,13 @@ module('Unit | Route | Assessments | Challenge', function (hooks) {
       });
     });
   });
+
+  module('#afterModel', function () {
+    test('it should redirect user to campaign archived error page', async function (assert) {
+      const code = 'ABCPIX123';
+      const assessment = { isForCampaign: true, campaign: Promise.resolve({ code, isAccessible: false }) };
+      await route.afterModel({ assessment });
+      assert.ok(route.router.replaceWith.calledWith('campaigns.archived-error', code));
+    });
+  });
 });

--- a/mon-pix/tests/unit/routes/campaigns/entry-point-test.js
+++ b/mon-pix/tests/unit/routes/campaigns/entry-point-test.js
@@ -231,7 +231,7 @@ module('Unit | Route | Entry Point', function (hooks) {
           await route.afterModel(campaign, transition);
 
           //then
-          sinon.assert.calledWith(route.router.replaceWith, 'campaigns.entrance');
+          sinon.assert.calledWith(route.router.replaceWith, 'campaigns.archived-error');
           assert.ok(true);
         });
       });


### PR DESCRIPTION

## 🥀 Problème

Si je reprends une campagne archivée en saisissant le code, à la fin comme je ne peux pas partager mes résultats, ça mouline. 

## 🏹 Proposition

Ne pas permettre de reprendre une campagne archivée. 
Elles sont déjà inactives dans PixApp, il faudrait bloquer la reprise via le code ou via URL.

## ❤️‍🔥 Pour tester
- Commencer la campagne PROASSMUL (sauvegarder l'url de la page du dernier challenge)
- Archiver la campagne sur pixOrga
- Tenter d'accéder à la campagne PROASSMUL
- Tenter d'accéder à la page du dernier challenge
- Tenter de faire un POST sur la route /api/answser
