### PR TITLE
[FEATURE] Affichage des réseaux dans Pix-Admin (PIX-21300).

### DIFF
--- a/admin/app/components/networks/list-items.gjs
+++ b/admin/app/components/networks/list-items.gjs
@@ -1,13 +1,14 @@
 import PixTable from '@1024pix/pix-ui/components/pix-table';
 import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import { t } from 'ember-intl';
 
 <template>
   {{#if @networks}}
-    <PixTable @variant="admin" @caption="Liste des réseaux. Contient le nom et l'ID." @data={{@networks}}>
+    <PixTable @variant="admin" @caption={{t "components.networks.list.table.caption"}} @data={{@networks}}>
       <:columns as |network context|>
         <PixTableColumn @context={{context}}>
           <:header>
-            ID
+            {{t "common.fields.id"}}
           </:header>
           <:cell>
             {{network.id}}
@@ -15,7 +16,7 @@ import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
         </PixTableColumn>
         <PixTableColumn @context={{context}} class="break-word">
           <:header>
-            Nom
+            {{t "common.fields.name"}}
           </:header>
           <:cell>
             {{network.name}}
@@ -24,6 +25,6 @@ import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
       </:columns>
     </PixTable>
   {{else}}
-    <div class="table__empty">Aucun résultat</div>
+    <div class="table__empty">{{t "common.tables.empty-result"}}</div>
   {{/if}}
 </template>

--- a/admin/app/components/networks/list-items.gjs
+++ b/admin/app/components/networks/list-items.gjs
@@ -1,0 +1,29 @@
+import PixTable from '@1024pix/pix-ui/components/pix-table';
+import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+
+<template>
+  {{#if @networks}}
+    <PixTable @variant="admin" @caption="Liste des réseaux. Contient le nom et l'ID." @data={{@networks}}>
+      <:columns as |network context|>
+        <PixTableColumn @context={{context}}>
+          <:header>
+            ID
+          </:header>
+          <:cell>
+            {{network.id}}
+          </:cell>
+        </PixTableColumn>
+        <PixTableColumn @context={{context}} class="break-word">
+          <:header>
+            Nom
+          </:header>
+          <:cell>
+            {{network.name}}
+          </:cell>
+        </PixTableColumn>
+      </:columns>
+    </PixTable>
+  {{else}}
+    <div class="table__empty">Aucun résultat</div>
+  {{/if}}
+</template>

--- a/admin/app/routes/authenticated/networks/list.js
+++ b/admin/app/routes/authenticated/networks/list.js
@@ -3,8 +3,13 @@ import { service } from '@ember/service';
 
 export default class ListRoute extends Route {
   @service accessControl;
+  @service store;
 
   beforeModel() {
     this.accessControl.restrictAccessTo(['isSuperAdmin'], 'authenticated');
+  }
+
+  model() {
+    return this.store.findAll('network');
   }
 }

--- a/admin/app/templates/authenticated/networks/list.gjs
+++ b/admin/app/templates/authenticated/networks/list.gjs
@@ -1,5 +1,6 @@
 import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
 import pageTitle from 'ember-page-title/helpers/page-title';
+import ListItems from 'pix-admin/components/networks/list-items';
 
 <template>
   {{pageTitle "Réseaux"}}
@@ -11,4 +12,10 @@ import pageTitle from 'ember-page-title/helpers/page-title';
       </PixButtonLink>
     </div>
   </header>
+
+  <main class="page-body">
+    <section class="page-section">
+      <ListItems @networks={{@model}} />
+    </section>
+  </main>
 </template>

--- a/admin/app/templates/authenticated/networks/list.gjs
+++ b/admin/app/templates/authenticated/networks/list.gjs
@@ -4,7 +4,7 @@ import pageTitle from 'ember-page-title/helpers/page-title';
 import ListItems from 'pix-admin/components/networks/list-items';
 
 <template>
-  {{pageTitle "Réseaux"}}
+  {{pageTitle (t "pages.networks.list.page-title")}}
   <header>
     <h1>{{t "pages.networks.list.title"}}</h1>
     <div class="page-actions">

--- a/admin/app/templates/authenticated/networks/list.gjs
+++ b/admin/app/templates/authenticated/networks/list.gjs
@@ -1,14 +1,15 @@
 import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import { t } from 'ember-intl';
 import pageTitle from 'ember-page-title/helpers/page-title';
 import ListItems from 'pix-admin/components/networks/list-items';
 
 <template>
   {{pageTitle "Réseaux"}}
   <header>
-    <h1>Tous les réseaux</h1>
+    <h1>{{t "pages.networks.list.title"}}</h1>
     <div class="page-actions">
       <PixButtonLink @route="authenticated.networks.new" @variant="secondary" @iconBefore="add">
-        Nouveau réseau
+        {{t "pages.networks.list.new-button"}}
       </PixButtonLink>
     </div>
   </header>

--- a/admin/tests/acceptance/authenticated/networks/list-test.js
+++ b/admin/tests/acceptance/authenticated/networks/list-test.js
@@ -1,5 +1,5 @@
-import { clickByName, visit } from '@1024pix/ember-testing-library';
-import { currentURL } from '@ember/test-helpers';
+import { screen, visit } from '@1024pix/ember-testing-library';
+import { click, currentURL } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateAdminMemberWithRole } from 'pix-admin/tests/helpers/test-init';
@@ -34,7 +34,8 @@ module('Acceptance | Networks | List', function (hooks) {
         await visit('/networks/list');
 
         // when
-        await clickByName(t('pages.networks.list.new-button'));
+        const networkCreationLink = screen.getByRole('link', { name: t('pages.networks.list.new-button') });
+        await click(networkCreationLink);
 
         // then
         assert.strictEqual(currentURL(), '/networks/new');

--- a/admin/tests/acceptance/authenticated/networks/list-test.js
+++ b/admin/tests/acceptance/authenticated/networks/list-test.js
@@ -34,7 +34,7 @@ module('Acceptance | Networks | List', function (hooks) {
         await visit('/networks/list');
 
         // when
-        await clickByName('Nouveau réseau');
+        await clickByName(t('pages.networks.list.new-button'));
 
         // then
         assert.strictEqual(currentURL(), '/networks/new');

--- a/admin/tests/acceptance/authenticated/networks/list-test.js
+++ b/admin/tests/acceptance/authenticated/networks/list-test.js
@@ -1,28 +1,80 @@
 import { clickByName, visit } from '@1024pix/ember-testing-library';
 import { currentURL } from '@ember/test-helpers';
+import { t } from 'ember-intl/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateAdminMemberWithRole } from 'pix-admin/tests/helpers/test-init';
 import { setupMirage } from 'pix-admin/tests/test-support/setup-mirage';
 import { module, test } from 'qunit';
 
+import setupIntl from '../../../helpers/setup-intl';
+
 module('Acceptance | Networks | List', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
+  setupIntl(hooks);
 
-  module('when user has super admin role', function (hooks) {
-    hooks.beforeEach(async function () {
-      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
-    });
-
-    test('it should redirect to network creation form on click "Nouveau réseau"', async function (assert) {
-      // given
+  module('when user is not logged in', function () {
+    test('it should not be accessible by an unauthenticated user', async function (assert) {
+      // when
       await visit('/networks/list');
 
-      // when
-      await clickByName('Nouveau réseau');
-
       // then
-      assert.strictEqual(currentURL(), '/networks/new');
+      assert.strictEqual(currentURL(), '/login');
+    });
+  });
+
+  module('when user is logged in', function () {
+    module('when user has super admin role', function (hooks) {
+      hooks.beforeEach(async function () {
+        await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+      });
+
+      test('it should redirect to network creation form on click "Nouveau réseau"', async function (assert) {
+        // given
+        await visit('/networks/list');
+
+        // when
+        await clickByName('Nouveau réseau');
+
+        // then
+        assert.strictEqual(currentURL(), '/networks/new');
+      });
+
+      test('it should be accessible', async function (assert) {
+        // when
+        await visit('/networks/list');
+
+        // then
+        assert.strictEqual(currentURL(), '/networks/list');
+      });
+
+      test('it should display the networks list', async function (assert) {
+        // given
+        server.create('network', { id: 1, name: 'Réseau Alpha' });
+        server.create('network', { id: 2, name: 'Réseau Beta' });
+
+        // when
+        const screen = await visit('/networks/list');
+
+        // then
+        const table = screen.getByRole('table', { name: t('components.networks.list.table.caption') });
+        assert.dom(table).exists();
+        assert.dom(screen.getByText('Réseau Alpha')).exists();
+        assert.dom(screen.getByText('Réseau Beta')).exists();
+      });
+    });
+
+    module('when user does not have super admin role', function () {
+      test('it should redirect to the organizations page', async function (assert) {
+        // given
+        await authenticateAdminMemberWithRole({ isSuperAdmin: false })(server);
+
+        // when
+        await visit('/networks/list');
+
+        // then
+        assert.strictEqual(currentURL(), '/organizations/list');
+      });
     });
   });
 });

--- a/admin/tests/integration/components/networks/list-items-test.gjs
+++ b/admin/tests/integration/components/networks/list-items-test.gjs
@@ -1,0 +1,52 @@
+import { render, within } from '@1024pix/ember-testing-library';
+import ListItems from 'pix-admin/components/networks/list-items';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Networks | ListItems', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  module('when there are networks', function () {
+    test('it renders a table with networks IDs and name', async function (assert) {
+      // given
+      const network1 = { id: 123, name: 'Network1' };
+      const network2 = { id: 456, name: 'Network2' };
+      const networks = [network1, network2];
+
+      // when
+      const screen = await render(<template><ListItems @networks={{networks}} /></template>);
+
+      // then
+      const table = screen.getByRole('table', {
+        name: "Liste des réseaux. Contient le nom et l'ID.",
+      });
+
+      assert.dom(within(table).getByRole('cell', { name: network1.id })).exists();
+      assert.dom(within(table).getByRole('cell', { name: network1.id })).exists();
+      assert.dom(within(table).getByRole('cell', { name: network1.name })).exists();
+      assert.dom(within(table).getByRole('cell', { name: network2.name })).exists();
+    });
+  });
+
+  module('when there are no networks', function () {
+    test('it does not render a table', async function (assert) {
+      // given
+      const networks = [];
+
+      // when
+      const screen = await render(<template><ListItems @networks={{networks}} /></template>);
+
+      // then
+      assert
+        .dom(
+          await screen.queryByRole('table', {
+            name: "Liste des réseaux. Contient le nom et l'ID.",
+          }),
+        )
+        .doesNotExist();
+
+      assert.dom(screen.getByText('Aucun résultat')).exists();
+    });
+  });
+});

--- a/admin/tests/integration/components/networks/list-items-test.gjs
+++ b/admin/tests/integration/components/networks/list-items-test.gjs
@@ -1,4 +1,5 @@
 import { render, within } from '@1024pix/ember-testing-library';
+import { t } from 'ember-intl/test-support';
 import ListItems from 'pix-admin/components/networks/list-items';
 import { module, test } from 'qunit';
 
@@ -19,7 +20,7 @@ module('Integration | Component | Networks | ListItems', function (hooks) {
 
       // then
       const table = screen.getByRole('table', {
-        name: "Liste des réseaux. Contient le nom et l'ID.",
+        name: t('components.networks.list.table.caption'),
       });
 
       assert.dom(within(table).getByRole('cell', { name: network1.id })).exists();
@@ -41,12 +42,12 @@ module('Integration | Component | Networks | ListItems', function (hooks) {
       assert
         .dom(
           await screen.queryByRole('table', {
-            name: "Liste des réseaux. Contient le nom et l'ID.",
+            name: t('components.networks.list.table.caption'),
           }),
         )
         .doesNotExist();
 
-      assert.dom(screen.getByText('Aucun résultat')).exists();
+      assert.dom(screen.getByText(t('common.tables.empty-result'))).exists();
     });
   });
 });

--- a/admin/tests/mirage/routes.js
+++ b/admin/tests/mirage/routes.js
@@ -368,6 +368,7 @@ export default function routes() {
     return organizationMembership.update({ disabledAt: new Date() });
   });
 
+  this.get('/admin/networks');
   this.post('/admin/networks', createNetwork);
 
   this.get('/admin/organizations', findPaginatedFilteredOrganizations);

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -1347,6 +1347,7 @@
     "networks": {
       "list": {
         "new-button": "New network",
+        "page-title": "Networks",
         "title": "All networks"
       },
       "title": "Create a network"

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -1345,6 +1345,10 @@
       "title": "Access to this Pix Admin space is limited to administrators."
     },
     "networks": {
+      "list": {
+        "new-button": "New network",
+        "title": "All networks"
+      },
       "title": "Create a network"
     },
     "organization": {

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -634,6 +634,11 @@
         "organization-id": {
           "label": "ID of the organization at the head of the network:"
         }
+      },
+      "list": {
+        "table": {
+          "caption": "List of networks. Contains the name and ID."
+        }
       }
     },
     "organization-learner-information": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -1350,6 +1350,7 @@
     "networks": {
       "list": {
         "new-button": "Nouveau réseau",
+        "page-title": "Réseaux",
         "title": "Tous les réseaux"
       },
       "title": "Créer un réseau"

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -1348,6 +1348,10 @@
       "title": "L'accès à Pix Admin est limité aux administrateurs de la plateforme"
     },
     "networks": {
+      "list": {
+        "new-button": "Nouveau réseau",
+        "title": "Tous les réseaux"
+      },
       "title": "Créer un réseau"
     },
     "organization": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -636,6 +636,11 @@
         "organization-id": {
           "label": "ID d'organisation à la tête du réseau:"
         }
+      },
+      "list": {
+        "table": {
+          "caption": "Liste des réseaux. Contient le nom et l'ID."
+        }
       }
     },
     "organization-learner-information": {


### PR DESCRIPTION
## 🥀 Problème

Les réseaux ne sont pas encore affichés.

## 🏹 Proposition

Ajout d'un tableau sur la page `networks/list` permettant d'afficher les IDs et noms de réseaux existants

## 💌 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## ❤️‍🔥 Pour tester

- Se connecter en tant que `superadmin@example.net`
- Aller sur la page réseaux via l'icône prévue à cet effet dans le menu de navigation
- Vérifier que les réseaux existants sont affichés
- En BDD supprimer les réseaux
- Vérifier que s'affiche `Aucun résultat` en rafraîchissant la page
