### PR TITLE
[TECH] Remplissage de la nouvelle colonne "framework" : au moment de la création du test de certification, ainsi que rétro-remplissage par script (PIX-21938)

### DIFF
--- a/api/db/database-builder/factory/build-certification-course.js
+++ b/api/db/database-builder/factory/build-certification-course.js
@@ -31,6 +31,7 @@ const buildCertificationCourse = function ({
   lang = null,
   versionId = null,
   candidateId = null,
+  framework = null,
 } = {}) {
   userId = _.isUndefined(userId) ? buildUser().id : userId;
   sessionId = _.isUndefined(sessionId) ? buildSession().id : sessionId;
@@ -60,6 +61,7 @@ const buildCertificationCourse = function ({
     lang,
     versionId,
     candidateId,
+    framework,
   };
   return databaseBuffer.pushInsertable({
     tableName: 'certification-courses',

--- a/api/scripts/certification/fill-new-column-framework-in-certification-course-table.js
+++ b/api/scripts/certification/fill-new-column-framework-in-certification-course-table.js
@@ -1,0 +1,145 @@
+import { setTimeout } from 'node:timers/promises';
+
+import { knex } from '../../db/knex-database-connection.js';
+import { Frameworks } from '../../src/certification/configuration/domain/models/Frameworks.js';
+import { Script } from '../../src/shared/application/scripts/script.js';
+import { ScriptRunner } from '../../src/shared/application/scripts/script-runner.js';
+import { DomainTransaction } from '../../src/shared/domain/DomainTransaction.js';
+import { batchUpdate } from '../../src/shared/infrastructure/utils/knex-utils.js';
+
+export class FillNewColumnFrameworkInCertificationCourseTable extends Script {
+  constructor() {
+    super({
+      description:
+        'Filling "framework" and "candidateId" columns in certification-courses table. For the "candidateId" column, it is already partially filled by a previous script, but not for v2 certifications',
+      permanent: false,
+      options: {
+        dryRun: {
+          type: 'boolean',
+          describe: 'Run the script without making any database changes',
+          default: true,
+        },
+        startId: {
+          type: 'number',
+          describe: 'Define the id of the certification-courses from which we start doing the process',
+          default: 1,
+        },
+        chunkSize: {
+          type: 'number',
+          describe:
+            'Define the number of certifications processed in a chunk (chunks determined how many certifications are updated and committed at the same time)',
+          default: 3000,
+        },
+        throttleDelay: {
+          type: 'number',
+          describe: 'The throttle delay',
+          default: 250,
+        },
+      },
+    });
+  }
+
+  async handle({ logger, options }) {
+    const { dryRun, startId, chunkSize, throttleDelay } = options;
+    logger.info('Script execution started');
+
+    let currentStartId = startId;
+    let certificationsData = await selectCertificationsToProcess(currentStartId, chunkSize);
+    while (certificationsData.length > 0) {
+      const { certificationCoursesToUpdate, latestCertificationIdProcessed } = await processCertifications(
+        certificationsData,
+        logger,
+      );
+
+      await DomainTransaction.execute(async () => {
+        const trx = DomainTransaction.getConnection();
+        try {
+          await batchUpdate({
+            tableName: 'certification-courses',
+            primaryKeyName: 'id',
+            rows: certificationCoursesToUpdate,
+          });
+
+          logger.info(`Certifications up until ID ${latestCertificationIdProcessed} DONE`);
+          if (dryRun) {
+            await trx.rollback();
+          } else {
+            await trx.commit();
+          }
+        } catch (error) {
+          await trx.rollback();
+          throw error;
+        }
+      });
+      await setTimeout(throttleDelay);
+      currentStartId = latestCertificationIdProcessed + 1;
+      certificationsData = await selectCertificationsToProcess(currentStartId, chunkSize);
+    }
+
+    logger.info('No more certifications to process youpi');
+  }
+}
+
+async function selectCertificationsToProcess(startId, chunkSize) {
+  return knex
+    .select({
+      certificationCourseId: 'certification-courses.id',
+      candidateId: 'certification-candidates.id',
+      complementaryCertificationKeys: knex.raw(
+        `json_agg(
+          "complementary-certifications"."key"
+          ORDER BY "complementary-certifications".key NULLS LAST
+        )`,
+      ),
+    })
+    .from('certification-courses')
+    .leftJoin('certification-candidates', function () {
+      this.on({ 'certification-candidates.sessionId': 'certification-courses.sessionId' }).andOn({
+        'certification-candidates.userId': 'certification-courses.userId',
+      });
+    })
+    .leftJoin(
+      'complementary-certification-courses',
+      'complementary-certification-courses.certificationCourseId',
+      'certification-courses.id',
+    )
+    .leftJoin(
+      'complementary-certifications',
+      'complementary-certifications.id',
+      'complementary-certification-courses.complementaryCertificationId',
+    )
+    .where('certification-courses.id', '>=', startId)
+    .whereNull('certification-courses.framework')
+    .groupBy('certification-courses.id', 'certification-candidates.id')
+    .orderBy('certification-courses.id', 'asc')
+    .limit(chunkSize);
+}
+
+async function processCertifications(certificationsData, logger) {
+  let latestCertificationIdProcessed;
+  const certificationCoursesToUpdate = [];
+  logger.info(
+    `Processing certification from ${certificationsData[0].certificationCourseId} to ${certificationsData.at(-1).certificationCourseId}...`,
+  );
+  for (const certificationData of certificationsData) {
+    try {
+      latestCertificationIdProcessed = certificationData.certificationCourseId;
+
+      const certificationCourseData = {
+        id: certificationData.certificationCourseId,
+        candidateId: certificationData.candidateId ?? null,
+        framework: certificationData.complementaryCertificationKeys?.[0] ?? Frameworks.CORE,
+      };
+      certificationCoursesToUpdate.push(certificationCourseData);
+    } catch (error) {
+      logger.error(error, `Certification ID ${latestCertificationIdProcessed} encountered an error`);
+      throw error;
+    }
+  }
+  return {
+    certificationCoursesToUpdate: certificationCoursesToUpdate.filter((cco) => !!cco),
+    latestCertificationIdProcessed,
+  };
+}
+
+await ScriptRunner.execute(import.meta.url, FillNewColumnFrameworkInCertificationCourseTable);

--- a/api/src/certification/enrolment/infrastructure/repositories/enrolled-candidate-repository.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/enrolled-candidate-repository.js
@@ -78,6 +78,7 @@ function buildBaseReadQuery(knexConn) {
             'complementaryCertificationKey', "complementary-certifications"."key",
             'certificationCandidateId', "certification-candidates"."id"
           )
+          ORDER BY "complementary-certifications"."key" ASC NULLS FIRST
       )`,
       ),
     })

--- a/api/src/certification/evaluation/domain/usecases/retrieve-last-or-create-certification-course.js
+++ b/api/src/certification/evaluation/domain/usecases/retrieve-last-or-create-certification-course.js
@@ -20,6 +20,7 @@ import {
   UnexpectedUserAccountError,
 } from '../../../../shared/domain/errors.js';
 import { Assessment } from '../../../../shared/domain/models/Assessment.js';
+import { Frameworks } from '../../../configuration/domain/models/Frameworks.js';
 import { SessionNotAccessible } from '../../../session-management/domain/errors.js';
 import { ComplementaryCertificationCourse } from '../../../session-management/domain/models/ComplementaryCertificationCourse.js';
 import { CenterHabilitationError } from '../../../shared/domain/errors.js';
@@ -195,8 +196,10 @@ async function _startNewCertification({
   const certificationCenter = await certificationCenterRepository.getBySessionId({ sessionId: session.id });
 
   let complementaryCertificationCourseData;
+  let framework = Frameworks.CORE;
 
   if (certificationCandidate.isEnrolledToComplementaryOnly()) {
+    framework = certificationCandidate.complementaryCertification.key;
     if (!certificationCenter.isHabilitated(certificationCandidate.complementaryCertification.key)) {
       throw new CenterHabilitationError();
     }
@@ -221,6 +224,7 @@ async function _startNewCertification({
     );
 
     if (doubleCertificationBadge) {
+      framework = Frameworks.CLEA;
       const { complementaryCertificationId, complementaryCertificationBadgeId } = doubleCertificationBadge;
       complementaryCertificationCourseData = { complementaryCertificationBadgeId, complementaryCertificationId };
     }
@@ -250,6 +254,7 @@ async function _startNewCertification({
     verifyCertificateCodeService,
     complementaryCertificationCourseData,
     lang: user.lang,
+    framework,
   });
 }
 
@@ -283,6 +288,7 @@ async function _createCertificationCourse({
   userId,
   complementaryCertificationCourseData,
   lang,
+  framework,
 }) {
   const verificationCode = await verifyCertificateCodeService.generateCertificateVerificationCode();
   const complementaryCertificationCourse = complementaryCertificationCourseData
@@ -300,6 +306,7 @@ async function _createCertificationCourse({
     verificationCode,
     algorithmEngineVersion: AlgorithmEngineVersion.V3,
     lang,
+    framework,
   });
 
   return DomainTransaction.execute(async () => {

--- a/api/src/certification/shared/domain/models/CertificationCourse.js
+++ b/api/src/certification/shared/domain/models/CertificationCourse.js
@@ -78,6 +78,7 @@ export class CertificationCourse {
     lang,
     versionId,
     candidateId,
+    framework,
   } = {}) {
     this._id = id;
     this._firstName = firstName;
@@ -108,6 +109,7 @@ export class CertificationCourse {
     this._lang = lang;
     this.versionId = versionId;
     this.candidateId = candidateId;
+    this.framework = framework;
   }
 
   static from({
@@ -120,6 +122,7 @@ export class CertificationCourse {
     numberOfChallenges,
     algorithmEngineVersion,
     lang,
+    framework,
   }) {
     return new CertificationCourse({
       userId: certificationCandidate.userId,
@@ -143,6 +146,7 @@ export class CertificationCourse {
       lang,
       versionId: certificationVersion.id,
       candidateId: certificationCandidate.id,
+      framework,
     });
   }
 
@@ -361,6 +365,7 @@ export class CertificationCourse {
       lang: this._lang,
       candidateId: this.candidateId,
       versionId: this.versionId,
+      framework: this.framework,
     };
   }
 }

--- a/api/src/certification/shared/infrastructure/repositories/certification-course-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/certification-course-repository.js
@@ -263,6 +263,7 @@ function _adaptModelToDb(certificationCourse) {
     lang: certificationCourseDTO.lang,
     candidateId: certificationCourseDTO.candidateId,
     versionId: certificationCourseDTO.versionId,
+    framework: certificationCourseDTO.framework,
   };
 }
 

--- a/api/tests/certification/evaluation/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
+++ b/api/tests/certification/evaluation/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
@@ -1,3 +1,4 @@
+import { Frameworks } from '../../../../../../src/certification/configuration/domain/models/Frameworks.js';
 import { retrieveLastOrCreateCertificationCourse } from '../../../../../../src/certification/evaluation/domain/usecases/retrieve-last-or-create-certification-course.js';
 import { SessionNotAccessible } from '../../../../../../src/certification/session-management/domain/errors.js';
 import { ComplementaryCertificationCourse } from '../../../../../../src/certification/session-management/domain/models/ComplementaryCertificationCourse.js';
@@ -496,6 +497,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                 algorithmEngineVersion: AlgorithmEngineVersion.V3,
                 complementaryCertificationCourses: [],
                 lang: user.lang,
+                framework: Frameworks.CORE,
               });
               const savedCertificationCourse = domainBuilder.buildCertificationCourse(
                 certificationCourseToSave.toDTO(),
@@ -631,6 +633,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                   algorithmEngineVersion: AlgorithmEngineVersion.V3,
                   lang: user.lang,
                   isAdjustedForAccessibility: foundCertificationCandidate.accessibilityAdjustmentNeeded,
+                  framework: Frameworks.CORE,
                 });
 
                 const savedCertificationCourse = domainBuilder.buildCertificationCourse(
@@ -715,6 +718,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                   complementaryCertificationCourses: [],
                   algorithmEngineVersion: AlgorithmEngineVersion.V3,
                   lang: user.lang,
+                  framework: Frameworks.CORE,
                 });
 
                 const savedCertificationCourse = domainBuilder.buildCertificationCourse(
@@ -813,6 +817,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                     complementaryCertificationCourse,
                     algorithmEngineVersion: AlgorithmEngineVersion.V3,
                     lang: user.lang,
+                    framework: Frameworks.DROIT,
                   });
 
                   const savedCertificationCourse = domainBuilder.buildCertificationCourse(
@@ -990,6 +995,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                       complementaryCertificationCourse,
                       algorithmEngineVersion: AlgorithmEngineVersion.V3,
                       lang: user.lang,
+                      framework: Frameworks.CLEA,
                     });
 
                     const savedCertificationCourse = domainBuilder.buildCertificationCourse(
@@ -1086,6 +1092,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                         maxReachableLevelOnCertificationDate: MAX_REACHABLE_LEVEL,
                         algorithmEngineVersion: AlgorithmEngineVersion.V3,
                         lang: user.lang,
+                        framework: Frameworks.CORE,
                       });
 
                       const savedCertificationCourse = domainBuilder.buildCertificationCourse(

--- a/api/tests/certification/scripts/integration/fill-new-column-framework-in-certification-course-table_test.js
+++ b/api/tests/certification/scripts/integration/fill-new-column-framework-in-certification-course-table_test.js
@@ -1,0 +1,274 @@
+import { FillNewColumnFrameworkInCertificationCourseTable } from '../../../../scripts/certification/fill-new-column-framework-in-certification-course-table.js';
+import { Frameworks } from '../../../../src/certification/configuration/domain/models/Frameworks.js';
+import { databaseBuilder, expect, knex, sinon } from '../../../test-helper.js';
+
+describe('Integration | Certification | Scripts | Fill new column framework in certification course table', function () {
+  let logger, script;
+
+  beforeEach(async function () {
+    logger = { info: sinon.stub(), error: sinon.stub() };
+    script = new FillNewColumnFrameworkInCertificationCourseTable();
+  });
+
+  it('should not commit if dryRun', async function () {
+    const sessionId = databaseBuilder.factory.buildSession().id;
+    const userId = databaseBuilder.factory.buildUser().id;
+    databaseBuilder.factory.buildCertificationCandidate({
+      sessionId,
+      userId,
+    }).id;
+    const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
+      sessionId,
+      userId,
+    }).id;
+
+    await databaseBuilder.commit();
+
+    const certificationCourseDataBefore = await knex('certification-courses').first();
+    expect(certificationCourseDataBefore.candidateId).to.be.null;
+    expect(certificationCourseDataBefore.framework).to.be.null;
+
+    await script.handle({
+      options: { dryRun: true, throttleDelay: 1, startId: certificationCourseId, chunkSize: 1 },
+      logger,
+    });
+
+    const certificationCourseDataAfter = await knex('certification-courses').first();
+    expect(certificationCourseDataAfter.candidateId).to.be.null;
+    expect(certificationCourseDataAfter.framework).to.be.null;
+  });
+
+  it("should fill framework with 'CORE' and let candidateId at null for a certification without candidate nor complementary-certification-course", async function () {
+    const sessionId = databaseBuilder.factory.buildSession().id;
+    const userId = databaseBuilder.factory.buildUser().id;
+    const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
+      sessionId,
+      userId,
+    }).id;
+
+    await databaseBuilder.commit();
+
+    const certificationCourseDataBefore = await knex('certification-courses').first();
+    expect(certificationCourseDataBefore.candidateId).to.be.null;
+    expect(certificationCourseDataBefore.framework).to.be.null;
+
+    await script.handle({
+      options: { dryRun: false, throttleDelay: 1, startId: certificationCourseId, chunkSize: 1 },
+      logger,
+    });
+
+    const certificationCourseDataAfter = await knex('certification-courses').first();
+    expect(certificationCourseDataAfter.candidateId).to.be.null;
+    expect(certificationCourseDataAfter.framework).to.equal(Frameworks.CORE);
+  });
+
+  it('should fill framework as CORE and fill candidateId when there are no complementary certification course', async function () {
+    const sessionId = databaseBuilder.factory.buildSession().id;
+    const userId = databaseBuilder.factory.buildUser().id;
+    const candidateId = databaseBuilder.factory.buildCertificationCandidate({
+      sessionId,
+      userId,
+    }).id;
+    const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
+      sessionId,
+      userId,
+    }).id;
+
+    await databaseBuilder.commit();
+
+    const certificationCourseDataBefore = await knex('certification-courses').first();
+    expect(certificationCourseDataBefore.candidateId).to.be.null;
+    expect(certificationCourseDataBefore.framework).to.be.null;
+
+    await script.handle({
+      options: { dryRun: false, throttleDelay: 1, startId: certificationCourseId, chunkSize: 1 },
+      logger,
+    });
+
+    const certificationCourseDataAfter = await knex('certification-courses').first();
+    expect(certificationCourseDataAfter.candidateId).to.equal(candidateId);
+    expect(certificationCourseDataAfter.framework).to.equal(Frameworks.CORE);
+  });
+
+  it('should fill framework as the complementary key and fill candidateId when there is a complementary certification course', async function () {
+    const complementaryCertificationId = databaseBuilder.factory.buildComplementaryCertification({
+      key: Frameworks.EDU_1ER_DEGRE,
+    }).id;
+    const sessionId = databaseBuilder.factory.buildSession().id;
+    const userId = databaseBuilder.factory.buildUser().id;
+    const candidateId = databaseBuilder.factory.buildCertificationCandidate({
+      sessionId,
+      userId,
+    }).id;
+    const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
+      sessionId,
+      userId,
+    }).id;
+    databaseBuilder.factory.buildComplementaryCertificationCourse({
+      certificationCourseId,
+      complementaryCertificationId,
+      complementaryCertificationBadgeId: null,
+    });
+
+    await databaseBuilder.commit();
+
+    const certificationCourseDataBefore = await knex('certification-courses').first();
+    expect(certificationCourseDataBefore.candidateId).to.be.null;
+    expect(certificationCourseDataBefore.framework).to.be.null;
+
+    await script.handle({
+      options: { dryRun: false, throttleDelay: 1, startId: certificationCourseId, chunkSize: 1 },
+      logger,
+    });
+
+    const certificationCourseDataAfter = await knex('certification-courses').first();
+    expect(certificationCourseDataAfter.candidateId).to.equal(candidateId);
+    expect(certificationCourseDataAfter.framework).to.equal(Frameworks.EDU_1ER_DEGRE);
+  });
+
+  it('should not update certification course when information already filled (especially the framework one, the purpose of the script is not to fix data, just to fill the blanks)', async function () {
+    const sessionId = databaseBuilder.factory.buildSession().id;
+    const userId = databaseBuilder.factory.buildUser().id;
+    databaseBuilder.factory.buildCertificationCandidate({
+      sessionId,
+      userId,
+    }).id;
+    const someOtherCandidateId = databaseBuilder.factory.buildCertificationCandidate().id;
+    const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
+      sessionId,
+      userId,
+      candidateId: someOtherCandidateId,
+      framework: Frameworks.CLEA,
+    }).id;
+
+    await databaseBuilder.commit();
+
+    const certificationCourseDataBefore = await knex('certification-courses').first();
+    expect(certificationCourseDataBefore.candidateId).to.equal(someOtherCandidateId);
+    expect(certificationCourseDataBefore.framework).to.equal(Frameworks.CLEA);
+
+    await script.handle({
+      options: { dryRun: false, startId: certificationCourseId, chunkSize: 1 },
+      logger,
+    });
+
+    const certificationCourseDataAfter = await knex('certification-courses').first();
+    expect(certificationCourseDataAfter.candidateId).to.equal(someOtherCandidateId);
+    expect(certificationCourseDataAfter.framework).to.equal(Frameworks.CLEA);
+    expect(logger.info.getCall(0)).to.have.been.calledWithExactly('Script execution started');
+    expect(logger.info.getCall(1)).to.have.been.calledWithExactly('No more certifications to process youpi');
+  });
+
+  it('should work when fetching several certification-courses with different contexts', async function () {
+    const sessionId1 = databaseBuilder.factory.buildSession().id;
+    const userId1 = databaseBuilder.factory.buildUser().id;
+    const certificationCourseId1 = databaseBuilder.factory.buildCertificationCourse({
+      sessionId: sessionId1,
+      userId: userId1,
+    }).id;
+    const sessionId2 = databaseBuilder.factory.buildSession().id;
+    const userId2 = databaseBuilder.factory.buildUser().id;
+    const candidateId2 = databaseBuilder.factory.buildCertificationCandidate({
+      sessionId: sessionId2,
+      userId: userId2,
+    }).id;
+    const certificationCourseId2 = databaseBuilder.factory.buildCertificationCourse({
+      sessionId: sessionId2,
+      userId: userId2,
+    }).id;
+    const complementaryCertificationId = databaseBuilder.factory.buildComplementaryCertification({
+      key: Frameworks.EDU_1ER_DEGRE,
+    }).id;
+    const sessionId3 = databaseBuilder.factory.buildSession().id;
+    const userId3 = databaseBuilder.factory.buildUser().id;
+    const candidateId3 = databaseBuilder.factory.buildCertificationCandidate({
+      sessionId: sessionId3,
+      userId: userId3,
+    }).id;
+    const certificationCourseId3 = databaseBuilder.factory.buildCertificationCourse({
+      sessionId: sessionId3,
+      userId: userId3,
+    }).id;
+    databaseBuilder.factory.buildComplementaryCertificationCourse({
+      certificationCourseId: certificationCourseId3,
+      complementaryCertificationId,
+      complementaryCertificationBadgeId: null,
+    });
+    const sessionId4 = databaseBuilder.factory.buildSession().id;
+    const userId4 = databaseBuilder.factory.buildUser().id;
+    databaseBuilder.factory.buildCertificationCandidate({
+      sessionId: sessionId4,
+      userId: userId4,
+    }).id;
+    const someOtherCandidateId = databaseBuilder.factory.buildCertificationCandidate().id;
+    const certificationCourseId4 = databaseBuilder.factory.buildCertificationCourse({
+      sessionId: sessionId4,
+      userId: userId4,
+      candidateId: someOtherCandidateId,
+      framework: Frameworks.CLEA,
+    }).id;
+
+    await databaseBuilder.commit();
+
+    await script.handle({
+      options: { dryRun: false, throttleDelay: 1, startId: certificationCourseId1, chunkSize: 1 },
+      logger,
+    });
+
+    const certificationCourseDatas = await knex('certification-courses')
+      .select(['id', 'candidateId', 'framework'])
+      .orderBy('id');
+    expect(certificationCourseDatas.length).to.equal(4);
+    expect(certificationCourseDatas[0]).to.deep.equal({
+      id: certificationCourseId1,
+      candidateId: null,
+      framework: Frameworks.CORE,
+    });
+    expect(certificationCourseDatas[1]).to.deep.equal({
+      id: certificationCourseId2,
+      candidateId: candidateId2,
+      framework: Frameworks.CORE,
+    });
+    expect(certificationCourseDatas[2]).to.deep.equal({
+      id: certificationCourseId3,
+      candidateId: candidateId3,
+      framework: Frameworks.EDU_1ER_DEGRE,
+    });
+    expect(certificationCourseDatas[3]).to.deep.equal({
+      id: certificationCourseId4,
+      candidateId: someOtherCandidateId,
+      framework: Frameworks.CLEA,
+    });
+  });
+
+  it('should provide appropriate logger informations', async function () {
+    const sessionId = databaseBuilder.factory.buildSession().id;
+    const userId = databaseBuilder.factory.buildUser().id;
+    const certificationCourseIds = [];
+    for (let i = 0; i < 4; i++) {
+      const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
+        sessionId,
+        userId,
+      }).id;
+      certificationCourseIds.push(certificationCourseId);
+    }
+    await databaseBuilder.commit();
+
+    await script.handle({ options: { dryRun: false, startId: certificationCourseIds[0], chunkSize: 2 }, logger });
+
+    expect(logger.info.getCall(0)).to.have.been.calledWithExactly('Script execution started');
+    expect(logger.info.getCall(1)).to.have.been.calledWithExactly(
+      `Processing certification from ${certificationCourseIds[0]} to ${certificationCourseIds[1]}...`,
+    );
+    expect(logger.info.getCall(2)).to.have.been.calledWithExactly(
+      `Certifications up until ID ${certificationCourseIds[1]} DONE`,
+    );
+    expect(logger.info.getCall(3)).to.have.been.calledWithExactly(
+      `Processing certification from ${certificationCourseIds[2]} to ${certificationCourseIds[3]}...`,
+    );
+    expect(logger.info.getCall(4)).to.have.been.calledWithExactly(
+      `Certifications up until ID ${certificationCourseIds[3]} DONE`,
+    );
+    expect(logger.info.getCall(5)).to.have.been.calledWithExactly('No more certifications to process youpi');
+  });
+});

--- a/api/tests/certification/shared/integration/infrastructure/repositories/certification-course-repository_test.js
+++ b/api/tests/certification/shared/integration/infrastructure/repositories/certification-course-repository_test.js
@@ -1,6 +1,7 @@
 import dayjs from 'dayjs';
 import _ from 'lodash';
 
+import { Frameworks } from '../../../../../../src/certification/configuration/domain/models/Frameworks.js';
 import { CertificationCourse } from '../../../../../../src/certification/shared/domain/models/CertificationCourse.js';
 import * as certificationCourseRepository from '../../../../../../src/certification/shared/infrastructure/repositories/certification-course-repository.js';
 import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
@@ -37,6 +38,7 @@ describe('Certification | Shared | Integration | Repository | Certification Cour
         verificationCode: 'MONCODE',
         maxReachableLevelOnCertificationDate: 7,
         abortReason: null,
+        framework: Frameworks.CORE,
       };
 
       databaseBuilder.factory.buildCertificationCandidate({ userId, sessionId });

--- a/api/tests/tooling/domain-builder/factory/build-certification-course.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-course.js
@@ -1,3 +1,4 @@
+import { Frameworks } from '../../../../src/certification/configuration/domain/models/Frameworks.js';
 import { AlgorithmEngineVersion } from '../../../../src/certification/shared/domain/models/AlgorithmEngineVersion.js';
 import { CertificationCourse } from '../../../../src/certification/shared/domain/models/CertificationCourse.js';
 import { CertificationIssueReport } from '../../../../src/certification/shared/domain/models/CertificationIssueReport.js';
@@ -33,6 +34,7 @@ function buildCertificationCourse({
   numberOfChallenges,
   isAdjustedForAccessibility = false,
   lang,
+  framework = Frameworks.CORE,
 } = {}) {
   const certificationIssueReports = [];
   if (examinerComment && examinerComment !== '') {
@@ -78,6 +80,7 @@ function buildCertificationCourse({
     numberOfChallenges: finalNumberOfChallenges,
     isAdjustedForAccessibility,
     lang,
+    framework,
   });
 }
 
@@ -108,6 +111,7 @@ buildCertificationCourse.unpersisted = function ({
   lang,
   versionId = 123,
   candidateId = 456,
+  framework = Frameworks.CORE,
 } = {}) {
   return new CertificationCourse({
     firstName,
@@ -137,6 +141,7 @@ buildCertificationCourse.unpersisted = function ({
     lang,
     versionId,
     candidateId,
+    framework,
   });
 };
 


### PR DESCRIPTION
## 🌎 Problème

On souhaite remplir cette nouvelle colonne : https://github.com/1024pix/pix/pull/15503

## 🔭 Proposition

_**Dans le code :**_ au moment de créer le test de certification. Cas particulier de CléA : il faut bien s'assurer de ne remplir la colonne que si le candidat est bien éligible à cette double certification.

**_Rétro-remplissage :_**
- Cas V1 : pas de candidat ni de notion de complémentaire, on met `CORE`
- Cas V2 : les doubles certifications. Pour chaque certification, on regarde si il existe un `complementary-certification-course`. Si oui, on inscrit la complémentaire, si non `CORE`
- Cas V3 : on fait pareil qu'au-dessus car les v3 impliquent aussi la création d'un `complementary-certification-course` et en principe on ne devrait pas trouver en prod de candidats inscrits à un pix plus sans `complementary-certification-course` (à vérifier quand même)

## 🪐 Remarques

C'est sous la main, on profite aussi de remplir les valeurs `candidateId` manquantes de `certification-courses`. On n'avait rempli que pour la v3.
On passe le `chunk` à 3000, on soupçonne que ça ira mieux pour la prod (envisager même de monter).
On utilise le `throttleDelay` pour laisser respirer d'une part l'event-loop, d'autre part le CPU de la machine pour ne pas être un mauvais voisin

## 🚀 Pour tester
Joindre une certification (idéalement coeur, pixplus et cléa (avec et sans badge)) pour vérifier le remplissage idoine de la colonne.

Pour le script, ben yolo + exécution dans la recette

🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘 🌑
