### PR TITLE
[écri+] Ajouter à lcms-client la possibilité de charger des release à partir d'url `file://`

### DIFF
--- a/api/src/shared/infrastructure/lcms-client.js
+++ b/api/src/shared/infrastructure/lcms-client.js
@@ -1,21 +1,41 @@
-import { config } from '../config.js';
-import { httpAgent } from './http-agent.js';
-import { logger } from './utils/logger.js';
+import { readFile } from "fs/promises";
+import { fileURLToPath } from "url";
+import { config } from "../config.js";
+import { httpAgent } from "./http-agent.js";
+import { logger } from "./utils/logger.js";
 
 const { lcms: lcmsConfig } = config;
-const getRelease = async function () {
+
+const getReleaseFile = async function () {
+  const filePath = fileURLToPath(lcmsConfig.url);
+  const raw = await readFile(filePath, "utf-8");
+  const data = JSON.parse(raw);
+
+  const version = data.id;
+  const createdAt = data.createdAt;
+  const message = `Release ${version} created on ${createdAt} successfully received from LCMS file`;
+
+  logger.info(message);
+  return data.content;
+};
+
+const getReleaseHttp = async function () {
   let signature;
 
   if (process.env.APP) {
     signature = `${process.env.APP}-${process.env.CONTAINER}@${process.env.REGION_NAME}`;
   } else {
-    signature = 'pix-api';
+    signature = "pix-api";
   }
 
-  const url = lcmsConfig.url + '/releases/' + (lcmsConfig.releaseId ?? 'latest');
+  const url =
+    lcmsConfig.url + "/releases/" + (lcmsConfig.releaseId ?? "latest");
   const response = await httpAgent.get({
     url,
-    headers: { Authorization: `Bearer ${lcmsConfig.apiKey}`, Referer: signature },
+    headers: {
+      Authorization: `Bearer ${lcmsConfig.apiKey}`,
+      Referer: signature,
+    },
   });
 
   if (!response.isSuccessful) {
@@ -30,15 +50,26 @@ const getRelease = async function () {
   return response.data.content;
 };
 
+const getRelease = async function () {
+  if (lcmsConfig.url.startsWith("file://")) {
+    return getReleaseFile();
+  }
+  return getReleaseHttp();
+};
+
 const createRelease = async function () {
   const response = await httpAgent.post({
-    url: lcmsConfig.url + '/releases',
+    url: lcmsConfig.url + "/releases",
     headers: { Authorization: `Bearer ${lcmsConfig.apiKey}` },
   });
 
   if (!response.isSuccessful) {
-    logger.error(`An error occurred while creating a release on ${lcmsConfig.url}: ${JSON.stringify(response)}`);
-    throw new Error(`An error occurred while creating a release on ${lcmsConfig.url}`);
+    logger.error(
+      `An error occurred while creating a release on ${lcmsConfig.url}: ${JSON.stringify(response)}`,
+    );
+    throw new Error(
+      `An error occurred while creating a release on ${lcmsConfig.url}`,
+    );
   }
 
   return response.data.content;

--- a/api/tests/shared/integration/infrastructure/lcms-client_test.js
+++ b/api/tests/shared/integration/infrastructure/lcms-client_test.js
@@ -1,6 +1,6 @@
 import { config } from '../../../../src/shared/config.js';
 import { lcmsClient } from '../../../../src/shared/infrastructure/lcms-client.js';
-import { catchErr, expect, mockLearningContent, nock } from '../../../test-helper.js';
+import { catchErr, createTempFile, expect, mockLearningContent, nock, removeTempFile } from '../../../test-helper.js';
 
 describe('Integration | Infrastructure | LCMS Client', function () {
   describe('#getRelease', function () {
@@ -42,6 +42,46 @@ describe('Integration | Infrastructure | LCMS Client', function () {
         expect(error).to.be.instanceOf(Error);
         expect(error.message).to.equal(`An error occurred while fetching https://lcms-test.pix.fr/api`);
         expect(lcmsCall.isDone()).to.be.true;
+      });
+    });
+
+    context('when url is a file:// url', function () {
+      let originalUrl;
+      let tempFilePath;
+
+      beforeEach(function () {
+        originalUrl = config.lcms.url;
+      });
+
+      afterEach(async function () {
+        config.lcms.url = originalUrl;
+        await removeTempFile(tempFilePath);
+      });
+
+      it('reads learning content from the file', async function () {
+        // given
+        const learningContent = { models: [{ id: 'fromFile' }] };
+        const releaseData = { id: 'v1', createdAt: '2024-01-01', content: learningContent };
+        tempFilePath = await createTempFile('lcms-release.json', JSON.stringify(releaseData));
+        config.lcms.url = `file://${tempFilePath}`;
+
+        // when
+        const response = await lcmsClient.getRelease();
+
+        // then
+        expect(response).to.deep.equal(learningContent);
+      });
+
+      it('rejects when file does not exist', async function () {
+        // given
+        tempFilePath = '/tmp/nonexistent-lcms-release.json';
+        config.lcms.url = `file://${tempFilePath}`;
+
+        // when
+        const error = await catchErr(lcmsClient.getRelease)();
+
+        // then
+        expect(error).to.be.instanceOf(Error);
       });
     });
 


### PR DESCRIPTION
## 🥀 Problème
Il est parfois utile de pouvoir charger une release du référentiel à partir d'un dump JSON de l'API de PixEditor, par exemple pour travailler en développement sans dépendre d'une instance LCMS distante, ou pour rejouer un scénario précis lors de tests. Cette PR ajoute la capacité de configurer LCMS_API_URL avec une URL file:// pointant vers un fichier de release local, et couvre ce chemin par des tests d'intégration.

## 🏹 Proposition
La fonction getRelease dispatche au moment de l'appel selon le schéma de l'URL configurée (file:// ou HTTP). Cela permet :

- De tester les deux chemins (getReleaseFile et getReleaseHttp) sans redémarrer le process
- D'ajouter des tests d'intégration couvrant le cas file:// (lecture réussie d'un fichier temporaire, et rejet si le fichier est absent)

## 💌 Remarques
Les tests utilisent les utilitaires existants `createTempFile` / `removeTempFile` du `test-helper` pour créer et nettoyer les fichiers temporaires.

## ❤️‍🔥 Pour tester
 Lancer les tests d'intégration du lcms-client :
 Vérifier que les deux nouveaux cas passent (reads learning content from the file et rejects when file does not exist)
Le reste du code de getRelease reste inchangé, y compris les tests.

