### PR TITLE
[FEATURE] Gérer l'activation de l'import générique pour une orga depuis pix admin (PIX-21784)

### DIFF
--- a/admin/app/adapters/organization-learner-import-format.js
+++ b/admin/app/adapters/organization-learner-import-format.js
@@ -1,0 +1,5 @@
+import ApplicationAdapter from './application';
+
+export default class OrganizationLearnerImportFormat extends ApplicationAdapter {
+  namespace = 'api/admin';
+}

--- a/admin/app/components/organizations/information-section-edit.gjs
+++ b/admin/app/components/organizations/information-section-edit.gjs
@@ -1,6 +1,7 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixCheckbox from '@1024pix/pix-ui/components/pix-checkbox';
 import PixInput from '@1024pix/pix-ui/components/pix-input';
+import PixModal from '@1024pix/pix-ui/components/pix-modal';
 import PixSelect from '@1024pix/pix-ui/components/pix-select';
 import { concat, fn, get } from '@ember/helper';
 import { on } from '@ember/modifier';
@@ -29,10 +30,12 @@ export default class OrganizationInformationSectionEditionMode extends Component
   @tracked isEditMode = false;
   @tracked form = {};
   @tracked showArchivingConfirmationModal = false;
-  @tracked toggleLockPlaces = false;
   @tracked administrationTeams = [];
+  @tracked importFormats = [];
   @tracked organizationLearnerTypes = [];
   @tracked countries = [];
+  @tracked displayLearnerImportActivationDialog = false;
+  @tracked learnerImportActivationConfirmed = false;
 
   noIdentityProviderOption = { label: this.intl.t('common.words.none'), value: 'None' };
   garIdentityProviderOption = { label: 'GAR', value: 'GAR' };
@@ -43,13 +46,20 @@ export default class OrganizationInformationSectionEditionMode extends Component
     super(...arguments);
     this.#initForm();
     this.#loadAsyncData();
-    this.toggleLockPlaces = this.form.features['PLACES_MANAGEMENT']?.active ?? false;
   }
 
   async #loadAsyncData() {
     this.administrationTeams = await this.store.findAll('administration-team');
+    this.importFormats = await this.store.findAll('organization-learner-import-format');
     this.organizationLearnerTypes = await this.store.findAll('organization-learner-type');
     this.countries = await this.store.findAll('country');
+  }
+
+  get importFormatOptions() {
+    return this.importFormats.map((importFormats) => ({
+      value: importFormats.name,
+      label: importFormats.name,
+    }));
   }
 
   #initForm() {
@@ -129,10 +139,45 @@ export default class OrganizationInformationSectionEditionMode extends Component
 
   @action
   updateFormCheckBoxValue(key) {
-    if (key === 'features.PLACES_MANAGEMENT.active') {
-      this.toggleLockPlaces = !lodashGet(this.form, key);
+    if (key === 'features.LEARNER_IMPORT.active') {
+      this.form = lodashSet(
+        this.form,
+        'features.LEARNER_IMPORT',
+        this.form.features?.LEARNER_IMPORT?.active
+          ? {
+              active: false,
+            }
+          : {
+              active: true,
+              params: {
+                name: this.importFormatOptions[0].label,
+              },
+            },
+      );
+      if (this.form.features.LEARNER_IMPORT.active && !this.args.organization.features?.LEARNER_IMPORT?.active) {
+        this.displayLearnerImportActivationDialog = true;
+        this.learnerImportActivationConfirmed = false;
+      }
+    } else {
+      this.form = lodashSet(this.form, key, !lodashGet(this.form, key));
     }
-    lodashSet(this.form, key, !lodashGet(this.form, key));
+  }
+
+  @action
+  closeLearnerImportActivationDialog() {
+    this.displayLearnerImportActivationDialog = false;
+    this.updateFormCheckBoxValue('features.LEARNER_IMPORT.active');
+  }
+  @action
+  toggleConfirmLearnerImportActivation() {
+    this.learnerImportActivationConfirmed = !this.learnerImportActivationConfirmed;
+  }
+
+  @action
+  confirmLearnerImportActivation() {
+    if (this.learnerImportActivationConfirmed) {
+      this.displayLearnerImportActivationDialog = false;
+    }
   }
 
   @action
@@ -142,8 +187,9 @@ export default class OrganizationInformationSectionEditionMode extends Component
 
   @action
   updateValue(key, value) {
-    this.form = { ...this.form, [key]: value };
-    this.validator.validateField(key, this.form[key]);
+    this.form = lodashSet(this.form, key, value);
+    if (key.includes('.')) return;
+    this.validator.validateField(key, lodashGet(this.form, key));
   }
 
   @action
@@ -337,10 +383,11 @@ export default class OrganizationInformationSectionEditionMode extends Component
           @title={{t "components.organizations.creation.features"}}
         >
           <FeaturesForm
-            @features={{this.form.features}}
+            @form={{this.form}}
+            @importFormatOptions={{this.importFormatOptions}}
             @updateFormCheckBoxValue={{this.updateFormCheckBoxValue}}
+            @updateValue={{this.updateValue}}
             @isManagingStudentAvailable={{this.isManagingStudentAvailable}}
-            @toggleLockPlaces={{this.toggleLockPlaces}}
           />
         </Card>
 
@@ -380,6 +427,37 @@ export default class OrganizationInformationSectionEditionMode extends Component
         </PixButton>
       </section>
     </form>
+
+    <PixModal
+      @title={{t "components.organizations.editing.organization-learner-import-format.dialog.title"}}
+      @onCloseButtonClick={{this.closeLearnerImportActivationDialog}}
+      @showModal={{this.displayLearnerImportActivationDialog}}
+    >
+      <:content>
+        <p>
+          {{t "components.organizations.editing.organization-learner-import-format.dialog.message"}}
+        </p>
+        <p>
+          <PixCheckbox
+            @checked={{this.learnerImportActivationConfirmed}}
+            {{on "change" this.toggleConfirmLearnerImportActivation}}
+          ><:label>
+              <strong>
+                {{t "components.organizations.editing.organization-learner-import-format.dialog.confirmation"}}
+              </strong>
+            </:label>
+          </PixCheckbox>
+        </p>
+      </:content>
+      <:footer>
+        <PixButton @variant="secondary" @triggerAction={{this.closeLearnerImportActivationDialog}}>
+          {{t "common.actions.cancel"}}
+        </PixButton>
+        <PixButton @variant="error" @triggerAction={{this.confirmLearnerImportActivation}}>{{t
+            "common.actions.confirm"
+          }}</PixButton>
+      </:footer>
+    </PixModal>
   </template>
 }
 
@@ -390,18 +468,46 @@ function keys(obj) {
 const FeaturesForm = <template>
   {{#each (keys Organization.editableFeatureList) as |feature|}}
     {{#let
-      (get @features feature) (concat "components.organizations.information-section-view.features." feature)
+      (get @form.features feature) (concat "components.organizations.information-section-view.features." feature)
       as |organizationFeature featureLabel|
     }}
       {{#if (or @isManagingStudentAvailable (notEq feature "IS_MANAGING_STUDENTS"))}}
-        <div class="form-field">
-          <PixCheckbox
-            @checked={{organizationFeature.active}}
-            {{on "change" (fn @updateFormCheckBoxValue (concat "features." feature ".active"))}}
-          ><:label>{{t featureLabel}}</:label></PixCheckbox>
-        </div>
+        {{#if
+          (or
+            (notEq feature "LEARNER_IMPORT")
+            (and (eq feature "LEARNER_IMPORT") (notEq (get @importFormatOptions "length") 0))
+          )
+        }}
+          <div class="form-field">
+            <PixCheckbox
+              @checked={{organizationFeature.active}}
+              {{on "change" (fn @updateFormCheckBoxValue (concat "features." feature ".active"))}}
+            ><:label>{{t featureLabel}}</:label></PixCheckbox>
+            {{#if (and (eq feature "LEARNER_IMPORT") (get organizationFeature "active"))}}
+              <PixSelect
+                required
+                @aria-required={{true}}
+                @requiredLabel={{t "common.forms.mandatory"}}
+                @options={{@importFormatOptions}}
+                @value={{organizationFeature.params.name}}
+                @onChange={{fn @updateValue "features.LEARNER_IMPORT.params.name"}}
+                @hideDefaultOption={{true}}
+                @isFullWidth={{false}}
+                @placeholder={{t
+                  "components.organizations.editing.organization-learner-import-format.selector.placeholder"
+                }}
+              >
+
+                <:label>{{t
+                    "components.organizations.editing.organization-learner-import-format.selector.label"
+                  }}</:label>
+              </PixSelect>
+            {{/if}}
+          </div>
+        {{/if}}
       {{/if}}
-      {{#if (and (eq feature "PLACES_MANAGEMENT") @toggleLockPlaces)}}
+
+      {{#if (and (eq feature "PLACES_MANAGEMENT") (get organizationFeature "active"))}}
         <div class="form-field">
           <PixCheckbox
             @checked={{organizationFeature.params.enableMaximumPlacesLimit}}

--- a/admin/app/models/organization-learner-import-format.js
+++ b/admin/app/models/organization-learner-import-format.js
@@ -1,0 +1,5 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class OrganizationLearnerImportFormat extends Model {
+  @attr('string') name;
+}

--- a/admin/app/models/organization.js
+++ b/admin/app/models/organization.js
@@ -61,6 +61,7 @@ export default class Organization extends Model {
       'CAMPAIGN_WITHOUT_USER_PROFILE',
       'SHOW_SKILLS',
       'PLACES_MANAGEMENT',
+      'LEARNER_IMPORT',
     );
   }
 

--- a/admin/tests/integration/components/organizations/information-section-edit-test.gjs
+++ b/admin/tests/integration/components/organizations/information-section-edit-test.gjs
@@ -1,8 +1,7 @@
-import { fillByLabel, render, within } from '@1024pix/ember-testing-library';
+import { fillByLabel, render, waitForElementToBeRemoved, within } from '@1024pix/ember-testing-library';
 import EmberObject from '@ember/object';
 import Service from '@ember/service';
-import { click } from '@ember/test-helpers';
-import { fillIn } from '@ember/test-helpers';
+import { click, fillIn } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import InformationSectionEdit from 'pix-admin/components/organizations/information-section-edit';
 import { module, test } from 'qunit';
@@ -12,9 +11,10 @@ import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | organizations/information-section-edit', function (hooks) {
   setupIntlRenderingTest(hooks);
+  let findAllStub, store;
   hooks.beforeEach(function () {
-    const store = this.owner.lookup('service:store');
-    const findAllStub = sinon.stub(store, 'findAll');
+    store = this.owner.lookup('service:store');
+    findAllStub = sinon.stub(store, 'findAll');
 
     findAllStub
       .withArgs('administration-team')
@@ -35,6 +35,12 @@ module('Integration | Component | organizations/information-section-edit', funct
       .resolves([
         store.createRecord('organization-learner-type', { id: '789', name: 'Student' }),
         store.createRecord('organization-learner-type', { id: '987', name: 'Teacher' }),
+      ]);
+    findAllStub
+      .withArgs('organization-learner-import-format')
+      .resolves([
+        store.createRecord('organization-learner-import-format', { id: '123', name: 'GENERIC' }),
+        store.createRecord('organization-learner-import-format', { id: '456', name: 'ONDE' }),
       ]);
   });
 
@@ -664,71 +670,288 @@ module('Integration | Component | organizations/information-section-edit', funct
       );
     });
   });
-});
 
-module('Rendering', function (hooks) {
-  setupIntlRenderingTest(hooks);
-  hooks.beforeEach(function () {
-    const store = this.owner.lookup('service:store');
-    const findAllStub = sinon.stub(store, 'findAll');
+  module('Features', function () {
+    module('when Learner Import is not selected', function () {
+      test('it should hide IS_MANAGING_STUDENTS feature for non SCO organization', async function (assert) {
+        const organization = EmberObject.create({
+          id: 1,
+          name: 'Organization',
+          externalId: 'VELIT',
+          provinceCode: 'h50',
+          email: 'generic.account@example.net',
+          isOrganizationSCO: false,
+          isLearnerImportEnabled: true,
+          credit: 0,
+          documentationUrl: 'https://pix.fr/',
+          features: {},
+          administrationTeamId: 123,
+          countryCode: 99100,
+        });
+        //when
+        const screen = await render(<template><InformationSectionEdit @organization={{organization}} /></template>);
+        assert.notOk(
+          screen.queryByRole('checkbox', {
+            name: `${t('components.organizations.information-section-view.features.IS_MANAGING_STUDENTS')}`,
+          }),
+        );
+      });
+      test('it should hide LEARNER IMPORT feature when there is no import format available', async function (assert) {
+        findAllStub.withArgs('organization-learner-import-format').resolves([]);
+        const organization = EmberObject.create({
+          id: 1,
+          name: 'Organization',
+          externalId: 'VELIT',
+          provinceCode: 'h50',
+          email: 'generic.account@example.net',
+          isOrganizationSCO: false,
+          credit: 0,
+          documentationUrl: 'https://pix.fr/',
+          features: {},
+          administrationTeamId: 123,
+          countryCode: 99100,
+        });
+        //when
+        const screen = await render(<template><InformationSectionEdit @organization={{organization}} /></template>);
+        assert.notOk(
+          screen.queryByRole('checkbox', {
+            name: `${t('components.organizations.information-section-view.features.LEARNER_IMPORT')}`,
+          }),
+        );
+      });
+      test('should display a modal when user activate learner import', async function (assert) {
+        // given
+        const organization = EmberObject.create({
+          id: 1,
+          name: 'Organization',
+          externalId: 'VELIT',
+          provinceCode: 'h50',
+          email: 'generic.account@example.net',
+          isOrganizationSCO: false,
+          credit: 0,
+          documentationUrl: 'https://pix.fr/',
+          features: {},
+          administrationTeamId: 123,
+          countryCode: 99100,
+        });
 
-    findAllStub
-      .withArgs('administration-team')
-      .resolves([
-        store.createRecord('administration-team', { id: '123', name: 'Équipe 1' }),
-        store.createRecord('administration-team', { id: '456', name: 'Équipe 2' }),
-      ]);
+        //when
+        const screen = await render(<template><InformationSectionEdit @organization={{organization}} /></template>);
+        await click(
+          screen.getByRole('checkbox', {
+            name: `${t('components.organizations.information-section-view.features.LEARNER_IMPORT')}`,
+          }),
+        );
+        const modale = await screen.findByRole('dialog');
 
-    findAllStub
-      .withArgs('country')
-      .resolves([
-        store.createRecord('country', { code: '99101', name: 'Danemark' }),
-        store.createRecord('country', { code: '99100', name: 'France' }),
-      ]);
+        assert.ok(
+          within(modale).getByRole('heading', {
+            level: 1,
+            name: t('components.organizations.editing.organization-learner-import-format.dialog.title'),
+          }),
+        );
+      });
 
-    findAllStub
-      .withArgs('organization-learner-type')
-      .resolves([
-        store.createRecord('organization-learner-type', { id: '789', name: 'Student' }),
-        store.createRecord('organization-learner-type', { id: '987', name: 'Teacher' }),
-      ]);
+      test('should unchecked import feature when user close dialog', async function (assert) {
+        // given
+        const organization = EmberObject.create({
+          id: 1,
+          name: 'Organization',
+          externalId: 'VELIT',
+          provinceCode: 'h50',
+          email: 'generic.account@example.net',
+          isOrganizationSCO: false,
+          credit: 0,
+          documentationUrl: 'https://pix.fr/',
+          features: {},
+          administrationTeamId: 123,
+          countryCode: 99100,
+        });
 
-    class AccessControlStub extends Service {
-      hasAccessToOrganizationActionsScope = true;
-    }
-    this.owner.register('service:access-control', AccessControlStub);
-  });
+        //when
+        const screen = await render(<template><InformationSectionEdit @organization={{organization}} /></template>);
+        await click(
+          screen.getByRole('checkbox', {
+            name: `${t('components.organizations.information-section-view.features.LEARNER_IMPORT')}`,
+          }),
+        );
+        const modale = await screen.findByRole('dialog');
+        // await this.pauseTest();
+        await click(within(modale).getByRole('button', { name: t('common.actions.close') }));
+        // await this.pauseTest();
+        await waitForElementToBeRemoved(() => screen.queryByRole('dialog'));
+        assert.ok(
+          screen.getByRole('checkbox', {
+            checked: false,
+            name: `${t('components.organizations.information-section-view.features.LEARNER_IMPORT')}`,
+          }),
+        );
+      });
 
-  test('it should render the organization edit form with all sections', async function (assert) {
-    // given
-    const organization = EmberObject.create({
-      id: 1,
-      name: 'Organization SCO',
-      externalId: 'VELIT',
-      provinceCode: 'h50',
-      email: 'sco.generic.account@example.net',
-      administrationTeamId: '123',
-      isOrganizationSCO: true,
-      credit: 0,
-      documentationUrl: 'https://pix.fr/',
-      features: {},
+      test('should close dialog feature and leave import feature active', async function (assert) {
+        // given
+        const organization = EmberObject.create({
+          id: 1,
+          name: 'Organization',
+          externalId: 'VELIT',
+          provinceCode: 'h50',
+          email: 'generic.account@example.net',
+          isOrganizationSCO: false,
+          credit: 0,
+          documentationUrl: 'https://pix.fr/',
+          features: {},
+          administrationTeamId: 123,
+          countryCode: 99100,
+        });
+
+        //when
+        const screen = await render(<template><InformationSectionEdit @organization={{organization}} /></template>);
+        await click(
+          screen.getByRole('checkbox', {
+            name: `${t('components.organizations.information-section-view.features.LEARNER_IMPORT')}`,
+          }),
+        );
+        const modale = await screen.findByRole('dialog');
+        await click(
+          within(modale).getByRole('checkbox', {
+            name: t('components.organizations.editing.organization-learner-import-format.dialog.confirmation'),
+          }),
+        );
+        await click(within(modale).getByRole('button', { name: t('common.actions.confirm') }));
+        await waitForElementToBeRemoved(() => screen.queryByRole('dialog'));
+        assert.ok(
+          screen.getByRole('checkbox', {
+            checked: true,
+            name: `${t('components.organizations.information-section-view.features.LEARNER_IMPORT')}`,
+          }),
+        );
+      });
     });
 
-    // when
-    const screen = await render(<template><InformationSectionEdit @organization={{organization}} /></template>);
+    module('when Learner Import is active', function () {
+      test('it should hide IS_MANAGING_STUDENTS feature for SCO organization', async function (assert) {
+        const organization = EmberObject.create({
+          id: 1,
+          name: 'Organization',
+          externalId: 'VELIT',
+          provinceCode: 'h50',
+          email: 'generic.account@example.net',
+          isOrganizationSCO: true,
+          isLearnerImportEnabled: true,
+          credit: 0,
+          documentationUrl: 'https://pix.fr/',
+          features: { LEARNER_IMPORT: { active: true, params: { name: 'GENERIC' } } },
+          administrationTeamId: 123,
+          countryCode: 99100,
+        });
+        //when
+        const screen = await render(<template><InformationSectionEdit @organization={{organization}} /></template>);
+        assert.notOk(
+          screen.queryByRole('checkbox', {
+            name: `${t('components.organizations.information-section-view.features.IS_MANAGING_STUDENTS')}`,
+          }),
+        );
+      });
+      test('it should display selected import format', async function (assert) {
+        // given
+        const organization = EmberObject.create({
+          id: 1,
+          name: 'Organization',
+          externalId: 'VELIT',
+          provinceCode: 'h50',
+          email: 'generic.account@example.net',
+          isOrganizationSCO: false,
+          isLearnerImportEnabled: true,
+          credit: 0,
+          documentationUrl: 'https://pix.fr/',
+          features: { LEARNER_IMPORT: { active: true, params: { name: 'ONDE' } } },
+          administrationTeamId: 123,
+          countryCode: 99100,
+        });
 
-    // then
-    assert.dom(screen.getByText(t('components.organizations.creation.general-information'))).exists();
-    assert.dom(screen.getByText(t('components.organizations.creation.configuration'))).exists();
-    assert.dom(screen.getByText(t('components.organizations.creation.features'))).exists();
-    assert
-      .dom(
-        screen.getByText(
-          `${t('components.organizations.creation.dpo.definition')} (${t('components.organizations.creation.dpo.acronym')})`,
-        ),
-      )
-      .exists();
-    assert.dom(screen.getByRole('button', { name: t('common.actions.save') })).exists();
-    assert.dom(screen.getByRole('button', { name: t('common.actions.cancel') })).exists();
+        //when
+        const screen = await render(<template><InformationSectionEdit @organization={{organization}} /></template>);
+        assert.ok(
+          screen.getByRole('checkbox', {
+            checked: true,
+            name: `${t('components.organizations.information-section-view.features.LEARNER_IMPORT')}`,
+          }),
+        );
+        const select = screen.getByRole('button', { name: /Format d'import/ });
+        assert.ok(within(select).getByText('ONDE'));
+      });
+      test('it should hide the select import format', async function (assert) {
+        // given
+        const organization = EmberObject.create({
+          id: 1,
+          name: 'Organization',
+          externalId: 'VELIT',
+          provinceCode: 'h50',
+          email: 'generic.account@example.net',
+          isOrganizationSCO: false,
+          credit: 0,
+          documentationUrl: 'https://pix.fr/',
+          features: { LEARNER_IMPORT: { active: true, params: { name: 'ONDE' } } },
+          administrationTeamId: 123,
+          countryCode: 99100,
+        });
+
+        //when
+        const screen = await render(<template><InformationSectionEdit @organization={{organization}} /></template>);
+        await click(
+          screen.getByRole('checkbox', {
+            checked: true,
+            name: `${t('components.organizations.information-section-view.features.LEARNER_IMPORT')}`,
+          }),
+        );
+        assert.notOk(
+          screen.queryByLabelText(
+            t('components.organizations.editing.organization-learner-import-format.selector.label'),
+          ),
+        );
+      });
+    });
+  });
+
+  module('Rendering', function (hooks) {
+    hooks.beforeEach(function () {
+      class AccessControlStub extends Service {
+        hasAccessToOrganizationActionsScope = true;
+      }
+      this.owner.register('service:access-control', AccessControlStub);
+    });
+
+    test('it should render the organization edit form with all sections', async function (assert) {
+      // given
+      const organization = EmberObject.create({
+        id: 1,
+        name: 'Organization SCO',
+        externalId: 'VELIT',
+        provinceCode: 'h50',
+        email: 'sco.generic.account@example.net',
+        administrationTeamId: '123',
+        isOrganizationSCO: true,
+        credit: 0,
+        documentationUrl: 'https://pix.fr/',
+        features: {},
+      });
+
+      // when
+      const screen = await render(<template><InformationSectionEdit @organization={{organization}} /></template>);
+
+      // then
+      assert.dom(screen.getByText(t('components.organizations.creation.general-information'))).exists();
+      assert.dom(screen.getByText(t('components.organizations.creation.configuration'))).exists();
+      assert.dom(screen.getByText(t('components.organizations.creation.features'))).exists();
+      assert
+        .dom(
+          screen.getByText(
+            `${t('components.organizations.creation.dpo.definition')} (${t('components.organizations.creation.dpo.acronym')})`,
+          ),
+        )
+        .exists();
+      assert.dom(screen.getByRole('button', { name: t('common.actions.save') })).exists();
+      assert.dom(screen.getByRole('button', { name: t('common.actions.cancel') })).exists();
+    });
   });
 });

--- a/admin/tests/integration/components/organizations/information-section-test.gjs
+++ b/admin/tests/integration/components/organizations/information-section-test.gjs
@@ -41,6 +41,13 @@ module('Integration | Component | organizations/information-section', function (
         store.createRecord('organization-learner-type', { id: '789', name: 'Student' }),
         store.createRecord('organization-learner-type', { id: '987', name: 'Teacher' }),
       ]);
+
+    findAllStub
+      .withArgs('organization-learner-import-format')
+      .resolves([
+        store.createRecord('organization-learner-import-format', { id: '123', name: 'GENERIC' }),
+        store.createRecord('organization-learner-import-format', { id: '456', name: 'ONDE' }),
+      ]);
   });
 
   module('when editing organization', function () {

--- a/admin/tests/mirage/models.js
+++ b/admin/tests/mirage/models.js
@@ -47,6 +47,7 @@ import oidcIdentityProvider from './models/oidc-identity-provider';
 import organization from './models/organization';
 import organizationInvitation from './models/organization-invitation';
 import organizationLearner from './models/organization-learner';
+import organizationLearnerImportFormat from './models/organization-learner-import-format';
 import organizationMembership from './models/organization-membership';
 import organizationPlace from './models/organization-place';
 import profile from './models/profile';
@@ -121,6 +122,7 @@ export default {
   organization,
   organizationInvitation,
   organizationLearner,
+  organizationLearnerImportFormat,
   organizationMembership,
   organizationPlace,
   profile,

--- a/admin/tests/mirage/models/organization-learner-import-format.js
+++ b/admin/tests/mirage/models/organization-learner-import-format.js
@@ -1,0 +1,3 @@
+import { Model } from 'miragejs';
+
+export default Model.extend();

--- a/admin/tests/mirage/routes.js
+++ b/admin/tests/mirage/routes.js
@@ -741,7 +741,7 @@ export default function routes() {
       ],
     };
   });
-
+  this.get('/admin/organization-learner-import-formats');
   this.get('/admin/combined-course-blueprints');
   this.post('/admin/combined-course-blueprints');
   this.post(

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -780,6 +780,18 @@
         "name": {
           "label": "Name"
         },
+        "organization-learner-import-format": {
+          "dialog": {
+            "confirm-label": "Yes, I confirm.",
+            "confirmation": "By ticking this box, you confirm that you have the rights and authorisation from the organisation to carry out this action.",
+            "message": "You are about to activate generic import for this organisation. If the organisation already has prescriptions, they will all be deleted. This deletion cannot be undone.",
+            "title": "Enabling generic import"
+          },
+          "selector": {
+            "label": "Import format",
+            "placeholder": "Select an import format"
+          }
+        },
         "organization-learner-type": {
           "selector": {
             "error-message": "Organization learner type is required",

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -782,6 +782,18 @@
         "name": {
           "label": "Nom"
         },
+        "organization-learner-import-format": {
+          "dialog": {
+            "confirm-label": "Oui, je confirme",
+            "confirmation": "En cochant cette case vous affirmez avoir les droits et l’autorisation de l’organisation pour effectuer cette action",
+            "message": "Vous êtes sur le point d’activer l’import générique pour cette organisation. Si l’organisation a déjà des prescrits, ceux-ci seront tous supprimés. Cette suppression est irréversible.",
+            "title": "Activation de l'import générique"
+          },
+          "selector": {
+            "label": "Format d'import",
+            "placeholder": "Sélectionner un format d'import"
+          }
+        },
         "organization-learner-type": {
           "selector": {
             "error-message": "Le public prescrit est requis",
@@ -835,7 +847,7 @@
           "CAMPAIGN_WITHOUT_USER_PROFILE": "Mode interro (nom non définitif)",
           "COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY": "Certificabilité automatique",
           "IS_MANAGING_STUDENTS": "Gestion d'élèves/étudiants",
-          "LEARNER_IMPORT": "Import",
+          "LEARNER_IMPORT": "Import générique",
           "MULTIPLE_SENDING_ASSESSMENT": "Envoi multiple sur les campagnes d'évaluation",
           "ORGANIZATION_PLACES_LIMIT": {
             "disabled": "Sans blocage automatique",

--- a/api/src/organizational-entities/application/organization/organization.admin.controller.js
+++ b/api/src/organizational-entities/application/organization/organization.admin.controller.js
@@ -159,8 +159,9 @@ const updateOrganizationInformation = async function (
   },
 ) {
   const organizationDeserialized = dependencies.organizationForAdminSerializer.deserialize(request.payload);
-
+  const { userId } = request.auth.credentials;
   const organizationUpdated = await usecases.updateOrganizationInformation({
+    userId,
     organization: organizationDeserialized,
   });
   return h.response(dependencies.organizationForAdminSerializer.serialize(organizationUpdated));

--- a/api/src/organizational-entities/domain/models/OrganizationForAdmin.js
+++ b/api/src/organizational-entities/domain/models/OrganizationForAdmin.js
@@ -17,6 +17,7 @@ const schema = Joi.object({
 
 class OrganizationForAdmin {
   #provinceCode;
+  shouldDeletePreviousLearners = false;
 
   constructor({
     id,
@@ -227,32 +228,38 @@ class OrganizationForAdmin {
       : features[ORGANIZATION_FEATURE.IS_MANAGING_STUDENTS.key].active;
   }
 
-  updateWithDataProtectionOfficerAndTags(organization, dataProtectionOfficer = {}, tags = []) {
+  updateWithDataProtectionOfficerAndTags(newOrganization, dataProtectionOfficer = {}, tags = []) {
     const isAEFE = Boolean(tags.find((tag) => tag.name === 'AEFE'));
 
-    if (organization.name) this.name = organization.name;
-    if (organization.type) this.type = organization.type;
-    if (organization.logoUrl) this.logoUrl = organization.logoUrl;
-    this.email = isEmpty(organization.email) ? null : organization.email;
-    this.credit = organization.credit;
-    this.externalId = organization.externalId;
-    this.provinceCode = organization.provinceCode;
-    this.documentationUrl = isEmpty(organization.documentationUrl) ? null : organization.documentationUrl;
-    this.updateIsManagingStudents(organization.features);
-    this.showSkills = organization.features[ORGANIZATION_FEATURE.SHOW_SKILLS.key].active;
-    this.identityProviderForCampaigns = organization.identityProviderForCampaigns;
+    if (newOrganization.name) this.name = newOrganization.name;
+    if (newOrganization.type) this.type = newOrganization.type;
+    if (newOrganization.logoUrl) this.logoUrl = newOrganization.logoUrl;
+    this.email = isEmpty(newOrganization.email) ? null : newOrganization.email;
+    this.credit = newOrganization.credit;
+    this.externalId = newOrganization.externalId;
+    this.provinceCode = newOrganization.provinceCode;
+    this.documentationUrl = isEmpty(newOrganization.documentationUrl) ? null : newOrganization.documentationUrl;
+    this.updateIsManagingStudents(newOrganization.features);
+    this.showSkills = newOrganization.features[ORGANIZATION_FEATURE.SHOW_SKILLS.key].active;
+    this.identityProviderForCampaigns = newOrganization.identityProviderForCampaigns;
     this.dataProtectionOfficer.updateInformation(dataProtectionOfficer);
-    this.features = organization.features;
+    if (
+      !this.features[ORGANIZATION_FEATURE.LEARNER_IMPORT.key]?.active &&
+      newOrganization.features[ORGANIZATION_FEATURE.LEARNER_IMPORT.key]?.active
+    ) {
+      this.shouldDeletePreviousLearners = true;
+    }
+    this.features = newOrganization.features;
     this.features[ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key] = {
       active: this.type === 'SCO' && (this.isManagingStudents || isAEFE),
       params: null,
     };
     this.tagsToAdd = differenceBy(tags, this.tags, 'id').map(({ id }) => ({ tagId: id, organizationId: this.id }));
     this.tagsToRemove = differenceBy(this.tags, tags, 'id').map(({ id }) => ({ tagId: id, organizationId: this.id }));
-    if (organization.administrationTeamId) this.administrationTeamId = organization.administrationTeamId;
-    if (organization.countryCode) this.countryCode = organization.countryCode;
-    if (organization.organizationLearnerType.id) {
-      this.organizationLearnerType = organization.organizationLearnerType;
+    if (newOrganization.administrationTeamId) this.administrationTeamId = newOrganization.administrationTeamId;
+    if (newOrganization.countryCode) this.countryCode = newOrganization.countryCode;
+    if (newOrganization.organizationLearnerType.id) {
+      this.organizationLearnerType = newOrganization.organizationLearnerType;
     }
   }
 

--- a/api/src/organizational-entities/domain/usecases/update-organization-information.usecase.js
+++ b/api/src/organizational-entities/domain/usecases/update-organization-information.usecase.js
@@ -1,6 +1,7 @@
 import { withTransaction } from '../../../shared/domain/DomainTransaction.js';
 
 const updateOrganizationInformation = withTransaction(async function ({
+  userId,
   organization,
   organizationForAdminRepository,
   tagRepository,
@@ -8,6 +9,7 @@ const updateOrganizationInformation = withTransaction(async function ({
   organizationLearnerTypeRepository,
   organizationVerificationService,
   countryRepository,
+  learnersApi,
 }) {
   const existingOrganization = await organizationForAdminRepository.get({
     organizationId: organization.id,
@@ -38,6 +40,10 @@ const updateOrganizationInformation = withTransaction(async function ({
     organization.dataProtectionOfficer,
     tagsToUpdate,
   );
+
+  if (existingOrganization.shouldDeletePreviousLearners) {
+    await learnersApi.deleteOrganizationLearnerBeforeImportFeature({ userId, organizationId: organization.id });
+  }
 
   await organizationForAdminRepository.update({
     organization: existingOrganization,

--- a/api/src/prescription/learner-management/application/organization-import-controller.js
+++ b/api/src/prescription/learner-management/application/organization-import-controller.js
@@ -1,5 +1,6 @@
 import { usecases } from '../domain/usecases/index.js';
 import * as organizationImportDetailSerializer from '../infrastructure/serializers/jsonapi/organization-import-detail-serializer.js';
+import * as organizationLearnerImportFormatSerializer from '../infrastructure/serializers/jsonapi/organization-learner-import-format-serializer.js';
 
 const getOrganizationImportStatus = async function (request, h, dependencies = { organizationImportDetailSerializer }) {
   const { organizationId } = request.params;
@@ -17,6 +18,19 @@ const saveOrganizationLearnerImportFormats = async function (request) {
   return null;
 };
 
-const organizationImportController = { getOrganizationImportStatus, saveOrganizationLearnerImportFormats };
+const findAllOrganizationLearnerImportFormats = async (
+  request,
+  h,
+  dependencies = { organizationLearnerImportFormatSerializer },
+) => {
+  const results = await usecases.findAllOrganizationLearnerImportFormats();
+  return h.response(dependencies.organizationLearnerImportFormatSerializer.serialize(results)).code(200);
+};
+
+const organizationImportController = {
+  getOrganizationImportStatus,
+  saveOrganizationLearnerImportFormats,
+  findAllOrganizationLearnerImportFormats,
+};
 
 export { organizationImportController };

--- a/api/src/prescription/learner-management/application/organization-import-route.js
+++ b/api/src/prescription/learner-management/application/organization-import-route.js
@@ -41,20 +41,13 @@ const register = async (server) => {
         tags: ['api', 'organization-imports'],
       },
     },
-  ]);
-
-  server.route([
     {
       method: 'POST',
-      path: '/api/admin/import-organization-learners-format',
+      path: '/api/admin/organization-learner-import-formats',
       config: {
         pre: [
           {
-            method: (request, h) =>
-              securityPreHandlers.hasAtLeastOneAccessOf([securityPreHandlers.checkAdminMemberHasRoleSuperAdmin])(
-                request,
-                h,
-              ),
+            method: securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
             assign: 'hasAuthorizationToAccessAdminScope',
           },
         ],
@@ -76,6 +69,29 @@ const register = async (server) => {
             "- Elle permet d'ajouter/modifier des imports à format.",
         ],
         tags: ['api', 'organization-learners'],
+      },
+    },
+    {
+      method: 'GET',
+      path: '/api/admin/organization-learner-import-formats',
+      config: {
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.hasAtLeastOneAccessOf([
+                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+                securityPreHandlers.checkAdminMemberHasRoleSupport,
+                securityPreHandlers.checkAdminMemberHasRoleMetier,
+              ])(request, h),
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        handler: organizationImportController.findAllOrganizationLearnerImportFormats,
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés en tant que superadmin, support ou métier**\n' +
+            "- Elle permet de récupérer la liste des formats d'import.",
+        ],
+        tags: ['api', 'admin', 'organization-learner-import-format'],
       },
     },
   ]);

--- a/api/src/prescription/learner-management/domain/models/OrganizationLearnerImportFormat.js
+++ b/api/src/prescription/learner-management/domain/models/OrganizationLearnerImportFormat.js
@@ -3,6 +3,7 @@ import Joi from 'joi';
 import { EntityValidationError } from '../../../../shared/domain/errors.js';
 
 const organizationLearnerImportFormatSchame = Joi.object({
+  id: Joi.number(),
   name: Joi.string().required(),
   config: Joi.object().required(),
   fileType: Joi.string().valid('csv', 'xml'),
@@ -18,7 +19,8 @@ class OrganizationLearnerImportFormat {
    * @param {Object} data.createdAt
    * @param {Object} data.createdBy
    */
-  constructor({ name, fileType, config, createdAt, createdBy } = {}) {
+  constructor({ id, name, fileType, config, createdAt, createdBy } = {}) {
+    this.id = id;
     this.name = name;
     this.fileType = fileType;
     this.config = config;

--- a/api/src/prescription/learner-management/domain/usecases/find-all-organization-learner-import-format.js
+++ b/api/src/prescription/learner-management/domain/usecases/find-all-organization-learner-import-format.js
@@ -1,0 +1,4 @@
+const findAllOrganizationLearnerImportFormats = async ({ organizationLearnerImportFormatRepository }) =>
+  organizationLearnerImportFormatRepository.findAll();
+
+export { findAllOrganizationLearnerImportFormats };

--- a/api/src/prescription/learner-management/domain/usecases/index.js
+++ b/api/src/prescription/learner-management/domain/usecases/index.js
@@ -77,6 +77,7 @@ import { anonymizeUser } from './anonymize-user.js';
 import { computeOrganizationLearnerCertificability } from './compute-organization-learner-certificability.js';
 import { deleteOrganizationLearners } from './delete-organization-learners.js';
 import { dissociateUserFromOrganizationLearner } from './dissociate-user-from-organization-learner.js';
+import { findAllOrganizationLearnerImportFormats } from './find-all-organization-learner-import-format.js';
 import { findOrganizationLearnersBeforeImportFeature } from './find-organization-learners-before-import-feature.js';
 import { getDeltaOrganizationLearnerIds } from './get-delta-organization-learner-ids.js';
 import { getOrganizationImport } from './get-organization-import.js';
@@ -110,6 +111,7 @@ const usecasesWithoutInjectedDependencies = {
   computeOrganizationLearnerCertificability,
   deleteOrganizationLearners,
   dissociateUserFromOrganizationLearner,
+  findAllOrganizationLearnerImportFormats,
   findOrganizationLearnersBeforeImportFeature,
   getDeltaOrganizationLearnerIds,
   getOrganizationImportStatus,

--- a/api/src/prescription/learner-management/infrastructure/repositories/organization-learner-import-format-repository.js
+++ b/api/src/prescription/learner-management/infrastructure/repositories/organization-learner-import-format-repository.js
@@ -30,6 +30,12 @@ const get = async function (organizationId) {
   return _toDomain(result);
 };
 
+const findAll = async function () {
+  const knex = DomainTransaction.getConnection();
+  const results = await knex('organization-learner-import-formats');
+  return results.map(_toDomain);
+};
+
 /**
  * @type {function}
  * @param {Object} params
@@ -48,4 +54,4 @@ const save = async function ({ organizationLearnerImportFormats }) {
   }
 };
 
-export { get, save };
+export { findAll, get, save };

--- a/api/src/prescription/learner-management/infrastructure/serializers/jsonapi/organization-learner-import-format-serializer.js
+++ b/api/src/prescription/learner-management/infrastructure/serializers/jsonapi/organization-learner-import-format-serializer.js
@@ -1,0 +1,12 @@
+import jsonapiSerializer from 'jsonapi-serializer';
+
+const { Serializer } = jsonapiSerializer;
+
+const serialize = function (organizationLearnerImportFormat, meta) {
+  return new Serializer('organization-learner-import-format', {
+    attributes: ['name', 'fileType', 'config'],
+    meta,
+  }).serialize(organizationLearnerImportFormat);
+};
+
+export { serialize };

--- a/api/tests/organizational-entities/integration/application/organization-administration.controller.test.js
+++ b/api/tests/organizational-entities/integration/application/organization-administration.controller.test.js
@@ -7,10 +7,11 @@ describe('Integration | Organizational Entities | Application | Controller | Org
   let organization;
   let featureId;
   let administrationTeamId;
+  let adminUserId;
 
   beforeEach(async function () {
+    adminUserId = databaseBuilder.factory.buildUser().id;
     administrationTeamId = databaseBuilder.factory.buildAdministrationTeam().id;
-
     organization = databaseBuilder.factory.buildOrganization({
       name: 'organization name',
       type: 'SCO',
@@ -35,6 +36,7 @@ describe('Integration | Organizational Entities | Application | Controller | Org
     it('return updated basic organization information', async function () {
       //given && when
       const request = {
+        auth: { credentials: { userId: adminUserId } },
         payload: {
           data: {
             id: organization.id,
@@ -93,6 +95,7 @@ describe('Integration | Organizational Entities | Application | Controller | Org
 
     // when
     const request = {
+      auth: { credentials: { userId: adminUserId } },
       payload: {
         data: {
           id: organization.id,
@@ -131,6 +134,7 @@ describe('Integration | Organizational Entities | Application | Controller | Org
 
     // when
     const request = {
+      auth: { credentials: { userId: adminUserId } },
       payload: {
         data: {
           id: organization.id,
@@ -159,6 +163,7 @@ describe('Integration | Organizational Entities | Application | Controller | Org
   it('return activated feature sending multiple assessment of organization', async function () {
     // given && when
     const request = {
+      auth: { credentials: { userId: adminUserId } },
       payload: {
         data: {
           id: organization.id,
@@ -193,6 +198,7 @@ describe('Integration | Organizational Entities | Application | Controller | Org
 
     // when
     const request = {
+      auth: { credentials: { userId: adminUserId } },
       payload: {
         data: {
           id: organization.id,

--- a/api/tests/organizational-entities/integration/domain/usecases/update-organization-information.usecase_test.js
+++ b/api/tests/organizational-entities/integration/domain/usecases/update-organization-information.usecase_test.js
@@ -5,16 +5,21 @@ import {
 } from '../../../../../src/organizational-entities/domain/errors.js';
 import { OrganizationForAdmin } from '../../../../../src/organizational-entities/domain/models/OrganizationForAdmin.js';
 import { usecases } from '../../../../../src/organizational-entities/domain/usecases/index.js';
+import { ORGANIZATION_FEATURE } from '../../../../../src/shared/domain/constants.js';
 import {
   catchErr,
   databaseBuilder,
   domainBuilder,
   expect,
+  insertLearnerImportFeatureForNewOrganization,
   insertMultipleSendingFeatureForNewOrganization,
+  knex,
 } from '../../../../test-helper.js';
 
 describe('Integration | Organizational Entities | Domain | UseCases | update-organization', function () {
+  let adminUserId;
   beforeEach(async function () {
+    adminUserId = databaseBuilder.factory.buildUser().id;
     await insertMultipleSendingFeatureForNewOrganization();
   });
 
@@ -50,6 +55,7 @@ describe('Integration | Organizational Entities | Domain | UseCases | update-org
 
     // when
     const updatedOrganization = await usecases.updateOrganizationInformation({
+      userId: adminUserId,
       organization: organizationNewInformation,
     });
 
@@ -59,6 +65,60 @@ describe('Integration | Organizational Entities | Domain | UseCases | update-org
     expect(updatedOrganization.administrationTeamId).to.equal(newAdministrationTeamId);
     expect(updatedOrganization.countryCode).to.equal(99102);
     expect(updatedOrganization.organizationLearnerType.name).to.equal(newOrganizationLearnerType.name);
+  });
+
+  context('features', function () {
+    let organizationId;
+    beforeEach(async function () {
+      await insertLearnerImportFeatureForNewOrganization();
+      organizationId = databaseBuilder.factory.buildOrganization().id;
+
+      await databaseBuilder.commit();
+    });
+    context('Activating learner import format', function () {
+      it('should delete previous organization learners', async function () {
+        const learnerFromOrganization = databaseBuilder.factory.buildOrganizationLearner({ organizationId });
+        const learnerFromOtherOrganization = databaseBuilder.factory.buildOrganizationLearner();
+        const newAdministrationTeamId = databaseBuilder.factory.buildAdministrationTeam().id;
+
+        const newOrganizationLearnerType = databaseBuilder.factory.buildOrganizationLearnerType({
+          id: 1,
+          name: 'New Type',
+        });
+
+        const newCountry = databaseBuilder.factory.buildCertificationCpfCountry({
+          code: 99102,
+          originalName: 'Islande',
+          commonName: 'Islande',
+        });
+        await databaseBuilder.commit();
+
+        const organizationNewInformation = domainBuilder.buildOrganizationForAdmin({
+          id: organizationId,
+          name: "Nouveau nom d'organization",
+          administrationTeamId: newAdministrationTeamId,
+          countryCode: newCountry.code,
+          organizationLearnerType: domainBuilder.acquisition.buildOrganizationLearnerType({
+            id: newOrganizationLearnerType.id,
+            name: undefined,
+          }),
+          features: {
+            [ORGANIZATION_FEATURE.LEARNER_IMPORT.key]: { active: true, params: { name: 'ONDE' } },
+          },
+        });
+        await usecases.updateOrganizationInformation({
+          userId: adminUserId,
+          organization: organizationNewInformation,
+        });
+        const learnerInDB = await knex('organization-learners').where({ id: learnerFromOrganization.id }).first();
+        expect(learnerInDB.deletedAt).not.null;
+
+        const otherLearnerInDB = await knex('organization-learners')
+          .where({ id: learnerFromOtherOrganization.id })
+          .first();
+        expect(otherLearnerInDB.deletedAt).null;
+      });
+    });
   });
 
   context('when organization learner type does not exist', function () {
@@ -78,6 +138,7 @@ describe('Integration | Organizational Entities | Domain | UseCases | update-org
 
       // when
       const error = await catchErr(usecases.updateOrganizationInformation)({
+        userId: adminUserId,
         organization: organizationNewInformations,
       });
 
@@ -107,6 +168,7 @@ describe('Integration | Organizational Entities | Domain | UseCases | update-org
 
       // when
       const error = await catchErr(usecases.updateOrganizationInformation)({
+        userId: adminUserId,
         organization: organizationNewInformations,
       });
 
@@ -136,6 +198,7 @@ describe('Integration | Organizational Entities | Domain | UseCases | update-org
 
       // when
       const error = await catchErr(usecases.updateOrganizationInformation)({
+        userId: adminUserId,
         organization: organizationNewInformations,
       });
 
@@ -169,6 +232,7 @@ describe('Integration | Organizational Entities | Domain | UseCases | update-org
 
       // when
       const response = await usecases.updateOrganizationInformation({
+        userId: adminUserId,
         organization: organizationNewInformations,
       });
 

--- a/api/tests/organizational-entities/unit/application/organization/organization.admin.controller.test.js
+++ b/api/tests/organizational-entities/unit/application/organization/organization.admin.controller.test.js
@@ -125,6 +125,7 @@ describe('Unit | Organizational Entities | Application | Controller | Admin | or
   describe('#updateOrganizationInformation', function () {
     it('should return the serialized organization', async function () {
       // given
+      const adminUserId = Symbol('userId');
       const organizationAttributes = {
         id: 7,
         name: 'Acme',
@@ -137,6 +138,7 @@ describe('Unit | Organizational Entities | Application | Controller | Admin | or
       };
       const tagAttributes = { id: '4', type: 'tags' };
       const request = {
+        auth: { credentials: { userId: adminUserId } },
         payload: {
           data: {
             id: organizationAttributes.id,
@@ -183,7 +185,7 @@ describe('Unit | Organizational Entities | Application | Controller | Admin | or
         .withArgs(request.payload)
         .returns(organizationDeserialized);
       usecases.updateOrganizationInformation
-        .withArgs({ organization: organizationDeserialized })
+        .withArgs({ userId: adminUserId, organization: organizationDeserialized })
         .resolves(updatedOrganization);
       dependencies.organizationForAdminSerializer.serialize
         .withArgs(updatedOrganization)

--- a/api/tests/organizational-entities/unit/domain/models/OrganizationForAdmin_test.js
+++ b/api/tests/organizational-entities/unit/domain/models/OrganizationForAdmin_test.js
@@ -865,6 +865,78 @@ describe('Unit | Organizational Entities | Domain | Model | OrganizationForAdmin
       // then
       expect(givenOrganization.organizationLearnerType).to.deep.equal(formerOrganizationLearnerType);
     });
+    context('when learner import feature does not exist', function () {
+      it('set shouldDeletePreviousLearner to true when activating LEARNER_IMPORT feature', function () {
+        // given
+        const givenOrganization = new OrganizationForAdmin({
+          features: {},
+        });
+
+        // when
+        givenOrganization.updateWithDataProtectionOfficerAndTags({
+          features: {
+            ...features,
+            [ORGANIZATION_FEATURE.LEARNER_IMPORT.key]: { active: true, params: { name: 'GENERIC' } },
+          },
+          organizationLearnerType,
+        });
+
+        // then
+        expect(givenOrganization.features).to.deep.includes({
+          [ORGANIZATION_FEATURE.LEARNER_IMPORT.key]: { active: true, params: { name: 'GENERIC' } },
+        });
+        expect(givenOrganization.shouldDeletePreviousLearners).true;
+      });
+    });
+
+    context('when learner import feature exists', function () {
+      it('set shouldDeletePreviousLearner to true when activating LEARNER_IMPORT feature', function () {
+        // given
+        const givenOrganization = new OrganizationForAdmin({
+          features: {
+            [ORGANIZATION_FEATURE.LEARNER_IMPORT.key]: { active: false },
+          },
+        });
+
+        // when
+        givenOrganization.updateWithDataProtectionOfficerAndTags({
+          features: {
+            ...features,
+            [ORGANIZATION_FEATURE.LEARNER_IMPORT.key]: { active: true, params: { name: 'ONDE' } },
+          },
+          organizationLearnerType,
+        });
+
+        // then
+        expect(givenOrganization.features).to.deep.includes({
+          [ORGANIZATION_FEATURE.LEARNER_IMPORT.key]: { active: true, params: { name: 'ONDE' } },
+        });
+        expect(givenOrganization.shouldDeletePreviousLearners).true;
+      });
+      it('set shouldDeletePreviousLearner to false when updating LEARNER_IMPORT format', function () {
+        // given
+        const givenOrganization = new OrganizationForAdmin({
+          features: {
+            [ORGANIZATION_FEATURE.LEARNER_IMPORT.key]: { active: true, params: { name: 'GENERIC' } },
+          },
+        });
+
+        // when
+        givenOrganization.updateWithDataProtectionOfficerAndTags({
+          features: {
+            ...features,
+            [ORGANIZATION_FEATURE.LEARNER_IMPORT.key]: { active: true, params: { name: 'ONDE' } },
+          },
+          organizationLearnerType,
+        });
+
+        // then
+        expect(givenOrganization.features).to.deep.includes({
+          [ORGANIZATION_FEATURE.LEARNER_IMPORT.key]: { active: true, params: { name: 'ONDE' } },
+        });
+        expect(givenOrganization.shouldDeletePreviousLearners).false;
+      });
+    });
   });
 
   context('#updateParentOrganizationId', function () {

--- a/api/tests/prescription/learner-management/acceptance/application/organization-import-route_test.js
+++ b/api/tests/prescription/learner-management/acceptance/application/organization-import-route_test.js
@@ -122,7 +122,7 @@ describe('Acceptance | Application | organization-import', function () {
     });
   });
 
-  describe('POST /api/admin/import-organization-learners-format', function () {
+  describe('POST /api/admin/organization-learner-import-formats', function () {
     let options, connectedUser;
 
     beforeEach(async function () {
@@ -137,7 +137,7 @@ describe('Acceptance | Application | organization-import', function () {
 
       options = {
         method: 'POST',
-        url: `/api/admin/import-organization-learners-format`,
+        url: `/api/admin/organization-learner-import-formats`,
         headers: generateAuthenticatedUserRequestHeaders({ userId: connectedUser.id }),
         payload: buffer,
       };
@@ -146,6 +146,58 @@ describe('Acceptance | Application | organization-import', function () {
 
       // then
       expect(response.statusCode).to.equal(204);
+    });
+  });
+
+  describe('GET /api/admin/organization-learner-import-formats', function () {
+    let options, connectedUser;
+
+    beforeEach(async function () {
+      connectedUser = databaseBuilder.factory.buildUser.withRole({ role: PIX_ADMIN.ROLES.SUPER_ADMIN });
+      await databaseBuilder.commit();
+    });
+
+    it('should return all organization learner import formats', async function () {
+      // given
+      const scoOrganizationId = databaseBuilder.factory.buildOrganization().id;
+      const supOrganizationId = databaseBuilder.factory.buildOrganization().id;
+
+      const featureId = databaseBuilder.factory.buildFeature({
+        key: ORGANIZATION_FEATURE.LEARNER_IMPORT.key,
+      }).id;
+
+      const scoImportFormat = databaseBuilder.factory.buildOrganizationLearnerImportFormat({ name: 'SCO' });
+      const supImportFormat = databaseBuilder.factory.buildOrganizationLearnerImportFormat({ name: 'SUP' });
+
+      databaseBuilder.factory.buildOrganizationFeature({
+        organizationId: scoOrganizationId,
+        featureId,
+        params: {
+          organizationLearnerImportFormatId: scoImportFormat.id,
+          organizationLearnerImportFormatName: scoImportFormat.name,
+        },
+      });
+      databaseBuilder.factory.buildOrganizationFeature({
+        organizationId: supOrganizationId,
+        featureId,
+        params: {
+          organizationLearnerImportFormatId: supImportFormat.id,
+          organizationLearnerImportFormatName: supImportFormat.name,
+        },
+      });
+      await databaseBuilder.commit();
+
+      options = {
+        method: 'GET',
+        url: `/api/admin/organization-learner-import-formats`,
+        headers: generateAuthenticatedUserRequestHeaders({ userId: connectedUser.id }),
+      };
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result.data[0].type).to.equal('organization-learner-import-formats');
     });
   });
 });

--- a/api/tests/prescription/learner-management/integration/domain/usecases/find-all-organization-learner-import-format_test.js
+++ b/api/tests/prescription/learner-management/integration/domain/usecases/find-all-organization-learner-import-format_test.js
@@ -1,0 +1,48 @@
+import { OrganizationLearnerImportFormat } from '../../../../../../src/prescription/learner-management/domain/models/OrganizationLearnerImportFormat.js';
+import { usecases } from '../../../../../../src/prescription/learner-management/domain/usecases/index.js';
+import { ORGANIZATION_FEATURE } from '../../../../../../src/shared/domain/constants.js';
+import { databaseBuilder, expect } from '../../../../../test-helper.js';
+
+describe('Integration | UseCase | Learner Management | find-all-organization-learner-import-format', function () {
+  let scoImportFormat, supImportFormat;
+
+  beforeEach(async function () {
+    const scoOrganizationId = databaseBuilder.factory.buildOrganization().id;
+    const supOrganizationId = databaseBuilder.factory.buildOrganization().id;
+
+    const featureId = databaseBuilder.factory.buildFeature({
+      key: ORGANIZATION_FEATURE.LEARNER_IMPORT.key,
+    }).id;
+
+    scoImportFormat = databaseBuilder.factory.buildOrganizationLearnerImportFormat({ name: 'SCO' });
+    supImportFormat = databaseBuilder.factory.buildOrganizationLearnerImportFormat({ name: 'SUP' });
+
+    databaseBuilder.factory.buildOrganizationFeature({
+      organizationId: scoOrganizationId,
+      featureId,
+      params: {
+        organizationLearnerImportFormatId: scoImportFormat.id,
+        organizationLearnerImportFormatName: scoImportFormat.name,
+      },
+    });
+    databaseBuilder.factory.buildOrganizationFeature({
+      organizationId: supOrganizationId,
+      featureId,
+      params: {
+        organizationLearnerImportFormatId: supImportFormat.id,
+        organizationLearnerImportFormatName: supImportFormat.name,
+      },
+    });
+
+    await databaseBuilder.commit();
+  });
+
+  it('should return all OrganizationLearnerImportFormat', async function () {
+    // when
+    const result = await usecases.findAllOrganizationLearnerImportFormats();
+
+    // then
+    expect(result).lengthOf(2);
+    expect(result[0]).instanceOf(OrganizationLearnerImportFormat);
+  });
+});

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/organization-learner-import-format-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/organization-learner-import-format-repository_test.js
@@ -150,6 +150,7 @@ describe('Integration | Repository | Organization Learner Management | Organizat
       // given
       const organizationLearnerImportFormats = [
         new OrganizationLearnerImportFormat({
+          id: 123,
           name: 'FIRST_FORMAT',
           fileType: 'csv',
           config: { new_config: 'awesome' },
@@ -157,6 +158,7 @@ describe('Integration | Repository | Organization Learner Management | Organizat
           createdAt: now,
         }),
         new OrganizationLearnerImportFormat({
+          id: 456,
           name: 'SECOND_FORMAT',
           fileType: 'csv',
           config: { new_config: 'not_bad' },
@@ -191,6 +193,7 @@ describe('Integration | Repository | Organization Learner Management | Organizat
       // given
       const organizationLearnerImportFormats = [
         new OrganizationLearnerImportFormat({
+          id: 123,
           name: 'FIRST_FORMAT',
           fileType: 'csv',
           config: { new_config: 'awesome' },
@@ -215,6 +218,7 @@ describe('Integration | Repository | Organization Learner Management | Organizat
       // given
       const organizationLearnerImportFormats = [
         new OrganizationLearnerImportFormat({
+          id: 123,
           name: 'FIRST_FORMAT',
           fileType: 'csv',
           config: { new_config: 'awesome' },
@@ -240,6 +244,7 @@ describe('Integration | Repository | Organization Learner Management | Organizat
       // given
       const organizationLearnerImportFormats = [
         new OrganizationLearnerImportFormat({
+          id: 123,
           name: 'FIRST_FORMAT',
           fileType: 'csv',
           config: { new_config: 'awesome' },
@@ -266,6 +271,7 @@ describe('Integration | Repository | Organization Learner Management | Organizat
       // given
       const organizationLearnerImportFormats = [
         new OrganizationLearnerImportFormat({
+          id: 123,
           name: 'NEW_FORMAT',
           fileType: 'csv',
           config: { new_config: 'awesome' },

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/organization-learner-import-format-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/organization-learner-import-format-repository_test.js
@@ -60,7 +60,53 @@ describe('Integration | Repository | Organization Learner Management | Organizat
       expect(result).to.equal(null);
     });
   });
+  describe('#findAll', function () {
+    it('should return all import formats', async function () {
+      const scoOrganizationId = databaseBuilder.factory.buildOrganization().id;
+      const supOrganizationId = databaseBuilder.factory.buildOrganization().id;
 
+      const featureId = databaseBuilder.factory.buildFeature({
+        key: ORGANIZATION_FEATURE.LEARNER_IMPORT.key,
+      }).id;
+
+      const scoImportFormat = databaseBuilder.factory.buildOrganizationLearnerImportFormat({ name: 'SCO' });
+      const supImportFormat = databaseBuilder.factory.buildOrganizationLearnerImportFormat({ name: 'SUP' });
+
+      databaseBuilder.factory.buildOrganizationFeature({
+        organizationId: scoOrganizationId,
+        featureId,
+        params: {
+          organizationLearnerImportFormatId: scoImportFormat.id,
+          organizationLearnerImportFormatName: scoImportFormat.name,
+        },
+      });
+      databaseBuilder.factory.buildOrganizationFeature({
+        organizationId: supOrganizationId,
+        featureId,
+        params: {
+          organizationLearnerImportFormatId: supImportFormat.id,
+          organizationLearnerImportFormatName: supImportFormat.name,
+        },
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const result = await organizationLearnerImportFormatRepository.findAll();
+
+      // then
+      expect(result).lengthOf(2);
+      expect(result[0]).to.be.an.instanceOf(OrganizationLearnerImportFormat);
+      expect(result[0]).to.be.deep.equal(new OrganizationLearnerImportFormat(scoImportFormat));
+      expect(result[1]).to.be.deep.equal(new OrganizationLearnerImportFormat(supImportFormat));
+    });
+
+    it('should return an empty array if nothing was found', async function () {
+      const result = await organizationLearnerImportFormatRepository.findAll();
+
+      expect(result).lengthOf(0);
+    });
+  });
   describe('#save', function () {
     let clock, userId;
     const now = new Date('2022-02-02');

--- a/api/tests/prescription/learner-management/unit/application/organization-import-controller_test.js
+++ b/api/tests/prescription/learner-management/unit/application/organization-import-controller_test.js
@@ -58,4 +58,28 @@ describe('Unit | Application | Learner Management | organization-import-controll
       });
     });
   });
+
+  describe('#findAllOrganizationLearnerImportFormats', function () {
+    const organizationId = 123;
+    const request = {
+      params: { organizationId },
+    };
+
+    beforeEach(function () {
+      sinon.stub(usecases, 'findAllOrganizationLearnerImportFormats');
+      usecaseResultSymbol = Symbol();
+      usecases.findAllOrganizationLearnerImportFormats.resolves(usecaseResultSymbol);
+      serializeStub = sinon.stub();
+      dependencies = { organizationLearnerImportFormatSerializer: { serialize: serializeStub } };
+    });
+
+    it('should get last organization import', async function () {
+      hFake.request = {
+        path: `/api/organizations/${organizationId}/import-information`,
+      };
+      await organizationImportController.findAllOrganizationLearnerImportFormats(request, hFake, dependencies);
+      expect(usecases.findAllOrganizationLearnerImportFormats).calledOnce;
+      expect(serializeStub).calledOnceWithExactly(usecaseResultSymbol);
+    });
+  });
 });

--- a/api/tests/prescription/learner-management/unit/application/organization-import-route_test.js
+++ b/api/tests/prescription/learner-management/unit/application/organization-import-route_test.js
@@ -186,20 +186,27 @@ describe('Unit | Router | organization-import-router', function () {
     );
   });
 
-  describe('POST /api/admin/import-organization-learners-format', function () {
-    let hasAtLeastOneAccessOfStub, saveOrganizationLearnerImportFormatsStub;
+  describe('GET /api/admin/organization-learner-import-formats', function () {
+    const method = 'GET';
+    const url = '/api/admin/organization-learner-import-formats';
+
+    let hasAtLeastOneAccessOfStub, findAllOrganizationLearnerImportFormatsStub;
 
     beforeEach(function () {
       hasAtLeastOneAccessOfStub = sinon
         .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
-        .withArgs([securityPreHandlers.checkAdminMemberHasRoleSuperAdmin]);
+        .withArgs([
+          securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+          securityPreHandlers.checkAdminMemberHasRoleSupport,
+          securityPreHandlers.checkAdminMemberHasRoleMetier,
+        ]);
 
-      saveOrganizationLearnerImportFormatsStub = sinon
-        .stub(organizationImportController, 'saveOrganizationLearnerImportFormats')
+      findAllOrganizationLearnerImportFormatsStub = sinon
+        .stub(organizationImportController, 'findAllOrganizationLearnerImportFormats')
         .resolves(null);
     });
 
-    it('should not called controller when user is not super admin', async function () {
+    it('should not call controller when user is not allowed', async function () {
       hasAtLeastOneAccessOfStub.callsFake(
         () => (request, h) =>
           h
@@ -207,8 +214,53 @@ describe('Unit | Router | organization-import-router', function () {
             .code(403)
             .takeover(),
       );
+
+      const httpTestServer = new HttpTestServer(moduleUnderTest);
+      await httpTestServer.register(moduleUnderTest);
+
+      await httpTestServer.request(method, url);
+
+      expect(findAllOrganizationLearnerImportFormatsStub.notCalled).to.be.true;
+    });
+
+    it('should call controller when user is allowed', async function () {
+      hasAtLeastOneAccessOfStub.returns(() => true);
+
+      const httpTestServer = new HttpTestServer(moduleUnderTest);
+      await httpTestServer.register(moduleUnderTest);
+
+      await httpTestServer.request(method, url);
+
+      expect(findAllOrganizationLearnerImportFormatsStub.called).to.be.true;
+    });
+  });
+
+  describe('POST /api/admin/organization-learner-import-formats', function () {
+    let checkAdminMemberHasRoleSuperAdmin, saveOrganizationLearnerImportFormatsStub;
+
+    beforeEach(function () {
+      checkAdminMemberHasRoleSuperAdmin = sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin');
+
+      saveOrganizationLearnerImportFormatsStub = sinon
+        .stub(organizationImportController, 'saveOrganizationLearnerImportFormats')
+        .resolves(null);
+    });
+
+    it('should not call controller when user is not super admin', async function () {
+      checkAdminMemberHasRoleSuperAdmin.callsFake((_, h) =>
+        h
+          .response(
+            new jsonapiSerializer.Error({
+              code: 403,
+              title: 'Forbidden access',
+              detail: 'Missing or insufficient permissions.',
+            }),
+          )
+          .code(403)
+          .takeover(),
+      );
       const method = 'POST';
-      const url = '/api/admin/import-organization-learners-format';
+      const url = '/api/admin/organization-learner-import-formats';
 
       const httpTestServer = new HttpTestServer(moduleUnderTest);
       await httpTestServer.register(moduleUnderTest);
@@ -218,10 +270,10 @@ describe('Unit | Router | organization-import-router', function () {
       expect(saveOrganizationLearnerImportFormatsStub.notCalled).to.be.true;
     });
 
-    it('should called controller when user is super admin', async function () {
-      hasAtLeastOneAccessOfStub.returns(() => true);
+    it('should call controller when user is super admin', async function () {
+      checkAdminMemberHasRoleSuperAdmin.returns(() => true);
       const method = 'POST';
-      const url = '/api/admin/import-organization-learners-format';
+      const url = '/api/admin/organization-learner-import-formats';
 
       const httpTestServer = new HttpTestServer(moduleUnderTest);
       await httpTestServer.register(moduleUnderTest);

--- a/api/tests/prescription/learner-management/unit/domain/models/OrganizationLearnerImportFormat_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/models/OrganizationLearnerImportFormat_test.js
@@ -69,6 +69,7 @@ describe('Unit | Models | OrganizationLearnerImportFormat', function () {
     it('should initialize valid object', function () {
       //when
       const organizationLearnerImportFormat = new OrganizationLearnerImportFormat({
+        id: 123,
         name: 'SAY_MY_NAME',
         config: { basic_config: 'toto' },
         fileType: 'csv',
@@ -77,6 +78,7 @@ describe('Unit | Models | OrganizationLearnerImportFormat', function () {
       });
       // then
       expect(organizationLearnerImportFormat).to.deep.equal({
+        id: 123,
         name: 'SAY_MY_NAME',
         config: { basic_config: 'toto' },
         fileType: 'csv',
@@ -90,6 +92,7 @@ describe('Unit | Models | OrganizationLearnerImportFormat', function () {
         //when
         try {
           new OrganizationLearnerImportFormat({
+            id: 123,
             name: 'SAY_MY_NAME',
             config: { basic_config: 'toto' },
             fileType: 'incalif_file_type',
@@ -107,6 +110,7 @@ describe('Unit | Models | OrganizationLearnerImportFormat', function () {
         //when
         try {
           new OrganizationLearnerImportFormat({
+            id: 123,
             config: { basic_config: 'toto' },
             fileType: 'csv',
             createdAt: new Date('2025-01-01'),
@@ -123,6 +127,7 @@ describe('Unit | Models | OrganizationLearnerImportFormat', function () {
         //when
         try {
           new OrganizationLearnerImportFormat({
+            id: 123,
             name: 'SAY_MY_NAME',
             fileType: 'csv',
             createdAt: new Date('2025-01-01'),
@@ -139,6 +144,7 @@ describe('Unit | Models | OrganizationLearnerImportFormat', function () {
         //when
         try {
           new OrganizationLearnerImportFormat({
+            id: 123,
             fileType: 'csv',
             createdAt: new Date('2025-01-01'),
             createdBy: 12,

--- a/api/tests/prescription/learner-management/unit/domain/usecases/get-organization-learners-csv-template_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/usecases/get-organization-learners-csv-template_test.js
@@ -25,6 +25,7 @@ describe('Unit | UseCase | get-organization-learners-csv-template', function () 
       sinon.stub(membershipRepository, 'findByUserIdAndOrganizationId').resolves([membership]);
       organizationLearnerImportFormatRepository.get.resolves(
         new OrganizationLearnerImportFormat({
+          id: 123,
           name: 'GENERIC',
           filetype: 'csv',
           config: {

--- a/api/tests/prescription/learner-management/unit/infrastructure/serializers/jsonapi/organization-learner-import-format-serializer_test.js
+++ b/api/tests/prescription/learner-management/unit/infrastructure/serializers/jsonapi/organization-learner-import-format-serializer_test.js
@@ -1,0 +1,56 @@
+import { OrganizationLearnerImportFormat } from '../../../../../../../src/prescription/learner-management/domain/models/OrganizationLearnerImportFormat.js';
+import { serialize } from '../../../../../../../src/prescription/learner-management/infrastructure/serializers/jsonapi/organization-learner-import-format-serializer.js';
+import { expect } from '../../../../../../test-helper.js';
+
+describe('Unit | Serializer | JSONAPI | organization-learner-import-format-serializer', function () {
+  describe('#serialize', function () {
+    it('should convert an organizationLearnerImportFormat model object into JSON API data', function () {
+      // given
+      const updatedAt = new Date();
+      const createdAt = new Date();
+      const organizationImport = new OrganizationLearnerImportFormat({
+        id: 123,
+        name: 'SCOIMPORT',
+        fileType: 'csv',
+        config: {
+          acceptedEncoding: ['utf-8'],
+          unicityColumns: ['my_column'],
+          validationRules: { formats: [{ name: 'my_column', type: 'string' }] },
+          headers: [
+            {
+              name: 'Prénom apprenant',
+              config: {
+                property: 'firstName',
+                validate: {
+                  type: 'string',
+                  required: true,
+                },
+                reconcile: {
+                  name: 'COMMON_FIRSTNAME',
+                  fieldId: 'reconcileField2',
+                  position: 2,
+                },
+              },
+              required: true,
+            },
+          ],
+        },
+        createdBy: 1,
+        updatedAt,
+        createdAt,
+      });
+
+      expect(serialize(organizationImport)).deep.equal({
+        data: {
+          type: 'organization-learner-import-formats',
+          id: '123',
+          attributes: {
+            'file-type': 'csv',
+            name: 'SCOIMPORT',
+            config: organizationImport.config,
+          },
+        },
+      });
+    });
+  });
+});

--- a/api/tests/prescription/organization-learner/unit/domain/models/OrganizationToJoin_test.js
+++ b/api/tests/prescription/organization-learner/unit/domain/models/OrganizationToJoin_test.js
@@ -6,6 +6,7 @@ describe('Unit | Domain | Read-Models | OrganizationToJoin', function () {
   describe('for an organization with import format', function () {
     it('should return the organization with reconciliation fields and isRestricted true', function () {
       const organizationLearnerImportFormat = new OrganizationLearnerImportFormat({
+        id: 123,
         name: 'MY_TEST_EXPORT',
         fileType: 'csv',
         config: {

--- a/api/tests/prescription/organization-learner/unit/infrastructure/repositories/organization-to-join-repository_test.js
+++ b/api/tests/prescription/organization-learner/unit/infrastructure/repositories/organization-to-join-repository_test.js
@@ -6,6 +6,7 @@ import { domainBuilder, expect, sinon } from '../../../../../test-helper.js';
 describe('Unit | Repository | organization-to-join-repository', function () {
   it('returns organization to join', async function () {
     const organizationLearnerImportFormat = new OrganizationLearnerImportFormat({
+      id: 123,
       name: 'MY_TEST_EXPORT',
       fileType: 'csv',
       config: {

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -261,6 +261,15 @@ async function insertMultipleSendingFeatureForNewOrganization() {
   return feature.id;
 }
 
+async function insertLearnerImportFeatureForNewOrganization() {
+  const featureId = databaseBuilder.factory.buildFeature(ORGANIZATION_FEATURE.LEARNER_IMPORT).id;
+  databaseBuilder.factory.buildOrganizationLearnerImportFormat({
+    name: ORGANIZATION_FEATURE.LEARNER_IMPORT.FORMAT.ONDE,
+  });
+  await databaseBuilder.commit();
+  return featureId;
+}
+
 async function insertPixJuniorFeatureForNewOrganization() {
   databaseBuilder.factory.buildFeature(ORGANIZATION_FEATURE.LEARNER_IMPORT);
   databaseBuilder.factory.buildFeature(ORGANIZATION_FEATURE.MISSIONS_MANAGEMENT);
@@ -480,6 +489,7 @@ export {
   generateValidRequestAuthorizationHeaderForApplication,
   hFake,
   HttpTestServer,
+  insertLearnerImportFeatureForNewOrganization,
   insertMultipleSendingFeatureForNewOrganization,
   insertOrganizationUserWithRoleAdmin,
   insertPixJuniorFeatureForNewOrganization,

--- a/api/tests/tooling/domain-builder/factory/prescription/learner-management/build-organization-learner-import-format.js
+++ b/api/tests/tooling/domain-builder/factory/prescription/learner-management/build-organization-learner-import-format.js
@@ -1,6 +1,7 @@
 import { OrganizationLearnerImportFormat } from '../../../../../../src/prescription/learner-management/domain/models/OrganizationLearnerImportFormat.js';
 
 export const buildOrganizationLearnerImportFormat = function ({
+  id = 1,
   name = 'GENERIC',
   fileType = 'csv',
   config = {
@@ -30,6 +31,7 @@ export const buildOrganizationLearnerImportFormat = function ({
   createdBy = 12,
 } = {}) {
   return new OrganizationLearnerImportFormat({
+    id,
     name,
     fileType,
     config,


### PR DESCRIPTION
## 🥀 Problème

Dans Pix Admin, depuis la page organisations, la feature “IMPORT” n’est pas sélectionnable lors de la modification de l’orga. Actuellement l’activation de la feature “IMPORT” ne peut être faite que par un PO/PM avec les droits SuperADMIN. L’activation se fait par import de fichier que ce soit pour une activation en masse ou pour une seule organisation. C’est pénible pour tout le monde.

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

## 🏹 Proposition

Dans Pix Admin pour le rôle Métier, directement depuis la page d’une organisation :
- rendre disponible l’activation de la feature “Import générique”
- informer le Métier que l’activation de l’import supprime tous les prescrits via une modale avant validation

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 💌 Remarques
Wording pour la modale : 

``` 
Vous êtes sur le point d’activer l’import générique pour cette organisation. Si l’organisation a déjà des prescrits, ceux-ci seront tous supprimés. Cette suppression est irréversible.
[ ] En cochant cette case vous affirmez avoir les droits et l’autorisation de l’organisation pour effectuer cette action
```
  
<!-- Des infos supplémentaires, trucs et astuces ? -->

## ❤️‍🔥 Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
--> 
- ADMIN - activer un import générique sur une orga sans import et sans learners
- ORGA - tester un import de learners
- ADMIN - faire pareil sur une orga qui a déjà des learners avec un import non généric
- ORGA -  vérifier que tous les learners sont bien supprimés et tester un import de learners
- ADMIN - définir un autre import générique sur une orga avec un déjà un format d'import générique
- ORGA - Vérifier que les anciens learners importés sont encore présents, tester un import de learners
- ADMIN - retirer la feature d'import Générique à une des orgas avec learners
- ORGA - vérifier ce que ça donne
-  🎉 
