### PR TITLE
[FEATURE] Ajoute l'identifiant de version et de candidate au parcours de certification (PIX-21824)

### DIFF
--- a/api/db/migrations/20260305093219_add-candidateid-and-versionid-to-certification-courses-table.js
+++ b/api/db/migrations/20260305093219_add-candidateid-and-versionid-to-certification-courses-table.js
@@ -1,0 +1,44 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ *
+ * 2 tables changes for this migration :
+ *
+ * 1/ add link from certification course to version of certification, and link
+ * from certification course to candidate
+ *
+ * 2/ add subscription key into candidate. When candidate is created, he is
+ * link to a framework. Value is extract from
+ * https://github.com/1024pix/pix/blob/dev/api/src/certification/configuration/domain/models/Frameworks.js
+ *
+ * TODO Column `subscription` is need for CLEA usage ! Remove it when CLEA is merge with standard certification
+ *
+ */
+const up = async function (knex) {
+  await knex.schema.table('certification-courses', function (table) {
+    table
+      .integer('versionId')
+      .references('certification_versions.id')
+      .comment('Active certification version at creation time of this certification course');
+    table.integer('candidateId').references('certification-candidates.id').comment('link to certification candidate');
+  });
+  await knex.schema.table('certification-candidates', function (table) {
+    table.string('subscription').comment('Enum value of Framework that candidate is subscribe to');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.table('certification-courses', function (table) {
+    table.dropColumn('versionId');
+    table.dropColumn('candidateId');
+  });
+  await knex.schema.table('certification-candidates', function (table) {
+    table.dropColumn('subscription');
+  });
+};
+
+export { down, up };

--- a/api/tests/certification/enrolment/integration/infrastructure/repositories/candidate-repository_test.js
+++ b/api/tests/certification/enrolment/integration/infrastructure/repositories/candidate-repository_test.js
@@ -344,6 +344,7 @@ describe('Integration | Certification | Enrolment | Repository | Candidate', fun
         accessibilityAdjustmentNeeded: false,
         subscriptions: [subscriptionCore, subscriptionComplementary],
         reconciledAt: null,
+        subscription: null,
       };
       databaseBuilder.factory.buildSession({ id: candidateData.sessionId });
       databaseBuilder.factory.buildComplementaryCertification({
@@ -469,6 +470,7 @@ describe('Integration | Certification | Enrolment | Repository | Candidate', fun
         prepaymentCode: candidateA.prepaymentCode,
         hasSeenCertificationInstructions: false,
         accessibilityAdjustmentNeeded: candidateA.accessibilityAdjustmentNeeded,
+        subscription: null,
       });
       expect(savedCandidateAData.createdAt).to.be.instanceOf(Date);
       expect(parseFloat(savedCandidateAData.extraTimePercentage)).to.equal(candidateA.extraTimePercentage);
@@ -522,6 +524,7 @@ describe('Integration | Certification | Enrolment | Repository | Candidate', fun
         prepaymentCode: candidateB.prepaymentCode,
         hasSeenCertificationInstructions: false,
         accessibilityAdjustmentNeeded: candidateB.accessibilityAdjustmentNeeded,
+        subscription: null,
       });
       expect(savedCandidateBData.createdAt).to.be.instanceOf(Date);
       expect(parseFloat(savedCandidateBData.extraTimePercentage)).to.equal(candidateB.extraTimePercentage);
@@ -567,6 +570,7 @@ describe('Integration | Certification | Enrolment | Repository | Candidate', fun
         prepaymentCode: candidateC.prepaymentCode,
         hasSeenCertificationInstructions: false,
         accessibilityAdjustmentNeeded: candidateC.accessibilityAdjustmentNeeded,
+        subscription: null,
       });
       expect(savedCandidateCData.createdAt).to.be.instanceOf(Date);
       expect(parseFloat(savedCandidateCData.extraTimePercentage)).to.equal(candidateC.extraTimePercentage);


### PR DESCRIPTION
## 🥀 Problème

Nous avons souvent besoin de connaitre la version de configuration du parcours de certification.
Aujourd'hui, il n'y a pas de lien direct entre un parcours de certification et un candidat. Nous devons passer par les sessions, les subscriptions, ...

Nous avons également fréquemment besoin d'identifier les parcours de certification CLEA qui sont un peu particuliers.

## 🏹 Proposition

Au moment de créer le parcours de certification, nous proposons d'ajouter 
- le lien vers la version de référentiel (`versionId`)
- le lien vers le candidat (`candidateId`)

Nous ajoutons également la clef de la certification choisie pour un candidat à la table `certification-candidates`.

## 💌 Remarques

## ❤️‍🔥 Pour tester

Sur pixApp, entré en certif sur la session 7407, avec Max Lagagne, né le 30/10/200 et le code AZERTY. Aller jusqu'à la première épreuve. Tout devrait se passer normalement.
En base, ça a créé un enregistrement `certificationCourses` sans `versionId` et sans `frameworkType` sans faire d'erreur.
