### PR TITLE
[BUGFIX] Temporairement enlever la révocation des Access Tokens et Refresh Tokens pour le SSO OIDC (PIX-21850)

### DIFF
--- a/api/src/identity-access-management/domain/usecases/logout-oidc-user.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/logout-oidc-user.usecase.js
@@ -14,17 +14,19 @@ async function logoutOidcUser({
   requestedApplication,
   logoutUrlUUID,
   oidcAuthenticationServiceRegistry,
-  revokedUserAccessRepository,
-  refreshTokenRepository,
 }) {
   // Revoke user AccessToken
-  await revokedUserAccessRepository.saveForUser({
+  //temporarily pause revoke user access token to fix SSO bugs
+  /*await revokedUserAccessRepository.saveForUser({
     userId,
     revokeUntil: new Date(),
-  });
+  });*/
 
   // Revoke user RefreshToken
+  //temporarily pause revoke user refresh token to fix SSO bugs
+  /*
   await refreshTokenRepository.revokeAllByUserId({ userId });
+*/
 
   const oidcAuthenticationService = await oidcAuthenticationServiceRegistry.getOidcProviderServiceByCode({
     identityProviderCode: identityProvider,

--- a/api/tests/identity-access-management/acceptance/application/oidc-provider.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/oidc-provider.route.test.js
@@ -3,8 +3,6 @@ import querystring from 'node:querystring';
 import jsonwebtoken from 'jsonwebtoken';
 
 import { authenticationSessionService } from '../../../../src/identity-access-management/domain/services/authentication-session.service.js';
-import { refreshTokenRepository } from '../../../../src/identity-access-management/infrastructure/repositories/refresh-token.repository.js';
-import { revokedUserAccessRepository } from '../../../../src/identity-access-management/infrastructure/repositories/revoked-user-access.repository.js';
 import { AuthenticationSessionContent } from '../../../../src/shared/domain/models/AuthenticationSessionContent.js';
 import { tokenService } from '../../../../src/shared/domain/services/token-service.js';
 import {
@@ -617,10 +615,10 @@ describe('Acceptance | Identity Access Management | Application | Route | oidc-p
         'https://oidc.example.net/ea5ac20c-5076-4806-860a-b0aeb01645d4/oauth2/v2.0/logout?client_id=client',
       );
 
-      const revokedUserAccess = await revokedUserAccessRepository.findByUserId(userId);
+      /*const revokedUserAccess = await revokedUserAccessRepository.findByUserId(userId);
       expect(revokedUserAccess.revokeTimeStamp).to.be.a('number');
       const refreshTokens = await refreshTokenRepository.findAllByUserId(userId);
-      expect(refreshTokens).to.have.lengthOf(0);
+      expect(refreshTokens).to.have.lengthOf(0);*/
     });
   });
 


### PR DESCRIPTION
## 🥀 Problème
Des bugs de 401 en boucle suite à la révocation des access et fresh tokens mise en place avec #15130 ont été constatés. 

## 🏹 Proposition
En attendant de consolider une solution pérenne, mettre en commentaire les révocations d'access token et refresh token. 

## ❤️‍🔥 Pour tester
- Se connecter à une appli front à l'aide d'un SSO
- Se déconnecter
- Pouvoir se reconnecter ensuite