### PR TITLE
[FEATURE] Masquage du bouton de création d'organisation fille (PIX-22040).

### DIFF
--- a/admin/app/components/organizations/children/actions-section.gjs
+++ b/admin/app/components/organizations/children/actions-section.gjs
@@ -9,19 +9,26 @@ import AttachChildForm from './attach-child-form';
 export default class ActionsSection extends Component {
   @service accessControl;
 
+  get canCreateChildOrganization() {
+    return (
+      this.accessControl.hasAccessToAttachChildOrganizationActionsScope &&
+      !!this.args.organization.belongsTo('network').id()
+    );
+  }
+
   <template>
     <section class="page-section">
       <div class="content-text content-text--small organization-children__actions-section">
-        {{#unless @organization.parentOrganizationId}}
-
-          <PixButtonLink
-            @iconBefore="add"
-            @variant="secondary"
-            @route="authenticated.organizations.new"
-            @query={{hash parentOrganizationId=@organization.id parentOrganizationName=@organization.name}}
-          >{{t "components.organizations.children.create-child-organization-button"}}</PixButtonLink>
-
-        {{/unless}}
+        {{#if this.canCreateChildOrganization}}
+          {{#unless @organization.parentOrganizationId}}
+            <PixButtonLink
+              @iconBefore="add"
+              @variant="secondary"
+              @route="authenticated.organizations.new"
+              @query={{hash parentOrganizationId=@organization.id parentOrganizationName=@organization.name}}
+            >{{t "components.organizations.children.create-child-organization-button"}}</PixButtonLink>
+          {{/unless}}
+        {{/if}}
 
         {{#if this.accessControl.hasAccessToAttachChildOrganizationActionsScope}}
           <AttachChildForm @onFormSubmitted={{@onAttachChildSubmitForm}} />

--- a/admin/tests/acceptance/authenticated/organizations/get/children-test.js
+++ b/admin/tests/acceptance/authenticated/organizations/get/children-test.js
@@ -125,10 +125,12 @@ module('Acceptance | Organizations | Children', function (hooks) {
     module('when creating child organization from parent page', function () {
       test('it should redirect to New organization page, with parent id in query params', async function (assert) {
         // given
+        const network = this.server.create('network', { name: 'Test Network' });
         const parentOrganization = this.server.create('organization', {
           id: 1,
           name: 'Parent Organization Name',
           features: { PLACES_MANAGEMENT: { active: true } },
+          network,
         });
         const screen = await visit(`/organizations/${parentOrganization.id}/children`);
 
@@ -160,13 +162,13 @@ module('Acceptance | Organizations | Children', function (hooks) {
         }).id;
       });
 
-      test('it displays actions section with create child organization button', async function (assert) {
+      test('it does not display create child organization button', async function (assert) {
         // when
         const screen = await visit(`/organizations/${parentOrganizationId}/children`);
 
         // then
-        assert.ok(
-          screen.getByRole('link', { name: t('components.organizations.children.create-child-organization-button') }),
+        assert.notOk(
+          screen.queryByRole('link', { name: t('components.organizations.children.create-child-organization-button') }),
         );
       });
     });

--- a/admin/tests/integration/components/organizations/children-test.gjs
+++ b/admin/tests/integration/components/organizations/children-test.gjs
@@ -13,6 +13,7 @@ module('Integration | Component | organizations/children', function (hooks) {
     hooks.beforeEach(function () {
       class AccessControlStub extends Service {
         hasAccessToOrganizationActionsScope = true;
+        hasAccessToAttachChildOrganizationActionsScope = true;
       }
       this.owner.register('service:access-control', AccessControlStub);
     });
@@ -20,7 +21,8 @@ module('Integration | Component | organizations/children', function (hooks) {
     test('it should display children list and actions section', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');
-      const organization = store.createRecord('organization', { id: '1', name: 'Parent' });
+      const network = store.push({ data: { id: '10', type: 'network', attributes: { name: 'Réseau Test' } } });
+      const organization = store.createRecord('organization', { id: '1', name: 'Parent', network });
       const child1 = store.createRecord('organization', { id: '2', name: 'Child 1' });
       const child2 = store.createRecord('organization', { id: '3', name: 'Child 2' });
       const children = [child1, child2];

--- a/admin/tests/integration/components/organizations/children/actions-section-test.gjs
+++ b/admin/tests/integration/components/organizations/children/actions-section-test.gjs
@@ -17,15 +17,19 @@ module('Integration | Component | organizations/children/actions-section', funct
 
   module('create child organization button', function (hooks) {
     hooks.beforeEach(async function () {
-      class AccessControlStub extends Service {}
+      class AccessControlStub extends Service {
+        hasAccessToAttachChildOrganizationActionsScope = true;
+      }
       this.owner.register('service:access-control', AccessControlStub);
     });
 
-    test('it should display create child organization button', async function (assert) {
+    test('it should display create child organization button when user is superAdmin and organization belongs to a network', async function (assert) {
       // given
+      const network = store.createRecord('network', { id: '10', name: 'Réseau Test' });
       const organization = store.createRecord('organization', {
         id: '1',
         name: 'Orga 1',
+        network,
       });
 
       const onAttachChildSubmitFormStub = sinon.stub();
@@ -44,10 +48,12 @@ module('Integration | Component | organizations/children/actions-section', funct
 
     test('it should not display create child organization button if organization is already a child', async function (assert) {
       // given
+      const network = store.createRecord('network', { id: '10', name: 'Réseau Test' });
       const childOrganization = store.createRecord('organization', {
         id: '2',
         name: 'Orga 2',
         parentOrganizationId: '1234',
+        network,
       });
 
       const onAttachChildSubmitFormStub = sinon.stub();
@@ -59,6 +65,55 @@ module('Integration | Component | organizations/children/actions-section', funct
             @organization={{childOrganization}}
             @onAttachChildSubmitForm={{onAttachChildSubmitFormStub}}
           />
+        </template>,
+      );
+
+      assert.notOk(
+        screen.queryByRole('link', { name: t('components.organizations.children.create-child-organization-button') }),
+      );
+    });
+
+    test('it should not display create child organization button when user is not superAdmin', async function (assert) {
+      // given
+      class AccessControlStub extends Service {
+        hasAccessToAttachChildOrganizationActionsScope = false;
+      }
+      this.owner.register('service:access-control', AccessControlStub);
+
+      const network = store.createRecord('network', { id: '10', name: 'Réseau Test' });
+      const organization = store.createRecord('organization', {
+        id: '1',
+        name: 'Orga 1',
+        network,
+      });
+
+      const onAttachChildSubmitFormStub = sinon.stub();
+
+      // when
+      const screen = await render(
+        <template>
+          <ActionsSection @organization={{organization}} @onAttachChildSubmitForm={{onAttachChildSubmitFormStub}} />
+        </template>,
+      );
+
+      assert.notOk(
+        screen.queryByRole('link', { name: t('components.organizations.children.create-child-organization-button') }),
+      );
+    });
+
+    test('it should not display create child organization button when organization does not belong to a network', async function (assert) {
+      // given
+      const organization = store.createRecord('organization', {
+        id: '1',
+        name: 'Orga 1',
+      });
+
+      const onAttachChildSubmitFormStub = sinon.stub();
+
+      // when
+      const screen = await render(
+        <template>
+          <ActionsSection @organization={{organization}} @onAttachChildSubmitForm={{onAttachChildSubmitFormStub}} />
         </template>,
       );
 

--- a/admin/tests/mirage/models/organization.js
+++ b/admin/tests/mirage/models/organization.js
@@ -1,4 +1,4 @@
-import { hasMany, Model } from 'miragejs';
+import { belongsTo, hasMany, Model } from 'miragejs';
 
 export default Model.extend({
   organizationMemberships: hasMany('organizationMembership'),
@@ -6,4 +6,5 @@ export default Model.extend({
   tags: hasMany('tag'),
   children: hasMany('organization'),
   organizationInvitations: hasMany('organizationInvitation'),
+  network: belongsTo('network'),
 });

--- a/admin/tests/mirage/serializers/organization.js
+++ b/admin/tests/mirage/serializers/organization.js
@@ -17,4 +17,8 @@ export default ApplicationSerializer.extend({
       },
     };
   },
+
+  shouldIncludeLinkageData(relationshipKey) {
+    return relationshipKey === 'network';
+  },
 });


### PR DESCRIPTION
## 🌎 Problème

Tout le monde ne doit pas pouvoir créer d'organisation fille à une organisation parente.

## 🔭 Proposition

Nous souhaitons cacher le bouton de création d’organisation dans les cas suivants :

- Utilisateur n’ayant pas le rôle SUPER_ADMIN
- Utilisateur ayant le rôle SUPER_ADMIN mais l’organisation parente n’appartient à aucun réseau

## 🚀 Pour tester

- Se connecter à Pix-Admin en tant que `superadmin@example.net`
- Vérifier sur la page de détails d'une organisation qu'il est **POSSIBLE** de créer une organisation fille si celle-ci fait partie d'un réseau
- Vérifier sur la page de détails d'une organisation qu'il est **IMPOSSIBLE** de créer une organisation fille si celle-ci fait partie d'un réseau

- Se connecter à Pix-Admin en tant que `certifadminexample.net`
- Vérifier sur la page de détails d'une organisation qu'il est **IMPOSSIBLE** de créer une organisation fille même si celle-ci fait partie d'un réseau
- Vérifier sur la page de détails d'une organisation qu'il est **IMPOSSIBLE** de créer une organisation fille si celle-ci ne fait pas partie d'un réseau
