### PR TITLE
[TECH] Simplifier encore la sortie des scripts pour les variables d’environnement du GAR (PIX-21897)

### DIFF
--- a/api/src/identity-access-management/scripts/gar-generate-env-SAML_IDP_CONFIG.js
+++ b/api/src/identity-access-management/scripts/gar-generate-env-SAML_IDP_CONFIG.js
@@ -7,9 +7,9 @@ if (!metadataIdpfilePath) {
 
 // eslint-disable-next-line no-console
 console.log(
-  `SAML_IDP_CONFIG=${JSON.stringify({
+  JSON.stringify({
     metadata: await getInlineContent(metadataIdpfilePath),
-  })}`,
+  }),
 );
 
 function getInlineContent(filePath) {

--- a/api/src/identity-access-management/scripts/gar-generate-env-SAML_SP_CONFIG.js
+++ b/api/src/identity-access-management/scripts/gar-generate-env-SAML_SP_CONFIG.js
@@ -12,10 +12,10 @@ if (!privateKeyfilePath) {
 
 // eslint-disable-next-line no-console
 console.log(
-  `SAML_SP_CONFIG=${JSON.stringify({
+  JSON.stringify({
     metadata: await getInlineContent(metadataSpfilePath),
     encPrivateKey: await readFile(privateKeyfilePath, 'utf-8'),
-  })}`,
+  }),
 );
 
 function getInlineContent(filePath) {


### PR DESCRIPTION
## 🥀 Problème

La sortie des scripts `gar-generate-env-SAML_IDP_CONFIG.js` et `gar-generate-env-SAML_SP_CONFIG.js` porte encore à confusion car : 
* formellement, il y manque des guillemets,
* elle ne peut être directement copiée-collée comme valeur pour une variable d’environnement.

## 🏹 Proposition

Simplifier la sortie de ces scripts pour qu’elle soit directement à copier-coller dans la valeur des variables d’environnement.

## 💌 Remarques

Cette PR poursuit l’amélioration sur ces scripts commencée avec la PR #15204

## ❤️‍🔥 Pour tester

En local

Récupérer les métadonnées SAML du GAR de production : 

```shell
wget https://idp-auth.gar.education.fr/idp/metadata
```

Créer 1 fichier `metadata_sp` XML bidon et 1 fichier `privatekey.pem` de clé privée bidon, par exemple : 

`metadata_sp`  : 
```
<EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata">
</EntityDescriptor>
```

`privatekey.pem` : 
```
123456789
```

Puis exécuter les scripts : 

```shell
node src/identity-access-management/scripts/gar-generate-env-SAML_IDP_CONFIG.js metadata
```
```shell
node src/identity-access-management/scripts/gar-generate-env-SAML_SP_CONFIG.js metadata_sp privatekey.pem
```

Constater que la sortie des 2 scripts est prête à être directement copiée-collée comme valeur pour une variable d’environnement.
