### PR TITLE
[TECH] Résolution de test flaky sur le test d'intégration du "combined-course-blueprint-repository.js"

### DIFF
--- a/api/src/quest/infrastructure/repositories/combined-course-blueprint-repository.js
+++ b/api/src/quest/infrastructure/repositories/combined-course-blueprint-repository.js
@@ -109,7 +109,8 @@ export async function findByOrganizationId({ organizationId }) {
       'combined_course_blueprint_shares.combinedCourseBlueprintId',
     )
     .where({ organizationId })
-    .groupBy('combined_course_blueprints.id');
+    .groupBy('combined_course_blueprints.id')
+    .orderBy('combined_course_blueprints.id');
   return results.map((result) => _toDomain(result));
 }
 

--- a/api/tests/quest/integration/infrastructure/repositories/campaign-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/campaign-repository_test.js
@@ -1,7 +1,7 @@
 import * as campaignRepository from '../../../../../src/quest/infrastructure/repositories/campaign-repository.js';
 import { databaseBuilder, expect } from '../../../../test-helper.js';
 
-describe('Quest | Integration | Repository | combined-course-blueprint', function () {
+describe('Quest | Integration | Repository | campaign', function () {
   describe('#getCampaignIdsByCombinedCourseIds', function () {
     it('should return correct campaign ids', async function () {
       const { id: campaignId } = databaseBuilder.factory.buildCampaign();


### PR DESCRIPTION
## 🌎 Problème

Le test est flaky. Vu l'erreur ça ressemble à une collection avec un ordre incertain.

## 🔭 Proposition

Ajouter la clause `orderBy` dans la requête pour garantir l'ordre des résultats.

## 🪐 Remarques

Je vous laisse merge quand vous voulez

## 🚀 Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->

🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘 🌑
