### PR TITLE
[TECH] Crée une Quest lors de la création d'un CombinedCourseBlueprint (PIX-21837).

### DIFF
--- a/api/db/database-builder/factory/build-combined-course-blueprint.js
+++ b/api/db/database-builder/factory/build-combined-course-blueprint.js
@@ -1,4 +1,9 @@
+import _ from 'lodash';
+
+import { CombinedCourseBlueprint } from '../../../src/quest/domain/models/CombinedCourseBlueprint.js';
 import { databaseBuffer } from '../database-buffer.js';
+import { buildQuest } from './build-quest.js';
+import { buildTargetProfile } from './build-target-profile.js';
 
 const buildCombinedCourseBlueprint = function ({
   id = databaseBuffer.getNextId(),
@@ -9,7 +14,17 @@ const buildCombinedCourseBlueprint = function ({
   createdAt = new Date(),
   updatedAt,
   content = [],
+  questId,
 } = {}) {
+  const targetProfileId = buildTargetProfile().id;
+  questId = _.isUndefined(questId)
+    ? buildQuest({
+        rewardType: null,
+        rewardId: null,
+        successRequirements: [CombinedCourseBlueprint.buildRequirementForCombinedCourse({ targetProfileId }).toDTO()],
+      }).id
+    : questId;
+
   const values = {
     id,
     name,
@@ -19,6 +34,7 @@ const buildCombinedCourseBlueprint = function ({
     createdAt,
     updatedAt: updatedAt ?? createdAt,
     content: JSON.stringify(content),
+    questId,
   };
 
   return databaseBuffer.pushInsertable({

--- a/api/src/quest/domain/models/CombinedCourseBlueprint.js
+++ b/api/src/quest/domain/models/CombinedCourseBlueprint.js
@@ -16,6 +16,7 @@ export class CombinedCourseBlueprint {
     createdAt,
     updatedAt,
     organizationIds = [],
+    quest = null,
   }) {
     this.id = id;
     this.name = name;
@@ -26,6 +27,7 @@ export class CombinedCourseBlueprint {
     this.createdAt = createdAt;
     this.updatedAt = updatedAt;
     this.organizationIds = organizationIds;
+    this.quest = quest;
   }
 
   get targetProfileIds() {
@@ -82,13 +84,57 @@ export class CombinedCourseBlueprint {
     );
   }
 
-  static buildRequirementForCombinedCourse({ campaignId, moduleId }) {
+  static buildWithQuest({ combinedCourseBlueprint, modulesByShortId }) {
+    const successRequirements = combinedCourseBlueprint.content.map((requirement) => {
+      if (requirement.type === COMBINED_COURSE_BLUEPRINT_ITEMS.EVALUATION) {
+        const requirementTargetProfileId = requirement.value;
+        return CombinedCourseBlueprint.buildRequirementForCombinedCourse({
+          targetProfileId: requirementTargetProfileId,
+        });
+      } else if (requirement.type === COMBINED_COURSE_BLUEPRINT_ITEMS.MODULE) {
+        const [module] = modulesByShortId[requirement.value];
+        return CombinedCourseBlueprint.buildRequirementForCombinedCourse({
+          moduleId: module.id,
+        });
+      } else {
+        return requirement;
+      }
+    });
+
+    const quest = new Quest({
+      createdAt: combinedCourseBlueprint.createdAt,
+      updatedAt: combinedCourseBlueprint.createdAt,
+      rewardType: null,
+      rewardId: null,
+      eligibilityRequirements: [],
+      successRequirements,
+    });
+
+    return new CombinedCourseBlueprint({
+      ...combinedCourseBlueprint,
+      quest,
+    });
+  }
+
+  static buildRequirementForCombinedCourse({ campaignId, moduleId, targetProfileId }) {
     if (campaignId) {
       return buildRequirement({
         requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
         comparison: REQUIREMENT_COMPARISONS.ALL,
         data: {
           campaignId: { data: campaignId, comparison: CRITERION_COMPARISONS.EQUAL },
+          status: {
+            data: CampaignParticipationStatuses.SHARED,
+            comparison: CRITERION_COMPARISONS.EQUAL,
+          },
+        },
+      });
+    } else if (targetProfileId) {
+      return buildRequirement({
+        requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
+        comparison: REQUIREMENT_COMPARISONS.ALL,
+        data: {
+          targetProfileId: { data: targetProfileId, comparison: CRITERION_COMPARISONS.EQUAL },
           status: {
             data: CampaignParticipationStatuses.SHARED,
             comparison: CRITERION_COMPARISONS.EQUAL,
@@ -114,9 +160,11 @@ export class CombinedCourseBlueprint {
     });
     return Joi.attempt(data, contentSchema);
   }
+
   detachOrganization({ organizationId }) {
     this.organizationIds = this.organizationIds.filter((id) => id !== organizationId);
   }
+
   attachOrganizations({ organizationIds }) {
     const duplicatedOrganizationIds = [];
     const attachedOrganizationIds = [];

--- a/api/src/quest/domain/usecases/create-combined-course-blueprint.js
+++ b/api/src/quest/domain/usecases/create-combined-course-blueprint.js
@@ -4,10 +4,17 @@ export const createCombinedCourseBlueprint = async ({
   combinedCourseBlueprint,
   combinedCourseBlueprintRepository,
   targetProfileRepository,
+  moduleRepository,
 }) => {
   const targetProfileIds = combinedCourseBlueprint.content
     .filter((item) => item.type === COMBINED_COURSE_BLUEPRINT_ITEMS.EVALUATION)
     .map(({ value }) => value);
   await targetProfileRepository.findByIds({ ids: targetProfileIds });
+
+  const moduleShortIds = combinedCourseBlueprint.content
+    .filter((item) => item.type === COMBINED_COURSE_BLUEPRINT_ITEMS.MODULE)
+    .map(({ value }) => value);
+  await moduleRepository.getByShortIds({ moduleShortIds });
+
   return combinedCourseBlueprintRepository.save({ combinedCourseBlueprint });
 };

--- a/api/src/quest/domain/usecases/create-combined-course-blueprint.js
+++ b/api/src/quest/domain/usecases/create-combined-course-blueprint.js
@@ -1,4 +1,6 @@
-import { COMBINED_COURSE_BLUEPRINT_ITEMS } from '../models/CombinedCourseBlueprint.js';
+import _ from 'lodash';
+
+import { COMBINED_COURSE_BLUEPRINT_ITEMS, CombinedCourseBlueprint } from '../models/CombinedCourseBlueprint.js';
 
 export const createCombinedCourseBlueprint = async ({
   combinedCourseBlueprint,
@@ -14,7 +16,10 @@ export const createCombinedCourseBlueprint = async ({
   const moduleShortIds = combinedCourseBlueprint.content
     .filter((item) => item.type === COMBINED_COURSE_BLUEPRINT_ITEMS.MODULE)
     .map(({ value }) => value);
-  await moduleRepository.getByShortIds({ moduleShortIds });
+  const modules = await moduleRepository.getByShortIds({ moduleShortIds });
+  const modulesByShortId = _.groupBy(modules, 'shortId');
 
-  return combinedCourseBlueprintRepository.save({ combinedCourseBlueprint });
+  return combinedCourseBlueprintRepository.save({
+    combinedCourseBlueprint: CombinedCourseBlueprint.buildWithQuest({ combinedCourseBlueprint, modulesByShortId }),
+  });
 };

--- a/api/src/quest/infrastructure/repositories/combined-course-blueprint-repository.js
+++ b/api/src/quest/infrastructure/repositories/combined-course-blueprint-repository.js
@@ -3,6 +3,7 @@ import difference from 'lodash/difference.js';
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../shared/domain/errors.js';
 import { CombinedCourseBlueprint } from '../../domain/models/CombinedCourseBlueprint.js';
+import * as questRepository from './quest-repository.js';
 
 /**
  * @returns {Promise<import('../../domain/models/CombinedCourseBlueprint.js').CombinedCourseBlueprint[]>}
@@ -12,18 +13,28 @@ export async function findAll() {
   const knexConn = DomainTransaction.getConnection();
 
   const results = await knexConn('combined_course_blueprints');
-  return results.map(_toDomain);
+
+  const blueprints = [];
+  for (const result of results) {
+    const quest = await questRepository.findById({ questId: result.questId });
+    blueprints.push(_toDomain(result, quest));
+  }
+  return blueprints;
 }
 
 export async function save({ combinedCourseBlueprint }) {
   const knexConn = DomainTransaction.getConnection();
 
+  const questId = await questRepository.save({ quest: combinedCourseBlueprint.quest });
+
   if (!combinedCourseBlueprint.id) {
     const [insertedValues] = await knexConn('combined_course_blueprints')
-      .insert(_toDTO({ combinedCourseBlueprint }))
+      .insert(_toDTO({ combinedCourseBlueprint, questId }))
       .returning('*');
 
-    return _toDomain(insertedValues);
+    const quest = await questRepository.findById({ questId });
+
+    return _toDomain(insertedValues, quest);
   }
 
   const [updatedValues] = await knexConn('combined_course_blueprints')
@@ -84,7 +95,8 @@ export async function findById({ id }) {
   if (!result) {
     return null;
   }
-  return _toDomain(result);
+  const quest = await questRepository.findById({ questId: result.questId });
+  return _toDomain(result, quest);
 }
 
 export async function findByOrganizationId({ organizationId }) {
@@ -98,10 +110,10 @@ export async function findByOrganizationId({ organizationId }) {
     )
     .where({ organizationId })
     .groupBy('combined_course_blueprints.id');
-  return results.map(_toDomain);
+  return results.map((result) => _toDomain(result));
 }
 
-function _toDTO({ combinedCourseBlueprint }) {
+function _toDTO({ combinedCourseBlueprint, questId }) {
   return {
     id: combinedCourseBlueprint.id,
     name: combinedCourseBlueprint.name,
@@ -111,10 +123,11 @@ function _toDTO({ combinedCourseBlueprint }) {
     content: JSON.stringify(combinedCourseBlueprint.content),
     createdAt: combinedCourseBlueprint.createdAt,
     updatedAt: combinedCourseBlueprint.updatedAt,
+    questId,
   };
 }
 
-function _toDomain(rawData) {
+function _toDomain(rawData, quest) {
   return new CombinedCourseBlueprint({
     id: rawData.id,
     name: rawData.name,
@@ -125,6 +138,7 @@ function _toDomain(rawData) {
     createdAt: rawData.createdAt,
     updatedAt: rawData.updatedAt,
     organizationIds: rawData.organizationIds,
+    quest,
   });
 }
 
@@ -139,5 +153,6 @@ function _buildSelectFields(knexConn) {
     createdAt: 'combined_course_blueprints.createdAt',
     updatedAt: 'combined_course_blueprints.updatedAt',
     organizationIds: knexConn.raw(`array_remove(array_agg("combined_course_blueprint_shares"."organizationId"), NULL)`),
+    questId: 'combined_course_blueprints.questId',
   };
 }

--- a/api/src/quest/infrastructure/serializers/combined-course-blueprint-serializer.js
+++ b/api/src/quest/infrastructure/serializers/combined-course-blueprint-serializer.js
@@ -1,5 +1,7 @@
 import jsonapiSerializer from 'jsonapi-serializer';
 
+import { CombinedCourseBlueprint } from '../../domain/models/CombinedCourseBlueprint.js';
+
 const { Deserializer, Serializer } = jsonapiSerializer;
 
 const serialize = function (combinedCourseBlueprint) {
@@ -8,10 +10,11 @@ const serialize = function (combinedCourseBlueprint) {
   }).serialize(combinedCourseBlueprint);
 };
 
-const deserialize = function (payload) {
-  return new Deserializer({
+const deserialize = async function (payload) {
+  const deserializedData = await new Deserializer({
     keyForAttribute: 'camelCase',
   }).deserialize(payload);
+  return new CombinedCourseBlueprint(deserializedData);
 };
 
 export { deserialize, serialize };

--- a/api/tests/quest/acceptance/application/combined-course-blueprint-route_test.js
+++ b/api/tests/quest/acceptance/application/combined-course-blueprint-route_test.js
@@ -57,7 +57,7 @@ describe('Quest | Acceptance | Application | Combined course blueprint Route ', 
               'internal-name': 'Mon schéma de parcours combiné',
               description: 'La description combinix',
               illustration: 'illustration.svg',
-              content: CombinedCourseBlueprint.buildContentItems([{ moduleShortId: 'modulox' }]),
+              content: CombinedCourseBlueprint.buildContentItems([{ moduleShortId: 'e67ec5d0' }]),
             },
           },
         };

--- a/api/tests/quest/integration/domain/usecases/create-combined-course-blueprint_test.js
+++ b/api/tests/quest/integration/domain/usecases/create-combined-course-blueprint_test.js
@@ -1,10 +1,16 @@
+import { CampaignParticipationStatuses } from '../../../../../src/prescription/shared/domain/constants.js';
 import { CombinedCourseBlueprint } from '../../../../../src/quest/domain/models/CombinedCourseBlueprint.js';
+import {
+  CRITERION_COMPARISONS,
+  REQUIREMENT_COMPARISONS,
+  REQUIREMENT_TYPES,
+} from '../../../../../src/quest/domain/models/Quest.js';
 import { usecases } from '../../../../../src/quest/domain/usecases/index.js';
 import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
 import { catchErr, databaseBuilder, expect, knex } from '../../../../test-helper.js';
 
 describe('Integration | Combined course | Domain | UseCases | create-combined-course-blueprint', function () {
-  it('should create a combined course blueprint', async function () {
+  it('should create a combined course blueprint with quest', async function () {
     // given
     const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
     await databaseBuilder.commit();
@@ -19,15 +25,49 @@ describe('Integration | Combined course | Domain | UseCases | create-combined-co
 
     await usecases.createCombinedCourseBlueprint({ combinedCourseBlueprint });
 
-    const result = await knex('combined_course_blueprints');
-    expect(result).lengthOf(1);
-    expect(result[0].name).to.equal(combinedCourseBlueprint.name);
-    expect(result[0].internalName).to.equal(combinedCourseBlueprint.internalName);
-    expect(result[0].illustration).to.equal(combinedCourseBlueprint.illustration);
-    expect(result[0].description).to.equal(combinedCourseBlueprint.description);
-    expect(result[0].content).to.deep.equal(combinedCourseBlueprint.content);
-    expect(result[0].updatedAt).to.be.instanceOf(Date);
-    expect(result[0].createdAt).to.be.instanceOf(Date);
+    const combinedCourseBlueprints = await knex('combined_course_blueprints');
+    expect(combinedCourseBlueprints).lengthOf(1);
+    expect(combinedCourseBlueprints[0].name).to.equal(combinedCourseBlueprint.name);
+    expect(combinedCourseBlueprints[0].internalName).to.equal(combinedCourseBlueprint.internalName);
+    expect(combinedCourseBlueprints[0].illustration).to.equal(combinedCourseBlueprint.illustration);
+    expect(combinedCourseBlueprints[0].description).to.equal(combinedCourseBlueprint.description);
+    expect(combinedCourseBlueprints[0].content).to.deep.equal(combinedCourseBlueprint.content);
+    expect(combinedCourseBlueprints[0].updatedAt).to.be.instanceOf(Date);
+    expect(combinedCourseBlueprints[0].createdAt).to.be.instanceOf(Date);
+
+    const quests = await knex('quests');
+    expect(quests).lengthOf(1);
+    expect(
+      quests[0].successRequirements.map((successRequirement) => {
+        return { ...successRequirement, data: successRequirement.data };
+      }),
+    ).deep.equal([
+      {
+        comparison: REQUIREMENT_COMPARISONS.ALL,
+        requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
+        data: {
+          isTerminated: { comparison: CRITERION_COMPARISONS.EQUAL, data: true },
+          moduleId: {
+            comparison: CRITERION_COMPARISONS.EQUAL,
+            data: '6282925d-4775-4bca-b513-4c3009ec5886',
+          },
+        },
+      },
+      {
+        comparison: REQUIREMENT_COMPARISONS.ALL,
+        data: {
+          status: {
+            comparison: CRITERION_COMPARISONS.EQUAL,
+            data: CampaignParticipationStatuses.SHARED,
+          },
+          targetProfileId: {
+            comparison: CRITERION_COMPARISONS.EQUAL,
+            data: targetProfileId,
+          },
+        },
+        requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
+      },
+    ]);
   });
 
   it('should return error if a targetProfileId in content is not found', async function () {

--- a/api/tests/quest/integration/domain/usecases/create-combined-course-blueprint_test.js
+++ b/api/tests/quest/integration/domain/usecases/create-combined-course-blueprint_test.js
@@ -9,13 +9,13 @@ describe('Integration | Combined course | Domain | UseCases | create-combined-co
     const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
     await databaseBuilder.commit();
 
-    const combinedCourseBlueprint = {
+    const combinedCourseBlueprint = new CombinedCourseBlueprint({
       name: 'Mon épure',
       internalName: 'Une épure pour tel niveau',
       illustration: 'illustrations/mon-epure.png',
       description: 'Description',
-      content: CombinedCourseBlueprint.buildContentItems([{ moduleShortId: 'abc-123' }, { targetProfileId }]),
-    };
+      content: CombinedCourseBlueprint.buildContentItems([{ moduleShortId: '6a68bf32' }, { targetProfileId }]),
+    });
 
     await usecases.createCombinedCourseBlueprint({ combinedCourseBlueprint });
 
@@ -29,15 +29,33 @@ describe('Integration | Combined course | Domain | UseCases | create-combined-co
     expect(result[0].updatedAt).to.be.instanceOf(Date);
     expect(result[0].createdAt).to.be.instanceOf(Date);
   });
+
   it('should return error if a targetProfileId in content is not found', async function () {
     // given
-    const combinedCourseBlueprint = {
+    const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+    await databaseBuilder.commit();
+
+    const combinedCourseBlueprint = new CombinedCourseBlueprint({
       name: 'Mon épure',
       internalName: 'Une épure pour tel niveau',
       illustration: 'illustrations/mon-epure.png',
       description: 'Description',
-      content: CombinedCourseBlueprint.buildContentItems([{ moduleShortId: 'abc-123' }, { targetProfileId: 123 }]),
-    };
+      content: CombinedCourseBlueprint.buildContentItems([{ targetProfileId }, { targetProfileId: 123 }]),
+    });
+
+    const error = await catchErr(usecases.createCombinedCourseBlueprint)({ combinedCourseBlueprint });
+    expect(error).to.be.instanceOf(NotFoundError);
+  });
+
+  it('should return error if one of the modules in content is not found', async function () {
+    // given
+    const combinedCourseBlueprint = new CombinedCourseBlueprint({
+      name: 'Mon épure',
+      internalName: 'Une épure pour tel niveau',
+      illustration: 'illustrations/mon-epure.png',
+      description: 'Description',
+      content: CombinedCourseBlueprint.buildContentItems([{ moduleShortId: '6a68bf32' }, { moduleShortId: 'abc-123' }]),
+    });
 
     const error = await catchErr(usecases.createCombinedCourseBlueprint)({ combinedCourseBlueprint });
     expect(error).to.be.instanceOf(NotFoundError);

--- a/api/tests/quest/integration/domain/usecases/get-combined-course-blueprint-by-id_test.js
+++ b/api/tests/quest/integration/domain/usecases/get-combined-course-blueprint-by-id_test.js
@@ -37,7 +37,7 @@ describe('Integration | Quest | Domain | UseCases | get-combined-course-blueprin
 
     //then
     expect(result).to.be.instanceOf(CombinedCourseBlueprint);
-    expect(result).deep.equal({
+    expect(result).deep.contain({
       id: 1,
       name: 'Mon parcours combiné',
       internalName: 'Mon schéma de parcours combiné',

--- a/api/tests/quest/integration/infrastructure/repositories/combined-course-blueprint-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/combined-course-blueprint-repository_test.js
@@ -1,20 +1,31 @@
+import { CampaignParticipationStatuses } from '../../../../../src/prescription/shared/domain/constants.js';
 import { CombinedCourseBlueprint } from '../../../../../src/quest/domain/models/CombinedCourseBlueprint.js';
+import {
+  CRITERION_COMPARISONS,
+  Quest,
+  REQUIREMENT_COMPARISONS,
+  REQUIREMENT_TYPES,
+} from '../../../../../src/quest/domain/models/Quest.js';
 import * as combinedCourseBluePrintRepository from '../../../../../src/quest/infrastructure/repositories/combined-course-blueprint-repository.js';
 import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
 import { catchErr, databaseBuilder, domainBuilder, expect } from '../../../../test-helper.js';
 
 describe('Quest | Integration | Repository | combined-course-blueprint', function () {
   describe('#save', function () {
-    it('should create a combined course blueprint', async function () {
+    it('should create a combined course blueprint with its quest', async function () {
       // given
-      const combinedCourseBlueprint = {
-        name: 'Combined course IA',
-        internalName: 'Ia combined course blueprint',
-        description: "L'ia c'est magique",
-        illustration: 'illustration/ia.svg',
-        content: CombinedCourseBlueprint.buildContentItems([{ moduleShortId: 'modulix' }]),
-        organizationIds: [],
-      };
+      const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+      const combinedCourseBlueprint = CombinedCourseBlueprint.buildWithQuest({
+        combinedCourseBlueprint: new CombinedCourseBlueprint({
+          name: 'Combined course IA',
+          internalName: 'Ia combined course blueprint',
+          description: "L'ia c'est magique",
+          illustration: 'illustration/ia.svg',
+          content: CombinedCourseBlueprint.buildContentItems([{ targetProfileId }, { moduleShortId: '6a68bf32' }]),
+          organizationIds: [],
+        }),
+        modulesByShortId: { '6a68bf32': [{ id: '6282925d-4775-4bca-b513-4c3009ec5886' }] },
+      });
 
       // when
       const savedCombinedCourseBlueprint = await combinedCourseBluePrintRepository.save({ combinedCourseBlueprint });
@@ -23,8 +34,38 @@ describe('Quest | Integration | Repository | combined-course-blueprint', functio
       const results = await combinedCourseBluePrintRepository.findAll();
       expect(results).lengthOf(1);
       expect(results[0]).deep.equal(savedCombinedCourseBlueprint);
-
-      expect(savedCombinedCourseBlueprint).deep.contain(combinedCourseBlueprint);
+      expect(results[0]).deep.contain({ ...combinedCourseBlueprint.combinedCourseBlueprint });
+      expect(
+        results[0].quest.successRequirements.map((successRequirement) => {
+          return { ...successRequirement, data: successRequirement.data };
+        }),
+      ).deep.equal([
+        {
+          comparison: REQUIREMENT_COMPARISONS.ALL,
+          data: {
+            status: {
+              comparison: CRITERION_COMPARISONS.EQUAL,
+              data: CampaignParticipationStatuses.SHARED,
+            },
+            targetProfileId: {
+              comparison: CRITERION_COMPARISONS.EQUAL,
+              data: targetProfileId,
+            },
+          },
+          requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
+        },
+        {
+          comparison: REQUIREMENT_COMPARISONS.ALL,
+          requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
+          data: {
+            isTerminated: { comparison: CRITERION_COMPARISONS.EQUAL, data: true },
+            moduleId: {
+              comparison: CRITERION_COMPARISONS.EQUAL,
+              data: '6282925d-4775-4bca-b513-4c3009ec5886',
+            },
+          },
+        },
+      ]);
     });
 
     it('should delete combined course blueprint share for a given organizationId', async function () {
@@ -97,27 +138,135 @@ describe('Quest | Integration | Repository | combined-course-blueprint', functio
       // then
       expect(error).instanceOf(NotFoundError);
     });
+
+    it('should update a combined course blueprint and its quest', async function () {
+      // given
+      const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+      const quest = databaseBuilder.factory.buildQuest({
+        rewardType: null,
+        rewardId: null,
+        successRequirements: [
+          CombinedCourseBlueprint.buildRequirementForCombinedCourse({ targetProfileId }).toDTO(),
+          CombinedCourseBlueprint.buildRequirementForCombinedCourse({
+            moduleId: '6282925d-4775-4bca-b513-4c3009ec5886',
+          }).toDTO(),
+        ],
+      });
+      const combinedCourseBlueprintInDb = databaseBuilder.factory.buildCombinedCourseBlueprint({
+        questId: quest.id,
+        content: CombinedCourseBlueprint.buildContentItems([{ targetProfileId }, { moduleShortId: '6a68bf32' }]),
+      });
+      await databaseBuilder.commit();
+
+      const combinedCourseBlueprintWithoutTargetProfile = new CombinedCourseBlueprint({
+        id: combinedCourseBlueprintInDb.id,
+        name: 'Updated Combined course IA',
+        internalName: 'Ia combined course blueprint',
+        description: "L'ia c'est magique",
+        illustration: 'illustration/ia.svg',
+        content: CombinedCourseBlueprint.buildContentItems([{ moduleShortId: '6a68bf32' }]),
+        organizationIds: [],
+        quest: new Quest({
+          ...quest,
+          successRequirements: [
+            {
+              comparison: REQUIREMENT_COMPARISONS.ALL,
+              requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
+              data: {
+                isTerminated: { comparison: CRITERION_COMPARISONS.EQUAL, data: true },
+                moduleId: {
+                  comparison: CRITERION_COMPARISONS.EQUAL,
+                  data: '6282925d-4775-4bca-b513-4c3009ec5886',
+                },
+              },
+            },
+          ],
+        }),
+      });
+
+      // when
+      await combinedCourseBluePrintRepository.save({
+        combinedCourseBlueprint: combinedCourseBlueprintWithoutTargetProfile,
+      });
+
+      // then
+      const results = await combinedCourseBluePrintRepository.findAll();
+      expect(results).lengthOf(1);
+      expect(results[0].name).equal('Updated Combined course IA');
+      expect(
+        results[0].quest.successRequirements.map((successRequirement) => {
+          return { ...successRequirement, data: successRequirement.data };
+        }),
+      ).deep.equal([
+        {
+          comparison: REQUIREMENT_COMPARISONS.ALL,
+          requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
+          data: {
+            isTerminated: { comparison: CRITERION_COMPARISONS.EQUAL, data: true },
+            moduleId: {
+              comparison: CRITERION_COMPARISONS.EQUAL,
+              data: '6282925d-4775-4bca-b513-4c3009ec5886',
+            },
+          },
+        },
+      ]);
+
+      // TODO integration test for usecase (create combined course bp)
+    });
   });
 
   describe('#findAll', function () {
-    it('should return all combined course blueprints', async function () {
-      const expectedCombinedCourseBlueprint = domainBuilder.buildCombinedCourseBlueprint();
-      databaseBuilder.factory.buildCombinedCourseBlueprint(expectedCombinedCourseBlueprint);
+    it('should return all combined course blueprints with quests', async function () {
+      // given
+      const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+
+      const questId = databaseBuilder.factory.buildQuest({
+        rewardType: null,
+        rewardId: null,
+        successRequirements: [
+          CombinedCourseBlueprint.buildRequirementForCombinedCourse({ targetProfileId }).toDTO(),
+          CombinedCourseBlueprint.buildRequirementForCombinedCourse({
+            moduleId: '6282925d-4775-4bca-b513-4c3009ec5886',
+          }).toDTO(),
+        ],
+      }).id;
+
+      const expectedCombinedCourseBlueprint = databaseBuilder.factory.buildCombinedCourseBlueprint({
+        questId,
+        content: CombinedCourseBlueprint.buildContentItems([{ targetProfileId }, { moduleShortId: '6a68bf32' }]),
+      });
+      databaseBuilder.factory.buildCombinedCourseBlueprint();
       await databaseBuilder.commit();
 
+      // when
       const results = await combinedCourseBluePrintRepository.findAll();
-      expect(results).lengthOf(1);
+
+      // then
+      expect(results).lengthOf(2);
       expect(results[0]).to.be.instanceOf(CombinedCourseBlueprint);
-      expect(results[0]).to.deep.equal(expectedCombinedCourseBlueprint);
+      expect(results[0]).to.deep.contain({
+        id: expectedCombinedCourseBlueprint.id,
+        name: expectedCombinedCourseBlueprint.name,
+        internalName: expectedCombinedCourseBlueprint.internalName,
+        description: expectedCombinedCourseBlueprint.description,
+        illustration: expectedCombinedCourseBlueprint.illustration,
+        createdAt: expectedCombinedCourseBlueprint.createdAt,
+        updatedAt: expectedCombinedCourseBlueprint.updatedAt,
+      });
+      expect(JSON.stringify(results[0].content)).to.deep.equal(expectedCombinedCourseBlueprint.content);
+      expect(results[0].quest.id).to.equal(questId);
     });
+
     it('should return an empty array when no results are found', async function () {
       const result = await combinedCourseBluePrintRepository.findAll();
       expect(result).lengthOf(0);
     });
   });
+
   describe('#findById', function () {
     it('should return combined course blueprint by its id with shared organization ids', async function () {
-      const combinedCourseBlueprint = databaseBuilder.factory.buildCombinedCourseBlueprint();
+      const quest = databaseBuilder.factory.buildQuest();
+      const combinedCourseBlueprint = databaseBuilder.factory.buildCombinedCourseBlueprint({ questId: quest.id });
       const combinedCourseBlueprintShare = databaseBuilder.factory.buildCombinedCourseBlueprintShare({
         combinedCourseBlueprintId: combinedCourseBlueprint.id,
       });
@@ -132,11 +281,23 @@ describe('Quest | Integration | Repository | combined-course-blueprint', functio
       const result = await combinedCourseBluePrintRepository.findById({ id: expectedCombinedCourseBlueprint.id });
       expect(result.organizationIds).to.deep.equal([combinedCourseBlueprintShare.organizationId]);
       expect(result).to.be.instanceOf(CombinedCourseBlueprint);
-      expect(result).to.deep.equal(expectedCombinedCourseBlueprint);
+      expect(result).to.deep.contain({
+        id: expectedCombinedCourseBlueprint.id,
+        name: expectedCombinedCourseBlueprint.name,
+        internalName: expectedCombinedCourseBlueprint.internalName,
+        description: expectedCombinedCourseBlueprint.description,
+        illustration: expectedCombinedCourseBlueprint.illustration,
+        createdAt: expectedCombinedCourseBlueprint.createdAt,
+        updatedAt: expectedCombinedCourseBlueprint.updatedAt,
+        content: expectedCombinedCourseBlueprint.content,
+        organizationIds: expectedCombinedCourseBlueprint.organizationIds,
+      });
+      expect(result.quest.toDTO()).to.deep.equal(quest);
     });
 
     it('should return combined course blueprint by its id when it is not shared', async function () {
-      const combinedCourseBlueprint = databaseBuilder.factory.buildCombinedCourseBlueprint();
+      const quest = databaseBuilder.factory.buildQuest();
+      const combinedCourseBlueprint = databaseBuilder.factory.buildCombinedCourseBlueprint({ questId: quest.id });
       await databaseBuilder.commit();
 
       const expectedCombinedCourseBlueprint = domainBuilder.buildCombinedCourseBlueprint({
@@ -147,7 +308,18 @@ describe('Quest | Integration | Repository | combined-course-blueprint', functio
       const result = await combinedCourseBluePrintRepository.findById({ id: expectedCombinedCourseBlueprint.id });
       expect(result.organizationIds).to.deep.equal([]);
       expect(result).to.be.instanceOf(CombinedCourseBlueprint);
-      expect(result).to.deep.equal(expectedCombinedCourseBlueprint);
+      expect(result).to.deep.contain({
+        id: expectedCombinedCourseBlueprint.id,
+        name: expectedCombinedCourseBlueprint.name,
+        internalName: expectedCombinedCourseBlueprint.internalName,
+        description: expectedCombinedCourseBlueprint.description,
+        illustration: expectedCombinedCourseBlueprint.illustration,
+        createdAt: expectedCombinedCourseBlueprint.createdAt,
+        updatedAt: expectedCombinedCourseBlueprint.updatedAt,
+        content: expectedCombinedCourseBlueprint.content,
+        organizationIds: [],
+      });
+      expect(result.quest.toDTO()).to.deep.equal(quest);
     });
 
     it('should return null when no results are found', async function () {
@@ -155,6 +327,7 @@ describe('Quest | Integration | Repository | combined-course-blueprint', functio
       expect(result).null;
     });
   });
+
   describe('#findByOrganizationId', function () {
     it('should return blueprint if the given organization has at least one combined course blueprint share', async function () {
       //given
@@ -182,9 +355,10 @@ describe('Quest | Integration | Repository | combined-course-blueprint', functio
 
       //then
       expect(result.length).to.equal(2);
-      expect(result[0]).to.deep.equal(expectedCombinedCourseBlueprint);
-      expect(result[1]).to.deep.equal(expectedCombinedCourseBlueprint2);
+      expect(result[0]).to.deep.equal({ ...expectedCombinedCourseBlueprint, quest: null });
+      expect(result[1]).to.deep.equal({ ...expectedCombinedCourseBlueprint2, quest: null });
     });
+
     it('should return an empty array when the organization is not found', async function () {
       const result = await combinedCourseBluePrintRepository.findByOrganizationId({ organizationId: 123 });
 

--- a/api/tests/quest/unit/domain/models/CombinedCourseBlueprint_test.js
+++ b/api/tests/quest/unit/domain/models/CombinedCourseBlueprint_test.js
@@ -26,6 +26,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourseBlueprint ', function (
         createdAt: new Date('2024-01-25'),
         updatedAt: new Date('2024-01-26'),
         organizationIds: [],
+        quest: null,
       };
       // when
       const blueprint = new CombinedCourseBlueprint(values);
@@ -236,6 +237,79 @@ describe('Quest | Unit | Domain | Models | CombinedCourseBlueprint ', function (
       expect(combinedCourse.illustration).to.equal(illustration);
       expect(combinedCourse.code).to.equal(code);
       expect(combinedCourse.organizationId).to.equal(organizationId);
+    });
+  });
+
+  describe('#buildWithQuest', function () {
+    it('should return combined course blueprint with quest', async function () {
+      // given
+      const targetProfileId = 1;
+      const modulesByShortId = {
+        ecc13f55: [new Module({ id: 'eeeb4951-6f38-4467-a4ba-0c85ed71321a' })],
+      };
+      const combinedCourseContent = [
+        {
+          type: COMBINED_COURSE_BLUEPRINT_ITEMS.EVALUATION,
+          value: targetProfileId,
+        },
+        {
+          type: COMBINED_COURSE_BLUEPRINT_ITEMS.MODULE,
+          value: 'ecc13f55',
+        },
+      ];
+      const name = 'Combinix';
+      const description = 'bla bla bla';
+      const illustration = 'illu.svg';
+
+      // when
+      const combinedCourseBlueprint = CombinedCourseBlueprint.buildWithQuest({
+        combinedCourseBlueprint: new CombinedCourseBlueprint({
+          name,
+          content: combinedCourseContent,
+          description,
+          illustration,
+        }),
+        modulesByShortId,
+      });
+
+      // then
+      const quest = new Quest({
+        eligibilityRequirements: [],
+        successRequirements: [
+          {
+            requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
+            comparison: REQUIREMENT_COMPARISONS.ALL,
+            data: {
+              targetProfileId: {
+                data: targetProfileId,
+                comparison: CRITERION_COMPARISONS.EQUAL,
+              },
+              status: {
+                data: 'SHARED',
+                comparison: CRITERION_COMPARISONS.EQUAL,
+              },
+            },
+          },
+          {
+            requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
+            comparison: REQUIREMENT_COMPARISONS.ALL,
+            data: {
+              moduleId: {
+                data: 'eeeb4951-6f38-4467-a4ba-0c85ed71321a',
+                comparison: CRITERION_COMPARISONS.EQUAL,
+              },
+              isTerminated: {
+                data: true,
+                comparison: CRITERION_COMPARISONS.EQUAL,
+              },
+            },
+          },
+        ],
+      });
+      const questDTO = quest.toDTO();
+
+      expect(combinedCourseBlueprint.quest).to.be.instanceOf(Quest);
+      expect(combinedCourseBlueprint.quest.toDTO().successRequirements).to.deep.equal(questDTO.successRequirements);
     });
   });
 

--- a/api/tests/quest/unit/infrastructure/serializers/combined-course-blueprint-serializer_test.js
+++ b/api/tests/quest/unit/infrastructure/serializers/combined-course-blueprint-serializer_test.js
@@ -2,6 +2,7 @@ import {
   COMBINED_COURSE_BLUEPRINT_ITEMS,
   CombinedCourseBlueprint,
 } from '../../../../../src/quest/domain/models/CombinedCourseBlueprint.js';
+import { Module } from '../../../../../src/quest/domain/models/Module.js';
 import * as combinedCourseBlueprintSerializer from '../../../../../src/quest/infrastructure/serializers/combined-course-blueprint-serializer.js';
 import { domainBuilder, expect } from '../../../../test-helper.js';
 
@@ -10,6 +11,7 @@ describe('Quest | Unit | Infrastructure | Serializers | combined-course-blueprin
     // given
     const combinedCourseBlueprint = domainBuilder.buildCombinedCourseBlueprint({
       content: CombinedCourseBlueprint.buildContentItems([{ moduleShortId: 'mon-module' }, { targetProfileId: 123 }]),
+      modulesByShortId: { 'mon-module': [new Module({ id: '1' })] },
     });
 
     // when
@@ -54,7 +56,7 @@ describe('Quest | Unit | Infrastructure | Serializers | combined-course-blueprin
           'internal-name': 'Mon modèle de parcours',
           illustration: '/illustrations/image.svg',
           description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
-          'success-requirements': [
+          content: [
             {
               type: 'passages',
               value: 'mon-module',
@@ -82,7 +84,7 @@ describe('Quest | Unit | Infrastructure | Serializers | combined-course-blueprin
       internalName: 'Mon modèle de parcours',
       illustration: '/illustrations/image.svg',
       description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
-      successRequirements: [
+      content: [
         {
           type: 'passages',
           value: 'mon-module',
@@ -92,6 +94,8 @@ describe('Quest | Unit | Infrastructure | Serializers | combined-course-blueprin
           value: 123,
         },
       ],
+      quest: null,
+      organizationIds: [],
       createdAt: date,
       updatedAt: date,
     });

--- a/api/tests/tooling/domain-builder/factory/build-combined-course-blueprint.js
+++ b/api/tests/tooling/domain-builder/factory/build-combined-course-blueprint.js
@@ -13,17 +13,21 @@ function buildCombinedCourseBlueprint({
   updatedAt = new Date(),
   content = [{ type: COMBINED_COURSE_BLUEPRINT_ITEMS.MODULE, value: 'module-123' }],
   organizationIds = [],
+  modulesByShortId,
 } = {}) {
-  return new CombinedCourseBlueprint({
-    id,
-    name,
-    internalName,
-    description,
-    illustration,
-    content,
-    createdAt,
-    updatedAt,
-    organizationIds,
+  return CombinedCourseBlueprint.buildWithQuest({
+    combinedCourseBlueprint: {
+      id,
+      name,
+      internalName,
+      description,
+      illustration,
+      content,
+      createdAt,
+      updatedAt,
+      organizationIds,
+    },
+    modulesByShortId,
   });
 }
 


### PR DESCRIPTION
## 🥀 Problème

On ne dispose pas de façon de rattacher une attestation à un blueprint de parcours combiné.
Cela nous empêche de délivrer facilement une attestation à un utilisateur ayant terminé un parcours combiné.

## 🏹 Proposition

On crée et maintent à jour un enregistrement de `quests` lors de la création et la mise à jour d'un enregistrement de `combined_course_blueprints`.

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 💌 Remarques

Cette PR est un pré-requis à l'ajout effectif d'une attestation à un modèle de parcours combiné.

<!-- Des infos supplémentaires, trucs et astuces ? -->

## ❤️‍🔥 Pour tester

Créer un modèle de parcours combiné depuis Pix Admin.
Vérifier dans la base de données que une ligne dans la table `quest` a été ajouté contenant les `successRequirements` propre au parcours combiné.
Vérifier que le modèle de parcours combiné est toujours utilisable pour créer un parcours combiné depuis Pix Admin.
<!--
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc.
- [ ] Documentation de la fonctionnalité (lien)
-->
