### PR TITLE
[BUGFIX] Réparer la page de détail des parcours combinés dans Pix Orga

### DIFF
--- a/api/src/quest/infrastructure/repositories/combined-course-participation-repository.js
+++ b/api/src/quest/infrastructure/repositories/combined-course-participation-repository.js
@@ -163,6 +163,7 @@ export const findPaginatedCombinedCourseParticipationById = async function ({ co
       referenceId: combinedCourseId.toString(),
       type: OrganizationLearnerParticipationTypes.COMBINED_COURSE,
     })
+    .whereNull('organization_learner_participations.deletedAt')
     .orderBy(['lastName', 'firstName']);
 
   queryBuilder.modify(addSearchFilters, filters);

--- a/api/tests/quest/integration/infrastructure/repositories/combined-course-participation-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/combined-course-participation-repository_test.js
@@ -425,7 +425,7 @@ describe('Quest | Integration | Infrastructure | repositories | Combined-Course-
 
   describe('#findPaginatedCombinedCourseParticipationById', function () {
     let combinedCourseId;
-    let organizationLearner1, organizationLearner2, organizationLearner3;
+    let organizationLearner1, organizationLearner2, organizationLearner3, organizationLearner4;
 
     beforeEach(async function () {
       //given
@@ -450,6 +450,15 @@ describe('Quest | Integration | Infrastructure | repositories | Combined-Course-
         userId: null,
         firstName: 'Nour',
         lastName: 'Aresto',
+        division: null,
+        group: 'A',
+        organizationId: combinedCourse.organizationId,
+      });
+
+      organizationLearner4 = databaseBuilder.factory.buildOrganizationLearner({
+        userId: null,
+        firstName: 'Abc',
+        lastName: 'Def',
         division: null,
         group: 'A',
         organizationId: combinedCourse.organizationId,
@@ -485,6 +494,14 @@ describe('Quest | Integration | Infrastructure | repositories | Combined-Course-
         type: OrganizationLearnerParticipationTypes.COMBINED_COURSE,
       });
 
+      databaseBuilder.factory.buildOrganizationLearnerParticipation({
+        organizationLearnerId: organizationLearner4.id,
+        combinedCourseId,
+        status: CombinedCourseParticipationStatuses.COMPLETED,
+        type: OrganizationLearnerParticipationTypes.COMBINED_COURSE,
+        deletedAt: new Date(),
+      });
+
       await databaseBuilder.commit();
     });
 
@@ -512,6 +529,12 @@ describe('Quest | Integration | Infrastructure | repositories | Combined-Course-
         });
       // then
       expect(organizationLearnerIds).deep.equal([organizationLearner1.id]);
+    });
+
+    it('should not return deleted participations to combined course', async function () {
+      const { organizationLearnerIds } =
+        await combinedCourseParticipationRepository.findPaginatedCombinedCourseParticipationById({ combinedCourseId });
+      expect(organizationLearnerIds).to.not.include(organizationLearner4.id);
     });
 
     describe('filters', function () {


### PR DESCRIPTION
## 🌎 Problème
On a eu des erreurs 500 sur /api/combined-courses/{id}/participations suite à un script de suppression des parcours combinés.

## 🔭 Proposition
On exclut les participations supprimées du listing, à l'image de ce qui se fait sur les campagnes.

## 🚀 Pour tester
Supprimer une participation grâce au script https://1024pix.atlassian.net/wiki/spaces/prescription/pages/5919604737/COMBINIX+-+Supprimer+les+participations+d+un+learner+un+parcours+combin

Puis aller sur la page de détails du parcours combiné correspondant et vérifier que la participation ne remonte pas.

🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘 🌑
