### PR TITLE
[TECH] Eviter des appels N+1 lors de l'archivage d'une organisation (PIX-21889).

### DIFF
--- a/api/src/prescription/campaign-participation/domain/models/CampaignParticipation.js
+++ b/api/src/prescription/campaign-participation/domain/models/CampaignParticipation.js
@@ -78,12 +78,10 @@ class CampaignParticipation {
   get dataToUpdateOnDeletion() {
     return {
       id: this.id,
-      attributes: {
-        deletedAt: this.deletedAt,
-        deletedBy: this.deletedBy,
-        userId: this.userId,
-        participantExternalId: this.participantExternalId,
-      },
+      deletedAt: this.deletedAt,
+      deletedBy: this.deletedBy,
+      userId: this.userId,
+      participantExternalId: this.participantExternalId,
     };
   }
 

--- a/api/src/prescription/campaign-participation/domain/models/CampaignParticipation.js
+++ b/api/src/prescription/campaign-participation/domain/models/CampaignParticipation.js
@@ -85,6 +85,13 @@ class CampaignParticipation {
     };
   }
 
+  get dataToUpdateOnAnonymisation() {
+    return {
+      id: this.id,
+      userId: this.userId,
+    };
+  }
+
   share() {
     this._canBeShared();
     this.sharedAt = new Date();

--- a/api/src/prescription/campaign-participation/domain/usecases/delete-campaign-participation.js
+++ b/api/src/prescription/campaign-participation/domain/usecases/delete-campaign-participation.js
@@ -22,11 +22,12 @@ const deleteCampaignParticipation = async function ({
     });
 
   const auditLoggingJobs = [];
+  const campaignParticipationToDelete = [];
 
   await DomainTransaction.execute(async () => {
     for (const campaignParticipation of campaignParticipations) {
       campaignParticipation.delete(userId);
-      await campaignParticipationRepository.remove(campaignParticipation.dataToUpdateOnDeletion);
+      campaignParticipationToDelete.push(campaignParticipation.dataToUpdateOnDeletion);
 
       auditLoggingJobs.push(
         AuditLoggingJob.forUser({
@@ -39,6 +40,9 @@ const deleteCampaignParticipation = async function ({
         }),
       );
     }
+
+    await campaignParticipationRepository.updateInBatchByIds(campaignParticipationToDelete);
+
     const campaignParticipationIds = campaignParticipations.map(({ id }) => id);
     await badgeAcquisitionRepository.deleteUserIdOnNonCertifiableBadgesForCampaignParticipations(
       campaignParticipationIds,

--- a/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-repository.js
@@ -1,12 +1,10 @@
-import lodash from 'lodash';
-
 import { OrganizationLearnerParticipationTypes } from '../../../../quest/domain/models/OrganizationLearnerParticipation.js';
 import { constants } from '../../../../shared/domain/constants.js';
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { Assessment } from '../../../../shared/domain/models/Assessment.js';
 import * as knowledgeElementRepository from '../../../../shared/infrastructure/repositories/knowledge-element-repository.js';
-import { fetchPage } from '../../../../shared/infrastructure/utils/knex-utils.js';
+import { batchUpdate, fetchPage } from '../../../../shared/infrastructure/utils/knex-utils.js';
 import { Campaign } from '../../../campaign/domain/models/Campaign.js';
 import { CampaignParticipationInfo } from '../../../campaign/domain/read-models/CampaignParticipationInfo.js';
 import * as campaignRepository from '../../../campaign/infrastructure/repositories/campaign-repository.js';
@@ -18,20 +16,13 @@ import { AvailableCampaignParticipation } from '../../domain/read-models/Availab
 
 const { STARTED, SHARED } = CampaignParticipationStatuses;
 
-const { pick } = lodash;
-
-const CAMPAIGN_PARTICIPATION_ATTRIBUTES = [
-  'participantExternalId',
-  'sharedAt',
-  'status',
-  'userId',
-  'organizationLearnerId',
-  'deletedAt',
-  'deletedBy',
-];
-
 const updateWithSnapshot = async function (campaignParticipation) {
-  await update(campaignParticipation);
+  const knexConn = DomainTransaction.getConnection();
+
+  await knexConn('campaign-participations')
+    .where({ id: campaignParticipation.id })
+    .update({ sharedAt: campaignParticipation.sharedAt, status: campaignParticipation.status });
+
   const campaign = await campaignRepository.getByCampaignParticipationId(campaignParticipation.id);
   if (campaign.isExam) {
     return;
@@ -44,14 +35,6 @@ const updateWithSnapshot = async function (campaignParticipation) {
     snapshot: new KnowledgeElementCollection(knowledgeElements).toSnapshot(),
     campaignParticipationId: campaignParticipation.id,
   });
-};
-
-const update = async function (campaignParticipation) {
-  const knexConn = DomainTransaction.getConnection();
-
-  await knexConn('campaign-participations')
-    .where({ id: campaignParticipation.id })
-    .update(pick(campaignParticipation, CAMPAIGN_PARTICIPATION_ATTRIBUTES));
 };
 
 const getLocked = async function (id) {
@@ -157,9 +140,12 @@ const getAllCampaignParticipationsForOrganizationLearner = async function ({
   return campaignParticipations.map((campaignParticipation) => new CampaignParticipation(campaignParticipation));
 };
 
-const remove = async function ({ id, attributes }) {
-  const knexConn = DomainTransaction.getConnection();
-  return await knexConn('campaign-participations').where({ id }).update(attributes);
+const updateInBatchByIds = async function (campaignParticipations) {
+  return await batchUpdate({
+    tableName: 'campaign-participations',
+    primaryKeyName: 'id',
+    rows: campaignParticipations,
+  });
 };
 
 const findInfoByCampaignId = async function ({ campaignId, page, since }) {
@@ -346,7 +332,6 @@ export {
   getSharedParticipationIds,
   hasAssessmentParticipations,
   isRetrying,
-  remove,
-  update,
+  updateInBatchByIds,
   updateWithSnapshot,
 };

--- a/api/src/prescription/campaign/application/api/campaigns-api.js
+++ b/api/src/prescription/campaign/application/api/campaigns-api.js
@@ -241,7 +241,12 @@ export const getCampaignParticipations = async function ({ campaignId, page, sin
  */
 export const deleteActiveCampaigns = withTransaction(async ({ userId, organizationId }) => {
   const campaignIdsToDelete = await usecases.findActiveCampaignIdsByOrganization({ organizationId });
-  await usecases.deleteCampaigns({ userId, organizationId, campaignIds: campaignIdsToDelete });
+  await usecases.deleteCampaigns({
+    userId,
+    organizationId,
+    campaignIds: campaignIdsToDelete,
+    isPartOfDeletingCombinedCourse: true,
+  });
 });
 
 export const deleteCampaignsInCombinedCourses = async ({

--- a/api/src/prescription/campaign/domain/usecases/delete-campaigns.js
+++ b/api/src/prescription/campaign/domain/usecases/delete-campaigns.js
@@ -56,11 +56,10 @@ const deleteCampaigns = async ({
   campaignDestructor.delete({ keepPreviousDeletion });
 
   const auditLoggingJobs = [];
+  const campaignParticipationsToUpdate = [];
 
   await DomainTransaction.execute(async () => {
     for (const campaignParticipation of campaignDestructor.campaignParticipations) {
-      await campaignParticipationRepository.update(campaignParticipation);
-
       auditLoggingJobs.push(
         AuditLoggingJob.forUser({
           client: client ?? CLIENTS.ORGA,
@@ -71,7 +70,11 @@ const deleteCampaigns = async ({
           data: {},
         }),
       );
+
+      campaignParticipationsToUpdate.push(campaignParticipation.dataToUpdateOnDeletion);
     }
+
+    await campaignParticipationRepository.updateInBatchByIds(campaignParticipationsToUpdate);
 
     const campaignParticipationIds = campaignParticipationsToDelete.map(({ id }) => id);
 

--- a/api/src/prescription/campaign/domain/usecases/delete-campaigns.js
+++ b/api/src/prescription/campaign/domain/usecases/delete-campaigns.js
@@ -33,10 +33,12 @@ const deleteCampaigns = async ({
     }
   }
 
-  for (const campaignId of campaignIds) {
-    const combinedCourses = await CombinedCourseRepository.findByCampaignId({ campaignId });
-    if (combinedCourses.length > 0 && !isPartOfDeletingCombinedCourse) {
-      throw new CampaignBelongsToCombinedCourseError();
+  if (!isPartOfDeletingCombinedCourse) {
+    for (const campaignId of campaignIds) {
+      const combinedCourses = await CombinedCourseRepository.findByCampaignId({ campaignId });
+      if (combinedCourses.length > 0) {
+        throw new CampaignBelongsToCombinedCourseError();
+      }
     }
   }
 

--- a/api/src/prescription/learner-management/domain/usecases/anonymize-user.js
+++ b/api/src/prescription/learner-management/domain/usecases/anonymize-user.js
@@ -3,6 +3,8 @@ import { withTransaction } from '../../../../shared/domain/DomainTransaction.js'
 export const anonymizeUser = withTransaction(
   async ({ userId, campaignParticipationRepositoryFromBC, organizationLearnerRepository }) => {
     const learners = await organizationLearnerRepository.findByUserId({ userId });
+    const campaignParticipationToAnonymize = [];
+
     for (const learner of learners) {
       learner.detachUser();
       await organizationLearnerRepository.update(learner);
@@ -10,10 +12,13 @@ export const anonymizeUser = withTransaction(
         await campaignParticipationRepositoryFromBC.getAllCampaignParticipationsForOrganizationLearner({
           organizationLearnerId: learner.id,
         });
+
       for (const campaignParticipation of campaignParticipations) {
         campaignParticipation.detachUser();
-        await campaignParticipationRepositoryFromBC.update(campaignParticipation);
+        campaignParticipationToAnonymize.push(campaignParticipation.dataToUpdateOnAnonymisation);
       }
+
+      await campaignParticipationRepositoryFromBC.updateInBatchByIds(campaignParticipationToAnonymize);
     }
   },
 );

--- a/api/src/prescription/learner-management/domain/usecases/delete-organization-learners.js
+++ b/api/src/prescription/learner-management/domain/usecases/delete-organization-learners.js
@@ -41,6 +41,7 @@ const deleteOrganizationLearners = async function ({
   const organizationProfileRewards = await organizationsProfileRewardRepository.getByOrganizationId({ organizationId });
 
   const auditLoggingJobs = [];
+  const campaignParticipationsToDelete = [];
 
   await DomainTransaction.execute(async () => {
     const assessmentsToUpdate = [];
@@ -72,7 +73,7 @@ const deleteOrganizationLearners = async function ({
 
       for (const campaignParticipation of campaignParticipations) {
         campaignParticipation.delete(userId);
-        await campaignParticipationRepositoryFromBC.remove(campaignParticipation.dataToUpdateOnDeletion);
+        campaignParticipationsToDelete.push(campaignParticipation.dataToUpdateOnDeletion);
 
         auditLoggingJobs.push(
           AuditLoggingJob.forUser({
@@ -99,6 +100,7 @@ const deleteOrganizationLearners = async function ({
       await userRecommendedTrainingRepository.deleteCampaignParticipationIds({ campaignParticipationIds });
     }
     await assessmentRepository.batchRemoveParticipationId(assessmentsToUpdate);
+    await campaignParticipationRepositoryFromBC.updateInBatchByIds(campaignParticipationsToDelete);
   });
 
   for (const auditLoggingJob of auditLoggingJobs) {

--- a/api/src/prescription/learner-management/domain/usecases/delete-organization-learners.js
+++ b/api/src/prescription/learner-management/domain/usecases/delete-organization-learners.js
@@ -42,6 +42,7 @@ const deleteOrganizationLearners = async function ({
 
   const auditLoggingJobs = [];
   const campaignParticipationsToDelete = [];
+  const allCampaignParticipationIds = [];
 
   await DomainTransaction.execute(async () => {
     const assessmentsToUpdate = [];
@@ -88,18 +89,22 @@ const deleteOrganizationLearners = async function ({
       }
 
       const campaignParticipationIds = campaignParticipations.map(({ id }) => id);
-      await badgeAcquisitionRepository.deleteUserIdOnNonCertifiableBadgesForCampaignParticipations(
-        campaignParticipationIds,
-      );
+      allCampaignParticipationIds.push(...campaignParticipationIds);
+
       const assessments = await assessmentRepository.getByCampaignParticipationIds(campaignParticipationIds);
 
       assessments.forEach((assessment) => assessment.detachCampaignParticipation());
 
       assessmentsToUpdate.push(...assessments);
-
-      await userRecommendedTrainingRepository.deleteCampaignParticipationIds({ campaignParticipationIds });
     }
+
     await assessmentRepository.batchRemoveParticipationId(assessmentsToUpdate);
+    await badgeAcquisitionRepository.deleteUserIdOnNonCertifiableBadgesForCampaignParticipations(
+      allCampaignParticipationIds,
+    );
+    await userRecommendedTrainingRepository.deleteCampaignParticipationIds({
+      campaignParticipationIds: allCampaignParticipationIds,
+    });
     await campaignParticipationRepositoryFromBC.updateInBatchByIds(campaignParticipationsToDelete);
   });
 

--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -52,7 +52,7 @@ describe('Integration | Repository | Campaign Participation', function () {
         clock.restore();
       });
 
-      it('persists the campaign-participation changes', async function () {
+      it('persists the campaign-participation changes shared status and date only', async function () {
         // given
         campaignParticipation.campaign = {};
         campaignParticipation.assessments = [];
@@ -73,7 +73,8 @@ describe('Integration | Repository | Campaign Participation', function () {
           .first();
         // then
         expect(updatedCampaignParticipation.status).to.equals(SHARED);
-        expect(updatedCampaignParticipation.participantExternalId).to.equals('Laura');
+        expect(updatedCampaignParticipation.sharedAt).to.deep.equals(campaignParticipation.sharedAt);
+        expect(updatedCampaignParticipation.participantExternalId).to.equals('participantExternalId');
       });
 
       it('should save a snapshot', async function () {
@@ -174,7 +175,6 @@ describe('Integration | Repository | Campaign Participation', function () {
         campaignParticipation.isShared = true;
         campaignParticipation.sharedAt = new Date('2020-01-02');
         campaignParticipation.status = SHARED;
-        campaignParticipation.participantExternalId = 'Laura';
 
         // when
         await campaignParticipationRepository.updateWithSnapshot(campaignParticipation);
@@ -183,8 +183,10 @@ describe('Integration | Repository | Campaign Participation', function () {
         const updatedCampaignParticipation = await knex('campaign-participations')
           .where({ id: campaignParticipation.id })
           .first();
+
         expect(updatedCampaignParticipation.status).to.equals(SHARED);
-        expect(updatedCampaignParticipation.participantExternalId).to.equals('Laura');
+        expect(updatedCampaignParticipation.sharedAt).to.deep.equals(campaignParticipation.sharedAt);
+        expect(updatedCampaignParticipation.participantExternalId).to.equals('participantExternalId');
       });
 
       it('should left existing snapshot untouched', async function () {
@@ -505,55 +507,7 @@ describe('Integration | Repository | Campaign Participation', function () {
     });
   });
 
-  describe('#update', function () {
-    it('save the changes of the campaignParticipation', async function () {
-      const campaignParticipationToUpdate = databaseBuilder.factory.buildCampaignParticipation({
-        status: STARTED,
-        sharedAt: null,
-      });
-
-      await databaseBuilder.commit();
-
-      await DomainTransaction.execute(async () => {
-        await campaignParticipationRepository.update({
-          ...campaignParticipationToUpdate,
-          sharedAt: new Date('2021-01-01'),
-          status: SHARED,
-        });
-      });
-
-      const campaignParticipation = await knex('campaign-participations')
-        .where({ id: campaignParticipationToUpdate.id })
-        .first();
-
-      expect(campaignParticipation.sharedAt).to.deep.equals(new Date('2021-01-01'));
-      expect(campaignParticipation.status).to.equals(SHARED);
-    });
-
-    it('should not update campaignId', async function () {
-      const campaignId = databaseBuilder.factory.buildCampaign().id;
-      const campaignParticipationToUpdate = databaseBuilder.factory.buildCampaignParticipation({
-        campaignId,
-        status: STARTED,
-        sharedAt: null,
-      });
-
-      await databaseBuilder.commit();
-      const participation = new CampaignParticipation(campaignParticipationToUpdate);
-
-      await DomainTransaction.execute(async () => {
-        await campaignParticipationRepository.update(participation);
-      });
-
-      const campaignParticipation = await knex('campaign-participations')
-        .where({ id: campaignParticipationToUpdate.id })
-        .first();
-
-      expect(campaignParticipation.campaignId).to.equal(campaignId);
-    });
-  });
-
-  describe('#remove', function () {
+  describe('#updateInBatchByIds', function () {
     it('should mark as deleted given participation', async function () {
       const ownerId = databaseBuilder.factory.buildUser().id;
       const participantUserId = databaseBuilder.factory.buildUser().id;
@@ -579,13 +533,13 @@ describe('Integration | Repository | Campaign Participation', function () {
 
       const deletedAt = new Date('2022-11-01T23:00:00Z');
 
-      await campaignParticipationRepository.remove({
-        id: campaignParticipationToDelete.id,
-        attributes: {
+      await campaignParticipationRepository.updateInBatchByIds([
+        {
+          id: campaignParticipationToDelete.id,
           deletedAt,
           deletedBy: ownerId,
         },
-      });
+      ]);
 
       const deletedCampaignParticipation = await knex('campaign-participations').whereNotNull('deletedAt').first();
 
@@ -612,15 +566,15 @@ describe('Integration | Repository | Campaign Participation', function () {
 
       const deletedAt = new Date('2022-11-01T23:00:00Z');
 
-      await campaignParticipationRepository.remove({
-        id: campaignParticipation.id,
-        attributes: {
+      await campaignParticipationRepository.updateInBatchByIds([
+        {
+          id: campaignParticipation.id,
           participantExternalId: null,
           userId: null,
           deletedAt,
           deletedBy: ownerId,
         },
-      });
+      ]);
 
       const deletedCampaignParticipation = await knex('campaign-participations').first();
 

--- a/api/tests/prescription/campaign-participation/unit/domain/models/CampaignParticipation_test.js
+++ b/api/tests/prescription/campaign-participation/unit/domain/models/CampaignParticipation_test.js
@@ -77,6 +77,22 @@ describe('Unit | Domain | Models | CampaignParticipation', function () {
     });
   });
 
+  describe('dataToUpdateOnAnonymisation', function () {
+    it('should return payload to send on repository with specific field', function () {
+      const campaignParticipation = new CampaignParticipation({
+        userId: 666,
+        participantExternalId: 'thisismyemailbuddy@buddy.org',
+        deletedAt: new Date('2024-04-03'),
+        deletedBy: 777,
+      });
+
+      expect(campaignParticipation.dataToUpdateOnAnonymisation).to.deep.equal({
+        id: campaignParticipation.id,
+        userId: campaignParticipation.userId,
+      });
+    });
+  });
+
   describe('lastAssessment', function () {
     it('should retrieve the last assessment by creation date', function () {
       const campaignParticipation = new CampaignParticipation({

--- a/api/tests/prescription/campaign-participation/unit/domain/models/CampaignParticipation_test.js
+++ b/api/tests/prescription/campaign-participation/unit/domain/models/CampaignParticipation_test.js
@@ -69,12 +69,10 @@ describe('Unit | Domain | Models | CampaignParticipation', function () {
 
       expect(campaignParticipation.dataToUpdateOnDeletion).to.deep.equal({
         id: campaignParticipation.id,
-        attributes: {
-          userId: campaignParticipation.userId,
-          participantExternalId: campaignParticipation.participantExternalId,
-          deletedAt: campaignParticipation.deletedAt,
-          deletedBy: campaignParticipation.deletedBy,
-        },
+        userId: campaignParticipation.userId,
+        participantExternalId: campaignParticipation.participantExternalId,
+        deletedAt: campaignParticipation.deletedAt,
+        deletedBy: campaignParticipation.deletedBy,
       });
     });
   });


### PR DESCRIPTION
## 🌎 Problème

Trop de requête en BDD lors de l'archivage d'une organisation lors de la suppresion des participants et des campagnes. 

## 🔭 Proposition

Utiliser le batchUpdate pour ne faire qu'un seul appel de suppression/anonymization

## 🪐 Remarques

les methode des badges et des recommanded trainings peuvent atteindre leur limite lorsqu'une orgnisation contient beaucoup de données.

| DEV | Branch |
|:-------- |:--------:|
| 1145     | 784  |

## 🚀 Pour tester
Ci au vert et faire la suppression d'une organisation de type SUP MANAGING STUDENT et vérifier que tout est OK
🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘 🌑
