### PR TITLE
[TECH] :recycle: Remplace les appels à la fonction `trim` de `lodash` pour la fonction native dans pixAdmin

### DIFF
--- a/admin/app/components/certifications/search-form.gjs
+++ b/admin/app/components/certifications/search-form.gjs
@@ -6,7 +6,6 @@ import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
-import trim from 'lodash/trim';
 
 export default class CertificationsSearchForm extends Component {
   @service router;
@@ -21,7 +20,7 @@ export default class CertificationsSearchForm extends Component {
   @action
   loadCertification(event) {
     event.preventDefault();
-    const certifId = trim(this.inputId);
+    const certifId = this.inputId?.trim() ?? '';
     this.router.transitionTo('authenticated.sessions.certification', certifId);
   }
 

--- a/admin/app/controllers/authenticated/sessions/session.js
+++ b/admin/app/controllers/authenticated/sessions/session.js
@@ -2,7 +2,6 @@ import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
-import trim from 'lodash/trim';
 
 export default class SessionController extends Controller {
   @service router;
@@ -17,7 +16,7 @@ export default class SessionController extends Controller {
   @action
   loadSession(event) {
     event.preventDefault();
-    const sessionId = trim(this.inputId);
+    const sessionId = this.inputId?.trim() ?? '';
     const routeName = this.router.currentRouteName;
     this.router.transitionTo(routeName, sessionId);
   }

--- a/admin/app/models/session.js
+++ b/admin/app/models/session.js
@@ -1,6 +1,5 @@
 import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 import isEmpty from 'lodash/isEmpty';
-import trim from 'lodash/trim';
 
 export const CREATED = 'created';
 export const FINALIZED = 'finalized';
@@ -50,7 +49,7 @@ export default class Session extends Model {
   }
 
   get hasExaminerGlobalComment() {
-    return !isEmpty(trim(this.examinerGlobalComment));
+    return !isEmpty(this.examinerGlobalComment?.trim() ?? '');
   }
 
   get hasComplementaryInfo() {

--- a/admin/app/routes/authenticated/sessions/list/all.js
+++ b/admin/app/routes/authenticated/sessions/list/all.js
@@ -1,6 +1,5 @@
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
-import trim from 'lodash/trim';
 
 export default class AuthenticatedSessionsAllRoute extends Route {
   @service store;
@@ -21,9 +20,9 @@ export default class AuthenticatedSessionsAllRoute extends Route {
     try {
       sessions = await this.store.query('session', {
         filter: {
-          id: trim(params.id) || undefined,
-          certificationCenterName: trim(params.certificationCenterName) || undefined,
-          certificationCenterExternalId: trim(params.certificationCenterExternalId) || undefined,
+          id: params.id?.trim() || undefined,
+          certificationCenterName: params.certificationCenterName?.trim() || undefined,
+          certificationCenterExternalId: params.certificationCenterExternalId?.trim() || undefined,
           certificationCenterType: params.certificationCenterType || undefined,
           status: params.status || undefined,
           version: params.version || undefined,


### PR DESCRIPTION
## 🌎 Problème

Nous utilisons beaucoup de function `lodash` alors qu'il existe des functions natives aussi efficace.

## 🔭 Proposition

Remplacer la fonction `trim` de `lodash` par la fonction `trim` native.

## 🪐 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🚀 Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->

🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘 🌑
