### PR TITLE
[FEATURE] Ajouter un placeholder dans la liste des formats d'import (PIX-21925)

### DIFF
--- a/admin/app/components/organizations/features-section.gjs
+++ b/admin/app/components/organizations/features-section.gjs
@@ -84,8 +84,12 @@ export default class OrganizationFeaturesSection extends Component {
 
   get isFormValid() {
     const attestations = this.form.features?.ATTESTATIONS_MANAGEMENT;
-    if (attestations?.active) {
-      return attestations.params?.length;
+    if (attestations?.active && !attestations.params?.length) {
+      return false;
+    }
+    const importFormat = this.form.features?.LEARNER_IMPORT;
+    if (importFormat?.active && !importFormat.params?.name) {
+      return false;
     }
     return true;
   }
@@ -93,6 +97,14 @@ export default class OrganizationFeaturesSection extends Component {
   get isAttestationsInvalid() {
     const attestations = this.form.features?.ATTESTATIONS_MANAGEMENT;
     return attestations?.active && !(attestations.params?.length > 0);
+  }
+
+  get learnerImportError() {
+    const importFormat = this.form.features?.LEARNER_IMPORT;
+    if (importFormat?.active && !importFormat.params?.name) {
+      return this.intl.t('components.organizations.editing.organization-learner-import-format.selector.error');
+    }
+    return null;
   }
 
   @action
@@ -103,13 +115,9 @@ export default class OrganizationFeaturesSection extends Component {
   @action
   updateFormCheckBoxValue(key) {
     if (key === 'features.LEARNER_IMPORT.active') {
-      this.form = lodashSet(
-        this.form,
-        'features.LEARNER_IMPORT',
-        this.form.features?.LEARNER_IMPORT?.active
-          ? { active: false }
-          : { active: true, params: { name: this.importFormatOptions[0].label } },
-      );
+      this.form = lodashSet(this.form, 'features.LEARNER_IMPORT', {
+        active: !this.form.features?.LEARNER_IMPORT?.active,
+      });
       if (this.form.features.LEARNER_IMPORT.active && !this.args.organization.features?.LEARNER_IMPORT?.active) {
         this.displayLearnerImportActivationDialog = true;
         this.learnerImportActivationConfirmed = false;
@@ -173,6 +181,7 @@ export default class OrganizationFeaturesSection extends Component {
               @isManagingStudentDisabled={{this.isManagingStudentDisabled}}
               @isLearnerImportDisabled={{this.isLearnerImportDisabled}}
               @editableFeatureList={{this.editableFeatureList}}
+              @learnerImportError={{this.learnerImportError}}
               @canEdit={{this.accessControl.hasAccessToOrganizationActionsScope}}
             />
           </Card>
@@ -281,6 +290,7 @@ const FeaturesForm = <template>
                 @placeholder={{t
                   "components.organizations.editing.organization-learner-import-format.selector.placeholder"
                 }}
+                @errorMessage={{@learnerImportError}}
               >
                 <:label>
                   {{t "components.organizations.editing.organization-learner-import-format.selector.label"}}

--- a/admin/tests/integration/components/organizations/features-section-test.gjs
+++ b/admin/tests/integration/components/organizations/features-section-test.gjs
@@ -926,5 +926,55 @@ module('Integration | Component | organizations/features-section', function (hoo
         }),
       );
     });
+
+    test('it shows an error and disables save when feature is active with no format selected', async function (assert) {
+      // given
+      const onSubmit = onSubmitStub;
+      const organization = EmberObject.create({
+        features: { LEARNER_IMPORT: { active: false } },
+      });
+
+      const screen = await render(
+        <template><FeaturesSection @organization={{organization}} @onSubmit={{onSubmit}} /></template>,
+      );
+
+      // when
+      await click(
+        screen.getByRole('checkbox', {
+          name: t('components.organizations.information-section-view.features.LEARNER_IMPORT'),
+        }),
+      );
+      const dialog = await screen.findByRole('dialog');
+      await click(within(dialog).getByRole('button', { name: t('common.actions.confirm') }));
+
+      // then
+      assert
+        .dom(screen.getByText(t('components.organizations.editing.organization-learner-import-format.selector.error')))
+        .exists();
+      assert.dom(screen.getByRole('button', { name: t('common.actions.save') })).hasAttribute('aria-disabled');
+    });
+
+    test('it does not submit the form when feature is active with no attestation selected', async function (assert) {
+      // given
+      const onSubmit = onSubmitStub;
+      const organization = EmberObject.create({
+        features: { ATTESTATIONS_MANAGEMENT: { active: false } },
+      });
+
+      const screen = await render(
+        <template><FeaturesSection @organization={{organization}} @onSubmit={{onSubmit}} /></template>,
+      );
+      await click(
+        screen.getByRole('checkbox', {
+          name: t('components.organizations.information-section-view.features.ATTESTATIONS_MANAGEMENT'),
+        }),
+      );
+
+      // when
+      await click(screen.getByRole('button', { name: t('common.actions.save') }));
+
+      // then
+      assert.false(onSubmit.called);
+    });
   });
 });

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -881,6 +881,7 @@
             "title": "Enabling generic import"
           },
           "selector": {
+            "error": "Please select an import format",
             "label": "Import format",
             "placeholder": "Select an import format"
           }

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -883,6 +883,7 @@
             "title": "Activation de l’import générique"
           },
           "selector": {
+            "error": "Veuillez sélectionner un format d'import",
             "label": "Format d’import",
             "placeholder": "Sélectionner un format d’import"
           }


### PR DESCRIPTION
## 🌎 Problème

pour l’instant le premier élément de la liste est sélectionné, on souhaite ne pas pré-sélectionner d’élément pour que le pixou choisisse le bon format.

## 🔭 Proposition

Arrêter de préselectionner le premier import et gérer les cas d'erreurs (validation, bloquer la soumission du formulaire) 

## 🪐 Remarques

RAS

## 🚀 Pour tester
Aller sur la page des fonctionnalités sur pixAdmin pour l'orga [PRO CLASSIC](https://admin-pr15606.review.pix.fr/organizations/1005/features)
cocher l'import générique
- voir le bouton enregistrer bloquer
- voir le message d'erreur "Veuillez sélectionner un format d'import"
- ne pas pouvoir soumettre le formulaire
- Ajouter un format d'import
- ne plus voir le message d'erreur
- pouvoir soumettre le formulaire
