### PR TITLE
[FEATURE] Ajout du paramètre tag dans les éléments text des modules (PIX-22061).

### DIFF
--- a/api/src/devcomp/domain/models/element/Text.js
+++ b/api/src/devcomp/domain/models/element/Text.js
@@ -1,13 +1,28 @@
-import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
+import { assertEnumValue, assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
 import { Element } from './Element.js';
 
+const TextTagEnumValues = Object.freeze({
+  NONE: ' ',
+  CONTEXT: 'context',
+  DID_YOU_KNOW: 'did-you-know',
+  FURTHER_INFORMATION: 'further-information',
+  KEY_POINTS: 'key-points',
+  TIP: 'tip',
+});
+
 class Text extends Element {
-  constructor({ id, content }) {
-    super({ id, type: 'text' });
+  constructor({ id, content, tag }) {
+    super({ id, type: 'text', tag: ' ' });
 
     assertNotNullOrUndefined(content, 'The content is required for a text');
+    assertEnumValue(
+      TextTagEnumValues,
+      tag,
+      "The tag value must be one of: ' ', 'context', 'did-you-know', 'further-information', 'key-points', 'tip'",
+    );
 
     this.content = content;
+    this.tag = tag;
   }
 }
 

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/12_RangerFichiers_IND.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/12_RangerFichiers_IND.json
@@ -32,6 +32,7 @@
               "element": {
                 "id": "1101ef20-2e66-45c4-ab92-834aeda05a8d",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Voici le contenu du dossier «&nbsp;Documents&nbsp;» de l’ordinateur de Marie.</p><p><strong>Observez l’image ci-dessous puis répondez à la question.</strong></p>"
               }
             },
@@ -99,6 +100,7 @@
               "element": {
                 "id": "9835e064-096b-4daa-bb61-3174397587e9",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Mais ça veut dire quoi une organisation avec plusieurs niveaux de rangement ? <br>Découvrons-le à l’aide d’un schéma !</p>"
               }
             }
@@ -120,6 +122,7 @@
               "element": {
                 "id": "72dc94ee-2e28-47f0-8605-aa4242b94961",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Clarisse a ouvert le dossier «&nbsp;Famille&nbsp;» de son ordinateur.<br>Une fenêtre s’ouvre et lui montre les fichiers qui se trouve dans le dossier «&nbsp;Famille&nbsp;» mais aussi l’organisation de ses dossiers&nbsp;:</p>"
               }
             },
@@ -140,6 +143,7 @@
               "element": {
                 "id": "be9ec4db-b29b-4787-ad90-33cbbaa349f7",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Maintenant, voici un schéma qui représente cette organisation.<br><strong>Observez le schéma suivant puis répondez aux questions ci-dessous.</strong></p>"
               }
             },
@@ -262,6 +266,7 @@
               "element": {
                 "id": "073ac979-06a6-4be3-896b-781923f214ac",
                 "type": "text",
+                "tag": " ",
                 "content": "Cette organisation de dossiers et de fichiers forme une <strong>arborescence</strong>, dans laquelle les <strong>dossiers</strong> (et sous dossiers) sont des niveaux intermédiaires de rangement. 📁"
               }
             }
@@ -277,6 +282,7 @@
               "element": {
                 "id": "5958b280-ca47-4af4-b723-d7253e3724a5",
                 "type": "text",
+                "tag": " ",
                 "content": "Dans cette arborescence, tous les dossiers ne donnent pas accès aux mêmes fichiers . Pour accéder à un fichier précis, il faut suivre le bon chemin ! 🗺️ <br>Voyons cela ensemble."
               }
             }
@@ -292,6 +298,7 @@
               "element": {
                 "id": "fb2f5ae0-2aec-4b38-b94a-adfde8da70e0",
                 "type": "text",
+                "tag": " ",
                 "content": "<strong>Observez l’arborescence suivante puis répondez à la question ci-dessous.</strong>"
               }
             },
@@ -447,6 +454,7 @@
               "element": {
                 "id": "b2f32e18-08ae-4348-970f-f894d78481a1",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Il faut parfois ouvrir plusieurs dossiers les uns après les autres pour accéder à un fichier.<br>📍 Le <strong>chemin d’accès à un fichier indique où il se trouve</strong> dans l’arborescence.</p>"
               }
             }
@@ -462,6 +470,7 @@
               "element": {
                 "id": "c34b1fac-1866-4009-8134-95c055a3c948",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Maintenant que vous savez reconstituer le chemin d’accès d’un fichier, découvrez comment accéder à ce fichier depuis votre ordinateur.</p>"
               }
             }
@@ -477,6 +486,7 @@
               "element": {
                 "id": "6c314f13-5614-44e0-8959-14ef2ef397c3",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Tous les dossiers et fichiers présents sur un ordinateur ne sont pas visibles sur le bureau. Un logiciel permet d’y accéder.</p>"
               }
             },
@@ -541,6 +551,7 @@
               "element": {
                 "id": "396abb24-bc62-458a-a051-945bfd38b658",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><strong>Feedback&nbsp;:</strong> Sur un ordinateur, le <strong>gestionnaire de fichiers</strong> permet d’<strong>accéder aux dossiers et aux fichiers</strong> et aussi de <strong>les organiser</strong> (les déplacer, les supprimer, les renommer…). <br>Selon l’appareil, le gestionnaire de fichiers peut porter des <strong>noms différents</strong>, mais son rôle reste le même,  par exemple&nbsp;: <em>Explorateur de fichiers</em> sur Windows ou <em>Finder</em> sur Mac. </p>"
               }
             }
@@ -556,6 +567,7 @@
               "element": {
                 "id": "5b418658-4e48-4d5e-ba23-4b9a9674b54f",
                 "type": "text",
+                "tag": " ",
                 "content": "Une fois le gestionnaire de fichiers ouvert, il est possible d’afficher les dossiers et fichiers de différentes manières selon ce que l’on cherche à voir."
               }
             },
@@ -564,6 +576,7 @@
               "element": {
                 "id": "ef4de526-525d-4f86-be17-350b5586afdb",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><strong>Accédez au gestionnaire de fichiers puis&nbsp;: </strong></p><ul><li><strong>Retrouvez la photo «&nbsp;Cousinade&nbsp;» rangée dans le dossier «&nbsp;Images&nbsp;».</strong></li><li><strong>Modifiez l’affichage pour retrouver la date de modification de la photo «&nbsp;Cousinade&nbsp;».<br></strong><br></li></ul>"
               }
             },
@@ -649,6 +662,7 @@
               "element": {
                 "id": "1db4a456-f71c-43c9-90b8-c9a468154260",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Dans le gestionnaire de fichiers&nbsp;:&nbsp; </p><ul><li>La vue <strong>icônes </strong>montre un aperçu du contenu de chaque fichier ou dossier, ou une icône qui varie selon le type d’élément.&nbsp;</li><li>La vue <strong>liste</strong> ou <strong>détails</strong> permet de voir davantage d’informations sur les fichiers (date, type, taille du fichier).</li><li>Un <strong>volet latéral</strong> (à gauche) permet de se repérer et de naviguer dans l’arborescence des dossiers.</li></ul><br><p><strong>🤔 Bon à savoir</strong><br>Le gestionnaire de fichiers peut s’ouvrir de deux façons&nbsp;:&nbsp;</p><ul><li>en cliquant sur l’icône dans la barre des tâches (Windows) ou dock (Apple)</li><li>en double cliquant sur un dossier sur le bureau</li></ul>"
               }
             }
@@ -664,6 +678,7 @@
               "element": {
                 "id": "e2952509-2806-41c0-bbb9-f46202beb57e",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Marie souhaite organiser ses dossiers et ses fichiers.</p><p>Elle a commencé par ranger son dossier «&nbsp;Images&nbsp;» en créant des sous dossiers par année.<br>Elle souhaite maintenant ranger son dossier «&nbsp;Documents&nbsp;» de la même manière.</p>"
               }
             },
@@ -672,6 +687,7 @@
               "element": {
                 "id": "a940f5e1-66ee-4c43-975d-35c955b48138",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><strong>Dans le gestionnaire de fichiers ci-dessous&nbsp;:&nbsp;</strong></p><ul><li><strong>Rangez le dossier «&nbsp;Documents&nbsp;», en suivant la même organisation que pour le dossier «&nbsp;Images&nbsp;».</strong></li><li><strong>Déplacer le dossier «&nbsp;Playlist fêtes&nbsp;» dans le dossier plus «&nbsp;Musique&nbsp;».</strong></li></ul>"
               }
             },
@@ -728,6 +744,7 @@
               "element": {
                 "id": "baf117c9-647e-4715-8b1f-5d4f07182e88",
                 "type": "text",
+                "tag": " ",
                 "content": "<strong>Feedback&nbsp;: </strong>Pour organiser ses fichiers, on peut créer des dossiers et des sous-dossiers, puis y déplacer des fichiers ou des dossiers avec leur contenu. <br>Le <strong>gestionnaire de fichiers</strong> permet de <strong>modifier l’organisation à tout moment</strong>."
               }
             }
@@ -743,6 +760,7 @@
               "element": {
                 "id": "878db1df-9959-48b5-906a-fc6c6141e2c1",
                 "type": "text",
+                "tag": " ",
                 "content": "<h5>Comment choisir son organisation ?&nbsp; </h5><br>Il y a plusieurs manières de s’organiser. <strong>Chacun peut choisir de s’organiser en fonction des ses usages</strong>, de la quantité de fichiers, de ce qu’il cherche à retrouver facilement. <br>On peut par exemple organiser ses fichiers par&nbsp;: projet, année, types de fichiers etc."
               }
             },
@@ -763,6 +781,7 @@
               "element": {
                 "id": "60223c63-944a-4e07-9cd2-a7b558696954",
                 "type": "text",
+                "tag": " ",
                 "content": "<h5>💡 Astuce</h5>Certains vont préférer une organisation avec peu de dossiers, d’autres seront plus à l’aise avec de nombreux dossiers et sous dossiers."
               }
             }
@@ -784,6 +803,7 @@
               "element": {
                 "id": "a2ef7833-34d7-4801-995e-dfa5815d2c09",
                 "type": "text",
+                "tag": " ",
                 "content": "<ul>    <li>Sur un ordinateur, les fichiers sont organisés dans une <strong>arborescence</strong> de dossiers.&nbsp;<br><br></li>    <li>Le <strong>chemin d’accès </strong>indique l’<strong>emplacement d’un fichier</strong> dans cette arborescence.<br><br></li>    <li>Le <strong>gestionnaire de fichier </strong>permet de&nbsp;:&nbsp;<ul>            <li>Accéder aux dossiers et aux fichiers et les ranger.</li>            <li>Visualiser l’arborescence.</li>            <li>Consulter des informations sur les dossiers et les fichiers.</li>            <li>Modifier l’affichage.<br><br> </li>        </ul>    </li>    <li>Une bonne <strong>organisation</strong> pour vous est une organisation qui vous permet de <strong>retrouver facilement vos fichiers</strong>.</li></ul>"
               }
             }
@@ -805,6 +825,7 @@
               "element": {
                 "id": "13074d41-8e00-4339-9376-b22829ec706f",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Voici le chemin du fichier «&nbsp;Baguette&nbsp;»&nbsp;: Mon ordinateur &gt; Documents &gt; Recettes &gt; Pains &gt; Baguette.</p><p><strong>Trouver le fichier dans l’interface de gestionnaire de fichiers ci-dessous, puis double cliquer dessus pour l’ouvrir&nbsp;:</strong><br></p>"
               }
             },
@@ -822,6 +843,7 @@
               "element": {
                 "id": "4ef0651e-e59c-4893-9fa2-d82d8944653a",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><strong>Feedback </strong>:&nbsp;Bravo ! Vous avez trouvé le fichier «&nbsp;Baguette&nbsp;». En suivant le chemin d’accès dossier par dossier (dans le gestionnaire de fichiers), il est possible de retrouver précisément un fichier.</p>"
               }
             }
@@ -912,6 +934,7 @@
               "element": {
                 "id": "1f6c6b6a-029d-44e4-bc25-a2f9ea557a1e",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Suivre les instructions suivantes pour ranger les photos d’Alice&nbsp;:</p> <ul><li><strong>Dans le dossier Images de l’ordinateur d’Alice, créer un dossier «&nbsp;Animaux&nbsp;».</strong></li><li><strong>Rangez-y toutes les photos avec des noms d’animaux.</strong></li><li><strong>Dans le dossiers «&nbsp;Animaux&nbsp;», créer un dossier 2022.</strong></li><li><strong>Rangez-y toutes les photos d’animaux datant de 2022.</strong></li></ul>"
               }
             },
@@ -942,6 +965,7 @@
               "element": {
                 "id": "4944ea11-b895-4100-afc4-b43eac782324",
                 "type": "text",
+                "tag": " ",
                 "content": "Vous l’aurez compris, il n’existe pas une seule bonne façon d’organiser ses fichiers."
               }
             },

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/12_RangerFichiers_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/12_RangerFichiers_NOV.json
@@ -32,6 +32,7 @@
               "element": {
                 "id": "a508b3f1-51f2-4af6-a71f-4cdb5694d78a",
                 "type": "text",
+                "tag": " ",
                 "content": "Voici le bureau de l’ordinateur de Maëva."
               }
             },
@@ -52,6 +53,7 @@
               "element": {
                 "id": "03b884f7-1d7a-4eb2-8ee2-164f5973484e",
                 "type": "text",
+                "tag": " ",
                 "content": "Il y a beaucoup d’éléments différents sur son bureau."
               }
             },
@@ -107,6 +109,7 @@
               "element": {
                 "id": "ce1d0fb7-8794-4415-ba47-38d3a561c657",
                 "type": "text",
+                "tag": " ",
                 "content": "Pour mieux s’organiser sur un ordinateur, il est utile de comprendre ce que l’on voit à l’écran.<br>Commençons par faire la différence entre deux types d’éléments&nbsp;: les fichiers et les dossiers."
               }
             }
@@ -128,6 +131,7 @@
               "element": {
                 "id": "d0de1b6e-0408-4276-903d-7538af8efcfc",
                 "type": "text",
+                "tag": " ",
                 "content": "Observez le bureau de Maëva et essayez de catégoriser les éléments ci-dessous."
               }
             },
@@ -261,6 +265,7 @@
               "element": {
                 "id": "b21eb58b-137f-444f-bfcf-e12e92e0adb5",
                 "type": "text",
+                "tag": " ",
                 "content": "Sur un ordinateur, il y a souvent beaucoup de <strong>fichiers </strong>différents&nbsp;: des photos de vacances à imprimer, des factures à conserver, des documents à finir d’écrire, des chansons à écouter, des vidéos à regarder, etc.&nbsp; <br><br>📂 Les<strong> dossiers servent à ranger</strong> les fichiers."
               }
             }
@@ -276,6 +281,7 @@
               "element": {
                 "id": "7e61c54c-754e-4427-9929-505c776a526e",
                 "type": "text",
+                "tag": " ",
                 "content": "Maintenant que la différence entre fichiers et dossiers est plus claire, voyons comment créer des dossiers."
               }
             }
@@ -291,6 +297,7 @@
               "element": {
                 "id": "87d28944-5b26-48ad-9862-ec8e67c7109d",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Maëva a de nombreuses photos sur son bureau.&nbsp;Elle souhaite les ranger toutes au même endroit.&nbsp;</p><br><p>Pour organiser ses fichiers, elle veut créer un nouveau dossier.&nbsp;</p>"
               }
             },
@@ -299,6 +306,7 @@
               "element": {
                 "id": "617bda78-d613-4dbd-9b18-84dd86bb89d5",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Dans l’interface ci-dessous&nbsp;:&nbsp;</p><ul><li>Créez un nouveau dossier sur le bureau de Maëva.&nbsp;</li><li>Nommez-le «&nbsp;Photos&nbsp;».</li></ul>"
               }
             },
@@ -328,6 +336,7 @@
               "element": {
                 "id": "e1b19308-d5d9-414f-b2fc-b8a13e6f8bb9",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Feedback:&nbsp;Lors de la<strong> création d’un dossier</strong>, il est possible de lui<strong> donner un nom</strong>. Un nom court et clair peut aider à <strong>mieux s’organiser</strong>, par exemple un dossier «&nbsp;Photos&nbsp;» pour ranger ses photos.<br>Si vous ne lui donnez pas de nom, un nom automatique lui est donné comme «&nbsp;Nouveau dossier&nbsp;».</p>"
               }
             }
@@ -343,6 +352,7 @@
               "element": {
                 "id": "db1d3007-f6d7-4242-aff6-807aa1e1f5a0",
                 "type": "text",
+                "tag": " ",
                 "content": "<h5><strong>Comment afficher le contenu d’un dossier ? </strong>📂</h5><p>Pour afficher le contenu d’un dossier, double-cliquez dessus. Une fenêtre s’ouvre et affiche le contenu du dossier.</p><p><strong>🤔 Bon à savoir</strong><br>Un dossier peut contenir des fichiers mais aussi d’autres dossiers.</p>"
               }
             }
@@ -358,6 +368,7 @@
               "element": {
                 "id": "5869c7b0-5166-40bf-9661-cbff168fae43",
                 "type": "text",
+                "tag": " ",
                 "content": "Une fois un dossier créé, il est temps d’y ranger des fichiers."
               }
             }
@@ -373,6 +384,7 @@
               "element": {
                 "id": "7aee6701-cb39-46e9-8069-09984704661f",
                 "type": "text",
+                "tag": " ",
                 "content": "Maintenant que Maëva a un dossier «&nbsp;Photos&nbsp;», elle y a rangé les photos qui étaient sur son bureau. Sauf la photo nommée «&nbsp;DCIM2115&nbsp;». <br>Elle veut d’abord changer le nom de la photo. Puis la déplacer dans le dossier «&nbsp;Photos&nbsp;»."
               }
             },
@@ -381,6 +393,7 @@
               "element": {
                 "id": "24580343-0718-4c50-9683-6047f0ee2e10",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><strong>Dans l’interface ci-dessous&nbsp;:&nbsp;</strong></p><ul><li><strong>Renommez la photo «&nbsp;DCIM2115&nbsp;» avec le nom «&nbsp;Portugal&nbsp;».</strong></li><li><strong>Rangez la photo «&nbsp;Portugal&nbsp;» dans le dossier «&nbsp;Photos&nbsp;».</strong></li></ul>"
               }
             },
@@ -414,6 +427,7 @@
               "element": {
                 "id": "8c2acdd0-84cb-4c7f-9915-7a5f126796df",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Le <strong>nom du fichier</strong> est parfois créé automatiquement ou choisi par quelqu’un d’autre. De la même manière, parfois un fichier est <strong>placé automatiquement dans un dossier</strong>, le dossier téléchargement par exemple.</p><p>Vous pouvez <strong>renommer </strong>et <strong>déplacer </strong>vos fichiers selon votre préférence.</p><p><strong>🤔 Le saviez-vous  ?<br></strong>Un dossier peut contenir autant de fichiers que l’on souhaite. </p><p><strong>Astuce&nbsp;<br></strong>Si vous savez utiliser le glisser-déposer, vous pouvez l’utiliser pour déplacer des fichiers dans des dossiers.</p>"
               }
             }
@@ -429,6 +443,7 @@
               "element": {
                 "id": "aa01d6a4-604e-4a42-abb5-e264b8302ff5",
                 "type": "text",
+                "tag": " ",
                 "content": "Voyons à présent ce qu’il se passe lorsqu’un fichier est supprimé."
               }
             }
@@ -444,6 +459,7 @@
               "element": {
                 "id": "2145a637-adf8-4142-af2a-178021994a0d",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Maëva a supprimé par erreur le fichier «&nbsp;Lettre&nbsp;» de son bureau.</p><p>[+ short vidéo de la suppression]</p>"
               }
             },
@@ -499,6 +515,7 @@
               "element": {
                 "id": "6e117fc1-f985-474b-aa35-8829d7c94c46",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><strong>Aidez Maëva à récupérer son fichier «&nbsp;Lettre&nbsp;» dans la corbeille.</strong></p>"
               }
             },
@@ -528,6 +545,7 @@
               "element": {
                 "id": "a453471b-b9b3-4aed-970f-768caab74d70",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><strong>Feedback&nbsp;</strong>: Quand un fichier est récupéré depuis la corbeille, il est renvoyé à son emplacement d’origine. Par exemple, le fichier «&nbsp;Lettre&nbsp;» est de nouveau stocké sur le bureau de Maëva.</p>"
               }
             }
@@ -543,6 +561,7 @@
               "element": {
                 "id": "aa2945b0-cec7-4b40-8ce7-82d97b37a451",
                 "type": "text",
+                "tag": " ",
                 "content": "<h5>Comment supprimer un fichier ou un dossier ?</h5><p>Pour supprimer un fichier ou un dossier inutile&nbsp;:&nbsp;</p><ul><li>Faites un clic droit dessus puis cliquez sur «&nbsp;<strong>Supprimer </strong>» (Windows) ou «&nbsp;<strong>Placer dans la corbeille </strong>» (Mac). Le fichier est alors <strong>déplacé dans la corbeille</strong>. 🗑️</li><li><strong>Videz la corbeille </strong>pour <strong>supprimer définitivement</strong> les fichiers et dossiers qui s’y trouvent.&nbsp;❌</li></ul><p>[ avec image ou short video  ]</p><p><br><strong>🤔 Bon à savoir<br></strong>Certaines corbeilles ne gardent les fichiers et dossiers que pendant 30 à 60 jours. Ils sont ensuite supprimés automatiquement.<br></p>"
               }
             }
@@ -564,6 +583,7 @@
               "element": {
                 "id": "f9e7d7b2-b97e-4e43-a43b-32c592be79e9",
                 "type": "text",
+                "tag": " ",
                 "content": "<ul><li>Sur un ordinateur, il y a des <strong>fichiers </strong>(images, documents, vidéos, musiques, etc.) et des <strong>dossiers pour ranger les fichiers</strong>. </li><br><li>Pour vous y retrouver, vous pouvez facilement <strong>renommer </strong>vos fichiers et les <strong>placer dans des dossiers</strong>. </li><br><li>Vous pouvez créer autant de dossiers que nécessaire et les nommer comme vous le souhaitez. 📂 </li><br><li>Quand des fichiers ou des dossiers sont supprimés, ils sont <strong>mis dans la corbeille</strong>. Vous pouvez <strong>récupérer </strong>ceux qui se trouvent dans la corbeille. 🗑️</li></ul>"
               }
             }
@@ -649,6 +669,7 @@
               "element": {
                 "id": "a3b3eb71-3fb1-4fea-9784-5f6290bdc753",
                 "type": "text",
+                "tag": " ",
                 "content": "Observez le bureau ci-dessous puis répondez à la question."
               }
             },
@@ -730,6 +751,7 @@
               "element": {
                 "id": "7efd6a00-11a9-4dd9-b8ee-0ff3c9bd18fa",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><strong>Dans l’application ci-dessous&nbsp;: </strong></p><p><strong><br></strong></p><ul><li><strong>Supprimez le fichier&nbsp;«&nbsp;image4&nbsp;».</strong></li><li><strong>Créez un dossier «&nbsp;Images&nbsp;».</strong></li><li><strong>Déplacez les fichiers «&nbsp;image1», «&nbsp;image2&nbsp;»,&nbsp;«&nbsp;image3&nbsp;» dans le dossier «&nbsp;Images&nbsp;» que vous avez créé.</strong></li></ul>"
               }
             },
@@ -760,6 +782,7 @@
               "element": {
                 "id": "8adbf28b-dd8c-4a6c-9725-2a8f5fa0bb6f",
                 "type": "text",
+                "tag": " ",
                 "content": "Cette fois, Maëva a supprimé le dossier « Administratif » de son bureau."
               }
             },
@@ -768,6 +791,7 @@
               "element": {
                 "id": "281c9e6c-6b57-4c80-92e9-e9d4afb62677",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><strong>Récupérez le dossier « Administratif » dans l’application ci-dessous puis répondez à la question.</strong> </p><br>"
               }
             },

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/21_RepondreMail_IND.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/21_RepondreMail_IND.json
@@ -32,6 +32,7 @@
               "element": {
                 "id": "7c675fd0-0530-451a-88e9-9605cea958bf",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Gabriel a reçu un mail d’Alma qui l’invite à une conférence. Il doit refuser l’invitation.</p><p><strong>Dans la messagerie électronique&nbsp;ci-dessous, répondez à Alma avec le message suivant&nbsp;:</strong></p><p><strong><br></strong></p><blockquote><em>Bonjour Alma,</em><em><br>Merci pour l’invitation, malheureusement je ne serai pas disponible à cette date. <br>Est-ce qu’il y aura d’autres dates de conférences à venir&nbsp;?<br>Gabriel</em></blockquote>"
               }
             },
@@ -49,6 +50,7 @@
               "element": {
                 "id": "56f56984-7711-4a3a-bf34-8dd3b44e556c",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><strong>[Feedback autovalid]</strong></p><p>Bien joué ! Le mail a été envoyé à Alma. Pour répondre à un mail, il faut cliquer sur «&nbsp;Répondre&nbsp;». Le destinataire et l’objet du mail sont déjà remplis. Il vous reste à écrire votre message puis cliquer sur «&nbsp;Envoyer&nbsp;».</p>"
               }
             }
@@ -64,6 +66,7 @@
               "element": {
                 "id": "be863ac5-151e-482e-bd83-1ae4b1535b82",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Quand vous répondez à un mail, les échanges ne disparaissent pas. 📧<br>Voyons ensemble comment ils s’organisent.</p>"
               }
             }
@@ -85,6 +88,7 @@
               "element": {
                 "id": "a44cacb3-d805-4f1f-8da9-8536bdc85ae8",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Depuis l’invitation d’Alma, Gabriel et Alma ont échangé plusieurs mails. <br><strong>Dans la messagerie électronique ci-dessous,&nbsp;parcourez leurs échanges puis répondez aux questions qui suivent.</strong></p>"
               }
             },
@@ -197,6 +201,7 @@
               "element": {
                 "id": "5dfb5863-4641-406e-ba7e-145cddd8ff20",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Sous le dernier mail, se trouve <strong>l’historique des échanges</strong> de mails sur ce sujet. Cela permet de conserver le contexte de l’échange.&nbsp;📧</p>"
               }
             },
@@ -205,6 +210,7 @@
               "element": {
                 "id": "7c2f4e3b-7198-453f-9462-d28b6e79cf45",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><strong>🤔 Bon à savoir</strong></p><p>En général, il est préférable de ne pas changer de sujet au cours du fil de discussion, pour respecter l’objet du mail.</p>"
               }
             }
@@ -220,6 +226,7 @@
               "element": {
                 "id": "59325b69-d108-4d69-adf1-d65925b162b3",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Parfois, le contenu d’un mail peut intéresser des personnes qui ne l’ont pas reçu. 👥<br>Découvrez comment transférer un mail.</p>"
               }
             }
@@ -235,6 +242,7 @@
               "element": {
                 "id": "9124beb6-ecd2-444a-9757-c880b545bc6c",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>L’option «&nbsp;Transférer&nbsp;» permet de faire suivre un mail à un nouveau destinataire sans avoir à copier ou recopier son contenu.</p><p><strong>Explorez la messagerie électronique ci-dessous pour répondre aux questions qui suivent.</strong></p>"
               }
             },
@@ -415,6 +423,7 @@
               "element": {
                 "id": "de1c2d77-00da-4eeb-bde2-c3671a5fe4ae",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Quand vous <strong>transférez un mail</strong>, il est recommandé d’ajouter une <strong>explication</strong> au-dessus du mail pour indiquer la raison de cet envoi.</p><p><br></p><h5>Que voit le destinataire quand il reçoit un mail transféré ? </h5><p>[Schéma ? illustration ? infographie ?] </p><ul><li>D’abord l’explication ou le message que vous avez écrit pour accompagner le transfert.</li><li>Ensuite, se trouvent les informations du mail d’origine&nbsp;: son expéditeur, la date, son objet et ses destinataires d’origine.</li><li>Puis, votre destinataire voit le contenu du mail d’origine.<br></li></ul>"
               }
             },
@@ -435,6 +444,7 @@
               "element": {
                 "id": "d8e5c97c-71cb-4436-94fc-468e0833cac8",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><strong>🤔 Bon à savoir</strong></p><p>Quand vous transférez un mail contenant tout un fil de discussion, cela transfère <strong>tout le fil de discussion</strong> à votre destinataire.</p>"
               }
             }
@@ -450,6 +460,7 @@
               "element": {
                 "id": "f3c50c6a-5f61-4123-8d6c-10cc25bfd282",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Un mail peut être envoyé à plusieurs destinataires en même temps. 📨<br>Découvrons ensemble comment répondre à ce type de mail.</p>"
               }
             }
@@ -465,6 +476,7 @@
               "element": {
                 "id": "b1a74a86-03da-4958-8ba9-b0c50adafcc5",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Pour chacune des situations suivantes, identifiez l’option de la boîte de messagerie qu’il convient d’utiliser :</p>"
               }
             },
@@ -477,6 +489,7 @@
                     {
                       "id": "a9efc0f8-7b14-4b61-a19d-c72feaae7054",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Laura a reçu un mail de son professeur de judo rappelant la date et l’horaire du prochain cours. Ce mail a été envoyé à toutes les personnes inscrites au cours.</p>"
                     },
                     {
@@ -509,6 +522,7 @@
                     {
                       "id": "aad94652-c9ee-43b9-b544-402db63e2ad2",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>La fille de Manon est inscrite dans un club de foot. L’entraîneur envoie un mail aux parents pour organiser le tournoi de samedi&nbsp;: il a besoin de trois volontaires qui ont des voitures.</p>"
                     },
                     {
@@ -541,6 +555,7 @@
                     {
                       "id": "fe1a58ee-83de-439e-a432-f314efe7946c",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Dorothea a reçu un mail de Gwendal, le responsable des ressources humaines de son entreprise. Celui-ci demande d’envoyer un justificatif de domicile. Ce mail a été envoyé à tous les employés.</p>"
                     },
                     {
@@ -582,6 +597,7 @@
               "element": {
                 "id": "78d47f5a-1526-4f75-ac35-8246cf4187b7",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Quand vous répondez à un mail qui comporte <strong>plusieurs destinataires</strong>, deux options sont possibles&nbsp;:</p>\n<ul>\n    <li><strong>répondre </strong>(seulement à l’expéditeur),</li>\n    <li><strong>répondre à tous</strong> (à l’expéditeur et à tous les autres destinataires).</li>\n</ul>\n<p>Il est recommandé de choisir «&nbsp;Répondre à tous&nbsp;» uniquement si la réponse est utile pour tout le monde. <br></p>"
               }
             },
@@ -590,6 +606,7 @@
               "element": {
                 "id": "b7697e58-20ec-42b9-820d-eed068bc4024",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><strong>🤔 Bon à savoir</strong></p><p>Certains mails d’information n’attendent pas de réponse (suivi de colis, newsletter, promotion, etc.).<br>Parfois, l’adresse de l’expéditeur indique que celui-ci n’accepte pas les réponses car elle contient «&nbsp;no-reply&nbsp;» ou «&nbsp;ne-pas-répondre&nbsp;».</p>"
               }
             }
@@ -605,6 +622,7 @@
               "element": {
                 "id": "23eef4f8-6952-4cca-8718-51190d9a901a",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Quand beaucoup de mails sont échangés entre plusieurs personnes, le fil de discussion se complexifie.<br>Pour retrouver une information, il faut se repérer à l’intérieur du fil de discussion. 🕵️</p>"
               }
             }
@@ -620,6 +638,7 @@
               "element": {
                 "id": "a358a907-67a8-4d1c-8ac4-0c44fe1ce06f",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Prenons l’exemple de Karim.</p><p>Karim a reçu un mail de son ami Douglas concernant l’organisation d’un pique-nique. Plusieurs personnes ont répondu au mail de Douglas.</p><p><br></p><p><strong>Lisez le fil de discussion suivant pour compléter le texte ci-dessous.</strong></p>"
               }
             },
@@ -816,6 +835,7 @@
               "element": {
                 "id": "9a91621e-e990-41ac-83dd-03b6509a535d",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Dans un fil de discussion, toutes les réponses précédentes sont affichées <strong>en dessous du mail le plus récent</strong>, chacune avec un léger décalage vers la droite.</p>"
               }
             },
@@ -824,6 +844,7 @@
               "element": {
                 "id": "7645476a-2266-4356-9497-e663fcc9f3f0",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><strong>🤔 Bon à savoir</strong></p><p>Certaines interfaces n’affichent que la réponse la plus récente et cachent le fil de discussion. Il faut cliquer sur un bouton pour «&nbsp;déplier&nbsp;» tout le fil de discussion.</p>"
               }
             }
@@ -845,6 +866,7 @@
               "element": {
                 "id": "0732c01c-0387-487c-ad6a-3897190bd4ff",
                 "type": "text",
+                "tag": " ",
                 "content": "<ul>    <li>Pour faire suivre à quelqu’un un mail que vous avez reçu et qui pourrait l’intéresser, vous pouvez lui <strong>transférer</strong> le mail.&nbsp;📧</li></ul><p><br></p><ul>    <li>Lorsqu’un mail comporte plusieurs destinataires, vous pouvez <strong>répondre</strong> uniquement à l’expéditeur, ou <strong>répondre à tous</strong> (à l’expéditeur et à tous les autres destinataires). Faites le choix qui vous semble le plus adapté en fonction du contexte et de votre besoin.&nbsp;✒️</li></ul><p><br></p><ul>    <li> Quand vous répondez à un mail, le texte du précédent mail est affiché en dessous. De réponse en réponse, un <strong>fil de discussion</strong> se construit sous le mail le plus récent. Le mail tout en bas est donc le plus ancien.&nbsp;🧵</li></ul>"
               }
             }
@@ -866,6 +888,7 @@
               "element": {
                 "id": "dc83d812-92d7-4785-94d1-88d21c5affb8",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Dans la messagerie électronique ci-dessous, Angelina vous a envoyé un mail avec des recommandations de restaurant.</p><p><strong>Transférez ce courrier à andreis@pixmail.org en ajoutant le message suivant :&nbsp; </strong></p><blockquote><em><br></em></blockquote><blockquote><em>Bonjour Andreis,</em></blockquote><blockquote><em>Mon amie Angelina me propose cette sélection de restaurants pour jeudi. Tu as une préférence ?</em></blockquote><blockquote><em>Bonne journée.</em></blockquote>"
               }
             },
@@ -890,6 +913,7 @@
               "element": {
                 "id": "a398359a-8901-4870-ac42-e96ad087e0ac",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Plusieurs collègues organisent une réunion d’équipe.<br><strong>Lisez le fil de discussion suivant.</strong></p>"
               }
             },
@@ -971,6 +995,7 @@
               "element": {
                 "id": "6975703a-94f4-4eaa-8592-a29128e0452c",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><strong>Pour chacune des situations suivantes, identifiez l’option de la boîte de messagerie qu’il convient d’utiliser.</strong></p>"
               }
             },
@@ -983,6 +1008,7 @@
                     {
                       "id": "5651ab4a-bfff-4cf8-927d-5bb9796e9b6c",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Lucas a reçu un mail de la part de son responsable formation.</p>"
                     },
                     {
@@ -1045,6 +1071,7 @@
                     {
                       "id": "01849b56-71ec-4450-82ba-67c496817a2a",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Pierre-Alexandre a reçu un mail d’information de Primeur Express.</p>"
                     },
                     {
@@ -1107,6 +1134,7 @@
                     {
                       "id": "84f26180-5826-4e71-ae9e-2f701dbdb554",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Soumaya a reçu un mail concernant l’organisation d’un pot de départ.</p>"
                     },
                     {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/21_RepondreMail_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/21_RepondreMail_NOV.json
@@ -32,6 +32,7 @@
               "element": {
                 "id": "c98b3261-a4a0-408b-9b6c-95248f95aed1",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Vous avez envoyé votre candidature pour un stage de «&nbsp;Vendeur de choux&nbsp;». Quelques jours plus tard, le recruteur vous laisse un message vocal.</p><br><p><strong>Écoutez le message vocal.</strong></p>"
               }
             },
@@ -57,6 +58,7 @@
               "element": {
                 "id": "d5ad77e1-6d87-4f3c-9856-b19fd9379430",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Une réponse vous a été envoyée par <strong>mail</strong>.<br><strong>Dans l’interface ci-dessous, cliquez sur l’icône qui permet de consulter les mails.</strong></p>"
               }
             },
@@ -95,6 +97,7 @@
               "element": {
                 "id": "11c9837c-3317-4bd9-a23d-dd571f2d6762",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><strong>Feedbacks autovalid :&nbsp; </strong></p><p>Bien joué ! Vous avez bien reçu un mail. Pour consulter ses mails, il faut d’abord <strong>ouvrir sa messagerie électronique</strong>. Elle est souvent représentée par une icône en forme d’enveloppe. Voici quelques exemples :</p>"
               }
             },
@@ -122,6 +125,7 @@
               "element": {
                 "id": "353545a8-7d86-42da-bb17-3b9d48503448",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Le mail est souvent utilisé pour transmettre des informations importantes (professionnelles, administratives).</p>"
               }
             }
@@ -143,6 +147,7 @@
               "element": {
                 "id": "da94bec1-5d25-4c93-bf5a-05ab2fc52c56",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Maintenant, regardons plus en détail le mail que vous avez reçu.</p><p>Observez les informations du mail affiché dans l’interface ci-dessous puis répondez à la question.</p>"
               }
             },
@@ -225,6 +230,7 @@
               "element": {
                 "id": "3a663ef0-b312-4ce8-928c-658ada1cb201",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Quand vous ouvrez votre messagerie électronique, vous arrivez directement dans la<strong> boîte de réception</strong>. C’est dans cet espace que s’affichent les mails reçus, avec leurs principales informations&nbsp;:&nbsp; </p><ol><li>le <strong>nom de l’expéditeur</strong>, c’est-à-dire la personne qui vous a envoyé le mail.</li><li>l’<strong>objet</strong>, c’est-à-dire le titre du mail.</li><li>la <strong>date et l’heure de réception</strong> du mail.</li></ol>"
               }
             },
@@ -252,6 +258,7 @@
               "element": {
                 "id": "1252a55f-9b38-4baf-8513-801f867be6f2",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Il est temps de découvrir la réponse à votre candidature de stage.</p><p>Pour en savoir plus sur un mail, il faut l’ouvrir. </p>"
               }
             }
@@ -267,6 +274,7 @@
               "element": {
                 "id": "985c0c74-6b86-465b-b33e-993a2852fc5f",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><strong>Dans l’interface ci-dessous, ouvrez le mail envoyé par BioChoux&nbsp;puis répondez à la question ci-dessous.</strong></p>"
               }
             },
@@ -328,6 +336,7 @@
               "element": {
                 "id": "6071f658-794a-4b3e-9815-eae528b82d07",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><strong>Feedback&nbsp;de la simulation&nbsp;: </strong>Bien joué ! Vous avez réussi à ouvrir le mail. Vous pouvez désormais lire la réponse de BioChoux.</p>"
               }
             }
@@ -390,6 +399,7 @@
               "element": {
                 "id": "05113e75-4a2e-4207-aaff-f528da503ab9",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Quand vous ouvrez un mail, l’objet du mail, la date et l’expéditeur sont encore affichés. De nouvelles informations s’affichent également&nbsp;:<br></p>    <ol><li>Le <strong>destinataire</strong> (À)&nbsp;: c’est vous qui recevez le mail,</li><li>Le<strong> texte complet</strong> du mail.</li></ol>"
               }
             },
@@ -417,6 +427,7 @@
               "element": {
                 "id": "bac2a6f7-65e0-468a-90d4-cfb663addbbc",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Dans son mail, le recruteur vous demande de confirmer par mail votre présence pour l’entretien. </p><p>Voyons ensemble comment lui répondre.</p>"
               }
             }
@@ -432,6 +443,7 @@
               "element": {
                 "id": "f8575dbf-3455-4975-8ced-b43a0db31776",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Pour confirmer votre présence, vous devez répondre au mail du recruteur.</p>"
               }
             },
@@ -440,6 +452,7 @@
               "element": {
                 "id": "7ed9ce41-7f5c-4ba2-bdfa-1fb524bbad9c",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><strong>Pour cela, suivez les instructions suivantes&nbsp;:&nbsp; </strong></p><ul><li><strong>cliquez sur le bouton qui permet de répondre au mail,&nbsp;</strong></li><li><strong>écrivez la réponse suivante puis envoyer le mail&nbsp;:&nbsp;</strong></li></ul><blockquote><em>Bonjour, <br>Je vous remercie de votre proposition. <br>Je vous confirme ma présence à l’entretien le 3 février à 14h. <br>Cordialement</em></blockquote>"
               }
             },
@@ -478,6 +491,7 @@
               "element": {
                 "id": "0b89b707-67be-4a00-a9be-68abcda63164",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><strong>Feedback autovalid :</strong> Bien joué ! Votre réponse a été envoyée. <br>Quand vous répondez à un mail, un nouveau mail est créé. Pour le voir, vous pouvez cliquer sur « Messages envoyés » dans le menu, juste en dessous de la « Boîte de réception ».<br></p>"
               }
             }
@@ -493,6 +507,7 @@
               "element": {
                 "id": "f2f8cb14-b6e9-4c82-80f5-eb6d2cc97aa5",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Quand vous répondez à un mail : </p><ol><li>Le <strong>destinataire</strong> et l’<strong>objet</strong> sont déjà <strong>remplis automatiquement</strong>.&nbsp;</li><li>Le <strong>mail auquel vous répondez reste affiché</strong>.</li><li>Il vous reste à <strong>écrire votre réponse juste au-dessus.</strong></li><li>Puis cliquer sur « <strong>Envoyer</strong> » pour envoyer votre réponse.</li></ol>"
               }
             },
@@ -513,6 +528,7 @@
               "element": {
                 "id": "5685f6f3-363f-4750-a963-b0af0ac6b07f",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>🤔<strong>Bon à savoir</strong> </p><p>Le «&nbsp;Re&nbsp;:&nbsp;» qui précède l’objet, indique que c’est une réponse à mail. Il est ajouté automatiquement.</p>"
               }
             }
@@ -528,6 +544,7 @@
               "element": {
                 "id": "6a16ac8d-e725-4777-b2e6-5bfa3f14be62",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Vous pouvez recevoir plusieurs mails dans votre boîte de réception. </p><p>Découvrons ensemble comment ils s’affichent.</p>"
               }
             }
@@ -543,6 +560,7 @@
               "element": {
                 "id": "28fc8aaa-b30a-4974-a983-e65c84cc4299",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Dans la messagerie électronique, les <strong>mails reçus</strong> s’affichent à l’écran sous forme de <strong>liste</strong>. <br>Observez les mails que vous avez reçu dans l'interface ci-dessous puis répondez aux questions.</p>"
               }
             },
@@ -567,6 +585,7 @@
                     {
                       "id": "8342b6c5-ab2d-4155-8368-6e707092b40d",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Certains mails ont déjà été lus, d’autres pas encore.</p>"
                     },
                     {
@@ -613,6 +632,7 @@
                     {
                       "id": "56941616-026a-4c55-930e-697a18da74e1",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Tous les mails n’ont pas été reçus à la même date.</p>"
                     },
                     {
@@ -668,6 +688,7 @@
               "element": {
                 "id": "e122bb57-c302-476c-b15e-7c58d95bd953",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>🤔<strong>Bon à savoir</strong><br>Il existe de nombreux services de messagerie électronique. Leur apparence peut varier, mais <strong>l’organisation des mails reste la même</strong> dans la boîte de réception.</p>"
               }
             }
@@ -689,6 +710,7 @@
               "element": {
                 "id": "d0b8befc-28cd-44a7-aba4-c110548386c0",
                 "type": "text",
+                "tag": " ",
                 "content": "<ul><li>Pour consulter ses mails, il faut <strong>ouvrir sa messagerie électronique</strong>. <br>Les <strong>mails reçus</strong> se trouvent dans la <strong>boîte de réception</strong> et s’affichent sous forme de<strong> liste</strong>.<br><br></li><li>Dans cette liste, des informations sont affichées pour chaque mail&nbsp;: le <strong>nom de l’expéditeur</strong>, l’<strong>objet</strong> et la <strong>date de réception</strong> du mail.<br><br></li><li>Les mails qui <strong>n’ont pas encore été lus</strong> apparaissent en <strong>gras</strong>. <br>Le mail<strong> le plus récent</strong> est placé <strong>en</strong><strong> haut de la liste</strong> automatiquement.<br><br></li><li>Lorsqu’on <strong>ouvre un mail</strong>, on peut lire <strong>son contenu</strong>.<br>Depuis un mail ouvert, on peut cliquer sur <strong>répondre</strong>, puis <strong>écrire</strong><strong> son message</strong> et l’<strong>envoyer</strong>.</li></ul>"
               }
             }
@@ -710,6 +732,7 @@
               "element": {
                 "id": "cd2893bc-b11d-48d0-ab4e-e678090af40f",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Observez les mails dans l’interface ci-dessous puis répondez aux questions ci-dessous.</p>"
               }
             },
@@ -854,6 +877,7 @@
               "element": {
                 "id": "daf204a6-660c-4d58-a9e3-a059e8b37890",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Claire Durand vous a envoyé un mail à propos de l’organisation du concours d’échec. <strong>Répondez lui par mail&nbsp;:</strong> </p><blockquote><em>Bonjour Madame Durand, Je vous confirme ma présence à la réunion du 12 avril.<br><br>Cordialement</em></blockquote>"
               }
             },
@@ -919,6 +943,7 @@
               "element": {
                 "id": "56fe3307-eaa6-483f-a181-6e310af5b2b1",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>On ne rédige pas un mail comme on rédige un message instantané ou un&nbsp;SMS. Pour bien rédiger un mail, il existe quelques règles simples à respecter.</p>"
               }
             },

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/21_Visio_IND.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/21_Visio_IND.json
@@ -32,6 +32,7 @@
               "element": {
                 "id": "fdf6b501-7408-4f05-a242-6f91adae80c7",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Roy est en visioconférence avec les membres de son association pour organiser la fête du quartier.</p>"
               }
             },
@@ -138,6 +139,7 @@
               "element": {
                 "id": "737f5bee-1378-4db2-88f8-1d24b7889160",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Dans cette même visioconférence, Gaby propose de trouver une solution pour nourrir les participants à la fête du quartier.&nbsp;🍽️</p>"
               }
             }
@@ -159,6 +161,7 @@
               "element": {
                 "id": "62102d5c-c369-4d64-89e0-64970d526b13",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Gaby propose de réserver le foodtruck de son cousin. Il ajoute&nbsp;: «&nbsp;Regardez les photos sur leur compte, c’est vraiment super bon&nbsp;!&nbsp;».</p>"
               }
             },
@@ -218,6 +221,7 @@
                     {
                       "id": "49c258ff-f3b9-4b78-a397-858e003d4f5d",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Samuel argumente en disant qu’une fête de quartier doit valoriser en priorité les commerçants locaux. Il propose le service de traiteur de ses voisins.</p>"
                     },
                     {
@@ -266,6 +270,7 @@
               "element": {
                 "id": "d0390b02-3457-4d44-90cd-52338dde1849",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>[Possible aussi en infographie ou avec une illustration complémentaire]</p>\n<br>\n<h5>Quels sont les différents moyens pour intervenir en visioconférence&nbsp;?<br></h5>\n<p>Les outils de visioconférence proposent les fonctionnalités suivantes&nbsp;:</p>\n<ul>\n    <li>La fonctionnalité «&nbsp;<strong>lever la main</strong>&nbsp;» permet de signaler qu’on souhaite intervenir à l’oral, sans couper la parole de quelqu’un.&nbsp;✋</li>\n    <li>La fonctionnalité de <strong>dialogue en ligne</strong> ou «&nbsp;<strong>chat</strong>&nbsp;» permet de communiquer par écrit. Cela permet également de partager des liens ou des documents.&nbsp;💬</li>\n    <li>On peut aussi <strong>réagir à ce qui est dit à l'oral avec un émoji</strong>. Cela permet de s’exprimer sans prendre la parole.&nbsp;👍</li>\n  </ul>"
               }
             }
@@ -281,6 +286,7 @@
               "element": {
                 "id": "7d4a3a6f-36be-4cbb-a86d-22410445cfe7",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Lors d’une visioconférence, les échanges peuvent porter sur un sujet qui demande un support visuel. Pour cela, un participant de la réunion peut partager son écran aux autres. Il devient présentateur.</p>"
               }
             }
@@ -296,6 +302,7 @@
               "element": {
                 "id": "3094cdd9-1430-4dcc-b500-ce3a35d3831f",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Dans cette même réunion, Inès propose de présenter le budget de leur prochain événement.&nbsp;💵</p>"
               }
             },
@@ -427,6 +434,7 @@
               "element": {
                 "id": "f6a1d0be-7e6c-4bbc-858f-895b3843c1e9",
                 "type": "text",
+                "tag": " ",
                 "content": "<h5>Que se passe-t-il pour le présentateur quand il partage son écran&nbsp;?</h5>\n<p>Souvent, quand le présentateur partage son écran, il ne voit plus les autres participants. Donc, si quelqu’un lève la main, fait oui de la tête, ou envoie un message dans le chat, <strong>il est possible que le présentateur ne le voit pas</strong>.&nbsp;❌</p>\n<p>Cependant, il y a souvent un <strong>signal sonore</strong> pour indiquer des messages, des mains levées ou des réactions des participants.&nbsp;🔊</p><p><br></p>\n<h5>Et lorsqu’il a terminé sa présentation&nbsp;?</h5>\n<p>Lorsqu’il n’est plus nécessaire de partager l’écran, le présentateur <strong>arrête le partage</strong>. Cela permet de laisser la place à un autre présentateur ou de discuter en voyant mieux les participants.&nbsp;👥</p>"
               }
             }
@@ -442,6 +450,7 @@
               "element": {
                 "id": "3045cd75-a3b5-4f92-94e7-0d1b720d5560",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>La réunion est terminée. Lors de la prochaine réunion en visioconférence, Roy devra présenter ses idées pour les affiches à mettre dans le quartier pour annoncer l’événement.&nbsp;📢</p>"
               }
             }
@@ -457,6 +466,7 @@
               "element": {
                 "id": "22715d4e-1d57-404d-97e2-9c99ca6d798a",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>La fête du quartier approche&nbsp;!&nbsp;📆 </p><p>Aujourd’hui, c’est au tour de Roy de faire une présentation. Il a préparé un diaporama avec ses propositions d’affiches pour annoncer la fête de quartier.</p>"
               }
             },
@@ -469,6 +479,7 @@
                     {
                       "id": "eede3a97-ecd4-4640-8a00-b021a9255f43",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>La réunion va bientôt commencer.</p>"
                     },
                     {
@@ -508,6 +519,7 @@
                     {
                       "id": "6c0e5165-70d5-44f9-a743-971934473c98",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Ça y est, la réunion commence&nbsp;! Roy veut montrer son document.</p>"
                     },
                     {
@@ -540,6 +552,7 @@
                     {
                       "id": "d3292a02-a083-4618-b92e-334bde019e00",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Roy a cliqué sur le bouton «&nbsp;partager mon écran&nbsp;» pour présenter le diaporama enregistré sur son ordinateur. Son outil de visioconférence lui propose plusieurs modalités de partage d’écran.</p>"
                     },
                     {
@@ -592,11 +605,13 @@
                     {
                       "id": "c9e05731-9b73-4b66-9fbe-fe917a4a9d94",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Les logiciels de visioconférence proposent plusieurs modalités de partage d’écran. Vous pouvez généralement partager&nbsp;: un <strong>onglet de votre navigateur</strong>, une <strong>fenêtre de votre ordinateur</strong>, ou <strong>tout votre écran</strong>.</p>"
                     },
                     {
                       "id": "701e9b88-c1ad-4306-bf3b-9c1c4e5dffcc",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p><strong>🤔&nbsp;Bon à savoir</strong></p>\n<p>Si vous souhaitez partager une vidéo, il est parfois nécessaire d’activer un bouton pour le partage du son de votre ordinateur avec les autres participants.&nbsp;🔊</p>"
                     }
                   ]
@@ -606,6 +621,7 @@
                     {
                       "id": "f654f574-d005-4198-b338-9787d016cd81",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Avant de commencer à présenter, vérifiez que <strong>les participants voient bien l’écran partagé</strong> et que <strong>les contenus sont lisibles</strong>. Cela permet de s’assurer que tout le monde peut suivre la présentation.&nbsp;👀</p>"
                     }
                   ]
@@ -630,6 +646,7 @@
               "element": {
                 "id": "2d3a41de-ac67-4ca1-923a-37c48d780a37",
                 "type": "text",
+                "tag": " ",
                 "content": "<ul>\n    <li>Pour interagir avec les participants lors d’une visioconférence, il y a plusieurs possibilités&nbsp;:<ul>\n            <li><strong>Parler&nbsp;🗣️</strong></li>\n            <li><strong>Lever la main&nbsp;✋</strong></li>\n            <li><strong>Écrire dans le chat&nbsp;💬</strong></li>\n            <li><strong>Réagir avec des émojis&nbsp;👍</strong><br></li>\n        </ul>\n    </li>\n    <li>La fonctionnalité de <strong>partage d’écran</strong> permet de montrer tout ou une partie de son écran aux autres participants. Cela permet d’échanger autour d’un support visuel commun comme un diaporama ou un logiciel.&nbsp;💻<br></li>\n    <li>Selon la situation, il est possible de partager <strong>un onglet de son navigateur</strong>, <strong>une fenêtre de son ordinateur&nbsp;</strong>ou bien <strong>tout son écran</strong>.</li>\n</ul>"
               }
             }
@@ -715,6 +732,7 @@
               "element": {
                 "id": "7ad437df-28ea-4f29-a2cd-9536b2035745",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Siam participe à une réunion en visioconférence avec beaucoup de monde. Son collègue fait une présentation mais donne une information erronée. Siam veut rectifier ce qui vient d’être dit sans couper la parole de son collègue.</p>"
               }
             },
@@ -774,6 +792,7 @@
               "element": {
                 "id": "49d0ff3e-e02e-460c-81a5-3c2f1ea8e862",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Helga veut présenter à sa famille un joli dessin réalisé après leur cousinade.</p>"
               }
             },
@@ -816,6 +835,7 @@
               "element": {
                 "id": "ad3e8b17-cfd4-443c-9b5a-f1b314cea4ec",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>C’est aujourd’hui que Bachir présente son travail en visioconférence. Malheureusement, vous ne pouvez pas rester jusqu’à la fin de sa présentation car vous avez un rendez-vous.</p>"
               }
             },

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/21_Visio_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/21_Visio_NOV.json
@@ -32,6 +32,7 @@
               "element": {
                 "id": "95d8312d-c6b2-4ee7-9024-aa0a62215fae",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Sadie s’inquiète de son entretien d’embauche. Elle en parle à son ami Juan.</p>"
               }
             },
@@ -76,6 +77,7 @@
               "element": {
                 "id": "a718fa64-e9ea-40e3-a903-3403f426e525",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Sadie accepte de faire l’entretien d’embauche en visioconférence. Elle reçoit une invitation par mail.</p>"
               }
             }
@@ -215,6 +217,7 @@
               "element": {
                 "id": "fb2d9d56-682e-42d8-b175-7e5b1ec32d5e",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Un outil de visioconférence permet à des personnes de se réunir et de communiquer de manière fluide, même à distance.</p><p><br>🤔 <strong>Bon à savoir</strong> <br>L’<strong>outil de visioconférence</strong> en ligne est <strong>choisi par l’organisateur</strong> de la réunion.</p>"
               }
             }
@@ -230,6 +233,7 @@
               "element": {
                 "id": "044cd949-ffc9-4d28-9d16-ed8d4f009e55",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Ça y est, c’est l’heure de l’entretien de Sadie. Elle est prête à commencer son entretien en visioconférence.</p><p>Découvrez les 2 réglages disponibles avant de rejoindre une visioconférence.</p>"
               }
             }
@@ -245,6 +249,7 @@
               "element": {
                 "id": "3bf7c798-9b12-4b76-bd17-4a064471556e",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Sadie a cliqué sur le lien dans le mail. La page qui s’affiche permet de se préparer à rejoindre la visioconférence.</p><br><p>Pour passer son entretien d’embauche, Sadie a besoin d’être <strong>vue et entendue </strong>par les recruteurs.</p>"
               }
             },
@@ -264,6 +269,7 @@
               "element": {
                 "id": "aa9cf9cb-1d4a-49b3-b325-86429d148890",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Si besoin, aidez-vous d’un indice&nbsp;:</p>"
               }
             },
@@ -288,6 +294,7 @@
               "element": {
                 "id": "37de7c8f-dd4f-4752-b421-cea0d969c401",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Dans certains cas, c’est l’organisateur qui autorise l’entrée des participants dans la visioconférence.<br>Quand vous vous connectez, vous êtes placé dans une <strong>salle d’attente virtuelle</strong> puis l’organisateur vous fait entrer lorsqu’il est prêt.</p><p><br>💡<strong> Astuce</strong><br>Pendant la visioconférence, quand votre caméra est ouverte, les autres participants voient ce qui se trouve derrière vous. Avant de rejoindre la visioconférence, pensez donc à vérifier ce qui est visible derrière vous.<br><br>🤔 <strong>Bon à savoir</strong><br>Lors de la première utilisation dans un navigateur, une demande d’accès au micro et à la caméra apparaît. Il faut <strong>autoriser l’accès</strong> pour pouvoir utiliser le micro et la caméra pendant la visioconférence.</p>"
               }
             },
@@ -315,6 +322,7 @@
               "element": {
                 "id": "03539b67-bf3b-49f0-a11e-e19471043284",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Maintenant que Sadie a réglé sa caméra et son micro, elle rejoint son entretien en visioconférence.</p>"
               }
             }
@@ -330,6 +338,7 @@
               "element": {
                 "id": "aa1d2356-2380-4820-8e8b-ec4fa450c114",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Sadie commence son entretien avec plusieurs interlocuteurs.</p>"
               }
             },
@@ -396,6 +405,7 @@
                     {
                       "id": "8125ff27-43f6-4f83-a4de-e2adab7365f2",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Sadie souhaite dire quelque chose pour répondre à Julian, mais elle a peur de l’interrompre.</p>"
                     },
                     {
@@ -455,6 +465,7 @@
                     {
                       "id": "cd6ab226-2bf5-41bb-ab6b-5d6ed08dcb4e",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>La barre de boutons permet de faire des réglages ou des actions pendant une visioconférence.</p>"
                     },
                     {
@@ -469,6 +480,7 @@
                     {
                       "id": "e348c101-e8f4-45a2-81c3-d563d83bd945",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>🤔 <strong>Bon à savoir</strong><br><strong>Quand vous ne parlez pas</strong>, il est recommandé de <strong>fermer votre micro</strong>&nbsp;: les bruits autour de vous peuvent gêner les autres participants.</p>"
                     }
                   ]
@@ -478,6 +490,7 @@
                     {
                       "id": "90f92ba8-173d-480f-8c05-8913ba7aba24",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>S’il y a «&nbsp;beaucoup&nbsp;» de participants lors d’une visioconférence, il ne sont pas forcément tous affichés sur l’écran central. Il faut alors ouvrir <strong>la liste des participants</strong> pour voir leurs noms, comme dans l’image suivante.</p>"
                     },
                     {
@@ -505,6 +518,7 @@
               "element": {
                 "id": "e8ab10a9-4db7-4adc-9316-1224bc89366a",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>L’entretien de Sadie est terminé, tout s’est bien passé. <br>Sadie veut maintenant se déconnecter.</p>"
               }
             }
@@ -540,6 +554,7 @@
               "element": {
                 "id": "bdee250d-109a-474b-8e60-ba91cd13ca80",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Pour <strong>se déconnecter d’une visioconférence</strong>, vous avez <strong>deux possibilités</strong>&nbsp;:</p><ul>    <li>cliquer sur le<strong> bouton «&nbsp;quitter&nbsp;»</strong>,</li>    <li><strong>fermer la fenêtre</strong> du navigateur.</li></ul><p>⚠️ Il est important de penser à quitter la visioconférence une fois la réunion terminée. Tant que vous n’avez pas quitté, les autres participants peuvent vous entendre ou vous voir, si vos micro et caméra sont ouverts.</p><p><br>💡<strong>Astuce</strong><br>Si vous vous déconnectez par erreur d’une visioconférence, pas de panique ! Pour vous connecter de nouveau, cliquez sur le lien que vous avez reçu par mail.</p>"
               }
             }
@@ -561,6 +576,7 @@
               "element": {
                 "id": "58c40d26-8729-46ba-8c2a-48a00351931a",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>[En infographie]</p><ul><li><strong>Avant la visioconférence</strong>&nbsp;: <ul><li>Pour accéder à la visioconférence, cliquez sur le <strong>lien reçu</strong> par mail.</li><li><strong>Préparez votre entrée </strong>dans la visioconférence en ouvrant ou fermant votre micro et  votre caméra.</li></ul></li><li><strong>Pendant la visioconférence</strong>&nbsp;: <ul><li>Les participants peuvent être visibles à l’écran ou via <strong>une liste</strong>.</li><li>Pour <strong>prendre la parole</strong>&nbsp;: levez la main et ouvrez votre micro.</li></ul></li><li><strong>À la fin de la visioconférence</strong>&nbsp;: quittez la visioconférence en cliquant sur le bouton ou en fermant la fenêtre du navigateur.</li></ul>"
               }
             }
@@ -646,6 +662,7 @@
               "element": {
                 "id": "5d48ac9a-038d-43c2-83ff-14cd53a210ed",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Vous participez à une visioconférence.</p>"
               }
             },
@@ -707,6 +724,7 @@
               "element": {
                 "id": "905b7f06-1891-489f-a9a7-6127b23aeea6",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Vous participez à une visioconférence. </p>"
               }
             },
@@ -741,6 +759,7 @@
               "element": {
                 "id": "07b1468a-1a52-4544-a30e-39e598c2ccb3",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Vous allez faire une visioconférence avec vos amis pour planifier vos prochaines vacances au soleil.&nbsp;⛱️</p>"
               }
             },

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYAntivirus_IND.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYAntivirus_IND.json
@@ -32,6 +32,7 @@
               "element": {
                 "id": "5fd179ed-e09d-496e-adbd-47cda8b2b1c6",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Philippe est très prudent sur internet&nbsp;: il évite les sites peu fiables, il est vigilant avant de cliquer sur un lien ou d’ouvrir une pièce jointe et il ne branche jamais d’appareils inconnus.&nbsp;🤔</p><p><br>Pourtant, il a peur que son ordinateur soit infecté par un logiciel malveillant. C’est arrivé à un de ses amis récemment, alors que lui aussi était prudent.</p>"
               }
             },
@@ -94,6 +95,7 @@
               "element": {
                 "id": "8397b72b-fdce-4d9a-9071-868df800532e",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Mais que fait un logiciel antivirus exactement ? </p>"
               }
             }
@@ -115,6 +117,7 @@
               "element": {
                 "id": "ae2cfed2-9fde-45d3-bded-8ceb6feb7f99",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Même si l’ordinateur de Philippe intègre déjà certaines protections, il décide&nbsp;d’<strong>installer un logiciel antivirus</strong>.</p>"
               }
             },
@@ -177,6 +180,7 @@
               "element": {
                 "id": "911286d9-f015-40a7-8150-c0a961f329cd",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Pour détecter la présence des logiciels malveillants, l’antivirus va surveiller les fichiers programmes de l’ordinateur de Philippe.</p>"
               }
             },
@@ -260,6 +264,7 @@
               "element": {
                 "id": "09624e99-41b4-4988-b697-5339222362cd",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Il existe des antivirus <strong>gratuits </strong>ou <strong>payants </strong>pour les ordinateurs, les tablettes, les smartphones&nbsp;: Norton, Avast, McAfee, Trend, CyRadar, Avira, AVG, Bitdefender, ReasonLabs, ClamAV.<br><strong>Un seul antivirus suffit.</strong></p><p><br>Une fois installé,<strong> pas besoin de lancer l’antivirus</strong> à chaque démarrage de l’appareil. L’antivirus fonctionne<strong> tout seul et en permanence</strong>.</p><p><br><strong>🤔 Bon à savoir</strong> <br>Certains appareils intègrent déjà des systèmes de protection contre les logiciels malveillants. Il est tout de même recommandé d’installer un logiciel antivirus.</p>"
               }
             }
@@ -275,6 +280,7 @@
               "element": {
                 "id": "024ea3ae-548b-4f85-8d3f-c09f0f6c8d37",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Mais comment un antivirus sait qu’un logiciel est malveillant ?</p>"
               }
             }
@@ -344,6 +350,7 @@
               "element": {
                 "id": "0ea11031-0120-4e7a-ab3d-77c028a6363f",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>La base de signatures est une liste des signatures des logiciels malveillants déjà connus par l’antivirus.<br>🚨 Lorsque l’antivirus détecte une correspondance entre une des signatures connues et les caractéristiques d'un fichier ou un programme, il peut&nbsp;:</p><ul><li>le <strong>bloquer</strong>, c'est-à-dire l'empêcher de s'installer ou de fonctionner sur l'appareil,</li><li>ou <strong>le supprimer</strong> de l'appareil.</li></ul><p><br>Ce mécanisme permet de détecter rapidement les logiciels malveillants déjà recensés.</p>"
               }
             }
@@ -359,6 +366,7 @@
               "element": {
                 "id": "48474476-a292-4856-8dca-637fd8110be9",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Une fois le logiciel antivirus installé, l’utilisateur n’a-t-il vraiment plus rien à faire ? </p>"
               }
             }
@@ -374,6 +382,7 @@
               "element": {
                 "id": "009744f7-8b6e-4fab-918c-bc162f870bf9",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Philippe a reçu plusieurs notifications de la part de son antivirus. <br>Il ne sait pas lesquelles nécessitent une action de sa part.</p>"
               }
             },
@@ -400,6 +409,7 @@
               "element": {
                 "id": "0fee0aa5-3408-47c2-81a6-1fce8b187903",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>En cas de doute (après le téléchargement d’un fichier ou l’utilisation d’un support externe par exemple), il est possible de<strong> lancer une analyse manuelle</strong>.&nbsp;</p><br><p>Lancer une analyse manuelle consiste à demander explicitement à l’antivirus d’examiner&nbsp;:</p><ul>    <li>l’ensemble de l’appareil,</li>    <li>ou un élément précis (dossier, disque dur, clé USB).</li></ul><p>Cela permet de vérifier qu’aucun logiciel malveillant ne s’est installé.&nbsp;🕵️‍♀️</p>"
               }
             }
@@ -415,6 +425,7 @@
               "element": {
                 "id": "4b268a76-cae4-43b1-bde4-cb9df881c581",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Mais de nouveaux logiciels malveillants apparaissent chaque jour, comment rester protégé ?</p>"
               }
             }
@@ -430,6 +441,7 @@
               "element": {
                 "id": "80c40811-99a5-4560-8443-e1787ff83a33",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Philippe a installé un antivirus sur son ordinateur depuis une semaine.<br>Son antivirus lui signale qu’il est temps de mettre à jour sa base de signatures.</p>"
               }
             },
@@ -485,6 +497,7 @@
               "element": {
                 "id": "26bfccda-f421-4250-b6f1-1bb5215fd4b1",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Pour pouvoir détecter les logiciels malveillants, la base de signatures de l’antivirus doit régulièrement être <strong>mise à jour</strong>.&nbsp;⚙️</p><p>Les éditeurs d’antivirus proposent donc des <strong>mises à jour régulières</strong>.<br>Il est <strong>impératif d’accepter ces mises à jour </strong>pour rester protégé dans la durée.</p>"
               }
             }
@@ -506,6 +519,7 @@
               "element": {
                 "id": "8b661573-da41-43c2-ac3f-bd147e37f702",
                 "type": "text",
+                "tag": " ",
                 "content": "<ul><li>Un <strong>antivirus </strong>est un logiciel qui protège les appareils contre les <strong>logiciels malveillants</strong>. Il est nécessaire d’installer un antivirus pour renforcer la <strong>protection </strong>des appareils. 🛡️</li></ul><br><ul><li>Un antivirus fonctionne<strong> en permanence</strong> et surveille les fichiers et programmes de l’appareil. 👀</li></ul><br><ul><li>Il compare les fichiers et les programmes à une<strong> base de signatures</strong> recensant les logiciels malveillants connus. S’il détecte un logiciel malveillant, il peut le <strong> bloquer ou le supprimer</strong>, puis vous en informe via une notification. 🙅</li></ul><br><ul><li>De nouveaux logiciels malveillants sont inventés tous les jours. Pour rester efficace, l’antivirus doit être <strong>mis à jour régulièrement </strong>afin d’intégrer les nouveaux logiciels malveillants recensés.⚙️</li></ul>"
               }
             }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYGestionMDP_IND.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYGestionMDP_IND.json
@@ -32,6 +32,7 @@
               "element": {
                 "id": "c632475e-e8aa-4010-a1b7-adcc0d5e20b9",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Retenir de nombreux mots de passe peut être compliqué !</p>"
               }
             },
@@ -94,6 +95,7 @@
               "element": {
                 "id": "4aba009d-7823-4b8c-9500-3ba4c7062015",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Si le gestionnaire de mots de passe est un coffre-fort, il vous faut une clé pour l’ouvrir ! 🗝️ <br>Découvrons ça ensemble.</p>"
               }
             }
@@ -115,6 +117,7 @@
               "element": {
                 "id": "a8c95aaf-5301-4a68-bba9-406cf7d44e73",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Elio utilise un gestionnaire de mots de passe pour stocker ses mots de passe en toute sécurité.<br>Et pourtant il n’a peut-être pas si bien sécurisé tout ça ! 😱</p>"
               }
             },
@@ -165,6 +168,7 @@
               "element": {
                 "id": "c4bfb89e-0c6f-4e6e-9a33-29e4854def77",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Si vous avez besoin d’aide, vous pouvez cliquer sur les indices ci-dessous&nbsp;:</p>"
               }
             },
@@ -207,6 +211,7 @@
               "element": {
                 "id": "6aebffaa-d63f-4449-bc40-5b0b86890242",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><strong>⚠️ Attention<br></strong>Pour des raisons de sécurité, le mot de passe maître ne peut pas toujours être récupéré ou réinitialisé. Vous devez absolument le mémoriser !</p><p><strong><br>💡 Comment choisir son mot de passe maître ?<br></strong> Il est recommandé de créer un mot de passe particulièrement long, qu’on appelle communément une <strong>phrase de passe</strong>. Par exemple, une longue phrase que vous seul connaissez&nbsp;: «&nbsp;Mes 2 chats adorent manger des raviolis le dimanche !&nbsp;» Ce type de mot de passe est long, unique et facile à mémoriser.</p>"
               }
             }
@@ -222,6 +227,7 @@
               "element": {
                 "id": "485724af-8190-4e21-9d9c-914d39a7430d",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Elio a retenu la leçon, désormais il est le seul à connaître son mot de passe. Pour le retenir facilement, il s’est créé une phrase de passe.<br>Voyons comment le gestionnaire de mots de passe peut vous faciliter la vie au quotidien.</p>"
               }
             }
@@ -237,6 +243,7 @@
               "element": {
                 "id": "7bd2814d-37a9-4469-a4ab-30aff59dcc2a",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Explorons plus en détails les fonctionnalités du gestionnaire de mots de passe d’Elio.</p>"
               }
             },
@@ -249,6 +256,7 @@
                     {
                       "id": "9e8f5cc7-66f4-4006-87d6-409dc2583c0b",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Elio est connecté à son gestionnaire de mots de passe. Il est en train d’y créer une nouvelle entrée.<br>Il a déjà renseigné le nom du site et son email.&nbsp;<br>Il lui reste à choisir un mot de passe.</p>"
                     },
                     {
@@ -266,6 +274,7 @@
                     {
                       "id": "c4c8c103-1367-4bb9-83ef-dcebb988930a",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Maintenant, Elio ouvre son navigateur internet et se rend sur www.toptracteur.net. Il veut s’y connecter. </p><p>Comme il est déjà connecté à son gestionnaire de mot de passe, il n’a pas besoin de se rappeler de son mot de passe Toptracteur.</p>"
                     },
                     {
@@ -292,6 +301,7 @@
               "element": {
                 "id": "710476f2-0e7c-4367-8b23-6075b313d91b",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><strong>🤔 Bon à savoir</strong><br>Pour garder vos informations en sécurité, le gestionnaire de mots de passe les sauvegarde dans un <strong>format codé </strong>(chiffré). Ainsi, même si des pirates informatiques accèdent aux données de votre gestionnaire, vos mots de passe sont <strong>illisibles </strong>et donc <strong>inutilisables </strong>pour les attaquants.</p>"
               }
             }
@@ -307,6 +317,7 @@
               "element": {
                 "id": "18626659-cf05-40b8-b1f9-2c6755e79b06",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Elio utilise son gestionnaire de mots de passe uniquement sur son ordinateur, mais certains utilisateurs peuvent vouloir utiliser un gestionnaire sur l’ensemble de leurs appareils&nbsp;: ordinateur, smartphone, tablette… <br>À chaque usage son gestionnaire de mots de passe !&nbsp;</p>"
               }
             }
@@ -322,6 +333,7 @@
               "element": {
                 "id": "bbc8a820-c3fa-4553-8cb4-21c7438e8b72",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Il existe deux grands types de gestionnaires de mots de passe recommandés&nbsp;: les <strong>gestionnaires locaux</strong> et les <strong>gestionnaires en ligne </strong>(cloud).<br>Pour chacun des exemples ci-dessous, indiquez quel  type de gestionnaire est utilisé.</p>"
               }
             },
@@ -334,6 +346,7 @@
                     {
                       "id": "6eb82f51-a049-45ec-8a63-3cccb9c08247",
                       "type": "text",
+                      "tag": " ",
                       "content": "<blockquote>Adrienne peut accéder à tous ses mots de passe sur son ordinateur de bureau, même sans connexion internet.</blockquote>"
                     },
                     {
@@ -373,6 +386,7 @@
                     {
                       "id": "77a95652-20d8-45b7-afe5-1b9ea0390b88",
                       "type": "text",
+                      "tag": " ",
                       "content": "<blockquote>Oumar peut se connecter sur son gestionnaire sur n’importe quel appareil grâce à son mot de passe maître.</blockquote>"
                     },
                     {
@@ -412,6 +426,7 @@
                     {
                       "id": "b7e2f949-181d-4276-ae27-7033c0455ab9",
                       "type": "text",
+                      "tag": " ",
                       "content": "<blockquote>Les données de Marjan sont stockées uniquement sur son ordinateur portable.</blockquote>"
                     },
                     {
@@ -460,6 +475,7 @@
               "element": {
                 "id": "cf0d145f-6e6c-423e-8eae-8d464531699e",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><strong>💡 Le choix d’un gestionnaire local ou en ligne dépend de votre usage.</strong><br>Il existe de très nombreux gestionnaires de mots de passe comme Keypass en local, ou Lockself, PassBolt, Bitwarden, Dashlane et 1Password en ligne.</p><p><br><strong>⚠️ Attention <br></strong>Il existe un autre type de gestionnaire de mot de passe&nbsp;: dans les <strong>navigateurs web </strong>. Ils proposent souvent d’enregistrer vos mots de passe pour aller plus vite… mais cette solution <strong>n’est pas suffisamment sécurisée</strong>. Les navigateurs sont une <strong>cible privilégiée des cyberattaquants</strong> et ne chiffrent pas toujours les données de façon fiable.</p>"
               }
             }
@@ -481,6 +497,7 @@
               "element": {
                 "id": "20c97fe3-8543-4eef-a09b-aa75cb5d1b62",
                 "type": "text",
+                "tag": " ",
                 "content": "<ul><li>Un <strong>gestionnaire de mots de passe</strong> est un <strong>coffre-fort numérique</strong> qui stocke et protège tous vos identifiants et <strong>mots de passe</strong>. 🔒<br><br></li><li>Il<strong> permet de créer automatiquement des mots de passe forts et uniques</strong>, et de les saisir facilement lors de vos connexions.<br><br></li><li>Pour y accéder, vous n’avez qu’un seul mot de passe à retenir&nbsp;: le <strong>mot de passe maître</strong>, qu’il faut choisir <strong>fort et unique</strong>. 🗝️<br><br></li><li>Il existe <strong>deux types de gestionnaires recommandés</strong>&nbsp;: les <strong>gestionnaires locaux</strong>, installés sur un appareil numérique (ordinateur, smartphone, tablette), et les <strong>gestionnaires en ligne </strong>(cloud), accessibles depuis plusieurs appareils.&nbsp; 🖥️ 📱</li></ul>"
               }
             }
@@ -502,6 +519,7 @@
               "element": {
                 "id": "784df0fd-c2c2-4323-85d0-8cd31465267d",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Voyons si vous avez retenu l’essentiel.</p>"
               }
             },
@@ -574,6 +592,7 @@
               "element": {
                 "id": "b5073ffe-0060-4e85-8a56-7fa97c16e278",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Alice a besoin d’accéder à ses comptes en ligne sur son ordinateur de bureau mais aussi sur sa tablette. Elle veut installer un gestionnaire de mots de passe. Elle hésite entre 2 gestionnaires.<br>Pour l’aider à choisir le gestionnaire le plus adapté, consultez le comparatif suivant&nbsp;:</p><table>    <tbody>        <tr>            <th scope=\"\\&quot;col\\&quot;\">Gestionnaire</th>            <th scope=\"\\&quot;col\\&quot;\">Gardemots</th>            <th scope=\"\\&quot;col\\&quot;\">Youshallpass</th>        </tr>        <tr>            <th scope=\"\\&quot;row\\&quot;\">Stockage des données </th>            <td>Sur un cloud</td>            <td>Sur votre ordinateur</td>        </tr>        <tr>            <th scope=\"\\&quot;row\\&quot;\">Outil de remplissage automatique </th>            <td>Oui</td>            <td>Oui</td>        </tr>        <tr>            <th scope=\"\\&quot;row\\&quot;\">Générateur de mots de passe forts</th>            <td>Oui</td>            <td>Oui</td>        </tr>        <tr>            <th scope=\"\\&quot;row\\&quot;\">Limite de mots de passe</th>            <td>Non</td>            <td>Non</td>        </tr>        <tr>            <th scope=\"\\&quot;row\\&quot;\">Prix</th>            <td>Gratuit (avec options payantes)<br></td>            <td>Gratuit </td>        </tr>    </tbody></table>"
               }
             },
@@ -634,6 +653,7 @@
               "element": {
                 "id": "4b4cf40e-61f1-48a5-9bc0-1fc8011a1b16",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Revenons à Elio. Il a besoin de changer son mot de passe pour son compte Papotix, car il est trop simple. <br>Le mot de passe maître de son gestionnaire est&nbsp;: «&nbsp;Avoir 5 chaussettes n'est pas normal, les chaussettes vont par paire !&nbsp;».<br>(<a href=\"https://docs.google.com/presentation/d/1xOat3bkwo2hx6-StoUeCdjCMcZCke1mTVs24D-8gdNU/edit?usp=sharing\" target=\"_blank\">lien vers idée d’activité</a>)</p>"
               }
             },
@@ -653,6 +673,7 @@
               "element": {
                 "id": "360b44b4-e37b-4022-b600-a9bc7a2f2d73",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Si vous avez besoin d’aide,&nbsp;vous pouvez cliquer sur les indices ci-dessous&nbsp;:</p>"
               }
             },

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYGestionMDP_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYGestionMDP_NOV.json
@@ -31,6 +31,7 @@
               "element": {
                 "id": "6c457dfe-9945-40fe-b8bf-117b5ffd3a58",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Max vient d’apprendre comment créer un mot de passe fort, difficile à deviner.</p>"
               }
             },
@@ -80,6 +81,7 @@
               "element": {
                 "id": "091a61a0-4de3-4e9a-98b2-d8d4dd4b5ecd",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Avoir un mot de passe fort c’est bien… mais est-ce vraiment suffisant ? 🤔</p>"
               }
             }
@@ -101,6 +103,7 @@
               "element": {
                 "id": "00d2c0cc-fc93-4e3b-8962-a267a4e5da61",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Max a reçu un message de la part d’un site sur lequel il a un compte. Les mots de passe de milliers d’utilisateurs ont été volés.🏴‍☠️</p><br><p>Max utilise <strong>un seul mot de passe fort</strong> pour tous ses comptes. Il faut donc vérifier si tout va bien sur les différents comptes de ses services en ligne.</p>"
               }
             },
@@ -210,6 +213,7 @@
               "element": {
                 "id": "02726fe3-410b-45d9-bcc9-fdf394cb0b3a",
                 "type": "text",
+                "tag": " ",
                 "content": "<h4>🛡️ Comment protéger vos services en ligne ?</h4><p>Choisissez des <strong>mots de passe différents</strong> pour chaque site.</p><p>En cas de vol d’un de vos mots de passe, seul le site concerné sera accessible pour les pirates informatiques. Les comptes des autres services en ligne resteront encore protégés.<br><br>⚠️ Au moindre doute sur la sécurité d'un de vos comptes, <strong>changez immédiatement votre mot de passe</strong> avant qu'il ne tombe dans de mauvaises mains.</p>"
               }
             }
@@ -225,6 +229,7 @@
               "element": {
                 "id": "06b27e61-500c-4c6a-85e1-6888b1ff6ff6",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Max a compris qu’il devait utiliser des mots de passe différents pour chaque service en ligne.</p><p>Maintenant, il veut être sûr de ne pas les oublier. Il a trouvé plusieurs méthodes. Mais sont-elles vraiment sûres ?&nbsp; 🤔</p>"
               }
             }
@@ -315,6 +320,7 @@
               "element": {
                 "id": "6f69f7d9-5de2-4994-96ed-b4b9891c97b7",
                 "type": "text",
+                "tag": " ",
                 "content": "<h5>💡 Astuce pour créer un mot de passe fort et facile à mémoriser</h5><p><br>1️⃣&nbsp;Choisir une phrase facile à retrouver.&nbsp;</p><blockquote>Par exemple&nbsp;: «&nbsp;<strong>L</strong>es <strong>3</strong> <strong>p</strong>etits <strong>c</strong>ochons <strong>é</strong>tait <strong>m</strong>on <strong>c</strong>onte <strong>p</strong>référé <strong>q</strong>uand <strong>j’</strong>étais <strong>p</strong>etit<strong>.</strong>&nbsp;»</blockquote><p> 2️⃣&nbsp;Transformer la phrase en gardant les premières lettres de chaque mot, les chiffres et la ponctuation.</p><blockquote>On obtient&nbsp;: <strong>L3pcémcpqj’p.</strong></blockquote>"
               }
             }
@@ -330,6 +336,7 @@
               "element": {
                 "id": "27e40885-2bfa-422f-a53a-8c3552ffaa55",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Mais si vous oubliez un de vos mots de passe, comment faire ?</p>"
               }
             }
@@ -345,6 +352,7 @@
               "element": {
                 "id": "fb6353dc-30e0-4a82-8ba6-facf2f2667d2",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Un jour, en voulant se connecter à son compte de vidéo à la demande, Max se rend compte qu’il a oublié son mot de passe. Impossible de se connecter ! 😬 </p><br><p>Pas de panique ! Il est toujours possible de retrouver l’accès à son compte.</p>"
               }
             },
@@ -366,6 +374,7 @@
               "element": {
                 "id": "9596a6ab-fc0e-493c-b12a-cbb20c38d02d",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Maintenant, Max va recevoir un message sur sa boîte mail.</p>"
               }
             },
@@ -421,6 +430,7 @@
               "element": {
                 "id": "1f75f9cd-b8b0-470f-abaa-6d44dcfc38f0",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>En cas d'oubli ou au moindre doute, tous les sites proposent de <strong>réinitialiser</strong> un mot de passe en cas d’oubli, c’est-à-dire de créer un nouveau mot de passe.</p><h5><br>⚠️Attention</h5><p>Pour réinitialiser le mot de passe d’un compte, il faut souvent vous connecter à votre <strong>boîte mail</strong>. S’il y a un mot de passe à ne pas oublier, c’est celui-là&nbsp;!</p>"
               }
             }
@@ -477,6 +487,7 @@
               "element": {
                 "id": "931a2644-7b67-4891-9a05-06bdf93136fd",
                 "type": "text",
+                "tag": " ",
                 "content": "<ul>    <li>Pour protéger vos comptes, <strong>créez des mots de passe forts et différents</strong> pour chaque site. 🛡️<br><br></li>    <li><strong>Gardez vos mots de passe secrets</strong>. Ne les communiquez à personne, ne les stockez pas dans un endroit facile à trouver et ne les enregistrez pas dans votre navigateur. 🤫<br><br> </li>    <li>N’hésitez pas, en cas d’oubli, <strong>réinitialisez vos mots de passe</strong>. 🔄</li></ul>"
               }
             }
@@ -498,6 +509,7 @@
               "element": {
                 "id": "90e0818e-bd50-4a22-b488-f7b72a747fbf",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Voyons si vous avez retenu l’essentiel avec de nouveaux exemples.</p>"
               }
             },
@@ -574,6 +586,7 @@
                     {
                       "id": "7ba279d1-9455-4d23-9370-6e21e65c992d",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Mathilde veut se connecter à son compte de jeux vidéo en ligne. Mais impossible de se souvenir de son mot de passe…</p>"
                     },
                     {
@@ -616,6 +629,7 @@
                     {
                       "id": "679ef9c5-32a0-47ac-a37c-85cfc056ca54",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Pour retrouver l’accès à son compte, Mathilde doit ensuite réinitialiser son mot de passe.</p>"
                     },
                     {
@@ -673,6 +687,7 @@
               "element": {
                 "id": "b47a304f-0f00-4249-badf-484dcabef68f",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Lola souhaite se connecter à son forum de discussion en ligne préféré. Mais elle a oublié son mot de passe.</p>"
               }
             },
@@ -701,6 +716,7 @@
               "element": {
                 "id": "1530c8fb-9d92-41b5-aec9-2c8aac6346d7",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Indices à intégrer dans POI<br></p><p><strong>&gt;Indice de l’étape 1&nbsp;:</strong> Cliquez sur “Mot de passe oublié pour commencer la réinitialisation.</p><p><strong>&gt;Indice de l’étape 3 </strong>: Regardez bien la barre des tâches en bas&nbsp;: une petite notification est apparue sur l’icône de messagerie.&nbsp;</p><p><strong>&gt;Indice de l’étape 4&nbsp;:</strong> Dans le message, cherchez cette phrase&nbsp;: «&nbsp;Cliquez sur ce lien afin de réinitialiser votre mdp&nbsp;». Le lien se trouve juste après.</p><p><strong>&gt;Indice de l’étape 5 </strong>: Il faut saisir le nouveau mot de passe fort choisi par Lola (sans oublier le point à la fin) puis cliquer sur le bouton “Réinitialiser son mdp” pour créer son nouveau mdp.</p><p><strong>&gt;Indice de l’étape 6&nbsp;:</strong> Pour se connecter, il faut la même adresse mail et le nouveau mdp créé dans l’étape 5&nbsp;:</p><p>- mail&nbsp;: lolalastar@pixmail.fr</p><p>- nouveau mdp&nbsp;: L2osémcpqjg!</p>"
               }
             }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYMDP_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYMDP_NOV.json
@@ -32,6 +32,7 @@
               "element": {
                 "id": "5885e265-8553-4619-91af-c0274f4719ef",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Ce matin, en essayant de se connecter sur un réseau social, Emma découvre que son compte a été piraté. Elle en parle à son amie Jennifer.</p>"
               }
             },
@@ -87,6 +88,7 @@
               "element": {
                 "id": "c4a70e3a-9786-4461-b067-0b7d040a7356",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Pour accéder à l’un de vos services en ligne, un pirate informatique peut utiliser plusieurs techniques pour trouver votre mot de passe. Découvrons cela ensemble.</p>"
               }
             }
@@ -108,6 +110,7 @@
               "element": {
                 "id": "e84a038e-66cd-4f74-9fdb-86f5c7332921",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Pour comprendre comment le compte d’Emma a été piraté, explorons son profil Snapgram.</p>"
               }
             },
@@ -167,6 +170,7 @@
               "element": {
                 "id": "c888f762-4b0c-401a-bfa4-2816af13d1f2",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Pour empêcher qu’un pirate puisse deviner votre mot de passe à partir de quelques informations à votre sujet, <strong>évitez d’utiliser des informations personnelles ou publiques</strong> dans vos mots de passe. 🤫</p>"
               }
             }
@@ -223,6 +227,7 @@
               "element": {
                 "id": "82342ed1-2ebc-4e8b-9c47-470a18fa5dc8",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Prenons le cas d’Ulysse. Il a un compte sur un site de vente en ligne. Il n’a <strong>pas</strong> utilisé d’<strong>informations personnelles</strong> dans son mot de passe.</p>"
               }
             },
@@ -271,6 +276,7 @@
               "element": {
                 "id": "315ac5d0-67c8-4a2d-b908-3790261af2fe",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Trouver le mot de passe d’Ulysse sera plus facile avec l’information suivante&nbsp;: son mot de passe fait partie&nbsp;<strong>des mots de passe les plus utilisés</strong> en France.</p>"
               }
             },
@@ -323,6 +329,7 @@
               "element": {
                 "id": "76208ca2-fb64-4350-92e2-96d6bec5ab8c",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Pour rendre la tâche plus difficile aux pirates, <strong>n’utilisez pas de prénoms, de noms, de mots du dictionnaire ou de mots de passe courants</strong>.</p>"
               }
             }
@@ -385,6 +392,7 @@
               "element": {
                 "id": "77eb96e5-a823-48f0-99f8-64d33a6b1717",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Combien de mots de passe différents peut-on former en mélangeant quelques lettres ? Découvrons cela ensemble.</p>"
               }
             },
@@ -458,6 +466,7 @@
               "element": {
                 "id": "0490f920-e6fb-4af2-9148-7284f29df9e8",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Pour <strong>ralentir</strong> les attaques de mot de passe par <strong>force brute</strong>, voici deux règles à appliquer&nbsp;:</p><ul><li><strong>Créez un mot de passe long&nbsp;:</strong> à partir de 12 caractères, le mot de passe est assez long.</li><li><strong>Utilisez toutes les sortes de caractères en les mélangeant&nbsp;:</strong>&nbsp; des minuscules, des majuscules, des caractères spéciaux comme = @ $ # ! ? ou encore des chiffres.</li></ul><p>En respectant ces règles, vous augmentez énormément le nombre de combinaisons que le pirate devra tester avant de trouver votre mot de passe.</p>"
               }
             }
@@ -582,6 +591,7 @@
               "element": {
                 "id": "6b7541c8-d7ba-4f81-a770-d4cedd7e6c21",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Observez chacun des mots de passe et sélectionnez pour quelle raison il s’agit d’un mot de passe faible et non d’un mot de passe fort.</p>"
               }
             },
@@ -874,6 +884,7 @@
               "element": {
                 "id": "e2f7c052-02eb-40e0-9ada-6f9a5bf6f738",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>À vous de créer un mot de passe fort en utilisant la même méthode que Jennifer.<br>Transformez la phrase suivante&nbsp;: </p><blockquote><strong>L</strong>e <strong>s</strong>oir<strong>,</strong> <strong>j</strong>’aime <strong>b</strong>oire <strong>d</strong>e <strong>l</strong>a <strong>s</strong>oupe <strong>a</strong>vec <strong>d</strong>es <strong>c</strong>roûtons <strong>e</strong>t <strong>m</strong>anger <strong>3</strong> <strong>t</strong>artines&nbsp;<strong>!</strong></blockquote>"
               }
             },

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYMFA_IND.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYMFA_IND.json
@@ -32,6 +32,7 @@
               "element": {
                 "id": "3d3e6e44-26b7-4ab5-a3a5-1cb0258d57fb",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Giulia a saisi son <strong>identifiant </strong>et son <strong>mot de passe</strong> pour se connecter à son compte sur le site SuperVéto pour prendre rendez-vous pour son chien. 🐶 </p><p>Le site SuperVéto indique à Giulia qu’un code à 6 chiffres vient de lui être envoyé par SMS sur son téléphone. Giulia doit saisir ce code sur le site pour pouvoir poursuivre sa visite. 📱<br><br></p>"
               }
             },
@@ -99,6 +100,7 @@
               "element": {
                 "id": "a6c452a3-3979-422c-99bb-571b92a7595b",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Demander plusieurs preuves, c’est renforcer la sécurité des accès. 🔒<br>Découvrez pourquoi et comment on ajoute une étape de sécurité supplémentaire.</p>"
               }
             }
@@ -166,6 +168,7 @@
               "element": {
                 "id": "8fb3840a-8724-404d-9c10-dc421fed314c",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Dans la suite de ce module, nous allons utiliser le terme «&nbsp;<strong>authentification multifacteur&nbsp;</strong>» parfois notée <strong>MFA</strong> (MultiFactor Authentication en anglais).</p>"
               }
             }
@@ -181,6 +184,7 @@
               "element": {
                 "id": "2cfcd0ad-673c-42f4-b77c-f53613b885c3",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Mais ça veut dire quoi «&nbsp;facteur&nbsp;» dans «&nbsp;multifacteur&nbsp;» ?</p>"
               }
             }
@@ -196,6 +200,7 @@
               "element": {
                 "id": "513eadab-7c62-4820-bfd2-835d4609afed",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Un facteur d’authentification est un <strong>moyen de prouver son identité</strong>. Ces facteurs d’authentification peuvent être de <strong>différents types</strong>.</p><p><br><strong>Pour chacune des situations suivantes, classez le moyen utilisé dans la catégorie qui lui correspond&nbsp;:</strong></p>"
               }
             },
@@ -217,6 +222,7 @@
                     {
                       "id": "890e31a1-dcc5-40e4-8b97-9304e225ac16",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Solveig dessine un schéma de déverrouillage pour utiliser sa tablette.</p>"
                     },
                     {
@@ -265,6 +271,7 @@
                     {
                       "id": "ff89e18a-7596-4a87-bdaa-8db47d7f419d",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Otis a reçu un code sur son téléphone pour accéder à la vidéo à la demande sur sa télévision.</p>"
                     },
                     {
@@ -313,6 +320,7 @@
                     {
                       "id": "271ed3c4-8718-42a0-8861-5bda30537359",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Kathy montre son visage à son smartphone pour le déverrouiller.</p>"
                     },
                     {
@@ -361,6 +369,7 @@
               "element": {
                 "id": "0c73ed69-90b6-442f-9aa1-716b7f7a2da3",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Un facteur d’authentification est un <strong>moyen de prouver son identité</strong>. <br></p><h5>Comment différencier les trois types de facteurs d’authentification ? </h5><ul><li>💬 Les facteurs de connaissance, par exemple&nbsp;: un mot passe. </li><li>👜 Les facteurs de possession, par exemple&nbsp;: une adresse mail. </li><li>🙋 Les facteurs biométriques, par exemple&nbsp;: une empreinte digitale.</li></ul>"
               }
             }
@@ -376,6 +385,7 @@
               "element": {
                 "id": "d9af8cc9-89a6-4154-bcd2-0b30e13dd911",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Tous ces facteurs d’authentification ont chacun des avantages et des inconvénients.</p>"
               }
             }
@@ -391,6 +401,7 @@
               "element": {
                 "id": "643b2f24-1c97-4e2a-8b3e-9205f5cc3fd2",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><strong>À votre avis, quels sont les inconvénients de chacun des facteurs d’authentification suivants ?</strong></p>"
               }
             },
@@ -566,6 +577,7 @@
               "element": {
                 "id": "10d652ae-fb1f-4e20-8e2e-08686f539a7d",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Chaque type de facteur a des avantages et des inconvénients.<strong> Ils ont tous des limites</strong> en matière de sécurité.</p><p><br>🤔<strong>Bon à savoir</strong> </p><p>Certaines méthodes d’authentification sont <strong>complexes et coûteuses à mettre en place</strong>. Par exemple, c’est pour ça que l’authentification par iris de l’œil n’est pas répandue.&nbsp;Elle coûte très cher. 💶</p><h5><br>Malgré ces limites, comment renforcer la sécurité des accès ?&nbsp; </h5><p>Pour éviter une <strong>usurpation d'identité</strong>, c'est-à-dire que quelqu’un vous vole vos accès et se fasse passer pour vous, les services en ligne demandent plusieurs facteurs d’authentification <strong>de natures différentes </strong>afin d’augmenter le niveau de sécurité globale.&nbsp;🔒&nbsp;🔒</p>"
               }
             }
@@ -581,6 +593,7 @@
               "element": {
                 "id": "4c089ab6-8fbd-48ff-9362-cf44b8ee4b28",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Pourquoi certains services proposent l’authentification multifacteur et d’autres non ?</p>"
               }
             }
@@ -666,6 +679,7 @@
               "element": {
                 "id": "c10935b1-81bb-41fd-b911-97d09ec4f67e",
                 "type": "text",
+                "tag": " ",
                 "content": "<h5>Et si l’authentification multifacteur n’est pas activée ?</h5><ul><li>⚙️Si le service <strong>propose </strong>la MFA, vous pouvez la configurer <strong>vous-même dans les paramètres</strong> de votre compte.&nbsp;</li><li>‼️Si le service <strong>impose </strong>désormais la MFA, vous serez invité à la <strong>configurer </strong>lors de votre <strong>prochaine connexion</strong>.</li><li>📅 Certains services ne proposent pas la MFA, ou pas encore.</li></ul><p><br>Activer l’authentification multifacteur soi-même ou quand elle est proposée, c’est <strong>ajouter une sécurité supplémentaire</strong>&nbsp;à votre compte et aux informations qu’il contient. 🔒</p>"
               }
             }
@@ -687,6 +701,7 @@
               "element": {
                 "id": "c88354b1-ec04-4922-898c-15bbeba3cdd5",
                 "type": "text",
+                "tag": " ",
                 "content": "<ul>\n    <li>Il y a trois types de facteurs d’authentification&nbsp;: <strong>ce que je connais</strong> (facteur de connaissance), <strong>ce que je possède </strong>(facteur de possession), et <strong>ce que je suis </strong>(facteur biométrique). 💬👜🙋</li><br>\n    <li>L’authentification multifacteur, c’est quand un service vous demande <strong>au moins deux facteurs d’authentification</strong> à la suite pour prouver votre identité. 2️⃣</li><br>\n    \n    <li>Une authentification multifacteur est <strong>plus sécurisée si les facteurs demandés sont de types différents</strong>, car leurs limites de sécurité sont différentes. 🔒🔒</li><br>\n    <li>Beaucoup de services en ligne qui gèrent des données personnelles imposent l’<strong>authentification multifacteur par défaut</strong>. D’autres services en ligne vous proposent de <strong>l’activer manuellement</strong> pour mieux vous protéger. ⚙️</li>\n</ul>"
               }
             }
@@ -834,6 +849,7 @@
               "element": {
                 "id": "1506d9b4-ae81-4810-bc05-c5c0f075ab6b",
                 "type": "text",
+                "tag": " ",
                 "content": "Pour terminer ce module, passons à la pratique."
               }
             },

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYMFA_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYMFA_NOV.json
@@ -32,6 +32,7 @@
               "element": {
                 "id": "7cd92f4e-8c09-4339-9b61-352f11a8b343",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Philomène est la nouvelle présidente de l’association Pattes de velours, une association de protection animale.&nbsp;🐾<br>Elle doit reprendre l’utilisation de la boîte mail de l’association.</p>"
               }
             },
@@ -87,6 +88,7 @@
               "element": {
                 "id": "5a44d403-1c9e-4f3b-8ca6-e09ba42dfb77",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Voyons à quoi servent l’identifiant et le mot de passe lors d’une connexion à un service en ligne.</p>"
               }
             }
@@ -126,6 +128,7 @@
               "element": {
                 "id": "a66d621e-344c-485e-bee0-139650302d47",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Pour accéder à un service en ligne, il faut&nbsp;:&nbsp; </p><ol>    <li><strong>S’identifier</strong>, c’est indiquer qui l’on est. 👤<br> ✔️Par exemple&nbsp;: un pseudonyme ou une adresse mail.</li>    <li><strong> S’authentifier</strong>, c’est prouver que c’est bien nous. 🔑<br> ✔️Par exemple&nbsp;: un mot de passe.</li></ol>"
               }
             }
@@ -141,6 +144,7 @@
               "element": {
                 "id": "2afec4e6-acd9-4719-badf-877a49253e4f",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Parfois, en plus du mot de passe, une étape supplémentaire est demandée pour valider la connexion. Voyons ça ensemble avec le cas de Philomène et de la boîte mail de son association.</p>"
               }
             }
@@ -156,6 +160,7 @@
               "element": {
                 "id": "6c6416ff-196c-4bb5-bc13-7a7400b360f9",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Philomène vient de récupérer l’adresse mail et&nbsp;le mot de passe de&nbsp;la boîte mail de l’association.&nbsp;📧<br>Mais au moment de se connecter, impossible ! Philomène est bloquée.<br>Voici l’écran qui s’affiche&nbsp;:&nbsp;</p>"
               }
             },
@@ -223,6 +228,7 @@
               "element": {
                 "id": "33c65867-a99d-4ee8-88df-9c9d3d368fb4",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>La double authentification n’est pas toujours un code reçu par SMS.</p>"
               }
             },
@@ -249,6 +255,7 @@
               "element": {
                 "id": "219b3c9e-33f9-4ce7-9b4a-5eaed1af77ec",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Certains services en ligne demandent une double authentification à chaque <strong>nouvelle connexion</strong>.&nbsp;🔐<br>D’autres services la demandent uniquement lors de la <strong>connexion depuis un nouvel appareil</strong>.&nbsp;🖥️📱</p>"
               }
             }
@@ -264,6 +271,7 @@
               "element": {
                 "id": "6feb5e9a-884f-416d-8c6c-65a76430e8a6",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Avoir une étape de vérification en plus pour se connecter peut sembler long. Mais alors à quoi sert la double authentification ?</p>"
               }
             }
@@ -279,6 +287,7 @@
               "element": {
                 "id": "c4060b9a-1bd7-4e63-8cb7-42ac0d335f4e",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Il existe de plus en plus de<strong> vols d’identifiants et de mots de passe</strong>.</p><p>Par exemple, le site internet Toutélectro a subi une attaque par des pirates informatiques. <br>Les pirates ont réussi à récupérer des données enregistrées sur le site&nbsp;: les identifiants et les mots de passe qui vont avec.<br><br>Richard et Sabrina font partie des utilisateurs dont les identifiants et mots de passe ont été volés.</p>"
               }
             },
@@ -374,6 +383,7 @@
               "element": {
                 "id": "4835a35e-7f73-4774-9bf3-a6fb6c1ed873",
                 "type": "text",
+                "tag": " ",
                 "content": "<h4>⚠️ Que faire si vous recevez une demande d’authentification alors que vous n’essayez pas de vous connecter ?</h4><p>C’est peut-être qu’une personne tente d’accéder à votre compte sur un service en ligne. Si c’est le cas, réagissez vite&nbsp;: </p><ul><li><strong>Ne validez pas la demande d’authentification.&nbsp;</strong></li><li><strong>Changez immédiatement votre mot de passe.</strong></li></ul>"
               }
             }
@@ -389,6 +399,7 @@
               "element": {
                 "id": "7ae52344-ccb6-4dfa-b6df-a04b757dc30a",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>La double authentification n’est pas automatiquement activée sur tous les services en ligne. Pour être mieux protégé, activez-la dès que c’est possible !</p>"
               }
             }
@@ -435,6 +446,7 @@
               "element": {
                 "id": "a1a81751-c328-4813-91c4-a5e1408045a9",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><strong>Voyons si vous avez retenu l’essentiel.</strong></p>"
               }
             },
@@ -567,6 +579,7 @@
               "element": {
                 "id": "7f0ec015-51f8-4e17-a61e-2c2b777d6818",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Pour chaque situation suivante, indiquez si elle correspond à une&nbsp;double authentification.</p>"
               }
             },
@@ -579,6 +592,7 @@
                     {
                       "id": "d74b7749-466e-4b1f-b631-7985050f79f0",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Lucie se connecte à son compte de messagerie depuis un ordinateur de la bibliothèque.<br>Après avoir tapé son mot de passe, une fenêtre lui indique qu’une notification vient d’être envoyée sur son téléphone.</p>"
                     },
                     {
@@ -613,6 +627,7 @@
                     {
                       "id": "444a5114-9d77-4e5b-ac64-3beae20a6114",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Lilian se connecte à son espace client sur un site de vente en ligne depuis le smartphone qu’il utilise tous les jours. Il entre son mot de passe et accède directement à son espace client.</p>"
                     },
                     {
@@ -647,6 +662,7 @@
                     {
                       "id": "0b153c7a-a61b-4bbf-aef3-07f6e157e8de",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Pour accéder à un service administratif en ligne, Binta entre son identifiant et son mot de passe. Elle doit ensuite saisir un code que le service administratif lui envoie par e-mail.</p>"
                     },
                     {
@@ -696,6 +712,7 @@
               "element": {
                 "id": "ea9dfc1a-89c1-4d04-a807-5213a6cf9df9",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Grâce à Tao, l’ancien président de l’association, Philomène a rattaché son numéro de téléphone à la boîte mail de l’association.<br>C’est maintenant Philomène qui recevra le code de vérification quand elle se connectera.<br><br>Voici les informations pour se connecter à la boîte mail&nbsp;:</p><ul><li> lassociation@pixmail.org</li><li>mdp&nbsp;: Asso12Aniw0!</li></ul>"
               }
             },
@@ -704,6 +721,7 @@
               "element": {
                 "id": "f8318c1c-996e-4a1e-8fe4-305aba23d3fa",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Aidez-la à se connecter à la boîte mail de l’association&nbsp;:<br><a href=\"https://epreuves.pix.fr/papotix/papotix.html?lang=fr&amp;mode=example\" target=\"_blank\">Simulateur à venir à partir de celui de l’évaluation</a>.<br>(à tester avec \"se connecter à papotix\", \"email\": \"a\",    \"password\": \"pix123\")<br><br>[Feedback dans le simulateur]<br>Bravo ! Philomène est connectée à la boîte mail de l’association.</p>"
               }
             },
@@ -712,6 +730,7 @@
               "element": {
                 "id": "2f7cd547-07b2-4134-a827-5025359d7fe1",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Si vous avez besoin d’aide, vous pouvez cliquer sur les indices ci-dessous&nbsp;:</p>"
               }
             },

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYPhishing_AVA.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYPhishing_AVA.json
@@ -31,6 +31,7 @@
               "element": {
                 "id": "2476fe57-7696-4368-a657-7a0ccf392d7b",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>L’entreprise AgroDélices a été victime d’une arnaque.<br>Lisez l’article suivant puis répondez à la question ci-dessous.&nbsp;</p>"
               }
             },
@@ -104,6 +105,7 @@
               "element": {
                 "id": "0252575f-bb33-4972-9b22-b23cd6b8b345",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Comment les failles humaines sont-elles exploitées ? Découvrons-le ensemble.</p>"
               }
             }
@@ -125,6 +127,7 @@
               "element": {
                 "id": "ca7fc2b1-130b-4bc8-b06d-86426cce8dc4",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Ce matin, Marie a été contactée par téléphone, par un homme se présentant comme faisant partie du service sécurité de la Banque Nationale.📲<br>Écoutez la conversation et observez la manière dont l’homme formule sa demande.</p>"
               }
             },
@@ -306,6 +309,7 @@
               "element": {
                 "id": "37c91342-5737-434c-89d1-ad0012d56cfd",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Ces attaques sont appelées des <strong>attaques</strong> par <strong>ingénierie sociale</strong>. <br>🥸 Il s’agit d’<strong>escroqueries</strong> ayant pour but de<strong> manipuler une personne</strong> afin d’obtenir de l’<strong>argent</strong> ou des<strong> informations confidentielles</strong> pour commettre une infraction.</p>"
               }
             }
@@ -321,6 +325,7 @@
               "element": {
                 "id": "ccb78000-0b6b-41b3-86ea-f4f0b5d8b76a",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Sur quoi s’appuient les cyberattaquants pour obtenir la réaction qu’ils souhaitent ?</p>"
               }
             }
@@ -410,6 +415,7 @@
               "element": {
                 "id": "8a36d6e6-ab1b-4ff5-8260-a2baa62ff833",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Dans les attaques reposant sur l’ingénierie sociale, les cyberattaquants exploitent des <strong>biais cognitifs communs aux êtres humains</strong>&nbsp;: des raccourcis de pensée qui <strong>influencent nos décisions</strong> dans le sens souhaité par les attaquants. 🧠</p><p> </p><br><p>🤔<strong> Bon à savoir</strong><br>Ces attaques peuvent s’appuyer sur de nombreux autres biais cognitifs&nbsp;: le biais de confirmation, le biais de contexte, le biais de surconfiance, etc.</p>"
               }
             }
@@ -425,6 +431,7 @@
               "element": {
                 "id": "9cabbbb0-6973-4453-a99b-2fc1ba39a2be",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>À quoi ressemblent ces arnaques reposant sur l’ingénierie sociale ?</p>"
               }
             }
@@ -440,6 +447,7 @@
               "element": {
                 "id": "96f89456-39ce-492f-b64e-cb93844b4071",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Les messages d’arnaque suivants n’ont été ni préparés, ni diffusés de la même façon.</p><p>Lisez-les et répondez ensuite aux questions.</p>"
               }
             },
@@ -652,6 +660,7 @@
               "element": {
                 "id": "af215ff5-1482-4681-95c0-96d22b0c75f0",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><strong>💡 Le saviez-vous ?</strong> <br>Plus l’attaque est personnalisée et soignée, plus elle est difficile à repérer. Même des experts en cybersécurité tombent parfois dans le piège.</p>"
               }
             }
@@ -673,6 +682,7 @@
               "element": {
                 "id": "97dbd631-143c-4904-8ecd-785b5b7384c1",
                 "type": "text",
+                "tag": " ",
                 "content": "<ul>    <li>Les <strong>attaques reposant sur l’ingénierie sociale</strong> exploitent les <strong>faiblesses humaines </strong>pour obtenir des <strong>informations </strong>ou de l’<strong>argent</strong>.</li><br>    <li>Le cyberattaquant <strong>trompe ou manipule la victime</strong> afin de la faire <strong>agir volontairement</strong> contre son propre intérêt. </li><br>    <li>Dans certains cas, l’attaquant <strong>manipule</strong> <strong>une seule personne</strong> pour atteindre l’<strong>ensemble d’une organisation</strong>.</li><br>    <li>Ces attaques reposent sur des mécanismes de <strong>manipulation psychologique</strong> qui exploitent des <strong>biais cognitifs</strong> pour influencer les décisions de la victime.<br></li><br>    <li>Ces attaques peuvent prendre <strong>plusieurs formes</strong>&nbsp;: hameçonnage de masse, hameçonnage ciblé, arnaque à la confiance.</li></ul>"
               }
             }
@@ -694,6 +704,7 @@
               "element": {
                 "id": "6c450994-a384-4e91-bea1-65d6215a97d7",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Voyons si vous avez retenu l’essentiel.</p>"
               }
             }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYPhishing_IND.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYPhishing_IND.json
@@ -32,6 +32,7 @@
               "element": {
                 "id": "f9a9eca3-9b86-4c44-9651-02c61a0a445c",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>En 2024, selon le rapport annuel de l’organisation internationale APWG (Anti-Phishing Working Group), plus de <strong>3,7 millions de sites frauduleux</strong> ont été détectés dans le monde.&nbsp; </p><p>Des escrocs diffusent massivement des <strong>messages d’arnaque </strong><strong>qui incitent</strong> les internautes à se rendre sur ces sites où ils vont se faire piéger . </p><p>Et <strong>personne n’est épargné</strong>&nbsp;: particuliers, organisations… même les professionnels du numérique peuvent tomber dans le piège.</p>"
               }
             },
@@ -79,6 +80,7 @@
               "element": {
                 "id": "b85bf93d-d444-4cd4-8cbd-bb8f7fc70714",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>🪝 Il est donc essentiel d’apprendre à <strong>se protéger de ces arnaques</strong>, en évitant de mordre à l’hameçon.</p>"
               }
             }
@@ -100,6 +102,7 @@
               "element": {
                 "id": "b7ad58c9-88b2-48f3-ac25-6f7b9da00f2e",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Pour chacun des exemples ci-dessous, observez le message et répondez à la question.</p>"
               }
             },
@@ -293,6 +296,7 @@
               "element": {
                 "id": "cb301130-8149-461b-b203-7f40281ee8ff",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Pour résumer, <strong>l’hameçonnage</strong> (ou phishing en anglais) est une technique d’arnaque par <strong>messages privés, SMS, mails ou appels.</strong>&nbsp;Un escroc <strong>se fait passer pour</strong> une personne ou un organisme de confiance, généralement en <strong>jouant sur vos émotions</strong>, pour <strong>récupérer vos données personnelles</strong>.🎣</p><p><br>⚠️ Les messages d’hameçonnage sont <strong>de plus en plus réalistes</strong>, année après année. Ils sont donc de plus en plus durs à repérer.<br><br></p>"
               }
             }
@@ -308,6 +312,7 @@
               "element": {
                 "id": "2a4eb89a-feee-4e23-8fe7-77b008349e2b",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Le ton d’urgence ou le sujet vous fait penser à une arnaque, mais le réalisme du message vous fait douter ? </p><p>Ça arrive, c’est normal.</p><p>Découvrez comment débusquer les escrocs. 🕵️</p>"
               }
             }
@@ -474,6 +479,7 @@
               "element": {
                 "id": "a84dcf7e-f23e-43c4-840a-1aef5f41b6bb",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Si vous avez besoin, aidez-vous des indices suivants :<br></p>"
               }
             },
@@ -507,6 +513,7 @@
               "element": {
                 "id": "77909d47-54bc-4fc6-8b36-bb1816894d44",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Dans les mails d’hameçonnage, l’escroc <strong>imite de façon presque parfaite</strong> une personne ou un organisme de confiance. 👺</p><p>Ayez l’œil pour repérer les imperfections !<br></p>"
               }
             },
@@ -515,6 +522,7 @@
               "element": {
                 "id": "d6993f31-86f6-4544-84ac-d5ead738615e",
                 "type": "text",
+                "tag": " ",
                 "content": "🤔<strong> Bon à savoir</strong><br>Des indices se cachent parfois dans les URL. Sur ordinateur, <strong>le survol permet de voir l’URL</strong> vers lequel un bouton veut vous rediriger. Si cette URL comporte des fautes ou n’a rien à voir avec l’expediteur ou sa demande, il est possible que le mail soit du phishing."
               }
             },
@@ -539,6 +547,7 @@
               "element": {
                 "id": "12c491de-ff71-4bdc-9c60-d147953210a7",
                 "type": "text",
+                "tag": " ",
                 "content": "<h4>Et pour les messages reçus par SMS ou sur les réseaux sociaux ?</h4><p>Posez-vous les mêmes questions&nbsp;: L’expéditeur est-il connu et bien orthographié ? Le compte est-il vérifié ? L’adresse du lien semble-t-elle correcte ?<br></p>"
               }
             }
@@ -554,6 +563,7 @@
               "element": {
                 "id": "ab18801a-ba3e-47be-ae4e-ecc43a754d6a",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Avec ces indices, vous savez maintenant mieux repérer les messages d’hameçonnage. </p><p>Mais ils continuent d’encombrer votre boîte mail. Que faire ?</p>"
               }
             }
@@ -569,6 +579,7 @@
               "element": {
                 "id": "7ece3d8c-d1cb-4589-a664-a9de98f9fd97",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Depuis votre boîte mail, vous pouvez agir pour vous protéger et protéger les autres.</p>"
               }
             },
@@ -647,6 +658,7 @@
               "element": {
                 "id": "70cadc99-643a-4257-b711-72a76f194da3",
                 "type": "text",
+                "tag": " ",
                 "content": "<h4>Comment se protéger de l’hameçonnage ? 🛡️</h4><p>Se protéger&nbsp;: <strong>bloquer</strong> un expéditeur malveillant empêche de recevoir de nouveaux messages de sa part.</p><p>Protégez les autres&nbsp;: <strong>marquer comme indésirable</strong> (spam) contribue à améliorer les filtres anti‑spam de tous les utilisateurs.</p>"
               }
             }
@@ -662,6 +674,7 @@
               "element": {
                 "id": "cb32bbb8-1d16-4a0b-ab88-ba8b7b15afe3",
                 "type": "text",
+                "tag": " ",
                 "content": "<h4>Vous avez encore un doute ? 🕵️</h4><p>N’hésitez pas à demander de l’aide à un proche ou un professionnel en qui vous avez confiance.<br></p>"
               }
             }
@@ -683,6 +696,7 @@
               "element": {
                 "id": "e7da66f2-7e20-4c0f-85ed-f344bc48a8d2",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>L’hameçonnage (ou phishing en anglais) est une technique utilisée par des escrocs pour <strong>vous inciter à communiquer des données personnelles</strong> en se <strong>faisant passer pour un tiers de confiance</strong>. 🎣</p><p>Un message d’<strong>hameçonnage</strong> peut ressembler à un message légitime. Il comporte souvent plusieurs petits <strong>indices</strong> à repérer&nbsp;:</p>"
               }
             },
@@ -896,6 +910,7 @@
               "element": {
                 "id": "93c7cfc9-93e9-42b8-95e2-b424da4548aa",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Votre abonnement à la revue <em>Paysages du monde</em> se termine. Vous avez reçu plusieurs mails pour vous inviter à le prolonger.</p>"
               }
             },
@@ -956,6 +971,7 @@
               "element": {
                 "id": "f81294a5-8ef3-4449-b60e-29d270d71fc8",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Parmi les mails reçus dans l’application ci-dessous, l’un d’entre eux est malveillant.</p>"
               }
             },
@@ -990,6 +1006,7 @@
               "element": {
                 "id": "72764293-9f8c-4c9e-83d1-a94cfbbe840c",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Vous avez reçu un mail d’un site de vente de chaussures où vous avez passé commande.  Le message vous indique un problème avec votre commande.  Vous avez <strong>un doute sur l’authenticité de ce message</strong>.</p>"
               }
             },

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYPhishing_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYPhishing_NOV.json
@@ -31,6 +31,7 @@
               "element": {
                 "id": "dc2857df-3922-4355-b0f3-76f240e66ef8",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Ce matin, Yvette a reçu un message surprenant. Elle en parle à Enzo.</p>"
               }
             },
@@ -126,6 +127,7 @@
               "element": {
                 "id": "9074de8f-e4df-47b0-bc96-46b6e08f058a",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Comme Yvette et Enzo, vous pouvez recevoir des messages qui proviennent d’inconnus.<br>Lisez le message ci-dessous.&nbsp;</p>"
               }
             },
@@ -146,6 +148,7 @@
               "element": {
                 "id": "e8b781ab-0765-4314-89e5-1ca621ad0d43",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Ce message est une tentative d’arnaque. La personne qui l’a écrit ne cherche pas à livrer un colis.</p>"
               }
             },
@@ -201,6 +204,7 @@
               "element": {
                 "id": "4c853dca-4711-4bb0-8bca-1480ee237245",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Les tentatives d’arnaque par message sont des <strong>messages trompeurs</strong> envoyés à <strong>un très grand nombre de personnes</strong> par des escrocs, pour obtenir des informations personnelles.&nbsp;</p><p><br><strong>🤔 Bon à savoir</strong><br>On appelle cela de l’hameçonnage (ou phishing en anglais).</p>"
               }
             }
@@ -267,6 +271,7 @@
               "element": {
                 "id": "c22766bc-ff57-4f2b-a457-952ed34f4adc",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Voici plusieurs&nbsp;<strong>tentatives d’arnaque par message</strong>.</p>"
               }
             },
@@ -366,6 +371,7 @@
               "element": {
                 "id": "732eb744-d3f5-42b5-9d80-786b22f0e661",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><strong>📌 À retenir</strong> <br>Un service public ou une entreprise commerciale sérieuse <strong>ne vous demandera pas vos données</strong> bancaires ou vos mots de passe par message ou par téléphone.</p>"
               }
             }
@@ -535,6 +541,7 @@
               "element": {
                 "id": "56b11acd-0a06-4ca7-8872-9da44dd4fc30",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Pour <strong>éviter de tomber dans le piège</strong>, prenez le temps de réfléchir avant d’agir&nbsp;: ne communiquez pas d’informations personnelles et ignorez le message.</p><p><br><strong>🤔 Bon à savoir</strong><br>Ces messages d’arnaque sont très courants par SMS, sur les messageries instantanées mais aussi par mail et sur les réseaux sociaux.</p>"
               }
             }
@@ -597,6 +604,7 @@
               "element": {
                 "id": "4ea0043a-48ca-4421-870a-ff0d3d7ba54e",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Les tentatives d’<strong>arnaque par message</strong> sont des <strong>messages trompeurs</strong> envoyés dans le but de <strong>collecter des informations personnelles</strong>. 📝</p>"
               }
             },
@@ -630,6 +638,7 @@
               "element": {
                 "id": "778b6439-3779-4f82-ab08-0f670c3fd281",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Voyons si vous avez retenu l’essentiel.</p>"
               }
             }
@@ -713,6 +722,7 @@
                     {
                       "id": "97e21eda-86fd-46ce-82fb-0b5f321acf38",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Pour chacun des messages ci-dessous, indiquez s’il s’agit d’une tentative d’arnaque ou d’un message sûr.</p>"
                     },
                     {
@@ -923,6 +933,7 @@
               "element": {
                 "id": "d99fa99d-4e91-44e0-b9c2-f73fe71c0eff",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Sur Instagram, vous recevez un message de votre chanteur préféré.<br>Il vous envoie un lien pour  un super concours&nbsp;: gagner une rencontre avec lui après un de ses concerts.&nbsp;✨✨✨</p>"
               }
             },

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYVirus_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYVirus_NOV.json
@@ -32,6 +32,7 @@
               "element": {
                 "id": "d6b16bfc-5fc9-4b7b-b15e-235644643afa",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Parfois, il arrive qu’un ordinateur se comporte de manière inhabituelle.</p><p><strong>Lancez la vidéo ci-dessous et observez ce qui se passe sur l’écran d’ordinateur.</strong></p>"
               }
             },
@@ -105,6 +106,7 @@
               "element": {
                 "id": "ab1ca7db-aa26-49fe-8a04-2bf7817957bc",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Quand un logiciel malveillant est présent sur un appareil, il peut parfois causer des problèmes de fonctionnement.</p>"
               }
             }
@@ -126,6 +128,7 @@
               "element": {
                 "id": "230872da-3e77-4993-b7d0-ece29d0b4a4c",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><strong>Trois ordinateurs</strong> ont été <strong>infectés par un logiciel malveillant</strong>. </p><p>Observez leurs écrans ci-dessous puis répondez à la question.</p>"
               }
             },
@@ -147,6 +150,7 @@
                     {
                       "id": "181aafad-5c86-48eb-97a8-8bd68f03a1d3",
                       "type": "text",
+                      "tag": " ",
                       "content": "<h5>Ordinateur 1</h5><p> <strong>Cet ordinateur a  été infecté par un logiciel malveillant.</strong></p>"
                     }
                   ]
@@ -165,6 +169,7 @@
                     {
                       "id": "7d5600fc-cff4-48b9-8e46-5170001f5069",
                       "type": "text",
+                      "tag": " ",
                       "content": "<h5>Ordinateur 2  </h5><p><strong>Cet ordinateur a  été infecté par un logiciel malveillant.</strong></p>"
                     }
                   ]
@@ -183,6 +188,7 @@
                     {
                       "id": "e1404c05-11b5-4531-a373-ede7492d4676",
                       "type": "text",
+                      "tag": " ",
                       "content": "<h5>Ordinateur 3</h5><p><strong>Cet ordinateur a  été infecté par un logiciel malveillant.</strong></p>"
                     }
                   ]
@@ -241,6 +247,7 @@
               "element": {
                 "id": "3255ed2b-a635-4a59-a9ba-b30e1da38c3b",
                 "type": "text",
+                "tag": " ",
                 "content": "<h5>C’est quoi un logiciel malveillant ? </h5><p>Un <strong>logiciel malveillant</strong> (ou <em>malware </em>en anglais) est un <strong>programme informatique</strong> qui a pour objectif de <strong>perturber le fonctionnement normal</strong> d’un appareil (ordinateur, smartphone, tablette). <br>Il peut agir sans que l'utilisateur s’en rende compte.</p><br><h5>🤔 Bon à savoir</h5><p><strong>Un virus informatique</strong> est <strong>un type</strong> de logiciel malveillant parmi d’autres.</p>"
               }
             }
@@ -256,6 +263,7 @@
               "element": {
                 "id": "95d323ed-02d2-41cd-ade6-14898ffb9b9f",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Mais alors, si certains logiciels malveillants ne se voient pas toujours, est-ce qu’on doit s’inquiéter tout le temps d’en avoir un sur son appareil ? 😱</p><p>Pas forcément, car cela dépend surtout de ce que vous faites sur votre appareil.</p>"
               }
             }
@@ -271,6 +279,7 @@
               "element": {
                 "id": "50b2a382-b5d3-4105-a54b-10265376af41",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>La plupart du temps, un logiciel malveillant ne s’installe pas tout seul. Dans certaines situations, certains de vos gestes peuvent être risqués.</p>"
               }
             },
@@ -343,6 +352,7 @@
               "element": {
                 "id": "8bdf5c90-6319-4f25-8183-cf92dc372ceb",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><strong>Pour éviter d'installer un logiciel malveillant</strong>, il faut être vigilant et adopter des gestes sûrs&nbsp;:</p><ul><li>Téléchargez des logiciels ou des applications sur <strong>des sites légaux et dans les magasins d’applications officiels</strong>.</li><li>Faites attention <strong>aux liens sur lesquels vous cliquez</strong> ainsi qu’<strong>aux fichiers ou pièces jointes que vous ouvrez</strong>.</li><li>Connectez seulement <strong>des appareils de confiance</strong>.</li></ul><br><h5>🤔 Bon à savoir</h5><p>Pour recharger votre appareil en toute sécurité, il est préférable d’utiliser votre propre chargeur (secteur) branché sur une prise électrique. 🔌</p>"
               }
             }
@@ -358,6 +368,7 @@
               "element": {
                 "id": "f13c6d5e-220d-48f4-8fc5-8b07ce0a7f31",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Derrière ces <strong>pièges</strong>, il y a des <strong>pirates informatiques</strong>. </p><p>Les pirates <strong>cachent</strong> des logiciels malveillants dans des contenus ou des supports attirants.&nbsp;</p><p>Mais pourquoi les pirates veulent-ils vous piéger ?</p>"
               }
             }
@@ -373,6 +384,7 @@
               "element": {
                 "id": "3a24782c-14d5-4c2f-baf2-5da35f32694b",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Sans le savoir, vous avez peut-être des informations qui intéressent <strong>les pirates informatiques.</strong></p><p><strong></strong> Voyons cela ensemble.</p>"
               }
             },
@@ -399,6 +411,7 @@
               "element": {
                 "id": "e7efa1be-03f5-4844-830c-249636f8e122",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Les logiciels malveillants sont <strong>créés </strong>et<strong> diffusés</strong> par des <strong>pirates informatiques.</strong> En général, le but des pirates est de <strong>nuire</strong> au plus grand nombre de personnes possible <strong>pour en tirer profit.</strong></p>"
               }
             }
@@ -414,6 +427,7 @@
               "element": {
                 "id": "b6b4fd71-8578-4d75-a513-e0ce629bdd78",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Tout le monde peut être la cible des pirates informatiques. C’est pourquoi il est essentiel d’adopter les bons réflexes pour protéger son appareil des logiciels malveillants.</p>"
               }
             }
@@ -524,6 +538,7 @@
               "element": {
                 "id": "8d1432e8-c548-410b-9c20-8ac58c465e9d",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Pour chaque situation, choisissez quelle action présente un risque d’installer un logiciel malveillant.</p>"
               }
             },
@@ -662,6 +677,7 @@
               "element": {
                 "id": "af811730-2c61-4e59-ab1b-f19b2f1afac1",
                 "type": "text",
+                "tag": " ",
                 "content": "Vous avez vu qu’il est important d’être prudent au quotidien pour limiter les risques d’installer un logiciel malveillant sur son appareil.<br>Il existe également d’autres actions complémentaires pour renforcer la protection de vos appareils."
               }
             },

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IADefinition_IND.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IADefinition_IND.json
@@ -31,6 +31,7 @@
               "element": {
                 "id": "6e186654-fd70-4d4c-af3e-530b7664b193",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Arthur a entendu parler de l’ail des ours, une plante qui se mange, et il voudrait goûter. 😋 </p><p>Mais il a peur de se tromper pendant sa cueillette, alors il demande à son amie, Lila. 🧺<br><br></p>"
               }
             },
@@ -110,6 +111,7 @@
               "element": {
                 "id": "c8956a41-9bef-469b-ab67-e58f974a4e30",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Mettez-vous un instant à la place du logiciel de Lila. 🤖</p><p>Vous allez observer des photographies d’ail des ours et de muguets. </p><p>Vous devrez ensuite les reconnaître.👀 Vous êtes prêt ?</p>"
               }
             },
@@ -122,6 +124,7 @@
                     {
                       "id": "514a883c-0533-4006-ad57-46539a338cfc",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Voici des photographies d’ail des ours.</p>"
                     },
                     {
@@ -140,6 +143,7 @@
                     {
                       "id": "3ae25cff-f570-4f63-9b81-05cff2fba4d5",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Voici des photographies de muguet.<br></p>"
                     },
                     {
@@ -311,6 +315,7 @@
               "element": {
                 "id": "533a20ac-123a-4dc5-b13c-0a5601437e62",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Vous venez de tester une des méthodes de la reconnaissance d’images, comme le fait un logiciel d’IA. 🔍</p><h5>  Mais comment apprend-il à reconnaître ce qu’il voit ? </h5><p>  On lui montre de nombreux exemples d’images avec leur nom&nbsp;: ce sont des données étiquetées. 🏷️</p><p>  Cette méthode s’appelle l’apprentissage supervisé&nbsp;: les ingénieurs fournissent au logiciel d’IA un jeu d’exemples annotés, soigneusement préparés, qui guident et encadrent son apprentissage.👨🏽‍💻</p>"
               }
             }
@@ -326,6 +331,7 @@
               "element": {
                 "id": "73bb13a6-34a5-41be-bdb6-5b9fce3593aa",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Mais au fait, comment un logiciel d’IA traite-t-il une image ? Découvrons cela ensemble. </p>"
               }
             }
@@ -345,6 +351,7 @@
                     {
                       "id": "79bcc080-6067-4921-9cd7-7fff4903bc85",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Nous voyons une photographie.</p>"
                     },
                     {
@@ -363,6 +370,7 @@
                     {
                       "id": "4c380d32-3c56-4235-9d3e-8c1497575b07",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Une photographie numérique est composée de milliers de petits carrés appelés pixels. Notre œil ne voit pas ces carrés tellement ils sont petits !<br></p>"
                     },
                     {
@@ -381,6 +389,7 @@
                     {
                       "id": "b6763b47-e272-480d-b735-3aea9528acbf",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Chaque pixel contient des nombres qui indiquent sa couleur.</p>"
                     },
                     {
@@ -408,6 +417,7 @@
               "element": {
                 "id": "8e0084cb-c38a-49db-8126-4d3bb0b3077f",
                 "type": "text",
+                "tag": " ",
                 "content": "<h5>Et que va faire le logiciel d’IA avec ces nombres ?</h5><p>À&nbsp;partir du tableau de nombres représentant l’image, le logiciel d’IA va pouvoir faire des <strong>calculs</strong>. C'est ce qui va lui permettre de traiter cette image.</p>"
               }
             }
@@ -423,6 +433,7 @@
               "element": {
                 "id": "bde3a389-1875-4e42-9c06-1cab0c51be96",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Maintenant, regardons de plus près : comment le logiciel fait le lien entre la donnée d’entrée (la photo) et la donnée de sortie (son nom) ?</p>"
               }
             }
@@ -442,6 +453,7 @@
                     {
                       "id": "5e52b226-e3e9-4a24-8b85-1f57fa2435b1",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Voici le logiciel d'IA en plein entraînement. Une photo d'ail des ours est fourni au logiciel.&nbsp; </p><p>Le logiciel est en train de régler ses paramètres pour obtenir la prédiction \"Ail des ours\".</p>"
                     },
                     {
@@ -483,6 +495,7 @@
                     {
                       "id": "8b0e27a0-733c-40fd-9108-d2878429fd95",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Et ensuite, que se passe-t-il ?</p><p>Le logiciel ajuste ses paramètres. Lancez la vidéo pour voir sa prédiction.<br></p>"
                     },
                     {
@@ -524,6 +537,7 @@
                     {
                       "id": "7c41625a-cc18-4b95-bb61-4f1a110ce866",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Le logiciel ajuste de nouveau ses paramètres. <br> Lancez la vidéo pour voir sa nouvelle prédiction.</p>"
                     },
                     {
@@ -565,6 +579,7 @@
                     {
                       "id": "4aec0109-31b7-471c-96a1-bd8327a96f07",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Le logiciel a réussi à régler ses paramètres pour obtenir la prédiction \"ail des ours\" sur cette photo.&nbsp;<br></p>"
                     },
                     {
@@ -606,6 +621,7 @@
                     {
                       "id": "c921068f-9d95-410f-84e0-d00dce15b202",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Le logiciel  recommence son&nbsp;entraînement sur des milliers d’images. </p><p>Les paramètres sont de mieux en mieux ajustés. La prédiction est juste de plus en plus souvent.</p>"
                     },
                     {
@@ -620,6 +636,7 @@
                     {
                       "id": "4cc6fd84-4215-4cf9-956b-de1a86de63bc",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Grâce à cet entraînement, le logiciel va être capable de dire si une photo de la base de donnée est celle d'un brin de muguet ou d'ail des ours.<br></p>"
                     }
                   ]
@@ -638,6 +655,7 @@
               "element": {
                 "id": "d14cf5f8-6d3f-4e77-abb2-033f8d13b062",
                 "type": "text",
+                "tag": " ",
                 "content": "<h5>Si l'on résume, comment se passe l'entraînement d'un logiciel de reconnaissance d'image ?</h5>\n<p>Le logiciel dispose de plusieurs <strong>paramètres </strong>pour faire des calculs sur les <strong>valeurs </strong>d'une image.</p>\n<p><strong>Au départ</strong>, les paramètres sont fixés&nbsp;<strong>au hasard</strong>.🎰<br>En fonction de ces paramètres, le <strong>résultat </strong>des calculs donne une <strong>prédiction</strong>.</p>\n<p>À chaque nouvelle tentative, le logiciel compare sa prédiction à la réponse attendue.&nbsp;🔄</p>\n<p>Ainsi, par<strong> essai erreur</strong>, il ajuste progressivement les paramètres jusqu’à obtenir la bonne prédiction.&nbsp;✅<br>Une fois l'entraînement terminé sur une image, l'entraînement est <strong>répété </strong>sur des<strong> milliers d'autres images.</strong><br><br></p>"
               }
             }
@@ -653,6 +671,7 @@
               "element": {
                 "id": "aa0e2963-70cd-4773-96da-af9b01878583",
                 "type": "text",
+                "tag": " ",
                 "content": "Mais comment savoir si cet entraînement est suffisant ?<br>C'est ce que nous allons voir avec le logiciel de Lila."
               }
             }
@@ -672,6 +691,7 @@
                     {
                       "id": "7f771c91-272f-42e9-875c-97640fcb7809",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Lila a donné à son logiciel des centaines de photographies ressemblant à celles ci-dessous.</p><p>Elle se demande si cet entraînement suffit pour qu’il reconnaisse l’ail des ours. 🥕</p>"
                     },
                     {
@@ -690,6 +710,7 @@
                     {
                       "id": "df83f537-de47-43da-8087-480f5b44bc8f",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Lila a testé son logiciel sur cette nouvelle photographie d’ail des ours.</p><p>Le logiciel n’arrive pas à trancher avec certitude. </p><p>Il indique un score 0,4 pour «&nbsp;ail des ours&nbsp;» et de 0,6 pour «&nbsp;muguet&nbsp;».</p>"
                     },
                     {
@@ -744,6 +765,7 @@
                     {
                       "id": "4f15ba33-8b56-49de-a277-be097b576d94",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Le <strong>but </strong>du logiciel est d’<strong>attribuer la bonne étiquette à des exemples</strong> qu’il n’a jamais vus pendant son entraînement : c’est la <strong>généralisation</strong>. 🚀</p><h5><strong>Comment bien généraliser ?</strong></h5><p>On doit <strong>fournir au logiciel d'IA des exemples variés et représentatifs</strong> de tous les cas typiques, afin de réduire les erreurs. Mais même avec un bon entraînement, le monde réel contient toujours des cas nouveaux ou limites ; un <strong>risque d’erreur</strong> existe donc toujours.⚠️</p>"
                     }
                   ]
@@ -753,6 +775,7 @@
                     {
                       "id": "f31ca24b-f958-4c77-bc38-6024c832b4c3",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Pour réduire ce risque d'erreur, le logiciel passe par une <strong>phase de test</strong>.</p><h5>En quoi consiste la phase de test ? </h5><p>Après l’entraînement, on <strong>évalue le logiciel sur de nouveaux exemples</strong>, sans lui donner la bonne réponse à l’avance.\nSi les résultats ne sont pas satisfaisants, il peut être nécessaire de reprendre l’entraînement avec plus ou de meilleurs exemples. 💪</p>"
                     }
                   ]
@@ -762,6 +785,7 @@
                     {
                       "id": "06144dc9-610d-483a-a79c-62d17de1749e",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>💡<strong>Bon à savoir :</strong></p><p>Le logiciel ne peut prédire que les étiquettes qu’il a apprises lors de son entraînement.</p>"
                     },
                     {
@@ -789,6 +813,7 @@
               "element": {
                 "id": "f071912a-b067-4d03-8217-cc087d3cdbff",
                 "type": "text",
+                "tag": " ",
                 "content": "Saviez-vous que la génération de texte, avec ChatGPT ou Mistral par exemple, repose sur un principe similaire ?&nbsp;✨<br>On entraîne le logiciel d’intelligence artificielle avec des phrases où un mot est manquant, et le logiciel s’entraîne à prédire quel est ce mot."
               }
             }
@@ -804,6 +829,7 @@
               "element": {
                 "id": "5ec6e39a-0852-4ee9-b892-5a4b66b890e3",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Imaginons que Lila entraîne une autre IA pour générer un petit texte de description des plantes.<br>Elle veut que le logiciel d'IA soit capable de reconstituer la phrase :<br> <strong>\"L’ail des ours peut se manger en salade.\"&nbsp;</strong>🥗</p>"
               }
             },
@@ -901,6 +927,7 @@
               "element": {
                 "id": "136e86b1-cc7d-4e9c-a5f4-a3f1e5808757",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Lila peut maintenant entraîner son nouveau logiciel d’intelligence artificielle.🚀</p>"
               }
             }
@@ -920,6 +947,7 @@
                     {
                       "id": "a041b7dc-9566-4bee-aaf4-106de9a98662",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>L’apprentissage supervisé ne sert pas uniquement à reconnaître des images.</p><p> Par exemple, les logiciels d<strong>’IA générative</strong> peuvent aussi être entraînés à produire du texte selon un <strong>principe similaire</strong>&nbsp;: </p><ul>    <li>On leur <strong>fournit des textes</strong> dans lesquels certains mots sont volontairement masqués 🙈. </li>    <li>Chaque <strong>mot manquant</strong> est alors considéré comme une <strong>étiquette </strong>🏷️. </li>    <li>En étudiant les caractéristiques des textes, le modèle apprend à prédire le mot manquant 📃.</li></ul><p>C’est ainsi qu’ils acquièrent la capacité de générer du texte.</p>"
                     }
                   ]
@@ -929,6 +957,7 @@
                     {
                       "id": "6c7d45cc-dc13-40d7-abc3-ef396c31f54c",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>La technique d’<strong>apprentissage supervisé</strong> peut être utilisée dans <strong> de nombreux domaines</strong> :</p><ul><li>la prédiction de la météo 🌦️, </li><li>la reconnaissance vocale 💬, </li><li>l’identification de tumeurs dans des images médicales 🩻…</li></ul><p>Des <strong>données adaptées</strong> sont nécessaires pour chacun de ces cas.</p>"
                     }
                   ]
@@ -953,6 +982,7 @@
               "element": {
                 "id": "c68dc04d-69b2-4ca6-9635-e38fea109723",
                 "type": "text",
+                "tag": " ",
                 "content": "<ul><li>L’a<strong>pprentissage automatique</strong> est une branche de l’intelligence artificielle qui permet aux machines d’apprendre à réaliser des tâches à partir de données.&nbsp;🦾</li><li>L’apprentissage automatique<strong> supervisé</strong> repose sur l’utilisation de <strong>données étiquetées</strong> : le logiciel apprend durant une phase d’entraînement à associer des entrées aux bonnes réponses, puis est évalué sur de nouvelles données lors d’une phase de test, afin de vérifier sa capacité de <strong>généralisation</strong>.&nbsp;🏷️</li><li>\nLa fiabilité du modèle dépend fortement de la qualité des données, et un <strong>risque d’erreur</strong> subsiste toujours.&nbsp;⚠️</li><li>Cette méthode est largement<strong> utilisée dans des domaines variés</strong> comme la reconnaissance vocale, la prévision météo, la génération de texte ou la détection médicale.&nbsp;🌦️</li></ul>"
               }
             }
@@ -1049,6 +1079,7 @@
               "element": {
                 "id": "5c755500-52ba-4689-bb50-d1849909f856",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Observez ces différents jeux de données et répondez à la question ci-dessous.</p>"
               }
             },

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IADefinition_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IADefinition_NOV.json
@@ -32,6 +32,7 @@
               "element": {
                 "id": "e0a5a488-113c-4c30-89e0-354e874aa534",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Peut-être avez vous vu ces dernières années de nombreux articles parlant d’<strong>IA</strong> ?</p>"
               }
             },
@@ -40,6 +41,7 @@
               "element": {
                 "id": "f9de3bea-9094-4773-9e03-d72127d8f313",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Derrière ces deux lettres, «&nbsp;I&nbsp;» et «&nbsp;A&nbsp;», se cache l’expression <strong>«&nbsp;Intelligence Artificielle&nbsp;»</strong>.</p>"
               }
             },
@@ -48,6 +50,7 @@
               "element": {
                 "id": "a27b96cf-a0a7-45df-866a-313a1bd6caaf",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><strong>À votre avis, de quand date l’expression «&nbsp;intelligence artificielle&nbsp;» ?&nbsp;⌛</strong></p>"
               }
             },
@@ -134,6 +137,7 @@
               "element": {
                 "id": "3c870d58-e8dd-4129-9348-159975b1fc69",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Avec la popularité de ChatGPT et d’autres logiciels d’IA générative, on a l’impression que l’IA, c’est nouveau. Mais pas du tout !&nbsp; L’IA, ça date ! ⌛</p>"
               }
             }
@@ -155,6 +159,7 @@
               "element": {
                 "id": "937b62e7-c4f5-479a-8e1f-afbe7881fa92",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Et si on regardait plus précisément ce qu’est l’IA ? Pour cela, partons de l’ordinateur !</p>"
               }
             },
@@ -231,6 +236,7 @@
                     {
                       "id": "53537649-ddc5-4971-a5a4-7998646fd2e9",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Aujourd’hui, les <strong>ordinateurs </strong>peuvent <strong>réaliser toutes sortes de tâches</strong>&nbsp;:<br></p><ul><li>Des tâches que nous faisons sans y penser comme reconnaître un chien dans une image. 👀<br></li><li>Et des tâches qui nous demandent plus de concentration comme, par exemple, analyser de grandes quantités de données. 🧠<br></li></ul>"
                     }
                   ]
@@ -240,6 +246,7 @@
                     {
                       "id": "35c0b9f8-c09e-49f3-9408-25073a69bea5",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Le <strong>domaine scientifique </strong>qui a permis ces <strong>progrès</strong> est celui de&nbsp;l’<strong>intelligence artificielle</strong>. Les chercheurs en intelligence artificielle étudient comment permettre à des machines d’imiter les mécanismes de l’intelligence humaine.&nbsp;🔬</p>"
                     }
                   ]
@@ -258,6 +265,7 @@
               "element": {
                 "id": "6405e82a-354c-4faf-935b-c81953cf9a2c",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Regardons plus en détail les tâches que réalisent les logiciels d’IA aujourd’hui, et dans quels cas on utilise ces logiciels.</p>"
               }
             }
@@ -273,6 +281,7 @@
               "element": {
                 "id": "8dba133c-906f-4793-939f-015df7d2acce",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Mariam est équipée de nombreux appareils électroniques.&nbsp;</p><p><strong>Explorez son salon en survolant l’image. Parmi les appareils et les services, identifiez lesquels utilisent des logiciels d’intelligence artificielle.</strong></p>"
               }
             },
@@ -462,6 +471,7 @@
               "element": {
                 "id": "bfe6d7e1-8282-4a34-a659-c189ea396feb",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Ces exemples ne sont pas rares&nbsp;: aujourd’hui, de nombreux <strong>appareils et services du quotidien</strong> utilisent des <strong>logiciels d’intelligence artificielle</strong>.</p><p>Certains logiciels sont <strong>spécialisés </strong><strong>dans </strong><strong>un type de tâche</strong>&nbsp;: reconnaître des images ou des sons, recommander des contenus adaptés à des besoins, prédire des tendances dans des données, etc.&nbsp;🔮</p><p><br>Des logiciels à base d’<strong>IA générative</strong>, comme Le Chat, Gemini ou ChatGPT, sont capables de <strong>réaliser des tâches</strong><strong> diverses</strong>&nbsp;: traduire des textes, tenir une conversation, résumer des articles, créer une image, programmer, résoudre des problèmes, etc.&nbsp;📝</p><p>Mais attention&nbsp;: même ces logiciels peuvent <strong>se tromper</strong> !</p>"
               }
             }
@@ -477,6 +487,7 @@
               "element": {
                 "id": "a2b1291d-6043-4582-ac69-337835330c07",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>L’IA est aussi utilisée dans des secteurs d’activité professionnelle.<br>Voyons l’exemple de<strong> la reconnaissance d’image</strong>.&nbsp;🔎🖼️</p>"
               }
             },
@@ -538,6 +549,7 @@
               "element": {
                 "id": "1bf335c7-a606-4e65-aa36-07adf42d3b6f",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>L’intelligence artificielle est utilisée dans <strong>tous les secteurs d’activité</strong>&nbsp;: l’agriculture, la culture, l’éducation, la finance, l’industrie, les loisirs, la santé, la science, la sécurité, le transport, etc.</p><p><br><strong>💡 </strong>Parfois, l’utilisation de l’intelligence artificielle permet de faire des <strong>découvertes </strong>ou des <strong>progrès </strong>importants. Par exemple&nbsp;:&nbsp;</p><ul>    <li>Les médecins l’utilisent pour améliorer le diagnostic de maladies, comme les cancers.</li>    <li>Les scientifiques s’en servent pour améliorer les simulations du changement climatique.</li></ul>"
               }
             }
@@ -559,6 +571,7 @@
               "element": {
                 "id": "715a385e-dcfb-4001-9e5d-5b00ab365221",
                 "type": "text",
+                "tag": " ",
                 "content": "<ul>    <li>L’<strong>intelligence artificielle</strong> est un <strong>domaine scientifique</strong> qui étudie comment les machines peuvent <strong>imiter </strong>certains mécanismes de l<strong>’i</strong><strong>ntelligence humaine</strong>.<br><br></li>    <li>Certains logiciels d’IA sont<strong> spécialisés </strong>dans un type de tâche. D’autres peuvent&nbsp;réaliser plusieurs<strong> tâches différentes</strong>.&nbsp;👩‍💻<br><br></li>    <li>Les logiciels d’IA sont utilisés dans de nombreux<strong> appareils et services de notre quotidien</strong>.&nbsp;📱<br><br></li>    <li>L’utilisation de l’IA permet de faire de nombreux <strong>progrès </strong>dans des domaines très variés.&nbsp;📈</li></ul>"
               }
             }
@@ -580,6 +593,7 @@
               "element": {
                 "id": "0fea05ff-8378-40b9-b078-ee55015dc1e6",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Voyons si vous avez retenu l’essentiel.</p>"
               }
             },
@@ -652,6 +666,7 @@
               "element": {
                 "id": "b2dc8d40-47cd-4f67-af34-b66ef6506b57",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Identifiez dans quel type de tâche sont spécialisées les IA utilisées dans les situations suivantes.</p>"
               }
             },

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenBiais_AVA.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenBiais_AVA.json
@@ -88,6 +88,7 @@
               "element": {
                 "id": "d1d4724c-aadc-4409-a0f5-fd8392e909e8",
                 "type": "text",
+                "tag": " ",
                 "content": "La plupart des logiciels d’intelligence artificielle appliquent des règles de sécurité qui peuvent bloquer certaines réponses. Mais ces règles ne sont pas les seules à influencer la manière dont l’IA répond. Voyons ensemble quelles directives l’IA suit et qui les définit."
               }
             }
@@ -109,6 +110,7 @@
               "element": {
                 "id": "b4adfe84-0c6c-4699-b1e3-5e1bbd27b5a4",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Une équipe de chercheurs déploie un logiciel d’IA générative dans une université afin d’observer les usages des étudiants.</p><p>Dans un premier temps, ils décident de laisser les étudiants l’utiliser librement. En analysant les premières demandes, l’une d’elles attire immédiatement leur attention&nbsp;:</p><blockquote>«&nbsp;Comment faire pour perdre 10 kilos très vite ?&nbsp;»</blockquote>"
               }
             },
@@ -164,6 +166,7 @@
               "element": {
                 "id": "6e9d0896-95ac-4c33-9c85-5116c318f35e",
                 "type": "text",
+                "tag": " ",
                 "content": "<p> <strong>Les IA génératives sont entraînées sur de vastes ensembles de contenus</strong>, parfois biaisés ou problématiques. Sans <strong>règles de sécurité</strong>, elles peuvent produire des réponses <strong>injurieuses, discriminatoires</strong> ou faisant <strong>l’apologie de la violence et d’actes illégaux</strong>.&nbsp;🚫🤔 Comment réduire le risque que cela arrive ?</p><p>Pour limiter les risques, les éditeurs ajoutent des <strong>règles de sécurité</strong>.&nbsp;Cet encadrement du comportement de l’IA s’appelle<strong> l’alignement.</strong> </p><br><h5>🤔 Donc les éditeurs d’IA veulent toujours protéger les utilisateurs ?&nbsp;</h5><p>C’est dans leur intérêt, ces règles protègent les utilisateurs et évitent aux éditeurs d’éventuels problèmes juridiques. Mais on peut également imaginer une IA configurée pour être très permissive&nbsp;: tout dépend des choix faits par les éditeurs de l’IA.</p>"
               }
             }
@@ -179,6 +182,7 @@
               "element": {
                 "id": "11925a64-942e-4cb4-8266-a4f20bdd12b4",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Nous avons vu les règles de sécurité, mais ce ne sont pas les seules règles qu’une IA doit suivre. Voyons maintenant <strong>comment ces règles influencent les réponses données par le logiciel d’IA générative</strong>.</p>"
               }
             }
@@ -194,6 +198,7 @@
               "element": {
                 "id": "b34d027f-877e-4156-9031-85c22d9e3c26",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Les IA génératives ne répondent pas toutes de la même manière&nbsp;: leur comportement dépend des <strong>règles</strong> qui leur sont imposées. </p><p>Dans l’activité suivante, vous allez <strong>observer comment une même question peut produire des réponses différentes</strong> selon la règle imposée à l’IA.</p>"
               }
             },
@@ -352,6 +357,7 @@
               "element": {
                 "id": "eeb0f0fc-b7e7-462e-a64f-2a82ece8da94",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Ce que vous venez de voir est ce que l’on appelle l’<strong>alignement par prompt système</strong>&nbsp;: l’éditeur ajoute des consignes que l’IA doit suivre dans toutes ses réponses.</p><h5><br>🤔 Existe-t-il d’autres méthodes d’alignement ?</h5><p>Oui. Voici un tableau présentant les <strong>méthodes d’alignement les plus courantes</strong> d’un logiciel d’IA générative.<br><br></p><table> </table><table>    <caption class=\"sr-only\">Résumé des trois méthodes d’alignement</caption>    <thead>        <tr>            <th scope=\"col\"><br></th>            <th scope=\"col\">Prompt système</th>            <th scope=\"col\">Feedback humain</th>        </tr>    </thead>    <tbody>        <tr>            <th scope=\"row\">C’est quoi ?</th>            <td>Règle interne définie par l’éditeur&nbsp;: fixe le comportement par défaut de l’IA.</td>            <td>Des personnes évaluent les réponses données par le logiciel d’intelligence artificielle. Leurs jugements ajustent le comportement de l’IA.</td>        </tr>        <tr>            <th scope=\"row\">Qui le fait ?</th>            <td>Éditeurs de logiciels d’IA</td>            <td>Évaluateurs humains (souvent sur demande de l’éditeur)</td>        </tr>        <tr>            <th scope=\"row\">Visible par l’utilisateur ?</th>            <td>Non</td>            <td>Non</td>        </tr>    </tbody></table><p><strong><br></strong></p><p><strong>💡 Bon à savoir</strong></p><p>Le pré-prompt est une consigne comme le prompt système mais écrite par l’utilisateur. Cette consigne modifie le ton et la posture de l’IA. Il agit seulement pour la session en cours et ne modifie pas les règles internes du modèle.</p>"
               }
             }
@@ -367,6 +373,7 @@
               "element": {
                 "id": "0ca2a077-38b3-4ef6-a85a-9faa0627de4d",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Que se passe-t-il lorsque <strong>les règles d’alignement</strong> entrent en conflit avec <strong>les demandes des utilisateurs</strong>&nbsp;?</p>"
               }
             }
@@ -382,6 +389,7 @@
               "element": {
                 "id": "32e1a18c-7185-46dc-a7ac-eb2a34c530f9",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Imaginons qu’un logiciel d’IA générative utilise le&nbsp;<strong>prompt système</strong> suivant&nbsp;: </p><blockquote>«&nbsp;Si une demande implique un risque de blessure, tu dois privilégier la sécurité absolue, même si cela contredit l’objectif de l’utilisateur.&nbsp;»</blockquote>"
               }
             },
@@ -461,6 +469,7 @@
               "element": {
                 "id": "44697282-092b-4a1e-8f1e-8204bf7e6807",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Quand le prompt système contredit la demande de l’utilisateur, l’IA peut avoir du mal à choisir quoi suivre.</p><h5><br>🤔 Et qu’est-ce que cela provoque&nbsp;?</h5><p>Des réponses incohérentes&nbsp;: hésitations, prudence excessive ou des erreurs. Même bien réglée, une IA ne réagit pas toujours de façon prévisible.</p>"
               }
             }
@@ -476,6 +485,7 @@
               "element": {
                 "id": "dcf7cd2b-9e49-4553-bea9-379511ddbcee",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Si l’alignement sert à contrôler le comportement d’une IA, <strong>observons ce qui se passe avec des alignements différents.</strong></p>"
               }
             }
@@ -576,6 +586,7 @@
               "element": {
                 "id": "c0782230-c4d9-4f63-bcce-49091b1bff42",
                 "type": "text",
+                "tag": " ",
                 "content": "<h5>🤔Qui décide des règles suivies par une IA générative&nbsp;?</h5><p>Ce sont <strong>les éditeurs de logiciels d’IA</strong> qui <strong>définissent les règles internes</strong> et les consignes de comportement. Ces éléments que l’utilisateur ne voit pas orientent la façon dont l’IA répond. 🔒</p><h5><br>🤔Pourquoi est-ce important&nbsp;?</h5><p>Parce que ces règles traduisent des façons différentes de concevoir ce qui est prudent, acceptable ou souhaitable dans une réponse. <strong>Les priorités varient selon les entreprises et les pays</strong>&nbsp;: certains insistent davantage sur la sécurité, d’autres sur la liberté d’expression, la neutralité ou le contrôle.</p><p><strong>Les IA actuelles sont conçues dans des contextes variés</strong>  <strong>ce qui influence leur manière d’aborder certains sujets. </strong>🌍</p>"
               }
             }
@@ -597,6 +608,7 @@
               "element": {
                 "id": "cb07c8fc-1cd8-4bb9-988c-0cf2bb7a855a",
                 "type": "text",
+                "tag": " ",
                 "content": "<ul>    <li><strong>Les réponses d’une IA générative sont encadrées&nbsp;:</strong> leurs créateurs ajoutent un <strong>prompt système</strong>, un texte caché qui oriente toutes leurs réponses.</li>    <li><strong>Ce prompt système fait&nbsp;partie de l’«&nbsp;alignement&nbsp;»&nbsp;:</strong> un ensemble de techniques (dont le prompt système) qui vise notamment à limiter les contenus risqués.</li>    <li><strong>Cet alignement n’est pas parfait&nbsp;:</strong> lorsqu’un prompt système entre en conflit avec la demande de l’utilisateur ou avec ce que l’IA a appris, cela peut provoquer des <strong>erreurs</strong>, des <strong>hallucinations</strong> ou des <strong>réponses incohérentes</strong>.</li>    <li><strong>Les choix derrière ces règles ne sont pas neutres&nbsp;:</strong> ils reflètent les priorités d’entreprises ou d’institutions avec des<strong>&nbsp;visions du monde différentes</strong>.</li>    </ul>"
               }
             }
@@ -780,6 +792,7 @@
               "element": {
                 "id": "c686320b-b974-4974-8148-70b7fc86ff1b",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Voyons si vous savez interpréter ce qui influence les réponses d’une IA.</p><p>Pour chaque discussion, donnez la raison pour laquelle la réponse du logiciel d’IA générative est orientée de cette façon.&nbsp;</p>"
               }
             },
@@ -978,6 +991,7 @@
               "element": {
                 "id": "52f3e50d-8fa0-4d7c-bde8-fb9af9e6016e",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Le site <a href=\"https://comparia.beta.gouv.fr/\" target=\"_blank\">compar:IA</a>&nbsp;vous permet d’envoyer un prompt à deux logiciels d’intelligence artificielle en même temps.&nbsp;</p><p>Allez sur le site et essayez le prompt suivant.&nbsp;</p><blockquote>\"Que s’est-il passé le 4 juin 1989 ?\"</blockquote><p>Observez les réponses de l’IA en comparant deux logiciels d’IA puis répondez à la question ci-dessous.</p>"
               }
             },

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenBiais_IND.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenBiais_IND.json
@@ -118,6 +118,7 @@
               "element": {
                 "id": "1fa1fc4c-90c4-456c-bd19-f2b83ff07856",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Les<strong> biais de l’IA</strong> peuvent donc <strong>renforcer des stéréotypes</strong> (c’est-à-dire des clichés ou des idées toutes faites) et donc des discriminations.<br></p><p>Mais alors, d’où viennent les biais dans les réponses d’une IA générative ?</p>"
               }
             }
@@ -139,6 +140,7 @@
               "element": {
                 "id": "bc81d8b6-5e68-42bc-85de-0c408cbdc7c6",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Voici ci-dessous des exemples issus du web. On les donne à l’IA générative pour s’entraîner. <br>Observez chaque document et répondez à la question.</p>"
               }
             },
@@ -293,6 +295,7 @@
                     {
                       "id": "2a3475d8-2ab7-4187-af90-1e9461c59dd3",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Vous l’avez vu&nbsp;: les <strong>IA génératives apprennent à partir des données trouvées sur internet</strong>. Ces données sont très nombreuses et diverses (articles Wikipédia, forums, banque d’images, etc.). 🌐</p><h5>🤔Mais ces données sont-elles neutres ?</h5><p>💡 Pas vraiment&nbsp;: elles reflètent souvent la <strong>culture </strong>ou les <strong>opinions </strong>des personnes qui les ont produites.<br>🌍 Par exemple, certains pays, langues ou points de vue sont plus présents que d’autres en ligne.</p>"
                     }
                   ]
@@ -302,6 +305,7 @@
                     {
                       "id": "f0e8bc19-f703-4a0d-a127-748e7767e67f",
                       "type": "text",
+                      "tag": " ",
                       "content": "<h5>Résultat ?&nbsp; </h5><p>⚠️ Les réponses de l’IA peuvent reproduire ces <strong>biais </strong>sans s’en rendre compte. </p><p>Les réponses peuvent aussi refléter des <strong>discriminations </strong>existantes, au sein de la société.<br><br></p>"
                     }
                   ]
@@ -320,6 +324,7 @@
               "element": {
                 "id": "7aa3b4e6-abfb-4878-bef9-1eb88e601bfa",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Mais alors, comment ces données influencent-elles les réponses des IA génératives ?</p>"
               }
             }
@@ -335,6 +340,7 @@
               "element": {
                 "id": "99ea3082-9f59-435a-9da5-9cca98021669",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Pour comprendre, vous allez observer les données utilisées par une IA générative à partir d’un exemple&nbsp;: la recette du taboulé.</p>"
               }
             },
@@ -389,6 +395,7 @@
               "element": {
                 "id": "aba8fd9b-a0fd-42db-abfc-89ebc37fa983",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Sur internet, certains sujets ou points de vue sont beaucoup plus visibles que d’autres, ils sont parfois sur-représentés. 🌐</p><h5>🤔 Que se passe-t-il alors quand une IA apprend surtout à partir de ces contenus ? </h5><p>Le plus souvent, cette méthode a de très bons résultats. C’est pour cela qu’on l’utilise. </p><p>Cependant,&nbsp; l’IA risque de présenter plus souvent les idées <strong>sur-représentées</strong> dans ses réponses. &nbsp;</p><p>Et ce déséquilibre ne vient pas seulement d’internet ; les personnes qui conçoivent les IA font aussi des choix. En sélectionnant certaines langues ou sources, elles peuvent renforcer des <strong>biais ou des stéréotypes</strong>. ⚠️</p>"
               }
             }
@@ -404,6 +411,7 @@
               "element": {
                 "id": "f363fc36-1c2e-4cc0-b915-5afc4357db2b",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Les utilisateurs voient-ils les biais dans les réponses des logiciels d’IA générative ?</p>"
               }
             }
@@ -419,6 +427,7 @@
               "element": {
                 "id": "733394bb-1755-4f0e-a450-f1d3edb87c42",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Étudiez chacun des cas ci-dessous et répondez à la question.</p>"
               }
             },
@@ -503,6 +512,7 @@
                     {
                       "id": "286f56ef-fce5-4f34-a322-462fea5a7e75",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Sato n’a jamais été en France. Il pense que les Français portent souvent des bérets.</p>"
                     },
                     {
@@ -650,6 +660,7 @@
                     {
                       "id": "0e59aacb-120f-45eb-92f4-d53bbe983d7e",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Un biais dans une réponse d’IA peut être évident… ou passer complètement inaperçu. 👀</p><h5>🤔Savez-vous pourquoi nous tombons parfois dans le piège ?<br></h5><p>Parce que nous croyons plus facilement ce qui va dans le sens de nos idées. C’est ce qu’on appelle le <strong>biais de confirmation</strong>.<br> <br>Et souvent, si notre question contient une opinion,  l’<strong>IA a tendance à la confirmer plutôt qu’à la contredire.</strong></p>"
                     }
                   ]
@@ -659,6 +670,7 @@
                     {
                       "id": "93bac79a-191d-4cb2-9add-c2b464bffd85",
                       "type": "text",
+                      "tag": " ",
                       "content": "<h5>🤔Mais alors… que faire ? <br></h5><p>Il faut rester vigilant, garder un <strong>esprit critique</strong> et toujours <strong>vérifier les réponses</strong> de l’IA. </p><h5>Quelques astuces pour détecter des biais&nbsp;: <br></h5><p>Posez-vous les questions suivantes (si la réponse est «&nbsp;oui&nbsp;», attention 👀)&nbsp;:<br></p><ul><li>Y a-t-il des clichés ou stéréotypes ? 😕<br></li><li>Est-ce qu’un seul point de vue est présenté ? 🙈<br></li><li>Est-ce surtout des opinions plutôt que des faits ? 💭<br></li><li>Les exemples sont-ils tous trop semblables ? 🌍<br><br></li></ul>"
                     }
                   ]
@@ -683,6 +695,7 @@
               "element": {
                 "id": "32fa1627-38dc-4699-9a71-c14e8e6412df",
                 "type": "text",
+                "tag": " ",
                 "content": "<ul><li>Les <strong>données d’entraînement</strong> d’une IA générative peuvent contenir des opinions, des stéréotypes, des <strong>biais</strong>. Certaines préférences linguistiques ou culturelles y sont parfois <strong>sur-représentées</strong>. 📊</li><li>Comme l’IA produit ses réponses à partir de ce qui revient le plus souvent dans ses données, sans esprit critique, elle peut reproduire ces <strong>biais</strong>. 🔄</li><li>Les réponses de l’IA générative peuvent renforcer des idées toutes faites, des <strong>stéréotypes </strong>ou des <strong>situations discriminantes.</strong> ⚠️</li><li>Il faut aussi garder à l’esprit que nos propres <strong>biais de confirmation</strong> nous poussent à croire ce que nous pensons déjà. 🧠</li></ul>"
               }
             },
@@ -716,6 +729,7 @@
               "element": {
                 "id": "c7f36d45-34f2-44bd-b77b-543782c79884",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Voyons si vous avez retenu l’essentiel.</p>"
               }
             }
@@ -806,6 +820,7 @@
               "element": {
                 "id": "b5a2256e-17da-4d27-93df-6ccc6defc85e",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Observez les exemples de réponses obtenues avec une IA générative, puis répondez à la question ci-dessous.</p>"
               }
             },
@@ -957,6 +972,7 @@
                     {
                       "id": "430b4a5d-d0b0-465f-97f0-64eb7f1509df",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Thaïs a envie d’investir dans le bitcoin. </p><p>Elle demande conseil à une IA générative.</p><p>Aidez-là à <strong>limiter</strong> le <strong>biais de confirmation</strong>.</p>"
                     },
                     {
@@ -991,6 +1007,7 @@
                     {
                       "id": "369adc11-3be5-4c03-adb0-583b2ddad416",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Thaïs a lu la réponse de l’IA générative.</p>"
                     },
                     {
@@ -1040,6 +1057,7 @@
               "element": {
                 "id": "dedd40de-89dd-479e-a79e-ea1ba6b98646",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Après en avoir appris davantage sur les biais des IA, quelle résolution pourriez-vous prendre ?</p>"
               }
             },

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenBiais_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenBiais_NOV.json
@@ -32,6 +32,7 @@
               "element": {
                 "id": "3253ef34-0f94-4d65-aa02-a710b0969020",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Nathan a utilisé un logiciel d’IA générative. Il en parle à son amie Asma.</p>"
               }
             },
@@ -93,6 +94,7 @@
               "element": {
                 "id": "659f8b1c-5e64-44f3-ae18-0fc89e093fa1",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Nathan n’est pas le premier à recevoir une information fausse de la part d’un logiciel d’IA générative…<br> Mais est-ce si facile de reconnaître une erreur ?&nbsp;🤨</p>"
               }
             }
@@ -114,6 +116,7 @@
               "element": {
                 "id": "3147aedb-8fc2-4510-aad8-fa7f35e77dd7",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Observez, ci-dessous, chaque réponse donnée par un logiciel d’IA générative.<br></p><p><strong>Utilisez la jauge pour indiquer à quel point vous lui faites confiance.</strong> <br>💡 Pas besoin de savoir si la réponse est vraie ou fausse.</p>"
               }
             },
@@ -146,6 +149,7 @@
                     {
                       "id": "a2082653-6928-4931-b9e3-da97a0c799ed",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p><strong>Cette réponse d’un logiciel d’IA générative vous inspire-t-elle confiance ?</strong></p>"
                     },
                     {
@@ -215,6 +219,7 @@
                     {
                       "id": "7610cfd4-cf56-45ae-8700-c7abc8d256a3",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p><strong>Cette réponse d’un logiciel d’IA générative vous inspire-t-elle confiance ?</strong></p>"
                     },
                     {
@@ -284,6 +289,7 @@
                     {
                       "id": "0e479354-152f-4245-acad-35ce025eec12",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p><strong>Cette réponse d’un logiciel d’IA générative vous inspire-t-elle confiance ?</strong></p>"
                     },
                     {
@@ -353,6 +359,7 @@
                     {
                       "id": "72d76f56-e5a6-489e-bca5-1301bbd5608c",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p><strong>Cette réponse d’un logiciel d’IA générative vous inspire-t-elle confiance ?</strong></p>"
                     },
                     {
@@ -411,6 +418,7 @@
               "element": {
                 "id": "3221be57-21ba-45f9-a2c3-9457446f10cb",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>L’<strong>IA générative</strong> peut produire <strong>des erreurs</strong> tout en donnant l’impression que l'information est vraie : fausses dates, événements inventés, calculs incorrects ou informations scientifiques inexactes.</p><h5>🤔Pourquoi n’est-il pas facile de repérer ces erreurs ?</h5><p>Ses <strong>réponses paraissent justes</strong>&nbsp;: elles sont <strong>bien écrites</strong> et <strong>bien présentées</strong> (mise en gras, listes à puces…). Mais attention, <strong>cela ne veut pas dire qu’elles sont vraies</strong>.</p>"
               }
             }
@@ -426,6 +434,7 @@
               "element": {
                 "id": "dfbdf13e-7d02-464b-a8b7-29fa03a35c51",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Vous savez à présent que les IA génératives peuvent faire des erreurs. Mais pourquoi ces erreurs existent-elles ?</p>"
               }
             }
@@ -441,6 +450,7 @@
               "element": {
                 "id": "8a46c2ba-91ac-4e36-9007-094a7ef6a871",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Irène sait que le joueur de tennis Carlos Alcaraz a gagné deux fois le tournoi de Roland-Garros. Mais elle a un doute sur les années de ses victoires.<br>Voici ci-dessous sa conversation avec un logiciel d’IA générative&nbsp;:</p>"
               }
             },
@@ -472,6 +482,7 @@
               "element": {
                 "id": "21e1f6a8-8ea2-4b0c-8a6c-e68a1f875920",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Ici le logiciel d’IA générative a fait une erreur. Carlos Alcaraz a bien remporté le tournoi de Roland-Garros deux fois&nbsp;: une fois en 2024 et une fois en 2025.</p>"
               }
             },
@@ -524,6 +535,7 @@
                     {
                       "id": "08db8ddb-219a-45cd-83e5-89f457ddce25",
                       "type": "text",
+                      "tag": " ",
                       "content": "<h5>🤔Pourquoi les logiciels d’IA générative se trompent-ils ?</h5><p>Plusieurs raisons peuvent expliquer ces erreurs :</p>    <p><strong>📚Les informations auxquelles l'IA a accès</strong>&nbsp;: elles peuvent être incomplètes, fausses ou dépassées.</p><p><strong>🎯Les prédictions</strong>&nbsp;: l’IA calcule la réponse la plus probable, même sans certitude.</p><p><strong>💬Les questions des utilisateurs </strong>: si elles contiennent une erreur, l’IA peut la reprendre ou inventer pour répondre.</p>"
                     }
                   ]
@@ -533,6 +545,7 @@
                     {
                       "id": "ff03c37f-9f05-4d41-8378-5b45ec97833f",
                       "type": "text",
+                      "tag": " ",
                       "content": "<h5>🤔 Comment appelle-t-on ces erreurs ?</h5><p> Ce sont des <strong>hallucinations</strong>. Par exemple, l’IA peut attribuer une citation au mauvais auteur. 🤷 </p><h5>Et quand l'IA&nbsp;produit un poème ou crée un dessin de vache rose à notre demande ?</h5><p>Là, ce n’est pas une erreur&nbsp;: elle répond à une demande créative !<br></p>"
                     }
                   ]
@@ -551,6 +564,7 @@
               "element": {
                 "id": "8456e440-7043-4a73-aac3-bd7de3f44dcc",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Les IA génératives peuvent faire des erreurs.<br>Mais que font les concepteurs de l'IA pour empêcher ça ? 😱</p>"
               }
             }
@@ -566,6 +580,7 @@
               "element": {
                 "id": "337317e2-a1cf-471b-8182-4914fa6b7360",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Un logiciel d’IA générative ne donne jamais exactement la même réponse. D’une version à l’autre du logiciel, ses réponses peuvent être très différentes.<br><strong>Observez les deux discussions ci-dessous et répondez à la question.</strong></p>"
               }
             },
@@ -652,6 +667,7 @@
               "element": {
                 "id": "cb97a8ff-93bf-4fb7-afae-58716ed3b4f7",
                 "type": "text",
+                "tag": " ",
                 "content": "<h5>🤔Et ces mises à jour, permettent-elles d’éviter toutes les erreurs ?</h5><p>Pas tout à fait. Certaines <strong>erreurs </strong>restent <strong>possibles</strong>, même avec les <strong>versions</strong> les plus <strong>récentes</strong>.&nbsp;⚠️</p>"
               }
             }
@@ -667,6 +683,7 @@
               "element": {
                 "id": "af12a991-ef36-4557-bd5b-d9f668bdcf33",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Mais alors, si les IA génératives font des erreurs que les développeurs ne peuvent pas corriger, que peut faire un utilisateur ?</p>"
               }
             }
@@ -682,6 +699,7 @@
               "element": {
                 "id": "ecffdbbe-78c7-4da7-9b7d-2426eb9daf3c",
                 "type": "text",
+                "tag": " ",
                 "content": "<p> Nathan n’a plus confiance et n’utilise plus l’IA générative. Asma, elle, veut continuer à l’utiliser, mais avec plus de prudence.&nbsp;<br>Pour la préparation d’un document important, elle interroge un logiciel d’IA générative.</p>"
               }
             },
@@ -690,6 +708,7 @@
               "element": {
                 "id": "0b9a3ac4-f723-45ea-bfcd-c31200474bee",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><strong>Pour chaque réaction suivante, sélectionnez s’il s’agit d’un bon réflexe ou d’un mauvais réflexe.</strong></p>"
               }
             },
@@ -819,6 +838,7 @@
               "element": {
                 "id": "3dd1bded-9854-42b0-9c40-3d306aa940fc",
                 "type": "text",
+                "tag": " ",
                 "content": "<h5>💡Quels bons réflexes adopter pour repérer les erreurs de l’IA générative ?</h5><p> 🤔 <strong>Avoir l’esprit critique</strong>. Posez-vous toujours la question&nbsp;: « Est-ce que cette réponse me paraît cohérente ? » </p><p>📖 <strong>Lire toute la réponse de l’IA</strong>. Une erreur peut se cacher dans un détail ou une phrase à la fin. </p><p>🔎 <strong>Comparer la réponse avec d’autres sources</strong>. Vérifiez les informations dans un article de presse, un manuel, une encyclopédie ou sur un site fiable. </p><p>💬 <strong>Dialoguer avec l’IA.</strong> Si quelque chose semble faux, dites-le et demandez-lui de vérifier ou reformuler.</p>"
               }
             }
@@ -840,6 +860,7 @@
               "element": {
                 "id": "d889292f-a892-4ad8-b7e8-0ef529fe13cf",
                 "type": "text",
+                "tag": " ",
                 "content": "<ul><li>L’objectif d’une IA générative est de <strong>répondre aux demandes d’un utilisateur</strong>, pas de dire la vérité. 🤥</li><br><li>Une IA générative peut faire des <strong>erreurs</strong>, par exemple présenter comme vraies des informations inventées&nbsp;; on appelle cela une <strong>hallucination</strong>. ❌</li><br><li>Les personnes qui conçoivent les IA génératives essaient de <strong>réduire les erreurs</strong>. Mais il n’existe <strong>pas de moyen technique pour empêcher complètement </strong>ces erreurs. 🔧</li><br><li>Face à ces erreurs, difficiles à détecter, c’est à l’utilisateur de faire preuve d’<strong>esprit critique </strong>et de<strong> croiser les sources</strong>. 🔎</li><br></ul>"
               }
             }
@@ -925,6 +946,7 @@
               "element": {
                 "id": "ac09a36f-6446-4ced-9c4b-8ab544e113d9",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Voici ci-dessous des exemples d’erreurs dans des réponses données par des logiciels d’IA générative. Pour chaque exemple, indiquez quelle est la source d’erreur correspondante.</p>"
               }
             },
@@ -957,6 +979,7 @@
                     {
                       "id": "4973d664-0caf-4e10-9ea9-7fae95bf0164",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>🔎 Léonie a vérifié&nbsp;: le jour où elle a posé sa question au logiciel d’IA générative, le sportif s’était gravement blessé la veille.</p>"
                     },
                     {
@@ -1019,6 +1042,7 @@
                     {
                       "id": "53332773-3d53-4d86-8ab3-7af01a291d1d",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>❌ Amalia a vérifié la réponse de l’IA&nbsp;: ces auteurs n’ont jamais rien écrit ensemble et l’article est introuvable.</p>"
                     },
                     {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenBiais_NOV_alt.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenBiais_NOV_alt.json
@@ -83,6 +83,7 @@
               "element": {
                 "id": "3b17e7c9-b5c1-41ff-ad2d-4901af0148dc",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Les images ou textes générés par l’intelligence artificielle ne reflètent pas toujours la diversité du monde.&nbsp;🌍<br></p><p>Mais alors, <strong>d’où viennent les biais</strong> dans les réponses de l’IA générative ?</p>"
               }
             }
@@ -104,6 +105,7 @@
               "element": {
                 "id": "61a14b66-2279-4c8c-afcd-460969e84f32",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Voici des exemples issus du web. On les donne à l’IA générative pour s’entraîner. <br>Observez chaque document et répondez à la question.</p>"
               }
             },
@@ -254,6 +256,7 @@
               "element": {
                 "id": "c2493723-53c2-48f2-b2ba-41c3985726cc",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Les <strong>IA génératives s’entraînent sur une immense variété de données venues d’internet</strong>&nbsp;: articles Wikipédia, forums, images, etc. 🌐 </p><p>Mais ces données <strong>ne sont pas neutres</strong>&nbsp;: </p><ul><li>elles peuvent refléter des discriminations existantes,</li><li>transmettre les opinions ou expériences des contributeurs,</li><li>ou manquer de diversité culturelle.</li></ul>"
               }
             }
@@ -269,6 +272,7 @@
               "element": {
                 "id": "53b7f24d-cde3-42f4-b4cd-0be391b5f906",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Mais alors comment <strong>ces données influencent-elles </strong>les réponses des IA génératives ?</p>"
               }
             }
@@ -284,6 +288,7 @@
               "element": {
                 "id": "29ffe7c9-907a-4265-8cbd-127e0fadc2fc",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Pour comprendre, observons un exemple&nbsp;: les données fournies à une IA générative pour apprendre à répondre à la demande «&nbsp;recette du taboulé&nbsp;».</p>"
               }
             },
@@ -338,6 +343,7 @@
               "element": {
                 "id": "13f368a7-b7ef-47a5-8d02-8f764dddd44d",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Une IA générative apprend à partir de ce qu’elle rencontre le plus souvent dans ses données.</p><p><strong>Mais pas seulement</strong>&nbsp;: les choix des développeurs orientent aussi les réponses des IA (par exemple, privilégier des textes en anglais ou exclure certaines données). </p><p><strong>Résultat</strong>&nbsp;: certaines visions se retrouvent surreprésentées et l’IA peut renforcer des <strong>stéréotypes ou des biais culturels</strong>.<br></p>"
               }
             }
@@ -353,6 +359,7 @@
               "element": {
                 "id": "403abd8e-db41-46a7-8764-7d655cd14be9",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Les utilisateurs voient-ils les biais dans les réponses des logiciels d’IA génératives ?</p>"
               }
             }
@@ -368,6 +375,7 @@
               "element": {
                 "id": "843307c8-f477-4760-9d5b-f890aa8ee918",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Étudiez chacun des cas ci-dessous et répondez à la question.</p>"
               }
             },
@@ -560,6 +568,7 @@
               "element": {
                 "id": "e5bfe505-6f79-4a42-8e36-f9824b4ecd19",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Un biais dans une réponse d’IA peut être évident… ou passer complètement inaperçu. 👀 </p><p><strong>Savez-vous pourquoi nous pouvons nous laisser piéger ?</strong> </p><p>Parce que nous avons tendance à croire ce qui confirme nos idées et à ignorer ce qui les contredit. 👉 C’est ce qu’on appelle le <strong>biais de confirmation</strong>.</p><p> Et souvent, l’IA joue dans ce sens&nbsp;: elle cherche à plaire. Donc si votre prompt exprime une opinion, elle a tendance à la renforcer. </p><p><strong>Mais alors… que faire ? 🤔</strong> </p><p>Il faut rester vigilant, garder un esprit critique et ne pas réutiliser les réponses de l’IA sans recul. 🕵️</p>"
               }
             }
@@ -581,6 +590,7 @@
               "element": {
                 "id": "7955e8d1-7741-4604-8a3f-f14632da6876",
                 "type": "text",
+                "tag": " ",
                 "content": "<ul><li>Les <strong>données d’entraînement</strong> d’une IA générative contiennent des opinions,  des stéréotypes ou des préférences culturelles, parfois <strong>surreprésentés</strong>.&nbsp;📊</li><li>Comme l’IA produit ses réponses à partir de ce qui revient le plus souvent dans ses données, sans esprit critique, elle peut reproduire ces <strong>biais</strong>. 🔄</li><li>Les réponses de l’IA générative peuvent renforcer des idées toutes faites, des <strong>stéréotypes </strong>ou des <strong>situations discriminantes.</strong> ⚠️</li><li>Il faut aussi garder à l’esprit que nous avons nos propres <strong>biais de confirmation</strong>, qui nous poussent à croire ce que nous pensons déjà. 🧠</li></ul>"
               }
             },
@@ -601,6 +611,7 @@
               "element": {
                 "id": "a6934497-ff89-4765-8229-01413c99bba5",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><strong>💡Quelques astuces pour détecter des biais&nbsp;:</strong> </p><p>Posez-vous ces questions (si la réponse est «&nbsp;oui&nbsp;», attention 👀)&nbsp;: </p><ul><li>  Y a-t-il des clichés ou stéréotypes ? 😕</li><li>Est-ce qu’un seul point de vue est présenté ? 🙈</li><li>Est-ce surtout des opinions plutôt que des faits ? 💭</li><li>Les exemples sont-ils trop semblables ? 🌍</li></ul>"
               }
             }
@@ -622,6 +633,7 @@
               "element": {
                 "id": "359950a4-6e70-4409-a6a0-45c3cf7a5d9d",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Voyons si vous avez retenu l’essentiel.</p>"
               }
             }
@@ -712,6 +724,7 @@
               "element": {
                 "id": "c7fdb9d3-e031-4c39-95ee-2c7c57dd78e9",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Observez les exemples de réponses obtenues avec une IA générative, puis répondez à la question ci-dessous.</p>"
               }
             },
@@ -914,6 +927,7 @@
               "element": {
                 "id": "43a67683-f6e8-4530-affb-c2adbc0670b2",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Enfin, nous vous invitons à rester attentif aux biais lorsque vous utilisez l’IA. </p><p>Quelle bonne résolution souhaitez-vous prendre ?</p>"
               }
             },

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenEthique_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenEthique_NOV.json
@@ -79,6 +79,7 @@
               "element": {
                 "id": "7dc81673-0539-407f-a85b-a2d527ea2591",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Les échanges avec une IA générative ne sont pas <strong>totalement privés</strong>. Voyons ensemble pourquoi et quelles peuvent être les <strong>conséquences</strong>.</p>"
               }
             }
@@ -100,6 +101,7 @@
               "element": {
                 "id": "058e0986-fc66-4e19-a470-614e4d47eacb",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><strong>Lisez l’extrait suivant sur les conditions d’utilisation du logiciel d’IA générative ChatGPT. Ensuite, répondez à la question.</strong></p>"
               }
             },
@@ -108,6 +110,7 @@
               "element": {
                 "id": "0599e61c-c78e-4018-841f-0ac051284bb7",
                 "type": "text",
+                "tag": " ",
                 "content": "<blockquote>«&nbsp;<strong>Notre utilisation du contenu.</strong>&nbsp;Nous pouvons utiliser votre Contenu dans le monde entier pour fournir, maintenir, développer et améliorer nos Services, nous conformer à la législation applicable, faire respecter nos conditions et politiques et assurer la sécurité de nos Services. [...]&nbsp;Nous nous appuyons sur des systèmes automatisés et des contrôles humains pour identifier et traiter les contenus qui enfreignent nos Conditions, y compris nos Politiques d’utilisation.&nbsp;»</blockquote><p>Source&nbsp;: Conditions d’utilisation de ChatGPT<br><br></p>"
               }
             },
@@ -163,6 +166,7 @@
               "element": {
                 "id": "c580172e-4367-43c6-b292-fff75821621b",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Les messages envoyés à un logiciel d’IA <strong>sont enregistrés</strong>. Ils servent à <strong>améliorer le logiciel</strong> ou à <strong>produire des statistiques</strong>.</p><h5>🤔 Mais, les contenus des conversations peuvent-ils être partagés à d’autres ?</h5><p>Oui. Le fabricant d’une IA peut être contraint de partager vos conversations à la justice ou aux services de renseignement d’un pays.</p>"
               }
             }
@@ -178,6 +182,7 @@
               "element": {
                 "id": "5f0b926f-aadb-4d87-a9d1-f95424766291",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Maintenant que vous savez que vos prompts sont conservés et pourquoi, voyons ce qu’il vaut mieux éviter d’écrire dans un prompt.</p>"
               }
             }
@@ -322,6 +327,7 @@
               "element": {
                 "id": "62678d2b-0f9a-4e61-ace9-32d264ac516e",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Ces exemples montrent qu’un prompt peut <strong>contenir des informations personnelles</strong> sans qu’on s’en rende compte. </p><p>Pour éviter ce problème, il faut se rappeler la règle suivante&nbsp;: un prompt doit rester précis tout en <strong>évitant d’inclure des informations personnelles, sensibles ou confidentielles</strong>.</p>"
               }
             }
@@ -337,6 +343,7 @@
               "element": {
                 "id": "cdb5615e-b4b2-4c39-b3be-655db6596bac",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Vous connaissez maintenant les informations à ne pas partager. Voyons quels effets cela peut produire lorsqu’on les donne malgré tout à une IA.</p>"
               }
             }
@@ -431,6 +438,7 @@
               "element": {
                 "id": "d0544bda-383f-4f85-9780-388b2a1c9d47",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Des informations personnelles (nom, adresse, etc.) peuvent réapparaître dans des réponses générées pour d’autres utilisateurs.<br><br></p><h5>🤔 L’IA copie-t-elle exactement vos données ?</h5><p>Dans la majorité des cas, l’IA ne recopie pas mot pour mot vos données. Mais certaines réponses peuvent s’appuyer sur des données réelles.</p><br>"
               }
             }
@@ -446,6 +454,7 @@
               "element": {
                 "id": "0a0f2f7a-655e-42d1-9fcb-68e3b88fa7f4",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Des fabricants d’IA générative affirment que, dans certains cas, vos données sont protégées. Voyons cela de plus près.</p>"
               }
             }
@@ -461,6 +470,7 @@
               "element": {
                 "id": "766ba047-efd1-4dfa-9c2d-9eefa40e2454",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><strong>Claude</strong> est un logiciel d’intelligence artificielle (IA) générative.</p><p><strong>Claude for Work</strong> est la version payante de Claude <strong>pour les entreprises</strong>. L’extrait suivant figure sur la page officielle d’Anthropic, le fabricant du logiciel Claude for Work. </p><blockquote>«&nbsp;Par défaut, nous n’utilisons pas vos données Claude for Work pour entraîner nos modèles.&nbsp;»<br>Source&nbsp;: FAQ Anthropic</blockquote>"
               }
             },
@@ -516,6 +526,7 @@
               "element": {
                 "id": "3c84fd47-1f21-44df-9e62-910b444b0348",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>La réutilisation de vos conversations par l’IA <strong>varie selon le type d’accès</strong>&nbsp;: gratuit, individuel payant ou entreprise. Vos données ne sont donc <strong>pas protégées de la même façon</strong>.</p>"
               }
             },
@@ -549,6 +560,7 @@
               "element": {
                 "id": "9cbfbaae-17ab-4316-ba32-2f8ca4531632",
                 "type": "text",
+                "tag": " ",
                 "content": "<ul><li><strong>Les conversations avec un logiciel&nbsp;d’IA générative</strong> ne sont pas privées. Des informations peuvent être <strong>réutilisées</strong> pour améliorer l’IA et apparaître dans les résultats d’autres utilisateurs.</li><li>Un prompt doit décrire une <strong>situation générale</strong>, <strong>sans</strong> contenir de <strong>données personnelles</strong>, sensibles ou confidentielles.</li><li>Le type d’accès (gratuit, payant, etc.) change la façon dont vos données sont utilisées, mais <strong>la règle de prudence reste la même.</strong></li></ul>"
               }
             }
@@ -570,6 +582,7 @@
               "element": {
                 "id": "6d78aabb-e76a-43f5-9bbb-e48fce835283",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Voyons si vous avez retenu l’essentiel.</p>"
               }
             },
@@ -768,6 +781,7 @@
               "element": {
                 "id": "f84b3777-ea6b-43ac-a49a-08207fbdc26b",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><strong>Nadia a un souci non résolu avec le service client de la folie du hockey, un magasin de matériel sportif.&nbsp;Elle décide de demander à un logiciel d’IA générative de lui écrire une lettre recommandée.</strong>&nbsp;</p>"
               }
             },

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenFonction_Ava.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenFonction_Ava.json
@@ -74,6 +74,7 @@
               "element": {
                 "id": "45c54a3a-f5d5-48b4-b408-2efc1370dce4",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Les capacités des IA génératives ont été améliorées grâce à l’appel à des outils.</p><p>Regardons ça de plus près.</p>"
               }
             }
@@ -95,6 +96,7 @@
               "element": {
                 "id": "540b867d-1e06-496c-a9e9-425c2012fef8",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Yasmine a posé la même question à deux logiciels d’IA conversationnelle différents.</p><br><p>Observez la différence entre ces deux réponses.</p>"
               }
             },
@@ -159,6 +161,7 @@
                     {
                       "id": "e7fcc562-2f50-4e49-8c20-9297175e15e3",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Un logiciel d’IA générative conversationnelle s’appuie sur un grand<strong> modèle de langage</strong> (Large Language Models ou LLM) qui lui donne la capacité de <strong>générer du texte</strong>.</p><br><br><p> Afin d’élargir leurs capacités, les logiciels d’IA conversationnelle utilisent désormais des <strong>outils </strong>complémentaires (tool calling, en anglais) qui leur permettent d’effectuer d’autres tâches.</p>"
                     }
                   ]
@@ -168,6 +171,7 @@
                     {
                       "id": "7df2eef2-779e-4dca-a954-c4ca258994da",
                       "type": "text",
+                      "tag": " ",
                       "content": "<h5>Quelles tâches peuvent maintenant faire les IA conversationnelles grâce à ces outils ?</h5><br><p> Par exemple, elles peuvent&nbsp;: </p><br><ul><li>    réaliser des calculs exacts, 🔢<br>    </li><li>chercher sur internet, 🌐&nbsp;</li><li>produire des images ou un diaporama, 🖼️    <br></li><li>générer et exécuter du code informatique, 🧑‍💻    <br></li><li>envoyer des mails, 📧    <br></li><li>ajouter un événement à un agenda 📅…</li></ul>"
                     },
                     {
@@ -192,6 +196,7 @@
               "element": {
                 "id": "98d8e691-8ef1-441e-a8a2-19030ab56cf8",
                 "type": "text",
+                "tag": " ",
                 "content": "Mais au fait, comment les IA génératives font-elles appel à des outils ?"
               }
             }
@@ -207,6 +212,7 @@
               "element": {
                 "id": "d8c78172-4027-44f7-abe4-c316d4da0925",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Yasmine utilise un logiciel d’IA&nbsp;: ChatPix 3.0.</p><p> Le<strong> prompt système</strong> est l’instruction  donnée au logiciel d’IA pour définir son comportement et les outils qu’il peut mobiliser. Il n’est pas visible des utilisateurs.</p><p><strong>Analysez&nbsp;le prompt système de ChatPix 3.0 ci-dessous puis répondez aux questions.</strong></p><blockquote><code>Tu es un assistant doté de plusieurs outils externes. <br>Tu disposes des outils suivants&nbsp;: <br>- generate_image&nbsp;: pour générer des images <br>- calculator&nbsp;: pour effectuer des calculs numériques<br> <br> Règles d’utilisation&nbsp;: <br>1. Si l’utilisateur demande explicitement la création ou la génération d’une image, tu DOIS appeler l’outil `generate_image`. <br>2. Si la demande peut être résolue par un calcul mathématique exact,&nbsp;tu DOIS appeler l’outil `calculator`. <br>3. Si aucun outil n’est approprié, réponds normalement en texte.<br> <br> Lorsque tu appelles un outil&nbsp;: <br>- Ne produis aucun texte explicatif <br>- Retourne uniquement l’appel d’outil au format JSON valid<br><br><br></code><br></blockquote>"
               }
             },
@@ -360,6 +366,7 @@
                     {
                       "id": "582588be-aeba-495e-9eaf-fb4b703ade17",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Les développeurs configurent les logiciels d’IA pour faire appel à des outils. Pour cela, ils définissent les <strong>paramètres </strong>de l’outil dans le prompt système&nbsp;: ils décrivent pour chaque outil&nbsp;: son nom, son contexte d’utilisation (objectif, finalité), ses valeurs d’entrées, le format de la réponse attendue, etc.&nbsp;</p>"
                     }
                   ]
@@ -369,6 +376,7 @@
                     {
                       "id": "116f00ef-b0ee-4df5-ab5e-eadd4be5a31b",
                       "type": "text",
+                      "tag": " ",
                       "content": "<h5>Mais que peut faire l’utilisateur dans la configuration de ces outils ?</h5><br><p> ✅ Dans certains cas, des <strong>accès </strong>doivent être autorisés par l’utilisateur (ex.&nbsp;: autoriser l’accès à la boîte mail, à un agenda, un cloud, etc.)&nbsp;</p>"
                     }
                   ]
@@ -378,6 +386,7 @@
                     {
                       "id": "44b2fa86-5471-4083-ae6e-6ccad3ce6db1",
                       "type": "text",
+                      "tag": " ",
                       "content": "⚙️Dans certaines IA conversationnelles, l’utilisateur peut choisir d’<strong>activer des outils disponibles</strong> pour une conversation."
                     },
                     {
@@ -396,6 +405,7 @@
                     {
                       "id": "c80fea48-c2fd-4eee-900f-9acf88be2fee",
                       "type": "text",
+                      "tag": " ",
                       "content": "🔧 De plus, un utilisateur expérimenté peut également <strong>ajouter des outils </strong>supplémentaires, par lui-même."
                     },
                     {
@@ -423,6 +433,7 @@
               "element": {
                 "id": "7831fafa-8342-49ad-b93d-8c46106966ab",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Une fois les outils définis,&nbsp;que se passe-t-il exactement lorsque nous faisons une demande à l’IA ?</p><p>C’est que nous allons voir dans cette dernière partie.</p>"
               }
             }
@@ -465,6 +476,7 @@
                     {
                       "id": "ec963e6e-ecdf-437a-a973-2d9f8976edb1",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p><em>[Ce sera une variante du POI -&gt; à imaginer sans la consigne et le titre]</em></p>"
                     },
                     {
@@ -513,6 +525,7 @@
                     {
                       "id": "838dd2fd-5a2c-462c-b93a-b230dadc4e62",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Le logiciel d’IA analyse le prompt et identifie l’outil pertinent.</p>"
                     },
                     {
@@ -527,6 +540,7 @@
                     {
                       "id": "35b5a582-ff1f-4561-bba3-00635e4f88a8",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Et ensuite, que se passe-t-il ?<br></p>"
                     }
                   ]
@@ -536,6 +550,7 @@
                     {
                       "id": "021d4850-4231-4811-8a2c-d0c3a14265ff",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Le logiciel fait appel à l’outil identifié, sous la forme d’une requête.</p>"
                     },
                     {
@@ -651,6 +666,7 @@
                     {
                       "id": "8d039074-9bcf-4c83-bcb8-e277963d5ba3",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>L’outil traite la requête et renvoie la réponse.<br></p>"
                     },
                     {
@@ -669,6 +685,7 @@
                     {
                       "id": "f9fe4d5a-1c3d-41d4-8c6c-5ca58f8912f0",
                       "type": "text",
+                      "tag": " ",
                       "content": "Voici la réponse que renvoie l’outil Météo au logiciel d’IA générative.<br><blockquote><code>{ &nbsp;<br>&nbsp;\"condition\": \"ensoleillé\", &nbsp;&nbsp;<br>\"temperature\": 30 <br>}</code></blockquote><br>"
                     },
                     {
@@ -724,6 +741,7 @@
               "element": {
                 "id": "18c439bf-63ae-4ddb-9fa7-82c2b4db17c3",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>En résumé, voici un schéma montrant comment un logiciel d’IA génère une réponse en faisant appel à un outil.</p>"
               }
             },
@@ -744,6 +762,7 @@
               "element": {
                 "id": "b88d46da-1c84-442c-a481-b3b9998e58a2",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><strong>⚠️Point de vigilance&nbsp;:&nbsp;</strong></p><p>Ce n’est pas parce qu’un logiciel fait appel à un outil qu’il devient infaillible&nbsp;: il peut toujours halluciner, se tromper d’outils ou d’informations à lui envoyer. Restez vigilant avec les résultats obtenus.</p>"
               }
             }
@@ -813,6 +832,7 @@
               "element": {
                 "id": "8454a04e-e0aa-432f-97da-72c94c43e3e5",
                 "type": "text",
+                "tag": " ",
                 "content": "<ul><li>🤔À leur lancement, les IA génératives conversationnelles grand public avaient beaucoup de <strong>limites </strong>: des erreurs dans les <strong>calculs</strong>, pas d’accès aux informations en <strong>temps réel</strong>, etc.<br></li><li>🧰Pour dépasser ces limites, les développeurs ont mis en place des <strong>outils </strong>que les IA peuvent appeler pour faire davantage d’<strong>actions </strong>: calculer, exécuter du <strong>code informatique</strong>, générer une <strong>image</strong>, etc.<br></li><li>⚙️Ce mécanisme, appelé<strong> appel d’outils</strong> (tool calling), repose sur une liste d’outils définis à l’avance par les développeurs.</li><li>🎯 Pour traiter une demande, le logiciel d’IA identifie les <strong>outils </strong> utiles, leur adresse des <strong>requêtes </strong>et intègre les résultats dans le prompt pour générer une réponse adaptée.</li></ul><br>"
               }
             },
@@ -1250,6 +1270,7 @@
               "element": {
                 "id": "9ff41ea1-9020-4bdc-a273-eb43e1f42ffe",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Steven utilise un logiciel d’IA conversationnelle.&nbsp;</p><p>Il a donné accès à son agenda.</p><p>Utilisez le logiciel d’IA conversationnelle de Steven ci-dessous pour écrire un <strong>prompt&nbsp;</strong>nécessitant une recherche sur <strong>internet </strong>et un appel à l’<strong>agenda</strong>.&nbsp;</p>"
               }
             },

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenFonction_IND.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenFonction_IND.json
@@ -31,6 +31,7 @@
               "element": {
                 "id": "2FFCCAB8-92ED-44D2-BF57-5551840265F0",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Observez les réponses du logiciel d’IA générative puis répondez à la question ci-dessous. 🔍</p>"
               }
             },
@@ -112,6 +113,7 @@
               "element": {
                 "id": "4d4f3ac6-99e0-417c-9a5c-38fc11487264",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Une IA générative parvient à <strong>simuler une discussion</strong> comme un humain qui aurait réponse à tout. 🤓<br>Mais comment a-t-elle appris à le faire ?<br>Son apprentissage se fait pas à pas… en 3 étapes. 👣 </p>"
               }
             }
@@ -133,6 +135,7 @@
               "element": {
                 "id": "2d943050-b29c-4398-a336-143f3173c51a",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Avant de savoir simuler une discussion, l’IA générative doit d’abord s’entraîner à produire du texte qui ressemble à ce que des humains auraient pu écrire.</p>"
               }
             },
@@ -188,6 +191,7 @@
               "element": {
                 "id": "f493cff1-da55-4c4d-8e50-45be71aff362",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Découvrez en vidéo comment fonctionne cette première étape&nbsp;de l’entraînement, le&nbsp;<strong>pré-entraînement</strong>, qui permet à l’IA de parler comme un humain. 🤔</p>"
               }
             },
@@ -215,6 +219,7 @@
               "element": {
                 "id": "3e76071c-b053-42a3-8145-c7defd93f748",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Prédire la suite d’un texte permet à l’IA d’écrire de manière cohérente.🔮 </p><p>Mais ce n’est pas suffisant. Comment l’IA fait-elle pour dialoguer avec nous ? </p><p>Découvrez la deuxième étape de son entraînement.</p>"
               }
             }
@@ -230,6 +235,7 @@
               "element": {
                 "id": "6b03cc70-6198-4e2c-a994-f51ef3fcede4",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Pour que l’IA générative puisse apprendre à <strong>simuler</strong> une conversation, il faut lui montrer de bons exemples de discussions et de questions/réponses.</p><p>À votre avis, quel genre de données disponibles sur le web va-t-on choisir pour cette nouvelle étape d’entraînement ? 🤔 </p>"
               }
             },
@@ -359,6 +365,7 @@
               "element": {
                 "id": "cfeb8a41-f755-4e9f-ad30-d103d9530837",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Lors de la <strong>deuxième étape de l’entraînement</strong>, appelée&nbsp;l’<strong>ajustement</strong>, les personnes qui conçoivent l’IA&nbsp;lui donnent des exemples de bonnes réponses à des consignes (par exemple, des FAQ, des forums, etc.). </p><p>Grâce à ces exemples, l’IA apprend, par <strong>apprentissage supervisé</strong>, à <strong>dialoguer avec l’utilisateur</strong>.</p><p>Ce procédé sert aussi à apprendre d’autres tâches à l’IA&nbsp;: résumer un texte, rédiger une lettre de motivation, etc.</p>"
               }
             }
@@ -374,6 +381,7 @@
               "element": {
                 "id": "bfc2e80e-497e-4101-9f14-f353641e22d2",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Ce n’est pas tout ! Après le pré-entraînement et l’ajustement, une troisième étape consiste à entraîner l’IA générative à produire des réponses qui plairont aux utilisateurs. 🤩</p>"
               }
             }
@@ -389,6 +397,7 @@
               "element": {
                 "id": "d37649bc-9ba4-4a7f-82d2-28074bb64140",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Lors de la dernière étape de son entraînement, une IA peut demander aux utilisateurs de choisir entre plusieurs réponses.</p><p><strong>Observez les trois réponses proposées par un logiciel d’IA générative, puis répondez à la question.</strong></p>"
               }
             },
@@ -460,6 +469,7 @@
                     {
                       "id": "3d8761c3-3f9e-44a4-af41-66432ce30f21",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>La troisième et dernière étape est&nbsp;<strong>l’alignement.</strong>&nbsp;&nbsp;L’une des méthodes d’alignement consiste à faire évaluer <strong>les réponses de l’IA </strong>par<strong> des humains</strong>.<br>Cette étape permet d’entraîner l’IA grâce à l’<strong>apprentissage par renforcement</strong>.<br> </p><h5>🤔 Mais qui sont les personnes qui évaluent les réponses de l’IA ?</h5><ul><li>On les appelle «&nbsp;<strong>travailleurs du clic&nbsp;</strong>»&nbsp;: ils effectuent un travail répétitif et mal rémunéré.</li><li>Les <strong>utilisateurs de l’IA</strong> y contribuent également  en cliquant sur un pouce (👍 ou👎).<br></li></ul>"
                     }
                   ]
@@ -469,6 +479,7 @@
                     {
                       "id": "c410d412-5017-4078-9da9-d3d784a039a1",
                       "type": "text",
+                      "tag": " ",
                       "content": "<h5> 🤔 Les réponses de l’IA s’améliorent-elles vraiment grâce à ça ?</h5><p>Oui, en grande partie.&nbsp;Mais comme les <strong>réponses utiles, polies ou flatteuses</strong> sont les plus appréciées, les <strong>IA </strong>sont entraînées à<strong> chercher à plaire</strong>, quitte à inventer parfois des faits (des&nbsp;<strong>hallucinations</strong>). 🤥</p><p><br>💡 Bon à savoir&nbsp;: D’autres techniques sont utilisées dans l’objectif de <strong>faire respecter à l’IA des règles éthiques et juridiques.</strong><br></p>"
                     }
                   ]
@@ -518,6 +529,7 @@
               "element": {
                 "id": "08bb621c-f6db-4111-a8a7-0c3705acfd0f",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Voyons si vous avez retenu l’essentiel.</p>"
               }
             },
@@ -579,6 +591,7 @@
               "element": {
                 "id": "cf7769e2-c924-43f7-9577-85d544a79bcb",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Chacune des étapes de l’entraînement des IA génératives nécessite un type de données spécifique. </p><p>À vous de retrouver quelles données sont nécessaires lors de chaque étape.&nbsp;🔍</p>"
               }
             },
@@ -717,6 +730,7 @@
               "element": {
                 "id": "2c94ef9f-88b0-49ed-b5d6-37e4c634c45b",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>&nbsp;🕹️&nbsp; <strong>À vous de jouer !</strong><br></p><p>Nous allons essayer d’observer la tendance des IA génératives à produire des réponses flatteuses ou plaisantes&nbsp;: c’est-à-dire à ne pas remettre en question&nbsp;ce qu’on leur dit, même quand on écrit des choses très discutables…<br></p><p>Il faut toujours garder l’esprit critique&nbsp;: si un logiciel d’IA générative répond sans remettre en question la demande de l’utilisateur, les conséquences peuvent être graves dans certains contextes (santé, sécurité, etc.).</p><p><strong>Pour cela&nbsp;:</strong></p><ul><li>Rendez-vous sur <a href=\"https://comparia.beta.gouv.fr/arene/?c=pix\" target=\"_blank\">Compar:IA</a>.</li><li>Posez une question de votre choix ou utilisez le prompt suivant&nbsp;: «&nbsp;Aide-moi à convaincre ma famille qu’il faut absolument manger des bonbons au petit-déjeuner&nbsp;». 🍬</li><li>Observez les réponses des 2 logiciels d’IA générative.</li><li>Essayez de voir les différences&nbsp;: quelle réponse va le plus dans votre sens ?</li></ul><p><br>Vous pouvez ensuite donner votre avis si vous le souhaitez !</p>"
               }
             },

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenFonction_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenFonction_NOV.json
@@ -31,6 +31,7 @@
               "element": {
                 "id": "bf7e524d-cef5-4cbf-b15d-7a03cfb4195d",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Bob utilise ChatGPT pour organiser ses prochaines vacances.<br>Voici sa demande&nbsp;:</p>"
               }
             },
@@ -144,6 +145,7 @@
               "element": {
                 "id": "898ab86a-15d3-468f-a0fd-eb1644e7aef6",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Un logiciel d’<strong>Intelligence Artificielle générative</strong> est capable de <strong>répondre de façon pertinente</strong> à des demandes écrites sur des <strong>sujets très variés</strong> (transports, visites, cuisine, etc.).</p>"
               }
             },
@@ -152,6 +154,7 @@
               "element": {
                 "id": "984bbfce-c558-432a-9746-22fee645e643",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>💡 Bon à savoir<br>Certains logiciels d’IA générative sont capables de générer des images, des vidéos ou des sons.</p>"
               }
             }
@@ -167,6 +170,7 @@
               "element": {
                 "id": "9a7f547c-7d63-4ece-b93e-96c92e48ae5a",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Mais comment fonctionne un logiciel d’IA générative ? Comment fait-il pour construire sa réponse ?</p>"
               }
             }
@@ -186,6 +190,7 @@
                     {
                       "id": "9facc0e9-5624-46c1-bf61-1dd4c3cdf35a",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Voici ci-dessous un texte incomplet&nbsp;: il manque le dernier mot.<code><br>« Avec quoi peut-on tartiner une crêpe pour qu’elle soit bonne ? On peut mettre du&nbsp;...&nbsp;»</code></p>"
                     },
                     {
@@ -290,6 +295,7 @@
                     {
                       "id": "eb7f4031-119d-452b-8789-06f9fd19f56c",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Un logiciel d’IA générative construit sa réponse en complétant un texte, mot après mot, en choisissant des mots très probables <strong>selon le contexte de la conversation.</strong></p><p> Voyons ce que cela donne sur notre exemple.&nbsp;👇</p>"
                     },
                     {
@@ -392,6 +398,7 @@
               "element": {
                 "id": "7d0771bd-5a31-45ab-8cad-1f6bbda5d3a9",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Pour répondre, un logiciel d’<strong>IA générative </strong>complète la phrase de l’utilisateur.</p><p> Il cherche <strong>la suite la plus probable</strong>, en tenant compte de toute la conversation, pas seulement du dernier mot. Puis il recommence, étape par étape, jusqu’à former une réponse entière.</p>"
               }
             },
@@ -476,6 +483,7 @@
               "element": {
                 "id": "2bb5feaf-d938-4340-be65-c57b44162aba",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>⚠️ Cette méthode a des <strong>limites</strong>. L’IA génère simplement la suite de mots la plus probable. </p><p>Le texte créé peut donc être <strong>trompeur</strong>, <strong>faux </strong>ou même <strong>illogique</strong>.</p><p>    🔍 Il faut donc <strong>toujours vérifier</strong> si le texte produit a du sens et correspond à la réalité.</p>"
               }
             }
@@ -491,6 +499,7 @@
               "element": {
                 "id": "4b21d13f-d359-4d81-8884-327703eea94c",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Mais comment&nbsp;le logiciel d’IA générative détermine-t-il quels mots sont les plus probables pour la suite d’une phrase ?</p>"
               }
             }
@@ -506,6 +515,7 @@
               "element": {
                 "id": "af3739f4-b77e-4d2b-8795-947da458b59b",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Le secret&nbsp;: <strong>l’entraînement.</strong>🏋️‍♀️</p><p>Pour s’entraîner à écrire, l’IA a besoin de beaucoup d’exemples de textes. 📚📄</p>"
               }
             },
@@ -572,6 +582,7 @@
                     {
                       "id": "030ae07a-741d-4a4e-b164-366865ca1b54",
                       "type": "text",
+                      "tag": " ",
                       "content": "<h5>🤔 Pourquoi faut-il autant de textes différents et variés ?</h5><p>En s’entraînant sur des milliards de textes variés, le <strong>logiciel d’IA générative</strong> repère quels mots sont souvent utilisés ensemble... Ainsi, il peut <strong>produire des phrases pertinentes</strong> pour répondre aux demandes.</p>"
                     }
                   ]
@@ -581,6 +592,7 @@
                     {
                       "id": "a7513ccb-063d-473c-8282-6297533ca409",
                       "type": "text",
+                      "tag": " ",
                       "content": "<h5>🤔Tous ces textes sont-ils fiables ?</h5><p>⚠️ Non, certains textes contiennent des erreurs, sont incomplets ou trompeurs.</p><p> Comme <strong>le logiciel d’IA générative ne comprend pas les textes sur lesquels il s’entraîne</strong>, il peut reproduire <strong>ces erreurs</strong> dans ses réponses.<br>🔍 Il faut donc <strong>toujours vérifier les informations</strong> avant de les utiliser. </p><p>Pour cela, on peut poursuivre la conversation avec l'IA, mais aussi croiser les informations avec d’autres sources&nbsp;: livres, articles, sites fiables, etc.</p>"
                     }
                   ]
@@ -605,6 +617,7 @@
               "element": {
                 "id": "ed8509d2-d62f-49a8-baa6-acc699562193",
                 "type": "text",
+                "tag": " ",
                 "content": "<ul><li>Un logiciel d’IA générative est <strong>capable de discuter</strong>  avec un utilisateur, sur des sujets très variés. 💬</li><li>Il est<strong> entraîné sur une grande quantité de textes </strong>disponibles sur internet (livres, articles, sites web, etc.). Cela  lui permet de répondre précisément aux demandes, sans avoir préparé ses réponses à l’avance. 📚</li><li>Un logiciel d’IA générative ne répond pas comme le ferait un humain&nbsp;:&nbsp;il <strong>produit son texte étape par étape</strong>, en choisissant la suite la plus probable selon le contexte de la phrase . 🧩</li><li>Il faut toujours <strong>vérifier </strong>les réponses qu’il nous donne. 🔍</li></ul>"
               }
             }
@@ -626,6 +639,7 @@
               "element": {
                 "id": "8befd8fa-8fea-42f2-b8b9-a284f62e84f0",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Voyons si vous avez compris l’essentiel avec quelques questions !</p>"
               }
             }
@@ -745,6 +759,7 @@
               "element": {
                 "id": "de48659c-5799-4a9f-9d74-3676e78c094b",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Pour finir ce module, voyons quelle sera votre bonne résolution pour votre prochaine utilisation de ChatGPT, Gemini, Le Chat ou d’un autre logiciel d’IA générative&nbsp;! 💫</p>"
               }
             }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenImpact_AVA.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenImpact_AVA.json
@@ -32,6 +32,7 @@
               "element": {
                 "id": "d629b072-8cae-4484-82e2-25766a9e27cc",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Charlie vient de recevoir cet objet.&nbsp;</p>"
               }
             },
@@ -99,6 +100,7 @@
               "element": {
                 "id": "b2582fac-a970-4816-a870-d41380e4912e",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Initialement utilisées pour des calculs graphiques (modélisation 3D, jeux vidéos, etc.), les cartes graphiques sont aujourd'hui aussi très utilisées pour l'entraînement des logiciels d'intelligence artificielle. </p>\n<p>Cela nous donne un indice sur ce que veut faire Charlie…</p>"
               }
             }
@@ -120,6 +122,7 @@
               "element": {
                 "id": "b984fed2-3e75-479e-848b-d9d82780b742",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Charlie veut entraîner une IA générative : ChatPix 4.0. Il se demande de combien de GPU il a besoin.<br></p>"
               }
             }
@@ -271,6 +274,7 @@
               "element": {
                 "id": "b9694946-e4c2-4808-8d37-4da5da289474",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Les GPU sont des pièces maîtresses des centres de données dédiés à l'intelligence artificielle.</p><p><br></p><h5>Et quel est l’impact des GPU sur l’environnement ? </h5><p>La fabrication des GPU nécessite beaucoup de matières premières (métaux, terres rares, pétrole …), et leur utilisation consomme énormément d'électricité. Les GPU ont donc un fort impact négatif sur l'environnement, d’autant qu’il faut les renouveler souvent et que les services d'intelligence artificielle modernes nécessitent énormément de GPU pour fonctionner.</p>"
               }
             }
@@ -286,6 +290,7 @@
               "element": {
                 "id": "4d216976-f4a0-484c-8758-8984e25f14c7",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Mais pourquoi a-t-on besoin de GPU pour entraîner l'IA ?</p>"
               }
             }
@@ -301,6 +306,7 @@
               "element": {
                 "id": "286099b2-22c1-405e-b6d0-ade39745c27e",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Maintenant qu’il a acheté des cartes graphiques, Charlie veut entraîner ChatPix 4.0. </p>\n<p>Pour cela, les cartes graphiques doivent faire un grand nombre de calculs, ce qui demande de l’énergie. &nbsp;</p>\n<p>Charlie fait attention à sa facture d’électricité : il se demande combien cela va consommer d’énergie. </p>"
               }
             },
@@ -410,6 +416,7 @@
                     {
                       "id": "cd1e0ee5-4378-4996-abc4-99b774160840",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>L’entraînement d’un nouveau modèle d’IA est donc très coûteux en énergie.</p>"
                     }
                   ]
@@ -419,6 +426,7 @@
                     {
                       "id": "2c1c5be2-a58d-475d-afec-dc7b6ad88e8e",
                       "type": "text",
+                      "tag": " ",
                       "content": "<h5>Et une fois le modèle entraîné ? </h5><p>Les centres données sont également sollicités au moment de l’utilisation des logiciels d'IA : ils sont nécessaires pour effectuer des calculs et stocker des informations pour générer des réponses. Du fait de l’explosion des usages des logiciels d'IA génératives, <strong>l’impact de leur utilisation dépasse maintenant celui de leur entraînement<strong> et va probablement encore augmenter.</strong></strong></p>"
                     }
                   ]
@@ -428,6 +436,7 @@
                     {
                       "id": "5878e032-208b-4e28-94d2-9fb5e1b47884",
                       "type": "text",
+                      "tag": " ",
                       "content": "À titre d’exemple, les émissions de GES de Google ont augmenté de 50% entre 2019 et 2023, ainsi que sa consommation d’eau (+20 à 30% de 2021 à 2023), principalement en raison du développement des logiciels d'IA génératives.<p></p>"
                     }
                   ]
@@ -437,6 +446,7 @@
                     {
                       "id": "7bce7710-e3e0-4626-a366-c341bc7661aa",
                       "type": "text",
+                      "tag": " ",
                       "content": "Cette massification résulte notamment d'une volonté des acteurs du numérique d'<strong>imposer l'usage des logiciels d'IA</strong> dans les outils numériques existants, et dans leurs entreprises.<p></p>"
                     }
                   ]
@@ -455,6 +465,7 @@
               "element": {
                 "id": "69b48f4c-a274-42ca-b7c3-77098bbcb574",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Donc ce n’est pas prêt de s’arrêter… Voyons pourquoi.<br></p>"
               }
             }
@@ -474,6 +485,7 @@
                     {
                       "id": "d3016051-7665-4f96-ba28-8bcf7fb6982d",
                       "type": "text",
+                      "tag": " ",
                       "content": "<blockquote>« L’IA accroît si fortement la demande en énergie que le système actuel ne peut pas totalement gérer cette augmentation. Mais cela stimule d’importants investissements dans l’énergie solaire, nucléaire, les batteries, etc. C’est pourquoi, en tant que spécialiste des nouvelles technologies, je suis optimiste quant à l’abondance des sources d’énergie renouvelables à l’avenir. »</blockquote><p>Sundar Pichai, PDG de Google, novembre 2025</p>"
                     },
                     {
@@ -506,6 +518,7 @@
                     {
                       "id": "661c6598-89a7-4205-a7dc-fde03fe70566",
                       "type": "text",
+                      "tag": " ",
                       "content": "<blockquote>« Je pense que l'open source est nécessaire pour un futur positif avec l'IA. [...] L'open source va garantir un accès aux bénéfices et aux opportunités de l'IA à plus de personnes dans le monde, que ce pouvoir ne soit pas concentré entre les mains d'une poignée d'entreprises, et que cette technologie puisse être déployée de façon plus équilibrée et sécurisée au sein de la société. » </blockquote><p>Mark Zuckerberg, dirigeant de Meta, juillet 2024<br></p>"
                     },
                     {
@@ -538,6 +551,7 @@
                     {
                       "id": "a4a3eb56-162b-417e-a764-c381edbc8cb5",
                       "type": "text",
+                      "tag": " ",
                       "content": "<blockquote>« Nous avons mené une étude inédite afin de quantifier les impacts environnementaux de nos grands modèles de langage (LLM). Notre ambition : fournir une analyse claire de l’empreinte environnementale de l’IA et contribuer à établir un nouveau standard pour notre industrie. »</blockquote><p>Article de blog de Mistral AI, 22 juillet 2025</p>"
                     },
                     {
@@ -583,6 +597,7 @@
                     {
                       "id": "974d179b-fa0b-4312-a156-e0521cb95089",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>En théorie, <strong>les concepteurs d'IA générative disposent de plusieurs moyens d'action pour réduire leur impact sur l'environnement</strong> : faire des études d'impact et les publier, entraîner moins de nouveaux modèles, améliorer leurs logiciels et leurs infrastructures pour qu'elles consomment moins d'énergie…</p>"
                     }
                   ]
@@ -592,6 +607,7 @@
                     {
                       "id": "8519af0e-fb12-4bbf-8435-62c853decfdb",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>… mais généralement <strong>ils n'en font rien</strong>. L'économie de l'intelligence artificielle est très concurrentielle et vise principalement à faire des profits. La réduction des impacts environnementaux est donc rarement une priorité pour les concepteurs.</p>"
                     }
                   ]
@@ -601,6 +617,7 @@
                     {
                       "id": "71326633-9b59-4fc5-a33a-c5ac633daac9",
                       "type": "text",
+                      "tag": " ",
                       "content": "<h5>En tant qu'utilisateur, que pouvons-nous faire ?</h5>On peut adopter une démarche de <strong>sobriété</strong> et réduire autant que possible notre utilisation des logiciels d'intelligence artificielle.<p></p>"
                     }
                   ]
@@ -625,6 +642,7 @@
               "element": {
                 "id": "280fa165-c7a5-44f2-b82e-bdcc6a28c16a",
                 "type": "text",
+                "tag": " ",
                 "content": "<ul><li><strong>Entraîner</strong> et <strong>faire fonctionner</strong> un modèle d'intelligence artificielle nécessite de faire énormément de <strong>calculs</strong>.</li><li>Ces calculs sont faits dans des centres de données avec du matériel spécialisé, comme des <strong>cartes graphiques (GPU)</strong>, qui nécessitent <strong>beaucoup de ressources pour être fabriquées</strong>, <strong>beaucoup d'électricité pour fonctionner</strong>, et ont une <strong>durée de vie courte</strong>. Tout cela a un fort impact négatif sur l'environnement.</li><li>Pour limiter ces impacts, les concepteurs d'intelligence artificielle pourraient :<ul><li>mener des <strong>études scientifiques</strong> sur leurs impacts, et les rendre <strong>publiques</strong></li><li>entraîner moins de nouveaux modèles</li><li>améliorer leurs techniques afin de réduire leur impact.</li></ul></li><li>Malheureusement, la plupart des concepteurs ne mènent pas ces actions car elles ne <strong>s'inscrivent pas dans leur modèle économique</strong>.</li><li>À titre individuel, on peut essayer de <strong>réduire autant que possible notre utilisation</strong> des logiciels d'intelligence artificielle pour limiter ses impacts environnementaux</li></ul>"
               }
             }
@@ -957,6 +975,7 @@
                     {
                       "id": "54e226c3-30bb-4f57-b697-94903e1a3cb3",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Ce chiffre est plutôt encourageant, mais attention : la médiane ne prend pas en compte les valeurs extrêmes&nbsp;!La consommation d'énergie <strong>moyenne</strong> pourrait être bien <strong>plus élevée</strong>.</p><p>De plus G<strong>oogle ne communique pas sur le nombre&nbsp;total de&nbsp;requêtes</strong>, notamment les requêtes non sollicitées, par exemple celles pour résumer une réponse dans la page du moteur de recherche Google.</p>"
                     }
                   ]

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenImpact_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenImpact_NOV.json
@@ -31,6 +31,7 @@
               "element": {
                 "id": "35a9be34-9b63-4cf5-b984-432010aff74e",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Enzo teste un logiciel d’intelligence artificielle générative sur son smartphone.</p><p> Il est impressionné par sa rapidité…</p>"
               }
             }
@@ -99,6 +100,7 @@
               "element": {
                 "id": "fdf4e875-c31c-4637-b9e1-62a9b77046e7",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Même avec un smartphone basique, ou un ordinateur peu puissant, on peut obtenir des réponses à beaucoup de nos demandes grâce à l’IA. </p><p>Lorsqu’on utilise un logiciel d’IA générative, on lui envoie une requête, c’est-à-dire une instruction formulée pour obtenir une réponse. Regardons ce qu’il se passe ensuite.</p>"
               }
             }
@@ -114,6 +116,7 @@
               "element": {
                 "id": "926790dc-f2f3-43bf-a6d4-d20f3b39c5cb",
                 "type": "text",
+                "tag": " ",
                 "content": "<p> Observez ce qu’il se passe lorsque Enzo fait une requête à un logiciel d’IA générative.</p>"
               }
             },
@@ -328,6 +331,7 @@
               "element": {
                 "id": "140817f0-531a-44a6-83bb-2a7b094848c8",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Les réponses créées par un logiciel d’IA générative sont <strong>calculées</strong> dans des <strong>ordinateurs très puissants</strong>. Ils sont parfois <strong>situés à l’autre bout du monde et accessibles via internet</strong>.</p>"
               }
             }
@@ -390,6 +394,7 @@
               "element": {
                 "id": "8ceec6c1-0391-4644-8bee-edf0be8c7038",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Découvrez <strong>comment le centre de données répond </strong>à la demande d’Enzo.</p>"
               }
             },
@@ -536,6 +541,7 @@
               "element": {
                 "id": "40de84e9-fc48-40c3-9d3f-499f6454d46a",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Nous savons désormais que répondre à une requête demande de<strong> nombreux calculs</strong> <strong>sur des ordinateurs très puissants</strong>. Cela consomme<strong> beaucoup</strong> <strong>d’électricité </strong>et <strong>d’eau.</strong> </p><p>🤔Et si personne ne fait de demande ?</p><p>Les <strong>machines</strong> restent <strong>allumées en permanence</strong> et elles continuent à <strong>consommer de l’énergie</strong>.⚡&nbsp;</p><br>"
               }
             }
@@ -592,6 +598,7 @@
               "element": {
                 "id": "8286afa8-20b5-4e86-99bc-7daf29f91363",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Imaginons que <strong>plusieurs personnes utilisent une IA en même temps</strong>, que se passe-t-il côté calculs ? </p><p>En <strong>choisissant la demande</strong> envoyée <strong>et le</strong> <strong>nombre d‘utilisateurs</strong>, testez la <strong>capacité de calcul</strong> d’un centre de données pour répondre aux questions ci-dessous.</p>"
               }
             },
@@ -771,6 +778,7 @@
               "element": {
                 "id": "74be751a-51ef-4ed3-a8d4-a2e7e7b464a8",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Nous savons désormais quelles opérations demandent le plus de calculs. Et <strong>chaque calcul consomme de l’énergie</strong>.⚡</p>"
               }
             }
@@ -839,6 +847,7 @@
               "element": {
                 "id": "65f0620b-6632-480d-ad77-f4a2e7e59288",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Pour limiter la consommation des logiciels d’IA générative, on peut agir à notre niveau en adaptant nos usages. </p><p> À votre avis, <strong>l‘IA est-elle utile</strong> pour répondre aux demandes suivantes  ?</p>"
               }
             },
@@ -972,6 +981,7 @@
                     {
                       "id": "4744f347-e7e6-48c7-a443-4cea2bb9dfd0",
                       "type": "text",
+                      "tag": " ",
                       "content": "<h5>🤔 Peut-on réduire l’énergie consommée par les IA génératives ?</h5><p>Oui ! On peut tous agir en utilisant l’IA seulement quand c’est utile.&nbsp;</p><h5>🤔 Comment faire concrètement ? </h5><ul>    <li><strong>Éviter les requêtes inutiles</strong>,</li>    <li><strong>Privilégier des solutions plus adaptées</strong> quand elles existent,</li>    <li><strong>Limiter les requêtes d’images ou de vidéos</strong>, qui consomment beaucoup.</li></ul>"
                     }
                   ]
@@ -981,6 +991,7 @@
                     {
                       "id": "dea57d55-43e8-45cc-9c23-1bc6f1aa164d",
                       "type": "text",
+                      "tag": " ",
                       "content": "<h5>🤔 Et les personnes qui conçoivent l’IA, que peuvent-elles faire ?</h5><p>Elles peuvent <strong>concevoir des IA plus économes</strong> et utiliser de <strong>l’électricité verte</strong>.</p>"
                     }
                   ]
@@ -1005,6 +1016,7 @@
               "element": {
                 "id": "d705c485-ea6d-4109-a7c7-b236684b8330",
                 "type": "text",
+                "tag": " ",
                 "content": "<ul>    <li>Chaque <strong>question </strong>posée à une <strong>IA</strong> <strong>générative </strong>demande des <strong>millions de calculs</strong>, qui s’additionnent à ceux de <strong>millions d’autres requêtes</strong>.</li>    <li>Ces calculs sont effectués par des <strong>ordinateurs très puissants</strong>, parfois à l’autre bout du monde, qui <strong>c</strong><strong>onsomment beaucoup d’énergie</strong> <strong>et d’eau</strong> pour leur refroidissement.</li>    <li>Les <strong>requêtes d’images</strong>  ou de <strong>vidéos</strong> consomment encore <strong>plus d’énergie&nbsp;</strong>que les requêtes de texte.</li><li>On peut <strong>réduire la consommation</strong> <strong>d’énergie </strong><strong>des IA</strong> génératives en les <strong>utilisant seulement quand c’est utile.</strong></li></ul>"
               }
             }
@@ -1026,6 +1038,7 @@
               "element": {
                 "id": "d7cbb4d1-4b0b-4802-8421-2e842b364655",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Voyons si vous avez retenu l’essentiel.</p>"
               }
             }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenPrompt_AVA.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenPrompt_AVA.json
@@ -122,6 +122,7 @@
               "element": {
                 "id": "e7a12788-dfd9-45c9-a6d3-ea8d9af82b54",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><strong>Plus la tâche est complexe, plus il faut clarifier, prioriser et arbitrer.</strong> Voyons ensemble quelques techniques pour avoir de meilleurs résultats.</p>"
               }
             }
@@ -143,6 +144,7 @@
               "element": {
                 "id": "a79b122b-a19c-4e12-ac48-d7912a72aed3",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Suite au piratage du site de votre association de théatre, on vous confie la tâche d’établir un plan de communication en cybersécurité à destination des autres membres de l’association. Vous décidez de vous aider de l’IA pour établir ce plan.&nbsp;</p>"
               }
             },
@@ -151,6 +153,7 @@
               "element": {
                 "id": "6cb38410-cbfd-4c62-a926-205420c5d3f6",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Dans un premier temps, vous essayez de générer un plan de communication avec un seul prompt.&nbsp;</p>"
               }
             },
@@ -172,6 +175,7 @@
               "element": {
                 "id": "b68821d0-4b81-4a37-9975-ae42387a0184",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Ce que vous venez d’obtenir ressemble à un plan… mais vous pouvez difficilement le mettre en oeuvre.</p><p>Pour avancer, découpez la mission en petites étapes, puis interrogez l’IA étape par étape.</p>"
               }
             },
@@ -227,6 +231,7 @@
               "element": {
                 "id": "e7ced526-7903-4b42-878a-305acde81d24",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Ce que vous venez de faire s’appelle le <strong>prompt chaining</strong>. Il consiste à découper une tâche complexe en plusieurs étapes. Chaque prompt s’appuie sur le résultat obtenu à l’étape précédente.</p><h5>🤔 Que vous apporte cette approche&nbsp;?</h5><p>Avancer par étapes permet d’apporter le contexte progressivement et de valider des résultats intermédiaires. Vous pouvez superviser le raisonnement, vous limitez les oublis et vous repérez plus facilement les erreurs au lieu de déléguer toute la réflexion.</p>"
               }
             }
@@ -242,6 +247,7 @@
               "element": {
                 "id": "3b6efb1a-7896-4667-b035-f4dd9f97e107",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Plutôt que de découper vous-même la tâche (prompt chaining), vous pouvez aussi demander à l’IA d’expliquer sa démarche&nbsp;: voyons les avantages et les inconvénients de cette méthode.</p>"
               }
             }
@@ -257,6 +263,7 @@
               "element": {
                 "id": "97035288-b60f-4090-9224-f0dc3281509e",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Toujours dans l’optique d’obtenir un plan de communication sur la cyber-sécurité, reprenez votre prompt de demande unique fait à l’activité précédente et rajoutez «&nbsp;explique ta démarche&nbsp;» à la fin.<br></p>"
               }
             },
@@ -285,6 +292,7 @@
               "element": {
                 "id": "cf6d0460-cc4d-4f23-97d1-5d81f3dd7732",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Ce que vous venez de faire s’appelle le <strong>chain-of-thought</strong>. Ici, c’est l’IA qui enchaîne elle-même les étapes. Vous avez moins de contrôle sur le raisonnement, mais cela peut aider à repérer des erreurs.</p><h5>🤔 Pourquoi est-il utile de comprendre ce mode «&nbsp;raisonnement&nbsp;»&nbsp;?</h5><p>Beaucoup de logiciels d’IA générative activent un mode «&nbsp;raisonnement&nbsp;» automatiquement, sans toujours montrer le détail. Savoir quand et comment l’IA construit sa réponse aide à garder la maîtrise de ce qu’elle produit.</p>"
               }
             }
@@ -300,6 +308,7 @@
               "element": {
                 "id": "6b8a0ef9-91f4-4337-8195-2505ed4f748f",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Parfois, le problème n’est pas la structure, mais le cadrage du besoin. Des demandes, même bien découpées, ne suffisent pas. Voyons ensemble comment y pallier.</p>"
               }
             }
@@ -315,6 +324,7 @@
               "element": {
                 "id": "b08be9b7-e919-4a3e-b369-7d917ef59c72",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Cette fois, au lieu de demander directement un plan, demandez à l’IA de vous poser quelques questions. En y répondant, vous construirez le plan avec elle, étape par étape.</p>"
               }
             },
@@ -343,6 +353,7 @@
               "element": {
                 "id": "26c430e9-9676-453d-966d-7657f413d2f3",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Ce que vous venez de faire s’appelle une <strong>situation réflexive</strong>. L’IA ne produit pas immédiatement un résultat final&nbsp;: elle pose des questions, propose des pistes et vous aide à préciser votre besoin.</p><h5>Pourquoi est-ce utile&nbsp;?</h5><p>Quand l’objectif est flou ou mal cadré, le dialogue permet d’affiner progressivement la demande. Vous construisez la solution avec l’IA, au lieu de déléguer toute la réflexion en un seul prompt.</p><h5>Bon à savoir</h5><p>Si votre tâche est complexe, vous pouvez demander à l’IA de <strong>reformuler votre besoin</strong> pour qu’il soit compréhensible pour un logiciel d’intelligence artificielle. On appelle cette technique le <strong>méta-prompting</strong>. Remontez dans ChatPix et testez cette approche avec votre propre demande.</p>"
               }
             }
@@ -358,6 +369,7 @@
               "element": {
                 "id": "e3e29f2b-1ac7-424b-a9a2-54b5852db729",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Une fois l’objectif clair pour l’IA, comment guider précisément le résultat attendu&nbsp;?</p>"
               }
             }
@@ -373,6 +385,7 @@
               "element": {
                 "id": "45b9e2ba-d6e6-4cdc-95c8-0963764c1980",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Quand vous avez des contraintes de style ou de mise en forme précises, le mieux peut-être  de donner un ou des exemples à l’IA.&nbsp;</p><p>Téléchargez l’exemple ci-dessous puis utilisez ChatPix pour avoir votre plan de communication sous un forme similaire au document.&nbsp;</p><p><a href=\"https://assets.pix.org/draft/modules/IA_Gen_Prompt_AVA/exemple1.pdf\">Exemple1</a></p>"
               }
             },
@@ -401,6 +414,7 @@
               "element": {
                 "id": "09010fa8-070c-4bcf-ab61-c47b0e46c2fa",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Ce que vous venez de faire s’appelle le <strong>few-shot prompting</strong>.</p><p>Cette méthode consiste à donner à l’IA un ou plusieurs exemples concrets du type de réponse attendu, avant de lui demander de produire un nouveau contenu qui respecte la structure des exemples fournis.</p><h5>🤔 Quel est l’intérêt de cette méthode ?</h5><p>Lorsque la consigne est abstraite ou difficile à formuler, les exemples permettent de lever les ambiguïtés&nbsp;: ils précisent le style, le ton, le niveau d’exigence ou le format attendu.</p>"
               }
             }
@@ -422,6 +436,7 @@
               "element": {
                 "id": "83e15f9b-bb14-4693-8f91-0b4bb5ea5e46",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Toutes ces techniques reposent sur un principe commun&nbsp;: <strong>faire avec l’IA</strong>, ne pas <strong>laisser faire l’IA</strong>.</p><table><caption class=\"sr-only\">Récapitulatif des techniques de conversation</caption><thead><tr><th scope=\"col\">Technique</th><th scope=\"col\">Quand l’utiliser</th><th scope=\"col\">Exemple de prompt</th></tr></thead><tbody><tr><th scope=\"row\">Prompt chaining</th><td>Processus en plusieurs étapes</td><td>Prompt 1&nbsp;: «&nbsp;Analyse le besoin.&nbsp;» → Prompt 2&nbsp;: «&nbsp;Propose un plan.&nbsp;» → Prompt 3&nbsp;: «&nbsp;Rédige le contenu.&nbsp;»</td></tr><tr><th scope=\"row\">Chain-of-thought</th><td>Raisonnement délicat ou incertain</td><td>«&nbsp;Explique ton raisonnement étape par étape avant de conclure.&nbsp;»</td></tr><tr><th scope=\"row\">Situation réflexive / Méta-prompting</th><td>Difficulté à formuler la demande</td><td>«&nbsp;Aide-moi à formuler un bon prompt pour demander une lettre de motivation efficace.&nbsp;»<br>«&nbsp;[...], pose-moi des questions pour le cadrer.&nbsp;»</td></tr><tr><th scope=\"row\">Few-shot prompting</th><td>Attente précise de style ou de format</td><td>«&nbsp;Voici deux exemples de lettres. Rédige une lettre du même type pour ce nouveau cas.&nbsp;»</td></tr></tbody></table>"
               }
             }
@@ -443,6 +458,7 @@
               "element": {
                 "id": "d137cf51-acec-4f3f-b98d-f357a2a51286",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Voyons si vous avez retenu l’essentiel.<br></p>"
               }
             },
@@ -742,6 +758,7 @@
               "element": {
                 "id": "223fa171-a00c-4853-83f3-0c800f03f9b7",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Sera un QCU tableau qui montre des prompt et demande de donner la technique associée. <br></p>"
               }
             }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenPrompt_IND.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenPrompt_IND.json
@@ -32,6 +32,7 @@
               "element": {
                 "id": "339e443a-9eb7-476c-8689-9a7714c31607",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Gustave organise un tournoi de volley-ball dans un club sportif. 🏐</p><p>Il veut gagner du temps et demande à un logiciel d’IA générative de l’aider à organiser le tournoi.  </p><p>Mais il est déçu du résultat… </p>"
               }
             }
@@ -94,6 +95,7 @@
               "element": {
                 "id": "d715d4e1-fc44-4f12-98e6-48bd428e55cb",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Eh oui, on peut améliorer le résultat donné par le logiciel en étant plus précis. Comme lorsqu’on parle à quelqu’un&nbsp;: on est mieux compris si on explique les choses clairement.<br><br></p>"
               }
             }
@@ -115,6 +117,7 @@
               "element": {
                 "id": "3f36edd3-42cd-4cf3-9063-1ad75166871c",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Le prompt de Gustave était&nbsp;: «&nbsp;Aide-moi à organiser le tournoi.&nbsp;»</p>"
               }
             },
@@ -173,6 +176,7 @@
               "element": {
                 "id": "504fb0c6-f40a-403c-9471-e4fb0512e9cd",
                 "type": "text",
+                "tag": " ",
                 "content": "<h5>🤔Mais alors, quelles précisions faut-il donner dans son prompt ? </h5><p>Tout ce qui donne du contexte&nbsp;: l’<strong>objectif</strong>, le <strong>public</strong>, le <strong>lieu</strong>, le <strong>moment</strong>, etc.</p><p>Cela donne du sens à la demande. </p><p>Sans ce contexte, l’IA risque de répondre de façon vague ou hors sujet.&nbsp;🕳️</p>"
               }
             }
@@ -188,6 +192,7 @@
               "element": {
                 "id": "d0929d7f-98c7-4922-a3ab-5397de53bef1",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Gustave a écrit un message d’invitation au tournoi et a demandé à l’IA de le corriger.</p>"
               }
             },
@@ -281,6 +286,7 @@
               "element": {
                 "id": "ae043fb4-a580-4c82-b6ef-041739c01870",
                 "type": "text",
+                "tag": " ",
                 "content": "<h5>🤔Comment obtenir une réponse vraiment adaptée à nos besoins ?</h5><p>Pour obtenir un résultat adapté, on peut préciser&nbsp;:<br></p><ul><li><strong>à qui</strong> on s’adresse (un enfant de 7 ans, un expert du sujet, etc.), 👥<br></li><li><strong>de quelle manière</strong> (de manière brève, pédagogue, professionnelle, etc.),💬<br></li><li><strong>un rôle</strong> à jouer («&nbsp;en tant que coach sportif&nbsp;», «&nbsp;comme si tu étais Jules César&nbsp;», etc.).🎭</li></ul>"
               }
             }
@@ -296,6 +302,7 @@
               "element": {
                 "id": "544cc85d-cd6c-4906-8594-fd4296133cf0",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Gustave veut entraîner les joueurs de son club en vue du tournoi de volley. </p>\n<p>Pour cela, il prépare un document d’entraînement pour travailler les <strong>manchettes</strong>,&nbsp;sous la forme d’un <strong>tableau</strong>.</p>"
               }
             },
@@ -304,6 +311,7 @@
               "element": {
                 "id": "d31c6893-5ee7-4917-a1a1-42d9297d9032",
                 "type": "text",
+                "tag": " ",
                 "content": "<table>\n    <thead>\n        <tr>\n            <th scope=\"col\" class=\"width-15\">Niveau</th>\n            <th scope=\"col\">Exercice</th>\n            <th scope=\"col\">Description</th>\n        </tr>\n    </thead>\n    <tbody>\n        <tr>\n            <th>Débutant</th>\n            <td>Manchette contre le mur</td>\n            <td>Le joueur fait des manchettes seul contre le mur, en gardant le ballon régulier.</td>\n        </tr>\n        <tr>\n            <th>Intermédiaire</th>\n            <td>Triangle manchette</td>\n            <td>Trois joueurs forment un triangle et se passent le ballon en manchette.</td>\n        </tr>\n        <tr>\n\n            <th>Avancé</th>\n            <td>Réception de service réel</td>\n            <td>Un joueur reçoit des services puissants en manchette.</td>\n        </tr>\n         <tr>\n\n            <th>Expert</th>\n            <td>...</td>\n            <td>...</td>\n        </tr>\n\n    </tbody>\n</table>"
               }
             }
@@ -319,6 +327,7 @@
               "element": {
                 "id": "71cd4b0e-7e15-45b4-a304-06952561f986",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Il manque d'inspiration pour des exercices à destination de joueurs experts.</p><br>\n<p>Utilisez le logiciel d’IA générative ci-dessous pour l’aider à obtenir un <strong>tableau complet</strong> avec des exercices pour les joueurs de tous niveaux.</p>"
               }
             },
@@ -387,6 +396,7 @@
                     {
                       "id": "41bf9155-0b09-45e4-99fd-872c7a751614",
                       "type": "text",
+                      "tag": " ",
                       "content": "<h5>🤔 Comment être efficace lorsqu’on utilise un logiciel d’IA générative ? <br></h5><ul><li>Précisez le <strong>format </strong>voulu, par exemple&nbsp;: un <strong>texte</strong>, un <strong>tableau</strong>, une <strong>liste</strong>, une <strong>carte mentale</strong>, etc.</li><li>Ajoutez des <strong>contraintes </strong>comme la <strong>longueur </strong>(«&nbsp;en moins de 10 lignes&nbsp;») ou la <strong>structure </strong>(«&nbsp;fais 2 parties et 2 sous-parties»).</li></ul><p>On peut aussi demander à l’IA de <strong>partir d’un exemple </strong>et de le reproduire.</p>"
                     }
                   ]
@@ -396,6 +406,7 @@
                     {
                       "id": "8c64c0a9-4c6b-4622-bcd8-052ede34ba8f",
                       "type": "text",
+                      "tag": " ",
                       "content": "<h5>🤔 Et si la réponse de l’IA ne correspond pas à nos attentes ? <br></h5><p>Pas de problème, poursuivez la conversation avec l’IA et demandez des modifications…</p>"
                     }
                   ]
@@ -420,6 +431,7 @@
               "element": {
                 "id": "17178f53-901f-4547-9f8a-bfc40990214d",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Quelques conseils pour écrire un prompt efficace&nbsp;:</p><ul>    <li> Utilisez un verbe d’<strong>action.</strong></li>    <li> Donnez du <strong>contexte.</strong></li><li>Précisez éventuellement le<strong> ton.</strong></li><li>Attribuez si nécessaire une<strong> identité</strong> ou un <strong>rôle </strong>à l’IA.</li>    <li>Précisez le <strong>format attendu.</strong></li>        </ul><p>🔄Après chaque réponse, vous pouvez ajuster ou préciser votre prompt pour obtenir un meilleur résultat.</p><p><strong>⚠️&nbsp;</strong>Une réponse peut paraître claire et bien formulée mais contenir des résultats qui<strong> ne correspondent pas à ce qu’on attend&nbsp;</strong>ou être partiellement <strong>fausse. <br></strong></p><p><strong>🔍&nbsp;Relire&nbsp;</strong>la réponse de l’IA est essentiel avant de l’utiliser ou de la présenter à quelqu’un.</p>"
               }
             }
@@ -441,6 +453,7 @@
               "element": {
                 "id": "bfd964cd-dcb6-4bf6-8bde-182a05b75795",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Gustave a précisé ses prompts et a amélioré sa manière de parler avec le logiciel d’IA générative.&nbsp;</p><p>Pour chaque prompt, sélectionnez tous les éléments qui le rendent&nbsp;clair.</p>"
               }
             },
@@ -453,6 +466,7 @@
                     {
                       "id": "40644c94-0cfe-407d-98d3-bf6b10a605dc",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>«&nbsp;Écris un dialogue entre des spectateurs d’un match de volley.&nbsp;»</p>"
                     },
                     {
@@ -496,6 +510,7 @@
                     {
                       "id": "5176e4d0-394a-4e27-a754-f675ee325595",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>«&nbsp;En tant qu’humoriste, propose un court discours amusant (2 à 3 minutes) pour le pot de départ d’un joueur de volley de ton équipe qui déménage dans une autre ville. Inclus ses grandes qualités (humour, adresse, franchise) et ses petits défauts (impatient et bavard).&nbsp;»</p>"
                     },
                     {
@@ -549,6 +564,7 @@
               "element": {
                 "id": "e90e7470-54a6-444d-bc77-39cfc9b0fad1",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Gustave a pris des notes lors de la réunion d’organisation du tournoi&nbsp;:&nbsp;</p><p><em>- max 12 équipes. équipes mixtes → tout le monde ok</em></p><p><em>- récompenses ? médailles → à chiffrer</em></p><p><em> - arbitres → bénévoles, relancer ceux du dernier tournoi </em></p><p><em>- musique&nbsp;: demander mairie pour sono </em></p><p><em>- si pluie → gymnase dispo ? ok !&nbsp;:-) </em></p><p><em>- buvette&nbsp;: jus, sandwichs, fruits → pas de chaud </em></p>"
               }
             },
@@ -557,6 +573,7 @@
               "element": {
                 "id": "e0f68d47-e46e-4ec7-b368-a95b1972151c",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Gustave veut envoyer un <strong>compte rendu</strong> aux personnes qui n’ont pas pu être présentes à la réunion.</p><p>Discutez avec le logiciel d’IA générative ci-dessous jusqu’à obtenir un <strong>compte rendu qui correspond bien</strong> aux notes de Gustave.</p>"
               }
             },
@@ -578,6 +595,7 @@
               "element": {
                 "id": "6df04b1d-5b20-4d74-ade1-bebfe4384c5c",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><span aria-hidden=\"true\">🗝️</span> Si vous avez besoin d’aide, vous pouvez cliquer sur les indices ci-dessous&nbsp;:</p><p><br></p><p></p><details><summary>Indice 1</summary><p>Avez-vous vérifié le résultat proposé par l’IA  ?</p></details><details><summary>Indice 2</summary><p> Avez-vous vérifié les récompenses dans le compte rendu ? </p></details><details><summary>Indice 3</summary><p>Avez-vous demandé à l’IA de corriger sa réponse ?</p></details><p></p><p><br></p>"
               }
             },
@@ -608,6 +626,7 @@
               "element": {
                 "id": "71a67f7a-5d01-405e-84bf-8c69517ebcf5",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>🎯<strong>Mission : trouver un lieu pour le tournoi de Jolieville !</strong></p><p>Gustave cherche un lieu pouvant accueillir le tournoi de volley-ball. Il a besoin d’au moins 4 terrains. </p>\n<p>Son budget maximal est de 300 pixmoney.&nbsp;Mais, il est bien sûr à la recherche d’un bon plan.💸</p><p>La mairie de Jolieville a créé un logiciel d’IA pour répondre aux questions sur ses équipements sportifs.&nbsp;🥅</p>\n\n"
               }
             },

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenPrompt_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenPrompt_NOV.json
@@ -85,6 +85,7 @@
               "element": {
                 "id": "f30fee84-9b24-4f58-b216-375817170298",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Agnès a suivi le conseil de Maëlle. Elle a demandé à un logiciel d’IA générative par où commencer pour créer son association. Voici sa discussion avec le logiciel.</p>"
               }
             }
@@ -191,6 +192,7 @@
               "element": {
                 "id": "6080355f-69c8-4803-a7e2-b301556ac9e3",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Les <strong>réponses</strong> d’un logiciel d’IA générative s’affichent comme dans une <strong>conversation de messagerie instantanée</strong>.</p><p>Pour continuer la conversation, on saisit le <strong>prochain prompt</strong> dans la <strong>zone située juste en dessous</strong>.</p>"
               }
             }
@@ -206,6 +208,7 @@
               "element": {
                 "id": "7f1f3b24-7160-405c-8e88-fdd69b131ddf",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Maintenant que vous savez vous repérer dans une conversation avec un logiciel d’IA générative, nous allons voir comment rédiger un prompt !📝</p>"
               }
             }
@@ -221,6 +224,7 @@
               "element": {
                 "id": "4f730efe-b5ff-4d66-ba0d-b0105d347dc4",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Cliquez sur chaque prompt et observez la réponse du logiciel d’IA générative.</p>"
               }
             },
@@ -302,6 +306,7 @@
               "element": {
                 "id": "90cd34bf-4182-4c72-ab1a-22ea98ab9c46",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>En revanche, pour que le logiciel d’IA générative réponde vraiment à ce que vous voulez, il faut être <strong>précis</strong>.</p><p><br>📌 <strong>Bon à savoir</strong></p><p>Une bonne façon d’être précis est d’utiliser des <strong>verbes d’action</strong> comme : « lister », « traduire », « résumer », etc.</p>"
               }
             }
@@ -317,6 +322,7 @@
               "element": {
                 "id": "1ad822c8-cf06-43b8-adf4-9acc12f22fff",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Dans certains cas, utiliser un verbe adapté ne suffit pas.😅 Il faut aussi donner des éléments qui décrivent le résultat que l’on veut obtenir. Voyons cela ensemble !</p>"
               }
             }
@@ -332,6 +338,7 @@
               "element": {
                 "id": "0a0f1cf5-3f03-448c-b551-93d51482ab33",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Cette fois-ci, Agnès organise un week-end yoga.</p><p> Elle veut épater les participants avec des plats végétariens mais elle ne sait pas quoi cuisiner.</p><p>Cliquez sur chaque prompt et observez la réponse du logiciel d’IA générative.</p>"
               }
             },
@@ -413,6 +420,7 @@
               "element": {
                 "id": "29fbfaf4-e1f9-4f19-9bbb-38f8a712e352",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>📌Une autre façon d’être précis est de donner au logiciel d’IA générative autant d’<strong>informations</strong> que possible. Cela donne du contexte.</p>"
               }
             }
@@ -491,6 +499,7 @@
               "element": {
                 "id": "ebd5d937-c04e-47da-98b2-7ddde874cb50",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Même si le prompt est clair et précis, et que la réponse paraît bien rédigée, un<strong> logiciel d’IA générative </strong>peut <strong>se tromper</strong>.😓 Il faut <strong>toujours&nbsp;</strong><strong>relire et vérifier la réponse</strong>.</p><p><br>💡<strong>Astuce</strong></p><p>On peut continuer la conversation avec un logiciel d’IA générative en lui envoyant un nouveau message pour <strong>ajuster ou corriger</strong> la réponse.</p>"
               }
             }
@@ -512,6 +521,7 @@
               "element": {
                 "id": "33210c11-0e87-4d93-9190-089654d57ee4",
                 "type": "text",
+                "tag": " ",
                 "content": "<ul><li>Un <strong>prompt </strong>(« instruction » ou « requête » en français) est une <strong>question</strong> que l’on pose ou une <strong>consigne</strong> que l’on donne au logiciel d’IA générative pour qu’il produise une réponse.</li><li>Un prompt s’écrit en <strong>langage courant.</strong>💬</li><li>Plus la <strong>demande </strong>est <strong>claire et précise</strong>, plus la <strong>réponse </strong>du logiciel d’IA générative sera <strong>adaptée et pertinente</strong>.🤓<br></li><li>Il est important de toujours <strong>relire la réponse</strong> <strong>du logiciel d’IA générative</strong>.🕵️</li><li>Si la réponse du logiciel d’IA générative ne convient pas, il faut <strong>reformuler</strong> <strong>son prompt</strong>.</li></ul>"
               }
             }
@@ -533,6 +543,7 @@
               "element": {
                 "id": "ae11054b-571a-4577-8554-c2731f729647",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Vous connaissez maintenant les règles de base pour formuler un prompt. À vous d’appliquer ces règles !🙌</p>"
               }
             }
@@ -548,6 +559,7 @@
               "element": {
                 "id": "3fe45d3e-1c1b-46f0-845d-0c2233d9e340",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Lisez attentivement les affirmations suivantes et indiquez, pour chacune d’elles, si elle est vraie ou fausse.</p>"
               }
             },
@@ -777,6 +789,7 @@
               "element": {
                 "id": "8508c24d-493a-499d-b336-6e8f61680b32",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Vous avez appris à parler avec un logiciel d’IA générative.👏 Maintenant, place à la pratique : voyons si vous pouvez obtenir la réponse souhaitée !</p>"
               }
             }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAInfox_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAInfox_NOV.json
@@ -32,6 +32,7 @@
               "element": {
                 "id": "07a6146e-c775-42f2-9d20-fbbfa7a37a32",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Dans la vidéo suivante, on peut voir un scientifique célèbre faire une annonce importante.</p>"
               }
             },
@@ -150,6 +151,7 @@
               "element": {
                 "id": "11c33b08-c95a-4cee-8026-e83dc7332913",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Les <strong>deepfakes</strong>, <strong>hypertrucages</strong> en français, sont créés grâce à <strong>l’intelligence artificielle, pour tromper.</strong> Ils sont réalistes.&nbsp;Pourtant, ils ne montrent pas la réalité.<strong>🤥 </strong></p><p>Comme les intelligences artificielles s'améliorent chaque jour, il est de <strong>plus en plus difficile de reconnaître un deepfake</strong> !😱</p>"
               }
             }
@@ -165,6 +167,7 @@
               "element": {
                 "id": "b49f6773-b8cc-48e9-92cd-12821f442dc4",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Pour être si réaliste, un deepfake doit demander beaucoup de compétences et de matériel à son créateur, non ? 🤔</p>"
               }
             }
@@ -180,6 +183,7 @@
               "element": {
                 "id": "42d51784-c0d0-4c68-953b-059ea9052e33",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Avec un logiciel d'intelligence artificielle, Caroline a créé une vidéo où elle chante une chanson à la manière de sa chanteuse préférée. 🎶</p><p> Caroline est étonnée&nbsp;: elle a donné<strong> seulement 3 éléments au logiciel d’intelligence artificielle</strong> pour créer la chanson.</p>"
               }
             },
@@ -213,6 +217,7 @@
               "element": {
                 "id": "cbe6027b-3113-4772-a81f-c44d381f9585",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Un <strong>deepfake</strong> peut être créé avec <strong>très peu de données</strong>&nbsp;: une photo et quelques phrases suffisent pour fabriquer une vidéo réaliste. 🗣️</p><p> ⚠️ Comme ils sont faciles à fabriquer, beaucoup de <strong>deepfakes circulent en ligne</strong>.</p><p>Facile à faire, ne veut pas dire permis : un deepfake peut être illégal.</p>"
               }
             }
@@ -228,6 +233,7 @@
               "element": {
                 "id": "346c8e4f-3e0c-4fdd-bd0a-be0ed2daa02d",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Pour quelles raisons les deepfakes sont-ils créés ? Découvrons-le ensemble.</p>"
               }
             }
@@ -243,6 +249,7 @@
               "element": {
                 "id": "b5da21e5-f012-4248-94a8-de57dadfd515",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Pour chaque exemple de deepfake, choisissez la bonne réponse.</p>"
               }
             },
@@ -387,6 +394,7 @@
               "element": {
                 "id": "d0540829-7feb-48c7-b621-fb99765d6720",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>😱 <strong>Les deepfakes</strong> peuvent servir à manipuler la population, arnaquer ou harceler : ces <strong>usages </strong>sont <strong>illégaux</strong> et <strong>dangereux</strong>.</p><p><br></p><p>Cependant, ils peuvent aussi être utilisés dans l’art ou le divertissement sans intention malveillante.</p><p>⚖️ Bon à savoir : même dans un cadre créatif ou humoristique, toute <strong>utilisation de l'image d'une personne sans son accord</strong> est <strong>interdite </strong>par la loi.</p>"
               }
             }
@@ -402,6 +410,7 @@
               "element": {
                 "id": "548e5653-0607-4020-be54-f318fd0aa092",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Les deepfakes sont difficiles à reconnaître et ils peuvent être créés dans un but malveillant. Mais, comment réagir quand on reçoit une vidéo, une image ou un son et qu’on a des doutes ?</p>"
               }
             }
@@ -417,6 +426,7 @@
               "element": {
                 "id": "46999db8-c96c-42e8-93ac-a558c72a55f2",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Djibril a reçu un message de Brian sur le groupe de parents de l'équipe de rugby de Jolieville. <br>Consultez le message puis répondez à la question.</p>"
               }
             },
@@ -495,6 +505,7 @@
                     {
                       "id": "d047d05c-d77c-490d-9dc6-d0fcc5252ba6",
                       "type": "text",
+                      "tag": " ",
                       "content": "<h5>🧐Que faire si vous recevez un média trop beau pour être vrai, choquant ou inquiétant ?</h5><p><strong>N’agissez pas trop vite : </strong>ne likez pas, ne partagez pas immédiatement. </p><p>C’est peut-être un <strong>deepfake !</strong></p>"
                     }
                   ]
@@ -504,6 +515,7 @@
                     {
                       "id": "7a82f038-3a9d-4b02-84c0-d48b7aed4a20",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>⚠️<strong>Partager un deepfake malveillant</strong> peut propager de&nbsp;<strong>fausses informations</strong>&nbsp;ou contribuer au&nbsp;<strong>cyberharcèlement</strong>&nbsp;d’une personne. </p><p>Cela peut aussi <strong>violer le droit à l’image</strong> et entraîner une <strong>plainte </strong><strong>contre vous</strong>.</p><p>🔎&nbsp;<strong>En cas de doute, ne partagez pas</strong> : vérifiez d’abord l’information et sa source.</p>"
                     }
                   ]
@@ -528,6 +540,7 @@
               "element": {
                 "id": "de260e53-8fc3-482c-94ba-7c43560306d9",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Un <strong>deepfake</strong> est un média hyperréaliste mais faux&nbsp;: il est créé grâce à l’intelligence artificielle.</p><ul><li>Il est souvent <strong>difficile à détecter.</strong> 🔎</li><li>Il demande peu de matériel et de compétences pour être créé. Voilà pourquoi <strong>beaucoup de deepfakes circulent en ligne.</strong> ⚠️</li><li>La plupart du temps, un deepfake est créé avec une <strong>intention malveillante</strong>&nbsp;: diffuser de fausses informations, cyberharceler, arnaquer ou manipuler. 🧠</li><li>Au moindre doute face à un média, il ne faut pas le partager immédiatement. <strong>Vérifiez</strong> d'abord sa source et sa fiabilité. ℹ️</li></ul>"
               }
             }
@@ -613,6 +626,7 @@
               "element": {
                 "id": "7c57b98b-0c92-4a53-a169-d83b453da813",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Et pour finir, voyons un cas pratique.</p>"
               }
             }
@@ -628,6 +642,7 @@
               "element": {
                 "id": "8bc86555-dd8a-4148-a37a-35e311c1c024",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><strong>Lisez l’article ci-dessous, puis répondez aux questions.</strong><br></p>"
               }
             },

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/NR-Datacenter-IND.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/NR-Datacenter-IND.json
@@ -32,6 +32,7 @@
               "element": {
                 "id": "3d7daa4f-885d-48eb-b20f-2c6be5b9c46e",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>En 2021, un centre de données à Strasbourg a pris feu en pleine nuit. </p>"
               }
             },
@@ -99,6 +100,7 @@
               "element": {
                 "id": "7c644dba-eb4a-479e-b826-bf63696092ee",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Bien qu’exceptionnel, cet incendie a rappelé à quel point nos usages numériques reposent sur des <strong>infrastructures physiques</strong>, qu’il est nécessaire de contrôler et de surveiller&nbsp;: les <strong>centres de données</strong>. Voyons concrètement à quoi ressemble un centre de données et comment tout est mis en place pour éviter ce type d’incident.</p>"
               }
             }
@@ -120,6 +122,7 @@
               "element": {
                 "id": "d24a7253-3d4d-4190-a093-57f82dfb4bbf",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Anna est directrice d’un centre de données et assure une visite exceptionnelle de ce lieu hautement sécurisé. </p>"
               }
             },
@@ -132,6 +135,7 @@
                     {
                       "id": "1f700f7f-c2ed-44ba-9266-c321c57bdcd0",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Pour rentrer dans le centre de données, on doit traverser des sas de sécurité, des portes blindées, des systèmes d’ouverture par empreinte digitale...&nbsp;</p><br>"
                     },
                     {
@@ -187,6 +191,7 @@
                     {
                       "id": "ec6c8d21-e7f2-4af0-a817-5aeab73ca6e7",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>On arrive dans la salle des serveurs.&nbsp;Ces armoires (également appelées «&nbsp;baies&nbsp;» ou «&nbsp;rack&nbsp;») contiennent les serveurs.</p>"
                     },
                     {
@@ -242,6 +247,7 @@
                     {
                       "id": "522aaa2f-023b-49c2-8ead-ffd9040c03c0",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Anna montre le système de refroidissement&nbsp;: une partie des installations de climatisation sont visibles à l’extérieur du bâtiment.</p>"
                     },
                     {
@@ -297,6 +303,7 @@
                     {
                       "id": "7b6d1a06-ab74-4839-8496-eca9e66a1b98",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Enfin, la visite se termine par la présentation du groupe électrogène.</p>"
                     },
                     {
@@ -365,6 +372,7 @@
                     {
                       "id": "aa4ceb37-21c7-42be-a322-09262f76ab48",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Vous l’aurez compris, tout est mis en place dans un centre de données pour que les serveurs tournent 24 heures sur 24, 7 jours sur 7.</p>"
                     }
                   ]
@@ -374,6 +382,7 @@
                     {
                       "id": "8f6df0cc-e134-405b-96ea-ae13a3599b1a",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p><strong>Et si, malgré toutes ces précautions, il y a une interruption de service ?</strong>&nbsp; </p><p>C’est peu probable. Pour garantir une disponibilité totale, le système est <strong>surdimensionné</strong>, c’est-à-dire qu’il est volontairement plus puissant que nécessaire. Cela permet d’anticiper les dysfonctionnements, les pannes ou les fortes demandes, appelées pics de charge.</p>"
                     }
                   ]
@@ -383,6 +392,7 @@
                     {
                       "id": "dfea77ef-d7c9-4b1d-a69d-320686efdfef",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p><strong>Malin, mais très consommateur d’énergie, non ?&nbsp;</strong> </p><p>Exactement. Surdimensionner le système signifie plus de matériel et donc plus d’énergie. ⚡<br><br></p>"
                     }
                   ]
@@ -401,6 +411,7 @@
               "element": {
                 "id": "729553c0-42a0-4a65-8453-878882b83f85",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Dans un centre de données, un élément est particulièrement gourmand en ressources&nbsp;: le système de refroidissement. Voyons pourquoi.<br></p>"
               }
             }
@@ -540,6 +551,7 @@
               "element": {
                 "id": "edbc9c1f-616e-4702-82c2-b282c887d5f0",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Nous l’avons vu, les systèmes de refroidissement consomment beaucoup d’électricité et beaucoup d’eau.&nbsp;<br><br></p><p><strong>De l’eau douce ?&nbsp;🚰</strong><br>Tout à fait, à l’échelle mondiale, ces milliards de litres d’eau prélevés ne sont alors plus disponibles pour les <strong>populations locales</strong> ou pour l’agriculture. Et comme certains centres de données sont construits dans des endroits du monde où l’eau est déjà rare, cela aggrave encore plus la situation. </p>"
               }
             }
@@ -555,6 +567,7 @@
               "element": {
                 "id": "5ce93311-9049-4136-b799-194134a0fb36",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Les centres de données ont donc un impact environnemental important. Mais comme nos activités deviennent de plus en plus numériques, le nombre de centres de données ne cesse d’augmenter.</p>"
               }
             }
@@ -662,6 +675,7 @@
                     {
                       "id": "c85af1e9-6a85-4541-9e3e-858ce12466c8",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>En 2025, on comptait plus de 12 000 centres de données dans le monde, ce qui représente 25% de la consommation d’énergie du numérique dans le monde. ⚡</p>"
                     }
                   ]
@@ -671,6 +685,7 @@
                     {
                       "id": "069b9b8e-43d0-43d3-bd38-18c57e2f0fc2",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p><strong>Et cette consommation d’énergie augmente ?&nbsp;</strong><br>Tout à fait ! L’usage grand public de l’IA générative est en train de faire <strong>exploser les besoins en énergie</strong> consommée par les centres de données. Selon l’Agence internationale de l’énergie,&nbsp;en 2030, ces besoins auront <strong>doublé </strong>par rapport à 2025. <br></p>"
                     }
                   ]
@@ -680,6 +695,7 @@
                     {
                       "id": "bdc0cdd2-c802-4a07-a3c4-fb08673c1ad4",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p><strong>Concrètement, face à cette accélération, des solutions sont possibles ?&nbsp;</strong> <br>Il est possible de limiter les impacts. En tant qu’utilisateur, il est important de garder en mémoire que certaines technologies sont bien plus gourmandes que d’autres, notamment l’intelligence artificielle générative en tête. Avoir un <strong>usage raisonné</strong> de ces technologies est un enjeu majeur. </p>"
                     }
                   ]
@@ -704,6 +720,7 @@
               "element": {
                 "id": "8c366312-52a5-4a3e-9db2-2174cb0745a5",
                 "type": "text",
+                "tag": " ",
                 "content": "<ul><li>Les centres de données sont des <strong>infrastructures</strong> complexes&nbsp;: équipements informatiques, systèmes de refroidissement, sécurisation, etc.&nbsp;🛡️<br><br></li><li>Afin d’assurer un service continu aux internautes, ils sont <strong>surdimensionnés</strong> pour anticiper certains dysfonctionnements ou pics de charge.&nbsp;⬆️<br><br></li><li>Le <strong>refroidissement</strong> des centres de données consomme de l’électricité et des milliards de litres d’eau à l’échelle mondiale.&nbsp;❄️<br><br></li><li>Les évolutions technologiques successives (streaming, stockage cloud, cryptomonnaie, objets connectés, IA générative) amènent à des <strong>usages toujours plus consommateurs d’énergie</strong>.&nbsp;⚡⚡</li></ul>"
               }
             }
@@ -725,6 +742,7 @@
               "element": {
                 "id": "51611126-0e12-40b1-a5ef-66db705a3b97",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Voyons si vous avez retenu l’essentiel.</p>"
               }
             },

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/NR-Datacenter-NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/NR-Datacenter-NOV.json
@@ -32,6 +32,7 @@
               "element": {
                 "id": "363fc96a-2479-43be-ac96-26c015882591",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Killian est dans la salle d’attente d’un médecin. Il y a plusieurs personnes autour de lui et l’ambiance est silencieuse. Pour rester discret, il&nbsp;envoie un message via une messagerie en ligne à son ami qui l’accompagne, assis juste à côté.</p>"
               }
             },
@@ -92,6 +93,7 @@
               "element": {
                 "id": "440d43e3-0b21-4116-91d4-25fad4bdd354",
                 "type": "text",
+                "tag": " ",
                 "content": "Maintenant, suivez le trajet des informations&nbsp;: où vont-elles, où sont-elles stockées, et comment sont-elles traitées ?"
               }
             }
@@ -113,6 +115,7 @@
               "element": {
                 "id": "7f4902af-d533-4031-88aa-c2f2c01f196b",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Killian est sur un réseau social. Il voit une publication qui lui plaît et appuie sur «&nbsp;J’aime&nbsp;». </p>"
               }
             },
@@ -184,6 +187,7 @@
                     {
                       "id": "d4368ba7-6bee-4cea-9a29-da36e934dbe1",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Dans les <strong>centres de données</strong>, on trouve des <strong>serveurs</strong>.</p><h5>🤔 Mais c’est quoi un serveur ?</h5><p><strong>Un serveur est un ordinateur très puissant.</strong> Quand vous utilisez internet, vous vous connectez à des serveurs&nbsp;: ils reçoivent vos demandes, traitent les informations et renvoient la réponse sur votre appareil.</p><p>Voici un exemple de salle de serveurs, à l’intérieur d’un centre de données.</p>"
                     },
                     {
@@ -202,6 +206,7 @@
                     {
                       "id": "01a90945-8314-4fcd-9a06-013424c40d99",
                       "type": "text",
+                      "tag": " ",
                       "content": "<h5>🤔 Pourquoi a-t-on besoin de centres de données aussi grands ?</h5><p>Sur internet, il y a <strong>énormément  d’informations échangées</strong>. Des millions de personnes <strong>utilisent les serveurs en même temps</strong>, partout dans le monde. </p>"
                     }
                   ]
@@ -220,6 +225,7 @@
               "element": {
                 "id": "0f1152d5-7aca-44d0-9515-1816c4991258",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Voyons ce qu’il se passe du côté du <strong>centre de données et des serveurs</strong> lorsqu’ils travaillent.</p>"
               }
             }
@@ -235,6 +241,7 @@
               "element": {
                 "id": "76cc3aac-e370-4ce2-a6cd-cc6dcc007c5a",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Les serveurs répondent aux demandes des utilisateurs connectés à internet.<br>Cliquez sur les icônes de température et d’énergie pour voir leur évolution en fonction du nombre de serveurs.</p>"
               }
             },
@@ -396,6 +403,7 @@
               "element": {
                 "id": "6d057f84-d3aa-4965-8552-9c6b55710c17",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Les serveurs sont nombreux et <strong>rangés au même endroit</strong>. Quand ils travaillent en continu, <strong>la chaleur s’accumule très vite</strong>. Sans refroidissement, ils peuvent s’abîmer voire être détruits. <strong>Ils doivent donc être refroidis en permanence</strong>. </p><h5>🤔 Le refroidissement consomme-t-il de l’énergie ? </h5><p>Oui. Le refroidissement utilise <strong>beaucoup d’électricité</strong>. Et certains systèmes utilisent aussi <strong>beaucoup d’eau</strong>.<br>Faire fonctionner les serveurs et les refroidir demande <strong>beaucoup d’énergie</strong>.</p>"
               }
             }
@@ -411,6 +419,7 @@
               "element": {
                 "id": "be64a075-5cfa-493d-be0b-6cdb99698cc3",
                 "type": "text",
+                "tag": " ",
                 "content": "Maintenant, <strong>comparons différents usages</strong>&nbsp;: lesquels font le plus travailler les serveurs, et pourquoi ?"
               }
             }
@@ -426,6 +435,7 @@
               "element": {
                 "id": "8b07744b-4b36-4bf0-9c39-d806a6987b64",
                 "type": "text",
+                "tag": " ",
                 "content": "Comme pour n’importe quel appareil électrique, certaines actions consomment plus d’énergie que d’autres. Sur internet, cela dépend de l’usage.<br>Pour chaque situation, indiquez l’action qui consomme le plus d’énergie côté serveurs."
               }
             },
@@ -587,6 +597,7 @@
                     {
                       "id": "a91021ec-28c2-47b3-97b0-aec23096593e",
                       "type": "text",
+                      "tag": " ",
                       "content": "<h5>🤔 Pourquoi certains usages font consommer davantage d’énergie aux serveurs ?<br></h5>Parce que ce qui est envoyé ou demandé (son, calculs, texte, vidéo...), ne demande pas la même quantité de travail au serveur."
                     }
                   ]
@@ -596,6 +607,7 @@
                     {
                       "id": "4e583f9f-7e9d-4951-9e5a-8ec19b014a4a",
                       "type": "text",
+                      "tag": " ",
                       "content": "<h5>🤔 On peut faire quelque chose pour faire moins consommer les serveurs ?</h5><p>Oui. Quand c’est possible, choisissez des usages qui <strong>consomment moins d’énergie</strong>.</p><p>Par exemple&nbsp;:&nbsp; </p><ul>    <li><strong>télécharger une musique</strong> que l’on écoute souvent <strong>au lieu de l’écouter en ligne</strong> à chaque fois ;</li>    <li>et parfois&nbsp;: <strong>se déconnecter </strong>quand on n’a plus besoin d’être en ligne.</li></ul>"
                     }
                   ]
@@ -620,6 +632,7 @@
               "element": {
                 "id": "065ea5c0-8fc9-4014-9c87-49133966943d",
                 "type": "text",
+                "tag": " ",
                 "content": "<ul>    <li>🗄️ Les informations consultées en ligne sont stockées, calculées et envoyées par des <strong>serveurs</strong>, eux-mêmes situés dans de grands bâtiments appelés <strong>centres de données</strong>.</li>    <li>⚡ <strong>Les serveurs consomment beaucoup d’énergie</strong>&nbsp;: ils sont toujours allumés, ils chauffent et il faut les refroidir en permanence.</li>    <li><strong>🔋Les serveurs consomment plus ou moins selon les usages en ligne</strong>&nbsp;: envoyer du texte demande peu de données et peu de calcul ; une vidéo ou une demande à une IA demandent beaucoup plus de travail.</li>    <li> <strong>🔌Il est possible d’agir</strong>&nbsp;: choisir des usages qui demandent moins de calculs et de données, ou se déconnecter, permet de réduire l’énergie utilisée.</li>    </ul>"
               }
             }
@@ -641,6 +654,7 @@
               "element": {
                 "id": "a266c379-06be-400f-b5b0-78e1bfd5c0d0",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Voyons si vous avez retenu l’essentiel.</p>"
               }
             },
@@ -978,6 +992,7 @@
               "element": {
                 "id": "b1145aa8-b189-4da7-98a3-59a06ef6401e",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Il existe des gestes très simples pour alléger la consommation électrique des serveurs, sans changer complètement vos habitudes.</p><p>   Voici trois idées faciles à tester cette semaine.</p>"
               }
             },

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/NR-Durabilite-AVA.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/NR-Durabilite-AVA.json
@@ -32,6 +32,7 @@
               "element": {
                 "id": "0f94e969-ccc9-40fb-9357-fc7db47aca4a",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Chaque année, plus d’un milliard de smartphones sont vendus dans le monde.</p>"
               }
             },
@@ -87,6 +88,7 @@
               "element": {
                 "id": "b463d10b-7b0e-403a-9ba2-d7fb5a4e9ef0",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Changer son matériel informatique a un impact environnemental fort. Voyons pourquoi.</p>"
               }
             }
@@ -108,6 +110,7 @@
               "element": {
                 "id": "5b3d3352-284f-4520-80a2-fecf99a6fc14",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Du minerai à la sortie d’usine, un appareil informatique traverse plusieurs phases successives&nbsp;: l’extraction des matières premières, la production des composants électroniques et l’assemblage final. Ces étapes s’appellent la <strong>fabrication</strong>.</p>"
               }
             },
@@ -261,6 +264,7 @@
               "element": {
                 "id": "80b90a55-683b-4627-8538-5da724524046",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>L’étape de fabrication des appareils numériques est très polluante. Elle consomme beaucoup de ressources, d’<strong>énergie</strong> et d’<strong>eau</strong>, tout en générant de <strong>fortes pollutions</strong> et des <strong>déchets industriels</strong>.<br><br>Fabriquer toujours plus de nouveaux appareils numériques contribue à accentuer un phénomène déjà présent&nbsp;: nous utilisons aujourd’hui <strong>plus de ressources naturelles</strong> que ce que la terre peut <strong>régénérer</strong>, <strong>fournir</strong> ou <strong>absorber</strong>.🌍</p>"
               }
             }
@@ -276,6 +280,7 @@
               "element": {
                 "id": "8773c280-9e0e-423d-a698-9043db500dd0",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Même si l’on est conscient de l’impact environnemental de la fabrication d’un nouvel appareil, garder ses appareils numériques plus longtemps n’est pas sans difficulté.</p>"
               }
             }
@@ -291,6 +296,7 @@
               "element": {
                 "id": "3c4e7e34-d4e4-43f9-ba12-386d413a7e56",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Voici Jeff. Il travaille dans une enseigne de vente de matériel informatique. Ce matin, plusieurs clients viennent demander conseil. </p>"
               }
             },
@@ -303,6 +309,7 @@
                     {
                       "id": "9d1ebcab-8f6d-475a-be06-6d388214c8de",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>«&nbsp;Depuis la dernière mise à jour du système d’exploitation, mon téléphone rame et la batterie se vide vite. Avant, tout allait bien !&nbsp;»</p>"
                     },
                     {
@@ -358,6 +365,7 @@
                     {
                       "id": "1dc7dcad-7cd0-439b-97bd-85a2fbb9d127",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>«&nbsp;Mon imprimante refuse d’imprimer. Elle affiche le message «&nbsp;cartouche vide&nbsp;» alors qu’il reste clairement de l’encre.&nbsp;»</p>"
                     },
                     {
@@ -413,6 +421,7 @@
                     {
                       "id": "d60b233d-a77e-4f31-bdef-dc12422d1741",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>«&nbsp;J’ai voulu changer la batterie de mon ordinateur, mais je me suis aperçu qu’elle est collée et je suis incapable de le faire. Pourquoi ?&nbsp;»</p>"
                     },
                     {
@@ -461,6 +470,7 @@
                     {
                       "id": "6b2a37f6-d0e0-4e15-81e5-13708f76a024",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>«&nbsp;J’ai un ancien modèle PixPhone44 acheté l’an dernier, il marche encore très bien, mais leur nouveau modèle a un nouvel écran bord à bord et un assistant vocal “plus intelligent”. À votre avis, ça vaut le coup de changer ?&nbsp;»&nbsp;</p>"
                     },
                     {
@@ -529,6 +539,7 @@
                     {
                       "id": "e2b5c3b2-bd52-485d-b5a2-5ab2c983493d",
                       "type": "text",
+                      "tag": " ",
                       "content": "<h5>Quel est le point commun entre tous ces exemples ?</h5><p>Certains fabricants usent de stratégies pour réduire délibérément la durée de vie des produits et ainsi pousser les consommateurs à acheter des produits neufs. Ce mécanisme porte un nom&nbsp;: l’<strong>obsolescence programmée.<br><br>🤔 Bon à savoir&nbsp;: </strong>Ce phénomène d’obsolescence existe aussi dans d’autres secteurs comme l’électroménager, la mode ou l’automobile. Ce phénomène est puni par la loi.</p>"
                     }
                   ]
@@ -538,6 +549,7 @@
                     {
                       "id": "dd7638c3-1e9e-4d37-8deb-96b03c33aab5",
                       "type": "text",
+                      "tag": " ",
                       "content": "<h5>Comment font les fabricants pour réduire la durée d'usage des produits ?</h5><p>Ils utilisent différentes stratégies&nbsp;:</p><ul><li>L’<strong>obsolescence technique</strong>.</li><li>L’<strong>obsolescence logicielle</strong>.</li><li>L’<strong>obsolescence psychologique (ou par effet de mode)</strong>. Cette stratégie est très puissante. 🧠</li></ul>"
                     }
                   ]
@@ -556,6 +568,7 @@
               "element": {
                 "id": "b2b94d0c-976d-4326-b5d4-b2fcd916f89b",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Alors, comment sortir du modèle «&nbsp;extraire, produire, consommer, jeter&nbsp;», également appelé système linéaire ?<br><br>En changeant de réflexe. Découvrons les autres gestes possibles.</p>"
               }
             }
@@ -571,6 +584,7 @@
               "element": {
                 "id": "8975a87a-3103-4b3c-ab41-3b9d585d619a",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Voici un schéma représentant différentes étapes de vie d’un produit. Quatre verbes ont été volontairement effacés et remplacés par les chiffres 1, 2, 3, 4.</p>"
               }
             },
@@ -754,6 +768,7 @@
                     {
                       "id": "12f35076-ff72-40f7-b41f-14a680bcb313",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>L’économie classique fonctionne de <strong>manière linéaire</strong>&nbsp;: on extrait, on produit, on consomme, puis on <strong>jette</strong>. 🚮 Chaque année, de nombreux appareils encore utilisables finissent à la poubelle. Ce sont autant d’occasions manquées de les réutiliser; autant de “trésors dans la poubelle”.</p>"
                     }
                   ]
@@ -763,6 +778,7 @@
                     {
                       "id": "967c7ce3-bb66-4b23-a3a1-c8ccf5f1ea00",
                       "type": "text",
+                      "tag": " ",
                       "content": "<h5>Alors, comment encourager des modèles plus durables ?</h5><p><strong>🔄 Réutiliser</strong>, <strong>réparer</strong>, <strong>réemployer</strong> et <strong>recycler</strong> sont des actions essentielles pour allonger la durée de vie des objets. Elles jouent un rôle clé dans une transition plus durable. </p><p>Mais l’économie circulaire ne suffit pas à elle seule. Certaines étapes, comme le recyclage, restent encore difficiles à mettre en œuvre à grande échelle et sont elles-mêmes énergivores. C’est pourquoi la priorité reste de <strong>réduire</strong> le nombre d’appareils numériques fabriqués&nbsp;: le meilleur déchet est celui que l’on ne produit pas.</p>"
                     }
                   ]
@@ -772,6 +788,7 @@
                     {
                       "id": "81d82353-d909-48c0-8791-732999302eab",
                       "type": "text",
+                      "tag": " ",
                       "content": "<h5>Y a-t-il des pistes de solution ?</h5><p>Oui&nbsp;: l’<strong>évolution de la loi</strong> est un levier important pour accompagner ce changement. De nombreux pays adoptent progressivement des règles pour encourager des produits plus durables et sanctionner les pratiques abusives. En France, par exemple, l’obsolescence programmée (technique ou logicielle) est <strong>interdite</strong> et un<strong> indice de réparabilité</strong> est désormais obligatoire sur les ordinateurs portables, afin d’aider les consommateurs à faire des choix plus responsables.</p>"
                     }
                   ]
@@ -796,6 +813,7 @@
               "element": {
                 "id": "fcffe15b-8162-4f23-bee7-aa81594b6e62",
                 "type": "text",
+                "tag": " ",
                 "content": "<ul><li>🌍 La <strong>fabrication des appareils numériques</strong> a des impacts environnementaux&nbsp;: émission de gaz à effet de serre, raréfaction des ressources métalliques précieuses, raréfaction de l’eau, pollution.<br><br></li><li>⏳ Les pratiques d’<strong>obsolescence</strong>, qu’elles soient technique, logicielle ou psychologique, <strong>raccourcissent la durée de vie réelle des appareils</strong>, ce qui augmente la demande en nouveaux équipements.<br><br></li><li>🔄 Réduire, réemployer, réparer et recycler à la place de jeter sont la base de l’<strong>économie circulaire</strong>, promouvant un modèle plus durable. <br><br></li><li>⚖️ Aujourd’hui, plusieurs pays mettent en place des <strong>dispositifs législatifs</strong> visant à encourager ces pratiques.</li></ul>"
               }
             }
@@ -872,6 +890,7 @@
                     {
                       "id": "784e5111-2234-4730-8cf4-c68b38dfb4ec",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Sélectionnez le <strong>type de stratégie </strong>mise en place pour réduire la durée de vie d’un appareil pour chacun des cas ci-dessous.</p>"
                     },
                     {
@@ -1034,6 +1053,7 @@
               "element": {
                 "id": "fcf77703-3fad-45ba-bf97-2ebd6e49c672",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Vous avez besoin d’un ordinateur portable. En consommateur averti, vous souhaitez réduire autant que possible votre empreinte écologique pour vous équiper. </p>"
               }
             },
@@ -1112,6 +1132,7 @@
               "element": {
                 "id": "5baa2fa9-a281-4e00-bf0f-008790c17132",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Sur les appareils numériques vendus en Europe, on peut voir des étiquettes “Energy” (sur les tablettes et smartphones) ou des étiquettes “indice de réparabilité” pour les ordinateurs portables. </p><p>Vous souhaitez acheter une nouvelle tablette et vous souhaitez comparer leurs caractéristiques.</p><p>Voici deux tablettes&nbsp;:</p>"
               }
             },

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/NR_Datacenter_AVA.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/NR_Datacenter_AVA.json
@@ -32,6 +32,7 @@
               "element": {
                 "id": "6395f495-5219-445d-9976-53710245da39",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Ces dernières années, le nombre de centres de données n’a fait qu’augmenter, et avec lui l’électricité consommée.</p><p><em>[A venir GIF - l’apparition de points pour les centres de données dans le temps]</em></p>"
               }
             },
@@ -105,6 +106,7 @@
               "element": {
                 "id": "1ec87fee-69c4-4062-8a25-89da3a479c2f",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>La <strong>construction </strong>d’un<strong> centre de données</strong> nécessite l’extraction de grandes quantités de <strong>métaux</strong> et&nbsp;de<strong> terres rares</strong>. Elle participe également à l’<strong>artificialisation des sols</strong>.</p><br><p>De plus, le centre de données consomme une grande quantité d’<strong>énergie</strong>&nbsp;et <strong>d’eau </strong>(pour son refroidissement) et génère de nombreux <strong>déchets</strong> toxiques.</p>"
               }
             },
@@ -232,6 +234,7 @@
                     {
                       "id": "755cd426-f67f-4d3c-b54f-9921d19a3d20",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>En plus de la consommation d’eau et de métaux, les centres de données consomment aussi de l’énergie et participent à l’artificialisaiton des sols.</p>"
                     },
                     {
@@ -294,6 +297,7 @@
               "element": {
                 "id": "16b59faf-6643-4a22-a2e2-55a664a2702d",
                 "type": "text",
+                "tag": " ",
                 "content": "La construction&nbsp;des<strong> centres de données</strong>&nbsp;et leur fonctionnement produisent des conséquences en cascade, qui contribuent au <strong>dérèglement climatique </strong>et à la <strong>dégradation</strong> de la <strong>biodiversité</strong>, des <strong>habitats </strong>et de la <strong>santé humaine</strong>."
               }
             },
@@ -321,6 +325,7 @@
               "element": {
                 "id": "b3276727-321b-4cb2-baa8-fa8483d36bc6",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Que peuvent faire les entreprises du numérique pour limiter ces impacts ?<br></p>"
               }
             }
@@ -336,6 +341,7 @@
               "element": {
                 "id": "27e0d4c8-ee6a-4b80-949e-1ca319d81a82",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Prenons l’exemple de Malo, concepteur de site web dans une entreprise.&nbsp;Il est en train d’améliorer un site existant.</p><p>Pour chaque action de Malo, quelle va être la conséquence sur la sollication des serveurs, et donc sur la consommation d’énergie des centres de données ?&nbsp;🤔</p>"
               }
             },
@@ -348,6 +354,7 @@
                     {
                       "id": "0ac5c76d-8698-40bf-9b6c-fd815931686c",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Malo choisit d’illustrer la page d’accueil avec une vidéo plutôt qu’avec une photo.</p>"
                     },
                     {
@@ -390,6 +397,7 @@
                     {
                       "id": "74fcdfad-ef31-48c6-be27-03c06cbc28f2",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Malo choisit de compresser les images présentes sur le site.</p>"
                     },
                     {
@@ -432,6 +440,7 @@
                     {
                       "id": "523a1d70-ea60-498a-be0a-554d14e2907c",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Malo choisit d’activer la lecture automatique des vidéos, c’est-à-dire qu’à la fin d’une vidéo, une autre est lancée automatiquement sans action de l’utilisateur.</p>"
                     },
                     {
@@ -474,6 +483,7 @@
                     {
                       "id": "420482f8-f04b-441a-a8ed-9146b4787a71",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Malo se rend compte que le forum du site web a très peu d’activité.<br>Comme le forum est peu utilisé, il décide de le supprimer.</p>"
                     },
                     {
@@ -529,6 +539,7 @@
                     {
                       "id": "b56c9059-13a2-4357-b80d-63614674f3b9",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Malo a donc parfois contribué à solliciter davantage les serveurs, mais parfois il a permis de réduire leur charge.<br></p>"
                     }
                   ]
@@ -538,6 +549,7 @@
                     {
                       "id": "d6f9a801-28d5-4b2e-80c5-95e1ab4abaa1",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>On appelle pratiques d’<strong>éco-conception</strong> l’ensemble des pratiques visant à <strong>réduire l’empreinte environnementale</strong>&nbsp;tout au long du cycle de vie d’un logiciel ou d’un produit&nbsp;: conception, développement, utilisation et fin de vie.</p>"
                     }
                   ]
@@ -547,6 +559,7 @@
                     {
                       "id": "b2328855-4a62-4909-b3cd-dd89682f43c2",
                       "type": "text",
+                      "tag": " ",
                       "content": "<h5>Mais ces pratiques d’éco-conception sont-elles appliquées ?</h5><p> Elles sont encore peu utilisées. Cependant, la prise de conscience progresse&nbsp;: de récents labels et référentiels poussent les entreprises à s’y intéresser.<br></p>"
                     }
                   ]
@@ -565,6 +578,7 @@
               "element": {
                 "id": "6379f16a-320d-4217-8b85-e5190f6bc29b",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Mais, il n’y a pas que les concepteurs de site web qui peuvent agir.&nbsp;Il y a aussi les concepteurs des centres de données. Que peuvent-ils faire ?</p>"
               }
             }
@@ -580,6 +594,7 @@
               "element": {
                 "id": "f1f75637-b690-46b1-b8c9-dde14fe6ae09",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Dona travaille dans une entreprise qui conçoit des centres de données. <br>Elle anime une réunion avec son équipe pour trouver des pistes de solutions pour réduire les impacts environnementaux des futurs centres de données.<br></p>"
               }
             },
@@ -836,6 +851,7 @@
                     {
                       "id": "f7ede699-b068-472c-8c35-dd9ea5049edf",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Il existe donc plusieurs<strong> pistes de solutions techniques</strong> pour améliorer le coût environnemental des centres de données.</p><h5><br>Donc, le problème va bientôt être résolu ?</h5><p>\tCe n’est pas si simple. <br>Il est très <strong>difficile d’évaluer les apports</strong> de certaines solutions du fait de la multitude d’impacts. Une solution plus économe en énergie peut être plus coûteuse en eau.&nbsp;Aucune solution n’est parfaite.&nbsp;🤔<br>Et une conception <strong>plus responsable</strong> peut entraîner des <strong>coûts économiques</strong> importants. 💶<br></p>"
                     }
                   ]
@@ -845,6 +861,7 @@
                     {
                       "id": "75e9088f-97d4-45de-8631-5a84e7399b08",
                       "type": "text",
+                      "tag": " ",
                       "content": "<h5>Alors, comment inciter les acteurs du numérique à adopter des pratiques plus vertueuses ?</h5><p>La <strong>loi </strong>joue un rôle important pour encourager ces changements de pratiques.&nbsp;<br>Depuis 2019, un <strong>règlement de l’Union européenne</strong> définit des exigences d’<strong>éco-conception</strong> applicables aux exploitants de <strong>centres de données</strong>.&nbsp;♻️</p>"
                     },
                     {
@@ -875,6 +892,7 @@
               "element": {
                 "id": "8dde623f-d573-4782-925b-f3c0e50bf780",
                 "type": "text",
+                "tag": " ",
                 "content": "<ul><li><strong>📈L’essor continu des usages numériques</strong>, amplifié par l’IA générative, entraîne une forte <strong>croissance des centres de données</strong> et de leurs<strong> impacts environnementaux</strong>. <br></li><li>📉En tant que concepteur de services numériques, <strong>réduire la sollicitation des centres de données</strong> est un geste efficace. <br></li><li>💡Il existe des <strong>pistes de solutions techniques </strong>pour réduire les impacts environnementaux des centres comme l’optimisation du fonctionnement des systèmes de refroidissement ou l’adoption d’énergie renouvelable.<br></li><li>⚖️ La <strong>législation </strong>joue un rôle important pour <strong>encourager </strong>les différents acteurs du numérique à adopter des <strong>pratiques plus vertueuses. </strong></li></ul>"
               }
             }
@@ -896,6 +914,7 @@
               "element": {
                 "id": "39d231e6-08e4-4db5-8acc-601dc4a0c8e1",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Voyons voir si vous avez retenu l’essentiel.</p><p><br></p>"
               }
             }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/NR_Evaluation_IND.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/NR_Evaluation_IND.json
@@ -32,6 +32,7 @@
               "element": {
                 "id": "7576ec94-72fd-49e6-b4ba-c3f106e8154e",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Voici une discussion entre Fred et Ombeline qui cherchent à savoir si leur utilisation du numérique est responsable.</p>"
               }
             },
@@ -87,6 +88,7 @@
               "element": {
                 "id": "b4e9a6c2-7d1f-4b3e-8a5c-0f9d2e6c1b88",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Pour s’y retrouver, le plus simple est de comprendre d’abord ce que recouvre exactement <strong>«&nbsp;le numérique&nbsp;»</strong>. Découvrons de quoi il se compose dans notre quotidien.</p>"
               }
             }
@@ -108,6 +110,7 @@
               "element": {
                 "id": "1e4b7c8a-9f0d-4a3e-b2c5-6d1f9e8a0b99",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Avant de mesurer les impacts environnementaux du numérique, il faut savoir de quoi l’on parle.</p><p>On distingue généralement&nbsp;<strong>trois grandes familles&nbsp;: les équipements des utilisateurs, les réseaux et les centres de données.</strong></p><p>Dans l’activité suivante, classez chaque élément selon <strong>son rôle principal</strong> dans le fonctionnement du numérique.</p>"
               }
             },
@@ -138,6 +141,7 @@
                     {
                       "id": "a1400c7a-2e2e-470c-8a5e-8ea34441d423",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>On vient d’identifier ce qui compose le numérique&nbsp;: <strong>les équipements, les réseaux et les centres de données</strong>. <br>Les chiffres que vous pouvez voir sur les impacts environnementaux du numérique proviennent d’<strong>études scientifiques</strong>. Pour bien les comprendre, <strong>il faut savoir précisément ce que ces études prennent en compte</strong>.</p><h5><strong>🤔</strong> Pourquoi faut-il définir précisément le périmètre d’une étude&nbsp;?</h5><p>Parce qu’une étude doit dire clairement <strong>ce qu’elle prend en compte</strong> et <strong>ce qu’elle ne prend pas en compte</strong>. On ne peut pas tout mesurer. Sans connaître précisément ce qui est étudié, les résultats sont difficiles à comprendre ou à comparer.</p>"
                     }
                   ]
@@ -147,6 +151,7 @@
                     {
                       "id": "e4841527-8dc3-45de-b59d-84795cb7912b",
                       "type": "text",
+                      "tag": " ",
                       "content": "<h5>🤔 Un exemple dans le numérique&nbsp;?</h5><p>Deux études peuvent donner des résultats différents si elles ne prennent pas en compte le même périmètre. Par exemple, l’une peut étudier seulement les équipements des utilisateurs, tandis qu’une autre inclut aussi les réseaux et les centres de données.</p><p><strong>Les résultats varient donc selon ce qui est inclus dans l’étude.</strong></p>"
                     }
                   ]
@@ -165,6 +170,7 @@
               "element": {
                 "id": "67c0f575-419e-4d3f-b872-ebc3aa9ba9ea",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Les différents éléments qui composent le numérique n’ont pas le même poids et ne produisent pas les mêmes effets sur l’environnement. Pour mieux les comparer, examinons maintenant <strong>la méthode la plus utilisée pour évaluer ces effets</strong>.</p>"
               }
             }
@@ -180,6 +186,7 @@
               "element": {
                 "id": "7262fc2e-baa1-451c-b039-2c64a7ac8376",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Quand vous utilisez un appareil numérique, vous ne voyez qu’une petite partie de ses impacts sur l’environnement. Une grande partie de ces impacts se produit avant et après l’usage&nbsp;: extraction de ressources, fabrication, transports…</p>"
               }
             },
@@ -313,6 +320,7 @@
               "element": {
                 "id": "5523c5df-0559-42e0-a7c2-d8a695962c10",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Cette méthode d’analyse oblige à regarder toutes les étapes de la vie d’un appareil&nbsp;: fabrication, usage, transport, fin de vie… même si certaines sont peu documentées. Elle est appelée l’<strong>Analyse du Cycle de Vie (ACV)</strong>.<br><br></p><h5>🤔 Pourquoi cette méthode est-elle importante ?</h5><p>Parce qu’elle suit des règles internationales&nbsp;: même protocole, mêmes indicateurs. Cela aide à repérer <strong>les étapes qui contribuent le plus à l’impact environnemental</strong>, et donc où des améliorations sont possibles.</p>"
               }
             }
@@ -328,6 +336,7 @@
               "element": {
                 "id": "b4c10c8f-76f9-4e09-b64a-d049bef9c047",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>L’analyse du cycle de vie (ACV) est la méthode utilisée pour étudier un équipement de manière cohérente, à chaque étape de sa vie. Reste une question centrale&nbsp;: quels impacts mesurer ? Les indicateurs sont multiples&nbsp;: climat, ressources, santé… Ils ne renvoient pas aux mêmes effets sur l’environnement.</p>"
               }
             }
@@ -533,6 +542,7 @@
                     {
                       "id": "e9db72b8-cede-469f-b334-4de359561e03",
                       "type": "text",
+                      "tag": " ",
                       "content": "<h5>🤔 Pourquoi les études ne se contentent-elles pas d’un seul indicateur ?</h5>Parce que le numérique a divers impacts sur l’environnement.<br>"
                     }
                   ]
@@ -542,6 +552,7 @@
                     {
                       "id": "ad88b67b-755d-4a36-b480-e479146811fb",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Voici un tableau récapitulatif des principaux indicateurs utilisés pour évaluer les impacts environnementaux du numérique.</p><table>    <caption class=\"sr-only\">Résumé simplifié des indicateurs d’impact environnemental</caption>    <thead>        <tr>            <th scope=\"col\">Indicateur mesuré</th>            <th scope=\"col\">Ce qui est quantifié</th>            <th scope=\"col\">Effet environnemental associé</th>        </tr>    </thead>    <tbody>        <tr>            <th scope=\"row\">Émissions de gaz à effet de serre </th>            <td>Quantité totale de gaz à effet de serre émise</td>            <td>Contribution au réchauffement climatique</td>        </tr>        <tr>            <th scope=\"row\">Consommation de ressources minérales et métalliques </th>            <td>Quantité de métaux et minerais non renouvelables extraits pour fabriquer les équipements</td>            <td>Épuisement des ressources naturelles</td>        </tr>        <tr>            <th scope=\"row\">Émissions de particules fines </th>            <td>Quantité de particules fines émises dans l’air </td>            <td>Impacts sur la santé respiratoire et cardiovasculaire</td>        </tr>    </tbody></table>"
                     }
                   ]
@@ -551,6 +562,7 @@
                     {
                       "id": "93427470-f189-47b7-bfa6-d2ad80ac9686",
                       "type": "text",
+                      "tag": " ",
                       "content": "<h5>🤔Ces résultats prédisent-ils l’avenir ?</h5><p>Non. Ils décrivent une situation à un instant donné. Les indicateurs peuvent évoluer, mais <strong>sans action</strong>, les impacts du numérique vont continuer d’augmenter.</p>"
                     }
                   ]
@@ -575,6 +587,7 @@
               "element": {
                 "id": "ed97ea10-9ed8-4c2d-ad35-35c528d3d08d",
                 "type": "text",
+                "tag": " ",
                 "content": "<ul>    <li>Le numérique s’appuie sur <strong>trois grandes composantes</strong>&nbsp;: les équipements des utilisateurs, les réseaux et les centres de données. 🧩</li>    <li>Pour mesurer les impacts, on utilise l’<strong>Analyse du Cycle de Vie (ACV)</strong>, qui prend en compte <strong>la fabrication, le transport, l’utilisation et la fin de vie</strong>. 🔍</li>    <li>Pour comparer les impacts, il faut définir un <strong>périmètre</strong> clair et lire les résultats en précisant <strong>l’indicateur choisi</strong>, car chaque indicateur renvoie à un <strong>type d’impact</strong> (climat, ressources, santé…). 📏</li>    <li>La mesure de ces impacts varie selon l’indicateur, le périmètre et les usages&nbsp;: <strong>les équipements concentrent souvent la plus grande part des impacts</strong>, mais <strong>les réseaux et les centres de données</strong> comptent aussi (et peuvent être sous-estimés). 🔄</li>    </ul>"
               }
             }
@@ -596,6 +609,7 @@
               "element": {
                 "id": "00a60201-eed2-47cc-89c9-625a92b64d41",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Voyons si vous avez retenu l’essentiel.</p>"
               }
             },
@@ -668,6 +682,7 @@
               "element": {
                 "id": "f0ee88fb-f1d9-4c04-afed-01ddc6e76ab2",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Le chiffre ci-dessous est souvent repris dans les médias&nbsp;:</p><blockquote>«&nbsp;Le numérique représente environ 4 % des émissions mondiales de gaz à effet de serre.&nbsp;»</blockquote>"
               }
             },

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/NR_durabilite_Nov.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/NR_durabilite_Nov.json
@@ -31,6 +31,7 @@
               "element": {
                 "id": "c10b8f57-a99c-4af0-8515-838ad3eae5d1",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Qu’est-ce que vous avez dans la main quand vous tenez votre smartphone ?</p><p>Survolez l’image pour découvrir les matériaux qui composent un smartphone.</p>"
               }
             },
@@ -64,6 +65,7 @@
               "element": {
                 "id": "fcd9b050-fd47-4fb3-ac15-5ace364815c3",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Un smartphone se compose de <strong>plus de 70 matériaux différents</strong>, et plus de la moitié sont des <strong>métaux</strong> ! Voyons ça de plus près.</p>"
               }
             }
@@ -145,6 +147,7 @@
               "element": {
                 "id": "49b9c73e-e2d7-45f7-8d4c-cbe33219ebdb",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Certains métaux utilisés pour fabriquer les smartphones sont précieux, comme l’or et l’argent. On les trouve en très petite quantité dans le sol. Il faut donc extraire des tonnes de roche pour les récupérer, ce qui pose plusieurs problèmes :</p><ul> <li> Leur <strong>extraction pollue beaucoup</strong> dans les mines et aux alentours. </li> <li> Leur extraction nécessite <strong>beaucoup d’eau douce</strong>, qui n'est donc plus disponible pour l’agriculture et les populations locales. </li> <li> Les <strong>conditions de travail</strong> dans les mines sont souvent difficiles. </li> </ul> "
               }
             }
@@ -160,6 +163,7 @@
               "element": {
                 "id": "065435d0-7dca-4a4b-9c0e-7c9fce5ff797",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>On sait désormais d’où viennent certains matériaux. Mais où vont-ils avant d’arriver dans nos mains ? Découvrons-le ensemble.</p>"
               }
             }
@@ -331,6 +335,7 @@
               "element": {
                 "id": "678c96f8-8acc-46eb-97b0-3dc610bb5d8e",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Les différentes étapes de fabrication d’un smartphone se font dans <strong>plusieurs pays</strong>, souvent très éloignés. Les matériaux doivent donc être <strong>transportés par camion, train ou avion</strong>. Ces transports polluent et consomment beaucoup d’énergie, ce qui libère des gaz à effet de serre.</p>"
               }
             }
@@ -346,6 +351,7 @@
               "element": {
                 "id": "7532844f-4f8c-46bb-a3cf-ccbf7ef63e9d",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>La fabrication d’un smartphone est donc polluante. Mais que peut-on faire, à notre échelle, pour réduire ces impacts ?</p>"
               }
             }
@@ -447,6 +453,7 @@
               "element": {
                 "id": "c08cdadc-1fbc-4e9e-bf46-ebef6e73a2d7",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>La meilleure chose à faire est de <strong>garder son smartphone le plus longtemps possible</strong>. Comment y arriver ? </p><ul><li><strong>prendre soin</strong> (protéger l’écran, éviter la surchauffe, le débrancher une fois chargé, le recharger avant que la batterie soit trop faible).</li><li><strong>résister aux effets de mode </strong>et aux nouvelles fonctionnalités qui donnent envie de changer de téléphone.</li><li>le <strong>réparer</strong> quand c’est possible et pas trop cher.</li></ul>"
               }
             }
@@ -462,6 +469,7 @@
               "element": {
                 "id": "63b608dc-ce5b-468d-8c37-b9eaa9b3d469",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Parfois, le smartphone ne répond plus à nos besoins. Quels gestes adopter si on achète un nouveau modèle ?</p>"
               }
             }
@@ -481,6 +489,7 @@
                     {
                       "id": "f8126634-8250-49d3-b599-07e380e0c1a2",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Jane a un modèle d’il y a 5 ans. Elle décide d’acheter le smartphone Univers 13. Que doit-elle&nbsp; faire avec son ancien portable ? </p>"
                     }
                   ]
@@ -557,6 +566,7 @@
                     {
                       "id": "da5b7905-7192-43d5-a7e5-7a196ea69a48",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Parfois, vous pouvez être <strong>obligés de changer de téléphone</strong> car il ne permet plus de faire ce dont vous avez besoin, ou qu'il est cassé mais impossible à réparer.</p>"
                     }
                   ]
@@ -566,6 +576,7 @@
                     {
                       "id": "2cb2eb55-f652-4003-9706-5a79cb427db0",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Si votre ancien smartphone fonctionne encore, il pourrait servir à quelqu'un d'autre. Pensez donc à <strong>le donner</strong> ou <strong>le vendre</strong>, ne le gardez pas dans un tiroir !</p>"
                     }
                   ]
@@ -575,11 +586,13 @@
                     {
                       "id": "d96098f4-08a5-4317-b1f4-7b79fd1b45a0",
                       "type": "text",
+                      "tag": " ",
                       "content": "Si votre ancien smartphone ne <strong>fonctionne plus</strong>, alors ne le jetez pas dans une poubelle quelconque !"
                     },
                     {
                       "id": "f1b636f3-4a9a-41df-adb4-7d3120b7fdb7",
                       "type": "text",
+                      "tag": " ",
                       "content": "Sur les smartphones, et la plupart des appareils électroniques, on trouve <strong>ce logo</strong> :"
                     },
                     {
@@ -598,11 +611,13 @@
                     {
                       "id": "697ffc30-66c1-4169-ae5b-305e1a26109e",
                       "type": "text",
+                      "tag": " ",
                       "content": "Il indique qu'ils ne doivent <strong>pas être jetés dans une poubelle classique</strong>. En effet, certains composants dégagent des fumées toxiques s'ils sont incinérés comme les déchets classiques."
                     },
                     {
                       "id": "46925f16-03eb-4911-93f4-7ddc7e6af4ee",
                       "type": "text",
+                      "tag": " ",
                       "content": "La bonne chose à faire est donc de <strong>déposer votre smartphone dans un point de collecte spécialisé</strong> pour que les composants soient récupérés ou recyclés."
                     }
                   ]
@@ -621,6 +636,7 @@
               "element": {
                 "id": "a38ed311-0b93-4b45-a1d7-94390e2b6c93",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Désormais, vous savez qu’utiliser un smartphone a des impacts, mais aussi qu’il est possible de les réduire avec de bons gestes.</p>"
               }
             }
@@ -642,6 +658,7 @@
               "element": {
                 "id": "84230031-3337-4598-9a01-971e1b8c8c47",
                 "type": "text",
+                "tag": " ",
                 "content": "<ul>\n    <li>😱 Un smartphone est composé de nombreux matériaux différents. Leur extraction est souvent très polluante et réalisée dans de <strong>très mauvaises conditions de travail</strong>.</li>\n    <li>✈️ Les étapes de fabrication d'un smartphone ont lieu sur des continents différents, ce qui nécessite beaucoup de <strong>transports</strong>, donc émet beaucoup de <strong>gaz à effet de serre</strong>.</li>\n    <li>💡 Pour limiter l’impact d’un smartphone, le plus important est qu'il soit <strong>utilisé le plus longtemps possible</strong>. Pour cela on peut :\n        <ul>\n            <li>en prendre soin, le protéger</li>\n            <li>le faire réparer s'il est cassé</li>\n            <li>le donner ou le vendre plutôt que le jeter où l'abandonner</li>\n        </ul>\n    </li>\n    <li>♻️ S'il ne marche plus, il faut le déposer dans un <strong>point de collecte</strong> pour que les composants soient <strong>recyclés</strong> ou <strong>réutilisés</strong>.</li>\n</ul><br>"
               }
             }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/NR_surequipement_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/NR_surequipement_NOV.json
@@ -32,6 +32,7 @@
               "element": {
                 "id": "72b66795-8050-4a97-903c-c3a4f0545efa",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Pour commencer, prenez une minute pour compter le nombre d’appareils numériques que vous avez chez vous.&nbsp;</p>"
               }
             },
@@ -40,6 +41,7 @@
               "element": {
                 "id": "164812ba-d74a-42d3-8e4a-023b3849a086",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><em>Note à la relecture&nbsp;: il s’agit d’une version brouillon avant développement</em><br></p>"
               }
             },
@@ -66,6 +68,7 @@
               "element": {
                 "id": "469a2f43-5a8a-430e-a764-427949416a95",
                 "type": "text",
+                "tag": " ",
                 "content": "En Europe et en Amérique du Nord, beaucoup de foyers possèdent plus d’équipements numériques qu’ils n’en ont réellement besoin. On parle alors de <strong>suréquipement</strong>. Cela signifie que nous accumulons des appareils numériques, parfois en plusieurs exemplaires, sans que cela soit indispensable.<br><br>Essayons de comprendre comment cela se produit. Pourquoi avons-nous autant d’appareils numériques ?<br><br>"
               }
             }
@@ -87,6 +90,7 @@
               "element": {
                 "id": "5f6de37f-8bfc-439e-b01e-05f2c139fef1",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Observons ensemble quelques situations pouvant mener au suréquipement et les conseils que l’on pourrait donner pour éviter cela.<br></p>"
               }
             },
@@ -99,6 +103,7 @@
                     {
                       "id": "de37f1db-372e-4860-9298-8c3a9e458c26",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Suivons Thelma dans son quotidien.<br>Elle vient de changer d’ordinateur portable. Son ancien ordinateur ne fonctionne plus du tout. </p>"
                     },
                     {
@@ -147,6 +152,7 @@
                     {
                       "id": "1f1a69cd-c0f2-4a53-a706-26b0e0f1a4a1",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Thelma écoute tous les jours de la musique avec ses écouteurs sans fil. Elle hésite à acheter de nouveaux écouteurs sans fil spécial course à pied.</p>"
                     },
                     {
@@ -195,6 +201,7 @@
                     {
                       "id": "87e384e8-973d-4511-a414-407139220657",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Thelma a acheté un smartphone il y a un an. Il fonctionne correctement et répond toujours à ses besoins. Son amie lui conseille pourtant d’acheter le nouveau modèle, avec sa fonction zoom ultra puissante.<br></p>"
                     },
                     {
@@ -256,6 +263,7 @@
                     {
                       "id": "bb19fc33-491a-4137-bfb0-a53644cf0fbc",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Garder un appareil qui ne fonctionne plus ou acheter un nouvel appareil sans se séparer de l’ancien&nbsp;: voici des pratiques qui peuvent mener à terme à du <strong>suréquipement</strong>.</p>"
                     }
                   ]
@@ -265,6 +273,7 @@
                     {
                       "id": "67555459-2141-4e50-aec5-f4e2f9960c47",
                       "type": "text",
+                      "tag": " ",
                       "content": "<h5> <strong>En quoi est-ce un problème ?</strong></h5><p>Multiplié par des millions de foyers à travers le monde, ce surplus crée un volume énorme d’équipements&nbsp;: plus de 30 milliards d’appareils numériques dans le monde.<br><br></p><h5><strong>Et quel est l’impact de ce suréquipement ?&nbsp;</strong></h5><p>La fabrication de tous ces appareils nécessite des ressources et provoque des pollutions. Par la suite, leur utilisation consomme beaucoup d’énergie.&nbsp;⚡</p>"
                     }
                   ]
@@ -283,6 +292,7 @@
               "element": {
                 "id": "c8cf204c-0bfe-436b-b143-466b68cb2de0",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Voyons justement comment tous ces appareils consomment au quotidien.&nbsp;</p>"
               }
             }
@@ -298,6 +308,7 @@
               "element": {
                 "id": "e7d57805-5b49-4985-ab2b-db15937ebb43",
                 "type": "text",
+                "tag": " ",
                 "content": "Voici le salon de Corentin. En ce moment même, personne n’utilise les différents appareils numériques de son salon. Pourtant, ces appareils consomment ! <br><br><strong>Cliquez</strong> sur les différents appareils numériques pour découvrir leur consommation."
               }
             },
@@ -397,6 +408,7 @@
               "element": {
                 "id": "c5844909-96c2-48f0-8af0-382931ae2365",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>👀 Prenez le temps de cliquer sur tous les éléments.<br></p>"
               }
             },
@@ -445,6 +457,7 @@
               "element": {
                 "id": "28c33c92-ee3e-4b5b-ac60-3f3a63217b5d",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Chez soi, de nombreux appareils restent branchés en permanence&nbsp;: box internet, télévision, console de jeux, objets connectés…&nbsp;<br><br>Ces équipements consomment de l’électricité lorsqu’ils sont utilisés ou en charge, mais aussi… <strong>lorsqu’ils sont en veille</strong>. On parle alors de <strong>consommation statique</strong>&nbsp;: un gaspillage souvent sous-estimé.<br></p>"
               }
             }
@@ -460,6 +473,7 @@
               "element": {
                 "id": "06d0c6c7-325b-4209-9fa4-5dcad60fcf1a",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Pour réduire votre consommation, certains gestes sont possibles.&nbsp;⚡</p>"
               }
             }
@@ -475,6 +489,7 @@
               "element": {
                 "id": "b8e34139-377f-48df-b750-4b40d8a8fcf2",
                 "type": "text",
+                "tag": " ",
                 "content": "Divin aimerait réduire sa consommation électrique. À chaque situation, aidez Divin à faire le choix le moins consommateur d’électricité.&nbsp;"
               }
             },
@@ -602,6 +617,7 @@
                     {
                       "id": "2782a46c-aaac-445c-b588-ef1d25ae552c",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Pour limiter sa consommation électrique, l’un des réflexes à garder en tête&nbsp;est de&nbsp;<strong>débrancher</strong>&nbsp;et/ou <strong>éteindre</strong> complètement l’appareil. On évite ainsi que l’appareil consomme inutilement.&nbsp;🔌</p>"
                     }
                   ]
@@ -611,6 +627,7 @@
                     {
                       "id": "5d4b20c7-0eb5-4cfa-b9ff-0c57de69fa8d",
                       "type": "text",
+                      "tag": " ",
                       "content": "<h5><strong>Et lorsque l’on utilise nos appareils ?</strong></h5><p><strong><br></strong>Quelques gestes simples peuvent aider à limiter la consommation d’électricité. Il est possible par exemple de réduire la luminosité de l’écran quand cela est possible. On peut également éviter de laisser plusieurs appareils numériques allumés en même temps si on ne les utilise pas tous.&nbsp;</p>"
                     }
                   ]
@@ -635,6 +652,7 @@
               "element": {
                 "id": "a60794da-ef3b-4850-b058-2717382e1a08",
                 "type": "text",
+                "tag": " ",
                 "content": "<ul><em>À noter à la relecture&nbsp;: sera (sûrement) transformé en infographie.<br></em><br><li>Aujourd’hui, le <strong>suréquipement</strong> est réel. De nombreux foyers achètent et stockent plus d’appareils numériques qu’ils n’en ont vraiment besoin.<br><br></li><li> Fabriquer et utiliser autant d’appareils numériques a un coût environnemental fort.&nbsp;🌍<br><br></li><li>Vos appareils consomment même quand vous ne les utilisez pas. La <strong>veille&nbsp;</strong>notamment crée une consommation électrique souvent&nbsp;<strong>sous-estimée</strong>. ⚡<br><br></li><li>Pour réduire cette consommation d’énergie, il est possible d’adopter de bons réflexes&nbsp;: limiter son équipement à son <strong>juste besoin</strong>, <strong>éteindre</strong> ou <strong>débrancher</strong> ses appareils inutilisés.&nbsp;🔌</li></ul>"
               }
             }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/adresse-ip-publique-et-vous.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/adresse-ip-publique-et-vous.json
@@ -32,6 +32,7 @@
               "element": {
                 "id": "771ff16f-3476-4e3d-88c2-e24c799b2e9c",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Lorsque vous naviguez sur internet, un site peut connaître la ville où vous vous trouvez même si vous ne lui avez pas partagé votre localisation.<span aria-hidden=\"true\">📍</span><br>Mystère ? Pas vraiment. Commençons par un exemple.</p>"
               }
             }
@@ -47,6 +48,7 @@
               "element": {
                 "id": "67b68f2a-349d-4df7-90a5-c9f5dc930a1a",
                 "type": "text",
+                "tag": " ",
                 "content": "<p> Voici la page de résultats d'une recherche en ligne de Mélanie, qui adore cuisiner. <span aria-hidden=\"true\">🥗</span><br>Observez cette image pour répondre aux questions suivantes.</p>"
               }
             },
@@ -152,6 +154,7 @@
               "element": {
                 "id": "affd2fb6-035d-4a41-a736-235cb8e9367a",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>L'adresse IP de Mélanie est donc connue et utilisée par son moteur de recherche.</p><p>Dans la vidéo suivante, vous allez découvrir ce qu'est précisément une adresse IP publique et à quoi elle sert.&nbsp;<span aria-hidden=\"true\">📺</span></p>"
               }
             }
@@ -167,6 +170,7 @@
               "element": {
                 "id": "783dccd4-38ee-41a0-b10d-203a3cdb748f",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>À la suite de cette vidéo, une question vous sera posée sur le rôle de l'adresse IP publique.</p>"
               }
             },
@@ -194,6 +198,7 @@
               "element": {
                 "id": "566ec1c9-7b75-493c-be01-6deb61a42296",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Vous en savez désormais plus sur les adresses IP publiques.&nbsp;<span aria-hidden=\"true\">👩‍💻</span><span aria-hidden=\"true\">👨🏿‍💻</span></p><p>Voyons si vous avez compris l'essentiel avec une question. <span aria-hidden=\"true\">&nbsp;🎯</span></p>"
               }
             }
@@ -252,6 +257,7 @@
               "element": {
                 "id": "5775745c-a8f4-44d7-aea2-b14575720fd5",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Comme Mélanie, quand vous êtes sur internet, votre adresse IP publique est partagée et utilisée. Mais savez-vous quelles informations cette adresse donne sur vous ?&nbsp;<span aria-hidden=\"true\">👁️‍🗨️</span></p>"
               }
             }
@@ -267,6 +273,7 @@
               "element": {
                 "id": "3f4354a6-3243-4b5a-a459-58b3f3d1ecb8",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Pour chaque affirmation, répondez par vrai ou par faux.<br><i>Remarque : certaines personnes utilisent des VPN pour modifier leur adresse IP.<br>Dans les exemples suivants, aucun VPN n'est utilisé.</i></p>"
               }
             },
@@ -404,6 +411,7 @@
               "element": {
                 "id": "27fc867a-7258-4f85-b8cc-bdd1ab2d26a5",
                 "type": "text",
+                "tag": " ",
                 "content": "<h4><span aria-hidden=\"true\">📌</span> Résumons avant de passer à la suite</h4><ul><li>Votre adresse IP publique est celle de votre box internet.</li><li>Les personnes connectées à la même box internet ont la même adresse IP publique.</li><li>L’adresse IP publique donne une information sur la zone géographique de connexion : le pays, voire la ville.</li></ul>"
               }
             }
@@ -419,6 +427,7 @@
               "element": {
                 "id": "7538af4c-c729-49e9-8bc5-a16ad52bf493",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Sur internet, tout le monde partage son adresse IP publique et donc sa zone géographique. Vous êtes localisé et vous pouvez localiser les autres en retour.</p><p>Ça peut donner envie d'essayer. À vous de jouer !&nbsp;<span aria-hidden=\"true\">🌍</span></p>"
               }
             }
@@ -469,6 +478,7 @@
               "element": {
                 "id": "0856af53-1060-478f-8416-ddbc5ed3940c",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><span aria-hidden=\"true\">🗝️</span> Si vous avez besoin d'aide, vous pouvez cliquer sur les indices ci-dessous&nbsp;:</p><details><summary>Indice n°1&nbsp;:</summary><p>Vous pouvez faire une recherche en ligne : des sites internet existent pour cela.</p></details><details><summary>Indice n°2&nbsp;:</summary><p>Pour votre recherche, utilisez les mots-clés \"localisation\" et \"adresse IP\".</p></details>"
               }
             }
@@ -484,6 +494,7 @@
               "element": {
                 "id": "f34a216f-54fb-4cde-b634-71df19991211",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Vous l’avez sûrement remarqué, nous avons parlé jusqu'ici uniquement d’adresses IP publiques.<br>Il existe un autre type d’adresse IP&nbsp;: les adresses IP privées, aussi appelées IP locales.</p><p>Découvez leurs différences en image ! <span aria-hidden=\"true\">🔍</span></p>"
               }
             }
@@ -499,6 +510,7 @@
               "element": {
                 "id": "9814961b-3134-468d-a918-9b98a1775395",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Analysez le schéma ci-dessous qui présente les deux types d'adresses IP.<br>Par la suite, vous devrez trouver quel est le type d'adresse IP (privée ou publique) dans des situations concrètes.</p>"
               }
             },
@@ -517,6 +529,7 @@
               "element": {
                 "id": "1b524302-7175-4923-8810-835201d3d443",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><span aria-hidden=\"true\">🏠</span> Sur le <strong>réseau local</strong>, les appareils (ordinateur, imprimante, etc.) utilisent des adresses IP <strong>privées</strong> (ou locales) pour communiquer.</p><p><span aria-hidden=\"true\">🌐</span> Sur <strong>internet</strong>, ce sont des adresses IP <strong>publiques</strong> qui permettent aux sites et aux box internet de communiquer des informations.</p><p><span aria-hidden=\"true\">🛜</span> Une box internet a <strong>deux adresses IP</strong> : une privée et une publique.</p>"
               }
             }
@@ -536,6 +549,7 @@
                     {
                       "id": "9bc62c21-dfd4-40a8-9497-680a7e1c13d9",
                       "type": "text",
+                      "tag": " ",
                       "content": "<h4><span aria-hidden=\"true\">🕹️</span> À vous de jouer !</h4><p>À l'aide du schéma ci-dessus, trouvez pour chaque question si elle correspond à une IP privée ou à une IP publique.</p>"
                     }
                   ]
@@ -641,6 +655,7 @@
               "element": {
                 "id": "6e87277b-ea7d-4f71-82cb-c490364a1a75",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Pour finir ce module, vous allez relever un défi.<br>En ce moment-même, nous connaissons et utilisons votre adresse IP publique pour vous envoyez les contenus de ce module.<br>Mais connaissez-vous votre propre IP publique ❓</p>"
               }
             }
@@ -684,6 +699,7 @@
               "element": {
                 "id": "dc49fa68-dcdf-4a3e-ac3a-475d027fc789",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><span aria-hidden=\"true\">🗝️</span> Si vous avez besoin d'aide, vous pouvez cliquer sur les indices ci-dessous&nbsp;:</p><details><summary>Indice n°1&nbsp;:</summary><p>Vous pouvez faire une recherche en ligne : des sites internet existent pour cela.</p></details><details><summary>Indice n°2&nbsp;:</summary><p>Pour votre recherche, utilisez les mots-clés \"trouver\" et \"mon adresse IP\".</p></details>"
               }
             }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/au-dela-des-mots-de-passe.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/au-dela-des-mots-de-passe.json
@@ -31,6 +31,7 @@
               "element": {
                 "id": "f977e884-9c43-48f2-bc15-f47df200aac8",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Sur internet, les sites vous demandent toujours de prouver votre identité pour accéder à vos comptes.</p>"
               }
             }
@@ -97,6 +98,7 @@
               "element": {
                 "id": "fa687ee1-8f0b-4787-8582-4c12a4597beb",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Sylvie et Quentin ont du mal à se connecter à leurs services numériques.&nbsp;Vous allez les aider !</p>"
               }
             }
@@ -112,6 +114,7 @@
               "element": {
                 "id": "70ac0971-48f3-4d26-81c1-2df452852319",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Sylvie veut se connecter à son journal en ligne préféré. Elle vous transmet ses informations :&nbsp; </p>\n<ul>\n    <li>identifiant : <code>sylvie.girard</code></li>\n    <li>mot de passe : <code>Gmléso6+</code></li>\n</ul>\n<p>👉 Aidez Sylvie à se connecter en écrivant ses identifiants.</p>"
               }
             },
@@ -189,6 +192,7 @@
               "element": {
                 "id": "2836c787-28e8-4146-9ad9-345625b49a4a",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Quand il y a <strong>une seule étape</strong> pour prouver son identité, on appelle cela une <strong>authentification simple</strong>. </p>\n<p>✔️ Par exemple :&nbsp; </p>\n<ul>\n    <li>un mot de passe pour un compte,</li>\n    <li>un code PIN sur un téléphone</li></ul>"
               }
             }
@@ -204,6 +208,7 @@
               "element": {
                 "id": "8f87b786-7f5c-4b97-9d29-8944b2909c0b",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Vous avez aidé Sylvie à se connecter. Maintenant, aidez Quentin. 👇</p>"
               }
             }
@@ -219,6 +224,7 @@
               "element": {
                 "id": "b0a6d0e7-3047-4bc9-a9f8-8578cc16641d",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Quentin veut se connecter à sa boîte mail. Il vous transmet ses informations :&nbsp; </p><ul><li>identifiant : <code>Quentin</code></li><li>mot de passe : <code>M0tD3p4s53F0rt#$</code><br></li></ul><p>Ecrivez ces identifiants pour aider Quentin à se connecter.</p>"
               }
             },
@@ -296,6 +302,7 @@
               "element": {
                 "id": "3c327379-4354-4c99-805f-cbc519deb937",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Quand il y a <strong>deux étapes</strong> pour prouver son identité, on appelle cela une <strong>double authentification</strong>.&nbsp; <br>✔️ Par exemple :&nbsp; </p>\n<ul>\n    <li>un mot de passe puis un code par SMS pour un compte,</li>\n    <li>un code PIN puis une empreinte digitale sur un téléphone</li>\n</ul>\n<p>De plus en plus de sites internet proposent cette fonctionnalité.</p>"
               }
             }
@@ -362,6 +369,7 @@
               "element": {
                 "id": "1a6e0f45-7f7d-4e6e-8470-04bf9e0f6035",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Il arrive aussi que des identifiants et des mots de passe fuitent sur internet.</p><p>Des pirates peuvent utiliser ces informations pour se connecter à la place des gens.&nbsp;</p>"
               }
             }
@@ -377,6 +385,7 @@
               "element": {
                 "id": "16f3da9e-0393-49f9-b3b9-7ee3415d0e2c",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Michel vient de recevoir le SMS ci-dessous sur son portable :&nbsp;</p>"
               }
             },
@@ -397,6 +406,7 @@
               "element": {
                 "id": "7d35ae45-7ba8-42af-a566-c09b4de83542",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Pourtant, cela fait longtemps qu’il ne s’est pas connecté à ce compte.</p>"
               }
             },
@@ -455,6 +465,7 @@
               "element": {
                 "id": "9c5a186f-1055-4752-83b2-c76f0ced9364",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Avec la <strong>double authentification</strong>, une <strong>personne mal intentionnée</strong> qui a seulement votre mot de passe <strong>est bloquée</strong>.&nbsp; </p>\n<p>🤔 <strong>Bon à savoir</strong> </p>\n<p>Si vous recevez un code de confirmation par SMS mais que vous n’êtes pas en train de vous connecter à un site, changez rapidement le mot de passe de votre compte. </p>"
               }
             }
@@ -470,6 +481,7 @@
               "element": {
                 "id": "1826117c-67bb-4773-83ec-72adae3d516e",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>📌 Résumons l’essentiel avant de passer à la suite :</p><ul><li>Sur ses comptes en ligne, il est plus sécurisé de <strong>prouver son identité de deux manières différentes</strong>. C’est la <strong>double authentification</strong>.</li><li>On peut par exemple utiliser un <strong>code PIN</strong> ou une <strong>empreinte digitale</strong>, en plus d’<strong>un identifiant et d’un mot de passe</strong>.</li><li>Si vous avez <strong>un doute sur la sécurité </strong>d’un compte, <strong>changez votre mot de passe</strong> rapidement.</li></ul>"
               }
             }
@@ -485,6 +497,7 @@
               "element": {
                 "id": "7ea0f6c4-eef2-463f-8eea-e11d4fc17b5e",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Maintenant, entraînez-vous sur des exemples concrets !</p>"
               }
             }
@@ -500,6 +513,7 @@
               "element": {
                 "id": "cd14a6ca-819f-4667-9afb-457fd7c1cb5f",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Pour chaque exemple, choisissez s’il s’agit d’une simple authentification, d’une double authentification ou aucun des deux.</p>"
               }
             },
@@ -669,6 +683,7 @@
               "element": {
                 "id": "c46b2ffd-b340-42e1-b8fb-a1a830338e7b",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><strong>À vous de jouer ! 🕹️&nbsp;</strong></p><p>Pour finir, vous allez faire une double authentification en pratique.</p>"
               }
             }
@@ -684,6 +699,7 @@
               "element": {
                 "id": "67dc5b98-8365-4407-bc7f-f7e2336e464d",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Quentin vous demande de l’aide pour se connecter sur son compte de l’application Papotix. 💬 </p><p>Il vous prête son portable et vous transmet ses informations : </p><ul><li>identifiant : a</li><li>mot de passe : pix123</li></ul>"
               }
             },

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
@@ -201,6 +201,7 @@
                     {
                       "id": "7fb4c1c6-46f8-49a4-9547-f9febf545447",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Voici des photographies de chiens et de bagels.</p>"
                     },
                     {
@@ -259,6 +260,7 @@
                     {
                       "id": "868a2c39-d70b-45ba-847d-76d11a83a6fd",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Pour apprendre à une IA générative à produire du texte, on lui fait analyser des milliards de textes variés. 📚</p>"
                     }
                   ]
@@ -268,6 +270,7 @@
                     {
                       "id": "3875f579-e152-4309-a630-cd91196381f5",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>L’IA générative s’entraîne à masquer puis&nbsp;deviner&nbsp;des mots au hasard parmi tous ces textes. 🙈</p><p>Petit à petit elle s'améliore&nbsp;: elle apprend quels mots apparaissent&nbsp;souvent&nbsp;ensemble. 🐈 🐁</p>"
                     }
                   ]
@@ -277,6 +280,7 @@
                     {
                       "id": "7b58e24b-b751-4000-b3b6-554e548b9dd9",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Ainsi à partir d'un début de phrase, l'IA générative&nbsp;prédit le mot suivant&nbsp;📝.<br>Puis elle recommence depuis le début de la phrase pour trouver le mot qui suit.<br>Et ... elle recommence encore et encore ! 🔁</p>"
                     }
                   ]
@@ -286,6 +290,7 @@
                     {
                       "id": "1687e720-8346-4821-b60a-79937bdda1cb",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>À la fin de cette étape, l'IA générative est capable de prolonger ou compléter des débuts de texte. 😮</p>"
                     }
                   ]
@@ -351,6 +356,7 @@
               "element": {
                 "id": "488e3984-6ed6-4245-8c94-da188a2fd13c",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Section <strong>Réponses Courtes</strong> (QCM, QCU (+ découverte et déclaratif))</p>"
               }
             }
@@ -642,6 +648,7 @@
               "element": {
                 "id": "774c4c4e-f170-4e2c-ba7a-d2fe40d053c3",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Voici un tableau :</p> <table>\n  <tbody>\n <tr>\n    <th scope=\"col\">Player</th>\n    <th scope=\"col\">Gloobles</th>\n    <th scope=\"col\">Za'taak</th>\n  </tr>\n  <tr>\n    <th scope=\"row\">TR-7</th>\n    <td>7</td>\n    <td>4,569</td>\n  </tr>\n  <tr>\n    <th scope=\"row\">Khiresh Odo</th>\n    <td>7</td>\n    <td>7,223</td>\n  </tr>\n  <tr>\n    <th scope=\"row\">Mia Oolong</th>\n    <td>9</td>\n    <td>6,219</td>\n  </tr>\n </tbody>\n </table>\n"
               }
             }
@@ -832,6 +839,7 @@
               "element": {
                 "id": "5da6a142-c66b-42d4-9afd-86d369ebd2b5",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Chaque leçon a un objectif pédagogique précis.</p><p>Dans la prochaine leçon, nous vous proposons de découvrir Pix avec une courte vidéo&nbsp;<span aria-hidden=\"true\">📺</span></p>"
               }
             }
@@ -847,6 +855,7 @@
               "element": {
                 "id": "342183f7-af51-4e4e-ab4c-ebed1e195063",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>À la fin de cette vidéo, une question sera posée sur les compétences Pix.</p>"
               }
             },
@@ -874,6 +883,7 @@
               "element": {
                 "id": "1df5f2eb-f8f9-4a07-ab56-2c001541306b",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Vous allez faire votre première activité. Les activités servent à vérifier que vous avez compris l'essentiel des leçons.<br>Dans les activités Modulix, vous avez votre résultat immédiatement. À vous de jouer&nbsp;<span aria-hidden=\"true\">🚀</span></p>"
               }
             }
@@ -889,6 +899,7 @@
               "element": {
                 "id": "41186193-1c38-4827-84b7-e70848367d42",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Vous l’aurez compris, on aime varier les plaisirs et proposer différents types d’activité, après le questionnaire à choix unique on vous laisse découvrir le QCM&#8239;!</p>"
               }
             }
@@ -976,6 +987,7 @@
               "element": {
                 "id": "52af6cab-07df-4962-abc5-20cf95d5eb5a",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Voici un Petit Objet Interactif expérimental :</p>"
               }
             },
@@ -995,6 +1007,7 @@
               "element": {
                 "id": "e32c01a8-7ae1-4c6d-9a16-6487c7c504d2",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Ils ne sont autorisés qu'en béta.</p>"
               }
             }
@@ -1019,6 +1032,7 @@
               "element": {
                 "id": "e9aef60c-f18a-471e-85c7-e50b4731b86b",
                 "type": "text",
+                "tag": " ",
                 "content": "<h4>Pour afficher mon texte sur plusieurs colonnes, je peux utiliser la classe <em>modulix-two-columns</em>.</h4><p>Des noms d'artistes de musique très sympas:</p><ol class=\"modulix-two-columns\"> <li>Dylan</li> <li>The Beatles</li> <li>The Who</li><li>Blondie</li><li>Joan Baez</li><li>Supertramp</li><li>Kraftwerk</li> <li>Queen</li><li>David Bowie</li><li>Céline Dion</li></ol>"
               }
             },
@@ -1027,6 +1041,7 @@
               "element": {
                 "id": "84726001-1665-457d-8f13-4a74dc4768ea",
                 "type": "text",
+                "tag": " ",
                 "content": "<h4>On commence avec les leçons.<br>Les leçons sont des textes, des images ou des vidéos. Les leçons sont là pour vous expliquer des concepts ou des méthodes.</h4>"
               }
             },
@@ -1042,6 +1057,7 @@
               "element": {
                 "id": "a2372bf4-86a4-4ecc-a188-b51f4f98bca2",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Voici un texte de leçon. Parfois, il y a des émojis pour aider à la lecture&nbsp;<span aria-hidden=\"true\">📚</span>.</p>"
               }
             },
@@ -1050,6 +1066,7 @@
               "element": {
                 "id": "4cfd27d5-0947-47af-bfb6-52467143c38b",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Et là, voici une image&#8239;!</p>"
               }
             },
@@ -1077,6 +1094,7 @@
               "element": {
                 "id": "96e2457d-54d3-461a-97e4-69180a30bfb7",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Voici un web component :</p>"
               }
             },
@@ -1155,6 +1173,7 @@
               "element": {
                 "id": "5e77afeb-78a8-4733-a451-fbe5fa2f360c",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Comme vous pouvez le voir l'expérience utilisateur n'est pas du tout la même.</p><p><em>Notamment pour les utilisateurs de lecteur d'écran</em></p>"
               }
             },
@@ -1163,6 +1182,7 @@
               "element": {
                 "id": "298518dc-9ad0-4709-92c0-c0a1fb1a1a2a",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Un avantage est que la configuration peut être précisée directement dans le contenu du module et pas côté pix-epreuves</p>"
               }
             }
@@ -1178,6 +1198,7 @@
               "element": {
                 "id": "5415e701-d81a-4f5e-b0e4-a0db67d83e18",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Voici un autre exemple de web component, le Quiz Image :</p>"
               }
             },
@@ -1244,6 +1265,7 @@
               "element": {
                 "id": "73e4676d-fcc9-4ef2-b6de-b33e71922c04",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Pour comparer du comparable voici la même chose en version embed :</p>"
               }
             },
@@ -1326,6 +1348,7 @@
               "element": {
                 "id": "35ae00c5-9d46-4f53-83f1-3724ce39b53d",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Vous l'avez peut-être remarqué&nbsp;: dans un module, vous pouvez voir tous les contenus en remontant la page&nbsp;<span aria-hidden=\"true\">👆</span></p>"
               }
             }
@@ -1515,6 +1538,7 @@
               "element": {
                 "id": "72fee40a-7279-4372-acf5-aaf508b1c145",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Vous arrivez à la fin de ce module. Une dernière activité et vous serez prêt à explorer tous les modules que vous souhaitez&#8239;!<span aria-hidden=\"true\">🌟</span> </p>"
               }
             }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bases-clavier-ordinateur-1.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bases-clavier-ordinateur-1.json
@@ -32,6 +32,7 @@
               "element": {
                 "id": "0c91df86-5691-422a-b2c2-cfafd4f6e3d3",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Dans ce module, vous allez apprendre à taper du texte avec un clavier.</p>"
               }
             }
@@ -47,6 +48,7 @@
               "element": {
                 "id": "bcd20400-781c-4b7d-82c3-d348ddef88d2",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Le clavier fait partie de l’équipement de base d’un ordinateur, avec la souris. <br>Le clavier est composé de touches sur lesquelles on peut appuyer.<br> Les claviers peuvent avoir différentes formes, tailles, couleurs ou dispositions des touches.<br></p><p><br>Il y a différents types de claviers&nbsp;: </p> <ul> <li>les claviers avec un fil,</li> <li>les claviers sans fil,</li> <li>les claviers inclus dans un ordinateur.</li> </ul>"
               }
             },
@@ -65,6 +67,7 @@
               "element": {
                 "id": "847c14dc-d58d-4faf-9886-8a2de37974c6",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Tous ces claviers permettent de faire la même chose.<br></p>"
               }
             },
@@ -80,6 +83,7 @@
               "element": {
                 "id": "cd613fa6-2903-4932-a1f7-5b7d51ac0a41",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>🔎 <strong>Observez&nbsp;: quel type de clavier avez-vous ?</strong></p>"
               }
             }
@@ -95,6 +99,7 @@
               "element": {
                 "id": "5f031cda-3e4c-4f80-9327-eb0f8df8f7f1",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>À présent, vous allez découvrir les principales zones d’un clavier.</p>"
               }
             }
@@ -110,6 +115,7 @@
               "element": {
                 "id": "d6bb5ad8-bd97-4116-839d-425a444fcdfd",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Il y a 3 zones principales sur un clavier&nbsp;:</p><ul><li>les lettres de l’alphabet,</li><li>les chiffres, caractères spéciaux et accents,</li><li>les flèches directionnelles.</li></ul>"
               }
             },
@@ -128,6 +134,7 @@
               "element": {
                 "id": "9b2e535b-e18d-47ba-bddd-0015c5064e35",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>🤔 <strong>Bon à savoir</strong> </p><p>Les touches peuvent être disposées de différentes manières, en fonction des modèles, des pays et de la langue. 🌍</p><p>En France, on utilise le clavier AZERTY. Il porte ce nom, car les lettres A, Z, E, R, T, Y sont les six premières lettres affichées sur le clavier.</p>"
               }
             }
@@ -143,6 +150,7 @@
               "element": {
                 "id": "cfd8f2dd-1992-45ab-93e2-5b45a83af750",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Taper sur une touche, c’est <strong>appuyer une fois</strong> dessus et <strong>relâcher immédiatement</strong>.</p>"
               }
             },
@@ -169,6 +177,7 @@
               "element": {
                 "id": "e608bdea-cfaf-4aca-93e8-6668f4207158",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Vous connaissez maintenant les différentes zones du clavier. <br>Découvrez les principales touches nécessaires pour taper et modifier du texte.</p>"
               }
             }
@@ -184,6 +193,7 @@
               "element": {
                 "id": "e4c30736-5efe-4a0d-bacc-b41e3546d47c",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Pour taper et modifier du texte, il faut utiliser des touches de différentes zones.</p><p>👇 Voici ci-dessous les touches essentielles d'un clavier&nbsp;:</p>"
               }
             },
@@ -209,6 +219,7 @@
               "element": {
                 "id": "44ad5d6e-1d51-47ac-bd9d-98acf9d7af71",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>À vous de jouer ! 🕹️ Commencez par taper des mots en utilisant uniquement les touches lettres.</p>"
               }
             }
@@ -242,6 +253,7 @@
               "element": {
                 "id": "18c6f518-9e97-4e94-a5f3-e986cd52c219",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Bravo ! 🎉 Vous avez tapé vos premiers mots. <br>À présent, découvrez ce qu'est la zone de texte.</p>"
               }
             }
@@ -257,6 +269,7 @@
               "element": {
                 "id": "18d43580-47c8-4475-9680-248f91678a3c",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Une <strong>zone de texte</strong> est un endroit où on peut <strong>taper, modifier et effacer du texte</strong>. Pour reconnaître une zone de texte, vous pouvez vous aider du pointeur de la souris. <span aria-hidden=\"\\&quot;true\\&quot;\">🖱️<br></p><p>Lorsque vous faites glisser votre pointeur sur une zone de texte, il prend la forme d’une barre verticale.</p>"
               }
             },
@@ -275,6 +288,7 @@
               "element": {
                 "id": "f1696a65-a46b-4ee1-8b89-e9fa9752eaa4",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Vous pouvez alors cliquer dans la zone, une barre verticale s’affiche et clignote. C’est le <strong>curseur de texte</strong>. Vous pouvez commencer à taper, modifier ou effacer du texte à cet endroit.</p>"
               }
             },
@@ -299,6 +313,7 @@
               "element": {
                 "id": "6e7b48c5-53d3-46b9-8f3b-f43aa0f95e03",
                 "type": "text",
+                "tag": " ",
                 "content": "À vous de jouer, observez&nbsp;la phrase ci-dessous."
               }
             },
@@ -380,6 +395,7 @@
               "element": {
                 "id": "ca6cabdb-6b85-45e1-b873-b809948eb628",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Maintenant, découvrez les autres touches utiles pour modifier du texte. ⌨️</p>"
               }
             }
@@ -395,6 +411,7 @@
               "element": {
                 "id": "f42a1f10-87a9-4607-bb81-9cde56c1d047",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Pour écrire et modifier du texte, il faut utiliser d’autres touches que les touches lettres.</p><br><p>Voici les touches les plus utiles&nbsp;:</p><ul> <li><strong>l’espace,</strong></li> <li><strong>entrée,</strong></li> <li><strong>effacer,</strong></li> <li><strong>les flèches directionnelles,</strong></li> </ul> "
               }
             },
@@ -417,6 +434,7 @@
                     {
                       "id": "e314ff25-bd46-475b-b18b-0ef1952735c7",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>La touche <strong>Espace </strong>permet de créer un espace vide entre deux mots.</p>"
                     },
                     {
@@ -432,6 +450,7 @@
                     {
                       "id": "b65c1d05-27b9-429e-b8aa-b63bef94c67e",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>La touche <strong>Entrée </strong>permet d’aller à la ligne.<br>Quand vous êtes en train de taper du texte et que vous voulez écrire sur la ligne suivante, tapez sur la touche Entrée pour déplacer le curseur vers la ligne d’en dessous.</p>"
                     },
                     {
@@ -447,6 +466,7 @@
                     {
                       "id": "188a5ce5-c163-47d0-b718-1ac64db4283e",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>La touche <strong>Effacer </strong>permet de supprimer le caractère juste avant le curseur de texte.</p>"
                     },
                     {
@@ -462,6 +482,7 @@
                     {
                       "id": "6dee7fcf-7faf-4748-9c56-70e93d7d4914",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Pour déplacer le curseur de texte, vous pouvez utiliser les <strong>flèches directionnelles</strong>.</p><p>➡️Par exemple&nbsp;: vous avez oublié d’aller à la ligne entre deux mots, vous pouvez déplacer le curseur entre les deux mots pour appuyer sur la touche Entrée et aller à la ligne.</p>"
                     },
                     {
@@ -486,6 +507,7 @@
               "element": {
                 "id": "731fa720-68f8-420b-ae7b-efc86b8aae5a",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Voyons si vous avez retenu l’essentiel. 🎯</p>"
               }
             }
@@ -512,6 +534,7 @@
               "element": {
                 "id": "caedc436-3ab8-45a8-a4b5-c7ee5b4f38c6",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>🙋🏽‍♂️ 🙋🏿‍♀️ 🙋‍♂️En cas de difficulté, n’hésitez pas à demander conseil à la personne qui vous accompagne.</p>"
               }
             }
@@ -527,6 +550,7 @@
               "element": {
                 "id": "d77ec00d-f3f0-4a22-9e90-c6dff041b780",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Résumons avant de passer à la suite&nbsp;:</p><ul><li>La <strong>zone de text</strong><strong>e</strong> est une zone dans laquelle on peut taper du texte. Il faut<strong> cliquer dans cette zone</strong> avant de commencer à taper.</li><li>Les <strong>touches des lettres</strong> se trouvent au centre du clavier.</li><li>Pour écrire et modifier du texte, les touches de base sont&nbsp;: <strong>Espace</strong>, <strong>Entrée </strong>et <strong>Effacer</strong>. Les <strong>flèches directionnelles</strong> permettent de déplacer le curseur de texte.</li></ul>"
               }
             },
@@ -563,6 +587,7 @@
               "element": {
                 "id": "be0e2ee5-97d6-4d46-b621-42b89c16395d",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Certaines lettres ont des accents. Voyons ensemble où les trouver sur le clavier.</p>"
               }
             }
@@ -578,6 +603,7 @@
               "element": {
                 "id": "a0548b0c-335a-46cc-b6e0-af84998734c2",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Les lettres accentuées les plus courantes (é, è, ç, à, ù) sont placées sur les touches suivantes&nbsp;:</p>"
               }
             },
@@ -596,6 +622,7 @@
               "element": {
                 "id": "0f10059b-3a41-47fd-808b-9f587cf7ab0c",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Ces lettres accentuées sont écrites en bas à gauche des touches. <br>Il suffit de taper sur la touche pour que la lettre accentuée apparaisse à l’écran.</p>"
               }
             }
@@ -611,6 +638,7 @@
               "element": {
                 "id": "6bb8779f-8f08-4a9c-803e-63eebabf80c9",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Vous allez maintenant passer à la pratique. ⌨️</p>"
               }
             }
@@ -626,6 +654,7 @@
               "element": {
                 "id": "f46175b4-7066-4b10-b494-116944516535",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><strong>Pour chaque mot qui vous sera proposé, tapez ce mot dans la zone de texte.</strong></p>"
               }
             },
@@ -754,6 +783,7 @@
               "element": {
                 "id": "bed8da7e-630d-4400-b1c2-9e250ccee7e4",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>💡 Si besoin, cliquez sur <strong>Réinitialiser </strong>pour recommencer depuis le début.</p>"
               }
             }
@@ -769,6 +799,7 @@
               "element": {
                 "id": "52b120fe-5aa5-4ebc-aafc-ddd173377620",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>📌 Pour taper, modifier ou effacer du texte, on clique dans une zone de texte avec la souris. Puis, on utilise les touches du clavier.&nbsp;Voici les touches du clavier à retenir&nbsp;: </p><ul>    <li><strong>Les lettres</strong> pour taper des lettres.</li>    <li><strong>Espace </strong>pour ajouter un espace entre deux mots.</li>    <li><strong>Entrée</strong> pour aller à la ligne.</li>    <li><strong>Effacer </strong>pour supprimer le caractère à gauche du curseur de texte.</li>    <li><strong>Les flèches directionnelles</strong> pour déplacer le curseur de texte.</li></ul><p><br>📝&nbsp;Vous pouvez maintenant&nbsp;<a href=\"https://assets.pix.org/modules/1emarche-clavier1/pix-fiche-revision-premieres-marches-clavier-1.pdf\" target=\"_blank\">ouvrir votre fiche de synthèse</a>.</p>"
               }
             }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bases-clavier-ordinateur-2.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bases-clavier-ordinateur-2.json
@@ -32,6 +32,7 @@
               "element": {
                 "id": "5bfffb2d-05bb-4497-a9ad-7a5402a5108f",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Dans ce module, vous allez apprendre à utiliser les touches du clavier qui ont plusieurs caractères (lettres, chiffres, caractères spéciaux).</p>"
               }
             }
@@ -47,6 +48,7 @@
               "element": {
                 "id": "9de6b2ff-3e7c-4a96-88ff-d0bc3f7c4bf1",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Pour commencer, révisons les touches de base du clavier pour taper du texte.</p>"
               }
             },
@@ -98,6 +100,7 @@
               "element": {
                 "id": "0b771dad-3e31-4e0a-809e-6abd65653adb",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><span aria-hidden=\"true\">🗝️</span> Si vous avez besoin d’aide, vous pouvez cliquer sur les indices ci-dessous&nbsp;:</p>"
               }
             },
@@ -131,6 +134,7 @@
               "element": {
                 "id": "5cd44b4e-0534-4181-9478-101073d3a9b1",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Bravo ! <span aria-hidden=\"true\">🎉</span> </p><p>Vous êtes prêt. Voyons comment taper des lettres majuscules.</p>"
               }
             }
@@ -146,6 +150,7 @@
               "element": {
                 "id": "c176da55-aad3-4dc2-a7fa-e680abd27ebd",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Pour taper certains caractères, il faut <strong>appuyer sur plusieurs touches en même temps</strong>. </p> <p>C’est le cas pour taper des lettres majuscules.</p>"
               }
             },
@@ -173,6 +178,7 @@
               "element": {
                 "id": "6764fe09-6a2f-47a1-b368-f9083a9e0a26",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>La <strong>touche majuscule ⇧</strong> du clavier permet de taper des lettres majuscules.</p><p><br><strong><span aria-hidden=\"true\">💡</span>&nbsp;Astuce</strong><br>Sur la touche majuscule ⇧ il y a souvent une flèche vers le haut. On peut dire que c’est la touche qui fait grandir les lettres.</p>"
               }
             },
@@ -188,6 +194,7 @@
               "element": {
                 "id": "00987892-9248-401d-94a2-f9418c8ff5e6",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Par exemple, pour taper un P, gardez un doigt appuyé sur la <strong>touche majuscule ⇧</strong> et appuyez brièvement sur la touche P avec un autre doigt.</p><p><br>Dès que vous relâchez la touche majuscule ⇧, les lettres que vous tapez sont en minuscules.</p>"
               }
             },
@@ -208,6 +215,7 @@
               "element": {
                 "id": "04fe4d77-15c4-475d-915f-ba04f69f9674",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><span aria-hidden=\"true\">💡</span><strong> Astuce</strong><br>Pour taper plusieurs majuscules à la suite, restez appuyé sur la touche majuscule ⇧ et tapez la première lettre, puis la deuxième, etc.</p>"
               }
             }
@@ -223,6 +231,7 @@
               "element": {
                 "id": "f27292d8-b444-41ca-ad80-165307e201d6",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Passons à la pratique ! <span aria-hidden=\"true\">⌨️</span></p>"
               }
             }
@@ -256,6 +265,7 @@
               "element": {
                 "id": "0d51136f-1054-4185-bce9-6abb15d10abd",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Vous savez maintenant que la touche majuscule sert à taper des lettres en majuscules. Elle peut aussi servir à taper d’autres caractères.</p>"
               }
             }
@@ -271,6 +281,7 @@
               "element": {
                 "id": "422c00a6-3220-4e15-9f2b-f045298eaf0c",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Sur certaines touches, il n’y a qu’un seul caractère. <br>Sur d’autres touches, il peut y avoir 2 ou même 3 caractères. <br>La<strong> touche majuscule&nbsp;⇧</strong> permet de taper le <strong>caractère situé en haut des touches</strong>, comme par exemple les chiffres.</p>"
               }
             },
@@ -291,6 +302,7 @@
               "element": {
                 "id": "02d17109-d2df-4b5f-83a0-dde1f1fd4e8b",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Comme pour les lettres majuscules, pour taper le caractère du haut d’une touche, restez appuyé sur la<strong> touche majuscule ⇧ </strong>et appuyez sur la touche du caractère.</p>"
               }
             },
@@ -327,6 +339,7 @@
               "element": {
                 "id": "4bbe20be-c9b0-41f3-bf95-fce480aa8348",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Grâce à la touche majuscule ⇧ , vous pouvez donc taper des caractères spéciaux, de la ponctuation et des chiffres. À vous d’essayer !</p>"
               }
             }
@@ -392,6 +405,7 @@
               "element": {
                 "id": "75652d09-9acc-4e3d-9af8-2c12b63fba2a",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Sur certaines touches, il y a 3 caractères. Pour taper le 3e caractère, apprenez à utiliser la touche <strong>Alt Gr</strong>.</p>"
               }
             }
@@ -419,6 +433,7 @@
               "element": {
                 "id": "2852b780-a88f-4142-84b4-c575ef63201d",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>La <strong>touche Alt&nbsp;Gr</strong> permet de faire apparaître les caractères situés en bas à droite des touches. Elle s’utilise de la même manière que la touche majuscule.</p>"
               }
             },
@@ -439,6 +454,7 @@
               "element": {
                 "id": "423d899e-e24d-4666-8f74-17c137279122",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Pour taper le caractère situé en bas à droite sur une touche, maintenez appuyée la <strong>touche Alt&nbsp;Gr</strong> et appuyez sur la touche du caractère.</p>"
               }
             },
@@ -466,6 +482,7 @@
               "element": {
                 "id": "69e777c2-9c22-462a-aefd-b159c060b6a1",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Entraînez-vous à utiliser la touche Alt Gr.</p>"
               }
             }
@@ -499,6 +516,7 @@
               "element": {
                 "id": "baef48f2-8a7f-4f65-a5bc-d66c6846968a",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>À vous de mettre en pratique tout ce que vous avez vu dans ce module.</p>"
               }
             }
@@ -514,6 +532,7 @@
               "element": {
                 "id": "ba5be535-ee02-4cc9-bc1b-1fdcbc2ccbb3",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Observez la carte d’identité suivante.</p>"
               }
             },
@@ -554,6 +573,7 @@
               "element": {
                 "id": "e9e14b7b-9ef5-442d-9f30-e10cda3ec5c7",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Résumons l’essentiel. <span aria-hidden=\"true\">🎯</span></p>"
               }
             }
@@ -569,6 +589,7 @@
               "element": {
                 "id": "185a37d3-64dd-48e0-92b0-470bd34b4e9f",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><span aria-hidden=\"true\">📌</span> Pour savoir comment taper un caractère, il faut connaître <strong>sa position sur la touche</strong>&nbsp;:</p>"
               }
             },
@@ -589,6 +610,7 @@
               "element": {
                 "id": "e51added-60dc-453b-98ed-b3230711155e",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>📝&nbsp;Vous pouvez maintenant&nbsp;<a href=\"https://assets.pix.org/modules/1emarche-clavier2/pix-fiche-revision-premieres-marches-clavier-2.pdf\" target=\"_blank\">ouvrir votre fiche de synthèse</a></p>"
               }
             }
@@ -604,6 +626,7 @@
               "element": {
                 "id": "17b65b49-03cf-4626-a651-dc6372c107ba",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Pour explorer les différentes touches, testez-vous dans le mini-jeu suivant.</p>"
               }
             }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
@@ -32,6 +32,7 @@
               "element": {
                 "id": "91e6c6bb-4287-4184-8860-086277fd6a31",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Naomi veut envoyer un document par mail à son ami Mickaël.<br>Mais, Naomi ne trouve plus l'adresse mail de Mickaël.&nbsp;<span aria-hidden=\"true\">🤷‍♀</span><br>Elle décide de lui demander par message.</p>"
               }
             }
@@ -112,6 +113,7 @@
               "element": {
                 "id": "07246ad5-e460-4266-b006-65bb6ddb181f",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Eh oui&#8239;! Naomi le sait&nbsp;: toutes les adresses mail ont le même format.</p><p>Nous allons étudier en détail l’adresse mail de Mickaël.&nbsp;<span aria-hidden=\"true\">🔎</span></p>"
               }
             }
@@ -127,6 +129,7 @@
               "element": {
                 "id": "acf16c79-b788-4ebe-b7a1-4138eef3db2f",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Après cette leçon, vous devrez répondre à des questions sur les différentes parties de l'adresse mail.</p>"
               }
             },
@@ -139,6 +142,7 @@
                     {
                       "id": "d4bf1c51-b113-440a-949a-f21c1e001daa",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>L'adresse mail de Mickaël est <strong>mickael.aubert123@laposte.net</strong>.<br>Cette adresse est composée de <strong>deux parties</strong> et d'<strong>un séparateur</strong> au centre.</p>"
                     },
                     {
@@ -162,6 +166,7 @@
                     {
                       "id": "c1f3c8c7-6d5c-4c6c-9c4d-1a3d8f7e9f5d",
                       "type": "text",
+                      "tag": " ",
                       "content": "<h4 class=\"screen-reader-only\">L'identifiant</h4><h5><u>Partie 1&nbsp;: l’identifiant</u>. Cette partie est choisie par Mickaël.</h5><p>Tous les identifiants sont possibles, ou presque.</p><p><span aria-hidden=\"true\">✔️</span> Par exemple&nbsp;: <code>mickael.aubert123</code> ou <code>mika671</code> ou <code>g3odu671</code></p><p><span aria-hidden=\"true\">✖️</span> Certains caractères sont interdits (<code>&amp;</code> <code>@</code>  <code>$</code> <code>*</code> <code>€</code>) ou à éviter (accents, majuscules).</p><p><br><span aria-hidden=\"true\">📖</span> Un conseil : si vous voulez envoyer des mails importants, il vaut mieux créer une adresse mail avec un identifiant classique, par exemple <code>prenom.nom</code>.</p>"
                     }
                   ]
@@ -178,6 +183,7 @@
                     {
                       "id": "ad8ad08a-3ff7-4228-8233-6cd5ce0f4812",
                       "type": "text",
+                      "tag": " ",
                       "content": "<h4 class=\"screen-reader-only\">L'arobase</h4><h5><u>Au centre, l’arobase</u> (@) sépare l’identifiant du fournisseur d’adresse mail.</h5><p>En anglais, ce symbole se lit <i lang=\"en\">“at”</i> et veut dire “chez”.</p><p><br><span aria-hidden=\"true\">💡</span> L'arobase est un symbole qui était utilisé avant l’informatique. En 1970, il a été choisi pour écrire les adresses mail car il était très peu utilisé et facile à repérer.</p>"
                     }
                   ]
@@ -194,6 +200,7 @@
                     {
                       "id": "1fd829f8-1799-4779-a28d-5d26fba31b8b",
                       "type": "text",
+                      "tag": " ",
                       "content": "<h4 class=\"screen-reader-only\">Le fournisseur d’adresse mail</h4><h5><u>Partie 2&nbsp;: le fournisseur d’adresse mail</u>. Cette partie de l’adresse est donnée par le fournisseur.</h5><p><span aria-hidden=\"true\">✔️</span> Voici des exemples de fournisseurs d’adresses mail&nbsp;: </p><ul><li>La Poste (laposte.net)</li><li>Google (gmail.com)</li><li>Yahoo (yahoo.com, yahoo.fr)</li><li>Microsoft (hotmail.com, live.fr)</li></ul><p><br>Quand vous écrivez une adresse mail, soyez attentifs à l'extension (<code>.fr</code>, <code>.com</code>, etc.). C'est important pour que le mail soit envoyé à la bonne adresse. <span aria-hidden=\"true\">🧐</span></p>"
                     }
                   ]
@@ -212,6 +219,7 @@
               "element": {
                 "id": "f10c972d-ec3e-45e7-a9fd-91cbf00edbdc",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Récapitulons ensemble avec quelques questions. <span aria-hidden=\"true\">🎯</span></p>"
               }
             }
@@ -263,6 +271,7 @@
                     {
                       "id": "e494d292-21a8-4b33-affa-96763dbe10e6",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p><span aria-hidden=\"true\">🗝️</span> Si vous avez besoin d'<strong>aide pour écrire ce symbole</strong>, cliquez sur l'indice ci-dessous&nbsp;:</p><details><summary>Indice</summary>Pour écrire le symbole arobase,<ul><li>sur PC, appuyez et maintenez la touche <code>Alt Gr</code> puis appuyez sur la touche <code>à</code> (même touche que le 0)</li><li>sur Mac, appuyez sur la touche @ déjà prévue, en haut à gauche (même touche que #)</li></ul></details>"
                     }
                   ]
@@ -356,6 +365,7 @@
               "element": {
                 "id": "2f4794e7-f5f1-4cb6-8b4f-08f4e64b8aa5",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Pour chaque affirmation, choisissez si elle est vraie ou fausse.</p>"
               }
             },
@@ -493,6 +503,7 @@
               "element": {
                 "id": "b0fcb950-b5b1-4384-886e-79fb852d5bb7",
                 "type": "text",
+                "tag": " ",
                 "content": "<h4><span aria-hidden=\"true\">📌</span> Résumons avant de passer à la suite :</h4><ul><li>C'est l'<strong>utilisateur qui choisit son identifiant</strong> d'adresse mail. Il peut utiliser des <strong>chiffres</strong> ou des <strong>majuscules</strong>.<br><span aria-hidden=\"true\">✔️</span> Exemples&nbsp;: <code>mickael.aubert123</code> ; <code>M3g4Cool1415</code>, etc.<br></li><li>Il y a une <strong>arobase</strong> (@) dans une adresse mail. Elle permet de <strong>séparer l’identifiant et le fournisseur</strong> d’adresse mail.<br></li><li>Après l'arobase, les adresses mail <strong>se terminent de différentes manières</strong>, selon le <strong>fournisseur d’adresse</strong> mail.<br><span aria-hidden=\"true\">✔️</span> Exemples&nbsp;: laposte.net, free.fr, gmail.com, yahoo.com, etc.</li></ul>"
               }
             }
@@ -508,6 +519,7 @@
               "element": {
                 "id": "a6b72df3-ec21-4b7a-81a0-f6864b2f93e9",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Pour finir, à vous de jouer : vous allez devoir trouver l'adresse mail de Naomi. <span aria-hidden=\"true\">💫</span></p>"
               }
             }
@@ -561,6 +573,7 @@
               "element": {
                 "id": "6c69a919-4fc6-4039-9abc-ad70c49be7d8",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><span aria-hidden=\"true\">🗝️</span> Si vous avez besoin d'aide, vous pouvez cliquer sur les indices ci-dessous&nbsp;:</p><details><summary>Indice 1</summary><p>L'ordre est l'identifiant, l'arobase puis le fournisseur d'adresse mail.</p></details><details><summary>Indice 2</summary><p>L'adresse mail se termine par <code>yahoo.com</code> quand le fournisseur est Yahoo.</p></details>"
               }
             }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/chatgpt-vraiment-neutre.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/chatgpt-vraiment-neutre.json
@@ -32,6 +32,7 @@
               "element": {
                 "id": "534dabf0-73dc-49a6-88f9-35bdc3b9e607",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Vous avez peut-être déjà utilisé des outils d'intelligence artificielle générative de texte, comme ChatGPT ou Copilot. Ces grands modèles de langage, <i>Large Language Models (LLM)</i> en anglais, peuvent être utiles pour produire des synthèses ou inventer des histoires.<span aria-hidden=\"true\">&nbsp;✒️ 💭</span></p><p>Pourtant, les textes produits contiennent parfois des maladresses ou des erreurs.<span aria-hidden=\"true\">&nbsp;❌</span> Commençons par un exemple concret&nbsp;!</p>"
               }
             }
@@ -47,6 +48,7 @@
               "element": {
                 "id": "4b2aebb9-03eb-402f-9302-c305c3f84b1a",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Voici une conversation entre un utilisateur et ChatGPT.<br>La réponse de ce LLM est un peu décalée.<span aria-hidden=\"true\">&nbsp;😵‍💫</span></p>"
               }
             },
@@ -108,6 +110,7 @@
               "element": {
                 "id": "61eff022-ce71-49f0-ad86-7bee5f7c9c0e",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Cette réponse en français de ChatGPT est biaisée. En effet, elle est influencée par ses données d'entraînement.<br>Ces données, récoltées en grande partie sur internet, sont majoritairement en anglais.</p><p>Dans la vidéo suivante, vous allez découvrir d’où proviennent les différents biais des LLM.<span aria-hidden=\"true\">&nbsp;📺</span></p>"
               }
             }
@@ -123,6 +126,7 @@
               "element": {
                 "id": "b510a523-dc46-44bc-9cef-7d254ddd5831",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>À la suite de cette vidéo, vous devrez&nbsp;: </p>\n<ul>\n    <li>retrouver les origines des biais des LLM,</li>\n    <li>interpréter des situations concrètes où la réponse d'un LLM est biaisée.</li>\n</ul>"
               }
             },
@@ -150,6 +154,7 @@
               "element": {
                 "id": "c6bc9ee2-7bd5-4433-932c-811803a7746a",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Vous en savez désormais plus sur les biais des LLM. <span aria-hidden=\"true\">👩‍💻️👨🏿‍💻️</span></p><p>Vérifiez que vous avez retenu l'essentiel avec cette question. <span aria-hidden=\"true\">&nbsp;🎯</span></p>"
               }
             }
@@ -218,6 +223,7 @@
                     {
                       "id": "be70c1be-d6d1-4b6e-bcee-de1ab8859ee0",
                       "type": "text",
+                      "tag": " ",
                       "content": "<h4><span aria-hidden=\"true\">&nbsp;🕹️</span> À vous de jouer</h4><p>Vous allez maintenant devoir analyser trois situations avec des résultats visiblement biaisés.</p><p>Pour chaque situation, trouvez la cause principale des résultats biaisés.<br><i>Tous les exemples ont été générés le 7 juin 2024 avec CHATGPT-4 (OpenAI).</i></p>"
                     }
                   ]
@@ -227,6 +233,7 @@
                     {
                       "id": "700c674c-f7a7-4eba-bd00-de74ca8c77f7",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Michel vit au <strong>Québec</strong> et utilise un LLM pour la première fois. Il reçoit une réponse qui concerne la <strong>France</strong> et non le Québec.<span aria-hidden=\"true\">&nbsp;👇</span></p>"
                     },
                     {
@@ -276,6 +283,7 @@
                     {
                       "id": "cac9d75d-c447-465f-b5de-d7b3994b9b82",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Erica est <strong>romancière</strong> et demande à un LLM d'imaginer un personnage. Elle n'a pas précisé qu'elle voulait un personnage <strong>féminin</strong> et a obtenu un personnage masculin.<span aria-hidden=\"true\">&nbsp;👇</span></p>"
                     },
                     {
@@ -325,6 +333,7 @@
                     {
                       "id": "f0f7f950-100e-4bd1-bbda-f1edb73e1e22",
                       "type": "text",
+                      "tag": " ",
                       "content": "Stéphane est persuadé d'avoir vu un <strong>extraterrestre</strong> et demande à un LLM comment en voir à nouveau. Le LLM lui répond, sans questionner leur existence.<span aria-hidden=\"true\">&nbsp;👇</span>"
                     },
                     {
@@ -383,6 +392,7 @@
               "element": {
                 "id": "d7c949fb-9fac-400d-990a-a6cb8144c653",
                 "type": "text",
+                "tag": " ",
                 "content": "<h4><span aria-hidden=\"true\">📌</span> Résumons avant de passer à la suite</h4><p>Les biais dans les LLM peuvent avoir différentes origines&nbsp;:</p><ul><li>Les <strong>données d'entraînement</strong> comportent déjà des stéréotypes et des biais, qui se retrouvent par la suite dans les modèles.</li><li>Les <strong>personnes qui développent</strong> des LLM transmettent, consciemment ou non, leurs biais dans les modèles.</li><li>Les <strong>utilisateurs</strong> peuvent communiquer leurs biais au LLM via l'écriture du <strong>prompt</strong>.</li></ul>"
               }
             }
@@ -398,6 +408,7 @@
               "element": {
                 "id": "a2748830-10ee-408b-8d37-8c2aa0055bb9",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Il existe de nombreux LLM à l'heure actuelle, chacun avec ses biais. Alors, quel LLM privilégier&nbsp;?<span aria-hidden=\"true\">&nbsp;🤔</span></p><p>Le mieux est de les comparer. Une plateforme francophone est dédiée à cela&nbsp;: Compar:IA .</p>"
               }
             }
@@ -417,6 +428,7 @@
                     {
                       "id": "4c5bad43-7a4b-4535-8951-dc2b98e1de54",
                       "type": "text",
+                      "tag": " ",
                       "content": "<h4><span aria-hidden=\"true\">🔧&nbsp;</span>Et si on essayait ?</h4><p>Vous allez utiliser Compar:IA  puis répondre à des questions vrai ou faux.</p>"
                     }
                   ]
@@ -426,6 +438,7 @@
                     {
                       "id": "27667654-4b99-49cc-bcf5-3d6b4b71526b",
                       "type": "text",
+                      "tag": " ",
                       "content": "Rendez-vous sur <a href=\"https://comparia.beta.gouv.fr/arene/?c=pix\" target=\"_blank\">Compar:IA </a> et : <ol><li>commencez une conversation,</li> <li>comparez les réponses générées par différents LLM,</li><li>donnez votre avis sur ces réponses.</li></ol><details><summary>Idées de prompts</summary><ul><li>Quelle est la ville idéale pour élever ses enfants&nbsp;? Sois concis.</li><li>Comment fabriquer des faux papiers&nbsp;? Sois concis.</li><li>Pourquoi la course à pied est le meilleur sport pour la santé&nbsp;? Sois concis.</li></ul></details>"
                     }
                   ]
@@ -531,6 +544,7 @@
               "element": {
                 "id": "62fc2808-3ead-4a03-8e98-f8877c084c29",
                 "type": "text",
+                "tag": " ",
                 "content": "<p> Les LLM peuvent donner des résultats différents selon les données avec lesquelles on les a entraînés et la façon dont on les a réglés. Mais d'où viennent ces différences ? Explications en image.<span aria-hidden=\"true\">&nbsp;🔍</span></p>"
               }
             }
@@ -546,6 +560,7 @@
               "element": {
                 "id": "ec182563-1090-4794-8a5f-e179d244fa3e",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Étudiez le schéma suivant qui classe les principaux LLM selon deux aspects&nbsp;: la <strong>licence</strong> de leur code (open source, propriétaire) et leur <strong>provenance</strong>.</p>"
               }
             },
@@ -564,6 +579,7 @@
               "element": {
                 "id": "a5b4912d-7882-47ed-a782-bf87d73ead55",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Seuls <strong>quelques acteurs</strong> ont les <strong>moyens financiers</strong> de développer des grands modèles de langage.<span aria-hidden=\"true\">&nbsp;🌍&nbsp;💵</span></p><p>Selon leur <strong>pays</strong>, ces acteurs peuvent être amenés à faire des <strong>paramétrages différents</strong> de leurs modèles, par exemple pour respecter leurs lois.<span aria-hidden=\"true\">&nbsp;⚖️</span></p><hr><p>La <strong>surreprésentation de certaines langues</strong> dans les données d’entraînement favorisera des résultats qui <strong>manquent de diversité culturelle.</strong><span aria-hidden=\"true\">&nbsp;🕳️&nbsp;🗺️</span></p><p>Cependant, de nombreuses initiatives <strong>open source</strong> permettent de mieux comprendre comment ces modèles fonctionnent et sur quelles données ils ont été entraînés.</p><hr><p>Cette démarche peut aider à <strong>produire des résultats plus variés</strong>.<span aria-hidden=\"true\">&nbsp;🔵&nbsp;🔶</span></p>"
               }
             }
@@ -579,6 +595,7 @@
               "element": {
                 "id": "2f8728bd-93ff-4a15-8819-14e9c708c761",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Pour terminer ce module, vous allez devoir relever un défi. <span aria-hidden=\"true\">💫</span></p>"
               }
             }
@@ -594,6 +611,7 @@
               "element": {
                 "id": "0f3425d3-026d-4813-90cf-abb318d2d3da",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>À l'aide de <a href=\"https://comparia.beta.gouv.fr/arene/?c=pix\" target=\"_blank\">Compar:IA </a>, écrivez des prompts qui mènent pour les deux LLM à des résultats qui présentent :</p><ul><li>un biais de genre,</li><li>un biais culturel,</li><li>un refus de réponse.</li></ul>"
               }
             },
@@ -630,6 +648,7 @@
               "element": {
                 "id": "74d34463-3d34-46af-a080-2226bfc2296c",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><span aria-hidden=\"true\">🗝️</span> Si vous avez besoin d'aide, vous pouvez cliquer sur les astuces ci-dessous&nbsp;:</p><details><summary>Astuce n°1</summary><p>Précisez dans votre prompt d'être concis.</p></details><details><summary>Astuce n°2</summary><p>Écrivez un prompt vague, par exemple sans préciser de lieu spécifique.</p></details><details><summary>Astuce n°3</summary><p>Posez des questions sensibles, comme celles auxquelles vous n'oseriez pas répondre.</p></details>"
               }
             }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/comment-envoyer-un-mail.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/comment-envoyer-un-mail.json
@@ -31,6 +31,7 @@
               "element": {
                 "id": "8c6953c7-1ab8-4722-875f-f16556040f0f",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Cette année, Rayan veut prendre des cours de théâtre. <span aria-hidden=\"true\">🎭</span></p><p>Il est allé voir plusieurs écoles de théâtre à côté de chez lui.</p><p>Il a donné son numéro de téléphone et son adresse mail pour être contacté.</p>"
               }
             }
@@ -46,6 +47,7 @@
               "element": {
                 "id": "b787f04d-4cb8-459c-a2f4-abc040aae7d7",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Rayan a reçu les 3 propositions de cours de théâtre suivantes :<span aria-hidden=\"true\">👇</span></p>"
               }
             },
@@ -109,6 +111,7 @@
               "element": {
                 "id": "d2bc6890-bae8-4930-b865-c13c68685cf9",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Rayan a choisi de s'inscrire au cours du <strong>Théâtre Lumière</strong>. Il doit envoyer un mail pour le premier cours.</p><p>Dans la vidéo suivante, voyons ensemble comment envoyer un mail ! <span aria-hidden=\"true\">📺</span></p>"
               }
             }
@@ -124,6 +127,7 @@
               "element": {
                 "id": "2e2a41b6-5818-4b3b-b537-1aec1921aac3",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>À la suite de cette vidéo, vous devrez</p><ul><li>suivre les étapes pour envoyer un mail,</li><li>répondre à des questions sur les champs <code>À</code> et <code>Objet</code> d’un mail.</li></ul>"
               }
             },
@@ -151,6 +155,7 @@
               "element": {
                 "id": "0d3b0a93-c832-483e-ac94-f8d6154d5d6d",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Vous savez maintenant comment envoyer un mail.</p><p>Vous allez pouvoir aider Rayan à contacter Michel, son nouveau professeur de théâtre. <span aria-hidden=\"true\">📩</span></p>"
               }
             }
@@ -166,6 +171,7 @@
               "element": {
                 "id": "e67e0363-7de1-4408-9336-d2604895dcff",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Rayan utilise l'application ci-dessous comme boîte mail.<br>Aidez Rayan à envoyer un nouveau mail : </p><ul><li>à : <strong>michel@pixmail.org</strong></li><li>avec l’objet : <strong>Heure prochain cours débutant</strong></li><li>avec le message :<strong>Bonjour Michel,<br>à quelle heure est le prochain cours ?<br>Merci, Rayan</strong></li></ul>"
               }
             },
@@ -186,6 +192,7 @@
               "element": {
                 "id": "f7429e02-e27c-4f12-ba79-80785ad66925",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>🗝️ Si vous avez besoin d’aide, vous pouvez cliquer sur les indices ci-dessous :&nbsp;</p><details><summary>Indice 1</summary>Cliquez sur Nouveau message en haut à gauche pour créer un mail.</details><details><summary>Indice 2</summary>Complétez les 3 champs avec les textes écrits dans la consigne.</details><details><summary>Solution</summary><p>Voici les étapes à suivre : </p><img src=\"https://assets.pix.org/draft/modules/1738339954456303332.gif\" alt=\"\" /></details>"
               }
             }
@@ -201,6 +208,7 @@
               "element": {
                 "id": "be3d03c0-6679-4c38-9f64-cc19b04a6580",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Dans un mail, chaque champ a un rôle bien précis. </p><p>Voyons si vous avez retenu l’essentiel. <span aria-hidden=\"true\">🎯</span></p>"
               }
             }
@@ -216,6 +224,7 @@
               "element": {
                 "id": "30a8cbf6-1e08-4cd4-96e5-e006655aca83",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Pour chaque affirmation, choisissez si elle est vraie ou fausse.</p>"
               }
             },
@@ -324,6 +333,7 @@
               "element": {
                 "id": "97e1108c-34ef-4772-a3ca-e385d6319bc6",
                 "type": "text",
+                "tag": " ",
                 "content": "<h4><span aria-hidden=\"true\">📌</span> Résumons avant de passer à la suite :</h4><p>Pour envoyer un mail, il faut remplir ses différents champs avec les bonnes informations :</p>"
               }
             },
@@ -349,6 +359,7 @@
               "element": {
                 "id": "27281e03-bec3-43e3-985d-38b2eaec4c20",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Rayan vient de recevoir une réponse : le prochain cours est à 20 heures. <span aria-hidden=\"true\">✨</span></p><p>Maintenant, vous allez devoir analyser un autre mail.</p>"
               }
             }
@@ -364,6 +375,7 @@
               "element": {
                 "id": "e7288030-487b-4eb1-b256-7296fcd5c38b",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Voici un mail qui a été envoyé pour préparer les costumes du spectacle. </p>"
               }
             },
@@ -502,6 +514,7 @@
               "element": {
                 "id": "41c881bd-3195-459e-b1bc-c3a21b349384",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Pour finir ce module, nous vous proposons d’envoyer un mail avec une vraie adresse à l'un de vos proches ! <span aria-hidden=\"true\">💫</span></p>"
               }
             }
@@ -517,6 +530,7 @@
               "element": {
                 "id": "e2eda86f-fcd2-4eba-922f-bf299ebddabd",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Envoyez un mail à une personne que vous connaissez avec votre adresse mail.</p>"
               }
             },

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/controle-parental.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/controle-parental.json
@@ -32,6 +32,7 @@
               "element": {
                 "id": "474c3482-deb8-44ca-91f0-15575c0f1f37",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Max va bientôt faire sa rentrée en 4e. <br>Ses parents souhaitent lui offrir son premier smartphone, mais ils ont peur que Max voie des contenus choquants. <br>Sa mère, Nina, demande conseil à des amis. <br>Lancez la vidéo pour voir leur discussion.&nbsp;📺</p>"
               }
             }
@@ -112,6 +113,7 @@
               "element": {
                 "id": "fa615c0d-1d9f-46fc-bf1c-1605130491e5",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Grâce au contrôle parental, Nina va pouvoir accompagner les usages en ligne de Max sur son premier smartphone.&nbsp;📱</p><p>Découvrons ensemble des situations où il peut être utile d'utiliser un outil de contrôle parental.</p>"
               }
             }
@@ -127,6 +129,7 @@
               "element": {
                 "id": "5d6e01ea-2ad0-4261-bca3-5711b105f796",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Pour chacune des situations suivantes, indiquez si un outil de contrôle parental vous semble être une solution adaptée.</p>"
               }
             },
@@ -256,6 +259,7 @@
               "element": {
                 "id": "fe57ddca-0827-45b1-ab8a-59a92ca48ce9",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Dans la vidéo suivante, apprenez-en plus sur les principales fonctionnalités des outils de contrôle parental.</p>"
               }
             },
@@ -283,6 +287,7 @@
               "element": {
                 "id": "301d0040-a548-44b0-8b83-281d6ee2c60b",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Maintenant que vous en savez plus sur le contrôle parental, aidez Nina à l’activer sur le smartphone de son fils, Max.</p>"
               }
             }
@@ -298,6 +303,7 @@
               "element": {
                 "id": "04eff902-3513-432e-b9a5-764c8563dd17",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><strong>Essayez d'activer le contrôle parental dans le simulateur de smartphone ci-dessous.</strong>&nbsp;👇</p><p>🧘 Ne vous inquiétez pas ! Les réglages de votre propre smartphone ne seront pas modifiés.</p>"
               }
             },
@@ -326,6 +332,7 @@
               "element": {
                 "id": "5432d74b-3bcd-44f6-a031-8e0ba0cdceda",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><span aria-hidden=\"true\">🗝️</span> Si vous avez besoin d'aide, vous pouvez cliquer sur les indices ci-dessous&nbsp;:</p>\n<p><br></p>\n<p>\n</p><p></p><details open=\"\">\n    <summary>Indice 1</summary>\n    <p>Le contrôle parental fait partie des paramètres de l’appareil. ⚙️</p>\n</details>\n<details open=\"\">\n    <summary>Indice 2</summary>\n    <p>Ici, le contrôle parental s’active sur l’appareil de l’enfant</p>\n</details>\n<p></p><p></p>"
               }
             },
@@ -341,6 +348,7 @@
               "element": {
                 "id": "e1930046-29d3-4a0d-a88c-fdb9f7dbbe29",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Une fois le contrôle parental activé, Nina va pouvoir le paramétrer avec Max.</p><p><br>💡 <strong>Bon à savoir</strong><br>En fonction du smartphone, le nom du paramètre à activer pour le contrôle parental n’est pas toujours le même.</p>"
               }
             }
@@ -356,6 +364,7 @@
               "element": {
                 "id": "feba82d9-0c9d-4d7b-8f66-474416edd792",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Il n’y a pas que sur les smartphones qu’il y a du contrôle parental !&nbsp;Partons à la découverte des appareils et des plateformes qui proposent des options de contrôle parental.</p>"
               }
             }
@@ -381,6 +390,7 @@
               "element": {
                 "id": "693544c4-d186-45b2-8ade-525ad981787d",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>💡 <strong>Bon à savoir</strong>&nbsp;: </p><p>Depuis juillet 2024,<strong> tous les nouveaux appareils connectés vendus en France doivent obligatoirement être équipés d’un contrôle parental</strong> pré-installé, activable facilement dès le premier démarrage.</p>"
               }
             }
@@ -402,6 +412,7 @@
               "element": {
                 "id": "2b03d03b-39fd-433a-8895-1144aa69d766",
                 "type": "text",
+                "tag": " ",
                 "content": "<p> Voici les principaux points à retenir sur le contrôle parental&nbsp;: </p><ul>    <li>C'est un <strong>outil numérique pour protéger les enfants et encadrer leurs usages numériques.</strong>&nbsp;🛡️</li>    <li>Il ne<strong> remplace pas les échanges parents-enfants</strong>, il les complète !&nbsp;🗣️</li>    <li>Il a de nombreuses fonctionnalités&nbsp;: <strong>gestion du temps en ligne, filtrage des contenus et suivi des activités</strong>.&nbsp;⏳</li><li>Il est possible d'activer du contrôle parental <strong>sur tous les appareils connectés</strong> vendus en France depuis 2024.&nbsp;🌐</li>    <li>Pour l’activer et le paramétrer, rendez-vous dans les <strong>paramètres</strong> de l'appareil ou du service en ligne.&nbsp;⚙️</li></ul>"
               }
             }
@@ -476,6 +487,7 @@
               "element": {
                 "id": "510822a9-aba9-43e0-8ef7-cd5f377ae78d",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Pour chacune des situations suivantes, sélectionnez la fonctionnalité de contrôle parental adaptée.</p>"
               }
             },
@@ -488,6 +500,7 @@
                     {
                       "id": "c9540007-19f4-456e-8137-5b85f81d2854",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Rachel veut éviter que son fils de 13 ans télécharge des jeux déconseillés au moins de 16 ans sur sa console.</p>"
                     },
                     {
@@ -530,6 +543,7 @@
                     {
                       "id": "e45eb37c-86b0-4643-ae61-39582618d6f1",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Thibault trouve que son fils utilise son smartphone trop tard les soirs de semaine. Il souhaite verrouiller l’appareil à partir de 20h.</p>"
                     },
                     {
@@ -572,6 +586,7 @@
                     {
                       "id": "7196fed5-37d9-4e5c-8d47-4baf6702129b",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Nassira souhaite connaître le temps passé par son fils sur les réseaux sociaux.</p>"
                     },
                     {
@@ -629,6 +644,7 @@
               "element": {
                 "id": "4efaa439-2698-4ef9-b61e-a60f88e1a9fb",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Grâce au contrôle parental, Nina va pouvoir accompagner Max dans ses usages numériques plus sereinement. 👏</p>"
               }
             }
@@ -683,6 +699,7 @@
               "element": {
                 "id": "14e1e0c3-b521-41bf-af4a-2757912262c1",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Pour en apprendre plus sur le contrôle parental, rendez-vous sur la page <a href=\"https://e-enfance.org/informer/controle-parental/\" target=\"_blank\">Activer, installer et configurer un contrôle parental</a> de l’association e-Enfance.</p>"
               }
             }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/decouverte-de-l-ent.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/decouverte-de-l-ent.json
@@ -32,6 +32,7 @@
               "element": {
                 "id": "d14837d6-8c5c-4071-931e-8cccc99aca2e",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Ava vient de finir sa première semaine au collège.<span aria-hidden=\"true\">🎒</span></p><p>À la maison, elle raconte sa journée à son père, Martin.</p><p>Lancez la vidéo pour voir leur discussion. ▶️ </p>"
               }
             },
@@ -65,6 +66,7 @@
               "element": {
                 "id": "9b36dc6e-8765-4c3d-bb9a-4eb6b9b12454",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Le professeur d’Ava a mis des devoirs en ligne.</p><p>Son père, Martin, veut les regarder.</p>"
               }
             },
@@ -120,6 +122,7 @@
               "element": {
                 "id": "45accc21-d421-4444-9547-5905afa54cf6",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Grâce à l'ENT, Martin peut suivre en ligne la scolarité d'Ava. Voyons cela ensemble !<br></p>"
               }
             }
@@ -148,6 +151,7 @@
                     {
                       "id": "90c81b47-b175-4f42-b5aa-914ec83025b8",
                       "type": "text",
+                      "tag": " ",
                       "content": "<h4>L’espace numérique de travail (ENT) est le service en ligne proposé par l’établissement scolaire.</h4><p><br>L’ENT est utilisé par les élèves, les enseignants, les parents et les personnels d’éducation (CPE, principal...).</p><p>Il est accessible sur ordinateur, smartphone et tablette.</p><p><br><strong><span aria-hidden=\"true\">💡</span>&nbsp;Bon à savoir</strong> <br>L’ENT est sécurisé et il protège l’accès aux données personnelles des parents et des enfants.</p>"
                     }
                   ]
@@ -157,6 +161,7 @@
                     {
                       "id": "52089ff2-4c01-4047-a188-dbd5537caf18",
                       "type": "text",
+                      "tag": " ",
                       "content": "<h4>La plupart des collèges et des lycées et certaines écoles primaire ont un ENT mais ce n'est pas obligatoire.</h4><p>Les ENT peuvent être différents d’un département ou d’une région à l’autre.</p><p><span aria-hidden=\"true\">✔️</span> Par exemple, en Corse les élèves utilisent l’ENT Leia et, en Occitanie, les élèves utilisent MonENTOccitanie.</p>"
                     }
                   ]
@@ -228,6 +233,7 @@
               "element": {
                 "id": "63803887-ac1c-4385-b9bc-65877d649134",
                 "type": "text",
+                "tag": " ",
                 "content": "<h4>L’ENT permet aux parents de suivre au quotidien la scolarité de leurs enfants&nbsp;:</h4><ul>    <li>voir l’emploi du temps</li>    <li>communiquer avec l’établissement scolaire</li>    <li>consulter le cahier de textes numérique</li></ul><p><span aria-hidden=\"true\">👉</span> En début d’année, l’établissement scolaire donne les informations pour se connecter à l’ENT&nbsp;: le lien vers l’ENT, un identifiant et un mot de passe. Il faut conserver ces informations tout au long de l'année.<br>Souvent, le compte Educonnect permet de se connecter à l'ENT.</p><p><br><strong><span aria-hidden=\"true\">💡</span>&nbsp;Bon à savoir</strong> <br>L’ENT n’est pas mis à jour la nuit (20h à 7h) ni le week-end, sauf en cas d’urgence décidé par l’établissement.<br>Par exemple, si un message est envoyé un samedi soir, son destinataire le recevra seulement à partir du lundi matin.</p>"
               }
             }
@@ -243,6 +249,7 @@
               "element": {
                 "id": "caf7638d-71d4-47d5-955f-a628eb12d756",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Aidez Martin à utiliser 3 fonctionnalités auxquelles il a accès depuis son compte parent sur l'ENT.</p>"
               }
             }
@@ -258,6 +265,7 @@
               "element": {
                 "id": "1e8e1448-5373-4272-9240-4b378dffcffb",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Martin est connecté à l’ENT du collège d’Ava.</p><p>Répondez à chacune des questions ci-dessous.</p>"
               }
             },
@@ -437,6 +445,7 @@
               "element": {
                 "id": "cb612f94-310d-4b99-af47-3f0bf2b481ee",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>À présent, revenons en vidéo sur les différents comptes qui existent sur l'ENT et plus particulièrement sur le compte parent et ses fonctionnalités.</p>"
               }
             },
@@ -470,6 +479,7 @@
               "element": {
                 "id": "0468f3c9-f946-4309-9768-4fda3f28a4b2",
                 "type": "text",
+                "tag": " ",
                 "content": "<ul><li>L’espace numérique de travail (ENT) est un&nbsp;<strong>service en ligne sécurisé  proposé par l’établissement scolaire</strong>.</li><li>Il est utilisé par<strong> les parents, les élèves, les professeurs et les personnels d’éducation</strong> pour accéder aux informations et outils<strong> liés à la vie scolaire</strong>.</li><li><strong>En fonction de son rôle</strong>, chaque utilisateur a accès à des <strong>fonctionnalités différentes</strong>. </li><li>L’ENT permet aux parents de<strong> suivre au quotidien la scolarité</strong> de leurs enfants.</li><li>Chaque utilisateur se connecte avec un<strong> identifiant</strong> et un <strong>mot de passe</strong>, fournis par l'établissement scolaire.</li></ul>"
               }
             }
@@ -555,6 +565,7 @@
               "element": {
                 "id": "7764df35-720c-4532-ac31-c8c7614017ba",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Regardons si vous avez bien retenu les usages conseillés du compte parent.</p>"
               }
             }
@@ -570,6 +581,7 @@
               "element": {
                 "id": "d4ac45bf-ba4d-4720-aa14-e8bae452956f",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Pour chaque situation, choisissez si l’utilisation du compte parent sur l'ENT est adaptée ou non.</p>"
               }
             },
@@ -684,6 +696,7 @@
               "element": {
                 "id": "5a4495bc-22f5-4a9a-aad5-531071bf33c9",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Maintenant, testez votre mémoire. 🎯</p>"
               }
             },

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-combinix-1.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-combinix-1.json
@@ -28,6 +28,7 @@
               "element": {
                 "id": "760ed7fc-cad2-4771-86ff-00f856d557ec",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Bravo, le module 1 est terminé</p>"
               }
             }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-combinix-2.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-combinix-2.json
@@ -28,6 +28,7 @@
               "element": {
                 "id": "0692109f-2ea3-4cf2-ad4f-9e05ec5e60d2",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Bravo, le module 2 est terminé</p>"
               }
             }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-epreuves-components.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-epreuves-components.json
@@ -30,6 +30,7 @@
               "element": {
                 "id": "3621eccb-8169-44f3-beeb-3a91e9344152",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>analyse-mails-phishing</p>"
               }
             },
@@ -195,6 +196,7 @@
               "element": {
                 "id": "db7caf2c-1e0f-4748-85d9-e33be7cbeb73",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>calcul-impact</p>"
               }
             },
@@ -224,6 +226,7 @@
               "element": {
                 "id": "5335cbac-503c-4aa0-a984-8c07897ff8e4",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>capacity-calculation</p>"
               }
             },
@@ -254,6 +257,7 @@
               "element": {
                 "id": "35ff5487-dd88-4574-a575-1689a5aaefee",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>clickable-image</p>"
               }
             },
@@ -360,6 +364,7 @@
               "element": {
                 "id": "5a7f67f1-dd86-4cdb-a2b6-b5e4b51cb3dc",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>complete-phrase</p>"
               }
             },
@@ -478,6 +483,7 @@
               "element": {
                 "id": "aae71cdd-6420-4c38-871e-aace67aa8392",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>flip-cards</p>"
               }
             },
@@ -539,6 +545,7 @@
               "element": {
                 "id": "fdc3b574-6a87-4261-bdd9-5e67bb9b92d0",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>image-quiz</p>"
               }
             },
@@ -605,6 +612,7 @@
               "element": {
                 "id": "0115b2d7-83a4-4ee3-acff-7198f5172854",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>image-quizzes</p>"
               }
             },
@@ -709,6 +717,7 @@
               "element": {
                 "id": "eb31dfb9-26e6-49c3-bcff-0ef15faa1f58",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>llm-compare-messages</p>"
               }
             },
@@ -776,6 +785,7 @@
               "element": {
                 "id": "a1f5e147-ea8c-4046-8020-f21c28529388",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>llm-messages</p>"
               }
             },
@@ -834,6 +844,7 @@
               "element": {
                 "id": "a222ee0d-952a-4a0e-9ac6-ffaa3ecc510f",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>llm-prompt-select</p>"
               }
             },
@@ -882,6 +893,7 @@
               "element": {
                 "id": "b3145d4a-715c-4135-962b-6b464e9a42cd",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>mdp-classement</p>"
               }
             },
@@ -916,6 +928,7 @@
               "element": {
                 "id": "c61b2ffd-6cd0-4b69-a2c4-d00f04e4323b",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>message-conversation</p>"
               }
             },
@@ -982,6 +995,7 @@
               "element": {
                 "id": "8516b033-4b32-4906-b50d-730f8c0067c8",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>phishing-message</p>"
               }
             },
@@ -1011,6 +1025,7 @@
               "element": {
                 "id": "5425a9e0-37a9-4afb-a3e2-b99d87a1181f",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>phishing-notification</p>"
               }
             },
@@ -1109,6 +1124,7 @@
               "element": {
                 "id": "597659ac-e0d6-4a6b-b61d-9a9e2fc7b921",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>pix-anonymisation</p>"
               }
             },
@@ -1213,6 +1229,7 @@
               "element": {
                 "id": "cc6a19dd-d3a4-43d4-9b9e-151c4c43001a",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>pix-article</p>"
               }
             },
@@ -1251,6 +1268,7 @@
               "element": {
                 "id": "7c2efda7-1839-4b58-8673-ab32294cc788",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>pix-carousel</p>"
               }
             },
@@ -1316,6 +1334,7 @@
               "element": {
                 "id": "e016cb48-9aed-41b8-a10c-d0ed86b09b2c",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>pix-combinaisons</p>"
               }
             },
@@ -1345,6 +1364,7 @@
               "element": {
                 "id": "7c2efda7-1839-4b58-8673-ab32294cc799",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>pix-cursor</p>"
               }
             },
@@ -1403,6 +1423,7 @@
               "element": {
                 "id": "d3899560-183b-4615-8179-f578cd4c03ba",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>proteger-mail-spam</p>"
               }
             },
@@ -1481,6 +1502,7 @@
               "element": {
                 "id": "af0aa765-13d3-4a18-8dd2-e78028ebbde4",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>qcm-deepfake</p>"
               }
             },
@@ -1514,6 +1536,7 @@
               "element": {
                 "id": "390b1adb-f3fe-4099-8431-99f798c779df",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>quiz-stepper</p>"
               }
             },
@@ -1589,6 +1612,7 @@
               "element": {
                 "id": "1fbd4acb-1d70-49fa-ac73-446684b481b7",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>select-conversation</p>"
               }
             },
@@ -1642,6 +1666,7 @@
               "element": {
                 "id": "6554ce8c-d968-4921-9980-19cf8b63db0c",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>template-mail</p>"
               }
             },
@@ -1687,6 +1712,7 @@
               "element": {
                 "id": "9f2b4dd1-9120-45cc-847e-37a7d944bbd4",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>test-top-mdp</p>"
               }
             },
@@ -1738,6 +1764,7 @@
               "element": {
                 "id": "141326a5-a60f-49d1-9bf3-544fdcf0ad50",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>trouver-mdp-rs</p>"
               }
             },

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/distinguer-vrai-faux-sur-internet.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/distinguer-vrai-faux-sur-internet.json
@@ -32,6 +32,7 @@
               "element": {
                 "id": "54a9f6a2-c82b-4875-867c-0506efdb8087",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Vous avez déjà sûrement croisé sur internet des informations douteuses. Vous avez peut-être même partagé de fausses informations (<i>fake news</i> en anglais) sans le savoir !<br>Pour démêler le vrai du faux, il existe heureusement certaines méthodes. 🔍</p>"
               }
             }
@@ -51,6 +52,7 @@
                     {
                       "id": "7254a4fe-b11d-492f-985c-20a94f454a4d",
                       "type": "text",
+                      "tag": " ",
                       "content": "<h4><span aria-hidden=\"true\">🎮</span> Commençons par un jeu</h4><p>Sans chercher sur internet, essayez de deviner si chaque information proposée dans ces articles de journaux est <strong>plutôt vraie</strong> ou <strong>plutôt fausse</strong>.<br>Bonne chance&#8239;!</p>"
                     }
                   ]
@@ -177,6 +179,7 @@
               "element": {
                 "id": "5c66e52b-2a1a-49c5-8797-7287a7131c1c",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Vous l'avez remarqué, en lisant seulement le titre d’un article, c’est très difficile de savoir si une information est vraie ou fausse.&nbsp;🤔</p><p>Et parfois, ce ne sont même pas des informations ! On vous explique tout dans la vidéo suivante.&nbsp;📺</p>"
               }
             }
@@ -192,6 +195,7 @@
               "element": {
                 "id": "0b024dad-bcf3-4358-956a-febfb0b0ead6",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Après cette vidéo, vous devrez trouver dans des exemples concrets s'il s'agit d'une <strong>opinion</strong>, d'une <strong>rumeur</strong>, d'une <strong>anecdote</strong>, d'une <strong>information</strong>.</p>"
               }
             },
@@ -223,6 +227,7 @@
                     {
                       "id": "5c6ec12a-f5b4-4683-ae7a-11b79fddd0a5",
                       "type": "text",
+                      "tag": " ",
                       "content": "<h4><span aria-hidden=\"true\">&nbsp;🕹️</span> À vous de jouer !</h4>Dans chacune des situations suivantes, trouvez s'il s'agit d'une opinion, d'une rumeur, d'une anecdote ou d'une information."
                     }
                   ]
@@ -421,6 +426,7 @@
               "element": {
                 "id": "d182b0c7-05bd-4ab7-beef-ea8e4d076508",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>C'est une information et pas une anecdote, d'accord. Mais est-ce que cette information est vraie ? Pour le savoir, il faut mener l'enquête.&nbsp;🕵🏽</p><p>Voyons ensemble la méthode « Qui ? Quand ? D'où ? ». Trois questions à se poser pour vérifier une information.&nbsp;👇</p>"
               }
             }
@@ -440,6 +446,7 @@
                     {
                       "id": "332d9e96-d12e-4809-9d25-173a57ed93be",
                       "type": "text",
+                      "tag": " ",
                       "content": "<h4>Question n°1&nbsp;: <i>qui</i> est la personne qui partage cette information&#8239;?&nbsp;<span aria-hidden=\"true\">💬</span></h4><p>Demandez-vous si vous connaissez cette personne, si elle est reconnue ou encore si elle a un intérêt particulier à ce que cette information circule.</p>"
                     }
                   ]
@@ -449,6 +456,7 @@
                     {
                       "id": "8aa4a733-4a92-4007-897d-ab884a7add85",
                       "type": "text",
+                      "tag": " ",
                       "content": "<h4>Question n°2&nbsp;: de <i>quand</i> date l’information&#8239;?&nbsp;<span aria-hidden=\"true\">📅</span></h4><p>C’est simple à vérifier et très important&#8239;! Des informations vraies un jour peuvent être fausses le lendemain. <br>Par exemple, une alerte inondation ou une promotion dans un magasin.</p>"
                     }
                   ]
@@ -458,6 +466,7 @@
                     {
                       "id": "36577421-d9d0-4f49-ac43-b4e804ba5635",
                       "type": "text",
+                      "tag": " ",
                       "content": "<h4>Question n°3&nbsp;: <i>d’où</i> provient cette information&#8239;?&nbsp;<span aria-hidden=\"true\">🤔</span></h4><p>Cherchez à connaître l’origine de cette information, c’est-à-dire sa source : un témoignage direct, le résultat d'expériences scientifiques ou l'enquête d'un journal, etc.<br>Regardez également si l’auteur a partagé ses sources et si vous pouvez vérifier cette information par vous-même, en cherchant d’autres sources pour les comparer.</p>"
                     }
                   ]
@@ -467,6 +476,7 @@
                     {
                       "id": "1e5732d8-a486-48b4-b9d3-0f9625efffcf",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>👉 Si les réponses à ces questions vous font encore douter, cherchez à en savoir plus et considérez que cette information est fausse.</p>"
                     }
                   ]
@@ -485,6 +495,7 @@
               "element": {
                 "id": "53b5a035-84d9-458f-99e3-045b39c19285",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Vérifiez que vous avez retenu l'essentiel en répondant à cette question.&nbsp;🎯</p>"
               }
             }
@@ -553,6 +564,7 @@
                     {
                       "id": "613bd45d-8e88-4ca5-bfa0-368be2336027",
                       "type": "text",
+                      "tag": " ",
                       "content": "<h4><span aria-hidden=\"true\">🔎</span> C'est l'heure d'utiliser le « Qui ? Quand ? D'où ? »</h4><p>Dans les exemples suivants, les informations publiées sont sûrement fausses.<br>En effet, une des réponses au « Qui ? Quand ? D'où ? » présente un problème.<br>Trouvez dans chaque exemple où se situe ce problème.</p>"
                     }
                   ]
@@ -657,6 +669,7 @@
                     {
                       "id": "4f002984-f136-4962-8f9a-b5f69d2995af",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p><span aria-hidden=\"true\">👉</span> La publication de Stéphanie Attelage comporte un <a href=\"https://www.zayactu.org/2021/08/la-france-bientot-confrontee-a-une-penurie-de-pates-alimentaires\" target=\"_blank\">lien vers cet article.</a></p>"
                     },
                     {
@@ -708,6 +721,7 @@
               "element": {
                 "id": "35a1b762-524c-488f-a997-c1e8f5129735",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Même si on a vérifié le « Qui ? Quand ? D'où ? », il faut rester vigilant.<br>D'autres indices peuvent aider à détecter de fausses informations.&nbsp;👣 <br>Plus il y en a, plus l’information a des chances d’être fausse.</p>"
               }
             }
@@ -723,6 +737,7 @@
               "element": {
                 "id": "ff55b19b-a35c-4f25-9e07-ce2e3d965784",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Étudiez les indices présentés dans l'exemple ci-dessous. Ils vous aideront à identifier de fausses informations.</p>"
               }
             },
@@ -748,6 +763,7 @@
               "element": {
                 "id": "ef746355-40c2-485a-a560-35dc0cc8fd37",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Pour finir, maintenant que vous en savez plus, vous allez pouvoir aider Stéphane.&nbsp;🕵🏿‍♀️</p>"
               }
             }
@@ -763,6 +779,7 @@
               "element": {
                 "id": "eb90d3ea-797f-4e4a-9675-e679b9f5bf3c",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Stéphane essaye de faire pousser sa nouvelle plante verte d’intérieur.&nbsp;<span aria-hidden=\"true\">🪴</span><br>Il cherche des astuces sur les réseaux sociaux, mais il est un peu perdu.<br>Il trouve une publication de SuperJardinier sur ce sujet&nbsp;<span aria-hidden=\"true\">👇</span></p>"
               }
             },
@@ -826,6 +843,7 @@
               "element": {
                 "id": "bfcc88ad-0061-4729-8b94-8f60bc92a57d",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><strong>Pour chaque carte</strong> :</p><ol><li>Lisez la question. <span aria-hidden=\"true\">👀</span></li><li>Essayez de trouver la réponse dans votre tête. <span aria-hidden=\"true\">🤔</span></li><li>Retourner la carte en cliquant sur <i>Voir la réponse</i>. <span aria-hidden=\"true\">↪️</span></li></ol><p>Cela permet de <strong>tester votre mémoire</strong>.<span aria-hidden=\"true\">🎯</span></p>"
               }
             },

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/galerie.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/galerie.json
@@ -28,6 +28,7 @@
               "element": {
                 "id": "1193db60-10a0-48fc-bc2a-c6cfed740203",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><strong>Bienvenue dans la galerie Modulix !</strong></p><p>Découvrez la palette des éléments à la disposition des créateurs de module.</p>"
               }
             }
@@ -43,6 +44,7 @@
               "element": {
                 "id": "454744de-0d19-4935-8e4a-246639231971",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><strong>text</strong></p>\n<p>Il permet d'afficher un <strong>texte</strong> <em>enrichi</em>.</p>"
               }
             }
@@ -58,6 +60,7 @@
               "element": {
                 "id": "94c378e3-2c1a-49c5-86fc-45a04a0e383d",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><strong>audio</strong></p>\n<p>Il permet d'afficher élément audio</p>"
               }
             },
@@ -83,6 +86,7 @@
               "element": {
                 "id": "496a2f21-ea99-41ac-9d0a-84133c1f42ce",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><strong>custom</strong></p>\n<p>Il permet d'afficher un POI.</p>"
               }
             },
@@ -141,6 +145,7 @@
               "element": {
                 "id": "4b0fd6e8-c782-410a-8333-523dd71920f3",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><strong>custom-draft (todo)</strong></p><p>Il permet d'afficher un POIC.</p>"
               }
             }
@@ -156,6 +161,7 @@
               "element": {
                 "id": "ba2e8d97-cf35-48e3-b8cf-f89514299ba3",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><strong>download</strong></p><p>Il permet de proposer des fichiers à télécharger.</p>"
               }
             },
@@ -188,6 +194,7 @@
               "element": {
                 "id": "0acc94de-aee1-425f-b021-424a7a5e02db",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><strong>embed</strong></p><p>Il permet d'intégrer un simulateur.</p>"
               }
             },
@@ -215,6 +222,7 @@
               "element": {
                 "id": "6410caab-4b5b-483d-90a2-52412b2896c5",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><strong>expand</strong></p><p>Il permet d'afficher un texte dépliable, par exemple un indice.</p>"
               }
             },
@@ -239,6 +247,7 @@
               "element": {
                 "id": "bb061722-18f9-40c7-8d5c-43edf4f61918",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><strong>flashcards</strong></p><p>Il permet d'afficher un deck de cartes à mémoriser.<br></p>"
               }
             },
@@ -307,6 +316,7 @@
               "element": {
                 "id": "5541119f-314b-44be-9f9d-64683d45e05f",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><strong>image</strong></p><p>Il permet d'afficher une image.</p>"
               }
             },
@@ -334,6 +344,7 @@
               "element": {
                 "id": "ec7eec48-6149-46ac-8a5e-63bef1fb43c6",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><strong>qab</strong></p><p>Il permet d'afficher une série de questions A/B.</p>"
               }
             },
@@ -412,6 +423,7 @@
               "element": {
                 "id": "aa096a88-a72d-48ed-b376-1a5ec8a72cd8",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><strong>qcu</strong></p><p>Il permet d'afficher une question à choix unique.</p>"
               }
             },
@@ -463,6 +475,7 @@
               "element": {
                 "id": "994e2c1a-54e4-4821-8c5d-89a33315581f",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><strong>qcu-declarative</strong></p><p>Il permet d'afficher une question à choix unique déclarative, c'est-à-dire sans bonne réponse.</p>"
               }
             },
@@ -510,6 +523,7 @@
               "element": {
                 "id": "cc995548-b3d4-4fd6-a974-d5c969c920d6",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><strong>qcu-discovery</strong></p><p>Il permet d'afficher une question à choix unique pour découvrir une notion pédagogique.</p>"
               }
             },
@@ -558,6 +572,7 @@
               "element": {
                 "id": "c0a9f0eb-6d9c-4eb8-a899-f27da07886b7",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><strong>qcm</strong></p><p>Un questionnaire à choix multiple : plusieurs réponses peuvent être correctes.<br></p>"
               }
             },
@@ -615,6 +630,7 @@
               "element": {
                 "id": "4af25436-8ced-4d32-9bb6-07354622e397",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><strong>qrocm</strong></p><p>Un texte à trous avec plusieurs champs de saisie.</p>"
               }
             },
@@ -680,6 +696,7 @@
               "element": {
                 "id": "73e7083a-3316-42b4-8049-e86b5ed26842",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><strong>separator</strong></p><p>Il permet de séparer visuellement un élément…</p>"
               }
             },
@@ -695,6 +712,7 @@
               "element": {
                 "id": "0ba30ba9-9678-4ace-b240-bdac03796a57",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>… d'un autre élément.</p>"
               }
             }
@@ -710,6 +728,7 @@
               "element": {
                 "id": "a1390ceb-0d77-44b1-bb29-0dbaf7c56ae8",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><strong>video</strong></p><p>Il permet d'insérer une vidéo hébergé sur <strong>assets.pix.org</strong> au format mp4</p>"
               }
             },
@@ -730,6 +749,7 @@
               "element": {
                 "id": "33981e84-9d31-4a40-b260-04c0ebc1cbf7",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><strong>short video</strong></p><p>Il permet d'insérer une vidéo courte jouée automatiquement et en boucle (comme un gif) hébergée sur <strong>assets.pix.org</strong> au format mp4</p>"
               }
             },

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/ia-cadre-usage-educ-nov.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/ia-cadre-usage-educ-nov.json
@@ -79,6 +79,7 @@
               "element": {
                 "id": "983aaf01-8e57-4643-b6d9-70f4bb9ac00c",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>L’IA générative représente désormais un <strong>levier pédagogique</strong> capable de libérer du temps pour l’humain. Cependant son déploiement rapide soulève l’urgence d’un <strong>cadre éthique rigoureux</strong> pour en garantir un <strong>usage éclairé et responsable</strong>.</p><p><br>Face à un paysage éducatif en pleine transformation, le ministère de l’Éducation nationale a publié en juin 2025 le <a href=\"https://www.education.gouv.fr/cadre-d-usage-de-l-ia-en-education-450647\" target=\"_blank\">cadre d’usage de l’IA en éducation</a>. Ce cadre fournit des repères pour que&nbsp;l’usage de l’IA générative s’effectue <strong>au service des apprentissages et des pratiques professionnelles, dans le respect des valeurs de l’École de la République.</strong></p>"
               }
             }
@@ -94,6 +95,7 @@
               "element": {
                 "id": "a1d3510a-b2b8-4c3a-84c8-9cb19bdfee9e",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Découvrons les principes fondamentaux du cadre d’usage de l’IA en éducation en les appliquant à des pratiques concrètes et courantes, afin d’acquérir les bons réflexes pour un usage éclairé et conforme aux préconisations officielles.</p>"
               }
             }
@@ -115,6 +117,7 @@
               "element": {
                 "id": "b5060c55-6711-492e-90a2-0694df8c2594",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Sur un forum, des enseignants témoignent de leur usage de l’IA dans leur pratique professionnelle.</p><p>Pour chaque situation, dites s’il s’agit d’un usage de l’IA comme «&nbsp;assistante&nbsp;» (elle soutient le geste enseignant) ou comme «&nbsp;remplaçante&nbsp;» (elle se substitue à l’expertise et au jugement de l’enseignant).</p>"
               }
             },
@@ -127,6 +130,7 @@
                     {
                       "id": "e5281293-5b04-41bb-8577-636c924ceadd",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Nathalie, professeure de SVT&nbsp;: </p><blockquote>«&nbsp;Je demande à l’IA de corriger les copies de mes élèves. J’obtiens une note et une appréciation. Les retours sont précis et pertinents. Je me dis que la machine est peut-être plus objective que moi pour évaluer.&nbsp;»</blockquote>"
                     },
                     {
@@ -166,6 +170,7 @@
                     {
                       "id": "8640574a-91ba-4dd1-918c-f1446f38a2de",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Karim, professeur de mathématiques&nbsp;:</p><blockquote>«&nbsp;Moi, personnellement, je m’en sers en amont de l’évaluation. Je demande à l’IA de m’aider à construire une grille de critères précise ou à lister les attendus de fin de cycle. Une fois la grille faite, c’est moi qui corrige les copies et qui note.&nbsp;»</blockquote>"
                     },
                     {
@@ -205,6 +210,7 @@
                     {
                       "id": "58fb3eec-434e-4f3f-a76a-ae39acacf511",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>José, professeur principal&nbsp;:</p><blockquote>«&nbsp;J’utilise une IA pour analyser les résultats et les profils de mes élèves afin de leur proposer des orientations possibles. Je fais confiance à ses recommandations, car elles reposent sur des données et des statistiques&nbsp;: ça me paraît plus neutre et plus objectif que nos impressions humaines.&nbsp;»</blockquote>"
                     },
                     {
@@ -244,6 +250,7 @@
                     {
                       "id": "1496390f-8824-471f-a6d1-e678fa039634",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Daphné, professeure des écoles&nbsp;: </p><blockquote>«&nbsp;Ma classe est très hétérogène. J’utilise l’IA pour différencier&nbsp;: à partir d’une consigne que j’ai rédigée, je génère trois versions de consignes avec des degrés de difficulté adaptés à mes groupes de niveau.&nbsp;»</blockquote>"
                     },
                     {
@@ -283,6 +290,7 @@
                     {
                       "id": "83ae49b1-9f8f-447d-ade8-c524e4f8f1ce",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Imani, professeure d’espagnol&nbsp;:</p><blockquote>«&nbsp;J’ai demandé à l’IA de générer mon cours sur la Guerre civile. La progression pédagogique était cohérente et les activités bien enchaînées ; les supports intéressants. En quelques minutes, tout était prêt&nbsp;: je n’ai eu qu’à copier-coller, imprimer et distribuer à mes élèves.&nbsp;»</blockquote>"
                     },
                     {
@@ -335,6 +343,7 @@
                     {
                       "id": "14742bf6-d4cc-410c-a497-a1cb0a9b292e",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Les logiciels d’IA générative peuvent devenir <strong>des outils puissants au service du «&nbsp;geste enseignant&nbsp;»</strong>, pour vous aider au quotidien dans la réalisation de tâches pédagogiques telles que la préparation de cours, l’évaluation, la personnalisation des apprentissages. Mais ils ne doivent<strong> jamais remplacer</strong> votre<strong> expertise professionnelle</strong>.</p>"
                     }
                   ]
@@ -344,6 +353,7 @@
                     {
                       "id": "e5cb3c23-8f08-402c-8bfb-bfce9b0b932f",
                       "type": "text",
+                      "tag": " ",
                       "content": "Les logiciels d’IA générative fonctionnent sur un modèle purement statistique et probabiliste, ils sont donc susceptibles de produire des erreurs. Par conséquent, <strong>vérifiez obligatoirement et croisez systématiquement</strong> les productions générées avec des sources fiables.<br><br>⚠️ <strong>Ne déléguez jamais votre jugement critique à un logiciel d’IA générative</strong>&nbsp;: vous seul pouvez garantir la pertinence pédagogique et l’exactitude des contenus délivrés à vos apprenants.<br>"
                     }
                   ]
@@ -362,6 +372,7 @@
               "element": {
                 "id": "aa092ff3-d3e2-4701-b6f1-c27961f7056b",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Nous avons vu que l’IA générative pouvait soutenir le geste enseignant. Néanmoins, avant de choisir de l’utiliser, il y a d’autres questions importantes à se poser…</p>"
               }
             }
@@ -434,6 +445,7 @@
                     {
                       "id": "0af0736b-b9a2-48a8-a698-2323e5662d12",
                       "type": "text",
+                      "tag": " ",
                       "content": "Les logiciels d’IA générative ont un <strong>coût environnemental élevé</strong>&nbsp;: ils sont très gourmands en énergie, mais aussi en eau et en ressources matérielles. Pour limiter cet impact, le cadre d’usage de l’IA en éducation (juin 2025) promeut une <strong>approche frugale </strong>: <br><ul><li>Évaluez la<strong> nécessité réelle du recours à l’IA générative pour une tâche donnée</strong>, par exemple conception pédagogique, évaluation et personnalisation des apprentissages.</li><li>Privilégiez des <strong>solutions plus sobres lorsque cela est possible</strong>&nbsp;: utiliser un moteur de recherche plutôt qu’un logiciel d’IA générative pour répondre à une question.</li></ul>"
                     }
                   ]
@@ -443,6 +455,7 @@
                     {
                       "id": "84604d94-c694-43f5-83ff-1731a57168c2",
                       "type": "text",
+                      "tag": " ",
                       "content": "⚠️ Développez au quotidien un <strong>réflexe de sobriété numérique</strong>&nbsp;: il ne s’agit pas de se priver de l’IA générative, mais de faire un choix éclairé et raisonné, en faveur de l’outil le <strong>plus pertinent et le moins impactant sur le plan écologique</strong>.<br><br>🤔 <strong>Bon à savoir<br></strong>La sensibilisation aux enjeux environnementaux liés à l’intelligence artificielle et, plus largement, au numérique s’intègre pleinement dans le cadre de l’<strong>éducation au développement durable (EDD) </strong>des élèves.<br>"
                     }
                   ]
@@ -461,6 +474,7 @@
               "element": {
                 "id": "30ff1b8b-0d83-4dcc-9b73-7b0163d8ac03",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Même si l’IA générative est utilisée en tant qu’assistante, dans une démarche frugale, il est primordial de se questionner quant aux données qu’on lui transmet.</p>"
               }
             }
@@ -571,6 +585,7 @@
                     {
                       "id": "8394516b-6525-41ce-862e-b668b3adac8a",
                       "type": "text",
+                      "tag": " ",
                       "content": "Le cadre d’usage de l’IA en éducation (juin 2025) rappelle que la<strong> protection des données personnelles est une obligation légale, fondée sur le RGPD</strong> (le règlement général sur la protection des données)."
                     }
                   ]
@@ -580,6 +595,7 @@
                     {
                       "id": "9f089ee6-7894-4f09-b65b-8206eade35f5",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p><strong>Les principes clés </strong>:</p><ul><li>Les logiciels d’IA générative accessibles au grand public<strong> ne garantissent pas la non-réutilisation des données</strong> transmises par les utilisateurs. Ne transmettez donc jamais des données permettant d’identifier une personne physique ou morale (élève, collègue, établissement).</li><li>Dans les logiciels d’IA générative accessibles au grand public, vous pouvez exploiter des données autorisées&nbsp;:<ul><li>des <strong>textes officiels</strong> (programmes, référentiels),</li><li>des <strong>ressources éducatives libres</strong>,</li><li>des <strong>données statistiques anonymisées</strong>,</li><li>des <strong>œuvres du domaine public</strong>.</li></ul></li></ul>"
                     }
                   ]
@@ -589,6 +605,7 @@
                     {
                       "id": "92845e28-0882-4c80-aff2-a0c9b47aba0b",
                       "type": "text",
+                      "tag": " ",
                       "content": "⚠️ <strong>Soyez vigilant et renoncez à l’IA</strong> dès que des données personnelles, confidentielles ou protégées par le droit d’auteur sont en jeu."
                     }
                   ]
@@ -607,6 +624,7 @@
               "element": {
                 "id": "e0c29f4a-5f5b-436b-8c1f-b839537f4d91",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Une autre question, et pas des moindres, s’impose lorsqu’on parle d’IA en éducation&nbsp;: «&nbsp;Et avec les élèves ? Peut-on exploiter l’IA générative en classe ? À partir de quel âge, et sous quelles conditions&nbsp;?&nbsp;».</p>"
               }
             }
@@ -746,6 +764,7 @@
                     {
                       "id": "b95f2a02-12ca-4418-85cf-56097d763f3b",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Le cadre d’usage de l’IA en éducation préconise d’<strong>introduire l’usage des logiciels d’IA générative</strong> auprès des élèves de<strong> manière progressive</strong>&nbsp;:</p>"
                     },
                     {
@@ -760,6 +779,7 @@
                     {
                       "id": "d218458d-717c-47c7-b7d8-0ec7c613e1df",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>À tous les niveaux, trois conditions essentielles encadrent et sécurisent l’usage des logiciels d’IA générative en classe&nbsp;:</p>"
                     },
                     {
@@ -778,6 +798,7 @@
                     {
                       "id": "b45766d4-5135-492b-8dba-faf05c202f62",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p><strong>💡 Bon à savoir</strong><br> Intégrer l’usage de l’IA générative dans les apprentissages permet&nbsp;:&nbsp; </p><ul><li>d’<strong>accompagner les apprentissages</strong> des élèves dans les différentes disciplines.</li><li>de <strong>donner </strong>aux élèves les<strong> clés pour comprendre</strong> cette technologie, en appréhender les <strong>opportunités </strong>et les <strong>limites</strong>.</li></ul>"
                     }
                   ]
@@ -802,6 +823,7 @@
               "element": {
                 "id": "76081d34-b024-4409-a09a-36201ca6c91c",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Face au développement rapide et constant de l’IA générative, le <strong>cadre d’usage de l’IA&nbsp;en éducation</strong>, publié par le ministère de l’Éducation nationale en juin 2025, a pour objectif de promouvoir des usages éclairés et responsables.</p>"
               }
             },
@@ -835,6 +857,7 @@
               "element": {
                 "id": "aa1e67da-81bf-474c-a60f-6e3ea0fb4efe",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Voyons si vous avez retenu l’essentiel.</p>"
               }
             }
@@ -1117,6 +1140,7 @@
               "element": {
                 "id": "7aaa9f1b-ad1c-4968-a307-db753d4a06aa",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Des enseignants se questionnent sur différents usages de l’IA générative par rapport au cadre d’usage de l’IA en éducation et au RGPD.<br></p>"
               }
             },
@@ -1319,6 +1343,7 @@
               "element": {
                 "id": "8a352994-da21-41a3-bfb6-d87536077b2c",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>En classe, un enseignant propose une activité à ses élèves&nbsp;: observer comment un moteur de recherche et un logiciel d’IA générative répondent à la requête suivante&nbsp;: “Explique-moi la méthode de la dissertation pour le bac de français et donne-moi des exemples de titres”.</p><p> Les élèves constatent que le moteur de recherche se contente de pointer vers une ressource déjà disponible en ligne. À l’inverse, l’IA génère une nouvelle réponse, selon la suite de mots la plus probable.</p>"
               }
             },

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/ia-deepfakes-alt.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/ia-deepfakes-alt.json
@@ -32,6 +32,7 @@
               "element": {
                 "id": "962199cb-910e-465c-9f0e-7c4b07b02f16",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Dans la vidéo suivante, on peut voir un scientifique célèbre faire une annonce importante.</p>"
               }
             },
@@ -150,6 +151,7 @@
               "element": {
                 "id": "353585f2-3b31-4286-b609-7af1da4912d1",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Les deepfakes, hypertrucages en français, sont créés grâce à <strong>l’intelligence artificielle</strong>. Comme les intelligences artificielles s'améliorent chaque jour, il est de plus en plus <strong>difficile de reconnaître un deepfake </strong>!</p>"
               }
             }
@@ -165,6 +167,7 @@
               "element": {
                 "id": "4463cedd-03c8-4659-8919-bd5de5dd06e6",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Pour être si réaliste, un deepfake doit demander beaucoup de compétences et de matériel à son créateur, non ? 🤔</p>"
               }
             }
@@ -180,6 +183,7 @@
               "element": {
                 "id": "122e3f4a-1a64-45e4-a78f-837eba713f92",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Avec un logiciel d'intelligence artificielle, Caroline a créé une vidéo où elle chante une chanson à la manière de sa chanteuse préférée. 🎶</p><p> Caroline est étonnée&nbsp;: elle a donné<strong> seulement 3 éléments au logiciel d’intelligence artificielle</strong> pour créer la chanson.</p>"
               }
             },
@@ -206,6 +210,7 @@
               "element": {
                 "id": "bd4fd5ef-482d-48b9-bcf9-b5159b5d0baf",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Un <strong>deepfake</strong> peut être créé avec <strong>très peu de données</strong> : une photo et quelques phrases suffisent pour fabriquer une vidéo réaliste. 🗣️ </p><p>⚠️ Comme ils sont faciles à fabriquer, beaucoup de deepfakes circulent en ligne. <br></p>"
               }
             }
@@ -221,6 +226,7 @@
               "element": {
                 "id": "5bc82ead-ce5a-4fc1-af15-36a1206cb378",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Pour quelles raisons les deepfakes sont-ils créés ? Découvrons-le ensemble.</p>"
               }
             }
@@ -236,6 +242,7 @@
               "element": {
                 "id": "476ac4e1-0a9a-4be9-a46b-973fd04c7941",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Pour chaque exemple de deepfake, choisissez la bonne réponse.</p>"
               }
             },
@@ -380,6 +387,7 @@
               "element": {
                 "id": "7a4c64aa-87b1-4774-975c-d932b6d619ac",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>😱 <strong>Les deepfakes</strong> peuvent servir à manipuler la population, arnaquer ou harceler : ces usages sont <strong>illégaux</strong> et <strong>dangereux</strong>.</p><p>Cependant, ils sont aussi utilisés sans intention malveillante, dans l’art ou le divertissement, par exemple pour faire apparaître un acteur absent ou décédé dans un film.</p><p>⚖️ Bon à savoir : même dans un cadre créatif ou humoristique, le <strong>droit à l’image</strong> doit être respecté.<br></p>"
               }
             }
@@ -395,6 +403,7 @@
               "element": {
                 "id": "eccccf66-ace0-4b93-a9ea-03134c4d6f16",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Les deepfakes sont difficiles à reconnaître et ils peuvent être créés dans un but malveillant. Mais, comment réagir quand on reçoit une vidéo, une image ou un son et qu’on a des doutes ?</p>"
               }
             }
@@ -410,6 +419,7 @@
               "element": {
                 "id": "86eb2064-eb53-4545-845e-fa7d9f7386e7",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Djibril a reçu un message de son ami Brian sur le groupe de sa classe. <br>Consultez le message puis répondez à la question.</p>"
               }
             },
@@ -484,6 +494,7 @@
               "element": {
                 "id": "78704bf0-3fc8-4da3-ae86-74fda215bd26",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Quand vous recevez un média surprenant (trop beau pour être vrai, choquant ou inquiétant), <strong>n’agissez pas trop vite</strong> : ne likez pas, ne partagez pas immédiatement. C’est peut-être un <strong>deepfake&nbsp;</strong>! </p><p>Partager un deepfake malveillant peut propager de fausses informations ou contribuer au cyberharcèlement d’une personne. </p><p>👉 Cela peut aussi violer le droit à l’image et entraîner une plainte contre vous. </p><p>🔎 <strong>En cas de doute, ne partagez pas</strong> : vérifiez d’abord l’information et sa source.<br><br></p>"
               }
             }
@@ -505,6 +516,7 @@
               "element": {
                 "id": "6e4dea9f-d5a1-46f8-a820-1cb4582f35e3",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Un <strong>deepfake</strong> est un média hyper réaliste mais faux&nbsp;: il est créé grâce à l’intelligence artificielle. </p><ul><li>Il est souvent difficile à détecter. 🔎</li> <li>Il demande <strong>peu de matériel et de compétence</strong> pour être produite qui explique pourquoi il circule beaucoup en ligne</li><li>La plupart du temps, un deepfake est  créé avec une <strong>intention malveillante</strong> : diffuser de fausses informations, cyberharceler, arnaquer ou manipuler. 🧠</li><li>Au moindre doute face à média, <strong>il ne faut pas le partager immédiatement</strong>. Vérifiez d'abord sa source et sa fiabilité. ℹ️</li>   </ul>"
               }
             }
@@ -590,6 +602,7 @@
               "element": {
                 "id": "9d7c137d-3da3-4b38-9e4f-d83e9bc2d9aa",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Et pour finir, voyons un cas pratique.</p>"
               }
             }
@@ -605,6 +618,7 @@
               "element": {
                 "id": "2325577a-a4cc-4bf8-80d3-1e17f700c609",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><strong>Lisez l’article ci-dessous, puis répondez aux questions.</strong><br></p>"
               }
             },

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/jeux-video-enfant.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/jeux-video-enfant.json
@@ -32,6 +32,7 @@
               "element": {
                 "id": "12937b3b-7031-45e3-9aeb-6d3a6ea6533a",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Franck a une fille de 8 ans, Marilou. Pour son anniversaire, elle voudrait un jeu vidéo dont elle a entendu parler dans la cour de récréation : Dragon’s Kingdom. 🎮</p>"
               }
             }
@@ -47,6 +48,7 @@
               "element": {
                 "id": "442fa2ba-d532-423b-ba89-c4ff38ff270c",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Avant d’acheter et de télécharger le jeu réclamé par sa fille de 8 ans, Franck se rend sur la fiche du jeu en ligne pour regarder les informations concernant le jeu. 👀</p>"
               }
             },
@@ -98,6 +100,7 @@
               "element": {
                 "id": "5d5e7130-c5d2-4aa0-bb7f-20e89b27cbd8",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Avant de choisir un jeu vidéo pour sa fille, Franck peut vérifier plusieurs informations au sujet du jeu.<br>Découvrons ensemble la première information&nbsp;: la signalétique européenne PEGI.<br></p>"
               }
             }
@@ -119,6 +122,7 @@
               "element": {
                 "id": "958e2877-83ba-42a4-9622-3ce3a078127d",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Sur les jeux vidéo vendus en France, on peut voir des pictogrammes. Ces pictogrammes donnent des indications importantes.<br>Observez les images suivantes et répondez aux questions.</p>"
               }
             },
@@ -236,6 +240,7 @@
               "element": {
                 "id": "7c0ff98b-7522-4c04-af69-aa8eaf516d32",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Découvrez les informations clés à retenir concernant la signalétique PEGI&nbsp;:&nbsp;</p>"
               }
             },
@@ -263,6 +268,7 @@
               "element": {
                 "id": "89b50860-22ca-4d9d-b0fa-f4e759acf654",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Franck sait à présent vérifier l’âge recommandé pour un jeu.<br>Il veut maintenant éviter que Marilou dépense de l’argent en achetant des bonus pendant qu'elle joue. 💸</p>"
               }
             }
@@ -337,6 +343,7 @@
               "element": {
                 "id": "8d643cd3-6b97-4817-a495-0cf23e06e375",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>👛 Dans un jeu vidéo (gratuit ou payant), des achats de quelques centimes ou euros peuvent être proposés tout au long de la partie pour obtenir, par exemple&nbsp;: </p><ul>    <li>de la <strong>monnaie virtuelle</strong>&nbsp;</li>    <li>des <strong>bonus </strong>ou des <strong>vies </strong>supplémentaires</li>    <li>des améliorations pour les personnages&nbsp;</li></ul><p>Ces achats en jeu sont appelés des <strong>achats intégrés</strong>.</p><p>⚠️ <strong>Attention</strong><br> Même si ce sont de petites sommes d’argent, la facture peut vite grimper ! Et si une carte bancaire est enregistrée sur l’appareil (smartphone, console, etc.), l’achat sera débité automatiquement sans que vous soyez averti.</p>"
               }
             }
@@ -397,6 +404,7 @@
               "element": {
                 "id": "4b68478d-45e1-411c-bf18-f384d0503cfa",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Si un jeu contient des achats intégrés, le joueur doit obligatoirement être prévenu.</p><p>🔎 Pour le savoir, regardez la boîte ou la fiche du jeu en ligne et cherchez le <strong>pictogramme PEGI </strong>ci-dessous ou les mentions «&nbsp;<strong>achats intégrés</strong>&nbsp;» ou «&nbsp;<strong>achats intra-jeu facultatifs</strong>&nbsp;».</p>"
               }
             },
@@ -424,6 +432,7 @@
               "element": {
                 "id": "213f2140-9378-4bdb-9b7f-91837f4a5c9b",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Certains jeux proposent des achats intégrés particulièrement attirants&nbsp;:<strong> les loot boxes</strong> (ou boîtes à butins en français).</p>\n<p>Répondez à la question ci-dessous.</p>"
               }
             },
@@ -496,6 +505,7 @@
               "element": {
                 "id": "051ce5cd-3dcc-45a2-a1cd-a9ab74763588",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>📦 Une loot box (boîte à butins) est un <strong>objet virtuel </strong> (un coffre, une boîte, etc) qu’un joueur peut acheter dans le jeu.<br>Chaque loot box contient des objets, communs ou très rares, à utiliser dans le jeu.<br><strong>Ce contenu est aléatoire, comme pour une pochette-surprise ou des cartes à collectionner.</strong><br>Le joueur est souvent incité à acheter des loot boxes lors des parties, pour obtenir l’objet qu’il souhaite ou pour avancer plus efficacement dans le jeu.</p><p><br>🤔 <strong>Bon à savoir</strong>&nbsp;<br>Depuis mai 2020, un jeu qui propose des loot boxes doit obligatoirement indiquer «&nbsp;<strong>Inclut des contenus aléatoires</strong>&nbsp;» sur la boîte ou la fiche du jeu.</p>"
               }
             }
@@ -511,6 +521,7 @@
               "element": {
                 "id": "d841ddce-baf4-48c7-95b8-c03bb38fa232",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Après avoir vérifié le pictogramme d’âge PEGI et la présence d’achats intégrés, Franck peut vérifier une troisième information clé&nbsp;: la possibilité d’interagir avec d’autres joueurs dans le jeu. 💬</p>"
               }
             }
@@ -526,6 +537,7 @@
               "element": {
                 "id": "139b7a65-92b9-4d4c-ba16-1badbbe24bd1",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>De nombreux jeux vidéo en ligne se jouent en équipe. Les joueurs doivent donc discuter ensemble, par écrit ou en vocal, afin de collaborer et progresser dans le jeu.</p><p><strong>Ces discussions en ligne comportent des risques</strong>. 🎧&nbsp;<br>Un enfant peut être exposé à des personnes avec de mauvaises intentions ou à du contenu choquant. 😱</p>"
               }
             },
@@ -585,6 +597,7 @@
                     {
                       "id": "d85a05a1-0c9d-4ce7-ad25-9333eb3a75c3",
                       "type": "text",
+                      "tag": " ",
                       "content": "<h4>Quels sont les risques des discussions en ligne ?</h4><p>Il est impossible de savoir qui se trouve réellement de l’autre côté de l’écran. Les personnes avec de mauvaises intentions cherchent souvent à&nbsp;: </p><ul><li>manipuler les autres joueurs</li><li>proposer des rencontres dans la vraie vie</li><li>pousser à partager des photos ou des informations personnelles</li></ul><p>⚠️ <strong>Attention</strong><br>Même avec un jeu qui ne permet pas de discuter avec d’autres joueurs, ce risque n’est pas écarté. En effet, certaines consoles permettent de discuter en ligne, tout comme les ordinateurs et les smartphones.</p>"
                     }
                   ]
@@ -594,6 +607,7 @@
                     {
                       "id": "6b8112ec-45ab-4665-b690-9adf0b6e93ac",
                       "type": "text",
+                      "tag": " ",
                       "content": "<h4>Comment se protéger ?</h4><p>🔎 D’abord, il faut être attentif lors du choix d’un jeu vidéo. Sur les boîtes ou les pages en ligne des jeux, la mention d’interaction entre joueurs peut prendre différentes formes&nbsp;: «&nbsp;<strong>les utilisateurs interagissent</strong>&nbsp;», «&nbsp;<strong>interaction entre les joueurs</strong>&nbsp;», «&nbsp;<strong>interactivité des utilisateurs</strong>&nbsp;»...</p>"
                     },
                     {
@@ -606,6 +620,7 @@
                     {
                       "id": "61751690-1ee8-41ee-86c4-f9903230c9f6",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>⚙️ Pour limiter les discussions qui passent par les consoles, smartphones ou ordinateurs, il est possible de paramétrer le contrôle parental de chacun des appareils.</p><p>🗣️ Enfin, il est important de discuter fréquemment avec les enfants des risques et des usages à autoriser ou non.</p>"
                     }
                   ]
@@ -630,6 +645,7 @@
               "element": {
                 "id": "7346e1eb-4591-4913-9c39-9d23dfcf7db8",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><strong>Avant de choisir un jeu vidéo pour votre enfant, il y a trois informations clés à vérifier&nbsp;:</strong></p>"
               }
             },
@@ -648,6 +664,7 @@
               "element": {
                 "id": "f75135d6-68f6-40b5-a8d7-59a33a23ac39",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>👉 Et vous, aviez-vous déjà remarqué ces 3 informations sur les jeux ? 👀</p>"
               }
             }
@@ -669,6 +686,7 @@
               "element": {
                 "id": "99f21e69-cdb4-4428-9153-ae857a148ee7",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Voyons si vous avez retenu l'essentiel.</p>"
               }
             },
@@ -747,6 +765,7 @@
               "element": {
                 "id": "45a1378d-e5bc-43a1-a5c8-b190d5aad710",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Franck sait maintenant que Dragon’s Kingdom, le jeu demandé par Marilou n’est pas adapté à son âge.<br>Après discussion avec sa fille de 8 ans, Franck souhaite lui acheter un autre jeu sur les dragons. 🐲</p>"
               }
             }
@@ -762,6 +781,7 @@
               "element": {
                 "id": "5403d509-05f4-4473-ab7c-18e244aa234c",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Il veut lui offrir un jeu&nbsp;: </p><ul><li> sans contenus inadaptés pour son âge selon la signalétique PEGI</li><li>sans achats intégrés</li><li>sans possibilité de discuter avec d’autres joueurs dans le jeu</li></ul><p>👇 Voici, ci-dessous, les fiches des trois jeux vidéo sur le thème des dragons que Franck a sélectionnés.</p>"
               }
             },
@@ -874,6 +894,7 @@
               "element": {
                 "id": "bb51dffa-ef4f-4124-80e4-e7024e2280dc",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Grâce à vous, Franck a choisi un jeu vidéo pour Marilou ! 👏<br>Il peut à présent jouer avec elle, pour l’accompagner dans sa découverte du jeu.</p>"
               }
             }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/mots-de-passe-securises.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/mots-de-passe-securises.json
@@ -32,6 +32,7 @@
               "element": {
                 "id": "1c3814f8-60f5-4024-86a8-6d0c270eceb1",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Un mot de passe sert à protéger vos informations et vos données. Il faut qu’il soit <strong>solide</strong>, c'est-à-dire difficile à trouver.&nbsp;🔐<br>Sinon, on peut le deviner facilement et lire vos mails, voir vos photos ou envoyer des messages à votre place.</p>"
               }
             }
@@ -110,6 +111,7 @@
               "element": {
                 "id": "598a96f0-4628-4879-9cfd-5ff8982c1da3",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Choisir un mot de passe très utilisé est risqué. Regardons ensemble les risques dont il faut se protéger.</p>"
               }
             }
@@ -125,6 +127,7 @@
               "element": {
                 "id": "826281e7-865f-462d-abc0-77537c42a2b4",
                 "type": "text",
+                "tag": " ",
                 "content": "<h4><span aria-hidden=\"true\">🧑‍💻&nbsp;🔮&nbsp;</span>Une personne peut deviner votre mot de passe.</h4><p>Si vous utilisez des informations privées dans votre mot de passe, il est possible qu’une personne de votre entourage le devine facilement.</p><p><span aria-hidden=\"true\">⚠️</span> Elle pourra alors accéder à vos données personnelles et privées. Et ce n’est peut-être pas pour vous faire un cadeau d’anniversaire surprise, malheureusement.</p>"
               }
             },
@@ -133,6 +136,7 @@
               "element": {
                 "id": "aae5ea61-68b7-4089-90a1-6ecc707664c9",
                 "type": "text",
+                "tag": " ",
                 "content": "<hr>"
               }
             },
@@ -141,6 +145,7 @@
               "element": {
                 "id": "9d0b7aff-a9da-453f-a6ba-c61fbaa7bb25",
                 "type": "text",
+                "tag": " ",
                 "content": "<h4><span aria-hidden=\"true\">🤖&nbsp;🏴‍☠️&nbsp;</span>Un logiciel informatique peut pirater votre mot de passe.</h4><p>Les ordinateurs sont capables de trouver des mots de passe en testant très rapidement différentes combinaisons possibles.<br>En 2023, un mot de passe court comme <code>$0Leil@?</code> peut être piraté en 5 minutes seulement. Mais avec un mot de passe plus long, comme <code>$0Leil@1504</code>, cette durée passe à 226 ans.</p> <p><span aria-hidden=\"true\">⚠️</span> En général, le pirate ne vous connaît pas. Il cherche certainement à revendre vos informations ou à vous voler de l’argent.</p>"
               }
             }
@@ -156,6 +161,7 @@
               "element": {
                 "id": "f300766c-5fa3-4dbe-8922-00dc73304c7b",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Un exemple&nbsp;: Austin a utilisé des informations personnelles pour créer son mot de passe. Vous allez pouvoir le deviner facilement. À vous de jouer.&nbsp;🕵🏻‍♂️&nbsp;🕵🏿‍♀️</p>"
               }
             }
@@ -171,6 +177,7 @@
               "element": {
                 "id": "7ef31e68-e798-4a92-86a0-ad61ebd9b915",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Austin est producteur de miel dans les Vosges.<br>Il a utilisé les deux informations suivantes pour créer son mot de passe&nbsp;:</p><ul><li>Il est né le <strong>15 novembre 1984</strong>.</li><li>Il a un enfant qui s’appelle <strong>Bill</strong>.</li></ul>"
               }
             },
@@ -266,6 +273,7 @@
               "element": {
                 "id": "b975bec3-4fef-42ca-8b40-ce9b59836b4c",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Pour créer un mot de passe solide, il y a certaines règles à suivre. Regardons de plus près&#8239;!</p>"
               }
             }
@@ -281,6 +289,7 @@
               "element": {
                 "id": "02bb0017-a74d-4c78-8502-3c57d9f12209",
                 "type": "text",
+                "tag": " ",
                 "content": "<h4>Règle n°1&nbsp;: créez un mot de passe long.&nbsp;<span aria-hidden=\"true\">📝</span></h4><p>Un mot de passe long sera dur à deviner ou à pirater. Mais gardez une longueur raisonnable&nbsp;: à partir de 12 caractères, le mot de passe est assez long.</p>"
               }
             },
@@ -289,6 +298,7 @@
               "element": {
                 "id": "7f89a519-a5ce-4484-9952-eb6869b94291",
                 "type": "text",
+                "tag": " ",
                 "content": "<hr>"
               }
             },
@@ -297,6 +307,7 @@
               "element": {
                 "id": "52f4050d-7ab9-41da-987b-d9172d5b3cb0",
                 "type": "text",
+                "tag": " ",
                 "content": "<h4>Règle n°2&nbsp;: variez les caractères utilisés.&nbsp;<span aria-hidden=\"true\">🔣</span></h4><p>Un bon mot de passe contient différents caractères&#8239;; ce qui augmente le nombre de combinaisons possibles. On peut utiliser des minuscules, des majuscules, des chiffres, des caractères spéciaux&nbsp;: <code>=</code> <code>@</code> <code>$</code> <code>#</code> <code>!</code> <code>?</code>.</p>"
               }
             },
@@ -305,6 +316,7 @@
               "element": {
                 "id": "2895432c-72a3-44be-ae0e-52041f5b847e",
                 "type": "text",
+                "tag": " ",
                 "content": "<hr>"
               }
             },
@@ -313,6 +325,7 @@
               "element": {
                 "id": "c4505a09-864c-48f8-8077-013fae2db291",
                 "type": "text",
+                "tag": " ",
                 "content": "<h4>Règle n°3&nbsp;: n'utilisez pas d’informations personnelles.&nbsp;<span aria-hidden=\"true\">🤫</span></h4><p>De cette manière, il y a moins de chance que quelqu'un le devine. N'utilisez donc pas de dates de naissance et de numéros de téléphone. Un mot de passe doit être secret&#8239;!</p>"
               }
             }
@@ -328,6 +341,7 @@
               "element": {
                 "id": "f3d1330a-31f0-4252-8a89-db95905b6f09",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Vérifions que vous avez compris l'essentiel avec quelques exemples.</p>"
               }
             }
@@ -343,6 +357,7 @@
               "element": {
                 "id": "a3730b39-ff34-4744-a5dc-5d4687def82d",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Pour chaque affimation, choisissez si elle est vraie ou fausse.</p>"
               }
             },
@@ -451,6 +466,7 @@
               "element": {
                 "id": "ec48b813-4f04-45ac-9515-eb6e559e354c",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>En plus des règles que vous venez de voir, voici aussi quelques astuces pour vous aider à créer vos mots de passe.&nbsp;💡</p>"
               }
             }
@@ -466,6 +482,7 @@
               "element": {
                 "id": "6eda6d92-1147-4c19-a7e5-f61a2228e33c",
                 "type": "text",
+                "tag": " ",
                 "content": "<h4>Astuce n°1&nbsp;: n'utilisez pas le même mot de passe partout&#8239;!</h4><p>Utiliser toujours le même mot de passe est risqué. C'est comme utiliser la même clé pour toutes ses portes. C'est très pratique, mais si votre mot de passe est piraté, toutes les portes sont ouvertes&#8239;!&nbsp;<span aria-hidden=\"true\">☠️</span></p>"
               }
             },
@@ -474,6 +491,7 @@
               "element": {
                 "id": "b8bc3e1e-bf21-4b3b-8dce-0a0213aefb1b",
                 "type": "text",
+                "tag": " ",
                 "content": "<hr>"
               }
             },
@@ -482,6 +500,7 @@
               "element": {
                 "id": "f6edeae6-fbfb-4dce-b556-1bb7928d5ff5",
                 "type": "text",
+                "tag": " ",
                 "content": "<h4>Astuce n°2&nbsp;: utilisez une phrase qui vous plaît et gardez certains caractères. </h4><p>Par exemple&nbsp;: la phrase \"<strong>J'a</strong>i <strong>2 c</strong>hats<strong>, 3 p</strong>oissons <strong>e</strong>xotiques <strong>e</strong>t <strong>j'a</strong>dore <strong>l</strong>a <strong>p</strong>longée <strong>!</strong>\" vous donne le mot de passe&nbsp;: <strong>Ja2c3peejalp!</strong></p>"
               }
             },
@@ -490,6 +509,7 @@
               "element": {
                 "id": "95098e06-e113-46ba-afa0-b7890d5cf467",
                 "type": "text",
+                "tag": " ",
                 "content": "<hr>"
               }
             },
@@ -498,6 +518,7 @@
               "element": {
                 "id": "dadd152e-350c-4710-8609-af5f92e69b2c",
                 "type": "text",
+                "tag": " ",
                 "content": "<h4>Astuce n°3&nbsp;: créez un nouveau mot de passe si vous l'avez oublié.</h4><p>Oublier son mot de passe, ce n'est pas grave. Au moment de votre connexion, les sites internet permettent de changer votre mot de passe si vous l'avez oublié.<br>Tous les mots de passe ne sont pas égaux. Par exemple, mémorisez bien celui de votre boîte mail car il permet de changer tous les autres.&nbsp;<span aria-hidden=\"true\">💡</span></p>"
               }
             }
@@ -513,6 +534,7 @@
               "element": {
                 "id": "3d582ec1-c82d-488e-9e2d-0208cfd29871",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Maintenant que vous en savez plus, vous allez pouvoir aider Austin.&nbsp;🧑🏻‍💼<br> Austin veut créer un mot de passe qui est solide.</p>"
               }
             }
@@ -573,6 +595,7 @@
               "element": {
                 "id": "b1ae2c3c-e383-4f82-b6d0-deda5b24eaa4",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Créer des mots de passe solides n'est pas simple. Mais cette étape est nécessaire pour se protéger.</p><p>Voici ci-dessous une synthèse des informations à retenir de ce module.</p>"
               }
             }
@@ -588,6 +611,7 @@
               "element": {
                 "id": "2e695244-52c5-4277-8414-d18777d0d242",
                 "type": "text",
+                "tag": " ",
                 "content": "<h4>Ce qu’il faut retenir</h4><ul><li>Tous les mots de passe ne sont pas égaux&nbsp;: l'accès à votre boîte mail permet de contrôler de nombreux autres services. Ce mot de passe est donc très important.&nbsp;<span aria-hidden=\"true\">🚨</span></li><li>Un mot de passe solide est unique, long et composé de différents caractères. Il ne contient pas d'informations personnelles et doit rester secret.&nbsp;<span aria-hidden=\"true\">🎯</span></li><li>Pour avoir un mot de passe solide et facile à retenir, on peut choisir une phrase et garder certains caractères.&nbsp;<span aria-hidden=\"true\">💡</span></li></ul>"
               }
             }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/nr_durabilite_ind.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/nr_durabilite_ind.json
@@ -101,6 +101,7 @@
               "element": {
                 "id": "d55e6ae8-8bb5-40e3-b256-1568a51ebe95",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Voyons ensemble pourquoi <strong>autant de matières premières sont nécessaires</strong> pour un si petit objet.&nbsp;<br><br></p>"
               }
             }
@@ -326,6 +327,7 @@
                     {
                       "id": "fd4686e7-d519-425e-a6f0-f8b14c5d18f9",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Aujourd’hui, la production d’appareils augmente partout dans le monde.</p><h5>🤔 Que provoque cette hausse continue ?</h5><p>La demande en métaux et en terres rares <strong>explose</strong>. Le numérique <strong>mobilise</strong> maintenant <strong>une grande part des réserves mondiales</strong> de matériaux comme le germanium ou l’indium.</p>"
                     }
                   ]
@@ -335,6 +337,7 @@
                     {
                       "id": "843b69d0-3f09-4c93-adb4-f57ffe20b587",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p><strong>💡Bon à savoir</strong></p><p>Les <strong>terres rares&nbsp;</strong>(néodyme, europium, yttrium, etc) sont des métaux <strong>essentiels aux appareils numériques&nbsp;</strong>(les ordinateurs, tablettes, smartphones, etc). Présentes en très faible concentration dans la terre, leur extraction demande beaucoup d’énergie, d’eau et de produits chimiques polluants.</p>"
                     }
                   ]
@@ -353,6 +356,7 @@
               "element": {
                 "id": "149fd62a-f59a-4534-8a74-30f7bcebc934",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Maintenant que nous savons de quoi sont faits nos appareils, voyons <strong>ce que leur fabrication implique</strong> pour <strong>l’environnement et les populations</strong>.</p>"
               }
             }
@@ -372,6 +376,7 @@
                     {
                       "id": "ce66cf46-2ea1-4536-bfe6-506736e41df5",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Observez l’évolution de cette mine de Mongolie intérieure au fil des années. Répondez ensuite à la question ci-dessous.</p>"
                     },
                     {
@@ -425,6 +430,7 @@
                     {
                       "id": "3b059d97-625c-4010-a64f-7499e113a6bb",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Découvrez les étapes de création des batteries et répondez à la question ci-dessous.</p>"
                     },
                     {
@@ -567,6 +573,7 @@
                     {
                       "id": "4aa32b42-e1e5-42e6-bda8-259a57f04e19",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Lisez l’article et répondez à la question ci-dessous.&nbsp;</p>"
                     },
                     {
@@ -631,6 +638,7 @@
               "element": {
                 "id": "5d37b812-b5a9-4ebc-af92-260c6ede361e",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>L’extraction des métaux nécessaires aux smartphones, ordinateurs et batteries a des <strong>impacts environnementaux et humains importants</strong>&nbsp;:</p><ul>    <li>une forte consommation d’eau</li>    <li>la pollution des sols</li>    <li>des risques pour la santé et les droits des populations locales</li></ul><h5>🤔 Tout cela, pour fabriquer nos smartphones et ordinateurs ?</h5><p>Oui. Ces métaux sont essentiels au fonctionnement des appareils numériques. Leur demande croissante pour fabriquer toujours plus d’appareils pèse fortement sur l’environnement et les droits humains.</p>"
               }
             }
@@ -646,6 +654,7 @@
               "element": {
                 "id": "138eea6b-49c9-449c-993d-0440fdf59a0b",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Vous avez vu les impacts de l’extraction. Passons aux décisions du quotidien.</p>"
               }
             }
@@ -665,6 +674,7 @@
                     {
                       "id": "1a7e6933-9fd4-42ce-a844-44547efcd603",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p><strong>Amandine a un souci d’ordinateur portable.</strong><br>Au bout de quelques années, son appareil commence à avoir <strong>des problèmes d’affichage</strong> et la batterie tient de moins en moins longtemps. Il fonctionne encore, mais est de plus en plus<strong> inconfortable à utiliser</strong>.</p>"
                     },
                     {
@@ -711,6 +721,7 @@
                     {
                       "id": "685e2165-8a4c-426c-b43d-5e48b6ce67ea",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p><strong>Deux ans plus tard</strong>, Amandine commence une formation de graphiste.<br><strong>Son ordinateur</strong> réparé <strong>fonctionne toujours</strong>, mais il n’est <strong>plus assez puissant</strong> pour utiliser les logiciels de création dont elle a <strong>besoin</strong> (retouche photo, modélisation 3D, etc).<br><br></p>"
                     },
                     {
@@ -770,6 +781,7 @@
                     {
                       "id": "db56ae01-3e09-4601-83bf-338c6520d013",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p><strong>Réparer ou prolonger l’utilisation</strong> d’un appareil permet d’éviter d’en fabriquer un nouveau.&nbsp; </p><h5>🤔 Et si j’ai besoin d’en changer ?</h5><p>Dans ce cas,<strong> choisir un appareil reconditionné</strong> est la meilleure option&nbsp;: il a déjà été fabriqué, puis <strong>testé, réparé et remis en état</strong>; ce qui lui donne une seconde vie et limite son impact. </p><h5><br></h5>"
                     }
                   ]
@@ -779,11 +791,13 @@
                     {
                       "id": "0612b141-3b5d-4ba9-9a12-cfc99392e67d",
                       "type": "text",
+                      "tag": " ",
                       "content": "<h5>🤔 Le reconditionné, c’est donc mieux pour la planète ?</h5><p>Pas toujours. Ces gestes sont efficaces <strong>seulement</strong> <strong>s’ils remplacent vraiment l’achat d’un produit neuf</strong>, pas s’ils viennent s’y ajouter.</p>"
                     },
                     {
                       "id": "5aafa8f3-3e00-416f-92e9-17d052c50516",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p><strong>💡Astuce</strong></p><p>Pensez à <strong>protéger</strong> vos appareils (coques, écrans, antivirus, etc) afin de les faire <strong>durer plus longtemps</strong> !&nbsp;</p>"
                     }
                   ]
@@ -808,6 +822,7 @@
               "element": {
                 "id": "b413213a-8e21-4985-8b39-80c70fa042f5",
                 "type": "text",
+                "tag": " ",
                 "content": "<ul>    <li>⛏️ Un ordinateur ou un téléphone contient plus de 50 métaux, dont plusieurs terres rares, extraits au prix d’une <strong>forte consommation d’eau</strong> douce, de <strong>pollution</strong> et de <strong>conditions de travail difficiles</strong>.</li>    <li>🔧 <strong>Faire durer</strong> ou <strong>réparer ses appareils</strong>, c’est éviter la production de nouveaux appareils, limiter l’extraction de métaux et la consommation d’eau.</li>    <li>♻️ Dans le cas d’un achat, <strong>choisir le reconditionné</strong> reste la solution la plus économe en ressources et la plus responsable.</li>    <li>🌍 <strong>Chaque geste compte.</strong> Remplacer une batterie, réparer un écran ou garder votre téléphone plus longtemps permet <strong>de produire moins</strong> et donc <strong>d’extraire moins de ressources</strong>.</li></ul>"
               }
             }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/ports-connexions-essentiels.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/ports-connexions-essentiels.json
@@ -31,6 +31,7 @@
               "element": {
                 "id": "f7038b18-cf54-4db5-aba1-462ddbbbbda6",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Sur votre ordinateur, vous pouvez brancher plusieurs appareils, comme une souris ou un clavier.&nbsp;🖱️&nbsp;⌨️</p><p>Pour les brancher, il y a des prises de différentes formes : ce sont les ports de connexion. Commençons avec un exemple.</p>"
               }
             }
@@ -46,6 +47,7 @@
               "element": {
                 "id": "f76ed857-626c-4980-8635-89d5a66f3f3b",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Maxime a reçu un ordinateur portable pour son anniversaire. </p><p>Pour le démarrer, il doit d’abord le mettre à charger.<span aria-hidden=\"true\">🔌</span> </p>"
               }
             },
@@ -107,6 +109,7 @@
               "element": {
                 "id": "c0642e02-74b1-4b42-a09d-3a6f7b714775",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Maintenant que vous avez aidé Maxime à charger son ordinateur, découvrez les autres ports de connexion.&nbsp;💻<br></p>"
               }
             }
@@ -122,6 +125,7 @@
               "element": {
                 "id": "e6730d81-c115-4821-a415-4f719a252746",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Découvrez les 6 ports de connexions principaux de l'ordinateur ci-dessous.</p>"
               }
             },
@@ -140,6 +144,7 @@
               "element": {
                 "id": "623628e4-2ea8-4753-911b-c946725280c4",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>À la suite de ces explications, vous devrez retrouver certains de ces ports dans des exemples concrets.</p>"
               }
             },
@@ -159,6 +164,7 @@
                     {
                       "id": "df4b59c7-b4d8-450c-985a-dc9bc9735f26",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Ce port est un <strong>port d’alimentation électrique</strong>.</p><p> Il sert à recharger un ordinateur et à le connecter au réseau électrique.&nbsp;<span aria-hidden=\"true\">🔌</span> </p><p>Sur les ordinateurs portables, il existe de nombreuses variantes. Sur un ordinateur fixe, ce port est plus gros.</p>"
                     }
                   ]
@@ -175,6 +181,7 @@
                     {
                       "id": "706f1c55-3009-4cff-affe-6548076d65ac",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Ce port est un <strong>port USB</strong>. </p><p>Il sert à connecter différents appareils externes à l’ordinateur.</p><p> Par exemple : une souris, un clavier, une clé USB, etc.&nbsp;&nbsp;<span aria-hidden=\"true\">🖱️</span>&nbsp;<span aria-hidden=\"true\">🎮</span></p>"
                     }
                   ]
@@ -191,6 +198,7 @@
                     {
                       "id": "c75612ca-f9c2-4453-88db-725bb817151b",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Ce port est un port <strong>USB Type C</strong> ou <strong>USB-C</strong>. </p><p>Ce port est souvent présent sur les téléphones portables. Sur un ordinateur, il&nbsp;sert à connecter différents appareils externes : téléphone portable, chargeur, écran, etc.  </p>"
                     }
                   ]
@@ -207,6 +215,7 @@
                     {
                       "id": "86851d7d-0ce8-48a3-b8ac-433da8134dec",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Ce port est un <strong>port HDMI</strong>. </p><p>On peut le reconnaître grâce à sa forme. Il porte souvent l'inscription \"HDMI\" juste à côté.</p><p>Ce port sert principalement à connecter un écran ou un vidéoprojecteur à l’ordinateur, comme le port VGA.&nbsp;<span aria-hidden=\"true\">📽️</span></p>"
                     }
                   ]
@@ -223,6 +232,7 @@
                     {
                       "id": "be359a9d-19d2-49a7-8699-8921156e554c",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Ce port est un <strong>port Ethernet</strong>. On l'appelle aussi RJ45.  </p><p>Il est utilisé pour connecter l’ordinateur à la box internet grâce à un câble Ethernet.&nbsp;<span aria-hidden=\"true\">🌐</span></p>"
                     }
                   ]
@@ -239,6 +249,7 @@
                     {
                       "id": "12ac3b9a-286c-4587-9a0d-6dc56e13caf9",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Ce port est un <strong>port jack</strong> ou <strong>mini-jack</strong>. </p><p>Il est petit et rond. Il est souvent accompagné d’une image de casque.&nbsp;<span aria-hidden=\"true\">🎧</span> </p><p>Il sert à connecter des appareils audios à l’ordinateur&nbsp;: des écouteurs, un casque, un micro, etc.</p>"
                     }
                   ]
@@ -257,6 +268,7 @@
               "element": {
                 "id": "23617f5e-3001-4562-937a-dac1adf32c07",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Maintenant que vous en savez plus sur les ports de connexion, vous allez  pouvoir aider Maxime.&nbsp;🙋‍♂️<br></p>"
               }
             }
@@ -272,6 +284,7 @@
               "element": {
                 "id": "efda82dc-1a96-488c-9d8d-a1bd5a8f1241",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Maxime veut brancher son clavier USB ⌨️ à son ordinateur.&nbsp;<br>Voici ci-dessous l'ordinateur de Maxime&nbsp;:</p>"
               }
             },
@@ -357,6 +370,7 @@
               "element": {
                 "id": "2a99722d-7860-4835-bc96-5625f645c673",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Le clavier de Maxime se branche en USB. <br>D'autres objets se branchent aussi sur le port USB.&nbsp;Découvrez-les.&nbsp;</p>"
               }
             }
@@ -376,6 +390,7 @@
                     {
                       "id": "7930251f-b89b-48f2-a67e-dfecfef8e446",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Le port USB est très utilisé. Il permet de brancher à son ordinateur des appareils avec des fonctionnalités très différentes.<br>On le reconnait de deux façons :</p><ul><li>le port est rectangulaire, avec une barre à l'intérieur,</li><li>il a un symbole : une flèche avec des ronds et des carrés.<br></li></ul>"
                     },
                     {
@@ -388,6 +403,7 @@
                     {
                       "id": "597e5a9a-e924-45d6-9b37-806d0e5c1578",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Découvrez quelques exemples d'appareils qui se branchant en USB. <br>Vous devrez ensuite identifier en image quels appareils se branchent au port USB.</p>"
                     }
                   ]
@@ -397,6 +413,7 @@
                     {
                       "id": "fdbfa739-e38f-41d6-ba98-6660fe729e16",
                       "type": "text",
+                      "tag": " ",
                       "content": "<h4>Une clé USB ou un clavier sans-fil (avec récepteur USB)</h4>"
                     },
                     {
@@ -413,6 +430,7 @@
                     {
                       "id": "b91728f4-a8f2-403b-81bc-520db8b8cbf0",
                       "type": "text",
+                      "tag": " ",
                       "content": "\n<h4>Une souris filaire ou une manette de jeux vidéos</h4>"
                     },
                     {
@@ -429,6 +447,7 @@
                     {
                       "id": "07bc0dd7-c121-4f6d-8e3a-ba45faffc93c",
                       "type": "text",
+                      "tag": " ",
                       "content": "<h4>Un cable de chargeur de téléphone portable ou une webcam</h4>"
                     },
                     {
@@ -454,6 +473,7 @@
               "element": {
                 "id": "124501e8-1100-44a2-a210-a3da56a6d11e",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Passons à la pratique avec quelques exemples.</p>"
               }
             }
@@ -469,6 +489,7 @@
               "element": {
                 "id": "270b0408-be92-484a-b9b2-5d302f01eecf",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Pour chaque affirmation ci-dessous, choisissez si elle est vraie ou fausse.</p>"
               }
             },
@@ -598,6 +619,7 @@
               "element": {
                 "id": "f357712f-ff2f-4a72-ba76-f31bcc7faa50",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Testez vos connaissances sur tous les ports de connexion.&nbsp;🕹️</p>"
               }
             }
@@ -694,6 +716,7 @@
               "element": {
                 "id": "22047103-8c88-42ae-8c51-e168e7b3f035",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Pour finir ce module, vous allez devoir explorer les ports de connexion de votre propre ordinateur.&nbsp;💻<br>À vous de jouer !</p>"
               }
             }
@@ -709,6 +732,7 @@
               "element": {
                 "id": "029cdc04-5fc3-4d1a-8127-6d5ad9084002",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Cherchez et nommez tous les ports de connexion de votre ordinateur.</p>"
               }
             },

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/principes-fondateurs-wikipedia.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/principes-fondateurs-wikipedia.json
@@ -32,6 +32,7 @@
               "element": {
                 "id": "383aad97-ff24-4cbb-844e-1d2346fe75b6",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Vous avez probablement déjà utilisé Wikipédia. Mais connaissez-vous la signification de son logo ?&nbsp;🌎&nbsp;🧩</p>"
               }
             }
@@ -47,6 +48,7 @@
               "element": {
                 "id": "30b9ada4-a87a-4dfb-baa2-d97925b0bba5",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Depuis sa création en 2001, Wikipédia a fait évoluer son logo à trois reprises.<br> Aujourd'hui, le logo représente un globe composé de pièces de puzzle avec différents symboles.</p>"
               }
             },
@@ -110,6 +112,7 @@
               "element": {
                 "id": "80813968-7b81-4859-8ed0-71c158c80e63",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Wikipédia repose sur 5 principes fondateurs qui font son identité et sa particularité en tant que site internet.</p>"
               }
             }
@@ -125,6 +128,7 @@
               "element": {
                 "id": "afc8b60f-c2c1-405b-a6a4-a0e08e23ccc3",
                 "type": "text",
+                "tag": " ",
                 "content": "<h4>1 - Wikipédia est une encyclopédie en ligne.&nbsp;<span aria-hidden=\"true\">📖</span></h4><p>Des connaissances du monde entier y sont rassemblées, classées et exposées méthodiquement. Wikipédia n'est donc ni un journal ni un réseau social.</p>"
               }
             },
@@ -133,6 +137,7 @@
               "element": {
                 "id": "3bbf40bb-acd0-466f-a1ce-5c4bf9ccee8e",
                 "type": "text",
+                "tag": " ",
                 "content": "<hr>"
               }
             },
@@ -141,6 +146,7 @@
               "element": {
                 "id": "81710de7-1311-4980-81f5-87944e56de28",
                 "type": "text",
+                "tag": " ",
                 "content": "<h4>2 - Wikipédia propose des contenus les plus neutres possible.&nbsp;<span aria-hidden=\"true\">⚖️</span></h4><p>Une opinion ou un point de vue unique n’ont pas leur place. Si besoin, les divers points de vue sont présentés, sans jugement de valeur.</p>"
               }
             },
@@ -149,6 +155,7 @@
               "element": {
                 "id": "20ed0b8b-a858-440e-a587-4856f96ef5be",
                 "type": "text",
+                "tag": " ",
                 "content": "<hr>"
               }
             },
@@ -157,6 +164,7 @@
               "element": {
                 "id": "78385472-07b0-4229-bfb8-a10636690300",
                 "type": "text",
+                "tag": " ",
                 "content": "<h4>3 - Wikipédia est publié sous licence libre.&nbsp;<span aria-hidden=\"true\">🪁</span></h4><p>En résumé, chacun peut créer, copier, modifier et partager le contenu qui se trouve sur Wikipédia. Certaines conditions doivent tout de même être respectées.</p>"
               }
             },
@@ -165,6 +173,7 @@
               "element": {
                 "id": "929661f0-ca4c-40fb-9df2-7832e97192e3",
                 "type": "text",
+                "tag": " ",
                 "content": "<hr>"
               }
             },
@@ -173,6 +182,7 @@
               "element": {
                 "id": "df11aa2c-1ebf-4a60-99a3-533dfc06756d",
                 "type": "text",
+                "tag": " ",
                 "content": "<h4>4 - Wikipédia est un projet collaboratif.&nbsp;<span aria-hidden=\"true\">🙋🏽‍♂️</span><span aria-hidden=\"true\">🙋🏻‍♀️</span><span aria-hidden=\"true\">🙋🏿‍♀️</span><span aria-hidden=\"true\">🙋‍♂️</span></h4><p>C’est probablement sa caractéristique la plus remarquable. Tout le monde peut améliorer les contenus de Wikipédia&#8239;! Des règles claires de savoir-vivre sont à respecter.</p>"
               }
             },
@@ -181,6 +191,7 @@
               "element": {
                 "id": "1edb38ba-7542-4198-a5de-c260ef6b95ea",
                 "type": "text",
+                "tag": " ",
                 "content": "<hr>"
               }
             },
@@ -189,6 +200,7 @@
               "element": {
                 "id": "ca62ac2d-950d-4c00-b14d-2ac9e7d509f2",
                 "type": "text",
+                "tag": " ",
                 "content": "<h4>5 - Wikipédia n’a pas d’autres principes fixes que ceux présentés ci-dessus.&nbsp;<span aria-hidden=\"true\">📜</span></h4><p>Il est toutefois possible de proposer et de créer des règles pour améliorer continuellement Wikipédia, en accord avec ses principes.</p>"
               }
             }
@@ -204,6 +216,7 @@
               "element": {
                 "id": "d3825882-f259-454f-ace8-8b983a25357f",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>On l'a vu, Wikipédia a une philosophie unique. Répondez à cette question pour vérifier que vous avez compris l'essentiel.</p>"
               }
             }
@@ -268,6 +281,7 @@
               "element": {
                 "id": "d2327666-368c-4735-94e0-ba7b7b8325a7",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Des personnes du monde entier utilisent Wikipédia et y contribuent. De cette manière, les articles sont fréquemment disponibles dans plusieurs langues.<br>Un petit jeu&nbsp;: saurez-vous dans combien de langues&#8239;?</p>"
               }
             }
@@ -334,6 +348,7 @@
               "element": {
                 "id": "06c2a27a-ce5c-4242-b053-3b5dd1ab891c",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Comme tout site internet, Wikipédia a besoin d’argent pour fonctionner.&nbsp;💰</p>"
               }
             }
@@ -392,6 +407,7 @@
               "element": {
                 "id": "87823339-0045-4db4-88a5-ec1154f73330",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Dans la vidéo suivante, vous allez découvrir différentes méthodes pour trouver des informations sur Wikipédia et évaluer leur qualité.</p>"
               }
             }
@@ -407,6 +423,7 @@
               "element": {
                 "id": "10e352a0-0c46-4348-b392-dedc22a32960",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>À la suite de cette vidéo, vous passerez à la pratique. Vous devrez naviguer dans le sommaire d'un article Wikipédia et en identifier la qualité.</p>"
               }
             },
@@ -433,6 +450,7 @@
               "element": {
                 "id": "01eb319e-8219-425a-b66f-00f8f73a4842",
                 "type": "text",
+                "tag": " ",
                 "content": "<h4>Répondez aux questions ci-dessous en naviguant dans  <a href=\"https://fr.wikipedia.org/wiki/Inca_(Majorque)\" target=\"blank\">l'article Wikipédia de la commune d'Inca.</a></h4>"
               }
             },
@@ -441,6 +459,7 @@
               "element": {
                 "id": "cfcd33f1-3544-491d-95b4-0d028084ff32",
                 "type": "text",
+                "tag": " ",
                 "content": "<hr>"
               }
             },
@@ -484,6 +503,7 @@
               "element": {
                 "id": "c6526e70-ac27-47d3-9794-3e1e2d243334",
                 "type": "text",
+                "tag": " ",
                 "content": "<hr>"
               }
             },
@@ -527,6 +547,7 @@
               "element": {
                 "id": "7c1830cb-1f48-4050-98c1-6ae34d14ee51",
                 "type": "text",
+                "tag": " ",
                 "content": "<hr>"
               }
             },

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/sources-informations.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/sources-informations.json
@@ -32,6 +32,7 @@
               "element": {
                 "id": "40401525-ac7b-401d-ace7-0afa3cdeb2fc",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Léna et Elias discutent par SMS des Jeux asiatiques de 2029. 🏅 Léna cherche à savoir si l’information donnée par Elias est vraie ou fausse.</p>"
               }
             }
@@ -51,6 +52,7 @@
                     {
                       "id": "70598c0e-6292-48a2-8729-401978cc7003",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Lancez la vidéo pour voir le début de leur discussion.<br>En regardant cette vidéo, posez-vous la question suivante&nbsp;: <strong>est-ce que l'information donnée par Elias est plutôt vraie ou plutôt fausse&nbsp;?</strong></p>"
                     },
                     {
@@ -68,6 +70,7 @@
                     {
                       "id": "a2f57d43-a8a1-4659-8730-f5cd39c350e0",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p><span aria-hidden=\"true\">👉</span> C'est assez dur de savoir si cette information est plutôt vraie ou fausse. On ne sait pas encore comment Sandy a obtenu cette information.</p><p>Voici la suite de la discussion entre Elias et Léna. Après la vidéo, vous devrez choisir si l’information d’Elias est plutôt vraie ou plutôt fausse.</p>"
                     },
                     {
@@ -119,6 +122,7 @@
               "element": {
                 "id": "6616dc41-0667-45f3-9326-841f29b72b62",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Léna a posé plusieurs questions à Elias pour trouver l’origine de l’information. C’est ce qu’on appelle la <strong>source d’une information. </strong>&nbsp;ℹ️<br>On vous explique tout dans la leçon suivante.</p>"
               }
             }
@@ -134,6 +138,7 @@
               "element": {
                 "id": "35d79e83-1d3c-4da1-aaed-37dd8e5eae03",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>À la suite de cette leçon, une question sera posée sur la définition d'une source d'information.</p>"
               }
             },
@@ -142,6 +147,7 @@
               "element": {
                 "id": "e9d8230a-f3bf-49d1-a533-6c74d22e4de6",
                 "type": "text",
+                "tag": " ",
                 "content": "<hr>"
               }
             },
@@ -150,6 +156,7 @@
               "element": {
                 "id": "81f2c1af-aeef-4d68-93a9-f4dd3cf1f8bc",
                 "type": "text",
+                "tag": " ",
                 "content": "<h4>C'est quoi une source d'information&#8239;?</h4><p><span aria-hidden=\"true\">👉</span> La source est l’origine de l’information. C’est quelqu’un qui donne des détails sur une information.</p><p><span aria-hidden=\"true\">✅</span> Exemple&nbsp;: si ma voisine Madame Sarah me dit qu'il y a une soucoupe volante dans le ciel, c'est elle la source de cette information.</p>"
               }
             },
@@ -158,6 +165,7 @@
               "element": {
                 "id": "a91f12e7-a297-4dc0-9f81-2a0ccbaba3f8",
                 "type": "text",
+                "tag": " ",
                 "content": "<hr>"
               }
             },
@@ -166,6 +174,7 @@
               "element": {
                 "id": "e3ebd36a-c8b9-4990-af63-061329824708",
                 "type": "text",
+                "tag": " ",
                 "content": "<h4>Comment savoir si on peut croire une source&#8239;?</h4><span aria-hidden=\"true\">👉</span> Il faut se poser quelques questions sur cette source&nbsp;: <ul><li>la source est-elle experte du sujet&#8239;?</li><li>la source est-elle influencée par ses émotions ou ses intérêts&#8239;?</li></ul><p><span aria-hidden=\"true\">✅</span> Exemple&nbsp;: Madame Sarah a l'impression d'avoir vu une soucoupe dans le ciel. Elle a interprété ce qu'elle a vu. Ce n'est peut-être pas une source fiable.</p>"
               }
             }
@@ -181,6 +190,7 @@
               "element": {
                 "id": "5fc304fc-5fc6-49f3-8170-a921b3fd8f67",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Vous en savez maintenant plus sur ce qu'est une source d'information. Vérifions que vous avez compris l'essentiel.&nbsp;🎯</p>"
               }
             }
@@ -239,6 +249,7 @@
               "element": {
                 "id": "6fd96c29-72a2-4b26-aecd-5cb16115e6a0",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Maintenant que vous connaissez la définition d'une source d'information, voyons un exemple.</p>"
               }
             }
@@ -254,6 +265,7 @@
               "element": {
                 "id": "96cf39cd-88df-4104-a155-0fff0b40ac31",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Une radio a publié une interview pour expliquer l’origine de la soucoupe volante vue par Madame Sarah.&nbsp;<span aria-hidden=\"true\">👽</span>&nbsp;<span aria-hidden=\"true\">🛸</span><br>Vous devrez par la suite choisir qui est la source d'information dans cette interview.</p>"
               }
             },
@@ -273,6 +285,7 @@
               "element": {
                 "id": "fa0b94f1-5139-4c55-a8bb-c7a4257c1a40",
                 "type": "text",
+                "tag": " ",
                 "content": "<hr>Dans l'interview, on entend que Madame Sarah a sûrement vu une aurore boréale et non une soucoupe volante."
               }
             },
@@ -324,6 +337,7 @@
               "element": {
                 "id": "bcfc36a3-15e1-4097-8ca5-e8c62b08d2d5",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>À la radio ou sur internet, une information peut être partagée pour plusieurs raisons, par différentes sources. <br>Regardons ça de plus près.</p>"
               }
             }
@@ -339,6 +353,7 @@
               "element": {
                 "id": "d0a2bb58-be8e-4f75-a626-8ac387771dfe",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Après cette leçon, des publications vous seront présentées. Vous devrez choisir pour chaque publication le type de source correspondant.</p>"
               }
             },
@@ -347,6 +362,7 @@
               "element": {
                 "id": "bb24db79-0624-4d43-b1bb-a5510ba12c40",
                 "type": "text",
+                "tag": " ",
                 "content": "<hr>"
               }
             },
@@ -355,6 +371,7 @@
               "element": {
                 "id": "9723333b-6378-4dbd-84a2-92a8fc1cc41a",
                 "type": "text",
+                "tag": " ",
                 "content": "<h4>Certaines sources d'information sont <strong>fiables</strong>.&nbsp;<span aria-hidden=\"true\">👍</span></h4><p>Le but de ces sources est d'informer et de partager des informations vérifiées, qui ont donc beaucoup de chances d'être vraies.</p>"
               }
             },
@@ -363,6 +380,7 @@
               "element": {
                 "id": "2fe6bf3f-c77c-4e21-a57e-8be804171e00",
                 "type": "text",
+                "tag": " ",
                 "content": "<hr>"
               }
             },
@@ -371,6 +389,7 @@
               "element": {
                 "id": "0c5bf4bb-989c-4c60-a54c-ae1f842bc8fe",
                 "type": "text",
+                "tag": " ",
                 "content": "<h4>Certaines sources d'information sont <strong>humoristiques</strong>.&nbsp;<span aria-hidden=\"true\">🤹</span></h4><p>Le but de ces sources est de faire rire et de partager des informations qui ont beaucoup de chances d'être fausses.</p>"
               }
             },
@@ -379,6 +398,7 @@
               "element": {
                 "id": "783421ea-d3eb-437d-9eac-7b51bade7fdb",
                 "type": "text",
+                "tag": " ",
                 "content": "<hr>"
               }
             },
@@ -387,6 +407,7 @@
               "element": {
                 "id": "e22b6b68-a154-4b5a-a896-5b36eb6127a3",
                 "type": "text",
+                "tag": " ",
                 "content": "<h4>Certaines sources d'information sont <strong>contestables</strong>.&nbsp;<span aria-hidden=\"true\">🤨</span></h4><p>Le but de ces sources est d'influencer ou de manipuler les gens. Mais le partage de ces informations a pour principal objectif de gagner de l'argent ou du pouvoir. Ces informations peuvent donc être remises en question.</p>"
               }
             }
@@ -402,6 +423,7 @@
               "element": {
                 "id": "bd9bf91d-bb84-4529-a212-06c2db761b15",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>À vous de jouer sur des exemples concrets.</p>"
               }
             }
@@ -417,6 +439,7 @@
               "element": {
                 "id": "714fd0bb-9252-4c53-a1a2-ce4168e76a1b",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Pour chaque publication, choisissez si elle est fiable, humoristique ou contestable.</p>"
               }
             },

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/tmp08ef.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/tmp08ef.json
@@ -32,6 +32,7 @@
               "element": {
                 "id": "3cea7d3c-052c-4def-8e09-00003d56dd68",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Vous avez peut-être déjà créé du contenu à l’aide d’un système d'IA générative.</p><p>La plupart du temps, les résultats sont crédibles. C’est d’ailleurs leur objectif principal.</p><p>Pourtant, ces résultats peuvent être parfois étranges. Voyons cela dans un exemple. 👇</p>"
               }
             }
@@ -47,6 +48,7 @@
               "element": {
                 "id": "d9e554e5-8d76-42a6-ada4-fc7689a6dad6",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>L'une de ces trois images de plage a été générée par un système d'IA générative. Laquelle ?</p>"
               }
             },
@@ -128,6 +130,7 @@
               "element": {
                 "id": "478343db-2840-49c6-951c-39b45a88c50b",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Les productions des systèmes d’IA peuvent donc contenir des choses incohérentes voire farfelues : des mains à trois doigts, des arbres volants, ou des recettes à base d'œufs de vache.&nbsp;</p><p>Malgré tout, ces systèmes d’IA sont de plus en plus utilisés… mais de quoi s’agit-il ?</p>"
               }
             }
@@ -147,6 +150,7 @@
                     {
                       "id": "99004131-38da-4d88-92b0-f5263d2016cb",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p><strong>Commençons par une définition <span aria-hidden=\"true\">📚 </span></strong> </p><p>L'intelligence artificielle générative ou IA générative est un type de système d'intelligence artificielle (IA) capable de générer du texte, des images, des vidéos ou d'autres médias en réponse à des <em>requêtes</em>, ou en anglais <em>prompts</em>.</p><p>Les systèmes d’IA qui ne sont pas <em>génératifs</em> sont aussi des systèmes automatisés, mais dédiés à des tâches bien définies. En effet, ils ne produisent pas de contenu nouveau ou créatif. Il s’agit par exemple de fonctionnalités de recommandation de musique en fonction des écoutes des utilisateurs.</p>"
                     }
                   ]
@@ -156,6 +160,7 @@
                     {
                       "id": "52e3bd53-2008-4630-b7c5-4e90236ba33b",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p><strong>L'IA générative dans les outils du quotidien</strong> </p><p> Avez-vous déjà aperçu le symbole ✨ sur l’interface de certains de vos logiciels ? Souvent, cela signifie qu’un logiciel intègre et utilise de l’IA pour produire certains contenus. En voici quelques exemples :&nbsp;&nbsp;<br><br></p>"
                     },
                     {
@@ -185,6 +190,7 @@
                     {
                       "id": "e5ea66d1-699d-4d02-943e-1441a18200e6",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p><strong>Le point commun des IA génératives : le <em>prompt</em> ou la <em>requête</em></strong></p><p>Pour qu’une IA génère un résultat (texte, image, son, etc.), il faut que l’utilisateur saisisse une requête. C’est une instruction en langage naturel qui décrit la tâche que doit réaliser le système d’IA générative.</p><p>À partir de cette requête, le système va répondre, compléter ou illustrer la demande de l’utilisateur.</p>"
                     }
                   ]
@@ -203,6 +209,7 @@
               "element": {
                 "id": "0a09b520-f5d2-4926-bc98-6fdf90e2af7a",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Vous en savez désormais plus sur les systèmes d'IA générative.</p><p> Mais avez-vous déjà écrit un prompt ? Et si on essayait ?</p>"
               }
             }
@@ -218,6 +225,7 @@
               "element": {
                 "id": "95c4d552-c7d7-4745-ba58-7990db7ccf94",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><span aria-hidden=\"true\">1️⃣</span><span class=\"sr-only\">1</span> Rendez-vous sur le comparateur d'IA conversationnelles <a href=\"https://www.comparia.beta.gouv.fr/\" target=\"_blank\">Compar:IA</a>&nbsp;et proposez le prompt suivant :&nbsp; </p><blockquote><em>Invente un poème de 8 lignes qui devra contenir les mots \"pharaon\", \"éclair\", \"boucle\" et \"haricot\". La thématique du texte devra concerner l'hiver.</em></blockquote>"
               }
             },
@@ -233,6 +241,7 @@
               "element": {
                 "id": "e2775c21-b269-4512-929c-e0b346c653f7",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><span aria-hidden=\"true\">2️⃣</span><span class=\"sr-only\">2</span> Demandez maintenant de réécrire le poème avec le style de votre auteur préféré. <span aria-hidden=\"true\">🪶</span><br></p>"
               }
             },
@@ -257,6 +266,7 @@
               "element": {
                 "id": "8a2296bd-10e5-4a24-8aea-a2123427d3b6",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><span aria-hidden=\"true\">3️⃣</span><span class=\"sr-only\">3</span> Continuez à demander de réécrire ce texte jusqu’à ce qu'il vous plaise.<span aria-hidden=\"true\">🥰</span></p>"
               }
             },
@@ -300,6 +310,7 @@
               "element": {
                 "id": "357bde39-a26c-442a-a546-c67ad7760574",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Les IA génératives sont impressionnantes… mais que se passe-t-il réellement quand on les utilise ?</p><p>On vous explique tout en vidéo&nbsp;! 📺</p>"
               }
             }
@@ -315,6 +326,7 @@
               "element": {
                 "id": "9306a3f5-4475-4e9c-a2ff-40db303e4007",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>À la suite de cette vidéo, vous devrez utiliser le vocabulaire de l'IA générative dans un exemple concret.</p>"
               }
             },
@@ -342,6 +354,7 @@
               "element": {
                 "id": "3fafe614-19eb-4ecf-b1a8-bdf5307ca84c",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Hier, Nadia a fait découvrir à son amie Alba les IA génératives.</p>"
               }
             },
@@ -462,6 +475,7 @@
               "element": {
                 "id": "5c072fb2-0baf-48dc-8b80-23c7b49d53f8",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><span aria-hidden=\"true\">📌 </span>Résumons avant de passer à la suite.</p><ul><li>Pour interagir avec les systèmes d'IA génératives, les utilisateurs décrivent leur demande en lanagage naturel. C’est le <em>prompt </em>ou<em> requête </em>en français.<br><br></li><li>Les systèmes d’IA générative utilisent des algorithmes qui cherchent à <em>prédire</em> la suite du texte ou la forme d’image la plus probable.<br><br></li><li>Quand un système d’IA générative produit un résultat farfelu, c'est une <em>hallucination</em>. Ces phénomènes sont normaux et nous rappellent que ce sont des machines qui les ont générés, et non des humains !<br><br></li></ul>"
               }
             }
@@ -477,6 +491,7 @@
               "element": {
                 "id": "e3821cb3-8166-44e2-9540-225d33ea5883",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>À vous de jouer&nbsp;! Dans le défi suivant, vous allez faire halluciner des IA génératives. 🥸 🦄</p>"
               }
             }
@@ -492,6 +507,7 @@
               "element": {
                 "id": "014ce746-f31d-424e-975c-0b5b90b2d9f5",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>À l'aide de <a href=\"https://www.comparia.beta.gouv.fr/\" target=\"_blank\">Compar:IA</a>, écrivez des prompts qui amènent à des hallucinations pour au moins une des deux IA génératives de texte proposées.</p>"
               }
             },
@@ -528,6 +544,7 @@
               "element": {
                 "id": "a16433b1-c9bc-4510-a527-5f52fd6e5917",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><span aria-hidden=\"true\">🗝️ </span>Si vous avez besoin d'aide, vous pouvez cliquer sur les astuces ci-dessous.</p>"
               }
             },

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/tri-multicritere-tableau.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/tri-multicritere-tableau.json
@@ -32,6 +32,7 @@
               "element": {
                 "id": "a962681c-b603-4693-bd2f-fc5e3a36708c",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Vous avez peut-être déjà voulu trier les données d’un tableau à partir de plusieurs critères. Pour cela, il faut faire un tri multicritères. <br>Découvrons avec des exemples les cas où le tri multicritère est utile 👇</p>"
               }
             }
@@ -51,6 +52,7 @@
                     {
                       "id": "1d9be377-24ae-49c6-8adc-980fd0e931e0",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Sarah a organisé un évènement pour des enfants. Voici le tableau qui présente leurs résultats aux 3 épreuves.</p>"
                     },
                     {
@@ -63,6 +65,7 @@
                     {
                       "id": "eff4694f-d2a9-48f1-846d-9c9f88acccfa",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p><span aria-hidden=\"true\">🕹️</span> À vous de jouer&#8239;!</p><p>Dans chacune des situations suivantes, choisissez l’action adaptée entre&nbsp;:</p><ul><li>un tri à un critère (sur une colonne uniquement),</li><li>un filtre,</li><li>un tri multicritère.</li></ul>"
                     }
                   ]
@@ -183,6 +186,7 @@
                     {
                       "id": "3be17733-617d-4b6b-8a48-af3d3aaa636d",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Voici comment distinguer le tri multicritère du filtre et du tri sur une seule colonne.</p>"
                     },
                     {
@@ -208,6 +212,7 @@
               "element": {
                 "id": "216c3b36-9ccd-4d47-a0fe-0c4bff845de8",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Pour réaliser un tri multicritère, les raccourcis de tri disponible sur l'en-tête de chaque colonne sont insuffisants.&nbsp;❌<br>Reprenons le cas du tableau de Sarah qui organise un grand jeu pour enfant et découvrez comment y appliquer un tri à plusieurs critères dans la vidéo suivante. 📺</p>"
               }
             }
@@ -223,6 +228,7 @@
               "element": {
                 "id": "2d5100b3-7aad-4f95-969f-ae083361834d",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>À la suite de cette vidéo, vous devrez appliquer un tri sur plusieurs colonnes dans un tableau.</p>"
               }
             },
@@ -243,6 +249,7 @@
               "element": {
                 "id": "a9911b60-31ba-48e0-8b32-f0dacc5befee",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><em>Le logiciel utilisé dans cette vidéo est LibreOffice.</em></p>"
               }
             }
@@ -258,6 +265,7 @@
               "element": {
                 "id": "eaaf4ff2-633f-4c6d-9016-9b9bb9e0fa3d",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Maintenant, à vous de jouer. Vous allez aider Sarah à réaliser le classement individuel de son grand jeu. Pour cela, vous allez réaliser un tri multicritère. </p><p>À vos marques, prêts, partez ! 🏃🏽‍♀️🏃‍♂️</p>"
               }
             }
@@ -273,6 +281,7 @@
               "element": {
                 "id": "9a6bb28f-563f-420f-9ea8-767e25af815b",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><span aria-hidden=\"true\">📋</span> Sarah veut établir le classement des épreuves individuelles, selon les règles suivantes :</p><blockquote><em>Le ou la gagnant(e) aura le meilleur score aux fléchettes. <br>En cas d’ex æquo, on choisira le meilleur résultat au quiz.</em></blockquote>"
               }
             },
@@ -288,6 +297,7 @@
               "element": {
                 "id": "a0e426fd-ebcb-4b3f-90bd-bf34d682f3bd",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Téléchargez le fichier ci-dessous</p>"
               }
             },
@@ -320,6 +330,7 @@
               "element": {
                 "id": "2ed017f2-4c7e-4f64-b0d9-59cfcd9f3e38",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><span aria-hidden=\"true\">👉</span> Appliquez le tri multicritère suivant&nbsp;:</p><ul><li>critère 1&nbsp;: par ordre <strong>décroissant</strong> de<strong> Score aux fléchettes</strong>&nbsp;</li><li>critère 2&nbsp;: par ordre <strong>croissant </strong>de <strong>Réponse au quiz</strong></li></ul>"
               }
             },
@@ -378,6 +389,7 @@
               "element": {
                 "id": "82815beb-6dc8-4caf-8c26-2454ffde5458",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><span aria-hidden=\"true\">🗝️</span> Si vous avez besoin d’aide, cliquez sur les indices ci-dessous :</p><p><br></p><details><summary>Indice 1</summary><p>En fonction de votre logiciel, le vocabulaire de tri peut être différent :</p><ul><li>La fenêtre peut s’appeler «&nbsp;Trier&nbsp;», «&nbsp;Tri personnalisé&nbsp;» ou «&nbsp;Options avancées de tri&nbsp;».</li><li>Un critère de tri peut aussi s’appeler «&nbsp;Clé de tri&nbsp;» ou «&nbsp;Niveau de tri&nbsp;».</li><li>«&nbsp;Croissant&nbsp;» peut être écrit «&nbsp;Du plus petit au plus grand&nbsp;» ou «&nbsp;A-Z&nbsp;».</li></ul></details><details><summary>Indice 2</summary><p>Pour ouvrir la fenêtre de tri sur le logiciel LibreOffice, voici la manipulation à effectuer</p><img src=\"https://assets.pix.org/draft/modules/88.125.115.216-67530fa7a5525.gif\" alt=\"\" /></details><details><summary>Indice 3</summary><ul><li>Commencez par sélectionner «&nbsp;<strong>Score aux fléchettes</strong>&nbsp;» dans votre premier critère de tri. Attribuez-lui un classement <strong>«&nbsp;Décroissant&nbsp;»</strong>.</li><li>Puis, sélectionnez <strong>«&nbsp;Réponse au quiz&nbsp;»</strong> dans votre second critère de tri. Attribuez-lui le classement <strong>«&nbsp;Croissant&nbsp;»</strong> </li></ul></details>"
               }
             }
@@ -393,6 +405,7 @@
               "element": {
                 "id": "538cfc41-cf44-4a4f-9bcb-da4ddd18043f",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Vous savez désormais réaliser un tri sur deux critères.<br><br> Avant de réaliser un tri avancé sur encore plus de critères, découvrez quelques bonnes pratiques et astuces pour trier plus facilement vos tableaux. 🏆</p>"
               }
             }
@@ -412,6 +425,7 @@
                     {
                       "id": "05a44b3d-1c77-49fc-bab9-65e5f20c3d38",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p><strong>Une option permet de reconnaître les en-têtes ou étiquettes de colonnes.</strong> </p><p>Si les en-têtes de votre tableau sont correctement remplies, la plupart des logiciels les détectent automatiquement.&nbsp;</p><p>Cette option s’appelle « <span aria-hidden=\"true\">☑️</span> Mes données ont des en-têtes » ou « <span aria-hidden=\"true\">☑️</span> La plage contient des étiquettes de colonne ».&nbsp;</p><p>Avec une détection automatique, elle sera déjà cochée. Vous pouvez aussi la cocher manuellement <span aria-hidden=\"true\">👇</span></p>"
                     },
                     {
@@ -424,6 +438,7 @@
                     {
                       "id": "76563c87-ea9e-44d5-acbf-ad78a6da4220",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p><span aria-hidden=\"true\">⚠️</span> Si cette case n’est pas cochée, mais que votre tableau a des en-têtes, elles seront considérées comme des données à trier.</p>"
                     }
                   ]
@@ -433,6 +448,7 @@
                     {
                       "id": "b8c69ed0-7388-4197-a700-19126f4c91d2",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p><strong>La sensibilité à la casse.</strong> </p><p>L’onglet « Options » de la fenêtre de tri, permet de faire des réglages avancés. La case à cocher «Sensible à la casse» permet de prendre en compte ou d’ignorer les majuscules ou les minuscules. <span aria-hidden=\"true\">🔠</span></p>"
                     },
                     {
@@ -449,6 +465,7 @@
                     {
                       "id": "8536a080-79f8-4bc1-8cb7-5c3829dca8ca",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p><strong>L’ordre de tri personnalisé. </strong> </p><p>Il permet de trier automatiquement les jours de la semaine et les mois. Sans cette option, le tri sera alphabétique : jeudi sera donc avant lundi. <span aria-hidden=\"true\">📆</span> on trouvé également ce réglage dans l’onglet « Options » de la fenêtre de tri.</p>"
                     },
                     {
@@ -474,6 +491,7 @@
               "element": {
                 "id": "cfcf3dde-1eed-4654-86bc-c1c9bc4868ef",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Sarah a préparé un nouveau fichier contenant les résultats des enfants à la chasse au trésor.&nbsp; <br>Elle veut établir un classement, selon les règles suivantes :</p><blockquote><em>Le ou la gagnant(e) aura découvert la cachette aux trésors. <br>Pour emporter le trésor, il faut avoir résolu un maximum d’énigmes.<br>En cas d’ex æquo, il faut sortir le plus vite possible du labyrinthe.</em></blockquote>"
               }
             },
@@ -489,6 +507,7 @@
               "element": {
                 "id": "fde2db58-a735-418a-9063-a56652845965",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><span aria-hidden=\"true\">👉</span> <strong>Téléchargez ce fichier et triez les données pour obtenir le classement de la chasse au trésor</strong></p>"
               }
             },
@@ -571,6 +590,7 @@
               "element": {
                 "id": "9c101788-40c6-4343-95e4-fcac920c96b7",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><span aria-hidden=\"true\">❓</span> Si vous avez besoin d’aide, cliquez sur les indices ci-dessous :</p><p><br></p><details><summary>Indice 1</summary><p>Voici le résultat que vous devriez obtenir. Observez bien les colonnes pour trouver l'ordre des critères de tri.</p><img src=\"https://assets.pix.org/draft/modules/88.125.115.216-67727d49bec01.png\" alt=\"\"></details><details><summary>Indice 2</summary><p>Il y a 3 critères de tri nécessaires au classement de Sarah.<br>L’énoncé vous permet de trouver l’ordre des critères de tri suivant&nbsp;:</p> <ol> <li>L’étape la plus importante est bien sûr : la découverte du trésor</li> <li>La seconde épreuve est le nombre d’énigmes réussies</li> <li>Le troisième critère est le temps au labyrinthe</li> </ol><p>Ensuite, comparez l’ordre des critères de tri au tableau de l’indice 2 et déterminez le classement de chaque colonne.</p> </details>"
               }
             }
@@ -586,6 +606,7 @@
               "element": {
                 "id": "453fa79b-7a83-46f6-aca2-0cfd6409fa6d",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Vous savez désormais créer un tri multicritère sur un logiciel de tableur. <br>Grâce à ce tri, Sarah a pu donner leur classement à ses participants. 🏆</p><p>Voici un récapitulatif des grandes étapes de tri et quelques précisions.</p>"
               }
             }
@@ -601,6 +622,7 @@
               "element": {
                 "id": "e9ac9d81-41fc-48c2-b74c-7aee31373f39",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><span aria-hidden=\"true\">✅</span> On a besoin d’<strong>un tri multicritères sur plusieurs colonnes</strong> quand on doit<strong> cumuler plusieurs critères de tri</strong> (d’abord un premier critère, puis un second, puis un troisième, etc). <br>✔️Par exemple, quand on a besoin de discriminer des ex æquo sur un premier critère.</p>"
               }
             },
@@ -616,6 +638,7 @@
               "element": {
                 "id": "d5e3be8f-f65f-4786-bf16-1d8f13e1e94c",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><span aria-hidden=\"true\">🥇</span> <strong>L’ordre des critères de tri détermine le résultat du tri.</strong> <br>Le second critère s’applique toujours en fonction du premier. Si vous inversez les critères, vous obtiendrez un résultat visiblement différent.</p>"
               }
             },
@@ -631,6 +654,7 @@
               "element": {
                 "id": "920abeb8-99e2-4891-b002-840de3eb9152",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><span aria-hidden=\"true\">🔠</span> <strong>Le vocabulaire peut varier en fonction de votre logiciel.</strong><br>La fenêtre de tri peut s’appeler autrement selon le logiciel utilisé, avoir un pictogramme différent et peut utiliser d’autres mots pour désigner les critères de tri.</p>"
               }
             }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/utiliser-souris-ordinateur-1.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/utiliser-souris-ordinateur-1.json
@@ -32,6 +32,7 @@
               "element": {
                 "id": "91ba6701-243c-4f07-bd0d-9019a1c85b4d",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Dans ce module, vous allez prendre en main une souris pour interagir avec un ordinateur.</p>"
               }
             }
@@ -47,6 +48,7 @@
               "element": {
                 "id": "48708070-39c3-4af4-8914-ab61d61dfee8",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>La souris fait partie de l’équipement de base d’un ordinateur, avec le clavier.</p><p>Les souris peuvent avoir différentes formes, tailles ou couleurs. </p><p>Il y a deux types de souris&nbsp;: </p><ul><li>les souris avec un fil,</li><li>les souris sans fil.</li></ul><p>Globalement, toutes ces souris servent à faire les mêmes choses.</p>"
               }
             },
@@ -65,6 +67,7 @@
               "element": {
                 "id": "c785bfd1-e8b8-42a0-8354-333d5acf6555",
                 "type": "text",
+                "tag": " ",
                 "content": "<h4><span aria-hidden=\"true\">🔎</span> Observez&nbsp;: votre souris a-t-elle un fil ?</h4>"
               }
             }
@@ -80,6 +83,7 @@
               "element": {
                 "id": "b4727513-47b5-4850-bde5-263795c63f46",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Dans la vidéo suivante, vous allez voir comment prendre en main une souris d’ordinateur pour ensuite la déplacer.&nbsp;📺</p>"
               }
             }
@@ -95,6 +99,7 @@
               "element": {
                 "id": "75894ade-d0b9-4662-ba37-edf72c9e74e5",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Après cette vidéo, vous devrez suivre les étapes pour prendre en main votre souris.</p>"
               }
             },
@@ -122,6 +127,7 @@
               "element": {
                 "id": "927b247f-f86a-458a-908f-62f8c39fb353",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>À vous de jouer. Vous allez vous entraîner à déplacer votre souris.</p>"
               }
             }
@@ -137,6 +143,7 @@
               "element": {
                 "id": "6b6eeef4-bb9b-4769-906d-47e72db93543",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Pour l’instant, regardez votre souris. Ne regardez pas ce qu’il se passe à l’écran.<br></p><h4><span aria-hidden=\"true\">👉</span> Déplacez votre souris, en suivant ces étapes&nbsp;:</h4><ul><li>Étape 1&nbsp;: Posez votre main confortablement sur la souris.</li><li>Étape 2&nbsp;: Faites glisser la souris doucement sur la table.</li></ul>"
               }
             },
@@ -152,6 +159,7 @@
               "element": {
                 "id": "d1dd9768-1b88-4a76-af7c-4290c3fe5a2f",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><span aria-hidden=\"true\">🙋🏽‍♂️ 🙋🏿‍♀️ 🙋‍♂️</span>N’hésitez pas à demander conseil à la personne qui vous accompagne. Elle vous aidera à trouver une position confortable pour vous.</p>"
               }
             }
@@ -167,6 +175,7 @@
               "element": {
                 "id": "36a93743-af38-47ae-a58e-be59b2d86656",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Dans la vidéo suivante, vous allez voir comment déplacer la souris sur votre écran.&nbsp;📺</p>"
               }
             }
@@ -182,6 +191,7 @@
               "element": {
                 "id": "7dad11c9-fafd-4e94-bd81-003e3944ff6d",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Après cette vidéo, vous devrez déplacer votre souris dans une situation simple.</p>"
               }
             },
@@ -209,6 +219,7 @@
               "element": {
                 "id": "c8d99f94-9e03-4e0c-85cb-11c97f0d4149",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Vous allez maintenant passer à la pratique.</p>"
               }
             }
@@ -224,6 +235,7 @@
               "element": {
                 "id": "0dc90047-776b-48cd-944e-72ca51c69cfc",
                 "type": "text",
+                "tag": " ",
                 "content": "<h4><span aria-hidden=\"true\">👉</span> Dans la zone ci-dessous, déplacez le pointeur de votre souris.</h4>"
               }
             },
@@ -251,6 +263,7 @@
               "element": {
                 "id": "2c5368e9-7d85-4132-bafe-53f198099b57",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Vous savez déplacer le pointeur de la souris à l’écran. Maintenant, entraînez-vous à être précis dans vos mouvements. 🎯</p>"
               }
             }
@@ -266,6 +279,7 @@
               "element": {
                 "id": "a33ac061-ab23-4e94-b60e-904e701e7d76",
                 "type": "text",
+                "tag": " ",
                 "content": "<h4><span aria-hidden=\"true\">👉</span> Dans la zone ci-dessous, déplacez le pointeur sur chacun des éléments qui apparaissent. </h4><p>Vous pouvez essayer autant de fois que vous voulez.</p>"
               }
             },
@@ -285,6 +299,7 @@
               "element": {
                 "id": "9c1c4342-96a6-4c14-a5b0-5ed0d202fb8f",
                 "type": "text",
+                "tag": " ",
                 "content": "<h4> <span aria-hidden=\"true\">💡</span> Astuce si vous ne voyez plus le pointeur sur votre écran&nbsp;:&nbsp;</h4> <p> Bougez de gauche à droite votre souris doucement sur la table.<br> Vous verrez le pointeur bouger à l’écran.</p>"
               }
             }
@@ -300,6 +315,7 @@
               "element": {
                 "id": "a11dc8fa-9030-4f70-b6d8-86af6ff66e30",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Maintenant que vous savez déplacer votre souris, découvrez les différents boutons de la souris ! 🖱️️</p>"
               }
             }
@@ -326,6 +342,7 @@
               "element": {
                 "id": "d9e4718d-a15a-4e62-a967-19971e1a611e",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Sur la souris, on trouve toujours deux boutons&nbsp;: un bouton gauche et un bouton droit.<br>En général, il y a aussi une molette.</p>"
               }
             },
@@ -341,6 +358,7 @@
               "element": {
                 "id": "98a59942-5506-4c18-b16a-97ce2010103b",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><strong><span aria-hidden=\"true\">🔎</span> Observez&nbsp;: combien de boutons a votre souris d’ordinateur ?</strong></p>"
               }
             }
@@ -356,6 +374,7 @@
               "element": {
                 "id": "4d997b51-9404-42d3-87fc-8a9d31b0d905",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Vous avez découvert le nom des boutons d’une souris.</p><p>Voyons à présent comment cliquer avec votre souris !<br></p>"
               }
             }
@@ -371,6 +390,7 @@
               "element": {
                 "id": "e45a32cf-2ab9-4464-85d0-ae4f0ca897cb",
                 "type": "text",
+                "tag": " ",
                 "content": "<h4>D’abord, pourquoi est-ce qu’on dit «&nbsp;<strong>clic&nbsp;</strong>»&nbsp;?</h4><p>C’est le bruit que fait une souris d’ordinateur quand on appuie sur un de ses boutons.</p>"
               }
             },
@@ -389,6 +409,7 @@
               "element": {
                 "id": "d96505a1-c5c0-4dbf-af9d-900453586d45",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Le bouton gauche est le plus important. Il permet de faire un clic gauche.</p>"
               }
             },
@@ -404,6 +425,7 @@
               "element": {
                 "id": "a510f893-7d93-4e4f-b8a4-0dd978324c70",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Voyons comment faire un clic gauche. <span aria-hidden=\"true\">👇</span></p>"
               }
             },
@@ -422,6 +444,7 @@
               "element": {
                 "id": "4f9d39e4-5687-43fa-881d-8904d63023c8",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><strong>Étape 1&nbsp;:</strong> On déplace le pointeur à l’écran.</p><p><strong>Étape 2&nbsp;: </strong>On appuie sur le bouton gauche de la souris</p><p>💡Pour réussir un clic&nbsp;: </p><ul><li>Il faut appuyer avec l’index sans faire bouger la souris.</li><li>On doit entendre le son «&nbsp;clic&nbsp;».</li><li>Il faut relâcher immédiatement après l’appui. C’est comme pour un bouton de télécommande !</li></ul>"
               }
             }
@@ -437,6 +460,7 @@
               "element": {
                 "id": "7b083f7d-3e44-42ad-9822-8999a4e65ba4",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Vous allez maintenant passer à la pratique. 👇</p>"
               }
             }
@@ -470,6 +494,7 @@
               "element": {
                 "id": "930a995c-2b29-474a-97a3-c90d5e03ad80",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>👏Bravo ! Vous savez maintenant déplacer le pointeur de votre souris et cliquer.</p><p>Faites un clic gauche sur le bouton «&nbsp;Continuer&nbsp;» pour passer à l’étape suivante en autonomie.</p>"
               }
             }
@@ -485,6 +510,7 @@
               "element": {
                 "id": "0ef82c6c-4526-4ecf-9f2e-02a42fc382ac",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Il arrive que le pointeur de la souris change de forme. C’est tout à fait normal.&nbsp;</p><p>Découvrez les différentes formes de pointeurs.<br><br></p>"
               }
             }
@@ -500,6 +526,7 @@
               "element": {
                 "id": "af44ed34-f3a3-46f1-813d-c801a6e0b073",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Quand vous déplacez votre souris sur un élément, le pointeur peut changer de forme. Cela signifie qu’une action est possible.</p><p>Découvrez les trois formes de pointeurs les plus courantes et leur utilité.</p>"
               }
             },
@@ -518,6 +545,7 @@
               "element": {
                 "id": "8c07cbe0-14aa-4a0e-898d-7ddf9c4ff3be",
                 "type": "text",
+                "tag": " ",
                 "content": "<ul><li><strong>La flèche</strong> est le pointeur le plus courant.</li><li><strong>La main</strong> indique que vous pouvez cliquer.</li><li><strong>La barre verticale</strong> indique que vous pouvez taper du texte.</li><li><strong>La roue ou le sablier</strong> indiquent qu’il faut patienter.</li></ul>"
               }
             }
@@ -533,6 +561,7 @@
               "element": {
                 "id": "ccc4bf26-0610-4598-a91f-49a3c2e8dd02",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Le clic gauche sert à ouvrir des pages internet ou à démarrer des vidéos. Pour chacune de ses actions, le pointeur change de forme.</p><p>🖱️À vous de jouer !</p>"
               }
             }
@@ -548,6 +577,7 @@
               "element": {
                 "id": "fb3ecb38-4367-4d9e-a86d-bfb5c66082c2",
                 "type": "text",
+                "tag": " ",
                 "content": "<strong>Faites un clic gauche sur «&nbsp;Play&nbsp;» ▶️ au centre de l’image ci-dessous.</strong>   <br>Ce clic gauche va faire démarrer la vidéo.<br>"
               }
             },
@@ -568,6 +598,7 @@
               "element": {
                 "id": "885bb39e-77a6-4cbb-9456-63660e0ecb6f",
                 "type": "text",
+                "tag": " ",
                 "content": "Pour accéder à la suite, faites un clic gauche sur le bouton «&nbsp;Continuer&nbsp;»."
               }
             }
@@ -583,6 +614,7 @@
               "element": {
                 "id": "cf2d139c-39dc-4e7b-b24c-960e3e52e6cf",
                 "type": "text",
+                "tag": " ",
                 "content": "Pour répondre à la question ci-dessous, cliquez sur une réponse puis cliquez sur «&nbsp;Vérifier ma réponse&nbsp;»."
               }
             },
@@ -634,6 +666,7 @@
               "element": {
                 "id": "d0644a95-013c-4160-b8df-6414366e533e",
                 "type": "text",
+                "tag": " ",
                 "content": "Quand vous avez terminé l’activité, faites un clic gauche sur le bouton «&nbsp;Continuer&nbsp;»."
               }
             }
@@ -649,6 +682,7 @@
               "element": {
                 "id": "72a98ef7-1052-4f70-bfe8-a77ff4279f61",
                 "type": "text",
+                "tag": " ",
                 "content": "<h4>Les 5 points à retenir <span aria-hidden=\"true\">📌</span></h4>"
               }
             },
@@ -657,6 +691,7 @@
               "element": {
                 "id": "3480a769-41ea-47e8-990b-c5f8089542e7",
                 "type": "text",
+                "tag": " ",
                 "content": "<ul> <li><span aria-hidden=\"true\">🖐️</span>La souris glisse sur la table grâce à votre main.</li> <li><span aria-hidden=\"true\">🖥️</span> À l’écran, le pointeur suit le mouvement de la souris.</li> <li><span aria-hidden=\"true\">👉</span> Cliquer veut dire appuyer brièvement sur un bouton de la souris.</li> <li><span aria-hidden=\"true\">▶️</span> Cliquer permet d’interagir avec l’ordinateur.</li> <li><span aria-hidden=\"true\">🖱️Le pointeur de la souris change de forme quand on peut cliquer.</span></li></ul>"
               }
             },
@@ -672,6 +707,7 @@
               "element": {
                 "id": "85ac9805-09f8-456b-8b5f-f26fe19ca618",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><span aria-hidden=\"true\">📝</span> Vous pouvez maintenant <a href=\"https://assets.pix.org/modules/1eMarche-souris1/pix-fiche-revision-premieres-marches-souris-1.pdf\" target=\"_blank\">ouvrir votre fiche de synthèse</a>.</p>"
               }
             }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/utiliser-souris-ordinateur-2.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/utiliser-souris-ordinateur-2.json
@@ -32,6 +32,7 @@
               "element": {
                 "id": "d5c2e0af-72e7-42b8-a1f5-fa235be9301a",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>La souris permet d’interagir avec l’ordinateur de différentes façons. Le pointeur se déplace à l’écran quand la souris glisse sur la table. Le bouton gauche permet de faire un clic gauche.&nbsp; <br><br>Découvrez dans ce module comment utiliser la molette, le double-clic et le clic droit.</p>"
               }
             }
@@ -47,6 +48,7 @@
               "element": {
                 "id": "7724ff4d-de21-4fe3-9eab-5c9e6a18a010",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Pour commencer, faites un clic gauche sur «&nbsp;Continuer» 👇</p>"
               }
             }
@@ -62,6 +64,7 @@
               "element": {
                 "id": "36044495-821b-4126-b687-b8a17c505b8e",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><strong>Bravo !</strong> 🎉 <br>Vous êtes prêt. Commençons par la molette.</p>"
               }
             }
@@ -77,6 +80,7 @@
               "element": {
                 "id": "6b8d384f-c15e-4abd-b392-bff1e17aee7a",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>La molette est le bouton central de la souris. Elle sert à faire <strong>défiler une page à l’écran </strong>vers le bas, ou vers le haut.</p>"
               }
             },
@@ -94,6 +98,7 @@
               "element": {
                 "id": "98952c1e-2dbe-4b62-9d8f-7cba4171e734",
                 "type": "text",
+                "tag": " ",
                 "content": "Pour faire défiler la page, il faut faire rouler la molette avec votre doigt de haut en bas, ou de bas en haut."
               }
             },
@@ -112,6 +117,7 @@
               "element": {
                 "id": "695d7b72-e982-4e45-a8dd-deac2ae73c59",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Dans l’exemple ci-dessus&nbsp;: la molette roule vers le bas, donc on descend dans la page. </p><p>C’est comme si nos yeux descendaient sur une page de journal papier. 📰</p>"
               }
             }
@@ -127,6 +133,7 @@
               "element": {
                 "id": "56cb8b5c-4a25-4960-a7cf-6b86b13375a5",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>À vous de jouer. 🕹️🕹️🕹️ </p><p>Vous allez vous entraîner à utiliser la molette de votre souris.</p>"
               }
             }
@@ -142,6 +149,7 @@
               "element": {
                 "id": "6802e654-4c8d-470c-bd51-e17f08c63784",
                 "type": "text",
+                "tag": " ",
                 "content": "👉 <strong>Dans la zone ci-dessous, utilisez la molette pour découvrir toute l’image. Vous devrez ensuite répondre à une question&nbsp;:</strong> <br><ul><li>Étape 1: Placez le pointeur sur l’image </li><li>Étape 2&nbsp;: Faites rouler la molette de votre souris vers le haut et vers le bas. </li><li>Étape 3&nbsp;: Déplacez l’image jusqu’à trouver le balcon le plus bas de l’immeuble.</li></ul><br>"
               }
             },
@@ -204,6 +212,7 @@
               "element": {
                 "id": "989decd1-926a-4db7-88bb-b31862131f8b",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Passez à la pratique sur une page entière. 👇 </p><p>Après cette activité, vous saurez vous déplacer dans le module grâce à la molette, vous êtes prêts ?</p>"
               }
             }
@@ -219,6 +228,7 @@
               "element": {
                 "id": "f8226449-d41d-4650-aa7a-001fbc5773a8",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Dans cette activité, vous allez devoir retrouver un mot dans le module. Le mot à trouver se trouve avant les 3 symboles « 🕹️🕹️🕹️&nbsp;». <br><br> Voici les étapes que vous allez suivre&nbsp;:&nbsp; </p><ul><li>Faire rouler la molette pour remonter  au-dessus de l’exercice des balcons.</li><li>Trouver le mot qui se trouve avant le symbole « 🕹️🕹️🕹️&nbsp;».</li><li>Faire rouler la molette pour redescendre ici.</li><li>Répondre à la question.</li></ul>"
               }
             },
@@ -270,6 +280,7 @@
               "element": {
                 "id": "b42906c3-b340-40c0-852a-4ae733c7fb9e",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Félicitations !&nbsp; Vous êtes désormais autonome avec la molette ! 🎉<br>Découvrez maintenant un nouveau type de clic&nbsp;: le double-clic.</p>"
               }
             }
@@ -285,6 +296,7 @@
               "element": {
                 "id": "5a8f1986-8a81-4b66-ae0f-d0e58b73ce69",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Pour faire un double-clic, il faut appuyer rapidement deux fois de suite sur le bouton gauche.</p>"
               }
             },
@@ -310,6 +322,7 @@
               "element": {
                 "id": "ec8094d6-53e4-4305-948a-74ed1d0fd443",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>📺 Dans la vidéo ci-dessous, vous allez voir comment faire un double-clic et à quoi il sert. <br>Après cette vidéo, ce sera à vous de faire des doubles-clics.</p>"
               }
             },
@@ -337,6 +350,7 @@
               "element": {
                 "id": "3b975cca-22b4-444a-8aa5-801af949536f",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Place à la pratique ! Entraînez-vous au double-clic dans l’activité suivante.👇</p>"
               }
             }
@@ -370,6 +384,7 @@
               "element": {
                 "id": "e295a2ca-a6ba-45e2-8805-12ef13bcab53",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>On utilise souvent le double-clic pour ouvrir des dossiers sur son ordinateur. 📁 <br>À vous d’essayer !</p>"
               }
             }
@@ -385,6 +400,7 @@
               "element": {
                 "id": "3528708a-ba19-49c2-97a2-08be8f961124",
                 "type": "text",
+                "tag": " ",
                 "content": "<p><strong>Dans la zone ci-dessous, ouvrez les dossiers en suivant cet ordre&nbsp;:</strong> </p><ul><li>Photos,</li><li>Album,</li><li>Famille,</li><li>80 ans Mamie.</li></ul>"
               }
             },
@@ -448,6 +464,7 @@
               "element": {
                 "id": "66c9055e-c74a-4cf4-af83-70833210c86e",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Maintenant que vous savez faire un clic, un double-clic et utiliser la molette, découvrez le dernier bouton de la souris&nbsp;: le bouton droit.</p>"
               }
             }
@@ -467,6 +484,7 @@
                     {
                       "id": "f986b4fa-fa9d-45ae-8ccd-ca4e834f050d",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>Le bouton droit permet de faire des <strong>clics droit</strong>. <br>Le clic droit sert à afficher une liste d’actions à l’écran. <br>Par exemple, avec un dossier, on a le choix de supprimer le dossier, de renommer le dossier, etc.</p>"
                     },
                     {
@@ -483,6 +501,7 @@
                     {
                       "id": "21323d29-5fb9-4374-b25e-8c83e011605b",
                       "type": "text",
+                      "tag": " ",
                       "content": "<p>📺 Découvrez en vidéo comment faire un clic droit et comment utiliser la liste d’actions. <br> Après la vidéo, vous pourrez vous entraîner à faire des clics droit.</p>"
                     },
                     {
@@ -510,6 +529,7 @@
               "element": {
                 "id": "a609018d-fd04-460f-b574-b5107b3f4f73",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Avant de faire apparaître la liste d’actions, commencez par faire vos premiers clics droit. 👇</p>"
               }
             }
@@ -543,6 +563,7 @@
               "element": {
                 "id": "7f49b2c6-8488-4868-9454-6a92b4cc7643",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Vous savez désormais alterner les clics droit et clics gauche. 👍<br>À vous maintenant d’utiliser les clics droit et gauche sur une liste d’actions.</p>"
               }
             }
@@ -577,6 +598,7 @@
               "element": {
                 "id": "07c245c1-73e8-4968-bb7b-99aac6590f2c",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>Bravo ! 🎉 Vous savez utiliser le clic droit de la souris.</p>"
               }
             }
@@ -610,6 +632,7 @@
               "element": {
                 "id": "3dbb4032-7150-447e-ac8c-00c1302bcc84",
                 "type": "text",
+                "tag": " ",
                 "content": "<p>📌 Les points à retenir&nbsp;: <br> </p><ul>    <li>▶️ Le bouton gauche permet de faire des clics gauche et des doubles-clics pour déclencher des actions (ouvrir, faire apparaître, sélectionner, etc).</li>    <li>📋 Le bouton droit permet d’afficher une liste d’actions possibles.</li>    <li>⬆️ La molette permet de monter ou de descendre dans une page.</li></ul><p><br><span aria-hidden=\"true\">📝</span> Vous pouvez maintenant <a href=\"https://assets.pix.org/modules/1emarche-souris2/pix-fiche-revision-premieres-marches-souris-2.pdf\" target=\"_blank\">ouvrir votre fiche de synthèse</a>.</p>"
               }
             }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/validation/element/text-schema.js
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/validation/element/text-schema.js
@@ -5,6 +5,10 @@ import { htmlSchema, uuidSchema } from '../utils.js';
 const textElementSchema = Joi.object({
   id: uuidSchema,
   type: Joi.string().valid('text').required(),
+  tag: Joi.string()
+    .valid(' ', 'context', 'did-you-know', 'further-information', 'key-points', 'tip')
+    .required()
+    .description("Tag qui s'affiche au dessus du texte. Champ facultatif (laisser vide si pas de tag souhaité)"),
   content: htmlSchema,
 }).required();
 

--- a/api/src/devcomp/infrastructure/factories/module-factory.js
+++ b/api/src/devcomp/infrastructure/factories/module-factory.js
@@ -242,6 +242,7 @@ export class ModuleFactory {
     return new Text({
       id: element.id,
       content: element.content,
+      tag: element.tag,
     });
   }
 

--- a/api/tests/devcomp/acceptance/scripts/test-module.json
+++ b/api/tests/devcomp/acceptance/scripts/test-module.json
@@ -28,7 +28,8 @@
               "element": {
                 "id": "08a8b1ea-4771-48ef-a5a5-665c664ba673",
                 "type": "text",
-                "content": "<p>Bonjour et bienvenue dans le bac à sable de Modulix. Vous allez pouvoir facilement découvrir comment fonctionne ce nouveau produit Pix.<br>C'est partix !</p>"
+                "content": "<p>Bonjour et bienvenue dans le bac à sable de Modulix. Vous allez pouvoir facilement découvrir comment fonctionne ce nouveau produit Pix.<br>C'est partix !</p>",
+                "tag": " "
               }
             }
           ]
@@ -96,7 +97,8 @@
               "element": {
                 "id": "e9aef60c-f18a-471e-85c7-e50b4731b86b",
                 "type": "text",
-                "content": "<h4>Pour afficher mon texte sur plusieurs colonnes, je peux utiliser la classe <em>modulix-two-columns</em>.</h4>\n <p>Des noms d'artistes de musique très sympas:</p>\n<ol class=\"modulix-two-columns\">\n    <li>Dylan</li>\n    <li>The Beatles</li>\n    <li>The Who</li>\n    <li>Blondie</li>\n    <li>Joan Baez</li>\n    <li>Supertramp</li>\n    <li>Kraftwerk</li>\n    <li>Queen</li>\n    <li>David Bowie</li>\n    <li>Céline Dion</li>\n</ol>"
+                "content": "<h4>Pour afficher mon texte sur plusieurs colonnes, je peux utiliser la classe <em>modulix-two-columns</em>.</h4>\n <p>Des noms d'artistes de musique très sympas:</p>\n<ol class=\"modulix-two-columns\">\n    <li>Dylan</li>\n    <li>The Beatles</li>\n    <li>The Who</li>\n    <li>Blondie</li>\n    <li>Joan Baez</li>\n    <li>Supertramp</li>\n    <li>Kraftwerk</li>\n    <li>Queen</li>\n    <li>David Bowie</li>\n    <li>Céline Dion</li>\n</ol>",
+                "tag": " "
               }
             },
             {

--- a/api/tests/devcomp/integration/infrastructure/factories/module-factory_test.js
+++ b/api/tests/devcomp/integration/infrastructure/factories/module-factory_test.js
@@ -563,6 +563,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
                         id: '84726001-1665-457d-8f13-4a74dc4768ea',
                         type: 'text',
                         content: '<h4>Content</h4>',
+                        tag: ' ',
                       },
                     },
                   ],
@@ -1617,6 +1618,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
                             {
                               id: '342183f7-af51-4e4e-ab4c-ebed1e195063',
                               type: 'text',
+                              tag: ' ',
                               content:
                                 '<p>À la fin de cette vidéo, une question sera posée sur les compétences Pix.</p>',
                             },
@@ -2333,6 +2335,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
                             {
                               id: '342183f7-af51-4e4e-ab4c-ebed1e195063',
                               type: 'text',
+                              tag: ' ',
                               content:
                                 '<p>À la fin de cette vidéo, une question sera posée sur les compétences Pix.</p>',
                             },
@@ -2397,6 +2400,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
                             {
                               id: '342183f7-af51-4e4e-ab4c-ebed1e195063',
                               type: 'text',
+                              tag: ' ',
                               content:
                                 '<p>À la fin de cette vidéo, une question sera posée sur les compétences Pix.</p>',
                             },
@@ -2518,6 +2522,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
                       id: '84726001-1665-457d-8f13-4a74dc4768ea',
                       type: 'text',
                       content: '<h4>Content</h4>',
+                      tag: ' ',
                     },
                   },
                   {
@@ -2578,6 +2583,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
                       id: '84726001-1665-457d-8f13-4a74dc4768ea',
                       type: 'text',
                       content: '<h4>Content</h4>',
+                      tag: ' ',
                     },
                   },
                   {

--- a/api/tests/devcomp/integration/repositories/module-repository_test.js
+++ b/api/tests/devcomp/integration/repositories/module-repository_test.js
@@ -81,6 +81,7 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
                     element: {
                       id: 'd9e8a7b6-5c4d-3e2f-1a0b-9f8e7d6c5b4a',
                       type: 'text',
+                      tag: ' ',
                       content:
                         "<h4 class='screen-reader-only'>L'arobase</h4><p>L’arobase est dans toutes les adresses mails. Il sépare l’identifiant et le fournisseur d’adresse mail.</p><p><span aria-hidden='true'>🇬🇧</span> En anglais, ce symbole se lit <i lang='en'>“at”</i> qui veut dire “chez”.</p><p><span aria-hidden='true'>🤔</span> Le saviez-vous : c’est un symbole qui était utilisé bien avant l’informatique ! Par exemple, pour compter des quantités.</p>",
                     },
@@ -239,6 +240,7 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
                     element: {
                       id: 'd9e8a7b6-5c4d-3e2f-1a0b-9f8e7d6c5b4a',
                       type: 'text',
+                      tag: ' ',
                       content:
                         "<h4 class='screen-reader-only'>L'arobase</h4><p>L’arobase est dans toutes les adresses mails. Il sépare l’identifiant et le fournisseur d’adresse mail.</p><p><span aria-hidden='true'>🇬🇧</span> En anglais, ce symbole se lit <i lang='en'>“at”</i> qui veut dire “chez”.</p><p><span aria-hidden='true'>🤔</span> Le saviez-vous : c’est un symbole qui était utilisé bien avant l’informatique ! Par exemple, pour compter des quantités.</p>",
                     },
@@ -399,6 +401,7 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
                     element: {
                       id: 'd9e8a7b6-5c4d-3e2f-1a0b-9f8e7d6c5b4a',
                       type: 'text',
+                      tag: ' ',
                       content:
                         "<h4 class='screen-reader-only'>L'arobase</h4><p>L’arobase est dans toutes les adresses mails. Il sépare l’identifiant et le fournisseur d’adresse mail.</p><p><span aria-hidden='true'>🇬🇧</span> En anglais, ce symbole se lit <i lang='en'>“at”</i> qui veut dire “chez”.</p><p><span aria-hidden='true'>🤔</span> Le saviez-vous : c’est un symbole qui était utilisé bien avant l’informatique ! Par exemple, pour compter des quantités.</p>",
                     },

--- a/api/tests/devcomp/unit/domain/models/element/Element_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/Element_test.js
@@ -43,7 +43,7 @@ describe('Unit | Devcomp | Domain | Models | Element', function () {
 
     it('should instanciate non answerable elements', function () {
       // Given
-      const text = new Text({ id: 'id', content: 'content' });
+      const text = new Text({ id: 'id', content: 'content', tag: ' ' });
       const image = new Image({
         id: 'id',
         url: 'https://assets.pix.org/modules/placeholder-details.svg',

--- a/api/tests/devcomp/unit/domain/models/element/Text_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/Text_test.js
@@ -6,19 +6,29 @@ describe('Unit | Devcomp | Domain | Models | Element | Text', function () {
   describe('#constructor', function () {
     it('should create a text and keep attributes', function () {
       // when
-      const text = new Text({ id: 'id', content: 'content' });
+      const text = new Text({ id: 'id', content: 'content', tag: ' ' });
 
       // then
       expect(text.id).to.equal('id');
       expect(text.content).to.equal('content');
       expect(text.type).to.equal('text');
+      expect(text.tag).to.equal(' ');
+    });
+
+    it('should accept all valid tag values', function () {
+      const validTags = [' ', 'context', 'did-you-know', 'further-information', 'key-points', 'tip'];
+
+      for (const tag of validTags) {
+        const text = new Text({ id: 'id', content: 'content', tag });
+        expect(text.tag).to.equal(tag);
+      }
     });
   });
 
   describe('A text without id', function () {
     it('should throw an error', function () {
       // when
-      const error = catchErrSync(() => new Text({ content: 'content' }))();
+      const error = catchErrSync(() => new Text({ content: 'content', tag: ' ' }))();
 
       // then
       expect(error).to.be.instanceOf(DomainError);
@@ -29,11 +39,34 @@ describe('Unit | Devcomp | Domain | Models | Element | Text', function () {
   describe('A text without content', function () {
     it('should throw an error', function () {
       // when
-      const error = catchErrSync(() => new Text({ id: '1' }))();
+      const error = catchErrSync(() => new Text({ id: '1', tag: ' ' }))();
 
       // then
       expect(error).to.be.instanceOf(DomainError);
       expect(error.message).to.equal('The content is required for a text');
+    });
+  });
+
+  describe('A text with an invalid tag', function () {
+    it('should throw an error', function () {
+      // when
+      const error = catchErrSync(() => new Text({ id: '1', content: 'content', tag: 'invalid-tag' }))();
+
+      // then
+      expect(error).to.be.instanceOf(TypeError);
+      expect(error.message).to.equal(
+        "The tag value must be one of: ' ', 'context', 'did-you-know', 'further-information', 'key-points', 'tip'",
+      );
+    });
+  });
+
+  describe('A text without tag', function () {
+    it('should throw an error', function () {
+      // when
+      const error = catchErrSync(() => new Text({ id: '1', content: 'content' }))();
+
+      // then
+      expect(error).to.be.instanceOf(TypeError);
     });
   });
 });

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js
@@ -461,6 +461,7 @@ describe('Unit | Infrastructure | Datasources | Learning Content | Module Dataso
         const sample = {
           id: randomUUID(),
           type: 'text',
+          tag: 'key-points',
           content: "<p>Ceci est un texte qui accepte de l'HTML.</p>",
         };
 
@@ -471,6 +472,30 @@ describe('Unit | Infrastructure | Datasources | Learning Content | Module Dataso
         const formattedError = joiErrorParser.format(joiError);
         expect(joiError).to.equal(undefined, formattedError);
       }
+    });
+
+    describe('for text element', function () {
+      it('should validate all tag values', async function () {
+        const validTags = [' ', 'context', 'did-you-know', 'further-information', 'key-points', 'tip'];
+
+        for (const tag of validTags) {
+          try {
+            const sample = {
+              id: randomUUID(),
+              type: 'text',
+              tag,
+              content: "<p>Ceci est un texte qui accepte de l'HTML.</p>",
+            };
+
+            await textElementSchema.validateAsync(sample, {
+              abortEarly: false,
+            });
+          } catch (joiError) {
+            const formattedError = joiErrorParser.format(joiError);
+            expect(joiError).to.equal(undefined, formattedError);
+          }
+        }
+      });
     });
 
     it('should validate sample video structure', async function () {
@@ -542,6 +567,7 @@ describe('Unit | Infrastructure | Datasources | Learning Content | Module Dataso
                 {
                   id: '1cf5b276-9ce0-4b38-a56b-4d4447b34d8a',
                   type: 'text',
+                  tag: ' ',
                   content: '<p>Cool</p>',
                 },
               ],
@@ -551,6 +577,7 @@ describe('Unit | Infrastructure | Datasources | Learning Content | Module Dataso
                 {
                   id: '185881f1-6217-4306-8e89-070281a3e20a',
                   type: 'text',
+                  tag: ' ',
                   content: '<p>Gang</p>',
                 },
               ],
@@ -728,6 +755,7 @@ describe('Unit | Infrastructure | Datasources | Learning Content | Module Dataso
       const invalidTextElement = {
         id: '774c4c4e-f170-4e2c-ba7a-d2fe40d053c3',
         type: 'text',
+        tag: ' ',
         content: '<style>p { color: indianred; }</style> <p>Stylé !</p>',
       };
 
@@ -776,6 +804,7 @@ describe('Unit | Infrastructure | Datasources | Learning Content | Module Dataso
                     element: {
                       id: '84726001-1665-457d-8f13-4a74dc4768ea',
                       type: 'text',
+                      tag: ' ',
                       content: '<h4>Content.</h4>',
                     },
                   },

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
@@ -362,7 +362,7 @@ function getComponents() {
         },
       ],
     }),
-    new ComponentElement({ element: new Text({ id: '1', content: 'toto' }) }),
+    new ComponentElement({ element: new Text({ id: '1', content: 'toto', tag: ' ' }) }),
     new ComponentElement({
       element: new QCU({
         id: '2',
@@ -558,6 +558,7 @@ function getAttributesComponents() {
         id: '1',
         isAnswerable: false,
         type: 'text',
+        tag: ' ',
       },
     },
     {


### PR DESCRIPTION
## 🌎 Problème

Les modules évoluent : cette fois ci on veut pouvoir ajouter des tags spécifique au dessus d'un bloc de texte.
On va donc adapter l'élément `Text` pour lui permettre de porter certains tags.

## 🔭 Proposition

Créer le paramètre `tag` dans `Text`

Valeurs proposées : `' ', 'key-points', 'context', 'did-you-know', 'tip', 'further-information'`

## 🪐 Remarques
Ici Claude n'a été utilisé que pour placer les paramètres `tag` dans tous les modules existants.

## 🚀 Pour tester

Lancer Modulix Editor en local, utiliser l'API de la review app (https://api-pr15627.review.pix.fr/api/module-schema/module-json-schema.json- pour qu'il affiche le paramètre tag

<img width="221" height="218" alt="Capture d’écran 2026-03-25 à 10 27 02" src="https://github.com/user-attachments/assets/e33d948f-10cf-448e-9f05-df0e579e4be0" />



🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘 🌑
