### PR TITLE
[BUGFIX] Éviter les problématiques de timezone des dates de PixCertif (PIX-22206).

### DIFF
--- a/certif/app/components/add-student-list.gjs
+++ b/certif/app/components/add-student-list.gjs
@@ -11,10 +11,11 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import dayjsFormat from 'ember-dayjs/helpers/dayjs-format';
 import t from 'ember-intl/helpers/t';
 import or from 'ember-truth-helpers/helpers/or';
 import some from 'lodash/some';
+
+import dayjsUtcFormat from '../helpers/dayjs-utc-format';
 
 export default class AddStudentList extends Component {
   @service pixToast;
@@ -204,7 +205,7 @@ export default class AddStudentList extends Component {
               {{t 'pages.sco.enrol-candidates-in-session.list.table.birthdate'}}
             </:header>
             <:cell>
-              {{dayjsFormat student.birthdate 'DD/MM/YYYY'}}
+              {{dayjsUtcFormat student.birthdate 'DD/MM/YYYY'}}
             </:cell>
           </PixTableColumn>
         </:columns>

--- a/certif/app/components/login-session-invigilator/form.gjs
+++ b/certif/app/components/login-session-invigilator/form.gjs
@@ -7,11 +7,9 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import dayjs from 'dayjs';
-import LocalizedFormat from 'dayjs/plugin/localizedFormat';
 import { t } from 'ember-intl';
 
-dayjs.extend(LocalizedFormat);
+import { dayjsUtcFormat } from '../../helpers/dayjs-utc-format';
 
 export default class LoginSessionInvigilator extends Component {
   @service intl;
@@ -52,7 +50,7 @@ export default class LoginSessionInvigilator extends Component {
           break;
         case 'SESSION_NOT_ACCESSIBLE':
           this.formError = this.intl.t('pages.session-supervising.login.form.errors.session-not-accessible', {
-            date: dayjs(error.meta?.blockedAccessDate).format('L'),
+            date: dayjsUtcFormat([error.meta?.blockedAccessDate, 'DD/MM/YYYY'], {}),
           });
           break;
         default:

--- a/certif/app/components/session-supervising/candidate-in-list.gjs
+++ b/certif/app/components/session-supervising/candidate-in-list.gjs
@@ -9,9 +9,7 @@ import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import dayjs from 'dayjs';
-import LocalizedFormat from 'dayjs/plugin/localizedFormat';
 import utc from 'dayjs/plugin/utc';
-import dayjsFormat from 'ember-dayjs/helpers/dayjs-format';
 import t from 'ember-intl/helpers/t';
 import Content from 'pix-certif/components/dropdown/content';
 import Item from 'pix-certif/components/dropdown/item';
@@ -21,7 +19,9 @@ import HandleLiveAlertModal from 'pix-certif/components/session-supervising/hand
 import LiveAlertHandledModal from 'pix-certif/components/session-supervising/live-alert-handled-modal';
 import formatPercentage from 'pix-certif/helpers/format-percentage';
 
-dayjs.extend(LocalizedFormat);
+import dayjsUtcFormatHelper from '../../helpers/dayjs-utc-format';
+import { dayjsUtcFormat } from '../../helpers/dayjs-utc-format';
+
 dayjs.extend(utc);
 
 const Modals = {
@@ -56,9 +56,7 @@ export default class CandidateInList extends Component {
   }
 
   get formattedBirthdate() {
-    if (!this.args.candidate.birthdate) return '';
-
-    return dayjs.utc(this.args.candidate.birthdate).format('L');
+    return dayjsUtcFormat([this.args.candidate.birthdate, 'DD/MM/YYYY'], { allowEmpty: true });
   }
 
   get isConfirmButtonToBeDisplayed() {
@@ -134,20 +132,17 @@ export default class CandidateInList extends Component {
   }
 
   get candidateStartTime() {
-    const startTime = dayjs(this.args.candidate.startDateTime).format('HH:mm');
-    return startTime;
+    return dayjsUtcFormat([this.args.candidate.startDateTime, 'HH:mm'], {});
   }
 
   get candidateTheoricalEndDateTime() {
     const pixPlusDuration = this._getPixPlusDurationInMinutes();
 
     if (pixPlusDuration !== null) {
-      const endTime = dayjs(this.args.candidate.startDateTime).add(pixPlusDuration, 'minute').format('HH:mm');
-      return endTime;
+      return dayjs.utc(this.args.candidate.startDateTime).add(pixPlusDuration, 'minute').format('HH:mm');
     }
 
-    const theoricalEndDateTime = dayjs(this.args.candidate.theoricalEndDateTime).format('HH:mm');
-    return theoricalEndDateTime;
+    return dayjsUtcFormat([this.args.candidate.theoricalEndDateTime, 'HH:mm'], {});
   }
 
   get currentLiveAlertLabel() {
@@ -406,7 +401,7 @@ export default class CandidateInList extends Component {
           </div>
 
           <div class='session-supervising-candidate-in-list__middle-information'>
-            <p>{{dayjsFormat @candidate.birthdate 'DD/MM/YYYY'}}</p>
+            <p>{{dayjsUtcFormatHelper @candidate.birthdate 'DD/MM/YYYY'}}</p>
             {{#if this.shouldDisplayEnrolledComplementaryCertification}}
               <p class='session-supervising-candidate-in-list-details__enrolment'>
                 <PixIcon

--- a/certif/app/components/session-supervising/header.gjs
+++ b/certif/app/components/session-supervising/header.gjs
@@ -5,9 +5,10 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import dayjsFormat from 'ember-dayjs/helpers/dayjs-format';
 import t from 'ember-intl/helpers/t';
 import ConfirmationModal from 'pix-certif/components/session-supervising/confirmation-modal';
+
+import dayjsUtcFormat from '../../helpers/dayjs-utc-format';
 
 export default class Header extends Component {
   @service router;
@@ -65,9 +66,9 @@ export default class Header extends Component {
           sessionId=@session.id
         }}</h1>
       <time class='session-supervising-header__date'>
-        {{dayjsFormat @session.date 'DD/MM/YYYY'}}
+        {{dayjsUtcFormat @session.date 'DD/MM/YYYY'}}
         ·
-        {{dayjsFormat @session.time 'HH:mm' inputFormat='HH:mm:ss' allow-empty=true}}
+        {{dayjsUtcFormat @session.time 'HH:mm' inputFormat='HH:mm:ss' allowEmpty=true}}
       </time>
 
       <dl>

--- a/certif/app/components/sessions/session-details/enrolled-candidates/candidate-creation-modal.gjs
+++ b/certif/app/components/sessions/session-details/enrolled-candidates/candidate-creation-modal.gjs
@@ -12,7 +12,6 @@ import { on } from '@ember/modifier';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import dayjs from 'dayjs';
 import { t } from 'ember-intl';
 
 import { COMPLEMENTARY_KEYS, SUBSCRIPTION_TYPES } from '../../../../models/subscription';
@@ -127,8 +126,7 @@ export default class CandidateCreationModal extends Component {
   };
 
   updateBirthdate = (event) => {
-    const birthdate = dayjs(event.target.value).format('YYYY-MM-DD');
-    this.args.updateCandidateDataFromValue(this.args.candidateData, 'birthdate', birthdate);
+    this.args.updateCandidateDataFromValue(this.args.candidateData, 'birthdate', event.target.value);
   };
 
   updateBillingMode = (billingMode) => {

--- a/certif/app/components/sessions/session-details/enrolled-candidates/candidate-details-modal.gjs
+++ b/certif/app/components/sessions/session-details/enrolled-candidates/candidate-details-modal.gjs
@@ -3,10 +3,10 @@ import PixModal from '@1024pix/pix-ui/components/pix-modal';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
-import dayjs from 'dayjs';
 import { t } from 'ember-intl';
 import { formatPercentage } from 'pix-certif/helpers/format-percentage';
 
+import { dayjsUtcFormat } from '../../../../helpers/dayjs-utc-format';
 import CandidateDetailsModalRow from './candidate-details-modal-row';
 
 const TRANSLATE_PREFIX = 'pages.sessions.detail.candidates';
@@ -22,7 +22,7 @@ const FIELDS = [
   {
     label: 'labels.candidate.birth-date',
     value: 'birthdate',
-    transform: (value) => (value ? dayjs(value).format('DD/MM/YYYY') : undefined),
+    transform: (value) => (value ? dayjsUtcFormat([value, 'DD/MM/YYYY'], {}) : undefined),
   },
   {
     label: 'labels.candidate.gender.title',

--- a/certif/app/components/sessions/session-details/enrolled-candidates/index.gjs
+++ b/certif/app/components/sessions/session-details/enrolled-candidates/index.gjs
@@ -10,12 +10,12 @@ import EmberObject, { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import dayjsFormat from 'ember-dayjs/helpers/dayjs-format';
 import { t } from 'ember-intl';
 import get from 'lodash/get';
 import toNumber from 'lodash/toNumber';
 import { SUBSCRIPTION_TYPES } from 'pix-certif/models/subscription';
 
+import dayjsUtcFormat from '../../../../helpers/dayjs-utc-format';
 import { formatPercentage } from '../../../../helpers/format-percentage';
 import CandidateCreationModal from './candidate-creation-modal';
 import CandidateDetailsModal from './candidate-details-modal';
@@ -361,7 +361,7 @@ export default class EnrolledCandidates extends Component {
               {{t 'common.labels.candidate.birth-date'}}
             </:header>
             <:cell>
-              {{dayjsFormat candidate.birthdate 'DD/MM/YYYY'}}
+              {{dayjsUtcFormat candidate.birthdate 'DD/MM/YYYY'}}
             </:cell>
           </PixTableColumn>
           {{#if @shouldDisplayScoStudentRegistration}}

--- a/certif/app/components/sessions/session-details/header.gjs
+++ b/certif/app/components/sessions/session-details/header.gjs
@@ -1,5 +1,6 @@
-import dayjsFormat from 'ember-dayjs/helpers/dayjs-format';
 import { t } from 'ember-intl';
+
+import dayjsUtcFormat from '../../../helpers/dayjs-utc-format';
 
 <template>
   <div class='session-details__header'>
@@ -11,14 +12,14 @@ import { t } from 'ember-intl';
       <div class='session-details-header-datetime__date'>
         <h2 class='label-text session-details-content__label'>{{t 'common.forms.session-labels.date'}}</h2>
         <span class='content-text content-text--big session-details-header-datetime__text'>
-          {{dayjsFormat @sessionDate 'dddd DD MMM YYYY' allow-empty=true}}
+          {{dayjsUtcFormat @sessionDate 'dddd DD MMM YYYY' allowEmpty=true}}
         </span>
       </div>
 
       <div>
         <h2 class='label-text session-details-content__label'>{{t 'common.forms.session-labels.time-start'}}</h2>
         <span class='content-text content-text--big session-details-header-datetime__text'>
-          {{dayjsFormat @sessionTime 'HH:mm' inputFormat='HH:mm:ss' allow-empty=true}}
+          {{dayjsUtcFormat @sessionTime 'HH:mm' inputFormat='HH:mm:ss' allowEmpty=true}}
         </span>
       </div>
     </div>

--- a/certif/app/components/sessions/session-list.gjs
+++ b/certif/app/components/sessions/session-list.gjs
@@ -9,10 +9,10 @@ import { LinkTo } from '@ember/routing';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import dayjsFormat from 'ember-dayjs/helpers/dayjs-format';
 import { t } from 'ember-intl';
 import get from 'lodash/get';
 
+import dayjsUtcFormat from '../../helpers/dayjs-utc-format';
 import { CREATED, FINALIZED, PROCESSED } from '../../models/session-management';
 import SessionDeleteConfirmModal from './session-delete-confirm-modal';
 
@@ -130,7 +130,7 @@ export default class SessionList extends Component {
               {{t 'common.forms.session-labels.date'}}
             </:header>
             <:cell>
-              {{dayjsFormat sessionSummary.date 'DD/MM/YYYY' allow-empty=true}}
+              {{dayjsUtcFormat sessionSummary.date 'DD/MM/YYYY' allowEmpty=true}}
             </:cell>
           </PixTableColumn>
           <PixTableColumn @context={{context}} class='table__column--small'>
@@ -138,7 +138,7 @@ export default class SessionList extends Component {
               {{t 'common.forms.session-labels.time'}}
             </:header>
             <:cell>
-              {{dayjsFormat sessionSummary.time 'HH:mm' inputFormat='HH:mm:ss' allow-empty=true}}
+              {{dayjsUtcFormat sessionSummary.time 'HH:mm' inputFormat='HH:mm:ss' allowEmpty=true}}
             </:cell>
           </PixTableColumn>
           <PixTableColumn @context={{context}}>

--- a/certif/app/components/team/invitations-list.gjs
+++ b/certif/app/components/team/invitations-list.gjs
@@ -3,8 +3,9 @@ import PixTable from '@1024pix/pix-ui/components/pix-table';
 import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
 import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
 import { fn } from '@ember/helper';
-import dayjsFormat from 'ember-dayjs/helpers/dayjs-format';
 import t from 'ember-intl/helpers/t';
+
+import dayjsUtcFormat from '../../helpers/dayjs-utc-format';
 
 <template>
   {{#if @invitations}}
@@ -23,7 +24,7 @@ import t from 'ember-intl/helpers/t';
             {{t 'pages.team-invitations.table.labels.last-sending-date'}}
           </:header>
           <:cell>
-            {{dayjsFormat invitation.updatedAt 'DD/MM/YYYY [-] HH:mm'}}
+            {{dayjsUtcFormat invitation.updatedAt 'DD/MM/YYYY [-] HH:mm'}}
           </:cell>
         </PixTableColumn>
         <PixTableColumn @context={{context}}>

--- a/certif/app/controllers/authenticated/restricted-access.js
+++ b/certif/app/controllers/authenticated/restricted-access.js
@@ -1,11 +1,7 @@
 import Controller from '@ember/controller';
 import { service } from '@ember/service';
-import dayjs from 'dayjs';
-import LocalizedFormat from 'dayjs/plugin/localizedFormat';
-import utc from 'dayjs/plugin/utc';
 
-dayjs.extend(LocalizedFormat);
-dayjs.extend(utc);
+import { dayjsUtcFormat } from '../../helpers/dayjs-utc-format';
 
 export default class RestrictedAccessController extends Controller {
   @service intl;
@@ -13,13 +9,13 @@ export default class RestrictedAccessController extends Controller {
   get certificationOpeningDate() {
     if (this.model.isAccessBlockedCollege) {
       return this.intl.t('pages.sco.restricted-access.title-access', {
-        date: dayjs(this.model.pixCertifScoBlockedAccessDateCollege).format('L'),
+        date: dayjsUtcFormat([this.model.pixCertifScoBlockedAccessDateCollege, 'DD/MM/YYYY'], {}),
       });
     }
 
     if (this.model.isAccessBlockedLycee || this.model.isAccessBlockedAEFE || this.model.isAccessBlockedAgri) {
       return this.intl.t('pages.sco.restricted-access.title-access', {
-        date: dayjs(this.model.pixCertifScoBlockedAccessDateLycee).format('L'),
+        date: dayjsUtcFormat([this.model.pixCertifScoBlockedAccessDateLycee, 'DD/MM/YYYY'], {}),
       });
     }
 

--- a/certif/app/helpers/dayjs-utc-format.js
+++ b/certif/app/helpers/dayjs-utc-format.js
@@ -1,0 +1,16 @@
+import { helper } from '@ember/component/helper';
+import dayjs from 'dayjs';
+import customParseFormat from 'dayjs/plugin/customParseFormat';
+import utc from 'dayjs/plugin/utc';
+
+dayjs.extend(utc);
+dayjs.extend(customParseFormat);
+
+export function dayjsUtcFormat([value, format], { inputFormat, allowEmpty }) {
+  if (!value) return allowEmpty ? '' : null;
+  const parsed = inputFormat ? dayjs.utc(value, inputFormat) : dayjs.utc(value);
+  if (!parsed.isValid()) return allowEmpty ? '' : null;
+  return parsed.format(format);
+}
+
+export default helper(dayjsUtcFormat);

--- a/certif/tests/acceptance/session-details-certification-candidates-test.js
+++ b/certif/tests/acceptance/session-details-certification-candidates-test.js
@@ -122,7 +122,7 @@ module('Acceptance | Session Details Certification Candidates', function (hooks)
           sessionId: sessionWithCandidates.id,
           isLinked: false,
           resultRecipientEmail: 'cendy@example.com',
-          birthdate: '10-10-2000',
+          birthdate: '2000-10-10',
           externalId: 'EXTERNAL-ID',
           subscriptions: [coreSubscription],
         });
@@ -149,8 +149,6 @@ module('Acceptance | Session Details Certification Candidates', function (hooks)
 
       test('it should display the list of certification candidates', async function (assert) {
         // given
-        const dayjs = this.owner.lookup('service:dayjs');
-
         // when
         const screen = await visit(`/sessions/${sessionWithCandidates.id}/candidats`);
 
@@ -164,9 +162,7 @@ module('Acceptance | Session Details Certification Candidates', function (hooks)
         assert.dom(within(rows[1]).getByRole('cell', { name: 'Cendy' })).exists();
         assert.dom(within(rows[1]).getByRole('cell', { name: 'Alin' })).exists();
         assert.dom(within(rows[1]).getByRole('cell', { name: 'cendy@example.com' })).exists();
-        assert
-          .dom(within(rows[1]).getByRole('cell', { name: dayjs.self('10-10-2000', 'YYYY-MM-DD').format('DD/MM/YYYY') }))
-          .exists();
+        assert.dom(within(rows[1]).getByRole('cell', { name: '10/10/2000' })).exists();
         assert.dom(within(rows[1]).getByRole('cell', { name: '30 %' })).exists();
         assert.dom(within(rows[1]).getByRole('cell', { name: 'Certification Pix' })).exists();
         assert.dom(within(rows[2]).getByRole('cell', { name: 'Pix+Droit' })).exists();

--- a/certif/tests/unit/helpers/dayjs-utc-format-test.js
+++ b/certif/tests/unit/helpers/dayjs-utc-format-test.js
@@ -1,0 +1,84 @@
+import { dayjsUtcFormat } from 'pix-certif/helpers/dayjs-utc-format';
+import { module, test } from 'qunit';
+
+module('Unit | Helpers | dayjs-utc-format', function () {
+  module('when formatting a date', function () {
+    test('it formats a YYYY-MM-DD date to DD/MM/YYYY', function (assert) {
+      // when
+      const result = dayjsUtcFormat(['2020-12-01', 'DD/MM/YYYY'], {});
+
+      // then
+      assert.strictEqual(result, '01/12/2020');
+    });
+
+    test('it formats a date with time information without timezone shift', function (assert) {
+      // when
+      const result = dayjsUtcFormat(['2020-12-01T00:00:00Z', 'DD/MM/YYYY'], {});
+
+      // then
+      assert.strictEqual(result, '01/12/2020');
+    });
+
+    test('it formats a date with localized format', function (assert) {
+      // when
+      const result = dayjsUtcFormat(['2020-12-01', 'YYYY'], {});
+
+      // then
+      assert.strictEqual(result, '2020');
+    });
+  });
+
+  module('when formatting a time', function () {
+    test('it formats a HH:mm:ss time to HH:mm using inputFormat', function (assert) {
+      // when
+      const result = dayjsUtcFormat(['15:30:00', 'HH:mm'], { inputFormat: 'HH:mm:ss' });
+
+      // then
+      assert.strictEqual(result, '15:30');
+    });
+  });
+
+  module('when value is empty', function () {
+    test('it returns empty string when allowEmpty is true and value is null', function (assert) {
+      // when
+      const result = dayjsUtcFormat([null, 'DD/MM/YYYY'], { allowEmpty: true });
+
+      // then
+      assert.strictEqual(result, '');
+    });
+
+    test('it returns empty string when allowEmpty is true and value is undefined', function (assert) {
+      // when
+      const result = dayjsUtcFormat([undefined, 'DD/MM/YYYY'], { allowEmpty: true });
+
+      // then
+      assert.strictEqual(result, '');
+    });
+
+    test('it returns null when allowEmpty is falsy and value is null', function (assert) {
+      // when
+      const result = dayjsUtcFormat([null, 'DD/MM/YYYY'], {});
+
+      // then
+      assert.strictEqual(result, null);
+    });
+  });
+
+  module('when value is invalid', function () {
+    test('it returns empty string when allowEmpty is true', function (assert) {
+      // when
+      const result = dayjsUtcFormat(['not-a-date', 'DD/MM/YYYY'], { allowEmpty: true });
+
+      // then
+      assert.strictEqual(result, '');
+    });
+
+    test('it returns null when allowEmpty is falsy', function (assert) {
+      // when
+      const result = dayjsUtcFormat(['not-a-date', 'DD/MM/YYYY'], {});
+
+      // then
+      assert.strictEqual(result, null);
+    });
+  });
+});


### PR DESCRIPTION
## 🌱 Problème

Les dates et heures affichées dans Pix Certif étaient converties en timezone locale du navigateur via `dayjs` (helper ember-dayjs), alors qu'elles devaient être affichées telles que stockées côté API (UTC). 

## 🐣 Proposition

- Création d'un helper `dayjs-utc-format` qui parse les dates en UTC (`dayjs.utc()`) au lieu de la timezone locale
- Remplacement de toutes les utilisations de `dayjsFormat` (`ember-dayjs`) par ce nouveau helper dans l'application.

## 🐝 Pour tester

Possibilité d'utiliser une extension pour changer la timezone (ex, [sur Chrome](https://chromewebstore.google.com/detail/change-timezone-for-googl/cejckpjfigehbeecbbfhangbknpidcnh)). 

Tester en RA la création de Session et d'ajout de candidat.
Les dates sauvegardées devraient bien être celles choisies.
