### PR TITLE
[FEATURE] Afficher les locales dans la page de détails d'un contenu formatif (PIX-21785).

### DIFF
--- a/admin/app/components/trainings/training-details-card.gjs
+++ b/admin/app/components/trainings/training-details-card.gjs
@@ -8,6 +8,7 @@ import StateTag from './state-tag';
 
 export default class TrainingDetailsCard extends Component {
   @service url;
+  @service featureToggles;
 
   get formattedDuration() {
     const days = this.args.training.duration.days ? `${this.args.training.duration.days}j ` : '';
@@ -18,6 +19,10 @@ export default class TrainingDetailsCard extends Component {
 
   get formattedLocale() {
     return localeCategories[this.args.training.locale];
+  }
+
+  get formattedLocales() {
+    return this.args.training.locales.map((locale) => localeCategories[locale]).join(', ');
   }
 
   get trainingLink() {
@@ -63,9 +68,15 @@ export default class TrainingDetailsCard extends Component {
 
         <DescriptionList.Divider />
 
-        <DescriptionList.Item @label={{t "pages.trainings.training.details.localizedLanguage"}}>
-          {{this.formattedLocale}}
-        </DescriptionList.Item>
+        {{#if this.featureToggles.featureToggles.multipleLocalesForTrainingsEnabled}}
+          <DescriptionList.Item @label={{t "pages.trainings.training.details.locales" count=@training.locales.length}}>
+            {{this.formattedLocales}}
+          </DescriptionList.Item>
+        {{else}}
+          <DescriptionList.Item @label={{t "pages.trainings.training.details.localizedLanguage"}}>
+            {{this.formattedLocale}}
+          </DescriptionList.Item>
+        {{/if}}
 
         <DescriptionList.Divider />
 

--- a/admin/app/models/training.js
+++ b/admin/app/models/training.js
@@ -28,6 +28,7 @@ export default class Training extends Model {
   @attr('string') link;
   @attr('string') type;
   @attr('string') locale;
+  @attr('array') locales;
   @attr('string') editorName;
   @attr('string') editorLogoUrl;
   @attr('boolean') isRecommendable;

--- a/admin/tests/integration/components/trainings/training-details-card-test.gjs
+++ b/admin/tests/integration/components/trainings/training-details-card-test.gjs
@@ -108,6 +108,71 @@ module('Integration | Component | Trainings::TrainingDetailsCard', function (hoo
     });
   });
 
+  module('when multipleLocalesForTrainingsEnabled feature toggle is enabled', function (hooks) {
+    hooks.beforeEach(function () {
+      const featureToggles = this.owner.lookup('service:featureToggles');
+      sinon.stub(featureToggles, 'featureToggles').value({ multipleLocalesForTrainingsEnabled: true });
+    });
+
+    test('it should not display locale information', async function (assert) {
+      // given
+      const trainingWithOneLocale = { ...training, locales: ['fr', 'en'] };
+
+      // when
+      const screen = await render(<template><TrainingDetailsCard @training={{trainingWithOneLocale}} /></template>);
+
+      // then
+      assert.dom(screen.queryByText('Langue localisée')).doesNotExist();
+      assert.dom(screen.queryByText('Franco-français (fr-fr)')).doesNotExist();
+    });
+
+    module('when there is one value in locales', function () {
+      test('it should display locales with a singular label', async function (assert) {
+        // given
+        const trainingWithOneLocale = { ...training, locales: ['fr'] };
+
+        // when
+        const screen = await render(<template><TrainingDetailsCard @training={{trainingWithOneLocale}} /></template>);
+
+        // then
+        assert.dom(screen.getByText(t('pages.trainings.training.details.locales', { count: 1 }))).exists();
+        assert.dom(screen.getByText('Francophone (fr)')).exists();
+      });
+    });
+
+    module('when there are multiple value in locales', function () {
+      test('it should display locales with a plural label', async function (assert) {
+        // given
+        const trainingWithMultipleLocales = { ...training, locales: ['fr', 'en'] };
+
+        // when
+        const screen = await render(
+          <template><TrainingDetailsCard @training={{trainingWithMultipleLocales}} /></template>,
+        );
+
+        // then
+        assert.dom(screen.getByText(t('pages.trainings.training.details.locales', { count: 2 }))).exists();
+        assert.dom(screen.getByText('Francophone (fr), Anglophone (en)')).exists();
+      });
+    });
+  });
+
+  module('when multipleLocalesForTrainingsEnabled feature toggle is disabled', function () {
+    test('it should not display locales and continue to display locale label', async function (assert) {
+      // given
+      const featureToggles = this.owner.lookup('service:featureToggles');
+      sinon.stub(featureToggles, 'featureToggles').value({ multipleLocalesForTrainingsEnabled: false });
+      const trainingWithLocales = { ...training, locales: ['fr', 'en'] };
+
+      // when
+      const screen = await render(<template><TrainingDetailsCard @training={{trainingWithLocales}} /></template>);
+
+      // then
+      assert.dom(screen.queryByText(t('pages.trainings.training.details.locales', { count: 2 }))).doesNotExist();
+      assert.dom(screen.getByText(t('pages.trainings.training.details.localizedLanguage'))).exists();
+    });
+  });
+
   module('when training type is modulix', function () {
     test('should display a link to a Pix App module', async function (assert) {
       // given

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -1621,6 +1621,7 @@
           "editorLogo": "Editor logo url",
           "editorName": "Editor name",
           "internalTitle": "Internal title",
+          "locales": "{ count, plural, one {Localized language} other {Localized languages}}",
           "localizedLanguage": "Localized language",
           "publishedOn": "Published on",
           "status": "Status",

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -1624,6 +1624,7 @@
           "editorLogo": "Url du logo de l'éditeur",
           "editorName": "Nom d'éditeur",
           "internalTitle": "Titre interne",
+          "locales": "{ count, plural, one {Langue localisée} other {Langues localisées}}",
           "localizedLanguage": "Langue localisée",
           "publishedOn": "Publié sur",
           "status": "Statut",


### PR DESCRIPTION
## 🥀 Problème

Désormais il est possible q'un CF puisse avoir plusieurs locales. On souhaite les voir sur Pix Admin.

## 🏹 Proposition

Afficher les locales sur Pix Admin (sous feature toggle)

## 💌 Remarques

Code réalisé par ✨CLAUDE✨ dans le cadre de l'expérimentation de l'IA.

Prompt principal : `Dans @admin/app/components/trainings/training-details-card.gjs je veux remonter l'attribut locales fourni par la route API. Cet attribut doit être positionné sous locale, mais elle ne doit s'afficher que si le feature toggle multipleLocalesForTrainingsEnabled est à true`

---

Finalement j'ai remanié moi même du code coté test et implem car plutôt que de placer locales sous locale, on veut passer de l'un à l'autre si le FT est actif.


## ❤️‍🔥 Pour tester

- Aller sur Pix Admin
- https://admin-pr15424.review.pix.fr/trainings/5000/triggers
- Voir dans la page que les langues localisées apparaissent bien
<img width="1217" height="565" alt="Capture d’écran 2026-03-11 à 17 46 57" src="https://github.com/user-attachments/assets/148781ef-4154-4389-881a-8b4866ddeae2" />

- Voir un autre CF et voir que c'est la même mais au singulier
<img width="1217" height="565" alt="Capture d’écran 2026-03-11 à 17 47 17" src="https://github.com/user-attachments/assets/24da4cf8-69ab-48b6-96bc-44f7ac59aef3" />


- Désactiver le feature toggle `multipleLocalesForTrainingsEnabled`
- Faire la non régression sur l'affichage de la locale classique