### PR TITLE
[FEATURE] Afficher le résultat d'un volet jury externe dans PixAdmin (PIX-22240)

### DIFF
--- a/admin/app/models/certification.js
+++ b/admin/app/models/certification.js
@@ -47,7 +47,7 @@ export default class Certification extends Model {
   @attr('string') commentForOrganization;
   @attr('string') commentByJury;
   @attr() pixScore;
-  @attr() reachedMeshIndex;
+  @attr() reachedResultKey;
   @attr() competencesWithMark;
   @attr('boolean', { defaultValue: false }) isPublished;
   @attr('number') version;
@@ -117,15 +117,7 @@ export default class Certification extends Model {
   }
 
   get result() {
-    if (this.isV3) {
-      const meshKey = this.reachedMeshIndex ?? 'BELOW_MINIMUM';
-
-      return this.intl.t(`common.certification.meshLevels.${this.certificationFramework}.${meshKey}`, {
-        pixScore: this.pixScore,
-      });
-    }
-
-    return this.intl.t(`common.certification.meshLevels.${this.certificationFramework}.NONE`, {
+    return this.intl.t(`common.certification.meshLevels.${this.reachedResultKey}`, {
       pixScore: this.pixScore,
     });
   }

--- a/admin/app/models/jury-certification-summary.js
+++ b/admin/app/models/jury-certification-summary.js
@@ -17,7 +17,7 @@ export default class JuryCertificationSummary extends Model {
   @attr() status;
   @attr() algorithmVersion;
   @attr() pixScore;
-  @attr() reachedMeshIndex;
+  @attr() reachedResultKey;
   @attr() createdAt;
   @attr() completedAt;
   @attr() isPublished;
@@ -67,15 +67,7 @@ export default class JuryCertificationSummary extends Model {
   }
 
   get result() {
-    if (this.algorithmVersion === 3) {
-      const meshKey = this.reachedMeshIndex ?? 'BELOW_MINIMUM';
-
-      return this.intl.t(`common.certification.meshLevels.${this.certificationFramework}.${meshKey}`, {
-        pixScore: this.pixScore,
-      });
-    }
-
-    return this.intl.t(`common.certification.meshLevels.${this.certificationFramework}.NONE`, {
+    return this.intl.t(`common.certification.meshLevels.${this.reachedResultKey}`, {
       pixScore: this.pixScore,
     });
   }

--- a/admin/app/models/v3-certification-course-details-for-administration.js
+++ b/admin/app/models/v3-certification-course-details-for-administration.js
@@ -21,7 +21,7 @@ export default class V3CertificationCourseDetailsForAdministration extends Model
   @attr('string') assessmentState;
   @attr('string') abortReason;
   @attr('number') pixScore;
-  @attr('number') reachedMeshIndex;
+  @attr('string') reachedResultKey;
   @attr('number') numberOfChallenges;
   @attr('string') certificationFramework;
   @hasMany('certification-challenges-for-administration', { async: true, inverse: null })
@@ -86,9 +86,7 @@ export default class V3CertificationCourseDetailsForAdministration extends Model
   }
 
   get result() {
-    const meshKey = this.reachedMeshIndex ?? 'BELOW_MINIMUM';
-
-    return this.intl.t(`common.certification.meshLevels.${this.certificationFramework}.${meshKey}`, {
+    return this.intl.t(`common.certification.meshLevels.${this.reachedResultKey}`, {
       pixScore: this.pixScore,
     });
   }

--- a/admin/tests/integration/components/certifications/certification/details-v3-test.gjs
+++ b/admin/tests/integration/components/certifications/certification/details-v3-test.gjs
@@ -626,7 +626,7 @@ function createCertificationCourseDetailsRecord({ certificationChallengesForAdmi
     assessmentResultStatus: 'validated',
     numberOfChallenges: 15,
     certificationFramework: 'CORE',
-    reachedMeshIndex: 5,
+    reachedResultKey: 'CORE.5',
     certificationChallengesForAdministration,
     ...params,
   });

--- a/admin/tests/unit/models/certification-test.js
+++ b/admin/tests/unit/models/certification-test.js
@@ -320,52 +320,25 @@ module('Unit | Model | certification', function (hooks) {
   });
 
   module('#result', function () {
-    test('it should return "Non admissible" for a v3 EDU certification without reachedMeshIndex', function (assert) {
-      // given
+    test('it should return the translated result for a given reachedResultKey', function (assert) {
+      // given & when
       const certification = store.createRecord('certification', {
-        version: 3,
-        certificationFramework: 'EDU_1ER_DEGRE',
-        reachedMeshIndex: null,
-        pixScore: 0,
+        reachedResultKey: 'EDU_1ER_DEGRE.0',
       });
 
-      // when
-      const result = certification.result;
-
       // then
-      assert.strictEqual(result, 'Non admissible');
+      assert.strictEqual(certification.result, intl.t('common.certification.meshLevels.EDU_1ER_DEGRE.0'));
     });
 
-    test('it should return "Admissible" for a v3 EDU certification with a reachedMeshIndex', function (assert) {
-      // given
+    test('it should pass pixScore to the translation', function (assert) {
+      // given & when
       const certification = store.createRecord('certification', {
-        version: 3,
-        certificationFramework: 'EDU_1ER_DEGRE',
-        reachedMeshIndex: 0,
-        pixScore: 100,
-      });
-
-      // when
-      const result = certification.result;
-
-      // then
-      assert.strictEqual(result, 'Admissible');
-    });
-
-    test('it should return pixScore for a v2 certification', function (assert) {
-      // given
-      const certification = store.createRecord('certification', {
-        version: 2,
-        certificationFramework: 'CORE',
-        reachedMeshIndex: null,
+        reachedResultKey: 'CORE.NONE',
         pixScore: 450,
       });
 
-      // when
-      const result = certification.result;
-
       // then
-      assert.strictEqual(result, '450 Pix');
+      assert.strictEqual(certification.result, intl.t('common.certification.meshLevels.CORE.NONE', { pixScore: 450 }));
     });
   });
 

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -61,16 +61,22 @@
         },
         "EDU_1ER_DEGRE": {
           "0": "Admissible",
+          "ADVANCED": "Avancé",
+          "EXPERT": "Expert",
           "BELOW_MINIMUM": "Non admissible",
           "NONE": "{pixScore} Pix"
         },
         "EDU_2ND_DEGRE": {
           "0": "Admissible",
+          "ADVANCED": "Avancé",
+          "EXPERT": "Expert",
           "BELOW_MINIMUM": "Non admissible",
           "NONE": "{pixScore} Pix"
         },
         "EDU_CPE": {
           "0": "Admissible",
+          "ADVANCED": "Avancé",
+          "EXPERT": "Expert",
           "BELOW_MINIMUM": "Non admissible",
           "NONE": "{pixScore} Pix"
         },

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -62,22 +62,22 @@
         "EDU_1ER_DEGRE": {
           "0": "Admissible",
           "ADVANCED": "Avancé",
-          "EXPERT": "Expert",
           "BELOW_MINIMUM": "Non admissible",
+          "EXPERT": "Expert",
           "NONE": "{pixScore} Pix"
         },
         "EDU_2ND_DEGRE": {
           "0": "Admissible",
           "ADVANCED": "Avancé",
-          "EXPERT": "Expert",
           "BELOW_MINIMUM": "Non admissible",
+          "EXPERT": "Expert",
           "NONE": "{pixScore} Pix"
         },
         "EDU_CPE": {
           "0": "Admissible",
           "ADVANCED": "Avancé",
-          "EXPERT": "Expert",
           "BELOW_MINIMUM": "Non admissible",
+          "EXPERT": "Expert",
           "NONE": "{pixScore} Pix"
         },
         "PRO_SANTE": {

--- a/api/db/database-builder/factory/build-assessment-result.js
+++ b/api/db/database-builder/factory/build-assessment-result.js
@@ -23,6 +23,7 @@ function buildAssessmentResult({
   certificationCourseId,
   capacity,
   reachedMeshIndex = null,
+  eduV3ExternalJuryResult = null,
   versionId,
 } = {}) {
   assessmentId = _.isUndefined(assessmentId) ? buildAssessment({ certificationCourseId }).id : assessmentId;
@@ -44,6 +45,7 @@ function buildAssessmentResult({
     createdAt,
     capacity,
     reachedMeshIndex,
+    eduV3ExternalJuryResult,
     versionId,
   };
   return databaseBuffer.pushInsertable({
@@ -71,6 +73,7 @@ buildAssessmentResult.last = function ({
   createdAt,
   capacity,
   reachedMeshIndex,
+  eduV3ExternalJuryResult,
   versionId,
 }) {
   const assessmentResult = buildAssessmentResult({
@@ -90,6 +93,7 @@ buildAssessmentResult.last = function ({
     certificationCourseId,
     capacity,
     reachedMeshIndex,
+    eduV3ExternalJuryResult,
     versionId,
   });
 

--- a/api/db/seeds/data/team-certification/cases/pix-plus-edu-2nd-degre-v3.js
+++ b/api/db/seeds/data/team-certification/cases/pix-plus-edu-2nd-degre-v3.js
@@ -134,6 +134,7 @@ export class PixPlusEdu2ndDegreV3Seed {
       pixScore: null,
       status: 'validated',
       reachedMeshIndex: 0,
+      eduV3ExternalJuryResult: 'EXPERT',
       capacity: 2.0,
       versionId,
     });

--- a/api/src/certification/evaluation/domain/models/CapacitySimulator.js
+++ b/api/src/certification/evaluation/domain/models/CapacitySimulator.js
@@ -1,5 +1,5 @@
 // TODO: bounded context violation
-import { MESH_CONFIGURATION } from '../../../shared/domain/constants/mesh-configuration.js';
+import { CORE_MESH_CONFIGURATION } from '../../../shared/domain/constants/mesh-configuration.js';
 import { findIntervalIndexFromScore } from '../../../shared/domain/services/mesh-service.js';
 import { Intervals } from './Intervals.js';
 import { ScoringAndCapacitySimulatorReport } from './ScoringAndCapacitySimulatorReport.js';
@@ -9,7 +9,7 @@ export class CapacitySimulator {
   static compute({ certificationScoringIntervals, competencesForScoring, score, maxReachableLevel }) {
     const scoringIntervals = new Intervals({ intervals: certificationScoringIntervals });
 
-    const meshes = Array.from(MESH_CONFIGURATION.values());
+    const meshes = Array.from(CORE_MESH_CONFIGURATION.values());
     const intervalIndex = findIntervalIndexFromScore({ score, maxReachableLevel });
 
     const intervalMaxValue = scoringIntervals.max(intervalIndex);

--- a/api/src/certification/evaluation/domain/models/ScoringSimulator.js
+++ b/api/src/certification/evaluation/domain/models/ScoringSimulator.js
@@ -1,5 +1,5 @@
 import { COMPETENCES_COUNT, PIX_COUNT_BY_LEVEL } from '../../../../shared/domain/constants.js';
-import { MESH_CONFIGURATION } from '../../../shared/domain/constants/mesh-configuration.js';
+import { CORE_MESH_CONFIGURATION } from '../../../shared/domain/constants/mesh-configuration.js';
 import { Intervals } from './Intervals.js';
 import { ScoringAndCapacitySimulatorReport } from './ScoringAndCapacitySimulatorReport.js';
 
@@ -41,7 +41,7 @@ function _calculateScore({ certificationScoringIntervals, capacity, intervalInde
 
   const intervalMaximum = certificationScoringIntervals.max(intervalIndex);
   const intervalMinimum = certificationScoringIntervals.min(intervalIndex);
-  const meshes = Array.from(MESH_CONFIGURATION.values());
+  const meshes = Array.from(CORE_MESH_CONFIGURATION.values());
   const intervalWeight = meshes[intervalIndex].weight;
   const intervalCoefficient = meshes[intervalIndex].coefficient;
   const progressionPercentage = 1 - (intervalMaximum - capacity) / (intervalMaximum - intervalMinimum);

--- a/api/src/certification/evaluation/domain/models/ScoringV3Algorithm.js
+++ b/api/src/certification/evaluation/domain/models/ScoringV3Algorithm.js
@@ -7,7 +7,7 @@
  */
 
 import { COMPETENCES_COUNT, PIX_COUNT_BY_LEVEL } from '../../../../shared/domain/constants.js';
-import { MESH_CONFIGURATION } from '../../../shared/domain/constants/mesh-configuration.js';
+import { CORE_MESH_CONFIGURATION } from '../../../shared/domain/constants/mesh-configuration.js';
 import { Intervals } from './Intervals.js';
 
 export class ScoringV3Algorithm {
@@ -85,7 +85,7 @@ export class ScoringV3Algorithm {
     const intervalIndex = scoringIntervals.findIntervalIndexFromCapacity(capacity);
     const intervalMaximum = scoringIntervals.max(intervalIndex);
     const intervalMinimum = scoringIntervals.min(intervalIndex);
-    const meshes = Array.from(MESH_CONFIGURATION.values());
+    const meshes = Array.from(CORE_MESH_CONFIGURATION.values());
     const intervalWeight = meshes[intervalIndex].weight;
     const intervalCoefficient = meshes[intervalIndex].coefficient;
     const progressionPercentage = 1 - (intervalMaximum - capacity) / (intervalMaximum - intervalMinimum);

--- a/api/src/certification/results/domain/models/v3/Certificate.js
+++ b/api/src/certification/results/domain/models/v3/Certificate.js
@@ -2,7 +2,7 @@
  * @typedef {import ('../../read-models/CertifiedBadge.js').CertifiedBadge} CertifiedBadge
  */
 import { MAX_REACHABLE_SCORE } from '../../../../../shared/domain/constants.js';
-import { CERTIFICATE_LEVELS } from '../../../../shared/domain/constants/mesh-configuration.js';
+import { CORE_CERTIFICATE_LEVELS } from '../../../../shared/domain/constants/mesh-configuration.js';
 import { GlobalCertificationLevel } from './GlobalCertificationLevel.js';
 
 export class Certificate {
@@ -60,6 +60,6 @@ export class Certificate {
   #findLevel(reachedMeshIndex, certificationFramework) {
     const globalCertificationLevel = new GlobalCertificationLevel({ reachedMeshIndex, certificationFramework });
 
-    return globalCertificationLevel.meshLevel === CERTIFICATE_LEVELS.preBeginner ? null : globalCertificationLevel;
+    return globalCertificationLevel.meshLevel === CORE_CERTIFICATE_LEVELS.preBeginner ? null : globalCertificationLevel;
   }
 }

--- a/api/src/certification/results/infrastructure/repositories/certification-parcoursup-repository.js
+++ b/api/src/certification/results/infrastructure/repositories/certification-parcoursup-repository.js
@@ -1,7 +1,7 @@
 import { knex as datamartKnex } from '../../../../../datamart/knex-database-connection.js';
 import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { logger } from '../../../../shared/infrastructure/utils/logger.js';
-import { MESH_CONFIGURATION } from '../../../shared/domain/constants/mesh-configuration.js';
+import { CORE_MESH_CONFIGURATION } from '../../../shared/domain/constants/mesh-configuration.js';
 import { CertificationResult } from '../../domain/read-models/parcoursup/CertificationResult.js';
 import { Competence } from '../../domain/read-models/parcoursup/Competence.js';
 
@@ -134,7 +134,7 @@ const _getMaxReachableLevel = (scoringConfiguration, ine) => {
       { ine },
       'Missing scoring_configuration in certification result, using MESH_CONFIGURATION as fallback',
     );
-    const lastMesh = [...MESH_CONFIGURATION.values()].at(-1);
+    const lastMesh = [...CORE_MESH_CONFIGURATION.values()].at(-1);
     return lastMesh.coefficient;
   }
   return scoringConfiguration.length - 1;

--- a/api/src/certification/session-management/domain/models/JuryCertification.js
+++ b/api/src/certification/session-management/domain/models/JuryCertification.js
@@ -1,3 +1,4 @@
+import { AlgorithmEngineVersion } from '../../../shared/domain/models/AlgorithmEngineVersion.js';
 import { CompetenceMark } from '../../../shared/domain/models/CompetenceMark.js';
 import { JuryComment, JuryCommentContexts } from '../../../shared/domain/models/JuryComment.js';
 
@@ -22,6 +23,7 @@ class JuryCertification {
    * @param {number} props.juryId
    * @param {number} props.pixScore
    * @param {number} props.reachedMeshIndex
+   * @param {string} props.eduV3ExternalJuryResult
    * @param {Array<CompetenceMark>} props.competenceMarks
    * @param {JuryComment} props.commentForCandidate
    * @param {JuryComment} props.commentForOrganization
@@ -52,6 +54,7 @@ class JuryCertification {
     juryId,
     pixScore,
     reachedMeshIndex,
+    eduV3ExternalJuryResult,
     competenceMarks,
     commentForCandidate,
     commentForOrganization,
@@ -82,6 +85,7 @@ class JuryCertification {
     this.juryId = juryId;
     this.pixScore = pixScore;
     this.reachedMeshIndex = reachedMeshIndex;
+    this.eduV3ExternalJuryResult = eduV3ExternalJuryResult;
     this.competenceMarks = competenceMarks;
     this.commentForCandidate = commentForCandidate;
     this.commentForOrganization = commentForOrganization;
@@ -91,6 +95,16 @@ class JuryCertification {
     this.commonComplementaryCertificationCourseResult = commonComplementaryCertificationCourseResult;
     this.version = version;
     this.certificationFramework = certificationFramework;
+  }
+
+  get reachedResultKey() {
+    if (this.version !== AlgorithmEngineVersion.V3) {
+      return `${this.certificationFramework}.NONE`;
+    }
+
+    const resultKey = this.eduV3ExternalJuryResult || (this.reachedMeshIndex ?? 'BELOW_MINIMUM');
+
+    return `${this.certificationFramework}.${resultKey}`;
   }
 
   static from({
@@ -144,6 +158,7 @@ class JuryCertification {
       juryId: juryCertificationDTO.juryId,
       pixScore: juryCertificationDTO.pixScore,
       reachedMeshIndex: juryCertificationDTO.reachedMeshIndex,
+      eduV3ExternalJuryResult: juryCertificationDTO.eduV3ExternalJuryResult,
       competenceMarks,
       commentForCandidate,
       commentForOrganization,

--- a/api/src/certification/session-management/domain/models/V3CertificationCourseDetailsForAdministration.js
+++ b/api/src/certification/session-management/domain/models/V3CertificationCourseDetailsForAdministration.js
@@ -11,6 +11,7 @@ export class V3CertificationCourseDetailsForAdministration {
     abortReason,
     pixScore,
     reachedMeshIndex,
+    eduV3ExternalJuryResult,
     numberOfChallenges,
     certificationFramework,
   }) {
@@ -24,9 +25,15 @@ export class V3CertificationCourseDetailsForAdministration {
     this.abortReason = abortReason;
     this.pixScore = pixScore;
     this.reachedMeshIndex = reachedMeshIndex;
+    this.eduV3ExternalJuryResult = eduV3ExternalJuryResult;
     this.numberOfChallenges = numberOfChallenges;
     this.endedAt = endedAt;
     this.certificationFramework = certificationFramework;
+  }
+
+  get reachedResultKey() {
+    const resultKey = this.eduV3ExternalJuryResult || (this.reachedMeshIndex ?? 'BELOW_MINIMUM');
+    return `${this.certificationFramework}.${resultKey}`;
   }
 
   setCompetencesDetails(competenceList) {

--- a/api/src/certification/session-management/domain/read-models/JuryCertificationSummary.js
+++ b/api/src/certification/session-management/domain/read-models/JuryCertificationSummary.js
@@ -1,4 +1,5 @@
 import { status as assessmentResultStatuses } from '../../../../shared/domain/models/AssessmentResult.js';
+import { AlgorithmEngineVersion } from '../../../shared/domain/models/AlgorithmEngineVersion.js';
 const STARTED = 'started';
 const ENDED_BY_INVIGILATOR = 'endedByInvigilator';
 const CORE_CERTIFICATION = 'CORE';
@@ -18,6 +19,7 @@ export class JuryCertificationSummary {
     abortReason,
     isPublished,
     isEndedByInvigilator,
+    eduV3ExternalJuryResult,
     certificationFramework,
     certificationIssueReports,
   } = {}) {
@@ -28,12 +30,23 @@ export class JuryCertificationSummary {
     this.algorithmVersion = algorithmVersion;
     this.pixScore = pixScore;
     this.reachedMeshIndex = reachedMeshIndex;
+    this.eduV3ExternalJuryResult = eduV3ExternalJuryResult;
     this.isFlaggedAborted = Boolean(abortReason) && !completedAt;
     this.certificationFramework = certificationFramework;
     this.createdAt = createdAt;
     this.completedAt = completedAt;
     this.isPublished = isPublished;
     this.certificationIssueReports = certificationIssueReports;
+  }
+
+  get reachedResultKey() {
+    if (this.algorithmVersion !== AlgorithmEngineVersion.V3) {
+      return `${this.certificationFramework}.NONE`;
+    }
+
+    const resultKey = this.eduV3ExternalJuryResult || (this.reachedMeshIndex ?? 'BELOW_MINIMUM');
+
+    return `${this.certificationFramework}.${resultKey}`;
   }
 
   isActionRequired() {

--- a/api/src/certification/session-management/infrastructure/repositories/jury-certification-repository.js
+++ b/api/src/certification/session-management/infrastructure/repositories/jury-certification-repository.js
@@ -92,6 +92,7 @@ function _selectJuryCertifications(knexConn) {
       assessmentResultId: 'assessment-results.id',
       pixScore: 'assessment-results.pixScore',
       reachedMeshIndex: 'assessment-results.reachedMeshIndex',
+      eduV3ExternalJuryResult: 'assessment-results.eduV3ExternalJuryResult',
       juryId: 'assessment-results.juryId',
       assessmentResultStatus: 'assessment-results.status',
       commentForCandidate: 'assessment-results.commentForCandidate',

--- a/api/src/certification/session-management/infrastructure/repositories/jury-certification-summary-repository.js
+++ b/api/src/certification/session-management/infrastructure/repositories/jury-certification-summary-repository.js
@@ -47,7 +47,12 @@ async function _getJuryCertificationSummaries(results) {
 async function _getByCertificationCourseIds(orderedCertificationCourseIds) {
   const knexConn = DomainTransaction.getConnection();
   const results = await knexConn
-    .select('certification-courses.*', 'assessment-results.pixScore', 'assessment-results.reachedMeshIndex')
+    .select(
+      'certification-courses.*',
+      'assessment-results.pixScore',
+      'assessment-results.reachedMeshIndex',
+      'assessment-results.eduV3ExternalJuryResult',
+    )
     .select({
       assessmentResultStatus: 'assessment-results.status',
       assessmentState: 'assessments.state',

--- a/api/src/certification/session-management/infrastructure/repositories/v3-certification-course-details-for-administration-repository.js
+++ b/api/src/certification/session-management/infrastructure/repositories/v3-certification-course-details-for-administration-repository.js
@@ -38,6 +38,7 @@ const getV3DetailsByCertificationCourseId = async function ({ certificationCours
       assessmentResultStatus: 'assessment-results.status',
       pixScore: 'assessment-results.pixScore',
       reachedMeshIndex: 'assessment-results.reachedMeshIndex',
+      eduV3ExternalJuryResult: 'assessment-results.eduV3ExternalJuryResult',
       endedAt: 'certification-courses.endedAt',
       certificationFramework: 'certification-courses.framework',
     })

--- a/api/src/certification/session-management/infrastructure/serializers/jury-certification-serializer.js
+++ b/api/src/certification/session-management/infrastructure/serializers/jury-certification-serializer.js
@@ -11,6 +11,7 @@ const serialize = function (juryCertification, { translate }) {
         competencesWithMark: juryCertification.competenceMarks,
         commentForOrganization: juryCertification.commentForOrganization.getComment(translate),
         commentForCandidate: juryCertification.commentForCandidate.getComment(translate),
+        reachedResultKey: juryCertification.reachedResultKey,
       };
     },
     attributes: [
@@ -32,7 +33,7 @@ const serialize = function (juryCertification, { translate }) {
       'isRejectedForFraud',
       'juryId',
       'pixScore',
-      'reachedMeshIndex',
+      'reachedResultKey',
       'competencesWithMark',
       'commentForCandidate',
       'commentForOrganization',

--- a/api/src/certification/session-management/infrastructure/serializers/jury-certification-summary-serializer.js
+++ b/api/src/certification/session-management/infrastructure/serializers/jury-certification-summary-serializer.js
@@ -14,6 +14,7 @@ const serialize = function (juryCertificationSummary, meta, { translate }) {
       result.certificationObtained = juryCertificationSummary.getCertificationLabel(translate);
       result.examinerComment = get(juryCertificationSummary, 'certificationIssueReports[0].description');
       result.numberOfCertificationIssueReports = juryCertificationSummary.certificationIssueReports.length;
+      result.reachedResultKey = juryCertificationSummary.reachedResultKey;
       result.numberOfCertificationIssueReportsWithRequiredAction =
         juryCertificationSummary.certificationIssueReports.filter(
           (issueReport) => issueReport.isImpactful && issueReport.resolvedAt === null,
@@ -26,7 +27,7 @@ const serialize = function (juryCertificationSummary, meta, { translate }) {
       'status',
       'pixScore',
       'algorithmVersion',
-      'reachedMeshIndex',
+      'reachedResultKey',
       'createdAt',
       'completedAt',
       'isPublished',

--- a/api/src/certification/session-management/infrastructure/serializers/v3-certification-course-details-for-administration-serializer.js
+++ b/api/src/certification/session-management/infrastructure/serializers/v3-certification-course-details-for-administration-serializer.js
@@ -14,7 +14,7 @@ const serialize = function ({ certificationDetails }) {
     'assessmentResultStatus',
     'abortReason',
     'pixScore',
-    'reachedMeshIndex',
+    'reachedResultKey',
     'numberOfChallenges',
     'certificationFramework',
   ];
@@ -24,6 +24,7 @@ const serialize = function ({ certificationDetails }) {
     transform: (record) => {
       return {
         ...record,
+        reachedResultKey: record.reachedResultKey,
         certificationChallengesForAdministration: record.certificationChallengesForAdministration.map(
           (certificationChallenge) => ({
             ...certificationChallenge,

--- a/api/src/certification/shared/domain/constants/mesh-configuration.js
+++ b/api/src/certification/shared/domain/constants/mesh-configuration.js
@@ -1,4 +1,4 @@
-export const CERTIFICATE_LEVELS = {
+export const CORE_CERTIFICATE_LEVELS = {
   preBeginner: 'LEVEL_PRE_BEGINNER',
   beginner1: 'LEVEL_BEGINNER_1',
   beginner2: 'LEVEL_BEGINNER_2',
@@ -10,14 +10,19 @@ export const CERTIFICATE_LEVELS = {
   expert8: 'LEVEL_EXPERT_8',
 };
 
-export const MESH_CONFIGURATION = new Map([
-  [CERTIFICATE_LEVELS.preBeginner, { weight: 64, coefficient: 0 }],
-  [CERTIFICATE_LEVELS.beginner1, { weight: 64, coefficient: 1 }],
-  [CERTIFICATE_LEVELS.beginner2, { weight: 128, coefficient: 1 }],
-  [CERTIFICATE_LEVELS.independent3, { weight: 128, coefficient: 2 }],
-  [CERTIFICATE_LEVELS.independent4, { weight: 128, coefficient: 3 }],
-  [CERTIFICATE_LEVELS.advanced5, { weight: 128, coefficient: 4 }],
-  [CERTIFICATE_LEVELS.advanced6, { weight: 128, coefficient: 5 }],
-  [CERTIFICATE_LEVELS.expert7, { weight: 128, coefficient: 6 }],
-  [CERTIFICATE_LEVELS.expert8, { weight: 128, coefficient: 7 }],
+export const CORE_MESH_CONFIGURATION = new Map([
+  [CORE_CERTIFICATE_LEVELS.preBeginner, { weight: 64, coefficient: 0 }],
+  [CORE_CERTIFICATE_LEVELS.beginner1, { weight: 64, coefficient: 1 }],
+  [CORE_CERTIFICATE_LEVELS.beginner2, { weight: 128, coefficient: 1 }],
+  [CORE_CERTIFICATE_LEVELS.independent3, { weight: 128, coefficient: 2 }],
+  [CORE_CERTIFICATE_LEVELS.independent4, { weight: 128, coefficient: 3 }],
+  [CORE_CERTIFICATE_LEVELS.advanced5, { weight: 128, coefficient: 4 }],
+  [CORE_CERTIFICATE_LEVELS.advanced6, { weight: 128, coefficient: 5 }],
+  [CORE_CERTIFICATE_LEVELS.expert7, { weight: 128, coefficient: 6 }],
+  [CORE_CERTIFICATE_LEVELS.expert8, { weight: 128, coefficient: 7 }],
 ]);
+
+export const PIX_PLUS_EDU_EXTERNAL_LEVELS = {
+  ADVANCED: 'ADVANCED',
+  EXPERT: 'EXPERT',
+};

--- a/api/src/certification/shared/domain/services/mesh-service.js
+++ b/api/src/certification/shared/domain/services/mesh-service.js
@@ -1,10 +1,10 @@
-import { MESH_CONFIGURATION } from '../constants/mesh-configuration.js';
+import { CORE_MESH_CONFIGURATION } from '../constants/mesh-configuration.js';
 
 /**
  * @returns {{key: string, value: Mesh}}
  */
 export function findMeshFromScore({ score, maxReachableLevel }) {
-  const configuration = MESH_CONFIGURATION.entries();
+  const configuration = CORE_MESH_CONFIGURATION.entries();
   let currentMesh = configuration.next();
   let cumulativeSumOfWeights = currentMesh.value[1].weight;
   let currentScoringInterval = 0;
@@ -22,7 +22,7 @@ export function findMeshFromScore({ score, maxReachableLevel }) {
  * @deprecated please use {@link MeshConfiguration#findMeshFromScore}
  */
 export function findIntervalIndexFromScore({ score, maxReachableLevel }) {
-  const configuration = MESH_CONFIGURATION.values();
+  const configuration = CORE_MESH_CONFIGURATION.values();
   let cumulativeSumOfWeights = configuration.next().value.weight;
   let currentScoringInterval = 0;
 

--- a/api/tests/acceptance/application/session/jury-certification-summaries-route_test.js
+++ b/api/tests/acceptance/application/session/jury-certification-summaries-route_test.js
@@ -1,3 +1,5 @@
+import { PIX_PLUS_EDU_EXTERNAL_LEVELS } from '../../../../src/certification/shared/domain/constants/mesh-configuration.js';
+import { AlgorithmEngineVersion } from '../../../../src/certification/shared/domain/models/AlgorithmEngineVersion.js';
 import { Frameworks } from '../../../../src/certification/shared/domain/models/Frameworks.js';
 import {
   createServer,
@@ -66,6 +68,24 @@ describe('Acceptance | Controller | session-controller-get-jury-certification-su
           framework: Frameworks.CLEA,
         });
         databaseBuilder.factory.buildAssessment({ certificationCourseId: certificationCourse2.id });
+
+        const certificationCourse3 = databaseBuilder.factory.buildCertificationCourse({
+          sessionId,
+          lastName: 'DDD',
+          framework: Frameworks.EDU_1ER_DEGRE,
+          version: AlgorithmEngineVersion.V3,
+        });
+        const assessmentId3 = databaseBuilder.factory.buildAssessment({
+          certificationCourseId: certificationCourse2.id,
+        }).id;
+        const asr3 = databaseBuilder.factory.buildAssessmentResult.last({
+          certificationCourseId: certificationCourse3.id,
+          createdAt: new Date('2018-04-15T00:00:00Z'),
+          reachedMeshIndex: 0,
+          eduV3ExternalJuryResult: PIX_PLUS_EDU_EXTERNAL_LEVELS.EXPERT,
+          assessmentId: assessmentId3,
+        });
+
         await databaseBuilder.commit();
 
         const request = {
@@ -85,7 +105,7 @@ describe('Acceptance | Controller | session-controller-get-jury-certification-su
           status: asr1.status,
           'pix-score': asr1.pixScore,
           'algorithm-version': certificationCourse1.version,
-          'reached-mesh-index': asr1.reachedMeshIndex,
+          'reached-result-key': 'CLEA.NONE',
           'is-published': certificationCourse1.isPublished,
           'created-at': certificationCourse1.createdAt,
           'completed-at': certificationCourse1.completedAt,
@@ -101,7 +121,7 @@ describe('Acceptance | Controller | session-controller-get-jury-certification-su
           status: 'started',
           'pix-score': null,
           'algorithm-version': certificationCourse2.version,
-          'reached-mesh-index': null,
+          'reached-result-key': 'CLEA.NONE',
           'is-published': certificationCourse2.isPublished,
           'created-at': certificationCourse2.createdAt,
           'number-of-certification-issue-reports': 0,
@@ -110,6 +130,22 @@ describe('Acceptance | Controller | session-controller-get-jury-certification-su
           'examiner-comment': undefined,
           'is-flagged-aborted': false,
           'certification-framework': Frameworks.CLEA,
+        };
+        const expectedJuryCertificationSummary3 = {
+          'first-name': certificationCourse3.firstName,
+          'last-name': certificationCourse3.lastName,
+          status: asr3.status,
+          'pix-score': asr3.pixScore,
+          'algorithm-version': certificationCourse3.version,
+          'reached-result-key': 'EDU_1ER_DEGRE.EXPERT',
+          'is-published': certificationCourse3.isPublished,
+          'created-at': certificationCourse3.createdAt,
+          'completed-at': certificationCourse3.completedAt,
+          'number-of-certification-issue-reports': 0,
+          'number-of-certification-issue-reports-with-required-action': 0,
+          'examiner-comment': undefined,
+          'is-flagged-aborted': false,
+          'certification-framework': Frameworks.EDU_1ER_DEGRE,
         };
 
         expect(response.statusCode).to.equal(200);
@@ -123,6 +159,11 @@ describe('Acceptance | Controller | session-controller-get-jury-certification-su
             type: 'jury-certification-summaries',
             id: certificationCourse2.id.toString(),
             attributes: expectedJuryCertificationSummary2,
+          },
+          {
+            type: 'jury-certification-summaries',
+            id: certificationCourse3.id.toString(),
+            attributes: expectedJuryCertificationSummary3,
           },
         ]);
       });

--- a/api/tests/certification/session-management/acceptance/application/certification-course-route_test.js
+++ b/api/tests/certification/session-management/acceptance/application/certification-course-route_test.js
@@ -449,7 +449,7 @@ describe('Certification | Session Management | Acceptance | Application | Routes
           'ended-at': null,
           'is-rejected-for-fraud': false,
           'pix-score': assessmentResult.pixScore,
-          'reached-mesh-index': assessmentResult.reachedMeshIndex,
+          'reached-result-key': 'CORE.BELOW_MINIMUM',
           'number-of-challenges': 10,
           'assessment-state': 'completed',
           'assessment-result-status': 'validated',

--- a/api/tests/certification/session-management/acceptance/application/jury-certification-route_test.js
+++ b/api/tests/certification/session-management/acceptance/application/jury-certification-route_test.js
@@ -149,7 +149,7 @@ describe('Certification | Session Management | Acceptance | Application | Routes
           'created-at': new Date('2020-01-01'),
           'completed-at': new Date('2020-02-01'),
           'pix-score': 55,
-          'reached-mesh-index': 1,
+          'reached-result-key': 'CLEA.NONE',
           'certification-framework': 'CLEA',
           'jury-id': 66,
           'comment-for-candidate':

--- a/api/tests/certification/session-management/integration/infrastructure/repositories/jury-certification-repository_test.js
+++ b/api/tests/certification/session-management/integration/infrastructure/repositories/jury-certification-repository_test.js
@@ -1,4 +1,5 @@
 import * as juryCertificationRepository from '../../../../../../src/certification/session-management/infrastructure/repositories/jury-certification-repository.js';
+import { PIX_PLUS_EDU_EXTERNAL_LEVELS } from '../../../../../../src/certification/shared/domain/constants/mesh-configuration.js';
 import { ComplementaryCertificationCourseResult } from '../../../../../../src/certification/shared/domain/models/ComplementaryCertificationCourseResult.js';
 import { Frameworks } from '../../../../../../src/certification/shared/domain/models/Frameworks.js';
 import { AutoJuryCommentKeys } from '../../../../../../src/certification/shared/domain/models/JuryComment.js';
@@ -21,234 +22,353 @@ describe('Certification | Session-management | Integration | Infrastructure | Re
       expect(error.message).to.equal('Certification course of id 2 does not exist.');
     });
 
-    context('When there is no external jury', function () {
-      it('should return the JuryCertification for given certificationCourseId', async function () {
-        // given
-        databaseBuilder.factory.buildComplementaryCertification({
-          id: 23,
-          name: 'Complementary certification without external jury',
-          hasExternalJury: false,
-        });
+    context('when certification version is 1 or 2', function () {
+      context('When there is no external jury', function () {
+        it('should return the JuryCertification for given certificationCourseId', async function () {
+          // given
+          databaseBuilder.factory.buildComplementaryCertification({
+            id: 23,
+            name: 'Complementary certification without external jury',
+            hasExternalJury: false,
+          });
 
-        databaseBuilder.factory.buildTargetProfile({ id: 5656, name: 'targetProfile CC 1' });
+          databaseBuilder.factory.buildTargetProfile({ id: 5656, name: 'targetProfile CC 1' });
 
-        _buildComplementaryBadge({
-          key: 'BADGE_FOR_COMPLEMENTARY_CERTIFICATION_WITHOUT_EXTERNAL_JURY',
-          targetProfileId: 5656,
-          complementaryCertificationId: 23,
-          complementaryCertificationBadgeId: 3453,
-          level: 1,
-          label: 'Badge for complementary certification without external jury',
-          complementaryCertificationCourse: null,
-        });
-
-        databaseBuilder.factory.buildUser({ id: 789 });
-        databaseBuilder.factory.buildSession({ id: 456 });
-        databaseBuilder.factory.buildCertificationCourse({
-          id: 1,
-          sessionId: 456,
-          userId: 789,
-          firstName: 'Buffy',
-          lastName: 'Summers',
-          birthdate: '1981-01-19',
-          sex: 'F',
-          birthplace: 'Torreilles',
-          birthINSEECode: '66212',
-          birthPostalCode: null,
-          birthCountry: 'FRANCE',
-          createdAt: new Date('2020-01-01'),
-          completedAt: new Date('2020-02-01'),
-          isPublished: false,
-          framework: Frameworks.CLEA,
-        });
-
-        databaseBuilder.factory.buildComplementaryCertificationCourse({
-          id: 456,
-          complementaryCertificationId: 23,
-          certificationCourseId: 1,
-          complementaryCertificationBadgeId: 3453,
-        });
-
-        databaseBuilder.factory.buildComplementaryCertificationCourseResult({
-          complementaryCertificationCourseId: 456,
-          complementaryCertificationId: 23,
-          certificationCourseId: 1,
-          complementaryCertificationBadgeId: 3453,
-        });
-
-        databaseBuilder.factory.buildUser({ id: 22, firstName: 'Jury' });
-        databaseBuilder.factory.buildAssessment({ id: 159, certificationCourseId: 1 });
-        const assessmentResultId = databaseBuilder.factory.buildAssessmentResult.last({
-          certificationCourseId: 1,
-          assessmentId: 159,
-          pixScore: 123,
-          reachedMeshIndex: 2,
-          status: 'validated',
-          commentForOrganization: 'Un commentaire orga',
-          commentForCandidate: 'Un commentaire candidat',
-          commentByJury: 'Un commentaire jury',
-          commentByAutoJury: AutoJuryCommentKeys.FRAUD,
-          juryId: 22,
-        }).id;
-        databaseBuilder.factory.buildCompetenceMark({
-          id: 123,
-          score: 10,
-          level: 4,
-          competence_code: '2.3',
-          area_code: '2',
-          competenceId: 'recComp23',
-          assessmentResultId,
-        });
-        await databaseBuilder.commit();
-
-        // when
-        const juryCertification = await juryCertificationRepository.get({ certificationCourseId: 1 });
-
-        // then
-        const expectedCompetenceMark = domainBuilder.buildCompetenceMark({
-          id: 123,
-          score: 10,
-          level: 4,
-          competence_code: '2.3',
-          area_code: '2',
-          competenceId: 'recComp23',
-          assessmentResultId,
-        });
-        const expectedJuryCertification = domainBuilder.buildJuryCertification({
-          certificationCourseId: 1,
-          sessionId: 456,
-          userId: 789,
-          assessmentId: 159,
-          firstName: 'Buffy',
-          lastName: 'Summers',
-          birthdate: '1981-01-19',
-          sex: 'F',
-          birthplace: 'Torreilles',
-          birthINSEECode: '66212',
-          birthPostalCode: null,
-          birthCountry: 'FRANCE',
-          status: 'validated',
-          createdAt: new Date('2020-01-01'),
-          completedAt: new Date('2020-02-01'),
-          isPublished: false,
-          isRejectedForFraud: false,
-          juryId: 22,
-          pixScore: 123,
-          reachedMeshIndex: 2,
-          commentForOrganization: 'Un commentaire orga',
-          commentForCandidate: 'Un commentaire candidat',
-          commentByJury: 'Un commentaire jury',
-          commentByAutoJury: AutoJuryCommentKeys.FRAUD,
-          competenceMarks: [expectedCompetenceMark],
-          certificationIssueReports: [],
-          version: 2,
-          certificationFramework: Frameworks.CLEA,
-          commonComplementaryCertificationCourseResult: {
-            acquired: true,
+          _buildComplementaryBadge({
+            key: 'BADGE_FOR_COMPLEMENTARY_CERTIFICATION_WITHOUT_EXTERNAL_JURY',
+            targetProfileId: 5656,
+            complementaryCertificationId: 23,
             complementaryCertificationBadgeId: 3453,
-            id: 456,
-            label: 'Badge for complementary certification without external jury',
-          },
-          complementaryCertificationCourseResultWithExternal: undefined,
-        });
-        expect(juryCertification).to.deepEqualInstance(expectedJuryCertification);
-      });
-    });
-
-    context('When there is an external jury', function () {
-      it('should return the JuryCertification with external', async function () {
-        // given
-        databaseBuilder.factory.buildComplementaryCertification({
-          id: 24,
-          name: 'Complementary certification with external jury',
-          hasExternalJury: true,
-        });
-
-        databaseBuilder.factory.buildTargetProfile({ id: 5656, name: 'targetProfile CC 1' });
-
-        _buildComplementaryBadge({
-          key: 'BADGE_FOR_COMPLEMENTARY_CERTIFICATION_1_WITH_EXTERNAL_JURY_LEVEL_1',
-          targetProfileId: 5656,
-          complementaryCertificationId: 24,
-          complementaryCertificationBadgeId: 3453,
-          level: 1,
-          label: 'Badge for complementary certification with external jury level 1',
-          complementaryCertificationCourse: null,
-        });
-        _buildComplementaryBadge({
-          key: 'BADGE_FOR_COMPLEMENTARY_CERTIFICATION_1_WITH_EXTERNAL_JURY_LEVEL_2',
-          targetProfileId: 5656,
-          complementaryCertificationId: 24,
-          complementaryCertificationBadgeId: 3454,
-          level: 2,
-          label: 'Badge for complementary certification with external jury level 2',
-          complementaryCertificationCourse: null,
-        });
-        _buildComplementaryBadge({
-          key: 'BADGE_FOR_COMPLEMENTARY_CERTIFICATION_1_WITH_EXTERNAL_JURY_LEVEL_3',
-          targetProfileId: 5656,
-          complementaryCertificationId: 24,
-          complementaryCertificationBadgeId: 3455,
-          level: 3,
-          label: 'Badge for complementary certification with external jury level 3',
-          complementaryCertificationCourse: null,
-        });
-
-        databaseBuilder.factory.buildUser({ id: 789, firstName: 'Jury' });
-        databaseBuilder.factory.buildSession({ id: 456 });
-        databaseBuilder.factory.buildCertificationCourse({
-          id: 1,
-          sessionId: 456,
-          userId: 789,
-        });
-
-        databaseBuilder.factory.buildComplementaryCertificationCourse({
-          id: 456,
-          complementaryCertificationId: 24,
-          certificationCourseId: 1,
-          complementaryCertificationBadgeId: 3454,
-        });
-
-        databaseBuilder.factory.buildComplementaryCertificationCourseResult({
-          complementaryCertificationCourseId: 456,
-          complementaryCertificationId: 24,
-          certificationCourseId: 1,
-          complementaryCertificationBadgeId: 3453,
-        });
-        databaseBuilder.factory.buildComplementaryCertificationCourseResult({
-          complementaryCertificationCourseId: 456,
-          complementaryCertificationId: 24,
-          certificationCourseId: 1,
-          complementaryCertificationBadgeId: 3454,
-          source: ComplementaryCertificationCourseResult.sources.EXTERNAL,
-        });
-
-        databaseBuilder.factory.buildAssessment({ id: 159, certificationCourseId: 1 });
-        databaseBuilder.factory.buildAssessmentResult.last({
-          certificationCourseId: 1,
-          assessmentId: 159,
-        });
-        await databaseBuilder.commit();
-
-        // when
-        const juryCertification = await juryCertificationRepository.get({ certificationCourseId: 1 });
-
-        // then
-        const expectedJuryCertification = {
-          complementaryCertificationCourseId: 456,
-          externalSection: {
-            complementaryCertificationBadgeId: 3454,
-            acquired: true,
-            label: 'Badge for complementary certification with external jury level 2',
-            level: 2,
-          },
-          pixSection: {
-            complementaryCertificationBadgeId: 3453,
-            acquired: true,
-            label: 'Badge for complementary certification with external jury level 1',
             level: 1,
-          },
-          allowedExternalLevels: [
+            label: 'Badge for complementary certification without external jury',
+            complementaryCertificationCourse: null,
+          });
+
+          databaseBuilder.factory.buildUser({ id: 789 });
+          databaseBuilder.factory.buildSession({ id: 456 });
+          databaseBuilder.factory.buildCertificationCourse({
+            id: 1,
+            sessionId: 456,
+            userId: 789,
+            firstName: 'Buffy',
+            lastName: 'Summers',
+            birthdate: '1981-01-19',
+            sex: 'F',
+            birthplace: 'Torreilles',
+            birthINSEECode: '66212',
+            birthPostalCode: null,
+            birthCountry: 'FRANCE',
+            createdAt: new Date('2020-01-01'),
+            completedAt: new Date('2020-02-01'),
+            isPublished: false,
+            framework: Frameworks.CLEA,
+          });
+
+          databaseBuilder.factory.buildComplementaryCertificationCourse({
+            id: 456,
+            complementaryCertificationId: 23,
+            certificationCourseId: 1,
+            complementaryCertificationBadgeId: 3453,
+          });
+
+          databaseBuilder.factory.buildComplementaryCertificationCourseResult({
+            complementaryCertificationCourseId: 456,
+            complementaryCertificationId: 23,
+            certificationCourseId: 1,
+            complementaryCertificationBadgeId: 3453,
+          });
+
+          databaseBuilder.factory.buildUser({ id: 22, firstName: 'Jury' });
+          databaseBuilder.factory.buildAssessment({ id: 159, certificationCourseId: 1 });
+          const assessmentResultId = databaseBuilder.factory.buildAssessmentResult.last({
+            certificationCourseId: 1,
+            assessmentId: 159,
+            pixScore: 123,
+            reachedMeshIndex: 2,
+            status: 'validated',
+            commentForOrganization: 'Un commentaire orga',
+            commentForCandidate: 'Un commentaire candidat',
+            commentByJury: 'Un commentaire jury',
+            commentByAutoJury: AutoJuryCommentKeys.FRAUD,
+            juryId: 22,
+          }).id;
+          databaseBuilder.factory.buildCompetenceMark({
+            id: 123,
+            score: 10,
+            level: 4,
+            competence_code: '2.3',
+            area_code: '2',
+            competenceId: 'recComp23',
+            assessmentResultId,
+          });
+          await databaseBuilder.commit();
+
+          // when
+          const juryCertification = await juryCertificationRepository.get({ certificationCourseId: 1 });
+
+          // then
+          const expectedCompetenceMark = domainBuilder.buildCompetenceMark({
+            id: 123,
+            score: 10,
+            level: 4,
+            competence_code: '2.3',
+            area_code: '2',
+            competenceId: 'recComp23',
+            assessmentResultId,
+          });
+          const expectedJuryCertification = domainBuilder.certification.sessionManagement.buildJuryCertification({
+            certificationCourseId: 1,
+            sessionId: 456,
+            userId: 789,
+            assessmentId: 159,
+            firstName: 'Buffy',
+            lastName: 'Summers',
+            birthdate: '1981-01-19',
+            sex: 'F',
+            birthplace: 'Torreilles',
+            birthINSEECode: '66212',
+            birthPostalCode: null,
+            birthCountry: 'FRANCE',
+            status: 'validated',
+            createdAt: new Date('2020-01-01'),
+            completedAt: new Date('2020-02-01'),
+            isPublished: false,
+            isRejectedForFraud: false,
+            juryId: 22,
+            pixScore: 123,
+            reachedMeshIndex: 2,
+            commentForOrganization: 'Un commentaire orga',
+            commentForCandidate: 'Un commentaire candidat',
+            commentByJury: 'Un commentaire jury',
+            commentByAutoJury: AutoJuryCommentKeys.FRAUD,
+            competenceMarks: [expectedCompetenceMark],
+            certificationIssueReports: [],
+            version: 2,
+            certificationFramework: Frameworks.CLEA,
+            commonComplementaryCertificationCourseResult: {
+              acquired: true,
+              complementaryCertificationBadgeId: 3453,
+              id: 456,
+              label: 'Badge for complementary certification without external jury',
+            },
+            complementaryCertificationCourseResultWithExternal: undefined,
+          });
+          expect(juryCertification).to.deepEqualInstance(expectedJuryCertification);
+        });
+      });
+
+      context('When there is an external jury', function () {
+        it('should return the JuryCertification with external', async function () {
+          // given
+          databaseBuilder.factory.buildComplementaryCertification({
+            id: 24,
+            name: 'Complementary certification with external jury',
+            hasExternalJury: true,
+          });
+
+          databaseBuilder.factory.buildTargetProfile({ id: 5656, name: 'targetProfile CC 1' });
+
+          _buildComplementaryBadge({
+            key: 'BADGE_FOR_COMPLEMENTARY_CERTIFICATION_1_WITH_EXTERNAL_JURY_LEVEL_1',
+            targetProfileId: 5656,
+            complementaryCertificationId: 24,
+            complementaryCertificationBadgeId: 3453,
+            level: 1,
+            label: 'Badge for complementary certification with external jury level 1',
+            complementaryCertificationCourse: null,
+          });
+          _buildComplementaryBadge({
+            key: 'BADGE_FOR_COMPLEMENTARY_CERTIFICATION_1_WITH_EXTERNAL_JURY_LEVEL_2',
+            targetProfileId: 5656,
+            complementaryCertificationId: 24,
+            complementaryCertificationBadgeId: 3454,
+            level: 2,
+            label: 'Badge for complementary certification with external jury level 2',
+            complementaryCertificationCourse: null,
+          });
+          _buildComplementaryBadge({
+            key: 'BADGE_FOR_COMPLEMENTARY_CERTIFICATION_1_WITH_EXTERNAL_JURY_LEVEL_3',
+            targetProfileId: 5656,
+            complementaryCertificationId: 24,
+            complementaryCertificationBadgeId: 3455,
+            level: 3,
+            label: 'Badge for complementary certification with external jury level 3',
+            complementaryCertificationCourse: null,
+          });
+
+          databaseBuilder.factory.buildUser({ id: 789, firstName: 'Jury' });
+          databaseBuilder.factory.buildSession({ id: 456 });
+          databaseBuilder.factory.buildCertificationCourse({
+            id: 1,
+            sessionId: 456,
+            userId: 789,
+          });
+
+          databaseBuilder.factory.buildComplementaryCertificationCourse({
+            id: 456,
+            complementaryCertificationId: 24,
+            certificationCourseId: 1,
+            complementaryCertificationBadgeId: 3454,
+          });
+
+          databaseBuilder.factory.buildComplementaryCertificationCourseResult({
+            complementaryCertificationCourseId: 456,
+            complementaryCertificationId: 24,
+            certificationCourseId: 1,
+            complementaryCertificationBadgeId: 3453,
+          });
+          databaseBuilder.factory.buildComplementaryCertificationCourseResult({
+            complementaryCertificationCourseId: 456,
+            complementaryCertificationId: 24,
+            certificationCourseId: 1,
+            complementaryCertificationBadgeId: 3454,
+            source: ComplementaryCertificationCourseResult.sources.EXTERNAL,
+          });
+
+          databaseBuilder.factory.buildAssessment({ id: 159, certificationCourseId: 1 });
+          databaseBuilder.factory.buildAssessmentResult.last({
+            certificationCourseId: 1,
+            assessmentId: 159,
+          });
+          await databaseBuilder.commit();
+
+          // when
+          const juryCertification = await juryCertificationRepository.get({ certificationCourseId: 1 });
+
+          // then
+          const expectedJuryCertification = {
+            complementaryCertificationCourseId: 456,
+            externalSection: {
+              complementaryCertificationBadgeId: 3454,
+              acquired: true,
+              label: 'Badge for complementary certification with external jury level 2',
+              level: 2,
+            },
+            pixSection: {
+              complementaryCertificationBadgeId: 3453,
+              acquired: true,
+              label: 'Badge for complementary certification with external jury level 1',
+              level: 1,
+            },
+            allowedExternalLevels: [
+              {
+                value: 3453,
+                label: 'Badge for complementary certification with external jury level 1',
+              },
+              {
+                value: 3454,
+                label: 'Badge for complementary certification with external jury level 2',
+              },
+              {
+                value: 3455,
+                label: 'Badge for complementary certification with external jury level 3',
+              },
+            ],
+            defaultJuryOptions: ['REJECTED', 'UNSET'],
+          };
+
+          expect(juryCertification.complementaryCertificationCourseResultWithExternal).to.deep.equals(
+            expectedJuryCertification,
+          );
+        });
+      });
+
+      context('When there are multiple target profile for the current complementary certification', function () {
+        it('should return allowed badges for the current target profile only', async function () {
+          // given
+          databaseBuilder.factory.buildComplementaryCertification({
+            id: 24,
+            name: 'Complementary certification with external jury',
+            hasExternalJury: true,
+          });
+
+          databaseBuilder.factory.buildTargetProfile({ id: 5656, name: 'targetProfile CC 1' });
+          databaseBuilder.factory.buildTargetProfile({ id: 5657, name: 'targetProfile CC 1 (other)' });
+
+          _buildComplementaryBadge({
+            key: 'BADGE_FOR_COMPLEMENTARY_CERTIFICATION_1_WITH_EXTERNAL_JURY_LEVEL_1',
+            targetProfileId: 5656,
+            complementaryCertificationId: 24,
+            complementaryCertificationBadgeId: 3453,
+            level: 1,
+            label: 'Badge for complementary certification with external jury level 1',
+            complementaryCertificationCourse: null,
+          });
+          _buildComplementaryBadge({
+            key: 'BADGE_FOR_COMPLEMENTARY_CERTIFICATION_1_WITH_EXTERNAL_JURY_LEVEL_2',
+            targetProfileId: 5656,
+            complementaryCertificationId: 24,
+            complementaryCertificationBadgeId: 3454,
+            level: 2,
+            label: 'Badge for complementary certification with external jury level 2',
+            complementaryCertificationCourse: null,
+          });
+          _buildComplementaryBadge({
+            key: 'BADGE_FOR_COMPLEMENTARY_CERTIFICATION_1_WITH_EXTERNAL_JURY_LEVEL_3',
+            targetProfileId: 5656,
+            complementaryCertificationId: 24,
+            complementaryCertificationBadgeId: 3455,
+            level: 3,
+            label: 'Badge for complementary certification with external jury level 3',
+            complementaryCertificationCourse: null,
+          });
+
+          _buildComplementaryBadge({
+            key: 'BADGE_FOR_COMPLEMENTARY_CERTIFICATION_1_OTHER_RT',
+            targetProfileId: 5657,
+            complementaryCertificationId: 24,
+            complementaryCertificationBadgeId: 3456,
+            level: 1,
+            label: 'Badge for complementary certification other RT',
+            complementaryCertificationCourse: null,
+          });
+
+          databaseBuilder.factory.buildUser({ id: 789, firstName: 'Jury' });
+          databaseBuilder.factory.buildSession({ id: 456 });
+          databaseBuilder.factory.buildCertificationCourse({
+            id: 1,
+            sessionId: 456,
+            userId: 789,
+          });
+
+          databaseBuilder.factory.buildComplementaryCertificationCourse({
+            id: 456,
+            complementaryCertificationId: 24,
+            certificationCourseId: 1,
+            complementaryCertificationBadgeId: 3454,
+          });
+
+          databaseBuilder.factory.buildComplementaryCertificationCourseResult({
+            complementaryCertificationCourseId: 456,
+            complementaryCertificationId: 24,
+            certificationCourseId: 1,
+            complementaryCertificationBadgeId: 3454,
+          });
+          databaseBuilder.factory.buildComplementaryCertificationCourseResult({
+            complementaryCertificationCourseId: 456,
+            complementaryCertificationId: 24,
+            certificationCourseId: 1,
+            complementaryCertificationBadgeId: 3455,
+            source: ComplementaryCertificationCourseResult.sources.EXTERNAL,
+          });
+
+          databaseBuilder.factory.buildAssessment({ id: 159, certificationCourseId: 1 });
+          const assessmentResultId = databaseBuilder.factory.buildAssessmentResult.last({
+            certificationCourseId: 1,
+            assessmentId: 159,
+          }).id;
+          databaseBuilder.factory.buildCompetenceMark({
+            assessmentResultId,
+          });
+          await databaseBuilder.commit();
+
+          // when
+          const { complementaryCertificationCourseResultWithExternal } = await juryCertificationRepository.get({
+            certificationCourseId: 1,
+          });
+
+          // then
+          expect(complementaryCertificationCourseResultWithExternal.allowedExternalLevels).to.deep.equals([
             {
               value: 3453,
               label: 'Badge for complementary certification with external jury level 1',
@@ -261,125 +381,91 @@ describe('Certification | Session-management | Integration | Infrastructure | Re
               value: 3455,
               label: 'Badge for complementary certification with external jury level 3',
             },
-          ],
-          defaultJuryOptions: ['REJECTED', 'UNSET'],
-        };
-
-        expect(juryCertification.complementaryCertificationCourseResultWithExternal).to.deep.equals(
-          expectedJuryCertification,
-        );
+          ]);
+        });
       });
     });
 
-    context('When there are multiple target profile for the current complementary certification', function () {
-      it('should return allowed badges for the current target profile only', async function () {
+    context('when certification version is 3', function () {
+      it('should return the JuryCertification with v3-specific fields', async function () {
         // given
-        databaseBuilder.factory.buildComplementaryCertification({
-          id: 24,
-          name: 'Complementary certification with external jury',
-          hasExternalJury: true,
+        const user = databaseBuilder.factory.buildUser();
+        const juryUser = databaseBuilder.factory.buildUser();
+        const session = databaseBuilder.factory.buildSession();
+        const certificationCourse = databaseBuilder.factory.buildCertificationCourse({
+          sessionId: session.id,
+          userId: user.id,
+          firstName: 'Buffy',
+          lastName: 'Summers',
+          birthdate: '1981-01-19',
+          sex: 'F',
+          birthplace: 'Torreilles',
+          birthINSEECode: '66212',
+          birthPostalCode: null,
+          birthCountry: 'FRANCE',
+          createdAt: new Date('2020-01-01'),
+          completedAt: new Date('2020-02-01'),
+          isPublished: false,
+          framework: Frameworks.EDU_1ER_DEGRE,
+          version: 3,
         });
 
-        databaseBuilder.factory.buildTargetProfile({ id: 5656, name: 'targetProfile CC 1' });
-        databaseBuilder.factory.buildTargetProfile({ id: 5657, name: 'targetProfile CC 1 (other)' });
-
-        _buildComplementaryBadge({
-          key: 'BADGE_FOR_COMPLEMENTARY_CERTIFICATION_1_WITH_EXTERNAL_JURY_LEVEL_1',
-          targetProfileId: 5656,
-          complementaryCertificationId: 24,
-          complementaryCertificationBadgeId: 3453,
-          level: 1,
-          label: 'Badge for complementary certification with external jury level 1',
-          complementaryCertificationCourse: null,
-        });
-        _buildComplementaryBadge({
-          key: 'BADGE_FOR_COMPLEMENTARY_CERTIFICATION_1_WITH_EXTERNAL_JURY_LEVEL_2',
-          targetProfileId: 5656,
-          complementaryCertificationId: 24,
-          complementaryCertificationBadgeId: 3454,
-          level: 2,
-          label: 'Badge for complementary certification with external jury level 2',
-          complementaryCertificationCourse: null,
-        });
-        _buildComplementaryBadge({
-          key: 'BADGE_FOR_COMPLEMENTARY_CERTIFICATION_1_WITH_EXTERNAL_JURY_LEVEL_3',
-          targetProfileId: 5656,
-          complementaryCertificationId: 24,
-          complementaryCertificationBadgeId: 3455,
-          level: 3,
-          label: 'Badge for complementary certification with external jury level 3',
-          complementaryCertificationCourse: null,
-        });
-
-        _buildComplementaryBadge({
-          key: 'BADGE_FOR_COMPLEMENTARY_CERTIFICATION_1_OTHER_RT',
-          targetProfileId: 5657,
-          complementaryCertificationId: 24,
-          complementaryCertificationBadgeId: 3456,
-          level: 1,
-          label: 'Badge for complementary certification other RT',
-          complementaryCertificationCourse: null,
-        });
-
-        databaseBuilder.factory.buildUser({ id: 789, firstName: 'Jury' });
-        databaseBuilder.factory.buildSession({ id: 456 });
-        databaseBuilder.factory.buildCertificationCourse({
-          id: 1,
-          sessionId: 456,
-          userId: 789,
-        });
-
-        databaseBuilder.factory.buildComplementaryCertificationCourse({
-          id: 456,
-          complementaryCertificationId: 24,
-          certificationCourseId: 1,
-          complementaryCertificationBadgeId: 3454,
-        });
-
-        databaseBuilder.factory.buildComplementaryCertificationCourseResult({
-          complementaryCertificationCourseId: 456,
-          complementaryCertificationId: 24,
-          certificationCourseId: 1,
-          complementaryCertificationBadgeId: 3454,
-        });
-        databaseBuilder.factory.buildComplementaryCertificationCourseResult({
-          complementaryCertificationCourseId: 456,
-          complementaryCertificationId: 24,
-          certificationCourseId: 1,
-          complementaryCertificationBadgeId: 3455,
-          source: ComplementaryCertificationCourseResult.sources.EXTERNAL,
-        });
-
-        databaseBuilder.factory.buildAssessment({ id: 159, certificationCourseId: 1 });
-        const assessmentResultId = databaseBuilder.factory.buildAssessmentResult.last({
-          certificationCourseId: 1,
-          assessmentId: 159,
-        }).id;
-        databaseBuilder.factory.buildCompetenceMark({
-          assessmentResultId,
+        const assessment = databaseBuilder.factory.buildAssessment({ certificationCourseId: certificationCourse.id });
+        databaseBuilder.factory.buildAssessmentResult.last({
+          certificationCourseId: certificationCourse.id,
+          assessmentId: assessment.id,
+          pixScore: 123,
+          reachedMeshIndex: 0,
+          eduV3ExternalJuryResult: PIX_PLUS_EDU_EXTERNAL_LEVELS.EXPERT,
+          status: 'validated',
+          commentForOrganization: 'Un commentaire orga',
+          commentForCandidate: 'Un commentaire candidat',
+          commentByJury: 'Un commentaire jury',
+          commentByAutoJury: AutoJuryCommentKeys.FRAUD,
+          juryId: juryUser.id,
         });
         await databaseBuilder.commit();
 
         // when
-        const { complementaryCertificationCourseResultWithExternal } = await juryCertificationRepository.get({
-          certificationCourseId: 1,
+        const juryCertification = await juryCertificationRepository.get({
+          certificationCourseId: certificationCourse.id,
         });
 
         // then
-        expect(complementaryCertificationCourseResultWithExternal.allowedExternalLevels).to.deep.equals([
-          {
-            value: 3453,
-            label: 'Badge for complementary certification with external jury level 1',
-          },
-          {
-            value: 3454,
-            label: 'Badge for complementary certification with external jury level 2',
-          },
-          {
-            value: 3455,
-            label: 'Badge for complementary certification with external jury level 3',
-          },
-        ]);
+        const expectedJuryCertification = domainBuilder.certification.sessionManagement.buildJuryCertification({
+          certificationCourseId: certificationCourse.id,
+          sessionId: session.id,
+          userId: user.id,
+          assessmentId: assessment.id,
+          firstName: certificationCourse.firstName,
+          lastName: certificationCourse.lastName,
+          birthdate: certificationCourse.birthdate,
+          sex: certificationCourse.sex,
+          birthplace: certificationCourse.birthplace,
+          birthINSEECode: certificationCourse.birthINSEECode,
+          birthPostalCode: certificationCourse.birthPostalCode,
+          birthCountry: certificationCourse.birthCountry,
+          status: 'validated',
+          createdAt: certificationCourse.createdAt,
+          completedAt: certificationCourse.completedAt,
+          isPublished: certificationCourse.isPublished,
+          isRejectedForFraud: false,
+          juryId: juryUser.id,
+          pixScore: 123,
+          reachedMeshIndex: 0,
+          eduV3ExternalJuryResult: PIX_PLUS_EDU_EXTERNAL_LEVELS.EXPERT,
+          commentForOrganization: 'Un commentaire orga',
+          commentForCandidate: 'Un commentaire candidat',
+          commentByJury: 'Un commentaire jury',
+          commentByAutoJury: AutoJuryCommentKeys.FRAUD,
+          competenceMarks: [],
+          certificationIssueReports: [],
+          version: 3,
+          certificationFramework: Frameworks.EDU_1ER_DEGRE,
+          commonComplementaryCertificationCourseResult: undefined,
+          complementaryCertificationCourseResultWithExternal: undefined,
+        });
+        expect(juryCertification).to.deepEqualInstance(expectedJuryCertification);
       });
     });
 

--- a/api/tests/certification/session-management/integration/infrastructure/repositories/jury-certification-summary-repository_test.js
+++ b/api/tests/certification/session-management/integration/infrastructure/repositories/jury-certification-summary-repository_test.js
@@ -79,6 +79,7 @@ describe('Integration | Repository | JuryCertificationSummary', function () {
           assessmentId: manyAsrAssessmentId,
           createdAt: new Date('2018-04-15T00:00:00Z'),
           status: AssessmentResult.status.VALIDATED,
+          eduV3ExternalJuryResult: 'COUCOU',
         });
 
         return databaseBuilder.commit();
@@ -89,30 +90,32 @@ describe('Integration | Repository | JuryCertificationSummary', function () {
         const juryCertificationSummaries = await juryCertificationSummaryRepository.findBySessionId({ sessionId });
 
         // then
-        const expectedJuryCertificationSummary = domainBuilder.buildJuryCertificationSummary({
-          completedAt: manyAsrCertification.completedAt,
-          createdAt: manyAsrCertification.createdAt,
-          firstName: manyAsrCertification.firstName,
-          id: manyAsrCertification.id,
-          isPublished: manyAsrCertification.isPublished,
-          lastName: 'AAA',
-          algorithmVersion: AlgorithmEngineVersion.V2,
-          pixScore: latestAssessmentResult.pixScore,
-          reachedMeshIndex: latestAssessmentResult.reachedMeshIndex,
-          status: latestAssessmentResult.status,
-          certificationIssueReports: [
-            domainBuilder.buildCertificationIssueReport({
-              id: certificationIssueReport.id,
-              certificationCourseId: manyAsrCertification.id,
-              description,
-              categoryId,
-              subcategory: null,
-              category: CertificationIssueReportCategory.OTHER,
-              hasBeenAutomaticallyResolved: null,
-            }),
-          ],
-          certificationFramework: Frameworks.DROIT,
-        });
+        const expectedJuryCertificationSummary =
+          domainBuilder.certification.sessionManagement.buildJuryCertificationSummary({
+            completedAt: manyAsrCertification.completedAt,
+            createdAt: manyAsrCertification.createdAt,
+            firstName: manyAsrCertification.firstName,
+            id: manyAsrCertification.id,
+            isPublished: manyAsrCertification.isPublished,
+            lastName: 'AAA',
+            algorithmVersion: AlgorithmEngineVersion.V2,
+            pixScore: latestAssessmentResult.pixScore,
+            reachedMeshIndex: latestAssessmentResult.reachedMeshIndex,
+            status: latestAssessmentResult.status,
+            certificationIssueReports: [
+              domainBuilder.buildCertificationIssueReport({
+                id: certificationIssueReport.id,
+                certificationCourseId: manyAsrCertification.id,
+                description,
+                categoryId,
+                subcategory: null,
+                category: CertificationIssueReportCategory.OTHER,
+                hasBeenAutomaticallyResolved: null,
+              }),
+            ],
+            certificationFramework: Frameworks.DROIT,
+            eduV3ExternalJuryResult: 'COUCOU',
+          });
         expect(juryCertificationSummaries).to.have.lengthOf(3);
         expect(juryCertificationSummaries[0]).to.deepEqualInstance(expectedJuryCertificationSummary);
         expect(juryCertificationSummaries[1].id).to.equal(startedCertification.id);
@@ -126,6 +129,9 @@ describe('Integration | Repository | JuryCertificationSummary', function () {
           // then
           expect(juryCertificationSummaries[0].pixScore).to.equal(latestAssessmentResult.pixScore);
           expect(juryCertificationSummaries[0].reachedMeshIndex).to.equal(latestAssessmentResult.reachedMeshIndex);
+          expect(juryCertificationSummaries[0].eduV3ExternalJuryResult).to.equal(
+            latestAssessmentResult.eduV3ExternalJuryResult,
+          );
           expect(juryCertificationSummaries[0].status).to.equal(AssessmentResult.status.VALIDATED);
           expect(juryCertificationSummaries[0].firstName).to.equal(manyAsrCertification.firstName);
           expect(juryCertificationSummaries[0].lastName).to.equal(manyAsrCertification.lastName);

--- a/api/tests/certification/session-management/integration/infrastructure/repositories/v3-certification-course-details-for-administration-repository_test.js
+++ b/api/tests/certification/session-management/integration/infrastructure/repositories/v3-certification-course-details-for-administration-repository_test.js
@@ -110,6 +110,7 @@ describe('Integration | Infrastructure | Repository | v3-certification-course-de
         abortReason,
         pixScore,
         reachedMeshIndex,
+        eduV3ExternalJuryResult: null,
         numberOfChallenges: null,
         certificationFramework,
         certificationChallengesForAdministration: [certificationChallengeForAdministration],

--- a/api/tests/certification/session-management/unit/application/jury-certification-controller_test.js
+++ b/api/tests/certification/session-management/unit/application/jury-certification-controller_test.js
@@ -18,7 +18,7 @@ describe('Certification | Session-management | Unit | Application | jury-certifi
         i18n: getI18n(),
       };
 
-      const juryCertification = domainBuilder.buildJuryCertification({
+      const juryCertification = domainBuilder.certification.sessionManagement.buildJuryCertification({
         certificationCourseId: 123,
         sessionId: 456,
         userId: 789,

--- a/api/tests/certification/session-management/unit/domain/models/JuryCertification_test.js
+++ b/api/tests/certification/session-management/unit/domain/models/JuryCertification_test.js
@@ -1,9 +1,9 @@
-import { JuryCertification } from '../../../../src/certification/session-management/domain/models/JuryCertification.js';
-import { PIX_PLUS_EDU_EXTERNAL_LEVELS } from '../../../../src/certification/shared/domain/constants/mesh-configuration.js';
-import { AlgorithmEngineVersion } from '../../../../src/certification/shared/domain/models/AlgorithmEngineVersion.js';
-import { Frameworks } from '../../../../src/certification/shared/domain/models/Frameworks.js';
-import { AutoJuryCommentKeys } from '../../../../src/certification/shared/domain/models/JuryComment.js';
-import { domainBuilder, expect } from '../../../test-helper.js';
+import { JuryCertification } from '../../../../../../src/certification/session-management/domain/models/JuryCertification.js';
+import { PIX_PLUS_EDU_EXTERNAL_LEVELS } from '../../../../../../src/certification/shared/domain/constants/mesh-configuration.js';
+import { AlgorithmEngineVersion } from '../../../../../../src/certification/shared/domain/models/AlgorithmEngineVersion.js';
+import { Frameworks } from '../../../../../../src/certification/shared/domain/models/Frameworks.js';
+import { AutoJuryCommentKeys } from '../../../../../../src/certification/shared/domain/models/JuryComment.js';
+import { domainBuilder, expect } from '../../../../../test-helper.js';
 
 describe('Unit | Domain | Models | JuryCertification', function () {
   describe('#from', function () {

--- a/api/tests/certification/session-management/unit/domain/models/V3CertificationCourseDetailsForAdministration_test.js
+++ b/api/tests/certification/session-management/unit/domain/models/V3CertificationCourseDetailsForAdministration_test.js
@@ -1,3 +1,5 @@
+import { PIX_PLUS_EDU_EXTERNAL_LEVELS } from '../../../../../../src/certification/shared/domain/constants/mesh-configuration.js';
+import { Frameworks } from '../../../../../../src/certification/shared/domain/models/Frameworks.js';
 import { domainBuilder, expect } from '../../../../../test-helper.js';
 
 describe('Unit | Domain | Models | V3CertificationCourseDetailsForAdministration', function () {
@@ -66,6 +68,119 @@ describe('Unit | Domain | Models | V3CertificationCourseDetailsForAdministration
         courseDetails.setCompetencesDetails(competenceList);
 
         expect(courseDetails.certificationChallengesForAdministration).to.deep.equal([]);
+      });
+    });
+  });
+
+  describe('#get reachedResultKey', function () {
+    context('CORE', function () {
+      [
+        { reachedMeshIndex: null, expectedReachedResultKey: 'CORE.BELOW_MINIMUM' },
+        { reachedMeshIndex: 0, expectedReachedResultKey: 'CORE.0' },
+        { reachedMeshIndex: 1, expectedReachedResultKey: 'CORE.1' },
+        { reachedMeshIndex: 2, expectedReachedResultKey: 'CORE.2' },
+        { reachedMeshIndex: 3, expectedReachedResultKey: 'CORE.3' },
+        { reachedMeshIndex: 4, expectedReachedResultKey: 'CORE.4' },
+        { reachedMeshIndex: 5, expectedReachedResultKey: 'CORE.5' },
+        { reachedMeshIndex: 6, expectedReachedResultKey: 'CORE.6' },
+        { reachedMeshIndex: 7, expectedReachedResultKey: 'CORE.7' },
+        { reachedMeshIndex: 8, expectedReachedResultKey: 'CORE.8' },
+      ].forEach(({ reachedMeshIndex, expectedReachedResultKey }) => {
+        context(`when reachedMeshIndex is ${reachedMeshIndex}`, function () {
+          it(`returns ${expectedReachedResultKey}`, function () {
+            const certificationCourseDetails = domainBuilder.buildV3CertificationCourseDetailsForAdministration({
+              certificationFramework: Frameworks.CORE,
+              reachedMeshIndex,
+            });
+            const reachedResultKey = certificationCourseDetails.reachedResultKey;
+
+            expect(reachedResultKey).to.equal(expectedReachedResultKey);
+          });
+        });
+      });
+    });
+
+    context('EDU', function () {
+      [
+        {
+          reachedMeshIndex: null,
+          eduV3ExternalJuryResult: null,
+          expectedReachedResultKey: 'EDU_1ER_DEGRE.BELOW_MINIMUM',
+        },
+        { reachedMeshIndex: 0, eduV3ExternalJuryResult: null, expectedReachedResultKey: 'EDU_1ER_DEGRE.0' },
+        {
+          reachedMeshIndex: 0,
+          eduV3ExternalJuryResult: PIX_PLUS_EDU_EXTERNAL_LEVELS.ADVANCED,
+          expectedReachedResultKey: 'EDU_1ER_DEGRE.ADVANCED',
+        },
+        {
+          reachedMeshIndex: 0,
+          eduV3ExternalJuryResult: PIX_PLUS_EDU_EXTERNAL_LEVELS.EXPERT,
+          expectedReachedResultKey: 'EDU_1ER_DEGRE.EXPERT',
+        },
+      ].forEach(({ reachedMeshIndex, eduV3ExternalJuryResult, expectedReachedResultKey }) => {
+        context(
+          `when reachedMeshIndex is ${reachedMeshIndex} and eduV3ExternalJuryResult is ${eduV3ExternalJuryResult}`,
+          function () {
+            it(`returns ${expectedReachedResultKey}`, function () {
+              const certificationCourseDetails = domainBuilder.buildV3CertificationCourseDetailsForAdministration({
+                certificationFramework: Frameworks.EDU_1ER_DEGRE,
+                eduV3ExternalJuryResult,
+                reachedMeshIndex,
+              });
+
+              const reachedResultKey = certificationCourseDetails.reachedResultKey;
+
+              expect(reachedResultKey).to.equal(expectedReachedResultKey);
+            });
+          },
+        );
+      });
+    });
+
+    context('DROIT', function () {
+      [
+        {
+          reachedMeshIndex: null,
+          expectedReachedResultKey: 'DROIT.BELOW_MINIMUM',
+        },
+        { reachedMeshIndex: 0, expectedReachedResultKey: 'DROIT.0' },
+      ].forEach(({ reachedMeshIndex, expectedReachedResultKey }) => {
+        context(`when reachedMeshIndex is ${reachedMeshIndex}`, function () {
+          it(`returns ${expectedReachedResultKey}`, function () {
+            const certificationCourseDetails = domainBuilder.buildV3CertificationCourseDetailsForAdministration({
+              certificationFramework: Frameworks.DROIT,
+              reachedMeshIndex,
+            });
+
+            const reachedResultKey = certificationCourseDetails.reachedResultKey;
+
+            expect(reachedResultKey).to.equal(expectedReachedResultKey);
+          });
+        });
+      });
+    });
+
+    context('PRO SANTÉ', function () {
+      [
+        {
+          reachedMeshIndex: null,
+          expectedReachedResultKey: 'PRO_SANTE.BELOW_MINIMUM',
+        },
+        { reachedMeshIndex: 0, expectedReachedResultKey: 'PRO_SANTE.0' },
+      ].forEach(({ reachedMeshIndex, expectedReachedResultKey }) => {
+        context(`when reachedMeshIndex is ${reachedMeshIndex}`, function () {
+          it(`returns ${expectedReachedResultKey}`, function () {
+            const certificationCourseDetails = domainBuilder.buildV3CertificationCourseDetailsForAdministration({
+              certificationFramework: Frameworks.PRO_SANTE,
+              reachedMeshIndex,
+            });
+
+            const reachedResultKey = certificationCourseDetails.reachedResultKey;
+
+            expect(reachedResultKey).to.equal(expectedReachedResultKey);
+          });
+        });
       });
     });
   });

--- a/api/tests/certification/session-management/unit/domain/read-models/JuryCertificationSummary_test.js
+++ b/api/tests/certification/session-management/unit/domain/read-models/JuryCertificationSummary_test.js
@@ -1,4 +1,5 @@
 import { JuryCertificationSummary } from '../../../../../../src/certification/session-management/domain/read-models/JuryCertificationSummary.js';
+import { PIX_PLUS_EDU_EXTERNAL_LEVELS } from '../../../../../../src/certification/shared/domain/constants/mesh-configuration.js';
 import { AlgorithmEngineVersion } from '../../../../../../src/certification/shared/domain/models/AlgorithmEngineVersion.js';
 import { Frameworks } from '../../../../../../src/certification/shared/domain/models/Frameworks.js';
 import { Assessment } from '../../../../../../src/shared/domain/models/Assessment.js';
@@ -23,6 +24,7 @@ describe('Unit | Domain | Models | JuryCertificationSummary', function () {
         pixScore: 751,
         reachedMeshIndex: 6,
         status: 'started',
+        eduV3ExternalJuryResult: 'coucou',
         certificationFramework: Frameworks.CORE,
       };
 
@@ -44,6 +46,7 @@ describe('Unit | Domain | Models | JuryCertificationSummary', function () {
         reachedMeshIndex: 6,
         status: 'started',
         certificationFramework: Frameworks.CORE,
+        eduV3ExternalJuryResult: 'coucou',
       });
     });
   });
@@ -242,6 +245,149 @@ describe('Unit | Domain | Models | JuryCertificationSummary', function () {
 
           // then
           expect(hasCompletedAssessment).to.be.false;
+        });
+      });
+    });
+  });
+
+  describe('#get reachedResultKey', function () {
+    context('when certification is not v3', function () {
+      it('returns the certification framework label followed by NONE', function () {
+        const juryCertificationSummaryV1 = domainBuilder.certification.sessionManagement.buildJuryCertificationSummary({
+          algorithmVersion: AlgorithmEngineVersion.V1,
+          certificationFramework: Frameworks.CORE,
+        });
+        const juryCertificationSummaryV2 = domainBuilder.certification.sessionManagement.buildJuryCertificationSummary({
+          algorithmVersion: AlgorithmEngineVersion.V2,
+          certificationFramework: Frameworks.EDU_1ER_DEGRE,
+        });
+
+        const reachedResultKeyV1 = juryCertificationSummaryV1.reachedResultKey;
+        const reachedResultKeyV2 = juryCertificationSummaryV2.reachedResultKey;
+
+        expect(reachedResultKeyV1).to.equal('CORE.NONE');
+        expect(reachedResultKeyV2).to.equal('EDU_1ER_DEGRE.NONE');
+      });
+    });
+
+    context('when certification is v3', function () {
+      context('CORE', function () {
+        [
+          { reachedMeshIndex: null, expectedReachedResultKey: 'CORE.BELOW_MINIMUM' },
+          { reachedMeshIndex: 0, expectedReachedResultKey: 'CORE.0' },
+          { reachedMeshIndex: 1, expectedReachedResultKey: 'CORE.1' },
+          { reachedMeshIndex: 2, expectedReachedResultKey: 'CORE.2' },
+          { reachedMeshIndex: 3, expectedReachedResultKey: 'CORE.3' },
+          { reachedMeshIndex: 4, expectedReachedResultKey: 'CORE.4' },
+          { reachedMeshIndex: 5, expectedReachedResultKey: 'CORE.5' },
+          { reachedMeshIndex: 6, expectedReachedResultKey: 'CORE.6' },
+          { reachedMeshIndex: 7, expectedReachedResultKey: 'CORE.7' },
+          { reachedMeshIndex: 8, expectedReachedResultKey: 'CORE.8' },
+        ].forEach(({ reachedMeshIndex, expectedReachedResultKey }) => {
+          context(`when reachedMeshIndex is ${reachedMeshIndex}`, function () {
+            it(`returns ${expectedReachedResultKey}`, function () {
+              const juryCertificationSummary =
+                domainBuilder.certification.sessionManagement.buildJuryCertificationSummary({
+                  certificationFramework: Frameworks.CORE,
+                  algorithmVersion: AlgorithmEngineVersion.V3,
+                  reachedMeshIndex,
+                });
+
+              const reachedResultKey = juryCertificationSummary.reachedResultKey;
+
+              expect(reachedResultKey).to.equal(expectedReachedResultKey);
+            });
+          });
+        });
+      });
+
+      context('EDU', function () {
+        [
+          {
+            reachedMeshIndex: null,
+            eduV3ExternalJuryResult: null,
+            expectedReachedResultKey: 'EDU_1ER_DEGRE.BELOW_MINIMUM',
+          },
+          { reachedMeshIndex: 0, eduV3ExternalJuryResult: null, expectedReachedResultKey: 'EDU_1ER_DEGRE.0' },
+          {
+            reachedMeshIndex: 0,
+            eduV3ExternalJuryResult: PIX_PLUS_EDU_EXTERNAL_LEVELS.ADVANCED,
+            expectedReachedResultKey: 'EDU_1ER_DEGRE.ADVANCED',
+          },
+          {
+            reachedMeshIndex: 0,
+            eduV3ExternalJuryResult: PIX_PLUS_EDU_EXTERNAL_LEVELS.EXPERT,
+            expectedReachedResultKey: 'EDU_1ER_DEGRE.EXPERT',
+          },
+        ].forEach(({ reachedMeshIndex, eduV3ExternalJuryResult, expectedReachedResultKey }) => {
+          context(
+            `when reachedMeshIndex is ${reachedMeshIndex} and eduV3ExternalJuryResult is ${eduV3ExternalJuryResult}`,
+            function () {
+              it(`returns ${expectedReachedResultKey}`, function () {
+                const juryCertificationSummary =
+                  domainBuilder.certification.sessionManagement.buildJuryCertificationSummary({
+                    certificationFramework: Frameworks.EDU_1ER_DEGRE,
+                    algorithmVersion: AlgorithmEngineVersion.V3,
+                    eduV3ExternalJuryResult,
+                    reachedMeshIndex,
+                  });
+
+                const reachedResultKey = juryCertificationSummary.reachedResultKey;
+
+                expect(reachedResultKey).to.equal(expectedReachedResultKey);
+              });
+            },
+          );
+        });
+      });
+
+      context('DROIT', function () {
+        [
+          {
+            reachedMeshIndex: null,
+            expectedReachedResultKey: 'DROIT.BELOW_MINIMUM',
+          },
+          { reachedMeshIndex: 0, expectedReachedResultKey: 'DROIT.0' },
+        ].forEach(({ reachedMeshIndex, expectedReachedResultKey }) => {
+          context(`when reachedMeshIndex is ${reachedMeshIndex}`, function () {
+            it(`returns ${expectedReachedResultKey}`, function () {
+              const juryCertificationSummary =
+                domainBuilder.certification.sessionManagement.buildJuryCertificationSummary({
+                  certificationFramework: Frameworks.DROIT,
+                  algorithmVersion: AlgorithmEngineVersion.V3,
+                  reachedMeshIndex,
+                });
+
+              const reachedResultKey = juryCertificationSummary.reachedResultKey;
+
+              expect(reachedResultKey).to.equal(expectedReachedResultKey);
+            });
+          });
+        });
+      });
+
+      context('PRO SANTÉ', function () {
+        [
+          {
+            reachedMeshIndex: null,
+            expectedReachedResultKey: 'PRO_SANTE.BELOW_MINIMUM',
+          },
+          { reachedMeshIndex: 0, expectedReachedResultKey: 'PRO_SANTE.0' },
+        ].forEach(({ reachedMeshIndex, expectedReachedResultKey }) => {
+          context(`when reachedMeshIndex is ${reachedMeshIndex}`, function () {
+            it(`returns ${expectedReachedResultKey}`, function () {
+              const juryCertificationSummary =
+                domainBuilder.certification.sessionManagement.buildJuryCertificationSummary({
+                  certificationFramework: Frameworks.PRO_SANTE,
+                  algorithmVersion: AlgorithmEngineVersion.V3,
+                  reachedMeshIndex,
+                });
+
+              const reachedResultKey = juryCertificationSummary.reachedResultKey;
+
+              expect(reachedResultKey).to.equal(expectedReachedResultKey);
+            });
+          });
         });
       });
     });

--- a/api/tests/certification/session-management/unit/domain/usecases/get-jury-certification_test.js
+++ b/api/tests/certification/session-management/unit/domain/usecases/get-jury-certification_test.js
@@ -4,7 +4,9 @@ import { domainBuilder, expect, sinon } from '../../../../../test-helper.js';
 describe('Certification | Session-management | Unit | Domain | Usecases | get-jury-certification', function () {
   it('should return the jury certification', async function () {
     // given
-    const expectedJuryCertification = domainBuilder.buildJuryCertification({ certificationCourseId: 777 });
+    const expectedJuryCertification = domainBuilder.certification.sessionManagement.buildJuryCertification({
+      certificationCourseId: 777,
+    });
     const juryCertificationRepository = { get: sinon.stub() };
     juryCertificationRepository.get.withArgs({ certificationCourseId: 123 }).resolves(expectedJuryCertification);
 

--- a/api/tests/certification/session-management/unit/infrastructure/serializers/jury-certification-serializer_test.js
+++ b/api/tests/certification/session-management/unit/infrastructure/serializers/jury-certification-serializer_test.js
@@ -1,4 +1,5 @@
 import * as serializer from '../../../../../../src/certification/session-management/infrastructure/serializers/jury-certification-serializer.js';
+import { PIX_PLUS_EDU_EXTERNAL_LEVELS } from '../../../../../../src/certification/shared/domain/constants/mesh-configuration.js';
 import { Frameworks } from '../../../../../../src/certification/shared/domain/models/Frameworks.js';
 import { AutoJuryCommentKeys } from '../../../../../../src/certification/shared/domain/models/JuryComment.js';
 import { getI18n } from '../../../../../../src/shared/infrastructure/i18n/i18n.js';
@@ -24,7 +25,7 @@ describe('Certification | Session-management | Unit | Infrastructure | Serialize
         });
         const certificationIssueReports = [certificationIssueReport];
         const competenceMarks = [domainBuilder.buildCompetenceMark()];
-        const juryCertification = domainBuilder.buildJuryCertification({
+        const juryCertification = domainBuilder.certification.sessionManagement.buildJuryCertification({
           certificationCourseId,
           sessionId: 11,
           userId: 867,
@@ -44,13 +45,14 @@ describe('Certification | Session-management | Unit | Infrastructure | Serialize
           isRejectedForFraud: false,
           juryId: 1,
           pixScore: 555,
-          reachedMeshIndex: 5,
+          reachedMeshIndex: 3,
+          eduV3ExternalJuryResult: PIX_PLUS_EDU_EXTERNAL_LEVELS.ADVANCED,
           commentForCandidate: 'coucou',
           commentForOrganization: 'comment',
           commentByJury: 'ça va',
           competenceMarks,
-          version: 2,
-          certificationFramework: Frameworks.CORE,
+          version: 3,
+          certificationFramework: Frameworks.EDU_1ER_DEGRE,
           certificationIssueReports,
           commonComplementaryCertificationCourseResult:
             domainBuilder.buildComplementaryCertificationCourseResultForJuryCertification({
@@ -109,13 +111,13 @@ describe('Certification | Session-management | Unit | Infrastructure | Serialize
               'is-rejected-for-fraud': false,
               'jury-id': 1,
               'pix-score': 555,
-              'reached-mesh-index': 5,
+              'reached-result-key': 'EDU_1ER_DEGRE.ADVANCED',
               'competences-with-mark': juryCertification.competenceMarks,
               'comment-for-candidate': 'coucou',
               'comment-by-jury': 'ça va',
               'comment-for-organization': 'comment',
-              version: 2,
-              'certification-framework': Frameworks.CORE,
+              version: 3,
+              'certification-framework': Frameworks.EDU_1ER_DEGRE,
             },
             relationships: {
               'certification-issue-reports': {
@@ -203,7 +205,7 @@ describe('Certification | Session-management | Unit | Infrastructure | Serialize
         });
         const certificationIssueReports = [certificationIssueReport];
         const competenceMarks = [domainBuilder.buildCompetenceMark()];
-        const juryCertification = domainBuilder.buildJuryCertification({
+        const juryCertification = domainBuilder.certification.sessionManagement.buildJuryCertification({
           certificationCourseId,
           sessionId: 11,
           userId: 867,

--- a/api/tests/certification/session-management/unit/infrastructure/serializers/jury-certification-serializer_test.js
+++ b/api/tests/certification/session-management/unit/infrastructure/serializers/jury-certification-serializer_test.js
@@ -289,7 +289,7 @@ describe('Certification | Session-management | Unit | Infrastructure | Serialize
               'is-rejected-for-fraud': false,
               'jury-id': 1,
               'pix-score': 555,
-              'reached-mesh-index': 5,
+              'reached-result-key': 'CORE.NONE',
               'competences-with-mark': juryCertification.competenceMarks,
               'comment-for-candidate': translate('jury.comment.FRAUD.candidate'),
               'comment-by-jury': 'ça va',

--- a/api/tests/certification/session-management/unit/infrastructure/serializers/jury-certification-summary-serializer_test.js
+++ b/api/tests/certification/session-management/unit/infrastructure/serializers/jury-certification-summary-serializer_test.js
@@ -1,4 +1,3 @@
-import { JuryCertificationSummary } from '../../../../../../src/certification/session-management/domain/read-models/JuryCertificationSummary.js';
 import * as serializer from '../../../../../../src/certification/session-management/infrastructure/serializers/jury-certification-summary-serializer.js';
 import { AlgorithmEngineVersion } from '../../../../../../src/certification/shared/domain/models/AlgorithmEngineVersion.js';
 import { Frameworks } from '../../../../../../src/certification/shared/domain/models/Frameworks.js';
@@ -19,7 +18,7 @@ describe('Unit | Serializer | JSONAPI | jury-certification-summary-serializer', 
         description: 'someComment',
         resolvedAt: null,
       });
-      modelJuryCertifSummary = new JuryCertificationSummary({
+      modelJuryCertifSummary = domainBuilder.certification.sessionManagement.buildJuryCertificationSummary({
         id: 1,
         firstName: 'someFirstName',
         lastName: 'someLastName',
@@ -45,7 +44,7 @@ describe('Unit | Serializer | JSONAPI | jury-certification-summary-serializer', 
             status: modelJuryCertifSummary.status,
             'pix-score': modelJuryCertifSummary.pixScore,
             'algorithm-version': modelJuryCertifSummary.algorithmVersion,
-            'reached-mesh-index': modelJuryCertifSummary.reachedMeshIndex,
+            'reached-result-key': modelJuryCertifSummary.reachedResultKey,
             'created-at': modelJuryCertifSummary.createdAt,
             'completed-at': modelJuryCertifSummary.completedAt,
             'is-published': modelJuryCertifSummary.isPublished,

--- a/api/tests/certification/session-management/unit/infrastructure/serializers/v3-certification-course-details-for-administration-serializer_test.js
+++ b/api/tests/certification/session-management/unit/infrastructure/serializers/v3-certification-course-details-for-administration-serializer_test.js
@@ -66,7 +66,7 @@ describe('Unit | Serializer | JSONAPI | v3-certification-details-for-administrat
             'assessment-result-status': assessmentResultStatus,
             'abort-reason': abortReason,
             'pix-score': pixScore,
-            'reached-mesh-index': reachedMeshIndex,
+            'reached-result-key': 'CORE.1',
             'number-of-challenges': 20,
             'certification-framework': certificationFramework,
           },

--- a/api/tests/certification/shared/unit/domain/services/mesh-service_test.js
+++ b/api/tests/certification/shared/unit/domain/services/mesh-service_test.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 
-import { MESH_CONFIGURATION } from '../../../../../../src/certification/shared/domain/constants/mesh-configuration.js';
+import { CORE_MESH_CONFIGURATION } from '../../../../../../src/certification/shared/domain/constants/mesh-configuration.js';
 import {
   findIntervalIndexFromScore,
   findMeshFromScore,
@@ -15,31 +15,31 @@ describe('Unit | Shared | Domain | Services | Mesh Service', function () {
         score: 0,
         meshKey: 'LEVEL_PRE_BEGINNER',
 
-        expectedInterval: MESH_CONFIGURATION.get('LEVEL_PRE_BEGINNER'),
+        expectedInterval: CORE_MESH_CONFIGURATION.get('LEVEL_PRE_BEGINNER'),
       },
       {
         score: 64,
         meshKey: 'LEVEL_BEGINNER_1',
 
-        expectedInterval: MESH_CONFIGURATION.get('LEVEL_BEGINNER_1'),
+        expectedInterval: CORE_MESH_CONFIGURATION.get('LEVEL_BEGINNER_1'),
       },
       {
         score: 200,
         meshKey: 'LEVEL_BEGINNER_2',
 
-        expectedInterval: MESH_CONFIGURATION.get('LEVEL_BEGINNER_2'),
+        expectedInterval: CORE_MESH_CONFIGURATION.get('LEVEL_BEGINNER_2'),
       },
       {
         score: 895,
         meshKey: 'LEVEL_EXPERT_7',
 
-        expectedInterval: MESH_CONFIGURATION.get('LEVEL_EXPERT_7'),
+        expectedInterval: CORE_MESH_CONFIGURATION.get('LEVEL_EXPERT_7'),
       },
       {
         score: 1024,
         meshKey: 'LEVEL_EXPERT_8',
 
-        expectedInterval: MESH_CONFIGURATION.get('LEVEL_EXPERT_8'),
+        expectedInterval: CORE_MESH_CONFIGURATION.get('LEVEL_EXPERT_8'),
       },
     ].forEach(({ score, meshKey, expectedInterval }) => {
       it(`returns the interval ${JSON.stringify(expectedInterval)} of key ${meshKey} when score is ${score}`, function () {

--- a/api/tests/tooling/domain-builder/factory/build-v3-certification-course-details-for-administration.js
+++ b/api/tests/tooling/domain-builder/factory/build-v3-certification-course-details-for-administration.js
@@ -11,6 +11,7 @@ export const buildV3CertificationCourseDetailsForAdministration = ({
   abortReason,
   pixScore,
   reachedMeshIndex,
+  eduV3ExternalJuryResult,
   numberOfChallenges,
   certificationFramework,
 }) => {
@@ -24,6 +25,7 @@ export const buildV3CertificationCourseDetailsForAdministration = ({
     abortReason,
     pixScore,
     reachedMeshIndex,
+    eduV3ExternalJuryResult,
     certificationChallengesForAdministration,
     numberOfChallenges,
     certificationFramework,

--- a/api/tests/tooling/domain-builder/factory/certification/session-management/build-jury-certification-summary.js
+++ b/api/tests/tooling/domain-builder/factory/certification/session-management/build-jury-certification-summary.js
@@ -1,5 +1,5 @@
-import { JuryCertificationSummary } from '../../../../src/certification/session-management/domain/read-models/JuryCertificationSummary.js';
-import { AssessmentResult } from '../../../../src/shared/domain/models/AssessmentResult.js';
+import { JuryCertificationSummary } from '../../../../../../src/certification/session-management/domain/read-models/JuryCertificationSummary.js';
+import { AssessmentResult } from '../../../../../../src/shared/domain/models/AssessmentResult.js';
 
 const buildJuryCertificationSummary = function ({
   id = 123,
@@ -14,6 +14,7 @@ const buildJuryCertificationSummary = function ({
   abortReason = null,
   isPublished = true,
   isEndedByInvigilator = false,
+  eduV3ExternalJuryResult = null,
   certificationIssueReports = [],
   certificationFramework = null,
 } = {}) {
@@ -30,6 +31,7 @@ const buildJuryCertificationSummary = function ({
     abortReason,
     isPublished,
     isEndedByInvigilator,
+    eduV3ExternalJuryResult,
     certificationIssueReports,
     certificationFramework,
   });

--- a/api/tests/tooling/domain-builder/factory/certification/session-management/build-jury-certification.js
+++ b/api/tests/tooling/domain-builder/factory/certification/session-management/build-jury-certification.js
@@ -1,8 +1,11 @@
-import { JuryCertification } from '../../../../src/certification/session-management/domain/models/JuryCertification.js';
-import { AlgorithmEngineVersion } from '../../../../src/certification/shared/domain/models/AlgorithmEngineVersion.js';
-import { JuryComment, JuryCommentContexts } from '../../../../src/certification/shared/domain/models/JuryComment.js';
-import { buildCertificationIssueReport } from './build-certification-issue-report.js';
-import { buildCompetenceMark } from './build-competence-mark.js';
+import { JuryCertification } from '../../../../../../src/certification/session-management/domain/models/JuryCertification.js';
+import { AlgorithmEngineVersion } from '../../../../../../src/certification/shared/domain/models/AlgorithmEngineVersion.js';
+import {
+  JuryComment,
+  JuryCommentContexts,
+} from '../../../../../../src/certification/shared/domain/models/JuryComment.js';
+import { buildCertificationIssueReport } from '../../build-certification-issue-report.js';
+import { buildCompetenceMark } from '../../build-competence-mark.js';
 
 const buildJuryCertification = function ({
   certificationCourseId = 123,
@@ -24,6 +27,7 @@ const buildJuryCertification = function ({
   completedAt = new Date('2020-02-01'),
   pixScore = 55,
   reachedMeshIndex = 5,
+  eduV3ExternalJuryResult = null,
   juryId = 66,
   commentForCandidate = 'comment candidate',
   commentForOrganization = 'comment organization',
@@ -56,6 +60,7 @@ const buildJuryCertification = function ({
     completedAt,
     pixScore,
     reachedMeshIndex,
+    eduV3ExternalJuryResult,
     juryId,
     commentForCandidate: new JuryComment({
       commentByAutoJury,

--- a/api/tests/tooling/domain-builder/factory/certification/session-management/index.js
+++ b/api/tests/tooling/domain-builder/factory/certification/session-management/index.js
@@ -3,6 +3,7 @@ import { buildCertificationCandidate } from './build-certification-candidate.js'
 import { buildCertificationCourse } from './build-certification-course.js';
 import { buildCertificationDetails } from './build-certification-details.js';
 import { buildCertificationSessionComplementaryCertification } from './build-certification-session-complementary-certification.js';
+import { buildJuryCertification } from './build-jury-certification.js';
 import { buildJuryCertificationSummary } from './build-jury-certification-summary.js';
 import { buildJurySessionCounters } from './build-jury-session-counters.js';
 import { buildSession } from './build-session.js';
@@ -14,8 +15,9 @@ export const builders = {
   buildCertificationCourse,
   buildCertificationDetails,
   buildCertificationSessionComplementaryCertification,
+  buildJuryCertification,
+  buildJuryCertificationSummary,
   buildJurySessionCounters,
   buildSessionManagement,
   buildSession,
-  buildJuryCertificationSummary,
 };

--- a/api/tests/tooling/domain-builder/factory/certification/session-management/index.js
+++ b/api/tests/tooling/domain-builder/factory/certification/session-management/index.js
@@ -3,6 +3,7 @@ import { buildCertificationCandidate } from './build-certification-candidate.js'
 import { buildCertificationCourse } from './build-certification-course.js';
 import { buildCertificationDetails } from './build-certification-details.js';
 import { buildCertificationSessionComplementaryCertification } from './build-certification-session-complementary-certification.js';
+import { buildJuryCertificationSummary } from './build-jury-certification-summary.js';
 import { buildJurySessionCounters } from './build-jury-session-counters.js';
 import { buildSession } from './build-session.js';
 import { buildSessionManagement } from './build-session-management.js';
@@ -16,4 +17,5 @@ export const builders = {
   buildJurySessionCounters,
   buildSessionManagement,
   buildSession,
+  buildJuryCertificationSummary,
 };

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -96,7 +96,6 @@ import { buildFlashAlgorithmConfiguration } from './build-flash-algorithm-config
 import { buildFramework } from './build-framework.js';
 import { buildHabilitation } from './build-habilitation.js';
 import { buildHint } from './build-hint.js';
-import { buildJuryCertification } from './build-jury-certification.js';
 import { buildJurySession } from './build-jury-session.js';
 import { buildKnowledgeElement, buildKnowledgeElementSnapshot } from './build-knowledge-element.js';
 import { buildLearningContent } from './build-learning-content.js';
@@ -212,6 +211,7 @@ import { buildCertificationResult as parcoursupCertificationResult } from './cer
 import { buildCompetence as parcoursupCompetence } from './certification/results/parcoursup/build-competence.js';
 import { buildParcoursupCertificationLevel } from './certification/results/parcoursup/build-parcoursup-certification-level.js';
 import { buildCertificationDetails } from './certification/session-management/build-certification-details.js';
+import { buildJuryCertification } from './certification/session-management/build-jury-certification.js';
 import { builders as sessionManagementBuilders } from './certification/session-management/index.js';
 import { buildCompetenceForScoring } from './certification/shared/build-competence-for-scoring.js';
 import { buildComplementaryCertification as buildSharedComplementaryCertification } from './certification/shared/build-complementary-certification.js';

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -97,7 +97,6 @@ import { buildFramework } from './build-framework.js';
 import { buildHabilitation } from './build-habilitation.js';
 import { buildHint } from './build-hint.js';
 import { buildJuryCertification } from './build-jury-certification.js';
-import { buildJuryCertificationSummary } from './build-jury-certification-summary.js';
 import { buildJurySession } from './build-jury-session.js';
 import { buildKnowledgeElement, buildKnowledgeElementSnapshot } from './build-knowledge-element.js';
 import { buildLearningContent } from './build-learning-content.js';
@@ -456,7 +455,6 @@ export {
   buildFramework,
   buildHint,
   buildJuryCertification,
-  buildJuryCertificationSummary,
   buildJurySession,
   buildKnowledgeElement,
   buildKnowledgeElementSnapshot,

--- a/api/tests/unit/domain/models/JuryCertification_test.js
+++ b/api/tests/unit/domain/models/JuryCertification_test.js
@@ -1,4 +1,6 @@
 import { JuryCertification } from '../../../../src/certification/session-management/domain/models/JuryCertification.js';
+import { PIX_PLUS_EDU_EXTERNAL_LEVELS } from '../../../../src/certification/shared/domain/constants/mesh-configuration.js';
+import { AlgorithmEngineVersion } from '../../../../src/certification/shared/domain/models/AlgorithmEngineVersion.js';
 import { Frameworks } from '../../../../src/certification/shared/domain/models/Frameworks.js';
 import { AutoJuryCommentKeys } from '../../../../src/certification/shared/domain/models/JuryComment.js';
 import { domainBuilder, expect } from '../../../test-helper.js';
@@ -80,7 +82,7 @@ describe('Unit | Domain | Models | JuryCertification', function () {
 
       // then
       const expectedCompetenceMarks = competenceMarkDTOs.map(domainBuilder.buildCompetenceMark);
-      const expectedJuryCertification = domainBuilder.buildJuryCertification({
+      const expectedJuryCertification = domainBuilder.certification.sessionManagement.buildJuryCertification({
         certificationCourseId: 123,
         sessionId: 456,
         userId: 789,
@@ -145,7 +147,7 @@ describe('Unit | Domain | Models | JuryCertification', function () {
 
       // then
       const expectedCompetenceMarks = competenceMarkDTOs.map(domainBuilder.buildCompetenceMark);
-      const expectedJuryCertification = domainBuilder.buildJuryCertification({
+      const expectedJuryCertification = domainBuilder.certification.sessionManagement.buildJuryCertification({
         certificationCourseId: 123,
         sessionId: 456,
         userId: 789,
@@ -177,6 +179,145 @@ describe('Unit | Domain | Models | JuryCertification', function () {
         complementaryCertificationCourseResultWithExternal,
       });
       expect(juryCertification).to.deepEqualInstance(expectedJuryCertification);
+    });
+  });
+
+  describe('#get reachedResultKey', function () {
+    context('when certification is not v3', function () {
+      it('returns the certification framework label followed by NONE', function () {
+        const juryCertificationSummaryV1 = domainBuilder.certification.sessionManagement.buildJuryCertification({
+          version: AlgorithmEngineVersion.V1,
+          certificationFramework: Frameworks.CORE,
+        });
+        const juryCertificationSummaryV2 = domainBuilder.certification.sessionManagement.buildJuryCertification({
+          version: AlgorithmEngineVersion.V2,
+          certificationFramework: Frameworks.EDU_1ER_DEGRE,
+        });
+
+        const reachedResultKeyV1 = juryCertificationSummaryV1.reachedResultKey;
+        const reachedResultKeyV2 = juryCertificationSummaryV2.reachedResultKey;
+
+        expect(reachedResultKeyV1).to.equal('CORE.NONE');
+        expect(reachedResultKeyV2).to.equal('EDU_1ER_DEGRE.NONE');
+      });
+    });
+
+    context('when certification is v3', function () {
+      context('CORE', function () {
+        [
+          { reachedMeshIndex: null, expectedReachedResultKey: 'CORE.BELOW_MINIMUM' },
+          { reachedMeshIndex: 0, expectedReachedResultKey: 'CORE.0' },
+          { reachedMeshIndex: 1, expectedReachedResultKey: 'CORE.1' },
+          { reachedMeshIndex: 2, expectedReachedResultKey: 'CORE.2' },
+          { reachedMeshIndex: 3, expectedReachedResultKey: 'CORE.3' },
+          { reachedMeshIndex: 4, expectedReachedResultKey: 'CORE.4' },
+          { reachedMeshIndex: 5, expectedReachedResultKey: 'CORE.5' },
+          { reachedMeshIndex: 6, expectedReachedResultKey: 'CORE.6' },
+          { reachedMeshIndex: 7, expectedReachedResultKey: 'CORE.7' },
+          { reachedMeshIndex: 8, expectedReachedResultKey: 'CORE.8' },
+        ].forEach(({ reachedMeshIndex, expectedReachedResultKey }) => {
+          context(`when reachedMeshIndex is ${reachedMeshIndex}`, function () {
+            it(`returns ${expectedReachedResultKey}`, function () {
+              const juryCertificationSummary = domainBuilder.certification.sessionManagement.buildJuryCertification({
+                certificationFramework: Frameworks.CORE,
+                version: AlgorithmEngineVersion.V3,
+                reachedMeshIndex,
+              });
+
+              const reachedResultKey = juryCertificationSummary.reachedResultKey;
+
+              expect(reachedResultKey).to.equal(expectedReachedResultKey);
+            });
+          });
+        });
+      });
+
+      context('EDU', function () {
+        [
+          {
+            reachedMeshIndex: null,
+            eduV3ExternalJuryResult: null,
+            expectedReachedResultKey: 'EDU_1ER_DEGRE.BELOW_MINIMUM',
+          },
+          { reachedMeshIndex: 0, eduV3ExternalJuryResult: null, expectedReachedResultKey: 'EDU_1ER_DEGRE.0' },
+          {
+            reachedMeshIndex: 0,
+            eduV3ExternalJuryResult: PIX_PLUS_EDU_EXTERNAL_LEVELS.ADVANCED,
+            expectedReachedResultKey: 'EDU_1ER_DEGRE.ADVANCED',
+          },
+          {
+            reachedMeshIndex: 0,
+            eduV3ExternalJuryResult: PIX_PLUS_EDU_EXTERNAL_LEVELS.EXPERT,
+            expectedReachedResultKey: 'EDU_1ER_DEGRE.EXPERT',
+          },
+        ].forEach(({ reachedMeshIndex, eduV3ExternalJuryResult, expectedReachedResultKey }) => {
+          context(
+            `when reachedMeshIndex is ${reachedMeshIndex} and eduV3ExternalJuryResult is ${eduV3ExternalJuryResult}`,
+            function () {
+              it(`returns ${expectedReachedResultKey}`, function () {
+                const juryCertificationSummary = domainBuilder.certification.sessionManagement.buildJuryCertification({
+                  certificationFramework: Frameworks.EDU_1ER_DEGRE,
+                  version: AlgorithmEngineVersion.V3,
+                  eduV3ExternalJuryResult,
+                  reachedMeshIndex,
+                });
+
+                const reachedResultKey = juryCertificationSummary.reachedResultKey;
+
+                expect(reachedResultKey).to.equal(expectedReachedResultKey);
+              });
+            },
+          );
+        });
+      });
+
+      context('DROIT', function () {
+        [
+          {
+            reachedMeshIndex: null,
+            expectedReachedResultKey: 'DROIT.BELOW_MINIMUM',
+          },
+          { reachedMeshIndex: 0, expectedReachedResultKey: 'DROIT.0' },
+        ].forEach(({ reachedMeshIndex, expectedReachedResultKey }) => {
+          context(`when reachedMeshIndex is ${reachedMeshIndex}`, function () {
+            it(`returns ${expectedReachedResultKey}`, function () {
+              const juryCertificationSummary = domainBuilder.certification.sessionManagement.buildJuryCertification({
+                certificationFramework: Frameworks.DROIT,
+                version: AlgorithmEngineVersion.V3,
+                reachedMeshIndex,
+              });
+
+              const reachedResultKey = juryCertificationSummary.reachedResultKey;
+
+              expect(reachedResultKey).to.equal(expectedReachedResultKey);
+            });
+          });
+        });
+      });
+
+      context('PRO SANTÉ', function () {
+        [
+          {
+            reachedMeshIndex: null,
+            expectedReachedResultKey: 'PRO_SANTE.BELOW_MINIMUM',
+          },
+          { reachedMeshIndex: 0, expectedReachedResultKey: 'PRO_SANTE.0' },
+        ].forEach(({ reachedMeshIndex, expectedReachedResultKey }) => {
+          context(`when reachedMeshIndex is ${reachedMeshIndex}`, function () {
+            it(`returns ${expectedReachedResultKey}`, function () {
+              const juryCertificationSummary = domainBuilder.certification.sessionManagement.buildJuryCertification({
+                certificationFramework: Frameworks.PRO_SANTE,
+                version: AlgorithmEngineVersion.V3,
+                reachedMeshIndex,
+              });
+
+              const reachedResultKey = juryCertificationSummary.reachedResultKey;
+
+              expect(reachedResultKey).to.equal(expectedReachedResultKey);
+            });
+          });
+        });
+      });
     });
   });
 });

--- a/api/tests/unit/domain/models/JuryCertification_test.js
+++ b/api/tests/unit/domain/models/JuryCertification_test.js
@@ -30,6 +30,7 @@ describe('Unit | Domain | Models | JuryCertification', function () {
         juryId: 1,
         pixScore: 555,
         reachedMeshIndex: 5,
+        eduV3ExternalJuryResult: null,
         commentForCandidate: 'coucou',
         commentForOrganization: 'comment',
         commentByJury: 'ça va',


### PR DESCRIPTION
## 🌱 Problème

Pour les certifications Pix+ Edu v3 nous devons trouver un moyen d'afficher le **niveau atteint** par le candidat lors du **volet externe**.

## 🐣 Proposition

- C'est maintenant le back qui a l'entière responsabilité de fournir la clé du niveau atteint pour le référentiel de la certification passée.
- Nous utilisons la nouvelle colonne `eduV3ExternalJuryResult` de la table `assessment-results` pour fournir le niveau du volet externe Pix+ Edu v3.

## 🌷 Remarques

Le front n'a maintenant plus besoin de connaître le "mesh index" atteint. 🤌 

## 🐝 Pour tester

Sur [Admin en RA](https://admin-pr15746.review.pix.fr/), aller voir la session Pix+ Edu v3 et constater l'affichage du niveau "Expert".

E2E OK ✅ 
