### PR TITLE
[BUGFIX] Réparer la mise à jour du logo d'une organisation (PIX-21772)

### DIFF
--- a/admin/app/components/organizations/head-information.gjs
+++ b/admin/app/components/organizations/head-information.gjs
@@ -6,11 +6,15 @@ import { LinkTo } from '@ember/routing';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import t from 'ember-intl/helpers/t';
+import get from 'lodash/get';
 import CopyButton from 'pix-admin/components/ui/copy-button';
 import ENV from 'pix-admin/config/environment';
 
 export default class HeadInformation extends Component {
   @service currentUser;
+  @service intl;
+  @service pixToast;
+
   @action
   onLogoUpload(event) {
     const file = event.target.files?.[0];
@@ -18,11 +22,34 @@ export default class HeadInformation extends Component {
 
     const reader = new FileReader();
     reader.onload = () => {
-      this.args.organization.logoUrl = reader.result;
-      this.args.onLogoUpdated();
+      this.updateLogo(reader.result);
     };
     reader.readAsDataURL(file);
   }
+
+  updateLogo = async (logoUrl) => {
+    this.args.organization.logoUrl = logoUrl;
+    try {
+      await this.args.organization.save();
+      this.pixToast.sendSuccessNotification({
+        message: this.intl.t('components.organizations.head-information.notifications.logo-update-success'),
+      });
+    } catch (responseError) {
+      this.args.organization.rollbackAttributes();
+      const error = get(responseError, 'errors[0]');
+      let message;
+      switch (error?.status) {
+        case '413':
+          message = this.intl.t('pages.organizations.notifications.errors.payload-too-large', {
+            maxSizeInMegaBytes: error?.meta?.maxSizeInMegaBytes,
+          });
+          break;
+        default:
+          message = this.intl.t('common.notifications.generic-error');
+      }
+      this.pixToast.sendErrorNotification({ message });
+    }
+  };
 
   get hasTags() {
     const tags = this.args.organization.tags;

--- a/admin/app/controllers/authenticated/organizations/get/details.js
+++ b/admin/app/controllers/authenticated/organizations/get/details.js
@@ -17,20 +17,9 @@ export default class DetailsController extends Controller {
         message: this.intl.t('components.organizations.information-section-view.update.notifications.success'),
       });
       this.router.transitionTo('authenticated.organizations.get');
-    } catch (responseError) {
+    } catch {
       this.model.rollbackAttributes();
-      const error = get(responseError, 'errors[0]');
-      let message;
-      switch (error?.status) {
-        case '413':
-          message = this.intl.t(I18N_KEY_ERROR_MESSAGES[error?.status], {
-            maxSizeInMegaBytes: error?.meta?.maxSizeInMegaBytes,
-          });
-          break;
-        default:
-          message = this.intl.t(I18N_KEY_ERROR_MESSAGES['default']);
-      }
-      this.pixToast.sendErrorNotification({ message });
+      this.pixToast.sendErrorNotification({ message: this.intl.t('common.notifications.generic-error') });
     }
   }
 
@@ -64,8 +53,3 @@ export default class DetailsController extends Controller {
     }
   }
 }
-
-const I18N_KEY_ERROR_MESSAGES = {
-  413: 'pages.organizations.notifications.errors.payload-too-large',
-  default: 'common.notifications.generic-error',
-};

--- a/admin/tests/integration/components/organizations/head-information-test.gjs
+++ b/admin/tests/integration/components/organizations/head-information-test.gjs
@@ -1,18 +1,27 @@
 import { render } from '@1024pix/ember-testing-library';
 import EmberObject from '@ember/object';
+import { triggerEvent } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import HeadInformation from 'pix-admin/components/organizations/head-information';
 import ENV from 'pix-admin/config/environment';
 import { module, test } from 'qunit';
+import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | organizations/header-information', function (hooks) {
   setupIntlRenderingTest(hooks);
 
+  let store, notificationService;
+
   hooks.beforeEach(function () {
     const currentUser = this.owner.lookup('service:currentUser');
     currentUser.adminMember = { isSuperAdmin: true };
+    store = this.owner.lookup('service:store');
+
+    notificationService = this.owner.lookup('service:pixToast');
+    sinon.stub(notificationService, 'sendSuccessNotification');
+    sinon.stub(notificationService, 'sendErrorNotification');
   });
 
   module('when displaying organization', function () {
@@ -175,6 +184,99 @@ module('Integration | Component | organizations/header-information', function (h
 
         // then
         assert.dom(screen.queryByText(t('components.organizations.head-information.network'))).doesNotExist();
+      });
+    });
+  });
+
+  module('when updating organization logo', function () {
+    module('when there is no error', function () {
+      test('should save model, display success notification and display new logo', async function (assert) {
+        // given
+        const organization = store.createRecord('organization', {
+          name: 'Organization SCO',
+          logoUrl: 'data:former-logo-file;base64,',
+        });
+
+        sinon.stub(organization, 'save').resolves();
+
+        const file = new Blob([''], { type: `new-logo-file` });
+
+        // when
+        const screen = await render(<template><HeadInformation @organization={{organization}} /></template>);
+
+        await triggerEvent('input[type="file"]', 'change', {
+          files: [file],
+        });
+
+        // then
+        assert.true(organization.save.calledOnce);
+        assert.true(
+          notificationService.sendSuccessNotification.calledOnceWithExactly({
+            message: t('components.organizations.head-information.notifications.logo-update-success'),
+          }),
+        );
+        const logo = screen.getByRole('presentation');
+        assert.dom(logo).hasAttribute('src', 'data:new-logo-file;base64,');
+      });
+    });
+
+    module('when file is too large', function () {
+      test('should rollback attributes and display payload-too-large error notification', async function (assert) {
+        // given
+        const organization = store.createRecord('organization', {
+          name: 'Organization SCO',
+          logoUrl: 'data:former-logo-file;base64,',
+        });
+
+        sinon.stub(organization, 'save').rejects({ errors: [{ status: '413', meta: { maxSizeInMegaBytes: '2.5' } }] });
+        sinon.stub(organization, 'rollbackAttributes').resolves();
+
+        const file = new Blob([''], { type: `new-logo-file` });
+
+        // when
+        await render(<template><HeadInformation @organization={{organization}} /></template>);
+
+        await triggerEvent('input[type="file"]', 'change', {
+          files: [file],
+        });
+
+        // then
+        assert.true(organization.rollbackAttributes.calledOnce);
+        assert.true(
+          notificationService.sendErrorNotification.calledOnceWithExactly({
+            message: t('pages.organizations.notifications.errors.payload-too-large', { maxSizeInMegaBytes: '2.5' }),
+          }),
+        );
+      });
+    });
+
+    module('when a generic error occurs', function () {
+      test('should rollback attributes and display generic error notification', async function (assert) {
+        // given
+        const organization = store.createRecord('organization', {
+          name: 'Organization SCO',
+          logoUrl: 'data:former-logo-file;base64,',
+        });
+
+        sinon.stub(organization, 'save').rejects();
+        sinon.stub(organization, 'rollbackAttributes').resolves();
+
+        const file = new Blob([''], { type: `new-logo-file` });
+
+        // when
+        await render(<template><HeadInformation @organization={{organization}} /></template>);
+
+        await triggerEvent('input[type="file"]', 'change', {
+          files: [file],
+        });
+
+        // then
+        assert.true(organization.rollbackAttributes.calledOnce);
+        assert.true(
+          notificationService.sendErrorNotification.calledOnceWithExactly({
+            message: t('common.notifications.generic-error'),
+          }),
+        );
       });
     });
   });

--- a/admin/tests/unit/controllers/authenticated/organizations/get/details-test.js
+++ b/admin/tests/unit/controllers/authenticated/organizations/get/details-test.js
@@ -10,7 +10,7 @@ module('Unit | Controller | authenticated/organizations/get/details', function (
   setupIntl(hooks);
 
   module('#updateOrganizationInformation', function () {
-    module('when the size of the payload is lower than 2.5 Mo limit', function () {
+    module('when there is no error', function () {
       test('displays a success notification', async function (assert) {
         // Given
         const controller = this.owner.lookup('controller:authenticated.organizations.get.details');
@@ -37,7 +37,7 @@ module('Unit | Controller | authenticated/organizations/get/details', function (
       });
     });
 
-    module('when the size of the payload is greater than 2.5 Mo limit', function () {
+    module('when there is an error', function () {
       test('displays an error notification', async function (assert) {
         // Given
         const controller = this.owner.lookup('controller:authenticated.organizations.get.details');
@@ -49,7 +49,7 @@ module('Unit | Controller | authenticated/organizations/get/details', function (
         controller.pixToast = {
           sendErrorNotification: sinon.stub(),
         };
-        controller.model.save.rejects({ errors: [{ status: '413', meta: { maxSizeInMegaBytes: '2.5' } }] });
+        controller.model.save.rejects();
 
         // When
         await controller.updateOrganizationInformation();
@@ -58,9 +58,7 @@ module('Unit | Controller | authenticated/organizations/get/details', function (
         sinon.assert.calledOnce(controller.model.save);
         sinon.assert.calledOnce(controller.model.rollbackAttributes);
         sinon.assert.calledWith(controller.pixToast.sendErrorNotification, {
-          message: t('pages.organizations.notifications.errors.payload-too-large', {
-            maxSizeInMegaBytes: '2.5',
-          }),
+          message: t('common.notifications.generic-error'),
         });
         assert.ok(true);
       });

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -894,6 +894,9 @@
         "child-organization": "Parent:",
         "copy-id": "Copy ID",
         "network": "Network:",
+        "notifications": {
+          "logo-update-success": "The organization logo has been updated successfully."
+        },
         "parent-organization": "Parent organization"
       },
       "information-section-view": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -896,6 +896,9 @@
         "child-organization": "Parent :",
         "copy-id": "Copier l'ID",
         "network": "Réseau :",
+        "notifications": {
+          "logo-update-success": "Le logo de l'organisation a bien été mis à jour."
+        },
         "parent-organization": "Organisation mère"
       },
       "information-section-view": {


### PR DESCRIPTION
🌎 Problème

Depuis l'introduction de l'onglet _Détails_ sur la page d'une organisation, la mise à jour du logo ne fonctionne plus. C'est dû au fait que la mise à jour d'une organisation et celle de son logo utilisent la même méthode. Mais les composants qui appellent cette méthode (le bouton _Modifier_ pour la mise à jour d'une organisation et l'image elle-même pour la mise à jour du logo) ne se trouvent désormais plus sur la même route.

## 🔭 Proposition

- dupliquer une partie de la méthode de mise à jour d'une organisation pour qu'elle s'applique plus spécifiquement au logo, et la déclarer au niveau du composant dans lequel on appelle cette méthode
- supprimer le code spécifique à la gestion du logo dans la méthode appelée dans l'onglet _Détails_

## 🪐 Remarques
RAS

## 🚀 Pour tester
Sur Pix Admin,
- aller sur la page d'une organisation
- cliquer sur le logo de l'organisation pour charger une nouvelle image
- constater que celle-ci s'affiche ainsi que la notification de succès
- recharger la page pour vérifier que c'est persisté

Pour tester l'erreur, il faut
- tenter de charger une image dépassant 2.5Mo

Ou lancer le projet en local et
- dans le fichier `api/src/organizational-entities/application/organization/organization.admin.route.js`
- modifier la valeur de la constante `TWO_AND_HALF_MEGABYTES` à `1` afin de déclencher l'erreur de fichier trop lourd

🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘 🌑
