### PR TITLE
[FEATURE] Insérer les configuration de filtres de l'organisation à l'insertion des learners en BDD (Pix-22222).

### DIFF
--- a/api/db/database-builder/factory/prescription/organization-learners/build-organization-learner-filter.js
+++ b/api/db/database-builder/factory/prescription/organization-learners/build-organization-learner-filter.js
@@ -1,0 +1,16 @@
+import { databaseBuffer } from '../../../database-buffer.js';
+
+const buildOrganizationLearnerFilter = function ({ organizationId, attributeName, values } = {}) {
+  const columns = {
+    organization_id: organizationId,
+    attribute_name: attributeName,
+    values: JSON.stringify(values),
+  };
+
+  return databaseBuffer.pushInsertable({
+    tableName: 'organization_learner_filters',
+    values: columns,
+  });
+};
+
+export { buildOrganizationLearnerFilter };

--- a/api/src/prescription/learner-management/domain/models/CommonOrganizationLearnerFilter.js
+++ b/api/src/prescription/learner-management/domain/models/CommonOrganizationLearnerFilter.js
@@ -1,0 +1,16 @@
+class CommonOrganizationLearnerFilter {
+  constructor({ organizationId, attributeName, values }) {
+    this.organizationId = organizationId;
+    this.attributeName = attributeName;
+    this.values = values;
+  }
+
+  get dataToInsert() {
+    return {
+      organization_id: this.organizationId,
+      attribute_name: this.attributeName,
+      values: JSON.stringify(this.values.sort()),
+    };
+  }
+}
+export { CommonOrganizationLearnerFilter };

--- a/api/src/prescription/learner-management/domain/models/ImportOrganizationLearnerSet.js
+++ b/api/src/prescription/learner-management/domain/models/ImportOrganizationLearnerSet.js
@@ -7,6 +7,7 @@ import {
 import { convertDateValue } from '../../../../shared/infrastructure/utils/date-utils.js';
 import { CommonOrganizationLearner } from '../models/CommonOrganizationLearner.js';
 import { validateCommonOrganizationLearner } from '../validators/common-organization-learner-validator.js';
+import { CommonOrganizationLearnerFilter } from './CommonOrganizationLearnerFilter.js';
 
 class ImportOrganizationLearnerSet {
   #learners;
@@ -250,6 +251,25 @@ class ImportOrganizationLearnerSet {
     if (errors.length > 0) {
       throw errors;
     }
+  }
+
+  get filtersAvailableValues() {
+    return this.#columnMapping
+      .filter((header) => header.config?.displayable?.filterable?.type === 'list')
+      .map((header) => {
+        const attributeName = header.config?.property ?? header.config?.mappingColumn ?? header.name;
+        const isProperty = Boolean(header.config?.property);
+
+        const values = [
+          ...new Set(
+            this.#learners
+              .map((learner) => (isProperty ? learner[attributeName] : learner.attributes?.[attributeName]))
+              .filter((value) => value != null),
+          ),
+        ];
+
+        return new CommonOrganizationLearnerFilter({ organizationId: this.#organizationId, attributeName, values });
+      });
   }
 
   get learners() {

--- a/api/src/prescription/learner-management/domain/usecases/import-from-feature/save-organization-learners-file.js
+++ b/api/src/prescription/learner-management/domain/usecases/import-from-feature/save-organization-learners-file.js
@@ -1,3 +1,4 @@
+import { DomainTransaction } from '../../../../../shared/domain/DomainTransaction.js';
 import { CommonCsvLearnerParser } from '../../../infrastructure/serializers/csv/common-csv-learner-parser.js';
 import { getDataBuffer } from '../../../infrastructure/utils/bufferize/get-data-buffer.js';
 import { AggregateImportError } from '../../errors.js';
@@ -7,6 +8,7 @@ const saveOrganizationLearnersFile = async function ({
   organizationImportId,
   organizationLearnerImportFormatRepository,
   organizationLearnerRepository,
+  organizationLearnerFilterRepository,
   organizationImportRepository,
   importStorage,
   dependencies = { getDataBuffer },
@@ -40,11 +42,20 @@ const saveOrganizationLearnersFile = async function ({
 
     const learners = learnerSet.learners;
 
-    await organizationLearnerRepository.disableCommonOrganizationLearnersFromOrganizationId({
-      organizationId,
-      excludeOrganizationLearnerIds: learners.existinglearnerIds,
+    await DomainTransaction.execute(async () => {
+      await organizationLearnerFilterRepository.deleteOrganizationLearnerFiltersFromOrganizationId(organizationId);
+      await organizationLearnerRepository.disableCommonOrganizationLearnersFromOrganizationId({
+        organizationId,
+        excludeOrganizationLearnerIds: learners.existinglearnerIds,
+      });
+      await organizationLearnerRepository.saveCommonOrganizationLearners(learners.list);
+
+      if (learnerSet.filtersAvailableValues.length > 0) {
+        await organizationLearnerFilterRepository.saveOrganizationLearnerFilters(
+          learnerSet.filtersAvailableValues.map((learnerFilter) => learnerFilter.dataToInsert),
+        );
+      }
     });
-    await organizationLearnerRepository.saveCommonOrganizationLearners(learners.list);
   } catch (error) {
     if (Array.isArray(error)) {
       errors.push(...error);

--- a/api/src/prescription/learner-management/domain/usecases/index.js
+++ b/api/src/prescription/learner-management/domain/usecases/index.js
@@ -26,6 +26,7 @@ import { validateCommonOrganizationImportFileJobRepository } from '../../infrast
 import { validateCsvOrganizationImportFileJobRepository } from '../../infrastructure/repositories/jobs/validate-csv-organization-learners-import-file-job-repository.js';
 import { validateOrganizationImportFileJobRepository } from '../../infrastructure/repositories/jobs/validate-organization-learners-import-file-job-repository.js';
 import * as organizationImportRepository from '../../infrastructure/repositories/organization-import-repository.js';
+import * as organizationLearnerFilterRepository from '../../infrastructure/repositories/organization-learner-filter-repository.js';
 import * as organizationLearnerImportFormatRepository from '../../infrastructure/repositories/organization-learner-import-format-repository.js';
 import * as organizationLearnerRepository from '../../infrastructure/repositories/organization-learner-repository.js';
 import * as studentRepository from '../../infrastructure/repositories/student-repository.js';
@@ -56,6 +57,7 @@ const dependencies = {
   organizationFeatureApi,
   organizationFeatureRepository: repositories.organizationFeatureRepository,
   organizationImportRepository,
+  organizationLearnerFilterRepository,
   organizationLearnerImportFormatRepository,
   organizationLearnerRepository,
   organizationRepository,

--- a/api/src/prescription/learner-management/infrastructure/repositories/organization-learner-filter-repository.js
+++ b/api/src/prescription/learner-management/infrastructure/repositories/organization-learner-filter-repository.js
@@ -1,0 +1,9 @@
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
+
+const deleteOrganizationLearnerFiltersFromOrganizationId = async function (organizationId) {
+  const knexConn = DomainTransaction.getConnection();
+
+  await knexConn('organization_learner_filters').where('organization_id', organizationId).del();
+};
+
+export { deleteOrganizationLearnerFiltersFromOrganizationId };

--- a/api/src/prescription/learner-management/infrastructure/repositories/organization-learner-filter-repository.js
+++ b/api/src/prescription/learner-management/infrastructure/repositories/organization-learner-filter-repository.js
@@ -1,4 +1,6 @@
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
+import { UnicityConstraintError } from '../../../../shared/domain/errors.js';
+import * as knexUtils from '../../../../shared/infrastructure/utils/knex-utils.js';
 
 const deleteOrganizationLearnerFiltersFromOrganizationId = async function (organizationId) {
   const knexConn = DomainTransaction.getConnection();
@@ -6,4 +8,20 @@ const deleteOrganizationLearnerFiltersFromOrganizationId = async function (organ
   await knexConn('organization_learner_filters').where('organization_id', organizationId).del();
 };
 
-export { deleteOrganizationLearnerFiltersFromOrganizationId };
+const saveOrganizationLearnerFilters = async function (organizationLearnerFilters) {
+  try {
+    const knexConn = DomainTransaction.getConnection();
+    await knexConn.batchInsert('organization_learner_filters', organizationLearnerFilters).transacting(knexConn);
+  } catch (error) {
+    if (knexUtils.isUniqConstraintViolated(error) && error.code === '23505') {
+      throw new UnicityConstraintError(
+        'Unicity constraint failed on organization learner filter repository',
+        error.detail,
+      );
+    }
+
+    throw error;
+  }
+};
+
+export { deleteOrganizationLearnerFiltersFromOrganizationId, saveOrganizationLearnerFilters };

--- a/api/src/shared/domain/errors.js
+++ b/api/src/shared/domain/errors.js
@@ -684,6 +684,12 @@ class AccountRecoveryUserAlreadyConfirmEmail extends DomainError {
   }
 }
 
+class UnicityConstraintError extends DomainError {
+  constructor(message = 'unicity constraint occured', meta) {
+    super(message, null, meta);
+  }
+}
+
 class OrganizationLearnersCouldNotBeSavedError extends DomainError {
   constructor(message = 'An error occurred during process') {
     super(message);
@@ -1160,6 +1166,7 @@ export {
   TargetProfileInvalidError,
   TargetProfileRequiresToBeLinkedToAutonomousCourseOrganization,
   UnexpectedUserAccountError,
+  UnicityConstraintError,
   UserAlreadyExistsWithAuthenticationMethodError,
   UserAlreadyLinkedToCandidateInSessionError,
   UserCouldNotBeReconciledError,

--- a/api/tests/prescription/learner-management/integration/domain/usecases/import-from-feature/save-organization-learners-file_test.js
+++ b/api/tests/prescription/learner-management/integration/domain/usecases/import-from-feature/save-organization-learners-file_test.js
@@ -29,6 +29,13 @@ describe('Integration | Infrastructure | Jobs | ImportSupOrganizationLearnersJob
           { name: 'Prénom', config: { property: 'firstName' }, required: true },
           {
             name: 'Classe',
+            config: {
+              displayable: {
+                filterable: {
+                  type: 'list',
+                },
+              },
+            },
             required: true,
           },
           {
@@ -72,5 +79,25 @@ O-Ren;Ishii;5B;01/02/1980`,
       .where({ organizationId });
 
     expect(learners).lengthOf(2);
+  });
+
+  it('keep only configured organization learner filter', async function () {
+    // given
+    databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearnerFilter({
+      organizationId,
+      attributeName: 'TOTO',
+      values: ['zero', 'plus', '0', 'égal'],
+    });
+
+    await databaseBuilder.commit();
+
+    // when
+    await usecases.saveOrganizationLearnersFile({ organizationImportId: organizationImport.id });
+
+    const filters = await knex('organization_learner_filters').where('organization_id', organizationId);
+
+    expect(filters).lengthOf(1);
+    expect(filters[0].attribute_name).equal('Classe');
+    expect(filters[0].values).deep.equal(['5B', '6A']);
   });
 });

--- a/api/tests/prescription/learner-management/integration/domain/usecases/import-from-feature/save-organization-learners-file_test.js
+++ b/api/tests/prescription/learner-management/integration/domain/usecases/import-from-feature/save-organization-learners-file_test.js
@@ -1,0 +1,76 @@
+import { Readable } from 'node:stream';
+
+import { usecases } from '../../../../../../../src/prescription/learner-management/domain/usecases/index.js';
+import { importStorage } from '../../../../../../../src/prescription/learner-management/infrastructure/storage/import-storage.js';
+import { ORGANIZATION_FEATURE } from '../../../../../../../src/shared/domain/constants.js';
+import { databaseBuilder, expect, knex, sinon } from '../../../../../../test-helper.js';
+
+describe('Integration | Infrastructure | Jobs | ImportSupOrganizationLearnersJobController', function () {
+  let organizationId, user, organizationImport;
+
+  beforeEach(async function () {
+    user = databaseBuilder.factory.buildUser();
+    organizationId = databaseBuilder.factory.buildOrganization().id;
+    organizationImport = databaseBuilder.factory.buildOrganizationImport({
+      organizationId,
+      createdBy: user.id,
+      filename: 'plop',
+    });
+
+    const importFeature = databaseBuilder.factory.buildFeature(ORGANIZATION_FEATURE.LEARNER_IMPORT);
+    const importFormat = databaseBuilder.factory.buildOrganizationLearnerImportFormat({
+      name: 'test',
+      fileType: 'csv',
+      config: {
+        acceptedEncoding: ['utf-8'],
+        unicityColumns: ['Classe'],
+        headers: [
+          { name: 'Nom', config: { property: 'lastName' }, required: true },
+          { name: 'Prénom', config: { property: 'firstName' }, required: true },
+          {
+            name: 'Classe',
+            required: true,
+          },
+          {
+            name: 'Date de naissance',
+            required: true,
+          },
+        ],
+      },
+    });
+
+    databaseBuilder.factory.buildOrganizationFeature({
+      featureId: importFeature.id,
+      organizationId,
+      params: { organizationLearnerImportFormatId: importFormat.id },
+    });
+
+    await databaseBuilder.commit();
+
+    sinon.stub(importStorage, 'deleteFile').withArgs({ filename: 'plop' }).resolves();
+    sinon
+      .stub(importStorage, 'readFile')
+      .withArgs({ filename: 'plop' })
+      .callsFake(() =>
+        Readable.from(
+          Buffer.from(
+            `Nom;Prénom;Classe;Date de naissance
+Beatrix;Kiddo;6A;01/01/1990
+O-Ren;Ishii;5B;01/02/1980`,
+            'utf-8',
+          ),
+        ),
+      );
+  });
+
+  it('save two learner on organization', async function () {
+    // when
+    await usecases.saveOrganizationLearnersFile({ organizationImportId: organizationImport.id });
+
+    const learners = await knex('organization-learners')
+      .select('firstName', 'lastName', 'attributes')
+      .where({ organizationId });
+
+    expect(learners).lengthOf(2);
+  });
+});

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/organization-learner-filter-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/organization-learner-filter-repository_test.js
@@ -1,5 +1,6 @@
 import * as organizationLearnerFilterRepository from '../../../../../../src/prescription/learner-management/infrastructure/repositories/organization-learner-filter-repository.js';
-import { databaseBuilder, expect, knex, sinon } from '../../../../../test-helper.js';
+import { UnicityConstraintError } from '../../../../../../src/shared/domain/errors.js';
+import { catchErr, databaseBuilder, expect, knex } from '../../../../../test-helper.js';
 
 describe('Integration | Repository | Organization Learner Management | Organization Learner Filter', function () {
   describe('#deleteOrganizationLearnerFiltersFromOrganizationId', function () {
@@ -46,6 +47,63 @@ describe('Integration | Repository | Organization Learner Management | Organizat
       expect(result).lengthOf(1);
       expect(result[0].attribute_name).equal('division');
       expect(result[0].values).deep.equal(['E3', '8R', 'Z6']);
+    });
+  });
+
+  describe('#saveOrganizationLearnerFilters', function () {
+    it('save organization learner filter', async function () {
+      // given
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+
+      await databaseBuilder.commit();
+      // when
+      await organizationLearnerFilterRepository.saveOrganizationLearnerFilters([
+        {
+          organization_id: organizationId,
+          attribute_name: 'Lofteur',
+          values: JSON.stringify(['ouai', 'cool', 'wahou']),
+        },
+        {
+          organization_id: organizationId,
+          attribute_name: 'MiniKeums',
+          values: JSON.stringify(['vanessa', 'non ne pleur pas', 'woho ho ho']),
+        },
+      ]);
+
+      // then
+      const result = await knex('organization_learner_filters').where('organization_id', organizationId);
+
+      expect(result).lengthOf(2);
+    });
+
+    it('throw an error when duplicate entry is found', async function () {
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearnerFilter({
+        organizationId,
+        attributeName: 'Lofteur',
+        values: JSON.stringify(['ouai', 'cool', 'wahou']),
+      });
+
+      await databaseBuilder.commit();
+      // when
+      const error = await catchErr(organizationLearnerFilterRepository.saveOrganizationLearnerFilters)([
+        {
+          organization_id: organizationId,
+          attribute_name: 'Lofteur',
+          values: JSON.stringify(['ouai', 'cool', 'wahou']),
+        },
+        {
+          organization_id: organizationId,
+          attribute_name: 'MiniKeums',
+          values: JSON.stringify(['vanessa', 'non ne pleur pas', 'woho ho ho']),
+        },
+      ]);
+
+      // then
+      expect(error).instanceOf(UnicityConstraintError);
+      const result = await knex('organization_learner_filters').where('organization_id', organizationId);
+
+      expect(result).lengthOf(1);
     });
   });
 });

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/organization-learner-filter-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/organization-learner-filter-repository_test.js
@@ -1,0 +1,51 @@
+import * as organizationLearnerFilterRepository from '../../../../../../src/prescription/learner-management/infrastructure/repositories/organization-learner-filter-repository.js';
+import { databaseBuilder, expect, knex, sinon } from '../../../../../test-helper.js';
+
+describe('Integration | Repository | Organization Learner Management | Organization Learner Filter', function () {
+  describe('#deleteOrganizationLearnerFiltersFromOrganizationId', function () {
+    it('should delete organization learner filter from organizationId', async function () {
+      // given
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+
+      databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearnerFilter({
+        organizationId,
+        attributeName: 'division',
+        values: ['E3', '8R', 'Z6'],
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      await organizationLearnerFilterRepository.deleteOrganizationLearnerFiltersFromOrganizationId(organizationId);
+
+      // then
+      const result = await knex('organization_learner_filters').where('organization_id', organizationId);
+
+      expect(result).lengthOf(0);
+    });
+
+    it('should not delete organization learner filter from another organizationId', async function () {
+      // given
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+
+      const anotherOrganizationId = databaseBuilder.factory.buildOrganization().id;
+      databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearnerFilter({
+        organizationId: anotherOrganizationId,
+        attributeName: 'division',
+        values: ['E3', '8R', 'Z6'],
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      await organizationLearnerFilterRepository.deleteOrganizationLearnerFiltersFromOrganizationId(organizationId);
+
+      // then
+      const result = await knex('organization_learner_filters').where('organization_id', anotherOrganizationId);
+
+      expect(result).lengthOf(1);
+      expect(result[0].attribute_name).equal('division');
+      expect(result[0].values).deep.equal(['E3', '8R', 'Z6']);
+    });
+  });
+});

--- a/api/tests/prescription/learner-management/unit/domain/models/CommonOrganizationLearnerFilter_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/models/CommonOrganizationLearnerFilter_test.js
@@ -1,0 +1,49 @@
+import { CommonOrganizationLearnerFilter } from '../../../../../../src/prescription/learner-management/domain/models/CommonOrganizationLearnerFilter.js';
+import { expect } from '../../../../../test-helper.js';
+
+describe('Unit | Models | CommonOrganizationLearnerFilter', function () {
+  describe('#constructor', function () {
+    it('should create a CommonOrganizationLearnerFilter from parameters', function () {
+      // given
+      const input = {
+        organizationId: 1,
+        userId: 2,
+        attributeName: 'Kimberley',
+        values: ['Tartine'],
+        email: 'test@example.net',
+        'date de naissance': '2000-01-01',
+      };
+
+      // when
+      const learnerFilter = new CommonOrganizationLearnerFilter(input);
+
+      // then
+      expect(learnerFilter).to.deep.equal({
+        organizationId: input.organizationId,
+        attributeName: input.attributeName,
+        values: input.values,
+      });
+    });
+  });
+
+  describe('#dataToInsert', function () {
+    it('should map model to database entity and sorting value', function () {
+      const input = {
+        organizationId: 1,
+        attributeName: 'Kimberley',
+        values: ['Noisette', 'Tartine', 'Confiture'],
+      };
+
+      // when
+      const learnerFilter = new CommonOrganizationLearnerFilter(input);
+
+      // when
+      const dataToInsert = learnerFilter.dataToInsert;
+
+      // then
+      expect(dataToInsert.organization_id).equal(input.organizationId);
+      expect(dataToInsert.attribute_name).equal(input.attributeName);
+      expect(dataToInsert.values).equal('["Confiture","Noisette","Tartine"]');
+    });
+  });
+});

--- a/api/tests/prescription/learner-management/unit/domain/models/ImportOrganizationLearnerSet_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/models/ImportOrganizationLearnerSet_test.js
@@ -938,4 +938,121 @@ describe('Unit | Models | ImportOrganizationLearnerSet', function () {
       expect(learnerSet.learners.existinglearnerIds).to.be.empty;
     });
   });
+
+  describe('#filtersAvailableValues', function () {
+    it('should return an empty array when no header is filterable', function () {
+      const learnerSet = ImportOrganizationLearnerSet.buildSet({ organizationId, importFormat });
+      learnerSet.addLearners([learnerAttributes]);
+
+      expect(learnerSet.filtersAvailableValues).to.deep.equal([]);
+    });
+
+    it('should not return values for a filterable header with a type other than "list"', function () {
+      importFormat.config.headers = [
+        ...importFormat.config.headers,
+        {
+          name: 'group',
+          config: {
+            displayable: { position: 1, name: 'division', filterable: { type: 'string' } },
+          },
+        },
+      ];
+      const learnerSet = ImportOrganizationLearnerSet.buildSet({ organizationId, importFormat });
+      learnerSet.addLearners([{ ...learnerAttributes, group: 'A' }]);
+
+      expect(learnerSet.filtersAvailableValues).to.deep.equal([]);
+    });
+
+    it('should return unique values for each filterable list attribute', function () {
+      importFormat.config.headers = [
+        ...importFormat.config.headers,
+        {
+          name: 'group',
+          config: {
+            displayable: { position: 1, name: 'division', filterable: { type: 'list' } },
+          },
+        },
+      ];
+      const learnerSet = ImportOrganizationLearnerSet.buildSet({ organizationId, importFormat });
+      learnerSet.addLearners([
+        { ...learnerAttributes, group: 'A' },
+        { ...learnerAttributes, prénom: 'Mieto', group: 'B' },
+        { ...learnerAttributes, prénom: 'Taro', group: 'A' },
+      ]);
+
+      expect(learnerSet.filtersAvailableValues).to.deep.equal([
+        { organizationId: 123, attributeName: 'group', values: ['A', 'B'] },
+      ]);
+    });
+
+    it('should return values for each filterable list attribute independently', function () {
+      importFormat.config.headers = [
+        ...importFormat.config.headers,
+        {
+          name: 'group',
+          config: {
+            displayable: { position: 1, name: 'division', filterable: { type: 'list' } },
+          },
+        },
+        {
+          name: 'status',
+          config: {
+            displayable: { position: 2, name: 'statut', filterable: { type: 'list' } },
+          },
+        },
+      ];
+      const learnerSet = ImportOrganizationLearnerSet.buildSet({ organizationId, importFormat });
+      learnerSet.addLearners([
+        { ...learnerAttributes, group: 'A', status: 'active' },
+        { ...learnerAttributes, prénom: 'Mieto', group: 'B', status: 'active' },
+        { ...learnerAttributes, prénom: 'Taro', group: 'A', status: 'inactive' },
+      ]);
+
+      expect(learnerSet.filtersAvailableValues).to.deep.equal([
+        { organizationId: 123, attributeName: 'group', values: ['A', 'B'] },
+        { organizationId: 123, attributeName: 'status', values: ['active', 'inactive'] },
+      ]);
+    });
+
+    it('should use mappingColumn as attributeName when defined', function () {
+      importFormat.config.headers = [
+        ...importFormat.config.headers,
+        {
+          name: 'CATEGORY',
+          config: {
+            mappingColumn: 'catégorie',
+            displayable: { position: 1, name: 'division', filterable: { type: 'list' } },
+          },
+        },
+      ];
+      const learnerSet = ImportOrganizationLearnerSet.buildSet({ organizationId, importFormat });
+      learnerSet.addLearners([{ ...learnerAttributes, CATEGORY: 'Solo' }]);
+
+      expect(learnerSet.filtersAvailableValues).to.deep.equal([
+        { organizationId: 123, attributeName: 'catégorie', values: ['Solo'] },
+      ]);
+    });
+
+    it('should use property as attributeName and read from learner directly when config.property is defined', function () {
+      importFormat.config.headers = [
+        {
+          name: 'prénom',
+          config: {
+            property: 'firstName',
+            displayable: { position: 1, name: 'Prénom', filterable: { type: 'list' } },
+          },
+        },
+        { name: 'nom', config: { property: 'lastName' } },
+      ];
+      const learnerSet = ImportOrganizationLearnerSet.buildSet({ organizationId, importFormat });
+      learnerSet.addLearners([
+        { prénom: 'Tomie', nom: 'Katana' },
+        { prénom: 'Mieto', nom: 'Nataka' },
+      ]);
+
+      expect(learnerSet.filtersAvailableValues).to.deep.equal([
+        { organizationId: 123, attributeName: 'firstName', values: ['Tomie', 'Mieto'] },
+      ]);
+    });
+  });
 });

--- a/api/tests/prescription/learner-management/unit/domain/usecases/import-from-feature/save-organization-learners-file_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/usecases/import-from-feature/save-organization-learners-file_test.js
@@ -113,47 +113,6 @@ describe('Unit | UseCase | saveOrganizationLearnersFile', function () {
     importOrganizationLearnerSetStub.addLearners.withArgs(parsedLearners);
   });
 
-  context('success cases', function () {
-    it('should process the file', async function () {
-      // when
-      await saveOrganizationLearnersFile({
-        organizationImportId,
-        importStorage: importStorageStub,
-        organizationImportRepository: organizationImportRepositoryStub,
-        organizationLearnerRepository: organizationLearnerRepositoryStub,
-        organizationLearnerImportFormatRepository: organizationLearnerImportFormatRepositoryStub,
-        dependencies: dependencieStub,
-      });
-
-      // then
-      expect(
-        organizationLearnerRepositoryStub.findAllCommonLearnersFromOrganizationId.calledOnceWithExactly({
-          organizationId,
-        }),
-        'organizationLearnerRepository.findAllCommonLearnersFromOrganizationId',
-      ).to.be.true;
-      expect(importOrganizationLearnerSetStub.setExistingLearners.calledOnceWithExactly(existingLearners)).to.be.true;
-      expect(
-        organizationLearnerRepositoryStub.disableCommonOrganizationLearnersFromOrganizationId.calledOnceWithExactly({
-          organizationId,
-          excludeOrganizationLearnerIds: learnerIds,
-        }),
-        'organizationLearnerRepository.disableCommonOrganizationLearnersFromOrganizationId',
-      ).to.be.true;
-      expect(
-        organizationLearnerRepositoryStub.saveCommonOrganizationLearners.calledOnceWithExactly(learnerToSave),
-        'organizationLearnerRepository.saveCommonOrganizationLearners',
-      ).to.be.true;
-
-      expect(
-        organizationImportRepositoryStub.save.calledOnceWith(organizationImportStub),
-        'orgnizationImportRepository.save',
-      ).to.be.true;
-      expect(importStorageStub.deleteFile.calledOnceWithExactly({ filename: s3Filepath }), 'importStorage.deleteFile')
-        .to.be.true;
-    });
-  });
-
   context(' error cases', function () {
     it('save the error when an error occured', async function () {
       // given


### PR DESCRIPTION
## 🌱 Problème

Pour chercher les données filtrables dans les listes déroulantes on parse tout les learners pour ne garder qu'une entité de chaques attribut données.

C'est dommage car lorsque l'on insère ses données, on est capable d'insérer cette donnée qui ne bougera pas avant le nouvel import

## 🐣 Proposition

lors de l'insertion en BDD des learners de l'import à format. nous sauvegardons tout les filtres disponibles avec leur données.

## 🌷 Remarques

Il faudra certainement jouer un script lorsque nous mettrons à jour l'import à format onde pour dire que le classe est filterable de type liste . pour insérer en BDD les classes disponible dans chaque établissement ayant la feature. ou leur demander de faire un nouvelle import avec le fichier de l'année courante ? ce qui permettrait de ne pas faire de script.
 
## 🐝 Pour tester

- [x] Ajouter un format d'import avec un flterable de type list dans l'import GENERIC
- [x] L'insérer dans PixAdmin
- [x] Aller sur PixOrga
- [x] Pro Classic
- [x] Importer une liste de personne
- [x] Vérifier qu'en BDD nous avons bien les données stocké dans "organization_learner_filters"