### PR TITLE
[TECH] Améliorer l'accessibilité de l'élément custom (PIX-21794)

### DIFF
--- a/mon-pix/app/components/module/element/custom-element.gjs
+++ b/mon-pix/app/components/module/element/custom-element.gjs
@@ -90,7 +90,11 @@ export default class ModulixCustomElement extends ModuleElement {
             </div>
           {{/if}}
 
-          <legend class="element-custom__legend">
+          {{#if this.hasInstruction}}
+            <legend class="sr-only">
+              {{htmlUnsafe @component.instruction}}{{htmlUnsafe @component.functionalInstruction}}</legend>
+          {{/if}}
+
           <legend class="element-custom__legend" aria-hidden="true">
             <PixIcon @name="leftClick" @plainIcon={{false}} @ariaHidden={{true}} />
             <span>{{t "pages.modulix.interactiveElement.label"}}</span>

--- a/mon-pix/app/components/module/element/custom-element.gjs
+++ b/mon-pix/app/components/module/element/custom-element.gjs
@@ -91,6 +91,7 @@ export default class ModulixCustomElement extends ModuleElement {
           {{/if}}
 
           <legend class="element-custom__legend">
+          <legend class="element-custom__legend" aria-hidden="true">
             <PixIcon @name="leftClick" @plainIcon={{false}} @ariaHidden={{true}} />
             <span>{{t "pages.modulix.interactiveElement.label"}}</span>
           </legend>


### PR DESCRIPTION
## 🥀 Problème

Les instructions ajoutées récemment sur l'élément custom ne sont pas mis dans une balise legend.
Cela fait qu'ils ne sont pas vocalisés sur un élément intéractif.

## 🏹 Proposition

Ajouter une balise `legend` contenant l'instruction et l'instruction fonctionnelle pour le lecteur écran. 

## 💌 Remarques

- La balise `fieldset` ne prend en compte que la première balise legend d'après la [doc](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/fieldset#name).

> The caption for the fieldset is given by the first [<legend>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/legend) element nested inside it.

- On masque le contenu de la deuxième balise `legend` car c'est décoratif.

## ❤️‍🔥 Pour tester
- Aller sur le module [bac-a-sable](https://app-pr15427.review.pix.fr/modules/6a68bf32/bac-a-sable/passage)
- Passer les grains pour arriver sur le QCU image
- Lancer le logiciel de lecteur d'écran. Vérifier qu'au focus sur la première proposition, alors le contenu de l'instruction et celui de l'instruction fonctionnelle sont bien vocalisés 🎉 