### PR TITLE
[BUGFIX] Classer les réseaux dans le bon ordre après une création (PIX-22050)

### DIFF
--- a/admin/app/routes/authenticated/networks/list.js
+++ b/admin/app/routes/authenticated/networks/list.js
@@ -14,10 +14,7 @@ export default class ListRoute extends Route {
   }
 
   model(params) {
-    if (params.name) {
-      return this.store.query('network', { filter: { name: params.name.trim() } });
-    }
-    return this.store.findAll('network');
+    return this.store.query('network', { filter: { name: params.name ? params.name.trim() : '' } });
   }
 
   resetController(controller, isExiting) {


### PR DESCRIPTION
## 🌎 Problème
Dans Pix Admin, sur la page des réseaux, l'API nous renvoie la liste des réseaux classés par ordre alphabétique. Mais lorsque l'on créé un nouveau réseau et qu'on retourne sur la page des réseaux, celui-ci se place toujours en dernier et non là où il devrait être tel que renvoyé par l'API. Tout rentre dans l'ordre lorsqu'on recharge la page.

## 🔭 Proposition

Dans la route, on utilise deux méthodes différentes pour fetcher les réseaux selon qu'il y ait un queryParam ou non: `store.query` avec param, `store.findAll` sans param. Cette dernière ne met pas à jour l'ordre des données car les éléments présents dans le store et ceux reçus par l'API sont les mêmes. On choisit d'utiliser donc `store.query` dans les tous cas, mais de passer le param en chaîne vide si il n'est pas présent (ISO à ce qui est fait pour les organizations).

## 🪐 Remarques

RAS

## 🚀 Pour tester

Sur Pix Admin, connecté en superadmin
- aller sur la pages des **Réseaux**
- créer un nouveau réseau dont le nom devra s'afficher en haut de la liste
- **sans recharger**, retourner sur la page des réseaux
- constater que ce nouveau réseau s'est bien placé en haut de la liste et pas en bas

🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘 🌑
