### PR TITLE
[TECH] Ajout de nouvelles colonnes avec une méthode "zero-downtime" pour les tables "certification-courses" et "certification-candidates" (PIX-21858)

### DIFF
--- a/api/db/migrations/20260309143554_add-versionid-candidateid-subscription-on-certification-courses-table.js
+++ b/api/db/migrations/20260309143554_add-versionid-candidateid-subscription-on-certification-courses-table.js
@@ -1,0 +1,58 @@
+// Make sure you properly test your migration, especially DDL (Data Definition Language)
+// ! If the target table is large, and the migration take more than 20 minutes, the deployment will fail !
+
+// You can design and test your migration to avoid this by following this guide
+// https://1024pix.atlassian.net/wiki/spaces/EDTDT/pages/3849323922/Cr+er+une+migration
+
+// If your migrations target :
+//
+// `answers`
+// `knowledge-elements`
+// `knowledge-element-snapshots`
+//
+// contact @team-captains, because automatic migrations are not active on `pix-datawarehouse-production`
+// this may prevent data replication to succeed the day after your migration is deployed on `pix-api-production`
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.table('certification-candidates', function (table) {
+    table.string('subscription', 50).comment('Enum value of Framework that candidate is subscribe to');
+  });
+  await knex.schema.table('certification-courses', function (table) {
+    table.integer('versionId').comment('Active certification version at candidate reconciliation.');
+    table.integer('candidateId').comment('link to certification candidate');
+  });
+  await knex.raw(`
+    ALTER TABLE "certification-courses"
+    ADD CONSTRAINT certification_courses_candidateid_foreign
+    FOREIGN KEY ("candidateId")
+    REFERENCES "certification-candidates"(id)
+    NOT VALID
+`);
+  await knex.raw(`
+    ALTER TABLE "certification-courses"
+    ADD CONSTRAINT certification_courses_versionid_foreign
+    FOREIGN KEY ("versionId")
+    REFERENCES certification_versions(id)
+    NOT VALID
+`);
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.table('certification-courses', function (table) {
+    table.dropColumn('versionId');
+    table.dropColumn('candidateId');
+  });
+  await knex.schema.table('certification-candidates', function (table) {
+    table.dropColumn('subscription');
+  });
+};
+
+export { down, up };

--- a/api/tests/certification/enrolment/integration/infrastructure/repositories/candidate-repository_test.js
+++ b/api/tests/certification/enrolment/integration/infrastructure/repositories/candidate-repository_test.js
@@ -344,6 +344,7 @@ describe('Integration | Certification | Enrolment | Repository | Candidate', fun
         accessibilityAdjustmentNeeded: false,
         subscriptions: [subscriptionCore, subscriptionComplementary],
         reconciledAt: null,
+        subscription: null,
       };
       databaseBuilder.factory.buildSession({ id: candidateData.sessionId });
       databaseBuilder.factory.buildComplementaryCertification({
@@ -469,6 +470,7 @@ describe('Integration | Certification | Enrolment | Repository | Candidate', fun
         prepaymentCode: candidateA.prepaymentCode,
         hasSeenCertificationInstructions: false,
         accessibilityAdjustmentNeeded: candidateA.accessibilityAdjustmentNeeded,
+        subscription: null,
       });
       expect(savedCandidateAData.createdAt).to.be.instanceOf(Date);
       expect(parseFloat(savedCandidateAData.extraTimePercentage)).to.equal(candidateA.extraTimePercentage);
@@ -522,6 +524,7 @@ describe('Integration | Certification | Enrolment | Repository | Candidate', fun
         prepaymentCode: candidateB.prepaymentCode,
         hasSeenCertificationInstructions: false,
         accessibilityAdjustmentNeeded: candidateB.accessibilityAdjustmentNeeded,
+        subscription: null,
       });
       expect(savedCandidateBData.createdAt).to.be.instanceOf(Date);
       expect(parseFloat(savedCandidateBData.extraTimePercentage)).to.equal(candidateB.extraTimePercentage);
@@ -567,6 +570,7 @@ describe('Integration | Certification | Enrolment | Repository | Candidate', fun
         prepaymentCode: candidateC.prepaymentCode,
         hasSeenCertificationInstructions: false,
         accessibilityAdjustmentNeeded: candidateC.accessibilityAdjustmentNeeded,
+        subscription: null,
       });
       expect(savedCandidateCData.createdAt).to.be.instanceOf(Date);
       expect(parseFloat(savedCandidateCData.extraTimePercentage)).to.equal(candidateC.extraTimePercentage);


### PR DESCRIPTION
## 🥀 Problème

On souhaite ajouter une colonne `subscription` dans la table `certification-candidates` (ça pas de pb).
On souhaite aussi ajouter deux colonnes qui auront des contraintes de FK dans la table `certification-courses` : `versionId` vers `certification_versions` et `candidateId` vers `certification-candidates`.

On a fait une première tentative infructueuse qui a été revert : https://github.com/1024pix/pix/pull/15381

Lorsqu'on ajoute une colonne avec une contrainte de clé étrangère à valider immédiatement (un cas d'usage très commun), PG va apposer des locks très rigides sur les tables concernées : la table référente et la table référée. Le lock mis est `SHARE ROW EXCLUSIVE` ([voir ceci](https://www.postgresql.org/docs/current/explicit-locking.html)), qui empêche toute modification de la table (et dans les données et dans le schéma, donc écritures bloquantes). De plus, l'application de la contrainte est gourmande car elle nécessite une lecture séquentielle de la table `certification-courses` car PG doit vérifier que la contrainte est respectée pour chaque ligne.

## 🏹 Proposition

Découper l'ajout des colonnes avec contraintes en deux parties : 

### Première partie (cette PR)
Ajout des colonnes + ajout des contraintes en mode "NO VALID". Ça indique à PG qu'on se souhaite pas vérifier la validité de la contrainte pour les enregistrements déjà présents, mais en revanche il vérifiera bien la contrainte pour les nouvelles insertions. Donc l'ajout de ces contraintes de cette manière n'appose aucun lock, puisque rien n'est fait 🤷🏿 

### Deuxième partie (PR du futur)
Indiquer à PG qu'on souhaite désormais rendre "VALID" les contraintes (donc que TOUTES les lignes doivent les respecter). Cette opération appose un lock de type `SHARE UPDATE EXCLUSIVE` qui n'empêche ni les lectures ni les écritures, mais empêche les altérations de schéma ainsi que les opérations de maintenance style `VACUUM`.

Note : cette deuxième PR portera aussi l'ajout d'un index sur candidateId en mode `IF NOT EXISTS`, car pour des raisons de temps d'exécution cet index sera ajouté à la demande par les captains en mode concurrent.

## 💌 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## ❤️‍🔥 Pour tester
migrate puis rollback puis vérifier que le schéma est ok (fait ensemble)
