### PR TITLE
[FEATURE] Ajout d'un formulaire de création d'attestation sur Pix Admin (PIX-21596)

### DIFF
--- a/admin/app/components/administration/common/create-attestations.gjs
+++ b/admin/app/components/administration/common/create-attestations.gjs
@@ -1,0 +1,142 @@
+import PixButton from '@1024pix/pix-ui/components/pix-button';
+import PixButtonUpload from '@1024pix/pix-ui/components/pix-button-upload';
+import PixInput from '@1024pix/pix-ui/components/pix-input';
+import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
+import { on } from '@ember/modifier';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { t } from 'ember-intl';
+import { not } from 'ember-truth-helpers';
+import ENV from 'pix-admin/config/environment';
+
+import AdministrationBlockLayout from '../block-layout';
+
+export default class CreateAttestations extends Component {
+  @service intl;
+  @service pixToast;
+  @service requestManager;
+
+  @tracked file;
+  @tracked templateKey;
+  @tracked templateName;
+
+  @service store;
+
+  get isFormFilled() {
+    return this.file && this.templateKey && this.templateName;
+  }
+
+  @action
+  async handleFile(files) {
+    this.file = files[0];
+  }
+
+  @action
+  async onTemplateKeyChange(event) {
+    this.templateKey = event.target.value;
+  }
+
+  @action
+  async onTemplateNameChange(event) {
+    this.templateName = event.target.value;
+  }
+
+  @action
+  async onSubmit(event) {
+    event.preventDefault();
+    try {
+      const formData = new FormData();
+
+      formData.append('templateKey', this.templateKey);
+      formData.append('templateName', this.templateName);
+      formData.append('templateFile', this.file);
+
+      await this.requestManager.request({
+        url: `${ENV.APP.API_HOST}/api/admin/attestations`,
+        method: 'POST',
+        body: formData,
+      });
+
+      this.pixToast.sendSuccessNotification({
+        message: this.intl.t('components.administration.create-attestations.notifications.success'),
+      });
+    } catch (error) {
+      if (error.status === 413) {
+        this.pixToast.sendErrorNotification({
+          message: this.intl.t('components.administration.create-attestations.notifications.error.payload-too-large'),
+        });
+      } else if (error.code === 'S3_UPLOAD_ERROR') {
+        this.pixToast.sendErrorNotification({
+          message: this.intl.t('components.administration.create-attestations.notifications.error.s3-upload-error'),
+        });
+      } else if (error.code === 'DUPLICATE_ATTESTATION_KEY') {
+        this.pixToast.sendErrorNotification({
+          message: this.intl.t(
+            'components.administration.create-attestations.notifications.error.duplicate-attestation-key',
+          ),
+        });
+      } else if (error.status === 400 && error.code === 'WRONG_FILE_FORMAT') {
+        this.pixToast.sendErrorNotification({
+          message: this.intl.t('components.administration.create-attestations.notifications.error.wrong-file-format'),
+        });
+      } else {
+        this.pixToast.sendErrorNotification({
+          message: this.intl.t('components.administration.create-attestations.notifications.error.generic-error'),
+        });
+      }
+    }
+  }
+
+  <template>
+    <form {{on "submit" this.onSubmit}}>
+      <AdministrationBlockLayout
+        @title={{t "components.administration.create-attestations.title"}}
+        @description={{t "components.administration.create-attestations.description"}}
+        @actionsClass="create-attestations__actions"
+        class="create-attestations"
+      >
+        <PixInput
+          required="true"
+          @value={{this.templateKey}}
+          {{on "input" this.onTemplateKeyChange}}
+          @requiredLabel="Champ obligatoire"
+        >
+          <:label>{{t "components.administration.create-attestations.template-key"}} </:label>
+        </PixInput>
+        <PixInput
+          required="true"
+          @value={{this.templateName}}
+          {{on "input" this.onTemplateNameChange}}
+          @requiredLabel="Champ obligatoire"
+        >
+          <:label>{{t "components.administration.create-attestations.template-name"}} </:label>
+        </PixInput>
+        <PixButtonUpload
+          @id="attestations-file-upload"
+          @onChange={{this.handleFile}}
+          @variant="secondary"
+          accept=".pdf"
+        >
+          {{t "components.administration.create-attestations.upload-button"}}
+        </PixButtonUpload>
+        <PixButton @type="submit" @size="small" @isDisabled={{not this.isFormFilled}}>
+          {{t "components.administration.create-attestations.submit-button"}}
+        </PixButton>
+      </AdministrationBlockLayout>
+    </form>
+
+    {{#if this.errors}}
+      <PixNotificationAlert @withIcon={{true}} @type="error" class="create-attestations__errors">
+        <ul>
+          {{#each this.errors as |error|}}
+            <li class="create-attestations__error">
+              <span>{{error.detail}}</span>
+            </li>
+          {{/each}}
+        </ul>
+      </PixNotificationAlert>
+    {{/if}}
+  </template>
+}

--- a/admin/app/components/administration/common/index.gjs
+++ b/admin/app/components/administration/common/index.gjs
@@ -1,4 +1,5 @@
 import AddOrganizationFeaturesInBatch from './add-organization-features-in-batch';
+import CreateAttestations from './create-attestations';
 import CreateCombinedCourses from './create-combined-courses';
 import LearningContent from './learning-content';
 import UpsertQuestsInBatch from './upsert-quests-in-batch';
@@ -10,4 +11,5 @@ import UserQuestChecker from './user-quest-checker';
   <UpsertQuestsInBatch />
   <UserQuestChecker />
   <CreateCombinedCourses />
+  <CreateAttestations />
 </template>

--- a/admin/app/components/administration/deployment/organizations-batch-archive.gjs
+++ b/admin/app/components/administration/deployment/organizations-batch-archive.gjs
@@ -23,7 +23,6 @@ export default class OrganizationsBatchArchive extends Component {
 
     const formData = new FormData();
     formData.append('file', files[0]);
-
     const numberOfDataLines = await _getCsvDataLinesCount(files);
 
     try {

--- a/admin/app/models/attestation.js
+++ b/admin/app/models/attestation.js
@@ -1,0 +1,7 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class Attestation extends Model {
+  @attr('string') templateName;
+  @attr('string') templateKey;
+  @attr() file;
+}

--- a/admin/app/styles/components/administration/create-attestations.scss
+++ b/admin/app/styles/components/administration/create-attestations.scss
@@ -1,0 +1,5 @@
+.create-attestations {
+  &__actions {
+      align-items: flex-end;
+  }
+}

--- a/admin/app/styles/components/administration/index.scss
+++ b/admin/app/styles/components/administration/index.scss
@@ -5,3 +5,4 @@
 @use 'upsert-quests-in-batch';
 @use 'user-quest-checker';
 @use 'create-combined-courses';
+@use 'create-attestations';

--- a/admin/tests/integration/components/administration/common/create-attestations-test.gjs
+++ b/admin/tests/integration/components/administration/common/create-attestations-test.gjs
@@ -1,0 +1,146 @@
+import { fillByLabel, render } from '@1024pix/ember-testing-library';
+import PixToastContainer from '@1024pix/pix-ui/components/pix-toast-container';
+import { click, triggerEvent } from '@ember/test-helpers';
+import { t } from 'ember-intl/test-support';
+import CreateAttestations from 'pix-admin/components/administration/common/create-attestations';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+
+const fileContent = 'foo';
+const file = new Blob([fileContent], { type: `valid-file` });
+
+module('Integration | Component | administration/create-attestations', function (hooks) {
+  setupIntlRenderingTest(hooks);
+  let requestManagerService;
+
+  hooks.beforeEach(function () {
+    requestManagerService = this.owner.lookup('service:requestManager');
+    sinon.stub(requestManagerService, 'request');
+  });
+
+  hooks.afterEach(function () {
+    sinon.restore();
+  });
+
+  module('when all fields are filled', function () {
+    test('it should enable submit button', async function (assert) {
+      const screen = await render(<template><CreateAttestations /></template>);
+
+      const inputFile = screen.getByLabelText(t('components.administration.create-attestations.upload-button'));
+      const submit = screen.getByRole('button', {
+        name: t('components.administration.create-attestations.submit-button'),
+      });
+
+      await triggerEvent(inputFile, 'change', { files: [file] });
+      await fillByLabel(t('components.administration.create-attestations.template-key'), 'key', { exact: false });
+      await fillByLabel(t('components.administration.create-attestations.template-name'), 'name', { exact: false });
+
+      assert.dom(submit).doesNotHaveAttribute('aria-disabled');
+    });
+
+    test('it should display success notification', async function (assert) {
+      // given
+      requestManagerService.request.resolves({ response: { ok: true, status: 204 } });
+
+      const screen = await render(
+        <template><CreateAttestations /><PixToastContainer @closeButtonAriaLabel="Close" /></template>,
+      );
+
+      const inputFile = screen.getByLabelText(t('components.administration.create-attestations.upload-button'));
+      const submit = screen.getByRole('button', {
+        name: t('components.administration.create-attestations.submit-button'),
+      });
+
+      await triggerEvent(inputFile, 'change', { files: [file] });
+      await fillByLabel(t('components.administration.create-attestations.template-key'), 'key', { exact: false });
+      await fillByLabel(t('components.administration.create-attestations.template-name'), 'name', { exact: false });
+
+      await click(submit);
+
+      assert.ok(await screen.findByText(t('components.administration.create-attestations.notifications.success')));
+    });
+  });
+
+  module('when not all fields are filled', function () {
+    test('it should disable submit button if no file', async function (assert) {
+      const screen = await render(
+        <template><CreateAttestations /><PixToastContainer @closeButtonAriaLabel="Close" /></template>,
+      );
+      const submit = screen.getByRole('button', {
+        name: t('components.administration.create-attestations.submit-button'),
+      });
+
+      await fillByLabel(t('components.administration.create-attestations.template-key'), 'key', { exact: false });
+      await fillByLabel(t('components.administration.create-attestations.template-name'), 'name', { exact: false });
+
+      assert.dom(submit).hasAttribute('aria-disabled');
+    });
+
+    test('it should disable submit button if no key or name', async function (assert) {
+      const screen = await render(
+        <template><CreateAttestations /><PixToastContainer @closeButtonAriaLabel="Close" /></template>,
+      );
+
+      const inputFile = screen.getByLabelText(t('components.administration.create-attestations.upload-button'));
+      const submit = screen.getByRole('button', {
+        name: t('components.administration.create-attestations.submit-button'),
+      });
+
+      await triggerEvent(inputFile, 'change', { files: [file] });
+
+      assert.dom(submit).hasAttribute('aria-disabled');
+    });
+  });
+
+  module('error cases', function () {
+    [
+      {
+        name: 'payload is too large',
+        status: 413,
+        code: null,
+        translationKey: 'components.administration.create-attestations.notifications.error.payload-too-large',
+      },
+      {
+        name: 'S3 upload',
+        status: null,
+        code: 'S3_UPLOAD_ERROR',
+        translationKey: 'components.administration.create-attestations.notifications.error.s3-upload-error',
+      },
+      {
+        name: 'duplicate attestation key',
+        status: null,
+        code: 'DUPLICATE_ATTESTATION_KEY',
+        translationKey: 'components.administration.create-attestations.notifications.error.duplicate-attestation-key',
+      },
+      {
+        name: 'wrong file format',
+        status: 400,
+        code: 'WRONG_FILE_FORMAT',
+        translationKey: 'components.administration.create-attestations.notifications.error.wrong-file-format',
+      },
+    ].forEach(({ name, status, code, translationKey }) => {
+      test(`it should display ${name} error`, async function (assert) {
+        // given
+        requestManagerService.request.rejects({ status, code });
+
+        const screen = await render(
+          <template><CreateAttestations /><PixToastContainer @closeButtonAriaLabel="Close" /></template>,
+        );
+
+        const inputFile = screen.getByLabelText(t('components.administration.create-attestations.upload-button'));
+        const submit = screen.getByRole('button', {
+          name: t('components.administration.create-attestations.submit-button'),
+        });
+
+        await triggerEvent(inputFile, 'change', { files: [file] });
+        await fillByLabel(t('components.administration.create-attestations.template-key'), 'key', { exact: false });
+        await fillByLabel(t('components.administration.create-attestations.template-name'), 'name', { exact: false });
+
+        await click(submit);
+        assert.ok(await screen.findByText(t(translationKey)));
+      });
+    });
+  });
+});

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -198,6 +198,23 @@
         "title": "Archiving of certification centers in batch",
         "upload-button": "Import a CSV file"
       },
+      "create-attestations": {
+        "description": "Ask for expert help if needed",
+        "notifications": {
+          "error": {
+            "S3-upload-error": "File import error.",
+            "duplicate-attestation-key": "An attestation with this key already exists.",
+            "payload-too-large": "The PDF file must not be larger than 1 MB.",
+            "wrong-file-format": "Incorrect file format."
+          },
+          "success": "The attestation has been successfully created."
+        },
+        "submit-button": "Create attestation",
+        "template-key": "Template key",
+        "template-name": "Template name",
+        "title": "Create attestation",
+        "upload-button": "Import PDF file"
+      },
       "create-combined-courses": {
         "description": "Ask for expert help if needed",
         "notifications": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -199,6 +199,23 @@
         "title": "Archivage des centres de certification en masse",
         "upload-button": "Importer un fichier CSV"
       },
+      "create-attestations": {
+        "description": "Sollicitez un spécialiste des attestations",
+        "notifications": {
+          "error": {
+            "duplicate-attestation-key": "Une attestation avec cette clé existe déjà.",
+            "payload-too-large": "Le fichier PDF doit avoir une taille maximum de 1 Mb.",
+            "s3-upload-error": "Erreur lors de l'import du fichier.",
+            "wrong-file-format": "Le format du fichier est incorrect."
+          },
+          "success": "L'attestation a été créée avec succès."
+        },
+        "submit-button": "Créer l'attestation",
+        "template-key": "Template key",
+        "template-name": "Template name",
+        "title": "Création d'attestation",
+        "upload-button": "Importer un fichier PDF"
+      },
       "create-combined-courses": {
         "description": "Sollicitez un spécialiste des parcours combinés",
         "notifications": {

--- a/api/src/quest/application/attestation-controller.js
+++ b/api/src/quest/application/attestation-controller.js
@@ -1,0 +1,25 @@
+import { Readable } from 'node:stream';
+
+import { BadRequestError } from '../../shared/application/http-errors.js';
+import { usecases } from '../domain/usecases/index.js';
+
+const WRONG_FILE_FORMAT = 'WRONG_FILE_FORMAT';
+
+const save = async (request, h) => {
+  const attestation = request.payload;
+
+  if (attestation.templateFile.headers['content-type'] !== 'application/pdf') {
+    throw new BadRequestError('The file is not a pdf.', WRONG_FILE_FORMAT);
+  }
+  const templateFile = Readable.from(attestation.templateFile.payload);
+  await usecases.createAttestation({
+    templateFile,
+    templateKey: attestation.templateKey,
+    templateName: attestation.templateName,
+  });
+  return h.response().code(204);
+};
+
+const attestationController = { save };
+
+export { attestationController };

--- a/api/src/quest/application/attestation-route.js
+++ b/api/src/quest/application/attestation-route.js
@@ -1,0 +1,48 @@
+import Joi from 'joi';
+
+import { securityPreHandlers } from '../../shared/application/security-pre-handlers.js';
+import { attestationController } from './attestation-controller.js';
+
+const MAX_FILE_SIZE_UPLOAD = 1048576 * 1; // 1Mb
+
+const register = async function (server) {
+  server.route([
+    {
+      method: 'POST',
+      path: '/api/admin/attestations',
+      config: {
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.hasAtLeastOneAccessOf([
+                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+                securityPreHandlers.checkAdminMemberHasRoleMetier,
+                securityPreHandlers.checkAdminMemberHasRoleSupport,
+                securityPreHandlers.checkAdminMemberHasRoleCertif,
+              ])(request, h),
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        validate: {
+          payload: Joi.object({
+            templateKey: Joi.string().required(),
+            templateName: Joi.string().required(),
+            templateFile: Joi.any().required(),
+          }).required(),
+        },
+        payload: {
+          maxBytes: MAX_FILE_SIZE_UPLOAD,
+          multipart: { output: 'annotated' },
+          output: 'file',
+          parse: true,
+        },
+        handler: attestationController.save,
+        notes: ["- Creation d'une attestation"],
+        tags: ['api', 'attestation'],
+      },
+    },
+  ]);
+};
+
+const name = 'quest/attestations-api';
+export { name, register };

--- a/api/src/quest/domain/models/Attestation.js
+++ b/api/src/quest/domain/models/Attestation.js
@@ -1,0 +1,8 @@
+export class Attestation {
+  constructor({ id, templateName, key, createdAt }) {
+    this.id = id;
+    this.templateName = templateName;
+    this.key = key;
+    this.createdAt = createdAt;
+  }
+}

--- a/api/src/quest/domain/usecases/create-attestation.js
+++ b/api/src/quest/domain/usecases/create-attestation.js
@@ -1,0 +1,3 @@
+export const createAttestation = async ({ templateKey, templateName, templateFile, attestationRepository }) => {
+  await attestationRepository.save({ templateKey, templateName, templateFile });
+};

--- a/api/src/quest/domain/usecases/index.js
+++ b/api/src/quest/domain/usecases/index.js
@@ -22,6 +22,7 @@ const { combinedCourseDetailsService: injectedCombinedCourseDetailsService } = i
 
 const dependencies = {
   accessCodeRepository: repositories.accessCodeRepository,
+  attestationRepository: repositories.attestationRepository,
   eligibilityRepository: repositories.eligibilityRepository,
   rewardRepository: repositories.rewardRepository,
   successRepository: repositories.successRepository,
@@ -46,6 +47,7 @@ const dependencies = {
 
 import { attachOrganizationsToCombinedCourseBlueprint } from './attach-organizations-to-combined-course-blueprint.js';
 import { checkUserQuest } from './check-user-quest-success.js';
+import { createAttestation } from './create-attestation.js';
 import { createCombinedCourse } from './create-combined-course.js';
 import { createCombinedCourseBlueprint } from './create-combined-course-blueprint.js';
 import { createCombinedCourses } from './create-combined-courses.js';
@@ -92,6 +94,7 @@ const usecasesWithoutInjectedDependencies = {
   rewardUser,
   startCombinedCourse,
   updateCombinedCourseProgress,
+  createAttestation,
   createCombinedCourses,
   createCombinedCourseBlueprint,
   createCombinedCourse,

--- a/api/src/quest/infrastructure/repositories/attestation-repository.js
+++ b/api/src/quest/infrastructure/repositories/attestation-repository.js
@@ -1,0 +1,22 @@
+import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
+import { AlreadyExistingEntityError } from '../../../shared/domain/errors.js';
+import * as knexUtils from '../../../shared/infrastructure/utils/knex-utils.js';
+
+const ATTESTATION_KEY_UNIQUE_CONSTRAINT = 'attestations_key_unique';
+const DUPLICATE_ATTESTATION_KEY = 'DUPLICATE_ATTESTATION_KEY';
+
+export const save = async ({ templateName, templateKey, templateFile, attestationStorage }) => {
+  await DomainTransaction.execute(async () => {
+    const knexConn = DomainTransaction.getConnection();
+
+    try {
+      await knexConn('attestations').insert({ key: templateKey, templateName });
+      await attestationStorage.startUpload({ filename: `${templateName}.pdf`, readableStream: templateFile });
+    } catch (error) {
+      if (knexUtils.isUniqConstraintViolated(error) && error.constraint === ATTESTATION_KEY_UNIQUE_CONSTRAINT) {
+        throw new AlreadyExistingEntityError(error.detail, DUPLICATE_ATTESTATION_KEY);
+      }
+      throw error;
+    }
+  });
+};

--- a/api/src/quest/infrastructure/repositories/index.js
+++ b/api/src/quest/infrastructure/repositories/index.js
@@ -13,6 +13,8 @@ import * as rewardApi from '../../../profile/application/api/reward-api.js';
 import { temporaryStorage } from '../../../shared/infrastructure/key-value-storages/index.js';
 import * as accessCodeRepository from '../../../shared/infrastructure/repositories/access-code-repository.js';
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
+import { AttestationStorage } from '../storage/attestation-storage.js';
+import * as attestationRepository from './attestation-repository.js';
 import * as campaignParticipationRepository from './campaign-participation-repository.js';
 import * as campaignRepository from './campaign-repository.js';
 import * as combinedCourseDetailsRepository from './combined-course-details-repository.js';
@@ -48,6 +50,7 @@ const repositoriesWithoutInjectedDependencies = {
   recommendedModuleRepository,
   targetProfileRepository,
   campaignParticipationRepository,
+  attestationRepository,
 };
 
 const dependencies = {
@@ -64,6 +67,7 @@ const dependencies = {
   rewardApi,
   userApi,
   recommendedModulesApi,
+  attestationStorage: AttestationStorage.createClient(),
 };
 
 const repositories = injectDependencies(repositoriesWithoutInjectedDependencies, dependencies);

--- a/api/src/quest/infrastructure/storage/attestation-storage.js
+++ b/api/src/quest/infrastructure/storage/attestation-storage.js
@@ -1,9 +1,17 @@
 import { config } from '../../../shared/config.js';
+import { S3UploadError } from '../../../shared/domain/errors.js';
 import { S3ObjectStorageProvider } from '../../../shared/storage/infrastructure/providers/S3ObjectStorageProvider.js';
 
 class AttestationStorage extends S3ObjectStorageProvider {
   static createClient() {
-    return super.createClient(config.attestations.storage.client);
+    return new AttestationStorage(config.attestations.storage.client);
+  }
+  async startUpload() {
+    try {
+      return await super.startUpload(...arguments);
+    } catch (error) {
+      throw new S3UploadError(error.message);
+    }
   }
 }
 

--- a/api/src/quest/routes.js
+++ b/api/src/quest/routes.js
@@ -1,8 +1,15 @@
+import * as attestationRoute from './application/attestation-route.js';
 import * as combinedCourseBlueprintRoute from './application/combined-course-blueprint-route.js';
 import * as combinedCourseRoute from './application/combined-course-route.js';
 import * as questRoute from './application/quest-route.js';
 import * as verifiedCodeRoute from './application/verified-code-route.js';
 
-const questRoutes = [combinedCourseRoute, questRoute, verifiedCodeRoute, combinedCourseBlueprintRoute];
+const questRoutes = [
+  combinedCourseRoute,
+  questRoute,
+  verifiedCodeRoute,
+  combinedCourseBlueprintRoute,
+  attestationRoute,
+];
 
 export { questRoutes };

--- a/api/src/shared/domain/errors.js
+++ b/api/src/shared/domain/errors.js
@@ -1015,6 +1015,13 @@ class CertificationRescoringNotAllowedError extends DomainError {
   }
 }
 
+class S3UploadError extends DomainError {
+  constructor(message = "Erreur lors de l'import du fichier sur le S3.", code = 'S3_UPLOAD_ERROR') {
+    super(message);
+    this.code = code;
+  }
+}
+
 export {
   AccountRecoveryDemandExpired,
   AccountRecoveryUserAlreadyConfirmEmail,
@@ -1120,6 +1127,7 @@ export {
   OrganizationNotFoundError,
   OrganizationTagNotFound,
   OrganizationWithoutEmailError,
+  S3UploadError,
   SendingEmailError,
   SendingEmailToInvalidDomainError,
   SendingEmailToInvalidEmailAddressError,

--- a/api/src/shared/storage/infrastructure/providers/S3ObjectStorageProvider.js
+++ b/api/src/shared/storage/infrastructure/providers/S3ObjectStorageProvider.js
@@ -10,17 +10,22 @@ class S3ObjectStorageProvider {
   #bucket;
 
   constructor({
-    credentials,
+    accessKeyId,
+    secretAccessKey,
     endpoint,
     region,
     bucket,
     dependencies = { clientS3, libStorage, s3RequestPresigner, logger },
     forcePathStyle = false,
   }) {
+    if ([accessKeyId, secretAccessKey, endpoint, region, bucket].some((prop) => prop === undefined)) {
+      logger.warn('Invalid S3 configuration provided');
+    }
+
     this.#dependencies = dependencies;
 
     this.#s3Client = new dependencies.clientS3.S3Client({
-      credentials,
+      credentials: { accessKeyId, secretAccessKey },
       endpoint,
       region,
       forcePathStyle,
@@ -38,12 +43,9 @@ class S3ObjectStorageProvider {
     dependencies = { clientS3, libStorage, s3RequestPresigner },
     forcePathStyle,
   }) {
-    if ([accessKeyId, secretAccessKey, endpoint, region, bucket].some((prop) => prop === undefined)) {
-      logger.warn('Invalid S3 configuration provided');
-    }
-
     return new S3ObjectStorageProvider({
-      credentials: { accessKeyId, secretAccessKey },
+      accessKeyId,
+      secretAccessKey,
       endpoint,
       region,
       bucket,

--- a/api/tests/quest/acceptance/application/attestation-route_test.js
+++ b/api/tests/quest/acceptance/application/attestation-route_test.js
@@ -1,0 +1,101 @@
+import fs from 'node:fs';
+import { unlink, writeFile } from 'node:fs/promises';
+import * as url from 'node:url';
+
+import FormData from 'form-data';
+import streamToPromise from 'stream-to-promise';
+
+import { PIX_ADMIN } from '../../../../src/authorization/domain/constants.js';
+import {
+  createServer,
+  databaseBuilder,
+  expect,
+  generateAuthenticatedUserRequestHeaders,
+  getFakeAttestationTemplate,
+  knex,
+  mockAttestationStorageUpload,
+} from '../../../test-helper.js';
+
+const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
+
+describe('Quest | Acceptance | Application | Attestation Route ', function () {
+  let server;
+
+  beforeEach(async function () {
+    server = await createServer();
+  });
+
+  describe('POST /api/admin/attestations', function () {
+    context('when user has one of the authorized roles', function () {
+      let userId;
+
+      beforeEach(async function () {
+        userId = databaseBuilder.factory.buildUser.withRole({ role: PIX_ADMIN.ROLES.SUPER_ADMIN }).id;
+        await databaseBuilder.commit();
+      });
+      context('when all parameters are valid', function () {
+        it('creates attestation', async function () {
+          const templateKey = 'key';
+          const templateName = 'name';
+
+          const formData = new FormData();
+          formData.append('templateKey', templateKey);
+          formData.append('templateName', templateName);
+          formData.append('templateFile', getFakeAttestationTemplate());
+          mockAttestationStorageUpload({ attestation: { templateName } });
+          const options = {
+            method: 'POST',
+            url: '/api/admin/attestations',
+            headers: {
+              ...formData.getHeaders(),
+              ...generateAuthenticatedUserRequestHeaders({ userId }),
+            },
+            payload: await streamToPromise(formData),
+          };
+
+          // when
+          const response = await server.inject(options);
+
+          // then
+          const createdAttestation = await knex('attestations').where('key', templateKey).first();
+
+          expect(response.statusCode).to.equal(204);
+
+          expect(createdAttestation.templateName).to.equal('name');
+        });
+      });
+
+      context('when file is not a pdf', function () {
+        it('should return a 400 error code', async function () {
+          // given
+          const formData = new FormData();
+          formData.append('templateKey', 'key');
+          formData.append('templateName', 'name');
+
+          const testFilePath = `${__dirname}/testFile_temp.jpeg`;
+          await writeFile(testFilePath, Buffer.alloc(0));
+          formData.append('templateFile', fs.createReadStream(testFilePath));
+
+          const options = {
+            method: 'POST',
+            url: '/api/admin/attestations',
+            headers: {
+              ...formData.getHeaders(),
+              ...generateAuthenticatedUserRequestHeaders({ userId }),
+            },
+            payload: await streamToPromise(formData),
+          };
+
+          // when
+          const response = await server.inject(options);
+
+          // then
+          expect(response.statusCode).to.equal(400);
+
+          // after
+          await unlink(testFilePath);
+        });
+      });
+    });
+  });
+});

--- a/api/tests/quest/integration/domain/usecases/create-attestation_test.js
+++ b/api/tests/quest/integration/domain/usecases/create-attestation_test.js
@@ -1,0 +1,22 @@
+import { usecases } from '../../../../../src/quest/domain/usecases/index.js';
+import { expect, getFakeAttestationTemplate, knex, mockAttestationStorageUpload } from '../../../../test-helper.js';
+
+describe('Integration | Attestation | Domain | UseCases | create-attestation', function () {
+  it('should create an attestation', async function () {
+    // given
+    const templateKey = 'key';
+    const templateName = 'name';
+    const templateFile = getFakeAttestationTemplate();
+    mockAttestationStorageUpload({ attestation: { templateName } });
+
+    // when
+    await usecases.createAttestation({ templateKey, templateName, templateFile });
+
+    // then
+    const result = await knex('attestations').where('key', templateKey);
+
+    expect(result.length).to.equal(1);
+    expect(result[0].key).to.equal(templateKey);
+    expect(result[0].templateName).to.equal(templateName);
+  });
+});

--- a/api/tests/quest/integration/infrastructure/repositories/attestation-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/attestation-repository_test.js
@@ -1,0 +1,86 @@
+import * as attestationRepository from '../../../../../src/quest/infrastructure/repositories/attestation-repository.js';
+import { AttestationStorage } from '../../../../../src/quest/infrastructure/storage/attestation-storage.js';
+import { AlreadyExistingEntityError } from '../../../../../src/shared/domain/errors.js';
+import { S3UploadError } from '../../../../../src/shared/domain/errors.js';
+import {
+  catchErr,
+  databaseBuilder,
+  expect,
+  getFakeAttestationTemplate,
+  knex,
+  mockAttestationStorageUpload,
+} from '../../../../test-helper.js';
+
+describe('Quest | Integration | Repository | attestation', function () {
+  describe('#save', function () {
+    it('should upload attestation file and save attestation in db', async function () {
+      const templateName = 'name';
+      const templateKey = 'key';
+      const templateFile = getFakeAttestationTemplate();
+
+      //when
+      const storageMock = mockAttestationStorageUpload({ attestation: { templateName } });
+
+      await attestationRepository.save({
+        templateName,
+        templateKey,
+        templateFile,
+        attestationStorage: AttestationStorage.createClient(),
+      });
+
+      // then
+      const results = await knex('attestations');
+
+      expect(storageMock.isDone()).to.be.true;
+      expect(results.length).to.equal(1);
+      expect(results[0].key).to.equal(templateKey);
+      expect(results[0].templateName).to.equal(templateName);
+    });
+
+    it('should not save attestation in db if file upload failed', async function () {
+      const templateName = 'name';
+      const templateKey = 'key';
+      const templateFile = getFakeAttestationTemplate();
+
+      //when
+      const storageMock = mockAttestationStorageUpload({ attestation: { templateName }, isFailed: true });
+      const error = await catchErr(attestationRepository.save)({
+        templateName,
+        templateKey,
+        templateFile,
+        attestationStorage: AttestationStorage.createClient(),
+      });
+
+      // then
+      const results = await knex('attestations');
+
+      expect(storageMock.isDone()).to.be.true;
+      expect(results.length).to.equal(0);
+      expect(error).to.be.instanceOf(S3UploadError);
+    });
+
+    it('should not save attestation in db if attestation exists', async function () {
+      const templateName = 'name';
+      const templateKey = 'key';
+      const templateFile = getFakeAttestationTemplate();
+
+      databaseBuilder.factory.buildAttestation({ key: templateKey, templateName: 'anotherTemplateName' });
+      await databaseBuilder.commit();
+
+      //when
+      const error = await catchErr(attestationRepository.save)({
+        templateName,
+        templateKey,
+        templateFile,
+        attestationStorage: null,
+      });
+
+      // then
+      const results = await knex('attestations');
+
+      expect(results.length).to.equal(1);
+      expect(results[0].templateName).to.equal('anotherTemplateName');
+      expect(error).to.be.instanceOf(AlreadyExistingEntityError);
+    });
+  });
+});

--- a/api/tests/quest/unit/application/attestation-route_test.js
+++ b/api/tests/quest/unit/application/attestation-route_test.js
@@ -1,0 +1,120 @@
+import FormData from 'form-data';
+import streamToPromise from 'stream-to-promise';
+
+import { attestationController } from '../../../../src/quest/application/attestation-controller.js';
+import * as attestationRoute from '../../../../src/quest/application/attestation-route.js';
+import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
+import {
+  expect,
+  generateAuthenticatedUserRequestHeaders,
+  getFakeAttestationTemplate,
+  HttpTestServer,
+  sinon,
+} from '../../../test-helper.js';
+
+describe('Quest | Unit | Routes | Attestation Route', function () {
+  describe('POST /api/admin/attestations', function () {
+    describe('when parameters are valid', function () {
+      it('should call prehandler with exact parameters', async function () {
+        // given
+        sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
+        sinon.stub(attestationController, 'save').resolves('ok');
+
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(attestationRoute);
+
+        const formData = new FormData();
+        formData.append('templateKey', 'my_key');
+        formData.append('templateName', 'my_name');
+        formData.append('templateFile', getFakeAttestationTemplate());
+
+        const headers = {
+          ...formData.getHeaders(),
+          ...generateAuthenticatedUserRequestHeaders({ userId: 132 }),
+        };
+        const payload = await streamToPromise(formData);
+        // when
+        await httpTestServer.request('POST', '/api/admin/attestations', payload, null, headers);
+
+        // then
+        expect(securityPreHandlers.hasAtLeastOneAccessOf).to.have.been.calledOnceWithExactly([
+          securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+          securityPreHandlers.checkAdminMemberHasRoleMetier,
+          securityPreHandlers.checkAdminMemberHasRoleSupport,
+          securityPreHandlers.checkAdminMemberHasRoleCertif,
+        ]);
+      });
+    });
+    describe('when parameters are invalid', function () {
+      it('should fail when templateKey is missing', async function () {
+        sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
+        sinon.stub(attestationController, 'save').resolves('ok');
+
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(attestationRoute);
+
+        const formData = new FormData();
+        formData.append('templateName', 'my_name');
+        formData.append('templateFile', getFakeAttestationTemplate());
+
+        const headers = {
+          ...formData.getHeaders(),
+          ...generateAuthenticatedUserRequestHeaders({ userId: 132 }),
+        };
+        const payload = await streamToPromise(formData);
+
+        // when
+        const response = await httpTestServer.request('POST', '/api/admin/attestations', payload, null, headers);
+
+        //then
+        expect(response.statusCode).to.equal(400);
+      });
+      it('should fail when templateName is missing', async function () {
+        sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
+        sinon.stub(attestationController, 'save').resolves('ok');
+
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(attestationRoute);
+
+        const formData = new FormData();
+        formData.append('templateKey', 'key');
+        formData.append('templateFile', getFakeAttestationTemplate());
+
+        const headers = {
+          ...formData.getHeaders(),
+          ...generateAuthenticatedUserRequestHeaders({ userId: 132 }),
+        };
+        const payload = await streamToPromise(formData);
+
+        // when
+        const response = await httpTestServer.request('POST', '/api/admin/attestations', payload, null, headers);
+
+        //then
+        expect(response.statusCode).to.equal(400);
+      });
+      it('should fail when templateFile is missing', async function () {
+        sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
+        sinon.stub(attestationController, 'save').resolves('ok');
+
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(attestationRoute);
+
+        const formData = new FormData();
+        formData.append('templateName', 'name');
+        formData.append('templateKey', 'key');
+
+        const headers = {
+          ...formData.getHeaders(),
+          ...generateAuthenticatedUserRequestHeaders({ userId: 132 }),
+        };
+        const payload = await streamToPromise(formData);
+
+        // when
+        const response = await httpTestServer.request('POST', '/api/admin/attestations', payload, null, headers);
+
+        //then
+        expect(response.statusCode).to.equal(400);
+      });
+    });
+  });
+});

--- a/api/tests/quest/unit/infrastructure/storage/attestation-storage_test.js
+++ b/api/tests/quest/unit/infrastructure/storage/attestation-storage_test.js
@@ -1,13 +1,14 @@
 import { AttestationStorage } from '../../../../../src/quest/infrastructure/storage/attestation-storage.js';
-import { S3ObjectStorageProvider } from '../../../../../src/shared/storage/infrastructure/providers/S3ObjectStorageProvider.js';
 import { expect } from '../../../../test-helper.js';
 
 describe('Unit | Storage | AttestationStorage', function () {
-  it('should create a S3 Client', function () {
-    // given & when
-    const client = AttestationStorage.createClient();
+  describe('#createClient', function () {
+    it('should create a S3 Client', function () {
+      // given & when
+      const client = AttestationStorage.createClient();
 
-    // then
-    expect(client).to.be.instanceOf(S3ObjectStorageProvider);
+      // then
+      expect(client).to.be.instanceOf(AttestationStorage);
+    });
   });
 });

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -447,6 +447,17 @@ function mockAttestationStorage(attestation) {
   return template;
 }
 
+function mockAttestationStorageUpload({ attestation, isFailed = false }) {
+  return nock('http://attestations.fake.endpoint.example.net:80')
+    .put(`/attestations.bucket/${attestation.templateName}.pdf?x-id=PutObject`)
+    .reply(isFailed ? 500 : 200)
+    .persist();
+}
+
+function getFakeAttestationTemplate() {
+  return fs.createReadStream(path.join(__dirname, 'attestation-template.pdf'));
+}
+
 const preventStubsToBeCalledUnexpectedly = (stubs) => {
   for (const stub of stubs) {
     stub.rejects(
@@ -487,6 +498,7 @@ export {
   generateIdTokenForExternalUser,
   generateInjectOptions,
   generateValidRequestAuthorizationHeaderForApplication,
+  getFakeAttestationTemplate,
   hFake,
   HttpTestServer,
   insertLearnerImportFeatureForNewOrganization,
@@ -498,6 +510,7 @@ export {
   knex,
   learningContentBuilder,
   mockAttestationStorage,
+  mockAttestationStorageUpload,
   MockDate,
   mockLearningContent,
   nock,


### PR DESCRIPTION
## 🌎 Problème

Actuellement, il n'est pas possible de créer simplement une attestation.

## 🔭 Proposition

Ajout d'une page de création d'attestation sur Pix Admin, permettant d'insérer l'attestation en base ainsi que son fichier PDF de template sur le S3.

## 🪐 Remarques

On modifie les paramètres d'entrées du `createClient` de `S3ObjectStorageProvider`.
Cela nous permet de surcharger cette classe avec une classe fille dédiée côté `quest` pour throw une erreur d'insertion plus simplement dans notre usecase de création d'attestation.

Un ticket à impact cross team pourra être traité à part pour retirer le `createClient` de `S3ObjectStorageProvider` qui apporte une complexité selon nous non nécessaire.

Un autre ticket cross team pourrait également être fait afin de remonter le throw d'erreur d'insertion au niveau de la class `S3ObjectStorageProvider` pour permettre à chaque contexte de disposer plus simplement de cette gestion d'erreur.

## 🚀 Pour tester

Se connecter à Pix Admin
Aller dans Administration -> Onglet commun

Compléter le formulaire de création d'attestation
- Tant que tous les champs ne sont pas remplis, le bouton d'envoi doit être désactivé
- Une fois les champs remplis, le bouton d'envoi doit être activé

- Tester un envoi avec une info manquante (désactiver le `required` d'un champ et le `disabled` du bouton dans le html)
   - Un message d'erreur doit s'afficher
   - Aucune insertion en base ou dans le S3

- Tester , vérifier les conditions suivantes :
   - Un message de succès apparaît
   - L'attestation est bien insérée en base
   - Le fichier est uploadé sur le S3 (il sera peut-être nécessaire de tirer la branche en local afin de vérifier le S3 de dev)
 

🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘 🌑
