### PR TITLE
[BUGFIX] Certaines methodes de connexion SSO non visibles dans Pix Admin (PIX-22071)

### DIFF
--- a/api/src/identity-access-management/application/oidc-provider/oidc-provider.admin.controller.js
+++ b/api/src/identity-access-management/application/oidc-provider/oidc-provider.admin.controller.js
@@ -21,8 +21,9 @@ async function createInBatch(request, h) {
  * @return {Promise<*>}
  */
 async function getAllIdentityProvidersForAdmin(request, h) {
-  const identityProviders = await usecases.getAllIdentityProviders();
-  return h.response(oidcProviderSerializer.serialize(identityProviders)).code(200);
+  const allIdentityProviders = await usecases.getAllIdentityProviders();
+  const uniqueIdentityProviders = allIdentityProviders.filter((provider) => !provider.connectionMethodCode);
+  return h.response(oidcProviderSerializer.serialize(uniqueIdentityProviders)).code(200);
 }
 
 /**

--- a/api/tests/identity-access-management/acceptance/application/oidc-provider.admin.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/oidc-provider.admin.route.test.js
@@ -78,13 +78,11 @@ describe('Acceptance | Identity Access Management | Route | Admin | oidc-provide
   });
 
   describe('GET /api/admin/oidc/identity-providers', function () {
-    beforeEach(async function () {
-      await createMockedTestOidcProviders([{ application: 'admin', applicationTld: '.fr' }]);
-      server = await createServer();
-    });
-
     it('returns the list of all oidc providers with an HTTP status code 200', async function () {
       // given
+      await createMockedTestOidcProviders([{ application: 'admin', applicationTld: '.fr' }]);
+      server = await createServer();
+
       const superAdmin = await insertUserWithRoleSuperAdmin();
       const options = {
         method: 'GET',
@@ -111,6 +109,45 @@ describe('Acceptance | Identity Access Management | Route | Admin | oidc-provide
           },
         },
       ]);
+    });
+
+    context('when there is a provider referencing another one with connectionMethodCode setting', function () {
+      it('returns only the referenced oidc provider', async function () {
+        // given
+        await createMockedTestOidcProviders([
+          {
+            identityProvider: 'IDP_1',
+            slug: 'idp-1',
+            source: 'IDP_1',
+            application: 'app',
+            applicationTld: '.fr',
+          },
+          {
+            identityProvider: 'IDP_2',
+            slug: 'idp-2',
+            source: 'IDP_2',
+            application: 'app',
+            applicationTld: '.fr',
+            connectionMethodCode: 'IDP_1',
+          },
+        ]);
+        server = await createServer();
+
+        const superAdmin = await insertUserWithRoleSuperAdmin();
+        const options = {
+          method: 'GET',
+          url: '/api/admin/oidc/identity-providers',
+          headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
+        };
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(200);
+        expect(response.result.data.length).to.equal(1);
+        expect(response.result.data.at(0).id).to.equal('idp-1');
+      });
     });
   });
 

--- a/api/tests/identity-access-management/acceptance/application/oidc-provider.admin.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/oidc-provider.admin.route.test.js
@@ -10,7 +10,7 @@ import {
   insertUserWithRoleSuperAdmin,
   knex,
 } from '../../../test-helper.js';
-import { createMockedTestOidcProvider } from '../../../tooling/openid-client/openid-client-mocks.js';
+import { createMockedTestOidcProviders } from '../../../tooling/openid-client/openid-client-mocks.js';
 
 describe('Acceptance | Identity Access Management | Route | Admin | oidc-provider', function () {
   let server;
@@ -79,7 +79,7 @@ describe('Acceptance | Identity Access Management | Route | Admin | oidc-provide
 
   describe('GET /api/admin/oidc/identity-providers', function () {
     beforeEach(async function () {
-      await createMockedTestOidcProvider({ application: 'admin', applicationTld: '.fr' });
+      await createMockedTestOidcProviders([{ application: 'admin', applicationTld: '.fr' }]);
       server = await createServer();
     });
 
@@ -116,7 +116,7 @@ describe('Acceptance | Identity Access Management | Route | Admin | oidc-provide
 
   describe('POST /api/admin/oidc/user/reconcile', function () {
     beforeEach(async function () {
-      await createMockedTestOidcProvider({ application: 'admin', applicationTld: '.fr' });
+      await createMockedTestOidcProviders([{ application: 'admin', applicationTld: '.fr' }]);
       server = await createServer();
     });
 
@@ -193,18 +193,20 @@ describe('Acceptance | Identity Access Management | Route | Admin | oidc-provide
 
   context('when the OIDC provider has a connectionMethodCode', function () {
     beforeEach(async function () {
-      await createMockedTestOidcProvider({ application: 'admin', applicationTld: '.fr' });
+      await createMockedTestOidcProviders([{ application: 'admin', applicationTld: '.fr' }]);
       server = await createServer();
     });
 
     describe('POST /api/admin/oidc/user/reconcile', function () {
       beforeEach(async function () {
-        await createMockedTestOidcProvider({
-          application: 'admin',
-          applicationTld: '.fr',
-          identityProvider: 'OIDC_EXAMPLE_NET-ADMIN',
-          connectionMethodCode: 'OIDC_EXAMPLE_NET',
-        });
+        await createMockedTestOidcProviders([
+          {
+            application: 'admin',
+            applicationTld: '.fr',
+            identityProvider: 'OIDC_EXAMPLE_NET-ADMIN',
+            connectionMethodCode: 'OIDC_EXAMPLE_NET',
+          },
+        ]);
         server = await createServer();
       });
 

--- a/api/tests/identity-access-management/acceptance/application/oidc-provider.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/oidc-provider.route.test.js
@@ -12,7 +12,7 @@ import {
   generateAuthenticatedUserRequestHeaders,
   knex,
 } from '../../../test-helper.js';
-import { createMockedTestOidcProvider } from '../../../tooling/openid-client/openid-client-mocks.js';
+import { createMockedTestOidcProviders } from '../../../tooling/openid-client/openid-client-mocks.js';
 
 const UUID_PATTERN = new RegExp(/^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i);
 
@@ -890,13 +890,17 @@ describe('Acceptance | Identity Access Management | Application | Route | oidc-p
     connectionMethodCode,
     postLogoutRedirectUri,
   }) {
-    openidClientMock = await createMockedTestOidcProvider({
-      application,
-      applicationTld,
-      identityProvider,
-      connectionMethodCode,
-      postLogoutRedirectUri,
-    });
+    const openidClientMocks = await createMockedTestOidcProviders([
+      {
+        application,
+        applicationTld,
+        identityProvider,
+        connectionMethodCode,
+        postLogoutRedirectUri,
+      },
+    ]);
+
+    openidClientMock = openidClientMocks.at(0);
     server = await createServer();
   }
 });

--- a/api/tests/identity-access-management/integration/application/oidc-provider.route.test.js
+++ b/api/tests/identity-access-management/integration/application/oidc-provider.route.test.js
@@ -20,7 +20,7 @@ import {
   HttpTestServer,
   sinon,
 } from '../../../test-helper.js';
-import { createMockedTestOidcProvider } from '../../../tooling/openid-client/openid-client-mocks.js';
+import { createMockedTestOidcProviders } from '../../../tooling/openid-client/openid-client-mocks.js';
 
 const routesUnderTest = identityAccessManagementRoutes[0];
 
@@ -264,11 +264,13 @@ describe('Integration | Identity Access Management | Application | Route | oidc-
         };
 
         const identityProvider = 'OIDC_LOGOUT_EXAMPLE_NET';
-        const openIdClientMock = await createMockedTestOidcProvider({
-          application: 'orga',
-          applicationTld: '.org',
-          identityProvider,
-        });
+        const [openIdClientMock] = await createMockedTestOidcProviders([
+          {
+            application: 'orga',
+            applicationTld: '.org',
+            identityProvider,
+          },
+        ]);
 
         openIdClientMock.buildEndSessionUrl.throws(new Error('Client Error: Wrong token hint'));
 

--- a/api/tests/tooling/openid-client/openid-client-mocks.js
+++ b/api/tests/tooling/openid-client/openid-client-mocks.js
@@ -50,49 +50,61 @@ function createOpenIdClientMock(oidcProviderConfig = Symbol('oidcProviderConfig'
   };
 }
 
-async function createMockedTestOidcProvider({
-  application,
-  applicationTld,
-  connectionMethodCode,
-  identityProvider = 'OIDC_EXAMPLE_NET',
-  postLogoutRedirectUri,
-}) {
-  const openidClientMock = createOpenIdClientMock(openIdConfigurationResponse);
+async function createMockedTestOidcProviders(mockedProviders) {
+  const openidClientMocks = [];
+  const oidcAuthenticationServices = [];
 
-  const redirectUri = `https://${application}.dev.pix${applicationTld}/connexion/oidc-example-net`;
+  for (const mockedProvider of mockedProviders) {
+    const {
+      application,
+      applicationTld,
+      connectionMethodCode,
+      identityProvider = 'OIDC_EXAMPLE_NET',
+      slug = 'oidc-example-net',
+      source = 'oidcexamplenet',
+      postLogoutRedirectUri,
+    } = mockedProvider;
 
-  const authorizationUrl = `${openIdConfigurationResponse.authorization_endpoint}?client_id=${clientId}&redirect_uri=${redirectUri}&response_type=code&scope=${scope}&state=state&nonce=nonce`;
-  openidClientMock.buildAuthorizationUrl.returns(authorizationUrl);
+    const openidClientMock = createOpenIdClientMock(openIdConfigurationResponse);
 
-  const endSessionUrl = `${openIdConfigurationResponse.end_session_endpoint}?client_id=${clientId}`;
-  openidClientMock.buildEndSessionUrl.returns(endSessionUrl);
+    const redirectUri = `https://${application}.dev.pix${applicationTld}/connexion/oidc-example-net`;
 
-  await oidcAuthenticationServiceRegistry.testOnly_reset([
-    new OidcAuthenticationService(
-      {
-        accessTokenLifespanMs: 60000,
-        application,
-        applicationTld,
-        clientId,
-        clientSecret: 'secret',
-        connectionMethodCode,
-        enabled: true,
-        enabledForPixAdmin: true,
-        configKey: 'oidcExampleNet',
-        shouldCloseSession: true,
-        identityProvider,
-        openidConfigurationUrl: 'https://oidc.example.net/.well-known/openid-configuration',
-        organizationName: 'OIDC Example',
-        redirectUri,
-        slug: 'oidc-example-net',
-        source: 'oidcexamplenet',
-        postLogoutRedirectUri,
-      },
-      { openidClient: openidClientMock },
-    ),
-  ]);
+    const authorizationUrl = `${openIdConfigurationResponse.authorization_endpoint}?client_id=${clientId}&redirect_uri=${redirectUri}&response_type=code&scope=${scope}&state=state&nonce=nonce`;
+    openidClientMock.buildAuthorizationUrl.returns(authorizationUrl);
 
-  return openidClientMock;
+    const endSessionUrl = `${openIdConfigurationResponse.end_session_endpoint}?client_id=${clientId}`;
+    openidClientMock.buildEndSessionUrl.returns(endSessionUrl);
+
+    openidClientMocks.push(openidClientMock);
+    oidcAuthenticationServices.push(
+      new OidcAuthenticationService(
+        {
+          accessTokenLifespanMs: 60000,
+          application,
+          applicationTld,
+          clientId,
+          clientSecret: 'secret',
+          connectionMethodCode,
+          enabled: true,
+          enabledForPixAdmin: true,
+          configKey: 'oidcExampleNet',
+          shouldCloseSession: true,
+          identityProvider,
+          openidConfigurationUrl: 'https://oidc.example.net/.well-known/openid-configuration',
+          organizationName: 'OIDC Example',
+          redirectUri,
+          slug,
+          source,
+          postLogoutRedirectUri,
+        },
+        { openidClient: openidClientMock },
+      ),
+    );
+  }
+
+  await oidcAuthenticationServiceRegistry.testOnly_reset(oidcAuthenticationServices);
+
+  return openidClientMocks;
 }
 
-export { createMockedTestOidcProvider, createOpenIdClientMock };
+export { createMockedTestOidcProviders, createOpenIdClientMock };


### PR DESCRIPTION
## 🌎 Problème

Certains méthode de connexion SSO ne sont pas visibles sur les fiches utilisateurs.

## 🔭 Proposition

Le problème vient des identity providers retournés par l'appel: `GET /api/admin/oidc/identity-providers`. À la sérialisation des oidc providers, le `slug` est utilisé en tant qu'`id` pour les ressources. Or le `slug` n'est plus unique, puisqu'il peut être le même pour plusieurs applications, quand un provider en référence un autre via `connectionMethodCode`.

Changer l'`id` du `slug` au `code` est **très impactant sur l'ensemble des fronts et sur leurs flows de connexion SSO**, car le serialiser est le même pour récupérer les OIDC providers dans les différentes apps.

**Afin de corriger le problème côté Pix Admin avec un minimum d'impact, nous allons exclure les providers qui ont le même slug,** c'est à dire ceux qui ont l'attribut `connectionMethodCode` référençant un autre oidc provider. 

Dans un autre ticket nous ferons en sorte de changer l'`id` du `slug` par le `code`.

## 🪐 Remarques

Modification du système de mock des oidc provider pour les tests d'acceptance (`createMockedTestOidcProvider(oidcProvider)`) qui ne permettait pas de mocker plusieurs OIDC Providers.

Maintenant il le permet : 
```
await createMockedTestOidcProviders([oidcProvider1, oidcProvider2]);
```

## 🚀 Pour tester

1. Charger la dernière version des providers.
2. Se connecter à Pix App avec un des providers qui pose problème. (voir le ticket)
3. Se connecter à Pix Admin et vérifier que le provider est visible dans la fiche de l'utilisateur précédemment créé.
