### PR TITLE
[TECH] Lancer les tests e2e cypress lorsque le dossier a été modifié (PIX-FIX).

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,3 +62,4 @@ workflows:
             junior/.*                           run-junior            true
             audit-logger/.*                     run-audit-logger      true
             high-level-tests/e2e-playwright/.*  run-e2e-playwright    true
+            high-level-tests/e2e/.*             run-e2e-cypress       true

--- a/.circleci/jobs.yml
+++ b/.circleci/jobs.yml
@@ -51,6 +51,9 @@ parameters:
   run-e2e-playwright:
     type: boolean
     default: false
+  run-e2e-cypress:
+    type: boolean
+    default: false
 
 orbs:
   browser-tools: circleci/browser-tools@1.5.3
@@ -944,7 +947,7 @@ jobs:
       - run:
           name: Skip if not needed
           command: |
-            if [[ "$CIRCLE_BRANCH" != "dev" ]] && [[ "<< pipeline.parameters.run-mon-pix >>" == "false" ]] && [[ "<< pipeline.parameters.run-api >>" == "false" ]]; then
+            if [[ "$CIRCLE_BRANCH" != "dev" ]] && [[ "<< pipeline.parameters.run-mon-pix >>" == "false" ]] && [[ "<< pipeline.parameters.run-api >>" == "false" ]] && [[ "<< pipeline.parameters.run-e2e-cypress >>" == "false" ]]; then
               circleci step halt
             fi
       - browser-tools/install-chrome
@@ -1024,7 +1027,7 @@ jobs:
       - run:
           name: Skip if not needed
           command: |
-            if [[ "$CIRCLE_BRANCH" != "dev" ]] && [[ "<< pipeline.parameters.run-orga >>" == "false" ]] && [[ "<< pipeline.parameters.run-api >>" == "false" ]]; then
+            if [[ "$CIRCLE_BRANCH" != "dev" ]] && [[ "<< pipeline.parameters.run-orga >>" == "false" ]] && [[ "<< pipeline.parameters.run-api >>" == "false" ]] && [[ "<< pipeline.parameters.run-e2e-cypress >>" == "false" ]]; then
               circleci step halt
             fi
       - browser-tools/install-chrome


### PR DESCRIPTION
## 🌎 Problème

Une montée de version des packages lock a été faites sur les e2e et c'était ko. Comme les tests ne sont pas trigger au changement. Nous avons vu que bien trop tard, l'état instable de ce merge.

## 🔭 Proposition

Ajouter le dossier e2e cypress en parameter et executer le job si le folder est modifié

## 🪐 Remarques

RAS

🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘 🌑