### PR TITLE
[TECH] Enlever le FT multipleLocalesForTrainingsEnabled de l'API (PIX-22002)(PIX-21691)

### DIFF
--- a/api/config/feature-toggles-config.js
+++ b/api/config/feature-toggles-config.js
@@ -94,13 +94,6 @@ export default {
     devDefaultValues: { test: true, reviewApp: true },
     tags: ['captain', 'backend', 'transactions'],
   },
-  multipleLocalesForTrainingsEnabled: {
-    type: 'boolean',
-    description: 'Enable trainings with multiple locales',
-    defaultValue: false,
-    devDefaultValues: { test: false, reviewApp: true },
-    tags: ['team-devcomp', 'pix-api', 'pix-admin', 'frontend', 'backend'],
-  },
   isAuditLoggingEnabled: {
     type: 'boolean',
     description: 'Enable sending audit logs to audit logger application',

--- a/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
+++ b/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
@@ -30,7 +30,6 @@ describe('Acceptance | Shared | Application | Controller | feature-toggle', func
             'use-pix-orga-new-auth-design': false,
             'is-pix-plus-candidate-a11y-enabled': false,
             'are-module-short-id-urls-enabled': false,
-            'multiple-locales-for-trainings-enabled': false,
             'add-email-connection-method-enabled': false,
           },
         },


### PR DESCRIPTION
## 🌎 Problème

Le FT `multipleLocalesForTrainingsEnabled` n'est plus utilisé côté front.

## 🔭 Proposition

Supprimer ce FT côté API.

## 🪐 Remarques

- Est-ce qu'il y a des actions à faire pour enlever ce FT de pix-exploit ?

## 🚀 Pour tester
✅CI au vert

### Test de non régression
- Se rendre dans [PixAdmin](https://admin-pr15645.review.pix.fr/)
- Ouvrir un CF, le modifier, enregistrer les modifications
- Les modifications sont bien prises en comptes

🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘 🌑
