### PR TITLE
[TECH] Utiliser le SDK PgBoss au lieu de Knex

### DIFF
--- a/api/db/database-builder/database-builder.js
+++ b/api/db/database-builder/database-builder.js
@@ -204,12 +204,10 @@ export class DatabaseBuilder {
 
     const publicResults = await this.knex.raw(_constructRawQuery('public'));
     const learningContentResults = await this.knex.raw(_constructRawQuery('learningcontent'));
-    const pgbossResults = await this.knex.raw(_constructRawQuery('pgboss'));
 
     this.#tablesOrderedByDependency = [
       ...publicResults.rows.map(({ table_name }) => table_name),
       ...learningContentResults.rows.map(({ table_name }) => `learningcontent.${table_name}`),
-      ...pgbossResults.rows.map(({ table_name }) => `pgboss.${table_name}`),
     ].filter((tableName) => !READONLY_TABLES.includes(tableName));
 
     this.#deletePriority = new Map(this.#tablesOrderedByDependency.map((tableName, index) => [tableName, index]));
@@ -225,7 +223,6 @@ export class DatabaseBuilder {
         const tableName = databaseHelpers.getTableNameFromInsertSqlQuery(queryData.sql);
 
         if (!tableName || tableName === '') return;
-        if (tableName === 'pgboss.version') return;
         if (tableName === 'db_type_parsing_test') return;
         if (tableName === 'batch_update_test') return;
 

--- a/api/index.js
+++ b/api/index.js
@@ -48,6 +48,8 @@ async function _exitOnSignal(signal) {
     logger.info('Stopping HAPI Oppsy server...');
     await server.oppsy.stop();
   }
+  logger.info('Stopping PG Boss client...');
+  await pgBoss.stop();
   logger.info('Closing connections to databases...');
   await databaseConnections.disconnect();
   logger.info('Closing connections to cache...');
@@ -59,15 +61,14 @@ async function _exitOnSignal(signal) {
   logger.info('Closing connections to redis monitor...');
   await redisMonitor.quit();
   await prometheusPushGateway.stopPushingMetrics();
-  await pgBoss.stop();
   logger.info('Exiting process...');
 }
 
-process.on('SIGTERM', () => {
-  _exitOnSignal('SIGTERM');
+process.on('SIGTERM', async () => {
+  await _exitOnSignal('SIGTERM');
 });
-process.on('SIGINT', () => {
-  _exitOnSignal('SIGINT');
+process.on('SIGINT', async () => {
+  await _exitOnSignal('SIGINT');
 });
 
 try {

--- a/api/index.js
+++ b/api/index.js
@@ -7,6 +7,7 @@ import { learningContentCache } from './src/shared/infrastructure/caches/learnin
 import { quitAllStorages } from './src/shared/infrastructure/key-value-storages/index.js';
 import * as prometheusPushGateway from './src/shared/infrastructure/metrics/pushgateway.js';
 import { quitMutex } from './src/shared/infrastructure/mutex/RedisMutex.js';
+import { pgBoss } from './src/shared/infrastructure/repositories/jobs/job-repository.js';
 import { logger } from './src/shared/infrastructure/utils/logger.js';
 import { redisMonitor } from './src/shared/infrastructure/utils/redis-monitor.js';
 import { validateEnvironmentVariables } from './src/shared/infrastructure/validate-environment-variables.js';
@@ -62,14 +63,14 @@ process.on('SIGINT', () => {
   _exitOnSignal('SIGINT');
 });
 
-(async () => {
-  try {
-    await start();
-    if (config.infra.startJobInWebProcess) {
-      registerJobs({ jobGroups: [JobGroup.DEFAULT, JobGroup.FAST] });
-    }
-  } catch (error) {
-    logger.error(error);
-    throw error;
+try {
+  await start();
+  if (config.infra.startJobInWebProcess) {
+    await registerJobs({ jobGroups: [JobGroup.DEFAULT, JobGroup.FAST] });
+  } else {
+    await pgBoss.start();
   }
-})();
+} catch (error) {
+  logger.error(error);
+  throw error;
+}

--- a/api/index.js
+++ b/api/index.js
@@ -31,6 +31,12 @@ const start = async function () {
   server = await createServer();
   await server.start();
   prometheusPushGateway.startPushingMetrics();
+
+  if (config.infra.startJobInWebProcess) {
+    await registerJobs({ jobGroups: [JobGroup.DEFAULT, JobGroup.FAST] });
+  } else {
+    await pgBoss.start();
+  }
 };
 
 async function _exitOnSignal(signal) {
@@ -53,6 +59,7 @@ async function _exitOnSignal(signal) {
   logger.info('Closing connections to redis monitor...');
   await redisMonitor.quit();
   await prometheusPushGateway.stopPushingMetrics();
+  await pgBoss.stop();
   logger.info('Exiting process...');
 }
 
@@ -65,11 +72,6 @@ process.on('SIGINT', () => {
 
 try {
   await start();
-  if (config.infra.startJobInWebProcess) {
-    await registerJobs({ jobGroups: [JobGroup.DEFAULT, JobGroup.FAST] });
-  } else {
-    await pgBoss.start();
-  }
 } catch (error) {
   logger.error(error);
   throw error;

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -458,6 +458,7 @@ const configuration = (function () {
       fetchTimeOut: ms(process.env.FETCH_TIMEOUT_MILLISECONDS || '20s'),
     },
     pgBoss: {
+      databaseUrl: process.env.PGBOSS_DATABASE_URL || process.env.DATABASE_URL,
       connexionPoolMaxSize: _getNumber(process.env.PGBOSS_CONNECTION_POOL_MAX_SIZE, 2),
       teamSize: _getNumber(process.env.PG_BOSS_TEAM_SIZE, 1),
       teamConcurrency: _getNumber(process.env.PG_BOSS_TEAM_CONCURRENCY, 1),
@@ -556,6 +557,8 @@ const configuration = (function () {
       postLogoutRedirectUri: 'https://app.dev.pix.local/connexion',
       redirectUri: 'https://app.dev.pix.local/connexion/oidc-example-net',
     };
+
+    config.pgBoss.databaseUrl = process.env.TEST_DATABASE_URL;
 
     config.port = 0;
 

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -458,8 +458,6 @@ const configuration = (function () {
       fetchTimeOut: ms(process.env.FETCH_TIMEOUT_MILLISECONDS || '20s'),
     },
     pgBoss: {
-      databaseUrl: process.env.PGBOSS_DATABASE_URL || process.env.DATABASE_URL,
-      connexionPoolMaxSize: _getNumber(process.env.PGBOSS_CONNECTION_POOL_MAX_SIZE, 2),
       teamSize: _getNumber(process.env.PG_BOSS_TEAM_SIZE, 1),
       teamConcurrency: _getNumber(process.env.PG_BOSS_TEAM_CONCURRENCY, 1),
       monitorStateIntervalSeconds: _getNumber(process.env.PGBOSS_MONITOR_STATE_INTERVAL_SECONDS, undefined),
@@ -557,8 +555,6 @@ const configuration = (function () {
       postLogoutRedirectUri: 'https://app.dev.pix.local/connexion',
       redirectUri: 'https://app.dev.pix.local/connexion/oidc-example-net',
     };
-
-    config.pgBoss.databaseUrl = process.env.TEST_DATABASE_URL;
 
     config.port = 0;
 

--- a/api/src/shared/infrastructure/jobs/JobQueue.js
+++ b/api/src/shared/infrastructure/jobs/JobQueue.js
@@ -28,10 +28,6 @@ class JobQueue {
   unscheduleCronJob(name) {
     return this.pgBoss.unschedule(name);
   }
-
-  async stop() {
-    await this.pgBoss.stop({ graceful: false, timeout: 1000, destroy: true });
-  }
 }
 
 export { JobQueue };

--- a/api/src/shared/infrastructure/repositories/jobs/job-repository.js
+++ b/api/src/shared/infrastructure/repositories/jobs/job-repository.js
@@ -1,16 +1,29 @@
 import Joi from 'joi';
 import PgBoss from 'pg-boss';
 
+import { knex } from '../../../../../db/knex-database-connection.js';
 import { config } from '../../../config.js';
 import { EntityValidationError } from '../../../domain/errors.js';
 
 const monitorStateIntervalSeconds = config.pgBoss.monitorStateIntervalSeconds;
 
 export const pgBoss = new PgBoss({
-  connectionString: config.pgBoss.databaseUrl,
-  max: config.pgBoss.connexionPoolMaxSize,
   ...(monitorStateIntervalSeconds ? { monitorStateIntervalSeconds } : {}),
   archiveFailedAfterSeconds: config.pgBoss.archiveFailedAfterSeconds,
+  db: {
+    // temporary code to reuse connection pool from knex one
+    // shall be deleted when using a dedicated pgboss database
+    executeSql: (query, values) => {
+      const remapped = [];
+      const converted = query.replace(/\$(\d+)/g, (_, index) => {
+        const value = values[parseInt(index, 10) - 1];
+        remapped.push(value ?? null);
+        return '?';
+      });
+      // eslint-disable-next-line knex/avoid-injections
+      return knex.raw(converted, remapped);
+    },
+  },
 });
 
 export class JobRepository {

--- a/api/src/shared/infrastructure/repositories/jobs/job-repository.js
+++ b/api/src/shared/infrastructure/repositories/jobs/job-repository.js
@@ -1,8 +1,17 @@
 import Joi from 'joi';
+import PgBoss from 'pg-boss';
 
-import { knex } from '../../../../../db/knex-database-connection.js';
-import { DomainTransaction } from '../../../domain/DomainTransaction.js';
+import { config } from '../../../config.js';
 import { EntityValidationError } from '../../../domain/errors.js';
+
+const monitorStateIntervalSeconds = config.pgBoss.monitorStateIntervalSeconds;
+
+export const pgBoss = new PgBoss({
+  connectionString: config.pgBoss.databaseUrl,
+  max: config.pgBoss.connexionPoolMaxSize,
+  ...(monitorStateIntervalSeconds ? { monitorStateIntervalSeconds } : {}),
+  archiveFailedAfterSeconds: config.pgBoss.archiveFailedAfterSeconds,
+});
 
 export class JobRepository {
   #schema = Joi.object({
@@ -41,45 +50,28 @@ export class JobRepository {
     this.expireIn = config.expireIn || JobExpireIn.INFINITE;
     this.priority = config.priority || JobPriority.DEFAULT;
 
-    this.#validate();
-  }
-
-  #buildPayload(data) {
-    return {
-      name: this.name,
-      retrylimit: this.retry.retryLimit,
-      retrydelay: this.retry.retryDelay,
-      retrybackoff: this.retry.retryBackoff,
-      expirein: this.expireIn,
-      data,
-      on_complete: true,
-      priority: this.priority,
-    };
-  }
-
-  async #send(jobs) {
-    const knexConn = DomainTransaction.getConnection();
-
-    const results = await knex.batchInsert('pgboss.job', jobs).transacting(knexConn.isTransaction ? knexConn : null);
-
-    const rowCount = results.reduce((total, batchResult) => total + (batchResult.rowCount || 0), 0);
-
-    return { rowCount };
-  }
-
-  async performAsync(...data) {
-    const jobs = data.map((payload) => {
-      return this.#buildPayload(payload);
-    });
-
-    return this.#send(jobs);
-  }
-
-  #validate() {
     const { error } = this.#schema.validate(this, { allowUnknown: true });
     if (error) {
       throw EntityValidationError.fromJoiErrors(error.details);
     }
+  }
+
+  get options() {
+    return {
+      expireInSeconds: this.expireIn,
+      retryLimit: this.retry.retryLimit,
+      retryDelay: this.retry.retryDelay,
+      retryBackoff: this.retry.retryBackoff,
+      priority: this.priority,
+      onComplete: true,
+    };
+  }
+
+  async performAsync(...payloads) {
+    for (const payload of payloads) {
+      await pgBoss.send(this.name, payload, this.options);
+    }
+    return { rowCount: payloads.length };
   }
 }
 
@@ -130,7 +122,7 @@ export const JobRetry = Object.freeze({
  * @enum {string}
  */
 export const JobExpireIn = Object.freeze({
-  INFINITE: '48:00:00',
+  INFINITE: 48 * 3600,
   /*
    pg-boss n'arrête pas les jobs expirés. De plus, il empile d'autres jobs par dessus et relance le job expiré, ce qui peut provoquer des états incohérents.
    Par conséquent nous définissons 48 heures comme durée maximale, ce qui fait plus que la durée maximale d'un conteneur.

--- a/api/tests/certification/evaluation/integration/infrastructure/repositories/jobs/certification-completed-job-repository_test.js
+++ b/api/tests/certification/evaluation/integration/infrastructure/repositories/jobs/certification-completed-job-repository_test.js
@@ -18,9 +18,9 @@ describe('Integration | Repository | Jobs | CertificationCompletedJobRepository'
 
       // then
       await expect(CertificationCompletedJob.name).to.have.been.performed.withJob({
-        retrylimit: 10,
-        retrydelay: 30,
-        retrybackoff: true,
+        retryLimit: 10,
+        retryDelay: 30,
+        retryBackoff: true,
         priority: JobPriority.HIGH,
         data,
       });

--- a/api/tests/evaluation/unit/infrastructure/repositories/answer-job-repository_test.js
+++ b/api/tests/evaluation/unit/infrastructure/repositories/answer-job-repository_test.js
@@ -1,15 +1,13 @@
 import { AnswerJobRepository } from '../../../../../src/evaluation/infrastructure/repositories/answer-job-repository.js';
 import { config } from '../../../../../src/shared/config.js';
-import { DomainTransaction } from '../../../../../src/shared/domain/DomainTransaction.js';
 import { featureToggles } from '../../../../../src/shared/infrastructure/feature-toggles/index.js';
-import { expect, knex, sinon } from '../../../../test-helper.js';
+import { pgBoss } from '../../../../../src/shared/infrastructure/repositories/jobs/job-repository.js';
+import { expect, sinon } from '../../../../test-helper.js';
 
 describe('Evaluation | Unit | Infrastructure | Repositories | AnswerJobRepository', function () {
   beforeEach(async function () {
     sinon.stub(config, 'featureToggles');
-    sinon.stub(knex, 'batchInsert').callsFake(() => ({
-      transacting: sinon.stub().resolves([{ rowCount: 1 }]),
-    }));
+    sinon.stub(pgBoss, 'send').resolves([]);
     await featureToggles.set('isQuestEnabled', true);
     await featureToggles.set('isAsyncQuestRewardingCalculationEnabled', true);
   });
@@ -18,11 +16,6 @@ describe('Evaluation | Unit | Infrastructure | Repositories | AnswerJobRepositor
     it('should do nothing if quests are disabled', async function () {
       // given
       const profileRewardTemporaryStorageStub = { increment: sinon.stub() };
-      const knexStub = { batchInsert: sinon.stub().resolves([]) };
-      sinon.stub(DomainTransaction, 'getConnection').returns(knexStub);
-      sinon.stub(DomainTransaction, 'execute').callsFake((callback) => {
-        return callback();
-      });
       await featureToggles.set('isQuestEnabled', false);
       const userId = Symbol('userId');
       const answerJobRepository = new AnswerJobRepository({
@@ -39,11 +32,6 @@ describe('Evaluation | Unit | Infrastructure | Repositories | AnswerJobRepositor
     it('should do nothing if quests are in sync mode', async function () {
       // given
       const profileRewardTemporaryStorageStub = { increment: sinon.stub() };
-      const knexStub = { batchInsert: sinon.stub().resolves([]) };
-      sinon.stub(DomainTransaction, 'getConnection').returns(knexStub);
-      sinon.stub(DomainTransaction, 'execute').callsFake((callback) => {
-        return callback();
-      });
       await featureToggles.set('isAsyncQuestRewardingCalculationEnabled', false);
       const userId = Symbol('userId');
       const answerJobRepository = new AnswerJobRepository({
@@ -60,11 +48,6 @@ describe('Evaluation | Unit | Infrastructure | Repositories | AnswerJobRepositor
     it("should increment user's jobs count in temporary storage", async function () {
       // given
       const profileRewardTemporaryStorageStub = { increment: sinon.stub() };
-      const knexStub = { batchInsert: sinon.stub().resolves([]) };
-      sinon.stub(DomainTransaction, 'getConnection').returns(knexStub);
-      sinon.stub(DomainTransaction, 'execute').callsFake((callback) => {
-        return callback();
-      });
       const userId = Symbol('userId');
       const answerJobRepository = new AnswerJobRepository({
         dependencies: { profileRewardTemporaryStorage: profileRewardTemporaryStorageStub },

--- a/api/tests/integration/tooling/jobs/expect-job.test.js
+++ b/api/tests/integration/tooling/jobs/expect-job.test.js
@@ -51,10 +51,10 @@ describe('Integration | Tooling | Expect Job', function () {
       await expect('JobTest').to.have.been.performed.withJob({
         name: 'JobTest',
         data: { foo: 'bar' },
-        retrylimit: job.retry.retryLimit,
-        retrydelay: job.retry.retryDelay,
-        retrybackoff: job.retry.retryBackoff,
-        expirein: job.expireIn,
+        retryLimit: job.retry.retryLimit,
+        retryDelay: job.retry.retryDelay,
+        retryBackoff: job.retry.retryBackoff,
+        expireIn: job.expireIn,
       });
     });
 
@@ -205,6 +205,12 @@ describe('Integration | Tooling | Expect Job', function () {
         // when
         await jobQueue.scheduleCronJob({
           name: jobName,
+          cron: '*/5 * * * *',
+          data: { my_data: 'awesome_data' },
+          options: { tz: 'Europe/Paris' },
+        });
+        await jobQueue.scheduleCronJob({
+          name: 'otherJob',
           cron: '*/5 * * * *',
           data: { my_data: 'awesome_data' },
           options: { tz: 'Europe/Paris' },

--- a/api/tests/integration/tooling/jobs/expect-job.test.js
+++ b/api/tests/integration/tooling/jobs/expect-job.test.js
@@ -195,7 +195,7 @@ describe('Integration | Tooling | Expect Job', function () {
     });
 
     afterEach(async function () {
-      await jobQueue.stop();
+      await pgBoss.stop();
     });
 
     describe('#withCronJobsCount', function () {

--- a/api/tests/learning-content/integration/infrastructure/repositories/jobs/lcms-create-release-job-repository_test.js
+++ b/api/tests/learning-content/integration/infrastructure/repositories/jobs/lcms-create-release-job-repository_test.js
@@ -10,9 +10,9 @@ describe('Learning Content | Integration | Repository | Jobs | LcmsCreateRelease
 
       // then
       await expect(LcmsCreateReleaseJob.name).to.have.been.performed.withJob({
-        retrylimit: 0,
-        retrydelay: 0,
-        retrybackoff: false,
+        retryLimit: 0,
+        retryDelay: 0,
+        retryBackoff: false,
         data: { userId: 123 },
       });
     });

--- a/api/tests/learning-content/integration/infrastructure/repositories/jobs/lcms-refresh-cache-job-repository_test.js
+++ b/api/tests/learning-content/integration/infrastructure/repositories/jobs/lcms-refresh-cache-job-repository_test.js
@@ -10,9 +10,9 @@ describe('Learning Content | Integration | Repository | Jobs | LcmsRefreshCacheJ
 
       // then
       await expect(LcmsRefreshCacheJob.name).to.have.been.performed.withJob({
-        retrylimit: 0,
-        retrydelay: 0,
-        retrybackoff: false,
+        retryLimit: 0,
+        retryDelay: 0,
+        retryBackoff: false,
         data: { userId: 123 },
       });
     });

--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/jobs/participation-result-calculation-job-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/jobs/participation-result-calculation-job-repository_test.js
@@ -12,9 +12,9 @@ describe('Integration | Prescription | Infrastructure | Repository | Jobs | part
       // then
       await expect(ParticipationResultCalculationJob.name).to.have.been.performed.withJob({
         name: ParticipationResultCalculationJob.name,
-        retrylimit: JobRetry.FEW_RETRY.retryLimit,
-        retrydelay: JobRetry.FEW_RETRY.retryDelay,
-        retrybackoff: JobRetry.FEW_RETRY.retryBackoff,
+        retryLimit: JobRetry.FEW_RETRY.retryLimit,
+        retryDelay: JobRetry.FEW_RETRY.retryDelay,
+        retryBackoff: JobRetry.FEW_RETRY.retryBackoff,
         data: { campaignParticipationId: 3 },
       });
     });

--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/jobs/participation-shared-job-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/jobs/participation-shared-job-repository_test.js
@@ -12,9 +12,9 @@ describe('Integration | Prescription | Infrastructure | Repository | Jobs | part
 
       await expect(ParticipationSharedJob.name).to.have.been.performed.withJob({
         name: ParticipationSharedJob.name,
-        retrylimit: 0,
-        retrydelay: 0,
-        retrybackoff: false,
+        retryLimit: 0,
+        retryDelay: 0,
+        retryBackoff: false,
         data: { campaignParticipationId: 2 },
       });
     });

--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/jobs/participation-started-job-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/jobs/participation-started-job-repository_test.js
@@ -14,9 +14,9 @@ describe('Integration | Prescription | Infrastructure | Repository | Jobs | part
 
       // then
       await expect(ParticipationStartedJob.name).to.have.been.performed.withJob({
-        retrylimit: 0,
-        retrydelay: 0,
-        retrybackoff: false,
+        retryLimit: 0,
+        retryDelay: 0,
+        retryBackoff: false,
         data: {
           campaignParticipationId: 777,
         },

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/compute-certificability-job-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/compute-certificability-job-repository_test.js
@@ -10,9 +10,9 @@ describe('Integration | Prescription | Application | Jobs | computeCertificabili
 
       // then
       await expect(ComputeCertificabilityJob.name).to.have.been.performed.withJob({
-        retrylimit: 0,
-        retrydelay: 0,
-        retrybackoff: false,
+        retryLimit: 0,
+        retryDelay: 0,
+        retryBackoff: false,
         data: { organizationLearnerId: 4123132 },
       });
     });

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/import-common-organization-learners-job-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/import-common-organization-learners-job-repository_test.js
@@ -13,9 +13,9 @@ describe('Integration | Prescription | Infrastructure | Repository | Jobs | impo
 
       // then
       await expect(ImportCommonOrganizationLearnersJob.name).to.have.have.been.performed.withJob({
-        retrylimit: JobRetry.FEW_RETRY.retryLimit,
-        retrydelay: JobRetry.FEW_RETRY.retryDelay,
-        retrybackoff: JobRetry.FEW_RETRY.retryBackoff,
+        retryLimit: JobRetry.FEW_RETRY.retryLimit,
+        retryDelay: JobRetry.FEW_RETRY.retryDelay,
+        retryBackoff: JobRetry.FEW_RETRY.retryBackoff,
         data: { organizationImportId: 4123132 },
       });
     });

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/import-organization-learners-job-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/import-organization-learners-job-repository_test.js
@@ -13,9 +13,9 @@ describe('Integration | Prescription | Infrastructure | Repository | Jobs | impo
 
       // then
       await expect(ImportOrganizationLearnersJob.name).to.have.have.been.performed.withJob({
-        retrylimit: JobRetry.FEW_RETRY.retryLimit,
-        retrydelay: JobRetry.FEW_RETRY.retryDelay,
-        retrybackoff: JobRetry.FEW_RETRY.retryBackoff,
+        retryLimit: JobRetry.FEW_RETRY.retryLimit,
+        retryDelay: JobRetry.FEW_RETRY.retryDelay,
+        retryBackoff: JobRetry.FEW_RETRY.retryBackoff,
         data: { organizationImportId: 4123132 },
       });
     });

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/import-sco-csv-organization-learners-job-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/import-sco-csv-organization-learners-job-repository_test.js
@@ -13,9 +13,9 @@ describe('Integration | Prescription | Infrastructure | Repository | Jobs | impo
 
       // then
       await expect(ImportScoCsvOrganizationLearnersJob.name).to.have.have.been.performed.withJob({
-        retrylimit: JobRetry.FEW_RETRY.retryLimit,
-        retrydelay: JobRetry.FEW_RETRY.retryDelay,
-        retrybackoff: JobRetry.FEW_RETRY.retryBackoff,
+        retryLimit: JobRetry.FEW_RETRY.retryLimit,
+        retryDelay: JobRetry.FEW_RETRY.retryDelay,
+        retryBackoff: JobRetry.FEW_RETRY.retryBackoff,
         data: { organizationImportId: 4123132, locale: 'fr' },
       });
     });

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/import-sup-organization-learners-job-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/import-sup-organization-learners-job-repository_test.js
@@ -13,9 +13,9 @@ describe('Integration | Prescription | Infrastructure | Repository | Jobs | impo
 
       // then
       await expect(ImportSupOrganizationLearnersJob.name).to.have.have.been.performed.withJob({
-        retrylimit: JobRetry.FEW_RETRY.retryLimit,
-        retrydelay: JobRetry.FEW_RETRY.retryDelay,
-        retrybackoff: JobRetry.FEW_RETRY.retryBackoff,
+        retryLimit: JobRetry.FEW_RETRY.retryLimit,
+        retryDelay: JobRetry.FEW_RETRY.retryDelay,
+        retryBackoff: JobRetry.FEW_RETRY.retryBackoff,
         data: { organizationImportId: 4123132, type: 'REPLACE', locale: 'fr' },
       });
     });

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/validate-common-organization-learners-import-file-job-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/validate-common-organization-learners-import-file-job-repository_test.js
@@ -13,9 +13,9 @@ describe('Integration | Prescription | Infrastructure | Repository | Jobs | vali
 
       // then
       await expect(ValidateCommonOrganizationImportFileJob.name).to.have.been.performed.withJob({
-        retrylimit: JobRetry.FEW_RETRY.retryLimit,
-        retrydelay: JobRetry.FEW_RETRY.retryDelay,
-        retrybackoff: JobRetry.FEW_RETRY.retryBackoff,
+        retryLimit: JobRetry.FEW_RETRY.retryLimit,
+        retryDelay: JobRetry.FEW_RETRY.retryDelay,
+        retryBackoff: JobRetry.FEW_RETRY.retryBackoff,
         data: { organizationImportId: 4123132 },
       });
     });

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/validate-csv-organization-learners-import-file-job-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/validate-csv-organization-learners-import-file-job-repository_test.js
@@ -13,9 +13,9 @@ describe('Integration | Prescription | Infrastructure | Repository | Jobs | vali
 
       // then
       await expect(ValidateCsvOrganizationImportFileJob.name).to.have.been.performed.withJob({
-        retrylimit: JobRetry.FEW_RETRY.retryLimit,
-        retrydelay: JobRetry.FEW_RETRY.retryDelay,
-        retrybackoff: JobRetry.FEW_RETRY.retryBackoff,
+        retryLimit: JobRetry.FEW_RETRY.retryLimit,
+        retryDelay: JobRetry.FEW_RETRY.retryDelay,
+        retryBackoff: JobRetry.FEW_RETRY.retryBackoff,
         data: { organizationImportId: 4123132, type: 'REPLACE', locale: 'fr' },
       });
     });

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/validate-organization-learners-import-file-job-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/validate-organization-learners-import-file-job-repository_test.js
@@ -13,9 +13,9 @@ describe('Integration | Prescription | Infrastructure | Repository | Jobs | vali
 
       // then
       await expect(ValidateOrganizationImportFileJob.name).to.have.been.performed.withJob({
-        retrylimit: JobRetry.FEW_RETRY.retryLimit,
-        retrydelay: JobRetry.FEW_RETRY.retryDelay,
-        retrybackoff: JobRetry.FEW_RETRY.retryBackoff,
+        retryLimit: JobRetry.FEW_RETRY.retryLimit,
+        retryDelay: JobRetry.FEW_RETRY.retryDelay,
+        retryBackoff: JobRetry.FEW_RETRY.retryBackoff,
         data: { organizationImportId: 4123132 },
       });
     });

--- a/api/tests/quest/integration/infrastructure/repositories/jobs/update-combine-course-job-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/jobs/update-combine-course-job-repository_test.js
@@ -14,9 +14,9 @@ describe('Integration | Prescription | Application | Jobs | updateCombinedCourse
 
       // then
       await expect(UpdateCombineCourseJob.name).to.have.been.performed.withJob({
-        retrylimit: 0,
-        retrydelay: 0,
-        retrybackoff: false,
+        retryLimit: 0,
+        retryDelay: 0,
+        retryBackoff: false,
         data: { userId, moduleId },
       });
     });

--- a/api/tests/shared/integration/infrastructure/repositories/jobs/job-repository_test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/jobs/job-repository_test.js
@@ -1,4 +1,3 @@
-import { DomainTransaction } from '../../../../../../src/shared/domain/DomainTransaction.js';
 import { EntityValidationError } from '../../../../../../src/shared/domain/errors.js';
 import {
   JobExpireIn,
@@ -6,7 +5,7 @@ import {
   JobRepository,
   JobRetry,
 } from '../../../../../../src/shared/infrastructure/repositories/jobs/job-repository.js';
-import { catchErr, catchErrSync, expect, knex } from '../../../../../test-helper.js';
+import { catchErrSync, expect } from '../../../../../test-helper.js';
 
 describe('Integration | Infrastructure | Repositories | Jobs | job-repository', function () {
   it('create one job db with given config', async function () {
@@ -24,11 +23,11 @@ describe('Integration | Infrastructure | Repositories | Jobs | job-repository', 
     await expect(name).to.have.been.performed.withJob({
       name,
       data: expectedParams,
-      expirein: '48:00:00',
+      expireIn: 48 * 3600,
       priority,
-      retrydelay: 30,
-      retrylimit: 10,
-      retrybackoff: true,
+      retryDelay: 30,
+      retryLimit: 10,
+      retryBackoff: true,
     });
   });
 
@@ -62,59 +61,6 @@ describe('Integration | Infrastructure | Repositories | Jobs | job-repository', 
 
     // then
     expect(jobsInserted.rowCount).to.equal(2);
-  });
-
-  context('transaction', function () {
-    context('when no transaction ongoing', function () {
-      it("should not insert any jobs if one of them is invalid and can't be inserted", async function () {
-        // given
-        const name = 'JobTest';
-        // Knex doc : default chunk for batchInsert is 1000
-        const defaultChunkValidJobs = [...Array(1000).keys()].map((i) => ({ jobParam: i }));
-        const invalidJob = '>';
-        const priority = JobPriority.HIGH;
-        const job = new JobRepository({ name, priority });
-
-        // when
-        const expectedError = await catchErr(job.performAsync, job)(...defaultChunkValidJobs, invalidJob);
-
-        // then
-        expect(expectedError.detail).to.equal('Token ">" is invalid.');
-        const { count } = await knex('pgboss.job').count('id').first();
-        expect(count).to.equal(0);
-      });
-    });
-
-    context('when a transaction ongoing in DomainTransaction', function () {
-      it('should use the same existing transaction', async function () {
-        // given
-        const name = 'JobTest';
-        const jobs = [{ jobParam: 1 }, { jobParam: 2 }];
-        const priority = JobPriority.HIGH;
-        const job = new JobRepository({ name, priority });
-
-        // when
-        let knexConn;
-        const callback = async () => {
-          knexConn = DomainTransaction.getConnection();
-          await knexConn('features').insert({ key: 'someRandomFeature' });
-          await job.performAsync(...jobs);
-          const { count: countFeaturesBefore } = await knexConn('features').count('id').first();
-          expect(countFeaturesBefore).to.equal(1);
-          const { count: countJobsBefore } = await knexConn('pgboss.job').count('id').first();
-          expect(countJobsBefore).to.equal(2);
-          throw new Error('I want to rollback');
-        };
-        const expectedError = await catchErr(DomainTransaction.execute)(callback);
-
-        // then
-        expect(expectedError.message).to.equal('I want to rollback');
-        const { count: countFeaturesAfter } = await knex('features').count('id').first();
-        expect(countFeaturesAfter).to.equal(0);
-        const { count: countJobsAfter } = await knex('pgboss.job').count('id').first();
-        expect(countJobsAfter).to.equal(0);
-      });
-    });
   });
 
   describe('JobExpireIn', function () {

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -40,6 +40,7 @@ import * as challengeRepository from '../src/shared/infrastructure/repositories/
 import * as competenceRepository from '../src/shared/infrastructure/repositories/competence-repository.js';
 import * as courseRepository from '../src/shared/infrastructure/repositories/course-repository.js';
 import * as frameworkRepository from '../src/shared/infrastructure/repositories/framework-repository.js';
+import { pgBoss } from '../src/shared/infrastructure/repositories/jobs/job-repository.js';
 import * as skillRepository from '../src/shared/infrastructure/repositories/skill-repository.js';
 import * as thematicRepository from '../src/shared/infrastructure/repositories/thematic-repository.js';
 import * as tubeRepository from '../src/shared/infrastructure/repositories/tube-repository.js';
@@ -61,7 +62,7 @@ chaiUse(sinonChai);
 
 _.each(customChaiHelpers, chaiUse);
 
-chaiUse(jobChai(knex));
+chaiUse(jobChai(pgBoss));
 
 const databaseBuilder = await DatabaseBuilder.create({
   knex,
@@ -87,6 +88,14 @@ const { ROLES } = PIX_ADMIN;
 
 /* eslint-disable mocha/no-top-level-hooks */
 
+before(async function () {
+  try {
+    await pgBoss.start();
+  } catch {
+    // pgBoss is not available on unit tests
+  }
+});
+
 afterEach(async function () {
   sinon.restore();
   nock.cleanAll();
@@ -103,11 +112,21 @@ afterEach(async function () {
   await featureToggles.resetDefaults();
   await datamartBuilder.clean();
   await clearMutex();
+  try {
+    await pgBoss.clearStorage();
+  } catch {
+    // pgBoss is not available on unit tests
+  }
   return databaseBuilder.clean();
 });
 
 after(async function () {
   await quitMutex();
+  try {
+    await pgBoss.stop();
+  } catch {
+    // pgBoss is not available on unit tests
+  }
   return await disconnect();
 });
 

--- a/api/tests/tooling/jobs/expect-job.js
+++ b/api/tests/tooling/jobs/expect-job.js
@@ -1,6 +1,6 @@
 import { assert, Assertion } from 'chai';
 
-export const jobChai = (knex) => (_chai, utils) => {
+export const jobChai = (pgBoss) => (_chai, utils) => {
   utils.addProperty(Assertion.prototype, 'performed', function () {
     return this;
   });
@@ -11,50 +11,67 @@ export const jobChai = (knex) => (_chai, utils) => {
 
   Assertion.addMethod('withJobsCount', async function (expectedCount) {
     const jobName = this._obj;
-    const jobs = await knex('pgboss.job').where({ name: jobName });
+    const jobs = await pgBoss.fetch(jobName, expectedCount + 1, { includeMetadata: true });
+    const actualCount = jobs?.length ?? 0;
     assert.strictEqual(
-      jobs.length,
+      actualCount,
       expectedCount,
-      `expected ${jobName} to have been performed ${expectedCount} times, but it was performed ${jobs.length} times`,
+      `expected ${jobName} to have been performed ${expectedCount} times, but it was performed ${actualCount} times`,
+    );
+    return (jobs ?? []).map(
+      ({ id, name, data, retrylimit, retrydelay, retrybackoff, expire_in_seconds, priority }) => ({
+        id,
+        name,
+        data,
+        retryLimit: retrylimit,
+        retryDelay: retrydelay,
+        retryBackoff: retrybackoff,
+        expireIn: Math.round(expire_in_seconds),
+        priority,
+      }),
     );
   });
 
   Assertion.addMethod('withJob', async function (jobData) {
-    await this.withJobsCount(1);
+    const jobs = await this.withJobsCount(1);
 
     const jobName = this._obj;
-    const jobs = await knex('pgboss.job').select(knex.raw(`*, expirein::varchar`)).where({ name: jobName });
-    assert.deepInclude(jobs[0], jobData, `Job '${jobName}' was performed with a different payload`);
+    assert.deepOwnInclude(
+      jobs[0],
+      jobData,
+      `Job '${jobName}' was performed with a different payload (${JSON.stringify(jobData)} was expected but performed with ${JSON.stringify(jobs[0])})`,
+    );
   });
 
   Assertion.addMethod('withCronJobsCount', async function (expectedCount) {
     const jobName = this._obj;
-    const jobs = await knex('pgboss.schedule').where({ name: jobName });
+    const allJobs = (await pgBoss.getSchedules()) ?? [];
+    const jobs = allJobs.filter(({ name }) => name === jobName);
     assert.strictEqual(
       jobs.length,
       expectedCount,
       `expected ${jobName} to have been performed ${expectedCount} times, but it was performed ${jobs.length} times`,
     );
+    return jobs;
   });
 
   Assertion.addMethod('withCronJob', async function (jobData) {
-    await this.withCronJobsCount(1);
+    const jobs = await this.withCronJobsCount(1);
 
     const jobName = this._obj;
-    const job = await knex('pgboss.schedule')
-      .select('name', 'cron', 'data', 'options')
-      .where({ name: jobName })
-      .first();
-    assert.deepInclude(job, jobData, `Job '${jobName}' was schedule with a different payload`);
+    assert.deepOwnInclude(
+      jobs[0],
+      jobData,
+      `Job '${jobName}' was schedule with a different payload (${JSON.stringify(jobData)} was expected but performed with ${JSON.stringify(jobs[0])})`,
+    );
   });
 
   Assertion.addMethod('withJobPayloads', async function (payloads) {
-    await this.withJobsCount(payloads.length);
+    const jobs = await this.withJobsCount(payloads.length);
 
     const jobName = this._obj;
-    const jobs = await knex('pgboss.job').where({ name: jobName });
     const actualPayloads = jobs.map((job) => job.data);
-    assert.deepEqual(actualPayloads, payloads, `Job '${jobName}' was performed with a different payload`);
+    assert.sameDeepMembers(actualPayloads, payloads, `Job '${jobName}' was performed with a different payload`);
   });
 
   Assertion.addMethod('withJobPayload', async function (payload) {

--- a/api/tests/unit/tooling/database-builder/database-helpers_test.js
+++ b/api/tests/unit/tooling/database-builder/database-helpers_test.js
@@ -10,9 +10,9 @@ describe('Unit | Tooling | DatabaseBuilder | database-helpers', function () {
           '/* path:  */ insert into "users" ("cgu", "createdAt", "email", "emailConfirmedAt", "firstName", "hasBeenAnonymised", "hasBeenAnonymisedBy", "hasSeenAssessmentInstructions", "hasSeenFocusedChallengeTooltip", "hasSeenNewDashboardInfo", "hasSeenOtherChallengesTooltip", "id", "isAnonymous", "lang", "lastDataProtectionPolicySeenAt", "lastName", "lastPixCertifTermsOfServiceValidatedAt", "lastPixOrgaTermsOfServiceValidatedAt", "lastTermsOfServiceValidatedAt", "locale", "mustValidateTermsOfService", "pixCertifTermsOfServiceAccepted", "pixOrgaTermsOfServiceAccepted", "updatedAt", "username") values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, DEFAULT, $21, $22, $23, $24, $25)',
       },
       {
-        expectedTableName: 'pgboss.job',
+        expectedTableName: 'schema.table',
         insertSqlQuery:
-          '/* path: /api/campaign-participations/{campaignParticipationId} */ insert into "pgboss"."job" ("data", "expirein", "name", "on_complete", "retrybackoff", "retrydelay", "retrylimit") values ($1, $2, $3, $4, $5, $6, $7)',
+          '/* path: /api/campaign-participations/{campaignParticipationId} */ insert into "schema"."table" ("data", "expirein", "name", "on_complete", "retrybackoff", "retrydelay", "retrylimit") values ($1, $2, $3, $4, $5, $6, $7)',
       },
       {
         expectedTableName: 'user-logins',

--- a/api/tests/unit/worker_test.js
+++ b/api/tests/unit/worker_test.js
@@ -7,7 +7,7 @@ import { JobGroup } from '../../src/shared/application/jobs/job-controller.js';
 import { config } from '../../src/shared/config.js';
 import { AuditLoggingJob } from '../../src/shared/domain/models/jobs/AuditLoggingJob.js';
 import { JobExpireIn } from '../../src/shared/infrastructure/repositories/jobs/job-repository.js';
-import { registerJobs, startPgBoss } from '../../worker.js';
+import { registerJobs } from '../../worker.js';
 import { catchErr, expect, sinon } from '../test-helper.js';
 
 describe('Unit | Worker', function () {
@@ -214,19 +214,6 @@ describe('Unit | Worker', function () {
           expect(jobQueueStub.unscheduleCronJob).to.have.been.calledWithExactly('CpfExportSenderJob');
         });
       });
-    });
-  });
-
-  context('#startPgBoss', function () {
-    it('should return null when pgboss connexionPoolMaxSize is 0', async function () {
-      //given
-      sinon.stub(config.pgBoss, 'connexionPoolMaxSize').value(0);
-
-      //when
-      const pgboss = await startPgBoss();
-
-      //then
-      expect(pgboss).to.be.null;
     });
   });
 });

--- a/api/tests/unit/worker_test.js
+++ b/api/tests/unit/worker_test.js
@@ -6,21 +6,20 @@ import { AuditLoggingJobController } from '../../src/shared/application/jobs/aud
 import { JobGroup } from '../../src/shared/application/jobs/job-controller.js';
 import { config } from '../../src/shared/config.js';
 import { AuditLoggingJob } from '../../src/shared/domain/models/jobs/AuditLoggingJob.js';
+import { JobQueue } from '../../src/shared/infrastructure/jobs/JobQueue.js';
 import { JobExpireIn } from '../../src/shared/infrastructure/repositories/jobs/job-repository.js';
 import { registerJobs } from '../../worker.js';
 import { catchErr, expect, sinon } from '../test-helper.js';
 
 describe('Unit | Worker', function () {
   context('#registerJobs', function () {
-    let startPgBossStub, createJobQueueStub, jobQueueStub;
+    let startPgBossStub;
 
     beforeEach(function () {
-      const pgBossStub = Symbol('pgBoss');
-      jobQueueStub = { register: sinon.stub(), scheduleCronJob: sinon.stub(), unscheduleCronJob: sinon.stub() };
-      startPgBossStub = sinon.stub();
-      startPgBossStub.resolves(pgBossStub);
-      createJobQueueStub = sinon.stub();
-      createJobQueueStub.withArgs(pgBossStub).returns(jobQueueStub);
+      startPgBossStub = sinon.stub().resolves(Symbol('pgBoss'));
+      sinon.stub(JobQueue.prototype, 'register');
+      sinon.stub(JobQueue.prototype, 'scheduleCronJob');
+      sinon.stub(JobQueue.prototype, 'unscheduleCronJob');
     });
 
     afterEach(function () {
@@ -33,12 +32,11 @@ describe('Unit | Worker', function () {
         jobGroups: [JobGroup.DEFAULT],
         dependencies: {
           startPgBoss: startPgBossStub,
-          createJobQueue: createJobQueueStub,
         },
       });
 
       // then
-      expect(jobQueueStub.register).to.have.been.calledWithExactly(
+      expect(JobQueue.prototype.register).to.have.been.calledWithExactly(
         new Metrics({ config: { metrics: { isDirectMetricsEnabled: false } } }),
         AuditLoggingJob.name,
         AuditLoggingJobController,
@@ -52,12 +50,11 @@ describe('Unit | Worker', function () {
         jobGroups: [JobGroup.DEFAULT],
         dependencies: {
           startPgBoss: startPgBossStub,
-          createJobQueue: createJobQueueStub,
         },
       });
 
       // then
-      expect(jobQueueStub.register).to.have.been.calledWithExactly(
+      expect(JobQueue.prototype.register).to.have.been.calledWithExactly(
         new Metrics({ config: { metrics: { isDirectMetricsEnabled: false } } }),
         'legacyNameForAuditLoggingJobController',
         AuditLoggingJobController,
@@ -73,12 +70,11 @@ describe('Unit | Worker', function () {
         jobGroups: [JobGroup.DEFAULT],
         dependencies: {
           startPgBoss: startPgBossStub,
-          createJobQueue: createJobQueueStub,
         },
       });
 
       // then
-      expect(jobQueueStub.register).to.have.been.calledWithExactly(
+      expect(JobQueue.prototype.register).to.have.been.calledWithExactly(
         new Metrics({ config: { metrics: { isDirectMetricsEnabled: false } } }),
         ValidateOrganizationImportFileJob.name,
         ValidateOrganizationLearnersImportFileJobController,
@@ -94,12 +90,11 @@ describe('Unit | Worker', function () {
         jobGroups: [JobGroup.DEFAULT],
         dependencies: {
           startPgBoss: startPgBossStub,
-          createJobQueue: createJobQueueStub,
         },
       });
 
       // then
-      expect(jobQueueStub.register).to.not.have.been.calledWithExactly(
+      expect(JobQueue.prototype.register).to.not.have.been.calledWithExactly(
         ValidateOrganizationImportFileJob.name,
         ValidateOrganizationLearnersImportFileJobController,
       );
@@ -114,14 +109,12 @@ describe('Unit | Worker', function () {
         jobGroups: [JobGroup.DEFAULT],
         dependencies: {
           startPgBoss: startPgBossStub,
-          createJobQueue: createJobQueueStub,
         },
       });
 
       // then
-      expect(createJobQueueStub).to.not.have.been.called;
-      expect(jobQueueStub.register).to.not.have.been.called;
-      expect(jobQueueStub.scheduleCronJob).to.not.have.been.called;
+      expect(JobQueue.prototype.register).to.not.have.been.called;
+      expect(JobQueue.prototype.scheduleCronJob).to.not.have.been.called;
     });
 
     it('should throws an error when no groups is invalid', async function () {
@@ -129,7 +122,6 @@ describe('Unit | Worker', function () {
       const error = await catchErr(registerJobs)({
         dependencies: {
           startPgBoss: startPgBossStub,
-          createJobQueue: createJobQueueStub,
         },
       });
 
@@ -144,7 +136,6 @@ describe('Unit | Worker', function () {
         jobGroups: ['pouet'],
         dependencies: {
           startPgBoss: startPgBossStub,
-          createJobQueue: createJobQueueStub,
         },
       });
 
@@ -162,15 +153,14 @@ describe('Unit | Worker', function () {
           jobGroups: [JobGroup.DEFAULT],
           dependencies: {
             startPgBoss: startPgBossStub,
-            createJobQueue: createJobQueueStub,
           },
         });
 
         // then
-        expect(jobQueueStub.scheduleCronJob).to.have.been.calledWithExactly({
+        expect(JobQueue.prototype.scheduleCronJob).to.have.been.calledWithExactly({
           name: 'ScheduleComputeOrganizationLearnersCertificabilityJob',
           cron: '0 21 * * *',
-          options: { tz: 'Europe/Paris', expireIn: JobExpireIn.INFINITE },
+          options: { tz: 'Europe/Paris', expireInSeconds: JobExpireIn.INFINITE },
         });
       });
 
@@ -186,12 +176,11 @@ describe('Unit | Worker', function () {
           jobGroups: [JobGroup.DEFAULT],
           dependencies: {
             startPgBoss: startPgBossStub,
-            createJobQueue: createJobQueueStub,
           },
         });
 
         // then
-        expect(jobQueueStub.unscheduleCronJob).to.have.been.calledWithExactly(
+        expect(JobQueue.prototype.unscheduleCronJob).to.have.been.calledWithExactly(
           'legyNameForScheduleComputeOrganizationLearnersCertificabilityJobController',
         );
       });
@@ -206,12 +195,11 @@ describe('Unit | Worker', function () {
             jobGroups: [JobGroup.DEFAULT],
             dependencies: {
               startPgBoss: startPgBossStub,
-              createJobQueue: createJobQueueStub,
             },
           });
 
           // then
-          expect(jobQueueStub.unscheduleCronJob).to.have.been.calledWithExactly('CpfExportSenderJob');
+          expect(JobQueue.prototype.unscheduleCronJob).to.have.been.calledWithExactly('CpfExportSenderJob');
         });
       });
     });

--- a/api/worker.js
+++ b/api/worker.js
@@ -24,14 +24,6 @@ const workerDirPath = dirname(fileURLToPath(import.meta.url));
 const metrics = new Metrics({ config });
 
 export async function startPgBoss() {
-  if (config.pgBoss.connexionPoolMaxSize === 0) {
-    logger.info(
-      'Pgboss will not be started and configured as connexionPoolMaxSize is set to 0. ' +
-        'Please set a value greater than zero on environment variable "PGBOSS_CONNECTION_POOL_MAX_SIZE" to be able to process jobs.',
-    );
-    return null;
-  }
-
   logger.info('Starting pg-boss');
 
   pgBoss.on('monitor-states', (state) => {

--- a/api/worker.js
+++ b/api/worker.js
@@ -38,9 +38,7 @@ export async function startPgBoss() {
   pgBoss.on('wip', (data) => {
     logger.info({ event: 'pg-boss-wip' }, data);
   });
-  if (config.pgBoss.connexionPoolMaxSize !== 0) {
-    await pgBoss.start();
-  }
+  await pgBoss.start();
   return pgBoss;
 }
 
@@ -107,7 +105,7 @@ export async function registerJobs({ jobGroups, dependencies = { startPgBoss, cr
         await jobQueues.scheduleCronJob({
           name: job.jobName,
           cron: job.jobCron,
-          options: { tz: 'Europe/Paris', expireIn: job.expireIn },
+          options: { tz: 'Europe/Paris', expireInSeconds: job.expireIn },
         });
         logger.info(`Cron for job "${job.jobName}" scheduled "${job.jobCron}"`);
 
@@ -149,6 +147,7 @@ async function main() {
     await metrics.clearMetrics();
     await databaseConnections.disconnect();
     await learningContentCache.quit();
+    await pgBoss.stop();
   });
 }
 

--- a/api/worker.js
+++ b/api/worker.js
@@ -3,7 +3,6 @@ import { dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import _ from 'lodash';
-import PgBoss from 'pg-boss';
 
 import { databaseConnections } from './db/database-connections.js';
 import { Metrics } from './src/monitoring/infrastructure/metrics.js';
@@ -13,6 +12,7 @@ import { learningContentCache } from './src/shared/infrastructure/caches/learnin
 import { JobQueue } from './src/shared/infrastructure/jobs/JobQueue.js';
 import { quitAllStorages } from './src/shared/infrastructure/key-value-storages/index.js';
 import { quitMutex } from './src/shared/infrastructure/mutex/RedisMutex.js';
+import { pgBoss } from './src/shared/infrastructure/repositories/jobs/job-repository.js';
 import { importNamedExportFromFile } from './src/shared/infrastructure/utils/import-named-exports-from-directory.js';
 import { child } from './src/shared/infrastructure/utils/logger.js';
 import { validateEnvironmentVariables } from './src/shared/infrastructure/validate-environment-variables.js';
@@ -33,13 +33,7 @@ export async function startPgBoss() {
   }
 
   logger.info('Starting pg-boss');
-  const monitorStateIntervalSeconds = config.pgBoss.monitorStateIntervalSeconds;
-  const pgBoss = new PgBoss({
-    connectionString: process.env.DATABASE_URL,
-    max: config.pgBoss.connexionPoolMaxSize,
-    ...(monitorStateIntervalSeconds ? { monitorStateIntervalSeconds } : {}),
-    archiveFailedAfterSeconds: config.pgBoss.archiveFailedAfterSeconds,
-  });
+
   pgBoss.on('monitor-states', (state) => {
     logger.info({ event: 'pg-boss-state', name: 'global' }, { ...state, queues: undefined });
     _.each(state.queues, (queueState, queueName) => {

--- a/api/worker.js
+++ b/api/worker.js
@@ -42,14 +42,6 @@ export async function startPgBoss() {
   return pgBoss;
 }
 
-function createJobQueue(pgBoss) {
-  const jobQueue = new JobQueue(pgBoss);
-  process.on('SIGINT', async () => {
-    await jobQueue.stop();
-  });
-  return jobQueue;
-}
-
 function checkJobGroups(jobGroups) {
   if (!jobGroups) throw new Error('Job groups are mandatory');
   jobGroups.forEach((jobGroup) => checkJobGroup(jobGroup));
@@ -61,7 +53,7 @@ function checkJobGroup(jobGroup) {
   }
 }
 
-export async function registerJobs({ jobGroups, dependencies = { startPgBoss, createJobQueue } }) {
+export async function registerJobs({ jobGroups, dependencies = { startPgBoss } }) {
   checkJobGroups(jobGroups);
 
   const pgBoss = await dependencies.startPgBoss();
@@ -71,7 +63,7 @@ export async function registerJobs({ jobGroups, dependencies = { startPgBoss, cr
     return;
   }
 
-  const jobQueues = dependencies.createJobQueue(pgBoss);
+  const jobQueues = new JobQueue(pgBoss);
 
   const globPattern = `${workerDirPath}/src/**/application/**/*job-controller.js`;
 
@@ -135,19 +127,32 @@ export async function registerJobs({ jobGroups, dependencies = { startPgBoss, cr
 
 const isRunningFromCli = import.meta.filename === process.argv[1];
 
+let isShuttingDown = false;
+
+async function exitOnSignal(signal) {
+  if (isShuttingDown) return;
+  isShuttingDown = true;
+
+  logger.info(`Received signal: ${signal}.`);
+  await pgBoss.stop({ graceful: false, timeout: 1000, destroy: true });
+  await databaseConnections.disconnect();
+  await metrics.clearMetrics();
+  await learningContentCache.quit();
+  await quitAllStorages();
+  await quitMutex();
+}
+
 async function main() {
   validateEnvironmentVariables(configSchema);
 
   const jobGroup = process.argv[2] ? JobGroup[process.argv[2]?.toUpperCase()] : JobGroup.DEFAULT;
   await registerJobs({ jobGroups: [jobGroup] });
 
+  process.on('SIGTERM', async () => {
+    await exitOnSignal('SIGTERM');
+  });
   process.on('SIGINT', async () => {
-    await quitAllStorages();
-    await quitMutex();
-    await metrics.clearMetrics();
-    await databaseConnections.disconnect();
-    await learningContentCache.quit();
-    await pgBoss.stop();
+    await exitOnSignal('SIGINT');
   });
 }
 


### PR DESCRIPTION
## 🥀 Problème

Dans les serveurs web, on fait directement des requêtes SQL sur les tables `pgboss` au lieu d'utiliser le SDK, ce qui rend difficile la montée de version de `pgboss` et l'utilisation d'une base de données dédiée.

## 🏹 Proposition

Utiliser le SDK de `pgboss` pour gérer la création des jobs et ne plus faire d'appel SQL directs sur les tables `pgboss`.

Dans des PRs futures, nous réaliserons la montée de version de `pgboss` et l'utilisation d'une base de données dédiée.

## 💌 Remarques

**Corrections ajoutées**
- Les `workers` ne captaient le signal `SIGTERM` au shutdown et ne fermaient pas les ressources correctement (sur les envs Scalingo).


## ❤️‍🔥 Pour tester

**Tester en mode "worker dédié" et "worker embarqué dans le conteneur web":**
- envoi des jobs : OK
- traitement des jobs : OK
- schedule des jobs : OK
- l'archivage des jobs : OK

