### PR TITLE
[FEATURE] MAJ de la `fct_structure` lors de la création d'un réseau (PIX-22067)

### DIFF
--- a/api/src/organizational-entities/infrastructure/repositories/network.repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/network.repository.js
@@ -93,13 +93,13 @@ async function findByOrganizationId(organizationId) {
 async function save({ organizationId, networkName }) {
   const knexConn = DomainTransaction.getConnection();
 
-  const [{ id: structureId }] = await knexConn('structures').insert({}, ['id']);
   const [savedNetwork] = await knexConn('networks').insert({ name: networkName }, ['id', 'name']);
-  await knexConn('fct_structures').insert({
-    structure_id: structureId,
-    organization_id: organizationId,
-    network_id: savedNetwork.id,
-  });
+
+  await knexConn('fct_structures')
+    .update({
+      network_id: savedNetwork.id,
+    })
+    .where({ organization_id: organizationId });
 
   return _toDomain(savedNetwork);
 }

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/network.repository.test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/network.repository.test.js
@@ -242,6 +242,12 @@ describe('Integration | Organizational Entities | Infrastructure | Repositories 
     it('saves and returns the new network', async function () {
       // given
       const organizationId = databaseBuilder.factory.buildOrganization().id;
+      const structure = databaseBuilder.factory.buildStructure();
+      databaseBuilder.factory.buildFactStructure({
+        structureId: structure.id,
+        networkId: null,
+        organizationId: organizationId,
+      });
       const networkName = 'Network 1';
       await databaseBuilder.commit();
 
@@ -254,15 +260,10 @@ describe('Integration | Organizational Entities | Infrastructure | Repositories 
         id: foundNetwork.id,
         name: networkName,
       });
-      const createdStructure = await knex('structures')
-        .join('fct_structures', 'structures.id', 'fct_structures.structure_id')
+      const updatedFactStructure = await knex('fct_structures')
         .where('fct_structures.organization_id', organizationId)
         .first();
-      expect(createdStructure).to.exist;
-      const createdFactStructure = await knex('fct_structures')
-        .where('fct_structures.organization_id', organizationId)
-        .first();
-      expect(createdFactStructure.network_id).to.equal(foundNetwork.id);
+      expect(updatedFactStructure.network_id).to.equal(foundNetwork.id);
       const expectedNetwork = domainBuilder.acquisition.buildNetwork(foundNetwork);
       expect(savedNetwork).to.deep.equal(expectedNetwork);
     });


### PR DESCRIPTION
## 🌎 Problème

Suite à la création de la grappe `structure` + `fct_structure` lors de la création d'une organisation ([voir PR](https://github.com/1024pix/pix/pull/15605)) et du travail de rattrapage des données par script ([voir PR](https://github.com/1024pix/pix/pull/15635)), il n'est désormais plus nécessaire de créer cette même grappe de `structure` et `fct_structure` à la création d'un réseau comme cela avait été fait initialement.

## 🔭 Proposition

Puisque il n'y désormais plus d'`organization` sans `structure` ni `fct_structure`, nous mettons simplement à jour la valeur du réseau `network_id` dans la ligne de `fct_structure` associée à l'organisation.

## 🪐 Remarques

Il n'y a pas de code défensif.
A voir si l'on veut se prémunir d'éventuels méfaits lors de la création d'un réseau.

## 🚀 Pour tester

- Se connecter à PixAdmin en tant que `superadmin@example.net`
- Aller sur la page de création d'un réseau
- Ajouter une ID d'organisation ayant déjà une `structure` et `fct_structure` associés (ex: `155467`, `155464`) à la tête du réseau
- Vérifier que le réseau a bien été créé et que la `fct_structure` possède désormais l'ID du réseau dans la colonne `network_id`

Requête pour pouvoir réassigner une organisation précédemment rattachée à un réseau :
```sql
update fct_structures set network_id = null where network_id = <NETWORK_ID>;
```
