### PR TITLE
[TECH] Accéder facilement à un grain spécifique d'un module (PIX-21992)

### DIFF
--- a/mon-pix/app/components/global/modulix-app-layout.gjs
+++ b/mon-pix/app/components/global/modulix-app-layout.gjs
@@ -12,7 +12,7 @@ export default class ModulixAppLayout extends Component {
   @service router;
 
   get currentModule() {
-    const moduleSlug = this.router.currentRoute.parent.params.slug;
+    const moduleSlug = this.router.currentRoute.parent.params.slug || this.router.currentRoute.attributes.module?.slug;
     const modules = this.store.peekAll('module');
     return modules.find((module) => module.slug === moduleSlug);
   }

--- a/mon-pix/app/components/module/passage.gjs
+++ b/mon-pix/app/components/module/passage.gjs
@@ -20,6 +20,8 @@ export default class ModulePassage extends Component {
   @service featureToggles;
   @service modulixNavigationProgress;
 
+  @tracked grainsToDisplay = this.computeGrainsToDisplay();
+
   get enrichedSections() {
     return this.args.module.sections.map((section, index) => {
       return {
@@ -58,7 +60,20 @@ export default class ModulePassage extends Component {
   }
 
   displayableGrains = this.flatGrains.filter((grain) => ModuleGrain.getSupportedComponents(grain).length > 0);
-  @tracked grainsToDisplay = this.displayableGrains.length > 0 ? [this.displayableGrains[0]] : [];
+
+  computeGrainsToDisplay() {
+    if (this.displayableGrains.length <= 0) {
+      return [];
+    }
+
+    const grainIndex = Number(this.args.grainIndex);
+    const isGrainIndexValid = grainIndex && grainIndex > 0 && grainIndex < this.displayableGrains.length;
+    if (isGrainIndexValid && !this.args.module.redirectionUrl) {
+      return this.displayableGrains.slice(0, grainIndex + 1);
+    }
+
+    return [this.displayableGrains[0]];
+  }
 
   @action
   hasGrainJustAppeared(index) {

--- a/mon-pix/app/components/module/passage.gjs
+++ b/mon-pix/app/components/module/passage.gjs
@@ -19,8 +19,15 @@ export default class ModulePassage extends Component {
   @service passageEvents;
   @service featureToggles;
   @service modulixNavigationProgress;
+  @service modulixPreviewMode;
 
   @tracked grainsToDisplay = this.computeGrainsToDisplay();
+
+  constructor(...args) {
+    super(...args);
+
+    this.modulixPreviewMode.disable();
+  }
 
   get enrichedSections() {
     return this.args.module.sections.map((section, index) => {

--- a/mon-pix/app/components/module/preview.gjs
+++ b/mon-pix/app/components/module/preview.gjs
@@ -175,6 +175,11 @@ export default class ModulixPreview extends Component {
 
   @action
   goToModuleGrain() {
+    this.router.transitionTo('module.passage', this.args.module, {
+      queryParams: {
+        grainIndex: this.selectedGrainIndex,
+      },
+    });
   }
 
   @action

--- a/mon-pix/app/components/module/preview.gjs
+++ b/mon-pix/app/components/module/preview.gjs
@@ -1,6 +1,7 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
 import PixSegmentedControl from '@1024pix/pix-ui/components/pix-segmented-control';
+import PixSelect from '@1024pix/pix-ui/components/pix-select';
 import PixTextarea from '@1024pix/pix-ui/components/pix-textarea';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
@@ -16,8 +17,10 @@ import ModulixSectionTitle from 'mon-pix/components/module/section-title';
 import didInsert from '../../modifiers/modifier-did-insert';
 
 export default class ModulixPreview extends Component {
+  @service router;
   @service store;
   @service modulixPreviewMode;
+  @service modulixNavigationProgress;
   @service intl;
 
   @tracked moduleCodeDisplayed = false;
@@ -90,6 +93,8 @@ export default class ModulixPreview extends Component {
   }]
 }`;
   @tracked errorMessage = null;
+  @tracked selectedGrainIndex =
+    this.formattedGrainListWithLabel.length > 0 ? this.formattedGrainListWithLabel[0].value : 1;
 
   constructor(owner, args) {
     super(owner, args);
@@ -110,6 +115,19 @@ export default class ModulixPreview extends Component {
 
   get previewingExistingModule() {
     return this.args.module !== undefined;
+  }
+
+  get formattedGrainListWithLabel() {
+    return this.moduleGrains.map((grain, index) => ({
+      label: this.intl.t('pages.modulix.preview.grain-select.grain-label', { index, title: grain.title }),
+      value: `${index}`,
+    }));
+  }
+
+  get moduleGrains() {
+    if (!this.args.module?.sections) return [];
+
+    return this.args.module.sections.flatMap((section) => section.grains);
   }
 
   get passage() {
@@ -156,8 +174,17 @@ export default class ModulixPreview extends Component {
   }
 
   @action
+  goToModuleGrain() {
+  }
+
+  @action
   toggleModuleCodeEditor() {
     this.moduleCodeDisplayed = !this.moduleCodeDisplayed;
+  }
+
+  @action
+  onGrainSelectedChange(value) {
+    this.selectedGrainIndex = value;
   }
 
   @action
@@ -189,12 +216,29 @@ export default class ModulixPreview extends Component {
       </div>
     {{/unless}}
 
-    <div class="modulix-preview__elements-id-button" {{didInsert this.setHTMLElementOffset}}>
+    <div class="modulix-preview__panel" {{didInsert this.setHTMLElementOffset}}>
       <PixSegmentedControl @onChange={{this.toggleElementIdButton}} @variant="primary" @toggled={{false}}>
         <:label>{{t "pages.modulix.preview.elements-id-button.label"}}</:label>
         <:viewA>{{t "pages.modulix.preview.elements-id-button.choices.yes"}}</:viewA>
         <:viewB>{{t "pages.modulix.preview.elements-id-button.choices.no"}}</:viewB>
       </PixSegmentedControl>
+      {{#if this.previewingExistingModule}}
+        <hr />
+        <form class="modulix-preview-panel__grain-form">
+          <PixSelect
+            @isComputeWidthDisabled={{true}}
+            @hideDefaultOption={{true}}
+            @options={{this.formattedGrainListWithLabel}}
+            @onChange={{this.onGrainSelectedChange}}
+            @value={{this.selectedGrainIndex}}
+          >
+            <:label>{{t "pages.modulix.preview.grain-select.label"}}</:label>
+          </PixSelect>
+          <PixButton @triggerAction={{this.goToModuleGrain}}>{{t
+              "pages.modulix.preview.grain-select.button"
+            }}</PixButton>
+        </form>
+      {{/if}}
     </div>
 
     <div class="module-preview {{if this.moduleCodeDisplayed 'module-preview--with-editor'}}">

--- a/mon-pix/app/controllers/module/passage.js
+++ b/mon-pix/app/controllers/module/passage.js
@@ -1,0 +1,8 @@
+import Controller from '@ember/controller';
+import { tracked } from '@glimmer/tracking';
+
+export default class Module extends Controller {
+  queryParams = ['grainIndex'];
+
+  @tracked grainIndex;
+}

--- a/mon-pix/app/routes/module/passage.js
+++ b/mon-pix/app/routes/module/passage.js
@@ -5,6 +5,7 @@ export default class ModulePassageRoute extends Route {
   @service store;
   @service passageEvents;
   @service moduleIssueReport;
+  @service modulixNavigationProgress;
   @service router;
 
   async model() {
@@ -20,6 +21,14 @@ export default class ModulePassageRoute extends Route {
     this.passageEvents.initialize({ passageId: passage.id });
     this.moduleIssueReport.initialize({ passageId: passage.id, moduleId: module.id });
     return { module, passage };
+  }
+
+  afterModel({ module }, transition) {
+    const grainIndex = transition.to?.queryParams?.grainIndex;
+
+    if (grainIndex) {
+      this.modulixNavigationProgress.computeCurrentSectionByGrainIndex(module, Number(grainIndex));
+    }
   }
 
   redirect({ module }) {

--- a/mon-pix/app/services/modulix-navigation-progress.js
+++ b/mon-pix/app/services/modulix-navigation-progress.js
@@ -23,4 +23,18 @@ export default class ModulixNavigationProgress extends Service {
       }
     }
   }
+
+  computeCurrentSectionByGrainIndex(module, grainIndex) {
+    const grains = module.sections.flatMap((section, index) => {
+      return section.grains.map((grain) => ({
+        ...grain,
+        sectionIndex: index,
+      }));
+    });
+
+    const isGrainIndexValid = !Number.isNaN(grainIndex) && grainIndex > 0 && grainIndex < grains.length;
+    const index = isGrainIndexValid ? grainIndex : 0;
+
+    this.currentSectionIndex = grains[index].sectionIndex;
+  }
 }

--- a/mon-pix/app/services/modulix-preview-mode.js
+++ b/mon-pix/app/services/modulix-preview-mode.js
@@ -10,6 +10,10 @@ export default class ModulixPreviewModeService extends Service {
     this.isEnabled = true;
   }
 
+  disable() {
+    this.isEnabled = false;
+  }
+
   get isPreviewAndElementsIdButtonEnabled() {
     return this.isEnabled && this.isElementsIdButtonEnabled;
   }

--- a/mon-pix/app/styles/components/llm/preview.scss
+++ b/mon-pix/app/styles/components/llm/preview.scss
@@ -5,11 +5,12 @@
 }
 
 .modulix-preview {
-  &__elements-id-button {
+  &__panel {
     position: sticky;
     top: var(--pix-spacing-6x);
     z-index: 200;
     display: inline-block;
+    width: 15rem;
     margin-left: var(--pix-spacing-6x);
     padding: var(--pix-spacing-4x);
     background-color: var(--pix-neutral-0);
@@ -19,5 +20,13 @@
 
   &__elements-id-tag {
     margin: var(--pix-spacing-2x) 0;
+  }
+}
+
+.modulix-preview-panel {
+  &__grain-form {
+    display: flex;
+    flex-direction: column;
+    gap: var(--pix-spacing-2x);
   }
 }

--- a/mon-pix/app/styles/components/llm/preview.scss
+++ b/mon-pix/app/styles/components/llm/preview.scss
@@ -6,7 +6,7 @@
 
 .modulix-preview {
   &__panel {
-    position: sticky;
+    position: fixed;
     top: var(--pix-spacing-6x);
     z-index: 200;
     display: inline-block;

--- a/mon-pix/app/templates/module/passage.gjs
+++ b/mon-pix/app/templates/module/passage.gjs
@@ -1,6 +1,6 @@
 import Passage from 'mon-pix/components/module/passage';
 <template>
   <div class="modulix">
-    <Passage @module={{@model.module}} @passage={{@model.passage}} />
+    <Passage @grainIndex={{@controller.grainIndex}} @module={{@model.module}} @passage={{@model.passage}} />
   </div>
 </template>

--- a/mon-pix/tests/integration/components/module/passage_test.gjs
+++ b/mon-pix/tests/integration/components/module/passage_test.gjs
@@ -1466,6 +1466,25 @@ module('Integration | Component | Module | Passage', function (hooks) {
     });
   });
 
+  module('when passage is initialized', function () {
+    test('should disable preview mode', async function (assert) {
+      // given
+      const previewMode = this.owner.lookup('service:modulix-preview-mode');
+
+      const textElement = { content: 'content', type: 'text' };
+      const grain = { components: [{ type: 'element', element: textElement }] };
+      const section = { id: 'section1', type: 'blank', grains: [grain] };
+      const module = { title: 'Module title', sections: [section] };
+      const passage = { id: '1' };
+
+      // when
+      await render(<template><ModulePassage @module={{module}} @passage={{passage}} /></template>);
+
+      // then
+      assert.false(previewMode.isEnabled);
+    });
+  });
+
   module('when grainIndex is provided', function () {
     function buildModuleWithGrains(count) {
       const textElement = { content: 'content', type: 'text' };

--- a/mon-pix/tests/integration/components/module/passage_test.gjs
+++ b/mon-pix/tests/integration/components/module/passage_test.gjs
@@ -1,5 +1,4 @@
 import { clickByName, render } from '@1024pix/ember-testing-library';
-import Service from '@ember/service';
 import { click, findAll } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import ApplicationAdapter from 'mon-pix/adapters/application';

--- a/mon-pix/tests/integration/components/module/passage_test.gjs
+++ b/mon-pix/tests/integration/components/module/passage_test.gjs
@@ -1470,7 +1470,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
       // given
       const previewMode = this.owner.lookup('service:modulix-preview-mode');
 
-      const textElement = { content: 'content', type: 'text' };
+      const textElement = { content: 'content', type: 'text', tag: ' ' };
       const grain = { components: [{ type: 'element', element: textElement }] };
       const section = { id: 'section1', type: 'blank', grains: [grain] };
       const module = { title: 'Module title', sections: [section] };
@@ -1486,7 +1486,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
 
   module('when grainIndex is provided', function () {
     function buildModuleWithGrains(count) {
-      const textElement = { content: 'content', type: 'text' };
+      const textElement = { content: 'content', type: 'text', tag: ' ' };
       const grains = Array.from({ length: count }, () => ({
         components: [{ type: 'element', element: textElement }],
       }));

--- a/mon-pix/tests/integration/components/module/passage_test.gjs
+++ b/mon-pix/tests/integration/components/module/passage_test.gjs
@@ -1,4 +1,5 @@
 import { clickByName, render } from '@1024pix/ember-testing-library';
+import Service from '@ember/service';
 import { click, findAll } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import ApplicationAdapter from 'mon-pix/adapters/application';
@@ -1462,6 +1463,107 @@ module('Integration | Component | Module | Passage', function (hooks) {
         },
       });
       assert.ok(true);
+    });
+  });
+
+  module('when grainIndex is provided', function () {
+    function buildModuleWithGrains(count) {
+      const textElement = { content: 'content', type: 'text' };
+      const grains = Array.from({ length: count }, () => ({
+        components: [{ type: 'element', element: textElement }],
+      }));
+      const section = { id: 'section1', type: 'blank', grains };
+      return { title: 'Module title', sections: [section] };
+    }
+
+    test('when grainIndex is valid, should display grains up to and including grainIndex', async function (assert) {
+      // given
+      const module = buildModuleWithGrains(4);
+      const passage = { id: '1' };
+      const grainIndex = '2';
+
+      // when
+      const screen = await render(
+        <template><ModulePassage @module={{module}} @passage={{passage}} @grainIndex={{grainIndex}} /></template>,
+      );
+
+      // then
+      assert.strictEqual(screen.getAllByRole('article').length, 3);
+    });
+
+    test('when grainIndex is "0", should display only the first grain', async function (assert) {
+      // given
+      const module = buildModuleWithGrains(4);
+      const passage = { id: '1' };
+      const grainIndex = '0';
+
+      // when
+      const screen = await render(
+        <template><ModulePassage @module={{module}} @passage={{passage}} @grainIndex={{grainIndex}} /></template>,
+      );
+
+      // then
+      assert.strictEqual(screen.getAllByRole('article').length, 1);
+    });
+
+    test('when grainIndex equals the total number of grains, should display only the first grain', async function (assert) {
+      // given
+      const module = buildModuleWithGrains(4);
+      const passage = { id: '1' };
+      const grainIndex = '4';
+
+      // when
+      const screen = await render(
+        <template><ModulePassage @module={{module}} @passage={{passage}} @grainIndex={{grainIndex}} /></template>,
+      );
+
+      // then
+      assert.strictEqual(screen.getAllByRole('article').length, 1);
+    });
+
+    test('when grainIndex is negative, should display only the first grain', async function (assert) {
+      // given
+      const module = buildModuleWithGrains(4);
+      const passage = { id: '1' };
+      const grainIndex = '-1';
+
+      // when
+      const screen = await render(
+        <template><ModulePassage @module={{module}} @passage={{passage}} @grainIndex={{grainIndex}} /></template>,
+      );
+
+      // then
+      assert.strictEqual(screen.getAllByRole('article').length, 1);
+    });
+
+    test('when grainIndex is non-numeric, should display only the first grain', async function (assert) {
+      // given
+      const module = buildModuleWithGrains(4);
+      const passage = { id: '1' };
+      const grainIndex = 'abc';
+
+      // when
+      const screen = await render(
+        <template><ModulePassage @module={{module}} @passage={{passage}} @grainIndex={{grainIndex}} /></template>,
+      );
+
+      // then
+      assert.strictEqual(screen.getAllByRole('article').length, 1);
+    });
+
+    test('when grainIndex is valid but module has a redirectionUrl, should display only the first grain', async function (assert) {
+      // given
+      const module = { ...buildModuleWithGrains(4), redirectionUrl: 'https://example.com' };
+      const passage = { id: '1' };
+      const grainIndex = '2';
+
+      // when
+      const screen = await render(
+        <template><ModulePassage @module={{module}} @passage={{passage}} @grainIndex={{grainIndex}} /></template>,
+      );
+
+      // then
+      assert.strictEqual(screen.getAllByRole('article').length, 1);
     });
   });
 

--- a/mon-pix/tests/integration/components/module/preview_test.gjs
+++ b/mon-pix/tests/integration/components/module/preview_test.gjs
@@ -82,11 +82,58 @@ module('Integration | Component | Module | Preview', function (hooks) {
       assert.dom(displayJsonButton).doesNotExist();
     });
 
+    test('should display the grain navigation form', async function (assert) {
+      // given
+      const moduleData = {
+        title: 'Existing module',
+        sections: [{ type: 'blank', grains: [{ title: 'Grain 1', components: [] }] }],
+      };
+
+      // when
+      const screen = await render(<template><ModulixPreview @module={{moduleData}} /></template>);
+
+      // then
+      assert.dom(screen.getByRole('button', { name: t('pages.modulix.preview.grain-select.button') })).exists();
+    });
+
+    module('#goToModuleGrain', function () {
+      test('should transition to module.passage with the selected grain index', async function (assert) {
+        // given
+        const router = this.owner.lookup('service:router');
+        const transitionToStub = sinon.stub(router, 'transitionTo');
+        const navigationProgress = this.owner.lookup('service:modulix-navigation-progress');
+        sinon.stub(navigationProgress, 'setCurrentSectionIndex');
+
+        const moduleData = {
+          title: 'Existing module',
+          sections: [
+            {
+              type: 'blank',
+              grains: [
+                { title: 'Grain 1', components: [] },
+                { title: 'Grain 2', components: [] },
+              ],
+            },
+          ],
+        };
+        const screen = await render(<template><ModulixPreview @module={{moduleData}} /></template>);
+
+        // when
+        await click(screen.getByRole('button', { name: t('pages.modulix.preview.grain-select.button') }));
+
+        // then
+        sinon.assert.calledOnceWithExactly(transitionToStub, 'module.passage', moduleData, {
+          queryParams: { grainIndex: '0' },
+        });
+        assert.ok(true);
+      });
+    });
+
     module('when has a section', function () {
       module('when section is type "blank"', function () {
         test('should not display section title', async function (assert) {
           // given
-          const moduleData = { title: 'Existing module', sections: [{ type: 'blank' }] };
+          const moduleData = { title: 'Existing module', sections: [{ type: 'blank', grains: [] }] };
           const screen = await render(<template><ModulixPreview @module={{moduleData}} /></template>);
 
           // then
@@ -100,7 +147,7 @@ module('Integration | Component | Module | Preview', function (hooks) {
           // given
           const moduleData = {
             title: 'Existing module',
-            sections: [{ type: 'question-yourself' }],
+            sections: [{ type: 'question-yourself', grains: [] }],
           };
           const screen = await render(<template><ModulixPreview @module={{moduleData}} /></template>);
 
@@ -118,7 +165,7 @@ module('Integration | Component | Module | Preview', function (hooks) {
           // given
           const moduleData = {
             title: 'Existing module',
-            sections: [{ type: 'practise' }],
+            sections: [{ type: 'practise', grains: [] }],
           };
           const screen = await render(<template><ModulixPreview @module={{moduleData}} /></template>);
 
@@ -131,6 +178,14 @@ module('Integration | Component | Module | Preview', function (hooks) {
         });
       });
     });
+  });
+
+  test('should not display grain navigation form when no module is provided', async function (assert) {
+    // when
+    const screen = await render(<template><ModulixPreview /></template>);
+
+    // then
+    assert.dom(screen.queryByRole('button', { name: t('pages.modulix.preview.grain-select.button') })).doesNotExist();
   });
 
   test('should display a button display elements id', async function (assert) {

--- a/mon-pix/tests/unit/routes/module/passage-test.js
+++ b/mon-pix/tests/unit/routes/module/passage-test.js
@@ -79,6 +79,42 @@ module('Unit | Route | modules | passage', function (hooks) {
     });
   });
 
+  module('#afterModel', function () {
+    test('should call computeCurrentSectionByGrainIndex when grainIndex is present in query params', function (assert) {
+      // given
+      const route = this.owner.lookup('route:module.passage');
+      const modulixNavigationProgress = this.owner.lookup('service:modulix-navigation-progress');
+      modulixNavigationProgress.computeCurrentSectionByGrainIndex = sinon.stub();
+
+      const module = { id: 'module-id' };
+      const transition = { to: { queryParams: { grainIndex: '3' } } };
+
+      // when
+      route.afterModel({ module }, transition);
+
+      // then
+      sinon.assert.calledOnceWithExactly(modulixNavigationProgress.computeCurrentSectionByGrainIndex, module, 3);
+      assert.ok(true);
+    });
+
+    test('should not call computeCurrentSectionByGrainIndex when grainIndex is absent from query params', function (assert) {
+      // given
+      const route = this.owner.lookup('route:module.passage');
+      const modulixNavigationProgress = this.owner.lookup('service:modulix-navigation-progress');
+      modulixNavigationProgress.computeCurrentSectionByGrainIndex = sinon.stub();
+
+      const module = { id: 'module-id' };
+      const transition = { to: { queryParams: {} } };
+
+      // when
+      route.afterModel({ module }, transition);
+
+      // then
+      sinon.assert.notCalled(modulixNavigationProgress.computeCurrentSectionByGrainIndex);
+      assert.ok(true);
+    });
+  });
+
   module('#redirect', function () {
     test('should call replaceWith function with the right arguments', async function (assert) {
       // given

--- a/mon-pix/tests/unit/services/modulix-navigation-progress-test.js
+++ b/mon-pix/tests/unit/services/modulix-navigation-progress-test.js
@@ -133,4 +133,69 @@ module('Unit | Services | Module | ModulixNavigationProgress', function (hooks) 
       });
     });
   });
+
+  module('#computeCurrentSectionByGrainIndex', function () {
+    const module = {
+      sections: [
+        { grains: [{ id: 'grain-0' }, { id: 'grain-1' }] },
+        { grains: [{ id: 'grain-2' }, { id: 'grain-3' }] },
+        { grains: [{ id: 'grain-4' }] },
+      ],
+    };
+
+    test('should set currentSectionIndex based on a valid grainIndex', function (assert) {
+      // given
+      const service = this.owner.lookup('service:modulix-navigation-progress');
+
+      // when
+      service.computeCurrentSectionByGrainIndex(module, 2);
+
+      // then
+      assert.strictEqual(service.currentSectionIndex, 1);
+    });
+
+    test('should set currentSectionIndex to 0 when grainIndex is 0', function (assert) {
+      // given
+      const service = this.owner.lookup('service:modulix-navigation-progress');
+
+      // when
+      service.computeCurrentSectionByGrainIndex(module, 0);
+
+      // then
+      assert.strictEqual(service.currentSectionIndex, 0);
+    });
+
+    test('should set currentSectionIndex to 0 when grainIndex is negative', function (assert) {
+      // given
+      const service = this.owner.lookup('service:modulix-navigation-progress');
+
+      // when
+      service.computeCurrentSectionByGrainIndex(module, -1);
+
+      // then
+      assert.strictEqual(service.currentSectionIndex, 0);
+    });
+
+    test('should set currentSectionIndex to 0 when grainIndex is out of bounds', function (assert) {
+      // given
+      const service = this.owner.lookup('service:modulix-navigation-progress');
+
+      // when
+      service.computeCurrentSectionByGrainIndex(module, 5);
+
+      // then
+      assert.strictEqual(service.currentSectionIndex, 0);
+    });
+
+    test('should set currentSectionIndex to 0 when grainIndex is NaN', function (assert) {
+      // given
+      const service = this.owner.lookup('service:modulix-navigation-progress');
+
+      // when
+      service.computeCurrentSectionByGrainIndex(module, NaN);
+
+      // then
+      assert.strictEqual(service.currentSectionIndex, 0);
+    });
+  });
 });

--- a/mon-pix/tests/unit/services/modulix-preview-mode-test.js
+++ b/mon-pix/tests/unit/services/modulix-preview-mode-test.js
@@ -23,6 +23,20 @@ module('Unit | Service | modulix-preview-mode', function (hooks) {
     assert.true(previewMode.isEnabled);
   });
 
+  module('disable', function () {
+    test('it disables preview mode', function (assert) {
+      // given
+      const previewMode = this.owner.lookup('service:modulix-preview-mode');
+      previewMode.enable();
+
+      // when
+      previewMode.disable();
+
+      // then
+      assert.false(previewMode.isEnabled);
+    });
+  });
+
   module('isElementsIdButtonEnabled', function () {
     test('it should be enabled by default', function (assert) {
       // when

--- a/mon-pix/translations/de.json
+++ b/mon-pix/translations/de.json
@@ -1781,6 +1781,11 @@
           },
           "label": "ID der Elemente anzeigen"
         },
+        "grain-select": {
+          "button": "Grain testen",
+          "grain-label": "Grain {index} : {title}",
+          "label": "Wählen Sie das zu testende Grain aus"
+        },
         "modulix-editor": "Modulix Editor",
         "showJson": "JSON anzeigen",
         "stepper": "Preview: Stepper {direction}",

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1781,6 +1781,11 @@
           },
           "label": "Display elements ID"
         },
+        "grain-select": {
+          "button": "Test the grain",
+          "grain-label": "Grain {index} : {title}",
+          "label": "Choose the grain to test"
+        },
         "modulix-editor": "Modulix Editor",
         "showJson": "Show JSON",
         "stepper": "Preview : stepper {direction}",

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1777,6 +1777,11 @@
           },
           "label": "Mostrar ID de los elementos"
         },
+        "grain-select": {
+          "button": "Probar el grain",
+          "grain-label": "Grain {index} : {title}",
+          "label": "Elige el grain a probar"
+        },
         "modulix-editor": "Modulix Editor",
         "showJson": "Show JSON",
         "stepper": "Preview : stepper {direction}",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1783,6 +1783,11 @@
           },
           "label": "Afficher l'ID des éléments"
         },
+        "grain-select": {
+          "button": "Tester le grain",
+          "grain-label": "Grain {index} : {title}",
+          "label": "Choisissez le grain à tester"
+        },
         "modulix-editor": "Modulix Editor",
         "showJson": "Afficher le JSON",
         "stepper": "Preview : stepper {direction}",

--- a/mon-pix/translations/it.json
+++ b/mon-pix/translations/it.json
@@ -1775,6 +1775,11 @@
         }
       },
       "preview": {
+        "grain-select": {
+          "button": "Testare il grain",
+          "grain-label": "Grain {index} : {title}",
+          "label": "Scegli il grain da testare"
+        },
         "showJson": "Visualizzare JSON",
         "stepper": "Anteprima: stepper {direction}",
         "textarea-label": "Contenuto del modulo"

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1781,6 +1781,11 @@
           },
           "label": "De ID's van de elementen weergeven"
         },
+        "grain-select": {
+          "button": "Grain testen",
+          "grain-label": "Grain {index} : {title}",
+          "label": "Kies het te testen grain"
+        },
         "modulix-editor": "Modulix Editor",
         "showJson": "Show JSON",
         "stepper": "Preview : stepper {direction}",


### PR DESCRIPTION
## 🌎 Problème

Dans le cas où on veut accéder à un grain spécifique d’un module, il faut faire à chaque fois tout le contenu du module jusqu'à ce grain ce qui peut prendre beaucoup de temps.

## 🔭 Proposition
Ajouter, dans la preview d'un module, un formulaire permettant d'accéder au grain qu'on veut.
Ce formulaire est composé d'un sélecteur de grain ainsi que d'un bouton.
Ceci va immédiatement lancer le module à partir du grain en question avec un query param `grainIndex`

## 🪐 Remarques
- Des vérifications ont été mises pour ne pas utiliser cette fonctionnalité dans le cadre d'un combinix (vérification du param `redirectionUrl`)
- Claude a été utilisé sur cette PR en utilisant 2 prompts : 
  - ajoutes la traduction pour les textes en dur sur le dernier commit
  - ajoutes des tests d'intégration sur le fichier X 

## 🚀 Pour tester
- Aller sur la [preview](https://app-pr15611.review.pix.fr/modules/preview/bac-a-sable) du module bac-a-sable
- Constater qu'un formulaire apparaît maintenant à gauche en dessous du toggle pour afficher les élément Ids.
- Sélectionner un grain dans la liste et cliquer sur `Tester le grain`
- Vérifier que le bon grain est affiché et que la barre de navigation pointe bien sur la bonne section

🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘 🌑
