### PR TITLE
[TECH] Réécrire l'url en cas d'accès à un module avec un slug personnalisé (PIX-21904)

### DIFF
--- a/mon-pix/app/routes/module/details.js
+++ b/mon-pix/app/routes/module/details.js
@@ -1,7 +1,14 @@
 import Route from '@ember/routing/route';
+import { service } from '@ember/service';
 
 export default class ModuleDetailsRoute extends Route {
+  @service router;
+
   model() {
     return this.modelFor('module');
+  }
+
+  redirect(model) {
+    this.router.replaceWith('module.details', model.shortId, model.slug);
   }
 }

--- a/mon-pix/app/routes/module/passage.js
+++ b/mon-pix/app/routes/module/passage.js
@@ -5,6 +5,7 @@ export default class ModulePassageRoute extends Route {
   @service store;
   @service passageEvents;
   @service moduleIssueReport;
+  @service router;
 
   async model() {
     const module = this.modelFor('module');
@@ -19,5 +20,9 @@ export default class ModulePassageRoute extends Route {
     this.passageEvents.initialize({ passageId: passage.id });
     this.moduleIssueReport.initialize({ passageId: passage.id, moduleId: module.id });
     return { module, passage };
+  }
+
+  redirect({ module }) {
+    this.router.replaceWith('module.passage', module.shortId, module.slug);
   }
 }

--- a/mon-pix/tests/unit/routes/module/details-test.js
+++ b/mon-pix/tests/unit/routes/module/details-test.js
@@ -26,4 +26,25 @@ module('Unit | Route | modules | details', function (hooks) {
     // then
     assert.strictEqual(model, module);
   });
+
+  module('#redirect', function () {
+    test('should call replaceWith function with the right arguments', async function (assert) {
+      // given
+      const model = {
+        shortId: 'shortId',
+        slug: 'slug',
+      };
+      const router = this.owner.lookup('service:router');
+      const replaceWithStub = sinon.stub(router, 'replaceWith');
+
+      const route = this.owner.lookup('route:module.details');
+
+      // when
+      route.redirect(model);
+
+      // then
+      sinon.assert.calledOnceWithExactly(replaceWithStub, 'module.details', model.shortId, model.slug);
+      assert.ok(true);
+    });
+  });
 });

--- a/mon-pix/tests/unit/routes/module/passage-test.js
+++ b/mon-pix/tests/unit/routes/module/passage-test.js
@@ -78,4 +78,28 @@ module('Unit | Route | modules | passage', function (hooks) {
       passageId: 2019,
     });
   });
+
+  module('#redirect', function () {
+    test('should call replaceWith function with the right arguments', async function (assert) {
+      // given
+      const module = {
+        shortId: 'shortId',
+        slug: 'slug',
+      };
+      const model = {
+        module,
+      };
+      const router = this.owner.lookup('service:router');
+      const replaceWithStub = sinon.stub(router, 'replaceWith');
+
+      const route = this.owner.lookup('route:module.passage');
+
+      // when
+      route.redirect(model);
+
+      // then
+      sinon.assert.calledOnceWithExactly(replaceWithStub, 'module.passage', module.shortId, module.slug);
+      assert.ok(true);
+    });
+  });
 });


### PR DESCRIPTION
## 🌎 Problème

Avec le nouveau format d’url des modules (`/modules/shortId/slug`), nous n’utilisons que le shortId pour vérifier si un module existe ou non pour l’url concerné. Cela fait qu’on peut mettre ce qu’on veut dans le slug pour accéder au même module.

## 🔭 Proposition

Réécrire l'url pour toujours avoir le slug du module affiché.

## 🪐 Remarques

RAS

## 🚀 Pour tester
### Test de non régression
- Aller sur l'url https://app-pr15481.review.pix.fr/modules/bac-a-sable/details et vérifier que cela redirige bien vers https://app-pr15481.review.pix.fr/modules/6a68bf32/bac-a-sable/details
- Faire la même chose pour ttps://app-pr15481.review.pix.fr/modules/bac-a-sable/passage
### Test de réécriture des urls
- Aller sur l'url https://app-pr15481.review.pix.fr/modules/6a68bf32/pas-mon-bac-a-sable/details. Vérifier que l'url affiché est maintenant bien https://app-pr15481.review.pix.fr/modules/6a68bf32/bac-a-sable/details
- Faire la même chose pour https://app-pr15481.review.pix.fr/modules/6a68bf32/bac-a-sable/passage

🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘 🌑
