### PR TITLE
[TECH] Éviter un test d'intégration certif flaky

### DIFF
--- a/certif/tests/integration/components/issue-report-modal/in-challenge-certification-issue-report-fields-test.js
+++ b/certif/tests/integration/components/issue-report-modal/in-challenge-certification-issue-report-fields-test.js
@@ -156,14 +156,15 @@ module('Integration | Component | in-challenge-certification-issue-report-fields
     );
 
     // then
+    const subcategorySelect = screen.getByRole('button', {
+      name: t('pages.session-finalization.add-issue-modal.actions.select-subcategory'),
+    });
     assert
-      .dom(
-        screen.getByRole('option', {
-          name: `${subcategoryToCode[certificationIssueReportSubcategories.FILE_NOT_OPENING]} ${t(
-            subcategoryToLabel[certificationIssueReportSubcategories.FILE_NOT_OPENING],
-          )}`,
-        }),
-      )
-      .exists();
+      .dom(subcategorySelect)
+      .includesText(
+        `${subcategoryToCode[certificationIssueReportSubcategories.FILE_NOT_OPENING]} ${t(
+          subcategoryToLabel[certificationIssueReportSubcategories.FILE_NOT_OPENING],
+        )}`,
+      );
   });
 });


### PR DESCRIPTION
## 🥀 Problème

La CI nous a donné un [test flaky](https://app.circleci.com/pipelines/github/1024pix/pix/161356/workflows/d4a8e91e-83bc-428a-9b5d-0c4bbaace7d7/jobs/1821742/tests) côté certif.

## 🏹 Proposition

Modifier le test concerné pour éviter ça.

## 💌 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## ❤️‍🔥 Pour tester

✅ Tests ok
