### PR TITLE
[TECH] Figer la version de la librairie "axios" dans l'API

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -110,7 +110,7 @@
     "@json2csv/plainjs": "^7.0.2",
     "@pdf-lib/fontkit": "^1.1.1",
     "@xmldom/xmldom": "^0.9.0",
-    "axios": "^1.0.0",
+    "axios": "1.13.6",
     "bcrypt": "^6.0.0",
     "cron-parser": "^5.0.0",
     "datadog-metrics": "^0.12.0",


### PR DESCRIPTION
## (ง'̀-'́)ง - Pour tester
E2E OK

## ¯\\_(ツ)_/¯ - Remarques

PR pour remplacer axios en cours : https://github.com/1024pix/pix/pull/15711

## <(^_^)> - Proposition

J'ai fait
```
❯ npm why axios
axios@1.13.6
node_modules/axios
  axios@"^1.0.0" from the root project
```

Donc pas de peer-dependency. J'ai figé axios à la version actuellement installée dans le package-lock

## (╯°□°)╯︵ ┻━┻ - Problème

Axios a des versions compromises.
