### PR TITLE
[FEATURE] Permettre le tri par classe pour les imports génériques (PIX-22011)

### DIFF
--- a/api/src/prescription/organization-learner/application/learner-list-route.js
+++ b/api/src/prescription/organization-learner/application/learner-list-route.js
@@ -35,6 +35,7 @@ const register = async function (server) {
               participationCount: Joi.string().empty(''),
               lastnameSort: Joi.string().empty(''),
               latestParticipationOrder: Joi.string().empty(''),
+              divisionSort: Joi.string().empty(''),
             }).default({}),
           }),
         },

--- a/api/src/prescription/organization-learner/infrastructure/repositories/organization-participant-repository.js
+++ b/api/src/prescription/organization-learner/infrastructure/repositories/organization-participant-repository.js
@@ -5,6 +5,7 @@ import {
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { filterByFullName } from '../../../../shared/infrastructure/utils/filter-utils.js';
 import { fetchPage } from '../../../../shared/infrastructure/utils/knex-utils.js';
+import { IMPORT_KEY_FIELD } from '../../../learner-management/domain/constants.js';
 import { OrganizationParticipant } from '../../domain/read-models/OrganizationParticipant.js';
 
 async function findPaginatedFilteredParticipants({ organizationId, page, filters = {}, sort = {} }) {
@@ -55,7 +56,7 @@ function _organizationLearnerParticipantsQuery({
 }) {
   const knexConn = DomainTransaction.getConnection();
 
-  const orderByClause = _getOrderClause(sort);
+  const orderByClause = _getOrderClause(sort, extraColumns);
 
   const withQuery = _buildWithQuery({ organizationId, extraColumns, withImport, knexConn });
 
@@ -74,7 +75,7 @@ function _organizationLearnerParticipantsQuery({
   return query;
 }
 
-function _getOrderClause(sort) {
+function _getOrderClause(sort, extraColumns = []) {
   const orderByClause = ['lastName', 'firstName', 'id'];
   if (sort.participationCount) {
     orderByClause.unshift({
@@ -94,6 +95,16 @@ function _getOrderClause(sort) {
       column: 'lastParticipationDate',
       order: sort.latestParticipationOrder === 'desc' ? 'desc' : 'asc',
     });
+  }
+
+  if (sort.divisionSort) {
+    const divisionColumn = extraColumns.find(({ name }) => name === IMPORT_KEY_FIELD.COMMON_DIVISION);
+    if (divisionColumn) {
+      orderByClause.unshift({
+        column: divisionColumn.name,
+        order: sort.divisionSort === 'desc' ? 'desc' : 'asc',
+      });
+    }
   }
 
   return orderByClause;

--- a/api/tests/prescription/organization-learner/integration/infrastructure/repositories/organization-participant-repository_test.js
+++ b/api/tests/prescription/organization-learner/integration/infrastructure/repositories/organization-participant-repository_test.js
@@ -2370,6 +2370,65 @@ describe('Integration | Infrastructure | Repository | OrganizationParticipant', 
             expect(organizationParticipants[2].id).to.equal(eminemLearnerId);
           });
         });
+
+        context('sort by division', function () {
+          let cm1LearnerId, cm2LearnerId, cpLearnerId;
+
+          beforeEach(async function () {
+            organizationId = databaseBuilder.factory.buildOrganization().id;
+
+            const cm1 = databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
+              organizationId,
+              attributes: { Classe: 'CM1' },
+            });
+            const cm2 = databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
+              organizationId,
+              attributes: { Classe: 'CM2' },
+            });
+            const cp = databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
+              organizationId,
+              attributes: { Classe: 'CP' },
+            });
+
+            cm1LearnerId = cm1.id;
+            cm2LearnerId = cm2.id;
+            cpLearnerId = cp.id;
+
+            await databaseBuilder.commit();
+          });
+
+          it('should return participants sorted by ascendant division', async function () {
+            // when
+            const { organizationParticipants } =
+              await organizationParticipantRepository.findPaginatedFilteredImportedParticipants({
+                organizationId,
+                extraColumns: [{ key: 'Classe', name: 'COMMON_DIVISION' }],
+                sort: { divisionSort: 'asc' },
+              });
+
+            // then
+            expect(organizationParticipants).to.have.lengthOf(3);
+            expect(organizationParticipants[0].id).to.equal(cm1LearnerId);
+            expect(organizationParticipants[1].id).to.equal(cm2LearnerId);
+            expect(organizationParticipants[2].id).to.equal(cpLearnerId);
+          });
+
+          it('should return participants sorted by descendant division', async function () {
+            // when
+            const { organizationParticipants } =
+              await organizationParticipantRepository.findPaginatedFilteredImportedParticipants({
+                organizationId,
+                extraColumns: [{ key: 'Classe', name: 'COMMON_DIVISION' }],
+                sort: { divisionSort: 'desc' },
+              });
+
+            // then
+            expect(organizationParticipants).to.have.lengthOf(3);
+            expect(organizationParticipants[0].id).to.equal(cpLearnerId);
+            expect(organizationParticipants[1].id).to.equal(cm2LearnerId);
+            expect(organizationParticipants[2].id).to.equal(cm1LearnerId);
+          });
+        });
       });
     });
 

--- a/orga/app/components/organization-participant/list.gjs
+++ b/orga/app/components/organization-participant/list.gjs
@@ -251,34 +251,54 @@ export default class List extends Component {
             </PixTableColumn>
 
             {{#each this.customColumns as |heading|}}
-              <PixTableColumn @context={{context}}>
-                <:header>
-                  <div class="organization-participant__align-element">
+              {{#if (eq heading "COMMON_DIVISION")}}
+                <PixTableColumn
+                  @context={{context}}
+                  @onSort={{fn this.addResetOnFunction @sortByDivision reset}}
+                  @sortOrder={{@divisionSort}}
+                  @ariaLabelDefaultSort={{t
+                    "pages.organization-participants.table.column.division.ariaLabelDefaultSort"
+                  }}
+                  @ariaLabelSortAsc={{t "pages.organization-participants.table.column.division.ariaLabelSortUp"}}
+                  @ariaLabelSortDesc={{t "pages.organization-participants.table.column.division.ariaLabelSortDown"}}
+                >
+                  <:header>
                     {{t (getColumnName heading)}}
-                    {{#if (eq heading "ORALIZATION")}}
-                      <PixTooltip @id="organization-participants-oralization-tooltip" @isWide="true">
-                        <:triggerElement>
-                          <PixIcon
-                            @name="help"
-                            @plainIcon="true"
-                            aria-label={{t
-                              "pages.organization-participants.table.oralization-header-tooltip-aria-label"
-                            }}
-                            aria-describedby="organization-participants-oralization-tooltip"
-                          />
-                        </:triggerElement>
+                  </:header>
+                  <:cell>
+                    {{this.getExtraColumnRowValue heading participant}}
+                  </:cell>
+                </PixTableColumn>
+              {{else}}
+                <PixTableColumn @context={{context}}>
+                  <:header>
+                    <div class="organization-participant__align-element">
+                      {{t (getColumnName heading)}}
+                      {{#if (eq heading "ORALIZATION")}}
+                        <PixTooltip @id="organization-participants-oralization-tooltip" @isWide="true">
+                          <:triggerElement>
+                            <PixIcon
+                              @name="help"
+                              @plainIcon="true"
+                              aria-label={{t
+                                "pages.organization-participants.table.oralization-header-tooltip-aria-label"
+                              }}
+                              aria-describedby="organization-participants-oralization-tooltip"
+                            />
+                          </:triggerElement>
 
-                        <:tooltip>
-                          {{t "pages.organization-participants.table.oralization-header-tooltip"}}
-                        </:tooltip>
-                      </PixTooltip>
-                    {{/if}}
-                  </div>
-                </:header>
-                <:cell>
-                  {{this.getExtraColumnRowValue heading participant}}
-                </:cell>
-              </PixTableColumn>
+                          <:tooltip>
+                            {{t "pages.organization-participants.table.oralization-header-tooltip"}}
+                          </:tooltip>
+                        </PixTooltip>
+                      {{/if}}
+                    </div>
+                  </:header>
+                  <:cell>
+                    {{this.getExtraColumnRowValue heading participant}}
+                  </:cell>
+                </PixTableColumn>
+              {{/if}}
             {{/each}}
 
             {{#unless this.currentUser.canAccessMissionsPage}}

--- a/orga/app/controllers/authenticated/organization-participants/list.js
+++ b/orga/app/controllers/authenticated/organization-participants/list.js
@@ -20,6 +20,7 @@ export default class ListController extends Controller {
   @tracked participationCountOrder = null;
   @tracked latestParticipationOrder = null;
   @tracked lastnameSort = 'asc';
+  @tracked divisionSort = null;
 
   get hasComputeOrganizationLearnerCertificabilityEnabled() {
     return this.currentUser.prescriber.computeOrganizationLearnerCertificability;
@@ -54,6 +55,7 @@ export default class ListController extends Controller {
     this.pageNumber = null;
     this.latestParticipationOrder = null;
     this.lastnameSort = null;
+    this.divisionSort = null;
   }
 
   @action
@@ -64,6 +66,7 @@ export default class ListController extends Controller {
     this.pageNumber = null;
     this.participationCountOrder = null;
     this.lastnameSort = null;
+    this.divisionSort = null;
   }
 
   @action
@@ -74,6 +77,18 @@ export default class ListController extends Controller {
     this.pageNumber = null;
     this.participationCountOrder = null;
     this.latestParticipationOrder = null;
+    this.divisionSort = null;
+  }
+
+  @action
+  sortByDivision() {
+    if (!this.divisionSort) this.divisionSort = 'asc';
+    else this.divisionSort = this.divisionSort === 'asc' ? 'desc' : 'asc';
+
+    this.pageNumber = null;
+    this.participationCountOrder = null;
+    this.latestParticipationOrder = null;
+    this.lastnameSort = null;
   }
 
   @action

--- a/orga/app/routes/authenticated/organization-participants/list.js
+++ b/orga/app/routes/authenticated/organization-participants/list.js
@@ -14,6 +14,7 @@ export default class ListRoute extends Route {
     participationCountOrder: { refreshModel: true },
     latestParticipationOrder: { refreshModel: true },
     lastnameSort: { refreshModel: true },
+    divisionSort: { refreshModel: true },
   };
 
   @service currentUser;
@@ -33,6 +34,7 @@ export default class ListRoute extends Route {
         participationCount: params.participationCountOrder,
         latestParticipationOrder: params.latestParticipationOrder,
         lastnameSort: params.lastnameSort,
+        divisionSort: params.divisionSort,
       },
       page: {
         number: params.pageNumber,
@@ -51,6 +53,7 @@ export default class ListRoute extends Route {
       controller.participationCountOrder = null;
       controller.latestParticipationOrder = null;
       controller.lastnameSort = 'asc';
+      controller.divisionSort = null;
     }
   }
 

--- a/orga/app/templates/authenticated/organization-participants/list.gjs
+++ b/orga/app/templates/authenticated/organization-participants/list.gjs
@@ -24,6 +24,8 @@ import NoParticipantPanel from 'pix-orga/components/organization-participant/no-
         @sortByLastname={{@controller.sortByLastname}}
         @lastnameSort={{@controller.lastnameSort}}
         @latestParticipationOrder={{@controller.latestParticipationOrder}}
+        @divisionSort={{@controller.divisionSort}}
+        @sortByDivision={{@controller.sortByDivision}}
         @deleteParticipants={{@controller.deleteOrganizationLearners}}
         @hasComputeOrganizationLearnerCertificabilityEnabled={{@controller.hasComputeOrganizationLearnerCertificabilityEnabled}}
         @hasOrganizationParticipantPage={{@controller.hasOrganizationParticipantPage}}

--- a/orga/tests/unit/routes/authenticated/organization-participants/list-test.js
+++ b/orga/tests/unit/routes/authenticated/organization-participants/list-test.js
@@ -17,6 +17,7 @@ module('Unit | Route | authenticated/organization-participants/list', function (
   const participationCountOrderSymbol = Symbol('participationCountOrder');
   const latestParticipationOrderSymbol = Symbol('latestParticipationOrder');
   const lastnameSortSymbol = Symbol('lastnameSort');
+  const divisionSortSymbol = Symbol('divisionSort');
   const pageNumberSymbol = Symbol('pageNumber');
   const pageSizeSymbol = Symbol('pageSize');
 
@@ -26,6 +27,7 @@ module('Unit | Route | authenticated/organization-participants/list', function (
     extraFilters: extraFiltersSymbol,
     participationCountOrder: participationCountOrderSymbol,
     latestParticipationOrder: latestParticipationOrderSymbol,
+    divisionSort: divisionSortSymbol,
     lastnameSort: lastnameSortSymbol,
     pageNumber: pageNumberSymbol,
     pageSize: pageSizeSymbol,
@@ -56,6 +58,7 @@ module('Unit | Route | authenticated/organization-participants/list', function (
           participationCount: participationCountOrderSymbol,
           latestParticipationOrder: latestParticipationOrderSymbol,
           lastnameSort: lastnameSortSymbol,
+          divisionSort: divisionSortSymbol,
         },
         page: {
           number: pageNumberSymbol,
@@ -89,6 +92,7 @@ module('Unit | Route | authenticated/organization-participants/list', function (
       participationCountOrder: null,
       latestParticipationOrder: null,
       lastnameSort: 'asc',
+      divisionSort: null,
     });
   });
 });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -1460,6 +1460,11 @@
         },
         "column": {
           "checkbox": "Select/Unselect {firstname} {lastname}",
+          "division": {
+            "ariaLabelDefaultSort": "The table is currently not sorted by class. Click to sort by alphabetical order.",
+            "ariaLabelSortDown": "The table is sorted by class, in reverse alphabetical order. Click to sort by alphabetical order.",
+            "ariaLabelSortUp": "The table is sorted by class, in alphabetical order. Click to sort by reverse alphabetical order."
+          },
           "first-name": "First name",
           "is-certifiable": {
             "label": "Eligibility for certification"

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -1447,6 +1447,11 @@
         },
         "column": {
           "checkbox": "Sélectionner/Désélectionner {firstname} {lastname}",
+          "division": {
+            "ariaLabelDefaultSort": "Le tableau n'est actuellement pas trié par classe. Cliquez pour trier par ordre alphabétique.",
+            "ariaLabelSortDown": "Le tableau est trié par classe, dans l'ordre alphabétique inverse. Cliquez pour trier par ordre alphabétique.",
+            "ariaLabelSortUp": "Le tableau est trié par classe, dans l'ordre alphabétique. Cliquez pour trier par ordre alphabétique inverse."
+          },
           "first-name": "Prénom",
           "is-certifiable": {
             "label": "Certificabilité"


### PR DESCRIPTION
## 🌎 Problème

Les organisations utilisant un format d'import générique (ONDE, FWB, etc.) stockent la classe des apprenants dans la colonne `attributes` (JSONB) sous la clé `COMMON_DIVISION`. La page de liste des participants ne proposait pas de tri sur cette colonne, contrairement aux organisations SCO qui bénéficient déjà d'un tri par classe.

## 🔭 Proposition

Ajout du tri par classe (`divisionSort`) pour les participants issus d'un import générique :

- **API** : ajout du paramètre `divisionSort` dans la route et la logique de tri du repository
- **Orga** : la colonne `COMMON_DIVISION` devient cliquable et envoie le paramètre `divisionSort` à l'API

## 🚀 Pour tester

- [ ] Se connecter en tant que `admin-orga@example.net` sur PixOrga
- [ ] Aller sur l'organisation **PRO Import (Generic)**
- [ ]  Importer le fichier CSV
```
Nom apprenant;Prénom apprenant;Classe;Date de naissance
Dupont;Alice;CM1;2000-01-01
Martin;Bob;CP;2000-06-15
Bernard;Charlie;CM2;1999-03-20
Leroy;Diana;CM1;2001-05-10
Moreau;Ethan;CP;1999-11-22
Petit;Fiona;CM2;2000-08-03
Simon;Gabriel;CM1;2001-02-14
Laurent;Hannah;CP;1999-07-30
```
- [ ] Sur la page des participants, cliquer sur l'en-tête de la colonne **Classe**:  les participants se trient par classe (asc puis desc)

🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘 🌑