### PR TITLE
[BUGFIX] Éviter de provoquer des erreurs lors de la collecte de métriques du LearningContentRepository

### DIFF
--- a/api/src/shared/infrastructure/repositories/learning-content-repository.js
+++ b/api/src/shared/infrastructure/repositories/learning-content-repository.js
@@ -111,7 +111,7 @@ export class LearningContentRepository {
 
       return dtos;
     } finally {
-      this.#metrics.find.observe(dtos.length);
+      if (dtos) this.#metrics.find.observe(dtos.length);
     }
   }
 

--- a/api/tests/school/unit/application/mission-route_test.js
+++ b/api/tests/school/unit/application/mission-route_test.js
@@ -40,6 +40,7 @@ describe('Unit | Router | mission-route', function () {
       // given
       const mock = sinon.mock(securityPreHandlers);
       mock.expects('checkUserBelongsToOrganization').once().returns(true);
+      sinon.stub(missionController, 'findAllActive').callsFake((request, h) => h.response('ok'));
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);
 


### PR DESCRIPTION
## 🌎 Problème

Dans le bloc `finally` de la méthode `find` du LearningContentRepository, on suppose que la variable `dtos` est une liste. Cependant, cela n'est pas forcément toujours le cas, notamment s'il y a eu une erreur avant que la variable ne puisse être assignée.

Ce comportement a été remarqué lors du lancement d'un test unitaire (`GET /api/organizations/{id}/missions`) dans lequel il manquait un stub du `mission-controller`.


## 🔭 Proposition

- Vérifier que `dtos` existe avant de l'utiliser.
- Ajouter le stub manquant dans le test concerné.

## 🚀 Pour tester

- Lancer les tests unitaires de l'API (`npm run test:api:unit`).
- Constater qu'aucune erreur `TypeError: Cannot read properties of undefined (reading 'length')` n'est affichée dans la console.