### PR TITLE
[TECH] Ajouter des seeds pour avoir des réseaux sur plusieurs niveaux (PIX-22041)

### DIFF
--- a/api/db/database-builder/factory/build-network.js
+++ b/api/db/database-builder/factory/build-network.js
@@ -28,7 +28,7 @@ const buildNetwork = function ({
  * @param {number} [options.id] - Network id
  * @param {string} [options.name] - Network name
  * @param {Parameters<typeof buildOrganization>[0]} [options.headOrganization] - Any parameter accepted by buildOrganization
- * @returns {{ id: number, name: string }} The created network
+ * @returns {{ network: {id: number, name: string }, structure: {id: number}}} The created network
  */
 const buildNetworkAndHeadOrganization = function ({
   id = databaseBuffer.getNextId(),
@@ -39,7 +39,7 @@ const buildNetworkAndHeadOrganization = function ({
   const organization = buildOrganization({ name: 'Head Organization', ...headOrganization });
   const structure = buildStructure();
   buildFactStructure({ structureId: structure.id, networkId: network.id, organizationId: organization.id });
-  return network;
+  return { network, structure };
 };
 
 /**

--- a/api/db/seeds/data/common/tooling/organization-tooling.js
+++ b/api/db/seeds/data/common/tooling/organization-tooling.js
@@ -99,6 +99,8 @@ async function createOrganization({
     organizationLearnerTypeId,
   }).id;
 
+  _buildAndLinkStructure({ databaseBuilder, organizationId });
+
   _buildMemberships({
     databaseBuilder,
     organizationId,
@@ -197,6 +199,11 @@ function _buildMemberships({ databaseBuilder, organizationId, adminIds, memberId
       organizationRole: 'MEMBER',
     }),
   );
+}
+
+function _buildAndLinkStructure({ databaseBuilder, organizationId }) {
+  const structureId = databaseBuilder.factory.buildStructure().id;
+  databaseBuilder.factory.buildFactStructure({ structureId, organizationId });
 }
 
 function _buildOrganization({

--- a/api/db/seeds/data/team-acquisition/build-networks.js
+++ b/api/db/seeds/data/team-acquisition/build-networks.js
@@ -6,57 +6,265 @@ import {
 } from './constants.js';
 
 function _buildProNetwork(databaseBuilder) {
-  const network = databaseBuilder.factory.buildNetwork({ name: 'Réseau Professionnel' });
+  const { network, structure: headStructure } = databaseBuilder.factory.buildNetworkAndHeadOrganization({
+    name: 'Réseau Professionnel',
+    headOrganization: {
+      name: 'ABC Comptabilité',
+      externalId: 'PRO_FOR_NETWORK',
+      type: 'PRO',
+      provinceCode: '75',
+      credit: null,
+      createdAt: new Date('2026-09-03'),
+      updatedAt: new Date('2026-09-03'),
 
-  const headOrganization = databaseBuilder.factory.buildOrganization({
-    name: 'ABC Comptabilité Loire-Atlantique',
-    externalId: 'PRO_FOR_NETWORK',
-    type: 'PRO',
-    provinceCode: '44',
-    credit: null,
-    createdAt: new Date('2026-09-03'),
-    updatedAt: new Date('2026-09-03'),
-
-    administrationTeamId: ADMINISTRATION_TEAM_SOLO_ID,
-    organizationLearnerTypeId: ORGANIZATION_LEARNER_TYPE_PROFESSIONAL_ID,
+      administrationTeamId: ADMINISTRATION_TEAM_SOLO_ID,
+      organizationLearnerTypeId: ORGANIZATION_LEARNER_TYPE_PROFESSIONAL_ID,
+    },
   });
+  _buildRegionalAgencies();
 
-  const structure = databaseBuilder.factory.buildStructure();
+  function _buildRegionalAgencies() {
+    databaseBuilder.factory.buildOrganizationInNetwork({
+      networkId: network.id,
+      parentStructureId: headStructure.id,
+      organizationData: {
+        name: 'ABC Comptabilité Agence Ile-de-France',
+        externalId: 'PRO_FOR_NETWORK',
+        type: 'PRO',
+        provinceCode: '75',
+        createdAt: new Date('2026-09-03'),
+        updatedAt: new Date('2026-09-03'),
 
-  databaseBuilder.factory.buildFactStructure({
-    structureId: structure.id,
-    networkId: network.id,
-    organizationId: headOrganization.id,
-  });
+        administrationTeamId: ADMINISTRATION_TEAM_SOLO_ID,
+        organizationLearnerTypeId: ORGANIZATION_LEARNER_TYPE_PROFESSIONAL_ID,
+      },
+    });
+
+    databaseBuilder.factory.buildOrganizationInNetwork({
+      networkId: network.id,
+      parentStructureId: headStructure.id,
+      organizationData: {
+        name: 'ABC Comptabilité Agence Hauts de France',
+        externalId: 'PRO_FOR_NETWORK',
+        type: 'PRO',
+        provinceCode: '59',
+        createdAt: new Date('2026-09-03'),
+        updatedAt: new Date('2026-09-03'),
+
+        administrationTeamId: ADMINISTRATION_TEAM_SOLO_ID,
+        organizationLearnerTypeId: ORGANIZATION_LEARNER_TYPE_PROFESSIONAL_ID,
+      },
+    });
+
+    databaseBuilder.factory.buildOrganizationInNetwork({
+      networkId: network.id,
+      parentStructureId: headStructure.id,
+      organizationData: {
+        name: 'ABC Comptabilité Agence Corse',
+        externalId: 'PRO_FOR_NETWORK',
+        type: 'PRO',
+        provinceCode: '20',
+        createdAt: new Date('2026-09-03'),
+        updatedAt: new Date('2026-09-03'),
+
+        administrationTeamId: ADMINISTRATION_TEAM_SOLO_ID,
+        organizationLearnerTypeId: ORGANIZATION_LEARNER_TYPE_PROFESSIONAL_ID,
+      },
+    });
+  }
 }
 
 function _buildScoNetwork(databaseBuilder) {
-  const network = databaseBuilder.factory.buildNetwork({ name: 'Réseau Scolaire' });
+  const { network, structure: ministereStructure } = databaseBuilder.factory.buildNetworkAndHeadOrganization({
+    name: 'Réseau Scolaire',
+    headOrganization: {
+      name: 'Ministère',
+      externalId: 'SCO_FOR_NETWORK',
+      type: 'SCO',
+      provinceCode: '75',
+      isManagingStudents: true,
+      createdAt: new Date('2026-09-03'),
+      updatedAt: new Date('2026-09-03'),
 
-  const headOrganization = databaseBuilder.factory.buildOrganization({
-    name: 'Ministère',
-    externalId: 'SCO_FOR_NETWORK',
-    type: 'SCO',
-    provinceCode: '75',
-    credit: null,
-    isManagingStudents: true,
-    createdAt: new Date('2026-09-03'),
-    updatedAt: new Date('2026-09-03'),
-
-    administrationTeamId: ADMINISTRATION_TEAM_ALPHA_ID,
-    organizationLearnerTypeId: ORGANIZATION_LEARNER_TYPE_STUDENT_ID,
+      administrationTeamId: ADMINISTRATION_TEAM_ALPHA_ID,
+      organizationLearnerTypeId: ORGANIZATION_LEARNER_TYPE_STUDENT_ID,
+    },
   });
 
-  const structure = databaseBuilder.factory.buildStructure();
+  _buildAcademieVersaillesAndChildren();
+  _buildAcademieNantesAndChildren();
+  _buildAcademieLilleAndChildren();
 
-  databaseBuilder.factory.buildFactStructure({
-    structureId: structure.id,
-    networkId: network.id,
-    organizationId: headOrganization.id,
+  function _buildAcademieVersaillesAndChildren() {
+    const { structure: academieVersaillesStructure } = databaseBuilder.factory.buildOrganizationInNetwork({
+      networkId: network.id,
+      parentStructureId: ministereStructure.id,
+      organizationData: {
+        name: 'Académie de Versailles',
+        externalId: 'SCO_FOR_NETWORK',
+        type: 'SCO',
+        provinceCode: '78',
+        isManagingStudents: true,
+        createdAt: new Date('2026-09-03'),
+        updatedAt: new Date('2026-09-03'),
+
+        administrationTeamId: ADMINISTRATION_TEAM_ALPHA_ID,
+        organizationLearnerTypeId: ORGANIZATION_LEARNER_TYPE_STUDENT_ID,
+      },
+    });
+
+    databaseBuilder.factory.buildOrganizationInNetwork({
+      networkId: network.id,
+      parentStructureId: academieVersaillesStructure.id,
+      organizationData: {
+        name: "Lycée 1 de l'Académie de Versailles",
+        externalId: 'SCO_FOR_NETWORK',
+        type: 'SCO',
+        provinceCode: '78',
+        isManagingStudents: true,
+        createdAt: new Date('2026-09-03'),
+        updatedAt: new Date('2026-09-03'),
+
+        administrationTeamId: ADMINISTRATION_TEAM_ALPHA_ID,
+        organizationLearnerTypeId: ORGANIZATION_LEARNER_TYPE_STUDENT_ID,
+      },
+    });
+
+    databaseBuilder.factory.buildOrganizationInNetwork({
+      networkId: network.id,
+      parentStructureId: academieVersaillesStructure.id,
+      organizationData: {
+        name: "Collège 1 de l'Académie de Versailles",
+        externalId: 'SCO_FOR_NETWORK',
+        type: 'SCO',
+        provinceCode: '78',
+        isManagingStudents: true,
+        createdAt: new Date('2026-09-03'),
+        updatedAt: new Date('2026-09-03'),
+
+        administrationTeamId: ADMINISTRATION_TEAM_ALPHA_ID,
+        organizationLearnerTypeId: ORGANIZATION_LEARNER_TYPE_STUDENT_ID,
+      },
+    });
+  }
+
+  function _buildAcademieNantesAndChildren() {
+    const { structure: academieNantesStructure } = databaseBuilder.factory.buildOrganizationInNetwork({
+      networkId: network.id,
+      parentStructureId: ministereStructure.id,
+      organizationData: {
+        name: 'Académie de Nantes',
+        externalId: 'SCO_FOR_NETWORK',
+        type: 'SCO',
+        provinceCode: '44',
+        isManagingStudents: true,
+        createdAt: new Date('2026-09-03'),
+        updatedAt: new Date('2026-09-03'),
+
+        administrationTeamId: ADMINISTRATION_TEAM_ALPHA_ID,
+        organizationLearnerTypeId: ORGANIZATION_LEARNER_TYPE_STUDENT_ID,
+      },
+    });
+
+    databaseBuilder.factory.buildOrganizationInNetwork({
+      networkId: network.id,
+      parentStructureId: academieNantesStructure.id,
+      organizationData: {
+        name: "Lycée 1 de l'Académie de Nantes",
+        externalId: 'SCO_FOR_NETWORK',
+        type: 'SCO',
+        provinceCode: '44',
+        isManagingStudents: true,
+        createdAt: new Date('2026-09-03'),
+        updatedAt: new Date('2026-09-03'),
+
+        administrationTeamId: ADMINISTRATION_TEAM_ALPHA_ID,
+        organizationLearnerTypeId: ORGANIZATION_LEARNER_TYPE_STUDENT_ID,
+      },
+    });
+
+    databaseBuilder.factory.buildOrganizationInNetwork({
+      networkId: network.id,
+      parentStructureId: academieNantesStructure.id,
+      organizationData: {
+        name: "Collège 1 de l'Académie de Nantes",
+        externalId: 'SCO_FOR_NETWORK',
+        type: 'SCO',
+        provinceCode: '44',
+        isManagingStudents: true,
+        createdAt: new Date('2026-09-03'),
+        updatedAt: new Date('2026-09-03'),
+
+        administrationTeamId: ADMINISTRATION_TEAM_ALPHA_ID,
+        organizationLearnerTypeId: ORGANIZATION_LEARNER_TYPE_STUDENT_ID,
+      },
+    });
+  }
+
+  function _buildAcademieLilleAndChildren() {
+    const { structure: academieLilleStructure } = databaseBuilder.factory.buildOrganizationInNetwork({
+      networkId: network.id,
+      parentStructureId: ministereStructure.id,
+      organizationData: {
+        name: 'Académie de Lille',
+        externalId: 'SCO_FOR_NETWORK',
+        type: 'SCO',
+        provinceCode: '59',
+        isManagingStudents: true,
+        createdAt: new Date('2026-09-03'),
+        updatedAt: new Date('2026-09-03'),
+
+        administrationTeamId: ADMINISTRATION_TEAM_ALPHA_ID,
+        organizationLearnerTypeId: ORGANIZATION_LEARNER_TYPE_STUDENT_ID,
+      },
+    });
+
+    databaseBuilder.factory.buildOrganizationInNetwork({
+      networkId: network.id,
+      parentStructureId: academieLilleStructure.id,
+      organizationData: {
+        name: "Lycée 1 de l'Académie de Lille",
+        externalId: 'SCO_FOR_NETWORK',
+        type: 'SCO',
+        provinceCode: '59',
+        isManagingStudents: true,
+        createdAt: new Date('2026-09-03'),
+        updatedAt: new Date('2026-09-03'),
+
+        administrationTeamId: ADMINISTRATION_TEAM_ALPHA_ID,
+        organizationLearnerTypeId: ORGANIZATION_LEARNER_TYPE_STUDENT_ID,
+      },
+    });
+
+    databaseBuilder.factory.buildOrganizationInNetwork({
+      networkId: network.id,
+      parentStructureId: academieLilleStructure.id,
+      organizationData: {
+        name: "Collège 1 de l'Académie de Lille",
+        externalId: 'SCO_FOR_NETWORK',
+        type: 'SCO',
+        provinceCode: '59',
+        isManagingStudents: true,
+        createdAt: new Date('2026-09-03'),
+        updatedAt: new Date('2026-09-03'),
+
+        administrationTeamId: ADMINISTRATION_TEAM_ALPHA_ID,
+        organizationLearnerTypeId: ORGANIZATION_LEARNER_TYPE_STUDENT_ID,
+      },
+    });
+  }
+}
+
+function _buildComplexNetwork(databaseBuilder) {
+  databaseBuilder.factory.buildNetworkWithMultipleLevels({
+    name: 'Réseau Complexe',
+    numberOfLevels: 4,
+    childrenPerNode: 3,
   });
 }
 
 export function buildNetworks(databaseBuilder) {
   _buildProNetwork(databaseBuilder);
   _buildScoNetwork(databaseBuilder);
+  _buildComplexNetwork(databaseBuilder);
 }

--- a/api/tests/organizational-entities/acceptance/application/network/network.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/network/network.admin.route.test.js
@@ -57,10 +57,10 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | N
   });
 
   describe('GET /api/admin/networks/1', function () {
-    it('returns a list of networks with 200 HTTP status code', async function () {
+    it('returns a specific network with 200 HTTP status code', async function () {
       // given
       const server = await createServer();
-      const network = databaseBuilder.factory.buildNetworkAndHeadOrganization({
+      const { network } = databaseBuilder.factory.buildNetworkAndHeadOrganization({
         id: 1,
         name: 'Mon réseau',
         headOrganization: { id: 555, name: 'Tête de réseau' },
@@ -95,7 +95,7 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | N
   describe('PATCH /api/admin/networks/{networkId}', function () {
     it('updates the network name and returns 200', async function () {
       // given
-      const network = databaseBuilder.factory.buildNetworkAndHeadOrganization({ name: 'Ancien nom' });
+      const { network } = databaseBuilder.factory.buildNetworkAndHeadOrganization({ name: 'Ancien nom' });
       await databaseBuilder.commit();
 
       const request = {

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/network.repository.test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/network.repository.test.js
@@ -97,7 +97,7 @@ describe('Integration | Organizational Entities | Infrastructure | Repositories 
       it('returns the network with head organization informations', async function () {
         // given
         const headOrganizationId = 999;
-        const network = databaseBuilder.factory.buildNetworkAndHeadOrganization({
+        const { network } = databaseBuilder.factory.buildNetworkAndHeadOrganization({
           name: 'Mon super réseau',
           headOrganization: { id: headOrganizationId, name: 'Orga tête de réseau' },
         });


### PR DESCRIPTION
## 🌎 Problème

Dans le cadre de la fonctionnalité des réseaux d'organisations, on veut pouvoir visualiser des réseaux sur plusieurs niveaux dans Pix Admin.

## 🔭 Proposition

Créer 3 réseaux dans les seeds:
- 1 réseau PRO sur 2 niveaux
- 1 réseau SCO sur 3 niveaux
- 1 réseau plus "technique" sur 4 niveaux

## 🪐 Remarques

- On a profité de ce ticket pour venir créer des structures en même temps que les orgas dans la méthode de tooling `createOrganization`. Cela permet de réduire le nombre d'orgas sans structures (qui devront tomber à 0 à terme afin d'être cohérent avec les données de recette et de prod). Il en reste tout de même aux endroits où les seeds d'orgas sont créées directement avec la databaseBuilder sans créer de structures en même temps.
- On utilise les nouveaux database builders pour créer les réseaux et les organisations filles. Un de ces builders a dû être modifié pour notre utilisation.

## 🚀 Pour tester

- `npm run db:reset` ne génère pas d'erreur
- on peut avoir un aperçu des réseaux et des orgas créés sur Pix Admin aussi (mais pas encore le lien entre les différents niveaux)

🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘 🌑
