### PR TITLE
[FEATURE] Supprimer le logo national des emails FR (PIX-22197)

### DIFF
--- a/api/src/identity-access-management/domain/emails/create-account-creation.email.js
+++ b/api/src/identity-access-management/domain/emails/create-account-creation.email.js
@@ -1,4 +1,3 @@
-import { isFranceLocale } from '../../../shared/domain/services/locale-service.js';
 import {
   getEmailValidationUrl,
   getPixAppConnexionUrl,
@@ -35,7 +34,6 @@ export function createAccountCreationEmail({ locale, email, firstName, token, re
       homeName: getPixWebsiteDomain(locale),
       homeUrl: getPixWebsiteUrl(locale),
       helpdeskUrl: getSupportUrl(locale),
-      displayNationalLogo: isFranceLocale(locale),
       askForHelp: i18n.__('pix-account-creation-email.params.askForHelp'),
       disclaimer: i18n.__('pix-account-creation-email.params.disclaimer'),
       doNotAnswer: i18n.__('pix-account-creation-email.params.doNotAnswer'),

--- a/api/src/identity-access-management/domain/emails/create-reset-password-demand.email.js
+++ b/api/src/identity-access-management/domain/emails/create-reset-password-demand.email.js
@@ -1,4 +1,4 @@
-import { FRENCH_FRANCE, isFranceLocale } from '../../../shared/domain/services/locale-service.js';
+import { FRENCH_FRANCE } from '../../../shared/domain/services/locale-service.js';
 import {
   getPixAppUrl,
   getPixWebsiteDomain,
@@ -30,7 +30,6 @@ export function createResetPasswordDemandEmail({ email, temporaryKey, locale = F
       homeName: getPixWebsiteDomain(locale),
       homeUrl: getPixWebsiteUrl(locale),
       helpdeskUrl: getSupportUrl(locale),
-      displayNationalLogo: isFranceLocale(locale),
       resetUrl: getPixAppUrl(locale, { pathname: `/changer-mot-de-passe/${temporaryKey}` }),
       clickOnTheButton: i18n.__('reset-password-demand-email.params.clickOnTheButton'),
       contactUs: i18n.__('reset-password-demand-email.params.contactUs'),

--- a/api/src/identity-access-management/domain/emails/create-self-delete-user-account.email.js
+++ b/api/src/identity-access-management/domain/emails/create-self-delete-user-account.email.js
@@ -1,4 +1,3 @@
-import { isFranceLocale } from '../../../shared/domain/services/locale-service.js';
 import { getPixWebsiteDomain, getPixWebsiteUrl, getSupportUrl } from '../../../shared/domain/services/url-service.js';
 import { EmailFactory } from '../../../shared/mail/domain/models/EmailFactory.js';
 import { mailer } from '../../../shared/mail/infrastructure/services/mailer.js';
@@ -25,7 +24,6 @@ export function createSelfDeleteUserAccountEmail({ locale, email, firstName }) {
       homeName: getPixWebsiteDomain(locale),
       homeUrl: getPixWebsiteUrl(locale),
       helpdeskUrl: getSupportUrl(locale),
-      displayNationalLogo: isFranceLocale(locale),
       doNotAnswer: i18n.__('common.email.doNotAnswer'),
       moreOn: i18n.__('common.email.moreOn'),
       pixPresentation: i18n.__('common.email.pixPresentation'),

--- a/api/src/identity-access-management/domain/emails/create-warning-connection.email.js
+++ b/api/src/identity-access-management/domain/emails/create-warning-connection.email.js
@@ -1,4 +1,4 @@
-import { FRENCH_FRANCE, isFranceLocale } from '../../../shared/domain/services/locale-service.js';
+import { FRENCH_FRANCE } from '../../../shared/domain/services/locale-service.js';
 import {
   getEmailValidationUrl,
   getPixAppUrl,
@@ -34,7 +34,6 @@ export function createWarningConnectionEmail({ locale = FRENCH_FRANCE, email, fi
       homeName: getPixWebsiteDomain(locale),
       homeUrl: getPixWebsiteUrl(locale),
       helpDeskUrl: getEmailValidationUrl({ locale, redirectUrl: getSupportUrl(locale), token: validationToken }),
-      displayNationalLogo: isFranceLocale(locale),
       contactUs: i18n.__('common.email.contactUs'),
       doNotAnswer: i18n.__('common.email.doNotAnswer'),
       moreOn: i18n.__('common.email.moreOn'),

--- a/api/src/identity-access-management/domain/emails/email-change-verification-code.email.js
+++ b/api/src/identity-access-management/domain/emails/email-change-verification-code.email.js
@@ -1,4 +1,3 @@
-import { isFranceLocale } from '../../../shared/domain/services/locale-service.js';
 import { getPixWebsiteDomain, getPixWebsiteUrl } from '../../../shared/domain/services/url-service.js';
 import { EmailFactory } from '../../../shared/mail/domain/models/EmailFactory.js';
 import { mailer } from '../../../shared/mail/infrastructure/services/mailer.js';
@@ -28,7 +27,6 @@ export function emailChangeVerificationCodeEmail({ email, code, locale }) {
       code,
       homeName: getPixWebsiteDomain(locale),
       homeUrl: getPixWebsiteUrl(locale),
-      displayNationalLogo: isFranceLocale(locale),
       context: i18n.__('verification-code-email.body.context'),
       doNotAnswer: i18n.__('verification-code-email.body.doNotAnswer'),
       greeting: i18n.__('verification-code-email.body.greeting'),

--- a/api/tests/identity-access-management/unit/domain/emails/create-account-creation.email.test.js
+++ b/api/tests/identity-access-management/unit/domain/emails/create-account-creation.email.test.js
@@ -23,7 +23,6 @@ describe('Unit | Identity Access Management | Domain | Email | create-account-cr
     const variables = email.variables;
     expect(variables).to.have.property('askForHelp').that.is.a('string');
     expect(variables).to.have.property('disclaimer').that.is.a('string');
-    expect(variables).to.have.property('displayNationalLogo').that.is.a('boolean');
     expect(variables).to.have.property('doNotAnswer').that.is.a('string');
     expect(variables).to.have.property('goToPix').that.is.a('string');
     expect(variables).to.have.property('helpdeskLinkLabel').that.is.a('string');

--- a/api/tests/identity-access-management/unit/domain/emails/create-self-delete-user-account.email.test.js
+++ b/api/tests/identity-access-management/unit/domain/emails/create-self-delete-user-account.email.test.js
@@ -19,7 +19,6 @@ describe('Unit | Identity Access Management | Domain | Email | create-self-delet
     expect(email.template).to.equal(mailer.selfAccountDeletionTemplateId);
 
     const variables = email.variables;
-    expect(variables).to.have.property('displayNationalLogo').that.is.a('boolean');
     expect(variables).to.have.property('doNotAnswer').that.is.a('string');
     expect(variables).to.have.property('helpdeskUrl').that.is.a('string');
     expect(variables).to.have.property('homeName').that.is.a('string');

--- a/api/tests/identity-access-management/unit/domain/emails/create-warning-connection.email.test.js
+++ b/api/tests/identity-access-management/unit/domain/emails/create-warning-connection.email.test.js
@@ -23,7 +23,6 @@ describe('Unit | Identity Access Management | Domain | Email | create-warning-co
 
     expect(variables).to.have.property('homeName').that.is.a('string');
     expect(variables).to.have.property('homeUrl').that.is.a('string');
-    expect(variables).to.have.property('displayNationalLogo').that.is.a('boolean');
     expect(variables).to.have.property('contactUs').that.is.a('string');
     expect(variables).to.have.property('doNotAnswer').that.is.a('string');
     expect(variables).to.have.property('moreOn').that.is.a('string');

--- a/api/tests/identity-access-management/unit/domain/emails/email-change-verification-code.email.test.js
+++ b/api/tests/identity-access-management/unit/domain/emails/email-change-verification-code.email.test.js
@@ -20,7 +20,6 @@ describe('Unit | Identity Access Management | Domain | Email | email-change-veri
 
     const variables = email.variables;
     expect(variables.code).to.equal(emailParams.code);
-    expect(variables.displayNationalLogo).to.be.false;
     expect(variables).to.have.property('homeName').that.is.a('string');
     expect(variables).to.have.property('homeUrl').that.is.a('string');
     expect(variables).to.have.property('context').that.is.a('string');
@@ -31,20 +30,5 @@ describe('Unit | Identity Access Management | Domain | Email | email-change-veri
     expect(variables).to.have.property('seeYouSoon').that.is.a('string');
     expect(variables).to.have.property('signing').that.is.a('string');
     expect(variables).to.have.property('warningMessage').that.is.a('string');
-  });
-
-  context('when locale is fr-FR', function () {
-    it('displays french national logo', function () {
-      const emailParams = {
-        email: 'test@example.com',
-        code: '123',
-        locale: 'fr-FR',
-      };
-
-      const email = emailChangeVerificationCodeEmail(emailParams);
-
-      const variables = email.variables;
-      expect(variables.displayNationalLogo).to.be.true;
-    });
   });
 });


### PR DESCRIPTION
## 🌱 Problème

On ne souhaite plus avoir le logo national dans les emails.

## 🐣 Proposition

Supprimer la variable `displayNationalLogo` des emails.

Emails impactés : 
- Nouveau compte
- Reset de mot de passe
- Changement d'email via Mon Compte
- Connexion au compte après une longue période
- Email de suppression de compte

## 🌷 Remarques

N/A

## 🐝 Pour tester

**Pré-requis:**
- Faire les tests sur la RA : L'envois d'email et le provider ont été activé
- Faire les tests sur `.fr` : https://app-pr15739.review.pix.fr
- Utiliser un email réel pour vérifier le template

**Les emails à tester sont pour les use-case suivants :** 
- Créer de nouveau compte => _vérifier l'email_
- Changer d'email via Mon Compte => _vérifier l'email_
- Réinitialiser le mot de passe => _vérifier l'email_
- Se connecter au compte après une longue période : Mettre la date de dernière connexion à plus d'un an: `update "user-logins" set "lastLoggedAt"='2020-01-01' where "userId"==xxxxxxx;` => _vérifier l'email_
- Supprimer son compte  => _vérifier l'email_