### PR TITLE
[FEATURE] Ajouter un bouton de création de réseau sur Pix-Admin (PIX-21305)

### DIFF
--- a/admin/app/templates/authenticated/networks.gjs
+++ b/admin/app/templates/authenticated/networks.gjs
@@ -1,0 +1,5 @@
+<template>
+  <div class="page">
+    {{outlet}}
+  </div>
+</template>

--- a/admin/app/templates/authenticated/networks/list.gjs
+++ b/admin/app/templates/authenticated/networks/list.gjs
@@ -1,8 +1,14 @@
+import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
 import pageTitle from 'ember-page-title/helpers/page-title';
 
 <template>
   {{pageTitle "Réseaux"}}
-  <h1>
-    Tous les réseaux
-  </h1>
+  <header>
+    <h1>Tous les réseaux</h1>
+    <div class="page-actions">
+      <PixButtonLink @route="authenticated.networks.new" @variant="secondary" @iconBefore="add">
+        Nouveau réseau
+      </PixButtonLink>
+    </div>
+  </header>
 </template>

--- a/admin/tests/acceptance/authenticated/networks/list-test.js
+++ b/admin/tests/acceptance/authenticated/networks/list-test.js
@@ -1,0 +1,28 @@
+import { clickByName, visit } from '@1024pix/ember-testing-library';
+import { currentURL } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { authenticateAdminMemberWithRole } from 'pix-admin/tests/helpers/test-init';
+import { setupMirage } from 'pix-admin/tests/test-support/setup-mirage';
+import { module, test } from 'qunit';
+
+module('Acceptance | Networks | List', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  module('when user has super admin role', function (hooks) {
+    hooks.beforeEach(async function () {
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+    });
+
+    test('it should redirect to network creation form on click "Nouveau réseau"', async function (assert) {
+      // given
+      await visit('/networks/list');
+
+      // when
+      await clickByName('Nouveau réseau');
+
+      // then
+      assert.strictEqual(currentURL(), '/networks/new');
+    });
+  });
+});


### PR DESCRIPTION
## 🥀 Problème

Nous avons besoin de pouvoir créer des nouveaux réseaux

## 🏹 Proposition

Ajouter un bouton “créer un réseau” sur la page de la liste des réseaux qui redirige vers la page de création précédemment crée



## ❤️‍🔥 Pour tester
- Depuis pix-admin
- Aller sur la page Réseaux et cliquer sur le bouton "Nouveau réseaux"
- Constater qu'on est bien redirigé vers la page de création d'un réseau
