### PR TITLE
[FEATURE] Ajouter le feature toggle addEmailConnectionMethodEnabled (PIX-21978)

### DIFF
--- a/api/config/feature-toggles-config.js
+++ b/api/config/feature-toggles-config.js
@@ -108,4 +108,11 @@ export default {
     devDefaultValues: { test: true, reviewApp: false },
     tags: ['team-acces', 'audit-logger'],
   },
+  addEmailConnectionMethodEnabled: {
+    type: 'boolean',
+    description: 'Enable adding email connection method',
+    defaultValue: false,
+    devDefaultValues: { test: false, reviewApp: false },
+    tags: ['team-acces', 'pix-api', 'mon-pix', 'frontend', 'backend'],
+  },
 };

--- a/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
+++ b/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
@@ -31,6 +31,7 @@ describe('Acceptance | Shared | Application | Controller | feature-toggle', func
             'is-pix-plus-candidate-a11y-enabled': false,
             'are-module-short-id-urls-enabled': false,
             'multiple-locales-for-trainings-enabled': false,
+            'add-email-connection-method-enabled': false,
           },
         },
       };

--- a/mon-pix/app/models/feature-toggle.js
+++ b/mon-pix/app/models/feature-toggle.js
@@ -6,4 +6,5 @@ export default class FeatureToggle extends Model {
   @attr('boolean') isSurveyEnabledForCombinedCourses;
   @attr('boolean') areModuleShortIdUrlsEnabled;
   @attr('array') disabledLocalesInFrontend;
+  @attr('boolean') addEmailConnectionMethodEnabled;
 }


### PR DESCRIPTION
## 🌎 Problème

Nous avons besoin d'un feature toggle pour développer la nouvelle fonctionnalité d'ajout d'une nouvelle méthode de connexion pour les utilisateurs ne disposant que d'une méthode par SSO.

## 🔭 Proposition

Ajouter le feature toggle `addEmailConnectionMethodEnabled`

## 🪐 Remarques

ras

## 🚀 Pour tester
- Lancer Pix App
- Voir l'API retourner `false` sur `addEmailConnectionMethodEnabled`
- Changer la valeur du FT => 
`scalingo -a pix-api-review-pr15529 run "npm run toggles -- --key=addEmailConnectionMethodEnabled --value=true"`
- Constater que l'API retourne `true`

🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘 🌑
