### PR TITLE
[FEATURE] Renommer "langues localisées" en "locales" (PIX-22184)

### DIFF
--- a/admin/tests/integration/components/trainings/create-or-update-training-form-test.gjs
+++ b/admin/tests/integration/components/trainings/create-or-update-training-form-test.gjs
@@ -41,7 +41,7 @@ module('Integration | Component | trainings | CreateOrUpdateTrainingForm', funct
     assert.dom(screen.getByLabelText('Jours (JJ)')).exists();
     assert.dom(screen.getByLabelText('Heures (HH)')).exists();
     assert.dom(screen.getByLabelText('Minutes (MM)')).exists();
-    assert.dom(screen.getByLabelText('Langues localisées')).exists();
+    assert.dom(screen.getByLabelText('Locales')).exists();
     assert
       .dom(
         screen.getByRole('textbox', {
@@ -116,7 +116,7 @@ module('Integration | Component | trainings | CreateOrUpdateTrainingForm', funct
       assert.dom(screen.getByLabelText('Jours (JJ)')).hasValue(model.duration.days.toString());
       assert.dom(screen.getByLabelText('Heures (HH)')).hasValue(model.duration.hours.toString());
       assert.dom(screen.getByLabelText('Minutes (MM)')).hasValue(model.duration.minutes.toString());
-      assert.strictEqual(screen.getByLabelText('Langues localisées').innerText, localeCategories[model.locales[0]]);
+      assert.strictEqual(screen.getByLabelText('Locales').innerText, localeCategories[model.locales[0]]);
 
       assert
         .dom(

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -1867,6 +1867,12 @@
         "error-messages": {
           "incorrect-editor-logo-url-format": "The url format of the editor's logo is incorrect."
         },
+        "form": {
+          "locales": {
+            "label": "Locales",
+            "placeholder": "-- Select one or more locales --"
+          }
+        },
         "list": {
           "caption": "Trainings list",
           "goalThreshold": "Goal Threshold",

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -1842,7 +1842,7 @@
           "editorLogo": "Editor logo url",
           "editorName": "Editor name",
           "internalTitle": "Internal title",
-          "locales": "{ count, plural, one {Localized language} other {Localized languages}}",
+          "locales": "{ count, plural, one {Locale} other {Locales}}",
           "localizedLanguage": "Localized language",
           "publishedOn": "Published on",
           "status": "Status",

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -1843,7 +1843,6 @@
           "editorName": "Editor name",
           "internalTitle": "Internal title",
           "locales": "{ count, plural, one {Locale} other {Locales}}",
-          "localizedLanguage": "Localized language",
           "publishedOn": "Published on",
           "status": "Status",
           "status-label": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -1851,7 +1851,7 @@
           "editorLogo": "Url du logo de l'éditeur",
           "editorName": "Nom d'éditeur",
           "internalTitle": "Titre interne",
-          "locales": "{ count, plural, one {Langue localisée} other {Langues localisées}}",
+          "locales": "{ count, plural, one {Locale} other {Locales}}",
           "localizedLanguage": "Langue localisée",
           "publishedOn": "Publié sur",
           "status": "Statut",
@@ -1878,8 +1878,8 @@
         },
         "form": {
           "locales": {
-            "label": "Langues localisées",
-            "placeholder": "-- Sélectionnez une ou plusieurs langues --"
+            "label": "Locales",
+            "placeholder": "-- Sélectionnez une ou plusieurs locales --"
           }
         },
         "list": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -1852,7 +1852,6 @@
           "editorName": "Nom d'éditeur",
           "internalTitle": "Titre interne",
           "locales": "{ count, plural, one {Locale} other {Locales}}",
-          "localizedLanguage": "Langue localisée",
           "publishedOn": "Publié sur",
           "status": "Statut",
           "status-label": {


### PR DESCRIPTION
## 🌱 Problème

Dans PixAdmin, lors de la consultation/création/modification d’un contenu formatif il faudrait renommer le champ “Langue(s) localisée(s)” en “Locale(s)”. Ceci permet de s’assurer que tout le monde utilise les mêmes termes pour parler des même choses.

## 🐣 Proposition

Modifier les traductions pour renommer le champ en question.

## 🌷 Remarques

- J'en ai profité pour supprimer une entrée non utilisée dans les fichier de traduction.

## 🐝 Pour tester

- Ouvrir [PixAdmin](https://admin-pr15756.review.pix.fr/) et se connecter
- Vérifier que dans les écrans d'affiche, création, modification d'un CF, on voit maintenant "locale" ou "locales"
