### PR TITLE
[FEATURE] Pouvoir donner une valeur au résultat du volet Externe pour les certifications Pix+ EDU (PIX-21820)

### DIFF
--- a/admin/app/adapters/certification.js
+++ b/admin/app/adapters/certification.js
@@ -30,7 +30,7 @@ export default class Certification extends ApplicationAdapter {
   }
 
   urlForEduExternalJuryResult(certificationCourseId) {
-    return `${this.host}/${this.namespace}/admin/certification-courses/${certificationCourseId}/edu-external-jury-result`;
+    return `${this.host}/${this.namespace}/admin/certification-courses/${certificationCourseId}/edu-v3-external-jury-result`;
   }
 
   urlForEditJuryLevel() {
@@ -56,7 +56,14 @@ export default class Certification extends ApplicationAdapter {
       };
       return this.ajax(this.urlForUpdateJuryComment(snapshot.id), 'POST', { data: payload });
     } else if (snapshot.adapterOptions.updateEduExternalJuryResult) {
-      return this.ajax(this.urlForEduExternalJuryResult(snapshot.id), 'PATCH');
+      const payload = {
+        data: {
+          attributes: {
+            'edu-v3-external-jury-result': snapshot.adapterOptions.eduV3ExternalJuryResult,
+          },
+        },
+      };
+      return this.ajax(this.urlForEduExternalJuryResult(snapshot.id), 'POST', { data: payload });
     } else if (snapshot.adapterOptions.isCertificationCancel) {
       return this.ajax(this.urlForCancelCertification(snapshot.id), 'PATCH');
     } else if (snapshot.adapterOptions.isCertificationUncancel) {

--- a/admin/app/adapters/certification.js
+++ b/admin/app/adapters/certification.js
@@ -29,6 +29,10 @@ export default class Certification extends ApplicationAdapter {
     return `${this.host}/${this.namespace}/admin/certification-courses/${certificationCourseId}/unreject`;
   }
 
+  urlForEduExternalJuryResult(certificationCourseId) {
+    return `${this.host}/${this.namespace}/admin/certification-courses/${certificationCourseId}/edu-external-jury-result`;
+  }
+
   urlForEditJuryLevel() {
     return `${this.host}/${this.namespace}/admin/complementary-certification-course-results`;
   }
@@ -51,6 +55,8 @@ export default class Certification extends ApplicationAdapter {
         },
       };
       return this.ajax(this.urlForUpdateJuryComment(snapshot.id), 'POST', { data: payload });
+    } else if (snapshot.adapterOptions.updateEduExternalJuryResult) {
+      return this.ajax(this.urlForEduExternalJuryResult(snapshot.id), 'PATCH');
     } else if (snapshot.adapterOptions.isCertificationCancel) {
       return this.ajax(this.urlForCancelCertification(snapshot.id), 'PATCH');
     } else if (snapshot.adapterOptions.isCertificationUncancel) {

--- a/admin/app/components/certifications/certification/informations.gjs
+++ b/admin/app/components/certifications/certification/informations.gjs
@@ -1,7 +1,4 @@
 import PixBlock from '@1024pix/pix-ui/components/pix-block';
-import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixIconButton from '@1024pix/pix-ui/components/pix-icon-button';
-import PixSelect from '@1024pix/pix-ui/components/pix-select';
 import { DescriptionList } from 'pix-admin/components/ui/description-list';
 
 import CertificationCompetenceList from '../competence-list';
@@ -9,6 +6,8 @@ import CertificationComments from './comments';
 import CertificationInformationCandidate from './informations/candidate';
 import CertificationInformationGlobalActions from './informations/global-actions';
 import CertificationInformationIssueReports from './informations/issue-reports';
+import PixPlusEduV2Results from './informations/pix-plus-edu-v2-results';
+import PixPlusEduV3Results from './informations/pix-plus-edu-v3-results';
 import CertificationInformationState from './informations/state';
 
 <template>
@@ -38,67 +37,19 @@ import CertificationInformationState from './informations/state';
           {{/if}}
 
           {{#if @certification.complementaryCertificationCourseResultWithExternal}}
-            <div class="certification-information-pix-edu">
-              <h2 class="certification-information__title">Résultats de la certification complémentaire Pix+ Edu</h2>
-              <div class="certification-information-pix-edu__container">
-                <div class="certification-information-pix-edu__card">
-                  <h3>Volet Pix</h3>
-                  <p>
-                    {{@certification.complementaryCertificationCourseResultWithExternal.pixResult}}
-                  </p>
-                </div>
-                <div class="certification-information-pix-edu__card">
-                  <h3>Volet jury</h3>
-                  {{#if @displayJuryLevelSelect}}
-                    <div class="certification-information-pix-edu__jury-level-editor">
-                      <PixSelect
-                        @screenReaderOnly={{true}}
-                        @options={{@juryLevelOptions}}
-                        @value={{@selectedJuryLevel}}
-                        @hideDefaultOption={{true}}
-                        @onChange={{@selectJuryLevel}}
-                        @placeholder="Choisir un niveau"
-                      >
-                        <:label>Sélectionner un niveau</:label>
-                      </PixSelect>
-                      <div>
-                        <PixButton
-                          @variant="secondary"
-                          @size="small"
-                          @triggerAction={{@onCancelJuryLevelEditButtonClick}}
-                        >
-                          Annuler
-                        </PixButton>
-                        <PixButton
-                          @size="small"
-                          @triggerAction={{@onEditJuryLevelSave}}
-                          aria-label="Modifier le niveau du jury"
-                        >
-                          Enregistrer
-                        </PixButton>
-                      </div>
-                    </div>
-                  {{else}}
-                    <div class="certification-information-pix-edu__jury-level">
-                      <p>
-                        {{@certification.complementaryCertificationCourseResultWithExternal.externalResult}}
-                      </p>
-                      {{#if @shouldDisplayJuryLevelEditButton}}
-                        <PixIconButton
-                          @ariaLabel="Modifier le volet jury"
-                          @triggerAction={{@editJury}}
-                          @iconName="edit"
-                        />
-                      {{/if}}
-                    </div>
-                  {{/if}}
-                </div>
-                <div class="certification-information-pix-edu__card">
-                  <h3>Niveau final</h3>
-                  <p>{{@certification.complementaryCertificationCourseResultWithExternal.finalResult}}</p>
-                </div>
-              </div>
-            </div>
+            <PixPlusEduV2Results
+              @certification={{@certification}}
+              @displayJuryLevelSelect={{@displayJuryLevelSelect}}
+              @juryLevelOptions={{@juryLevelOptions}}
+              @selectedJuryLevel={{@selectedJuryLevel}}
+              @selectJuryLevel={{@selectJuryLevel}}
+              @onCancelJuryLevelEditButtonClick={{@onCancelJuryLevelEditButtonClick}}
+              @onEditJuryLevelSave={{@onEditJuryLevelSave}}
+              @shouldDisplayJuryLevelEditButton={{@shouldDisplayJuryLevelEditButton}}
+              @editJury={{@editJury}}
+            />
+          {{else if @certification.isPixPlusEduV3}}
+            <PixPlusEduV3Results />
           {{/if}}
         </div>
       </PixBlock>

--- a/admin/app/components/certifications/certification/informations.gjs
+++ b/admin/app/components/certifications/certification/informations.gjs
@@ -20,7 +20,7 @@ export default class CertificationInformations extends Component {
     return (
       this.args.certification.isPixPlusEdu &&
       this.args.certification.isV3 &&
-      this.args.certification.reachedResultKey !== 'BELOW_MINIMUM'
+      this.args.certification.status === 'validated'
     );
   }
 

--- a/admin/app/components/certifications/certification/informations.gjs
+++ b/admin/app/components/certifications/certification/informations.gjs
@@ -1,4 +1,5 @@
 import PixBlock from '@1024pix/pix-ui/components/pix-block';
+import Component from '@glimmer/component';
 import { DescriptionList } from 'pix-admin/components/ui/description-list';
 
 import CertificationCompetenceList from '../competence-list';
@@ -10,20 +11,31 @@ import PixPlusEduV2Results from './informations/pix-plus-edu-v2-results';
 import PixPlusEduV3Results from './informations/pix-plus-edu-v3-results';
 import CertificationInformationState from './informations/state';
 
-<template>
-  <div class="certification-information">
-    <div class="certification-information__buttons-row">
-      <CertificationInformationGlobalActions @certification={{@certification}} @session={{@session}} />
-    </div>
-    <div class="certification-information__block-row">
-      <CertificationInformationState @certification={{@certification}} @session={{@session}} />
-      <CertificationInformationCandidate @certification={{@certification}} />
-    </div>
+export default class CertificationInformations extends Component {
+  get shouldDisplayV2EduResult() {
+    return this.args.certification.isPixPlusEdu && !this.args.certification.isV3;
+  }
 
-    {{#if @certification.hasComplementaryCertifications}}
-      <PixBlock @variant="admin">
-        <div>
-          {{#if @certification.commonComplementaryCertificationCourseResult}}
+  get shouldDisplayV3EduResult() {
+    return (
+      this.args.certification.isPixPlusEdu &&
+      this.args.certification.isV3 &&
+      this.args.certification.reachedResultKey !== 'BELOW_MINIMUM'
+    );
+  }
+
+  <template>
+    <div class="certification-information">
+      <div class="certification-information__buttons-row">
+        <CertificationInformationGlobalActions @certification={{@certification}} @session={{@session}} />
+      </div>
+      <div class="certification-information__block-row">
+        <CertificationInformationState @certification={{@certification}} @session={{@session}} />
+        <CertificationInformationCandidate @certification={{@certification}} />
+      </div>
+      <div>
+        {{#if @certification.commonComplementaryCertificationCourseResult.content}}
+          <PixBlock @variant="admin">
             <h2 class="certification-information__title">Certification complémentaire</h2>
 
             <DescriptionList
@@ -34,9 +46,10 @@ import CertificationInformationState from './informations/state';
                 {{@certification.commonComplementaryCertificationCourseResult.status}}
               </DescriptionList.Item>
             </DescriptionList>
-          {{/if}}
-
-          {{#if @certification.complementaryCertificationCourseResultWithExternal}}
+          </PixBlock>
+        {{/if}}
+        {{#if this.shouldDisplayV2EduResult}}
+          <PixBlock @variant="admin">
             <PixPlusEduV2Results
               @certification={{@certification}}
               @displayJuryLevelSelect={{@displayJuryLevelSelect}}
@@ -48,33 +61,36 @@ import CertificationInformationState from './informations/state';
               @shouldDisplayJuryLevelEditButton={{@shouldDisplayJuryLevelEditButton}}
               @editJury={{@editJury}}
             />
-          {{else if @certification.isPixPlusEduV3}}
+          </PixBlock>
+        {{/if}}
+        {{#if this.shouldDisplayV3EduResult}}
+          <PixBlock @variant="admin">
             <PixPlusEduV3Results @certification={{@certification}} />
-          {{/if}}
-        </div>
-      </PixBlock>
-    {{/if}}
+          </PixBlock>
+        {{/if}}
+      </div>
 
-    {{#if @certificationIssueReports.length}}
-      <section class="certification-informations__row">
-        <CertificationInformationIssueReports
-          @certificationIssueReports={{@certificationIssueReports}}
-          @certification={{@certification}}
-        />
-      </section>
-    {{/if}}
+      {{#if @certificationIssueReports.length}}
+        <section class="certification-informations__row">
+          <CertificationInformationIssueReports
+            @certificationIssueReports={{@certificationIssueReports}}
+            @certification={{@certification}}
+          />
+        </section>
+      {{/if}}
 
-    <CertificationComments @onJuryCommentSave={{@onJuryCommentSave}} @certification={{@certification}} />
+      <CertificationComments @onJuryCommentSave={{@onJuryCommentSave}} @certification={{@certification}} />
 
-    {{#if @certification.competences.length}}
-      <PixBlock @variant="admin" class="certification-information-results">
-        <h2 class="certification-information__title">Résultats</h2>
+      {{#if @certification.competences.length}}
+        <PixBlock @variant="admin" class="certification-information-results">
+          <h2 class="certification-information__title">Résultats</h2>
 
-        <CertificationCompetenceList
-          @competences={{@certification.competences}}
-          @shouldDisplayPixScore={{@shouldDisplayPixScore}}
-        />
-      </PixBlock>
-    {{/if}}
-  </div>
-</template>
+          <CertificationCompetenceList
+            @competences={{@certification.competences}}
+            @shouldDisplayPixScore={{@shouldDisplayPixScore}}
+          />
+        </PixBlock>
+      {{/if}}
+    </div>
+  </template>
+}

--- a/admin/app/components/certifications/certification/informations.gjs
+++ b/admin/app/components/certifications/certification/informations.gjs
@@ -49,7 +49,7 @@ import CertificationInformationState from './informations/state';
               @editJury={{@editJury}}
             />
           {{else if @certification.isPixPlusEduV3}}
-            <PixPlusEduV3Results />
+            <PixPlusEduV3Results @certification={{@certification}} />
           {{/if}}
         </div>
       </PixBlock>

--- a/admin/app/components/certifications/certification/informations/pix-plus-edu-v2-results.gjs
+++ b/admin/app/components/certifications/certification/informations/pix-plus-edu-v2-results.gjs
@@ -27,18 +27,10 @@ import PixSelect from '@1024pix/pix-ui/components/pix-select';
               <:label>Sélectionner un niveau</:label>
             </PixSelect>
             <div>
-              <PixButton
-                @variant="secondary"
-                @size="small"
-                @triggerAction={{@onCancelJuryLevelEditButtonClick}}
-              >
+              <PixButton @variant="secondary" @size="small" @triggerAction={{@onCancelJuryLevelEditButtonClick}}>
                 Annuler
               </PixButton>
-              <PixButton
-                @size="small"
-                @triggerAction={{@onEditJuryLevelSave}}
-                aria-label="Modifier le niveau du jury"
-              >
+              <PixButton @size="small" @triggerAction={{@onEditJuryLevelSave}} aria-label="Modifier le niveau du jury">
                 Enregistrer
               </PixButton>
             </div>
@@ -49,11 +41,7 @@ import PixSelect from '@1024pix/pix-ui/components/pix-select';
               {{@certification.complementaryCertificationCourseResultWithExternal.externalResult}}
             </p>
             {{#if @shouldDisplayJuryLevelEditButton}}
-              <PixIconButton
-                @ariaLabel="Modifier le volet jury"
-                @triggerAction={{@editJury}}
-                @iconName="edit"
-              />
+              <PixIconButton @ariaLabel="Modifier le volet jury" @triggerAction={{@editJury}} @iconName="edit" />
             {{/if}}
           </div>
         {{/if}}

--- a/admin/app/components/certifications/certification/informations/pix-plus-edu-v2-results.gjs
+++ b/admin/app/components/certifications/certification/informations/pix-plus-edu-v2-results.gjs
@@ -1,0 +1,67 @@
+import PixButton from '@1024pix/pix-ui/components/pix-button';
+import PixIconButton from '@1024pix/pix-ui/components/pix-icon-button';
+import PixSelect from '@1024pix/pix-ui/components/pix-select';
+
+<template>
+  <div class="certification-information-pix-edu">
+    <h2 class="certification-information__title">Résultats de la certification complémentaire Pix+ Edu</h2>
+    <div class="certification-information-pix-edu__container">
+      <div class="certification-information-pix-edu__card">
+        <h3>Volet Pix</h3>
+        <p>
+          {{@certification.complementaryCertificationCourseResultWithExternal.pixResult}}
+        </p>
+      </div>
+      <div class="certification-information-pix-edu__card">
+        <h3>Volet jury</h3>
+        {{#if @displayJuryLevelSelect}}
+          <div class="certification-information-pix-edu__jury-level-editor">
+            <PixSelect
+              @screenReaderOnly={{true}}
+              @options={{@juryLevelOptions}}
+              @value={{@selectedJuryLevel}}
+              @hideDefaultOption={{true}}
+              @onChange={{@selectJuryLevel}}
+              @placeholder="Choisir un niveau"
+            >
+              <:label>Sélectionner un niveau</:label>
+            </PixSelect>
+            <div>
+              <PixButton
+                @variant="secondary"
+                @size="small"
+                @triggerAction={{@onCancelJuryLevelEditButtonClick}}
+              >
+                Annuler
+              </PixButton>
+              <PixButton
+                @size="small"
+                @triggerAction={{@onEditJuryLevelSave}}
+                aria-label="Modifier le niveau du jury"
+              >
+                Enregistrer
+              </PixButton>
+            </div>
+          </div>
+        {{else}}
+          <div class="certification-information-pix-edu__jury-level">
+            <p>
+              {{@certification.complementaryCertificationCourseResultWithExternal.externalResult}}
+            </p>
+            {{#if @shouldDisplayJuryLevelEditButton}}
+              <PixIconButton
+                @ariaLabel="Modifier le volet jury"
+                @triggerAction={{@editJury}}
+                @iconName="edit"
+              />
+            {{/if}}
+          </div>
+        {{/if}}
+      </div>
+      <div class="certification-information-pix-edu__card">
+        <h3>Niveau final</h3>
+        <p>{{@certification.complementaryCertificationCourseResultWithExternal.finalResult}}</p>
+      </div>
+    </div>
+  </div>
+</template>

--- a/admin/app/components/certifications/certification/informations/pix-plus-edu-v3-results.gjs
+++ b/admin/app/components/certifications/certification/informations/pix-plus-edu-v3-results.gjs
@@ -14,7 +14,11 @@ export default class PixPlusEduV3Results extends Component {
   @service pixToast;
 
   @tracked displayJurySelect = false;
-  @tracked selectedJuryLevel = this.args.certification.reachedResultKey.split('.').at(-1);
+  @tracked selectedJuryLevel = this.initialJuryLevel;
+
+  get initialJuryLevel() {
+    return this.args.certification.reachedResultKey.split('.').at(-1);
+  }
 
   get hasExternalJuryResult() {
     return this.args.certification.reachedResultKey.includes('0');
@@ -48,16 +52,28 @@ export default class PixPlusEduV3Results extends Component {
   async updateExternalJuryResult(event) {
     event.preventDefault();
     try {
-      await this.args.certification.save({ adapterOptions: { updateEduExternalJuryResult: true } });
+      await this.args.certification.save({
+        adapterOptions: {
+          updateEduExternalJuryResult: true,
+          eduV3ExternalJuryResult: this.selectedJuryLevel,
+        },
+      });
       this.pixToast.sendSuccessNotification({
         message: this.intl.t('components.certifications.edu-results.v3.success'),
       });
       this.toggleJurySelect();
-    } catch {
-      this.pixToast.sendErrorNotification({
-        message: this.intl.t('components.certifications.edu-results.v3.error'),
-      });
+    } catch (responseError) {
+      const errorMessage =
+        responseError?.errors?.[0]?.detail ??
+        this.intl.t('components.certifications.edu-results.v3.error');
+      this.pixToast.sendErrorNotification({ message: errorMessage });
     }
+  }
+
+  @action
+  handleFormReset() {
+    this.selectedJuryLevel = this.initialJuryLevel;
+    this.toggleJurySelect();
   }
 
   <template>
@@ -73,7 +89,7 @@ export default class PixPlusEduV3Results extends Component {
           {{#if this.displayJurySelect}}
             <form
               {{on "submit" this.updateExternalJuryResult}}
-              {{on "reset" this.toggleJurySelect}}
+              {{on "reset" this.handleFormReset}}
               class="certification-information-pix-edu__jury-level-editor"
             >
               <PixSelect
@@ -87,7 +103,7 @@ export default class PixPlusEduV3Results extends Component {
                 <:label>{{t "components.certifications.edu-results.v3.select"}}</:label>
               </PixSelect>
               <div class="actions">
-                <PixButton @variant="secondary" @size="small" @type="reset">
+                <PixButton @variant="secondary" @size="small" type="reset">
                   Annuler
                 </PixButton>
                 <PixButton @type="submit" @size="small" @aria-label="Modifier le niveau du jury">

--- a/admin/app/components/certifications/certification/informations/pix-plus-edu-v3-results.gjs
+++ b/admin/app/components/certifications/certification/informations/pix-plus-edu-v3-results.gjs
@@ -64,8 +64,7 @@ export default class PixPlusEduV3Results extends Component {
       this.toggleJurySelect();
     } catch (responseError) {
       const errorMessage =
-        responseError?.errors?.[0]?.detail ??
-        this.intl.t('components.certifications.edu-results.v3.error');
+        responseError?.errors?.[0]?.detail ?? this.intl.t('components.certifications.edu-results.v3.error');
       this.pixToast.sendErrorNotification({ message: errorMessage });
     }
   }
@@ -116,18 +115,23 @@ export default class PixPlusEduV3Results extends Component {
               <p class="level">
                 {{this.externalJuryResult}}
               </p>
-              <PixTooltip>
+              <PixTooltip @isWide={{true}}>
                 <:triggerElement>
                   <PixIconButton
                     @size="xsmall"
                     @ariaLabel="Modifier le volet jury"
                     @triggerAction={{this.toggleJurySelect}}
                     @iconName="edit"
+                    @isDisabled={{if @certification.isPublished false true}}
                   />
                 </:triggerElement>
 
                 <:tooltip>
-                  {{t "common.actions.edit"}}
+                  {{#if @certification.isPublished}}
+                    {{t "common.actions.edit"}}
+                  {{else}}
+                    {{t "components.certifications.edu-results.v3.edit-disabled"}}
+                  {{/if}}
                 </:tooltip>
               </PixTooltip>
             </div>

--- a/admin/app/components/certifications/certification/informations/pix-plus-edu-v3-results.gjs
+++ b/admin/app/components/certifications/certification/informations/pix-plus-edu-v3-results.gjs
@@ -1,3 +1,84 @@
-<template>
-  <p>Ici bientôt les résultats d'un pix Plus Édu en v3 !</p>
-</template>
+import PixButton from '@1024pix/pix-ui/components/pix-button';
+import PixIconButton from '@1024pix/pix-ui/components/pix-icon-button';
+import PixSelect from '@1024pix/pix-ui/components/pix-select';
+import { on } from '@ember/modifier';
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+export default class PixPlusEduV3Results extends Component {
+  @tracked displayJurySelect = false;
+  @tracked selectedJuryLevel = this.args.certification.externalJuryResultKey;
+
+  @action
+  changeJurySelect(value) {
+    console.log(value);
+    this.selectedJuryLevel = value;
+  }
+
+  @action
+  toggleJurySelect() {
+    console.log('la ?');
+    this.displayJurySelect = !this.displayJurySelect;
+  }
+
+  @action
+  updateExternalJuryResult(event) {
+    console.log('call update external jury result', this.selectedJuryLevel);
+    event.preventDefault();
+  }
+
+  <template>
+    <div class="certification-information-pix-edu">
+      <h2 class="certification-information__title">Résultats de la certification complémentaire Pix+ Edu</h2>
+      <div class="certification-information-pix-edu__container">
+        <div class="certification-information-pix-edu__card">
+          <h3>Volet Pix</h3>
+          <p>
+            {{@certification.result}}
+          </p>
+        </div>
+        <div class="certification-information-pix-edu__card">
+          <h3>Volet jury externe</h3>
+          {{#if this.displayJurySelect}}
+            <form
+              {{on "submit" this.updateExternalJuryResult}}
+              {{on "reset" this.toggleJurySelect}}
+              class="certification-information-pix-edu__jury-level-editor"
+            >
+              <PixSelect
+                @screenReaderOnly={{true}}
+                @options={{@certification.externalJuryResultOptions}}
+                @value={{this.selectedJuryLevel}}
+                @hideDefaultOption={{true}}
+                @onChange={{this.changeJurySelect}}
+                @placeholder="Choisir un niveau"
+              >
+                <:label>Sélectionner un niveau</:label>
+              </PixSelect>
+              <div>
+                <PixButton @variant="secondary" @size="small" @type="reset">
+                  Annuler
+                </PixButton>
+                <PixButton @type="submit" @size="small" @aria-label="Modifier le niveau du jury">
+                  Enregistrer
+                </PixButton>
+              </div>
+            </form>
+          {{else}}
+            <div class="certification-information-pix-edu__jury-level">
+              <p>
+                {{@certification.externalJuryResult}}
+              </p>
+              <PixIconButton
+                @ariaLabel="Modifier le volet jury"
+                @triggerAction={{this.toggleJurySelect}}
+                @iconName="edit"
+              />
+            </div>
+          {{/if}}
+        </div>
+      </div>
+    </div>
+  </template>
+}

--- a/admin/app/components/certifications/certification/informations/pix-plus-edu-v3-results.gjs
+++ b/admin/app/components/certifications/certification/informations/pix-plus-edu-v3-results.gjs
@@ -1,45 +1,75 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixIconButton from '@1024pix/pix-ui/components/pix-icon-button';
 import PixSelect from '@1024pix/pix-ui/components/pix-select';
+import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
+import { t } from 'ember-intl';
 
 export default class PixPlusEduV3Results extends Component {
+  @service intl;
+  @service pixToast;
+
   @tracked displayJurySelect = false;
-  @tracked selectedJuryLevel = this.args.certification.externalJuryResultKey;
+  @tracked selectedJuryLevel = this.args.certification.reachedResultKey.split('.').at(-1);
+
+  get hasExternalJuryResult() {
+    return this.args.certification.reachedResultKey.includes('0');
+  }
+
+  get externalJuryResult() {
+    if (this.hasExternalJuryResult) {
+      return this.intl.t('components.certifications.edu-results.v3.waiting');
+    }
+    return this.intl.t(`common.certification.meshLevels.${this.args.certification.reachedResultKey}`);
+  }
+
+  get externalJuryResultOptions() {
+    return ['UNSET', 'ADVANCED', 'EXPERT'].map((optionKey) => ({
+      value: optionKey,
+      label: this.intl.t(`components.certifications.edu-results.v3.external-jury-select-options.${optionKey}`),
+    }));
+  }
 
   @action
   changeJurySelect(value) {
-    console.log(value);
     this.selectedJuryLevel = value;
   }
 
   @action
   toggleJurySelect() {
-    console.log('la ?');
     this.displayJurySelect = !this.displayJurySelect;
   }
 
   @action
-  updateExternalJuryResult(event) {
-    console.log('call update external jury result', this.selectedJuryLevel);
+  async updateExternalJuryResult(event) {
     event.preventDefault();
+    try {
+      await this.args.certification.save({ adapterOptions: { updateEduExternalJuryResult: true } });
+      this.pixToast.sendSuccessNotification({
+        message: this.intl.t('components.certifications.edu-results.v3.success'),
+      });
+      this.toggleJurySelect();
+    } catch {
+      this.pixToast.sendErrorNotification({
+        message: this.intl.t('components.certifications.edu-results.v3.error'),
+      });
+    }
   }
 
   <template>
     <div class="certification-information-pix-edu">
-      <h2 class="certification-information__title">Résultats de la certification complémentaire Pix+ Edu</h2>
+      <h2 class="certification-information__title">{{t "components.certifications.edu-results.v3.title"}}</h2>
       <div class="certification-information-pix-edu__container">
         <div class="certification-information-pix-edu__card">
-          <h3>Volet Pix</h3>
-          <p>
-            {{@certification.result}}
-          </p>
+          <h3 class="title">{{t "components.certifications.edu-results.v3.internal-jury"}}</h3>
+          <p class="level">{{t "components.certifications.edu-results.v3.admissible"}}</p>
         </div>
         <div class="certification-information-pix-edu__card">
-          <h3>Volet jury externe</h3>
+          <h3 class="title">{{t "components.certifications.edu-results.v3.external-jury"}}</h3>
           {{#if this.displayJurySelect}}
             <form
               {{on "submit" this.updateExternalJuryResult}}
@@ -48,15 +78,15 @@ export default class PixPlusEduV3Results extends Component {
             >
               <PixSelect
                 @screenReaderOnly={{true}}
-                @options={{@certification.externalJuryResultOptions}}
+                @options={{this.externalJuryResultOptions}}
                 @value={{this.selectedJuryLevel}}
                 @hideDefaultOption={{true}}
                 @onChange={{this.changeJurySelect}}
-                @placeholder="Choisir un niveau"
+                @placeholder={{t "components.certifications.edu-results.v3.waiting"}}
               >
-                <:label>Sélectionner un niveau</:label>
+                <:label>{{t "components.certifications.edu-results.v3.select"}}</:label>
               </PixSelect>
-              <div>
+              <div class="actions">
                 <PixButton @variant="secondary" @size="small" @type="reset">
                   Annuler
                 </PixButton>
@@ -67,14 +97,23 @@ export default class PixPlusEduV3Results extends Component {
             </form>
           {{else}}
             <div class="certification-information-pix-edu__jury-level">
-              <p>
-                {{@certification.externalJuryResult}}
+              <p class="level">
+                {{this.externalJuryResult}}
               </p>
-              <PixIconButton
-                @ariaLabel="Modifier le volet jury"
-                @triggerAction={{this.toggleJurySelect}}
-                @iconName="edit"
-              />
+              <PixTooltip>
+                <:triggerElement>
+                  <PixIconButton
+                    @size="xsmall"
+                    @ariaLabel="Modifier le volet jury"
+                    @triggerAction={{this.toggleJurySelect}}
+                    @iconName="edit"
+                  />
+                </:triggerElement>
+
+                <:tooltip>
+                  {{t "common.actions.edit"}}
+                </:tooltip>
+              </PixTooltip>
             </div>
           {{/if}}
         </div>

--- a/admin/app/components/certifications/certification/informations/pix-plus-edu-v3-results.gjs
+++ b/admin/app/components/certifications/certification/informations/pix-plus-edu-v3-results.gjs
@@ -8,6 +8,7 @@ import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
+import { not } from 'ember-truth-helpers';
 
 export default class PixPlusEduV3Results extends Component {
   @service intl;
@@ -17,15 +18,16 @@ export default class PixPlusEduV3Results extends Component {
   @tracked selectedJuryLevel = this.initialJuryLevel;
 
   get initialJuryLevel() {
-    return this.args.certification.reachedResultKey.split('.').at(-1);
+    const level = this.args.certification.reachedResultKey.split('.').at(-1);
+    return level === '0' ? 'UNSET' : level;
   }
 
-  get hasExternalJuryResult() {
-    return this.args.certification.reachedResultKey.includes('0');
+  get isExternalJuryResultPending() {
+    return this.initialJuryLevel === 'UNSET';
   }
 
   get externalJuryResult() {
-    if (this.hasExternalJuryResult) {
+    if (this.isExternalJuryResultPending) {
       return this.intl.t('components.certifications.edu-results.v3.waiting');
     }
     return this.intl.t(`common.certification.meshLevels.${this.args.certification.reachedResultKey}`);
@@ -55,7 +57,7 @@ export default class PixPlusEduV3Results extends Component {
       await this.args.certification.save({
         adapterOptions: {
           updateEduExternalJuryResult: true,
-          eduV3ExternalJuryResult: this.selectedJuryLevel,
+          eduV3ExternalJuryResult: this.selectedJuryLevel === 'UNSET' ? null : this.selectedJuryLevel,
         },
       });
       this.pixToast.sendSuccessNotification({
@@ -103,10 +105,10 @@ export default class PixPlusEduV3Results extends Component {
               </PixSelect>
               <div class="actions">
                 <PixButton @variant="secondary" @size="small" type="reset">
-                  Annuler
+                  {{t "common.actions.cancel"}}
                 </PixButton>
-                <PixButton @type="submit" @size="small" @aria-label="Modifier le niveau du jury">
-                  Enregistrer
+                <PixButton @type="submit" @size="small">
+                  {{t "common.actions.save"}}
                 </PixButton>
               </div>
             </form>
@@ -119,10 +121,10 @@ export default class PixPlusEduV3Results extends Component {
                 <:triggerElement>
                   <PixIconButton
                     @size="xsmall"
-                    @ariaLabel="Modifier le volet jury"
+                    @ariaLabel={{t "components.certifications.edu-results.v3.edit-external-jury"}}
                     @triggerAction={{this.toggleJurySelect}}
                     @iconName="edit"
-                    @isDisabled={{if @certification.isPublished false true}}
+                    @isDisabled={{not @certification.isPublished}}
                   />
                 </:triggerElement>
 

--- a/admin/app/components/certifications/certification/informations/pix-plus-edu-v3-results.gjs
+++ b/admin/app/components/certifications/certification/informations/pix-plus-edu-v3-results.gjs
@@ -1,0 +1,3 @@
+<template>
+  <p>Ici bientôt les résultats d'un pix Plus Édu en v3 !</p>
+</template>

--- a/admin/app/controllers/authenticated/sessions/certification/informations.js
+++ b/admin/app/controllers/authenticated/sessions/certification/informations.js
@@ -24,7 +24,7 @@ export default class CertificationInformationsController extends Controller {
       .get('defaultJuryOptions')
       .map((value) => ({
         value,
-        label: this.intl.t(`components.certifications.v2.external-jury-select-options.${value}`),
+        label: this.intl.t(`components.certifications.edu-results.v2.external-jury-select-options.${value}`),
       }));
     return [
       ...this.certification.complementaryCertificationCourseResultWithExternal.get('allowedExternalLevels'),

--- a/admin/app/controllers/authenticated/sessions/certification/informations.js
+++ b/admin/app/controllers/authenticated/sessions/certification/informations.js
@@ -24,7 +24,7 @@ export default class CertificationInformationsController extends Controller {
       .get('defaultJuryOptions')
       .map((value) => ({
         value,
-        label: this.intl.t(`components.certifications.external-jury-select-options.${value}`),
+        label: this.intl.t(`components.certifications.v2.external-jury-select-options.${value}`),
       }));
     return [
       ...this.certification.complementaryCertificationCourseResultWithExternal.get('allowedExternalLevels'),

--- a/admin/app/models/certification.js
+++ b/admin/app/models/certification.js
@@ -52,7 +52,6 @@ export default class Certification extends Model {
   @attr('boolean', { defaultValue: false }) isPublished;
   @attr('number') version;
   @attr('string') certificationFramework;
-  @attr('string') eduV3ExternalJuryResult;
 
   @belongsTo('complementary-certification-course-result-with-external', { async: true, inverse: null })
   complementaryCertificationCourseResultWithExternal;
@@ -63,18 +62,6 @@ export default class Certification extends Model {
 
   get creationDate() {
     return this.intl.formatDate(this.createdAt, { format: 'long' });
-  }
-
-  get externalJuryResult() {
-    const externalJuryResult = this.eduV3ExternalJuryResult || 'UNSET';
-    return this.intl.t(`components.certifications.v3.external-jury-select-options.${externalJuryResult}`);
-  }
-
-  get externalJuryResultOptions() {
-    return ['UNSET', 'ADVANCED', 'EXPERT'].map((optionKey) => ({
-      value: optionKey,
-      label: this.intl.t(`components.certifications.v3.external-jury-select-options.${optionKey}`),
-    }));
   }
 
   get completionDate() {
@@ -98,14 +85,6 @@ export default class Certification extends Model {
 
   get isCertificationCancelled() {
     return this.status === assessmentResultStatus.CANCELLED;
-  }
-
-  get hasComplementaryCertifications() {
-    return (
-      this.isPixPlusEduV3 ||
-      Boolean(this.commonComplementaryCertificationCourseResult.content) ||
-      Boolean(this.complementaryCertificationCourseResultWithExternal.get('pixResult'))
-    );
   }
 
   get indexedCompetences() {
@@ -136,8 +115,8 @@ export default class Certification extends Model {
     });
   }
 
-  get isPixPlusEduV3() {
-    return ['EDU_1ER_DEGRE', 'EDU_2ND_DEGRE', 'EDU_CPE'].includes(this.certificationFramework) && this.isV3;
+  get isPixPlusEdu() {
+    return ['EDU_1ER_DEGRE', 'EDU_2ND_DEGRE', 'EDU_CPE'].includes(this.certificationFramework);
   }
 
   wasBornInFrance() {

--- a/admin/app/models/certification.js
+++ b/admin/app/models/certification.js
@@ -122,6 +122,10 @@ export default class Certification extends Model {
     });
   }
 
+  get isPixPlusEduV3() {
+    return ['EDU_1ER_DEGRE', 'EDU_2ND_DEGRE', 'EDU_CPE'].includes(this.certificationFramework) && this.isV3;
+  }
+
   wasBornInFrance() {
     return this.birthCountry === 'FRANCE';
   }

--- a/admin/app/models/certification.js
+++ b/admin/app/models/certification.js
@@ -52,6 +52,7 @@ export default class Certification extends Model {
   @attr('boolean', { defaultValue: false }) isPublished;
   @attr('number') version;
   @attr('string') certificationFramework;
+  @attr('string') eduV3ExternalJuryResult;
 
   @belongsTo('complementary-certification-course-result-with-external', { async: true, inverse: null })
   complementaryCertificationCourseResultWithExternal;
@@ -62,6 +63,18 @@ export default class Certification extends Model {
 
   get creationDate() {
     return this.intl.formatDate(this.createdAt, { format: 'long' });
+  }
+
+  get externalJuryResult() {
+    const externalJuryResult = this.eduV3ExternalJuryResult || 'UNSET';
+    return this.intl.t(`components.certifications.v3.external-jury-select-options.${externalJuryResult}`);
+  }
+
+  get externalJuryResultOptions() {
+    return ['UNSET', 'ADVANCED', 'EXPERT'].map((optionKey) => ({
+      value: optionKey,
+      label: this.intl.t(`components.certifications.v3.external-jury-select-options.${optionKey}`),
+    }));
   }
 
   get completionDate() {

--- a/admin/app/models/certification.js
+++ b/admin/app/models/certification.js
@@ -89,6 +89,7 @@ export default class Certification extends Model {
 
   get hasComplementaryCertifications() {
     return (
+      this.isPixPlusEduV3 ||
       Boolean(this.commonComplementaryCertificationCourseResult.content) ||
       Boolean(this.complementaryCertificationCourseResultWithExternal.get('pixResult'))
     );

--- a/admin/app/styles/authenticated/certifications/certification/informations.scss
+++ b/admin/app/styles/authenticated/certifications/certification/informations.scss
@@ -51,49 +51,46 @@
   &__container {
     display: flex;
     gap: var(--pix-spacing-4x);
-    margin-top: var(--pix-spacing-4x);
+    margin-top: var(--pix-spacing-6x);
   }
 
   &__card {
-    display: flex;
     flex: 1;
-    flex-direction: column;
-    gap: var(--pix-spacing-2x);
-    padding: var(--pix-spacing-4x) 0;
+    padding: var(--pix-spacing-6x) var(--pix-spacing-2x);
     font-weight: 500;
     text-align: center;
     background-color: var(--pix-neutral-20);
     border-radius: var(--pix-spacing-2x);
 
-    h3 {
-      @extend %pix-title-xs;
+    .title {
+      @extend %pix-title-xxs;
 
+      margin-bottom: var(--pix-spacing-2x);
       color: var(--pix-neutral-500);
-      text-transform: uppercase;
+    }
+
+    .level {
+      @extend %pix-body-m;
+
+      color: var(--pix-neutral-900);
+      font-weight: bold;
     }
   }
 
   &__jury-level {
     display: flex;
-    align-items: start;
+    align-items: center;
     justify-content: center;
+    gap: var(--pix-spacing-2x);
   }
 
   &__jury-level-editor {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    max-width: 100%;
-    padding: 0 8px;
-
-    section:nth-of-type(2) {
+    .actions {
       display: flex;
-      gap: 1rem;
-      margin: 8px 0;
-
-      button:last-child {
-        flex: 2;
-      }
+      justify-content: center;
+      align-items: center;
+      gap: var(--pix-spacing-2x);
+      margin-top: var(--pix-spacing-4x);
     }
   }
 }

--- a/admin/app/styles/authenticated/certifications/certification/informations.scss
+++ b/admin/app/styles/authenticated/certifications/certification/informations.scss
@@ -79,17 +79,17 @@
 
   &__jury-level {
     display: flex;
+    gap: var(--pix-spacing-2x);
     align-items: center;
     justify-content: center;
-    gap: var(--pix-spacing-2x);
   }
 
   &__jury-level-editor {
     .actions {
       display: flex;
-      justify-content: center;
-      align-items: center;
       gap: var(--pix-spacing-2x);
+      align-items: center;
+      justify-content: center;
       margin-top: var(--pix-spacing-4x);
     }
   }

--- a/admin/tests/acceptance/authenticated/sessions/certification/informations-test.js
+++ b/admin/tests/acceptance/authenticated/sessions/certification/informations-test.js
@@ -302,6 +302,7 @@ module('Acceptance | Route | routes/authenticated/sessions/certification | infor
         test('should be possible to update jury level', async function (assert) {
           //given
           await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+          certification.update({ certificationFramework: 'EDU_1ER_DEGRE' });
           const complementaryCertificationCourseResultWithExternal = server.create(
             'complementary-certification-course-result-with-external',
             {
@@ -344,6 +345,7 @@ module('Acceptance | Route | routes/authenticated/sessions/certification | infor
         test('should be possible to unset jury level', async function (assert) {
           //given
           await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+          certification.update({ certificationFramework: 'EDU_1ER_DEGRE' });
           const complementaryCertificationCourseResultWithExternal = server.create(
             'complementary-certification-course-result-with-external',
             {
@@ -404,6 +406,7 @@ module('Acceptance | Route | routes/authenticated/sessions/certification | infor
         test('it should not display previously opened jury level options', async function (assert) {
           //given
           await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+          certification.update({ certificationFramework: 'EDU_1ER_DEGRE' });
           this.server.create('user', { id: 777 });
           this.server.create('user', { id: 666 });
           const juryCertificationSummaries = [
@@ -435,6 +438,7 @@ module('Acceptance | Route | routes/authenticated/sessions/certification | infor
             id: 398,
             sessionId: session.id,
             userId: 777,
+            certificationFramework: 'EDU_1ER_DEGRE',
             complementaryCertificationCourseResultWithExternal: complementaryCertificationCourseResultWithExternal1,
             competencesWithMark: [],
           });
@@ -459,6 +463,7 @@ module('Acceptance | Route | routes/authenticated/sessions/certification | infor
             id: 456,
             userId: 666,
             sessionId: session.id,
+            certificationFramework: 'EDU_2ND_DEGRE',
             complementaryCertificationCourseResultWithExternal: complementaryCertificationCourseResultWithExternal2,
             competencesWithMark: [],
           });
@@ -507,6 +512,7 @@ module('Acceptance | Route | routes/authenticated/sessions/certification | infor
       test('it displays external complementary certifications', async function (assert) {
         // given
         await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+        certification.update({ certificationFramework: 'EDU_1ER_DEGRE' });
         const complementaryCertificationCourseResultWithExternal = server.create(
           'complementary-certification-course-result-with-external',
           {
@@ -530,6 +536,33 @@ module('Acceptance | Route | routes/authenticated/sessions/certification | infor
         assert.dom(screen.getByText('Niveau final')).exists();
         assert.strictEqual(screen.getAllByText('Pix+ Édu Initié (entrée dans le métier)').length, 2);
         assert.strictEqual(screen.getAllByText('Pix+ Édu Avancé').length, 1);
+      });
+    });
+
+    module('when certification is v3 Pix+ Edu', function () {
+      test('should be possible to update the external jury level', async function (assert) {
+        // given
+        await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+        certification.update({
+          version: 3,
+          isPublished: true,
+          certificationFramework: 'EDU_1ER_DEGRE',
+          reachedResultKey: 'PIX_EDU_FORMATION_INITIALE_1ER_DEGRE.0',
+        });
+
+        const screen = await visit(`/sessions/certification/${certification.id}`);
+
+        // when
+        await click(screen.getByRole('button', { name: 'Modifier le volet jury' }));
+
+        await click(screen.getByRole('button', { name: 'Sélectionner un niveau' }));
+        await screen.findByRole('listbox');
+        await click(screen.getByRole('option', { name: 'Avancé' }));
+
+        await clickByName('Enregistrer');
+
+        // then
+        assert.dom(await screen.findByText('Le résultat du volet jury externe a bien été enregistré')).exists();
       });
     });
 

--- a/admin/tests/integration/components/certifications/certification/informations-test.gjs
+++ b/admin/tests/integration/components/certifications/certification/informations-test.gjs
@@ -1,5 +1,6 @@
 import { render } from '@1024pix/ember-testing-library';
 import Service from '@ember/service';
+import { t } from 'ember-intl/test-support';
 import CertificationInformations from 'pix-admin/components/certifications/certification/informations';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
@@ -61,6 +62,72 @@ module('Integration | Component | Certifications | Certification | Informations'
 
     // then
     assert.dom(screen.getByRole('heading', { name: 'Candidat' })).exists();
+  });
+
+  module('Pix+ Edu V3 results', function () {
+    test('should display Pix+ Edu V3 results when certification is Pix+ Edu, V3 and validated', async function (assert) {
+      // given
+      const certification = store.createRecord('certification', {
+        competencesWithMark: [],
+        certificationFramework: 'EDU_1ER_DEGRE',
+        version: 3,
+        status: 'validated',
+        reachedResultKey: 'PIX_EDU_FORMATION_INITIALE_1ER_DEGRE.ADVANCED',
+      });
+      const session = store.createRecord('session', { id: '7404' });
+
+      // when
+      const screen = await render(
+        <template><CertificationInformations @certification={{certification}} @session={{session}} /></template>,
+      );
+
+      // then
+      assert.dom(screen.getByRole('heading', { name: t('components.certifications.edu-results.v3.title') })).exists();
+    });
+
+    test('should not display Pix+ Edu V3 results when certification is cancelled', async function (assert) {
+      // given
+      const certification = store.createRecord('certification', {
+        competencesWithMark: [],
+        certificationFramework: 'EDU_1ER_DEGRE',
+        version: 3,
+        status: 'cancelled',
+        reachedResultKey: 'PIX_EDU_FORMATION_INITIALE_1ER_DEGRE.ADVANCED',
+      });
+      const session = store.createRecord('session', { id: '7404' });
+
+      // when
+      const screen = await render(
+        <template><CertificationInformations @certification={{certification}} @session={{session}} /></template>,
+      );
+
+      // then
+      assert
+        .dom(screen.queryByRole('heading', { name: t('components.certifications.edu-results.v3.title') }))
+        .doesNotExist();
+    });
+
+    test('should not display Pix+ Edu V3 results when certification is rejected', async function (assert) {
+      // given
+      const certification = store.createRecord('certification', {
+        competencesWithMark: [],
+        certificationFramework: 'EDU_1ER_DEGRE',
+        version: 3,
+        status: 'rejected',
+        reachedResultKey: 'BELOW_MINIMUM',
+      });
+      const session = store.createRecord('session', { id: '7404' });
+
+      // when
+      const screen = await render(
+        <template><CertificationInformations @certification={{certification}} @session={{session}} /></template>,
+      );
+
+      // then
+      assert
+        .dom(screen.queryByRole('heading', { name: t('components.certifications.edu-results.v3.title') }))
+        .doesNotExist();
+    });
   });
 
   module('issue reports', function () {

--- a/admin/tests/integration/components/certifications/certification/informations/pix-plus-edu-v3-results-test.gjs
+++ b/admin/tests/integration/components/certifications/certification/informations/pix-plus-edu-v3-results-test.gjs
@@ -57,22 +57,6 @@ module(
       });
     });
 
-    module('when certification is not published', function () {
-      test('should disable the edit button', async function (assert) {
-        // given
-        const certification = store.createRecord('certification', {
-          reachedResultKey: 'PIX_EDU_FORMATION_INITIALE_1ER_DEGRE.0',
-          isPublished: false,
-        });
-
-        // when
-        const screen = await render(<template><PixPlusEduV3Results @certification={{certification}} /></template>);
-
-        // then
-        assert.dom(screen.getByRole('button', { name: 'Modifier le volet jury' })).isDisabled();
-      });
-    });
-
     module('jury level edition', function (hooks) {
       let successNotificationStub, errorNotificationStub;
 
@@ -98,11 +82,11 @@ module(
         const screen = await render(<template><PixPlusEduV3Results @certification={{certification}} /></template>);
 
         // when
-        await clickByName('Modifier le volet jury');
+        await clickByName(t('components.certifications.edu-results.v3.edit-external-jury'));
 
         // then
-        assert.dom(screen.getByRole('button', { name: 'Annuler' })).exists();
-        assert.dom(screen.getByRole('button', { name: 'Enregistrer' })).exists();
+        assert.dom(screen.getByRole('button', { name: t('common.actions.cancel') })).exists();
+        assert.dom(screen.getByRole('button', { name: t('common.actions.save') })).exists();
       });
 
       test('should hide jury select form when cancel button is clicked', async function (assert) {
@@ -114,15 +98,15 @@ module(
 
         const screen = await render(<template><PixPlusEduV3Results @certification={{certification}} /></template>);
 
-        await clickByName('Modifier le volet jury');
+        await clickByName(t('components.certifications.edu-results.v3.edit-external-jury'));
 
         // when
-        const form = screen.getByRole('button', { name: 'Annuler' }).closest('form');
+        const form = screen.getByRole('button', { name: t('common.actions.cancel') }).closest('form');
         await triggerEvent(form, 'reset');
 
         // then
-        assert.dom(screen.queryByRole('button', { name: 'Annuler' })).doesNotExist();
-        assert.dom(screen.queryByRole('button', { name: 'Enregistrer' })).doesNotExist();
+        assert.dom(screen.queryByRole('button', { name: t('common.actions.cancel') })).doesNotExist();
+        assert.dom(screen.queryByRole('button', { name: t('common.actions.save') })).doesNotExist();
       });
 
       test('should save and display success notification when form is submitted', async function (assert) {
@@ -138,16 +122,16 @@ module(
 
         await render(<template><PixPlusEduV3Results @certification={{certification}} /></template>);
 
-        await clickByName('Modifier le volet jury');
+        await clickByName(t('components.certifications.edu-results.v3.edit-external-jury'));
 
         // when
-        await clickByName('Enregistrer');
+        await clickByName(t('common.actions.save'));
 
         // then
         sinon.assert.calledWith(currentCertification.save, {
           adapterOptions: {
             updateEduExternalJuryResult: true,
-            eduV3ExternalJuryResult: '0',
+            eduV3ExternalJuryResult: null,
           },
         });
         sinon.assert.calledWith(successNotificationStub, {
@@ -170,10 +154,10 @@ module(
 
         await render(<template><PixPlusEduV3Results @certification={{certification}} /></template>);
 
-        await clickByName('Modifier le volet jury');
+        await clickByName(t('components.certifications.edu-results.v3.edit-external-jury'));
 
         // when
-        await clickByName('Enregistrer');
+        await clickByName(t('common.actions.save'));
 
         // then
         sinon.assert.calledWith(errorNotificationStub, {
@@ -195,10 +179,10 @@ module(
 
         await render(<template><PixPlusEduV3Results @certification={{certification}} /></template>);
 
-        await clickByName('Modifier le volet jury');
+        await clickByName(t('components.certifications.edu-results.v3.edit-external-jury'));
 
         // when
-        await clickByName('Enregistrer');
+        await clickByName(t('common.actions.save'));
 
         // then
         sinon.assert.calledWith(errorNotificationStub, {

--- a/admin/tests/integration/components/certifications/certification/informations/pix-plus-edu-v3-results-test.gjs
+++ b/admin/tests/integration/components/certifications/certification/informations/pix-plus-edu-v3-results-test.gjs
@@ -1,0 +1,190 @@
+import { clickByName, render } from '@1024pix/ember-testing-library';
+import Service from '@ember/service';
+import { triggerEvent } from '@ember/test-helpers';
+import { setupIntl, t } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'ember-qunit';
+import PixPlusEduV3Results from 'pix-admin/components/certifications/certification/informations/pix-plus-edu-v3-results';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module(
+  'Integration | Component | Certifications | Certification | Information | PixPlusEduV3Results',
+  function (hooks) {
+    setupRenderingTest(hooks);
+    setupIntl(hooks, 'fr');
+
+    let store;
+
+    hooks.beforeEach(function () {
+      store = this.owner.lookup('service:store');
+    });
+
+    module('when external jury result is pending', function () {
+      test('should display waiting status for external jury', async function (assert) {
+        // given
+        const certification = store.createRecord('certification', {
+          reachedResultKey: 'PIX_EDU_FORMATION_INITIALE_1ER_DEGRE.0',
+        });
+
+        // when
+        const screen = await render(<template><PixPlusEduV3Results @certification={{certification}} /></template>);
+
+        // then
+        assert.dom(screen.getByRole('heading', { name: t('components.certifications.edu-results.v3.title') })).exists();
+
+        assert.dom(screen.getByText(t('components.certifications.edu-results.v3.internal-jury'))).exists();
+        assert.dom(screen.getByText(t('components.certifications.edu-results.v3.admissible'))).exists();
+
+        assert.dom(screen.getByText(t('components.certifications.edu-results.v3.external-jury'))).exists();
+        assert.dom(screen.getByText(t('components.certifications.edu-results.v3.waiting'))).exists();
+      });
+    });
+
+    module('when external jury result is set', function () {
+      test('should display the reached level for external jury', async function (assert) {
+        // given
+        const certification = store.createRecord('certification', {
+          reachedResultKey: 'PIX_EDU_FORMATION_INITIALE_1ER_DEGRE.ADVANCED',
+        });
+
+        // when
+        const screen = await render(<template><PixPlusEduV3Results @certification={{certification}} /></template>);
+
+        // then
+        assert
+          .dom(screen.getByText(t('common.certification.meshLevels.PIX_EDU_FORMATION_INITIALE_1ER_DEGRE.ADVANCED')))
+          .exists();
+      });
+    });
+
+    module('jury level edition', function (hooks) {
+      let successNotificationStub, errorNotificationStub;
+
+      hooks.beforeEach(function () {
+        successNotificationStub = sinon.stub();
+        errorNotificationStub = sinon.stub();
+
+        class PixToastStub extends Service {
+          sendSuccessNotification = successNotificationStub;
+          sendErrorNotification = errorNotificationStub;
+        }
+
+        this.owner.register('service:pixToast', PixToastStub);
+      });
+
+      test('should display jury select form when edit button is clicked', async function (assert) {
+        // given
+        const certification = store.createRecord('certification', {
+          reachedResultKey: 'PIX_EDU_FORMATION_INITIALE_1ER_DEGRE.0',
+        });
+
+        const screen = await render(<template><PixPlusEduV3Results @certification={{certification}} /></template>);
+
+        // when
+        await clickByName('Modifier le volet jury');
+
+        // then
+        assert.dom(screen.getByRole('button', { name: 'Annuler' })).exists();
+        assert.dom(screen.getByRole('button', { name: 'Enregistrer' })).exists();
+      });
+
+      test('should hide jury select form when cancel button is clicked', async function (assert) {
+        // given
+        const certification = store.createRecord('certification', {
+          reachedResultKey: 'PIX_EDU_FORMATION_INITIALE_1ER_DEGRE.0',
+        });
+
+        const screen = await render(<template><PixPlusEduV3Results @certification={{certification}} /></template>);
+
+        await clickByName('Modifier le volet jury');
+
+        // when
+        const form = screen.getByRole('button', { name: 'Annuler' }).closest('form');
+        await triggerEvent(form, 'reset');
+
+        // then
+        assert.dom(screen.queryByRole('button', { name: 'Annuler' })).doesNotExist();
+        assert.dom(screen.queryByRole('button', { name: 'Enregistrer' })).doesNotExist();
+      });
+
+      test('should save and display success notification when form is submitted', async function (assert) {
+        // given
+        const certification = store.createRecord('certification', {
+          id: '1',
+          reachedResultKey: 'PIX_EDU_FORMATION_INITIALE_1ER_DEGRE.0',
+        });
+
+        const currentCertification = store.peekRecord('certification', 1);
+        currentCertification.save = sinon.stub().resolves();
+
+        await render(<template><PixPlusEduV3Results @certification={{certification}} /></template>);
+
+        await clickByName('Modifier le volet jury');
+
+        // when
+        await clickByName('Enregistrer');
+
+        // then
+        sinon.assert.calledWith(currentCertification.save, {
+          adapterOptions: {
+            updateEduExternalJuryResult: true,
+            eduV3ExternalJuryResult: '0',
+          },
+        });
+        sinon.assert.calledWith(successNotificationStub, {
+          message: t('components.certifications.edu-results.v3.success'),
+        });
+        assert.ok(true);
+      });
+
+      test('should display API error detail when save fails with error detail', async function (assert) {
+        // given
+        const certification = store.createRecord('certification', {
+          id: '2',
+          reachedResultKey: 'PIX_EDU_FORMATION_INITIALE_1ER_DEGRE.0',
+        });
+
+        const currentCertification = store.peekRecord('certification', 2);
+        const apiError = { errors: [{ detail: 'Le niveau de jury est invalide.' }] };
+        currentCertification.save = sinon.stub().rejects(apiError);
+
+        await render(<template><PixPlusEduV3Results @certification={{certification}} /></template>);
+
+        await clickByName('Modifier le volet jury');
+
+        // when
+        await clickByName('Enregistrer');
+
+        // then
+        sinon.assert.calledWith(errorNotificationStub, {
+          message: 'Le niveau de jury est invalide.',
+        });
+        assert.ok(true);
+      });
+
+      test('should display default error notification when save fails without error detail', async function (assert) {
+        // given
+        const certification = store.createRecord('certification', {
+          id: '3',
+          reachedResultKey: 'PIX_EDU_FORMATION_INITIALE_1ER_DEGRE.0',
+        });
+
+        const currentCertification = store.peekRecord('certification', 3);
+        currentCertification.save = sinon.stub().rejects(new Error('Network error'));
+
+        await render(<template><PixPlusEduV3Results @certification={{certification}} /></template>);
+
+        await clickByName('Modifier le volet jury');
+
+        // when
+        await clickByName('Enregistrer');
+
+        // then
+        sinon.assert.calledWith(errorNotificationStub, {
+          message: t('components.certifications.edu-results.v3.error'),
+        });
+        assert.ok(true);
+      });
+    });
+  },
+);

--- a/admin/tests/integration/components/certifications/certification/informations/pix-plus-edu-v3-results-test.gjs
+++ b/admin/tests/integration/components/certifications/certification/informations/pix-plus-edu-v3-results-test.gjs
@@ -57,6 +57,22 @@ module(
       });
     });
 
+    module('when certification is not published', function () {
+      test('should disable the edit button', async function (assert) {
+        // given
+        const certification = store.createRecord('certification', {
+          reachedResultKey: 'PIX_EDU_FORMATION_INITIALE_1ER_DEGRE.0',
+          isPublished: false,
+        });
+
+        // when
+        const screen = await render(<template><PixPlusEduV3Results @certification={{certification}} /></template>);
+
+        // then
+        assert.dom(screen.getByRole('button', { name: 'Modifier le volet jury' })).isDisabled();
+      });
+    });
+
     module('jury level edition', function (hooks) {
       let successNotificationStub, errorNotificationStub;
 
@@ -76,6 +92,7 @@ module(
         // given
         const certification = store.createRecord('certification', {
           reachedResultKey: 'PIX_EDU_FORMATION_INITIALE_1ER_DEGRE.0',
+          isPublished: true,
         });
 
         const screen = await render(<template><PixPlusEduV3Results @certification={{certification}} /></template>);
@@ -92,6 +109,7 @@ module(
         // given
         const certification = store.createRecord('certification', {
           reachedResultKey: 'PIX_EDU_FORMATION_INITIALE_1ER_DEGRE.0',
+          isPublished: true,
         });
 
         const screen = await render(<template><PixPlusEduV3Results @certification={{certification}} /></template>);
@@ -112,6 +130,7 @@ module(
         const certification = store.createRecord('certification', {
           id: '1',
           reachedResultKey: 'PIX_EDU_FORMATION_INITIALE_1ER_DEGRE.0',
+          isPublished: true,
         });
 
         const currentCertification = store.peekRecord('certification', 1);
@@ -142,6 +161,7 @@ module(
         const certification = store.createRecord('certification', {
           id: '2',
           reachedResultKey: 'PIX_EDU_FORMATION_INITIALE_1ER_DEGRE.0',
+          isPublished: true,
         });
 
         const currentCertification = store.peekRecord('certification', 2);
@@ -167,6 +187,7 @@ module(
         const certification = store.createRecord('certification', {
           id: '3',
           reachedResultKey: 'PIX_EDU_FORMATION_INITIALE_1ER_DEGRE.0',
+          isPublished: true,
         });
 
         const currentCertification = store.peekRecord('certification', 3);

--- a/admin/tests/mirage/handlers/update-edu-v3-external-jury-result.js
+++ b/admin/tests/mirage/handlers/update-edu-v3-external-jury-result.js
@@ -1,0 +1,11 @@
+export function updateEduV3ExternalJuryResult(schema, request) {
+  const certificationId = request.params.id;
+  const body = JSON.parse(request.requestBody);
+  const juryResult = body.data.attributes['edu-v3-external-jury-result'];
+  const certification = schema.certifications.find(certificationId);
+  certification.update({
+    reachedResultKey: `EDU_1ER_DEGRE.${juryResult}`,
+  });
+
+  return certification;
+}

--- a/admin/tests/mirage/routes.js
+++ b/admin/tests/mirage/routes.js
@@ -56,6 +56,7 @@ import {
   getTraining,
   updateTraining,
 } from './handlers/trainings';
+import { updateEduV3ExternalJuryResult } from './handlers/update-edu-v3-external-jury-result';
 import { findPaginatedFilteredUsers } from './handlers/users';
 
 /* eslint-disable ember/no-get */
@@ -658,6 +659,8 @@ export default function routes() {
   this.post('/admin/certification-courses/:id/assessment-results', () => {
     return new Response(204);
   });
+
+  this.post('/admin/certification-courses/:id/edu-v3-external-jury-result', updateEduV3ExternalJuryResult);
 
   this.get('/admin/tags');
   this.post('/admin/tags', (schema, request) => {

--- a/admin/tests/unit/models/certification-test.js
+++ b/admin/tests/unit/models/certification-test.js
@@ -168,6 +168,16 @@ module('Unit | Model | certification', function (hooks) {
         assert.true(certification.hasComplementaryCertifications);
       });
     });
+
+    module('when certification is about pix plus edu v3', function () {
+      test('returns true', function (assert) {
+        const certification = store.createRecord('certification', {
+          version: 3,
+          certificationFramework: 'EDU_1ER_DEGRE',
+        });
+        assert.true(certification.hasComplementaryCertifications);
+      });
+    });
   });
 
   module('when there is only a common complementary certification result', function () {

--- a/admin/tests/unit/models/certification-test.js
+++ b/admin/tests/unit/models/certification-test.js
@@ -365,4 +365,42 @@ module('Unit | Model | certification', function (hooks) {
       assert.false(wasBornInFrance);
     });
   });
+
+  module('#isPixPlusV3', function () {
+    test('returns true when certification is v3 and pix plus Édu 1er degré', function (assert) {
+      const certification = store.createRecord('certification', {
+        version: 3,
+        certificationFramework: 'EDU_1ER_DEGRE',
+      });
+
+      assert.true(certification.isPixPlusEduV3);
+    });
+
+    test('returns true when certification is v3 and pix plus Édu 2er degré', function (assert) {
+      const certification = store.createRecord('certification', {
+        version: 3,
+        certificationFramework: 'EDU_2ND_DEGRE',
+      });
+
+      assert.true(certification.isPixPlusEduV3);
+    });
+
+    test('returns true when certification is v3 and pix plus Édu CPE', function (assert) {
+      const certification = store.createRecord('certification', { version: 3, certificationFramework: 'EDU_CPE' });
+
+      assert.true(certification.isPixPlusEduV3);
+    });
+
+    test('returns false when certification is not v3', function (assert) {
+      const certification = store.createRecord('certification', { version: 2, certificationFramework: 'EDU_CPE' });
+
+      assert.false(certification.isPixPlusEduV3);
+    });
+
+    test('returns false when certification is v3 and NOT pix plus Édu 1er degré', function (assert) {
+      const certification = store.createRecord('certification', { version: 3, certificationFramework: 'DROIT' });
+
+      assert.false(certification.isPixPlusEduV3);
+    });
+  });
 });

--- a/admin/tests/unit/models/certification-test.js
+++ b/admin/tests/unit/models/certification-test.js
@@ -133,70 +133,6 @@ module('Unit | Model | certification', function (hooks) {
     });
   });
 
-  module('#hasComplementaryCertifications', function () {
-    module('when there are no complementary certification results', function () {
-      test('should return false', function (assert) {
-        // given
-        const complementaryCertificationCourseResultWithExternal = null;
-        const commonComplementaryCertificationCourseResult = null;
-        const certification = store.createRecord('certification', {
-          complementaryCertificationCourseResultWithExternal,
-          commonComplementaryCertificationCourseResult,
-        });
-
-        //when / then
-        assert.false(certification.hasComplementaryCertifications);
-      });
-    });
-
-    module('when there is only an external complementary certification result', function () {
-      test('should return true', function (assert) {
-        // given
-        const complementaryCertificationCourseResultWithExternal = store.createRecord(
-          'complementary-certification-course-result-with-external',
-          {
-            pixResult: 'TOTO',
-          },
-        );
-        const commonComplementaryCertificationCourseResult = null;
-        const certification = store.createRecord('certification', {
-          complementaryCertificationCourseResultWithExternal,
-          commonComplementaryCertificationCourseResult,
-        });
-
-        //when / then
-        assert.true(certification.hasComplementaryCertifications);
-      });
-    });
-
-    module('when certification is about pix plus edu v3', function () {
-      test('returns true', function (assert) {
-        const certification = store.createRecord('certification', {
-          version: 3,
-          certificationFramework: 'EDU_1ER_DEGRE',
-        });
-        assert.true(certification.hasComplementaryCertifications);
-      });
-    });
-  });
-
-  module('when there is only a common complementary certification result', function () {
-    test('should return true', function (assert) {
-      // given
-      const complementaryCertificationCourseResultWithExternal = null;
-      const commonComplementaryCertificationCourseResult = store.createRecord(
-        'common-complementary-certification-course-result',
-      );
-      const certification = store.createRecord('certification', {
-        complementaryCertificationCourseResultWithExternal,
-        commonComplementaryCertificationCourseResult,
-      });
-
-      //when / then
-      assert.true(certification.hasComplementaryCertifications);
-    });
-  });
-
   module('#statusLabelAndValue', function () {
     [
       { value: assessmentStates.STARTED, label: 'Démarrée' },
@@ -373,44 +309,6 @@ module('Unit | Model | certification', function (hooks) {
 
       // then
       assert.false(wasBornInFrance);
-    });
-  });
-
-  module('#isPixPlusV3', function () {
-    test('returns true when certification is v3 and pix plus Édu 1er degré', function (assert) {
-      const certification = store.createRecord('certification', {
-        version: 3,
-        certificationFramework: 'EDU_1ER_DEGRE',
-      });
-
-      assert.true(certification.isPixPlusEduV3);
-    });
-
-    test('returns true when certification is v3 and pix plus Édu 2er degré', function (assert) {
-      const certification = store.createRecord('certification', {
-        version: 3,
-        certificationFramework: 'EDU_2ND_DEGRE',
-      });
-
-      assert.true(certification.isPixPlusEduV3);
-    });
-
-    test('returns true when certification is v3 and pix plus Édu CPE', function (assert) {
-      const certification = store.createRecord('certification', { version: 3, certificationFramework: 'EDU_CPE' });
-
-      assert.true(certification.isPixPlusEduV3);
-    });
-
-    test('returns false when certification is not v3', function (assert) {
-      const certification = store.createRecord('certification', { version: 2, certificationFramework: 'EDU_CPE' });
-
-      assert.false(certification.isPixPlusEduV3);
-    });
-
-    test('returns false when certification is v3 and NOT pix plus Édu 1er degré', function (assert) {
-      const certification = store.createRecord('certification', { version: 3, certificationFramework: 'DROIT' });
-
-      assert.false(certification.isPixPlusEduV3);
     });
   });
 });

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -535,6 +535,29 @@
         "ariaLabel": "Search for a certification with an identifier",
         "label": "Find a certification",
         "placeholder": "Certification ID"
+      },
+      "edu-results": {
+        "v2": {
+          "external-jury-select-options": {
+            "REJECTED": "Rejected",
+            "UNSET": "Pending"
+          }
+        },
+        "v3": {
+          "admissible": "Admissible",
+          "title": "Pix+ Edu certification results",
+          "internal-jury": "Pix section",
+          "external-jury": "External jury section",
+          "select": "Select a level",
+          "external-jury-select-options": {
+            "UNSET": "Pending",
+            "ADVANCED": "Advanced",
+            "EXPERT": "Expert"
+          },
+          "waiting": "Pending",
+          "error": "An error occurred",
+          "success": "The external jury section result has been saved"
+        }
       }
     },
     "combined-course-blueprints": {

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -503,6 +503,7 @@
         },
         "v3": {
           "admissible": "Admissible",
+          "edit-disabled": "Cannot be edited because the session is not published",
           "error": "An error occurred",
           "external-jury": "External jury section",
           "external-jury-select-options": {

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -504,6 +504,7 @@
         "v3": {
           "admissible": "Admissible",
           "edit-disabled": "Cannot be edited because the session is not published",
+          "edit-external-jury": "Edit external jury section",
           "error": "An error occurred",
           "external-jury": "External jury section",
           "external-jury-select-options": {
@@ -517,10 +518,6 @@
           "title": "Pix+ Edu certification results",
           "waiting": "Pending"
         }
-      },
-      "external-jury-select-options": {
-        "REJECTED": "Rejected",
-        "UNSET": "Waiting"
       },
       "global-actions": {
         "cancel": {

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -494,6 +494,29 @@
       "page-title": "Certification Frameworks"
     },
     "certifications": {
+      "edu-results": {
+        "v2": {
+          "external-jury-select-options": {
+            "REJECTED": "Rejected",
+            "UNSET": "Pending"
+          }
+        },
+        "v3": {
+          "admissible": "Admissible",
+          "error": "An error occurred",
+          "external-jury": "External jury section",
+          "external-jury-select-options": {
+            "ADVANCED": "Advanced",
+            "EXPERT": "Expert",
+            "UNSET": "Pending"
+          },
+          "internal-jury": "Pix section",
+          "select": "Select a level",
+          "success": "The external jury section result has been saved",
+          "title": "Pix+ Edu certification results",
+          "waiting": "Pending"
+        }
+      },
       "external-jury-select-options": {
         "REJECTED": "Rejected",
         "UNSET": "Waiting"
@@ -535,29 +558,6 @@
         "ariaLabel": "Search for a certification with an identifier",
         "label": "Find a certification",
         "placeholder": "Certification ID"
-      },
-      "edu-results": {
-        "v2": {
-          "external-jury-select-options": {
-            "REJECTED": "Rejected",
-            "UNSET": "Pending"
-          }
-        },
-        "v3": {
-          "admissible": "Admissible",
-          "title": "Pix+ Edu certification results",
-          "internal-jury": "Pix section",
-          "external-jury": "External jury section",
-          "select": "Select a level",
-          "external-jury-select-options": {
-            "UNSET": "Pending",
-            "ADVANCED": "Advanced",
-            "EXPERT": "Expert"
-          },
-          "waiting": "Pending",
-          "error": "An error occurred",
-          "success": "The external jury section result has been saved"
-        }
       }
     },
     "combined-course-blueprints": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -511,6 +511,7 @@
         "v3": {
           "admissible": "Admissible",
           "edit-disabled": "Non modifiable car la session n'est pas publiée",
+          "edit-external-jury": "Modifier le volet jury",
           "error": "Une erreur est survenue",
           "external-jury": "Volet jury externe",
           "external-jury-select-options": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -501,6 +501,29 @@
       "page-title": "Référentiels de certification"
     },
     "certifications": {
+      "edu-results": {
+        "v2": {
+          "external-jury-select-options": {
+            "REJECTED": "Rejetée",
+            "UNSET": "En attente"
+          }
+        },
+        "v3": {
+          "admissible": "Admissible",
+          "error": "Une erreur est survenue",
+          "external-jury": "Volet jury externe",
+          "external-jury-select-options": {
+            "ADVANCED": "Avancé",
+            "EXPERT": "Expert",
+            "UNSET": "En attente"
+          },
+          "internal-jury": "Volet Pix",
+          "select": "Sélectionner un niveau",
+          "success": "Le résultat du volet jury externe a bien été enregistré",
+          "title": "Résultats de la certification Pix+ Edu",
+          "waiting": "En attente"
+        }
+      },
       "global-actions": {
         "cancel": {
           "button": "Annuler la certification",
@@ -538,29 +561,6 @@
         "ariaLabel": "Rechercher une certification avec un identifiant",
         "label": "Trouver une certification",
         "placeholder": "ID de la certification"
-      },
-      "edu-results": {
-        "v2": {
-          "external-jury-select-options": {
-            "REJECTED": "Rejetée",
-            "UNSET": "En attente"
-          }
-        },
-        "v3": {
-          "admissible": "Admissible",
-          "title": "Résultats de la certification Pix+ Edu",
-          "internal-jury": "Volet Pix",
-          "external-jury": "Volet jury externe",
-          "select": "Sélectionner un niveau",
-          "external-jury-select-options": {
-            "UNSET": "En attente",
-            "ADVANCED": "Avancé",
-            "EXPERT": "Expert"
-          },
-          "waiting": "En attente",
-          "error": "Une erreur est survenue",
-          "success": "LE résultat du volet jury externe a bien été enregistré"
-        }
       }
     },
     "combined-course-blueprints": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -539,17 +539,27 @@
         "label": "Trouver une certification",
         "placeholder": "ID de la certification"
       },
-      "v2": {
-        "external-jury-select-options": {
-          "REJECTED": "Rejetée",
-          "UNSET": "En attente"
-        }
-      },
-      "v3": {
-        "external-jury-select-options": {
-          "ADVANCED": "Avancé",
-          "EXPERT": "Expert",
-          "UNSET": "En attente"
+      "edu-results": {
+        "v2": {
+          "external-jury-select-options": {
+            "REJECTED": "Rejetée",
+            "UNSET": "En attente"
+          }
+        },
+        "v3": {
+          "admissible": "Admissible",
+          "title": "Résultats de la certification Pix+ Edu",
+          "internal-jury": "Volet Pix",
+          "external-jury": "Volet jury externe",
+          "select": "Sélectionner un niveau",
+          "external-jury-select-options": {
+            "UNSET": "En attente",
+            "ADVANCED": "Avancé",
+            "EXPERT": "Expert"
+          },
+          "waiting": "En attente",
+          "error": "Une erreur est survenue",
+          "success": "LE résultat du volet jury externe a bien été enregistré"
         }
       }
     },

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -501,10 +501,6 @@
       "page-title": "Référentiels de certification"
     },
     "certifications": {
-      "external-jury-select-options": {
-        "REJECTED": "Rejetée",
-        "UNSET": "En attente"
-      },
       "global-actions": {
         "cancel": {
           "button": "Annuler la certification",
@@ -542,6 +538,19 @@
         "ariaLabel": "Rechercher une certification avec un identifiant",
         "label": "Trouver une certification",
         "placeholder": "ID de la certification"
+      },
+      "v2": {
+        "external-jury-select-options": {
+          "REJECTED": "Rejetée",
+          "UNSET": "En attente"
+        }
+      },
+      "v3": {
+        "external-jury-select-options": {
+          "ADVANCED": "Avancé",
+          "EXPERT": "Expert",
+          "UNSET": "En attente"
+        }
       }
     },
     "combined-course-blueprints": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -510,6 +510,7 @@
         },
         "v3": {
           "admissible": "Admissible",
+          "edit-disabled": "Non modifiable car la session n'est pas publiée",
           "error": "Une erreur est survenue",
           "external-jury": "Volet jury externe",
           "external-jury-select-options": {

--- a/api/src/certification/session-management/application/certification-course-controller.js
+++ b/api/src/certification/session-management/application/certification-course-controller.js
@@ -1,5 +1,7 @@
+import { getI18nFromRequest } from '../../../shared/infrastructure/i18n/i18n.js';
 import { usecases } from '../domain/usecases/index.js';
 import * as certificationSerializer from '../infrastructure/serializers/certification-serializer.js';
+import * as juryCertificationSerializer from '../infrastructure/serializers/jury-certification-serializer.js';
 import * as juryCommentSerializer from '../infrastructure/serializers/jury-comment-serializer.js';
 import * as v3CertificationDetailsForAdministrationSerializer from '../infrastructure/serializers/v3-certification-course-details-for-administration-serializer.js';
 
@@ -66,13 +68,20 @@ const update = async function (request, h, dependencies = { certificationSeriali
   return dependencies.certificationSerializer.serializeFromCertificationCourse(updatedCertificationCourse);
 };
 
-const updateEduV3ExternalJuryResult = async function (request, h) {
+const updateEduV3ExternalJuryResult = async function (request, h, dependencies = { juryCertificationSerializer }) {
+  const i18n = getI18nFromRequest(request);
+
   const eduV3ExternalJuryResult = request.payload.data.attributes['edu-v3-external-jury-result'];
   const certificationCourseId = request.params.certificationCourseId;
 
-  await usecases.updateEduV3ExternalJuryResult({ certificationCourseId, eduV3ExternalJuryResult });
+  const juryCertification = await usecases.updateEduV3ExternalJuryResult({
+    certificationCourseId,
+    eduV3ExternalJuryResult,
+  });
 
-  return h.response().code(200);
+  return h
+    .response(dependencies.juryCertificationSerializer.serialize(juryCertification, { translate: i18n.__ }))
+    .code(200);
 };
 
 export const certificationCourseController = {

--- a/api/src/certification/session-management/application/certification-course-controller.js
+++ b/api/src/certification/session-management/application/certification-course-controller.js
@@ -66,10 +66,20 @@ const update = async function (request, h, dependencies = { certificationSeriali
   return dependencies.certificationSerializer.serializeFromCertificationCourse(updatedCertificationCourse);
 };
 
+const updateEduV3ExternalJuryResult = async function (request, h) {
+  const eduV3ExternalJuryResult = request.payload.data.attributes['edu-v3-external-jury-result'];
+  const certificationCourseId = request.params.certificationCourseId;
+
+  await usecases.updateEduV3ExternalJuryResult({ certificationCourseId, eduV3ExternalJuryResult });
+
+  return h.response().code(200);
+};
+
 export const certificationCourseController = {
   reject,
   unreject,
   getCertificationV3Details,
   update,
   updateJuryComment,
+  updateEduV3ExternalJuryResult,
 };

--- a/api/src/certification/session-management/application/certification-course-route.js
+++ b/api/src/certification/session-management/application/certification-course-route.js
@@ -2,6 +2,7 @@ import Joi from 'joi';
 
 import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
 import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
+import { PIX_PLUS_EDU_EXTERNAL_LEVELS } from '../../shared/domain/constants/mesh-configuration.js';
 import { certificationCourseController } from './certification-course-controller.js';
 
 const register = async function (server) {
@@ -114,6 +115,43 @@ const register = async function (server) {
         notes: [
           "- **Cette route est restreinte aux utilisateurs ayant les droits d'accès**\n" +
             ' - Elle recrée un assessment result pour mettre à jour les notes internes du jury\n',
+        ],
+      },
+    },
+    {
+      method: 'POST',
+      path: '/api/admin/certification-courses/{certificationCourseId}/edu-v3-external-jury-result',
+      config: {
+        validate: {
+          params: Joi.object({
+            certificationCourseId: identifiersType.certificationCourseId,
+          }),
+          payload: Joi.object({
+            data: {
+              attributes: {
+                'edu-v3-external-jury-result': Joi.string()
+                  .allow(null)
+                  .valid(...Object.values(PIX_PLUS_EDU_EXTERNAL_LEVELS))
+                  .required(),
+              },
+            },
+          }),
+        },
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.hasAtLeastOneAccessOf([
+                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+                securityPreHandlers.checkAdminMemberHasRoleCertif,
+              ])(request, h),
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        handler: certificationCourseController.updateEduV3ExternalJuryResult,
+        tags: ['api', 'admin', 'assessment-results', 'certification-courses', 'volet externe'],
+        notes: [
+          "- **Cette route est restreinte aux utilisateurs ayant les droits d'accès**\n" +
+            ' - Elle permet de mettre à jour le résultat du volet externe EDU\n',
         ],
       },
     },

--- a/api/src/certification/session-management/domain/models/JuryCertification.js
+++ b/api/src/certification/session-management/domain/models/JuryCertification.js
@@ -2,7 +2,7 @@ import { AlgorithmEngineVersion } from '../../../shared/domain/models/AlgorithmE
 import { CompetenceMark } from '../../../shared/domain/models/CompetenceMark.js';
 import { JuryComment, JuryCommentContexts } from '../../../shared/domain/models/JuryComment.js';
 
-class JuryCertification {
+export class JuryCertification {
   /**
    * @param {object} props
    * @param {number} props.certificationCourseId
@@ -171,5 +171,3 @@ class JuryCertification {
     });
   }
 }
-
-export { JuryCertification };

--- a/api/src/certification/session-management/domain/models/JuryCertification.js
+++ b/api/src/certification/session-management/domain/models/JuryCertification.js
@@ -1,4 +1,5 @@
 import { DomainError } from '../../../../shared/domain/errors.js';
+import { AssessmentResult } from '../../../../shared/domain/models/AssessmentResult.js';
 import { AlgorithmEngineVersion } from '../../../shared/domain/models/AlgorithmEngineVersion.js';
 import { CompetenceMark } from '../../../shared/domain/models/CompetenceMark.js';
 import { JuryComment, JuryCommentContexts } from '../../../shared/domain/models/JuryComment.js';
@@ -175,6 +176,9 @@ export class JuryCertification {
   updateEduV3ExternalJuryResult(eduV3ExternalJuryResult) {
     if (!this.isPublished) {
       throw new DomainError('Impossible de définir le résultat du volet externe pour une certification non publiée');
+    }
+    if (this.status !== AssessmentResult.status.VALIDATED) {
+      throw new DomainError('Impossible de définir le résultat du volet externe pour une certification non validée');
     }
     if (this.version !== AlgorithmEngineVersion.V3) {
       throw new DomainError('Impossible de définir le résultat du volet externe pour une certification non V3');

--- a/api/src/certification/session-management/domain/models/JuryCertification.js
+++ b/api/src/certification/session-management/domain/models/JuryCertification.js
@@ -1,3 +1,4 @@
+import { DomainError } from '../../../../shared/domain/errors.js';
 import { AlgorithmEngineVersion } from '../../../shared/domain/models/AlgorithmEngineVersion.js';
 import { CompetenceMark } from '../../../shared/domain/models/CompetenceMark.js';
 import { JuryComment, JuryCommentContexts } from '../../../shared/domain/models/JuryComment.js';
@@ -169,5 +170,26 @@ export class JuryCertification {
       version: juryCertificationDTO.version,
       certificationFramework: juryCertificationDTO.certificationFramework,
     });
+  }
+
+  updateEduV3ExternalJuryResult(eduV3ExternalJuryResult) {
+    if (!this.isPublished) {
+      throw new DomainError('Impossible de définir le résultat du volet externe pour une certification non publiée');
+    }
+    if (this.version !== AlgorithmEngineVersion.V3) {
+      throw new DomainError('Impossible de définir le résultat du volet externe pour une certification non V3');
+    }
+
+    if (!this.certificationFramework.startsWith('EDU_')) {
+      throw new DomainError('Impossible de définir le résultat du volet externe pour une certification non "EDU"');
+    }
+
+    if (this.reachedMeshIndex === null) {
+      throw new DomainError(
+        'Impossible de définir le résultat du volet externe pour une certification EDU non admissible',
+      );
+    }
+
+    this.eduV3ExternalJuryResult = eduV3ExternalJuryResult;
   }
 }

--- a/api/src/certification/session-management/domain/read-models/ComplementaryCertificationCourseResultForJuryCertificationWithExternal.js
+++ b/api/src/certification/session-management/domain/read-models/ComplementaryCertificationCourseResultForJuryCertificationWithExternal.js
@@ -5,7 +5,7 @@ const { minBy } = lodash;
 import { ChallengesReferential } from '../../../shared/domain/models/ChallengesReferential.js';
 import { juryOptions } from '../../../shared/domain/models/ComplementaryCertificationCourseResult.js';
 
-class ComplementaryCertificationCourseResultForJuryCertificationWithExternal {
+export class ComplementaryCertificationCourseResultForJuryCertificationWithExternal {
   constructor({
     complementaryCertificationCourseId,
     pixComplementaryCertificationBadgeId,
@@ -98,5 +98,3 @@ class Section {
     return Boolean(this.complementaryCertificationBadgeId);
   }
 }
-
-export { ComplementaryCertificationCourseResultForJuryCertificationWithExternal };

--- a/api/src/certification/session-management/domain/usecases/index.js
+++ b/api/src/certification/session-management/domain/usecases/index.js
@@ -178,6 +178,7 @@ import { uncancel } from './uncancel.js';
 import { unfinalizeSession } from './unfinalize-session.js';
 import { unpublishSession } from './unpublish-session.js';
 import { unrejectCertificationCourse } from './unreject-certification-course.js';
+import { updateEduV3ExternalJuryResult } from './update-edu-v3-external-jury-result.js';
 import { updateJuryComment } from './update-jury-comment.js';
 import { uploadCpfFiles } from './upload-cpf-files.js';
 import { validateLiveAlert } from './validate-live-alert.js';
@@ -225,6 +226,7 @@ const usecasesWithoutInjectedDependencies = {
   updateJuryComment,
   uploadCpfFiles,
   validateLiveAlert,
+  updateEduV3ExternalJuryResult,
 };
 
 const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);

--- a/api/src/certification/session-management/domain/usecases/update-edu-v3-external-jury-result.js
+++ b/api/src/certification/session-management/domain/usecases/update-edu-v3-external-jury-result.js
@@ -1,0 +1,12 @@
+export async function updateEduV3ExternalJuryResult({
+  certificationCourseId,
+  eduV3ExternalJuryResult,
+  juryCertificationRepository,
+}) {
+  const juryCertification = await juryCertificationRepository.get({ certificationCourseId });
+  juryCertification.updateEduV3ExternalJuryResult(eduV3ExternalJuryResult);
+
+  await juryCertificationRepository.update(juryCertification);
+
+  return juryCertification;
+}

--- a/api/src/certification/session-management/infrastructure/repositories/jury-certification-repository.js
+++ b/api/src/certification/session-management/infrastructure/repositories/jury-certification-repository.js
@@ -71,16 +71,21 @@ export async function update(juryCertification) {
   const knexConn = DomainTransaction.getConnection();
 
   await knexConn('assessment-results')
-    .where({
-      'assessment-results.assessmentId': juryCertification.assessmentId,
-    })
-    .join(
-      { cclar: 'certification-courses-last-assessment-results' },
-      'cclar.lastAssessmentResultId',
-      'assessment-results.id',
-    )
     .update({
       eduV3ExternalJuryResult: juryCertification.eduV3ExternalJuryResult,
+    })
+    .where('assessment-results.id', '=', function (qb) {
+      qb.select('certification-courses-last-assessment-results.lastAssessmentResultId')
+        .from('certification-courses-last-assessment-results')
+        .join(
+          'assessment-results',
+          'assessment-results.id',
+          'certification-courses-last-assessment-results.lastAssessmentResultId',
+        )
+        .where(
+          'certification-courses-last-assessment-results.certificationCourseId',
+          juryCertification.certificationCourseId,
+        );
     });
 }
 

--- a/api/src/certification/session-management/infrastructure/repositories/jury-certification-repository.js
+++ b/api/src/certification/session-management/infrastructure/repositories/jury-certification-repository.js
@@ -65,7 +65,24 @@ export async function get({ certificationCourseId }) {
     complementaryCertificationCourseResultDTOs,
     badgeIdAndLabels,
   });
-};
+}
+
+export async function update(juryCertification) {
+  const knexConn = DomainTransaction.getConnection();
+
+  await knexConn('assessment-results')
+    .where({
+      'assessment-results.assessmentId': juryCertification.assessmentId,
+    })
+    .join(
+      { cclar: 'certification-courses-last-assessment-results' },
+      'cclar.lastAssessmentResultId',
+      'assessment-results.id',
+    )
+    .update({
+      eduV3ExternalJuryResult: juryCertification.eduV3ExternalJuryResult,
+    });
+}
 
 function _selectJuryCertifications(knexConn) {
   return knexConn

--- a/api/src/certification/session-management/infrastructure/repositories/jury-certification-repository.js
+++ b/api/src/certification/session-management/infrastructure/repositories/jury-certification-repository.js
@@ -5,7 +5,7 @@ import { JuryCertification } from '../../domain/models/JuryCertification.js';
 import { ComplementaryCertificationCourseResultForJuryCertification } from '../../domain/read-models/ComplementaryCertificationCourseResultForJuryCertification.js';
 import { ComplementaryCertificationCourseResultForJuryCertificationWithExternal } from '../../domain/read-models/ComplementaryCertificationCourseResultForJuryCertificationWithExternal.js';
 
-const get = async function ({ certificationCourseId }) {
+export async function get({ certificationCourseId }) {
   const knexConn = DomainTransaction.getConnection();
   const juryCertificationDTO = await _selectJuryCertifications(knexConn)
     .where('certification-courses.id', certificationCourseId)
@@ -66,8 +66,6 @@ const get = async function ({ certificationCourseId }) {
     badgeIdAndLabels,
   });
 };
-
-export { get };
 
 function _selectJuryCertifications(knexConn) {
   return knexConn

--- a/api/tests/certification/session-management/acceptance/application/certification-course-route_test.js
+++ b/api/tests/certification/session-management/acceptance/application/certification-course-route_test.js
@@ -491,20 +491,23 @@ describe('Certification | Session Management | Acceptance | Application | Routes
   });
 
   describe('POST /api/admin/certification-courses/{certificationCourseId}/edu-v3-external-jury-result', function () {
-    let certificationCourseId;
+    let certificationCourseFromDB;
+    let assessmentResultFromDB;
     let options;
     let server;
 
     beforeEach(async function () {
-      certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
+      certificationCourseFromDB = databaseBuilder.factory.buildCertificationCourse({
         isPublished: true,
         framework: Frameworks.EDU_1ER_DEGRE,
         version: AlgorithmEngineVersion.V3,
-      }).id;
-      databaseBuilder.factory.buildAssessmentResult.last({
-        certificationCourseId,
+        birthINSEECode: '12345',
+      });
+      assessmentResultFromDB = databaseBuilder.factory.buildAssessmentResult.last({
+        certificationCourseId: certificationCourseFromDB.id,
         reachedMeshIndex: 0,
         eduV3ExternalJuryResult: null,
+        commentByJury: null,
       });
       await databaseBuilder.commit();
 
@@ -512,7 +515,7 @@ describe('Certification | Session Management | Acceptance | Application | Routes
 
       options = {
         method: 'POST',
-        url: `/api/admin/certification-courses/${certificationCourseId}/edu-v3-external-jury-result`,
+        url: `/api/admin/certification-courses/${certificationCourseFromDB.id}/edu-v3-external-jury-result`,
         headers: generateAuthenticatedUserRequestHeaders(),
         payload: {
           data: {
@@ -534,6 +537,35 @@ describe('Certification | Session Management | Acceptance | Application | Routes
       expect(assessmentResults).to.have.lengthOf(1);
       expect(assessmentResults[0].eduV3ExternalJuryResult).to.equal(PIX_PLUS_EDU_EXTERNAL_LEVELS.ADVANCED);
       expect(response.statusCode).to.equal(200);
+      expect(response.result.data.type).to.equal('certifications');
+      expect(response.result.data.id).to.equal(certificationCourseFromDB.id.toString());
+      expect(response.result.data.attributes).to.deep.equal({
+        'first-name': certificationCourseFromDB.firstName,
+        'last-name': certificationCourseFromDB.lastName,
+        sex: certificationCourseFromDB.sex,
+        'birth-country': certificationCourseFromDB.birthCountry,
+        'birth-insee-code': certificationCourseFromDB.birthINSEECode,
+        'birth-postal-code': certificationCourseFromDB.birthPostalCode,
+        birthdate: certificationCourseFromDB.birthdate,
+        birthplace: certificationCourseFromDB.birthplace,
+        'created-at': certificationCourseFromDB.createdAt,
+        'user-id': certificationCourseFromDB.userId,
+        'session-id': certificationCourseFromDB.sessionId,
+        version: certificationCourseFromDB.version,
+        'certification-framework': certificationCourseFromDB.framework,
+        'completed-at': certificationCourseFromDB.completedAt,
+        'is-published': certificationCourseFromDB.isPublished,
+        'assessment-id': assessmentResultFromDB.assessmentId,
+        'is-rejected-for-fraud': certificationCourseFromDB.isRejectedForFraud,
+        status: assessmentResultFromDB.status,
+        'pix-score': assessmentResultFromDB.pixScore,
+        'reached-result-key': Frameworks.EDU_1ER_DEGRE + '.' + PIX_PLUS_EDU_EXTERNAL_LEVELS.ADVANCED,
+        'comment-by-jury': assessmentResultFromDB.commentByJury,
+        'comment-for-candidate': assessmentResultFromDB.commentForCandidate,
+        'comment-for-organization': assessmentResultFromDB.commentForOrganization,
+        'jury-id': assessmentResultFromDB.juryId,
+        'competences-with-mark': [],
+      });
     });
   });
 });

--- a/api/tests/certification/session-management/acceptance/application/certification-course-route_test.js
+++ b/api/tests/certification/session-management/acceptance/application/certification-course-route_test.js
@@ -1,3 +1,4 @@
+import { PIX_PLUS_EDU_EXTERNAL_LEVELS } from '../../../../../src/certification/shared/domain/constants/mesh-configuration.js';
 import { AlgorithmEngineVersion } from '../../../../../src/certification/shared/domain/models/AlgorithmEngineVersion.js';
 import { Frameworks } from '../../../../../src/certification/shared/domain/models/Frameworks.js';
 import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
@@ -382,7 +383,7 @@ describe('Certification | Session Management | Acceptance | Application | Routes
     });
   });
 
-  describe('POST /api/admin/certification-courses-v3/{certificationCourseId}/details', function () {
+  describe('GET /api/admin/certification-courses-v3/{certificationCourseId}/details', function () {
     let certificationCourse;
     let certificationChallenges;
     let assessmentResult;
@@ -486,6 +487,53 @@ describe('Certification | Session Management | Acceptance | Application | Routes
           type: 'certification-challenges-for-administration',
         },
       ]);
+    });
+  });
+
+  describe('POST /api/admin/certification-courses/{certificationCourseId}/edu-v3-external-jury-result', function () {
+    let certificationCourseId;
+    let options;
+    let server;
+
+    beforeEach(async function () {
+      certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
+        isPublished: true,
+        framework: Frameworks.EDU_1ER_DEGRE,
+        version: AlgorithmEngineVersion.V3,
+      }).id;
+      databaseBuilder.factory.buildAssessmentResult.last({
+        certificationCourseId,
+        reachedMeshIndex: 0,
+        eduV3ExternalJuryResult: null,
+      });
+      await databaseBuilder.commit();
+
+      server = await createServer();
+
+      options = {
+        method: 'POST',
+        url: `/api/admin/certification-courses/${certificationCourseId}/edu-v3-external-jury-result`,
+        headers: generateAuthenticatedUserRequestHeaders(),
+        payload: {
+          data: {
+            attributes: {
+              'edu-v3-external-jury-result': PIX_PLUS_EDU_EXTERNAL_LEVELS.ADVANCED,
+            },
+          },
+        },
+      };
+      return insertUserWithRoleSuperAdmin();
+    });
+
+    it('should save edu v3 external jury result in database and return the refreshed certification', async function () {
+      // when
+      const response = await server.inject(options);
+
+      // then
+      const assessmentResults = await knex('assessment-results').orderBy('createdAt', 'desc');
+      expect(assessmentResults).to.have.lengthOf(1);
+      expect(assessmentResults[0].eduV3ExternalJuryResult).to.equal(PIX_PLUS_EDU_EXTERNAL_LEVELS.ADVANCED);
+      expect(response.statusCode).to.equal(200);
     });
   });
 });

--- a/api/tests/certification/session-management/integration/domain/usecases/update-edu-v3-external-jury-result_test.js
+++ b/api/tests/certification/session-management/integration/domain/usecases/update-edu-v3-external-jury-result_test.js
@@ -1,0 +1,68 @@
+import { usecases } from '../../../../../../src/certification/session-management/domain/usecases/index.js';
+import { PIX_PLUS_EDU_EXTERNAL_LEVELS } from '../../../../../../src/certification/shared/domain/constants/mesh-configuration.js';
+import { AlgorithmEngineVersion } from '../../../../../../src/certification/shared/domain/models/AlgorithmEngineVersion.js';
+import { Frameworks } from '../../../../../../src/certification/shared/domain/models/Frameworks.js';
+import { catchErr, databaseBuilder, domainBuilder, expect } from '../../../../../test-helper.js';
+
+describe('Certification | Session Management | Integration | Domain | UseCase | Update Edu v3 External Jury result', function () {
+  context('when certification is does not exist', function () {
+    it('throws an Error', async function () {
+      const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
+        isPublished: false,
+        framework: Frameworks.EDU_1ER_DEGRE,
+        version: AlgorithmEngineVersion.V3,
+      }).id;
+      databaseBuilder.factory.buildAssessmentResult.last({
+        certificationCourseId,
+        reachedMeshIndex: 0,
+        eduV3ExternalJuryResult: null,
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const err = await catchErr(usecases.updateEduV3ExternalJuryResult)({
+        certificationCourseId: certificationCourseId + 1,
+        eduV3ExternalJuryResult: PIX_PLUS_EDU_EXTERNAL_LEVELS.EXPERT,
+      });
+
+      expect(err.message).to.equal(`Certification course of id ${certificationCourseId + 1} does not exist.`);
+    });
+  });
+
+  context('success case', function () {
+    it('updates the certification and returns the update certification', async function () {
+      const certificationCourse = databaseBuilder.factory.buildCertificationCourse({
+        isPublished: true,
+        framework: Frameworks.EDU_1ER_DEGRE,
+        version: AlgorithmEngineVersion.V3,
+      });
+      const assessmentResult = databaseBuilder.factory.buildAssessmentResult.last({
+        certificationCourseId: certificationCourse.id,
+        reachedMeshIndex: 0,
+        eduV3ExternalJuryResult: null,
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const juryCertificationUpdated = await usecases.updateEduV3ExternalJuryResult({
+        certificationCourseId: certificationCourse.id,
+        eduV3ExternalJuryResult: PIX_PLUS_EDU_EXTERNAL_LEVELS.EXPERT,
+      });
+
+      expect(juryCertificationUpdated).to.deepEqualInstance(
+        domainBuilder.certification.sessionManagement.buildJuryCertification({
+          ...assessmentResult,
+          ...certificationCourse,
+          eduV3ExternalJuryResult: PIX_PLUS_EDU_EXTERNAL_LEVELS.EXPERT,
+          certificationCourseId: certificationCourse.id,
+          version: AlgorithmEngineVersion.V3,
+          certificationFramework: Frameworks.EDU_1ER_DEGRE,
+          commentForCandidate: 'Some comment for candidate',
+          certificationIssueReports: [],
+          commentByJury: null,
+          competenceMarks: [],
+        }),
+      );
+    });
+  });
+});

--- a/api/tests/certification/session-management/unit/application/certification-course-route_test.js
+++ b/api/tests/certification/session-management/unit/application/certification-course-route_test.js
@@ -1,5 +1,6 @@
 import { certificationCourseController } from '../../../../../src/certification/session-management/application/certification-course-controller.js';
 import * as moduleUnderTest from '../../../../../src/certification/session-management/application/certification-course-route.js';
+import { PIX_PLUS_EDU_EXTERNAL_LEVELS } from '../../../../../src/certification/shared/domain/constants/mesh-configuration.js';
 import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
 import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
 
@@ -99,6 +100,152 @@ describe('Certification | Session Management | Unit | Application | Routes | Cer
 
       // then
       expect(response.statusCode).to.equal(403);
+    });
+  });
+
+  describe('POST /api/admin/certification-courses/{certificationCourseId}/edu-v3-external-jury-result', function () {
+    let validPayload;
+
+    beforeEach(function () {
+      validPayload = {
+        data: {
+          attributes: {
+            'edu-v3-external-jury-result': null,
+          },
+        },
+      };
+    });
+
+    it('return forbidden access if user has a role that is not allowed', async function () {
+      // given
+      const securityPrehandlerStub = sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf');
+      securityPrehandlerStub
+        .withArgs([
+          securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+          securityPreHandlers.checkAdminMemberHasRoleCertif,
+        ])
+        .callsFake(
+          () => (request, h) =>
+            h
+              .response({ errors: new Error('forbidden') })
+              .code(403)
+              .takeover(),
+        );
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      const response = await httpTestServer.request(
+        'POST',
+        '/api/admin/certification-courses/1/edu-v3-external-jury-result',
+        validPayload,
+      );
+
+      // then
+      expect(response.statusCode).to.equal(403);
+    });
+
+    it('return bad request if certification course ID is not a number ', async function () {
+      // given
+      sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      const response = await httpTestServer.request(
+        'POST',
+        '/api/admin/certification-courses/coucou/edu-v3-external-jury-result',
+        validPayload,
+      );
+
+      // then
+      expect(response.statusCode).to.equal(400);
+      expect(JSON.stringify(response.payload)).to.includes('certificationCourseId');
+      expect(JSON.stringify(response.payload)).to.includes('must be a number');
+    });
+
+    it('return bad request if extra unexpected attributes are added to the payload', async function () {
+      // given
+      const invalidPayload = structuredClone(validPayload);
+      invalidPayload.data.attributes.coucou = 'cava';
+      sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      const response = await httpTestServer.request(
+        'POST',
+        '/api/admin/certification-courses/1/edu-v3-external-jury-result',
+        invalidPayload,
+      );
+
+      // then
+      expect(response.statusCode).to.equal(400);
+      expect(JSON.stringify(response.payload)).to.includes('data.attributes.coucou');
+      expect(JSON.stringify(response.payload)).to.includes('is not allowed');
+    });
+
+    it('return bad request if invalid value in edu-v3-external-jury-result', async function () {
+      // given
+      const invalidPayload = structuredClone(validPayload);
+      invalidPayload.data.attributes['edu-v3-external-jury-result'] = 'cava';
+      sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      const response = await httpTestServer.request(
+        'POST',
+        '/api/admin/certification-courses/1/edu-v3-external-jury-result',
+        invalidPayload,
+      );
+
+      // then
+      expect(response.statusCode).to.equal(400);
+      expect(JSON.stringify(response.payload)).to.includes('data.attributes.edu-v3-external-jury-result');
+      expect(JSON.stringify(response.payload)).to.includes('must be one of [null, ADVANCED, EXPERT]');
+    });
+
+    it('return bad request if edu-v3-external-jury-result is empty', async function () {
+      // given
+      const invalidPayload = structuredClone(validPayload);
+      invalidPayload.data.attributes['edu-v3-external-jury-result'] = undefined;
+      sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      const response = await httpTestServer.request(
+        'POST',
+        '/api/admin/certification-courses/1/edu-v3-external-jury-result',
+        invalidPayload,
+      );
+
+      // then
+      expect(response.statusCode).to.equal(400);
+      expect(JSON.stringify(response.payload)).to.includes('data.attributes.edu-v3-external-jury-result');
+      expect(JSON.stringify(response.payload)).to.includes('is required');
+    });
+
+    [null, ...Object.values(PIX_PLUS_EDU_EXTERNAL_LEVELS)].forEach(function (eduV3Result) {
+      it(`executes the handler controller when request is valid and edu-v3-external-jury-result is ${eduV3Result}`, async function () {
+        // given
+        validPayload.data.attributes['edu-v3-external-jury-result'] = eduV3Result;
+        sinon.stub(certificationCourseController, 'updateEduV3ExternalJuryResult').returns('ok');
+        sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const response = await httpTestServer.request(
+          'POST',
+          '/api/admin/certification-courses/1/edu-v3-external-jury-result',
+          validPayload,
+        );
+
+        // then
+        expect(response.statusCode).to.equal(200);
+      });
     });
   });
 

--- a/api/tests/certification/session-management/unit/domain/models/JuryCertification_test.js
+++ b/api/tests/certification/session-management/unit/domain/models/JuryCertification_test.js
@@ -320,4 +320,104 @@ describe('Unit | Domain | Models | JuryCertification', function () {
       });
     });
   });
+
+  describe('#updateEduV3ExternalJuryResult', function () {
+    context('when certification is not published', function () {
+      it('throws an error', function () {
+        const juryCertificationSummary = domainBuilder.certification.sessionManagement.buildJuryCertification({
+          version: AlgorithmEngineVersion.V3,
+          certificationFramework: Frameworks.EDU_1ER_DEGRE,
+          isPublished: false,
+          reachedMeshIndex: 0,
+        });
+
+        expect(() =>
+          juryCertificationSummary.updateEduV3ExternalJuryResult(PIX_PLUS_EDU_EXTERNAL_LEVELS.ADVANCED),
+        ).to.throw('Impossible de définir le résultat du volet externe pour une certification non publiée');
+      });
+    });
+
+    context('when certification is not v3', function () {
+      it('throws an error', function () {
+        const juryCertificationSummaryV1 = domainBuilder.certification.sessionManagement.buildJuryCertification({
+          version: AlgorithmEngineVersion.V2,
+          certificationFramework: Frameworks.EDU_1ER_DEGRE,
+          isPublished: true,
+          reachedMeshIndex: 0,
+        });
+        const juryCertificationSummaryV2 = domainBuilder.certification.sessionManagement.buildJuryCertification({
+          version: AlgorithmEngineVersion.V2,
+          certificationFramework: Frameworks.EDU_CPE,
+          isPublished: true,
+          reachedMeshIndex: 0,
+        });
+
+        expect(() =>
+          juryCertificationSummaryV1.updateEduV3ExternalJuryResult(PIX_PLUS_EDU_EXTERNAL_LEVELS.ADVANCED),
+        ).to.throw('Impossible de définir le résultat du volet externe pour une certification non V3');
+
+        expect(() =>
+          juryCertificationSummaryV2.updateEduV3ExternalJuryResult(PIX_PLUS_EDU_EXTERNAL_LEVELS.ADVANCED),
+        ).to.throw('Impossible de définir le résultat du volet externe pour une certification non V3');
+      });
+    });
+
+    context('when certification is not "EDU"', function () {
+      [Frameworks.CORE, Frameworks.CLEA, Frameworks.DROIT, Frameworks.PRO_SANTE].forEach(function (framework) {
+        it(`throws an error when certification is ${framework}`, function () {
+          const juryCertificationSummary = domainBuilder.certification.sessionManagement.buildJuryCertification({
+            version: AlgorithmEngineVersion.V3,
+            certificationFramework: framework,
+            isPublished: true,
+            reachedMeshIndex: 0,
+          });
+
+          expect(() =>
+            juryCertificationSummary.updateEduV3ExternalJuryResult(PIX_PLUS_EDU_EXTERNAL_LEVELS.ADVANCED),
+          ).to.throw('Impossible de définir le résultat du volet externe pour une certification non "EDU"');
+        });
+      });
+    });
+
+    context('when certification is "Non admissible"', function () {
+      it('throws an error', function () {
+        const juryCertificationSummary = domainBuilder.certification.sessionManagement.buildJuryCertification({
+          version: AlgorithmEngineVersion.V3,
+          certificationFramework: Frameworks.EDU_1ER_DEGRE,
+          isPublished: true,
+          reachedMeshIndex: null,
+        });
+
+        expect(() =>
+          juryCertificationSummary.updateEduV3ExternalJuryResult(PIX_PLUS_EDU_EXTERNAL_LEVELS.ADVANCED),
+        ).to.throw('Impossible de définir le résultat du volet externe pour une certification EDU non admissible');
+      });
+    });
+
+    context('when all conditions are reunited', function () {
+      [Frameworks.EDU_CPE, Frameworks.EDU_1ER_DEGRE, Frameworks.EDU_2ND_DEGRE].forEach(function (framework) {
+        it(`update the edu v3 external jury result value when certification is ${framework}`, function () {
+          const juryCertificationSummary = domainBuilder.certification.sessionManagement.buildJuryCertification({
+            version: AlgorithmEngineVersion.V3,
+            certificationFramework: framework,
+            isPublished: true,
+            reachedMeshIndex: 0,
+            eduV3ExternalJuryResult: null,
+          });
+
+          juryCertificationSummary.updateEduV3ExternalJuryResult(PIX_PLUS_EDU_EXTERNAL_LEVELS.ADVANCED);
+
+          expect(juryCertificationSummary).to.deepEqualInstance(
+            domainBuilder.certification.sessionManagement.buildJuryCertification({
+              version: AlgorithmEngineVersion.V3,
+              certificationFramework: framework,
+              isPublished: true,
+              reachedMeshIndex: 0,
+              eduV3ExternalJuryResult: PIX_PLUS_EDU_EXTERNAL_LEVELS.ADVANCED,
+            }),
+          );
+        });
+      });
+    });
+  });
 });

--- a/api/tests/certification/session-management/unit/domain/models/JuryCertification_test.js
+++ b/api/tests/certification/session-management/unit/domain/models/JuryCertification_test.js
@@ -3,6 +3,7 @@ import { PIX_PLUS_EDU_EXTERNAL_LEVELS } from '../../../../../../src/certificatio
 import { AlgorithmEngineVersion } from '../../../../../../src/certification/shared/domain/models/AlgorithmEngineVersion.js';
 import { Frameworks } from '../../../../../../src/certification/shared/domain/models/Frameworks.js';
 import { AutoJuryCommentKeys } from '../../../../../../src/certification/shared/domain/models/JuryComment.js';
+import { AssessmentResult } from '../../../../../../src/shared/domain/models/AssessmentResult.js';
 import { domainBuilder, expect } from '../../../../../test-helper.js';
 
 describe('Unit | Domain | Models | JuryCertification', function () {
@@ -329,12 +330,33 @@ describe('Unit | Domain | Models | JuryCertification', function () {
           certificationFramework: Frameworks.EDU_1ER_DEGRE,
           isPublished: false,
           reachedMeshIndex: 0,
+          status: AssessmentResult.status.VALIDATED,
         });
 
         expect(() =>
           juryCertificationSummary.updateEduV3ExternalJuryResult(PIX_PLUS_EDU_EXTERNAL_LEVELS.ADVANCED),
         ).to.throw('Impossible de définir le résultat du volet externe pour une certification non publiée');
       });
+    });
+
+    context('when certification is not validated', function () {
+      [AssessmentResult.status.ERROR, AssessmentResult.status.REJECTED, AssessmentResult.status.CANCELLED].forEach(
+        function (assessmentResultStatus) {
+          it(`throws an error when status is ${assessmentResultStatus}`, function () {
+            const juryCertificationSummary = domainBuilder.certification.sessionManagement.buildJuryCertification({
+              version: AlgorithmEngineVersion.V3,
+              certificationFramework: Frameworks.EDU_1ER_DEGRE,
+              isPublished: true,
+              reachedMeshIndex: 0,
+              status: assessmentResultStatus,
+            });
+
+            expect(() =>
+              juryCertificationSummary.updateEduV3ExternalJuryResult(PIX_PLUS_EDU_EXTERNAL_LEVELS.ADVANCED),
+            ).to.throw('Impossible de définir le résultat du volet externe pour une certification non validée');
+          });
+        },
+      );
     });
 
     context('when certification is not v3', function () {
@@ -344,12 +366,14 @@ describe('Unit | Domain | Models | JuryCertification', function () {
           certificationFramework: Frameworks.EDU_1ER_DEGRE,
           isPublished: true,
           reachedMeshIndex: 0,
+          status: AssessmentResult.status.VALIDATED,
         });
         const juryCertificationSummaryV2 = domainBuilder.certification.sessionManagement.buildJuryCertification({
           version: AlgorithmEngineVersion.V2,
           certificationFramework: Frameworks.EDU_CPE,
           isPublished: true,
           reachedMeshIndex: 0,
+          status: AssessmentResult.status.VALIDATED,
         });
 
         expect(() =>
@@ -370,6 +394,7 @@ describe('Unit | Domain | Models | JuryCertification', function () {
             certificationFramework: framework,
             isPublished: true,
             reachedMeshIndex: 0,
+            status: AssessmentResult.status.VALIDATED,
           });
 
           expect(() =>
@@ -386,6 +411,7 @@ describe('Unit | Domain | Models | JuryCertification', function () {
           certificationFramework: Frameworks.EDU_1ER_DEGRE,
           isPublished: true,
           reachedMeshIndex: null,
+          status: AssessmentResult.status.VALIDATED,
         });
 
         expect(() =>
@@ -403,6 +429,7 @@ describe('Unit | Domain | Models | JuryCertification', function () {
             isPublished: true,
             reachedMeshIndex: 0,
             eduV3ExternalJuryResult: null,
+            status: AssessmentResult.status.VALIDATED,
           });
 
           juryCertificationSummary.updateEduV3ExternalJuryResult(PIX_PLUS_EDU_EXTERNAL_LEVELS.ADVANCED);
@@ -414,6 +441,7 @@ describe('Unit | Domain | Models | JuryCertification', function () {
               isPublished: true,
               reachedMeshIndex: 0,
               eduV3ExternalJuryResult: PIX_PLUS_EDU_EXTERNAL_LEVELS.ADVANCED,
+              status: AssessmentResult.status.VALIDATED,
             }),
           );
         });

--- a/high-level-tests/e2e-playwright/pages/pix-admin/CertificationInformationPage.ts
+++ b/high-level-tests/e2e-playwright/pages/pix-admin/CertificationInformationPage.ts
@@ -2,6 +2,8 @@ import type { Page } from '@playwright/test';
 
 import { getNumberValueFromDescriptionList, getStringValueFromDescriptionList } from '../../helpers/utils.ts';
 
+export type EXTERNAL_JURY_LEVELS = 'En attente' | 'Avancé' | 'Expert';
+
 export class CertificationInformationPage {
   constructor(public readonly page: Page) {}
 
@@ -131,5 +133,12 @@ export class CertificationInformationPage {
     await this.page.getByRole('button', { name: 'Re-scorer la certification' }).click();
 
     await this.page.getByText('La certification a bien été rescorée').waitFor({ state: 'visible' });
+  }
+
+  async setExternalJuryResult(externalJuryChoice: EXTERNAL_JURY_LEVELS) {
+    await this.page.getByRole('button', { name: 'Modifier le volet jury', exact: true }).click();
+    await this.page.getByRole('button', { name: 'Sélectionner un niveau' }).click();
+    await this.page.getByRole('option', { name: externalJuryChoice }).click();
+    await this.page.getByRole('button', { name: 'Enregistrer' }).click();
   }
 }

--- a/high-level-tests/e2e-playwright/pages/pix-admin/CertificationSessionsMainPage.ts
+++ b/high-level-tests/e2e-playwright/pages/pix-admin/CertificationSessionsMainPage.ts
@@ -1,7 +1,7 @@
 import type { Page } from '@playwright/test';
 
 import { waitForVisibleWithReload } from '../../helpers/utils.ts';
-import { CertificationSessionPage } from './index.ts';
+import { CertificationInformationPage, CertificationSessionPage } from './index.ts';
 
 export class CertificationSessionsMainPage {
   constructor(public readonly page: Page) {}
@@ -46,5 +46,12 @@ export class CertificationSessionsMainPage {
       has: this.page.getByText(sessionNumber, { exact: true }),
     });
     await row.waitFor({ state: 'detached' });
+  }
+
+  async goToCertificationWithSearchBar(certificationNumber: string) {
+    await this.page.getByLabel('Rechercher une certification avec un identifiant').fill(certificationNumber);
+    await this.page.getByRole('button', { name: 'Charger' }).click();
+    await this.page.waitForURL(/\/sessions\/certification\/\d+$/);
+    return new CertificationInformationPage(this.page);
   }
 }

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/edu/EDU_0OK-32KO.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/edu/EDU_0OK-32KO.spec.ts
@@ -152,6 +152,14 @@ test(
       ]);
     });
 
+    await test.step('Cannot set external jury result', async () => {
+      await pixAdminRoleCertifPage.goto(process.env.PIX_ADMIN_URL!);
+      const adminHomepage = new AdminHomePage(pixAdminRoleCertifPage);
+      const sessionsMainPage = await adminHomepage.goToCertificationSessionsTab();
+      await sessionsMainPage.goToCertificationWithSearchBar(certificationNumber);
+      await expect(pixAdminRoleCertifPage.getByText('Résultats de la certification Pix+ Edu')).not.toBeVisible();
+    });
+
     await snapshotHandler.expectOrRecord(snapshotPath);
   },
 );

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/edu/EDU_1OK-0KO_EndedByFinalization_Abandonment.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/edu/EDU_1OK-0KO_EndedByFinalization_Abandonment.spec.ts
@@ -151,6 +151,14 @@ test(
       ]);
     });
 
+    await test.step('Cannot set external jury result', async () => {
+      await pixAdminRoleCertifPage.goto(process.env.PIX_ADMIN_URL!);
+      const adminHomepage = new AdminHomePage(pixAdminRoleCertifPage);
+      const sessionsMainPage = await adminHomepage.goToCertificationSessionsTab();
+      await sessionsMainPage.goToCertificationWithSearchBar(certificationNumber);
+      await expect(pixAdminRoleCertifPage.getByText('Résultats de la certification Pix+ Edu')).not.toBeVisible();
+    });
+
     await snapshotHandler.expectOrRecord(snapshotPath);
   },
 );

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/edu/EDU_1OK-0KO_EndedByFinalization_TechnicalIssue.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/edu/EDU_1OK-0KO_EndedByFinalization_TechnicalIssue.spec.ts
@@ -151,6 +151,14 @@ test(
       ]);
     });
 
+    await test.step('Cannot set external jury result', async () => {
+      await pixAdminRoleCertifPage.goto(process.env.PIX_ADMIN_URL!);
+      const adminHomepage = new AdminHomePage(pixAdminRoleCertifPage);
+      const sessionsMainPage = await adminHomepage.goToCertificationSessionsTab();
+      await sessionsMainPage.goToCertificationWithSearchBar(certificationNumber);
+      await expect(pixAdminRoleCertifPage.getByText('Résultats de la certification Pix+ Edu')).not.toBeVisible();
+    });
+
     await snapshotHandler.expectOrRecord(snapshotPath);
   },
 );

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/edu/EDU_1OK-0KO_EndedByInvigilator_Abandonment.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/edu/EDU_1OK-0KO_EndedByInvigilator_Abandonment.spec.ts
@@ -156,6 +156,14 @@ test(
       ]);
     });
 
+    await test.step('Cannot set external jury result', async () => {
+      await pixAdminRoleCertifPage.goto(process.env.PIX_ADMIN_URL!);
+      const adminHomepage = new AdminHomePage(pixAdminRoleCertifPage);
+      const sessionsMainPage = await adminHomepage.goToCertificationSessionsTab();
+      await sessionsMainPage.goToCertificationWithSearchBar(certificationNumber);
+      await expect(pixAdminRoleCertifPage.getByText('Résultats de la certification Pix+ Edu')).not.toBeVisible();
+    });
+
     await snapshotHandler.expectOrRecord(snapshotPath);
   },
 );

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/edu/EDU_1OK-0KO_EndedByInvigilator_TechnicalIssue.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/edu/EDU_1OK-0KO_EndedByInvigilator_TechnicalIssue.spec.ts
@@ -156,6 +156,14 @@ test(
       ]);
     });
 
+    await test.step('Cannot set external jury result', async () => {
+      await pixAdminRoleCertifPage.goto(process.env.PIX_ADMIN_URL!);
+      const adminHomepage = new AdminHomePage(pixAdminRoleCertifPage);
+      const sessionsMainPage = await adminHomepage.goToCertificationSessionsTab();
+      await sessionsMainPage.goToCertificationWithSearchBar(certificationNumber);
+      await expect(pixAdminRoleCertifPage.getByText('Résultats de la certification Pix+ Edu')).not.toBeVisible();
+    });
+
     await snapshotHandler.expectOrRecord(snapshotPath);
   },
 );

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/edu/EDU_32OK-0KO.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/edu/EDU_32OK-0KO.spec.ts
@@ -15,7 +15,7 @@ const snapshotPath = `recette-certif/${testRef}/${testRef}.json`;
 const csvResultPath = `recette-certif/${testRef}/${testRef}_csvresult.json`;
 
 test(
-  `${testRef} - User takes a certification test for a Pix+ Edu subscription. 32 right answers`,
+  `${testRef} - User takes a certification test for a Pix+ Edu subscription. 32 right answers. Volet externe also attributed`,
   {
     tag: ['@snapshot'],
     annotation: [
@@ -150,6 +150,102 @@ test(
         'Numéro de certification',
         'Centre de certification',
       ]);
+    });
+
+    await test.step('Setting external jury result to EXPERT', async () => {
+      await test.step('Set value', async () => {
+        await pixAdminRoleCertifPage.goto(process.env.PIX_ADMIN_URL!);
+        const adminHomepage = new AdminHomePage(pixAdminRoleCertifPage);
+        const sessionsMainPage = await adminHomepage.goToCertificationSessionsTab();
+        const certificationInformationPage = await sessionsMainPage.goToCertificationWithSearchBar(certificationNumber);
+        await certificationInformationPage.setExternalJuryResult('Expert');
+        await pixAdminRoleCertifPage
+          .getByText('Le résultat du volet jury externe a bien été enregistré')
+          .waitFor({ state: 'visible' });
+        await pixAdminRoleCertifPage.getByRole('button', { name: 'Fermer la notification' }).click();
+      });
+
+      await test.step('Check result is impacted everywhere', async () => {
+        await pixAdminRoleCertifPage.goto(process.env.PIX_ADMIN_URL!);
+        const adminHomepage = new AdminHomePage(pixAdminRoleCertifPage);
+        const sessionPage = await adminHomepage.goToSession(sessionNumber);
+        const certificationListPage = await sessionPage.goToCertificationListPage();
+        const certificationData = await certificationListPage.getCertificationData();
+        expect(certificationData.length).toBe(1);
+        expect(certificationData[0]).toMatchObject({
+          Prénom: certifiableUserData.firstName,
+          Nom: certifiableUserData.lastName,
+          Statut: 'Validée',
+          Résultats: 'Expert',
+          'Signalements impactants non résolus': '',
+          'Certification passée': 'Pix+ Édu 1er degré',
+        });
+        const certificationInformationPage = await certificationListPage.goToCertificationInfoPage(
+          certifiableUserData.firstName,
+        );
+        await checkCertificationGeneralInformationAndExpectSuccess(certificationInformationPage, {
+          sessionNumber,
+          status: 'Validée',
+          result: 'Expert',
+        });
+        await checkCertificationDetailsAndExpectSuccess(certificationInformationPage, {
+          status: 'Validée',
+          nbAnsweredQuestionsOverTotal: '32/32',
+          nbQuestionsOK: 32,
+          nbQuestionsKO: 0,
+          nbQuestionsAband: 0,
+          nbValidatedTechnicalIssues: 0,
+          result: 'Expert',
+        });
+      });
+    });
+
+    await test.step('Setting external jury result to PENDING', async () => {
+      await test.step('Set value', async () => {
+        await pixAdminRoleCertifPage.goto(process.env.PIX_ADMIN_URL!);
+        const adminHomepage = new AdminHomePage(pixAdminRoleCertifPage);
+        const sessionsMainPage = await adminHomepage.goToCertificationSessionsTab();
+        const certificationInformationPage = await sessionsMainPage.goToCertificationWithSearchBar(certificationNumber);
+        await certificationInformationPage.setExternalJuryResult('En attente');
+        await pixAdminRoleCertifPage
+          .getByText('Le résultat du volet jury externe a bien été enregistré')
+          .waitFor({ state: 'visible' });
+        await pixAdminRoleCertifPage.getByRole('button', { name: 'Fermer la notification' }).click();
+      });
+
+      await test.step('Check result is impacted everywhere', async () => {
+        await pixAdminRoleCertifPage.goto(process.env.PIX_ADMIN_URL!);
+        const adminHomepage = new AdminHomePage(pixAdminRoleCertifPage);
+        const sessionPage = await adminHomepage.goToSession(sessionNumber);
+        const certificationListPage = await sessionPage.goToCertificationListPage();
+        const certificationData = await certificationListPage.getCertificationData();
+        expect(certificationData.length).toBe(1);
+        expect(certificationData[0]).toMatchObject({
+          Prénom: certifiableUserData.firstName,
+          Nom: certifiableUserData.lastName,
+          Statut: 'Validée',
+          Résultats: 'Admissible',
+          'Signalements impactants non résolus': '',
+          'Certification passée': 'Pix+ Édu 1er degré',
+        });
+        const certificationInformationPage = await certificationListPage.goToCertificationInfoPage(
+          certifiableUserData.firstName,
+        );
+        await checkCertificationGeneralInformationAndExpectSuccess(certificationInformationPage, {
+          sessionNumber,
+          status: 'Validée',
+          result: 'Admissible',
+        });
+        await checkCertificationDetailsAndExpectSuccess(certificationInformationPage, {
+          status: 'Validée',
+          nbAnsweredQuestionsOverTotal: '32/32',
+          nbQuestionsOK: 32,
+          nbQuestionsKO: 0,
+          nbQuestionsAband: 0,
+          nbValidatedTechnicalIssues: 0,
+          result: 'Admissible',
+        });
+      });
     });
 
     await snapshotHandler.expectOrRecord(snapshotPath);

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/edu/EDU_32OK-0KO_RejectForFraud.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/edu/EDU_32OK-0KO_RejectForFraud.spec.ts
@@ -163,6 +163,14 @@ test(
       ]);
     });
 
+    await test.step('Cannot set external jury result', async () => {
+      await pixAdminRoleCertifPage.goto(process.env.PIX_ADMIN_URL!);
+      const adminHomepage = new AdminHomePage(pixAdminRoleCertifPage);
+      const sessionsMainPage = await adminHomepage.goToCertificationSessionsTab();
+      await sessionsMainPage.goToCertificationWithSearchBar(certificationNumber);
+      await expect(pixAdminRoleCertifPage.getByText('Résultats de la certification Pix+ Edu')).not.toBeVisible();
+    });
+
     await snapshotHandler.expectOrRecord(snapshotPath);
   },
 );

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/edu/EDU_32OK-0KO_Rescore.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/edu/EDU_32OK-0KO_Rescore.spec.ts
@@ -118,6 +118,7 @@ test(
           nbValidatedTechnicalIssues: 0,
           result: 'Admissible',
         });
+
         await test.step('Rescore certification and check for scoring', async () => {
           await test.step('Alter candidate answers directly in BDD to have all answers wrong, to demonstrate re-scoring', async () => {
             const wrongAnswersSequence = Array(32).fill(false);
@@ -166,6 +167,14 @@ test(
         'Numéro de certification',
         'Centre de certification',
       ]);
+    });
+
+    await test.step('Cannot set external jury result', async () => {
+      await pixAdminRoleCertifPage.goto(process.env.PIX_ADMIN_URL!);
+      const adminHomepage = new AdminHomePage(pixAdminRoleCertifPage);
+      const sessionsMainPage = await adminHomepage.goToCertificationSessionsTab();
+      await sessionsMainPage.goToCertificationWithSearchBar(certificationNumber);
+      await expect(pixAdminRoleCertifPage.getByText('Résultats de la certification Pix+ Edu')).not.toBeVisible();
     });
 
     await snapshotHandler.expectOrRecord(snapshotPath);


### PR DESCRIPTION
## 🌱 Problème

Sur PixAdmin, il n'est pas encore possible d'ajouter un niveau pour le volet externe d'une certification v3 Pix+ Edu.

## 🐣 Proposition

Dans une [précédente PR](https://github.com/1024pix/pix/pull/15740), nous avons fait une migration pour ajouter la colonne `eduV3ExternalJuryResult` dans la table `assessment-results`.

Dans cette nouvelle PR : 
- Nous ajoutons un endpoint permettant la sauvegarde d'un niveau de volet externe.
- Côté Admin : 
  * nous créons des composants spécifiques à la v3,
  * nous permettons la sauvegarde d'un niveau de volet externe.

## 🐝 Pour tester

- Se connecter sur PixAdmin en RA
- Visiter la [session dédiée](https://admin-pr15725.review.pix.fr/sessions/7409/certifications) à du Pix+edu en v3
- Modifier le volet externe d'une des certifications
