### PR TITLE
[FEATURE] Trier par nom de famille au lieu du prénom en premier dans la page attestations (PIX-22243).

### DIFF
--- a/api/src/prescription/organization-learner/infrastructure/repositories/organization-learner-repository.js
+++ b/api/src/prescription/organization-learner/infrastructure/repositories/organization-learner-repository.js
@@ -177,8 +177,8 @@ async function findPaginatedAttestationStatusForOrganizationLearnersAndKey({
     .from('view-active-organization-learners')
     .join('users', 'users.id', 'view-active-organization-learners.userId')
     .where({ isDisabled: false, organizationId, isAnonymous: false, hasBeenAnonymised: false })
-    .orderByRaw('LOWER("view-active-organization-learners"."firstName") ASC')
-    .orderByRaw('LOWER("view-active-organization-learners"."lastName") ASC');
+    .orderByRaw('LOWER("view-active-organization-learners"."lastName") ASC')
+    .orderByRaw('LOWER("view-active-organization-learners"."firstName") ASC');
 
   if (filter) {
     const { name, divisions } = filter;

--- a/api/tests/prescription/organization-learner/integration/infrastructure/repositories/organization-learner-repository_test.js
+++ b/api/tests/prescription/organization-learner/integration/infrastructure/repositories/organization-learner-repository_test.js
@@ -858,15 +858,15 @@ describe('Integration | Infrastructure | Repository | Organization Learner', fun
       secondUser = new User(databaseBuilder.factory.buildUser({ firstName: 'theo', lastName: 'Courant' }));
       organizationLearner1 = databaseBuilder.factory.buildOrganizationLearner({
         organizationId,
-        firstName: 'firstName1',
-        lastName: 'lastName1',
+        firstName: 'xandri',
+        lastName: 'Alek',
         division: '6eme A',
         userId: firstUser.id,
       });
       organizationLearner2 = databaseBuilder.factory.buildOrganizationLearner({
         organizationId,
-        firstName: 'firstName2',
-        lastName: 'lastName2',
+        firstName: 'xandra',
+        lastName: 'Balek',
         division: '6eme B',
         userId: secondUser.id,
       });
@@ -1067,7 +1067,7 @@ describe('Integration | Infrastructure | Repository | Organization Learner', fun
     });
 
     context('ordered learners without case sensitive', function () {
-      it('orders by firstName', async function () {
+      it('orders by lastName', async function () {
         const { attestationParticipantsStatus: result } =
           await organizationLearnerRepository.findPaginatedAttestationStatusForOrganizationLearnersAndKey({
             organizationId,
@@ -1079,17 +1079,17 @@ describe('Integration | Infrastructure | Repository | Organization Learner', fun
         expect(result[1].organizationLearnerId).to.equal(organizationLearner2.id);
       });
 
-      it('orders by lastName when firstName are identical', async function () {
+      it('orders by firstName when lastName are identical', async function () {
         const secondLearner = databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
           organizationId,
           firstName: 'Toto',
-          lastName: 'Auberto',
+          lastName: 'Quberto',
         });
 
         const thirdLearner = databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
           organizationId,
-          firstName: 'Toto',
-          lastName: 'auberti',
+          firstName: 'Tota',
+          lastName: 'Quberto',
         });
 
         await databaseBuilder.commit();
@@ -1141,7 +1141,7 @@ describe('Integration | Infrastructure | Repository | Organization Learner', fun
                 size: 1,
                 number: 1,
               },
-              filter: { name: 'firstName', divisions: ['6eme A'] },
+              filter: { name: 'xandri', divisions: ['6eme A'] },
             });
 
           expect(result.pagination).to.deep.equal({


### PR DESCRIPTION
## 🌱 Problème

La page des attestations est trié par prenom puis par nom. ce qui n'est pas forcément usuel

## 🐣 Proposition

trier d'abord par nom de famille puis par prénom dans le cas ou le nom de famille est identique. 

## 🌷 Remarques

RAS

## 🐝 Pour tester
- [ ] Se connecter a PixOrga avec le compte admin-orga@example.net
- [ ] Se positionner sur l'organisation Attestation 123ABC
- [ ] Aller sur la page Attestations
- [ ] Vérifier que la tableau est trié par nom de famille puis par prénom