### PR TITLE
[FEATURE] Afficher les boutons d'action sur l'onglet Réseau d'une organisation (PIX-22135)

### DIFF
--- a/admin/app/components/organizations/children.gjs
+++ b/admin/app/components/organizations/children.gjs
@@ -1,3 +1,5 @@
+// TODO: delete file at the end of EPIX PIX-21277
+
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';

--- a/admin/app/components/organizations/children/actions-section.gjs
+++ b/admin/app/components/organizations/children/actions-section.gjs
@@ -1,3 +1,5 @@
+// TODO: delete file at the end of EPIX PIX-21277
+
 import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
 import { hash } from '@ember/helper';
 import { service } from '@ember/service';

--- a/admin/app/components/organizations/children/attach-child-form.gjs
+++ b/admin/app/components/organizations/children/attach-child-form.gjs
@@ -1,3 +1,5 @@
+// TODO: delete file at the end of EPIX PIX-21277
+
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixInput from '@1024pix/pix-ui/components/pix-input';
 import { on } from '@ember/modifier';

--- a/admin/app/components/organizations/children/list-item.gjs
+++ b/admin/app/components/organizations/children/list-item.gjs
@@ -1,3 +1,5 @@
+// TODO: delete file at the end of EPIX PIX-21277
+
 import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
 import { LinkTo } from '@ember/routing';
 import { t } from 'ember-intl';

--- a/admin/app/components/organizations/children/list.gjs
+++ b/admin/app/components/organizations/children/list.gjs
@@ -1,3 +1,5 @@
+// TODO: delete file at the end of EPIX PIX-21277
+
 import PixTable from '@1024pix/pix-ui/components/pix-table';
 import { t } from 'ember-intl';
 

--- a/admin/app/components/organizations/network.gjs
+++ b/admin/app/components/organizations/network.gjs
@@ -1,0 +1,76 @@
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import t from 'ember-intl/helpers/t';
+import get from 'lodash/get';
+import ActionsSection from 'pix-admin/components/organizations/network/actions-section';
+import List from 'pix-admin/components/organizations/network/list';
+
+export default class OrganizationNetworkComponent extends Component {
+  @service accessControl;
+  @service pixToast;
+  @service store;
+  @service intl;
+
+  @action
+  refreshOrganizationChildren() {
+    this.args.organization.hasMany('children').reload();
+  }
+
+  @action
+  async handleAttachOrganizations(childOrganizationIds) {
+    const organizationAdapter = this.store.adapterFor('organization');
+    const parentOrganizationId = this.args.organization.id;
+
+    try {
+      await organizationAdapter.attachChildOrganization({ childOrganizationIds, parentOrganizationId });
+      const count = childOrganizationIds.split(',').length;
+      this.pixToast.sendSuccessNotification({
+        message: this.intl.t('pages.organization-network.notifications.success.attach-child-organization', {
+          count,
+        }),
+      });
+
+      await this.refreshOrganizationChildren();
+    } catch (responseError) {
+      const error = get(responseError, 'errors[0]');
+      const childOrganizationId = error.meta?.organizationId;
+      let message;
+      switch (error?.code) {
+        case 'UNABLE_TO_ATTACH_CHILD_ORGANIZATION_TO_ITSELF':
+          message = this.intl.t(
+            'pages.organization-network.notifications.error.unable-to-attach-child-organization-to-itself',
+            { childOrganizationId },
+          );
+          break;
+        case 'UNABLE_TO_ATTACH_ALREADY_ATTACHED_CHILD_ORGANIZATION':
+          message = this.intl.t(
+            'pages.organization-network.notifications.error.unable-to-attach-already-attached-child-organization',
+            { childOrganizationId },
+          );
+          break;
+        default:
+          message = this.intl.t('common.notifications.generic-error');
+      }
+
+      this.pixToast.sendErrorNotification({ message });
+    }
+  }
+
+  <template>
+    {{#if this.accessControl.hasAccessToOrganizationActionsScope}}
+      <ActionsSection @onAttachChildSubmitForm={{this.handleAttachOrganizations}} @organization={{@organization}} />
+    {{/if}}
+
+    <section class="page-section">
+      <header class="page-section__header">
+        <h2 class="page-section__title">{{t "pages.organization-network.title"}}</h2>
+      </header>
+      {{#if @children}}
+        <List @childOrganizations={{@children}} @onRefreshOrganizationChildren={{this.refreshOrganizationChildren}} />
+      {{else}}
+        <p class="table__empty">{{t "components.organizations.network.empty-table"}}</p>
+      {{/if}}
+    </section>
+  </template>
+}

--- a/admin/app/components/organizations/network/actions-section.gjs
+++ b/admin/app/components/organizations/network/actions-section.gjs
@@ -1,0 +1,39 @@
+import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import { hash } from '@ember/helper';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import { t } from 'ember-intl';
+
+import AttachChildForm from './attach-child-form';
+
+export default class ActionsSection extends Component {
+  @service accessControl;
+
+  get canCreateChildOrganization() {
+    return (
+      this.accessControl.hasAccessToAttachChildOrganizationActionsScope &&
+      !!this.args.organization.belongsTo('network').id()
+    );
+  }
+
+  <template>
+    <section class="page-section">
+      <div class="content-text content-text--small organization-network__actions-section">
+        {{#if this.canCreateChildOrganization}}
+          {{#unless @organization.parentOrganizationId}}
+            <PixButtonLink
+              @iconBefore="add"
+              @variant="secondary"
+              @route="authenticated.organizations.new"
+              @query={{hash parentOrganizationId=@organization.id parentOrganizationName=@organization.name}}
+            >{{t "components.organizations.network.create-child-organization-button"}}</PixButtonLink>
+          {{/unless}}
+        {{/if}}
+
+        {{#if this.accessControl.hasAccessToAttachChildOrganizationActionsScope}}
+          <AttachChildForm @onFormSubmitted={{@onAttachChildSubmitForm}} />
+        {{/if}}
+      </div>
+    </section>
+  </template>
+}

--- a/admin/app/components/organizations/network/actions-section.scss
+++ b/admin/app/components/organizations/network/actions-section.scss
@@ -1,0 +1,6 @@
+.organization-network__actions-section {
+  display: flex;
+  gap: var(--pix-spacing-10x);
+  align-items: end;
+  justify-content: flex-start;
+}

--- a/admin/app/components/organizations/network/attach-child-form.gjs
+++ b/admin/app/components/organizations/network/attach-child-form.gjs
@@ -1,0 +1,43 @@
+import PixButton from '@1024pix/pix-ui/components/pix-button';
+import PixInput from '@1024pix/pix-ui/components/pix-input';
+import { on } from '@ember/modifier';
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { t } from 'ember-intl';
+
+export default class OrganizationNetworkAttachChildFormComponent extends Component {
+  @tracked childOrganizationIds = '';
+
+  @action
+  childOrganizationInputValueChanged(event) {
+    this.childOrganizationIds = event.target.value;
+  }
+
+  @action
+  submitForm(event) {
+    event.preventDefault();
+    this.args.onFormSubmitted(this.childOrganizationIds);
+    this.childOrganizationIds = '';
+  }
+
+  <template>
+    <form
+      aria-label={{t "components.organizations.network.attach-child-form.name"}}
+      class="organization__attach-child-form"
+      {{on "submit" this.submitForm}}
+    >
+      <div class="organization__attach-child-form__content">
+        <PixInput
+          @id="child-organizations"
+          @subLabel={{t "components.organizations.network.attach-child-form.input-information"}}
+          value={{this.childOrganizationIds}}
+          {{on "change" this.childOrganizationInputValueChanged}}
+        >
+          <:label>{{t "components.organizations.network.attach-child-form.input-label"}}</:label>
+        </PixInput>
+        <PixButton @size="small" @type="submit">{{t "common.actions.add"}}</PixButton>
+      </div>
+    </form>
+  </template>
+}

--- a/admin/app/components/organizations/network/list-item.gjs
+++ b/admin/app/components/organizations/network/list-item.gjs
@@ -1,0 +1,32 @@
+import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import { LinkTo } from '@ember/routing';
+import { t } from 'ember-intl';
+
+<template>
+  <PixTableColumn @context={{@context}}>
+    <:header>
+      {{t "components.organizations.network.children-list.table-headers.id"}}
+    </:header>
+    <:cell>
+      <LinkTo @route="authenticated.organizations.get" @model={{@childOrganization.id}}>
+        {{@childOrganization.id}}
+      </LinkTo>
+    </:cell>
+  </PixTableColumn>
+  <PixTableColumn @context={{@context}} class="break-word">
+    <:header>
+      {{t "components.organizations.network.children-list.table-headers.name"}}
+    </:header>
+    <:cell>
+      {{@childOrganization.name}}
+    </:cell>
+  </PixTableColumn>
+  <PixTableColumn @context={{@context}} class="break-word">
+    <:header>
+      {{t "components.organizations.network.children-list.table-headers.external-id"}}
+    </:header>
+    <:cell>
+      {{@childOrganization.externalId}}
+    </:cell>
+  </PixTableColumn>
+</template>

--- a/admin/app/components/organizations/network/list.gjs
+++ b/admin/app/components/organizations/network/list.gjs
@@ -1,0 +1,20 @@
+import PixTable from '@1024pix/pix-ui/components/pix-table';
+import { t } from 'ember-intl';
+
+import ListItem from './list-item';
+
+<template>
+  <PixTable
+    @variant="admin"
+    @caption={{t "components.organizations.network.children-list.table-name"}}
+    @data={{@childOrganizations}}
+  >
+    <:columns as |childOrganization context|>
+      <ListItem
+        @childOrganization={{childOrganization}}
+        @context={{context}}
+        @onRefreshOrganizationChildren={{@onRefreshOrganizationChildren}}
+      />
+    </:columns>
+  </PixTable>
+</template>

--- a/admin/app/controllers/authenticated/organizations/get/children.js
+++ b/admin/app/controllers/authenticated/organizations/get/children.js
@@ -1,3 +1,5 @@
+// TODO: delete file at the end of EPIX PIX-21277
+
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { service } from '@ember/service';

--- a/admin/app/router.js
+++ b/admin/app/router.js
@@ -51,6 +51,7 @@ Router.map(function () {
           this.route('new');
         });
         this.route('invitations');
+        // TODO: delete children route at the end of EPIX PIX-21277
         this.route('children');
         this.route('network');
       });

--- a/admin/app/routes/authenticated/organizations/get/children.js
+++ b/admin/app/routes/authenticated/organizations/get/children.js
@@ -1,3 +1,5 @@
+// TODO: delete file at the end of EPIX PIX-21277
+
 import Route from '@ember/routing/route';
 import RSVP from 'rsvp';
 

--- a/admin/app/routes/authenticated/organizations/get/network.js
+++ b/admin/app/routes/authenticated/organizations/get/network.js
@@ -14,4 +14,12 @@ export default class Network extends Route {
       this.router.replaceWith('authenticated.organizations.get.details');
     }
   }
+
+  async model() {
+    const organization = this.modelFor('authenticated.organizations.get');
+    return {
+      organization,
+      children: organization.children,
+    };
+  }
 }

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -119,3 +119,4 @@
 @use 'organizations/creation-form' as *;
 @use 'organizations/features-section' as *;
 @use 'organizations/head-information' as *;
+@use 'organizations/network/actions-section' as *;

--- a/admin/app/styles/authenticated/organizations/children.scss
+++ b/admin/app/styles/authenticated/organizations/children.scss
@@ -1,3 +1,4 @@
+// TODO: delete file at the end of EPIX PIX-21277
 .organization-children__actions-section {
   display: flex;
   gap: var(--pix-spacing-10x);

--- a/admin/app/templates/authenticated/organizations/get/children.gjs
+++ b/admin/app/templates/authenticated/organizations/get/children.gjs
@@ -1,3 +1,5 @@
+// TODO: delete file at the end of EPIX PIX-21277
+
 import pageTitle from 'ember-page-title/helpers/page-title';
 import Children from 'pix-admin/components/organizations/children';
 

--- a/admin/app/templates/authenticated/organizations/get/network.gjs
+++ b/admin/app/templates/authenticated/organizations/get/network.gjs
@@ -1,0 +1,7 @@
+import pageTitle from 'ember-page-title/helpers/page-title';
+import Network from 'pix-admin/components/organizations/network';
+
+<template>
+  {{pageTitle "Orga " @model.organization.id " | Réseau"}}
+  <Network @organization={{@model.organization}} @children={{@model.children}} />
+</template>

--- a/admin/tests/acceptance/authenticated/organizations/get/children-test.js
+++ b/admin/tests/acceptance/authenticated/organizations/get/children-test.js
@@ -1,3 +1,5 @@
+// TODO: delete file at the end of EPIX PIX-21277
+
 import { clickByName, fillByLabel, visit, within } from '@1024pix/ember-testing-library';
 import { click, currentURL } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';

--- a/admin/tests/acceptance/authenticated/organizations/get/network-test.js
+++ b/admin/tests/acceptance/authenticated/organizations/get/network-test.js
@@ -1,0 +1,187 @@
+import { clickByName, fillByLabel, visit, within } from '@1024pix/ember-testing-library';
+import { click, currentURL } from '@ember/test-helpers';
+import { t } from 'ember-intl/test-support';
+import { setupApplicationTest } from 'ember-qunit';
+import setupIntl from 'pix-admin/tests/helpers/setup-intl';
+import { authenticateAdminMemberWithRole } from 'pix-admin/tests/helpers/test-init';
+import { setupMirage } from 'pix-admin/tests/test-support/setup-mirage';
+import { module, test } from 'qunit';
+
+module('Acceptance | Organizations | Network', function (hooks) {
+  setupApplicationTest(hooks);
+  setupIntl(hooks);
+  setupMirage(hooks);
+
+  module('when user has role "SUPER_ADMIN"', function (hooks) {
+    hooks.beforeEach(async function () {
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+    });
+
+    module('Layout', function () {
+      test('displays page title', async function (assert) {
+        // given
+        const network = this.server.create('network', { name: 'My network' });
+        const organizationId = this.server.create('organization', {
+          name: 'Orga name',
+          features: { PLACES_MANAGEMENT: { active: true } },
+          network,
+        }).id;
+
+        // when
+        const screen = await visit(`/organizations/${organizationId}/network`);
+
+        // then
+        assert.dom(screen.getByRole('heading', { name: t('pages.organization-network.title'), level: 2 })).exists();
+        const headScreen = within(document.head);
+        assert.ok(headScreen.getByText(`Orga ${organizationId} | Réseau`, { selector: 'title' }));
+      });
+    });
+
+    module('when there is at least one child organization', function () {
+      test('displays a list of child organizations', async function (assert) {
+        // given
+        const network = this.server.create('network', { name: 'My network' });
+
+        const parentOrganizationId = this.server.create('organization', {
+          id: 1,
+          name: 'Orga name',
+          features: { PLACES_MANAGEMENT: { active: true } },
+          network,
+        }).id;
+
+        this.server.create('organization', {
+          id: 2,
+          parentOrganizationId: 1,
+          name: 'Child',
+          features: { PLACES_MANAGEMENT: { active: true } },
+        });
+
+        // when
+        const screen = await visit(`/organizations/${parentOrganizationId}/network`);
+
+        // then
+        assert.dom(screen.queryByText(t('components.organization.network.empty-table'))).doesNotExist();
+        assert
+          .dom(screen.getByRole('table', { name: t('components.organizations.network.children-list.table-name') }))
+          .exists();
+        assert.dom(screen.getByRole('cell', { name: 'Child' })).exists();
+      });
+    });
+
+    module('when attaching child organization', function () {
+      test('attaches child organization to parent organization and displays success notification', async function (assert) {
+        // given
+        const network = this.server.create('network', { name: 'My network' });
+
+        const parentOrganization = this.server.create('organization', {
+          id: 1,
+          name: 'Parent Organization Name',
+          features: { PLACES_MANAGEMENT: { active: true } },
+          network,
+        });
+        this.server.create('organization', {
+          id: 2,
+          name: 'Child Organization Name',
+          features: { PLACES_MANAGEMENT: { active: true } },
+        });
+        const screen = await visit(`/organizations/${parentOrganization.id}/network`);
+
+        await fillByLabel(
+          `${t('components.organizations.network.attach-child-form.input-label')} ${t('components.organizations.network.attach-child-form.input-information')}`,
+          '2',
+        );
+
+        // when
+        await clickByName(t('common.actions.add'));
+
+        // then
+        assert.dom(await screen.findByRole('cell', { name: 'Child Organization Name' })).exists();
+        assert
+          .dom(
+            screen.getByText(
+              t('pages.organization-network.notifications.success.attach-child-organization', { count: 1 }),
+            ),
+          )
+          .exists();
+      });
+    });
+
+    module('when creating child organization from parent page', function () {
+      test('it should redirect to New organization page, with parent id in query params', async function (assert) {
+        // given
+        const network = this.server.create('network', { name: 'Test Network' });
+        const parentOrganization = this.server.create('organization', {
+          id: 1,
+          name: 'Parent Organization Name',
+          features: { PLACES_MANAGEMENT: { active: true } },
+          network,
+        });
+        const screen = await visit(`/organizations/${parentOrganization.id}/network`);
+
+        // when
+        await click(
+          screen.getByRole('link', { name: t('components.organizations.network.create-child-organization-button') }),
+        );
+
+        const expectedQueryParams = `?parentOrganizationId=${parentOrganization.id}`;
+
+        // then
+        assert.strictEqual(currentURL(), `/organizations/new${expectedQueryParams}`);
+      });
+    });
+  });
+
+  // Network Tab is not accessible to these roles for the moment so these tests are irrelevent. TODO: delete skip at the end of EPIX PIX-21277
+  [
+    { name: 'METIER', authData: { isMetier: true } },
+    { name: 'SUPPORT', authData: { isSupport: true } },
+  ].forEach((role) => {
+    module.skip(`when user has role "${role.name}"`, function (hooks) {
+      let parentOrganizationId;
+
+      hooks.beforeEach(async function () {
+        await authenticateAdminMemberWithRole(role.authData)(server);
+        const network = this.server.create('network', { name: 'My network' });
+
+        parentOrganizationId = this.server.create('organization', {
+          name: 'Parent Orga name',
+          features: { PLACES_MANAGEMENT: { active: true } },
+          network,
+        }).id;
+      });
+
+      test('it does not display create child organization button', async function (assert) {
+        // when
+        const screen = await visit(`/organizations/${parentOrganizationId}/network`);
+
+        // then
+        assert.notOk(
+          screen.queryByRole('link', { name: t('components.organizations.network.create-child-organization-button') }),
+        );
+      });
+    });
+  });
+
+  module.skip('when user has role "CERTIF"', function () {
+    test('it should not display actions section', async function (assert) {
+      await authenticateAdminMemberWithRole({ isCertif: true })(server);
+      const parentOrganizationId = this.server.create('organization', {
+        name: 'Parent Orga name',
+        features: { PLACES_MANAGEMENT: { active: true } },
+      }).id;
+      this.server.create('organization', {
+        name: 'Child Orga name',
+        parentOrganizationId,
+        features: { PLACES_MANAGEMENT: { active: true } },
+      });
+
+      // when
+      const screen = await visit(`/organizations/${parentOrganizationId}/network`);
+
+      // then
+      assert.notOk(
+        screen.queryByRole(('link', { name: t('components.organizations.network.create-child-organization-button') })),
+      );
+    });
+  });
+});

--- a/admin/tests/integration/components/organizations/children/actions-section-test.gjs
+++ b/admin/tests/integration/components/organizations/children/actions-section-test.gjs
@@ -1,3 +1,5 @@
+// TODO: delete file at the end of EPIX PIX-21277
+
 import { render } from '@1024pix/ember-testing-library';
 import Service from '@ember/service';
 import { t } from 'ember-intl/test-support';

--- a/admin/tests/integration/components/organizations/children/attach-child-form-test.gjs
+++ b/admin/tests/integration/components/organizations/children/attach-child-form-test.gjs
@@ -1,3 +1,5 @@
+// TODO: delete file at the end of EPIX PIX-21277
+
 import { clickByName, fillByLabel, render as renderScreen } from '@1024pix/ember-testing-library';
 import AttachChildForm from 'pix-admin/components/organizations/children/attach-child-form';
 import { module, test } from 'qunit';

--- a/admin/tests/integration/components/organizations/children/attach-children-form-test.gjs
+++ b/admin/tests/integration/components/organizations/children/attach-children-form-test.gjs
@@ -1,3 +1,5 @@
+// TODO: delete file at the end of EPIX PIX-21277
+
 import { render } from '@1024pix/ember-testing-library';
 import { click, fillIn, triggerEvent } from '@ember/test-helpers';
 import AttachChildForm from 'pix-admin/components/organizations/children/attach-child-form';

--- a/admin/tests/integration/components/organizations/children/list-item-test.gjs
+++ b/admin/tests/integration/components/organizations/children/list-item-test.gjs
@@ -1,3 +1,5 @@
+// TODO: delete file at the end of EPIX PIX-21277
+
 import { render } from '@1024pix/ember-testing-library';
 import { t } from 'ember-intl/test-support';
 import ListItem from 'pix-admin/components/organizations/children/list-item';

--- a/admin/tests/integration/components/organizations/children/list-test.gjs
+++ b/admin/tests/integration/components/organizations/children/list-test.gjs
@@ -1,3 +1,5 @@
+// TODO: delete file at the end of EPIX PIX-21277
+
 import { render as renderScreen } from '@1024pix/ember-testing-library';
 import { t } from 'ember-intl/test-support';
 import List from 'pix-admin/components/organizations/children/list';

--- a/admin/tests/integration/components/organizations/network-test.gjs
+++ b/admin/tests/integration/components/organizations/network-test.gjs
@@ -1,0 +1,255 @@
+import { fillByLabel, render } from '@1024pix/ember-testing-library';
+import Service from '@ember/service';
+import { click } from '@ember/test-helpers';
+import { t } from 'ember-intl/test-support';
+import Network from 'pix-admin/components/organizations/network';
+import setupIntlRenderingTest from 'pix-admin/tests/helpers/setup-intl-rendering';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module('Integration | Component | organizations/network', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  module('when the admin member has access to organization scope', function (hooks) {
+    let store, network;
+
+    hooks.beforeEach(function () {
+      class AccessControlStub extends Service {
+        hasAccessToOrganizationActionsScope = true;
+        hasAccessToAttachChildOrganizationActionsScope = true;
+      }
+      this.owner.register('service:access-control', AccessControlStub);
+
+      store = this.owner.lookup('service:store');
+      network = store.createRecord('network', { id: 10, name: 'My network' });
+    });
+
+    test('it should display children list and actions section', async function (assert) {
+      // given
+      const organization = store.createRecord('organization', { id: '1', name: 'Parent', network });
+      const child1 = store.createRecord('organization', { id: '2', name: 'Child 1' });
+      const child2 = store.createRecord('organization', { id: '3', name: 'Child 2' });
+      const children = [child1, child2];
+
+      // when
+      const screen = await render(
+        <template><Network @organization={{organization}} @children={{children}} /></template>,
+      );
+
+      // then
+      assert.dom(screen.getByRole('cell', { name: 'Child 1' })).exists();
+      assert.dom(screen.getByRole('cell', { name: 'Child 2' })).exists();
+
+      assert.ok(
+        screen.getByRole('link', { name: t('components.organizations.network.create-child-organization-button') }),
+      );
+    });
+
+    test('it should display an empty message when no children', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const organization = store.createRecord('organization', { id: '1', name: 'Parent' });
+      const children = [];
+
+      // when
+      const screen = await render(
+        <template><Network @organization={{organization}} @children={{children}} /></template>,
+      );
+
+      // then
+      assert.dom(screen.getByText(t('components.organizations.network.empty-table'))).exists();
+    });
+
+    module('when submitting form', function (hooks) {
+      let notificationSuccessStub, notificationErrorStub;
+
+      hooks.beforeEach(function () {
+        notificationSuccessStub = sinon.stub();
+        notificationErrorStub = sinon.stub();
+        class NotificationsStub extends Service {
+          sendSuccessNotification = notificationSuccessStub;
+          sendErrorNotification = notificationErrorStub;
+        }
+
+        this.owner.register('service:pixToast', NotificationsStub);
+      });
+      module('when attachChildOrganization is a success', function () {
+        test('it should reload model and display success notification', async function (assert) {
+          // given
+          const reloadChildrenStub = sinon.stub();
+
+          const parentOrganization = store.createRecord('organization', {
+            id: 1,
+            name: 'Parent Organization Name',
+            features: { PLACES_MANAGEMENT: { active: true } },
+            network,
+            hasMany: sinon.stub(),
+          });
+          const childOrganization = store.createRecord('organization', {
+            id: 2,
+            name: 'Child Organization Name',
+            features: { PLACES_MANAGEMENT: { active: true } },
+          });
+          parentOrganization.hasMany.withArgs('children').returns({ reload: reloadChildrenStub });
+
+          const childOrganizationIdsToFill = `${childOrganization.id}`;
+
+          const adapter = store.adapterFor('organization');
+          const attachChildOrganizationStub = sinon.stub(adapter, 'attachChildOrganization');
+          attachChildOrganizationStub
+            .withArgs({ childOrganizationIds: childOrganizationIdsToFill, parentOrganizationId: parentOrganization.id })
+            .resolves();
+
+          const screen = await render(<template><Network @organization={{parentOrganization}} /></template>);
+
+          await fillByLabel(
+            `${t('components.organizations.network.attach-child-form.input-label')} ${t('components.organizations.network.attach-child-form.input-information')}`,
+            childOrganizationIdsToFill,
+          );
+
+          // when
+          await click(screen.getByRole('button', { name: t('common.actions.add') }));
+
+          // then
+          assert.true(
+            notificationSuccessStub.calledOnceWithExactly({
+              message: t('pages.organization-network.notifications.success.attach-child-organization', { count: 1 }),
+            }),
+          );
+
+          assert.true(reloadChildrenStub.calledOnce);
+        });
+      });
+
+      module('error cases', function () {
+        test('it should display correct error notification for UNABLE_TO_ATTACH_CHILD_ORGANIZATION_TO_ITSELF error code', async function (assert) {
+          // given
+          const parentOrganization = store.createRecord('organization', {
+            id: 1,
+            name: 'Parent Organization Name',
+            features: { PLACES_MANAGEMENT: { active: true } },
+            network,
+            hasMany: sinon.stub(),
+          });
+
+          const adapter = store.adapterFor('organization');
+          const attachChildOrganizationStub = sinon.stub(adapter, 'attachChildOrganization');
+          attachChildOrganizationStub.rejects({
+            errors: [{ code: 'UNABLE_TO_ATTACH_CHILD_ORGANIZATION_TO_ITSELF', meta: { organizationId: '1' } }],
+          });
+
+          const screen = await render(<template><Network @organization={{parentOrganization}} /></template>);
+
+          // when
+          await click(screen.getByRole('button', { name: t('common.actions.add') }));
+
+          // then
+          assert.true(
+            notificationErrorStub.calledOnceWithExactly({
+              message: t(
+                'pages.organization-network.notifications.error.unable-to-attach-child-organization-to-itself',
+                { childOrganizationId: '1' },
+              ),
+            }),
+          );
+        });
+
+        test('it should display correct error notification for UNABLE_TO_ATTACH_ALREADY_ATTACHED_CHILD_ORGANIZATION error code', async function (assert) {
+          // given
+          const parentOrganization = store.createRecord('organization', {
+            id: 1,
+            name: 'Parent Organization Name',
+            features: { PLACES_MANAGEMENT: { active: true } },
+            network,
+            hasMany: sinon.stub(),
+          });
+
+          const alreadyAttachedChildOrganizationId = 99;
+
+          const adapter = store.adapterFor('organization');
+          const attachChildOrganizationStub = sinon.stub(adapter, 'attachChildOrganization');
+          attachChildOrganizationStub.rejects({
+            errors: [
+              {
+                code: 'UNABLE_TO_ATTACH_ALREADY_ATTACHED_CHILD_ORGANIZATION',
+                meta: { organizationId: alreadyAttachedChildOrganizationId },
+              },
+            ],
+          });
+
+          const screen = await render(<template><Network @organization={{parentOrganization}} /></template>);
+
+          // when
+          await click(screen.getByRole('button', { name: t('common.actions.add') }));
+
+          // then
+          assert.true(
+            notificationErrorStub.calledOnceWithExactly({
+              message: t(
+                'pages.organization-network.notifications.error.unable-to-attach-already-attached-child-organization',
+                { childOrganizationId: `${alreadyAttachedChildOrganizationId}` },
+              ),
+            }),
+          );
+        });
+
+        test('it should display generic error notification for any other error code', async function (assert) {
+          // given
+          const parentOrganization = store.createRecord('organization', {
+            id: 1,
+            name: 'Parent Organization Name',
+            features: { PLACES_MANAGEMENT: { active: true } },
+            network,
+            hasMany: sinon.stub(),
+          });
+
+          const adapter = store.adapterFor('organization');
+          const attachChildOrganizationStub = sinon.stub(adapter, 'attachChildOrganization');
+          attachChildOrganizationStub.rejects({
+            errors: [
+              {
+                code: 'DEFAULT_CODE',
+              },
+            ],
+          });
+
+          const screen = await render(<template><Network @organization={{parentOrganization}} /></template>);
+
+          // when
+          await click(screen.getByRole('button', { name: t('common.actions.add') }));
+
+          // then
+          assert.true(
+            notificationErrorStub.calledOnceWithExactly({
+              message: t('common.notifications.generic-error'),
+            }),
+          );
+        });
+      });
+    });
+  });
+
+  module('when the admin member does not have access to organization scope', function () {
+    test('it should not render the actions section', async function (assert) {
+      // given
+      class AccessControlStub extends Service {
+        hasAccessToOrganizationActionsScope = false;
+      }
+      this.owner.register('service:access-control', AccessControlStub);
+
+      const store = this.owner.lookup('service:store');
+      const organization = store.createRecord('organization', { id: '1', name: 'Parent' });
+      const children = [];
+
+      // when
+      const screen = await render(
+        <template><Network @organization={{organization}} @children={{children}} /></template>,
+      );
+
+      // then
+      assert.notOk(
+        screen.queryByRole('link', { name: t('components.organizations.network.create-child-organization-button') }),
+      );
+    });
+  });
+});

--- a/admin/tests/integration/components/organizations/network/actions-section-test.gjs
+++ b/admin/tests/integration/components/organizations/network/actions-section-test.gjs
@@ -1,0 +1,179 @@
+import { render } from '@1024pix/ember-testing-library';
+import Service from '@ember/service';
+import { t } from 'ember-intl/test-support';
+import ActionsSection from 'pix-admin/components/organizations/network/actions-section';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | organizations/network/actions-section', function (hooks) {
+  setupIntlRenderingTest(hooks);
+  let store;
+
+  hooks.beforeEach(async function () {
+    store = this.owner.lookup('service:store');
+  });
+
+  module('create child organization button', function (hooks) {
+    hooks.beforeEach(async function () {
+      class AccessControlStub extends Service {
+        hasAccessToAttachChildOrganizationActionsScope = true;
+      }
+      this.owner.register('service:access-control', AccessControlStub);
+    });
+
+    test('it should display create child organization button when user is superAdmin and organization belongs to a network', async function (assert) {
+      // given
+      const network = store.createRecord('network', { id: '10', name: 'Réseau Test' });
+      const organization = store.createRecord('organization', {
+        id: '1',
+        name: 'Orga 1',
+        network,
+      });
+
+      const onAttachChildSubmitFormStub = sinon.stub();
+
+      // when
+      const screen = await render(
+        <template>
+          <ActionsSection @organization={{organization}} @onAttachChildSubmitForm={{onAttachChildSubmitFormStub}} />
+        </template>,
+      );
+
+      assert.ok(
+        screen.getByRole('link', { name: t('components.organizations.network.create-child-organization-button') }),
+      );
+    });
+
+    test('it should not display create child organization button if organization is already a child', async function (assert) {
+      // given
+      const network = store.createRecord('network', { id: '10', name: 'Réseau Test' });
+      const childOrganization = store.createRecord('organization', {
+        id: '2',
+        name: 'Orga 2',
+        parentOrganizationId: '1234',
+        network,
+      });
+
+      const onAttachChildSubmitFormStub = sinon.stub();
+
+      // when
+      const screen = await render(
+        <template>
+          <ActionsSection
+            @organization={{childOrganization}}
+            @onAttachChildSubmitForm={{onAttachChildSubmitFormStub}}
+          />
+        </template>,
+      );
+
+      assert.notOk(
+        screen.queryByRole('link', { name: t('components.organizations.network.create-child-organization-button') }),
+      );
+    });
+
+    test('it should not display create child organization button when user is not superAdmin', async function (assert) {
+      // given
+      class AccessControlStub extends Service {
+        hasAccessToAttachChildOrganizationActionsScope = false;
+      }
+      this.owner.register('service:access-control', AccessControlStub);
+
+      const network = store.createRecord('network', { id: '10', name: 'Réseau Test' });
+      const organization = store.createRecord('organization', {
+        id: '1',
+        name: 'Orga 1',
+        network,
+      });
+
+      const onAttachChildSubmitFormStub = sinon.stub();
+
+      // when
+      const screen = await render(
+        <template>
+          <ActionsSection @organization={{organization}} @onAttachChildSubmitForm={{onAttachChildSubmitFormStub}} />
+        </template>,
+      );
+
+      assert.notOk(
+        screen.queryByRole('link', { name: t('components.organizations.network.create-child-organization-button') }),
+      );
+    });
+
+    test('it should not display create child organization button when organization does not belong to a network', async function (assert) {
+      // given
+      const organization = store.createRecord('organization', {
+        id: '1',
+        name: 'Orga 1',
+      });
+
+      const onAttachChildSubmitFormStub = sinon.stub();
+
+      // when
+      const screen = await render(
+        <template>
+          <ActionsSection @organization={{organization}} @onAttachChildSubmitForm={{onAttachChildSubmitFormStub}} />
+        </template>,
+      );
+
+      assert.notOk(
+        screen.queryByRole('link', { name: t('components.organizations.network.create-child-organization-button') }),
+      );
+    });
+  });
+
+  module('when user have access to attach child organization actions scope', function () {
+    test('it should display attach child organization form', async function (assert) {
+      // given
+      class AccessControlStub extends Service {
+        hasAccessToAttachChildOrganizationActionsScope = true;
+      }
+      this.owner.register('service:access-control', AccessControlStub);
+
+      const organization = store.createRecord('organization', {
+        id: '1',
+        name: 'Orga 1',
+      });
+
+      const onAttachChildSubmitFormStub = sinon.stub();
+
+      // when
+      const screen = await render(
+        <template>
+          <ActionsSection @organization={{organization}} @onAttachChildSubmitForm={{onAttachChildSubmitFormStub}} />
+        </template>,
+      );
+
+      assert.ok(screen.getByRole('form', { name: t('components.organizations.network.attach-child-form.name') }));
+    });
+
+    module('when user does not have access to attach child organization actions scope', function () {
+      test('it should not display attach child organization form ', async function (assert) {
+        // given
+        class AccessControlStub extends Service {
+          hasAccessToAttachChildOrganizationActionsScope = false;
+        }
+        this.owner.register('service:access-control', AccessControlStub);
+
+        const organization = store.createRecord('organization', {
+          id: '1',
+          name: 'Orga 1',
+        });
+
+        const onAttachChildSubmitFormStub = sinon.stub();
+
+        // when
+        const screen = await render(
+          <template>
+            <ActionsSection @organization={{organization}} @onAttachChildSubmitForm={{onAttachChildSubmitFormStub}} />
+          </template>,
+        );
+
+        assert.notOk(
+          screen.queryByRole('form', { name: t('components.organizations.network.attach-child-form.name') }),
+        );
+      });
+    });
+  });
+});

--- a/admin/tests/integration/components/organizations/network/attach-child-form-test.gjs
+++ b/admin/tests/integration/components/organizations/network/attach-child-form-test.gjs
@@ -1,0 +1,58 @@
+import { render } from '@1024pix/ember-testing-library';
+import { click, fillIn, triggerEvent } from '@ember/test-helpers';
+import AttachChildForm from 'pix-admin/components/organizations/network/attach-child-form';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | organizations/network/attach-child-form', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('should update input value when typing', async function (assert) {
+    // given
+    const onFormSubmitted = sinon.stub();
+
+    // when
+    const screen = await render(<template><AttachChildForm @onFormSubmitted={{onFormSubmitted}} /></template>);
+
+    const input = screen.getByRole('textbox');
+    await fillIn(input, '5432,789');
+
+    // then
+    assert.dom(input).hasValue('5432,789');
+  });
+
+  test('should submit form with input value and reset form', async function (assert) {
+    // given
+    const onFormSubmitted = sinon.stub();
+
+    // when
+    const screen = await render(<template><AttachChildForm @onFormSubmitted={{onFormSubmitted}} /></template>);
+
+    const input = screen.getByRole('textbox');
+    await fillIn(input, '1234');
+    await click(screen.getByRole('button', { name: 'Ajouter' }));
+
+    // then
+    assert.ok(onFormSubmitted.calledOnceWithExactly('1234'));
+    assert.dom(input).hasValue('');
+  });
+
+  test('should prevent default form submission', async function (assert) {
+    // given
+    const onFormSubmitted = sinon.stub();
+
+    // when
+    const screen = await render(<template><AttachChildForm @onFormSubmitted={{onFormSubmitted}} /></template>);
+
+    const input = screen.getByRole('textbox');
+    await fillIn(input, '1234');
+
+    const form = screen.getByRole('form');
+    await triggerEvent(form, 'submit');
+
+    // then
+    assert.ok(onFormSubmitted.called, 'Form submission callback was called');
+  });
+});

--- a/admin/tests/integration/components/organizations/network/list-item-test.gjs
+++ b/admin/tests/integration/components/organizations/network/list-item-test.gjs
@@ -1,0 +1,31 @@
+import { render } from '@1024pix/ember-testing-library';
+import { t } from 'ember-intl/test-support';
+import ListItem from 'pix-admin/components/organizations/network/list-item';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | organizations/network/list-item', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('displays child organization items', async function (assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+    const organization = store.createRecord('organization', {
+      id: '1',
+      name: 'Collège The Night Watch',
+      externalId: 'UA123456',
+    });
+
+    // when
+    const screen = await render(<template><ListItem @childOrganization={{organization}} /></template>);
+
+    // then
+    assert.ok(screen.getByRole('cell', { name: '1' }));
+    assert.ok(screen.getByRole('cell', { name: 'Collège The Night Watch' }));
+    assert.ok(screen.getByRole('cell', { name: 'UA123456' }));
+    assert.notOk(
+      screen.queryByRole('button', { name: t('components.organizations.network.children-list.actions.detach.button') }),
+    );
+  });
+});

--- a/admin/tests/integration/components/organizations/network/list-test.gjs
+++ b/admin/tests/integration/components/organizations/network/list-test.gjs
@@ -1,0 +1,43 @@
+import { render as renderScreen } from '@1024pix/ember-testing-library';
+import { t } from 'ember-intl/test-support';
+import List from 'pix-admin/components/organizations/network/list';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | organizations/network/list', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('display children organizations list', async function (assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+    const organization1 = store.createRecord('organization', {
+      id: '1',
+      name: 'Collège The Night Watch',
+      externalId: 'UA123456',
+    });
+    const organization2 = store.createRecord('organization', {
+      id: '2',
+      name: 'Lycée KingsLanding',
+      externalId: 'UB64321',
+    });
+    const organizations = [organization1, organization2];
+
+    //  when
+    const screen = await renderScreen(<template><List @childOrganizations={{organizations}} /></template>);
+
+    // then
+    assert
+      .dom(screen.getByRole('table', { name: t('components.organizations.network.children-list.table-name') }))
+      .exists();
+
+    assert.dom(screen.getByRole('columnheader', { name: 'ID' })).exists();
+    assert.dom(screen.getByRole('columnheader', { name: 'Nom' })).exists();
+    assert.dom(screen.getByRole('columnheader', { name: 'Identifiant externe' })).exists();
+
+    assert.strictEqual((await screen.findAllByRole('row')).length, 3);
+
+    assert.dom(screen.getByRole('cell', { name: 'Collège The Night Watch' })).exists();
+    assert.dom(screen.getByRole('cell', { name: 'Lycée KingsLanding' })).exists();
+  });
+});

--- a/admin/tests/unit/routes/authenticated/organizations/get/children-test.js
+++ b/admin/tests/unit/routes/authenticated/organizations/get/children-test.js
@@ -1,3 +1,5 @@
+// TODO: delete file at the end of EPIX PIX-21277
+
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -1009,6 +1009,31 @@
       "member-items": {
         "no-last-connection-date-info": "Has not been connected since 03/2025"
       },
+      "network": {
+        "attach-child-form": {
+          "input-information": "ID of organisation(s) to add",
+          "input-label": "Add one or more child organisations",
+          "name": "Add child organisation(s) form"
+        },
+        "children-list": {
+          "actions": {
+            "detach": {
+              "button": "Detach",
+              "confirm-modal-message": "Are you sure you want to detach Orga ID {organizationId}?",
+              "confirm-modal-title": "Detach an organization"
+            }
+          },
+          "table-headers": {
+            "actions": "Actions",
+            "external-id": "External Identifier",
+            "id": "ID",
+            "name": "Name"
+          },
+          "table-name": "List of children organisations"
+        },
+        "create-child-organization-button": "Create a child organization",
+        "empty-table": "No child organisation"
+      },
       "places": {
         "creation": {
           "error-messages": {
@@ -1535,6 +1560,22 @@
     },
     "organization-children": {
       "empty-table": "No child organisation",
+      "notifications": {
+        "error": {
+          "unable-to-attach-already-attached-child-organization": "Child organization {childOrganizationId} already belonging to a network",
+          "unable-to-attach-child-organization-to-another-child-organization": "Unable to attach the child organization to another child organization",
+          "unable-to-attach-child-organization-to-itself": "Unable to attach organization {childOrganizationId} to itself",
+          "unable-to-attach-to-organization-not-in-network": "Unable to attach an organisation to an organisation without a network",
+          "unable-to-detach-child-organization": "An error occurred while detaching the child organization."
+        },
+        "success": {
+          "attach-child-organization": "{count, plural, =1 {The child organization has been linked to the parent organization} other {The {count} child organizations have been linked to the parent organization}}",
+          "detach-child-organization": "The child organization has been successfully detached."
+        }
+      },
+      "title": "Children organisations"
+    },
+    "organization-network": {
       "notifications": {
         "error": {
           "unable-to-attach-already-attached-child-organization": "Child organization {childOrganizationId} already belonging to a network",

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -1011,6 +1011,31 @@
       "member-items": {
         "no-last-connection-date-info": "Non connecté depuis 03/2025"
       },
+      "network": {
+        "attach-child-form": {
+          "input-information": "ID d'organisation(s) à ajouter",
+          "input-label": "Ajouter une ou plusieurs organisations filles",
+          "name": "Formulaire d'ajout d'organisation(s) fille(s)"
+        },
+        "children-list": {
+          "actions": {
+            "detach": {
+              "button": "Détacher",
+              "confirm-modal-message": "Êtes-vous sûr de vouloir détacher l'Orga ID {organizationId} ?",
+              "confirm-modal-title": "Détacher une organisation"
+            }
+          },
+          "table-headers": {
+            "actions": "Actions",
+            "external-id": "Identifiant externe",
+            "id": "ID",
+            "name": "Nom"
+          },
+          "table-name": "Liste des organisations filles"
+        },
+        "create-child-organization-button": "Créer une organisation fille",
+        "empty-table": "Aucune organisation fille"
+      },
       "places": {
         "creation": {
           "error-messages": {
@@ -1538,6 +1563,22 @@
     },
     "organization-children": {
       "empty-table": "Aucune organisation fille",
+      "notifications": {
+        "error": {
+          "unable-to-attach-already-attached-child-organization": "L'organisation fille {childOrganizationId} appartient déjà à un réseau.",
+          "unable-to-attach-child-organization-to-another-child-organization": "Impossible d'attacher l'organisation fille à une autre organisation fille.",
+          "unable-to-attach-child-organization-to-itself": "Impossible d'attacher l'organisation {childOrganizationId} à elle-même",
+          "unable-to-attach-to-organization-not-in-network": "Impossible de rattacher l'organisation fille à une organisation hors réseau.",
+          "unable-to-detach-child-organization": "Une erreur est survenue lors du détachement de l'organisation fille."
+        },
+        "success": {
+          "attach-child-organization": "{count, plural, =1 {L'organisation fille a bien été liée à l'organisation mère} other {Les {count} organisations filles ont bien été liées à l'organisation mère}}",
+          "detach-child-organization": "L'organisation fille a été détachée avec succès."
+        }
+      },
+      "title": "Organisations filles"
+    },
+    "organization-network": {
       "notifications": {
         "error": {
           "unable-to-attach-already-attached-child-organization": "L'organisation fille {childOrganizationId} appartient déjà à un réseau.",

--- a/api/src/organizational-entities/application/http-error-mapper-configuration.js
+++ b/api/src/organizational-entities/application/http-error-mapper-configuration.js
@@ -12,6 +12,7 @@ import {
   OrganizationBatchUpdateError,
   OrganizationLearnerTypeNotFound,
   OrganizationNotFound,
+  StructureNotFoundError,
   TagNotFoundError,
   UnableToAttachChildOrganizationToParentOrganizationError,
   UnableToDetachParentOrganizationFromChildOrganization,
@@ -73,6 +74,10 @@ const organizationalEntitiesDomainErrorMappingConfiguration = [
   {
     name: CountryNotFoundError.name,
     httpErrorFn: (error) => new HttpErrors.NotFoundError(error.message, error.code, error.meta),
+  },
+  {
+    name: StructureNotFoundError.name,
+    httpErrorFn: (error) => new HttpErrors.UnprocessableEntityError(error.message, error.code, error.meta),
   },
 ].map((domainErrorMappingConfiguration) => new DomainErrorMappingConfiguration(domainErrorMappingConfiguration));
 

--- a/api/src/organizational-entities/domain/errors.js
+++ b/api/src/organizational-entities/domain/errors.js
@@ -130,6 +130,14 @@ class NetworkAlreadyExistError extends DomainError {
   }
 }
 
+class StructureNotFoundError extends DomainError {
+  constructor({ code = 'STRUCTURE_NOT_FOUND', message = 'Structure not found', meta } = {}) {
+    super(message);
+    this.code = code;
+    this.meta = meta;
+  }
+}
+
 export {
   AdministrationTeamNotFound,
   ArchiveCertificationCentersInBatchError,
@@ -143,6 +151,7 @@ export {
   OrganizationBatchUpdateError,
   OrganizationLearnerTypeNotFound,
   OrganizationNotFound,
+  StructureNotFoundError,
   TagNotFoundError,
   UnableToAttachChildOrganizationToParentOrganizationError,
   UnableToDetachParentOrganizationFromChildOrganization,

--- a/api/src/organizational-entities/infrastructure/repositories/network.repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/network.repository.js
@@ -1,5 +1,7 @@
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../shared/domain/errors.js';
+import { logger } from '../../../shared/infrastructure/utils/logger.js';
+import { StructureNotFoundError } from '../../domain/errors.js';
 import { Network } from '../../domain/models/Network.js';
 
 /**
@@ -135,6 +137,33 @@ async function attachOrganization({ childOrganizationId, parentOrganizationId })
     .from('fct_structures')
     .where({ organization_id: parentOrganizationId })
     .first();
+
+  const childFactStructure = await knexConn('id, structure_id')
+    .from('fct_structures')
+    .where({ organization_id: childOrganizationId })
+    .first();
+
+  if (!parentFactStructure) {
+    logger.error({
+      event: 'Not_found_structure',
+      message: `Not found structure for organization ${parentOrganizationId}`,
+    });
+    throw new StructureNotFoundError({
+      message: `Structure not found for organization ${parentOrganizationId}`,
+      meta: { organizationId: parentOrganizationId },
+    });
+  }
+
+  if (!childFactStructure) {
+    logger.error({
+      event: 'Not_found_structure',
+      message: `Not found structure for organization ${childOrganizationId}`,
+    });
+    throw new StructureNotFoundError({
+      message: `Structure not found for organization ${childOrganizationId}`,
+      meta: { organizationId: childOrganizationId },
+    });
+  }
 
   await knexConn('fct_structures').where({ organization_id: childOrganizationId }).update({
     network_id: parentFactStructure.network_id,

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/network.repository.test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/network.repository.test.js
@@ -1,3 +1,4 @@
+import { StructureNotFoundError } from '../../../../../src/organizational-entities/domain/errors.js';
 import * as networkRepository from '../../../../../src/organizational-entities/infrastructure/repositories/network.repository.js';
 import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
 import { catchErr, databaseBuilder, domainBuilder, expect, knex } from '../../../../test-helper.js';
@@ -301,6 +302,51 @@ describe('Integration | Organizational Entities | Infrastructure | Repositories 
         network_id: network.id,
         parent_structure_id: parentStructure.id,
         child_structure_id: null,
+      });
+    });
+
+    context('error handling', function () {
+      it('throws when parent organization does not have a structure', async function () {
+        const parentOrganization = databaseBuilder.factory.buildOrganization({ name: 'Parent organization' });
+
+        const { organization: childOrganization } = databaseBuilder.factory.buildOrganizationWithStructure({
+          name: 'Child Organization',
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const error = await catchErr(networkRepository.attachOrganization)({
+          childOrganizationId: childOrganization.id,
+          parentOrganizationId: parentOrganization.id,
+        });
+
+        // then
+        expect(error).to.be.instanceOf(StructureNotFoundError);
+        expect(error.meta).to.deep.equal({ organizationId: parentOrganization.id });
+      });
+
+      it('throws when child organization does not have a structure', async function () {
+        const { organization: parentOrganization } = databaseBuilder.factory.buildNetworkAndHeadOrganization({
+          name: 'My network',
+          headOrganization: { name: 'Parent organization' },
+        });
+
+        const childOrganization = databaseBuilder.factory.buildOrganization({
+          name: 'Child Organization without structure',
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const error = await catchErr(networkRepository.attachOrganization)({
+          childOrganizationId: childOrganization.id,
+          parentOrganizationId: parentOrganization.id,
+        });
+
+        // then
+        expect(error).to.be.instanceOf(StructureNotFoundError);
+        expect(error.meta).to.deep.equal({ organizationId: childOrganization.id });
       });
     });
   });

--- a/api/tests/organizational-entities/unit/application/http-error-mapper-configuration_test.js
+++ b/api/tests/organizational-entities/unit/application/http-error-mapper-configuration_test.js
@@ -2,6 +2,7 @@ import { organizationalEntitiesDomainErrorMappingConfiguration } from '../../../
 import {
   CountryNotFoundError,
   NetworkAlreadyExistError,
+  StructureNotFoundError,
   TagNotFoundError,
   UnableToDetachParentOrganizationFromChildOrganization,
 } from '../../../../src/organizational-entities/domain/errors.js';
@@ -110,6 +111,25 @@ describe('Unit | Organizational Entities | Application | HttpErrorMapperConfigur
       // then
       expect(error).to.be.instanceOf(HttpErrors.ConflictError);
       expect(error.message).to.equal('Network already exists');
+      expect(error.meta).to.equal(meta);
+    });
+  });
+
+  context('when mapping "StructureNotFoundError"', function () {
+    it('should return a UnprocessableEntityError Http Error', function () {
+      // given
+      const httpErrorMapper = organizationalEntitiesDomainErrorMappingConfiguration.find(
+        (httpErrorMapper) => httpErrorMapper.name === StructureNotFoundError.name,
+      );
+
+      const meta = { organizationId: 99 };
+
+      // when
+      const error = httpErrorMapper.httpErrorFn(new StructureNotFoundError({ meta }));
+
+      // then
+      expect(error).to.be.instanceOf(HttpErrors.UnprocessableEntityError);
+      expect(error.message).to.equal('Structure not found');
       expect(error.meta).to.equal(meta);
     });
   });


### PR DESCRIPTION
## (ง'̀-'́)ง - Pour tester
Dans Pix Admin, connecté en tant que Super Admin:
- aller sur la page d'une organisation faisant partie d'un réseau
- sur l'onglet **Réseau**
- constater les boutons d'actions et la liste vide
- vérifier que les mêmes actions sont possibles que sur la page **Organisations filles** (la liste ne se met pas à jour mais c'est normal, voir remarques)

#### Procédure pour tester la gestion d'erreur côté API pour les orgas sans structure (uniquement possible en local et RA)
⚠️ Ne pas executer le script de rattrapage des données `create-structure-for-every-organization.js` sur la RA afin de pouvoir tester la gestion d'erreur
- à l'aide de cette requête à executer en console psql de la RA, noter l'ID d'une orga sans structure
```sql
SELECT id, name
     FROM organizations
     LEFT JOIN fct_structures ON organizations.id = fct_structures.organization_id
     WHERE fct_structures.organization_id IS NULL;
```
- aller sur la page d'une orga faisant partie d'un réseau
- dans l'onglet **Réseau**, tenter de rattacher une orga sans structure
- vérifier l'affichage du toast d'erreur et que l'erreur remontée dans la console du navigateur précise en metadonnées l'ID de l'orga sans structure.

## ¯\\_(ツ)_/¯ - Remarques
- tous les sous composants et tests associés ont aussi été copiés (formulaires de rattachement, tableau des orgas...) et renommés
- les clés de traduction ont aussi été copiées dans de nouvelles clés et adaptées pour refléter la nouvelle arborescence (organizations.network)
- au moment de supprimer l'ancien onglet, on aura ainsi plus qu'à supprimer les composants, sous-composants, clés de traduction et tests relatifs à organization-children
- certains tests ont été _skip_ car non pertinents tant que l'onglet n'est pas visible aux autres rôles
- la liste des orgas filles n'est pas encore alimentée avec le nouveau système (prochain ticket API) mais c'est implémenté tout de même dans les tests
- ⚠️ cette PR remet en lumière un problème lié à nos seeds pour les environnements de RA et de développement local: toutes les organisations ne possèdent pas de structure dans ces environnements. C'est lié au fait que toutes les orgas ne sont pas créées de la même manière dans tous les scopes (par les fonctions de tooling de seeds, directement par les database-builders, par les usecases...) et qu'on ne voulait pas impacter le code des autres scopes en allant créer des structures pour tous. Le problème est que si on essaye de rattacher une orga sans structure à un réseau, aucun update en base n'est fait et aucune erreur n'est lancée quand une structure n'est pas trouvée. On avait décidé de ne pas traiter ce cas d'erreur car il n'existe pas en prod et en recette suite au passage du script de rattrapage, mais il subsiste dans les autres environnements. On décide donc de finalement traiter ces erreurs pour les phases de développement afin de pouvoir facilement identifier le problème. On ajoute également un logger pour ces cas si à l'avenir il se produit en prod, il nous permettra d'être alerté rapidement.

## <(^_^)> - Proposition

Copier le code relatif au contenu de l'onglet **Organisations filles** (children) dans ce nouvel onglet.

## (╯°□°)╯︵ ┻━┻ - Problème

On avait jusqu'à maintenant un onglet **Réseau** vide sur la page d'une organisation.
