### PR TITLE
[FEATURE] Réconcilier des learner issue de l'import générique (PIX-22010)

### DIFF
--- a/api/src/prescription/learner-management/domain/usecases/reconcile-sco-organization-learner-automatically.js
+++ b/api/src/prescription/learner-management/domain/usecases/reconcile-sco-organization-learner-automatically.js
@@ -1,29 +1,54 @@
 import _ from 'lodash';
 
 import { UserCouldNotBeReconciledError } from '../../../../shared/domain/errors.js';
+import { OrganizationLearner } from '../models/OrganizationLearner.js';
 
 const reconcileScoOrganizationLearnerAutomatically = async function ({
   organizationId,
   userId,
   organizationLearnerRepository,
+  organizationLearnerImportFormatRepository,
 }) {
-  const studentOrganizationLearners = await organizationLearnerRepository.findByUserId({ userId });
-  if (_.isEmpty(studentOrganizationLearners)) {
-    throw new UserCouldNotBeReconciledError();
+  const importFormat = await organizationLearnerImportFormatRepository.get(organizationId);
+
+  if (!importFormat) {
+    const studentOrganizationLearners = await organizationLearnerRepository.findByUserId({ userId });
+    if (_.isEmpty(studentOrganizationLearners)) {
+      throw new UserCouldNotBeReconciledError();
+    }
+    const nationalStudentIdForReconcile = _.orderBy(studentOrganizationLearners, 'updatedAt', 'desc')[0]
+      .nationalStudentId;
+
+    if (!nationalStudentIdForReconcile) {
+      throw new UserCouldNotBeReconciledError();
+    }
+
+    return organizationLearnerRepository.reconcileUserByNationalStudentIdAndOrganizationId({
+      userId,
+      nationalStudentId: nationalStudentIdForReconcile,
+      organizationId,
+    });
+  } else {
+    const previousLearners = await organizationLearnerRepository.findByUserId({ userId });
+    if (_.isEmpty(previousLearners)) {
+      throw new UserCouldNotBeReconciledError();
+    }
+    const mostRecentUpdatedLearner = _.orderBy(previousLearners, 'updatedAt', 'desc')[0];
+    const unicityCriteria = importFormat.config?.unicityColumns.reduce((acc, field) => {
+      return { ...acc, [field]: mostRecentUpdatedLearner.attributes[field] };
+    }, {});
+    const matchingLearners = await organizationLearnerRepository.findAllCommonOrganizationLearnerByReconciliationInfos({
+      organizationId,
+      reconciliationInformations: unicityCriteria,
+    });
+    if (matchingLearners.length !== 1) {
+      throw new UserCouldNotBeReconciledError();
+    }
+    const learnerToReconcile = matchingLearners[0];
+    learnerToReconcile.reconcileUser(userId);
+    await organizationLearnerRepository.update(learnerToReconcile);
+    return new OrganizationLearner({ ...learnerToReconcile, ...learnerToReconcile.attributes });
   }
-
-  const nationalStudentIdForReconcile = _.orderBy(studentOrganizationLearners, 'updatedAt', 'desc')[0]
-    .nationalStudentId;
-
-  if (!nationalStudentIdForReconcile) {
-    throw new UserCouldNotBeReconciledError();
-  }
-
-  return organizationLearnerRepository.reconcileUserByNationalStudentIdAndOrganizationId({
-    userId,
-    nationalStudentId: nationalStudentIdForReconcile,
-    organizationId,
-  });
 };
 
 export { reconcileScoOrganizationLearnerAutomatically };

--- a/api/tests/prescription/learner-management/integration/domain/usecases/reconcile-sco-organization-learner-automatically_test.js
+++ b/api/tests/prescription/learner-management/integration/domain/usecases/reconcile-sco-organization-learner-automatically_test.js
@@ -1,43 +1,229 @@
+import { OrganizationLearner } from '../../../../../../src/prescription/learner-management/domain/models/OrganizationLearner.js';
 import { usecases } from '../../../../../../src/prescription/learner-management/domain/usecases/index.js';
+import { ORGANIZATION_FEATURE } from '../../../../../../src/shared/domain/constants.js';
 import { UserCouldNotBeReconciledError } from '../../../../../../src/shared/domain/errors.js';
 import { catchErr, databaseBuilder, expect } from '../../../../../test-helper.js';
 
 describe('Integration | UseCases | reconcile-sco-organization-learner-automatically', function () {
-  context('When user has no nationalStudentId', function () {
-    it('should throw a UserCouldNotBeReconciledError code error', async function () {
-      // when
-      const organization = databaseBuilder.factory.buildOrganization();
-      const user = databaseBuilder.factory.buildUser();
+  context('When organization has learner import feature', function () {
+    context('When organisation learner is found', function () {
+      it('should reconcile learner', async function () {
+        // when
+        const learnerImportFeatureId = databaseBuilder.factory.buildFeature(ORGANIZATION_FEATURE.LEARNER_IMPORT).id;
+        const importFormat = databaseBuilder.factory.buildOrganizationLearnerImportFormat({
+          name: 'GENERIC',
+          fileType: 'csv',
+          config: {
+            acceptedEncoding: ['utf-8'],
+            unicityColumns: ['ine'],
+            headers: [
+              { name: 'Nom', required: true, config: { property: 'lastName' } },
+              { name: 'Prénom', required: true, config: { property: 'firstName' } },
+              { name: 'Date de naissance', required: true, config: { attributeProperty: 'birthdate' } },
+              { name: 'INE', required: true, config: { attributeProperty: 'ine' } },
+            ],
+          },
+        });
+        const organizationId = databaseBuilder.factory.buildOrganization().id;
+        databaseBuilder.factory.buildOrganizationFeature({
+          organizationId,
+          featureId: learnerImportFeatureId,
+          params: { organizationLearnerImportFormatId: importFormat.id },
+        });
+        const userId = databaseBuilder.factory.buildUser().id;
 
-      databaseBuilder.factory.buildOrganizationLearner({
-        userId: user.id,
-        nationalStudentId: null,
-        firstName: 'old-learner-in-orga-without-import',
+        const learner = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId,
+          userId: null,
+          firstName: 'Hélo',
+          lastName: 'de Die',
+          attributes: {
+            ine: '1234',
+          },
+        });
+
+        // least recent learner in other organization
+        databaseBuilder.factory.buildOrganizationLearner({
+          userId: userId,
+          firstName: 'Hélo',
+          lastName: 'de Die',
+          attributes: {
+            ine: '1234',
+          },
+          updatedAt: '2025-01-13',
+        });
+        // most recent learner in other organization
+        databaseBuilder.factory.buildOrganizationLearner({
+          userId: userId,
+          firstName: 'Hélo',
+          lastName: 'de Die',
+          attributes: {
+            ine: '1234',
+          },
+          updatedAt: '2025-05-21',
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const result = await usecases.reconcileScoOrganizationLearnerAutomatically({
+          userId: userId,
+          organizationId,
+        });
+        expect(result).to.be.instanceOf(OrganizationLearner);
+        expect(result).deep.equal(
+          new OrganizationLearner({
+            id: learner.id,
+            firstName: learner.firstName,
+            lastName: learner.lastName,
+            organizationId,
+            birthdate: learner.attributes.birthdate,
+            userId,
+            attributes: learner.attributes,
+          }),
+        );
       });
+    });
+    context('When there is no previous learners', function () {
+      it('should throw a UserCouldNotBeReconciledError code error', async function () {
+        // when
+        const learnerImportFeatureId = databaseBuilder.factory.buildFeature(ORGANIZATION_FEATURE.LEARNER_IMPORT).id;
+        const importFormat = databaseBuilder.factory.buildOrganizationLearnerImportFormat({
+          name: 'GENERIC',
+          fileType: 'csv',
+          config: {
+            acceptedEncoding: ['utf-8'],
+            unicityColumns: ['ine'],
+            headers: [
+              { name: 'Nom', required: true, config: { property: 'lastName' } },
+              { name: 'Prénom', required: true, config: { property: 'firstName' } },
+              { name: 'Date de naissance', required: true, config: { attributeProperty: 'birthdate' } },
+              { name: 'INE', required: true, config: { attributeProperty: 'ine' } },
+            ],
+          },
+        });
+        const organizationId = databaseBuilder.factory.buildOrganization().id;
+        databaseBuilder.factory.buildOrganizationFeature({
+          organizationId,
+          featureId: learnerImportFeatureId,
+          params: { organizationLearnerImportFormatId: importFormat.id },
+        });
+        const userId = databaseBuilder.factory.buildUser().id;
 
-      databaseBuilder.factory.buildOrganizationLearner({
-        organizationId: organization.id,
-        userId: null,
-        nationalStudentId: '1234',
-        firstName: 'new-learner-in-sco-with-import',
+        databaseBuilder.factory.buildOrganizationLearner({
+          organizationId,
+          userId: null,
+          firstName: 'Hélo',
+          lastName: 'de Die',
+          attributes: {
+            ine: '1234',
+          },
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const error = await catchErr(usecases.reconcileScoOrganizationLearnerAutomatically)({
+          userId: userId,
+          organizationId,
+        });
+        expect(error).to.be.instanceOf(UserCouldNotBeReconciledError);
       });
-      databaseBuilder.factory.buildOrganizationLearner({
-        organizationId: organization.id,
-        userId: null,
-        nationalStudentId: null,
-        firstName: '(anonymised)',
-        deletedAt: new Date(),
+    });
+
+    context('When there is no matching learners', function () {
+      it('should throw a UserCouldNotBeReconciledError code error', async function () {
+        // when
+        const learnerImportFeatureId = databaseBuilder.factory.buildFeature(ORGANIZATION_FEATURE.LEARNER_IMPORT).id;
+        const importFormat = databaseBuilder.factory.buildOrganizationLearnerImportFormat({
+          name: 'GENERIC',
+          fileType: 'csv',
+          config: {
+            acceptedEncoding: ['utf-8'],
+            unicityColumns: ['ine'],
+            headers: [
+              { name: 'Nom', required: true, config: { property: 'lastName' } },
+              { name: 'Prénom', required: true, config: { property: 'firstName' } },
+              { name: 'Date de naissance', required: true, config: { attributeProperty: 'birthdate' } },
+              { name: 'INE', required: true, config: { attributeProperty: 'ine' } },
+            ],
+          },
+        });
+        const organizationId = databaseBuilder.factory.buildOrganization().id;
+        databaseBuilder.factory.buildOrganizationFeature({
+          organizationId,
+          featureId: learnerImportFeatureId,
+          params: { organizationLearnerImportFormatId: importFormat.id },
+        });
+        const userId = databaseBuilder.factory.buildUser().id;
+
+        databaseBuilder.factory.buildOrganizationLearner({
+          organizationId,
+          userId: null,
+          firstName: 'Hélo',
+          lastName: 'de Die',
+          attributes: {
+            ine: '9876',
+          },
+        });
+
+        databaseBuilder.factory.buildOrganizationLearner({
+          userId: userId,
+          firstName: 'Hélo',
+          lastName: 'de Die',
+          attributes: {
+            ine: '1234',
+          },
+          updatedAt: '2025-05-21',
+        });
+        await databaseBuilder.commit();
+
+        // when
+        const error = await catchErr(usecases.reconcileScoOrganizationLearnerAutomatically)({
+          userId: userId,
+          organizationId,
+        });
+        expect(error).to.be.instanceOf(UserCouldNotBeReconciledError);
       });
+    });
+  });
+  context("When organization don't rely learner import feature", function () {
+    context('When user has no nationalStudentId', function () {
+      it('should throw a UserCouldNotBeReconciledError code error', async function () {
+        // when
+        const organization = databaseBuilder.factory.buildOrganization();
+        const user = databaseBuilder.factory.buildUser();
 
-      await databaseBuilder.commit();
+        databaseBuilder.factory.buildOrganizationLearner({
+          userId: user.id,
+          nationalStudentId: null,
+          firstName: 'old-learner-in-orga-without-import',
+        });
 
-      const error = await catchErr(usecases.reconcileScoOrganizationLearnerAutomatically)({
-        organizationId: organization.id,
-        userId: user.id,
+        databaseBuilder.factory.buildOrganizationLearner({
+          organizationId: organization.id,
+          userId: null,
+          nationalStudentId: '1234',
+          firstName: 'new-learner-in-sco-with-import',
+        });
+        databaseBuilder.factory.buildOrganizationLearner({
+          organizationId: organization.id,
+          userId: null,
+          nationalStudentId: null,
+          firstName: '(anonymised)',
+          deletedAt: new Date(),
+        });
+
+        await databaseBuilder.commit();
+
+        const error = await catchErr(usecases.reconcileScoOrganizationLearnerAutomatically)({
+          organizationId: organization.id,
+          userId: user.id,
+        });
+
+        // then
+        expect(error).to.be.instanceof(UserCouldNotBeReconciledError);
       });
-
-      // then
-      expect(error).to.be.instanceof(UserCouldNotBeReconciledError);
     });
   });
 });

--- a/api/tests/prescription/learner-management/unit/domain/usecases/reconcile-sco-organization-learner-automatically_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/usecases/reconcile-sco-organization-learner-automatically_test.js
@@ -9,6 +9,7 @@ describe('Unit | UseCase | reconcile-sco-organization-learner-automatically', fu
   let organizationLearner;
   let userId;
   let organizationLearnerRepository;
+  let organizationLearnerImportFormatRepository;
   const organizationId = 1;
   const organizationLearnerId = 1;
   const nationalStudentId = '123456789AZ';
@@ -21,6 +22,8 @@ describe('Unit | UseCase | reconcile-sco-organization-learner-automatically', fu
       nationalStudentId,
     });
 
+    organizationLearnerImportFormatRepository = { get: sinon.stub() };
+    organizationLearnerImportFormatRepository.get.resolves(null);
     organizationLearnerRepository = {
       reconcileUserByNationalStudentIdAndOrganizationId: sinon.stub(),
       findByUserId: sinon.stub(),
@@ -40,6 +43,7 @@ describe('Unit | UseCase | reconcile-sco-organization-learner-automatically', fu
         userId,
         organizationId,
         organizationLearnerRepository,
+        organizationLearnerImportFormatRepository,
       });
 
       // then
@@ -59,6 +63,7 @@ describe('Unit | UseCase | reconcile-sco-organization-learner-automatically', fu
         userId,
         organizationId,
         organizationLearnerRepository,
+        organizationLearnerImportFormatRepository,
       });
 
       // then
@@ -78,6 +83,7 @@ describe('Unit | UseCase | reconcile-sco-organization-learner-automatically', fu
         userId,
         organizationId,
         organizationLearnerRepository,
+        organizationLearnerImportFormatRepository,
       });
 
       // then
@@ -115,6 +121,7 @@ describe('Unit | UseCase | reconcile-sco-organization-learner-automatically', fu
         userId,
         organizationId,
         organizationLearnerRepository,
+        organizationLearnerImportFormatRepository,
       });
 
       // then


### PR DESCRIPTION
## 🌎 Problème

Actuellement, la réconciliation automatique ne prend pas en compte les données issue de l'import génériques (celles stockées dans le champs `attributes`). Cela nous empeche de basculer l'import de fichier CSV du sco sur le système d'import générique.

## 🔭 Proposition

Utiliser les données de l'import générique si l'organization à cette fonctionnalité d'activée pour réaliser les réconciliation auto 
<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 🪐 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🚀 Pour tester

ÇAY COMPLIQUÉ <!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. [ ] Documentation de la fonctionnalité (lien) -->

