### PR TITLE
[TECH] :card_file_box: Ajoute une colonne `eduV3ExternalJuryResult` à la table `assessment-results` (PIX-22236)

### DIFF
--- a/api/db/migrations/20260403092606_add-edu-external-jury-result-column.js
+++ b/api/db/migrations/20260403092606_add-edu-external-jury-result-column.js
@@ -1,0 +1,27 @@
+const TABLE_NAME = 'assessment-results';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table
+      .string('eduV3ExternalJuryResult', 30)
+      .nullable()
+      .defaultTo(null)
+      .comment('store v3 external jury result key (UNSET, ADVANCED or EXPERT)');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn('eduV3ExternalJuryResult');
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## 🌱 Problème

Nous avons besoin de stocker le résultat du jury externe pour les certifications pix+ Édu* V3.

## 🐣 Proposition

:card_file_box: Ajouter une colonne `eduV3ExternalJuryResult` à la table `assessment-results` (pix-22236)

## 🌷 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🐝 Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
