### PR TITLE
[FEATURE] Ajouter l'information "canAddEmailConnectionMethod" dans la route /me (PIX-21983)

### DIFF
--- a/api/config/feature-toggles-config.js
+++ b/api/config/feature-toggles-config.js
@@ -108,4 +108,11 @@ export default {
     devDefaultValues: { test: false, reviewApp: false },
     tags: ['team-acces', 'pix-api', 'mon-pix', 'frontend', 'backend'],
   },
+  restrictedOidcProvidersForEmailCreation: {
+    type: 'array',
+    description:
+      'Forbid email connexion method creation for user which has only one oidc provider and included in this list',
+    defaultValue: [],
+    tags: ['team-acces', 'iam', 'backend'],
+  },
 };

--- a/api/src/identity-access-management/domain/models/UserAccountInfo.js
+++ b/api/src/identity-access-management/domain/models/UserAccountInfo.js
@@ -1,8 +1,36 @@
+export const RESTRICTED_OIDC_PROVIDERS = {
+  list: ['CNAV'],
+};
+
 export class UserAccountInfo {
-  constructor({ id, email, username, canSelfDeleteAccount } = {}) {
+  #addEmailConnectionMethodEnabled;
+  #oidcAuthenticationMethods;
+
+  constructor({
+    id,
+    email,
+    username,
+    canSelfDeleteAccount,
+    addEmailConnectionMethodEnabled = false,
+    oidcAuthenticationMethods = [],
+  }) {
     this.id = id;
     this.email = email;
     this.username = username;
     this.canSelfDeleteAccount = canSelfDeleteAccount;
+    this.#addEmailConnectionMethodEnabled = addEmailConnectionMethodEnabled;
+    this.#oidcAuthenticationMethods = oidcAuthenticationMethods;
+  }
+
+  get canAddEmailConnectionMethod() {
+    if (!this.#addEmailConnectionMethodEnabled) {
+      return false;
+    }
+    if (this.email || this.#oidcAuthenticationMethods.length === 0) {
+      return false;
+    }
+    return this.#oidcAuthenticationMethods.some(
+      (method) => !RESTRICTED_OIDC_PROVIDERS.list.includes(method.identityProvider),
+    );
   }
 }

--- a/api/src/identity-access-management/domain/models/UserAccountInfo.js
+++ b/api/src/identity-access-management/domain/models/UserAccountInfo.js
@@ -1,16 +1,14 @@
-export const RESTRICTED_OIDC_PROVIDERS = {
-  list: ['CNAV'],
-};
-
 export class UserAccountInfo {
   #addEmailConnectionMethodEnabled;
   #oidcAuthenticationMethods;
+  #restrictedOidcProvidersForEmailCreation;
 
   constructor({
     id,
     email,
     username,
     canSelfDeleteAccount,
+    restrictedOidcProvidersForEmailCreation = [],
     addEmailConnectionMethodEnabled = false,
     oidcAuthenticationMethods = [],
   }) {
@@ -18,6 +16,7 @@ export class UserAccountInfo {
     this.email = email;
     this.username = username;
     this.canSelfDeleteAccount = canSelfDeleteAccount;
+    this.#restrictedOidcProvidersForEmailCreation = restrictedOidcProvidersForEmailCreation;
     this.#addEmailConnectionMethodEnabled = addEmailConnectionMethodEnabled;
     this.#oidcAuthenticationMethods = oidcAuthenticationMethods;
   }
@@ -26,11 +25,17 @@ export class UserAccountInfo {
     if (!this.#addEmailConnectionMethodEnabled) {
       return false;
     }
-    if (this.email || this.#oidcAuthenticationMethods.length === 0) {
+    if (this.email) {
       return false;
     }
-    return this.#oidcAuthenticationMethods.some(
-      (method) => !RESTRICTED_OIDC_PROVIDERS.list.includes(method.identityProvider),
-    );
+    if (this.#oidcAuthenticationMethods.length === 0) {
+      return false;
+    }
+    if (this.#oidcAuthenticationMethods.length === 1) {
+      const { identityProvider } = this.#oidcAuthenticationMethods.at(0);
+      return !this.#restrictedOidcProvidersForEmailCreation.includes(identityProvider);
+    }
+
+    return true;
   }
 }

--- a/api/src/identity-access-management/domain/usecases/get-user-account-info.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/get-user-account-info.usecase.js
@@ -14,6 +14,8 @@ const getUserAccountInfo = async ({
     userId,
   });
   const addEmailConnectionMethodEnabled = await featureToggles.get('addEmailConnectionMethodEnabled');
+  const restrictedOidcProvidersForEmailCreation = await featureToggles.get('restrictedOidcProvidersForEmailCreation');
+
   return new UserAccountInfo({
     id: user.id,
     email: user.email,
@@ -21,6 +23,7 @@ const getUserAccountInfo = async ({
     canSelfDeleteAccount,
     oidcAuthenticationMethods,
     addEmailConnectionMethodEnabled,
+    restrictedOidcProvidersForEmailCreation,
   });
 };
 

--- a/api/src/identity-access-management/domain/usecases/get-user-account-info.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/get-user-account-info.usecase.js
@@ -1,15 +1,26 @@
+import { featureToggles } from '../../../shared/infrastructure/feature-toggles/index.js';
 import { UserAccountInfo } from '../models/UserAccountInfo.js';
 
-const getUserAccountInfo = async ({ userId, userRepository, privacyUsersApiRepository }) => {
+const getUserAccountInfo = async ({
+  userId,
+  userRepository,
+  privacyUsersApiRepository,
+  authenticationMethodRepository,
+}) => {
   const user = await userRepository.get(userId);
 
   const canSelfDeleteAccount = await privacyUsersApiRepository.canSelfDeleteAccount({ userId });
-
+  const oidcAuthenticationMethods = await authenticationMethodRepository.findAllOidcAuthenticationMethodsByUser({
+    userId,
+  });
+  const addEmailConnectionMethodEnabled = await featureToggles.get('addEmailConnectionMethodEnabled');
   return new UserAccountInfo({
     id: user.id,
     email: user.email,
     username: user.username,
     canSelfDeleteAccount,
+    oidcAuthenticationMethods,
+    addEmailConnectionMethodEnabled,
   });
 };
 

--- a/api/src/identity-access-management/infrastructure/repositories/authentication-method.repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/authentication-method.repository.js
@@ -128,6 +128,17 @@ const hasIdentityProviderPIX = async function ({ userId }) {
   return Boolean(authenticationMethodDTO);
 };
 
+const findAllOidcAuthenticationMethodsByUser = async function ({ userId }) {
+  const knexConn = DomainTransaction.getConnection();
+  const oidcAuthenticationMethods = await knexConn
+    .select(COLUMNS)
+    .from(AUTHENTICATION_METHODS_TABLE)
+    .where({ userId })
+    .whereNotIn('identityProvider', [NON_OIDC_IDENTITY_PROVIDERS.PIX.code, NON_OIDC_IDENTITY_PROVIDERS.GAR.code]);
+
+  return oidcAuthenticationMethods;
+};
+
 const hasIdentityProviderGar = async function ({ userId }) {
   const knexConn = DomainTransaction.getConnection();
   const authenticationMethodDTO = await knexConn
@@ -299,6 +310,7 @@ const findByUserIdsAndIdentityProvider = async ({ userIds, identityProvider }) =
  * @property {function} hasIdentityProviderGar
  * @property {function} removeAllAuthenticationMethodsByUserId
  * @property {function} removeByUserIdAndIdentityProvider
+ * @property {function} findAllOidcAuthenticationMethodsByUser
  * @property {function} findByUserIdsAndIdentityProvider
  * @property {function} update
  * @property {function} updateAuthenticationComplementByUserIdAndIdentityProvider
@@ -311,6 +323,7 @@ export {
   batchUpsertPasswordThatShouldBeChanged,
   create,
   createPasswordThatShouldBeChanged,
+  findAllOidcAuthenticationMethodsByUser,
   findByUserId,
   findByUserIdsAndIdentityProvider,
   findOneByExternalIdentifierAndIdentityProvider,

--- a/api/src/identity-access-management/infrastructure/serializers/jsonapi/user-account-info.serializer.js
+++ b/api/src/identity-access-management/infrastructure/serializers/jsonapi/user-account-info.serializer.js
@@ -4,7 +4,7 @@ const { Serializer } = jsonapiSerializer;
 
 const serialize = function (userAccountInfo, meta) {
   return new Serializer('account-info', {
-    attributes: ['email', 'username', 'canSelfDeleteAccount'],
+    attributes: ['email', 'username', 'canSelfDeleteAccount', 'canAddEmailConnectionMethod'],
     meta,
   }).serialize(userAccountInfo);
 };

--- a/api/tests/identity-access-management/acceptance/application/user/user.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/user/user.route.test.js
@@ -335,6 +335,7 @@ describe('Acceptance | Identity Access Management | Application | Route | User',
             'can-self-delete-account': false,
             email: user.email,
             username: user.username,
+            'can-add-email-connection-method': false,
           },
         },
       });

--- a/api/tests/identity-access-management/integration/domain/usecases/get-user-account-info.usecase.test.js
+++ b/api/tests/identity-access-management/integration/domain/usecases/get-user-account-info.usecase.test.js
@@ -3,21 +3,82 @@ import { featureToggles } from '../../../../../src/shared/infrastructure/feature
 import { databaseBuilder, expect } from '../../../../test-helper.js';
 
 describe('Integration | Identity Access Management  | Domain | Usecases | get-user-account-info', function () {
-  it('returns user account info', async function () {
-    // given
+  beforeEach(async function () {
     await featureToggles.set('isSelfAccountDeletionEnabled', false);
-    const user = databaseBuilder.factory.buildUser();
-    await databaseBuilder.commit();
+  });
 
-    // when
-    const userAccountInfo = await usecases.getUserAccountInfo({ userId: user.id });
+  describe('when feature toggle addEmailConnectionMethodEnabled is not enabled', function () {
+    it('returns user account info with canAddEmailConnectionMethod set to false', async function () {
+      // given
+      await featureToggles.set('addEmailConnectionMethodEnabled', false);
 
-    // then
-    expect(userAccountInfo).to.deep.equal({
-      id: user.id,
-      email: user.email,
-      username: user.username,
-      canSelfDeleteAccount: false,
+      const user = databaseBuilder.factory.buildUser();
+      await databaseBuilder.commit();
+
+      // when
+      const userAccountInfo = await usecases.getUserAccountInfo({ userId: user.id });
+
+      // then
+      expect(userAccountInfo).to.deep.equal({
+        id: user.id,
+        email: user.email,
+        username: user.username,
+        canSelfDeleteAccount: false,
+      });
+      expect(userAccountInfo.canAddEmailConnectionMethod).to.be.false;
+    });
+  });
+
+  describe('when feature toggle addEmailConnectionMethodEnabled is enabled', function () {
+    beforeEach(async function () {
+      await featureToggles.set('addEmailConnectionMethodEnabled', true);
+    });
+
+    describe('when user has no email', function () {
+      describe('when user has at least one authorized identity provider', function () {
+        it('returns user account info with canAddEmailConnectionMethod set to true', async function () {
+          // given
+          const user = databaseBuilder.factory.buildUser({ email: null });
+          databaseBuilder.factory.buildAuthenticationMethod.withOidcProviderAsIdentityProvider({
+            userId: user.id,
+            identityProvider: 'AUTHORIZED_IDENTITY_PROVIDER',
+          });
+          await databaseBuilder.commit();
+
+          // when
+          const userAccountInfo = await usecases.getUserAccountInfo({ userId: user.id });
+
+          // then
+          expect(userAccountInfo).to.deep.equal({
+            id: user.id,
+            email: null,
+            username: user.username,
+            canSelfDeleteAccount: false,
+          });
+          expect(userAccountInfo.canAddEmailConnectionMethod).to.be.true;
+        });
+      });
+
+      describe('when user has no authorized identity provider', function () {
+        it('returns user account info with canAddEmailConnectionMethod set to false', async function () {
+          // given
+          const user = databaseBuilder.factory.buildUser({ email: null });
+          databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider({ userId: user.id });
+          await databaseBuilder.commit();
+
+          // when
+          const userAccountInfo = await usecases.getUserAccountInfo({ userId: user.id });
+
+          // then
+          expect(userAccountInfo).to.deep.equal({
+            id: user.id,
+            email: null,
+            username: user.username,
+            canSelfDeleteAccount: false,
+          });
+          expect(userAccountInfo.canAddEmailConnectionMethod).to.be.false;
+        });
+      });
     });
   });
 });

--- a/api/tests/identity-access-management/integration/infrastructure/repositories/authentication-method.repository.test.js
+++ b/api/tests/identity-access-management/integration/infrastructure/repositories/authentication-method.repository.test.js
@@ -784,6 +784,63 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
     });
   });
 
+  describe('#findAllOidcAuthenticationMethodsByUser', function () {
+    it('returns all OIDC authentication methods for a user', async function () {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      databaseBuilder.factory.buildAuthenticationMethod.withPixAsIdentityProviderAndPassword({ userId });
+      databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider({ userId });
+      const oidcAuthMethod1 = databaseBuilder.factory.buildAuthenticationMethod.withOidcProviderAsIdentityProvider({
+        userId,
+        identityProvider: 'firstOidcProvider',
+      });
+      const oidcAuthMethod2 = databaseBuilder.factory.buildAuthenticationMethod.withOidcProviderAsIdentityProvider({
+        userId,
+        identityProvider: 'secondOidcProvider',
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const result = await authenticationMethodRepository.findAllOidcAuthenticationMethodsByUser({
+        userId,
+      });
+
+      // then
+      expect(result).to.have.lengthOf(2);
+      expect(result.map((method) => method.id)).to.have.members([oidcAuthMethod1.id, oidcAuthMethod2.id]);
+    });
+
+    it('returns an empty array if user has only non-OIDC authentication methods', async function () {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      databaseBuilder.factory.buildAuthenticationMethod.withPixAsIdentityProviderAndPassword({ userId });
+      databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider({ userId });
+      await databaseBuilder.commit();
+
+      // when
+      const result = await authenticationMethodRepository.findAllOidcAuthenticationMethodsByUser({
+        userId,
+      });
+
+      // then
+      expect(result).to.be.empty;
+    });
+
+    it('returns an empty array if user has no authentication methods', async function () {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      await databaseBuilder.commit();
+
+      // when
+      const result = await authenticationMethodRepository.findAllOidcAuthenticationMethodsByUser({
+        userId,
+      });
+
+      // then
+      expect(result).to.be.empty;
+    });
+  });
+
   describe('#removeByUserIdAndIdentityProvider', function () {
     it('deletes from database the authentication method by userId and identityProvider', async function () {
       // given

--- a/api/tests/identity-access-management/unit/domain/models/UserAccountInfo.test.js
+++ b/api/tests/identity-access-management/unit/domain/models/UserAccountInfo.test.js
@@ -1,0 +1,130 @@
+import {
+  RESTRICTED_OIDC_PROVIDERS,
+  UserAccountInfo,
+} from '../../../../../src/identity-access-management/domain/models/UserAccountInfo.js';
+import { expect } from '../../../../test-helper.js';
+
+describe('Unit | Domain | Models | UserAccountInfo', function () {
+  beforeEach(function () {
+    RESTRICTED_OIDC_PROVIDERS.list = ['RESTRICTED_OIDC_PARTNER_1', 'RESTRICTED_OIDC_PARTNER_2'];
+  });
+
+  describe('constructor', function () {
+    it('creates a user account info with required properties and sets default values for optional properties', function () {
+      // given
+      const userAccountInfoData = {
+        id: 123,
+        email: 'user@example.net',
+        username: 'user123',
+        canSelfDeleteAccount: true,
+      };
+
+      // when
+      const userAccountInfo = new UserAccountInfo(userAccountInfoData);
+
+      // then
+      expect(userAccountInfo.id).to.equal(123);
+      expect(userAccountInfo.email).to.equal('user@example.net');
+      expect(userAccountInfo.username).to.equal('user123');
+      expect(userAccountInfo.canSelfDeleteAccount).to.be.true;
+      expect(userAccountInfo.canAddEmailConnectionMethod).to.be.false;
+    });
+  });
+
+  describe('#canAddEmailConnectionMethod', function () {
+    context('when addEmailConnectionMethodEnabled feature toggle is false', function () {
+      it('canAddEmailConnectionMethod returns false', function () {
+        // given
+        const userAccountInfo = new UserAccountInfo({
+          id: 123,
+          email: null,
+          username: 'user123',
+          canSelfDeleteAccount: true,
+          addEmailConnectionMethodEnabled: false,
+          oidcAuthenticationMethods: [{ identityProvider: 'OIDC_PARTNER' }],
+        });
+
+        // when / then
+        expect(userAccountInfo.canAddEmailConnectionMethod).to.be.false;
+      });
+    });
+
+    context('when addEmailConnectionMethodEnabled is true', function () {
+      context('when user already has an email', function () {
+        it('canAddEmailConnectionMethod returns false', function () {
+          // given
+          const userAccountInfo = new UserAccountInfo({
+            id: 123,
+            email: 'user@example.net',
+            username: 'user123',
+            canSelfDeleteAccount: true,
+            addEmailConnectionMethodEnabled: true,
+            oidcAuthenticationMethods: [{ identityProvider: 'AUTHORIZED_OIDC_PARTNER' }],
+          });
+
+          // when / then
+          expect(userAccountInfo.canAddEmailConnectionMethod).to.be.false;
+        });
+      });
+
+      context('when user has no email', function () {
+        context('when oidcAuthenticationMethods is empty', function () {
+          it('canAddEmailConnectionMethod returns false', function () {
+            // given
+            const userAccountInfo = new UserAccountInfo({
+              id: 123,
+              email: null,
+              username: 'user123',
+              canSelfDeleteAccount: true,
+              addEmailConnectionMethodEnabled: true,
+              oidcAuthenticationMethods: [],
+            });
+
+            // when / then
+            expect(userAccountInfo.canAddEmailConnectionMethod).to.be.false;
+          });
+        });
+
+        context('when all oidcAuthenticationMethods are restricted SSO providers', function () {
+          it('canAddEmailConnectionMethod returns false', function () {
+            // given
+            const userAccountInfo = new UserAccountInfo({
+              id: 123,
+              email: null,
+              username: 'user123',
+              canSelfDeleteAccount: true,
+              addEmailConnectionMethodEnabled: true,
+              oidcAuthenticationMethods: [
+                { identityProvider: 'RESTRICTED_OIDC_PARTNER_1' },
+                { identityProvider: 'RESTRICTED_OIDC_PARTNER_2' },
+              ],
+            });
+
+            // when / then
+            expect(userAccountInfo.canAddEmailConnectionMethod).to.be.false;
+          });
+        });
+
+        context('when at least one oidcAuthenticationMethod is not a restricted SSO provider', function () {
+          it('canAddEmailConnectionMethod returns true', function () {
+            // given
+            const userAccountInfo = new UserAccountInfo({
+              id: 123,
+              email: null,
+              username: 'user123',
+              canSelfDeleteAccount: true,
+              addEmailConnectionMethodEnabled: true,
+              oidcAuthenticationMethods: [
+                { identityProvider: 'OIDC_PARTNER' },
+                { identityProvider: 'RESTRICTED_OIDC_PARTNER_1' },
+              ],
+            });
+
+            // when / then
+            expect(userAccountInfo.canAddEmailConnectionMethod).to.be.true;
+          });
+        });
+      });
+    });
+  });
+});

--- a/api/tests/identity-access-management/unit/domain/models/UserAccountInfo.test.js
+++ b/api/tests/identity-access-management/unit/domain/models/UserAccountInfo.test.js
@@ -1,13 +1,8 @@
-import {
-  RESTRICTED_OIDC_PROVIDERS,
-  UserAccountInfo,
-} from '../../../../../src/identity-access-management/domain/models/UserAccountInfo.js';
+import { UserAccountInfo } from '../../../../../src/identity-access-management/domain/models/UserAccountInfo.js';
 import { expect } from '../../../../test-helper.js';
 
 describe('Unit | Domain | Models | UserAccountInfo', function () {
-  beforeEach(function () {
-    RESTRICTED_OIDC_PROVIDERS.list = ['RESTRICTED_OIDC_PARTNER_1', 'RESTRICTED_OIDC_PARTNER_2'];
-  });
+  const restrictedOidcProvidersForEmailCreation = ['RESTRICTED_OIDC_PROVIDER_1'];
 
   describe('constructor', function () {
     it('creates a user account info with required properties and sets default values for optional properties', function () {
@@ -17,6 +12,7 @@ describe('Unit | Domain | Models | UserAccountInfo', function () {
         email: 'user@example.net',
         username: 'user123',
         canSelfDeleteAccount: true,
+        restrictedOidcProvidersForEmailCreation,
       };
 
       // when
@@ -41,6 +37,7 @@ describe('Unit | Domain | Models | UserAccountInfo', function () {
           username: 'user123',
           canSelfDeleteAccount: true,
           addEmailConnectionMethodEnabled: false,
+          restrictedOidcProvidersForEmailCreation,
           oidcAuthenticationMethods: [{ identityProvider: 'OIDC_PARTNER' }],
         });
 
@@ -59,6 +56,7 @@ describe('Unit | Domain | Models | UserAccountInfo', function () {
             username: 'user123',
             canSelfDeleteAccount: true,
             addEmailConnectionMethodEnabled: true,
+            restrictedOidcProvidersForEmailCreation,
             oidcAuthenticationMethods: [{ identityProvider: 'AUTHORIZED_OIDC_PARTNER' }],
           });
 
@@ -77,6 +75,7 @@ describe('Unit | Domain | Models | UserAccountInfo', function () {
               username: 'user123',
               canSelfDeleteAccount: true,
               addEmailConnectionMethodEnabled: true,
+              restrictedOidcProvidersForEmailCreation,
               oidcAuthenticationMethods: [],
             });
 
@@ -85,7 +84,7 @@ describe('Unit | Domain | Models | UserAccountInfo', function () {
           });
         });
 
-        context('when all oidcAuthenticationMethods are restricted SSO providers', function () {
+        context('when user has one oidcAuthenticationMethod from a restricted provider', function () {
           it('canAddEmailConnectionMethod returns false', function () {
             // given
             const userAccountInfo = new UserAccountInfo({
@@ -94,10 +93,8 @@ describe('Unit | Domain | Models | UserAccountInfo', function () {
               username: 'user123',
               canSelfDeleteAccount: true,
               addEmailConnectionMethodEnabled: true,
-              oidcAuthenticationMethods: [
-                { identityProvider: 'RESTRICTED_OIDC_PARTNER_1' },
-                { identityProvider: 'RESTRICTED_OIDC_PARTNER_2' },
-              ],
+              restrictedOidcProvidersForEmailCreation,
+              oidcAuthenticationMethods: [{ identityProvider: 'RESTRICTED_OIDC_PROVIDER_1' }],
             });
 
             // when / then
@@ -114,6 +111,7 @@ describe('Unit | Domain | Models | UserAccountInfo', function () {
               username: 'user123',
               canSelfDeleteAccount: true,
               addEmailConnectionMethodEnabled: true,
+              restrictedOidcProvidersForEmailCreation,
               oidcAuthenticationMethods: [
                 { identityProvider: 'OIDC_PARTNER' },
                 { identityProvider: 'RESTRICTED_OIDC_PARTNER_1' },

--- a/api/tests/identity-access-management/unit/infrastructure/serializers/jsonapi/user-account-info.serializer.test.js
+++ b/api/tests/identity-access-management/unit/infrastructure/serializers/jsonapi/user-account-info.serializer.test.js
@@ -9,6 +9,7 @@ describe('Unit | Identity Access Management | Infrastructure | Serializer | JSON
         email: 'user@email.com',
         username: 'my-username',
         canSelfDeleteAccount: true,
+        canAddEmailConnectionMethod: true,
       };
 
       // when
@@ -22,6 +23,7 @@ describe('Unit | Identity Access Management | Infrastructure | Serializer | JSON
             email: 'user@email.com',
             username: 'my-username',
             'can-self-delete-account': true,
+            'can-add-email-connection-method': true,
           },
         },
       });


### PR DESCRIPTION
## 🌎 Problème

Il faut récupérer une information supplémentaire sur la route /mon-compte de Pix App : l'utilisateur a-t-il le droit de s'ajouter une méthode de connexion par email ?

## 🔭 Proposition

Règles fonctionnelles : 

    Si le FT `addEmailConnectionMethodEnabled` est activé 
    Et utilisateurs SSO sans méthode de connexion email
        Sauf pour les utilisateurs de 2 SSO (voir la spec/craquage)

## 🪐 Remarques
Le cas suivant est possible : un utilisateur a 2 SSO, l'une autorisée, l'autre non.
Il se connecte via le SSO autorisé OU **via le SSO non autorisé** > il a le droit de rajouter une adresse mail à son compte.
En effet pour décider si un utilisateur a le droit ou non d'ajouter une adresse email, on ne regarde pas avec quelle méthode de connexion l'utilisateur est en train de se connecter, on regarde de quelles méthodes de connexion il dispose.


## 🚀 Pour tester (en local)
Dans cette PR les fournisseurs "non autorisés" sont les deux nommés plus haut, tous les autres sont dits "autorisés".

DANS TOUS LES CAS : 
- choisir un fournisseur d'identité à mettre dans la liste des "fournisseurs non autorisés"
- exécuter la commande suivante :
`npm run toggles -- --key restrictedOidcProvidersForEmailCreation --value 'PROVIDER_CODE'`


SI LE FEATURE TOGGLE EST ON
- `npm run toggles -- --key addEmailConnectionMethodEnabled --value true`
- Créez un utilisateur avec SSO autorisé, et un autre avec SSO non autorisé. 
- connectez vous avec le premier compte et allez sur "mon-compte" > vérifiez que la route /mon-compte retourne bien `canAddEmailConnectionMethod = true `
- Faites la même chose pour le deuxième utilisateur et vérifiez que canAddEmailConnectionMethod = false OK
- Sur Pix Admin, déplacez la méthode de connexion du premier utilisateur sur le compte du deuxième, puis allez sur mon-compte et vérifiez que `canAddEmailConnectionMethod = true `
- Connectez vous sur le compte d'un utilisateur qui n'a qu'un email et vérifiez que `canAddEmailConnectionMethod = false`
- Connectez-vous sur le compte d'un utilisateur qui n'a qu'un username (bob.leponge.0202) et vérifiez que c`anAddEmailConnectionMethod = false`
- Lors d'une nouvelle connexion SSO avec un fournisseur d'identité autorisé, associez/réconciliez votre compte à un compte Pix existant pour avoir deux méthodes de connexion (Pix et SSO), puis allez sur mon-compte : vérifiez que `canAddEmailConnectionMethod = false.`


SI LE FEATURE TOGGLE EST OFF
- `npm run toggles -- --key addEmailConnectionMethodEnabled --value false`

Refaites les opérations ci-dessus et vérifiez que `canAddEmailConnectionMethod = false` dans tous les cas.

🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘 🌑
