### PR TITLE
[FEATURE] Rediriger vers la page de détails d'un réseau après sa création (PIX-22029).

### DIFF
--- a/admin/app/components/networks/creation-form.gjs
+++ b/admin/app/components/networks/creation-form.gjs
@@ -25,6 +25,7 @@ export default class CreationForm extends Component {
   @service pixToast;
   @service intl;
   @service store;
+  @service router;
 
   @tracked form = {
     name: '',
@@ -55,7 +56,10 @@ export default class CreationForm extends Component {
       this.focusOnFirstFieldInError();
       return;
     }
-    await this.createNetwork(this.form);
+    const network = await this.createNetwork(this.form);
+    if (network) {
+      this.router.transitionTo('authenticated.networks.get', network.id);
+    }
   };
 
   @action
@@ -67,18 +71,11 @@ export default class CreationForm extends Component {
       this.pixToast.sendSuccessNotification({
         message: this.intl.t('components.networks.creation.notifications.success'),
       });
-      this._resetForm();
+      return network;
     } catch {
       this.pixToast.sendErrorNotification({ message: this.intl.t('components.networks.creation.notifications.error') });
       network.rollbackAttributes();
     }
-  }
-
-  _resetForm() {
-    this.form = {
-      name: '',
-      organizationId: '',
-    };
   }
 
   <template>

--- a/admin/tests/acceptance/authenticated/networks/create-network-test.js
+++ b/admin/tests/acceptance/authenticated/networks/create-network-test.js
@@ -56,6 +56,19 @@ module('Acceptance | Networks | Create', function (hooks) {
         // then
         assert.ok(await screen.findByText(t('components.networks.creation.notifications.success')));
       });
+
+      test('it redirects to created network details page', async function (assert) {
+        // given
+        const screen = await visit('/networks/new');
+
+        // when
+        await fillByLabel(`${t('components.networks.creation.name.label')} *`, 'Nouveau réseau');
+        await fillByLabel(`${t('components.networks.creation.organization-id.label')} *`, '1');
+        await click(screen.getByRole('button', { name: t('components.networks.creation.actions.submit') }));
+
+        // then
+        assert.strictEqual(currentURL(), '/networks/10');
+      });
     });
   });
 });

--- a/admin/tests/integration/components/networks/creation-form-test.gjs
+++ b/admin/tests/integration/components/networks/creation-form-test.gjs
@@ -22,6 +22,9 @@ module('Integration | Component | networks/creation-form', function (hooks) {
     pixToast = this.owner.lookup('service:pixToast');
     sinon.stub(pixToast, 'sendSuccessNotification');
     sinon.stub(pixToast, 'sendErrorNotification');
+
+    const router = this.owner.lookup('service:router');
+    sinon.stub(router, 'transitionTo');
   });
 
   test('it renders the form fields and submit button', async function (assert) {

--- a/admin/tests/mirage/handlers/networks.js
+++ b/admin/tests/mirage/handlers/networks.js
@@ -2,6 +2,7 @@ export function createNetwork(schema, request) {
   const params = JSON.parse(request.requestBody);
 
   return schema.create('network', {
+    id: 10,
     name: params.data.attributes.name,
     organizationId: params.data.attributes['organization-id'],
   });


### PR DESCRIPTION
## 🌎 Problème

La page de détails d'un réseau n'était pas encore créée lors que l'on avait mis en place la création de réseaux.
Le succès lors de la création d'un réseau nous laissait sur le formulaire de création.

## 🔭 Proposition

Redirection vers la page de détails d'un réseau une fois celui-ci créé.

## 🪐 Remarques

Il y a possibilité de modifier la gestion d'erreur afin de ne pas avoir à checker le présence du network avant redirection.
A voir si l'on veut la faire.

## 🚀 Pour tester

- Se connecter à PixAdmin en tant que `superadmin@example.net`
- Aller sur l'onglet réseaux
- Créer un nouveau réseau
- Vérifier que l'on est bien ramené à la page de détails du réseau nouvellement créé
