### PR TITLE
[FEATURE] Gérer le contenu de la bannière SCO depuis Pix Admin (PIX-21847)

### DIFF
--- a/admin/app/adapters/announcement.js
+++ b/admin/app/adapters/announcement.js
@@ -1,0 +1,7 @@
+import ApplicationAdapter from './application';
+
+export default class AnnouncementAdapter extends ApplicationAdapter {
+  urlForUpdateRecord(id) {
+    return `${this.host}/${this.namespace}/admin/announcements/${id}`;
+  }
+}

--- a/admin/app/components/announcements/edit-form.gjs
+++ b/admin/app/components/announcements/edit-form.gjs
@@ -1,0 +1,71 @@
+import PixBannerAlert from '@1024pix/pix-ui/components/pix-banner-alert';
+import PixButton from '@1024pix/pix-ui/components/pix-button';
+import PixTextArea from '@1024pix/pix-ui/components/pix-textarea';
+import { fn, get } from '@ember/helper';
+import { on } from '@ember/modifier';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+export default class AnnouncementsEditForm extends Component {
+  @service pixToast;
+  @service locale;
+
+  @tracked content = { ...this.args.announcement?.content };
+  @tracked isSaving = false;
+
+  locales = this.locale.pixLocales;
+
+  @action
+  updateContent(locale, event) {
+    this.content = { ...this.content, [locale]: event.target.value };
+  }
+
+  @action
+  async save() {
+    this.isSaving = true;
+    try {
+      const announcement = this.args.announcement;
+      announcement.content = this.content;
+      await announcement.save();
+      this.pixToast.sendSuccessNotification({
+        message: 'Annonce mise à jour avec succès.',
+      });
+    } catch {
+      this.pixToast.sendErrorNotification({
+        message: "Une erreur est survenue lors de la mise à jour de l'annonce.",
+      });
+    } finally {
+      this.isSaving = false;
+    }
+  }
+
+  <template>
+    <PixBannerAlert class="announcements-instructions" @type="information">
+      Le contenu est rendu en Markdown. Syntaxe disponible :
+      <ul>
+        <li><code>**texte**</code> → gras</li>
+        <li><code>*texte*</code> → italique</li>
+        <li><code>~~texte~~</code> → barré</li>
+        <li><code>[libellé](url)</code> → lien (s'ouvre dans un nouvel onglet)</li>
+        <li><code>- item</code> → liste à puces</li>
+      </ul>
+    </PixBannerAlert>
+    {{#each this.locales as |locale|}}
+      <div class="announcements-edit-form">
+        <PixTextArea
+          @id="announcement-content-{{locale}}"
+          rows="6"
+          value={{get this.content locale}}
+          {{on "input" (fn this.updateContent locale)}}
+        >
+          <:label>{{locale}}</:label>
+        </PixTextArea>
+      </div>
+    {{/each}}
+    <PixButton @triggerAction={{this.save}} @isLoading={{this.isSaving}}>
+      Enregistrer
+    </PixButton>
+  </template>
+}

--- a/admin/app/components/safe-markdown-to-html.gjs
+++ b/admin/app/components/safe-markdown-to-html.gjs
@@ -19,9 +19,10 @@ const showdownOptions = {
   strikethrough: true,
 };
 
+const converter = new showdown.Converter(showdownOptions);
+
 export default class SafeMarkdownToHtml extends Component {
   toHtml(markdown) {
-    const converter = new showdown.Converter(showdownOptions);
     const unsafeHtml = converter.makeHtml(markdown);
     const html = xss(unsafeHtml, {
       whiteList: xssWhitelist,

--- a/admin/app/models/announcement.js
+++ b/admin/app/models/announcement.js
@@ -1,0 +1,5 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class AnnouncementModel extends Model {
+  @attr() content;
+}

--- a/admin/app/router.js
+++ b/admin/app/router.js
@@ -185,6 +185,10 @@ Router.map(function () {
         this.route('organizations');
       });
     });
+
+    this.route('announcements', function () {
+      this.route('edit', { path: '/' });
+    });
   });
 
   this.route('authentication', { path: '/connexion' }, function () {

--- a/admin/app/routes/authenticated/announcements/edit.js
+++ b/admin/app/routes/authenticated/announcements/edit.js
@@ -1,0 +1,15 @@
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+export default class AnnouncementsEditRoute extends Route {
+  @service accessControl;
+  @service store;
+
+  beforeModel() {
+    this.accessControl.restrictAccessTo(['isSuperAdmin'], 'authenticated');
+  }
+
+  model() {
+    return this.store.findRecord('announcement', 'SCO');
+  }
+}

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -25,6 +25,7 @@
 @use 'authenticated/users/list' as *;
 
 /* components */
+@use 'components/announcements/edit-form' as *;
 @use 'components/quests/form' as *;
 @use 'components/combined-course/form' as *;
 @use 'components/combined-course-blueprints/list' as *;

--- a/admin/app/styles/components/announcements/edit-form.scss
+++ b/admin/app/styles/components/announcements/edit-form.scss
@@ -1,0 +1,3 @@
+.announcements-edit-form, .announcements-instructions {
+  margin-bottom: 1rem;
+}

--- a/admin/app/templates/authenticated/announcements.gjs
+++ b/admin/app/templates/authenticated/announcements.gjs
@@ -1,0 +1,15 @@
+import { pageTitle } from 'ember-page-title';
+
+const title = "Bandeau d'annonce Orga";
+
+<template>
+  {{pageTitle title}}
+  <div class="page">
+    <header>
+      <h1>{{title}}</h1>
+    </header>
+    <main class="page-body">
+      {{outlet}}
+    </main>
+  </div>
+</template>

--- a/admin/app/templates/authenticated/announcements/edit.gjs
+++ b/admin/app/templates/authenticated/announcements/edit.gjs
@@ -1,0 +1,3 @@
+import EditForm from 'pix-admin/components/announcements/edit-form';
+
+<template><EditForm @announcement={{@model}} /></template>

--- a/admin/tests/integration/components/announcements/edit-form-test.gjs
+++ b/admin/tests/integration/components/announcements/edit-form-test.gjs
@@ -1,0 +1,57 @@
+import { render } from '@1024pix/ember-testing-library';
+import { fillIn } from '@ember/test-helpers';
+import AnnouncementsEditForm from 'pix-admin/components/announcements/edit-form';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | announcements/edit-form', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('it pre-fills textareas with existing announcement content', async function (assert) {
+    // given
+    const announcement = { content: { fr: 'Contenu français', en: 'English content' }, save: sinon.stub().resolves() };
+
+    // when
+    const screen = await render(<template><AnnouncementsEditForm @announcement={{announcement}} /></template>);
+
+    // then
+    assert.strictEqual(screen.getByLabelText('fr').value, 'Contenu français');
+    assert.strictEqual(screen.getByLabelText('en').value, 'English content');
+  });
+
+  test('it saves the announcement with updated content on submit', async function (assert) {
+    // given
+    const announcement = { content: { fr: 'Ancien contenu' }, save: sinon.stub().resolves() };
+    const pixToast = this.owner.lookup('service:pixToast');
+    const successStub = sinon.stub(pixToast, 'sendSuccessNotification');
+
+    const screen = await render(<template><AnnouncementsEditForm @announcement={{announcement}} /></template>);
+
+    // when
+    await fillIn(screen.getByLabelText('fr'), 'Nouveau contenu');
+    await screen.getByRole('button', { name: 'Enregistrer' }).click();
+
+    // then
+    assert.ok(announcement.save.calledOnce);
+    assert.deepEqual(announcement.content, { fr: 'Nouveau contenu' });
+    assert.ok(successStub.calledOnceWith({ message: 'Annonce mise à jour avec succès.' }));
+  });
+
+  test('it shows an error notification when save fails', async function (assert) {
+    // given
+    const announcement = { content: { fr: 'Contenu' }, save: sinon.stub().rejects() };
+    const pixToast = this.owner.lookup('service:pixToast');
+    const errorStub = sinon.stub(pixToast, 'sendErrorNotification');
+
+    const screen = await render(<template><AnnouncementsEditForm @announcement={{announcement}} /></template>);
+
+    // when
+    await screen.getByRole('button', { name: 'Enregistrer' }).click();
+
+    // then
+    assert.ok(announcement.save.calledOnce);
+    assert.ok(errorStub.calledOnceWith({ message: "Une erreur est survenue lors de la mise à jour de l'annonce." }));
+  });
+});

--- a/api/db/migrations/20260306130812_create-banners-table.js
+++ b/api/db/migrations/20260306130812_create-banners-table.js
@@ -1,0 +1,24 @@
+const TABLE_NAME = 'announcements';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.createTable(TABLE_NAME, function (table) {
+    table.text('name').primary();
+    table.jsonb('content').notNullable().defaultTo('{}');
+    table.dateTime('created_at').notNullable().defaultTo(knex.fn.now());
+    table.dateTime('updated_at').notNullable().defaultTo(knex.fn.now());
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.dropTable(TABLE_NAME);
+};
+
+export { down, up };

--- a/api/server.js
+++ b/api/server.js
@@ -5,6 +5,7 @@ import { parse } from 'neoqs';
 import { setupErrorHandling } from './config/server-setup-error-handling.js';
 import { databaseConnections } from './db/database-connections.js';
 import { knex } from './db/knex-database-connection.js';
+import { announcementRoutes } from './src/announcements/routes.js';
 import { bannerRoutes } from './src/banner/routes.js';
 import {
   attachTargetProfileRoutes,
@@ -239,6 +240,7 @@ const setupRoutesAndPlugins = async function (server) {
     ...certificationRoutes,
     ...prescriptionRoutes,
     bannerRoutes,
+    ...announcementRoutes,
     llmRoutes,
     {
       name: 'root',

--- a/api/src/announcements/application/announcement-controller.js
+++ b/api/src/announcements/application/announcement-controller.js
@@ -1,0 +1,20 @@
+import { usecases } from '../domain/usecases/index.js';
+import * as announcementSerializer from '../infrastructure/serializers/jsonapi/announcement-serializer.js';
+
+const get = async (request, h, dependencies = { announcementSerializer }) => {
+  const { name } = request.params;
+  const announcement = await usecases.getAnnouncement({ name });
+  return dependencies.announcementSerializer.serialize(announcement);
+};
+
+const update = async (request, h, dependencies = { announcementSerializer }) => {
+  const { name } = request.params;
+  const content = request.payload?.data?.attributes?.content ?? null;
+  const announcement = await usecases.updateAnnouncement({ name, content });
+  return dependencies.announcementSerializer.serialize(announcement);
+};
+
+export const announcementController = {
+  get,
+  update,
+};

--- a/api/src/announcements/application/announcement-route.js
+++ b/api/src/announcements/application/announcement-route.js
@@ -1,0 +1,63 @@
+import Joi from 'joi';
+
+import { securityPreHandlers } from '../../shared/application/security-pre-handlers.js';
+import { getSupportedLocales } from '../../shared/domain/services/locale-service.js';
+import { announcementController } from './announcement-controller.js';
+
+const ANNOUNCEMENT_NAME_SCHEMA = Joi.string().valid('SCO').required();
+
+const register = async function (server) {
+  server.route([
+    {
+      method: 'GET',
+      path: '/api/announcements/{name}',
+      options: {
+        auth: false,
+        validate: {
+          params: Joi.object({
+            name: ANNOUNCEMENT_NAME_SCHEMA,
+          }),
+        },
+        handler: announcementController.get,
+        tags: ['api', 'announcement'],
+      },
+    },
+    {
+      method: 'PATCH',
+      path: '/api/admin/announcements/{name}',
+      options: {
+        pre: [
+          {
+            method: securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+            assign: 'hasRoleSuperAdmin',
+          },
+        ],
+        validate: {
+          params: Joi.object({
+            name: ANNOUNCEMENT_NAME_SCHEMA,
+          }),
+          payload: Joi.object({
+            data: Joi.object({
+              id: Joi.string(),
+              type: Joi.string().required(),
+              attributes: Joi.object({
+                content: Joi.object({})
+                  .pattern(Joi.string().equal(...getSupportedLocales()), Joi.string())
+                  .required(),
+              }).required(),
+            }).required(),
+          }),
+        },
+        handler: announcementController.update,
+        tags: ['api', 'admin', 'announcement'],
+        notes: [
+          'Cette route est restreinte aux utilisateurs authentifiés avec le rôle Super Admin',
+          "Elle permet de mettre à jour le contenu d'une annonce.",
+        ],
+      },
+    },
+  ]);
+};
+
+const name = 'announcements-api';
+export { name, register };

--- a/api/src/announcements/domain/models/Announcement.js
+++ b/api/src/announcements/domain/models/Announcement.js
@@ -1,0 +1,6 @@
+export class Announcement {
+  constructor({ name, content }) {
+    this.id = name;
+    this.content = content ?? null;
+  }
+}

--- a/api/src/announcements/domain/usecases/get-announcement.js
+++ b/api/src/announcements/domain/usecases/get-announcement.js
@@ -1,0 +1,1 @@
+export const getAnnouncement = ({ name, announcementRepository }) => announcementRepository.get(name);

--- a/api/src/announcements/domain/usecases/index.js
+++ b/api/src/announcements/domain/usecases/index.js
@@ -1,0 +1,18 @@
+import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
+import * as announcementRepository from '../../infrastructure/repositories/announcement-repository.js';
+
+const dependencies = {
+  announcementRepository,
+};
+
+import { getAnnouncement } from './get-announcement.js';
+import { updateAnnouncement } from './update-announcement.js';
+
+const usecasesWithoutInjectedDependencies = {
+  getAnnouncement,
+  updateAnnouncement,
+};
+
+const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);
+
+export { usecases };

--- a/api/src/announcements/domain/usecases/update-announcement.js
+++ b/api/src/announcements/domain/usecases/update-announcement.js
@@ -1,0 +1,2 @@
+export const updateAnnouncement = ({ name, content, announcementRepository }) =>
+  announcementRepository.update(name, content);

--- a/api/src/announcements/infrastructure/repositories/announcement-repository.js
+++ b/api/src/announcements/infrastructure/repositories/announcement-repository.js
@@ -1,0 +1,40 @@
+import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
+import { announcementsStorage } from '../../../shared/infrastructure/key-value-storages/index.js';
+import { Announcement } from '../../domain/models/Announcement.js';
+
+const TTL = 24 * 60 * 60;
+const EMPTY_CONTENT = '__empty__';
+
+const _cacheKey = (name) => `announcement:${name}`;
+
+const get = async (name) => {
+  const cacheKey = _cacheKey(name);
+  const cached = await announcementsStorage.get(cacheKey);
+  if (cached) {
+    const content = cached === EMPTY_CONTENT ? null : cached;
+    return new Announcement({ name, content });
+  }
+
+  const knex = DomainTransaction.getConnection();
+  const row = await knex('announcements').where({ name }).first();
+  const content = row?.content ?? null;
+
+  await announcementsStorage.save({
+    key: cacheKey,
+    value: content === null ? EMPTY_CONTENT : content,
+    expirationDelaySeconds: TTL,
+  });
+
+  return new Announcement({ name, content });
+};
+
+const update = async (name, content) => {
+  const knex = DomainTransaction.getConnection();
+  await knex('announcements').insert({ name, content }).onConflict('name').merge(['content']);
+
+  await announcementsStorage.delete(_cacheKey(name));
+
+  return new Announcement({ name, content });
+};
+
+export { get, update };

--- a/api/src/announcements/infrastructure/serializers/jsonapi/announcement-serializer.js
+++ b/api/src/announcements/infrastructure/serializers/jsonapi/announcement-serializer.js
@@ -1,0 +1,10 @@
+import jsonapiSerializer from 'jsonapi-serializer';
+
+const { Serializer } = jsonapiSerializer;
+
+const serialize = (announcement) =>
+  new Serializer('announcements', {
+    attributes: ['content'],
+  }).serialize(announcement);
+
+export { serialize };

--- a/api/src/announcements/routes.js
+++ b/api/src/announcements/routes.js
@@ -1,0 +1,3 @@
+import * as announcementRoute from './application/announcement-route.js';
+
+export const announcementRoutes = [announcementRoute];

--- a/api/src/shared/infrastructure/key-value-storages/index.js
+++ b/api/src/shared/infrastructure/key-value-storages/index.js
@@ -16,9 +16,11 @@ function _createKeyValueStorage({ prefix }) {
 export const temporaryStorage = _createKeyValueStorage({ prefix: 'temporary-storage:' });
 export const informationBannersStorage = _createKeyValueStorage({ prefix: 'information-banners:' });
 export const featureTogglesStorage = _createKeyValueStorage({ prefix: 'feature-toggles:' });
+export const announcementsStorage = _createKeyValueStorage({ prefix: 'announcements:' });
 
 export async function quitAllStorages() {
   await temporaryStorage.quit();
   await informationBannersStorage.quit();
   await featureTogglesStorage.quit();
+  await announcementsStorage.quit();
 }

--- a/api/tests/announcements/acceptance/application/announcement-route_test.js
+++ b/api/tests/announcements/acceptance/application/announcement-route_test.js
@@ -1,0 +1,112 @@
+import { announcementsStorage } from '../../../../src/shared/infrastructure/key-value-storages/index.js';
+import {
+  createServer,
+  databaseBuilder,
+  expect,
+  generateAuthenticatedUserRequestHeaders,
+  insertUserWithRoleSuperAdmin,
+  knex,
+} from '../../../test-helper.js';
+
+const CONTENT = { fr: 'Contenu en français', en: 'Content in English' };
+
+let server;
+
+describe('Acceptance | Router | announcement-route', function () {
+  beforeEach(async function () {
+    server = await createServer();
+    await announcementsStorage.flushAll();
+  });
+
+  describe('GET /api/announcements/SCO', function () {
+    context('when no announcement exists in the database', function () {
+      it('should return an announcement with null content', async function () {
+        const response = await server.inject({ method: 'GET', url: '/api/announcements/SCO' });
+
+        expect(response.statusCode).to.equal(200);
+        expect(response.result.data.attributes.content).to.be.null;
+      });
+    });
+
+    context('when an announcement exists in the database', function () {
+      beforeEach(async function () {
+        await knex('announcements').insert({ name: 'SCO', content: JSON.stringify(CONTENT) });
+      });
+
+      it('should return the announcement content', async function () {
+        const response = await server.inject({ method: 'GET', url: '/api/announcements/SCO' });
+
+        expect(response.statusCode).to.equal(200);
+        expect(response.result.data.attributes.content).to.deep.equal(CONTENT);
+      });
+    });
+  });
+
+  describe('PATCH /api/admin/announcements/SCO', function () {
+    context('when user is super admin', function () {
+      let headers;
+
+      beforeEach(async function () {
+        await insertUserWithRoleSuperAdmin();
+        headers = generateAuthenticatedUserRequestHeaders({ userId: 1234 });
+      });
+
+      it('should update the announcement content and return 200', async function () {
+        const response = await server.inject({
+          method: 'PATCH',
+          url: '/api/admin/announcements/SCO',
+          headers,
+          payload: {
+            data: {
+              type: 'announcements',
+              attributes: { content: CONTENT },
+            },
+          },
+        });
+
+        expect(response.statusCode).to.equal(200);
+        expect(response.result.data.attributes.content).to.deep.equal(CONTENT);
+        const row = await knex('announcements').where({ name: 'SCO' }).first();
+        expect(row.content).to.deep.equal(CONTENT);
+      });
+    });
+
+    context('when user is not super admin', function () {
+      it('should return 403 Forbidden', async function () {
+        const user = databaseBuilder.factory.buildUser();
+        await databaseBuilder.commit();
+
+        const response = await server.inject({
+          method: 'PATCH',
+          url: '/api/admin/announcements/SCO',
+          headers: generateAuthenticatedUserRequestHeaders({ userId: user.id }),
+          payload: {
+            data: {
+              type: 'announcements',
+              attributes: { content: CONTENT },
+            },
+          },
+        });
+
+        expect(response.statusCode).to.equal(403);
+      });
+    });
+
+    context('when user is not authenticated', function () {
+      it('should return 401 Unauthorized', async function () {
+        const response = await server.inject({
+          method: 'PATCH',
+          url: '/api/admin/announcements/SCO',
+          payload: {
+            data: {
+              type: 'announcements',
+              attributes: { content: CONTENT },
+            },
+          },
+        });
+
+        expect(response.statusCode).to.equal(401);
+      });
+    });
+  });
+});

--- a/api/tests/announcements/integration/infrastructure/repositories/announcement-repository_test.js
+++ b/api/tests/announcements/integration/infrastructure/repositories/announcement-repository_test.js
@@ -1,0 +1,107 @@
+import { Announcement } from '../../../../../src/announcements/domain/models/Announcement.js';
+import * as announcementRepository from '../../../../../src/announcements/infrastructure/repositories/announcement-repository.js';
+import { announcementsStorage } from '../../../../../src/shared/infrastructure/key-value-storages/index.js';
+import { expect, knex } from '../../../../test-helper.js';
+
+const NAME = 'SCO';
+const CONTENT = { fr: 'Contenu en français', en: 'Content in English' };
+
+describe('Integration | Infrastructure | Repository | Announcements | announcement-repository', function () {
+  beforeEach(async function () {
+    await announcementsStorage.flushAll();
+  });
+
+  describe('#get', function () {
+    context('when no row exists in the database', function () {
+      it('should return an Announcement with null content', async function () {
+        const result = await announcementRepository.get(NAME);
+
+        expect(result).to.be.an.instanceOf(Announcement);
+        expect(result.content).to.be.null;
+      });
+
+      it('should cache the empty sentinel in Redis', async function () {
+        await announcementRepository.get(NAME);
+
+        const cached = await announcementsStorage.get(`announcement:${NAME}`);
+        expect(cached).to.equal('__empty__');
+      });
+    });
+
+    context('when a row exists in the database', function () {
+      beforeEach(async function () {
+        await knex('announcements').insert({ name: NAME, content: JSON.stringify(CONTENT) });
+      });
+
+      it('should return an Announcement with the stored content', async function () {
+        const result = await announcementRepository.get(NAME);
+
+        expect(result).to.be.an.instanceOf(Announcement);
+        expect(result.content).to.deep.equal(CONTENT);
+      });
+
+      it('should cache the content in Redis', async function () {
+        await announcementRepository.get(NAME);
+
+        const cached = await announcementsStorage.get(`announcement:${NAME}`);
+        expect(cached).to.deep.equal(CONTENT);
+      });
+    });
+
+    context('when content is cached in Redis', function () {
+      beforeEach(async function () {
+        await announcementsStorage.save({ key: `announcement:${NAME}`, value: CONTENT });
+      });
+
+      it('should return the cached content without hitting the database', async function () {
+        const result = await announcementRepository.get(NAME);
+
+        expect(result).to.be.an.instanceOf(Announcement);
+        expect(result.content).to.deep.equal(CONTENT);
+      });
+    });
+
+    context('when the empty sentinel is cached in Redis', function () {
+      beforeEach(async function () {
+        await announcementsStorage.save({ key: `announcement:${NAME}`, value: '__empty__' });
+      });
+
+      it('should return an Announcement with null content', async function () {
+        const result = await announcementRepository.get(NAME);
+
+        expect(result).to.be.an.instanceOf(Announcement);
+        expect(result.content).to.be.null;
+      });
+    });
+  });
+
+  describe('#update', function () {
+    it('should insert a row and return the updated Announcement', async function () {
+      const result = await announcementRepository.update(NAME, CONTENT);
+
+      expect(result).to.be.an.instanceOf(Announcement);
+      expect(result.content).to.deep.equal(CONTENT);
+      const row = await knex('announcements').where({ name: NAME }).first();
+      expect(row.content).to.deep.equal(CONTENT);
+    });
+
+    it('should update an existing row (upsert)', async function () {
+      await knex('announcements').insert({ name: NAME, content: JSON.stringify({ fr: 'Ancien contenu' }) });
+
+      await announcementRepository.update(NAME, CONTENT);
+
+      const rows = await knex('announcements');
+      expect(rows).to.have.length(1);
+      expect(rows[0].content).to.deep.equal(CONTENT);
+    });
+
+    it('should invalidate the Redis cache after update', async function () {
+      await announcementsStorage.save({ key: `announcement:${NAME}`, value: CONTENT });
+
+      await announcementRepository.update(NAME, { fr: 'Nouveau contenu' });
+
+      const cached = await announcementsStorage.get(`announcement:${NAME}`);
+      expect(cached).to.be.null;
+    });
+  });
+});

--- a/api/tests/announcements/unit/domain/usecases/get-announcement_test.js
+++ b/api/tests/announcements/unit/domain/usecases/get-announcement_test.js
@@ -1,0 +1,20 @@
+import { getAnnouncement } from '../../../../../src/announcements/domain/usecases/get-announcement.js';
+import { expect, sinon } from '../../../../test-helper.js';
+
+describe('Unit | UseCase | Get Announcement', function () {
+  it('should use announcement repository to get the announcement by name', async function () {
+    // given
+    const name = 'SCO';
+    const expectedAnnouncement = Symbol('announcement');
+    const announcementRepository = {
+      get: sinon.stub().resolves(expectedAnnouncement),
+    };
+
+    // when
+    const result = await getAnnouncement({ name, announcementRepository });
+
+    // then
+    expect(result).to.equal(expectedAnnouncement);
+    expect(announcementRepository.get).to.have.been.calledOnceWithExactly(name);
+  });
+});

--- a/api/tests/announcements/unit/domain/usecases/update-announcement_test.js
+++ b/api/tests/announcements/unit/domain/usecases/update-announcement_test.js
@@ -1,0 +1,21 @@
+import { updateAnnouncement } from '../../../../../src/announcements/domain/usecases/update-announcement.js';
+import { expect, sinon } from '../../../../test-helper.js';
+
+describe('Unit | UseCase | Update Announcement', function () {
+  it('should use announcement repository to update the announcement by name', async function () {
+    // given
+    const name = 'SCO';
+    const content = 'Nouveau contenu Markdown';
+    const expectedAnnouncement = Symbol('updated-announcement');
+    const announcementRepository = {
+      update: sinon.stub().resolves(expectedAnnouncement),
+    };
+
+    // when
+    const result = await updateAnnouncement({ name, content, announcementRepository });
+
+    // then
+    expect(result).to.equal(expectedAnnouncement);
+    expect(announcementRepository.update).to.have.been.calledOnceWith(name, content);
+  });
+});


### PR DESCRIPTION
## 🌋 Problème

La bannière SCO dans Pix Orga avait un contenu statique géré par des clés de traduction et un feature toggle. Il n'était pas possible de modifier le message sans déploiement.

## 🦄 Proposition

Remplacer le système statique par un contenu dynamique Markdown éditable depuis Pix Admin: 

- Nouveau top domain `announcements`
- Nouvelle table `announcements` avec colonne JSONB multi-langue ( utilisation du service pour recuperer toutes les locales disponibles )
- Route `GET /api/announcements/SCO` et `PATCH /api/admin/announcements/SCO` (SuperAdmin)
- Cache Redis TTL 24h par sécurité, invalidé à chaque mise à jour
- Nouvelle page d'édition dans Pix Admin avec aide Markdown inline

## 🥑 Remarques

Prevenir les captains de mettre un cache sur la route /announcements/SCO une fois merged.

## 🧨 Pour tester

- [ ] Se connecter à Pix Admin en tant que super admin
- [ ] Aller sur `/announcements`
- [ ] Saisir un contenu Markdown dans le champ souhaité et enregistrer
- [ ] Bonus: Vérifier en DB que le contenu a été mis a jour
- [ ] MegaBonus: Vérifier sur Redis que le contenu a été mis a jour