### PR TITLE
[FEATURE] Ajouter la date d'archivage des campagnes dans l'api Maddo (PIX-21881)

### DIFF
--- a/api/src/maddo/application/organizations-routes.js
+++ b/api/src/maddo/application/organizations-routes.js
@@ -87,6 +87,7 @@ const register = async function (server) {
                     ),
                     code: Joi.string().description('Code campagne'),
                     createdAt: Joi.date().description('Date de création de la campagne'),
+                    archivedAt: Joi.date().description("Date d'archivage de la campagne"),
                     tubes: Joi.array()
                       .items(
                         Joi.object({

--- a/api/src/maddo/domain/models/Campaign.js
+++ b/api/src/maddo/domain/models/Campaign.js
@@ -1,11 +1,12 @@
 export class Campaign {
-  constructor({ id, name, type, targetProfileName, code, createdAt, tubes }) {
+  constructor({ id, name, type, targetProfileName, code, archivedAt, createdAt, tubes }) {
     this.id = id;
     this.name = name;
     this.type = type;
     this.targetProfileName = targetProfileName;
     this.code = code;
     this.createdAt = createdAt;
+    this.archivedAt = archivedAt;
     this.tubes = tubes;
   }
 }

--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-report-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-report-repository.js
@@ -104,7 +104,7 @@ const findMasteryRates = async (campaignId) => {
 
 const findPaginatedFilteredByOrganizationId = async function ({
   organizationId,
-  filter = {},
+  filter,
   page,
   userId,
   combinedCourseDetailsRepository = injectedCombinedCourseDetailRepository,
@@ -140,8 +140,11 @@ const findPaginatedFilteredByOrganizationId = async function ({
     .where('campaigns.organizationId', organizationId)
     .whereNull('campaigns.deletedAt')
     .whereNotIn('campaigns.id', campaignIdsToExclude)
-    .modify(_setSearchFiltersForQueryBuilder, filter, userId)
     .orderBy('campaigns.createdAt', 'DESC');
+
+  if (filter) {
+    query.modify(_setSearchFiltersForQueryBuilder, filter, userId);
+  }
 
   const { results, pagination } = await fetchPage({ queryBuilder: query, paginationParams: page });
   const atLeastOneCampaign = await knexConn('campaigns')

--- a/api/tests/maddo/application/acceptance/organizations-routes_test.js
+++ b/api/tests/maddo/application/acceptance/organizations-routes_test.js
@@ -153,6 +153,7 @@ describe('Acceptance | Maddo | Route | Organizations', function () {
           targetProfileName: targetProfile.name,
           code: campaign1InJurisdiction.code,
           createdAt: campaign1InJurisdiction.createdAt,
+          archivedAt: campaign1InJurisdiction.archivedAt,
           tubes: [
             {
               id: tube.id,
@@ -197,6 +198,7 @@ describe('Acceptance | Maddo | Route | Organizations', function () {
             targetProfileName: null,
             code: campaign1InJurisdiction.code,
             createdAt: campaign1InJurisdiction.createdAt,
+            archivedAt: campaign1InJurisdiction.archivedAt,
             tubes: null,
           }),
         ]);
@@ -264,6 +266,7 @@ describe('Acceptance | Maddo | Route | Organizations', function () {
             targetProfileName: targetProfile.name,
             code: campaign1InJurisdiction.code,
             createdAt: campaign1InJurisdiction.createdAt,
+            archivedAt: campaign1InJurisdiction.archivedAt,
             tubes: [
               {
                 id: tube.id,
@@ -338,6 +341,7 @@ describe('Acceptance | Maddo | Route | Organizations', function () {
             targetProfileName: targetProfile.name,
             code: campaignInJurisdiction.code,
             createdAt: campaignInJurisdiction.createdAt,
+            archivedAt: campaignInJurisdiction.archivedAt,
             tubes: [
               {
                 id: tube.id,

--- a/api/tests/maddo/infrastructure/integration/repositories/campaign-repository_test.js
+++ b/api/tests/maddo/infrastructure/integration/repositories/campaign-repository_test.js
@@ -83,6 +83,7 @@ describe('Maddo | Infrastructure | Repositories | Integration | campaign', funct
           targetProfileName: targetProfile.name,
           code: campaign1.code,
           createdAt: campaign1.createdAt,
+          archivedAt: campaign1.archivedAt,
           tubes: [
             {
               competenceId: competence.id,
@@ -100,6 +101,7 @@ describe('Maddo | Infrastructure | Repositories | Integration | campaign', funct
           type: campaign2.type,
           targetProfileName: targetProfile.name,
           code: campaign2.code,
+          archivedAt: campaign2.archivedAt,
           createdAt: campaign2.createdAt,
           tubes: [
             {

--- a/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-report-repository_test.js
+++ b/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-report-repository_test.js
@@ -793,7 +793,7 @@ describe('Integration | Repository | Campaign-Report', function () {
         });
       });
 
-      context('when some campaigns matched the archived filter', function () {
+      context('when there is both ongoing and archived campaign', function () {
         it('should be able to retrieve only campaigns that are archived', async function () {
           // given
           organizationId = databaseBuilder.factory.buildOrganization().id;
@@ -816,6 +816,61 @@ describe('Integration | Repository | Campaign-Report', function () {
           expect(archivedCampaigns).to.have.lengthOf(1);
           expect(archivedCampaigns[0].id).to.equal(archivedCampaign.id);
           expect(archivedCampaigns[0].archivedAt).to.deep.equal(archivedCampaign.archivedAt);
+        });
+
+        it('should be able to retrieve only ongoing campaigns by default', async function () {
+          // given
+          organizationId = databaseBuilder.factory.buildOrganization().id;
+          databaseBuilder.factory.buildCampaign({
+            organizationId,
+            archivedAt: new Date('2010-07-30T09:35:45Z'),
+          });
+          const ongoingCampaign = databaseBuilder.factory.buildCampaign({ organizationId, archivedAt: null });
+          filter = {};
+
+          await databaseBuilder.commit();
+          // when
+          const { models: campaigns } = await campaignReportRepository.findPaginatedFilteredByOrganizationId({
+            organizationId,
+            filter,
+            page,
+          });
+
+          // then
+          expect(campaigns).to.have.lengthOf(1);
+          expect(campaigns[0].id).to.equal(ongoingCampaign.id);
+          expect(campaigns[0].archivedAt).to.deep.equal(ongoingCampaign.archivedAt);
+        });
+
+        it('should be able to return all campaigns', async function () {
+          // given
+          organizationId = databaseBuilder.factory.buildOrganization().id;
+          const archivedCampaign = databaseBuilder.factory.buildCampaign({
+            organizationId,
+            createdAt: new Date('2010-07-01T09:35:45Z'),
+            archivedAt: new Date('2010-07-30T09:35:45Z'),
+          });
+          const ongoingCampaign = databaseBuilder.factory.buildCampaign({
+            organizationId,
+            createdAt: new Date('2012-07-01T09:35:45Z'),
+            archivedAt: null,
+          });
+          filter.ongoing = false;
+
+          await databaseBuilder.commit();
+          // when
+          const { models: campaigns } = await campaignReportRepository.findPaginatedFilteredByOrganizationId({
+            organizationId,
+            filter: undefined,
+            page,
+          });
+
+          // then
+          expect(campaigns).to.have.lengthOf(2);
+          expect(campaigns[0].id).to.equal(ongoingCampaign.id);
+          expect(campaigns[0].archivedAt).to.deep.equal(ongoingCampaign.archivedAt);
+          expect(campaigns[1].id).to.equal(archivedCampaign.id);
+          expect(campaigns[1].archivedAt).to.deep.equal(archivedCampaign.archivedAt);
         });
       });
 


### PR DESCRIPTION
## 🌎 Problème

On ne remonte pas la date d'archivage des campagnes, ce qui peut poser des problèmes pour nos partenaires qui utilisent notre API. 

## 🔭 Proposition

Ajouter la date d'archivage des campagnes

## 🪐 Remarques

RAS

## 🚀 Pour tester

curl baby curl!

```sh
ACCESS_TOKEN=$(curl --no-progress-meter -X POST \
  --data "grant_type=client_credentials" \
  --data "client_id=maddo-client" \
  --data "client_secret=maddo-secret" \
  --data "scope=meta campaigns" \
"https://pix-api-maddo-review-pr15527.osc-fr1.scalingo.io/api/application/token" | jq -r '.access_token'
)
```
et 
```sh
curl --no-progress-meter "https://pix-api-maddo-review-pr15527.osc-fr1.scalingo.io/api/organizations/1000/campaigns" \
  -H "accept: application/json" \
  -H "Authorization: Bearer $ACCESS_TOKEN" \
| jq '.campaigns[] | {id, name, archivedAt}'
```

Archiver un campagne de l'orga sco-siecle
et relancer 
```sh
curl --no-progress-meter "https://pix-api-maddo-review-pr15527.osc-fr1.scalingo.io/api/organizations/1000/campaigns" \
  -H "accept: application/json" \
  -H "Authorization: Bearer $ACCESS_TOKEN" \
| jq '.campaigns[] | {id, name, archivedAt}'
```

Voir que la date d'archivage remonte bien