### PR TITLE
[TECH] Supprimer les campaignParticipationId des assessments en batchUpdate (PIX-21888).

### DIFF
--- a/api/src/prescription/campaign-participation/domain/usecases/delete-campaign-participation.js
+++ b/api/src/prescription/campaign-participation/domain/usecases/delete-campaign-participation.js
@@ -46,10 +46,8 @@ const deleteCampaignParticipation = async function ({
     await userRecommendedTrainingRepository.deleteCampaignParticipationIds({ campaignParticipationIds });
 
     const assessments = await assessmentRepository.getByCampaignParticipationIds(campaignParticipationIds);
-    for (const assessment of assessments) {
-      assessment.detachCampaignParticipation();
-      await assessmentRepository.updateCampaignParticipationId(assessment);
-    }
+    assessments.forEach((assessment) => assessment.detachCampaignParticipation());
+    await assessmentRepository.batchRemoveParticipationId(assessments);
   });
 
   for (const auditLoggingJob of auditLoggingJobs) {

--- a/api/src/prescription/campaign/domain/usecases/delete-campaigns.js
+++ b/api/src/prescription/campaign/domain/usecases/delete-campaigns.js
@@ -82,10 +82,9 @@ const deleteCampaigns = async ({
       campaignParticipationIds,
     );
     const assessments = await assessmentRepository.getByCampaignParticipationIds(campaignParticipationIds);
-    for (const assessment of assessments) {
-      assessment.detachCampaignParticipation();
-      await assessmentRepository.updateCampaignParticipationId(assessment);
-    }
+
+    assessments.forEach((assessment) => assessment.detachCampaignParticipation());
+    await assessmentRepository.batchRemoveParticipationId(assessments);
 
     const campaignIdsToDelete = campaignDestructor.campaigns.map(({ id }) => id);
 

--- a/api/src/prescription/learner-management/domain/usecases/delete-organization-learners.js
+++ b/api/src/prescription/learner-management/domain/usecases/delete-organization-learners.js
@@ -43,6 +43,7 @@ const deleteOrganizationLearners = async function ({
   const auditLoggingJobs = [];
 
   await DomainTransaction.execute(async () => {
+    const assessmentsToUpdate = [];
     for (const organizationLearner of organizationLearnersToDelete) {
       const organizationLearnerRewards = organizationProfileRewards.filter(
         (organizationProfileReward) => organizationProfileReward.userId === organizationLearner.userId,
@@ -92,13 +93,14 @@ const deleteOrganizationLearners = async function ({
         campaignParticipationIds,
       );
       const assessments = await assessmentRepository.getByCampaignParticipationIds(campaignParticipationIds);
-      for (const assessment of assessments) {
-        assessment.detachCampaignParticipation();
-        await assessmentRepository.updateCampaignParticipationId(assessment);
-      }
+
+      assessments.forEach((assessment) => assessment.detachCampaignParticipation());
+
+      assessmentsToUpdate.push(...assessments);
 
       await userRecommendedTrainingRepository.deleteCampaignParticipationIds({ campaignParticipationIds });
     }
+    await assessmentRepository.batchRemoveParticipationId(assessmentsToUpdate);
   });
 
   for (const auditLoggingJob of auditLoggingJobs) {

--- a/api/src/shared/infrastructure/repositories/assessment-repository.js
+++ b/api/src/shared/infrastructure/repositories/assessment-repository.js
@@ -4,6 +4,7 @@ import * as campaignRepository from '../../../prescription/campaign/infrastructu
 import { DomainTransaction } from '../../domain/DomainTransaction.js';
 import { NotFoundError } from '../../domain/errors.js';
 import { Assessment } from '../../domain/models/Assessment.js';
+import { batchUpdate } from '../utils/knex-utils.js';
 
 const { omit } = lodash;
 
@@ -193,17 +194,21 @@ const getByCampaignParticipationIds = async function (campaignParticipationIds =
   return assessments.map((assessment) => new Assessment({ ...assessment }));
 };
 
-const updateCampaignParticipationId = async function (assessment) {
-  const knexConn = DomainTransaction.getConnection();
-  const [assessmentUpdated] = await knexConn('assessments')
-    .update({ campaignParticipationId: assessment.campaignParticipationId, updatedAt: assessment.updatedAt })
-    .where('id', assessment.id)
-    .returning('*');
-  if (!assessmentUpdated) return null;
+const batchRemoveParticipationId = async function (assessments) {
+  await batchUpdate({
+    tableName: 'assessments',
+    primaryKeyName: 'id',
+    rows: assessments.map((assessment) => ({
+      id: assessment.id,
+      campaignParticipationId: assessment.campaignParticipationId,
+      updatedAt: assessment.updatedAt,
+    })),
+  });
 };
 
 export {
   abortByAssessmentId,
+  batchRemoveParticipationId,
   completeByAssessmentId,
   findLastCompletedAssessmentsForEachCompetenceByUser,
   findNotAbortedCampaignAssessmentsByUserId,
@@ -215,7 +220,6 @@ export {
   ownedByUser,
   save,
   setAssessmentsAsStarted,
-  updateCampaignParticipationId,
   updateLastQuestionDate,
   updateLastQuestionState,
   updateWhenNewChallengeIsAsked,

--- a/api/tests/shared/integration/infrastructure/repositories/assessment-repository_test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/assessment-repository_test.js
@@ -591,12 +591,12 @@ describe('Integration | Infrastructure | Repositories | assessment-repository', 
     });
   });
 
-  describe('#updateCampaignParticipationId', function () {
-    it('should update assessment', async function () {
+  describe('#batchRemoveParticipationId', function () {
+    it('should update assessment campaign participation ID', async function () {
       // given
       const participation = databaseBuilder.factory.buildCampaignParticipation();
       const initialCreatedAt = new Date('2020-01-01');
-      const assessment = databaseBuilder.factory.buildAssessment({
+      const assessment1 = databaseBuilder.factory.buildAssessment({
         state: Assessment.states.STARTED,
         lastQuestionDate: new Date('2020-01-10'),
         lastChallengeId: 'rechallenge1',
@@ -604,36 +604,60 @@ describe('Integration | Infrastructure | Repositories | assessment-repository', 
         updatedAt: new Date('2020-01-01'),
         createdAt: initialCreatedAt,
         lastQuestionState: null,
+        isImproving: false,
       });
+
+      const assessment2 = databaseBuilder.factory.buildAssessment({
+        state: Assessment.states.STARTED,
+        lastQuestionDate: new Date('2020-01-10'),
+        lastChallengeId: 'rechallenge2',
+        campaignParticipationId: participation.id,
+        updatedAt: new Date('2020-01-01'),
+        createdAt: initialCreatedAt,
+        lastQuestionState: null,
+        isImproving: true,
+      });
+
       await databaseBuilder.commit();
 
-      assessment.campaignParticipationId = null;
-      assessment.state = Assessment.states.ABORTED;
-      assessment.updatedAt = new Date('2020-01-12');
+      assessment1.campaignParticipationId = null;
+      assessment1.state = Assessment.states.ABORTED;
+      assessment1.updatedAt = new Date('2020-01-12');
+
+      assessment2.campaignParticipationId = null;
+      assessment2.state = Assessment.states.ABORTED;
+      assessment2.updatedAt = new Date('2020-01-12');
+
       // when
-      await assessmentRepository.updateCampaignParticipationId(assessment);
+      await assessmentRepository.batchRemoveParticipationId([assessment1, assessment2]);
 
       // then
-      const assessmentInDb = await knex('assessments').where('id', assessment.id).first();
+      const assessmentInDb1 = await knex('assessments').where('id', assessment1.id).first();
+      const assessmentInDb2 = await knex('assessments').where('id', assessment2.id).first();
 
-      expect(assessmentInDb.campaignParticipationId).null;
-      expect(assessmentInDb.updatedAt).deep.equal(new Date('2020-01-12'));
-      expect(assessmentInDb.state).equal(Assessment.states.STARTED);
+      expect(assessmentInDb1.campaignParticipationId).null;
+      expect(assessmentInDb1.updatedAt).deep.equal(new Date('2020-01-12'));
+      expect(assessmentInDb1.state).equal(Assessment.states.STARTED);
+
+      expect(assessmentInDb2.campaignParticipationId).null;
+      expect(assessmentInDb2.updatedAt).deep.equal(new Date('2020-01-12'));
+      expect(assessmentInDb2.state).equal(Assessment.states.STARTED);
     });
 
     context('when assessment does not exist', function () {
-      it('should return null', async function () {
+      it('should not throw an error', async function () {
         const notExistingAssessmentId = 1;
 
-        // when
-        const result = await assessmentRepository.updateCampaignParticipationId({
-          id: notExistingAssessmentId,
-          campaingParticipationId: 123,
-          updatedAt: new Date('2020-12-02'),
-        });
-
         // then
-        expect(result).to.equal(null);
+        await expect(
+          assessmentRepository.batchRemoveParticipationId([
+            {
+              id: notExistingAssessmentId,
+              campaingParticipationId: 123,
+              updatedAt: new Date('2020-12-02'),
+            },
+          ]),
+        ).not.to.be.rejected;
       });
     });
   });


### PR DESCRIPTION
## 🌎 Problème

Actuellement nous bouclions sur toutes chaque assessement pour faire cette suppression. ce qui est assez gourmand en terme de requete sql

## 🔭 Proposition

Utiliser le batchUpdate de knexUtils permettant de reduire la nombre d'appel sur la suppresion des assessments

## 🪐 Remarques

Bug remonté sur l'archivage des organization ayant des places actives ( il n'y a pas de distinction entre les places supprimés et les autres ).

différence de requete :

| DEV | Branch |
|:-------- |:--------:|
| 1159     | 1029  |

## 🚀 Pour tester
Archiver une campagne d'évaluation sur PixAdmin qui n'a ni parcours combiné, ni places. et vérifier que tout et OK ( certainement la SUP_MANAGING_STUDENT pour eviter ces cas là)

🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘 🌑
