### PR TITLE
[TECH] Rendre la colonne content de combined_course_blueprints nullable (PIX-22212)

### DIFF
--- a/api/db/migrations/20260402152749_make-combined-course-content-nullable.js
+++ b/api/db/migrations/20260402152749_make-combined-course-content-nullable.js
@@ -1,0 +1,24 @@
+const TABLE_NAME = 'combined_course_blueprints';
+const COLUMN_NAME = 'content';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.setNullable(COLUMN_NAME);
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropNullable(COLUMN_NAME);
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## 🌱 Problème
On veut pouvoir se baser sur la quest pour afficher le contenu d'un blueprint côté admin. 
A terme, on n'aura plus besoin de la colonne content.


## 🐣 Proposition
On rend la colonne content nullable.

## 🌷 Remarques
Un script de rattrapage devra être joué plus tard pour vider les données de content, avant de supprimer la colonne définitivement.

## 🐝 Pour tester
Se connecter à la RA -> pgsql-console 
/d combined_course_blueprints : la colonne content est nullable
