### PR TITLE
[BUGFIX] Filtrer les tubes sans nom dans le sélecteur de sujets (PIX-21916)

### DIFF
--- a/api/src/prescription/shared/infrastructure/repositories/learning-content-repository.js
+++ b/api/src/prescription/shared/infrastructure/repositories/learning-content-repository.js
@@ -55,10 +55,11 @@ export async function findByOrganizationId({ organizationId, locale }) {
     return [];
   }
 
-  const tubes = await tubeRepository.findByRecordIds(
+  const allTubes = await tubeRepository.findByRecordIds(
     tubesWithLevel.map((dto) => dto.id),
     locale,
   );
+  const tubes = allTubes.filter((tube) => tube.practicalTitle);
 
   const frameworks = await _getLearningContentByTubes(tubes, locale);
 

--- a/api/tests/prescription/shared/integration/infrastructure/repositories/learning-content-repository_test.js
+++ b/api/tests/prescription/shared/integration/infrastructure/repositories/learning-content-repository_test.js
@@ -152,6 +152,22 @@ describe('Integration | Repository | learning-content', function () {
       thematicId: 'recThematic3',
     });
 
+    databaseBuilder.factory.learningContent.buildTube({
+      id: 'recTubeNotitle',
+      name: '@recTubeNotitle_name',
+      title: 'recTubeNotitle_title',
+      description: 'recTubeNotitle_description',
+      practicalTitle_i18n: { fr: null, en: null },
+      practicalDescription_i18n: {
+        fr: null,
+        en: null,
+      },
+      isMobileCompliant: false,
+      isTabletCompliant: false,
+      competenceId: 'recCompetence3',
+      thematicId: 'recThematic3',
+    });
+
     const skill2DB = databaseBuilder.factory.learningContent.buildSkill({
       id: 'recSkill2',
       name: '@tube2_name1',
@@ -454,6 +470,30 @@ describe('Integration | Repository | learning-content', function () {
       expect(results).lengthOf(2);
       expect(results[0]).deep.equals(framework2Fr);
       expect(results[1]).deep.equals(framework1Fr);
+    });
+
+    it('should filter out tubes without practicalTitle', async function () {
+      // given
+      const anotherOrganizationId = databaseBuilder.factory.buildOrganization().id;
+
+      const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+      databaseBuilder.factory.buildTargetProfileShare({ organizationId: anotherOrganizationId, targetProfileId });
+      databaseBuilder.factory.buildTargetProfileTube({ targetProfileId, tubeId: 'recTube4', level: 4 });
+      databaseBuilder.factory.buildTargetProfileTube({ targetProfileId, tubeId: 'recTubeNotitle', level: 4 });
+      await databaseBuilder.commit();
+
+      framework2Fr.areas = [area2Fr];
+      area2Fr.competences = [competence3Fr];
+      competence3Fr.thematics = [thematic3Fr];
+      competence3Fr.tubes = [tube4Fr];
+      thematic3Fr.tubes = [tube4Fr];
+      tube4Fr.skills = [];
+
+      // when
+      const results = await learningContentRepository.findByOrganizationId({ organizationId: anotherOrganizationId });
+      // then
+      expect(results).lengthOf(1);
+      expect(results[0]).deep.equals(framework2Fr);
     });
 
     context('when organization has no target profile shares', function () {


### PR DESCRIPTION
## 🌎 Problème

Le sélecteur de sujet plante lorsqu'on remonte des tubes sans nom

## 🔭 Proposition

ne plus remonter les tubes sans nom

## 🪐 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🚀 Pour tester
Créer un PC avec un tube sans nom et un tube avec un nom
Afficher le selecteur de sujet
<!-- 


Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->

🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘 🌑
