### PR TITLE
[TECH] Réduire la durée de la transaction dans le endpoint POST /api/answers pour la positionner seulement autour de l'insertion en BDD de la réponse et des KE

### DIFF
--- a/api/src/evaluation/application/answers/answer-controller.js
+++ b/api/src/evaluation/application/answers/answer-controller.js
@@ -9,7 +9,7 @@ import { evaluationUsecases } from '../../domain/usecases/index.js';
 import * as answerSerializer from '../../infrastructure/serializers/jsonapi/answer-serializer.js';
 import * as correctionSerializer from '../../infrastructure/serializers/jsonapi/correction-serializer.js';
 
-const save = async function (request, h, dependencies = { answerSerializer, assessmentRepository }) {
+async function save(request, h, dependencies = { answerSerializer, assessmentRepository }) {
   const answer = dependencies.answerSerializer.deserialize(request.payload);
   const userId = extractUserIdFromRequest(request);
   const locale = getChallengeLocale(request);
@@ -49,25 +49,25 @@ const save = async function (request, h, dependencies = { answerSerializer, asse
   // }
 
   return h.response(dependencies.answerSerializer.serialize(correctedAnswer)).created();
-};
+}
 
-const get = async function (request) {
+async function get(request) {
   const userId = extractUserIdFromRequest(request);
   const answerId = request.params.id;
   const answer = await evaluationUsecases.getAnswer({ answerId, userId });
 
   return answerSerializer.serialize(answer);
-};
+}
 
-const update = async function (request) {
+async function update(request) {
   const userId = extractUserIdFromRequest(request);
   const answerId = request.params.id;
   const answer = await evaluationUsecases.getAnswer({ answerId, userId });
 
   return answerSerializer.serialize(answer);
-};
+}
 
-const find = async function (request) {
+async function find(request) {
   const userId = extractUserIdFromRequest(request);
   const challengeId = request.query.challengeId;
   const assessmentId = request.query.assessmentId;
@@ -80,9 +80,9 @@ const find = async function (request) {
   }
 
   return answerSerializer.serialize(answers);
-};
+}
 
-const getCorrection = async function (request, _h, dependencies = { correctionSerializer }) {
+async function getCorrection(request, _h, dependencies = { correctionSerializer }) {
   const userId = extractUserIdFromRequest(request);
   const locale = getChallengeLocale(request);
   const answerId = request.params.id;
@@ -94,7 +94,7 @@ const getCorrection = async function (request, _h, dependencies = { correctionSe
   });
 
   return dependencies.correctionSerializer.serialize(correction);
-};
+}
 
 const answerController = { save, get, update, find, getCorrection };
 

--- a/api/src/evaluation/domain/usecases/save-and-correct-answer-for-campaign.js
+++ b/api/src/evaluation/domain/usecases/save-and-correct-answer-for-campaign.js
@@ -5,7 +5,7 @@ import { ChallengeNotAskedError } from '../../../shared/domain/errors.js';
 import { KnowledgeElement } from '../../../shared/domain/models/KnowledgeElement.js';
 import { EmptyAnswerError } from '../errors.js';
 
-const saveAndCorrectAnswerForCampaign = async function ({
+export async function saveAndCorrectAnswerForCampaign({
   answer,
   userId,
   assessment,
@@ -21,52 +21,52 @@ const saveAndCorrectAnswerForCampaign = async function ({
   knowledgeElementForParticipationService,
   correctionService,
   campaignRepository,
-} = {}) {
-  const savedAnswer = await DomainTransaction.execute(async () => {
-    if (assessment.userId !== userId) {
-      throw new ForbiddenAccess('User is not allowed to add an answer for this assessment.');
-    }
-    if (!assessment.isCampaignParticipationAvailable() || !assessment?.campaign.isAccessible) {
-      throw new ForbiddenAccess('Campaign does not accept any answer.');
-    }
-    if (assessment.answers.some((existingAnswer) => existingAnswer.challengeId === answer.challengeId)) {
-      throw new ChallengeAlreadyAnsweredError();
-    }
-    if (assessment.lastChallengeId && assessment.lastChallengeId !== answer.challengeId) {
-      throw new ChallengeNotAskedError();
-    }
-    if (!answer.hasValue && !answer.hasTimedOut) {
-      throw new EmptyAnswerError();
-    }
+}) {
+  if (assessment.userId !== userId) {
+    throw new ForbiddenAccess('User is not allowed to add an answer for this assessment.');
+  }
+  if (!assessment.isCampaignParticipationAvailable() || !assessment?.campaign.isAccessible) {
+    throw new ForbiddenAccess('Campaign does not accept any answer.');
+  }
+  if (assessment.answers.some((existingAnswer) => existingAnswer.challengeId === answer.challengeId)) {
+    throw new ChallengeAlreadyAnsweredError();
+  }
+  if (assessment.lastChallengeId && assessment.lastChallengeId !== answer.challengeId) {
+    throw new ChallengeNotAskedError();
+  }
+  if (!answer.hasValue && !answer.hasTimedOut) {
+    throw new EmptyAnswerError();
+  }
 
-    const challenge = await challengeRepository.get(answer.challengeId);
-    const correctedAnswer = correctionService.evaluateAnswer({
-      challenge,
-      answer,
-      assessment,
-      accessibilityAdjustmentNeeded: false,
-      forceOKAnswer,
-    });
-    const now = new Date();
-    const lastQuestionDate = assessment.lastQuestionDate || now;
-    correctedAnswer.setTimeSpentFrom({ now, lastQuestionDate });
+  const challenge = await challengeRepository.get(answer.challengeId);
+  const correctedAnswer = correctionService.evaluateAnswer({
+    challenge,
+    answer,
+    assessment,
+    accessibilityAdjustmentNeeded: false,
+    forceOKAnswer,
+  });
+  const now = new Date();
+  const lastQuestionDate = assessment.lastQuestionDate || now;
+  correctedAnswer.setTimeSpentFrom({ now, lastQuestionDate });
 
-    let answerToBeSaved;
-    if (assessment.isSmartRandom()) {
-      const knowledgeElementsBefore =
-        await knowledgeElementForParticipationService.findUniqByUserOrCampaignParticipationId({
-          userId,
-          campaignParticipationId: assessment.campaignParticipationId,
-        });
-
-      const targetSkills = await campaignRepository.findSkillsByCampaignParticipationId({
+  let savedAnswer;
+  if (assessment.isSmartRandom()) {
+    const knowledgeElementsBefore =
+      await knowledgeElementForParticipationService.findUniqByUserOrCampaignParticipationId({
+        userId,
         campaignParticipationId: assessment.campaignParticipationId,
       });
-      const campaignId = await campaignRepository.getCampaignIdByCampaignParticipationId(
-        assessment.campaignParticipationId,
-      );
-      const campaign = await campaignRepository.get(campaignId);
-      answerToBeSaved = await answerRepository.save({ answer: correctedAnswer });
+
+    const targetSkills = await campaignRepository.findSkillsByCampaignParticipationId({
+      campaignParticipationId: assessment.campaignParticipationId,
+    });
+    const campaignId = await campaignRepository.getCampaignIdByCampaignParticipationId(
+      assessment.campaignParticipationId,
+    );
+    const campaign = await campaignRepository.get(campaignId);
+    savedAnswer = await DomainTransaction.execute(async () => {
+      const answerToBeSaved = await answerRepository.save({ answer: correctedAnswer });
       const knowledgeElementsToAdd = computeKnowledgeElements({
         campaign,
         assessment,
@@ -95,15 +95,15 @@ const saveAndCorrectAnswerForCampaign = async function ({
         });
       }
       return answerToBeSaved;
-    }
-  });
+    });
+  }
 
   if (userId) {
     await answerJobRepository.performAsync(new AnswerJob({ userId }));
   }
 
   return savedAnswer;
-};
+}
 
 function computeKnowledgeElements({ campaign, assessment, answer, challenge, targetSkills, knowledgeElementsBefore }) {
   let knowledgeElements;
@@ -185,5 +185,3 @@ async function computeLevelUpInformation({
     knowledgeElementsForCompetenceAfter: uniqKnowledgeElementsForCompetenceAfter,
   });
 }
-
-export { saveAndCorrectAnswerForCampaign };

--- a/api/src/evaluation/domain/usecases/save-and-correct-answer-for-certification.js
+++ b/api/src/evaluation/domain/usecases/save-and-correct-answer-for-certification.js
@@ -1,14 +1,14 @@
-import { withTransaction } from '../../../shared/domain/DomainTransaction.js';
+import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import {
   CertificationEndedByFinalizationError,
   CertificationEndedByInvigilatorError,
   ChallengeAlreadyAnsweredError,
+  ChallengeNotAskedError,
   ForbiddenAccess,
 } from '../../../shared/domain/errors.js';
-import { ChallengeNotAskedError } from '../../../shared/domain/errors.js';
 import { EmptyAnswerError } from '../errors.js';
 
-const saveAndCorrectAnswerForCertification = withTransaction(async function ({
+export async function saveAndCorrectAnswerForCertification({
   answer,
   userId,
   assessment,
@@ -18,7 +18,7 @@ const saveAndCorrectAnswerForCertification = withTransaction(async function ({
   certificationChallengeLiveAlertRepository,
   certificationEvaluationCandidateRepository,
   correctionService,
-} = {}) {
+}) {
   if (assessment.userId !== userId) {
     throw new ForbiddenAccess('User is not allowed to add an answer for this assessment.');
   }
@@ -63,10 +63,9 @@ const saveAndCorrectAnswerForCertification = withTransaction(async function ({
   const lastQuestionDate = assessment.lastQuestionDate || now;
   correctedAnswer.setTimeSpentFrom({ now, lastQuestionDate });
 
-  const answerSaved = await answerRepository.save({ answer: correctedAnswer });
-  answerSaved.levelup = {};
-
-  return answerSaved;
-});
-
-export { saveAndCorrectAnswerForCertification };
+  return DomainTransaction.execute(async () => {
+    const answerSaved = await answerRepository.save({ answer: correctedAnswer });
+    answerSaved.levelup = {};
+    return answerSaved;
+  });
+}

--- a/api/src/evaluation/domain/usecases/save-and-correct-answer-for-certification.js
+++ b/api/src/evaluation/domain/usecases/save-and-correct-answer-for-certification.js
@@ -1,4 +1,3 @@
-import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import {
   CertificationEndedByFinalizationError,
   CertificationEndedByInvigilatorError,
@@ -63,9 +62,7 @@ export async function saveAndCorrectAnswerForCertification({
   const lastQuestionDate = assessment.lastQuestionDate || now;
   correctedAnswer.setTimeSpentFrom({ now, lastQuestionDate });
 
-  return DomainTransaction.execute(async () => {
-    const answerSaved = await answerRepository.save({ answer: correctedAnswer });
-    answerSaved.levelup = {};
-    return answerSaved;
-  });
+  const answerSaved = await answerRepository.save({ answer: correctedAnswer });
+  answerSaved.levelup = {};
+  return answerSaved;
 }

--- a/api/src/evaluation/domain/usecases/save-and-correct-answer-for-competence-evaluation.js
+++ b/api/src/evaluation/domain/usecases/save-and-correct-answer-for-competence-evaluation.js
@@ -1,12 +1,11 @@
 import { AnswerJob } from '../../../quest/domain/models/AnwserJob.js';
-import { withTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { ChallengeAlreadyAnsweredError, ForbiddenAccess } from '../../../shared/domain/errors.js';
 import { ChallengeNotAskedError } from '../../../shared/domain/errors.js';
 import { KnowledgeElement } from '../../../shared/domain/models/KnowledgeElement.js';
 import { EmptyAnswerError } from '../errors.js';
 
-const saveAndCorrectAnswerForCompetenceEvaluation = withTransaction(async function ({
+export async function saveAndCorrectAnswerForCompetenceEvaluation({
   answer,
   userId,
   assessment,
@@ -22,35 +21,35 @@ const saveAndCorrectAnswerForCompetenceEvaluation = withTransaction(async functi
   skillRepository,
   knowledgeElementRepository,
   correctionService,
-} = {}) {
+}) {
+  if (assessment.userId !== userId) {
+    throw new ForbiddenAccess('User is not allowed to add an answer for this assessment.');
+  }
+  if (assessment.answers.some((existingAnswer) => existingAnswer.challengeId === answer.challengeId)) {
+    throw new ChallengeAlreadyAnsweredError();
+  }
+  if (assessment.lastChallengeId && assessment.lastChallengeId !== answer.challengeId) {
+    throw new ChallengeNotAskedError();
+  }
+  if (!answer.hasValue && !answer.hasTimedOut) {
+    throw new EmptyAnswerError();
+  }
+
+  const challenge = await challengeRepository.get(answer.challengeId);
+  const correctedAnswer = correctionService.evaluateAnswer({
+    challenge,
+    answer,
+    assessment,
+    accessibilityAdjustmentNeeded: false,
+    forceOKAnswer,
+  });
+  const now = new Date();
+  const lastQuestionDate = assessment.lastQuestionDate || now;
+  correctedAnswer.setTimeSpentFrom({ now, lastQuestionDate });
+
+  const targetSkills = await skillRepository.findActiveByCompetenceId(assessment.competenceId);
+  const knowledgeElementsBefore = await knowledgeElementRepository.findUniqByUserId({ userId });
   const savedAnswer = await DomainTransaction.execute(async () => {
-    if (assessment.userId !== userId) {
-      throw new ForbiddenAccess('User is not allowed to add an answer for this assessment.');
-    }
-    if (assessment.answers.some((existingAnswer) => existingAnswer.challengeId === answer.challengeId)) {
-      throw new ChallengeAlreadyAnsweredError();
-    }
-    if (assessment.lastChallengeId && assessment.lastChallengeId !== answer.challengeId) {
-      throw new ChallengeNotAskedError();
-    }
-    if (!answer.hasValue && !answer.hasTimedOut) {
-      throw new EmptyAnswerError();
-    }
-
-    const challenge = await challengeRepository.get(answer.challengeId);
-    const correctedAnswer = correctionService.evaluateAnswer({
-      challenge,
-      answer,
-      assessment,
-      accessibilityAdjustmentNeeded: false,
-      forceOKAnswer,
-    });
-    const now = new Date();
-    const lastQuestionDate = assessment.lastQuestionDate || now;
-    correctedAnswer.setTimeSpentFrom({ now, lastQuestionDate });
-
-    const targetSkills = await skillRepository.findActiveByCompetenceId(assessment.competenceId);
-    const knowledgeElementsBefore = await knowledgeElementRepository.findUniqByUserId({ userId });
     const answerToBeSaved = await answerRepository.save({ answer: correctedAnswer });
     const knowledgeElementsToAdd = computeKnowledgeElements({
       assessment,
@@ -80,7 +79,7 @@ const saveAndCorrectAnswerForCompetenceEvaluation = withTransaction(async functi
   }
 
   return savedAnswer;
-});
+}
 
 function computeKnowledgeElements({ assessment, answer, challenge, targetSkills, knowledgeElementsBefore }) {
   const knowledgeElements = knowledgeElementsBefore.filter(
@@ -155,5 +154,3 @@ async function computeLevelUpInformation({
     knowledgeElementsForCompetenceAfter: uniqKnowledgeElementsForCompetenceAfter,
   });
 }
-
-export { saveAndCorrectAnswerForCompetenceEvaluation };

--- a/api/src/evaluation/domain/usecases/save-and-correct-answer-for-demo-and-preview.js
+++ b/api/src/evaluation/domain/usecases/save-and-correct-answer-for-demo-and-preview.js
@@ -1,15 +1,15 @@
-import { withTransaction } from '../../../shared/domain/DomainTransaction.js';
+import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { ChallengeAlreadyAnsweredError, ChallengeNotAskedError } from '../../../shared/domain/errors.js';
 import { EmptyAnswerError } from '../errors.js';
 
-const saveAndCorrectAnswerForDemoAndPreview = withTransaction(async function ({
+export async function saveAndCorrectAnswerForDemoAndPreview({
   answer,
   assessment,
   forceOKAnswer = false,
   answerRepository,
   challengeRepository,
   correctionService,
-} = {}) {
+}) {
   if (assessment.answers.some((existingAnswer) => existingAnswer.challengeId === answer.challengeId)) {
     throw new ChallengeAlreadyAnsweredError();
   }
@@ -32,9 +32,9 @@ const saveAndCorrectAnswerForDemoAndPreview = withTransaction(async function ({
   const lastQuestionDate = assessment.lastQuestionDate || now;
   correctedAnswer.setTimeSpentFrom({ now, lastQuestionDate });
 
-  const answerSaved = await answerRepository.save({ answer: correctedAnswer });
-  answerSaved.levelup = {};
-  return answerSaved;
-});
-
-export { saveAndCorrectAnswerForDemoAndPreview };
+  return DomainTransaction.execute(async () => {
+    const answerSaved = await answerRepository.save({ answer: correctedAnswer });
+    answerSaved.levelup = {};
+    return answerSaved;
+  });
+}

--- a/api/src/evaluation/domain/usecases/save-and-correct-answer-for-demo-and-preview.js
+++ b/api/src/evaluation/domain/usecases/save-and-correct-answer-for-demo-and-preview.js
@@ -1,4 +1,3 @@
-import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { ChallengeAlreadyAnsweredError, ChallengeNotAskedError } from '../../../shared/domain/errors.js';
 import { EmptyAnswerError } from '../errors.js';
 
@@ -32,9 +31,7 @@ export async function saveAndCorrectAnswerForDemoAndPreview({
   const lastQuestionDate = assessment.lastQuestionDate || now;
   correctedAnswer.setTimeSpentFrom({ now, lastQuestionDate });
 
-  return DomainTransaction.execute(async () => {
-    const answerSaved = await answerRepository.save({ answer: correctedAnswer });
-    answerSaved.levelup = {};
-    return answerSaved;
-  });
+  const answerSaved = await answerRepository.save({ answer: correctedAnswer });
+  answerSaved.levelup = {};
+  return answerSaved;
 }


### PR DESCRIPTION
## 🌎 Problème

les transactions sont en `READ COMMITTED` par défaut, ce qui signifie que faire les lectures dans la transaction n'isole en rien des modifications extérieures.


## 🔭 Proposition

Pour ce niveau d'isolation, autant exclure les lectures qui ne dépendent pas des écritures de la transaction, et réduire ainsi la durée de la transaction

## 🪐 Remarques

Un commentaire dans la PR évoquait la raison pour laquelle à l'époque on avait choisi de mettre une grosse transaction qui wrap tout : pour gagner en perte de temps à demander des connexions au pool knex.

Avec l'expérience et les constats des récents événements de prod, on a eu des apprentissages nouveaux et différents que je vais essayer de résumer ici :
- PG utilise un système de MVCC. Donc à chaque transaction simultanée, PG doit maintenir cohérent autant de "versions" de la BDD et ça lui coûte beaucoup. Donc : si on a des transactions longues => PG doit maintenir plusieurs versions cohérentes en même temps et plus longtemps.
- Si la transaction est ouverte tôt et rendue tard (donc si sa durée est plus longue) logiquement le pool de connexions du container s'épuise plus vite. C'est peu scalable, car en cas de dégradation des performances on va avoir beaucoup de handler bloqués dès le début en attente d'une connexion.
- Obtenir une connexion auprès du pool de connexion de Knex n'est pas si couteux que cela, surtout si on met en balance cette petite perte au profit d'une plus grande stabilité en cas de fort traffic

Donc pour répondre au commentaire, les effets ne se voient pas nécessairement en cas de fonctionnement normal, mais ce travail est supposé réduire la probabilité d'avoir une plateforme qui s'emballe en cas de fort traffic

## 🚀 Pour tester
Non-régression sur la partie évaluation d'assessment de tout type.

- certification
- campagne (exam et pas exam)
- compétence éval
- démo
- preview

🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘 🌑
