### PR TITLE
[BUGFIX] Rendre le logout SSO OIDC plus robuste (PIX-21856)

### DIFF
--- a/mon-pix/app/authenticators/oidc.js
+++ b/mon-pix/app/authenticators/oidc.js
@@ -79,16 +79,20 @@ export default class OidcAuthenticator extends BaseAuthenticator {
       return;
     }
 
-    const response = await fetch(
-      `${ENV.APP.API_HOST}/api/oidc/redirect-logout-url?identity_provider=${identityProviderCode}&logout_url_uuid=${logoutUrlUuid}`,
-      {
-        headers: {
-          Authorization: `Bearer ${access_token}`,
+    try {
+      const response = await fetch(
+        `${ENV.APP.API_HOST}/api/oidc/redirect-logout-url?identity_provider=${identityProviderCode}&logout_url_uuid=${logoutUrlUuid}`,
+        {
+          headers: {
+            Authorization: `Bearer ${access_token}`,
+          },
         },
-      },
-    );
-    const { redirectLogoutUrl } = await response.json();
+      );
+      const { redirectLogoutUrl } = await response.json();
 
-    this.session.alternativeRootURL = redirectLogoutUrl;
+      this.session.alternativeRootURL = redirectLogoutUrl;
+    } catch {
+      // Catch all errors because invalidate must never fail
+    }
   }
 }

--- a/orga/app/authenticators/oidc.js
+++ b/orga/app/authenticators/oidc.js
@@ -79,16 +79,20 @@ export default class OidcAuthenticator extends BaseAuthenticator {
       return;
     }
 
-    const response = await fetch(
-      `${ENV.APP.API_HOST}/api/oidc/redirect-logout-url?identity_provider=${identityProviderCode}&logout_url_uuid=${logoutUrlUuid}`,
-      {
-        headers: {
-          Authorization: `Bearer ${access_token}`,
+    try {
+      const response = await fetch(
+        `${ENV.APP.API_HOST}/api/oidc/redirect-logout-url?identity_provider=${identityProviderCode}&logout_url_uuid=${logoutUrlUuid}`,
+        {
+          headers: {
+            Authorization: `Bearer ${access_token}`,
+          },
         },
-      },
-    );
-    const { redirectLogoutUrl } = await response.json();
+      );
+      const { redirectLogoutUrl } = await response.json();
 
-    this.session.routeAfterInvalidation = redirectLogoutUrl;
+      this.session.routeAfterInvalidation = redirectLogoutUrl;
+    } catch {
+      // Catch all errors because invalidate must never fail
+    }
   }
 }


### PR DESCRIPTION
## 🥀 Problème

Lorsqu’un problème se produit dans le `fetch` du `invalidate` de `mon-pix/app/authenticators/oidc.js` et de `orga/app/authenticators/oidc.js` la déconnexion de ember-simple-auth n’a pas lieu.

## 🏹 Proposition

Entourer les appels `fetch` du `invalidate` de `mon-pix/app/authenticators/oidc.js` et de `orga/app/authenticators/oidc.js` avec un `try`/`catch` de manière à ce que le `invalidate` ne throw aucune exception et que la déconnexion puisse avoir lieu **dans tous les cas**.

## 💌 Remarques

RAS

## ❤️‍🔥 Pour tester

1. Se connecter par un SSO OIDC avec un navigateur web 1 (par exemple Firefox),
2. Se connecter par un SSO OIDC avec un autre navigateur web 2 (par exemple Chrome),
3. Se déconnecter au niveau du navigateur web 2 et constater qu’on est bien déconnecté sans erreur,
4. Se reconnecter avec navigateur web 2 et constater qu’on peut bien se reconnecter sans erreur,
5. Constater qu’on reste bien toujours connecté avec navigateur web 1 et qu’on peut continuer d’utiliser Pix sans erreur.
