### PR TITLE
[BUGFIX] Éviter de mettre en cache deux fois les épreuves qui sont jouées dans le cadre de la certification

### DIFF
--- a/api/src/certification/evaluation/infrastructure/repositories/calibrated-challenge-repository.js
+++ b/api/src/certification/evaluation/infrastructure/repositories/calibrated-challenge-repository.js
@@ -4,14 +4,11 @@
 
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../../shared/domain/errors.js';
-import { LearningContentRepository } from '../../../../shared/infrastructure/repositories/learning-content-repository.js';
+import * as challengeRepository from '../../../../shared/infrastructure/repositories/challenge-repository.js';
 import * as skillRepository from '../../../../shared/infrastructure/repositories/skill-repository.js';
 import { logger } from '../../../../shared/infrastructure/utils/logger.js';
 import { CalibratedChallenge } from '../../domain/models/CalibratedChallenge.js';
 import { CalibratedChallengeSkill } from '../../domain/models/CalibratedChallengeSkill.js';
-
-const TABLE_NAME = 'learningcontent.challenges';
-const VALIDATED_STATUS = 'validé';
 
 /**
  * @param {object} params
@@ -19,16 +16,8 @@ const VALIDATED_STATUS = 'validé';
  * @param {Version} params.version
  * @returns {Promise<CalibratedChallenge[]>} challenges with validated LCMS status
  */
-export async function findActiveFlashCompatible({
-  locale,
-  version,
-  dependencies = {
-    getInstance,
-  },
-} = {}) {
+export async function findActiveFlashCompatible({ locale, version } = {}) {
   const knexConn = DomainTransaction.getConnection();
-  _assertLocaleIsDefined(locale);
-  const cacheKey = `findActiveFlashCompatible({ versionId: ${version?.id}, locale: ${locale} })`;
 
   const certificationChallenges = await knexConn
     .select('difficulty', 'discriminant', 'challengeId')
@@ -39,19 +28,14 @@ export async function findActiveFlashCompatible({
 
   const certificationChallengeIds = certificationChallenges.map(({ challengeId }) => challengeId);
 
-  const findCallback = async (lcmsKnex) => {
-    return lcmsKnex
-      .select('id', 'skillId', 'accessibility1', 'accessibility2')
-      .whereIn('id', certificationChallengeIds)
-      .where('status', VALIDATED_STATUS)
-      .whereRaw('?=ANY(??)', [locale, 'locales'])
-      .orderBy('id');
-  };
-
-  const validChallengeDtos = await dependencies.getInstance().find(cacheKey, findCallback);
+  const lcmsChallenges = await challengeRepository.findValidatedByIds_proxy({
+    version: version.id,
+    locale,
+    ids: certificationChallengeIds,
+  });
 
   const challengeDtos = decorateWithCertificationCalibration({
-    validChallengeDtos,
+    lcmsChallenges,
     certificationChallenges,
   });
 
@@ -65,13 +49,7 @@ export async function findActiveFlashCompatible({
  * @param {Version} params.version
  * @returns {Promise<CalibratedChallenge[]>}
  */
-export async function getMany({
-  ids,
-  version,
-  dependencies = {
-    getInstance,
-  },
-} = {}) {
+export async function getMany({ ids, version }) {
   const knexConn = DomainTransaction.getConnection();
   const calibrations = await knexConn
     .select('difficulty', 'discriminant', 'challengeId')
@@ -86,17 +64,11 @@ export async function getMany({
     throw new NotFoundError('Some challenges do not exist in certification version');
   }
 
-  const lcmsChallenges = await dependencies.getInstance().loadMany(ids);
-  lcmsChallenges.forEach((challengeDto, index) => {
-    if (challengeDto) return;
-    logger.error({ challengeId: ids[index] }, 'Some challenges do not exist in LCMS');
-    throw new NotFoundError('Some challenges do not exist in LCMS');
-  });
-
+  const lcmsChallenges = await challengeRepository.getMany_proxy(ids);
   lcmsChallenges.sort(_byId);
 
   const challengesWithCalibration = decorateWithCertificationCalibration({
-    validChallengeDtos: lcmsChallenges,
+    lcmsChallenges,
     certificationChallenges: calibrations,
   });
 
@@ -109,12 +81,7 @@ export async function getMany({
  * @param {Version} params.version
  * @returns {Promise<CalibratedChallenge[]>}
  */
-export const getAllCalibratedChallenges = async ({
-  version,
-  dependencies = {
-    getInstance,
-  },
-}) => {
+export async function getAllCalibratedChallenges({ version }) {
   const knexConn = DomainTransaction.getConnection();
 
   const calibrationForThisVersion = await knexConn
@@ -127,23 +94,17 @@ export const getAllCalibratedChallenges = async ({
 
   const challengesIds = calibrationForThisVersion.map(({ challengeId }) => challengeId);
 
-  const lcmsChallenges = await dependencies.getInstance().loadMany(challengesIds);
-  lcmsChallenges.forEach((challengeDto, index) => {
-    if (challengeDto) return;
-    logger.error({ challengeId: challengesIds[index] }, 'Some challenges do not exist in LCMS');
-    throw new NotFoundError('Some challenges do not exist in LCMS');
-  });
-
+  const lcmsChallenges = await challengeRepository.getMany_proxy(challengesIds);
   lcmsChallenges.sort(_byId);
 
   const challengesWithCalibration = decorateWithCertificationCalibration({
-    validChallengeDtos: lcmsChallenges,
+    lcmsChallenges,
     certificationChallenges: calibrationForThisVersion,
   });
 
   const challengesDtosWithSkills = await loadChallengeDtosSkills(challengesWithCalibration);
   return challengesDtosWithSkills.map(([challengeDto, skill]) => _toDomain({ challengeDto, skill }));
-};
+}
 
 const _byId = (challenge1, challenge2) => {
   return challenge1.id < challenge2.id ? -1 : 1;
@@ -158,24 +119,21 @@ async function loadChallengeDtosSkills(challengeDtos) {
   );
 }
 
-function decorateWithCertificationCalibration({ validChallengeDtos, certificationChallenges }) {
-  return validChallengeDtos.map((challenge) => {
+function decorateWithCertificationCalibration({ lcmsChallenges, certificationChallenges }) {
+  return lcmsChallenges.map((lcmsChallenge) => {
     const { discriminant, difficulty } = certificationChallenges.find(
-      ({ challengeId }) => challengeId === challenge.id,
+      ({ challengeId }) => challengeId === lcmsChallenge.id,
     );
 
     return {
-      ...challenge,
+      id: lcmsChallenge.id,
+      blindnessCompatibility: lcmsChallenge.accessibility1,
+      colorBlindnessCompatibility: lcmsChallenge.accessibility2,
+      skillId: lcmsChallenge.skillId,
       discriminant,
       difficulty,
     };
   });
-}
-
-function _assertLocaleIsDefined(locale) {
-  if (!locale) {
-    throw new Error('Locale shall be defined');
-  }
 }
 
 function _toDomain({ challengeDto, skill }) {
@@ -183,8 +141,8 @@ function _toDomain({ challengeDto, skill }) {
     id: challengeDto.id,
     discriminant: challengeDto.discriminant,
     difficulty: challengeDto.difficulty,
-    blindnessCompatibility: challengeDto.accessibility1,
-    colorBlindnessCompatibility: challengeDto.accessibility2,
+    blindnessCompatibility: challengeDto.blindnessCompatibility,
+    colorBlindnessCompatibility: challengeDto.colorBlindnessCompatibility,
     skill: new CalibratedChallengeSkill({
       id: skill.id,
       name: skill.name,
@@ -192,13 +150,4 @@ function _toDomain({ challengeDto, skill }) {
       tubeId: skill.tubeId,
     }),
   });
-}
-
-let instance;
-
-function getInstance() {
-  if (!instance) {
-    instance = new LearningContentRepository({ tableName: TABLE_NAME });
-  }
-  return instance;
 }

--- a/api/src/certification/evaluation/infrastructure/repositories/calibrated-challenge-repository.js
+++ b/api/src/certification/evaluation/infrastructure/repositories/calibrated-challenge-repository.js
@@ -33,14 +33,9 @@ export async function findActiveFlashCompatible({ locale, version } = {}) {
     locale,
     ids: certificationChallengeIds,
   });
+  const calibratedSkillsMap = await loadCalibratedSkillsMap(lcmsChallenges);
 
-  const challengeDtos = decorateWithCertificationCalibration({
-    lcmsChallenges,
-    certificationChallenges,
-  });
-
-  const challengesDtosWithSkills = await loadChallengeDtosSkills(challengeDtos);
-  return challengesDtosWithSkills.map(([challengeDto, skill]) => _toDomain({ challengeDto, skill }));
+  return toDomainMap({ lcmsChallenges, certificationChallenges, calibratedSkillsMap });
 }
 
 /**
@@ -66,14 +61,9 @@ export async function getMany({ ids, version }) {
 
   const lcmsChallenges = await challengeRepository.getMany_proxy(ids);
   lcmsChallenges.sort(_byId);
+  const calibratedSkillsMap = await loadCalibratedSkillsMap(lcmsChallenges);
 
-  const challengesWithCalibration = decorateWithCertificationCalibration({
-    lcmsChallenges,
-    certificationChallenges: calibrations,
-  });
-
-  const challengesDtosWithSkills = await loadChallengeDtosSkills(challengesWithCalibration);
-  return challengesDtosWithSkills.map(([challengeDto, skill]) => _toDomain({ challengeDto, skill }));
+  return toDomainMap({ lcmsChallenges, certificationChallenges: calibrations, calibratedSkillsMap });
 }
 
 /**
@@ -96,58 +86,44 @@ export async function getAllCalibratedChallenges({ version }) {
 
   const lcmsChallenges = await challengeRepository.getMany_proxy(challengesIds);
   lcmsChallenges.sort(_byId);
+  const calibratedSkillsMap = await loadCalibratedSkillsMap(lcmsChallenges);
 
-  const challengesWithCalibration = decorateWithCertificationCalibration({
-    lcmsChallenges,
-    certificationChallenges: calibrationForThisVersion,
-  });
-
-  const challengesDtosWithSkills = await loadChallengeDtosSkills(challengesWithCalibration);
-  return challengesDtosWithSkills.map(([challengeDto, skill]) => _toDomain({ challengeDto, skill }));
+  return toDomainMap({ lcmsChallenges, certificationChallenges: calibrationForThisVersion, calibratedSkillsMap });
 }
 
 const _byId = (challenge1, challenge2) => {
   return challenge1.id < challenge2.id ? -1 : 1;
 };
 
-async function loadChallengeDtosSkills(challengeDtos) {
-  return Promise.all(
-    challengeDtos.map(async (challengeDto) => [
-      challengeDto,
-      challengeDto.skillId ? await skillRepository.get(challengeDto.skillId) : null,
+async function loadCalibratedSkillsMap(lcmsChallenges) {
+  const uniqueSkillIds = [...new Set(lcmsChallenges.map((lcmsChallenge) => lcmsChallenge.skillId))];
+  const baseSkills = await skillRepository.findByRecordIds(uniqueSkillIds);
+  return new Map(
+    baseSkills.map((bs) => [
+      bs.id,
+      new CalibratedChallengeSkill({
+        id: bs.id,
+        name: bs.name,
+        competenceId: bs.competenceId,
+        tubeId: bs.tubeId,
+      }),
     ]),
   );
 }
 
-function decorateWithCertificationCalibration({ lcmsChallenges, certificationChallenges }) {
+function toDomainMap({ lcmsChallenges, certificationChallenges, calibratedSkillsMap }) {
   return lcmsChallenges.map((lcmsChallenge) => {
     const { discriminant, difficulty } = certificationChallenges.find(
       ({ challengeId }) => challengeId === lcmsChallenge.id,
     );
-
-    return {
+    const calibratedSkill = lcmsChallenge.skillId ? calibratedSkillsMap.get(lcmsChallenge.skillId) : null;
+    return new CalibratedChallenge({
       id: lcmsChallenge.id,
-      blindnessCompatibility: lcmsChallenge.accessibility1,
-      colorBlindnessCompatibility: lcmsChallenge.accessibility2,
-      skillId: lcmsChallenge.skillId,
       discriminant,
       difficulty,
-    };
-  });
-}
-
-function _toDomain({ challengeDto, skill }) {
-  return new CalibratedChallenge({
-    id: challengeDto.id,
-    discriminant: challengeDto.discriminant,
-    difficulty: challengeDto.difficulty,
-    blindnessCompatibility: challengeDto.blindnessCompatibility,
-    colorBlindnessCompatibility: challengeDto.colorBlindnessCompatibility,
-    skill: new CalibratedChallengeSkill({
-      id: skill.id,
-      name: skill.name,
-      competenceId: skill.competenceId,
-      tubeId: skill.tubeId,
-    }),
+      blindnessCompatibility: lcmsChallenge.accessibility1,
+      colorBlindnessCompatibility: lcmsChallenge.accessibility2,
+      skill: calibratedSkill,
+    });
   });
 }

--- a/api/src/learning-content/domain/models/Challenge.js
+++ b/api/src/learning-content/domain/models/Challenge.js
@@ -1,0 +1,42 @@
+export class Challenge {
+  #cachedChallengeDto;
+
+  /**
+   * @param {Object} cachedChallengeDto
+   */
+  constructor(cachedChallengeDto) {
+    this.#cachedChallengeDto = cachedChallengeDto;
+  }
+
+  /**
+   * @readonly
+   * @type {string}
+   */
+  get id() {
+    return this.#cachedChallengeDto.id;
+  }
+
+  /**
+   * @readonly
+   * @type {string}
+   */
+  get accessibility1() {
+    return this.#cachedChallengeDto.accessibility1;
+  }
+
+  /**
+   * @readonly
+   * @type {string}
+   */
+  get accessibility2() {
+    return this.#cachedChallengeDto.accessibility2;
+  }
+
+  /**
+   * @readonly
+   * @type {string}
+   */
+  get skillId() {
+    return this.#cachedChallengeDto.skillId;
+  }
+}

--- a/api/src/shared/infrastructure/repositories/challenge-repository.js
+++ b/api/src/shared/infrastructure/repositories/challenge-repository.js
@@ -1,3 +1,4 @@
+import { Challenge as ChallengeProxy } from '../../../learning-content/domain/models/Challenge.js';
 import { NotFoundError } from '../../domain/errors.js';
 import { Challenge } from '../../domain/models/Challenge.js';
 import * as solutionAdapter from '../../infrastructure/adapters/solution-adapter.js';
@@ -130,6 +131,31 @@ export async function getManyTypes(ids) {
     throw new NotFoundError();
   }
   return Object.fromEntries(challengeDtos.map(({ id, type }) => [id, type]));
+}
+
+export async function findValidatedByIds_proxy({ versionId, ids, locale }) {
+  _assertLocaleIsDefined(locale);
+  const cacheKey = `findActiveFlashCompatible({ versionId: ${versionId}, locale: ${locale} })`;
+  const findCallback = async (knex) => {
+    return knex
+      .select('id', 'skillId', 'accessibility1', 'accessibility2')
+      .whereIn('id', ids)
+      .where('status', VALIDATED_STATUS)
+      .whereRaw('?=ANY(??)', [locale, 'locales'])
+      .orderBy('id');
+  };
+  const challengeDtos = await getInstance().find(cacheKey, findCallback);
+  return challengeDtos.map((challengeDto) => new ChallengeProxy(challengeDto));
+}
+
+export async function getMany_proxy(ids) {
+  const challengeDtos = await getInstance().loadMany(ids);
+  challengeDtos.forEach((challengeDto, index) => {
+    if (challengeDto) return;
+    logger.warn({ challengeId: ids[index] }, 'Épreuve introuvable');
+    throw new NotFoundError('Épreuve introuvable');
+  });
+  return challengeDtos.map((challengeDto) => new ChallengeProxy(challengeDto));
 }
 
 export function clearCache(id) {

--- a/api/tests/certification/evaluation/integration/infrastructure/repositories/calibrated-challenge-repository_test.js
+++ b/api/tests/certification/evaluation/integration/infrastructure/repositories/calibrated-challenge-repository_test.js
@@ -5,164 +5,36 @@ import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
 import { catchErr, databaseBuilder, domainBuilder, expect } from '../../../../../test-helper.js';
 
 describe('Certification | Evaluation | Integration | Repository | calibrated-challenge-repository', function () {
-  const challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson = {
+  const challengeData00_skill00_valide_frnl = {
     id: 'challengeId00',
-    instruction: 'instruction challengeId00',
-    alternativeInstruction: 'alternativeInstruction challengeId00',
-    proposals: 'proposals challengeId00',
-    type: 'QCU',
-    solution: 'solution challengeId00',
-    solutionToDisplay: 'solutionToDisplay challengeId00',
-    t1Status: true,
-    t2Status: false,
-    t3Status: true,
     status: 'validé',
-    genealogy: 'genealogy challengeId00',
     accessibility1: 'accessibility1 challengeId00',
     accessibility2: 'accessibility2 challengeId00',
-    requireGafamWebsiteAccess: true,
-    isIncompatibleIpadCertif: false,
-    deafAndHardOfHearing: 'deafAndHardOfHearing challengeId00',
-    isAwarenessChallenge: true,
-    toRephrase: false,
-    alternativeVersion: 10,
-    shuffled: true,
-    illustrationAlt: 'illustrationAlt challengeId00',
-    illustrationUrl: 'illustrationUrl challengeId00',
-    attachments: ['attachment1', 'attachment2'],
-    responsive: 'responsive challengeId00',
-    alpha: 1.1,
-    delta: 3.3,
-    autoReply: true,
-    focusable: true,
-    format: 'format challengeId00',
-    timer: 180,
-    embedHeight: 800,
-    embedUrl: 'embedUrl challengeId00',
-    embedTitle: 'embedTitle challengeId00',
     locales: ['fr', 'nl'],
-    competenceId: 'competenceId00',
     skillId: 'skillId00',
-    hasEmbedInternalValidation: true,
-    noValidationNeeded: true,
   };
-  const challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson = {
+  const challengeData01_skill00_valide_fren = {
     id: 'challengeId01',
-    instruction: 'instruction challengeId01',
-    alternativeInstruction: 'alternativeInstruction challengeId01',
-    proposals: 'proposals challengeId01',
-    type: 'QCU',
-    solution: 'solution challengeId01',
-    solutionToDisplay: 'solutionToDisplay challengeId01',
-    t1Status: false,
-    t2Status: true,
-    t3Status: true,
     status: 'validé',
-    genealogy: 'genealogy challengeId01',
     accessibility1: 'accessibility1 challengeId01',
     accessibility2: 'accessibility2 challengeId01',
-    requireGafamWebsiteAccess: false,
-    isIncompatibleIpadCertif: true,
-    deafAndHardOfHearing: 'deafAndHardOfHearing challengeId01',
-    isAwarenessChallenge: true,
-    toRephrase: false,
-    alternativeVersion: 20,
-    shuffled: false,
-    illustrationAlt: 'illustrationAlt challengeId01',
-    illustrationUrl: 'illustrationUrl challengeId01',
-    attachments: ['attachment1', 'attachment2'],
-    responsive: 'responsive challengeId01',
-    alpha: 1.2,
-    delta: 3.4,
-    autoReply: true,
-    focusable: false,
-    format: 'format challengeId01',
-    timer: 180,
-    embedHeight: 801,
-    embedUrl: 'https://example.com/embed.json',
-    embedTitle: 'embedTitle challengeId01',
     locales: ['fr', 'en'],
-    competenceId: 'competenceId00',
     skillId: 'skillId00',
-    hasEmbedInternalValidation: true,
-    noValidationNeeded: true,
   };
-  const challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson = {
+  const challengeData02_skill00_archive_en = {
     id: 'challengeId02',
-    instruction: 'instruction challengeId02',
-    alternativeInstruction: 'alternativeInstruction challengeId02',
-    proposals: 'proposals challengeId02',
-    type: 'QCM',
-    solution: 'solution challengeId02',
-    solutionToDisplay: 'solutionToDisplay challengeId02',
-    t1Status: false,
-    t2Status: true,
-    t3Status: false,
     status: 'archivé',
-    genealogy: 'genealogy challengeId02',
     accessibility1: 'accessibility1 challengeId02',
     accessibility2: 'accessibility2 challengeId02',
-    requireGafamWebsiteAccess: false,
-    isIncompatibleIpadCertif: false,
-    deafAndHardOfHearing: 'deafAndHardOfHearing challengeId02',
-    isAwarenessChallenge: true,
-    toRephrase: false,
-    alternativeVersion: 30,
-    shuffled: false,
-    illustrationAlt: 'illustrationAlt challengeId02',
-    illustrationUrl: 'illustrationUrl challengeId02',
-    attachments: ['attachment1', 'attachment2'],
-    responsive: 'responsive challengeId02',
-    alpha: 1.3,
-    delta: 3.5,
-    autoReply: false,
-    focusable: false,
-    format: 'format challengeId02',
-    timer: null,
-    embedHeight: 802,
-    embedUrl: 'embed url challengeId02',
-    embedTitle: 'embedTitle challengeId02',
     locales: ['en'],
-    competenceId: 'competenceId00',
     skillId: 'skillId00',
   };
-  const challengeData03_skill00_qcm_valide_flashCompatible_nl_noEmbedJson = {
+  const challengeData03_skill00_valide_nl = {
     id: 'challengeId03',
-    instruction: 'instruction challengeId03',
-    alternativeInstruction: 'alternativeInstruction challengeId03',
-    proposals: 'proposals challengeId03',
-    type: 'QCM',
-    solution: 'solution challengeId03',
-    solutionToDisplay: 'solutionToDisplay challengeId03',
-    t1Status: true,
-    t2Status: true,
-    t3Status: false,
     status: 'validé',
-    genealogy: 'genealogy challengeId03',
     accessibility1: 'accessibility1 challengeId03',
     accessibility2: 'accessibility2 challengeId03',
-    requireGafamWebsiteAccess: true,
-    isIncompatibleIpadCertif: false,
-    deafAndHardOfHearing: 'deafAndHardOfHearing challengeId03',
-    isAwarenessChallenge: true,
-    toRephrase: false,
-    alternativeVersion: 40,
-    shuffled: true,
-    illustrationAlt: 'illustrationAlt challengeId03',
-    illustrationUrl: 'illustrationUrl challengeId03',
-    attachments: ['attachment1', 'attachment2'],
-    responsive: 'responsive challengeId03',
-    alpha: 1.4,
-    delta: 3.6,
-    autoReply: true,
-    focusable: false,
-    format: 'format challengeId03',
-    timer: null,
-    embedHeight: 803,
-    embedUrl: 'embed url challengeId03',
-    embedTitle: 'embedTitle challengeId03',
     locales: ['nl'],
-    competenceId: 'competenceId00',
     skillId: 'skillId00',
   };
   const skillData00_tube00competence00_actif = {
@@ -179,43 +51,12 @@ describe('Certification | Evaluation | Integration | Repository | calibrated-cha
     learningMoreTutorialIds: [],
     hint_i18n: { fr: 'hint FR skillId00', en: 'hint EN skillId00' },
   };
-  const challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson = {
+  const challengeData04_skill01_valide_ennl = {
     id: 'challengeId04',
-    instruction: 'instruction challengeId04',
-    alternativeInstruction: 'alternativeInstruction challengeId04',
-    proposals: 'proposals challengeId04',
-    type: 'QCU',
-    solution: 'solution challengeId04',
-    solutionToDisplay: 'solutionToDisplay challengeId04',
-    t1Status: true,
-    t2Status: false,
-    t3Status: false,
     status: 'validé',
-    genealogy: 'genealogy challengeId04',
     accessibility1: 'accessibility1 challengeId04',
     accessibility2: 'accessibility2 challengeId04',
-    requireGafamWebsiteAccess: false,
-    isIncompatibleIpadCertif: false,
-    deafAndHardOfHearing: 'deafAndHardOfHearing challengeId04',
-    isAwarenessChallenge: true,
-    toRephrase: false,
-    alternativeVersion: 10,
-    shuffled: false,
-    illustrationAlt: 'illustrationAlt challengeId04',
-    illustrationUrl: 'illustrationUrl challengeId04',
-    attachments: ['attachment1'],
-    responsive: 'responsive challengeId04',
-    alpha: 1.5,
-    delta: 3.7,
-    autoReply: true,
-    focusable: false,
-    format: 'format challengeId04',
-    timer: 555,
-    embedHeight: 804,
-    embedUrl: 'embedUrl challengeId04',
-    embedTitle: 'embedTitle challengeId04',
     locales: ['en', 'nl'],
-    competenceId: 'competenceId00',
     skillId: 'skillId01',
   };
   const skillData01_tube01competence00_actif = {
@@ -232,82 +73,20 @@ describe('Certification | Evaluation | Integration | Repository | calibrated-cha
     learningMoreTutorialIds: [],
     hint_i18n: { fr: 'hint FR skillId01', en: 'hint EN skillId01' },
   };
-  const challengeData05_skill02_qcm_perime_flashCompatible_fren_noEmbedJson = {
+  const challengeData05_skill02_perime_fren = {
     id: 'challengeId05',
-    instruction: 'instruction challengeId05',
-    alternativeInstruction: 'alternativeInstruction challengeId05',
-    proposals: 'proposals challengeId05',
-    type: 'QCM',
-    solution: 'solution challengeId05',
-    solutionToDisplay: 'solutionToDisplay challengeId05',
-    t1Status: true,
-    t2Status: false,
-    t3Status: true,
     status: 'périmé',
-    genealogy: 'genealogy challengeId05',
     accessibility1: 'accessibility1 challengeId05',
     accessibility2: 'accessibility2 challengeId05',
-    requireGafamWebsiteAccess: false,
-    isIncompatibleIpadCertif: true,
-    deafAndHardOfHearing: 'deafAndHardOfHearing challengeId05',
-    isAwarenessChallenge: true,
-    toRephrase: false,
-    alternativeVersion: 10,
-    shuffled: true,
-    illustrationAlt: 'illustrationAlt challengeId05',
-    illustrationUrl: 'illustrationUrl challengeId05',
-    attachments: ['attachment1'],
-    responsive: 'responsive challengeId05',
-    alpha: 1.6,
-    delta: 3.8,
-    autoReply: true,
-    focusable: true,
-    format: 'format challengeId05',
-    timer: null,
-    embedHeight: 805,
-    embedUrl: 'embedUrl challengeId05',
-    embedTitle: 'embedTitle challengeId05',
     locales: ['en', 'fr'],
-    competenceId: 'competenceId01',
     skillId: 'skillId02',
   };
-  const challengeData06_skill02_qcm_perime_notFlashCompatible_fren_noEmbedJson = {
+  const challengeData06_skill02_perime_fren = {
     id: 'challengeId06',
-    instruction: 'instruction challengeId06',
-    alternativeInstruction: 'alternativeInstruction challengeId06',
-    proposals: 'proposals challengeId06',
-    type: 'QCM',
-    solution: 'solution challengeId06',
-    solutionToDisplay: 'solutionToDisplay challengeId06',
-    t1Status: true,
-    t2Status: false,
-    t3Status: true,
     status: 'périmé',
-    genealogy: 'genealogy challengeId06',
     accessibility1: 'accessibility1 challengeId06',
     accessibility2: 'accessibility2 challengeId06',
-    requireGafamWebsiteAccess: false,
-    isIncompatibleIpadCertif: true,
-    deafAndHardOfHearing: 'deafAndHardOfHearing challengeId06',
-    isAwarenessChallenge: true,
-    toRephrase: false,
-    alternativeVersion: 10,
-    shuffled: true,
-    illustrationAlt: 'illustrationAlt challengeId06',
-    illustrationUrl: 'illustrationUrl challengeId06',
-    attachments: ['attachment1'],
-    responsive: 'responsive challengeId06',
-    alpha: null,
-    delta: 3.8,
-    autoReply: true,
-    focusable: true,
-    format: 'format challengeId06',
-    timer: null,
-    embedHeight: 806,
-    embedUrl: 'embedUrl challengeId06',
-    embedTitle: 'embedTitle challengeId06',
     locales: ['en', 'fr'],
-    competenceId: 'competenceId01',
     skillId: 'skillId02',
   };
   const skillData02_tube02competence01_perime = {
@@ -324,121 +103,28 @@ describe('Certification | Evaluation | Integration | Repository | calibrated-cha
     learningMoreTutorialIds: [],
     hint_i18n: { fr: 'hint FR skillId02', en: 'hint EN skillId02' },
   };
-  const challengeData07_skill03_qcm_valide_notFlashCompatible_frnl_noEmbedJson = {
+  const challengeData07_skill03_valide_frnl = {
     id: 'challengeId07',
-    instruction: 'instruction challengeId07',
-    alternativeInstruction: 'alternativeInstruction challengeId07',
-    proposals: 'proposals challengeId07',
-    type: 'QCM',
-    solution: 'solution challengeId07',
-    solutionToDisplay: 'solutionToDisplay challengeId07',
-    t1Status: true,
-    t2Status: true,
-    t3Status: true,
     status: 'validé',
-    genealogy: 'genealogy challengeId07',
     accessibility1: 'accessibility1 challengeId07',
     accessibility2: 'accessibility2 challengeId07',
-    requireGafamWebsiteAccess: false,
-    isIncompatibleIpadCertif: true,
-    deafAndHardOfHearing: 'deafAndHardOfHearing challengeId07',
-    isAwarenessChallenge: true,
-    toRephrase: false,
-    alternativeVersion: 10,
-    shuffled: true,
-    illustrationAlt: 'illustrationAlt challengeId07',
-    illustrationUrl: 'illustrationUrl challengeId07',
-    attachments: ['attachment1'],
-    responsive: 'responsive challengeId07',
-    alpha: 0.8,
-    delta: null,
-    autoReply: false,
-    focusable: true,
-    format: 'format challengeId07',
-    timer: null,
-    embedHeight: null,
-    embedUrl: 'embedUrl challengeId07',
-    embedTitle: 'embedTitle challengeId07',
     locales: ['nl', 'fr'],
-    competenceId: 'competenceId01',
     skillId: 'skillId03',
   };
-  const challengeData08_skill03_qcu_archive_notFlashCompatible_fr_noEmbedJson = {
+  const challengeData08_skill03_archive_fr = {
     id: 'challengeId08',
-    instruction: 'instruction challengeId08',
-    alternativeInstruction: 'alternativeInstruction challengeId08',
-    proposals: 'proposals challengeId08',
-    type: 'QCU',
-    solution: 'solution challengeId08',
-    solutionToDisplay: 'solutionToDisplay challengeId08',
-    t1Status: false,
-    t2Status: false,
-    t3Status: true,
     status: 'archivé',
-    genealogy: 'genealogy challengeId08',
     accessibility1: 'accessibility1 challengeId08',
     accessibility2: 'accessibility2 challengeId08',
-    requireGafamWebsiteAccess: false,
-    isIncompatibleIpadCertif: false,
-    deafAndHardOfHearing: 'deafAndHardOfHearing challengeId08',
-    isAwarenessChallenge: true,
-    toRephrase: false,
-    alternativeVersion: 10,
-    shuffled: true,
-    illustrationAlt: 'illustrationAlt challengeId08',
-    illustrationUrl: 'illustrationUrl challengeId08',
-    attachments: ['attachment1'],
-    responsive: 'responsive challengeId08',
-    alpha: null,
-    delta: null,
-    autoReply: false,
-    focusable: true,
-    format: 'format challengeId08',
-    timer: null,
-    embedHeight: null,
-    embedUrl: 'embedUrl challengeId08',
-    embedTitle: 'embedTitle challengeId08',
     locales: ['fr'],
-    competenceId: 'competenceId01',
     skillId: 'skillId03',
   };
-  const challengeData09_skill03_qcu_archive_flashCompatible_fr_noEmbedJson = {
+  const challengeData09_skill03_archive_fr = {
     id: 'challengeId09',
-    instruction: 'instruction challengeId09',
-    alternativeInstruction: 'alternativeInstruction challengeId09',
-    proposals: 'proposals challengeId09',
-    type: 'QCU',
-    solution: 'solution challengeId09',
-    solutionToDisplay: 'solutionToDisplay challengeId09',
-    t1Status: false,
-    t2Status: false,
-    t3Status: false,
     status: 'archivé',
-    genealogy: 'genealogy challengeId09',
     accessibility1: 'accessibility1 challengeId09',
     accessibility2: 'accessibility2 challengeId09',
-    requireGafamWebsiteAccess: true,
-    isIncompatibleIpadCertif: false,
-    deafAndHardOfHearing: 'deafAndHardOfHearing challengeId09',
-    isAwarenessChallenge: true,
-    toRephrase: false,
-    alternativeVersion: 10,
-    shuffled: true,
-    illustrationAlt: 'illustrationAlt challengeId09',
-    illustrationUrl: 'illustrationUrl challengeId09',
-    attachments: ['attachment1'],
-    responsive: 'responsive challengeId09',
-    alpha: 1.0,
-    delta: 2.0,
-    autoReply: true,
-    focusable: true,
-    format: 'format challengeId09',
-    timer: null,
-    embedHeight: null,
-    embedUrl: 'embedUrl challengeId09',
-    embedTitle: 'embedTitle challengeId09',
     locales: ['fr'],
-    competenceId: 'competenceId01',
     skillId: 'skillId03',
   };
   const skillData03_tube02competence01_actif = {
@@ -465,16 +151,16 @@ describe('Certification | Evaluation | Integration | Repository | calibrated-cha
         skillData03_tube02competence01_actif,
       ],
       challenges: [
-        challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson,
-        challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson,
-        challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson,
-        challengeData03_skill00_qcm_valide_flashCompatible_nl_noEmbedJson,
-        challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson,
-        challengeData05_skill02_qcm_perime_flashCompatible_fren_noEmbedJson,
-        challengeData06_skill02_qcm_perime_notFlashCompatible_fren_noEmbedJson,
-        challengeData07_skill03_qcm_valide_notFlashCompatible_frnl_noEmbedJson,
-        challengeData08_skill03_qcu_archive_notFlashCompatible_fr_noEmbedJson,
-        challengeData09_skill03_qcu_archive_flashCompatible_fr_noEmbedJson,
+        challengeData00_skill00_valide_frnl,
+        challengeData01_skill00_valide_fren,
+        challengeData02_skill00_archive_en,
+        challengeData03_skill00_valide_nl,
+        challengeData04_skill01_valide_ennl,
+        challengeData05_skill02_perime_fren,
+        challengeData06_skill02_perime_fren,
+        challengeData07_skill03_valide_frnl,
+        challengeData08_skill03_archive_fr,
+        challengeData09_skill03_archive_fr,
       ],
     });
     await databaseBuilder.commit();
@@ -492,9 +178,9 @@ describe('Certification | Evaluation | Integration | Repository | calibrated-cha
       skillsLC.push(skillData02_tube02competence01_perime);
       skillsLC.push(skillData03_tube02competence01_actif);
       skillsLC.push(skillData00_tube00competence00_actif);
-      challengesLC.push(challengeData06_skill02_qcm_perime_notFlashCompatible_fren_noEmbedJson);
-      challengesLC.push(challengeData07_skill03_qcm_valide_notFlashCompatible_frnl_noEmbedJson);
-      challengesLC.push(challengeData08_skill03_qcu_archive_notFlashCompatible_fr_noEmbedJson);
+      challengesLC.push(challengeData06_skill02_perime_fren);
+      challengesLC.push(challengeData07_skill03_valide_frnl);
+      challengesLC.push(challengeData08_skill03_archive_fr);
     });
 
     it('returns only valid calibrated flash compatible challenges', async function () {
@@ -555,7 +241,7 @@ describe('Certification | Evaluation | Integration | Repository | calibrated-cha
         await databaseBuilder.commit();
 
         // when
-        const err = await catchErr(calibratedChallengeRepository.findActiveFlashCompatible)();
+        const err = await catchErr(calibratedChallengeRepository.findActiveFlashCompatible)({ version: { id: 1 } });
 
         // then
         expect(err.message).to.equal('Locale shall be defined');
@@ -584,11 +270,11 @@ describe('Certification | Evaluation | Integration | Repository | calibrated-cha
       context('when active flash compatible challenges found', function () {
         it('should return the challenges', async function () {
           // given
-          challengesLC.push(challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson);
-          challengesLC.push(challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson);
-          challengesLC.push(challengeData03_skill00_qcm_valide_flashCompatible_nl_noEmbedJson);
-          challengesLC.push(challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson);
-          challengesLC.push(challengeData09_skill03_qcu_archive_flashCompatible_fr_noEmbedJson);
+          challengesLC.push(challengeData01_skill00_valide_fren);
+          challengesLC.push(challengeData00_skill00_valide_frnl);
+          challengesLC.push(challengeData03_skill00_valide_nl);
+          challengesLC.push(challengeData02_skill00_archive_en);
+          challengesLC.push(challengeData09_skill03_archive_fr);
           databaseBuilder.factory.learningContent.build({ skills: skillsLC, challenges: challengesLC });
           const version = databaseBuilder.factory.buildCertificationVersion();
 
@@ -613,14 +299,11 @@ describe('Certification | Evaluation | Integration | Repository | calibrated-cha
           // then
           expect(challenges).to.deep.equal([
             domainBuilder.certification.evaluation.buildCalibratedChallenge({
-              id: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.id,
-              blindnessCompatibility:
-                challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.accessibility1,
-              colorBlindnessCompatibility:
-                challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.accessibility2,
+              id: challengeData00_skill00_valide_frnl.id,
+              blindnessCompatibility: challengeData00_skill00_valide_frnl.accessibility1,
+              colorBlindnessCompatibility: challengeData00_skill00_valide_frnl.accessibility2,
               discriminant: certificationFrameworkChallenge.discriminant,
               difficulty: certificationFrameworkChallenge.difficulty,
-              competenceId: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.competenceId,
               skill: domainBuilder.certification.evaluation.buildCalibratedChallengeSkill({
                 id: 'skillId00',
                 name: 'name skillId00',
@@ -675,7 +358,7 @@ describe('Certification | Evaluation | Integration | Repository | calibrated-cha
 
         // then
         expect(err).to.be.instanceOf(NotFoundError);
-        expect(err).to.have.property('message', 'Some challenges do not exist in LCMS');
+        expect(err).to.have.property('message', 'Épreuve introuvable');
       });
     });
 
@@ -691,9 +374,9 @@ describe('Certification | Evaluation | Integration | Repository | calibrated-cha
         skillsLC.push(skillData02_tube02competence01_perime);
         skillsLC.push(skillData03_tube02competence01_actif);
         skillsLC.push(skillData00_tube00competence00_actif);
-        challengesLC.push(challengeData06_skill02_qcm_perime_notFlashCompatible_fren_noEmbedJson);
-        challengesLC.push(challengeData07_skill03_qcm_valide_notFlashCompatible_frnl_noEmbedJson);
-        challengesLC.push(challengeData08_skill03_qcu_archive_notFlashCompatible_fr_noEmbedJson);
+        challengesLC.push(challengeData06_skill02_perime_fren);
+        challengesLC.push(challengeData07_skill03_valide_frnl);
+        challengesLC.push(challengeData08_skill03_archive_fr);
       });
 
       it('should return only the challenges for given locale', async function () {
@@ -716,21 +399,21 @@ describe('Certification | Evaluation | Integration | Repository | calibrated-cha
         databaseBuilder.factory.learningContent.build({ skills: skillsLC, challenges: challengesLC });
 
         const challengeValide = databaseBuilder.factory.buildCertificationFrameworksChallenge({
-          challengeId: challengeData07_skill03_qcm_valide_notFlashCompatible_frnl_noEmbedJson.id,
+          challengeId: challengeData07_skill03_valide_frnl.id,
           versionId: versionActive.id,
           discriminant: 1.0,
           difficulty: 2.1,
         });
 
         const challengeArchive = databaseBuilder.factory.buildCertificationFrameworksChallenge({
-          challengeId: challengeData08_skill03_qcu_archive_notFlashCompatible_fr_noEmbedJson.id,
+          challengeId: challengeData08_skill03_archive_fr.id,
           versionId: versionActive.id,
           discriminant: 2.0,
           difficulty: 3.1,
         });
 
         databaseBuilder.factory.buildCertificationFrameworksChallenge({
-          challengeId: challengeData06_skill02_qcm_perime_notFlashCompatible_fren_noEmbedJson.id,
+          challengeId: challengeData06_skill02_perime_fren.id,
           versionId: otherVersion.id,
         });
 
@@ -745,14 +428,11 @@ describe('Certification | Evaluation | Integration | Repository | calibrated-cha
         // then
         expect(challenges).to.deep.equal([
           domainBuilder.certification.evaluation.buildCalibratedChallenge({
-            id: challengeData07_skill03_qcm_valide_notFlashCompatible_frnl_noEmbedJson.id,
-            blindnessCompatibility:
-              challengeData07_skill03_qcm_valide_notFlashCompatible_frnl_noEmbedJson.accessibility1,
-            colorBlindnessCompatibility:
-              challengeData07_skill03_qcm_valide_notFlashCompatible_frnl_noEmbedJson.accessibility2,
+            id: challengeData07_skill03_valide_frnl.id,
+            blindnessCompatibility: challengeData07_skill03_valide_frnl.accessibility1,
+            colorBlindnessCompatibility: challengeData07_skill03_valide_frnl.accessibility2,
             discriminant: challengeValide.discriminant,
             difficulty: challengeValide.difficulty,
-            competenceId: challengeData07_skill03_qcm_valide_notFlashCompatible_frnl_noEmbedJson.competenceId,
             skill: domainBuilder.certification.evaluation.buildCalibratedChallengeSkill({
               id: skillData03_tube02competence01_actif.id,
               name: skillData03_tube02competence01_actif.name,
@@ -761,14 +441,11 @@ describe('Certification | Evaluation | Integration | Repository | calibrated-cha
             }),
           }),
           domainBuilder.certification.evaluation.buildCalibratedChallenge({
-            id: challengeData08_skill03_qcu_archive_notFlashCompatible_fr_noEmbedJson.id,
-            blindnessCompatibility:
-              challengeData08_skill03_qcu_archive_notFlashCompatible_fr_noEmbedJson.accessibility1,
-            colorBlindnessCompatibility:
-              challengeData08_skill03_qcu_archive_notFlashCompatible_fr_noEmbedJson.accessibility2,
+            id: challengeData08_skill03_archive_fr.id,
+            blindnessCompatibility: challengeData08_skill03_archive_fr.accessibility1,
+            colorBlindnessCompatibility: challengeData08_skill03_archive_fr.accessibility2,
             discriminant: challengeArchive.discriminant,
             difficulty: challengeArchive.difficulty,
-            competenceId: challengeData08_skill03_qcu_archive_notFlashCompatible_fr_noEmbedJson.competenceId,
             skill: domainBuilder.certification.evaluation.buildCalibratedChallengeSkill({
               id: skillData03_tube02competence01_actif.id,
               name: skillData03_tube02competence01_actif.name,
@@ -793,9 +470,9 @@ describe('Certification | Evaluation | Integration | Repository | calibrated-cha
       skillsLC.push(skillData02_tube02competence01_perime);
       skillsLC.push(skillData03_tube02competence01_actif);
       skillsLC.push(skillData00_tube00competence00_actif);
-      challengesLC.push(challengeData06_skill02_qcm_perime_notFlashCompatible_fren_noEmbedJson);
-      challengesLC.push(challengeData07_skill03_qcm_valide_notFlashCompatible_frnl_noEmbedJson);
-      challengesLC.push(challengeData08_skill03_qcu_archive_notFlashCompatible_fr_noEmbedJson);
+      challengesLC.push(challengeData06_skill02_perime_fren);
+      challengesLC.push(challengeData07_skill03_valide_frnl);
+      challengesLC.push(challengeData08_skill03_archive_fr);
     });
 
     context('when retrieving challenges from archive', function () {
@@ -841,9 +518,9 @@ describe('Certification | Evaluation | Integration | Repository | calibrated-cha
       context('when flash compatible challenges found', function () {
         it('should return the challenges', async function () {
           // given
-          challengesLC.push(challengeData03_skill00_qcm_valide_flashCompatible_nl_noEmbedJson);
-          challengesLC.push(challengeData05_skill02_qcm_perime_flashCompatible_fren_noEmbedJson);
-          challengesLC.push(challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson);
+          challengesLC.push(challengeData03_skill00_valide_nl);
+          challengesLC.push(challengeData05_skill02_perime_fren);
+          challengesLC.push(challengeData02_skill00_archive_en);
           databaseBuilder.factory.learningContent.build({ skills: skillsLC, challenges: challengesLC });
 
           const { id } = databaseBuilder.factory.buildCertificationVersion({
@@ -854,21 +531,21 @@ describe('Certification | Evaluation | Integration | Repository | calibrated-cha
           const expectedDiscriminant = 2.221;
           const expectedDifficulty = 3.554;
           databaseBuilder.factory.buildCertificationFrameworksChallenge({
-            challengeId: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.id,
+            challengeId: challengeData02_skill00_archive_en.id,
             versionId: archivedVersionWithEligibleChallenge.id,
             discriminant: expectedDiscriminant,
             difficulty: expectedDifficulty,
           });
           const notACompartibleDiscriminant = null;
           databaseBuilder.factory.buildCertificationFrameworksChallenge({
-            challengeId: challengeData05_skill02_qcm_perime_flashCompatible_fren_noEmbedJson.id,
+            challengeId: challengeData05_skill02_perime_fren.id,
             versionId: archivedVersionWithEligibleChallenge.id,
             discriminant: notACompartibleDiscriminant,
             difficulty: expectedDifficulty,
           });
           const notACompartibleDifficulty = null;
           databaseBuilder.factory.buildCertificationFrameworksChallenge({
-            challengeId: challengeData03_skill00_qcm_valide_flashCompatible_nl_noEmbedJson.id,
+            challengeId: challengeData03_skill00_valide_nl.id,
             versionId: archivedVersionWithEligibleChallenge.id,
             discriminant: expectedDiscriminant,
             difficulty: notACompartibleDifficulty,
@@ -879,7 +556,7 @@ describe('Certification | Evaluation | Integration | Repository | calibrated-cha
             expirationDate: null,
           });
           databaseBuilder.factory.buildCertificationFrameworksChallenge({
-            challengeId: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.id,
+            challengeId: challengeData02_skill00_archive_en.id,
             versionId: activeVersionWithNonCompatibleChallenge.id,
             discriminant: null,
             difficulty: null,
@@ -894,13 +571,11 @@ describe('Certification | Evaluation | Integration | Repository | calibrated-cha
           // then
           expect(challenges).to.deep.equal([
             domainBuilder.certification.evaluation.buildCalibratedChallenge({
-              id: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.id,
-              blindnessCompatibility: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.accessibility1,
-              colorBlindnessCompatibility:
-                challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.accessibility2,
+              id: challengeData02_skill00_archive_en.id,
+              blindnessCompatibility: challengeData02_skill00_archive_en.accessibility1,
+              colorBlindnessCompatibility: challengeData02_skill00_archive_en.accessibility2,
               discriminant: expectedDiscriminant,
               difficulty: expectedDifficulty,
-              competenceId: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.competenceId,
               skill: domainBuilder.certification.evaluation.buildCalibratedChallengeSkill({
                 id: skillData00_tube00competence00_actif.id,
                 name: skillData00_tube00competence00_actif.name,
@@ -958,9 +633,9 @@ describe('Certification | Evaluation | Integration | Repository | calibrated-cha
         context('when flash compatible challenges found', function () {
           it('should return the challenges', async function () {
             // given
-            challengesLC.push(challengeData03_skill00_qcm_valide_flashCompatible_nl_noEmbedJson);
-            challengesLC.push(challengeData05_skill02_qcm_perime_flashCompatible_fren_noEmbedJson);
-            challengesLC.push(challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson);
+            challengesLC.push(challengeData03_skill00_valide_nl);
+            challengesLC.push(challengeData05_skill02_perime_fren);
+            challengesLC.push(challengeData02_skill00_archive_en);
             databaseBuilder.factory.learningContent.build({ skills: skillsLC, challenges: challengesLC });
 
             const archivedVersionWithNonCompatibleChallenge = databaseBuilder.factory.buildCertificationVersion({
@@ -969,19 +644,19 @@ describe('Certification | Evaluation | Integration | Repository | calibrated-cha
             });
 
             databaseBuilder.factory.buildCertificationFrameworksChallenge({
-              challengeId: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.id,
+              challengeId: challengeData02_skill00_archive_en.id,
               versionId: archivedVersionWithNonCompatibleChallenge.id,
               discriminant: null,
               difficulty: null,
             });
             databaseBuilder.factory.buildCertificationFrameworksChallenge({
-              challengeId: challengeData05_skill02_qcm_perime_flashCompatible_fren_noEmbedJson.id,
+              challengeId: challengeData05_skill02_perime_fren.id,
               versionId: archivedVersionWithNonCompatibleChallenge.id,
               discriminant: null,
               difficulty: null,
             });
             databaseBuilder.factory.buildCertificationFrameworksChallenge({
-              challengeId: challengeData03_skill00_qcm_valide_flashCompatible_nl_noEmbedJson.id,
+              challengeId: challengeData03_skill00_valide_nl.id,
               versionId: archivedVersionWithNonCompatibleChallenge.id,
               discriminant: null,
               difficulty: null,
@@ -995,19 +670,19 @@ describe('Certification | Evaluation | Integration | Repository | calibrated-cha
             const expectedDiscriminant = 2.222;
             const expectedDifficulty = 3.555;
             databaseBuilder.factory.buildCertificationFrameworksChallenge({
-              challengeId: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.id,
+              challengeId: challengeData02_skill00_archive_en.id,
               versionId: activeVersionWithEligibleChallenge.id,
               discriminant: expectedDiscriminant,
               difficulty: expectedDifficulty,
             });
             databaseBuilder.factory.buildCertificationFrameworksChallenge({
-              challengeId: challengeData05_skill02_qcm_perime_flashCompatible_fren_noEmbedJson.id,
+              challengeId: challengeData05_skill02_perime_fren.id,
               versionId: activeVersionWithEligibleChallenge.id,
               discriminant: expectedDiscriminant,
               difficulty: expectedDifficulty,
             });
             databaseBuilder.factory.buildCertificationFrameworksChallenge({
-              challengeId: challengeData03_skill00_qcm_valide_flashCompatible_nl_noEmbedJson.id,
+              challengeId: challengeData03_skill00_valide_nl.id,
               versionId: activeVersionWithEligibleChallenge.id,
               discriminant: expectedDiscriminant,
               difficulty: expectedDifficulty,
@@ -1022,14 +697,11 @@ describe('Certification | Evaluation | Integration | Repository | calibrated-cha
             // then
             expect(challenges).to.deep.equal([
               domainBuilder.certification.evaluation.buildCalibratedChallenge({
-                id: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.id,
-                blindnessCompatibility:
-                  challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.accessibility1,
-                colorBlindnessCompatibility:
-                  challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.accessibility2,
+                id: challengeData02_skill00_archive_en.id,
+                blindnessCompatibility: challengeData02_skill00_archive_en.accessibility1,
+                colorBlindnessCompatibility: challengeData02_skill00_archive_en.accessibility2,
                 discriminant: expectedDiscriminant,
                 difficulty: expectedDifficulty,
-                competenceId: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.competenceId,
                 skill: domainBuilder.certification.evaluation.buildCalibratedChallengeSkill({
                   id: skillData00_tube00competence00_actif.id,
                   name: skillData00_tube00competence00_actif.name,
@@ -1038,14 +710,11 @@ describe('Certification | Evaluation | Integration | Repository | calibrated-cha
                 }),
               }),
               domainBuilder.certification.evaluation.buildCalibratedChallenge({
-                id: challengeData03_skill00_qcm_valide_flashCompatible_nl_noEmbedJson.id,
-                blindnessCompatibility:
-                  challengeData03_skill00_qcm_valide_flashCompatible_nl_noEmbedJson.accessibility1,
-                colorBlindnessCompatibility:
-                  challengeData03_skill00_qcm_valide_flashCompatible_nl_noEmbedJson.accessibility2,
+                id: challengeData03_skill00_valide_nl.id,
+                blindnessCompatibility: challengeData03_skill00_valide_nl.accessibility1,
+                colorBlindnessCompatibility: challengeData03_skill00_valide_nl.accessibility2,
                 discriminant: expectedDiscriminant,
                 difficulty: expectedDifficulty,
-                competenceId: challengeData03_skill00_qcm_valide_flashCompatible_nl_noEmbedJson.competenceId,
                 skill: domainBuilder.certification.evaluation.buildCalibratedChallengeSkill({
                   id: skillData00_tube00competence00_actif.id,
                   name: skillData00_tube00competence00_actif.name,
@@ -1054,14 +723,11 @@ describe('Certification | Evaluation | Integration | Repository | calibrated-cha
                 }),
               }),
               domainBuilder.certification.evaluation.buildCalibratedChallenge({
-                id: challengeData05_skill02_qcm_perime_flashCompatible_fren_noEmbedJson.id,
-                blindnessCompatibility:
-                  challengeData05_skill02_qcm_perime_flashCompatible_fren_noEmbedJson.accessibility1,
-                colorBlindnessCompatibility:
-                  challengeData05_skill02_qcm_perime_flashCompatible_fren_noEmbedJson.accessibility2,
+                id: challengeData05_skill02_perime_fren.id,
+                blindnessCompatibility: challengeData05_skill02_perime_fren.accessibility1,
+                colorBlindnessCompatibility: challengeData05_skill02_perime_fren.accessibility2,
                 discriminant: expectedDiscriminant,
                 difficulty: expectedDifficulty,
-                competenceId: challengeData05_skill02_qcm_perime_flashCompatible_fren_noEmbedJson.competenceId,
                 skill: domainBuilder.certification.evaluation.buildCalibratedChallengeSkill({
                   id: skillData02_tube02competence01_perime.id,
                   name: skillData02_tube02competence01_perime.name,

--- a/api/tests/shared/integration/infrastructure/repositories/challenge-repository_test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/challenge-repository_test.js
@@ -1809,4 +1809,159 @@ describe('Integration | Repository | challenge-repository', function () {
       });
     }),
   );
+
+  describe('proxy', function () {
+    describe('#findValidatedByIds_proxy', function () {
+      context('when no locale defined', function () {
+        it('throws an error', async function () {
+          const err = await catchErr(challengeRepository.findValidatedByIds_proxy)({ versionId: 1, ids: [] });
+
+          expect(err.message).to.equal('Locale shall be defined');
+        });
+      });
+      context('when locale is defined', function () {
+        const locale = 'fr';
+
+        it('returns validated challenge that exist in the given locale according to provided ids', async function () {
+          const chalValidatedFr1 = {
+            id: 'chalValidatedFr1',
+            accessibility1: 'accessibility1 chalValidatedFr1',
+            accessibility2: 'accessibility2 chalValidatedFr1',
+            skillId: 'skill0',
+            status: 'validé',
+            locales: ['fr'],
+          };
+          const chalValidatedFr2 = {
+            id: 'chalValidatedFr2',
+            accessibility1: 'accessibility1 chalValidatedFr2',
+            accessibility2: 'accessibility2 chalValidatedFr2',
+            skillId: 'skill0',
+            status: 'validé',
+            locales: ['fr'],
+          };
+          const chalValidatedEn3 = {
+            id: 'chalValidatedEn3',
+            accessibility1: 'accessibility1 chalValidatedEn3',
+            accessibility2: 'accessibility2 chalValidatedEn3',
+            skillId: 'skill0',
+            status: 'validé',
+            locale: ['en'],
+          };
+          const chalArchiveFr4 = {
+            id: 'chalArchiveFr4',
+            accessibility1: 'accessibility1 chalArchiveFr4',
+            accessibility2: 'accessibility2 chalArchiveFr4',
+            skillId: 'skill0',
+            status: 'archivé',
+            locales: ['fr'],
+          };
+          const chalValidatedFr5 = {
+            id: 'chalValidatedFr5',
+            accessibility1: 'accessibility1 chalValidatedFr5',
+            accessibility2: 'accessibility2 chalValidatedFr5',
+            skillId: 'skill0',
+            status: 'validé',
+            locales: ['fr'],
+          };
+          databaseBuilder.factory.learningContent.build(
+            {
+              challenges: [chalValidatedFr1, chalValidatedFr2, chalValidatedEn3, chalArchiveFr4, chalValidatedFr5],
+            },
+            { noDefaultValues: true },
+          );
+          await databaseBuilder.commit();
+
+          const challenges = await challengeRepository.findValidatedByIds_proxy({
+            versionId: 1,
+            ids: ['chalValidatedFr5', 'chalValidatedFr1', 'chalValidatedEn3', 'chalArchiveFr4'],
+            locale,
+          });
+
+          expect(challenges).to.deepEqualArray(
+            [chalValidatedFr1, chalValidatedFr5].map(domainBuilder.learningContent.buildChallenge),
+          );
+        });
+      });
+    });
+    describe('#getMany_proxy', function () {
+      context('when some challenges are not found', function () {
+        it('throws a NotFoundError', async function () {
+          const chal1 = {
+            id: 'chal1',
+            accessibility1: 'accessibility1 chal1',
+            accessibility2: 'accessibility2 chal1',
+            skillId: 'skill0',
+            status: 'validé',
+            locales: ['fr'],
+          };
+          const chal2 = {
+            id: 'chal2',
+            accessibility1: 'accessibility1 chal2',
+            accessibility2: 'accessibility2 chal2',
+            skillId: 'skill0',
+            status: 'validé',
+            locales: ['fr'],
+          };
+          const chal3 = {
+            id: 'chal3',
+            accessibility1: 'accessibility1 chal3',
+            accessibility2: 'accessibility2 chal3',
+            skillId: 'skill0',
+            status: 'validé',
+            locale: ['en'],
+          };
+          databaseBuilder.factory.learningContent.build(
+            {
+              challenges: [chal1, chal2, chal3],
+            },
+            { noDefaultValues: true },
+          );
+          await databaseBuilder.commit();
+
+          const err = await catchErr(challengeRepository.getMany_proxy)(['chal2', 'chalIllusion']);
+
+          expect(err).to.deepEqualInstance(new NotFoundError('Épreuve introuvable'));
+        });
+      });
+      context('when all challenges are found', function () {
+        it('returns challenges according to provided ids', async function () {
+          const chal1 = {
+            id: 'chal1',
+            accessibility1: 'accessibility1 chal1',
+            accessibility2: 'accessibility2 chal1',
+            skillId: 'skill0',
+            status: 'validé',
+            locales: ['fr'],
+          };
+          const chal2 = {
+            id: 'chal2',
+            accessibility1: 'accessibility1 chal2',
+            accessibility2: 'accessibility2 chal2',
+            skillId: 'skill0',
+            status: 'validé',
+            locales: ['fr'],
+          };
+          const chal3 = {
+            id: 'chal3',
+            accessibility1: 'accessibility1 chal3',
+            accessibility2: 'accessibility2 chal3',
+            skillId: 'skill0',
+            status: 'validé',
+            locale: ['en'],
+          };
+          databaseBuilder.factory.learningContent.build(
+            {
+              challenges: [chal1, chal2, chal3],
+            },
+            { noDefaultValues: true },
+          );
+          await databaseBuilder.commit();
+
+          const challenges = await challengeRepository.getMany_proxy(['chal3', 'chal1']);
+
+          expect(challenges).to.deepEqualArray([chal3, chal1].map(domainBuilder.learningContent.buildChallenge));
+        });
+      });
+    });
+  });
 });

--- a/api/tests/tooling/domain-builder/factory/certification/evaluation/build-calibrated-challenge.js
+++ b/api/tests/tooling/domain-builder/factory/certification/evaluation/build-calibrated-challenge.js
@@ -10,7 +10,6 @@ export function buildCalibratedChallenge({
   difficulty = 0,
   blindnessCompatibility = Accessibility.OK,
   colorBlindnessCompatibility = Accessibility.RAS,
-  competenceId = 'competenceId',
   skill = buildCalibratedChallengeSkill(),
 } = {}) {
   return new CalibratedChallenge({
@@ -19,7 +18,6 @@ export function buildCalibratedChallenge({
     difficulty,
     blindnessCompatibility,
     colorBlindnessCompatibility,
-    competenceId,
     skill,
   });
 }

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -225,6 +225,7 @@ import {
   buildLtiPlatformRegistrationWithPlatformConfig,
 } from './identity-access-management/build-lti-platform-registration.js';
 import { buildUserLogin } from './identity-access-management/build-user-login.js';
+import { builders as learningContentBuilders } from './learning-content/index.js';
 import { buildChat } from './llm/build-chat.js';
 import { buildConfiguration } from './llm/build-configuration.js';
 import { buildAssistantMessage, buildUserMessage } from './llm/build-message.js';
@@ -350,7 +351,7 @@ const maddo = {
   buildCampaignParticipation: maddoBuildCampaignParticipation,
   buildTubeCoverage,
 };
-
+const learningContent = learningContentBuilders;
 const llm = {
   buildAssistantMessage,
   buildChat,
@@ -533,6 +534,7 @@ export {
   certification,
   devcomp,
   identityAccessManagement,
+  learningContent,
   llm,
   maddo,
   organizationalEntities,

--- a/api/tests/tooling/domain-builder/factory/learning-content/build-challenge.js
+++ b/api/tests/tooling/domain-builder/factory/learning-content/build-challenge.js
@@ -1,0 +1,15 @@
+import { Challenge } from '../../../../../src/learning-content/domain/models/Challenge.js';
+
+export function buildChallenge({
+  id = 'challengeFoo123',
+  accessibility1 = 'OK',
+  accessibility2 = 'OK',
+  skillId = 'skillFoo123',
+} = {}) {
+  return new Challenge({
+    id,
+    accessibility1,
+    accessibility2,
+    skillId,
+  });
+}

--- a/api/tests/tooling/domain-builder/factory/learning-content/index.js
+++ b/api/tests/tooling/domain-builder/factory/learning-content/index.js
@@ -1,0 +1,5 @@
+import { buildChallenge } from './build-challenge.js';
+
+export const builders = {
+  buildChallenge,
+};


### PR DESCRIPTION
## (╯°□°)╯︵ ┻━┻ - Problème

L'équipe souhaitait faire des optimisations autour de la récupération d'épreuves dans le cadre de la certification. Aujourd'hui, les modèles retournées par le `challenge-repository` sont gros, et surtout les modèles `Challenges` provoquent également la récupération du modèle `Skill` correspondant, de manière peu optimisée.
On voulait donc récupérer directement le DTO mis en cache pour ne prélever que les 3 attributs nécessaires au modèle du bounded-context correspondant (`CalibratedChallenge`).
Ce faisant, nous avons fait une boulette et avons dupliqué plusieurs épreuves en RAM.

## <(^_^)> - Proposition

- Repasser par le `challenge-repository` (qui est responsable d'intéragir avec le cache) pour récupérer nos données
- Le `challenge-repository` via ces nouvelles méthodes retournent des modèles qui sont des Proxy du DTO, sans retourner automatiquement le skill correspondant + potentiellement le web-component (en cas d'embed en JSON) etc. Juste les données protégées.
- Léger refacto pour la récupération des acquis correspondants : avant on faisait pour chaque épreuve on récupère son acquis. Or en général on a N challenges === 1 acquis. Donc on récupère en premier les acquis, puis on dispatch les modèles `CalibratedSkill` correspondant aux `CalibratedChallenges`. Ainsi on va plus vite en complexité algo + on évite d'instancier 3 ou 4 fois le même `CalibratedSkill`

## ¯\\_(ツ)_/¯ - Remarques

C'est un tout tout début de projet, après discussion avec l'équipe contenus.

Clairement dans le code aujourd'hui l'accès au contenu pédagogique (dit **CP**) est poussièreux et hors de contrôle.
- Les `repositories` permettant de récupérer des ressources du **CP** sont dans le dossier `shared`, manquant ainsi d'indiquer aux développeurs qu'il s'agit en réalité d'un code dont l'ownership et la maintenance revient à l'équipe contenus
- Le mécanisme de mise en cache du **CP** doit être un détail d'implémentation de l'équipe, et en aucun cas un code à copier-coller un peu partout. C'est un mécanisme compliqué et un peu touffu, les sachants sont chez contenus
- Les modèles du domaine aujourd'hui retournés sont aussi dans `shared`, et sont sur-utilisés par tous les bounded-contexts. L'idéal serait de faire en sorte que les bounded contexts établissent leurs propres modèles (et pas le modèle `Challenge` dans `shared` avec 40 attributs dont 38 pas utilisés...)
- Enfin, ces modèles dans l'esprit devrait être read-only : le **CP** est une ressource en lecture seule pour l'API de PIX. Aujourd'hui, des modèles sont créés en recopiant des références du `DTO` dans le cache, risquant ainsi de compromettre le contenu.

Il faut résoudre tous ces problèmes petit à petit.

Il a été convenu avec l'équipe d'attaquer dans un premier temps l'aspect read-only des modèles. Une solution envisagée est de faire en sorte que les `repositories` du **CP** fournissent des modèles qui implémentent un pattern `Proxy` : qui agissent en enveloppe autour du `DTO` mise en cache et fournissent une interface pour récupérer des données (via des `getters` par exemple)

Cette PR commence un début de cela, sans pour autant proposer une implémentation complète et finale, mais suffisante pour corriger le bug de la double mise en cache et conserver les optimisations souhaitées par les développeurs d'origine.

## (ง'̀-'́)ง - Pour tester
Non régression sur les choix d'épreuves (eval, campagnes, certif) (les e2e sont là pour ça 🌈 )
