### PR TITLE
[FEATURE] Ajout d'un mode readOnly pour les webcomponents de junior (pix-22080)

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {
-        "@1024pix/epreuves-components": "^4.1.0",
+        "@1024pix/epreuves-components": "^4.2.0",
         "@1024pix/oppsy": "^1.0.2",
         "@aws-sdk/client-s3": "^3.121.0",
         "@aws-sdk/lib-storage": "^3.121.0",
@@ -116,10 +116,9 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-4.1.0.tgz",
-      "integrity": "sha512-CdWoNGYUWyUAx8BuJM1bswQKWFxH4U9wdK12vo/Q5/E/AiqmfltxvNK2lc7/csT5jvCPvOamMz70kjEf9/409A==",
-      "license": "MIT",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-4.2.0.tgz",
+      "integrity": "sha512-RIiHRkeLUhC/vUsyy8Cp9fIJnzkNanKqoigraZW/z8O89cMCOdXInEfOW1zNIB386jzqHw1loPVFxJBCxTfLUw==",
       "peerDependencies": {
         "joi": "^17.0.0 || ^18.0.0"
       }

--- a/api/package.json
+++ b/api/package.json
@@ -91,7 +91,7 @@
     "modulix:test": "npm run test:api:path -- 'tests/devcomp/unit/infrastructure/datasources/learning-content/module-datasource_test.js' 'tests/devcomp/acceptance/module-instantiation_test.js' 'tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js' 'tests/devcomp/integration/repositories/module-repository_test.js'"
   },
   "dependencies": {
-    "@1024pix/epreuves-components": "^4.1.0",
+    "@1024pix/epreuves-components": "^4.2.0",
     "@1024pix/oppsy": "^1.0.2",
     "@aws-sdk/client-s3": "^3.121.0",
     "@aws-sdk/lib-storage": "^3.121.0",

--- a/junior/app/components/challenge/challenge-content.gjs
+++ b/junior/app/components/challenge/challenge-content.gjs
@@ -83,6 +83,7 @@ export default class ChallengeContent extends Component {
           @tagName={{@challenge.webComponentTagName}}
           @props={{@challenge.webComponentProps}}
           @setAnswerValue={{@setAnswerValue}}
+          @isDisabled={{@isDisabled}}
         />
       {{/if}}
       {{#if @challenge.hasForm}}

--- a/junior/app/components/challenge/content/embedded-web-component.gjs
+++ b/junior/app/components/challenge/content/embedded-web-component.gjs
@@ -9,11 +9,14 @@ export default class EmbeddedWebComponent extends Component {
 
   @action
   mountCustomElement(container) {
-    this.#customElement = document.createElement(this.args.tagName);
-    Object.assign(this.#customElement, this.args.props);
-    this.#customElement.addEventListener('answer', this.#handleAnswer);
-    this.#customElement.dataset.testid = this.args.tagName;
-    container.append(this.#customElement);
+    if (!this.#customElement) {
+      this.#customElement = document.createElement(this.args.tagName);
+      Object.assign(this.#customElement, this.args.props);
+      this.#customElement.addEventListener('answer', this.#handleAnswer);
+      this.#customElement.dataset.testid = this.args.tagName;
+      container.append(this.#customElement);
+    }
+    this.#customElement.readonly = !!this.args.isDisabled;
   }
 
   willDestroy(...args) {

--- a/junior/package-lock.json
+++ b/junior/package-lock.json
@@ -11,7 +11,7 @@
       "license": "AGPL-3.0",
       "devDependencies": {
         "@1024pix/ember-testing-library": "^3.0.27",
-        "@1024pix/epreuves-components": "^4.1.0",
+        "@1024pix/epreuves-components": "^4.2.0",
         "@1024pix/eslint-plugin": "^2.1.19",
         "@1024pix/pix-ui": "^60.2.0",
         "@1024pix/stylelint-config": "^5.1.37",
@@ -180,11 +180,10 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-4.1.0.tgz",
-      "integrity": "sha512-CdWoNGYUWyUAx8BuJM1bswQKWFxH4U9wdK12vo/Q5/E/AiqmfltxvNK2lc7/csT5jvCPvOamMz70kjEf9/409A==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-4.2.0.tgz",
+      "integrity": "sha512-RIiHRkeLUhC/vUsyy8Cp9fIJnzkNanKqoigraZW/z8O89cMCOdXInEfOW1zNIB386jzqHw1loPVFxJBCxTfLUw==",
       "dev": true,
-      "license": "MIT",
       "peerDependencies": {
         "joi": "^17.0.0 || ^18.0.0"
       }

--- a/junior/package.json
+++ b/junior/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^3.0.27",
-    "@1024pix/epreuves-components": "^4.1.0",
+    "@1024pix/epreuves-components": "^4.2.0",
     "@1024pix/eslint-plugin": "^2.1.19",
     "@1024pix/pix-ui": "^60.2.0",
     "@1024pix/stylelint-config": "^5.1.37",

--- a/junior/tests/acceptance/challenge-item-qcm-image-test.js
+++ b/junior/tests/acceptance/challenge-item-qcm-image-test.js
@@ -38,4 +38,18 @@ module('Acceptance | Displaying a QCM Image challenge', function (hooks) {
     // then
     assert.dom(screen.getByText(t('pages.challenge.messages.wrong-answer'))).exists();
   });
+
+  test('should have readonly mode after submit response', async function (assert) {
+    // when
+    const screen = await visit(`/assessments/${assessment.id}/challenges`);
+    const imageQuiz = within(find('image-quiz').shadowRoot);
+
+    assert.strictEqual(imageQuiz.getByRole('option', { name: 'bad-answer' }).getAttribute('readonly'), null);
+
+    await click(imageQuiz.getByRole('option', { name: 'bad-answer' }));
+    await click(screen.getByRole('button', { name: t('pages.challenge.actions.check') }));
+
+    assert.strictEqual(imageQuiz.getByRole('option', { name: 'bad-answer' }).getAttribute('readonly'), '');
+    assert.strictEqual(imageQuiz.getByRole('option', { name: 'Choix1' }).getAttribute('readonly'), '');
+  });
 });

--- a/junior/tests/acceptance/challenge-item-qcu-image-test.js
+++ b/junior/tests/acceptance/challenge-item-qcu-image-test.js
@@ -36,4 +36,18 @@ module('Acceptance | Displaying a QCU Image challenge', function (hooks) {
     // then
     assert.dom(screen.getByText(t('pages.challenge.messages.wrong-answer'))).exists();
   });
+
+  test('should have readonly mode after submit response', async function (assert) {
+    // when
+    const screen = await visit(`/assessments/${assessment.id}/challenges`);
+    const imageQuiz = within(find('image-quiz').shadowRoot);
+
+    assert.strictEqual(imageQuiz.getByRole('option', { name: 'bad-answer' }).getAttribute('readonly'), null);
+
+    await click(imageQuiz.getByRole('option', { name: 'bad-answer' }));
+    await click(screen.getByRole('button', { name: t('pages.challenge.actions.check') }));
+
+    assert.strictEqual(imageQuiz.getByRole('option', { name: 'bad-answer' }).getAttribute('readonly'), '');
+    assert.strictEqual(imageQuiz.getByRole('option', { name: 'Choix1' }).getAttribute('readonly'), '');
+  });
 });

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -12,7 +12,7 @@
       "devDependencies": {
         "@1024pix/ember-api-actions": "^1.1.0",
         "@1024pix/ember-testing-library": "^3.0.27",
-        "@1024pix/epreuves-components": "^4.1.0",
+        "@1024pix/epreuves-components": "^4.2.0",
         "@1024pix/eslint-plugin": "^2.1.19",
         "@1024pix/pix-ui": "^60.2.0",
         "@1024pix/stylelint-config": "^5.1.37",
@@ -818,11 +818,10 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-4.1.0.tgz",
-      "integrity": "sha512-CdWoNGYUWyUAx8BuJM1bswQKWFxH4U9wdK12vo/Q5/E/AiqmfltxvNK2lc7/csT5jvCPvOamMz70kjEf9/409A==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-4.2.0.tgz",
+      "integrity": "sha512-RIiHRkeLUhC/vUsyy8Cp9fIJnzkNanKqoigraZW/z8O89cMCOdXInEfOW1zNIB386jzqHw1loPVFxJBCxTfLUw==",
       "dev": true,
-      "license": "MIT",
       "peerDependencies": {
         "joi": "^17.0.0 || ^18.0.0"
       }

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@1024pix/ember-api-actions": "^1.1.0",
     "@1024pix/ember-testing-library": "^3.0.27",
-    "@1024pix/epreuves-components": "^4.1.0",
+    "@1024pix/epreuves-components": "^4.2.0",
     "@1024pix/eslint-plugin": "^2.1.19",
     "@1024pix/pix-ui": "^60.2.0",
     "@1024pix/stylelint-config": "^5.1.37",


### PR DESCRIPTION
## 🌎 Problème

Lorsqu'un user envoi sa réponse il n'est pas sensé pouvoir modifier ses choix dans des qcu_image/qcm_image/ etc...

Un version de mode disabled est présente sur les embed mais pas sur les webcomponents.

## 🔭 Proposition

Aves la version epreuve-components 4.2.0 on peu ajouter un readOnly sur les qcu_image et qcm_image qui spont des webcomponent.

Donc autant l'utiliser :)

## 🪐 Remarques

La monté de version 4.2.0 pour les app est présente dans cette PR

## 🚀 Pour tester
Avec NINA c'est compliqué de tester ça, en local c'est plus simple.

Sur les challenge possèdant des webcomponent il faut répondre + appuyer sur le bouton submit. Une fois les réponse envoyé il est normalement plus possible de modifier les choix.

QCU_IMAGE:
[ici](http://localhost:4205/challenges/challenge14pYI4XcHiZR94/preview) challenge: challenge14pYI4XcHiZR94

QCM_IMAGE:
[ici](http://localhost:4205/challenges/challenge2rdpv4KYuPlL6U/preview) challenge: challenge2rdpv4KYuPlL6U
