### PR TITLE
[FEATURE] Afficher un nouvel onglet Réseau sur la page d'une organisation (PIX-22042)

### DIFF
--- a/admin/app/router.js
+++ b/admin/app/router.js
@@ -52,6 +52,7 @@ Router.map(function () {
         });
         this.route('invitations');
         this.route('children');
+        this.route('network');
       });
     });
 

--- a/admin/app/routes/authenticated/organizations/get/network.js
+++ b/admin/app/routes/authenticated/organizations/get/network.js
@@ -1,0 +1,17 @@
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+export default class Network extends Route {
+  @service accessControl;
+  @service router;
+
+  beforeModel() {
+    this.accessControl.restrictAccessTo(['isSuperAdmin'], 'authenticated.organizations.get.details');
+
+    const organization = this.modelFor('authenticated.organizations.get');
+
+    if (!organization.network.id) {
+      this.router.replaceWith('authenticated.organizations.get.details');
+    }
+  }
+}

--- a/admin/app/templates/authenticated/organizations/get.gjs
+++ b/admin/app/templates/authenticated/organizations/get.gjs
@@ -74,6 +74,13 @@ import HeadInformation from 'pix-admin/components/organizations/head-information
         {{t "pages.organization.navbar.children"}}
         ({{@model.children.length}})
       </LinkTo>
+      {{#if @controller.accessControl.currentUser.adminMember.isSuperAdmin}}
+        {{#if @model.network.id}}
+          <LinkTo @route="authenticated.organizations.get.network" @model={{@model}}>
+            {{t "pages.organization.navbar.network" nbrOfChildren=@model.children.length}}
+          </LinkTo>
+        {{/if}}
+      {{/if}}
     </PixTabs>
 
     {{outlet}}

--- a/admin/tests/acceptance/authenticated/organizations/get-test.js
+++ b/admin/tests/acceptance/authenticated/organizations/get-test.js
@@ -27,6 +27,7 @@ module('Acceptance | Organizations | Get', function (hooks) {
     const ORGANIZATION_ID = 1;
     const ARCHIVED_ORGANIZATION_ID = 2;
     const ORGANIZATION_WITHOUT_PLACES_MANAGEMENT_ID = 3;
+    const ORGANIZATION_IN_NETWORK_ID = 4;
 
     hooks.beforeEach(async () => {
       await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
@@ -382,6 +383,71 @@ module('Acceptance | Organizations | Get', function (hooks) {
           assert.strictEqual(currentURL(), `/organizations/${ORGANIZATION_ID}/children`);
         });
       });
+
+      module('Network tab', function () {
+        module('when organization is part of a network', function (hooks) {
+          hooks.beforeEach(() => {
+            const network = server.create('network', { name: 'Réseau Pro' });
+
+            server.create('organization', {
+              id: ORGANIZATION_IN_NETWORK_ID,
+              name: 'My Organization In Network',
+              features: { PLACES_MANAGEMENT: { active: true } },
+              network: network,
+            });
+
+            server.create('organization', {
+              parentOrganizationId: ORGANIZATION_IN_NETWORK_ID,
+              name: 'Child of My Organization In Network',
+              features: { PLACES_MANAGEMENT: { active: false } },
+            });
+          });
+
+          test('it should display Network tab, with number of sub-level organizations', async function (assert) {
+            // when
+            const screen = await visit(`/organizations/${ORGANIZATION_IN_NETWORK_ID}`);
+
+            // then
+            const navigationTabs = screen.getByRole('navigation', { name: t('pages.organization.navbar.aria-label') });
+            assert.ok(
+              within(navigationTabs).getByRole('link', {
+                name: t('pages.organization.navbar.network', { nbrOfChildren: 1 }),
+              }),
+            );
+          });
+
+          test('it should navigate to organization network page when clicking tab', async function (assert) {
+            // given
+            const screen = await visit(`/organizations/${ORGANIZATION_IN_NETWORK_ID}`);
+
+            // when
+            const navigationTabs = screen.getByRole('navigation', { name: t('pages.organization.navbar.aria-label') });
+
+            const networkTab = within(navigationTabs).getByRole('link', {
+              name: t('pages.organization.navbar.network', { nbrOfChildren: 1 }),
+            });
+            await click(networkTab);
+
+            // then
+            assert.strictEqual(currentURL(), `/organizations/${ORGANIZATION_IN_NETWORK_ID}/network`);
+          });
+        });
+
+        module('when organization is not part of a network', function () {
+          test('it should not display Network tab', async function (assert) {
+            // when
+            const screen = await visit(`/organizations/${ORGANIZATION_ID}`);
+
+            // then
+            const navigationTabs = screen.getByRole('navigation', { name: t('pages.organization.navbar.aria-label') });
+            assert.notOk(
+              within(navigationTabs).queryByRole('link', {
+                name: t('pages.organization.navbar.network', { nbrOfChildren: 0 }),
+              }),
+            );
+          });
+        });
+      });
     });
   });
 
@@ -440,6 +506,63 @@ module('Acceptance | Organizations | Get', function (hooks) {
       // then
       const navigationTabs = screen.getByRole('navigation', { name: t('pages.organization.navbar.aria-label') });
       assert.notOk(within(navigationTabs).queryByRole('link', { name: t('pages.organization.navbar.tags') }));
+    });
+  });
+
+  module('Network tab Access control (temporary tests, to be deleted at the end of epix PIX-21277)', function (hooks) {
+    hooks.beforeEach(() => {
+      server.create('organization', {
+        id: 99,
+        name: 'My Organization',
+        features: { PLACES_MANAGEMENT: { active: true } },
+      });
+    });
+    test('should not be visible for Certif member', async function (assert) {
+      // given
+      await authenticateAdminMemberWithRole({ isCertif: true })(server);
+
+      // when
+      const screen = await visit('/organizations/99');
+
+      // then
+      const navigationTabs = screen.getByRole('navigation', { name: t('pages.organization.navbar.aria-label') });
+      assert.notOk(
+        within(navigationTabs).queryByRole('link', {
+          name: t('pages.organization.navbar.network', { nbrOfChildren: 0 }),
+        }),
+      );
+    });
+
+    test('should not be visible for Support member', async function (assert) {
+      // given
+      await authenticateAdminMemberWithRole({ isSupport: true })(server);
+
+      //when
+      const screen = await visit('/organizations/99');
+
+      // then
+      const navigationTabs = screen.getByRole('navigation', { name: t('pages.organization.navbar.aria-label') });
+      assert.notOk(
+        within(navigationTabs).queryByRole('link', {
+          name: t('pages.organization.navbar.network', { nbrOfChildren: 0 }),
+        }),
+      );
+    });
+
+    test('should not be visible for Metier member', async function (assert) {
+      // given
+      await authenticateAdminMemberWithRole({ isMetier: true })(server);
+
+      // when
+      const screen = await visit('/organizations/99');
+
+      // then
+      const navigationTabs = screen.getByRole('navigation', { name: t('pages.organization.navbar.aria-label') });
+      assert.notOk(
+        within(navigationTabs).queryByRole('link', {
+          name: t('pages.organization.navbar.network', { nbrOfChildren: 0 }),
+        }),
+      );
     });
   });
 });

--- a/admin/tests/unit/routes/authenticated/organizations/get/network-test.js
+++ b/admin/tests/unit/routes/authenticated/organizations/get/network-test.js
@@ -1,0 +1,48 @@
+import EmberObject from '@ember/object';
+import Service from '@ember/service';
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module('Unit | Route | authenticated/organizations/get/network', function (hooks) {
+  setupTest(hooks);
+
+  let route, restrictAccessToStub;
+
+  hooks.beforeEach(function () {
+    route = this.owner.lookup('route:authenticated/organizations/get/network');
+    sinon.stub(route.router, 'replaceWith');
+
+    restrictAccessToStub = sinon.stub().returns();
+    class AccessControlStub extends Service {
+      restrictAccessTo = restrictAccessToStub;
+    }
+    this.owner.register('service:access-control', AccessControlStub);
+  });
+
+  module('#beforeModel', function () {
+    test('it should check if current user is super admin', function (assert) {
+      // given
+      const organization = EmberObject.create({ network: { id: 123, name: 'My Network' } });
+      sinon.stub(route, 'modelFor').returns(organization);
+
+      // when
+      route.beforeModel();
+
+      // then
+      assert.ok(restrictAccessToStub.calledWith(['isSuperAdmin'], 'authenticated.organizations.get.details'));
+    });
+
+    test('it should transition to details route when organization does not belong to a network', async function (assert) {
+      // given
+      const organization = EmberObject.create({ network: { id: null, name: null } });
+      sinon.stub(route, 'modelFor').returns(organization);
+
+      // when
+      await route.beforeModel();
+
+      // then
+      assert.ok(route.router.replaceWith.calledWith('authenticated.organizations.get.details'));
+    });
+  });
+});

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -1522,6 +1522,7 @@
         "details": "Details",
         "features": "Features",
         "invitations": "Invitations",
+        "network": "Network {nbrOfChildren, plural, =1 {({nbrOfChildren} child)} other {({nbrOfChildren} children)}}",
         "places": "Places",
         "tags": "Tags",
         "target-profiles": "Target profiles",

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -1525,6 +1525,7 @@
         "details": "Détails",
         "features": "Fonctionnalités",
         "invitations": "Invitations",
+        "network": "Réseau {nbrOfChildren, plural, =1 {({nbrOfChildren} fille)} other {({nbrOfChildren} filles)}}",
         "places": "Places",
         "tags": "Tags",
         "target-profiles": "Profils cibles",


### PR DESCRIPTION
## 🌎 Problème

Sur Pix Admin, on a désormais des réseaux d'organisations. On veut pouvoir visualiser les organisations filles d'une organisation au sein de son réseau.

## 🔭 Proposition

Afficher un nouvel onglet "Réseau" sur la page d'une organisation. Ici s'afficheront plus tard les organisations filles selon le nouveau système de réseaux.

## 🪐 Remarques

- cet onglet n'est visible que pour le superAdmin pour le moment
- cet onglet n'est pas visible pour une orga ne faisant pas partie d'un réseau
- cet onglet ne contient rien pour le moment

## 🚀 Pour tester
Sur Pix Admin:
Test 1
- se connecter en superAdmin et naviguer vers la page d'une organisation faisant partie d'un réseau
- constater la présence d'un onglet Réseau
- cliquer sur cet onglet et constater que l'URL est bonne mais qu'il n'y a pas de contenu

Test 2
- naviguer sur une organisation ne faisant pas partie d'un réseau
- constater l'absence de l'onglet Réseau
- constater qu'il n'est pas possible d'accéder à l'URL `organizations/{id}/network`

Test 3
- se connecter avec les autres rôles
- constater que l'onglet n'est jamais visible pour aucune organisation et qu'il n'est pas possible d'accéder à l'URL `organizations/{id}/network`

🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘 🌑
