### PR TITLE
[TECH] Utilise la quête du blueprint plutôt que son attribut `content` (PIX-22204).

### DIFF
--- a/admin/app/components/combined-course-blueprints/details.gjs
+++ b/admin/app/components/combined-course-blueprints/details.gjs
@@ -59,6 +59,12 @@ export default class Details extends Component {
                 {{formatDate @model.createdAt}}
               </DescriptionList.Item>
 
+              <DescriptionList.Divider />
+
+              <DescriptionList.Item @label={{t "components.combined-course-blueprints.labels.attestation"}}>
+                <SafeMarkdownToHtml @markdown={{@model.attestationKey}} />
+              </DescriptionList.Item>
+
               {{#if @model.description}}
                 <DescriptionList.Divider />
 
@@ -74,6 +80,7 @@ export default class Details extends Component {
                 </DescriptionList.Item>
                 <DescriptionList.Divider />
               {{/if}}
+
             </DescriptionList>
             <div class="combined-course-blueprint__content">
               {{#each @model.content as |requirement|}}

--- a/admin/tests/integration/components/combined-course-blueprints/details-test.gjs
+++ b/admin/tests/integration/components/combined-course-blueprints/details-test.gjs
@@ -21,6 +21,7 @@ module('Integration | Component | CombinedCourseBlueprints::Details', function (
       name: 'Parcours apprenant',
       description: 'Mon super parcours apprenant',
       illustration: 'http://pix.fr/mon-illu.png',
+      attestationKey: 'SIXTH_GRADE',
       content: [
         { type: 'module', value: 'abc-123' },
         { type: 'evaluation', value: 123 },
@@ -35,6 +36,7 @@ module('Integration | Component | CombinedCourseBlueprints::Details', function (
     assert.ok(screen.getByRole('heading', { name: 'Modèle de parcours apprenant' }));
     assert.ok(screen.getByText('Parcours apprenant'));
     assert.ok(screen.getByText('25/12/2025'));
+    assert.ok(screen.getByText('SIXTH_GRADE'));
     assert.ok(screen.getByText('Mon super parcours apprenant'));
     assert.ok(screen.getByText('Module - abc-123', { exact: false }));
     assert.ok(screen.getByText('Profil cible - 123', { exact: false }));

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -562,6 +562,7 @@
         "targetProfile": "Target profile"
       },
       "labels": {
+        "attestation": "Attestation",
         "created-at": "Date de création",
         "description": " Description",
         "illustration": "Illustration",

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -569,6 +569,7 @@
         "targetProfile": "Profil Cible"
       },
       "labels": {
+        "attestation": "Attestation",
         "created-at": "Date de création",
         "description": "Description",
         "illustration": "Illustration",

--- a/api/db/database-builder/factory/build-combined-course-blueprint.js
+++ b/api/db/database-builder/factory/build-combined-course-blueprint.js
@@ -13,7 +13,6 @@ const buildCombinedCourseBlueprint = function ({
   illustration = 'images/illustration.svg',
   createdAt = new Date(),
   updatedAt,
-  content = [],
   questId,
 } = {}) {
   const targetProfileId = buildTargetProfile().id;
@@ -21,7 +20,12 @@ const buildCombinedCourseBlueprint = function ({
     ? buildQuest({
         rewardType: null,
         rewardId: null,
-        successRequirements: [CombinedCourseBlueprint.buildRequirementForCombinedCourse({ targetProfileId }).toDTO()],
+        successRequirements: [
+          CombinedCourseBlueprint.buildRequirementForCombinedCourse({ targetProfileId }).toDTO(),
+          CombinedCourseBlueprint.buildRequirementForCombinedCourse({
+            moduleId: 'eeeb4951-6f38-4467-a4ba-0c85ed71321a',
+          }).toDTO(),
+        ],
       }).id
     : questId;
 
@@ -33,7 +37,6 @@ const buildCombinedCourseBlueprint = function ({
     illustration,
     createdAt,
     updatedAt: updatedAt ?? createdAt,
-    content: JSON.stringify(content),
     questId,
   };
 

--- a/api/db/seeds/data/team-prescription/build-combined-courses.js
+++ b/api/db/seeds/data/team-prescription/build-combined-courses.js
@@ -1,5 +1,4 @@
 import { CampaignParticipationStatuses } from '../../../../src/prescription/shared/domain/constants.js';
-import { CombinedCourseBlueprint } from '../../../../src/quest/domain/models/CombinedCourseBlueprint.js';
 import { OrganizationLearnerParticipationTypes } from '../../../../src/quest/domain/models/OrganizationLearnerParticipation.js';
 import { Assessment } from '../../../../src/shared/domain/models/Assessment.js';
 import { buildCombinedCourseBlueprint } from '../../../database-builder/factory/build-combined-course-blueprint.js';
@@ -187,16 +186,10 @@ const buildCombinixQuest = (databaseBuilder, combinedCourseData) => {
   });
 };
 
-export const buildCombinedCourseBlueprints = (databaseBuilder) => {
-  const targetProfileId = databaseBuilder.factory.buildTargetProfile({
-    name: 'Mon profil cible de parcours combiné',
-  }).id;
-  const moduleShortId = '27d6ca4f';
-
+export const buildCombinedCourseBlueprints = () => {
   const combinedCourseBlueprintId = buildCombinedCourseBlueprint({
     name: 'Mon parcours combiné 2',
     internalName: 'Mon schéma de parcours combiné 2',
-    content: CombinedCourseBlueprint.buildContentItems([{ targetProfileId }, { moduleShortId }]),
     illustration: 'https://assets.pix.org/combined-courses/illu_ia.svg',
     description:
       "Un parcours pour découvrir l’essentiel sur l'intelligence artificielle : comprendre sa définition, ses domaines d'application, comment elle fonctionne, ainsi que ses enjeux, notamment en matière d'impact environnemental.",

--- a/api/src/quest/application/combined-course-blueprint-controller.js
+++ b/api/src/quest/application/combined-course-blueprint-controller.js
@@ -1,4 +1,5 @@
 import { usecases } from '../domain/usecases/index.js';
+import * as adminCombinedCourseBlueprintSerializer from '../infrastructure/serializers/admin-combined-course-blueprint-serializer.js';
 import * as combinedCourseBlueprintOrganizationSerializer from '../infrastructure/serializers/combined-course-blueprint-organization-serializer.js';
 import * as combinedCourseBlueprintSerializer from '../infrastructure/serializers/combined-course-blueprint-serializer.js';
 
@@ -7,19 +8,19 @@ export const findAll = async (request, _, dependencies = { combinedCourseBluepri
   return dependencies.combinedCourseBlueprintSerializer.serialize(combinedCourseBlueprints);
 };
 
-export const save = async (request, h, dependencies = { combinedCourseBlueprintSerializer }) => {
-  const adminCombinedCourseBlueprint = await dependencies.combinedCourseBlueprintSerializer.deserialize(
+export const save = async (request, h, dependencies = { adminCombinedCourseBlueprintSerializer }) => {
+  const adminCombinedCourseBlueprint = await dependencies.adminCombinedCourseBlueprintSerializer.deserialize(
     request.payload,
   );
   const combinedCourseBlueprint = await usecases.createCombinedCourseBlueprint({
     adminCombinedCourseBlueprint,
   });
-  return h.response(dependencies.combinedCourseBlueprintSerializer.serialize(combinedCourseBlueprint)).created();
+  return h.response(dependencies.adminCombinedCourseBlueprintSerializer.serialize(combinedCourseBlueprint)).created();
 };
 
-export const getById = async (request, _, dependencies = { combinedCourseBlueprintSerializer }) => {
+export const getById = async (request, _, dependencies = { adminCombinedCourseBlueprintSerializer }) => {
   const combinedCourseBlueprint = await usecases.getCombinedCourseBlueprintById({ id: request.params.blueprintId });
-  return dependencies.combinedCourseBlueprintSerializer.serialize(combinedCourseBlueprint);
+  return dependencies.adminCombinedCourseBlueprintSerializer.serialize(combinedCourseBlueprint);
 };
 
 export const detachOrganization = async (request, h) => {

--- a/api/src/quest/application/combined-course-blueprint-controller.js
+++ b/api/src/quest/application/combined-course-blueprint-controller.js
@@ -8,11 +8,13 @@ export const findAll = async (request, _, dependencies = { combinedCourseBluepri
 };
 
 export const save = async (request, h, dependencies = { combinedCourseBlueprintSerializer }) => {
-  const { combinedCourseBlueprint, attestationKey } = await dependencies.combinedCourseBlueprintSerializer.deserialize(
+  const adminCombinedCourseBlueprint = await dependencies.combinedCourseBlueprintSerializer.deserialize(
     request.payload,
   );
-  const createdBlueprint = await usecases.createCombinedCourseBlueprint({ combinedCourseBlueprint, attestationKey });
-  return h.response(dependencies.combinedCourseBlueprintSerializer.serialize(createdBlueprint)).created();
+  const combinedCourseBlueprint = await usecases.createCombinedCourseBlueprint({
+    adminCombinedCourseBlueprint,
+  });
+  return h.response(dependencies.combinedCourseBlueprintSerializer.serialize(combinedCourseBlueprint)).created();
 };
 
 export const getById = async (request, _, dependencies = { combinedCourseBlueprintSerializer }) => {

--- a/api/src/quest/application/combined-course-blueprint-controller.js
+++ b/api/src/quest/application/combined-course-blueprint-controller.js
@@ -3,12 +3,12 @@ import * as adminCombinedCourseBlueprintSerializer from '../infrastructure/seria
 import * as combinedCourseBlueprintOrganizationSerializer from '../infrastructure/serializers/combined-course-blueprint-organization-serializer.js';
 import * as combinedCourseBlueprintSerializer from '../infrastructure/serializers/combined-course-blueprint-serializer.js';
 
-export const findAll = async (request, _, dependencies = { combinedCourseBlueprintSerializer }) => {
+const findAll = async (request, _, dependencies = { combinedCourseBlueprintSerializer }) => {
   const combinedCourseBlueprints = await usecases.findCombinedCourseBlueprints();
   return dependencies.combinedCourseBlueprintSerializer.serialize(combinedCourseBlueprints);
 };
 
-export const save = async (request, h, dependencies = { adminCombinedCourseBlueprintSerializer }) => {
+const save = async (request, h, dependencies = { adminCombinedCourseBlueprintSerializer }) => {
   const adminCombinedCourseBlueprint = await dependencies.adminCombinedCourseBlueprintSerializer.deserialize(
     request.payload,
   );
@@ -18,12 +18,12 @@ export const save = async (request, h, dependencies = { adminCombinedCourseBluep
   return h.response(dependencies.adminCombinedCourseBlueprintSerializer.serialize(combinedCourseBlueprint)).created();
 };
 
-export const getById = async (request, _, dependencies = { adminCombinedCourseBlueprintSerializer }) => {
+const getById = async (request, _, dependencies = { adminCombinedCourseBlueprintSerializer }) => {
   const combinedCourseBlueprint = await usecases.getCombinedCourseBlueprintById({ id: request.params.blueprintId });
   return dependencies.adminCombinedCourseBlueprintSerializer.serialize(combinedCourseBlueprint);
 };
 
-export const detachOrganization = async (request, h) => {
+const detachOrganization = async (request, h) => {
   await usecases.detachOrganizationFromCombinedCourseBlueprint({
     combinedCourseBlueprintId: request.params.blueprintId,
     organizationId: request.params.organizationId,
@@ -31,11 +31,7 @@ export const detachOrganization = async (request, h) => {
   return h.response().code(204);
 };
 
-export const attachOrganizations = async (
-  request,
-  h,
-  dependencies = { combinedCourseBlueprintOrganizationSerializer },
-) => {
+const attachOrganizations = async (request, h, dependencies = { combinedCourseBlueprintOrganizationSerializer }) => {
   const combinedCourseBlueprintId = request.params.blueprintId;
   const results = await usecases.attachOrganizationsToCombinedCourseBlueprint({
     combinedCourseBlueprintId,
@@ -48,9 +44,20 @@ export const attachOrganizations = async (
     .code(201);
 };
 
-export const findByOrganizationId = async (request, _, dependencies = { combinedCourseBlueprintSerializer }) => {
+const findByOrganizationId = async (request, _, dependencies = { combinedCourseBlueprintSerializer }) => {
   const combinedCourseBlueprint = await usecases.findByOrganizationId({
     organizationId: request.params.organizationId,
   });
   return dependencies.combinedCourseBlueprintSerializer.serialize(combinedCourseBlueprint);
 };
+
+const combinedCourseBlueprintController = {
+  findAll,
+  save,
+  getById,
+  detachOrganization,
+  attachOrganizations,
+  findByOrganizationId,
+};
+
+export { combinedCourseBlueprintController };

--- a/api/src/quest/application/combined-course-blueprint-route.js
+++ b/api/src/quest/application/combined-course-blueprint-route.js
@@ -3,7 +3,7 @@ import Joi from 'joi';
 import { securityPreHandlers } from '../../shared/application/security-pre-handlers.js';
 import { identifiersType } from '../../shared/domain/types/identifiers-type.js';
 import { contentSchema } from '../domain/models/AdminCombinedCourseBlueprint.js';
-import * as combinedCourseBlueprintController from './combined-course-blueprint-controller.js';
+import { combinedCourseBlueprintController } from './combined-course-blueprint-controller.js';
 
 const register = async function (server) {
   server.route([

--- a/api/src/quest/application/combined-course-blueprint-route.js
+++ b/api/src/quest/application/combined-course-blueprint-route.js
@@ -2,7 +2,7 @@ import Joi from 'joi';
 
 import { securityPreHandlers } from '../../shared/application/security-pre-handlers.js';
 import { identifiersType } from '../../shared/domain/types/identifiers-type.js';
-import { contentSchema } from '../domain/models/CombinedCourseBlueprint.js';
+import { contentSchema } from '../domain/models/AdminCombinedCourseBlueprint.js';
 import * as combinedCourseBlueprintController from './combined-course-blueprint-controller.js';
 
 const register = async function (server) {

--- a/api/src/quest/domain/models/AdminCombinedCourseBlueprint.js
+++ b/api/src/quest/domain/models/AdminCombinedCourseBlueprint.js
@@ -1,0 +1,82 @@
+import Joi from 'joi';
+
+import { REQUIREMENT_TYPES } from './Quest.js';
+
+export class AdminCombinedCourseBlueprint {
+  constructor({
+    id,
+    name,
+    internalName,
+    description,
+    illustration,
+    content,
+    attestationKey,
+    createdAt,
+    updatedAt,
+    organizationIds = [],
+  }) {
+    this.id = id;
+    this.name = name;
+    this.internalName = internalName;
+    this.description = description;
+    this.illustration = illustration;
+    this.organizationIds = organizationIds;
+    this.content = content;
+    this.attestationKey = attestationKey;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
+  }
+
+  static buildContentItems(items) {
+    const data = items.map(({ moduleShortId, targetProfileId }) => {
+      return moduleShortId
+        ? { type: ADMIN_COMBINED_COURSE_BLUEPRINT_ITEMS.MODULE, value: moduleShortId }
+        : { type: ADMIN_COMBINED_COURSE_BLUEPRINT_ITEMS.EVALUATION, value: targetProfileId };
+    });
+    return Joi.attempt(data, contentSchema);
+  }
+
+  static buildFromBlueprint({ combinedCourseBlueprint, modulesById, attestationKey }) {
+    const items = combinedCourseBlueprint.quest.successRequirements.map((requirement) => {
+      if (requirement.requirement_type === REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS) {
+        return { targetProfileId: requirement.data.targetProfileId.data };
+      } else if (requirement.requirement_type === REQUIREMENT_TYPES.OBJECT.PASSAGES) {
+        const module = modulesById[requirement.data.moduleId.data];
+        return { moduleShortId: module?.[0].shortId };
+      }
+    });
+
+    const content = AdminCombinedCourseBlueprint.buildContentItems(items);
+    return new AdminCombinedCourseBlueprint({ ...combinedCourseBlueprint, content, attestationKey });
+  }
+}
+
+export const ADMIN_COMBINED_COURSE_BLUEPRINT_ITEMS = {
+  MODULE: 'module',
+  EVALUATION: 'evaluation',
+};
+
+export const contentSchema = Joi.array()
+  .items(
+    Joi.object({
+      type: Joi.string()
+        .valid(ADMIN_COMBINED_COURSE_BLUEPRINT_ITEMS.EVALUATION, ADMIN_COMBINED_COURSE_BLUEPRINT_ITEMS.MODULE)
+        .required(),
+      value: Joi.alternatives()
+        .conditional('type', {
+          switch: [
+            {
+              is: ADMIN_COMBINED_COURSE_BLUEPRINT_ITEMS.EVALUATION,
+              then: Joi.number().integer(),
+            },
+            {
+              is: ADMIN_COMBINED_COURSE_BLUEPRINT_ITEMS.MODULE,
+              then: Joi.string(),
+            },
+          ],
+        })
+        .required(),
+    }),
+  )
+  .required()
+  .strict();

--- a/api/src/quest/domain/models/CombinedCourseBlueprint.js
+++ b/api/src/quest/domain/models/CombinedCourseBlueprint.js
@@ -1,6 +1,5 @@
-import Joi from 'joi';
-
 import { CampaignParticipationStatuses } from '../../../prescription/shared/domain/constants.js';
+import { ADMIN_COMBINED_COURSE_BLUEPRINT_ITEMS } from './AdminCombinedCourseBlueprint.js';
 import { CombinedCourse } from './CombinedCourse.js';
 import { CRITERION_COMPARISONS, Quest, REQUIREMENT_COMPARISONS, REQUIREMENT_TYPES } from './Quest.js';
 import { buildRequirement } from './Requirement.js';
@@ -12,7 +11,6 @@ export class CombinedCourseBlueprint {
     internalName,
     description,
     illustration,
-    content,
     createdAt,
     updatedAt,
     organizationIds = [],
@@ -23,7 +21,6 @@ export class CombinedCourseBlueprint {
     this.internalName = internalName;
     this.description = description;
     this.illustration = illustration;
-    this.content = content;
     this.createdAt = createdAt;
     this.updatedAt = updatedAt;
     this.organizationIds = organizationIds;
@@ -62,7 +59,7 @@ export class CombinedCourseBlueprint {
     const createdAt = new Date();
 
     const quest = new Quest({
-      createdAt: createdAt,
+      createdAt,
       updatedAt: createdAt,
       rewardType: this.quest.rewardType,
       rewardId: this.quest.rewardId,
@@ -83,14 +80,14 @@ export class CombinedCourseBlueprint {
     );
   }
 
-  static buildWithQuest({ combinedCourseBlueprint, modulesByShortId, rewardId, rewardType }) {
-    const successRequirements = combinedCourseBlueprint.content.map((requirement) => {
-      if (requirement.type === COMBINED_COURSE_BLUEPRINT_ITEMS.EVALUATION) {
+  static buildWithQuest({ adminCombinedCourseBlueprint, modulesByShortId, rewardId, rewardType }) {
+    const successRequirements = adminCombinedCourseBlueprint.content.map((requirement) => {
+      if (requirement.type === ADMIN_COMBINED_COURSE_BLUEPRINT_ITEMS.EVALUATION) {
         const requirementTargetProfileId = requirement.value;
         return CombinedCourseBlueprint.buildRequirementForCombinedCourse({
           targetProfileId: requirementTargetProfileId,
         });
-      } else if (requirement.type === COMBINED_COURSE_BLUEPRINT_ITEMS.MODULE) {
+      } else if (requirement.type === ADMIN_COMBINED_COURSE_BLUEPRINT_ITEMS.MODULE) {
         const [module] = modulesByShortId[requirement.value];
         return CombinedCourseBlueprint.buildRequirementForCombinedCourse({
           moduleId: module.id,
@@ -101,8 +98,6 @@ export class CombinedCourseBlueprint {
     });
 
     const quest = new Quest({
-      createdAt: combinedCourseBlueprint.createdAt,
-      updatedAt: combinedCourseBlueprint.createdAt,
       rewardType,
       rewardId,
       eligibilityRequirements: [],
@@ -110,7 +105,7 @@ export class CombinedCourseBlueprint {
     });
 
     return new CombinedCourseBlueprint({
-      ...combinedCourseBlueprint,
+      ...adminCombinedCourseBlueprint,
       quest,
     });
   }
@@ -151,14 +146,6 @@ export class CombinedCourseBlueprint {
       });
     }
   }
-  static buildContentItems(items) {
-    const data = items.map(({ moduleShortId, targetProfileId }) => {
-      return moduleShortId
-        ? { type: COMBINED_COURSE_BLUEPRINT_ITEMS.MODULE, value: moduleShortId }
-        : { type: COMBINED_COURSE_BLUEPRINT_ITEMS.EVALUATION, value: targetProfileId };
-    });
-    return Joi.attempt(data, contentSchema);
-  }
 
   detachOrganization({ organizationId }) {
     this.organizationIds = this.organizationIds.filter((id) => id !== organizationId);
@@ -179,33 +166,3 @@ export class CombinedCourseBlueprint {
     return { duplicatedOrganizationIds, attachedOrganizationIds };
   }
 }
-
-export const COMBINED_COURSE_BLUEPRINT_ITEMS = {
-  MODULE: 'module',
-  EVALUATION: 'evaluation',
-};
-
-export const contentSchema = Joi.array()
-  .items(
-    Joi.object({
-      type: Joi.string()
-        .valid(COMBINED_COURSE_BLUEPRINT_ITEMS.EVALUATION, COMBINED_COURSE_BLUEPRINT_ITEMS.MODULE)
-        .required(),
-      value: Joi.alternatives()
-        .conditional('type', {
-          switch: [
-            {
-              is: COMBINED_COURSE_BLUEPRINT_ITEMS.EVALUATION,
-              then: Joi.number().integer(),
-            },
-            {
-              is: COMBINED_COURSE_BLUEPRINT_ITEMS.MODULE,
-              then: Joi.string(),
-            },
-          ],
-        })
-        .required(),
-    }),
-  )
-  .required()
-  .strict();

--- a/api/src/quest/domain/usecases/create-combined-course-blueprint.js
+++ b/api/src/quest/domain/usecases/create-combined-course-blueprint.js
@@ -1,32 +1,33 @@
 import _ from 'lodash';
 
-import { COMBINED_COURSE_BLUEPRINT_ITEMS, CombinedCourseBlueprint } from '../models/CombinedCourseBlueprint.js';
+import { ADMIN_COMBINED_COURSE_BLUEPRINT_ITEMS } from '../models/AdminCombinedCourseBlueprint.js';
+import { CombinedCourseBlueprint } from '../models/CombinedCourseBlueprint.js';
 
 export const createCombinedCourseBlueprint = async ({
-  attestationKey,
-  combinedCourseBlueprint,
+  adminCombinedCourseBlueprint,
   combinedCourseBlueprintRepository,
   targetProfileRepository,
   moduleRepository,
   rewardRepository,
 }) => {
-  // We are using content from the front-end before building quests
-  const targetProfileIds = combinedCourseBlueprint.content
-    .filter((item) => item.type === COMBINED_COURSE_BLUEPRINT_ITEMS.EVALUATION)
+  const targetProfileIds = adminCombinedCourseBlueprint.content
+    .filter((item) => item.type === ADMIN_COMBINED_COURSE_BLUEPRINT_ITEMS.EVALUATION)
     .map(({ value }) => value);
   await targetProfileRepository.findByIds({ ids: targetProfileIds });
 
-  const moduleShortIds = combinedCourseBlueprint.content
-    .filter((item) => item.type === COMBINED_COURSE_BLUEPRINT_ITEMS.MODULE)
+  const moduleShortIds = adminCombinedCourseBlueprint.content
+    .filter((item) => item.type === ADMIN_COMBINED_COURSE_BLUEPRINT_ITEMS.MODULE)
     .map(({ value }) => value);
   const modules = await moduleRepository.getByShortIds({ moduleShortIds });
   const modulesByShortId = _.groupBy(modules, 'shortId');
 
-  const reward = attestationKey ? await rewardRepository.getByAttestationKey({ key: attestationKey }) : null;
+  const reward = adminCombinedCourseBlueprint.attestationKey
+    ? await rewardRepository.getByAttestationKey({ key: adminCombinedCourseBlueprint.attestationKey })
+    : null;
 
   return combinedCourseBlueprintRepository.save({
     combinedCourseBlueprint: CombinedCourseBlueprint.buildWithQuest({
-      combinedCourseBlueprint,
+      adminCombinedCourseBlueprint,
       modulesByShortId,
       rewardId: reward?.id,
       rewardType: reward?.type,

--- a/api/src/quest/domain/usecases/get-combined-course-blueprint-by-id.js
+++ b/api/src/quest/domain/usecases/get-combined-course-blueprint-by-id.js
@@ -1,38 +1,32 @@
+import _ from 'lodash';
+
 import { NotFoundError } from '../../../shared/domain/errors.js';
-import { COMBINED_COURSE_BLUEPRINT_ITEMS } from '../models/CombinedCourseBlueprint.js';
+import { AdminCombinedCourseBlueprint } from '../models/AdminCombinedCourseBlueprint.js';
+import { REQUIREMENT_TYPES } from '../models/Quest.js';
 
 export const getCombinedCourseBlueprintById = async ({
   id,
   combinedCourseBlueprintRepository,
-  targetProfileRepository,
   moduleRepository,
+  attestationRepository,
 }) => {
-  const result = await combinedCourseBlueprintRepository.findById({ id });
-  if (!result) {
+  const combinedCourseBlueprint = await combinedCourseBlueprintRepository.findById({ id });
+  if (!combinedCourseBlueprint) {
     throw new NotFoundError('Combined course blueprint not found');
   }
 
-  const evaluationItemIds = result.content
-    .filter((item) => item.type === COMBINED_COURSE_BLUEPRINT_ITEMS.EVALUATION)
-    .map((item) => item.value);
-  const moduleItemShortIds = result.content
-    .filter((item) => item.type === COMBINED_COURSE_BLUEPRINT_ITEMS.MODULE)
-    .map((item) => item.value);
+  const moduleIds = combinedCourseBlueprint.quest.successRequirements
+    .filter((requirement) => requirement.requirement_type === REQUIREMENT_TYPES.OBJECT.PASSAGES)
+    .map((requirement) => requirement.data.moduleId.data);
 
-  const evaluationItems = await targetProfileRepository.findByIds({ ids: evaluationItemIds });
-  const moduleItems = await moduleRepository.getByShortIds({ moduleShortIds: moduleItemShortIds });
+  const modules = await moduleRepository.getByIds({ moduleIds });
+  const modulesById = _.groupBy(modules, 'id');
 
-  const evaluationMap = new Map(evaluationItems.map((item) => [item.id, item]));
+  const attestation = await attestationRepository.getByRewardId({ rewardId: combinedCourseBlueprint.quest.rewardId });
 
-  const moduleMap = new Map(moduleItems.map((item) => [item.shortId, item]));
-
-  result.content = result.content.map((item) => ({
-    ...item,
-    label:
-      item.type === COMBINED_COURSE_BLUEPRINT_ITEMS.EVALUATION
-        ? evaluationMap.get(item.value).name
-        : moduleMap.get(item.value).title,
-  }));
-
-  return result;
+  return AdminCombinedCourseBlueprint.buildFromBlueprint({
+    combinedCourseBlueprint,
+    modulesById,
+    attestationKey: attestation.key,
+  });
 };

--- a/api/src/quest/domain/usecases/get-combined-course-blueprint-by-id.js
+++ b/api/src/quest/domain/usecases/get-combined-course-blueprint-by-id.js
@@ -1,5 +1,3 @@
-import _ from 'lodash';
-
 import { NotFoundError } from '../../../shared/domain/errors.js';
 import { AdminCombinedCourseBlueprint } from '../models/AdminCombinedCourseBlueprint.js';
 import { REQUIREMENT_TYPES } from '../models/Quest.js';
@@ -20,7 +18,7 @@ export const getCombinedCourseBlueprintById = async ({
     .map((requirement) => requirement.data.moduleId.data);
 
   const modules = await moduleRepository.getByIds({ moduleIds });
-  const modulesById = _.groupBy(modules, 'id');
+  const modulesById = Object.groupBy(modules, ({ id }) => id);
 
   const attestation = await attestationRepository.getByRewardId({ rewardId: combinedCourseBlueprint.quest.rewardId });
 

--- a/api/src/quest/infrastructure/repositories/attestation-repository.js
+++ b/api/src/quest/infrastructure/repositories/attestation-repository.js
@@ -1,6 +1,7 @@
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { AlreadyExistingEntityError } from '../../../shared/domain/errors.js';
 import * as knexUtils from '../../../shared/infrastructure/utils/knex-utils.js';
+import { REWARD_TYPES } from '../../domain/constants.js';
 
 const ATTESTATION_KEY_UNIQUE_CONSTRAINT = 'attestations_key_unique';
 const DUPLICATE_ATTESTATION_KEY = 'DUPLICATE_ATTESTATION_KEY';
@@ -19,4 +20,8 @@ export const save = async ({ templateName, templateKey, templateFile, attestatio
       throw error;
     }
   });
+};
+
+export const getByRewardId = async ({ rewardId, rewardApi }) => {
+  return rewardApi.getByIdAndType({ rewardId, rewardType: REWARD_TYPES.ATTESTATION });
 };

--- a/api/src/quest/infrastructure/repositories/combined-course-blueprint-repository.js
+++ b/api/src/quest/infrastructure/repositories/combined-course-blueprint-repository.js
@@ -27,26 +27,30 @@ export async function save({ combinedCourseBlueprint }) {
 
   const questId = await questRepository.save({ quest: combinedCourseBlueprint.quest });
 
-  if (!combinedCourseBlueprint.id) {
-    const [insertedValues] = await knexConn('combined_course_blueprints')
-      .insert(_toDTO({ combinedCourseBlueprint, questId }))
-      .returning('*');
+  const blueprintToSave = {
+    id: combinedCourseBlueprint.id,
+    name: combinedCourseBlueprint.name,
+    internalName: combinedCourseBlueprint.internalName,
+    description: combinedCourseBlueprint.description,
+    illustration: combinedCourseBlueprint.illustration,
+    updatedAt: knexConn.fn.now(),
+    questId,
+  };
 
-    const quest = await questRepository.findById({ questId });
+  const createdBlueprint = await knexConn('combined_course_blueprints')
+    .insert(blueprintToSave)
+    .onConflict('id')
+    .merge(['updatedAt', 'name', 'internalName', 'description', 'illustration', 'questId'])
+    .returning('*');
 
-    return _toDomain(insertedValues, quest);
+  const doesCombinedCourseBlueprintExists = !!combinedCourseBlueprint.id;
+  if (doesCombinedCourseBlueprintExists) {
+    await updateShares({ combinedCourseBlueprint, knexConn });
   }
 
-  const [updatedValues] = await knexConn('combined_course_blueprints')
-    .update(_toDTO({ combinedCourseBlueprint, questId }))
-    .where({ id: combinedCourseBlueprint.id })
-    .returning('*');
-  await updateShares({ combinedCourseBlueprint, knexConn });
+  const quest = await questRepository.findById({ questId });
 
-  return _toDomain({
-    ...updatedValues,
-    organizationIds: combinedCourseBlueprint.organizationIds,
-  });
+  return _toDomain({ ...createdBlueprint[0], organizationIds: combinedCourseBlueprint.organizationIds }, quest);
 }
 
 async function updateShares({ combinedCourseBlueprint, knexConn }) {
@@ -112,20 +116,6 @@ export async function findByOrganizationId({ organizationId }) {
     .groupBy('combined_course_blueprints.id')
     .orderBy('combined_course_blueprints.id');
   return results.map((result) => _toDomain(result));
-}
-
-function _toDTO({ combinedCourseBlueprint, questId }) {
-  return {
-    id: combinedCourseBlueprint.id,
-    name: combinedCourseBlueprint.name,
-    internalName: combinedCourseBlueprint.internalName,
-    description: combinedCourseBlueprint.description,
-    illustration: combinedCourseBlueprint.illustration,
-    content: JSON.stringify(combinedCourseBlueprint.content),
-    createdAt: combinedCourseBlueprint.createdAt,
-    updatedAt: combinedCourseBlueprint.updatedAt,
-    questId,
-  };
 }
 
 function _toDomain(rawData, quest) {

--- a/api/src/quest/infrastructure/repositories/quest-repository.js
+++ b/api/src/quest/infrastructure/repositories/quest-repository.js
@@ -23,24 +23,30 @@ const findById = async ({ questId }) => {
   return new Quest(quest);
 };
 
-// envisager de mettre tableau vide en valeur par défaut des requirements si pas renseigné pour pas péter le code
-// ensuite
 const saveInBatch = async ({ quests }) => {
   const knexConn = DomainTransaction.getConnection();
 
   const chunks = chunk(quests, 10);
   const questIds = [];
   for (const chunk of chunks) {
-    const dtoToSaveInDB = chunk.map((quest) => {
-      const dto = quest.toDTO();
+    const questsToSave = chunk.map((quest) => {
       return {
-        ...dto,
-        eligibilityRequirements: quest.eligibilityRequirements ? JSON.stringify(dto.eligibilityRequirements) : [],
-        successRequirements: quest.successRequirements ? JSON.stringify(dto.successRequirements) : [],
-        updatedAt: new Date(),
+        id: quest.id,
+        updatedAt: knexConn.fn.now(),
+        rewardId: quest.rewardId,
+        rewardType: quest.rewardType,
+        eligibilityRequirements: quest.eligibilityRequirements
+          ? JSON.stringify(quest.toDTO().eligibilityRequirements)
+          : [],
+        successRequirements: quest.successRequirements ? JSON.stringify(quest.toDTO().successRequirements) : [],
       };
     });
-    const questsInserted = await knexConn('quests').insert(dtoToSaveInDB).onConflict('id').merge().returning('id');
+    const questsInserted = await knexConn('quests')
+      .insert(questsToSave)
+      .onConflict('id')
+      .merge(['updatedAt', 'rewardId', 'rewardType', 'eligibilityRequirements', 'successRequirements'])
+      .returning('id');
+
     questsInserted.map((quest) => questIds.push(quest.id));
   }
   return questIds;
@@ -48,15 +54,22 @@ const saveInBatch = async ({ quests }) => {
 
 const save = async ({ quest }) => {
   const knexConn = DomainTransaction.getConnection();
-  const dto = quest.toDTO();
 
-  const dtoToSaveInDB = {
-    ...dto,
-    eligibilityRequirements: quest.eligibilityRequirements ? JSON.stringify(dto.eligibilityRequirements) : [],
-    successRequirements: quest.successRequirements ? JSON.stringify(dto.successRequirements) : [],
-    updatedAt: new Date(),
+  const questToSave = {
+    id: quest.id,
+    updatedAt: knexConn.fn.now(),
+    rewardId: quest.rewardId,
+    rewardType: quest.rewardType,
+    eligibilityRequirements: quest.eligibilityRequirements ? JSON.stringify(quest.toDTO().eligibilityRequirements) : [],
+    successRequirements: quest.successRequirements ? JSON.stringify(quest.toDTO().successRequirements) : [],
   };
-  const result = await knexConn('quests').insert(dtoToSaveInDB).onConflict('id').merge().returning('id');
+
+  const result = await knexConn('quests')
+    .insert(questToSave)
+    .onConflict('id')
+    .merge(['updatedAt', 'rewardId', 'rewardType', 'eligibilityRequirements', 'successRequirements'])
+    .returning('id');
+
   return result[0].id;
 };
 

--- a/api/src/quest/infrastructure/serializers/admin-combined-course-blueprint-serializer.js
+++ b/api/src/quest/infrastructure/serializers/admin-combined-course-blueprint-serializer.js
@@ -1,0 +1,29 @@
+import jsonapiSerializer from 'jsonapi-serializer';
+
+import { AdminCombinedCourseBlueprint } from '../../domain/models/AdminCombinedCourseBlueprint.js';
+
+const { Deserializer, Serializer } = jsonapiSerializer;
+
+const serialize = function (adminCombinedCourseBlueprint) {
+  return new Serializer('combined-course-blueprints', {
+    attributes: [
+      'name',
+      'internalName',
+      'description',
+      'illustration',
+      'content',
+      'createdAt',
+      'updatedAt',
+      'attestationKey',
+    ],
+  }).serialize(adminCombinedCourseBlueprint);
+};
+
+const deserialize = async function (payload) {
+  const deserializedData = await new Deserializer({
+    keyForAttribute: 'camelCase',
+  }).deserialize(payload);
+  return new AdminCombinedCourseBlueprint(deserializedData);
+};
+
+export { deserialize, serialize };

--- a/api/src/quest/infrastructure/serializers/combined-course-blueprint-serializer.js
+++ b/api/src/quest/infrastructure/serializers/combined-course-blueprint-serializer.js
@@ -1,12 +1,21 @@
 import jsonapiSerializer from 'jsonapi-serializer';
 
-import { CombinedCourseBlueprint } from '../../domain/models/CombinedCourseBlueprint.js';
+import { AdminCombinedCourseBlueprint } from '../../domain/models/AdminCombinedCourseBlueprint.js';
 
 const { Deserializer, Serializer } = jsonapiSerializer;
 
 const serialize = function (combinedCourseBlueprint) {
   return new Serializer('combined-course-blueprints', {
-    attributes: ['name', 'internalName', 'description', 'illustration', 'content', 'createdAt', 'updatedAt'],
+    attributes: [
+      'name',
+      'internalName',
+      'description',
+      'illustration',
+      'content',
+      'createdAt',
+      'updatedAt',
+      'attestationKey',
+    ],
   }).serialize(combinedCourseBlueprint);
 };
 
@@ -14,10 +23,7 @@ const deserialize = async function (payload) {
   const deserializedData = await new Deserializer({
     keyForAttribute: 'camelCase',
   }).deserialize(payload);
-  return {
-    combinedCourseBlueprint: new CombinedCourseBlueprint(deserializedData),
-    attestationKey: deserializedData.attestationKey,
-  };
+  return new AdminCombinedCourseBlueprint(deserializedData);
 };
 
 export { deserialize, serialize };

--- a/api/src/quest/infrastructure/serializers/combined-course-blueprint-serializer.js
+++ b/api/src/quest/infrastructure/serializers/combined-course-blueprint-serializer.js
@@ -1,29 +1,11 @@
 import jsonapiSerializer from 'jsonapi-serializer';
 
-import { AdminCombinedCourseBlueprint } from '../../domain/models/AdminCombinedCourseBlueprint.js';
-
-const { Deserializer, Serializer } = jsonapiSerializer;
+const { Serializer } = jsonapiSerializer;
 
 const serialize = function (combinedCourseBlueprint) {
   return new Serializer('combined-course-blueprints', {
-    attributes: [
-      'name',
-      'internalName',
-      'description',
-      'illustration',
-      'content',
-      'createdAt',
-      'updatedAt',
-      'attestationKey',
-    ],
+    attributes: ['name', 'internalName', 'description', 'illustration', 'createdAt', 'updatedAt'],
   }).serialize(combinedCourseBlueprint);
 };
 
-const deserialize = async function (payload) {
-  const deserializedData = await new Deserializer({
-    keyForAttribute: 'camelCase',
-  }).deserialize(payload);
-  return new AdminCombinedCourseBlueprint(deserializedData);
-};
-
-export { deserialize, serialize };
+export { serialize };

--- a/api/src/shared/application/security-pre-handlers.js
+++ b/api/src/shared/application/security-pre-handlers.js
@@ -944,7 +944,7 @@ function _noOrganizationFound(error) {
   return error instanceof NotFoundError;
 }
 
-const securityPreHandlers = {
+export const securityPreHandlers = {
   hasAtLeastOneAccessOf,
   validateAllAccess,
   checkAdminMemberHasRoleCertif,
@@ -988,5 +988,3 @@ const securityPreHandlers = {
   checkOrganizationAccess,
   checkParticipationBelongsToCombinedCourse,
 };
-
-export { securityPreHandlers };

--- a/api/tests/quest/acceptance/application/combined-course-blueprint-route_test.js
+++ b/api/tests/quest/acceptance/application/combined-course-blueprint-route_test.js
@@ -1,5 +1,5 @@
 import { ATTESTATIONS } from '../../../../src/profile/domain/constants.js';
-import { CombinedCourseBlueprint } from '../../../../src/quest/domain/models/CombinedCourseBlueprint.js';
+import { AdminCombinedCourseBlueprint } from '../../../../src/quest/domain/models/AdminCombinedCourseBlueprint.js';
 import {
   createServer,
   databaseBuilder,
@@ -21,12 +21,8 @@ describe('Quest | Acceptance | Application | Combined course blueprint Route ', 
         // given
         const adminUser = await insertUserWithRoleSuperAdmin();
 
-        databaseBuilder.factory.buildCombinedCourseBlueprint({
-          content: CombinedCourseBlueprint.buildContentItems([{ moduleShortId: 'mon-module' }]),
-        });
-        databaseBuilder.factory.buildCombinedCourseBlueprint({
-          content: CombinedCourseBlueprint.buildContentItems([{ moduleShortId: 'mon-module-abc' }]),
-        });
+        databaseBuilder.factory.buildCombinedCourseBlueprint();
+        databaseBuilder.factory.buildCombinedCourseBlueprint();
         await databaseBuilder.commit();
 
         const options = {
@@ -63,7 +59,7 @@ describe('Quest | Acceptance | Application | Combined course blueprint Route ', 
               description: 'La description combinix',
               illustration: 'illustration.svg',
               'attestation-key': ATTESTATIONS.SIXTH_GRADE,
-              content: CombinedCourseBlueprint.buildContentItems([{ moduleShortId: 'e67ec5d0' }]),
+              content: AdminCombinedCourseBlueprint.buildContentItems([{ moduleShortId: 'e67ec5d0' }]),
             },
           },
         };
@@ -90,9 +86,7 @@ describe('Quest | Acceptance | Application | Combined course blueprint Route ', 
         // given
         const adminUser = await insertUserWithRoleSuperAdmin();
 
-        const combinedCourseBlueprint = databaseBuilder.factory.buildCombinedCourseBlueprint({
-          content: CombinedCourseBlueprint.buildContentItems([{ moduleShortId: 'e67ec5d0' }]),
-        });
+        const combinedCourseBlueprint = databaseBuilder.factory.buildCombinedCourseBlueprint();
         await databaseBuilder.commit();
 
         const options = {
@@ -136,6 +130,7 @@ describe('Quest | Acceptance | Application | Combined course blueprint Route ', 
       });
     });
   });
+
   describe('POST /api/admin/combined-course-blueprints/:blueprintId/organizations', function () {
     context('when user is admin ', function () {
       it('should attach a combined course blueprint to one or several organizations', async function () {
@@ -182,6 +177,7 @@ describe('Quest | Acceptance | Application | Combined course blueprint Route ', 
       });
     });
   });
+
   describe('GET /api/organizations/:id/combined-course-blueprints', function () {
     context('when user is authenticated', function () {
       let user;

--- a/api/tests/quest/integration/domain/usecases/create-combined-course-blueprint_test.js
+++ b/api/tests/quest/integration/domain/usecases/create-combined-course-blueprint_test.js
@@ -1,4 +1,5 @@
 import { REWARD_TYPES } from '../../../../../src/quest/domain/constants.js';
+import { AdminCombinedCourseBlueprint } from '../../../../../src/quest/domain/models/AdminCombinedCourseBlueprint.js';
 import { CombinedCourseBlueprint } from '../../../../../src/quest/domain/models/CombinedCourseBlueprint.js';
 import { usecases } from '../../../../../src/quest/domain/usecases/index.js';
 import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
@@ -9,27 +10,43 @@ describe('Integration | Combined course | Domain | UseCases | create-combined-co
     // given
     const moduleShortId = '6a68bf32';
     const moduleId = '6282925d-4775-4bca-b513-4c3009ec5886';
+    const modulesByShortId = { '6a68bf32': [{ id: '6282925d-4775-4bca-b513-4c3009ec5886' }] };
     const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
     const attestation = databaseBuilder.factory.buildAttestation();
     await databaseBuilder.commit();
 
-    const combinedCourseBlueprint = new CombinedCourseBlueprint({
+    const adminCombinedCourseBlueprint = new AdminCombinedCourseBlueprint({
       name: 'Mon épure',
       internalName: 'Une épure pour tel niveau',
       illustration: 'illustrations/mon-epure.png',
       description: 'Description',
-      content: CombinedCourseBlueprint.buildContentItems([{ moduleShortId }, { targetProfileId }]),
+      content: AdminCombinedCourseBlueprint.buildContentItems([{ moduleShortId }, { targetProfileId }]),
+      attestationKey: attestation.key,
     });
 
-    await usecases.createCombinedCourseBlueprint({ combinedCourseBlueprint, attestationKey: attestation.key });
+    const expectedCombinedCourseBlueprint = CombinedCourseBlueprint.buildWithQuest({
+      adminCombinedCourseBlueprint,
+      modulesByShortId,
+      rewardId: attestation.id,
+      rewardType: REWARD_TYPES.ATTESTATION,
+    });
+
+    const expectedQuest = expectedCombinedCourseBlueprint.quest.toDTO();
+
+    await usecases.createCombinedCourseBlueprint({ adminCombinedCourseBlueprint });
 
     const combinedCourseBlueprints = await knex('combined_course_blueprints');
+    const questLinkedToBlueprint = await knex('quests').where('id', combinedCourseBlueprints[0].questId).first();
     expect(combinedCourseBlueprints).lengthOf(1);
-    expect(combinedCourseBlueprints[0].name).to.equal(combinedCourseBlueprint.name);
-    expect(combinedCourseBlueprints[0].internalName).to.equal(combinedCourseBlueprint.internalName);
-    expect(combinedCourseBlueprints[0].illustration).to.equal(combinedCourseBlueprint.illustration);
-    expect(combinedCourseBlueprints[0].description).to.equal(combinedCourseBlueprint.description);
-    expect(combinedCourseBlueprints[0].content).to.deep.equal(combinedCourseBlueprint.content);
+    expect(combinedCourseBlueprints[0].name).to.equal(adminCombinedCourseBlueprint.name);
+    expect(combinedCourseBlueprints[0].internalName).to.equal(adminCombinedCourseBlueprint.internalName);
+    expect(combinedCourseBlueprints[0].illustration).to.equal(adminCombinedCourseBlueprint.illustration);
+    expect(combinedCourseBlueprints[0].description).to.equal(adminCombinedCourseBlueprint.description);
+
+    expect(questLinkedToBlueprint.successRequirements).to.deep.equal(expectedQuest.successRequirements);
+    expect(questLinkedToBlueprint.rewardId).to.deep.equal(expectedQuest.rewardId);
+    expect(questLinkedToBlueprint.rewardType).to.deep.equal(expectedQuest.rewardType);
+
     expect(combinedCourseBlueprints[0].updatedAt).to.be.instanceOf(Date);
     expect(combinedCourseBlueprints[0].createdAt).to.be.instanceOf(Date);
 
@@ -48,16 +65,16 @@ describe('Integration | Combined course | Domain | UseCases | create-combined-co
     const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
     await databaseBuilder.commit();
 
-    const combinedCourseBlueprint = new CombinedCourseBlueprint({
+    const adminCombinedCourseBlueprint = new AdminCombinedCourseBlueprint({
       name: 'Mon épure',
       internalName: 'Une épure pour tel niveau',
       illustration: 'illustrations/mon-epure.png',
       description: 'Description',
-      content: CombinedCourseBlueprint.buildContentItems([{ moduleShortId: '6a68bf32' }, { targetProfileId }]),
+      content: AdminCombinedCourseBlueprint.buildContentItems([{ moduleShortId: '6a68bf32' }, { targetProfileId }]),
       attestationKey: undefined,
     });
 
-    await usecases.createCombinedCourseBlueprint({ combinedCourseBlueprint });
+    await usecases.createCombinedCourseBlueprint({ adminCombinedCourseBlueprint });
 
     const combinedCourseBlueprints = await knex('combined_course_blueprints');
     expect(combinedCourseBlueprints).lengthOf(1);
@@ -79,29 +96,32 @@ describe('Integration | Combined course | Domain | UseCases | create-combined-co
     const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
     await databaseBuilder.commit();
 
-    const combinedCourseBlueprint = new CombinedCourseBlueprint({
+    const adminCombinedCourseBlueprint = new AdminCombinedCourseBlueprint({
       name: 'Mon épure',
       internalName: 'Une épure pour tel niveau',
       illustration: 'illustrations/mon-epure.png',
       description: 'Description',
-      content: CombinedCourseBlueprint.buildContentItems([{ targetProfileId }, { targetProfileId: 123 }]),
+      content: AdminCombinedCourseBlueprint.buildContentItems([{ targetProfileId }, { targetProfileId: 123 }]),
     });
 
-    const error = await catchErr(usecases.createCombinedCourseBlueprint)({ combinedCourseBlueprint });
+    const error = await catchErr(usecases.createCombinedCourseBlueprint)({ adminCombinedCourseBlueprint });
     expect(error).to.be.instanceOf(NotFoundError);
   });
 
   it('should return error if one of the modules in content is not found', async function () {
     // given
-    const combinedCourseBlueprint = new CombinedCourseBlueprint({
+    const adminCombinedCourseBlueprint = new AdminCombinedCourseBlueprint({
       name: 'Mon épure',
       internalName: 'Une épure pour tel niveau',
       illustration: 'illustrations/mon-epure.png',
       description: 'Description',
-      content: CombinedCourseBlueprint.buildContentItems([{ moduleShortId: '6a68bf32' }, { moduleShortId: 'abc-123' }]),
+      content: AdminCombinedCourseBlueprint.buildContentItems([
+        { moduleShortId: '6a68bf32' },
+        { moduleShortId: 'abc-123' },
+      ]),
     });
 
-    const error = await catchErr(usecases.createCombinedCourseBlueprint)({ combinedCourseBlueprint });
+    const error = await catchErr(usecases.createCombinedCourseBlueprint)({ adminCombinedCourseBlueprint });
     expect(error).to.be.instanceOf(NotFoundError);
   });
 });

--- a/api/tests/quest/integration/domain/usecases/find-combined-course-blueprints_test.js
+++ b/api/tests/quest/integration/domain/usecases/find-combined-course-blueprints_test.js
@@ -4,9 +4,7 @@ import { databaseBuilder, expect } from '../../../../test-helper.js';
 
 describe('Integration | Quest | Domain | UseCases | find-combined-course-blueprints', function () {
   it('should return combined course blueprints array if at least a result is found', async function () {
-    databaseBuilder.factory.buildCombinedCourseBlueprint({
-      content: CombinedCourseBlueprint.buildContentItems([{ moduleShortId: 'abc-123' }]),
-    });
+    databaseBuilder.factory.buildCombinedCourseBlueprint();
     await databaseBuilder.commit();
     const results = await usecases.findCombinedCourseBlueprints();
     expect(results).lengthOf(1);

--- a/api/tests/quest/integration/domain/usecases/get-combined-course-blueprint-by-id_test.js
+++ b/api/tests/quest/integration/domain/usecases/get-combined-course-blueprint-by-id_test.js
@@ -1,7 +1,6 @@
-import {
-  COMBINED_COURSE_BLUEPRINT_ITEMS,
-  CombinedCourseBlueprint,
-} from '../../../../../src/quest/domain/models/CombinedCourseBlueprint.js';
+import { REWARD_TYPES } from '../../../../../src/quest/domain/constants.js';
+import { AdminCombinedCourseBlueprint } from '../../../../../src/quest/domain/models/AdminCombinedCourseBlueprint.js';
+import { CombinedCourseBlueprint } from '../../../../../src/quest/domain/models/CombinedCourseBlueprint.js';
 import { usecases } from '../../../../../src/quest/domain/usecases/index.js';
 import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
 import { catchErr, databaseBuilder, expect, sinon } from '../../../../test-helper.js';
@@ -20,24 +19,35 @@ describe('Integration | Quest | Domain | UseCases | get-combined-course-blueprin
 
   it('should return a combined course blueprint for a given id', async function () {
     //given
-    const targetProfile = await databaseBuilder.factory.buildTargetProfile({ name: 'Mon profil cible' });
+    const { id: targetProfileId } = await databaseBuilder.factory.buildTargetProfile({ name: 'Mon profil cible' });
 
+    const { id: rewardId, key: attestationKey } = await databaseBuilder.factory.buildAttestation();
+
+    const quest = databaseBuilder.factory.buildQuest({
+      rewardType: REWARD_TYPES.ATTESTATION,
+      rewardId,
+      successRequirements: [
+        CombinedCourseBlueprint.buildRequirementForCombinedCourse({ targetProfileId }).toDTO(),
+        CombinedCourseBlueprint.buildRequirementForCombinedCourse({
+          moduleId: '9beb922f-4d8e-495d-9c85-0e7265ca78d6',
+        }).toDTO(),
+      ],
+    });
     await databaseBuilder.factory.buildCombinedCourseBlueprint({
       id: 1,
-      content: [
-        { type: COMBINED_COURSE_BLUEPRINT_ITEMS.EVALUATION, value: targetProfile.id },
-        { type: COMBINED_COURSE_BLUEPRINT_ITEMS.MODULE, value: 'e074af34' },
-      ],
+      questId: quest.id,
     });
 
     await databaseBuilder.commit();
 
     //when
-    const result = await usecases.getCombinedCourseBlueprintById({ id: 1 });
+    const adminCombinedCourseBlueprint = await usecases.getCombinedCourseBlueprintById({
+      id: 1,
+    });
 
     //then
-    expect(result).to.be.instanceOf(CombinedCourseBlueprint);
-    expect(result).deep.contain({
+    expect(adminCombinedCourseBlueprint).to.be.instanceOf(AdminCombinedCourseBlueprint);
+    expect(adminCombinedCourseBlueprint).deep.contain({
       id: 1,
       name: 'Mon parcours combiné',
       internalName: 'Mon schéma de parcours combiné',
@@ -45,16 +55,12 @@ describe('Integration | Quest | Domain | UseCases | get-combined-course-blueprin
       illustration: 'images/illustration.svg',
       createdAt: now,
       updatedAt: now,
-      content: [
-        { type: COMBINED_COURSE_BLUEPRINT_ITEMS.EVALUATION, value: targetProfile.id, label: targetProfile.name },
-        {
-          type: COMBINED_COURSE_BLUEPRINT_ITEMS.MODULE,
-          value: 'e074af34',
-          label: 'Au-delà des mots de passe : comment s’authentifier ?',
-        },
-      ],
       organizationIds: [],
+      attestationKey,
     });
+    expect(adminCombinedCourseBlueprint.content).to.deep.equal(
+      AdminCombinedCourseBlueprint.buildContentItems([{ targetProfileId }, { moduleShortId: 'e074af34' }]),
+    );
   });
 
   it('should throw when no combined course blueprint is found for a given id', async function () {

--- a/api/tests/quest/integration/infrastructure/repositories/combined-course-blueprint-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/combined-course-blueprint-repository_test.js
@@ -1,14 +1,13 @@
 import { CampaignParticipationStatuses } from '../../../../../src/prescription/shared/domain/constants.js';
+import { AdminCombinedCourseBlueprint } from '../../../../../src/quest/domain/models/AdminCombinedCourseBlueprint.js';
 import { CombinedCourseBlueprint } from '../../../../../src/quest/domain/models/CombinedCourseBlueprint.js';
 import {
   CRITERION_COMPARISONS,
-  Quest,
   REQUIREMENT_COMPARISONS,
   REQUIREMENT_TYPES,
 } from '../../../../../src/quest/domain/models/Quest.js';
 import * as combinedCourseBluePrintRepository from '../../../../../src/quest/infrastructure/repositories/combined-course-blueprint-repository.js';
-import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
-import { catchErr, databaseBuilder, domainBuilder, expect } from '../../../../test-helper.js';
+import { databaseBuilder, domainBuilder, expect } from '../../../../test-helper.js';
 
 describe('Quest | Integration | Repository | combined-course-blueprint', function () {
   describe('#save', function () {
@@ -16,12 +15,12 @@ describe('Quest | Integration | Repository | combined-course-blueprint', functio
       // given
       const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
       const combinedCourseBlueprint = CombinedCourseBlueprint.buildWithQuest({
-        combinedCourseBlueprint: new CombinedCourseBlueprint({
+        adminCombinedCourseBlueprint: new AdminCombinedCourseBlueprint({
           name: 'Combined course IA',
           internalName: 'Ia combined course blueprint',
           description: "L'ia c'est magique",
           illustration: 'illustration/ia.svg',
-          content: CombinedCourseBlueprint.buildContentItems([{ targetProfileId }, { moduleShortId: '6a68bf32' }]),
+          content: AdminCombinedCourseBlueprint.buildContentItems([{ targetProfileId }, { moduleShortId: '6a68bf32' }]),
           organizationIds: [],
         }),
         modulesByShortId: { '6a68bf32': [{ id: '6282925d-4775-4bca-b513-4c3009ec5886' }] },
@@ -32,6 +31,7 @@ describe('Quest | Integration | Repository | combined-course-blueprint', functio
 
       // then
       const results = await combinedCourseBluePrintRepository.findAll();
+
       expect(results).lengthOf(1);
       expect(results[0]).deep.equal(savedCombinedCourseBlueprint);
       expect(results[0]).deep.contain({ ...combinedCourseBlueprint.combinedCourseBlueprint });
@@ -110,31 +110,6 @@ describe('Quest | Integration | Repository | combined-course-blueprint', functio
       expect(result.organizationIds).deep.equal([organization1.id, organization2.id]);
     });
 
-    it('should throw a NotFound error when combined course blueprint does not exist', async function () {
-      // given
-      const combinedCourseBlueprintShare = databaseBuilder.factory.buildCombinedCourseBlueprintShare();
-      databaseBuilder.factory.buildCombinedCourseBlueprintShare({
-        combinedCourseBlueprintId: combinedCourseBlueprintShare.combinedCourseBlueprintId,
-      });
-
-      await databaseBuilder.commit();
-
-      const combinedCourseBlueprint = await combinedCourseBluePrintRepository.findById({
-        id: combinedCourseBlueprintShare.combinedCourseBlueprintId,
-      });
-
-      combinedCourseBlueprint.detachOrganization({ organizationId: combinedCourseBlueprintShare.organizationId });
-
-      // when
-      const nonExistingCombinedCourseBlueprint = { ...combinedCourseBlueprint, id: 404 };
-      const error = await catchErr(combinedCourseBluePrintRepository.save)({
-        combinedCourseBlueprint: nonExistingCombinedCourseBlueprint,
-      });
-
-      // then
-      expect(error).instanceOf(NotFoundError);
-    });
-
     it('should update a combined course blueprint and its quest', async function () {
       // given
       const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
@@ -150,34 +125,21 @@ describe('Quest | Integration | Repository | combined-course-blueprint', functio
       });
       const combinedCourseBlueprintInDb = databaseBuilder.factory.buildCombinedCourseBlueprint({
         questId: quest.id,
-        content: CombinedCourseBlueprint.buildContentItems([{ targetProfileId }, { moduleShortId: '6a68bf32' }]),
       });
+
       await databaseBuilder.commit();
 
-      const combinedCourseBlueprintWithoutTargetProfile = new CombinedCourseBlueprint({
-        id: combinedCourseBlueprintInDb.id,
-        name: 'Updated Combined course IA',
-        internalName: 'Ia combined course blueprint',
-        description: "L'ia c'est magique",
-        illustration: 'illustration/ia.svg',
-        content: CombinedCourseBlueprint.buildContentItems([{ moduleShortId: '6a68bf32' }]),
-        organizationIds: [],
-        quest: new Quest({
-          ...quest,
-          successRequirements: [
-            {
-              comparison: REQUIREMENT_COMPARISONS.ALL,
-              requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
-              data: {
-                isTerminated: { comparison: CRITERION_COMPARISONS.EQUAL, data: true },
-                moduleId: {
-                  comparison: CRITERION_COMPARISONS.EQUAL,
-                  data: '6282925d-4775-4bca-b513-4c3009ec5886',
-                },
-              },
-            },
-          ],
+      const combinedCourseBlueprintWithoutTargetProfile = CombinedCourseBlueprint.buildWithQuest({
+        adminCombinedCourseBlueprint: new AdminCombinedCourseBlueprint({
+          id: combinedCourseBlueprintInDb.id,
+          name: 'Updated Combined course IA',
+          internalName: 'Ia combined course blueprint',
+          description: "L'ia c'est magique",
+          illustration: 'illustration/ia.svg',
+          content: AdminCombinedCourseBlueprint.buildContentItems([{ moduleShortId: '6a68bf32' }]),
+          organizationIds: [],
         }),
+        modulesByShortId: { '6a68bf32': [{ id: '6282925d-4775-4bca-b513-4c3009ec5886' }] },
       });
 
       // when
@@ -208,17 +170,16 @@ describe('Quest | Integration | Repository | combined-course-blueprint', functio
       // given
       const combinedCourseBlueprintInDb = databaseBuilder.factory.buildCombinedCourseBlueprint({
         questId: null,
-        content: CombinedCourseBlueprint.buildContentItems([{ moduleShortId: '6a68bf32' }]),
       });
 
       const combinedCourseBlueprint = CombinedCourseBlueprint.buildWithQuest({
-        combinedCourseBlueprint: new CombinedCourseBlueprint({
+        adminCombinedCourseBlueprint: new AdminCombinedCourseBlueprint({
           id: combinedCourseBlueprintInDb.id,
           name: 'Combined course IA',
           internalName: 'Ia combined course blueprint',
           description: "L'ia c'est magique",
           illustration: 'illustration/ia.svg',
-          content: CombinedCourseBlueprint.buildContentItems([{ moduleShortId: '6a68bf32' }]),
+          content: AdminCombinedCourseBlueprint.buildContentItems([{ moduleShortId: '6a68bf32' }]),
           organizationIds: [],
         }),
         modulesByShortId: { '6a68bf32': [{ id: '6282925d-4775-4bca-b513-4c3009ec5886' }] },
@@ -268,7 +229,6 @@ describe('Quest | Integration | Repository | combined-course-blueprint', functio
 
       const expectedCombinedCourseBlueprint = databaseBuilder.factory.buildCombinedCourseBlueprint({
         questId,
-        content: CombinedCourseBlueprint.buildContentItems([{ targetProfileId }, { moduleShortId: '6a68bf32' }]),
       });
       databaseBuilder.factory.buildCombinedCourseBlueprint();
       await databaseBuilder.commit();
@@ -309,7 +269,6 @@ describe('Quest | Integration | Repository | combined-course-blueprint', functio
 
       const expectedCombinedCourseBlueprint = domainBuilder.buildCombinedCourseBlueprint({
         ...combinedCourseBlueprint,
-        content: [],
         organizationIds: [combinedCourseBlueprintShare.organizationId],
       });
 
@@ -325,7 +284,6 @@ describe('Quest | Integration | Repository | combined-course-blueprint', functio
         illustration: expectedCombinedCourseBlueprint.illustration,
         createdAt: expectedCombinedCourseBlueprint.createdAt,
         updatedAt: expectedCombinedCourseBlueprint.updatedAt,
-        content: expectedCombinedCourseBlueprint.content,
         organizationIds: expectedCombinedCourseBlueprint.organizationIds,
       });
       expect(result.quest.toDTO()).to.deep.equal(quest);
@@ -338,7 +296,6 @@ describe('Quest | Integration | Repository | combined-course-blueprint', functio
 
       const expectedCombinedCourseBlueprint = domainBuilder.buildCombinedCourseBlueprint({
         ...combinedCourseBlueprint,
-        content: [],
       });
 
       const result = await combinedCourseBluePrintRepository.findById({ id: expectedCombinedCourseBlueprint.id });
@@ -352,7 +309,6 @@ describe('Quest | Integration | Repository | combined-course-blueprint', functio
         illustration: expectedCombinedCourseBlueprint.illustration,
         createdAt: expectedCombinedCourseBlueprint.createdAt,
         updatedAt: expectedCombinedCourseBlueprint.updatedAt,
-        content: expectedCombinedCourseBlueprint.content,
         organizationIds: [],
       });
       expect(result.quest.toDTO()).to.deep.equal(quest);

--- a/api/tests/quest/integration/infrastructure/repositories/quest-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/quest-repository_test.js
@@ -4,18 +4,80 @@ import * as questRepository from '../../../../../src/quest/infrastructure/reposi
 import { databaseBuilder, expect, knex, sinon } from '../../../../test-helper.js';
 
 describe('Quest | Integration | Repository | quest', function () {
+  describe('#save', function () {
+    it('should save quest and return its id', async function () {
+      // given
+      const quest = new Quest({
+        id: 1,
+        createdAt: new Date(),
+        updatedAt: null,
+        rewardType: REWARD_TYPES.ATTESTATION,
+        rewardId: 1,
+        eligibilityRequirements: [],
+        successRequirements: [],
+      });
+
+      // when
+      const result = await questRepository.save({ quest });
+
+      // then
+      expect(result).to.equal(quest.id);
+    });
+
+    it('should update quest if it already exists in db', async function () {
+      // given
+      const oldRewardId = 1;
+      const newRewardId = 2;
+      const createdAt = new Date();
+
+      const questInDatabase = databaseBuilder.factory.buildQuest({
+        id: 1,
+        createdAt,
+        updatedAt: createdAt,
+        rewardId: oldRewardId,
+        eligibilityRequirements: [],
+        successRequirements: [],
+      });
+
+      const newQuest = new Quest({
+        id: 1,
+        rewardType: REWARD_TYPES.ATTESTATION,
+        rewardId: newRewardId,
+        eligibilityRequirements: [],
+        successRequirements: [],
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const result = await questRepository.save({ quest: newQuest });
+
+      const resultQuest = await knex('quests').where('id', questInDatabase.id).first();
+
+      // then
+      expect(result).to.equal(questInDatabase.id);
+      expect(resultQuest.createdAt).to.be.instanceOf(Date);
+      expect(resultQuest.createdAt.toString()).to.equal(createdAt.toString());
+      expect(resultQuest.updatedAt).to.not.equal(questInDatabase.updatedAt);
+      expect(resultQuest.rewardId).to.equal(newRewardId);
+    });
+  });
+
   describe('#saveInBatch', function () {
     it('should save quests and return their ids', async function () {
+      const createdAt = new Date('2020-01-01T00:00:00Z');
+      const createdAt2 = new Date('2020-01-01T00:00:00Z');
+
       const { id: rewardId } = databaseBuilder.factory.buildAttestation();
       const questInDatabase = databaseBuilder.factory.buildQuest({
-        createdAt: new Date('2020-01-01T00:00:00Z'),
-        updatedAt: new Date('2020-01-01T00:00:00Z'),
+        createdAt,
+        updatedAt: createdAt,
         rewardId,
         successRequirements: [],
       });
       databaseBuilder.factory.buildQuest({
-        createdAt: new Date('2021-02-02T00:00:00Z'),
-        updatedAt: new Date('2021-02-02T00:00:00Z'),
+        createdAt: createdAt2,
+        updatedAt: createdAt2,
         rewardId,
       });
       await databaseBuilder.commit();
@@ -35,11 +97,12 @@ describe('Quest | Integration | Repository | quest', function () {
       });
 
       // then
-      const [firstQuest, secondQuest, thirdQuest] = await knex('quests').orderBy('id');
-      expect(firstQuest.updatedAt).to.not.deep.equal(new Date('2020-01-01T00:00:00Z'));
-      expect(secondQuest.updatedAt).to.deep.equal(new Date('2021-02-02T00:00:00Z'));
+      const [updatedQuest, notUpdatedQuest, createdQuest] = await knex('quests').orderBy('id');
+
+      expect(updatedQuest.updatedAt).to.not.deep.equal(createdAt);
+      expect(notUpdatedQuest.updatedAt).to.deep.equal(createdAt2);
       sinon.assert.match(
-        new Quest(thirdQuest),
+        new Quest(createdQuest),
         sinon.match(
           new Quest({
             ...expectedNewQuest,
@@ -53,7 +116,7 @@ describe('Quest | Integration | Repository | quest', function () {
           }),
         ),
       );
-      expect(result[0]).to.equal(thirdQuest.id);
+      expect(result[0]).to.equal(createdQuest.id);
     });
   });
 

--- a/api/tests/quest/unit/application/combined-course-blueprint-route_test.js
+++ b/api/tests/quest/unit/application/combined-course-blueprint-route_test.js
@@ -1,0 +1,189 @@
+import { ATTESTATIONS } from '../../../../src/profile/domain/constants.js';
+import { combinedCourseBlueprintController } from '../../../../src/quest/application/combined-course-blueprint-controller.js';
+import * as combinedCourseBlueprintRoute from '../../../../src/quest/application/combined-course-blueprint-route.js';
+import { AdminCombinedCourseBlueprint } from '../../../../src/quest/domain/models/AdminCombinedCourseBlueprint.js';
+import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
+import { expect, generateAuthenticatedUserRequestHeaders, HttpTestServer, sinon } from '../../../test-helper.js';
+
+describe('Quest | Unit | Routes | combined-course-blueprint-route', function () {
+  describe('GET /api/admin/combined-course-blueprints', function () {
+    it('should call prehandler', async function () {
+      // given
+      sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
+      sinon.stub(combinedCourseBlueprintController, 'findAll').callsFake((_, h) => h.response());
+
+      const httpTestServer = new HttpTestServer();
+      httpTestServer.setupAuthentication();
+      await httpTestServer.register(combinedCourseBlueprintRoute);
+
+      // when
+      await httpTestServer.request(
+        'GET',
+        '/api/admin/combined-course-blueprints',
+        null,
+        null,
+        generateAuthenticatedUserRequestHeaders({ userId: 123 }),
+      );
+
+      // then
+      expect(securityPreHandlers.hasAtLeastOneAccessOf).to.have.been.calledWithExactly([
+        securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+        securityPreHandlers.checkAdminMemberHasRoleMetier,
+        securityPreHandlers.checkAdminMemberHasRoleSupport,
+        securityPreHandlers.checkAdminMemberHasRoleCertif,
+      ]);
+    });
+  });
+
+  describe('POST /api/admin/combined-course-blueprints', function () {
+    it('should call prehandler', async function () {
+      // given
+      sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
+      sinon.stub(combinedCourseBlueprintController, 'save').callsFake((_, h) => h.response());
+
+      const payload = {
+        data: {
+          type: 'combined-course-blueprints',
+          attributes: {
+            name: 'Mon parcours combiné',
+            'internal-name': 'Mon schéma de parcours combiné',
+            description: 'La description combinix',
+            illustration: 'illustration.svg',
+            'attestation-key': ATTESTATIONS.SIXTH_GRADE,
+            content: AdminCombinedCourseBlueprint.buildContentItems([{ moduleShortId: 'e67ec5d0' }]),
+          },
+        },
+      };
+
+      const httpTestServer = new HttpTestServer();
+      httpTestServer.setupAuthentication();
+      await httpTestServer.register(combinedCourseBlueprintRoute);
+
+      // when
+      await httpTestServer.request(
+        'POST',
+        '/api/admin/combined-course-blueprints',
+        payload,
+        null,
+        generateAuthenticatedUserRequestHeaders({ userId: 123 }),
+      );
+
+      // then
+      expect(securityPreHandlers.hasAtLeastOneAccessOf).to.have.been.calledWithExactly([
+        securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+        securityPreHandlers.checkAdminMemberHasRoleMetier,
+        securityPreHandlers.checkAdminMemberHasRoleSupport,
+        securityPreHandlers.checkAdminMemberHasRoleCertif,
+      ]);
+    });
+  });
+
+  describe('GET /api/admin/combined-course-blueprints/{blueprintId}', function () {
+    it('should call prehandler', async function () {
+      // given
+      sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
+      sinon.stub(combinedCourseBlueprintController, 'getById').callsFake((_, h) => h.response());
+
+      const httpTestServer = new HttpTestServer();
+      httpTestServer.setupAuthentication();
+      await httpTestServer.register(combinedCourseBlueprintRoute);
+
+      // when
+      await httpTestServer.request(
+        'GET',
+        '/api/admin/combined-course-blueprints/123',
+        null,
+        null,
+        generateAuthenticatedUserRequestHeaders({ userId: 123 }),
+      );
+
+      // then
+      expect(securityPreHandlers.hasAtLeastOneAccessOf).to.have.been.calledWithExactly([
+        securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+        securityPreHandlers.checkAdminMemberHasRoleMetier,
+        securityPreHandlers.checkAdminMemberHasRoleSupport,
+        securityPreHandlers.checkAdminMemberHasRoleCertif,
+      ]);
+    });
+  });
+
+  describe('DELETE /api/admin/combined-course-blueprints/{blueprintId}/organizations/{organizationId}', function () {
+    it('should call prehandler', async function () {
+      // given
+      sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
+      sinon.stub(combinedCourseBlueprintController, 'detachOrganization').callsFake((_, h) => h.response());
+
+      const httpTestServer = new HttpTestServer();
+      httpTestServer.setupAuthentication();
+      await httpTestServer.register(combinedCourseBlueprintRoute);
+
+      // when
+      await httpTestServer.request(
+        'DELETE',
+        '/api/admin/combined-course-blueprints/123/organizations/456',
+        null,
+        null,
+        generateAuthenticatedUserRequestHeaders({ userId: 123 }),
+      );
+
+      // then
+      expect(securityPreHandlers.hasAtLeastOneAccessOf).to.have.been.calledWithExactly([
+        securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+        securityPreHandlers.checkAdminMemberHasRoleMetier,
+      ]);
+    });
+  });
+
+  describe('POST /api/admin/combined-course-blueprints/{blueprintId}/organizations', function () {
+    it('should call prehandler', async function () {
+      // given
+      sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
+      sinon.stub(combinedCourseBlueprintController, 'attachOrganizations').callsFake((_, h) => h.response());
+
+      const payload = { 'organization-ids': [456] };
+
+      const httpTestServer = new HttpTestServer();
+      httpTestServer.setupAuthentication();
+      await httpTestServer.register(combinedCourseBlueprintRoute);
+
+      // when
+      await httpTestServer.request(
+        'POST',
+        '/api/admin/combined-course-blueprints/123/organizations',
+        payload,
+        null,
+        generateAuthenticatedUserRequestHeaders({ userId: 123 }),
+      );
+
+      // then
+      expect(securityPreHandlers.hasAtLeastOneAccessOf).to.have.been.calledWithExactly([
+        securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+        securityPreHandlers.checkAdminMemberHasRoleMetier,
+      ]);
+    });
+  });
+
+  describe('GET /api/organizations/{organizationId}/combined-course-blueprints', function () {
+    it('should call prehandler', async function () {
+      // given
+      sinon.stub(securityPreHandlers, 'checkOrganizationAccess').returns(() => true);
+      sinon.stub(combinedCourseBlueprintController, 'findByOrganizationId').callsFake((_, h) => h.response());
+
+      const httpTestServer = new HttpTestServer();
+      httpTestServer.setupAuthentication();
+      await httpTestServer.register(combinedCourseBlueprintRoute);
+
+      // when
+      await httpTestServer.request(
+        'GET',
+        '/api/organizations/456/combined-course-blueprints',
+        null,
+        null,
+        generateAuthenticatedUserRequestHeaders({ userId: 123 }),
+      );
+
+      // then
+      expect(securityPreHandlers.checkOrganizationAccess).to.have.been.called;
+    });
+  });
+});

--- a/api/tests/quest/unit/domain/models/AdminCombinedCourseBlueprint_test.js
+++ b/api/tests/quest/unit/domain/models/AdminCombinedCourseBlueprint_test.js
@@ -1,0 +1,87 @@
+import { ATTESTATIONS } from '../../../../../src/profile/domain/constants.js';
+import {
+  ADMIN_COMBINED_COURSE_BLUEPRINT_ITEMS,
+  AdminCombinedCourseBlueprint,
+} from '../../../../../src/quest/domain/models/AdminCombinedCourseBlueprint.js';
+import { CombinedCourseBlueprint } from '../../../../../src/quest/domain/models/CombinedCourseBlueprint.js';
+import { domainBuilder, expect } from '../../../../test-helper.js';
+
+describe('Quest | Unit | Domain | Models | AdminCombinedCourseBlueprint ', function () {
+  describe('#constructor', function () {
+    it('should construct object', function () {
+      // given
+      const values = {
+        id: 1,
+        name: 'name',
+        internalName: 'internalName',
+        description: 'description',
+        illustration: 'illustration',
+        content: AdminCombinedCourseBlueprint.buildContentItems([{ moduleShortId: '123' }]),
+        attestationKey: ATTESTATIONS.PARENTHOOD,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        organizationIds: [],
+      };
+      // when
+      const blueprint = new AdminCombinedCourseBlueprint(values);
+
+      // then
+      expect(blueprint).deep.equal(values);
+    });
+  });
+
+  describe('#buildContentItems', function () {
+    it('should build blueprint content items for targetProfileId and moduleId', function () {
+      const requirements = AdminCombinedCourseBlueprint.buildContentItems([
+        { targetProfileId: 123 },
+        { moduleShortId: 'az-123' },
+      ]);
+
+      expect(requirements).deep.equal([
+        {
+          type: ADMIN_COMBINED_COURSE_BLUEPRINT_ITEMS.EVALUATION,
+          value: 123,
+        },
+        {
+          type: ADMIN_COMBINED_COURSE_BLUEPRINT_ITEMS.MODULE,
+          value: 'az-123',
+        },
+      ]);
+    });
+  });
+
+  describe('#buildFromBlueprint', function () {
+    it('should return an object containing combined course blueprint, content and attestation key', function () {
+      // given
+      const combinedCourseBlueprint = domainBuilder.buildCombinedCourseBlueprint({
+        quest: domainBuilder.buildQuest({
+          successRequirements: [
+            CombinedCourseBlueprint.buildRequirementForCombinedCourse({ targetProfileId: 123 }),
+            CombinedCourseBlueprint.buildRequirementForCombinedCourse({ moduleId: 'completeId-az-123' }),
+          ],
+        }),
+      });
+
+      const expectedContent = AdminCombinedCourseBlueprint.buildContentItems([
+        { targetProfileId: 123 },
+        { moduleShortId: 'az-123' },
+      ]);
+
+      // when
+      const readyToSerialize = AdminCombinedCourseBlueprint.buildFromBlueprint({
+        combinedCourseBlueprint,
+        modulesById: { 'completeId-az-123': [{ shortId: 'az-123' }] },
+        attestationKey: 'PARENTHOOD',
+      });
+
+      // then
+      expect(readyToSerialize).deep.equal(
+        new AdminCombinedCourseBlueprint({
+          ...combinedCourseBlueprint,
+          content: expectedContent,
+          attestationKey: 'PARENTHOOD',
+        }),
+      );
+    });
+  });
+});

--- a/api/tests/quest/unit/domain/models/CombinedCourseBlueprint_test.js
+++ b/api/tests/quest/unit/domain/models/CombinedCourseBlueprint_test.js
@@ -1,16 +1,10 @@
+import { ATTESTATIONS } from '../../../../../src/profile/domain/constants.js';
 import { REWARD_TYPES } from '../../../../../src/quest/domain/constants.js';
+import { AdminCombinedCourseBlueprint } from '../../../../../src/quest/domain/models/AdminCombinedCourseBlueprint.js';
 import { CombinedCourse } from '../../../../../src/quest/domain/models/CombinedCourse.js';
-import {
-  COMBINED_COURSE_BLUEPRINT_ITEMS,
-  CombinedCourseBlueprint,
-} from '../../../../../src/quest/domain/models/CombinedCourseBlueprint.js';
+import { CombinedCourseBlueprint } from '../../../../../src/quest/domain/models/CombinedCourseBlueprint.js';
 import { Module } from '../../../../../src/quest/domain/models/Module.js';
-import {
-  CRITERION_COMPARISONS,
-  Quest,
-  REQUIREMENT_COMPARISONS,
-  REQUIREMENT_TYPES,
-} from '../../../../../src/quest/domain/models/Quest.js';
+import { Quest } from '../../../../../src/quest/domain/models/Quest.js';
 import { expect } from '../../../../test-helper.js';
 
 describe('Quest | Unit | Domain | Models | CombinedCourseBlueprint ', function () {
@@ -20,39 +14,20 @@ describe('Quest | Unit | Domain | Models | CombinedCourseBlueprint ', function (
       const values = {
         id: 1,
         name: 'name',
-        internalName: 'internaleName',
+        internalName: 'internalName',
         description: 'description',
         illustration: 'illustration',
-        content: CombinedCourseBlueprint.buildContentItems([{ moduleShortId: '123' }]),
         createdAt: new Date('2024-01-25'),
         updatedAt: new Date('2024-01-26'),
         organizationIds: [],
         quest: null,
       };
+
       // when
       const blueprint = new CombinedCourseBlueprint(values);
 
       // then
       expect(blueprint).deep.equal(values);
-    });
-  });
-  describe('#buildContentItems', function () {
-    it('should build blueprint content items for targetProfileId and moduleId', function () {
-      const requirements = CombinedCourseBlueprint.buildContentItems([
-        { targetProfileId: 123 },
-        { moduleShortId: 'az-123' },
-      ]);
-
-      expect(requirements).deep.equal([
-        {
-          type: COMBINED_COURSE_BLUEPRINT_ITEMS.EVALUATION,
-          value: 123,
-        },
-        {
-          type: COMBINED_COURSE_BLUEPRINT_ITEMS.MODULE,
-          value: 'az-123',
-        },
-      ]);
     });
   });
 
@@ -63,48 +38,9 @@ describe('Quest | Unit | Domain | Models | CombinedCourseBlueprint ', function (
       const quest = new Quest({
         eligibilityRequirements: [],
         successRequirements: [
-          {
-            requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
-            comparison: REQUIREMENT_COMPARISONS.ALL,
-            data: {
-              moduleId: {
-                data: 'moduleId-555',
-                comparison: CRITERION_COMPARISONS.EQUAL,
-              },
-              isTerminated: {
-                data: true,
-                comparison: CRITERION_COMPARISONS.EQUAL,
-              },
-            },
-          },
-          {
-            requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
-            comparison: REQUIREMENT_COMPARISONS.ALL,
-            data: {
-              moduleId: {
-                data: 'moduleId-777',
-                comparison: CRITERION_COMPARISONS.EQUAL,
-              },
-              isTerminated: {
-                data: true,
-                comparison: CRITERION_COMPARISONS.EQUAL,
-              },
-            },
-          },
-          {
-            requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
-            comparison: REQUIREMENT_COMPARISONS.ALL,
-            data: {
-              targetProfileId: {
-                data: firstTargetProfileId,
-                comparison: CRITERION_COMPARISONS.EQUAL,
-              },
-              status: {
-                data: 'SHARED',
-                comparison: CRITERION_COMPARISONS.EQUAL,
-              },
-            },
-          },
+          CombinedCourseBlueprint.buildRequirementForCombinedCourse({ moduleId: 'moduleId-555' }),
+          CombinedCourseBlueprint.buildRequirementForCombinedCourse({ moduleId: 'moduleId-777' }),
+          CombinedCourseBlueprint.buildRequirementForCombinedCourse({ targetProfileId: firstTargetProfileId }),
         ],
       });
 
@@ -121,20 +57,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourseBlueprint ', function (
       const quest = new Quest({
         eligibilityRequirements: [],
         successRequirements: [
-          {
-            requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
-            comparison: REQUIREMENT_COMPARISONS.ALL,
-            data: {
-              targetProfileId: {
-                data: firstTargetProfileId,
-                comparison: CRITERION_COMPARISONS.EQUAL,
-              },
-              status: {
-                data: 'SHARED',
-                comparison: CRITERION_COMPARISONS.EQUAL,
-              },
-            },
-          },
+          CombinedCourseBlueprint.buildRequirementForCombinedCourse({ targetProfileId: firstTargetProfileId }),
         ],
       });
 
@@ -151,34 +74,8 @@ describe('Quest | Unit | Domain | Models | CombinedCourseBlueprint ', function (
       const quest = new Quest({
         eligibilityRequirements: [],
         successRequirements: [
-          {
-            requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
-            comparison: REQUIREMENT_COMPARISONS.ALL,
-            data: {
-              targetProfileId: {
-                data: 1,
-                comparison: CRITERION_COMPARISONS.EQUAL,
-              },
-              status: {
-                data: 'SHARED',
-                comparison: CRITERION_COMPARISONS.EQUAL,
-              },
-            },
-          },
-          {
-            requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
-            comparison: REQUIREMENT_COMPARISONS.ALL,
-            data: {
-              targetProfileId: {
-                data: 8,
-                comparison: CRITERION_COMPARISONS.EQUAL,
-              },
-              status: {
-                data: 'SHARED',
-                comparison: CRITERION_COMPARISONS.EQUAL,
-              },
-            },
-          },
+          CombinedCourseBlueprint.buildRequirementForCombinedCourse({ targetProfileId: 1 }),
+          CombinedCourseBlueprint.buildRequirementForCombinedCourse({ targetProfileId: 8 }),
         ],
       });
 
@@ -188,24 +85,14 @@ describe('Quest | Unit | Domain | Models | CombinedCourseBlueprint ', function (
       });
       expect(combinedCourseBlueprint.targetProfileIds).to.deep.equal([1, 8]);
     });
+
     it('should return empty list of ids if template has not any campaignParticipations success requirements', async function () {
       const quest = new Quest({
         eligibilityRequirements: [],
         successRequirements: [
-          {
-            requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
-            comparison: REQUIREMENT_COMPARISONS.ALL,
-            data: {
-              moduleId: {
-                data: 'eeeb4951-6f38-4467-a4ba-0c85ed71321a',
-                comparison: CRITERION_COMPARISONS.EQUAL,
-              },
-              isTerminated: {
-                data: true,
-                comparison: CRITERION_COMPARISONS.EQUAL,
-              },
-            },
-          },
+          CombinedCourseBlueprint.buildRequirementForCombinedCourse({
+            moduleId: 'eeeb4951-6f38-4467-a4ba-0c85ed71321a',
+          }),
         ],
       });
 
@@ -249,48 +136,9 @@ describe('Quest | Unit | Domain | Models | CombinedCourseBlueprint ', function (
         rewardType,
         eligibilityRequirements: [],
         successRequirements: [
-          {
-            requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
-            comparison: REQUIREMENT_COMPARISONS.ALL,
-            data: {
-              targetProfileId: {
-                data: firstTargetProfileId,
-                comparison: CRITERION_COMPARISONS.EQUAL,
-              },
-              status: {
-                data: 'SHARED',
-                comparison: CRITERION_COMPARISONS.EQUAL,
-              },
-            },
-          },
-          {
-            requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
-            comparison: REQUIREMENT_COMPARISONS.ALL,
-            data: {
-              targetProfileId: {
-                data: secondTargetProfileId,
-                comparison: CRITERION_COMPARISONS.EQUAL,
-              },
-              status: {
-                data: 'SHARED',
-                comparison: CRITERION_COMPARISONS.EQUAL,
-              },
-            },
-          },
-          {
-            requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
-            comparison: REQUIREMENT_COMPARISONS.ALL,
-            data: {
-              moduleId: {
-                data: moduleId,
-                comparison: CRITERION_COMPARISONS.EQUAL,
-              },
-              isTerminated: {
-                data: true,
-                comparison: CRITERION_COMPARISONS.EQUAL,
-              },
-            },
-          },
+          CombinedCourseBlueprint.buildRequirementForCombinedCourse({ targetProfileId: firstTargetProfileId }),
+          CombinedCourseBlueprint.buildRequirementForCombinedCourse({ targetProfileId: secondTargetProfileId }),
+          CombinedCourseBlueprint.buildRequirementForCombinedCourse({ moduleId }),
         ],
       });
 
@@ -313,53 +161,14 @@ describe('Quest | Unit | Domain | Models | CombinedCourseBlueprint ', function (
         rewardType,
         eligibilityRequirements: [],
         successRequirements: [
-          {
-            requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
-            comparison: REQUIREMENT_COMPARISONS.ALL,
-            data: {
-              campaignId: {
-                data: firstCampaignId,
-                comparison: CRITERION_COMPARISONS.EQUAL,
-              },
-              status: {
-                data: 'SHARED',
-                comparison: CRITERION_COMPARISONS.EQUAL,
-              },
-            },
-          },
-          {
-            requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
-            comparison: REQUIREMENT_COMPARISONS.ALL,
-            data: {
-              campaignId: {
-                data: secondCampaignId,
-                comparison: CRITERION_COMPARISONS.EQUAL,
-              },
-              status: {
-                data: 'SHARED',
-                comparison: CRITERION_COMPARISONS.EQUAL,
-              },
-            },
-          },
-          {
-            requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
-            comparison: REQUIREMENT_COMPARISONS.ALL,
-            data: {
-              moduleId: {
-                data: moduleId,
-                comparison: CRITERION_COMPARISONS.EQUAL,
-              },
-              isTerminated: {
-                data: true,
-                comparison: CRITERION_COMPARISONS.EQUAL,
-              },
-            },
-          },
+          CombinedCourseBlueprint.buildRequirementForCombinedCourse({ targetProfileId: firstTargetProfileId }),
+          CombinedCourseBlueprint.buildRequirementForCombinedCourse({ targetProfileId: secondTargetProfileId }),
+          CombinedCourseBlueprint.buildRequirementForCombinedCourse({ moduleId }),
         ],
       });
 
       expect(combinedCourse).to.be.instanceOf(CombinedCourse);
-      expect(combinedCourse.quest.toDTO().successRequirements).to.deep.equal(expectedQuest.toDTO().successRequirements);
+      expect(combinedCourse.quest.successRequirements).to.deep.equal(expectedQuest.successRequirements);
       expect(combinedCourse.name).to.equal(name);
       expect(combinedCourse.description).to.equal(description);
       expect(combinedCourse.illustration).to.equal(illustration);
@@ -372,88 +181,53 @@ describe('Quest | Unit | Domain | Models | CombinedCourseBlueprint ', function (
     it('should return combined course blueprint with quest', async function () {
       // given
       const targetProfileId = 1;
+      const moduleShortId = 'ecc13f55';
       const moduleId = 'eeeb4951-6f38-4467-a4ba-0c85ed71321a';
       const modulesByShortId = {
         ecc13f55: [new Module({ id: moduleId })],
       };
-      const combinedCourseContent = [
-        {
-          type: COMBINED_COURSE_BLUEPRINT_ITEMS.EVALUATION,
-          value: targetProfileId,
-        },
-        {
-          type: COMBINED_COURSE_BLUEPRINT_ITEMS.MODULE,
-          value: 'ecc13f55',
-        },
-      ];
-      const name = 'Combinix';
-      const description = 'bla bla bla';
-      const illustration = 'illu.svg';
+      const content = AdminCombinedCourseBlueprint.buildContentItems([{ targetProfileId, moduleShortId }]);
+      const adminCombinedCourseBlueprint = new AdminCombinedCourseBlueprint({
+        id: 1,
+        name: 'Combinix',
+        internalName: 'Combinix',
+        description: 'bla bla bla',
+        illustration: 'illu.svg',
+        content,
+        attestationKey: ATTESTATIONS.PARENTHOOD,
+        organizationIds: [1, 2],
+        createdAt: new Date(),
+      });
 
-      const blueprintQuest = new Quest({
+      const expectedBlueprintQuest = new Quest({
+        rewardId: 1,
+        rewardType: REWARD_TYPES.ATTESTATION,
         eligibilityRequirements: [],
         successRequirements: [
-          {
-            requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
-            comparison: REQUIREMENT_COMPARISONS.ALL,
-            data: {
-              targetProfileId: {
-                data: targetProfileId,
-                comparison: CRITERION_COMPARISONS.EQUAL,
-              },
-              status: {
-                data: 'SHARED',
-                comparison: CRITERION_COMPARISONS.EQUAL,
-              },
-            },
-          },
-          {
-            requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
-            comparison: REQUIREMENT_COMPARISONS.ALL,
-            data: {
-              moduleId: {
-                data: 'eeeb4951-6f38-4467-a4ba-0c85ed71321a',
-                comparison: CRITERION_COMPARISONS.EQUAL,
-              },
-              isTerminated: {
-                data: true,
-                comparison: CRITERION_COMPARISONS.EQUAL,
-              },
-            },
-          },
+          CombinedCourseBlueprint.buildRequirementForCombinedCourse({ targetProfileId: targetProfileId }),
+          CombinedCourseBlueprint.buildRequirementForCombinedCourse({ moduleId }),
         ],
       });
 
       // when
       const combinedCourseBlueprint = CombinedCourseBlueprint.buildWithQuest({
-        combinedCourseBlueprint: new CombinedCourseBlueprint({
-          name,
-          content: combinedCourseContent,
-          quest: blueprintQuest,
-          description,
-          illustration,
-        }),
+        adminCombinedCourseBlueprint,
         modulesByShortId,
+        rewardId: 1,
+        rewardType: REWARD_TYPES.ATTESTATION,
       });
 
       // then
-      const questDTO = blueprintQuest.toDTO();
-      const targetProfileRequirement = questDTO.successRequirements[0];
-      const moduleRequirementWithId = {
-        ...questDTO.successRequirements[1],
-        data: {
-          ...questDTO.successRequirements[1].data,
-          moduleId: { data: moduleId, comparison: CRITERION_COMPARISONS.EQUAL },
-        },
-      };
+      expect(combinedCourseBlueprint).to.be.instanceOf(CombinedCourseBlueprint);
+      expect(combinedCourseBlueprint.name).to.equal(adminCombinedCourseBlueprint.name);
+      expect(combinedCourseBlueprint.internalName).to.equal(adminCombinedCourseBlueprint.internalName);
+      expect(combinedCourseBlueprint.description).to.equal(adminCombinedCourseBlueprint.description);
+      expect(combinedCourseBlueprint.illustration).to.equal(adminCombinedCourseBlueprint.illustration);
+      expect(combinedCourseBlueprint.createdAt).to.equal(adminCombinedCourseBlueprint.createdAt);
+      expect(combinedCourseBlueprint.organizationIds).to.deep.equal([1, 2]);
 
-      //todo: check content as well
       expect(combinedCourseBlueprint.quest).to.be.instanceOf(Quest);
-      expect(combinedCourseBlueprint.quest.toDTO().successRequirements[0]).to.deep.equal(targetProfileRequirement);
-
-      expect(combinedCourseBlueprint.quest.toDTO().successRequirements.length).to.equal(2);
-
-      expect(combinedCourseBlueprint.quest.toDTO().successRequirements[1]).to.deep.equal(moduleRequirementWithId);
+      expect(combinedCourseBlueprint.quest).to.deep.equal(expectedBlueprintQuest);
     });
   });
 
@@ -475,6 +249,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourseBlueprint ', function (
       expect(combinedCourseBlueprint.organizationIds).empty;
     });
   });
+
   describe('#attachOrganizations', function () {
     it('should add organization ids to the model instance', async function () {
       //given

--- a/api/tests/quest/unit/infrastructure/repositories/attestation-repository_test.js
+++ b/api/tests/quest/unit/infrastructure/repositories/attestation-repository_test.js
@@ -1,0 +1,23 @@
+import { Attestation } from '../../../../../src/profile/domain/models/Attestation.js';
+import * as attestationRepository from '../../../../../src/quest/infrastructure/repositories/attestation-repository.js';
+import { expect, sinon } from '../../../../test-helper.js';
+
+describe('Quest | Unit | Infrastructure | Repositories | attestation-repository', function () {
+  let rewardApiStub, now;
+
+  beforeEach(async function () {
+    now = new Date();
+    rewardApiStub = {
+      getByIdAndType: sinon
+        .stub()
+        .resolves(new Attestation({ id: 1, templateName: 'templateName', key: 'KEY', createdAt: now })),
+    };
+  });
+  describe('#getByRewardId', function () {
+    it('should return an attestation key if reward id exists', async function () {
+      const result = await attestationRepository.getByRewardId({ rewardId: 1, rewardApi: rewardApiStub });
+      expect(result).to.be.instanceOf(Attestation);
+      expect(result).to.deep.equal({ id: 1, templateName: 'templateName', key: 'KEY', createdAt: now });
+    });
+  });
+});

--- a/api/tests/quest/unit/infrastructure/serializers/admin-combined-course-blueprint-serializer_test.js
+++ b/api/tests/quest/unit/infrastructure/serializers/admin-combined-course-blueprint-serializer_test.js
@@ -1,0 +1,112 @@
+import {
+  ADMIN_COMBINED_COURSE_BLUEPRINT_ITEMS,
+  AdminCombinedCourseBlueprint,
+} from '../../../../../src/quest/domain/models/AdminCombinedCourseBlueprint.js';
+import * as adminCombinedCourseBlueprintSerializer from '../../../../../src/quest/infrastructure/serializers/admin-combined-course-blueprint-serializer.js';
+import { expect } from '../../../../test-helper.js';
+
+describe('Quest | Unit | Infrastructure | Serializers | admin-combined-course-blueprint', function () {
+  it('#serialize', function () {
+    // given
+    const adminCombinedCourseBlueprint = new AdminCombinedCourseBlueprint({
+      id: 1,
+      name: 'Mon parcours',
+      internalName: 'Mon modèle de parcours',
+      description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+      illustration: '/illustrations/image.svg',
+      content: AdminCombinedCourseBlueprint.buildContentItems([
+        { moduleShortId: 'mon-module' },
+        { targetProfileId: 123 },
+      ]),
+      attestationKey: 'PARENTHOOD',
+      organizationIds: [],
+    });
+
+    // when
+    const serializedCombinedCourseBlueprint =
+      adminCombinedCourseBlueprintSerializer.serialize(adminCombinedCourseBlueprint);
+
+    // then
+    expect(serializedCombinedCourseBlueprint).to.deep.equal({
+      data: {
+        attributes: {
+          name: 'Mon parcours',
+          'internal-name': 'Mon modèle de parcours',
+          illustration: '/illustrations/image.svg',
+          description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+          content: [
+            {
+              type: ADMIN_COMBINED_COURSE_BLUEPRINT_ITEMS.MODULE,
+              value: 'mon-module',
+            },
+            {
+              type: ADMIN_COMBINED_COURSE_BLUEPRINT_ITEMS.EVALUATION,
+              value: 123,
+            },
+          ],
+          'created-at': adminCombinedCourseBlueprint.createdAt,
+          'updated-at': adminCombinedCourseBlueprint.updatedAt,
+          'attestation-key': 'PARENTHOOD',
+        },
+        type: 'combined-course-blueprints',
+        id: '1',
+      },
+    });
+  });
+
+  it('#deserialize', async function () {
+    const date = new Date();
+    // given
+    const serializedBlueprint = {
+      data: {
+        attributes: {
+          name: 'Mon parcours',
+          'internal-name': 'Mon modèle de parcours',
+          illustration: '/illustrations/image.svg',
+          description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+          'attestation-key': 'SIXTH_GRADE',
+          content: [
+            {
+              type: 'passages',
+              value: 'mon-module',
+            },
+            {
+              type: 'campaignParticipations',
+              value: 123,
+            },
+          ],
+          'created-at': date,
+          'updated-at': date,
+        },
+        type: 'combined-course-blueprints',
+        id: '1',
+      },
+    };
+
+    // when
+    const deserialize = await adminCombinedCourseBlueprintSerializer.deserialize(serializedBlueprint);
+
+    // then
+    expect(deserialize).deep.equal({
+      id: '1',
+      name: 'Mon parcours',
+      internalName: 'Mon modèle de parcours',
+      illustration: '/illustrations/image.svg',
+      description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+      content: [
+        {
+          type: 'passages',
+          value: 'mon-module',
+        },
+        {
+          type: 'campaignParticipations',
+          value: 123,
+        },
+      ],
+      attestationKey: 'SIXTH_GRADE',
+      organizationIds: [],
+      createdAt: date,
+      updatedAt: date,
+    });
+  });
+});

--- a/api/tests/quest/unit/infrastructure/serializers/combined-course-blueprint-serializer_test.js
+++ b/api/tests/quest/unit/infrastructure/serializers/combined-course-blueprint-serializer_test.js
@@ -1,17 +1,28 @@
 import {
-  COMBINED_COURSE_BLUEPRINT_ITEMS,
-  CombinedCourseBlueprint,
-} from '../../../../../src/quest/domain/models/CombinedCourseBlueprint.js';
-import { Module } from '../../../../../src/quest/domain/models/Module.js';
+  ADMIN_COMBINED_COURSE_BLUEPRINT_ITEMS,
+  AdminCombinedCourseBlueprint,
+} from '../../../../../src/quest/domain/models/AdminCombinedCourseBlueprint.js';
+import { CombinedCourseBlueprint } from '../../../../../src/quest/domain/models/CombinedCourseBlueprint.js';
 import * as combinedCourseBlueprintSerializer from '../../../../../src/quest/infrastructure/serializers/combined-course-blueprint-serializer.js';
-import { domainBuilder, expect } from '../../../../test-helper.js';
+import { expect } from '../../../../test-helper.js';
 
 describe('Quest | Unit | Infrastructure | Serializers | combined-course-blueprint', function () {
   it('#serialize', function () {
     // given
-    const combinedCourseBlueprint = domainBuilder.buildCombinedCourseBlueprint({
-      content: CombinedCourseBlueprint.buildContentItems([{ moduleShortId: 'mon-module' }, { targetProfileId: 123 }]),
-      modulesByShortId: { 'mon-module': [new Module({ id: '1' })] },
+    const combinedCourseBlueprint = CombinedCourseBlueprint.buildWithQuest({
+      adminCombinedCourseBlueprint: new AdminCombinedCourseBlueprint({
+        id: 1,
+        name: 'Mon parcours',
+        internalName: 'Mon modèle de parcours',
+        description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+        illustration: '/illustrations/image.svg',
+        content: AdminCombinedCourseBlueprint.buildContentItems([
+          { moduleShortId: 'mon-module' },
+          { targetProfileId: 123 },
+        ]),
+        attestationKey: 'PARENTHOOD',
+        organizationIds: [],
+      }),
     });
 
     // when
@@ -28,16 +39,17 @@ describe('Quest | Unit | Infrastructure | Serializers | combined-course-blueprin
             description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
             content: [
               {
-                type: COMBINED_COURSE_BLUEPRINT_ITEMS.MODULE,
+                type: ADMIN_COMBINED_COURSE_BLUEPRINT_ITEMS.MODULE,
                 value: 'mon-module',
               },
               {
-                type: COMBINED_COURSE_BLUEPRINT_ITEMS.EVALUATION,
+                type: ADMIN_COMBINED_COURSE_BLUEPRINT_ITEMS.EVALUATION,
                 value: 123,
               },
             ],
             'created-at': combinedCourseBlueprint.createdAt,
             'updated-at': combinedCourseBlueprint.updatedAt,
+            'attestation-key': 'PARENTHOOD',
           },
           type: 'combined-course-blueprints',
           id: '1',
@@ -79,8 +91,7 @@ describe('Quest | Unit | Infrastructure | Serializers | combined-course-blueprin
     const deserialize = await combinedCourseBlueprintSerializer.deserialize(serializedBlueprint);
 
     // then
-    expect(deserialize.attestationKey).to.equal('SIXTH_GRADE');
-    expect(deserialize.combinedCourseBlueprint).deep.equal({
+    expect(deserialize).deep.equal({
       id: '1',
       name: 'Mon parcours',
       internalName: 'Mon modèle de parcours',
@@ -96,7 +107,7 @@ describe('Quest | Unit | Infrastructure | Serializers | combined-course-blueprin
           value: 123,
         },
       ],
-      quest: null,
+      attestationKey: 'SIXTH_GRADE',
       organizationIds: [],
       createdAt: date,
       updatedAt: date,

--- a/api/tests/quest/unit/infrastructure/serializers/combined-course-blueprint-serializer_test.js
+++ b/api/tests/quest/unit/infrastructure/serializers/combined-course-blueprint-serializer_test.js
@@ -1,7 +1,3 @@
-import {
-  ADMIN_COMBINED_COURSE_BLUEPRINT_ITEMS,
-  AdminCombinedCourseBlueprint,
-} from '../../../../../src/quest/domain/models/AdminCombinedCourseBlueprint.js';
 import { CombinedCourseBlueprint } from '../../../../../src/quest/domain/models/CombinedCourseBlueprint.js';
 import * as combinedCourseBlueprintSerializer from '../../../../../src/quest/infrastructure/serializers/combined-course-blueprint-serializer.js';
 import { expect } from '../../../../test-helper.js';
@@ -9,108 +5,32 @@ import { expect } from '../../../../test-helper.js';
 describe('Quest | Unit | Infrastructure | Serializers | combined-course-blueprint', function () {
   it('#serialize', function () {
     // given
-    const combinedCourseBlueprint = CombinedCourseBlueprint.buildWithQuest({
-      adminCombinedCourseBlueprint: new AdminCombinedCourseBlueprint({
-        id: 1,
-        name: 'Mon parcours',
-        internalName: 'Mon modèle de parcours',
-        description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
-        illustration: '/illustrations/image.svg',
-        content: AdminCombinedCourseBlueprint.buildContentItems([
-          { moduleShortId: 'mon-module' },
-          { targetProfileId: 123 },
-        ]),
-        attestationKey: 'PARENTHOOD',
-        organizationIds: [],
-      }),
+    const combinedCourseBlueprint = new CombinedCourseBlueprint({
+      id: 1,
+      name: 'Mon parcours',
+      internalName: 'Mon modèle de parcours',
+      description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+      illustration: '/illustrations/image.svg',
+      organizationIds: [],
     });
 
     // when
-    const serializedCombinedCourseBlueprints = combinedCourseBlueprintSerializer.serialize([combinedCourseBlueprint]);
+    const serializedCombinedCourseBlueprints = combinedCourseBlueprintSerializer.serialize(combinedCourseBlueprint);
 
     // then
     expect(serializedCombinedCourseBlueprints).to.deep.equal({
-      data: [
-        {
-          attributes: {
-            name: 'Mon parcours',
-            'internal-name': 'Mon modèle de parcours',
-            illustration: '/illustrations/image.svg',
-            description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
-            content: [
-              {
-                type: ADMIN_COMBINED_COURSE_BLUEPRINT_ITEMS.MODULE,
-                value: 'mon-module',
-              },
-              {
-                type: ADMIN_COMBINED_COURSE_BLUEPRINT_ITEMS.EVALUATION,
-                value: 123,
-              },
-            ],
-            'created-at': combinedCourseBlueprint.createdAt,
-            'updated-at': combinedCourseBlueprint.updatedAt,
-            'attestation-key': 'PARENTHOOD',
-          },
-          type: 'combined-course-blueprints',
-          id: '1',
-        },
-      ],
-    });
-  });
-
-  it('#deserialize', async function () {
-    const date = new Date();
-    // given
-    const serializedBlueprint = {
       data: {
         attributes: {
           name: 'Mon parcours',
           'internal-name': 'Mon modèle de parcours',
           illustration: '/illustrations/image.svg',
           description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
-          'attestation-key': 'SIXTH_GRADE',
-          content: [
-            {
-              type: 'passages',
-              value: 'mon-module',
-            },
-            {
-              type: 'campaignParticipations',
-              value: 123,
-            },
-          ],
-          'created-at': date,
-          'updated-at': date,
+          'created-at': combinedCourseBlueprint.createdAt,
+          'updated-at': combinedCourseBlueprint.updatedAt,
         },
         type: 'combined-course-blueprints',
         id: '1',
       },
-    };
-
-    // when
-    const deserialize = await combinedCourseBlueprintSerializer.deserialize(serializedBlueprint);
-
-    // then
-    expect(deserialize).deep.equal({
-      id: '1',
-      name: 'Mon parcours',
-      internalName: 'Mon modèle de parcours',
-      illustration: '/illustrations/image.svg',
-      description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
-      content: [
-        {
-          type: 'passages',
-          value: 'mon-module',
-        },
-        {
-          type: 'campaignParticipations',
-          value: 123,
-        },
-      ],
-      attestationKey: 'SIXTH_GRADE',
-      organizationIds: [],
-      createdAt: date,
-      updatedAt: date,
     });
   });
 });

--- a/api/tests/tooling/domain-builder/factory/build-combined-course-blueprint.js
+++ b/api/tests/tooling/domain-builder/factory/build-combined-course-blueprint.js
@@ -1,7 +1,4 @@
-import {
-  COMBINED_COURSE_BLUEPRINT_ITEMS,
-  CombinedCourseBlueprint,
-} from '../../../../src/quest/domain/models/CombinedCourseBlueprint.js';
+import { CombinedCourseBlueprint } from '../../../../src/quest/domain/models/CombinedCourseBlueprint.js';
 
 function buildCombinedCourseBlueprint({
   id = 1,
@@ -11,25 +8,19 @@ function buildCombinedCourseBlueprint({
   illustration = '/illustrations/image.svg',
   createdAt = new Date(),
   updatedAt = new Date(),
-  content = [{ type: COMBINED_COURSE_BLUEPRINT_ITEMS.MODULE, value: 'module-123' }],
   organizationIds = [],
-  modulesByShortId,
   quest,
 } = {}) {
-  return CombinedCourseBlueprint.buildWithQuest({
-    combinedCourseBlueprint: {
-      id,
-      name,
-      internalName,
-      description,
-      illustration,
-      content,
-      createdAt,
-      updatedAt,
-      organizationIds,
-      quest,
-    },
-    modulesByShortId,
+  return new CombinedCourseBlueprint({
+    id,
+    name,
+    internalName,
+    description,
+    illustration,
+    createdAt,
+    updatedAt,
+    organizationIds,
+    quest,
   });
 }
 

--- a/api/tests/tooling/domain-builder/factory/build-quest.js
+++ b/api/tests/tooling/domain-builder/factory/build-quest.js
@@ -1,0 +1,24 @@
+import { REWARD_TYPES } from '../../../../src/quest/domain/constants.js';
+import { Quest } from '../../../../src/quest/domain/models/Quest.js';
+
+function buildQuest({
+  id = 1,
+  createdAt = new Date(),
+  updatedAt = new Date(),
+  rewardId = 1,
+  rewardType = REWARD_TYPES.ATTESTATION,
+  eligibilityRequirements = [],
+  successRequirements = [],
+} = {}) {
+  return new Quest({
+    id,
+    createdAt,
+    updatedAt,
+    rewardId,
+    rewardType,
+    eligibilityRequirements,
+    successRequirements,
+  });
+}
+
+export { buildQuest };

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -119,6 +119,7 @@ import { buildPrescriber } from './build-prescriber.js';
 import { buildPrivateCertificate } from './build-private-certificate.js';
 import { buildPrivateCertificate as buildPrivateCertificateWithCompetenceTree } from './build-private-certificate-with-competence-tree.js';
 import { buildProgression } from './build-progression.js';
+import { buildQuest } from './build-quest.js';
 import { buildReproducibilityRate } from './build-reproducibility-rate.js';
 import { buildResultCompetenceTree } from './build-result-competence-tree.js';
 import { buildSchoolAssessment } from './build-school-assessment.js';
@@ -480,6 +481,7 @@ export {
   buildPrivateCertificate,
   buildPrivateCertificateWithCompetenceTree,
   buildProgression,
+  buildQuest,
   buildReproducibilityRate,
   buildResultCompetenceTree,
   buildSchoolAssessment,


### PR DESCRIPTION
## 🌱 Problème

On a modifié la mécanique interne aux blueprints pour ne plus avoir besoin de l'attribut `content` mais on s'en sert encore pour afficher le détail d'un blueprint.

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

## 🐣 Proposition

On crée un modèle `AdminCombinedCourseBlueprint` et un sérialiseur dédié pour faire l'adaptation entre le front (Pix Admin) et le domaine métier qui n'utilise plus l'attribut `content`.

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 🌷 Remarques

RAS

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🐝 Pour tester

Sur Pix Admin, afficher la liste des modèles de parcours apprenants.
Afficher le détail d'un parcours apprenant.
Créer un parcours apprenant, avec et sans attestation.

<!--
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc.
- [ ] Documentation de la fonctionnalité (lien)
-->
