### PR TITLE
[TECH] Rendre la colonne maxReachableLevelOnCertificationDate de la table certification-courses nullable (PIX-22169) 

### DIFF
--- a/api/db/migrations/20260331161119_make-max-reachable-level-on-certification-date-nullable.js
+++ b/api/db/migrations/20260331161119_make-max-reachable-level-on-certification-date-nullable.js
@@ -1,0 +1,16 @@
+const TABLE_NAME = 'certification-courses';
+const COLUMN_NAME = 'maxReachableLevelOnCertificationDate';
+
+const up = async function (knex) {
+  await knex.schema.alterTable(TABLE_NAME, (table) => {
+    table.integer(COLUMN_NAME).nullable().defaultTo(null).comment('V2 only - not used for V3 certification').alter();
+  });
+};
+
+const down = async function (knex) {
+  await knex.schema.alterTable(TABLE_NAME, (table) => {
+    table.integer(COLUMN_NAME).notNullable().defaultTo(5).alter();
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## 🌎 Problème

La valeur maxReachableLevelOnCertificationDate de la table certification-courses n'est actuellement plus utilisée pour les certifications V3. Il semble donc inutile de continuer à remplir cette colonne lors de leur création.

## 🔭 Proposition

Rendre la colonne nullable, avec un commentaire précisant que la colonne ne sert qu'en V2

## 🪐 Remarques

Lié à la PR #15709  

## 🚀 Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->

🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘 🌑
