### PR TITLE
[FEATURE] Pouvoir modifier le nom d'un réseau (PIX-21949)

### DIFF
--- a/admin/app/components/networks/edit-form.gjs
+++ b/admin/app/components/networks/edit-form.gjs
@@ -1,0 +1,89 @@
+import PixButton from '@1024pix/pix-ui/components/pix-button';
+import PixInput from '@1024pix/pix-ui/components/pix-input';
+import { fn } from '@ember/helper';
+import { on } from '@ember/modifier';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { t } from 'ember-intl';
+import Joi from 'joi';
+import { FormValidator } from 'pix-admin/utils/form-validator';
+
+const NETWORK_EDIT_FORM_VALIDATION_SCHEMA = Joi.object({
+  name: Joi.string().empty(['', null]).max(50).required().messages({
+    'any.required': 'components.networks.editing.error-messages.name',
+    'string.empty': 'components.networks.editing.error-messages.name',
+    'string.max': 'components.networks.editing.error-messages.name-max-length',
+  }),
+});
+
+export default class NetworkEditForm extends Component {
+  @service pixToast;
+  @service intl;
+
+  @tracked form = { name: this.args.network.name };
+
+  validator = new FormValidator(NETWORK_EDIT_FORM_VALIDATION_SCHEMA);
+
+  handleInputChange = (key, event) => {
+    const { value } = event.target;
+    this.validator.validateField(key, value);
+    this.form = { ...this.form, [key]: value };
+  };
+
+  @action
+  async handleSubmit(event) {
+    event.preventDefault();
+
+    const isValid = this.validator.validate(this.form);
+    if (!isValid) {
+      this.pixToast.sendErrorNotification({
+        message: this.intl.t('components.networks.editing.notifications.validation-error'),
+      });
+      return;
+    }
+
+    try {
+      this.args.network.set('name', this.form.name);
+      await this.args.network.save();
+      this.pixToast.sendSuccessNotification({
+        message: this.intl.t('components.networks.editing.notifications.success'),
+      });
+      this.args.hideForm();
+    } catch {
+      this.pixToast.sendErrorNotification({
+        message: this.intl.t('components.networks.editing.notifications.error'),
+      });
+      this.args.network.rollbackAttributes();
+    }
+  }
+
+  <template>
+    <form class="admin-form" {{on "submit" this.handleSubmit}}>
+      <section class="admin-form__content">
+        <div class="network-edit-form__name-input">
+          <PixInput
+            @id="network-name"
+            @value={{this.form.name}}
+            @requiredLabel={{t "common.fields.required-field"}}
+            required={{true}}
+            {{on "change" (fn this.handleInputChange "name")}}
+            @errorMessage={{if this.validator.errors.name (t this.validator.errors.name)}}
+            @validationStatus={{if this.validator.errors.name "error"}}
+          >
+            <:label>{{t "components.networks.editing.name.label"}}</:label>
+          </PixInput>
+        </div>
+      </section>
+      <section class="admin-form__actions">
+        <PixButton @size="small" @variant="secondary" @triggerAction={{@hideForm}}>
+          {{t "common.actions.cancel"}}
+        </PixButton>
+        <PixButton @type="submit" @size="small" @variant="success">
+          {{t "common.actions.save"}}
+        </PixButton>
+      </section>
+    </form>
+  </template>
+}

--- a/admin/app/components/networks/edit-form.scss
+++ b/admin/app/components/networks/edit-form.scss
@@ -1,0 +1,3 @@
+.network-edit-form__name-input {
+  width: 400px;
+}

--- a/admin/app/components/networks/head-information.gjs
+++ b/admin/app/components/networks/head-information.gjs
@@ -1,19 +1,25 @@
-import t from 'ember-intl/helpers/t';
-import CopyButton from 'pix-admin/components/ui/copy-button';
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 
-<template>
-  <div class="network__head-information">
-    <div class="network__title-section">
-      <h1 class="network__name">{{@network.name}}</h1>
-      <div class="network__id">
-        <p>ID : <span>{{@network.id}}</span></p>
-        <CopyButton
-          @id="copy-network-id"
-          @value={{@network.id}}
-          @tooltip={{t "components.networks.copy-id"}}
-          @label={{t "components.networks.copy-id"}}
-        />
-      </div>
+import NetworkEditForm from './edit-form';
+import NetworkTitleView from './title-view';
+
+export default class NetworkHeadInformation extends Component {
+  @tracked isEditMode = false;
+
+  @action
+  toggleEditMode() {
+    this.isEditMode = !this.isEditMode;
+  }
+
+  <template>
+    <div class="network__head-information">
+      {{#if this.isEditMode}}
+        <NetworkEditForm @network={{@network}} @hideForm={{this.toggleEditMode}} />
+      {{else}}
+        <NetworkTitleView @network={{@network}} @onEdit={{this.toggleEditMode}} />
+      {{/if}}
     </div>
-  </div>
-</template>
+  </template>
+}

--- a/admin/app/components/networks/head-information.scss
+++ b/admin/app/components/networks/head-information.scss
@@ -13,6 +13,12 @@
     display: flex;
     flex-direction: column;
 
+    .network__name-row {
+      display: flex;
+      align-items: center;
+      gap: var(--pix-spacing-2x);
+    }
+
     .network__name {
       @extend %pix-title-s;
     }

--- a/admin/app/components/networks/title-view.gjs
+++ b/admin/app/components/networks/title-view.gjs
@@ -1,0 +1,33 @@
+import PixIconButton from '@1024pix/pix-ui/components/pix-icon-button';
+import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
+import t from 'ember-intl/helpers/t';
+import CopyButton from 'pix-admin/components/ui/copy-button';
+
+<template>
+  <div class="network__title-section">
+    <div class="network__name-row">
+      <h1 class="network__name">{{@network.name}}</h1>
+      <PixTooltip @id="edit-network-tooltip" @position="top" @isInline={{true}}>
+        <:triggerElement>
+          <PixIconButton
+            @iconName="edit"
+            @ariaLabel={{t "common.actions.edit"}}
+            @size="small"
+            @triggerAction={{@onEdit}}
+            aria-describedby="edit-network-tooltip"
+          />
+        </:triggerElement>
+        <:tooltip>{{t "components.networks.editing.actions.edit-tooltip"}}</:tooltip>
+      </PixTooltip>
+    </div>
+    <div class="network__id">
+      <p>ID : <span>{{@network.id}}</span></p>
+      <CopyButton
+        @id="copy-network-id"
+        @value={{@network.id}}
+        @tooltip={{t "components.networks.copy-id"}}
+        @label={{t "components.networks.copy-id"}}
+      />
+    </div>
+  </div>
+</template>

--- a/admin/app/serializers/network.js
+++ b/admin/app/serializers/network.js
@@ -1,0 +1,15 @@
+import ApplicationSerializer from './application';
+
+export default class NetworkSerializer extends ApplicationSerializer {
+  serialize(snapshot, options) {
+    const json = super.serialize(snapshot, options);
+
+    if (!snapshot.record.isNew) {
+      json.data.attributes = {
+        name: json.data.attributes.name,
+      };
+    }
+
+    return json;
+  }
+}

--- a/admin/tests/acceptance/authenticated/networks/edit-network-test.js
+++ b/admin/tests/acceptance/authenticated/networks/edit-network-test.js
@@ -1,0 +1,31 @@
+import { fillByLabel, visit } from '@1024pix/ember-testing-library';
+import { click } from '@ember/test-helpers';
+import { t } from 'ember-intl/test-support';
+import { setupApplicationTest } from 'ember-qunit';
+import { authenticateAdminMemberWithRole } from 'pix-admin/tests/helpers/test-init';
+import { setupMirage } from 'pix-admin/tests/test-support/setup-mirage';
+import { module, test } from 'qunit';
+
+import setupIntl from '../../../helpers/setup-intl';
+
+module('Acceptance | Networks | Edit', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+  setupIntl(hooks);
+
+  test('it edits the network name successfully', async function (assert) {
+    // given
+    await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+    const network = server.create('network', { name: 'Ancien nom' });
+    const screen = await visit(`/networks/${network.id}`);
+
+    // when
+    await click(screen.getByRole('button', { name: t('common.actions.edit') }));
+    await fillByLabel(`${t('components.networks.editing.name.label')} *`, 'Nouveau nom');
+    await click(screen.getByRole('button', { name: t('common.actions.save') }));
+
+    // then
+    assert.ok(await screen.findByText(t('components.networks.editing.notifications.success')));
+    assert.dom(screen.getByRole('heading', { name: 'Nouveau nom' })).exists();
+  });
+});

--- a/admin/tests/integration/components/networks/edit-form-test.gjs
+++ b/admin/tests/integration/components/networks/edit-form-test.gjs
@@ -1,0 +1,122 @@
+import { fillByLabel, render } from '@1024pix/ember-testing-library';
+import EmberObject from '@ember/object';
+import { click } from '@ember/test-helpers';
+import { t } from 'ember-intl/test-support';
+import NetworkEditForm from 'pix-admin/components/networks/edit-form';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | networks/edit-form', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  let pixToast;
+
+  hooks.beforeEach(function () {
+    pixToast = this.owner.lookup('service:pixToast');
+    sinon.stub(pixToast, 'sendSuccessNotification');
+    sinon.stub(pixToast, 'sendErrorNotification');
+  });
+
+  test('it renders the name field pre-filled with the network name', async function (assert) {
+    // given
+    const network = EmberObject.create({ name: 'Mon réseau' });
+    const hideFormNoop = sinon.stub();
+
+    // when
+    const screen = await render(
+      <template><NetworkEditForm @network={{network}} @hideForm={{hideFormNoop}} /></template>,
+    );
+
+    // then
+    const nameInput = screen.getByRole('textbox', { name: `${t('components.networks.editing.name.label')} *` });
+    assert.dom(nameInput).hasValue('Mon réseau');
+  });
+
+  test('it renders the cancel and save buttons', async function (assert) {
+    // given
+    const network = EmberObject.create({ name: 'Mon réseau' });
+    const hideFormNoop = sinon.stub();
+
+    // when
+    const screen = await render(
+      <template><NetworkEditForm @network={{network}} @hideForm={{hideFormNoop}} /></template>,
+    );
+
+    // then
+    assert.dom(screen.getByRole('button', { name: t('common.actions.cancel') })).exists();
+    assert.dom(screen.getByRole('button', { name: t('common.actions.save') })).exists();
+  });
+
+  module('when submitting an empty name', function () {
+    test('it does not call network.save()', async function (assert) {
+      // given
+      const network = EmberObject.create({ name: null, save: sinon.stub(), set: sinon.stub() });
+      const hideFormNoop = sinon.stub();
+      const screen = await render(
+        <template><NetworkEditForm @network={{network}} @hideForm={{hideFormNoop}} /></template>,
+      );
+
+      // when
+      await click(screen.getByRole('button', { name: t('common.actions.save') }));
+
+      // then
+      assert.ok(network.save.notCalled);
+    });
+  });
+
+  module('when submitting a valid name', function () {
+    test('it saves the network and shows a success notification', async function (assert) {
+      // given
+      const network = EmberObject.create({ name: 'Ancien nom', save: sinon.stub().resolves(), set: sinon.stub() });
+      const onHideForm = sinon.stub();
+
+      // when
+      const screen = await render(
+        <template><NetworkEditForm @network={{network}} @hideForm={{onHideForm}} /></template>,
+      );
+      await fillByLabel(`${t('components.networks.editing.name.label')} *`, 'Nouveau nom');
+      await click(screen.getByRole('button', { name: t('common.actions.save') }));
+
+      // then
+      assert.ok(network.set.calledOnceWith('name', 'Nouveau nom'));
+      assert.ok(network.save.calledOnce);
+      assert.ok(
+        pixToast.sendSuccessNotification.calledOnceWith({
+          message: t('components.networks.editing.notifications.success'),
+        }),
+      );
+      assert.ok(onHideForm.calledOnce);
+    });
+  });
+
+  module('when the save fails', function () {
+    test('it shows an error notification and rollbacks the network attributes', async function (assert) {
+      // given
+      const network = EmberObject.create({
+        name: 'Ancien nom',
+        save: sinon.stub().rejects(),
+        set: sinon.stub(),
+        rollbackAttributes: sinon.stub(),
+      });
+      const onHideForm = sinon.stub();
+
+      // when
+      const screen = await render(
+        <template><NetworkEditForm @network={{network}} @hideForm={{onHideForm}} /></template>,
+      );
+      await fillByLabel(`${t('components.networks.editing.name.label')} *`, 'Nouveau nom');
+      await click(screen.getByRole('button', { name: t('common.actions.save') }));
+
+      // then
+      assert.ok(
+        pixToast.sendErrorNotification.calledOnceWith({
+          message: t('components.networks.editing.notifications.error'),
+        }),
+      );
+      assert.ok(network.rollbackAttributes.calledOnce);
+      assert.ok(onHideForm.notCalled);
+    });
+  });
+});

--- a/admin/tests/integration/components/networks/head-information-test.gjs
+++ b/admin/tests/integration/components/networks/head-information-test.gjs
@@ -1,5 +1,6 @@
 import { render } from '@1024pix/ember-testing-library';
 import EmberObject from '@ember/object';
+import { click } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import HeadInformation from 'pix-admin/components/networks/head-information';
 import { module, test } from 'qunit';
@@ -22,5 +23,32 @@ module('Integration | Component | Networks | head-information', function (hooks)
       assert.dom(screen.getByText((_, element) => element.textContent === 'ID : 1')).exists();
       assert.dom(screen.getByRole('button', { name: t('components.networks.copy-id') })).exists();
     });
+  });
+
+  test('clicking the edit button shows the edit form', async function (assert) {
+    // given
+    const network = EmberObject.create({ id: 1, name: 'Mon réseau' });
+    const screen = await render(<template><HeadInformation @network={{network}} /></template>);
+
+    // when
+    await click(screen.getByRole('button', { name: t('common.actions.edit') }));
+
+    // then
+    assert.dom(screen.getByRole('button', { name: t('common.actions.cancel') })).exists();
+    assert.dom(screen.queryByRole('heading', { name: 'Mon réseau' })).doesNotExist();
+  });
+
+  test('clicking the cancel button hides the form and shows the title view', async function (assert) {
+    // given
+    const network = EmberObject.create({ id: 1, name: 'Mon réseau' });
+    const screen = await render(<template><HeadInformation @network={{network}} /></template>);
+    await click(screen.getByRole('button', { name: t('common.actions.edit') }));
+
+    // when
+    await click(screen.getByRole('button', { name: t('common.actions.cancel') }));
+
+    // then
+    assert.dom(screen.getByRole('heading', { name: 'Mon réseau' })).exists();
+    assert.dom(screen.queryByRole('button', { name: t('common.actions.cancel') })).doesNotExist();
   });
 });

--- a/admin/tests/integration/components/networks/title-view-test.gjs
+++ b/admin/tests/integration/components/networks/title-view-test.gjs
@@ -1,0 +1,41 @@
+import { render } from '@1024pix/ember-testing-library';
+import EmberObject from '@ember/object';
+import { click } from '@ember/test-helpers';
+import { t } from 'ember-intl/test-support';
+import NetworkTitleView from 'pix-admin/components/networks/title-view';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | networks/title-view', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('it displays the network name, id and edit button', async function (assert) {
+    // given
+    const network = EmberObject.create({ id: 42, name: 'Mon réseau' });
+    const noop = sinon.stub();
+
+    // when
+    const screen = await render(<template><NetworkTitleView @network={{network}} @onEdit={{noop}} /></template>);
+
+    // then
+    assert.dom(screen.getByRole('heading', { name: 'Mon réseau' })).exists();
+    assert.dom(screen.getByText((_, element) => element.textContent === 'ID : 42')).exists();
+    assert.dom(screen.getByRole('button', { name: t('components.networks.copy-id') })).exists();
+    assert.dom(screen.getByRole('button', { name: t('common.actions.edit') })).exists();
+  });
+
+  test('clicking the edit button calls @onEdit', async function (assert) {
+    // given
+    const network = EmberObject.create({ id: 1, name: 'Mon réseau' });
+    const onEdit = sinon.stub();
+
+    // when
+    const screen = await render(<template><NetworkTitleView @network={{network}} @onEdit={{onEdit}} /></template>);
+    await click(screen.getByRole('button', { name: t('common.actions.edit') }));
+
+    // then
+    assert.ok(onEdit.calledOnce);
+  });
+});

--- a/admin/tests/mirage/handlers/networks.js
+++ b/admin/tests/mirage/handlers/networks.js
@@ -8,6 +8,14 @@ export function createNetwork(schema, request) {
   });
 }
 
+export function updateNetwork(schema, request) {
+  const networkId = request.params.id;
+  const params = JSON.parse(request.requestBody);
+
+  const network = schema.find('network', networkId);
+  return network.update({ name: params.data.attributes.name });
+}
+
 export function findAllFilteredNetworks(schema, request) {
   const name = request.queryParams['filter[name]'];
   let networks = schema.networks.all().models;

--- a/admin/tests/mirage/routes.js
+++ b/admin/tests/mirage/routes.js
@@ -18,7 +18,7 @@ import { findFrameworkAreas } from './handlers/frameworks';
 import { getPaginatedJuryCertificationSummariesBySessionId } from './handlers/get-jury-certification-summaries-by-session-id';
 import { getToBePublishedSessions } from './handlers/get-to-be-published-sessions';
 import { getWithRequiredActionSessions } from './handlers/get-with-required-action-sessions';
-import { createNetwork, findAllFilteredNetworks } from './handlers/networks';
+import { createNetwork, findAllFilteredNetworks, updateNetwork } from './handlers/networks';
 import { createOrganizationMembership } from './handlers/organization-memberships';
 import {
   archiveOrganization,
@@ -371,6 +371,7 @@ export default function routes() {
   this.get('/admin/networks', findAllFilteredNetworks);
   this.get('/admin/networks/:id');
   this.post('/admin/networks', createNetwork);
+  this.patch('/admin/networks/:id', updateNetwork);
 
   this.get('/admin/organizations', findPaginatedFilteredOrganizations);
   this.post('/admin/organizations', (schema, request) => {

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -702,6 +702,23 @@
           "label": "ID of the organization at the head of the network:"
         }
       },
+      "editing": {
+        "actions": {
+          "edit-tooltip": "Edit network name"
+        },
+        "error-messages": {
+          "name": "The network name is required.",
+          "name-max-length": "The network name cannot exceed 50 characters."
+        },
+        "name": {
+          "label": "Network name:"
+        },
+        "notifications": {
+          "error": "An error occurred while updating the network.",
+          "success": "The network was successfully updated.",
+          "validation-error": "The form contains errors."
+        }
+      },
       "information-view": {
         "head-organization": "Head organisation",
         "head-organization-id": "ID of the head organisation"

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -704,6 +704,23 @@
           "label": "ID d'organisation à la tête du réseau:"
         }
       },
+      "editing": {
+        "actions": {
+          "edit-tooltip": "Modifier le nom du réseau"
+        },
+        "error-messages": {
+          "name": "Le nom du réseau est requis.",
+          "name-max-length": "Le nom du réseau ne peut pas dépasser 50 caractères."
+        },
+        "name": {
+          "label": "Nom du réseau :"
+        },
+        "notifications": {
+          "error": "Une erreur est survenue lors de la modification du réseau.",
+          "success": "Le réseau a été modifié avec succès.",
+          "validation-error": "Le formulaire contient des erreurs."
+        }
+      },
       "information-view": {
         "head-organization": "Organisation tête de réseau",
         "head-organization-id": "ID de l'organisation tête de réseau"

--- a/api/src/organizational-entities/application/network/network.admin.controller.js
+++ b/api/src/organizational-entities/application/network/network.admin.controller.js
@@ -13,6 +13,13 @@ const getNetworkDetails = async function (request, h, dependencies = { networkSe
   return dependencies.networkSerializer.serialize(network);
 };
 
+const update = async function (request, h, dependencies = { networkSerializer }) {
+  const networkId = request.params.networkId;
+  const { networkName } = networkSerializer.deserialize({ data: request.payload.data });
+  const network = await usecases.updateNetwork({ networkId, networkName });
+  return dependencies.networkSerializer.serialize(network);
+};
+
 const create = async function (request, h, dependencies = { networkSerializer }) {
   const { organizationId, networkName } = networkSerializer.deserialize({
     data: request.payload.data,
@@ -32,6 +39,7 @@ const networkAdminController = {
   create,
   findAllFilteredNetworks,
   getNetworkDetails,
+  update,
 };
 
 export { networkAdminController };

--- a/api/src/organizational-entities/application/network/network.admin.route.js
+++ b/api/src/organizational-entities/application/network/network.admin.route.js
@@ -70,6 +70,42 @@ const register = async function (server) {
       },
     },
     {
+      method: 'PATCH',
+      path: '/api/admin/networks/{networkId}',
+      config: {
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.hasAtLeastOneAccessOf([securityPreHandlers.checkAdminMemberHasRoleSuperAdmin])(
+                request,
+                h,
+              ),
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        validate: {
+          params: Joi.object({
+            networkId: identifiersType.networkId,
+          }),
+          payload: Joi.object({
+            data: Joi.object({
+              id: Joi.string(),
+              attributes: Joi.object({
+                name: Joi.string().required(),
+              }),
+              type: Joi.string(),
+            }),
+          }),
+        },
+        handler: (request, h) => networkAdminController.update(request, h),
+        tags: ['api', 'organizational-entities', 'network'],
+        notes: [
+          "- **Cette route est restreinte aux utilisateurs ayant les droits d'accès Superadmin**\n" +
+            "- Modification du nom d'un réseau.",
+        ],
+      },
+    },
+    {
       method: 'POST',
       path: '/api/admin/networks',
       config: {

--- a/api/src/organizational-entities/domain/models/Network.js
+++ b/api/src/organizational-entities/domain/models/Network.js
@@ -8,6 +8,10 @@ class Network {
       this.headOrganization = new NetworkHeadOrganization({ id: organizationId, name: organizationName });
     }
   }
+
+  updateName(name) {
+    this.name = name;
+  }
 }
 
 export { Network };

--- a/api/src/organizational-entities/domain/usecases/index.js
+++ b/api/src/organizational-entities/domain/usecases/index.js
@@ -110,6 +110,7 @@ import { getOrganizationPlacesStatistics } from './get-organization-places-stati
 import { getRecentlyUsedTags } from './get-recently-used-tags.usecase.js';
 import { updateCertificationCenter } from './update-certification-center.usecase.js';
 import { updateCertificationCenterDataProtectionOfficerInformation } from './update-certification-center-data-protection-officer-information.usecase.js';
+import { updateNetwork } from './update-network.usecase.js';
 import { updateOrganizationInformation } from './update-organization-information.usecase.js';
 import { updateOrganizationsInBatch } from './update-organizations-in-batch.usecase.js';
 
@@ -143,6 +144,7 @@ const usecasesWithoutInjectedDependencies = {
   getRecentlyUsedTags,
   updateCertificationCenterDataProtectionOfficerInformation,
   updateCertificationCenter,
+  updateNetwork,
   updateOrganizationInformation,
   updateOrganizationsInBatch,
 };

--- a/api/src/organizational-entities/domain/usecases/update-network.usecase.js
+++ b/api/src/organizational-entities/domain/usecases/update-network.usecase.js
@@ -1,0 +1,14 @@
+/**
+ * @param {object} params
+ * @param {number} params.networkId
+ * @param {string} params.networkName
+ * @param {NetworkRepository} params.networkRepository
+ * @returns {Promise<Network>}
+ */
+const updateNetwork = async function ({ networkId, networkName, networkRepository }) {
+  const network = await networkRepository.getById(networkId);
+  network.updateName(networkName);
+  return networkRepository.update(network);
+};
+
+export { updateNetwork };

--- a/api/src/organizational-entities/infrastructure/repositories/network.repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/network.repository.js
@@ -104,8 +104,26 @@ async function save({ organizationId, networkName }) {
   return _toDomain(savedNetwork);
 }
 
+/**
+ * @param {Network} network
+ * @returns {Promise<Network>}
+ */
+async function update(network) {
+  const knexConn = DomainTransaction.getConnection();
+
+  const [updatedNetwork] = await knexConn('networks')
+    .where({ id: network.id })
+    .update({ name: network.name }, ['id', 'name']);
+
+  if (!updatedNetwork) {
+    throw new NotFoundError();
+  }
+
+  return _toDomain(updatedNetwork);
+}
+
 function _toDomain(network) {
   return new Network(network);
 }
 
-export { findAll, findByOrganizationId, getById, save };
+export { findAll, findByOrganizationId, getById, save, update };

--- a/api/tests/organizational-entities/acceptance/application/network/network.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/network/network.admin.route.test.js
@@ -93,6 +93,34 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | N
     });
   });
 
+  describe('PATCH /api/admin/networks/{networkId}', function () {
+    it('updates the network name and returns 200', async function () {
+      // given
+      const network = databaseBuilder.factory.buildNetworkAndHeadOrganization({ name: 'Ancien nom' });
+      await databaseBuilder.commit();
+
+      const request = {
+        method: 'PATCH',
+        url: `/api/admin/networks/${network.id}`,
+        headers: generateAuthenticatedUserRequestHeaders(superAdmin),
+        payload: {
+          data: {
+            attributes: {
+              name: 'Nouveau nom',
+            },
+          },
+        },
+      };
+
+      // when
+      const response = await server.inject(request);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result.data.attributes.name).to.equal('Nouveau nom');
+    });
+  });
+
   describe('GET /api/admin/networks with filter', function () {
     it('returns filtered networks by name with 200 HTTP status code', async function () {
       // given

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/network.repository.test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/network.repository.test.js
@@ -235,6 +235,40 @@ describe('Integration | Organizational Entities | Infrastructure | Repositories 
     });
   });
 
+  describe('#update', function () {
+    describe('when the network exists', function () {
+      it('updates and returns the network with the new name', async function () {
+        // given
+        const persistedNetwork = databaseBuilder.factory.buildNetwork({ name: 'Ancien nom' });
+        await databaseBuilder.commit();
+        const network = domainBuilder.acquisition.buildNetwork({ id: persistedNetwork.id, name: 'Nouveau nom' });
+
+        // when
+        const updatedNetwork = await networkRepository.update(network);
+
+        // then
+        const foundNetwork = await knex('networks').select('id', 'name').where({ id: persistedNetwork.id }).first();
+        expect(foundNetwork.name).to.equal('Nouveau nom');
+        expect(updatedNetwork).to.deep.equal(
+          domainBuilder.acquisition.buildNetwork({ id: persistedNetwork.id, name: 'Nouveau nom' }),
+        );
+      });
+    });
+
+    describe('when the network does not exist', function () {
+      it('throws a NotFoundError', async function () {
+        // given
+        const network = domainBuilder.acquisition.buildNetwork({ id: 99999, name: 'Nom' });
+
+        // when
+        const error = await catchErr(networkRepository.update)(network);
+
+        // then
+        expect(error).to.be.instanceOf(NotFoundError);
+      });
+    });
+  });
+
   describe('#save', function () {
     it('saves and returns the new network', async function () {
       // given

--- a/api/tests/organizational-entities/unit/application/network/network.admin.controller.test.js
+++ b/api/tests/organizational-entities/unit/application/network/network.admin.controller.test.js
@@ -63,6 +63,32 @@ describe('Unit | Organizational Entities | Application | Network', function () {
     });
   });
 
+  describe('#update', function () {
+    it('calls "updateNetwork" use case with the right parameters', async function () {
+      // given
+      const networkId = 1;
+      const networkName = 'Nouveau nom';
+      const request = {
+        params: { networkId },
+        payload: {
+          data: {
+            attributes: { name: networkName },
+          },
+        },
+      };
+      const updatedNetwork = domainBuilder.acquisition.buildNetwork({ id: networkId, name: networkName });
+      sinon.stub(usecases, 'updateNetwork').resolves(updatedNetwork);
+      const networkSerializer = { serialize: sinon.stub(), deserialize: sinon.stub().returns({ networkName }) };
+
+      // when
+      await networkAdminController.update(request, hFake, { networkSerializer });
+
+      // then
+      expect(usecases.updateNetwork).to.have.been.calledOnceWith({ networkId, networkName });
+      expect(networkSerializer.serialize).to.have.been.calledWithExactly(updatedNetwork);
+    });
+  });
+
   describe('#create', function () {
     context('when payload contains only required fields', function () {
       it('calls "createNetwork" use case with the right parameters', async function () {

--- a/api/tests/organizational-entities/unit/application/network/network.admin.route.test.js
+++ b/api/tests/organizational-entities/unit/application/network/network.admin.route.test.js
@@ -98,6 +98,53 @@ describe('Unit | Application | Admin | Route | Network', function () {
     });
   });
 
+  describe('PATCH /api/admin/networks/{networkId}', function () {
+    describe('when the authenticated user has super admin role', function () {
+      it('should call update controller method', async function () {
+        // given
+        sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
+        sinon.stub(usecases, 'updateNetwork').returns('ok');
+        sinon.stub(networkAdminController, 'update').returns('ok');
+
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        await httpTestServer.request('PATCH', '/api/admin/networks/1', {
+          data: {
+            attributes: { name: 'Nouveau nom' },
+          },
+        });
+
+        // then
+        sinon.assert.called(networkAdminController.update);
+      });
+    });
+
+    describe('when the user authenticated has no role', function () {
+      it('should return 403 HTTP status code', async function () {
+        // given
+        sinon
+          .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
+          .returns((request, h) => h.response().code(403).takeover());
+        sinon.stub(networkAdminController, 'update').returns('ok');
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const response = await httpTestServer.request('PATCH', '/api/admin/networks/1', {
+          data: {
+            attributes: { name: 'Nouveau nom' },
+          },
+        });
+
+        // then
+        expect(response.statusCode).to.equal(403);
+        sinon.assert.notCalled(networkAdminController.update);
+      });
+    });
+  });
+
   describe('POST /api/admin/networks', function () {
     describe('when the authenticated user has super admin role', function () {
       it('should call create controller method', async function () {

--- a/api/tests/organizational-entities/unit/domain/models/Network_test.js
+++ b/api/tests/organizational-entities/unit/domain/models/Network_test.js
@@ -38,4 +38,17 @@ describe('Unit | Organizational Entities | Domain | Model | Network', function (
       });
     });
   });
+
+  describe('#updateName', function () {
+    it('should update the network name', function () {
+      // given
+      const network = new Network({ id: 1, name: 'Ancien nom' });
+
+      // when
+      network.updateName('Nouveau nom');
+
+      // then
+      expect(network.name).to.equal('Nouveau nom');
+    });
+  });
 });


### PR DESCRIPTION
## 🌎 Problème

Dans le cadre de la gestion des réseaux, l'utilisateur SUPER_ADMIN doit pouvoir modifier le nom d'un réseau

## 🔭 Proposition

- Ajouter un bouton de modification sur la page de détail d'un réseau



## 🚀 Pour tester
- Depuis pix-admin
- Aller sur la page de détail d'un réseau
- Cliquer sur l'icone de modification du nom du réseau
- Changer le nom
- Constater que le nouveau nom a bien été enregistré 

🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘 🌑
