### PR TITLE
[FEATURE] Ajouter une nouvelle route pour récupérer le détail d'un réseau (PIX-21337)

### DIFF
--- a/api/db/database-builder/factory/build-network.js
+++ b/api/db/database-builder/factory/build-network.js
@@ -1,4 +1,7 @@
 import { databaseBuffer } from '../database-buffer.js';
+import { buildFactStructure } from './build-fact-structure.js';
+import { buildOrganization } from './build-organization.js';
+import { buildStructure } from './build-structure.js';
 
 const buildNetwork = function ({
   id = databaseBuffer.getNextId(),
@@ -17,5 +20,17 @@ const buildNetwork = function ({
     values,
   });
 };
+const buildNetworkAndHeadOrganization = function ({
+  id = databaseBuffer.getNextId(),
+  name = 'Network',
+  organizationId,
+  organizationName = 'Head Organization',
+} = {}) {
+  const network = buildNetwork({ id, name });
+  const organization = buildOrganization({ id: organizationId, name: organizationName });
+  const structure = buildStructure();
+  buildFactStructure({ structureId: structure.id, networkId: network.id, organizationId: organization.id });
+  return network;
+};
 
-export { buildNetwork };
+export { buildNetwork, buildNetworkAndHeadOrganization };

--- a/api/src/organizational-entities/application/network/network.admin.controller.js
+++ b/api/src/organizational-entities/application/network/network.admin.controller.js
@@ -6,6 +6,12 @@ const findAllNetworks = async function (request, h, dependencies = { networkSeri
   return dependencies.networkSerializer.serialize(networks);
 };
 
+const getNetworkDetails = async function (request, h, dependencies = { networkSerializer }) {
+  const networkId = request.params.networkId;
+  const network = await usecases.getNetworkDetails({ networkId });
+  return dependencies.networkSerializer.serialize(network);
+};
+
 const create = async function (request, h, dependencies = { networkSerializer }) {
   const { organizationId, networkName } = networkSerializer.deserialize({
     data: request.payload.data,
@@ -24,6 +30,7 @@ const create = async function (request, h, dependencies = { networkSerializer })
 const networkAdminController = {
   create,
   findAllNetworks,
+  getNetworkDetails,
 };
 
 export { networkAdminController };

--- a/api/src/organizational-entities/application/network/network.admin.route.js
+++ b/api/src/organizational-entities/application/network/network.admin.route.js
@@ -28,9 +28,33 @@ const register = async function (server) {
         tags: ['api', 'organizational-entities', 'network'],
       },
     },
-  ]);
-
-  server.route([
+    {
+      method: 'GET',
+      path: '/api/admin/networks/{networkId}',
+      config: {
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.hasAtLeastOneAccessOf([securityPreHandlers.checkAdminMemberHasRoleSuperAdmin])(
+                request,
+                h,
+              ),
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        validate: {
+          params: Joi.object({
+            networkId: identifiersType.networkId,
+          }),
+        },
+        handler: (request, h) => networkAdminController.getNetworkDetails(request, h),
+        tags: ['api', 'organizational-entities', 'network'],
+        notes: [
+          "- **Cette route est restreinte aux utilisateurs authentifiés ayant les droits d'accès super admin**\n" +
+            "- Elle permet de récupérer les informations d'un réseau",
+        ],
+      },
+    },
     {
       method: 'POST',
       path: '/api/admin/networks',

--- a/api/src/organizational-entities/domain/models/Network.js
+++ b/api/src/organizational-entities/domain/models/Network.js
@@ -1,7 +1,12 @@
+import { NetworkHeadOrganization } from './NetworkHeadOrganization.js';
+
 class Network {
-  constructor({ id, name } = {}) {
+  constructor({ id, name, organizationId, organizationName } = {}) {
     this.id = id;
     this.name = name;
+    if (organizationId && organizationName) {
+      this.headOrganization = new NetworkHeadOrganization({ id: organizationId, name: organizationName });
+    }
   }
 }
 

--- a/api/src/organizational-entities/domain/models/NetworkHeadOrganization.js
+++ b/api/src/organizational-entities/domain/models/NetworkHeadOrganization.js
@@ -1,0 +1,8 @@
+class NetworkHeadOrganization {
+  constructor({ id, name } = {}) {
+    this.id = id;
+    this.name = name;
+  }
+}
+
+export { NetworkHeadOrganization };

--- a/api/src/organizational-entities/domain/usecases/get-network-details.usecase.js
+++ b/api/src/organizational-entities/domain/usecases/get-network-details.usecase.js
@@ -1,0 +1,3 @@
+export function getNetworkDetails({ networkId, networkRepository }) {
+  return networkRepository.getById(networkId);
+}

--- a/api/src/organizational-entities/domain/usecases/index.js
+++ b/api/src/organizational-entities/domain/usecases/index.js
@@ -103,6 +103,7 @@ import { findOrganizationFeatures } from './find-organization-features.js';
 import { findPaginatedFilteredCertificationCenters } from './find-paginated-filtered-certification-centers.usecase.js';
 import { findPaginatedFilteredOrganizations } from './find-paginated-filtered-organizations.usecase.js';
 import { getCenterForAdmin } from './get-center-for-admin.usecase.js';
+import { getNetworkDetails } from './get-network-details.usecase.js';
 import { getOrganizationById } from './get-organization-by-id.js';
 import { getOrganizationDetails } from './get-organization-details.usecase.js';
 import { getOrganizationPlacesStatistics } from './get-organization-places-statistics.usecase.js';
@@ -135,6 +136,7 @@ const usecasesWithoutInjectedDependencies = {
   findAllAdministrationTeams,
   findAllOrganizationLearnerTypes,
   getCenterForAdmin,
+  getNetworkDetails,
   getOrganizationById,
   getOrganizationDetails,
   getOrganizationPlacesStatistics,
@@ -153,6 +155,7 @@ const usecasesWithoutInjectedDependencies = {
  * @property {detachParentOrganizationFromOrganization} detachParentOrganizationFromOrganization
  * @property {findPaginatedFilteredCertificationCenters} findPaginatedFilteredCertificationCenters
  * @property {getOrganizationDetails} getOrganizationDetails
+ * @property {getNetworkDetails} getNetworkDetails
  * @property {updateOrganizationsInBatch} updateOrganizationsInBatch
  * @property {updateOrganizationInformation} updateOrganizationInformation
  * @property {archiveOrganizationsInBatch} archiveOrganizationsInBatch

--- a/api/src/organizational-entities/infrastructure/repositories/network.repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/network.repository.js
@@ -1,4 +1,5 @@
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
+import { NotFoundError } from '../../../shared/domain/errors.js';
 import { Network } from '../../domain/models/Network.js';
 
 /**
@@ -11,6 +12,38 @@ async function findAll() {
   const networks = await knexConn('networks').select('networks.id', 'networks.name').orderBy('name');
 
   return networks.map(_toDomain);
+}
+
+/**
+ * @param {number} networkId
+ * @returns {Promise<Network>}
+ */
+async function getById(networkId) {
+  const knexConn = DomainTransaction.getConnection();
+
+  const network = await knexConn('fct_structures')
+    .select(
+      'fct_structures.network_id as id',
+      'networks.name as name',
+      'organizations.name as organizationName',
+      'fct_structures.organization_id as organizationId',
+    )
+    .join('networks', 'fct_structures.network_id', 'networks.id')
+    .join('organizations', 'fct_structures.organization_id', 'organizations.id')
+    .where('fct_structures.network_id', networkId)
+    .andWhere('fct_structures.parent_structure_id', null)
+    .first();
+
+  if (!network) {
+    throw new NotFoundError();
+  }
+
+  return _toDomain({
+    id: network.id,
+    name: network.name,
+    organizationId: network.organizationId,
+    organizationName: network.organizationName,
+  });
 }
 
 /**
@@ -58,4 +91,4 @@ function _toDomain(network) {
   return new Network(network);
 }
 
-export { findAll, findByOrganizationId, save };
+export { findAll, findByOrganizationId, getById, save };

--- a/api/src/organizational-entities/infrastructure/serializers/jsonapi/network/network.serializer.js
+++ b/api/src/organizational-entities/infrastructure/serializers/jsonapi/network/network.serializer.js
@@ -4,7 +4,7 @@ const { Serializer } = jsonapiSerializer;
 
 const serialize = function (network) {
   return new Serializer('networks', {
-    attributes: ['name'],
+    attributes: ['name', 'headOrganization'],
   }).serialize(network);
 };
 

--- a/api/src/shared/domain/types/identifiers-type.js
+++ b/api/src/shared/domain/types/identifiers-type.js
@@ -67,6 +67,7 @@ const typesPositiveInteger32bits = [
   'complementaryCertificationId',
   'membershipId',
   'missionId',
+  'networkId',
   'organizationId',
   'organizationInvitationId',
   'organizationLearnerId',

--- a/api/tests/organizational-entities/acceptance/application/network/network.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/network/network.admin.route.test.js
@@ -56,6 +56,43 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | N
     });
   });
 
+  describe('GET /api/admin/networks/1', function () {
+    it('returns a list of networks with 200 HTTP status code', async function () {
+      // given
+      const server = await createServer();
+      const network = databaseBuilder.factory.buildNetworkAndHeadOrganization({
+        id: 1,
+        name: 'Mon réseau',
+        organizationId: 555,
+        organizationName: 'Tête de réseau',
+      });
+      await databaseBuilder.commit();
+      const options = {
+        method: 'GET',
+        url: '/api/admin/networks/1',
+        headers: generateAuthenticatedUserRequestHeaders(superAdmin),
+      };
+      const expectedNetwork = {
+        attributes: {
+          name: network.name,
+          'head-organization': {
+            id: 555,
+            name: 'Tête de réseau',
+          },
+        },
+        id: network.id.toString(),
+        type: 'networks',
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result.data).to.deep.equal(expectedNetwork);
+    });
+  });
+
   describe('POST /api/admin/networks', function () {
     it('creates a new network', async function () {
       // given

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/network.repository.test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/network.repository.test.js
@@ -1,5 +1,6 @@
 import * as networkRepository from '../../../../../src/organizational-entities/infrastructure/repositories/network.repository.js';
-import { databaseBuilder, domainBuilder, expect, knex } from '../../../../test-helper.js';
+import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
+import { catchErr, databaseBuilder, domainBuilder, expect, knex } from '../../../../test-helper.js';
 
 describe('Integration | Organizational Entities | Infrastructure | Repositories | network', function () {
   describe('#findAll', function () {
@@ -38,6 +39,108 @@ describe('Integration | Organizational Entities | Infrastructure | Repositories 
 
         // then
         expect(foundNetworks).to.be.empty;
+      });
+    });
+  });
+
+  describe('#getById', function () {
+    describe('when the network is found', function () {
+      it('returns the network with head organization informations', async function () {
+        // given
+        const headOrganization = databaseBuilder.factory.buildOrganization({ name: 'Orga tête de réseau' });
+        const headStructureId = databaseBuilder.factory.buildStructure().id;
+
+        const network = databaseBuilder.factory.buildNetwork({ name: 'Mon super réseau' });
+
+        databaseBuilder.factory.buildFactStructure({
+          structureId: headStructureId,
+          networkId: network.id,
+          organizationId: headOrganization.id,
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const foundNetwork = await networkRepository.getById(network.id);
+
+        // then
+        const expectedNetwork = domainBuilder.acquisition.buildNetwork({
+          id: network.id,
+          name: 'Mon super réseau',
+          organizationId: headOrganization.id,
+          organizationName: 'Orga tête de réseau',
+        });
+
+        expect(foundNetwork).to.deepEqualInstance(expectedNetwork);
+      });
+
+      context('when there are several organizations in the network', function () {
+        it('returns the network with correct head organization informations', async function () {
+          // given
+          const childOrganization = databaseBuilder.factory.buildOrganization({
+            name: 'Not head organization but still in the same network',
+          });
+          const childStructureId = databaseBuilder.factory.buildStructure().id;
+          const headOrganization = databaseBuilder.factory.buildOrganization({ name: 'Head organization' });
+          const headStructureId = databaseBuilder.factory.buildStructure().id;
+
+          const network = databaseBuilder.factory.buildNetwork({ name: 'My network' });
+
+          databaseBuilder.factory.buildFactStructure({
+            structureId: headStructureId,
+            networkId: network.id,
+            organizationId: headOrganization.id,
+          });
+
+          databaseBuilder.factory.buildFactStructure({
+            structureId: childStructureId,
+            networkId: network.id,
+            organizationId: childOrganization.id,
+            parentStructureId: headStructureId,
+          });
+
+          await databaseBuilder.commit();
+
+          // when
+          const foundNetwork = await networkRepository.getById(network.id);
+
+          // then
+          const expectedNetwork = domainBuilder.acquisition.buildNetwork({
+            id: network.id,
+            name: 'My network',
+            organizationId: headOrganization.id,
+            organizationName: 'Head organization',
+          });
+
+          expect(foundNetwork).to.deepEqualInstance(expectedNetwork);
+        });
+      });
+    });
+
+    describe('when the network is not found', function () {
+      it('throws a not found error', async function () {
+        // given
+        const headOrganization = databaseBuilder.factory.buildOrganization({ name: 'Orga tête de réseau' });
+        const headStructureId = databaseBuilder.factory.buildStructure().id;
+
+        const network = databaseBuilder.factory.buildNetwork({ id: 1, name: 'Réseau avec id 1' });
+
+        databaseBuilder.factory.buildFactStructure({
+          structureId: headStructureId,
+          networkId: network.id,
+          organizationId: headOrganization.id,
+        });
+
+        await databaseBuilder.commit();
+
+        const nonExistingNetworkId = 2;
+
+        // when
+        const error = await catchErr(networkRepository.getById)(nonExistingNetworkId);
+
+        // then
+
+        expect(error).to.be.instanceOf(NotFoundError);
       });
     });
   });

--- a/api/tests/organizational-entities/unit/application/network/network.admin.controller.test.js
+++ b/api/tests/organizational-entities/unit/application/network/network.admin.controller.test.js
@@ -21,6 +21,31 @@ describe('Unit | Organizational Entities | Application | Network', function () {
     });
   });
 
+  describe('#getNetworkDetails', function () {
+    it('calls getNetworkById usecase and Network serializer', async function () {
+      // given
+      const network = domainBuilder.acquisition.buildNetwork({
+        id: 1,
+        name: 'Mon Réseau',
+        organizationId: 555,
+        organizationName: 'Tête de réseau',
+      });
+
+      const networkId = 1;
+
+      const requestStub = { params: { networkId } };
+      sinon.stub(usecases, 'getNetworkDetails').resolves(network);
+      const networkSerializer = { serialize: sinon.stub() };
+
+      // when
+      await networkAdminController.getNetworkDetails(requestStub, hFake, { networkSerializer });
+
+      // then
+      expect(usecases.getNetworkDetails).to.have.been.calledOnce;
+      expect(networkSerializer.serialize).to.have.been.calledWithExactly(network);
+    });
+  });
+
   describe('#create', function () {
     context('when payload contains only required fields', function () {
       it('calls "createNetwork" use case with the right parameters', async function () {

--- a/api/tests/organizational-entities/unit/application/network/network.admin.route.test.js
+++ b/api/tests/organizational-entities/unit/application/network/network.admin.route.test.js
@@ -44,6 +44,45 @@ describe('Unit | Application | Admin | Route | Network', function () {
     });
   });
 
+  describe('GET /api/admin/networks/{networkId}', function () {
+    describe('when the authenticated user has super admin role', function () {
+      it('should call getNetworkById controller method', async function () {
+        // given
+        sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
+        sinon.stub(usecases, 'getNetworkDetails').returns('ok');
+        sinon.stub(networkAdminController, 'getNetworkDetails').returns('ok');
+
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        await httpTestServer.request('GET', '/api/admin/networks/1', {});
+
+        // then
+        sinon.assert.called(networkAdminController.getNetworkDetails);
+      });
+    });
+
+    describe('when the user authenticated has no role', function () {
+      it('should return 403 HTTP status code', async function () {
+        // given
+        sinon
+          .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
+          .returns((request, h) => h.response().code(403).takeover());
+        sinon.stub(networkAdminController, 'getNetworkDetails').returns('ok');
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const response = await httpTestServer.request('GET', '/api/admin/networks/1', {});
+
+        // then
+        expect(response.statusCode).to.equal(403);
+        sinon.assert.notCalled(networkAdminController.getNetworkDetails);
+      });
+    });
+  });
+
   describe('POST /api/admin/networks', function () {
     describe('when the authenticated user has super admin role', function () {
       it('should call create controller method', async function () {

--- a/api/tests/organizational-entities/unit/domain/models/Network_test.js
+++ b/api/tests/organizational-entities/unit/domain/models/Network_test.js
@@ -1,0 +1,41 @@
+import { Network } from '../../../../../src/organizational-entities/domain/models/Network.js';
+import { NetworkHeadOrganization } from '../../../../../src/organizational-entities/domain/models/NetworkHeadOrganization.js';
+import { expect } from '../../../../test-helper.js';
+
+describe('Unit | Organizational Entities | Domain | Model | Network', function () {
+  describe('constructor', function () {
+    describe('head organization', function () {
+      context('when organizationId and organizationName are provided', function () {
+        it('should create NetworkHeadOrganization sub-model', function () {
+          // when
+          const network = new Network({
+            id: 1,
+            name: 'Mon réseau',
+            organizationId: 555,
+            organizationName: 'Ministère',
+          });
+
+          // then
+          expect(network.headOrganization).to.deepEqualInstance(
+            new NetworkHeadOrganization({ id: 555, name: 'Ministère' }),
+          );
+        });
+      });
+
+      context('when organizationId and organizationName are not provided', function () {
+        it('should not create NetworkHeadOrganization sub-model', function () {
+          // when
+          const network = new Network({
+            id: 1,
+            name: 'Mon réseau',
+            organizationId: undefined,
+            organizationName: undefined,
+          });
+
+          // then
+          expect(network.headOrganization).to.be.undefined;
+        });
+      });
+    });
+  });
+});

--- a/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/network/network.serializer.test.js
+++ b/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/network/network.serializer.test.js
@@ -8,12 +8,18 @@ describe('Unit | Infrastructure | Serializers | JsonApi |  Network | network-ser
       const network = domainBuilder.acquisition.buildNetwork({
         id: 42,
         name: 'Mon réseau',
+        organizationId: 555,
+        organizationName: 'Tête de réseau',
       });
 
       const expectedSerializedNetwork = {
         data: {
           attributes: {
             name: 'Mon réseau',
+            'head-organization': {
+              id: 555,
+              name: 'Tête de réseau',
+            },
           },
           id: '42',
           type: 'networks',

--- a/api/tests/tooling/domain-builder/factory/acquisition/build-network.js
+++ b/api/tests/tooling/domain-builder/factory/acquisition/build-network.js
@@ -1,6 +1,6 @@
 import { Network } from '../../../../../src/organizational-entities/domain/models/Network.js';
-const buildNetwork = function ({ id = 1234, name = 'Mon réseau' } = {}) {
-  return new Network({ id, name });
+const buildNetwork = function ({ id = 1234, name = 'Mon réseau', organizationId, organizationName } = {}) {
+  return new Network({ id, name, organizationId, organizationName });
 };
 
 export { buildNetwork };


### PR DESCRIPTION
## 🥀 Problème

Il va falloir bientôt pouvoir visualiser les premières informations d'un réseau dont on dispose: son id, son nom, l'id de son organisation tête et son nom.

## 🏹 Proposition

Ajouter un endpoint API `/networks/{networkId}` pour renvoyer ces informations

## 💌 Remarques

Ce endpoint est pour le moment restreint au rôle Super admin

## ❤️‍🔥 Pour tester
Sur Pix Admin
- se connecter en tant que super admin
- récupérer le token
- prendre un id de Network existant dans les seeds: `149164` (Réseau scolaire)
- requêter l'API avec un client HTTP sur `https://admin-pr15467.review.pix.fr/api/admin/networks/149164`

ou en curl
``` bash
curl https://admin-pr15467.review.pix.fr/api/admin/networks/149164 \
-H "Authorization: Bearer <mon-token-ici>" \
-H "Content-Type: application/json" \
-X GET
```

- constater que l'API renvoie les informations du réseau et de son orga tête.
- faire la même requête avec les autres rôles et constater un accès refusé (Erreur 403)