### PR TITLE
[FEATURE] Ajoute la sélection d'une attestation dans un modèle de Parcours Combiné (PIX-22159).

### DIFF
--- a/admin/app/components/combined-course-blueprints/form.gjs
+++ b/admin/app/components/combined-course-blueprints/form.gjs
@@ -14,6 +14,7 @@ import { eq, gt } from 'ember-truth-helpers';
 import PixFieldset from 'pix-admin/components/ui/pix-fieldset';
 
 import RequirementTag from '../common/combined-courses/requirement-tag';
+import SelectAttestation from './select-attestation';
 
 export default class CombineCourseBluePrintForm extends Component {
   @service pixToast;
@@ -111,6 +112,11 @@ export default class CombineCourseBluePrintForm extends Component {
   @action
   setData(key, e) {
     this.blueprint[key] = e.target.value;
+  }
+
+  @action
+  setAttestationKey(value) {
+    this.blueprint.attestationKey = value;
   }
 
   @action
@@ -236,6 +242,12 @@ export default class CombineCourseBluePrintForm extends Component {
 
           </:label>
         </PixTextarea>
+
+        <SelectAttestation
+          @attestations={{@attestations}}
+          @value={{this.blueprint.attestationKey}}
+          @onChange={{this.setAttestationKey}}
+        />
 
       </form>
 

--- a/admin/app/components/combined-course-blueprints/select-attestation.gjs
+++ b/admin/app/components/combined-course-blueprints/select-attestation.gjs
@@ -1,0 +1,23 @@
+import PixSelect from '@1024pix/pix-ui/components/pix-select';
+import Component from '@glimmer/component';
+import { t } from 'ember-intl';
+
+export default class SelectAttestation extends Component {
+  get attestationsOptions() {
+    return this.args.attestations?.map((attestation) => ({ value: attestation.key, label: attestation.key })) ?? [];
+  }
+
+  <template>
+    <PixSelect
+      size="small"
+      @options={{this.attestationsOptions}}
+      @value={{@value}}
+      @onChange={{@onChange}}
+      @placeholder={{t "components.combined-course-blueprints.attestation.select-placeholder"}}
+    >
+      <:label>
+        {{t "components.combined-course-blueprints.attestation.select-label"}}
+      </:label>
+    </PixSelect>
+  </template>
+}

--- a/admin/app/models/combined-course-blueprint.js
+++ b/admin/app/models/combined-course-blueprint.js
@@ -5,6 +5,7 @@ export default class CombinedCourseBlueprint extends Model {
   @attr('string') internalName;
   @attr('string') illustration;
   @attr('string') description;
+  @attr('string') attestationKey;
   @attr({ type: 'date', defaultValue: () => undefined }) createdAt;
   @attr({ defaultValue: () => [] }) content;
 }

--- a/admin/app/routes/authenticated/combined-course-blueprints/new.js
+++ b/admin/app/routes/authenticated/combined-course-blueprints/new.js
@@ -1,0 +1,10 @@
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+
+export default class NewRoute extends Route {
+  @service('store') store;
+
+  model() {
+    return this.store.findAll('attestation');
+  }
+}

--- a/admin/app/templates/authenticated/combined-course-blueprints/new.gjs
+++ b/admin/app/templates/authenticated/combined-course-blueprints/new.gjs
@@ -1,3 +1,3 @@
 import CombinedCourseBlueprintForm from 'pix-admin/components/combined-course-blueprints/form';
 
-<template><CombinedCourseBlueprintForm /></template>
+<template><CombinedCourseBlueprintForm @attestations={{@model}} /></template>

--- a/admin/tests/integration/components/combined-course-blueprints/form-test.gjs
+++ b/admin/tests/integration/components/combined-course-blueprints/form-test.gjs
@@ -27,12 +27,12 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
 
     sinon.stub(store, 'createRecord').withArgs('combined-course-blueprint').returns(blueprintStub);
     const findRecordStub = sinon.stub(store, 'findRecord');
+    const attestations = [{ key: 'PARENTHOOD' }, { key: 'SIXTH_GRADE' }];
     findRecordStub.withArgs('module', 'module-123').resolves({ title: 'module 123' });
     findRecordStub.withArgs('target-profile', '1').resolves({ internalName: 'super pc' });
 
     //when
-
-    const screen = await render(<template><CombinedCourseBlueprintForm /></template>);
+    const screen = await render(<template><CombinedCourseBlueprintForm @attestations={{attestations}} /></template>);
 
     await fillIn(screen.getByLabelText(t('components.combined-course-blueprints.labels.itemId'), { exact: false }), 1);
     await click(screen.getByRole('button', { name: t('components.combined-course-blueprints.create.addItemButton') }));
@@ -58,6 +58,14 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
 
     await fillIn(screen.getByLabelText(t('components.combined-course-blueprints.labels.description')), 'description');
 
+    await click(
+      screen.getByRole('button', { name: t('components.combined-course-blueprints.attestation.select-label') }),
+    );
+
+    await screen.findByRole('listbox');
+
+    await click(screen.getByRole('option', { name: 'PARENTHOOD' }));
+
     await click(screen.getByRole('button', { name: t('components.combined-course-blueprints.create.createButton') }));
 
     //then
@@ -71,6 +79,7 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
     ]);
     assert.strictEqual(blueprintStub.illustration, 'illustrations/hello.svg');
     assert.strictEqual(blueprintStub.description, 'description');
+    assert.strictEqual(blueprintStub.attestationKey, 'PARENTHOOD');
     assert.ok(
       pixToastSuccessStub.calledOnceWith({
         message: t('components.combined-course-blueprints.create.notifications.success'),
@@ -132,7 +141,7 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
       );
     });
 
-    test('it should display mutliple validation error messages from API', async function (assert) {
+    test('it should display multiple validation error messages from API', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');
       const pixToast = this.owner.lookup('service:pixToast');

--- a/admin/tests/integration/components/combined-course-blueprints/select-attestation-test.gjs
+++ b/admin/tests/integration/components/combined-course-blueprints/select-attestation-test.gjs
@@ -1,0 +1,39 @@
+import { render } from '@1024pix/ember-testing-library';
+import { click } from '@ember/test-helpers';
+import { t } from 'ember-intl/test-support';
+import SelectAttestation from 'pix-admin/components/combined-course-blueprints/select-attestation';
+import setupIntlRenderingTest from 'pix-admin/tests/helpers/setup-intl-rendering';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module('Integration | Component | CombinedCourseBlueprints::SelectAttestation', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('it should display every attestation available in select options', async function (assert) {
+    const attestations = [{ key: 'KEY_1' }, { key: 'KEY_2' }];
+    const screen = await render(<template><SelectAttestation @attestations={{attestations}} /></template>);
+    await click(
+      screen.getByRole('button', { name: t('components.combined-course-blueprints.attestation.select-label') }),
+    );
+    await screen.findByRole('listbox');
+
+    assert.ok(screen.getByRole('option', { name: 'KEY_1' }));
+    assert.ok(screen.getByRole('option', { name: 'KEY_2' }));
+  });
+
+  test('it should select an attestation', async function (assert) {
+    const onChangeStub = sinon.stub();
+    const attestations = [{ key: 'KEY_1' }, { key: 'KEY_2' }];
+    const screen = await render(
+      <template><SelectAttestation @attestations={{attestations}} @onChange={{onChangeStub}} /></template>,
+    );
+    await click(
+      screen.getByRole('button', { name: t('components.combined-course-blueprints.attestation.select-label') }),
+    );
+    await screen.findByRole('listbox');
+
+    await click(screen.getByRole('option', { name: 'KEY_1' }));
+
+    assert.ok(onChangeStub.calledWithExactly('KEY_1'));
+  });
+});

--- a/admin/tests/mirage/models.js
+++ b/admin/tests/mirage/models.js
@@ -4,6 +4,7 @@ import adminMember from './models/admin-member';
 import administrationTeam from './models/administration-team';
 import area from './models/area';
 import attachableTargetProfile from './models/attachable-target-profile';
+import attestation from './models/attestation.js';
 import authenticationMethod from './models/authentication-method';
 import autonomousCourse from './models/autonomous-course';
 import autonomousCourseListItem from './models/autonomous-course-list-item';
@@ -79,6 +80,7 @@ export default {
   administrationTeam,
   area,
   attachableTargetProfile,
+  attestation,
   authenticationMethod,
   autonomousCourse,
   autonomousCourseListItem,

--- a/admin/tests/mirage/models/attestation.js
+++ b/admin/tests/mirage/models/attestation.js
@@ -1,0 +1,3 @@
+import { Model } from 'miragejs';
+
+export default Model.extend();

--- a/admin/tests/mirage/routes.js
+++ b/admin/tests/mirage/routes.js
@@ -771,6 +771,7 @@ export default function routes() {
   });
 
   this.get('/admin/combined-course-blueprints/:id');
+  this.get('/admin/attestations');
   _configureOrganizationsRoutes(this);
 }
 

--- a/admin/tests/unit/serializers/combined-course-blueprint-test.js
+++ b/admin/tests/unit/serializers/combined-course-blueprint-test.js
@@ -16,6 +16,7 @@ module('Unit | Serializer | combined-course-blueprint', function (hooks) {
           label: 'Profil cilble 1',
         },
       ],
+      attestationKey: 'attestationKey',
     });
 
     const serializedRecord = record.serialize();
@@ -36,6 +37,7 @@ module('Unit | Serializer | combined-course-blueprint', function (hooks) {
                 value: 1,
               },
             ],
+            'attestation-key': 'attestationKey',
           },
         },
       },

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -538,6 +538,10 @@
       }
     },
     "combined-course-blueprints": {
+      "attestation": {
+        "select-label": "Add an attestation",
+        "select-placeholder": "Select an attestation"
+      },
       "create": {
         "addItemButton": "Add",
         "contentFeedback": "Your course does not have any items yet.",

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -539,6 +539,10 @@
       }
     },
     "combined-course-blueprints": {
+      "attestation": {
+        "select-label": "Ajouter une attestation",
+        "select-placeholder": "Sélectionner une attestation"
+      },
       "create": {
         "addItemButton": "Ajouter",
         "contentFeedback": "Votre parcours n'a aucun élément ajouté.",

--- a/api/src/profile/application/api/reward-api.js
+++ b/api/src/profile/application/api/reward-api.js
@@ -3,3 +3,7 @@ import { usecases } from '../../domain/usecases/index.js';
 export const getByIdAndType = ({ rewardId, rewardType }) => {
   return usecases.getRewardByIdAndType({ rewardId, rewardType });
 };
+
+export const getByAttestationKey = ({ key }) => {
+  return usecases.getByAttestationKey({ key });
+};

--- a/api/src/profile/domain/models/Reward.js
+++ b/api/src/profile/domain/models/Reward.js
@@ -1,0 +1,6 @@
+export class Reward {
+  constructor({ id, type }) {
+    this.id = id;
+    this.type = type;
+  }
+}

--- a/api/src/profile/domain/usecases/get-by-attestation-key.js
+++ b/api/src/profile/domain/usecases/get-by-attestation-key.js
@@ -1,0 +1,3 @@
+export const getByAttestationKey = async ({ key, rewardRepository }) => {
+  return rewardRepository.getByAttestationKey({ key });
+};

--- a/api/src/profile/domain/usecases/index.js
+++ b/api/src/profile/domain/usecases/index.js
@@ -34,6 +34,7 @@ const dependencies = {
 import { getAllAttestations } from './get-all-attestations.js';
 import { getAttestationDataForUsers } from './get-attestation-data-for-users.js';
 import { getAttestationDetails } from './get-attestation-details.js';
+import { getByAttestationKey } from './get-by-attestation-key.js';
 import { getProfileRewardsByUserId } from './get-profile-rewards-by-user-id.js';
 import { getRewardByIdAndType } from './get-reward-by-id-and-type.js';
 import { getSharedAttestationsForOrganizationByUserIds } from './get-shared-attestations-for-organization-by-user-ids.js';
@@ -53,6 +54,7 @@ const usecasesWithoutInjectedDependencies = {
   getUserProfile,
   rewardUser,
   shareProfileReward,
+  getByAttestationKey,
 };
 
 const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);

--- a/api/src/profile/infrastructure/repositories/reward-repository.js
+++ b/api/src/profile/infrastructure/repositories/reward-repository.js
@@ -1,7 +1,9 @@
 import { REWARD_TYPES } from '../../../quest/domain/constants.js';
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
+import { NotFoundError } from '../../../shared/domain/errors.js';
 import { RewardTypeDoesNotExistError } from '../../domain/errors.js';
 import { Attestation } from '../../domain/models/Attestation.js';
+import { Reward } from '../../domain/models/Reward.js';
 
 export const getByIdAndType = async ({ rewardId, rewardType }) => {
   const knexConn = DomainTransaction.getConnection();
@@ -14,4 +16,14 @@ export const getByIdAndType = async ({ rewardId, rewardType }) => {
   } catch (error) {
     throw new RewardTypeDoesNotExistError(error);
   }
+};
+
+export const getByAttestationKey = async ({ key }) => {
+  const knexConn = DomainTransaction.getConnection();
+
+  const result = await knexConn('attestations').select('id').where('attestations.key', key).first();
+
+  if (!result) throw new NotFoundError('Attestation not found.');
+
+  return new Reward({ id: result.id, type: REWARD_TYPES.ATTESTATION });
 };

--- a/api/src/quest/application/combined-course-blueprint-controller.js
+++ b/api/src/quest/application/combined-course-blueprint-controller.js
@@ -8,8 +8,10 @@ export const findAll = async (request, _, dependencies = { combinedCourseBluepri
 };
 
 export const save = async (request, h, dependencies = { combinedCourseBlueprintSerializer }) => {
-  const combinedCourseBlueprint = await dependencies.combinedCourseBlueprintSerializer.deserialize(request.payload);
-  const createdBlueprint = await usecases.createCombinedCourseBlueprint({ combinedCourseBlueprint });
+  const { combinedCourseBlueprint, attestationKey } = await dependencies.combinedCourseBlueprintSerializer.deserialize(
+    request.payload,
+  );
+  const createdBlueprint = await usecases.createCombinedCourseBlueprint({ combinedCourseBlueprint, attestationKey });
   return h.response(dependencies.combinedCourseBlueprintSerializer.serialize(createdBlueprint)).created();
 };
 

--- a/api/src/quest/application/combined-course-blueprint-route.js
+++ b/api/src/quest/application/combined-course-blueprint-route.js
@@ -53,6 +53,7 @@ const register = async function (server) {
                 'internal-name': Joi.string().required(),
                 illustration: Joi.string().allow(null),
                 description: Joi.string().allow(null),
+                'attestation-key': Joi.string().allow(null),
                 content: contentSchema,
                 createdAt: Joi.date(),
               },

--- a/api/src/quest/domain/models/CombinedCourseBlueprint.js
+++ b/api/src/quest/domain/models/CombinedCourseBlueprint.js
@@ -64,8 +64,8 @@ export class CombinedCourseBlueprint {
     const quest = new Quest({
       createdAt: createdAt,
       updatedAt: createdAt,
-      rewardType: null,
-      rewardId: null,
+      rewardType: this.quest.rewardType,
+      rewardId: this.quest.rewardId,
       eligibilityRequirements: [],
       successRequirements,
     });
@@ -83,7 +83,7 @@ export class CombinedCourseBlueprint {
     );
   }
 
-  static buildWithQuest({ combinedCourseBlueprint, modulesByShortId }) {
+  static buildWithQuest({ combinedCourseBlueprint, modulesByShortId, rewardId, rewardType }) {
     const successRequirements = combinedCourseBlueprint.content.map((requirement) => {
       if (requirement.type === COMBINED_COURSE_BLUEPRINT_ITEMS.EVALUATION) {
         const requirementTargetProfileId = requirement.value;
@@ -103,8 +103,8 @@ export class CombinedCourseBlueprint {
     const quest = new Quest({
       createdAt: combinedCourseBlueprint.createdAt,
       updatedAt: combinedCourseBlueprint.createdAt,
-      rewardType: null,
-      rewardId: null,
+      rewardType,
+      rewardId,
       eligibilityRequirements: [],
       successRequirements,
     });

--- a/api/src/quest/domain/usecases/create-combined-course-blueprint.js
+++ b/api/src/quest/domain/usecases/create-combined-course-blueprint.js
@@ -3,10 +3,12 @@ import _ from 'lodash';
 import { COMBINED_COURSE_BLUEPRINT_ITEMS, CombinedCourseBlueprint } from '../models/CombinedCourseBlueprint.js';
 
 export const createCombinedCourseBlueprint = async ({
+  attestationKey,
   combinedCourseBlueprint,
   combinedCourseBlueprintRepository,
   targetProfileRepository,
   moduleRepository,
+  rewardRepository,
 }) => {
   // We are using content from the front-end before building quests
   const targetProfileIds = combinedCourseBlueprint.content
@@ -20,7 +22,14 @@ export const createCombinedCourseBlueprint = async ({
   const modules = await moduleRepository.getByShortIds({ moduleShortIds });
   const modulesByShortId = _.groupBy(modules, 'shortId');
 
+  const reward = attestationKey ? await rewardRepository.getByAttestationKey({ key: attestationKey }) : null;
+
   return combinedCourseBlueprintRepository.save({
-    combinedCourseBlueprint: CombinedCourseBlueprint.buildWithQuest({ combinedCourseBlueprint, modulesByShortId }),
+    combinedCourseBlueprint: CombinedCourseBlueprint.buildWithQuest({
+      combinedCourseBlueprint,
+      modulesByShortId,
+      rewardId: reward?.id,
+      rewardType: reward?.type,
+    }),
   });
 };

--- a/api/src/quest/infrastructure/repositories/reward-repository.js
+++ b/api/src/quest/infrastructure/repositories/reward-repository.js
@@ -46,3 +46,7 @@ export const getByQuestAndUserId = async ({
     reward,
   });
 };
+
+export const getByAttestationKey = async ({ rewardApi, key }) => {
+  return rewardApi.getByAttestationKey({ key });
+};

--- a/api/src/quest/infrastructure/serializers/combined-course-blueprint-serializer.js
+++ b/api/src/quest/infrastructure/serializers/combined-course-blueprint-serializer.js
@@ -14,7 +14,10 @@ const deserialize = async function (payload) {
   const deserializedData = await new Deserializer({
     keyForAttribute: 'camelCase',
   }).deserialize(payload);
-  return new CombinedCourseBlueprint(deserializedData);
+  return {
+    combinedCourseBlueprint: new CombinedCourseBlueprint(deserializedData),
+    attestationKey: deserializedData.attestationKey,
+  };
 };
 
 export { deserialize, serialize };

--- a/api/tests/profile/integration/infrastructure/repositories/reward-repository_test.js
+++ b/api/tests/profile/integration/infrastructure/repositories/reward-repository_test.js
@@ -1,7 +1,11 @@
+import { ATTESTATIONS } from '../../../../../src/profile/domain/constants.js';
 import { RewardTypeDoesNotExistError } from '../../../../../src/profile/domain/errors.js';
 import { Attestation } from '../../../../../src/profile/domain/models/Attestation.js';
+import { Reward } from '../../../../../src/profile/domain/models/Reward.js';
 import { getByIdAndType } from '../../../../../src/profile/infrastructure/repositories/reward-repository.js';
+import { getByAttestationKey } from '../../../../../src/profile/infrastructure/repositories/reward-repository.js';
 import { REWARD_TYPES } from '../../../../../src/quest/domain/constants.js';
+import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
 import { catchErr, databaseBuilder, expect } from '../../../../test-helper.js';
 
 describe('Profile | Integration | Infrastructure | Repository | Reward', function () {
@@ -26,6 +30,33 @@ describe('Profile | Integration | Infrastructure | Repository | Reward', functio
 
       // then
       expect(error).to.be.an.instanceof(RewardTypeDoesNotExistError);
+    });
+  });
+  describe('#getByAttestationKey', function () {
+    it('should return the correct attestation for a given key', async function () {
+      //given
+      const attestation = await databaseBuilder.factory.buildAttestation({ key: ATTESTATIONS.PARENTHOOD });
+
+      await databaseBuilder.commit();
+
+      //when
+      const result = await getByAttestationKey({ key: attestation.key });
+
+      //then
+      expect(result).to.deep.equal(new Reward({ id: attestation.id, type: REWARD_TYPES.ATTESTATION }));
+    });
+
+    it('should throw not found error if no attestation match given key', async function () {
+      //given
+      await databaseBuilder.factory.buildAttestation({ key: ATTESTATIONS.PARENTHOOD });
+      await databaseBuilder.commit();
+
+      //when
+      const error = await catchErr(getByAttestationKey)({ key: 'unknown_key' });
+
+      //then
+      expect(error).to.instanceOf(NotFoundError);
+      expect(error.message).to.equal('Attestation not found.');
     });
   });
 });

--- a/api/tests/profile/unit/application/api/reward-api_test.js
+++ b/api/tests/profile/unit/application/api/reward-api_test.js
@@ -1,5 +1,7 @@
-import { getByIdAndType } from '../../../../../src/profile/application/api/reward-api.js';
+import { getByAttestationKey, getByIdAndType } from '../../../../../src/profile/application/api/reward-api.js';
+import { Reward } from '../../../../../src/profile/domain/models/Reward.js';
 import { usecases } from '../../../../../src/profile/domain/usecases/index.js';
+import { REWARD_TYPES } from '../../../../../src/quest/domain/constants.js';
 import { expect, sinon } from '../../../../test-helper.js';
 
 describe('Profile | Unit | Application | Api | reward', function () {
@@ -19,6 +21,18 @@ describe('Profile | Unit | Application | Api | reward', function () {
 
       // then
       expect(result).to.equal(rewardSymbol);
+    });
+  });
+  describe('#getByAttestationKey', function () {
+    it('should return a reward for a given attestation key', async function () {
+      //given
+      sinon.stub(usecases, 'getByAttestationKey');
+      const reward = new Reward({ id: 1, type: REWARD_TYPES.ATTESTATION });
+
+      usecases.getByAttestationKey.withArgs({ key: 1 }).resolves(reward);
+
+      const result = await getByAttestationKey({ key: 1 });
+      expect(result).to.equal(reward);
     });
   });
 });

--- a/api/tests/quest/acceptance/application/combined-course-blueprint-route_test.js
+++ b/api/tests/quest/acceptance/application/combined-course-blueprint-route_test.js
@@ -1,3 +1,4 @@
+import { ATTESTATIONS } from '../../../../src/profile/domain/constants.js';
 import { CombinedCourseBlueprint } from '../../../../src/quest/domain/models/CombinedCourseBlueprint.js';
 import {
   createServer,
@@ -48,7 +49,11 @@ describe('Quest | Acceptance | Application | Combined course blueprint Route ', 
     context('when user is admin ', function () {
       it('should create a combined course blueprint', async function () {
         // given
+        databaseBuilder.factory.buildAttestation({ key: ATTESTATIONS.SIXTH_GRADE });
         const adminUser = await insertUserWithRoleSuperAdmin();
+
+        await databaseBuilder.commit();
+
         const payload = {
           data: {
             type: 'combined-course-blueprints',
@@ -57,6 +62,7 @@ describe('Quest | Acceptance | Application | Combined course blueprint Route ', 
               'internal-name': 'Mon schéma de parcours combiné',
               description: 'La description combinix',
               illustration: 'illustration.svg',
+              'attestation-key': ATTESTATIONS.SIXTH_GRADE,
               content: CombinedCourseBlueprint.buildContentItems([{ moduleShortId: 'e67ec5d0' }]),
             },
           },

--- a/api/tests/quest/integration/domain/usecases/create-combined-course-blueprint_test.js
+++ b/api/tests/quest/integration/domain/usecases/create-combined-course-blueprint_test.js
@@ -1,14 +1,8 @@
-import { CampaignParticipationStatuses } from '../../../../../src/prescription/shared/domain/constants.js';
+import { REWARD_TYPES } from '../../../../../src/quest/domain/constants.js';
 import { CombinedCourseBlueprint } from '../../../../../src/quest/domain/models/CombinedCourseBlueprint.js';
-import {
-  CRITERION_COMPARISONS,
-  Quest,
-  REQUIREMENT_COMPARISONS,
-  REQUIREMENT_TYPES,
-} from '../../../../../src/quest/domain/models/Quest.js';
 import { usecases } from '../../../../../src/quest/domain/usecases/index.js';
 import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
-import { catchErr, databaseBuilder, expect } from '../../../../test-helper.js';
+import { catchErr, databaseBuilder, expect, knex } from '../../../../test-helper.js';
 
 describe('Integration | Combined course | Domain | UseCases | create-combined-course-blueprint', function () {
   it('should create a combined course blueprint with quest', async function () {
@@ -16,38 +10,8 @@ describe('Integration | Combined course | Domain | UseCases | create-combined-co
     const moduleShortId = '6a68bf32';
     const moduleId = '6282925d-4775-4bca-b513-4c3009ec5886';
     const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+    const attestation = databaseBuilder.factory.buildAttestation();
     await databaseBuilder.commit();
-
-    const expectedQuest = new Quest({
-      eligibilityRequirements: [],
-      successRequirements: [
-        {
-          comparison: REQUIREMENT_COMPARISONS.ALL,
-          requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
-          data: {
-            isTerminated: { comparison: CRITERION_COMPARISONS.EQUAL, data: true },
-            moduleId: {
-              comparison: CRITERION_COMPARISONS.EQUAL,
-              data: moduleId,
-            },
-          },
-        },
-        {
-          comparison: REQUIREMENT_COMPARISONS.ALL,
-          data: {
-            status: {
-              comparison: CRITERION_COMPARISONS.EQUAL,
-              data: CampaignParticipationStatuses.SHARED,
-            },
-            targetProfileId: {
-              comparison: CRITERION_COMPARISONS.EQUAL,
-              data: targetProfileId,
-            },
-          },
-          requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
-        },
-      ],
-    });
 
     const combinedCourseBlueprint = new CombinedCourseBlueprint({
       name: 'Mon épure',
@@ -57,16 +21,57 @@ describe('Integration | Combined course | Domain | UseCases | create-combined-co
       content: CombinedCourseBlueprint.buildContentItems([{ moduleShortId }, { targetProfileId }]),
     });
 
-    const result = await usecases.createCombinedCourseBlueprint({ combinedCourseBlueprint });
+    await usecases.createCombinedCourseBlueprint({ combinedCourseBlueprint, attestationKey: attestation.key });
 
-    expect(result.name).to.equal(combinedCourseBlueprint.name);
-    expect(result.internalName).to.equal(combinedCourseBlueprint.internalName);
-    expect(result.illustration).to.equal(combinedCourseBlueprint.illustration);
-    expect(result.content).to.deep.equal(combinedCourseBlueprint.content);
-    expect(result.description).to.equal(combinedCourseBlueprint.description);
-    expect(result.quest.toDTO().successRequirements).deep.equal(expectedQuest.toDTO().successRequirements);
-    expect(result.quest.toDTO().rewardId).to.be.null;
-    expect(result.quest.toDTO().rewardType).to.be.null;
+    const combinedCourseBlueprints = await knex('combined_course_blueprints');
+    expect(combinedCourseBlueprints).lengthOf(1);
+    expect(combinedCourseBlueprints[0].name).to.equal(combinedCourseBlueprint.name);
+    expect(combinedCourseBlueprints[0].internalName).to.equal(combinedCourseBlueprint.internalName);
+    expect(combinedCourseBlueprints[0].illustration).to.equal(combinedCourseBlueprint.illustration);
+    expect(combinedCourseBlueprints[0].description).to.equal(combinedCourseBlueprint.description);
+    expect(combinedCourseBlueprints[0].content).to.deep.equal(combinedCourseBlueprint.content);
+    expect(combinedCourseBlueprints[0].updatedAt).to.be.instanceOf(Date);
+    expect(combinedCourseBlueprints[0].createdAt).to.be.instanceOf(Date);
+
+    const quests = await knex('quests');
+    expect(quests).lengthOf(1);
+    expect(quests[0].successRequirements).deep.equal([
+      CombinedCourseBlueprint.buildRequirementForCombinedCourse({ moduleId }).toDTO(),
+      CombinedCourseBlueprint.buildRequirementForCombinedCourse({ targetProfileId }).toDTO(),
+    ]);
+    expect(quests[0].rewardId).to.equal(attestation.id);
+    expect(quests[0].rewardType).to.equal(REWARD_TYPES.ATTESTATION);
+  });
+
+  it('should create a combined course blueprint quest without reward', async function () {
+    // given
+    const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+    await databaseBuilder.commit();
+
+    const combinedCourseBlueprint = new CombinedCourseBlueprint({
+      name: 'Mon épure',
+      internalName: 'Une épure pour tel niveau',
+      illustration: 'illustrations/mon-epure.png',
+      description: 'Description',
+      content: CombinedCourseBlueprint.buildContentItems([{ moduleShortId: '6a68bf32' }, { targetProfileId }]),
+      attestationKey: undefined,
+    });
+
+    await usecases.createCombinedCourseBlueprint({ combinedCourseBlueprint });
+
+    const combinedCourseBlueprints = await knex('combined_course_blueprints');
+    expect(combinedCourseBlueprints).lengthOf(1);
+
+    const quests = await knex('quests');
+    expect(quests).lengthOf(1);
+    expect(quests[0].successRequirements).deep.equal([
+      CombinedCourseBlueprint.buildRequirementForCombinedCourse({
+        moduleId: '6282925d-4775-4bca-b513-4c3009ec5886',
+      }).toDTO(),
+      CombinedCourseBlueprint.buildRequirementForCombinedCourse({ targetProfileId }).toDTO(),
+    ]);
+    expect(quests[0].rewardId).to.be.null;
+    expect(quests[0].rewardType).to.be.null;
   });
 
   it('should return error if a targetProfileId in content is not found', async function () {

--- a/api/tests/quest/integration/domain/usecases/create-combined-course_test.js
+++ b/api/tests/quest/integration/domain/usecases/create-combined-course_test.js
@@ -1,3 +1,4 @@
+import { REWARD_TYPES } from '../../../../../src/quest/domain/constants.js';
 import { CombinedCourseBlueprint } from '../../../../../src/quest/domain/models/CombinedCourseBlueprint.js';
 import { usecases } from '../../../../../src/quest/domain/usecases/index.js';
 import { databaseBuilder, expect, knex } from '../../../../test-helper.js';
@@ -25,7 +26,11 @@ describe('Integration | Combined course | Domain | UseCases | create-combined-co
       trainingId: trainingId,
     });
 
+    const attestation = databaseBuilder.factory.buildAttestation();
+
     const quest = databaseBuilder.factory.buildQuest({
+      rewardId: attestation.id,
+      rewardType: REWARD_TYPES.ATTESTATION,
       successRequirements: [
         CombinedCourseBlueprint.buildRequirementForCombinedCourse({
           targetProfileId: targetProfileWithTraining.id,
@@ -65,6 +70,8 @@ describe('Integration | Combined course | Domain | UseCases | create-combined-co
     expect(createdQuest.combinedCourseBlueprintId).to.equal(combinedCourseBlueprintId);
     expect(createdQuest.code).not.to.be.null;
     expect(createdQuest.name).to.equal(nameInput);
+    expect(createdQuest.rewardId).to.equal(attestation.id);
+    expect(createdQuest.rewardType).to.equal(REWARD_TYPES.ATTESTATION);
 
     //Campaign 1
     expect(campaigns[0].name).to.equal(targetProfileWithTraining.internalName);

--- a/api/tests/quest/unit/domain/models/CombinedCourseBlueprint_test.js
+++ b/api/tests/quest/unit/domain/models/CombinedCourseBlueprint_test.js
@@ -1,3 +1,4 @@
+import { REWARD_TYPES } from '../../../../../src/quest/domain/constants.js';
 import { CombinedCourse } from '../../../../../src/quest/domain/models/CombinedCourse.js';
 import {
   COMBINED_COURSE_BLUEPRINT_ITEMS,
@@ -240,8 +241,12 @@ describe('Quest | Unit | Domain | Models | CombinedCourseBlueprint ', function (
 
       const description = 'bla bla bla';
       const illustration = 'illu.svg';
+      const rewardId = 1;
+      const rewardType = REWARD_TYPES.ATTESTATION;
 
       const combinedCourseBlueprintQuest = new Quest({
+        rewardId,
+        rewardType,
         eligibilityRequirements: [],
         successRequirements: [
           {
@@ -304,6 +309,8 @@ describe('Quest | Unit | Domain | Models | CombinedCourseBlueprint ', function (
 
       // then
       const expectedQuest = new Quest({
+        rewardId,
+        rewardType,
         eligibilityRequirements: [],
         successRequirements: [
           {

--- a/api/tests/quest/unit/infrastructure/repositories/reward-repository_test.js
+++ b/api/tests/quest/unit/infrastructure/repositories/reward-repository_test.js
@@ -1,5 +1,9 @@
+import { REWARD_TYPES } from '../../../../../src/quest/domain/constants.js';
 import { QuestResult } from '../../../../../src/quest/domain/models/QuestResult.js';
-import { getByQuestAndUserId } from '../../../../../src/quest/infrastructure/repositories/reward-repository.js';
+import {
+  getByAttestationKey,
+  getByQuestAndUserId,
+} from '../../../../../src/quest/infrastructure/repositories/reward-repository.js';
 import { expect, sinon } from '../../../../test-helper.js';
 
 describe('Quest | Unit | Infrastructure | Repositories | Reward', function () {
@@ -102,6 +106,24 @@ describe('Quest | Unit | Infrastructure | Repositories | Reward', function () {
       expect(result.reward).to.equal(reward);
       expect(result.profileRewardId).to.be.null;
       expect(result.obtained).to.be.null;
+    });
+  });
+  describe('#getByAttestationKey', function () {
+    let rewardApiStub;
+    beforeEach(function () {
+      rewardApiStub = {
+        getByAttestationKey: sinon.stub(),
+      };
+
+      rewardApiStub.getByAttestationKey
+        .withArgs({ key: 'PARENTHOOD' })
+        .resolves({ id: 1, type: REWARD_TYPES.ATTESTATION });
+    });
+
+    it('should return a reward for given attestation key', async function () {
+      const result = await getByAttestationKey({ key: 'PARENTHOOD', rewardApi: rewardApiStub });
+
+      expect(result.id).to.equal(1);
     });
   });
 });

--- a/api/tests/quest/unit/infrastructure/serializers/combined-course-blueprint-serializer_test.js
+++ b/api/tests/quest/unit/infrastructure/serializers/combined-course-blueprint-serializer_test.js
@@ -56,6 +56,7 @@ describe('Quest | Unit | Infrastructure | Serializers | combined-course-blueprin
           'internal-name': 'Mon modèle de parcours',
           illustration: '/illustrations/image.svg',
           description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+          'attestation-key': 'SIXTH_GRADE',
           content: [
             {
               type: 'passages',
@@ -75,10 +76,11 @@ describe('Quest | Unit | Infrastructure | Serializers | combined-course-blueprin
     };
 
     // when
-    const deserializedBlueprint = await combinedCourseBlueprintSerializer.deserialize(serializedBlueprint);
+    const deserialize = await combinedCourseBlueprintSerializer.deserialize(serializedBlueprint);
 
     // then
-    expect(deserializedBlueprint).deep.equal({
+    expect(deserialize.attestationKey).to.equal('SIXTH_GRADE');
+    expect(deserialize.combinedCourseBlueprint).deep.equal({
       id: '1',
       name: 'Mon parcours',
       internalName: 'Mon modèle de parcours',


### PR DESCRIPTION
## (╯°□°)╯︵ ┻━┻ - Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

Bien qu'on puisse récompenser un utilisateur lors d'un Parcours Apprenant, il n'est pas possible d'ajouter une attestation (récompense) lors de la création d'un modèle de Parcours Apprenant.

## <(^\_^)> - Proposition

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

On ajoute un sélecteur d'attestation dans Pix Admin, lors de la création d'un modèle de Parcours Apprenant.
On transmet l'attestation key sélectionnée à l'API qui peut ainsi renseigner les propriétés `rewardId` et `rewardType` de la `quest` attachée au `CombinedCourseBlueprint`.

## ¯\\_(ツ)_/¯ - Remarques

RAS

<!-- Des infos supplémentaires, trucs et astuces ? -->

## (ง'̀-'́)ง - Pour tester

Sur Pix Admin, dans l'onglet `Modèles de parcours`, créer un modèle en sélectionnant au préalable une attestation.
Utiliser le modèle pour créer un Parcours Apprenant.
Compléter le Parcours Apprenant avec un utilisateur de l'organisation.
Vérifier que l'attestation a été délivrée à l'utilisateur.

<!--
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc.
- [ ] Documentation de la fonctionnalité (lien)
-->
