### PR TITLE
[FEATURE] Suivre l'utilisation de la remise à zéro et de l'amélioration des compétences (PIX-21882)

### DIFF
--- a/mon-pix/app/components/scorecard-details.gjs
+++ b/mon-pix/app/components/scorecard-details.gjs
@@ -261,11 +261,13 @@ export default class ScorecardDetails extends Component {
       </:footer>
     </PixModal>
   </template>
+
   @service currentUser;
   @service store;
   @service router;
   @service competenceEvaluation;
   @service featureToggles;
+  @service pixMetrics;
 
   @tracked showResetModal = false;
 
@@ -335,6 +337,7 @@ export default class ScorecardDetails extends Component {
         competenceId: this.args.scorecard.competenceId,
       },
     });
+    this.pixMetrics.trackEvent('resetCompetence', { competenceId: this.args.scorecard.competenceId });
 
     this.showResetModal = false;
   }
@@ -344,6 +347,7 @@ export default class ScorecardDetails extends Component {
     const userId = this.currentUser.user.id;
     const competenceId = this.args.scorecard.competenceId;
     const scorecardId = this.args.scorecard.id;
+    this.pixMetrics.trackEvent('improveCompetence', { competenceId: this.args.scorecard.competenceId });
     return this.competenceEvaluation.improve({ userId, competenceId, scorecardId });
   }
 }

--- a/mon-pix/tests/integration/components/scorecard-details-test.js
+++ b/mon-pix/tests/integration/components/scorecard-details-test.js
@@ -1,8 +1,11 @@
-import { render } from '@1024pix/ember-testing-library';
+import { render, within } from '@1024pix/ember-testing-library';
 import { A } from '@ember/array';
+import Service from '@ember/service';
+import { click } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { t } from 'ember-intl/test-support';
 import { module, test } from 'qunit';
+import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 
@@ -82,7 +85,15 @@ module('Integration | Component | scorecard-details', function (hooks) {
           level: 3,
           isFinished: true,
           tutorials: [],
+          save: sinon.stub().resolves(),
         });
+
+        this.owner.register(
+          'service:current-user',
+          class UserService extends Service {
+            user = { id: 123 };
+          },
+        );
       });
 
       test('should not display remainingPixToNextLevel', async function (assert) {
@@ -120,6 +131,48 @@ module('Integration | Component | scorecard-details', function (hooks) {
 
         // then
         assert.ok(screen.getByRole('button', t('pages.competence-details.actions.improve.label')));
+      });
+
+      test('should track improve competence button click', async function (assert) {
+        // given
+        const pixMetrics = this.owner.lookup('service:pix-metrics');
+        const trackEventStub = sinon.stub(pixMetrics, 'trackEvent');
+        const competenceEvaluation = this.owner.lookup('service:competence-evaluation');
+        sinon.stub(competenceEvaluation, 'improve').resolves();
+
+        scorecard.isImprovable = true;
+        scorecard.remainingDaysBeforeImproving = 0;
+        scorecard.pixScoreAheadOfNextLevel = 8;
+        this.set('scorecard', scorecard);
+        const screen = await render(hbs`<ScorecardDetails @scorecard={{this.scorecard}} />`);
+
+        // when
+        await click(
+          screen.getByRole('button', { name: new RegExp(t('pages.competence-details.actions.improve.label')) }),
+        );
+
+        // then
+        assert.ok(trackEventStub.calledWithExactly('improveCompetence', { competenceId: scorecard.competenceId }));
+      });
+
+      test('should track reset competence button click', async function (assert) {
+        // given
+        const pixMetrics = this.owner.lookup('service:pix-metrics');
+        const trackEventStub = sinon.stub(pixMetrics, 'trackEvent');
+
+        scorecard.isResettable = true;
+        scorecard.remainingDaysBeforeReset = 0;
+        this.set('scorecard', scorecard);
+        const screen = await render(hbs`<ScorecardDetails @scorecard={{this.scorecard}} />`);
+
+        // when
+        await click(
+          screen.getByRole('button', { name: new RegExp(t('pages.competence-details.actions.reset.label')) }),
+        );
+        const dialog = await screen.findByRole('dialog');
+        await click(within(dialog).getByRole('button', { name: t('pages.competence-details.actions.reset.label') }));
+        // then
+        assert.ok(trackEventStub.calledWithExactly('resetCompetence', { competenceId: scorecard.competenceId }));
       });
 
       test('should show the improving countdown if the remaining days before improving are different than 0', async function (assert) {

--- a/mon-pix/tests/unit/components/scorecard-details-test.js
+++ b/mon-pix/tests/unit/components/scorecard-details-test.js
@@ -6,7 +6,7 @@ import sinon from 'sinon';
 
 import createGlimmerComponent from '../../helpers/create-glimmer-component';
 
-module('Unit | Component | scorecard-details ', function (hooks) {
+module('Unit | Component | scorecard-details', function (hooks) {
   setupTest(hooks);
 
   module('#tutorialsGroupedByTubeName', function () {


### PR DESCRIPTION
## 🌎 Problème
Dans le cadre de la suppression des 4Jours pour retenter ou remettre à zéro une compétence nous souhaitons pouvoir monitorer l’usage des deux features via Plausible.

On ne sait pas si et comment les features retenter et raz une compétence sont utilisées. Il faudrait pouvoir mesurer ces usages par compétences et pouvoir mesurer si un même user utilise les features plusieurs fois d’affilé dans un temps réduit.

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

## 🔭 Proposition
mesurer l’utilisation de la feature retenter une compétence

mesurer l’utilisation de la feature RAZ une compétence
<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 🪐 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🚀 Pour tester
- Se connecter sur pixApp avec admin-orga
- améliorer une compétence
- remettre à zero une compétence


Aller dans Plausible

- faire une recherche des évenements
- `resetCompetence` et `improveCompetence`
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->

🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘 🌑
