### PR TITLE
[BUGFIX] Répare la pagination sur les participations aux parcours combinés (PIX-22034)

### DIFF
--- a/orga/app/controllers/authenticated/combined-course/participations.js
+++ b/orga/app/controllers/authenticated/combined-course/participations.js
@@ -2,9 +2,13 @@ import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 
+const DEFAULT_PAGE_NUMBER = 1;
+
 export default class ParticipationsController extends Controller {
   queryParams = ['fullName', 'statuses', 'divisions', 'groups'];
 
+  @tracked pageNumber = DEFAULT_PAGE_NUMBER;
+  @tracked pageSize = 50;
   @tracked fullName = '';
   @tracked statuses = [];
   @tracked divisions = [];
@@ -19,6 +23,7 @@ export default class ParticipationsController extends Controller {
   @action
   triggerFiltering(fieldName, value) {
     this[fieldName] = value;
+    this.pageNumber = null;
   }
 
   @action

--- a/orga/tests/unit/controllers/authenticated/combined-course/participations-test.js
+++ b/orga/tests/unit/controllers/authenticated/combined-course/participations-test.js
@@ -48,6 +48,21 @@ module('Unit | Controller | authenticated/combined-course/participations', funct
         assert.deepEqual(controller.divisions, ['6eme']);
         assert.deepEqual(controller.groups, ['A']);
       });
+      test('when at least one filter is filled in, should take user back to page 1 of results', async function (assert) {
+        //given
+        controller.fullName = 'nom1';
+        controller.statuses = [];
+        controller.divisions = [];
+        controller.groups = [];
+        controller.pageSize = 10;
+        controller.pageNumber = 2;
+
+        //when
+        controller.triggerFiltering('fullName', 'nom2');
+
+        //then
+        assert.strictEqual(controller.pageNumber, null);
+      });
     });
   });
 });


### PR DESCRIPTION
## 🌎 Problème
La pagination sur les participations ne fonctionne plus : quand il y a un filtre et qu'on est sur une page autre que la 1, les résultats sont complètement vidés.

## 🔭 Proposition
On réinitialise le numéro de page lors de la modification d'un filtre de la page des participations à un parcours combiné. 

## 🚀 Pour tester
Tirer la branche en local.
Aller sur la page des participations aux parcours combinés sur Pix Orga. Réduire la taille de page à 1 ou 2 dans le code en dur. 
Appliquer un filtre sur les classes ou sur nom / prénom.
Vérifier qu'on a la bonne liste de résultats.

🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘 🌑
