### PR TITLE
[TECH] Désactiver l'exécution des scripts de cycle de vie (postinstall, preinstall) lors de l'installation de paquets npm

### DIFF
--- a/.circleci/jobs.yml
+++ b/.circleci/jobs.yml
@@ -187,6 +187,22 @@ commands:
           paths:
             - ~/.npm
 
+  npm_install_cypress_with_cache:
+    parameters:
+      cache_key:
+        type: string
+    steps:
+      - run: cat package*.json > cachekey
+      - restore_cache:
+          keys:
+            - v7-<<parameters.cache_key>>-npm-{{ checksum "cachekey" }}
+      - run: npm ci
+      - run: npx cypress install
+      - save_cache:
+          key: v7-<<parameters.cache_key>>-npm-{{ checksum "cachekey" }}
+          paths:
+            - ~/.npm
+
   frontend_build:
     parameters:
       app_name:
@@ -964,7 +980,7 @@ jobs:
           background: true
       - attach_workspace:
           at: ~/pix
-      - npm_install_with_cache:
+      - npm_install_cypress_with_cache:
           cache_key: e2e
       - run:
           name: Lint
@@ -1044,7 +1060,7 @@ jobs:
           background: true
       - attach_workspace:
           at: ~/pix
-      - npm_install_with_cache:
+      - npm_install_cypress_with_cache:
           cache_key: e2e
       - run:
           name: Lint

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/admin/.npmrc
+++ b/admin/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/api/.npmrc
+++ b/api/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/audit-logger/.npmrc
+++ b/audit-logger/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/certif/.npmrc
+++ b/certif/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/high-level-tests/e2e-playwright/.npmrc
+++ b/high-level-tests/e2e-playwright/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/high-level-tests/e2e/.npmrc
+++ b/high-level-tests/e2e/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/high-level-tests/load-testing/.npmrc
+++ b/high-level-tests/load-testing/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/junior/.npmrc
+++ b/junior/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/mon-pix/.npmrc
+++ b/mon-pix/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/orga/.npmrc
+++ b/orga/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/package.json
+++ b/package.json
@@ -49,8 +49,6 @@
     "clean:junior": "cd junior && npm run clean",
     "clean:root": "rm -rf node_modules && rm -rf tmp",
     "configure": "./scripts/configure.sh",
-    "install:components": "cd api && npm i @1024pix/epreuves-components@latest && cd ../mon-pix && npm i @1024pix/epreuves-components@latest && cd ../junior && npm i @1024pix/epreuves-components@latest",
-    "postinstall:components": "node api/scripts/modulix/generate-demo-epreuve-component.js",
     "lint": "run-p --print-label lint:*",
     "lint:admin": "cd admin && npm run lint",
     "lint:api": "cd api && npm run lint",
@@ -89,7 +87,8 @@
     "domains:start": "cd ./scripts/local-domains/ && docker compose up -d",
     "domains:stop": "cd ./scripts/local-domains/ && docker compose down",
     "domains:trust-self-signed-certificate:mac": "cd ./scripts/local-domains/ && docker compose cp caddy:/data/caddy/pki/authorities/local/root.crt /tmp/root.crt && sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain /tmp/root.crt",
-    "domains:trust-self-signed-certificate:linux": "cd ./scripts/local-domains/ && sudo docker cp caddy:/data/caddy/pki/authorities/local/root.crt /usr/local/share/ca-certificates/root.crt && sudo update-ca-certificates --fresh"
+    "domains:trust-self-signed-certificate:linux": "cd ./scripts/local-domains/ && sudo docker cp caddy:/data/caddy/pki/authorities/local/root.crt /usr/local/share/ca-certificates/root.crt && sudo update-ca-certificates --fresh",
+    "demo-epreuves:update": "./scripts/update-demo-epreuves.sh"
   },
   "dependencies": {
     "npm-run-all2": "^8.0.0"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "ci:mon-pix": "cd mon-pix && npm ci",
     "ci:orga": "cd orga && npm ci",
     "ci:junior": "cd junior && npm ci",
-    "compute-lead-times": "node ./scripts/compute-lead-times",
     "clean": "run-p --print-label clean:api clean:audit-logger clean:mon-pix clean:orga clean:certif clean:admin clean:junior && npm run clean:root",
     "clean:admin": "cd admin && npm run clean",
     "clean:api": "cd api && npm run clean",

--- a/scripts/update-demo-epreuves.sh
+++ b/scripts/update-demo-epreuves.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -e
+
+cd api
+npm i @1024pix/epreuves-components@latest
+
+cd ../mon-pix
+npm i @1024pix/epreuves-components@latest
+
+cd ../junior
+npm i @1024pix/epreuves-components@latest
+
+cd ..
+node api/scripts/modulix/generate-demo-epreuve-component.js


### PR DESCRIPTION
## 🌱 Problème

Les installations des dépendances npm peuvent déclencher des scripts `postinstall` et `preinstall`. C'est un risque sécurité lors de potentielles attaques supply-chain.

## 🐣 Proposition

Pour chaque projet, ajouter le fichier `.npmrc` avec `ignore-scripts=true`.

## 🌷 Remarques

1. Le `post-install` à la racine du monorepo était utilisé pour **la mise à jour de la dépendance `1024pix/epreuves-components`** dans différents projets. Il a été remplacé par un script manuel :
```
npm run demo-epreuves:update
```
2. **`Cypress` utilise un `post-install` pour installer ses binaires**. La commande `npx cypress install` a été explicitement ajoutée dans la CI pour l'installer. Une tâche `npm_install_cypress_with_cache` dans `jobs.yml` a été configurée pour gérer le cache correctement.
3. **Scout:** Suppression du script `compute-lead-times` à la racine du monorepo. Le script appelé n'existe pas.

## 🐝 Pour tester

- La CI doit passer et déploiement OK
- Tester `npm run demo-epreuves:update`