### PR TITLE
[TECH] Mettre à jour les récupérations d'un contenu formatif à partir d'une locale (PIX-21789)

### DIFF
--- a/api/db/database-builder/factory/build-training.js
+++ b/api/db/database-builder/factory/build-training.js
@@ -12,6 +12,7 @@ import { databaseBuffer } from '../database-buffer.js';
  *  locales: string[],
  *  editorName: string,
  *  editorLogoUrl: string,
+ *  isDisabled: boolean,
  *  createdAt: Date,
  *  updatedAt: Date
  * }} Training

--- a/api/src/devcomp/infrastructure/repositories/training-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/training-repository.js
@@ -3,6 +3,7 @@ import lodash from 'lodash';
 import { USER_RECOMMENDED_TRAININGS_TABLE_NAME } from '../../../../db/migrations/20221017085933_create-user-recommended-trainings.js';
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../shared/domain/errors.js';
+import { featureToggles } from '../../../shared/infrastructure/feature-toggles/index.js';
 import { fetchPage } from '../../../shared/infrastructure/utils/knex-utils.js';
 import { Training } from '../../domain/models/Training.js';
 import { TrainingTrigger } from '../../domain/models/TrainingTrigger.js';
@@ -181,12 +182,20 @@ async function update({ id, attributesToUpdate }) {
 
 async function findPaginatedByUserId({ userId, locale, page }) {
   const knexConn = DomainTransaction.getConnection();
-  const query = knexConn(TABLE_NAME)
+
+  const multipleLocalesForTrainingsEnabled = await featureToggles.get('multipleLocalesForTrainingsEnabled');
+
+  const baseQuery = knexConn(TABLE_NAME)
     .select('trainings.*')
     .distinct('trainings.id')
     .join(USER_RECOMMENDED_TRAININGS_TABLE_NAME, 'trainings.id', 'trainingId')
-    .where({ userId, locale, isDisabled: false })
+    .where({ userId, isDisabled: false })
     .orderBy('id', 'asc');
+
+  const query = multipleLocalesForTrainingsEnabled
+    ? baseQuery.whereRaw('? = ANY(locales)', locale)
+    : baseQuery.where({ locale });
+
   const { results, pagination } = await fetchPage({ queryBuilder: query, paginationParams: page });
 
   const userRecommendedTrainings = results.map(

--- a/api/src/devcomp/infrastructure/repositories/training-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/training-repository.js
@@ -111,14 +111,19 @@ async function findPaginatedSummariesByTargetProfileId({ targetProfileId, page }
 
 async function findWithTriggersByCampaignParticipationIdAndLocale({ campaignParticipationId, locale }) {
   const knexConn = DomainTransaction.getConnection();
-  const trainingsDTO = await knexConn(TABLE_NAME)
+  const multipleLocalesForTrainingsEnabled = await featureToggles.get('multipleLocalesForTrainingsEnabled');
+
+  const baseQuery = knexConn(TABLE_NAME)
     .select('trainings.*')
     .join('target-profile-trainings', `${TABLE_NAME}.id`, 'trainingId')
     .join('campaigns', 'campaigns.targetProfileId', 'target-profile-trainings.targetProfileId')
     .join('campaign-participations', 'campaign-participations.campaignId', 'campaigns.id')
     .where({ 'campaign-participations.id': campaignParticipationId })
-    .where({ locale })
     .orderBy('trainings.id', 'asc');
+
+  const trainingsDTO = multipleLocalesForTrainingsEnabled
+    ? await baseQuery.whereRaw('? = ANY(locales)', locale)
+    : await baseQuery.where({ locale });
 
   const targetProfileTrainings = await knexConn('target-profile-trainings').whereIn(
     'trainingId',

--- a/api/tests/devcomp/integration/infrastructure/repositories/training-repository_test.js
+++ b/api/tests/devcomp/integration/infrastructure/repositories/training-repository_test.js
@@ -9,6 +9,7 @@ import { TrainingTriggerForAdmin } from '../../../../../src/devcomp/domain/read-
 import { UserRecommendedTraining } from '../../../../../src/devcomp/domain/read-models/UserRecommendedTraining.js';
 import * as trainingRepository from '../../../../../src/devcomp/infrastructure/repositories/training-repository.js';
 import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
+import { featureToggles } from '../../../../../src/shared/infrastructure/feature-toggles/index.js';
 import {
   catchErr,
   databaseBuilder,
@@ -746,115 +747,230 @@ describe('Integration | Repository | training-repository', function () {
   });
 
   describe('#findPaginatedByUserId', function () {
-    it('should return paginated trainings related to given userId', async function () {
-      // given
-      const { userId, id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation();
-      const { id: campaignParticipationId2 } = databaseBuilder.factory.buildCampaignParticipation({ userId });
-      const { userId: anotherUserId, id: anotherCampaignParticipationId } =
-        databaseBuilder.factory.buildCampaignParticipation();
-      const training1 = databaseBuilder.factory.buildTraining();
-      const training2 = databaseBuilder.factory.buildTraining();
-      const training3 = databaseBuilder.factory.buildTraining();
-      const training4 = databaseBuilder.factory.buildTraining();
-      const trainingWithAnotherLocale = databaseBuilder.factory.buildTraining({ locale: 'en' });
-      databaseBuilder.factory.buildUserRecommendedTraining({
-        userId,
-        trainingId: training1.id,
-        campaignParticipationId,
-      });
-      databaseBuilder.factory.buildUserRecommendedTraining({
-        userId,
-        trainingId: training1.id,
-        campaignParticipationId: campaignParticipationId2,
-      });
-      databaseBuilder.factory.buildUserRecommendedTraining({
-        userId,
-        trainingId: training2.id,
-        campaignParticipationId,
-      });
-      databaseBuilder.factory.buildUserRecommendedTraining({
-        userId,
-        trainingId: training3.id,
-        campaignParticipationId,
-      });
-      databaseBuilder.factory.buildUserRecommendedTraining({
-        userId,
-        trainingId: training4.id,
-        campaignParticipationId,
-      });
-      databaseBuilder.factory.buildUserRecommendedTraining({
-        userId,
-        trainingId: trainingWithAnotherLocale.id,
-        campaignParticipationId,
-      });
-      databaseBuilder.factory.buildUserRecommendedTraining({
-        userId: anotherUserId,
-        trainingId: training2.id,
-        campaignParticipationId: anotherCampaignParticipationId,
-      });
-      await databaseBuilder.commit();
-
-      const page = { size: 2, number: 2 };
-
-      // when
-      const { userRecommendedTrainings, pagination } = await trainingRepository.findPaginatedByUserId({
-        userId,
-        locale: 'fr-fr',
-        page,
+    describe('when "multipleLocalesForTrainingsEnabled" feature toggle is true', function () {
+      beforeEach(async function () {
+        await featureToggles.set('multipleLocalesForTrainingsEnabled', true);
       });
 
-      // then
-      expect(userRecommendedTrainings).to.be.lengthOf(2);
-      expect(userRecommendedTrainings[0]).to.be.instanceOf(UserRecommendedTraining);
-      expect(userRecommendedTrainings).to.deep.equal([
-        new UserRecommendedTraining({ ...training3, duration: { hours: 6 } }),
-        new UserRecommendedTraining({ ...training4, duration: { hours: 6 } }),
-      ]);
-      expect(pagination).to.equal(pagination);
+      it('should return paginated trainings related to given userId', async function () {
+        // given
+        const { userId, id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation();
+        const { id: campaignParticipationId2 } = databaseBuilder.factory.buildCampaignParticipation({ userId });
+        const userLocales = ['fr', 'fr-fr'];
+
+        const training1 = databaseBuilder.factory.buildTraining({
+          title: 'training1',
+          internalTitle: 'internalTitle1',
+          locales: userLocales,
+        });
+        const training2 = databaseBuilder.factory.buildTraining({
+          title: 'training2',
+          internalTitle: 'internalTitle2',
+          locales: userLocales,
+        });
+        const training3 = databaseBuilder.factory.buildTraining({
+          title: 'training3',
+          internalTitle: 'internalTitle3',
+          locales: userLocales,
+        });
+
+        databaseBuilder.factory.buildUserRecommendedTraining({
+          userId,
+          trainingId: training1.id,
+          campaignParticipationId,
+        });
+        databaseBuilder.factory.buildUserRecommendedTraining({
+          userId,
+          trainingId: training2.id,
+          campaignParticipationId,
+        });
+        databaseBuilder.factory.buildUserRecommendedTraining({
+          userId,
+          trainingId: training3.id,
+          campaignParticipationId2,
+        });
+
+        await databaseBuilder.commit();
+
+        const page = { number: 1, size: 2 };
+
+        // when
+        const { userRecommendedTrainings, pagination } = await trainingRepository.findPaginatedByUserId({
+          userId,
+          locale: 'fr',
+          page,
+        });
+
+        // then
+        expect(userRecommendedTrainings).to.be.lengthOf(2);
+        expect(userRecommendedTrainings).to.deep.equal([
+          new UserRecommendedTraining({ ...training1, duration: { hours: 6 } }),
+          new UserRecommendedTraining({ ...training2, duration: { hours: 6 } }),
+        ]);
+        expect(pagination).to.deep.equal({
+          page: 1,
+          pageCount: 2,
+          pageSize: 2,
+          rowCount: 3,
+        });
+      });
+
+      it('should return an empty array when given user does not have recommended trainings', async function () {
+        // given
+        const { id: userId } = databaseBuilder.factory.buildUser();
+
+        await databaseBuilder.commit();
+
+        // when
+        const { userRecommendedTrainings, pagination } = await trainingRepository.findPaginatedByUserId({
+          userId,
+          locale: 'fr-fr',
+        });
+
+        // then
+        expect(userRecommendedTrainings).to.be.lengthOf(0);
+        expect(pagination).to.deep.equal({ page: 1, pageSize: 10, rowCount: 0, pageCount: 0 });
+      });
+
+      it('should return an empty array when user only has disabled trainings', async function () {
+        // given
+        const { userId, id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation();
+        const locales = ['fr', 'fr-fr'];
+
+        const disabledTraining = databaseBuilder.factory.buildTraining({ isDisabled: true, locales });
+        databaseBuilder.factory.buildUserRecommendedTraining({
+          userId,
+          trainingId: disabledTraining.id,
+          campaignParticipationId,
+        });
+        await databaseBuilder.commit();
+
+        // when
+        const { userRecommendedTrainings, pagination } = await trainingRepository.findPaginatedByUserId({
+          userId,
+          locale: 'fr-fr',
+        });
+
+        // then
+        expect(userRecommendedTrainings).to.be.lengthOf(0);
+        expect(pagination).to.deep.equal({ page: 1, pageSize: 10, rowCount: 0, pageCount: 0 });
+      });
     });
 
-    it('should return an empty array when given user does not have recommended trainings', async function () {
-      // given
-      const { userId, id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation();
-      const training1 = databaseBuilder.factory.buildTraining();
-      databaseBuilder.factory.buildUserRecommendedTraining({
-        userId,
-        trainingId: training1.id,
-        campaignParticipationId,
+    describe('when "multipleLocalesForTrainingsEnabled" feature toggle is false', function () {
+      beforeEach(async function () {
+        await featureToggles.set('multipleLocalesForTrainingsEnabled', false);
       });
-      await databaseBuilder.commit();
+      it('should return paginated trainings related to given userId', async function () {
+        // given
+        const { userId, id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation();
+        const { id: campaignParticipationId2 } = databaseBuilder.factory.buildCampaignParticipation({ userId });
+        const { userId: anotherUserId, id: anotherCampaignParticipationId } =
+          databaseBuilder.factory.buildCampaignParticipation();
+        const training1 = databaseBuilder.factory.buildTraining();
+        const training2 = databaseBuilder.factory.buildTraining();
+        const training3 = databaseBuilder.factory.buildTraining();
+        const training4 = databaseBuilder.factory.buildTraining();
+        const trainingWithAnotherLocale = databaseBuilder.factory.buildTraining({ locale: 'en' });
+        databaseBuilder.factory.buildUserRecommendedTraining({
+          userId,
+          trainingId: training1.id,
+          campaignParticipationId,
+        });
+        databaseBuilder.factory.buildUserRecommendedTraining({
+          userId,
+          trainingId: training1.id,
+          campaignParticipationId: campaignParticipationId2,
+        });
+        databaseBuilder.factory.buildUserRecommendedTraining({
+          userId,
+          trainingId: training2.id,
+          campaignParticipationId,
+        });
+        databaseBuilder.factory.buildUserRecommendedTraining({
+          userId,
+          trainingId: training3.id,
+          campaignParticipationId,
+        });
+        databaseBuilder.factory.buildUserRecommendedTraining({
+          userId,
+          trainingId: training4.id,
+          campaignParticipationId,
+        });
+        databaseBuilder.factory.buildUserRecommendedTraining({
+          userId,
+          trainingId: trainingWithAnotherLocale.id,
+          campaignParticipationId,
+        });
+        databaseBuilder.factory.buildUserRecommendedTraining({
+          userId: anotherUserId,
+          trainingId: training2.id,
+          campaignParticipationId: anotherCampaignParticipationId,
+        });
+        await databaseBuilder.commit();
 
-      // when
-      const { userRecommendedTrainings, pagination } = await trainingRepository.findPaginatedByUserId({
-        userId: '0293',
-        locale: 'fr-fr',
+        const page = { size: 2, number: 2 };
+
+        // when
+        const { userRecommendedTrainings, pagination } = await trainingRepository.findPaginatedByUserId({
+          userId,
+          locale: 'fr-fr',
+          page,
+        });
+
+        // then
+        expect(userRecommendedTrainings).to.be.lengthOf(2);
+        expect(userRecommendedTrainings[0]).to.be.instanceOf(UserRecommendedTraining);
+        expect(userRecommendedTrainings).to.deep.equal([
+          new UserRecommendedTraining({ ...training3, duration: { hours: 6 } }),
+          new UserRecommendedTraining({ ...training4, duration: { hours: 6 } }),
+        ]);
+        expect(pagination).to.equal(pagination);
       });
 
-      // then
-      expect(userRecommendedTrainings).to.be.lengthOf(0);
-      expect(pagination).to.deep.equal({ page: 1, pageSize: 10, rowCount: 0, pageCount: 0 });
-    });
+      it('should return an empty array when given user does not have recommended trainings', async function () {
+        // given
+        const { userId, id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation();
+        const training1 = databaseBuilder.factory.buildTraining();
+        databaseBuilder.factory.buildUserRecommendedTraining({
+          userId,
+          trainingId: training1.id,
+          campaignParticipationId,
+        });
+        await databaseBuilder.commit();
 
-    it('should not return disabled trainings', async function () {
-      // given
-      const { userId, id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation();
-      const training1 = databaseBuilder.factory.buildTraining({ isDisabled: true });
-      databaseBuilder.factory.buildUserRecommendedTraining({
-        userId,
-        trainingId: training1.id,
-        campaignParticipationId,
+        // when
+        const { userRecommendedTrainings, pagination } = await trainingRepository.findPaginatedByUserId({
+          userId: '0293',
+          locale: 'fr-fr',
+        });
+
+        // then
+        expect(userRecommendedTrainings).to.be.lengthOf(0);
+        expect(pagination).to.deep.equal({ page: 1, pageSize: 10, rowCount: 0, pageCount: 0 });
       });
-      await databaseBuilder.commit();
 
-      // when
-      const { userRecommendedTrainings, pagination } = await trainingRepository.findPaginatedByUserId({
-        userId,
-        locale: 'fr-fr',
+      it('should not return disabled trainings', async function () {
+        // given
+        const { userId, id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation();
+        const training1 = databaseBuilder.factory.buildTraining({ isDisabled: true });
+        databaseBuilder.factory.buildUserRecommendedTraining({
+          userId,
+          trainingId: training1.id,
+          campaignParticipationId,
+        });
+        await databaseBuilder.commit();
+
+        // when
+        const { userRecommendedTrainings, pagination } = await trainingRepository.findPaginatedByUserId({
+          userId,
+          locale: 'fr-fr',
+        });
+
+        // then
+        expect(userRecommendedTrainings).to.be.lengthOf(0);
+        expect(pagination).to.deep.equal({ page: 1, pageSize: 10, rowCount: 0, pageCount: 0 });
       });
-
-      // then
-      expect(userRecommendedTrainings).to.be.lengthOf(0);
-      expect(pagination).to.deep.equal({ page: 1, pageSize: 10, rowCount: 0, pageCount: 0 });
     });
   });
 

--- a/api/tests/devcomp/integration/infrastructure/repositories/training-repository_test.js
+++ b/api/tests/devcomp/integration/infrastructure/repositories/training-repository_test.js
@@ -413,180 +413,374 @@ describe('Integration | Repository | training-repository', function () {
       await mockLearningContent(learningContent);
     });
 
-    it('should find trainings by campaignParticipationId and locale', async function () {
-      // given
-      const targetProfile1 = databaseBuilder.factory.buildTargetProfile();
-      const targetProfile2 = databaseBuilder.factory.buildTargetProfile();
-      const campaign = databaseBuilder.factory.buildCampaign({
-        targetProfileId: targetProfile1.id,
-      });
-      const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
-        campaignId: campaign.id,
-      });
-      const training1 = domainBuilder.buildTraining({
-        id: 1,
-        title: 'training 1',
-        targetProfileIds: [targetProfile1.id],
-        locale: 'fr-fr',
-        trainingTriggers: [],
-      });
-      const training2 = domainBuilder.buildTraining({
-        id: 2,
-        title: 'training 2',
-        targetProfileIds: [targetProfile1.id],
-        locale: 'fr-fr',
-        trainingTriggers: [],
-      });
-      const trainingWithDifferentLocale = domainBuilder.buildTraining({
-        id: 3,
-        title: 'training 3',
-        targetProfileIds: [targetProfile1.id],
-        locale: 'en',
-        trainingTriggers: [],
-      });
-      const trainingWithDifferentTargetProfile = domainBuilder.buildTraining({
-        id: 4,
-        title: 'training 4',
-        targetProfileIds: [targetProfile2.id],
-        locale: 'fr-fr',
-        trainingTriggers: [],
+    describe('when "multipleLocalesForTrainingsEnabled" feature toggle is true', function () {
+      beforeEach(async function () {
+        await featureToggles.set('multipleLocalesForTrainingsEnabled', true);
       });
 
-      databaseBuilder.factory.buildTraining({ ...training1, duration: '5h' });
-      databaseBuilder.factory.buildTraining({ ...training2, duration: '5h' });
-      databaseBuilder.factory.buildTraining({ ...trainingWithDifferentLocale, duration: '5h' });
-      databaseBuilder.factory.buildTraining({ ...trainingWithDifferentTargetProfile, duration: '5h' });
+      it('should find trainings by campaignParticipationId and locale', async function () {
+        // given
+        const targetProfile1 = databaseBuilder.factory.buildTargetProfile();
+        const targetProfile2 = databaseBuilder.factory.buildTargetProfile();
+        const campaign = databaseBuilder.factory.buildCampaign({
+          targetProfileId: targetProfile1.id,
+        });
+        const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: campaign.id,
+        });
+        const training1 = domainBuilder.buildTraining({
+          id: 1,
+          title: 'training 1',
+          targetProfileIds: [targetProfile1.id],
+          locale: 'fr-fr',
+          locales: ['fr', 'fr-fr'],
+          trainingTriggers: [],
+        });
+        const training2 = domainBuilder.buildTraining({
+          id: 2,
+          title: 'training 2',
+          targetProfileIds: [targetProfile1.id],
+          locale: 'fr-fr',
+          locales: ['fr', 'fr-fr'],
+          trainingTriggers: [],
+        });
+        const trainingWithDifferentLocale = domainBuilder.buildTraining({
+          id: 3,
+          title: 'training 3',
+          targetProfileIds: [targetProfile1.id],
+          locale: 'en',
+          locales: ['en'],
+          trainingTriggers: [],
+        });
+        const trainingWithDifferentTargetProfile = domainBuilder.buildTraining({
+          id: 4,
+          title: 'training 4',
+          targetProfileIds: [targetProfile2.id],
+          locale: 'fr-fr',
+          locales: ['fr', 'fr-fr'],
+          trainingTriggers: [],
+        });
 
-      databaseBuilder.factory.buildTargetProfileTraining({
-        trainingId: training1.id,
-        targetProfileId: training1.targetProfileIds[0],
+        databaseBuilder.factory.buildTraining({ ...training1, duration: '5h' });
+        databaseBuilder.factory.buildTraining({ ...training2, duration: '5h' });
+        databaseBuilder.factory.buildTraining({ ...trainingWithDifferentLocale, duration: '5h' });
+        databaseBuilder.factory.buildTraining({ ...trainingWithDifferentTargetProfile, duration: '5h' });
+
+        databaseBuilder.factory.buildTargetProfileTraining({
+          trainingId: training1.id,
+          targetProfileId: training1.targetProfileIds[0],
+        });
+
+        databaseBuilder.factory.buildTargetProfileTraining({
+          trainingId: training2.id,
+          targetProfileId: training2.targetProfileIds[0],
+        });
+
+        databaseBuilder.factory.buildTargetProfileTraining({
+          trainingId: trainingWithDifferentLocale.id,
+          targetProfileId: trainingWithDifferentLocale.targetProfileIds[0],
+        });
+
+        databaseBuilder.factory.buildTargetProfileTraining({
+          trainingId: trainingWithDifferentTargetProfile.id,
+          targetProfileId: trainingWithDifferentTargetProfile.targetProfileIds[0],
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const trainings = await trainingRepository.findWithTriggersByCampaignParticipationIdAndLocale({
+          campaignParticipationId: campaignParticipation.id,
+          locale: 'fr',
+        });
+
+        // then
+        expect(trainings).to.have.lengthOf(2);
+        expect(trainings[0]).to.be.instanceOf(Training);
+        expect(trainings[0]).to.deep.equal(training1);
       });
 
-      databaseBuilder.factory.buildTargetProfileTraining({
-        trainingId: training2.id,
-        targetProfileId: training2.targetProfileIds[0],
+      it('should return trainings with trainingTriggers', async function () {
+        // given
+        const targetProfile = databaseBuilder.factory.buildTargetProfile();
+        const campaign = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id });
+        const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({ campaignId: campaign.id });
+        const training = domainBuilder.buildTraining({
+          id: 1,
+          title: 'training 1',
+          targetProfileIds: [targetProfile.id],
+          locale: 'fr-fr',
+          locales: ['fr', 'fr-fr'],
+        });
+
+        const goalTrainingTrigger = {
+          trainingId: training.id,
+          type: TrainingTrigger.types.GOAL,
+          threshold: 80,
+        };
+
+        databaseBuilder.factory.buildTraining({ ...training, duration: '5h' });
+        databaseBuilder.factory.buildTargetProfileTraining({
+          trainingId: training.id,
+          targetProfileId: training.targetProfileIds[0],
+        });
+
+        const expectedGoalTrainingTrigger = databaseBuilder.factory.buildTrainingTrigger(goalTrainingTrigger);
+        const expectedGoalTube = databaseBuilder.factory.buildTrainingTriggerTube({
+          trainingTriggerId: expectedGoalTrainingTrigger.id,
+          tubeId: tube.id,
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const trainings = await trainingRepository.findWithTriggersByCampaignParticipationIdAndLocale({
+          campaignParticipationId: campaignParticipation.id,
+          locale: 'fr',
+        });
+
+        // then
+        expect(trainings).to.have.lengthOf(1);
+        expect(trainings[0]).to.be.instanceOf(Training);
+        expect(_.omit(trainings[0], 'trainingTriggers')).to.deep.equal(_.omit(training, 'trainingTriggers'));
+
+        expect(trainings[0].trainingTriggers).to.have.lengthOf(1);
+
+        const trainingTrigger0 = trainings[0].trainingTriggers[0];
+        expect(trainingTrigger0).to.be.instanceOf(TrainingTrigger);
+        expect(_.omit(trainingTrigger0, 'triggerTubes')).to.deep.equal(
+          _.omit(
+            new TrainingTrigger({
+              ...expectedGoalTrainingTrigger,
+            }),
+            'triggerTubes',
+          ),
+        );
+        expect(trainingTrigger0.triggerTubes).to.have.lengthOf(1);
+        expect(trainingTrigger0.triggerTubes[0]).to.be.instanceOf(TrainingTriggerTube);
+        expect(trainingTrigger0.triggerTubes[0].id).to.equal(expectedGoalTube.id);
+        expect(trainingTrigger0.triggerTubes[0].tube.id).to.equal(expectedGoalTube.tubeId);
+        expect(trainingTrigger0.triggerTubes[0].level).to.equal(expectedGoalTube.level);
       });
 
-      databaseBuilder.factory.buildTargetProfileTraining({
-        trainingId: trainingWithDifferentLocale.id,
-        targetProfileId: trainingWithDifferentLocale.targetProfileIds[0],
+      it('should return an empty array when campaign has target-profile not linked to training', async function () {
+        // given
+        const targetProfile1 = databaseBuilder.factory.buildTargetProfile();
+        const targetProfile2 = databaseBuilder.factory.buildTargetProfile();
+        const campaign = databaseBuilder.factory.buildCampaign({
+          targetProfileId: targetProfile1.id,
+        });
+        const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: campaign.id,
+        });
+        const training = domainBuilder.buildTraining({
+          id: 1,
+          title: 'training 1',
+          targetProfileIds: [targetProfile2.id],
+          locale: 'fr-fr',
+          locales: ['fr', 'fr-fr'],
+        });
+
+        databaseBuilder.factory.buildTraining({ ...training, duration: '5h' });
+
+        databaseBuilder.factory.buildTargetProfileTraining({
+          trainingId: training.id,
+          targetProfileId: training.targetProfileIds[0],
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const trainings = await trainingRepository.findWithTriggersByCampaignParticipationIdAndLocale({
+          campaignParticipationId: campaignParticipation.id,
+          locale: 'fr',
+        });
+
+        // then
+        expect(trainings).to.have.lengthOf(0);
       });
-
-      databaseBuilder.factory.buildTargetProfileTraining({
-        trainingId: trainingWithDifferentTargetProfile.id,
-        targetProfileId: trainingWithDifferentTargetProfile.targetProfileIds[0],
-      });
-
-      await databaseBuilder.commit();
-
-      // when
-      const trainings = await trainingRepository.findWithTriggersByCampaignParticipationIdAndLocale({
-        campaignParticipationId: campaignParticipation.id,
-        locale: 'fr-fr',
-      });
-
-      // then
-      expect(trainings).to.have.lengthOf(2);
-      expect(trainings[0]).to.be.instanceOf(Training);
-      expect(trainings[0]).to.deep.equal(training1);
     });
 
-    it('should return trainings with trainingTriggers', async function () {
-      // given
-      const targetProfile = databaseBuilder.factory.buildTargetProfile();
-      const campaign = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id });
-      const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({ campaignId: campaign.id });
-      const training = domainBuilder.buildTraining({
-        id: 1,
-        title: 'training 1',
-        targetProfileIds: [targetProfile.id],
-        locale: 'fr-fr',
+    describe('when "multipleLocalesForTrainingsEnabled" feature toggle is false', function () {
+      beforeEach(async function () {
+        await featureToggles.set('multipleLocalesForTrainingsEnabled', false);
       });
 
-      const goalTrainingTrigger = {
-        trainingId: training.id,
-        type: TrainingTrigger.types.GOAL,
-        threshold: 80,
-      };
+      it('should find trainings by campaignParticipationId and locale', async function () {
+        // given
+        const targetProfile1 = databaseBuilder.factory.buildTargetProfile();
+        const targetProfile2 = databaseBuilder.factory.buildTargetProfile();
+        const campaign = databaseBuilder.factory.buildCampaign({
+          targetProfileId: targetProfile1.id,
+        });
+        const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: campaign.id,
+        });
+        const training1 = domainBuilder.buildTraining({
+          id: 1,
+          title: 'training 1',
+          targetProfileIds: [targetProfile1.id],
+          locale: 'fr-fr',
+          trainingTriggers: [],
+        });
+        const training2 = domainBuilder.buildTraining({
+          id: 2,
+          title: 'training 2',
+          targetProfileIds: [targetProfile1.id],
+          locale: 'fr-fr',
+          trainingTriggers: [],
+        });
+        const trainingWithDifferentLocale = domainBuilder.buildTraining({
+          id: 3,
+          title: 'training 3',
+          targetProfileIds: [targetProfile1.id],
+          locale: 'en',
+          trainingTriggers: [],
+        });
+        const trainingWithDifferentTargetProfile = domainBuilder.buildTraining({
+          id: 4,
+          title: 'training 4',
+          targetProfileIds: [targetProfile2.id],
+          locale: 'fr-fr',
+          trainingTriggers: [],
+        });
 
-      databaseBuilder.factory.buildTraining({ ...training, duration: '5h' });
-      databaseBuilder.factory.buildTargetProfileTraining({
-        trainingId: training.id,
-        targetProfileId: training.targetProfileIds[0],
+        databaseBuilder.factory.buildTraining({ ...training1, duration: '5h' });
+        databaseBuilder.factory.buildTraining({ ...training2, duration: '5h' });
+        databaseBuilder.factory.buildTraining({ ...trainingWithDifferentLocale, duration: '5h' });
+        databaseBuilder.factory.buildTraining({ ...trainingWithDifferentTargetProfile, duration: '5h' });
+
+        databaseBuilder.factory.buildTargetProfileTraining({
+          trainingId: training1.id,
+          targetProfileId: training1.targetProfileIds[0],
+        });
+
+        databaseBuilder.factory.buildTargetProfileTraining({
+          trainingId: training2.id,
+          targetProfileId: training2.targetProfileIds[0],
+        });
+
+        databaseBuilder.factory.buildTargetProfileTraining({
+          trainingId: trainingWithDifferentLocale.id,
+          targetProfileId: trainingWithDifferentLocale.targetProfileIds[0],
+        });
+
+        databaseBuilder.factory.buildTargetProfileTraining({
+          trainingId: trainingWithDifferentTargetProfile.id,
+          targetProfileId: trainingWithDifferentTargetProfile.targetProfileIds[0],
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const trainings = await trainingRepository.findWithTriggersByCampaignParticipationIdAndLocale({
+          campaignParticipationId: campaignParticipation.id,
+          locale: 'fr-fr',
+        });
+
+        // then
+        expect(trainings).to.have.lengthOf(2);
+        expect(trainings[0]).to.be.instanceOf(Training);
+        expect(trainings[0]).to.deep.equal(training1);
       });
 
-      const expectedGoalTrainingTrigger = databaseBuilder.factory.buildTrainingTrigger(goalTrainingTrigger);
-      const expectedGoalTube = databaseBuilder.factory.buildTrainingTriggerTube({
-        trainingTriggerId: expectedGoalTrainingTrigger.id,
-        tubeId: tube.id,
+      it('should return trainings with trainingTriggers', async function () {
+        // given
+        const targetProfile = databaseBuilder.factory.buildTargetProfile();
+        const campaign = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id });
+        const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({ campaignId: campaign.id });
+        const training = domainBuilder.buildTraining({
+          id: 1,
+          title: 'training 1',
+          targetProfileIds: [targetProfile.id],
+          locale: 'fr-fr',
+        });
+
+        const goalTrainingTrigger = {
+          trainingId: training.id,
+          type: TrainingTrigger.types.GOAL,
+          threshold: 80,
+        };
+
+        databaseBuilder.factory.buildTraining({ ...training, duration: '5h' });
+        databaseBuilder.factory.buildTargetProfileTraining({
+          trainingId: training.id,
+          targetProfileId: training.targetProfileIds[0],
+        });
+
+        const expectedGoalTrainingTrigger = databaseBuilder.factory.buildTrainingTrigger(goalTrainingTrigger);
+        const expectedGoalTube = databaseBuilder.factory.buildTrainingTriggerTube({
+          trainingTriggerId: expectedGoalTrainingTrigger.id,
+          tubeId: tube.id,
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const trainings = await trainingRepository.findWithTriggersByCampaignParticipationIdAndLocale({
+          campaignParticipationId: campaignParticipation.id,
+          locale: 'fr-fr',
+        });
+
+        // then
+        expect(trainings).to.have.lengthOf(1);
+        expect(trainings[0]).to.be.instanceOf(Training);
+        expect(_.omit(trainings[0], 'trainingTriggers')).to.deep.equal(_.omit(training, 'trainingTriggers'));
+
+        expect(trainings[0].trainingTriggers).to.have.lengthOf(1);
+
+        const trainingTrigger0 = trainings[0].trainingTriggers[0];
+        expect(trainingTrigger0).to.be.instanceOf(TrainingTrigger);
+        expect(_.omit(trainingTrigger0, 'triggerTubes')).to.deep.equal(
+          _.omit(
+            new TrainingTrigger({
+              ...expectedGoalTrainingTrigger,
+            }),
+            'triggerTubes',
+          ),
+        );
+        expect(trainingTrigger0.triggerTubes).to.have.lengthOf(1);
+        expect(trainingTrigger0.triggerTubes[0]).to.be.instanceOf(TrainingTriggerTube);
+        expect(trainingTrigger0.triggerTubes[0].id).to.equal(expectedGoalTube.id);
+        expect(trainingTrigger0.triggerTubes[0].tube.id).to.equal(expectedGoalTube.tubeId);
+        expect(trainingTrigger0.triggerTubes[0].level).to.equal(expectedGoalTube.level);
       });
 
-      await databaseBuilder.commit();
+      it('should return an empty array when campaign has target-profile not linked to training', async function () {
+        // given
+        const targetProfile1 = databaseBuilder.factory.buildTargetProfile();
+        const targetProfile2 = databaseBuilder.factory.buildTargetProfile();
+        const campaign = databaseBuilder.factory.buildCampaign({
+          targetProfileId: targetProfile1.id,
+        });
+        const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: campaign.id,
+        });
+        const training = domainBuilder.buildTraining({
+          id: 1,
+          title: 'training 1',
+          targetProfileIds: [targetProfile2.id],
+          locale: 'fr-fr',
+        });
 
-      // when
-      const trainings = await trainingRepository.findWithTriggersByCampaignParticipationIdAndLocale({
-        campaignParticipationId: campaignParticipation.id,
-        locale: 'fr-fr',
+        databaseBuilder.factory.buildTraining({ ...training, duration: '5h' });
+
+        databaseBuilder.factory.buildTargetProfileTraining({
+          trainingId: training.id,
+          targetProfileId: training.targetProfileIds[0],
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const trainings = await trainingRepository.findWithTriggersByCampaignParticipationIdAndLocale({
+          campaignParticipationId: campaignParticipation.id,
+          locale: 'fr-fr',
+        });
+
+        // then
+        expect(trainings).to.have.lengthOf(0);
       });
-
-      // then
-      expect(trainings).to.have.lengthOf(1);
-      expect(trainings[0]).to.be.instanceOf(Training);
-      expect(_.omit(trainings[0], 'trainingTriggers')).to.deep.equal(_.omit(training, 'trainingTriggers'));
-
-      expect(trainings[0].trainingTriggers).to.have.lengthOf(1);
-
-      const trainingTrigger0 = trainings[0].trainingTriggers[0];
-      expect(trainingTrigger0).to.be.instanceOf(TrainingTrigger);
-      expect(_.omit(trainingTrigger0, 'triggerTubes')).to.deep.equal(
-        _.omit(
-          new TrainingTrigger({
-            ...expectedGoalTrainingTrigger,
-          }),
-          'triggerTubes',
-        ),
-      );
-      expect(trainingTrigger0.triggerTubes).to.have.lengthOf(1);
-      expect(trainingTrigger0.triggerTubes[0]).to.be.instanceOf(TrainingTriggerTube);
-      expect(trainingTrigger0.triggerTubes[0].id).to.equal(expectedGoalTube.id);
-      expect(trainingTrigger0.triggerTubes[0].tube.id).to.equal(expectedGoalTube.tubeId);
-      expect(trainingTrigger0.triggerTubes[0].level).to.equal(expectedGoalTube.level);
-    });
-
-    it('should return an empty array when campaign has target-profile not linked to training', async function () {
-      // given
-      const targetProfile1 = databaseBuilder.factory.buildTargetProfile();
-      const targetProfile2 = databaseBuilder.factory.buildTargetProfile();
-      const campaign = databaseBuilder.factory.buildCampaign({
-        targetProfileId: targetProfile1.id,
-      });
-      const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
-        campaignId: campaign.id,
-      });
-      const training = domainBuilder.buildTraining({
-        id: 1,
-        title: 'training 1',
-        targetProfileIds: [targetProfile2.id],
-        locale: 'fr-fr',
-      });
-
-      databaseBuilder.factory.buildTraining({ ...training, duration: '5h' });
-
-      databaseBuilder.factory.buildTargetProfileTraining({
-        trainingId: training.id,
-        targetProfileId: training.targetProfileIds[0],
-      });
-
-      await databaseBuilder.commit();
-
-      // when
-      const trainings = await trainingRepository.findWithTriggersByCampaignParticipationIdAndLocale({
-        campaignParticipationId: campaignParticipation.id,
-        locale: 'fr-fr',
-      });
-
-      // then
-      expect(trainings).to.have.lengthOf(0);
     });
   });
 


### PR DESCRIPTION
## 🥀 Problème

Actuellement, lorsque l'on veut récupérer des Contenu formatif par rapport à une locale, nous utilisons la colonne `locale` pour filtrer cela. 
Avec l'ajout de la nouvelle colonne `locales`, nous devons mettre à jour les requêtes concernées pour 
plutôt utiliser cette nouvelle colonne.

Ceci conditionné par le feature toggle `multipleLocalesForTrainingsEnabled`

## 🏹 Proposition

Faire cela: filtrer selon la colonne `locales`.

## 💌 Remarques

Il faudrait voir pour simplifier les tests dans le fichier `api/tests/devcomp/integration/infrastructure/repositories/training-repository_test.js`. Ceci afin de gagner en maintenabilité. 

## ❤️‍🔥 Pour tester
Pour faciliter les tests, tous les contenus formatifs sur la BDD de RA ont été modifié : 
- la colonne `locale` avec une valeur `fr-fr`
- la colonne `locales` avec une valeur `{fr}`

### Test avec une locale fr-fr
- Mettre le feature toggles multipleLocalesForTrainingsEnabled à false
- Créer un compte sur [Pix App (.fr)](https://app-pr15437.review.pix.fr/inscription) 
- Passer la campagne avec le code MAXICAMP
- Une fois arrivé sur la page de résultats, quitter la campagne pour revenir sur la page d'accueil
- Rafraîchir la page et constater que dans l'onglet `mes formations`, 8 contenus formatifs sont bien affichés.
- Créer un compte sur [Pix App (.org)](https://app-pr15437.review.pix.org/inscription) 
- Passer la campagne avec le même code et répéter les même étapes
- Constater cette fois-ci qu'il n'y a pas de contenu formatif recommandé (car la locale de l'utilisateur est fr, et pas fr-fr comme dans la colonne `locale`)

### Test avec une locale fr
- Mettre le feature toggles multipleLocalesForTrainingsEnabled à true
- Créer un compte sur [Pix App (.org)](https://app-pr15437.review.pix.org/inscription) 
- Passer la campagne avec le code MAXICAMP
- Une fois arrivé sur la page de résultats, quitter la campagne pour revenir sur la page d'accueil
- Rafraîchir la page et constater que dans l'onglet `mes formations`, 8 contenus formatifs sont bien affichés.
- Créer un compte sur [Pix App (.fr)](https://app-pr15437.review.pix.fr/inscription) 
- Passer la campagne avec le même code et répéter les même étapes
- Constater cette fois-ci qu'il n'y a pas de contenu formatif recommandé (car la locale de l'utilisateur est fr-fr)
