### PR TITLE
[FEATURE] Prometheus : Activer la collecte des metrics par défaut

### DIFF
--- a/api/src/shared/infrastructure/metrics/metrics.js
+++ b/api/src/shared/infrastructure/metrics/metrics.js
@@ -1,7 +1,9 @@
-import { Counter, Gauge, Histogram, Summary } from 'prom-client';
+import { collectDefaultMetrics, Counter, Gauge, Histogram, Summary } from 'prom-client';
 
 import { config } from '../../config.js';
 import { register } from './register.js';
+
+collectDefaultMetrics({ register });
 
 /**
  * @param {Omit<ConstructorParameters<typeof Counter>[0], 'registers'>} configuration

--- a/docs/Prometheus.md
+++ b/docs/Prometheus.md
@@ -1,0 +1,17 @@
+# Collecte de metrics avec Prometheus
+
+## Tester en dev
+
+Démarrer les containers nécessaires :
+
+```
+docker compose -f compose.yaml -f compose.prometheus.yaml up -d
+```
+
+Dans le fichier [`api/.env`](../api/.env),
+recopier les variables `PROMETHEUS_*` depuis le fichier [`api/sample.env`](../api/sample.env),
+puis passer la variable `PROMETHEUS_ENABLED` à `true`.
+
+Démarrer ou redémarrer l’API.
+
+Visionner les metrics collectées sur Grafana http://localhost:3210/, identifiants par défaut admin/admin.


### PR DESCRIPTION
## 🌎 Problème

La collecte des metrics NodeJS par défaut n’est pas activée sur prom-client.

## 🔭 Proposition

Activer la collecte des metrics par défaut.

## 🪐 Remarques

N/A

## 🚀 Pour tester

Vérifier que les metrics node de la RA sont bien collectées sur le Prometheus sandbox, avec le filtre job=pix-api-review-pr15713-web-1 :

https://grafana.sandbox.pix.digital/explore?schemaVersion=1&panes=%7B%22uiv%22:%7B%22datasource%22:%22prometheus%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22%7Bjob%3D%5C%22pix-api-review-pr15713-web-1%5C%22%7D%22,%22range%22:true,%22instant%22:true,%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22prometheus%22%7D,%22editorMode%22:%22builder%22,%22legendFormat%22:%22__auto%22%7D%5D,%22range%22:%7B%22from%22:%22now-1h%22,%22to%22:%22now%22%7D,%22compact%22:false%7D%7D&orgId=1