### PR TITLE
[TECH] Ajout d'une colonne "framework" dans la table "certification-courses" pour savoir rapidement quelle certification a été passée (PIX-21937)

### DIFF
--- a/api/db/migrations/20260316162308_add-column-framework-in-certification-courses-table.js
+++ b/api/db/migrations/20260316162308_add-column-framework-in-certification-courses-table.js
@@ -1,0 +1,38 @@
+// Make sure you properly test your migration, especially DDL (Data Definition Language)
+// ! If the target table is large, and the migration take more than 20 minutes, the deployment will fail !
+
+// You can design and test your migration to avoid this by following this guide
+// https://1024pix.atlassian.net/wiki/spaces/EDTDT/pages/3849323922/Cr+er+une+migration
+
+// If your migrations target :
+//
+// `answers`
+// `knowledge-elements`
+// `knowledge-element-snapshots`
+//
+// contact @team-captains, because automatic migrations are not active on `pix-datawarehouse-production`
+// this may prevent data replication to succeed the day after your migration is deployed on `pix-api-production`
+const TABLE_NAME = 'certification-courses';
+const COLUMN_NAME = 'framework';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.string(COLUMN_NAME, 50).comment('Enum value of Framework that certification course is evaluating');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## 🌎 Problème

Pour savoir quelle certification a réellement été passée, c'est assez galère.
Il faut dans un premier temps regarder les subscriptions : `join "certification-candidates" + join "certification-subscriptions"`.
Puis, comme en v2 il était possible d'être inscrit à une double certification mais de ne passer que la coeur, faute de badge par exemple, il faut aussi vérifier :  `join "complementary-certification-courses" + join "complementary-certifications"`.

C'est plutôt pénible.

## 🔭 Proposition

Dans le cadre de notre démarche de faire des écritures qui facilitent nos lectures, nous proposons d'ajouter une colonne `framework` à la table `certification-courses`, qui va contenir la clé de la certification effectivement passée. Sa règle de remplissage est similaire à la colonne `subscription` dans `certification-candidates` : en cas de double certification (en particulier pour la v2), mettre la complémentaire, sinon mettre le coeur. 

## 🪐 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🚀 Pour tester
en local
`
npm run db:migrate
npm run db:rollback:latest
`

🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘 🌑
