### PR TITLE
[BUGFIX] En Mode Preview, l'instruction des Stepper horizontaux ne s'affiche pas (PIX-22188)

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
@@ -97,7 +97,7 @@
             },
             {
               "type": "stepper",
-              "instruction": "<p>Cette instruction permet d'avoir un texte commun à tous les steps du stepper horizontal</p>",
+              "instruction": "<p>Ce texte s'affiche uniquement pour ce stepper car il est horizontal.</p>",
               "steps": [
                 {
                   "elements": [

--- a/mon-pix/app/components/module/component/_stepper.scss
+++ b/mon-pix/app/components/module/component/_stepper.scss
@@ -24,6 +24,18 @@
   }
 }
 
+.stepper--preview-mode {
+  padding: var(--pix-spacing-1x);
+  border: 1px dashed var(--pix-neutral-100);
+  border-radius: var(--pix-spacing-2x);
+}
+
+.stepper-instruction--preview-mode {
+  &__instruction {
+    padding: var(--pix-spacing-2x) 0;
+  }
+}
+
 .stepper-controls {
   &__position {
     margin: 0;

--- a/mon-pix/app/components/module/component/stepper.gjs
+++ b/mon-pix/app/components/module/component/stepper.gjs
@@ -201,9 +201,14 @@ export default class ModulixStepper extends Component {
       <PixTag @color="dark">
         {{t "pages.modulix.preview.stepper" direction=@direction}}
       </PixTag>
+      {{#if this.isHorizontalDirection}}
+        <div class="stepper-instruction--preview-mode">
+          {{htmlUnsafe @instruction}}
+        </div>
+      {{/if}}
     {{/if}}
     <div
-      class="stepper stepper--{{this.direction}}"
+      class="stepper stepper--{{this.direction}}{{if this.modulixPreviewMode.isEnabled ' stepper--preview-mode' ''}}"
       aria-live="{{if (eq @direction 'vertical') 'polite'}}"
       aria-roledescription="{{t 'pages.modulix.stepper.aria-role-description'}}"
       {{didInsert this.modulixAutoScroll.setHTMLElementScrollOffsetCssProperty}}

--- a/mon-pix/app/components/module/component/stepper.gjs
+++ b/mon-pix/app/components/module/component/stepper.gjs
@@ -152,7 +152,7 @@ export default class ModulixStepper extends Component {
   }
 
   get isHorizontalDirection() {
-    return this.args.direction === ModuleGrain.STEPPER_DIRECTION.HORIZONTAL && !this.modulixPreviewMode.isEnabled;
+    return this.args.direction === ModuleGrain.STEPPER_DIRECTION.HORIZONTAL;
   }
 
   get isPreviousButtonControlDisabled() {
@@ -168,9 +168,13 @@ export default class ModulixStepper extends Component {
   }
 
   get direction() {
-    return this.isHorizontalDirection
+    return this.canUseHorizontalStepperDesign
       ? ModuleGrain.STEPPER_DIRECTION.HORIZONTAL
       : ModuleGrain.STEPPER_DIRECTION.VERTICAL;
+  }
+
+  get canUseHorizontalStepperDesign() {
+    return this.isHorizontalDirection && !this.modulixPreviewMode.isEnabled;
   }
 
   @action
@@ -204,7 +208,7 @@ export default class ModulixStepper extends Component {
       aria-roledescription="{{t 'pages.modulix.stepper.aria-role-description'}}"
       {{didInsert this.modulixAutoScroll.setHTMLElementScrollOffsetCssProperty}}
     >
-      {{#if this.isHorizontalDirection}}
+      {{#if this.canUseHorizontalStepperDesign}}
         <div class="stepper__controls">
           <PixIconButton
             @ariaLabel={{t "pages.modulix.buttons.stepper.controls.previous.ariaLabel"}}

--- a/mon-pix/tests/integration/components/module/stepper_test.gjs
+++ b/mon-pix/tests/integration/components/module/stepper_test.gjs
@@ -2496,10 +2496,18 @@ module('Integration | Component | Module | Stepper', function (hooks) {
 
         // when
         const screen = await render(
-          <template><ModulixStepper @id="stepper-container-id-1" @steps={{steps}} @direction="horizontal" /></template>,
+          <template>
+            <ModulixStepper
+              @id="stepper-container-id-1"
+              @steps={{steps}}
+              @direction="horizontal"
+              @instruction="<p>Voici l'instruction de mon stepper horizontal</p>"
+            />
+          </template>,
         );
 
         // then
+        assert.dom(screen.getByText("Voici l'instruction de mon stepper horizontal")).exists();
         assert.dom(screen.getByText('Text 1')).exists();
         assert.dom(screen.getByText('Text 2')).exists();
         assert.dom(find('.stepper--vertical')).exists();


### PR DESCRIPTION
## (╯°□°)╯︵ ┻━┻ - Problème

On nous a remonté que l'instruction d'un stepper horizontal a disparu en mode Preview!
Ceci n'est point pratique pour vérifier en mode Preview qu'on est en train de faire un Stepper horizontal de haute qualité.

Voici les indices
- _Mode normal en Recette aujourd'hui_:
<img width="820" height="386" alt="image" src="https://github.com/user-attachments/assets/b91bd88e-92b0-4a66-a0f6-26619382a02a" />

- _Mode Preview en Recette ajd_: 
<img width="824" height="485" alt="image" src="https://github.com/user-attachments/assets/3abe1752-0135-4016-9521-5d12bdf3a2c1" />

Quel mystère ...

## <(^_^)> - Proposition

Appeler la brigade du cool pour investiguer sur ce problème. Et découvrir que dans le template `stepper.gjs`, l'instruction n'est visible que dans le mode "horizontal" + !previewMode (voir la méthode `isHorizontalDirection`)

## ¯\\_(ツ)_/¯ - Remarques

- Ajout d'un encadré autour des Steppers, en mode Preview, pour mettre en avant les éléments qui sont contenus à l'intérieur. Ca permet en même temps de comprendre que l'instruction est le texte au-dessus de l'encadré !
- Niveau code, Hercule Poirot aurait peut-être été plus subtil. A vos idées pour résoudre plus noblement cette enquête ... 🔍

## (ง'̀-'́)ง - Pour tester

- Ouvrir le [bac-a-sable en mode preview](https://app-pr15717.review.pix.fr/modules/preview/bac-a-sable)
- Chercher le stepper contenant le texte "Pix évalue 16 compétences numériques différentes."
- Vérifier qu'on voit bien l'instruction "Ce texte s'affiche uniquement pour ce stepper car il est horizontal."
