### PR TITLE
[TECH] Rendre le Mutex via Redis plus générique et plus robuste

### DIFF
--- a/api/src/llm/domain/usecases/prompt-chat.js
+++ b/api/src/llm/domain/usecases/prompt-chat.js
@@ -42,7 +42,8 @@ export async function promptChat({
     throw new ChatNotFoundError('null id provided');
   }
 
-  const locked = await redisMutex.lock(chatId, config.llm.lockChatExpirationDelayMilliseconds);
+  const owner = crypto.randomUUID();
+  const locked = await redisMutex.lock(chatId, owner, config.llm.lockChatExpirationDelayMilliseconds);
   if (!locked) {
     throw new PromptAlreadyOngoingError(chatId);
   }
@@ -66,9 +67,9 @@ export async function promptChat({
       });
     }
 
-    runFlow({ chat, chatRepository, llmResponseHandler, logger, redisMutex });
+    runFlow({ chat, owner, chatRepository, llmResponseHandler, logger, redisMutex });
   } catch (error) {
-    await redisMutex.release(chatId);
+    await redisMutex.release(chatId, owner);
     throw error;
   }
 }
@@ -79,13 +80,14 @@ export async function promptChat({
  *
  * @param {object} params
  * @param {Chat} params.chat
+ * @param {string} params.owner - redis mutex lock owner
  * @param {ChatRepository} params.chatRepository
  * @param {RedisMutex} params.redisMutex
  * @param {LLMResponseHandler} params.llmResponseHandler
  * @param {Logger=} params.logger
  * @returns {Promise<void>}
  */
-async function runFlow({ chat, chatRepository, llmResponseHandler, logger = defaultLogger, redisMutex }) {
+async function runFlow({ chat, owner, chatRepository, llmResponseHandler, logger = defaultLogger, redisMutex }) {
   /** @type {LLMResponseMetadata} */
   let llmResponseMetadata;
   try {
@@ -148,6 +150,6 @@ async function runFlow({ chat, chatRepository, llmResponseHandler, logger = defa
     );
     await llmResponseHandler.finish();
   } finally {
-    await redisMutex.release(chat.id);
+    await redisMutex.release(chat.id, owner);
   }
 }

--- a/api/src/llm/domain/usecases/prompt-chat.js
+++ b/api/src/llm/domain/usecases/prompt-chat.js
@@ -1,3 +1,4 @@
+import { config } from '../../../shared/config.js';
 import { child, SCOPES } from '../../../shared/infrastructure/utils/logger.js';
 import { ChatForbiddenError, ChatNotFoundError, LLMApiError, PromptAlreadyOngoingError } from '../errors.js';
 import { Chat } from '../models/Chat.js';
@@ -41,7 +42,7 @@ export async function promptChat({
     throw new ChatNotFoundError('null id provided');
   }
 
-  const locked = await redisMutex.lock(chatId);
+  const locked = await redisMutex.lock(chatId, config.llm.lockChatExpirationDelayMilliseconds);
   if (!locked) {
     throw new PromptAlreadyOngoingError(chatId);
   }

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -697,6 +697,8 @@ const configuration = (function () {
     config.apiManager.url = 'http://external-partners-access/';
 
     config.infra.engineeringUserId = 800;
+
+    config.timeouts.server = 10_000;
   }
 
   return config;

--- a/api/src/shared/infrastructure/mutex/RedisMutex.js
+++ b/api/src/shared/infrastructure/mutex/RedisMutex.js
@@ -11,20 +11,23 @@ class RedisMutex {
   /**
    *
    * @param { string } resourceId
+   * @param { string } ownerId
    * @param { number } lockExpirationDelay - in milliseconds. Default value : 5 seconds less than HTTP server timeout
    * @returns { Promise<boolean> } true : successful lock
    */
-  async lock(resourceId, lockExpirationDelay = config.timeouts.server - 5_000) {
-    return (await this._client.set(resourceId, '1', 'PX', lockExpirationDelay, 'NX')) === 'OK';
+  async lock(resourceId, ownerId, lockExpirationDelay = config.timeouts.server - 5_000) {
+    return (await this._client.set(resourceId, ownerId, 'PX', lockExpirationDelay, 'NX')) === 'OK';
   }
 
   /**
    *
    * @param { string } resourceId
+   * @param { string } ownerId
    * @returns { Promise<boolean> } true : successful release
    */
-  async release(resourceId) {
-    return (await this._client.del(resourceId)) === 1;
+  async release(resourceId, ownerId) {
+    const result = await this._client.releaseLock(resourceId, ownerId);
+    return result === 1;
   }
 
   async quit() {

--- a/api/src/shared/infrastructure/mutex/RedisMutex.js
+++ b/api/src/shared/infrastructure/mutex/RedisMutex.js
@@ -11,12 +11,11 @@ class RedisMutex {
   /**
    *
    * @param { string } resourceId
+   * @param { number } lockExpirationDelay - in milliseconds. Default value : 5 seconds less than HTTP server timeout
    * @returns { Promise<boolean> } true : successful lock
    */
-  async lock(resourceId) {
-    return (
-      (await this._client.set(resourceId, '1', 'PX', config.llm.lockChatExpirationDelayMilliseconds, 'NX')) === 'OK'
-    );
+  async lock(resourceId, lockExpirationDelay = config.timeouts.server - 5_000) {
+    return (await this._client.set(resourceId, '1', 'PX', lockExpirationDelay, 'NX')) === 'OK';
   }
 
   /**

--- a/api/src/shared/infrastructure/utils/RedisClient.js
+++ b/api/src/shared/infrastructure/utils/RedisClient.js
@@ -13,12 +13,23 @@ class RedisClient {
     this._client.on('connect', () => logger.info({ redisClient: this._clientName }, 'Connected to server'));
     this._client.on('end', () => logger.info({ redisClient: this._clientName }, 'Disconnected from server'));
     this._client.on('error', (err) => logger.error({ redisClient: this._clientName, err }, 'Error encountered'));
+    this._client.defineCommand('releaseLock', {
+      numberOfKeys: 1,
+      lua: `
+        if redis.call("GET", KEYS[1]) == ARGV[1] then
+          return redis.call("DEL", KEYS[1])
+        else
+          return 0
+        end
+      `,
+    });
 
     this.ttl = this._wrapWithPrefix(this._client.ttl).bind(this._client);
     this.get = this._wrapWithPrefix(this._client.get).bind(this._client);
     this.incr = this._wrapWithPrefix(this._client.incr).bind(this._client);
     this.decr = this._wrapWithPrefix(this._client.decr).bind(this._client);
     this.set = this._wrapWithPrefix(this._client.set).bind(this._client);
+    this.releaseLock = this._wrapWithPrefix(this._client.releaseLock).bind(this._client);
     this.del = this._wrapWithPrefix(this._client.del).bind(this._client);
     this.expire = this._wrapWithPrefix(this._client.expire).bind(this._client);
     this.lpush = this._wrapWithPrefix(this._client.lpush).bind(this._client);

--- a/api/tests/shared/integration/infrastructure/mutex/RedisMutex_test.js
+++ b/api/tests/shared/integration/infrastructure/mutex/RedisMutex_test.js
@@ -3,46 +3,115 @@ import { expect, wait } from '../../../../test-helper.js';
 
 describe('Shared | Integration | Infrastructure | Mutex | RedisMutex', function () {
   describe('#lock', function () {
-    it('should successfully lock resource for the first time, but fail the second time because resource is already locked', async function () {
-      // when
-      const isLockSuccess_firstCall = await redisMutex.lock('someResourceId');
-      const isLockSuccess_secondCall = await redisMutex.lock('someResourceId');
+    context('same owner', function () {
+      it('should successfully lock resource for the first time, but fail the second time because resource is already locked', async function () {
+        // when
+        const isLockSuccess_firstCall = await redisMutex.lock('someResourceId', 'processA');
+        const isLockSuccess_secondCall = await redisMutex.lock('someResourceId', 'processA');
 
-      // then
-      expect(isLockSuccess_firstCall).to.be.true;
-      expect(isLockSuccess_secondCall).to.be.false;
+        // then
+        expect(isLockSuccess_firstCall).to.be.true;
+        expect(isLockSuccess_secondCall).to.be.false;
+      });
+    });
+
+    context('different owner', function () {
+      it('should successfully lock resource for the first time, but fail the second time because resource is already locked', async function () {
+        // when
+        const isLockSuccess_firstCall = await redisMutex.lock('someResourceId', 'processA');
+        const isLockSuccess_secondCall = await redisMutex.lock('someResourceId', 'processB');
+
+        // then
+        expect(isLockSuccess_firstCall).to.be.true;
+        expect(isLockSuccess_secondCall).to.be.false;
+      });
     });
 
     it('should release automatically after expiration delay', async function () {
       const lockExpirationDelay = 250;
-      await redisMutex.lock('someResourceId', lockExpirationDelay);
+      await redisMutex.lock('someResourceId', 'ownerId', lockExpirationDelay);
 
       // when
-      const isLockSuccess_beforeDelay1 = await redisMutex.lock('someResourceId', lockExpirationDelay);
+      const isLockSuccess_beforeDelay1 = await redisMutex.lock('someResourceId', 'ownerId', lockExpirationDelay);
       await wait(100);
-      const isLockSuccess_beforeDelay2 = await redisMutex.lock('someResourceId', lockExpirationDelay);
+      const isLockSuccess_beforeDelay2 = await redisMutex.lock('someResourceId', 'ownerId', lockExpirationDelay);
       await wait(151);
-      const isLockSuccess_afterDelay = await redisMutex.lock('someResourceId', lockExpirationDelay);
+      const isLockSuccess_afterDelay = await redisMutex.lock('someResourceId', 'ownerId', lockExpirationDelay);
 
       // then
       expect(isLockSuccess_beforeDelay1).to.be.false;
       expect(isLockSuccess_beforeDelay2).to.be.false;
       expect(isLockSuccess_afterDelay).to.be.true;
     });
+
+    it('only allows one process to take the lock', async function () {
+      const results = await Promise.all([
+        redisMutex.lock('resource', 'A'),
+        redisMutex.lock('resource', 'B'),
+        redisMutex.lock('resource', 'C'),
+      ]);
+
+      const successCount = results.filter(Boolean).length;
+
+      expect(successCount).to.equal(1);
+    });
   });
 
   describe('#release', function () {
-    it('should successfully release the resource for the first time, but fail the second time because resource is already released', async function () {
-      // given
-      await redisMutex.lock('someResourceId');
+    context('same owner', function () {
+      it('should successfully release the resource for the first time, but fail the second time because resource is already released', async function () {
+        // given
+        await redisMutex.lock('someResourceId', 'ownerId');
 
-      // when
-      const isReleaseSuccess_firstCall = await redisMutex.release('someResourceId');
-      const isReleaseSuccess_secondCall = await redisMutex.release('someResourceId');
+        // when
+        const isReleaseSuccess_firstCall = await redisMutex.release('someResourceId', 'ownerId');
+        const isReleaseSuccess_secondCall = await redisMutex.release('someResourceId', 'ownerId');
 
-      // then
-      expect(isReleaseSuccess_firstCall).to.be.true;
-      expect(isReleaseSuccess_secondCall).to.be.false;
+        // then
+        expect(isReleaseSuccess_firstCall).to.be.true;
+        expect(isReleaseSuccess_secondCall).to.be.false;
+      });
+    });
+
+    context('different owner', function () {
+      it('should always fail to release the resource because owner is not the right one', async function () {
+        // given
+        await redisMutex.lock('someResourceId', 'ownerA');
+
+        // when
+        const isReleaseSuccess = await redisMutex.release('someResourceId', 'ownerB');
+
+        // then
+        expect(isReleaseSuccess).to.be.false;
+      });
+    });
+
+    it('should fail to release a resource that was never locked', async function () {
+      const result = await redisMutex.release('unknownResource', 'ownerA');
+
+      expect(result).to.be.false;
+    });
+  });
+
+  describe('lock and release scenarios', function () {
+    it('should allow locking again after release', async function () {
+      await redisMutex.lock('someResourceId', 'ownerA');
+
+      await redisMutex.release('someResourceId', 'ownerA');
+
+      const isLockSuccess = await redisMutex.lock('someResourceId', 'ownerB');
+
+      expect(isLockSuccess).to.be.true;
+    });
+
+    it('should not release lock if ownership changed after expiration', async function () {
+      await redisMutex.lock('someResourceId', 'ownerA', 100);
+      await wait(120);
+      await redisMutex.lock('someResourceId', 'ownerB');
+
+      const result = await redisMutex.release('someResourceId', 'ownerA');
+
+      expect(result).to.be.false;
     });
   });
 });

--- a/api/tests/shared/integration/infrastructure/mutex/RedisMutex_test.js
+++ b/api/tests/shared/integration/infrastructure/mutex/RedisMutex_test.js
@@ -1,6 +1,5 @@
-import { config } from '../../../../../src/shared/config.js';
 import { redisMutex } from '../../../../../src/shared/infrastructure/mutex/RedisMutex.js';
-import { expect, sinon, wait } from '../../../../test-helper.js';
+import { expect, wait } from '../../../../test-helper.js';
 
 describe('Shared | Integration | Infrastructure | Mutex | RedisMutex', function () {
   describe('#lock', function () {
@@ -15,15 +14,15 @@ describe('Shared | Integration | Infrastructure | Mutex | RedisMutex', function 
     });
 
     it('should release automatically after expiration delay', async function () {
-      sinon.stub(config.llm, 'lockChatExpirationDelayMilliseconds').value(250);
-      await redisMutex.lock('someResourceId');
+      const lockExpirationDelay = 250;
+      await redisMutex.lock('someResourceId', lockExpirationDelay);
 
       // when
-      const isLockSuccess_beforeDelay1 = await redisMutex.lock('someResourceId');
+      const isLockSuccess_beforeDelay1 = await redisMutex.lock('someResourceId', lockExpirationDelay);
       await wait(100);
-      const isLockSuccess_beforeDelay2 = await redisMutex.lock('someResourceId');
+      const isLockSuccess_beforeDelay2 = await redisMutex.lock('someResourceId', lockExpirationDelay);
       await wait(151);
-      const isLockSuccess_afterDelay = await redisMutex.lock('someResourceId');
+      const isLockSuccess_afterDelay = await redisMutex.lock('someResourceId', lockExpirationDelay);
 
       // then
       expect(isLockSuccess_beforeDelay1).to.be.false;

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -457,7 +457,7 @@ function wait(ms) {
 }
 
 function waitForStreamFinalizationToBeDone() {
-  return wait(500);
+  return wait(300);
 }
 // eslint-disable-next-line mocha/no-exports
 export {


### PR DESCRIPTION
## 🥀 Problème

Dans le cadre du développement des fonctionnalités liées au sujet LLM, on avait mis en place un mutex via Redis pour éviter de la race concurrence notamment.
Cet outil pourrait servir pour d'autres endpoints. Il faut le rendre plus générique et un poil plus robuste

## 🏹 Proposition

- Retirer les spécificités LLM du RedisMutex (le timeout notamment)

- Le rendre plus robuste en cas de ralentissement. Exemple de bug avec le code avant la PR :

1. Requête A prend le lock sur la ressource d'id 123
2. Requête A pédale dans la semoule
3. Le timeout du lock est atteint, le mutex est relâché
4. Requête B prend le lock sur la ressource d'id 123
5. Requête A se réveille et fini sa tâche, puis le relâche (alors que ce n'était plus lui l'initiateur du lock)

La solution est de lock une ressource en apposant un `ownerId` au lock, de sorte à ce que les deux seuls moyens pour que le lock soit relâché sont :
- Le owner relâche
- Le lock timeout

## 💌 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## ❤️‍🔥 Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
