### PR TITLE
[FEATURE] Créer une route pour récupérer les frameworks d'une organisation (PIX-21788)

### DIFF
--- a/api/src/prescription/shared/infrastructure/repositories/learning-content-repository.js
+++ b/api/src/prescription/shared/infrastructure/repositories/learning-content-repository.js
@@ -13,12 +13,12 @@ import * as skillRepository from '../../../../shared/infrastructure/repositories
 import * as thematicRepository from '../../../../shared/infrastructure/repositories/thematic-repository.js';
 import * as tubeRepository from '../../../../shared/infrastructure/repositories/tube-repository.js';
 
-async function findByCampaignParticipationId(campaignParticipationId, locale) {
+export async function findByCampaignParticipationId(campaignParticipationId, locale) {
   const campaignId = await campaignRepository.getCampaignIdByCampaignParticipationId(campaignParticipationId);
   return await findByCampaignId(campaignId, locale);
 }
 
-async function findByCampaignId(campaignId, locale) {
+export async function findByCampaignId(campaignId, locale) {
   const skills = await campaignRepository.findSkills({ campaignId });
 
   const frameworks = await _getLearningContentBySkillIds(skills, locale);
@@ -26,7 +26,7 @@ async function findByCampaignId(campaignId, locale) {
   return new CampaignLearningContent(frameworks);
 }
 
-async function findByTargetProfileId(targetProfileId, locale) {
+export async function findByTargetProfileId(targetProfileId, locale) {
   const knexConn = DomainTransaction.getConnection();
 
   const cappedTubesDTO = await knexConn('target-profile_tubes')
@@ -44,7 +44,7 @@ async function findByTargetProfileId(targetProfileId, locale) {
   return new LearningContent(frameworks);
 }
 
-async function findByFrameworkNames({ frameworkNames, locale }) {
+export async function findByFrameworkNames({ frameworkNames, locale }) {
   const baseFrameworks = [];
   for (const frameworkName of frameworkNames) {
     baseFrameworks.push(await frameworkRepository.getByName(frameworkName));
@@ -52,6 +52,32 @@ async function findByFrameworkNames({ frameworkNames, locale }) {
 
   const frameworks = await _getLearningContentByFrameworks(baseFrameworks, locale);
   return new LearningContent(frameworks);
+}
+
+export async function findByOrganizationId({ organizationId, locale }) {
+  const knexConn = DomainTransaction.getConnection();
+  const tubesWithLevel = await knexConn('target-profile-shares')
+    .join('target-profile_tubes', 'target-profile_tubes.targetProfileId', '=', 'target-profile-shares.targetProfileId')
+    .select({ id: 'tubeId' })
+    .where({ organizationId })
+    .groupBy('tubeId');
+
+  if (tubesWithLevel.length === 0) {
+    return [];
+  }
+
+  const tubes = await tubeRepository.findByRecordIds(
+    tubesWithLevel.map((dto) => dto.id),
+    locale,
+  );
+
+  const frameworks = await _getLearningContentByTubes(tubes, locale);
+
+  return frameworks.sort((frameworkA, frameworkB) => {
+    if (frameworkA.name === 'Pix') return -1;
+    if (frameworkB.name === 'Pix') return 1;
+    return frameworkA.name.localeCompare(frameworkB.name);
+  });
 }
 
 async function _getLearningContentBySkillIds(skills, locale) {
@@ -147,5 +173,3 @@ async function _getLearningContentByFrameworks(frameworks, locale) {
 
   return frameworks;
 }
-
-export { findByCampaignId, findByCampaignParticipationId, findByFrameworkNames, findByTargetProfileId };

--- a/api/src/prescription/target-profile/application/target-profile-controller.js
+++ b/api/src/prescription/target-profile/application/target-profile-controller.js
@@ -1,6 +1,6 @@
 import { getChallengeLocale } from '../../../shared/infrastructure/utils/request-response-utils.js';
 import { usecases } from '../domain/usecases/index.js';
-import * as frameworkwithoutskillserializer from '../infrastructure/serializers/jsonapi/framework-without-skills-serializer.js';
+import * as frameworkWithoutSkillSerializer from '../infrastructure/serializers/jsonapi/framework-without-skills-serializer.js';
 import * as targetProfileForSpecifierSerializer from '../infrastructure/serializers/jsonapi/target-profile-for-specifier-serializer.js';
 
 const findTargetProfiles = async function (request, h, dependencies = { targetProfileForSpecifierSerializer }) {
@@ -12,22 +12,22 @@ const findTargetProfiles = async function (request, h, dependencies = { targetPr
 const getFrameworksForTargetProfileSubmission = async function (
   request,
   _,
-  dependencies = { frameworkwithoutskillserializer },
+  dependencies = { frameworkWithoutSkillSerializer },
 ) {
   const locale = getChallengeLocale(request);
   const learningContent = await usecases.getLearningContentForTargetProfileSubmission({ locale });
-  return dependencies.frameworkwithoutskillserializer.serialize(learningContent.frameworks);
+  return dependencies.frameworkWithoutSkillSerializer.serialize(learningContent.frameworks);
 };
 
 const findLearningContentsByOrganizationId = async function (
   request,
   _,
-  dependencies = { frameworkwithoutskillserializer },
+  dependencies = { frameworkWithoutSkillSerializer },
 ) {
   const organizationId = request.params.organizationId;
   const locale = getChallengeLocale(request);
   const learningContents = await usecases.findLearningContentsByOrganizationId({ organizationId, locale });
-  return dependencies.frameworkwithoutskillserializer.serialize(learningContents);
+  return dependencies.frameworkWithoutSkillSerializer.serialize(learningContents);
 };
 
 const targetProfileController = {

--- a/api/src/prescription/target-profile/application/target-profile-controller.js
+++ b/api/src/prescription/target-profile/application/target-profile-controller.js
@@ -4,7 +4,7 @@ import * as frameworkwithoutskillserializer from '../infrastructure/serializers/
 import * as targetProfileForSpecifierSerializer from '../infrastructure/serializers/jsonapi/target-profile-for-specifier-serializer.js';
 
 const findTargetProfiles = async function (request, h, dependencies = { targetProfileForSpecifierSerializer }) {
-  const organizationId = request.params.id;
+  const organizationId = request.params.organizationId;
   const targetProfiles = await usecases.getAvailableTargetProfilesForOrganization({ organizationId });
   return dependencies.targetProfileForSpecifierSerializer.serialize(targetProfiles);
 };

--- a/api/src/prescription/target-profile/application/target-profile-controller.js
+++ b/api/src/prescription/target-profile/application/target-profile-controller.js
@@ -19,8 +19,20 @@ const getFrameworksForTargetProfileSubmission = async function (
   return dependencies.frameworkwithoutskillserializer.serialize(learningContent.frameworks);
 };
 
+const findLearningContentsByOrganizationId = async function (
+  request,
+  _,
+  dependencies = { frameworkwithoutskillserializer },
+) {
+  const organizationId = request.params.organizationId;
+  const locale = getChallengeLocale(request);
+  const learningContents = await usecases.findLearningContentsByOrganizationId({ organizationId, locale });
+  return dependencies.frameworkwithoutskillserializer.serialize(learningContents);
+};
+
 const targetProfileController = {
   getFrameworksForTargetProfileSubmission,
+  findLearningContentsByOrganizationId,
   findTargetProfiles,
 };
 

--- a/api/src/prescription/target-profile/application/target-profile-route.js
+++ b/api/src/prescription/target-profile/application/target-profile-route.js
@@ -8,7 +8,7 @@ const register = async function (server) {
   server.route([
     {
       method: 'GET',
-      path: '/api/organizations/{id}/target-profiles',
+      path: '/api/organizations/{organizationId}/target-profiles',
       config: {
         pre: [
           {
@@ -18,7 +18,7 @@ const register = async function (server) {
         ],
         validate: {
           params: Joi.object({
-            id: identifiersType.organizationId,
+            organizationId: identifiersType.organizationId,
           }),
         },
         handler: targetProfileController.findTargetProfiles,

--- a/api/src/prescription/target-profile/application/target-profile-route.js
+++ b/api/src/prescription/target-profile/application/target-profile-route.js
@@ -47,6 +47,29 @@ const register = async function (server) {
         ],
       },
     },
+    {
+      method: 'GET',
+      path: '/api/organizations/{organizationId}/frameworks',
+      config: {
+        handler: targetProfileController.findLearningContentsByOrganizationId,
+        pre: [
+          {
+            method: securityPreHandlers.checkUserBelongsToOrganization,
+            assign: 'checkUserBelongsToOrganization',
+          },
+        ],
+        validate: {
+          params: Joi.object({
+            organizationId: identifiersType.organizationId,
+          }),
+        },
+        tags: ['api', 'framework'],
+        notes: [
+          "Cette route est restreinte aux utilisateurs authentifiés membre d'une organisation",
+          'Elle permet de récupérer tous les référentiel à disposition pour formuler une demande de création de profil cible',
+        ],
+      },
+    },
   ]);
 };
 

--- a/api/src/prescription/target-profile/domain/usecases/find-learning-contents-by-organization-id.js
+++ b/api/src/prescription/target-profile/domain/usecases/find-learning-contents-by-organization-id.js
@@ -1,0 +1,8 @@
+const findLearningContentsByOrganizationId = async function ({ organizationId, locale, learningContentRepository }) {
+  return learningContentRepository.findByOrganizationId({
+    organizationId,
+    locale,
+  });
+};
+
+export { findLearningContentsByOrganizationId };

--- a/api/src/prescription/target-profile/domain/usecases/index.js
+++ b/api/src/prescription/target-profile/domain/usecases/index.js
@@ -45,6 +45,7 @@ import { attachTargetProfilesToOrganization } from './attach-target-profiles-to-
 import { copyTargetProfile } from './copy-target-profile.js';
 import { createTargetProfile } from './create-target-profile.js';
 import { detachOrganizationsFromTargetProfile } from './detach-organizations-from-target-profile.js';
+import { findLearningContentsByOrganizationId } from './find-learning-contents-by-organization-id.js';
 import { findOrganizationTargetProfileSummariesForAdmin } from './find-organization-target-profile-summaries-for-admin.js';
 import { findPaginatedFilteredTargetProfileSummariesForAdmin } from './find-paginated-filtered-target-profile-summaries-for-admin.js';
 import { findSkillsByTargetProfileIds } from './find-skills-by-target-profile-ids.js';
@@ -65,6 +66,7 @@ const usecasesWithoutInjectedDependencies = {
   copyTargetProfile,
   createTargetProfile,
   detachOrganizationsFromTargetProfile,
+  findLearningContentsByOrganizationId,
   findOrganizationTargetProfileSummariesForAdmin,
   findPaginatedFilteredTargetProfileSummariesForAdmin,
   findSkillsByTargetProfileIds,

--- a/api/tests/prescription/shared/integration/infrastructure/repositories/learning-content-repository_test.js
+++ b/api/tests/prescription/shared/integration/infrastructure/repositories/learning-content-repository_test.js
@@ -17,7 +17,7 @@ describe('Integration | Repository | learning-content', function () {
     });
     const framework2DB = databaseBuilder.factory.learningContent.buildFramework({
       id: 'recFramework2',
-      name: 'Mon référentiel 2',
+      name: 'Pix',
     });
     const area1DB = databaseBuilder.factory.learningContent.buildArea({
       id: 'recArea1',
@@ -432,6 +432,114 @@ describe('Integration | Repository | learning-content', function () {
     });
   });
 
+  describe('#findByOrganizationId', function () {
+    let organizationId;
+    beforeEach(async function () {
+      organizationId = databaseBuilder.factory.buildOrganization().id;
+      const otherOrganizationId = databaseBuilder.factory.buildOrganization().id;
+
+      const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+      databaseBuilder.factory.buildTargetProfileShare({ organizationId, targetProfileId });
+      databaseBuilder.factory.buildTargetProfileTube({ targetProfileId, tubeId: 'recTube1', level: 4 });
+      databaseBuilder.factory.buildTargetProfileTube({ targetProfileId, tubeId: 'recTube4', level: 4 });
+
+      const secondTargetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+      databaseBuilder.factory.buildTargetProfileShare({ organizationId, targetProfileId: secondTargetProfileId });
+      databaseBuilder.factory.buildTargetProfileTube({
+        targetProfileId: secondTargetProfileId,
+        tubeId: 'recTube1',
+        level: 2,
+      });
+      databaseBuilder.factory.buildTargetProfileTube({
+        targetProfileId: secondTargetProfileId,
+        tubeId: 'recTube2',
+        level: 2,
+      });
+
+      const targetProfileIdFromOtherOrganization = databaseBuilder.factory.buildTargetProfile().id;
+      databaseBuilder.factory.buildTargetProfileShare({
+        organizationId: otherOrganizationId,
+        targetProfileId: targetProfileIdFromOtherOrganization,
+      });
+      databaseBuilder.factory.buildTargetProfileTube({
+        targetProfileId: targetProfileIdFromOtherOrganization,
+        tubeId: 'recTube3',
+        level: 2,
+      });
+
+      await databaseBuilder.commit();
+    });
+
+    it('should return an array of LearningContents', async function () {
+      // given
+      framework1Fr.areas = [area1Fr];
+      area1Fr.competences = [competence1Fr, competence2Fr];
+      competence1Fr.thematics = [thematic1Fr];
+      competence2Fr.thematics = [thematic2Fr];
+      competence1Fr.tubes = [tube1Fr];
+      competence2Fr.tubes = [tube2Fr];
+      thematic1Fr.tubes = [tube1Fr];
+      thematic2Fr.tubes = [tube2Fr];
+      tube1Fr.skills = [];
+      tube2Fr.skills = [];
+
+      framework2Fr.areas = [area2Fr];
+      area2Fr.competences = [competence3Fr];
+      competence3Fr.thematics = [thematic3Fr];
+      competence3Fr.tubes = [tube4Fr];
+      thematic3Fr.tubes = [tube4Fr];
+      tube4Fr.skills = [];
+
+      // when
+      const results = await learningContentRepository.findByOrganizationId({ organizationId });
+
+      // then
+      expect(results).lengthOf(2);
+      expect(results[0]).deep.equals(framework2Fr);
+      expect(results[1]).deep.equals(framework1Fr);
+    });
+
+    context('when organization has no target profile shares', function () {
+      it('it should returns empty array', async function () {
+        // when
+        const frameworks = await learningContentRepository.findByOrganizationId({ organizationId: 213 });
+
+        // then
+        expect(frameworks).lengthOf(0);
+      });
+    });
+
+    context('when using a specific locale', function () {
+      it('should translate names and descriptions', async function () {
+        framework1En.areas = [area1En];
+        area1En.competences = [competence1En, competence2En];
+        competence1En.thematics = [thematic1En];
+        competence2En.thematics = [thematic2En];
+        competence1En.tubes = [tube1En];
+        competence2En.tubes = [tube2En];
+        thematic1En.tubes = [tube1En];
+        thematic2En.tubes = [tube2En];
+        tube1En.skills = [];
+        tube2En.skills = [];
+
+        framework2En.areas = [area2En];
+        area2En.competences = [competence3En];
+        competence3En.thematics = [thematic3En];
+        competence3En.tubes = [tube4En];
+        thematic3En.tubes = [tube4En];
+        tube4En.skills = [];
+
+        // when
+        const results = await learningContentRepository.findByOrganizationId({ organizationId, locale: 'en' });
+
+        // then
+        expect(results).lengthOf(2);
+        expect(results[0]).deep.equals(framework2En);
+        expect(results[1]).deep.equals(framework1En);
+      });
+    });
+  });
+
   describe('#findByFrameworkNames', function () {
     it('should return an active LearningContent with the frameworks designated by name', async function () {
       // given
@@ -454,7 +562,7 @@ describe('Integration | Repository | learning-content', function () {
 
       // when
       const learningContent = await learningContentRepository.findByFrameworkNames({
-        frameworkNames: ['Mon référentiel 1', 'Mon référentiel 2'],
+        frameworkNames: ['Mon référentiel 1', 'Pix'],
       });
 
       // then
@@ -483,7 +591,7 @@ describe('Integration | Repository | learning-content', function () {
 
       // when
       const learningContent = await learningContentRepository.findByFrameworkNames({
-        frameworkNames: ['Mon référentiel 1', 'Mon référentiel 2'],
+        frameworkNames: ['Mon référentiel 1', 'Pix'],
         locale: 'en',
       });
 

--- a/api/tests/prescription/target-profile/acceptance/application/target-profile-route_test.js
+++ b/api/tests/prescription/target-profile/acceptance/application/target-profile-route_test.js
@@ -367,4 +367,219 @@ describe('Acceptance | Route | target-profile', function () {
       expect(response.result).to.deep.equal(expectedResult);
     });
   });
+
+  describe('GET /api/organizations/{organizationId}/frameworks', function () {
+    let userId, organizationId;
+
+    beforeEach(async function () {
+      const learningContent = {
+        frameworks: [
+          {
+            id: 'frameworkPix',
+            name: 'Pix',
+          },
+          {
+            id: 'frameworkFrance',
+            name: 'France',
+          },
+          {
+            id: 'frameworkCuisine',
+            name: 'Cuisine',
+          },
+        ],
+        areas: [
+          {
+            id: 'areaPix1',
+            code: '1',
+            title_i18n: {
+              fr: 'areaPix1 title fr',
+            },
+            color: 'areaPix1 color',
+            competenceIds: ['competencePix1_1'],
+            frameworkId: 'frameworkPix',
+          },
+          {
+            id: 'areaFrance1',
+            code: '1',
+            title_i18n: {
+              fr: 'areaFrance1 title fr',
+            },
+            color: 'areaFrance1 color',
+            competenceIds: ['competenceFrance1_1'],
+            frameworkId: 'frameworkFrance',
+          },
+          {
+            id: 'areaCuisine1',
+            code: '1',
+            title_i18n: {
+              fr: 'areaCuisine1 title fr',
+            },
+            color: 'areaCuisine1 color',
+            competenceIds: ['competenceCuisine1_1'],
+            frameworkId: 'frameworkCuisine',
+          },
+        ],
+        competences: [
+          {
+            id: 'competencePix1_1',
+            name_i18n: {
+              fr: 'competencePix1_1 name fr',
+              en: 'competencePix1_1 name en',
+            },
+            areaId: 'areaPix1',
+            index: '0',
+            origin: 'Pix',
+            thematicIds: ['thematicPix1_1_1'],
+          },
+          {
+            id: 'competenceFrance1_1',
+            name_i18n: {
+              fr: 'competenceFrance1_1 name fr',
+              en: 'competenceFrance1_1 name en',
+            },
+            areaId: 'areaFrance1',
+            index: '0',
+            origin: 'France',
+            thematicIds: ['thematicFrance1_1_1'],
+          },
+          {
+            id: 'competenceCuisine1_1',
+            name_i18n: {
+              fr: 'competenceCuisine1_1 name fr',
+              en: 'competenceCuisine1_1 name en',
+            },
+            areaId: 'areaCuisine1',
+            index: '0',
+            origin: 'Cuisine',
+            thematicIds: ['thematicCuisine1_1_1'],
+          },
+        ],
+        thematics: [
+          {
+            id: 'thematicPix1_1_1',
+            name_i18n: {
+              fr: 'thematicPix1_1_1 name fr',
+            },
+            index: 0,
+            tubeIds: ['tubePix1_1_1_1'],
+            competenceId: 'competencePix1_1',
+          },
+          {
+            id: 'thematicFrance1_1_1',
+            name_i18n: {
+              fr: 'thematicFrance1_1_1 name fr',
+            },
+            index: 0,
+            tubeIds: ['tubeFrance1_1_1_1'],
+            competenceId: 'competenceFrance1_1',
+          },
+          {
+            id: 'thematicCuisine1_1_1',
+            name_i18n: {
+              fr: 'thematicCuisine1_1_1 name fr',
+            },
+            index: 0,
+            tubeIds: ['tubeCuisine1_1_1_1'],
+            competenceId: 'competenceCuisine1_1',
+          },
+        ],
+        tubes: [
+          {
+            id: 'tubePix1_1_1_1',
+            name: '@tubePix1_1_1_1',
+            practicalTitle_i18n: {
+              fr: 'tubePix1_1_1_1 practicalTitle fr',
+            },
+            practicalDescription_i18n: {
+              fr: 'tubePix1_1_1_1 practicalDescription fr',
+            },
+            competenceId: 'competencePix1_1',
+            isMobileCompliant: true,
+            isTabletCompliant: true,
+          },
+          {
+            id: 'tubeFrance1_1_1_1',
+            name: '@tubeFrance1_1_1_1',
+            practicalTitle_i18n: {
+              fr: 'tubeFrance1_1_1_1 practicalTitle fr',
+            },
+            practicalDescription_i18n: {
+              fr: 'tubeFrance1_1_1_1 practicalDescription fr',
+            },
+            competenceId: 'competenceFrance1_1',
+            isMobileCompliant: true,
+            isTabletCompliant: false,
+            skills: ['skillFrance1_1_1_1_1'],
+          },
+          {
+            id: 'tubeCuisine1_1_1_1',
+            name: '@tubeCuisine1_1_1_1',
+            practicalTitle_i18n: {
+              fr: 'tubeCuisine1_1_1_1 practicalTitle fr',
+            },
+            practicalDescription_i18n: {
+              fr: 'tubeCuisine1_1_1_1 practicalDescription fr',
+            },
+            competenceId: 'competenceCuisine1_1',
+            isMobileCompliant: false,
+            isTabletCompliant: true,
+            skills: ['skillCuisine1_1_1_1_1'],
+          },
+        ],
+        skills: [
+          {
+            id: 'skillPix1_1_1_1_1',
+            status: 'actif',
+            tubeId: 'tubePix1_1_1_1',
+          },
+          {
+            id: 'skillFrance1_1_1_1_1',
+            status: 'actif',
+            tubeId: 'tubeFrance1_1_1_1',
+          },
+          {
+            id: 'skillCuisine1_1_1_1_1',
+            status: 'actif',
+            tubeId: 'tubeCuisine1_1_1_1',
+          },
+        ],
+      };
+
+      organizationId = databaseBuilder.factory.buildOrganization().id;
+      userId = databaseBuilder.factory.buildUser().id;
+      databaseBuilder.factory.buildMembership({ userId, organizationId });
+
+      const targetProfilePixId = databaseBuilder.factory.buildTargetProfile().id;
+      databaseBuilder.factory.buildTargetProfileShare({ targetProfileId: targetProfilePixId, organizationId });
+      databaseBuilder.factory.buildTargetProfileTube({
+        targetProfileId: targetProfilePixId,
+        tubeId: 'tubePix1_1_1_1',
+      });
+
+      const targetProfileFranceId = databaseBuilder.factory.buildTargetProfile().id;
+      databaseBuilder.factory.buildTargetProfileShare({ targetProfileId: targetProfileFranceId, organizationId });
+      databaseBuilder.factory.buildTargetProfileTube({
+        targetProfileId: targetProfileFranceId,
+        tubeId: 'tubeFrance1_1_1_1',
+      });
+
+      await databaseBuilder.commit();
+      await mockLearningContent(learningContent);
+    });
+
+    it('should return response code 200', async function () {
+      // given
+      const options = {
+        method: 'GET',
+        url: `/api/organizations/${organizationId}/frameworks`,
+        headers: generateAuthenticatedUserRequestHeaders({ userId }),
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      expect(response.statusCode).to.equal(200);
+      expect(response.result.data[0].type).equal('frameworks');
+    });
+  });
 });

--- a/api/tests/prescription/target-profile/acceptance/application/target-profile-route_test.js
+++ b/api/tests/prescription/target-profile/acceptance/application/target-profile-route_test.js
@@ -16,7 +16,7 @@ describe('Acceptance | Route | target-profile', function () {
     await insertUserWithRoleSuperAdmin();
   });
 
-  describe('GET /api/organizations/{id}/target-profiles', function () {
+  describe('GET /api/organizations/{organizationId}/target-profiles', function () {
     context('when user is authenticated', function () {
       let user;
       let linkedOrganization;

--- a/api/tests/prescription/target-profile/integration/application/target-profile-route_test.js
+++ b/api/tests/prescription/target-profile/integration/application/target-profile-route_test.js
@@ -67,4 +67,62 @@ describe('Integration | Application | target-profile-route', function () {
       expect(response.statusCode).to.equal(400);
     });
   });
+  describe('GET /organizations/{organizationId}/frameworks', function () {
+    const method = 'GET';
+
+    let headers, httpTestServer, organizationId, url, payload;
+
+    beforeEach(async function () {
+      sinon.stub(targetProfileController, 'findLearningContentsByOrganizationId').returns('ok');
+      httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+      httpTestServer.setupAuthentication();
+      organizationId = databaseBuilder.factory.buildOrganization().id;
+    });
+
+    it('return a 401 status code when trying to call route unauthenticated', async function () {
+      url = '/api/organizations/2/frameworks';
+      // given
+      headers = {
+        authorization: null,
+      };
+
+      // when
+      const response = await httpTestServer.request(method, url, null, null, headers);
+
+      // then
+      expect(response.statusCode).to.equal(401);
+    });
+
+    it('return a 403 status code if authenticated user does not belong to organization', async function () {
+      const lambdaUser = databaseBuilder.factory.buildUser().id;
+      url = `/api/organizations/${organizationId}/frameworks`;
+      // given
+      headers = generateAuthenticatedUserRequestHeaders({ userId: lambdaUser });
+
+      // when
+      const response = await httpTestServer.request(method, url, null, null, headers);
+
+      // then
+      expect(response.statusCode).to.equal(403);
+    });
+
+    it('return a 400 status code when trying to call route with illegal organization id', async function () {
+      // given
+      const wrongUrl = `/api/organizations/GodZilla/frameworks`;
+      const adminUser = databaseBuilder.factory.buildUser().id;
+      databaseBuilder.factory.buildMembership({ organizationId, userId: adminUser, organizationRole: 'ADMIN' });
+      await databaseBuilder.commit();
+      headers = generateAuthenticatedUserRequestHeaders({ userId: adminUser });
+      payload = {
+        listLearners: [123],
+      };
+
+      // when
+      const response = await httpTestServer.request(method, wrongUrl, payload, null, headers);
+
+      // then
+      expect(response.statusCode).to.equal(400);
+    });
+  });
 });

--- a/api/tests/prescription/target-profile/integration/application/target-profile-route_test.js
+++ b/api/tests/prescription/target-profile/integration/application/target-profile-route_test.js
@@ -9,7 +9,7 @@ import {
 } from '../../../../test-helper.js';
 
 describe('Integration | Application | target-profile-route', function () {
-  describe('GET /organizations/{id}/target-profiles', function () {
+  describe('GET /organizations/{organizationId}/target-profiles', function () {
     const method = 'GET';
 
     let headers, httpTestServer, organizationId, url, payload;

--- a/api/tests/prescription/target-profile/integration/domain/usecases/find-learning-contents-by-organization-id_test.js
+++ b/api/tests/prescription/target-profile/integration/domain/usecases/find-learning-contents-by-organization-id_test.js
@@ -1,0 +1,289 @@
+import { usecases } from '../../../../../../src/prescription/target-profile/domain/usecases/index.js';
+import { databaseBuilder, domainBuilder, expect } from '../../../../../test-helper.js';
+
+describe('Integration | UseCases | find-learning-contents-by-organization-id', function () {
+  let organizationId;
+  let framework1Fr, framework2Fr;
+  let area1Fr, area2Fr;
+  let competence1Fr, competence2Fr, competence3Fr;
+  let thematic1Fr, thematic2Fr, thematic3Fr;
+  let tube1Fr, tube2Fr, tube4Fr;
+
+  beforeEach(async function () {
+    const framework1DB = databaseBuilder.factory.learningContent.buildFramework({
+      id: 'recFramework1',
+      name: 'Mon référentiel 1',
+    });
+    const framework2DB = databaseBuilder.factory.learningContent.buildFramework({
+      id: 'recFramework2',
+      name: 'Mon référentiel 2',
+    });
+    const area1DB = databaseBuilder.factory.learningContent.buildArea({
+      id: 'recArea1',
+      name: 'area1_name',
+      title_i18n: { fr: 'domaine1_TitreFr', en: 'area1_TitleEn' },
+      color: 'area1_color',
+      code: 'area1_code',
+      frameworkId: 'recFramework1',
+      competenceIds: ['recCompetence1', 'recCompetence2'],
+    });
+    const area2DB = databaseBuilder.factory.learningContent.buildArea({
+      id: 'recArea2',
+      name: 'area2_name',
+      title_i18n: { fr: 'domaine2_TitreFr', en: 'area2_TitleEn' },
+      color: 'area2_color',
+      code: 'area2_code',
+      frameworkId: 'recFramework2',
+      competenceIds: ['recCompetence3'],
+    });
+    const competence1DB = databaseBuilder.factory.learningContent.buildCompetence({
+      id: 'recCompetence1',
+      name_i18n: { fr: 'competence1_nomFr', en: 'competence1_nameEn' },
+      index: '1',
+      description_i18n: { fr: 'competence1_descriptionFr', en: 'competence1_descriptionEn' },
+      origin: 'Pix',
+      areaId: 'recArea1',
+    });
+    const competence2DB = databaseBuilder.factory.learningContent.buildCompetence({
+      id: 'recCompetence2',
+      name_i18n: { fr: 'competence2_nomFr', en: 'competence2_nameEn' },
+      index: '2',
+      description_i18n: { fr: 'competence2_descriptionFr', en: 'competence2_descriptionEn' },
+      origin: 'Pix',
+      areaId: 'recArea1',
+    });
+    const competence3DB = databaseBuilder.factory.learningContent.buildCompetence({
+      id: 'recCompetence3',
+      name_i18n: { fr: 'competence3_nomFr', en: 'competence3_nameEn' },
+      index: '1',
+      description_i18n: { fr: 'competence3_descriptionFr', en: 'competence3_descriptionEn' },
+      origin: 'Pix',
+      areaId: 'recArea2',
+    });
+    const thematic1DB = databaseBuilder.factory.learningContent.buildThematic({
+      id: 'recThematic1',
+      name_i18n: {
+        fr: 'thematique1_nomFr',
+        en: 'thematic1_nameEn',
+      },
+      index: 10,
+      competenceId: 'recCompetence1',
+      tubeIds: ['recTube1'],
+    });
+    const thematic2DB = databaseBuilder.factory.learningContent.buildThematic({
+      id: 'recThematic2',
+      name_i18n: {
+        fr: 'thematique2_nomFr',
+        en: 'thematic2_nameEn',
+      },
+      index: 20,
+      competenceId: 'recCompetence2',
+      tubeIds: ['recTube2', 'recTube3'],
+    });
+    const thematic3DB = databaseBuilder.factory.learningContent.buildThematic({
+      id: 'recThematic3',
+      name_i18n: {
+        fr: 'thematique3_nomFr',
+        en: 'thematic3_nameEn',
+      },
+      index: 30,
+      competenceId: 'recCompetence3',
+      tubeIds: ['recTube4'],
+    });
+    const tube1DB = databaseBuilder.factory.learningContent.buildTube({
+      id: 'recTube1',
+      name: '@tube1_name',
+      title: 'tube1_title',
+      description: 'tube1_description',
+      practicalTitle_i18n: { fr: 'tube1_practicalTitleFr', en: 'tube1_practicalTitleEn' },
+      practicalDescription_i18n: {
+        fr: 'tube1_practicalDescriptionFr',
+        en: 'tube1_practicalDescriptionEn',
+      },
+      isMobileCompliant: true,
+      isTabletCompliant: false,
+      competenceId: 'recCompetence1',
+      thematicId: 'recThematic1',
+    });
+    const tube2DB = databaseBuilder.factory.learningContent.buildTube({
+      id: 'recTube2',
+      name: '@tube2_name',
+      title: '@tube2_title',
+      description: '@tube2_description',
+      practicalTitle_i18n: { fr: 'tube2_practicalTitleFr', en: 'tube2_practicalTitleEn' },
+      practicalDescription_i18n: {
+        fr: 'tube2_practicalDescriptionFr',
+        en: 'tube2_practicalDescriptionEn',
+      },
+      isMobileCompliant: false,
+      isTabletCompliant: true,
+      competenceId: 'recCompetence2',
+      thematicId: 'recThematic2',
+    });
+    const tube3DB = databaseBuilder.factory.learningContent.buildTube({
+      id: 'recTube3',
+      name: '@tube3_name',
+      title: '@tube3_title',
+      description: '@tube3_description',
+      practicalTitle_i18n: { fr: 'tube3_practicalTitleFr', en: 'tube3_practicalTitleEn' },
+      practicalDescription_i18n: {
+        fr: 'tube3_practicalDescriptionFr',
+        en: 'tube3_practicalDescriptionEn',
+      },
+      isMobileCompliant: true,
+      isTabletCompliant: true,
+      competenceId: 'recCompetence2',
+      thematicId: 'recThematic2',
+    });
+    const tube4DB = databaseBuilder.factory.learningContent.buildTube({
+      id: 'recTube4',
+      name: '@tube4_name',
+      title: 'tube4_title',
+      description: 'tube4_description',
+      practicalTitle_i18n: { fr: 'tube4_practicalTitleFr', en: 'tube4_practicalTitleEn' },
+      practicalDescription_i18n: {
+        fr: 'tube4_practicalDescriptionFr',
+        en: 'tube4_practicalDescriptionEn',
+      },
+      isMobileCompliant: false,
+      isTabletCompliant: false,
+      competenceId: 'recCompetence3',
+      thematicId: 'recThematic3',
+    });
+
+    organizationId = databaseBuilder.factory.buildOrganization().id;
+    const otherOrganizationId = databaseBuilder.factory.buildOrganization().id;
+
+    const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+    databaseBuilder.factory.buildTargetProfileShare({ organizationId, targetProfileId });
+    databaseBuilder.factory.buildTargetProfileTube({ targetProfileId, tubeId: 'recTube1', level: 4 });
+    databaseBuilder.factory.buildTargetProfileTube({ targetProfileId, tubeId: 'recTube4', level: 4 });
+
+    const secondTargetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+    databaseBuilder.factory.buildTargetProfileShare({ organizationId, targetProfileId: secondTargetProfileId });
+    databaseBuilder.factory.buildTargetProfileTube({
+      targetProfileId: secondTargetProfileId,
+      tubeId: 'recTube1',
+      level: 2,
+    });
+    databaseBuilder.factory.buildTargetProfileTube({
+      targetProfileId: secondTargetProfileId,
+      tubeId: 'recTube2',
+      level: 2,
+    });
+
+    const targetProfileIdFromOtherOrganization = databaseBuilder.factory.buildTargetProfile().id;
+    databaseBuilder.factory.buildTargetProfileShare({
+      organizationId: otherOrganizationId,
+      targetProfileId: targetProfileIdFromOtherOrganization,
+    });
+    databaseBuilder.factory.buildTargetProfileTube({
+      targetProfileId: targetProfileIdFromOtherOrganization,
+      tubeId: 'recTube3',
+      level: 2,
+    });
+
+    await databaseBuilder.commit();
+
+    [framework1Fr, framework2Fr] = _buildDomainFrameworksFromDB([framework1DB, framework2DB]);
+    [area1Fr, area2Fr] = _buildDomainAreasFromDB([area1DB, area2DB], 'fr');
+    [competence1Fr, competence2Fr, competence3Fr] = _buildDomainCompetencesFromDB(
+      [competence1DB, competence2DB, competence3DB],
+      'fr',
+    );
+
+    [thematic1Fr, thematic2Fr, thematic3Fr] = _buildDomainThematicsFromDB(
+      [thematic1DB, thematic2DB, thematic3DB],
+      'fr',
+    );
+
+    [tube1Fr, tube2Fr, , tube4Fr] = _buildDomainTubesFromDB([tube1DB, tube2DB, tube3DB, tube4DB], 'fr');
+
+    // build localised frameworks
+    framework1Fr.areas = [area1Fr];
+    area1Fr.competences = [competence1Fr, competence2Fr];
+    competence1Fr.thematics = [thematic1Fr];
+    competence2Fr.thematics = [thematic2Fr];
+    competence1Fr.tubes = [tube1Fr];
+    competence2Fr.tubes = [tube2Fr];
+    thematic1Fr.tubes = [tube1Fr];
+    thematic2Fr.tubes = [tube2Fr];
+    tube1Fr.skills = [];
+    tube2Fr.skills = [];
+
+    framework2Fr.areas = [area2Fr];
+    area2Fr.competences = [competence3Fr];
+    competence3Fr.thematics = [thematic3Fr];
+    competence3Fr.tubes = [tube4Fr];
+    thematic3Fr.tubes = [tube4Fr];
+    tube4Fr.skills = [];
+  });
+
+  it('it should returns frameworks for a given organization', async function () {
+    // when
+    const frameworks = await usecases.findLearningContentsByOrganizationId({ organizationId, locale: 'fr' });
+
+    // then
+    expect(frameworks).lengthOf(2);
+    expect(frameworks[0]).deep.equal(framework1Fr);
+    expect(frameworks[1]).deep.equal(framework2Fr);
+  });
+
+  context('when organization has no target profile shares', function () {
+    it('it should returns empty array', async function () {
+      // when
+      const frameworks = await usecases.findLearningContentsByOrganizationId({ organizationId: 213 });
+
+      // then
+      expect(frameworks).lengthOf(0);
+    });
+  });
+});
+
+function _buildDomainFrameworksFromDB(frameworksDB) {
+  return frameworksDB.map((frameworkDB) =>
+    domainBuilder.buildFramework({
+      id: frameworkDB.id,
+      name: frameworkDB.name,
+      areas: [],
+    }),
+  );
+}
+
+function _buildDomainAreasFromDB(areasDB, locale) {
+  return areasDB.map((areaDB) =>
+    domainBuilder.buildArea({
+      ...areaDB,
+      title: areaDB.title_i18n[locale],
+    }),
+  );
+}
+
+function _buildDomainCompetencesFromDB(competencesDB, locale) {
+  return competencesDB.map((competenceDB) =>
+    domainBuilder.buildCompetence({
+      ...competenceDB,
+      name: competenceDB.name_i18n[locale],
+      description: competenceDB.description_i18n[locale],
+    }),
+  );
+}
+
+function _buildDomainThematicsFromDB(thematicsDB, locale) {
+  return thematicsDB.map((thematicDB) =>
+    domainBuilder.buildThematic({
+      ...thematicDB,
+      name: thematicDB.name_i18n[locale],
+    }),
+  );
+}
+
+function _buildDomainTubesFromDB(tubesDB, locale) {
+  return tubesDB.map((tubeDB) =>
+    domainBuilder.buildTube({
+      ...tubeDB,
+      practicalTitle: tubeDB.practicalTitle_i18n[locale],
+      practicalDescription: tubeDB.practicalDescription_i18n[locale],
+    }),
+  );
+}

--- a/api/tests/prescription/target-profile/unit/application/target-profile-controller_test.js
+++ b/api/tests/prescription/target-profile/unit/application/target-profile-controller_test.js
@@ -44,7 +44,7 @@ describe('Unit | Application | Target Profile | target-profile-controller', func
       frameworks = Symbol('frameworks');
       serializedFrameworks = Symbol('serializedFrameworks');
 
-      sinon.stub(usecases, 'getLearningContentForTargetProfileSubmission').returns({ frameworks });
+      sinon.stub(usecases, 'getLearningContentForTargetProfileSubmission').resolves({ frameworks });
       frameworkwithoutskillserializer = {
         serialize: sinon.stub().returns(serializedFrameworks),
       };
@@ -66,6 +66,49 @@ describe('Unit | Application | Target Profile | target-profile-controller', func
       expect(result).to.equal(serializedFrameworks);
       expect(usecases.getLearningContentForTargetProfileSubmission).to.have.been.calledWithExactly({ locale: 'en' });
       expect(frameworkwithoutskillserializer.serialize).to.have.been.calledWithExactly(frameworks);
+    });
+  });
+
+  describe('#findLearningContentsByOrganizationId', function () {
+    let frameworks;
+    let frameworkwithoutskillserializer;
+    let organizationId;
+    let serializedFrameworks;
+
+    beforeEach(function () {
+      frameworks = Symbol('frameworks');
+      organizationId = Symbol('organizationId');
+      serializedFrameworks = Symbol('serializedFrameworks');
+
+      sinon.stub(usecases, 'findLearningContentsByOrganizationId');
+
+      frameworkwithoutskillserializer = {
+        serialize: sinon.stub(),
+      };
+    });
+
+    it('should fetch and return frameworks, serialized as JSONAPI', async function () {
+      // given
+      const locale = 'en';
+      const request = {
+        params: { organizationId },
+        state: { locale },
+      };
+
+      usecases.findLearningContentsByOrganizationId
+        .resolves([])
+        .withArgs({ organizationId, locale: 'en' })
+        .resolves(frameworks);
+
+      frameworkwithoutskillserializer.serialize.withArgs(frameworks).returns(serializedFrameworks);
+      // when
+
+      const result = await targetProfileController.findLearningContentsByOrganizationId(request, hFake, {
+        frameworkwithoutskillserializer,
+      });
+
+      // then
+      expect(result).to.equal(serializedFrameworks);
     });
   });
 });

--- a/api/tests/prescription/target-profile/unit/application/target-profile-controller_test.js
+++ b/api/tests/prescription/target-profile/unit/application/target-profile-controller_test.js
@@ -11,7 +11,7 @@ describe('Unit | Application | Target Profile | target-profile-controller', func
 
       const request = {
         auth: { credentials: { userId: connectedUserId } },
-        params: { id: organizationId },
+        params: { organizationId },
       };
 
       const foundTargetProfiles = Symbol('TargetProfile');

--- a/api/tests/prescription/target-profile/unit/application/target-profile-controller_test.js
+++ b/api/tests/prescription/target-profile/unit/application/target-profile-controller_test.js
@@ -37,7 +37,7 @@ describe('Unit | Application | Target Profile | target-profile-controller', func
 
   describe('#getFrameworksForTargetProfileSubmission', function () {
     let frameworks;
-    let frameworkwithoutskillserializer;
+    let frameworkWithoutSkillSerializer;
     let serializedFrameworks;
 
     beforeEach(function () {
@@ -45,7 +45,7 @@ describe('Unit | Application | Target Profile | target-profile-controller', func
       serializedFrameworks = Symbol('serializedFrameworks');
 
       sinon.stub(usecases, 'getLearningContentForTargetProfileSubmission').resolves({ frameworks });
-      frameworkwithoutskillserializer = {
+      frameworkWithoutSkillSerializer = {
         serialize: sinon.stub().returns(serializedFrameworks),
       };
     });
@@ -59,19 +59,19 @@ describe('Unit | Application | Target Profile | target-profile-controller', func
 
       // when
       const result = await targetProfileController.getFrameworksForTargetProfileSubmission(request, hFake, {
-        frameworkwithoutskillserializer,
+        frameworkWithoutSkillSerializer,
       });
 
       // then
       expect(result).to.equal(serializedFrameworks);
       expect(usecases.getLearningContentForTargetProfileSubmission).to.have.been.calledWithExactly({ locale: 'en' });
-      expect(frameworkwithoutskillserializer.serialize).to.have.been.calledWithExactly(frameworks);
+      expect(frameworkWithoutSkillSerializer.serialize).to.have.been.calledWithExactly(frameworks);
     });
   });
 
   describe('#findLearningContentsByOrganizationId', function () {
     let frameworks;
-    let frameworkwithoutskillserializer;
+    let frameworkWithoutSkillSerializer;
     let organizationId;
     let serializedFrameworks;
 
@@ -82,7 +82,7 @@ describe('Unit | Application | Target Profile | target-profile-controller', func
 
       sinon.stub(usecases, 'findLearningContentsByOrganizationId');
 
-      frameworkwithoutskillserializer = {
+      frameworkWithoutSkillSerializer = {
         serialize: sinon.stub(),
       };
     });
@@ -100,11 +100,11 @@ describe('Unit | Application | Target Profile | target-profile-controller', func
         .withArgs({ organizationId, locale: 'en' })
         .resolves(frameworks);
 
-      frameworkwithoutskillserializer.serialize.withArgs(frameworks).returns(serializedFrameworks);
+      frameworkWithoutSkillSerializer.serialize.withArgs(frameworks).returns(serializedFrameworks);
       // when
 
       const result = await targetProfileController.findLearningContentsByOrganizationId(request, hFake, {
-        frameworkwithoutskillserializer,
+        frameworkWithoutSkillSerializer,
       });
 
       // then


### PR DESCRIPTION

## 🥀 Problème

Actuellement, on récupère seulement les sujets du référentiel Pix Coeur via la route existante for-target-profile-submission.

## 🏹 Proposition

On crée une nouvelle route `/organization/{organizationId}/frameworks`
qui renvoie une liste de frameworks

## 💌 Remarques

## ❤️‍🔥 Pour tester
via curl
```bash
ACCESS_TOKEN=$(curl --no-progress-meter \
  'https://api-pr15376.review.pix.fr/api/token' \
  --data-raw 'grant_type=password&username=admin-orga@example.net&password=pix123' \
| jq -r .access_token)
```
```bash
curl --no-progress-meter \
  "https://api-pr15376.review.pix.fr/api/organizations/1005/frameworks" \
  -H 'content-type: application/vnd.api+json' \
  -H "Authorization: Bearer $ACCESS_TOKEN" \
| jq
```

