### PR TITLE
[BUGFIX] Supprime une clause distinct très coûteuse en CPU lors de la récupération de contenus recommandés 

### DIFF
--- a/api/src/devcomp/infrastructure/repositories/user-recommended-training-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/user-recommended-training-repository.js
@@ -28,10 +28,17 @@ const findModulesByCampaignParticipationIds = async function ({ campaignParticip
     .innerJoin('trainings', 'trainings.id', `${USER_RECOMMENDED_TRAININGS_TABLE_NAME}.trainingId`)
     .where({ isDisabled: false, type: 'modulix' })
     .whereIn('campaignParticipationId', campaignParticipationIds)
-    .distinct('trainings.id')
     .orderBy('trainings.id', 'asc');
 
-  return moduleLinks.map(_toDomain);
+  // We removed the distinct because it was extremely costly in CPU
+  const seen = new Set();
+  const uniqueModuleLinks = moduleLinks.filter((moduleLink) => {
+    if (seen.has(moduleLink.id)) return false;
+    seen.add(moduleLink.id);
+    return true;
+  });
+
+  return uniqueModuleLinks.map(_toDomain);
 };
 
 const hasRecommendedTrainings = async function ({ userId }) {


### PR DESCRIPTION
## 🌎 Problème
Lors de l'accès aux parcours combinés, on récupère les contenus formatifs recommandés à un utilisateur grâce à ce usecase `findModulesByCampaignParticipationIds`.
Après une analyse du plan d'exécution grâce à Dalibo, la clause distinct sur les trainings.id semble beaucoup ralentir la requête.
 
## 🔭 Proposition
On enlève la clause distinct et on la remplace par un traitement en JS.

## 🚀 Pour tester
Participer à un parcours combiné qui a une campagne et des modules (MAXICOMBI), vérifier que des modules sont toujours recommandés.

🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘 🌑
