### PR TITLE
[FEATURE] Renommer le wording du tag A verrouiler sur PixOrga dans les parcours combiné (PXI-20844).

### DIFF
--- a/orga/translations/de.json
+++ b/orga/translations/de.json
@@ -470,7 +470,7 @@
     },
     "participation-status": {
       "COMPLETED": "Abgeschlossen",
-      "LOCKED": "Zu entsperren",
+      "LOCKED": "Gesperrt",
       "NOT_STARTED": "Zu tun",
       "SHARED": "Abgeschlossen",
       "STARTED": "In Arbeit"

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -471,7 +471,7 @@
     },
     "participation-status": {
       "COMPLETED": "Completed",
-      "LOCKED": "To unlock",
+      "LOCKED": "Locked",
       "NOT_STARTED": "To do",
       "SHARED": "Completed",
       "STARTED": "In progress"

--- a/orga/translations/es.json
+++ b/orga/translations/es.json
@@ -471,7 +471,7 @@
     },
     "participation-status": {
       "COMPLETED": "Completado",
-      "LOCKED": "Para desbloquear",
+      "LOCKED": "Bloqueado",
       "NOT_STARTED": "Para hacer",
       "SHARED": "Completado",
       "STARTED": "En curso"

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -471,7 +471,7 @@
     },
     "participation-status": {
       "COMPLETED": "Terminé",
-      "LOCKED": "A déverrouiller",
+      "LOCKED": "Verrouillé",
       "NOT_STARTED": "A faire",
       "SHARED": "Terminé",
       "STARTED": "En cours"

--- a/orga/translations/it.json
+++ b/orga/translations/it.json
@@ -471,7 +471,7 @@
     },
     "participation-status": {
       "COMPLETED": "Completato",
-      "LOCKED": "Per sbloccare",
+      "LOCKED": "Bloccato",
       "NOT_STARTED": "Per fare",
       "SHARED": "Completato",
       "STARTED": "In corso"

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -470,7 +470,7 @@
     },
     "participation-status": {
       "COMPLETED": "Voltooid",
-      "LOCKED": "Te ontgrendelen",
+      "LOCKED": "Vergrendeld",
       "NOT_STARTED": "Te doen",
       "SHARED": "Voltooid",
       "STARTED": "Bezig"


### PR DESCRIPTION
## 🥀 Problème

Le wording pour les morceaux du parcours combiné verrouillé n'est pas fifou

## 🏹 Proposition

Renommer le A Deverrouiller en Verrouillé
## 💌 Remarques

rien

## ❤️‍🔥 Pour tester
Va sur PixOrga et constate les dégâts !