### PR TITLE
[BUGFIX] Ne pas remonter les participations d'un parcours supprimé dans les statistiques du parcours (PIX-22139)

### DIFF
--- a/api/src/quest/infrastructure/repositories/combined-course-participation-repository.js
+++ b/api/src/quest/infrastructure/repositories/combined-course-participation-repository.js
@@ -1,5 +1,4 @@
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
-import { NotFoundError } from '../../../shared/domain/errors.js';
 import { filterByFullName } from '../../../shared/infrastructure/utils/filter-utils.js';
 import { fetchPage } from '../../../shared/infrastructure/utils/knex-utils.js';
 import { CombinedCourseParticipation } from '../../domain/models/CombinedCourseParticipation.js';
@@ -71,41 +70,6 @@ export const isParticipationOnCombinedCourse = async function ({ combinedCourseI
     })
     .first();
   return Boolean(count);
-};
-
-export const getByUserId = async function ({ userId, combinedCourseId }) {
-  const knexConnection = DomainTransaction.getConnection();
-
-  const combinedCourseParticipations = await knexConnection('organization_learner_participations')
-    .select(
-      'organization_learner_participations.id',
-      'organizationLearnerId',
-      'view-active-organization-learners.firstName',
-      'view-active-organization-learners.lastName',
-      'view-active-organization-learners.division',
-      'view-active-organization-learners.group',
-      'organization_learner_participations.status',
-      'organization_learner_participations.createdAt',
-      'organization_learner_participations.updatedAt',
-      'organization_learner_participations.referenceId',
-    )
-    .join(
-      'view-active-organization-learners',
-      'view-active-organization-learners.id',
-      '=',
-      'organization_learner_participations.organizationLearnerId',
-    )
-    .where({
-      'view-active-organization-learners.userId': userId,
-      'organization_learner_participations.referenceId': combinedCourseId.toString(),
-      'organization_learner_participations.type': OrganizationLearnerParticipationTypes.COMBINED_COURSE,
-    });
-  if (combinedCourseParticipations.length === 0) {
-    throw new NotFoundError(
-      `CombinedCourseParticipation introuvable pour l'utilisateur d'id ${userId} et au parcours d'id ${combinedCourseId}`,
-    );
-  }
-  return new CombinedCourseParticipation(combinedCourseParticipations[0]);
 };
 
 export const findByLearnerId = async function ({ organizationLearnerId, combinedCourseId }) {

--- a/api/src/quest/infrastructure/repositories/combined-course-participation-repository.js
+++ b/api/src/quest/infrastructure/repositories/combined-course-participation-repository.js
@@ -215,7 +215,8 @@ export const findByCombinedCourseIds = async ({ combinedCourseIds }) => {
       'organization_learner_participations.referenceId',
       combinedCourseIds.map((combinedCourseId) => combinedCourseId.toString()),
     )
-    .where('organization_learner_participations.type', OrganizationLearnerParticipationTypes.COMBINED_COURSE);
+    .where('organization_learner_participations.type', OrganizationLearnerParticipationTypes.COMBINED_COURSE)
+    .whereNull('organization_learner_participations.deletedAt');
 
   return results.map((participation) => new CombinedCourseParticipation(participation));
 };

--- a/api/tests/quest/integration/infrastructure/repositories/combined-course-participation-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/combined-course-participation-repository_test.js
@@ -7,8 +7,7 @@ import {
   OrganizationLearnerParticipationTypes,
 } from '../../../../../src/quest/domain/models/OrganizationLearnerParticipation.js';
 import * as combinedCourseParticipationRepository from '../../../../../src/quest/infrastructure/repositories/combined-course-participation-repository.js';
-import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
-import { catchErr, databaseBuilder, expect, knex } from '../../../../test-helper.js';
+import { databaseBuilder, expect, knex } from '../../../../test-helper.js';
 
 describe('Quest | Integration | Infrastructure | repositories | Combined-Course-Participation', function () {
   describe('#save', function () {
@@ -222,51 +221,6 @@ describe('Quest | Integration | Infrastructure | repositories | Combined-Course-
 
       // then
       expect(result).false;
-    });
-  });
-
-  describe('#getByUserId', function () {
-    it('should return combinedCourse participation for given user and combinedCourse ids', async function () {
-      // given
-      const userId = databaseBuilder.factory.buildUser().id;
-      const {
-        firstName,
-        lastName,
-        id: organizationLearnerId,
-      } = databaseBuilder.factory.buildOrganizationLearner({ userId });
-      const { id: combinedCourseId } = databaseBuilder.factory.buildCombinedCourse();
-      databaseBuilder.factory.buildOrganizationLearnerParticipation({
-        organizationLearnerId,
-        status: OrganizationLearnerParticipationStatuses.COMPLETED,
-        type: OrganizationLearnerParticipationTypes.COMBINED_COURSE,
-        combinedCourseId,
-      });
-      await databaseBuilder.commit();
-
-      // when
-      const result = await combinedCourseParticipationRepository.getByUserId({ userId, combinedCourseId });
-
-      // then
-      expect(result.combinedCourseId).to.deep.equal(combinedCourseId);
-      expect(result.organizationLearnerId).to.deep.equal(organizationLearnerId);
-      expect(result.firstName).equal(firstName);
-      expect(result.lastName).equal(lastName);
-      expect(result.status).to.deep.equal(OrganizationLearnerParticipationStatuses.COMPLETED);
-    });
-
-    it('should throw NotFound error when combinedCourse participation does not exist for given user and combinedCourse ids', async function () {
-      // given
-      const userId = 1;
-      const combinedCourseId = 2;
-
-      // when
-      const error = await catchErr(combinedCourseParticipationRepository.getByUserId)({ userId, combinedCourseId });
-
-      // then
-      expect(error).to.be.instanceof(NotFoundError);
-      expect(error.message).to.equal(
-        `CombinedCourseParticipation introuvable pour l'utilisateur d'id ${userId} et au parcours d'id ${combinedCourseId}`,
-      );
     });
   });
 

--- a/api/tests/quest/integration/infrastructure/repositories/combined-course-participation-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/combined-course-participation-repository_test.js
@@ -828,5 +828,38 @@ describe('Quest | Integration | Infrastructure | repositories | Combined-Course-
       // then
       expect(combinedCourseParticipations).to.deep.equal([]);
     });
+
+    it('should not return deleted participations', async function () {
+      // given
+      const { id: combinedCourseId, organizationId } = databaseBuilder.factory.buildCombinedCourse({
+        code: 'COMBI1',
+      });
+
+      const { id: organizationLearnerId } = databaseBuilder.factory.buildOrganizationLearner({
+        firstName: 'Alice',
+        lastName: 'Azerty',
+        division: '6eme',
+        group: 'Groupe 2',
+        organizationId,
+      });
+
+      databaseBuilder.factory.buildOrganizationLearnerParticipation({
+        organizationLearnerId,
+        status: OrganizationLearnerParticipationStatuses.COMPLETED,
+        combinedCourseId,
+        type: OrganizationLearnerParticipationTypes.COMBINED_COURSE,
+        deletedAt: new Date(),
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const combinedCourseParticipations = await combinedCourseParticipationRepository.findByCombinedCourseIds({
+        combinedCourseIds: [combinedCourseId],
+      });
+
+      // then
+      expect(combinedCourseParticipations.length).to.equal(0);
+    });
   });
 });


### PR DESCRIPTION
## 🌎 Problème

Actuellement, on n'affiche plus les participations à un parcours qui ont été supprimée (`deletedAt` non null) dans la liste des participations, mais elles sont toujours comptabilisées sur :
- La liste des parcours combinés d'une orga (colonne du nombre de participants)
- Les statistiques de la page de détail d'un parcours combiné

## 🔭 Proposition

On ne comptabilise plus les participations supprimées dans ces statistiques pour disposer du bon nombre de participations partout.

## 🪐 Remarques

Après rééxamen du repo des `combinedCourseParticipations`, on a remarqué que la méthode `getByUserId` n'était plus utilisée. On en profite pour la supprimer.

## 🚀 Pour tester

Se connecter à Pix Orga
Afficher la liste des parcours combiné d'une orga (SCO SIECLE) 
-> 3 participations sont indiquée sur la ligne du parcours SCOMBINIX
Afficher la page du parcours combiné SCOMBINIX
-> 3 participations au total sont indiquée sur les statistiques du parcours

Ajouter un `deletedAt` à une des 3 participations pour indiquer qu'elle est supprimée

Afficher la page du parcours combiné SCOMBINIX
-> 2 participations au total sont indiquée sur les statistiques du parcours (et la participation supprimée disparait)
Revenir à la liste des parcours combiné de l'orga SCO SIECLE
-> 2 participations sont indiquée sur la ligne du parcours SCOMBINIX

🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘 🌑
