### PR TITLE
[FEATURE] Renseigne la référence à la version et au candidat lié au parcours de certification (PIX-21826)

### DIFF
--- a/api/db/database-builder/factory/build-certification-candidate.js
+++ b/api/db/database-builder/factory/build-certification-candidate.js
@@ -29,6 +29,7 @@ const buildCertificationCandidate = function ({
   hasSeenCertificationInstructions = false,
   accessibilityAdjustmentNeeded = false,
   reconciledAt = null,
+  subscription = null,
 } = {}) {
   sessionId = _.isUndefined(sessionId) ? buildSession().id : sessionId;
   userId = _.isUndefined(userId) ? buildUser().id : userId;
@@ -59,6 +60,7 @@ const buildCertificationCandidate = function ({
     hasSeenCertificationInstructions,
     accessibilityAdjustmentNeeded,
     reconciledAt,
+    subscription,
   };
 
   databaseBuffer.pushInsertable({
@@ -91,6 +93,7 @@ const buildCertificationCandidate = function ({
     hasSeenCertificationInstructions,
     accessibilityAdjustmentNeeded,
     reconciledAt,
+    subscription,
   };
 };
 

--- a/api/db/database-builder/factory/build-certification-course.js
+++ b/api/db/database-builder/factory/build-certification-course.js
@@ -29,6 +29,8 @@ const buildCertificationCourse = function ({
   isRejectedForFraud = false,
   abortReason = null,
   lang = null,
+  versionId = null,
+  candidateId = null,
 } = {}) {
   userId = _.isUndefined(userId) ? buildUser().id : userId;
   sessionId = _.isUndefined(sessionId) ? buildSession().id : sessionId;
@@ -56,6 +58,8 @@ const buildCertificationCourse = function ({
     isRejectedForFraud,
     abortReason,
     lang,
+    versionId,
+    candidateId,
   };
   return databaseBuffer.pushInsertable({
     tableName: 'certification-courses',

--- a/api/db/seeds/data/team-certification/cases/simple-CLEA-v3.js
+++ b/api/db/seeds/data/team-certification/cases/simple-CLEA-v3.js
@@ -174,7 +174,7 @@ export class CleaV3Seed {
   async #addCandidateToSession({ pixAppUser, session }) {
     const candidateBirthdate = '2000-10-30';
 
-    const candidate = new Candidate({
+    const candidateDTO = {
       firstName: pixAppUser.firstName,
       lastName: pixAppUser.lastName,
       sex: 'F',
@@ -194,11 +194,11 @@ export class CleaV3Seed {
       ],
       userId: pixAppUser.id,
       billingMode: BILLING_MODES.FREE,
-    });
+    };
 
     const candidateId = await enrolmentUseCases.addCandidateToSession({
       sessionId: session.id,
-      candidate: new Candidate(candidate), // Warning: usecase modifies the entry model...
+      candidate: Candidate.create(candidateDTO), // Warning: usecase modifies the entry model...
       normalizeStringFnc: normalize,
     });
 
@@ -210,8 +210,8 @@ export class CleaV3Seed {
     await enrolmentServices.registerCandidateParticipation({
       userId: pixAppUser.id,
       sessionId: session.id,
-      firstName: candidate.firstName,
-      lastName: candidate.lastName,
+      firstName: candidateDTO.firstName,
+      lastName: candidateDTO.lastName,
       birthdate: candidateBirthdate,
       isFrenchDomainExtension: true,
       normalizeStringFnc: normalize,

--- a/api/db/seeds/data/team-certification/cases/simple-pro-certification.js
+++ b/api/db/seeds/data/team-certification/cases/simple-pro-certification.js
@@ -147,7 +147,7 @@ export class ProSeed {
 
   async #addCandidateToSession({ pixAppUser, session }) {
     const candidateBirthdate = '2000-10-30';
-    const candidate = new Candidate({
+    const candidateDTO = {
       firstName: pixAppUser.firstName,
       lastName: pixAppUser.lastName,
       sex: 'F',
@@ -161,19 +161,19 @@ export class ProSeed {
       subscriptions: [Subscription.buildCore({ certificationCandidateId: null })],
       userId: pixAppUser.id,
       billingMode: BILLING_MODES.FREE,
-    });
+    };
 
     const candidateId = await enrolmentUseCases.addCandidateToSession({
       sessionId: session.id,
-      candidate: new Candidate(candidate), // Warning: usecase modifies the entry model...
+      candidate: Candidate.create(candidateDTO), // Warning: usecase modifies the entry model...
       normalizeStringFnc: normalize,
     });
 
     await enrolmentServices.registerCandidateParticipation({
       userId: pixAppUser.id,
       sessionId: session.id,
-      firstName: candidate.firstName,
-      lastName: candidate.lastName,
+      firstName: candidateDTO.firstName,
+      lastName: candidateDTO.lastName,
       birthdate: candidateBirthdate,
       isFrenchDomainExtension: true,
       normalizeStringFnc: normalize,

--- a/api/db/seeds/data/team-certification/cases/simple-sco-managing-students-certification.js
+++ b/api/db/seeds/data/team-certification/cases/simple-sco-managing-students-certification.js
@@ -173,7 +173,7 @@ export class ScoManagingStudent {
   }
 
   async #addCandidateToSession({ organizationLearner, session }) {
-    const candidate = new Candidate({
+    const candidate = Candidate.create({
       firstName: organizationLearner.firstName,
       lastName: organizationLearner.lastName,
       sex: 'F',

--- a/api/db/seeds/data/team-certification/cases/sup-certification-centre-with-habilitations.js
+++ b/api/db/seeds/data/team-certification/cases/sup-certification-centre-with-habilitations.js
@@ -177,7 +177,7 @@ export class SupWithHabilitationsSeed {
   async #addCandidateToSession({ pixAppUser, session, subscriptions }) {
     const candidateBirthdate = '2000-10-30';
 
-    const candidate = new Candidate({
+    const candidateDTO = {
       firstName: pixAppUser.firstName,
       lastName: pixAppUser.lastName,
       sex: 'F',
@@ -191,11 +191,11 @@ export class SupWithHabilitationsSeed {
       subscriptions,
       userId: pixAppUser.id,
       billingMode: BILLING_MODES.FREE,
-    });
+    };
 
     const candidateId = await enrolmentUseCases.addCandidateToSession({
       sessionId: session.id,
-      candidate: new Candidate(candidate), // Warning: usecase modifies the entry model...
+      candidate: Candidate.create(candidateDTO), // Warning: usecase modifies the entry model...
       normalizeStringFnc: normalize,
     });
 
@@ -207,8 +207,8 @@ export class SupWithHabilitationsSeed {
     await enrolmentServices.registerCandidateParticipation({
       userId: pixAppUser.id,
       sessionId: session.id,
-      firstName: candidate.firstName,
-      lastName: candidate.lastName,
+      firstName: candidateDTO.firstName,
+      lastName: candidateDTO.lastName,
       birthdate: candidateBirthdate,
       isFrenchDomainExtension: true,
       normalizeStringFnc: normalize,

--- a/api/src/certification/enrolment/domain/models/Candidate.js
+++ b/api/src/certification/enrolment/domain/models/Candidate.js
@@ -2,6 +2,7 @@
  * @typedef {import ('./Subscription.js').Subscription} Subscription
  */
 import { CertificationCandidatesError } from '../../../../shared/domain/errors.js';
+import { Frameworks } from '../../../configuration/domain/models/Frameworks.js';
 import { BILLING_MODES, SUBSCRIPTION_TYPES } from '../../../shared/domain/constants.js';
 import { validate } from '../validators/candidate-validator.js';
 
@@ -34,6 +35,7 @@ export class Candidate {
     billingMode,
     prepaymentCode,
     hasSeenCertificationInstructions = false,
+    subscription,
     subscriptions = [],
     accessibilityAdjustmentNeeded,
   } = {}) {
@@ -59,9 +61,22 @@ export class Candidate {
     this.billingMode = billingMode;
     this.prepaymentCode = prepaymentCode;
     this.hasSeenCertificationInstructions = hasSeenCertificationInstructions;
+    this.subscription = subscription;
     this.subscriptions = subscriptions;
     this.accessibilityAdjustmentNeeded = accessibilityAdjustmentNeeded;
     this.reconciledAt = reconciledAt;
+  }
+
+  static create(candidateDTO) {
+    const complementaryKey = candidateDTO.subscriptions.find((sub) => {
+      return sub.type === SUBSCRIPTION_TYPES.COMPLEMENTARY;
+    })?.complementaryCertificationKey;
+    const mainSubscription = complementaryKey || Frameworks.CORE;
+
+    return new Candidate({
+      ...candidateDTO,
+      subscription: mainSubscription,
+    });
   }
 
   isReconciled() {

--- a/api/src/certification/enrolment/domain/models/SCOCertificationCandidate.js
+++ b/api/src/certification/enrolment/domain/models/SCOCertificationCandidate.js
@@ -1,7 +1,9 @@
 import JoiDate from '@joi/date';
 import BaseJoi from 'joi';
 const Joi = BaseJoi.extend(JoiDate);
+import { Frameworks } from '../../../configuration/domain/models/Frameworks.js';
 import { InvalidCertificationCandidate } from '../errors.js';
+import { Subscription } from '../models/Subscription.js';
 
 const scoCertificationCandidateValidationJoiSchema = Joi.object({
   firstName: Joi.string().required().empty(null),
@@ -27,7 +29,6 @@ class SCOCertificationCandidate {
     sex,
     sessionId,
     organizationLearnerId,
-    subscriptions,
   } = {}) {
     this.id = id;
     this.firstName = firstName;
@@ -39,7 +40,8 @@ class SCOCertificationCandidate {
     this.sex = sex;
     this.sessionId = sessionId;
     this.organizationLearnerId = organizationLearnerId;
-    this.subscriptions = subscriptions;
+    this.subscriptions = [Subscription.buildCore({ certificationCandidateId: null })];
+    this.subscription = Frameworks.CORE;
     this.validate();
   }
 

--- a/api/src/certification/enrolment/domain/services/certification-candidates-ods-service.js
+++ b/api/src/certification/enrolment/domain/services/certification-candidates-ods-service.js
@@ -108,7 +108,7 @@ async function extractCertificationCandidatesFromCandidatesImportSheet({
       }
     }
 
-    const candidate = new Candidate({
+    const candidate = Candidate.create({
       ...candidateData,
       birthCountry,
       birthINSEECode,

--- a/api/src/certification/enrolment/domain/usecases/create-sessions.js
+++ b/api/src/certification/enrolment/domain/usecases/create-sessions.js
@@ -76,6 +76,8 @@ async function _deleteExistingCandidatesInSession({ candidateRepository, session
 }
 
 async function _saveCandidates({ candidates, sessionId, candidateRepository }) {
-  const candidatesToSave = candidates.map((candidate) => new Candidate({ ...candidate, sessionId }));
+  const candidatesToSave = candidates.map((candidate) => {
+    return Candidate.create({ ...candidate, sessionId });
+  });
   await candidateRepository.save({ candidates: candidatesToSave });
 }

--- a/api/src/certification/enrolment/domain/usecases/enrol-students-to-session.js
+++ b/api/src/certification/enrolment/domain/usecases/enrol-students-to-session.js
@@ -10,7 +10,6 @@ import { ForbiddenAccess } from '../../../../shared/domain/errors.js';
 import { PromiseUtils } from '../../../../shared/infrastructure/utils/promise-utils.js';
 import { UnknownCountryForStudentEnrolmentError } from '../errors.js';
 import { SCOCertificationCandidate } from '../models/SCOCertificationCandidate.js';
-import { Subscription } from '../models/Subscription.js';
 
 const INSEE_PREFIX_CODE = '99';
 
@@ -83,7 +82,6 @@ const enrolStudentsToSession = async function ({
       sex: student.sex,
       sessionId,
       organizationLearnerId: student.id,
-      subscriptions: [Subscription.buildCore({ certificationCandidateId: null })],
     });
   });
 

--- a/api/src/certification/enrolment/domain/usecases/validate-sessions.js
+++ b/api/src/certification/enrolment/domain/usecases/validate-sessions.js
@@ -133,7 +133,7 @@ async function _createValidCertificationCandidates({
 
     certificationCandidateErrors.push(...certificationCandidateComplementaryErrors);
 
-    const candidate = new Candidate({
+    const candidate = Candidate.create({
       ...candidateDTO,
       sessionId,
       billingMode: billingMode || candidateDTO.billingMode,

--- a/api/src/certification/enrolment/infrastructure/repositories/candidate-repository.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/candidate-repository.js
@@ -138,7 +138,7 @@ export async function save({ candidates }) {
       (insertedCandidateData) =>
         insertedCandidateData.firstName === candidate.firstName &&
         insertedCandidateData.lastName === candidate.lastName &&
-        dayjs(insertedCandidateData.birthdate).format('YYYY-MM-DD') === candidate.birthdate,
+        dayjs(insertedCandidateData.birthdate).format('YYYY-MM-DD') === dayjs(candidate.birthdate).format('YYYY-MM-DD'),
     ).id;
 
     subscriptionsData.push(

--- a/api/src/certification/enrolment/infrastructure/repositories/candidate-repository.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/candidate-repository.js
@@ -106,61 +106,21 @@ export async function update(candidate) {
 }
 
 /**
+ * @deprecated use save instead
  * @function
  * @param {Candidate} candidate
  *
  * @returns {Promise<number>}
  */
 export async function insert(candidate) {
-  const candidateDataToSave = adaptModelToDb(candidate);
-  const knexTransaction = DomainTransaction.getConnection();
-
-  const [{ id: candidateId }] = await knexTransaction('certification-candidates')
-    .insert(candidateDataToSave)
-    .returning('id');
-
-  for (const subscription of candidate.subscriptions) {
-    if (subscription.type === SUBSCRIPTION_TYPES.CORE) {
-      await knexTransaction('certification-subscriptions').insert({
-        certificationCandidateId: candidateId,
-        type: subscription.type,
-        complementaryCertificationId: null,
-      });
-    } else {
-      const { id: complementaryCertificationId } = await knexTransaction('complementary-certifications')
-        .select('id')
-        .where({ key: subscription.complementaryCertificationKey })
-        .first();
-      await knexTransaction('certification-subscriptions').insert({
-        certificationCandidateId: candidateId,
-        type: subscription.type,
-        complementaryCertificationId: complementaryCertificationId,
-      });
-    }
-  }
-
-  return candidateId;
-}
-
-/**
- * @function
- * @param {object} params
- * @param {number} params.sessionId
- * @returns {Promise<void>}
- */
-export async function deleteBySessionId({ sessionId }) {
-  const knexConn = DomainTransaction.getConnection();
-  await knexConn('certification-subscriptions')
-    .whereIn('certificationCandidateId', knexConn.select('id').from('certification-candidates').where({ sessionId }))
-    .del();
-
-  await knexConn('certification-candidates').where({ sessionId }).del();
+  const insertedIds = await save({ candidates: [candidate] });
+  return insertedIds[0];
 }
 
 /**
  * @function
  * @param {Candidate[]} candidates
- * @returns {Promise<void>}
+ * @returns {Promise<Number[]>}
  */
 export async function save({ candidates }) {
   const knexConn = DomainTransaction.getConnection();
@@ -194,6 +154,23 @@ export async function save({ candidates }) {
     );
   }
   await knexConn('certification-subscriptions').insert(subscriptionsData);
+
+  return insertedCandidatesData.map(({ id }) => id);
+}
+
+/**
+ * @function
+ * @param {object} params
+ * @param {number} params.sessionId
+ * @returns {Promise<void>}
+ */
+export async function deleteBySessionId({ sessionId }) {
+  const knexConn = DomainTransaction.getConnection();
+  await knexConn('certification-subscriptions')
+    .whereIn('certificationCandidateId', knexConn.select('id').from('certification-candidates').where({ sessionId }))
+    .del();
+
+  await knexConn('certification-candidates').where({ sessionId }).del();
 }
 
 /**

--- a/api/src/certification/enrolment/infrastructure/repositories/candidate-repository.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/candidate-repository.js
@@ -273,6 +273,7 @@ function adaptModelToDb(candidate) {
     prepaymentCode: candidate.prepaymentCode,
     hasSeenCertificationInstructions: candidate.hasSeenCertificationInstructions,
     accessibilityAdjustmentNeeded: candidate.accessibilityAdjustmentNeeded,
+    subscription: candidate.subscription,
   };
 }
 

--- a/api/src/certification/enrolment/infrastructure/repositories/sco-certification-candidate-repository.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/sco-certification-candidate-repository.js
@@ -78,6 +78,7 @@ function _scoCandidateToDTOForSession(sessionId) {
     birthINSEECode: scoCandidate.birthINSEECode,
     birthCity: scoCandidate.birthCity,
     birthCountry: scoCandidate.birthCountry,
+    subscription: scoCandidate.subscription,
     sessionId,
   });
 }

--- a/api/src/certification/enrolment/infrastructure/serializers/candidate-serializer.js
+++ b/api/src/certification/enrolment/infrastructure/serializers/candidate-serializer.js
@@ -19,7 +19,7 @@ export async function deserialize(json) {
       }),
   );
 
-  return new Candidate({
+  return Candidate.create({
     ...deserializedCandidate,
     id: deserializedCandidate?.id ? parseInt(deserializedCandidate?.id) : null,
     subscriptions,

--- a/api/src/certification/evaluation/domain/usecases/retrieve-last-or-create-certification-course.js
+++ b/api/src/certification/evaluation/domain/usecases/retrieve-last-or-create-certification-course.js
@@ -9,7 +9,7 @@
  * @typedef {import('./index.js').ScoringConfigurationRepository} ScoringConfigurationRepository
  * @typedef {import('./index.js').CertificationBadgesService} CertificationBadgesService
  * @typedef {import('./index.js').VerifyCertificateCodeService} VerifyCertificateCodeService
- * @typedef {import('../../../src/shared/domain/models/CertificationCandidate.js').CertificationCandidate} CertificationCandidate
+ * @typedef {import('../../../shared/domain/models/CertificationCandidate.js').CertificationCandidate} CertificationCandidate
  */
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { LanguageNotSupportedError } from '../../../../shared/domain/errors.js';
@@ -260,7 +260,7 @@ async function _startNewCertification({
  * @param {SessionId} params.sessionId
  * @returns {Promise<CertificationCourse>}
  */
-async function _getCertificationCourseIfCreatedMeanwhile(certificationCourseRepository, userId, sessionId) {
+function _getCertificationCourseIfCreatedMeanwhile(certificationCourseRepository, userId, sessionId) {
   return certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId({
     userId,
     sessionId,
@@ -294,6 +294,7 @@ async function _createCertificationCourse({
 
   const newCertificationCourse = CertificationCourse.from({
     certificationCandidate,
+    certificationVersion,
     maxReachableLevelOnCertificationDate,
     complementaryCertificationCourse,
     verificationCode,

--- a/api/src/certification/shared/domain/models/CertificationCourse.js
+++ b/api/src/certification/shared/domain/models/CertificationCourse.js
@@ -76,6 +76,8 @@ export class CertificationCourse {
     isRejectedForFraud = false,
     isAdjustedForAccessibility,
     lang,
+    versionId,
+    candidateId,
   } = {}) {
     this._id = id;
     this._firstName = firstName;
@@ -104,10 +106,13 @@ export class CertificationCourse {
     this._isAdjustedForAccessibility = isAdjustedForAccessibility;
     this._numberOfChallenges = numberOfChallenges;
     this._lang = lang;
+    this.versionId = versionId;
+    this.candidateId = candidateId;
   }
 
   static from({
     certificationCandidate,
+    certificationVersion,
     challenges,
     verificationCode,
     maxReachableLevelOnCertificationDate,
@@ -136,6 +141,8 @@ export class CertificationCourse {
       complementaryCertificationCourse,
       version: algorithmEngineVersion,
       lang,
+      versionId: certificationVersion.id,
+      candidateId: certificationCandidate.id,
     });
   }
 
@@ -352,6 +359,8 @@ export class CertificationCourse {
       numberOfChallenges: this._numberOfChallenges,
       version: this._version,
       lang: this._lang,
+      candidateId: this.candidateId,
+      versionId: this.versionId,
     };
   }
 }

--- a/api/src/certification/shared/infrastructure/repositories/certification-course-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/certification-course-repository.js
@@ -240,19 +240,30 @@ export {
 };
 
 function _adaptModelToDb(certificationCourse) {
-  /* eslint-disable no-unused-vars */
-  const {
-    complementaryCertificationCourse,
-    certificationIssueReports,
-    assessment,
-    challenges,
-    createdAt,
-    numberOfChallenges,
-    isAdjustedForAccessibility,
-    ...rest
-  } = certificationCourse.toDTO();
-  /* eslint-enable no-unused-vars */
-  return rest;
+  const certificationCourseDTO = certificationCourse.toDTO();
+  return {
+    firstName: certificationCourseDTO.firstName,
+    lastName: certificationCourseDTO.lastName,
+    birthdate: certificationCourseDTO.birthdate,
+    birthplace: certificationCourseDTO.birthplace,
+    birthPostalCode: certificationCourseDTO.birthPostalCode,
+    birthINSEECode: certificationCourseDTO.birthINSEECode,
+    birthCountry: certificationCourseDTO.birthCountry,
+    sex: certificationCourseDTO.sex,
+    externalId: certificationCourseDTO.externalId,
+    completedAt: certificationCourseDTO.completedAt,
+    isPublished: certificationCourseDTO.isPublished,
+    isRejectedForFraud: certificationCourseDTO.isRejectedForFraud,
+    verificationCode: certificationCourseDTO.verificationCode,
+    userId: certificationCourseDTO.userId,
+    sessionId: certificationCourseDTO.sessionId,
+    maxReachableLevelOnCertificationDate: certificationCourseDTO.maxReachableLevelOnCertificationDate,
+    abortReason: certificationCourseDTO.abortReason,
+    version: certificationCourseDTO.version,
+    lang: certificationCourseDTO.lang,
+    candidateId: certificationCourseDTO.candidateId,
+    versionId: certificationCourseDTO.versionId,
+  };
 }
 
 function _extractPropertiesForUpdate(certificationCourse) {

--- a/api/tests/certification/enrolment/acceptance/application/certification-candidate-controller-post-certification-candidate_test.js
+++ b/api/tests/certification/enrolment/acceptance/application/certification-candidate-controller-post-certification-candidate_test.js
@@ -74,6 +74,7 @@ describe('Acceptance | Controller | Certification | Enrolment | session-controll
         sessionId = databaseBuilder.factory.buildSession({ certificationCenterId, certificationCenter }).id;
         databaseBuilder.factory.buildCertificationCenterMembership({ userId, certificationCenterId });
         databaseBuilder.factory.buildCertificationCpfCountry({
+          commonName: 'FRANCE',
           originalName: 'FRANCE',
           code: '99100',
           matcher: 'ACEFNR',
@@ -132,6 +133,39 @@ describe('Acceptance | Controller | Certification | Enrolment | session-controll
         expect(response.statusCode).to.equal(201);
         expect(response.result.data.id).to.equal(candidateId.toString());
         expect(response.result.data.type).to.equal('certification-candidates');
+      });
+
+      it('should save the complete candidate in database', async function () {
+        // when
+        const response = await server.inject(options);
+
+        // then
+        const candidateId = parseInt(response.result.data.id);
+        const savedCandidate = await knex('certification-candidates').where({ id: candidateId }).first();
+
+        expect(savedCandidate).to.contain({
+          firstName: candidate.firstName,
+          lastName: candidate.lastName,
+          sex: candidate.sex,
+          birthdate: candidate.birthdate,
+          birthCountry: 'FRANCE',
+          birthINSEECode: '75115',
+          birthCity: 'PARIS 15',
+          birthPostalCode: null,
+          birthProvinceCode: null,
+          email: candidate.email,
+          resultRecipientEmail: candidate.resultRecipientEmail,
+          externalId: candidate.externalId,
+          extraTimePercentage: '0.30',
+          billingMode: 'FREE',
+          prepaymentCode: null,
+          sessionId,
+          userId: null,
+          organizationLearnerId: null,
+          authorizedToStart: false,
+          hasSeenCertificationInstructions: false,
+          subscription: ComplementaryCertificationKeys.CLEA,
+        });
       });
 
       it('should save subscriptions (core and complementary if any)', async function () {

--- a/api/tests/certification/enrolment/acceptance/application/enrolment-route_test.js
+++ b/api/tests/certification/enrolment/acceptance/application/enrolment-route_test.js
@@ -1,6 +1,8 @@
 import fs from 'node:fs';
 import * as url from 'node:url';
 
+import { Frameworks } from '../../../../../src/certification/configuration/domain/models/Frameworks.js';
+import { SUBSCRIPTION_TYPES } from '../../../../../src/certification/shared/domain/constants.js';
 import { ComplementaryCertificationKeys } from '../../../../../src/certification/shared/domain/models/ComplementaryCertificationKeys.js';
 import { clearResolveMx, setResolveMx } from '../../../../../src/shared/mail/infrastructure/services/mail-check.js';
 import {
@@ -8,6 +10,7 @@ import {
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
+  knex,
   sinon,
 } from '../../../../test-helper.js';
 
@@ -165,11 +168,50 @@ describe('Certification | Enrolment | Acceptance | Application | Routes | enrolm
               type: 'subscriptions',
               id: sinon.match.string,
               attributes: {
-                type: 'CORE',
+                type: SUBSCRIPTION_TYPES.CORE,
                 'complementary-certification-key': null,
               },
             },
           ],
+        });
+
+        const savedCandidate = await knex('certification-candidates')
+          .select(
+            'firstName',
+            'lastName',
+            'birthdate',
+            'birthINSEECode',
+            'birthCity',
+            'birthCountry',
+            'sex',
+            'sessionId',
+            'organizationLearnerId',
+            'subscription',
+            'email',
+            'externalId',
+            'extraTimePercentage',
+            'billingMode',
+            'prepaymentCode',
+          )
+          .where({ sessionId, organizationLearnerId: organizationLearner.id })
+          .first();
+
+        expect(savedCandidate).to.deep.equal({
+          firstName: organizationLearner.firstName,
+          lastName: organizationLearner.lastName,
+          birthdate: organizationLearner.birthdate,
+          birthINSEECode: birthCityCode,
+          birthCity: organizationLearner.birthCity,
+          birthCountry: country.commonName,
+          sex: organizationLearner.sex,
+          sessionId,
+          organizationLearnerId: organizationLearner.id,
+          subscription: Frameworks.CORE,
+          email: null,
+          externalId: null,
+          extraTimePercentage: null,
+          billingMode: null,
+          prepaymentCode: null,
         });
       });
     });

--- a/api/tests/certification/enrolment/integration/domain/services/certification-candidates-ods-service/certification-candidates-ods-service_test.js
+++ b/api/tests/certification/enrolment/integration/domain/services/certification-candidates-ods-service/certification-candidates-ods-service_test.js
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import * as url from 'node:url';
 
+import { Frameworks } from '../../../../../../../src/certification/configuration/domain/models/Frameworks.js';
 import * as certificationCandidatesOdsService from '../../../../../../../src/certification/enrolment/domain/services/certification-candidates-ods-service.js';
 import * as centerRepository from '../../../../../../../src/certification/enrolment/infrastructure/repositories/center-repository.js';
 import * as certificationCpfCityRepository from '../../../../../../../src/certification/enrolment/infrastructure/repositories/certification-cpf-city-repository.js';
@@ -204,7 +205,12 @@ describe('Integration | Services | extractCertificationCandidatesFromCandidatesI
 
     // then
     candidateList = _buildCandidateList({ sessionId });
-    const expectedCandidates = candidateList.map(domainBuilder.certification.enrolment.buildCandidate);
+    const expectedCandidates = candidateList.map((candidate) => {
+      return domainBuilder.certification.enrolment.buildCandidate({
+        ...candidate,
+        subscription: candidate.subscriptions[0].complementaryCertificationKey || Frameworks.CORE,
+      });
+    });
     expect(actualCandidates).to.deep.equal(expectedCandidates);
   });
 
@@ -241,7 +247,12 @@ describe('Integration | Services | extractCertificationCandidatesFromCandidatesI
           ComplementaryCertificationKeys.CLEA,
         ],
       });
-      const expectedCandidates = candidateList.map(domainBuilder.certification.enrolment.buildCandidate);
+      const expectedCandidates = candidateList.map((candidate) => {
+        return domainBuilder.certification.enrolment.buildCandidate({
+          ...candidate,
+          subscription: candidate.subscriptions[0].complementaryCertificationKey || Frameworks.CORE,
+        });
+      });
 
       // when
       const actualCandidates =
@@ -315,7 +326,12 @@ describe('Integration | Services | extractCertificationCandidatesFromCandidatesI
     const odsFilePath = `${__dirname}/attendance_sheet_extract_with_billing_ok_test.ods`;
     const odsBuffer = await readFile(odsFilePath);
     candidateList = _buildCandidateList({ billingModes: [BILLING_MODES.PAID, BILLING_MODES.FREE], sessionId });
-    const expectedCandidates = candidateList.map(domainBuilder.certification.enrolment.buildCandidate);
+    const expectedCandidates = candidateList.map((candidate) => {
+      return domainBuilder.certification.enrolment.buildCandidate({
+        ...candidate,
+        subscription: candidate.subscriptions[0].complementaryCertificationKey || Frameworks.CORE,
+      });
+    });
 
     // when
     const actualCandidates =
@@ -357,7 +373,12 @@ describe('Integration | Services | extractCertificationCandidatesFromCandidatesI
       });
 
     // then
-    const expectedCandidates = candidateList.map(domainBuilder.certification.enrolment.buildCandidate);
+    const expectedCandidates = candidateList.map((candidate) => {
+      return domainBuilder.certification.enrolment.buildCandidate({
+        ...candidate,
+        subscription: candidate.subscriptions[0].complementaryCertificationKey || Frameworks.CORE,
+      });
+    });
     expect(actualCandidates).to.deep.equal(expectedCandidates);
   });
 });

--- a/api/tests/certification/enrolment/integration/infrastructure/repositories/candidate-repository_test.js
+++ b/api/tests/certification/enrolment/integration/infrastructure/repositories/candidate-repository_test.js
@@ -1,8 +1,8 @@
+import { Frameworks } from '../../../../../../src/certification/configuration/domain/models/Frameworks.js';
 import { CertificationCandidateNotFoundError } from '../../../../../../src/certification/enrolment/domain/errors.js';
 import { Candidate } from '../../../../../../src/certification/enrolment/domain/models/Candidate.js';
 import * as candidateRepository from '../../../../../../src/certification/enrolment/infrastructure/repositories/candidate-repository.js';
 import { SUBSCRIPTION_TYPES } from '../../../../../../src/certification/shared/domain/constants.js';
-import { ComplementaryCertificationKeys } from '../../../../../../src/certification/shared/domain/models/ComplementaryCertificationKeys.js';
 import { _ } from '../../../../../../src/shared/infrastructure/utils/lodash-utils.js';
 import { catchErr, databaseBuilder, domainBuilder, expect, knex } from '../../../../../test-helper.js';
 
@@ -19,7 +19,7 @@ describe('Integration | Certification | Enrolment | Repository | Candidate', fun
 
         const complementaryCertification = databaseBuilder.factory.buildComplementaryCertification({
           id: 1,
-          key: ComplementaryCertificationKeys.CLEA,
+          key: Frameworks.CLEA,
         });
 
         databaseBuilder.factory.buildComplementaryCertificationSubscription({
@@ -71,7 +71,7 @@ describe('Integration | Certification | Enrolment | Repository | Candidate', fun
         const sessionId = databaseBuilder.factory.buildSession().id;
         databaseBuilder.factory.buildComplementaryCertification({
           id: 1,
-          key: ComplementaryCertificationKeys.CLEA,
+          key: Frameworks.CLEA,
         });
         const certificationCandidate1 = databaseBuilder.factory.buildCertificationCandidate({
           sessionId,
@@ -103,7 +103,7 @@ describe('Integration | Certification | Enrolment | Repository | Candidate', fun
             subscriptions: [
               domainBuilder.certification.enrolment.buildComplementarySubscription({
                 certificationCandidateId: certificationCandidate1.id,
-                complementaryCertificationKey: ComplementaryCertificationKeys.CLEA,
+                complementaryCertificationKey: Frameworks.CLEA,
               }),
               domainBuilder.certification.enrolment.buildCoreSubscription({
                 certificationCandidateId: certificationCandidate1.id,
@@ -221,11 +221,11 @@ describe('Integration | Certification | Enrolment | Repository | Candidate', fun
         // when
         const complementaryCertificationDroit = databaseBuilder.factory.buildComplementaryCertification({
           id: 555,
-          key: ComplementaryCertificationKeys.PIX_PLUS_DROIT,
+          key: Frameworks.DROIT,
         });
         const complementaryCertificationEdu = databaseBuilder.factory.buildComplementaryCertification({
           id: 666,
-          key: ComplementaryCertificationKeys.PIX_PLUS_EDU_1ER_DEGRE,
+          key: Frameworks.EDU_1ER_DEGRE,
         });
         const certificationCandidate = databaseBuilder.factory.buildCertificationCandidate({
           firstName: 'toto',
@@ -350,7 +350,7 @@ describe('Integration | Certification | Enrolment | Repository | Candidate', fun
       databaseBuilder.factory.buildComplementaryCertification({
         id: 22,
         label: 'Pix+DROIT',
-        key: ComplementaryCertificationKeys.PIX_PLUS_DROIT,
+        key: Frameworks.DROIT,
       });
       return databaseBuilder.commit();
     });
@@ -411,9 +411,10 @@ describe('Integration | Certification | Enrolment | Repository | Candidate', fun
         subscriptions: [
           domainBuilder.certification.enrolment.buildCoreSubscription(),
           domainBuilder.certification.enrolment.buildComplementarySubscription({
-            complementaryCertificationKey: ComplementaryCertificationKeys.CLEA,
+            complementaryCertificationKey: Frameworks.CLEA,
           }),
         ],
+        subscription: Frameworks.CLEA,
       });
       const candidateB = domainBuilder.certification.enrolment.buildCandidate({
         firstName: 'Geogeo',
@@ -421,6 +422,7 @@ describe('Integration | Certification | Enrolment | Repository | Candidate', fun
         accessibilityAdjustmentNeeded: true,
         sessionId,
         subscriptions: [domainBuilder.certification.enrolment.buildCoreSubscription()],
+        subscription: Frameworks.CORE,
       });
       const candidateC = domainBuilder.certification.enrolment.buildCandidate({
         firstName: 'Loulou',
@@ -429,9 +431,10 @@ describe('Integration | Certification | Enrolment | Repository | Candidate', fun
         accessibilityAdjustmentNeeded: false,
         subscriptions: [
           domainBuilder.certification.enrolment.buildComplementarySubscription({
-            complementaryCertificationKey: ComplementaryCertificationKeys.PIX_PLUS_DROIT,
+            complementaryCertificationKey: Frameworks.DROIT,
           }),
         ],
+        subscription: Frameworks.DROIT,
       });
 
       // when
@@ -470,7 +473,7 @@ describe('Integration | Certification | Enrolment | Repository | Candidate', fun
         prepaymentCode: candidateA.prepaymentCode,
         hasSeenCertificationInstructions: false,
         accessibilityAdjustmentNeeded: candidateA.accessibilityAdjustmentNeeded,
-        subscription: null,
+        subscription: Frameworks.CLEA,
       });
       expect(savedCandidateAData.createdAt).to.be.instanceOf(Date);
       expect(parseFloat(savedCandidateAData.extraTimePercentage)).to.equal(candidateA.extraTimePercentage);
@@ -524,7 +527,7 @@ describe('Integration | Certification | Enrolment | Repository | Candidate', fun
         prepaymentCode: candidateB.prepaymentCode,
         hasSeenCertificationInstructions: false,
         accessibilityAdjustmentNeeded: candidateB.accessibilityAdjustmentNeeded,
-        subscription: null,
+        subscription: Frameworks.CORE,
       });
       expect(savedCandidateBData.createdAt).to.be.instanceOf(Date);
       expect(parseFloat(savedCandidateBData.extraTimePercentage)).to.equal(candidateB.extraTimePercentage);
@@ -570,7 +573,7 @@ describe('Integration | Certification | Enrolment | Repository | Candidate', fun
         prepaymentCode: candidateC.prepaymentCode,
         hasSeenCertificationInstructions: false,
         accessibilityAdjustmentNeeded: candidateC.accessibilityAdjustmentNeeded,
-        subscription: null,
+        subscription: Frameworks.DROIT,
       });
       expect(savedCandidateCData.createdAt).to.be.instanceOf(Date);
       expect(parseFloat(savedCandidateCData.extraTimePercentage)).to.equal(candidateC.extraTimePercentage);

--- a/api/tests/certification/enrolment/integration/infrastructure/repositories/sco-certification-candidate-repository_test.js
+++ b/api/tests/certification/enrolment/integration/infrastructure/repositories/sco-certification-candidate-repository_test.js
@@ -45,16 +45,10 @@ describe('Certification | Enrolment | Integration | Repository | SCOCertificatio
         domainBuilder.buildSCOCertificationCandidate({
           ...scoCandidateAlreadySaved1,
           organizationLearnerId: scoCandidateAlreadySaved1.organizationLearnerId,
-          subscriptions: [
-            domainBuilder.certification.enrolment.buildCoreSubscription({ certificationCandidateId: null }),
-          ],
         }),
         domainBuilder.buildSCOCertificationCandidate({
           ...scoCandidateAlreadySaved2,
           organizationLearnerId: scoCandidateAlreadySaved2.organizationLearnerId,
-          subscriptions: [
-            domainBuilder.certification.enrolment.buildCoreSubscription({ certificationCandidateId: null }),
-          ],
         }),
         domainBuilder.buildSCOCertificationCandidate({
           id: null,
@@ -65,17 +59,11 @@ describe('Certification | Enrolment | Integration | Repository | SCOCertificatio
           birthINSEECode: '75005',
           organizationLearnerId: organizationLearnerId3,
           sessionId,
-          subscriptions: [
-            domainBuilder.certification.enrolment.buildCoreSubscription({ certificationCandidateId: null }),
-          ],
         }),
         domainBuilder.buildSCOCertificationCandidate({
           id: null,
           organizationLearnerId: organizationLearnerId4,
           sessionId,
-          subscriptions: [
-            domainBuilder.certification.enrolment.buildCoreSubscription({ certificationCandidateId: null }),
-          ],
         }),
       ];
 
@@ -94,6 +82,7 @@ describe('Certification | Enrolment | Integration | Repository | SCOCertificatio
         'birthINSEECode',
         'organizationLearnerId',
         'sessionId',
+        'subscription',
       ]);
       const actualCandidates = candidatesToBeCompared(candidates);
       const expectedCandidates = candidatesToBeCompared(scoCandidates);
@@ -123,9 +112,6 @@ describe('Certification | Enrolment | Integration | Repository | SCOCertificatio
         domainBuilder.buildSCOCertificationCandidate({
           ...scoCandidateAlreadySaved1,
           organizationLearnerId: scoCandidateAlreadySaved1.organizationLearnerId,
-          subscriptions: [
-            domainBuilder.certification.enrolment.buildCoreSubscription({ certificationCandidateId: null }),
-          ],
         }),
         domainBuilder.buildSCOCertificationCandidate({
           id: null,
@@ -136,20 +122,11 @@ describe('Certification | Enrolment | Integration | Repository | SCOCertificatio
           birthINSEECode: '75005',
           organizationLearnerId: organizationLearnerId2,
           sessionId,
-          subscriptions: [
-            domainBuilder.certification.enrolment.buildCoreSubscription({ certificationCandidateId: null }),
-          ],
         }),
         domainBuilder.buildSCOCertificationCandidate({
           id: null,
           organizationLearnerId: organizationLearnerId3,
           sessionId,
-          subscriptions: [
-            domainBuilder.certification.enrolment.buildCoreSubscription({ certificationCandidateId: null }),
-            domainBuilder.certification.enrolment.buildComplementarySubscription({
-              certificationCandidateId: null,
-            }),
-          ],
         }),
       ];
 

--- a/api/tests/certification/enrolment/unit/domain/models/Candidate_test.js
+++ b/api/tests/certification/enrolment/unit/domain/models/Candidate_test.js
@@ -1,3 +1,4 @@
+import { Frameworks } from '../../../../../../src/certification/configuration/domain/models/Frameworks.js';
 import { Candidate } from '../../../../../../src/certification/enrolment/domain/models/Candidate.js';
 import { SUBSCRIPTION_TYPES } from '../../../../../../src/certification/shared/domain/constants.js';
 import { CERTIFICATION_CANDIDATES_ERRORS } from '../../../../../../src/certification/shared/domain/constants/certification-candidates-errors.js';
@@ -50,6 +51,67 @@ describe('Certification | Enrolment | Unit | Domain | Models | Candidate', funct
         },
       ],
     };
+  });
+
+  context('create', function () {
+    context('when the candidate subscription is registered for CORE', function () {
+      it('should create a new Candidate with a CORE subscription attribute', function () {
+        // given
+        const candidateDTO = domainBuilder.certification.enrolment.buildCandidate({
+          ...candidateData,
+          subscriptions: [domainBuilder.certification.enrolment.buildCoreSubscription()],
+        });
+
+        // when
+        const expectedCandidate = Candidate.create(candidateDTO);
+
+        // then
+        expect(expectedCandidate.subscription).to.equal(Frameworks.CORE);
+      });
+    });
+
+    context('when the candidate is registered for a double certification', function () {
+      it('should create a new Candidate with a CORE subscription attribute', function () {
+        // given
+        const candidateDTO = domainBuilder.certification.enrolment.buildCandidate({
+          ...candidateData,
+          subscriptions: [
+            domainBuilder.certification.enrolment.buildCoreSubscription(),
+            domainBuilder.certification.enrolment.buildComplementarySubscription({
+              certificationCandidateId: null,
+              complementaryCertificationKey: ComplementaryCertificationKeys.CLEA,
+            }),
+          ],
+        });
+
+        // when
+        const expectedCandidate = Candidate.create(candidateDTO);
+
+        // then
+        expect(expectedCandidate.subscription).to.equal(Frameworks.CLEA);
+      });
+    });
+
+    context('when the candidate is registered for a Pix+ certification', function () {
+      it('should create a new Candidate with a PIX+ subscription attribute', function () {
+        // given
+        const candidateDTO = domainBuilder.certification.enrolment.buildCandidate({
+          ...candidateData,
+          subscriptions: [
+            domainBuilder.certification.enrolment.buildComplementarySubscription({
+              certificationCandidateId: null,
+              complementaryCertificationKey: ComplementaryCertificationKeys.PIX_PLUS_DROIT,
+            }),
+          ],
+        });
+
+        // when
+        const expectedCandidate = Candidate.create(candidateDTO);
+
+        // then
+        expect(expectedCandidate.subscription).to.equal(Frameworks.DROIT);
+      });
+    });
   });
 
   context('updateBirthInformation', function () {

--- a/api/tests/certification/enrolment/unit/domain/usecases/create-sessions_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/create-sessions_test.js
@@ -145,7 +145,13 @@ describe('Unit | UseCase | sessions-mass-import | create-sessions', function () 
           const expectedSession = new SessionEnrolment({ ...temporaryCachedSessions[0], createdBy: sessionCreatorId });
           expect(sessionRepository.save).to.have.been.calledOnceWith({ session: expectedSession });
           expect(candidateRepository.save).to.have.been.calledOnceWith({
-            candidates: [domainBuilder.certification.enrolment.buildCandidate({ ...candidate, sessionId: 1234 })],
+            candidates: [
+              domainBuilder.certification.enrolment.buildCandidate({
+                ...candidate,
+                sessionId: 1234,
+                subscription: ComplementaryCertificationKeys.PIX_PLUS_DROIT,
+              }),
+            ],
           });
         });
       });
@@ -181,7 +187,13 @@ describe('Unit | UseCase | sessions-mass-import | create-sessions', function () 
           sessionId: 1234,
         });
         expect(candidateRepository.save).to.have.been.calledOnceWith({
-          candidates: [domainBuilder.certification.enrolment.buildCandidate({ ...candidate, sessionId: 1234 })],
+          candidates: [
+            domainBuilder.certification.enrolment.buildCandidate({
+              ...candidate,
+              sessionId: 1234,
+              subscription: ComplementaryCertificationKeys.PIX_PLUS_DROIT,
+            }),
+          ],
         });
       });
     });

--- a/api/tests/certification/enrolment/unit/domain/usecases/validate-sessions_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/validate-sessions_test.js
@@ -123,28 +123,22 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
   context('when sessions and candidates are valid', function () {
     it('return a sessions report', async function () {
       // given
-      const candidate1 = domainBuilder.certification.enrolment.buildCandidate({
+      const candidate1 = domainBuilder.certification.enrolment.buildCandidate.withCoreSubscription({
         ...candidateData1,
         id: null,
         createdAt: null,
         userId: null,
         reconciledAt: null,
         billingMode: CertificationCandidate.BILLING_MODES.FREE,
-        subscriptions: [
-          domainBuilder.certification.enrolment.buildCoreSubscription({ certificationCandidateId: null }),
-        ],
       });
       const session1 = { ...firstSession, candidates: [candidateData1] };
-      const candidate2 = domainBuilder.certification.enrolment.buildCandidate({
+      const candidate2 = domainBuilder.certification.enrolment.buildCandidate.withCoreSubscription({
         ...candidateData2,
         id: null,
         createdAt: null,
         userId: null,
         reconciledAt: null,
         billingMode: CertificationCandidate.BILLING_MODES.FREE,
-        subscriptions: [
-          domainBuilder.certification.enrolment.buildCoreSubscription({ certificationCandidateId: null }),
-        ],
       });
       const session2 = { ...secondSession, candidates: [candidateData2] };
 
@@ -233,40 +227,31 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
     context('when there is only sessionId and candidate information', function () {
       it('should validate the candidates in the session', async function () {
         // given
-        const candidate1 = domainBuilder.certification.enrolment.buildCandidate({
+        const candidate1 = domainBuilder.certification.enrolment.buildCandidate.withCoreSubscription({
           ...candidateData1,
           id: null,
           createdAt: null,
           userId: null,
           reconciledAt: null,
           billingMode: CertificationCandidate.BILLING_MODES.FREE,
-          subscriptions: [
-            domainBuilder.certification.enrolment.buildCoreSubscription({ certificationCandidateId: null }),
-          ],
         });
         const session1 = { ...firstSession, candidates: [candidateData1] };
-        const candidate2 = domainBuilder.certification.enrolment.buildCandidate({
+        const candidate2 = domainBuilder.certification.enrolment.buildCandidate.withCoreSubscription({
           ...candidateData2,
           id: null,
           createdAt: null,
           userId: null,
           reconciledAt: null,
           billingMode: CertificationCandidate.BILLING_MODES.FREE,
-          subscriptions: [
-            domainBuilder.certification.enrolment.buildCoreSubscription({ certificationCandidateId: null }),
-          ],
         });
         const candidateData3 = { ...candidateData2, lastName: 'Brun', firstName: 'Petit Ours' };
-        const candidate3 = domainBuilder.certification.enrolment.buildCandidate({
+        const candidate3 = domainBuilder.certification.enrolment.buildCandidate.withCoreSubscription({
           ...candidateData3,
           id: null,
           createdAt: null,
           userId: null,
           reconciledAt: null,
           billingMode: CertificationCandidate.BILLING_MODES.FREE,
-          subscriptions: [
-            domainBuilder.certification.enrolment.buildCoreSubscription({ certificationCandidateId: null }),
-          ],
         });
         const session2 = { sessionId: 2, candidates: [candidateData2, candidateData3] };
 
@@ -449,25 +434,19 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
     context('when there is at least one duplicate candidate in a session', function () {
       it('should remove duplicate certification candidates from the session', async function () {
         // given
-        const candidate1 = domainBuilder.certification.enrolment.buildCandidate({
+        const candidate1 = domainBuilder.certification.enrolment.buildCandidate.withCoreSubscription({
           ...candidateData1,
           id: null,
           createdAt: null,
           userId: null,
           billingMode: CertificationCandidate.BILLING_MODES.FREE,
-          subscriptions: [
-            domainBuilder.certification.enrolment.buildCoreSubscription({ certificationCandidateId: null }),
-          ],
         });
-        const candidate2 = domainBuilder.certification.enrolment.buildCandidate({
+        const candidate2 = domainBuilder.certification.enrolment.buildCandidate.withCoreSubscription({
           ...candidateData2,
           id: null,
           createdAt: null,
           userId: null,
           billingMode: CertificationCandidate.BILLING_MODES.FREE,
-          subscriptions: [
-            domainBuilder.certification.enrolment.buildCoreSubscription({ certificationCandidateId: null }),
-          ],
         });
         const sessionsData = [
           {
@@ -478,7 +457,7 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
 
         sessionsImportValidationService.getValidatedSubscriptionsForMassImport.resolves({
           certificationCandidateComplementaryErrors: [],
-          complementaryCertification: [
+          subscriptions: [
             domainBuilder.certification.enrolment.buildCoreSubscription({ certificationCandidateId: null }),
           ],
         });

--- a/api/tests/certification/enrolment/unit/infrastructure/serializers/candidate-serializer_test.js
+++ b/api/tests/certification/enrolment/unit/infrastructure/serializers/candidate-serializer_test.js
@@ -1,3 +1,4 @@
+import { Frameworks } from '../../../../../../src/certification/configuration/domain/models/Frameworks.js';
 import * as serializer from '../../../../../../src/certification/enrolment/infrastructure/serializers/candidate-serializer.js';
 import { SUBSCRIPTION_TYPES } from '../../../../../../src/certification/shared/domain/constants.js';
 import { CertificationCandidate } from '../../../../../../src/certification/shared/domain/models/CertificationCandidate.js';
@@ -106,6 +107,7 @@ describe('Certification | Enrolment | Unit | Serializer | candidate', function (
         domainBuilder.certification.enrolment.buildCandidate({
           ...candidateData,
           complementaryCertificationKey: ComplementaryCertificationKeys.PIX_PLUS_PRO_SANTE,
+          subscription: Frameworks.PRO_SANTE,
           subscriptions: [
             domainBuilder.certification.enrolment.buildComplementarySubscription({
               certificationCandidateId: null,

--- a/api/tests/certification/evaluation/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
+++ b/api/tests/certification/evaluation/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
@@ -465,6 +465,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                 accessCode: 'accessCode',
               });
               evaluationSessionRepository.get.withArgs({ id: foundSession.id }).resolves(foundSession);
+              const certificationVersion = domainBuilder.certification.shared.buildVersion();
 
               const foundCertificationCandidate = domainBuilder.buildCertificationCandidate({
                 userId: user.id,
@@ -489,6 +490,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
               // TODO: extraire jusqu'à la ligne 387 dans une fonction ?
               const certificationCourseToSave = CertificationCourse.from({
                 certificationCandidate: foundCertificationCandidate,
+                certificationVersion,
                 verificationCode,
                 maxReachableLevelOnCertificationDate: MAX_REACHABLE_LEVEL,
                 algorithmEngineVersion: AlgorithmEngineVersion.V3,
@@ -593,6 +595,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                   version: 3,
                 });
                 evaluationSessionRepository.get.withArgs({ id: 1 }).resolves(foundSession);
+                const certificationVersion = domainBuilder.certification.shared.buildVersion();
 
                 const foundCertificationCandidate = domainBuilder.buildCertificationCandidate({
                   userId,
@@ -622,6 +625,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
 
                 const certificationCourseToSave = CertificationCourse.from({
                   certificationCandidate: foundCertificationCandidate,
+                  certificationVersion,
                   verificationCode,
                   maxReachableLevelOnCertificationDate: MAX_REACHABLE_LEVEL,
                   algorithmEngineVersion: AlgorithmEngineVersion.V3,
@@ -681,6 +685,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                   accessCode: 'accessCode',
                 });
                 evaluationSessionRepository.get.withArgs({ id: 1 }).resolves(foundSession);
+                const certificationVersion = domainBuilder.certification.shared.buildVersion();
 
                 const foundCertificationCandidate = domainBuilder.buildCertificationCandidate({
                   userId: 2,
@@ -704,6 +709,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
 
                 const certificationCourseToSave = CertificationCourse.from({
                   certificationCandidate: foundCertificationCandidate,
+                  certificationVersion,
                   verificationCode,
                   maxReachableLevelOnCertificationDate: MAX_REACHABLE_LEVEL,
                   complementaryCertificationCourses: [],
@@ -759,6 +765,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                       key: ComplementaryCertificationKeys.PIX_PLUS_DROIT,
                     },
                   );
+                  const certificationVersion = domainBuilder.certification.shared.buildVersion();
 
                   const foundSession = domainBuilder.certification.sessionManagement.buildSessionManagement.created({
                     id: 1,
@@ -800,6 +807,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
 
                   const certificationCourseToSave = CertificationCourse.from({
                     certificationCandidate: foundCertificationCandidate,
+                    certificationVersion,
                     verificationCode,
                     maxReachableLevelOnCertificationDate: MAX_REACHABLE_LEVEL,
                     complementaryCertificationCourse,
@@ -923,6 +931,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                     const cleaCertification = domainBuilder.certification.shared.buildComplementaryCertification({
                       key: ComplementaryCertificationKeys.CLEA,
                     });
+                    const certificationVersion = domainBuilder.certification.shared.buildVersion();
 
                     const certifiableBadgeAcquisition = domainBuilder.buildCertifiableBadgeAcquisition({
                       badgeKey: 'CLEA_BADGE_1',
@@ -975,6 +984,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
 
                     const certificationCourseToSave = CertificationCourse.from({
                       certificationCandidate: foundCertificationCandidate,
+                      certificationVersion,
                       verificationCode,
                       maxReachableLevelOnCertificationDate: MAX_REACHABLE_LEVEL,
                       complementaryCertificationCourse,
@@ -1030,6 +1040,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                       const cleaCertification = domainBuilder.certification.shared.buildComplementaryCertification({
                         key: ComplementaryCertificationKeys.CLEA,
                       });
+                      const certificationVersion = domainBuilder.certification.shared.buildVersion();
 
                       const foundSession = domainBuilder.certification.sessionManagement.buildSessionManagement.created(
                         {
@@ -1070,6 +1081,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
 
                       const certificationCourseToSave = CertificationCourse.from({
                         certificationCandidate: foundCertificationCandidate,
+                        certificationVersion,
                         verificationCode,
                         maxReachableLevelOnCertificationDate: MAX_REACHABLE_LEVEL,
                         algorithmEngineVersion: AlgorithmEngineVersion.V3,

--- a/api/tests/certification/shared/integration/infrastructure/repositories/certification-course-repository_test.js
+++ b/api/tests/certification/shared/integration/infrastructure/repositories/certification-course-repository_test.js
@@ -1,6 +1,5 @@
 import dayjs from 'dayjs';
 import _ from 'lodash';
-import sinon from 'sinon';
 
 import { CertificationCourse } from '../../../../../../src/certification/shared/domain/models/CertificationCourse.js';
 import * as certificationCourseRepository from '../../../../../../src/certification/shared/infrastructure/repositories/certification-course-repository.js';

--- a/api/tests/certification/shared/integration/infrastructure/repositories/certification-course-repository_test.js
+++ b/api/tests/certification/shared/integration/infrastructure/repositories/certification-course-repository_test.js
@@ -1,5 +1,6 @@
 import dayjs from 'dayjs';
 import _ from 'lodash';
+import sinon from 'sinon';
 
 import { CertificationCourse } from '../../../../../../src/certification/shared/domain/models/CertificationCourse.js';
 import * as certificationCourseRepository from '../../../../../../src/certification/shared/infrastructure/repositories/certification-course-repository.js';
@@ -8,20 +9,39 @@ import { catchErr, databaseBuilder, domainBuilder, expect, knex } from '../../..
 
 describe('Certification | Shared | Integration | Repository | Certification Course', function () {
   describe('#save', function () {
-    let certificationCourse, userId, sessionId;
+    let certificationCourseData, certificationCourse, userId, sessionId, candidateId, versionId;
 
     beforeEach(function () {
       userId = databaseBuilder.factory.buildUser().id;
       sessionId = databaseBuilder.factory.buildSession({ version: 3 }).id;
-
-      databaseBuilder.factory.buildCertificationCandidate({ userId, sessionId });
-      certificationCourse = domainBuilder.buildCertificationCourse.unpersisted({
+      candidateId = databaseBuilder.factory.buildCertificationCandidate({ sessionId }).id;
+      versionId = databaseBuilder.factory.buildCertificationVersion().id;
+      certificationCourseData = {
         userId,
         sessionId,
-        complementaryCertificationCourse: null,
         version: 3,
         lang: 'fr',
-      });
+        candidateId,
+        versionId,
+        firstName: 'JePasse',
+        lastName: 'MaCertif',
+        birthdate: '1990-04-01',
+        birthplace: 'MonLit',
+        birthPostalCode: '66000',
+        birthINSEECode: '66000',
+        birthCountry: 'FRANCE',
+        sex: 'F',
+        externalId: 'OUIOUITOUTAFÉ',
+        completedAt: new Date(),
+        isPublished: false,
+        isRejectedForFraud: false,
+        verificationCode: 'MONCODE',
+        maxReachableLevelOnCertificationDate: 7,
+        abortReason: null,
+      };
+
+      databaseBuilder.factory.buildCertificationCandidate({ userId, sessionId });
+      certificationCourse = domainBuilder.buildCertificationCourse.unpersisted(certificationCourseData);
 
       return databaseBuilder.commit();
     });
@@ -31,11 +51,11 @@ describe('Certification | Shared | Integration | Repository | Certification Cour
       const savedCertificationCourse = await certificationCourseRepository.save({ certificationCourse });
 
       // then
-      const retrievedCertificationCourse = await certificationCourseRepository.get({
-        id: savedCertificationCourse.getId(),
-      });
-      expect(retrievedCertificationCourse.getVersion()).to.equal(3);
-      expect(retrievedCertificationCourse.getLanguage()).to.equal('fr');
+      const savedCertifData = await knex('certification-courses')
+        .select('*')
+        .where({ id: savedCertificationCourse.getId() })
+        .first();
+      expect(savedCertifData).to.deep.include(certificationCourseData);
     });
 
     it('should return the saved certification course', async function () {
@@ -45,41 +65,6 @@ describe('Certification | Shared | Integration | Repository | Certification Cour
       // then
       expect(savedCertificationCourse).to.be.an.instanceOf(CertificationCourse);
       expect(savedCertificationCourse.getId()).not.to.be.null;
-    });
-
-    context('when there is a complementary certification', function () {
-      it('should also persist the complementary certification course', async function () {
-        // given
-        const badgeId = databaseBuilder.factory.buildBadge().id;
-        const complementaryCertificationId = databaseBuilder.factory.buildComplementaryCertification({}).id;
-        const complementaryCertificationBadgeId = databaseBuilder.factory.buildComplementaryCertificationBadge({
-          badgeId,
-          complementaryCertificationId,
-        }).id;
-
-        await databaseBuilder.commit();
-
-        certificationCourse = domainBuilder.buildCertificationCourse.unpersisted({
-          userId,
-          sessionId,
-          complementaryCertificationCourse: {
-            complementaryCertificationBadgeId,
-            complementaryCertificationId,
-          },
-          version: 3,
-          lang: 'fr',
-        });
-
-        // when
-        const savedCertificationCourse = await certificationCourseRepository.save({ certificationCourse });
-
-        // then
-        const retrievedCertificationCourse = await certificationCourseRepository.get({
-          id: savedCertificationCourse.getId(),
-        });
-        expect(retrievedCertificationCourse.getVersion()).to.equal(3);
-        expect(retrievedCertificationCourse.getLanguage()).to.equal('fr');
-      });
     });
   });
 

--- a/api/tests/certification/shared/unit/domain/models/CertificationCourse_test.js
+++ b/api/tests/certification/shared/unit/domain/models/CertificationCourse_test.js
@@ -19,7 +19,7 @@ describe('Unit | Domain | Models | CertificationCourse', function () {
       expect(certificationCourse.toDTO().abortReason).to.equal('technical');
     });
 
-    it('should fail if abort reason is unknown', async function () {
+    it('should fail if abort reason is unknown', function () {
       // given
       const certificationCourse = domainBuilder.buildCertificationCourse({
         abortReason: null,

--- a/api/tests/tooling/domain-builder/factory/build-certification-course.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-course.js
@@ -106,6 +106,8 @@ buildCertificationCourse.unpersisted = function ({
   complementaryCertificationCourse = null,
   maxReachableLevelOnCertificationDate = 7,
   lang,
+  versionId = 123,
+  candidateId = 456,
 } = {}) {
   return new CertificationCourse({
     firstName,
@@ -133,6 +135,8 @@ buildCertificationCourse.unpersisted = function ({
     complementaryCertificationCourse,
     maxReachableLevelOnCertificationDate,
     lang,
+    versionId,
+    candidateId,
   });
 };
 

--- a/api/tests/tooling/domain-builder/factory/build-sco-certification-candidate.js
+++ b/api/tests/tooling/domain-builder/factory/build-sco-certification-candidate.js
@@ -1,4 +1,6 @@
+import { Frameworks } from '../../../../src/certification/configuration/domain/models/Frameworks.js';
 import { SCOCertificationCandidate } from '../../../../src/certification/enrolment/domain/models/SCOCertificationCandidate.js';
+import { domainBuilder } from '../domain-builder.js';
 
 const buildSCOCertificationCandidate = function ({
   id = 123,
@@ -9,7 +11,8 @@ const buildSCOCertificationCandidate = function ({
   birthINSEECode = '66001',
   sessionId = 456,
   organizationLearnerId = 789,
-  subscriptions = [],
+  subscriptions = [domainBuilder.certification.enrolment.buildCoreSubscription({ certificationCandidateId: null })],
+  subscription = Frameworks.CORE,
 } = {}) {
   return new SCOCertificationCandidate({
     id,
@@ -21,6 +24,7 @@ const buildSCOCertificationCandidate = function ({
     sessionId,
     organizationLearnerId,
     subscriptions,
+    subscription,
   });
 };
 

--- a/api/tests/tooling/domain-builder/factory/certification/enrolment/build-candidate.js
+++ b/api/tests/tooling/domain-builder/factory/certification/enrolment/build-candidate.js
@@ -1,4 +1,6 @@
+import { Frameworks } from '../../../../../../src/certification/configuration/domain/models/Frameworks.js';
 import { Candidate } from '../../../../../../src/certification/enrolment/domain/models/Candidate.js';
+import { domainBuilder } from '../../../domain-builder.js';
 
 const buildCandidate = function ({
   id = 123,
@@ -55,6 +57,14 @@ const buildCandidate = function ({
     subscriptions,
     accessibilityAdjustmentNeeded,
     subscription,
+  });
+};
+
+buildCandidate.withCoreSubscription = function (args) {
+  return buildCandidate({
+    ...args,
+    subscriptions: [domainBuilder.certification.enrolment.buildCoreSubscription({ certificationCandidateId: null })],
+    subscription: Frameworks.CORE,
   });
 };
 

--- a/api/tests/tooling/domain-builder/factory/certification/enrolment/build-candidate.js
+++ b/api/tests/tooling/domain-builder/factory/certification/enrolment/build-candidate.js
@@ -26,6 +26,7 @@ const buildCandidate = function ({
   hasSeenCertificationInstructions = false,
   subscriptions = [],
   accessibilityAdjustmentNeeded,
+  subscription = null,
 } = {}) {
   return new Candidate({
     id,
@@ -53,6 +54,7 @@ const buildCandidate = function ({
     hasSeenCertificationInstructions,
     subscriptions,
     accessibilityAdjustmentNeeded,
+    subscription,
   });
 };
 


### PR DESCRIPTION
## 🥀 Problème

Nous devons souvent faire toute une série de jointures pour retrouver un candidat (`certificationCandidate`) à partir d'un parcours de certification (`certificationCourse`).
Nous avons besoin d'accéder à la version du parcours de certification. Aujourd'hui, nous recalculons à chaque fois à partir de la date de réconciliation et à la souscription d'un candidat quelle version était active à ce moment-là

## 🏹 Proposition

Enregistrer dans le parcours de certification la référence de la version et du candidat dans la table `certification-courses`

## 💌 Remarques

- [x] :warning: dépends de la ~~PR  #15363~~ ~~PR #15399~~ PR #15401 qui ajoute les colonnes dans cette table

## ❤️‍🔥 Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
