### PR TITLE
[FEATURE] Créer un nouveau réseau via Pix-Admin (PIX-21296).

### DIFF
--- a/admin/app/adapters/network.js
+++ b/admin/app/adapters/network.js
@@ -1,0 +1,5 @@
+import ApplicationAdapter from './application';
+
+export default class NetworkAdapter extends ApplicationAdapter {
+  namespace = 'api/admin';
+}

--- a/admin/app/components/networks/creation-form.gjs
+++ b/admin/app/components/networks/creation-form.gjs
@@ -1,0 +1,117 @@
+import PixButton from '@1024pix/pix-ui/components/pix-button';
+import PixInput from '@1024pix/pix-ui/components/pix-input';
+import { fn } from '@ember/helper';
+import { on } from '@ember/modifier';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { t } from 'ember-intl';
+import Joi from 'joi';
+import { FormValidator } from 'pix-admin/utils/form-validator';
+
+const NETWORK_CREATION_FORM_VALIDATION_SCHEMA = Joi.object({
+  name: Joi.string().empty(['', null]).required().messages({
+    'any.required': 'components.networks.creation.error-messages.name',
+    'string.empty': 'components.networks.creation.error-messages.name',
+  }),
+  organizationId: Joi.string().empty(['', null]).required().messages({
+    'any.required': 'components.networks.creation.error-messages.organization-id',
+    'string.empty': 'components.networks.creation.error-messages.organization-id',
+  }),
+});
+
+export default class CreationForm extends Component {
+  @service pixToast;
+  @service intl;
+  @service store;
+
+  @tracked form = {
+    name: '',
+    organizationId: '',
+  };
+
+  validator = new FormValidator(NETWORK_CREATION_FORM_VALIDATION_SCHEMA);
+
+  handleInputChange = (key, event) => {
+    const { value } = event.target;
+    this.validator.validateField(key, value);
+    this.form = { ...this.form, [key]: value };
+  };
+
+  focusOnFirstFieldInError = () => {
+    const fieldsInError = Object.keys(this.validator.errors);
+    const firstHtmlElementInError = document.getElementById(fieldsInError[0]);
+    firstHtmlElementInError.focus();
+  };
+
+  handleSubmit = async (event) => {
+    event.preventDefault();
+    const isFormValid = this.validator.validate(this.form);
+    if (!isFormValid) {
+      this.pixToast.sendErrorNotification({
+        message: this.intl.t('components.organizations.creation.error-messages.error-toast'),
+      });
+      this.focusOnFirstFieldInError();
+      return;
+    }
+    await this.createNetwork(this.form);
+  };
+
+  @action
+  async createNetwork(form) {
+    const network = this.store.createRecord('network', { ...form });
+
+    try {
+      await network.save();
+      this.pixToast.sendSuccessNotification({
+        message: this.intl.t('components.networks.creation.notifications.success'),
+      });
+      this._resetForm();
+    } catch {
+      this.pixToast.sendErrorNotification({ message: this.intl.t('components.networks.creation.notifications.error') });
+      network.rollbackAttributes();
+    }
+  }
+
+  _resetForm() {
+    this.form = {
+      name: '',
+      organizationId: '',
+    };
+  }
+
+  <template>
+    <form {{on "submit" this.handleSubmit}} class="network-creation-form">
+      <div class="network-creation-form__input network-creation-form__input--full">
+        <PixInput
+          @id="name"
+          @value={{this.form.name}}
+          @requiredLabel={{t "common.fields.required-field"}}
+          required={{false}}
+          {{on "change" (fn this.handleInputChange "name")}}
+          @errorMessage={{if this.validator.errors.name (t this.validator.errors.name)}}
+          @validationStatus={{if this.validator.errors.name "error"}}
+        >
+          <:label>{{t "components.networks.creation.name.label"}}</:label>
+        </PixInput>
+      </div>
+      <div class="network-creation-form__input network-creation-form__input--full">
+        <PixInput
+          @id="organizationId"
+          @value={{this.form.organizationId}}
+          {{on "change" (fn this.handleInputChange "organizationId")}}
+          @requiredLabel={{t "common.fields.required-field"}}
+          required={{false}}
+          @errorMessage={{if this.validator.errors.organizationId (t this.validator.errors.organizationId)}}
+          @validationStatus={{if this.validator.errors.organizationId "error"}}
+        >
+          <:label>{{t "components.networks.creation.organization-id.label"}}</:label>
+        </PixInput>
+      </div>
+      <PixButton @type="submit" @size="small" @variant="success">
+        {{t "components.networks.creation.actions.submit"}}
+      </PixButton>
+    </form>
+  </template>
+}

--- a/admin/app/components/networks/creation-form.scss
+++ b/admin/app/components/networks/creation-form.scss
@@ -1,0 +1,13 @@
+.network-creation-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  max-width: 50%;
+
+  &__input {
+    .pix-input,
+    .pix-button {
+      width: 100%;
+    }
+  }
+}

--- a/admin/app/models/network.js
+++ b/admin/app/models/network.js
@@ -1,0 +1,6 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class Network extends Model {
+  @attr('string') name;
+  @attr('number') organizationId;
+}

--- a/admin/app/router.js
+++ b/admin/app/router.js
@@ -54,6 +54,10 @@ Router.map(function () {
       });
     });
 
+    this.route('networks', function () {
+      this.route('new');
+    });
+
     this.route('campaigns', function () {
       this.route('campaign', { path: '/:campaign_id' }, function () {
         this.route('participations');

--- a/admin/app/routes/authenticated/networks/new.js
+++ b/admin/app/routes/authenticated/networks/new.js
@@ -1,0 +1,10 @@
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+export default class NewRoute extends Route {
+  @service accessControl;
+
+  beforeModel() {
+    this.accessControl.restrictAccessTo(['isSuperAdmin'], 'authenticated');
+  }
+}

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -111,5 +111,6 @@
 @use 'certification-centers/member-item' as *;
 @use 'certification-centers/membership-item' as *;
 @use 'certification-centers/invitations-action' as *;
+@use 'networks/creation-form' as *;
 @use 'organizations/creation-form' as *;
 @use 'organizations/head-information' as *;

--- a/admin/app/templates/authenticated/networks/new.gjs
+++ b/admin/app/templates/authenticated/networks/new.gjs
@@ -1,0 +1,7 @@
+import { t } from 'ember-intl';
+import CreationForm from 'pix-admin/components/networks/creation-form';
+
+<template>
+  <h1>{{t "pages.networks.title"}}</h1>
+  <CreationForm />
+</template>

--- a/admin/tests/acceptance/authenticated/networks/create-network-test.js
+++ b/admin/tests/acceptance/authenticated/networks/create-network-test.js
@@ -1,0 +1,61 @@
+import { fillByLabel, visit } from '@1024pix/ember-testing-library';
+import { click, currentURL } from '@ember/test-helpers';
+import { t } from 'ember-intl/test-support';
+import { setupApplicationTest } from 'ember-qunit';
+import { authenticateAdminMemberWithRole } from 'pix-admin/tests/helpers/test-init';
+import { setupMirage } from 'pix-admin/tests/test-support/setup-mirage';
+import { module, test } from 'qunit';
+
+import setupIntl from '../../../helpers/setup-intl';
+
+module('Acceptance | Networks | Create', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+  setupIntl(hooks);
+
+  module('when user does not have super admin role', function () {
+    test('user cannot access the network creation page', async function (assert) {
+      // given
+      await authenticateAdminMemberWithRole({ isSuperAdmin: false })(server);
+
+      // when
+      await visit('/networks/new');
+
+      // then
+      assert.strictEqual(currentURL(), '/organizations/list');
+    });
+  });
+
+  module('when user has super admin role', function (hooks) {
+    hooks.beforeEach(async function () {
+      server.create('country', { code: '99100', name: 'France' });
+
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+    });
+
+    test('it shows the creation form', async function (assert) {
+      // when
+      const screen = await visit('/networks/new');
+
+      // then
+      assert.dom(screen.getByLabelText(`${t('components.networks.creation.name.label')} *`)).exists();
+      assert.dom(screen.getByText(t('pages.networks.title'))).exists();
+      assert.dom(screen.getByRole('button', { name: t('components.networks.creation.actions.submit') })).exists();
+    });
+
+    module('when creating an network', function () {
+      test('it creates a new network', async function (assert) {
+        // given
+        const screen = await visit('/networks/new');
+
+        // when
+        await fillByLabel(`${t('components.networks.creation.name.label')} *`, 'Nouveau réseau');
+        await fillByLabel(`${t('components.networks.creation.organization-id.label')} *`, '1');
+        await click(screen.getByRole('button', { name: t('components.networks.creation.actions.submit') }));
+
+        // then
+        assert.ok(await screen.findByText(t('components.networks.creation.notifications.success')));
+      });
+    });
+  });
+});

--- a/admin/tests/integration/components/networks/creation-form-test.gjs
+++ b/admin/tests/integration/components/networks/creation-form-test.gjs
@@ -1,0 +1,119 @@
+import { fillByLabel, render } from '@1024pix/ember-testing-library';
+import { click } from '@ember/test-helpers';
+import { t } from 'ember-intl/test-support';
+import CreationForm from 'pix-admin/components/networks/creation-form';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | networks/creation-form', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  let store, pixToast;
+
+  hooks.beforeEach(function () {
+    store = this.owner.lookup('service:store');
+    sinon.stub(store, 'createRecord').returns({
+      save: sinon.stub().resolves(),
+      rollbackAttributes: sinon.stub(),
+    });
+
+    pixToast = this.owner.lookup('service:pixToast');
+    sinon.stub(pixToast, 'sendSuccessNotification');
+    sinon.stub(pixToast, 'sendErrorNotification');
+  });
+
+  test('it renders the form fields and submit button', async function (assert) {
+    // when
+    const screen = await render(<template><CreationForm /></template>);
+
+    // then
+    assert.ok(screen.getByRole('textbox', { name: `${t('components.networks.creation.name.label')} *` }));
+    assert.ok(screen.getByRole('textbox', { name: `${t('components.networks.creation.organization-id.label')} *` }));
+    assert.ok(screen.getByRole('button', { name: t('components.networks.creation.actions.submit') }));
+  });
+
+  module('when submitting a valid form', function () {
+    test('creates the network and shows a success notification', async function (assert) {
+      // given
+      const screen = await render(<template><CreationForm /></template>);
+
+      // when
+      await fillByLabel(`${t('components.networks.creation.name.label')} *`, 'Mon super réseau');
+      await fillByLabel(`${t('components.networks.creation.organization-id.label')} *`, '123');
+      await click(screen.getByRole('button', { name: t('components.networks.creation.actions.submit') }));
+
+      // then
+      assert.ok(store.createRecord.calledOnce);
+
+      const [modelName, attrs] = store.createRecord.getCall(0).args;
+      assert.strictEqual(modelName, 'network');
+      assert.deepEqual(attrs, { name: 'Mon super réseau', organizationId: '123' });
+      assert.ok(
+        pixToast.sendSuccessNotification.calledOnceWith({
+          message: t('components.networks.creation.notifications.success'),
+        }),
+      );
+    });
+  });
+
+  module('when the save fails', function () {
+    test('displays an error notification and rollbacks the record', async function (assert) {
+      // given
+      const networkRecord = { save: sinon.stub().rejects(), rollbackAttributes: sinon.stub() };
+      store.createRecord.returns(networkRecord);
+
+      const screen = await render(<template><CreationForm /></template>);
+
+      // when
+      await fillByLabel(`${t('components.networks.creation.name.label')} *`, 'Mon super réseau');
+      await fillByLabel(`${t('components.networks.creation.organization-id.label')} *`, '123');
+      await click(screen.getByRole('button', { name: t('components.networks.creation.actions.submit') }));
+
+      // then
+      assert.ok(
+        pixToast.sendErrorNotification.calledOnceWith({
+          message: t('components.networks.creation.notifications.error'),
+        }),
+      );
+      assert.ok(networkRecord.rollbackAttributes.calledOnce);
+    });
+  });
+
+  module('when submitting an empty form', function () {
+    test('does not create a network', async function (assert) {
+      // given
+      const screen = await render(<template><CreationForm /></template>);
+
+      // when
+      await click(screen.getByRole('button', { name: t('components.networks.creation.actions.submit') }));
+
+      // then
+      assert.ok(store.createRecord.notCalled);
+    });
+
+    test('shows a validation error notification', async function (assert) {
+      // given
+      const screen = await render(<template><CreationForm /></template>);
+
+      // when
+      await click(screen.getByRole('button', { name: t('components.networks.creation.actions.submit') }));
+
+      // then
+      assert.ok(pixToast.sendErrorNotification.calledOnce);
+    });
+
+    test('focuses on the first field in error', async function (assert) {
+      // given
+      const screen = await render(<template><CreationForm /></template>);
+
+      // when
+      await click(screen.getByRole('button', { name: t('components.networks.creation.actions.submit') }));
+
+      // then
+      const nameInput = screen.getByRole('textbox', { name: `${t('components.networks.creation.name.label')} *` });
+      assert.strictEqual(document.activeElement, nameInput);
+    });
+  });
+});

--- a/admin/tests/mirage/handlers/networks.js
+++ b/admin/tests/mirage/handlers/networks.js
@@ -1,0 +1,8 @@
+export function createNetwork(schema, request) {
+  const params = JSON.parse(request.requestBody);
+
+  return schema.create('network', {
+    name: params.data.attributes.name,
+    organizationId: params.data.attributes['organization-id'],
+  });
+}

--- a/admin/tests/mirage/models.js
+++ b/admin/tests/mirage/models.js
@@ -42,6 +42,7 @@ import framework from './models/framework';
 import frameworkHistory from './models/framework-history';
 import juryCertificationSummary from './models/jury-certification-summary';
 import lastApplicationConnection from './models/last-application-connection';
+import network from './models/network';
 import oidcIdentityProvider from './models/oidc-identity-provider';
 import organization from './models/organization';
 import organizationInvitation from './models/organization-invitation';
@@ -115,6 +116,7 @@ export default {
   frameworkHistory,
   juryCertificationSummary,
   lastApplicationConnection,
+  network,
   oidcIdentityProvider,
   organization,
   organizationInvitation,

--- a/admin/tests/mirage/models/network.js
+++ b/admin/tests/mirage/models/network.js
@@ -1,0 +1,3 @@
+import { Model } from 'miragejs';
+
+export default Model.extend();

--- a/admin/tests/mirage/routes.js
+++ b/admin/tests/mirage/routes.js
@@ -18,6 +18,7 @@ import { findFrameworkAreas } from './handlers/frameworks';
 import { getPaginatedJuryCertificationSummariesBySessionId } from './handlers/get-jury-certification-summaries-by-session-id';
 import { getToBePublishedSessions } from './handlers/get-to-be-published-sessions';
 import { getWithRequiredActionSessions } from './handlers/get-with-required-action-sessions';
+import { createNetwork } from './handlers/networks';
 import { createOrganizationMembership } from './handlers/organization-memberships';
 import {
   archiveOrganization,
@@ -366,6 +367,8 @@ export default function routes() {
     const organizationMembership = schema.organizationMemberships.findBy({ id: organizationMembershipId });
     return organizationMembership.update({ disabledAt: new Date() });
   });
+
+  this.post('/admin/networks', createNetwork);
 
   this.get('/admin/organizations', findPaginatedFilteredOrganizations);
   this.post('/admin/organizations', (schema, request) => {

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -614,6 +614,27 @@
         "caption": "Liste des membres appartenant au centre de certification. Contient son identifiant, nom et prénom, son adresse e-mail, son rôle, son dernier accès et sa date de rattachement à l'espace de certification. Des actions permettent de modifier son rôle ou de le supprimer du centre."
       }
     },
+    "networks": {
+      "creation": {
+        "actions": {
+          "submit": "Create the network"
+        },
+        "error-messages": {
+          "name": "The network name is required.",
+          "organization-id": "The organization ID is required."
+        },
+        "name": {
+          "label": "Network name:"
+        },
+        "notifications": {
+          "error": "An error occurred.",
+          "success": "The network was successfully created."
+        },
+        "organization-id": {
+          "label": "ID of the organization at the head of the network:"
+        }
+      }
+    },
     "organization-learner-information": {
       "deletion-modal": {
         "success-message": "The user has been successfully removed from the organisation.",
@@ -1316,6 +1337,9 @@
         }
       },
       "title": "Access to this Pix Admin space is limited to administrators."
+    },
+    "networks": {
+      "title": "Create a network"
     },
     "organization": {
       "get": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -616,6 +616,27 @@
         "caption": "Liste des membres appartenant au centre de certification. Contient son identifiant, nom et prénom, son adresse e-mail, son rôle, son dernier accès et sa date de rattachement à l'espace de certification. Des actions permettent de modifier son rôle ou de le supprimer du centre."
       }
     },
+    "networks": {
+      "creation": {
+        "actions": {
+          "submit": "Créer le réseau"
+        },
+        "error-messages": {
+          "name": "Le nom du réseau est requis.",
+          "organization-id": "L'ID d'organisation est requis."
+        },
+        "name": {
+          "label": "Nom du réseau :"
+        },
+        "notifications": {
+          "error": "Une erreur est survenue.",
+          "success": "Le réseau a été créé avec succès."
+        },
+        "organization-id": {
+          "label": "ID d'organisation à la tête du réseau:"
+        }
+      }
+    },
     "organization-learner-information": {
       "deletion-modal": {
         "success-message": "l'utilisateur a bien été supprimé de l'organisation.",
@@ -1319,6 +1340,9 @@
         }
       },
       "title": "L'accès à Pix Admin est limité aux administrateurs de la plateforme"
+    },
+    "networks": {
+      "title": "Créer un réseau"
     },
     "organization": {
       "get": {

--- a/api/src/organizational-entities/application/network/network.admin.controller.js
+++ b/api/src/organizational-entities/application/network/network.admin.controller.js
@@ -6,17 +6,19 @@ const findAllNetworks = async function (request, h, dependencies = { networkSeri
   return dependencies.networkSerializer.serialize(networks);
 };
 
-const create = async function (request, h) {
+const create = async function (request, h, dependencies = { networkSerializer }) {
   const { organizationId, networkName } = networkSerializer.deserialize({
     data: request.payload.data,
   });
 
-  await usecases.createNetwork({
+  const network = await usecases.createNetwork({
     organizationId,
     networkName,
   });
 
-  return h.response().code(201);
+  const serializedNetwork = await dependencies.networkSerializer.serialize(network);
+
+  return h.response(serializedNetwork).code(201);
 };
 
 const networkAdminController = {

--- a/api/src/organizational-entities/application/network/network.admin.route.js
+++ b/api/src/organizational-entities/application/network/network.admin.route.js
@@ -52,6 +52,7 @@ const register = async function (server) {
                 'network-name': Joi.string().required(),
                 'organization-id': identifiersType.organizationId.required(),
               }),
+              type: Joi.string(),
             }),
           }),
         },

--- a/api/src/organizational-entities/application/network/network.admin.route.js
+++ b/api/src/organizational-entities/application/network/network.admin.route.js
@@ -49,7 +49,7 @@ const register = async function (server) {
           payload: Joi.object({
             data: Joi.object({
               attributes: Joi.object({
-                'network-name': Joi.string().required(),
+                name: Joi.string().required(),
                 'organization-id': identifiersType.organizationId.required(),
               }),
               type: Joi.string(),

--- a/api/src/organizational-entities/domain/usecases/create-network.usecase.js
+++ b/api/src/organizational-entities/domain/usecases/create-network.usecase.js
@@ -5,7 +5,7 @@ import { NetworkAlreadyExistError } from '../errors.js';
  * @param{number} params.organizationId
  * @param{string} params.networkName
  * @param{NetworkRepository} params.networkRepository
- * @returns {Promise<void>}
+ * @returns {Promise<Network>}
  */
 const createNetwork = async function ({ organizationId, networkName, networkRepository }) {
   const existingNetwork = await networkRepository.findByOrganizationId(organizationId);
@@ -14,7 +14,7 @@ const createNetwork = async function ({ organizationId, networkName, networkRepo
     throw new NetworkAlreadyExistError();
   }
 
-  await networkRepository.save({ networkName, organizationId });
+  return networkRepository.save({ networkName, organizationId });
 };
 
 export { createNetwork };

--- a/api/src/organizational-entities/domain/usecases/create-network.usecase.js
+++ b/api/src/organizational-entities/domain/usecases/create-network.usecase.js
@@ -8,9 +8,9 @@ import { NetworkAlreadyExistError } from '../errors.js';
  * @returns {Promise<void>}
  */
 const createNetwork = async function ({ organizationId, networkName, networkRepository }) {
-  const existingNEtwork = await networkRepository.findByOrganizationId(organizationId);
+  const existingNetwork = await networkRepository.findByOrganizationId(organizationId);
 
-  if (existingNEtwork) {
+  if (existingNetwork) {
     throw new NetworkAlreadyExistError();
   }
 

--- a/api/src/organizational-entities/domain/usecases/create-network.usecase.js
+++ b/api/src/organizational-entities/domain/usecases/create-network.usecase.js
@@ -1,4 +1,4 @@
-import { NetworkAlreadyExistError } from '../errors.js';
+import { NetworkAlreadyExistError, OrganizationNotFound } from '../errors.js';
 
 /**
  * @param{object} params
@@ -7,7 +7,24 @@ import { NetworkAlreadyExistError } from '../errors.js';
  * @param{NetworkRepository} params.networkRepository
  * @returns {Promise<Network>}
  */
-const createNetwork = async function ({ organizationId, networkName, networkRepository }) {
+const createNetwork = async function ({
+  organizationId,
+  networkName,
+  networkRepository,
+  organizationForAdminRepository,
+}) {
+  const isOrganizationExisting = await organizationForAdminRepository.exist({
+    organizationId,
+  });
+
+  if (!isOrganizationExisting) {
+    throw new OrganizationNotFound({
+      meta: {
+        organizationId: Number(organizationId),
+      },
+    });
+  }
+
   const existingNetwork = await networkRepository.findByOrganizationId(organizationId);
 
   if (existingNetwork) {

--- a/api/src/organizational-entities/infrastructure/repositories/network.repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/network.repository.js
@@ -38,18 +38,20 @@ async function findByOrganizationId(organizationId) {
  * @param {object} params
  * @param {number} params.organizationId
  * @param {string} params.networkName
- * @returns {Promise<void>}
+ * @returns {Promise<Network>}
  */
 async function save({ organizationId, networkName }) {
   const knexConn = DomainTransaction.getConnection();
 
   const [{ id: structureId }] = await knexConn('structures').insert({}, ['id']);
-  const [{ id: networkId }] = await knexConn('networks').insert({ name: networkName }, ['id']);
+  const [savedNetwork] = await knexConn('networks').insert({ name: networkName }, ['id', 'name']);
   await knexConn('fct_structures').insert({
     structure_id: structureId,
     organization_id: organizationId,
-    network_id: networkId,
+    network_id: savedNetwork.id,
   });
+
+  return _toDomain(savedNetwork);
 }
 
 function _toDomain(network) {

--- a/api/src/organizational-entities/infrastructure/serializers/jsonapi/network/network.serializer.js
+++ b/api/src/organizational-entities/infrastructure/serializers/jsonapi/network/network.serializer.js
@@ -12,7 +12,7 @@ const deserialize = function (json) {
   const attributes = json.data.attributes;
 
   return {
-    networkName: attributes['network-name'],
+    networkName: attributes['name'],
     organizationId: attributes['organization-id'],
   };
 };

--- a/api/tests/organizational-entities/acceptance/application/network/network.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/network/network.admin.route.test.js
@@ -80,9 +80,10 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | N
       const response = await server.inject(request);
 
       // then
-      expect(response.statusCode).to.equal(201);
       const createdNetwork = await knex('networks').first();
-      expect(createdNetwork.name).to.equal('Network name');
+      expect(response.statusCode).to.equal(201);
+      expect(response.result.data.id).to.equal(createdNetwork.id.toString());
+      expect(response.result.data.attributes.name).to.equal('Network name');
     });
   });
 });

--- a/api/tests/organizational-entities/acceptance/application/network/network.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/network/network.admin.route.test.js
@@ -69,7 +69,7 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | N
         payload: {
           data: {
             attributes: {
-              'network-name': 'Network name',
+              name: 'Network name',
               'organization-id': organizationId,
             },
           },

--- a/api/tests/organizational-entities/integration/domain/usecases/create-network.usecase.test.js
+++ b/api/tests/organizational-entities/integration/domain/usecases/create-network.usecase.test.js
@@ -1,24 +1,25 @@
 import { knex } from '../../../../../db/knex-database-connection.js';
 import { NetworkAlreadyExistError } from '../../../../../src/organizational-entities/domain/errors.js';
 import { usecases } from '../../../../../src/organizational-entities/domain/usecases/index.js';
-import { catchErr, databaseBuilder, expect } from '../../../../test-helper.js';
+import { catchErr, databaseBuilder, domainBuilder, expect } from '../../../../test-helper.js';
 
 describe('Integration | Organizational Entities | Domain | UseCase | create-network', function () {
   describe('when the organization does not belong to a network', function () {
-    it('creates a new network', async function () {
+    it('returns the newly created network', async function () {
       // given
       const organizationId = databaseBuilder.factory.buildOrganization().id;
       await databaseBuilder.commit();
 
       // when
-      await usecases.createNetwork({
+      const network = await usecases.createNetwork({
         organizationId,
         networkName: 'Random Network Name',
       });
 
       // then
       const createdNetwork = await knex('networks').first();
-      expect(createdNetwork.name).to.equal('Random Network Name');
+      const expectedNetwork = domainBuilder.acquisition.buildNetwork(createdNetwork);
+      expect(network).to.deep.equal(expectedNetwork);
     });
   });
 

--- a/api/tests/organizational-entities/integration/domain/usecases/create-network.usecase.test.js
+++ b/api/tests/organizational-entities/integration/domain/usecases/create-network.usecase.test.js
@@ -1,5 +1,8 @@
 import { knex } from '../../../../../db/knex-database-connection.js';
-import { NetworkAlreadyExistError } from '../../../../../src/organizational-entities/domain/errors.js';
+import {
+  NetworkAlreadyExistError,
+  OrganizationNotFound,
+} from '../../../../../src/organizational-entities/domain/errors.js';
 import { usecases } from '../../../../../src/organizational-entities/domain/usecases/index.js';
 import { catchErr, databaseBuilder, domainBuilder, expect } from '../../../../test-helper.js';
 
@@ -45,6 +48,28 @@ describe('Integration | Organizational Entities | Domain | UseCase | create-netw
 
       // then
       expect(error).to.deepEqualInstance(new NetworkAlreadyExistError());
+    });
+  });
+
+  describe('when the organization does not exist', function () {
+    it('throw an error', async function () {
+      // given
+      const unknownOrganizationId = 123;
+
+      // when
+      const error = await catchErr(usecases.createNetwork)({
+        organizationId: unknownOrganizationId,
+        networkName: 'Random Network Name',
+      });
+
+      // then
+      expect(error).to.deepEqualInstance(
+        new OrganizationNotFound({
+          meta: {
+            organizationId: Number(unknownOrganizationId),
+          },
+        }),
+      );
     });
   });
 });

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/network.repository.test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/network.repository.test.js
@@ -84,14 +84,14 @@ describe('Integration | Organizational Entities | Infrastructure | Repositories 
   });
 
   describe('#save', function () {
-    it('saves a new network', async function () {
+    it('saves and returns the new network', async function () {
       // given
       const organizationId = databaseBuilder.factory.buildOrganization().id;
       const networkName = 'Network 1';
       await databaseBuilder.commit();
 
       // when
-      await networkRepository.save({ organizationId, networkName });
+      const savedNetwork = await networkRepository.save({ organizationId, networkName });
 
       // then
       const foundNetwork = await knex('networks').select('id', 'name').where({ name: networkName }).first();
@@ -108,6 +108,8 @@ describe('Integration | Organizational Entities | Infrastructure | Repositories 
         .where('fct_structures.organization_id', organizationId)
         .first();
       expect(createdFactStructure.network_id).to.equal(foundNetwork.id);
+      const expectedNetwork = domainBuilder.acquisition.buildNetwork(foundNetwork);
+      expect(savedNetwork).to.deep.equal(expectedNetwork);
     });
   });
 });

--- a/api/tests/organizational-entities/unit/application/network/network.admin.controller.test.js
+++ b/api/tests/organizational-entities/unit/application/network/network.admin.controller.test.js
@@ -29,7 +29,7 @@ describe('Unit | Organizational Entities | Application | Network', function () {
           payload: {
             data: {
               attributes: {
-                'network-name': 'Network name',
+                name: 'Network name',
                 'organization-id': 123,
               },
             },

--- a/api/tests/organizational-entities/unit/application/network/network.admin.controller.test.js
+++ b/api/tests/organizational-entities/unit/application/network/network.admin.controller.test.js
@@ -36,9 +36,16 @@ describe('Unit | Organizational Entities | Application | Network', function () {
           },
         };
         const createNetworkStub = sinon.stub(usecases, 'createNetwork');
+        const createdNetwork = createNetworkStub.resolves(Symbol('createdNetwork'));
+        const serializedNetwork = Symbol('serializedNetwork');
+        const networkSerializerStub = { serialize: sinon.stub() };
+        networkSerializerStub.serialize.withArgs(createdNetwork).returns(serializedNetwork);
+        const dependencies = {
+          networkSerializer: networkSerializerStub,
+        };
 
         // when
-        await networkAdminController.create(request, hFake);
+        await networkAdminController.create(request, hFake, dependencies);
 
         // then
         expect(createNetworkStub).to.have.been.calledOnceWith({

--- a/api/tests/organizational-entities/unit/application/network/network.admin.route.test.js
+++ b/api/tests/organizational-entities/unit/application/network/network.admin.route.test.js
@@ -60,7 +60,7 @@ describe('Unit | Application | Admin | Route | Network', function () {
           data: {
             attributes: {
               'organization-id': 123,
-              'network-name': 'Some network name',
+              name: 'Some network name',
             },
           },
         });
@@ -85,7 +85,7 @@ describe('Unit | Application | Admin | Route | Network', function () {
           data: {
             attributes: {
               'organization-id': 123,
-              'network-name': 'Some network name',
+              name: 'Some network name',
             },
           },
         });

--- a/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/network/network.serializer.test.js
+++ b/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/network/network.serializer.test.js
@@ -32,14 +32,14 @@ describe('Unit | Infrastructure | Serializers | JsonApi |  Network | network-ser
     it('should convert JSON API data to a Organization', function () {
       // given
       const formData = {
-        networkName: 'Some network name',
+        name: 'Some network name',
         organizationId: 123,
       };
 
       const jsonApiFormData = {
         data: {
           attributes: {
-            'network-name': formData.networkName,
+            name: formData.name,
             'organization-id': formData.organizationId,
           },
         },
@@ -50,7 +50,7 @@ describe('Unit | Infrastructure | Serializers | JsonApi |  Network | network-ser
 
       // then
       expect(deserializedData).to.deep.equal({
-        networkName: formData.networkName,
+        networkName: formData.name,
         organizationId: formData.organizationId,
       });
     });


### PR DESCRIPTION
## 🥀 Problème

Il n'existe pas encore de page pour créer un réseau, tout se fait en curl. C'est quand même pas très pratique.

## 🏹 Proposition

Création d'une nouvelle page pour le moment accessible uniquement via l'URL `/networks/new`

## 💌 Remarques

On retourne également dans cette PR le réseau créé dans #15365 
Nous ne disposons pas de maquette, j'ai sorti quelque chose mais c'est pas de l'art.

## ❤️‍🔥 Pour tester

- Se connecter à pix-admin en tant que `superadmin@example.net`
- Aller à l'URL :  `/networks/new` 
- Créer un réseau à partir d'une organisation existante
- Une notification de succès apparaît
- Essayer de créer un nouveau réseau avec le même `organizationId`
- Une notification d'erreur apparaît (message indiquant qu'une orga est déjà rattachée à un réseau disponible dans la console)
- Essayer de créer un nouveau réseau avec un `organizationId` qui n'existe pas
- Une notification d'erreur apparaît
- Vérifier l'impossibilité de créer un réseau en n'étant pas superadmin

