### PR TITLE
[FEATURE] Débloquer aussi les comptes élèves lors de la réinitialisation des mots de passe (PIX-21844)

### DIFF
--- a/api/src/prescription/organization-learner/domain/usecases/generate-organization-learners-username-and-temporary-password.js
+++ b/api/src/prescription/organization-learner/domain/usecases/generate-organization-learners-username-and-temporary-password.js
@@ -17,6 +17,7 @@ export const generateOrganizationLearnersUsernameAndTemporaryPassword = async fu
   organizationRepository,
   organizationLearnerIdentityRepository,
   userRepository,
+  userLoginRepository,
 }) {
   const errorMessage = `User ${userId} cannot reset passwords of some students in organization ${organizationId}`;
   const organization = await organizationRepository.get(organizationId);
@@ -42,6 +43,7 @@ export const generateOrganizationLearnersUsernameAndTemporaryPassword = async fu
     authenticationMethodRepository,
     cryptoService,
     passwordGenerator,
+    userLoginRepository,
   });
 
   return _buildOrganizationLearnerPasswordResetDTOs({
@@ -101,6 +103,7 @@ async function _generateAndUpdateUsersWithTemporaryPassword({
   authenticationMethodRepository,
   cryptoService,
   passwordGenerator,
+  userLoginRepository,
 }) {
   _assertAllUsersHasAnUsername({ errorMessage, users: organizationLearnerIdentities });
 
@@ -112,6 +115,8 @@ async function _generateAndUpdateUsersWithTemporaryPassword({
   await authenticationMethodRepository.batchUpsertPasswordThatShouldBeChanged({
     usersToUpdateWithNewPassword: userIdWithPasswords,
   });
+  const userIds = userIdWithPasswords.map((userIdWithPasswords) => userIdWithPasswords.userId);
+  await userLoginRepository.batchUnblock(userIds);
 
   return userIdWithPasswords;
 }

--- a/api/src/shared/infrastructure/repositories/user-login-repository.js
+++ b/api/src/shared/infrastructure/repositories/user-login-repository.js
@@ -4,19 +4,6 @@ import { DomainTransaction } from '../../domain/DomainTransaction.js';
 
 const USER_LOGINS_TABLE_NAME = 'user-logins';
 
-function _toDomain(userLoginDTO) {
-  return new UserLogin({
-    id: userLoginDTO.id,
-    userId: userLoginDTO.userId,
-    failureCount: userLoginDTO.failureCount,
-    temporaryBlockedUntil: userLoginDTO.temporaryBlockedUntil,
-    blockedAt: userLoginDTO.blockedAt,
-    createdAt: userLoginDTO.createdAt,
-    updatedAt: userLoginDTO.updatedAt,
-    lastLoggedAt: userLoginDTO.lastLoggedAt,
-  });
-}
-
 const findByUserId = async function (userId) {
   const knexConn = DomainTransaction.getConnection();
   const userLoginDTO = await knexConn.from(USER_LOGINS_TABLE_NAME).where({ userId }).first();
@@ -79,3 +66,16 @@ const updateLastLoggedAt = async function ({ userId }) {
 };
 
 export { create, findByUserId, findByUsername, getByUserId, update, updateLastLoggedAt };
+
+function _toDomain(userLoginDTO) {
+  return new UserLogin({
+    id: userLoginDTO.id,
+    userId: userLoginDTO.userId,
+    failureCount: userLoginDTO.failureCount,
+    temporaryBlockedUntil: userLoginDTO.temporaryBlockedUntil,
+    blockedAt: userLoginDTO.blockedAt,
+    createdAt: userLoginDTO.createdAt,
+    updatedAt: userLoginDTO.updatedAt,
+    lastLoggedAt: userLoginDTO.lastLoggedAt,
+  });
+}

--- a/api/src/shared/infrastructure/repositories/user-login-repository.js
+++ b/api/src/shared/infrastructure/repositories/user-login-repository.js
@@ -65,7 +65,21 @@ const updateLastLoggedAt = async function ({ userId }) {
     .merge();
 };
 
-export { create, findByUserId, findByUsername, getByUserId, update, updateLastLoggedAt };
+const batchUnblock = async function (userIds) {
+  const now = new Date();
+
+  const knexConn = DomainTransaction.getConnection();
+  await knexConn(USER_LOGINS_TABLE_NAME)
+    .update({
+      failureCount: 0,
+      temporaryBlockedUntil: null,
+      blockedAt: null,
+      updatedAt: now,
+    })
+    .whereIn('userId', userIds);
+};
+
+export { batchUnblock, create, findByUserId, findByUsername, getByUserId, update, updateLastLoggedAt };
 
 function _toDomain(userLoginDTO) {
   return new UserLogin({

--- a/api/tests/prescription/organization-learner/acceptance/application/sco-organization-learner-controller_test.js
+++ b/api/tests/prescription/organization-learner/acceptance/application/sco-organization-learner-controller_test.js
@@ -3,6 +3,7 @@ import {
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
+  knex,
 } from '../../../../test-helper.js';
 
 describe('Acceptance | Controller | sco-organization-learners', function () {
@@ -183,9 +184,15 @@ describe('Acceptance | Controller | sco-organization-learners', function () {
         databaseBuilder.factory.buildMembership({ organizationId, userId });
 
         const paul = databaseBuilder.factory.buildUser.withRawPassword({ firstName: 'Paul', username: 'paul' });
+
         const jacques = databaseBuilder.factory.buildUser.withRawPassword({
           firstName: 'Jacques',
           username: 'jacques',
+        });
+        databaseBuilder.factory.buildUserLogin({
+          userId: jacques.id,
+          failureCount: 50,
+          blockedAt: new Date(),
         });
 
         const organizationLearnersId = [
@@ -227,6 +234,12 @@ describe('Acceptance | Controller | sco-organization-learners', function () {
         const [fileHeaders, firstRow, ...unusedRows] = payload.split('\n').map((row) => row.trim());
         expect(fileHeaders).to.equal('"Classe";"Nom";"Prénom";"Identifiant";"Mot de passe"');
         expect(firstRow).to.match(/^"3A";/);
+
+        const jacquesUserLogin = await knex('user-logins').select().where({ userId: jacques.id }).first();
+        expect(jacquesUserLogin).to.deep.contain({
+          failureCount: 0,
+          blockedAt: null,
+        });
       });
     });
   });

--- a/api/tests/prescription/organization-learner/integration/domain/usecases/generate-organization-learners-username-and-temporary-password_test.js
+++ b/api/tests/prescription/organization-learner/integration/domain/usecases/generate-organization-learners-username-and-temporary-password_test.js
@@ -7,12 +7,16 @@ import { generateOrganizationLearnersUsernameAndTemporaryPassword } from '../../
 import { UserNotAuthorizedToUpdatePasswordError } from '../../../../../../src/shared/domain/errors.js';
 import * as userReconciliationService from '../../../../../../src/shared/domain/services/user-reconciliation-service.js';
 import * as organizationRepository from '../../../../../../src/shared/infrastructure/repositories/organization-repository.js';
-import { catchErr, databaseBuilder, domainBuilder, expect, sinon } from '../../../../../test-helper.js';
+import * as userLoginRepository from '../../../../../../src/shared/infrastructure/repositories/user-login-repository.js';
+import { catchErr, databaseBuilder, domainBuilder, expect, knex, sinon } from '../../../../../test-helper.js';
 
 describe('Integration | UseCases | generate organization learners username and temporary password', function () {
   const hashedPassword = '21fedcba';
   const generatedPassword = 'abcdef12';
   let cryptoService, passwordGenerator;
+
+  let clock;
+  const now = new Date('2025-05-05');
 
   const allAuthenticationMethodUsername = 'laurent.bar';
   const division = '3B';
@@ -25,8 +29,11 @@ describe('Integration | UseCases | generate organization learners username and t
   let organizationLearnerWithGarIdentityProvider, organizationLearnerWithAllAuthenticationMethod;
 
   let userWithEmail, userWithGarIdentityProvider, userWithUsername, userWithAllAuthenticationMethod;
+  let aNotToTouchBlockedUserId;
 
   beforeEach(function () {
+    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+
     organization = domainBuilder.buildOrganization({ id: undefined });
     cryptoService = { hashPassword: sinon.stub().resolves(hashedPassword) };
     passwordGenerator = { generateSimplePassword: sinon.stub().returns(generatedPassword) };
@@ -56,6 +63,18 @@ describe('Integration | UseCases | generate organization learners username and t
       databaseBuilder.factory.buildUser.withRawPassword({ ...user }),
     );
 
+    databaseBuilder.factory.buildUserLogin({
+      userId: userWithAllAuthenticationMethod.id,
+      failureCount: 50,
+      blockedAt: new Date(),
+    });
+
+    aNotToTouchBlockedUserId = databaseBuilder.factory.buildUserLogin({
+      failureCount: 500,
+      blockedAt: new Date('2020-01-01'),
+      updatedAt: new Date('2020-01-01'),
+    }).userId;
+
     userWithGarIdentityProvider = databaseBuilder.factory.buildUser({
       email: '',
       firstName: 'Ray',
@@ -74,6 +93,10 @@ describe('Integration | UseCases | generate organization learners username and t
     });
 
     userId = databaseBuilder.factory.buildUser().id;
+  });
+
+  afterEach(async function () {
+    clock.restore();
   });
 
   context('When organization is of type SCO and has isManagingStudents at true', function () {
@@ -125,6 +148,7 @@ describe('Integration | UseCases | generate organization learners username and t
           organizationRepository,
           organizationLearnerIdentityRepository,
           userRepository,
+          userLoginRepository,
           cryptoService,
           passwordGenerator,
           userReconciliationService,
@@ -149,6 +173,27 @@ describe('Integration | UseCases | generate organization learners username and t
         });
 
         expect(result).to.have.deep.members(expectedResult);
+
+        const userIds = [userWithAllAuthenticationMethod.id, aNotToTouchBlockedUserId];
+        const userLogins = await knex('user-logins').select().whereIn('userId', userIds);
+        const userWithAllAuthenticationMethodLogin = userLogins.find(
+          (userLogin) => userLogin.userId == userWithAllAuthenticationMethod.id,
+        );
+        expect(userWithAllAuthenticationMethodLogin).to.deep.contain({
+          failureCount: 0,
+          temporaryBlockedUntil: null,
+          blockedAt: null,
+          updatedAt: now,
+        });
+
+        const aNotToTouchBlockedUserLogin = userLogins.find(
+          (userLogin) => userLogin.userId == aNotToTouchBlockedUserId,
+        );
+        expect(aNotToTouchBlockedUserLogin).to.deep.contain({
+          failureCount: 500,
+          blockedAt: new Date('2020-01-01'),
+          updatedAt: new Date('2020-01-01'),
+        });
       });
     });
 
@@ -178,6 +223,7 @@ describe('Integration | UseCases | generate organization learners username and t
           organizationRepository,
           organizationLearnerIdentityRepository,
           userRepository,
+          userLoginRepository,
           cryptoService,
           passwordGenerator,
           userReconciliationService,
@@ -202,6 +248,27 @@ describe('Integration | UseCases | generate organization learners username and t
         ];
 
         expect(result).to.deep.equal(expectedResult);
+
+        const userIds = [userWithAllAuthenticationMethod.id, aNotToTouchBlockedUserId];
+        const userLogins = await knex('user-logins').select().whereIn('userId', userIds);
+        const userWithAllAuthenticationMethodLogin = userLogins.find(
+          (userLogin) => userLogin.userId == userWithAllAuthenticationMethod.id,
+        );
+        expect(userWithAllAuthenticationMethodLogin).to.deep.contain({
+          failureCount: 0,
+          temporaryBlockedUntil: null,
+          blockedAt: null,
+          updatedAt: now,
+        });
+
+        const aNotToTouchBlockedUserLogin = userLogins.find(
+          (userLogin) => userLogin.userId == aNotToTouchBlockedUserId,
+        );
+        expect(aNotToTouchBlockedUserLogin).to.deep.contain({
+          failureCount: 500,
+          blockedAt: new Date('2020-01-01'),
+          updatedAt: new Date('2020-01-01'),
+        });
       });
     });
   });
@@ -243,6 +310,7 @@ describe('Integration | UseCases | generate organization learners username and t
           organizationRepository,
           organizationLearnerIdentityRepository,
           userRepository,
+          userLoginRepository,
           cryptoService,
           passwordGenerator,
           userReconciliationService,
@@ -285,6 +353,7 @@ describe('Integration | UseCases | generate organization learners username and t
             organizationRepository,
             organizationLearnerIdentityRepository,
             userRepository,
+            userLoginRepository,
             cryptoService,
             passwordGenerator,
             userReconciliationService,

--- a/api/tests/prescription/organization-learner/integration/domain/usecases/generate-organization-learners-username-and-temporary-password_test.js
+++ b/api/tests/prescription/organization-learner/integration/domain/usecases/generate-organization-learners-username-and-temporary-password_test.js
@@ -1,13 +1,7 @@
 import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../../../../src/identity-access-management/domain/constants/identity-providers.js';
-import * as authenticationMethodRepository from '../../../../../../src/identity-access-management/infrastructure/repositories/authentication-method.repository.js';
-import { organizationLearnerIdentityRepository } from '../../../../../../src/identity-access-management/infrastructure/repositories/organization-learner-identity.repository.js';
-import * as userRepository from '../../../../../../src/identity-access-management/infrastructure/repositories/user.repository.js';
 import { OrganizationLearnerPasswordResetDTO } from '../../../../../../src/prescription/organization-learner/domain/models/OrganizationLearnerPasswordResetDTO.js';
-import { generateOrganizationLearnersUsernameAndTemporaryPassword } from '../../../../../../src/prescription/organization-learner/domain/usecases/generate-organization-learners-username-and-temporary-password.js';
+import { usecases } from '../../../../../../src/prescription/organization-learner/domain/usecases/index.js';
 import { UserNotAuthorizedToUpdatePasswordError } from '../../../../../../src/shared/domain/errors.js';
-import * as userReconciliationService from '../../../../../../src/shared/domain/services/user-reconciliation-service.js';
-import * as organizationRepository from '../../../../../../src/shared/infrastructure/repositories/organization-repository.js';
-import * as userLoginRepository from '../../../../../../src/shared/infrastructure/repositories/user-login-repository.js';
 import { catchErr, databaseBuilder, domainBuilder, expect, knex, sinon } from '../../../../../test-helper.js';
 
 describe('Integration | UseCases | generate organization learners username and temporary password', function () {
@@ -140,18 +134,12 @@ describe('Integration | UseCases | generate organization learners username and t
         };
 
         // when
-        const result = await generateOrganizationLearnersUsernameAndTemporaryPassword({
+        const result = await usecases.generateOrganizationLearnersUsernameAndTemporaryPassword({
           organizationId: organization.id,
           organizationLearnersId,
           userId,
-          authenticationMethodRepository,
-          organizationRepository,
-          organizationLearnerIdentityRepository,
-          userRepository,
-          userLoginRepository,
           cryptoService,
           passwordGenerator,
-          userReconciliationService,
         });
 
         // then
@@ -215,18 +203,12 @@ describe('Integration | UseCases | generate organization learners username and t
         ];
 
         // when
-        const result = await generateOrganizationLearnersUsernameAndTemporaryPassword({
+        const result = await usecases.generateOrganizationLearnersUsernameAndTemporaryPassword({
           organizationId: organization.id,
           organizationLearnersId,
           userId,
-          authenticationMethodRepository,
-          organizationRepository,
-          organizationLearnerIdentityRepository,
-          userRepository,
-          userLoginRepository,
           cryptoService,
           passwordGenerator,
-          userReconciliationService,
         });
 
         // then
@@ -302,18 +284,12 @@ describe('Integration | UseCases | generate organization learners username and t
         ];
 
         // when
-        const error = await catchErr(generateOrganizationLearnersUsernameAndTemporaryPassword)({
+        const error = await catchErr(usecases.generateOrganizationLearnersUsernameAndTemporaryPassword)({
           organizationId: organization.id,
           organizationLearnersId,
           userId,
-          authenticationMethodRepository,
-          organizationRepository,
-          organizationLearnerIdentityRepository,
-          userRepository,
-          userLoginRepository,
           cryptoService,
           passwordGenerator,
-          userReconciliationService,
         });
 
         // then
@@ -345,18 +321,12 @@ describe('Integration | UseCases | generate organization learners username and t
           ];
 
           // when
-          const error = await catchErr(generateOrganizationLearnersUsernameAndTemporaryPassword)({
+          const error = await catchErr(usecases.generateOrganizationLearnersUsernameAndTemporaryPassword)({
             organizationId: organization.id,
             organizationLearnersId,
             userId,
-            authenticationMethodRepository,
-            organizationRepository,
-            organizationLearnerIdentityRepository,
-            userRepository,
-            userLoginRepository,
             cryptoService,
             passwordGenerator,
-            userReconciliationService,
           });
 
           // then

--- a/api/tests/shared/integration/infrastructure/repositories/user-login-repository_test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/user-login-repository_test.js
@@ -227,4 +227,84 @@ describe('Integration | Shared | Infrastructure | Repositories | UserLoginReposi
       });
     });
   });
+
+  describe('#batchUnblock', function () {
+    let clock;
+    const now = new Date('2025-05-05');
+
+    beforeEach(function () {
+      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+    });
+
+    afterEach(async function () {
+      clock.restore();
+    });
+
+    it('resets account blocking for the given accounts', async function () {
+      // given
+      const nonBlockedUserId = databaseBuilder.factory.buildUserLogin().userId;
+      const temporarilyBlockedUserId = databaseBuilder.factory.buildUserLogin({
+        failureCount: 50,
+        temporaryBlockedUntil: new Date(Date.now() + 12 * 31 * 24 * 3600 * 1000), // 1 year into the future
+      }).userId;
+      const blockedUserId = databaseBuilder.factory.buildUserLogin({
+        failureCount: 200,
+        blockedAt: now,
+      }).userId;
+
+      const aNotToTouchBlockedUserId = databaseBuilder.factory.buildUserLogin({
+        failureCount: 500,
+        blockedAt: new Date('2020-01-01'),
+        updatedAt: new Date('2020-01-01'),
+      }).userId;
+
+      await databaseBuilder.commit();
+
+      const userIdsToBatchUnblock = [nonBlockedUserId, temporarilyBlockedUserId, blockedUserId];
+      const allUserIds = userIdsToBatchUnblock.concat(aNotToTouchBlockedUserId);
+
+      // when
+      await userLoginRepository.batchUnblock(userIdsToBatchUnblock);
+
+      // then
+      const allUserLogins = await knex(USER_LOGINS_TABLE_NAME).select().whereIn('userId', allUserIds);
+
+      const nonBlockedUserLogin = allUserLogins.find((userLogin) => {
+        return userLogin.userId == nonBlockedUserId;
+      });
+      expect(nonBlockedUserLogin).to.deep.contain({
+        failureCount: 0,
+        temporaryBlockedUntil: null,
+        blockedAt: null,
+        updatedAt: now,
+      });
+
+      const temporarilyBlockedUserLogin = allUserLogins.find(
+        (userLogin) => userLogin.userId == temporarilyBlockedUserId,
+      );
+      expect(temporarilyBlockedUserLogin).to.deep.contain({
+        failureCount: 0,
+        temporaryBlockedUntil: null,
+        blockedAt: null,
+        updatedAt: now,
+      });
+
+      const blockedUserLogin = allUserLogins.find((userLogin) => userLogin.userId == blockedUserId);
+      expect(blockedUserLogin).to.deep.contain({
+        failureCount: 0,
+        temporaryBlockedUntil: null,
+        blockedAt: null,
+        updatedAt: now,
+      });
+
+      const aNotToTouchBlockedUserLogin = allUserLogins.find(
+        (userLogin) => userLogin.userId == aNotToTouchBlockedUserId,
+      );
+      expect(aNotToTouchBlockedUserLogin).to.deep.contain({
+        failureCount: 500,
+        blockedAt: new Date('2020-01-01'),
+        updatedAt: new Date('2020-01-01'),
+      });
+    });
+  });
 });


### PR DESCRIPTION
## 🥀 Problème

Lorsqu’un membre d’une organisation SCO réinitialise les mots de passe des comptes des élèves on s’attend à ce que les comptes bloqués soient débloqués.

## 🏹 Proposition

Lors de la réinitialisation des mots de passe des élèves d’une organisation SCO, ajouter le déblocage des comptes qui pourraient être bloqués (temporairement ou non).

## 💌 Remarques

RAS

## ❤️‍🔥 Pour tester

<img width="1443" height="1210" alt="559172484-d482335e-330a-4931-ad4e-ab182b276b0a" src="https://github.com/user-attachments/assets/b6f98673-71d4-431a-85b0-9bead057c038" />

1. Se connecter à Pix Orga avec un admin d’orga (`orgacces@example.net`) pour gérer l’organisation `Collège House of The Dragon` (`ACCES_SCO`),
2. Aller sur la page `Élèves`,
3. Certains comptes d’élèves sont créés bloqués dans les seeds, et vous pouvez bloquer d’autres comptes d’élèves, respectivement temporairement et non-temporairement, avec les commandes ci-dessous : 
   ```sql
   -- Adding a temporary blocking
   insert into "user-logins" ("temporaryBlockedUntil", "userId") values (
     now() + interval '+30 days',
     (select id from users where email='hermione@example.net')
   );
   
   -- Adding a blocking
   insert into "user-logins" ("blockedAt", "userId") values (
     now(),
     (select id from users where email='bart@example.net')
   );
   ```
4. Sélectionner certains/tous les comptes d’élèves, notamment des comptes bloqués, un bouton `Réinitialiser les mots de passe des élèves sélectionnés` apparaît,
5. Actionner alors ce bouton `Réinitialiser les mots de passe des élèves sélectionnés`,
6. Constater que l’action réussit et que l’affichage indique maintenant que les comptes d’élèves bloqués sélectionnés sont maintenant débloqués.
