### PR TITLE
[TECH] Remplacer l'usage d'Axios par le fetch natif (PIX-22183)

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -28,7 +28,6 @@
         "@json2csv/plainjs": "^7.0.2",
         "@pdf-lib/fontkit": "^1.1.1",
         "@xmldom/xmldom": "^0.9.10",
-        "axios": "1.17.0",
         "bcrypt": "^6.0.0",
         "cron-parser": "^5.0.0",
         "datadog-metrics": "^0.12.0",
@@ -5301,41 +5300,6 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/axios": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
-      "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
-      "dependencies": {
-        "follow-redirects": "^1.16.0",
-        "https-proxy-agent": "^5.0.1",
-        "proxy-from-env": "^2.1.0"
-      }
-    },
-    "node_modules/axios/node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/axios/node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -7502,11 +7466,6 @@
       "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/follow-redirects": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
-      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw=="
     },
     "node_modules/fontkit": {
       "version": "2.0.4",
@@ -11421,14 +11380,6 @@
       },
       "engines": {
         "node": ">=12.0.0"
-      }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
-      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/pstree.remy": {

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -5305,10 +5305,8 @@
       "version": "1.17.0",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
       "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
-      "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
-        "form-data": "^4.0.5",
         "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
@@ -7508,22 +7506,7 @@
     "node_modules/follow-redirects": {
       "version": "1.16.0",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
-      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw=="
     },
     "node_modules/fontkit": {
       "version": "2.0.4",
@@ -11444,7 +11427,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
       "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
-      "license": "MIT",
       "engines": {
         "node": ">=10"
       }

--- a/api/package.json
+++ b/api/package.json
@@ -110,7 +110,6 @@
     "@json2csv/plainjs": "^7.0.2",
     "@pdf-lib/fontkit": "^1.1.1",
     "@xmldom/xmldom": "^0.9.10",
-    "axios": "1.17.0",
     "bcrypt": "^6.0.0",
     "cron-parser": "^5.0.0",
     "datadog-metrics": "^0.12.0",

--- a/api/src/identity-access-management/domain/usecases/register-lti-platform.js
+++ b/api/src/identity-access-management/domain/usecases/register-lti-platform.js
@@ -121,7 +121,6 @@ export async function registerLtiPlatform({
     url: platformConfiguration.registration_endpoint,
     headers: {
       Authorization: `Bearer ${registrationToken}`,
-      'Content-type': 'application/json',
     },
     payload: pixToolConfiguration,
   });

--- a/api/src/shared/infrastructure/http-agent.js
+++ b/api/src/shared/infrastructure/http-agent.js
@@ -14,114 +14,70 @@ class HttpResponse {
 
 const httpAgent = {
   async post({ url, payload, headers }) {
-    const startTime = performance.now();
-    let responseTime = null;
-    try {
-      const finalHeaders = structuredClone(headers);
-      finalHeaders['Content-type'] = 'application/json';
-      const httpResponse = await fetch(url, {
-        method: 'POST',
-        body: JSON.stringify(payload),
-        headers: finalHeaders,
-      });
-      responseTime = performance.now() - startTime;
-      if (!httpResponse.ok) {
-        const data = await _parseResponseBody(httpResponse);
-        const code = httpResponse.status;
-        const message = `End POST request to ${url} error: ${code || ''} ${JSON.stringify(data)}`;
-
-        logger.error({
-          metrics: { responseTime },
-          message,
-        });
-
-        return new HttpResponse({
-          code,
-          data,
-          isSuccessful: false,
-        });
-      }
-
-      logger.info({
-        metrics: { responseTime },
-        message: `End POST request to ${url} success: ${httpResponse.status}`,
-      });
-      const data = await _parseResponseBody(httpResponse);
-
-      return new HttpResponse({
-        code: httpResponse.status,
-        data,
-        isSuccessful: true,
-      });
-    } catch (httpErr) {
-      responseTime = performance.now() - startTime;
-      const message = `End POST request to ${url} , unexpected error: ${httpErr.message}`;
-      logger.error({
-        metrics: { responseTime },
-        message,
-      });
-
-      return new HttpResponse({
-        code: null,
-        data: httpErr.message,
-        isSuccessful: false,
-      });
-    }
+    const finalHeaders = structuredClone(headers);
+    finalHeaders['Content-type'] = 'application/json';
+    return _doRequest({ url, headers: finalHeaders, payload, method: 'POST' });
   },
 
   async get({ url, headers }) {
-    const startTime = performance.now();
-    let responseTime = null;
-    try {
-      const httpResponse = await fetch(url, {
-        method: 'GET',
-        headers: headers,
-      });
-      responseTime = performance.now() - startTime;
-      if (!httpResponse.ok) {
-        const data = await _parseResponseBody(httpResponse);
-        const code = httpResponse.status;
-        const message = `End GET request to ${url} error: ${code || ''} ${JSON.stringify(data)}`;
+    return _doRequest({ url, headers, method: 'GET' });
+  },
+};
 
-        logger.error({
-          metrics: { responseTime },
-          message,
-        });
-
-        return new HttpResponse({
-          code,
-          data,
-          isSuccessful: false,
-        });
-      }
-
-      logger.info({
-        metrics: { responseTime },
-        message: `End GET request to ${url} success: ${httpResponse.status}`,
-      });
+async function _doRequest({ url, payload, headers, method }) {
+  const startTime = performance.now();
+  let responseTime = null;
+  const body = payload ? JSON.stringify(payload) : undefined;
+  try {
+    const httpResponse = await fetch(url, {
+      method,
+      body,
+      headers,
+    });
+    responseTime = performance.now() - startTime;
+    if (!httpResponse.ok) {
       const data = await _parseResponseBody(httpResponse);
+      const code = httpResponse.status;
+      const message = `End ${method} request to ${url} error: ${code || ''} ${JSON.stringify(data)}`;
 
-      return new HttpResponse({
-        code: httpResponse.status,
-        data,
-        isSuccessful: true,
-      });
-    } catch (httpErr) {
-      responseTime = performance.now() - startTime;
-      const message = `End GET request to ${url} , unexpected error: ${httpErr.message}`;
       logger.error({
         metrics: { responseTime },
         message,
       });
 
       return new HttpResponse({
-        code: null,
-        data: httpErr.message,
+        code,
+        data,
         isSuccessful: false,
       });
     }
-  },
-};
+
+    logger.info({
+      metrics: { responseTime },
+      message: `End ${method} request to ${url} success: ${httpResponse.status}`,
+    });
+    const data = await _parseResponseBody(httpResponse);
+
+    return new HttpResponse({
+      code: httpResponse.status,
+      data,
+      isSuccessful: true,
+    });
+  } catch (httpErr) {
+    responseTime = performance.now() - startTime;
+    const message = `End ${method} request to ${url} , unexpected error: ${httpErr.message}`;
+    logger.error({
+      metrics: { responseTime },
+      message,
+    });
+
+    return new HttpResponse({
+      code: null,
+      data: httpErr.message,
+      isSuccessful: false,
+    });
+  }
+}
 
 async function _parseResponseBody(response) {
   const contentType = response.headers.get('content-type') ?? '';

--- a/api/src/shared/infrastructure/http-agent.js
+++ b/api/src/shared/infrastructure/http-agent.js
@@ -15,55 +15,62 @@ class HttpResponse {
 }
 
 const httpAgent = {
-  async post({ url, payload, headers, timeout }) {
+  async post({ url, payload, headers }) {
     const startTime = performance.now();
     let responseTime = null;
     try {
-      const config = {
-        headers,
-      };
-      if (timeout != undefined) {
-        config.timeout = timeout;
-      }
-      const httpResponse = await axios.post(url, payload, config);
+      const finalHeaders = structuredClone(headers);
+      finalHeaders['Content-type'] = 'application/json';
+      const httpResponse = await fetch(url, {
+        method: 'POST',
+        body: JSON.stringify(payload),
+        headers: finalHeaders,
+      });
       responseTime = performance.now() - startTime;
+      if (!httpResponse.ok) {
+        const data = await _parseResponseBody(httpResponse);
+        const code = httpResponse.status;
+        const message = `End POST request to ${url} error: ${code || ''} ${JSON.stringify(data)}`;
+
+        logger.error({
+          metrics: { responseTime },
+          message,
+        });
+
+        return new HttpResponse({
+          code,
+          data,
+          isSuccessful: false,
+        });
+      }
+
       logger.info({
         metrics: { responseTime },
         message: `End POST request to ${url} success: ${httpResponse.status}`,
       });
+      const data = await _parseResponseBody(httpResponse);
 
       return new HttpResponse({
         code: httpResponse.status,
-        data: httpResponse.data,
+        data,
         isSuccessful: true,
       });
     } catch (httpErr) {
       responseTime = performance.now() - startTime;
-      let code = null;
-      let data;
-
-      if (httpErr.response) {
-        code = httpErr.response.status;
-        data = httpErr.response.data;
-      } else {
-        code = httpErr.code;
-        data = httpErr.message;
-      }
-
-      const message = `End POST request to ${url} error: ${code || ''} ${JSON.stringify(data)}`;
-
+      const message = `End POST request to ${url} , unexpected error: ${httpErr.message}`;
       logger.error({
         metrics: { responseTime },
         message,
       });
 
       return new HttpResponse({
-        code,
-        data,
+        code: null,
+        data: httpErr.message,
         isSuccessful: false,
       });
     }
   },
+
   async get({ url, payload, headers, timeout }) {
     const startTime = performance.now();
     let responseTime = null;
@@ -115,5 +122,13 @@ const httpAgent = {
     }
   },
 };
+
+async function _parseResponseBody(response) {
+  const contentType = response.headers.get('content-type') ?? '';
+  if (contentType.includes('application/json')) {
+    return response.json();
+  }
+  return response.text();
+}
 
 export { httpAgent };

--- a/api/src/shared/infrastructure/http-agent.js
+++ b/api/src/shared/infrastructure/http-agent.js
@@ -13,12 +13,27 @@ class HttpResponse {
 }
 
 const httpAgent = {
+  /**
+   * Sends a POST request with a JSON payload.
+   * @param {Object} options
+   * @param {string} options.url
+   * @param {Object} options.payload
+   * @param {Object} [options.headers={}]
+   * @returns {Promise<HttpResponse>}
+   */
   async post({ url, payload, headers }) {
     const finalHeaders = structuredClone(headers);
     finalHeaders['Content-type'] = 'application/json';
     return _doRequest({ url, headers: finalHeaders, payload, method: 'POST' });
   },
 
+  /**
+   * Sends a GET request to the specified URL.
+   * @param {Object} options
+   * @param {string} options.url
+   * @param {Object} [options.headers]
+   * @returns {Promise<HttpResponse>}
+   */
   async get({ url, headers }) {
     return _doRequest({ url, headers, method: 'GET' });
   },

--- a/api/src/shared/infrastructure/http-agent.js
+++ b/api/src/shared/infrastructure/http-agent.js
@@ -1,7 +1,5 @@
 import perf_hooks from 'node:perf_hooks';
 
-import axios from 'axios';
-
 const { performance } = perf_hooks;
 
 import { logger } from './utils/logger.js';
@@ -71,53 +69,55 @@ const httpAgent = {
     }
   },
 
-  async get({ url, payload, headers, timeout }) {
+  async get({ url, headers }) {
     const startTime = performance.now();
     let responseTime = null;
     try {
-      const config = {
-        data: payload,
-        headers,
-      };
-      if (timeout != undefined) {
-        config.timeout = timeout;
-      }
-      const httpResponse = await axios.get(url, config);
+      const httpResponse = await fetch(url, {
+        method: 'GET',
+        headers: headers,
+      });
       responseTime = performance.now() - startTime;
+      if (!httpResponse.ok) {
+        const data = await _parseResponseBody(httpResponse);
+        const code = httpResponse.status;
+        const message = `End GET request to ${url} error: ${code || ''} ${JSON.stringify(data)}`;
+
+        logger.error({
+          metrics: { responseTime },
+          message,
+        });
+
+        return new HttpResponse({
+          code,
+          data,
+          isSuccessful: false,
+        });
+      }
+
       logger.info({
         metrics: { responseTime },
         message: `End GET request to ${url} success: ${httpResponse.status}`,
       });
+      const data = await _parseResponseBody(httpResponse);
 
       return new HttpResponse({
         code: httpResponse.status,
-        data: httpResponse.data,
+        data,
         isSuccessful: true,
       });
     } catch (httpErr) {
       responseTime = performance.now() - startTime;
-      const isSuccessful = false;
-
-      let code;
-      let data;
-
-      if (httpErr.response) {
-        code = httpErr.response.status;
-        data = httpErr.response.data;
-      } else {
-        code = httpErr.code;
-        data = httpErr.message;
-      }
-
+      const message = `End GET request to ${url} , unexpected error: ${httpErr.message}`;
       logger.error({
         metrics: { responseTime },
-        message: `End GET request to ${url} error: ${code || ''} ${JSON.stringify(data)}`,
+        message,
       });
 
       return new HttpResponse({
-        code,
-        data,
-        isSuccessful,
+        code: null,
+        data: httpErr.message,
+        isSuccessful: false,
       });
     }
   },

--- a/api/src/shared/infrastructure/http-agent.js
+++ b/api/src/shared/infrastructure/http-agent.js
@@ -24,7 +24,8 @@ const httpAgent = {
   async post({ url, payload, headers }) {
     const finalHeaders = structuredClone(headers ?? {});
     finalHeaders['Content-type'] = 'application/json';
-    return _doRequest({ url, headers: finalHeaders, payload, method: 'POST' });
+    const body = payload && JSON.stringify(payload);
+    return _doRequest({ url, headers: finalHeaders, body, method: 'POST' });
   },
 
   /**
@@ -39,10 +40,9 @@ const httpAgent = {
   },
 };
 
-async function _doRequest({ url, payload, headers, method }) {
+async function _doRequest({ url, body, headers, method }) {
   const startTime = performance.now();
-  let responseTime = null;
-  const body = payload ? JSON.stringify(payload) : undefined;
+  let responseTime;
   try {
     const httpResponse = await fetch(url, {
       method,

--- a/api/src/shared/infrastructure/http-agent.js
+++ b/api/src/shared/infrastructure/http-agent.js
@@ -18,11 +18,11 @@ const httpAgent = {
    * @param {Object} options
    * @param {string} options.url
    * @param {Object} options.payload
-   * @param {Object} [options.headers={}]
+   * @param {Object} [options.headers]
    * @returns {Promise<HttpResponse>}
    */
   async post({ url, payload, headers }) {
-    const finalHeaders = structuredClone(headers);
+    const finalHeaders = structuredClone(headers ?? {});
     finalHeaders['Content-type'] = 'application/json';
     return _doRequest({ url, headers: finalHeaders, payload, method: 'POST' });
   },

--- a/api/src/shared/infrastructure/http-agent.js
+++ b/api/src/shared/infrastructure/http-agent.js
@@ -94,12 +94,17 @@ async function _doRequest({ url, payload, headers, method }) {
   }
 }
 
+// Deliberately not checking headers for content-type to determine
+// whether to use response.json() or not
+// to mimic how axios handles it (axios is much more agressive and does not read the headers)
+// ref: https://github.com/axios/axios/blob/v1.x/lib/defaults/index.js  fnc: stringifySafely
 async function _parseResponseBody(response) {
-  const contentType = response.headers.get('content-type') ?? '';
-  if (contentType.includes('application/json')) {
-    return response.json();
+  const rawData = await response.text();
+  try {
+    return JSON.parse(rawData);
+  } catch {
+    return rawData;
   }
-  return response.text();
 }
 
 export { httpAgent };

--- a/api/tests/identity-access-management/integration/domain/usecases/register-lti-platform.test.js
+++ b/api/tests/identity-access-management/integration/domain/usecases/register-lti-platform.test.js
@@ -83,7 +83,6 @@ describe('Integration | Identity Access Management | Domain | Usecases | registe
       url: platformOpenIdConfig.registration_endpoint,
       headers: {
         Authorization: 'Bearer token1234',
-        'Content-type': 'application/json',
       },
       payload: expectedPixConfig,
     });
@@ -261,7 +260,6 @@ describe('Integration | Identity Access Management | Domain | Usecases | registe
         url: platformOpenIdConfig.registration_endpoint,
         headers: {
           Authorization: 'Bearer token1234',
-          'Content-type': 'application/json',
         },
         payload: expectedPixConfig,
       });

--- a/api/tests/shared/integration/infrastructure/http-agent_test.js
+++ b/api/tests/shared/integration/infrastructure/http-agent_test.js
@@ -16,9 +16,7 @@ describe('Shared | Integration | Infrastructure | http-agent', function () {
         reqheaders: { 'content-type': 'application/json', ...headers },
       })
         .post('/someresource', payload)
-        .reply(201, JSON.stringify(response), {
-          'Content-Type': 'application/json',
-        });
+        .reply(201, JSON.stringify(response));
 
       // when
       const actualResponse = await post({ url: 'https://my-url.com/someresource', payload, headers });
@@ -93,9 +91,7 @@ describe('Shared | Integration | Infrastructure | http-agent', function () {
         reqheaders: headers,
       })
         .get('/someresource')
-        .reply(200, JSON.stringify(response), {
-          'Content-Type': 'application/json',
-        });
+        .reply(200, JSON.stringify(response));
 
       // when
       const actualResponse = await get({ url: 'https://my-url.com/someresource', headers });

--- a/api/tests/shared/integration/infrastructure/http-agent_test.js
+++ b/api/tests/shared/integration/infrastructure/http-agent_test.js
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import nock from 'nock';
 import sinon from 'sinon';
 
 import { httpAgent } from '../../../../src/shared/infrastructure/http-agent.js';
@@ -7,116 +8,80 @@ import { expect } from '../../../test-helper.js';
 
 const { post, get } = httpAgent;
 
-describe('Shared | Unit | Infrastructure | http-agent', function () {
+describe('Shared | Integration | Infrastructure | http-agent', function () {
   describe('#post', function () {
     it('should return the response status and success from the http call when successful', async function () {
       // given
-      const url = 'someUrl';
-      const payload = 'somePayload';
-      const headers = { a: 'someHeaderInfo' };
-      const axiosResponse = {
-        data: Symbol('data'),
-        status: 'someStatus',
-      };
-      const timeout = 'someTimeout';
-      sinon
-        .stub(axios, 'post')
-        .withArgs(url, payload, {
-          headers,
-          timeout,
-        })
-        .resolves(axiosResponse);
+      const response = { coucou: 'cava' };
+      const payload = { foo: 'bar' };
+      const headers = { Authorization: 'Bearer monsupertoken' };
+      const requestScope = nock('https://my-url.com', {
+        reqheaders: { 'content-type': 'application/json', ...headers },
+      })
+        .post('/someresource', payload)
+        .reply(201, JSON.stringify(response), {
+          'Content-Type': 'application/json',
+        });
 
       // when
-      const actualResponse = await post({ url, payload, headers, timeout });
+      const actualResponse = await post({ url: 'https://my-url.com/someresource', payload, headers });
 
       // then
       expect(actualResponse).to.deep.equal({
         isSuccessful: true,
-        code: axiosResponse.status,
-        data: axiosResponse.data,
+        code: 201,
+        data: response,
       });
+      expect(requestScope.isDone()).to.be.true;
     });
 
     context('when an error occurs', function () {
-      it('should log the response error data and response time', async function () {
-        // given
-        sinon.stub(logger, 'error');
-        logger.error.resolves();
-
-        const url = 'someUrl';
-        const payload = 'somePayload';
-        const headers = { a: 'someHeaderInfo' };
-        const axiosError = {
-          response: {
-            data: { a: '1', b: '2' },
-            status: 400,
-          },
-        };
-        sinon.stub(axios, 'post').withArgs(url, payload, { headers }).rejects(axiosError);
-
-        // when
-        await post({ url, payload, headers });
-
-        // then
-        const expected = 'End POST request to someUrl error: 400 {"a":"1","b":"2"}';
-        const { message, metrics } = logger.error.firstCall.args[0];
-        expect(message).to.equal(expected);
-        expect(metrics.responseTime).to.be.greaterThan(0);
-      });
-
-      context('when error.response exists', function () {
+      context('when fetch succeed but response is not 2xx', function () {
         it("should return an http response with the error's response status as code and data from the failed http call", async function () {
           // given
-          const url = 'someUrl';
-          const payload = 'somePayload';
-          const headers = { a: 'someHeaderInfo' };
-          const axiosError = {
-            response: {
-              data: Symbol('data'),
-              status: 'someStatus',
-            },
-          };
-          sinon.stub(axios, 'post').withArgs(url, payload, { headers }).rejects(axiosError);
+          const response = { error: 'cavapas' };
+          const payload = { foo: 'bar' };
+          const headers = { Authorization: 'Bearer monsupertoken' };
+          const requestScope = nock('https://my-url.com', {
+            reqheaders: { 'content-type': 'application/json', ...headers },
+          })
+            .post('/someresource', payload)
+            .reply(429, response);
 
           // when
-          const actualResponse = await post({ url, payload, headers });
+          const actualResponse = await post({ url: 'https://my-url.com/someresource', payload, headers });
 
           // then
           expect(actualResponse).to.deep.equal({
             isSuccessful: false,
-            code: axiosError.response.status,
-            data: axiosError.response.data,
+            code: 429,
+            data: response,
           });
+          expect(requestScope.isDone()).to.be.true;
         });
       });
 
-      context("when error.response doesn't exists", function () {
-        it('should return an http response with error with code 500 and data null', async function () {
+      context('when fetch fails', function () {
+        it('should return an http response containing the error message', async function () {
           // given
-          const url = 'someUrl';
-          const payload = 'somePayload';
-          const headers = { a: 'someHeaderInfo' };
-
-          const axiosError = {
-            response: {
-              data: { error: 'HTTP error' },
-              status: 400,
-            },
-          };
-          sinon.stub(axios, 'post').withArgs(url, payload, { headers }).rejects(axiosError);
-
-          const expectedResponse = {
-            isSuccessful: false,
-            code: axiosError.response.status,
-            data: axiosError.response.data,
-          };
+          const payload = { foo: 'bar' };
+          const headers = { Authorization: 'Bearer monsupertoken' };
+          const requestScope = nock('https://my-url.com', {
+            reqheaders: { 'content-type': 'application/json', ...headers },
+          })
+            .post('/someresource', payload)
+            .replyWithError('some network error occurred');
 
           // when
-          const actualResponse = await post({ url, payload, headers });
+          const actualResponse = await post({ url: 'https://my-url.com/someresource', payload, headers });
 
           // then
-          expect(actualResponse).to.deep.equal(expectedResponse);
+          expect(actualResponse).to.deep.equal({
+            isSuccessful: false,
+            code: null,
+            data: 'some network error occurred',
+          });
+          expect(requestScope.isDone()).to.be.true;
         });
       });
     });

--- a/api/tests/shared/integration/infrastructure/http-agent_test.js
+++ b/api/tests/shared/integration/infrastructure/http-agent_test.js
@@ -1,9 +1,6 @@
-import axios from 'axios';
 import nock from 'nock';
-import sinon from 'sinon';
 
 import { httpAgent } from '../../../../src/shared/infrastructure/http-agent.js';
-import { logger } from '../../../../src/shared/infrastructure/utils/logger.js';
 import { expect } from '../../../test-helper.js';
 
 const { post, get } = httpAgent;
@@ -90,104 +87,73 @@ describe('Shared | Integration | Infrastructure | http-agent', function () {
   describe('#get', function () {
     it('should return the response status and success from the http call when successful', async function () {
       // given
-      const url = 'someUrl';
-      const payload = 'somePayload';
-      const headers = { a: 'someHeaderInfo' };
-      const axiosResponse = {
-        data: Symbol('data'),
-        status: 'someStatus',
-      };
-      sinon.stub(axios, 'get').withArgs(url, { data: payload, headers }).resolves(axiosResponse);
+      const response = { coucou: 'cava' };
+      const headers = { Authorization: 'Bearer monsupertoken' };
+      const requestScope = nock('https://my-url.com', {
+        reqheaders: headers,
+      })
+        .get('/someresource')
+        .reply(200, JSON.stringify(response), {
+          'Content-Type': 'application/json',
+        });
 
       // when
-      const actualResponse = await get({ url, payload, headers });
+      const actualResponse = await get({ url: 'https://my-url.com/someresource', headers });
 
       // then
       expect(actualResponse).to.deep.equal({
         isSuccessful: true,
-        code: axiosResponse.status,
-        data: axiosResponse.data,
+        code: 200,
+        data: response,
       });
+      expect(requestScope.isDone()).to.be.true;
     });
 
     context('when an error occurs', function () {
-      it('should log the response error data and response time', async function () {
-        // given
-        sinon.stub(logger, 'error');
-        logger.error.resolves();
-
-        const url = 'someUrl';
-        const payload = 'somePayload';
-        const headers = { a: 'someHeaderInfo' };
-        const axiosError = {
-          response: {
-            data: { a: '1', b: '2' },
-            status: 400,
-          },
-        };
-        sinon.stub(axios, 'get').withArgs(url, { data: payload, headers }).rejects(axiosError);
-
-        // when
-        await get({ url, payload, headers });
-
-        // then
-        const expected = 'End GET request to someUrl error: 400 {"a":"1","b":"2"}';
-        const { message, metrics } = logger.error.firstCall.args[0];
-        expect(message).to.equal(expected);
-        expect(metrics.responseTime).to.be.greaterThan(0);
-      });
-
-      context('when error.response exists', function () {
+      context('when fetch succeed but response is not 2xx', function () {
         it("should return an http response with the error's response status as code and data from the failed http call", async function () {
           // given
-          const url = 'someUrl';
-          const payload = 'somePayload';
-          const headers = { a: 'someHeaderInfo' };
-          const axiosError = {
-            response: {
-              data: Symbol('data'),
-              status: 'someStatus',
-            },
-          };
-          sinon.stub(axios, 'get').withArgs(url, { data: payload, headers }).rejects(axiosError);
+          const response = { error: 'cavapas' };
+          const headers = { Authorization: 'Bearer monsupertoken' };
+          const requestScope = nock('https://my-url.com', {
+            reqheaders: headers,
+          })
+            .get('/someresource')
+            .reply(429, response);
 
           // when
-          const actualResponse = await get({ url, payload, headers });
+          const actualResponse = await get({ url: 'https://my-url.com/someresource', headers });
 
           // then
           expect(actualResponse).to.deep.equal({
             isSuccessful: false,
-            code: axiosError.response.status,
-            data: axiosError.response.data,
+            code: 429,
+            data: response,
           });
+          expect(requestScope.isDone()).to.be.true;
         });
       });
 
-      context("when error.response doesn't exists", function () {
-        it('should return an http response with error with code 500 and data null', async function () {
+      context('when fetch fails', function () {
+        it('should return an http response containing the error message', async function () {
           // given
-          const url = 'someUrl';
-          const payload = 'somePayload';
-          const headers = { a: 'someHeaderInfo' };
-
-          const axiosError = {
-            name: 'error name',
-            message: 'MESSAGE_ERROR',
-            code: 'CODE_ERROR',
-          };
-          sinon.stub(axios, 'get').withArgs(url, { data: payload, headers }).rejects(axiosError);
-
-          const expectedResponse = {
-            isSuccessful: false,
-            code: 'CODE_ERROR',
-            data: 'MESSAGE_ERROR',
-          };
+          const headers = { Authorization: 'Bearer monsupertoken' };
+          const requestScope = nock('https://my-url.com', {
+            reqheaders: headers,
+          })
+            .get('/someresource')
+            .replyWithError('some network error occurred');
 
           // when
-          const actualResponse = await get({ url, payload, headers });
+          const actualResponse = await get({ url: 'https://my-url.com/someresource', headers });
 
           // then
-          expect(actualResponse).to.deep.equal(expectedResponse);
+          expect(actualResponse).to.deep.equal({
+            isSuccessful: false,
+            code: null,
+            data: 'some network error occurred',
+          });
+          expect(requestScope.isDone()).to.be.true;
         });
       });
     });

--- a/api/tests/shared/integration/infrastructure/repositories/challenge-repository_test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/challenge-repository_test.js
@@ -762,7 +762,9 @@ describe('Integration | Repository | challenge-repository', function () {
             // given
             const webComponentServerCall = nock('https://example.com')
               .get('/embed.json')
-              .reply(200, JSON.stringify({ name: 'web-component', props: { prop1: 'value1', prop2: 'value2' } }));
+              .reply(200, JSON.stringify({ name: 'web-component', props: { prop1: 'value1', prop2: 'value2' } }), {
+                'Content-Type': 'application/json',
+              });
 
             // when
             const challenge = await challengeRepository.get('challengeId01');


### PR DESCRIPTION
## 🌎 Problème

Des versions d'Axios ont été compromises. Et l'API utilise Axios 😬 
Heureusement nous ne sommes pas sur une version compromise actuellement, mais il faut éviter d'en installer une par mégarde.

## 🔭 Proposition

- Remplacer axios par fetch

Note : pour remplacer axios sans trop se prendre la tête, on a mimé son comportement lorsqu'il s'agit de récupérer le payload de response : en gros axios ne se soucie pas du header de response 'Content-type' et force le parsing en JSON, et en cas d'échec retourne la donnée brute

## 🪐 Remarques

## 🚀 Pour tester
Non régression sur la récupération du référentiel : ✅ 
PixJunior et épreuve avec WebComponent : ✅ 
Registration LTI : ☑️ 

🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘 🌑
