### PR TITLE
[TECH] :recycle: Réduit l'utilisation de `Lodash` - suppression de `_.compact`

### DIFF
--- a/api/scripts/prod/target-profile-migrations/common.js
+++ b/api/scripts/prod/target-profile-migrations/common.js
@@ -25,7 +25,7 @@ const autoMigrateTargetProfile = async function (id, trx) {
     if (!tubeExists) throw new Error(`Le sujet "${foundSkill.tubeId}" n'existe pas dans le référentiel.`);
     return foundSkill;
   });
-  const skillsGroupedByTubeId = _.groupBy(_.compact(skills), 'tubeId');
+  const skillsGroupedByTubeId = _.groupBy(skills.filter(Boolean), 'tubeId');
   const tubes = [];
   for (const [tubeId, skills] of Object.entries(skillsGroupedByTubeId)) {
     const skillWithHighestDifficulty = _.maxBy(skills, 'difficulty');

--- a/api/scripts/prod/target-profile-migrations/parse-xls-files-for-target-profiles-migration.js
+++ b/api/scripts/prod/target-profile-migrations/parse-xls-files-for-target-profiles-migration.js
@@ -1,8 +1,6 @@
 import perf_hooks from 'node:perf_hooks';
 import * as url from 'node:url';
 
-import _ from 'lodash';
-
 const { performance } = perf_hooks;
 
 import XLSX from 'xlsx';
@@ -131,7 +129,7 @@ function toLevel(s) {
 }
 
 async function migrateTargetProfiles(targetProfiles, multiFormData, dryRun) {
-  for (const targetProfile of _.compact(targetProfiles)) {
+  for (const targetProfile of targetProfiles.filter(Boolean)) {
     try {
       await knex.transaction(async (trx) => {
         let hasError = false;

--- a/api/src/certification/results/infrastructure/repositories/certificate-repository.js
+++ b/api/src/certification/results/infrastructure/repositories/certificate-repository.js
@@ -251,9 +251,9 @@ function _filterMostRecentCertificationCoursePerOrganizationLearner(DTOs) {
 }
 
 async function _toDomainForCertificationAttestation({ certificationCourseDTO, competenceTree, certifiedBadges }) {
-  const competenceMarks = _.compact(certificationCourseDTO.competenceMarks).map(
-    (competenceMark) => new CompetenceMark({ ...competenceMark }),
-  );
+  const competenceMarks = certificationCourseDTO.competenceMarks
+    .filter(Boolean)
+    .map((competenceMark) => new CompetenceMark({ ...competenceMark }));
 
   const resultCompetenceTree = ResultCompetenceTree.generateTreeFromCompetenceMarks({
     competenceTree,
@@ -282,9 +282,9 @@ function _toDomainForPrivateCertificate({ certificationCourseDTO, competenceTree
   let resultCompetenceTree = null;
 
   if (competenceTree) {
-    const competenceMarks = _.compact(certificationCourseDTO.competenceMarks).map(
-      (competenceMark) => new CompetenceMark({ ...competenceMark }),
-    );
+    const competenceMarks = certificationCourseDTO.competenceMarks
+      .filter(Boolean)
+      .map((competenceMark) => new CompetenceMark({ ...competenceMark }));
 
     resultCompetenceTree = ResultCompetenceTree.generateTreeFromCompetenceMarks({
       competenceTree,
@@ -304,7 +304,7 @@ function _toDomainForPrivateCertificate({ certificationCourseDTO, competenceTree
 function _toDomainForShareableCertificate({ shareableCertificateDTO, competenceTree, certifiedBadges }) {
   const resultCompetenceTree = ResultCompetenceTree.generateTreeFromCompetenceMarks({
     competenceTree,
-    competenceMarks: _.compact(shareableCertificateDTO.competenceMarks),
+    competenceMarks: shareableCertificateDTO.competenceMarks.filter(Boolean),
     certificationId: shareableCertificateDTO.id,
     assessmentResultId: shareableCertificateDTO.assessmentResultId,
   });

--- a/api/src/prescription/campaign/infrastructure/serializers/csv/campaign-assessment-export.js
+++ b/api/src/prescription/campaign/infrastructure/serializers/csv/campaign-assessment-export.js
@@ -152,7 +152,7 @@ class CampaignAssessmentExport {
     // WHY: add \uFEFF the UTF-8 BOM at the start of the text, see:
     // - https://en.wikipedia.org/wiki/Byte_order_mark
     // - https://stackoverflow.com/a/38192870
-    return '\uFEFF' + csvSerializer.serializeLine(_.compact(headers));
+    return '\uFEFF' + csvSerializer.serializeLine(headers.filter(Boolean));
   }
 
   #competenceColumnHeaders() {

--- a/api/src/prescription/campaign/infrastructure/serializers/csv/campaign-profiles-collection-export.js
+++ b/api/src/prescription/campaign/infrastructure/serializers/csv/campaign-profiles-collection-export.js
@@ -78,7 +78,7 @@ class CampaignProfilesCollectionExport {
     // WHY: add \uFEFF the UTF-8 BOM at the start of the text, see:
     // - https://en.wikipedia.org/wiki/Byte_order_mark
     // - https://stackoverflow.com/a/38192870
-    return '\uFEFF' + csvSerializer.serializeLine(_.compact(header));
+    return '\uFEFF' + csvSerializer.serializeLine(header.filter(Boolean));
   }
 
   async _getUsersPlacementProfiles(campaignParticipationResultDataChunk, placementProfileService) {

--- a/api/src/shared/infrastructure/repositories/badge-for-calculation-repository.js
+++ b/api/src/shared/infrastructure/repositories/badge-for-calculation-repository.js
@@ -1,5 +1,3 @@
-import _ from 'lodash';
-
 import * as campaignRepository from '../../../prescription/campaign/infrastructure/repositories/campaign-repository.js';
 import { DomainTransaction } from '../../domain/DomainTransaction.js';
 import { BadgeCriterionForCalculation } from '../../domain/models/BadgeCriterionForCalculation.js';
@@ -41,7 +39,7 @@ const findByCampaignParticipationId = async function ({ campaignParticipationId 
     );
     badges.push(badge);
   }
-  return _.compact(badges);
+  return badges.filter(Boolean);
 };
 
 const findByCampaignId = async function ({ campaignId }) {
@@ -76,7 +74,7 @@ const findByCampaignId = async function ({ campaignId }) {
     );
     badges.push(badge);
   }
-  return _.compact(badges);
+  return badges.filter(Boolean);
 };
 
 const getByCertifiableBadgeAcquisition = async function ({ certifiableBadgeAcquisition }) {

--- a/api/tests/certification/enrolment/unit/domain/models/Center_test.js
+++ b/api/tests/certification/enrolment/unit/domain/models/Center_test.js
@@ -1,5 +1,3 @@
-import _ from 'lodash';
-
 import { CenterTypes } from '../../../../../../src/certification/enrolment/domain/models/CenterTypes.js';
 import { types } from '../../../../../../src/organizational-entities/domain/models/Organization.js';
 import { CERTIFICATION_CENTER_TYPES } from '../../../../../../src/shared/domain/constants.js';
@@ -47,7 +45,7 @@ describe('Unit | Certification | Enrolment | Domain | Models | Center', function
           });
         return null;
       });
-      notScoCenters = _.compact(notScoCenters);
+      notScoCenters = notScoCenters.filter(Boolean);
 
       // when
       for (const notScoCenter of notScoCenters) {

--- a/api/tests/certification/enrolment/unit/domain/models/SessionEnrolment_test.js
+++ b/api/tests/certification/enrolment/unit/domain/models/SessionEnrolment_test.js
@@ -78,7 +78,7 @@ describe('Unit | Certification | Enrolment | Domain | Models | SessionEnrolment'
           });
         return null;
       });
-      notScoSessions = _.compact(notScoSessions);
+      notScoSessions = notScoSessions.filter(Boolean);
 
       // when
       for (const notScoSession of notScoSessions) {

--- a/api/tests/tooling/learning-content-builder/build-learning-content.js
+++ b/api/tests/tooling/learning-content-builder/build-learning-content.js
@@ -146,7 +146,7 @@ const buildLearningContent = function (learningContent) {
     competences: allCompetences.flat(),
     tubes: allTubes.flat(),
     skills: allSkills.flat(),
-    challenges: _.compact(allChallenges.flat()),
+    challenges: allChallenges.flat().filter(Boolean),
     courses: _.compact(allCourses.flat()),
     tutorials: _.compact(allTutorials.flat()),
     thematics: allThematics.flat(),


### PR DESCRIPTION
## 🥀 Problème

Nous utilisons parfois `lodash`, cela cré une dépendance externe (et un vecteur d'attaque).
Beaucoup de fonctions proposées par Lodash peuvent être remplacé facilement par du simple JavaScript.

## 🏹 Proposition

Remplacer l'utilisation de `_.compact()` par `.filter(Boolean)`.

## 💌 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## ❤️‍🔥 Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
