### PR TITLE
[TECH] Exclure les participations supprimées du script d'attribution des rewards (PIX-22007).

### DIFF
--- a/api/src/profile/scripts/attestation-reward-recovery.js
+++ b/api/src/profile/scripts/attestation-reward-recovery.js
@@ -85,16 +85,18 @@ export class AttestationRewardRecoveryScript extends Script {
     endDate.setDate(endDate.getDate() + 1);
     const formatedEndDate = endDate.toISOString().split('T')[0];
 
-    const users = await knexConnection('campaign-participations')
-      .distinct('campaign-participations.userId')
+    return await knexConnection('campaign-participations')
+      .select('campaign-participations.userId')
       .join('campaigns', 'campaign-participations.campaignId', 'campaigns.id')
       .join('target-profiles', 'campaigns.targetProfileId', 'target-profiles.id')
       .where('campaign-participations.createdAt', '>=', formatedStartDate)
       .where('campaign-participations.createdAt', '<=', formatedEndDate)
       .where('campaign-participations.status', '<>', CampaignParticipationStatuses.STARTED)
-      .whereIn('campaigns.targetProfileId', TARGET_PROFILE_IDS);
-
-    return users.map(({ userId }) => userId);
+      .whereNotNull('campaign-participations.userId')
+      .whereNull('campaign-participations.deletedAt')
+      .whereIn('campaigns.targetProfileId', TARGET_PROFILE_IDS)
+      .groupBy('userId')
+      .pluck('userId');
   }
 
   /**

--- a/api/tests/profile/integration/scripts/attestation-reward-recovery_test.js
+++ b/api/tests/profile/integration/scripts/attestation-reward-recovery_test.js
@@ -76,6 +76,25 @@ describe('Integration | Profile | Scripts | attestation-reward-recovery', functi
       expect(userIds).to.not.contains(userId);
     });
 
+    it('should not return deleted participation even status is shared', async function () {
+      const { id: targetProfileId } = databaseBuilder.factory.buildTargetProfile({
+        id: TARGET_PROFILE_IDS[0],
+      });
+      const campaign = databaseBuilder.factory.buildCampaign({ targetProfileId });
+
+      databaseBuilder.factory.buildCampaignParticipation({
+        userId: null,
+        campaignId: campaign.id,
+        status: CampaignParticipationStatuses.SHARED,
+        createdAt: '2024-12-02',
+        deletedAt: new Date('2026-01-01'),
+      });
+
+      await databaseBuilder.commit();
+      const userIds = await script.fetchUserIds(new Date('2024-12-01'), new Date('2024-12-06'));
+      expect(userIds).to.have.lengthOf(0);
+    });
+
     it('should not return the user if the campaign target profile is not included in targeted target profiles', async function () {
       const { id: targetProfileId1 } = databaseBuilder.factory.buildTargetProfile({
         id: TARGET_PROFILE_IDS[0],


### PR DESCRIPTION
## 🌎 Problème

Le script qui permet de donner les attestations sur une plage de date n'exclu pas les participations supprimées ( sans userId ), ce qui empêche le déroulement du script jusqu'au bout. 

## 🔭 Proposition

Ajouter la condition userId not null et deletedAt null pour récupérer seulement les particiaptions actives. 

## 🪐 Remarques

utilisation du groupBy au lieu du distinct qui permet de garder l'utilisation des index si la requêtes en utilise. 
utilisation du pluck pour retirer le map. 

## 🚀 Pour tester
les tests au vert ? je ne suis pas sûr qu'on ai un JDD qui permet de lancer ce script en local. 


🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘 🌑
