### PR TITLE
[FEATURE] Créer une route de déblocage d'un élève par un membre de son organisation (PIX-21566).

### DIFF
--- a/api/src/prescription/organization-learner/application/sco-organization-learner-controller.js
+++ b/api/src/prescription/organization-learner/application/sco-organization-learner-controller.js
@@ -149,9 +149,17 @@ const generateUsername = async function (request, h, dependencies = { scoOrganiz
     .code(200);
 };
 
+const unblockOrganizationLearnerAccount = async function (request, h) {
+  const organizationLearnerId = request.params.organizationLearnerId;
+  const organizationId = request.params.organizationId;
+  await usecases.unblockOrganizationLearnerAccount({ organizationId, organizationLearnerId });
+  return h.response().code(204);
+};
+
 const scoOrganizationLearnerController = {
   createUserAndReconcileToOrganizationLearnerFromExternalUser,
   createAndReconcileUserToOrganizationLearner,
+  unblockOrganizationLearnerAccount,
   updatePassword,
   batchGenerateOrganizationLearnersUsernameWithTemporaryPassword,
   generateUsernameWithTemporaryPassword,

--- a/api/src/prescription/organization-learner/application/sco-organization-learner-route.js
+++ b/api/src/prescription/organization-learner/application/sco-organization-learner-route.js
@@ -216,6 +216,21 @@ const register = async function (server) {
         tags: ['api', 'sco-organization-learners'],
       },
     },
+    {
+      method: 'PUT',
+      path: '/api/organizations/{organizationId}/sco-organization-learners/{organizationLearnerId}/unblock',
+      config: {
+        pre: [
+          {
+            method: securityPreHandlers.checkUserBelongsToScoOrganizationAndManagesStudents,
+            assign: 'belongsToScoOrganizationAndManageStudents',
+          },
+        ],
+        handler: scoOrganizationLearnerController.unblockOrganizationLearnerAccount,
+        notes: ["- Permet à un membre d'une organisation de débloquer le compte d'un élève"],
+        tags: ['api', 'sco-organization-learners'],
+      },
+    },
   ]);
 };
 

--- a/api/src/prescription/organization-learner/domain/usecases/index.js
+++ b/api/src/prescription/organization-learner/domain/usecases/index.js
@@ -107,6 +107,7 @@ import { getAttestationPdfFromFilters } from './get-attestation-pdf-from-filters
 import { getOrganizationLearner } from './get-organization-learner.js';
 import { getOrganizationLearnerActivity } from './get-organization-learner-activity.js';
 import { getOrganizationToJoin } from './get-organization-to-join.js';
+import { unblockOrganizationLearnerAccount } from './unblock-organization-learner-account.js';
 import { updateOrganizationLearnerDependentUserPassword } from './update-organization-learner-dependent-user-password.js';
 
 const usecasesWithoutInjectedDependencies = {
@@ -131,6 +132,7 @@ const usecasesWithoutInjectedDependencies = {
   getOrganizationLearnerActivity,
   getOrganizationLearnerStatistics: getCampaignParticipationStatistics,
   getOrganizationToJoin,
+  unblockOrganizationLearnerAccount,
   updateOrganizationLearnerDependentUserPassword,
 };
 const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);

--- a/api/src/prescription/organization-learner/domain/usecases/unblock-organization-learner-account.js
+++ b/api/src/prescription/organization-learner/domain/usecases/unblock-organization-learner-account.js
@@ -1,0 +1,17 @@
+const unblockOrganizationLearnerAccount = async function ({
+  organizationId,
+  organizationLearnerId,
+  userLoginRepository,
+  prescriptionOrganizationLearnerRepository,
+}) {
+  const [organizationLearner] =
+    await prescriptionOrganizationLearnerRepository.findOrganizationLearnersByOrganizationIdAndLearnerIds({
+      organizationId,
+      organizationLearnerIds: [organizationLearnerId],
+    });
+  const userLogin = await userLoginRepository.getByUserId(organizationLearner.userId);
+  userLogin.resetUserBlocking();
+  return await userLoginRepository.update(userLogin);
+};
+
+export { unblockOrganizationLearnerAccount };

--- a/api/src/shared/application/security-pre-handlers.js
+++ b/api/src/shared/application/security-pre-handlers.js
@@ -419,7 +419,8 @@ async function checkUserBelongsToScoOrganizationAndManagesStudents(
   }
 
   const userId = request.auth.credentials.userId;
-  const organizationId = request.params.id || request.payload.data.attributes['organization-id'];
+  const organizationId =
+    request.params.id || request.params.organizationId || request.payload.data.attributes['organization-id'];
 
   let belongsToScoOrganizationAndManageStudents;
   try {

--- a/api/tests/prescription/organization-learner/acceptance/application/sco-organization-learner-route_test.js
+++ b/api/tests/prescription/organization-learner/acceptance/application/sco-organization-learner-route_test.js
@@ -1,4 +1,5 @@
 import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../../../src/identity-access-management/domain/constants/identity-providers.js';
+import { Membership } from '../../../../../src/shared/domain/models/Membership.js';
 import {
   createServer,
   databaseBuilder,
@@ -335,6 +336,58 @@ describe('Prescription | Organization Learner | Acceptance | Application | sco-o
 
       // then
       expect(response.statusCode).to.equal(403);
+    });
+  });
+
+  describe('PUT /api/organizations/{organizationId}/sco-organization-learners/{id}/unblock', function () {
+    it('unblocks the organization learner account and returns 204', async function () {
+      // given
+      const organizationId = databaseBuilder.factory.buildOrganization({
+        type: 'SCO',
+        isManagingStudents: true,
+      }).id;
+      const organizationMemberId = databaseBuilder.factory.buildUser.withRawPassword().id;
+      databaseBuilder.factory.buildMembership({
+        organizationId,
+        userId: organizationMemberId,
+        organizationRole: Membership.roles.MEMBER,
+      });
+
+      const blockedUserId = databaseBuilder.factory.buildUser.withoutPixAuthenticationMethod().id;
+      databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider({
+        externalIdentifier: 'samlId',
+        userId: blockedUserId,
+      });
+      databaseBuilder.factory.buildUserLogin({
+        userId: blockedUserId,
+        blockedAt: new Date(Date.now() + 3600 * 1000),
+        failureCount: 10,
+      });
+      const organizationLearnerId = databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
+        firstName: 'TemporaryBlocked',
+        lastName: 'User',
+        userId: blockedUserId,
+        organizationId,
+      }).id;
+
+      await databaseBuilder.commit();
+
+      const options = {
+        method: 'PUT',
+        url: `/api/organizations/${organizationId}/sco-organization-learners/${organizationLearnerId}/unblock`,
+        headers: generateAuthenticatedUserRequestHeaders({ userId: organizationMemberId }),
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(204);
+
+      const userLogins = await knex('user-logins');
+      const formerlyBlockedUser = userLogins.find((userLogin) => userLogin.userId === blockedUserId);
+      expect(formerlyBlockedUser.blockedAt).to.be.null;
+      expect(formerlyBlockedUser.failureCount).to.equal(0);
     });
   });
 });

--- a/api/tests/prescription/organization-learner/integration/application/sco-organization-learner-route_test.js
+++ b/api/tests/prescription/organization-learner/integration/application/sco-organization-learner-route_test.js
@@ -1,145 +1,148 @@
 import { scoOrganizationLearnerController } from '../../../../../src/prescription/organization-learner/application/sco-organization-learner-controller.js';
 import * as moduleUnderTest from '../../../../../src/prescription/organization-learner/application/sco-organization-learner-route.js';
 import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
-import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
+import { Membership } from '../../../../../src/shared/domain/models/Membership.js';
+import {
+  databaseBuilder,
+  expect,
+  generateAuthenticatedUserRequestHeaders,
+  HttpTestServer,
+  sinon,
+} from '../../../../test-helper.js';
 
 describe('Integration | Application | Route | sco-organization-learners', function () {
   let httpTestServer;
 
-  beforeEach(async function () {
-    sinon
-      .stub(securityPreHandlers, 'checkUserBelongsToScoOrganizationAndManagesStudents')
-      .callsFake((request, h) => h.response(true));
-    sinon
-      .stub(scoOrganizationLearnerController, 'generateUsername')
-      .callsFake((request, h) => h.response('ok').code(200));
-    sinon
-      .stub(scoOrganizationLearnerController, 'updatePassword')
-      .callsFake((request, h) => h.response('ok').code(200));
-    sinon
-      .stub(scoOrganizationLearnerController, 'createUserAndReconcileToOrganizationLearnerFromExternalUser')
-      .callsFake((request, h) => h.response('ok').code(200));
-    sinon
-      .stub(scoOrganizationLearnerController, 'generateUsernameWithTemporaryPassword')
-      .callsFake((request, h) => h.response('ok').code(200));
+  describe('PUT /api/organizations/{organizationId}/sco-organization-learners/{organizationLearnerId}/unblock', function () {
+    describe('When user does not belong to any organization', function () {
+      it('returns a 403 error', async function () {
+        const userId = databaseBuilder.factory.buildUser.withRawPassword().id;
+        await databaseBuilder.commit();
 
-    httpTestServer = new HttpTestServer();
-    await httpTestServer.register(moduleUnderTest);
+        httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        const method = 'PUT';
+        const headers = generateAuthenticatedUserRequestHeaders({ userId });
+        const organizationId = 123;
+        const organizationLearnerId = 456;
+        const url = `/api/organizations/${organizationId}/sco-organization-learners/${organizationLearnerId}/unblock`;
+
+        // when
+        const response = await httpTestServer.request(method, url, null, null, headers);
+
+        // then
+        expect(response.statusCode).to.equal(403);
+      });
+    });
+
+    describe('When user belongs to another managing student SCO organization', function () {
+      it('returns a 403 error', async function () {
+        const organizationId = databaseBuilder.factory.buildOrganization({
+          type: 'SCO',
+          isManagingStudents: true,
+        }).id;
+        const otherOrganizationId = databaseBuilder.factory.buildOrganization({
+          type: 'SCO',
+          isManagingStudents: true,
+        }).id;
+        const otherOrganizationMemberId = databaseBuilder.factory.buildUser.withRawPassword().id;
+        databaseBuilder.factory.buildMembership({
+          otherOrganizationId,
+          userId: otherOrganizationMemberId,
+          organizationRole: Membership.roles.MEMBER,
+        });
+        await databaseBuilder.commit();
+
+        httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        const method = 'PUT';
+        const headers = generateAuthenticatedUserRequestHeaders({ userId: otherOrganizationMemberId });
+        const organizationLearnerId = 456;
+        const url = `/api/organizations/${organizationId}/sco-organization-learners/${organizationLearnerId}/unblock`;
+
+        // when
+        const response = await httpTestServer.request(method, url, null, null, headers);
+
+        // then
+        expect(response.statusCode).to.equal(403);
+      });
+    });
   });
 
-  describe('POST /api/sco-organization-learners/external', function () {
-    let method;
-    let url;
-    let payload;
-    let response;
-
+  describe('When user belongs to this managing students SCO organization', function () {
     beforeEach(async function () {
-      // given
-      method = 'POST';
-      url = '/api/sco-organization-learners/external';
-      payload = {
-        data: {
-          attributes: {
-            'organization-id': 1,
-            'external-user-token': 'external-user-token',
-            birthdate: '1948-12-21',
-            'access-token': null,
-          },
-          type: 'external-users',
-        },
-      };
+      sinon
+        .stub(securityPreHandlers, 'checkUserBelongsToScoOrganizationAndManagesStudents')
+        .callsFake((request, h) => h.response(true));
+      sinon
+        .stub(scoOrganizationLearnerController, 'generateUsername')
+        .callsFake((request, h) => h.response('ok').code(200));
+      sinon
+        .stub(scoOrganizationLearnerController, 'updatePassword')
+        .callsFake((request, h) => h.response('ok').code(200));
+      sinon
+        .stub(scoOrganizationLearnerController, 'createUserAndReconcileToOrganizationLearnerFromExternalUser')
+        .callsFake((request, h) => h.response('ok').code(200));
+      sinon
+        .stub(scoOrganizationLearnerController, 'generateUsernameWithTemporaryPassword')
+        .callsFake((request, h) => h.response('ok').code(200));
+
+      httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
     });
 
-    it('should return a 400 Bad Request when organizationId is missing', async function () {
-      // given
-      payload.data.attributes['organization-id'] = undefined;
+    describe('POST /api/sco-organization-learners/external', function () {
+      let method;
+      let url;
+      let payload;
+      let response;
 
-      // when
-      response = await httpTestServer.request(method, url, payload);
-
-      // then
-      expect(response.statusCode).to.equal(400);
-      expect(JSON.parse(response.payload).errors[0].detail).to.equal('"data.attributes.organization-id" is required');
-    });
-
-    it('should return 400 Bad Request when external-user-token is missing', async function () {
-      // given
-      payload.data.attributes['external-user-token'] = '';
-
-      // when
-      response = await httpTestServer.request(method, url, payload);
-
-      // then
-      expect(response.statusCode).to.equal(400);
-      expect(JSON.parse(response.payload).errors[0].detail).to.equal(
-        '"data.attributes.external-user-token" is not allowed to be empty',
-      );
-    });
-
-    it('should return 400 Bad Request when birthDate is not a valid date', async function () {
-      // given
-      payload.data.attributes.birthdate = '2012*-12-12';
-
-      // when
-      response = await httpTestServer.request(method, url, payload);
-
-      // then
-      expect(response.statusCode).to.equal(400);
-      expect(JSON.parse(response.payload).errors[0].detail).to.equal(
-        '"data.attributes.birthdate" must be in YYYY-MM-DD format',
-      );
-    });
-  });
-
-  describe('POST /api/sco-organization-learners/dependent', function () {
-    let method;
-    let url;
-    let payload;
-    let response;
-
-    context('Error cases', function () {
       beforeEach(async function () {
         // given
         method = 'POST';
-        url = '/api/sco-organization-learners/dependent';
+        url = '/api/sco-organization-learners/external';
         payload = {
           data: {
             attributes: {
               'organization-id': 1,
-              'first-name': 'Robert',
-              'last-name': 'Smith',
-              birthdate: '2012-12-12',
-              username: 'robert.smith1212',
-              password: 'P@ssw0rd',
-              'with-username': true,
+              'external-user-token': 'external-user-token',
+              birthdate: '1948-12-21',
+              'access-token': null,
             },
+            type: 'external-users',
           },
         };
       });
 
-      it('should return 400 when firstName is empty', async function () {
+      it('should return a 400 Bad Request when organizationId is missing', async function () {
         // given
-        payload.data.attributes['first-name'] = '';
+        payload.data.attributes['organization-id'] = undefined;
 
         // when
         response = await httpTestServer.request(method, url, payload);
 
         // then
         expect(response.statusCode).to.equal(400);
+        expect(JSON.parse(response.payload).errors[0].detail).to.equal('"data.attributes.organization-id" is required');
       });
 
-      it('should return 400 when lastName is empty', async function () {
+      it('should return 400 Bad Request when external-user-token is missing', async function () {
         // given
-        payload.data.attributes['last-name'] = '';
+        payload.data.attributes['external-user-token'] = '';
 
         // when
         response = await httpTestServer.request(method, url, payload);
 
         // then
         expect(response.statusCode).to.equal(400);
+        expect(JSON.parse(response.payload).errors[0].detail).to.equal(
+          '"data.attributes.external-user-token" is not allowed to be empty',
+        );
       });
 
-      it('should return 400 when birthDate is not a valid date', async function () {
+      it('should return 400 Bad Request when birthDate is not a valid date', async function () {
         // given
         payload.data.attributes.birthdate = '2012*-12-12';
 
@@ -148,300 +151,364 @@ describe('Integration | Application | Route | sco-organization-learners', functi
 
         // then
         expect(response.statusCode).to.equal(400);
+        expect(JSON.parse(response.payload).errors[0].detail).to.equal(
+          '"data.attributes.birthdate" must be in YYYY-MM-DD format',
+        );
       });
+    });
 
-      it('should return 400 when organizationId is null', async function () {
+    describe('POST /api/sco-organization-learners/dependent', function () {
+      let method;
+      let url;
+      let payload;
+      let response;
+
+      context('Error cases', function () {
+        beforeEach(async function () {
+          // given
+          method = 'POST';
+          url = '/api/sco-organization-learners/dependent';
+          payload = {
+            data: {
+              attributes: {
+                'organization-id': 1,
+                'first-name': 'Robert',
+                'last-name': 'Smith',
+                birthdate: '2012-12-12',
+                username: 'robert.smith1212',
+                password: 'P@ssw0rd',
+                'with-username': true,
+              },
+            },
+          };
+        });
+
+        it('should return 400 when firstName is empty', async function () {
+          // given
+          payload.data.attributes['first-name'] = '';
+
+          // when
+          response = await httpTestServer.request(method, url, payload);
+
+          // then
+          expect(response.statusCode).to.equal(400);
+        });
+
+        it('should return 400 when lastName is empty', async function () {
+          // given
+          payload.data.attributes['last-name'] = '';
+
+          // when
+          response = await httpTestServer.request(method, url, payload);
+
+          // then
+          expect(response.statusCode).to.equal(400);
+        });
+
+        it('should return 400 when birthDate is not a valid date', async function () {
+          // given
+          payload.data.attributes.birthdate = '2012*-12-12';
+
+          // when
+          response = await httpTestServer.request(method, url, payload);
+
+          // then
+          expect(response.statusCode).to.equal(400);
+        });
+
+        it('should return 400 when organizationId is null', async function () {
+          // given
+          payload.data.attributes['organization-id'] = null;
+
+          // when
+          response = await httpTestServer.request(method, url, payload);
+
+          // then
+          expect(response.statusCode).to.equal(400);
+        });
+
+        it('should return 400 when password is not valid', async function () {
+          // given
+          payload.data.attributes.password = 'not_valid';
+
+          // when
+          response = await httpTestServer.request(method, url, payload);
+
+          // then
+          expect(response.statusCode).to.equal(400);
+        });
+
+        it('should return 400 when withUsername is not a boolean', async function () {
+          // given
+          payload.data.attributes['with-username'] = 'not_a_boolean';
+
+          // when
+          response = await httpTestServer.request(method, url, payload);
+
+          // then
+          expect(response.statusCode).to.equal(400);
+        });
+
+        context('when username is not valid', function () {
+          it('should return 400 when username is an email', async function () {
+            // given
+            payload.data.attributes.username = 'robert.smith1212@example.net';
+
+            // when
+            response = await httpTestServer.request(method, url, payload);
+
+            // then
+            expect(response.statusCode).to.equal(400);
+          });
+
+          it('should return 400 when username has not dot between names', async function () {
+            // given
+            payload.data.attributes.username = 'robertsmith1212';
+
+            // when
+            response = await httpTestServer.request(method, url, payload);
+
+            // then
+            expect(response.statusCode).to.equal(400);
+          });
+
+          it('should return 400 when username does not end with 4 digits', async function () {
+            // given
+            payload.data.attributes.username = 'robert.smith';
+
+            // when
+            response = await httpTestServer.request(method, url, payload);
+
+            // then
+            expect(response.statusCode).to.equal(400);
+          });
+
+          it('should return 400 when username is capitalized', async function () {
+            // given
+            payload.data.attributes.username = 'Robert.Smith1212';
+
+            // when
+            response = await httpTestServer.request(method, url, payload);
+            // then
+            expect(response.statusCode).to.equal(400);
+          });
+
+          it('should return 400 when username is a phone number', async function () {
+            // given
+            payload.data.attributes.username = '0601010101';
+
+            // when
+            response = await httpTestServer.request(method, url, payload);
+            // then
+            expect(response.statusCode).to.equal(400);
+          });
+        });
+      });
+    });
+
+    describe('POST /api/sco-organization-learners/password-update', function () {
+      it('should succeed', async function () {
         // given
-        payload.data.attributes['organization-id'] = null;
+        const method = 'POST';
+        const url = '/api/sco-organization-learners/password-update';
+        const payload = {
+          data: {
+            attributes: {
+              'organization-learner-id': 1,
+              'organization-id': 3,
+            },
+          },
+        };
 
         // when
-        response = await httpTestServer.request(method, url, payload);
+        const response = await httpTestServer.request(method, url, payload);
 
         // then
-        expect(response.statusCode).to.equal(400);
+        expect(response.statusCode).to.equal(200);
       });
+    });
 
-      it('should return 400 when password is not valid', async function () {
+    describe('POST /api/sco-organization-learners/username-password-generation', function () {
+      it('should succeed', async function () {
         // given
-        payload.data.attributes.password = 'not_valid';
+        const method = 'POST';
+        const url = '/api/sco-organization-learners/username-password-generation';
+        const payload = {
+          data: {
+            attributes: {
+              'organization-learner-id': 1,
+              'organization-id': 3,
+            },
+          },
+        };
 
         // when
-        response = await httpTestServer.request(method, url, payload);
+        const response = await httpTestServer.request(method, url, payload);
 
         // then
-        expect(response.statusCode).to.equal(400);
+        expect(response.statusCode).to.equal(200);
       });
+    });
 
-      it('should return 400 when withUsername is not a boolean', async function () {
+    describe('PUT /api/sco-organization-learners/possibilities', function () {
+      const method = 'PUT';
+      const url = '/api/sco-organization-learners/possibilities';
+
+      it('should exist', async function () {
         // given
-        payload.data.attributes['with-username'] = 'not_a_boolean';
+        const payload = {
+          data: {
+            attributes: {
+              'first-name': 'Robert',
+              'last-name': 'Smith',
+              birthdate: '2012-12-12',
+              'organization-id': 1,
+            },
+          },
+        };
 
         // when
-        response = await httpTestServer.request(method, url, payload);
+        const response = await httpTestServer.request(method, url, payload);
 
         // then
-        expect(response.statusCode).to.equal(400);
+        expect(response.statusCode).to.equal(200);
       });
 
-      context('when username is not valid', function () {
-        it('should return 400 when username is an email', async function () {
-          // given
-          payload.data.attributes.username = 'robert.smith1212@example.net';
+      it('should return an error when there is no payload', async function () {
+        // when
+        const response = await httpTestServer.request(method, url);
 
-          // when
-          response = await httpTestServer.request(method, url, payload);
-
-          // then
-          expect(response.statusCode).to.equal(400);
-        });
-
-        it('should return 400 when username has not dot between names', async function () {
-          // given
-          payload.data.attributes.username = 'robertsmith1212';
-
-          // when
-          response = await httpTestServer.request(method, url, payload);
-
-          // then
-          expect(response.statusCode).to.equal(400);
-        });
-
-        it('should return 400 when username does not end with 4 digits', async function () {
-          // given
-          payload.data.attributes.username = 'robert.smith';
-
-          // when
-          response = await httpTestServer.request(method, url, payload);
-
-          // then
-          expect(response.statusCode).to.equal(400);
-        });
-
-        it('should return 400 when username is capitalized', async function () {
-          // given
-          payload.data.attributes.username = 'Robert.Smith1212';
-
-          // when
-          response = await httpTestServer.request(method, url, payload);
-          // then
-          expect(response.statusCode).to.equal(400);
-        });
-
-        it('should return 400 when username is a phone number', async function () {
-          // given
-          payload.data.attributes.username = '0601010101';
-
-          // when
-          response = await httpTestServer.request(method, url, payload);
-          // then
-          expect(response.statusCode).to.equal(400);
-        });
+        // then
+        expect(response.statusCode).to.equal(422);
       });
-    });
-  });
 
-  describe('POST /api/sco-organization-learners/password-update', function () {
-    it('should succeed', async function () {
-      // given
-      const method = 'POST';
-      const url = '/api/sco-organization-learners/password-update';
-      const payload = {
-        data: {
-          attributes: {
-            'organization-learner-id': 1,
-            'organization-id': 3,
+      it('should return an error when there is an invalid first name attribute in the payload', async function () {
+        // given
+        const INVALID_FIRSTNAME = ' ';
+        const payload = {
+          data: {
+            attributes: {
+              'first-name': INVALID_FIRSTNAME,
+              'last-name': 'Smith',
+              birthdate: '2012-12-12',
+              'organization-id': 1,
+            },
           },
-        },
-      };
+        };
 
-      // when
-      const response = await httpTestServer.request(method, url, payload);
+        // when
+        const response = await httpTestServer.request(method, url, payload);
 
-      // then
-      expect(response.statusCode).to.equal(200);
-    });
-  });
+        // then
+        expect(response.statusCode).to.equal(422);
+      });
 
-  describe('POST /api/sco-organization-learners/username-password-generation', function () {
-    it('should succeed', async function () {
-      // given
-      const method = 'POST';
-      const url = '/api/sco-organization-learners/username-password-generation';
-      const payload = {
-        data: {
-          attributes: {
-            'organization-learner-id': 1,
-            'organization-id': 3,
+      it('should return an error when there is an invalid last name attribute in the payload', async function () {
+        // given
+        const INVALID_LASTNAME = '';
+        const payload = {
+          data: {
+            attributes: {
+              'first-name': 'Robert',
+              'last-name': INVALID_LASTNAME,
+              birthdate: '2012-12-12',
+              'organization-id': 1,
+            },
           },
-        },
-      };
+        };
 
-      // when
-      const response = await httpTestServer.request(method, url, payload);
+        // when
+        const response = await httpTestServer.request(method, url, payload);
 
-      // then
-      expect(response.statusCode).to.equal(200);
-    });
-  });
+        // then
+        expect(response.statusCode).to.equal(422);
+      });
 
-  describe('PUT /api/sco-organization-learners/possibilities', function () {
-    const method = 'PUT';
-    const url = '/api/sco-organization-learners/possibilities';
-
-    it('should exist', async function () {
-      // given
-      const payload = {
-        data: {
-          attributes: {
-            'first-name': 'Robert',
-            'last-name': 'Smith',
-            birthdate: '2012-12-12',
-            'organization-id': 1,
+      it('should return an error when there is an invalid a birthdate attribute (with space) in the payload', async function () {
+        // given
+        const INVALID_BIRTHDATE = '2012- 12-12';
+        const payload = {
+          data: {
+            attributes: {
+              'first-name': 'Robert',
+              'last-name': 'Smith',
+              birthdate: INVALID_BIRTHDATE,
+              'organization-id': 1,
+            },
           },
-        },
-      };
+        };
 
-      // when
-      const response = await httpTestServer.request(method, url, payload);
+        // when
+        const response = await httpTestServer.request(method, url, payload);
 
-      // then
-      expect(response.statusCode).to.equal(200);
-    });
+        // then
+        expect(response.statusCode).to.equal(422);
+      });
 
-    it('should return an error when there is no payload', async function () {
-      // when
-      const response = await httpTestServer.request(method, url);
+      it('should return an error when there is an invalid birthdate attribute (with extra zeros) in the payload', async function () {
+        // given
+        const INVALID_BIRTHDATE = '2012-012-12';
 
-      // then
-      expect(response.statusCode).to.equal(422);
-    });
-
-    it('should return an error when there is an invalid first name attribute in the payload', async function () {
-      // given
-      const INVALID_FIRSTNAME = ' ';
-      const payload = {
-        data: {
-          attributes: {
-            'first-name': INVALID_FIRSTNAME,
-            'last-name': 'Smith',
-            birthdate: '2012-12-12',
-            'organization-id': 1,
+        // when
+        const payload = {
+          data: {
+            attributes: {
+              'first-name': 'Robert',
+              'last-name': 'Smith',
+              birthdate: INVALID_BIRTHDATE,
+              'organization-id': 1,
+            },
           },
-        },
-      };
+        };
 
-      // when
-      const response = await httpTestServer.request(method, url, payload);
+        // when
+        const response = await httpTestServer.request(method, url, payload);
 
-      // then
-      expect(response.statusCode).to.equal(422);
-    });
+        // then
+        expect(response.statusCode).to.equal(422);
+      });
 
-    it('should return an error when there is an invalid last name attribute in the payload', async function () {
-      // given
-      const INVALID_LASTNAME = '';
-      const payload = {
-        data: {
-          attributes: {
-            'first-name': 'Robert',
-            'last-name': INVALID_LASTNAME,
-            birthdate: '2012-12-12',
-            'organization-id': 1,
+      it('should return an error when there is an invalid birthdate attribute (not a proper date) in the payload', async function () {
+        // given
+        const INVALID_BIRTHDATE = '1999-99-99';
+        const payload = {
+          data: {
+            attributes: {
+              'first-name': 'Robert',
+              'last-name': 'Smith',
+              birthdate: INVALID_BIRTHDATE,
+              'organization-id': 1,
+            },
           },
-        },
-      };
+        };
 
-      // when
-      const response = await httpTestServer.request(method, url, payload);
+        // when
+        const response = await httpTestServer.request(method, url, payload);
 
-      // then
-      expect(response.statusCode).to.equal(422);
-    });
+        // then
+        expect(response.statusCode).to.equal(422);
+      });
 
-    it('should return an error when there is an invalid a birthdate attribute (with space) in the payload', async function () {
-      // given
-      const INVALID_BIRTHDATE = '2012- 12-12';
-      const payload = {
-        data: {
-          attributes: {
-            'first-name': 'Robert',
-            'last-name': 'Smith',
-            birthdate: INVALID_BIRTHDATE,
-            'organization-id': 1,
+      it('should return an error when there is an invalid campaign code attribute in the payload', async function () {
+        // given
+        const INVALID_CAMPAIGNCODE = '';
+        const payload = {
+          data: {
+            attributes: {
+              'first-name': 'Robert',
+              'last-name': 'Smith',
+              birthdate: '2012-12-12',
+              'organization-id': INVALID_CAMPAIGNCODE,
+            },
           },
-        },
-      };
+        };
 
-      // when
-      const response = await httpTestServer.request(method, url, payload);
+        // when
+        const response = await httpTestServer.request(method, url, payload);
 
-      // then
-      expect(response.statusCode).to.equal(422);
-    });
-
-    it('should return an error when there is an invalid birthdate attribute (with extra zeros) in the payload', async function () {
-      // given
-      const INVALID_BIRTHDATE = '2012-012-12';
-
-      // when
-      const payload = {
-        data: {
-          attributes: {
-            'first-name': 'Robert',
-            'last-name': 'Smith',
-            birthdate: INVALID_BIRTHDATE,
-            'organization-id': 1,
-          },
-        },
-      };
-
-      // when
-      const response = await httpTestServer.request(method, url, payload);
-
-      // then
-      expect(response.statusCode).to.equal(422);
-    });
-
-    it('should return an error when there is an invalid birthdate attribute (not a proper date) in the payload', async function () {
-      // given
-      const INVALID_BIRTHDATE = '1999-99-99';
-      const payload = {
-        data: {
-          attributes: {
-            'first-name': 'Robert',
-            'last-name': 'Smith',
-            birthdate: INVALID_BIRTHDATE,
-            'organization-id': 1,
-          },
-        },
-      };
-
-      // when
-      const response = await httpTestServer.request(method, url, payload);
-
-      // then
-      expect(response.statusCode).to.equal(422);
-    });
-
-    it('should return an error when there is an invalid campaign code attribute in the payload', async function () {
-      // given
-      const INVALID_CAMPAIGNCODE = '';
-      const payload = {
-        data: {
-          attributes: {
-            'first-name': 'Robert',
-            'last-name': 'Smith',
-            birthdate: '2012-12-12',
-            'organization-id': INVALID_CAMPAIGNCODE,
-          },
-        },
-      };
-
-      // when
-      const response = await httpTestServer.request(method, url, payload);
-
-      // then
-      expect(response.statusCode).to.equal(422);
+        // then
+        expect(response.statusCode).to.equal(422);
+      });
     });
   });
 });

--- a/api/tests/prescription/organization-learner/integration/domain/usecases/unblock-organization-learner-account.test.js
+++ b/api/tests/prescription/organization-learner/integration/domain/usecases/unblock-organization-learner-account.test.js
@@ -1,0 +1,37 @@
+import { usecases } from '../../../../../../src/prescription/organization-learner/domain/usecases/index.js';
+import { databaseBuilder, expect } from '../../../../../test-helper.js';
+
+describe('Integration | Prescription | Organization Learner | Domain | UseCase | unblockOrganizationLearnerAccount', function () {
+  it('unblocks an organization learner account', async function () {
+    // given
+    const blockedUserId = databaseBuilder.factory.buildUser.withoutPixAuthenticationMethod().id;
+    databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider({
+      externalIdentifier: 'samlId',
+      userId: blockedUserId,
+    });
+    databaseBuilder.factory.buildUserLogin({
+      temporaryBlockedUntil: new Date(Date.now() + 3600 * 1000),
+      userId: blockedUserId,
+    });
+
+    const organizationId = databaseBuilder.factory.buildOrganization({
+      type: 'SCO',
+      isManagingStudents: true,
+    }).id;
+    const organizationLearnerId = databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
+      firstName: 'Blocked',
+      lastName: 'User',
+      userId: blockedUserId,
+      organizationId,
+    }).id;
+
+    await databaseBuilder.commit();
+
+    // when
+    const result = await usecases.unblockOrganizationLearnerAccount({ organizationId, organizationLearnerId });
+
+    // then
+    expect(result.temporaryBlockedUntil).equal(null);
+    expect(result.blockedAt).equal(null);
+  });
+});

--- a/api/tests/prescription/organization-learner/integration/domain/usecases/unblock-organization-learner-account.test.js
+++ b/api/tests/prescription/organization-learner/integration/domain/usecases/unblock-organization-learner-account.test.js
@@ -2,7 +2,7 @@ import { usecases } from '../../../../../../src/prescription/organization-learne
 import { databaseBuilder, expect } from '../../../../../test-helper.js';
 
 describe('Integration | Prescription | Organization Learner | Domain | UseCase | unblockOrganizationLearnerAccount', function () {
-  it('unblocks an organization learner account', async function () {
+  it('unblocks a blocked organization learner account', async function () {
     // given
     const blockedUserId = databaseBuilder.factory.buildUser.withoutPixAuthenticationMethod().id;
     databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider({
@@ -10,7 +10,8 @@ describe('Integration | Prescription | Organization Learner | Domain | UseCase |
       userId: blockedUserId,
     });
     databaseBuilder.factory.buildUserLogin({
-      temporaryBlockedUntil: new Date(Date.now() + 3600 * 1000),
+      blockedAt: new Date(Date.now() + 3600 * 1000),
+      failureCount: 10,
       userId: blockedUserId,
     });
 
@@ -31,7 +32,41 @@ describe('Integration | Prescription | Organization Learner | Domain | UseCase |
     const result = await usecases.unblockOrganizationLearnerAccount({ organizationId, organizationLearnerId });
 
     // then
-    expect(result.temporaryBlockedUntil).equal(null);
     expect(result.blockedAt).equal(null);
+    expect(result.failureCount).equal(0);
+  });
+
+  it('unblocks a temporary blocked organization learner account', async function () {
+    // given
+    const temporaryBlockedUserId = databaseBuilder.factory.buildUser.withoutPixAuthenticationMethod().id;
+    databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider({
+      externalIdentifier: 'samlId',
+      userId: temporaryBlockedUserId,
+    });
+    databaseBuilder.factory.buildUserLogin({
+      temporaryBlockedUntil: new Date(Date.now() + 3600 * 1000),
+      failureCount: 5,
+      userId: temporaryBlockedUserId,
+    });
+
+    const organizationId = databaseBuilder.factory.buildOrganization({
+      type: 'SCO',
+      isManagingStudents: true,
+    }).id;
+    const organizationLearnerId = databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
+      firstName: 'Blocked',
+      lastName: 'User',
+      userId: temporaryBlockedUserId,
+      organizationId,
+    }).id;
+
+    await databaseBuilder.commit();
+
+    // when
+    const result = await usecases.unblockOrganizationLearnerAccount({ organizationId, organizationLearnerId });
+
+    // then
+    expect(result.temporaryBlockedUntil).equal(null);
+    expect(result.failureCount).equal(0);
   });
 });


### PR DESCRIPTION
## 🥀 Problème
On souhaite qu'un professeur membre d'une organisation puisse débloquer le compte bloqué d’un élève.

## 🏹 Proposition
Ajouter une nouvelle route qui permettra à un membre d'une orga Scolaire de débloquer les élèves dont il a la responsabilité.

## ❤️‍🔥 Pour tester

En local :

- Connectez-vous sur Pix Orga en tant que membre d'une orga (par exemple orgacces).
- Récupérez l'access token de l'utilisateur connecté, et l'id de l'organisation (${organizationId}).
- Dans la liste des élèves, récupérez l'organizationLearnerId de l'élève temporairement bloqué et l'organizationLearnerId de l'élève bloqué , en cliquant sur leurs fiches par exemple.

Pour l'**élève temporairement bloqué** puis pour l'**élève bloqué**, faire cette requête curl en plaçant les 3 bonnes valeurs :

```shell
curl -H "Authorization: Bearer ${access-token}" -H 'Accept: application/json' -H "Content-Type: application/json" -X PUT  https://orga.dev.pix.fr/api/organizations/${organizationId}/sco-organization-learners/${organizationLearnerId}/unblock
```

- Vérifier que les informations des élèves ont été mises à jour :
Dans la table `user-logins` : `temporaryBlockedUntil` doit être à `NULL` pour l'élève temporairement bloqué, `blockedAt` doit être à `NULL` pour l'élève bloqué, et dans les deux cas le `failureCount` doit être à 0 (pour cela il faut récupérer le `userId`  de l'organization learner :
`SELECT * from "organization-learners" WHERE "id" = ${organizationLearnerId};`
puis`SELECT * FROM "user-logins" WHERE "userId" = ${userId};`)

- Vérifiez que vous pouvez vous connecter sur Pix App en tant qu'élève anciennement bloqué.