### PR TITLE
[TECH] Ajoute un script permettant de retro-remplir les nouvelles colonnes des certifications et des candidats (PIX-21825)

### DIFF
--- a/api/db/database-builder/factory/build-complementary-certification.js
+++ b/api/db/database-builder/factory/build-complementary-certification.js
@@ -52,7 +52,7 @@ buildComplementaryCertification.droit = function ({
   minimumReproducibilityRateLowerLevel = 60,
   hasExternalJury = false,
   certificationExtraTime = 45,
-}) {
+} = {}) {
   return buildComplementaryCertification({
     id,
     label: 'Pix+ Droit',

--- a/api/scripts/certification/fill-new-columns-in-certification-courses-and-candidates-tables.js
+++ b/api/scripts/certification/fill-new-columns-in-certification-courses-and-candidates-tables.js
@@ -35,7 +35,7 @@ export class FillNewColumnsInCertificationCoursesAndCandidatesTables extends Scr
   async handle({ logger, options }) {
     const { dryRun, startId, chunkSize } = options;
     logger.info('Script execution started');
-    const certificationFrameworkVersions = await getScoringConfigurations();
+    const certificationFrameworkVersions = await getVersions();
 
     let currentStartId = startId;
     let certificationsData = await selectCertificationsToProcess(currentStartId, chunkSize);
@@ -77,7 +77,7 @@ export class FillNewColumnsInCertificationCoursesAndCandidatesTables extends Scr
   }
 }
 
-async function getScoringConfigurations() {
+async function getVersions() {
   const versionsData = await knex('certification_versions')
     .select('id', 'startDate', 'expirationDate', 'scope')
     .orderByRaw('"expirationDate" ASC NULLS LAST');
@@ -103,7 +103,12 @@ async function selectCertificationsToProcess(startId, chunkSize) {
       certificationCourseVersion: 'certification-courses.version',
       candidateId: 'certification-candidates.id',
       reconciledAt: 'certification-candidates.reconciledAt',
-      subscriptionKey: 'complementary-certifications.key',
+      subscriptionKeys: knex.raw(
+        `json_agg(
+          "complementary-certifications"."key"
+          ORDER BY "complementary-certifications".key NULLS LAST
+        )`,
+      ),
     })
     .from('certification-courses')
     .join('certification-candidates', function () {
@@ -123,6 +128,7 @@ async function selectCertificationsToProcess(startId, chunkSize) {
     )
     .where('certification-courses.id', '>=', startId)
     .where('certification-courses.version', 3)
+    .groupBy('certification-courses.id', 'certification-candidates.id')
     .orderBy('certification-courses.id', 'asc')
     .limit(chunkSize);
 }
@@ -138,12 +144,12 @@ async function processCertifications(certificationsData, certificationFrameworkV
     try {
       latestCertificationIdProcessed = certificationData.certificationCourseId;
 
-      const subscription = !certificationData.subscriptionKey ? Frameworks.CORE : certificationData.subscriptionKey;
+      const subscription = certificationData.subscriptionKeys[0] || Frameworks.CORE;
       const cerficationCandidateData = { id: certificationData.candidateId, subscription };
       certificationCandidatesToUpdate.push(cerficationCandidateData);
 
       const scope = subscription == Frameworks.CLEA ? Frameworks.CORE : subscription;
-      const versionId = findCorrespondingScoringConfigurationId(
+      const versionId = findCorrespondingVersionId(
         certificationFrameworkVersions,
         certificationData.reconciledAt,
         scope,
@@ -160,13 +166,13 @@ async function processCertifications(certificationsData, certificationFrameworkV
     }
   }
   return {
-    certificationCoursesToUpdate: certificationCoursesToUpdate.filter((ar) => !!ar),
-    certificationCandidatesToUpdate: certificationCandidatesToUpdate.filter((ar) => !!ar),
+    certificationCoursesToUpdate: certificationCoursesToUpdate.filter((cco) => !!cco),
+    certificationCandidatesToUpdate: certificationCandidatesToUpdate.filter((cca) => !!cca),
     latestCertificationIdProcessed,
   };
 }
 
-function findCorrespondingScoringConfigurationId(v3CertificationFrameworkVersions, reconciledAt, scope) {
+function findCorrespondingVersionId(v3CertificationFrameworkVersions, reconciledAt, scope) {
   for (const v3CertificationFrameworkVersion of v3CertificationFrameworkVersions) {
     if (
       scope == v3CertificationFrameworkVersion.scope &&
@@ -178,7 +184,7 @@ function findCorrespondingScoringConfigurationId(v3CertificationFrameworkVersion
     }
   }
 
-  throw new Error(`No Certification Scoring found for ${reconciledAt} date.`);
+  throw new Error(`No Version found for ${reconciledAt} date.`);
 }
 
 await ScriptRunner.execute(import.meta.url, FillNewColumnsInCertificationCoursesAndCandidatesTables);

--- a/api/scripts/certification/fill-new-columns-in-certification-courses-and-candidates-tables.js
+++ b/api/scripts/certification/fill-new-columns-in-certification-courses-and-candidates-tables.js
@@ -1,0 +1,184 @@
+import { knex } from '../../db/knex-database-connection.js';
+import { Frameworks } from '../../src/certification/configuration/domain/models/Frameworks.js';
+import { Script } from '../../src/shared/application/scripts/script.js';
+import { ScriptRunner } from '../../src/shared/application/scripts/script-runner.js';
+import { DomainTransaction } from '../../src/shared/domain/DomainTransaction.js';
+import { batchUpdate } from '../../src/shared/infrastructure/utils/knex-utils.js';
+
+export class FillNewColumnsInCertificationCoursesAndCandidatesTables extends Script {
+  constructor() {
+    super({
+      description:
+        'CandidateId and versionId are two new columns recently added in certification-courses table, and subscription have been added to certification-candidate table. This script fills those columns',
+      permanent: false,
+      options: {
+        dryRun: {
+          type: 'boolean',
+          describe: 'Run the script without making any database changes',
+          default: true,
+        },
+        startId: {
+          type: 'number',
+          describe: 'Define the id of the certification-courses from which we start doing the process',
+          default: 5906059,
+        },
+        chunkSize: {
+          type: 'number',
+          describe:
+            'Define the number of certifications processed in a chunk (chunks determined how many certifications are updated and committed at the same time)',
+          default: 1000,
+        },
+      },
+    });
+  }
+
+  async handle({ logger, options }) {
+    const { dryRun, startId, chunkSize } = options;
+    logger.info('Script execution started');
+    const certificationFrameworkVersions = await getScoringConfigurations();
+
+    let currentStartId = startId;
+    let certificationsData = await selectCertificationsToProcess(currentStartId, chunkSize);
+    while (certificationsData.length > 0) {
+      const { certificationCoursesToUpdate, certificationCandidatesToUpdate, latestCertificationIdProcessed } =
+        await processCertifications(certificationsData, certificationFrameworkVersions, logger);
+
+      await DomainTransaction.execute(async () => {
+        const trx = DomainTransaction.getConnection();
+        try {
+          await batchUpdate({
+            tableName: 'certification-courses',
+            primaryKeyName: 'id',
+            rows: certificationCoursesToUpdate,
+          });
+          await batchUpdate({
+            tableName: 'certification-candidates',
+            primaryKeyName: 'id',
+            rows: certificationCandidatesToUpdate,
+          });
+
+          logger.info(`Certifications up until ID ${latestCertificationIdProcessed} DONE`);
+          if (dryRun) {
+            await trx.rollback();
+          } else {
+            await trx.commit();
+          }
+        } catch (error) {
+          await trx.rollback();
+          throw error;
+        }
+      });
+
+      currentStartId = latestCertificationIdProcessed + 1;
+      certificationsData = await selectCertificationsToProcess(currentStartId, chunkSize);
+    }
+
+    logger.info('No more certifications to process youpi');
+  }
+}
+
+async function getScoringConfigurations() {
+  const versionsData = await knex('certification_versions')
+    .select('id', 'startDate', 'expirationDate', 'scope')
+    .orderByRaw('"expirationDate" ASC NULLS LAST');
+
+  const v3CertificationFrameworkVersion = [];
+  for (const versionData of versionsData) {
+    const data = {
+      id: versionData.id,
+      startDate: versionData.startDate,
+      expirationDate: versionData.expirationDate,
+      scope: versionData.scope,
+    };
+    v3CertificationFrameworkVersion.push(data);
+  }
+
+  return v3CertificationFrameworkVersion;
+}
+
+async function selectCertificationsToProcess(startId, chunkSize) {
+  return await knex
+    .select({
+      certificationCourseId: 'certification-courses.id',
+      certificationCourseVersion: 'certification-courses.version',
+      candidateId: 'certification-candidates.id',
+      reconciledAt: 'certification-candidates.reconciledAt',
+      subscriptionKey: 'complementary-certifications.key',
+    })
+    .from('certification-courses')
+    .join('certification-candidates', function () {
+      this.on({ 'certification-candidates.sessionId': 'certification-courses.sessionId' }).andOn({
+        'certification-candidates.userId': 'certification-courses.userId',
+      });
+    })
+    .leftJoin(
+      'certification-subscriptions',
+      'certification-subscriptions.certificationCandidateId',
+      'certification-candidates.id',
+    )
+    .leftJoin(
+      'complementary-certifications',
+      'complementary-certifications.id',
+      'certification-subscriptions.complementaryCertificationId',
+    )
+    .where('certification-courses.id', '>=', startId)
+    .where('certification-courses.version', 3)
+    .orderBy('certification-courses.id', 'asc')
+    .limit(chunkSize);
+}
+
+async function processCertifications(certificationsData, certificationFrameworkVersions, logger) {
+  let latestCertificationIdProcessed;
+  const certificationCoursesToUpdate = [];
+  const certificationCandidatesToUpdate = [];
+  logger.info(
+    `Processing certification from ${certificationsData[0].certificationCourseId} to ${certificationsData.at(-1).certificationCourseId}...`,
+  );
+  for (const certificationData of certificationsData) {
+    try {
+      latestCertificationIdProcessed = certificationData.certificationCourseId;
+
+      const subscription = !certificationData.subscriptionKey ? Frameworks.CORE : certificationData.subscriptionKey;
+      const cerficationCandidateData = { id: certificationData.candidateId, subscription };
+      certificationCandidatesToUpdate.push(cerficationCandidateData);
+
+      const scope = subscription == Frameworks.CLEA ? Frameworks.CORE : subscription;
+      const versionId = findCorrespondingScoringConfigurationId(
+        certificationFrameworkVersions,
+        certificationData.reconciledAt,
+        scope,
+      );
+      const certificationCourseData = {
+        id: certificationData.certificationCourseId,
+        candidateId: certificationData.candidateId,
+        versionId,
+      };
+      certificationCoursesToUpdate.push(certificationCourseData);
+    } catch (error) {
+      logger.error(error, `Certification ID ${latestCertificationIdProcessed} encountered an error`);
+      throw error;
+    }
+  }
+  return {
+    certificationCoursesToUpdate: certificationCoursesToUpdate.filter((ar) => !!ar),
+    certificationCandidatesToUpdate: certificationCandidatesToUpdate.filter((ar) => !!ar),
+    latestCertificationIdProcessed,
+  };
+}
+
+function findCorrespondingScoringConfigurationId(v3CertificationFrameworkVersions, reconciledAt, scope) {
+  for (const v3CertificationFrameworkVersion of v3CertificationFrameworkVersions) {
+    if (
+      scope == v3CertificationFrameworkVersion.scope &&
+      reconciledAt >= v3CertificationFrameworkVersion.startDate &&
+      (v3CertificationFrameworkVersion.expirationDate === null ||
+        reconciledAt < v3CertificationFrameworkVersion.expirationDate)
+    ) {
+      return v3CertificationFrameworkVersion.id;
+    }
+  }
+
+  throw new Error(`No Certification Scoring found for ${reconciledAt} date.`);
+}
+
+await ScriptRunner.execute(import.meta.url, FillNewColumnsInCertificationCoursesAndCandidatesTables);

--- a/api/scripts/certification/fill-new-columns-in-certification-courses-and-candidates-tables.js
+++ b/api/scripts/certification/fill-new-columns-in-certification-courses-and-candidates-tables.js
@@ -128,6 +128,7 @@ async function selectCertificationsToProcess(startId, chunkSize) {
     )
     .where('certification-courses.id', '>=', startId)
     .where('certification-courses.version', 3)
+    .where('certification-courses.versionId', null)
     .groupBy('certification-courses.id', 'certification-candidates.id')
     .orderBy('certification-courses.id', 'asc')
     .limit(chunkSize);

--- a/api/tests/certification/scripts/integration/fill-new-columns-in-certification-courses-and-candidates-tables_test.js
+++ b/api/tests/certification/scripts/integration/fill-new-columns-in-certification-courses-and-candidates-tables_test.js
@@ -91,12 +91,20 @@ describe('Integration | Certification | Scripts | Fill new columns in certificat
 
     _createCertificationCourses({
       reconciledAt: reconciledAtArchivedVersion,
-      subscriptionIds: [null, droitComplementaryCertificationId, cleaComplementaryCertificationId],
+      subscriptions: [
+        { frameworkType: Frameworks.CORE, id: null },
+        { frameworkType: Frameworks.DROIT, id: droitComplementaryCertificationId },
+        { frameworkType: Frameworks.CLEA, id: cleaComplementaryCertificationId },
+      ],
       candidateIds,
     });
     _createCertificationCourses({
       reconciledAt: reconciledAtCurrentVersion,
-      subscriptionIds: [null, droitComplementaryCertificationId, cleaComplementaryCertificationId],
+      subscriptions: [
+        { frameworkType: Frameworks.CORE, id: null },
+        { frameworkType: Frameworks.DROIT, id: droitComplementaryCertificationId },
+        { frameworkType: Frameworks.CLEA, id: cleaComplementaryCertificationId },
+      ],
       candidateIds,
     });
 
@@ -161,7 +169,12 @@ describe('Integration | Certification | Scripts | Fill new columns in certificat
 
     _createCertificationCourses({
       reconciledAt,
-      subscriptionIds: [null, null, null, null],
+      subscriptions: [
+        { frameworkType: Frameworks.CORE, id: null },
+        { frameworkType: Frameworks.CORE, id: null },
+        { frameworkType: Frameworks.CORE, id: null },
+        { frameworkType: Frameworks.CORE, id: null },
+      ],
       certificationCourseIds,
     });
     await databaseBuilder.commit();
@@ -199,12 +212,16 @@ describe('Integration | Certification | Scripts | Fill new columns in certificat
 
     _createCertificationCourses({
       reconciledAt: reconciledAtArchivedVersion,
-      subscriptionIds: [null, null, null],
+      subscriptions: [
+        { frameworkType: Frameworks.CORE, id: null },
+        { frameworkType: Frameworks.CORE, id: null },
+        { frameworkType: Frameworks.CORE, id: null },
+      ],
       certificationCourseIds,
     });
     _createCertificationCourses({
       reconciledAt: reconciledAtNonExistingVersion,
-      subscriptionIds: [null],
+      subscriptions: [{ frameworkType: Frameworks.CORE, id: null }],
       certificationCourseIds,
     });
 
@@ -236,10 +253,7 @@ describe('Integration | Certification | Scripts | Fill new columns in certificat
       `Processing certification from ${certificationCourseIds[2]} to ${certificationCourseIds[3]}...`,
     );
     expect(err).to.be.instanceOf(Error);
-    expect(err).to.have.property(
-      'message',
-      `No Certification Scoring found for ${reconciledAtNonExistingVersion} date.`,
-    );
+    expect(err).to.have.property('message', `No Version found for ${reconciledAtNonExistingVersion} date.`);
     expect(logger.error).to.have.been.calledWithExactly(
       err,
       `Certification ID ${certificationCourseIds[3]} encountered an error`,
@@ -247,15 +261,10 @@ describe('Integration | Certification | Scripts | Fill new columns in certificat
   });
 });
 
-function _createCertificationCourses({
-  reconciledAt,
-  subscriptionIds,
-  candidateIds = [],
-  certificationCourseIds = [],
-}) {
+function _createCertificationCourses({ reconciledAt, subscriptions, candidateIds = [], certificationCourseIds = [] }) {
   const sessionId = databaseBuilder.factory.buildSession().id;
 
-  for (const subscriptionId of subscriptionIds) {
+  for (const subscription of subscriptions) {
     const userId = databaseBuilder.factory.buildUser().id;
     const candidateId = databaseBuilder.factory.buildCertificationCandidate({
       sessionId,
@@ -269,10 +278,15 @@ function _createCertificationCourses({
       version: AlgorithmEngineVersion.V3,
     }).id;
 
-    if (subscriptionId) {
+    if (subscription.frameworkType == Frameworks.CORE || subscription.frameworkType == Frameworks.CLEA) {
+      databaseBuilder.factory.buildCoreSubscription({
+        certificationCandidateId: candidateId,
+      });
+    }
+    if (subscription.frameworkType != Frameworks.CORE) {
       databaseBuilder.factory.buildComplementaryCertificationSubscription({
         certificationCandidateId: candidateId,
-        complementaryCertificationId: subscriptionId,
+        complementaryCertificationId: subscription.id,
       });
     }
 

--- a/api/tests/certification/scripts/integration/fill-new-columns-in-certification-courses-and-candidates-tables_test.js
+++ b/api/tests/certification/scripts/integration/fill-new-columns-in-certification-courses-and-candidates-tables_test.js
@@ -155,6 +155,52 @@ describe('Integration | Certification | Scripts | Fill new columns in certificat
     }
   });
 
+  it('should not update certification courses and candidates that already have the informations', async function () {
+    const versionId = databaseBuilder.factory.buildCertificationVersion({
+      startDate: new Date('2026-01-01'),
+      expirationDate: null,
+      scope: SCOPES.CORE,
+    }).id;
+
+    const sessionId = databaseBuilder.factory.buildSession().id;
+
+    const userId = databaseBuilder.factory.buildUser().id;
+    const candidateId = databaseBuilder.factory.buildCertificationCandidate({
+      sessionId,
+      reconciledAt: new Date(),
+      userId,
+    }).id;
+
+    const certificationCoursesId = databaseBuilder.factory.buildCertificationCourse({
+      sessionId,
+      userId,
+      version: AlgorithmEngineVersion.V3,
+      versionId: versionId,
+      candidateId,
+    }).id;
+
+    databaseBuilder.factory.buildCoreSubscription({
+      certificationCandidateId: candidateId,
+    });
+
+    await databaseBuilder.commit();
+
+    const certificationCourseDataBefore = await knex('certification-courses').first();
+    expect(certificationCourseDataBefore.versionId).to.equal(versionId);
+    expect(certificationCourseDataBefore.candidateId).to.equal(candidateId);
+
+    await script.handle({
+      options: { dryRun: false, startId: certificationCoursesId, chunkSize: 2 },
+      logger,
+    });
+
+    const certificationCourseDataAfter = await knex('certification-courses').first();
+    expect(certificationCourseDataAfter.versionId).to.equal(versionId);
+    expect(certificationCourseDataAfter.candidateId).to.equal(candidateId);
+    expect(logger.info.getCall(0)).to.have.been.calledWithExactly('Script execution started');
+    expect(logger.info.getCall(1)).to.have.been.calledWithExactly('No more certifications to process youpi');
+  });
+
   it('should provide appropriate logger informations', async function () {
     const startDateCurrentVersion = new Date('2026-01-01');
     const expirationDateCurrentVersion = null;

--- a/api/tests/certification/scripts/integration/fill-new-columns-in-certification-courses-and-candidates-tables_test.js
+++ b/api/tests/certification/scripts/integration/fill-new-columns-in-certification-courses-and-candidates-tables_test.js
@@ -1,0 +1,282 @@
+import { FillNewColumnsInCertificationCoursesAndCandidatesTables } from '../../../../scripts/certification/fill-new-columns-in-certification-courses-and-candidates-tables.js';
+import { Frameworks } from '../../../../src/certification/configuration/domain/models/Frameworks.js';
+import { AlgorithmEngineVersion } from '../../../../src/certification/shared/domain/models/AlgorithmEngineVersion.js';
+import { SCOPES } from '../../../../src/certification/shared/domain/models/Scopes.js';
+import { catchErr, databaseBuilder, expect, knex, sinon } from '../../../test-helper.js';
+
+describe('Integration | Certification | Scripts | Fill new columns in certification courses and candidate tables', function () {
+  let logger, script;
+
+  beforeEach(async function () {
+    logger = { info: sinon.stub(), error: sinon.stub() };
+    script = new FillNewColumnsInCertificationCoursesAndCandidatesTables();
+  });
+
+  it('should not commit if dryRun', async function () {
+    const startDate = new Date('2025-10-01');
+    const reconciledAt = new Date('2026-01-01');
+
+    const expirationDate = null;
+
+    databaseBuilder.factory.buildCertificationVersion({
+      startDate,
+      expirationDate,
+    }).id;
+
+    const sessionId = databaseBuilder.factory.buildSession().id;
+    const userId = databaseBuilder.factory.buildUser().id;
+    databaseBuilder.factory.buildCertificationCandidate({
+      sessionId,
+      reconciledAt: reconciledAt,
+      userId,
+    }).id;
+    const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
+      sessionId,
+      userId,
+      version: AlgorithmEngineVersion.V3,
+    }).id;
+
+    await databaseBuilder.commit();
+
+    const certificationCourseDataBefore = await knex('certification-courses').first();
+    expect(certificationCourseDataBefore.versionId).to.be.null;
+    expect(certificationCourseDataBefore.candidateId).to.be.null;
+    const certificationCandidateDataBefore = await knex('certification-candidates').first();
+    expect(certificationCandidateDataBefore.subscription).to.be.null;
+
+    await script.handle({ options: { dryRun: true, startId: certificationCourseId, chunkSize: 1 }, logger });
+
+    const certificationCourseDataAfter = await knex('certification-courses').first();
+    const certificationCandidateDataAfter = await knex('certification-candidates').first();
+    expect(certificationCourseDataAfter.versionId).to.be.null;
+    expect(certificationCourseDataAfter.candidateId).to.be.null;
+    expect(certificationCandidateDataAfter.subscription).to.be.null;
+  });
+
+  it('should fill candidateId and versionid in certification courses and subscription in certification candidate', async function () {
+    const startDateArchivedVersion = new Date('2025-01-01');
+    const expirationDateArchivedVersion = new Date('2026-01-01');
+    const startDateCurrentVersion = expirationDateArchivedVersion;
+    const expirationDateCurrentVersion = null;
+    const reconciledAtArchivedVersion = new Date('2025-07-01');
+    const reconciledAtCurrentVersion = new Date('2026-02-01');
+    const candidateIds = [];
+
+    const droitComplementaryCertificationId = databaseBuilder.factory.buildComplementaryCertification.droit().id;
+    const cleaComplementaryCertificationId = databaseBuilder.factory.buildComplementaryCertification.clea().id;
+
+    const coreVersionArchivedId = databaseBuilder.factory.buildCertificationVersion({
+      startDate: startDateArchivedVersion,
+      expirationDate: expirationDateArchivedVersion,
+      scope: SCOPES.CORE,
+    }).id;
+
+    const droitVersionArchivedId = databaseBuilder.factory.buildCertificationVersion({
+      startDate: startDateArchivedVersion,
+      expirationDate: expirationDateArchivedVersion,
+      scope: SCOPES.PIX_PLUS_DROIT,
+    }).id;
+
+    const coreVersionCurrentId = databaseBuilder.factory.buildCertificationVersion({
+      startDate: startDateCurrentVersion,
+      expirationDate: expirationDateCurrentVersion,
+      scope: SCOPES.CORE,
+    }).id;
+
+    const droitVersionCurrentId = databaseBuilder.factory.buildCertificationVersion({
+      startDate: startDateCurrentVersion,
+      expirationDate: expirationDateCurrentVersion,
+      scope: SCOPES.PIX_PLUS_DROIT,
+    }).id;
+
+    _createCertificationCourses({
+      reconciledAt: reconciledAtArchivedVersion,
+      subscriptionIds: [null, droitComplementaryCertificationId, cleaComplementaryCertificationId],
+      candidateIds,
+    });
+    _createCertificationCourses({
+      reconciledAt: reconciledAtCurrentVersion,
+      subscriptionIds: [null, droitComplementaryCertificationId, cleaComplementaryCertificationId],
+      candidateIds,
+    });
+
+    await databaseBuilder.commit();
+
+    const certificationCourseDataBefore = await knex('certification-courses').orderBy('id');
+    expect(certificationCourseDataBefore.length).to.equal(6);
+    const certificationCandidateDataBefore = await knex('certification-candidates').orderBy('id');
+    expect(certificationCandidateDataBefore.length).to.equal(6);
+    for (let i = 0; i < 6; i++) {
+      expect(certificationCourseDataBefore[i].versionId).to.be.null;
+      expect(certificationCourseDataBefore[i].candidateId).to.be.null;
+      expect(certificationCandidateDataBefore[i].subscription).to.be.null;
+    }
+
+    const expectedVersionIds = [
+      coreVersionArchivedId,
+      droitVersionArchivedId,
+      coreVersionArchivedId,
+      coreVersionCurrentId,
+      droitVersionCurrentId,
+      coreVersionCurrentId,
+    ];
+    const expectedSubscriptions = [
+      Frameworks.CORE,
+      Frameworks.DROIT,
+      Frameworks.CLEA,
+      Frameworks.CORE,
+      Frameworks.DROIT,
+      Frameworks.CLEA,
+    ];
+
+    await script.handle({
+      options: { dryRun: false, startId: certificationCourseDataBefore[0].id, chunkSize: 2 },
+      logger,
+    });
+
+    const certificationCourseDataAfter = await knex('certification-courses').orderBy('id');
+    const certificationCandidateDataAfter = await knex('certification-candidates').orderBy('id');
+
+    expect(certificationCourseDataAfter.length).to.equal(6);
+    expect(certificationCandidateDataAfter.length).to.equal(6);
+
+    for (let i = 0; i < 6; i++) {
+      expect(certificationCourseDataAfter[i].versionId).to.equal(expectedVersionIds[i]);
+      expect(certificationCourseDataAfter[i].candidateId).to.equal(candidateIds[i]);
+      expect(certificationCandidateDataAfter[i].subscription).to.equal(expectedSubscriptions[i]);
+    }
+  });
+
+  it('should provide appropriate logger informations', async function () {
+    const startDateCurrentVersion = new Date('2026-01-01');
+    const expirationDateCurrentVersion = null;
+    const reconciledAt = new Date('2026-02-01');
+    const certificationCourseIds = [];
+
+    databaseBuilder.factory.buildCertificationVersion({
+      startDate: startDateCurrentVersion,
+      expirationDate: expirationDateCurrentVersion,
+      scope: SCOPES.CORE,
+    }).id;
+
+    _createCertificationCourses({
+      reconciledAt,
+      subscriptionIds: [null, null, null, null],
+      certificationCourseIds,
+    });
+    await databaseBuilder.commit();
+
+    await script.handle({ options: { dryRun: false, startId: certificationCourseIds[0], chunkSize: 2 }, logger });
+
+    expect(logger.info.getCall(0)).to.have.been.calledWithExactly('Script execution started');
+    expect(logger.info.getCall(1)).to.have.been.calledWithExactly(
+      `Processing certification from ${certificationCourseIds[0]} to ${certificationCourseIds[1]}...`,
+    );
+    expect(logger.info.getCall(2)).to.have.been.calledWithExactly(
+      `Certifications up until ID ${certificationCourseIds[1]} DONE`,
+    );
+    expect(logger.info.getCall(3)).to.have.been.calledWithExactly(
+      `Processing certification from ${certificationCourseIds[2]} to ${certificationCourseIds[3]}...`,
+    );
+    expect(logger.info.getCall(4)).to.have.been.calledWithExactly(
+      `Certifications up until ID ${certificationCourseIds[3]} DONE`,
+    );
+    expect(logger.info.getCall(5)).to.have.been.calledWithExactly('No more certifications to process youpi');
+  });
+
+  it('should throw an error when no matching version to reconciledAt date is found, and rollback chunk', async function () {
+    const startDateArchivedVersion = new Date('2025-01-01');
+    const expirationDateArchivedVersion = new Date('2026-01-01');
+    const reconciledAtArchivedVersion = new Date('2025-07-01');
+    const reconciledAtNonExistingVersion = new Date('2026-02-01');
+    const certificationCourseIds = [];
+
+    const coreVersionArchivedId = databaseBuilder.factory.buildCertificationVersion({
+      startDate: startDateArchivedVersion,
+      expirationDate: expirationDateArchivedVersion,
+      scope: SCOPES.CORE,
+    }).id;
+
+    _createCertificationCourses({
+      reconciledAt: reconciledAtArchivedVersion,
+      subscriptionIds: [null, null, null],
+      certificationCourseIds,
+    });
+    _createCertificationCourses({
+      reconciledAt: reconciledAtNonExistingVersion,
+      subscriptionIds: [null],
+      certificationCourseIds,
+    });
+
+    await databaseBuilder.commit();
+
+    const err = await catchErr(script.handle)({
+      options: { dryRun: false, startId: certificationCourseIds[0], chunkSize: 2 },
+      logger,
+    });
+
+    const certificationCourseDataAfter = await knex('certification-courses').orderBy('id');
+    const certificationCandidateDataAfter = await knex('certification-candidates').orderBy('id');
+    expect(certificationCourseDataAfter.length).to.equal(4);
+    expect(certificationCandidateDataAfter.length).to.equal(4);
+
+    expect(certificationCourseDataAfter[0].versionId).to.equal(coreVersionArchivedId);
+    expect(certificationCandidateDataAfter[0].subscription).to.equal(Frameworks.CORE);
+    expect(certificationCourseDataAfter[2].versionId).to.be.null;
+    expect(certificationCandidateDataAfter[2].subscription).to.be.null;
+
+    expect(logger.info.getCall(0)).to.have.been.calledWithExactly('Script execution started');
+    expect(logger.info.getCall(1)).to.have.been.calledWithExactly(
+      `Processing certification from ${certificationCourseIds[0]} to ${certificationCourseIds[1]}...`,
+    );
+    expect(logger.info.getCall(2)).to.have.been.calledWithExactly(
+      `Certifications up until ID ${certificationCourseIds[1]} DONE`,
+    );
+    expect(logger.info.getCall(3)).to.have.been.calledWithExactly(
+      `Processing certification from ${certificationCourseIds[2]} to ${certificationCourseIds[3]}...`,
+    );
+    expect(err).to.be.instanceOf(Error);
+    expect(err).to.have.property(
+      'message',
+      `No Certification Scoring found for ${reconciledAtNonExistingVersion} date.`,
+    );
+    expect(logger.error).to.have.been.calledWithExactly(
+      err,
+      `Certification ID ${certificationCourseIds[3]} encountered an error`,
+    );
+  });
+});
+
+function _createCertificationCourses({
+  reconciledAt,
+  subscriptionIds,
+  candidateIds = [],
+  certificationCourseIds = [],
+}) {
+  const sessionId = databaseBuilder.factory.buildSession().id;
+
+  for (const subscriptionId of subscriptionIds) {
+    const userId = databaseBuilder.factory.buildUser().id;
+    const candidateId = databaseBuilder.factory.buildCertificationCandidate({
+      sessionId,
+      reconciledAt,
+      userId,
+    }).id;
+
+    const certificationCoursesId = databaseBuilder.factory.buildCertificationCourse({
+      sessionId,
+      userId,
+      version: AlgorithmEngineVersion.V3,
+    }).id;
+
+    if (subscriptionId) {
+      databaseBuilder.factory.buildComplementaryCertificationSubscription({
+        certificationCandidateId: candidateId,
+        complementaryCertificationId: subscriptionId,
+      });
+    }
+
+    candidateIds.push(candidateId);
+    certificationCourseIds.push(certificationCoursesId);
+  }
+}


### PR DESCRIPTION
## 🥀 Problème

La PR #15363 ajoute les colonnes versionId et candidateId à la table 'certification-courses' et la colonne subscription 'certification-candidates'. On souhaite remplir rétro-activement pour les certifications v3 déjà passée

## 🏹 Proposition

Rédaction d'un script remplissant ces colonnes

## 💌 Remarques

Paramètres du script : 
- dryRun (défaut true)
- startId: id du premier certification course à traiter (défaut 5906059)
- chunkSize (défaut 1000)

## ❤️‍🔥 Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
