### PR TITLE
[BUGFIX] Modifier l'illustration clé pour les grains short-lesson (PIX-22108)

### DIFF
--- a/mon-pix/app/components/module/grain/_grain.scss
+++ b/mon-pix/app/components/module/grain/_grain.scss
@@ -74,7 +74,7 @@ $grain-card-border-radius: var(--pix-spacing-4x);
     @include breakpoints.device-is('desktop') {
       top: -30px;
       right: -35px;
-      width: 75px;
+      width: 70px;
     }
   }
 


### PR DESCRIPTION
## 🌎 Problème

Problème remonté par le métier: la clé illustrant les short-lesson est trop proche du texte quand on atteint la taille limite du titre d'un short lesson.

<img width="203" height="135" alt="image" src="https://github.com/user-attachments/assets/87d80404-2123-4fe0-b6a6-7a5b0d525e34" />

## 🔭 Proposition

Réduire la taille de la clé de qq pixels pour qu'elle soit moins proche du texte. A valider ensemble:
<img width="146" height="121" alt="image" src="https://github.com/user-attachments/assets/e94f0a97-1d12-4a0a-a32d-33ddcab1c612" />


## 🪐 Remarques

A valider ensemble

## 🚀 Pour tester
- Ouvrir le module [ail-des-ours](https://app-pr15673.review.pix.fr/modules/43e420e6/ia-def-ind)
- Passer les grains jusqu'au grain avec le titre _Si l'on résume, comment se passe l'entraînement d'un logiciel de reconnaissance d'image ?_
- Constater l'affichage de l'image "clé" en haut à droite du grain

🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘 🌑
