### PR TITLE
[TECH] Corriger l'utilisation du logger dans le code de PgBoss

### DIFF
--- a/api/src/shared/infrastructure/jobs/JobQueue.js
+++ b/api/src/shared/infrastructure/jobs/JobQueue.js
@@ -23,13 +23,13 @@ class JobQueue {
       );
     });
 
-    this.pgBoss.onComplete(name, { teamSize, teamConcurrency }, (job) => {
-      const context = initContext(job);
+    this.pgBoss.onComplete(name, { teamSize, teamConcurrency }, (completedJob) => {
+      const context = initContext(completedJob.data.request);
       return executeInContext(
         context,
         async () => {
           const monitoringJobHandler = new MonitoringJobExecutionTimeHandler({ logger });
-          return monitoringJobHandler.handle(job);
+          return monitoringJobHandler.handle(completedJob);
         },
         EXECUTORS.JOB,
       );

--- a/api/src/shared/infrastructure/jobs/monitoring/MonitoredJobHandler.js
+++ b/api/src/shared/infrastructure/jobs/monitoring/MonitoredJobHandler.js
@@ -35,24 +35,30 @@ class MonitoredJobHandler {
   }
 
   logJobStarting({ data, jobName, jobId }) {
-    this.logger.info({
-      data,
-      handlerName: jobName,
-      type: 'JOB_LOG',
-      message: 'Job Started',
-      jobId,
-    });
+    this.logger.info(
+      {
+        data,
+        handlerName: jobName,
+        type: 'JOB_LOG',
+        message: 'Job Started',
+        jobId,
+      },
+      'PGBOSS JOB STARTING',
+    );
   }
 
   logJobFailed({ data, jobName, jobId, error }) {
-    this.logger.error({
-      data,
-      handlerName: jobName,
-      error: error?.message ? error.message + ' (see dedicated log for more information)' : undefined,
-      type: 'JOB_LOG_ERROR',
-      message: 'Job failed',
-      jobId,
-    });
+    this.logger.error(
+      {
+        data,
+        handlerName: jobName,
+        error: error?.message ? error.message + ' (see dedicated log for more information)' : undefined,
+        type: 'JOB_LOG_ERROR',
+        message: 'Job failed',
+        jobId,
+      },
+      'PGBOSS ERROR IN JOB',
+    );
   }
 }
 

--- a/api/src/shared/infrastructure/jobs/monitoring/MonitoringJobExecutionTimeHandler.js
+++ b/api/src/shared/infrastructure/jobs/monitoring/MonitoringJobExecutionTimeHandler.js
@@ -12,13 +12,16 @@ class MonitoringJobExecutionTimeHandler {
     const totalTime = completedOn.diff(createdOn, 'second', true);
     const executionTime = completedOn.diff(startedOn, 'second', true);
 
-    this.logger.info({
-      event: 'pg-boss-execution-time',
-      type: 'JOB_LOG_EXEC_TIME',
-      handlerName: job.data.request.name,
-      executionTime,
-      totalTime,
-    });
+    this.logger.info(
+      {
+        event: 'pg-boss-execution-time',
+        type: 'JOB_LOG_EXEC_TIME',
+        handlerName: job.data.request.name,
+        executionTime,
+        totalTime,
+      },
+      'PGBOSS ONCOMPLETE',
+    );
   }
 }
 

--- a/api/worker.js
+++ b/api/worker.js
@@ -40,17 +40,17 @@ export async function startPgBoss() {
     ...(monitorStateIntervalSeconds ? { monitorStateIntervalSeconds } : {}),
     archiveFailedAfterSeconds: config.pgBoss.archiveFailedAfterSeconds,
   });
-  pgBoss.on('monitor-states', (state) => {
-    logger.info({ event: 'pg-boss-state', name: 'global' }, { ...state, queues: undefined });
-    _.each(state.queues, (queueState, queueName) => {
-      logger.info({ event: 'pg-boss-state', name: queueName }, queueState);
+  pgBoss.on('monitor-states', ({ queues, ...state }) => {
+    logger.info({ event: 'pg-boss-state', name: 'global', queue: state }, 'PGBOSS MONITOR-STATES');
+    _.each(queues, (queue, name) => {
+      logger.info({ event: 'pg-boss-state', name, queue }, 'PGBOSS MONITOR-STATES');
     });
   });
   pgBoss.on('error', (err) => {
-    logger.error({ event: 'pg-boss-error' }, err);
+    logger.info({ err, event: 'pg-boss-error' }, 'PGBOSS ERROR');
   });
   pgBoss.on('wip', (data) => {
-    logger.info({ event: 'pg-boss-wip' }, data);
+    logger.info({ data, event: 'pg-boss-wip' }, 'PGBOSS WIP');
   });
   if (config.pgBoss.connexionPoolMaxSize !== 0) {
     await pgBoss.start();


### PR DESCRIPTION
## 🌱 Problème

On constate deux problèmes dans les logs de PgBoss :
- On n'a pas les infos de corrélation dans le log du `onComplete`
- On a des logs bizarres avec des `undefined` ou `Object object`

<img width="1175" height="38" alt="image" src="https://github.com/user-attachments/assets/b2ad8378-a8aa-4dbf-b02e-7ea9a3857a1c" />


## 🐣 Proposition

Pour les infos de corrélation : dans le hook `onComplete`, on n'a pas un objet `job` du même type que dans le handler, mais plutôt quelque chose qui s'apparente à un job complété, donc les infos de corrélation n'étaient pas au même endroit. (dans `job.data.request`)

Pour les logs chelou :
- Lorsqu'on utilise le logger, bien mettre dans l'ordre d'abord le mergingObject puis le message : `logger.info(mergingObject, message)`
- Ajout de messages dans les logs qui n'en avaient pas

## 🌷 Remarques

Les données de job pour le log concernant l'event `pg-boss-state` étaient jusqu`à présent mis dans le message puis on avait ajouté une étape de pipeline dans datadog pour déplacer le contenu de `msg` dans `queue`. On reproduit ce comportement dans le code. Ainsi dès lors que cette PR sera en production, on pourra désactiver cette étape de pipeline

## 🐝 Pour tester
- Mettre la variable d'env START_JOB_IN_WEB_PROCESS à faux
- Lancer à part le gestionnaire de jobs :
```sh
node npm run start:job
```
- Sur l'application Pix, faites une opération pour déclencher un job (inscription par exemple)
- Voir qu'on n'a plus de logs bizarre, et que tous les logs supposés avoir une donnée de corrélation l'ont
