### PR TITLE
[FEATURE] Ajuster le style de la page d'une organisation (PIX-21873)

### DIFF
--- a/admin/app/components/organizations/head-information.scss
+++ b/admin/app/components/organizations/head-information.scss
@@ -1,18 +1,16 @@
 @use 'pix-design-tokens/typography';
+@use 'pix-design-tokens/shadows';
 
 .organization__head-information {
+  @extend %pix-shadow-default;
+
   display: flex;
   gap: var(--pix-spacing-4x);
   align-items: center;
-  max-width: 1400px;
   padding: var(--pix-spacing-4x) var(--pix-spacing-6x);
   color: var(--pix-neutral-900);
   background-color: var(--pix-neutral-0);
-
-  // TODO: replace border and shadow by new shadow design-token once available
-  border: 1.2px var(--pix-neutral-100) solid;
   border-radius: var(--pix-spacing-4x);
-  box-shadow: 5px 4px 10px 2px rgb(0 0 0 / 10%);
 
   .organization__logo {
     width: 83px;

--- a/admin/app/styles/components/card.scss
+++ b/admin/app/styles/components/card.scss
@@ -1,10 +1,11 @@
 @use 'pix-design-tokens/typography';
+@use 'pix-design-tokens/shadows';
 
 .card {
+  @extend %pix-shadow-default;
+
   background: var(--pix-neutral-0);
-  border: 1.2px var(--pix-neutral-100) solid;
   border-radius: 8px;
-  box-shadow: 5px 4px 10px 2px rgb(0 0 0 / 10%);
 
   &__title {
     @extend %pix-title-xs;

--- a/admin/app/styles/components/organization-information-section.scss
+++ b/admin/app/styles/components/organization-information-section.scss
@@ -1,7 +1,6 @@
 @use 'pix-design-tokens/breakpoints';
 @use 'pix-design-tokens/typography';
 
-/* stylelint-disable color-no-hex */
 .organization-information-section {
   &__card {
     &--general {
@@ -94,7 +93,6 @@
         color: var(--pix-error-500);
       }
     }
-
 
     li {
       display: inline-flex;


### PR DESCRIPTION
 🌎 Problème

Plusieurs problèmes de style sur la page d'organisation
- la largeur du header n'est pas alignée avec les cartes du dessous
- les cartes n'utilisent pas les nouveaux tokens d'ombres du design system

## 🔭 Proposition

- retirer le max-width du header pour qu'il s'aligne avec le reste
- utiliser le nouveau token `pix-shadow-default` du design system sur les cartes

## 🪐 Remarques

L'ombre a été ajoutée directement au niveau du composant Card. Celui-ci étant utilisé à plusieurs endroits dans Pix Admin, les ombres vont changer partout.

## 🚀 Pour tester

Sur Pix Admin
- aller sur la page de détail d'une orga
- constater sur un écran de plus de 1400px de large que le header et le reste sont alignés
- constater que les nouvelles ombres sur les cartes sont de toute beauté

-- Aller faire un tour sur d'autres pages qui utilisent les Cards:
-  création d'orga/modification d'orga
- création/modification de profil cible
- création de parcours autonome
- création/modification de contenu formatif)

🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘 🌑
