### PR TITLE
[BUGFIX] Ne pas utiliser le bucket dans la route `/statuses` (PIX-21915)

### DIFF
--- a/api/src/profile/domain/usecases/get-shared-attestations-user-detail-by-organization-id.js
+++ b/api/src/profile/domain/usecases/get-shared-attestations-user-detail-by-organization-id.js
@@ -7,11 +7,10 @@ export async function getSharedAttestationsUserDetailByOrganizationId({
   profileRewardRepository,
   attestationRepository,
   organizationProfileRewardRepository,
-  attestationStorage,
 }) {
-  const attestationData = await attestationRepository.getDataByKey({ key: attestationKey, attestationStorage });
+  const attestation = await attestationRepository.getByKey({ attestationKey });
 
-  if (!attestationData) {
+  if (!attestation) {
     throw new AttestationNotFoundError();
   }
 

--- a/api/tests/profile/integration/domain/usecases/get-shared-attestations-user-detail-by-organization-id_test.js
+++ b/api/tests/profile/integration/domain/usecases/get-shared-attestations-user-detail-by-organization-id_test.js
@@ -2,7 +2,7 @@ import { AttestationNotFoundError } from '../../../../../src/profile/domain/erro
 import { AttestationUserDetail } from '../../../../../src/profile/domain/models/AttestationUserDetail.js';
 import { User } from '../../../../../src/profile/domain/models/User.js';
 import { usecases } from '../../../../../src/profile/domain/usecases/index.js';
-import { catchErr, databaseBuilder, expect, mockAttestationStorage, sinon } from '../../../../test-helper.js';
+import { catchErr, databaseBuilder, expect, sinon } from '../../../../test-helper.js';
 import { buildAttestationUserDetail } from '../../../../tooling/domain-builder/factory/index.js';
 
 describe('Profile | Integration | Domain | get-shared-attestations-user-detail-by-organization-id', function () {
@@ -24,7 +24,6 @@ describe('Profile | Integration | Domain | get-shared-attestations-user-detail-b
     it('should return array of AttestationUserDetail by organizationId', async function () {
       const locale = 'FR-fr';
       const attestation = databaseBuilder.factory.buildAttestation();
-      mockAttestationStorage(attestation);
       const firstUser = new User(databaseBuilder.factory.buildUser({ firstName: 'alex', lastName: 'Terieur' }));
       const secondUser = new User(databaseBuilder.factory.buildUser({ firstName: 'theo', lastName: 'Courant' }));
       const organizationId = databaseBuilder.factory.buildOrganization().id;
@@ -97,7 +96,6 @@ describe('Profile | Integration | Domain | get-shared-attestations-user-detail-b
       //given
       const locale = 'FR-fr';
       const attestation = databaseBuilder.factory.buildAttestation();
-      mockAttestationStorage(attestation);
       const firstUser = new User(databaseBuilder.factory.buildUser({ firstName: 'Alex', lastName: 'Terieur' }));
       const organizationId = databaseBuilder.factory.buildOrganization().id;
       databaseBuilder.factory.buildProfileReward({


### PR DESCRIPTION
## 🌎 Problème

Dans `get-shared-attestations-user-detail-by-organization-id.js`, l'appel à `attestationRepository.getDataByKey()` téléchargeait le fichier PDF de l'attestation depuis S3 juste pour vérifier son existence. Le Body (contenu PDF) était ensuite complètement ignoré.

## 🔭 Proposition

Remplacement de `getDataByKey` (SELECT + S3) par `getByKey` (SELECT seul) 
Le fichier PDF n'est jamais nécessaire pour la route /statuses

## 🚀 Pour tester

- [ ] Tests vert
- [ ] La page /statuses fonctionne