### PR TITLE
[BUGFIX] Les tests E2E de la recette de certification sont rouges car pix-admin est lancé avant d'être installé

### DIFF
--- a/.circleci/jobs.yml
+++ b/.circleci/jobs.yml
@@ -382,6 +382,7 @@ workflows:
             - mon_pix_install
             - orga_install
             - certif_install
+            - admin_install
           filters:
             branches:
               only: dev


### PR DESCRIPTION
## 🌎 Problème

Une PR récemment fait un refacto sur la config de circleci. Lors du refacto, un job a été oublié en tant que dépendance du job de recette certif : `admin_install`

## 🔭 Proposition

Ajouter `admin_install` au `requires` du job des E2E de certification.
En effet, les tests E2E de certification se jouent sur les 4 front ends !

## 🪐 Remarques

Question : je remarque que depuis le refacto, les tests E2E de cypress ne sont plus lancés nulle part. On les supprime ?

## 🚀 Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->

🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘 🌑
