### PR TITLE
[FEATURE] Améliorer le formulaire de création de campagne pour les parcours apprenants (PIX-22160)

### DIFF
--- a/orga/app/components/campaign/create-form.gjs
+++ b/orga/app/components/campaign/create-form.gjs
@@ -259,15 +259,17 @@ export default class CreateForm extends Component {
                 <:label>{{t "pages.campaign-creation.purpose.assessment"}}</:label>
               </PixRadioButton>
 
-              <PixRadioButton
-                name="campaign-goal"
-                @value="collect-participants-profile"
-                {{on "change" this.setCampaignGoal}}
-                aria-describedby="campaign-goal-profiles-collection-info"
-                checked={{this.isCampaignGoalProfileCollection}}
-              >
-                <:label>{{t "pages.campaign-creation.purpose.profiles-collection"}}</:label>
-              </PixRadioButton>
+              {{#if this.hasCombinedCourseBlueprintShares}}
+                <PixRadioButton
+                  name="campaign-goal"
+                  @value="combined-course"
+                  {{on "change" this.setCampaignGoal}}
+                  aria-describedby="combined-course-info"
+                  checked={{this.isCombinedCourseGoal}}
+                >
+                  <:label>{{t "pages.campaign-creation.purpose.combined-course"}}</:label>
+                </PixRadioButton>
+              {{/if}}
 
               {{#if this.isCreateCampaignOftypeExamEnabled}}
                 <PixRadioButton
@@ -281,17 +283,15 @@ export default class CreateForm extends Component {
                 </PixRadioButton>
               {{/if}}
 
-              {{#if this.hasCombinedCourseBlueprintShares}}
-                <PixRadioButton
-                  name="campaign-goal"
-                  @value="combined-course"
-                  {{on "change" this.setCampaignGoal}}
-                  aria-describedby="combined-course-info"
-                  checked={{this.isCombinedCourseGoal}}
-                >
-                  <:label>{{t "pages.campaign-creation.purpose.combined-course"}}</:label>
-                </PixRadioButton>
-              {{/if}}
+              <PixRadioButton
+                name="campaign-goal"
+                @value="collect-participants-profile"
+                {{on "change" this.setCampaignGoal}}
+                aria-describedby="campaign-goal-profiles-collection-info"
+                checked={{this.isCampaignGoalProfileCollection}}
+              >
+                <:label>{{t "pages.campaign-creation.purpose.profiles-collection"}}</:label>
+              </PixRadioButton>
 
               {{#if @errors.type}}
                 <div class="form__error error-message">
@@ -313,6 +313,12 @@ export default class CreateForm extends Component {
               <:title>{{t "pages.campaign-creation.purpose.assessment"}}</:title>
 
               <:message>{{t "pages.campaign-creation.purpose.assessment-info"}}</:message>
+            </ExplanationCard>
+          {{else if this.isCombinedCourseGoal}}
+            <ExplanationCard id="combined-course-info">
+              <:title>{{t "pages.campaign-creation.purpose.combined-course"}}</:title>
+
+              <:message>{{t "pages.campaign-creation.purpose.combined-course-info"}}</:message>
             </ExplanationCard>
           {{else if this.isCampaignGoalProfileCollection}}
             <ExplanationCard id="campaign-goal-profiles-collection-info">

--- a/orga/tests/acceptance/campaign-creation-test.js
+++ b/orga/tests/acceptance/campaign-creation-test.js
@@ -37,7 +37,7 @@ module('Acceptance | Campaign Creation', function (hooks) {
 
     const screen = await visit('/campagnes/creation');
     await fillByLabel('Nom de la campagne *', 'Mon parcours combiné');
-    await clickByName('Développer les compétences des participants (parcours apprenants)');
+    await clickByName(t('pages.campaign-creation.purpose.combined-course'));
 
     await click(screen.getByLabelText(`${t('pages.campaign-creation.combined-course-blueprints-list-label')} *`));
     await click(await screen.findByRole('option', { description: expectedCombinedCourseBlueprintName }));

--- a/orga/tests/integration/components/campaign/create-form-test.gjs
+++ b/orga/tests/integration/components/campaign/create-form-test.gjs
@@ -993,7 +993,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
       assert.dom(screen.queryByText(t('pages.campaign-creation.test-title.label'))).doesNotExist();
       assert.dom(screen.queryByText(t('pages.campaign-creation.target-profiles-list-label'))).doesNotExist();
       await fillByLabel('Nom de la campagne *', 'Mon parcours combiné');
-      await clickByName('Développer les compétences des participants (parcours apprenants)');
+      await clickByName(t('pages.campaign-creation.purpose.combined-course'));
 
       await click(screen.getByLabelText(`${t('pages.campaign-creation.combined-course-blueprints-list-label')} *`));
       assert.ok(await screen.findByRole('option', { description: combinedCourseBlueprint.name }));

--- a/orga/translations/de.json
+++ b/orga/translations/de.json
@@ -756,8 +756,8 @@
         "create": "Kampagne erstellen",
         "delete": "Löschen"
       },
-      "combined-course-blueprints-label": "Auswählen eines Streckenschemas",
-      "combined-course-blueprints-list-label": "Wählen Sie ein Streckenschema",
+      "combined-course-blueprints-label": "Einen Lernpfad auswählen",
+      "combined-course-blueprints-list-label": "Einen Lernpfad auswählen",
       "copy-of": "Kopieren von",
       "external-id-label": {
         "label": "Bezeichnung der Kennung",
@@ -799,7 +799,8 @@
       "purpose": {
         "assessment": "Bewerten Sie die Teilnehmer",
         "assessment-info": "Bei einer Evaluierungskampagne werden die Teilnehmer zu bestimmten Themen getestet.",
-        "combined-course": "Erstellen einer kombinierten Strecke",
+        "combined-course": "Kompetenzen der Teilnehmer entwickeln",
+        "combined-course-info": "Ein Lernpfad hilft den Teilnehmern, neue Kompetenzen zu erwerben.",
         "exam": "Testmodus [beta]",
         "exam-info": "Eine Kampagne vom Typ \"Testmodus\" ermöglicht es, die Teilnehmer zu bestimmten Themen zu testen, ohne das Nutzerprofil zu berücksichtigen oder zu beeinflussen. Die vorgeschlagenen Tests werden für jeden Teilnehmer entsprechend seinem Fortschritt auf der Strecke angepasst.",
         "label": "Was ist das Ziel Ihrer Kampagne?",

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -763,8 +763,8 @@
         "create": "Create a campaign",
         "delete": "Delete"
       },
-      "combined-course-blueprints-label": "Select a combined course blueprint",
-      "combined-course-blueprints-list-label": "Select a combined course blueprint",
+      "combined-course-blueprints-label": "Select a learning course",
+      "combined-course-blueprints-list-label": "Select a learning course",
       "copy-of": "Copy of",
       "external-id-label": {
         "label": "external user ID label",
@@ -806,7 +806,8 @@
       "purpose": {
         "assessment": "Assess participants",
         "assessment-info": "An assessment campaign tests participants on specific topics.",
-        "combined-course": "Developing participants' skills (learning courses)",
+        "combined-course": "Developing participants' skills",
+        "combined-course-info": "A learning course helps participants acquire new skills.",
         "exam": "Exam mode",
         "exam-info": "A ‘exam mode’ campaign enables participants to be tested on specific topics, without taking their user profile into account or having any impact on it. The campaign's questions are personalised for each participant, depending on how far they have progressed along the route.",
         "label": "What is the purpose of your campaign?",

--- a/orga/translations/es.json
+++ b/orga/translations/es.json
@@ -757,8 +757,8 @@
         "create": "Crear la campaña",
         "delete": "Borrar"
       },
-      "combined-course-blueprints-label": "Seleccione un plan de ruta",
-      "combined-course-blueprints-list-label": "Seleccione un plan de ruta",
+      "combined-course-blueprints-label": "Seleccionar una vía de aprendizaje",
+      "combined-course-blueprints-list-label": "Seleccionar una vía de aprendizaje",
       "copy-of": "Copia de",
       "external-id-label": {
         "label": "Texto del identificador",
@@ -800,7 +800,8 @@
       "purpose": {
         "assessment": "Evaluación de los participantes",
         "assessment-info": "Una campaña de evaluación permite poner a prueba a los participantes sobre temas concretos.",
-        "combined-course": "Crear una ruta combinada",
+        "combined-course": "Desarrollar las competencias de los participantes",
+        "combined-course-info": "Una vía de aprendizaje ayuda a los participantes a adquirir nuevas competencias.",
         "exam": "Modo de consulta",
         "exam-info": "Una campaña en \"modo test\" permite examinar a los participantes sobre temas específicos, sin tener en cuenta su perfil de usuario ni influir en él. Los tests propuestos son personalizados para cada participante, en función de lo avanzado que esté en el curso.",
         "label": "¿Cuál es el objetivo de su campaña?",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -751,8 +751,8 @@
         "create": "Créer la campagne",
         "delete": "Effacer"
       },
-      "combined-course-blueprints-label": "Sélectionner un schéma de parcours",
-      "combined-course-blueprints-list-label": "Sélectionnez un schéma de parcours",
+      "combined-course-blueprints-label": "Sélectionnez un parcours",
+      "combined-course-blueprints-list-label": "Sélectionnez un parcours apprenant",
       "copy-of": "Copie de",
       "external-id-label": {
         "label": "Libellé de l’identifiant",
@@ -794,7 +794,8 @@
       "purpose": {
         "assessment": "Évaluer les participants",
         "assessment-info": "Une campagne d’évaluation permet de tester les participants sur des sujets précis.",
-        "combined-course": "Développer les compétences des participants (parcours apprenants)",
+        "combined-course": "Développer les compétences des participants",
+        "combined-course-info": "Un parcours d'apprentissage permet d'accompagner les participants dans l'acquisition de nouvelles compétences.",
         "exam": "Mode interro",
         "exam-info": "Une campagne de type “mode interro” permet de tester les participants sur des sujets précis, sans prendre en compte le profil utilisateur, et sans impacter celui-ci. Les épreuves proposées sont personnalisées pour chaque participant selon son avancement dans le parcours.",
         "label": "Quel est l'objectif de votre campagne ?",

--- a/orga/translations/it.json
+++ b/orga/translations/it.json
@@ -757,8 +757,8 @@
         "create": "Creare la campagna",
         "delete": "Cancellare"
       },
-      "combined-course-blueprints-label": "Selezionare un piano di percorso",
-      "combined-course-blueprints-list-label": "Selezionare un piano di percorso",
+      "combined-course-blueprints-label": "Seleziona un percorso di apprendimento",
+      "combined-course-blueprints-list-label": "Seleziona un percorso di apprendimento",
       "copy-of": "Copia di",
       "external-id-label": {
         "label": "Formulazione dell'identificatore",
@@ -800,7 +800,8 @@
       "purpose": {
         "assessment": "Valutazione dei partecipanti",
         "assessment-info": "Una campagna di valutazione consente ai partecipanti di essere testati su argomenti specifici.",
-        "combined-course": "Creare un percorso combinato",
+        "combined-course": "Sviluppare le competenze dei partecipanti",
+        "combined-course-info": "Un percorso di apprendimento aiuta i partecipanti ad acquisire nuove competenze.",
         "exam": "Modalità di interrogazione",
         "exam-info": "Una campagna in \"modalità quiz\" consente di sottoporre i partecipanti a test su argomenti specifici, senza tenere conto del loro profilo utente e senza influire su di esso. I test proposti sono personalizzati per ogni partecipante, a seconda del livello di avanzamento del corso.",
         "label": "Qual è l'obiettivo della vostra campagna?",

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -750,8 +750,8 @@
         "create": "De campagne maken",
         "delete": "Wissen"
       },
-      "combined-course-blueprints-label": "Selecteer een gecombineerd cursusontwerp",
-      "combined-course-blueprints-list-label": "Selecteer een gecombineerd cursusontwerp",
+      "combined-course-blueprints-label": "Selecteer een leerprogramma",
+      "combined-course-blueprints-list-label": "Selecteer een leerprogramma",
       "copy-of": "Kopie van",
       "external-id-label": {
         "label": "Type externe user-ID",
@@ -793,7 +793,8 @@
       "purpose": {
         "assessment": "Deelnemers evalueren",
         "assessment-info": "Een beoordelingscampagne stelt deelnemers in staat om getest te worden op specifieke onderwerpen.",
-        "combined-course": "De vaardigheden van de deelnemers ontwikkelen (leerprogramma)",
+        "combined-course": "De vaardigheden van de deelnemers ontwikkelen",
+        "combined-course-info": "Een leerprogramma helpt deelnemers om nieuwe vaardigheden te verwerven.",
         "exam": "Vraagmodus",
         "exam-info": "Met een campagne in de “quizmodus” kunnen deelnemers worden getest op specifieke onderwerpen, zonder rekening te houden met hun gebruikersprofiel of er invloed op te hebben. De aangeboden tests zijn gepersonaliseerd voor elke deelnemer, afhankelijk van hoe ver ze gevorderd zijn in het traject.",
         "label": "Wat is het doel van je campagne?",


### PR DESCRIPTION
## 🌎 Problème

Quelques améliorations au niveau du formulaire avant de donner la main aux prescripteurs pour créer leurs campagnes de parcours apprenants.

## 🔭 Proposition

- Renommer l’objectif lié aux parcours apprenants en : “Développer les compétences des participants”
- Réordonner les radio buttons des objectifs dans le formulaire : Évaluer → Développer → Mode interro → Collecter
- Ajouter une carte de description pour l'objectif "Développer les compétences des participants" : "Développez les compétences de vos participants en leur proposant des modules d'apprentissage. Ces parcours sont composés de modules d'apprentissage seuls ou bien articulent diagnostic court et programme de modules adapté."

## 🪐 Remarques

J'ai glissé des modifs de wordings dans le sélecteur aussi 

## 🚀 Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->

🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘 🌑
