### PR TITLE
[TECH] Correction d'un test e2e flaky côté modulix-a11y (PIX-22147)

### DIFF
--- a/high-level-tests/e2e-playwright/tests/pix-app/modulix-a11y.test.ts
+++ b/high-level-tests/e2e-playwright/tests/pix-app/modulix-a11y.test.ts
@@ -6,7 +6,7 @@ test('test modulix a11y on galerie module', async ({ page }) => {
   await page.goto(process.env.PIX_APP_URL + '/modules/b9414fc3/galerie/details');
 
   // Module Details
-  await expect(page).toHaveTitle(/Galerie Modulix/);
+  await expect(page).toHaveTitle(/Galerie Modulix/, { timeout: 10_000 });
   await page.getByRole('button', { name: 'Commencer le module' }).click();
 
   // Module Passage


### PR DESCRIPTION
## 🌎 Problème

Laura a remonté un test flaky côté e2e, sur l'a11y des modules.

## 🔭 Proposition

Correction en utilisant l'option `timeout` de l'assert `toHaveTitle()` (doc playwright [ici](https://playwright.dev/docs/api/class-pageassertions#page-assertions-to-have-title))

## 🪐 Remarques

RAS

## 🚀 Pour tester

CI super green

🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘 🌑
