### PR TITLE
[BUGFIX] Éviter la double mise en cache de certaines épreuves (PIX-22238)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -28,6 +28,7 @@
 # Directories maintained by team Certification
 /api/db/seeds/data/team-certification/ @1024pix/team-certification
 /api/src/certification/ @1024pix/team-certification
+/api/scripts/certification/ @1024pix/team-certification
 /api/tests/certification/ @1024pix/team-certification
 
 
@@ -84,6 +85,27 @@
 
 /api/tests/organizational-entities/ @1024pix/team-acquisition
 /api/tests/team/ @1024pix/team-acquisition
+
+
+# Directories maintained by team Contenu
+/api/src/learning-content/ @1024pix/team-contenu
+/api/src/shared/infrastructure/repositories/area-repository.js @1024pix/team-contenu
+/api/src/shared/infrastructure/repositories/challenge-repository.js @1024pix/team-contenu
+/api/src/shared/infrastructure/repositories/competence-repository.js @1024pix/team-contenu
+/api/src/shared/infrastructure/repositories/course-repository.js @1024pix/team-contenu
+/api/src/shared/infrastructure/repositories/framework-repository.js @1024pix/team-contenu
+/api/src/shared/infrastructure/repositories/skill-repository.js @1024pix/team-contenu
+/api/src/shared/infrastructure/repositories/tube-repository.js @1024pix/team-contenu
+/api/src/shared/infrastructure/repositories/thematic-repository.js @1024pix/team-contenu
+/api/tests/learning-content/ @1024pix/team-contenu
+/api/tests/shared/integration/infrastructure/repositories/area-repository_test.js @1024pix/team-contenu
+/api/tests/shared/integration/infrastructure/repositories/challenge-repository_test.js @1024pix/team-contenu
+/api/tests/shared/integration/infrastructure/repositories/competence-repository_test.js @1024pix/team-contenu
+/api/tests/shared/integration/infrastructure/repositories/course-repository_test.js @1024pix/team-contenu
+/api/tests/shared/integration/infrastructure/repositories/framework-repository_test.js @1024pix/team-contenu
+/api/tests/shared/integration/infrastructure/repositories/skill-repository_test.js @1024pix/team-contenu
+/api/tests/shared/integration/infrastructure/repositories/tube-repository_test.js @1024pix/team-contenu
+/api/tests/shared/integration/infrastructure/repositories/thematic-repository_test.js @1024pix/team-contenu
 
 
 # Directories maintained by team Captains

--- a/api/src/certification/evaluation/infrastructure/repositories/calibrated-challenge-repository.js
+++ b/api/src/certification/evaluation/infrastructure/repositories/calibrated-challenge-repository.js
@@ -23,14 +23,14 @@ export async function findActiveFlashCompatible({ locale, version }) {
   _assertLocaleIsDefined(locale);
   const cacheKey = `findActiveFlashCompatible({ versionId: ${version?.id}, locale: ${locale} })`;
 
-  const certificationChallenges = await knexConn
+  const calibrations = await knexConn
     .select('difficulty', 'discriminant', 'challengeId')
     .from('certification-frameworks-challenges')
     .where({ versionId: version.id })
     .whereNotNull('discriminant')
     .whereNotNull('difficulty');
 
-  const certificationChallengeIds = certificationChallenges.map(({ challengeId }) => challengeId);
+  const certificationChallengeIds = calibrations.map(({ challengeId }) => challengeId);
 
   const findCallback = async (lcmsKnex) => {
     return lcmsKnex
@@ -41,15 +41,9 @@ export async function findActiveFlashCompatible({ locale, version }) {
       .orderBy('id');
   };
 
-  const validChallengeDtos = await getInstance().find(cacheKey, findCallback);
-
-  const challengeDtos = decorateWithCertificationCalibration({
-    validChallengeDtos,
-    certificationChallenges,
-  });
-
-  const challengesDtosWithSkills = await loadChallengeDtosSkills(challengeDtos);
-  return challengesDtosWithSkills.map(([challengeDto, skill]) => _toDomain({ challengeDto, skill }));
+  const lcmsChallengeDtos = await getInstance().find(cacheKey, findCallback);
+  const calibratedSkillsMap = await loadCalibratedSkillsMap(lcmsChallengeDtos);
+  return toDomainMap({ lcmsChallengeDtos, calibrations, calibratedSkillsMap });
 }
 
 /**
@@ -73,22 +67,16 @@ export async function getMany({ ids, version }) {
     throw new NotFoundError('Some challenges do not exist in certification version');
   }
 
-  const lcmsChallenges = await getInstance().loadMany(ids);
-  lcmsChallenges.forEach((challengeDto, index) => {
+  const lcmsChallengeDtos = await getInstance().loadMany(ids);
+  lcmsChallengeDtos.forEach((challengeDto, index) => {
     if (challengeDto) return;
     logger.error({ challengeId: ids[index] }, 'Some challenges do not exist in LCMS');
     throw new NotFoundError('Some challenges do not exist in LCMS');
   });
 
-  lcmsChallenges.sort(_byId);
-
-  const challengesWithCalibration = decorateWithCertificationCalibration({
-    validChallengeDtos: lcmsChallenges,
-    certificationChallenges: calibrations,
-  });
-
-  const challengesDtosWithSkills = await loadChallengeDtosSkills(challengesWithCalibration);
-  return challengesDtosWithSkills.map(([challengeDto, skill]) => _toDomain({ challengeDto, skill }));
+  lcmsChallengeDtos.sort(_byId);
+  const calibratedSkillsMap = await loadCalibratedSkillsMap(lcmsChallengeDtos);
+  return toDomainMap({ lcmsChallengeDtos, calibrations, calibratedSkillsMap });
 }
 
 /**
@@ -99,7 +87,7 @@ export async function getMany({ ids, version }) {
 export async function getAllCalibratedChallenges({ version }) {
   const knexConn = DomainTransaction.getConnection();
 
-  const calibrationForThisVersion = await knexConn
+  const calibrations = await knexConn
     .select('discriminant', 'difficulty', 'challengeId')
     .from('certification-frameworks-challenges')
     .where({ versionId: version.id })
@@ -107,51 +95,22 @@ export async function getAllCalibratedChallenges({ version }) {
     .whereNotNull('difficulty')
     .orderBy('challengeId');
 
-  const challengesIds = calibrationForThisVersion.map(({ challengeId }) => challengeId);
+  const challengesIds = calibrations.map(({ challengeId }) => challengeId);
 
-  const lcmsChallenges = await getInstance().loadMany(challengesIds);
-  lcmsChallenges.forEach((challengeDto, index) => {
+  const lcmsChallengeDtos = await getInstance().loadMany(challengesIds);
+  lcmsChallengeDtos.forEach((challengeDto, index) => {
     if (challengeDto) return;
     logger.error({ challengeId: challengesIds[index] }, 'Some challenges do not exist in LCMS');
     throw new NotFoundError('Some challenges do not exist in LCMS');
   });
 
-  lcmsChallenges.sort(_byId);
-
-  const challengesWithCalibration = decorateWithCertificationCalibration({
-    validChallengeDtos: lcmsChallenges,
-    certificationChallenges: calibrationForThisVersion,
-  });
-
-  const challengesDtosWithSkills = await loadChallengeDtosSkills(challengesWithCalibration);
-  return challengesDtosWithSkills.map(([challengeDto, skill]) => _toDomain({ challengeDto, skill }));
+  lcmsChallengeDtos.sort(_byId);
+  const calibratedSkillsMap = await loadCalibratedSkillsMap(lcmsChallengeDtos);
+  return toDomainMap({ lcmsChallengeDtos, calibrations, calibratedSkillsMap });
 }
 
 function _byId(challenge1, challenge2) {
   return challenge1.id < challenge2.id ? -1 : 1;
-}
-
-async function loadChallengeDtosSkills(challengeDtos) {
-  return Promise.all(
-    challengeDtos.map(async (challengeDto) => [
-      challengeDto,
-      challengeDto.skillId ? await skillRepository.get(challengeDto.skillId) : null,
-    ]),
-  );
-}
-
-function decorateWithCertificationCalibration({ validChallengeDtos, certificationChallenges }) {
-  return validChallengeDtos.map((challenge) => {
-    const { discriminant, difficulty } = certificationChallenges.find(
-      ({ challengeId }) => challengeId === challenge.id,
-    );
-
-    return {
-      ...challenge,
-      discriminant,
-      difficulty,
-    };
-  });
 }
 
 function _assertLocaleIsDefined(locale) {
@@ -160,18 +119,33 @@ function _assertLocaleIsDefined(locale) {
   }
 }
 
-function _toDomain({ challengeDto, skill }) {
-  return new CalibratedChallenge({
-    id: challengeDto.id,
-    discriminant: challengeDto.discriminant,
-    difficulty: challengeDto.difficulty,
-    blindnessCompatibility: challengeDto.accessibility1,
-    colorBlindnessCompatibility: challengeDto.accessibility2,
-    skill: new CalibratedChallengeSkill({
-      id: skill.id,
-      name: skill.name,
-      competenceId: skill.competenceId,
-      tubeId: skill.tubeId,
-    }),
+async function loadCalibratedSkillsMap(lcmsChallengeDtos) {
+  const uniqueSkillIds = [...new Set(lcmsChallengeDtos.map((lcmsChallengeDto) => lcmsChallengeDto.skillId))];
+  const baseSkills = await skillRepository.findByRecordIds(uniqueSkillIds);
+  return new Map(
+    baseSkills.map((bs) => [
+      bs.id,
+      new CalibratedChallengeSkill({
+        id: bs.id,
+        name: bs.name,
+        competenceId: bs.competenceId,
+        tubeId: bs.tubeId,
+      }),
+    ]),
+  );
+}
+
+function toDomainMap({ lcmsChallengeDtos, calibrations, calibratedSkillsMap }) {
+  return lcmsChallengeDtos.map((lcmsChallengeDto) => {
+    const { discriminant, difficulty } = calibrations.find(({ challengeId }) => challengeId === lcmsChallengeDto.id);
+    const calibratedSkill = lcmsChallengeDto.skillId ? calibratedSkillsMap.get(lcmsChallengeDto.skillId) : null;
+    return new CalibratedChallenge({
+      id: lcmsChallengeDto.id,
+      discriminant,
+      difficulty,
+      blindnessCompatibility: lcmsChallengeDto.accessibility1,
+      colorBlindnessCompatibility: lcmsChallengeDto.accessibility2,
+      skill: calibratedSkill,
+    });
   });
 }

--- a/api/src/certification/evaluation/infrastructure/repositories/calibrated-challenge-repository.js
+++ b/api/src/certification/evaluation/infrastructure/repositories/calibrated-challenge-repository.js
@@ -4,13 +4,12 @@
 
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../../shared/domain/errors.js';
-import { LearningContentRepository } from '../../../../shared/infrastructure/repositories/learning-content-repository.js';
+import { getInstance } from '../../../../shared/infrastructure/repositories/challenge-repository.js';
 import * as skillRepository from '../../../../shared/infrastructure/repositories/skill-repository.js';
 import { logger } from '../../../../shared/infrastructure/utils/logger.js';
 import { CalibratedChallenge } from '../../domain/models/CalibratedChallenge.js';
 import { CalibratedChallengeSkill } from '../../domain/models/CalibratedChallengeSkill.js';
 
-const TABLE_NAME = 'learningcontent.challenges';
 const VALIDATED_STATUS = 'validé';
 
 /**
@@ -19,13 +18,7 @@ const VALIDATED_STATUS = 'validé';
  * @param {Version} params.version
  * @returns {Promise<CalibratedChallenge[]>} challenges with validated LCMS status
  */
-export async function findActiveFlashCompatible({
-  locale,
-  version,
-  dependencies = {
-    getInstance,
-  },
-} = {}) {
+export async function findActiveFlashCompatible({ locale, version }) {
   const knexConn = DomainTransaction.getConnection();
   _assertLocaleIsDefined(locale);
   const cacheKey = `findActiveFlashCompatible({ versionId: ${version?.id}, locale: ${locale} })`;
@@ -48,7 +41,7 @@ export async function findActiveFlashCompatible({
       .orderBy('id');
   };
 
-  const validChallengeDtos = await dependencies.getInstance().find(cacheKey, findCallback);
+  const validChallengeDtos = await getInstance().find(cacheKey, findCallback);
 
   const challengeDtos = decorateWithCertificationCalibration({
     validChallengeDtos,
@@ -65,13 +58,7 @@ export async function findActiveFlashCompatible({
  * @param {Version} params.version
  * @returns {Promise<CalibratedChallenge[]>}
  */
-export async function getMany({
-  ids,
-  version,
-  dependencies = {
-    getInstance,
-  },
-} = {}) {
+export async function getMany({ ids, version }) {
   const knexConn = DomainTransaction.getConnection();
   const calibrations = await knexConn
     .select('difficulty', 'discriminant', 'challengeId')
@@ -86,7 +73,7 @@ export async function getMany({
     throw new NotFoundError('Some challenges do not exist in certification version');
   }
 
-  const lcmsChallenges = await dependencies.getInstance().loadMany(ids);
+  const lcmsChallenges = await getInstance().loadMany(ids);
   lcmsChallenges.forEach((challengeDto, index) => {
     if (challengeDto) return;
     logger.error({ challengeId: ids[index] }, 'Some challenges do not exist in LCMS');
@@ -109,12 +96,7 @@ export async function getMany({
  * @param {Version} params.version
  * @returns {Promise<CalibratedChallenge[]>}
  */
-export async function getAllCalibratedChallenges({
-  version,
-  dependencies = {
-    getInstance,
-  },
-}) {
+export async function getAllCalibratedChallenges({ version }) {
   const knexConn = DomainTransaction.getConnection();
 
   const calibrationForThisVersion = await knexConn
@@ -127,7 +109,7 @@ export async function getAllCalibratedChallenges({
 
   const challengesIds = calibrationForThisVersion.map(({ challengeId }) => challengeId);
 
-  const lcmsChallenges = await dependencies.getInstance().loadMany(challengesIds);
+  const lcmsChallenges = await getInstance().loadMany(challengesIds);
   lcmsChallenges.forEach((challengeDto, index) => {
     if (challengeDto) return;
     logger.error({ challengeId: challengesIds[index] }, 'Some challenges do not exist in LCMS');
@@ -192,13 +174,4 @@ function _toDomain({ challengeDto, skill }) {
       tubeId: skill.tubeId,
     }),
   });
-}
-
-let instance;
-
-function getInstance() {
-  if (!instance) {
-    instance = new LearningContentRepository({ tableName: TABLE_NAME });
-  }
-  return instance;
 }

--- a/api/src/certification/evaluation/infrastructure/repositories/calibrated-challenge-repository.js
+++ b/api/src/certification/evaluation/infrastructure/repositories/calibrated-challenge-repository.js
@@ -109,12 +109,12 @@ export async function getMany({
  * @param {Version} params.version
  * @returns {Promise<CalibratedChallenge[]>}
  */
-export const getAllCalibratedChallenges = async ({
+export async function getAllCalibratedChallenges({
   version,
   dependencies = {
     getInstance,
   },
-}) => {
+}) {
   const knexConn = DomainTransaction.getConnection();
 
   const calibrationForThisVersion = await knexConn
@@ -143,11 +143,11 @@ export const getAllCalibratedChallenges = async ({
 
   const challengesDtosWithSkills = await loadChallengeDtosSkills(challengesWithCalibration);
   return challengesDtosWithSkills.map(([challengeDto, skill]) => _toDomain({ challengeDto, skill }));
-};
+}
 
-const _byId = (challenge1, challenge2) => {
+function _byId(challenge1, challenge2) {
   return challenge1.id < challenge2.id ? -1 : 1;
-};
+}
 
 async function loadChallengeDtosSkills(challengeDtos) {
   return Promise.all(

--- a/api/src/shared/infrastructure/repositories/challenge-repository.js
+++ b/api/src/shared/infrastructure/repositories/challenge-repository.js
@@ -236,7 +236,7 @@ function toDomain({ challengeDto, webComponentTagName, webComponentProps, skill,
 /** @type {LearningContentRepository} */
 let instance;
 
-function getInstance() {
+export function getInstance() {
   if (!instance) {
     instance = new LearningContentRepository({ tableName: TABLE_NAME });
   }

--- a/api/tests/certification/evaluation/integration/infrastructure/repositories/calibrated-challenge-repository_test.js
+++ b/api/tests/certification/evaluation/integration/infrastructure/repositories/calibrated-challenge-repository_test.js
@@ -555,7 +555,7 @@ describe('Certification | Evaluation | Integration | Repository | calibrated-cha
         await databaseBuilder.commit();
 
         // when
-        const err = await catchErr(calibratedChallengeRepository.findActiveFlashCompatible)();
+        const err = await catchErr(calibratedChallengeRepository.findActiveFlashCompatible)({});
 
         // then
         expect(err.message).to.equal('Locale shall be defined');


### PR DESCRIPTION
## 🌱 Problème

L'équipe souhaitait faire des optimisations autour de la récupération d'épreuves dans le cadre de la certification. Aujourd'hui, les modèles retournées par le `challenge-repository` sont gros, et surtout les modèles `Challenges` provoquent également la récupération du modèle `Skill` correspondant, de manière peu optimisée.
On voulait donc récupérer directement le DTO mis en cache pour ne prélever que les 3 attributs nécessaires au modèle du bounded-context correspondant (`CalibratedChallenge`).
Ce faisant, nous avons fait une boulette et avons dupliqué plusieurs épreuves en RAM.

## 🐣 Proposition
La team-contenu est bien au courant que le code autour de la lecture et l'exploitation du contenu pédagogique :
- n'est pas à sa place
- n'est pas sécurisé
- est grossièrement exploité

En attendant qu'ils fassent leur travail de réflexion là-dessus, on se contente juste de résoudre le problème d'une manière simple (pour conserver les optimisations voulues initialement).
Nous sommes bien conscients que l'export de l'instance de cache du `challenge-repository` n'est pas une décision souhaitable pour du long-terme. Mais c'est la solution que nous adoptons aujourd'hui

## 🌷 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🐝 Pour tester
Non régression sur les choix d'épreuves (eval, campagnes, certif) (les e2e sont là pour ça 🌈 ) (et ils sont ✅ )
