### PR TITLE
[FEATURE] Réparation et amélioration du simulateur de scoring Pix transverse  (PIX-21851)

### DIFF
--- a/admin/app/adapters/scoring-and-capacity-simulator-report.js
+++ b/admin/app/adapters/scoring-and-capacity-simulator-report.js
@@ -3,12 +3,12 @@ import ApplicationAdapter from './application';
 export default class ScoringAndCapacitySimulatorReportAdapter extends ApplicationAdapter {
   namespace = 'api/admin';
 
-  getSimulatorResult({ score, capacity }) {
+  getSimulatorResult({ score, capacity, date }) {
     let data;
     if (score) {
-      data = { score };
+      data = { score, date };
     } else if (capacity) {
-      data = { capacity };
+      data = { capacity, date };
     }
     const url = `${this.host}/${this.namespace}/simulate-score-or-capacity`;
     return this.ajax(url, 'POST', {

--- a/admin/app/components/tools/certification/scoring-simulator.gjs
+++ b/admin/app/components/tools/certification/scoring-simulator.gjs
@@ -14,6 +14,7 @@ export default class ScoringSimulator extends Component {
   @tracked validationStatus = 'default';
   @tracked score = null;
   @tracked capacity = null;
+  @tracked date = new Date();
   @tracked simulatorReport = null;
   @tracked errors = [];
   @service store;
@@ -36,14 +37,15 @@ export default class ScoringSimulator extends Component {
     if (isFormInvalid) {
       return;
     }
-
     this.simulatorReport = await adapter.getSimulatorResult({
       score: this.score,
       capacity: this.capacity,
+      date: this.date,
     });
 
     this.score = null;
     this.capacity = null;
+    this.date = new Date();
   }
 
   @action
@@ -56,6 +58,11 @@ export default class ScoringSimulator extends Component {
   updateCapacity(event) {
     this._cleanErrors();
     this.capacity = event.target.value;
+  }
+
+  @action
+  updateDate(event) {
+    this.date = event.target.value;
   }
 
   checkFormValidity() {
@@ -89,6 +96,10 @@ export default class ScoringSimulator extends Component {
 
         <PixInput @id="capacity" {{on "input" this.updateCapacity}} @value={{this.capacity}} type="number">
           <:label>{{t "pages.administration.certification.scoring-simulator.labels.capacity-input"}}</:label>
+        </PixInput>
+
+        <PixInput type="date" @value={{this.date}} {{on "change" this.updateDate}}>
+          <:label>{{t "pages.administration.certification.scoring-simulator.labels.date-input"}}</:label>
         </PixInput>
 
         <PixButton

--- a/admin/app/components/tools/certification/scoring-simulator.gjs
+++ b/admin/app/components/tools/certification/scoring-simulator.gjs
@@ -9,12 +9,13 @@ import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
+import formatDateToStandard from 'pix-admin/utils/date';
 
 export default class ScoringSimulator extends Component {
   @tracked validationStatus = 'default';
   @tracked score = null;
   @tracked capacity = null;
-  @tracked date = new Date();
+  @tracked date = formatDateToStandard(new Date());
   @tracked simulatorReport = null;
   @tracked errors = [];
   @service store;
@@ -42,10 +43,6 @@ export default class ScoringSimulator extends Component {
       capacity: this.capacity,
       date: this.date,
     });
-
-    this.score = null;
-    this.capacity = null;
-    this.date = new Date();
   }
 
   @action
@@ -90,7 +87,7 @@ export default class ScoringSimulator extends Component {
       </header>
 
       <form class="scoring-simulator-form">
-        <PixInput {{on "input" this.updateScore}} @id="score" @value={{this.score}} type="number">
+        <PixInput @id="score" {{on "input" this.updateScore}} @value={{this.score}} type="number">
           <:label>{{t "pages.administration.certification.scoring-simulator.labels.score-input"}}</:label>
         </PixInput>
 
@@ -98,7 +95,7 @@ export default class ScoringSimulator extends Component {
           <:label>{{t "pages.administration.certification.scoring-simulator.labels.capacity-input"}}</:label>
         </PixInput>
 
-        <PixInput type="date" @value={{this.date}} {{on "change" this.updateDate}}>
+        <PixInput @id="date" {{on "change" this.updateDate}} @value={{this.date}} type="date">
           <:label>{{t "pages.administration.certification.scoring-simulator.labels.date-input"}}</:label>
         </PixInput>
 

--- a/admin/app/utils/date.js
+++ b/admin/app/utils/date.js
@@ -1,0 +1,3 @@
+export default function formatDateToStandard(date) {
+  return new Date(date).toLocaleDateString('en-CA');
+}

--- a/admin/tests/unit/adapters/scoring-and-capacity-simulator-report-test.js
+++ b/admin/tests/unit/adapters/scoring-and-capacity-simulator-report-test.js
@@ -12,9 +12,12 @@ module('Unit | Adapter | scoring-and-capacity-simulator-report', function (hooks
         const adapter = this.owner.lookup('adapter:scoring-and-capacity-simulator-report');
         sinon.stub(adapter, 'ajax');
 
+        const date = new Date();
+
         const adapterOptions = {
           score: 1,
           capacity: null,
+          date: new Date(),
         };
 
         // when
@@ -26,6 +29,7 @@ module('Unit | Adapter | scoring-and-capacity-simulator-report', function (hooks
           data: {
             data: {
               score: 1,
+              date,
             },
           },
         };
@@ -40,9 +44,12 @@ module('Unit | Adapter | scoring-and-capacity-simulator-report', function (hooks
         const adapter = this.owner.lookup('adapter:scoring-and-capacity-simulator-report');
         sinon.stub(adapter, 'ajax');
 
+        const date = new Date();
+
         const adapterOptions = {
           capacity: 1,
           score: null,
+          date,
         };
 
         // when
@@ -54,6 +61,7 @@ module('Unit | Adapter | scoring-and-capacity-simulator-report', function (hooks
           data: {
             data: {
               capacity: 1,
+              date,
             },
           },
         };

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -1064,6 +1064,8 @@
           "labels": {
             "capacity": "Capacity :",
             "capacity-input": "Capacity",
+            "date": "Date :",
+            "date-input": "Start of certification date",
             "level": "Level :",
             "score": "Score :",
             "score-input": "Global score in Pix"

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -1066,6 +1066,8 @@
           "labels": {
             "capacity": "Capacité :",
             "capacity-input": "Capacité",
+            "date": "Date :",
+            "date-input": "Date d'entrée en certif",
             "level": "Niveau :",
             "score": "Score :",
             "score-input": "Score global en Pix"

--- a/api/src/certification/evaluation/application/scoring-and-capacity-simulator-controller.js
+++ b/api/src/certification/evaluation/application/scoring-and-capacity-simulator-controller.js
@@ -2,20 +2,20 @@ import { usecases } from '../domain/usecases/index.js';
 import * as serializer from '../infrastructure/serializers/scoring-and-capacity-simulator-report-serializer.js';
 
 const simulateScoringOrCapacity = async (req, h) => {
-  const { capacity, score } = req.payload.data;
+  const { capacity, score, date } = req.payload.data;
 
   let scoringAndCapacitySimulatorReport;
   if (score) {
     scoringAndCapacitySimulatorReport = await usecases.simulateCapacityFromScore({
       score,
-      date: new Date(),
+      date,
     });
   }
 
   if (capacity) {
     scoringAndCapacitySimulatorReport = await usecases.simulateScoreFromCapacity({
       capacity,
-      date: new Date(),
+      date,
     });
   }
 

--- a/api/src/certification/evaluation/application/scoring-and-capacity-simulator-route.js
+++ b/api/src/certification/evaluation/application/scoring-and-capacity-simulator-route.js
@@ -20,6 +20,7 @@ const register = async (server) => {
             data: Joi.object({
               score: Joi.number(),
               capacity: Joi.number(),
+              date: Joi.date(),
             }).xor('score', 'capacity'),
           }),
         },

--- a/api/src/certification/evaluation/infrastructure/repositories/scoring-configuration-repository.js
+++ b/api/src/certification/evaluation/infrastructure/repositories/scoring-configuration-repository.js
@@ -2,6 +2,7 @@ import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.j
 import { NotFoundError } from '../../../../shared/domain/errors.js';
 import * as areaRepository from '../../../../shared/infrastructure/repositories/area-repository.js';
 import * as competenceRepository from '../../../../shared/infrastructure/repositories/competence-repository.js';
+import { SCOPES } from '../../../shared/domain/models/Scopes.js';
 import { V3CertificationScoring } from '../../domain/models/V3CertificationScoring.js';
 
 export const getLatestByDateAndLocale = async ({ locale, date }) => {
@@ -17,7 +18,8 @@ export const getLatestByDateAndLocale = async ({ locale, date }) => {
       'competencesScoringConfiguration',
       'minimumAnswersRequiredToValidateACertification',
     )
-    .where('startDate', '<=', date)
+    .where('scope', SCOPES.CORE)
+    .andWhere('startDate', '<=', date)
     .andWhere((queryBuilder) => {
       queryBuilder.whereNull('expirationDate').orWhere('expirationDate', '>', date);
     })

--- a/api/tests/certification/evaluation/acceptance/scoring-and-capacity-simulator-route_test.js
+++ b/api/tests/certification/evaluation/acceptance/scoring-and-capacity-simulator-route_test.js
@@ -484,6 +484,7 @@ describe('Certification | Evaluation | Acceptance | scoring-and-capacity-simulat
               data: {
                 score: 127,
                 capacity: undefined,
+                date: new Date(),
               },
             },
           };

--- a/api/tests/certification/evaluation/unit/application/scoring-and-capacity-simulator-controller_test.js
+++ b/api/tests/certification/evaluation/unit/application/scoring-and-capacity-simulator-controller_test.js
@@ -30,6 +30,7 @@ describe('Unit | Application | scoringAndCapacitySimulatorController', function 
             data: {
               capacity,
               score: undefined,
+              date: now,
             },
           },
         };
@@ -57,6 +58,7 @@ describe('Unit | Application | scoringAndCapacitySimulatorController', function 
             data: {
               capacity: undefined,
               score,
+              date: now,
             },
           },
         };


### PR DESCRIPTION
## 🥀 Problème

Dans le cadre des outils mis à disposition au métier dans Pix Admin, un simulateur de scoring leur permet d’obtenir la capacité correspondante à un score donné et inversement, ainsi qu’un détail des niveaux potentiellement atteints dans les différentes compétences du référentiel de certification Pix transverse.

Or, le simulateur est actuellement KO car il manque une condition sur le scope dans la requête récupérant la configuration de scoring et le simulateur fonctionne sur la version actuelle de cœur uniquement. 

## 🏹 Proposition

Corriger a requête et ajouter un champ date dans le front pour pouvoir simuler un résultat pour un date d'entrée en certif donnée.

<img width="823" height="220" alt="image" src="https://github.com/user-attachments/assets/e99bf671-8da0-484b-aef9-333c82989efe" />

## 💌 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## ❤️‍🔥 Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
