### PR TITLE
[TECH] Ajouter un script pour créer des structures (PIX-22038)

### DIFF
--- a/api/src/organizational-entities/scripts/create-structure-for-every-organization.js
+++ b/api/src/organizational-entities/scripts/create-structure-for-every-organization.js
@@ -1,0 +1,114 @@
+import { setTimeout } from 'node:timers/promises';
+
+import { knex } from '../../../db/knex-database-connection.js';
+import { Script } from '../../shared/application/scripts/script.js';
+import { ScriptRunner } from '../../shared/application/scripts/script-runner.js';
+
+const DEFAULT_CHUNK_SIZE = 1000;
+const DEFAULT_THROTTLE_DELAY = 1000;
+
+export class CreateStructureForEveryOrganizationScript extends Script {
+  constructor() {
+    super({
+      description: "This script creates a structure for every organization that doesn't have one.",
+      permanent: false,
+      options: {
+        dryRun: {
+          type: 'boolean',
+          describe: 'Run the script without making any database changes',
+          default: true,
+        },
+        chunkSize: {
+          type: 'number',
+          describe:
+            'Define the number of organizations processed in a chunk (defines how many structures and fct_structures are created and committed at the same time)',
+          default: DEFAULT_CHUNK_SIZE,
+        },
+        throttleDelay: {
+          type: 'number',
+          describe: 'The throttle delay',
+          default: DEFAULT_THROTTLE_DELAY,
+        },
+      },
+    });
+  }
+
+  async handle({ options, logger }) {
+    const { dryRun, chunkSize, throttleDelay } = options;
+
+    logger.info(`>>>> Begin initialization.`);
+
+    const organizationsLackingStructures = await _findOrganizationsLackingStructure();
+    logger.info(`Numbers of organizations lacking structure: ${organizationsLackingStructures.length}`);
+
+    if (!organizationsLackingStructures.length) {
+      logger.info(`>>>> All organizations already have a structure. Nothing to process. Exiting execution.`);
+      return;
+    }
+
+    logger.info(`>>>> Begin processing.`);
+
+    let chunkToProcess;
+    chunkToProcess = organizationsLackingStructures.splice(0, chunkSize);
+
+    let chunkCount = 1;
+    let createdStructuresTotalCount = 0;
+
+    while (chunkToProcess.length > 0) {
+      const trx = await knex.transaction();
+
+      try {
+        let createdStructuresInChunkCount = 0;
+        logger.info(
+          `Processing chunk n. ${chunkCount}: ${chunkToProcess.length} orgas. From ID ${chunkToProcess[0].id} to ${chunkToProcess[chunkToProcess.length - 1].id}`,
+        );
+
+        for (const organization of chunkToProcess) {
+          const [structure] = await trx('structures').returning('id').insert({});
+          await trx('fct_structures').insert({ structure_id: structure.id, organization_id: organization.id });
+
+          createdStructuresInChunkCount++;
+          createdStructuresTotalCount++;
+        }
+
+        if (dryRun) {
+          logger.info(
+            `> DryRun mode. End of chunk n.${chunkCount} with ${createdStructuresInChunkCount} structures should have been created.`,
+          );
+          await trx.rollback();
+        } else {
+          logger.info(`> End of chunk n.${chunkCount} with ${createdStructuresInChunkCount} structures created.`);
+          await trx.commit();
+        }
+
+        chunkToProcess = organizationsLackingStructures.splice(0, chunkSize);
+        chunkCount++;
+
+        await setTimeout(throttleDelay);
+      } catch (error) {
+        await trx.rollback();
+        throw error;
+      }
+    }
+
+    if (dryRun) {
+      logger.info(
+        `>>>> End of dryRun processing. Total numbers of structures that should have been created: ${createdStructuresTotalCount}`,
+      );
+    } else {
+      logger.info(`>>>> End of processing. Total numbers of structures created: ${createdStructuresTotalCount}`);
+    }
+  }
+}
+
+async function _findOrganizationsLackingStructure() {
+  const organizationsLackingStructures = await knex
+    .select('id', 'fct_structures.organization_id')
+    .from('organizations')
+    .leftJoin('fct_structures', 'fct_structures.organization_id', 'organizations.id')
+    .where('fct_structures.organization_id', null)
+    .orderBy('id');
+  return organizationsLackingStructures;
+}
+
+await ScriptRunner.execute(import.meta.url, CreateStructureForEveryOrganizationScript);

--- a/api/tests/organizational-entities/integration/scripts/create-structure-for-every-organization.test.js
+++ b/api/tests/organizational-entities/integration/scripts/create-structure-for-every-organization.test.js
@@ -1,0 +1,137 @@
+import { CreateStructureForEveryOrganizationScript } from '../../../../src/organizational-entities/scripts/create-structure-for-every-organization.js';
+import { databaseBuilder, expect, knex, sinon } from '../../../test-helper.js';
+
+describe('Integration | Organizational Entities | Scripts | Create structure for every organization', function () {
+  let logger, script;
+
+  beforeEach(async function () {
+    logger = { info: sinon.stub(), error: sinon.stub() };
+    script = new CreateStructureForEveryOrganizationScript();
+    await knex('fct_structures').delete();
+    await knex('structures').delete();
+  });
+
+  describe('when no organizations have a structure', function () {
+    it('should create fct_structures matching existing organization ids and with no duplicates of organizations ids', async function () {
+      // given
+      const organization2 = await databaseBuilder.factory.buildOrganization();
+      const organization1 = await databaseBuilder.factory.buildOrganization();
+
+      await databaseBuilder.commit();
+
+      // when
+      await script.handle({ options: { dryRun: false, chunkSize: 1, throttleDelay: 0 }, logger });
+
+      // then
+      const structures = await knex('structures');
+      const factStructures = await knex('fct_structures');
+
+      const organizationIdsFromFactStructures = factStructures.map((fct) => fct.organization_id);
+
+      const expectedOrganizationIdsFromFactStructures = [organization1.id, organization2.id];
+
+      expect(structures.length).to.deep.equal(2);
+      expect(factStructures.length).to.deep.equal(2);
+      expect(organizationIdsFromFactStructures).to.have.members(expectedOrganizationIdsFromFactStructures);
+    });
+
+    it('should create fct_structures with no duplicates of structures ids', async function () {
+      // given
+      await databaseBuilder.factory.buildOrganization();
+      await databaseBuilder.factory.buildOrganization();
+
+      await databaseBuilder.commit();
+
+      // when
+      await script.handle({ options: { dryRun: false, chunkSize: 1, throttleDelay: 0 }, logger });
+
+      // then
+      const factStructures = await knex('fct_structures');
+
+      const structureIdsFromFactStructures = factStructures.map((fct) => fct.structure_id);
+
+      const structureIdsFromFactStructuresWithNoDuplicates = new Set(structureIdsFromFactStructures);
+
+      expect(structureIdsFromFactStructuresWithNoDuplicates.size).to.equal(structureIdsFromFactStructures.length);
+    });
+  });
+
+  describe('when all organizations already have a structure', function () {
+    it('should not create structures and fct_structures.', async function () {
+      // given
+      const organization1 = await databaseBuilder.factory.buildOrganization();
+      const organization2 = await databaseBuilder.factory.buildOrganization();
+
+      const structure1 = await databaseBuilder.factory.buildStructure();
+      const structure2 = await databaseBuilder.factory.buildStructure();
+
+      await databaseBuilder.factory.buildFactStructure({
+        structureId: structure1.id,
+        organizationId: organization1.id,
+      });
+      await databaseBuilder.factory.buildFactStructure({
+        structureId: structure2.id,
+        organizationId: organization2.id,
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      await script.handle({ options: { dryRun: false, chunkSize: 1, throttleDelay: 0 }, logger });
+
+      // then
+      const structures = await knex('structures');
+      const factStructures = await knex('fct_structures');
+
+      expect(structures.length).to.deep.equal(2);
+      expect(factStructures.length).to.deep.equal(2);
+    });
+  });
+
+  describe("when some organizations have a structure but others don't", function () {
+    it('should create structures and fct_structures only for organizations without structures', async function () {
+      // given
+      const organization1 = await databaseBuilder.factory.buildOrganization();
+      await databaseBuilder.factory.buildOrganization();
+      await databaseBuilder.factory.buildOrganization();
+
+      const structure1 = await databaseBuilder.factory.buildStructure();
+
+      await databaseBuilder.factory.buildFactStructure({
+        structureId: structure1.id,
+        organizationId: organization1.id,
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      await script.handle({ options: { dryRun: false, chunkSize: 1, throttleDelay: 0 }, logger });
+
+      // then
+      const structures = await knex('structures');
+      const factStructures = await knex('fct_structures');
+
+      expect(structures.length).to.equal(3);
+      expect(factStructures.length).to.equal(3);
+    });
+  });
+
+  describe('when dryRun option is true', function () {
+    it('should not commit', async function () {
+      // given
+      await databaseBuilder.factory.buildOrganization();
+      await databaseBuilder.factory.buildOrganization();
+
+      await databaseBuilder.commit();
+
+      const structuresBefore = await knex('structures');
+
+      // when
+      await script.handle({ options: { dryRun: true, chunkSize: 1, throttleDelay: 0 }, logger });
+
+      // then
+      const structuresAfter = await knex('structures');
+      expect(structuresAfter.length).to.equal(structuresBefore.length);
+    });
+  });
+});


### PR DESCRIPTION
## 🌎 Problème

Dans le cadre des réseaux d'organisations, chaque organisation doit désormais avoir une structure associée. Une première tâche a déjà été effectuée: créer une structure à chaque création d'organisation sur Pix Admin. Il faut maintenant rattraper l'existant, à savoir créer une structure pour chaque organisation qui n'en a pas.

## 🔭 Proposition

Ajouter un script qui va permet de:
- aller chercher en base toutes les organisations qui n'ont pas de structure associée
- insérer une structure dans la table `structures` pour chaque orga
- rattacher chaque orga à une structure nouvellement créée via l'insertion d'une ligne dans la table de faits `fct_structures`

## 🪐 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🚀 Pour tester
 
En local ou sur la RA:
- s'assurer d'avoir une base "propre' correctement seedée (npm run db:seed)
- executer le script depuis le répertoirte `/api` en définissant un chunkSize (par exemple 15 pour les 80 orgas des seeds)
```bash
LOG_ENABLED=true node src/organizational-entities/scripts/create-structure-for-every-organization.js --dryRun false --chunkSize 15
```
- constater les logs
- ré-executer le script une nouvelle fois. Constater les logs disant que toutes les orgas ont une structure.
- pour vérifier executer cette requête SQL qui va chercher le nombre d'orgas qui n'ont pas de structure associée et vérifier qu'elle renvoie 0
```sql
SELECT COUNT(*) FROM organizations LEFT JOIN fct_structures ON organizations.id = fct_structures.organization_id WHERE fct_structures.organization_id IS NULL;
```

🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘 🌑
