### PR TITLE
[BUGFIX] Les QCM n'affichent plus les status success/error lorsqu'on envoie sa réponse (PIX-21806).

### DIFF
--- a/mon-pix/app/components/module/element/qcm.gjs
+++ b/mon-pix/app/components/module/element/qcm.gjs
@@ -65,7 +65,7 @@ export default class ModuleQcm extends ModuleElement {
 
   @action
   getProposalState(proposalId) {
-    if (!this.selectedAnswerIds.has(proposalId)) {
+    if (!this.correction || !this.selectedAnswerIds.has(proposalId)) {
       return 'neutral';
     }
 


### PR DESCRIPTION
## 🥀 Problème

Le métier a observé que les QCM n'avaient plus de changement d'état lorsqu'on validait la réponse.
<img width="842" height="398" alt="image-20260303-105725" src="https://github.com/user-attachments/assets/a6bde8db-8de3-49ea-8916-d8c43475d2cc" />


## 🏹 Proposition

Corriger cela

## 💌 Remarques

Pourquoi cet ajout de this.correction dans la condition ?

Cette vérification était déjà présente dans l'action et à été supprimé lors de la montée de version de Pix UI. Elle a été supprimé car elle retournait `null`, alors que nous avons besoin d'avoir un des 3 états attendu par Pix UI : neutral, success et error.
Lors des tests, les couleurs s'affichaient correctement, nous pensions que cette condition n'était plus pertinente mais elle est importante en réalité car this.correction permet une réactivité de l'action et lorsqu'on répond à la question, c'est grâce à lui qu'on re-parcours l'action pour appliquer le bon statut.

Ne souhaitant pas faire de test pour checker des couleurs (ou du css) il n'y a pas de test ajouté ici.

## ❤️‍🔥 Pour tester
Aller sur [bac-a-sable](https://app-pr15373.review.pix.fr/modules/6a68bf32/bac-a-sable/details)
Aller sur un QCM et jouer avec
Voir que les états des champs sont bons, lorsqu'on clique dessus, qu'on envoit la réponse, qu'on réessaye, qu'on valide qu'un choix et qu'on répond etc...
