### PR TITLE
[FEATURE] Afficher le nombre de membres d'une équipe d'un centre de certif (PIX-21448).

### DIFF
--- a/admin/app/adapters/certification-center.js
+++ b/admin/app/adapters/certification-center.js
@@ -3,6 +3,16 @@ import ApplicationAdapter from './application';
 export default class CertificationCenterAdapter extends ApplicationAdapter {
   namespace = 'api/admin';
 
+  findHasMany(store, snapshot, _url, relationship) {
+    if (relationship.key === 'certificationCenterMemberships') {
+      return this.ajax(
+        `${this.host}/${this.namespace}/certification-centers/${snapshot.id}/certification-center-memberships`,
+        'GET',
+      );
+    }
+    return super.findHasMany(...arguments);
+  }
+
   archiveCertificationCenter(certificationCenterId) {
     return this.ajax(`${this.host}/${this.namespace}/certification-centers/${certificationCenterId}/archive`, 'POST');
   }

--- a/admin/app/models/certification-center-membership.js
+++ b/admin/app/models/certification-center-membership.js
@@ -9,7 +9,7 @@ export default class CertificationCenterMembership extends Model {
   @attr('date') createdAt;
   @attr() role;
   @attr('date') lastAccessedAt;
-  @belongsTo('certification-center', { async: true, inverse: null }) certificationCenter;
+  @belongsTo('certification-center', { async: true, inverse: 'certificationCenterMemberships' }) certificationCenter;
   @belongsTo('user', { async: true, inverse: 'certificationCenterMemberships' }) user;
 
   get roleLabelKey() {

--- a/admin/app/models/certification-center.js
+++ b/admin/app/models/certification-center.js
@@ -20,6 +20,8 @@ export default class CertificationCenter extends Model {
   @attr() dataProtectionOfficerEmail;
 
   @hasMany('complementary-certification', { async: true, inverse: null }) habilitations;
+  @hasMany('certification-center-membership', { async: true, inverse: 'certificationCenter' })
+  certificationCenterMemberships;
 
   get typeLabel() {
     return types.find((type) => type.value === this.type).label;

--- a/admin/app/routes/authenticated/certification-centers/get/team.js
+++ b/admin/app/routes/authenticated/certification-centers/get/team.js
@@ -1,23 +1,15 @@
 import { action } from '@ember/object';
 import Route from '@ember/routing/route';
-import { service } from '@ember/service';
 
 export default class AuthenticatedCertificationCentersGetTeamRoute extends Route {
-  @service store;
-
   async model() {
     const { certificationCenter } = this.modelFor('authenticated.certification-centers.get');
-    const certificationCenterId = certificationCenter.id;
-    const certificationCenterMemberships = await this.store.query('certification-center-membership', {
-      filter: {
-        certificationCenterId,
-      },
-    });
+    await certificationCenter.hasMany('certificationCenterMemberships').reload();
 
     return {
-      certificationCenterMemberships,
+      certificationCenterMemberships: certificationCenter.certificationCenterMemberships,
       isCertificationCenterArchived: certificationCenter.isArchived,
-      certificationCenterId,
+      certificationCenterId: certificationCenter.id,
     };
   }
 

--- a/admin/app/templates/authenticated/certification-centers/get.gjs
+++ b/admin/app/templates/authenticated/certification-centers/get.gjs
@@ -20,7 +20,7 @@ import Information from 'pix-admin/components/certification-centers/information'
     {{#unless @controller.model.certificationCenter.isArchived}}
       <PixTabs @variant="primary" @ariaLabel="Navigation de la section centre de certification" class="navigation">
         <LinkTo @route="authenticated.certification-centers.get.team">
-          Équipe
+          Équipe ({{@controller.model.certificationCenter.certificationCenterMemberships.length}})
         </LinkTo>
 
         <LinkTo @route="authenticated.certification-centers.get.invitations">

--- a/admin/tests/acceptance/authenticated/certification-centers/get-test.js
+++ b/admin/tests/acceptance/authenticated/certification-centers/get-test.js
@@ -278,8 +278,35 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
             name: 'Navigation de la section centre de certification',
           }),
         );
-        assert.dom(certificationCenterNavigation.getByRole('link', { name: 'Équipe' })).exists();
+        assert.dom(certificationCenterNavigation.getByRole('link', { name: /Équipe/ })).exists();
         assert.dom(certificationCenterNavigation.getByRole('link', { name: 'Invitations' })).exists();
+      });
+
+      test('should display the number of active members in the Équipe tab', async function (assert) {
+        // given
+        await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+        const certificationCenter = server.create('certification-center', {
+          name: 'Pokemon Center',
+          externalId: 'ABCDEF',
+          type: 'PRO',
+          archivedAt: null,
+          archivistFullName: null,
+        });
+        const user1 = server.create('user');
+        const user2 = server.create('user');
+        server.create('certification-center-membership', { certificationCenter, role: 'MEMBER', user: user1 });
+        server.create('certification-center-membership', { certificationCenter, role: 'ADMIN', user: user2 });
+
+        // when
+        const screen = await visit(`/certification-centers/${certificationCenter.id}`);
+
+        // then
+        const certificationCenterNavigation = within(
+          screen.getByRole('navigation', {
+            name: 'Navigation de la section centre de certification',
+          }),
+        );
+        assert.dom(certificationCenterNavigation.getByRole('link', { name: 'Équipe (2)' })).exists();
       });
 
       test('displays invitation input and members list', async function (assert) {

--- a/admin/tests/mirage/models/certification-center.js
+++ b/admin/tests/mirage/models/certification-center.js
@@ -2,4 +2,5 @@ import { hasMany, Model } from 'miragejs';
 
 export default Model.extend({
   habilitations: hasMany('complementaryCertification'),
+  certificationCenterMemberships: hasMany('certificationCenterMembership'),
 });

--- a/admin/tests/mirage/serializers/certification-center.js
+++ b/admin/tests/mirage/serializers/certification-center.js
@@ -7,7 +7,7 @@ export default JSONAPISerializer.extend({
   links(certificationCenter) {
     return {
       certificationCenterMemberships: {
-        related: `/api/certification-centers/${certificationCenter.id}/certification-center-memberships`,
+        related: `/api/admin/certification-centers/${certificationCenter.id}/certification-center-memberships`,
       },
     };
   },

--- a/admin/tests/unit/routes/authenticated/certification-centers/get/team-test.js
+++ b/admin/tests/unit/routes/authenticated/certification-centers/get/team-test.js
@@ -8,25 +8,23 @@ module('Unit | Route | authenticated/certification-centers/get/team', function (
   test('it should return certification center memberships', async function (assert) {
     // given
     const route = this.owner.lookup('route:authenticated/certification-centers/get/team');
-    const store = this.owner.lookup('service:store');
 
     const certificationCenterMemberships = Symbol('some certification center memberships');
-    store.query = sinon.stub();
-    store.query
-      .withArgs('certification-center-membership', {
-        filter: {
-          certificationCenterId: 777,
-        },
-      })
-      .resolves(certificationCenterMemberships);
+    const certificationCenter = {
+      id: 777,
+      isArchived: false,
+      certificationCenterMemberships,
+      hasMany: sinon.stub().returns({ reload: sinon.stub().resolves() }),
+    };
 
     route.modelFor = sinon.stub();
-    route.modelFor.withArgs('authenticated.certification-centers.get').returns({ certificationCenter: { id: 777 } });
+    route.modelFor.withArgs('authenticated.certification-centers.get').returns({ certificationCenter });
 
     // when
     const result = await route.model();
 
     // then
+    sinon.assert.calledWith(certificationCenter.hasMany, 'certificationCenterMemberships');
     assert.strictEqual(result.certificationCenterMemberships, certificationCenterMemberships);
     assert.strictEqual(result.certificationCenterId, 777);
   });


### PR DESCRIPTION
## 🌎 Problème

Nous ne voyons pas d'un rapide coup d'oeil le nombre de membres actifs d'une centre de certification.

## 🔭 Proposition

Rajout du nombre de membres actifs

## 🪐 Remarques

- Nous ne occupons pas des traductions dans cette PR, une passe ultérieure sera faite pour l'entièreté de la page

## 🚀 Pour tester

- Se connecter à Pix-Admin
- Aller sur la page de détails d'un centre de certifications
- Vérifier que le nombre de membres actifs est affiché
- Archiver un membre
- Vérifier que le nombre se met à jour
