### PR TITLE
[TECH] Afficher les éléments ids d'un module lors de l'arrivée sur la preview (PIX-21990)

### DIFF
--- a/mon-pix/app/components/module/preview.gjs
+++ b/mon-pix/app/components/module/preview.gjs
@@ -187,7 +187,7 @@ export default class ModulixPreview extends Component {
     {{/unless}}
 
     <div class="modulix-preview__elements-id-button" {{didInsert this.setHTMLElementOffset}}>
-      <PixSegmentedControl @onChange={{this.toggleElementIdButton}} @variant="primary" @toggled={{true}}>
+      <PixSegmentedControl @onChange={{this.toggleElementIdButton}} @variant="primary" @toggled={{false}}>
         <:label>{{t "pages.modulix.preview.elements-id-button.label"}}</:label>
         <:viewA>{{t "pages.modulix.preview.elements-id-button.choices.yes"}}</:viewA>
         <:viewB>{{t "pages.modulix.preview.elements-id-button.choices.no"}}</:viewB>

--- a/mon-pix/app/components/module/preview.gjs
+++ b/mon-pix/app/components/module/preview.gjs
@@ -134,8 +134,8 @@ export default class ModulixPreview extends Component {
   noop() {}
 
   @action
-  enableElementsIdButton() {
-    this.modulixPreviewMode.enableElementsIdButton();
+  toggleElementIdButton() {
+    this.modulixPreviewMode.toggleElementIdButton();
   }
 
   @action
@@ -187,7 +187,7 @@ export default class ModulixPreview extends Component {
     {{/unless}}
 
     <div class="modulix-preview__elements-id-button" {{didInsert this.setHTMLElementOffset}}>
-      <PixSegmentedControl @onChange={{this.enableElementsIdButton}} @variant="primary" @toggled={{true}}>
+      <PixSegmentedControl @onChange={{this.toggleElementIdButton}} @variant="primary" @toggled={{true}}>
         <:label>{{t "pages.modulix.preview.elements-id-button.label"}}</:label>
         <:viewA>{{t "pages.modulix.preview.elements-id-button.choices.yes"}}</:viewA>
         <:viewB>{{t "pages.modulix.preview.elements-id-button.choices.no"}}</:viewB>

--- a/mon-pix/app/services/modulix-preview-mode.js
+++ b/mon-pix/app/services/modulix-preview-mode.js
@@ -4,7 +4,7 @@ import { tracked } from '@glimmer/tracking';
 
 export default class ModulixPreviewModeService extends Service {
   isEnabled = false;
-  @tracked isElementsIdButtonEnabled = false;
+  @tracked isElementsIdButtonEnabled = true;
 
   enable() {
     this.isEnabled = true;

--- a/mon-pix/app/services/modulix-preview-mode.js
+++ b/mon-pix/app/services/modulix-preview-mode.js
@@ -14,7 +14,7 @@ export default class ModulixPreviewModeService extends Service {
     return this.isEnabled && this.isElementsIdButtonEnabled;
   }
 
-  @action enableElementsIdButton() {
+  @action toggleElementIdButton() {
     this.isElementsIdButtonEnabled = !this.isElementsIdButtonEnabled;
   }
 }

--- a/mon-pix/tests/unit/services/modulix-preview-mode-test.js
+++ b/mon-pix/tests/unit/services/modulix-preview-mode-test.js
@@ -32,7 +32,8 @@ module('Unit | Service | modulix-preview-mode', function (hooks) {
       assert.false(previewMode.isElementsIdButtonEnabled);
     });
 
-    test('it enables elements id button', function (assert) {
+  module('toggleElementIdButton', function () {
+    test('it switches elements id button state', function (assert) {
       // given
       const previewMode = this.owner.lookup('service:modulix-preview-mode');
 
@@ -42,46 +43,46 @@ module('Unit | Service | modulix-preview-mode', function (hooks) {
       // then
       assert.true(previewMode.isElementsIdButtonEnabled);
     });
+  });
 
-    module('get isPreviewAndElementsIdButtonEnabled', function () {
-      module('when preview mode is not enabled', function () {
-        test('it returns false', function (assert) {
-          // given
-          const previewMode = this.owner.lookup('service:modulix-preview-mode');
+  module('get isPreviewAndElementsIdButtonEnabled', function () {
+    module('when preview mode is not enabled', function () {
+      test('it returns false', function (assert) {
+        // given
+        const previewMode = this.owner.lookup('service:modulix-preview-mode');
 
-          // when
-          previewMode.enableElementsIdButton();
+        // when
+        previewMode.toggleElementIdButton();
 
-          // then
-          assert.false(previewMode.isPreviewAndElementsIdButtonEnabled);
-        });
+        // then
+        assert.false(previewMode.isPreviewAndElementsIdButtonEnabled);
       });
+    });
 
-      module('when elements id button is not enabled', function () {
-        test('it returns false', function (assert) {
-          // given
-          const previewMode = this.owner.lookup('service:modulix-preview-mode');
+    module('when elements id button is not enabled', function () {
+      test('it returns false', function (assert) {
+        // given
+        const previewMode = this.owner.lookup('service:modulix-preview-mode');
 
           // when
           previewMode.enable();
 
-          // then
-          assert.false(previewMode.isPreviewAndElementsIdButtonEnabled);
-        });
+        // then
+        assert.false(previewMode.isPreviewAndElementsIdButtonEnabled);
       });
+    });
 
-      module('when both are enabled', function () {
-        test('it returns true', function (assert) {
-          // given
-          const previewMode = this.owner.lookup('service:modulix-preview-mode');
+    module('when both are enabled', function () {
+      test('it returns true', function (assert) {
+        // given
+        const previewMode = this.owner.lookup('service:modulix-preview-mode');
 
           // when
           previewMode.enable();
           previewMode.enableElementsIdButton();
 
-          // then
-          assert.true(previewMode.isPreviewAndElementsIdButtonEnabled);
-        });
+        // then
+        assert.true(previewMode.isPreviewAndElementsIdButtonEnabled);
       });
     });
   });

--- a/mon-pix/tests/unit/services/modulix-preview-mode-test.js
+++ b/mon-pix/tests/unit/services/modulix-preview-mode-test.js
@@ -24,13 +24,14 @@ module('Unit | Service | modulix-preview-mode', function (hooks) {
   });
 
   module('isElementsIdButtonEnabled', function () {
-    test('it should be disabled by default', function (assert) {
+    test('it should be enabled by default', function (assert) {
       // when
       const previewMode = this.owner.lookup('service:modulix-preview-mode');
 
       // then
-      assert.false(previewMode.isElementsIdButtonEnabled);
+      assert.true(previewMode.isElementsIdButtonEnabled);
     });
+  });
 
   module('toggleElementIdButton', function () {
     test('it switches elements id button state', function (assert) {
@@ -38,10 +39,10 @@ module('Unit | Service | modulix-preview-mode', function (hooks) {
       const previewMode = this.owner.lookup('service:modulix-preview-mode');
 
       // when
-      previewMode.enableElementsIdButton();
+      previewMode.toggleElementIdButton();
 
       // then
-      assert.true(previewMode.isElementsIdButtonEnabled);
+      assert.false(previewMode.isElementsIdButtonEnabled);
     });
   });
 
@@ -64,8 +65,9 @@ module('Unit | Service | modulix-preview-mode', function (hooks) {
         // given
         const previewMode = this.owner.lookup('service:modulix-preview-mode');
 
-          // when
-          previewMode.enable();
+        // when
+        previewMode.toggleElementIdButton();
+        previewMode.enable();
 
         // then
         assert.false(previewMode.isPreviewAndElementsIdButtonEnabled);
@@ -77,9 +79,8 @@ module('Unit | Service | modulix-preview-mode', function (hooks) {
         // given
         const previewMode = this.owner.lookup('service:modulix-preview-mode');
 
-          // when
-          previewMode.enable();
-          previewMode.enableElementsIdButton();
+        // when
+        previewMode.enable();
 
         // then
         assert.true(previewMode.isPreviewAndElementsIdButtonEnabled);


### PR DESCRIPTION
## 🌎 Problème

Lors de l’accès à une preview d’un module, les éléments ids ne sont pas affichés par défaut.

## 🔭 Proposition

Le faire

## 🪐 Remarques

On renomme le nom de la méthode pour afficher / cacher les elementIds.

## 🚀 Pour tester
- Aller sur la [preview](https://app-pr15534.review.pix.fr/modules/preview/bac-a-sable) d'un module (ex : /modules/preview/bac-a-sable)
- Constater que les elements ids sont maintenant bien affichés par défaut 😄 

🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘 🌑
