### PR TITLE
[FEATURE] Rejeter une certification v3 qui n'atteint pas la maille minimum  (PIX-22084).

### DIFF
--- a/admin/app/models/certification.js
+++ b/admin/app/models/certification.js
@@ -117,8 +117,15 @@ export default class Certification extends Model {
   }
 
   get result() {
-    const reachedMeshIndex = this.reachedMeshIndex?.toString() ?? 'NONE';
-    return this.intl.t(`common.certification.meshLevels.${this.certificationFramework}.${reachedMeshIndex}`, {
+    if (this.isV3) {
+      const meshKey = this.reachedMeshIndex ?? 'BELOW_MINIMUM';
+
+      return this.intl.t(`common.certification.meshLevels.${this.certificationFramework}.${meshKey}`, {
+        pixScore: this.pixScore,
+      });
+    }
+
+    return this.intl.t(`common.certification.meshLevels.${this.certificationFramework}.NONE`, {
       pixScore: this.pixScore,
     });
   }

--- a/admin/app/models/jury-certification-summary.js
+++ b/admin/app/models/jury-certification-summary.js
@@ -65,8 +65,15 @@ export default class JuryCertificationSummary extends Model {
   }
 
   get result() {
-    const reachedMeshIndex = this.reachedMeshIndex?.toString() ?? 'NONE';
-    return this.intl.t(`common.certification.meshLevels.${this.certificationFramework}.${reachedMeshIndex}`, {
+    if (this.algorithmVersion === 3) {
+      const meshKey = this.reachedMeshIndex ?? 'BELOW_MINIMUM';
+
+      return this.intl.t(`common.certification.meshLevels.${this.certificationFramework}.${meshKey}`, {
+        pixScore: this.pixScore,
+      });
+    }
+
+    return this.intl.t(`common.certification.meshLevels.${this.certificationFramework}.NONE`, {
       pixScore: this.pixScore,
     });
   }

--- a/admin/app/models/v3-certification-course-details-for-administration.js
+++ b/admin/app/models/v3-certification-course-details-for-administration.js
@@ -86,8 +86,9 @@ export default class V3CertificationCourseDetailsForAdministration extends Model
   }
 
   get result() {
-    const reachedMeshIndex = this.reachedMeshIndex?.toString() ?? 'NONE';
-    return this.intl.t(`common.certification.meshLevels.${this.certificationFramework}.${reachedMeshIndex}`, {
+    const meshKey = this.reachedMeshIndex ?? 'BELOW_MINIMUM';
+
+    return this.intl.t(`common.certification.meshLevels.${this.certificationFramework}.${meshKey}`, {
       pixScore: this.pixScore,
     });
   }

--- a/admin/tests/unit/models/certification-test.js
+++ b/admin/tests/unit/models/certification-test.js
@@ -319,6 +319,56 @@ module('Unit | Model | certification', function (hooks) {
     });
   });
 
+  module('#result', function () {
+    test('it should return "Non admissible" for a v3 EDU certification without reachedMeshIndex', function (assert) {
+      // given
+      const certification = store.createRecord('certification', {
+        version: 3,
+        certificationFramework: 'EDU_1ER_DEGRE',
+        reachedMeshIndex: null,
+        pixScore: 0,
+      });
+
+      // when
+      const result = certification.result;
+
+      // then
+      assert.strictEqual(result, 'Non admissible');
+    });
+
+    test('it should return "Admissible" for a v3 EDU certification with a reachedMeshIndex', function (assert) {
+      // given
+      const certification = store.createRecord('certification', {
+        version: 3,
+        certificationFramework: 'EDU_1ER_DEGRE',
+        reachedMeshIndex: 0,
+        pixScore: 100,
+      });
+
+      // when
+      const result = certification.result;
+
+      // then
+      assert.strictEqual(result, 'Admissible');
+    });
+
+    test('it should return pixScore for a v2 certification', function (assert) {
+      // given
+      const certification = store.createRecord('certification', {
+        version: 2,
+        certificationFramework: 'CORE',
+        reachedMeshIndex: null,
+        pixScore: 450,
+      });
+
+      // when
+      const result = certification.result;
+
+      // then
+      assert.strictEqual(result, '450 Pix');
+    });
+  });
+
   module('#wasBornInFrance', function () {
     test('it should return true when candidate was born in France', function (assert) {
       // given

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -38,6 +38,7 @@
           "6": "Advanced 2 ({pixScore} Pix)",
           "7": "Expert 1 ({pixScore} Pix)",
           "8": "Expert 2 ({pixScore} Pix)",
+          "BELOW_MINIMUM": "{pixScore} Pix",
           "NONE": "{pixScore} Pix"
         },
         "CORE": {
@@ -50,27 +51,32 @@
           "6": "Advanced 2 ({pixScore} Pix)",
           "7": "Expert 1 ({pixScore} Pix)",
           "8": "Expert 2 ({pixScore} Pix)",
+          "BELOW_MINIMUM": "{pixScore} Pix",
           "NONE": "{pixScore} Pix"
         },
         "DROIT": {
+          "0": "Obtained",
+          "BELOW_MINIMUM": "Not obtained",
           "NONE": "{pixScore} Pix"
         },
         "EDU_1ER_DEGRE": {
-          "0": "Non-admissible",
-          "1": "Admissible",
+          "0": "Admissible",
+          "BELOW_MINIMUM": "Not admissible",
           "NONE": "{pixScore} Pix"
         },
         "EDU_2ND_DEGRE": {
-          "0": "Non-admissible",
-          "1": "Admissible",
+          "0": "Admissible",
+          "BELOW_MINIMUM": "Not admissible",
           "NONE": "{pixScore} Pix"
         },
         "EDU_CPE": {
-          "0": "Non-admissible",
-          "1": "Admissible",
+          "0": "Admissible",
+          "BELOW_MINIMUM": "Not admissible",
           "NONE": "{pixScore} Pix"
         },
         "PRO_SANTE": {
+          "0": "Obtained",
+          "BELOW_MINIMUM": "Not obtained",
           "NONE": "{pixScore} Pix"
         }
       }

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -38,6 +38,7 @@
           "6": "Avancé 2 ({pixScore} Pix)",
           "7": "Expert 1 ({pixScore} Pix)",
           "8": "Expert 2 ({pixScore} Pix)",
+          "BELOW_MINIMUM": "{pixScore} Pix",
           "NONE": "{pixScore} Pix"
         },
         "CORE": {
@@ -50,27 +51,32 @@
           "6": "Avancé 2 ({pixScore} Pix)",
           "7": "Expert 1 ({pixScore} Pix)",
           "8": "Expert 2 ({pixScore} Pix)",
+          "BELOW_MINIMUM": "{pixScore} Pix",
           "NONE": "{pixScore} Pix"
         },
         "DROIT": {
+          "0": "Obtenue",
+          "BELOW_MINIMUM": "Non obtenue",
           "NONE": "{pixScore} Pix"
         },
         "EDU_1ER_DEGRE": {
-          "0": "Non-admissible",
-          "1": "Admissible",
+          "0": "Admissible",
+          "BELOW_MINIMUM": "Non admissible",
           "NONE": "{pixScore} Pix"
         },
         "EDU_2ND_DEGRE": {
-          "0": "Non-admissible",
-          "1": "Admissible",
+          "0": "Admissible",
+          "BELOW_MINIMUM": "Non admissible",
           "NONE": "{pixScore} Pix"
         },
         "EDU_CPE": {
-          "0": "Non-admissible",
-          "1": "Admissible",
+          "0": "Admissible",
+          "BELOW_MINIMUM": "Non admissible",
           "NONE": "{pixScore} Pix"
         },
         "PRO_SANTE": {
+          "0": "Obtenue",
+          "BELOW_MINIMUM": "Non obtenue",
           "NONE": "{pixScore} Pix"
         }
       }

--- a/api/db/database-builder/factory/build-certification-version.js
+++ b/api/db/database-builder/factory/build-certification-version.js
@@ -16,7 +16,7 @@ const defaultGlobalScoringConfiguration = [
   {
     meshLevel: 0,
     bounds: {
-      min: -8,
+      min: -4.6,
       max: -1.4,
     },
   },

--- a/api/db/seeds/data/team-certification/shared/common-certification-versions.js
+++ b/api/db/seeds/data/team-certification/shared/common-certification-versions.js
@@ -249,7 +249,7 @@ const GLOBAL_SCORING_CONFIGURATION = [
   {
     meshLevel: 0,
     bounds: {
-      min: -8,
+      min: -4.67,
       max: -1.4,
     },
   },

--- a/api/scripts/certification/remove-certification-versions-rejected-meshes.js
+++ b/api/scripts/certification/remove-certification-versions-rejected-meshes.js
@@ -1,0 +1,50 @@
+import { Script } from '../../src/shared/application/scripts/script.js';
+import { ScriptRunner } from '../../src/shared/application/scripts/script-runner.js';
+import { DomainTransaction } from '../../src/shared/domain/DomainTransaction.js';
+
+export class RemoveCertificationVersionsRejectedMeshes extends Script {
+  constructor() {
+    super({
+      description:
+        'Pix+ EDU certifications versions globalScoringConfiguration are filled with a rejected mesh. We want to remove those meshes.',
+      permanent: false,
+      options: {
+        dryRun: {
+          type: 'boolean',
+          describe: 'Run the script without making any database changes',
+          default: true,
+        },
+      },
+    });
+  }
+
+  async handle({ logger, options }) {
+    const { dryRun } = options;
+    logger.info('Script execution started');
+
+    await DomainTransaction.execute(async () => {
+      const trx = DomainTransaction.getConnection();
+
+      try {
+        await trx('certification_versions')
+          .where('scope', 'like', `EDU_%`)
+          .update({
+            globalScoringConfiguration: JSON.stringify([{ bounds: { max: 8, min: 1 }, meshLevel: 0 }]),
+          });
+
+        if (dryRun) {
+          await trx.rollback();
+        } else {
+          await trx.commit();
+        }
+      } catch (error) {
+        await trx.rollback();
+        throw error;
+      }
+    });
+
+    logger.info('Pix+ Edu certification versions globalScoringConfiguration are updated');
+  }
+}
+
+await ScriptRunner.execute(import.meta.url, RemoveCertificationVersionsRejectedMeshes);

--- a/api/src/certification/evaluation/domain/models/ScoringV3Algorithm.js
+++ b/api/src/certification/evaluation/domain/models/ScoringV3Algorithm.js
@@ -100,11 +100,14 @@ export class ScoringV3Algorithm {
   /**
    *  @param {object} params
    *  @param {number} params.capacity
-   *  @returns {number} reachedMeshIndex
+   *  @returns {number|null} reachedMeshIndex
    */
   computeReachedMeshIndex({ capacity }) {
     const certificationScoringIntervals = this.v3CertificationScoring.intervals;
     const scoringIntervals = new Intervals({ intervals: certificationScoringIntervals });
+    if (scoringIntervals.isCapacityBelowMinimum(capacity)) {
+      return null;
+    }
     return scoringIntervals.findIntervalIndexFromCapacity(capacity);
   }
 

--- a/api/src/certification/evaluation/domain/models/factories/AssessmentResultFactory.js
+++ b/api/src/certification/evaluation/domain/models/factories/AssessmentResultFactory.js
@@ -217,7 +217,7 @@ export class AssessmentResultFactory {
     });
   }
 
-  static buildRejectedDueToZeroPixScore({
+  static buildRejectedDueToBelowMinimumMesh({
     pixScore,
     reproducibilityRate,
     assessmentId,
@@ -228,7 +228,7 @@ export class AssessmentResultFactory {
     versionId,
   }) {
     return this.#buildWithAutoJuryComment({
-      autoJuryCommentKey: AutoJuryCommentKeys.REJECTED_DUE_TO_ZERO_PIX_SCORE,
+      autoJuryCommentKey: pixScore === 0 ? AutoJuryCommentKeys.REJECTED_DUE_TO_ZERO_PIX_SCORE : null,
       status: AssessmentResult.status.REJECTED,
       pixScore,
       reproducibilityRate,

--- a/api/src/certification/evaluation/domain/services/scoring/create-v3-assessment-result.js
+++ b/api/src/certification/evaluation/domain/services/scoring/create-v3-assessment-result.js
@@ -14,6 +14,7 @@ export function createV3AssessmentResult({
   isAbortReasonTechnical,
   juryId,
   minimumAnswersRequiredToValidateACertification,
+  isBelowMinimumMesh = false,
 }) {
   if (toBeCancelled) {
     return AssessmentResultFactory.buildCancelledAssessmentResult({
@@ -65,8 +66,8 @@ export function createV3AssessmentResult({
     }
   }
 
-  if (pixScore === 0) {
-    return AssessmentResultFactory.buildRejectedDueToZeroPixScore({
+  if (isBelowMinimumMesh) {
+    return AssessmentResultFactory.buildRejectedDueToBelowMinimumMesh({
       pixScore,
       assessmentId,
       juryId,

--- a/api/src/certification/evaluation/domain/services/scoring/create-v3-assessment-result.js
+++ b/api/src/certification/evaluation/domain/services/scoring/create-v3-assessment-result.js
@@ -14,7 +14,6 @@ export function createV3AssessmentResult({
   isAbortReasonTechnical,
   juryId,
   minimumAnswersRequiredToValidateACertification,
-  isBelowMinimumMesh = false,
 }) {
   if (toBeCancelled) {
     return AssessmentResultFactory.buildCancelledAssessmentResult({
@@ -66,7 +65,7 @@ export function createV3AssessmentResult({
     }
   }
 
-  if (isBelowMinimumMesh) {
+  if (reachedMeshIndex === null) {
     return AssessmentResultFactory.buildRejectedDueToBelowMinimumMesh({
       pixScore,
       assessmentId,

--- a/api/src/certification/evaluation/domain/services/scoring/scoring-v3.js
+++ b/api/src/certification/evaluation/domain/services/scoring/scoring-v3.js
@@ -21,7 +21,6 @@ import { status as CertificationStatus } from '../../../../../shared/domain/mode
 import { ABORT_REASONS } from '../../../../shared/domain/constants/abort-reasons.js';
 import { SCOPES } from '../../../../shared/domain/models/Scopes.js';
 import { DoubleCertificationScoring } from '../../models/DoubleCertificationScoring.js';
-import { Intervals } from '../../models/Intervals.js';
 import { ScoringV3Algorithm } from '../../models/ScoringV3Algorithm.js';
 import { createV3AssessmentResult } from './create-v3-assessment-result.js';
 
@@ -126,15 +125,12 @@ function scoreCertification({
   const reachedMeshIndex = scoringV3Algorithm.computeReachedMeshIndex({ capacity });
   const competenceMarks = scoringV3Algorithm.computeCompetenceMarks({ capacity });
 
-  const scoringIntervals = new Intervals({ intervals: scoringV3Algorithm.v3CertificationScoring.intervals });
-  const isBelowMinimumMesh = scoringIntervals.isCapacityBelowMinimum(capacity);
-
   const status =
     hasNotEnoughAnswers({
       answers: assessmentSheet.answers,
       abortReason: assessmentSheet.abortReason,
       minimumAnswersRequiredToValidateACertification,
-    }) || isBelowMinimumMesh
+    }) || reachedMeshIndex === null
       ? CertificationStatus.REJECTED
       : CertificationStatus.VALIDATED;
 
@@ -153,7 +149,6 @@ function scoreCertification({
     isAbortReasonTechnical: assessmentSheet.isAbortReasonTechnical,
     juryId: event?.juryId,
     minimumAnswersRequiredToValidateACertification,
-    isBelowMinimumMesh,
   });
   return assessmentResult;
 }

--- a/api/src/certification/evaluation/domain/services/scoring/scoring-v3.js
+++ b/api/src/certification/evaluation/domain/services/scoring/scoring-v3.js
@@ -21,6 +21,7 @@ import { status as CertificationStatus } from '../../../../../shared/domain/mode
 import { ABORT_REASONS } from '../../../../shared/domain/constants/abort-reasons.js';
 import { SCOPES } from '../../../../shared/domain/models/Scopes.js';
 import { DoubleCertificationScoring } from '../../models/DoubleCertificationScoring.js';
+import { Intervals } from '../../models/Intervals.js';
 import { ScoringV3Algorithm } from '../../models/ScoringV3Algorithm.js';
 import { createV3AssessmentResult } from './create-v3-assessment-result.js';
 
@@ -124,13 +125,18 @@ function scoreCertification({
     certificationScope === SCOPES.CORE ? scoringV3Algorithm.computePixScoreFromCapacity({ capacity }) : null;
   const reachedMeshIndex = scoringV3Algorithm.computeReachedMeshIndex({ capacity });
   const competenceMarks = scoringV3Algorithm.computeCompetenceMarks({ capacity });
-  const status = isCertificationRejected({
-    answers: assessmentSheet.answers,
-    abortReason: assessmentSheet.abortReason,
-    minimumAnswersRequiredToValidateACertification,
-  })
-    ? CertificationStatus.REJECTED
-    : CertificationStatus.VALIDATED;
+
+  const scoringIntervals = new Intervals({ intervals: scoringV3Algorithm.v3CertificationScoring.intervals });
+  const isBelowMinimumMesh = scoringIntervals.isCapacityBelowMinimum(capacity);
+
+  const status =
+    hasNotEnoughAnswers({
+      answers: assessmentSheet.answers,
+      abortReason: assessmentSheet.abortReason,
+      minimumAnswersRequiredToValidateACertification,
+    }) || isBelowMinimumMesh
+      ? CertificationStatus.REJECTED
+      : CertificationStatus.VALIDATED;
 
   const toBeCancelled = event instanceof CertificationCancelled;
   const assessmentResult = createV3AssessmentResult({
@@ -147,6 +153,7 @@ function scoreCertification({
     isAbortReasonTechnical: assessmentSheet.isAbortReasonTechnical,
     juryId: event?.juryId,
     minimumAnswersRequiredToValidateACertification,
+    isBelowMinimumMesh,
   });
   return assessmentResult;
 }
@@ -185,7 +192,7 @@ function shouldDowngradeCapacity({
   );
 }
 
-function isCertificationRejected({ answers, abortReason, minimumAnswersRequiredToValidateACertification }) {
+function hasNotEnoughAnswers({ answers, abortReason, minimumAnswersRequiredToValidateACertification }) {
   // Dans la vraie vie, en cas de nombre de réponses insuffisant, la certif est rejetée seulement si l'abortReason est "candidate"
   // ici on ne regarde pas la valeur de abortReason ce qui n'est pas très clair. Le coup est rattrapé plus tard dans createV3AssessmentResult ( et c'est moche )
   return answers.length < minimumAnswersRequiredToValidateACertification && abortReason;

--- a/api/tests/certification/evaluation/integration/infrastructure/repositories/scoring-configuration-repository_test.js
+++ b/api/tests/certification/evaluation/integration/infrastructure/repositories/scoring-configuration-repository_test.js
@@ -96,7 +96,7 @@ describe('Certification | Evaluation | Integration | Repositories | scoring-conf
       expect(result.versionId).to.be.a('number');
       expect(result._competencesForScoring[0].competenceId).to.be.equal(`${PIX_ORIGIN}Competence`);
       expect(result._competencesForScoring[0].intervals.length).not.to.be.equal(0);
-      expect(result._certificationScoringConfiguration[0].bounds.min).to.be.equal(-8);
+      expect(result._certificationScoringConfiguration[0].bounds.min).to.be.equal(-4.6);
       expect(result._certificationScoringConfiguration[7].bounds.max).to.be.equal(8);
     });
   });

--- a/api/tests/certification/evaluation/unit/domain/models/factories/AssessmentResultFactory_test.js
+++ b/api/tests/certification/evaluation/unit/domain/models/factories/AssessmentResultFactory_test.js
@@ -231,44 +231,71 @@ describe('Certification | Evaluation | Unit | Domain | Factories | AssessmentRes
     });
   });
 
-  describe('#buildRejectedDueToZeroPixScore', function () {
-    it('should return a rejected AssessmentResult due to zero pix score', function () {
-      // given
-      const competenceMarks = [domainBuilder.buildCompetenceMark()];
+  describe('#buildRejectedDueToBelowMinimumMesh', function () {
+    context('when pixScore is 0 (CORE scope)', function () {
+      it('should return a rejected AssessmentResult with auto-jury comment', function () {
+        // given
+        const competenceMarks = [domainBuilder.buildCompetenceMark()];
 
-      // when
-      const actualAssessmentResult = AssessmentResultFactory.buildRejectedDueToZeroPixScore({
-        pixScore: 0,
-        reproducibilityRate: 25,
-        assessmentId: 123,
-        juryId: 456,
-        competenceMarks,
-        capacity: -3.94,
-        reachedMeshIndex: 0,
-        versionId: 10,
-      });
+        // when
+        const actualAssessmentResult = AssessmentResultFactory.buildRejectedDueToBelowMinimumMesh({
+          pixScore: 0,
+          reproducibilityRate: 25,
+          assessmentId: 123,
+          juryId: 456,
+          competenceMarks,
+          capacity: -3.94,
+          reachedMeshIndex: 0,
+          versionId: 10,
+        });
 
-      // then
-      const expectedAssessmentResult = domainBuilder.buildAssessmentResult({
-        status: AssessmentResult.status.REJECTED,
-        pixScore: 0,
-        reproducibilityRate: 25,
-        assessmentId: 123,
-        juryId: 456,
-        competenceMarks,
-        capacity: -3.94,
-        reachedMeshIndex: 0,
-        versionId: 10,
-        commentForCandidate: domainBuilder.certification.shared.buildJuryComment.candidate({
-          commentByAutoJury: AutoJuryCommentKeys.REJECTED_DUE_TO_ZERO_PIX_SCORE,
-        }),
-        commentForOrganization: domainBuilder.certification.shared.buildJuryComment.organization({
-          commentByAutoJury: AutoJuryCommentKeys.REJECTED_DUE_TO_ZERO_PIX_SCORE,
-        }),
+        // then
+        const expectedAssessmentResult = domainBuilder.buildAssessmentResult({
+          status: AssessmentResult.status.REJECTED,
+          pixScore: 0,
+          reproducibilityRate: 25,
+          assessmentId: 123,
+          juryId: 456,
+          competenceMarks,
+          capacity: -3.94,
+          reachedMeshIndex: 0,
+          versionId: 10,
+          commentForCandidate: domainBuilder.certification.shared.buildJuryComment.candidate({
+            commentByAutoJury: AutoJuryCommentKeys.REJECTED_DUE_TO_ZERO_PIX_SCORE,
+          }),
+          commentForOrganization: domainBuilder.certification.shared.buildJuryComment.organization({
+            commentByAutoJury: AutoJuryCommentKeys.REJECTED_DUE_TO_ZERO_PIX_SCORE,
+          }),
+        });
+        expectedAssessmentResult.id = undefined;
+        expectedAssessmentResult.createdAt = undefined;
+        expect(actualAssessmentResult).to.deepEqualInstance(expectedAssessmentResult);
       });
-      expectedAssessmentResult.id = undefined;
-      expectedAssessmentResult.createdAt = undefined;
-      expect(actualAssessmentResult).to.deepEqualInstance(expectedAssessmentResult);
+    });
+
+    context('when pixScore is null (non-CORE scope)', function () {
+      it('should return a rejected AssessmentResult without auto-jury comment', function () {
+        // given
+        const competenceMarks = [domainBuilder.buildCompetenceMark()];
+
+        // when
+        const actualAssessmentResult = AssessmentResultFactory.buildRejectedDueToBelowMinimumMesh({
+          pixScore: null,
+          reproducibilityRate: 25,
+          assessmentId: 123,
+          juryId: 456,
+          competenceMarks,
+          capacity: -3.94,
+          reachedMeshIndex: 0,
+          versionId: 10,
+        });
+
+        // then
+        expect(actualAssessmentResult.status).to.equal(AssessmentResult.status.REJECTED);
+        expect(actualAssessmentResult.pixScore).to.be.null;
+        expect(actualAssessmentResult.commentForCandidate.commentByAutoJury).to.be.undefined;
+        expect(actualAssessmentResult.commentForOrganization.commentByAutoJury).to.be.undefined;
+      });
     });
   });
 

--- a/api/tests/certification/evaluation/unit/domain/services/scoring/create-v3-assessment-result_test.js
+++ b/api/tests/certification/evaluation/unit/domain/services/scoring/create-v3-assessment-result_test.js
@@ -14,65 +14,69 @@ describe('Unit | Certification | Evaluation | Domain | Services | Create V3 Asse
   const versionId = 7;
 
   describe('createV3AssessmentResult', function () {
-    it('it should return cancelled AssessmentResult if toBeCancelled is true', function () {
-      //when
-      const assessmentResult = createV3AssessmentResult({
-        toBeCancelled: true,
-        allAnswers: [],
-        assessmentId: 123,
-        pixScore,
-        capacity,
-        reachedMeshIndex,
-        versionId,
-        status: AssessmentResult.status.CANCELLED,
-        competenceMarks,
-        isRejectedForFraud: false,
-        isAbortReasonTechnical: false,
-        juryId: 123,
-        minimumAnswersRequiredToValidateACertification,
-      });
+    context('when assessment is going to be cancelled', function () {
+      it('it should return cancelled AssessmentResult', function () {
+        //when
+        const assessmentResult = createV3AssessmentResult({
+          toBeCancelled: true,
+          allAnswers: [],
+          assessmentId: 123,
+          pixScore,
+          capacity,
+          reachedMeshIndex,
+          versionId,
+          status: AssessmentResult.status.CANCELLED,
+          competenceMarks,
+          isRejectedForFraud: false,
+          isAbortReasonTechnical: false,
+          juryId: 123,
+          minimumAnswersRequiredToValidateACertification,
+        });
 
-      //then
-      expect(assessmentResult.status).to.equal(AssessmentResult.status.CANCELLED);
-      expect(assessmentResult.pixScore).to.equal(pixScore);
-      expect(assessmentResult.competenceMarks).to.deep.equal(competenceMarks);
-      expect(assessmentResult.capacity).to.equal(capacity);
-      expect(assessmentResult.reachedMeshIndex).to.equal(reachedMeshIndex);
-      expect(assessmentResult.versionId).to.equal(versionId);
+        //then
+        expect(assessmentResult.status).to.equal(AssessmentResult.status.CANCELLED);
+        expect(assessmentResult.pixScore).to.equal(pixScore);
+        expect(assessmentResult.competenceMarks).to.deep.equal(competenceMarks);
+        expect(assessmentResult.capacity).to.equal(capacity);
+        expect(assessmentResult.reachedMeshIndex).to.equal(reachedMeshIndex);
+        expect(assessmentResult.versionId).to.equal(versionId);
+      });
     });
 
-    it('it should return a rejected for fraud AssessmentResult if isRejectedForFraud is true', function () {
-      //when
-      const assessmentResult = createV3AssessmentResult({
-        toBeCancelled: false,
-        allAnswers: [],
-        pixScore,
-        capacity,
-        reachedMeshIndex,
-        versionId,
-        status: AssessmentResult.status.REJECTED,
-        competenceMarks,
-        assessmentId: 123,
-        isRejectedForFraud: true,
-        isAbortReasonTechnical: false,
-        juryId: 123,
-        minimumAnswersRequiredToValidateACertification,
-      });
+    context('when assessment is rejected for fraud', function () {
+      it('it should return a rejected for fraud AssessmentResult', function () {
+        //when
+        const assessmentResult = createV3AssessmentResult({
+          toBeCancelled: false,
+          allAnswers: [],
+          pixScore,
+          capacity,
+          reachedMeshIndex,
+          versionId,
+          status: AssessmentResult.status.REJECTED,
+          competenceMarks,
+          assessmentId: 123,
+          isRejectedForFraud: true,
+          isAbortReasonTechnical: false,
+          juryId: 123,
+          minimumAnswersRequiredToValidateACertification,
+        });
 
-      //then
-      const juryComment = domainBuilder.certification.shared.buildJuryComment.organization({
-        commentByAutoJury: AutoJuryCommentKeys.FRAUD,
+        //then
+        const juryComment = domainBuilder.certification.shared.buildJuryComment.organization({
+          commentByAutoJury: AutoJuryCommentKeys.FRAUD,
+        });
+        expect(assessmentResult.status).to.equal(AssessmentResult.status.REJECTED);
+        expect(assessmentResult.commentForOrganization).to.deep.equal(juryComment);
+        expect(assessmentResult.pixScore).to.equal(pixScore);
+        expect(assessmentResult.competenceMarks).to.deep.equal(competenceMarks);
+        expect(assessmentResult.capacity).to.equal(capacity);
+        expect(assessmentResult.reachedMeshIndex).to.equal(reachedMeshIndex);
+        expect(assessmentResult.versionId).to.equal(versionId);
       });
-      expect(assessmentResult.status).to.equal(AssessmentResult.status.REJECTED);
-      expect(assessmentResult.commentForOrganization).to.deep.equal(juryComment);
-      expect(assessmentResult.pixScore).to.equal(pixScore);
-      expect(assessmentResult.competenceMarks).to.deep.equal(competenceMarks);
-      expect(assessmentResult.capacity).to.equal(capacity);
-      expect(assessmentResult.reachedMeshIndex).to.equal(reachedMeshIndex);
-      expect(assessmentResult.versionId).to.equal(versionId);
     });
 
-    context('when there is an insuffisant number of answer', function () {
+    context('when assessment has an insuffisant number of answers', function () {
       it('should return a cancelled AssessmentResult if the cause is technical', function () {
         //when
         const assessmentResult = createV3AssessmentResult({
@@ -135,7 +139,8 @@ describe('Unit | Certification | Evaluation | Domain | Services | Create V3 Asse
         expect(assessmentResult.versionId).to.equal(versionId);
       });
     });
-    context('when there is a sufficient number of answers', function () {
+
+    context('when assessment has a sufficient number of answers', function () {
       let allChallenges, answeredChallenges, answers;
       beforeEach(function () {
         allChallenges = generateChallengeList({ length: minimumAnswersRequiredToValidateACertification + 1 });
@@ -144,62 +149,100 @@ describe('Unit | Certification | Evaluation | Domain | Services | Create V3 Asse
         answers = _buildDataFromAnsweredChallenges(answeredChallenges).answers;
       });
 
-      it('should return a rejected AssessmentResult if pix score is 0', function () {
-        //when
-        const assessmentResult = createV3AssessmentResult({
-          toBeCancelled: false,
-          allAnswers: answers,
-          assessmentId: 123,
-          pixScore: 0,
-          capacity,
-          reachedMeshIndex,
-          versionId,
-          status: AssessmentResult.status.VALIDATED,
-          competenceMarks,
-          isRejectedForFraud: false,
-          isAbortReasonTechnical: false,
-          juryId: 123,
-          minimumAnswersRequiredToValidateACertification,
+      context('when the capacity is below minimum mesh', function () {
+        context('there is a score equal to 0', function () {
+          it('should return a rejected AssessmentResult with auto-jury comment', function () {
+            //when
+            const assessmentResult = createV3AssessmentResult({
+              toBeCancelled: false,
+              allAnswers: answers,
+              assessmentId: 123,
+              pixScore: 0,
+              capacity,
+              reachedMeshIndex,
+              versionId,
+              status: AssessmentResult.status.REJECTED,
+              competenceMarks,
+              isRejectedForFraud: false,
+              isAbortReasonTechnical: false,
+              juryId: 123,
+              minimumAnswersRequiredToValidateACertification,
+              isBelowMinimumMesh: true,
+            });
+
+            //then
+            const juryComment = domainBuilder.certification.shared.buildJuryComment.organization({
+              commentByAutoJury: AutoJuryCommentKeys.REJECTED_DUE_TO_ZERO_PIX_SCORE,
+            });
+            expect(assessmentResult.status).to.equal(AssessmentResult.status.REJECTED);
+            expect(assessmentResult.commentForOrganization).to.deep.equal(juryComment);
+            expect(assessmentResult.pixScore).to.equal(0);
+            expect(assessmentResult.competenceMarks).to.deep.equal([]);
+            expect(assessmentResult.capacity).to.equal(capacity);
+            expect(assessmentResult.reachedMeshIndex).to.equal(reachedMeshIndex);
+            expect(assessmentResult.versionId).to.equal(versionId);
+          });
         });
 
-        //then
-        const juryComment = domainBuilder.certification.shared.buildJuryComment.organization({
-          commentByAutoJury: AutoJuryCommentKeys.REJECTED_DUE_TO_ZERO_PIX_SCORE,
+        context('when there is no score', function () {
+          it('should return a rejected AssessmentResult without auto-jury comment', function () {
+            //when
+            const assessmentResult = createV3AssessmentResult({
+              toBeCancelled: false,
+              allAnswers: answers,
+              assessmentId: 123,
+              pixScore: null,
+              capacity,
+              reachedMeshIndex,
+              versionId,
+              status: AssessmentResult.status.REJECTED,
+              competenceMarks,
+              isRejectedForFraud: false,
+              isAbortReasonTechnical: false,
+              juryId: 123,
+              minimumAnswersRequiredToValidateACertification,
+              isBelowMinimumMesh: true,
+            });
+
+            //then
+            expect(assessmentResult.status).to.equal(AssessmentResult.status.REJECTED);
+            expect(assessmentResult.commentForOrganization).to.deep.equal(
+              domainBuilder.certification.shared.buildJuryComment.organization({
+                commentByAutoJury: null,
+              }),
+            );
+            expect(assessmentResult.pixScore).to.be.null;
+          });
         });
-        expect(assessmentResult.status).to.equal(AssessmentResult.status.REJECTED);
-        expect(assessmentResult.commentForOrganization).to.deep.equal(juryComment);
-        expect(assessmentResult.pixScore).to.equal(0);
-        expect(assessmentResult.competenceMarks).to.deep.equal([]);
-        expect(assessmentResult.capacity).to.equal(capacity);
-        expect(assessmentResult.reachedMeshIndex).to.equal(reachedMeshIndex);
-        expect(assessmentResult.versionId).to.equal(versionId);
       });
 
-      it('should return a standard AssessmentResult if pix score is not 0', function () {
-        //when
-        const assessmentResult = createV3AssessmentResult({
-          toBeCancelled: false,
-          allAnswers: answers,
-          assessmentId: 123,
-          pixScore,
-          capacity,
-          reachedMeshIndex,
-          versionId,
-          status: AssessmentResult.status.VALIDATED,
-          competenceMarks,
-          isRejectedForFraud: false,
-          isAbortReasonTechnical: false,
-          juryId: 123,
-          minimumAnswersRequiredToValidateACertification,
-        });
+      context('when at least minimum mesh is reached', function () {
+        it('should return a standard AssessmentResult', function () {
+          //when
+          const assessmentResult = createV3AssessmentResult({
+            toBeCancelled: false,
+            allAnswers: answers,
+            assessmentId: 123,
+            pixScore,
+            capacity,
+            reachedMeshIndex,
+            versionId,
+            status: AssessmentResult.status.VALIDATED,
+            competenceMarks,
+            isRejectedForFraud: false,
+            isAbortReasonTechnical: false,
+            juryId: 123,
+            minimumAnswersRequiredToValidateACertification,
+          });
 
-        //then
-        expect(assessmentResult.status).to.equal(AssessmentResult.status.VALIDATED);
-        expect(assessmentResult.pixScore).to.equal(pixScore);
-        expect(assessmentResult.competenceMarks).to.deep.equal(competenceMarks);
-        expect(assessmentResult.capacity).to.equal(capacity);
-        expect(assessmentResult.reachedMeshIndex).to.equal(reachedMeshIndex);
-        expect(assessmentResult.versionId).to.equal(versionId);
+          //then
+          expect(assessmentResult.status).to.equal(AssessmentResult.status.VALIDATED);
+          expect(assessmentResult.pixScore).to.equal(pixScore);
+          expect(assessmentResult.competenceMarks).to.deep.equal(competenceMarks);
+          expect(assessmentResult.capacity).to.equal(capacity);
+          expect(assessmentResult.reachedMeshIndex).to.equal(reachedMeshIndex);
+          expect(assessmentResult.versionId).to.equal(versionId);
+        });
       });
     });
   });

--- a/api/tests/certification/evaluation/unit/domain/services/scoring/create-v3-assessment-result_test.js
+++ b/api/tests/certification/evaluation/unit/domain/services/scoring/create-v3-assessment-result_test.js
@@ -149,7 +149,7 @@ describe('Unit | Certification | Evaluation | Domain | Services | Create V3 Asse
         answers = _buildDataFromAnsweredChallenges(answeredChallenges).answers;
       });
 
-      context('when the capacity is below minimum mesh', function () {
+      context('when capacity does not belong to any mesh', function () {
         context('there is a score equal to 0', function () {
           it('should return a rejected AssessmentResult with auto-jury comment', function () {
             //when
@@ -159,7 +159,7 @@ describe('Unit | Certification | Evaluation | Domain | Services | Create V3 Asse
               assessmentId: 123,
               pixScore: 0,
               capacity,
-              reachedMeshIndex,
+              reachedMeshIndex: null,
               versionId,
               status: AssessmentResult.status.REJECTED,
               competenceMarks,
@@ -167,7 +167,6 @@ describe('Unit | Certification | Evaluation | Domain | Services | Create V3 Asse
               isAbortReasonTechnical: false,
               juryId: 123,
               minimumAnswersRequiredToValidateACertification,
-              isBelowMinimumMesh: true,
             });
 
             //then
@@ -179,7 +178,7 @@ describe('Unit | Certification | Evaluation | Domain | Services | Create V3 Asse
             expect(assessmentResult.pixScore).to.equal(0);
             expect(assessmentResult.competenceMarks).to.deep.equal([]);
             expect(assessmentResult.capacity).to.equal(capacity);
-            expect(assessmentResult.reachedMeshIndex).to.equal(reachedMeshIndex);
+            expect(assessmentResult.reachedMeshIndex).to.equal(null);
             expect(assessmentResult.versionId).to.equal(versionId);
           });
         });
@@ -193,7 +192,7 @@ describe('Unit | Certification | Evaluation | Domain | Services | Create V3 Asse
               assessmentId: 123,
               pixScore: null,
               capacity,
-              reachedMeshIndex,
+              reachedMeshIndex: null,
               versionId,
               status: AssessmentResult.status.REJECTED,
               competenceMarks,
@@ -201,7 +200,6 @@ describe('Unit | Certification | Evaluation | Domain | Services | Create V3 Asse
               isAbortReasonTechnical: false,
               juryId: 123,
               minimumAnswersRequiredToValidateACertification,
-              isBelowMinimumMesh: true,
             });
 
             //then

--- a/api/tests/certification/evaluation/unit/domain/services/scoring/scoring-v3_test.js
+++ b/api/tests/certification/evaluation/unit/domain/services/scoring/scoring-v3_test.js
@@ -92,7 +92,7 @@ describe('Unit | Certification | Evaluation | Domain | Services | Scoring V3', f
         expect(score.doubleCertificationScoring).to.be.null;
       });
 
-      context('when capacity is below minimum mesh', function () {
+      context('when capacity does not belong to any mesh', function () {
         it('should return a REJECTED AssessmentResult', function () {
           // given
           const assessmentId = 1214;
@@ -244,7 +244,7 @@ describe('Unit | Certification | Evaluation | Domain | Services | Scoring V3', f
           expect(score.doubleCertificationScoring).to.be.null;
         });
 
-        it('should return a REJECTED AssessmentResult when capacity is below minimum mesh', function () {
+        it('should return a REJECTED AssessmentResult when capacity is not included in any mesh', function () {
           // given
           const assessmentId = 1214;
           const certificationCourseId = 1234;

--- a/api/tests/certification/evaluation/unit/domain/services/scoring/scoring-v3_test.js
+++ b/api/tests/certification/evaluation/unit/domain/services/scoring/scoring-v3_test.js
@@ -42,7 +42,7 @@ describe('Unit | Certification | Evaluation | Domain | Services | Scoring V3', f
       clock.restore();
     });
 
-    context('when scoring a unique CORE scoped certification', function () {
+    context('when scoring a CORE certification', function () {
       it('should return an AssessmentResult with a pixScore', function () {
         // given
         const assessmentId = 1214;
@@ -90,6 +90,56 @@ describe('Unit | Certification | Evaluation | Domain | Services | Scoring V3', f
         expect(score.coreAssessmentResult.competenceMarks[0]).to.be.instanceOf(CompetenceMark);
         expect(score.coreAssessmentResult.pixScore).to.equal(880);
         expect(score.doubleCertificationScoring).to.be.null;
+      });
+
+      context('when capacity is below minimum mesh', function () {
+        it('should return a REJECTED AssessmentResult', function () {
+          // given
+          const assessmentId = 1214;
+          const certificationCourseId = 1234;
+
+          const candidate = domainBuilder.certification.evaluation.buildCandidate({
+            subscriptionScope: SCOPES.CORE,
+            hasCleaSubscription: false,
+            reconciledAt: new Date('2025-01-01'),
+          });
+          const assessmentSheet = domainBuilder.certification.evaluation.buildAssessmentSheet({
+            assessmentId,
+            certificationCourseId,
+          });
+
+          const event = new CertificationCompletedJob({
+            certificationCourseId,
+          });
+
+          const v3CertificationScoring = domainBuilder.buildV3CertificationScoring({
+            competencesForScoring: [domainBuilder.buildCompetenceForScoring()],
+            certificationScoringConfiguration: [{ bounds: { max: 8, min: 7 }, meshLevel: 0 }],
+          });
+          const challenges = generateChallengeList({
+            length: maximumAssessmentLength,
+          });
+          const { answers } = _buildDataFromAnsweredChallenges(challenges);
+
+          assessmentSheet.answers = answers;
+
+          // when
+          const score = handleV3CertificationScoring({
+            event,
+            assessmentSheet,
+            candidate,
+            allChallenges: challenges,
+            askedChallengesWithoutLiveAlerts: challenges,
+            algorithm,
+            v3CertificationScoring,
+            cleaScoringCriteria: null,
+            scoringDegradationService,
+          });
+
+          // then
+          expect(score.coreAssessmentResult.status).to.equal(AssessmentResult.status.REJECTED);
+          expect(score.coreAssessmentResult.pixScore).to.equal(0);
+        });
       });
     });
 
@@ -192,6 +242,55 @@ describe('Unit | Certification | Evaluation | Domain | Services | Scoring V3', f
           expect(score.coreAssessmentResult.competenceMarks).to.have.lengthOf(0);
           expect(score.coreAssessmentResult.pixScore).to.be.null;
           expect(score.doubleCertificationScoring).to.be.null;
+        });
+
+        it('should return a REJECTED AssessmentResult when capacity is below minimum mesh', function () {
+          // given
+          const assessmentId = 1214;
+          const certificationCourseId = 1234;
+
+          const candidate = domainBuilder.certification.evaluation.buildCandidate({
+            subscriptionScope: SCOPES.PIX_PLUS_EDU_1ER_DEGRE,
+            hasCleaSubscription: false,
+            reconciledAt: new Date('2021-01-01'),
+          });
+          const assessmentSheet = domainBuilder.certification.evaluation.buildAssessmentSheet({
+            assessmentId,
+            certificationCourseId,
+          });
+
+          const event = new CertificationCompletedJob({
+            certificationCourseId,
+          });
+
+          const v3CertificationScoring = domainBuilder.buildV3CertificationScoring({
+            certificationScoringConfiguration: [
+              { bounds: { max: 20, min: 10 }, meshLevel: 0 },
+              { bounds: { max: 30, min: 20 }, meshLevel: 1 },
+            ],
+          });
+          const challenges = generateChallengeList({
+            length: maximumAssessmentLength,
+          });
+          const { answers } = _buildDataFromAnsweredChallenges(challenges);
+
+          assessmentSheet.answers = answers;
+
+          // when
+          const score = handleV3CertificationScoring({
+            event,
+            assessmentSheet,
+            candidate,
+            allChallenges: challenges,
+            askedChallengesWithoutLiveAlerts: challenges,
+            algorithm,
+            v3CertificationScoring,
+            cleaScoringCriteria: null,
+            scoringDegradationService,
+          });
+
+          // then
+          expect(score.coreAssessmentResult.status).to.equal(AssessmentResult.status.REJECTED);
         });
       });
 

--- a/api/tests/certification/scripts/integration/fill-capacity-meshindex-versionid-columns-in-assessment-results-table_test.js
+++ b/api/tests/certification/scripts/integration/fill-capacity-meshindex-versionid-columns-in-assessment-results-table_test.js
@@ -88,7 +88,7 @@ describe('Integration | Certification | Scripts | Fill capacity, meshindex, vers
 
     const assessmentResultData = await knex('assessment-results').orderBy('id');
     expect(assessmentResultData).to.have.lengthOf(pixScores.length);
-    expect(Math.ceil(assessmentResultData[0].capacity)).to.equal(-8);
+    expect(Math.ceil(assessmentResultData[0].capacity)).to.equal(-4);
     expect(assessmentResultData[0].reachedMeshIndex).to.equal(0);
     expect(assessmentResultData[0].versionId).to.equal(versionId);
     expect(Math.ceil(assessmentResultData[1].capacity)).to.equal(8);
@@ -129,7 +129,7 @@ describe('Integration | Certification | Scripts | Fill capacity, meshindex, vers
 
     const assessmentResultData = await knex('assessment-results').orderBy('id');
     expect(assessmentResultData).to.have.lengthOf(pixScores.length);
-    expect(Math.ceil(assessmentResultData[0].capacity)).to.equal(-8);
+    expect(Math.ceil(assessmentResultData[0].capacity)).to.equal(-4);
     expect(assessmentResultData[0].reachedMeshIndex).to.equal(0);
     expect(assessmentResultData[0].versionId).to.equal(versionId);
     expect(Math.ceil(assessmentResultData[1].capacity)).to.equal(8);

--- a/api/tests/certification/session-management/acceptance/application/finalize-route_test.js
+++ b/api/tests/certification/session-management/acceptance/application/finalize-route_test.js
@@ -604,7 +604,7 @@ describe('Certification | Session Management | Acceptance | Application | Route 
             .orderBy('createdAt', 'desc')
             .first();
           expect(lastAssessmentResult).to.deep.include({
-            pixScore: 48,
+            pixScore: 31,
             capacity: -3,
             reachedMeshIndex: 0,
             status: AssessmentResult.status.VALIDATED,
@@ -731,7 +731,7 @@ describe('Certification | Session Management | Acceptance | Application | Route 
             const pixCoreResults = await knex('assessment-results').where({ assessmentId });
             expect(pixCoreResults).to.have.lengthOf(1);
             expect(pixCoreResults[0]).to.deep.include({
-              pixScore: 48,
+              pixScore: 31,
               capacity: -3,
               reachedMeshIndex: 0,
               status: AssessmentResult.status.VALIDATED,

--- a/api/tests/evaluation/unit/domain/models/ScoringV3Algorithm_test.js
+++ b/api/tests/evaluation/unit/domain/models/ScoringV3Algorithm_test.js
@@ -99,5 +99,13 @@ describe('Certification | Evaluation | Unit | Domain | Models | ScoringV3Algorit
 
       expect(reachedMeshIndex).to.equal(4);
     });
+
+    context('when capacity is below the minimum mesh', function () {
+      it('should return null', function () {
+        const reachedMeshIndex = scoringV3Algorithm.computeReachedMeshIndex({ capacity: -8 });
+
+        expect(reachedMeshIndex).to.be.null;
+      });
+    });
   });
 });

--- a/high-level-tests/e2e-playwright/helpers/certification/builders/build-pix-plus-edu-data.ts
+++ b/high-level-tests/e2e-playwright/helpers/certification/builders/build-pix-plus-edu-data.ts
@@ -10,10 +10,7 @@ export async function buildPixPlusEduData(knex: Knex) {
       expirationDate: null,
       assessmentDuration: 120,
       minimumAnswersRequiredToValidateACertification: 20,
-      globalScoringConfiguration: JSON.stringify([
-        { bounds: { max: 1, min: -8 }, meshLevel: 0 },
-        { bounds: { max: 8, min: 1 }, meshLevel: 1 },
-      ]),
+      globalScoringConfiguration: JSON.stringify([{ bounds: { max: 8, min: 1 }, meshLevel: 0 }]),
       competencesScoringConfiguration: JSON.stringify([]),
       challengesConfiguration: JSON.stringify({
         variationPercent: 0.3,

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/edu/EDU_0OK-32KO.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/edu/EDU_0OK-32KO.spec.ts
@@ -91,8 +91,8 @@ test(
         expect(certificationData[0]).toMatchObject({
           Prénom: certifiableUserData.firstName,
           Nom: certifiableUserData.lastName,
-          Statut: 'Validée',
-          Résultats: 'Non-admissible',
+          Statut: 'Rejetée',
+          Résultats: 'Non admissible',
           'Signalements impactants non résolus': '',
           'Certification passée': 'Pix+ Édu 1er degré',
         });
@@ -101,17 +101,17 @@ test(
         );
         await checkCertificationGeneralInformationAndExpectSuccess(certificationInformationPage, {
           sessionNumber,
-          status: 'Validée',
-          result: 'Non-admissible',
+          status: 'Rejetée',
+          result: 'Non admissible',
         });
         await checkCertificationDetailsAndExpectSuccess(certificationInformationPage, {
-          status: 'Validée',
+          status: 'Rejetée',
           nbAnsweredQuestionsOverTotal: '32/32',
           nbQuestionsOK: 0,
           nbQuestionsKO: 32,
           nbQuestionsAband: 0,
           nbValidatedTechnicalIssues: 0,
-          result: 'Non-admissible',
+          result: 'Non admissible',
         });
       });
     });

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/edu/EDU_1OK-0KO_EndedByFinalization_Abandonment.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/edu/EDU_1OK-0KO_EndedByFinalization_Abandonment.spec.ts
@@ -87,7 +87,7 @@ test(
           Prénom: certifiableUserData.firstName,
           Nom: certifiableUserData.lastName,
           Statut: 'Rejetée',
-          Résultats: 'Non-admissible',
+          Résultats: 'Non admissible',
           'Signalements impactants non résolus': '',
           'Certification passée': 'Pix+ Édu 1er degré',
         });
@@ -97,7 +97,7 @@ test(
         await checkCertificationGeneralInformationAndExpectSuccess(certificationInformationPage, {
           sessionNumber,
           status: 'Rejetée',
-          result: 'Non-admissible',
+          result: 'Non admissible',
         });
         await checkCertificationDetailsAndExpectSuccess(certificationInformationPage, {
           status: 'Rejetée',
@@ -108,7 +108,7 @@ test(
           nbValidatedTechnicalIssues: 0,
           testEndedBy: 'Finalisation session',
           abortReason: 'Abandon : Manque de temps ou départ prématuré',
-          result: 'Non-admissible',
+          result: 'Non admissible',
         });
       });
     });

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/edu/EDU_1OK-0KO_EndedByFinalization_TechnicalIssue.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/edu/EDU_1OK-0KO_EndedByFinalization_TechnicalIssue.spec.ts
@@ -87,7 +87,7 @@ test(
           Prénom: certifiableUserData.firstName,
           Nom: certifiableUserData.lastName,
           Statut: 'Annulée',
-          Résultats: 'Non-admissible',
+          Résultats: 'Non admissible',
           'Signalements impactants non résolus': '',
           'Certification passée': 'Pix+ Édu 1er degré',
         });
@@ -97,7 +97,7 @@ test(
         await checkCertificationGeneralInformationAndExpectSuccess(certificationInformationPage, {
           sessionNumber,
           status: 'Annulée',
-          result: 'Non-admissible',
+          result: 'Non admissible',
         });
         await checkCertificationDetailsAndExpectSuccess(certificationInformationPage, {
           status: 'Annulée',
@@ -108,7 +108,7 @@ test(
           nbValidatedTechnicalIssues: 0,
           testEndedBy: 'Finalisation session',
           abortReason: 'Problème technique',
-          result: 'Non-admissible',
+          result: 'Non admissible',
         });
       });
     });

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/edu/EDU_1OK-0KO_EndedByInvigilator_Abandonment.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/edu/EDU_1OK-0KO_EndedByInvigilator_Abandonment.spec.ts
@@ -91,7 +91,7 @@ test(
           Prénom: certifiableUserData.firstName,
           Nom: certifiableUserData.lastName,
           Statut: 'Terminée par le surveillant',
-          Résultats: 'Non-admissible',
+          Résultats: 'Non admissible',
           'Signalements impactants non résolus': '',
           'Certification passée': 'Pix+ Édu 1er degré',
         });
@@ -101,7 +101,7 @@ test(
         await checkCertificationGeneralInformationAndExpectSuccess(certificationInformationPage, {
           sessionNumber,
           status: 'Rejetée',
-          result: 'Non-admissible',
+          result: 'Non admissible',
         });
         await checkCertificationDetailsAndExpectSuccess(certificationInformationPage, {
           status: 'Rejetée',
@@ -112,7 +112,7 @@ test(
           nbValidatedTechnicalIssues: 0,
           testEndedBy: 'Le surveillant',
           abortReason: 'Abandon : Manque de temps ou départ prématuré',
-          result: 'Non-admissible',
+          result: 'Non admissible',
         });
       });
     });

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/edu/EDU_1OK-0KO_EndedByInvigilator_TechnicalIssue.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/edu/EDU_1OK-0KO_EndedByInvigilator_TechnicalIssue.spec.ts
@@ -91,7 +91,7 @@ test(
           Prénom: certifiableUserData.firstName,
           Nom: certifiableUserData.lastName,
           Statut: 'Terminée par le surveillant',
-          Résultats: 'Non-admissible',
+          Résultats: 'Non admissible',
           'Signalements impactants non résolus': '',
           'Certification passée': 'Pix+ Édu 1er degré',
         });
@@ -101,7 +101,7 @@ test(
         await checkCertificationGeneralInformationAndExpectSuccess(certificationInformationPage, {
           sessionNumber,
           status: 'Annulée',
-          result: 'Non-admissible',
+          result: 'Non admissible',
         });
         await checkCertificationDetailsAndExpectSuccess(certificationInformationPage, {
           status: 'Annulée',
@@ -112,7 +112,7 @@ test(
           nbValidatedTechnicalIssues: 0,
           testEndedBy: 'Le surveillant',
           abortReason: 'Problème technique',
-          result: 'Non-admissible',
+          result: 'Non admissible',
         });
       });
     });


### PR DESCRIPTION
## 🌎 Problème

Pour l’instant, nous avons une première maille dans la certification Pix+ Edu (allant de -8 à 1) qui nous sert à dire que le candidat n’est pas admissible à l’oral.

Mais puisqu’une maille est atteinte, comme pour le coeur, nous décrétons que la certification est “valide”.
Or, cela ne devrait pas être le cas.

## 🔭 Proposition

Si nous souhaitons que la certification soit en état “Rejeté”, il faut : 
1. ne pas avoir de maille non admissible dans la config de scoring de la version,
2. rejeter la certif si le candidat n'atteint pas la première maille

Ainsi, il sera uniformisé que : comme pour Pix coeur, si aucune maille n’est atteinte, alors la certif est rejetée. Sinon, elle est valide.

Aussi, **un script a été ajouté** pour mettre à jour les configurations des certifs Pix+ Edu en recette et en prod.

## 🪐 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🚀 Pour tester

- En local ou en RA, lancer le script et vérifier que Pix+ Edu n'a plus qu'une seule maille avec une borne min de 1.
- Lancer les tests e2e `results` et ✅ 

🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘 🌑
