### PR TITLE
[FEATURE] Ajouter la feature COVER_RATE dans le formulaire admin (PIX-21765)

### DIFF
--- a/admin/app/components/organizations/features-section.scss
+++ b/admin/app/components/organizations/features-section.scss
@@ -16,10 +16,8 @@
 }
 
 .features-section__feature-item {
-  &:not(:last-child) {
-    padding-bottom: var(--pix-spacing-3x);
-    border-bottom: 1px solid var(--pix-neutral-100);
-  }
+  padding-bottom: var(--pix-spacing-3x);
+  border-bottom: 1px solid var(--pix-neutral-100);
 
   .form-field {
     &:has(input[type='checkbox']:disabled) label {

--- a/admin/app/models/organization.js
+++ b/admin/app/models/organization.js
@@ -52,6 +52,7 @@ export default class Organization extends Model {
       CAMPAIGN_WITHOUT_USER_PROFILE: 'CAMPAIGN_WITHOUT_USER_PROFILE',
       SHOW_SKILLS: 'SHOW_SKILLS',
       ATTESTATIONS_MANAGEMENT: 'ATTESTATIONS_MANAGEMENT',
+      COVER_RATE: 'COVER_RATE',
     };
   }
 
@@ -64,6 +65,7 @@ export default class Organization extends Model {
       'SHOW_SKILLS',
       'PLACES_MANAGEMENT',
       'LEARNER_IMPORT',
+      'COVER_RATE',
     );
   }
 

--- a/admin/tests/integration/components/organizations/features-section-test.gjs
+++ b/admin/tests/integration/components/organizations/features-section-test.gjs
@@ -514,6 +514,51 @@ module('Integration | Component | organizations/features-section', function (hoo
     });
   });
 
+  module('COVER_RATE', function (hooks) {
+    hooks.beforeEach(function () {
+      class AccessControlStub extends Service {
+        hasAccessToOrganizationActionsScope = true;
+      }
+      this.owner.register('service:access-control', AccessControlStub);
+    });
+
+    test('it shows unchecked checkbox when feature is inactive', async function (assert) {
+      // given
+      const onSubmit = onSubmitStub;
+      const organization = EmberObject.create({
+        features: { COVER_RATE: { active: false } },
+      });
+
+      // when
+      const screen = await render(
+        <template><FeaturesSection @organization={{organization}} @onSubmit={{onSubmit}} /></template>,
+      );
+
+      // then
+      assert.false(
+        screen.getByLabelText(t('components.organizations.information-section-view.features.COVER_RATE')).checked,
+      );
+    });
+
+    test('it shows checked checkbox when feature is active', async function (assert) {
+      // given
+      const onSubmit = onSubmitStub;
+      const organization = EmberObject.create({
+        features: { COVER_RATE: { active: true } },
+      });
+
+      // when
+      const screen = await render(
+        <template><FeaturesSection @organization={{organization}} @onSubmit={{onSubmit}} /></template>,
+      );
+
+      // then
+      assert.true(
+        screen.getByLabelText(t('components.organizations.information-section-view.features.COVER_RATE')).checked,
+      );
+    });
+  });
+
   module('LEARNER_IMPORT', function (hooks) {
     hooks.beforeEach(function () {
       class AccessControlStub extends Service {

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -848,6 +848,7 @@
           "ATTESTATIONS_MANAGEMENT": "Attestations",
           "CAMPAIGN_WITHOUT_USER_PROFILE": "interro mode (temporary name)",
           "COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY": "Automatic certificability",
+          "COVER_RATE": "Pix Orga Statistics",
           "IS_MANAGING_STUDENTS": "Managing students",
           "LEARNER_IMPORT": "Import",
           "MULTIPLE_SENDING_ASSESSMENT": "Multiple sending on assessment campaigns",

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -850,6 +850,7 @@
           "ATTESTATIONS_MANAGEMENT": "Attestations",
           "CAMPAIGN_WITHOUT_USER_PROFILE": "Mode interro (nom non définitif)",
           "COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY": "Certificabilité automatique",
+          "COVER_RATE": "Statistiques Pix Orga",
           "IS_MANAGING_STUDENTS": "Gestion d'élèves/étudiants",
           "LEARNER_IMPORT": "Import générique",
           "MULTIPLE_SENDING_ASSESSMENT": "Envoi multiple sur les campagnes d'évaluation",


### PR DESCRIPTION
## 🌎 Problème

La feature `COVER_RATE` existe côté API mais n'est pas exposée dans le formulaire admin. Les administrateurs ne peuvent donc pas l'activer sur les organisations.

## 🔭 Proposition

- Ajouter `COVER_RATE` dans `featureList` et `editableFeatureList` du modèle `Organization`
- Ajouter les traductions FR/EN
- Ajouter les tests d'intégration correspondants
- Supprimer le `:not(:last-child)` sur le séparateur entre les features

## 🚀 Pour tester

- [ ] Ouvrir une organisation dans l'admin
- [ ] Aller dans l'onglet Features
- [ ] Vérifier que la checkbox "Statistiques Pix Orga" apparaît et est éditable
- [ ] Tester avec le compte en vue seule `certifadmin@example.net`

🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘 🌑