### PR TITLE
[TECH] Télécharger toutes les attestations dans un seul PDF (PIX-21846)

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -79,8 +79,7 @@
         "xml2js": "^0.6.0",
         "xmlbuilder2": "^4.0.0",
         "xregexp": "^5.1.1",
-        "yargs": "^18.0.0",
-        "yazl": "^3.3.1"
+        "yargs": "^18.0.0"
       },
       "devDependencies": {
         "@1024pix/eslint-plugin": "^2.1.18",
@@ -5327,15 +5326,6 @@
       "dependencies": {
         "base64-js": "^1.0.2",
         "ieee754": "^1.1.4"
-      }
-    },
-    "node_modules/buffer-crc32": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
-      "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.0.0"
       }
     },
     "node_modules/buffer-equal-constant-time": {
@@ -12903,15 +12893,6 @@
       "license": "ISC",
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=23"
-      }
-    },
-    "node_modules/yazl": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/yazl/-/yazl-3.3.1.tgz",
-      "integrity": "sha512-BbETDVWG+VcMUle37k5Fqp//7SDOK2/1+T7X8TD96M3D9G8jK5VLUdQVdVjGi8im7FGkazX7kk5hkU8X4L5Bng==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer-crc32": "^1.0.0"
       }
     },
     "node_modules/yocto-queue": {

--- a/api/package.json
+++ b/api/package.json
@@ -160,8 +160,7 @@
     "xml2js": "^0.6.0",
     "xmlbuilder2": "^4.0.0",
     "xregexp": "^5.1.1",
-    "yargs": "^18.0.0",
-    "yazl": "^3.3.1"
+    "yargs": "^18.0.0"
   },
   "devDependencies": {
     "@1024pix/eslint-plugin": "^2.1.18",

--- a/api/src/prescription/organization-learner/application/organization-learners-controller.js
+++ b/api/src/prescription/organization-learner/application/organization-learners-controller.js
@@ -3,7 +3,7 @@ import { usecases } from '../domain/usecases/index.js';
 import * as analysisByTubesSerializer from '../infrastructure/serializers/jsonapi/analysis-by-tubes-serializer.js';
 import * as attestationParticipantStatusSerializer from '../infrastructure/serializers/jsonapi/attestation-participants-status-serializer.js';
 
-const getAttestationZipFromFilters = async function (request, h) {
+const getAttestationPdfFromFilters = async function (request, h) {
   const organizationId = request.params.organizationId;
   const attestationKey = request.params.attestationKey;
   const divisions = request.query.divisions;
@@ -14,7 +14,7 @@ const getAttestationZipFromFilters = async function (request, h) {
       organizationId,
       divisions,
     });
-    return h.response(buffer).header('Content-Type', 'application/zip');
+    return h.response(buffer).header('Content-Type', 'application/pdf');
   } catch (error) {
     if (error instanceof NoProfileRewardsFoundError) {
       return h.response().code(204);
@@ -48,7 +48,7 @@ const getAttestationParticipantsStatus = async function (
 
 const organizationLearnersController = {
   getAnalysisByTubes,
-  getAttestationZipFromFilters,
+  getAttestationZipFromFilters: getAttestationPdfFromFilters,
   getAttestationParticipantsStatus,
 };
 

--- a/api/src/prescription/organization-learner/application/organization-learners-controller.js
+++ b/api/src/prescription/organization-learner/application/organization-learners-controller.js
@@ -9,7 +9,7 @@ const getAttestationPdfFromFilters = async function (request, h) {
   const divisions = request.query.divisions;
 
   try {
-    const buffer = await usecases.getAttestationZipFromFilters({
+    const buffer = await usecases.getAttestationPdfFromFilters({
       attestationKey,
       organizationId,
       divisions,
@@ -48,7 +48,7 @@ const getAttestationParticipantsStatus = async function (
 
 const organizationLearnersController = {
   getAnalysisByTubes,
-  getAttestationZipFromFilters: getAttestationPdfFromFilters,
+  getAttestationPdfFromFilters,
   getAttestationParticipantsStatus,
 };
 

--- a/api/src/prescription/organization-learner/application/organization-learners-route.js
+++ b/api/src/prescription/organization-learner/application/organization-learners-route.js
@@ -61,7 +61,7 @@ const register = async function (server) {
             divisions: Joi.array().items(Joi.string()).default([]),
           }),
         },
-        handler: organizationLearnersController.getAttestationZipFromFilters,
+        handler: organizationLearnersController.getAttestationPdfFromFilters,
         notes: [
           '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
             "- Génération d'un zip d'attestations pour une liste de classes d'une organisation" +

--- a/api/src/prescription/organization-learner/domain/usecases/get-attestation-pdf-from-filters.js
+++ b/api/src/prescription/organization-learner/domain/usecases/get-attestation-pdf-from-filters.js
@@ -1,4 +1,4 @@
-export const getAttestationZipFromFilters = async ({
+export const getAttestationPdfFromFilters = async ({
   attestationKey,
   organizationId,
   divisions,

--- a/api/src/prescription/organization-learner/domain/usecases/index.js
+++ b/api/src/prescription/organization-learner/domain/usecases/index.js
@@ -103,7 +103,7 @@ import { generateResetOrganizationLearnersPasswordCsvContent } from './generate-
 import { generateUsername } from './generate-username.js';
 import { generateUsernameWithTemporaryPassword } from './generate-username-with-temporary-password.js';
 import { getAnalysisByTubes } from './get-analysis-by-tubes.js';
-import { getAttestationZipFromFilters } from './get-attestation-zip-from-filters.js';
+import { getAttestationPdfFromFilters } from './get-attestation-pdf-from-filters.js';
 import { getOrganizationLearner } from './get-organization-learner.js';
 import { getOrganizationLearnerActivity } from './get-organization-learner-activity.js';
 import { getOrganizationToJoin } from './get-organization-to-join.js';
@@ -126,7 +126,7 @@ const usecasesWithoutInjectedDependencies = {
   generateUsername,
   generateUsernameWithTemporaryPassword,
   getAnalysisByTubes,
-  getAttestationZipFromFilters,
+  getAttestationPdfFromFilters,
   getOrganizationLearner,
   getOrganizationLearnerActivity,
   getOrganizationLearnerStatistics: getCampaignParticipationStatistics,

--- a/api/src/profile/infrastructure/serializers/pdf/pdf-with-form-serializer.js
+++ b/api/src/profile/infrastructure/serializers/pdf/pdf-with-form-serializer.js
@@ -1,15 +1,18 @@
-import { PDFDocument } from 'pdf-lib';
-import yazl from 'yazl';
+// PDFDict, PDFName, PDFNumber : types bas niveau de pdf-lib pour lire les dictionnaires PDF
+import { PDFDict, PDFDocument, PDFName, PDFNumber } from 'pdf-lib';
 
 import { FONTS, initializeFonts } from '../../../../shared/infrastructure/serializers/pdf/utils.js';
 import { getDataBuffer } from '../../../../shared/infrastructure/utils/buffer.js';
 
+// Point d'entrée : reçoit un stream (template depuis S3) et les données à injecter
 export async function serializeStream(stream, entry, creationDate = new Date()) {
+  // Convertit le stream en Buffer pour pouvoir le lire plusieurs fois
   const template = await getDataBuffer(stream);
 
   return serializePdf(template, entry, creationDate);
 }
 
+// Aiguillage : un seul élément → PDF simple, tableau → PDF multi-pages
 async function serializePdf(template, entry, creationDate = new Date()) {
   if (Array.isArray(entry)) {
     return serializeArray(template, entry, creationDate);
@@ -18,19 +21,165 @@ async function serializePdf(template, entry, creationDate = new Date()) {
   }
 }
 
+// Génère un PDF unique contenant une page par élève
 async function serializeArray(template, entries, creationDate) {
-  const zipfile = new yazl.ZipFile();
+  // Charge le template une seule fois pour extraire les positions des champs
+  const templateDoc = await PDFDocument.load(template);
+  // Lit dans le template l'emplacement et l'alignement de chaque champ de formulaire
+  const fieldPositions = extractFieldPositions(templateDoc);
+
+  const mergedPdf = await PDFDocument.create();
+  mergedPdf.setCreationDate(creationDate);
+  mergedPdf.setModificationDate(creationDate);
+
+  // Embarque la police Roboto une seule fois dans le document final (partagée par toutes les pages)
+  const { [FONTS.robotoRegular]: robotoFont } = await initializeFonts(mergedPdf, [FONTS.robotoRegular]);
+
+  // embedPage() convertit la page du template en Form XObject (un objet PDF réutilisable)
+  // Les annotations AcroForm (champs de formulaire vides) ne font PAS partie du content stream
+  // → elles ne seront donc pas visibles dans le PDF généré
+  const embeddedTemplate = await mergedPdf.embedPage(templateDoc.getPage(0));
+  // Récupère les dimensions du template pour créer des pages de même taille
+  const { width, height } = embeddedTemplate;
 
   for (const entry of entries) {
-    const buffer = await serializeObject(template, entry, creationDate);
-    zipfile.addBuffer(buffer, `${entry.get('filename')}.pdf`);
+    // Crée une nouvelle page vierge aux dimensions du template
+    const page = mergedPdf.addPage([width, height]);
+
+    // Dessine le fond commun (image, graphismes, texte décoratif) via le Form XObject partagé
+    // → le template n'est stocké qu'une seule fois dans le fichier, toutes les pages y font référence
+    page.drawPage(embeddedTemplate);
+
+    // Pour chaque champ à remplir (firstName, lastName, date…)
+    for (const [fieldName, value] of entry) {
+      // "filename" est une clé interne pour nommer le fichier, pas un champ PDF
+      if (fieldName === 'filename') continue;
+      const pos = fieldPositions.get(fieldName);
+      // Ignore les champs absents du template ou sans valeur
+      if (!pos || !value) continue;
+
+      // Si la taille est définie dans le template (DA ≠ 0), on l'utilise directement
+      // Sinon, on calcule la plus grande taille qui rentre dans les dimensions du champ
+      const fontSize = pos.daFontSize > 0 ? pos.daFontSize : autoFontSize(value, pos.width, pos.height, robotoFont);
+      // Mesure la largeur réelle du texte à cette taille (nécessaire pour le centrage horizontal)
+      const textWidth = robotoFont.widthOfTextAtSize(value, fontSize);
+      // Calcule x selon l'alignement du champ (gauche / centré / droite)
+      const x = computeX(pos, textWidth);
+      // Calcule y pour centrer verticalement le texte dans le champ
+      const y = computeY(pos, fontSize, robotoFont);
+
+      page.drawText(value, {
+        x,
+        y,
+        size: fontSize,
+        font: robotoFont,
+      });
+    }
   }
 
-  zipfile.end();
-
-  return zipfile.outputStream;
+  const bytes = await mergedPdf.save();
+  return Buffer.from(bytes);
 }
 
+// Valeurs du champ Q dans la spec PDF (quadding = alignement horizontal)
+const ALIGN_LEFT = 0;
+const ALIGN_CENTER = 1;
+const ALIGN_RIGHT = 2;
+
+// Lit dans le template la position, la taille de police et l'alignement de chaque champ
+function extractFieldPositions(pdfDoc) {
+  const form = pdfDoc.getForm();
+  const positions = new Map();
+
+  for (const field of form.getFields()) {
+    const name = field.getName();
+    const widgets = field.acroField.getWidgets();
+    // Un champ sans widget n'a pas de représentation visuelle sur la page
+    if (widgets.length === 0) continue;
+
+    // getRectangle() retourne {x, y, width, height} dans le repère de la page (origine bas-gauche)
+    const rect = widgets[0].getRectangle();
+    // Lit la taille de police depuis la Default Appearance string du champ (peut être 0 = auto)
+    const daFontSize = parseFontSizeFromDA(field);
+    // Lit l'alignement horizontal en remontant la hiérarchie des champs
+    const align = parseAlignFromQ(field);
+
+    positions.set(name, { x: rect.x, y: rect.y, width: rect.width, height: rect.height, daFontSize, align });
+  }
+
+  return positions;
+}
+
+// Calcule la position x du texte selon l'alignement du champ
+function computeX(pos, textWidth) {
+  // Centré : décale de (largeur_champ - largeur_texte) / 2 depuis le bord gauche du champ
+  if (pos.align === ALIGN_CENTER) return pos.x + (pos.width - textWidth) / 2;
+  // Droite : colle le texte au bord droit avec un petit padding
+  if (pos.align === ALIGN_RIGHT) return pos.x + pos.width - textWidth - 2;
+  // Gauche (défaut) : colle au bord gauche avec un petit padding
+  return pos.x + 2;
+}
+
+// Calcule la position y (baseline du texte) pour centrer verticalement dans le champ
+function computeY(pos, fontSize, font) {
+  // heightAtSize({ descender: false }) retourne la hauteur des capitales (cap height)
+  // qui correspond à la hauteur visuelle des majuscules, sans les jambages descendants
+  const capHeight = font.heightAtSize(fontSize, { descender: false });
+  // On centre le cap height dans la hauteur du champ :
+  //   baseline = bas_du_champ + (hauteur_champ - cap_height) / 2
+  // → le centre visuel du texte tombe exactement au centre du champ
+  return pos.y + (pos.height - capHeight) / 2;
+}
+
+// Lit l'alignement Q en remontant la chaîne de parents du champ
+// Q est un attribut héritable : il peut être défini sur un champ parent plutôt que sur le champ lui-même
+function parseAlignFromQ(field) {
+  let node = field.acroField.dict;
+  while (node instanceof PDFDict) {
+    // lookup() résout les références indirectes PDF (contrairement à get() qui retourne la ref brute)
+    const q = node.lookup(PDFName.of('Q'));
+    if (q instanceof PDFNumber) return q.asNumber();
+    // Remonte au champ parent s'il existe
+    const parent = node.lookup(PDFName.of('Parent'));
+    if (!(parent instanceof PDFDict)) break;
+    node = parent;
+  }
+  // Par défaut : alignement gauche (valeur 0 selon la spec PDF)
+  return ALIGN_LEFT;
+}
+
+// Calcule la plus grande taille de police qui rentre dans les dimensions du champ
+function autoFontSize(text, fieldWidth, fieldHeight, font) {
+  const PADDING = 4;
+  // Descend depuis 24pt jusqu'à 6pt par pas de 0.5
+  for (let size = 24; size >= 6; size -= 0.5) {
+    const textWidth = font.widthOfTextAtSize(text, size);
+    // heightAtSize() sans option retourne ascendants + descendants (hauteur totale de la ligne)
+    const textHeight = font.heightAtSize(size);
+    // Vérifie que le texte rentre en largeur ET en hauteur dans le champ (avec padding)
+    if (textWidth <= fieldWidth - PADDING && textHeight <= fieldHeight - PADDING) return size;
+  }
+  return 6;
+}
+
+// Lit la taille de police depuis la Default Appearance string (DA) du champ
+// La DA est une chaîne PDF du type "/FontName 12 Tf 0 g" (nom police, taille, opérateur, couleur)
+function parseFontSizeFromDA(field) {
+  try {
+    const da = field.acroField.DA?.();
+    if (typeof da === 'string') {
+      // Extrait le nombre qui précède "Tf" (ex: "12 Tf" → 12, "0 Tf" → 0 pour auto-size)
+      const match = da.match(/(\d+(?:\.\d+)?)\s+Tf/);
+      if (match) return parseFloat(match[1]);
+    }
+  } catch {
+    // Certains champs n'ont pas de DA (hérité du parent ou absent)
+  }
+  return null;
+}
+
+// Génère un PDF simple pour une seule attestation (téléchargement individuel)
+// Utilise l'API AcroForm de pdf-lib : remplit les champs et reconstruit les apparences
 async function serializeObject(template, entry, creationDate) {
   const pdf = await PDFDocument.load(template);
   const { [FONTS.robotoRegular]: embeddedRobotoFont } = await initializeFonts(pdf, [FONTS.robotoRegular]);
@@ -43,12 +192,15 @@ async function serializeObject(template, entry, creationDate) {
     if (fieldName === 'filename') continue;
     const field = form.getTextField(fieldName);
     field.setText(value);
+    // Rend le champ non-modifiable dans le PDF final
     field.enableReadOnly();
   }
 
+  // Reconstruit les apparences visuelles de tous les champs avec la police Roboto
   form.updateFieldAppearances(embeddedRobotoFont);
 
   const bytes = await pdf.save({
+    // false = format xref classique (PDF 1.4), compatibilité maximale avec les vieux lecteurs
     useObjectStreams: false,
   });
 

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -203,6 +203,7 @@ const configuration = (function () {
           endpoint: process.env.ATTESTATIONS_STORAGE_ENDPOINT,
           region: process.env.ATTESTATIONS_STORAGE_REGION,
           bucket: process.env.ATTESTATIONS_STORAGE_BUCKET_NAME,
+          forcePathStyle: true,
         },
       },
     },

--- a/api/tests/prescription/organization-learner/acceptance/application/organization-learners-route_test.js
+++ b/api/tests/prescription/organization-learner/acceptance/application/organization-learners-route_test.js
@@ -61,7 +61,7 @@ describe('Prescription | Organization Learner | Acceptance | Application | Organ
 
       // then
       expect(response.statusCode).to.equal(200);
-      expect(response.headers['content-type']).to.equal('application/zip');
+      expect(response.headers['content-type']).to.equal('application/pdf');
     });
   });
 

--- a/api/tests/prescription/organization-learner/integration/domain/usecases/get-attestation-pdf-from-filters_test.js
+++ b/api/tests/prescription/organization-learner/integration/domain/usecases/get-attestation-pdf-from-filters_test.js
@@ -31,7 +31,7 @@ describe('Integration | Prescription | Learner Management | Domain | UseCase | g
     await databaseBuilder.commit();
 
     // when
-    const result = await usecases.getAttestationZipFromFilters({
+    const result = await usecases.getAttestationPdfFromFilters({
       attestationKey: attestation.key,
       divisions: ['6eme A', '6eme B'],
       organizationId,

--- a/api/tests/prescription/organization-learner/integration/domain/usecases/get-attestation-zip-from-filters_test.js
+++ b/api/tests/prescription/organization-learner/integration/domain/usecases/get-attestation-zip-from-filters_test.js
@@ -1,10 +1,8 @@
-import { PassThrough } from 'node:stream';
-
 import { usecases } from '../../../../../../src/prescription/organization-learner/domain/usecases/index.js';
 import { databaseBuilder, expect, mockAttestationStorage } from '../../../../../test-helper.js';
 
 describe('Integration | Prescription | Learner Management | Domain | UseCase | get-attestation-zip-for-divisions', function () {
-  it('returns a zip attestation', async function () {
+  it('returns a pdf attestation', async function () {
     // given
     const templateName = 'sixth-grade-attestation-template';
     const organizationId = databaseBuilder.factory.buildOrganization().id;
@@ -40,6 +38,6 @@ describe('Integration | Prescription | Learner Management | Domain | UseCase | g
     });
 
     // then
-    expect(result instanceof PassThrough).true;
+    expect(Buffer.isBuffer(result)).to.be.true;
   });
 });

--- a/api/tests/prescription/organization-learner/unit/application/organization-learners-controller_test.js
+++ b/api/tests/prescription/organization-learner/unit/application/organization-learners-controller_test.js
@@ -6,7 +6,7 @@ import { catchErr, expect, hFake, sinon } from '../../../../test-helper.js';
 describe('Unit | Application | Organization-Learner | organization-learners-controller', function () {
   describe('#getAttestationZipFromFilters', function () {
     describe('success case', function () {
-      it('should return buffer', async function () {
+      it('should return a pdf buffer with correct headers', async function () {
         // given
         const organizationId = 123;
         const attestationKey = Symbol('attestationKey');
@@ -34,6 +34,7 @@ describe('Unit | Application | Organization-Learner | organization-learners-cont
 
         // then
         expect(response.statusCode).to.equal(200);
+        expect(response.headers['Content-Type']).to.equal('application/pdf');
       });
     });
 

--- a/api/tests/prescription/organization-learner/unit/application/organization-learners-controller_test.js
+++ b/api/tests/prescription/organization-learner/unit/application/organization-learners-controller_test.js
@@ -4,7 +4,7 @@ import { NoProfileRewardsFoundError } from '../../../../../src/profile/domain/er
 import { catchErr, expect, hFake, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Application | Organization-Learner | organization-learners-controller', function () {
-  describe('#getAttestationZipFromFilters', function () {
+  describe('#getAttestationPdfFromFilters', function () {
     describe('success case', function () {
       it('should return a pdf buffer with correct headers', async function () {
         // given
@@ -13,9 +13,9 @@ describe('Unit | Application | Organization-Learner | organization-learners-cont
         const divisions = Symbol('divisions');
         const expectedBuffer = Symbol('buffer');
 
-        sinon.stub(usecases, 'getAttestationZipFromFilters');
+        sinon.stub(usecases, 'getAttestationPdfFromFilters');
 
-        usecases.getAttestationZipFromFilters
+        usecases.getAttestationPdfFromFilters
           .withArgs({ organizationId, attestationKey, divisions })
           .resolves(expectedBuffer);
 
@@ -30,7 +30,7 @@ describe('Unit | Application | Organization-Learner | organization-learners-cont
         };
 
         // when
-        const response = await organizationLearnersController.getAttestationZipFromFilters(request, hFake);
+        const response = await organizationLearnersController.getAttestationPdfFromFilters(request, hFake);
 
         // then
         expect(response.statusCode).to.equal(200);
@@ -45,9 +45,9 @@ describe('Unit | Application | Organization-Learner | organization-learners-cont
         const attestationKey = Symbol('attestationKey');
         const divisions = Symbol('divisions');
 
-        sinon.stub(usecases, 'getAttestationZipFromFilters');
+        sinon.stub(usecases, 'getAttestationPdfFromFilters');
 
-        usecases.getAttestationZipFromFilters
+        usecases.getAttestationPdfFromFilters
           .withArgs({ organizationId, attestationKey, divisions })
           .rejects(new NoProfileRewardsFoundError());
 
@@ -62,7 +62,7 @@ describe('Unit | Application | Organization-Learner | organization-learners-cont
         };
 
         // when
-        const response = await organizationLearnersController.getAttestationZipFromFilters(request, hFake);
+        const response = await organizationLearnersController.getAttestationPdfFromFilters(request, hFake);
 
         // then
         expect(response.statusCode).to.equal(204);
@@ -74,9 +74,9 @@ describe('Unit | Application | Organization-Learner | organization-learners-cont
         const attestationKey = Symbol('attestationKey');
         const divisions = Symbol('divisions');
         const expectedError = Symbol('error');
-        sinon.stub(usecases, 'getAttestationZipFromFilters');
+        sinon.stub(usecases, 'getAttestationPdfFromFilters');
 
-        usecases.getAttestationZipFromFilters
+        usecases.getAttestationPdfFromFilters
           .withArgs({ organizationId, attestationKey, divisions })
           .rejects(expectedError);
 
@@ -91,7 +91,7 @@ describe('Unit | Application | Organization-Learner | organization-learners-cont
         };
 
         // when
-        const error = await catchErr(organizationLearnersController.getAttestationZipFromFilters)(request, hFake);
+        const error = await catchErr(organizationLearnersController.getAttestationPdfFromFilters)(request, hFake);
 
         // then
         expect(error).to.equal(expectedError);

--- a/api/tests/prescription/organization-learner/unit/application/organization-learners-route_test.js
+++ b/api/tests/prescription/organization-learner/unit/application/organization-learners-route_test.js
@@ -54,7 +54,7 @@ describe('Prescription | Unit | Router | organization-learner-router', function 
             .takeover(),
       );
       sinon
-        .stub(organizationLearnersController, 'getAttestationZipFromFilters')
+        .stub(organizationLearnersController, 'getAttestationPdfFromFilters')
         .callsFake((request, h) => h.response('ok'));
 
       const httpTestServer = new HttpTestServer();
@@ -67,7 +67,7 @@ describe('Prescription | Unit | Router | organization-learner-router', function 
 
       // then
       expect(response.statusCode).to.equal(403);
-      expect(organizationLearnersController.getAttestationZipFromFilters).to.not.have.been.called;
+      expect(organizationLearnersController.getAttestationPdfFromFilters).to.not.have.been.called;
     });
 
     it('should throw 403 if user is not admin in organization', async function () {
@@ -82,7 +82,7 @@ describe('Prescription | Unit | Router | organization-learner-router', function 
         .stub(securityPreHandlers, 'makeCheckOrganizationHasFeature')
         .callsFake(() => (request, h) => h.response(true));
       sinon
-        .stub(organizationLearnersController, 'getAttestationZipFromFilters')
+        .stub(organizationLearnersController, 'getAttestationPdfFromFilters')
         .callsFake((request, h) => h.response('ok'));
 
       const httpTestServer = new HttpTestServer();
@@ -95,13 +95,13 @@ describe('Prescription | Unit | Router | organization-learner-router', function 
 
       // then
       expect(response.statusCode).to.equal(403);
-      expect(organizationLearnersController.getAttestationZipFromFilters).to.not.have.been.called;
+      expect(organizationLearnersController.getAttestationPdfFromFilters).to.not.have.been.called;
     });
 
     it('should call prehandlers before calling controller method', async function () {
       // given
       sinon
-        .stub(organizationLearnersController, 'getAttestationZipFromFilters')
+        .stub(organizationLearnersController, 'getAttestationPdfFromFilters')
         .callsFake((request, h) => h.response('ok').code(200));
       sinon.stub(securityPreHandlers, 'checkUserIsAdminInOrganization').callsFake((request, h) => h.response(true));
       sinon
@@ -119,13 +119,13 @@ describe('Prescription | Unit | Router | organization-learner-router', function 
       // then
       expect(response.statusCode).to.equal(200);
       expect(securityPreHandlers.checkUserIsAdminInOrganization).to.have.been.calledBefore(
-        organizationLearnersController.getAttestationZipFromFilters,
+        organizationLearnersController.getAttestationPdfFromFilters,
       );
       expect(securityPreHandlers.makeCheckOrganizationHasFeature).calledWithExactly(
         ORGANIZATION_FEATURE.ATTESTATIONS_MANAGEMENT.key,
       );
       expect(securityPreHandlers.makeCheckOrganizationHasFeature).to.have.been.calledBefore(
-        organizationLearnersController.getAttestationZipFromFilters,
+        organizationLearnersController.getAttestationPdfFromFilters,
       );
     });
   });

--- a/api/tests/profile/integration/infrastructure/serializers/pdf/pdf-with-form-serializer_test.js
+++ b/api/tests/profile/integration/infrastructure/serializers/pdf/pdf-with-form-serializer_test.js
@@ -2,10 +2,9 @@ import { createReadStream } from 'node:fs';
 import { writeFile } from 'node:fs/promises';
 import * as url from 'node:url';
 
-import JSZip from 'jszip';
+import { PDFDocument } from 'pdf-lib';
 
 import { serializeStream } from '../../../../../../src/profile/infrastructure/serializers/pdf/pdf-with-form-serializer.js';
-import { getDataBuffer } from '../../../../../../src/shared/infrastructure/utils/buffer.js';
 import { expect } from '../../../../../test-helper.js';
 import { isSameBinary } from '../../../../../tooling/binary-comparator.js';
 
@@ -33,12 +32,9 @@ describe('Integration | Infrastructure | Serializers | Pdf | PdfWithForm', funct
       });
     });
 
-    context('when there are multiple objects to serialize in a zip', function () {
-      it('should return zip as a buffer', async function () {
+    context('when there are multiple objects to serialize', function () {
+      it('should return a single multi-page pdf as a buffer', async function () {
         // given
-        const expectedFirstFilename = '/expected-first.pdf';
-        const expectedSecondFilename = '/expected-second.pdf';
-
         const stream = createReadStream(`${__dirname}/template.pdf`);
         const data = [new Map(), new Map()];
         data[0].set('fullName', 'Nom complet 1');
@@ -47,20 +43,12 @@ describe('Integration | Infrastructure | Serializers | Pdf | PdfWithForm', funct
         data[1].set('filename', 'Sans titre 2');
 
         // when
-        const passtrough = await serializeStream(stream, data, new Date('2024-10-01'));
-
-        const zip = new JSZip();
-        await zip.loadAsync(await getDataBuffer(passtrough));
-
-        const firstPdfBuffer = await zip.file(data[0].get('filename') + '.pdf').async('nodebuffer');
-        const secondPdfBuffer = await zip.file(data[1].get('filename') + '.pdf').async('nodebuffer');
-
-        await recreatePDFFileReferenceTest({ outputFilename: expectedFirstFilename, buffer: firstPdfBuffer });
-        await recreatePDFFileReferenceTest({ outputFilename: expectedSecondFilename, buffer: secondPdfBuffer });
+        const buffer = await serializeStream(stream, data, new Date('2024-10-01'));
 
         // then
-        expect(await isSameBinary(`${__dirname}${expectedFirstFilename}`, firstPdfBuffer)).to.be.true;
-        expect(await isSameBinary(`${__dirname}${expectedSecondFilename}`, secondPdfBuffer)).to.be.true;
+        expect(Buffer.isBuffer(buffer)).to.be.true;
+        const pdfDoc = await PDFDocument.load(buffer);
+        expect(pdfDoc.getPageCount()).to.equal(2);
       });
     });
   });

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -21,7 +21,7 @@ services:
     image: adobe/s3mock:4.11.0
     container_name: pix-api-s3
     environment:
-      - initialBuckets=pix-import-dev,pix-import-test
+      - initialBuckets=pix-import-dev,pix-import-test,pix-attestations-dev
     ports:
       - '${PIX_S3_PORT:-9090}:9090'
 


### PR DESCRIPTION
## 💈 Problème

L'export des attestations sur Pix Orga génère un ZIP contenant un PDF par élève. C'est lent, lourd (~27MB pour 30 élèves), et oblige l'utilisateur à ouvrir chaque fichier un à un pour imprimer.

## 🦤 Proposition

Remplacer le ZIP par un seul PDF multi-pages (~300Ko pour 100 élèves), en partageant les ressources du template entre toutes les pages.

**Approche technique :**
- Le template PDF (stocké sur S3) est embarqué une seule fois comme **Form XObject** via `embedPage()`. Toutes les pages y font référence via `drawPage()` → les ressources (image de fond, graphismes) ne sont stockées qu'une seule fois.
- La police Roboto est embarquée une seule fois dans le document final.
- Les positions, alignements et tailles de police sont lus directement depuis les champs AcroForm du template (rect, Q, DA), puis le texte est dessiné avec `page.drawText()`.
- Les annotations AcroForm ne faisant pas partie du content stream, elles n'apparaissent pas dans le PDF final (pas de champs vides visibles).
- La dépendance `yazl` (génération de ZIP) a été supprimée.

## 🧑‍🎨 Remarques

- J´ai modifié la configuration et Docker pour faire fonctionner le S3 en local
- J'ai ajouté une tonne de commentaires sur le serializer pour qu'on ait une chance de comprendre ce que ça fait
- `serializeObject` (téléchargement individuel d'une attestation) est inchangé — il continue d'utiliser l'API AcroForm de pdf-lib
- Le code est un gros tas de boue, j'ai fait quelques recherches et je pense que ça vaudrait le coup d'investiguer [cette lib](https://pdfme.com/), ça pourrait permettre de faire ce qu'on veut avec des fichiers JSON sans utiliser les formulaires

## 🥯 Pour tester

- [x] Se connecter sur Pix Orga en tant qu'admin
- [x] Aller sur la page de gestion des attestations
- [x] Sélectionner une ou plusieurs classes et télécharger les attestations
- [x] Vérifier que le fichier téléchargé est un PDF (et non un ZIP)
- [x] Vérifier que le PDF contient autant de pages que d'élèves sélectionnés
- [x] Vérifier que le PDF fait autour de 300 Ko
- [x] Vérifier que les noms, prénoms et dates sont correctement affichés et centrés sur chaque page
- [x] Vérifier que la génération des attestations fonctionne toujours correctement sur PixApp (user all-attestations@example.net)