### PR TITLE
[FEATURE] Ajouter le tracking du téléchargement de la sélection de sujets (PIX-21829)

### DIFF
--- a/orga/app/components/tube/list.gjs
+++ b/orga/app/components/tube/list.gjs
@@ -1,6 +1,7 @@
 import PixAccordions from '@1024pix/pix-ui/components/pix-accordions';
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
@@ -8,6 +9,7 @@ import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 import { eq } from 'ember-truth-helpers';
 
+import { EVENT_NAME } from '../../helpers/metrics-event-name';
 import Header from '../table/header';
 import Thematic from './thematic';
 import Tube from './tube';
@@ -15,6 +17,7 @@ import Tube from './tube';
 export default class TubeList extends Component {
   @tracked selectedTubeIds = [];
   @service dayjs;
+  @service pixMetrics;
 
   @action
   selectThematic(thematic) {
@@ -100,6 +103,11 @@ export default class TubeList extends Component {
     return URL.createObjectURL(this.file);
   }
 
+  @action
+  trackDownloadClick() {
+    this.pixMetrics.trackEvent(EVENT_NAME.TUBES_SELECTION.DOWNLOAD_JSON_CLICK);
+  }
+
   <template>
     <section>
       <div class="download-file">
@@ -116,6 +124,7 @@ export default class TubeList extends Component {
               organizationName=@organization.name
               date=this.formattedCurrentDate
             }}
+            {{on "click" this.trackDownloadClick}}
           >
             {{t
               "pages.preselect-target-profile.download"

--- a/orga/app/helpers/metrics-event-name.js
+++ b/orga/app/helpers/metrics-event-name.js
@@ -9,4 +9,7 @@ export const EVENT_NAME = {
   COMBINED_COURSE: {
     VIEW_CAMPAIGN_CLICK: 'combinedCourseViewCampaignClick',
   },
+  TUBES_SELECTION: {
+    DOWNLOAD_JSON_CLICK: 'tubesSelectionDownloadJsonClick',
+  },
 };

--- a/orga/tests/integration/components/tube/list-test.js
+++ b/orga/tests/integration/components/tube/list-test.js
@@ -112,7 +112,7 @@ module('Integration | Component | tube:list', function (hooks) {
   });
 
   hooks.afterEach(function () {
-    dayjs.self.prototype.format.restore();
+    sinon.restore();
   });
 
   test('it should display frameworks title', async function (assert) {
@@ -171,6 +171,28 @@ module('Integration | Component | tube:list', function (hooks) {
     assert
       .dom(screen.getByText('Télécharger la sélection des sujets (1) (JSON, 0.04ko)'))
       .hasAttribute('download', expectedAttr);
+  });
+
+  test('it should track the download event when the download button is clicked', async function (assert) {
+    // given
+    sinon.stub(URL, 'createObjectURL').returns('blob:fake-url');
+    sinon.stub(URL, 'revokeObjectURL');
+
+    this.set('frameworks', frameworks);
+    this.set('organization', { name: 'mon orga' });
+    const pixMetrics = this.owner.lookup('service:pix-metrics');
+    const trackEventStub = sinon.stub(pixMetrics, 'trackEvent');
+
+    await render(hbs`<Tube::list @frameworks={{this.frameworks}} @organization={{this.organization}} />`);
+
+    await clickByName('1 · Titre domaine Pix');
+    await clickByName('Titre 1 Tube Pix : Description 1');
+
+    // when
+    await clickByName('Télécharger la sélection des sujets (1) (JSON, 0.04ko)');
+
+    // then
+    assert.ok(trackEventStub.calledOnceWith('tubesSelectionDownloadJsonClick'));
   });
 
   test('Enable the download button if a thematic is selected', async function (assert) {


### PR DESCRIPTION
## 🐜 Problème

Sur la page `/selection-sujets` de Pix Orga, le clic sur le bouton de téléchargement JSON n'était pas tracké dans Plausible.

## 🦇 Proposition

Ajout d'un événement Plausible `tubesSelectionDownloadJsonClick` déclenché au clic sur le bouton de téléchargement de la sélection de sujets.

## 🪠 Pour tester

- [x] Aller sur `/selection-sujets`
- [x] Sélectionner au moins un sujet
- [x] Cliquer sur le bouton de téléchargement
- [x] Vérifier dans Plausible que le funnel `Consulte la page /selection-sujets et crée un Json` [fonctionne correctement](https://plausible.io/review.pix.fr)