### PR TITLE
[TECH] Utiliser `logger.warn` pour logger les erreurs d'import (PIX-21692).

### DIFF
--- a/api/src/prescription/learner-management/infrastructure/utils/xml/siecle-file-streamer.js
+++ b/api/src/prescription/learner-management/infrastructure/utils/xml/siecle-file-streamer.js
@@ -18,15 +18,15 @@ const ERRORS = {
 };
 
 class SiecleFileStreamer {
-  static async create(readableStream, encoding = 'utf-8', logError = logger.error) {
-    const stream = new SiecleFileStreamer(readableStream, encoding, logError);
+  static async create(readableStream, encoding = 'utf-8', logWarn = logger.warn) {
+    const stream = new SiecleFileStreamer(readableStream, encoding, logWarn);
     return stream;
   }
 
-  constructor(readableStream, encoding, logError) {
+  constructor(readableStream, encoding, logWarn) {
     this.readableStream = readableStream;
     this.encoding = encoding;
-    this.logError = logError;
+    this.logWarn = logWarn;
   }
 
   async perform(callback) {
@@ -37,7 +37,7 @@ class SiecleFileStreamer {
 
   async _callbackAsPromise(callback) {
     return new Promise((resolve, reject) => {
-      const saxStream = _getSaxStream(this.readableStream, this.encoding, reject, this.logError);
+      const saxStream = _getSaxStream(this.readableStream, this.encoding, reject, this.logWarn);
       callback(saxStream, resolve, reject);
     });
   }
@@ -46,10 +46,10 @@ class SiecleFileStreamer {
   }
 }
 
-function _getSaxStream(inputStream, encoding, reject, logError) {
+function _getSaxStream(inputStream, encoding, reject, logWarn) {
   const decodeStream = _getDecodingStream(encoding);
   decodeStream.on('error', (err) => {
-    logError(err);
+    logWarn(err, 'Encoding not supported (decoded)');
     return reject(new FileValidationError(ERRORS.ENCODING_NOT_SUPPORTED));
   });
 
@@ -57,7 +57,7 @@ function _getSaxStream(inputStream, encoding, reject, logError) {
   saxParser.on(
     'error',
     _.once((err) => {
-      logError(err);
+      logWarn(err, 'Invalid file error');
       reject(new FileValidationError(ERRORS.INVALID_FILE));
     }),
   );
@@ -68,7 +68,7 @@ function _getDecodingStream(encoding) {
   try {
     return iconv.decodeStream(encoding);
   } catch (err) {
-    logger.error(err);
+    logger.warn(err, 'Encoding not supported (decoding)');
     throw new SiecleXmlImportError(ERRORS.ENCODING_NOT_SUPPORTED);
   }
 }

--- a/api/tests/prescription/learner-management/integration/infrastructure/serializers/xml/siecle-parser_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/serializers/xml/siecle-parser_test.js
@@ -25,10 +25,10 @@ describe('Integration | Serializers | siecle-parser', function () {
 
       const siecleFileStreamer = await SiecleFileStreamer.create(readableStream, encoding);
       const parser = SiecleParser.create(siecleFileStreamer);
-      const call = () => parser.parseUAJ('123ABC');
 
-      //then
-      expect(call).to.not.throw();
+      const result = parser.parseUAJ('123ABC');
+
+      await expect(result).to.be.fulfilled;
     });
 
     describe('error cases', function () {

--- a/api/tests/prescription/learner-management/integration/infrastructure/utils/xml/siecle-file-streamer_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/utils/xml/siecle-file-streamer_test.js
@@ -43,10 +43,10 @@ describe('SiecleFileStreamer', function () {
 
         it('log only the first sax error', async function () {
           const path = `${__dirname}/files/xml/garbage.xml`;
-          const logError = sinon.stub();
+          const logWarn = sinon.stub();
           const readableStream = fs.createReadStream(path);
 
-          const streamer = await SiecleFileStreamer.create(readableStream, 'utf-8', logError);
+          const streamer = await SiecleFileStreamer.create(readableStream, 'utf-8', logWarn);
 
           await catchErr(
             streamer.perform,
@@ -58,7 +58,7 @@ describe('SiecleFileStreamer', function () {
             saxStream.on('end', resolve);
           });
 
-          expect(logError).to.have.been.calledOnce;
+          expect(logWarn).to.have.been.calledOnce;
         });
       });
 


### PR DESCRIPTION

## 🥀 Problème

lorsqu’on parse le fichier xml et qu’une erreur intervient on se retrouve avec 2 erreurs
une en wargning et l'autre en error

## 🏹 Proposition

utiliser `.warn` plutot que `.error`  
<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 💌 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## ❤️‍🔥 Pour tester
RAS
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
