### PR TITLE
[TECH] :package: :lock: Force la version de `flatted` pour des raisons de sécurité.

### DIFF
--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -440,13 +440,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/@1024pix/stylelint-config-rational-order/node_modules/flatted": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
-      "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/@1024pix/stylelint-config-rational-order/node_modules/get-stdin": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
@@ -19304,9 +19297,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },

--- a/admin/package.json
+++ b/admin/package.json
@@ -118,5 +118,8 @@
   "exports": {
     "./tests/*": "./tests/*",
     "./*": "./app/*"
+  },
+  "overrides": {
+    "flatted": ">=3.4.2"
   }
 }

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -1185,13 +1185,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/@1024pix/stylelint-config-rational-order/node_modules/flatted": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
-      "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/@1024pix/stylelint-config-rational-order/node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",

--- a/certif/package.json
+++ b/certif/package.json
@@ -45,7 +45,8 @@
     "ember-dayjs": {
       "ember-source": "$ember-source"
     },
-    "handlebars": ">=4.7.9"
+    "handlebars": ">=4.7.9",
+    "flatted":">=3.4.2"
   },
   "devDependencies": {
     "@1024pix/ember-api-actions": "^1.1.0",

--- a/high-level-tests/e2e-playwright/package-lock.json
+++ b/high-level-tests/e2e-playwright/package-lock.json
@@ -2064,9 +2064,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },

--- a/high-level-tests/e2e-playwright/package.json
+++ b/high-level-tests/e2e-playwright/package.json
@@ -57,5 +57,8 @@
   },
   "dependencies": {
     "csv-parse": "^6.2.1"
-  }
+  },
+  "overrides": {
+  "flatted": ">=3.4.2"
+}
 }

--- a/high-level-tests/e2e/package-lock.json
+++ b/high-level-tests/e2e/package-lock.json
@@ -6310,10 +6310,11 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.2.tgz",
-      "integrity": "sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==",
-      "dev": true
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/for-each": {
       "version": "0.3.3",
@@ -16217,14 +16218,14 @@
       "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
       "dev": true,
       "requires": {
-        "flatted": "^3.2.9",
+        "flatted": ">=3.4.2",
         "keyv": "^4.5.4"
       }
     },
     "flatted": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.2.tgz",
-      "integrity": "sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true
     },
     "for-each": {

--- a/high-level-tests/e2e/package.json
+++ b/high-level-tests/e2e/package.json
@@ -50,5 +50,8 @@
   },
   "dependencies": {
     "jsonwebtoken": "8.5.1"
-  }
+  },
+  "overrides": {
+  "flatted": ">=3.4.2"
+}
 }

--- a/junior/package-lock.json
+++ b/junior/package-lock.json
@@ -580,13 +580,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/@1024pix/stylelint-config-rational-order/node_modules/flatted": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
-      "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/@1024pix/stylelint-config-rational-order/node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",

--- a/junior/package.json
+++ b/junior/package.json
@@ -108,5 +108,8 @@
   },
   "ember": {
     "edition": "octane"
-  }
+  },
+  "overrides": {
+    "flatted": ">=3.4.2"  
+}
 }

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -1228,13 +1228,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/@1024pix/stylelint-config-rational-order/node_modules/flatted": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
-      "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/@1024pix/stylelint-config-rational-order/node_modules/glob-parent": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
@@ -27362,9 +27355,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -137,7 +137,8 @@
     "ember-dayjs": {
       "ember-source": "$ember-source"
     },
-    "handlebars": ">=4.7.9"
+    "handlebars": ">=4.7.9",
+    "flatted": ">=3.4.2"
   },
   "engines": {
     "node": "^24.14.1"

--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -1334,13 +1334,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/@1024pix/stylelint-config-rational-order/node_modules/flatted": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
-      "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/@1024pix/stylelint-config-rational-order/node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",

--- a/orga/package.json
+++ b/orga/package.json
@@ -46,7 +46,8 @@
     "ember-dayjs": {
       "ember-source": "$ember-source"
     },
-    "handlebars": ">=4.7.9"
+    "handlebars": ">=4.7.9",
+    "flatted": ">=3.4.2"
   },
   "devDependencies": {
     "@1024pix/ember-cli-notifications": "^8.0.2",


### PR DESCRIPTION
## 🌱 Problème

La version de la librairie `flatted` que nous utilisons dans plusieurs sous-répertoires nous expose à un risque
(exemple : https://github.com/1024pix/pix/security/dependabot/1603

## 🐣 Proposition

forcer la version minimum de la librairie `flatted`

## 🌷 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🐝 Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
