### PR TITLE
[TECH] Retirer le feature toggle "enableTransactionForGetNext" qui permettait d'exécuter le code de "getNextChallenge" dans une transaction BDD

### DIFF
--- a/api/config/feature-toggles-config.js
+++ b/api/config/feature-toggles-config.js
@@ -81,12 +81,6 @@ export default {
     defaultValue: [],
     tags: ['team-acces', 'i18n', 'frontend'],
   },
-  enableTransactionForGetNext: {
-    type: 'boolean',
-    description: 'Enable wrapping the get next challenge usecase in a transaction',
-    defaultValue: true,
-    tags: ['captain', 'backend', 'db', 'pool'],
-  },
   successHandlersForDomainTransaction: {
     type: 'boolean',
     description: 'Enable success handlers for DomainTransaction',

--- a/api/src/shared/application/assessments/assessment-controller.js
+++ b/api/src/shared/application/assessments/assessment-controller.js
@@ -8,7 +8,6 @@ import * as competenceEvaluationSerializer from '../../../evaluation/infrastruct
 import { usecases as questUsecases } from '../../../quest/domain/usecases/index.js';
 import { DomainTransaction } from '../../domain/DomainTransaction.js';
 import { sharedUsecases } from '../../domain/usecases/index.js';
-import { featureToggles } from '../../infrastructure/feature-toggles/index.js';
 import * as assessmentRepository from '../../infrastructure/repositories/assessment-repository.js';
 import * as assessmentSerializer from '../../infrastructure/serializers/jsonapi/assessment-serializer.js';
 import { extractUserIdFromRequest, getChallengeLocale } from '../../infrastructure/utils/request-response-utils.js';
@@ -29,19 +28,6 @@ const getAssessmentWithNextChallenge = async function (
   const assessmentId = request.params.id;
   const locale = getChallengeLocale(request);
   const userId = dependencies.extractUserIdFromRequest(request);
-
-  const enableTransactionForGetNext = await featureToggles.get('enableTransactionForGetNext');
-  if (enableTransactionForGetNext) {
-    const { assessment, globalProgression } = await DomainTransaction.execute(async () => {
-      return sharedUsecases.updateAssessmentWithNextChallenge({
-        assessmentId,
-        userId,
-        locale,
-      });
-    });
-
-    return dependencies.assessmentSerializer.serialize(assessment.toDto(globalProgression));
-  }
 
   const { assessment, globalProgression } = await sharedUsecases.updateAssessmentWithNextChallenge({
     assessmentId,


### PR DESCRIPTION
## 🌎 Problème

Avec les remous de la prod en début d'année, on a compris qu'avoir des transactions au long cours peut empirer une situation déjà instable, et provoquer des bouchons au niveau du pool de connexions.
Il est établi que PG tolère mieux beaucoup d'opérations courtes que un volume d'opérations plus petit mais plus longues.

## 🔭 Proposition

Avait été mis en place un feature toggle permettant d'enrober ou pas le code du "getNextChallenge" afin de tester en prod si le retrait de la transaction avait des effets négatifs. Constat : ça se comporte très bien même sans transaction.

Je propose de retirer le feature toggle et de laisser le code être sans transaction.

## 🪐 Remarques

ça fait déjà un moment que ce FT est laissé à false en production, donc ça fait un moment que le code n'est plus sous transaction

## 🚀 Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->

🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘 🌑
