### PR TITLE
[TECH] Corriger les tests de téléchargement de résultats CSV sur les E2E de certification

### DIFF
--- a/high-level-tests/e2e-playwright/pages/pix-admin/CertificationSessionPage.ts
+++ b/high-level-tests/e2e-playwright/pages/pix-admin/CertificationSessionPage.ts
@@ -65,7 +65,11 @@ export class CertificationSessionPage {
     await this.page.getByRole('button', { name: 'Lien de téléchargement des résultats' }).click();
     await generateCsvLinkPromise;
     const link = await this.page.evaluate(() => navigator.clipboard.readText());
-    await this.page.goto(link);
+    const linkUrl = new URL(link);
+    const appPixUrl = new URL(process.env.PIX_APP_URL!);
+    linkUrl.protocol = appPixUrl.protocol;
+    linkUrl.host = appPixUrl.host;
+    await this.page.goto(linkUrl.toString());
 
     await this.page.getByText('Télécharger les résultats de session').waitFor({ state: 'visible' });
     const downloadTrigger = this.page.getByRole('button', { name: 'Télécharger les résultats', exact: true }).click();


### PR DESCRIPTION
## 🌎 Problème

Sur CircleCI, les tests impliquant un téléchargement de CSV ne marchent pas.
L'url de lien renvoie vers le pix-app de prod

## 🔭 Proposition

Remplacer l'url reçue par l'API en mettant localhost:4200 à la place

## 🪐 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🚀 Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->

🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘 🌑
