### PR TITLE
[TECH] Optimiser la récupération des knowledge elements pour la route CSV (PIX-21673)

### DIFF
--- a/api/src/shared/infrastructure/repositories/knowledge-element-repository.js
+++ b/api/src/shared/infrastructure/repositories/knowledge-element-repository.js
@@ -27,15 +27,23 @@ async function findAssessedByUserIdAndLimitDateQuery({ userId, limitDate, skillI
 }
 
 const findUniqByUserIds = async function ({ userIds }) {
-  const results = [];
-  for (const userId of userIds) {
-    const knowledgeElements = await findAssessedByUserIdAndLimitDateQuery({
-      userId,
-    });
+  if (userIds.length === 0) return [];
 
-    results.push({ userId, knowledgeElements });
+  const knexConn = DomainTransaction.getConnection();
+  const knowledgeElementRows = await knexConn(tableName).whereIn('userId', userIds);
+
+  const knowledgeElementsByUserId = new Map(userIds.map((userId) => [userId, []]));
+  for (const row of knowledgeElementRows) {
+    knowledgeElementsByUserId.get(row.userId)?.push(new KnowledgeElement(row));
   }
-  return results;
+
+  return userIds.map((userId) => {
+    const keCollection = new KnowledgeElementCollection(knowledgeElementsByUserId.get(userId));
+    return {
+      userId,
+      knowledgeElements: keCollection.latestUniqNonResetKnowledgeElements,
+    };
+  });
 };
 
 const batchSave = async function ({ knowledgeElements }) {


### PR DESCRIPTION
## 🥀 Problème

La route `GET /api/campaigns/{campaignId}/csv-assessment-results` effectuait autant de requêtes SQL que d'utilisateurs participants (problème N+1) pour récupérer leurs knowledge elements.

## 🏹 Proposition

Remplacement de la boucle `for...of` dans `findUniqByUserIds` par une unique requête SQL avec `whereIn('userId', userIds)`, puis regroupement des résultats en mémoire via une `Map`.

Les knowledge elements sont ensuite filtrés avec `KnowledgeElementCollection.latestUniqNonResetKnowledgeElements` comme avant, mais sans multiplier les allers-retours en base.

## ❤️‍🔥 Pour tester

- [x] Lancer la route `GET /api/campaigns/{campaignId}/csv-assessment-results` sur une campagne avec plusieurs participants et vérifier que le CSV est correct
- [x] Vérifier en base que le nombre de requêtes est réduit à 1 (au lieu de N)