### PR TITLE
[TECH] replace ember-dayjs with ember-intl (PIX-22241).

### DIFF
--- a/orga/app/components/attestations/list.gjs
+++ b/orga/app/components/attestations/list.gjs
@@ -6,8 +6,7 @@ import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
 import PixTag from '@1024pix/pix-ui/components/pix-tag';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
-import dayjsFormat from 'ember-dayjs/helpers/dayjs-format';
-import { t } from 'ember-intl';
+import { formatDate, t } from 'ember-intl';
 import MultiSelectFilter from 'pix-orga/components/ui/multi-select-filter';
 import ENV from 'pix-orga/config/environment';
 
@@ -104,10 +103,7 @@ export default class AttestationList extends Component {
           <:cell>
             {{#if participantStatus.obtainedAt}}
               <PixTag @color="green">
-                {{t
-                  "pages.attestations.table.status.obtained"
-                  date=(dayjsFormat participantStatus.obtainedAt "DD/MM/YYYY")
-                }}
+                {{t "pages.attestations.table.status.obtained" date=(formatDate participantStatus.obtainedAt)}}
               </PixTag>
             {{else}}
               <PixTag @color="yellow">

--- a/orga/app/components/campaign/charts/participants-by-day.gjs
+++ b/orga/app/components/campaign/charts/participants-by-day.gjs
@@ -1,8 +1,7 @@
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import dayjsFormat from 'ember-dayjs/helpers/dayjs-format';
-import { t } from 'ember-intl';
+import { formatDate, t } from 'ember-intl';
 import { maxBy, minBy } from 'pix-orga/utils/collection';
 
 import TableHeader from '../../table/header';
@@ -170,7 +169,7 @@ export default class ParticipantsByDay extends Component {
             <tbody>
               {{#each dataset.entries as |entry|}}
                 <tr>
-                  <td>{{dayjsFormat entry.day "DD/MM/YYYY"}}</td>
+                  <td>{{formatDate entry.day}}</td>
                   <td>{{entry.count}}</td>
                 </tr>
               {{/each}}

--- a/orga/app/components/campaign/header/title.gjs
+++ b/orga/app/components/campaign/header/title.gjs
@@ -1,8 +1,7 @@
 import { LinkTo } from '@ember/routing';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
-import dayjsFormat from 'ember-dayjs/helpers/dayjs-format';
-import { t } from 'ember-intl';
+import { formatDate, t } from 'ember-intl';
 import ActivityType from 'pix-orga/components/activity-type';
 
 import CopyPasteButton from '../../copy-paste-button';
@@ -72,7 +71,7 @@ export default class Header extends Component {
               {{t "pages.campaign.created-on"}}
             </dt>
             <dd>
-              {{dayjsFormat @campaign.createdAt "DD/MM/YYYY" allow-empty=true}}
+              {{formatDate @campaign.createdAt}}
             </dd>
           </div>
           <div class="campaign-header-title__detail-item">

--- a/orga/app/components/campaign/list.gjs
+++ b/orga/app/components/campaign/list.gjs
@@ -10,8 +10,7 @@ import { LinkTo } from '@ember/routing';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import dayjsFormat from 'ember-dayjs/helpers/dayjs-format';
-import { t } from 'ember-intl';
+import { formatDate, t } from 'ember-intl';
 import { not } from 'ember-truth-helpers';
 import ActivityType from 'pix-orga/components/activity-type';
 
@@ -151,7 +150,7 @@ export default class List extends Component {
                 {{t "pages.campaigns-list.table.column.created-on"}}
               </:header>
               <:cell>
-                {{dayjsFormat campaign.createdAt "DD/MM/YYYY" allow-empty=true}}
+                {{formatDate campaign.createdAt}}
               </:cell>
             </PixTableColumn>
 

--- a/orga/app/components/campaign/results/profile-list.gjs
+++ b/orga/app/components/campaign/results/profile-list.gjs
@@ -4,8 +4,7 @@ import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
 import PixTag from '@1024pix/pix-ui/components/pix-tag';
 import { array, fn } from '@ember/helper';
 import { LinkTo } from '@ember/routing';
-import dayjsFormat from 'ember-dayjs/helpers/dayjs-format';
-import { t } from 'ember-intl';
+import { formatDate, t } from 'ember-intl';
 import { gt } from 'ember-truth-helpers';
 import getService from 'pix-orga/helpers/get-service';
 
@@ -77,7 +76,7 @@ import ParticipationEvolutionIcon from './participation-evolution-icon';
           </:header>
           <:cell>
             {{#if participation.sharedAt}}
-              {{dayjsFormat participation.sharedAt "DD/MM/YYYY"}}
+              {{formatDate participation.sharedAt}}
             {{else}}
               <span class="table__column--highlight">{{t
                   "pages.profiles-list.table.column.sending-date.on-hold"

--- a/orga/app/components/certificability/cell.gjs
+++ b/orga/app/components/certificability/cell.gjs
@@ -1,4 +1,4 @@
-import dayjsFormat from 'ember-dayjs/helpers/dayjs-format';
+import { formatDate } from 'ember-intl';
 
 import IsCertifiable from '../ui/is-certifiable';
 
@@ -9,6 +9,6 @@ function displayCertificabilityDate(hideCertifiableDate, isCertifiable) {
 <template>
   <IsCertifiable @isCertifiable={{@isCertifiable}} />
   {{#if (displayCertificabilityDate @hideCertifiableDate @isCertifiable)}}
-    <span>{{dayjsFormat @certifiableAt "DD/MM/YYYY" allow-empty=true}}</span>
+    <span>{{formatDate @certifiableAt}}</span>
   {{/if}}
 </template>

--- a/orga/app/components/import/banner.gjs
+++ b/orga/app/components/import/banner.gjs
@@ -2,7 +2,6 @@ import PixIcon from '@1024pix/pix-ui/components/pix-icon';
 import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
-import dayjs from 'dayjs';
 
 const statusI18nLabel = {
   UPLOADING: 'upload-in-progress',
@@ -26,7 +25,7 @@ export default class ImportBanner extends Component {
       createdBy: { firstName, lastName },
     } = this.args.organizationImportDetail;
     return this.intl.t('pages.organization-participants-import.global-success', {
-      date: dayjs(updatedAt).format('D MMM YYYY'),
+      date: this.intl.formatDate(updatedAt, { format: 'LLL' }),
       firstName,
       lastName,
     });
@@ -82,7 +81,7 @@ export default class ImportBanner extends Component {
     return this.intl.t('pages.organization-participants-import.banner.upload-completed', {
       firstName,
       lastName,
-      date: dayjs(createdAt).format('D MMM YYYY'),
+      date: this.intl.formatDate(createdAt, { format: 'LLL' }),
     });
   }
 

--- a/orga/app/components/layout/school-session-management.gjs
+++ b/orga/app/components/layout/school-session-management.gjs
@@ -4,12 +4,9 @@ import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
-import dayjs from 'dayjs';
-import LocalizedFormat from 'dayjs/plugin/localizedFormat';
 import { t } from 'ember-intl';
 
 import CopyPasteButton from '../copy-paste-button';
-dayjs.extend(LocalizedFormat);
 
 export default class SchoolSessionManagement extends Component {
   @service currentUser;
@@ -36,7 +33,9 @@ export default class SchoolSessionManagement extends Component {
 
   get expirationDateParameter() {
     return {
-      sessionExpirationDate: dayjs(this.currentUser.organization.sessionExpirationDate).format('LT'),
+      sessionExpirationDate: this.intl.formatTime(this.currentUser.organization.sessionExpirationDate, {
+        format: 'hhmm',
+      }),
     };
   }
 

--- a/orga/app/components/organization-participant/list.gjs
+++ b/orga/app/components/organization-participant/list.gjs
@@ -12,7 +12,6 @@ import { LinkTo } from '@ember/routing';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import dayjs from 'dayjs';
 import { t } from 'ember-intl';
 import { eq, not } from 'ember-truth-helpers';
 
@@ -48,7 +47,7 @@ export default class List extends Component {
   @service locale;
 
   displayDate(date) {
-    return dayjs(date).format('DD/MM/YYYY');
+    return this.intl.formatDate(date);
   }
 
   @action
@@ -60,7 +59,7 @@ export default class List extends Component {
     }
     if (!extraColumnValue) return '';
 
-    if (dayjs(extraColumnValue).isValid()) {
+    if (!isNaN(new Date(extraColumnValue).getTime())) {
       return this.displayDate(extraColumnValue);
     }
 

--- a/orga/app/components/participant/assessment/header.gjs
+++ b/orga/app/components/participant/assessment/header.gjs
@@ -5,9 +5,7 @@ import PixSelect from '@1024pix/pix-ui/components/pix-select';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
-import dayjs from 'dayjs';
-import dayjsFormat from 'ember-dayjs/helpers/dayjs-format';
-import { t } from 'ember-intl';
+import { formatDate, t } from 'ember-intl';
 import { and } from 'ember-truth-helpers';
 
 import Badges from '../../campaign/badges';
@@ -53,7 +51,7 @@ export default class Header extends Component {
       let label = this.intl.t('pages.assessment-individual-results.participation-label', { participationNumber });
 
       if (participation.sharedAt) {
-        const participationDate = dayjs(participation.sharedAt).format('DD/MM/YYYY');
+        const participationDate = this.intl.formatDate(participation.sharedAt);
         label = `${label} - ${participationDate}`;
       }
 
@@ -134,7 +132,7 @@ export default class Header extends Component {
           {{/if}}
           <Information>
             <:title>{{t "pages.campaign-individual-results.start-date"}}</:title>
-            <:content>{{dayjsFormat @participation.createdAt "DD MMM YYYY"}}</:content>
+            <:content>{{formatDate @participation.createdAt format="LLL"}}</:content>
           </Information>
           {{#if this.displayProgression}}
             <Information>
@@ -145,7 +143,7 @@ export default class Header extends Component {
           {{#if @participation.isShared}}
             <Information>
               <:title>{{t "pages.campaign-individual-results.shared-date"}}</:title>
-              <:content>{{dayjsFormat @participation.sharedAt "DD MMM YYYY"}}</:content>
+              <:content>{{formatDate @participation.sharedAt format="LLL"}}</:content>
             </Information>
           {{/if}}
         </InformationWrapper>

--- a/orga/app/components/participant/profile/header.gjs
+++ b/orga/app/components/participant/profile/header.gjs
@@ -3,8 +3,7 @@ import PixIcon from '@1024pix/pix-ui/components/pix-icon';
 import PixTag from '@1024pix/pix-ui/components/pix-tag';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
-import dayjsFormat from 'ember-dayjs/helpers/dayjs-format';
-import { t } from 'ember-intl';
+import { formatDate, t } from 'ember-intl';
 import { and } from 'ember-truth-helpers';
 
 import Breadcrumb from '../../ui/breadcrumb';
@@ -79,12 +78,12 @@ export default class Header extends Component {
           {{/if}}
           <Information>
             <:title>{{t "pages.campaign-individual-results.start-date"}}</:title>
-            <:content>{{dayjsFormat @campaignProfile.createdAt "DD MMM YYYY"}}</:content>
+            <:content>{{formatDate @campaignProfile.createdAt format="LLL"}}</:content>
           </Information>
           {{#if @campaignProfile.isShared}}
             <Information>
               <:title>{{t "pages.campaign-individual-results.shared-date"}}</:title>
-              <:content>{{dayjsFormat @campaignProfile.sharedAt "DD MMM YYYY"}}</:content>
+              <:content>{{formatDate @campaignProfile.sharedAt format="LLL"}}</:content>
             </Information>
           {{/if}}
         </InformationWrapper>

--- a/orga/app/components/places/places-lot-table.gjs
+++ b/orga/app/components/places/places-lot-table.gjs
@@ -1,16 +1,11 @@
 import PixTable from '@1024pix/pix-ui/components/pix-table';
 import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
 import PixTag from '@1024pix/pix-ui/components/pix-tag';
-import dayjs from 'dayjs';
-import { t } from 'ember-intl';
+import { formatDate, t } from 'ember-intl';
 import { eq, gt } from 'ember-truth-helpers';
 
 import { STATUSES } from '../../models/organization-places-lot';
 import EmptyState from '../ui/empty-state.js';
-
-function displayDate(date) {
-  return dayjs(date).format('DD/MM/YYYY');
-}
 
 function emptyCell(value) {
   return value ? value : '-';
@@ -42,7 +37,7 @@ function emptyCell(value) {
             {{t "pages.places.places-lots.table.headers.activation-date"}}
           </:header>
           <:cell>
-            {{displayDate placesLot.activationDate}}
+            {{formatDate placesLot.activationDate}}
           </:cell>
         </PixTableColumn>
 
@@ -51,7 +46,7 @@ function emptyCell(value) {
             {{t "pages.places.places-lots.table.headers.expiration-date"}}
           </:header>
           <:cell>
-            {{emptyCell (displayDate placesLot.expirationDate)}}
+            {{emptyCell (formatDate placesLot.expirationDate)}}
           </:cell>
         </PixTableColumn>
 

--- a/orga/app/components/places/title.gjs
+++ b/orga/app/components/places/title.gjs
@@ -1,12 +1,11 @@
-import dayjs from 'dayjs';
-import { t } from 'ember-intl';
+import { formatDate, t } from 'ember-intl';
 
 import PageTitle from '../ui/page-title';
 import CapacityAlert from './capacity-alert';
 import PlacesLotAlert from './places-lot-alert';
 
-function todayDate() {
-  return dayjs().format('D MMM YYYY');
+function today() {
+  return new Date();
 }
 
 <template>
@@ -16,7 +15,7 @@ function todayDate() {
     </:title>
     <:tools>
       <span class="places-header-date">{{t "pages.places.before-date"}}
-        {{todayDate}}</span>
+        {{formatDate (today) format="LLL"}}</span>
     </:tools>
     <:notificationAlert>
       <PlacesLotAlert @placesLots={{@placesLots}} />

--- a/orga/app/components/sco-organization-participant/table-row.gjs
+++ b/orga/app/components/sco-organization-participant/table-row.gjs
@@ -3,8 +3,7 @@ import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
 import { fn, get } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { LinkTo } from '@ember/routing';
-import dayjsFormat from 'ember-dayjs/helpers/dayjs-format';
-import { t } from 'ember-intl';
+import { formatDate, t } from 'ember-intl';
 import { not } from 'ember-truth-helpers';
 
 import { CONNECTION_TYPES } from '../../helpers/connection-types';
@@ -61,7 +60,7 @@ import LastParticipationDateTooltip from '../ui/last-participation-date-tooltip'
   </PixTableColumn>
   <PixTableColumn @context={{@context}}>
     <:header>{{t "pages.sco-organization-participants.table.column.date-of-birth"}}</:header>
-    <:cell>{{dayjsFormat @student.birthdate "DD/MM/YYYY" allow-empty=true}}</:cell>
+    <:cell>{{formatDate @student.birthdate}}</:cell>
   </PixTableColumn>
   <PixTableColumn
     @context={{@context}}
@@ -109,7 +108,7 @@ import LastParticipationDateTooltip from '../ui/last-participation-date-tooltip'
     <:header>{{t "pages.sco-organization-participants.table.column.last-participation-date"}}</:header>
     <:cell>{{#if @student.lastParticipationDate}}
         <div class="organization-participant__align-element">
-          <span>{{dayjsFormat @student.lastParticipationDate "DD/MM/YYYY" allow-empty=true}}</span>
+          <span>{{formatDate @student.lastParticipationDate format="L"}}</span>
           <LastParticipationDateTooltip
             @id={{@index}}
             @campaignName={{@student.campaignName}}

--- a/orga/app/components/statistics/index.gjs
+++ b/orga/app/components/statistics/index.gjs
@@ -7,7 +7,6 @@ import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import dayjs from 'dayjs';
 import { t } from 'ember-intl';
 
 import PageTitle from '../ui/page-title';
@@ -15,6 +14,7 @@ import CoverRateGauge from './cover-rate-gauge';
 import TagLevel from './tag-level';
 
 export default class Statistics extends Component {
+  @service intl;
   @service router;
   @service locale;
 
@@ -88,7 +88,7 @@ export default class Statistics extends Component {
   };
 
   get extractedDate() {
-    return dayjs(this.analysisByTubes[0]?.extraction_date).format('D MMM YYYY');
+    return this.intl.formatDate(this.analysisByTubes[0]?.extraction_date, { format: 'LLL' });
   }
 
   get hasDataToDisplay() {

--- a/orga/app/components/sup-organization-participant/table-row.gjs
+++ b/orga/app/components/sup-organization-participant/table-row.gjs
@@ -3,8 +3,7 @@ import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { LinkTo } from '@ember/routing';
-import dayjsFormat from 'ember-dayjs/helpers/dayjs-format';
-import { t } from 'ember-intl';
+import { formatDate, t } from 'ember-intl';
 import { not } from 'ember-truth-helpers';
 
 import Cell from '../certificability/cell';
@@ -65,7 +64,7 @@ import LastParticipationDateTooltip from '../ui/last-participation-date-tooltip'
   </PixTableColumn>
   <PixTableColumn @context={{@context}}>
     <:header>{{t "pages.sup-organization-participants.table.column.date-of-birth"}}</:header>
-    <:cell>{{dayjsFormat @student.birthdate "DD/MM/YYYY"}}</:cell>
+    <:cell>{{formatDate @student.birthdate}}</:cell>
   </PixTableColumn>
   <PixTableColumn @context={{@context}}>
     <:header>{{t "pages.sup-organization-participants.table.column.group"}}</:header>
@@ -89,7 +88,7 @@ import LastParticipationDateTooltip from '../ui/last-participation-date-tooltip'
     <:header>{{t "pages.sup-organization-participants.table.column.last-participation-date"}}</:header>
     <:cell>{{#if @student.lastParticipationDate}}
         <div class="organization-participant__align-element">
-          <span>{{dayjsFormat @student.lastParticipationDate "DD/MM/YYYY" allow-empty=true}}</span>
+          <span>{{formatDate @student.lastParticipationDate}}</span>
           <LastParticipationDateTooltip
             @id={{@index}}
             @campaignName={{@student.campaignName}}

--- a/orga/app/components/team/invitations-list-item.gjs
+++ b/orga/app/components/team/invitations-list-item.gjs
@@ -6,8 +6,7 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import dayjsFormat from 'ember-dayjs/helpers/dayjs-format';
-import { t } from 'ember-intl';
+import { formatDate, t } from 'ember-intl';
 import ENV from 'pix-orga/config/environment';
 
 export default class InvitationsListItem extends Component {
@@ -58,7 +57,7 @@ export default class InvitationsListItem extends Component {
         {{t "pages.team-invitations.table.column.pending-invitation"}}
       </:header>
       <:cell>
-        {{dayjsFormat @invitation.updatedAt "DD/MM/YYYY [-] HH:mm"}}
+        {{formatDate @invitation.updatedAt format="medium"}}
       </:cell>
     </PixTableColumn>
 

--- a/orga/app/components/ui/date.gjs
+++ b/orga/app/components/ui/date.gjs
@@ -1,9 +1,8 @@
-import dayjsFormat from 'ember-dayjs/helpers/dayjs-format';
-import { t } from 'ember-intl';
+import { formatDate, t } from 'ember-intl';
 
 <template>
   {{#if @date}}
-    {{dayjsFormat @date "DD/MM/YYYY"}}
+    {{formatDate @date}}
   {{else}}
     <span aria-hidden="true">-</span>
     <span class="screen-reader-only">{{t "components.date.no-date"}}</span>

--- a/orga/app/ember-intl.js
+++ b/orga/app/ember-intl.js
@@ -26,6 +26,18 @@ export const formats = {
       month: 'long',
       year: 'numeric',
     },
+    LLL: {
+      day: 'numeric',
+      month: 'short',
+      year: 'numeric',
+    },
+    medium: {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    },
   },
   formatNumber: {
     EUR: {

--- a/orga/tests/integration/components/participant/assessment/header-test.gjs
+++ b/orga/tests/integration/components/participant/assessment/header-test.gjs
@@ -161,7 +161,7 @@ module('Integration | Component | ParticipantAssessmentHeader', function (hooks)
       <template><ParticipantAssessmentHeader @participation={{participation}} @campaign={{campaign}} /></template>,
     );
 
-    assert.ok(screen.getByText('01 janv. 2020'));
+    assert.ok(screen.getByText('1 janv. 2020'));
   });
 
   module('progression', function () {
@@ -205,7 +205,7 @@ module('Integration | Component | ParticipantAssessmentHeader', function (hooks)
         );
 
         assert.ok(screen.getByText(t('pages.campaign-individual-results.shared-date')));
-        assert.ok(screen.getByText('02 janv. 2020'));
+        assert.ok(screen.getByText('2 janv. 2020'));
       });
     });
 

--- a/orga/tests/integration/components/participant/profile/header-test.gjs
+++ b/orga/tests/integration/components/participant/profile/header-test.gjs
@@ -38,7 +38,7 @@ module('Integration | Component | Participant::Profile::Header', function (hooks
     );
 
     assert.strictEqual(screen.getByRole('term').textContent.trim(), t('pages.campaign-individual-results.start-date'));
-    assert.strictEqual(screen.getByRole('definition').textContent.trim(), '01 janv. 2020');
+    assert.strictEqual(screen.getByRole('definition').textContent.trim(), '1 janv. 2020');
   });
 
   module('is shared', function () {
@@ -58,7 +58,7 @@ module('Integration | Component | Participant::Profile::Header', function (hooks
           screen.getAllByRole('term')[1].textContent.trim(),
           t('pages.campaign-individual-results.shared-date'),
         );
-        assert.strictEqual(screen.getAllByRole('definition')[1].textContent.trim(), '02 janv. 2020');
+        assert.strictEqual(screen.getAllByRole('definition')[1].textContent.trim(), '2 janv. 2020');
       });
     });
     module('when participant has not shared results', function () {

--- a/orga/tests/integration/components/places/places-lot-table-test.gjs
+++ b/orga/tests/integration/components/places/places-lot-table-test.gjs
@@ -65,12 +65,12 @@ module('Integration | Component | Places | PlacesLotTable', function (hooks) {
       }),
     ];
     const screen = await render(<template><PlacesLotTable @placesLots={{placesLots}} /></template>);
-
+    const cells = screen.getAllByRole('cell');
     // then
-    assert.ok(screen.getByRole('cell', { name: '-' }));
-    assert.ok(screen.getByRole('cell', { name: '23/09/2021' }));
-    assert.ok(screen.getByRole('cell', { name: '-' }));
-    assert.ok(screen.getByRole('cell', { name: t('pages.places.places-lots.statuses.pending') }));
+    assert.strictEqual(cells[0].innerText, '-');
+    assert.strictEqual(cells[1].innerText, '23/09/2021');
+    assert.strictEqual(cells[2].innerText, '-');
+    assert.strictEqual(cells[3].innerText, t('pages.places.places-lots.statuses.pending'));
   });
   test('it should render an emty state if there is no places lots', async function (assert) {
     // when

--- a/orga/tests/integration/components/team/invitations-list-test.gjs
+++ b/orga/tests/integration/components/team/invitations-list-test.gjs
@@ -38,7 +38,7 @@ module('Integration | Component | Team::InvitationsList', function (hooks) {
 
   test('it should display email and creation date of invitation', async function (assert) {
     // given
-    const dayjsService = this.owner.lookup('service:dayjs');
+    const intl = this.owner.lookup('service:intl');
     const pendingInvitationDate = '2023-12-05T09:00:00Z';
 
     const invitations = [{ email: 'gigi@example.net', isPending: true, updatedAt: pendingInvitationDate }];
@@ -47,7 +47,7 @@ module('Integration | Component | Team::InvitationsList', function (hooks) {
     const component = await render(<template><TeamInvitationsList @invitations={{invitations}} /></template>);
 
     // then
-    const formattedPendingInvitationDate = dayjsService.self(pendingInvitationDate).format('DD/MM/YYYY [-] HH:mm');
+    const formattedPendingInvitationDate = intl.formatDate(pendingInvitationDate, { format: 'medium' });
 
     assert.dom(component.getByRole('cell', { name: 'gigi@example.net' })).exists();
     assert.dom(component.getByRole('cell', { name: formattedPendingInvitationDate })).exists();


### PR DESCRIPTION
## (ง'̀-'́)ง - Pour tester
RAS, c'est du refactor

## ¯\\_(ツ)_/¯ - Remarques

On profite de la PR pour preparer la suppression de dayjs aussi :axe:

## <(^_^)> - Proposition

On utilise ember-intl pour formater les dates 

## (╯°□°)╯︵ ┻━┻ - Problème

On ne veut plus d'ember-dayjs qui nous embete pour passer sur vite
<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->
