### PR TITLE
[TECH] Supprimer les target-profile-shares lors de la péremption d'un profil-cible (PIX-21606)

### DIFF
--- a/admin/app/components/target-profiles/target-profile.gjs
+++ b/admin/app/components/target-profiles/target-profile.gjs
@@ -105,6 +105,9 @@ export default class TargetProfile extends Component {
     try {
       await adapter.outdate(this.args.model.id);
       this.args.model.reload();
+      if (this.router.currentRouteName.startsWith('authenticated.target-profiles.target-profile.organizations')) {
+        this.router.refresh('authenticated.target-profiles.target-profile.organizations');
+      }
       return this.pixToast.sendSuccessNotification({ message: 'Profil cible marqué comme obsolète.' });
     } catch (responseError) {
       this._handleResponseError(responseError);

--- a/api/src/prescription/target-profile/domain/usecases/outdate-target-profile.js
+++ b/api/src/prescription/target-profile/domain/usecases/outdate-target-profile.js
@@ -1,4 +1,9 @@
-const outdateTargetProfile = async function ({ id, targetProfileAdministrationRepository }) {
+const outdateTargetProfile = async function ({
+  id,
+  targetProfileAdministrationRepository,
+  targetProfileBondRepository,
+}) {
+  await targetProfileBondRepository.deleteByTargetProfileId(id);
   await targetProfileAdministrationRepository.update({ id, outdated: true });
 };
 

--- a/api/src/prescription/target-profile/infrastructure/repositories/target-profile-bond-repository.js
+++ b/api/src/prescription/target-profile/infrastructure/repositories/target-profile-bond-repository.js
@@ -11,4 +11,9 @@ const update = async function (targetProfile) {
   return results.map(({ organizationId }) => organizationId);
 };
 
-export { update };
+const deleteByTargetProfileId = async function (targetProfileId) {
+  const knexConn = DomainTransaction.getConnection();
+  await knexConn('target-profile-shares').where({ targetProfileId }).del();
+};
+
+export { deleteByTargetProfileId, update };

--- a/api/tests/prescription/target-profile/integration/infrastructure/repositories/target-profile-bond-repository_test.js
+++ b/api/tests/prescription/target-profile/integration/infrastructure/repositories/target-profile-bond-repository_test.js
@@ -1,5 +1,5 @@
 import { knex } from '../../../../../../db/knex-database-connection.js';
-import * as targetProfileRepository from '../../../../../../src/prescription/target-profile/infrastructure/repositories/target-profile-bond-repository.js';
+import * as targetProfileBondRepository from '../../../../../../src/prescription/target-profile/infrastructure/repositories/target-profile-bond-repository.js';
 import { databaseBuilder, expect } from '../../../../../test-helper.js';
 
 describe('Integration | Repository | Target Profile Management | Target Profile ', function () {
@@ -20,7 +20,7 @@ describe('Integration | Repository | Target Profile Management | Target Profile 
       };
 
       // when
-      await targetProfileRepository.update(targetProfile);
+      await targetProfileBondRepository.update(targetProfile);
 
       // then
       const result = await knex
@@ -49,7 +49,7 @@ describe('Integration | Repository | Target Profile Management | Target Profile 
       };
 
       // when
-      await targetProfileRepository.update(targetProfile);
+      await targetProfileBondRepository.update(targetProfile);
 
       // then
       const result = await knex
@@ -77,10 +77,38 @@ describe('Integration | Repository | Target Profile Management | Target Profile 
       };
 
       // when
-      const result = await targetProfileRepository.update(targetProfile);
+      const result = await targetProfileBondRepository.update(targetProfile);
 
       // then
       expect(result).to.deepEqualArray([organizationId, otherOrganizationId]);
+    });
+  });
+
+  describe('#deleteByTargetProfileId', function () {
+    it('should delete all target profile shares for the given target profile', async function () {
+      // given
+      const firstOrganizationId = databaseBuilder.factory.buildOrganization().id;
+      const secondOrganizationId = databaseBuilder.factory.buildOrganization().id;
+      const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+      const otherTargetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+      databaseBuilder.factory.buildTargetProfileShare({ targetProfileId, organizationId: firstOrganizationId });
+      databaseBuilder.factory.buildTargetProfileShare({ targetProfileId, organizationId: secondOrganizationId });
+      databaseBuilder.factory.buildTargetProfileShare({
+        targetProfileId: otherTargetProfileId,
+        organizationId: firstOrganizationId,
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      await targetProfileBondRepository.deleteByTargetProfileId(targetProfileId);
+
+      // then
+      const deletedShares = await knex('target-profile-shares').where({ targetProfileId });
+      expect(deletedShares).to.have.lengthOf(0);
+
+      const otherShares = await knex('target-profile-shares').where({ targetProfileId: otherTargetProfileId });
+      expect(otherShares).to.have.lengthOf(1);
     });
   });
 });

--- a/api/tests/prescription/target-profile/unit/domain/usecases/outdate-target-profile_test.js
+++ b/api/tests/prescription/target-profile/unit/domain/usecases/outdate-target-profile_test.js
@@ -4,16 +4,20 @@ import { expect, sinon } from '../../../../../test-helper.js';
 const { outdateTargetProfile } = usecases;
 
 describe('Unit | Target Profile | Domain | UseCase | outdate-target-profile', function () {
-  it('should call repository method to update a target profile name', async function () {
+  it('should delete target profile shares and mark the target profile as outdated', async function () {
     //given
     const targetProfileAdministrationRepository = {
       update: sinon.stub(),
     };
+    const targetProfileBondRepository = {
+      deleteByTargetProfileId: sinon.stub(),
+    };
 
     //when
-    await outdateTargetProfile({ id: 123, outdated: true, targetProfileAdministrationRepository });
+    await outdateTargetProfile({ id: 123, targetProfileAdministrationRepository, targetProfileBondRepository });
 
     //then
+    expect(targetProfileBondRepository.deleteByTargetProfileId).to.have.been.calledOnceWithExactly(123);
     expect(targetProfileAdministrationRepository.update).to.have.been.calledOnceWithExactly({
       id: 123,
       outdated: true,


### PR DESCRIPTION
## 🥀 Problème

Lors de la péremption d'un profil-cible, les `target-profile-shares` associés n'étaient pas supprimés.

## 🏹 Proposition

- Ajout de la méthode `deleteByTargetProfileId` dans `target-profile-bond-repository`
- Modification du use case `outdate-target-profile` pour supprimer les shares avant de marquer le profil comme obsolète

## 💌 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## ❤️‍🔥 Pour tester

### Sur admin

- Partager un profil-cible avec au moins une organisation
- Marquer le profil-cible comme obsolète
- Vérifier que les organisations n’apparaissent plus dans l'onglet sur l'admin

### En DB

- Vérifier que les `target-profile-shares` ont bien été supprimés en base de données