### PR TITLE
[TECH] Amélioration des metrics du learning content

### DIFF
--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -435,7 +435,11 @@ const configuration = (function () {
           keepAliveMsec: ms(process.env.PROMETHEUS_PUSHGATEWAY_KEEP_ALIVE ?? '1s'),
         },
         buckets: Object.assign(
-          { lc_loadcachemiss: [0.01, 0.02, 0.04, 0.08, 0.16], lc_findcachemiss: [0.01, 0.02, 0.04, 0.08, 0.16] },
+          {
+            lc_read: [10, 100, 1000],
+            lc_cachemiss: [10, 100, 1000],
+            lc_cachepenalty: [0.001, 0.01, 0.1],
+          },
           parseJSONEnv('PROMETHEUS_METRICS_BUCKETS'),
         ),
       },

--- a/api/src/shared/infrastructure/metrics/metrics.js
+++ b/api/src/shared/infrastructure/metrics/metrics.js
@@ -4,7 +4,7 @@ import { config } from '../../config.js';
 import { register } from './register.js';
 
 /**
- * @param {Omit<ConstructorParameters<typeof Counter>[0], "registers">} configuration
+ * @param {Omit<ConstructorParameters<typeof Counter>[0], 'registers'>} configuration
  */
 export function createCounter({ name, ...configuration }) {
   return new Counter({
@@ -15,7 +15,7 @@ export function createCounter({ name, ...configuration }) {
 }
 
 /**
- * @param {Omit<ConstructorParameters<typeof Gauge>[0], "registers">} configuration
+ * @param {Omit<ConstructorParameters<typeof Gauge>[0], 'registers'>} configuration
  */
 export function createGauge({ name, ...configuration }) {
   return new Gauge({
@@ -26,18 +26,19 @@ export function createGauge({ name, ...configuration }) {
 }
 
 /**
- * @param {Omit<ConstructorParameters<typeof Histogram>[0], "registers">} configuration
+ * @param {Omit<ConstructorParameters<typeof Histogram>[0], 'registers' | 'buckets'>} configuration
  */
 export function createHistogram({ name, ...configuration }) {
   return new Histogram({
     ...configuration,
     name: `${config.metrics.prometheus.prefix}_${name}`,
     registers: [register],
+    buckets: config.metrics.prometheus.buckets[name] ?? [],
   });
 }
 
 /**
- * @param {Omit<ConstructorParameters<typeof Summary>[0], "registers">} configuration
+ * @param {Omit<ConstructorParameters<typeof Summary>[0], 'registers'>} configuration
  */
 export function createSummary({ name, ...configuration }) {
   return new Summary({

--- a/api/src/shared/infrastructure/metrics/pushgateway.js
+++ b/api/src/shared/infrastructure/metrics/pushgateway.js
@@ -1,3 +1,4 @@
+import http from 'node:http';
 import https from 'node:https';
 
 import { Pushgateway } from 'prom-client';
@@ -18,16 +19,24 @@ register.setDefaultLabels({
   instance: config.infra.containerName ?? 'localhost',
 });
 
+const httpAgentOptions = {
+  keepAlive: true,
+  keepAliveMsec: config.metrics.prometheus.pushgateway.keepAlive,
+  maxSockets: 1,
+};
+
+let httpAgent;
+if (URL.canParse(config.metrics.prometheus.pushgateway.url)) {
+  const { protocol } = new URL(config.metrics.prometheus.pushgateway.url);
+  httpAgent = protocol === 'https:' ? new https.Agent(httpAgentOptions) : new http.Agent(httpAgentOptions);
+}
+
 const pushgateway = new Pushgateway(
   config.metrics.prometheus.pushgateway.url,
   {
     headers,
     timeout: config.metrics.prometheus.pushgateway.timeout,
-    agent: new https.Agent({
-      keepAlive: true,
-      keepAliveMsec: config.metrics.prometheus.pushgateway.keepAlive,
-      maxSockets: 1,
-    }),
+    agent: httpAgent,
   },
   register,
 );

--- a/api/src/shared/infrastructure/repositories/learning-content-repository.js
+++ b/api/src/shared/infrastructure/repositories/learning-content-repository.js
@@ -1,30 +1,27 @@
 import Dataloader from 'dataloader';
 
-import { config } from '../../config.js';
 import { DomainTransaction } from '../../domain/DomainTransaction.js';
 import { LearningContentCache } from '../caches/learning-content-cache.js';
-import { createCounter, createHistogram } from '../metrics/metrics.js';
+import { createHistogram } from '../metrics/metrics.js';
 import { child, SCOPES } from '../utils/logger.js';
 
 const logger = child('learningcontent:repository', { event: SCOPES.LEARNING_CONTENT });
 
 const metrics = {
-  read: createCounter({
+  read: createHistogram({
     name: 'lc_read',
-    help: 'Total count of reads from learning content',
-    labelNames: ['type', 'table'],
+    help: 'Learning content entities read count',
+    labelNames: ['table', 'cache'],
   }),
-  loadCacheMiss: createHistogram({
-    name: 'lc_loadcachemiss',
-    help: 'Histogram of load cache misses when reading from learning content',
-    labelNames: ['table'],
-    buckets: config.metrics.prometheus.buckets.lc_loadcachemiss,
+  cacheMiss: createHistogram({
+    name: 'lc_cachemiss',
+    help: 'Learning content cache miss count',
+    labelNames: ['table', 'cache'],
   }),
-  findCacheMiss: createHistogram({
-    name: 'lc_findcachemiss',
-    help: 'Histogram of find cache misses when reading from learning content',
-    labelNames: ['table'],
-    buckets: config.metrics.prometheus.buckets.lc_findcachemiss,
+  cachePenalty: createHistogram({
+    name: 'lc_cachepenalty',
+    help: 'Learning content cache penalty',
+    labelNames: ['table', 'cache'],
   }),
 };
 
@@ -64,10 +61,12 @@ export class LearningContentRepository {
 
     const table = this.#tableName.split('.').at(-1);
     this.#metrics = {
-      loadRead: metrics.read.labels({ type: 'load', table }),
-      findRead: metrics.read.labels({ type: 'find', table }),
-      loadCacheMiss: metrics.loadCacheMiss.labels({ table }),
-      findCacheMiss: metrics.findCacheMiss.labels({ table }),
+      load: metrics.read.labels({ table, cache: 'entities' }),
+      find: metrics.read.labels({ table, cache: 'results' }),
+      loadCacheMiss: metrics.cacheMiss.labels({ table, cache: 'entities' }),
+      findCacheMiss: metrics.cacheMiss.labels({ table, cache: 'results' }),
+      loadCachePenalty: metrics.cachePenalty.labels({ table, cache: 'entities' }),
+      findCachePenalty: metrics.cachePenalty.labels({ table, cache: 'results' }),
     };
   }
 
@@ -80,23 +79,40 @@ export class LearningContentRepository {
    * @returns {Promise<object[]>}
    */
   async find(cacheKey, callback) {
-    this.#metrics.findRead.inc();
+    let dtos;
+    let stopFindCachePenaltyTimer;
 
-    let dtos = this.#findCache.get(cacheKey);
-    if (dtos) return dtos;
+    try {
+      dtos = this.#findCache.get(cacheKey);
+      if (dtos) return dtos;
 
-    dtos = this.#findCacheMiss.get(cacheKey);
-    if (dtos) return dtos;
+      let dtosPromise = this.#findCacheMiss.get(cacheKey);
+      if (dtosPromise) {
+        stopFindCachePenaltyTimer = this.#metrics.findCachePenalty.startTimer();
+        dtos = await dtosPromise.finally(() => {
+          stopFindCachePenaltyTimer();
+        });
 
-    const stopFindCachemissTimer = this.#metrics.findCacheMiss.startTimer();
+        this.#metrics.findCacheMiss.observe(dtos.length);
 
-    dtos = this.#loadDtos(callback, cacheKey).finally(() => {
-      this.#findCacheMiss.delete(cacheKey);
-      stopFindCachemissTimer();
-    });
-    this.#findCacheMiss.set(cacheKey, dtos);
+        return dtos;
+      }
 
-    return dtos;
+      stopFindCachePenaltyTimer = this.#metrics.findCachePenalty.startTimer();
+      dtosPromise = this.#loadDtos(callback, cacheKey).finally(() => {
+        this.#findCacheMiss.delete(cacheKey);
+        stopFindCachePenaltyTimer();
+      });
+      this.#findCacheMiss.set(cacheKey, dtosPromise);
+
+      dtos = await dtosPromise;
+
+      this.#metrics.findCacheMiss.observe(dtos.length);
+
+      return dtos;
+    } finally {
+      this.#metrics.find.observe(dtos.length);
+    }
   }
 
   /**
@@ -105,7 +121,7 @@ export class LearningContentRepository {
    * @returns {Promise<object|null>}
    */
   async load(id) {
-    this.#metrics.loadRead.inc();
+    this.#metrics.load.observe(1);
     return this.#dataloader.load(id);
   }
 
@@ -141,7 +157,7 @@ export class LearningContentRepository {
    * @returns {Promise<(object|null)[]>}
    */
   async #loadMany(ids, cacheKey) {
-    this.#metrics.loadRead.inc(ids.length);
+    this.#metrics.load.observe(ids.length);
 
     const dtos = await this.#dataloader.loadMany(ids);
 
@@ -182,7 +198,8 @@ export class LearningContentRepository {
   async #batchLoad(ids) {
     logger.debug({ tableName: this.#tableName, count: ids.length }, 'loading from PG');
 
-    const stopLoadCachemissTimer = this.#metrics.loadCacheMiss.startTimer();
+    this.#metrics.loadCacheMiss.observe(ids.length);
+    const stopLoadCachePenaltyTimer = this.#metrics.loadCachePenalty.startTimer();
 
     try {
       const knexConn = DomainTransaction.getConnection();
@@ -193,7 +210,7 @@ export class LearningContentRepository {
         .orderBy('ids.idx');
       return dtos.map((dto) => (dto.id ? dto : null));
     } finally {
-      stopLoadCachemissTimer();
+      stopLoadCachePenaltyTimer();
     }
   }
 


### PR DESCRIPTION
## 🥀 Problème

Certaines metrics du learning content ne sont pas cohérentes entre elles et/ou pas facilement exploitables.

## 🏹 Proposition

Produire des metrics plus cohérentes, 3 histograms par type de cache (results et entities) :
 - Nombre d’entités lues (3 buckets : <10, <100, <1000)
 - Cache miss en nombre d’entités lues (mêmes buckets)
 - Cache penalties en secondes (3 buckets : <1ms, <10ms, <100ms)

Les histograms produisent également un compteur, donc respectivement :
 - Nombre de lectures
 - Nombre de lectures sans cache
 - Nombre de lectures sans cache aussi

## 💌 Remarques

N/A

## ❤️‍🔥 Pour tester

Démarrer la stack :
```
docker compose -f compose.yaml -f compose.prometheus.yaml up -d
```

Ajouter dans le .env de l’api :
```
PROMETHEUS_PUSHGATEWAY_URL=http://localhost:9991
PROMETHEUS_ENABLED=true
```

Démarrer l’API et PixApp.

Passer des épreuves sur PixApp.

Aller dans Grafana http://localhost:3210, login admin/admin

Brancher la datasource Prometheus avec l’URL http://prometheus:9090 et sans authent’.

Vérifier que les metrics remontent bien.