### PR TITLE
[TECH] Permettre une modification des rewards en batchUpdate (PIX-21890)

### DIFF
--- a/api/src/prescription/learner-management/domain/usecases/delete-organization-learners.js
+++ b/api/src/prescription/learner-management/domain/usecases/delete-organization-learners.js
@@ -51,9 +51,7 @@ const deleteOrganizationLearners = async function ({
       organizationLearner.delete(userId, { keepPreviousDeletion });
       await organizationLearnerRepository.remove(organizationLearner.dataToUpdateOnDeletion);
 
-      for (const organizationLearnerReward of organizationLearnerRewards) {
-        await organizationsProfileRewardRepository.remove(organizationLearnerReward);
-      }
+      await organizationsProfileRewardRepository.removeInBatch(organizationLearnerRewards);
 
       auditLoggingJobs.push(
         AuditLoggingJob.forUser({

--- a/api/src/profile/domain/models/OrganizationProfileReward.js
+++ b/api/src/profile/domain/models/OrganizationProfileReward.js
@@ -1,5 +1,6 @@
 class OrganizationProfileReward {
-  constructor({ organizationId, profileRewardId, userId }) {
+  constructor({ id, organizationId, profileRewardId, userId }) {
+    this.id = id;
     this.profileRewardId = profileRewardId;
     this.organizationId = organizationId;
     this.userId = userId;

--- a/api/src/profile/infrastructure/repositories/organizations-profile-reward-repository.js
+++ b/api/src/profile/infrastructure/repositories/organizations-profile-reward-repository.js
@@ -23,6 +23,12 @@ export const remove = async ({ organizationId, profileRewardId }) => {
 export const getByOrganizationId = async ({ attestationKey, organizationId }) => {
   const knexConn = DomainTransaction.getConnection();
   const query = knexConn('organizations-profile-rewards')
+    .select(
+      'organizations-profile-rewards.id',
+      'organizations-profile-rewards.organizationId',
+      'organizations-profile-rewards.profileRewardId',
+      'profile-rewards.userId',
+    )
     .join('profile-rewards', 'organizations-profile-rewards.profileRewardId', '=', 'profile-rewards.id')
     .where({ organizationId });
 

--- a/api/src/profile/infrastructure/repositories/organizations-profile-reward-repository.js
+++ b/api/src/profile/infrastructure/repositories/organizations-profile-reward-repository.js
@@ -1,5 +1,6 @@
 import { ORGANIZATIONS_PROFILE_REWARDS_TABLE_NAME } from '../../../../db/migrations/20241118134739_create-organizations-profile-rewards-table.js';
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
+import { batchUpdate } from '../../../shared/infrastructure/utils/knex-utils.js';
 import { OrganizationProfileReward } from '../../domain/models/OrganizationProfileReward.js';
 
 export const save = async ({ organizationId, profileRewardId }) => {
@@ -13,11 +14,20 @@ export const save = async ({ organizationId, profileRewardId }) => {
     .ignore();
 };
 
-export const remove = async ({ organizationId, profileRewardId }) => {
-  const knexConn = DomainTransaction.getConnection();
-  await knexConn(ORGANIZATIONS_PROFILE_REWARDS_TABLE_NAME)
-    .update({ profileRewardId: null })
-    .where({ organizationId, profileRewardId });
+/**
+ * @type {function}
+ * @param {Array<OrganizationProfileReward>} organizationProfileRewards
+ * @returns {Promise<void>}
+ */
+export const removeInBatch = async (organizationProfileRewards) => {
+  await batchUpdate({
+    tableName: ORGANIZATIONS_PROFILE_REWARDS_TABLE_NAME,
+    primaryKeyName: 'id',
+    rows: organizationProfileRewards.map((organizationProfileReward) => ({
+      id: organizationProfileReward.id,
+      profileRewardId: null,
+    })),
+  });
 };
 
 export const getByOrganizationId = async ({ attestationKey, organizationId }) => {

--- a/api/tests/profile/integration/infrastructure/repositories/organizations-profile-reward-repository_test.js
+++ b/api/tests/profile/integration/infrastructure/repositories/organizations-profile-reward-repository_test.js
@@ -97,11 +97,11 @@ describe('Profile | Integration | Infrastructure | Repository | organizations-pr
       const firstProfileReward = databaseBuilder.factory.buildProfileReward({ rewardId });
       const secondProfileReward = databaseBuilder.factory.buildProfileReward({ rewardId });
       const organizationId = databaseBuilder.factory.buildOrganization().id;
-      databaseBuilder.factory.buildOrganizationsProfileRewards({
+      const firstOrganizationProfileReward = databaseBuilder.factory.buildOrganizationsProfileRewards({
         organizationId,
         profileRewardId: firstProfileReward.id,
       });
-      databaseBuilder.factory.buildOrganizationsProfileRewards({
+      const secondOrganizationProfileReward = databaseBuilder.factory.buildOrganizationsProfileRewards({
         organizationId,
         profileRewardId: secondProfileReward.id,
       });
@@ -116,8 +116,18 @@ describe('Profile | Integration | Infrastructure | Repository | organizations-pr
 
       // then
       const expectedResults = [
-        { profileRewardId: firstProfileReward.id, organizationId, userId: firstProfileReward.userId },
-        { profileRewardId: secondProfileReward.id, organizationId, userId: secondProfileReward.userId },
+        {
+          id: firstOrganizationProfileReward.id,
+          profileRewardId: firstProfileReward.id,
+          organizationId,
+          userId: firstProfileReward.userId,
+        },
+        {
+          id: secondOrganizationProfileReward.id,
+          profileRewardId: secondProfileReward.id,
+          organizationId,
+          userId: secondProfileReward.userId,
+        },
       ];
 
       expect(results).to.have.lengthOf(2);
@@ -131,7 +141,7 @@ describe('Profile | Integration | Infrastructure | Repository | organizations-pr
       const secondProfileReward = databaseBuilder.factory.buildProfileReward({ rewardId });
       const organizationId = databaseBuilder.factory.buildOrganization().id;
       const anotherOrganizationId = databaseBuilder.factory.buildOrganization().id;
-      databaseBuilder.factory.buildOrganizationsProfileRewards({
+      const firstOrganizationProfileReward = databaseBuilder.factory.buildOrganizationsProfileRewards({
         organizationId,
         profileRewardId: firstProfileReward.id,
       });
@@ -146,7 +156,12 @@ describe('Profile | Integration | Infrastructure | Repository | organizations-pr
 
       // then
       const expectedResults = [
-        { profileRewardId: firstProfileReward.id, organizationId, userId: firstProfileReward.userId },
+        {
+          id: firstOrganizationProfileReward.id,
+          profileRewardId: firstProfileReward.id,
+          organizationId,
+          userId: firstProfileReward.userId,
+        },
       ];
 
       expect(results).to.have.lengthOf(1);
@@ -189,11 +204,11 @@ describe('Profile | Integration | Infrastructure | Repository | organizations-pr
         const firstProfileReward = databaseBuilder.factory.buildProfileReward({ rewardId });
         const secondProfileReward = databaseBuilder.factory.buildProfileReward({ rewardId });
         const organizationId = databaseBuilder.factory.buildOrganization().id;
-        databaseBuilder.factory.buildOrganizationsProfileRewards({
+        const firstOrganizationProfileReward = databaseBuilder.factory.buildOrganizationsProfileRewards({
           organizationId,
           profileRewardId: firstProfileReward.id,
         });
-        databaseBuilder.factory.buildOrganizationsProfileRewards({
+        const secondOrganizationProfileReward = databaseBuilder.factory.buildOrganizationsProfileRewards({
           organizationId,
           profileRewardId: secondProfileReward.id,
         });
@@ -208,8 +223,18 @@ describe('Profile | Integration | Infrastructure | Repository | organizations-pr
 
         // then
         const expectedResults = [
-          { profileRewardId: firstProfileReward.id, organizationId, userId: firstProfileReward.userId },
-          { profileRewardId: secondProfileReward.id, organizationId, userId: secondProfileReward.userId },
+          {
+            id: firstOrganizationProfileReward.id,
+            profileRewardId: firstProfileReward.id,
+            organizationId,
+            userId: firstProfileReward.userId,
+          },
+          {
+            id: secondOrganizationProfileReward.id,
+            profileRewardId: secondProfileReward.id,
+            organizationId,
+            userId: secondProfileReward.userId,
+          },
         ];
 
         expect(results).to.have.lengthOf(2);

--- a/api/tests/profile/integration/infrastructure/repositories/organizations-profile-reward-repository_test.js
+++ b/api/tests/profile/integration/infrastructure/repositories/organizations-profile-reward-repository_test.js
@@ -2,7 +2,7 @@ import { ORGANIZATIONS_PROFILE_REWARDS_TABLE_NAME } from '../../../../../db/migr
 import { OrganizationProfileReward } from '../../../../../src/profile/domain/models/OrganizationProfileReward.js';
 import {
   getByOrganizationId,
-  remove,
+  removeInBatch,
   save,
 } from '../../../../../src/profile/infrastructure/repositories/organizations-profile-reward-repository.js';
 import { databaseBuilder, expect, knex } from '../../../../test-helper.js';
@@ -243,30 +243,37 @@ describe('Profile | Integration | Infrastructure | Repository | organizations-pr
     });
   });
 
-  describe('#remove', function () {
-    it('should remove profile reward', async function () {
+  describe('#removeInBatch', function () {
+    it('should removeInBatch profile rewards', async function () {
       // given
       const { id: rewardId } = databaseBuilder.factory.buildAttestation();
       const profileReward = databaseBuilder.factory.buildProfileReward({ rewardId });
       const otherProfileReward = databaseBuilder.factory.buildProfileReward({ rewardId });
+      const thirdProfileReward = databaseBuilder.factory.buildProfileReward({ rewardId });
       const organizationId = databaseBuilder.factory.buildOrganization().id;
-      const organizationProfileReward = databaseBuilder.factory.buildOrganizationsProfileRewards({
+      const organizationProfileReward1 = databaseBuilder.factory.buildOrganizationsProfileRewards({
         organizationId,
         profileRewardId: profileReward.id,
       });
-      databaseBuilder.factory.buildOrganizationsProfileRewards({
+      const organizationProfileReward2 = databaseBuilder.factory.buildOrganizationsProfileRewards({
         organizationId,
         profileRewardId: otherProfileReward.id,
       });
+      databaseBuilder.factory.buildOrganizationsProfileRewards({
+        organizationId,
+        profileRewardId: thirdProfileReward.id,
+      });
+
       await databaseBuilder.commit();
 
       // when
-      await remove({ organizationId, profileRewardId: profileReward.id });
+      await removeInBatch([organizationProfileReward1, organizationProfileReward2]);
 
       // then
       const results = await knex('organizations-profile-rewards').whereNull('profileRewardId');
-      expect(results).to.have.lengthOf(1);
-      expect(results[0]).to.deep.equal({ id: organizationProfileReward.id, organizationId, profileRewardId: null });
+      expect(results).to.have.lengthOf(2);
+      expect(results[0]).to.deep.equal({ id: organizationProfileReward1.id, organizationId, profileRewardId: null });
+      expect(results[1]).to.deep.equal({ id: organizationProfileReward2.id, organizationId, profileRewardId: null });
     });
   });
 });


### PR DESCRIPTION
## 🌎 Problème

Actuellement nous bouclions sur toutes chaque orga learner reward pour faire cette suppression. ce qui est assez gourmand en terme de requete sql

## 🔭 Proposition

Utiliser le batchUpdate de knexUtils permettant de reduire la nombre d'appel pour retirer les rewards

## 🪐 Remarques


## 🚀 Pour tester
Archiver une orgnisation sur PixAdmin qui n'a ni parcours combiné, ni places. et vérifier que tout et OK ( certainement la AUTONOMOUS_COURSE pour eviter ces cas là)

🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘 🌑
