### PR TITLE
[TECH] Modifier la façon d'envoyer les credentials dans l'action create-jira-version.yaml

### DIFF
--- a/.github/workflows/create-jira-version.yaml
+++ b/.github/workflows/create-jira-version.yaml
@@ -11,10 +11,9 @@ jobs:
     steps:
       - name: Create version in Jira
         run: |
-          AUTH_HEADER=$(echo -n "${{ secrets.JIRA_USER_EMAIL }}:${{ secrets.JIRA_API_TOKEN }}" | base64)
           curl -X POST \
-            -H "Authorization: Basic $AUTH_HEADER" \
             -H "Content-Type: application/json" \
+            --user "${{ secrets.JIRA_USER_EMAIL }}:${{ secrets.JIRA_API_TOKEN }}" \
             --url "${{ secrets.JIRA_BASE_URL }}/rest/api/3/version" \
             -d "{
               \"name\": \"${{ github.event.release.tag_name }}\",


### PR DESCRIPTION
## 🌱 Problème
La github action permettant de créer une version dans Jira à chaque release ne fonctionne plus. Nous avons mis à jour les l'email et le token mais nous recevons une erreur 43 de curl. Le token actuel est beaucoup plus long que le précédent, peut-être que la conversion manuelle en base64 se passe mal.  

## 🐣 Proposition
Modifier la façon d'envoyer les credentials dans l'action create-jira-version.yaml