### PR TITLE
[FEATURE] Affichage du réseau dans le détail d'une organisation (PIX-21341).

### DIFF
--- a/admin/app/components/organizations/head-information.gjs
+++ b/admin/app/components/organizations/head-information.gjs
@@ -3,12 +3,14 @@ import PixTag from '@1024pix/pix-ui/components/pix-tag';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { LinkTo } from '@ember/routing';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import t from 'ember-intl/helpers/t';
 import CopyButton from 'pix-admin/components/ui/copy-button';
 import ENV from 'pix-admin/config/environment';
 
 export default class HeadInformation extends Component {
+  @service currentUser;
   @action
   onLogoUpload(event) {
     const file = event.target.files?.[0];
@@ -30,6 +32,10 @@ export default class HeadInformation extends Component {
   get hasChildren() {
     const children = this.args.organization.children;
     return children?.length > 0;
+  }
+
+  get belongsToNetwork() {
+    return this.args.organization?.network;
   }
 
   get externalURL() {
@@ -76,6 +82,16 @@ export default class HeadInformation extends Component {
                 {{t "components.organizations.head-information.parent-organization"}}
               </PixTag>
             </li>
+          {{/if}}
+          {{#if this.belongsToNetwork}}
+            {{#if this.currentUser.adminMember.isSuperAdmin}}
+              <PixTag class="organization__child-tag" @color="success">
+                {{t "components.organizations.head-information.network"}}
+                <LinkTo @route="authenticated.networks.get" @model={{@organization.network.id}}>
+                  {{@organization.network.name}}
+                </LinkTo>
+              </PixTag>
+            {{/if}}
           {{/if}}
           {{#if @organization.parentOrganizationId}}
             <li>

--- a/admin/app/models/organization.js
+++ b/admin/app/models/organization.js
@@ -1,5 +1,5 @@
 import { service } from '@ember/service';
-import Model, { attr, hasMany } from '@ember-data/model';
+import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 import pick from 'lodash/pick';
 
 export default class Organization extends Model {
@@ -38,6 +38,8 @@ export default class Organization extends Model {
   @hasMany('tag', { async: true, inverse: null }) tags;
   @hasMany('organization', { async: true, inverse: null }) children;
   @hasMany('organization-invitation', { async: true, inverse: null }) organizationInvitations;
+
+  @belongsTo('network', { async: true, inverse: null }) network;
 
   static get featureList() {
     return {

--- a/admin/tests/acceptance/authenticated/organizations/get-test.js
+++ b/admin/tests/acceptance/authenticated/organizations/get-test.js
@@ -385,6 +385,44 @@ module('Acceptance | Organizations | Get', function (hooks) {
     });
   });
 
+  module('when the organization belongs to a network', function (hooks) {
+    hooks.beforeEach(async function () {
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+
+      server.create('network', { id: '42', name: 'Réseau Île-de-France' });
+
+      server.get('/admin/organizations/:id', () => ({
+        data: {
+          type: 'organizations',
+          id: '1',
+          attributes: {
+            name: 'My Organization',
+            features: { PLACES_MANAGEMENT: { active: true } },
+          },
+          relationships: {
+            network: { data: { type: 'networks', id: '42' } },
+            'organization-memberships': { links: { related: '/api/admin/organizations/1/memberships' } },
+            'target-profile-summaries': { links: { related: '/api/admin/organizations/1/target-profile-summaries' } },
+            children: { links: { related: '/api/admin/organizations/1/children' } },
+            'organization-invitations': { links: { related: '/api/admin/organizations/1/invitations' } },
+          },
+        },
+        included: [{ type: 'networks', id: '42', attributes: { name: 'Réseau Île-de-France' } }],
+      }));
+    });
+
+    test('clicking the network tag navigates to the network detail page', async function (assert) {
+      // given
+      const screen = await visit('/organizations/1/details');
+
+      // when
+      await click(screen.getByRole('link', { name: 'Réseau Île-de-France' }));
+
+      // then
+      assert.strictEqual(currentURL(), '/networks/42');
+    });
+  });
+
   module('When user is authenticated as Certif Admin', function (hooks) {
     hooks.beforeEach(async () => {
       await authenticateAdminMemberWithRole({ isCertif: true })(server);

--- a/admin/tests/integration/components/organizations/head-information-test.gjs
+++ b/admin/tests/integration/components/organizations/head-information-test.gjs
@@ -10,6 +10,11 @@ import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 module('Integration | Component | organizations/header-information', function (hooks) {
   setupIntlRenderingTest(hooks);
 
+  hooks.beforeEach(function () {
+    const currentUser = this.owner.lookup('service:currentUser');
+    currentUser.adminMember = { isSuperAdmin: true };
+  });
+
   module('when displaying organization', function () {
     test('it displays organization header information', async function (assert) {
       // given
@@ -118,6 +123,58 @@ module('Integration | Component | organizations/header-information', function (h
         assert
           .dom(screen.queryByText(t('components.organizations.head-information.parent-organization')))
           .doesNotExist();
+      });
+    });
+
+    module('when organization belongs to a network', function () {
+      module('when user is not super admin', function () {
+        test('it does not display a tag with a link to the network', async function (assert) {
+          // given
+          const currentUser = this.owner.lookup('service:currentUser');
+          currentUser.adminMember = { isSuperAdmin: false };
+          const store = this.owner.lookup('service:store');
+          const network = store.push({
+            data: { id: '42', type: 'network', attributes: { name: 'Réseau Île-de-France' } },
+          });
+          const organization = store.createRecord('organization', { network });
+
+          // when
+          const screen = await render(<template><HeadInformation @organization={{organization}} /></template>);
+
+          // then
+          assert.dom(screen.queryByRole('link', { name: 'Réseau Île-de-France' })).doesNotExist();
+        });
+      });
+
+      module('when user is super admin', function () {
+        test('it displays a tag with a link to the network', async function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          const network = store.push({
+            data: { id: '42', type: 'network', attributes: { name: 'Réseau Île-de-France' } },
+          });
+          const organization = store.createRecord('organization', { network });
+
+          // when
+          const screen = await render(<template><HeadInformation @organization={{organization}} /></template>);
+
+          // then
+          assert.dom(screen.getByRole('link', { name: 'Réseau Île-de-France' })).exists();
+        });
+      });
+    });
+
+    module('when organization does not belong to a network', function () {
+      test('it does not display a network tag', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const organization = store.createRecord('organization', { type: 'SCO' });
+
+        // when
+        const screen = await render(<template><HeadInformation @organization={{organization}} /></template>);
+
+        // then
+        assert.dom(screen.queryByText(t('components.organizations.head-information.network'))).doesNotExist();
       });
     });
   });

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -805,7 +805,7 @@
         "required-fields-error": "Please fill in all required fields."
       },
       "head-information": {
-        "child-organization": "Child organization of",
+        "child-organization": "Parent:",
         "copy-id": "Copy ID",
         "network": "Network:",
         "parent-organization": "Parent organization"

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -807,6 +807,7 @@
       "head-information": {
         "child-organization": "Child organization of",
         "copy-id": "Copy ID",
+        "network": "Network:",
         "parent-organization": "Parent organization"
       },
       "information-section-view": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -809,6 +809,7 @@
       "head-information": {
         "child-organization": "Organisation fille de",
         "copy-id": "Copier l'ID",
+        "network": "Réseau :",
         "parent-organization": "Organisation mère"
       },
       "information-section-view": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -807,7 +807,7 @@
         "required-fields-error": "Veuillez remplir tous les champs obligatoires."
       },
       "head-information": {
-        "child-organization": "Organisation fille de",
+        "child-organization": "Parent :",
         "copy-id": "Copier l'ID",
         "network": "Réseau :",
         "parent-organization": "Organisation mère"

--- a/api/src/organizational-entities/domain/models/OrganizationForAdmin.js
+++ b/api/src/organizational-entities/domain/models/OrganizationForAdmin.js
@@ -4,6 +4,7 @@ import isEmpty from 'lodash/isEmpty.js';
 
 import { ORGANIZATION_FEATURE } from '../../../shared/domain/constants.js';
 import { DataProtectionOfficer } from './DataProtectionOfficer.js';
+import { Network } from './Network.js';
 
 const PAD_TARGET_LENGTH = 3;
 const PAD_STRING = '0';
@@ -57,6 +58,8 @@ class OrganizationForAdmin {
     organizationLearnerType,
     networkId,
     networkName,
+    networkHeadOrganizationId,
+    networkHeadOrganizationName,
   } = {}) {
     this.id = id;
     this.name = name;
@@ -148,8 +151,16 @@ class OrganizationForAdmin {
     this.code = code;
     this.countryCode = countryCode;
     this.countryName = countryName;
-    this.networkId = networkId;
-    this.networkName = networkName;
+    if (networkId) {
+      this.network = new Network({
+        id: networkId,
+        name: networkName,
+        organizationId: networkHeadOrganizationId,
+        organizationName: networkHeadOrganizationName,
+      });
+    } else {
+      this.network = undefined;
+    }
 
     this.#validate();
   }

--- a/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
@@ -133,6 +133,8 @@ const get = async function ({ organizationId }) {
       organizationLearnerTypeId: 'organization_learner_types.id',
       networkId: 'networks.id',
       networkName: 'networks.name',
+      networkHeadOrganizationId: 'headOrganizations.id',
+      networkHeadOrganizationName: 'headOrganizations.name',
     })
     .leftJoin('users AS archivists', 'archivists.id', 'organizations.archivedBy')
     .leftJoin(
@@ -150,6 +152,10 @@ const get = async function ({ organizationId }) {
     .leftJoin('organizations AS parentOrganizations', 'parentOrganizations.id', 'organizations.parentOrganizationId')
     .leftJoin('fct_structures', 'fct_structures.organization_id', 'organizations.id')
     .leftJoin('networks', 'networks.id', 'fct_structures.network_id')
+    .leftJoin('fct_structures as headFctStructures', function () {
+      this.on('headFctStructures.network_id', 'networks.id').andOnNull('headFctStructures.parent_structure_id');
+    })
+    .leftJoin('organizations AS headOrganizations', 'headOrganizations.id', 'headFctStructures.organization_id')
     .where('organizations.id', organizationId)
     .first();
 
@@ -506,6 +512,8 @@ function _toDomain(rawOrganization) {
     ),
     networkId: rawOrganization.networkId,
     networkName: rawOrganization.networkName,
+    networkHeadOrganizationId: rawOrganization.networkHeadOrganizationId,
+    networkHeadOrganizationName: rawOrganization.networkHeadOrganizationName,
   });
 
   return organization;

--- a/api/src/organizational-entities/infrastructure/serializers/jsonapi/organizations-administration/organization-for-admin.serializer.js
+++ b/api/src/organizational-entities/infrastructure/serializers/jsonapi/organizations-administration/organization-for-admin.serializer.js
@@ -61,9 +61,12 @@ const serialize = function (organizations, meta) {
       'countryName',
       'organizationLearnerTypeId',
       'organizationLearnerTypeName',
-      'networkId',
-      'networkName',
+      'network',
     ],
+    network: {
+      ref: 'id',
+      attributes: ['name', 'headOrganization'],
+    },
     organizationMemberships: {
       ref: 'id',
       ignoreRelationshipData: true,

--- a/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
@@ -695,8 +695,6 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
               'country-name': country.commonName,
               'organization-learner-type-name': organizationLearnerType.name,
               'organization-learner-type-id': organizationLearnerType.id,
-              'network-id': network.id,
-              'network-name': network.name,
               features: {
                 [ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key]: {
                   active: false,
@@ -740,6 +738,12 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
                   },
                 ],
               },
+              network: {
+                data: {
+                  id: network.id.toString(),
+                  type: 'networks',
+                },
+              },
               'target-profile-summaries': {
                 links: {
                   related: `/api/admin/organizations/${organization.id}/target-profile-summaries`,
@@ -761,6 +765,17 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
               },
               id: tag.id.toString(),
               type: 'tags',
+            },
+            {
+              attributes: {
+                name: network.name,
+                'head-organization': {
+                  id: organization.id,
+                  name: organization.name,
+                },
+              },
+              id: network.id.toString(),
+              type: 'networks',
             },
           ],
         });

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/organization-for-admin.repository.test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/organization-for-admin.repository.test.js
@@ -1091,7 +1091,7 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
     });
 
     describe('when the organization belongs to a network', function () {
-      it('should return the network id and name', async function () {
+      it('should return the network with head organization info', async function () {
         // given
         const organization = databaseBuilder.factory.buildOrganization({
           organizationLearnerTypeId: organizationLearnerType.id,
@@ -1111,8 +1111,10 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
         });
 
         // then
-        expect(foundOrganizationForAdmin.networkId).to.equal(network.id);
-        expect(foundOrganizationForAdmin.networkName).to.equal(network.name);
+        expect(foundOrganizationForAdmin.network.id).to.equal(network.id);
+        expect(foundOrganizationForAdmin.network.name).to.equal(network.name);
+        expect(foundOrganizationForAdmin.network.headOrganization.id).to.equal(organization.id);
+        expect(foundOrganizationForAdmin.network.headOrganization.name).to.equal(organization.name);
       });
     });
 

--- a/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/organization-for-admin.serializer.test.js
+++ b/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/organization-for-admin.serializer.test.js
@@ -65,6 +65,8 @@ describe('Unit | Serializer | organization-for-admin-serializer', function () {
         organizationLearnerType: organizationLearnerType,
         networkId: 42,
         networkName: 'Réseau Île-de-France',
+        networkHeadOrganizationId: 99,
+        networkHeadOrganizationName: 'Orga tête de réseau',
       });
       const meta = { some: 'meta' };
 
@@ -108,8 +110,6 @@ describe('Unit | Serializer | organization-for-admin-serializer', function () {
             'country-name': organization.countryName,
             'organization-learner-type-name': organization.organizationLearnerType.name,
             'organization-learner-type-id': organization.organizationLearnerType.id,
-            'network-id': organization.networkId,
-            'network-name': organization.networkName,
           },
           relationships: {
             'organization-memberships': {
@@ -144,6 +144,12 @@ describe('Unit | Serializer | organization-for-admin-serializer', function () {
                 },
               ],
             },
+            network: {
+              data: {
+                id: '42',
+                type: 'networks',
+              },
+            },
           },
         },
         included: [
@@ -162,6 +168,17 @@ describe('Unit | Serializer | organization-for-admin-serializer', function () {
             },
             id: tags[1].id.toString(),
             type: 'tags',
+          },
+          {
+            attributes: {
+              name: 'Réseau Île-de-France',
+              'head-organization': {
+                id: 99,
+                name: 'Orga tête de réseau',
+              },
+            },
+            id: '42',
+            type: 'networks',
           },
         ],
         meta: {

--- a/api/tests/tooling/domain-builder/factory/build-organization-for-admin.js
+++ b/api/tests/tooling/domain-builder/factory/build-organization-for-admin.js
@@ -34,6 +34,10 @@ function buildOrganizationForAdmin({
   countryCode = null,
   countryName = null,
   organizationLearnerType,
+  networkId,
+  networkName,
+  networkHeadOrganizationId,
+  networkHeadOrganizationName,
 } = {}) {
   return new OrganizationForAdmin({
     id,
@@ -69,6 +73,10 @@ function buildOrganizationForAdmin({
     countryCode,
     countryName,
     organizationLearnerType,
+    networkId,
+    networkName,
+    networkHeadOrganizationId,
+    networkHeadOrganizationName,
   });
 }
 


### PR DESCRIPTION
## 🌎 Problème

Lorsque nous accédons à la page de détails d'une organisation, nous ne connaissons pas le réseau auquel elle appartient.

## 🔭 Proposition

Affichage via un tag cliquable dans le header d'une organisation le réseau auquel elle appartient.

## 🪐 Remarques

- On effectue un travail côté JSONAPi pour retourner l'organisation mère d'un réseau.

## 🚀 Pour tester

- Se connecter à PixAdmin
- Allez sur l'onglet organisations
- Aller sur la page de détails d'une orga
- Vérifier qu'un tag ramenant à la page de détails du réseau auquel l'organisation appartient
- Vérifier qu'il n'y ait pas de tag si une organisation n'appartient pas à un réseau
