### PR TITLE
[FEATURE] Remonter les informations du réseau dans les détails d'une organisation (PIX-21339).

### DIFF
--- a/api/src/organizational-entities/domain/models/OrganizationForAdmin.js
+++ b/api/src/organizational-entities/domain/models/OrganizationForAdmin.js
@@ -54,6 +54,8 @@ class OrganizationForAdmin {
     countryCode,
     countryName,
     organizationLearnerType,
+    networkId,
+    networkName,
   } = {}) {
     this.id = id;
     this.name = name;
@@ -145,6 +147,8 @@ class OrganizationForAdmin {
     this.code = code;
     this.countryCode = countryCode;
     this.countryName = countryName;
+    this.networkId = networkId;
+    this.networkName = networkName;
 
     this.#validate();
   }

--- a/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
@@ -115,6 +115,7 @@ const get = async function ({ organizationId }) {
       formNPSUrl: 'organizations.formNPSUrl',
       showSkills: 'organizations.showSkills',
       archivedAt: 'organizations.archivedAt',
+
       archivistFirstName: 'archivists.firstName',
       archivistLastName: 'archivists.lastName',
       dataProtectionOfficerFirstName: 'dataProtectionOfficers.firstName',
@@ -130,6 +131,8 @@ const get = async function ({ organizationId }) {
       countryCode: 'organizations.countryCode',
       organizationLearnerTypeName: 'organization_learner_types.name',
       organizationLearnerTypeId: 'organization_learner_types.id',
+      networkId: 'networks.id',
+      networkName: 'networks.name',
     })
     .leftJoin('users AS archivists', 'archivists.id', 'organizations.archivedBy')
     .leftJoin(
@@ -145,6 +148,8 @@ const get = async function ({ organizationId }) {
       'organizations.id',
     )
     .leftJoin('organizations AS parentOrganizations', 'parentOrganizations.id', 'organizations.parentOrganizationId')
+    .leftJoin('fct_structures', 'fct_structures.organization_id', 'organizations.id')
+    .leftJoin('networks', 'networks.id', 'fct_structures.network_id')
     .where('organizations.id', organizationId)
     .first();
 
@@ -499,6 +504,8 @@ function _toDomain(rawOrganization) {
       rawOrganization.organizationLearnerTypeId,
       rawOrganization.organizationLearnerTypeName,
     ),
+    networkId: rawOrganization.networkId,
+    networkName: rawOrganization.networkName,
   });
 
   return organization;

--- a/api/src/organizational-entities/infrastructure/serializers/jsonapi/organizations-administration/organization-for-admin.serializer.js
+++ b/api/src/organizational-entities/infrastructure/serializers/jsonapi/organizations-administration/organization-for-admin.serializer.js
@@ -61,6 +61,8 @@ const serialize = function (organizations, meta) {
       'countryName',
       'organizationLearnerTypeId',
       'organizationLearnerTypeName',
+      'networkId',
+      'networkName',
     ],
     organizationMemberships: {
       ref: 'id',

--- a/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
@@ -643,6 +643,13 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
           tagId: tag.id,
           organizationId: organization.id,
         });
+        const network = databaseBuilder.factory.buildNetwork({ name: 'Réseau Académique' });
+        const structure = databaseBuilder.factory.buildStructure();
+        databaseBuilder.factory.buildFactStructure({
+          structureId: structure.id,
+          networkId: network.id,
+          organizationId: organization.id,
+        });
         await databaseBuilder.commit();
 
         // when
@@ -688,6 +695,8 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
               'country-name': country.commonName,
               'organization-learner-type-name': organizationLearnerType.name,
               'organization-learner-type-id': organizationLearnerType.id,
+              'network-id': network.id,
+              'network-name': network.name,
               features: {
                 [ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key]: {
                   active: false,

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/organization-for-admin.repository.test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/organization-for-admin.repository.test.js
@@ -867,6 +867,8 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
         parentOrganizationId: parentOrganization.id,
         parentOrganizationName: 'Mother Of Dark Side',
         countryCode: 99100,
+        networkId: null,
+        networkName: null,
       });
       expect(foundOrganizationForAdmin).to.deep.equal(expectedOrganizationForAdmin);
     });
@@ -967,6 +969,8 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
           administrationTeamName: administrationTeam.name,
           countryCode: 99100,
           organizationLearnerType: domainOrganizationLearnerType,
+          networkId: null,
+          networkName: null,
         });
         expect(foundOrganizationForAdmin).to.deep.equal(expectedOrganizationForAdmin);
       });
@@ -1079,8 +1083,36 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
           administrationTeamName: administrationTeam.name,
           countryCode: 99100,
           organizationLearnerType: domainOrganizationLearnerType,
+          networkId: null,
+          networkName: null,
         });
         expect(foundOrganizationForAdmin).to.deep.equal(expectedOrganizationForAdmin);
+      });
+    });
+
+    describe('when the organization belongs to a network', function () {
+      it('should return the network id and name', async function () {
+        // given
+        const organization = databaseBuilder.factory.buildOrganization({
+          organizationLearnerTypeId: organizationLearnerType.id,
+        });
+        const network = databaseBuilder.factory.buildNetwork({ name: 'Réseau Académique' });
+        const structure = databaseBuilder.factory.buildStructure();
+        databaseBuilder.factory.buildFactStructure({
+          structureId: structure.id,
+          networkId: network.id,
+          organizationId: organization.id,
+        });
+        await databaseBuilder.commit();
+
+        // when
+        const foundOrganizationForAdmin = await repositories.organizationForAdminRepository.get({
+          organizationId: organization.id,
+        });
+
+        // then
+        expect(foundOrganizationForAdmin.networkId).to.equal(network.id);
+        expect(foundOrganizationForAdmin.networkName).to.equal(network.name);
       });
     });
 
@@ -1186,6 +1218,8 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
           administrationTeamName: administrationTeam.name,
           countryCode: 99100,
           organizationLearnerType: domainOrganizationLearnerType,
+          networkId: null,
+          networkName: null,
         });
         expect(foundOrganizationForAdmin).to.deepEqualInstance(expectedOrganizationForAdmin);
       });

--- a/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/organization-for-admin.serializer.test.js
+++ b/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/organization-for-admin.serializer.test.js
@@ -63,6 +63,8 @@ describe('Unit | Serializer | organization-for-admin-serializer', function () {
         countryCode: 99100,
         countryName: 'France',
         organizationLearnerType: organizationLearnerType,
+        networkId: 42,
+        networkName: 'Réseau Île-de-France',
       });
       const meta = { some: 'meta' };
 
@@ -106,6 +108,8 @@ describe('Unit | Serializer | organization-for-admin-serializer', function () {
             'country-name': organization.countryName,
             'organization-learner-type-name': organization.organizationLearnerType.name,
             'organization-learner-type-id': organization.organizationLearnerType.id,
+            'network-id': organization.networkId,
+            'network-name': organization.networkName,
           },
           relationships: {
             'organization-memberships': {


### PR DESCRIPTION
## 🥀 Problème

Nous ne connaissons pas dans le détail d'une organisation les informations du réseau auquel elle appartient.

## 🏹 Proposition

On remonte ces informations

## 💌 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## ❤️‍🔥 Pour tester

Se connecter à Pix-Admin
Aller sur la page de détails d'une organisation reliée à un réseau
Vérifier dans l'appel réseau que les informations du réseau sont bien remontées
Aller sur la page de détails d'une organisation NON reliée à un réseau
Vérifier dans l'appel réseau que les informations du réseau sont `null`
