### PR TITLE
[TECH] Learning content : Suppression de l’ancienne mise en cache

### DIFF
--- a/api/sample.env
+++ b/api/sample.env
@@ -418,18 +418,6 @@ LCMS_API_URL=https://lcms.minimal.pix.fr/api
 # default: null
 LCMS_API_RELEASE_ID=
 
-# Store ids in results cache
-#
-# 0 => disabled for all containers
-# 2 => enabled for web-2, web-4, web-6, etc
-# 10 => enabled for web-10, web-20, web-30, etc
-# 1 => enabled for all containers
-#
-# presence: optional
-# type: number
-# default: 0
-LCMS_CACHE_RESULT_IDS_MODULO=1
-
 # =======
 # LLM CHAT
 # =======

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -48,6 +48,7 @@ function _getLogForHumans() {
 
 // Can be useful for A/B testing, leaving it here
 // while we think on how we can do better
+// eslint-disable-next-line no-unused-vars
 function isEnabledByContainerModulo(envVarValue) {
   const modulo = _getNumber(envVarValue, 0);
   if (modulo === 0) return false;
@@ -354,7 +355,6 @@ const configuration = (function () {
         process.env.CYPRESS_LCMS_API_KEY ||
         process.env.LCMS_API_KEY,
       releaseId: process.env.LCMS_API_RELEASE_ID || null,
-      cacheResultIds: isEnabledByContainerModulo(process.env.LCMS_CACHE_RESULT_IDS_MODULO),
     },
     llm: {
       temporaryStorage: {
@@ -560,7 +560,6 @@ const configuration = (function () {
 
     config.lcms.apiKey = 'test-api-key';
     config.lcms.url = 'https://lcms-test.pix.fr/api';
-    config.lcms.cacheResultIds = true;
 
     config.llm.configurationEditorApi.getConfigurationUrl = 'https://llm-test.pix.fr/api/configurations';
     config.llm.inferenceApi.postPromptUrl = 'https://llm-test.pix.fr/api/chat';

--- a/api/src/shared/infrastructure/repositories/learning-content-repository.js
+++ b/api/src/shared/infrastructure/repositories/learning-content-repository.js
@@ -1,6 +1,5 @@
 import Dataloader from 'dataloader';
 
-import { config } from '../../config.js';
 import { DomainTransaction } from '../../domain/DomainTransaction.js';
 import { LearningContentCache } from '../caches/learning-content-cache.js';
 import { createHistogram } from '../metrics/metrics.js';
@@ -80,8 +79,6 @@ export class LearningContentRepository {
    * @returns {Promise<object[]>}
    */
   async find(cacheKey, callback) {
-    if (!config.lcms.cacheResultIds) return this.#findDtos(cacheKey, callback);
-
     const ids = await this.#findIds(cacheKey, callback);
 
     return this.#loadMany(ids);
@@ -127,43 +124,6 @@ export class LearningContentRepository {
       return ids;
     } finally {
       if (ids) this.#metrics.find.observe(ids.length);
-    }
-  }
-
-  async #findDtos(cacheKey, callback) {
-    let dtos;
-    let stopFindCachePenaltyTimer;
-
-    try {
-      dtos = this.#findCache.get(cacheKey);
-      if (dtos) return dtos;
-
-      let dtosPromise = this.#findCacheMiss.get(cacheKey);
-      if (dtosPromise) {
-        stopFindCachePenaltyTimer = this.#metrics.findCachePenalty.startTimer();
-        dtos = await dtosPromise.finally(() => {
-          stopFindCachePenaltyTimer();
-        });
-
-        this.#metrics.findCacheMiss.observe(dtos.length);
-
-        return dtos;
-      }
-
-      stopFindCachePenaltyTimer = this.#metrics.findCachePenalty.startTimer();
-      dtosPromise = this.#loadDtos(callback, cacheKey).finally(() => {
-        this.#findCacheMiss.delete(cacheKey);
-        stopFindCachePenaltyTimer();
-      });
-      this.#findCacheMiss.set(cacheKey, dtosPromise);
-
-      dtos = await dtosPromise;
-
-      this.#metrics.findCacheMiss.observe(dtos.length);
-
-      return dtos;
-    } finally {
-      if (dtos) this.#metrics.find.observe(dtos.length);
     }
   }
 
@@ -236,24 +196,6 @@ export class LearningContentRepository {
     this.#findCache.set(cacheKey, ids);
 
     return ids;
-  }
-
-  /**
-   * Loads entities from database using a request and writes result to cache.
-   * @param {string} cacheKey
-   * @param {QueryBuilderCallback} callback
-   * @returns {Promise<object[]>}
-   */
-  async #loadDtos(callback, cacheKey) {
-    const knexConn = DomainTransaction.getConnection();
-    const ids = await callback(knexConn.pluck(`${this.#tableName}.id`).from(this.#tableName));
-
-    const dtos = await this.#loadMany(ids, cacheKey);
-
-    logger.debug({ tableName: this.#tableName, cacheKey }, 'caching find result');
-    this.#findCache.set(cacheKey, dtos);
-
-    return dtos;
   }
 
   /**

--- a/api/tests/shared/integration/infrastructure/repositories/challenge-repository_test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/challenge-repository_test.js
@@ -1,9 +1,8 @@
 import { ValidatorQCM } from '../../../../../src/evaluation/domain/models/ValidatorQCM.js';
 import { ValidatorQCU } from '../../../../../src/evaluation/domain/models/ValidatorQCU.js';
-import { config } from '../../../../../src/shared/config.js';
 import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
 import * as challengeRepository from '../../../../../src/shared/infrastructure/repositories/challenge-repository.js';
-import { catchErr, databaseBuilder, domainBuilder, expect, nock, sinon } from '../../../../test-helper.js';
+import { catchErr, databaseBuilder, domainBuilder, expect, nock } from '../../../../test-helper.js';
 
 describe('Integration | Repository | challenge-repository', function () {
   const challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson = {
@@ -738,1564 +737,1547 @@ describe('Integration | Repository | challenge-repository', function () {
     await databaseBuilder.commit();
   });
 
-  [false, true].forEach((cacheResultIds) =>
-    describe(`when cacheResultIds is ${cacheResultIds}`, function () {
-      beforeEach(function () {
-        sinon.stub(config.lcms, 'cacheResultIds').value(cacheResultIds);
-      });
+  describe('#get', function () {
+    context('when no challenge found for id', function () {
+      it('should throw a NotFound error', async function () {
+        // when
+        const err = await catchErr(challengeRepository.get)('challengeIdPipeauPipette');
 
-      describe('#get', function () {
-        context('when no challenge found for id', function () {
+        // then
+        expect(err).to.be.instanceOf(NotFoundError);
+        expect(err).to.have.property('message', 'Épreuve introuvable');
+      });
+    });
+
+    context('when challenge found for id', function () {
+      context('when the challenge has an embed as webcomponent', function () {
+        context('when retrieving the resource successfully', function () {
+          it('should return the challenge with the loaded web component', async function () {
+            // given
+            const webComponentServerCall = nock('https://example.com')
+              .get('/embed.json')
+              .reply(200, JSON.stringify({ name: 'web-component', props: { prop1: 'value1', prop2: 'value2' } }));
+
+            // when
+            const challenge = await challengeRepository.get('challengeId01');
+
+            // then
+            expect(webComponentServerCall.isDone()).to.equal(true);
+            expect(challenge).to.deepEqualInstance(
+              domainBuilder.buildChallenge({
+                ...challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson,
+                blindnessCompatibility:
+                  challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.accessibility1,
+                colorBlindnessCompatibility:
+                  challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.accessibility2,
+                focused: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.focusable,
+                discriminant: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.alpha,
+                difficulty: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.delta,
+                validator: new ValidatorQCU({
+                  solution: domainBuilder.buildSolution({
+                    id: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.id,
+                    type: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.type,
+                    value: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.solution,
+                    isT1Enabled: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.t1Status,
+                    isT2Enabled: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.t2Status,
+                    isT3Enabled: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.t3Status,
+                    qrocBlocksTypes: {},
+                  }),
+                }),
+                skill: domainBuilder.buildSkill({
+                  ...skillData00_tube00competence00_actif,
+                  difficulty: skillData00_tube00competence00_actif.level,
+                  hint: skillData00_tube00competence00_actif.hint_i18n.fr,
+                }),
+                webComponentTagName: 'web-component',
+                webComponentProps: { prop1: 'value1', prop2: 'value2' },
+                hasEmbedInternalValidation: true,
+                noValidationNeeded: true,
+              }),
+            );
+          });
+        });
+
+        context('when we fail retrieving the resource', function () {
           it('should throw a NotFound error', async function () {
+            // given
+            const webComponentServerCall = nock('https://example.com').get('/embed.json').reply(404);
+
             // when
-            const err = await catchErr(challengeRepository.get)('challengeIdPipeauPipette');
+            const err = await catchErr(challengeRepository.get)('challengeId01');
 
             // then
+            expect(webComponentServerCall.isDone()).to.equal(true);
             expect(err).to.be.instanceOf(NotFoundError);
-            expect(err).to.have.property('message', 'Épreuve introuvable');
-          });
-        });
-
-        context('when challenge found for id', function () {
-          context('when the challenge has an embed as webcomponent', function () {
-            context('when retrieving the resource successfully', function () {
-              it('should return the challenge with the loaded web component', async function () {
-                // given
-                const webComponentServerCall = nock('https://example.com')
-                  .get('/embed.json')
-                  .reply(200, JSON.stringify({ name: 'web-component', props: { prop1: 'value1', prop2: 'value2' } }));
-
-                // when
-                const challenge = await challengeRepository.get('challengeId01');
-
-                // then
-                expect(webComponentServerCall.isDone()).to.equal(true);
-                expect(challenge).to.deepEqualInstance(
-                  domainBuilder.buildChallenge({
-                    ...challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson,
-                    blindnessCompatibility:
-                      challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.accessibility1,
-                    colorBlindnessCompatibility:
-                      challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.accessibility2,
-                    focused: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.focusable,
-                    discriminant: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.alpha,
-                    difficulty: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.delta,
-                    validator: new ValidatorQCU({
-                      solution: domainBuilder.buildSolution({
-                        id: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.id,
-                        type: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.type,
-                        value: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.solution,
-                        isT1Enabled: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.t1Status,
-                        isT2Enabled: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.t2Status,
-                        isT3Enabled: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.t3Status,
-                        qrocBlocksTypes: {},
-                      }),
-                    }),
-                    skill: domainBuilder.buildSkill({
-                      ...skillData00_tube00competence00_actif,
-                      difficulty: skillData00_tube00competence00_actif.level,
-                      hint: skillData00_tube00competence00_actif.hint_i18n.fr,
-                    }),
-                    webComponentTagName: 'web-component',
-                    webComponentProps: { prop1: 'value1', prop2: 'value2' },
-                    hasEmbedInternalValidation: true,
-                    noValidationNeeded: true,
-                  }),
-                );
-              });
-            });
-
-            context('when we fail retrieving the resource', function () {
-              it('should throw a NotFound error', async function () {
-                // given
-                const webComponentServerCall = nock('https://example.com').get('/embed.json').reply(404);
-
-                // when
-                const err = await catchErr(challengeRepository.get)('challengeId01');
-
-                // then
-                expect(webComponentServerCall.isDone()).to.equal(true);
-                expect(err).to.be.instanceOf(NotFoundError);
-                expect(err.message).to.equal(
-                  `Embed webcomponent config with URL ${challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.embedUrl} in challenge ${challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.id} not found`,
-                );
-              });
-            });
-          });
-
-          context('when the challenge has no embed as webcomponent', function () {
-            it('should return the challenge', async function () {
-              // when
-              const challenge = await challengeRepository.get('challengeId00');
-
-              // then
-              expect(challenge).to.deepEqualInstance(
-                domainBuilder.buildChallenge({
-                  ...challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson,
-                  blindnessCompatibility:
-                    challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.accessibility1,
-                  colorBlindnessCompatibility:
-                    challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.accessibility2,
-                  focused: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.focusable,
-                  discriminant: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.alpha,
-                  difficulty: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.delta,
-                  validator: new ValidatorQCU({
-                    solution: domainBuilder.buildSolution({
-                      id: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.id,
-                      type: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.type,
-                      value: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.solution,
-                      isT1Enabled: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.t1Status,
-                      isT2Enabled: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.t2Status,
-                      isT3Enabled: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.t3Status,
-                      qrocBlocksTypes: {},
-                    }),
-                  }),
-                  skill: domainBuilder.buildSkill({
-                    ...skillData00_tube00competence00_actif,
-                    difficulty: skillData00_tube00competence00_actif.level,
-                    hint: skillData00_tube00competence00_actif.hint_i18n.fr,
-                  }),
-                  hasEmbedInternalValidation: true,
-                  noValidationNeeded: true,
-                }),
-              );
-            });
-          });
-
-          context('when asking a challenge "for correction"', function () {
-            it('should return a dedicated DTO for correction', async function () {
-              // when
-              const challengeForCorrection = await challengeRepository.get('challengeId00', { forCorrection: true });
-
-              // then
-              expect(challengeForCorrection).to.deep.equal({
-                id: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.id,
-                skillId: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.skillId,
-                type: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.type,
-                solution: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.solution,
-                solutionToDisplay:
-                  challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.solutionToDisplay,
-                proposals: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.proposals,
-                t1Status: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.t1Status,
-                t2Status: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.t2Status,
-                t3Status: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.t3Status,
-              });
-            });
+            expect(err.message).to.equal(
+              `Embed webcomponent config with URL ${challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.embedUrl} in challenge ${challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.id} not found`,
+            );
           });
         });
       });
 
-      describe('#getMany', function () {
-        context('when no locale provided', function () {
-          context('when at least one challenge is not found amongst the provided ids', function () {
-            it('should throw a NotFound error', async function () {
-              // when
-              const err = await catchErr(challengeRepository.getMany)(['challengeIdPipeauPipette', 'challengeId00']);
-
-              // then
-              expect(err).to.be.instanceOf(NotFoundError);
-              expect(err).to.have.property('message', 'Épreuve introuvable');
-            });
-          });
-
-          context('when all challenges are found', function () {
-            it('should return the challenges', async function () {
-              // when
-              const challenges = await challengeRepository.getMany(['challengeId02', 'challengeId00']);
-
-              // then
-              expect(challenges).to.deepEqualArray([
-                domainBuilder.buildChallenge({
-                  ...challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson,
-                  blindnessCompatibility:
-                    challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.accessibility1,
-                  colorBlindnessCompatibility:
-                    challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.accessibility2,
-                  focused: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.focusable,
-                  discriminant: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.alpha,
-                  difficulty: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.delta,
-                  validator: new ValidatorQCU({
-                    solution: domainBuilder.buildSolution({
-                      id: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.id,
-                      type: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.type,
-                      value: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.solution,
-                      isT1Enabled: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.t1Status,
-                      isT2Enabled: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.t2Status,
-                      isT3Enabled: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.t3Status,
-                      qrocBlocksTypes: {},
-                    }),
-                  }),
-                  skill: domainBuilder.buildSkill({
-                    ...skillData00_tube00competence00_actif,
-                    difficulty: skillData00_tube00competence00_actif.level,
-                    hint: skillData00_tube00competence00_actif.hint_i18n.fr,
-                  }),
-                }),
-                domainBuilder.buildChallenge({
-                  ...challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson,
-                  blindnessCompatibility:
-                    challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.accessibility1,
-                  colorBlindnessCompatibility:
-                    challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.accessibility2,
-                  focused: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.focusable,
-                  discriminant: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.alpha,
-                  difficulty: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.delta,
-                  validator: new ValidatorQCM({
-                    solution: domainBuilder.buildSolution({
-                      id: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.id,
-                      type: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.type,
-                      value: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.solution,
-                      isT1Enabled: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.t1Status,
-                      isT2Enabled: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.t2Status,
-                      isT3Enabled: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.t3Status,
-                      qrocBlocksTypes: {},
-                    }),
-                  }),
-                  skill: domainBuilder.buildSkill({
-                    ...skillData00_tube00competence00_actif,
-                    difficulty: skillData00_tube00competence00_actif.level,
-                    hint: skillData00_tube00competence00_actif.hint_i18n.fr,
-                  }),
-                }),
-              ]);
-            });
-
-            it('should allow duplicates', async function () {
-              // when
-              const challenges = await challengeRepository.getMany(['challengeId02', 'challengeId00', 'challengeId02']);
-
-              // then
-              expect(challenges).to.deepEqualArray([
-                domainBuilder.buildChallenge({
-                  ...challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson,
-                  blindnessCompatibility:
-                    challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.accessibility1,
-                  colorBlindnessCompatibility:
-                    challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.accessibility2,
-                  focused: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.focusable,
-                  discriminant: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.alpha,
-                  difficulty: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.delta,
-                  validator: new ValidatorQCU({
-                    solution: domainBuilder.buildSolution({
-                      id: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.id,
-                      type: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.type,
-                      value: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.solution,
-                      isT1Enabled: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.t1Status,
-                      isT2Enabled: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.t2Status,
-                      isT3Enabled: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.t3Status,
-                      qrocBlocksTypes: {},
-                    }),
-                  }),
-                  skill: domainBuilder.buildSkill({
-                    ...skillData00_tube00competence00_actif,
-                    difficulty: skillData00_tube00competence00_actif.level,
-                    hint: skillData00_tube00competence00_actif.hint_i18n.fr,
-                  }),
-                }),
-                domainBuilder.buildChallenge({
-                  ...challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson,
-                  blindnessCompatibility:
-                    challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.accessibility1,
-                  colorBlindnessCompatibility:
-                    challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.accessibility2,
-                  focused: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.focusable,
-                  discriminant: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.alpha,
-                  difficulty: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.delta,
-                  validator: new ValidatorQCM({
-                    solution: domainBuilder.buildSolution({
-                      id: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.id,
-                      type: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.type,
-                      value: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.solution,
-                      isT1Enabled: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.t1Status,
-                      isT2Enabled: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.t2Status,
-                      isT3Enabled: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.t3Status,
-                      qrocBlocksTypes: {},
-                    }),
-                  }),
-                  skill: domainBuilder.buildSkill({
-                    ...skillData00_tube00competence00_actif,
-                    difficulty: skillData00_tube00competence00_actif.level,
-                    hint: skillData00_tube00competence00_actif.hint_i18n.fr,
-                  }),
-                }),
-                domainBuilder.buildChallenge({
-                  ...challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson,
-                  blindnessCompatibility:
-                    challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.accessibility1,
-                  colorBlindnessCompatibility:
-                    challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.accessibility2,
-                  focused: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.focusable,
-                  discriminant: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.alpha,
-                  difficulty: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.delta,
-                  validator: new ValidatorQCM({
-                    solution: domainBuilder.buildSolution({
-                      id: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.id,
-                      type: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.type,
-                      value: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.solution,
-                      isT1Enabled: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.t1Status,
-                      isT2Enabled: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.t2Status,
-                      isT3Enabled: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.t3Status,
-                      qrocBlocksTypes: {},
-                    }),
-                  }),
-                  skill: domainBuilder.buildSkill({
-                    ...skillData00_tube00competence00_actif,
-                    difficulty: skillData00_tube00competence00_actif.level,
-                    hint: skillData00_tube00competence00_actif.hint_i18n.fr,
-                  }),
-                }),
-              ]);
-            });
-          });
-        });
-
-        context('when locale is provided', function () {
-          context('when at least one challenge is not found amongst the provided ids', function () {
-            it('should throw a NotFound error', async function () {
-              // when
-              const err = await catchErr(challengeRepository.getMany)(['challengeIdPipeauPipette', 'challengeId00']);
-
-              // then
-              expect(err).to.be.instanceOf(NotFoundError);
-              expect(err).to.have.property('message', 'Épreuve introuvable');
-            });
-          });
-
-          context('when all challenges are found', function () {
-            it('should return only the challenges for given locale', async function () {
-              // when
-              const challenges = await challengeRepository.getMany(
-                ['challengeId02', 'challengeId00', 'challengeId01'],
-                'en',
-              );
-
-              // then
-              expect(challenges).to.deepEqualArray([
-                domainBuilder.buildChallenge({
-                  ...challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson,
-                  blindnessCompatibility:
-                    challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.accessibility1,
-                  colorBlindnessCompatibility:
-                    challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.accessibility2,
-                  focused: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.focusable,
-                  discriminant: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.alpha,
-                  difficulty: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.delta,
-                  validator: new ValidatorQCU({
-                    solution: domainBuilder.buildSolution({
-                      id: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.id,
-                      type: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.type,
-                      value: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.solution,
-                      isT1Enabled: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.t1Status,
-                      isT2Enabled: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.t2Status,
-                      isT3Enabled: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.t3Status,
-                      qrocBlocksTypes: {},
-                    }),
-                  }),
-                  skill: domainBuilder.buildSkill({
-                    ...skillData00_tube00competence00_actif,
-                    difficulty: skillData00_tube00competence00_actif.level,
-                    hint: skillData00_tube00competence00_actif.hint_i18n.fr,
-                  }),
-                }),
-                domainBuilder.buildChallenge({
-                  ...challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson,
-                  blindnessCompatibility:
-                    challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.accessibility1,
-                  colorBlindnessCompatibility:
-                    challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.accessibility2,
-                  focused: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.focusable,
-                  discriminant: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.alpha,
-                  difficulty: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.delta,
-                  validator: new ValidatorQCM({
-                    solution: domainBuilder.buildSolution({
-                      id: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.id,
-                      type: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.type,
-                      value: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.solution,
-                      isT1Enabled: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.t1Status,
-                      isT2Enabled: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.t2Status,
-                      isT3Enabled: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.t3Status,
-                      qrocBlocksTypes: {},
-                    }),
-                  }),
-                  skill: domainBuilder.buildSkill({
-                    ...skillData00_tube00competence00_actif,
-                    difficulty: skillData00_tube00competence00_actif.level,
-                    hint: skillData00_tube00competence00_actif.hint_i18n.fr,
-                  }),
-                }),
-              ]);
-            });
-          });
-        });
-      });
-
-      describe('list', function () {
-        context('when locale is not defined', function () {
-          it('should throw an Error', async function () {
-            // when
-            const err = await catchErr(challengeRepository.list)();
-
-            // then
-            expect(err.message).to.equal('Locale shall be defined');
-          });
-        });
-
-        context('when locale is defined', function () {
-          context('when no challenges found for locale', function () {
-            it('should return an empty array', async function () {
-              // when
-              const challenges = await challengeRepository.list('catalan');
-
-              // then
-              expect(challenges).to.deep.equal([]);
-            });
-          });
-
-          context('when challenges found for locale', function () {
-            it('should return the challenges', async function () {
-              // when
-              const challenges = await challengeRepository.list('en');
-
-              // then
-              expect(challenges).to.deepEqualArray([
-                domainBuilder.buildChallenge({
-                  ...challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson,
-                  blindnessCompatibility:
-                    challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.accessibility1,
-                  colorBlindnessCompatibility:
-                    challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.accessibility2,
-                  focused: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.focusable,
-                  discriminant: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.alpha,
-                  difficulty: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.delta,
-                  validator: new ValidatorQCU({
-                    solution: domainBuilder.buildSolution({
-                      id: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.id,
-                      type: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.type,
-                      value: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.solution,
-                      isT1Enabled: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.t1Status,
-                      isT2Enabled: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.t2Status,
-                      isT3Enabled: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.t3Status,
-                      qrocBlocksTypes: {},
-                    }),
-                  }),
-                  skill: domainBuilder.buildSkill({
-                    ...skillData00_tube00competence00_actif,
-                    difficulty: skillData00_tube00competence00_actif.level,
-                    hint: skillData00_tube00competence00_actif.hint_i18n.fr,
-                  }),
-                }),
-                domainBuilder.buildChallenge({
-                  ...challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson,
-                  blindnessCompatibility:
-                    challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.accessibility1,
-                  colorBlindnessCompatibility:
-                    challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.accessibility2,
-                  focused: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.focusable,
-                  discriminant: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.alpha,
-                  difficulty: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.delta,
-                  validator: new ValidatorQCM({
-                    solution: domainBuilder.buildSolution({
-                      id: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.id,
-                      type: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.type,
-                      value: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.solution,
-                      isT1Enabled: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.t1Status,
-                      isT2Enabled: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.t2Status,
-                      isT3Enabled: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.t3Status,
-                      qrocBlocksTypes: {},
-                    }),
-                  }),
-                  skill: domainBuilder.buildSkill({
-                    ...skillData00_tube00competence00_actif,
-                    difficulty: skillData00_tube00competence00_actif.level,
-                    hint: skillData00_tube00competence00_actif.hint_i18n.fr,
-                  }),
-                }),
-                domainBuilder.buildChallenge({
-                  ...challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson,
-                  blindnessCompatibility:
-                    challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.accessibility1,
-                  colorBlindnessCompatibility:
-                    challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.accessibility2,
-                  focused: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.focusable,
-                  discriminant: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.alpha,
-                  difficulty: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.delta,
-                  validator: new ValidatorQCU({
-                    solution: domainBuilder.buildSolution({
-                      id: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.id,
-                      type: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.type,
-                      value: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.solution,
-                      isT1Enabled: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.t1Status,
-                      isT2Enabled: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.t2Status,
-                      isT3Enabled: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.t3Status,
-                      qrocBlocksTypes: {},
-                    }),
-                  }),
-                  skill: domainBuilder.buildSkill({
-                    ...skillData01_tube01competence00_actif,
-                    difficulty: skillData01_tube01competence00_actif.level,
-                    hint: skillData01_tube01competence00_actif.hint_i18n.fr,
-                  }),
-                }),
-                domainBuilder.buildChallenge({
-                  ...challengeData05_skill02_qcm_perime_flashCompatible_fren_noEmbedJson,
-                  blindnessCompatibility:
-                    challengeData05_skill02_qcm_perime_flashCompatible_fren_noEmbedJson.accessibility1,
-                  colorBlindnessCompatibility:
-                    challengeData05_skill02_qcm_perime_flashCompatible_fren_noEmbedJson.accessibility2,
-                  focused: challengeData05_skill02_qcm_perime_flashCompatible_fren_noEmbedJson.focusable,
-                  discriminant: challengeData05_skill02_qcm_perime_flashCompatible_fren_noEmbedJson.alpha,
-                  difficulty: challengeData05_skill02_qcm_perime_flashCompatible_fren_noEmbedJson.delta,
-                  validator: new ValidatorQCM({
-                    solution: domainBuilder.buildSolution({
-                      id: challengeData05_skill02_qcm_perime_flashCompatible_fren_noEmbedJson.id,
-                      type: challengeData05_skill02_qcm_perime_flashCompatible_fren_noEmbedJson.type,
-                      value: challengeData05_skill02_qcm_perime_flashCompatible_fren_noEmbedJson.solution,
-                      isT1Enabled: challengeData05_skill02_qcm_perime_flashCompatible_fren_noEmbedJson.t1Status,
-                      isT2Enabled: challengeData05_skill02_qcm_perime_flashCompatible_fren_noEmbedJson.t2Status,
-                      isT3Enabled: challengeData05_skill02_qcm_perime_flashCompatible_fren_noEmbedJson.t3Status,
-                      qrocBlocksTypes: {},
-                    }),
-                  }),
-                  skill: domainBuilder.buildSkill({
-                    ...skillData02_tube02competence01_perime,
-                    difficulty: skillData02_tube02competence01_perime.level,
-                    hint: skillData02_tube02competence01_perime.hint_i18n.fr,
-                  }),
-                }),
-                domainBuilder.buildChallenge({
-                  ...challengeData06_skill02_qcm_perime_notFlashCompatible_fren_noEmbedJson,
-                  blindnessCompatibility:
-                    challengeData06_skill02_qcm_perime_notFlashCompatible_fren_noEmbedJson.accessibility1,
-                  colorBlindnessCompatibility:
-                    challengeData06_skill02_qcm_perime_notFlashCompatible_fren_noEmbedJson.accessibility2,
-                  focused: challengeData06_skill02_qcm_perime_notFlashCompatible_fren_noEmbedJson.focusable,
-                  discriminant: challengeData06_skill02_qcm_perime_notFlashCompatible_fren_noEmbedJson.alpha,
-                  difficulty: challengeData06_skill02_qcm_perime_notFlashCompatible_fren_noEmbedJson.delta,
-                  validator: new ValidatorQCM({
-                    solution: domainBuilder.buildSolution({
-                      id: challengeData06_skill02_qcm_perime_notFlashCompatible_fren_noEmbedJson.id,
-                      type: challengeData06_skill02_qcm_perime_notFlashCompatible_fren_noEmbedJson.type,
-                      value: challengeData06_skill02_qcm_perime_notFlashCompatible_fren_noEmbedJson.solution,
-                      isT1Enabled: challengeData06_skill02_qcm_perime_notFlashCompatible_fren_noEmbedJson.t1Status,
-                      isT2Enabled: challengeData06_skill02_qcm_perime_notFlashCompatible_fren_noEmbedJson.t2Status,
-                      isT3Enabled: challengeData06_skill02_qcm_perime_notFlashCompatible_fren_noEmbedJson.t3Status,
-                      qrocBlocksTypes: {},
-                    }),
-                  }),
-                  skill: domainBuilder.buildSkill({
-                    ...skillData02_tube02competence01_perime,
-                    difficulty: skillData02_tube02competence01_perime.level,
-                    hint: skillData02_tube02competence01_perime.hint_i18n.fr,
-                  }),
-                }),
-                domainBuilder.buildChallenge({
-                  ...enArchivedChallenge,
-                  blindnessCompatibility: enArchivedChallenge.accessibility1,
-                  colorBlindnessCompatibility: enArchivedChallenge.accessibility2,
-                  focused: enArchivedChallenge.focusable,
-                  discriminant: enArchivedChallenge.alpha,
-                  difficulty: enArchivedChallenge.delta,
-                  validator: new ValidatorQCU({
-                    solution: domainBuilder.buildSolution({
-                      id: enArchivedChallenge.id,
-                      type: enArchivedChallenge.type,
-                      value: enArchivedChallenge.solution,
-                      isT1Enabled: enArchivedChallenge.t1Status,
-                      isT2Enabled: enArchivedChallenge.t2Status,
-                      isT3Enabled: enArchivedChallenge.t3Status,
-                      qrocBlocksTypes: {},
-                    }),
-                  }),
-                  skill: domainBuilder.buildSkill({
-                    ...activeSkill,
-                    difficulty: activeSkill.level,
-                    hint: activeSkill.hint_i18n.fr,
-                  }),
-                }),
-                domainBuilder.buildChallenge({
-                  ...enUGValidatedChallenge,
-                  blindnessCompatibility: enUGValidatedChallenge.accessibility1,
-                  colorBlindnessCompatibility: enUGValidatedChallenge.accessibility2,
-                  focused: enUGValidatedChallenge.focusable,
-                  discriminant: enUGValidatedChallenge.alpha,
-                  difficulty: enUGValidatedChallenge.delta,
-                  validator: new ValidatorQCU({
-                    solution: domainBuilder.buildSolution({
-                      id: enUGValidatedChallenge.id,
-                      type: enUGValidatedChallenge.type,
-                      value: enUGValidatedChallenge.solution,
-                      isT1Enabled: enUGValidatedChallenge.t1Status,
-                      isT2Enabled: enUGValidatedChallenge.t2Status,
-                      isT3Enabled: enUGValidatedChallenge.t3Status,
-                      qrocBlocksTypes: {},
-                    }),
-                  }),
-                  skill: domainBuilder.buildSkill({
-                    ...activeSkill,
-                    difficulty: activeSkill.level,
-                    hint: activeSkill.hint_i18n.fr,
-                  }),
-                }),
-                domainBuilder.buildChallenge({
-                  ...enValidatedChallenge,
-                  blindnessCompatibility: enValidatedChallenge.accessibility1,
-                  colorBlindnessCompatibility: enValidatedChallenge.accessibility2,
-                  focused: enValidatedChallenge.focusable,
-                  discriminant: enValidatedChallenge.alpha,
-                  difficulty: enValidatedChallenge.delta,
-                  validator: new ValidatorQCU({
-                    solution: domainBuilder.buildSolution({
-                      id: enValidatedChallenge.id,
-                      type: enValidatedChallenge.type,
-                      value: enValidatedChallenge.solution,
-                      isT1Enabled: enValidatedChallenge.t1Status,
-                      isT2Enabled: enValidatedChallenge.t2Status,
-                      isT3Enabled: enValidatedChallenge.t3Status,
-                      qrocBlocksTypes: {},
-                    }),
-                  }),
-                  skill: domainBuilder.buildSkill({
-                    ...activeSkill,
-                    difficulty: activeSkill.level,
-                    hint: activeSkill.hint_i18n.fr,
-                  }),
-                }),
-              ]);
-            });
-          });
-        });
-      });
-
-      describe('#findValidated', function () {
-        context('when locale is not defined', function () {
-          it('should throw an Error', async function () {
-            // when
-            const err = await catchErr(challengeRepository.findValidated)();
-
-            // then
-            expect(err.message).to.equal('Locale shall be defined');
-          });
-        });
-
-        context('when locale is defined', function () {
-          context('when no validated challenges found for given locale', function () {
-            it('should return an empty array', async function () {
-              // when
-              const challenges = await challengeRepository.findValidated('catalan');
-
-              // then
-              expect(challenges).to.deep.equal([]);
-            });
-          });
-
-          context('when validated challenges are found for given locale', function () {
-            it('should return the challenges', async function () {
-              // when
-              const challenges = await challengeRepository.findValidated('nl');
-
-              // then
-              expect(challenges).to.deep.equal([
-                domainBuilder.buildChallenge({
-                  ...challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson,
-                  blindnessCompatibility:
-                    challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.accessibility1,
-                  colorBlindnessCompatibility:
-                    challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.accessibility2,
-                  focused: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.focusable,
-                  discriminant: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.alpha,
-                  difficulty: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.delta,
-                  validator: new ValidatorQCU({
-                    solution: domainBuilder.buildSolution({
-                      id: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.id,
-                      type: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.type,
-                      value: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.solution,
-                      isT1Enabled: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.t1Status,
-                      isT2Enabled: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.t2Status,
-                      isT3Enabled: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.t3Status,
-                      qrocBlocksTypes: {},
-                    }),
-                  }),
-                  skill: domainBuilder.buildSkill({
-                    ...skillData00_tube00competence00_actif,
-                    difficulty: skillData00_tube00competence00_actif.level,
-                    hint: skillData00_tube00competence00_actif.hint_i18n.fr,
-                  }),
-                }),
-                domainBuilder.buildChallenge({
-                  ...challengeData03_skill00_qcm_valide_flashCompatible_nl_noEmbedJson,
-                  blindnessCompatibility:
-                    challengeData03_skill00_qcm_valide_flashCompatible_nl_noEmbedJson.accessibility1,
-                  colorBlindnessCompatibility:
-                    challengeData03_skill00_qcm_valide_flashCompatible_nl_noEmbedJson.accessibility2,
-                  focused: challengeData03_skill00_qcm_valide_flashCompatible_nl_noEmbedJson.focusable,
-                  discriminant: challengeData03_skill00_qcm_valide_flashCompatible_nl_noEmbedJson.alpha,
-                  difficulty: challengeData03_skill00_qcm_valide_flashCompatible_nl_noEmbedJson.delta,
-                  validator: new ValidatorQCM({
-                    solution: domainBuilder.buildSolution({
-                      id: challengeData03_skill00_qcm_valide_flashCompatible_nl_noEmbedJson.id,
-                      type: challengeData03_skill00_qcm_valide_flashCompatible_nl_noEmbedJson.type,
-                      value: challengeData03_skill00_qcm_valide_flashCompatible_nl_noEmbedJson.solution,
-                      isT1Enabled: challengeData03_skill00_qcm_valide_flashCompatible_nl_noEmbedJson.t1Status,
-                      isT2Enabled: challengeData03_skill00_qcm_valide_flashCompatible_nl_noEmbedJson.t2Status,
-                      isT3Enabled: challengeData03_skill00_qcm_valide_flashCompatible_nl_noEmbedJson.t3Status,
-                      qrocBlocksTypes: {},
-                    }),
-                  }),
-                  skill: domainBuilder.buildSkill({
-                    ...skillData00_tube00competence00_actif,
-                    difficulty: skillData00_tube00competence00_actif.level,
-                    hint: skillData00_tube00competence00_actif.hint_i18n.fr,
-                  }),
-                }),
-                domainBuilder.buildChallenge({
-                  ...challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson,
-                  blindnessCompatibility:
-                    challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.accessibility1,
-                  colorBlindnessCompatibility:
-                    challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.accessibility2,
-                  focused: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.focusable,
-                  discriminant: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.alpha,
-                  difficulty: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.delta,
-                  validator: new ValidatorQCU({
-                    solution: domainBuilder.buildSolution({
-                      id: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.id,
-                      type: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.type,
-                      value: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.solution,
-                      isT1Enabled: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.t1Status,
-                      isT2Enabled: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.t2Status,
-                      isT3Enabled: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.t3Status,
-                      qrocBlocksTypes: {},
-                    }),
-                  }),
-                  skill: domainBuilder.buildSkill({
-                    ...skillData01_tube01competence00_actif,
-                    difficulty: skillData01_tube01competence00_actif.level,
-                    hint: skillData01_tube01competence00_actif.hint_i18n.fr,
-                  }),
-                }),
-                domainBuilder.buildChallenge({
-                  ...challengeData07_skill03_qcm_valide_notFlashCompatible_frnl_noEmbedJson,
-                  blindnessCompatibility:
-                    challengeData07_skill03_qcm_valide_notFlashCompatible_frnl_noEmbedJson.accessibility1,
-                  colorBlindnessCompatibility:
-                    challengeData07_skill03_qcm_valide_notFlashCompatible_frnl_noEmbedJson.accessibility2,
-                  focused: challengeData07_skill03_qcm_valide_notFlashCompatible_frnl_noEmbedJson.focusable,
-                  discriminant: challengeData07_skill03_qcm_valide_notFlashCompatible_frnl_noEmbedJson.alpha,
-                  difficulty: challengeData07_skill03_qcm_valide_notFlashCompatible_frnl_noEmbedJson.delta,
-                  validator: new ValidatorQCM({
-                    solution: domainBuilder.buildSolution({
-                      id: challengeData07_skill03_qcm_valide_notFlashCompatible_frnl_noEmbedJson.id,
-                      type: challengeData07_skill03_qcm_valide_notFlashCompatible_frnl_noEmbedJson.type,
-                      value: challengeData07_skill03_qcm_valide_notFlashCompatible_frnl_noEmbedJson.solution,
-                      isT1Enabled: challengeData07_skill03_qcm_valide_notFlashCompatible_frnl_noEmbedJson.t1Status,
-                      isT2Enabled: challengeData07_skill03_qcm_valide_notFlashCompatible_frnl_noEmbedJson.t2Status,
-                      isT3Enabled: challengeData07_skill03_qcm_valide_notFlashCompatible_frnl_noEmbedJson.t3Status,
-                      qrocBlocksTypes: {},
-                    }),
-                  }),
-                  skill: domainBuilder.buildSkill({
-                    ...skillData03_tube02competence01_actif,
-                    difficulty: skillData03_tube02competence01_actif.level,
-                    hint: skillData03_tube02competence01_actif.hint_i18n.fr,
-                  }),
-                }),
-              ]);
-            });
-          });
-        });
-      });
-
-      describe('#findValidatedByCompetenceId', function () {
-        context('when locale is not defined', function () {
-          it('should throw an Error', async function () {
-            // when
-            const err = await catchErr(challengeRepository.findValidatedByCompetenceId)('competenceId00');
-
-            // then
-            expect(err.message).to.equal('Locale shall be defined');
-          });
-        });
-
-        context('when locale is defined', function () {
-          context('when no validated challenges found for given locale and competenceId', function () {
-            it('should return an empty array', async function () {
-              // when
-              const challenges = await challengeRepository.findValidatedByCompetenceId('competenceId00', 'es');
-
-              // then
-              expect(challenges).to.deep.equal([]);
-            });
-          });
-
-          context('when validated challenges are found for given locale and competenceId', function () {
-            it('should return the challenges', async function () {
-              // when
-              const challenges = await challengeRepository.findValidatedByCompetenceId('competenceId00', 'en');
-
-              // then
-              expect(challenges).to.deep.equal([
-                domainBuilder.buildChallenge({
-                  ...challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson,
-                  blindnessCompatibility:
-                    challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.accessibility1,
-                  colorBlindnessCompatibility:
-                    challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.accessibility2,
-                  focused: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.focusable,
-                  discriminant: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.alpha,
-                  difficulty: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.delta,
-                  validator: new ValidatorQCU({
-                    solution: domainBuilder.buildSolution({
-                      id: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.id,
-                      type: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.type,
-                      value: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.solution,
-                      isT1Enabled: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.t1Status,
-                      isT2Enabled: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.t2Status,
-                      isT3Enabled: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.t3Status,
-                      qrocBlocksTypes: {},
-                    }),
-                  }),
-                  skill: domainBuilder.buildSkill({
-                    ...skillData00_tube00competence00_actif,
-                    difficulty: skillData00_tube00competence00_actif.level,
-                    hint: skillData00_tube00competence00_actif.hint_i18n.fr,
-                  }),
-                }),
-                domainBuilder.buildChallenge({
-                  ...challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson,
-                  blindnessCompatibility:
-                    challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.accessibility1,
-                  colorBlindnessCompatibility:
-                    challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.accessibility2,
-                  focused: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.focusable,
-                  discriminant: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.alpha,
-                  difficulty: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.delta,
-                  validator: new ValidatorQCU({
-                    solution: domainBuilder.buildSolution({
-                      id: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.id,
-                      type: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.type,
-                      value: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.solution,
-                      isT1Enabled: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.t1Status,
-                      isT2Enabled: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.t2Status,
-                      isT3Enabled: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.t3Status,
-                      qrocBlocksTypes: {},
-                    }),
-                  }),
-                  skill: domainBuilder.buildSkill({
-                    ...skillData01_tube01competence00_actif,
-                    difficulty: skillData01_tube01competence00_actif.level,
-                    hint: skillData01_tube01competence00_actif.hint_i18n.fr,
-                  }),
-                }),
-              ]);
-            });
-          });
-        });
-      });
-
-      describe('#findOperativeBySkills', function () {
-        context('when locale is not defined', function () {
-          it('should throw an Error', async function () {
-            // when
-            const err = await catchErr(challengeRepository.findOperativeBySkills)(domainBuilder.buildSkill());
-
-            // then
-            expect(err.message).to.equal('Locale shall be defined');
-          });
-        });
-
-        context('when locale is defined', function () {
-          context('when no operative challenges found for given locale', function () {
-            it('should return an empty array', async function () {
-              // given
-              const skill00 = domainBuilder.buildSkill({
-                ...skillData00_tube00competence00_actif,
-                difficulty: skillData00_tube00competence00_actif.level,
-                hint: skillData00_tube00competence00_actif.hint_i18n.fr,
-              });
-
-              // when
-              const challenges = await challengeRepository.findOperativeBySkills([skill00], 'catalan');
-
-              // then
-              expect(challenges).to.deep.equal([]);
-            });
-          });
-
-          context('when operative challenges are found for given locale', function () {
-            it('should return the challenges', async function () {
-              // given
-              const skills = [
-                domainBuilder.buildSkill({
-                  ...skillData00_tube00competence00_actif,
-                  difficulty: skillData00_tube00competence00_actif.level,
-                  hint: skillData00_tube00competence00_actif.hint_i18n.fr,
-                }),
-                domainBuilder.buildSkill({
-                  ...skillData02_tube02competence01_perime,
-                  difficulty: skillData02_tube02competence01_perime.level,
-                  hint: skillData02_tube02competence01_perime.hint_i18n.fr,
-                }),
-                domainBuilder.buildSkill({
-                  ...skillData01_tube01competence00_actif,
-                  difficulty: skillData01_tube01competence00_actif.level,
-                  hint: skillData01_tube01competence00_actif.hint_i18n.fr,
-                }),
-              ];
-
-              // when
-              const challenges = await challengeRepository.findOperativeBySkills(skills, 'en');
-
-              // then
-              expect(challenges).to.deep.equal([
-                domainBuilder.buildChallenge({
-                  ...challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson,
-                  blindnessCompatibility:
-                    challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.accessibility1,
-                  colorBlindnessCompatibility:
-                    challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.accessibility2,
-                  focused: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.focusable,
-                  discriminant: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.alpha,
-                  difficulty: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.delta,
-                  validator: new ValidatorQCU({
-                    solution: domainBuilder.buildSolution({
-                      id: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.id,
-                      type: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.type,
-                      value: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.solution,
-                      isT1Enabled: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.t1Status,
-                      isT2Enabled: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.t2Status,
-                      isT3Enabled: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.t3Status,
-                      qrocBlocksTypes: {},
-                    }),
-                  }),
-                  skill: domainBuilder.buildSkill({
-                    ...skillData00_tube00competence00_actif,
-                    difficulty: skillData00_tube00competence00_actif.level,
-                    hint: skillData00_tube00competence00_actif.hint_i18n.fr,
-                  }),
-                }),
-                domainBuilder.buildChallenge({
-                  ...challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson,
-                  blindnessCompatibility:
-                    challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.accessibility1,
-                  colorBlindnessCompatibility:
-                    challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.accessibility2,
-                  focused: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.focusable,
-                  discriminant: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.alpha,
-                  difficulty: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.delta,
-                  validator: new ValidatorQCM({
-                    solution: domainBuilder.buildSolution({
-                      id: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.id,
-                      type: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.type,
-                      value: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.solution,
-                      isT1Enabled: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.t1Status,
-                      isT2Enabled: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.t2Status,
-                      isT3Enabled: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.t3Status,
-                      qrocBlocksTypes: {},
-                    }),
-                  }),
-                  skill: domainBuilder.buildSkill({
-                    ...skillData00_tube00competence00_actif,
-                    difficulty: skillData00_tube00competence00_actif.level,
-                    hint: skillData00_tube00competence00_actif.hint_i18n.fr,
-                  }),
-                }),
-                domainBuilder.buildChallenge({
-                  ...challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson,
-                  blindnessCompatibility:
-                    challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.accessibility1,
-                  colorBlindnessCompatibility:
-                    challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.accessibility2,
-                  focused: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.focusable,
-                  discriminant: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.alpha,
-                  difficulty: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.delta,
-                  validator: new ValidatorQCU({
-                    solution: domainBuilder.buildSolution({
-                      id: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.id,
-                      type: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.type,
-                      value: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.solution,
-                      isT1Enabled: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.t1Status,
-                      isT2Enabled: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.t2Status,
-                      isT3Enabled: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.t3Status,
-                      qrocBlocksTypes: {},
-                    }),
-                  }),
-                  skill: domainBuilder.buildSkill({
-                    ...skillData01_tube01competence00_actif,
-                    difficulty: skillData01_tube01competence00_actif.level,
-                    hint: skillData01_tube01competence00_actif.hint_i18n.fr,
-                  }),
-                }),
-              ]);
-            });
-
-            it('should avoid duplicates', async function () {
-              // given
-              const skills = [
-                domainBuilder.buildSkill({
-                  ...skillData00_tube00competence00_actif,
-                  difficulty: skillData00_tube00competence00_actif.level,
-                  hint: skillData00_tube00competence00_actif.hint_i18n.fr,
-                }),
-                domainBuilder.buildSkill({
-                  ...skillData02_tube02competence01_perime,
-                  difficulty: skillData02_tube02competence01_perime.level,
-                  hint: skillData02_tube02competence01_perime.hint_i18n.fr,
-                }),
-                domainBuilder.buildSkill({
-                  ...skillData01_tube01competence00_actif,
-                  difficulty: skillData01_tube01competence00_actif.level,
-                  hint: skillData01_tube01competence00_actif.hint_i18n.fr,
-                }),
-                domainBuilder.buildSkill({
-                  ...skillData00_tube00competence00_actif,
-                  difficulty: skillData00_tube00competence00_actif.level,
-                  hint: skillData00_tube00competence00_actif.hint_i18n.fr,
-                }),
-              ];
-
-              // when
-              const challenges = await challengeRepository.findOperativeBySkills(skills, 'en');
-
-              // then
-              expect(challenges).to.deep.equal([
-                domainBuilder.buildChallenge({
-                  ...challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson,
-                  blindnessCompatibility:
-                    challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.accessibility1,
-                  colorBlindnessCompatibility:
-                    challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.accessibility2,
-                  focused: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.focusable,
-                  discriminant: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.alpha,
-                  difficulty: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.delta,
-                  validator: new ValidatorQCU({
-                    solution: domainBuilder.buildSolution({
-                      id: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.id,
-                      type: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.type,
-                      value: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.solution,
-                      isT1Enabled: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.t1Status,
-                      isT2Enabled: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.t2Status,
-                      isT3Enabled: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.t3Status,
-                      qrocBlocksTypes: {},
-                    }),
-                  }),
-                  skill: domainBuilder.buildSkill({
-                    ...skillData00_tube00competence00_actif,
-                    difficulty: skillData00_tube00competence00_actif.level,
-                    hint: skillData00_tube00competence00_actif.hint_i18n.fr,
-                  }),
-                }),
-                domainBuilder.buildChallenge({
-                  ...challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson,
-                  blindnessCompatibility:
-                    challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.accessibility1,
-                  colorBlindnessCompatibility:
-                    challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.accessibility2,
-                  focused: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.focusable,
-                  discriminant: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.alpha,
-                  difficulty: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.delta,
-                  validator: new ValidatorQCM({
-                    solution: domainBuilder.buildSolution({
-                      id: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.id,
-                      type: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.type,
-                      value: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.solution,
-                      isT1Enabled: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.t1Status,
-                      isT2Enabled: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.t2Status,
-                      isT3Enabled: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.t3Status,
-                      qrocBlocksTypes: {},
-                    }),
-                  }),
-                  skill: domainBuilder.buildSkill({
-                    ...skillData00_tube00competence00_actif,
-                    difficulty: skillData00_tube00competence00_actif.level,
-                    hint: skillData00_tube00competence00_actif.hint_i18n.fr,
-                  }),
-                }),
-                domainBuilder.buildChallenge({
-                  ...challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson,
-                  blindnessCompatibility:
-                    challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.accessibility1,
-                  colorBlindnessCompatibility:
-                    challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.accessibility2,
-                  focused: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.focusable,
-                  discriminant: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.alpha,
-                  difficulty: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.delta,
-                  validator: new ValidatorQCU({
-                    solution: domainBuilder.buildSolution({
-                      id: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.id,
-                      type: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.type,
-                      value: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.solution,
-                      isT1Enabled: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.t1Status,
-                      isT2Enabled: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.t2Status,
-                      isT3Enabled: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.t3Status,
-                      qrocBlocksTypes: {},
-                    }),
-                  }),
-                  skill: domainBuilder.buildSkill({
-                    ...skillData01_tube01competence00_actif,
-                    difficulty: skillData01_tube01competence00_actif.level,
-                    hint: skillData01_tube01competence00_actif.hint_i18n.fr,
-                  }),
-                }),
-              ]);
-            });
-          });
-        });
-      });
-
-      describe('#findOperativeBySkillsAndLocales', function () {
-        context('when locale is defined', function () {
-          context('when no operative challenges found for given locale', function () {
-            it('should return an empty array', async function () {
-              // given
-              const skill00 = domainBuilder.buildSkill({
-                ...skillData00_tube00competence00_actif,
-                difficulty: skillData00_tube00competence00_actif.level,
-                hint: skillData00_tube00competence00_actif.hint_i18n.fr,
-              });
-
-              // when
-              const challenges = await challengeRepository.findOperativeBySkillsAndLocales([skill00], ['catalan']);
-
-              // then
-              expect(challenges).to.deep.equal([]);
-            });
-          });
-
-          context('when searching for en-TZ and en operative challenges', function () {
-            it('should return the challenges having en-TZ or en included in their locales', async function () {
-              // given
-              const skills = [
-                domainBuilder.buildSkill({
-                  ...activeSkill,
-                  difficulty: activeSkill.level,
-                  hint: activeSkill.hint_i18n.fr,
-                }),
-              ];
-
-              // when
-              const challenges = await challengeRepository.findOperativeBySkillsAndLocales(skills, ['en-TZ', 'en']);
-              // then
-              expect(challenges).to.deep.equal([
-                domainBuilder.buildChallenge({
-                  ...enArchivedChallenge,
-                  blindnessCompatibility: enArchivedChallenge.accessibility1,
-                  colorBlindnessCompatibility: enArchivedChallenge.accessibility2,
-                  focused: enArchivedChallenge.focusable,
-                  discriminant: enArchivedChallenge.alpha,
-                  difficulty: enArchivedChallenge.delta,
-                  validator: new ValidatorQCU({
-                    solution: domainBuilder.buildSolution({
-                      id: enArchivedChallenge.id,
-                      type: enArchivedChallenge.type,
-                      value: enArchivedChallenge.solution,
-                      isT1Enabled: enArchivedChallenge.t1Status,
-                      isT2Enabled: enArchivedChallenge.t2Status,
-                      isT3Enabled: enArchivedChallenge.t3Status,
-                      qrocBlocksTypes: {},
-                    }),
-                  }),
-                  skill: domainBuilder.buildSkill({
-                    ...activeSkill,
-                    difficulty: activeSkill.level,
-                    hint: activeSkill.hint_i18n.fr,
-                  }),
-                }),
-                domainBuilder.buildChallenge({
-                  ...enTZArchivedChallenge,
-                  blindnessCompatibility: enTZArchivedChallenge.accessibility1,
-                  colorBlindnessCompatibility: enTZArchivedChallenge.accessibility2,
-                  focused: enTZArchivedChallenge.focusable,
-                  discriminant: enTZArchivedChallenge.alpha,
-                  difficulty: enTZArchivedChallenge.delta,
-                  validator: new ValidatorQCU({
-                    solution: domainBuilder.buildSolution({
-                      id: enTZArchivedChallenge.id,
-                      type: enTZArchivedChallenge.type,
-                      value: enTZArchivedChallenge.solution,
-                      isT1Enabled: enTZArchivedChallenge.t1Status,
-                      isT2Enabled: enTZArchivedChallenge.t2Status,
-                      isT3Enabled: enTZArchivedChallenge.t3Status,
-                      qrocBlocksTypes: {},
-                    }),
-                  }),
-                  skill: domainBuilder.buildSkill({
-                    ...activeSkill,
-                    difficulty: activeSkill.level,
-                    hint: activeSkill.hint_i18n.fr,
-                  }),
-                }),
-                domainBuilder.buildChallenge({
-                  ...enTZValidatedChallenge,
-                  blindnessCompatibility: enTZValidatedChallenge.accessibility1,
-                  colorBlindnessCompatibility: enTZValidatedChallenge.accessibility2,
-                  focused: enTZValidatedChallenge.focusable,
-                  discriminant: enTZValidatedChallenge.alpha,
-                  difficulty: enTZValidatedChallenge.delta,
-                  validator: new ValidatorQCU({
-                    solution: domainBuilder.buildSolution({
-                      id: enTZValidatedChallenge.id,
-                      type: enTZValidatedChallenge.type,
-                      value: enTZValidatedChallenge.solution,
-                      isT1Enabled: enTZValidatedChallenge.t1Status,
-                      isT2Enabled: enTZValidatedChallenge.t2Status,
-                      isT3Enabled: enTZValidatedChallenge.t3Status,
-                      qrocBlocksTypes: {},
-                    }),
-                  }),
-                  skill: domainBuilder.buildSkill({
-                    ...activeSkill,
-                    difficulty: activeSkill.level,
-                    hint: activeSkill.hint_i18n.fr,
-                  }),
-                }),
-                domainBuilder.buildChallenge({
-                  ...enUGValidatedChallenge,
-                  blindnessCompatibility: enUGValidatedChallenge.accessibility1,
-                  colorBlindnessCompatibility: enUGValidatedChallenge.accessibility2,
-                  focused: enUGValidatedChallenge.focusable,
-                  discriminant: enUGValidatedChallenge.alpha,
-                  difficulty: enUGValidatedChallenge.delta,
-                  validator: new ValidatorQCU({
-                    solution: domainBuilder.buildSolution({
-                      id: enUGValidatedChallenge.id,
-                      type: enUGValidatedChallenge.type,
-                      value: enUGValidatedChallenge.solution,
-                      isT1Enabled: enUGValidatedChallenge.t1Status,
-                      isT2Enabled: enUGValidatedChallenge.t2Status,
-                      isT3Enabled: enUGValidatedChallenge.t3Status,
-                      qrocBlocksTypes: {},
-                    }),
-                  }),
-                  skill: domainBuilder.buildSkill({
-                    ...activeSkill,
-                    difficulty: activeSkill.level,
-                    hint: activeSkill.hint_i18n.fr,
-                  }),
-                }),
-                domainBuilder.buildChallenge({
-                  ...enValidatedChallenge,
-                  blindnessCompatibility: enValidatedChallenge.accessibility1,
-                  colorBlindnessCompatibility: enValidatedChallenge.accessibility2,
-                  focused: enValidatedChallenge.focusable,
-                  discriminant: enValidatedChallenge.alpha,
-                  difficulty: enValidatedChallenge.delta,
-                  validator: new ValidatorQCU({
-                    solution: domainBuilder.buildSolution({
-                      id: enValidatedChallenge.id,
-                      type: enValidatedChallenge.type,
-                      value: enValidatedChallenge.solution,
-                      isT1Enabled: enValidatedChallenge.t1Status,
-                      isT2Enabled: enValidatedChallenge.t2Status,
-                      isT3Enabled: enValidatedChallenge.t3Status,
-                      qrocBlocksTypes: {},
-                    }),
-                  }),
-                  skill: domainBuilder.buildSkill({
-                    ...activeSkill,
-                    difficulty: activeSkill.level,
-                    hint: activeSkill.hint_i18n.fr,
-                  }),
-                }),
-              ]);
-            });
-          });
-        });
-      });
-
-      describe('#findValidatedBySkills', function () {
-        context('when locale is not defined', function () {
-          it('should throw an Error', async function () {
-            // when
-            const err = await catchErr(challengeRepository.findValidatedBySkills)(domainBuilder.buildSkill());
-
-            // then
-            expect(err.message).to.equal('Locale shall be defined');
-          });
-        });
-
-        context('when locale is defined', function () {
-          context('when no operative challenges found for given locale', function () {
-            it('should return an empty array', async function () {
-              // given
-              const skill00 = domainBuilder.buildSkill({
-                ...skillData00_tube00competence00_actif,
-                difficulty: skillData00_tube00competence00_actif.level,
-                hint: skillData00_tube00competence00_actif.hint_i18n.fr,
-              });
-
-              // when
-              const challenges = await challengeRepository.findValidatedBySkills([skill00], 'catalan');
-
-              // then
-              expect(challenges).to.deep.equal([]);
-            });
-          });
-
-          context('when operative challenges are found for given locale', function () {
-            it('should return the challenges', async function () {
-              // given
-              const skills = [
-                domainBuilder.buildSkill({
-                  ...skillData00_tube00competence00_actif,
-                  difficulty: skillData00_tube00competence00_actif.level,
-                  hint: skillData00_tube00competence00_actif.hint_i18n.fr,
-                }),
-                domainBuilder.buildSkill({
-                  ...skillData02_tube02competence01_perime,
-                  difficulty: skillData02_tube02competence01_perime.level,
-                  hint: skillData02_tube02competence01_perime.hint_i18n.fr,
-                }),
-                domainBuilder.buildSkill({
-                  ...skillData01_tube01competence00_actif,
-                  difficulty: skillData01_tube01competence00_actif.level,
-                  hint: skillData01_tube01competence00_actif.hint_i18n.fr,
-                }),
-              ];
-
-              // when
-              const challenges = await challengeRepository.findValidatedBySkills(skills, 'en');
-
-              // then
-              expect(challenges).to.deep.equal([
-                domainBuilder.buildChallenge({
-                  ...challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson,
-                  blindnessCompatibility:
-                    challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.accessibility1,
-                  colorBlindnessCompatibility:
-                    challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.accessibility2,
-                  focused: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.focusable,
-                  discriminant: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.alpha,
-                  difficulty: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.delta,
-                  validator: new ValidatorQCU({
-                    solution: domainBuilder.buildSolution({
-                      id: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.id,
-                      type: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.type,
-                      value: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.solution,
-                      isT1Enabled: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.t1Status,
-                      isT2Enabled: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.t2Status,
-                      isT3Enabled: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.t3Status,
-                      qrocBlocksTypes: {},
-                    }),
-                  }),
-                  skill: domainBuilder.buildSkill({
-                    ...skillData00_tube00competence00_actif,
-                    difficulty: skillData00_tube00competence00_actif.level,
-                    hint: skillData00_tube00competence00_actif.hint_i18n.fr,
-                  }),
-                }),
-                domainBuilder.buildChallenge({
-                  ...challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson,
-                  blindnessCompatibility:
-                    challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.accessibility1,
-                  colorBlindnessCompatibility:
-                    challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.accessibility2,
-                  focused: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.focusable,
-                  discriminant: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.alpha,
-                  difficulty: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.delta,
-                  validator: new ValidatorQCU({
-                    solution: domainBuilder.buildSolution({
-                      id: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.id,
-                      type: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.type,
-                      value: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.solution,
-                      isT1Enabled: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.t1Status,
-                      isT2Enabled: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.t2Status,
-                      isT3Enabled: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.t3Status,
-                      qrocBlocksTypes: {},
-                    }),
-                  }),
-                  skill: domainBuilder.buildSkill({
-                    ...skillData01_tube01competence00_actif,
-                    difficulty: skillData01_tube01competence00_actif.level,
-                    hint: skillData01_tube01competence00_actif.hint_i18n.fr,
-                  }),
-                }),
-              ]);
-            });
-
-            it('should avoid duplicates', async function () {
-              // given
-              const skills = [
-                domainBuilder.buildSkill({
-                  ...skillData00_tube00competence00_actif,
-                  difficulty: skillData00_tube00competence00_actif.level,
-                  hint: skillData00_tube00competence00_actif.hint_i18n.fr,
-                }),
-                domainBuilder.buildSkill({
-                  ...skillData02_tube02competence01_perime,
-                  difficulty: skillData02_tube02competence01_perime.level,
-                  hint: skillData02_tube02competence01_perime.hint_i18n.fr,
-                }),
-                domainBuilder.buildSkill({
-                  ...skillData01_tube01competence00_actif,
-                  difficulty: skillData01_tube01competence00_actif.level,
-                  hint: skillData01_tube01competence00_actif.hint_i18n.fr,
-                }),
-                domainBuilder.buildSkill({
-                  ...skillData00_tube00competence00_actif,
-                  difficulty: skillData00_tube00competence00_actif.level,
-                  hint: skillData00_tube00competence00_actif.hint_i18n.fr,
-                }),
-              ];
-
-              // when
-              const challenges = await challengeRepository.findValidatedBySkills(skills, 'en');
-
-              // then
-              expect(challenges).to.deep.equal([
-                domainBuilder.buildChallenge({
-                  ...challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson,
-                  blindnessCompatibility:
-                    challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.accessibility1,
-                  colorBlindnessCompatibility:
-                    challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.accessibility2,
-                  focused: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.focusable,
-                  discriminant: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.alpha,
-                  difficulty: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.delta,
-                  validator: new ValidatorQCU({
-                    solution: domainBuilder.buildSolution({
-                      id: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.id,
-                      type: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.type,
-                      value: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.solution,
-                      isT1Enabled: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.t1Status,
-                      isT2Enabled: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.t2Status,
-                      isT3Enabled: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.t3Status,
-                      qrocBlocksTypes: {},
-                    }),
-                  }),
-                  skill: domainBuilder.buildSkill({
-                    ...skillData00_tube00competence00_actif,
-                    difficulty: skillData00_tube00competence00_actif.level,
-                    hint: skillData00_tube00competence00_actif.hint_i18n.fr,
-                  }),
-                }),
-                domainBuilder.buildChallenge({
-                  ...challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson,
-                  blindnessCompatibility:
-                    challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.accessibility1,
-                  colorBlindnessCompatibility:
-                    challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.accessibility2,
-                  focused: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.focusable,
-                  discriminant: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.alpha,
-                  difficulty: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.delta,
-                  validator: new ValidatorQCU({
-                    solution: domainBuilder.buildSolution({
-                      id: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.id,
-                      type: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.type,
-                      value: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.solution,
-                      isT1Enabled: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.t1Status,
-                      isT2Enabled: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.t2Status,
-                      isT3Enabled: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.t3Status,
-                      qrocBlocksTypes: {},
-                    }),
-                  }),
-                  skill: domainBuilder.buildSkill({
-                    ...skillData01_tube01competence00_actif,
-                    difficulty: skillData01_tube01competence00_actif.level,
-                    hint: skillData01_tube01competence00_actif.hint_i18n.fr,
-                  }),
-                }),
-              ]);
-            });
-          });
-        });
-      });
-
-      describe('#findValidatedBySkillId', function () {
-        context('when locale is not defined', function () {
-          it('should throw an Error', async function () {
-            // when
-            const err = await catchErr(challengeRepository.findValidatedBySkillId)('skillId00');
-
-            // then
-            expect(err.message).to.equal('Locale shall be defined');
-          });
-        });
-
-        context('when locale is defined', function () {
-          context('when no validated challenges found for given locale and skillId', function () {
-            it('should return an empty array', async function () {
-              // when
-              const challenges = await challengeRepository.findValidatedBySkillId('skillId00', 'es');
-
-              // then
-              expect(challenges).to.deep.equal([]);
-            });
-          });
-
-          context('when validated challenges are found for given locale and skillId', function () {
-            it('should return the challenges', async function () {
-              // when
-              const challenges = await challengeRepository.findValidatedBySkillId('skillId00', 'en');
-
-              // then
-              expect(challenges).to.deep.equal([
-                domainBuilder.buildChallenge({
-                  ...challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson,
-                  blindnessCompatibility:
-                    challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.accessibility1,
-                  colorBlindnessCompatibility:
-                    challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.accessibility2,
-                  focused: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.focusable,
-                  discriminant: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.alpha,
-                  difficulty: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.delta,
-                  validator: new ValidatorQCU({
-                    solution: domainBuilder.buildSolution({
-                      id: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.id,
-                      type: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.type,
-                      value: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.solution,
-                      isT1Enabled: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.t1Status,
-                      isT2Enabled: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.t2Status,
-                      isT3Enabled: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.t3Status,
-                      qrocBlocksTypes: {},
-                    }),
-                  }),
-                  skill: domainBuilder.buildSkill({
-                    ...skillData00_tube00competence00_actif,
-                    difficulty: skillData00_tube00competence00_actif.level,
-                    hint: skillData00_tube00competence00_actif.hint_i18n.fr,
-                  }),
-                }),
-              ]);
-            });
-          });
-        });
-      });
-
-      describe('#getManyTypes', function () {
-        it('should return an object associating ids to type', async function () {
+      context('when the challenge has no embed as webcomponent', function () {
+        it('should return the challenge', async function () {
           // when
-          const challengesType = await challengeRepository.getManyTypes([
-            'challengeId09',
-            'challengeId04',
-            'challengeId07',
-            'challengeId02',
-            'challengeId01',
-          ]);
+          const challenge = await challengeRepository.get('challengeId00');
 
           // then
-          expect(challengesType).to.deep.equal({
-            challengeId01: 'QCU',
-            challengeId02: 'QCM',
-            challengeId04: 'QCU',
-            challengeId07: 'QCM',
-            challengeId09: 'QCU',
+          expect(challenge).to.deepEqualInstance(
+            domainBuilder.buildChallenge({
+              ...challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson,
+              blindnessCompatibility:
+                challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.accessibility1,
+              colorBlindnessCompatibility:
+                challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.accessibility2,
+              focused: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.focusable,
+              discriminant: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.alpha,
+              difficulty: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.delta,
+              validator: new ValidatorQCU({
+                solution: domainBuilder.buildSolution({
+                  id: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.id,
+                  type: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.type,
+                  value: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.solution,
+                  isT1Enabled: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.t1Status,
+                  isT2Enabled: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.t2Status,
+                  isT3Enabled: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.t3Status,
+                  qrocBlocksTypes: {},
+                }),
+              }),
+              skill: domainBuilder.buildSkill({
+                ...skillData00_tube00competence00_actif,
+                difficulty: skillData00_tube00competence00_actif.level,
+                hint: skillData00_tube00competence00_actif.hint_i18n.fr,
+              }),
+              hasEmbedInternalValidation: true,
+              noValidationNeeded: true,
+            }),
+          );
+        });
+      });
+
+      context('when asking a challenge "for correction"', function () {
+        it('should return a dedicated DTO for correction', async function () {
+          // when
+          const challengeForCorrection = await challengeRepository.get('challengeId00', { forCorrection: true });
+
+          // then
+          expect(challengeForCorrection).to.deep.equal({
+            id: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.id,
+            skillId: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.skillId,
+            type: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.type,
+            solution: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.solution,
+            solutionToDisplay: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.solutionToDisplay,
+            proposals: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.proposals,
+            t1Status: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.t1Status,
+            t2Status: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.t2Status,
+            t3Status: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.t3Status,
           });
         });
+      });
+    });
+  });
 
-        it('should throw NotFoundError when some ids are not found', async function () {
+  describe('#getMany', function () {
+    context('when no locale provided', function () {
+      context('when at least one challenge is not found amongst the provided ids', function () {
+        it('should throw a NotFound error', async function () {
           // when
-          const err = await catchErr(challengeRepository.getManyTypes)([
-            'challengeId09',
-            'challengeId04',
-            'challengeId666',
-            'challengeId02',
-            'challengeId01',
-          ]);
+          const err = await catchErr(challengeRepository.getMany)(['challengeIdPipeauPipette', 'challengeId00']);
 
           // then
           expect(err).to.be.instanceOf(NotFoundError);
+          expect(err).to.have.property('message', 'Épreuve introuvable');
         });
       });
-    }),
-  );
+
+      context('when all challenges are found', function () {
+        it('should return the challenges', async function () {
+          // when
+          const challenges = await challengeRepository.getMany(['challengeId02', 'challengeId00']);
+
+          // then
+          expect(challenges).to.deepEqualArray([
+            domainBuilder.buildChallenge({
+              ...challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson,
+              blindnessCompatibility:
+                challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.accessibility1,
+              colorBlindnessCompatibility:
+                challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.accessibility2,
+              focused: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.focusable,
+              discriminant: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.alpha,
+              difficulty: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.delta,
+              validator: new ValidatorQCU({
+                solution: domainBuilder.buildSolution({
+                  id: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.id,
+                  type: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.type,
+                  value: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.solution,
+                  isT1Enabled: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.t1Status,
+                  isT2Enabled: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.t2Status,
+                  isT3Enabled: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.t3Status,
+                  qrocBlocksTypes: {},
+                }),
+              }),
+              skill: domainBuilder.buildSkill({
+                ...skillData00_tube00competence00_actif,
+                difficulty: skillData00_tube00competence00_actif.level,
+                hint: skillData00_tube00competence00_actif.hint_i18n.fr,
+              }),
+            }),
+            domainBuilder.buildChallenge({
+              ...challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson,
+              blindnessCompatibility: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.accessibility1,
+              colorBlindnessCompatibility:
+                challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.accessibility2,
+              focused: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.focusable,
+              discriminant: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.alpha,
+              difficulty: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.delta,
+              validator: new ValidatorQCM({
+                solution: domainBuilder.buildSolution({
+                  id: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.id,
+                  type: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.type,
+                  value: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.solution,
+                  isT1Enabled: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.t1Status,
+                  isT2Enabled: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.t2Status,
+                  isT3Enabled: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.t3Status,
+                  qrocBlocksTypes: {},
+                }),
+              }),
+              skill: domainBuilder.buildSkill({
+                ...skillData00_tube00competence00_actif,
+                difficulty: skillData00_tube00competence00_actif.level,
+                hint: skillData00_tube00competence00_actif.hint_i18n.fr,
+              }),
+            }),
+          ]);
+        });
+
+        it('should allow duplicates', async function () {
+          // when
+          const challenges = await challengeRepository.getMany(['challengeId02', 'challengeId00', 'challengeId02']);
+
+          // then
+          expect(challenges).to.deepEqualArray([
+            domainBuilder.buildChallenge({
+              ...challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson,
+              blindnessCompatibility:
+                challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.accessibility1,
+              colorBlindnessCompatibility:
+                challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.accessibility2,
+              focused: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.focusable,
+              discriminant: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.alpha,
+              difficulty: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.delta,
+              validator: new ValidatorQCU({
+                solution: domainBuilder.buildSolution({
+                  id: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.id,
+                  type: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.type,
+                  value: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.solution,
+                  isT1Enabled: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.t1Status,
+                  isT2Enabled: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.t2Status,
+                  isT3Enabled: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.t3Status,
+                  qrocBlocksTypes: {},
+                }),
+              }),
+              skill: domainBuilder.buildSkill({
+                ...skillData00_tube00competence00_actif,
+                difficulty: skillData00_tube00competence00_actif.level,
+                hint: skillData00_tube00competence00_actif.hint_i18n.fr,
+              }),
+            }),
+            domainBuilder.buildChallenge({
+              ...challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson,
+              blindnessCompatibility: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.accessibility1,
+              colorBlindnessCompatibility:
+                challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.accessibility2,
+              focused: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.focusable,
+              discriminant: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.alpha,
+              difficulty: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.delta,
+              validator: new ValidatorQCM({
+                solution: domainBuilder.buildSolution({
+                  id: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.id,
+                  type: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.type,
+                  value: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.solution,
+                  isT1Enabled: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.t1Status,
+                  isT2Enabled: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.t2Status,
+                  isT3Enabled: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.t3Status,
+                  qrocBlocksTypes: {},
+                }),
+              }),
+              skill: domainBuilder.buildSkill({
+                ...skillData00_tube00competence00_actif,
+                difficulty: skillData00_tube00competence00_actif.level,
+                hint: skillData00_tube00competence00_actif.hint_i18n.fr,
+              }),
+            }),
+            domainBuilder.buildChallenge({
+              ...challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson,
+              blindnessCompatibility: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.accessibility1,
+              colorBlindnessCompatibility:
+                challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.accessibility2,
+              focused: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.focusable,
+              discriminant: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.alpha,
+              difficulty: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.delta,
+              validator: new ValidatorQCM({
+                solution: domainBuilder.buildSolution({
+                  id: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.id,
+                  type: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.type,
+                  value: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.solution,
+                  isT1Enabled: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.t1Status,
+                  isT2Enabled: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.t2Status,
+                  isT3Enabled: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.t3Status,
+                  qrocBlocksTypes: {},
+                }),
+              }),
+              skill: domainBuilder.buildSkill({
+                ...skillData00_tube00competence00_actif,
+                difficulty: skillData00_tube00competence00_actif.level,
+                hint: skillData00_tube00competence00_actif.hint_i18n.fr,
+              }),
+            }),
+          ]);
+        });
+      });
+    });
+
+    context('when locale is provided', function () {
+      context('when at least one challenge is not found amongst the provided ids', function () {
+        it('should throw a NotFound error', async function () {
+          // when
+          const err = await catchErr(challengeRepository.getMany)(['challengeIdPipeauPipette', 'challengeId00']);
+
+          // then
+          expect(err).to.be.instanceOf(NotFoundError);
+          expect(err).to.have.property('message', 'Épreuve introuvable');
+        });
+      });
+
+      context('when all challenges are found', function () {
+        it('should return only the challenges for given locale', async function () {
+          // when
+          const challenges = await challengeRepository.getMany(
+            ['challengeId02', 'challengeId00', 'challengeId01'],
+            'en',
+          );
+
+          // then
+          expect(challenges).to.deepEqualArray([
+            domainBuilder.buildChallenge({
+              ...challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson,
+              blindnessCompatibility:
+                challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.accessibility1,
+              colorBlindnessCompatibility:
+                challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.accessibility2,
+              focused: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.focusable,
+              discriminant: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.alpha,
+              difficulty: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.delta,
+              validator: new ValidatorQCU({
+                solution: domainBuilder.buildSolution({
+                  id: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.id,
+                  type: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.type,
+                  value: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.solution,
+                  isT1Enabled: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.t1Status,
+                  isT2Enabled: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.t2Status,
+                  isT3Enabled: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.t3Status,
+                  qrocBlocksTypes: {},
+                }),
+              }),
+              skill: domainBuilder.buildSkill({
+                ...skillData00_tube00competence00_actif,
+                difficulty: skillData00_tube00competence00_actif.level,
+                hint: skillData00_tube00competence00_actif.hint_i18n.fr,
+              }),
+            }),
+            domainBuilder.buildChallenge({
+              ...challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson,
+              blindnessCompatibility: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.accessibility1,
+              colorBlindnessCompatibility:
+                challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.accessibility2,
+              focused: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.focusable,
+              discriminant: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.alpha,
+              difficulty: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.delta,
+              validator: new ValidatorQCM({
+                solution: domainBuilder.buildSolution({
+                  id: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.id,
+                  type: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.type,
+                  value: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.solution,
+                  isT1Enabled: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.t1Status,
+                  isT2Enabled: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.t2Status,
+                  isT3Enabled: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.t3Status,
+                  qrocBlocksTypes: {},
+                }),
+              }),
+              skill: domainBuilder.buildSkill({
+                ...skillData00_tube00competence00_actif,
+                difficulty: skillData00_tube00competence00_actif.level,
+                hint: skillData00_tube00competence00_actif.hint_i18n.fr,
+              }),
+            }),
+          ]);
+        });
+      });
+    });
+  });
+
+  describe('list', function () {
+    context('when locale is not defined', function () {
+      it('should throw an Error', async function () {
+        // when
+        const err = await catchErr(challengeRepository.list)();
+
+        // then
+        expect(err.message).to.equal('Locale shall be defined');
+      });
+    });
+
+    context('when locale is defined', function () {
+      context('when no challenges found for locale', function () {
+        it('should return an empty array', async function () {
+          // when
+          const challenges = await challengeRepository.list('catalan');
+
+          // then
+          expect(challenges).to.deep.equal([]);
+        });
+      });
+
+      context('when challenges found for locale', function () {
+        it('should return the challenges', async function () {
+          // when
+          const challenges = await challengeRepository.list('en');
+
+          // then
+          expect(challenges).to.deepEqualArray([
+            domainBuilder.buildChallenge({
+              ...challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson,
+              blindnessCompatibility:
+                challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.accessibility1,
+              colorBlindnessCompatibility:
+                challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.accessibility2,
+              focused: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.focusable,
+              discriminant: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.alpha,
+              difficulty: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.delta,
+              validator: new ValidatorQCU({
+                solution: domainBuilder.buildSolution({
+                  id: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.id,
+                  type: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.type,
+                  value: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.solution,
+                  isT1Enabled: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.t1Status,
+                  isT2Enabled: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.t2Status,
+                  isT3Enabled: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.t3Status,
+                  qrocBlocksTypes: {},
+                }),
+              }),
+              skill: domainBuilder.buildSkill({
+                ...skillData00_tube00competence00_actif,
+                difficulty: skillData00_tube00competence00_actif.level,
+                hint: skillData00_tube00competence00_actif.hint_i18n.fr,
+              }),
+            }),
+            domainBuilder.buildChallenge({
+              ...challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson,
+              blindnessCompatibility: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.accessibility1,
+              colorBlindnessCompatibility:
+                challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.accessibility2,
+              focused: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.focusable,
+              discriminant: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.alpha,
+              difficulty: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.delta,
+              validator: new ValidatorQCM({
+                solution: domainBuilder.buildSolution({
+                  id: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.id,
+                  type: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.type,
+                  value: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.solution,
+                  isT1Enabled: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.t1Status,
+                  isT2Enabled: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.t2Status,
+                  isT3Enabled: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.t3Status,
+                  qrocBlocksTypes: {},
+                }),
+              }),
+              skill: domainBuilder.buildSkill({
+                ...skillData00_tube00competence00_actif,
+                difficulty: skillData00_tube00competence00_actif.level,
+                hint: skillData00_tube00competence00_actif.hint_i18n.fr,
+              }),
+            }),
+            domainBuilder.buildChallenge({
+              ...challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson,
+              blindnessCompatibility:
+                challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.accessibility1,
+              colorBlindnessCompatibility:
+                challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.accessibility2,
+              focused: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.focusable,
+              discriminant: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.alpha,
+              difficulty: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.delta,
+              validator: new ValidatorQCU({
+                solution: domainBuilder.buildSolution({
+                  id: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.id,
+                  type: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.type,
+                  value: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.solution,
+                  isT1Enabled: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.t1Status,
+                  isT2Enabled: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.t2Status,
+                  isT3Enabled: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.t3Status,
+                  qrocBlocksTypes: {},
+                }),
+              }),
+              skill: domainBuilder.buildSkill({
+                ...skillData01_tube01competence00_actif,
+                difficulty: skillData01_tube01competence00_actif.level,
+                hint: skillData01_tube01competence00_actif.hint_i18n.fr,
+              }),
+            }),
+            domainBuilder.buildChallenge({
+              ...challengeData05_skill02_qcm_perime_flashCompatible_fren_noEmbedJson,
+              blindnessCompatibility:
+                challengeData05_skill02_qcm_perime_flashCompatible_fren_noEmbedJson.accessibility1,
+              colorBlindnessCompatibility:
+                challengeData05_skill02_qcm_perime_flashCompatible_fren_noEmbedJson.accessibility2,
+              focused: challengeData05_skill02_qcm_perime_flashCompatible_fren_noEmbedJson.focusable,
+              discriminant: challengeData05_skill02_qcm_perime_flashCompatible_fren_noEmbedJson.alpha,
+              difficulty: challengeData05_skill02_qcm_perime_flashCompatible_fren_noEmbedJson.delta,
+              validator: new ValidatorQCM({
+                solution: domainBuilder.buildSolution({
+                  id: challengeData05_skill02_qcm_perime_flashCompatible_fren_noEmbedJson.id,
+                  type: challengeData05_skill02_qcm_perime_flashCompatible_fren_noEmbedJson.type,
+                  value: challengeData05_skill02_qcm_perime_flashCompatible_fren_noEmbedJson.solution,
+                  isT1Enabled: challengeData05_skill02_qcm_perime_flashCompatible_fren_noEmbedJson.t1Status,
+                  isT2Enabled: challengeData05_skill02_qcm_perime_flashCompatible_fren_noEmbedJson.t2Status,
+                  isT3Enabled: challengeData05_skill02_qcm_perime_flashCompatible_fren_noEmbedJson.t3Status,
+                  qrocBlocksTypes: {},
+                }),
+              }),
+              skill: domainBuilder.buildSkill({
+                ...skillData02_tube02competence01_perime,
+                difficulty: skillData02_tube02competence01_perime.level,
+                hint: skillData02_tube02competence01_perime.hint_i18n.fr,
+              }),
+            }),
+            domainBuilder.buildChallenge({
+              ...challengeData06_skill02_qcm_perime_notFlashCompatible_fren_noEmbedJson,
+              blindnessCompatibility:
+                challengeData06_skill02_qcm_perime_notFlashCompatible_fren_noEmbedJson.accessibility1,
+              colorBlindnessCompatibility:
+                challengeData06_skill02_qcm_perime_notFlashCompatible_fren_noEmbedJson.accessibility2,
+              focused: challengeData06_skill02_qcm_perime_notFlashCompatible_fren_noEmbedJson.focusable,
+              discriminant: challengeData06_skill02_qcm_perime_notFlashCompatible_fren_noEmbedJson.alpha,
+              difficulty: challengeData06_skill02_qcm_perime_notFlashCompatible_fren_noEmbedJson.delta,
+              validator: new ValidatorQCM({
+                solution: domainBuilder.buildSolution({
+                  id: challengeData06_skill02_qcm_perime_notFlashCompatible_fren_noEmbedJson.id,
+                  type: challengeData06_skill02_qcm_perime_notFlashCompatible_fren_noEmbedJson.type,
+                  value: challengeData06_skill02_qcm_perime_notFlashCompatible_fren_noEmbedJson.solution,
+                  isT1Enabled: challengeData06_skill02_qcm_perime_notFlashCompatible_fren_noEmbedJson.t1Status,
+                  isT2Enabled: challengeData06_skill02_qcm_perime_notFlashCompatible_fren_noEmbedJson.t2Status,
+                  isT3Enabled: challengeData06_skill02_qcm_perime_notFlashCompatible_fren_noEmbedJson.t3Status,
+                  qrocBlocksTypes: {},
+                }),
+              }),
+              skill: domainBuilder.buildSkill({
+                ...skillData02_tube02competence01_perime,
+                difficulty: skillData02_tube02competence01_perime.level,
+                hint: skillData02_tube02competence01_perime.hint_i18n.fr,
+              }),
+            }),
+            domainBuilder.buildChallenge({
+              ...enArchivedChallenge,
+              blindnessCompatibility: enArchivedChallenge.accessibility1,
+              colorBlindnessCompatibility: enArchivedChallenge.accessibility2,
+              focused: enArchivedChallenge.focusable,
+              discriminant: enArchivedChallenge.alpha,
+              difficulty: enArchivedChallenge.delta,
+              validator: new ValidatorQCU({
+                solution: domainBuilder.buildSolution({
+                  id: enArchivedChallenge.id,
+                  type: enArchivedChallenge.type,
+                  value: enArchivedChallenge.solution,
+                  isT1Enabled: enArchivedChallenge.t1Status,
+                  isT2Enabled: enArchivedChallenge.t2Status,
+                  isT3Enabled: enArchivedChallenge.t3Status,
+                  qrocBlocksTypes: {},
+                }),
+              }),
+              skill: domainBuilder.buildSkill({
+                ...activeSkill,
+                difficulty: activeSkill.level,
+                hint: activeSkill.hint_i18n.fr,
+              }),
+            }),
+            domainBuilder.buildChallenge({
+              ...enUGValidatedChallenge,
+              blindnessCompatibility: enUGValidatedChallenge.accessibility1,
+              colorBlindnessCompatibility: enUGValidatedChallenge.accessibility2,
+              focused: enUGValidatedChallenge.focusable,
+              discriminant: enUGValidatedChallenge.alpha,
+              difficulty: enUGValidatedChallenge.delta,
+              validator: new ValidatorQCU({
+                solution: domainBuilder.buildSolution({
+                  id: enUGValidatedChallenge.id,
+                  type: enUGValidatedChallenge.type,
+                  value: enUGValidatedChallenge.solution,
+                  isT1Enabled: enUGValidatedChallenge.t1Status,
+                  isT2Enabled: enUGValidatedChallenge.t2Status,
+                  isT3Enabled: enUGValidatedChallenge.t3Status,
+                  qrocBlocksTypes: {},
+                }),
+              }),
+              skill: domainBuilder.buildSkill({
+                ...activeSkill,
+                difficulty: activeSkill.level,
+                hint: activeSkill.hint_i18n.fr,
+              }),
+            }),
+            domainBuilder.buildChallenge({
+              ...enValidatedChallenge,
+              blindnessCompatibility: enValidatedChallenge.accessibility1,
+              colorBlindnessCompatibility: enValidatedChallenge.accessibility2,
+              focused: enValidatedChallenge.focusable,
+              discriminant: enValidatedChallenge.alpha,
+              difficulty: enValidatedChallenge.delta,
+              validator: new ValidatorQCU({
+                solution: domainBuilder.buildSolution({
+                  id: enValidatedChallenge.id,
+                  type: enValidatedChallenge.type,
+                  value: enValidatedChallenge.solution,
+                  isT1Enabled: enValidatedChallenge.t1Status,
+                  isT2Enabled: enValidatedChallenge.t2Status,
+                  isT3Enabled: enValidatedChallenge.t3Status,
+                  qrocBlocksTypes: {},
+                }),
+              }),
+              skill: domainBuilder.buildSkill({
+                ...activeSkill,
+                difficulty: activeSkill.level,
+                hint: activeSkill.hint_i18n.fr,
+              }),
+            }),
+          ]);
+        });
+      });
+    });
+  });
+
+  describe('#findValidated', function () {
+    context('when locale is not defined', function () {
+      it('should throw an Error', async function () {
+        // when
+        const err = await catchErr(challengeRepository.findValidated)();
+
+        // then
+        expect(err.message).to.equal('Locale shall be defined');
+      });
+    });
+
+    context('when locale is defined', function () {
+      context('when no validated challenges found for given locale', function () {
+        it('should return an empty array', async function () {
+          // when
+          const challenges = await challengeRepository.findValidated('catalan');
+
+          // then
+          expect(challenges).to.deep.equal([]);
+        });
+      });
+
+      context('when validated challenges are found for given locale', function () {
+        it('should return the challenges', async function () {
+          // when
+          const challenges = await challengeRepository.findValidated('nl');
+
+          // then
+          expect(challenges).to.deep.equal([
+            domainBuilder.buildChallenge({
+              ...challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson,
+              blindnessCompatibility:
+                challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.accessibility1,
+              colorBlindnessCompatibility:
+                challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.accessibility2,
+              focused: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.focusable,
+              discriminant: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.alpha,
+              difficulty: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.delta,
+              validator: new ValidatorQCU({
+                solution: domainBuilder.buildSolution({
+                  id: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.id,
+                  type: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.type,
+                  value: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.solution,
+                  isT1Enabled: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.t1Status,
+                  isT2Enabled: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.t2Status,
+                  isT3Enabled: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.t3Status,
+                  qrocBlocksTypes: {},
+                }),
+              }),
+              skill: domainBuilder.buildSkill({
+                ...skillData00_tube00competence00_actif,
+                difficulty: skillData00_tube00competence00_actif.level,
+                hint: skillData00_tube00competence00_actif.hint_i18n.fr,
+              }),
+            }),
+            domainBuilder.buildChallenge({
+              ...challengeData03_skill00_qcm_valide_flashCompatible_nl_noEmbedJson,
+              blindnessCompatibility: challengeData03_skill00_qcm_valide_flashCompatible_nl_noEmbedJson.accessibility1,
+              colorBlindnessCompatibility:
+                challengeData03_skill00_qcm_valide_flashCompatible_nl_noEmbedJson.accessibility2,
+              focused: challengeData03_skill00_qcm_valide_flashCompatible_nl_noEmbedJson.focusable,
+              discriminant: challengeData03_skill00_qcm_valide_flashCompatible_nl_noEmbedJson.alpha,
+              difficulty: challengeData03_skill00_qcm_valide_flashCompatible_nl_noEmbedJson.delta,
+              validator: new ValidatorQCM({
+                solution: domainBuilder.buildSolution({
+                  id: challengeData03_skill00_qcm_valide_flashCompatible_nl_noEmbedJson.id,
+                  type: challengeData03_skill00_qcm_valide_flashCompatible_nl_noEmbedJson.type,
+                  value: challengeData03_skill00_qcm_valide_flashCompatible_nl_noEmbedJson.solution,
+                  isT1Enabled: challengeData03_skill00_qcm_valide_flashCompatible_nl_noEmbedJson.t1Status,
+                  isT2Enabled: challengeData03_skill00_qcm_valide_flashCompatible_nl_noEmbedJson.t2Status,
+                  isT3Enabled: challengeData03_skill00_qcm_valide_flashCompatible_nl_noEmbedJson.t3Status,
+                  qrocBlocksTypes: {},
+                }),
+              }),
+              skill: domainBuilder.buildSkill({
+                ...skillData00_tube00competence00_actif,
+                difficulty: skillData00_tube00competence00_actif.level,
+                hint: skillData00_tube00competence00_actif.hint_i18n.fr,
+              }),
+            }),
+            domainBuilder.buildChallenge({
+              ...challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson,
+              blindnessCompatibility:
+                challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.accessibility1,
+              colorBlindnessCompatibility:
+                challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.accessibility2,
+              focused: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.focusable,
+              discriminant: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.alpha,
+              difficulty: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.delta,
+              validator: new ValidatorQCU({
+                solution: domainBuilder.buildSolution({
+                  id: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.id,
+                  type: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.type,
+                  value: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.solution,
+                  isT1Enabled: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.t1Status,
+                  isT2Enabled: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.t2Status,
+                  isT3Enabled: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.t3Status,
+                  qrocBlocksTypes: {},
+                }),
+              }),
+              skill: domainBuilder.buildSkill({
+                ...skillData01_tube01competence00_actif,
+                difficulty: skillData01_tube01competence00_actif.level,
+                hint: skillData01_tube01competence00_actif.hint_i18n.fr,
+              }),
+            }),
+            domainBuilder.buildChallenge({
+              ...challengeData07_skill03_qcm_valide_notFlashCompatible_frnl_noEmbedJson,
+              blindnessCompatibility:
+                challengeData07_skill03_qcm_valide_notFlashCompatible_frnl_noEmbedJson.accessibility1,
+              colorBlindnessCompatibility:
+                challengeData07_skill03_qcm_valide_notFlashCompatible_frnl_noEmbedJson.accessibility2,
+              focused: challengeData07_skill03_qcm_valide_notFlashCompatible_frnl_noEmbedJson.focusable,
+              discriminant: challengeData07_skill03_qcm_valide_notFlashCompatible_frnl_noEmbedJson.alpha,
+              difficulty: challengeData07_skill03_qcm_valide_notFlashCompatible_frnl_noEmbedJson.delta,
+              validator: new ValidatorQCM({
+                solution: domainBuilder.buildSolution({
+                  id: challengeData07_skill03_qcm_valide_notFlashCompatible_frnl_noEmbedJson.id,
+                  type: challengeData07_skill03_qcm_valide_notFlashCompatible_frnl_noEmbedJson.type,
+                  value: challengeData07_skill03_qcm_valide_notFlashCompatible_frnl_noEmbedJson.solution,
+                  isT1Enabled: challengeData07_skill03_qcm_valide_notFlashCompatible_frnl_noEmbedJson.t1Status,
+                  isT2Enabled: challengeData07_skill03_qcm_valide_notFlashCompatible_frnl_noEmbedJson.t2Status,
+                  isT3Enabled: challengeData07_skill03_qcm_valide_notFlashCompatible_frnl_noEmbedJson.t3Status,
+                  qrocBlocksTypes: {},
+                }),
+              }),
+              skill: domainBuilder.buildSkill({
+                ...skillData03_tube02competence01_actif,
+                difficulty: skillData03_tube02competence01_actif.level,
+                hint: skillData03_tube02competence01_actif.hint_i18n.fr,
+              }),
+            }),
+          ]);
+        });
+      });
+    });
+  });
+
+  describe('#findValidatedByCompetenceId', function () {
+    context('when locale is not defined', function () {
+      it('should throw an Error', async function () {
+        // when
+        const err = await catchErr(challengeRepository.findValidatedByCompetenceId)('competenceId00');
+
+        // then
+        expect(err.message).to.equal('Locale shall be defined');
+      });
+    });
+
+    context('when locale is defined', function () {
+      context('when no validated challenges found for given locale and competenceId', function () {
+        it('should return an empty array', async function () {
+          // when
+          const challenges = await challengeRepository.findValidatedByCompetenceId('competenceId00', 'es');
+
+          // then
+          expect(challenges).to.deep.equal([]);
+        });
+      });
+
+      context('when validated challenges are found for given locale and competenceId', function () {
+        it('should return the challenges', async function () {
+          // when
+          const challenges = await challengeRepository.findValidatedByCompetenceId('competenceId00', 'en');
+
+          // then
+          expect(challenges).to.deep.equal([
+            domainBuilder.buildChallenge({
+              ...challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson,
+              blindnessCompatibility:
+                challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.accessibility1,
+              colorBlindnessCompatibility:
+                challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.accessibility2,
+              focused: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.focusable,
+              discriminant: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.alpha,
+              difficulty: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.delta,
+              validator: new ValidatorQCU({
+                solution: domainBuilder.buildSolution({
+                  id: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.id,
+                  type: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.type,
+                  value: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.solution,
+                  isT1Enabled: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.t1Status,
+                  isT2Enabled: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.t2Status,
+                  isT3Enabled: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.t3Status,
+                  qrocBlocksTypes: {},
+                }),
+              }),
+              skill: domainBuilder.buildSkill({
+                ...skillData00_tube00competence00_actif,
+                difficulty: skillData00_tube00competence00_actif.level,
+                hint: skillData00_tube00competence00_actif.hint_i18n.fr,
+              }),
+            }),
+            domainBuilder.buildChallenge({
+              ...challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson,
+              blindnessCompatibility:
+                challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.accessibility1,
+              colorBlindnessCompatibility:
+                challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.accessibility2,
+              focused: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.focusable,
+              discriminant: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.alpha,
+              difficulty: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.delta,
+              validator: new ValidatorQCU({
+                solution: domainBuilder.buildSolution({
+                  id: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.id,
+                  type: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.type,
+                  value: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.solution,
+                  isT1Enabled: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.t1Status,
+                  isT2Enabled: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.t2Status,
+                  isT3Enabled: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.t3Status,
+                  qrocBlocksTypes: {},
+                }),
+              }),
+              skill: domainBuilder.buildSkill({
+                ...skillData01_tube01competence00_actif,
+                difficulty: skillData01_tube01competence00_actif.level,
+                hint: skillData01_tube01competence00_actif.hint_i18n.fr,
+              }),
+            }),
+          ]);
+        });
+      });
+    });
+  });
+
+  describe('#findOperativeBySkills', function () {
+    context('when locale is not defined', function () {
+      it('should throw an Error', async function () {
+        // when
+        const err = await catchErr(challengeRepository.findOperativeBySkills)(domainBuilder.buildSkill());
+
+        // then
+        expect(err.message).to.equal('Locale shall be defined');
+      });
+    });
+
+    context('when locale is defined', function () {
+      context('when no operative challenges found for given locale', function () {
+        it('should return an empty array', async function () {
+          // given
+          const skill00 = domainBuilder.buildSkill({
+            ...skillData00_tube00competence00_actif,
+            difficulty: skillData00_tube00competence00_actif.level,
+            hint: skillData00_tube00competence00_actif.hint_i18n.fr,
+          });
+
+          // when
+          const challenges = await challengeRepository.findOperativeBySkills([skill00], 'catalan');
+
+          // then
+          expect(challenges).to.deep.equal([]);
+        });
+      });
+
+      context('when operative challenges are found for given locale', function () {
+        it('should return the challenges', async function () {
+          // given
+          const skills = [
+            domainBuilder.buildSkill({
+              ...skillData00_tube00competence00_actif,
+              difficulty: skillData00_tube00competence00_actif.level,
+              hint: skillData00_tube00competence00_actif.hint_i18n.fr,
+            }),
+            domainBuilder.buildSkill({
+              ...skillData02_tube02competence01_perime,
+              difficulty: skillData02_tube02competence01_perime.level,
+              hint: skillData02_tube02competence01_perime.hint_i18n.fr,
+            }),
+            domainBuilder.buildSkill({
+              ...skillData01_tube01competence00_actif,
+              difficulty: skillData01_tube01competence00_actif.level,
+              hint: skillData01_tube01competence00_actif.hint_i18n.fr,
+            }),
+          ];
+
+          // when
+          const challenges = await challengeRepository.findOperativeBySkills(skills, 'en');
+
+          // then
+          expect(challenges).to.deep.equal([
+            domainBuilder.buildChallenge({
+              ...challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson,
+              blindnessCompatibility:
+                challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.accessibility1,
+              colorBlindnessCompatibility:
+                challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.accessibility2,
+              focused: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.focusable,
+              discriminant: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.alpha,
+              difficulty: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.delta,
+              validator: new ValidatorQCU({
+                solution: domainBuilder.buildSolution({
+                  id: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.id,
+                  type: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.type,
+                  value: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.solution,
+                  isT1Enabled: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.t1Status,
+                  isT2Enabled: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.t2Status,
+                  isT3Enabled: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.t3Status,
+                  qrocBlocksTypes: {},
+                }),
+              }),
+              skill: domainBuilder.buildSkill({
+                ...skillData00_tube00competence00_actif,
+                difficulty: skillData00_tube00competence00_actif.level,
+                hint: skillData00_tube00competence00_actif.hint_i18n.fr,
+              }),
+            }),
+            domainBuilder.buildChallenge({
+              ...challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson,
+              blindnessCompatibility: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.accessibility1,
+              colorBlindnessCompatibility:
+                challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.accessibility2,
+              focused: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.focusable,
+              discriminant: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.alpha,
+              difficulty: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.delta,
+              validator: new ValidatorQCM({
+                solution: domainBuilder.buildSolution({
+                  id: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.id,
+                  type: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.type,
+                  value: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.solution,
+                  isT1Enabled: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.t1Status,
+                  isT2Enabled: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.t2Status,
+                  isT3Enabled: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.t3Status,
+                  qrocBlocksTypes: {},
+                }),
+              }),
+              skill: domainBuilder.buildSkill({
+                ...skillData00_tube00competence00_actif,
+                difficulty: skillData00_tube00competence00_actif.level,
+                hint: skillData00_tube00competence00_actif.hint_i18n.fr,
+              }),
+            }),
+            domainBuilder.buildChallenge({
+              ...challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson,
+              blindnessCompatibility:
+                challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.accessibility1,
+              colorBlindnessCompatibility:
+                challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.accessibility2,
+              focused: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.focusable,
+              discriminant: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.alpha,
+              difficulty: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.delta,
+              validator: new ValidatorQCU({
+                solution: domainBuilder.buildSolution({
+                  id: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.id,
+                  type: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.type,
+                  value: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.solution,
+                  isT1Enabled: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.t1Status,
+                  isT2Enabled: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.t2Status,
+                  isT3Enabled: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.t3Status,
+                  qrocBlocksTypes: {},
+                }),
+              }),
+              skill: domainBuilder.buildSkill({
+                ...skillData01_tube01competence00_actif,
+                difficulty: skillData01_tube01competence00_actif.level,
+                hint: skillData01_tube01competence00_actif.hint_i18n.fr,
+              }),
+            }),
+          ]);
+        });
+
+        it('should avoid duplicates', async function () {
+          // given
+          const skills = [
+            domainBuilder.buildSkill({
+              ...skillData00_tube00competence00_actif,
+              difficulty: skillData00_tube00competence00_actif.level,
+              hint: skillData00_tube00competence00_actif.hint_i18n.fr,
+            }),
+            domainBuilder.buildSkill({
+              ...skillData02_tube02competence01_perime,
+              difficulty: skillData02_tube02competence01_perime.level,
+              hint: skillData02_tube02competence01_perime.hint_i18n.fr,
+            }),
+            domainBuilder.buildSkill({
+              ...skillData01_tube01competence00_actif,
+              difficulty: skillData01_tube01competence00_actif.level,
+              hint: skillData01_tube01competence00_actif.hint_i18n.fr,
+            }),
+            domainBuilder.buildSkill({
+              ...skillData00_tube00competence00_actif,
+              difficulty: skillData00_tube00competence00_actif.level,
+              hint: skillData00_tube00competence00_actif.hint_i18n.fr,
+            }),
+          ];
+
+          // when
+          const challenges = await challengeRepository.findOperativeBySkills(skills, 'en');
+
+          // then
+          expect(challenges).to.deep.equal([
+            domainBuilder.buildChallenge({
+              ...challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson,
+              blindnessCompatibility:
+                challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.accessibility1,
+              colorBlindnessCompatibility:
+                challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.accessibility2,
+              focused: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.focusable,
+              discriminant: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.alpha,
+              difficulty: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.delta,
+              validator: new ValidatorQCU({
+                solution: domainBuilder.buildSolution({
+                  id: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.id,
+                  type: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.type,
+                  value: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.solution,
+                  isT1Enabled: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.t1Status,
+                  isT2Enabled: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.t2Status,
+                  isT3Enabled: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.t3Status,
+                  qrocBlocksTypes: {},
+                }),
+              }),
+              skill: domainBuilder.buildSkill({
+                ...skillData00_tube00competence00_actif,
+                difficulty: skillData00_tube00competence00_actif.level,
+                hint: skillData00_tube00competence00_actif.hint_i18n.fr,
+              }),
+            }),
+            domainBuilder.buildChallenge({
+              ...challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson,
+              blindnessCompatibility: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.accessibility1,
+              colorBlindnessCompatibility:
+                challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.accessibility2,
+              focused: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.focusable,
+              discriminant: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.alpha,
+              difficulty: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.delta,
+              validator: new ValidatorQCM({
+                solution: domainBuilder.buildSolution({
+                  id: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.id,
+                  type: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.type,
+                  value: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.solution,
+                  isT1Enabled: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.t1Status,
+                  isT2Enabled: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.t2Status,
+                  isT3Enabled: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.t3Status,
+                  qrocBlocksTypes: {},
+                }),
+              }),
+              skill: domainBuilder.buildSkill({
+                ...skillData00_tube00competence00_actif,
+                difficulty: skillData00_tube00competence00_actif.level,
+                hint: skillData00_tube00competence00_actif.hint_i18n.fr,
+              }),
+            }),
+            domainBuilder.buildChallenge({
+              ...challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson,
+              blindnessCompatibility:
+                challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.accessibility1,
+              colorBlindnessCompatibility:
+                challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.accessibility2,
+              focused: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.focusable,
+              discriminant: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.alpha,
+              difficulty: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.delta,
+              validator: new ValidatorQCU({
+                solution: domainBuilder.buildSolution({
+                  id: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.id,
+                  type: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.type,
+                  value: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.solution,
+                  isT1Enabled: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.t1Status,
+                  isT2Enabled: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.t2Status,
+                  isT3Enabled: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.t3Status,
+                  qrocBlocksTypes: {},
+                }),
+              }),
+              skill: domainBuilder.buildSkill({
+                ...skillData01_tube01competence00_actif,
+                difficulty: skillData01_tube01competence00_actif.level,
+                hint: skillData01_tube01competence00_actif.hint_i18n.fr,
+              }),
+            }),
+          ]);
+        });
+      });
+    });
+  });
+
+  describe('#findOperativeBySkillsAndLocales', function () {
+    context('when locale is defined', function () {
+      context('when no operative challenges found for given locale', function () {
+        it('should return an empty array', async function () {
+          // given
+          const skill00 = domainBuilder.buildSkill({
+            ...skillData00_tube00competence00_actif,
+            difficulty: skillData00_tube00competence00_actif.level,
+            hint: skillData00_tube00competence00_actif.hint_i18n.fr,
+          });
+
+          // when
+          const challenges = await challengeRepository.findOperativeBySkillsAndLocales([skill00], ['catalan']);
+
+          // then
+          expect(challenges).to.deep.equal([]);
+        });
+      });
+
+      context('when searching for en-TZ and en operative challenges', function () {
+        it('should return the challenges having en-TZ or en included in their locales', async function () {
+          // given
+          const skills = [
+            domainBuilder.buildSkill({
+              ...activeSkill,
+              difficulty: activeSkill.level,
+              hint: activeSkill.hint_i18n.fr,
+            }),
+          ];
+
+          // when
+          const challenges = await challengeRepository.findOperativeBySkillsAndLocales(skills, ['en-TZ', 'en']);
+          // then
+          expect(challenges).to.deep.equal([
+            domainBuilder.buildChallenge({
+              ...enArchivedChallenge,
+              blindnessCompatibility: enArchivedChallenge.accessibility1,
+              colorBlindnessCompatibility: enArchivedChallenge.accessibility2,
+              focused: enArchivedChallenge.focusable,
+              discriminant: enArchivedChallenge.alpha,
+              difficulty: enArchivedChallenge.delta,
+              validator: new ValidatorQCU({
+                solution: domainBuilder.buildSolution({
+                  id: enArchivedChallenge.id,
+                  type: enArchivedChallenge.type,
+                  value: enArchivedChallenge.solution,
+                  isT1Enabled: enArchivedChallenge.t1Status,
+                  isT2Enabled: enArchivedChallenge.t2Status,
+                  isT3Enabled: enArchivedChallenge.t3Status,
+                  qrocBlocksTypes: {},
+                }),
+              }),
+              skill: domainBuilder.buildSkill({
+                ...activeSkill,
+                difficulty: activeSkill.level,
+                hint: activeSkill.hint_i18n.fr,
+              }),
+            }),
+            domainBuilder.buildChallenge({
+              ...enTZArchivedChallenge,
+              blindnessCompatibility: enTZArchivedChallenge.accessibility1,
+              colorBlindnessCompatibility: enTZArchivedChallenge.accessibility2,
+              focused: enTZArchivedChallenge.focusable,
+              discriminant: enTZArchivedChallenge.alpha,
+              difficulty: enTZArchivedChallenge.delta,
+              validator: new ValidatorQCU({
+                solution: domainBuilder.buildSolution({
+                  id: enTZArchivedChallenge.id,
+                  type: enTZArchivedChallenge.type,
+                  value: enTZArchivedChallenge.solution,
+                  isT1Enabled: enTZArchivedChallenge.t1Status,
+                  isT2Enabled: enTZArchivedChallenge.t2Status,
+                  isT3Enabled: enTZArchivedChallenge.t3Status,
+                  qrocBlocksTypes: {},
+                }),
+              }),
+              skill: domainBuilder.buildSkill({
+                ...activeSkill,
+                difficulty: activeSkill.level,
+                hint: activeSkill.hint_i18n.fr,
+              }),
+            }),
+            domainBuilder.buildChallenge({
+              ...enTZValidatedChallenge,
+              blindnessCompatibility: enTZValidatedChallenge.accessibility1,
+              colorBlindnessCompatibility: enTZValidatedChallenge.accessibility2,
+              focused: enTZValidatedChallenge.focusable,
+              discriminant: enTZValidatedChallenge.alpha,
+              difficulty: enTZValidatedChallenge.delta,
+              validator: new ValidatorQCU({
+                solution: domainBuilder.buildSolution({
+                  id: enTZValidatedChallenge.id,
+                  type: enTZValidatedChallenge.type,
+                  value: enTZValidatedChallenge.solution,
+                  isT1Enabled: enTZValidatedChallenge.t1Status,
+                  isT2Enabled: enTZValidatedChallenge.t2Status,
+                  isT3Enabled: enTZValidatedChallenge.t3Status,
+                  qrocBlocksTypes: {},
+                }),
+              }),
+              skill: domainBuilder.buildSkill({
+                ...activeSkill,
+                difficulty: activeSkill.level,
+                hint: activeSkill.hint_i18n.fr,
+              }),
+            }),
+            domainBuilder.buildChallenge({
+              ...enUGValidatedChallenge,
+              blindnessCompatibility: enUGValidatedChallenge.accessibility1,
+              colorBlindnessCompatibility: enUGValidatedChallenge.accessibility2,
+              focused: enUGValidatedChallenge.focusable,
+              discriminant: enUGValidatedChallenge.alpha,
+              difficulty: enUGValidatedChallenge.delta,
+              validator: new ValidatorQCU({
+                solution: domainBuilder.buildSolution({
+                  id: enUGValidatedChallenge.id,
+                  type: enUGValidatedChallenge.type,
+                  value: enUGValidatedChallenge.solution,
+                  isT1Enabled: enUGValidatedChallenge.t1Status,
+                  isT2Enabled: enUGValidatedChallenge.t2Status,
+                  isT3Enabled: enUGValidatedChallenge.t3Status,
+                  qrocBlocksTypes: {},
+                }),
+              }),
+              skill: domainBuilder.buildSkill({
+                ...activeSkill,
+                difficulty: activeSkill.level,
+                hint: activeSkill.hint_i18n.fr,
+              }),
+            }),
+            domainBuilder.buildChallenge({
+              ...enValidatedChallenge,
+              blindnessCompatibility: enValidatedChallenge.accessibility1,
+              colorBlindnessCompatibility: enValidatedChallenge.accessibility2,
+              focused: enValidatedChallenge.focusable,
+              discriminant: enValidatedChallenge.alpha,
+              difficulty: enValidatedChallenge.delta,
+              validator: new ValidatorQCU({
+                solution: domainBuilder.buildSolution({
+                  id: enValidatedChallenge.id,
+                  type: enValidatedChallenge.type,
+                  value: enValidatedChallenge.solution,
+                  isT1Enabled: enValidatedChallenge.t1Status,
+                  isT2Enabled: enValidatedChallenge.t2Status,
+                  isT3Enabled: enValidatedChallenge.t3Status,
+                  qrocBlocksTypes: {},
+                }),
+              }),
+              skill: domainBuilder.buildSkill({
+                ...activeSkill,
+                difficulty: activeSkill.level,
+                hint: activeSkill.hint_i18n.fr,
+              }),
+            }),
+          ]);
+        });
+      });
+    });
+  });
+
+  describe('#findValidatedBySkills', function () {
+    context('when locale is not defined', function () {
+      it('should throw an Error', async function () {
+        // when
+        const err = await catchErr(challengeRepository.findValidatedBySkills)(domainBuilder.buildSkill());
+
+        // then
+        expect(err.message).to.equal('Locale shall be defined');
+      });
+    });
+
+    context('when locale is defined', function () {
+      context('when no operative challenges found for given locale', function () {
+        it('should return an empty array', async function () {
+          // given
+          const skill00 = domainBuilder.buildSkill({
+            ...skillData00_tube00competence00_actif,
+            difficulty: skillData00_tube00competence00_actif.level,
+            hint: skillData00_tube00competence00_actif.hint_i18n.fr,
+          });
+
+          // when
+          const challenges = await challengeRepository.findValidatedBySkills([skill00], 'catalan');
+
+          // then
+          expect(challenges).to.deep.equal([]);
+        });
+      });
+
+      context('when operative challenges are found for given locale', function () {
+        it('should return the challenges', async function () {
+          // given
+          const skills = [
+            domainBuilder.buildSkill({
+              ...skillData00_tube00competence00_actif,
+              difficulty: skillData00_tube00competence00_actif.level,
+              hint: skillData00_tube00competence00_actif.hint_i18n.fr,
+            }),
+            domainBuilder.buildSkill({
+              ...skillData02_tube02competence01_perime,
+              difficulty: skillData02_tube02competence01_perime.level,
+              hint: skillData02_tube02competence01_perime.hint_i18n.fr,
+            }),
+            domainBuilder.buildSkill({
+              ...skillData01_tube01competence00_actif,
+              difficulty: skillData01_tube01competence00_actif.level,
+              hint: skillData01_tube01competence00_actif.hint_i18n.fr,
+            }),
+          ];
+
+          // when
+          const challenges = await challengeRepository.findValidatedBySkills(skills, 'en');
+
+          // then
+          expect(challenges).to.deep.equal([
+            domainBuilder.buildChallenge({
+              ...challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson,
+              blindnessCompatibility:
+                challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.accessibility1,
+              colorBlindnessCompatibility:
+                challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.accessibility2,
+              focused: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.focusable,
+              discriminant: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.alpha,
+              difficulty: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.delta,
+              validator: new ValidatorQCU({
+                solution: domainBuilder.buildSolution({
+                  id: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.id,
+                  type: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.type,
+                  value: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.solution,
+                  isT1Enabled: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.t1Status,
+                  isT2Enabled: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.t2Status,
+                  isT3Enabled: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.t3Status,
+                  qrocBlocksTypes: {},
+                }),
+              }),
+              skill: domainBuilder.buildSkill({
+                ...skillData00_tube00competence00_actif,
+                difficulty: skillData00_tube00competence00_actif.level,
+                hint: skillData00_tube00competence00_actif.hint_i18n.fr,
+              }),
+            }),
+            domainBuilder.buildChallenge({
+              ...challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson,
+              blindnessCompatibility:
+                challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.accessibility1,
+              colorBlindnessCompatibility:
+                challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.accessibility2,
+              focused: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.focusable,
+              discriminant: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.alpha,
+              difficulty: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.delta,
+              validator: new ValidatorQCU({
+                solution: domainBuilder.buildSolution({
+                  id: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.id,
+                  type: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.type,
+                  value: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.solution,
+                  isT1Enabled: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.t1Status,
+                  isT2Enabled: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.t2Status,
+                  isT3Enabled: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.t3Status,
+                  qrocBlocksTypes: {},
+                }),
+              }),
+              skill: domainBuilder.buildSkill({
+                ...skillData01_tube01competence00_actif,
+                difficulty: skillData01_tube01competence00_actif.level,
+                hint: skillData01_tube01competence00_actif.hint_i18n.fr,
+              }),
+            }),
+          ]);
+        });
+
+        it('should avoid duplicates', async function () {
+          // given
+          const skills = [
+            domainBuilder.buildSkill({
+              ...skillData00_tube00competence00_actif,
+              difficulty: skillData00_tube00competence00_actif.level,
+              hint: skillData00_tube00competence00_actif.hint_i18n.fr,
+            }),
+            domainBuilder.buildSkill({
+              ...skillData02_tube02competence01_perime,
+              difficulty: skillData02_tube02competence01_perime.level,
+              hint: skillData02_tube02competence01_perime.hint_i18n.fr,
+            }),
+            domainBuilder.buildSkill({
+              ...skillData01_tube01competence00_actif,
+              difficulty: skillData01_tube01competence00_actif.level,
+              hint: skillData01_tube01competence00_actif.hint_i18n.fr,
+            }),
+            domainBuilder.buildSkill({
+              ...skillData00_tube00competence00_actif,
+              difficulty: skillData00_tube00competence00_actif.level,
+              hint: skillData00_tube00competence00_actif.hint_i18n.fr,
+            }),
+          ];
+
+          // when
+          const challenges = await challengeRepository.findValidatedBySkills(skills, 'en');
+
+          // then
+          expect(challenges).to.deep.equal([
+            domainBuilder.buildChallenge({
+              ...challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson,
+              blindnessCompatibility:
+                challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.accessibility1,
+              colorBlindnessCompatibility:
+                challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.accessibility2,
+              focused: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.focusable,
+              discriminant: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.alpha,
+              difficulty: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.delta,
+              validator: new ValidatorQCU({
+                solution: domainBuilder.buildSolution({
+                  id: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.id,
+                  type: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.type,
+                  value: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.solution,
+                  isT1Enabled: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.t1Status,
+                  isT2Enabled: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.t2Status,
+                  isT3Enabled: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.t3Status,
+                  qrocBlocksTypes: {},
+                }),
+              }),
+              skill: domainBuilder.buildSkill({
+                ...skillData00_tube00competence00_actif,
+                difficulty: skillData00_tube00competence00_actif.level,
+                hint: skillData00_tube00competence00_actif.hint_i18n.fr,
+              }),
+            }),
+            domainBuilder.buildChallenge({
+              ...challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson,
+              blindnessCompatibility:
+                challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.accessibility1,
+              colorBlindnessCompatibility:
+                challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.accessibility2,
+              focused: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.focusable,
+              discriminant: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.alpha,
+              difficulty: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.delta,
+              validator: new ValidatorQCU({
+                solution: domainBuilder.buildSolution({
+                  id: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.id,
+                  type: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.type,
+                  value: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.solution,
+                  isT1Enabled: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.t1Status,
+                  isT2Enabled: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.t2Status,
+                  isT3Enabled: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.t3Status,
+                  qrocBlocksTypes: {},
+                }),
+              }),
+              skill: domainBuilder.buildSkill({
+                ...skillData01_tube01competence00_actif,
+                difficulty: skillData01_tube01competence00_actif.level,
+                hint: skillData01_tube01competence00_actif.hint_i18n.fr,
+              }),
+            }),
+          ]);
+        });
+      });
+    });
+  });
+
+  describe('#findValidatedBySkillId', function () {
+    context('when locale is not defined', function () {
+      it('should throw an Error', async function () {
+        // when
+        const err = await catchErr(challengeRepository.findValidatedBySkillId)('skillId00');
+
+        // then
+        expect(err.message).to.equal('Locale shall be defined');
+      });
+    });
+
+    context('when locale is defined', function () {
+      context('when no validated challenges found for given locale and skillId', function () {
+        it('should return an empty array', async function () {
+          // when
+          const challenges = await challengeRepository.findValidatedBySkillId('skillId00', 'es');
+
+          // then
+          expect(challenges).to.deep.equal([]);
+        });
+      });
+
+      context('when validated challenges are found for given locale and skillId', function () {
+        it('should return the challenges', async function () {
+          // when
+          const challenges = await challengeRepository.findValidatedBySkillId('skillId00', 'en');
+
+          // then
+          expect(challenges).to.deep.equal([
+            domainBuilder.buildChallenge({
+              ...challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson,
+              blindnessCompatibility:
+                challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.accessibility1,
+              colorBlindnessCompatibility:
+                challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.accessibility2,
+              focused: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.focusable,
+              discriminant: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.alpha,
+              difficulty: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.delta,
+              validator: new ValidatorQCU({
+                solution: domainBuilder.buildSolution({
+                  id: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.id,
+                  type: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.type,
+                  value: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.solution,
+                  isT1Enabled: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.t1Status,
+                  isT2Enabled: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.t2Status,
+                  isT3Enabled: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.t3Status,
+                  qrocBlocksTypes: {},
+                }),
+              }),
+              skill: domainBuilder.buildSkill({
+                ...skillData00_tube00competence00_actif,
+                difficulty: skillData00_tube00competence00_actif.level,
+                hint: skillData00_tube00competence00_actif.hint_i18n.fr,
+              }),
+            }),
+          ]);
+        });
+      });
+    });
+  });
+
+  describe('#getManyTypes', function () {
+    it('should return an object associating ids to type', async function () {
+      // when
+      const challengesType = await challengeRepository.getManyTypes([
+        'challengeId09',
+        'challengeId04',
+        'challengeId07',
+        'challengeId02',
+        'challengeId01',
+      ]);
+
+      // then
+      expect(challengesType).to.deep.equal({
+        challengeId01: 'QCU',
+        challengeId02: 'QCM',
+        challengeId04: 'QCU',
+        challengeId07: 'QCM',
+        challengeId09: 'QCU',
+      });
+    });
+
+    it('should throw NotFoundError when some ids are not found', async function () {
+      // when
+      const err = await catchErr(challengeRepository.getManyTypes)([
+        'challengeId09',
+        'challengeId04',
+        'challengeId666',
+        'challengeId02',
+        'challengeId01',
+      ]);
+
+      // then
+      expect(err).to.be.instanceOf(NotFoundError);
+    });
+  });
 });

--- a/api/tests/shared/integration/infrastructure/repositories/competence-repository_test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/competence-repository_test.js
@@ -1,8 +1,7 @@
-import { config } from '../../../../../src/shared/config.js';
 import { PIX_ORIGIN } from '../../../../../src/shared/domain/constants.js';
 import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
 import * as competenceRepository from '../../../../../src/shared/infrastructure/repositories/competence-repository.js';
-import { catchErr, databaseBuilder, domainBuilder, expect, sinon } from '../../../../test-helper.js';
+import { catchErr, databaseBuilder, domainBuilder, expect } from '../../../../test-helper.js';
 
 describe('Integration | Repository | competence-repository', function () {
   const competenceData1 = {
@@ -43,347 +42,339 @@ describe('Integration | Repository | competence-repository', function () {
     await databaseBuilder.commit();
   });
 
-  [false, true].forEach((cacheResultIds) =>
-    describe(`when cacheResultIds is ${cacheResultIds}`, function () {
-      beforeEach(function () {
-        sinon.stub(config.lcms, 'cacheResultIds').value(cacheResultIds);
-      });
+  describe('#get', function () {
+    context('when competence found for given id', function () {
+      context('when locale is provided', function () {
+        it('should return the competence translated in the provided locale or fallback to default locale FR', async function () {
+          // when
+          const competence = await competenceRepository.get({ id: 'recCompetence3_pix', locale: 'en' });
 
-      describe('#get', function () {
-        context('when competence found for given id', function () {
-          context('when locale is provided', function () {
-            it('should return the competence translated in the provided locale or fallback to default locale FR', async function () {
-              // when
-              const competence = await competenceRepository.get({ id: 'recCompetence3_pix', locale: 'en' });
-
-              // then
-              expect(competence).to.deepEqualInstance(
-                domainBuilder.buildCompetence({
-                  ...competenceData3,
-                  name: competenceData3.name_i18n.fr,
-                  description: competenceData3.description_i18n.en,
-                }),
-              );
-            });
-          });
-
-          context('when no locale provided', function () {
-            it('should return the competence translated in default locale FR', async function () {
-              // when
-              const competence = await competenceRepository.get({ id: 'recCompetence3_pix' });
-
-              // then
-              expect(competence).to.deepEqualInstance(
-                domainBuilder.buildCompetence({
-                  ...competenceData3,
-                  name: competenceData3.name_i18n.fr,
-                  description: competenceData3.description_i18n.fr,
-                }),
-              );
-            });
-          });
-        });
-
-        context('when no competence found', function () {
-          it('should throw a NotFound error', async function () {
-            // when
-            const err = await catchErr(
-              competenceRepository.get,
-              competenceRepository,
-            )({ id: 'CoucouLesZamis', locale: 'en' });
-
-            // then
-            expect(err).to.be.instanceOf(NotFoundError);
-            expect(err.message).to.equal('La compétence demandée n’existe pas');
-          });
+          // then
+          expect(competence).to.deepEqualInstance(
+            domainBuilder.buildCompetence({
+              ...competenceData3,
+              name: competenceData3.name_i18n.fr,
+              description: competenceData3.description_i18n.en,
+            }),
+          );
         });
       });
 
-      describe('#getCompetenceName', function () {
-        context('when competence found for given id', function () {
-          context('when locale is provided', function () {
-            it('should return the competence name translated in the provided locale or fallback to default locale FR', async function () {
-              // when
-              const competenceName = await competenceRepository.getCompetenceName({
-                id: 'recCompetence1_pix',
-                locale: 'en',
-              });
+      context('when no locale provided', function () {
+        it('should return the competence translated in default locale FR', async function () {
+          // when
+          const competence = await competenceRepository.get({ id: 'recCompetence3_pix' });
 
-              // then
-              expect(competenceName).to.equal(competenceData1.name_i18n.en);
-            });
-          });
-
-          context('when no locale provided', function () {
-            it('should return the competence name translated in default locale FR', async function () {
-              // when
-              const competenceName = await competenceRepository.getCompetenceName({ id: 'recCompetence1_pix' });
-
-              // then
-              expect(competenceName).to.equal(competenceData1.name_i18n.fr);
-            });
-          });
+          // then
+          expect(competence).to.deepEqualInstance(
+            domainBuilder.buildCompetence({
+              ...competenceData3,
+              name: competenceData3.name_i18n.fr,
+              description: competenceData3.description_i18n.fr,
+            }),
+          );
         });
+      });
+    });
 
-        context('when no competence found', function () {
-          it('should throw a NotFound error', async function () {
-            // when
-            const err = await catchErr(
-              competenceRepository.getCompetenceName,
-              competenceRepository,
-            )({ id: 'CoucouLesZamis', locale: 'en' });
+    context('when no competence found', function () {
+      it('should throw a NotFound error', async function () {
+        // when
+        const err = await catchErr(
+          competenceRepository.get,
+          competenceRepository,
+        )({ id: 'CoucouLesZamis', locale: 'en' });
 
-            // then
-            expect(err).to.be.instanceOf(NotFoundError);
-            expect(err.message).to.equal('La compétence demandée n’existe pas');
+        // then
+        expect(err).to.be.instanceOf(NotFoundError);
+        expect(err.message).to.equal('La compétence demandée n’existe pas');
+      });
+    });
+  });
+
+  describe('#getCompetenceName', function () {
+    context('when competence found for given id', function () {
+      context('when locale is provided', function () {
+        it('should return the competence name translated in the provided locale or fallback to default locale FR', async function () {
+          // when
+          const competenceName = await competenceRepository.getCompetenceName({
+            id: 'recCompetence1_pix',
+            locale: 'en',
           });
+
+          // then
+          expect(competenceName).to.equal(competenceData1.name_i18n.en);
         });
       });
 
-      describe('#list', function () {
-        context('when no locale provided', function () {
-          it('should return all competences translated by default with locale FR-FR ordered by index', async function () {
-            // when
-            const competences = await competenceRepository.list();
+      context('when no locale provided', function () {
+        it('should return the competence name translated in default locale FR', async function () {
+          // when
+          const competenceName = await competenceRepository.getCompetenceName({ id: 'recCompetence1_pix' });
 
-            // then
-            expect(competences).to.deepEqualArray([
-              domainBuilder.buildCompetence({
-                ...competenceData1,
-                name: competenceData1.name_i18n.fr,
-                description: competenceData1.description_i18n.fr,
-              }),
-              domainBuilder.buildCompetence({
-                ...competenceData2,
-                name: competenceData2.name_i18n.fr,
-                description: competenceData2.description_i18n.fr,
-              }),
-              domainBuilder.buildCompetence({
-                ...competenceData3,
-                name: competenceData3.name_i18n.fr,
-                description: competenceData3.description_i18n.fr,
-              }),
-            ]);
-          });
+          // then
+          expect(competenceName).to.equal(competenceData1.name_i18n.fr);
         });
+      });
+    });
 
-        context('when a locale is provided', function () {
-          it('should return all competences translated in the given locale or with fallback FR-FR', async function () {
-            // when
-            const competences = await competenceRepository.list({ locale: 'en' });
+    context('when no competence found', function () {
+      it('should throw a NotFound error', async function () {
+        // when
+        const err = await catchErr(
+          competenceRepository.getCompetenceName,
+          competenceRepository,
+        )({ id: 'CoucouLesZamis', locale: 'en' });
 
-            // then
-            expect(competences).to.deepEqualArray([
-              domainBuilder.buildCompetence({
-                ...competenceData1,
-                name: competenceData1.name_i18n.en,
-                description: competenceData1.description_i18n.fr,
-              }),
-              domainBuilder.buildCompetence({
-                ...competenceData2,
-                name: competenceData2.name_i18n.en,
-                description: competenceData2.description_i18n.en,
-              }),
-              domainBuilder.buildCompetence({
-                ...competenceData3,
-                name: competenceData3.name_i18n.fr,
-                description: competenceData3.description_i18n.en,
-              }),
-            ]);
+        // then
+        expect(err).to.be.instanceOf(NotFoundError);
+        expect(err.message).to.equal('La compétence demandée n’existe pas');
+      });
+    });
+  });
+
+  describe('#list', function () {
+    context('when no locale provided', function () {
+      it('should return all competences translated by default with locale FR-FR ordered by index', async function () {
+        // when
+        const competences = await competenceRepository.list();
+
+        // then
+        expect(competences).to.deepEqualArray([
+          domainBuilder.buildCompetence({
+            ...competenceData1,
+            name: competenceData1.name_i18n.fr,
+            description: competenceData1.description_i18n.fr,
+          }),
+          domainBuilder.buildCompetence({
+            ...competenceData2,
+            name: competenceData2.name_i18n.fr,
+            description: competenceData2.description_i18n.fr,
+          }),
+          domainBuilder.buildCompetence({
+            ...competenceData3,
+            name: competenceData3.name_i18n.fr,
+            description: competenceData3.description_i18n.fr,
+          }),
+        ]);
+      });
+    });
+
+    context('when a locale is provided', function () {
+      it('should return all competences translated in the given locale or with fallback FR-FR', async function () {
+        // when
+        const competences = await competenceRepository.list({ locale: 'en' });
+
+        // then
+        expect(competences).to.deepEqualArray([
+          domainBuilder.buildCompetence({
+            ...competenceData1,
+            name: competenceData1.name_i18n.en,
+            description: competenceData1.description_i18n.fr,
+          }),
+          domainBuilder.buildCompetence({
+            ...competenceData2,
+            name: competenceData2.name_i18n.en,
+            description: competenceData2.description_i18n.en,
+          }),
+          domainBuilder.buildCompetence({
+            ...competenceData3,
+            name: competenceData3.name_i18n.fr,
+            description: competenceData3.description_i18n.en,
+          }),
+        ]);
+      });
+    });
+  });
+
+  describe('#listPixCompetencesOnly', function () {
+    context('when no locale provided', function () {
+      it('should return all pix competences translated by default with locale FR-FR ordered by index', async function () {
+        // when
+        const competences = await competenceRepository.listPixCompetencesOnly();
+
+        // then
+        expect(competences).to.deepEqualArray([
+          domainBuilder.buildCompetence({
+            ...competenceData1,
+            name: competenceData1.name_i18n.fr,
+            description: competenceData1.description_i18n.fr,
+          }),
+          domainBuilder.buildCompetence({
+            ...competenceData3,
+            name: competenceData3.name_i18n.fr,
+            description: competenceData3.description_i18n.fr,
+          }),
+        ]);
+      });
+    });
+
+    context('when a locale is provided', function () {
+      it('should return all pix competences translated in the given locale or with fallback FR-FR', async function () {
+        // when
+        const competences = await competenceRepository.listPixCompetencesOnly({ locale: 'en' });
+
+        // then
+        expect(competences).to.deepEqualArray([
+          domainBuilder.buildCompetence({
+            ...competenceData1,
+            name: competenceData1.name_i18n.en,
+            description: competenceData1.description_i18n.fr,
+          }),
+          domainBuilder.buildCompetence({
+            ...competenceData3,
+            name: competenceData3.name_i18n.fr,
+            description: competenceData3.description_i18n.en,
+          }),
+        ]);
+      });
+    });
+  });
+
+  describe('#findByRecordIds', function () {
+    context('when competences found by ids', function () {
+      context('when no locale provided', function () {
+        it('should return all competences found translated in default locale FR given by their ids', async function () {
+          // when
+          const competences = await competenceRepository.findByRecordIds({
+            competenceIds: ['recCompetence3_pix', 'recCompetence2_pasPix'],
           });
+
+          // then
+          expect(competences).to.deepEqualArray([
+            domainBuilder.buildCompetence({
+              ...competenceData2,
+              name: competenceData2.name_i18n.fr,
+              description: competenceData2.description_i18n.fr,
+            }),
+            domainBuilder.buildCompetence({
+              ...competenceData3,
+              name: competenceData3.name_i18n.fr,
+              description: competenceData3.description_i18n.fr,
+            }),
+          ]);
         });
       });
 
-      describe('#listPixCompetencesOnly', function () {
-        context('when no locale provided', function () {
-          it('should return all pix competences translated by default with locale FR-FR ordered by index', async function () {
-            // when
-            const competences = await competenceRepository.listPixCompetencesOnly();
-
-            // then
-            expect(competences).to.deepEqualArray([
-              domainBuilder.buildCompetence({
-                ...competenceData1,
-                name: competenceData1.name_i18n.fr,
-                description: competenceData1.description_i18n.fr,
-              }),
-              domainBuilder.buildCompetence({
-                ...competenceData3,
-                name: competenceData3.name_i18n.fr,
-                description: competenceData3.description_i18n.fr,
-              }),
-            ]);
+      context('when a locale is provided', function () {
+        it('should return all competences found translated in provided locale of fallback to default locale FR', async function () {
+          // when
+          const competences = await competenceRepository.findByRecordIds({
+            competenceIds: ['recCompetence3_pix', 'recCompetence2_pasPix'],
+            locale: 'en',
           });
-        });
 
-        context('when a locale is provided', function () {
-          it('should return all pix competences translated in the given locale or with fallback FR-FR', async function () {
-            // when
-            const competences = await competenceRepository.listPixCompetencesOnly({ locale: 'en' });
-
-            // then
-            expect(competences).to.deepEqualArray([
-              domainBuilder.buildCompetence({
-                ...competenceData1,
-                name: competenceData1.name_i18n.en,
-                description: competenceData1.description_i18n.fr,
-              }),
-              domainBuilder.buildCompetence({
-                ...competenceData3,
-                name: competenceData3.name_i18n.fr,
-                description: competenceData3.description_i18n.en,
-              }),
-            ]);
-          });
+          // then
+          expect(competences).to.deepEqualArray([
+            domainBuilder.buildCompetence({
+              ...competenceData2,
+              name: competenceData2.name_i18n.en,
+              description: competenceData2.description_i18n.en,
+            }),
+            domainBuilder.buildCompetence({
+              ...competenceData3,
+              name: competenceData3.name_i18n.fr,
+              description: competenceData3.description_i18n.en,
+            }),
+          ]);
         });
       });
 
-      describe('#findByRecordIds', function () {
-        context('when competences found by ids', function () {
-          context('when no locale provided', function () {
-            it('should return all competences found translated in default locale FR given by their ids', async function () {
-              // when
-              const competences = await competenceRepository.findByRecordIds({
-                competenceIds: ['recCompetence3_pix', 'recCompetence2_pasPix'],
-              });
-
-              // then
-              expect(competences).to.deepEqualArray([
-                domainBuilder.buildCompetence({
-                  ...competenceData2,
-                  name: competenceData2.name_i18n.fr,
-                  description: competenceData2.description_i18n.fr,
-                }),
-                domainBuilder.buildCompetence({
-                  ...competenceData3,
-                  name: competenceData3.name_i18n.fr,
-                  description: competenceData3.description_i18n.fr,
-                }),
-              ]);
-            });
-          });
-
-          context('when a locale is provided', function () {
-            it('should return all competences found translated in provided locale of fallback to default locale FR', async function () {
-              // when
-              const competences = await competenceRepository.findByRecordIds({
-                competenceIds: ['recCompetence3_pix', 'recCompetence2_pasPix'],
-                locale: 'en',
-              });
-
-              // then
-              expect(competences).to.deepEqualArray([
-                domainBuilder.buildCompetence({
-                  ...competenceData2,
-                  name: competenceData2.name_i18n.en,
-                  description: competenceData2.description_i18n.en,
-                }),
-                domainBuilder.buildCompetence({
-                  ...competenceData3,
-                  name: competenceData3.name_i18n.fr,
-                  description: competenceData3.description_i18n.en,
-                }),
-              ]);
-            });
-          });
-
-          it('should ignore null and duplicates', async function () {
-            // when
-            const competences = await competenceRepository.findByRecordIds({
-              competenceIds: ['recCompetence3_pix', 'recCompetence2_pasPix', 'recCouCouMaman', 'recCompetence2_pasPix'],
-            });
-
-            // then
-            expect(competences).to.deepEqualArray([
-              domainBuilder.buildCompetence({
-                ...competenceData2,
-                name: competenceData2.name_i18n.fr,
-                description: competenceData2.description_i18n.fr,
-              }),
-              domainBuilder.buildCompetence({
-                ...competenceData3,
-                name: competenceData3.name_i18n.fr,
-                description: competenceData3.description_i18n.fr,
-              }),
-            ]);
-          });
+      it('should ignore null and duplicates', async function () {
+        // when
+        const competences = await competenceRepository.findByRecordIds({
+          competenceIds: ['recCompetence3_pix', 'recCompetence2_pasPix', 'recCouCouMaman', 'recCompetence2_pasPix'],
         });
 
-        context('when no competences found for given ids', function () {
-          it('should return an empty array', async function () {
-            // when
-            const competences = await competenceRepository.findByRecordIds({
-              competenceIds: ['recCompetenceCOUCOU', 'recCompetenceMAMAN'],
-            });
+        // then
+        expect(competences).to.deepEqualArray([
+          domainBuilder.buildCompetence({
+            ...competenceData2,
+            name: competenceData2.name_i18n.fr,
+            description: competenceData2.description_i18n.fr,
+          }),
+          domainBuilder.buildCompetence({
+            ...competenceData3,
+            name: competenceData3.name_i18n.fr,
+            description: competenceData3.description_i18n.fr,
+          }),
+        ]);
+      });
+    });
 
-            // then
-            expect(competences).to.deep.equal([]);
+    context('when no competences found for given ids', function () {
+      it('should return an empty array', async function () {
+        // when
+        const competences = await competenceRepository.findByRecordIds({
+          competenceIds: ['recCompetenceCOUCOU', 'recCompetenceMAMAN'],
+        });
+
+        // then
+        expect(competences).to.deep.equal([]);
+      });
+    });
+  });
+
+  describe('#findByAreaId', function () {
+    context('when competences found for area id', function () {
+      context('when no locale provided', function () {
+        it('should return all competences found translated in default locale FR given by their ids', async function () {
+          // when
+          const competences = await competenceRepository.findByAreaId({
+            areaId: 'recArea1',
           });
+
+          // then
+          expect(competences).to.deepEqualArray([
+            domainBuilder.buildCompetence({
+              ...competenceData1,
+              name: competenceData1.name_i18n.fr,
+              description: competenceData1.description_i18n.fr,
+            }),
+            domainBuilder.buildCompetence({
+              ...competenceData3,
+              name: competenceData3.name_i18n.fr,
+              description: competenceData3.description_i18n.fr,
+            }),
+          ]);
         });
       });
 
-      describe('#findByAreaId', function () {
-        context('when competences found for area id', function () {
-          context('when no locale provided', function () {
-            it('should return all competences found translated in default locale FR given by their ids', async function () {
-              // when
-              const competences = await competenceRepository.findByAreaId({
-                areaId: 'recArea1',
-              });
-
-              // then
-              expect(competences).to.deepEqualArray([
-                domainBuilder.buildCompetence({
-                  ...competenceData1,
-                  name: competenceData1.name_i18n.fr,
-                  description: competenceData1.description_i18n.fr,
-                }),
-                domainBuilder.buildCompetence({
-                  ...competenceData3,
-                  name: competenceData3.name_i18n.fr,
-                  description: competenceData3.description_i18n.fr,
-                }),
-              ]);
-            });
+      context('when a locale is provided', function () {
+        it('should return all competences found translated in provided locale of fallback to default locale FR', async function () {
+          // when
+          const competences = await competenceRepository.findByAreaId({
+            areaId: 'recArea1',
+            locale: 'en',
           });
 
-          context('when a locale is provided', function () {
-            it('should return all competences found translated in provided locale of fallback to default locale FR', async function () {
-              // when
-              const competences = await competenceRepository.findByAreaId({
-                areaId: 'recArea1',
-                locale: 'en',
-              });
-
-              // then
-              expect(competences).to.deepEqualArray([
-                domainBuilder.buildCompetence({
-                  ...competenceData1,
-                  name: competenceData1.name_i18n.en,
-                  description: competenceData1.description_i18n.fr,
-                }),
-                domainBuilder.buildCompetence({
-                  ...competenceData3,
-                  name: competenceData3.name_i18n.fr,
-                  description: competenceData3.description_i18n.en,
-                }),
-              ]);
-            });
-          });
-        });
-
-        context('when no competences found for given area id', function () {
-          it('should return an empty array', async function () {
-            // when
-            const competences = await competenceRepository.findByAreaId({
-              areaId: 'recCoucouRoro',
-            });
-
-            // then
-            expect(competences).to.deep.equal([]);
-          });
+          // then
+          expect(competences).to.deepEqualArray([
+            domainBuilder.buildCompetence({
+              ...competenceData1,
+              name: competenceData1.name_i18n.en,
+              description: competenceData1.description_i18n.fr,
+            }),
+            domainBuilder.buildCompetence({
+              ...competenceData3,
+              name: competenceData3.name_i18n.fr,
+              description: competenceData3.description_i18n.en,
+            }),
+          ]);
         });
       });
-    }),
-  );
+    });
+
+    context('when no competences found for given area id', function () {
+      it('should return an empty array', async function () {
+        // when
+        const competences = await competenceRepository.findByAreaId({
+          areaId: 'recCoucouRoro',
+        });
+
+        // then
+        expect(competences).to.deep.equal([]);
+      });
+    });
+  });
 });

--- a/api/tests/shared/integration/infrastructure/repositories/course-repository_test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/course-repository_test.js
@@ -1,7 +1,6 @@
-import { config } from '../../../../../src/shared/config.js';
 import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
 import * as courseRepository from '../../../../../src/shared/infrastructure/repositories/course-repository.js';
-import { catchErr, databaseBuilder, domainBuilder, expect, sinon } from '../../../../test-helper.js';
+import { catchErr, databaseBuilder, domainBuilder, expect } from '../../../../test-helper.js';
 
 describe('Integration | Repository | course-repository', function () {
   const courseData0 = {
@@ -28,33 +27,25 @@ describe('Integration | Repository | course-repository', function () {
     await databaseBuilder.commit();
   });
 
-  [false, true].forEach((cacheResultIds) =>
-    describe(`when cacheResultIds is ${cacheResultIds}`, function () {
-      beforeEach(function () {
-        sinon.stub(config.lcms, 'cacheResultIds').value(cacheResultIds);
+  describe('#get', function () {
+    context('when course found for given id', function () {
+      it('should return the course', async function () {
+        // when
+        const course = await courseRepository.get('courseId1');
+
+        // then
+        expect(course).to.deepEqualInstance(domainBuilder.buildCourse(courseData1));
       });
+    });
 
-      describe('#get', function () {
-        context('when course found for given id', function () {
-          it('should return the course', async function () {
-            // when
-            const course = await courseRepository.get('courseId1');
+    context('when no course found', function () {
+      it('should throw a NotFound error', async function () {
+        // when
+        const err = await catchErr(courseRepository.get, courseRepository)('coucouLoulou');
 
-            // then
-            expect(course).to.deepEqualInstance(domainBuilder.buildCourse(courseData1));
-          });
-        });
-
-        context('when no course found', function () {
-          it('should throw a NotFound error', async function () {
-            // when
-            const err = await catchErr(courseRepository.get, courseRepository)('coucouLoulou');
-
-            // then
-            expect(err).to.be.instanceOf(NotFoundError);
-          });
-        });
+        // then
+        expect(err).to.be.instanceOf(NotFoundError);
       });
-    }),
-  );
+    });
+  });
 });

--- a/api/tests/shared/integration/infrastructure/repositories/framework-repository_test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/framework-repository_test.js
@@ -1,7 +1,6 @@
-import { config } from '../../../../../src/shared/config.js';
 import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
 import * as frameworkRepository from '../../../../../src/shared/infrastructure/repositories/framework-repository.js';
-import { catchErr, databaseBuilder, domainBuilder, expect, knex, sinon } from '../../../../test-helper.js';
+import { catchErr, databaseBuilder, domainBuilder, expect, knex } from '../../../../test-helper.js';
 
 describe('Integration | Repository | framework-repository', function () {
   const frameworkData0 = {
@@ -24,89 +23,81 @@ describe('Integration | Repository | framework-repository', function () {
     await databaseBuilder.commit();
   });
 
-  [false, true].forEach((cacheResultIds) =>
-    describe(`when cacheResultIds is ${cacheResultIds}`, function () {
-      beforeEach(function () {
-        sinon.stub(config.lcms, 'cacheResultIds').value(cacheResultIds);
+  describe('#list', function () {
+    it('should return all frameworks when there are some in DB', async function () {
+      // when
+      const frameworks = await frameworkRepository.list();
+
+      // then
+      const expectedFramework0 = domainBuilder.buildFramework({ ...frameworkData0, areas: [] });
+      const expectedFramework1 = domainBuilder.buildFramework({ ...frameworkData1, areas: [] });
+      const expectedFramework2 = domainBuilder.buildFramework({ ...frameworkData2, areas: [] });
+      expect(frameworks).to.deepEqualArray([expectedFramework0, expectedFramework1, expectedFramework2]);
+    });
+
+    it('should return an empty array when no frameworks in DB', async function () {
+      // given
+      await knex('learningcontent.frameworks').truncate();
+
+      // when
+      const frameworks = await frameworkRepository.list();
+
+      // then
+      expect(frameworks).to.deep.equal([]);
+    });
+  });
+
+  describe('#getByName', function () {
+    it('should return a framework', async function () {
+      // when
+      const framework = await frameworkRepository.getByName('mon framework 1');
+
+      // then
+      const expectedFramework = domainBuilder.buildFramework({ ...frameworkData1, areas: [] });
+      expect(framework).to.deepEqualInstance(expectedFramework);
+    });
+
+    context('when framework is not found', function () {
+      it('should return a rejection', async function () {
+        //given
+        const frameworkName = 'frameworkData123';
+
+        // when
+        const error = await catchErr(frameworkRepository.getByName)(frameworkName);
+
+        // then
+        expect(error).to.be.an.instanceof(NotFoundError);
+        expect(error.message).to.equal('Framework not found for name frameworkData123');
       });
+    });
+  });
 
-      describe('#list', function () {
-        it('should return all frameworks when there are some in DB', async function () {
-          // when
-          const frameworks = await frameworkRepository.list();
+  describe('#findByRecordIds', function () {
+    it('should return frameworks for ids ordered by name', async function () {
+      // when
+      const frameworks = await frameworkRepository.findByRecordIds(['recId2', 'recId0']);
 
-          // then
-          const expectedFramework0 = domainBuilder.buildFramework({ ...frameworkData0, areas: [] });
-          const expectedFramework1 = domainBuilder.buildFramework({ ...frameworkData1, areas: [] });
-          const expectedFramework2 = domainBuilder.buildFramework({ ...frameworkData2, areas: [] });
-          expect(frameworks).to.deepEqualArray([expectedFramework0, expectedFramework1, expectedFramework2]);
-        });
+      // then
+      const expectedFramework0 = domainBuilder.buildFramework({ ...frameworkData0, areas: [] });
+      const expectedFramework2 = domainBuilder.buildFramework({ ...frameworkData2, areas: [] });
+      expect(frameworks).to.deepEqualArray([expectedFramework0, expectedFramework2]);
+    });
 
-        it('should return an empty array when no frameworks in DB', async function () {
-          // given
-          await knex('learningcontent.frameworks').truncate();
+    it('should return frameworks it managed to find once', async function () {
+      // when
+      const frameworks = await frameworkRepository.findByRecordIds(['recId2', 'recIdCAVA', 'recId2']);
 
-          // when
-          const frameworks = await frameworkRepository.list();
+      // then
+      const expectedFramework2 = domainBuilder.buildFramework({ ...frameworkData2, areas: [] });
+      expect(frameworks).to.deepEqualArray([expectedFramework2]);
+    });
 
-          // then
-          expect(frameworks).to.deep.equal([]);
-        });
-      });
+    it('should return an empty array when no frameworks found for ids', async function () {
+      // when
+      const frameworks = await frameworkRepository.findByRecordIds(['recIdCOUCOU', 'recIdCAVA']);
 
-      describe('#getByName', function () {
-        it('should return a framework', async function () {
-          // when
-          const framework = await frameworkRepository.getByName('mon framework 1');
-
-          // then
-          const expectedFramework = domainBuilder.buildFramework({ ...frameworkData1, areas: [] });
-          expect(framework).to.deepEqualInstance(expectedFramework);
-        });
-
-        context('when framework is not found', function () {
-          it('should return a rejection', async function () {
-            //given
-            const frameworkName = 'frameworkData123';
-
-            // when
-            const error = await catchErr(frameworkRepository.getByName)(frameworkName);
-
-            // then
-            expect(error).to.be.an.instanceof(NotFoundError);
-            expect(error.message).to.equal('Framework not found for name frameworkData123');
-          });
-        });
-      });
-
-      describe('#findByRecordIds', function () {
-        it('should return frameworks for ids ordered by name', async function () {
-          // when
-          const frameworks = await frameworkRepository.findByRecordIds(['recId2', 'recId0']);
-
-          // then
-          const expectedFramework0 = domainBuilder.buildFramework({ ...frameworkData0, areas: [] });
-          const expectedFramework2 = domainBuilder.buildFramework({ ...frameworkData2, areas: [] });
-          expect(frameworks).to.deepEqualArray([expectedFramework0, expectedFramework2]);
-        });
-
-        it('should return frameworks it managed to find once', async function () {
-          // when
-          const frameworks = await frameworkRepository.findByRecordIds(['recId2', 'recIdCAVA', 'recId2']);
-
-          // then
-          const expectedFramework2 = domainBuilder.buildFramework({ ...frameworkData2, areas: [] });
-          expect(frameworks).to.deepEqualArray([expectedFramework2]);
-        });
-
-        it('should return an empty array when no frameworks found for ids', async function () {
-          // when
-          const frameworks = await frameworkRepository.findByRecordIds(['recIdCOUCOU', 'recIdCAVA']);
-
-          // then
-          expect(frameworks).to.deepEqualArray([]);
-        });
-      });
-    }),
-  );
+      // then
+      expect(frameworks).to.deepEqualArray([]);
+    });
+  });
 });

--- a/api/tests/shared/integration/infrastructure/repositories/learning-content-repository_test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/learning-content-repository_test.js
@@ -1,4 +1,3 @@
-import { config } from '../../../../../src/shared/config.js';
 import { LearningContentRepository } from '../../../../../src/shared/infrastructure/repositories/learning-content-repository.js';
 import { catchErr, expect, knex, sinon } from '../../../../test-helper.js';
 
@@ -45,231 +44,223 @@ describe('Integration | Repository | learning-repository', function () {
     knex.removeListener('query', queryHook);
   });
 
-  [false, true].forEach((cacheResultIds) =>
-    describe(`when cacheResultIds is ${cacheResultIds}`, function () {
-      beforeEach(function () {
-        sinon.stub(config.lcms, 'cacheResultIds').value(cacheResultIds);
+  describe('#find', function () {
+    describe('when no database errors', function () {
+      it('should return matched entities', async function () {
+        // given
+        const group = 'group1';
+        const cacheKey = 'findByGroup(group1)';
+        const callback = (knex) => knex.where({ group }).orderBy('id');
+
+        // when
+        const dtos = await repository.find(cacheKey, callback);
+
+        // then
+        expect(dtos).to.deep.equal([
+          { id: 'entity1', name: 'Entity 1', group: 'group1' },
+          { id: 'entity2', name: 'Entity 2', group: 'group1' },
+          { id: 'entity3', name: 'Entity 3', group: 'group1' },
+        ]);
+        expect(queryHook).to.have.been.calledTwice;
       });
 
-      describe('#find', function () {
-        describe('when no database errors', function () {
-          it('should return matched entities', async function () {
-            // given
-            const group = 'group1';
-            const cacheKey = 'findByGroup(group1)';
-            const callback = (knex) => knex.where({ group }).orderBy('id');
+      describe('when result is cached', function () {
+        it('should return entities from cache', async function () {
+          // given
+          const group = 'group1';
+          const cacheKey = 'findByGroup(group1)';
+          const callback = (knex) => knex.where({ group }).orderBy('id');
+          await repository.find(cacheKey, callback);
+          queryHook.reset();
 
-            // when
-            const dtos = await repository.find(cacheKey, callback);
+          // when
+          const dtos = await repository.find(cacheKey, callback);
 
-            // then
-            expect(dtos).to.deep.equal([
-              { id: 'entity1', name: 'Entity 1', group: 'group1' },
-              { id: 'entity2', name: 'Entity 2', group: 'group1' },
-              { id: 'entity3', name: 'Entity 3', group: 'group1' },
-            ]);
-            expect(queryHook).to.have.been.calledTwice;
-          });
-
-          describe('when result is cached', function () {
-            it('should return entities from cache', async function () {
-              // given
-              const group = 'group1';
-              const cacheKey = 'findByGroup(group1)';
-              const callback = (knex) => knex.where({ group }).orderBy('id');
-              await repository.find(cacheKey, callback);
-              queryHook.reset();
-
-              // when
-              const dtos = await repository.find(cacheKey, callback);
-
-              // then
-              expect(dtos).to.deep.equal([
-                { id: 'entity1', name: 'Entity 1', group: 'group1' },
-                { id: 'entity2', name: 'Entity 2', group: 'group1' },
-                { id: 'entity3', name: 'Entity 3', group: 'group1' },
-              ]);
-              expect(queryHook).not.to.have.been.called;
-            });
-          });
-        });
-
-        describe('when database error in find ids query', function () {
-          it('should throw an Error', async function () {
-            // given
-            const group = 'group1';
-            const cacheKey = 'findByGroup(group1)';
-            const callback = (knex) => knex.where({ group }).orderBy('id');
-            queryHook.onFirstCall().throws(new Error());
-
-            // when
-            const err = await catchErr((...args) => repository.find(...args))(cacheKey, callback);
-
-            // then
-            expect(err).to.be.instanceOf(Error);
-            expect(queryHook).to.have.been.calledOnce;
-          });
-        });
-
-        describe('when database error in load entities query', function () {
-          it('should throw an Error', async function () {
-            // given
-            const group = 'group1';
-            const cacheKey = 'findByGroup(group1)';
-            const callback = (knex) => knex.where({ group }).orderBy('id');
-            queryHook.onSecondCall().throws(new Error());
-
-            // when
-            const err = await catchErr((...args) => repository.find(...args))(cacheKey, callback);
-
-            // then
-            expect(err).to.be.instanceOf(Error);
-            expect(queryHook).to.have.been.calledTwice;
-          });
+          // then
+          expect(dtos).to.deep.equal([
+            { id: 'entity1', name: 'Entity 1', group: 'group1' },
+            { id: 'entity2', name: 'Entity 2', group: 'group1' },
+            { id: 'entity3', name: 'Entity 3', group: 'group1' },
+          ]);
+          expect(queryHook).not.to.have.been.called;
         });
       });
+    });
 
-      describe('#loadMany', function () {
-        describe('when no database errors', function () {
-          it('should return entities', async function () {
-            // given
-            const ids = ['entity4', 'entity1', 'entity5'];
+    describe('when database error in find ids query', function () {
+      it('should throw an Error', async function () {
+        // given
+        const group = 'group1';
+        const cacheKey = 'findByGroup(group1)';
+        const callback = (knex) => knex.where({ group }).orderBy('id');
+        queryHook.onFirstCall().throws(new Error());
 
-            // when
-            const dtos = await repository.loadMany(ids);
+        // when
+        const err = await catchErr((...args) => repository.find(...args))(cacheKey, callback);
 
-            // then
-            expect(dtos).to.deep.equal([
-              { id: 'entity4', name: 'Entity 4', group: 'group2' },
-              { id: 'entity1', name: 'Entity 1', group: 'group1' },
-              { id: 'entity5', name: 'Entity 5', group: 'group2' },
-            ]);
-            expect(queryHook).to.have.been.calledOnce;
-          });
+        // then
+        expect(err).to.be.instanceOf(Error);
+        expect(queryHook).to.have.been.calledOnce;
+      });
+    });
 
-          describe('when result is cached', function () {
-            it('should return entities from cache', async function () {
-              // given
-              const ids = ['entity4', 'entity1', 'entity5'];
-              await repository.loadMany(ids);
-              queryHook.reset();
+    describe('when database error in load entities query', function () {
+      it('should throw an Error', async function () {
+        // given
+        const group = 'group1';
+        const cacheKey = 'findByGroup(group1)';
+        const callback = (knex) => knex.where({ group }).orderBy('id');
+        queryHook.onSecondCall().throws(new Error());
 
-              // when
-              const dtos = await repository.loadMany(ids);
+        // when
+        const err = await catchErr((...args) => repository.find(...args))(cacheKey, callback);
 
-              // then
-              expect(dtos).to.deep.equal([
-                { id: 'entity4', name: 'Entity 4', group: 'group2' },
-                { id: 'entity1', name: 'Entity 1', group: 'group1' },
-                { id: 'entity5', name: 'Entity 5', group: 'group2' },
-              ]);
-              expect(queryHook).not.to.have.been.called;
-            });
-          });
-        });
+        // then
+        expect(err).to.be.instanceOf(Error);
+        expect(queryHook).to.have.been.calledTwice;
+      });
+    });
+  });
 
-        describe('when database error', function () {
-          it('should throw an Error', async function () {
-            // given
-            const ids = ['entity4', 'entity1', 'entity5'];
-            queryHook.onFirstCall().throws(new Error());
+  describe('#loadMany', function () {
+    describe('when no database errors', function () {
+      it('should return entities', async function () {
+        // given
+        const ids = ['entity4', 'entity1', 'entity5'];
 
-            // when
-            const err = await catchErr((...args) => repository.loadMany(...args))(ids);
+        // when
+        const dtos = await repository.loadMany(ids);
 
-            // then
-            expect(err).to.be.instanceOf(Error);
-            expect(queryHook).to.have.been.calledOnce;
-          });
-        });
+        // then
+        expect(dtos).to.deep.equal([
+          { id: 'entity4', name: 'Entity 4', group: 'group2' },
+          { id: 'entity1', name: 'Entity 1', group: 'group1' },
+          { id: 'entity5', name: 'Entity 5', group: 'group2' },
+        ]);
+        expect(queryHook).to.have.been.calledOnce;
       });
 
-      describe('#load', function () {
-        describe('when no database errors', function () {
-          it('should return entity', async function () {
-            // given
-            const id = 'entity3';
+      describe('when result is cached', function () {
+        it('should return entities from cache', async function () {
+          // given
+          const ids = ['entity4', 'entity1', 'entity5'];
+          await repository.loadMany(ids);
+          queryHook.reset();
 
-            // when
-            const dto = await repository.load(id);
+          // when
+          const dtos = await repository.loadMany(ids);
 
-            // then
-            expect(dto).to.deep.equal({ id: 'entity3', name: 'Entity 3', group: 'group1' });
-            expect(queryHook).to.have.been.calledOnce;
-          });
-
-          describe('when result is cached', function () {
-            it('should return entity from cache', async function () {
-              // given
-              const id = 'entity3';
-              await repository.load(id);
-              queryHook.reset();
-
-              // when
-              const dto = await repository.load(id);
-
-              // then
-              expect(dto).to.deep.equal({ id: 'entity3', name: 'Entity 3', group: 'group1' });
-              expect(queryHook).not.to.have.been.called;
-            });
-          });
-        });
-
-        describe('when database error', function () {
-          it('should throw an Error', async function () {
-            // given
-            const id = 'entity3';
-            queryHook.onFirstCall().throws(new Error());
-
-            // when
-            const err = await catchErr((...args) => repository.load(...args))(id);
-
-            // then
-            expect(err).to.be.instanceOf(Error);
-            expect(queryHook).to.have.been.calledOnce;
-          });
+          // then
+          expect(dtos).to.deep.equal([
+            { id: 'entity4', name: 'Entity 4', group: 'group2' },
+            { id: 'entity1', name: 'Entity 1', group: 'group1' },
+            { id: 'entity5', name: 'Entity 5', group: 'group2' },
+          ]);
+          expect(queryHook).not.to.have.been.called;
         });
       });
+    });
 
-      describe('getMany', function () {
-        describe('when no database errors', function () {
-          it('should return entities', async function () {
-            // given
-            const ids = ['entity4', null, 'entity1', 'entity4', undefined, 'entity5', 'entity5'];
+    describe('when database error', function () {
+      it('should throw an Error', async function () {
+        // given
+        const ids = ['entity4', 'entity1', 'entity5'];
+        queryHook.onFirstCall().throws(new Error());
 
-            // when
-            const dtos = await repository.getMany(ids);
+        // when
+        const err = await catchErr((...args) => repository.loadMany(...args))(ids);
 
-            // then
-            expect(dtos).to.deep.equal([
-              { id: 'entity4', name: 'Entity 4', group: 'group2' },
-              { id: 'entity1', name: 'Entity 1', group: 'group1' },
-              { id: 'entity5', name: 'Entity 5', group: 'group2' },
-            ]);
-            expect(queryHook).to.have.been.calledOnce;
-          });
+        // then
+        expect(err).to.be.instanceOf(Error);
+        expect(queryHook).to.have.been.calledOnce;
+      });
+    });
+  });
 
-          describe('when result is cached', function () {
-            it('should return entities from cache', async function () {
-              // given
-              const ids = ['entity4', null, 'entity1', 'entity4', undefined, 'entity5', 'entity5'];
-              await repository.getMany(ids);
-              queryHook.reset();
+  describe('#load', function () {
+    describe('when no database errors', function () {
+      it('should return entity', async function () {
+        // given
+        const id = 'entity3';
 
-              // when
-              const dtos = await repository.getMany(ids);
+        // when
+        const dto = await repository.load(id);
 
-              // then
-              expect(dtos).to.deep.equal([
-                { id: 'entity4', name: 'Entity 4', group: 'group2' },
-                { id: 'entity1', name: 'Entity 1', group: 'group1' },
-                { id: 'entity5', name: 'Entity 5', group: 'group2' },
-              ]);
-              expect(queryHook).not.to.have.been.called;
-            });
-          });
+        // then
+        expect(dto).to.deep.equal({ id: 'entity3', name: 'Entity 3', group: 'group1' });
+        expect(queryHook).to.have.been.calledOnce;
+      });
+
+      describe('when result is cached', function () {
+        it('should return entity from cache', async function () {
+          // given
+          const id = 'entity3';
+          await repository.load(id);
+          queryHook.reset();
+
+          // when
+          const dto = await repository.load(id);
+
+          // then
+          expect(dto).to.deep.equal({ id: 'entity3', name: 'Entity 3', group: 'group1' });
+          expect(queryHook).not.to.have.been.called;
         });
       });
-    }),
-  );
+    });
+
+    describe('when database error', function () {
+      it('should throw an Error', async function () {
+        // given
+        const id = 'entity3';
+        queryHook.onFirstCall().throws(new Error());
+
+        // when
+        const err = await catchErr((...args) => repository.load(...args))(id);
+
+        // then
+        expect(err).to.be.instanceOf(Error);
+        expect(queryHook).to.have.been.calledOnce;
+      });
+    });
+  });
+
+  describe('getMany', function () {
+    describe('when no database errors', function () {
+      it('should return entities', async function () {
+        // given
+        const ids = ['entity4', null, 'entity1', 'entity4', undefined, 'entity5', 'entity5'];
+
+        // when
+        const dtos = await repository.getMany(ids);
+
+        // then
+        expect(dtos).to.deep.equal([
+          { id: 'entity4', name: 'Entity 4', group: 'group2' },
+          { id: 'entity1', name: 'Entity 1', group: 'group1' },
+          { id: 'entity5', name: 'Entity 5', group: 'group2' },
+        ]);
+        expect(queryHook).to.have.been.calledOnce;
+      });
+
+      describe('when result is cached', function () {
+        it('should return entities from cache', async function () {
+          // given
+          const ids = ['entity4', null, 'entity1', 'entity4', undefined, 'entity5', 'entity5'];
+          await repository.getMany(ids);
+          queryHook.reset();
+
+          // when
+          const dtos = await repository.getMany(ids);
+
+          // then
+          expect(dtos).to.deep.equal([
+            { id: 'entity4', name: 'Entity 4', group: 'group2' },
+            { id: 'entity1', name: 'Entity 1', group: 'group1' },
+            { id: 'entity5', name: 'Entity 5', group: 'group2' },
+          ]);
+          expect(queryHook).not.to.have.been.called;
+        });
+      });
+    });
+  });
 });

--- a/api/tests/shared/integration/infrastructure/repositories/skill-repository_test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/skill-repository_test.js
@@ -1,7 +1,6 @@
-import { config } from '../../../../../src/shared/config.js';
 import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
 import * as skillRepository from '../../../../../src/shared/infrastructure/repositories/skill-repository.js';
-import { catchErr, databaseBuilder, domainBuilder, expect, sinon } from '../../../../test-helper.js';
+import { catchErr, databaseBuilder, domainBuilder, expect } from '../../../../test-helper.js';
 
 describe('Integration | Repository | skill-repository', function () {
   const skillData00_tubeAcompetenceA_actif = {
@@ -208,492 +207,452 @@ describe('Integration | Repository | skill-repository', function () {
     await databaseBuilder.commit();
   });
 
-  [false, true].forEach((cacheResultIds) =>
-    describe(`when cacheResultIds is ${cacheResultIds}`, function () {
-      beforeEach(function () {
-        sinon.stub(config.lcms, 'cacheResultIds').value(cacheResultIds);
+  describe('#list', function () {
+    it('should return all skills', async function () {
+      // when
+      const skills = await skillRepository.list();
+
+      // then
+      expect(skills).to.deepEqualArray([
+        domainBuilder.buildSkill({
+          ...skillData00_tubeAcompetenceA_actif,
+          difficulty: skillData00_tubeAcompetenceA_actif.level,
+          hint: skillData00_tubeAcompetenceA_actif.hint_i18n.fr,
+        }),
+        domainBuilder.buildSkill({
+          ...skillData01_tubeAcompetenceA_archive,
+          difficulty: skillData01_tubeAcompetenceA_archive.level,
+          hint: skillData01_tubeAcompetenceA_archive.hint_i18n.fr,
+        }),
+        domainBuilder.buildSkill({
+          ...skillData02_tubeAcompetenceA_perime,
+          difficulty: skillData02_tubeAcompetenceA_perime.level,
+          hint: skillData02_tubeAcompetenceA_perime.hint_i18n.fr,
+        }),
+        domainBuilder.buildSkill({
+          ...skillData03_tubeBcompetenceA_actif,
+          difficulty: skillData03_tubeBcompetenceA_actif.level,
+          hint: skillData03_tubeBcompetenceA_actif.hint_i18n.fr,
+        }),
+        domainBuilder.buildSkill({
+          ...skillData04_tubeBcompetenceA_archive,
+          difficulty: skillData04_tubeBcompetenceA_archive.level,
+          hint: skillData04_tubeBcompetenceA_archive.hint_i18n.fr,
+        }),
+        domainBuilder.buildSkill({
+          ...skillData05_tubeBcompetenceA_perime,
+          difficulty: skillData05_tubeBcompetenceA_perime.level,
+          hint: skillData05_tubeBcompetenceA_perime.hint_i18n.fr,
+        }),
+        domainBuilder.buildSkill({
+          ...skillData06_tubeCcompetenceB_actif,
+          difficulty: skillData06_tubeCcompetenceB_actif.level,
+          hint: skillData06_tubeCcompetenceB_actif.hint_i18n.fr,
+        }),
+        domainBuilder.buildSkill({
+          ...skillData07_tubeCcompetenceB_archive,
+          difficulty: skillData07_tubeCcompetenceB_archive.level,
+          hint: skillData07_tubeCcompetenceB_archive.hint_i18n.fr,
+        }),
+        domainBuilder.buildSkill({
+          ...skillData08_tubeCcompetenceB_perime,
+          difficulty: skillData08_tubeCcompetenceB_perime.level,
+          hint: skillData08_tubeCcompetenceB_perime.hint_i18n.fr,
+        }),
+        domainBuilder.buildSkill({
+          ...skillData09_tubeDcompetenceB_actif,
+          difficulty: skillData09_tubeDcompetenceB_actif.level,
+          hint: skillData09_tubeDcompetenceB_actif.hint_i18n.fr,
+        }),
+        domainBuilder.buildSkill({
+          ...skillData10_tubeDcompetenceB_archive,
+          difficulty: skillData10_tubeDcompetenceB_archive.level,
+          hint: skillData10_tubeDcompetenceB_archive.hint_i18n.fr,
+        }),
+        domainBuilder.buildSkill({
+          ...skillData11_tubeDcompetenceB_perime,
+          difficulty: skillData11_tubeDcompetenceB_perime.level,
+          hint: skillData11_tubeDcompetenceB_perime.hint_i18n.fr,
+        }),
+        domainBuilder.buildSkill({
+          ...skillData12_tubeEcompetenceC_perime,
+          difficulty: skillData12_tubeEcompetenceC_perime.level,
+          hint: skillData12_tubeEcompetenceC_perime.hint_i18n.fr,
+        }),
+      ]);
+    });
+  });
+
+  describe('#findActiveByCompetenceId', function () {
+    context('when no active skills for given competence id', function () {
+      it('should return an empty array', async function () {
+        // when
+        const skills = await skillRepository.findActiveByCompetenceId('competenceIdC');
+
+        // then
+        expect(skills).to.deep.equal([]);
+      });
+    });
+
+    context('when active skills for given competence id', function () {
+      it('should return skills', async function () {
+        // when
+        const skills = await skillRepository.findActiveByCompetenceId('competenceIdB');
+
+        // then
+        expect(skills).to.deepEqualArray([
+          domainBuilder.buildSkill({
+            ...skillData06_tubeCcompetenceB_actif,
+            difficulty: skillData06_tubeCcompetenceB_actif.level,
+            hint: skillData06_tubeCcompetenceB_actif.hint_i18n.fr,
+          }),
+          domainBuilder.buildSkill({
+            ...skillData09_tubeDcompetenceB_actif,
+            difficulty: skillData09_tubeDcompetenceB_actif.level,
+            hint: skillData09_tubeDcompetenceB_actif.hint_i18n.fr,
+          }),
+        ]);
+      });
+    });
+  });
+
+  describe('#findOperativeByCompetenceId', function () {
+    context('when no operative skills for given competence id', function () {
+      it('should return an empty array', async function () {
+        // when
+        const skills = await skillRepository.findOperativeByCompetenceId('competenceIdC');
+
+        // then
+        expect(skills).to.deep.equal([]);
+      });
+    });
+
+    context('when operative skills for given competence id', function () {
+      it('should return skills', async function () {
+        // when
+        const skills = await skillRepository.findOperativeByCompetenceId('competenceIdB');
+
+        // then
+        expect(skills).to.deepEqualArray([
+          domainBuilder.buildSkill({
+            ...skillData06_tubeCcompetenceB_actif,
+            difficulty: skillData06_tubeCcompetenceB_actif.level,
+            hint: skillData06_tubeCcompetenceB_actif.hint_i18n.fr,
+          }),
+          domainBuilder.buildSkill({
+            ...skillData07_tubeCcompetenceB_archive,
+            difficulty: skillData07_tubeCcompetenceB_archive.level,
+            hint: skillData07_tubeCcompetenceB_archive.hint_i18n.fr,
+          }),
+          domainBuilder.buildSkill({
+            ...skillData09_tubeDcompetenceB_actif,
+            difficulty: skillData09_tubeDcompetenceB_actif.level,
+            hint: skillData09_tubeDcompetenceB_actif.hint_i18n.fr,
+          }),
+          domainBuilder.buildSkill({
+            ...skillData10_tubeDcompetenceB_archive,
+            difficulty: skillData10_tubeDcompetenceB_archive.level,
+            hint: skillData10_tubeDcompetenceB_archive.hint_i18n.fr,
+          }),
+        ]);
+      });
+    });
+  });
+
+  describe('#findOperativeByCompetenceIds', function () {
+    context('when some operative skills find for competence ids', function () {
+      it('should return skills', async function () {
+        // when
+        const skills = await skillRepository.findOperativeByCompetenceIds([
+          'competenceIdA',
+          'competenceIdB',
+          'competenceInconnue',
+        ]);
+
+        // then
+        expect(skills).to.deepEqualArray([
+          domainBuilder.buildSkill({
+            ...skillData00_tubeAcompetenceA_actif,
+            difficulty: skillData00_tubeAcompetenceA_actif.level,
+            hint: skillData00_tubeAcompetenceA_actif.hint_i18n.fr,
+          }),
+          domainBuilder.buildSkill({
+            ...skillData01_tubeAcompetenceA_archive,
+            difficulty: skillData01_tubeAcompetenceA_archive.level,
+            hint: skillData01_tubeAcompetenceA_archive.hint_i18n.fr,
+          }),
+          domainBuilder.buildSkill({
+            ...skillData03_tubeBcompetenceA_actif,
+            difficulty: skillData03_tubeBcompetenceA_actif.level,
+            hint: skillData03_tubeBcompetenceA_actif.hint_i18n.fr,
+          }),
+          domainBuilder.buildSkill({
+            ...skillData04_tubeBcompetenceA_archive,
+            difficulty: skillData04_tubeBcompetenceA_archive.level,
+            hint: skillData04_tubeBcompetenceA_archive.hint_i18n.fr,
+          }),
+          domainBuilder.buildSkill({
+            ...skillData06_tubeCcompetenceB_actif,
+            difficulty: skillData06_tubeCcompetenceB_actif.level,
+            hint: skillData06_tubeCcompetenceB_actif.hint_i18n.fr,
+          }),
+          domainBuilder.buildSkill({
+            ...skillData07_tubeCcompetenceB_archive,
+            difficulty: skillData07_tubeCcompetenceB_archive.level,
+            hint: skillData07_tubeCcompetenceB_archive.hint_i18n.fr,
+          }),
+          domainBuilder.buildSkill({
+            ...skillData09_tubeDcompetenceB_actif,
+            difficulty: skillData09_tubeDcompetenceB_actif.level,
+            hint: skillData09_tubeDcompetenceB_actif.hint_i18n.fr,
+          }),
+          domainBuilder.buildSkill({
+            ...skillData10_tubeDcompetenceB_archive,
+            difficulty: skillData10_tubeDcompetenceB_archive.level,
+            hint: skillData10_tubeDcompetenceB_archive.hint_i18n.fr,
+          }),
+        ]);
       });
 
-      describe('#list', function () {
-        it('should return all skills', async function () {
-          // when
-          const skills = await skillRepository.list();
+      it('should avoid returning duplicates', async function () {
+        // when
+        const skills = await skillRepository.findOperativeByCompetenceIds([
+          'competenceIdA',
+          'competenceIdB',
+          'competenceInconnue',
+          'competenceIdB',
+        ]);
 
-          // then
-          expect(skills).to.deepEqualArray([
-            domainBuilder.buildSkill({
-              ...skillData00_tubeAcompetenceA_actif,
-              difficulty: skillData00_tubeAcompetenceA_actif.level,
-              hint: skillData00_tubeAcompetenceA_actif.hint_i18n.fr,
-            }),
-            domainBuilder.buildSkill({
-              ...skillData01_tubeAcompetenceA_archive,
-              difficulty: skillData01_tubeAcompetenceA_archive.level,
-              hint: skillData01_tubeAcompetenceA_archive.hint_i18n.fr,
-            }),
-            domainBuilder.buildSkill({
-              ...skillData02_tubeAcompetenceA_perime,
-              difficulty: skillData02_tubeAcompetenceA_perime.level,
-              hint: skillData02_tubeAcompetenceA_perime.hint_i18n.fr,
-            }),
-            domainBuilder.buildSkill({
-              ...skillData03_tubeBcompetenceA_actif,
-              difficulty: skillData03_tubeBcompetenceA_actif.level,
-              hint: skillData03_tubeBcompetenceA_actif.hint_i18n.fr,
-            }),
-            domainBuilder.buildSkill({
-              ...skillData04_tubeBcompetenceA_archive,
-              difficulty: skillData04_tubeBcompetenceA_archive.level,
-              hint: skillData04_tubeBcompetenceA_archive.hint_i18n.fr,
-            }),
-            domainBuilder.buildSkill({
-              ...skillData05_tubeBcompetenceA_perime,
-              difficulty: skillData05_tubeBcompetenceA_perime.level,
-              hint: skillData05_tubeBcompetenceA_perime.hint_i18n.fr,
-            }),
-            domainBuilder.buildSkill({
-              ...skillData06_tubeCcompetenceB_actif,
-              difficulty: skillData06_tubeCcompetenceB_actif.level,
-              hint: skillData06_tubeCcompetenceB_actif.hint_i18n.fr,
-            }),
-            domainBuilder.buildSkill({
-              ...skillData07_tubeCcompetenceB_archive,
-              difficulty: skillData07_tubeCcompetenceB_archive.level,
-              hint: skillData07_tubeCcompetenceB_archive.hint_i18n.fr,
-            }),
-            domainBuilder.buildSkill({
-              ...skillData08_tubeCcompetenceB_perime,
-              difficulty: skillData08_tubeCcompetenceB_perime.level,
-              hint: skillData08_tubeCcompetenceB_perime.hint_i18n.fr,
-            }),
-            domainBuilder.buildSkill({
-              ...skillData09_tubeDcompetenceB_actif,
-              difficulty: skillData09_tubeDcompetenceB_actif.level,
-              hint: skillData09_tubeDcompetenceB_actif.hint_i18n.fr,
-            }),
-            domainBuilder.buildSkill({
-              ...skillData10_tubeDcompetenceB_archive,
-              difficulty: skillData10_tubeDcompetenceB_archive.level,
-              hint: skillData10_tubeDcompetenceB_archive.hint_i18n.fr,
-            }),
-            domainBuilder.buildSkill({
-              ...skillData11_tubeDcompetenceB_perime,
-              difficulty: skillData11_tubeDcompetenceB_perime.level,
-              hint: skillData11_tubeDcompetenceB_perime.hint_i18n.fr,
-            }),
-            domainBuilder.buildSkill({
-              ...skillData12_tubeEcompetenceC_perime,
-              difficulty: skillData12_tubeEcompetenceC_perime.level,
-              hint: skillData12_tubeEcompetenceC_perime.hint_i18n.fr,
-            }),
-          ]);
-        });
+        // then
+        expect(skills).to.deepEqualArray([
+          domainBuilder.buildSkill({
+            ...skillData00_tubeAcompetenceA_actif,
+            difficulty: skillData00_tubeAcompetenceA_actif.level,
+            hint: skillData00_tubeAcompetenceA_actif.hint_i18n.fr,
+          }),
+          domainBuilder.buildSkill({
+            ...skillData01_tubeAcompetenceA_archive,
+            difficulty: skillData01_tubeAcompetenceA_archive.level,
+            hint: skillData01_tubeAcompetenceA_archive.hint_i18n.fr,
+          }),
+          domainBuilder.buildSkill({
+            ...skillData03_tubeBcompetenceA_actif,
+            difficulty: skillData03_tubeBcompetenceA_actif.level,
+            hint: skillData03_tubeBcompetenceA_actif.hint_i18n.fr,
+          }),
+          domainBuilder.buildSkill({
+            ...skillData04_tubeBcompetenceA_archive,
+            difficulty: skillData04_tubeBcompetenceA_archive.level,
+            hint: skillData04_tubeBcompetenceA_archive.hint_i18n.fr,
+          }),
+          domainBuilder.buildSkill({
+            ...skillData06_tubeCcompetenceB_actif,
+            difficulty: skillData06_tubeCcompetenceB_actif.level,
+            hint: skillData06_tubeCcompetenceB_actif.hint_i18n.fr,
+          }),
+          domainBuilder.buildSkill({
+            ...skillData07_tubeCcompetenceB_archive,
+            difficulty: skillData07_tubeCcompetenceB_archive.level,
+            hint: skillData07_tubeCcompetenceB_archive.hint_i18n.fr,
+          }),
+          domainBuilder.buildSkill({
+            ...skillData09_tubeDcompetenceB_actif,
+            difficulty: skillData09_tubeDcompetenceB_actif.level,
+            hint: skillData09_tubeDcompetenceB_actif.hint_i18n.fr,
+          }),
+          domainBuilder.buildSkill({
+            ...skillData10_tubeDcompetenceB_archive,
+            difficulty: skillData10_tubeDcompetenceB_archive.level,
+            hint: skillData10_tubeDcompetenceB_archive.hint_i18n.fr,
+          }),
+        ]);
+      });
+    });
+
+    context('when no operative skills find for competence ids', function () {
+      it('should return an empty array', async function () {
+        // when
+        const skills = await skillRepository.findOperativeByCompetenceIds(['competenceIdC', 'competenceInconnue']);
+
+        // then
+        expect(skills).to.deep.equal([]);
+      });
+    });
+  });
+
+  describe('#findActiveByTubeId', function () {
+    context('when no active skills for given tube id', function () {
+      it('should return an empty array', async function () {
+        // when
+        const skills = await skillRepository.findActiveByTubeId('tubeD');
+
+        // then
+        expect(skills).to.deep.equal([]);
+      });
+    });
+
+    context('when active skills for given tube id', function () {
+      it('should return skills', async function () {
+        // when
+        const skills = await skillRepository.findActiveByTubeId('tubeIdB');
+
+        // then
+        expect(skills).to.deepEqualArray([
+          domainBuilder.buildSkill({
+            ...skillData03_tubeBcompetenceA_actif,
+            difficulty: skillData03_tubeBcompetenceA_actif.level,
+            hint: skillData03_tubeBcompetenceA_actif.hint_i18n.fr,
+          }),
+        ]);
+      });
+    });
+  });
+
+  describe('#findOperativeByTubeId', function () {
+    context('when no operative skills for given tube id', function () {
+      it('should return an empty array', async function () {
+        // when
+        const skills = await skillRepository.findOperativeByTubeId('tubeD');
+
+        // then
+        expect(skills).to.deep.equal([]);
+      });
+    });
+
+    context('when operative skills for given tube id', function () {
+      it('should return skills', async function () {
+        // when
+        const skills = await skillRepository.findOperativeByTubeId('tubeIdB');
+
+        // then
+        expect(skills).to.deepEqualArray([
+          domainBuilder.buildSkill({
+            ...skillData03_tubeBcompetenceA_actif,
+            difficulty: skillData03_tubeBcompetenceA_actif.level,
+            hint: skillData03_tubeBcompetenceA_actif.hint_i18n.fr,
+          }),
+          domainBuilder.buildSkill({
+            ...skillData04_tubeBcompetenceA_archive,
+            difficulty: skillData04_tubeBcompetenceA_archive.level,
+            hint: skillData04_tubeBcompetenceA_archive.hint_i18n.fr,
+          }),
+        ]);
+      });
+    });
+  });
+
+  describe('#findOperativeByIds', function () {
+    context('when no operative skills for given ids', function () {
+      it('should return an empty array', async function () {
+        // when
+        const skills = await skillRepository.findOperativeByIds(['skillId02', 'skillCoucou']);
+
+        // then
+        expect(skills).to.deep.equal([]);
+      });
+    });
+
+    context('when operative skills for given ids', function () {
+      it('should return skills', async function () {
+        // when
+        const skills = await skillRepository.findOperativeByIds([
+          'skillId02',
+          'skillId03',
+          'skillId01',
+          'skillIdCoucou',
+        ]);
+
+        // then
+        expect(skills).to.deepEqualArray([
+          domainBuilder.buildSkill({
+            ...skillData01_tubeAcompetenceA_archive,
+            difficulty: skillData01_tubeAcompetenceA_archive.level,
+            hint: skillData01_tubeAcompetenceA_archive.hint_i18n.fr,
+          }),
+          domainBuilder.buildSkill({
+            ...skillData03_tubeBcompetenceA_actif,
+            difficulty: skillData03_tubeBcompetenceA_actif.level,
+            hint: skillData03_tubeBcompetenceA_actif.hint_i18n.fr,
+          }),
+        ]);
       });
 
-      describe('#findActiveByCompetenceId', function () {
-        context('when no active skills for given competence id', function () {
-          it('should return an empty array', async function () {
-            // when
-            const skills = await skillRepository.findActiveByCompetenceId('competenceIdC');
+      it('should avoid returning duplicates', async function () {
+        // when
+        const skills = await skillRepository.findOperativeByIds([
+          'skillId02',
+          'skillId03',
+          'skillId01',
+          'skillIdCoucou',
+          'skillId01',
+        ]);
 
-            // then
-            expect(skills).to.deep.equal([]);
-          });
-        });
-
-        context('when active skills for given competence id', function () {
-          it('should return skills', async function () {
-            // when
-            const skills = await skillRepository.findActiveByCompetenceId('competenceIdB');
-
-            // then
-            expect(skills).to.deepEqualArray([
-              domainBuilder.buildSkill({
-                ...skillData06_tubeCcompetenceB_actif,
-                difficulty: skillData06_tubeCcompetenceB_actif.level,
-                hint: skillData06_tubeCcompetenceB_actif.hint_i18n.fr,
-              }),
-              domainBuilder.buildSkill({
-                ...skillData09_tubeDcompetenceB_actif,
-                difficulty: skillData09_tubeDcompetenceB_actif.level,
-                hint: skillData09_tubeDcompetenceB_actif.hint_i18n.fr,
-              }),
-            ]);
-          });
-        });
+        // then
+        expect(skills).to.deepEqualArray([
+          domainBuilder.buildSkill({
+            ...skillData01_tubeAcompetenceA_archive,
+            difficulty: skillData01_tubeAcompetenceA_archive.level,
+            hint: skillData01_tubeAcompetenceA_archive.hint_i18n.fr,
+          }),
+          domainBuilder.buildSkill({
+            ...skillData03_tubeBcompetenceA_actif,
+            difficulty: skillData03_tubeBcompetenceA_actif.level,
+            hint: skillData03_tubeBcompetenceA_actif.hint_i18n.fr,
+          }),
+        ]);
       });
+    });
 
-      describe('#findOperativeByCompetenceId', function () {
-        context('when no operative skills for given competence id', function () {
-          it('should return an empty array', async function () {
-            // when
-            const skills = await skillRepository.findOperativeByCompetenceId('competenceIdC');
+    context('when invalid value given for ids argument', function () {
+      it('should return an empty array', async function () {
+        // when
+        const skills1 = await skillRepository.findOperativeByIds(null);
+        const skills2 = await skillRepository.findOperativeByIds(undefined);
+        const skills3 = await skillRepository.findOperativeByIds([]);
 
-            // then
-            expect(skills).to.deep.equal([]);
-          });
-        });
-
-        context('when operative skills for given competence id', function () {
-          it('should return skills', async function () {
-            // when
-            const skills = await skillRepository.findOperativeByCompetenceId('competenceIdB');
-
-            // then
-            expect(skills).to.deepEqualArray([
-              domainBuilder.buildSkill({
-                ...skillData06_tubeCcompetenceB_actif,
-                difficulty: skillData06_tubeCcompetenceB_actif.level,
-                hint: skillData06_tubeCcompetenceB_actif.hint_i18n.fr,
-              }),
-              domainBuilder.buildSkill({
-                ...skillData07_tubeCcompetenceB_archive,
-                difficulty: skillData07_tubeCcompetenceB_archive.level,
-                hint: skillData07_tubeCcompetenceB_archive.hint_i18n.fr,
-              }),
-              domainBuilder.buildSkill({
-                ...skillData09_tubeDcompetenceB_actif,
-                difficulty: skillData09_tubeDcompetenceB_actif.level,
-                hint: skillData09_tubeDcompetenceB_actif.hint_i18n.fr,
-              }),
-              domainBuilder.buildSkill({
-                ...skillData10_tubeDcompetenceB_archive,
-                difficulty: skillData10_tubeDcompetenceB_archive.level,
-                hint: skillData10_tubeDcompetenceB_archive.hint_i18n.fr,
-              }),
-            ]);
-          });
-        });
+        // then
+        expect(skills1).to.deep.equal([]);
+        expect(skills2).to.deep.equal([]);
+        expect(skills3).to.deep.equal([]);
       });
+    });
+  });
 
-      describe('#findOperativeByCompetenceIds', function () {
-        context('when some operative skills find for competence ids', function () {
-          it('should return skills', async function () {
-            // when
-            const skills = await skillRepository.findOperativeByCompetenceIds([
-              'competenceIdA',
-              'competenceIdB',
-              'competenceInconnue',
-            ]);
+  describe('#get', function () {
+    context('when no skill for given id', function () {
+      it('should throw a NotFoundError', async function () {
+        // when
+        const err = await catchErr(skillRepository.get, skillRepository)('skillCoucou');
 
-            // then
-            expect(skills).to.deepEqualArray([
-              domainBuilder.buildSkill({
-                ...skillData00_tubeAcompetenceA_actif,
-                difficulty: skillData00_tubeAcompetenceA_actif.level,
-                hint: skillData00_tubeAcompetenceA_actif.hint_i18n.fr,
-              }),
-              domainBuilder.buildSkill({
-                ...skillData01_tubeAcompetenceA_archive,
-                difficulty: skillData01_tubeAcompetenceA_archive.level,
-                hint: skillData01_tubeAcompetenceA_archive.hint_i18n.fr,
-              }),
-              domainBuilder.buildSkill({
-                ...skillData03_tubeBcompetenceA_actif,
-                difficulty: skillData03_tubeBcompetenceA_actif.level,
-                hint: skillData03_tubeBcompetenceA_actif.hint_i18n.fr,
-              }),
-              domainBuilder.buildSkill({
-                ...skillData04_tubeBcompetenceA_archive,
-                difficulty: skillData04_tubeBcompetenceA_archive.level,
-                hint: skillData04_tubeBcompetenceA_archive.hint_i18n.fr,
-              }),
-              domainBuilder.buildSkill({
-                ...skillData06_tubeCcompetenceB_actif,
-                difficulty: skillData06_tubeCcompetenceB_actif.level,
-                hint: skillData06_tubeCcompetenceB_actif.hint_i18n.fr,
-              }),
-              domainBuilder.buildSkill({
-                ...skillData07_tubeCcompetenceB_archive,
-                difficulty: skillData07_tubeCcompetenceB_archive.level,
-                hint: skillData07_tubeCcompetenceB_archive.hint_i18n.fr,
-              }),
-              domainBuilder.buildSkill({
-                ...skillData09_tubeDcompetenceB_actif,
-                difficulty: skillData09_tubeDcompetenceB_actif.level,
-                hint: skillData09_tubeDcompetenceB_actif.hint_i18n.fr,
-              }),
-              domainBuilder.buildSkill({
-                ...skillData10_tubeDcompetenceB_archive,
-                difficulty: skillData10_tubeDcompetenceB_archive.level,
-                hint: skillData10_tubeDcompetenceB_archive.hint_i18n.fr,
-              }),
-            ]);
-          });
-
-          it('should avoid returning duplicates', async function () {
-            // when
-            const skills = await skillRepository.findOperativeByCompetenceIds([
-              'competenceIdA',
-              'competenceIdB',
-              'competenceInconnue',
-              'competenceIdB',
-            ]);
-
-            // then
-            expect(skills).to.deepEqualArray([
-              domainBuilder.buildSkill({
-                ...skillData00_tubeAcompetenceA_actif,
-                difficulty: skillData00_tubeAcompetenceA_actif.level,
-                hint: skillData00_tubeAcompetenceA_actif.hint_i18n.fr,
-              }),
-              domainBuilder.buildSkill({
-                ...skillData01_tubeAcompetenceA_archive,
-                difficulty: skillData01_tubeAcompetenceA_archive.level,
-                hint: skillData01_tubeAcompetenceA_archive.hint_i18n.fr,
-              }),
-              domainBuilder.buildSkill({
-                ...skillData03_tubeBcompetenceA_actif,
-                difficulty: skillData03_tubeBcompetenceA_actif.level,
-                hint: skillData03_tubeBcompetenceA_actif.hint_i18n.fr,
-              }),
-              domainBuilder.buildSkill({
-                ...skillData04_tubeBcompetenceA_archive,
-                difficulty: skillData04_tubeBcompetenceA_archive.level,
-                hint: skillData04_tubeBcompetenceA_archive.hint_i18n.fr,
-              }),
-              domainBuilder.buildSkill({
-                ...skillData06_tubeCcompetenceB_actif,
-                difficulty: skillData06_tubeCcompetenceB_actif.level,
-                hint: skillData06_tubeCcompetenceB_actif.hint_i18n.fr,
-              }),
-              domainBuilder.buildSkill({
-                ...skillData07_tubeCcompetenceB_archive,
-                difficulty: skillData07_tubeCcompetenceB_archive.level,
-                hint: skillData07_tubeCcompetenceB_archive.hint_i18n.fr,
-              }),
-              domainBuilder.buildSkill({
-                ...skillData09_tubeDcompetenceB_actif,
-                difficulty: skillData09_tubeDcompetenceB_actif.level,
-                hint: skillData09_tubeDcompetenceB_actif.hint_i18n.fr,
-              }),
-              domainBuilder.buildSkill({
-                ...skillData10_tubeDcompetenceB_archive,
-                difficulty: skillData10_tubeDcompetenceB_archive.level,
-                hint: skillData10_tubeDcompetenceB_archive.hint_i18n.fr,
-              }),
-            ]);
-          });
-        });
-
-        context('when no operative skills find for competence ids', function () {
-          it('should return an empty array', async function () {
-            // when
-            const skills = await skillRepository.findOperativeByCompetenceIds(['competenceIdC', 'competenceInconnue']);
-
-            // then
-            expect(skills).to.deep.equal([]);
-          });
-        });
+        // then
+        expect(err).to.be.instanceOf(NotFoundError);
+        expect(err.message).to.equal('Erreur, acquis introuvable');
       });
+    });
 
-      describe('#findActiveByTubeId', function () {
-        context('when no active skills for given tube id', function () {
-          it('should return an empty array', async function () {
-            // when
-            const skills = await skillRepository.findActiveByTubeId('tubeD');
-
-            // then
-            expect(skills).to.deep.equal([]);
-          });
-        });
-
-        context('when active skills for given tube id', function () {
-          it('should return skills', async function () {
-            // when
-            const skills = await skillRepository.findActiveByTubeId('tubeIdB');
-
-            // then
-            expect(skills).to.deepEqualArray([
-              domainBuilder.buildSkill({
-                ...skillData03_tubeBcompetenceA_actif,
-                difficulty: skillData03_tubeBcompetenceA_actif.level,
-                hint: skillData03_tubeBcompetenceA_actif.hint_i18n.fr,
-              }),
-            ]);
-          });
-        });
-      });
-
-      describe('#findOperativeByTubeId', function () {
-        context('when no operative skills for given tube id', function () {
-          it('should return an empty array', async function () {
-            // when
-            const skills = await skillRepository.findOperativeByTubeId('tubeD');
-
-            // then
-            expect(skills).to.deep.equal([]);
-          });
-        });
-
-        context('when operative skills for given tube id', function () {
-          it('should return skills', async function () {
-            // when
-            const skills = await skillRepository.findOperativeByTubeId('tubeIdB');
-
-            // then
-            expect(skills).to.deepEqualArray([
-              domainBuilder.buildSkill({
-                ...skillData03_tubeBcompetenceA_actif,
-                difficulty: skillData03_tubeBcompetenceA_actif.level,
-                hint: skillData03_tubeBcompetenceA_actif.hint_i18n.fr,
-              }),
-              domainBuilder.buildSkill({
-                ...skillData04_tubeBcompetenceA_archive,
-                difficulty: skillData04_tubeBcompetenceA_archive.level,
-                hint: skillData04_tubeBcompetenceA_archive.hint_i18n.fr,
-              }),
-            ]);
-          });
-        });
-      });
-
-      describe('#findOperativeByIds', function () {
-        context('when no operative skills for given ids', function () {
-          it('should return an empty array', async function () {
-            // when
-            const skills = await skillRepository.findOperativeByIds(['skillId02', 'skillCoucou']);
-
-            // then
-            expect(skills).to.deep.equal([]);
-          });
-        });
-
-        context('when operative skills for given ids', function () {
-          it('should return skills', async function () {
-            // when
-            const skills = await skillRepository.findOperativeByIds([
-              'skillId02',
-              'skillId03',
-              'skillId01',
-              'skillIdCoucou',
-            ]);
-
-            // then
-            expect(skills).to.deepEqualArray([
-              domainBuilder.buildSkill({
-                ...skillData01_tubeAcompetenceA_archive,
-                difficulty: skillData01_tubeAcompetenceA_archive.level,
-                hint: skillData01_tubeAcompetenceA_archive.hint_i18n.fr,
-              }),
-              domainBuilder.buildSkill({
-                ...skillData03_tubeBcompetenceA_actif,
-                difficulty: skillData03_tubeBcompetenceA_actif.level,
-                hint: skillData03_tubeBcompetenceA_actif.hint_i18n.fr,
-              }),
-            ]);
-          });
-
-          it('should avoid returning duplicates', async function () {
-            // when
-            const skills = await skillRepository.findOperativeByIds([
-              'skillId02',
-              'skillId03',
-              'skillId01',
-              'skillIdCoucou',
-              'skillId01',
-            ]);
-
-            // then
-            expect(skills).to.deepEqualArray([
-              domainBuilder.buildSkill({
-                ...skillData01_tubeAcompetenceA_archive,
-                difficulty: skillData01_tubeAcompetenceA_archive.level,
-                hint: skillData01_tubeAcompetenceA_archive.hint_i18n.fr,
-              }),
-              domainBuilder.buildSkill({
-                ...skillData03_tubeBcompetenceA_actif,
-                difficulty: skillData03_tubeBcompetenceA_actif.level,
-                hint: skillData03_tubeBcompetenceA_actif.hint_i18n.fr,
-              }),
-            ]);
-          });
-        });
-
-        context('when invalid value given for ids argument', function () {
-          it('should return an empty array', async function () {
-            // when
-            const skills1 = await skillRepository.findOperativeByIds(null);
-            const skills2 = await skillRepository.findOperativeByIds(undefined);
-            const skills3 = await skillRepository.findOperativeByIds([]);
-
-            // then
-            expect(skills1).to.deep.equal([]);
-            expect(skills2).to.deep.equal([]);
-            expect(skills3).to.deep.equal([]);
-          });
-        });
-      });
-
-      describe('#get', function () {
-        context('when no skill for given id', function () {
-          it('should throw a NotFoundError', async function () {
-            // when
-            const err = await catchErr(skillRepository.get, skillRepository)('skillCoucou');
-
-            // then
-            expect(err).to.be.instanceOf(NotFoundError);
-            expect(err.message).to.equal('Erreur, acquis introuvable');
-          });
-        });
-
-        context('when skill for given id', function () {
-          context('when locale provided', function () {
-            context('when no translations for provided locale', function () {
-              context('when no fallback asked', function () {
-                it('should return skill with null translations', async function () {
-                  // when
-                  const skills = await skillRepository.get('skillId03', { locale: 'nl', useFallback: false });
-
-                  // then
-                  expect(skills).to.deepEqualInstance(
-                    domainBuilder.buildSkill({
-                      ...skillData03_tubeBcompetenceA_actif,
-                      difficulty: skillData03_tubeBcompetenceA_actif.level,
-                      hint: null,
-                    }),
-                  );
-                });
-              });
-
-              context('when fallback asked', function () {
-                it('should return skill with fallback default locale FR', async function () {
-                  // when
-                  const skills = await skillRepository.get('skillId03', { locale: 'nl', useFallback: true });
-
-                  // then
-                  expect(skills).to.deepEqualInstance(
-                    domainBuilder.buildSkill({
-                      ...skillData03_tubeBcompetenceA_actif,
-                      difficulty: skillData03_tubeBcompetenceA_actif.level,
-                      hint: skillData03_tubeBcompetenceA_actif.hint_i18n.fr,
-                    }),
-                  );
-                });
-              });
-            });
-
-            context('when translation exist for provided locale', function () {
-              it('should return skill translated', async function () {
-                // when
-                const skills = await skillRepository.get('skillId03', { locale: 'en', useFallback: false });
-
-                // then
-                expect(skills).to.deepEqualInstance(
-                  domainBuilder.buildSkill({
-                    ...skillData03_tubeBcompetenceA_actif,
-                    difficulty: skillData03_tubeBcompetenceA_actif.level,
-                    hint: skillData03_tubeBcompetenceA_actif.hint_i18n.en,
-                  }),
-                );
-              });
-            });
-          });
-
-          context('when no locale provided', function () {
-            it('should return skill with default translation in locale FR', async function () {
+    context('when skill for given id', function () {
+      context('when locale provided', function () {
+        context('when no translations for provided locale', function () {
+          context('when no fallback asked', function () {
+            it('should return skill with null translations', async function () {
               // when
-              const skills = await skillRepository.get('skillId03');
+              const skills = await skillRepository.get('skillId03', { locale: 'nl', useFallback: false });
+
+              // then
+              expect(skills).to.deepEqualInstance(
+                domainBuilder.buildSkill({
+                  ...skillData03_tubeBcompetenceA_actif,
+                  difficulty: skillData03_tubeBcompetenceA_actif.level,
+                  hint: null,
+                }),
+              );
+            });
+          });
+
+          context('when fallback asked', function () {
+            it('should return skill with fallback default locale FR', async function () {
+              // when
+              const skills = await skillRepository.get('skillId03', { locale: 'nl', useFallback: true });
 
               // then
               expect(skills).to.deepEqualInstance(
@@ -706,185 +665,217 @@ describe('Integration | Repository | skill-repository', function () {
             });
           });
         });
-      });
 
-      describe('#findActiveByRecordIds', function () {
-        context('when no active skills for given ids', function () {
-          it('should return an empty array', async function () {
+        context('when translation exist for provided locale', function () {
+          it('should return skill translated', async function () {
             // when
-            const skills = await skillRepository.findActiveByRecordIds(['skillId01', 'skillCoucou']);
+            const skills = await skillRepository.get('skillId03', { locale: 'en', useFallback: false });
 
             // then
-            expect(skills).to.deep.equal([]);
-          });
-        });
-
-        context('when active skills for given ids', function () {
-          it('should return skills', async function () {
-            // when
-            const skills = await skillRepository.findActiveByRecordIds([
-              'skillId02',
-              'skillId03',
-              'skillId01',
-              'skillId00',
-              'skillIdCoucou',
-            ]);
-
-            // then
-            expect(skills).to.deepEqualArray([
-              domainBuilder.buildSkill({
-                ...skillData00_tubeAcompetenceA_actif,
-                difficulty: skillData00_tubeAcompetenceA_actif.level,
-                hint: skillData00_tubeAcompetenceA_actif.hint_i18n.fr,
-              }),
+            expect(skills).to.deepEqualInstance(
               domainBuilder.buildSkill({
                 ...skillData03_tubeBcompetenceA_actif,
                 difficulty: skillData03_tubeBcompetenceA_actif.level,
-                hint: skillData03_tubeBcompetenceA_actif.hint_i18n.fr,
+                hint: skillData03_tubeBcompetenceA_actif.hint_i18n.en,
               }),
-            ]);
-          });
-
-          it('should avoid returning duplicates', async function () {
-            // when
-            const skills = await skillRepository.findActiveByRecordIds([
-              'skillId02',
-              'skillId03',
-              'skillId01',
-              'skillId00',
-              'skillIdCoucou',
-              'skillId00',
-            ]);
-
-            // then
-            expect(skills).to.deepEqualArray([
-              domainBuilder.buildSkill({
-                ...skillData00_tubeAcompetenceA_actif,
-                difficulty: skillData00_tubeAcompetenceA_actif.level,
-                hint: skillData00_tubeAcompetenceA_actif.hint_i18n.fr,
-              }),
-              domainBuilder.buildSkill({
-                ...skillData03_tubeBcompetenceA_actif,
-                difficulty: skillData03_tubeBcompetenceA_actif.level,
-                hint: skillData03_tubeBcompetenceA_actif.hint_i18n.fr,
-              }),
-            ]);
-          });
-        });
-
-        context('when invalid value given for ids argument', function () {
-          it('should return an empty array', async function () {
-            // when
-            const skills1 = await skillRepository.findActiveByRecordIds(null);
-            const skills2 = await skillRepository.findActiveByRecordIds(undefined);
-            const skills3 = await skillRepository.findActiveByRecordIds([]);
-
-            // then
-            expect(skills1).to.deep.equal([]);
-            expect(skills2).to.deep.equal([]);
-            expect(skills3).to.deep.equal([]);
+            );
           });
         });
       });
 
-      describe('#findByRecordIds', function () {
-        context('when no skills for given ids', function () {
-          it('should return an empty array', async function () {
-            // when
-            const skills = await skillRepository.findByRecordIds(['skillCoucou']);
+      context('when no locale provided', function () {
+        it('should return skill with default translation in locale FR', async function () {
+          // when
+          const skills = await skillRepository.get('skillId03');
 
-            // then
-            expect(skills).to.deep.equal([]);
-          });
-        });
-
-        context('when skills for given ids', function () {
-          it('should return skills', async function () {
-            // when
-            const skills = await skillRepository.findByRecordIds([
-              'skillId02',
-              'skillId03',
-              'skillId01',
-              'skillId00',
-              'skillIdCoucou',
-            ]);
-
-            // then
-            expect(skills).to.deepEqualArray([
-              domainBuilder.buildSkill({
-                ...skillData00_tubeAcompetenceA_actif,
-                difficulty: skillData00_tubeAcompetenceA_actif.level,
-                hint: skillData00_tubeAcompetenceA_actif.hint_i18n.fr,
-              }),
-              domainBuilder.buildSkill({
-                ...skillData01_tubeAcompetenceA_archive,
-                difficulty: skillData01_tubeAcompetenceA_archive.level,
-                hint: skillData01_tubeAcompetenceA_archive.hint_i18n.fr,
-              }),
-              domainBuilder.buildSkill({
-                ...skillData02_tubeAcompetenceA_perime,
-                difficulty: skillData02_tubeAcompetenceA_perime.level,
-                hint: skillData02_tubeAcompetenceA_perime.hint_i18n.fr,
-              }),
-              domainBuilder.buildSkill({
-                ...skillData03_tubeBcompetenceA_actif,
-                difficulty: skillData03_tubeBcompetenceA_actif.level,
-                hint: skillData03_tubeBcompetenceA_actif.hint_i18n.fr,
-              }),
-            ]);
-          });
-
-          it('should avoid returning duplicates', async function () {
-            // when
-            const skills = await skillRepository.findByRecordIds([
-              'skillId02',
-              'skillId03',
-              'skillId01',
-              'skillId00',
-              'skillIdCoucou',
-              'skillId00',
-            ]);
-
-            // then
-            expect(skills).to.deepEqualArray([
-              domainBuilder.buildSkill({
-                ...skillData00_tubeAcompetenceA_actif,
-                difficulty: skillData00_tubeAcompetenceA_actif.level,
-                hint: skillData00_tubeAcompetenceA_actif.hint_i18n.fr,
-              }),
-              domainBuilder.buildSkill({
-                ...skillData01_tubeAcompetenceA_archive,
-                difficulty: skillData01_tubeAcompetenceA_archive.level,
-                hint: skillData01_tubeAcompetenceA_archive.hint_i18n.fr,
-              }),
-              domainBuilder.buildSkill({
-                ...skillData02_tubeAcompetenceA_perime,
-                difficulty: skillData02_tubeAcompetenceA_perime.level,
-                hint: skillData02_tubeAcompetenceA_perime.hint_i18n.fr,
-              }),
-              domainBuilder.buildSkill({
-                ...skillData03_tubeBcompetenceA_actif,
-                difficulty: skillData03_tubeBcompetenceA_actif.level,
-                hint: skillData03_tubeBcompetenceA_actif.hint_i18n.fr,
-              }),
-            ]);
-          });
-        });
-
-        context('when invalid value given for ids argument', function () {
-          it('should return an empty array', async function () {
-            // when
-            const skills1 = await skillRepository.findByRecordIds(null);
-            const skills2 = await skillRepository.findByRecordIds(undefined);
-            const skills3 = await skillRepository.findByRecordIds([]);
-
-            // then
-            expect(skills1).to.deep.equal([]);
-            expect(skills2).to.deep.equal([]);
-            expect(skills3).to.deep.equal([]);
-          });
+          // then
+          expect(skills).to.deepEqualInstance(
+            domainBuilder.buildSkill({
+              ...skillData03_tubeBcompetenceA_actif,
+              difficulty: skillData03_tubeBcompetenceA_actif.level,
+              hint: skillData03_tubeBcompetenceA_actif.hint_i18n.fr,
+            }),
+          );
         });
       });
-    }),
-  );
+    });
+  });
+
+  describe('#findActiveByRecordIds', function () {
+    context('when no active skills for given ids', function () {
+      it('should return an empty array', async function () {
+        // when
+        const skills = await skillRepository.findActiveByRecordIds(['skillId01', 'skillCoucou']);
+
+        // then
+        expect(skills).to.deep.equal([]);
+      });
+    });
+
+    context('when active skills for given ids', function () {
+      it('should return skills', async function () {
+        // when
+        const skills = await skillRepository.findActiveByRecordIds([
+          'skillId02',
+          'skillId03',
+          'skillId01',
+          'skillId00',
+          'skillIdCoucou',
+        ]);
+
+        // then
+        expect(skills).to.deepEqualArray([
+          domainBuilder.buildSkill({
+            ...skillData00_tubeAcompetenceA_actif,
+            difficulty: skillData00_tubeAcompetenceA_actif.level,
+            hint: skillData00_tubeAcompetenceA_actif.hint_i18n.fr,
+          }),
+          domainBuilder.buildSkill({
+            ...skillData03_tubeBcompetenceA_actif,
+            difficulty: skillData03_tubeBcompetenceA_actif.level,
+            hint: skillData03_tubeBcompetenceA_actif.hint_i18n.fr,
+          }),
+        ]);
+      });
+
+      it('should avoid returning duplicates', async function () {
+        // when
+        const skills = await skillRepository.findActiveByRecordIds([
+          'skillId02',
+          'skillId03',
+          'skillId01',
+          'skillId00',
+          'skillIdCoucou',
+          'skillId00',
+        ]);
+
+        // then
+        expect(skills).to.deepEqualArray([
+          domainBuilder.buildSkill({
+            ...skillData00_tubeAcompetenceA_actif,
+            difficulty: skillData00_tubeAcompetenceA_actif.level,
+            hint: skillData00_tubeAcompetenceA_actif.hint_i18n.fr,
+          }),
+          domainBuilder.buildSkill({
+            ...skillData03_tubeBcompetenceA_actif,
+            difficulty: skillData03_tubeBcompetenceA_actif.level,
+            hint: skillData03_tubeBcompetenceA_actif.hint_i18n.fr,
+          }),
+        ]);
+      });
+    });
+
+    context('when invalid value given for ids argument', function () {
+      it('should return an empty array', async function () {
+        // when
+        const skills1 = await skillRepository.findActiveByRecordIds(null);
+        const skills2 = await skillRepository.findActiveByRecordIds(undefined);
+        const skills3 = await skillRepository.findActiveByRecordIds([]);
+
+        // then
+        expect(skills1).to.deep.equal([]);
+        expect(skills2).to.deep.equal([]);
+        expect(skills3).to.deep.equal([]);
+      });
+    });
+  });
+
+  describe('#findByRecordIds', function () {
+    context('when no skills for given ids', function () {
+      it('should return an empty array', async function () {
+        // when
+        const skills = await skillRepository.findByRecordIds(['skillCoucou']);
+
+        // then
+        expect(skills).to.deep.equal([]);
+      });
+    });
+
+    context('when skills for given ids', function () {
+      it('should return skills', async function () {
+        // when
+        const skills = await skillRepository.findByRecordIds([
+          'skillId02',
+          'skillId03',
+          'skillId01',
+          'skillId00',
+          'skillIdCoucou',
+        ]);
+
+        // then
+        expect(skills).to.deepEqualArray([
+          domainBuilder.buildSkill({
+            ...skillData00_tubeAcompetenceA_actif,
+            difficulty: skillData00_tubeAcompetenceA_actif.level,
+            hint: skillData00_tubeAcompetenceA_actif.hint_i18n.fr,
+          }),
+          domainBuilder.buildSkill({
+            ...skillData01_tubeAcompetenceA_archive,
+            difficulty: skillData01_tubeAcompetenceA_archive.level,
+            hint: skillData01_tubeAcompetenceA_archive.hint_i18n.fr,
+          }),
+          domainBuilder.buildSkill({
+            ...skillData02_tubeAcompetenceA_perime,
+            difficulty: skillData02_tubeAcompetenceA_perime.level,
+            hint: skillData02_tubeAcompetenceA_perime.hint_i18n.fr,
+          }),
+          domainBuilder.buildSkill({
+            ...skillData03_tubeBcompetenceA_actif,
+            difficulty: skillData03_tubeBcompetenceA_actif.level,
+            hint: skillData03_tubeBcompetenceA_actif.hint_i18n.fr,
+          }),
+        ]);
+      });
+
+      it('should avoid returning duplicates', async function () {
+        // when
+        const skills = await skillRepository.findByRecordIds([
+          'skillId02',
+          'skillId03',
+          'skillId01',
+          'skillId00',
+          'skillIdCoucou',
+          'skillId00',
+        ]);
+
+        // then
+        expect(skills).to.deepEqualArray([
+          domainBuilder.buildSkill({
+            ...skillData00_tubeAcompetenceA_actif,
+            difficulty: skillData00_tubeAcompetenceA_actif.level,
+            hint: skillData00_tubeAcompetenceA_actif.hint_i18n.fr,
+          }),
+          domainBuilder.buildSkill({
+            ...skillData01_tubeAcompetenceA_archive,
+            difficulty: skillData01_tubeAcompetenceA_archive.level,
+            hint: skillData01_tubeAcompetenceA_archive.hint_i18n.fr,
+          }),
+          domainBuilder.buildSkill({
+            ...skillData02_tubeAcompetenceA_perime,
+            difficulty: skillData02_tubeAcompetenceA_perime.level,
+            hint: skillData02_tubeAcompetenceA_perime.hint_i18n.fr,
+          }),
+          domainBuilder.buildSkill({
+            ...skillData03_tubeBcompetenceA_actif,
+            difficulty: skillData03_tubeBcompetenceA_actif.level,
+            hint: skillData03_tubeBcompetenceA_actif.hint_i18n.fr,
+          }),
+        ]);
+      });
+    });
+
+    context('when invalid value given for ids argument', function () {
+      it('should return an empty array', async function () {
+        // when
+        const skills1 = await skillRepository.findByRecordIds(null);
+        const skills2 = await skillRepository.findByRecordIds(undefined);
+        const skills3 = await skillRepository.findByRecordIds([]);
+
+        // then
+        expect(skills1).to.deep.equal([]);
+        expect(skills2).to.deep.equal([]);
+        expect(skills3).to.deep.equal([]);
+      });
+    });
+  });
 });

--- a/api/tests/shared/integration/infrastructure/repositories/thematic-repository_test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/thematic-repository_test.js
@@ -1,6 +1,5 @@
-import { config } from '../../../../../src/shared/config.js';
 import * as thematicRepository from '../../../../../src/shared/infrastructure/repositories/thematic-repository.js';
-import { databaseBuilder, domainBuilder, expect, sinon } from '../../../../test-helper.js';
+import { databaseBuilder, domainBuilder, expect } from '../../../../test-helper.js';
 
 describe('Integration | Repository | thematic-repository', function () {
   const thematicData0 = {
@@ -39,227 +38,219 @@ describe('Integration | Repository | thematic-repository', function () {
     await databaseBuilder.commit();
   });
 
-  [false, true].forEach((cacheResultIds) =>
-    describe(`when cacheResultIds is ${cacheResultIds}`, function () {
-      beforeEach(function () {
-        sinon.stub(config.lcms, 'cacheResultIds').value(cacheResultIds);
+  describe('#list', function () {
+    context('when no locale provided', function () {
+      it('should return all thematics translated by default with locale FR-FR', async function () {
+        // when
+        const thematics = await thematicRepository.list();
+
+        // then
+        expect(thematics).to.deepEqualArray([
+          domainBuilder.buildThematic({
+            ...thematicData0,
+            name: thematicData0.name_i18n.fr,
+          }),
+          domainBuilder.buildThematic({
+            ...thematicData1,
+            name: thematicData1.name_i18n.fr,
+          }),
+          domainBuilder.buildThematic({
+            ...thematicData2,
+            name: thematicData2.name_i18n.fr,
+          }),
+          domainBuilder.buildThematic({
+            ...thematicData3,
+            name: thematicData3.name_i18n.fr,
+          }),
+        ]);
       });
+    });
 
-      describe('#list', function () {
-        context('when no locale provided', function () {
-          it('should return all thematics translated by default with locale FR-FR', async function () {
-            // when
-            const thematics = await thematicRepository.list();
+    context('when a locale is provided', function () {
+      it('should return all thematics translated in the given locale or with fallback FR-FR', async function () {
+        // when
+        const thematics = await thematicRepository.list({ locale: 'en' });
 
-            // then
-            expect(thematics).to.deepEqualArray([
-              domainBuilder.buildThematic({
-                ...thematicData0,
-                name: thematicData0.name_i18n.fr,
-              }),
-              domainBuilder.buildThematic({
-                ...thematicData1,
-                name: thematicData1.name_i18n.fr,
-              }),
-              domainBuilder.buildThematic({
-                ...thematicData2,
-                name: thematicData2.name_i18n.fr,
-              }),
-              domainBuilder.buildThematic({
-                ...thematicData3,
-                name: thematicData3.name_i18n.fr,
-              }),
-            ]);
-          });
-        });
-
-        context('when a locale is provided', function () {
-          it('should return all thematics translated in the given locale or with fallback FR-FR', async function () {
-            // when
-            const thematics = await thematicRepository.list({ locale: 'en' });
-
-            // then
-            expect(thematics).to.deepEqualArray([
-              domainBuilder.buildThematic({
-                ...thematicData0,
-                name: thematicData0.name_i18n.en,
-              }),
-              domainBuilder.buildThematic({
-                ...thematicData1,
-                name: thematicData1.name_i18n.fr,
-              }),
-              domainBuilder.buildThematic({
-                ...thematicData2,
-                name: thematicData2.name_i18n.en,
-              }),
-              domainBuilder.buildThematic({
-                ...thematicData3,
-                name: thematicData3.name_i18n.fr,
-              }),
-            ]);
-          });
-        });
+        // then
+        expect(thematics).to.deepEqualArray([
+          domainBuilder.buildThematic({
+            ...thematicData0,
+            name: thematicData0.name_i18n.en,
+          }),
+          domainBuilder.buildThematic({
+            ...thematicData1,
+            name: thematicData1.name_i18n.fr,
+          }),
+          domainBuilder.buildThematic({
+            ...thematicData2,
+            name: thematicData2.name_i18n.en,
+          }),
+          domainBuilder.buildThematic({
+            ...thematicData3,
+            name: thematicData3.name_i18n.fr,
+          }),
+        ]);
       });
+    });
+  });
 
-      describe('#findByCompetenceIds', function () {
-        context('when thematics found by competence ids', function () {
-          context('when no locale provided', function () {
-            it('should return all thematics found translated in default locale FR given by their ids', async function () {
-              // when
-              const thematics = await thematicRepository.findByCompetenceIds(['competenceIdB', 'competenceIdA']);
+  describe('#findByCompetenceIds', function () {
+    context('when thematics found by competence ids', function () {
+      context('when no locale provided', function () {
+        it('should return all thematics found translated in default locale FR given by their ids', async function () {
+          // when
+          const thematics = await thematicRepository.findByCompetenceIds(['competenceIdB', 'competenceIdA']);
 
-              // then
-              expect(thematics).to.deepEqualArray([
-                domainBuilder.buildThematic({
-                  ...thematicData0,
-                  name: thematicData0.name_i18n.fr,
-                }),
-                domainBuilder.buildThematic({
-                  ...thematicData1,
-                  name: thematicData1.name_i18n.fr,
-                }),
-                domainBuilder.buildThematic({
-                  ...thematicData2,
-                  name: thematicData2.name_i18n.fr,
-                }),
-              ]);
-            });
-          });
-
-          context('when a locale is provided', function () {
-            it('should return all thematics found translated in provided locale of fallback to default locale FR', async function () {
-              // when
-              const thematics = await thematicRepository.findByCompetenceIds(['competenceIdB', 'competenceIdA'], 'en');
-
-              // then
-              expect(thematics).to.deepEqualArray([
-                domainBuilder.buildThematic({
-                  ...thematicData0,
-                  name: thematicData0.name_i18n.en,
-                }),
-                domainBuilder.buildThematic({
-                  ...thematicData1,
-                  name: thematicData1.name_i18n.fr,
-                }),
-                domainBuilder.buildThematic({
-                  ...thematicData2,
-                  name: thematicData2.name_i18n.en,
-                }),
-              ]);
-            });
-          });
-
-          it('should ignore null and duplicates', async function () {
-            // when
-            const thematics = await thematicRepository.findByCompetenceIds([
-              'competenceIdB',
-              'competenceIdA',
-              'competenceCOUCOUMAMAN',
-              'competenceIdB',
-            ]);
-
-            // then
-            expect(thematics).to.deepEqualArray([
-              domainBuilder.buildThematic({
-                ...thematicData0,
-                name: thematicData0.name_i18n.fr,
-              }),
-              domainBuilder.buildThematic({
-                ...thematicData1,
-                name: thematicData1.name_i18n.fr,
-              }),
-              domainBuilder.buildThematic({
-                ...thematicData2,
-                name: thematicData2.name_i18n.fr,
-              }),
-            ]);
-          });
-        });
-
-        context('when no thematics found for given competence ids', function () {
-          it('should return an empty array', async function () {
-            // when
-            const thematics = await thematicRepository.findByCompetenceIds(['recCouCouRoRo', 'recCouCouGabDou']);
-
-            // then
-            expect(thematics).to.deep.equal([]);
-          });
+          // then
+          expect(thematics).to.deepEqualArray([
+            domainBuilder.buildThematic({
+              ...thematicData0,
+              name: thematicData0.name_i18n.fr,
+            }),
+            domainBuilder.buildThematic({
+              ...thematicData1,
+              name: thematicData1.name_i18n.fr,
+            }),
+            domainBuilder.buildThematic({
+              ...thematicData2,
+              name: thematicData2.name_i18n.fr,
+            }),
+          ]);
         });
       });
 
-      describe('#findByRecordIds', function () {
-        context('when thematics found by ids', function () {
-          context('when no locale provided', function () {
-            it('should return all thematics found translated in default locale FR given by their ids ordered by name', async function () {
-              // when
-              const thematics = await thematicRepository.findByRecordIds(['thematicId3', 'thematicId0']);
+      context('when a locale is provided', function () {
+        it('should return all thematics found translated in provided locale of fallback to default locale FR', async function () {
+          // when
+          const thematics = await thematicRepository.findByCompetenceIds(['competenceIdB', 'competenceIdA'], 'en');
 
-              // then
-              expect(thematics).to.deepEqualArray([
-                domainBuilder.buildThematic({
-                  ...thematicData0,
-                  name: thematicData0.name_i18n.fr,
-                }),
-                domainBuilder.buildThematic({
-                  ...thematicData3,
-                  name: thematicData3.name_i18n.fr,
-                }),
-              ]);
-            });
-          });
-
-          context('when a locale is provided', function () {
-            it('should return all thematics found translated in provided locale of fallback to default locale FR', async function () {
-              // when
-              const thematics = await thematicRepository.findByRecordIds(['thematicId3', 'thematicId0'], 'en');
-
-              // then
-              expect(thematics).to.deepEqualArray([
-                domainBuilder.buildThematic({
-                  ...thematicData0,
-                  name: thematicData0.name_i18n.en,
-                }),
-                domainBuilder.buildThematic({
-                  ...thematicData3,
-                  name: thematicData3.name_i18n.fr,
-                }),
-              ]);
-            });
-          });
-
-          it('should ignore nulls and duplicates', async function () {
-            // when
-            const thematics = await thematicRepository.findByRecordIds([
-              'thematicId3',
-              'thematicId0',
-              'thematicCOUCOUPAPA',
-              'thematicId3',
-            ]);
-
-            // then
-            expect(thematics).to.deepEqualArray([
-              domainBuilder.buildThematic({
-                ...thematicData0,
-                name: thematicData0.name_i18n.fr,
-              }),
-              domainBuilder.buildThematic({
-                ...thematicData3,
-                name: thematicData3.name_i18n.fr,
-              }),
-            ]);
-          });
-        });
-
-        context('when no thematics found for given ids', function () {
-          it('should return an empty array', async function () {
-            // when
-            const thematics = await thematicRepository.findByRecordIds(['recCouCouRoRo', 'recCouCouGabDou']);
-
-            // then
-            expect(thematics).to.deep.equal([]);
-          });
+          // then
+          expect(thematics).to.deepEqualArray([
+            domainBuilder.buildThematic({
+              ...thematicData0,
+              name: thematicData0.name_i18n.en,
+            }),
+            domainBuilder.buildThematic({
+              ...thematicData1,
+              name: thematicData1.name_i18n.fr,
+            }),
+            domainBuilder.buildThematic({
+              ...thematicData2,
+              name: thematicData2.name_i18n.en,
+            }),
+          ]);
         });
       });
-    }),
-  );
+
+      it('should ignore null and duplicates', async function () {
+        // when
+        const thematics = await thematicRepository.findByCompetenceIds([
+          'competenceIdB',
+          'competenceIdA',
+          'competenceCOUCOUMAMAN',
+          'competenceIdB',
+        ]);
+
+        // then
+        expect(thematics).to.deepEqualArray([
+          domainBuilder.buildThematic({
+            ...thematicData0,
+            name: thematicData0.name_i18n.fr,
+          }),
+          domainBuilder.buildThematic({
+            ...thematicData1,
+            name: thematicData1.name_i18n.fr,
+          }),
+          domainBuilder.buildThematic({
+            ...thematicData2,
+            name: thematicData2.name_i18n.fr,
+          }),
+        ]);
+      });
+    });
+
+    context('when no thematics found for given competence ids', function () {
+      it('should return an empty array', async function () {
+        // when
+        const thematics = await thematicRepository.findByCompetenceIds(['recCouCouRoRo', 'recCouCouGabDou']);
+
+        // then
+        expect(thematics).to.deep.equal([]);
+      });
+    });
+  });
+
+  describe('#findByRecordIds', function () {
+    context('when thematics found by ids', function () {
+      context('when no locale provided', function () {
+        it('should return all thematics found translated in default locale FR given by their ids ordered by name', async function () {
+          // when
+          const thematics = await thematicRepository.findByRecordIds(['thematicId3', 'thematicId0']);
+
+          // then
+          expect(thematics).to.deepEqualArray([
+            domainBuilder.buildThematic({
+              ...thematicData0,
+              name: thematicData0.name_i18n.fr,
+            }),
+            domainBuilder.buildThematic({
+              ...thematicData3,
+              name: thematicData3.name_i18n.fr,
+            }),
+          ]);
+        });
+      });
+
+      context('when a locale is provided', function () {
+        it('should return all thematics found translated in provided locale of fallback to default locale FR', async function () {
+          // when
+          const thematics = await thematicRepository.findByRecordIds(['thematicId3', 'thematicId0'], 'en');
+
+          // then
+          expect(thematics).to.deepEqualArray([
+            domainBuilder.buildThematic({
+              ...thematicData0,
+              name: thematicData0.name_i18n.en,
+            }),
+            domainBuilder.buildThematic({
+              ...thematicData3,
+              name: thematicData3.name_i18n.fr,
+            }),
+          ]);
+        });
+      });
+
+      it('should ignore nulls and duplicates', async function () {
+        // when
+        const thematics = await thematicRepository.findByRecordIds([
+          'thematicId3',
+          'thematicId0',
+          'thematicCOUCOUPAPA',
+          'thematicId3',
+        ]);
+
+        // then
+        expect(thematics).to.deepEqualArray([
+          domainBuilder.buildThematic({
+            ...thematicData0,
+            name: thematicData0.name_i18n.fr,
+          }),
+          domainBuilder.buildThematic({
+            ...thematicData3,
+            name: thematicData3.name_i18n.fr,
+          }),
+        ]);
+      });
+    });
+
+    context('when no thematics found for given ids', function () {
+      it('should return an empty array', async function () {
+        // when
+        const thematics = await thematicRepository.findByRecordIds(['recCouCouRoRo', 'recCouCouGabDou']);
+
+        // then
+        expect(thematics).to.deep.equal([]);
+      });
+    });
+  });
 });

--- a/api/tests/shared/integration/infrastructure/repositories/tube-repository_test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/tube-repository_test.js
@@ -1,7 +1,6 @@
-import { config } from '../../../../../src/shared/config.js';
 import { LearningContentResourceNotFound } from '../../../../../src/shared/domain/errors.js';
 import * as tubeRepository from '../../../../../src/shared/infrastructure/repositories/tube-repository.js';
-import { catchErr, databaseBuilder, domainBuilder, expect, sinon } from '../../../../test-helper.js';
+import { catchErr, databaseBuilder, domainBuilder, expect } from '../../../../test-helper.js';
 
 describe('Integration | Repository | tube-repository', function () {
   const tubeData0 = {
@@ -72,45 +71,72 @@ describe('Integration | Repository | tube-repository', function () {
     await databaseBuilder.commit();
   });
 
-  [false, true].forEach((cacheResultIds) =>
-    describe(`when cacheResultIds is ${cacheResultIds}`, function () {
-      beforeEach(function () {
-        sinon.stub(config.lcms, 'cacheResultIds').value(cacheResultIds);
+  describe('#get', function () {
+    context('when tube found for given id', function () {
+      it('should return the tube translated with default locale FR', async function () {
+        // when
+        const tube = await tubeRepository.get('tubeId0');
+
+        // then
+        expect(tube).to.deepEqualInstance(
+          domainBuilder.buildTube({
+            ...tubeData0,
+            practicalTitle: tubeData0.practicalTitle_i18n.fr,
+            practicalDescription: tubeData0.practicalDescription_i18n.fr,
+            skills: [],
+          }),
+        );
       });
+    });
 
-      describe('#get', function () {
-        context('when tube found for given id', function () {
-          it('should return the tube translated with default locale FR', async function () {
-            // when
-            const tube = await tubeRepository.get('tubeId0');
+    context('when no tube found', function () {
+      it('should throw a LearningContentResourceNotFound error', async function () {
+        // when
+        const err = await catchErr(tubeRepository.get, tubeRepository)('recCoucouZouZou');
 
-            // then
-            expect(tube).to.deepEqualInstance(
-              domainBuilder.buildTube({
-                ...tubeData0,
-                practicalTitle: tubeData0.practicalTitle_i18n.fr,
-                practicalDescription: tubeData0.practicalDescription_i18n.fr,
-                skills: [],
-              }),
-            );
-          });
-        });
-
-        context('when no tube found', function () {
-          it('should throw a LearningContentResourceNotFound error', async function () {
-            // when
-            const err = await catchErr(tubeRepository.get, tubeRepository)('recCoucouZouZou');
-
-            // then
-            expect(err).to.be.instanceOf(LearningContentResourceNotFound);
-          });
-        });
+        // then
+        expect(err).to.be.instanceOf(LearningContentResourceNotFound);
       });
+    });
+  });
 
-      describe('#list', function () {
-        it('should return all tubes translated by default locale FR ordered by name', async function () {
+  describe('#list', function () {
+    it('should return all tubes translated by default locale FR ordered by name', async function () {
+      // when
+      const tubes = await tubeRepository.list();
+
+      // then
+      expect(tubes).to.deepEqualArray([
+        domainBuilder.buildTube({
+          ...tubeData0,
+          practicalTitle: tubeData0.practicalTitle_i18n.fr,
+          practicalDescription: tubeData0.practicalDescription_i18n.fr,
+          skills: [],
+        }),
+        domainBuilder.buildTube({
+          ...tubeData1,
+          practicalTitle: tubeData1.practicalTitle_i18n.fr,
+          practicalDescription: tubeData1.practicalDescription_i18n.fr,
+          skills: [],
+        }),
+        domainBuilder.buildTube({
+          ...tubeData2,
+          practicalTitle: tubeData2.practicalTitle_i18n.fr,
+          practicalDescription: tubeData2.practicalDescription_i18n.fr,
+          skills: [],
+        }),
+      ]);
+    });
+  });
+
+  describe('#findByNames', function () {
+    context('when tubes found by names', function () {
+      context('when no locale provided', function () {
+        it('should return all tubes found translated in default locale FR given by their name', async function () {
           // when
-          const tubes = await tubeRepository.list();
+          const tubes = await tubeRepository.findByNames({
+            tubeNames: ['name Tube 2', 'name Tube 0', 'non existant mais on sen fiche'],
+          });
 
           // then
           expect(tubes).to.deepEqualArray([
@@ -118,12 +144,6 @@ describe('Integration | Repository | tube-repository', function () {
               ...tubeData0,
               practicalTitle: tubeData0.practicalTitle_i18n.fr,
               practicalDescription: tubeData0.practicalDescription_i18n.fr,
-              skills: [],
-            }),
-            domainBuilder.buildTube({
-              ...tubeData1,
-              practicalTitle: tubeData1.practicalTitle_i18n.fr,
-              practicalDescription: tubeData1.practicalDescription_i18n.fr,
               skills: [],
             }),
             domainBuilder.buildTube({
@@ -136,295 +156,262 @@ describe('Integration | Repository | tube-repository', function () {
         });
       });
 
-      describe('#findByNames', function () {
-        context('when tubes found by names', function () {
-          context('when no locale provided', function () {
-            it('should return all tubes found translated in default locale FR given by their name', async function () {
-              // when
-              const tubes = await tubeRepository.findByNames({
-                tubeNames: ['name Tube 2', 'name Tube 0', 'non existant mais on sen fiche'],
-              });
-
-              // then
-              expect(tubes).to.deepEqualArray([
-                domainBuilder.buildTube({
-                  ...tubeData0,
-                  practicalTitle: tubeData0.practicalTitle_i18n.fr,
-                  practicalDescription: tubeData0.practicalDescription_i18n.fr,
-                  skills: [],
-                }),
-                domainBuilder.buildTube({
-                  ...tubeData2,
-                  practicalTitle: tubeData2.practicalTitle_i18n.fr,
-                  practicalDescription: tubeData2.practicalDescription_i18n.fr,
-                  skills: [],
-                }),
-              ]);
-            });
+      context('when a locale is provided', function () {
+        it('should return all tubes found translated in default locale FR given by their name', async function () {
+          // when
+          const tubes = await tubeRepository.findByNames({
+            tubeNames: ['name Tube 2', 'name Tube 0'],
+            locale: 'en',
           });
 
-          context('when a locale is provided', function () {
-            it('should return all tubes found translated in default locale FR given by their name', async function () {
-              // when
-              const tubes = await tubeRepository.findByNames({
-                tubeNames: ['name Tube 2', 'name Tube 0'],
-                locale: 'en',
-              });
-
-              // then
-              expect(tubes).to.deepEqualArray([
-                domainBuilder.buildTube({
-                  ...tubeData0,
-                  practicalTitle: tubeData0.practicalTitle_i18n.en,
-                  practicalDescription: tubeData0.practicalDescription_i18n.en,
-                  skills: [],
-                }),
-                domainBuilder.buildTube({
-                  ...tubeData2,
-                  practicalTitle: tubeData2.practicalTitle_i18n.fr,
-                  practicalDescription: tubeData2.practicalDescription_i18n.en,
-                  skills: [],
-                }),
-              ]);
-            });
-          });
-
-          it('should ingore dupes and nulls', async function () {
-            // when
-            const tubes = await tubeRepository.findByNames({
-              tubeNames: ['name Tube 2', 'name Tube 0', 'non existant mais on sen fiche', 'name Tube 0'],
-            });
-
-            // then
-            expect(tubes).to.deepEqualArray([
-              domainBuilder.buildTube({
-                ...tubeData0,
-                practicalTitle: tubeData0.practicalTitle_i18n.fr,
-                practicalDescription: tubeData0.practicalDescription_i18n.fr,
-                skills: [],
-              }),
-              domainBuilder.buildTube({
-                ...tubeData2,
-                practicalTitle: tubeData2.practicalTitle_i18n.fr,
-                practicalDescription: tubeData2.practicalDescription_i18n.fr,
-                skills: [],
-              }),
-            ]);
-          });
-        });
-
-        context('when no tubes found for given names', function () {
-          it('should return an empty array', async function () {
-            // when
-            const tubes = await tubeRepository.findByNames({ tubeNames: ['name Tube 888888'] });
-
-            // then
-            expect(tubes).to.deep.equal([]);
-          });
-        });
-
-        context('when invalid value provided for tubeNames argument', function () {
-          it('should return an empty array', async function () {
-            // when
-            const tubes1 = await tubeRepository.findByNames({ tubeNames: null });
-            const tubes2 = await tubeRepository.findByNames({ tubeNames: undefined });
-            const tubes3 = await tubeRepository.findByNames({ tubeNames: [] });
-
-            // then
-            expect(tubes1).to.deep.equal([]);
-            expect(tubes2).to.deep.equal([]);
-            expect(tubes3).to.deep.equal([]);
-          });
+          // then
+          expect(tubes).to.deepEqualArray([
+            domainBuilder.buildTube({
+              ...tubeData0,
+              practicalTitle: tubeData0.practicalTitle_i18n.en,
+              practicalDescription: tubeData0.practicalDescription_i18n.en,
+              skills: [],
+            }),
+            domainBuilder.buildTube({
+              ...tubeData2,
+              practicalTitle: tubeData2.practicalTitle_i18n.fr,
+              practicalDescription: tubeData2.practicalDescription_i18n.en,
+              skills: [],
+            }),
+          ]);
         });
       });
 
-      describe('#findByRecordIds', function () {
-        context('when tubes found by ids', function () {
-          context('when no locale provided', function () {
-            it('should return all tubes found translated in default locale FR given by their name', async function () {
-              // when
-              const tubes = await tubeRepository.findByRecordIds([
-                'tubeId2',
-                'tubeId0',
-                'non existant mais on sen fiche',
-              ]);
-
-              // then
-              expect(tubes).to.deepEqualArray([
-                domainBuilder.buildTube({
-                  ...tubeData0,
-                  practicalTitle: tubeData0.practicalTitle_i18n.fr,
-                  practicalDescription: tubeData0.practicalDescription_i18n.fr,
-                  skills: [],
-                }),
-                domainBuilder.buildTube({
-                  ...tubeData2,
-                  practicalTitle: tubeData2.practicalTitle_i18n.fr,
-                  practicalDescription: tubeData2.practicalDescription_i18n.fr,
-                  skills: [],
-                }),
-              ]);
-            });
-          });
-
-          context('when a locale is provided', function () {
-            it('should return all tubes found translated in default locale FR given by their name', async function () {
-              // when
-              const tubes = await tubeRepository.findByRecordIds(
-                ['tubeId2', 'tubeId0', 'non existant mais on sen fiche'],
-                'en',
-              );
-
-              // then
-              expect(tubes).to.deepEqualArray([
-                domainBuilder.buildTube({
-                  ...tubeData0,
-                  practicalTitle: tubeData0.practicalTitle_i18n.en,
-                  practicalDescription: tubeData0.practicalDescription_i18n.en,
-                  skills: [],
-                }),
-                domainBuilder.buildTube({
-                  ...tubeData2,
-                  practicalTitle: tubeData2.practicalTitle_i18n.fr,
-                  practicalDescription: tubeData2.practicalDescription_i18n.en,
-                  skills: [],
-                }),
-              ]);
-            });
-          });
-
-          it('should ignore dupes and nulls', async function () {
-            // when
-            const tubes = await tubeRepository.findByRecordIds([
-              'tubeId2',
-              'tubeId0',
-              'non existant mais on sen fiche',
-              'tubeId0',
-            ]);
-
-            // then
-            expect(tubes).to.deepEqualArray([
-              domainBuilder.buildTube({
-                ...tubeData0,
-                practicalTitle: tubeData0.practicalTitle_i18n.fr,
-                practicalDescription: tubeData0.practicalDescription_i18n.fr,
-                skills: [],
-              }),
-              domainBuilder.buildTube({
-                ...tubeData2,
-                practicalTitle: tubeData2.practicalTitle_i18n.fr,
-                practicalDescription: tubeData2.practicalDescription_i18n.fr,
-                skills: [],
-              }),
-            ]);
-          });
+      it('should ingore dupes and nulls', async function () {
+        // when
+        const tubes = await tubeRepository.findByNames({
+          tubeNames: ['name Tube 2', 'name Tube 0', 'non existant mais on sen fiche', 'name Tube 0'],
         });
 
-        context('when no tubes found for given ids', function () {
-          it('should return an empty array', async function () {
-            // when
-            const tubes = await tubeRepository.findByRecordIds(['name Tube 888888']);
+        // then
+        expect(tubes).to.deepEqualArray([
+          domainBuilder.buildTube({
+            ...tubeData0,
+            practicalTitle: tubeData0.practicalTitle_i18n.fr,
+            practicalDescription: tubeData0.practicalDescription_i18n.fr,
+            skills: [],
+          }),
+          domainBuilder.buildTube({
+            ...tubeData2,
+            practicalTitle: tubeData2.practicalTitle_i18n.fr,
+            practicalDescription: tubeData2.practicalDescription_i18n.fr,
+            skills: [],
+          }),
+        ]);
+      });
+    });
 
-            // then
-            expect(tubes).to.deep.equal([]);
-          });
+    context('when no tubes found for given names', function () {
+      it('should return an empty array', async function () {
+        // when
+        const tubes = await tubeRepository.findByNames({ tubeNames: ['name Tube 888888'] });
+
+        // then
+        expect(tubes).to.deep.equal([]);
+      });
+    });
+
+    context('when invalid value provided for tubeNames argument', function () {
+      it('should return an empty array', async function () {
+        // when
+        const tubes1 = await tubeRepository.findByNames({ tubeNames: null });
+        const tubes2 = await tubeRepository.findByNames({ tubeNames: undefined });
+        const tubes3 = await tubeRepository.findByNames({ tubeNames: [] });
+
+        // then
+        expect(tubes1).to.deep.equal([]);
+        expect(tubes2).to.deep.equal([]);
+        expect(tubes3).to.deep.equal([]);
+      });
+    });
+  });
+
+  describe('#findByRecordIds', function () {
+    context('when tubes found by ids', function () {
+      context('when no locale provided', function () {
+        it('should return all tubes found translated in default locale FR given by their name', async function () {
+          // when
+          const tubes = await tubeRepository.findByRecordIds(['tubeId2', 'tubeId0', 'non existant mais on sen fiche']);
+
+          // then
+          expect(tubes).to.deepEqualArray([
+            domainBuilder.buildTube({
+              ...tubeData0,
+              practicalTitle: tubeData0.practicalTitle_i18n.fr,
+              practicalDescription: tubeData0.practicalDescription_i18n.fr,
+              skills: [],
+            }),
+            domainBuilder.buildTube({
+              ...tubeData2,
+              practicalTitle: tubeData2.practicalTitle_i18n.fr,
+              practicalDescription: tubeData2.practicalDescription_i18n.fr,
+              skills: [],
+            }),
+          ]);
         });
       });
 
-      describe('#findActiveByRecordIds', function () {
-        context('when active tubes found by ids', function () {
-          context('when no locale provided', function () {
-            it('should return all tubes that have at least one active skill found translated in default locale FR given by their ids', async function () {
-              // when
-              const tubes = await tubeRepository.findActiveByRecordIds([
-                'tubeId2',
-                'tubeId0',
-                'tubeId1',
-                'non existant mais on sen fiche',
-              ]);
+      context('when a locale is provided', function () {
+        it('should return all tubes found translated in default locale FR given by their name', async function () {
+          // when
+          const tubes = await tubeRepository.findByRecordIds(
+            ['tubeId2', 'tubeId0', 'non existant mais on sen fiche'],
+            'en',
+          );
 
-              // then
-              expect(tubes).to.deepEqualArray([
-                domainBuilder.buildTube({
-                  ...tubeData0,
-                  practicalTitle: tubeData0.practicalTitle_i18n.fr,
-                  practicalDescription: tubeData0.practicalDescription_i18n.fr,
-                  skills: [],
-                }),
-                domainBuilder.buildTube({
-                  ...tubeData2,
-                  practicalTitle: tubeData2.practicalTitle_i18n.fr,
-                  practicalDescription: tubeData2.practicalDescription_i18n.fr,
-                  skills: [],
-                }),
-              ]);
-            });
-          });
-
-          context('when a locale is provided', function () {
-            it('should return all tubes found translated in default locale FR given by their name', async function () {
-              // when
-              const tubes = await tubeRepository.findActiveByRecordIds(
-                ['tubeId2', 'tubeId0', 'tubeId1', 'non existant mais on sen fiche'],
-                'en',
-              );
-
-              // then
-              expect(tubes).to.deepEqualArray([
-                domainBuilder.buildTube({
-                  ...tubeData0,
-                  practicalTitle: tubeData0.practicalTitle_i18n.en,
-                  practicalDescription: tubeData0.practicalDescription_i18n.en,
-                  skills: [],
-                }),
-                domainBuilder.buildTube({
-                  ...tubeData2,
-                  practicalTitle: tubeData2.practicalTitle_i18n.fr,
-                  practicalDescription: tubeData2.practicalDescription_i18n.en,
-                  skills: [],
-                }),
-              ]);
-            });
-          });
-
-          it('should ignore duplicates and nulls', async function () {
-            // when
-            const tubes = await tubeRepository.findActiveByRecordIds([
-              'tubeId2',
-              'tubeId0',
-              'tubeId1',
-              'non existant mais on sen fiche',
-              'tubeId0',
-            ]);
-
-            // then
-            expect(tubes).to.deepEqualArray([
-              domainBuilder.buildTube({
-                ...tubeData0,
-                practicalTitle: tubeData0.practicalTitle_i18n.fr,
-                practicalDescription: tubeData0.practicalDescription_i18n.fr,
-                skills: [],
-              }),
-              domainBuilder.buildTube({
-                ...tubeData2,
-                practicalTitle: tubeData2.practicalTitle_i18n.fr,
-                practicalDescription: tubeData2.practicalDescription_i18n.fr,
-                skills: [],
-              }),
-            ]);
-          });
-        });
-
-        context('when no active tubes found for given ids', function () {
-          it('should return an empty array', async function () {
-            // when
-            const tubes = await tubeRepository.findActiveByRecordIds(['tubeId1']);
-
-            // then
-            expect(tubes).to.deep.equal([]);
-          });
+          // then
+          expect(tubes).to.deepEqualArray([
+            domainBuilder.buildTube({
+              ...tubeData0,
+              practicalTitle: tubeData0.practicalTitle_i18n.en,
+              practicalDescription: tubeData0.practicalDescription_i18n.en,
+              skills: [],
+            }),
+            domainBuilder.buildTube({
+              ...tubeData2,
+              practicalTitle: tubeData2.practicalTitle_i18n.fr,
+              practicalDescription: tubeData2.practicalDescription_i18n.en,
+              skills: [],
+            }),
+          ]);
         });
       });
-    }),
-  );
+
+      it('should ignore dupes and nulls', async function () {
+        // when
+        const tubes = await tubeRepository.findByRecordIds([
+          'tubeId2',
+          'tubeId0',
+          'non existant mais on sen fiche',
+          'tubeId0',
+        ]);
+
+        // then
+        expect(tubes).to.deepEqualArray([
+          domainBuilder.buildTube({
+            ...tubeData0,
+            practicalTitle: tubeData0.practicalTitle_i18n.fr,
+            practicalDescription: tubeData0.practicalDescription_i18n.fr,
+            skills: [],
+          }),
+          domainBuilder.buildTube({
+            ...tubeData2,
+            practicalTitle: tubeData2.practicalTitle_i18n.fr,
+            practicalDescription: tubeData2.practicalDescription_i18n.fr,
+            skills: [],
+          }),
+        ]);
+      });
+    });
+
+    context('when no tubes found for given ids', function () {
+      it('should return an empty array', async function () {
+        // when
+        const tubes = await tubeRepository.findByRecordIds(['name Tube 888888']);
+
+        // then
+        expect(tubes).to.deep.equal([]);
+      });
+    });
+  });
+
+  describe('#findActiveByRecordIds', function () {
+    context('when active tubes found by ids', function () {
+      context('when no locale provided', function () {
+        it('should return all tubes that have at least one active skill found translated in default locale FR given by their ids', async function () {
+          // when
+          const tubes = await tubeRepository.findActiveByRecordIds([
+            'tubeId2',
+            'tubeId0',
+            'tubeId1',
+            'non existant mais on sen fiche',
+          ]);
+
+          // then
+          expect(tubes).to.deepEqualArray([
+            domainBuilder.buildTube({
+              ...tubeData0,
+              practicalTitle: tubeData0.practicalTitle_i18n.fr,
+              practicalDescription: tubeData0.practicalDescription_i18n.fr,
+              skills: [],
+            }),
+            domainBuilder.buildTube({
+              ...tubeData2,
+              practicalTitle: tubeData2.practicalTitle_i18n.fr,
+              practicalDescription: tubeData2.practicalDescription_i18n.fr,
+              skills: [],
+            }),
+          ]);
+        });
+      });
+
+      context('when a locale is provided', function () {
+        it('should return all tubes found translated in default locale FR given by their name', async function () {
+          // when
+          const tubes = await tubeRepository.findActiveByRecordIds(
+            ['tubeId2', 'tubeId0', 'tubeId1', 'non existant mais on sen fiche'],
+            'en',
+          );
+
+          // then
+          expect(tubes).to.deepEqualArray([
+            domainBuilder.buildTube({
+              ...tubeData0,
+              practicalTitle: tubeData0.practicalTitle_i18n.en,
+              practicalDescription: tubeData0.practicalDescription_i18n.en,
+              skills: [],
+            }),
+            domainBuilder.buildTube({
+              ...tubeData2,
+              practicalTitle: tubeData2.practicalTitle_i18n.fr,
+              practicalDescription: tubeData2.practicalDescription_i18n.en,
+              skills: [],
+            }),
+          ]);
+        });
+      });
+
+      it('should ignore duplicates and nulls', async function () {
+        // when
+        const tubes = await tubeRepository.findActiveByRecordIds([
+          'tubeId2',
+          'tubeId0',
+          'tubeId1',
+          'non existant mais on sen fiche',
+          'tubeId0',
+        ]);
+
+        // then
+        expect(tubes).to.deepEqualArray([
+          domainBuilder.buildTube({
+            ...tubeData0,
+            practicalTitle: tubeData0.practicalTitle_i18n.fr,
+            practicalDescription: tubeData0.practicalDescription_i18n.fr,
+            skills: [],
+          }),
+          domainBuilder.buildTube({
+            ...tubeData2,
+            practicalTitle: tubeData2.practicalTitle_i18n.fr,
+            practicalDescription: tubeData2.practicalDescription_i18n.fr,
+            skills: [],
+          }),
+        ]);
+      });
+    });
+
+    context('when no active tubes found for given ids', function () {
+      it('should return an empty array', async function () {
+        // when
+        const tubes = await tubeRepository.findActiveByRecordIds(['tubeId1']);
+
+        // then
+        expect(tubes).to.deep.equal([]);
+      });
+    });
+  });
 });

--- a/high-level-tests/e2e-playwright/playwright.config.shared.ts
+++ b/high-level-tests/e2e-playwright/playwright.config.shared.ts
@@ -69,7 +69,6 @@ export function setupWebServer(app: App, reuseExistingServer: boolean): WebServe
           LCMS_API_URL: process.env.LCMS_API_URL ?? '',
           LCMS_API_KEY: process.env.LCMS_API_KEY ?? '',
           LCMS_API_RELEASE_ID: process.env.LCMS_API_RELEASE_ID ?? '',
-          LCMS_CACHE_RESULT_IDS_MODULO: '1',
         },
       };
     }


### PR DESCRIPTION
## 🌎 Problème

L’ancienne mise en cache des objets dans le cache de résultats n’est plus utilisée (cf #15595).

## 🔭 Proposition

Supprimer l’ancien code.

## 🪐 Remarques

Après le déploiement sur les différents environnements, il faudra supprimer la variable d’environnement `LCMS_CACHE_RESULT_IDS_MODULO`.

## 🚀 Pour tester

Faire de la non régression sur Pix App.