### PR TITLE
[FEATURE] Recherche des réseaux par nom (PIX-21953).

### DIFF
--- a/admin/app/components/networks/list-items.gjs
+++ b/admin/app/components/networks/list-items.gjs
@@ -4,40 +4,51 @@ import PixTable from '@1024pix/pix-ui/components/pix-table';
 import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
 import { fn } from '@ember/helper';
 import { LinkTo } from '@ember/routing';
+import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 
-<template>
-  <PixFilterBanner @title={{t "common.filters.title"}}>
-    <PixInput value={{@name}} oninput={{fn @triggerFiltering "name"}}>
-      <:label>{{t "components.networks.list.filters.name"}}</:label>
-    </PixInput>
-  </PixFilterBanner>
+export default class NetworkListItems extends Component {
+  get isClearFiltersButtonDisabled() {
+    return !this.args.name;
+  }
 
-  {{#if @networks}}
-    <PixTable @variant="admin" @caption={{t "components.networks.list.table.caption"}} @data={{@networks}}>
-      <:columns as |network context|>
-        <PixTableColumn @context={{context}}>
-          <:header>
-            {{t "common.fields.id"}}
-          </:header>
-          <:cell>
-            <LinkTo @route="authenticated.networks.get" @model={{network.id}}>
-              {{network.id}}
-            </LinkTo>
+  <template>
+    <PixFilterBanner
+      @title={{t "common.filters.title"}}
+      @onClearFilters={{@onResetFilter}}
+      @clearFiltersLabel={{t "common.filters.actions.clear"}}
+      @isClearFilterButtonDisabled={{this.isClearFiltersButtonDisabled}}
+    >
+      <PixInput value={{@name}} oninput={{fn @triggerFiltering "name"}}>
+        <:label>{{t "components.networks.list.filters.name"}}</:label>
+      </PixInput>
+    </PixFilterBanner>
 
-          </:cell>
-        </PixTableColumn>
-        <PixTableColumn @context={{context}} class="break-word">
-          <:header>
-            {{t "common.fields.name"}}
-          </:header>
-          <:cell>
-            {{network.name}}
-          </:cell>
-        </PixTableColumn>
-      </:columns>
-    </PixTable>
-  {{else}}
-    <div class="table__empty">{{t "common.tables.empty-result"}}</div>
-  {{/if}}
-</template>
+    {{#if @networks}}
+      <PixTable @variant="admin" @caption={{t "components.networks.list.table.caption"}} @data={{@networks}}>
+        <:columns as |network context|>
+          <PixTableColumn @context={{context}}>
+            <:header>
+              {{t "common.fields.id"}}
+            </:header>
+            <:cell>
+              <LinkTo @route="authenticated.networks.get" @model={{network.id}}>
+                {{network.id}}
+              </LinkTo>
+            </:cell>
+          </PixTableColumn>
+          <PixTableColumn @context={{context}} class="break-word">
+            <:header>
+              {{t "common.fields.name"}}
+            </:header>
+            <:cell>
+              {{network.name}}
+            </:cell>
+          </PixTableColumn>
+        </:columns>
+      </PixTable>
+    {{else}}
+      <div class="table__empty">{{t "common.tables.empty-result"}}</div>
+    {{/if}}
+  </template>
+}

--- a/admin/app/components/networks/list-items.gjs
+++ b/admin/app/components/networks/list-items.gjs
@@ -1,9 +1,18 @@
+import PixFilterBanner from '@1024pix/pix-ui/components/pix-filter-banner';
+import PixInput from '@1024pix/pix-ui/components/pix-input';
 import PixTable from '@1024pix/pix-ui/components/pix-table';
 import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import { fn } from '@ember/helper';
 import { LinkTo } from '@ember/routing';
 import { t } from 'ember-intl';
 
 <template>
+  <PixFilterBanner @title={{t "common.filters.title"}}>
+    <PixInput value={{@name}} oninput={{fn @triggerFiltering "name"}}>
+      <:label>{{t "components.networks.list.filters.name"}}</:label>
+    </PixInput>
+  </PixFilterBanner>
+
   {{#if @networks}}
     <PixTable @variant="admin" @caption={{t "components.networks.list.table.caption"}} @data={{@networks}}>
       <:columns as |network context|>

--- a/admin/app/controllers/authenticated/networks/list.js
+++ b/admin/app/controllers/authenticated/networks/list.js
@@ -1,0 +1,23 @@
+import Controller from '@ember/controller';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+import { debounceTask } from 'ember-lifeline';
+import config from 'pix-admin/config/environment';
+
+export default class NetworkListController extends Controller {
+  queryParams = ['name'];
+  DEBOUNCE_MS = config.pagination.debounce;
+
+  @tracked name = null;
+
+  _updateFilter(filters) {
+    for (const key of Object.keys(filters)) {
+      this[key] = filters[key] || null;
+    }
+  }
+
+  @action
+  triggerFiltering(fieldName, event) {
+    debounceTask(this, '_updateFilter', { [fieldName]: event.target.value }, this.DEBOUNCE_MS);
+  }
+}

--- a/admin/app/controllers/authenticated/networks/list.js
+++ b/admin/app/controllers/authenticated/networks/list.js
@@ -20,4 +20,9 @@ export default class NetworkListController extends Controller {
   triggerFiltering(fieldName, event) {
     debounceTask(this, '_updateFilter', { [fieldName]: event.target.value }, this.DEBOUNCE_MS);
   }
+
+  @action
+  onResetFilter() {
+    this.name = null;
+  }
 }

--- a/admin/app/routes/authenticated/networks/list.js
+++ b/admin/app/routes/authenticated/networks/list.js
@@ -5,11 +5,24 @@ export default class ListRoute extends Route {
   @service accessControl;
   @service store;
 
+  queryParams = {
+    name: { refreshModel: true },
+  };
+
   beforeModel() {
     this.accessControl.restrictAccessTo(['isSuperAdmin'], 'authenticated');
   }
 
-  model() {
+  model(params) {
+    if (params.name) {
+      return this.store.query('network', { filter: { name: params.name.trim() } });
+    }
     return this.store.findAll('network');
+  }
+
+  resetController(controller, isExiting) {
+    if (isExiting) {
+      controller.name = null;
+    }
   }
 }

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -68,6 +68,7 @@
 @use 'components/organization-information-section' as *;
 @use 'components/organization-invitations' as *;
 @use 'components/organization-team-section' as *;
+@use 'components/networks/list-items' as *;
 @use 'components/organizations/all-tags' as *;
 @use 'components/organizations/archiving-confirmation-modal' as *;
 @use 'components/organizations/children/attach-child-form' as *;

--- a/admin/app/styles/components/networks/list-items.scss
+++ b/admin/app/styles/components/networks/list-items.scss
@@ -1,0 +1,5 @@
+.networks-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pix-spacing-4x);
+}

--- a/admin/app/templates/authenticated/networks/list.gjs
+++ b/admin/app/templates/authenticated/networks/list.gjs
@@ -15,8 +15,8 @@ import ListItems from 'pix-admin/components/networks/list-items';
   </header>
 
   <main class="page-body">
-    <section class="page-section">
-      <ListItems @networks={{@model}} />
+    <section class="page-section networks-list">
+      <ListItems @networks={{@model}} @name={{@controller.name}} @triggerFiltering={{@controller.triggerFiltering}} />
     </section>
   </main>
 </template>

--- a/admin/app/templates/authenticated/networks/list.gjs
+++ b/admin/app/templates/authenticated/networks/list.gjs
@@ -16,7 +16,12 @@ import ListItems from 'pix-admin/components/networks/list-items';
 
   <main class="page-body">
     <section class="page-section networks-list">
-      <ListItems @networks={{@model}} @name={{@controller.name}} @triggerFiltering={{@controller.triggerFiltering}} />
+      <ListItems
+        @networks={{@model}}
+        @name={{@controller.name}}
+        @triggerFiltering={{@controller.triggerFiltering}}
+        @onResetFilter={{@controller.onResetFilter}}
+      />
     </section>
   </main>
 </template>

--- a/admin/tests/acceptance/authenticated/networks/list-test.js
+++ b/admin/tests/acceptance/authenticated/networks/list-test.js
@@ -79,6 +79,21 @@ module('Acceptance | Networks | List', function (hooks) {
         assert.dom(screen.queryByText('Autre réseau')).doesNotExist();
       });
 
+      test('it should reset the name filter when clicking the clear filters button', async function (assert) {
+        // given
+        server.create('network', { id: 1, name: 'Réseau Bretagne' });
+        server.create('network', { id: 2, name: 'Autre réseau' });
+
+        const screen = await visit('/networks/list');
+        await fillByLabel(t('components.networks.list.filters.name'), 'Bretagne');
+
+        // when
+        await click(screen.getByRole('button', { name: t('common.filters.actions.clear') }));
+
+        // then
+        assert.dom(screen.getByRole('textbox', { name: t('components.networks.list.filters.name') })).hasValue('');
+      });
+
       test('it should redirect to network get page when clicking on the ID', async function (assert) {
         // given
         server.create('network', { id: 1, name: 'Réseau Alpha' });

--- a/admin/tests/acceptance/authenticated/networks/list-test.js
+++ b/admin/tests/acceptance/authenticated/networks/list-test.js
@@ -1,4 +1,4 @@
-import { screen, visit } from '@1024pix/ember-testing-library';
+import { fillByLabel, screen, visit } from '@1024pix/ember-testing-library';
 import { click, currentURL } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import { setupApplicationTest } from 'ember-qunit';
@@ -62,6 +62,21 @@ module('Acceptance | Networks | List', function (hooks) {
         assert.dom(table).exists();
         assert.dom(screen.getByText('Réseau Alpha')).exists();
         assert.dom(screen.getByText('Réseau Beta')).exists();
+      });
+
+      test('it should filter networks by name when typing in the search field', async function (assert) {
+        // given
+        server.create('network', { id: 1, name: 'Réseau Bretagne' });
+        server.create('network', { id: 2, name: 'Autre réseau' });
+
+        await visit('/networks/list');
+
+        // when
+        await fillByLabel(t('components.networks.list.filters.name'), 'Bretagne');
+
+        // then
+        assert.dom(screen.getByText('Réseau Bretagne')).exists();
+        assert.dom(screen.queryByText('Autre réseau')).doesNotExist();
       });
 
       test('it should redirect to network get page when clicking on the ID', async function (assert) {

--- a/admin/tests/integration/components/networks/list-items-test.gjs
+++ b/admin/tests/integration/components/networks/list-items-test.gjs
@@ -2,11 +2,30 @@ import { render, within } from '@1024pix/ember-testing-library';
 import { t } from 'ember-intl/test-support';
 import ListItems from 'pix-admin/components/networks/list-items';
 import { module, test } from 'qunit';
+import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | Networks | ListItems', function (hooks) {
   setupIntlRenderingTest(hooks);
+
+  module('filter banner', function () {
+    test('it renders a name filter input', async function (assert) {
+      // given
+      const triggerFiltering = sinon.stub();
+      const networks = [];
+      const name = 'réseau';
+
+      // when
+      const screen = await render(
+        <template><ListItems @networks={{networks}} @name={{name}} @triggerFiltering={{triggerFiltering}} /></template>,
+      );
+
+      // then
+      assert.dom(screen.getByRole('textbox', { name: t('components.networks.list.filters.name') })).exists();
+      assert.dom(screen.getByRole('textbox', { name: t('components.networks.list.filters.name') })).hasValue('réseau');
+    });
+  });
 
   module('when there are networks', function () {
     test('it renders a table with networks IDs and name', async function (assert) {

--- a/admin/tests/integration/components/networks/list-items-test.gjs
+++ b/admin/tests/integration/components/networks/list-items-test.gjs
@@ -25,6 +25,38 @@ module('Integration | Component | Networks | ListItems', function (hooks) {
       assert.dom(screen.getByRole('textbox', { name: t('components.networks.list.filters.name') })).exists();
       assert.dom(screen.getByRole('textbox', { name: t('components.networks.list.filters.name') })).hasValue('réseau');
     });
+
+    test('the clear filters button is disabled when no filter is active', async function (assert) {
+      // given
+      const networks = [];
+      const name = null;
+      const triggerFiltering = sinon.stub();
+
+      // when
+      const screen = await render(
+        <template><ListItems @networks={{networks}} @name={{name}} @triggerFiltering={{triggerFiltering}} /></template>,
+      );
+
+      // then
+      assert.dom(screen.getByRole('button', { name: t('common.filters.actions.clear') })).hasAttribute('aria-disabled');
+    });
+
+    test('the clear filters button is enabled when a filter is active', async function (assert) {
+      // given
+      const networks = [];
+      const name = 'réseau';
+      const triggerFiltering = sinon.stub();
+
+      // when
+      const screen = await render(
+        <template><ListItems @networks={{networks}} @name={{name}} @triggerFiltering={{triggerFiltering}} /></template>,
+      );
+
+      // then
+      assert
+        .dom(screen.getByRole('button', { name: t('common.filters.actions.clear') }))
+        .doesNotHaveAttribute('aria-disabled');
+    });
   });
 
   module('when there are networks', function () {

--- a/admin/tests/mirage/handlers/networks.js
+++ b/admin/tests/mirage/handlers/networks.js
@@ -6,3 +6,12 @@ export function createNetwork(schema, request) {
     organizationId: params.data.attributes['organization-id'],
   });
 }
+
+export function findAllFilteredNetworks(schema, request) {
+  const name = request.queryParams['filter[name]'];
+  let networks = schema.networks.all().models;
+  if (name) {
+    networks = networks.filter((network) => network.name.toLowerCase().includes(name.toLowerCase()));
+  }
+  return { data: networks.map((n) => ({ id: n.id, type: 'networks', attributes: { name: n.name } })) };
+}

--- a/admin/tests/mirage/routes.js
+++ b/admin/tests/mirage/routes.js
@@ -18,7 +18,7 @@ import { findFrameworkAreas } from './handlers/frameworks';
 import { getPaginatedJuryCertificationSummariesBySessionId } from './handlers/get-jury-certification-summaries-by-session-id';
 import { getToBePublishedSessions } from './handlers/get-to-be-published-sessions';
 import { getWithRequiredActionSessions } from './handlers/get-with-required-action-sessions';
-import { createNetwork } from './handlers/networks';
+import { createNetwork, findAllFilteredNetworks } from './handlers/networks';
 import { createOrganizationMembership } from './handlers/organization-memberships';
 import {
   archiveOrganization,
@@ -368,7 +368,7 @@ export default function routes() {
     return organizationMembership.update({ disabledAt: new Date() });
   });
 
-  this.get('/admin/networks');
+  this.get('/admin/networks', findAllFilteredNetworks);
   this.get('/admin/networks/:id');
   this.post('/admin/networks', createNetwork);
 

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -641,6 +641,9 @@
         "head-organization-id": "ID of the head organisation"
       },
       "list": {
+        "filters": {
+          "name": "Network name"
+        },
         "table": {
           "caption": "List of networks. Contains the name and ID."
         }

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -643,6 +643,9 @@
         "head-organization-id": "ID de l'organisation tête de réseau"
       },
       "list": {
+        "filters": {
+          "name": "Nom du réseau"
+        },
         "table": {
           "caption": "Liste des réseaux. Contient le nom et l'ID."
         }

--- a/api/src/organizational-entities/application/network/network.admin.controller.js
+++ b/api/src/organizational-entities/application/network/network.admin.controller.js
@@ -1,9 +1,9 @@
 import { usecases } from '../../domain/usecases/index.js';
 import * as networkSerializer from '../../infrastructure/serializers/jsonapi/network/network.serializer.js';
 
-const findAllNetworks = async function (request, h, dependencies = { networkSerializer }) {
+const findAllFilteredNetworks = async function (request, h, dependencies = { networkSerializer }) {
   const { filter } = request.query;
-  const networks = await usecases.findAllNetworks({ filter });
+  const networks = await usecases.findAllFilteredNetworks({ filter });
   return dependencies.networkSerializer.serialize(networks);
 };
 
@@ -30,7 +30,7 @@ const create = async function (request, h, dependencies = { networkSerializer })
 
 const networkAdminController = {
   create,
-  findAllNetworks,
+  findAllFilteredNetworks,
   getNetworkDetails,
 };
 

--- a/api/src/organizational-entities/application/network/network.admin.controller.js
+++ b/api/src/organizational-entities/application/network/network.admin.controller.js
@@ -2,7 +2,8 @@ import { usecases } from '../../domain/usecases/index.js';
 import * as networkSerializer from '../../infrastructure/serializers/jsonapi/network/network.serializer.js';
 
 const findAllNetworks = async function (request, h, dependencies = { networkSerializer }) {
-  const networks = await usecases.findAllNetworks();
+  const { filter } = request.query;
+  const networks = await usecases.findAllNetworks({ filter });
   return dependencies.networkSerializer.serialize(networks);
 };
 

--- a/api/src/organizational-entities/application/network/network.admin.route.js
+++ b/api/src/organizational-entities/application/network/network.admin.route.js
@@ -34,7 +34,7 @@ const register = async function (server) {
             return sendJsonApiError(new BadRequestError('Un des champs de recherche saisis est invalide.'), h);
           },
         },
-        handler: networkAdminController.findAllNetworks,
+        handler: networkAdminController.findAllFilteredNetworks,
         notes: [
           "- **Cette route est restreinte aux utilisateurs ayant les droits d'accès Superadmin**\n" +
             '- Renvoie les réseaux, filtrés par nom si le paramètre filter[name] est fourni.',

--- a/api/src/organizational-entities/application/network/network.admin.route.js
+++ b/api/src/organizational-entities/application/network/network.admin.route.js
@@ -1,5 +1,6 @@
 import Joi from 'joi';
 
+import { BadRequestError, sendJsonApiError } from '../../../shared/application/http-errors.js';
 import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
 import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
 import { networkAdminController } from './network.admin.controller.js';
@@ -20,10 +21,23 @@ const register = async function (server) {
             assign: 'hasAuthorizationToAccessAdminScope',
           },
         ],
+        validate: {
+          options: {
+            allowUnknown: true,
+          },
+          query: Joi.object({
+            filter: Joi.object({
+              name: Joi.string().empty('').allow(null).optional(),
+            }).default({}),
+          }),
+          failAction: (request, h) => {
+            return sendJsonApiError(new BadRequestError('Un des champs de recherche saisis est invalide.'), h);
+          },
+        },
         handler: networkAdminController.findAllNetworks,
         notes: [
           "- **Cette route est restreinte aux utilisateurs ayant les droits d'accès Superadmin**\n" +
-            '- Renvoie tous les réseaux.',
+            '- Renvoie les réseaux, filtrés par nom si le paramètre filter[name] est fourni.',
         ],
         tags: ['api', 'organizational-entities', 'network'],
       },

--- a/api/src/organizational-entities/domain/usecases/find-all-filtered-networks.usecase.js
+++ b/api/src/organizational-entities/domain/usecases/find-all-filtered-networks.usecase.js
@@ -5,8 +5,8 @@
  * @param {NetworkRepository} params.networkRepository
  * @returns {Promise<Array<Network>>}
  */
-const findAllNetworks = async function ({ filter, networkRepository }) {
+const findAllFilteredNetworks = async function ({ filter, networkRepository }) {
   return networkRepository.findAll({ filter });
 };
 
-export { findAllNetworks };
+export { findAllFilteredNetworks };

--- a/api/src/organizational-entities/domain/usecases/find-all-networks.usecase.js
+++ b/api/src/organizational-entities/domain/usecases/find-all-networks.usecase.js
@@ -1,10 +1,12 @@
 /**
  * @param {object} params
+ * @param {object} [params.filter]
+ * @param {string} [params.filter.name]
  * @param {NetworkRepository} params.networkRepository
  * @returns {Promise<Array<Network>>}
  */
-const findAllNetworks = async function ({ networkRepository }) {
-  return networkRepository.findAll();
+const findAllNetworks = async function ({ filter, networkRepository }) {
+  return networkRepository.findAll({ filter });
 };
 
 export { findAllNetworks };

--- a/api/src/organizational-entities/domain/usecases/index.js
+++ b/api/src/organizational-entities/domain/usecases/index.js
@@ -95,7 +95,7 @@ import { createOrganizationsWithTagsAndTargetProfiles } from './create-organizat
 import { createTag } from './create-tag.js';
 import { detachParentOrganizationFromOrganization } from './detach-parent-organization-from-organization.usecase.js';
 import { findAllAdministrationTeams } from './find-all-administration-teams.usecase.js';
-import { findAllNetworks } from './find-all-networks.usecase.js';
+import { findAllFilteredNetworks } from './find-all-filtered-networks.usecase.js';
 import { findAllOrganizationLearnerTypes } from './find-all-organization-learner-types.refactor.js';
 import { findAllTags } from './find-all-tags.usecase.js';
 import { findChildrenOrganizations } from './find-children-organizations.usecase.js';
@@ -127,7 +127,7 @@ const usecasesWithoutInjectedDependencies = {
   createOrganizationsWithTagsAndTargetProfiles,
   createTag,
   detachParentOrganizationFromOrganization,
-  findAllNetworks,
+  findAllFilteredNetworks,
   findAllTags,
   findChildrenOrganizations,
   findOrganizationFeatures,
@@ -159,7 +159,7 @@ const usecasesWithoutInjectedDependencies = {
  * @property {updateOrganizationsInBatch} updateOrganizationsInBatch
  * @property {updateOrganizationInformation} updateOrganizationInformation
  * @property {archiveOrganizationsInBatch} archiveOrganizationsInBatch
- * @property {findAllNetworks} findAllNetworks
+ * @property {findAllFilteredNetworks} findAllFilteredNetworks
  */
 
 /**

--- a/api/src/organizational-entities/infrastructure/repositories/network.repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/network.repository.js
@@ -3,13 +3,30 @@ import { NotFoundError } from '../../../shared/domain/errors.js';
 import { Network } from '../../domain/models/Network.js';
 
 /**
- *
+ * @param {object} [params]
+ * @param {object} [params.filter]
+ * @param {string} [params.filter.name]
  * @returns {Promise<Array<Network>>}
  */
-async function findAll() {
+async function findAll({ filter } = {}) {
   const knexConn = DomainTransaction.getConnection();
 
-  const networks = await knexConn('networks').select('networks.id', 'networks.name').orderBy('name');
+  const query = knexConn('networks').select('networks.id', 'networks.name').orderBy('name');
+
+  if (filter?.name) {
+    query.where(
+      knexConn.raw(
+        `
+      regexp_replace(unaccent(networks.name), '[^[:alnum:]]', '', 'g')
+      ILIKE
+      '%' || regexp_replace(unaccent(?), '[^[:alnum:]]', '', 'g') || '%'
+      `,
+        [filter.name],
+      ),
+    );
+  }
+
+  const networks = await query;
 
   return networks.map(_toDomain);
 }

--- a/api/tests/organizational-entities/acceptance/application/network/network.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/network/network.admin.route.test.js
@@ -93,6 +93,30 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | N
     });
   });
 
+  describe('GET /api/admin/networks with filter', function () {
+    it('returns filtered networks by name with 200 HTTP status code', async function () {
+      // given
+      const matchingNetwork = databaseBuilder.factory.buildNetwork({ name: 'Réseau Bretagne' });
+      databaseBuilder.factory.buildNetwork({ name: 'Autre réseau' });
+      await databaseBuilder.commit();
+
+      const options = {
+        method: 'GET',
+        url: '/api/admin/networks?filter[name]=Bretagne',
+        headers: generateAuthenticatedUserRequestHeaders(superAdmin),
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result.data).to.have.lengthOf(1);
+      expect(response.result.data[0].id).to.equal(matchingNetwork.id.toString());
+      expect(response.result.data[0].attributes.name).to.equal(matchingNetwork.name);
+    });
+  });
+
   describe('POST /api/admin/networks', function () {
     it('creates a new network', async function () {
       // given

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/network.repository.test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/network.repository.test.js
@@ -41,6 +41,55 @@ describe('Integration | Organizational Entities | Infrastructure | Repositories 
         expect(foundNetworks).to.be.empty;
       });
     });
+
+    describe('when a filter name is provided', function () {
+      it('returns matching networks ordered by name', async function () {
+        // given
+        const matchingNetwork1 = databaseBuilder.factory.buildNetwork({ name: 'Réseau Bretagne' });
+        const matchingNetwork2 = databaseBuilder.factory.buildNetwork({ name: 'Réseau Alsace' });
+        databaseBuilder.factory.buildNetwork({ name: 'Autre' });
+        await databaseBuilder.commit();
+
+        // when
+        const foundNetworks = await networkRepository.findAll({ filter: { name: 'Réseau' } });
+
+        // then
+        expect(foundNetworks).to.have.lengthOf(2);
+        expect(foundNetworks[0]).to.deepEqualInstance(
+          domainBuilder.acquisition.buildNetwork({ id: matchingNetwork2.id, name: matchingNetwork2.name }),
+        );
+        expect(foundNetworks[1]).to.deepEqualInstance(
+          domainBuilder.acquisition.buildNetwork({ id: matchingNetwork1.id, name: matchingNetwork1.name }),
+        );
+      });
+
+      it('filters case-insensitively', async function () {
+        // given
+        const network = databaseBuilder.factory.buildNetwork({ name: 'Réseau National' });
+        await databaseBuilder.commit();
+
+        // when
+        const foundNetworks = await networkRepository.findAll({ filter: { name: 'réseau national' } });
+
+        // then
+        expect(foundNetworks).to.have.lengthOf(1);
+        expect(foundNetworks[0]).to.deepEqualInstance(
+          domainBuilder.acquisition.buildNetwork({ id: network.id, name: network.name }),
+        );
+      });
+
+      it('returns an empty array when no network matches', async function () {
+        // given
+        databaseBuilder.factory.buildNetwork({ name: 'Réseau Bretagne' });
+        await databaseBuilder.commit();
+
+        // when
+        const foundNetworks = await networkRepository.findAll({ filter: { name: 'Introuvable' } });
+
+        // then
+        expect(foundNetworks).to.be.empty;
+      });
+    });
   });
 
   describe('#getById', function () {

--- a/api/tests/organizational-entities/unit/application/network/network.admin.controller.test.js
+++ b/api/tests/organizational-entities/unit/application/network/network.admin.controller.test.js
@@ -3,37 +3,37 @@ import { usecases } from '../../../../../src/organizational-entities/domain/usec
 import { domainBuilder, expect, hFake, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Organizational Entities | Application | Network', function () {
-  describe('#findAllNetworks', function () {
-    it('calls findAllNetworks usecase with empty filter and serializes the result', async function () {
+  describe('#findAllFilteredNetworks', function () {
+    it('calls findAllFilteredNetworks usecase with empty filter and serializes the result', async function () {
       // given
       const network1 = domainBuilder.acquisition.buildNetwork({ id: 1, name: 'Network 1' });
       const network2 = domainBuilder.acquisition.buildNetwork({ id: 2, name: 'Network 2' });
       const networks = [network1, network2];
-      sinon.stub(usecases, 'findAllNetworks').resolves(networks);
+      sinon.stub(usecases, 'findAllFilteredNetworks').resolves(networks);
       const networkSerializer = { serialize: sinon.stub() };
       const request = { query: { filter: {} } };
 
       // when
-      await networkAdminController.findAllNetworks(request, hFake, { networkSerializer });
+      await networkAdminController.findAllFilteredNetworks(request, hFake, { networkSerializer });
 
       // then
-      expect(usecases.findAllNetworks).to.have.been.calledOnceWith({ filter: {} });
+      expect(usecases.findAllFilteredNetworks).to.have.been.calledOnceWith({ filter: {} });
       expect(networkSerializer.serialize).to.have.been.calledWithExactly(networks);
     });
 
-    it('calls findAllNetworks usecase with filter and serializes the result', async function () {
+    it('calls findAllFilteredNetworks usecase with filter and serializes the result', async function () {
       // given
       const network1 = domainBuilder.acquisition.buildNetwork({ id: 1, name: 'Mon réseau' });
       const networks = [network1];
-      sinon.stub(usecases, 'findAllNetworks').resolves(networks);
+      sinon.stub(usecases, 'findAllFilteredNetworks').resolves(networks);
       const networkSerializer = { serialize: sinon.stub() };
       const request = { query: { filter: { name: 'Mon' } } };
 
       // when
-      await networkAdminController.findAllNetworks(request, hFake, { networkSerializer });
+      await networkAdminController.findAllFilteredNetworks(request, hFake, { networkSerializer });
 
       // then
-      expect(usecases.findAllNetworks).to.have.been.calledOnceWith({ filter: { name: 'Mon' } });
+      expect(usecases.findAllFilteredNetworks).to.have.been.calledOnceWith({ filter: { name: 'Mon' } });
       expect(networkSerializer.serialize).to.have.been.calledWithExactly(networks);
     });
   });

--- a/api/tests/organizational-entities/unit/application/network/network.admin.controller.test.js
+++ b/api/tests/organizational-entities/unit/application/network/network.admin.controller.test.js
@@ -4,19 +4,36 @@ import { domainBuilder, expect, hFake, sinon } from '../../../../test-helper.js'
 
 describe('Unit | Organizational Entities | Application | Network', function () {
   describe('#findAllNetworks', function () {
-    it('calls findAllNetworks usecase and Network serializer', async function () {
+    it('calls findAllNetworks usecase with empty filter and serializes the result', async function () {
       // given
       const network1 = domainBuilder.acquisition.buildNetwork({ id: 1, name: 'Network 1' });
       const network2 = domainBuilder.acquisition.buildNetwork({ id: 2, name: 'Network 2' });
       const networks = [network1, network2];
       sinon.stub(usecases, 'findAllNetworks').resolves(networks);
       const networkSerializer = { serialize: sinon.stub() };
+      const request = { query: { filter: {} } };
 
       // when
-      await networkAdminController.findAllNetworks({}, hFake, { networkSerializer });
+      await networkAdminController.findAllNetworks(request, hFake, { networkSerializer });
 
       // then
-      expect(usecases.findAllNetworks).to.have.been.calledOnce;
+      expect(usecases.findAllNetworks).to.have.been.calledOnceWith({ filter: {} });
+      expect(networkSerializer.serialize).to.have.been.calledWithExactly(networks);
+    });
+
+    it('calls findAllNetworks usecase with filter and serializes the result', async function () {
+      // given
+      const network1 = domainBuilder.acquisition.buildNetwork({ id: 1, name: 'Mon réseau' });
+      const networks = [network1];
+      sinon.stub(usecases, 'findAllNetworks').resolves(networks);
+      const networkSerializer = { serialize: sinon.stub() };
+      const request = { query: { filter: { name: 'Mon' } } };
+
+      // when
+      await networkAdminController.findAllNetworks(request, hFake, { networkSerializer });
+
+      // then
+      expect(usecases.findAllNetworks).to.have.been.calledOnceWith({ filter: { name: 'Mon' } });
       expect(networkSerializer.serialize).to.have.been.calledWithExactly(networks);
     });
   });

--- a/api/tests/organizational-entities/unit/application/network/network.admin.route.test.js
+++ b/api/tests/organizational-entities/unit/application/network/network.admin.route.test.js
@@ -7,7 +7,7 @@ import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
 describe('Unit | Application | Admin | Route | Network', function () {
   describe('GET /api/admin/networks', function () {
     describe('when the authenticated user has super admin role', function () {
-      it('should call findAllNetworks controller method', async function () {
+      it('should call findAllNetworks controller method without filter', async function () {
         // given
         sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
         sinon.stub(usecases, 'findAllNetworks').returns('ok');
@@ -18,6 +18,21 @@ describe('Unit | Application | Admin | Route | Network', function () {
 
         // when
         await httpTestServer.request('GET', '/api/admin/networks', {});
+
+        // then
+        sinon.assert.called(networkAdminController.findAllNetworks);
+      });
+
+      it('should call findAllNetworks controller method with filter', async function () {
+        // given
+        sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
+        sinon.stub(networkAdminController, 'findAllNetworks').returns('ok');
+
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        await httpTestServer.request('GET', '/api/admin/networks?filter[name]=réseau', {});
 
         // then
         sinon.assert.called(networkAdminController.findAllNetworks);

--- a/api/tests/organizational-entities/unit/application/network/network.admin.route.test.js
+++ b/api/tests/organizational-entities/unit/application/network/network.admin.route.test.js
@@ -7,11 +7,11 @@ import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
 describe('Unit | Application | Admin | Route | Network', function () {
   describe('GET /api/admin/networks', function () {
     describe('when the authenticated user has super admin role', function () {
-      it('should call findAllNetworks controller method without filter', async function () {
+      it('should call findAllFilteredNetworks controller method without filter', async function () {
         // given
         sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
-        sinon.stub(usecases, 'findAllNetworks').returns('ok');
-        sinon.stub(networkAdminController, 'findAllNetworks').returns('ok');
+        sinon.stub(usecases, 'findAllFilteredNetworks').returns('ok');
+        sinon.stub(networkAdminController, 'findAllFilteredNetworks').returns('ok');
 
         const httpTestServer = new HttpTestServer();
         await httpTestServer.register(moduleUnderTest);
@@ -20,13 +20,13 @@ describe('Unit | Application | Admin | Route | Network', function () {
         await httpTestServer.request('GET', '/api/admin/networks', {});
 
         // then
-        sinon.assert.called(networkAdminController.findAllNetworks);
+        sinon.assert.called(networkAdminController.findAllFilteredNetworks);
       });
 
-      it('should call findAllNetworks controller method with filter', async function () {
+      it('should call findAllFilteredNetworks controller method with filter', async function () {
         // given
         sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
-        sinon.stub(networkAdminController, 'findAllNetworks').returns('ok');
+        sinon.stub(networkAdminController, 'findAllFilteredNetworks').returns('ok');
 
         const httpTestServer = new HttpTestServer();
         await httpTestServer.register(moduleUnderTest);
@@ -35,7 +35,7 @@ describe('Unit | Application | Admin | Route | Network', function () {
         await httpTestServer.request('GET', '/api/admin/networks?filter[name]=réseau', {});
 
         // then
-        sinon.assert.called(networkAdminController.findAllNetworks);
+        sinon.assert.called(networkAdminController.findAllFilteredNetworks);
       });
     });
 
@@ -45,7 +45,7 @@ describe('Unit | Application | Admin | Route | Network', function () {
         sinon
           .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
           .returns((request, h) => h.response().code(403).takeover());
-        sinon.stub(networkAdminController, 'findAllNetworks').returns('ok');
+        sinon.stub(networkAdminController, 'findAllFilteredNetworks').returns('ok');
         const httpTestServer = new HttpTestServer();
         await httpTestServer.register(moduleUnderTest);
 
@@ -54,7 +54,7 @@ describe('Unit | Application | Admin | Route | Network', function () {
 
         // then
         expect(response.statusCode).to.equal(403);
-        sinon.assert.notCalled(networkAdminController.findAllNetworks);
+        sinon.assert.notCalled(networkAdminController.findAllFilteredNetworks);
       });
     });
   });


### PR DESCRIPTION
## 🌎 Problème

Nous ne pouvons pas rechercher des réseaux par nom, ce qui posera problème lorsqu'il y en aura beaucoup.

## 🔭 Proposition

Ajout de la recherche par nom.

## 🪐 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🚀 Pour tester

- Se connecter à PixAdmin
- Aller sur la page des réseaux
- Chercher un ou des réseaux par nom
- Vérifier que la remise à zéro des filtres fonctionne
