### PR TITLE
[TECH] Mise à jour du script de remplissage des nouvelles colonnes de la table "assessment-results" pour gérer le cas des premières certifications V3 non gérées (PIX-22205)

### DIFF
--- a/api/scripts/certification/fill-capacity-meshindex-versionid-columns-in-assessment-results-table.js
+++ b/api/scripts/certification/fill-capacity-meshindex-versionid-columns-in-assessment-results-table.js
@@ -1,14 +1,14 @@
 import { knex } from '../../db/knex-database-connection.js';
-import { DomainTransaction } from '../../src/shared/domain/DomainTransaction.js';
-import { batchUpdate } from '../../src/shared/infrastructure/utils/knex-utils.js';
 import { CapacitySimulator } from '../../src/certification/evaluation/domain/models/CapacitySimulator.js';
 import { Intervals } from '../../src/certification/evaluation/domain/models/Intervals.js';
 import { V3CertificationScoring } from '../../src/certification/evaluation/domain/models/V3CertificationScoring.js';
 import { Frameworks } from '../../src/certification/shared/domain/models/Frameworks.js';
 import { Script } from '../../src/shared/application/scripts/script.js';
 import { ScriptRunner } from '../../src/shared/application/scripts/script-runner.js';
+import { DomainTransaction } from '../../src/shared/domain/DomainTransaction.js';
 import * as areaRepository from '../../src/shared/infrastructure/repositories/area-repository.js';
 import * as competenceRepository from '../../src/shared/infrastructure/repositories/competence-repository.js';
+import { batchUpdate } from '../../src/shared/infrastructure/utils/knex-utils.js';
 
 export class FillCapacityMeshindexVersionidColumnsInAssessmentResultsTable extends Script {
   constructor() {
@@ -56,7 +56,11 @@ export class FillCapacityMeshindexVersionidColumnsInAssessmentResultsTable exten
       await DomainTransaction.execute(async () => {
         const trx = DomainTransaction.getConnection();
         try {
-          await trx('assessment-results').insert(assessmentResultsToUpdate).onConflict('id').merge();
+          await batchUpdate({
+            tableName: 'assessment-results',
+            primaryKeyName: 'id',
+            rows: assessmentResultsToUpdate,
+          });
           await batchUpdate({
             tableName: 'certification-courses',
             primaryKeyName: 'id',
@@ -128,11 +132,7 @@ async function selectCertificationsToProcess(startId, endId, chunkSize) {
       reconciledAt: 'certification-candidates.reconciledAt',
     })
     .from('certification-courses')
-    .join('certification-candidates', function () {
-      this.on({ 'certification-candidates.sessionId': 'certification-courses.sessionId' }).andOn({
-        'certification-candidates.userId': 'certification-courses.userId',
-      });
-    })
+    .join('certification-candidates', 'certification-candidates.id', 'certification-courses.candidateId')
     .where('certification-courses.version', 3)
     .where('certification-courses.id', '>=', startId)
     .orderBy('certification-courses.id', 'asc')
@@ -163,7 +163,7 @@ async function processCertifications(certificationsData, coreScoringConfiguratio
   }
   const filtered = results.filter((r) => !!r);
   return {
-    assessmentResultsToUpdate: filtered.map((r) => r.assessmentResult),
+    assessmentResultsToUpdate: filtered.filter((r) => r.assessmentResult).map((r) => r.assessmentResult),
     certificationCoursesToUpdate: filtered.map((r) => ({ id: r.certificationCourseId, versionId: r.versionId })),
     latestCertificationIdProcessed,
   };
@@ -188,8 +188,15 @@ async function processCertification(v3CertificationScorings, certificationData) 
       certificationData.certificationCourseId,
     )
     .first();
+
+  const versionId = coreScoringConfiguration.id;
+
   if (!assessmentResultData) {
-    return null;
+    return {
+      certificationCourseId: certificationData.certificationCourseId,
+      versionId,
+      assessmentResult: null,
+    };
   }
 
   const capacity = computeCapacityFromPixScore(
@@ -197,7 +204,6 @@ async function processCertification(v3CertificationScorings, certificationData) 
     coreScoringConfiguration.scoringConfiguration,
   );
   const reachedMeshIndex = computeMeshIndexFromCapacity(capacity, coreScoringConfiguration.scoringConfiguration);
-  const versionId = coreScoringConfiguration.id;
 
   return {
     certificationCourseId: certificationData.certificationCourseId,

--- a/api/scripts/certification/fill-capacity-meshindex-versionid-columns-in-assessment-results-table.js
+++ b/api/scripts/certification/fill-capacity-meshindex-versionid-columns-in-assessment-results-table.js
@@ -9,6 +9,7 @@ import { DomainTransaction } from '../../src/shared/domain/DomainTransaction.js'
 import * as areaRepository from '../../src/shared/infrastructure/repositories/area-repository.js';
 import * as competenceRepository from '../../src/shared/infrastructure/repositories/competence-repository.js';
 import { batchUpdate } from '../../src/shared/infrastructure/utils/knex-utils.js';
+import { setTimeout } from 'node:timers/promises';
 
 export class FillCapacityMeshindexVersionidColumnsInAssessmentResultsTable extends Script {
   constructor() {
@@ -38,12 +39,17 @@ export class FillCapacityMeshindexVersionidColumnsInAssessmentResultsTable exten
             'Define the number of certifications processed in a chunk (chunks determined how many certifications are updated and committed at the same time)',
           default: 1000,
         },
+        throttleDelay: {
+          type: 'number',
+          describe: 'The throttle delay',
+          default: 250,
+        },
       },
     });
   }
 
   async handle({ logger, options }) {
-    const { dryRun, startId, endId, chunkSize } = options;
+    const { dryRun, startId, endId, chunkSize, throttleDelay } = options;
     logger.info('Script execution started');
     const coreScoringConfigurations = await getCoreScoringConfigurations();
 
@@ -77,7 +83,7 @@ export class FillCapacityMeshindexVersionidColumnsInAssessmentResultsTable exten
           throw error;
         }
       });
-
+      await setTimeout(throttleDelay);
       currentStartId = latestCertificationIdProcessed + 1;
       certificationsData = await selectCertificationsToProcess(currentStartId, endId, chunkSize);
     }

--- a/api/scripts/certification/fill-capacity-meshindex-versionid-columns-in-assessment-results-table.js
+++ b/api/scripts/certification/fill-capacity-meshindex-versionid-columns-in-assessment-results-table.js
@@ -1,3 +1,5 @@
+import { setTimeout } from 'node:timers/promises';
+
 import { knex } from '../../db/knex-database-connection.js';
 import { CapacitySimulator } from '../../src/certification/evaluation/domain/models/CapacitySimulator.js';
 import { Intervals } from '../../src/certification/evaluation/domain/models/Intervals.js';
@@ -9,7 +11,6 @@ import { DomainTransaction } from '../../src/shared/domain/DomainTransaction.js'
 import * as areaRepository from '../../src/shared/infrastructure/repositories/area-repository.js';
 import * as competenceRepository from '../../src/shared/infrastructure/repositories/competence-repository.js';
 import { batchUpdate } from '../../src/shared/infrastructure/utils/knex-utils.js';
-import { setTimeout } from 'node:timers/promises';
 
 export class FillCapacityMeshindexVersionidColumnsInAssessmentResultsTable extends Script {
   constructor() {

--- a/api/scripts/certification/fill-capacity-meshindex-versionid-columns-in-assessment-results-table.js
+++ b/api/scripts/certification/fill-capacity-meshindex-versionid-columns-in-assessment-results-table.js
@@ -1,4 +1,6 @@
 import { knex } from '../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../src/shared/domain/DomainTransaction.js';
+import { batchUpdate } from '../../src/shared/infrastructure/utils/knex-utils.js';
 import { CapacitySimulator } from '../../src/certification/evaluation/domain/models/CapacitySimulator.js';
 import { Intervals } from '../../src/certification/evaluation/domain/models/Intervals.js';
 import { V3CertificationScoring } from '../../src/certification/evaluation/domain/models/V3CertificationScoring.js';
@@ -25,6 +27,11 @@ export class FillCapacityMeshindexVersionidColumnsInAssessmentResultsTable exten
           describe: 'Define the id of the certification-courses from which we start doing the process',
           default: 5906059,
         },
+        endId: {
+          type: 'number',
+          describe: 'Define the id of the certification-courses at which we stop doing the process (inclusive)',
+          default: null,
+        },
         chunkSize: {
           type: 'number',
           describe:
@@ -36,35 +43,39 @@ export class FillCapacityMeshindexVersionidColumnsInAssessmentResultsTable exten
   }
 
   async handle({ logger, options }) {
-    const { dryRun, startId, chunkSize } = options;
+    const { dryRun, startId, endId, chunkSize } = options;
     logger.info('Script execution started');
     const coreScoringConfigurations = await getCoreScoringConfigurations();
 
     let currentStartId = startId;
-    let certificationsData = await selectCertificationsToProcess(currentStartId, chunkSize);
+    let certificationsData = await selectCertificationsToProcess(currentStartId, endId, chunkSize);
     while (certificationsData.length > 0) {
-      const { assessmentResultsToUpdate, latestCertificationIdProcessed } = await processCertifications(
-        certificationsData,
-        coreScoringConfigurations,
-        logger,
-      );
+      const { assessmentResultsToUpdate, certificationCoursesToUpdate, latestCertificationIdProcessed } =
+        await processCertifications(certificationsData, coreScoringConfigurations, logger);
 
-      const trx = await knex.transaction();
-      try {
-        await trx('assessment-results').insert(assessmentResultsToUpdate).onConflict('id').merge();
-        logger.info(`Certifications up until ID ${latestCertificationIdProcessed} DONE`);
-        if (dryRun) {
+      await DomainTransaction.execute(async () => {
+        const trx = DomainTransaction.getConnection();
+        try {
+          await trx('assessment-results').insert(assessmentResultsToUpdate).onConflict('id').merge();
+          await batchUpdate({
+            tableName: 'certification-courses',
+            primaryKeyName: 'id',
+            rows: certificationCoursesToUpdate,
+          });
+          logger.info(`Certifications up until ID ${latestCertificationIdProcessed} DONE`);
+          if (dryRun) {
+            await trx.rollback();
+          } else {
+            await trx.commit();
+          }
+        } catch (error) {
           await trx.rollback();
-        } else {
-          await trx.commit();
+          throw error;
         }
-      } catch (error) {
-        await trx.rollback();
-        throw error;
-      }
+      });
 
       currentStartId = latestCertificationIdProcessed + 1;
-      certificationsData = await selectCertificationsToProcess(currentStartId, chunkSize);
+      certificationsData = await selectCertificationsToProcess(currentStartId, endId, chunkSize);
     }
 
     logger.info('No more certifications to process youpi');
@@ -110,8 +121,8 @@ async function getCoreScoringConfigurations() {
   return v3CertificationScorings;
 }
 
-async function selectCertificationsToProcess(startId, chunkSize) {
-  return await knex
+async function selectCertificationsToProcess(startId, endId, chunkSize) {
+  const query = knex
     .select({
       certificationCourseId: 'certification-courses.id',
       reconciledAt: 'certification-candidates.reconciledAt',
@@ -126,26 +137,34 @@ async function selectCertificationsToProcess(startId, chunkSize) {
     .where('certification-courses.id', '>=', startId)
     .orderBy('certification-courses.id', 'asc')
     .limit(chunkSize);
+
+  if (endId != null) {
+    query.where('certification-courses.id', '<=', endId);
+  }
+
+  return query;
 }
 
 async function processCertifications(certificationsData, coreScoringConfigurations, logger) {
   let latestCertificationIdProcessed;
-  const assessmentResultsToUpdate = [];
+  const results = [];
   logger.info(
     `Processing certification from ${certificationsData[0].certificationCourseId} to ${certificationsData.at(-1).certificationCourseId}...`,
   );
   for (const certificationData of certificationsData) {
     try {
       latestCertificationIdProcessed = certificationData.certificationCourseId;
-      const assessmentResultData = await processCertification(coreScoringConfigurations, certificationData);
-      assessmentResultsToUpdate.push(assessmentResultData);
+      const result = await processCertification(coreScoringConfigurations, certificationData);
+      results.push(result);
     } catch (error) {
       logger.error(error, `Certification ID ${latestCertificationIdProcessed} encountered an error`);
       throw error;
     }
   }
+  const filtered = results.filter((r) => !!r);
   return {
-    assessmentResultsToUpdate: assessmentResultsToUpdate.filter((ar) => !!ar),
+    assessmentResultsToUpdate: filtered.map((r) => r.assessmentResult),
+    certificationCoursesToUpdate: filtered.map((r) => ({ id: r.certificationCourseId, versionId: r.versionId })),
     latestCertificationIdProcessed,
   };
 }
@@ -181,10 +200,14 @@ async function processCertification(v3CertificationScorings, certificationData) 
   const versionId = coreScoringConfiguration.id;
 
   return {
-    ...assessmentResultData,
-    capacity,
-    reachedMeshIndex,
+    certificationCourseId: certificationData.certificationCourseId,
     versionId,
+    assessmentResult: {
+      ...assessmentResultData,
+      capacity,
+      reachedMeshIndex,
+      versionId,
+    },
   };
 }
 

--- a/api/tests/certification/scripts/integration/fill-capacity-meshindex-versionid-columns-in-assessment-results-table_test.js
+++ b/api/tests/certification/scripts/integration/fill-capacity-meshindex-versionid-columns-in-assessment-results-table_test.js
@@ -48,11 +48,14 @@ describe('Integration | Certification | Scripts | Fill capacity, meshindex, vers
     await databaseBuilder.commit();
 
     const assessmentResultDataBefore = await knex('assessment-results').orderBy('id');
+    const certificationCourseDataBefore = await knex('certification-courses').orderBy('id');
 
     await script.handle({ options: { dryRun: true, startId: certificationCourseIds[0], chunkSize: 1 }, logger });
 
     const assessmentResultData = await knex('assessment-results').orderBy('id');
+    const certificationCourseData = await knex('certification-courses').orderBy('id');
     expect(assessmentResultData).to.deep.equal(assessmentResultDataBefore);
+    expect(certificationCourseData).to.deep.equal(certificationCourseDataBefore);
   });
 
   it('should fill capacity, meshindex and versionid in assessment results for current version', async function () {
@@ -83,6 +86,9 @@ describe('Integration | Certification | Scripts | Fill capacity, meshindex, vers
     expect(assessmentResultDataBefore[1].capacity).to.be.null;
     expect(assessmentResultDataBefore[1].reachedMeshIndex).to.be.null;
     expect(assessmentResultDataBefore[1].versionId).to.be.null;
+    const certificationCourseDataBefore = await knex('certification-courses').select('id', 'versionId').orderBy('id');
+    expect(certificationCourseDataBefore[0].versionId).to.be.null;
+    expect(certificationCourseDataBefore[1].versionId).to.be.null;
 
     await script.handle({ options: { dryRun: false, startId: certificationCourseIds[0], chunkSize: 1 }, logger });
 
@@ -94,6 +100,9 @@ describe('Integration | Certification | Scripts | Fill capacity, meshindex, vers
     expect(Math.ceil(assessmentResultData[1].capacity)).to.equal(8);
     expect(assessmentResultData[1].reachedMeshIndex).to.equal(7);
     expect(assessmentResultData[1].versionId).to.equal(versionId);
+    const certificationCourseData = await knex('certification-courses').select('id', 'versionId').orderBy('id');
+    expect(certificationCourseData[0].versionId).to.equal(versionId);
+    expect(certificationCourseData[1].versionId).to.equal(versionId);
   });
 
   it('should fill capacity, meshindex and versionid in assessment results for expired version', async function () {
@@ -124,6 +133,9 @@ describe('Integration | Certification | Scripts | Fill capacity, meshindex, vers
     expect(assessmentResultDataBefore[1].capacity).to.be.null;
     expect(assessmentResultDataBefore[1].reachedMeshIndex).to.be.null;
     expect(assessmentResultDataBefore[1].versionId).to.be.null;
+    const certificationCourseDataBefore = await knex('certification-courses').select('id', 'versionId').orderBy('id');
+    expect(certificationCourseDataBefore[0].versionId).to.be.null;
+    expect(certificationCourseDataBefore[1].versionId).to.be.null;
 
     await script.handle({ options: { dryRun: false, startId: certificationCourseIds[0], chunkSize: 1 }, logger });
 
@@ -135,6 +147,9 @@ describe('Integration | Certification | Scripts | Fill capacity, meshindex, vers
     expect(Math.ceil(assessmentResultData[1].capacity)).to.equal(8);
     expect(assessmentResultData[1].reachedMeshIndex).to.equal(7);
     expect(assessmentResultData[1].versionId).to.equal(versionId);
+    const certificationCourseData = await knex('certification-courses').select('id', 'versionId').orderBy('id');
+    expect(certificationCourseData[0].versionId).to.equal(versionId);
+    expect(certificationCourseData[1].versionId).to.equal(versionId);
   });
 
   it('should correctly process certification from two different versions with appropriate logger informations', async function () {
@@ -233,6 +248,9 @@ describe('Integration | Certification | Scripts | Fill capacity, meshindex, vers
     expect(assessmentResultData).to.have.lengthOf(4);
     expect(assessmentResultData[0].versionId).to.equal(versionId);
     expect(assessmentResultData[2].versionId).to.equal(null);
+    const certificationCourseData = await knex('certification-courses').select('id', 'versionId').orderBy('id');
+    expect(certificationCourseData[0].versionId).to.equal(versionId);
+    expect(certificationCourseData[2].versionId).to.equal(null);
     expect(logger.info.getCall(0)).to.have.been.calledWithExactly('Script execution started');
     expect(logger.info.getCall(1)).to.have.been.calledWithExactly(
       `Processing certification from ${certificationCourseIds[0]} to ${certificationCourseIds[1]}...`,

--- a/api/tests/certification/scripts/integration/fill-capacity-meshindex-versionid-columns-in-assessment-results-table_test.js
+++ b/api/tests/certification/scripts/integration/fill-capacity-meshindex-versionid-columns-in-assessment-results-table_test.js
@@ -58,7 +58,7 @@ describe('Integration | Certification | Scripts | Fill capacity, meshindex, vers
     expect(certificationCourseData).to.deep.equal(certificationCourseDataBefore);
   });
 
-  it('should fill capacity, meshindex and versionid in assessment results for current version', async function () {
+  it('should fill capacity, meshindex and versionid in assessment results and versionid in certification courses for current version', async function () {
     const startDate = new Date('2025-10-01');
     const expirationDate = null;
 
@@ -87,6 +87,7 @@ describe('Integration | Certification | Scripts | Fill capacity, meshindex, vers
     expect(assessmentResultDataBefore[1].reachedMeshIndex).to.be.null;
     expect(assessmentResultDataBefore[1].versionId).to.be.null;
     const certificationCourseDataBefore = await knex('certification-courses').select('id', 'versionId').orderBy('id');
+    expect(certificationCourseDataBefore).to.have.lengthOf(pixScores.length);
     expect(certificationCourseDataBefore[0].versionId).to.be.null;
     expect(certificationCourseDataBefore[1].versionId).to.be.null;
 
@@ -101,11 +102,12 @@ describe('Integration | Certification | Scripts | Fill capacity, meshindex, vers
     expect(assessmentResultData[1].reachedMeshIndex).to.equal(7);
     expect(assessmentResultData[1].versionId).to.equal(versionId);
     const certificationCourseData = await knex('certification-courses').select('id', 'versionId').orderBy('id');
+    expect(certificationCourseData).to.have.lengthOf(pixScores.length);
     expect(certificationCourseData[0].versionId).to.equal(versionId);
     expect(certificationCourseData[1].versionId).to.equal(versionId);
   });
 
-  it('should fill capacity, meshindex and versionid in assessment results for expired version', async function () {
+  it('should fill capacity, meshindex and versionid in assessment results and versionid in certification courses for expired version', async function () {
     const startDate = new Date('2025-10-01');
     const expirationDate = new Date('2026-01-01');
 
@@ -134,6 +136,7 @@ describe('Integration | Certification | Scripts | Fill capacity, meshindex, vers
     expect(assessmentResultDataBefore[1].reachedMeshIndex).to.be.null;
     expect(assessmentResultDataBefore[1].versionId).to.be.null;
     const certificationCourseDataBefore = await knex('certification-courses').select('id', 'versionId').orderBy('id');
+    expect(certificationCourseDataBefore).to.have.lengthOf(pixScores.length);
     expect(certificationCourseDataBefore[0].versionId).to.be.null;
     expect(certificationCourseDataBefore[1].versionId).to.be.null;
 
@@ -148,9 +151,44 @@ describe('Integration | Certification | Scripts | Fill capacity, meshindex, vers
     expect(assessmentResultData[1].reachedMeshIndex).to.equal(7);
     expect(assessmentResultData[1].versionId).to.equal(versionId);
     const certificationCourseData = await knex('certification-courses').select('id', 'versionId').orderBy('id');
+    expect(certificationCourseData).to.have.lengthOf(pixScores.length);
     expect(certificationCourseData[0].versionId).to.equal(versionId);
     expect(certificationCourseData[1].versionId).to.equal(versionId);
   });
+
+  it('should fill versionid in certification courses even when there is no assessment result found', async function () {
+    const startDate = new Date('2025-10-01');
+    const expirationDate = null;
+
+    const versionId = databaseBuilder.factory.buildCertificationVersion({
+      startDate,
+      expirationDate,
+    }).id;
+
+    const candidateId = databaseBuilder.factory.buildCertificationCandidate({ reconciledAt: new Date() }).id;
+    const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
+      candidateId,
+      version: AlgorithmEngineVersion.V3,
+    }).id;
+
+    await databaseBuilder.commit();
+
+    const assessmentResultDataBefore = await knex('assessment-results').orderBy('id');
+    expect(assessmentResultDataBefore).to.have.lengthOf(0);
+
+    const certificationCourseDataBefore = await knex('certification-courses').select('id', 'versionId').orderBy('id');
+    expect(certificationCourseDataBefore).to.have.lengthOf(1);
+    expect(certificationCourseDataBefore[0].versionId).to.be.null;
+
+    await script.handle({ options: { dryRun: false, startId: certificationCourseId, chunkSize: 1 }, logger });
+
+    const assessmentResultData = await knex('assessment-results').orderBy('id');
+    expect(assessmentResultData).to.have.lengthOf(0);
+
+    const certificationCourseData = await knex('certification-courses').select('id', 'versionId').orderBy('id');
+    expect(certificationCourseData[0].versionId).to.equal(versionId);
+  });
+
 
   it('should correctly process certification from two different versions with appropriate logger informations', async function () {
     const startDateArchivedVersion = new Date('2025-01-01');
@@ -190,6 +228,10 @@ describe('Integration | Certification | Scripts | Fill capacity, meshindex, vers
     expect(assessmentResultData).to.have.lengthOf(6);
     expect(assessmentResultData[0].versionId).to.equal(versionIdArchivedVersion);
     expect(assessmentResultData[3].versionId).to.equal(versionIdCurrentVersion);
+    const certificationCourseData = await knex('assessment-results').orderBy('id');
+    expect(certificationCourseData).to.have.lengthOf(6);
+    expect(certificationCourseData[0].versionId).to.equal(versionIdArchivedVersion);
+    expect(certificationCourseData[3].versionId).to.equal(versionIdCurrentVersion);
     expect(logger.info.getCall(0)).to.have.been.calledWithExactly('Script execution started');
     expect(logger.info.getCall(1)).to.have.been.calledWithExactly(
       `Processing certification from ${certificationCourseIds[0]} to ${certificationCourseIds[1]}...`,
@@ -272,12 +314,9 @@ describe('Integration | Certification | Scripts | Fill capacity, meshindex, vers
 
 function _createBatchAssessmentResults({ reconciledAt, pixScores, certificationCourseIds }) {
   for (const pixScore of pixScores) {
-    const sessionId = databaseBuilder.factory.buildSession().id;
-    const userId = databaseBuilder.factory.buildUser().id;
-    databaseBuilder.factory.buildCertificationCandidate({ sessionId, reconciledAt: reconciledAt, userId });
+    const candidateId = databaseBuilder.factory.buildCertificationCandidate({ reconciledAt: reconciledAt }).id;
     const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
-      sessionId,
-      userId,
+      candidateId,
       version: AlgorithmEngineVersion.V3,
     }).id;
     certificationCourseIds.push(certificationCourseId);

--- a/api/tests/certification/scripts/integration/fill-capacity-meshindex-versionid-columns-in-assessment-results-table_test.js
+++ b/api/tests/certification/scripts/integration/fill-capacity-meshindex-versionid-columns-in-assessment-results-table_test.js
@@ -50,7 +50,7 @@ describe('Integration | Certification | Scripts | Fill capacity, meshindex, vers
     const assessmentResultDataBefore = await knex('assessment-results').orderBy('id');
     const certificationCourseDataBefore = await knex('certification-courses').orderBy('id');
 
-    await script.handle({ options: { dryRun: true, startId: certificationCourseIds[0], chunkSize: 1 }, logger });
+    await script.handle({ options: { dryRun: true, startId: certificationCourseIds[0], chunkSize: 1, throttleDelay: 0 }, logger });
 
     const assessmentResultData = await knex('assessment-results').orderBy('id');
     const certificationCourseData = await knex('certification-courses').orderBy('id');
@@ -91,7 +91,7 @@ describe('Integration | Certification | Scripts | Fill capacity, meshindex, vers
     expect(certificationCourseDataBefore[0].versionId).to.be.null;
     expect(certificationCourseDataBefore[1].versionId).to.be.null;
 
-    await script.handle({ options: { dryRun: false, startId: certificationCourseIds[0], chunkSize: 1 }, logger });
+    await script.handle({ options: { dryRun: false, startId: certificationCourseIds[0], chunkSize: 1, throttleDelay: 0 }, logger });
 
     const assessmentResultData = await knex('assessment-results').orderBy('id');
     expect(assessmentResultData).to.have.lengthOf(pixScores.length);
@@ -140,7 +140,7 @@ describe('Integration | Certification | Scripts | Fill capacity, meshindex, vers
     expect(certificationCourseDataBefore[0].versionId).to.be.null;
     expect(certificationCourseDataBefore[1].versionId).to.be.null;
 
-    await script.handle({ options: { dryRun: false, startId: certificationCourseIds[0], chunkSize: 1 }, logger });
+    await script.handle({ options: { dryRun: false, startId: certificationCourseIds[0], chunkSize: 1, throttleDelay: 0 }, logger });
 
     const assessmentResultData = await knex('assessment-results').orderBy('id');
     expect(assessmentResultData).to.have.lengthOf(pixScores.length);
@@ -180,7 +180,7 @@ describe('Integration | Certification | Scripts | Fill capacity, meshindex, vers
     expect(certificationCourseDataBefore).to.have.lengthOf(1);
     expect(certificationCourseDataBefore[0].versionId).to.be.null;
 
-    await script.handle({ options: { dryRun: false, startId: certificationCourseId, chunkSize: 1 }, logger });
+    await script.handle({ options: { dryRun: false, startId: certificationCourseId, chunkSize: 1, throttleDelay: 0 }, logger });
 
     const assessmentResultData = await knex('assessment-results').orderBy('id');
     expect(assessmentResultData).to.have.lengthOf(0);
@@ -222,7 +222,7 @@ describe('Integration | Certification | Scripts | Fill capacity, meshindex, vers
 
     await databaseBuilder.commit();
 
-    await script.handle({ options: { dryRun: false, startId: certificationCourseIds[0], chunkSize: 2 }, logger });
+    await script.handle({ options: { dryRun: false, startId: certificationCourseIds[0], chunkSize: 2, throttleDelay: 0 }, logger });
 
     const assessmentResultData = await knex('assessment-results').orderBy('id');
     expect(assessmentResultData).to.have.lengthOf(6);

--- a/api/tests/certification/scripts/integration/fill-capacity-meshindex-versionid-columns-in-assessment-results-table_test.js
+++ b/api/tests/certification/scripts/integration/fill-capacity-meshindex-versionid-columns-in-assessment-results-table_test.js
@@ -50,7 +50,10 @@ describe('Integration | Certification | Scripts | Fill capacity, meshindex, vers
     const assessmentResultDataBefore = await knex('assessment-results').orderBy('id');
     const certificationCourseDataBefore = await knex('certification-courses').orderBy('id');
 
-    await script.handle({ options: { dryRun: true, startId: certificationCourseIds[0], chunkSize: 1, throttleDelay: 0 }, logger });
+    await script.handle({
+      options: { dryRun: true, startId: certificationCourseIds[0], chunkSize: 1, throttleDelay: 0 },
+      logger,
+    });
 
     const assessmentResultData = await knex('assessment-results').orderBy('id');
     const certificationCourseData = await knex('certification-courses').orderBy('id');
@@ -91,7 +94,10 @@ describe('Integration | Certification | Scripts | Fill capacity, meshindex, vers
     expect(certificationCourseDataBefore[0].versionId).to.be.null;
     expect(certificationCourseDataBefore[1].versionId).to.be.null;
 
-    await script.handle({ options: { dryRun: false, startId: certificationCourseIds[0], chunkSize: 1, throttleDelay: 0 }, logger });
+    await script.handle({
+      options: { dryRun: false, startId: certificationCourseIds[0], chunkSize: 1, throttleDelay: 0 },
+      logger,
+    });
 
     const assessmentResultData = await knex('assessment-results').orderBy('id');
     expect(assessmentResultData).to.have.lengthOf(pixScores.length);
@@ -140,7 +146,10 @@ describe('Integration | Certification | Scripts | Fill capacity, meshindex, vers
     expect(certificationCourseDataBefore[0].versionId).to.be.null;
     expect(certificationCourseDataBefore[1].versionId).to.be.null;
 
-    await script.handle({ options: { dryRun: false, startId: certificationCourseIds[0], chunkSize: 1, throttleDelay: 0 }, logger });
+    await script.handle({
+      options: { dryRun: false, startId: certificationCourseIds[0], chunkSize: 1, throttleDelay: 0 },
+      logger,
+    });
 
     const assessmentResultData = await knex('assessment-results').orderBy('id');
     expect(assessmentResultData).to.have.lengthOf(pixScores.length);
@@ -180,7 +189,10 @@ describe('Integration | Certification | Scripts | Fill capacity, meshindex, vers
     expect(certificationCourseDataBefore).to.have.lengthOf(1);
     expect(certificationCourseDataBefore[0].versionId).to.be.null;
 
-    await script.handle({ options: { dryRun: false, startId: certificationCourseId, chunkSize: 1, throttleDelay: 0 }, logger });
+    await script.handle({
+      options: { dryRun: false, startId: certificationCourseId, chunkSize: 1, throttleDelay: 0 },
+      logger,
+    });
 
     const assessmentResultData = await knex('assessment-results').orderBy('id');
     expect(assessmentResultData).to.have.lengthOf(0);
@@ -188,7 +200,6 @@ describe('Integration | Certification | Scripts | Fill capacity, meshindex, vers
     const certificationCourseData = await knex('certification-courses').select('id', 'versionId').orderBy('id');
     expect(certificationCourseData[0].versionId).to.equal(versionId);
   });
-
 
   it('should correctly process certification from two different versions with appropriate logger informations', async function () {
     const startDateArchivedVersion = new Date('2025-01-01');
@@ -222,7 +233,10 @@ describe('Integration | Certification | Scripts | Fill capacity, meshindex, vers
 
     await databaseBuilder.commit();
 
-    await script.handle({ options: { dryRun: false, startId: certificationCourseIds[0], chunkSize: 2, throttleDelay: 0 }, logger });
+    await script.handle({
+      options: { dryRun: false, startId: certificationCourseIds[0], chunkSize: 2, throttleDelay: 0 },
+      logger,
+    });
 
     const assessmentResultData = await knex('assessment-results').orderBy('id');
     expect(assessmentResultData).to.have.lengthOf(6);


### PR DESCRIPTION
## 🌱 Problème

On a découvert suite à une erreur 500 en production, qu'un certain nombre (1 681) des premières certifications V3 n'ont pas été couvertes lors des précédentes exécutions des scripts remplissant rétro-activement les nouvelles colonnes crées récemment. 
Pour ces certification V3, les colonnes suivantes sont vides : 
- reachedMeshIndex de la table assessment-results
- capacity  de la table assessment-results
- versionId  de la table assessment-results
- versionId  de la table certification-courses

## 🐣 Proposition

Mettre à jour le script ```FillCapacityMeshindexVersionidColumnsInAssessmentResultsTable``` pour prendre un endId en paramètre et ajouter l'update du versionId  de la table certification-courses.

## 🌷 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🐝 Pour tester
Vider les colonnes concernées et vérifier que le script les rempli correctement 
