### PR TITLE
[FEATURE] Voir l'entrée "réseaux" dans la navbar pix-admin (PIX-21299)

### DIFF
--- a/admin/app/components/layout/sidebar.gjs
+++ b/admin/app/components/layout/sidebar.gjs
@@ -38,6 +38,12 @@ export default class Sidebar extends Component {
           {{t "components.layout.sidebar.organizations"}}
         </PixNavigationButton>
 
+        {{#if this.currentUser.adminMember.isSuperAdmin}}
+          <PixNavigationButton class="sidebar__link" @route="authenticated.networks" @icon="accountTree">
+            {{t "components.layout.sidebar.networks"}}
+          </PixNavigationButton>
+        {{/if}}
+
         <PixNavigationButton class="sidebar__link" @route="authenticated.users" @icon="infoUser">
           {{t "components.layout.sidebar.users"}}
         </PixNavigationButton>

--- a/admin/app/router.js
+++ b/admin/app/router.js
@@ -56,6 +56,7 @@ Router.map(function () {
 
     this.route('networks', function () {
       this.route('new');
+      this.route('list');
     });
 
     this.route('campaigns', function () {

--- a/admin/app/routes/authenticated/networks/index.js
+++ b/admin/app/routes/authenticated/networks/index.js
@@ -1,0 +1,10 @@
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+export default class IndexRoute extends Route {
+  @service router;
+
+  beforeModel() {
+    this.router.transitionTo('authenticated.networks.list');
+  }
+}

--- a/admin/app/routes/authenticated/networks/list.js
+++ b/admin/app/routes/authenticated/networks/list.js
@@ -1,0 +1,10 @@
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+export default class ListRoute extends Route {
+  @service accessControl;
+
+  beforeModel() {
+    this.accessControl.restrictAccessTo(['isSuperAdmin'], 'authenticated');
+  }
+}

--- a/admin/app/templates/authenticated/networks/list.gjs
+++ b/admin/app/templates/authenticated/networks/list.gjs
@@ -1,0 +1,8 @@
+import pageTitle from 'ember-page-title/helpers/page-title';
+
+<template>
+  {{pageTitle "Réseaux"}}
+  <h1>
+    Tous les réseaux
+  </h1>
+</template>

--- a/admin/tests/integration/components/layout/sidebar_test.gjs
+++ b/admin/tests/integration/components/layout/sidebar_test.gjs
@@ -1,5 +1,6 @@
 import { render } from '@1024pix/ember-testing-library';
 import Service from '@ember/service';
+import { t } from 'ember-intl/test-support';
 import Sidebar from 'pix-admin/components/layout/sidebar';
 import { module, test } from 'qunit';
 
@@ -56,6 +57,34 @@ module('Integration | Component | Layout | Sidebar', function (hooks) {
 
     // then
     assert.dom(screen.getByRole('link', { name: 'Se déconnecter' })).exists();
+  });
+
+  module('Networks tab', function () {
+    module('When the user is a super admin', function () {
+      test('should display Networks menu', async function (assert) {
+        // given
+        currentUser.adminMember = { isSuperAdmin: true };
+
+        // when
+        const screen = await render(<template><Sidebar /></template>);
+
+        // then
+        assert.dom(screen.getByRole('link', { name: t('components.layout.sidebar.networks') })).exists();
+      });
+    });
+
+    module('When the user is not a super admin', function () {
+      test('should not display Networks menu', async function (assert) {
+        // given
+        currentUser.adminMember = { isSuperAdmin: false };
+
+        // when
+        const screen = await render(<template><Sidebar /></template>);
+
+        // then
+        assert.dom(screen.queryByRole('link', { name: t('components.layout.sidebar.networks') })).doesNotExist();
+      });
+    });
   });
 
   module('Target Profiles tab', function () {

--- a/admin/tests/unit/routes/networks/index-test.js
+++ b/admin/tests/unit/routes/networks/index-test.js
@@ -1,0 +1,21 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module('Unit | Route | authenticated/networks/index', function (hooks) {
+  setupTest(hooks);
+
+  module('#beforeModel', function () {
+    test('it should redirect to the networks list route', function (assert) {
+      // given
+      const route = this.owner.lookup('route:authenticated/networks/index');
+      const transitionToStub = sinon.stub(route.router, 'transitionTo').returns();
+
+      // when
+      route.beforeModel();
+
+      // then
+      assert.ok(transitionToStub.calledWith('authenticated.networks.list'));
+    });
+  });
+});

--- a/admin/tests/unit/routes/networks/list-test.js
+++ b/admin/tests/unit/routes/networks/list-test.js
@@ -1,0 +1,26 @@
+import Service from '@ember/service';
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module('Unit | Route | authenticated/networks/list', function (hooks) {
+  setupTest(hooks);
+
+  module('#beforeModel', function () {
+    test('it should check if current user is "SUPER_ADMIN"', function (assert) {
+      // given
+      const route = this.owner.lookup('route:authenticated/networks/list');
+      const restrictAccessToStub = sinon.stub().returns();
+      class AccessControlStub extends Service {
+        restrictAccessTo = restrictAccessToStub;
+      }
+      this.owner.register('service:access-control', AccessControlStub);
+
+      // when
+      route.beforeModel();
+
+      // then
+      assert.ok(restrictAccessToStub.calledWith(['isSuperAdmin'], 'authenticated'));
+    });
+  });
+});

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -596,6 +596,7 @@
           "open": "Open navigation"
         },
         "logout": "Log out",
+        "networks": "Networks",
         "organizations": "Organizations",
         "sessions": "Certification sessions",
         "target-profiles": "Target profiles",

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -598,6 +598,7 @@
           "open": "Ouvrir la navigation"
         },
         "logout": "Se déconnecter",
+        "networks": "Réseaux",
         "organizations": "Organisations",
         "sessions": "Sessions de certification",
         "target-profiles": "Profils cibles",


### PR DESCRIPTION
## 🥀 Problème

Dans le cadre de la mise enplace des réseaux, on doit pouvoir accéder à la page des réseaux en tant que super admin.

## 🏹 Proposition

- Ajouter un bouton "Réseaux" à la navbar
- Ajouter une page "Tous les réseaux"



## ❤️‍🔥 Pour tester
- Se connecter à pix-admin
- Constater le bouton dans la navbar et la page

<img width="585" height="849" alt="image" src="https://github.com/user-attachments/assets/80384e82-3579-412f-92d5-1f1344117a6c" />
<img width="585" height="350" alt="image" src="https://github.com/user-attachments/assets/ee06d393-113c-4462-84c4-ca9f3abc2e84" />

