### PR TITLE
[TECH] Corriger le test e2e flaky sur la gestion des étudiants SUP (PIX-22145)

### DIFF
--- a/high-level-tests/e2e-playwright/tests/pix-orga/sup-students-management.test.ts
+++ b/high-level-tests/e2e-playwright/tests/pix-orga/sup-students-management.test.ts
@@ -43,6 +43,7 @@ test('Managing sup students', async ({ page }) => {
     await orgaPage.waitForTheImportToComplete(page);
   });
   await test.step('show learners', async () => {
+    await page.goto(process.env.PIX_ORGA_URL as string);
     await page.getByRole('link', { name: 'Étudiants' }).click();
     await expect(
       page.getByRole('paragraph').filter({ hasText: 'Les participants ont bien été importés' }),


### PR DESCRIPTION
## 🌎 Problème

Le test e2e `sup-students-management` échouait de manière intermittente en CI : après un import réussi, la liste affichait 0 étudiants malgré le bandeau de succès visible.

## 🔭 Proposition

Aligner le test SUP avec le pattern SCO/generic : ajouter un `page.goto(PIX_ORGA_URL)` avant la navigation dans le step "show learners" pour forcer un rechargement complet avant d'interroger la liste.

## 🚀 Pour tester

- [x] 🟢 

🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘 🌑