### PR TITLE
[FEATURE] "Ajouter une adresse e-mail" aux méthodes de connexion pour les utilisateurs uniquement SSO (PIX-21984).

### DIFF
--- a/mon-pix/app/controllers/authenticated/user-account/connection-methods.js
+++ b/mon-pix/app/controllers/authenticated/user-account/connection-methods.js
@@ -38,6 +38,10 @@ export default class ConnectionMethodsController extends Controller {
     );
   }
 
+  get canAddEmailConnectionMethod() {
+    return this.model.accountInfo.canAddEmailConnectionMethod;
+  }
+
   @action
   enableEmailEditionMode() {
     this.isEmailEditionMode = true;

--- a/mon-pix/app/models/account-info.js
+++ b/mon-pix/app/models/account-info.js
@@ -4,4 +4,5 @@ export default class AccountInfo extends Model {
   @attr('string') email;
   @attr('string') username;
   @attr('boolean') canSelfDeleteAccount;
+  @attr('boolean') canAddEmailConnectionMethod;
 }

--- a/mon-pix/app/routes/authenticated/user-account/connection-methods.js
+++ b/mon-pix/app/routes/authenticated/user-account/connection-methods.js
@@ -7,9 +7,11 @@ export default class ConnectionMethodsRoute extends Route {
   async model() {
     const user = this.modelFor('authenticated.user-account');
     const authenticationMethods = await this.store.findAll('authentication-method', user.id);
+    const accountInfo = await user.belongsTo('accountInfo').reload();
     return {
       user,
       authenticationMethods,
+      accountInfo,
     };
   }
 

--- a/mon-pix/app/styles/pages/_connection-methods.scss
+++ b/mon-pix/app/styles/pages/_connection-methods.scss
@@ -36,8 +36,8 @@
 .user-account-panel-item__label {
   display: flex;
   align-items: center;
-  min-width: 200px;
-  margin: 0;
+  width: 250px;
+  margin: 0 var(--pix-spacing-10x) 0 0;
 }
 
 .user-account-panel-item__value {
@@ -49,4 +49,9 @@
 
 .user-account-panel-item__edit-button {
   margin-left: auto;
+}
+
+.user-account-panel-item__add-email-button {
+  align-self: flex-start;
+  max-width: 100%; /* don't overflow the container on small screens */
 }

--- a/mon-pix/app/templates/authenticated/user-account/connection-methods.gjs
+++ b/mon-pix/app/templates/authenticated/user-account/connection-methods.gjs
@@ -68,21 +68,38 @@ import UpdateEmailWithValidation from 'mon-pix/components/user-account/update-em
         </div>
       {{/if}}
 
+      {{#if @controller.canAddEmailConnectionMethod}}
+        <div class="user-account-panel__item">
+          <div class="user-account-panel-item__text">
+            <p class="form-textfield__label user-account-panel-item__label">{{t
+                "pages.user-account.connexion-methods.email"
+              }}</p>
+            <p class="user-account-panel-item__value">
+              —
+            </p>
+          </div>
+          <PixButton class="user-account-panel-item__add-email-button" @size="small">
+            {{t "pages.user-account.connexion-methods.add-email"}}
+          </PixButton>
+        </div>
+      {{/if}}
+
       {{#each @controller.oidcAuthenticationMethodOrganizationNames as |organizationName|}}
         <div class="user-account-panel__item">
           <div class="user-account-panel-item__text">
             <p class="form-textfield__label user-account-panel-item__label">
-              {{t "pages.user-account.connexion-methods.authentication-methods.label"}}
+              {{t "pages.user-account.connexion-methods.authentication-methods.other-authentication-label"}}
             </p>
             <p class="user-account-panel-item__value">
               {{t
-                "pages.user-account.connexion-methods.authentication-methods.via"
+                "pages.user-account.connexion-methods.authentication-methods.connection-via"
                 identityProviderOrganizationName=organizationName
               }}
             </p>
           </div>
         </div>
       {{/each}}
+
     {{/if}}
   </div>
 </template>

--- a/mon-pix/mirage/factories/user.js
+++ b/mon-pix/mirage/factories/user.js
@@ -428,6 +428,15 @@ export default Factory.extend({
       });
     },
   }),
+  withCanAddEmailConnectionMethod: trait({
+    afterCreate(user, server) {
+      user.update({
+        accountInfo: server.create('accountInfo', {
+          canAddEmailConnectionMethod: true,
+        }),
+      });
+    },
+  }),
   afterCreate(user, server) {
     _addDefaultIsCertifiable(user, server);
     _addDefaultScorecards(user, server);

--- a/mon-pix/tests/acceptance/user-account/connection-methods-test.js
+++ b/mon-pix/tests/acceptance/user-account/connection-methods-test.js
@@ -72,8 +72,10 @@ module('Acceptance | user-account | connection-methods', function (hooks) {
       const screen = await visit('/mon-compte/methodes-de-connexion');
 
       // then
-      assert.ok(screen.getByText(t('pages.user-account.connexion-methods.authentication-methods.label')));
-      assert.ok(screen.getByText('via Partenaire OIDC'));
+      assert.ok(
+        screen.getByText(t('pages.user-account.connexion-methods.authentication-methods.other-authentication-label')),
+      );
+      assert.ok(screen.getByText('Connexion via Partenaire OIDC'));
     });
 
     module('e-mail address', function () {
@@ -113,6 +115,36 @@ module('Acceptance | user-account | connection-methods', function (hooks) {
           // then
           assert.dom(screen.queryByText(t('pages.user-account.email-confirmed'))).doesNotExist();
         });
+      });
+    });
+
+    module('when canAddEmailConnectionMethod conditions are true', function () {
+      test('displays empty email label and add email button', async function (assert) {
+        // given
+        server.create('feature-toggle', { id: '0', addEmailConnectionMethodEnabled: true });
+
+        const userDetails = {
+          email: 'only.sso@example.net',
+        };
+        const user = server.create('user', 'withCanAddEmailConnectionMethod', userDetails);
+        server.create('authentication-method', 'withGenericOidcIdentityProvider', { user });
+
+        // when
+        await authenticate(user);
+        const screen = await visit('/mon-compte/methodes-de-connexion');
+
+        // then
+        assert.dom(screen.getByText(t('pages.user-account.connexion-methods.email'))).exists();
+        assert.dom(screen.getByText('—')).exists();
+        assert.dom(screen.getByRole('button', { name: t('pages.user-account.connexion-methods.add-email') })).exists();
+        // other connection methods
+        assert
+          .dom(
+            screen.getByText(
+              t('pages.user-account.connexion-methods.authentication-methods.other-authentication-label'),
+            ),
+          )
+          .exists();
       });
     });
   });

--- a/mon-pix/tests/unit/controllers/authenticated/user-account/connection-methods-test.js
+++ b/mon-pix/tests/unit/controllers/authenticated/user-account/connection-methods-test.js
@@ -138,4 +138,50 @@ module('Unit | Controller | user-account | connection-methods', function (hooks)
       });
     });
   });
+
+  module('#canAddEmailConnectionMethod', function () {
+    module('when feature toggle is enabled and canAddEmailConnectionMethod is true', function () {
+      test('returns true', function (assert) {
+        // given
+        class FeatureTogglesStub extends Service {
+          featureToggles = { addEmailConnectionMethodEnabled: true };
+        }
+        this.owner.register('service:featureToggles', FeatureTogglesStub);
+        const controller = this.owner.lookup('controller:authenticated/user-account/connection-methods');
+        const model = {
+          user: {},
+          accountInfo: { canAddEmailConnectionMethod: true },
+        };
+        controller.set('model', model);
+
+        // when
+        const result = controller.canAddEmailConnectionMethod;
+
+        // then
+        assert.true(result);
+      });
+    });
+
+    module('when feature toggle is enabled and canAddEmailConnectionMethod is false', function () {
+      test('returns false', function (assert) {
+        // given
+        class FeatureTogglesStub extends Service {
+          featureToggles = { addEmailConnectionMethodEnabled: true };
+        }
+        this.owner.register('service:featureToggles', FeatureTogglesStub);
+        const controller = this.owner.lookup('controller:authenticated/user-account/connection-methods');
+        const model = {
+          user: {},
+          accountInfo: { canAddEmailConnectionMethod: false },
+        };
+        controller.set('model', model);
+
+        // when
+        const result = controller.canAddEmailConnectionMethod;
+
+        // then
+        assert.false(result);
+      });
+    });
+  });
 });

--- a/mon-pix/translations/de.json
+++ b/mon-pix/translations/de.json
@@ -2346,10 +2346,12 @@
         "title": "Ändern Ihrer E-Mail-Adresse"
       },
       "connexion-methods": {
+        "add-email": "E-Mail-Adresse hinzufügen",
         "authentication-methods": {
-          "gar": "über ENT/Mediacentre",
+          "connection-via": "Verbindung über {identityProviderOrganizationName}",
+          "gar": "Verbindung über ENT/Mediacentre",
           "label": "Externe Verbindung",
-          "via": "über {identityProviderOrganizationName}"
+          "other-authentication-label": "Eine andere Verbindungsmethode"
         },
         "edit-button": "Bearbeiten",
         "email": "E-Mail-Adresse",

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -2346,10 +2346,12 @@
         "title": "Change your email address"
       },
       "connexion-methods": {
+        "add-email": "Add an email address",
         "authentication-methods": {
-          "gar": "ENT/Mediacentre",
+          "connection-via": "Login via {identityProviderOrganizationName}",
+          "gar": "Login via ENT/Mediacentre",
           "label": "External login",
-          "via": "via {identityProviderOrganizationName}"
+          "other-authentication-label": "Other connection method"
         },
         "edit-button": "Edit",
         "email": "Email address",

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -2333,10 +2333,12 @@
         "title": "Cambio de la dirección de correo electrónico"
       },
       "connexion-methods": {
+        "add-email": "Añadir una dirección de correo electrónico",
         "authentication-methods": {
-          "gar": "a través de ENT/Mediacentre",
+          "connection-via": "Conexión a través de {identityProviderOrganizationName}",
+          "gar": "Conexión a través de ENT/Mediacentre",
           "label": "Conexión externa",
-          "via": "a través de {identityProviderOrganizationName}"
+          "other-authentication-label": "Otro método de conexión"
         },
         "edit-button": "Modificar",
         "email": "Dirección de correo electrónico",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -2348,10 +2348,12 @@
         "title": "Modification de votre adresse e-mail"
       },
       "connexion-methods": {
+        "add-email": "Ajouter une adresse e-mail",
         "authentication-methods": {
-          "gar": "via ENT/Mediacentre",
+          "connection-via": "Connexion via {identityProviderOrganizationName}",
+          "gar": "Connexion via ENT/Mediacentre",
           "label": "Connexion externe",
-          "via": "via {identityProviderOrganizationName}"
+          "other-authentication-label": "Autre méthode de connexion"
         },
         "edit-button": "Modifier",
         "email": "Adresse e-mail",

--- a/mon-pix/translations/it.json
+++ b/mon-pix/translations/it.json
@@ -2339,10 +2339,12 @@
         "title": "Modifica dell'indirizzo e-mail"
       },
       "connexion-methods": {
+        "add-email": "Aggiungi un indirizzo e-mail",
         "authentication-methods": {
-          "gar": "via ENT/Mediacentre",
+          "connection-via": "Connessione tramite {identityProviderOrganizationName}",
+          "gar": "Connessione tramite ENT/Mediacentre",
           "label": "Collegamento esterno",
-          "via": "via {identityProviderOrganizationName}"
+          "other-authentication-label": "Un altro metodo di connessione"
         },
         "edit-button": "Modificare",
         "email": "Indirizzo e-mail",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -2337,10 +2337,12 @@
         "title": "Je e-mailadres wijzigen"
       },
       "connexion-methods": {
+        "add-email": "Een e-mailadres toevoegen",
         "authentication-methods": {
-          "gar": "via ENT/Mediacentre",
+          "connection-via": "Inloggen via {identityProviderOrganizationName}",
+          "gar": "Inloggen via ENT/Mediacentre",
           "label": "Externe aansluiting",
-          "via": "via {identityProviderOrganizationName}"
+          "other-authentication-label": "Een andere manier om verbinding te maken"
         },
         "edit-button": "Bewerk",
         "email": "E-mailadres",


### PR DESCRIPTION
## 🌎 Problème 
Les utilisateurs SSO ayant créé leur compte sans réconciliation avec un compte Pix existant n'ont pas la possibilité d'ajouter une adresse e-mail ultérieurement. 

## 🔭 Proposition
Pour les utilisateurs SSO ne disposant pas d'une adresse e-mail et ayant le droit d'en ajouter une à leur compte, proposer d'ajouter une adresse e-mail. 

## 🚀 Pour tester
- Mettre le feature toggle à true : npm run toggles -- --key=addEmailConnectionMethodEnabled --value=true
- Placer un SSO de votre choix dans la liste des SSO non autorisés : npm run toggles -- --key restrictedOidcProvidersForEmailCreation --value 'SSO_NON_AUTORISE'
- Se connecter à Pix App avec un utilisateur SSO autorisé n'ayant pas d'autre méthode de connexion
- Aller dans Mon Compte puis Méthodes de connexion
- Constater la présence du label Adresse e-mail et d'une valeur vide symbolisée par un trait
- Constater la présence du bouton Ajouter une adresse e-mail.

- Se connecter à Pix App avec un utilisateur ayant  comme seul méthode de connexion  le SSO non autorisé
- Aller dans Mon Compte puis Méthodes de connexion
- Constater l'absence des champs cités au-dessus

🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘 🌑
