### PR TITLE
[FEATURE] Scripte le rattachement de quêtes aux schémas de parcours combinés (PIX-21894)

### DIFF
--- a/api/scripts/prod/attach-quest-to-existing-combined-course-blueprints.js
+++ b/api/scripts/prod/attach-quest-to-existing-combined-course-blueprints.js
@@ -1,0 +1,58 @@
+import { usecases } from '../../src/quest/domain/usecases/index.js';
+import * as combinedCourseBlueprintRepository from '../../src/quest/infrastructure/repositories/combined-course-blueprint-repository.js';
+import { Script } from '../../src/shared/application/scripts/script.js';
+import { ScriptRunner } from '../../src/shared/application/scripts/script-runner.js';
+import { DomainTransaction } from '../../src/shared/domain/DomainTransaction.js';
+
+export class AttachQuestToExistingCombinedCourseBlueprintsScript extends Script {
+  constructor() {
+    super({
+      description: 'This script will create a quest for the existing combined course blueprints without quest',
+      permanent: false,
+      options: {
+        dryRun: {
+          type: 'boolean',
+          default: true,
+        },
+      },
+    });
+  }
+  async handle({
+    options,
+    logger,
+    dependencies = {
+      createCombinedCourseBlueprint: usecases.createCombinedCourseBlueprint,
+      combinedCourseBlueprintRepository,
+    },
+  }) {
+    await DomainTransaction.execute(async () => {
+      const knexConn = DomainTransaction.getConnection();
+      try {
+        const combinedCourseBlueprints = await dependencies.combinedCourseBlueprintRepository.findAll();
+        const combinedCourseBlueprintsToUpdate = combinedCourseBlueprints.filter(
+          (combinedCourseBlueprint) => !combinedCourseBlueprint.quest,
+        );
+
+        logger.info(`${combinedCourseBlueprintsToUpdate.length} quests to create.`);
+
+        for (const combinedCourseBlueprint of combinedCourseBlueprintsToUpdate) {
+          await dependencies.createCombinedCourseBlueprint({ combinedCourseBlueprint });
+        }
+        if (options.dryRun) {
+          await knexConn.rollback();
+          logger.info(`ROLLBACK due to dryRun`);
+          logger.info(`--dryRun true to persist changes`);
+          return;
+        }
+      } catch (error) {
+        await knexConn.rollback();
+        logger.error(
+          { event: 'AttachQuestToExistingCombinedCourseBlueprintsScript' },
+          `ROLLBACK: An error has occured, ${error}`,
+        );
+        throw error;
+      }
+    });
+  }
+}
+await ScriptRunner.execute(import.meta.url, AttachQuestToExistingCombinedCourseBlueprintsScript);

--- a/api/src/quest/infrastructure/repositories/combined-course-blueprint-repository.js
+++ b/api/src/quest/infrastructure/repositories/combined-course-blueprint-repository.js
@@ -38,7 +38,7 @@ export async function save({ combinedCourseBlueprint }) {
   }
 
   const [updatedValues] = await knexConn('combined_course_blueprints')
-    .update(_toDTO({ combinedCourseBlueprint }))
+    .update(_toDTO({ combinedCourseBlueprint, questId }))
     .where({ id: combinedCourseBlueprint.id })
     .returning('*');
   await updateShares({ combinedCourseBlueprint, knexConn });

--- a/api/tests/integration/scripts/prod/attach-quest-to-existing-combined-course-blueprints_test.js
+++ b/api/tests/integration/scripts/prod/attach-quest-to-existing-combined-course-blueprints_test.js
@@ -1,0 +1,62 @@
+import { AttachQuestToExistingCombinedCourseBlueprintsScript } from '../../../../scripts/prod/attach-quest-to-existing-combined-course-blueprints.js';
+import * as combinedCourseBlueprintRepository from '../../../../src/quest/infrastructure/repositories/combined-course-blueprint-repository.js';
+import { databaseBuilder, expect, sinon } from '../../../test-helper.js';
+
+describe('Script | Prod | Attach quest to existing combined course blueprints', function () {
+  let script;
+  describe('Options', function () {
+    it('has the correct options', function () {
+      // when
+      script = new AttachQuestToExistingCombinedCourseBlueprintsScript();
+      const { description } = script.metaInfo;
+      expect(description).to.equal(
+        'This script will create a quest for the existing combined course blueprints without quest',
+      );
+    });
+  });
+  describe('#handle', function () {
+    const logger = { info: sinon.spy(), error: sinon.spy() };
+
+    describe('#dryRun false', function () {
+      it('should create quest for combined course blueprint without quest id', async function () {
+        const { id: questId1 } = await databaseBuilder.factory.buildQuestForCombinedCourse({ rewardType: null });
+        const { id: questId2 } = await databaseBuilder.factory.buildQuestForCombinedCourse({ rewardType: null });
+
+        await databaseBuilder.factory.buildCombinedCourseBlueprint({ questId: null });
+        await databaseBuilder.factory.buildCombinedCourseBlueprint({ questId: null });
+        await databaseBuilder.factory.buildCombinedCourseBlueprint({ questId: questId1 });
+        await databaseBuilder.factory.buildCombinedCourseBlueprint({ questId: questId2 });
+
+        await databaseBuilder.commit();
+
+        //when
+        await script.handle({ options: { dryRun: false }, logger });
+
+        //then
+        const results = await combinedCourseBlueprintRepository.findAll();
+        expect(results.every((result) => result.quest)).to.be.true;
+      });
+    });
+    describe('#dryRun true', function () {
+      it('should not create any quest', async function () {
+        const { id: questId1 } = await databaseBuilder.factory.buildQuestForCombinedCourse({ rewardType: null });
+        const { id: questId2 } = await databaseBuilder.factory.buildQuestForCombinedCourse({ rewardType: null });
+
+        await databaseBuilder.factory.buildCombinedCourseBlueprint({ questId: null });
+        await databaseBuilder.factory.buildCombinedCourseBlueprint({ questId: null });
+        await databaseBuilder.factory.buildCombinedCourseBlueprint({ questId: questId1 });
+        await databaseBuilder.factory.buildCombinedCourseBlueprint({ questId: questId2 });
+
+        await databaseBuilder.commit();
+
+        //when
+        await script.handle({ options: { dryRun: true }, logger });
+
+        //then
+        const results = await combinedCourseBlueprintRepository.findAll();
+        expect(results.filter((result) => result.quest).length).to.equal(2);
+        expect(results.filter((result) => !result.quest).length).to.equal(2);
+      });
+    });
+  });
+});

--- a/api/tests/quest/integration/infrastructure/repositories/combined-course-blueprint-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/combined-course-blueprint-repository_test.js
@@ -35,11 +35,7 @@ describe('Quest | Integration | Repository | combined-course-blueprint', functio
       expect(results).lengthOf(1);
       expect(results[0]).deep.equal(savedCombinedCourseBlueprint);
       expect(results[0]).deep.contain({ ...combinedCourseBlueprint.combinedCourseBlueprint });
-      expect(
-        results[0].quest.successRequirements.map((successRequirement) => {
-          return { ...successRequirement, data: successRequirement.data };
-        }),
-      ).deep.equal([
+      expect(results[0].quest.toDTO().successRequirements).deep.equal([
         {
           comparison: REQUIREMENT_COMPARISONS.ALL,
           data: {
@@ -193,11 +189,7 @@ describe('Quest | Integration | Repository | combined-course-blueprint', functio
       const results = await combinedCourseBluePrintRepository.findAll();
       expect(results).lengthOf(1);
       expect(results[0].name).equal('Updated Combined course IA');
-      expect(
-        results[0].quest.successRequirements.map((successRequirement) => {
-          return { ...successRequirement, data: successRequirement.data };
-        }),
-      ).deep.equal([
+      expect(results[0].quest.toDTO().successRequirements).deep.equal([
         {
           comparison: REQUIREMENT_COMPARISONS.ALL,
           requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
@@ -210,8 +202,51 @@ describe('Quest | Integration | Repository | combined-course-blueprint', functio
           },
         },
       ]);
+    });
 
-      // TODO integration test for usecase (create combined course bp)
+    it('should attach a new quest to combined course blueprint when none', async function () {
+      // given
+      const combinedCourseBlueprintInDb = databaseBuilder.factory.buildCombinedCourseBlueprint({
+        questId: null,
+        content: CombinedCourseBlueprint.buildContentItems([{ moduleShortId: '6a68bf32' }]),
+      });
+
+      const combinedCourseBlueprint = CombinedCourseBlueprint.buildWithQuest({
+        combinedCourseBlueprint: new CombinedCourseBlueprint({
+          id: combinedCourseBlueprintInDb.id,
+          name: 'Combined course IA',
+          internalName: 'Ia combined course blueprint',
+          description: "L'ia c'est magique",
+          illustration: 'illustration/ia.svg',
+          content: CombinedCourseBlueprint.buildContentItems([{ moduleShortId: '6a68bf32' }]),
+          organizationIds: [],
+        }),
+        modulesByShortId: { '6a68bf32': [{ id: '6282925d-4775-4bca-b513-4c3009ec5886' }] },
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      await combinedCourseBluePrintRepository.save({
+        combinedCourseBlueprint,
+      });
+
+      // then
+      const results = await combinedCourseBluePrintRepository.findAll();
+      expect(results).lengthOf(1);
+      expect(results[0].quest.toDTO().successRequirements).deep.equal([
+        {
+          comparison: REQUIREMENT_COMPARISONS.ALL,
+          requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
+          data: {
+            isTerminated: { comparison: CRITERION_COMPARISONS.EQUAL, data: true },
+            moduleId: {
+              comparison: CRITERION_COMPARISONS.EQUAL,
+              data: '6282925d-4775-4bca-b513-4c3009ec5886',
+            },
+          },
+        },
+      ]);
     });
   });
 


### PR DESCRIPTION
## 🥀 Problème
Pour implémenter les attestations sur les parcours combinés, on a décidé que les schémas de parcours combinés doivent tous être porteurs d'une quête avec leur contenu et leurs éventuelles récompenses attachées.
Il faut donc rattraper les données de production car seuls les parcours combinés portaient cette information auparavant (pas les schémas de parcours).

## 🏹 Proposition
On scripte le rattachement en utilisant la méthode findAll du combinedCourseBlueprintRepository, et on utilise le usecase createCombinedCourseBlueprint car il appelle la méthode .save du repository qui fait un update.

## 💌 Remarques
On a remarqué que le .save ne passait pas le questId au toDTO au moment de l'update. On a donc profité de cette PR pour réparer ce point.

## ❤️‍🔥 Pour tester
node ./scripts/prod/attach-quest-to-existing-combined-course-blueprints.js --dryRun=true
Vérifier qu'aucune quête n'a été créée

node ./scripts/prod/attach-quest-to-existing-combined-course-blueprints.js --dryRun=false
Vérifier qu'il existe une quête pour chaque blueprint existant en base
