### PR TITLE
[TECH] Rendre les contraintes sur les colonnes "versionId" et "candidateId" valides dans la table "certification-courses" (PIX-21859)

### DIFF
--- a/api/db/migrations/20260309151229_enforce-constraints-on-versionid-candidateid-on-table-certification-courses.js
+++ b/api/db/migrations/20260309151229_enforce-constraints-on-versionid-candidateid-on-table-certification-courses.js
@@ -1,0 +1,67 @@
+// Make sure you properly test your migration, especially DDL (Data Definition Language)
+// ! If the target table is large, and the migration take more than 20 minutes, the deployment will fail !
+
+// You can design and test your migration to avoid this by following this guide
+// https://1024pix.atlassian.net/wiki/spaces/EDTDT/pages/3849323922/Cr+er+une+migration
+
+// If your migrations target :
+//
+// `answers`
+// `knowledge-elements`
+// `knowledge-element-snapshots`
+//
+// contact @team-captains, because automatic migrations are not active on `pix-datawarehouse-production`
+// this may prevent data replication to succeed the day after your migration is deployed on `pix-api-production`
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.raw(`
+    CREATE INDEX IF NOT EXISTS certification_courses_candidateid_index
+    ON "certification-courses"("candidateId");
+`);
+  await knex.raw(`
+    ALTER TABLE "certification-courses"
+    VALIDATE CONSTRAINT certification_courses_candidateid_foreign;
+`);
+  await knex.raw(`
+    ALTER TABLE "certification-courses"
+    VALIDATE CONSTRAINT certification_courses_versionid_foreign;
+`);
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.raw(`
+    ALTER TABLE "certification-courses"
+    DROP CONSTRAINT IF EXISTS certification_courses_versionid_foreign;
+`);
+  await knex.raw(`
+    ALTER TABLE "certification-courses"
+    ADD CONSTRAINT certification_courses_versionid_foreign
+    FOREIGN KEY ("versionId")
+    REFERENCES certification_versions(id)
+    NOT VALID
+`);
+  await knex.raw(`
+    ALTER TABLE "certification-courses"
+    DROP CONSTRAINT IF EXISTS certification_courses_candidateid_foreign;
+`);
+  await knex.raw(`
+    ALTER TABLE "certification-courses"
+    ADD CONSTRAINT certification_courses_candidateid_foreign
+    FOREIGN KEY ("candidateId")
+    REFERENCES "certification-candidates"(id)
+    NOT VALID
+`);
+  await knex.raw(`
+    DROP INDEX IF EXISTS certification_courses_candidateid_index
+`);
+};
+
+export { down, up };


### PR DESCRIPTION
## 🥀 Problème

Relire ceci svp : https://github.com/1024pix/pix/pull/15399

## 🏹 Proposition

Il s'agit maintenant d'indiquer à PG qu'on souhaite que nos contraintes soient valides pour tous les enregistrements de la table

## 💌 Remarques

Cette migration ajoute aussi un index.

**IMPORTANT** : il faut que cet index soit ajouté après la mise en production de cette [PR](https://github.com/1024pix/pix/pull/15399) mais avant la mise en production de cette PR ci.
Code à faire exécuter aux captains :

```
CREATE INDEX CONCURRENTLY IF NOT EXISTS certification_courses_candidateid_index
ON "certification-courses"("candidateId");
```

Cette PR doit donc restée bloquée tant que l'autre PR n'est pas en prod

## ❤️‍🔥 Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
