### PR TITLE
[FEATURE] Exclure certaines organisations du questionnaire de satisfaction Combinix

### DIFF
--- a/mon-pix/app/components/routes/combined-courses/presentation.gjs
+++ b/mon-pix/app/components/routes/combined-courses/presentation.gjs
@@ -131,7 +131,16 @@ export default class CombinedCoursePresentation extends Component {
   }
 
   get isSurveyEnabled() {
-    return this.featureToggles.featureToggles?.isSurveyEnabledForCombinedCourses;
+    const surveyEnabledForCombinedCourses = this.featureToggles.featureToggles?.isSurveyEnabledForCombinedCourses;
+
+    if (!ENV.APP.ORGANIZATIONS_COMBINIX_SURVEY_EXCLUSION_LIST) return surveyEnabledForCombinedCourses;
+
+    const organizationsToExclude = ENV.APP.ORGANIZATIONS_COMBINIX_SURVEY_EXCLUSION_LIST.split(',');
+
+    return (
+      surveyEnabledForCombinedCourses &&
+      !organizationsToExclude.includes(this.args.combinedCourse.organizationId.toString())
+    );
   }
 
   get surveyLink() {

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -139,6 +139,7 @@ module.exports = function (environment) {
       COMBINIX_SURVEY_LINK:
         process.env.COMBINIX_SURVEY_LINK ||
         'https://app-eu.123formbuilder.com/index.php?p=login&pactionafter=edit_fields%26id%3D86361%26startup_panel%3Deditor%26click_from%3Dyour_forms',
+      ORGANIZATIONS_COMBINIX_SURVEY_EXCLUSION_LIST: process.env.ORGANIZATIONS_COMBINIX_SURVEY_EXCLUSION_LIST || '1005',
       MODULIX_VERIFICATION_RESPONSE_DELAY: 500,
     },
 
@@ -223,6 +224,7 @@ module.exports = function (environment) {
     ENV.APP.AUTO_SHARE_AFTER_DATE = '2025-07-18';
     ENV.APP.COMBINIX_SURVEY_LINK =
       'https://app-eu.123formbuilder.com/index.php?p=login&pactionafter=edit_fields%26id%3D86361%26startup_panel%3Deditor%26click_from%3Dyour_forms';
+    ENV.APP.ORGANIZATIONS_COMBINIX_SURVEY_EXCLUSION_LIST = '1005';
 
     ENV.companion.disabled = true;
 

--- a/mon-pix/tests/integration/components/routes/combined-courses/presentation-test.gjs
+++ b/mon-pix/tests/integration/components/routes/combined-courses/presentation-test.gjs
@@ -2,6 +2,7 @@ import { render } from '@1024pix/ember-testing-library';
 import { click } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import CombinedCoursesPresentation from 'mon-pix/components/routes/combined-courses/presentation';
+import ENV from 'mon-pix/config/environment';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
@@ -431,6 +432,7 @@ module('Integration | Component | Combined Courses | Presentation', function (ho
         id: 1,
         status: CombinedCourseStatuses.COMPLETED,
         code: 'COMBINIX9',
+        organizationId: 123,
       });
 
       // when
@@ -448,6 +450,60 @@ module('Integration | Component | Combined Courses | Presentation', function (ho
         );
       assert.dom(link).hasAttribute('target', '_blank');
       assert.dom(link).hasAttribute('rel', 'noopener noreferrer');
+    });
+
+    test('should not display survey cta when organization is in the exclusion list', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const featureToggles = this.owner.lookup('service:featureToggles');
+      sinon.stub(featureToggles, 'featureToggles').value({ isSurveyEnabledForCombinedCourses: true });
+
+      const originalExcluded = ENV.APP.ORGANIZATIONS_COMBINIX_SURVEY_EXCLUSION_LIST;
+      ENV.APP.ORGANIZATIONS_COMBINIX_SURVEY_EXCLUSION_LIST = '123,456';
+
+      const combinedCourse = store.createRecord('combined-course', {
+        id: 1,
+        status: CombinedCourseStatuses.COMPLETED,
+        code: 'COMBINIX9',
+        organizationId: 123,
+      });
+
+      // when
+      const screen = await render(
+        <template><CombinedCoursesPresentation @combinedCourse={{combinedCourse}} /></template>,
+      );
+
+      // then
+      assert.notOk(screen.queryByRole('link', { name: t('pages.combined-courses.completed.survey-button') }));
+
+      ENV.APP.ORGANIZATIONS_COMBINIX_SURVEY_EXCLUSION_LIST = originalExcluded;
+    });
+
+    test('should display survey cta when organization is not in the exclusion list', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const featureToggles = this.owner.lookup('service:featureToggles');
+      sinon.stub(featureToggles, 'featureToggles').value({ isSurveyEnabledForCombinedCourses: true });
+
+      const originalExcluded = ENV.APP.ORGANIZATIONS_COMBINIX_SURVEY_EXCLUSION_LIST;
+      ENV.APP.ORGANIZATIONS_COMBINIX_SURVEY_EXCLUSION_LIST = '456,789';
+
+      const combinedCourse = store.createRecord('combined-course', {
+        id: 1,
+        status: CombinedCourseStatuses.COMPLETED,
+        code: 'COMBINIX9',
+        organizationId: 123,
+      });
+
+      // when
+      const screen = await render(
+        <template><CombinedCoursesPresentation @combinedCourse={{combinedCourse}} /></template>,
+      );
+
+      // then
+      assert.ok(screen.queryByRole('link', { name: t('pages.combined-courses.completed.survey-button') }));
+
+      ENV.APP.ORGANIZATIONS_COMBINIX_SURVEY_EXCLUSION_LIST = originalExcluded;
     });
     test('should display retry text for modules if there are any in the course', async function (assert) {
       // given


### PR DESCRIPTION
## 🌎 Problème

Le bouton d'accès au questionnaire de satisfaction s'affiche pour toutes les organisations ayant terminé un parcours combiné.

## 🔭 Proposition

Ajout d'une variable d'environnement `ORGANIZATIONS_WITHOUT_COMBINIX_SURVEY` permettant de lister les IDs d'organisations à exclure du questionnaire.

## 🪐 Remarques

La variable accepte une liste d'IDs séparés par des virgules (ex: `123,456,789`). Si elle est vide ou absente, aucune organisation n'est exclue.
C'est Géraldine qui m'a obligé. 

## 🚀 Pour tester

- [x] Activer le feature toggle `isSurveyEnabledForCombinedCourses`
- [x] Compléter un parcours combiné avec une organisation dont l'ID est dans `ORGANIZATIONS_WITHOUT_COMBINIX_SURVEY`: le bouton questionnaire ne doit **pas** apparaître
- [x] Compléter un parcours combiné avec une organisation dont l'ID n'est **pas** dans la liste: le bouton questionnaire doit apparaître

🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘 🌑