### PR TITLE
[TECH] Suppression des warnings lors du lint dans Admin.

### DIFF
--- a/admin/eslint.config.mjs
+++ b/admin/eslint.config.mjs
@@ -1,6 +1,5 @@
 import pixRecommendedConfig from '@1024pix/eslint-plugin/config';
 import babelParser from '@babel/eslint-parser';
-import emberParser from 'ember-eslint-parser';
 import emberRecommendedConfig from 'eslint-plugin-ember/configs/recommended';
 import emberGjsRecommendedConfig from 'eslint-plugin-ember/configs/recommended-gjs';
 import i18nJsonPlugin from 'eslint-plugin-i18n-json';
@@ -26,15 +25,10 @@ const nodeFiles = [
   'server/**/*.js',
 ];
 
-const emberPatchedParser = Object.assign(
-  {
-    meta: {
-      name: 'ember-eslint-parser',
-      version: '*',
-    },
-  },
-  emberParser,
-);
+// Reuse the same ember-eslint-parser instance that emberGjsRecommendedConfig uses internally,
+// so that the parser and the noop processor (which coordinate via a shared Set) stay in sync.
+const gjsParserConfig = emberGjsRecommendedConfig.find((c) => c.languageOptions?.parser);
+const emberParser = gjsParserConfig?.languageOptions?.parser;
 
 export default [
   ...pixRecommendedConfig,
@@ -70,13 +64,6 @@ export default [
     },
   },
   {
-    files: ['**/*.gjs'],
-    languageOptions: {
-      parser: emberPatchedParser,
-      sourceType: 'module',
-    },
-  },
-  {
     ...nRecommendedConfig.configs['flat/recommended'],
     files: nodeFiles,
 
@@ -95,6 +82,13 @@ export default [
           allowModules: ['eslint-plugin-i18n-json'],
         },
       ],
+    },
+  },
+  {
+    files: ['**/*.gjs'],
+    languageOptions: {
+      parser: emberParser,
+      sourceType: 'module',
     },
   },
   {

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -33,7 +33,6 @@
         "ember-cli-sass": "^11.0.1",
         "ember-cookies": "^1.3.0",
         "ember-data": "~5.8.0",
-        "ember-eslint-parser": "^0.7.0",
         "ember-exam": "^10.0.1",
         "ember-inflector": "^6.0.0",
         "ember-intl": "^8.0.0",
@@ -6923,13 +6922,6 @@
         "@types/eslint": "*",
         "@types/estree": "*"
       }
-    },
-    "node_modules/@types/esrecurse": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
-      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -15544,117 +15536,6 @@
         "qunit": {
           "optional": true
         }
-      }
-    },
-    "node_modules/ember-eslint-parser": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/ember-eslint-parser/-/ember-eslint-parser-0.7.0.tgz",
-      "integrity": "sha512-QvlYIXWPlPUqjuHrfBLAzax59A0X/YjGU2mMvwqwTexLi/r+hPqCen+CCfR3AZojjehsrT5bEXhj4igQx2z2sQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "@babel/eslint-parser": "^7.28.6",
-        "@glimmer/syntax": ">= 0.92.0",
-        "@typescript-eslint/tsconfig-utils": "^8.38.0",
-        "content-tag": "^4.1.0",
-        "eslint-scope": "^9.1.1",
-        "html-tags": "^5.1.0",
-        "mathml-tag-names": "^4.0.0",
-        "svg-tags": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.23.6",
-        "@typescript-eslint/parser": "*"
-      },
-      "peerDependenciesMeta": {
-        "@typescript-eslint/parser": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/ember-eslint-parser/node_modules/@glimmer/interfaces": {
-      "version": "0.94.6",
-      "resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.94.6.tgz",
-      "integrity": "sha512-sp/1WePvB/8O+jrcUHwjboNPTKrdGicuHKA9T/lh0vkYK2qM5Xz4i25lQMQ38tEMiw7KixrjHiTUiaXRld+IwA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@simple-dom/interface": "^1.4.0",
-        "type-fest": "^4.35.0"
-      }
-    },
-    "node_modules/ember-eslint-parser/node_modules/@glimmer/syntax": {
-      "version": "0.95.0",
-      "resolved": "https://registry.npmjs.org/@glimmer/syntax/-/syntax-0.95.0.tgz",
-      "integrity": "sha512-W/PHdODnpONsXjbbdY9nedgIHpglMfOzncf/moLVrKIcCfeQhw2vG07Rs/YW8KeJCgJRCLkQsi+Ix7XvrurGAg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@glimmer/interfaces": "0.94.6",
-        "@glimmer/util": "0.94.8",
-        "@glimmer/wire-format": "0.94.8",
-        "@handlebars/parser": "~2.2.0",
-        "simple-html-tokenizer": "^0.5.11"
-      }
-    },
-    "node_modules/ember-eslint-parser/node_modules/@glimmer/util": {
-      "version": "0.94.8",
-      "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.94.8.tgz",
-      "integrity": "sha512-HfCKeZ74clF9BsPDBOqK/yRNa/ke6niXFPM6zRn9OVYw+ZAidLs7V8He/xljUHlLRL322kaZZY8XxRW7ALEwyg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@glimmer/interfaces": "0.94.6"
-      }
-    },
-    "node_modules/ember-eslint-parser/node_modules/@handlebars/parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@handlebars/parser/-/parser-2.2.2.tgz",
-      "integrity": "sha512-n/SZW+12rwikx/f8YcSv9JCi5p9vn1Bnts9ZtVvfErG4h0gbjHI1H1ZMhVUnaOC7yzFc6PtsCKIK8XeTnL90Gw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^18 || ^20 || ^22 || >=24"
-      }
-    },
-    "node_modules/ember-eslint-parser/node_modules/content-tag": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/content-tag/-/content-tag-4.1.0.tgz",
-      "integrity": "sha512-On6gUuvI1l5MScHO+Xbwjeq1Pk9H6HOipDWkzqGGUGmKpq6K5TRmQuCl1LGSHbdIo2l+lSsgLKrLgCl5kKYA+A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/ember-eslint-parser/node_modules/eslint-scope": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
-      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "@types/esrecurse": "^4.3.1",
-        "@types/estree": "^1.0.8",
-        "esrecurse": "^4.3.0",
-        "estraverse": "^5.2.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/ember-eslint-parser/node_modules/mathml-tag-names": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-4.0.0.tgz",
-      "integrity": "sha512-aa6AU2Pcx0VP/XWnh8IGL0SYSgQHDT6Ucror2j2mXeFAlN3ahaNs8EZtG1YiticMkSLj3Gt6VPFfZogt7G5iFQ==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/ember-exam": {

--- a/admin/package.json
+++ b/admin/package.json
@@ -65,7 +65,6 @@
     "ember-cli-sass": "^11.0.1",
     "ember-cookies": "^1.3.0",
     "ember-data": "~5.8.0",
-    "ember-eslint-parser": "^0.7.0",
     "ember-exam": "^10.0.1",
     "ember-inflector": "^6.0.0",
     "ember-intl": "^8.0.0",


### PR DESCRIPTION
## 🌎 Problème

Lorsque l'on exécute la commande `npm run lint` dans PixAdmin, des warnings apparaissent en console et polluent la sortie en console.

<img width="935" height="51" alt="Capture d’écran 2026-03-18 à 16 16 13" src="https://github.com/user-attachments/assets/2515ab92-404d-483c-bfd8-b4da3d49da5a" />


Problème :

`eslint-plugin-ember` et le projet avaient deux versions différentes de ember-eslint-parser installées :                                                                                                              
                                                                                                                                                                                                                      
  - v0.5.13 — installée par eslint-plugin-ember dans ses propres node_modules                                                                                                                                         
  - v0.7.0 — installée directement par le projet                                                                                                                                                                    

`eslint.config.mjs` utilise v0.7.0 comme parser pour les fichiers .gjs. Mais `eslint-plugin-ember` configurait aussi un processor noop (issu de v0.5.13) dont le rôle est de valider que le parser a bien traité chaque fichier .gjs.

La coordination se fait via un Set partagé (parsedFiles) : le parser appelle `registerParsedFile()`, le processor vérifie que le fichier y est bien enregistré. 
V0.7.0 et V0.5.13 étant deux instances Node.js distinctes, chacune a son propre Set. 
Le parser v0.7.0 écrivait dans son Set, mais le processor v0.5.13 lisait dans le sien, ne menant à rien.

## 🔭 Proposition

Au lieu d'importer ember-eslint-parser directement (ce qui résolvait vers v0.7.0), on extrait la référence du parser depuis emberGjsRecommendedConfig lui-même :

const gjsParserConfig = emberGjsRecommendedConfig.find((c) => c.languageOptions?.parser);
const emberParser = gjsParserConfig?.languageOptions?.parser;

On obtient ainsi exactement la même instance (v0.5.13) que celle utilisée par le processor noop — le Set est partagé entre les deux et la coordination fonctionne.

## 🪐 Remarques

- Analyse du problème et réponses apportées par Claude Code.
- Suppression de la dépendance `ember-eslint-parser` devenue inutile.

## 🚀 Pour tester

- Se mettre sur la branche
- Lancer `npm run lint` ou `npm run lint:js:fix` dans `admin`
- Vérifier qu'il n'y ait pas de warning
- Mettre un `console.log()` quelque part (ou tout autre `.only` dans un test par exemple)
- Lancer de nouveaux les commandes et vérifier que le lint fonctionne et que les erreurs ressortent
