### PR TITLE
[FEATURE] Mise à jour du feedback du robot lors de la réalisation d'un challenge (PIX-22053)

### DIFF
--- a/junior/translations/fr.json
+++ b/junior/translations/fr.json
@@ -58,7 +58,7 @@
         "placeholder": "Chargement en cours"
       },
       "messages": {
-        "correct-answer": "Bien joué, tu as répondu correctement ! Tu peux continuer.",
+        "correct-answer": "Bien joué ! Tu peux continuer.",
         "wrong-answer": "Mauvaise réponse. Tu peux continuer."
       },
       "qcm-error": "Attention, sélectionne plusieurs réponses !",


### PR DESCRIPTION
## 🌎 Problème

Le contenu textuel du feedback fait par le robot n'est pas assez générique.

## 🔭 Proposition

Mettre a jour la trad

## 🪐 Remarques

RAS

## 🚀 Pour tester
Code: MINIPIXOU
Réussir un challenge et observer que le message du robot est bien : `Bien joué ! Tu peux continuer.`
<img width="480" height="270" alt="image" src="https://github.com/user-attachments/assets/c361d4fd-0be8-4351-a0e7-6f96861553b3" />
