### PR TITLE
[FEATURE] Gérer les attestations depuis la section features des organisations (PIX-21765)

### DIFF
--- a/admin/app/adapters/attestation.js
+++ b/admin/app/adapters/attestation.js
@@ -1,0 +1,5 @@
+import ApplicationAdapter from './application';
+
+export default class AttestationAdapter extends ApplicationAdapter {
+  namespace = 'api/admin';
+}

--- a/admin/app/components/organizations/features-section.gjs
+++ b/admin/app/components/organizations/features-section.gjs
@@ -1,6 +1,7 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixCheckbox from '@1024pix/pix-ui/components/pix-checkbox';
 import PixModal from '@1024pix/pix-ui/components/pix-modal';
+import PixMultiSelect from '@1024pix/pix-ui/components/pix-multi-select';
 import PixSelect from '@1024pix/pix-ui/components/pix-select';
 import { concat, fn, get } from '@ember/helper';
 import { on } from '@ember/modifier';
@@ -18,11 +19,13 @@ import Card from '../card';
 
 export default class OrganizationFeaturesSection extends Component {
   @service accessControl;
+  @service intl;
   @service store;
   @service pixToast;
 
   @tracked form = {};
   @tracked importFormats = [];
+  @tracked attestations = [];
   @tracked displayLearnerImportActivationDialog = false;
   @tracked learnerImportActivationConfirmed = false;
 
@@ -34,6 +37,7 @@ export default class OrganizationFeaturesSection extends Component {
 
   async #loadAsyncData() {
     this.importFormats = await this.store.findAll('organization-learner-import-format');
+    this.attestations = await this.store.findAll('attestation');
   }
 
   #initForm() {
@@ -46,6 +50,15 @@ export default class OrganizationFeaturesSection extends Component {
     return this.importFormats.map((importFormat) => ({
       value: importFormat.name,
       label: importFormat.name,
+    }));
+  }
+
+  get attestationOptions() {
+    return this.attestations.map((attestation) => ({
+      value: attestation.key,
+      label: this.intl.t(
+        `components.organizations.information-section-view.features.attestation-list.${attestation.key}`,
+      ),
     }));
   }
 
@@ -67,6 +80,19 @@ export default class OrganizationFeaturesSection extends Component {
 
   get hasFormChanged() {
     return JSON.stringify(this.form.features) !== JSON.stringify(this.args.organization.features);
+  }
+
+  get isFormValid() {
+    const attestations = this.form.features?.ATTESTATIONS_MANAGEMENT;
+    if (attestations?.active) {
+      return attestations.params?.length;
+    }
+    return true;
+  }
+
+  get isAttestationsInvalid() {
+    const attestations = this.form.features?.ATTESTATIONS_MANAGEMENT;
+    return attestations?.active && !(attestations.params?.length > 0);
   }
 
   @action
@@ -122,6 +148,7 @@ export default class OrganizationFeaturesSection extends Component {
   @action
   async saveFeatures(event) {
     event.preventDefault();
+    if (!this.hasFormChanged || !this.isFormValid) return;
     this.args.organization.set('features', this.form.features);
     await this.args.onSubmit();
     this.#initForm();
@@ -138,6 +165,8 @@ export default class OrganizationFeaturesSection extends Component {
             <FeaturesForm
               @form={{this.form}}
               @importFormatOptions={{this.importFormatOptions}}
+              @attestationOptions={{this.attestationOptions}}
+              @isAttestationsInvalid={{this.isAttestationsInvalid}}
               @updateFormCheckBoxValue={{this.updateFormCheckBoxValue}}
               @updateValue={{this.updateValue}}
               @isManagingStudentAvailable={{this.isManagingStudentAvailable}}
@@ -158,7 +187,12 @@ export default class OrganizationFeaturesSection extends Component {
             >
               {{t "common.actions.cancel"}}
             </PixButton>
-            <PixButton @type="submit" @size="small" @variant="success" @isDisabled={{not this.hasFormChanged}}>
+            <PixButton
+              @type="submit"
+              @size="small"
+              @variant="success"
+              @isDisabled={{or (not this.hasFormChanged) (not this.isFormValid)}}
+            >
               {{t "common.actions.save"}}
             </PixButton>
           </section>
@@ -235,6 +269,7 @@ const FeaturesForm = <template>
             {{#if (and (eq feature "LEARNER_IMPORT") (get organizationFeature "active"))}}
               <PixSelect
                 required
+                size="small"
                 @aria-required={{true}}
                 @requiredLabel={{t "common.forms.mandatory"}}
                 @options={{@importFormatOptions}}
@@ -251,6 +286,32 @@ const FeaturesForm = <template>
                   {{t "components.organizations.editing.organization-learner-import-format.selector.label"}}
                 </:label>
               </PixSelect>
+            {{/if}}
+
+            {{#if (and (eq feature "ATTESTATIONS_MANAGEMENT") (get organizationFeature "active"))}}
+              <PixMultiSelect
+                class="features-section__attestations-select
+                  {{if @isAttestationsInvalid 'features-section__attestations-select--error'}}"
+                size="small"
+                @isSearchable={{true}}
+                @values={{get organizationFeature "params"}}
+                @options={{@attestationOptions}}
+                @onChange={{fn @updateValue "features.ATTESTATIONS_MANAGEMENT.params"}}
+                @isDisabled={{not @canEdit}}
+                @placeholder={{t "components.organizations.editing.attestations.selector.placeholder"}}
+              >
+                <:label>
+                  {{t "components.organizations.editing.attestations.selector.label"}}
+                </:label>
+                <:default as |option|>
+                  {{option.label}}
+                </:default>
+              </PixMultiSelect>
+              {{#if @isAttestationsInvalid}}
+                <p class="features-section__attestations-error">
+                  {{t "components.organizations.editing.attestations.selector.error"}}
+                </p>
+              {{/if}}
             {{/if}}
           </div>
           {{#if (eq feature "PLACES_MANAGEMENT")}}

--- a/admin/app/components/organizations/features-section.scss
+++ b/admin/app/components/organizations/features-section.scss
@@ -1,11 +1,10 @@
 @use 'pix-design-tokens/typography';
 
-
 .organization-features-form {
   &__card {
     .card__content {
       display: grid;
-      grid-template-columns: 1fr 1fr;
+      grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
       gap: var(--pix-spacing-6x) var(--pix-spacing-6x);
     }
 
@@ -13,6 +12,20 @@
       margin-top: 0;
     }
   }
+}
+
+.features-section__attestations-select {
+  width: 100%;
+
+  &--error .pix-multi-select-main-input {
+    border: 2px solid var(--pix-error-700);
+  }
+}
+
+.features-section__attestations-error {
+  margin-top: var(--pix-spacing-1x);
+  color: var(--pix-error-700);
+  font-size: 0.75rem;
 }
 
 .features-section__feature-item {

--- a/admin/app/models/attestation.js
+++ b/admin/app/models/attestation.js
@@ -2,6 +2,6 @@ import Model, { attr } from '@ember-data/model';
 
 export default class Attestation extends Model {
   @attr('string') templateName;
-  @attr('string') templateKey;
+  @attr('string') key;
   @attr() file;
 }

--- a/admin/app/models/organization.js
+++ b/admin/app/models/organization.js
@@ -66,6 +66,7 @@ export default class Organization extends Model {
       'PLACES_MANAGEMENT',
       'LEARNER_IMPORT',
       'COVER_RATE',
+      'ATTESTATIONS_MANAGEMENT',
     );
   }
 

--- a/admin/tests/integration/components/organizations/features-section-test.gjs
+++ b/admin/tests/integration/components/organizations/features-section-test.gjs
@@ -24,6 +24,12 @@ module('Integration | Component | organizations/features-section', function (hoo
         store.createRecord('organization-learner-import-format', { id: '123', name: 'GENERIC' }),
         store.createRecord('organization-learner-import-format', { id: '456', name: 'ONDE' }),
       ]);
+    findAllStub
+      .withArgs('attestation')
+      .resolves([
+        store.createRecord('attestation', { id: '1', key: 'PARENTHOOD' }),
+        store.createRecord('attestation', { id: '2', key: 'SIXTH_GRADE' }),
+      ]);
 
     class AccessControlStub extends Service {
       hasAccessToOrganizationActionsScope = false;
@@ -281,29 +287,20 @@ module('Integration | Component | organizations/features-section', function (hoo
     });
   });
 
-  module('ATTESTATIONS_MANAGEMENT', function () {
-    test('it shows a disabled checked checkbox when feature is active', async function (assert) {
-      // given
-      const onSubmit = onSubmitStub;
-      const organization = EmberObject.create({
-        features: { ATTESTATIONS_MANAGEMENT: { active: true, params: ['PARENTHOOD'] } },
-      });
-
-      // when
-      const screen = await render(
-        <template><FeaturesSection @organization={{organization}} @onSubmit={{onSubmit}} /></template>,
-      );
-
-      // then
-      const checkbox = screen.getByLabelText(
-        t('components.organizations.information-section-view.features.ATTESTATIONS_MANAGEMENT'),
-      );
-      assert.true(checkbox.checked);
-      assert.true(checkbox.disabled);
+  module('ATTESTATIONS_MANAGEMENT', function (hooks) {
+    hooks.beforeEach(function () {
+      class AccessControlStub extends Service {
+        hasAccessToOrganizationActionsScope = true;
+      }
+      this.owner.register('service:access-control', AccessControlStub);
     });
 
-    test('it shows a disabled unchecked checkbox when feature is inactive', async function (assert) {
+    test('it shows a disabled unchecked checkbox when feature is inactive and user has no access', async function (assert) {
       // given
+      class AccessControlStub extends Service {
+        hasAccessToOrganizationActionsScope = false;
+      }
+      this.owner.register('service:access-control', AccessControlStub);
       const onSubmit = onSubmitStub;
       const organization = EmberObject.create({
         features: { ATTESTATIONS_MANAGEMENT: { active: false } },
@@ -320,6 +317,126 @@ module('Integration | Component | organizations/features-section', function (hoo
       );
       assert.false(checkbox.checked);
       assert.true(checkbox.disabled);
+    });
+
+    test('it shows a PixMultiSelect when feature is active', async function (assert) {
+      // given
+      const onSubmit = onSubmitStub;
+      const organization = EmberObject.create({
+        features: { ATTESTATIONS_MANAGEMENT: { active: true, params: ['PARENTHOOD'] } },
+      });
+
+      // when
+      const screen = await render(
+        <template><FeaturesSection @organization={{organization}} @onSubmit={{onSubmit}} /></template>,
+      );
+
+      // then
+      assert
+        .dom(
+          screen.getByRole('button', {
+            name: new RegExp(t('components.organizations.editing.attestations.selector.label')),
+          }),
+        )
+        .exists();
+    });
+
+    test('it disables the PixMultiSelect when user has no access', async function (assert) {
+      // given
+      class AccessControlStub extends Service {
+        hasAccessToOrganizationActionsScope = false;
+      }
+      this.owner.register('service:access-control', AccessControlStub);
+      const onSubmit = onSubmitStub;
+      const organization = EmberObject.create({
+        features: { ATTESTATIONS_MANAGEMENT: { active: true, params: ['PARENTHOOD'] } },
+      });
+
+      // when
+      const screen = await render(
+        <template><FeaturesSection @organization={{organization}} @onSubmit={{onSubmit}} /></template>,
+      );
+
+      // then
+      assert
+        .dom(
+          screen.getByRole('button', {
+            name: new RegExp(t('components.organizations.editing.attestations.selector.label')),
+          }),
+        )
+        .isDisabled();
+    });
+
+    test('it hides the PixMultiSelect when feature is unchecked', async function (assert) {
+      // given
+      const onSubmit = onSubmitStub;
+      const organization = EmberObject.create({
+        features: { ATTESTATIONS_MANAGEMENT: { active: true, params: ['PARENTHOOD'] } },
+      });
+
+      const screen = await render(
+        <template><FeaturesSection @organization={{organization}} @onSubmit={{onSubmit}} /></template>,
+      );
+
+      // when
+      await click(
+        screen.getByRole('checkbox', {
+          name: t('components.organizations.information-section-view.features.ATTESTATIONS_MANAGEMENT'),
+        }),
+      );
+
+      // then
+      assert.notOk(
+        screen.queryByRole('button', {
+          name: new RegExp(t('components.organizations.editing.attestations.selector.label')),
+        }),
+      );
+    });
+
+    test('it shows an error and disables save when feature is active with no attestation selected', async function (assert) {
+      // given
+      const onSubmit = onSubmitStub;
+      const organization = EmberObject.create({
+        features: { ATTESTATIONS_MANAGEMENT: { active: false } },
+      });
+
+      const screen = await render(
+        <template><FeaturesSection @organization={{organization}} @onSubmit={{onSubmit}} /></template>,
+      );
+
+      // when
+      await click(
+        screen.getByRole('checkbox', {
+          name: t('components.organizations.information-section-view.features.ATTESTATIONS_MANAGEMENT'),
+        }),
+      );
+
+      // then
+      assert.dom(screen.getByText(t('components.organizations.editing.attestations.selector.error'))).exists();
+      assert.dom(screen.getByRole('button', { name: t('common.actions.save') })).hasAttribute('aria-disabled');
+    });
+
+    test('it does not submit the form when feature is active with no attestation selected', async function (assert) {
+      // given
+      const onSubmit = onSubmitStub;
+      const organization = EmberObject.create({
+        features: { ATTESTATIONS_MANAGEMENT: { active: false } },
+      });
+
+      const screen = await render(
+        <template><FeaturesSection @organization={{organization}} @onSubmit={{onSubmit}} /></template>,
+      );
+      await click(
+        screen.getByRole('checkbox', {
+          name: t('components.organizations.information-section-view.features.ATTESTATIONS_MANAGEMENT'),
+        }),
+      );
+
+      // when
+      await click(screen.getByRole('button', { name: t('common.actions.save') }));
+
+      // then
+      assert.false(onSubmit.called);
     });
   });
 
@@ -657,7 +774,9 @@ module('Integration | Component | organizations/features-section', function (hoo
           name: t('components.organizations.information-section-view.features.LEARNER_IMPORT'),
         }).checked,
       );
-      const select = screen.getByRole('button', { name: /Format d'import/ });
+      const select = screen.getByRole('button', {
+        name: new RegExp(t('components.organizations.editing.organization-learner-import-format.selector.label')),
+      });
       assert.ok(within(select).getByText('ONDE'));
     });
 

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -856,6 +856,13 @@
             "placeholder": "Choose an administration team"
           }
         },
+        "attestations": {
+          "selector": {
+            "error": "Please select at least one attestation",
+            "label": "Available attestations",
+            "placeholder": "Select attestations"
+          }
+        },
         "country": {
           "selector": {
             "error-message": "Country is required",

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -858,6 +858,13 @@
             "placeholder": "Sélectionner une équipe en charge"
           }
         },
+        "attestations": {
+          "selector": {
+            "error": "Veuillez sélectionner au moins une attestation",
+            "label": "Attestations disponibles",
+            "placeholder": "Sélectionner les attestations"
+          }
+        },
         "country": {
           "selector": {
             "error-message": "Le pays est requis",
@@ -873,11 +880,11 @@
             "confirm-label": "Oui, je confirme",
             "confirmation": "En cochant cette case vous affirmez avoir les droits et l’autorisation de l’organisation pour effectuer cette action",
             "message": "Vous êtes sur le point d’activer l’import générique pour cette organisation. Si l’organisation a déjà des prescrits, ceux-ci seront tous supprimés. Cette suppression est irréversible.",
-            "title": "Activation de l'import générique"
+            "title": "Activation de l’import générique"
           },
           "selector": {
-            "label": "Format d'import",
-            "placeholder": "Sélectionner un format d'import"
+            "label": "Format d’import",
+            "placeholder": "Sélectionner un format d’import"
           }
         },
         "organization-learner-type": {

--- a/api/src/profile/application/attestation-controller.js
+++ b/api/src/profile/application/attestation-controller.js
@@ -1,6 +1,7 @@
 import { FRENCH_FRANCE } from '../../shared/domain/services/locale-service.js';
 import { usecases } from '../domain/usecases/index.js';
 import * as attestationSerializer from '../infrastructure/serializers/jsonapi/attestation-detail-serializer.js';
+import * as attestationAdminSerializer from '../infrastructure/serializers/jsonapi/attestation-serializer.js';
 import * as pdfWithFormSerializer from '../infrastructure/serializers/pdf/pdf-with-form-serializer.js';
 
 const getUserAttestation = async function (request, h, dependencies = { pdfWithFormSerializer }) {
@@ -27,7 +28,13 @@ const getUserAttestationsDetails = async function (request, _, dependencies = { 
   return usecases.getAttestationDetails({ profileRewards }).then(dependencies.attestationSerializer.serialize);
 };
 
+const getAll = async function (request, _, dependencies = { attestationAdminSerializer }) {
+  const attestations = await usecases.getAllAttestations();
+  return dependencies.attestationAdminSerializer.serialize(attestations);
+};
+
 const attestationController = {
+  getAll,
   getUserAttestation,
   getUserAttestationsDetails,
 };

--- a/api/src/profile/application/attestation-route.js
+++ b/api/src/profile/application/attestation-route.js
@@ -5,6 +5,32 @@ import { identifiersType } from '../../shared/domain/types/identifiers-type.js';
 import { attestationController } from './attestation-controller.js';
 
 const register = async function (server) {
+  const adminRoutes = [
+    {
+      method: 'GET',
+      path: '/api/admin/attestations',
+      config: {
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.hasAtLeastOneAccessOf([
+                securityPreHandlers.checkAdminMemberHasRoleCertif,
+                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+                securityPreHandlers.checkAdminMemberHasRoleMetier,
+                securityPreHandlers.checkAdminMemberHasRoleSupport,
+              ])(request, h),
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        handler: attestationController.getAll,
+        notes: [
+          '- **Cette route est restreinte aux membres admin**\n- Récupération de la liste de toutes les attestations',
+        ],
+        tags: ['api', 'admin', 'attestations', 'profile'],
+      },
+    },
+  ];
+
   const userRoutes = [
     {
       method: 'GET',
@@ -57,7 +83,7 @@ const register = async function (server) {
     },
   ];
 
-  server.route([...userRoutes]);
+  server.route([...adminRoutes, ...userRoutes]);
 };
 
 const name = 'profile/attestation-api';

--- a/api/src/profile/domain/usecases/get-all-attestations.js
+++ b/api/src/profile/domain/usecases/get-all-attestations.js
@@ -1,0 +1,5 @@
+const getAllAttestations = async function ({ attestationRepository }) {
+  return attestationRepository.findAll();
+};
+
+export { getAllAttestations };

--- a/api/src/profile/domain/usecases/index.js
+++ b/api/src/profile/domain/usecases/index.js
@@ -31,6 +31,7 @@ const dependencies = {
   attestationStorage,
 };
 
+import { getAllAttestations } from './get-all-attestations.js';
 import { getAttestationDataForUsers } from './get-attestation-data-for-users.js';
 import { getAttestationDetails } from './get-attestation-details.js';
 import { getProfileRewardsByUserId } from './get-profile-rewards-by-user-id.js';
@@ -42,6 +43,7 @@ import { rewardUser } from './reward-user.js';
 import { shareProfileReward } from './share-profile-reward.js';
 
 const usecasesWithoutInjectedDependencies = {
+  getAllAttestations,
   getAttestationDataForUsers,
   getAttestationDetails,
   getProfileRewardsByUserId,

--- a/api/src/profile/infrastructure/repositories/attestation-repository.js
+++ b/api/src/profile/infrastructure/repositories/attestation-repository.js
@@ -1,6 +1,12 @@
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { Attestation } from '../../domain/models/Attestation.js';
 
+export const findAll = async () => {
+  const knexConnection = DomainTransaction.getConnection();
+  const rows = await knexConnection('attestations').select('*');
+  return rows.map((row) => new Attestation(row));
+};
+
 export const getByKey = async ({ attestationKey }) => {
   const knexConnection = DomainTransaction.getConnection();
   const attestation = await knexConnection('attestations').where({ key: attestationKey }).first();

--- a/api/src/profile/infrastructure/serializers/jsonapi/attestation-serializer.js
+++ b/api/src/profile/infrastructure/serializers/jsonapi/attestation-serializer.js
@@ -1,0 +1,11 @@
+import jsonapiSerializer from 'jsonapi-serializer';
+
+const { Serializer } = jsonapiSerializer;
+
+const serialize = function (attestations) {
+  return new Serializer('attestation', {
+    attributes: ['key'],
+  }).serialize(attestations);
+};
+
+export { serialize };

--- a/api/tests/profile/acceptance/application/attestation-route_test.js
+++ b/api/tests/profile/acceptance/application/attestation-route_test.js
@@ -3,6 +3,7 @@ import {
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
+  insertUserWithRoleSuperAdmin,
   mockAttestationStorage,
 } from '../../../test-helper.js';
 
@@ -11,6 +12,33 @@ describe('Profile | Acceptance | Application | Attestation Route ', function () 
 
   beforeEach(async function () {
     server = await createServer();
+  });
+
+  describe('GET /api/admin/attestations', function () {
+    it('should return 200 with the list of attestations', async function () {
+      // given
+      const adminUser = await insertUserWithRoleSuperAdmin();
+      databaseBuilder.factory.buildAttestation({ key: 'PARENTHOOD' });
+      databaseBuilder.factory.buildAttestation({ key: 'SIXTH_GRADE' });
+      await databaseBuilder.commit();
+
+      const options = {
+        method: 'GET',
+        headers: generateAuthenticatedUserRequestHeaders({ userId: adminUser.id }),
+        url: '/api/admin/attestations',
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result.data).to.have.lengthOf(2);
+      expect(response.result.data.map(({ attributes }) => attributes.key)).to.include.members([
+        'PARENTHOOD',
+        'SIXTH_GRADE',
+      ]);
+    });
   });
 
   describe('GET /api/users/{userId}/attestations/{attestationKey}', function () {

--- a/api/tests/profile/integration/infrastructure/repositories/attestation-repository_test.js
+++ b/api/tests/profile/integration/infrastructure/repositories/attestation-repository_test.js
@@ -1,11 +1,37 @@
 import { Attestation } from '../../../../../src/profile/domain/models/Attestation.js';
 import {
+  findAll,
   getByKey,
   getDataByKey,
 } from '../../../../../src/profile/infrastructure/repositories/attestation-repository.js';
 import { databaseBuilder, expect, sinon } from '../../../../test-helper.js';
 
 describe('Profile | Integration | Infrastructure | Repository | Attestation', function () {
+  describe('#findAll', function () {
+    it('should return all attestations', async function () {
+      // given
+      databaseBuilder.factory.buildAttestation({ key: 'PARENTHOOD' });
+      databaseBuilder.factory.buildAttestation({ key: 'SIXTH_GRADE' });
+      await databaseBuilder.commit();
+
+      // when
+      const result = await findAll();
+
+      // then
+      expect(result).to.have.lengthOf(2);
+      expect(result[0]).to.be.an.instanceof(Attestation);
+      expect(result.map((a) => a.key)).to.include.members(['PARENTHOOD', 'SIXTH_GRADE']);
+    });
+
+    it('should return an empty array when there are no attestations', async function () {
+      // when
+      const result = await findAll();
+
+      // then
+      expect(result).to.deep.equal([]);
+    });
+  });
+
   describe('#getByKey', function () {
     it('should return attestation informations for given key', async function () {
       // given

--- a/api/tests/profile/unit/application/attestation-controller_test.js
+++ b/api/tests/profile/unit/application/attestation-controller_test.js
@@ -4,6 +4,24 @@ import { FRENCH_FRANCE } from '../../../../src/shared/domain/services/locale-ser
 import { expect, hFake, sinon } from '../../../test-helper.js';
 
 describe('Profile | Unit | Controller | attestation-controller', function () {
+  describe('#getAll', function () {
+    it('should call the expected usecase and serializer', async function () {
+      // given
+      const attestations = Symbol('attestations');
+      const serializerResult = Symbol('serializerResult');
+      const attestationAdminSerializer = { serialize: sinon.stub().withArgs(attestations).returns(serializerResult) };
+      sinon.stub(usecases, 'getAllAttestations').resolves(attestations);
+
+      // when
+      const result = await attestationController.getAll({}, hFake, { attestationAdminSerializer });
+
+      // then
+      expect(usecases.getAllAttestations).to.have.been.calledOnce;
+      expect(attestationAdminSerializer.serialize).to.have.been.calledWithExactly(attestations);
+      expect(result).to.equal(serializerResult);
+    });
+  });
+
   describe('#getUserAttestation', function () {
     it('should call the expected usecase and serializer', async function () {
       // given

--- a/api/tests/profile/unit/application/attestation-route_test.js
+++ b/api/tests/profile/unit/application/attestation-route_test.js
@@ -4,6 +4,49 @@ import { securityPreHandlers } from '../../../../src/shared/application/security
 import { expect, HttpTestServer, sinon } from '../../../test-helper.js';
 
 describe('Unit | Router | user-router', function () {
+  describe('GET /api/admin/attestations', function () {
+    it('should call hasAtLeastOneAccessOf with the correct prehandlers', async function () {
+      // given
+      sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
+      sinon.stub(attestationController, 'getAll').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      await httpTestServer.request('GET', '/api/admin/attestations');
+
+      // then
+      expect(securityPreHandlers.hasAtLeastOneAccessOf).to.have.been.calledOnceWithExactly([
+        securityPreHandlers.checkAdminMemberHasRoleCertif,
+        securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+        securityPreHandlers.checkAdminMemberHasRoleMetier,
+        securityPreHandlers.checkAdminMemberHasRoleSupport,
+      ]);
+    });
+
+    describe('when the user has no admin role', function () {
+      it('should return 403 HTTP status code', async function () {
+        // given
+        sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns((request, h) =>
+          h
+            .response({ errors: new Error('forbidden') })
+            .code(403)
+            .takeover(),
+        );
+        sinon.stub(attestationController, 'getAll').returns('ok');
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const response = await httpTestServer.request('GET', '/api/admin/attestations');
+
+        // then
+        expect(response.statusCode).to.equal(403);
+        expect(attestationController.getAll.called).to.be.false;
+      });
+    });
+  });
+
   describe('GET /api/users/{userId}/attestations-details', function () {
     const method = 'GET';
     const url = '/api/users/12/attestation-details';

--- a/api/tests/profile/unit/domain/usecases/get-all-attestations_test.js
+++ b/api/tests/profile/unit/domain/usecases/get-all-attestations_test.js
@@ -1,0 +1,16 @@
+import { getAllAttestations } from '../../../../../src/profile/domain/usecases/get-all-attestations.js';
+import { expect, sinon } from '../../../../test-helper.js';
+
+describe('Profile | Unit | Domain | Usecases | get-all-attestations', function () {
+  it('should return all attestations from repository', async function () {
+    // given
+    const attestations = Symbol('attestations');
+    const attestationRepository = { findAll: sinon.stub().resolves(attestations) };
+
+    // when
+    const result = await getAllAttestations({ attestationRepository });
+
+    // then
+    expect(result).to.equal(attestations);
+  });
+});

--- a/api/tests/profile/unit/infrastructure/serializers/jsonapi/attestation-serializer_test.js
+++ b/api/tests/profile/unit/infrastructure/serializers/jsonapi/attestation-serializer_test.js
@@ -1,0 +1,35 @@
+import { Attestation } from '../../../../../../src/profile/domain/models/Attestation.js';
+import * as serializer from '../../../../../../src/profile/infrastructure/serializers/jsonapi/attestation-serializer.js';
+import { expect } from '../../../../../test-helper.js';
+
+describe('Profile | Unit | Serializer | JSONAPI | attestation', function () {
+  describe('#serialize()', function () {
+    it('should convert attestation objects into JSON API data', function () {
+      // when
+      const json = serializer.serialize([
+        new Attestation({ id: 1, key: 'PARENTHOOD', templateName: 'template-parenthood' }),
+        new Attestation({ id: 2, key: 'SIXTH_GRADE', templateName: 'template-sixth-grade' }),
+      ]);
+
+      // then
+      expect(json).to.deep.equal({
+        data: [
+          {
+            type: 'attestations',
+            id: '1',
+            attributes: {
+              key: 'PARENTHOOD',
+            },
+          },
+          {
+            type: 'attestations',
+            id: '2',
+            attributes: {
+              key: 'SIXTH_GRADE',
+            },
+          },
+        ],
+      });
+    });
+  });
+});


### PR DESCRIPTION
## 🌎 Problème

La feature `ATTESTATIONS_MANAGEMENT` existait dans le modèle `Organization` mais était en lecture seule dans la section features de l'admin.

## 🔭 Proposition

- Rendre la feature `ATTESTATIONS_MANAGEMENT` éditable dans la section features des organisations
- Ajouter un `PixMultiSelect` (avec recherche) pour choisir les attestations à activer
- Bloquer la sauvegarde si la feature est activée sans sélectionner au moins une attestation (message d'erreur + bouton désactivé + guard côté JS)
- Ajouter une route API `GET /api/admin/attestations` et le modèle Ember `attestation` associé

## 🪐 Remarques

- Le `PixMultiSelect` ne supporte pas de prop `@errorMessage` nativement — l'état d'erreur est géré via une classe CSS custom
- `PixButton` utilise `aria-disabled` et non `disabled` natif, on peut quand même valider, d'où le guard dans `saveFeatures()`

## 🚀 Pour tester

- [ ] Ouvrir une organisation dans l'admin avec le compte `superadmin`
- [ ] Dans la section "Fonctionnalités", activer "Gestion des attestations"
- [ ] Vérifier que le bouton Enregistrer est désactivé et qu'un message d'erreur apparaît sur le sélecteur
- [ ] Sélectionner au moins une attestation,  le bouton Enregistrer devient actif
- [ ] Enregistrer et vérifier la persistance
- [ ] Tester le mode lecture seule avec le compte `certifadmin`

🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘 🌑