### PR TITLE
[TECH] Corriger la dropdown des élèves dans Orga

### DIFF
--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-overview-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-overview-repository_test.js
@@ -402,11 +402,11 @@ describe('Integration | Repository | Campaign Participation Overview', function 
       expect(campaignParticipation.get(organizationLearnerId)[0]).instanceOf(CampaignParticipationOverview);
       expect(campaignParticipation.get(organizationLearnerId)[1]).instanceOf(CampaignParticipationOverview);
 
-      expect(campaignParticipation.get(organizationLearnerId).map(({ id }) => id)).to.deep.equal([
+      expect(campaignParticipation.get(organizationLearnerId).map(({ id }) => id)).to.deep.members([
         participationId,
         participationId2,
       ]);
-      expect(campaignParticipation.get(organizationLearnerId2).map(({ id }) => id)).to.deep.equal([participationId3]);
+      expect(campaignParticipation.get(organizationLearnerId2).map(({ id }) => id)).to.deep.members([participationId3]);
       expect(campaignParticipation.get(organizationLearnerWithoutParticipationId)).to.be.undefined;
       expect(campaignParticipation.get(organizationLearnerDeletedId)).to.be.undefined;
     });

--- a/orga/app/components/sco-organization-participant/table-row.gjs
+++ b/orga/app/components/sco-organization-participant/table-row.gjs
@@ -139,8 +139,8 @@ import LastParticipationDateTooltip from '../ui/last-participation-date-tooltip'
     <:cell>{{#if @student.isAssociated}}
         <IconTrigger
           @icon="moreVert"
-          @dropdownButtonClass="organization-participant-list-page__dropdown-button"
-          @dropdownContentClass="organization-participant-list-page__dropdown-content"
+          @dropdownButtonClass="organization-participant__dropdown-button"
+          @dropdownContentClass="organization-participant__dropdown-content"
           @ariaLabel={{t "pages.sco-organization-participants.actions.show-actions"}}
         >
           <Item @onClick={{fn @openAuthenticationMethodModal @student}}>

--- a/orga/app/styles/pages/authenticated/organization-participants/list.scss
+++ b/orga/app/styles/pages/authenticated/organization-participants/list.scss
@@ -52,8 +52,8 @@ $margin-right: 32px;
   }
 
   &__dropdown-content {
-    right: $margin-right;
-    width: 200px;
+    right: 0;
+    width: max-content;
   }
 
   &__tag {

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -499,7 +499,7 @@
           "first-name": "First name",
           "last-name": "Last name"
         },
-        "label": "Udate the participant's name",
+        "label": "Update the participant's name",
         "success-message": "The participant's name has been successfully updated."
       }
     }


### PR DESCRIPTION
## 🌎 Problème

La largeur de la dropdown affichée dans les actions des élèves / étudiant n'est pas bonne (sur plusieurs lignes).

<img width="1419" height="277" alt="image" src="https://github.com/user-attachments/assets/028491c5-80fd-4117-816d-c1591b7b2073" />

## 🔭 Proposition

Afficher les éléments de la dropdown sur une seule ligne pour chaque menu.

<img width="1397" height="246" alt="image" src="https://github.com/user-attachments/assets/10ec0447-e3c6-4003-bf60-f8909d35fe6d" />

Ce n'était pas le bon nom de classe qui était utilisé.

## 🪐 Remarques

**Scouts:** 
- Le libellé anglais de `Update the participant's name` a été corrigé.
- Correction d'un flaky dans l'API

## 🚀 Pour tester

1. Se connecter sur Pix Orga (`orgacces@example.net`)
2. Aller sur la liste des élèves
3. Cliquer sur le menu déroulant