### PR TITLE
[BUGFIX] Répare le script de suppression des parcours combinés (PIX-21908)

### DIFF
--- a/api/src/quest/domain/usecases/delete-and-anonymise-participations-for-a-learner-id.js
+++ b/api/src/quest/domain/usecases/delete-and-anonymise-participations-for-a-learner-id.js
@@ -8,7 +8,6 @@ export const deleteAndAnonymizeParticipationsForALearnerId = withTransaction(
     combinedCourseId,
     userId,
     organizationLearnerId,
-    combinedCourseDetailsService,
     campaignParticipationRepository,
   }) => {
     await organizationLearnerParticipationRepository.deleteCombinedCourseParticipationByCombinedCourseIdAndOrganizationLearnerId(
@@ -16,19 +15,6 @@ export const deleteAndAnonymizeParticipationsForALearnerId = withTransaction(
     );
     const campaignIds = await campaignRepository.getCampaignIdsByCombinedCourseIds({
       combinedCourseIds: [combinedCourseId],
-    });
-
-    const modulesIdsToDelete = [];
-
-    const { modules } = await combinedCourseDetailsService.instantiateCombinedCourseDetails({
-      combinedCourseId,
-    });
-    modulesIdsToDelete.push(...modules.map((module) => module.id));
-
-    await organizationLearnerParticipationRepository.deletePassagesByModuleIdsAndOrganizationLearnerId({
-      moduleIds: modulesIdsToDelete,
-      organizationLearnerId,
-      userId,
     });
 
     for (const campaignId of campaignIds) {

--- a/api/src/quest/domain/usecases/delete-and-anonymize-combined-courses.js
+++ b/api/src/quest/domain/usecases/delete-and-anonymize-combined-courses.js
@@ -8,7 +8,6 @@ export const deleteAndAnonymizeCombinedCourses = withTransaction(
     campaignRepository,
     combinedCourseIds,
     userId,
-    combinedCourseDetailsService,
   }) => {
     await combinedCourseRepository.deleteCombinedCourses({
       combinedCourseIds,
@@ -17,20 +16,6 @@ export const deleteAndAnonymizeCombinedCourses = withTransaction(
     await organizationLearnerParticipationRepository.deleteCombinedCourseParticipations({ combinedCourseIds, userId });
     const campaignIds = await campaignRepository.getCampaignIdsByCombinedCourseIds({
       combinedCourseIds,
-    });
-
-    const modulesIdsToDelete = [];
-
-    for (const combinedCourseId of combinedCourseIds) {
-      const { modules } = await combinedCourseDetailsService.instantiateCombinedCourseDetails({
-        combinedCourseId: combinedCourseId,
-      });
-      modulesIdsToDelete.push(...modules.map((module) => module.id));
-    }
-
-    await organizationLearnerParticipationRepository.deletePassagesByModuleIds({
-      moduleIds: modulesIdsToDelete,
-      userId,
     });
 
     for (const campaignId of campaignIds) {

--- a/api/src/quest/infrastructure/repositories/organization-learner-participation-repository.js
+++ b/api/src/quest/infrastructure/repositories/organization-learner-participation-repository.js
@@ -45,7 +45,6 @@ export const synchronize = async ({ organizationLearnerId, moduleIds, modulesApi
 
   const learnerParticipationsByModule = await knexConn('organization_learner_participations')
     .select('organization_learner_participations.id', 'referenceId')
-    .whereNull('deletedAt')
     .where('organizationLearnerId', organizationLearnerId)
     .whereIn('referenceId', moduleIds);
 
@@ -87,17 +86,6 @@ export const deleteCombinedCourseParticipationByCombinedCourseIdAndOrganizationL
     .andWhere('referenceId', combinedCourseId.toString());
 };
 
-export const deletePassagesByModuleIdsAndOrganizationLearnerId = async ({
-  moduleIds,
-  organizationLearnerId,
-  userId,
-}) => {
-  const knexConn = DomainTransaction.getConnection();
-
-  await baseUpdateQuery(knexConn, userId)
-    .whereIn('referenceId', moduleIds)
-    .andWhere('organizationLearnerId', organizationLearnerId);
-};
 export const deleteCombinedCourseParticipations = async ({ combinedCourseIds, userId }) => {
   const knexConn = DomainTransaction.getConnection();
 
@@ -106,12 +94,6 @@ export const deleteCombinedCourseParticipations = async ({ combinedCourseIds, us
     'organization_learner_participations.referenceId',
     stringifiedCombinedCourseIds,
   );
-};
-
-export const deletePassagesByModuleIds = async ({ moduleIds, userId }) => {
-  const knexConn = DomainTransaction.getConnection();
-
-  await baseUpdateQuery(knexConn, userId).whereIn('organization_learner_participations.referenceId', moduleIds);
 };
 
 function baseUpdateQuery(knexConn, userId) {

--- a/api/tests/quest/integration/domain/usecases/delete-and-anonymise-participations-for-a-learner-id_test.js
+++ b/api/tests/quest/integration/domain/usecases/delete-and-anonymise-participations-for-a-learner-id_test.js
@@ -56,23 +56,23 @@ describe('Integration | Quest | Domain | UseCases | delete-and-anonymise-partici
     });
 
     databaseBuilder.factory.buildOrganizationLearnerParticipation({
-      combinedCourseId: combinedCourse.id.toString(),
-      type: OrganizationLearnerParticipationTypes.COMBINED_COURSE,
+      moduleId: 'ca47a7a8-4dc9-42bd-a1ac-4b1e849a054b',
+      type: OrganizationLearnerParticipationTypes.PASSAGE,
       organizationLearnerId,
       status: OrganizationLearnerParticipationStatuses.COMPLETED,
     });
 
     databaseBuilder.factory.buildOrganizationLearnerParticipation({
-      moduleId,
-      organizationLearnerId: otherOrganizationLearnerId,
+      combinedCourseId: combinedCourse.id.toString(),
       type: OrganizationLearnerParticipationTypes.COMBINED_COURSE,
+      organizationLearnerId: otherOrganizationLearnerId,
       status: OrganizationLearnerParticipationStatuses.COMPLETED,
     });
 
     await databaseBuilder.commit();
   });
 
-  it('flags organization_learner_participations and campaign_participations linked to combined Course with deletedBy/deletedAt attributes', async function () {
+  it('flags organization_learner_participations and campaign_participations linked to combined Course with deletedBy/deletedAt attributes but it does not flag passages', async function () {
     //given
     const { userId } = databaseBuilder.factory.buildMembership({
       organizationId: organization.id,
@@ -96,25 +96,28 @@ describe('Integration | Quest | Domain | UseCases | delete-and-anonymise-partici
       campaignParticipationsApi: campaignParticipationsApiStub,
     });
 
-    const deletedCombinedCourseParticipations = await knex('organization_learner_participations').where(
-      'organizationLearnerId',
-      organizationLearnerId,
-    );
+    const deletedCombinedCourseParticipations = await knex('organization_learner_participations')
+      .where('organizationLearnerId', organizationLearnerId)
+      .where('type', OrganizationLearnerParticipationTypes.COMBINED_COURSE);
 
-    const remainingCombinedCourseParticipations = await knex('organization_learner_participations').where(
-      'organizationLearnerId',
-      otherOrganizationLearnerId,
-    );
+    const remainingCombinedCourseParticipations = await knex('organization_learner_participations')
+      .where('organizationLearnerId', otherOrganizationLearnerId)
+      .where('type', OrganizationLearnerParticipationTypes.COMBINED_COURSE);
+
+    const remainingPassages = await knex('organization_learner_participations')
+      .where('organizationLearnerId', organizationLearnerId)
+      .where('type', OrganizationLearnerParticipationTypes.PASSAGE);
 
     //then
-    expect(deletedCombinedCourseParticipations).to.have.lengthOf(2);
+    expect(deletedCombinedCourseParticipations).to.have.lengthOf(1);
     expect(deletedCombinedCourseParticipations[0].deletedBy).to.equal(userId);
     expect(deletedCombinedCourseParticipations[0].deletedAt).to.not.be.null;
-    expect(deletedCombinedCourseParticipations[1].deletedBy).to.equal(userId);
-    expect(deletedCombinedCourseParticipations[1].deletedAt).to.not.be.null;
 
     expect(remainingCombinedCourseParticipations.length).to.equal(1);
     expect(remainingCombinedCourseParticipations[0].deletedBy).to.be.null;
     expect(remainingCombinedCourseParticipations[0].deletedAt).to.be.null;
+
+    expect(remainingPassages[0].deletedBy).to.be.null;
+    expect(remainingPassages[0].deletedAt).to.be.null;
   });
 });

--- a/api/tests/quest/integration/domain/usecases/delete-and-anonymize-combined-courses_test.js
+++ b/api/tests/quest/integration/domain/usecases/delete-and-anonymize-combined-courses_test.js
@@ -10,7 +10,8 @@ import { databaseBuilder, knex, sinon } from '../../../../test-helper.js';
 
 describe('Integration | Combined course | Domain | UseCases | delete-and-anonymize-combined-courses', function () {
   let campaign, organization, combinedCourse, otherCombinedCourse, campaignsApiStub;
-  const moduleId = '01151659-77c1-41cc-8724-89091357af3d';
+
+  const moduleId = 'ca47a7a8-4dc9-42bd-a1ac-4b1e849a054b';
 
   beforeEach(async function () {
     campaignsApiStub = {
@@ -20,13 +21,9 @@ describe('Integration | Combined course | Domain | UseCases | delete-and-anonymi
 
     organization = databaseBuilder.factory.buildOrganization();
     campaign = databaseBuilder.factory.buildCampaign({ organizationId: organization.id });
-    const combinedCourseBlueprint = databaseBuilder.factory.buildCombinedCourseBlueprint({
-      content: [{ type: 'EVALUATION', value: campaign.targetProfileId }],
-    });
 
     combinedCourse = databaseBuilder.factory.buildCombinedCourse({
-      combinedCourseContents: [{ campaignId: campaign.id }, { moduleId }],
-      combinedCourseBlueprintId: combinedCourseBlueprint.id,
+      combinedCourseContents: [{ campaignId: campaign.id, moduleId }],
       code: 'RANDOM',
     });
 
@@ -42,12 +39,6 @@ describe('Integration | Combined course | Domain | UseCases | delete-and-anonymi
       status: OrganizationLearnerParticipationStatuses.COMPLETED,
     });
 
-    databaseBuilder.factory.buildOrganizationLearnerParticipation({
-      moduleId,
-      type: OrganizationLearnerParticipationTypes.COMBINED_COURSE,
-      status: OrganizationLearnerParticipationStatuses.COMPLETED,
-    });
-
     otherCombinedCourse = databaseBuilder.factory.buildCombinedCourse({ organizationId: organization.id });
     databaseBuilder.factory.buildOrganizationLearnerParticipation({
       organizationId: organization.id,
@@ -59,10 +50,16 @@ describe('Integration | Combined course | Domain | UseCases | delete-and-anonymi
       status: OrganizationLearnerParticipationStatuses.COMPLETED,
     });
 
+    databaseBuilder.factory.buildOrganizationLearnerParticipation({
+      moduleId,
+      type: OrganizationLearnerParticipationTypes.PASSAGE,
+      status: OrganizationLearnerParticipationStatuses.COMPLETED,
+    });
+
     await databaseBuilder.commit();
   });
 
-  it('flags combined course, campaign linked to combined course, and organization_learner_participations linked to combined Course', async function () {
+  it('flags combined course, campaign linked to combined course, and organization_learner_participations linked to combined Course but not passages', async function () {
     //given
     const { userId } = databaseBuilder.factory.buildMembership({
       organizationId: organization.id,
@@ -82,32 +79,31 @@ describe('Integration | Combined course | Domain | UseCases | delete-and-anonymi
     });
 
     const deletedCombinedCourses = await knex('combined_courses').where('id', combinedCourse.id);
-    const deletedCombinedCourseParticipations = await knex('organization_learner_participations').where(
-      'referenceId',
-      combinedCourse.id,
-    );
-    const deletedCombinedCoursePassage = await knex('organization_learner_participations').where(
-      'referenceId',
-      moduleId,
-    );
+    const deletedCombinedCourseParticipations = await knex('organization_learner_participations')
+      .where('referenceId', combinedCourse.id)
+      .where('type', OrganizationLearnerParticipationTypes.COMBINED_COURSE);
 
     const remainingCombinedCourses = await knex('combined_courses').where('id', otherCombinedCourse.id);
-    const remainingCombinedCourseParticipations = await knex('organization_learner_participations').where(
-      'referenceId',
-      otherCombinedCourse.id,
-    );
+    const remainingCombinedCourseParticipations = await knex('organization_learner_participations')
+      .where('referenceId', otherCombinedCourse.id)
+      .where('type', OrganizationLearnerParticipationTypes.COMBINED_COURSE);
+
+    const remainingPassages = await knex('organization_learner_participations')
+      .where('referenceId', moduleId)
+      .where('type', OrganizationLearnerParticipationTypes.PASSAGE);
 
     //then
     expect(deletedCombinedCourses[0].deletedBy).to.equal(userId);
     expect(deletedCombinedCourses[0].deletedAt).to.not.be.null;
     expect(deletedCombinedCourseParticipations[0].deletedBy).to.equal(userId);
     expect(deletedCombinedCourseParticipations[0].deletedAt).to.not.be.null;
-    expect(deletedCombinedCoursePassage[0].deletedBy).to.equal(userId);
-    expect(deletedCombinedCoursePassage[0].deletedAt).to.not.be.null;
 
     expect(remainingCombinedCourses[0].deletedAt).to.be.null;
     expect(remainingCombinedCourses[0].deletedBy).to.be.null;
     expect(remainingCombinedCourseParticipations[0].deletedAt).to.be.null;
     expect(remainingCombinedCourseParticipations[0].deletedBy).to.be.null;
+
+    expect(remainingPassages[0].deletedAt).to.be.null;
+    expect(remainingPassages[0].deletedBy).to.be.null;
   });
 });

--- a/api/tests/quest/integration/infrastructure/repositories/organization-learner-participation-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/organization-learner-participation-repository_test.js
@@ -459,56 +459,6 @@ describe('Quest | Integration | Infrastructure | repositories | organization lea
       expect(remainingParticipation[0].deletedBy).to.be.null;
     });
   });
-  describe('#deletePassagesByModulesIdAndOrganizationLearnerId', function () {
-    it('should delete the exact passage for given learner id and module id', async function () {
-      const moduleId = '01151659-77c1-41cc-8724-89091357af3d';
-      const otherModuleId = 'f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d';
-
-      const { userId, organizationId } = await databaseBuilder.factory.buildMembership();
-
-      const organizationLearnerId = await databaseBuilder.factory.buildOrganizationLearner({
-        organizationId,
-      }).id;
-
-      await databaseBuilder.factory.buildOrganizationLearnerParticipation({
-        type: OrganizationLearnerParticipationTypes.COMBINED_COURSE,
-        moduleId,
-        organizationLearnerId,
-        status: OrganizationLearnerParticipationStatuses.COMPLETED,
-      });
-
-      const { organizationLearnerId: otherOrganizationLearnerId } =
-        await databaseBuilder.factory.buildOrganizationLearnerParticipation({
-          type: OrganizationLearnerParticipationTypes.COMBINED_COURSE,
-          moduleId: otherModuleId,
-          status: OrganizationLearnerParticipationStatuses.COMPLETED,
-        });
-
-      await databaseBuilder.commit();
-
-      //when
-      await organizationLearnerParticipationRepository.deletePassagesByModuleIdsAndOrganizationLearnerId({
-        moduleIds: [moduleId],
-        organizationLearnerId,
-        userId,
-      });
-
-      //then
-      const deletedPassage = await knex('organization_learner_participations').where({
-        referenceId: moduleId,
-        organizationLearnerId,
-      });
-      const remainingPassage = await knex('organization_learner_participations').where({
-        referenceId: otherModuleId,
-        organizationLearnerId: otherOrganizationLearnerId,
-      });
-
-      expect(deletedPassage[0].deletedAt).not.to.be.null;
-      expect(deletedPassage[0].deletedBy).to.equal(userId);
-      expect(remainingPassage[0].deletedAt).to.be.null;
-      expect(remainingPassage[0].deletedBy).to.be.null;
-    });
-  });
   describe('#deleteCombinedCourseParticipation', function () {
     it('should delete the exact participation', async function () {
       //given
@@ -549,49 +499,6 @@ describe('Quest | Integration | Infrastructure | repositories | organization lea
       expect(deletedParticipation[0].deletedBy).to.equal(userId);
       expect(remainingParticipation[0].deletedAt).to.be.null;
       expect(remainingParticipation[0].deletedBy).to.be.null;
-    });
-  });
-
-  describe('#deletePassagesByModuleIds', function () {
-    it('should delete the exact passage', async function () {
-      //given
-      const moduleId = '01151659-77c1-41cc-8724-89091357af3d';
-      const otherModuleId = 'f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d';
-
-      const { userId } = await databaseBuilder.factory.buildMembership();
-
-      await databaseBuilder.factory.buildOrganizationLearnerParticipation({
-        type: OrganizationLearnerParticipationTypes.COMBINED_COURSE,
-        moduleId,
-        status: OrganizationLearnerParticipationStatuses.COMPLETED,
-      });
-
-      await databaseBuilder.factory.buildOrganizationLearnerParticipation({
-        type: OrganizationLearnerParticipationTypes.COMBINED_COURSE,
-        moduleId: otherModuleId,
-        status: OrganizationLearnerParticipationStatuses.COMPLETED,
-      });
-
-      await databaseBuilder.commit();
-
-      //when
-      await organizationLearnerParticipationRepository.deletePassagesByModuleIds({
-        moduleIds: [moduleId],
-        userId,
-      });
-
-      //then
-      const deletedPassage = await knex('organization_learner_participations').where({
-        referenceId: moduleId,
-      });
-      const remainingPassage = await knex('organization_learner_participations').where({
-        referenceId: otherModuleId,
-      });
-
-      expect(deletedPassage[0].deletedAt).not.to.be.null;
-      expect(deletedPassage[0].deletedBy).to.equal(userId);
-      expect(remainingPassage[0].deletedAt).to.be.null;
-      expect(remainingPassage[0].deletedBy).to.be.null;
     });
   });
 });


### PR DESCRIPTION
## 🥀 Problème

On ne veut plus flagger les organization-learner-participations de type "PASSAGE" à deletedAt/deletedBy car la logique du synchronize faisait qu'un passage est recréé pour un moduleId/organizationLearnerId donné s'il était supprimé. On s'est également rendus compte qu'on avait pas besoin de ce niveau de détail sur la donnée.

## 💌 Remarques
On ne checke plus que les participations aux passages ne sont pas supprimées avant de savoir si on doit mettre à jour cette participation ou en insérer une nouvelle.

## ❤️‍🔥 Pour tester
Test de non-régression sur le script.

Pour tester le script de suppression de participation d'un learner pour un parcours combiné
Se connecter sur Pix App, passer un parcours combiné dont on aura relevé l'id. Relever l'organizationLearnerId. 
Lancer le script.
Vérifier que dans organization_learner_participations, la participation de type COMBINED_COURSE correspondante a bien été flaggée deletedAt/deletedBy. La participation à la campagne de diagnostic doit aussi être flaggée. 
