### PR TITLE
[TECH] :recycle:Remplace l'utilisation de `lodash` par du JavaScript à la vanille

### DIFF
--- a/api/src/certification/enrolment/domain/services/session-code-service.js
+++ b/api/src/certification/enrolment/domain/services/session-code-service.js
@@ -1,15 +1,18 @@
-import _ from 'lodash';
-
 import { config } from '../../../../../src/shared/config.js';
+
+function sample(array) {
+  const len = array == null ? 0 : array.length;
+  return len ? array[Math.floor(Math.random() * len)] : undefined;
+}
 
 function _randomLetter() {
   const letters = config.availableCharacterForCode.letters.split('');
-  return _.sample(letters);
+  return sample(letters);
 }
 
 function _randomNumberCharacter() {
   const numberCharacter = config.availableCharacterForCode.numbers.split('');
-  return _.sample(numberCharacter);
+  return sample(numberCharacter);
 }
 
 function _generateSessionCode() {

--- a/api/src/certification/enrolment/domain/validators/candidate-validator.js
+++ b/api/src/certification/enrolment/domain/validators/candidate-validator.js
@@ -1,14 +1,12 @@
 import JoiDate from '@joi/date';
 import BaseJoi from 'joi';
 const Joi = BaseJoi.extend(JoiDate);
-import { _ } from '../../../../shared/infrastructure/utils/lodash-utils.js';
 import { BILLING_MODES, SUBSCRIPTION_TYPES } from '../../../shared/domain/constants.js';
 import { CERTIFICATION_CANDIDATES_ERRORS } from '../../../shared/domain/constants/certification-candidates-errors.js';
 import { ComplementaryCertificationKeys } from '../../../shared/domain/models/ComplementaryCertificationKeys.js';
 
-const COMPLEMENTARY_CERTIFICATIONS_EXCEPTED_DOUBLE_CERTIFICATION = _.omit(ComplementaryCertificationKeys, [
-  ComplementaryCertificationKeys.CLEA,
-]);
+// eslint-disable-next-line no-unused-vars
+const { CLEA, ...COMPLEMENTARY_CERTIFICATIONS_EXCEPTED_DOUBLE_CERTIFICATION } = ComplementaryCertificationKeys;
 
 const alternativeCoreOnly = Joi.array()
   .length(1)

--- a/api/src/certification/results/domain/usecases/get-certifications-results-for-livret-scolaire.js
+++ b/api/src/certification/results/domain/usecases/get-certifications-results-for-livret-scolaire.js
@@ -1,11 +1,11 @@
-import lodash from 'lodash';
-
 import { CertificationsResults } from '../read-models/livret-scolaire/CertificationsResults.js';
 import { Competence } from '../read-models/livret-scolaire/Competence.js';
 
-const { sortBy } = lodash;
+function sortBy(key) {
+  return (a, b) => (a[key] > b[key] ? 1 : b[key] > a[key] ? -1 : 0);
+}
 
-const getCertificationsResultsForLivretScolaire = async function ({
+export async function getCertificationsResultsForLivretScolaire({
   uai,
   certificationLivretScolaireRepository,
   competenceTreeRepository,
@@ -22,9 +22,7 @@ const getCertificationsResultsForLivretScolaire = async function ({
       return new Competence({ area, id: competence.index, name: competence.name });
     }),
   );
-  const sortedCompetences = sortBy(competences, 'id');
+  const sortedCompetences = competences.sort(sortBy('id'));
 
   return new CertificationsResults({ certifications, competences: sortedCompetences });
-};
-
-export { getCertificationsResultsForLivretScolaire };
+}

--- a/api/src/certification/shared/domain/services/certification-cpf-service.js
+++ b/api/src/certification/shared/domain/services/certification-cpf-service.js
@@ -1,10 +1,7 @@
-import lodash from 'lodash';
-
 import { normalizeAndSortChars } from '../../../../shared/infrastructure/utils/string-utils.js';
-
-const { isEmpty } = lodash;
-
 import { CERTIFICATION_CANDIDATES_ERRORS } from '../constants/certification-candidates-errors.js';
+
+const isEmpty = (obj) => [Object, Array].includes((obj || {}).constructor) && !Object.entries(obj || {}).length;
 
 const CpfValidationStatus = {
   FAILURE: 'FAILURE',


### PR DESCRIPTION
## 🌎 Problème

Nous utilisons une librairie externe (lodash) pour faire des choses que nous pourrions faire nativement en JavaScript

## 🔭 Proposition

Replacer quelques  utilisation de lodash par un équivalent en JavaScript natif.

## 🪐 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🚀 Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->

🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘 🌑
