### PR TITLE
[TECH] Mise à jour des builders des réseaux, structures, organisations (PIX-22039)

### DIFF
--- a/api/db/database-builder/database-builder.js
+++ b/api/db/database-builder/database-builder.js
@@ -15,6 +15,13 @@ const READONLY_TABLES = [
 const CHUNK_SIZE = 1000;
 
 /**
+ * @typedef {object} Factory
+ * @property {typeof import('./factory/build-network.js').buildNetworkAndHeadOrganization} buildNetworkAndHeadOrganization
+ * @property {typeof import('./factory/build-network.js').buildNetworkWithMultipleLevels} buildNetworkWithMultipleLevels
+ * @property {typeof import('./factory/build-organization.js').buildOrganizationInNetwork} buildOrganizationInNetwork
+ */
+
+/**
  * @class DatabaseBuilder
  * @property {Factory} factory
  */
@@ -32,6 +39,7 @@ export class DatabaseBuilder {
 
   constructor({ knex, emptyFirst = true, databaseBuffer = defaultDatabaseBuffer, beforeEmptyDatabase }) {
     this.knex = knex;
+    /** @type {Factory} */
     this.factory = factory;
     this.#databaseBuffer = databaseBuffer;
     this.#emptyFirst = emptyFirst;

--- a/api/db/database-builder/factory/build-network.js
+++ b/api/db/database-builder/factory/build-network.js
@@ -20,17 +20,104 @@ const buildNetwork = function ({
     values,
   });
 };
+
+/**
+ * Creates a network with its head organization (organization + structure + fct_structure).
+ *
+ * @param {object} [options]
+ * @param {number} [options.id] - Network id
+ * @param {string} [options.name] - Network name
+ * @param {Parameters<typeof buildOrganization>[0]} [options.headOrganization] - Any parameter accepted by buildOrganization
+ * @returns {{ id: number, name: string }} The created network
+ */
 const buildNetworkAndHeadOrganization = function ({
   id = databaseBuffer.getNextId(),
   name = 'Network',
-  organizationId,
-  organizationName = 'Head Organization',
+  headOrganization = {},
 } = {}) {
   const network = buildNetwork({ id, name });
-  const organization = buildOrganization({ id: organizationId, name: organizationName });
+  const organization = buildOrganization({ name: 'Head Organization', ...headOrganization });
   const structure = buildStructure();
   buildFactStructure({ structureId: structure.id, networkId: network.id, organizationId: organization.id });
   return network;
 };
 
-export { buildNetwork, buildNetworkAndHeadOrganization };
+/**
+ * Creates a network with a multi-level organization hierarchy.
+ *
+ * @param {object} [options]
+ * @param {number} [options.id] - Network id
+ * @param {string} [options.name] - Network name
+ * @param {number} [options.numberOfLevels=3] - Total number of levels, head included
+ * @param {number} [options.childrenPerNode=1] - Number of children per node at each level
+ * @returns {{ network: object, head: { organization: object, structure: object }, levels: Array<Array<{ organization: object, structure: object }>> }}
+ *   - `network`: the created network
+ *   - `head`: the head node `{ organization, structure }`
+ *   - `levels`: array starting at level 1, each entry is an array of `{ organization, structure }`
+ *
+ * @example
+ * const { network, head, levels } = buildNetworkWithMultipleLevels({ numberOfLevels: 3, childrenPerNode: 2 });
+ * // network  → { id, name }
+ * //
+ * // head     → { organization: { name: 'Head Organization', ... }, structure: { ... } }
+ * //
+ * // levels[0] → level 1 : 2 nodes (direct children of head)
+ * //   [
+ * //     { organization: { name: 'Organization' }, structure: { parentStructureId: head.structure.id } },
+ * //     { organization: { name: 'Organization' }, structure: { parentStructureId: head.structure.id } },
+ * //   ]
+ * //
+ * // levels[1] → level 2 : 4 nodes (2 children per level-1 node)
+ * //   [
+ * //     { organization: { name: 'Organization' }, structure: { parentStructureId: levels[0][0].structure.id } },
+ * //     { organization: { name: 'Organization' }, structure: { parentStructureId: levels[0][0].structure.id } },
+ * //     { organization: { name: 'Organization' }, structure: { parentStructureId: levels[0][1].structure.id } },
+ * //     { organization: { name: 'Organization' }, structure: { parentStructureId: levels[0][1].structure.id } },
+ * //   ]
+ */
+const buildNetworkWithMultipleLevels = function ({
+  id = databaseBuffer.getNextId(),
+  name = 'Network',
+  numberOfLevels = 3,
+  childrenPerNode = 1,
+} = {}) {
+  const network = buildNetwork({ id, name });
+
+  const headStructure = buildStructure();
+  const headOrganization = buildOrganization({ name: 'Head Organization' });
+  buildFactStructure({
+    structureId: headStructure.id,
+    networkId: network.id,
+    organizationId: headOrganization.id,
+  });
+
+  const levels = [];
+  let parentNodes = [{ organization: headOrganization, structure: headStructure }];
+
+  for (let level = 1; level < numberOfLevels; level++) {
+    const currentLevel = [];
+    for (const { structure } of parentNodes) {
+      for (let i = 0; i < childrenPerNode; i++) {
+        currentLevel.push(_createChildNode(structure, level));
+      }
+    }
+    levels.push(currentLevel);
+    parentNodes = currentLevel;
+  }
+
+  return { network, head: { organization: headOrganization, structure: headStructure }, levels };
+};
+
+export { buildNetwork, buildNetworkAndHeadOrganization, buildNetworkWithMultipleLevels };
+
+function _createChildNode(parentStructure, level) {
+  const structure = buildStructure();
+  const organization = buildOrganization({ name: `Organization L${level}` });
+  buildFactStructure({
+    structureId: structure.id,
+    networkId: parentStructure.networkId,
+    organizationId: organization.id,
+    parentStructureId: parentStructure.id,
+  });
+  return { organization, structure };
+}

--- a/api/db/database-builder/factory/build-organization.js
+++ b/api/db/database-builder/factory/build-organization.js
@@ -1,7 +1,9 @@
 import { COUNTRY_FRANCE_CODE } from '../../seeds/data/common/constants.js';
 import { databaseBuffer } from '../database-buffer.js';
 import { buildAdministrationTeam } from './build-administration-team.js';
+import { buildFactStructure } from './build-fact-structure.js';
 import { buildOrganizationLearnerType } from './build-organization-learner-type.js';
+import { buildStructure } from './build-structure.js';
 
 const buildOrganization = function buildOrganization({
   id = databaseBuffer.getNextId(),
@@ -68,4 +70,20 @@ const buildOrganization = function buildOrganization({
   });
 };
 
-export { buildOrganization };
+/**
+ * Creates an organization attached to an existing network (organization + structure + fct_structure).
+ *
+ * @param {object} options
+ * @param {number} options.networkId - Id of the network to attach the organization to
+ * @param {number} [options.parentStructureId] - Id of the parent structure (null for a head organization)
+ * @param {object} [options.organizationData] - Any parameter accepted by buildOrganization
+ * @returns {{ organization: object, structure: object }}
+ */
+const buildOrganizationInNetwork = function ({ networkId, parentStructureId = null, organizationData = {} } = {}) {
+  const organization = buildOrganization(organizationData);
+  const structure = buildStructure();
+  buildFactStructure({ structureId: structure.id, networkId, organizationId: organization.id, parentStructureId });
+  return { organization, structure };
+};
+
+export { buildOrganization, buildOrganizationInNetwork };

--- a/api/tests/organizational-entities/acceptance/application/network/network.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/network/network.admin.route.test.js
@@ -63,8 +63,7 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | N
       const network = databaseBuilder.factory.buildNetworkAndHeadOrganization({
         id: 1,
         name: 'Mon réseau',
-        organizationId: 555,
-        organizationName: 'Tête de réseau',
+        headOrganization: { id: 555, name: 'Tête de réseau' },
       });
       await databaseBuilder.commit();
       const options = {

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/network.repository.test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/network.repository.test.js
@@ -96,15 +96,10 @@ describe('Integration | Organizational Entities | Infrastructure | Repositories 
     describe('when the network is found', function () {
       it('returns the network with head organization informations', async function () {
         // given
-        const headOrganization = databaseBuilder.factory.buildOrganization({ name: 'Orga tête de réseau' });
-        const headStructureId = databaseBuilder.factory.buildStructure().id;
-
-        const network = databaseBuilder.factory.buildNetwork({ name: 'Mon super réseau' });
-
-        databaseBuilder.factory.buildFactStructure({
-          structureId: headStructureId,
-          networkId: network.id,
-          organizationId: headOrganization.id,
+        const headOrganizationId = 999;
+        const network = databaseBuilder.factory.buildNetworkAndHeadOrganization({
+          name: 'Mon super réseau',
+          headOrganization: { id: headOrganizationId, name: 'Orga tête de réseau' },
         });
 
         await databaseBuilder.commit();
@@ -116,7 +111,7 @@ describe('Integration | Organizational Entities | Infrastructure | Repositories 
         const expectedNetwork = domainBuilder.acquisition.buildNetwork({
           id: network.id,
           name: 'Mon super réseau',
-          organizationId: headOrganization.id,
+          organizationId: headOrganizationId,
           organizationName: 'Orga tête de réseau',
         });
 
@@ -126,26 +121,9 @@ describe('Integration | Organizational Entities | Infrastructure | Repositories 
       context('when there are several organizations in the network', function () {
         it('returns the network with correct head organization informations', async function () {
           // given
-          const childOrganization = databaseBuilder.factory.buildOrganization({
-            name: 'Not head organization but still in the same network',
-          });
-          const childStructureId = databaseBuilder.factory.buildStructure().id;
-          const headOrganization = databaseBuilder.factory.buildOrganization({ name: 'Head organization' });
-          const headStructureId = databaseBuilder.factory.buildStructure().id;
-
-          const network = databaseBuilder.factory.buildNetwork({ name: 'My network' });
-
-          databaseBuilder.factory.buildFactStructure({
-            structureId: headStructureId,
-            networkId: network.id,
-            organizationId: headOrganization.id,
-          });
-
-          databaseBuilder.factory.buildFactStructure({
-            structureId: childStructureId,
-            networkId: network.id,
-            organizationId: childOrganization.id,
-            parentStructureId: headStructureId,
+          const { network, head } = databaseBuilder.factory.buildNetworkWithMultipleLevels({
+            name: 'My network',
+            numberOfLevels: 2,
           });
 
           await databaseBuilder.commit();
@@ -157,8 +135,8 @@ describe('Integration | Organizational Entities | Infrastructure | Repositories 
           const expectedNetwork = domainBuilder.acquisition.buildNetwork({
             id: network.id,
             name: 'My network',
-            organizationId: headOrganization.id,
-            organizationName: 'Head organization',
+            organizationId: head.organization.id,
+            organizationName: head.organization.name,
           });
 
           expect(foundNetwork).to.deepEqualInstance(expectedNetwork);
@@ -169,16 +147,7 @@ describe('Integration | Organizational Entities | Infrastructure | Repositories 
     describe('when the network is not found', function () {
       it('throws a not found error', async function () {
         // given
-        const headOrganization = databaseBuilder.factory.buildOrganization({ name: 'Orga tête de réseau' });
-        const headStructureId = databaseBuilder.factory.buildStructure().id;
-
-        const network = databaseBuilder.factory.buildNetwork({ id: 1, name: 'Réseau avec id 1' });
-
-        databaseBuilder.factory.buildFactStructure({
-          structureId: headStructureId,
-          networkId: network.id,
-          organizationId: headOrganization.id,
-        });
+        databaseBuilder.factory.buildNetworkAndHeadOrganization({ id: 1, name: 'Réseau avec id 1' });
 
         await databaseBuilder.commit();
 

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/organization-for-admin.repository.test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/organization-for-admin.repository.test.js
@@ -1093,15 +1093,10 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
     describe('when the organization belongs to a network', function () {
       it('should return the network with head organization info', async function () {
         // given
-        const organization = databaseBuilder.factory.buildOrganization({
-          organizationLearnerTypeId: organizationLearnerType.id,
-        });
         const network = databaseBuilder.factory.buildNetwork({ name: 'Réseau Académique' });
-        const structure = databaseBuilder.factory.buildStructure();
-        databaseBuilder.factory.buildFactStructure({
-          structureId: structure.id,
+        const { organization } = databaseBuilder.factory.buildOrganizationInNetwork({
           networkId: network.id,
-          organizationId: organization.id,
+          organizationData: { organizationLearnerTypeId: organizationLearnerType.id },
         });
         await databaseBuilder.commit();
 


### PR DESCRIPTION
## 🌎 Problème

Les builders de données de test pour les réseaux créaient les entités de manière atomique et séparée, ce qui forçait chaque test à orchestrer manuellement la création de `structure` + `fct_structure` + `organization`.

## 🔭 Proposition

**`buildNetworkAndHeadOrganization`**
Les paramètres `organizationId` / `organizationName` sont remplacés par un objet `headOrganization` qui accepte n'importe quel paramètre de `buildOrganization` (spread). Plus extensible, moins de paramètres épars.

**`buildNetworkWithMultipleLevels`**
Nouveau builder qui crée un réseau en arbre. `childrenPerNode` contrôle la largeur à chaque niveau. La valeur de retour expose `{ network, head, levels }` pour que les tests accèdent directement aux nœuds créés sans re-querier.

**`buildOrganizationInNetwork`** (dans `build-organization.js`)
Crée la grappe complète `organization + structure + fct_structure` en une ligne. Placé dans `build-organization.js` car le sujet principal est l'organisation, le réseau est le contexte.

**JSDoc + typage `Factory`**
JSDoc sur les nouveaux builders + `@typedef Factory` dans `database-builder.js` pour que VSCode affiche la doc au survol de `databaseBuilder.factory.*`.

## 🪐 Remarques

`buildOrganization` reste un builder atomique sans effet de bord — il n'y a pas de contrainte FK qui force la création d'une structure. `buildOrganizationInNetwork` est réservé aux tests qui ont besoin du contexte réseau complet.

`buildStructure` n'a pas été enrichi : `structure` est une table de dimension sans sémantique propre, elle n'existe que pour être référencée dans `fct_structure`. Si elle gagne des colonnes significatives (type d'établissement, code UAI…), ce sera le bon moment d'y revenir.


## 🚀 Pour tester

- Tests au vert
