### PR TITLE
[FEATURE] Créer un script pour migrer les données des apprenants avec imports dans attributes (Pix-22015).

### DIFF
--- a/api/src/prescription/scripts/delete-and-anonymise-organization-learners.js
+++ b/api/src/prescription/scripts/delete-and-anonymise-organization-learners.js
@@ -1,9 +1,9 @@
-import { knex } from '../../db/knex-database-connection.js';
-import { CLIENTS, PIX_ADMIN } from '../../src/authorization/domain/constants.js';
-import { usecases } from '../../src/prescription/learner-management/domain/usecases/index.js';
-import { commaSeparatedNumberParser } from '../../src/shared/application/scripts/parsers.js';
-import { Script } from '../../src/shared/application/scripts/script.js';
-import { ScriptRunner } from '../../src/shared/application/scripts/script-runner.js';
+import { knex } from '../../../db/knex-database-connection.js';
+import { CLIENTS, PIX_ADMIN } from '../../authorization/domain/constants.js';
+import { commaSeparatedNumberParser } from '../../shared/application/scripts/parsers.js';
+import { Script } from '../../shared/application/scripts/script.js';
+import { ScriptRunner } from '../../shared/application/scripts/script-runner.js';
+import { usecases } from '../learner-management/domain/usecases/index.js';
 // Définition du script
 export class DeleteAndAnonymiseOrganizationLearnerScript extends Script {
   constructor() {

--- a/api/src/prescription/scripts/delete-and-anonymise-previous-archive-organization.js
+++ b/api/src/prescription/scripts/delete-and-anonymise-previous-archive-organization.js
@@ -1,8 +1,8 @@
-import { usecases as campaignUsecases } from '../../src/prescription/campaign/domain/usecases/index.js';
-import { usecases as learnerManagementUsecases } from '../../src/prescription/learner-management/domain/usecases/index.js';
-import { Script } from '../../src/shared/application/scripts/script.js';
-import { ScriptRunner } from '../../src/shared/application/scripts/script-runner.js';
-import { DomainTransaction } from '../../src/shared/domain/DomainTransaction.js';
+import { Script } from '../../shared/application/scripts/script.js';
+import { ScriptRunner } from '../../shared/application/scripts/script-runner.js';
+import { DomainTransaction } from '../../shared/domain/DomainTransaction.js';
+import { usecases as campaignUsecases } from '../campaign/domain/usecases/index.js';
+import { usecases as learnerManagementUsecases } from '../learner-management/domain/usecases/index.js';
 
 export class DeleteAndAnonymisePreviousOrganizationScript extends Script {
   constructor() {

--- a/api/src/prescription/scripts/delete-and-anonymise-previous-campaigns.js
+++ b/api/src/prescription/scripts/delete-and-anonymise-previous-campaigns.js
@@ -1,9 +1,9 @@
-import { knex } from '../../db/knex-database-connection.js';
-import { CLIENTS, PIX_ADMIN } from '../../src/authorization/domain/constants.js';
-import { usecases as campaignUsecases } from '../../src/prescription/campaign/domain/usecases/index.js';
-import { Script } from '../../src/shared/application/scripts/script.js';
-import { ScriptRunner } from '../../src/shared/application/scripts/script-runner.js';
-import { DomainTransaction } from '../../src/shared/domain/DomainTransaction.js';
+import { knex } from '../../../db/knex-database-connection.js';
+import { CLIENTS, PIX_ADMIN } from '../../authorization/domain/constants.js';
+import { Script } from '../../shared/application/scripts/script.js';
+import { ScriptRunner } from '../../shared/application/scripts/script-runner.js';
+import { DomainTransaction } from '../../shared/domain/DomainTransaction.js';
+import { usecases as campaignUsecases } from '../campaign/domain/usecases/index.js';
 
 export class DeleteAndAnonymisePreviousCampaignsScript extends Script {
   constructor() {

--- a/api/src/prescription/scripts/delete-and-anonymise-previous-organization-learners.js
+++ b/api/src/prescription/scripts/delete-and-anonymise-previous-organization-learners.js
@@ -1,9 +1,9 @@
-import { knex } from '../../db/knex-database-connection.js';
-import { CLIENTS, PIX_ADMIN } from '../../src/authorization/domain/constants.js';
-import { usecases as learnerManagementUsecases } from '../../src/prescription/learner-management/domain/usecases/index.js';
-import { Script } from '../../src/shared/application/scripts/script.js';
-import { ScriptRunner } from '../../src/shared/application/scripts/script-runner.js';
-import { DomainTransaction } from '../../src/shared/domain/DomainTransaction.js';
+import { knex } from '../../../db/knex-database-connection.js';
+import { CLIENTS, PIX_ADMIN } from '../../authorization/domain/constants.js';
+import { Script } from '../../shared/application/scripts/script.js';
+import { ScriptRunner } from '../../shared/application/scripts/script-runner.js';
+import { DomainTransaction } from '../../shared/domain/DomainTransaction.js';
+import { usecases as learnerManagementUsecases } from '../learner-management/domain/usecases/index.js';
 
 export class DeleteAndAnonymisePreviousOrganizationLearnersScript extends Script {
   constructor() {

--- a/api/src/prescription/scripts/delete-and-anonymise-previous-participations.js
+++ b/api/src/prescription/scripts/delete-and-anonymise-previous-participations.js
@@ -1,9 +1,9 @@
-import { knex } from '../../db/knex-database-connection.js';
-import { CLIENTS, PIX_ADMIN } from '../../src/authorization/domain/constants.js';
-import { usecases } from '../../src/prescription/campaign-participation/domain/usecases/index.js';
-import { Script } from '../../src/shared/application/scripts/script.js';
-import { ScriptRunner } from '../../src/shared/application/scripts/script-runner.js';
-import { DomainTransaction } from '../../src/shared/domain/DomainTransaction.js';
+import { knex } from '../../../db/knex-database-connection.js';
+import { CLIENTS, PIX_ADMIN } from '../../authorization/domain/constants.js';
+import { Script } from '../../shared/application/scripts/script.js';
+import { ScriptRunner } from '../../shared/application/scripts/script-runner.js';
+import { DomainTransaction } from '../../shared/domain/DomainTransaction.js';
+import { usecases } from '../campaign-participation/domain/usecases/index.js';
 
 export class DeleteAndAnonymisePreviousCampaignParticipationsScript extends Script {
   constructor() {

--- a/api/src/prescription/scripts/delete-and-anonymize-organization-learner-participations-from-combined-courses.js
+++ b/api/src/prescription/scripts/delete-and-anonymize-organization-learner-participations-from-combined-courses.js
@@ -1,7 +1,7 @@
-import { usecases } from '../../src/quest/domain/usecases/index.js';
-import { Script } from '../../src/shared/application/scripts/script.js';
-import { ScriptRunner } from '../../src/shared/application/scripts/script-runner.js';
-import { DomainTransaction } from '../../src/shared/domain/DomainTransaction.js';
+import { usecases } from '../../quest/domain/usecases/index.js';
+import { Script } from '../../shared/application/scripts/script.js';
+import { ScriptRunner } from '../../shared/application/scripts/script-runner.js';
+import { DomainTransaction } from '../../shared/domain/DomainTransaction.js';
 
 // Définition du script
 export class DeleteAndAnonymizeOrganizationLearnerParticipationsScript extends Script {

--- a/api/src/prescription/scripts/delete-organization-learners-from-organization.js
+++ b/api/src/prescription/scripts/delete-organization-learners-from-organization.js
@@ -1,8 +1,8 @@
-import { USER_RECOMMENDED_TRAININGS_TABLE_NAME } from '../../db/migrations/20221017085933_create-user-recommended-trainings.js';
-import { usecases } from '../../src/prescription/learner-management/domain/usecases/index.js';
-import { Script } from '../../src/shared/application/scripts/script.js';
-import { ScriptRunner } from '../../src/shared/application/scripts/script-runner.js';
-import { DomainTransaction } from '../../src/shared/domain/DomainTransaction.js';
+import { USER_RECOMMENDED_TRAININGS_TABLE_NAME } from '../../../db/migrations/20221017085933_create-user-recommended-trainings.js';
+import { Script } from '../../shared/application/scripts/script.js';
+import { ScriptRunner } from '../../shared/application/scripts/script-runner.js';
+import { DomainTransaction } from '../../shared/domain/DomainTransaction.js';
+import { usecases } from '../learner-management/domain/usecases/index.js';
 
 export class DeleteOrganizationLearnersFromOrganizationScript extends Script {
   constructor() {

--- a/api/src/prescription/scripts/insert-missing-pole-emploi-sending-from-date.js
+++ b/api/src/prescription/scripts/insert-missing-pole-emploi-sending-from-date.js
@@ -2,20 +2,20 @@ import * as url from 'node:url';
 
 import dayjs from 'dayjs';
 
-import { disconnect, knex } from '../../db/knex-database-connection.js';
-import * as badgeAcquisitionRepository from '../../src/evaluation/infrastructure/repositories/badge-acquisition-repository.js';
-import * as badgeRepository from '../../src/evaluation/infrastructure/repositories/badge-repository.js';
-import * as userRepository from '../../src/identity-access-management/infrastructure/repositories/user.repository.js';
-import * as campaignRepository from '../../src/prescription/campaign/infrastructure/repositories/campaign-repository.js';
-import { PoleEmploiSending } from '../../src/prescription/campaign-participation/domain/models/PoleEmploiSending.js';
-import { PoleEmploiPayload } from '../../src/prescription/campaign-participation/infrastructure/externals/pole-emploi/PoleEmploiPayload.js';
-import * as campaignParticipationRepository from '../../src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-repository.js';
-import { campaignParticipationResultRepository } from '../../src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-result-repository.js';
-import * as poleEmploiSendingRepository from '../../src/prescription/campaign-participation/infrastructure/repositories/pole-emploi-sending-repository.js';
-import { CampaignParticipationStatuses } from '../../src/prescription/shared/domain/constants.js';
-import * as targetProfileRepository from '../../src/prescription/target-profile/infrastructure/repositories/target-profile-repository.js';
-import * as organizationRepository from '../../src/shared/infrastructure/repositories/organization-repository.js';
-import { logger } from '../../src/shared/infrastructure/utils/logger.js';
+import { disconnect, knex } from '../../../db/knex-database-connection.js';
+import * as badgeAcquisitionRepository from '../../evaluation/infrastructure/repositories/badge-acquisition-repository.js';
+import * as badgeRepository from '../../evaluation/infrastructure/repositories/badge-repository.js';
+import * as userRepository from '../../identity-access-management/infrastructure/repositories/user.repository.js';
+import * as organizationRepository from '../../shared/infrastructure/repositories/organization-repository.js';
+import { logger } from '../../shared/infrastructure/utils/logger.js';
+import * as campaignRepository from '../campaign/infrastructure/repositories/campaign-repository.js';
+import { PoleEmploiSending } from '../campaign-participation/domain/models/PoleEmploiSending.js';
+import { PoleEmploiPayload } from '../campaign-participation/infrastructure/externals/pole-emploi/PoleEmploiPayload.js';
+import * as campaignParticipationRepository from '../campaign-participation/infrastructure/repositories/campaign-participation-repository.js';
+import { campaignParticipationResultRepository } from '../campaign-participation/infrastructure/repositories/campaign-participation-result-repository.js';
+import * as poleEmploiSendingRepository from '../campaign-participation/infrastructure/repositories/pole-emploi-sending-repository.js';
+import { CampaignParticipationStatuses } from '../shared/domain/constants.js';
+import * as targetProfileRepository from '../target-profile/infrastructure/repositories/target-profile-repository.js';
 
 async function insertMissingPoleEmploiSendingFromDate(startDate, endDate = new Date(), campaignCode = 'YOURCODE') {
   const start = dayjs(startDate, 'YYYY-MM-DD');
@@ -93,8 +93,10 @@ const isLaunchedFromCommandLine = process.argv[1] === modulePath;
   if (isLaunchedFromCommandLine) {
     try {
       await insertMissingPoleEmploiSendingFromDate(process.argv[2], process.argv[3], process.argv[4]);
+      // eslint-disable-next-line no-console
       console.log('done');
     } catch (error) {
+      // eslint-disable-next-line no-console
       console.error(error);
       process.exitCode = 1;
     } finally {

--- a/api/src/prescription/scripts/migrate-learner-from-static-import-to-generic.js
+++ b/api/src/prescription/scripts/migrate-learner-from-static-import-to-generic.js
@@ -1,0 +1,141 @@
+import { Script } from '../../shared/application/scripts/script.js';
+import { ScriptRunner } from '../../shared/application/scripts/script-runner.js';
+import { DomainTransaction } from '../../shared/domain/DomainTransaction.js';
+import { batchUpdate } from '../../shared/infrastructure/utils/knex-utils.js';
+
+export class MigrateLearnerFromStaticImportToGeneric extends Script {
+  constructor() {
+    super({
+      description: 'Migrate learner from organization list to generic import',
+      permanent: false,
+      options: {
+        typology: {
+          type: 'string',
+          describe: 'update learner from specific organization',
+          choices: ['SCO', 'SUP', 'AGRI'],
+          required: true,
+          requiresArg: true,
+        },
+        dryRun: {
+          type: 'boolean',
+          describe: 'Run the script without making any database changes',
+          default: true,
+        },
+      },
+    });
+  }
+
+  async handle({ options, logger }) {
+    await DomainTransaction.execute(async () => {
+      logger.info(
+        `BEGIN: Migrate learners to generic import data for organizations managing student of type : ${options.typology}`,
+      );
+      const knexConn = DomainTransaction.getConnection();
+
+      try {
+        const organizationLearners = await findOrganizationLearnersToMigrate(options.typology);
+
+        logger.info(`learners to process : ${organizationLearners.length}.`);
+
+        const isSUP = options.typology === 'SUP';
+
+        const rows = organizationLearners.map((learner) => {
+          if (!isSUP) {
+            return {
+              id: learner.id,
+              attributes: {
+                middleName: learner.middleName ?? null,
+                thirdName: learner.thirdName ?? null,
+                preferredLastName: learner.preferredLastName ?? null,
+                sex: learner.sex ?? null,
+                nationalStudentId: learner.nationalStudentId ?? learner.nationalApprenticeId ?? null,
+                birthCity: learner.birthCity ?? null,
+                birthCityCode: learner.birthCityCode ?? null,
+                birthCountryCode: learner.birthCountryCode ?? null,
+                birthProvinceCode: learner.birthProvinceCode ?? null,
+                MEFCode: learner.MEFCode ?? null,
+                status: learner.status ?? null,
+                division: learner.division ?? null,
+                birthdate: learner.birthdate ?? null,
+              },
+            };
+          } else {
+            return {
+              id: learner.id,
+              attributes: {
+                middleName: learner.middleName ?? null,
+                thirdName: learner.thirdName ?? null,
+                preferredLastName: learner.preferredLastName ?? null,
+                birthdate: learner.birthdate ?? null,
+                studentNumber: learner.studentNumber ?? null,
+                department: learner.department ?? null,
+                email: learner.email ?? null,
+                educationalTeam: learner.educationalTeam ?? null,
+                group: learner.group ?? null,
+                diploma: learner.diploma ?? null,
+                status: learner.status ?? null,
+              },
+            };
+          }
+        });
+
+        await batchUpdate({ tableName: 'organization-learners', primaryKeyName: 'id', rows });
+
+        if (options.dryRun) {
+          await knexConn.rollback();
+          logger.info(
+            `ROLLBACK: Migrate learners to generic import data for organizations managing student of type : ${options.typology}`,
+          );
+          logger.info(`--dryRun false to persist changes`);
+          return;
+        }
+
+        logger.info(`COMMIT: Migrate learners to generic import data`);
+      } catch (error) {
+        await knexConn.rollback();
+        logger.error(
+          { error },
+          `ERROR: Migrate learners to generic import data for organizations managing student of type : ${options.typology}`,
+        );
+        throw error;
+      }
+    });
+  }
+}
+
+export function findOrganizationLearnersToMigrate(typology) {
+  const knexConn = DomainTransaction.getConnection();
+
+  const type = typology === 'SUP' ? 'SUP' : 'SCO';
+
+  const query = knexConn('organization-learners')
+    .select('organization-learners.*')
+    .whereNull('attributes')
+    .whereIn(
+      'organization-learners.organizationId',
+      knexConn('organizations').select('id').where({ type, isManagingStudents: true }),
+    );
+
+  if (typology === 'AGRI') {
+    query.join('organization-tags', function () {
+      this.on('organization-tags.organizationId', 'organization-learners.organizationId').andOnVal(
+        'organization-tags.tagId',
+        knexConn('tags').select('id').where('name', 'AGRICULTURE'),
+      );
+    });
+  }
+
+  if (typology === 'SCO') {
+    query.whereNotExists(function () {
+      this.select('organization-tags.organizationId')
+        .from('organization-tags')
+        .join('tags', 'tags.id', 'organization-tags.tagId')
+        .whereRaw('"organization-tags"."organizationId" = "organization-learners"."organizationId"')
+        .where('tags.name', 'AGRICULTURE');
+    });
+  }
+
+  return query.groupBy('organization-learners.id');
+}
+
+await ScriptRunner.execute(import.meta.url, MigrateLearnerFromStaticImportToGeneric);

--- a/api/tests/prescription/scripts/integration/delete-and-anonymise-organization-learners_test.js
+++ b/api/tests/prescription/scripts/integration/delete-and-anonymise-organization-learners_test.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 
 import { USER_RECOMMENDED_TRAININGS_TABLE_NAME } from '../../../../db/migrations/20221017085933_create-user-recommended-trainings.js';
-import { DeleteAndAnonymiseOrganizationLearnerScript } from '../../../../scripts/prod/delete-and-anonymise-organization-learners.js';
+import { DeleteAndAnonymiseOrganizationLearnerScript } from '../../../../src/prescription/scripts/delete-and-anonymise-organization-learners.js';
 import { databaseBuilder, knex } from '../../../test-helper.js';
 
 describe('DeleteAndAnonymiseOrganizationLearnerScript', function () {

--- a/api/tests/prescription/scripts/integration/delete-and-anonymise-previous-archive-organization_test.js
+++ b/api/tests/prescription/scripts/integration/delete-and-anonymise-previous-archive-organization_test.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 
-import { DeleteAndAnonymisePreviousOrganizationScript } from '../../../../scripts/prod/delete-and-anonymise-previous-archive-organization.js';
+import { DeleteAndAnonymisePreviousOrganizationScript } from '../../../../src/prescription/scripts/delete-and-anonymise-previous-archive-organization.js';
 import { databaseBuilder, knex } from '../../../test-helper.js';
 
 describe('DeleteAndAnonymisePreviousOrganizationScript', function () {

--- a/api/tests/prescription/scripts/integration/delete-and-anonymise-previous-campaigns_test.js
+++ b/api/tests/prescription/scripts/integration/delete-and-anonymise-previous-campaigns_test.js
@@ -1,13 +1,13 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 
-import { DeleteAndAnonymisePreviousCampaignParticipationsScript } from '../../../../scripts/prod/delete-and-anonymise-previous-participations.js';
+import { DeleteAndAnonymisePreviousCampaignsScript } from '../../../../src/prescription/scripts/delete-and-anonymise-previous-campaigns.js';
 import { databaseBuilder, knex } from '../../../test-helper.js';
 
-describe('DeleteAndAnonymisePreviousCampaignParticipationsScript', function () {
+describe('DeleteAndAnonymisePreviousCampaignsScript', function () {
   describe('Options', function () {
     it('has the correct options', function () {
-      const script = new DeleteAndAnonymisePreviousCampaignParticipationsScript();
+      const script = new DeleteAndAnonymisePreviousCampaignsScript();
       const { options } = script.metaInfo;
 
       expect(options.startArchiveDate).to.deep.include({
@@ -52,7 +52,7 @@ describe('DeleteAndAnonymisePreviousCampaignParticipationsScript', function () {
     };
 
     beforeEach(async function () {
-      script = new DeleteAndAnonymisePreviousCampaignParticipationsScript();
+      script = new DeleteAndAnonymisePreviousCampaignsScript();
       logger = { info: sinon.spy(), error: sinon.spy() };
       sinon.stub(process, 'env').value({ ENGINEERING_USER_ID });
       now = new Date(startArchiveDate);
@@ -116,6 +116,21 @@ describe('DeleteAndAnonymisePreviousCampaignParticipationsScript', function () {
           deletedBy: userId,
           archivedAt: null,
         });
+        archivedOrganizationAtDate.campaignDeletedAtDate = databaseBuilder.factory.buildCampaign({
+          targetProfileId,
+          name: 'campaignDeletedAtDate name',
+          title: 'campaignDeletedAtDate title',
+          customLandingPageText: 'campaignDeletedAtDate landing',
+          externalIdHelpImageUrl: 'campaignDeletedAtDate help',
+          alternativeTextToExternalIdHelpImage: 'campaignDeletedAtDate alt help',
+          customResultPageText: 'campaignDeletedAtDate custom text',
+          customResultPageButtonText: 'campaignDeletedAtDate custom button',
+          customResultPageButtonUrl: 'campaignDeletedAtDate custom url',
+          organizationId: archivedOrganizationAtDate.organization.id,
+          deletedAt: now,
+          deletedBy: userId,
+          archivedAt: null,
+        });
 
         // 3
         activeOrganization.campaignDeleted = databaseBuilder.factory.buildCampaign({
@@ -152,6 +167,200 @@ describe('DeleteAndAnonymisePreviousCampaignParticipationsScript', function () {
         await databaseBuilder.commit();
       });
 
+      describe('#archivedOrganizationBeforeDate', function () {
+        it('should not anonymize deleted campaigns of archived organization before date', async function () {
+          // when
+          await script.handle({ options: { startArchiveDate }, logger });
+
+          const campaignDeleted = await knex('campaigns')
+            .select(
+              'name',
+              'title',
+              'customLandingPageText',
+              'externalIdHelpImageUrl',
+              'alternativeTextToExternalIdHelpImage',
+              'customResultPageText',
+              'customResultPageButtonText',
+              'customResultPageButtonUrl',
+              'deletedAt',
+              'deletedBy',
+              'archivedAt',
+            )
+            .where('id', archivedOrganizationBeforeDate.campaignDeleted.id)
+            .first();
+
+          // then
+          expect(campaignDeleted).deep.equal({
+            name: archivedOrganizationBeforeDate.campaignDeleted.name,
+            title: archivedOrganizationBeforeDate.campaignDeleted.title,
+            customLandingPageText: archivedOrganizationBeforeDate.campaignDeleted.customLandingPageText,
+            externalIdHelpImageUrl: archivedOrganizationBeforeDate.campaignDeleted.externalIdHelpImageUrl,
+            alternativeTextToExternalIdHelpImage:
+              archivedOrganizationBeforeDate.campaignDeleted.alternativeTextToExternalIdHelpImage,
+            customResultPageText: archivedOrganizationBeforeDate.campaignDeleted.customResultPageText,
+            customResultPageButtonText: archivedOrganizationBeforeDate.campaignDeleted.customResultPageButtonText,
+            customResultPageButtonUrl: archivedOrganizationBeforeDate.campaignDeleted.customResultPageButtonUrl,
+            deletedAt: archivedOrganizationBeforeDate.campaignDeleted.deletedAt,
+            deletedBy: archivedOrganizationBeforeDate.campaignDeleted.deletedBy,
+            archivedAt: archivedOrganizationBeforeDate.campaignDeleted.archivedAt,
+          });
+        });
+      });
+
+      describe('#archivedOrganizationAtDate', function () {
+        it('should anonymise deleted campaigns before date of archived organization at date', async function () {
+          // when
+          await script.handle({ options: { startArchiveDate }, logger });
+
+          const campaignDeleted = await knex('campaigns')
+            .select(
+              'name',
+              'title',
+              'customLandingPageText',
+              'externalIdHelpImageUrl',
+              'alternativeTextToExternalIdHelpImage',
+              'customResultPageText',
+              'customResultPageButtonText',
+              'customResultPageButtonUrl',
+              'deletedAt',
+              'deletedBy',
+              'archivedAt',
+            )
+            .where('id', archivedOrganizationAtDate.campaignDeleted.id)
+            .first();
+
+          // then
+          expect(campaignDeleted).deep.equal({
+            name: '(anonymized)',
+            title: null,
+            customLandingPageText: null,
+            externalIdHelpImageUrl: null,
+            alternativeTextToExternalIdHelpImage: null,
+            customResultPageText: null,
+            customResultPageButtonText: null,
+            customResultPageButtonUrl: null,
+            deletedAt: archivedOrganizationAtDate.campaignDeleted.deletedAt,
+            deletedBy: archivedOrganizationAtDate.campaignDeleted.deletedBy,
+            archivedAt: null,
+          });
+        });
+
+        it('should not anonymise deleted campaigns at date of archived organization at date', async function () {
+          // when
+          await script.handle({ options: { startArchiveDate }, logger });
+
+          const campaignDeleted = await knex('campaigns')
+            .select(
+              'name',
+              'title',
+              'customLandingPageText',
+              'externalIdHelpImageUrl',
+              'alternativeTextToExternalIdHelpImage',
+              'customResultPageText',
+              'customResultPageButtonText',
+              'customResultPageButtonUrl',
+              'deletedAt',
+              'deletedBy',
+              'archivedAt',
+            )
+            .where('id', archivedOrganizationAtDate.campaignDeletedAtDate.id)
+            .first();
+
+          // then
+          expect(campaignDeleted).deep.equal({
+            name: archivedOrganizationAtDate.campaignDeletedAtDate.name,
+            title: archivedOrganizationAtDate.campaignDeletedAtDate.title,
+            customLandingPageText: archivedOrganizationAtDate.campaignDeletedAtDate.customLandingPageText,
+            externalIdHelpImageUrl: archivedOrganizationAtDate.campaignDeletedAtDate.externalIdHelpImageUrl,
+            alternativeTextToExternalIdHelpImage:
+              archivedOrganizationAtDate.campaignDeletedAtDate.alternativeTextToExternalIdHelpImage,
+            customResultPageText: archivedOrganizationAtDate.campaignDeletedAtDate.customResultPageText,
+            customResultPageButtonText: archivedOrganizationAtDate.campaignDeletedAtDate.customResultPageButtonText,
+            customResultPageButtonUrl: archivedOrganizationAtDate.campaignDeletedAtDate.customResultPageButtonUrl,
+            deletedAt: archivedOrganizationAtDate.campaignDeletedAtDate.deletedAt,
+            deletedBy: archivedOrganizationAtDate.campaignDeletedAtDate.deletedBy,
+            archivedAt: archivedOrganizationAtDate.campaignDeletedAtDate.archivedAt,
+          });
+        });
+      });
+
+      describe('#activeOrganization', function () {
+        it('should not anonymise active campaigns of active organization', async function () {
+          // when
+          await script.handle({ options: { startArchiveDate }, logger });
+
+          const campaignActive = await knex('campaigns')
+            .select(
+              'name',
+              'title',
+              'customLandingPageText',
+              'externalIdHelpImageUrl',
+              'alternativeTextToExternalIdHelpImage',
+              'customResultPageText',
+              'customResultPageButtonText',
+              'customResultPageButtonUrl',
+              'deletedAt',
+              'deletedBy',
+              'archivedAt',
+            )
+            .where('id', activeOrganization.campaignActive.id)
+            .first();
+
+          // then
+          expect(campaignActive).deep.equal({
+            name: activeOrganization.campaignActive.name,
+            title: activeOrganization.campaignActive.title,
+            customLandingPageText: activeOrganization.campaignActive.customLandingPageText,
+            externalIdHelpImageUrl: activeOrganization.campaignActive.externalIdHelpImageUrl,
+            alternativeTextToExternalIdHelpImage:
+              activeOrganization.campaignActive.alternativeTextToExternalIdHelpImage,
+            customResultPageText: activeOrganization.campaignActive.customResultPageText,
+            customResultPageButtonText: activeOrganization.campaignActive.customResultPageButtonText,
+            customResultPageButtonUrl: activeOrganization.campaignActive.customResultPageButtonUrl,
+            deletedAt: activeOrganization.campaignActive.deletedAt,
+            deletedBy: activeOrganization.campaignActive.deletedBy,
+            archivedAt: activeOrganization.campaignActive.archivedAt,
+          });
+        });
+
+        it('should anonymise deleted campaigns of active organization', async function () {
+          // when
+          await script.handle({ options: { startArchiveDate }, logger });
+
+          const campaignDeleted = await knex('campaigns')
+            .select(
+              'name',
+              'title',
+              'customLandingPageText',
+              'externalIdHelpImageUrl',
+              'alternativeTextToExternalIdHelpImage',
+              'customResultPageText',
+              'customResultPageButtonText',
+              'customResultPageButtonUrl',
+              'deletedAt',
+              'deletedBy',
+              'archivedAt',
+            )
+            .where('id', activeOrganization.campaignDeleted.id)
+            .first();
+
+          // then
+          expect(campaignDeleted).deep.equal({
+            name: '(anonymized)',
+            title: null,
+            customLandingPageText: null,
+            externalIdHelpImageUrl: null,
+            alternativeTextToExternalIdHelpImage: null,
+            customResultPageText: null,
+            customResultPageButtonText: null,
+            customResultPageButtonUrl: null,
+            deletedAt: archivedOrganizationAtDate.campaignDeleted.deletedAt,
+            deletedBy: archivedOrganizationAtDate.campaignDeleted.deletedBy,
+            archivedAt: null,
+          });
+        });
+      });
+
       describe('#participations', function () {
         beforeEach(async function () {
           // 1
@@ -182,8 +391,6 @@ describe('DeleteAndAnonymisePreviousCampaignParticipationsScript', function () {
               firstName: 'johnny',
               lastName: 'be good',
               organizationId: activeOrganization.organization.id,
-              deletedAt: null,
-              deletedBy: null,
             });
 
           await databaseBuilder.commit();
@@ -216,7 +423,6 @@ describe('DeleteAndAnonymisePreviousCampaignParticipationsScript', function () {
               userId: activeOrganization.activeLearner.userId,
               organizationLearnerId: activeOrganization.activeLearner.id,
               participantExternalId: 'second',
-              isImproved: true,
               campaignId: activeOrganization.campaignActive.id,
               deletedAt: null,
               deletedBy: null,
@@ -236,7 +442,7 @@ describe('DeleteAndAnonymisePreviousCampaignParticipationsScript', function () {
 
           describe('#participations', function () {
             describe('#archivedOrganizationBeforeDate', function () {
-              it('should not update delete participation of deleted campaign on archived organization before date', async function () {
+              it('should not update delete participation of archived organization before date', async function () {
                 // when
                 await script.handle({
                   options: { startArchiveDate },
@@ -259,7 +465,7 @@ describe('DeleteAndAnonymisePreviousCampaignParticipationsScript', function () {
             });
 
             describe('#archivedOrganizationAtDate', function () {
-              it('should not update deleted participation of deleted campaigns on archived organization at date', async function () {
+              it('anonymize deleted participation of archived organization at date', async function () {
                 // when
                 await script.handle({
                   options: { startArchiveDate },
@@ -273,8 +479,8 @@ describe('DeleteAndAnonymisePreviousCampaignParticipationsScript', function () {
 
                 // then
                 expect(deletedParticipation).deep.equal({
-                  userId: archivedOrganizationAtDate.deletedParticipation.userId,
-                  participantExternalId: archivedOrganizationAtDate.deletedParticipation.participantExternalId,
+                  userId: null,
+                  participantExternalId: null,
                   deletedAt: archivedOrganizationAtDate.deletedParticipation.deletedAt,
                   deletedBy: archivedOrganizationAtDate.deletedParticipation.deletedBy,
                 });
@@ -282,7 +488,7 @@ describe('DeleteAndAnonymisePreviousCampaignParticipationsScript', function () {
             });
 
             describe('#activeOrganization', function () {
-              it('should not anonymise deleted participation of deleted campaign on active organization', async function () {
+              it('should anonymise deleted participation of active organization', async function () {
                 // when
                 await script.handle({
                   options: { startArchiveDate },
@@ -296,14 +502,14 @@ describe('DeleteAndAnonymisePreviousCampaignParticipationsScript', function () {
 
                 // then
                 expect(deleteParticipation).deep.equal({
-                  userId: activeOrganization.deletedParticipation.userId,
-                  participantExternalId: activeOrganization.deletedParticipation.participantExternalId,
+                  userId: null,
+                  participantExternalId: null,
                   deletedAt: activeOrganization.deletedParticipation.deletedAt,
                   deletedBy: userId,
                 });
               });
 
-              it('should not anonymise of active participation of active organization', async function () {
+              it('should not anonymise or active participation of active organization', async function () {
                 // when
                 await script.handle({
                   options: { startArchiveDate },
@@ -323,68 +529,17 @@ describe('DeleteAndAnonymisePreviousCampaignParticipationsScript', function () {
                   deletedBy: null,
                 });
               });
-
-              it('should anonymise of deleted participation only of active campaign on active organization', async function () {
-                // when
-                const deletedParticipationActiveCampaign = databaseBuilder.factory.buildCampaignParticipation({
-                  userId: activeOrganization.activeLearner.userId,
-                  organizationLearnerId: activeOrganization.activeLearner.id,
-                  participantExternalId: 'second',
-                  campaignId: activeOrganization.campaignActive.id,
-                  deletedAt: new Date('2024-01-01'),
-                  deletedBy: userId,
-                  isImproved: true,
-                });
-
-                const deletedImprovedParticipationActiveCampaign = databaseBuilder.factory.buildCampaignParticipation({
-                  userId: activeOrganization.activeLearner.userId,
-                  organizationLearnerId: activeOrganization.activeLearner.id,
-                  participantExternalId: 'second',
-                  isImproved: false,
-                  campaignId: activeOrganization.campaignActive.id,
-                  deletedAt: new Date('2024-02-01'),
-                  deletedBy: userId,
-                });
-
-                await databaseBuilder.commit();
-                await script.handle({
-                  options: { startArchiveDate },
-                  logger,
-                });
-
-                const activeParticipation = await knex('campaign-participations')
-                  .select('id', 'userId', 'participantExternalId', 'deletedAt', 'deletedBy')
-                  .whereNull('userId');
-
-                // then
-                expect(activeParticipation).deep.members([
-                  {
-                    id: deletedParticipationActiveCampaign.id,
-                    userId: null,
-                    participantExternalId: null,
-                    deletedAt: deletedParticipationActiveCampaign.deletedAt,
-                    deletedBy: deletedParticipationActiveCampaign.deletedBy,
-                  },
-                  {
-                    id: deletedImprovedParticipationActiveCampaign.id,
-                    userId: null,
-                    participantExternalId: null,
-                    deletedAt: deletedImprovedParticipationActiveCampaign.deletedAt,
-                    deletedBy: deletedImprovedParticipationActiveCampaign.deletedBy,
-                  },
-                ]);
-              });
             });
           });
 
           describe('#assessments', function () {
-            it('should detach assessments and update updatedAt column only on deleted participations on active campaign', async function () {
+            it('should detach assessments and update updatedAt column only on archived organization before date', async function () {
               // given
               // 1
               const assessmentFromDeletedParticipationOnArchivedOrganizationBeforeDate =
                 databaseBuilder.factory.buildAssessment({
                   userId: archivedOrganizationBeforeDate.deletedLearner.userId,
-                  campaignParticipationId: archivedOrganizationBeforeDate.deletedParticipation.id,
+                  campaignParticipationId: null,
                   updatedAt: new Date('2024-01-01'),
                 });
 
@@ -397,19 +552,9 @@ describe('DeleteAndAnonymisePreviousCampaignParticipationsScript', function () {
                 });
 
               // 3
-              const deletedImprovedParticipationActiveCampaign = databaseBuilder.factory.buildCampaignParticipation({
-                userId: activeOrganization.activeLearner.userId,
-                organizationLearnerId: activeOrganization.activeLearner.id,
-                participantExternalId: 'second',
-                isImproved: false,
-                campaignId: activeOrganization.campaignActive.id,
-                deletedAt: new Date('2024-02-01'),
-                deletedBy: userId,
-              });
-
               const assessmentFromDActiveParticipationOnActiveOrganization = databaseBuilder.factory.buildAssessment({
                 userId: activeOrganization.activeLearner.userId,
-                campaignParticipationId: deletedImprovedParticipationActiveCampaign.id,
+                campaignParticipationId: activeOrganization.activeParticipation.id,
                 updatedAt: new Date('2024-01-01'),
               });
 
@@ -430,6 +575,12 @@ describe('DeleteAndAnonymisePreviousCampaignParticipationsScript', function () {
                 .whereNull('campaignParticipationId')
                 .pluck('id');
 
+              const previousAnonymuzedAssessments = await knex('assessments')
+                .select('id')
+                .whereNot({ updatedAt: now })
+                .whereNull('campaignParticipationId')
+                .pluck('id');
+
               const activeAssessments = await knex('assessments')
                 .select('id')
                 .whereNot({ updatedAt: now })
@@ -437,15 +588,19 @@ describe('DeleteAndAnonymisePreviousCampaignParticipationsScript', function () {
                 .pluck('id');
 
               // then
-              expect(activeAssessments).lengthOf(3);
-              expect(activeAssessments).deep.members([
-                assessmentFromDDeletedParticipationOnActiveOrganization.id,
-                assessmentFromDeletedParticipationOnArchivedOrganizationAtDate.id,
+              expect(activeAssessments).lengthOf(1);
+              expect(activeAssessments).deep.members([assessmentFromDActiveParticipationOnActiveOrganization.id]);
+
+              expect(previousAnonymuzedAssessments).lengthOf(1);
+              expect(previousAnonymuzedAssessments).deep.members([
                 assessmentFromDeletedParticipationOnArchivedOrganizationBeforeDate.id,
               ]);
 
-              expect(anonymizedAssessments).lengthOf(1);
-              expect(anonymizedAssessments).deep.members([assessmentFromDActiveParticipationOnActiveOrganization.id]);
+              expect(anonymizedAssessments).lengthOf(2);
+              expect(anonymizedAssessments).deep.members([
+                assessmentFromDeletedParticipationOnArchivedOrganizationAtDate.id,
+                assessmentFromDDeletedParticipationOnActiveOrganization.id,
+              ]);
             });
           });
 
@@ -482,28 +637,11 @@ describe('DeleteAndAnonymisePreviousCampaignParticipationsScript', function () {
                 campaignParticipationId: activeOrganization.activeParticipation.id,
                 trainingId: training2.id,
                 userId: activeOrganization.activeLearner.userId,
-                updatedAt: new Date('2022-01-01'),
+                updatedAt: new Date('2023-01-01'),
               });
 
               databaseBuilder.factory.buildUserRecommendedTraining({
                 campaignParticipationId: activeOrganization.deletedParticipation.id,
-                trainingId: training2.id,
-                userId: activeOrganization.activeLearner.userId,
-                updatedAt: new Date('2023-01-01'),
-              });
-
-              const deletedImprovedParticipationActiveCampaign = databaseBuilder.factory.buildCampaignParticipation({
-                userId: activeOrganization.activeLearner.userId,
-                organizationLearnerId: activeOrganization.activeLearner.id,
-                participantExternalId: 'second',
-                isImproved: false,
-                campaignId: activeOrganization.campaignActive.id,
-                deletedAt: new Date('2024-02-01'),
-                deletedBy: userId,
-              });
-
-              databaseBuilder.factory.buildUserRecommendedTraining({
-                campaignParticipationId: deletedImprovedParticipationActiveCampaign.id,
                 trainingId: training2.id,
                 userId: activeOrganization.activeLearner.userId,
                 updatedAt: new Date('2023-01-01'),
@@ -524,28 +662,22 @@ describe('DeleteAndAnonymisePreviousCampaignParticipationsScript', function () {
                 .whereNotNull('campaignParticipationId');
 
               // then
-              expect(anonymizedRecommendedTrainingResults).lengthOf(1);
+              expect(anonymizedRecommendedTrainingResults).lengthOf(2);
               expect(anonymizedRecommendedTrainingResults).deep.members([
                 {
                   campaignParticipationId: null,
-                  userId: activeOrganization.activeLearner.userId,
+                  userId: archivedOrganizationAtDate.deletedParticipation.userId,
+                },
+                {
+                  campaignParticipationId: null,
+                  userId: activeOrganization.deletedParticipation.userId,
                 },
               ]);
-              expect(activeRecommendedTrainings).lengthOf(3);
+              expect(activeRecommendedTrainings).lengthOf(1);
               expect(activeRecommendedTrainings).deep.members([
-                {
-                  campaignParticipationId: archivedOrganizationAtDate.deletedParticipation.id,
-                  userId: archivedOrganizationAtDate.deletedParticipation.userId,
-                  updatedAt: new Date('2024-01-01'),
-                },
                 {
                   campaignParticipationId: activeOrganization.activeParticipation.id,
                   userId: activeOrganization.activeParticipation.userId,
-                  updatedAt: new Date('2022-01-01'),
-                },
-                {
-                  campaignParticipationId: activeOrganization.deletedParticipation.id,
-                  userId: activeOrganization.deletedParticipation.userId,
                   updatedAt: new Date('2023-01-01'),
                 },
               ]);
@@ -602,22 +734,6 @@ describe('DeleteAndAnonymisePreviousCampaignParticipationsScript', function () {
                 campaignParticipationId: activeOrganization.deletedParticipation.id,
               });
 
-              const deletedImprovedParticipationActiveCampaign = databaseBuilder.factory.buildCampaignParticipation({
-                userId: activeOrganization.activeLearner.userId,
-                organizationLearnerId: activeOrganization.activeLearner.id,
-                participantExternalId: 'second',
-                isImproved: false,
-                campaignId: activeOrganization.campaignActive.id,
-                deletedAt: new Date('2024-02-01'),
-                deletedBy: userId,
-              });
-
-              databaseBuilder.factory.buildBadgeAcquisition({
-                userId: deletedImprovedParticipationActiveCampaign.userId,
-                badgeId: nonCertifiableBadge.id,
-                campaignParticipationId: deletedImprovedParticipationActiveCampaign.id,
-              });
-
               await databaseBuilder.commit();
 
               // when
@@ -628,11 +744,15 @@ describe('DeleteAndAnonymisePreviousCampaignParticipationsScript', function () {
                 .whereNull('userId');
 
               // then
-              expect(detachBadges).lengthOf(1);
+              expect(detachBadges).lengthOf(2);
               expect(detachBadges).deep.members([
                 {
                   badgeId: nonCertifiableBadge.id,
-                  campaignParticipationId: deletedImprovedParticipationActiveCampaign.id,
+                  campaignParticipationId: archivedOrganizationAtDate.deletedParticipation.id,
+                },
+                {
+                  badgeId: nonCertifiableBadge.id,
+                  campaignParticipationId: activeOrganization.deletedParticipation.id,
                 },
               ]);
             });
@@ -644,21 +764,10 @@ describe('DeleteAndAnonymisePreviousCampaignParticipationsScript', function () {
                 badgeId: certifiableBadge.id,
                 campaignParticipationId: archivedOrganizationBeforeDate.deletedParticipation.id,
               });
-
-              const deletedImprovedParticipationActiveCampaign = databaseBuilder.factory.buildCampaignParticipation({
-                userId: activeOrganization.activeLearner.userId,
-                organizationLearnerId: activeOrganization.activeLearner.id,
-                participantExternalId: 'second',
-                isImproved: false,
-                campaignId: activeOrganization.campaignActive.id,
-                deletedAt: new Date('2024-02-01'),
-                deletedBy: userId,
-              });
-
               databaseBuilder.factory.buildBadgeAcquisition({
-                userId: deletedImprovedParticipationActiveCampaign.userId,
+                userId: activeOrganization.activeLearner.userId,
                 badgeId: certifiableBadge.id,
-                campaignParticipationId: deletedImprovedParticipationActiveCampaign.id,
+                campaignParticipationId: activeOrganization.deletedParticipation.id,
               });
 
               await databaseBuilder.commit();
@@ -682,8 +791,8 @@ describe('DeleteAndAnonymisePreviousCampaignParticipationsScript', function () {
                 },
                 {
                   badgeId: certifiableBadge.id,
-                  campaignParticipationId: deletedImprovedParticipationActiveCampaign.id,
-                  userId: deletedImprovedParticipationActiveCampaign.userId,
+                  campaignParticipationId: activeOrganization.deletedParticipation.id,
+                  userId: activeOrganization.activeLearner.userId,
                 },
               ]);
             });

--- a/api/tests/prescription/scripts/integration/delete-and-anonymise-previous-organization-learners_test.js
+++ b/api/tests/prescription/scripts/integration/delete-and-anonymise-previous-organization-learners_test.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 
-import { DeleteAndAnonymisePreviousOrganizationLearnersScript } from '../../../../scripts/prod/delete-and-anonymise-previous-organization-learners.js';
+import { DeleteAndAnonymisePreviousOrganizationLearnersScript } from '../../../../src/prescription/scripts/delete-and-anonymise-previous-organization-learners.js';
 import { databaseBuilder, knex } from '../../../test-helper.js';
 
 describe('DeleteAndAnonymisePreviousOrganizationLearnersScript', function () {

--- a/api/tests/prescription/scripts/integration/delete-and-anonymise-previous-participations_test.js
+++ b/api/tests/prescription/scripts/integration/delete-and-anonymise-previous-participations_test.js
@@ -1,13 +1,13 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 
-import { DeleteAndAnonymisePreviousCampaignsScript } from '../../../../scripts/prod/delete-and-anonymise-previous-campaigns.js';
+import { DeleteAndAnonymisePreviousCampaignParticipationsScript } from '../../../../src/prescription/scripts/delete-and-anonymise-previous-participations.js';
 import { databaseBuilder, knex } from '../../../test-helper.js';
 
-describe('DeleteAndAnonymisePreviousCampaignsScript', function () {
+describe('DeleteAndAnonymisePreviousCampaignParticipationsScript', function () {
   describe('Options', function () {
     it('has the correct options', function () {
-      const script = new DeleteAndAnonymisePreviousCampaignsScript();
+      const script = new DeleteAndAnonymisePreviousCampaignParticipationsScript();
       const { options } = script.metaInfo;
 
       expect(options.startArchiveDate).to.deep.include({
@@ -52,7 +52,7 @@ describe('DeleteAndAnonymisePreviousCampaignsScript', function () {
     };
 
     beforeEach(async function () {
-      script = new DeleteAndAnonymisePreviousCampaignsScript();
+      script = new DeleteAndAnonymisePreviousCampaignParticipationsScript();
       logger = { info: sinon.spy(), error: sinon.spy() };
       sinon.stub(process, 'env').value({ ENGINEERING_USER_ID });
       now = new Date(startArchiveDate);
@@ -116,21 +116,6 @@ describe('DeleteAndAnonymisePreviousCampaignsScript', function () {
           deletedBy: userId,
           archivedAt: null,
         });
-        archivedOrganizationAtDate.campaignDeletedAtDate = databaseBuilder.factory.buildCampaign({
-          targetProfileId,
-          name: 'campaignDeletedAtDate name',
-          title: 'campaignDeletedAtDate title',
-          customLandingPageText: 'campaignDeletedAtDate landing',
-          externalIdHelpImageUrl: 'campaignDeletedAtDate help',
-          alternativeTextToExternalIdHelpImage: 'campaignDeletedAtDate alt help',
-          customResultPageText: 'campaignDeletedAtDate custom text',
-          customResultPageButtonText: 'campaignDeletedAtDate custom button',
-          customResultPageButtonUrl: 'campaignDeletedAtDate custom url',
-          organizationId: archivedOrganizationAtDate.organization.id,
-          deletedAt: now,
-          deletedBy: userId,
-          archivedAt: null,
-        });
 
         // 3
         activeOrganization.campaignDeleted = databaseBuilder.factory.buildCampaign({
@@ -167,200 +152,6 @@ describe('DeleteAndAnonymisePreviousCampaignsScript', function () {
         await databaseBuilder.commit();
       });
 
-      describe('#archivedOrganizationBeforeDate', function () {
-        it('should not anonymize deleted campaigns of archived organization before date', async function () {
-          // when
-          await script.handle({ options: { startArchiveDate }, logger });
-
-          const campaignDeleted = await knex('campaigns')
-            .select(
-              'name',
-              'title',
-              'customLandingPageText',
-              'externalIdHelpImageUrl',
-              'alternativeTextToExternalIdHelpImage',
-              'customResultPageText',
-              'customResultPageButtonText',
-              'customResultPageButtonUrl',
-              'deletedAt',
-              'deletedBy',
-              'archivedAt',
-            )
-            .where('id', archivedOrganizationBeforeDate.campaignDeleted.id)
-            .first();
-
-          // then
-          expect(campaignDeleted).deep.equal({
-            name: archivedOrganizationBeforeDate.campaignDeleted.name,
-            title: archivedOrganizationBeforeDate.campaignDeleted.title,
-            customLandingPageText: archivedOrganizationBeforeDate.campaignDeleted.customLandingPageText,
-            externalIdHelpImageUrl: archivedOrganizationBeforeDate.campaignDeleted.externalIdHelpImageUrl,
-            alternativeTextToExternalIdHelpImage:
-              archivedOrganizationBeforeDate.campaignDeleted.alternativeTextToExternalIdHelpImage,
-            customResultPageText: archivedOrganizationBeforeDate.campaignDeleted.customResultPageText,
-            customResultPageButtonText: archivedOrganizationBeforeDate.campaignDeleted.customResultPageButtonText,
-            customResultPageButtonUrl: archivedOrganizationBeforeDate.campaignDeleted.customResultPageButtonUrl,
-            deletedAt: archivedOrganizationBeforeDate.campaignDeleted.deletedAt,
-            deletedBy: archivedOrganizationBeforeDate.campaignDeleted.deletedBy,
-            archivedAt: archivedOrganizationBeforeDate.campaignDeleted.archivedAt,
-          });
-        });
-      });
-
-      describe('#archivedOrganizationAtDate', function () {
-        it('should anonymise deleted campaigns before date of archived organization at date', async function () {
-          // when
-          await script.handle({ options: { startArchiveDate }, logger });
-
-          const campaignDeleted = await knex('campaigns')
-            .select(
-              'name',
-              'title',
-              'customLandingPageText',
-              'externalIdHelpImageUrl',
-              'alternativeTextToExternalIdHelpImage',
-              'customResultPageText',
-              'customResultPageButtonText',
-              'customResultPageButtonUrl',
-              'deletedAt',
-              'deletedBy',
-              'archivedAt',
-            )
-            .where('id', archivedOrganizationAtDate.campaignDeleted.id)
-            .first();
-
-          // then
-          expect(campaignDeleted).deep.equal({
-            name: '(anonymized)',
-            title: null,
-            customLandingPageText: null,
-            externalIdHelpImageUrl: null,
-            alternativeTextToExternalIdHelpImage: null,
-            customResultPageText: null,
-            customResultPageButtonText: null,
-            customResultPageButtonUrl: null,
-            deletedAt: archivedOrganizationAtDate.campaignDeleted.deletedAt,
-            deletedBy: archivedOrganizationAtDate.campaignDeleted.deletedBy,
-            archivedAt: null,
-          });
-        });
-
-        it('should not anonymise deleted campaigns at date of archived organization at date', async function () {
-          // when
-          await script.handle({ options: { startArchiveDate }, logger });
-
-          const campaignDeleted = await knex('campaigns')
-            .select(
-              'name',
-              'title',
-              'customLandingPageText',
-              'externalIdHelpImageUrl',
-              'alternativeTextToExternalIdHelpImage',
-              'customResultPageText',
-              'customResultPageButtonText',
-              'customResultPageButtonUrl',
-              'deletedAt',
-              'deletedBy',
-              'archivedAt',
-            )
-            .where('id', archivedOrganizationAtDate.campaignDeletedAtDate.id)
-            .first();
-
-          // then
-          expect(campaignDeleted).deep.equal({
-            name: archivedOrganizationAtDate.campaignDeletedAtDate.name,
-            title: archivedOrganizationAtDate.campaignDeletedAtDate.title,
-            customLandingPageText: archivedOrganizationAtDate.campaignDeletedAtDate.customLandingPageText,
-            externalIdHelpImageUrl: archivedOrganizationAtDate.campaignDeletedAtDate.externalIdHelpImageUrl,
-            alternativeTextToExternalIdHelpImage:
-              archivedOrganizationAtDate.campaignDeletedAtDate.alternativeTextToExternalIdHelpImage,
-            customResultPageText: archivedOrganizationAtDate.campaignDeletedAtDate.customResultPageText,
-            customResultPageButtonText: archivedOrganizationAtDate.campaignDeletedAtDate.customResultPageButtonText,
-            customResultPageButtonUrl: archivedOrganizationAtDate.campaignDeletedAtDate.customResultPageButtonUrl,
-            deletedAt: archivedOrganizationAtDate.campaignDeletedAtDate.deletedAt,
-            deletedBy: archivedOrganizationAtDate.campaignDeletedAtDate.deletedBy,
-            archivedAt: archivedOrganizationAtDate.campaignDeletedAtDate.archivedAt,
-          });
-        });
-      });
-
-      describe('#activeOrganization', function () {
-        it('should not anonymise active campaigns of active organization', async function () {
-          // when
-          await script.handle({ options: { startArchiveDate }, logger });
-
-          const campaignActive = await knex('campaigns')
-            .select(
-              'name',
-              'title',
-              'customLandingPageText',
-              'externalIdHelpImageUrl',
-              'alternativeTextToExternalIdHelpImage',
-              'customResultPageText',
-              'customResultPageButtonText',
-              'customResultPageButtonUrl',
-              'deletedAt',
-              'deletedBy',
-              'archivedAt',
-            )
-            .where('id', activeOrganization.campaignActive.id)
-            .first();
-
-          // then
-          expect(campaignActive).deep.equal({
-            name: activeOrganization.campaignActive.name,
-            title: activeOrganization.campaignActive.title,
-            customLandingPageText: activeOrganization.campaignActive.customLandingPageText,
-            externalIdHelpImageUrl: activeOrganization.campaignActive.externalIdHelpImageUrl,
-            alternativeTextToExternalIdHelpImage:
-              activeOrganization.campaignActive.alternativeTextToExternalIdHelpImage,
-            customResultPageText: activeOrganization.campaignActive.customResultPageText,
-            customResultPageButtonText: activeOrganization.campaignActive.customResultPageButtonText,
-            customResultPageButtonUrl: activeOrganization.campaignActive.customResultPageButtonUrl,
-            deletedAt: activeOrganization.campaignActive.deletedAt,
-            deletedBy: activeOrganization.campaignActive.deletedBy,
-            archivedAt: activeOrganization.campaignActive.archivedAt,
-          });
-        });
-
-        it('should anonymise deleted campaigns of active organization', async function () {
-          // when
-          await script.handle({ options: { startArchiveDate }, logger });
-
-          const campaignDeleted = await knex('campaigns')
-            .select(
-              'name',
-              'title',
-              'customLandingPageText',
-              'externalIdHelpImageUrl',
-              'alternativeTextToExternalIdHelpImage',
-              'customResultPageText',
-              'customResultPageButtonText',
-              'customResultPageButtonUrl',
-              'deletedAt',
-              'deletedBy',
-              'archivedAt',
-            )
-            .where('id', activeOrganization.campaignDeleted.id)
-            .first();
-
-          // then
-          expect(campaignDeleted).deep.equal({
-            name: '(anonymized)',
-            title: null,
-            customLandingPageText: null,
-            externalIdHelpImageUrl: null,
-            alternativeTextToExternalIdHelpImage: null,
-            customResultPageText: null,
-            customResultPageButtonText: null,
-            customResultPageButtonUrl: null,
-            deletedAt: archivedOrganizationAtDate.campaignDeleted.deletedAt,
-            deletedBy: archivedOrganizationAtDate.campaignDeleted.deletedBy,
-            archivedAt: null,
-          });
-        });
-      });
-
       describe('#participations', function () {
         beforeEach(async function () {
           // 1
@@ -391,6 +182,8 @@ describe('DeleteAndAnonymisePreviousCampaignsScript', function () {
               firstName: 'johnny',
               lastName: 'be good',
               organizationId: activeOrganization.organization.id,
+              deletedAt: null,
+              deletedBy: null,
             });
 
           await databaseBuilder.commit();
@@ -423,6 +216,7 @@ describe('DeleteAndAnonymisePreviousCampaignsScript', function () {
               userId: activeOrganization.activeLearner.userId,
               organizationLearnerId: activeOrganization.activeLearner.id,
               participantExternalId: 'second',
+              isImproved: true,
               campaignId: activeOrganization.campaignActive.id,
               deletedAt: null,
               deletedBy: null,
@@ -442,7 +236,7 @@ describe('DeleteAndAnonymisePreviousCampaignsScript', function () {
 
           describe('#participations', function () {
             describe('#archivedOrganizationBeforeDate', function () {
-              it('should not update delete participation of archived organization before date', async function () {
+              it('should not update delete participation of deleted campaign on archived organization before date', async function () {
                 // when
                 await script.handle({
                   options: { startArchiveDate },
@@ -465,7 +259,7 @@ describe('DeleteAndAnonymisePreviousCampaignsScript', function () {
             });
 
             describe('#archivedOrganizationAtDate', function () {
-              it('anonymize deleted participation of archived organization at date', async function () {
+              it('should not update deleted participation of deleted campaigns on archived organization at date', async function () {
                 // when
                 await script.handle({
                   options: { startArchiveDate },
@@ -479,8 +273,8 @@ describe('DeleteAndAnonymisePreviousCampaignsScript', function () {
 
                 // then
                 expect(deletedParticipation).deep.equal({
-                  userId: null,
-                  participantExternalId: null,
+                  userId: archivedOrganizationAtDate.deletedParticipation.userId,
+                  participantExternalId: archivedOrganizationAtDate.deletedParticipation.participantExternalId,
                   deletedAt: archivedOrganizationAtDate.deletedParticipation.deletedAt,
                   deletedBy: archivedOrganizationAtDate.deletedParticipation.deletedBy,
                 });
@@ -488,7 +282,7 @@ describe('DeleteAndAnonymisePreviousCampaignsScript', function () {
             });
 
             describe('#activeOrganization', function () {
-              it('should anonymise deleted participation of active organization', async function () {
+              it('should not anonymise deleted participation of deleted campaign on active organization', async function () {
                 // when
                 await script.handle({
                   options: { startArchiveDate },
@@ -502,14 +296,14 @@ describe('DeleteAndAnonymisePreviousCampaignsScript', function () {
 
                 // then
                 expect(deleteParticipation).deep.equal({
-                  userId: null,
-                  participantExternalId: null,
+                  userId: activeOrganization.deletedParticipation.userId,
+                  participantExternalId: activeOrganization.deletedParticipation.participantExternalId,
                   deletedAt: activeOrganization.deletedParticipation.deletedAt,
                   deletedBy: userId,
                 });
               });
 
-              it('should not anonymise or active participation of active organization', async function () {
+              it('should not anonymise of active participation of active organization', async function () {
                 // when
                 await script.handle({
                   options: { startArchiveDate },
@@ -529,17 +323,68 @@ describe('DeleteAndAnonymisePreviousCampaignsScript', function () {
                   deletedBy: null,
                 });
               });
+
+              it('should anonymise of deleted participation only of active campaign on active organization', async function () {
+                // when
+                const deletedParticipationActiveCampaign = databaseBuilder.factory.buildCampaignParticipation({
+                  userId: activeOrganization.activeLearner.userId,
+                  organizationLearnerId: activeOrganization.activeLearner.id,
+                  participantExternalId: 'second',
+                  campaignId: activeOrganization.campaignActive.id,
+                  deletedAt: new Date('2024-01-01'),
+                  deletedBy: userId,
+                  isImproved: true,
+                });
+
+                const deletedImprovedParticipationActiveCampaign = databaseBuilder.factory.buildCampaignParticipation({
+                  userId: activeOrganization.activeLearner.userId,
+                  organizationLearnerId: activeOrganization.activeLearner.id,
+                  participantExternalId: 'second',
+                  isImproved: false,
+                  campaignId: activeOrganization.campaignActive.id,
+                  deletedAt: new Date('2024-02-01'),
+                  deletedBy: userId,
+                });
+
+                await databaseBuilder.commit();
+                await script.handle({
+                  options: { startArchiveDate },
+                  logger,
+                });
+
+                const activeParticipation = await knex('campaign-participations')
+                  .select('id', 'userId', 'participantExternalId', 'deletedAt', 'deletedBy')
+                  .whereNull('userId');
+
+                // then
+                expect(activeParticipation).deep.members([
+                  {
+                    id: deletedParticipationActiveCampaign.id,
+                    userId: null,
+                    participantExternalId: null,
+                    deletedAt: deletedParticipationActiveCampaign.deletedAt,
+                    deletedBy: deletedParticipationActiveCampaign.deletedBy,
+                  },
+                  {
+                    id: deletedImprovedParticipationActiveCampaign.id,
+                    userId: null,
+                    participantExternalId: null,
+                    deletedAt: deletedImprovedParticipationActiveCampaign.deletedAt,
+                    deletedBy: deletedImprovedParticipationActiveCampaign.deletedBy,
+                  },
+                ]);
+              });
             });
           });
 
           describe('#assessments', function () {
-            it('should detach assessments and update updatedAt column only on archived organization before date', async function () {
+            it('should detach assessments and update updatedAt column only on deleted participations on active campaign', async function () {
               // given
               // 1
               const assessmentFromDeletedParticipationOnArchivedOrganizationBeforeDate =
                 databaseBuilder.factory.buildAssessment({
                   userId: archivedOrganizationBeforeDate.deletedLearner.userId,
-                  campaignParticipationId: null,
+                  campaignParticipationId: archivedOrganizationBeforeDate.deletedParticipation.id,
                   updatedAt: new Date('2024-01-01'),
                 });
 
@@ -552,9 +397,19 @@ describe('DeleteAndAnonymisePreviousCampaignsScript', function () {
                 });
 
               // 3
+              const deletedImprovedParticipationActiveCampaign = databaseBuilder.factory.buildCampaignParticipation({
+                userId: activeOrganization.activeLearner.userId,
+                organizationLearnerId: activeOrganization.activeLearner.id,
+                participantExternalId: 'second',
+                isImproved: false,
+                campaignId: activeOrganization.campaignActive.id,
+                deletedAt: new Date('2024-02-01'),
+                deletedBy: userId,
+              });
+
               const assessmentFromDActiveParticipationOnActiveOrganization = databaseBuilder.factory.buildAssessment({
                 userId: activeOrganization.activeLearner.userId,
-                campaignParticipationId: activeOrganization.activeParticipation.id,
+                campaignParticipationId: deletedImprovedParticipationActiveCampaign.id,
                 updatedAt: new Date('2024-01-01'),
               });
 
@@ -575,12 +430,6 @@ describe('DeleteAndAnonymisePreviousCampaignsScript', function () {
                 .whereNull('campaignParticipationId')
                 .pluck('id');
 
-              const previousAnonymuzedAssessments = await knex('assessments')
-                .select('id')
-                .whereNot({ updatedAt: now })
-                .whereNull('campaignParticipationId')
-                .pluck('id');
-
               const activeAssessments = await knex('assessments')
                 .select('id')
                 .whereNot({ updatedAt: now })
@@ -588,19 +437,15 @@ describe('DeleteAndAnonymisePreviousCampaignsScript', function () {
                 .pluck('id');
 
               // then
-              expect(activeAssessments).lengthOf(1);
-              expect(activeAssessments).deep.members([assessmentFromDActiveParticipationOnActiveOrganization.id]);
-
-              expect(previousAnonymuzedAssessments).lengthOf(1);
-              expect(previousAnonymuzedAssessments).deep.members([
+              expect(activeAssessments).lengthOf(3);
+              expect(activeAssessments).deep.members([
+                assessmentFromDDeletedParticipationOnActiveOrganization.id,
+                assessmentFromDeletedParticipationOnArchivedOrganizationAtDate.id,
                 assessmentFromDeletedParticipationOnArchivedOrganizationBeforeDate.id,
               ]);
 
-              expect(anonymizedAssessments).lengthOf(2);
-              expect(anonymizedAssessments).deep.members([
-                assessmentFromDeletedParticipationOnArchivedOrganizationAtDate.id,
-                assessmentFromDDeletedParticipationOnActiveOrganization.id,
-              ]);
+              expect(anonymizedAssessments).lengthOf(1);
+              expect(anonymizedAssessments).deep.members([assessmentFromDActiveParticipationOnActiveOrganization.id]);
             });
           });
 
@@ -637,11 +482,28 @@ describe('DeleteAndAnonymisePreviousCampaignsScript', function () {
                 campaignParticipationId: activeOrganization.activeParticipation.id,
                 trainingId: training2.id,
                 userId: activeOrganization.activeLearner.userId,
-                updatedAt: new Date('2023-01-01'),
+                updatedAt: new Date('2022-01-01'),
               });
 
               databaseBuilder.factory.buildUserRecommendedTraining({
                 campaignParticipationId: activeOrganization.deletedParticipation.id,
+                trainingId: training2.id,
+                userId: activeOrganization.activeLearner.userId,
+                updatedAt: new Date('2023-01-01'),
+              });
+
+              const deletedImprovedParticipationActiveCampaign = databaseBuilder.factory.buildCampaignParticipation({
+                userId: activeOrganization.activeLearner.userId,
+                organizationLearnerId: activeOrganization.activeLearner.id,
+                participantExternalId: 'second',
+                isImproved: false,
+                campaignId: activeOrganization.campaignActive.id,
+                deletedAt: new Date('2024-02-01'),
+                deletedBy: userId,
+              });
+
+              databaseBuilder.factory.buildUserRecommendedTraining({
+                campaignParticipationId: deletedImprovedParticipationActiveCampaign.id,
                 trainingId: training2.id,
                 userId: activeOrganization.activeLearner.userId,
                 updatedAt: new Date('2023-01-01'),
@@ -662,22 +524,28 @@ describe('DeleteAndAnonymisePreviousCampaignsScript', function () {
                 .whereNotNull('campaignParticipationId');
 
               // then
-              expect(anonymizedRecommendedTrainingResults).lengthOf(2);
+              expect(anonymizedRecommendedTrainingResults).lengthOf(1);
               expect(anonymizedRecommendedTrainingResults).deep.members([
                 {
                   campaignParticipationId: null,
-                  userId: archivedOrganizationAtDate.deletedParticipation.userId,
-                },
-                {
-                  campaignParticipationId: null,
-                  userId: activeOrganization.deletedParticipation.userId,
+                  userId: activeOrganization.activeLearner.userId,
                 },
               ]);
-              expect(activeRecommendedTrainings).lengthOf(1);
+              expect(activeRecommendedTrainings).lengthOf(3);
               expect(activeRecommendedTrainings).deep.members([
+                {
+                  campaignParticipationId: archivedOrganizationAtDate.deletedParticipation.id,
+                  userId: archivedOrganizationAtDate.deletedParticipation.userId,
+                  updatedAt: new Date('2024-01-01'),
+                },
                 {
                   campaignParticipationId: activeOrganization.activeParticipation.id,
                   userId: activeOrganization.activeParticipation.userId,
+                  updatedAt: new Date('2022-01-01'),
+                },
+                {
+                  campaignParticipationId: activeOrganization.deletedParticipation.id,
+                  userId: activeOrganization.deletedParticipation.userId,
                   updatedAt: new Date('2023-01-01'),
                 },
               ]);
@@ -734,6 +602,22 @@ describe('DeleteAndAnonymisePreviousCampaignsScript', function () {
                 campaignParticipationId: activeOrganization.deletedParticipation.id,
               });
 
+              const deletedImprovedParticipationActiveCampaign = databaseBuilder.factory.buildCampaignParticipation({
+                userId: activeOrganization.activeLearner.userId,
+                organizationLearnerId: activeOrganization.activeLearner.id,
+                participantExternalId: 'second',
+                isImproved: false,
+                campaignId: activeOrganization.campaignActive.id,
+                deletedAt: new Date('2024-02-01'),
+                deletedBy: userId,
+              });
+
+              databaseBuilder.factory.buildBadgeAcquisition({
+                userId: deletedImprovedParticipationActiveCampaign.userId,
+                badgeId: nonCertifiableBadge.id,
+                campaignParticipationId: deletedImprovedParticipationActiveCampaign.id,
+              });
+
               await databaseBuilder.commit();
 
               // when
@@ -744,15 +628,11 @@ describe('DeleteAndAnonymisePreviousCampaignsScript', function () {
                 .whereNull('userId');
 
               // then
-              expect(detachBadges).lengthOf(2);
+              expect(detachBadges).lengthOf(1);
               expect(detachBadges).deep.members([
                 {
                   badgeId: nonCertifiableBadge.id,
-                  campaignParticipationId: archivedOrganizationAtDate.deletedParticipation.id,
-                },
-                {
-                  badgeId: nonCertifiableBadge.id,
-                  campaignParticipationId: activeOrganization.deletedParticipation.id,
+                  campaignParticipationId: deletedImprovedParticipationActiveCampaign.id,
                 },
               ]);
             });
@@ -764,10 +644,21 @@ describe('DeleteAndAnonymisePreviousCampaignsScript', function () {
                 badgeId: certifiableBadge.id,
                 campaignParticipationId: archivedOrganizationBeforeDate.deletedParticipation.id,
               });
-              databaseBuilder.factory.buildBadgeAcquisition({
+
+              const deletedImprovedParticipationActiveCampaign = databaseBuilder.factory.buildCampaignParticipation({
                 userId: activeOrganization.activeLearner.userId,
+                organizationLearnerId: activeOrganization.activeLearner.id,
+                participantExternalId: 'second',
+                isImproved: false,
+                campaignId: activeOrganization.campaignActive.id,
+                deletedAt: new Date('2024-02-01'),
+                deletedBy: userId,
+              });
+
+              databaseBuilder.factory.buildBadgeAcquisition({
+                userId: deletedImprovedParticipationActiveCampaign.userId,
                 badgeId: certifiableBadge.id,
-                campaignParticipationId: activeOrganization.deletedParticipation.id,
+                campaignParticipationId: deletedImprovedParticipationActiveCampaign.id,
               });
 
               await databaseBuilder.commit();
@@ -791,8 +682,8 @@ describe('DeleteAndAnonymisePreviousCampaignsScript', function () {
                 },
                 {
                   badgeId: certifiableBadge.id,
-                  campaignParticipationId: activeOrganization.deletedParticipation.id,
-                  userId: activeOrganization.activeLearner.userId,
+                  campaignParticipationId: deletedImprovedParticipationActiveCampaign.id,
+                  userId: deletedImprovedParticipationActiveCampaign.userId,
                 },
               ]);
             });

--- a/api/tests/prescription/scripts/integration/delete-organization-learners-from-organization_test.js
+++ b/api/tests/prescription/scripts/integration/delete-organization-learners-from-organization_test.js
@@ -1,5 +1,5 @@
 import { USER_RECOMMENDED_TRAININGS_TABLE_NAME } from '../../../../db/migrations/20221017085933_create-user-recommended-trainings.js';
-import { DeleteOrganizationLearnersFromOrganizationScript } from '../../../../scripts/prod/delete-organization-learners-from-organization.js';
+import { DeleteOrganizationLearnersFromOrganizationScript } from '../../../../src/prescription/scripts/delete-organization-learners-from-organization.js';
 import { catchErr, databaseBuilder, expect, knex, sinon } from '../../../test-helper.js';
 
 describe('Script | Prod | Delete Organization Learners From Organization', function () {

--- a/api/tests/prescription/scripts/integration/insert-missing-pole-emploi-sending-from-date_test.js
+++ b/api/tests/prescription/scripts/integration/insert-missing-pole-emploi-sending-from-date_test.js
@@ -1,8 +1,8 @@
 import dayjs from 'dayjs';
 
-import { insertMissingPoleEmploiSendingFromDate } from '../../../../scripts/prod/insert-missing-pole-emploi-sending-from-date.js';
 import { Tag } from '../../../../src/organizational-entities/domain/models/Tag.js';
 import { PoleEmploiSending } from '../../../../src/prescription/campaign-participation/domain/models/PoleEmploiSending.js';
+import { insertMissingPoleEmploiSendingFromDate } from '../../../../src/prescription/scripts/insert-missing-pole-emploi-sending-from-date.js';
 import { CampaignParticipationStatuses, CampaignTypes } from '../../../../src/prescription/shared/domain/constants.js';
 import { Assessment } from '../../../../src/shared/domain/models/Assessment.js';
 import {

--- a/api/tests/prescription/scripts/integration/migrate-learner-from-static-import-to-generic_test.js
+++ b/api/tests/prescription/scripts/integration/migrate-learner-from-static-import-to-generic_test.js
@@ -1,0 +1,451 @@
+import {
+  findOrganizationLearnersToMigrate,
+  MigrateLearnerFromStaticImportToGeneric,
+} from '../../../../src/prescription/scripts/migrate-learner-from-static-import-to-generic.js';
+import { databaseBuilder, expect, knex, sinon } from '../../../test-helper.js';
+
+describe('Script | Prod | Migrate learner from static import to generic', function () {
+  describe('context AGRI', function () {
+    let organizationAgri, anotherOrganizationAgri, tagIdSco;
+
+    beforeEach(async function () {
+      organizationAgri = databaseBuilder.factory.buildOrganization({ type: 'SCO', isManagingStudents: true });
+      anotherOrganizationAgri = databaseBuilder.factory.buildOrganization({ type: 'SCO', isManagingStudents: true });
+      const tagIdAgri = databaseBuilder.factory.buildTag({ name: 'AGRICULTURE' }).id;
+      tagIdSco = databaseBuilder.factory.buildTag({ name: 'SCO' }).id;
+
+      databaseBuilder.factory.buildOrganizationTag({ organizationId: organizationAgri.id, tagId: tagIdAgri });
+      databaseBuilder.factory.buildOrganizationTag({ organizationId: organizationAgri.id, tagId: tagIdSco });
+
+      databaseBuilder.factory.buildOrganizationTag({ organizationId: anotherOrganizationAgri.id, tagId: tagIdAgri });
+
+      const organizationPro = databaseBuilder.factory.buildOrganization({ type: 'PRO', isManagingStudents: false });
+      const organizationNonImport = databaseBuilder.factory.buildOrganization({
+        type: 'SCO',
+        isManagingStudents: false,
+      });
+      const organizationSCONoAgri = databaseBuilder.factory.buildOrganization({
+        type: 'SCO',
+        isManagingStudents: true,
+      });
+      const organizationSUP = databaseBuilder.factory.buildOrganization({ type: 'SUP', isManagingStudents: true });
+
+      databaseBuilder.factory.buildOrganizationTag({ organizationId: organizationSCONoAgri.id, tagId: tagIdSco });
+      databaseBuilder.factory.buildOrganizationTag({ organizationId: organizationNonImport.id, tagId: tagIdSco });
+
+      databaseBuilder.factory.buildOrganizationLearner({ organizationId: organizationNonImport.id });
+      databaseBuilder.factory.buildOrganizationLearner({ organizationId: organizationPro.id });
+      databaseBuilder.factory.buildOrganizationLearner({ organizationId: organizationSCONoAgri.id });
+      databaseBuilder.factory.buildOrganizationLearner({ organizationId: organizationSUP.id });
+
+      await databaseBuilder.commit();
+    });
+
+    describe('findOrganizationLearnersToMigrate', function () {
+      it('should return learner from organization matching requirement', async function () {
+        databaseBuilder.factory.buildOrganizationLearner({ organizationId: organizationAgri.id });
+        databaseBuilder.factory.buildOrganizationLearner({ organizationId: anotherOrganizationAgri.id });
+
+        await databaseBuilder.commit();
+
+        const organizationLearners = await findOrganizationLearnersToMigrate('AGRI');
+
+        expect(organizationLearners).lengthOf(2);
+      });
+
+      it('should return deleted learner from organization matching requirement', async function () {
+        databaseBuilder.factory.buildOrganizationLearner({
+          organizationId: organizationAgri.id,
+          deletedAt: new Date(),
+        });
+        databaseBuilder.factory.buildOrganizationLearner({
+          organizationId: anotherOrganizationAgri.id,
+          deletedAt: new Date(),
+        });
+
+        await databaseBuilder.commit();
+
+        const organizationLearners = await findOrganizationLearnersToMigrate('AGRI');
+
+        expect(organizationLearners).lengthOf(2);
+      });
+    });
+
+    describe('Handle', function () {
+      it('should update learner from organization matching requirement', async function () {
+        const script = new MigrateLearnerFromStaticImportToGeneric();
+        const logger = { info: sinon.spy(), error: sinon.spy() };
+
+        databaseBuilder.factory.buildOrganizationLearner({
+          organizationId: organizationAgri.id,
+          middleName: 'oui',
+          thirdName: 'non',
+          preferredLastName: 'quoi',
+          sex: 'M',
+          birthCity: 'Tournai',
+          nationalStudentId: '197446465',
+          birthCityCode: '15468',
+          birthCountryCode: 'B487',
+          birthProvinceCode: '184',
+          MEFCode: '666',
+          status: 'AT-AT',
+          division: 'StormTrooper',
+          birthdate: '2012-01-16',
+        });
+
+        databaseBuilder.factory.buildOrganizationLearner({
+          organizationId: anotherOrganizationAgri.id,
+          middleName: 'jean',
+          thirdName: 'pierre',
+          preferredLastName: 'yves',
+          nationalStudentId: '249849874',
+          sex: 'F',
+          birthCity: 'Caramba',
+          birthCityCode: '97891',
+          birthCountryCode: 'A787',
+          birthProvinceCode: '666',
+          MEFCode: '78921B45',
+          status: 'AT-ST',
+          division: 'DeathStar',
+          birthdate: '1845-01-16',
+        });
+
+        await databaseBuilder.commit();
+
+        await script.handle({ options: { dryRun: false, typology: 'AGRI' }, logger });
+
+        const learnerAttributes = await knex('organization-learners')
+          .select('attributes')
+          .whereNotNull('attributes')
+          .pluck('attributes');
+
+        expect(learnerAttributes).lengthOf(2);
+        expect(learnerAttributes).deep.members([
+          {
+            middleName: 'jean',
+            thirdName: 'pierre',
+            preferredLastName: 'yves',
+            sex: 'F',
+            birthCity: 'Caramba',
+            birthCityCode: '97891',
+            nationalStudentId: '249849874',
+            birthCountryCode: 'A787',
+            birthProvinceCode: '666',
+            MEFCode: '78921B45',
+            status: 'AT-ST',
+            division: 'DeathStar',
+            birthdate: '1845-01-16',
+          },
+          {
+            middleName: 'oui',
+            thirdName: 'non',
+            preferredLastName: 'quoi',
+            sex: 'M',
+            birthCity: 'Tournai',
+            nationalStudentId: '197446465',
+            birthCityCode: '15468',
+            birthCountryCode: 'B487',
+            birthProvinceCode: '184',
+            MEFCode: '666',
+            status: 'AT-AT',
+            division: 'StormTrooper',
+            birthdate: '2012-01-16',
+          },
+        ]);
+      });
+    });
+  });
+
+  describe('context SCO', function () {
+    let organizationSCO, anotherOrganizationSCO, tagIdSco;
+
+    beforeEach(async function () {
+      organizationSCO = databaseBuilder.factory.buildOrganization({ type: 'SCO', isManagingStudents: true });
+      anotherOrganizationSCO = databaseBuilder.factory.buildOrganization({ type: 'SCO', isManagingStudents: true });
+      tagIdSco = databaseBuilder.factory.buildTag({ name: 'SCO' }).id;
+
+      const organizationPro = databaseBuilder.factory.buildOrganization({ type: 'PRO', isManagingStudents: false });
+      const organizationNonImport = databaseBuilder.factory.buildOrganization({
+        type: 'SCO',
+        isManagingStudents: false,
+      });
+      const organizationSCOAgri = databaseBuilder.factory.buildOrganization({
+        type: 'SCO',
+        isManagingStudents: true,
+      });
+      const tagIdAgri = databaseBuilder.factory.buildTag({ name: 'AGRICULTURE' }).id;
+
+      const organizationSUP = databaseBuilder.factory.buildOrganization({ type: 'SUP', isManagingStudents: true });
+
+      databaseBuilder.factory.buildOrganizationTag({ organizationId: organizationSCOAgri.id, tagId: tagIdSco });
+      databaseBuilder.factory.buildOrganizationTag({ organizationId: organizationSCOAgri.id, tagId: tagIdAgri });
+      databaseBuilder.factory.buildOrganizationTag({ organizationId: organizationNonImport.id, tagId: tagIdSco });
+
+      databaseBuilder.factory.buildOrganizationLearner({ organizationId: organizationNonImport.id });
+      databaseBuilder.factory.buildOrganizationLearner({ organizationId: organizationPro.id });
+      databaseBuilder.factory.buildOrganizationLearner({ organizationId: organizationSCOAgri.id });
+      databaseBuilder.factory.buildOrganizationLearner({ organizationId: organizationSUP.id });
+
+      await databaseBuilder.commit();
+    });
+
+    describe('findOrganizationLearnersToMigrate', function () {
+      it('should update learner from organization matching requirement', async function () {
+        databaseBuilder.factory.buildOrganizationLearner({ organizationId: organizationSCO.id });
+        databaseBuilder.factory.buildOrganizationLearner({ organizationId: anotherOrganizationSCO.id });
+
+        await databaseBuilder.commit();
+
+        const organizationLearners = await findOrganizationLearnersToMigrate('SCO');
+
+        expect(organizationLearners).lengthOf(2);
+      });
+
+      it('should return deleted learner from organization matching requirement', async function () {
+        databaseBuilder.factory.buildOrganizationLearner({
+          organizationId: organizationSCO.id,
+          deletedAt: new Date(),
+        });
+        databaseBuilder.factory.buildOrganizationLearner({
+          organizationId: anotherOrganizationSCO.id,
+          deletedAt: new Date(),
+        });
+
+        await databaseBuilder.commit();
+
+        const organizationLearners = await findOrganizationLearnersToMigrate('SCO');
+
+        expect(organizationLearners).lengthOf(2);
+      });
+    });
+
+    describe('Handle', function () {
+      it('should update learner from organization matching requirement', async function () {
+        const script = new MigrateLearnerFromStaticImportToGeneric();
+        const logger = { info: sinon.spy(), error: sinon.spy() };
+
+        databaseBuilder.factory.buildOrganizationLearner({
+          organizationId: organizationSCO.id,
+          middleName: 'oui',
+          thirdName: 'non',
+          preferredLastName: 'quoi',
+          sex: 'M',
+          birthCity: 'Tournai',
+          nationalStudentId: '197446465',
+          birthCityCode: '15468',
+          birthCountryCode: 'B487',
+          birthProvinceCode: '184',
+          MEFCode: '666',
+          status: 'AT-AT',
+          division: 'StormTrooper',
+          birthdate: '2012-01-16',
+        });
+
+        databaseBuilder.factory.buildOrganizationLearner({
+          organizationId: anotherOrganizationSCO.id,
+          middleName: 'jean',
+          thirdName: 'pierre',
+          preferredLastName: 'yves',
+          nationalStudentId: '249849874',
+          sex: 'F',
+          birthCity: 'Caramba',
+          birthCityCode: '97891',
+          birthCountryCode: 'A787',
+          birthProvinceCode: '666',
+          MEFCode: '78921B45',
+          status: 'AT-ST',
+          division: 'DeathStar',
+          birthdate: '1845-01-16',
+        });
+
+        await databaseBuilder.commit();
+
+        await script.handle({ options: { dryRun: false, typology: 'SCO' }, logger });
+
+        const learnerAttributes = await knex('organization-learners')
+          .select('attributes')
+          .whereNotNull('attributes')
+          .pluck('attributes');
+
+        expect(learnerAttributes).lengthOf(2);
+        expect(learnerAttributes).deep.members([
+          {
+            middleName: 'jean',
+            thirdName: 'pierre',
+            preferredLastName: 'yves',
+            sex: 'F',
+            birthCity: 'Caramba',
+            birthCityCode: '97891',
+            nationalStudentId: '249849874',
+            birthCountryCode: 'A787',
+            birthProvinceCode: '666',
+            MEFCode: '78921B45',
+            status: 'AT-ST',
+            division: 'DeathStar',
+            birthdate: '1845-01-16',
+          },
+          {
+            middleName: 'oui',
+            thirdName: 'non',
+            preferredLastName: 'quoi',
+            sex: 'M',
+            birthCity: 'Tournai',
+            nationalStudentId: '197446465',
+            birthCityCode: '15468',
+            birthCountryCode: 'B487',
+            birthProvinceCode: '184',
+            MEFCode: '666',
+            status: 'AT-AT',
+            division: 'StormTrooper',
+            birthdate: '2012-01-16',
+          },
+        ]);
+      });
+    });
+  });
+
+  describe('context SUP', function () {
+    let organizationSUP, anotherOrganizationSUP;
+
+    beforeEach(async function () {
+      organizationSUP = databaseBuilder.factory.buildOrganization({ type: 'SUP', isManagingStudents: true });
+      anotherOrganizationSUP = databaseBuilder.factory.buildOrganization({ type: 'SUP', isManagingStudents: true });
+
+      const organizationPro = databaseBuilder.factory.buildOrganization({ type: 'PRO', isManagingStudents: false });
+      const organizationSCOImport = databaseBuilder.factory.buildOrganization({
+        type: 'SCO',
+        isManagingStudents: true,
+      });
+      const organizationSCONonImport = databaseBuilder.factory.buildOrganization({
+        type: 'SCO',
+        isManagingStudents: false,
+      });
+      const organizationSCOAgri = databaseBuilder.factory.buildOrganization({
+        type: 'SCO',
+        isManagingStudents: true,
+      });
+      const tagIdAgri = databaseBuilder.factory.buildTag({ name: 'AGRICULTURE' }).id;
+
+      const organizationNonImportSUP = databaseBuilder.factory.buildOrganization({
+        type: 'SUP',
+        isManagingStudents: false,
+      });
+
+      databaseBuilder.factory.buildOrganizationTag({ organizationId: organizationSCOAgri.id, tagId: tagIdAgri });
+
+      databaseBuilder.factory.buildOrganizationLearner({ organizationId: organizationSCONonImport.id });
+      databaseBuilder.factory.buildOrganizationLearner({ organizationId: organizationSCOImport.id });
+      databaseBuilder.factory.buildOrganizationLearner({ organizationId: organizationPro.id });
+      databaseBuilder.factory.buildOrganizationLearner({ organizationId: organizationSCOAgri.id });
+      databaseBuilder.factory.buildOrganizationLearner({ organizationId: organizationNonImportSUP.id });
+
+      await databaseBuilder.commit();
+    });
+
+    describe('findOrganizationLearnersToMigrate', function () {
+      it('should return learner from organization matching requirement', async function () {
+        databaseBuilder.factory.buildOrganizationLearner({ organizationId: organizationSUP.id });
+        databaseBuilder.factory.buildOrganizationLearner({ organizationId: anotherOrganizationSUP.id });
+
+        await databaseBuilder.commit();
+
+        const organizationLearners = await findOrganizationLearnersToMigrate('SUP');
+
+        expect(organizationLearners).lengthOf(2);
+      });
+
+      it('should return deleted learner from organization matching requirement', async function () {
+        databaseBuilder.factory.buildOrganizationLearner({
+          organizationId: organizationSUP.id,
+          deletedAt: new Date(),
+        });
+        databaseBuilder.factory.buildOrganizationLearner({
+          organizationId: anotherOrganizationSUP.id,
+          deletedAt: new Date(),
+        });
+
+        await databaseBuilder.commit();
+
+        const organizationLearners = await findOrganizationLearnersToMigrate('SUP');
+
+        expect(organizationLearners).lengthOf(2);
+      });
+    });
+
+    describe('Handle', function () {
+      it('should update learner from organization matching requirement', async function () {
+        const script = new MigrateLearnerFromStaticImportToGeneric();
+        const logger = { info: sinon.spy(), error: sinon.spy() };
+
+        databaseBuilder.factory.buildOrganizationLearner({
+          organizationId: organizationSUP.id,
+          middleName: 'oui',
+          thirdName: 'non',
+          preferredLastName: 'quoi',
+          birthdate: '2012-01-16',
+          studentNumber: '1448956',
+          department: 'science',
+          email: 'io.io@io.fr',
+          educationalTeam: 'pouet',
+          group: 'T4',
+          diploma: 'licence',
+          status: 'erier,erkeorknemrlepmr,emrer',
+        });
+
+        databaseBuilder.factory.buildOrganizationLearner({
+          organizationId: anotherOrganizationSUP.id,
+          middleName: 'jean',
+          thirdName: 'pierre',
+          preferredLastName: 'yves',
+          birthdate: '1940-01-16',
+          studentNumber: '98765654',
+          department: 'lettrer',
+          email: 'pouet.io@io.fr',
+          educationalTeam: 'cacahuete',
+          group: 'T2',
+          diploma: 'master',
+          status: 'manger',
+        });
+
+        await databaseBuilder.commit();
+
+        await script.handle({ options: { dryRun: false, typology: 'SUP' }, logger });
+
+        const learnerAttributes = await knex('organization-learners')
+          .select('attributes')
+          .whereNotNull('attributes')
+          .pluck('attributes');
+
+        expect(learnerAttributes).lengthOf(2);
+        expect(learnerAttributes).deep.members([
+          {
+            middleName: 'jean',
+            thirdName: 'pierre',
+            preferredLastName: 'yves',
+            birthdate: '1940-01-16',
+            studentNumber: '98765654',
+            department: 'lettrer',
+            email: 'pouet.io@io.fr',
+            educationalTeam: 'cacahuete',
+            group: 'T2',
+            diploma: 'master',
+            status: 'manger',
+          },
+          {
+            middleName: 'oui',
+            thirdName: 'non',
+            preferredLastName: 'quoi',
+            birthdate: '2012-01-16',
+            studentNumber: '1448956',
+            department: 'science',
+            email: 'io.io@io.fr',
+            educationalTeam: 'pouet',
+            group: 'T4',
+            diploma: 'licence',
+            status: 'erier,erkeorknemrlepmr,emrer',
+          },
+        ]);
+      });
+    });
+  });
+});

--- a/api/tests/unit/scripts/delete-and-anonymize-organization-learner-participations-from-combined-courses_test.js
+++ b/api/tests/unit/scripts/delete-and-anonymize-organization-learner-participations-from-combined-courses_test.js
@@ -1,4 +1,4 @@
-import { DeleteAndAnonymizeOrganizationLearnerParticipationsScript } from '../../../scripts/prod/delete-and-anonymize-organization-learner-participations-from-combined-courses.js';
+import { DeleteAndAnonymizeOrganizationLearnerParticipationsScript } from '../../../src/prescription/scripts/delete-and-anonymize-organization-learner-participations-from-combined-courses.js';
 import { DomainTransaction } from '../../../src/shared/domain/DomainTransaction.js';
 import { catchErr, expect, sinon } from '../../test-helper.js';
 


### PR DESCRIPTION
## 🌎 Problème

Nous avons maintenant deux typologie d'import, les legacy SIECLE / FREGATA / SUP . et l'import modulaire ( ONDE / FWB ) 
## 🔭 Proposition

Faire un script pour rattraper les données des anciens learners pour conserver toutes la rétrocompatibilité de la réconciliation

## 🪐 Remarques

RAS

## 🚀 Pour tester
Executer le script sur PixOrga et constater que tout va bien dans la partie attributes POUR : 

- [x] SIECLE
- [x] FREGATA
- [x]  SUP Avec Import




🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘 🌑
