### PR TITLE
[FEATURE] Ajouter un script pour copier le contenu de la colonne locale -> locales (PIX-21775)

### DIFF
--- a/api/db/database-builder/factory/build-training.js
+++ b/api/db/database-builder/factory/build-training.js
@@ -9,6 +9,7 @@ import { databaseBuffer } from '../database-buffer.js';
  *  type: string,
  *  duration: string,
  *  locale: string,
+ *  locales: string[],
  *  editorName: string,
  *  editorLogoUrl: string,
  *  createdAt: Date,

--- a/api/scripts/modulix/locale-to-locales.js
+++ b/api/scripts/modulix/locale-to-locales.js
@@ -1,0 +1,50 @@
+import { knex } from '../../db/knex-database-connection.js';
+import { Script } from '../../src/shared/application/scripts/script.js';
+import { ScriptRunner } from '../../src/shared/application/scripts/script-runner.js';
+
+export class LocaleToLocalesScript extends Script {
+  constructor() {
+    super({
+      description: 'Copy the "locale" column value into the "locales" array column for each training',
+      permanent: false,
+      options: {
+        dryRun: {
+          type: 'boolean',
+          describe: 'Run the script without making any database changes',
+          default: false,
+        },
+      },
+    });
+  }
+
+  async handle({ logger, options }) {
+    const { dryRun } = options;
+    logger.info('Script execution started');
+
+    const trx = await knex.transaction();
+    try {
+      const trainings = await trx('trainings').select('id', 'locale');
+      logger.info(`Found ${trainings.length} trainings to update`);
+
+      for (const training of trainings) {
+        await trx('trainings')
+          .where('id', training.id)
+          .update({ locales: [training.locale] });
+      }
+
+      if (dryRun) {
+        await trx.rollback();
+        logger.info(`Dry run: ${trainings.length} trainings would have been updated`);
+        return;
+      }
+
+      await trx.commit();
+      logger.info(`${trainings.length} trainings have been successfully updated`);
+    } catch (error) {
+      await trx.rollback();
+      throw error;
+    }
+  }
+}
+
+await ScriptRunner.execute(import.meta.url, LocaleToLocalesScript);

--- a/api/tests/integration/scripts/modulix/locale-to-locales_test.js
+++ b/api/tests/integration/scripts/modulix/locale-to-locales_test.js
@@ -1,0 +1,50 @@
+import { LocaleToLocalesScript } from '../../../../scripts/modulix/locale-to-locales.js';
+import { databaseBuilder, expect, knex, sinon } from '../../../test-helper.js';
+
+describe('Integration | Modulix | scripts | locale-to-locales.js', function () {
+  describe('#handle', function () {
+    let logger;
+    let script;
+
+    beforeEach(function () {
+      script = new LocaleToLocalesScript();
+      logger = { info: sinon.spy() };
+    });
+
+    it('runs the script with dryRun', async function () {
+      // given
+      databaseBuilder.factory.buildTraining({ locale: 'fr', locales: [] });
+      databaseBuilder.factory.buildTraining({ locale: 'fr-fr', locales: [] });
+      databaseBuilder.factory.buildTraining({ locale: 'en', locales: [] });
+      await databaseBuilder.commit();
+
+      // when
+      await script.handle({ options: { dryRun: true }, logger });
+
+      // then
+      const trainings = await knex('trainings').select('locales').orderBy('id');
+      expect(trainings[0].locales).to.deep.equal([]);
+      expect(trainings[1].locales).to.deep.equal([]);
+      expect(trainings[2].locales).to.deep.equal([]);
+      expect(logger.info).to.have.been.calledWith('Dry run: 3 trainings would have been updated');
+    });
+
+    it('runs the script without dryRun', async function () {
+      // given
+      databaseBuilder.factory.buildTraining({ locale: 'fr', locales: [] });
+      databaseBuilder.factory.buildTraining({ locale: 'fr-fr', locales: [] });
+      databaseBuilder.factory.buildTraining({ locale: 'en', locales: [] });
+      await databaseBuilder.commit();
+
+      // when
+      await script.handle({ options: { dryRun: false }, logger });
+
+      // then
+      const trainings = await knex('trainings').select('locales').orderBy('id');
+      expect(trainings[0].locales).to.deep.equal(['fr']);
+      expect(trainings[1].locales).to.deep.equal(['fr-fr']);
+      expect(trainings[2].locales).to.deep.equal(['en']);
+      expect(logger.info).to.have.been.calledWith('3 trainings have been successfully updated');
+    });
+  });
+});


### PR DESCRIPTION
## 🥀 Problème

La colonne `locales` (de type `text[]`) de la table `trainings` n'est pas renseignée pour les trainings existants qui ont uniquement une valeur dans la colonne `locale`.

## 🏹 Proposition

Création d'un script de migration en base qui copie la valeur de la colonne `locale` vers la colonne `locales` pour chaque training concerné.

Le script supporte un mode `--dryRun` pour vérifier les changements sans les appliquer.

## 💌 Remarques

- Tout le code a été créé en utilisant Claude Code, depuis jetBrains.
- Une fois que le commit sera en prod, contacter les captains pour exécuter le script dans la db de prod.

## ❤️‍🔥 Pour tester

- [ ] Lancer le script en dry run : `node --env-file-if-exists=api/.env api/scripts/modulix/locale-to-locales.js --dryRun`
- [ ] Vérifier les logs (nombre de trainings concernés, valeurs)
- [ ] Lancer le script sans dry run : `node --env-file-if-exists=api/.env api/scripts/modulix/locale-to-locales.js`
- [ ] Vérifier en base que la colonne `locales` est bien renseignée