### PR TITLE
[FEATURE] Création d'une structure lors de la création d'une organisation (PIX-22037).

### DIFF
--- a/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
@@ -239,6 +239,7 @@ const save = async function ({ organization }) {
     'parentOrganizationId',
     'countryCode',
   ]);
+
   const [organizationCreated] = await knexConn(ORGANIZATIONS_TABLE_NAME)
     .returning('*')
     .insert({
@@ -246,6 +247,13 @@ const save = async function ({ organization }) {
       organizationLearnerTypeId: organization.organizationLearnerType.id,
     });
   const savedOrganization = _toDomain(organizationCreated);
+
+  const [structure] = await knexConn('structures').returning('*').insert({});
+
+  await knexConn('fct_structures').insert({
+    structure_id: structure.id,
+    organization_id: savedOrganization.id,
+  });
 
   if (!_.isEmpty(savedOrganization.features)) {
     await _enableFeatures(knexConn, savedOrganization.features, savedOrganization.id);

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/organization-for-admin.repository.test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/organization-for-admin.repository.test.js
@@ -1264,6 +1264,45 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
       expect(savedOrganization.organizationLearnerType.id).to.equal(organizationLearnerType.id);
     });
 
+    it('creates a structure and fct_structure associated to the created organization', async function () {
+      // given
+      const superAdminUserId = databaseBuilder.factory.buildUser.withRole().id;
+      databaseBuilder.factory.buildCertificationCpfCountry({
+        code: 99100,
+      });
+      await insertMultipleSendingFeatureForNewOrganization();
+
+      await databaseBuilder.commit();
+
+      const organization = new OrganizationForAdmin({
+        name: 'Organization SCO',
+        type: 'SCO',
+        createdBy: superAdminUserId,
+        administrationTeamId: administrationTeam.id,
+        countryCode: 99100,
+        organizationLearnerType: new OrganizationLearnerType({
+          id: organizationLearnerType.id,
+          name: organizationLearnerType.name,
+        }),
+      });
+
+      // when
+      const savedOrganization = await repositories.organizationForAdminRepository.save({
+        organization,
+      });
+
+      // then
+      const fct_structure = await knex('fct_structures').where({ organization_id: savedOrganization.id }).first();
+      const structure = await knex('structures').where({ id: fct_structure.structure_id }).first();
+      expect(fct_structure).to.deep.equal({
+        child_structure_id: null,
+        network_id: null,
+        organization_id: savedOrganization.id,
+        parent_structure_id: null,
+        structure_id: structure.id,
+      });
+    });
+
     context('when the organization type is SCO-1D', function () {
       it('adds mission_management, oralization and learner_import features to the organization', async function () {
         const superAdminUserId = databaseBuilder.factory.buildUser().id;


### PR DESCRIPTION
## 🌎 Problème

Il ne faut pas que de nouvelles organisations puissent être créées sans une structure associée.

Au moment de la création d’une nouvelle organisation, il nous faut donc: 
- Créer une nouvelle structure
- Créer une fct_structure, dont les seuls champs renseignés lors de la création seront structure_id et organization_id

A l’heure actuelle, le référencement de la structure se fera via la structure_id de la fct_structure pour :
• Eviter toute désynchronisation de nom entre la structure et l’organisation qu’elle contient
• Ne pas faire apparaître d’élements métier dans l'élement technique qu’est pour l’instant la structure

## 🔭 Proposition

Création d'une structure et fct_structure lors de la création de l'orga

## 🪐 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🚀 Pour tester

Vérifier lors de la création d'une orga (unique ou via la création en masse) qu'une structure et une fct_structure soient créées.
