### PR TITLE
[TECH] Utiliser le batchUpdate pour supprimer les learners (Pix-21891)

### DIFF
--- a/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-repository.js
@@ -122,15 +122,13 @@ const getCampaignParticipationsForOrganizationLearner = async function ({ organi
   );
 };
 
-const getAllCampaignParticipationsForOrganizationLearner = async function ({
-  organizationLearnerId,
+const getAllCampaignParticipationsForOrganizationLearnerIds = async function ({
+  organizationLearnerIds,
   withDeletedParticipation = false,
 } = {}) {
   const knexConn = DomainTransaction.getConnection();
   const queryBuilder = knexConn('campaign-participations')
-    .where({
-      organizationLearnerId,
-    })
+    .whereIn('organizationLearnerId', organizationLearnerIds)
     .orderBy('createdAt', 'desc');
 
   if (!withDeletedParticipation) queryBuilder.whereNull('deletedAt');
@@ -322,7 +320,7 @@ export {
   findInfoByCampaignId,
   findOneByCampaignIdAndUserId,
   get,
-  getAllCampaignParticipationsForOrganizationLearner,
+  getAllCampaignParticipationsForOrganizationLearnerIds,
   getAllCampaignParticipationsInCampaignForASameLearner,
   getByCampaignIds,
   getCampaignParticipationsCountByUserId,

--- a/api/src/prescription/learner-management/domain/usecases/anonymize-user.js
+++ b/api/src/prescription/learner-management/domain/usecases/anonymize-user.js
@@ -4,21 +4,24 @@ export const anonymizeUser = withTransaction(
   async ({ userId, campaignParticipationRepositoryFromBC, organizationLearnerRepository }) => {
     const learners = await organizationLearnerRepository.findByUserId({ userId });
     const campaignParticipationToAnonymize = [];
+    const learnerIds = [];
 
     for (const learner of learners) {
       learner.detachUser();
+      learnerIds.push(learner.id);
       await organizationLearnerRepository.update(learner);
-      const campaignParticipations =
-        await campaignParticipationRepositoryFromBC.getAllCampaignParticipationsForOrganizationLearner({
-          organizationLearnerId: learner.id,
-        });
-
-      for (const campaignParticipation of campaignParticipations) {
-        campaignParticipation.detachUser();
-        campaignParticipationToAnonymize.push(campaignParticipation.dataToUpdateOnAnonymisation);
-      }
-
-      await campaignParticipationRepositoryFromBC.updateInBatchByIds(campaignParticipationToAnonymize);
     }
+
+    const campaignParticipations =
+      await campaignParticipationRepositoryFromBC.getAllCampaignParticipationsForOrganizationLearnerIds({
+        organizationLearnerIds: learnerIds,
+      });
+
+    for (const campaignParticipation of campaignParticipations) {
+      campaignParticipation.detachUser();
+      campaignParticipationToAnonymize.push(campaignParticipation.dataToUpdateOnAnonymisation);
+    }
+
+    await campaignParticipationRepositoryFromBC.updateInBatchByIds(campaignParticipationToAnonymize);
   },
 );

--- a/api/src/prescription/learner-management/domain/usecases/delete-organization-learners.js
+++ b/api/src/prescription/learner-management/domain/usecases/delete-organization-learners.js
@@ -45,7 +45,6 @@ const deleteOrganizationLearners = async function ({
   const allCampaignParticipationIds = [];
 
   await DomainTransaction.execute(async () => {
-    const assessmentsToUpdate = [];
     const organizationLearnersToUpdate = [];
     const organizationProfileRewardsToUpdate = [];
 
@@ -74,42 +73,41 @@ const deleteOrganizationLearners = async function ({
           withDeletedParticipation: keepPreviousDeletion,
         });
 
-      for (const campaignParticipation of campaignParticipations) {
-        campaignParticipation.delete(userId);
-        campaignParticipationsToDelete.push(campaignParticipation.dataToUpdateOnDeletion);
+    for (const campaignParticipation of campaignParticipations) {
+      campaignParticipation.delete(userId);
+      campaignParticipationsToDelete.push(campaignParticipation.dataToUpdateOnDeletion);
 
-        auditLoggingJobs.push(
-          AuditLoggingJob.forUser({
-            client,
-            action: campaignParticipation.loggerContext,
-            role: userRole,
-            userId: campaignParticipation.id,
-            updatedByUserId: userId,
-            data: {},
-          }),
-        );
-      }
+      auditLoggingJobs.push(
+        AuditLoggingJob.forUser({
+          client,
+          action: campaignParticipation.loggerContext,
+          role: userRole,
+          userId: campaignParticipation.id,
+          updatedByUserId: userId,
+          data: {},
+        }),
+      );
+    }
 
       const campaignParticipationIds = campaignParticipations.map(({ id }) => id);
       allCampaignParticipationIds.push(...campaignParticipationIds);
 
-      const assessments = await assessmentRepository.getByCampaignParticipationIds(campaignParticipationIds);
 
-      assessments.forEach((assessment) => assessment.detachCampaignParticipation());
-
-      assessmentsToUpdate.push(...assessments);
     }
 
-    await organizationsProfileRewardRepository.removeInBatch(organizationProfileRewardsToUpdate);
+    const assessments = await assessmentRepository.getByCampaignParticipationIds(allCampaignParticipationIds);
+    assessments.forEach((assessment) => assessment.detachCampaignParticipation());
+
     await organizationLearnerRepository.updateInBatchByIds(organizationLearnersToUpdate);
-    await assessmentRepository.batchRemoveParticipationId(assessmentsToUpdate);
+    await campaignParticipationRepositoryFromBC.updateInBatchByIds(campaignParticipationsToDelete);
+    await assessmentRepository.batchRemoveParticipationId(assessments);
     await badgeAcquisitionRepository.deleteUserIdOnNonCertifiableBadgesForCampaignParticipations(
       allCampaignParticipationIds,
     );
+    await organizationsProfileRewardRepository.removeInBatch(organizationProfileRewardsToUpdate);
     await userRecommendedTrainingRepository.deleteCampaignParticipationIds({
       campaignParticipationIds: allCampaignParticipationIds,
     });
-    await campaignParticipationRepositoryFromBC.updateInBatchByIds(campaignParticipationsToDelete);
   });
 
   for (const auditLoggingJob of auditLoggingJobs) {

--- a/api/src/prescription/learner-management/domain/usecases/delete-organization-learners.js
+++ b/api/src/prescription/learner-management/domain/usecases/delete-organization-learners.js
@@ -46,12 +46,13 @@ const deleteOrganizationLearners = async function ({
 
   await DomainTransaction.execute(async () => {
     const assessmentsToUpdate = [];
+    const organizationLearnersToUpdate = [];
     for (const organizationLearner of organizationLearnersToDelete) {
       const organizationLearnerRewards = organizationProfileRewards.filter(
         (organizationProfileReward) => organizationProfileReward.userId === organizationLearner.userId,
       );
       organizationLearner.delete(userId, { keepPreviousDeletion });
-      await organizationLearnerRepository.remove(organizationLearner.dataToUpdateOnDeletion);
+      organizationLearnersToUpdate.push(organizationLearner.dataToUpdateOnDeletion);
 
       await organizationsProfileRewardRepository.removeInBatch(organizationLearnerRewards);
 
@@ -98,6 +99,7 @@ const deleteOrganizationLearners = async function ({
       assessmentsToUpdate.push(...assessments);
     }
 
+    await organizationLearnerRepository.updateInBatchByIds(organizationLearnersToUpdate);
     await assessmentRepository.batchRemoveParticipationId(assessmentsToUpdate);
     await badgeAcquisitionRepository.deleteUserIdOnNonCertifiableBadgesForCampaignParticipations(
       allCampaignParticipationIds,

--- a/api/src/prescription/learner-management/domain/usecases/delete-organization-learners.js
+++ b/api/src/prescription/learner-management/domain/usecases/delete-organization-learners.js
@@ -47,8 +47,10 @@ const deleteOrganizationLearners = async function ({
   await DomainTransaction.execute(async () => {
     const organizationLearnersToUpdate = [];
     const organizationProfileRewardsToUpdate = [];
+    const organizationLearnerIds = [];
 
     for (const organizationLearner of organizationLearnersToDelete) {
+      organizationLearnerIds.push(organizationLearner.id);
       const organizationLearnerRewards = organizationProfileRewards.filter(
         (organizationProfileReward) => organizationProfileReward.userId === organizationLearner.userId,
       );
@@ -66,16 +68,18 @@ const deleteOrganizationLearners = async function ({
           data: {},
         }),
       );
+    }
 
-      const campaignParticipations =
-        await campaignParticipationRepositoryFromBC.getAllCampaignParticipationsForOrganizationLearner({
-          organizationLearnerId: organizationLearner.id,
-          withDeletedParticipation: keepPreviousDeletion,
-        });
+    const campaignParticipations =
+      await campaignParticipationRepositoryFromBC.getAllCampaignParticipationsForOrganizationLearnerIds({
+        organizationLearnerIds,
+        withDeletedParticipation: keepPreviousDeletion,
+      });
 
     for (const campaignParticipation of campaignParticipations) {
       campaignParticipation.delete(userId);
       campaignParticipationsToDelete.push(campaignParticipation.dataToUpdateOnDeletion);
+      allCampaignParticipationIds.push(campaignParticipation.id);
 
       auditLoggingJobs.push(
         AuditLoggingJob.forUser({
@@ -87,12 +91,6 @@ const deleteOrganizationLearners = async function ({
           data: {},
         }),
       );
-    }
-
-      const campaignParticipationIds = campaignParticipations.map(({ id }) => id);
-      allCampaignParticipationIds.push(...campaignParticipationIds);
-
-
     }
 
     const assessments = await assessmentRepository.getByCampaignParticipationIds(allCampaignParticipationIds);

--- a/api/src/prescription/learner-management/domain/usecases/delete-organization-learners.js
+++ b/api/src/prescription/learner-management/domain/usecases/delete-organization-learners.js
@@ -47,14 +47,15 @@ const deleteOrganizationLearners = async function ({
   await DomainTransaction.execute(async () => {
     const assessmentsToUpdate = [];
     const organizationLearnersToUpdate = [];
+    const organizationProfileRewardsToUpdate = [];
+
     for (const organizationLearner of organizationLearnersToDelete) {
       const organizationLearnerRewards = organizationProfileRewards.filter(
         (organizationProfileReward) => organizationProfileReward.userId === organizationLearner.userId,
       );
       organizationLearner.delete(userId, { keepPreviousDeletion });
       organizationLearnersToUpdate.push(organizationLearner.dataToUpdateOnDeletion);
-
-      await organizationsProfileRewardRepository.removeInBatch(organizationLearnerRewards);
+      organizationProfileRewardsToUpdate.push(...organizationLearnerRewards);
 
       auditLoggingJobs.push(
         AuditLoggingJob.forUser({
@@ -99,6 +100,7 @@ const deleteOrganizationLearners = async function ({
       assessmentsToUpdate.push(...assessments);
     }
 
+    await organizationsProfileRewardRepository.removeInBatch(organizationProfileRewardsToUpdate);
     await organizationLearnerRepository.updateInBatchByIds(organizationLearnersToUpdate);
     await assessmentRepository.batchRemoveParticipationId(assessmentsToUpdate);
     await badgeAcquisitionRepository.deleteUserIdOnNonCertifiableBadgesForCampaignParticipations(

--- a/api/src/prescription/learner-management/infrastructure/repositories/organization-learner-repository.js
+++ b/api/src/prescription/learner-management/infrastructure/repositories/organization-learner-repository.js
@@ -57,14 +57,6 @@ const getOrganizationLearnerForAdmin = async function (organizationLearnerId) {
   return new OrganizationLearnerForAdmin(organizationLearner);
 };
 
-const removeByIds = function ({ organizationLearnerIds, userId }) {
-  const knexConn = DomainTransaction.getConnection();
-  return knexConn('organization-learners')
-    .whereIn('id', organizationLearnerIds)
-    .whereNull('deletedAt')
-    .update({ updatedAt: new Date(), deletedAt: new Date(), deletedBy: userId });
-};
-
 const disableAllOrganizationLearnersInOrganization = async function ({ organizationId, nationalStudentIds }) {
   const knexConn = DomainTransaction.getConnection();
   await knexConn('organization-learners')
@@ -375,7 +367,6 @@ export {
   getOrganizationLearnerForAdmin,
   reconcileUserByNationalStudentIdAndOrganizationId,
   reconcileUserToOrganizationLearner,
-  removeByIds,
   saveCommonOrganizationLearners,
   update,
   updateCertificability,

--- a/api/src/prescription/learner-management/infrastructure/repositories/organization-learner-repository.js
+++ b/api/src/prescription/learner-management/infrastructure/repositories/organization-learner-repository.js
@@ -7,6 +7,7 @@ import {
   OrganizationLearnersCouldNotBeSavedError,
   UserCouldNotBeReconciledError,
 } from '../../../../shared/domain/errors.js';
+import { batchUpdate } from '../../../../shared/infrastructure/utils/knex-utils.js';
 import { OrganizationLearnerCertificabilityNotUpdatedError } from '../../domain/errors.js';
 import { CommonOrganizationLearner } from '../../domain/models/CommonOrganizationLearner.js';
 import { OrganizationLearner } from '../../domain/models/OrganizationLearner.js';
@@ -340,44 +341,12 @@ async function getLearnerInfo(organizationLearnerId) {
   return new OrganizationLearner(organizationLearner);
 }
 
-const remove = async (organizationLearner) => {
-  const knexConn = DomainTransaction.getConnection();
-
-  return knexConn('organization-learners').where('id', organizationLearner.id).update(_toInfra(organizationLearner));
+const updateInBatchByIds = async (organizationLearners) => {
+  return batchUpdate({ tableName: 'organization-learners', primaryKeyName: 'id', rows: organizationLearners });
 };
 
 function _toDomain(result) {
   return new OrganizationLearner(result);
-}
-
-function _toInfra(organizationLearner) {
-  return {
-    lastName: organizationLearner.lastName,
-    preferredLastName: organizationLearner.preferredLastName,
-    firstName: organizationLearner.firstName,
-    middleName: organizationLearner.middleName,
-    thirdName: organizationLearner.thirdName,
-    sex: organizationLearner.sex,
-    birthdate: organizationLearner.birthdate,
-    birthCity: organizationLearner.birthCity,
-    birthCityCode: organizationLearner.birthCityCode,
-    birthProvinceCode: organizationLearner.birthProvinceCode,
-    birthCountryCode: organizationLearner.birthCountryCode,
-    status: organizationLearner.status,
-    nationalStudentId: organizationLearner.nationalStudentId,
-    division: organizationLearner.division,
-    updatedAt: organizationLearner.updatedAt,
-    userId: organizationLearner.userId,
-    email: organizationLearner.email,
-    studentNumber: organizationLearner.studentNumber,
-    department: organizationLearner.department,
-    educationalTeam: organizationLearner.educationalTeam,
-    group: organizationLearner.group,
-    diploma: organizationLearner.diploma,
-    nationalApprenticeId: organizationLearner.nationalApprenticeId,
-    deletedAt: organizationLearner.deletedAt,
-    deletedBy: organizationLearner.deletedBy,
-  };
 }
 
 /**
@@ -406,9 +375,9 @@ export {
   getOrganizationLearnerForAdmin,
   reconcileUserByNationalStudentIdAndOrganizationId,
   reconcileUserToOrganizationLearner,
-  remove,
   removeByIds,
   saveCommonOrganizationLearners,
   update,
   updateCertificability,
+  updateInBatchByIds,
 };

--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -852,7 +852,7 @@ describe('Integration | Repository | Campaign Participation', function () {
     });
   });
 
-  describe('#getAllCampaignParticipationsForOrganizationLearner', function () {
+  describe('#getAllCampaignParticipationsForOrganizationLearnerIds', function () {
     let organizationLearnerId;
     let organizationId;
 
@@ -872,11 +872,10 @@ describe('Integration | Repository | Campaign Participation', function () {
 
         await databaseBuilder.commit();
 
-        const participations = await campaignParticipationRepository.getAllCampaignParticipationsForOrganizationLearner(
-          {
-            organizationLearnerId,
-          },
-        );
+        const participations =
+          await campaignParticipationRepository.getAllCampaignParticipationsForOrganizationLearnerIds({
+            organizationLearnerIds: [organizationLearnerId],
+          });
 
         expect(participations).lengthOf(0);
       });
@@ -887,11 +886,10 @@ describe('Integration | Repository | Campaign Participation', function () {
 
         await databaseBuilder.commit();
 
-        const participations = await campaignParticipationRepository.getAllCampaignParticipationsForOrganizationLearner(
-          {
-            organizationLearnerId,
-          },
-        );
+        const participations =
+          await campaignParticipationRepository.getAllCampaignParticipationsForOrganizationLearnerIds({
+            organizationLearnerIds: [organizationLearnerId],
+          });
 
         expect(participations).to.lengthOf(0);
       });
@@ -906,9 +904,10 @@ describe('Integration | Repository | Campaign Participation', function () {
 
       await databaseBuilder.commit();
 
-      const participations = await campaignParticipationRepository.getAllCampaignParticipationsForOrganizationLearner({
-        organizationLearnerId,
-      });
+      const participations =
+        await campaignParticipationRepository.getAllCampaignParticipationsForOrganizationLearnerIds({
+          organizationLearnerIds: [organizationLearnerId],
+        });
 
       expect(participations[0]).instanceOf(CampaignParticipation);
       const { id, sharedAt, status } = participations[0];
@@ -927,10 +926,11 @@ describe('Integration | Repository | Campaign Participation', function () {
 
       await databaseBuilder.commit();
 
-      const participations = await campaignParticipationRepository.getAllCampaignParticipationsForOrganizationLearner({
-        organizationLearnerId,
-        withDeletedParticipation: true,
-      });
+      const participations =
+        await campaignParticipationRepository.getAllCampaignParticipationsForOrganizationLearnerIds({
+          organizationLearnerIds: [organizationLearnerId],
+          withDeletedParticipation: true,
+        });
 
       expect(participations).lengthOf(1);
     });

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/organization-learner-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/organization-learner-repository_test.js
@@ -17,7 +17,6 @@ import {
   getOrganizationLearnerForAdmin,
   reconcileUserByNationalStudentIdAndOrganizationId,
   reconcileUserToOrganizationLearner,
-  removeByIds,
   saveCommonOrganizationLearners,
   update,
   updateCertificability,
@@ -59,107 +58,6 @@ describe('Integration | Repository | Organization Learner Management | Organizat
 
       // then
       expect(result).to.be.instanceOf(NotFoundError);
-    });
-  });
-
-  describe('#removeByIds', function () {
-    let clock;
-    const now = new Date('2023-02-02');
-
-    beforeEach(function () {
-      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-    });
-
-    afterEach(function () {
-      clock.restore();
-    });
-
-    it('delete one organization learner', async function () {
-      // given
-      const organizationId = databaseBuilder.factory.buildOrganization().id;
-      const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({
-        organizationId,
-      }).id;
-      const userId = databaseBuilder.factory.buildUser().id;
-
-      await databaseBuilder.commit();
-
-      // when
-      const organizationLearnersIdsToDelete = [organizationLearnerId];
-
-      await DomainTransaction.execute(async (domainTransaction) => {
-        await removeByIds({ organizationLearnerIds: organizationLearnersIdsToDelete, userId, domainTransaction });
-      });
-
-      // then
-      const organizationLearnerResult = await knex('organization-learners')
-        .select('updatedAt', 'deletedAt', 'deletedBy')
-        .where('id', organizationLearnerId)
-        .first();
-
-      expect(organizationLearnerResult.updatedAt).to.deep.equal(now);
-      expect(organizationLearnerResult.deletedAt).to.deep.equal(now);
-      expect(organizationLearnerResult.deletedBy).to.equal(userId);
-    });
-
-    it('not update organization learner already deleted', async function () {
-      // given
-      const otherUserId = databaseBuilder.factory.buildUser().id;
-      const userId = databaseBuilder.factory.buildUser().id;
-
-      const organizationId = databaseBuilder.factory.buildOrganization().id;
-      const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({
-        organizationId,
-        deletedAt: new Date('2020-02-01'),
-        deletedBy: otherUserId,
-      }).id;
-
-      await databaseBuilder.commit();
-
-      // when
-      const organizationLearnersIdsToDelete = [organizationLearnerId];
-
-      await DomainTransaction.execute(async (domainTransaction) => {
-        await removeByIds({ organizationLearnerIds: organizationLearnersIdsToDelete, userId, domainTransaction });
-      });
-
-      // then
-      const organizationLearnerResult = await knex('organization-learners')
-        .select('deletedAt', 'deletedBy')
-        .where('id', organizationLearnerId)
-        .first();
-
-      expect(organizationLearnerResult.deletedAt).to.deep.equal(new Date('2020-02-01'));
-      expect(organizationLearnerResult.deletedBy).to.equal(otherUserId);
-    });
-
-    it('delete more than one organization learners at the same time', async function () {
-      // given
-      const organizationId = databaseBuilder.factory.buildOrganization().id;
-      const firstOrganizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({
-        organizationId,
-      }).id;
-      const secondOrganizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({
-        organizationId,
-      }).id;
-      const thirdOrganisationLearnerId = databaseBuilder.factory.buildOrganizationLearner({
-        organizationId,
-      }).id;
-      const userId = databaseBuilder.factory.buildUser().id;
-
-      await databaseBuilder.commit();
-
-      // when
-      const organizationLearnersIdToDelete = [firstOrganizationLearnerId, secondOrganizationLearnerId];
-
-      await DomainTransaction.execute(async (domainTransaction) => {
-        await removeByIds({ organizationLearnerIds: organizationLearnersIdToDelete, userId, domainTransaction });
-      });
-
-      // then
-      const learners = await knex('view-active-organization-learners').where({ organizationId });
-      expect(learners).to.have.lengthOf(1);
-      expect(learners[0].id).to.equal(thirdOrganisationLearnerId);
     });
   });
 

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/organization-learner-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/organization-learner-repository_test.js
@@ -17,11 +17,11 @@ import {
   getOrganizationLearnerForAdmin,
   reconcileUserByNationalStudentIdAndOrganizationId,
   reconcileUserToOrganizationLearner,
-  remove,
   removeByIds,
   saveCommonOrganizationLearners,
   update,
   updateCertificability,
+  updateInBatchByIds,
 } from '../../../../../../src/prescription/learner-management/infrastructure/repositories/organization-learner-repository.js';
 import * as organizationLearnerRepository from '../../../../../../src/prescription/organization-learner/infrastructure/repositories/organization-learner-repository.js';
 import { DomainTransaction } from '../../../../../../src/shared/domain/DomainTransaction.js';
@@ -163,7 +163,7 @@ describe('Integration | Repository | Organization Learner Management | Organizat
     });
   });
 
-  describe('#remove', function () {
+  describe('#updateInBatchByIds', function () {
     let clock;
     const now = new Date('2023-02-02');
 
@@ -179,6 +179,34 @@ describe('Integration | Repository | Organization Learner Management | Organizat
       // given
       const adminUserId = databaseBuilder.factory.buildUser().id;
       const organizationId = databaseBuilder.factory.buildOrganization().id;
+      const anotherOrganizationLearnerFromDB = databaseBuilder.factory.buildOrganizationLearner({
+        lastName: 'Steve',
+        preferredLastName: 'Mc',
+        firstName: 'Chicken',
+        middleName: 'Fry',
+        thirdName: 'BBQ',
+        sex: 'F',
+        MEFCode: '14',
+        birthdate: '2001-05-08',
+        birthCity: 'Mans',
+        birthCityCode: '546789',
+        birthProvinceCode: '50',
+        birthCountryCode: '19',
+        status: 'AM/PM',
+        nationalStudentId: '45679721',
+        division: '6eme RAINBOW',
+        updatedAt: new Date('1999-01-01'),
+        email: 'littlecat@animal.org',
+        studentNumber: '4987644',
+        department: '52',
+        educationalTeam: 'CoreTex',
+        group: 'C',
+        diploma: 'pujze, peozaeza; pzaezae',
+        nationalApprenticeId: '489798485',
+        deletedBy: null,
+        deletedAt: null,
+      });
+
       const organizationLearnerFromDB = databaseBuilder.factory.buildOrganizationLearner({
         organizationId,
         lastName: 'Richard',
@@ -214,38 +242,70 @@ describe('Integration | Repository | Organization Learner Management | Organizat
       const organizationLearner = domainBuilder.buildOrganizationLearner(organizationLearnerFromDB);
       organizationLearner.delete(adminUserId);
 
-      await remove(organizationLearner.dataToUpdateOnDeletion);
+      await updateInBatchByIds([organizationLearner.dataToUpdateOnDeletion]);
 
       // then
-      const organizationLearnerResult = await knex('organization-learners')
+      const organizationAnonymizedLearner = await knex('organization-learners')
         .where({ id: organizationLearner.id })
         .first();
 
-      expect(organizationLearnerResult.MEFCode).equal('12');
-      expect(organizationLearnerResult.lastName).equal('(anonymized)');
-      expect(organizationLearnerResult.firstName).equal('(anonymized)');
-      expect(organizationLearnerResult.preferredLastName).null;
-      expect(organizationLearnerResult.middleName).null;
-      expect(organizationLearnerResult.thirdName).null;
-      expect(organizationLearnerResult.sex).null;
-      expect(organizationLearnerResult.birthdate).deep.equal('2001-01-01');
-      expect(organizationLearnerResult.birthCity).null;
-      expect(organizationLearnerResult.birthCityCode).null;
-      expect(organizationLearnerResult.birthProvinceCode).null;
-      expect(organizationLearnerResult.birthCountryCode).null;
-      expect(organizationLearnerResult.status).null;
-      expect(organizationLearnerResult.nationalStudentId).null;
-      expect(organizationLearnerResult.division).null;
-      expect(organizationLearnerResult.updatedAt).deep.equal(now);
-      expect(organizationLearnerResult.email).null;
-      expect(organizationLearnerResult.studentNumber).null;
-      expect(organizationLearnerResult.department).null;
-      expect(organizationLearnerResult.educationalTeam).null;
-      expect(organizationLearnerResult.group).null;
-      expect(organizationLearnerResult.diploma).null;
-      expect(organizationLearnerResult.nationalApprenticeId).null;
-      expect(organizationLearnerResult.deletedBy).equal(adminUserId);
-      expect(organizationLearnerResult.deletedAt).deep.equal(now);
+      expect(organizationAnonymizedLearner.MEFCode).equal('12');
+      expect(organizationAnonymizedLearner.lastName).equal('(anonymized)');
+      expect(organizationAnonymizedLearner.firstName).equal('(anonymized)');
+      expect(organizationAnonymizedLearner.preferredLastName).null;
+      expect(organizationAnonymizedLearner.middleName).null;
+      expect(organizationAnonymizedLearner.thirdName).null;
+      expect(organizationAnonymizedLearner.sex).null;
+      expect(organizationAnonymizedLearner.birthdate).deep.equal('2001-01-01');
+      expect(organizationAnonymizedLearner.birthCity).null;
+      expect(organizationAnonymizedLearner.birthCityCode).null;
+      expect(organizationAnonymizedLearner.birthProvinceCode).null;
+      expect(organizationAnonymizedLearner.birthCountryCode).null;
+      expect(organizationAnonymizedLearner.status).null;
+      expect(organizationAnonymizedLearner.nationalStudentId).null;
+      expect(organizationAnonymizedLearner.division).null;
+      expect(organizationAnonymizedLearner.updatedAt).deep.equal(now);
+      expect(organizationAnonymizedLearner.email).null;
+      expect(organizationAnonymizedLearner.studentNumber).null;
+      expect(organizationAnonymizedLearner.department).null;
+      expect(organizationAnonymizedLearner.educationalTeam).null;
+      expect(organizationAnonymizedLearner.group).null;
+      expect(organizationAnonymizedLearner.diploma).null;
+      expect(organizationAnonymizedLearner.nationalApprenticeId).null;
+      expect(organizationAnonymizedLearner.deletedBy).equal(adminUserId);
+      expect(organizationAnonymizedLearner.deletedAt).deep.equal(now);
+
+      const organizationLearnerActive = await knex('organization-learners')
+        .where({ id: anotherOrganizationLearnerFromDB.id })
+        .first();
+
+      expect(organizationLearnerActive.MEFCode).equal(anotherOrganizationLearnerFromDB.MEFCode);
+      expect(organizationLearnerActive.lastName).equal(anotherOrganizationLearnerFromDB.lastName);
+      expect(organizationLearnerActive.firstName).equal(anotherOrganizationLearnerFromDB.firstName);
+      expect(organizationLearnerActive.preferredLastName).equal(anotherOrganizationLearnerFromDB.preferredLastName);
+      expect(organizationLearnerActive.middleName).equal(anotherOrganizationLearnerFromDB.middleName);
+      expect(organizationLearnerActive.thirdName).equal(anotherOrganizationLearnerFromDB.thirdName);
+      expect(organizationLearnerActive.sex).equal(anotherOrganizationLearnerFromDB.sex);
+      expect(organizationLearnerActive.birthdate).equal(anotherOrganizationLearnerFromDB.birthdate);
+      expect(organizationLearnerActive.birthCity).equal(anotherOrganizationLearnerFromDB.birthCity);
+      expect(organizationLearnerActive.birthCityCode).equal(anotherOrganizationLearnerFromDB.birthCityCode);
+      expect(organizationLearnerActive.birthProvinceCode).equal(anotherOrganizationLearnerFromDB.birthProvinceCode);
+      expect(organizationLearnerActive.birthCountryCode).equal(anotherOrganizationLearnerFromDB.birthCountryCode);
+      expect(organizationLearnerActive.status).equal(anotherOrganizationLearnerFromDB.status);
+      expect(organizationLearnerActive.nationalStudentId).equal(anotherOrganizationLearnerFromDB.nationalStudentId);
+      expect(organizationLearnerActive.division).equal(anotherOrganizationLearnerFromDB.division);
+      expect(organizationLearnerActive.updatedAt).deep.equal(anotherOrganizationLearnerFromDB.updatedAt);
+      expect(organizationLearnerActive.email).equal(anotherOrganizationLearnerFromDB.email);
+      expect(organizationLearnerActive.studentNumber).equal(anotherOrganizationLearnerFromDB.studentNumber);
+      expect(organizationLearnerActive.department).equal(anotherOrganizationLearnerFromDB.department);
+      expect(organizationLearnerActive.educationalTeam).equal(anotherOrganizationLearnerFromDB.educationalTeam);
+      expect(organizationLearnerActive.group).equal(anotherOrganizationLearnerFromDB.group);
+      expect(organizationLearnerActive.diploma).equal(anotherOrganizationLearnerFromDB.diploma);
+      expect(organizationLearnerActive.nationalApprenticeId).equal(
+        anotherOrganizationLearnerFromDB.nationalApprenticeId,
+      );
+      expect(organizationLearnerActive.deletedBy).null;
+      expect(organizationLearnerActive.deletedAt).null;
     });
   });
 


### PR DESCRIPTION
## 🌎 Problème

Certaines requêtes http execute enormement de query N+1  sur pg. Chose que l'on pourrait diminuer avec des update en masse

## 🔭 Proposition

Pour la suppression des learners. remplacer la methode remove par une methode batchUpdateByIds qui permet de faire des suppression par chunk de 500 par défaut. afin de limiter le nombre de query que la route de suppresion de leanrer / archivage d'orgnisation fait. 

## 🪐 Remarques

Déplacement du batchUpate des remards pour le sortir de la boucle utilisateur. 
Suppression d'une méthode que nous n'utilisions plus

Metrics en local sur le Pro Classic ( petit hack pour éviter le bug de gestion de place. )
| DEV (hash vendredi dernier) | Dev (today) | Branch |
|:-------- |:-------- |:--------:|
| 1159     | 654 | 234  |

## 🚀 Pour tester
Aller sur PixAdmin et faire un archivage d'organisation. Vérifier que tout est OK. et que le nombre de query a descendu :)

🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘 🌑