### PR TITLE
[FEATURE] Ajouter le paramètre instruction pour les stepper horizontaux (PIX-21921).

### DIFF
--- a/api/src/devcomp/domain/models/component/ComponentStepper.js
+++ b/api/src/devcomp/domain/models/component/ComponentStepper.js
@@ -2,12 +2,13 @@ import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asser
 import { ModuleInstantiationError } from '../../errors.js';
 
 class ComponentStepper {
-  constructor({ steps }) {
+  constructor({ steps, instruction }) {
     assertNotNullOrUndefined(steps, 'Steps are required for a componentStepper');
     this.#assertStepsAreAnArray(steps);
 
     this.steps = steps;
     this.type = 'stepper';
+    this.instruction = instruction;
   }
 
   #assertStepsAreAnArray(steps) {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/12_RangerFichiers_IND.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/12_RangerFichiers_IND.json
@@ -157,6 +157,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/12_RangerFichiers_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/12_RangerFichiers_NOV.json
@@ -145,6 +145,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/21_RepondreMail_IND.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/21_RepondreMail_IND.json
@@ -99,6 +99,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -248,6 +249,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -427,7 +429,7 @@
                 "legend": "",
                 "licence": ""
               }
-            },            
+            },
             {
               "type": "element",
               "element": {
@@ -468,6 +470,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -973,6 +976,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/21_RepondreMail_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/21_RepondreMail_NOV.json
@@ -560,6 +560,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -726,6 +727,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/21_Visio_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/21_Visio_NOV.json
@@ -117,6 +117,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -347,6 +348,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -446,6 +448,7 @@
           "components": [
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYGestionMDP_IND.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYGestionMDP_IND.json
@@ -242,6 +242,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -326,6 +327,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYGestionMDP_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYGestionMDP_NOV.json
@@ -574,6 +574,7 @@
           "components": [
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYMDP_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYMDP_NOV.json
@@ -587,6 +587,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYMFA_IND.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYMFA_IND.json
@@ -201,6 +201,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -395,6 +396,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYMFA_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYMFA_NOV.json
@@ -572,6 +572,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYPhishing_AVA.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYPhishing_AVA.json
@@ -445,6 +445,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -774,6 +775,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYPhishing_IND.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYPhishing_IND.json
@@ -105,6 +105,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYPhishing_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYPhishing_NOV.json
@@ -706,6 +706,7 @@
           "components": [
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYVirus_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYVirus_NOV.json
@@ -131,6 +131,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -528,6 +529,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IADefinition_IND.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IADefinition_IND.json
@@ -115,6 +115,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -337,6 +338,7 @@
           "components": [
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -433,6 +435,7 @@
           "components": [
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -662,6 +665,7 @@
           "components": [
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -733,6 +737,7 @@
           "components": [
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -904,6 +909,7 @@
           "components": [
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IADefinition_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IADefinition_NOV.json
@@ -224,6 +224,7 @@
           "components": [
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -656,6 +657,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenBiais_AVA.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenBiais_AVA.json
@@ -199,6 +199,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -784,6 +785,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenBiais_IND.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenBiais_IND.json
@@ -144,6 +144,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -285,6 +286,7 @@
           "components": [
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -422,6 +424,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -640,6 +643,7 @@
           "components": [
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -946,6 +950,7 @@
           "components": [
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenBiais_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenBiais_NOV.json
@@ -119,6 +119,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -516,6 +517,7 @@
           "components": [
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -693,6 +695,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -927,6 +930,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenBiais_NOV_alt.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenBiais_NOV_alt.json
@@ -109,6 +109,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -372,6 +373,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenFonction_Ava.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenFonction_Ava.json
@@ -152,6 +152,7 @@
           "components": [
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -211,6 +212,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -351,6 +353,7 @@
           "components": [
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -455,6 +458,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenFonction_IND.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenFonction_IND.json
@@ -235,6 +235,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -452,6 +453,7 @@
           "components": [
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -582,6 +584,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenFonction_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenFonction_NOV.json
@@ -179,6 +179,7 @@
           "components": [
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -564,6 +565,7 @@
           "components": [
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenImpact_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenImpact_NOV.json
@@ -612,6 +612,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -843,6 +844,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -963,6 +965,7 @@
           "components": [
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenPrompt_AVA.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenPrompt_AVA.json
@@ -148,6 +148,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenPrompt_IND.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenPrompt_IND.json
@@ -380,6 +380,7 @@
           "components": [
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -445,6 +446,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenPrompt_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenPrompt_NOV.json
@@ -553,6 +553,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAInfox_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAInfox_NOV.json
@@ -248,6 +248,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -487,6 +488,7 @@
           "components": [
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -654,6 +656,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/NR-Datacenter-IND.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/NR-Datacenter-IND.json
@@ -125,6 +125,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -357,6 +358,7 @@
           "components": [
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -653,6 +655,7 @@
           "components": [
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/NR-Datacenter-NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/NR-Datacenter-NOV.json
@@ -177,6 +177,7 @@
           "components": [
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -239,6 +240,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -429,6 +431,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -577,6 +580,7 @@
           "components": [
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -706,6 +710,7 @@
           "components": [
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/NR-Durabilite-AVA.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/NR-Durabilite-AVA.json
@@ -113,6 +113,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -295,6 +296,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -520,6 +522,7 @@
           "components": [
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -744,6 +747,7 @@
           "components": [
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -861,6 +865,7 @@
           "components": [
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/NR_Datacenter_AVA.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/NR_Datacenter_AVA.json
@@ -129,6 +129,7 @@
           "components": [
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -340,6 +341,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -520,6 +522,7 @@
           "components": [
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -582,6 +585,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -825,6 +829,7 @@
           "components": [
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -903,6 +908,7 @@
           "components": [
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -1255,6 +1261,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/NR_Evaluation_IND.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/NR_Evaluation_IND.json
@@ -131,6 +131,7 @@
           "components": [
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -403,6 +404,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -524,6 +526,7 @@
           "components": [
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -925,6 +928,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/NR_durabilite_Nov.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/NR_durabilite_Nov.json
@@ -474,6 +474,7 @@
           "components": [
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -549,6 +550,7 @@
           "components": [
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -658,6 +660,7 @@
           "components": [
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/NR_surequipement_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/NR_surequipement_NOV.json
@@ -92,6 +92,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -248,6 +249,7 @@
           "components": [
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -478,6 +480,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -592,6 +595,7 @@
           "components": [
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/adresse-ip-publique-et-vous.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/adresse-ip-publique-et-vous.json
@@ -62,6 +62,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -271,6 +272,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -527,6 +529,7 @@
           "components": [
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/au-dela-des-mots-de-passe.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/au-dela-des-mots-de-passe.json
@@ -505,6 +505,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
@@ -45,6 +45,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "<p>Cette instruction permet d'avoir un texte commun à tous les steps du stepper horizontal</p>",
               "steps": [
                 {
                   "elements": [
@@ -251,6 +252,7 @@
           "components": [
             {
               "type": "stepper",
+              "instruction": "<p>😎COOL GANG 😎. Cette instruction ne sera pas visible dans le module.</p>",
               "steps": [
                 {
                   "elements": [

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bases-clavier-ordinateur-1.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bases-clavier-ordinateur-1.json
@@ -410,6 +410,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -630,6 +631,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
@@ -132,6 +132,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -223,6 +224,7 @@
           "components": [
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -359,6 +361,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/chatgpt-vraiment-neutre.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/chatgpt-vraiment-neutre.json
@@ -211,6 +211,7 @@
           "components": [
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -409,6 +410,7 @@
           "components": [
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/comment-envoyer-un-mail.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/comment-envoyer-un-mail.json
@@ -221,6 +221,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/controle-parental.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/controle-parental.json
@@ -132,6 +132,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -480,6 +481,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/decouverte-de-l-ent.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/decouverte-de-l-ent.json
@@ -132,6 +132,7 @@
           "components": [
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -262,6 +263,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -573,6 +575,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/distinguer-vrai-faux-sur-internet.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/distinguer-vrai-faux-sur-internet.json
@@ -44,6 +44,7 @@
           "components": [
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -215,6 +216,7 @@
           "components": [
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -431,6 +433,7 @@
           "components": [
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -543,6 +546,7 @@
           "components": [
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/ia-cadre-usage-educ-nov.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/ia-cadre-usage-educ-nov.json
@@ -120,6 +120,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -327,6 +328,7 @@
           "components": [
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -425,6 +427,7 @@
           "components": [
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -561,6 +564,7 @@
           "components": [
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -735,6 +739,7 @@
           "components": [
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -842,6 +847,7 @@
           "components": [
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/ia-deepfakes-alt.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/ia-deepfakes-alt.json
@@ -241,6 +241,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -632,6 +633,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/jeux-video-enfant.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/jeux-video-enfant.json
@@ -124,6 +124,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -577,6 +578,7 @@
           "components": [
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/mots-de-passe-securises.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/mots-de-passe-securises.json
@@ -348,6 +348,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/nr_durabilite_ind.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/nr_durabilite_ind.json
@@ -319,6 +319,7 @@
           "components": [
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -364,6 +365,7 @@
           "components": [
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -656,6 +658,7 @@
           "components": [
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -760,6 +763,7 @@
           "components": [
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/ports-connexions-essentiels.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/ports-connexions-essentiels.json
@@ -145,6 +145,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -368,6 +369,7 @@
           "components": [
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -472,6 +474,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/sources-informations.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/sources-informations.json
@@ -44,6 +44,7 @@
           "components": [
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -421,6 +422,7 @@
             },
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/tmp08ef.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/tmp08ef.json
@@ -140,6 +140,7 @@
           "components": [
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/tri-multicritere-tableau.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/tri-multicritere-tableau.json
@@ -44,6 +44,7 @@
           "components": [
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [
@@ -404,6 +405,7 @@
           "components": [
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/utiliser-souris-ordinateur-2.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/utiliser-souris-ordinateur-2.json
@@ -460,6 +460,7 @@
           "components": [
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [

--- a/api/src/devcomp/infrastructure/datasources/learning-content/validation/module-schema.js
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/validation/module-schema.js
@@ -86,6 +86,10 @@ const componentElementSchema = Joi.object({
 
 const componentStepperSchema = Joi.object({
   type: Joi.string().valid('stepper').required(),
+  instruction: htmlSchema
+    .allow('')
+    .required()
+    .description("Instruction du stepper. S'affiche uniquement pour le stepper horizontal."),
   steps: Joi.array()
     .items(
       Joi.object({
@@ -165,4 +169,4 @@ const moduleSchema = Joi.object({
   sections: Joi.array().items(moduleSectionSchema).required(),
 }).required();
 
-export { grainSchema, moduleSchema };
+export { componentStepperSchema, grainSchema, moduleSchema };

--- a/api/src/devcomp/infrastructure/factories/module-factory.js
+++ b/api/src/devcomp/infrastructure/factories/module-factory.js
@@ -92,6 +92,7 @@ export class ModuleFactory {
                                         });
                                       }),
                                     ),
+                                    instruction: component.instruction,
                                   });
                                 default:
                                   logger.warn({

--- a/api/tests/devcomp/acceptance/scripts/test-module.json
+++ b/api/tests/devcomp/acceptance/scripts/test-module.json
@@ -213,6 +213,7 @@
           "components": [
             {
               "type": "stepper",
+              "instruction": "",
               "steps": [
                 {
                   "elements": [

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js
@@ -21,6 +21,7 @@ import { shortVideoElementSchema } from '../../../../../../../src/devcomp/infras
 import { textElementSchema } from '../../../../../../../src/devcomp/infrastructure/datasources/learning-content/validation/element/text-schema.js';
 import { videoElementSchema } from '../../../../../../../src/devcomp/infrastructure/datasources/learning-content/validation/element/video-schema.js';
 import {
+  componentStepperSchema,
   grainSchema,
   moduleSchema,
 } from '../../../../../../../src/devcomp/infrastructure/datasources/learning-content/validation/module-schema.js';
@@ -522,6 +523,42 @@ describe('Unit | Infrastructure | Datasources | Learning Content | Module Dataso
         };
 
         await audioElementSchema.validateAsync(sample, {
+          abortEarly: false,
+        });
+      } catch (joiError) {
+        const formattedError = joiErrorParser.format(joiError);
+        expect(joiError).to.equal(undefined, formattedError);
+      }
+    });
+
+    it('should validate stepper structure', async function () {
+      try {
+        const sample = {
+          type: 'stepper',
+          instruction: 'Ceci est une instruction pour un stepper',
+          steps: [
+            {
+              elements: [
+                {
+                  id: '1cf5b276-9ce0-4b38-a56b-4d4447b34d8a',
+                  type: 'text',
+                  content: '<p>Cool</p>',
+                },
+              ],
+            },
+            {
+              elements: [
+                {
+                  id: '185881f1-6217-4306-8e89-070281a3e20a',
+                  type: 'text',
+                  content: '<p>Gang</p>',
+                },
+              ],
+            },
+          ],
+        };
+
+        await componentStepperSchema.validateAsync(sample, {
           abortEarly: false,
         });
       } catch (joiError) {

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
@@ -355,6 +355,7 @@ function getComponents() {
   });
   return [
     new ComponentStepper({
+      instruction: '',
       steps: [
         {
           elements: [qrocmElement],
@@ -543,6 +544,7 @@ function getAttributesComponents() {
   return [
     {
       type: 'stepper',
+      instruction: '',
       steps: [
         {
           elements: [expectedQrocm],

--- a/mon-pix/app/components/module/component/_stepper.scss
+++ b/mon-pix/app/components/module/component/_stepper.scss
@@ -18,6 +18,10 @@
   &__steps {
     display: flex;
   }
+
+  &__instruction {
+    padding-bottom: var(--pix-spacing-2x);
+  }
 }
 
 .stepper-controls {

--- a/mon-pix/app/components/module/component/stepper.gjs
+++ b/mon-pix/app/components/module/component/stepper.gjs
@@ -241,6 +241,11 @@ export default class ModulixStepper extends Component {
             {{/each}}
           </div>
         </div>
+        {{#if @instruction}}
+          <div class="stepper__instruction">
+            {{htmlUnsafe @instruction}}
+          </div>
+        {{/if}}
         <div
           id={{this.id}}
           class="stepper__steps"

--- a/mon-pix/app/components/module/grain/grain.gjs
+++ b/mon-pix/app/components/module/grain/grain.gjs
@@ -321,6 +321,7 @@ export default class ModuleGrain extends Component {
                   @preventInitialFocusAndScroll={{this.preventStepperInitialScrollAndFocus index}}
                   @direction={{this.stepperDirection}}
                   @updateSkipButton={{this.updateSkipButton}}
+                  @instruction={{component.instruction}}
                 />
               </div>
             {{/if}}

--- a/mon-pix/tests/integration/components/module/stepper_test.gjs
+++ b/mon-pix/tests/integration/components/module/stepper_test.gjs
@@ -863,6 +863,41 @@ module('Integration | Component | Module | Stepper', function (hooks) {
         });
       });
     });
+
+    module('when instruction exists', function () {
+      test('should not display instruction', async function (assert) {
+        // given
+        const instruction = 'Ceci est une instruction';
+        const steps = [
+          {
+            elements: [
+              {
+                id: '342183f7-af51-4e4e-ab4c-ebed1e195063',
+                type: 'text',
+                content: '<p>Text 1</p>',
+              },
+            ],
+          },
+          {
+            elements: [
+              {
+                id: '768441a5-a7d6-4987-ada9-7253adafd842',
+                type: 'text',
+                content: '<p>Text 2</p>',
+              },
+            ],
+          },
+        ];
+
+        // when
+        const screen = await render(
+          <template><ModulixStepper @steps={{steps}} @direction="vertical" @instruction={{instruction}} /></template>,
+        );
+
+        // then
+        assert.dom(screen.queryByText(instruction)).doesNotExist();
+      });
+    });
   });
 
   module('When stepper is horizontal', function () {
@@ -2494,6 +2529,41 @@ module('Integration | Component | Module | Stepper', function (hooks) {
           assert.strictEqual(screen.getAllByRole('group', { name: '1 sur 2' }).length, 1);
           assert.strictEqual(screen.getAllByRole('group', { name: '2 sur 2' }).length, 1);
         });
+      });
+    });
+
+    module('when instruction exists', function () {
+      test('should display instruction', async function (assert) {
+        // given
+        const instruction = 'Ceci est une instruction';
+        const steps = [
+          {
+            elements: [
+              {
+                id: '342183f7-af51-4e4e-ab4c-ebed1e195063',
+                type: 'text',
+                content: '<p>Text 1</p>',
+              },
+            ],
+          },
+          {
+            elements: [
+              {
+                id: '768441a5-a7d6-4987-ada9-7253adafd842',
+                type: 'text',
+                content: '<p>Text 2</p>',
+              },
+            ],
+          },
+        ];
+
+        // when
+        const screen = await render(
+          <template><ModulixStepper @steps={{steps}} @direction="horizontal" @instruction={{instruction}} /></template>,
+        );
+
+        // then
+        assert.dom(screen.getByText(instruction)).exists();
       });
     });
   });


### PR DESCRIPTION
## 🌎 Problème

On souhaite pouvoir avoir la possibilité de mettre un texte au dessus du stepper, qui servira d'instruction pour tous les steps.
Aujourd'hui, le métier peut avoir à répéter un même texte dans plusieurs steps.

## 🔭 Proposition

Créer le paramètre `instruction`, visible uniquement dans les stepper horizontaux.

## 🚀 Pour tester

Dans https://app-pr15532.review.pix.fr/modules/6a68bf32/bac-a-sable

- 2 instructions ont été ajoutées

<img width="641" height="352" alt="Capture d’écran 2026-03-18 à 17 26 58" src="https://github.com/user-attachments/assets/42bac659-a66c-4b0d-be3b-3b4540db3519" />


- Dans le stepper horizontal de bac-a-sable, voir l'instruction s'afficher entre le bouton de contrôle et les steps.

<img width="849" height="457" alt="Capture d’écran 2026-03-18 à 17 25 01" src="https://github.com/user-attachments/assets/e41286d3-d051-4172-8a77-c307a668ecb2" />

- Voir que la seconde instruction, placé dans un grain `lesson`, ne s'affiche pas. Il est dans un stepper vertical.


🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘 🌑
