### PR TITLE
[FEATURE] Remonter le référentiel Pix par défaut dans la sélection de sujet (PIX-21935)

### DIFF
--- a/api/src/prescription/shared/infrastructure/repositories/learning-content-repository.js
+++ b/api/src/prescription/shared/infrastructure/repositories/learning-content-repository.js
@@ -2,6 +2,7 @@ import _ from 'lodash';
 
 import * as learningContentConversionService from '../../../../../lib/domain/services/learning-content/learning-content-conversion-service.js';
 import * as campaignRepository from '../../../../prescription/campaign/infrastructure/repositories/campaign-repository.js';
+import { PIX_ORIGIN } from '../../../../shared/domain/constants.js';
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { NoSkillsInCampaignError, NotFoundError } from '../../../../shared/domain/errors.js';
 import { CampaignLearningContent } from '../../../../shared/domain/models/CampaignLearningContent.js';
@@ -45,27 +46,30 @@ export async function findByTargetProfileId(targetProfileId, locale) {
 
 export async function findByOrganizationId({ organizationId, locale }) {
   const knexConn = DomainTransaction.getConnection();
-  const tubesWithLevel = await knexConn('target-profile-shares')
+  const tubesIdsFromTargetProfile = await knexConn('target-profile-shares')
     .join('target-profile_tubes', 'target-profile_tubes.targetProfileId', '=', 'target-profile-shares.targetProfileId')
     .select({ id: 'tubeId' })
     .where({ organizationId })
-    .groupBy('tubeId');
+    .pluck('tubeId');
 
-  if (tubesWithLevel.length === 0) {
+  const pixCompetences = await competenceRepository.listPixCompetencesOnly({ locale });
+  const pixCompetenceIds = pixCompetences.map(({ id: competenceId }) => competenceId);
+
+  const thematics = await thematicRepository.findByCompetenceIds(pixCompetenceIds, locale);
+
+  const tubeIds = thematics.flatMap((thematic) => thematic.tubeIds).concat(tubesIdsFromTargetProfile);
+
+  const tubes = await tubeRepository.findActiveByRecordIds(tubeIds, locale);
+
+  if (tubes.length === 0) {
     return [];
   }
-
-  const allTubes = await tubeRepository.findByRecordIds(
-    tubesWithLevel.map((dto) => dto.id),
-    locale,
-  );
-  const tubes = allTubes.filter((tube) => tube.practicalTitle);
 
   const frameworks = await _getLearningContentByTubes(tubes, locale);
 
   return frameworks.sort((frameworkA, frameworkB) => {
-    if (frameworkA.name === 'Pix') return -1;
-    if (frameworkB.name === 'Pix') return 1;
+    if (frameworkA.name === PIX_ORIGIN) return -1;
+    if (frameworkB.name === PIX_ORIGIN) return 1;
     return frameworkA.name.localeCompare(frameworkB.name);
   });
 }

--- a/api/tests/prescription/shared/integration/infrastructure/repositories/learning-content-repository_test.js
+++ b/api/tests/prescription/shared/integration/infrastructure/repositories/learning-content-repository_test.js
@@ -1,4 +1,5 @@
 import * as learningContentRepository from '../../../../../../src/prescription/shared/infrastructure/repositories/learning-content-repository.js';
+import { PIX_ORIGIN } from '../../../../../../src/shared/domain/constants.js';
 import { NoSkillsInCampaignError, NotFoundError } from '../../../../../../src/shared/domain/errors.js';
 import { catchErr, databaseBuilder, domainBuilder, expect } from '../../../../../test-helper.js';
 
@@ -13,7 +14,7 @@ describe('Integration | Repository | learning-content', function () {
   beforeEach(async function () {
     const framework1DB = databaseBuilder.factory.learningContent.buildFramework({
       id: 'recFramework1',
-      name: 'Pix',
+      name: PIX_ORIGIN,
     });
     const framework2DB = databaseBuilder.factory.learningContent.buildFramework({
       id: 'recFramework2',
@@ -42,7 +43,7 @@ describe('Integration | Repository | learning-content', function () {
       name_i18n: { fr: 'competence1_nomFr', en: 'competence1_nameEn' },
       index: '1',
       description_i18n: { fr: 'competence1_descriptionFr', en: 'competence1_descriptionEn' },
-      origin: 'Pix',
+      origin: PIX_ORIGIN,
       areaId: 'recArea1',
     });
     const competence2DB = databaseBuilder.factory.learningContent.buildCompetence({
@@ -50,7 +51,7 @@ describe('Integration | Repository | learning-content', function () {
       name_i18n: { fr: 'competence2_nomFr', en: 'competence2_nameEn' },
       index: '2',
       description_i18n: { fr: 'competence2_descriptionFr', en: 'competence2_descriptionEn' },
-      origin: 'Pix',
+      origin: PIX_ORIGIN,
       areaId: 'recArea1',
     });
     const competence3DB = databaseBuilder.factory.learningContent.buildCompetence({
@@ -168,6 +169,16 @@ describe('Integration | Repository | learning-content', function () {
       thematicId: 'recThematic3',
     });
 
+    databaseBuilder.factory.learningContent.buildSkill({
+      id: 'recSkill1',
+      name: 'tube1_name1',
+      status: 'actif',
+      level: 2,
+      pixValue: 16,
+      version: 14,
+      tubeId: 'recTube1',
+    });
+
     const skill2DB = databaseBuilder.factory.learningContent.buildSkill({
       id: 'recSkill2',
       name: '@tube2_name1',
@@ -185,6 +196,16 @@ describe('Integration | Repository | learning-content', function () {
       pixValue: 56,
       version: 54,
       tubeId: 'recTube2',
+    });
+
+    databaseBuilder.factory.learningContent.buildSkill({
+      id: 'recSkill4',
+      name: 'tube4_name1',
+      status: 'actif',
+      level: 2,
+      pixValue: 56,
+      version: 54,
+      tubeId: 'recTube4',
     });
 
     await databaseBuilder.commit();
@@ -265,7 +286,7 @@ describe('Integration | Repository | learning-content', function () {
     it('should throw a NoSkillsInCampaignError when there are no more operative skills', async function () {
       // given
       campaignId = databaseBuilder.factory.buildCampaign().id;
-      databaseBuilder.factory.buildCampaignSkill({ campaignId, skillId: 'recSkill4' });
+      databaseBuilder.factory.buildCampaignSkill({ campaignId, skillId: 'recSkillUnknown' });
       await databaseBuilder.commit();
 
       // when
@@ -326,7 +347,7 @@ describe('Integration | Repository | learning-content', function () {
       const otherCampaignParticipation = databaseBuilder.factory.buildCampaignParticipation();
       databaseBuilder.factory.buildCampaignSkill({
         campaignId: otherCampaignParticipation.campaignId,
-        skillId: 'recSkill4',
+        skillId: 'recSkillUnknown',
       });
       await databaseBuilder.commit();
 
@@ -409,26 +430,12 @@ describe('Integration | Repository | learning-content', function () {
     let organizationId;
     beforeEach(async function () {
       organizationId = databaseBuilder.factory.buildOrganization().id;
-      const otherOrganizationId = databaseBuilder.factory.buildOrganization().id;
 
       const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
       databaseBuilder.factory.buildTargetProfileShare({ organizationId, targetProfileId });
-      databaseBuilder.factory.buildTargetProfileTube({ targetProfileId, tubeId: 'recTube1', level: 4 });
       databaseBuilder.factory.buildTargetProfileTube({ targetProfileId, tubeId: 'recTube4', level: 4 });
 
-      const secondTargetProfileId = databaseBuilder.factory.buildTargetProfile().id;
-      databaseBuilder.factory.buildTargetProfileShare({ organizationId, targetProfileId: secondTargetProfileId });
-      databaseBuilder.factory.buildTargetProfileTube({
-        targetProfileId: secondTargetProfileId,
-        tubeId: 'recTube1',
-        level: 2,
-      });
-      databaseBuilder.factory.buildTargetProfileTube({
-        targetProfileId: secondTargetProfileId,
-        tubeId: 'recTube2',
-        level: 2,
-      });
-
+      const otherOrganizationId = databaseBuilder.factory.buildOrganization().id;
       const targetProfileIdFromOtherOrganization = databaseBuilder.factory.buildTargetProfile().id;
       databaseBuilder.factory.buildTargetProfileShare({
         organizationId: otherOrganizationId,
@@ -443,7 +450,7 @@ describe('Integration | Repository | learning-content', function () {
       await databaseBuilder.commit();
     });
 
-    it('should return an array of LearningContents', async function () {
+    it('should return an array of LearningContents with complete Pix frameworks', async function () {
       // given
       framework1Fr.areas = [area1Fr];
       area1Fr.competences = [competence1Fr, competence2Fr];
@@ -471,37 +478,13 @@ describe('Integration | Repository | learning-content', function () {
       expect(results).deep.members([framework1Fr, framework2Fr]);
     });
 
-    it('should filter out tubes without practicalTitle', async function () {
-      // given
-      const anotherOrganizationId = databaseBuilder.factory.buildOrganization().id;
-
-      const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
-      databaseBuilder.factory.buildTargetProfileShare({ organizationId: anotherOrganizationId, targetProfileId });
-      databaseBuilder.factory.buildTargetProfileTube({ targetProfileId, tubeId: 'recTube4', level: 4 });
-      databaseBuilder.factory.buildTargetProfileTube({ targetProfileId, tubeId: 'recTubeNotitle', level: 4 });
-      await databaseBuilder.commit();
-
-      framework2Fr.areas = [area2Fr];
-      area2Fr.competences = [competence3Fr];
-      competence3Fr.thematics = [thematic3Fr];
-      competence3Fr.tubes = [tube4Fr];
-      thematic3Fr.tubes = [tube4Fr];
-      tube4Fr.skills = [];
-
-      // when
-      const results = await learningContentRepository.findByOrganizationId({ organizationId: anotherOrganizationId });
-      // then
-      expect(results).lengthOf(1);
-      expect(results[0]).deep.equals(framework2Fr);
-    });
-
     context('when organization has no target profile shares', function () {
-      it('it should returns empty array', async function () {
+      it('it should returns Pix frameworks', async function () {
         // when
         const frameworks = await learningContentRepository.findByOrganizationId({ organizationId: 213 });
 
         // then
-        expect(frameworks).lengthOf(0);
+        expect(frameworks).lengthOf(1);
       });
     });
 

--- a/api/tests/prescription/shared/integration/infrastructure/repositories/learning-content-repository_test.js
+++ b/api/tests/prescription/shared/integration/infrastructure/repositories/learning-content-repository_test.js
@@ -13,11 +13,11 @@ describe('Integration | Repository | learning-content', function () {
   beforeEach(async function () {
     const framework1DB = databaseBuilder.factory.learningContent.buildFramework({
       id: 'recFramework1',
-      name: 'Mon référentiel 1',
+      name: 'Pix',
     });
     const framework2DB = databaseBuilder.factory.learningContent.buildFramework({
       id: 'recFramework2',
-      name: 'Pix',
+      name: 'Pix+',
     });
     const area1DB = databaseBuilder.factory.learningContent.buildArea({
       id: 'recArea1',
@@ -58,7 +58,7 @@ describe('Integration | Repository | learning-content', function () {
       name_i18n: { fr: 'competence3_nomFr', en: 'competence3_nameEn' },
       index: '1',
       description_i18n: { fr: 'competence3_descriptionFr', en: 'competence3_descriptionEn' },
-      origin: 'Pix',
+      origin: 'Pix+',
       areaId: 'recArea2',
     });
     const thematic1DB = databaseBuilder.factory.learningContent.buildThematic({
@@ -468,8 +468,7 @@ describe('Integration | Repository | learning-content', function () {
 
       // then
       expect(results).lengthOf(2);
-      expect(results[0]).deep.equals(framework2Fr);
-      expect(results[1]).deep.equals(framework1Fr);
+      expect(results).deep.members([framework1Fr, framework2Fr]);
     });
 
     it('should filter out tubes without practicalTitle', async function () {
@@ -531,8 +530,7 @@ describe('Integration | Repository | learning-content', function () {
 
         // then
         expect(results).lengthOf(2);
-        expect(results[0]).deep.equals(framework2En);
-        expect(results[1]).deep.equals(framework1En);
+        expect(results).deep.members([framework1En, framework2En]);
       });
     });
   });

--- a/api/tests/prescription/target-profile/integration/domain/usecases/find-learning-contents-by-organization-id_test.js
+++ b/api/tests/prescription/target-profile/integration/domain/usecases/find-learning-contents-by-organization-id_test.js
@@ -1,4 +1,5 @@
 import { usecases } from '../../../../../../src/prescription/target-profile/domain/usecases/index.js';
+import { PIX_ORIGIN } from '../../../../../../src/shared/domain/constants.js';
 import { databaseBuilder, domainBuilder, expect } from '../../../../../test-helper.js';
 
 describe('Integration | UseCases | find-learning-contents-by-organization-id', function () {
@@ -12,11 +13,11 @@ describe('Integration | UseCases | find-learning-contents-by-organization-id', f
   beforeEach(async function () {
     const framework1DB = databaseBuilder.factory.learningContent.buildFramework({
       id: 'recFramework1',
-      name: 'Mon référentiel 1',
+      name: PIX_ORIGIN,
     });
     const framework2DB = databaseBuilder.factory.learningContent.buildFramework({
       id: 'recFramework2',
-      name: 'Mon référentiel 2',
+      name: 'Pix+',
     });
     const area1DB = databaseBuilder.factory.learningContent.buildArea({
       id: 'recArea1',
@@ -41,7 +42,7 @@ describe('Integration | UseCases | find-learning-contents-by-organization-id', f
       name_i18n: { fr: 'competence1_nomFr', en: 'competence1_nameEn' },
       index: '1',
       description_i18n: { fr: 'competence1_descriptionFr', en: 'competence1_descriptionEn' },
-      origin: 'Pix',
+      origin: PIX_ORIGIN,
       areaId: 'recArea1',
     });
     const competence2DB = databaseBuilder.factory.learningContent.buildCompetence({
@@ -49,7 +50,7 @@ describe('Integration | UseCases | find-learning-contents-by-organization-id', f
       name_i18n: { fr: 'competence2_nomFr', en: 'competence2_nameEn' },
       index: '2',
       description_i18n: { fr: 'competence2_descriptionFr', en: 'competence2_descriptionEn' },
-      origin: 'Pix',
+      origin: PIX_ORIGIN,
       areaId: 'recArea1',
     });
     const competence3DB = databaseBuilder.factory.learningContent.buildCompetence({
@@ -57,7 +58,7 @@ describe('Integration | UseCases | find-learning-contents-by-organization-id', f
       name_i18n: { fr: 'competence3_nomFr', en: 'competence3_nameEn' },
       index: '1',
       description_i18n: { fr: 'competence3_descriptionFr', en: 'competence3_descriptionEn' },
-      origin: 'Pix',
+      origin: 'Pix+',
       areaId: 'recArea2',
     });
     const thematic1DB = databaseBuilder.factory.learningContent.buildThematic({
@@ -151,24 +152,48 @@ describe('Integration | UseCases | find-learning-contents-by-organization-id', f
       thematicId: 'recThematic3',
     });
 
+    databaseBuilder.factory.learningContent.buildSkill({
+      id: `recSkill1`,
+      name: `@tube1_name1`,
+      status: 'actif',
+      level: 1,
+      pixValue: 2,
+      version: 1,
+      tubeId: `recTube1`,
+    });
+
+    databaseBuilder.factory.learningContent.buildSkill({
+      id: `recSkill2`,
+      name: `@tube2_name1`,
+      status: 'actif',
+      level: 1,
+      pixValue: 3,
+      version: 1,
+      tubeId: `recTube2`,
+    });
+
+    databaseBuilder.factory.learningContent.buildSkill({
+      id: `recSkill4`,
+      name: `@tube4_name1`,
+      status: 'actif',
+      level: 1,
+      pixValue: 4,
+      version: 1,
+      tubeId: `recTube4`,
+    });
+
     organizationId = databaseBuilder.factory.buildOrganization().id;
     const otherOrganizationId = databaseBuilder.factory.buildOrganization().id;
 
     const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
     databaseBuilder.factory.buildTargetProfileShare({ organizationId, targetProfileId });
     databaseBuilder.factory.buildTargetProfileTube({ targetProfileId, tubeId: 'recTube1', level: 4 });
-    databaseBuilder.factory.buildTargetProfileTube({ targetProfileId, tubeId: 'recTube4', level: 4 });
 
     const secondTargetProfileId = databaseBuilder.factory.buildTargetProfile().id;
     databaseBuilder.factory.buildTargetProfileShare({ organizationId, targetProfileId: secondTargetProfileId });
     databaseBuilder.factory.buildTargetProfileTube({
       targetProfileId: secondTargetProfileId,
-      tubeId: 'recTube1',
-      level: 2,
-    });
-    databaseBuilder.factory.buildTargetProfileTube({
-      targetProfileId: secondTargetProfileId,
-      tubeId: 'recTube2',
+      tubeId: 'recTube4',
       level: 2,
     });
 
@@ -225,8 +250,7 @@ describe('Integration | UseCases | find-learning-contents-by-organization-id', f
 
     // then
     expect(frameworks).lengthOf(2);
-    expect(frameworks[0]).deep.equal(framework1Fr);
-    expect(frameworks[1]).deep.equal(framework2Fr);
+    expect(frameworks).deep.members([framework1Fr, framework2Fr]);
   });
 
   context('when organization has no target profile shares', function () {
@@ -235,7 +259,8 @@ describe('Integration | UseCases | find-learning-contents-by-organization-id', f
       const frameworks = await usecases.findLearningContentsByOrganizationId({ organizationId: 213 });
 
       // then
-      expect(frameworks).lengthOf(0);
+      expect(frameworks).lengthOf(1);
+      expect(frameworks).deep.members([framework1Fr]);
     });
   });
 });


### PR DESCRIPTION

## 🌎 Problème

  La page de séléction de sujets ne remonte pas le référentiel pix complet par défaut
ce qui limite les prescriptieur avancé dans la création de PC
## 🔭 Proposition

Ajouter par défaut le reférenitel pix
## 🪐 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🚀 Pour tester
- Choisir l'orga SUP_CLASSIC (elle a pas de PC)
- Afficher la page de selection de sujets
- Voir le référentiel pix complet 
--
- Choisir l'orga PRO_CLASSIC (avec des PC pas coeur)
- Afficher la page de selection de sujets
- Voir les référentiel pix complet 

<!-- 

Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
