### PR TITLE
[FEATURE] Ajouter le nom des référentiels dans la page de sélection de sujet (PIX-21790)

### DIFF
--- a/orga/app/adapters/framework.js
+++ b/orga/app/adapters/framework.js
@@ -4,4 +4,9 @@ export default class FrameworkAdapter extends ApplicationAdapter {
   urlForQuery() {
     return `${this.host}/${this.namespace}/frameworks/for-target-profile-submission`;
   }
+
+  urlForFindAll(modelName, { adapterOptions }) {
+    const { organizationId } = adapterOptions;
+    return `${this.host}/${this.namespace}/organizations/${organizationId}/frameworks`;
+  }
 }

--- a/orga/app/components/tube/list.gjs
+++ b/orga/app/components/tube/list.gjs
@@ -61,16 +61,6 @@ export default class TubeList extends Component {
   isTubeSelected = (tube) => {
     return this.selectedTubeIds.includes(tube.id);
   };
-
-  get sortedAreas() {
-    return this.args.frameworks
-      .map((framework) => framework.sortedAreas)
-      .flat()
-      .sort((a, b) => {
-        return a.code.localeCompare(b.code);
-      });
-  }
-
   get haveNoTubeSelected() {
     return this.selectedTubeIds.length === 0;
   }
@@ -135,58 +125,64 @@ export default class TubeList extends Component {
           </PixButtonLink>
         {{/if}}
       </div>
-      {{#each this.sortedAreas as |area|}}
-        <PixAccordions class="{{area.color}}">
-          <:title>{{area.code}} · {{area.title}}</:title>
-          <:content>
-            {{#each area.sortedCompetences as |competence|}}
-              <h2>{{competence.index}} {{competence.name}}</h2>
-              <table class="table content-text content-text--small preselect-tube-table">
-                <caption>{{t "pages.preselect-target-profile.table.caption"}}</caption>
-                <thead>
-                  <tr>
-                    <Header @size="medium" scope="col">
-                      {{t "pages.preselect-target-profile.table.column.theme-name"}}
-                    </Header>
-                    <Header @size="wide" scope="col">
-                      {{t "pages.preselect-target-profile.table.column.name"}}
-                    </Header>
-                    <Header @size="small" @align="center" scope="col">
-                      {{t "pages.preselect-target-profile.table.column.mobile"}}
-                    </Header>
-                    <Header @size="small" @align="center" scope="col">
-                      {{t "pages.preselect-target-profile.table.column.tablet"}}
-                    </Header>
-                  </tr>
-                </thead>
+      {{#each @frameworks as |framework|}}
+        <section class="framework">
+          <h2 class="framework__title">{{framework.name}}</h2>
+          <div>
+            {{#each framework.sortedAreas as |area|}}
+              <PixAccordions class="{{area.color}}">
+                <:title>{{area.code}} · {{area.title}}</:title>
+                <:content>
+                  {{#each area.sortedCompetences as |competence|}}
+                    <h3>{{competence.index}} {{competence.name}}</h3>
+                    <table class="table content-text content-text--small preselect-tube-table">
+                      <caption>{{t "pages.preselect-target-profile.table.caption"}}</caption>
+                      <thead>
+                        <tr>
+                          <Header @size="medium" scope="col">
+                            {{t "pages.preselect-target-profile.table.column.theme-name"}}
+                          </Header>
+                          <Header @size="wide" scope="col">
+                            {{t "pages.preselect-target-profile.table.column.name"}}
+                          </Header>
+                          <Header @size="small" @align="center" scope="col">
+                            {{t "pages.preselect-target-profile.table.column.mobile"}}
+                          </Header>
+                          <Header @size="small" @align="center" scope="col">
+                            {{t "pages.preselect-target-profile.table.column.tablet"}}
+                          </Header>
+                        </tr>
+                      </thead>
 
-                <tbody>
-                  {{#each competence.sortedThematics as |thematic|}}
-                    {{#each thematic.tubes as |tube index|}}
-                      <tr class="row-tube" aria-label={{t "pages.preselect-target-profile.table.row-title"}}>
-                        {{#if (eq index 0)}}
-                          <Thematic
-                            @thematic={{thematic}}
-                            @getThematicState={{this.getThematicState}}
-                            @selectThematic={{this.selectThematic}}
-                            @unselectThematic={{this.unselectThematic}}
-                          />
-                        {{/if}}
-                        <Tube
-                          @tube={{tube}}
-                          @isTubeSelected={{this.isTubeSelected}}
-                          @selectTube={{this.selectTube}}
-                          @unselectTube={{this.unselectTube}}
-                        />
-                      </tr>
-                    {{/each}}
+                      <tbody>
+                        {{#each competence.sortedThematics as |thematic|}}
+                          {{#each thematic.tubes as |tube index|}}
+                            <tr class="row-tube" aria-label={{t "pages.preselect-target-profile.table.row-title"}}>
+                              {{#if (eq index 0)}}
+                                <Thematic
+                                  @thematic={{thematic}}
+                                  @getThematicState={{this.getThematicState}}
+                                  @selectThematic={{this.selectThematic}}
+                                  @unselectThematic={{this.unselectThematic}}
+                                />
+                              {{/if}}
+                              <Tube
+                                @tube={{tube}}
+                                @isTubeSelected={{this.isTubeSelected}}
+                                @selectTube={{this.selectTube}}
+                                @unselectTube={{this.unselectTube}}
+                              />
+                            </tr>
+                          {{/each}}
+                        {{/each}}
+                      </tbody>
+                    </table>
                   {{/each}}
-                </tbody>
-              </table>
+                </:content>
+              </PixAccordions>
             {{/each}}
-          </:content>
-        </PixAccordions>
-
+          </div>
+        </section>
       {{/each}}
     </section>
   </template>

--- a/orga/app/routes/authenticated/preselect-target-profile.js
+++ b/orga/app/routes/authenticated/preselect-target-profile.js
@@ -1,18 +1,17 @@
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
-import RSVP from 'rsvp';
 
 export default class PreselectTargetProfileRoute extends Route {
   @service currentUser;
   @service store;
 
   async model() {
-    const organization = this.currentUser.organization;
-    const frameworks = this.store.query('framework', {});
+    const organization = await this.currentUser.organization;
+    const frameworks = await this.store.findAll('framework', { adapterOptions: { organizationId: organization.id } });
 
-    return RSVP.hash({
+    return {
       organization,
       frameworks,
-    });
+    };
   }
 }

--- a/orga/app/styles/pages/authenticated/preselect-target-profile.scss
+++ b/orga/app/styles/pages/authenticated/preselect-target-profile.scss
@@ -119,4 +119,14 @@
       }
     }
   }
+
+  .framework {
+    margin: var(--pix-spacing-4x) 0 var(--pix-spacing-8x);
+
+    &__title {
+      @extend %pix-title-s;
+
+      margin-bottom: var(--pix-spacing-4x);
+    }
+  }
 }

--- a/orga/mirage/config.js
+++ b/orga/mirage/config.js
@@ -566,6 +566,10 @@ function routes() {
     return schema.frameworks.all();
   });
 
+  this.get('/organizations/:organizationId/frameworks', (schema) => {
+    return schema.frameworks.all();
+  });
+
   this.delete('/campaigns/:campaignId/campaign-participations/:campaignParticipationId', (schema, request) => {
     const campaignParticipationId = request.params.campaignParticipationId;
 

--- a/orga/tests/acceptance/preselect-target-profile-test.js
+++ b/orga/tests/acceptance/preselect-target-profile-test.js
@@ -29,7 +29,18 @@ module('Acceptance | preselect-target-profile', function (hooks) {
     });
     server.create('competence', { id: 'recCompetence1', name: 'Competence 1', thematicIds: ['recThematic1'] });
     server.create('area', { id: 'area1', title: 'Area 1', competenceIds: ['recCompetence1'] });
-    server.create('framework', { id: 'framework1', areaIds: ['area1'] });
+    server.create('framework', { id: 'framework1', name: 'Pix', areaIds: ['area1'] });
+
+    server.create('tube', { id: 'recTube4', practicalTitle: 'Tube 4' });
+    server.create('tube', { id: 'recTube5', practicalTitle: 'Tube 5' });
+    server.create('thematic', {
+      id: 'recThematic2',
+      name: 'Competence 2',
+      tubeIds: ['recTube4', 'recTube5'],
+    });
+    server.create('competence', { id: 'recCompetence2', name: 'Competence 2', thematicIds: ['recThematic2'] });
+    server.create('area', { id: 'area2', title: 'Area 2', competenceIds: ['recCompetence2'] });
+    server.create('framework', { id: 'framework2', name: 'Edu+', areaIds: ['area2'] });
 
     // when
     const screen = await visit('/selection-sujets');
@@ -39,8 +50,10 @@ module('Acceptance | preselect-target-profile', function (hooks) {
     await click(area);
 
     // then
+    assert.ok(screen.getByRole('heading', { level: 2, name: 'Pix' }));
     assert.dom(await screen.findByLabelText('Tube 1 :')).exists();
     assert.dom(await screen.findByLabelText('Tube 2 :')).exists();
     assert.dom(await screen.findByLabelText('Tube 3 :')).exists();
+    assert.ok(screen.getByRole('heading', { level: 2, name: 'Edu+' }));
   });
 });

--- a/orga/tests/integration/components/tube/list-test.js
+++ b/orga/tests/integration/components/tube/list-test.js
@@ -12,52 +12,98 @@ module('Integration | Component | tube:list', function (hooks) {
   let dayjs;
 
   hooks.beforeEach(function () {
-    const tubes = [
+    const tubesPix = [
       {
-        id: 'tubeId1',
-        practicalTitle: 'Titre 1',
+        id: 'tubeId1Pix',
+        practicalTitle: 'Titre 1 Tube Pix',
         practicalDescription: 'Description 1',
       },
       {
-        id: 'tubeId2',
-        practicalTitle: 'Titre 2',
+        id: 'tubeId2Pix',
+        practicalTitle: 'Titre 2 Tube Pix',
         practicalDescription: 'Description 2',
       },
     ];
-    const thematics = [
+    const thematicsPix = [
       {
         id: 'thematicId',
         name: 'thematic1',
-        tubes,
+        tubes: tubesPix,
         get sortedTubes() {
-          return tubes;
+          return tubesPix;
         },
       },
     ];
-    const competences = [
+    const competencesPix = [
       {
-        thematics,
+        thematics: thematicsPix,
         get sortedThematics() {
-          return thematics;
+          return thematicsPix;
         },
       },
     ];
-    const areas = [
+    const areasPix = [
       {
-        title: 'Titre domaine',
+        title: 'Titre domaine Pix',
         code: 1,
-        competences,
+        competences: competencesPix,
         get sortedCompetences() {
-          return competences;
+          return competencesPix;
         },
       },
     ];
+
+    const tubesEdu = [
+      {
+        id: 'tubeIdEdu1',
+        practicalTitle: 'Titre 1 Tube Edu',
+        practicalDescription: 'Description 1',
+      },
+    ];
+    const thematicsEdu = [
+      {
+        id: 'thematicId',
+        name: 'thematic1',
+        tubes: tubesEdu,
+        get sortedTubes() {
+          return tubesEdu;
+        },
+      },
+    ];
+    const competencesEdu = [
+      {
+        thematics: thematicsEdu,
+        get sortedThematics() {
+          return thematicsEdu;
+        },
+      },
+    ];
+    const areasEdu = [
+      {
+        title: 'Titre domaine Edu',
+        code: 1,
+        competences: competencesEdu,
+        get sortedCompetences() {
+          return competencesEdu;
+        },
+      },
+    ];
+
     frameworks = [
       {
-        id: 'fmkId',
-        areas,
+        id: 'fmkId1',
+        name: 'Pix',
+        areas: areasPix,
         get sortedAreas() {
-          return areas;
+          return areasPix;
+        },
+      },
+      {
+        id: 'fmkId2',
+        name: 'Edu+',
+        areas: areasEdu,
+        get sortedAreas() {
+          return areasEdu;
         },
       },
     ];
@@ -69,17 +115,26 @@ module('Integration | Component | tube:list', function (hooks) {
     dayjs.self.prototype.format.restore();
   });
 
+  test('it should display frameworks title', async function (assert) {
+    // given
+    this.set('frameworks', frameworks);
+
+    // when
+    const screen = await render(hbs`<Tube::list @frameworks={{this.frameworks}} />`);
+    assert.ok(screen.getByRole('heading', { level: 2, name: 'Pix' }));
+    assert.ok(screen.getByRole('heading', { level: 2, name: 'Edu+' }));
+  });
+
   test('it should display a list of tubes', async function (assert) {
     // given
     this.set('frameworks', frameworks);
 
     // when
     const screen = await render(hbs`<Tube::list @frameworks={{this.frameworks}} />`);
-    await clickByName('1 · Titre domaine');
+    await clickByName('1 · Titre domaine Pix');
     // then
-
-    assert.dom(screen.getByLabelText('Titre 1 : Description 1')).exists();
-    assert.dom(screen.getByLabelText('Titre 2 : Description 2')).exists();
+    assert.dom(screen.getByLabelText('Titre 1 Tube Pix : Description 1')).exists();
+    assert.dom(screen.getByLabelText('Titre 2 Tube Pix : Description 2')).exists();
   });
 
   test('it should disable the download button if not tube is selected', async function (assert) {
@@ -105,8 +160,8 @@ module('Integration | Component | tube:list', function (hooks) {
       hbs`<Tube::list @frameworks={{this.frameworks}} @organization={{this.organization}} />`,
     );
 
-    await clickByName('1 · Titre domaine');
-    await clickByName('Titre 1 : Description 1');
+    await clickByName('1 · Titre domaine Pix');
+    await clickByName('Titre 1 Tube Pix : Description 1');
 
     // then
     assert
@@ -125,7 +180,7 @@ module('Integration | Component | tube:list', function (hooks) {
     // when
     await render(hbs`<Tube::list @frameworks={{this.frameworks}} />`);
 
-    await clickByName('1 · Titre domaine');
+    await clickByName('1 · Titre domaine Pix');
     await clickByName('thematic1');
 
     // then
@@ -139,12 +194,12 @@ module('Integration | Component | tube:list', function (hooks) {
     // when
     const screen = await render(hbs`<Tube::list @frameworks={{this.frameworks}} />`);
 
-    await clickByName('1 · Titre domaine');
+    await clickByName('1 · Titre domaine Pix');
     await clickByName('thematic1');
 
     // then
-    assert.dom(screen.getByLabelText('Titre 1 : Description 1')).isChecked();
-    assert.dom(screen.getByLabelText('Titre 2 : Description 2')).isChecked();
+    assert.dom(screen.getByLabelText('Titre 1 Tube Pix : Description 1')).isChecked();
+    assert.dom(screen.getByLabelText('Titre 2 Tube Pix : Description 2')).isChecked();
   });
 
   test('Should check the thematics if all corresponding tubes are selected', async function (assert) {
@@ -154,9 +209,9 @@ module('Integration | Component | tube:list', function (hooks) {
     // when
     const screen = await render(hbs`<Tube::list @frameworks={{this.frameworks}} />`);
 
-    await clickByName('1 · Titre domaine');
-    await clickByName('Titre 1 : Description 1');
-    await clickByName('Titre 2 : Description 2');
+    await clickByName('1 · Titre domaine Pix');
+    await clickByName('Titre 1 Tube Pix : Description 1');
+    await clickByName('Titre 2 Tube Pix : Description 2');
 
     // then
     assert.dom(screen.getByLabelText('thematic1')).isChecked();

--- a/orga/tests/unit/adapters/framework-test.js
+++ b/orga/tests/unit/adapters/framework-test.js
@@ -1,0 +1,22 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Unit | Adapters | framework', function (hooks) {
+  setupTest(hooks);
+
+  let adapter;
+
+  hooks.beforeEach(function () {
+    adapter = this.owner.lookup('adapter:framework');
+  });
+
+  module('#urlForFindAll', function () {
+    test('should build url for findAll from adapterOptions', async function (assert) {
+      // when
+      const url = await adapter.urlForFindAll('framework', { adapterOptions: { organizationId: 123 } });
+
+      // then
+      assert.true(url.endsWith(`/organizations/${123}/frameworks`));
+    });
+  });
+});

--- a/orga/tests/unit/routes/authenticated/preselect-target-profile-test.js
+++ b/orga/tests/unit/routes/authenticated/preselect-target-profile-test.js
@@ -1,0 +1,35 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module('Unit | Route | authenticated/preselect-target-profile', function (hooks) {
+  setupTest(hooks);
+
+  hooks.afterEach(function () {
+    sinon.restore();
+  });
+
+  module('model', function () {
+    test('fetch a frameworks', async function (assert) {
+      // given
+      const organization = { id: Symbol('organizationId') };
+      const frameworks = Symbol('frameworks');
+      const route = this.owner.lookup('route:authenticated/preselect-target-profile');
+      const store = this.owner.lookup('service:store');
+      const currentUser = this.owner.lookup('service:current-user');
+
+      sinon.stub(currentUser, 'organization').value(organization);
+
+      sinon
+        .stub(store, 'findAll')
+        .withArgs('framework', { adapterOptions: { organizationId: organization.id } })
+        .resolves(frameworks);
+
+      // when
+      const result = await route.model();
+
+      // then
+      assert.deepEqual(result, { frameworks, organization });
+    });
+  });
+});


### PR DESCRIPTION
## 🥀 Problème

Dans la page de selection de sujet pixOrga, maintenant qu'on remonte la liste de tout les référentiels,
les compétences sont remontées telles quelles sur la page du sélecteur de sujets, sans être associées à leur référentiel. 

Il n’est ainsi pas forcément simple de s’y retrouver.

## 🏹 Proposition
On groupe les différentes compétences remontées en affichant le nom du référentiel auquel elles sont associées au dessus 
<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 💌 Remarques

A rebaser une fois #15376 mergée

<!-- Des infos supplémentaires, trucs et astuces ? -->

## ❤️‍🔥 Pour tester
- se rendre sur la [page de sélection de sujets](https://orga-pr15383.review.pix.fr/selection-sujets)
- voir les référentiels et leurs titres
<!-- 

jku
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
