### PR TITLE
[TECH] Correction de faux positifs dans les tests.

### DIFF
--- a/api/tests/certification/enrolment/integration/infrastructure/ods/read-ods-utils_test.js
+++ b/api/tests/certification/enrolment/integration/infrastructure/ods/read-ods-utils_test.js
@@ -196,15 +196,13 @@ describe('Integration | Shared | Infrastructure | Utils | Ods | read-ods-utils',
         odsBuffer = await readFile(DEFAULT_ODS_FILE_PATH);
 
         // when
-        const call = async () => {
-          await validateOdsHeaders({
+        // then
+        await expect(
+          validateOdsHeaders({
             odsBuffer,
             headers: VALID_HEADERS,
-          });
-        };
-
-        // then
-        expect(call).to.not.throw();
+          }),
+        ).not.to.be.rejected;
       });
     });
 

--- a/api/tests/evaluation/unit/domain/services/scorecard-service_test.js
+++ b/api/tests/evaluation/unit/domain/services/scorecard-service_test.js
@@ -366,8 +366,9 @@ describe('Unit | Service | ScorecardService', function () {
           .resolves([anonymizedAssessment]);
 
         // when
-        const call = async () => {
-          await scorecardService.resetScorecard({
+        // then
+        await expect(
+          scorecardService.resetScorecard({
             userId,
             competenceId,
             shouldResetCompetenceEvaluation,
@@ -376,9 +377,8 @@ describe('Unit | Service | ScorecardService', function () {
             campaignParticipationRepository,
             competenceEvaluationRepository,
             campaignRepository,
-          });
-        };
-        expect(call).not.to.throw();
+          }),
+        ).not.to.be.rejected;
       });
 
       // then

--- a/api/tests/school/unit/domain/services/activity_test.js
+++ b/api/tests/school/unit/domain/services/activity_test.js
@@ -23,11 +23,7 @@ describe('Unit | Service | Activity', function () {
 
       activityRepository.getLastActivity.withArgs(assessmentId).rejects(new ActivityNotFoundError());
 
-      const functionToCall = async () => {
-        await getCurrentActivity(activityRepository, assessmentId);
-      };
-
-      expect(functionToCall).to.not.throw();
+      await expect(getCurrentActivity(activityRepository, assessmentId)).not.to.be.rejected;
     });
 
     it('throws an error when the error is not a ActivityNotFoundError', async function () {


### PR DESCRIPTION
## 🌎 Problème

Quelques tests utilisent la syntaxe : 

```
const call = async () => {………}
expect(call).not.to.throw();
```

Cette fonction anonyme `async` retourne toujours une Promise, quel que soit son contenu.

Mocha exécute call() et reçoit **immédiatement** un objet Promise en retour. Comme l'instanciation de la promesse n'a pas crashé immédiatement de manière synchrone, `expect` considère que tout va bien.

L'erreur qui survient plus tard lorsque le await échoue n'est donc pas capturée par .throw(). Elle "flotte" dans le vide alors que le test est déjà vert. ✅ 

## 🔭 Proposition

On utilise await expect(...) pour spécifier à Mocha de ne pas terminer l'exécution de ce test avant que la promesse ne soit résolue ou rejetée.
On remplace `throw()` par `rejected` issu de [`chai-as-promised`](https://www.chaijs.com/plugins/chai-as-promised/) 
On supprime la fonction call() pour ne pas créer de fonction anonyme inutile.

## 🪐 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🚀 Pour tester

Tests verts ✅ 

Remplacer par exemple dans le code la fonction 

```
async function validateOdsHeaders({ odsBuffer, headers }) {
  const sheetDataRows = await getSheetDataRowsFromOdsBuffer({ odsBuffer });
  const headerRow = _findHeaderRow(sheetDataRows, headers);
  if (!headerRow) {
    throw new UnprocessableEntityError('Unknown attendance sheet version');
  }
}
```

par 

```
async function validateOdsHeaders({ odsBuffer, headers }) {
  throw new UnprocessableEntityError('Unknown attendance sheet version');
}
```

Et vérifier que le test suivant échoue :

```
context('when the headers are found', function () {
      it('should not throw a UnprocessableEntityError', async function () {
        // given
        odsBuffer = await readFile(DEFAULT_ODS_FILE_PATH);

        // when
        // then
        await expect(
          validateOdsHeaders({
            odsBuffer,
            headers: VALID_HEADERS,
          }),
        ).not.to.be.rejected;
      });
    });
```
