### PR TITLE
[TECH] :recycle: Remplace l'utilisation de `lodash.isNill`par `== null`

### DIFF
--- a/api/src/certification/enrolment/domain/services/certification-candidates-ods-service.js
+++ b/api/src/certification/enrolment/domain/services/certification-candidates-ods-service.js
@@ -150,13 +150,13 @@ async function extractCertificationCandidatesFromCandidatesImportSheet({
 function _filterOutEmptyCandidateData(certificationCandidatesData) {
   return _(certificationCandidatesData)
     .mapValues(_nullifyObjectWithOnlyNilValues)
-    .pickBy((value) => !_.isNull(value))
+    .pickBy((value) => value !== null)
     .value();
 }
 
 function _nullifyObjectWithOnlyNilValues(data) {
   for (const propName in data) {
-    if (!_.isNil(data[propName])) {
+    if (data[propName] != null) {
       return data;
     }
   }

--- a/api/src/certification/session-management/domain/models/CertificationCandidateForSupervising.js
+++ b/api/src/certification/session-management/domain/models/CertificationCandidateForSupervising.js
@@ -1,7 +1,4 @@
-import lodash from 'lodash';
-
-const { isNil } = lodash;
-class CertificationCandidateForSupervising {
+export class CertificationCandidateForSupervising {
   constructor({
     id,
     userId,
@@ -25,7 +22,7 @@ class CertificationCandidateForSupervising {
     this.firstName = firstName;
     this.lastName = lastName;
     this.birthdate = birthdate;
-    this.extraTimePercentage = !isNil(extraTimePercentage) ? parseFloat(extraTimePercentage) : extraTimePercentage;
+    this.extraTimePercentage = extraTimePercentage != null ? parseFloat(extraTimePercentage) : extraTimePercentage;
     this.authorizedToStart = authorizedToStart;
     this.assessmentStatus = assessmentStatus;
     this.startDateTime = startDateTime;
@@ -49,5 +46,3 @@ class CertificationCandidateForSupervising {
     );
   }
 }
-
-export { CertificationCandidateForSupervising };

--- a/api/src/certification/shared/domain/models/CertificationCandidate.js
+++ b/api/src/certification/shared/domain/models/CertificationCandidate.js
@@ -1,8 +1,4 @@
-import lodash from 'lodash';
-
 import { BILLING_MODES } from '../constants.js';
-
-const { isNil } = lodash;
 
 class CertificationCandidate {
   /**
@@ -50,7 +46,7 @@ class CertificationCandidate {
     this.resultRecipientEmail = resultRecipientEmail;
     this.externalId = externalId;
     this.birthdate = birthdate;
-    this.extraTimePercentage = !isNil(extraTimePercentage) ? parseFloat(extraTimePercentage) : extraTimePercentage;
+    this.extraTimePercentage = extraTimePercentage != null ? parseFloat(extraTimePercentage) : extraTimePercentage;
     this.createdAt = createdAt;
     this.authorizedToStart = authorizedToStart;
     this.sessionId = sessionId;

--- a/api/src/evaluation/domain/models/Badge.js
+++ b/api/src/evaluation/domain/models/Badge.js
@@ -1,9 +1,6 @@
-import lodash from 'lodash';
-const { isNil } = lodash;
-
 const UPDATABLE_PROPERTIES = ['message', 'altMessage', 'key', 'title', 'imageUrl', 'isCertifiable', 'isAlwaysVisible'];
 
-class Badge {
+export class Badge {
   constructor({
     id,
     key,
@@ -30,7 +27,7 @@ class Badge {
 
   updateBadgeProperties(badgeToUpdate) {
     UPDATABLE_PROPERTIES.forEach((property) => {
-      if (!isNil(badgeToUpdate[property])) this[property] = badgeToUpdate[property];
+      if (badgeToUpdate[property] != null) this[property] = badgeToUpdate[property];
     });
   }
 
@@ -49,5 +46,3 @@ class Badge {
     });
   }
 }
-
-export { Badge };

--- a/api/src/evaluation/domain/models/target-profile-management/StageCollectionUpdate.js
+++ b/api/src/evaluation/domain/models/target-profile-management/StageCollectionUpdate.js
@@ -7,9 +7,9 @@ const DEFAULT_VALUE_FIRST_SKILL = -1;
 class StageCollectionUpdate {
   constructor({ stagesDTO, stageCollection }) {
     this._stagesDTO = stagesDTO.map((stageDTO) => ({
-      id: _.isNil(stageDTO.id) ? null : parseInt(stageDTO.id),
-      threshold: _.isNil(stageDTO.threshold) ? null : parseInt(stageDTO.threshold),
-      level: _.isNil(stageDTO.level) ? null : parseInt(stageDTO.level),
+      id: stageDTO.id == null ? null : parseInt(stageDTO.id),
+      threshold: stageDTO.threshold == null ? null : parseInt(stageDTO.threshold),
+      level: stageDTO.level == null ? null : parseInt(stageDTO.level),
       isFirstSkill: Boolean(stageDTO.isFirstSkill),
       title: _.isEmpty(stageDTO.title) ? '' : stageDTO.title,
       message: _.isEmpty(stageDTO.message) ? '' : stageDTO.message,

--- a/api/src/organizational-entities/infrastructure/serializers/jsonapi/organizations-administration/organization-for-admin.serializer.js
+++ b/api/src/organizational-entities/infrastructure/serializers/jsonapi/organizations-administration/organization-for-admin.serializer.js
@@ -1,5 +1,4 @@
 import { Serializer } from 'jsonapi-serializer';
-import _ from 'lodash';
 
 import { OrganizationForAdmin } from '../../../../domain/models/OrganizationForAdmin.js';
 import { OrganizationLearnerType } from '../../../../domain/models/OrganizationLearnerType.js';
@@ -128,7 +127,7 @@ const deserialize = function (json) {
   }
 
   const organization = new OrganizationForAdmin({
-    id: _.isNil(json.data.id) ? null : parseInt(json.data.id),
+    id: json.data.id == null ? null : parseInt(json.data.id),
     name: attributes.name,
     type: attributes.type,
     email: attributes.email,

--- a/api/src/prescription/campaign-participation/domain/models/CampaignAssessmentParticipation.js
+++ b/api/src/prescription/campaign-participation/domain/models/CampaignAssessmentParticipation.js
@@ -1,10 +1,8 @@
-import _ from 'lodash';
-
 import { CampaignParticipationStatuses } from '../../../shared/domain/constants.js';
 
 const { SHARED } = CampaignParticipationStatuses;
 
-class CampaignAssessmentParticipation {
+export class CampaignAssessmentParticipation {
   constructor({
     userId,
     firstName,
@@ -37,7 +35,7 @@ class CampaignAssessmentParticipation {
     this.createdAt = createdAt;
     this.progression = progression;
     this.badges = badges ?? [];
-    this.masteryRate = !_.isNil(masteryRate) ? Number(masteryRate) : null;
+    this.masteryRate = masteryRate != null ? Number(masteryRate) : null;
     this.validatedSkillsCount = validatedSkillsCount;
     this.reachedStage = reachedStage;
     this.totalStage = totalStage;
@@ -60,5 +58,3 @@ class CampaignAssessmentParticipation {
     this.prescriberDescription = reachedStage.prescriberDescription;
   }
 }
-
-export { CampaignAssessmentParticipation };

--- a/api/src/prescription/campaign-participation/domain/read-models/CampaignParticipationOverview.js
+++ b/api/src/prescription/campaign-participation/domain/read-models/CampaignParticipationOverview.js
@@ -40,7 +40,7 @@ class CampaignParticipationOverview {
     this.campaignCode = campaignCode;
     this.campaignTitle = campaignTitle;
     this.campaignName = campaignName;
-    this.masteryRate = !_.isNil(masteryRate) ? Number(masteryRate) : null;
+    this.masteryRate = masteryRate != null ? Number(masteryRate) : null;
     this.validatedSkillsCount = validatedSkillsCount;
     const dates = [deletedAt, campaignArchivedAt].filter((a) => a != null);
     this.totalStagesCount = totalStagesCount;

--- a/api/src/prescription/campaign/application/api/models/CampaignParticipation.js
+++ b/api/src/prescription/campaign/application/api/models/CampaignParticipation.js
@@ -1,5 +1,3 @@
-import _ from 'lodash';
-
 class CampaignParticipation {
   /**
    * @typedef {Object} CampaignParticipationArgs
@@ -61,7 +59,7 @@ class AssessmentCampaignParticipation extends CampaignParticipation {
    */
   constructor(args) {
     super(args);
-    this.masteryRate = !_.isNil(args.masteryRate) ? Number(args.masteryRate) : null;
+    this.masteryRate = args.masteryRate != null ? Number(args.masteryRate) : null;
     this.tubes = args.tubes?.map((tube) => new TubeCoverage(tube));
     this.stages = args.stages;
     this.badges = args.badges;

--- a/api/src/prescription/campaign/domain/read-models/CampaignAssessmentParticipationResultMinimal.js
+++ b/api/src/prescription/campaign/domain/read-models/CampaignAssessmentParticipationResultMinimal.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 
-class CampaignAssessmentParticipationResultMinimal {
+export class CampaignAssessmentParticipationResultMinimal {
   #previousMasteryRate;
   constructor({
     campaignParticipationId,
@@ -20,8 +20,8 @@ class CampaignAssessmentParticipationResultMinimal {
     this.firstName = firstName;
     this.lastName = lastName;
     this.participantExternalId = participantExternalId;
-    this.masteryRate = !_.isNil(masteryRate) ? Number(masteryRate) : null;
-    this.#previousMasteryRate = !_.isNil(previousMasteryRate) ? Number(previousMasteryRate) : null;
+    this.masteryRate = masteryRate != null ? Number(masteryRate) : null;
+    this.#previousMasteryRate = previousMasteryRate != null ? Number(previousMasteryRate) : null;
     this.reachedStage = reachedStage;
     this.totalStage = totalStage;
     this.prescriberTitle = prescriberTitle;
@@ -39,5 +39,3 @@ class CampaignAssessmentParticipationResultMinimal {
     if (this.masteryRate === this.#previousMasteryRate) return 'stable';
   }
 }
-
-export { CampaignAssessmentParticipationResultMinimal };

--- a/api/src/prescription/campaign/domain/read-models/CampaignParticipation.js
+++ b/api/src/prescription/campaign/domain/read-models/CampaignParticipation.js
@@ -1,5 +1,3 @@
-import _ from 'lodash';
-
 class CampaignParticipation {
   /**
    * @typedef {Object} CampaignParticipationArgs
@@ -66,7 +64,7 @@ class AssessmentCampaignParticipation extends CampaignParticipation {
    */
   constructor(args) {
     super(args);
-    this.masteryRate = !_.isNil(args.masteryRate) ? Number(args.masteryRate) : null;
+    this.masteryRate = args.masteryRate != null ? Number(args.masteryRate) : null;
     this.tubes = args.tubes;
     this.stages = args.stages;
     this.badges = args.badges;

--- a/api/src/prescription/campaign/domain/read-models/CampaignParticipationInfo.js
+++ b/api/src/prescription/campaign/domain/read-models/CampaignParticipationInfo.js
@@ -1,7 +1,6 @@
 import JoiDate from '@joi/date';
 import BaseJoi from 'joi';
 const Joi = BaseJoi.extend(JoiDate);
-import _ from 'lodash';
 
 import { validateEntity } from '../../../../shared/domain/validators/entity-validator.js';
 import { CampaignParticipationStatuses } from '../../../shared/domain/constants.js';
@@ -27,7 +26,7 @@ const validationSchema = Joi.object({
   pixScore: Joi.number().default(null).allow(null),
 });
 
-class CampaignParticipationInfo {
+export class CampaignParticipationInfo {
   constructor({
     participantFirstName,
     participantLastName,
@@ -58,8 +57,8 @@ class CampaignParticipationInfo {
     this.sharedAt = sharedAt;
     this.division = division;
     this.group = group;
-    this.masteryRate = !_.isNil(masteryRate) ? Number(masteryRate) : null;
-    this.validatedSkillsCount = !_.isNil(validatedSkillsCount) ? Number(validatedSkillsCount) : null;
+    this.masteryRate = masteryRate != null ? Number(masteryRate) : null;
+    this.validatedSkillsCount = validatedSkillsCount != null ? Number(validatedSkillsCount) : null;
     this.status = status;
     this.pixScore = pixScore;
     validateEntity(validationSchema, this);
@@ -73,5 +72,3 @@ class CampaignParticipationInfo {
     return Boolean(this.sharedAt);
   }
 }
-
-export { CampaignParticipationInfo };

--- a/api/src/prescription/learner-management/infrastructure/serializers/xml/xml-organization-learner-set.js
+++ b/api/src/prescription/learner-management/infrastructure/serializers/xml/xml-organization-learner-set.js
@@ -3,7 +3,7 @@ import customParseFormat from 'dayjs/plugin/customParseFormat.js';
 dayjs.extend(customParseFormat);
 
 import lodash from 'lodash';
-const { isEmpty, isNil, each } = lodash;
+const { isEmpty, each } = lodash;
 
 import { SIECLE_ERRORS } from '../../../../../shared/domain/errors.js';
 import { isValidDate } from '../../../../../shared/infrastructure/utils/date-utils.js';
@@ -134,7 +134,7 @@ function _convertSexCode(obj) {
 }
 
 function _getValueFromParsedElement(obj) {
-  if (isNil(obj)) return null;
+  if (obj == null) return null;
   return Array.isArray(obj) && !isEmpty(obj) ? obj[0] : obj;
 }
 

--- a/api/src/prescription/organization-learner/domain/usecases/create-and-reconcile-user-to-organization-learner.js
+++ b/api/src/prescription/organization-learner/domain/usecases/create-and-reconcile-user-to-organization-learner.js
@@ -1,6 +1,3 @@
-import lodash from 'lodash';
-const { isNil } = lodash;
-
 import { createAccountCreationEmail } from '../../../../identity-access-management/domain/emails/create-account-creation.email.js';
 import { User } from '../../../../identity-access-management/domain/models/User.js';
 import { STUDENT_RECONCILIATION_ERRORS } from '../../../../shared/domain/constants.js';
@@ -11,7 +8,7 @@ import {
   OrganizationLearnerAlreadyLinkedToUserError,
 } from '../../../../shared/domain/errors.js';
 
-const createAndReconcileUserToOrganizationLearner = async function ({
+export async function createAndReconcileUserToOrganizationLearner({
   organizationId,
   redirectionUrl,
   locale,
@@ -39,7 +36,7 @@ const createAndReconcileUserToOrganizationLearner = async function ({
       obfuscationService,
     });
 
-  const organizationLearnerFound = !isNil(matchedOrganizationLearner.userId);
+  const organizationLearnerFound = matchedOrganizationLearner.userId != null;
   if (organizationLearnerFound) {
     const detail = 'Un compte existe déjà pour l‘élève dans le même établissement.';
     const error = STUDENT_RECONCILIATION_ERRORS.LOGIN_OR_REGISTER.IN_SAME_ORGANIZATION.username;
@@ -89,7 +86,7 @@ const createAndReconcileUserToOrganizationLearner = async function ({
     );
   }
   return createdUser;
-};
+}
 
 function _encryptPassword(userPassword, cryptoService) {
   const encryptedPassword = cryptoService.hashPassword(userPassword);
@@ -190,5 +187,3 @@ async function _validateData({
     throw EntityValidationError.fromMultipleEntityValidationErrors(relevantErrors);
   }
 }
-
-export { createAndReconcileUserToOrganizationLearner };

--- a/api/src/shared/domain/services/user-reconciliation-service.js
+++ b/api/src/shared/domain/services/user-reconciliation-service.js
@@ -55,7 +55,7 @@ export async function findMatchingSupOrganizationLearnerIdForGivenOrganizationId
     throw new NotFoundError('Found no organization learner matching organization and names');
   }
 
-  if (!lodash.isNil(organizationLearner.userId)) {
+  if (organizationLearner.userId != null) {
     throw new OrganizationLearnerAlreadyLinkedToUserError();
   }
   return organizationLearner;
@@ -89,7 +89,7 @@ export async function assertStudentHasAnAlreadyReconciledAccount(
   obfuscationService,
   studentRepository,
 ) {
-  if (!lodash.isNil(organizationLearner.userId)) {
+  if (organizationLearner.userId != null) {
     await _buildStudentReconciliationError(
       organizationLearner.userId,
       'IN_SAME_ORGANIZATION',

--- a/api/src/shared/infrastructure/repositories/assessment-result-repository.js
+++ b/api/src/shared/infrastructure/repositories/assessment-result-repository.js
@@ -56,7 +56,7 @@ const save = async function ({ certificationCourseId, assessmentResult }) {
   } = assessmentResult;
   const commentByAutoJury = _getCommentByAutoJury(assessmentResult);
 
-  if (_.isNil(assessmentId)) {
+  if (assessmentId == null) {
     throw new MissingAssessmentId();
   }
 

--- a/api/src/shared/infrastructure/utils/lodash-utils.js
+++ b/api/src/shared/infrastructure/utils/lodash-utils.js
@@ -4,7 +4,7 @@ const { runInContext } = pkg;
 const _ = runInContext();
 
 const isBlank = (string) => {
-  return _.isNil(string) || (_.isString(string) && string.trim().length === 0);
+  return string == null || (_.isString(string) && string.trim().length === 0);
 };
 
 _.mixin({

--- a/api/src/team/domain/models/AdminMember.js
+++ b/api/src/team/domain/models/AdminMember.js
@@ -1,16 +1,13 @@
 import JoiDate from '@joi/date';
 import BaseJoi from 'joi';
 const Joi = BaseJoi.extend(JoiDate);
-import lodash from 'lodash';
 
 import { PIX_ADMIN } from '../../../authorization/domain/constants.js';
 import { validateEntity } from '../../../shared/domain/validators/entity-validator.js';
 
-const { isNil } = lodash;
-
 const { ROLES } = PIX_ADMIN;
 
-class AdminMember {
+export class AdminMember {
   constructor({ id, userId, firstName, lastName, email, role, createdAt, updatedAt, disabledAt }) {
     this.id = id;
     this.userId = userId;
@@ -39,28 +36,26 @@ class AdminMember {
   }
 
   get hasAccessToAdminScope() {
-    return this.role in ROLES && isNil(this.disabledAt);
+    return this.role in ROLES && this.disabledAt == null;
   }
 
   get isSuperAdmin() {
-    return this.role === ROLES.SUPER_ADMIN && isNil(this.disabledAt);
+    return this.role === ROLES.SUPER_ADMIN && this.disabledAt == null;
   }
 
   get isCertif() {
-    return this.role === ROLES.CERTIF && isNil(this.disabledAt);
+    return this.role === ROLES.CERTIF && this.disabledAt == null;
   }
 
   get isMetier() {
-    return this.role === ROLES.METIER && isNil(this.disabledAt);
+    return this.role === ROLES.METIER && this.disabledAt == null;
   }
 
   get isSupport() {
-    return this.role === ROLES.SUPPORT && isNil(this.disabledAt);
+    return this.role === ROLES.SUPPORT && this.disabledAt == null;
   }
 
   get fullName() {
     return `${this.firstName} ${this.lastName}`;
   }
 }
-
-export { AdminMember };


### PR DESCRIPTION
## 🌎 Problème

Nous utilisons des fonctions `lodash` pour des opérations qui pourraient être réalisés en JavaScript natif.

## 🔭 Proposition

Remplacé les utilisations de `isNil` par l'utilisation de ` == null` et ` != null`.

## 🪐 Remarques
```javascript
// Lodash
console.log(_.isNil(null))
// output: true
console.log(_.isNil(NaN))
// output: false
console.log(_.isNil(undefined))
// output: true

// Native
console.log(null == null);
// output: true
console.log(NaN == null);
// output: false
console.log(undefined == null)
// output: true
```
## 🚀 Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->

🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘 🌑
