### PR TITLE
[FEATURE] Désactiver la locale es sur Pix Orga temporairement (PIX-22121)

### DIFF
--- a/orga/config/environment.js
+++ b/orga/config/environment.js
@@ -36,7 +36,7 @@ module.exports = function (environment) {
       SUPPORTED_LOCALES: [
         { value: 'de-AT', nativeName: 'Deutsch (Österreich)', displayedInSwitcher: true },
         { value: 'en', nativeName: 'English', displayedInSwitcher: true },
-        { value: 'es', nativeName: 'Español', displayedInSwitcher: true },
+        // { value: 'es', nativeName: 'Español', displayedInSwitcher: true },
         { value: 'fr', nativeName: 'Français', displayedInSwitcher: true },
         { value: 'fr-BE', nativeName: 'Français (Belgique)', displayedInSwitcher: true },
         { value: 'fr-FR', nativeName: 'Français (France)', displayedInSwitcher: false },

--- a/orga/tests/unit/services/locale-test.js
+++ b/orga/tests/unit/services/locale-test.js
@@ -280,10 +280,6 @@ module('Unit | Services | locale', function (hooks) {
           value: 'en',
         },
         {
-          label: 'Español',
-          value: 'es',
-        },
-        {
           label: 'Français',
           value: 'fr',
         },


### PR DESCRIPTION
## 🌎 Problème

On ne veut plus avoir la possibilité d'avoir Pix Orga en espagnol tant que toutes les traductions ne sont pas validées.

## 🔭 Proposition

Enlever temporairement la locale de la liste des locales supportées par Pix Orga.

## 🪐 Remarques

La locale `es` est utilisée sur Pix App pour des épreuves, on ne peut donc pas la désactiver globalement via le feature toggle `disableLocalesInFrontend`

## 🚀 Pour tester

1. Se connecter Pix Orga : https://orga-pr15695.review.pix.org/
2. Vérifier que l'espagnol n'est pas dans le local switcher.
3. Vérifier que si le cookie `locale` est `es`, il passe en `fr` automatiquement.
