### PR TITLE
[FEATURE] Afficher un message lorsqu'un contenu est manquant dans les modules (PIX-21813).

### DIFF
--- a/mon-pix/app/components/module/element/_audio.scss
+++ b/mon-pix/app/components/module/element/_audio.scss
@@ -1,4 +1,18 @@
-.element-audio{
+@use 'pix-design-tokens/typography';
+
+.element-audio {
+  &__missing-content {
+    @extend %pix-body-s;
+
+    display: flex;
+    flex-direction: column;
+    padding: var(--pix-spacing-6x) 0;
+    color: var(--pix-neutral-800);
+    text-align: center;
+    background-color: var(--pix-neutral-20);
+    border-radius: var(--pix-spacing-2x);
+  }
+
   &__container {
     padding: var(--pix-spacing-4x);
     border: 1px solid var(--pix-neutral-100);

--- a/mon-pix/app/components/module/element/_image.scss
+++ b/mon-pix/app/components/module/element/_image.scss
@@ -4,6 +4,21 @@
   &__container {
     margin: 0 auto;
   }
+
+  &__missing-content {
+    @extend %pix-body-s;
+
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    max-width: 700px;
+    min-height: 400px;
+    margin: auto;
+    color: var(--pix-neutral-800);
+    text-align: center;
+    background-color: var(--pix-neutral-20);
+    border-radius: var(--pix-spacing-2x);
+  }
 }
 
 .element-image-container {

--- a/mon-pix/app/components/module/element/_short-video.scss
+++ b/mon-pix/app/components/module/element/_short-video.scss
@@ -1,7 +1,21 @@
-.element-short-video {
+@use 'pix-design-tokens/typography';
 
+.element-short-video {
   &__video {
     width: 100%;
     border-radius: var(--pix-spacing-2x);
+  }
+
+  &__missing-content {
+    @extend %pix-body-s;
+
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    color: var(--pix-neutral-800);
+    text-align: center;
+    background-color: var(--pix-neutral-20);
+    border-radius: var(--pix-spacing-2x);
+    aspect-ratio: 16 / 9;
   }
 }

--- a/mon-pix/app/components/module/element/audio.gjs
+++ b/mon-pix/app/components/module/element/audio.gjs
@@ -10,9 +10,20 @@ import { htmlUnsafe } from 'mon-pix/helpers/html-unsafe';
 
 export default class ModulixAudio extends Component {
   @tracked modalIsOpen = false;
+  @tracked audioHasError = false;
 
   @service passageEvents;
   @service pixMetrics;
+
+  get shouldShowFallback() {
+    return !this.args.audio?.url || this.audioHasError;
+  }
+
+  @action
+  onAudioError(event) {
+    event.stopPropagation();
+    this.audioHasError = true;
+  }
 
   @action
   onPlay() {
@@ -53,17 +64,26 @@ export default class ModulixAudio extends Component {
   <template>
     <div class="element-audio">
       <div class="element-audio__container">
-        <p class="element-audio__container__title">{{@audio.title}}</p>
-        {{! template-lint-disable require-media-caption }}
-        <audio
-          id={{@audio.id}}
-          ref="audio"
-          class="pix-audio-player"
-          controls
-          src="{{@audio.url}}"
-          {{on "play" this.onPlay}}
-        ></audio>
-
+        {{#if this.shouldShowFallback}}
+          <div class="element-audio__missing-content" role="status">
+            <p>{{t "pages.modulix.elements.audio.missing-content"}}</p>
+            {{#if this.hasTranscription}}
+              <p>{{t "pages.modulix.elements.audio.consult-transcription"}}</p>
+            {{/if}}
+          </div>
+        {{else}}
+          <p class="element-audio__container__title">{{@audio.title}}</p>
+          {{! template-lint-disable require-media-caption }}
+          <audio
+            id={{@audio.id}}
+            ref="audio"
+            class="pix-audio-player"
+            controls
+            src="{{@audio.url}}"
+            {{on "play" this.onPlay}}
+            {{on "error" this.onAudioError}}
+          ></audio>
+        {{/if}}
         {{#if this.hasTranscription}}
           <PixButton @variant="tertiary" @triggerAction={{this.showModal}}>
             {{t "pages.modulix.buttons.element.transcription"}}
@@ -78,7 +98,6 @@ export default class ModulixAudio extends Component {
             </:content>
           </PixModal>
         {{/if}}
-
       </div>
     </div>
   </template>

--- a/mon-pix/app/components/module/element/image.gjs
+++ b/mon-pix/app/components/module/element/image.gjs
@@ -1,5 +1,6 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixModal from '@1024pix/pix-ui/components/pix-modal';
+import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
@@ -10,8 +11,19 @@ import { resizeImage } from '../../../utils/resize-image';
 
 export default class ModulixImageElement extends Component {
   @tracked modalIsOpen = false;
+  @tracked imageHasError = false;
 
   static MAX_WIDTH = 700;
+
+  get shouldShowFallback() {
+    return !this.args.image?.url || this.imageHasError;
+  }
+
+  @action
+  onImageError(event) {
+    event.stopPropagation();
+    this.imageHasError = true;
+  }
 
   get hasAlternativeText() {
     return this.args.image.alternativeText.length > 0;
@@ -38,20 +50,30 @@ export default class ModulixImageElement extends Component {
 
   <template>
     <div class="element-image">
-      <figure class="element-image__container">
-        <img
-          class="element-image-container__image"
-          alt={{@image.alt}}
-          src={{@image.url}}
-          width={{this.dimensions.width}}
-          height={{this.dimensions.height}}
-        />
-        {{#if this.hasCaption}}
-          <figcaption class="element-image-container__caption">{{@image.legend}}<span
-              class="element-image-container__licence"
-            >{{@image.licence}}</span></figcaption>
-        {{/if}}
-      </figure>
+      {{#if this.shouldShowFallback}}
+        <div class="element-image__missing-content" role="status">
+          <p>{{t "pages.modulix.elements.image.missing-content"}}</p>
+          {{#if this.hasAlternativeText}}
+            <p>{{t "pages.modulix.elements.image.consult-alternative-text"}}</p>
+          {{/if}}
+        </div>
+      {{else}}
+        <figure class="element-image__container">
+          <img
+            class="element-image-container__image"
+            alt={{@image.alt}}
+            src={{@image.url}}
+            width={{this.dimensions.width}}
+            height={{this.dimensions.height}}
+            {{on "error" this.onImageError}}
+          />
+          {{#if this.hasCaption}}
+            <figcaption class="element-image-container__caption">{{@image.legend}}<span
+                class="element-image-container__licence"
+              >{{@image.licence}}</span></figcaption>
+          {{/if}}
+        </figure>
+      {{/if}}
       {{#if this.hasAlternativeText}}
         <PixButton class="element-image__button" @variant="tertiary" @triggerAction={{this.showModal}}>
           {{t "pages.modulix.buttons.element.alternativeText"}}

--- a/mon-pix/app/components/module/element/short-video.gjs
+++ b/mon-pix/app/components/module/element/short-video.gjs
@@ -1,5 +1,6 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixModal from '@1024pix/pix-ui/components/pix-modal';
+import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
@@ -10,8 +11,19 @@ import ModuleElement from './module-element';
 
 export default class ModulixShortVideoElement extends ModuleElement {
   @tracked modalIsOpen = false;
+  @tracked videoHasError = false;
   @service passageEvents;
   @service pixMetrics;
+
+  get shouldShowFallback() {
+    return !this.args.element?.url || this.videoHasError;
+  }
+
+  @action
+  onVideoError(event) {
+    event.stopPropagation();
+    this.videoHasError = true;
+  }
 
   @action
   showModal() {
@@ -37,7 +49,21 @@ export default class ModulixShortVideoElement extends ModuleElement {
 
   <template>
     <div class="element-short-video">
-      <video class="element-short-video__video" autoplay loop muted={{true}} src={{@element.url}}></video>
+      {{#if this.shouldShowFallback}}
+        <div class="element-short-video__missing-content" role="status">
+          <p>{{t "pages.modulix.elements.short-video.missing-content"}}</p>
+          <p>{{t "pages.modulix.elements.short-video.consult-transcription"}}</p>
+        </div>
+      {{else}}
+        <video
+          class="element-short-video__video"
+          autoplay
+          loop
+          muted={{true}}
+          src={{@element.url}}
+          {{on "error" this.onVideoError}}
+        ></video>
+      {{/if}}
       <PixButton @variant="tertiary" @triggerAction={{this.showModal}}>
         {{t "pages.modulix.buttons.element.transcription"}}
       </PixButton>

--- a/mon-pix/tests/integration/components/module/audio_test.gjs
+++ b/mon-pix/tests/integration/components/module/audio_test.gjs
@@ -1,6 +1,7 @@
 import { render } from '@1024pix/ember-testing-library';
 // eslint-disable-next-line no-restricted-imports
-import { click, find, findAll } from '@ember/test-helpers';
+import { click, find, findAll, triggerEvent } from '@ember/test-helpers';
+import { t } from 'ember-intl/test-support';
 import ModulixAudioElement from 'mon-pix/components/module/element/audio';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
@@ -101,5 +102,80 @@ module('Integration | Component | Module | Audio', function (hooks) {
       },
     });
     assert.ok(true);
+  });
+
+  module('when the audio url is missing', function () {
+    test('it should not display the audio element and display a fallback message', async function (assert) {
+      // given
+      const audioElement = { url: null, title: 'title', transcription: '' };
+
+      // when
+      const screen = await render(<template><ModulixAudioElement @audio={{audioElement}} /></template>);
+
+      // then
+      assert.dom('audio').doesNotExist();
+      assert.dom(screen.getByText(t('pages.modulix.elements.audio.missing-content'))).exists();
+      assert.dom(screen.queryByText(t('pages.modulix.elements.audio.consult-transcription'))).doesNotExist();
+    });
+
+    module('when there is a transcription', function () {
+      test('it should also suggest to consult it', async function (assert) {
+        // given
+        const audioElement = { url: null, title: 'title', transcription: 'transcription' };
+
+        // when
+        const screen = await render(<template><ModulixAudioElement @audio={{audioElement}} /></template>);
+
+        // then
+        assert.dom(screen.getByText(t('pages.modulix.elements.audio.missing-content'))).exists();
+        assert.dom(screen.getByText(t('pages.modulix.elements.audio.consult-transcription'))).exists();
+      });
+    });
+  });
+
+  module('when the audio fails to load', function () {
+    test('it should hide the audio element and display a fallback message', async function (assert) {
+      // given
+      const audioElement = {
+        url: 'https://assets.pix.fr/modulix/placeholder-audio.mp3',
+        title: 'title',
+        transcription: '',
+      };
+
+      // when
+      const screen = await render(<template><ModulixAudioElement @audio={{audioElement}} /></template>);
+
+      // then
+      assert.dom('audio').exists();
+      assert.dom(screen.queryByText(t('pages.modulix.elements.audio.missing-content'))).doesNotExist();
+
+      // when
+      await triggerEvent('audio', 'error');
+
+      // then
+      assert.dom('audio').doesNotExist();
+      assert.dom(screen.getByText(t('pages.modulix.elements.audio.missing-content'))).exists();
+      assert.dom(screen.queryByText(t('pages.modulix.elements.audio.consult-transcription'))).doesNotExist();
+    });
+
+    module('when there is a transcription', function () {
+      test('it should also suggest to consult it', async function (assert) {
+        // given
+        const audioElement = {
+          url: 'https://assets.pix.fr/modulix/placeholder-audio.mp3',
+          title: 'title',
+          transcription: 'transcription',
+        };
+
+        // when
+        const screen = await render(<template><ModulixAudioElement @audio={{audioElement}} /></template>);
+        await triggerEvent(find('audio'), 'error');
+
+        // then
+        assert.dom('audio').doesNotExist();
+        assert.dom(screen.getByText(t('pages.modulix.elements.audio.missing-content'))).exists();
+        assert.dom(screen.getByText(t('pages.modulix.elements.audio.consult-transcription'))).exists();
+      });
+    });
   });
 });

--- a/mon-pix/tests/integration/components/module/element/short-video_test.gjs
+++ b/mon-pix/tests/integration/components/module/element/short-video_test.gjs
@@ -1,5 +1,6 @@
 import { render } from '@1024pix/ember-testing-library';
-import { click } from '@ember/test-helpers';
+import { click, triggerEvent } from '@ember/test-helpers';
+import { t } from 'ember-intl/test-support';
 import ModulixShortVideo from 'mon-pix/components/module/element/short-video';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
@@ -10,8 +11,11 @@ module('Integration | Component | Module | ShortVideo', function (hooks) {
   setupIntlRenderingTest(hooks);
 
   test('it should display a video element with autoplay and loop attribute', async function (assert) {
+    // given
+    const element = { url: 'https://assets.pix.org/modules/placeholder-video.mp4' };
+
     // when
-    await render(<template><ModulixShortVideo /></template>);
+    await render(<template><ModulixShortVideo @element={{element}} /></template>);
 
     // then
     assert.dom('video').hasAttribute('autoplay');
@@ -29,6 +33,43 @@ module('Integration | Component | Module | ShortVideo', function (hooks) {
     await render(<template><ModulixShortVideo @element={{element}} /></template>);
     // then
     assert.dom('video').hasAttribute('src', 'https://assets.pix.org/modules/placeholder-video.mp4');
+  });
+
+  module('when the video url is missing', function () {
+    test('it should not display the video and display a fallback message', async function (assert) {
+      // given
+      const element = { url: null, transcription: 'transcription' };
+
+      // when
+      const screen = await render(<template><ModulixShortVideo @element={{element}} /></template>);
+
+      // then
+      assert.dom('video').doesNotExist();
+      assert.dom(screen.getByText(t('pages.modulix.elements.short-video.missing-content'))).exists();
+      assert.dom(screen.getByText(t('pages.modulix.elements.short-video.consult-transcription'))).exists();
+    });
+  });
+
+  module('when the video fails to load', function () {
+    test('it should hide the video and display a fallback message', async function (assert) {
+      // given
+      const element = { url: 'https://assets.pix.org/modules/placeholder-video.mp4', transcription: 'transcription' };
+
+      // when
+      const screen = await render(<template><ModulixShortVideo @element={{element}} /></template>);
+
+      // then
+      assert.dom('video').exists();
+      assert.dom(screen.queryByText(t('pages.modulix.elements.short-video.missing-content'))).doesNotExist();
+
+      // when
+      await triggerEvent('video', 'error');
+
+      // then
+      assert.dom('video').doesNotExist();
+      assert.dom(screen.getByText(t('pages.modulix.elements.short-video.missing-content'))).exists();
+      assert.dom(screen.getByText(t('pages.modulix.elements.short-video.consult-transcription'))).exists();
+    });
   });
 
   test('should be able to use the modal for transcription', async function (assert) {

--- a/mon-pix/tests/integration/components/module/image_test.gjs
+++ b/mon-pix/tests/integration/components/module/image_test.gjs
@@ -1,5 +1,6 @@
 import { render } from '@1024pix/ember-testing-library';
-import { click, findAll } from '@ember/test-helpers';
+import { click, findAll, triggerEvent } from '@ember/test-helpers';
+import { t } from 'ember-intl/test-support';
 import ModulixImageElement from 'mon-pix/components/module/element/image';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
@@ -113,5 +114,87 @@ module('Integration | Component | Module | Image', function (hooks) {
     // then
     const alternativeTextButton = await screen.queryByRole('button', { name: "Afficher l'alternative textuelle" });
     assert.dom(alternativeTextButton).doesNotExist();
+  });
+
+  module('when the image url is missing', function () {
+    test('it should not display the image and display a fallback message', async function (assert) {
+      // given
+      const imageElement = {
+        url: null,
+        alt: 'alt text',
+        alternativeText: '',
+      };
+
+      // when
+      const screen = await render(<template><ModulixImageElement @image={{imageElement}} /></template>);
+
+      // then
+      assert.dom(screen.queryByRole('img')).doesNotExist();
+      assert.dom(screen.getByText(t('pages.modulix.elements.image.missing-content'))).exists();
+      assert.dom(screen.queryByText(t('pages.modulix.elements.image.consult-alternative-text'))).doesNotExist();
+    });
+
+    module('when there is an alternative text', function () {
+      test('it should display an alternative text message', async function (assert) {
+        // given
+        const imageElement = {
+          url: null,
+          alt: 'alt text',
+          alternativeText: 'alternative instruction',
+        };
+
+        // when
+        const screen = await render(<template><ModulixImageElement @image={{imageElement}} /></template>);
+
+        // then
+        assert.dom(screen.getByText(t('pages.modulix.elements.image.consult-alternative-text'))).exists();
+      });
+    });
+  });
+
+  module('when the image fails to load', function () {
+    test('it should hide the image and display a fallback message', async function (assert) {
+      // given
+      const imageElement = {
+        url: 'https://assets.pix.org/draft/flamingo.jpg',
+        alt: 'alt text',
+        alternativeText: '',
+      };
+
+      // when
+      const screen = await render(<template><ModulixImageElement @image={{imageElement}} /></template>);
+
+      // then
+      assert.dom(screen.getByRole('img')).exists();
+      assert.dom(screen.queryByText(t('pages.modulix.elements.image.missing-content'))).doesNotExist();
+
+      // when
+      await triggerEvent('img', 'error');
+
+      // then
+      assert.dom(screen.queryByRole('img')).doesNotExist();
+      assert.dom(screen.getByText(t('pages.modulix.elements.image.missing-content'))).exists();
+      assert.dom(screen.queryByText(t('pages.modulix.elements.image.consult-alternative-text'))).doesNotExist();
+    });
+
+    module('when there is an alternative text', function () {
+      test('it should display an alternative text message', async function (assert) {
+        // given
+        const imageElement = {
+          url: 'https://assets.pix.org/draft/flamingo.jpg',
+          alt: 'alt text',
+          alternativeText: 'alternative instruction',
+        };
+
+        // when
+        const screen = await render(<template><ModulixImageElement @image={{imageElement}} /></template>);
+        await triggerEvent('img', 'error');
+
+        // then
+        assert.dom(screen.queryByRole('img')).doesNotExist();
+        assert.dom(screen.getByText(t('pages.modulix.elements.image.missing-content'))).exists();
+        assert.dom(screen.getByText(t('pages.modulix.elements.image.consult-alternative-text'))).exists();
+      });
+    });
   });
 });

--- a/mon-pix/translations/de.json
+++ b/mon-pix/translations/de.json
@@ -1650,6 +1650,10 @@
         "label": "Datei im Format {format} herunterladen"
       },
       "elements": {
+        "audio": {
+          "consult-transcription": "Lesen Sie die Transkription, um den Inhalt zu erfahren.",
+          "missing-content": "Beim Anzeigen des Audios ist ein Fehler aufgetreten."
+        },
         "image": {
           "consult-alternative-text": "Lesen Sie den alternativen Text, um den Inhalt zu erfahren.",
           "missing-content": "Beim Anzeigen des Bildes ist ein Fehler aufgetreten."

--- a/mon-pix/translations/de.json
+++ b/mon-pix/translations/de.json
@@ -1649,6 +1649,12 @@
         "intro": "Wählen Sie das Dateiformat, das Sie verwenden möchten.",
         "label": "Datei im Format {format} herunterladen"
       },
+      "elements": {
+        "short-video": {
+          "consult-transcription": "Lesen Sie die Transkription, um den Inhalt zu erfahren.",
+          "missing-content": "Beim Anzeigen des Videos ist ein Fehler aufgetreten."
+        }
+      },
       "flashcards": {
         "answerDirection": "Hatten Sie die Antwort?",
         "completed": "Abgeschlossen",

--- a/mon-pix/translations/de.json
+++ b/mon-pix/translations/de.json
@@ -1650,6 +1650,10 @@
         "label": "Datei im Format {format} herunterladen"
       },
       "elements": {
+        "image": {
+          "consult-alternative-text": "Lesen Sie den alternativen Text, um den Inhalt zu erfahren.",
+          "missing-content": "Beim Anzeigen des Bildes ist ein Fehler aufgetreten."
+        },
         "short-video": {
           "consult-transcription": "Lesen Sie die Transkription, um den Inhalt zu erfahren.",
           "missing-content": "Beim Anzeigen des Videos ist ein Fehler aufgetreten."

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1650,6 +1650,10 @@
         "label": "Download file in {format} format"
       },
       "elements": {
+        "image": {
+          "consult-alternative-text": "Please consult the alternative text to view its content.",
+          "missing-content": "An error occurred while displaying the image."
+        },
         "short-video": {
           "consult-transcription": "Please consult the transcription to view its content.",
           "missing-content": "An error occurred while displaying the video."

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1649,6 +1649,12 @@
         "intro": "Choose the file format you would like to use.",
         "label": "Download file in {format} format"
       },
+      "elements": {
+        "short-video": {
+          "consult-transcription": "Please consult the transcription to view its content.",
+          "missing-content": "An error occurred while displaying the video."
+        }
+      },
       "flashcards": {
         "answerDirection": "Did you have the answer?",
         "completed": "Completed",

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1650,6 +1650,10 @@
         "label": "Download file in {format} format"
       },
       "elements": {
+        "audio": {
+          "consult-transcription": "Please consult the transcription to view its content.",
+          "missing-content": "An error occurred while displaying the audio."
+        },
         "image": {
           "consult-alternative-text": "Please consult the alternative text to view its content.",
           "missing-content": "An error occurred while displaying the image."

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1646,6 +1646,10 @@
         "label": "Descargue el archivo en {format}"
       },
       "elements": {
+        "audio": {
+          "consult-transcription": "Consulte la transcripción para conocer su contenido.",
+          "missing-content": "Se produjo un error al reproducir el audio."
+        },
         "image": {
           "consult-alternative-text": "Consulte el texto alternativo para conocer su contenido.",
           "missing-content": "Se produjo un error al mostrar la imagen."

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1645,6 +1645,12 @@
         "intro": "Elija el formato de archivo que desea utilizar.",
         "label": "Descargue el archivo en {format}"
       },
+      "elements": {
+        "short-video": {
+          "consult-transcription": "Consulte la transcripción para conocer su contenido.",
+          "missing-content": "Se produjo un error al mostrar el vídeo."
+        }
+      },
       "flashcards": {
         "answerDirection": "¿Tienes la respuesta?",
         "completed": "Finalizado",

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1646,6 +1646,10 @@
         "label": "Descargue el archivo en {format}"
       },
       "elements": {
+        "image": {
+          "consult-alternative-text": "Consulte el texto alternativo para conocer su contenido.",
+          "missing-content": "Se produjo un error al mostrar la imagen."
+        },
         "short-video": {
           "consult-transcription": "Consulte la transcripción para conocer su contenido.",
           "missing-content": "Se produjo un error al mostrar el vídeo."

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1651,6 +1651,10 @@
         "label": "Télécharger le fichier au format {format}"
       },
       "elements": {
+        "audio": {
+          "consult-transcription": "Consultez la transcription pour en connaître le contenu.",
+          "missing-content": "Une erreur est survenue lors de l'affichage de l'audio."
+        },
         "image": {
           "consult-alternative-text": "Consultez l'alternative textuelle pour en connaître le contenu.",
           "missing-content": "Une erreur est survenue lors de l'affichage de l'image."

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1650,6 +1650,12 @@
         "intro": "Choisissez le format de fichier que vous voulez utiliser.",
         "label": "Télécharger le fichier au format {format}"
       },
+      "elements": {
+        "short-video": {
+          "consult-transcription": "Consultez la transcription pour en connaître le contenu.",
+          "missing-content": "Une erreur est survenue lors de l'affichage de la vidéo."
+        }
+      },
       "flashcards": {
         "answerDirection": "Vous aviez la réponse ?",
         "completed": "Terminé",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1651,6 +1651,10 @@
         "label": "Télécharger le fichier au format {format}"
       },
       "elements": {
+        "image": {
+          "consult-alternative-text": "Consultez l'alternative textuelle pour en connaître le contenu.",
+          "missing-content": "Une erreur est survenue lors de l'affichage de l'image."
+        },
         "short-video": {
           "consult-transcription": "Consultez la transcription pour en connaître le contenu.",
           "missing-content": "Une erreur est survenue lors de l'affichage de la vidéo."

--- a/mon-pix/translations/it.json
+++ b/mon-pix/translations/it.json
@@ -1651,6 +1651,10 @@
         "label": "Scaricare il file in formato {format}."
       },
       "elements": {
+        "audio": {
+          "consult-transcription": "Consultare la trascrizione per conoscerne il contenuto.",
+          "missing-content": "Si è verificato un errore durante la riproduzione dell'audio."
+        },
         "image": {
           "consult-alternative-text": "Consultare il testo alternativo per conoscerne il contenuto.",
           "missing-content": "Si è verificato un errore durante la visualizzazione dell'immagine."

--- a/mon-pix/translations/it.json
+++ b/mon-pix/translations/it.json
@@ -1650,6 +1650,12 @@
         "intro": "Scegliere il formato di file che si desidera utilizzare.",
         "label": "Scaricare il file in formato {format}."
       },
+      "elements": {
+        "short-video": {
+          "consult-transcription": "Consultare la trascrizione per conoscerne il contenuto.",
+          "missing-content": "Si è verificato un errore durante la visualizzazione del video."
+        }
+      },
       "flashcards": {
         "answerDirection": "Avevi la risposta?",
         "completed": "Completato",

--- a/mon-pix/translations/it.json
+++ b/mon-pix/translations/it.json
@@ -1651,6 +1651,10 @@
         "label": "Scaricare il file in formato {format}."
       },
       "elements": {
+        "image": {
+          "consult-alternative-text": "Consultare il testo alternativo per conoscerne il contenuto.",
+          "missing-content": "Si è verificato un errore durante la visualizzazione dell'immagine."
+        },
         "short-video": {
           "consult-transcription": "Consultare la trascrizione per conoscerne il contenuto.",
           "missing-content": "Si è verificato un errore durante la visualizzazione del video."

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1650,6 +1650,10 @@
         "label": "Download het bestand in {format}"
       },
       "elements": {
+        "audio": {
+          "consult-transcription": "Raadpleeg de transcriptie om de inhoud te bekijken.",
+          "missing-content": "Er is een fout opgetreden bij het weergeven van de audio."
+        },
         "image": {
           "consult-alternative-text": "Raadpleeg de alternatieve tekst om de inhoud te bekijken.",
           "missing-content": "Er is een fout opgetreden bij het weergeven van de afbeelding."

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1650,6 +1650,10 @@
         "label": "Download het bestand in {format}"
       },
       "elements": {
+        "image": {
+          "consult-alternative-text": "Raadpleeg de alternatieve tekst om de inhoud te bekijken.",
+          "missing-content": "Er is een fout opgetreden bij het weergeven van de afbeelding."
+        },
         "short-video": {
           "consult-transcription": "Raadpleeg de transcriptie om de inhoud te bekijken.",
           "missing-content": "Er is een fout opgetreden bij het weergeven van de video."

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1649,6 +1649,12 @@
         "intro": "Kies het bestandsformaat dat je wilt gebruiken.",
         "label": "Download het bestand in {format}"
       },
+      "elements": {
+        "short-video": {
+          "consult-transcription": "Raadpleeg de transcriptie om de inhoud te bekijken.",
+          "missing-content": "Er is een fout opgetreden bij het weergeven van de video."
+        }
+      },
       "flashcards": {
         "answerDirection": "Had je het antwoord?",
         "completed": "Afgewerkt",


### PR DESCRIPTION
## 🌎 Problème

Actuellement, lorsqu'un contenu est manquant dans un module, le module peut quand même être joué mais aucun message d'erreur n'est mentionné.

## 🔭 Proposition

Pour shortVideo, Image et Audio, afficher un message d'erreur en cas de source manquant ou si la source ne se charge pas correctement (source pointant sur un contenu qui a été supprimé par erreur ou mal renseigné)

Promp initial : `Dans @mon-pix/app/components/module/element/short-video.gjs, si le src de la balise video ne renvoie rien, je souhaite qu'elle soit remplacé par un message indiquant que le contenu est manquant. Ajoute des tests d'intégration à ce que tu ajoutes.`

## 🪐 Remarques

Un commit casse bac-a-sable pour voir le rendu en cas d'erreur. Ce commit sera supprimé lors du merge.


## 🚀 Pour tester

- Aller sur [bac-a-sable](https://app-pr15599.review.pix.fr/modules/6a68bf32/bac-a-sable/passage)
- Constater l'affichage en cas d'erreur 
- Le design n'a jamais été craqué ensemble, n'hésitez pas à faire des suggestions. Je suis partie sur un fond grisé avec un message centré.

> [!NOTE]
>  Dans les elements `Audio` et `Image`, la transcription/alternative textuelle sont en conditionnel, le second message invitant l'utilisateur à les consulter est donc en conditionnel aussi.
Pour `shortVideo`, ce n'est pas le cas.


<img width="1109" height="645" alt="Capture d’écran 2026-03-23 à 11 23 43" src="https://github.com/user-attachments/assets/17036a94-f63c-44c1-98b2-884e18d67d49" />
<img width="1109" height="755" alt="Capture d’écran 2026-03-23 à 11 22 40" src="https://github.com/user-attachments/assets/09a27d1b-3dd8-481f-89e5-512441e50a24" />

Cas sans alternative textuelle (l'image des chiens/bagels dans le stepper horizontal)
<img width="868" height="697" alt="Capture d’écran 2026-03-23 à 14 26 00" src="https://github.com/user-attachments/assets/d371f5b8-64d8-479b-b853-14491d9035a2" />




🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘 🌑
