### PR TITLE
[FEATURE] Trier les attestations PDF par nom de famille et prénom (PIX-21887)

### DIFF
--- a/api/db/seeds/data/team-prescription/build-quests.js
+++ b/api/db/seeds/data/team-prescription/build-quests.js
@@ -1,3 +1,4 @@
+import { faker } from '@faker-js/faker';
 import dayjs from 'dayjs';
 
 import { CampaignParticipationStatuses } from '../../../../src/prescription/shared/domain/constants.js';
@@ -520,8 +521,8 @@ export const buildQuests = async (databaseBuilder) => {
   //create learners with participations to test download 100 attestations
   for (let i = 0; i < 100; i++) {
     const user = databaseBuilder.factory.buildUser.withRawPassword({
-      firstName: `attestation-success${i}`,
-      lastName: `attestation${i}`,
+      firstName: `${faker.person.firstName()}${i}`,
+      lastName: `${faker.person.lastName()}${i}`,
       email: `attestation-success${i}@example.net`,
     });
 

--- a/api/src/profile/domain/usecases/get-shared-attestations-for-organization-by-user-ids.js
+++ b/api/src/profile/domain/usecases/get-shared-attestations-for-organization-by-user-ids.js
@@ -31,14 +31,29 @@ export async function getSharedAttestationsForOrganizationByUserIds({
     throw new NoProfileRewardsFoundError();
   }
 
-  const data = [];
-
   const users = await userRepository.getByIds({ userIds: filteredProfileRewards.map(({ userId }) => userId) });
+  const profileRewardByUserId = new Map(
+    filteredProfileRewards.map((profileReward) => [profileReward.userId, profileReward]),
+  );
 
-  filteredProfileRewards.forEach(({ userId, createdAt }) => {
-    const user = users.find((user) => user.id === userId);
-    if (user) data.push(user.toForm(createdAt, locale, stringUtils.normalizeAndRemoveAccents));
-  });
+  const sortByLastNameThenFirstName = (userA, userB) => {
+    const lastNameComparison = userA.lastName.localeCompare(userB.lastName, 'fr', { sensitivity: 'base' });
+    return lastNameComparison !== 0
+      ? lastNameComparison
+      : userA.firstName.localeCompare(userB.firstName, 'fr', {
+          sensitivity: 'base',
+        });
+  };
+
+  const usersToAttestationForm = (attestationForms, user) => {
+    const profileReward = profileRewardByUserId.get(user.id);
+    if (profileReward) {
+      attestationForms.push(user.toForm(profileReward.createdAt, locale, stringUtils.normalizeAndRemoveAccents));
+    }
+    return attestationForms;
+  };
+
+  const data = users.sort(sortByLastNameThenFirstName).reduce(usersToAttestationForm, []);
 
   return {
     data,

--- a/api/tests/profile/integration/domain/usecases/get-shared-attestations-for-organization-by-user-ids_test.js
+++ b/api/tests/profile/integration/domain/usecases/get-shared-attestations-for-organization-by-user-ids_test.js
@@ -64,6 +64,57 @@ describe('Profile | Integration | Domain | get-shared-attestations-for-organizat
       expect(results.data[0].get('lastName')).to.equal('TERIEUR');
     });
 
+    it('should return profile rewards sorted by last name then first name', async function () {
+      const locale = 'FR-fr';
+      const attestation = databaseBuilder.factory.buildAttestation();
+      mockAttestationStorage(attestation);
+      const userZoe = new User(databaseBuilder.factory.buildUser({ firstName: 'Zoe', lastName: 'Abadie' }));
+      const userAlice = new User(databaseBuilder.factory.buildUser({ firstName: 'Alice', lastName: 'Martin' }));
+      const userBob = new User(databaseBuilder.factory.buildUser({ firstName: 'Bob', lastName: 'Abadie' }));
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      databaseBuilder.factory.buildOrganizationLearner({ organizationId, userId: userZoe.id });
+      databaseBuilder.factory.buildOrganizationLearner({ organizationId, userId: userAlice.id });
+      databaseBuilder.factory.buildOrganizationLearner({ organizationId, userId: userBob.id });
+
+      const profileRewardZoe = databaseBuilder.factory.buildProfileReward({
+        rewardId: attestation.id,
+        userId: userZoe.id,
+      });
+      databaseBuilder.factory.buildOrganizationsProfileRewards({
+        organizationId,
+        profileRewardId: profileRewardZoe.id,
+      });
+      const profileRewardAlice = databaseBuilder.factory.buildProfileReward({
+        rewardId: attestation.id,
+        userId: userAlice.id,
+      });
+      databaseBuilder.factory.buildOrganizationsProfileRewards({
+        organizationId,
+        profileRewardId: profileRewardAlice.id,
+      });
+      const profileRewardBob = databaseBuilder.factory.buildProfileReward({
+        rewardId: attestation.id,
+        userId: userBob.id,
+      });
+      databaseBuilder.factory.buildOrganizationsProfileRewards({
+        organizationId,
+        profileRewardId: profileRewardBob.id,
+      });
+
+      await databaseBuilder.commit();
+
+      const results = await usecases.getSharedAttestationsForOrganizationByUserIds({
+        attestationKey: attestation.key,
+        organizationId,
+        userIds: [userZoe.id, userAlice.id, userBob.id],
+        locale,
+      });
+
+      expect(results.data[0].get('firstName')).to.equal('Bob');
+      expect(results.data[1].get('firstName')).to.equal('Zoe');
+      expect(results.data[2].get('firstName')).to.equal('Alice');
+    });
+
     it('should not return profile rewards for anonymous userIds', async function () {
       const locale = 'FR-fr';
       const attestation = databaseBuilder.factory.buildAttestation();


### PR DESCRIPTION
## 🐙 Problème

Les attestations PDF générées n'étaient pas triées.

## 🦩 Proposition

Ajout d'un tri par nom de famille puis par prénom lors de la génération des attestations PDF.

## 🎸 Remarques

![IMG-20260312-WA0006](https://github.com/user-attachments/assets/337d06e4-b1ca-4e40-bb77-cb21f7db75ee)

## 🌮 Pour tester

- [x] Générer un PDF d'attestations et vérifier que les entrées sont triées par nom puis prénom
- [x] Si vous êtes vraiment motivés vous pouvez vous inscrire avec des noms étranges, des accents, tout ca et vérifier que ca trie correctement. 