### PR TITLE
[FEATURE] Ajouter la table organization_learner_filters (PIX-22220).

### DIFF
--- a/api/db/migrations/20260403072405_add-filter-learner-table.js
+++ b/api/db/migrations/20260403072405_add-filter-learner-table.js
@@ -1,0 +1,27 @@
+const TABLE_NAME = 'organization_learner_filters';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.createTable(TABLE_NAME, function (table) {
+    table.increments('id').primary();
+    table.integer('organization_id').references('organizations.id').comment('Refers to organizations table').index();
+    table
+      .string('attribute_name')
+      .comment('Refers to organization learners attributes key to identify specific filters');
+    table.jsonb('values').comment('list of values we can use to filter attribute column');
+    table.datetime('created_at').comment('creation date of filter');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.dropTable(TABLE_NAME);
+};
+
+export { down, up };

--- a/api/db/migrations/20260403072405_add-filter-learner-table.js
+++ b/api/db/migrations/20260403072405_add-filter-learner-table.js
@@ -6,13 +6,14 @@ const TABLE_NAME = 'organization_learner_filters';
  */
 const up = async function (knex) {
   await knex.schema.createTable(TABLE_NAME, function (table) {
-    table.increments('id').primary();
     table.integer('organization_id').references('organizations.id').comment('Refers to organizations table').index();
     table
       .string('attribute_name')
-      .comment('Refers to organization learners attributes key to identify specific filters');
-    table.jsonb('values').comment('list of values we can use to filter attribute column');
+      .comment('Refers to organization-learners attributes "key" where we can find all values for an organization');
+    table.jsonb('values').comment('list of value stored in attributes[key] on organization-learners table');
     table.datetime('created_at').comment('creation date of filter');
+
+    table.unique(['organization_id', 'attribute_name']);
   });
 };
 


### PR DESCRIPTION
## 🌱 Problème

Pour savoir quel filtre sont disponible sur les organisation avec imports nous faisons à chaque fois un appel pour récupérer la liste des classes par exemple. Ce qui est un peu nulle étant donnée que ces données ne change qu'à chaque nouvel import ( une fois par an minimum ), mais certainement pas tout les 4 matins.

## 🐣 Proposition

Ajouter une table organization_learner_filters pour stocker lors de l'insertion en bdd de nouveau learner, les nouvelles classes, division, ou autre joyeuseté ayant pour but d'être filtré (comme un bon café).

## 🌷 Remarques

RAS

## 🐝 Pour tester
Ci au vert, vérifier que dans pgsql on a bien une nouvelle table vide. 