### PR TITLE
[FEATURE] Ajout d'un lien vers le parcours sur l'écran des parcours combinés dans PixOrga (PIX-21252)

### DIFF
--- a/orga/app/components/combined-course/header.gjs
+++ b/orga/app/components/combined-course/header.gjs
@@ -51,7 +51,39 @@ export default class CombinedCourseHeader extends Component {
       </:title>
       <:subtitle>
         <div class="combined-course-page__header">
-          <p class="combined-course-page__header-body">{{t "pages.combined-course.introduction"}}</p>
+          <div>
+            <p class="combined-course-page__header-body">{{t "pages.combined-course.introduction"}}</p>
+            <dl class="campaign-header-title__details">
+              <div class="campaign-header-title__detail-item">
+                <dt class="label-text">
+                  {{t "pages.campaign.code"}}
+                </dt>
+                <dd class="campaign-header-title__campaign-code">
+                  <span>{{@code}}</span>
+                  <CopyPasteButton
+                    @clipBoardtext={{@code}}
+                    @successMessage={{t "pages.campaign.copy.code.success"}}
+                    @defaultMessage={{t "pages.campaign.copy.code.default"}}
+                    class="hide-on-mobile"
+                  />
+                </dd>
+              </div>
+              <div class="campaign-header-title__detail-item">
+                <dt class="label-text">
+                  {{t "pages.campaign.link"}}
+                </dt>
+                <dd class="campaign-header-title__campaign-link">
+                  <a href={{this.combinedCourseUrl}}>{{this.combinedCourseUrl}}</a>
+                  <CopyPasteButton
+                    @clipBoardtext={{this.combinedCourseUrl}}
+                    @successMessage={{t "pages.campaign.copy.link.success"}}
+                    @defaultMessage={{t "pages.campaign.copy.link.default"}}
+                    class="hide-on-mobile"
+                  />
+                </dd>
+              </div>
+            </dl>
+          </div>
           {{#if @campaignIds.length}}
             <div class="combined-course-page__campaigns">
               {{#each @campaignIds as |campaignId index|}}

--- a/orga/app/components/combined-course/header.gjs
+++ b/orga/app/components/combined-course/header.gjs
@@ -14,6 +14,7 @@ import { EVENT_NAME } from 'pix-orga/helpers/metrics-event-name';
 export default class CombinedCourseHeader extends Component {
   @service intl;
   @service pixMetrics;
+  @service url;
 
   get breadcrumbLinks() {
     return [
@@ -29,6 +30,10 @@ export default class CombinedCourseHeader extends Component {
         label: this.args.name,
       },
     ];
+  }
+
+  get combinedCourseUrl() {
+    return `${this.url.combinedCoursesRootUrl}${this.args.code}`;
   }
 
   getCampaignIndex(index) {
@@ -100,25 +105,6 @@ export default class CombinedCourseHeader extends Component {
           {{/if}}
         </div>
       </:subtitle>
-      <:tools>
-        <dl class="campaign-header-title__details">
-
-          <div class="campaign-header-title__detail-item">
-            <dt class="label-text">
-              {{t "pages.campaign.code"}}
-            </dt>
-            <dd class="campaign-header-title__campaign-code">
-              <span>{{@code}}</span>
-              <CopyPasteButton
-                @clipBoardtext={{@code}}
-                @successMessage={{t "pages.campaign.copy.code.success"}}
-                @defaultMessage={{t "pages.campaign.copy.code.default"}}
-                class="hide-on-mobile"
-              />
-            </dd>
-          </div>
-        </dl>
-      </:tools>
     </PageTitle>
     <div class="combined-course-page__statistics">
       <PixIndicatorCard

--- a/orga/app/services/url.js
+++ b/orga/app/services/url.js
@@ -32,6 +32,11 @@ export default class Url extends UrlBaseService {
     return `${this.pixAppUrl}/campagnes/`;
   }
 
+  get combinedCoursesRootUrl() {
+    if (ENV.APP.COMBINED_COURSES_ROOT_URL) return ENV.APP.COMBINED_COURSES_ROOT_URL;
+    return `${this.pixAppUrl}/parcours/`;
+  }
+
   get pixJuniorSchoolUrl() {
     const schoolCode = this.currentUser.organization.schoolCode;
     if (!schoolCode) return '';

--- a/orga/app/styles/components/campaign/header/title.scss
+++ b/orga/app/styles/components/campaign/header/title.scss
@@ -11,7 +11,7 @@
     & > * {
       margin-right: 15px;
       padding-right: 15px;
-      border-right: 1px solid var(--pix-neutral-20);
+      border-right: 1px solid var(--pix-neutral-100);
     }
 
     & > *:last-child {
@@ -37,7 +37,8 @@
     }
   }
 
-  &__campaign-code {
+  &__campaign-code, &__campaign-link {
     display: inline-flex;
   }
+
 }

--- a/orga/app/styles/pages/authenticated/combined-course.scss
+++ b/orga/app/styles/pages/authenticated/combined-course.scss
@@ -16,6 +16,8 @@
 
   &__header-body {
     @extend %pix-body-s;
+
+    margin-bottom: var(--pix-spacing-4x);
   }
 
   &__campaigns {

--- a/orga/config/environment.js
+++ b/orga/config/environment.js
@@ -55,6 +55,8 @@ module.exports = function (environment) {
           minValue: 10,
         }),
       CAMPAIGNS_ROOT_URL: process.env.CAMPAIGNS_ROOT_URL,
+      COMBINED_COURSES_ROOT_URL: process.env.COMBINED_COURSES_ROOT_URL,
+
       MAX_CONCURRENT_AJAX_CALLS: _getEnvironmentVariableAsNumber({
         environmentVariableName: 'MAX_CONCURRENT_AJAX_CALLS',
         defaultValue: 8,
@@ -122,6 +124,7 @@ module.exports = function (environment) {
 
   if (environment === 'development') {
     ENV.APP.CAMPAIGNS_ROOT_URL = 'http://localhost:4200/campagnes/';
+    ENV.APP.COMBINED_COURSES_ROOT_URL = 'http://localhost:4200/parcours/';
     ENV.APP.CERTIFICATION_BANNER_DISPLAY_DATES = '04 05 06 07';
     ENV.APP.SURVEY_LINK = 'http://localhost:4200/campagnes/';
     ENV.APP.SURVEY_BANNER_ENABLED = true;
@@ -142,6 +145,7 @@ module.exports = function (environment) {
 
     ENV.APP.CERTIFICATION_BANNER_DISPLAY_DATES = '04 05 06 07';
     ENV.APP.CAMPAIGNS_ROOT_URL = 'http://localhost:4200/campagnes/';
+    ENV.APP.COMBINED_COURSES_ROOT_URL = 'http://localhost:4200/parcours/';
 
     // keep test console output quieter
     ENV.APP.LOG_ACTIVE_GENERATION = false;

--- a/orga/sample.env
+++ b/orga/sample.env
@@ -92,3 +92,14 @@
 # type: String
 # default: <empty>
 # CAMPAIGNS_ROOT_URL=http://localhost:4200/campagnes/
+
+
+# =========
+# Combined courses
+# =========
+
+# presence: optional
+# type: String
+# default: <empty>
+# COMBINED_COURSES_ROOT_URL=http://localhost:4200/parcours/
+

--- a/orga/tests/integration/components/banner/survey_test.gjs
+++ b/orga/tests/integration/components/banner/survey_test.gjs
@@ -75,7 +75,7 @@ module('Integration | Component | Banner::Survey', function (hooks) {
         assert.notOk(screen.queryByRole('link', { name: 'Accédez à l’enquête' }));
       });
 
-      test('when the environnement variable is not set', async function (assert) {
+      test('when the environment variable is not set', async function (assert) {
         // given
         ENV.APP.SURVEY_BANNER_ENABLED = false;
         ENV.APP.SURVEY_LINK = 'https://www.google.com';

--- a/orga/tests/unit/services/url-test.js
+++ b/orga/tests/unit/services/url-test.js
@@ -123,7 +123,7 @@ module('Unit | Service | url', function (hooks) {
       assert.strictEqual(campaignsRootUrl, 'https://app.test.pix.fr/campagnes/');
     });
 
-    test('returns campaigns root url for current pix-app environnement', function (assert) {
+    test('returns campaigns root url for current pix-app environment', function (assert) {
       // given
       const service = this.owner.lookup('service:url');
       sinon
@@ -153,7 +153,7 @@ module('Unit | Service | url', function (hooks) {
       // then
       assert.strictEqual(combinedCoursesRootUrl, 'https://app.test.pix.fr/parcours/');
     });
-    test('returns combined courses root url for current pix-app environnement', function (assert) {
+    test('returns combined courses root url for current pix-app environment', function (assert) {
       // given
       const service = this.owner.lookup('service:url');
       sinon.stub(ENV, 'APP').value({ PIX_APP_URL_WITHOUT_EXTENSION: 'https://app.test.pix.' });

--- a/orga/tests/unit/services/url-test.js
+++ b/orga/tests/unit/services/url-test.js
@@ -123,7 +123,7 @@ module('Unit | Service | url', function (hooks) {
       assert.strictEqual(campaignsRootUrl, 'https://app.test.pix.fr/campagnes/');
     });
 
-    test('returns campaigns root url for current pix-app environement', function (assert) {
+    test('returns campaigns root url for current pix-app environnement', function (assert) {
       // given
       const service = this.owner.lookup('service:url');
       sinon
@@ -138,6 +138,34 @@ module('Unit | Service | url', function (hooks) {
 
       // then
       assert.strictEqual(campaignsRootUrl, 'https://app.test.pix.org/campagnes/');
+    });
+  });
+
+  module('#combinedCoursesRootUrl', function () {
+    test('returns default combined courses root url when is defined', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url');
+      sinon.stub(ENV, 'APP').value({ COMBINED_COURSES_ROOT_URL: 'https://app.test.pix.fr/parcours/' });
+
+      // when
+      const combinedCoursesRootUrl = service.combinedCoursesRootUrl;
+
+      // then
+      assert.strictEqual(combinedCoursesRootUrl, 'https://app.test.pix.fr/parcours/');
+    });
+    test('returns combined courses root url for current pix-app environnement', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url');
+      sinon.stub(ENV, 'APP').value({ PIX_APP_URL_WITHOUT_EXTENSION: 'https://app.test.pix.' });
+
+      const domainService = this.owner.lookup('service:currentDomain');
+      sinon.stub(domainService, 'getExtension').returns('org');
+
+      // when
+      const combinedCoursesRootUrl = service.combinedCoursesRootUrl;
+
+      // then
+      assert.strictEqual(combinedCoursesRootUrl, 'https://app.test.pix.org/parcours/');
     });
   });
 

--- a/orga/translations/de.json
+++ b/orga/translations/de.json
@@ -674,6 +674,7 @@
       "empty-state-with-copy-link": "Bisher gibt es noch keine Teilnehmer! Schicken Sie ihnen den folgenden Link, um sich Ihrer Kampagne anzuschließen.",
       "included-in-combined-course": "Diese Bewertungskampagne ist im Lernpfad enthalten",
       "included-in-combined-course-end": ".",
+      "link": "Link",
       "multiple-sendings": {
         "status": {
           "disabled": "Nicht",

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -669,6 +669,7 @@
       "empty-state-with-copy-link": "No participants yet! Share with them the following link to join this campaign.",
       "included-in-combined-course": "This assessment campaign is included in the",
       "included-in-combined-course-end": "learning program.",
+      "link": "Link",
       "multiple-sendings": {
         "status": {
           "disabled": "No",

--- a/orga/translations/es.json
+++ b/orga/translations/es.json
@@ -675,6 +675,7 @@
       "empty-state-with-copy-link": "¡Aún no hay participantes! Envíales el siguiente enlace para que se unan a tu campaña.",
       "included-in-combined-course": "Esta campaña de evaluación está incluida en el itinerario del alumno",
       "included-in-combined-course-end": ".",
+      "link": "Enlace",
       "multiple-sendings": {
         "status": {
           "disabled": "No",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -669,6 +669,7 @@
       "empty-state-with-copy-link": "Aucun participant pour l’instant ! Envoyez-leur le lien suivant pour rejoindre votre campagne.",
       "included-in-combined-course": "Cette campagne d'évaluation est incluse dans le parcours apprenant",
       "included-in-combined-course-end": ".",
+      "link": "Lien",
       "multiple-sendings": {
         "status": {
           "disabled": "Non",

--- a/orga/translations/it.json
+++ b/orga/translations/it.json
@@ -675,6 +675,7 @@
       "empty-state-with-copy-link": "Non ci sono ancora partecipanti! Inviate loro il seguente link per aderire alla campagna.",
       "included-in-combined-course": "Questa campagna di valutazione è inclusa nel percorso di apprendimento.",
       "included-in-combined-course-end": ".",
+      "link": "Link",
       "multiple-sendings": {
         "status": {
           "disabled": "No",

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -668,6 +668,7 @@
       "empty-state-with-copy-link": "Geen deelnemers op het moment! Stuur ze de volgende link om mee te doen aan je campagne.",
       "included-in-combined-course": "Deze evaluatiecampagne maakt deel uit van het",
       "included-in-combined-course-end": "-leerprogramma.",
+      "link": "Link",
       "multiple-sendings": {
         "status": {
           "disabled": "Nee",


### PR DESCRIPTION
## 🌎 Problème

Suite à une demande de la Sécurité sociale, on veut pouvoir afficher le lien vers un parcours combiné directement dans PixOrga pour faciliter la vie des prescripteurs.

## 🪐 Remarques


## 🚀 Pour tester
Aller dans Campagnes -> Parcours apprenants 
Cliquer sur l'un des parcours
Vérifier que le lien vers le parcours apparaît à côté du code.
Cliquer sur le lien et vérifier qu'on arrive sur PixApp avec la bonne locale.



🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘 🌑
