### PR TITLE
[FEATURE] Feature toggles : Lecture synchrone et observabilité

### DIFF
--- a/api/src/shared/infrastructure/feature-toggles/feature-toggles-client.js
+++ b/api/src/shared/infrastructure/feature-toggles/feature-toggles-client.js
@@ -1,5 +1,10 @@
 import Joi from 'joi';
 
+import { getTopic } from '../pubsub.js';
+import { child } from '../utils/logger.js';
+
+const logger = child('feature-toggles', { event: 'feature-toggles' });
+
 const ConfigSchema = Joi.object().pattern(
   Joi.string(),
   Joi.object({
@@ -25,15 +30,23 @@ export class FeatureToggleNotFoundError extends Error {
  * Class representing a feature toggles client.
  */
 export class FeatureTogglesClient {
+  #topic;
+  /** @type {Record<string, any>} */
+  #currentValues;
+  #eventTarget;
+
   /**
    * Create a feature toggles client.
    * @param {KeyValueStorage} storage - A KeyValueStorage instance.
    * @param {'test' | 'reviewApp'} [environment] - environment (test or reviewApp)
+   * @param {import('../pubsub.js').Topic} topic - PubSub topic object
    */
-  constructor(storage, environment) {
+  constructor(storage, environment, topic = getTopic('feature-toggles')) {
     this.storage = storage;
     this.environment = environment;
+    this.#topic = topic;
     this.config = {};
+    this.#eventTarget = new EventTarget();
   }
 
   /**
@@ -60,6 +73,10 @@ export class FeatureTogglesClient {
     }
 
     await this.storage.save({ key: '_config', value: this.config });
+
+    this.#topic.subscribe(async (message) => this.#onMessage(message));
+
+    this.#currentValues = await this.all();
   }
 
   /**
@@ -88,11 +105,34 @@ export class FeatureTogglesClient {
     }
 
     await this.storage.save({ key, value });
+
+    this.#topic.publish({
+      type: 'set',
+      key,
+    });
+  }
+
+  /**
+   * Use a feature toggle reference.
+   *
+   * A feature toggle reference allows synchronously reading the current value,
+   * and watching the value changes.
+   *
+   * @param {string} key - The key of the feature toggle.
+   * @returns {FeatureToggleRef} A reference to the feature toggle’s value
+   */
+  use(key) {
+    const featureToggle = this.config[key];
+    if (!featureToggle) {
+      throw new FeatureToggleNotFoundError(key);
+    }
+
+    return new FeatureToggleRef(key, this.#currentValues, this.#eventTarget);
   }
 
   /**
    * Get all feature toggles.
-   * @returns {Promise<Object>} An object containing all feature toggles.
+   * @returns {Promise<Record<string, any>>} An object containing all feature toggles.
    */
   async all() {
     const values = {};
@@ -106,7 +146,7 @@ export class FeatureTogglesClient {
   /**
    * Get feature toggles with a specific tag.
    * @param {string} tag - The tag to filter feature toggles.
-   * @returns {Promise<Object>} An object containing the filtered feature toggles.
+   * @returns {Promise<Record<string, any>>} An object containing the filtered feature toggles.
    */
   async withTag(tag) {
     const configWithTagEntries = Object.entries(this.config).filter(([, config]) => config.tags?.includes(tag));
@@ -138,5 +178,111 @@ export class FeatureTogglesClient {
     }
 
     return featureToggle.defaultValue;
+  }
+
+  /**
+   * @param {{
+   *   type: 'set'
+   *   key: string
+   * }} message
+   */
+  async #onMessage(message) {
+    if (message.type !== 'set') return;
+
+    const oldValue = this.#currentValues[message.key];
+    const newValue = await this.get(message.key);
+
+    // skip updating/notifying on strict equality,
+    // array/object types will update/notify
+    // even if internal values don't change
+    if (newValue === oldValue) return;
+
+    this.#currentValues[message.key] = newValue;
+
+    this.#eventTarget.dispatchEvent(new FeatureTogglesEvent('set', message.key, newValue, oldValue));
+  }
+}
+
+/**
+ * Reference to a feature toggle.
+ *
+ * Use {@link FeatureTogglesClient#use} to create a new reference.
+ */
+export class FeatureToggleRef {
+  #key;
+  #currentValues;
+  #eventTarget;
+
+  /**
+   * @param {string} key
+   * @param {Record<string, any>} currentValues
+   * @param {EventTarget} eventTarget
+   */
+  constructor(key, currentValues, eventTarget) {
+    this.#key = key;
+    this.#currentValues = currentValues;
+    this.#eventTarget = eventTarget;
+  }
+
+  /**
+   * Current value of the feature toggle.
+   */
+  get value() {
+    return this.#currentValues[this.#key];
+  }
+
+  /**
+   * Watch the feature toggle value changes.
+   *
+   * @typedef {() => void} UnwatchFeatureToggleFn
+   * @typedef {(value: any, oldValue: any) => any | Promise<any>} WatchFeatureToggleCallback
+   *
+   * @param {WatchFeatureToggleCallback} callback Callback function receiving the value changes.
+   * @returns {UnwatchFeatureToggleFn} Unwatch function.
+   */
+  watch(callback) {
+    /**
+     * @param {FeatureTogglesEvent} event
+     */
+    const listener = async (event) => {
+      if (event.detail.key !== this.#key) return;
+      try {
+        await callback(event.detail.value, event.detail.oldValue);
+      } catch (err) {
+        logger.error({ err, featureToggleKey: this.#key }, 'error in feature toggle watcher');
+      }
+    };
+    this.#eventTarget.addEventListener('set', listener);
+    return () => {
+      this.#eventTarget.removeEventListener('set', listener);
+    };
+  }
+}
+
+/**
+ * @typedef {{
+ *   key: string
+ *   value: any
+ *   oldValue: any
+ * }} FeatureToggleEventDetail
+ *
+ * @extends {CustomEvent<FeatureToggleEventDetail>}
+ */
+class FeatureTogglesEvent extends CustomEvent {
+  /**
+   *
+   * @param {string} type
+   * @param {string} key
+   * @param {any} value
+   * @param {any} oldValue
+   */
+  constructor(type, key, value, oldValue) {
+    super(type, {
+      detail: {
+        key,
+        value,
+        oldValue,
+      },
+    });
   }
 }

--- a/api/tests/shared/unit/infrastructure/feature-toggles/feature-toggles-client.test.js
+++ b/api/tests/shared/unit/infrastructure/feature-toggles/feature-toggles-client.test.js
@@ -1,12 +1,20 @@
+import { setImmediate } from 'node:timers/promises';
+
+import { createPubSub } from '@graphql-yoga/subscription';
 import Joi from 'joi';
 
-import { FeatureTogglesClient } from '../../../../../src/shared/infrastructure/feature-toggles/feature-toggles-client.js';
+import {
+  FeatureToggleRef,
+  FeatureTogglesClient,
+} from '../../../../../src/shared/infrastructure/feature-toggles/feature-toggles-client.js';
 import { InMemoryKeyValueStorage } from '../../../../../src/shared/infrastructure/key-value-storages/InMemoryKeyValueStorage.js';
-import { expect } from '../../../../test-helper.js';
+import { getTopic } from '../../../../../src/shared/infrastructure/pubsub.js';
+import { expect, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Infrastructure | FeatureToggles | FeatureTogglesClient', function () {
   let config;
   let storage;
+  let topic;
 
   beforeEach(async function () {
     storage = new InMemoryKeyValueStorage();
@@ -15,12 +23,16 @@ describe('Unit | Infrastructure | FeatureToggles | FeatureTogglesClient', functi
       myToggle2: { description: 'Description 2', type: 'boolean', defaultValue: true },
       myToggle3: { description: 'Description 3', type: 'string', defaultValue: 'foo', tags: ['tag3'] },
     };
+    topic = {
+      publish: sinon.stub(),
+      subscribe: sinon.stub(),
+    };
   });
 
   describe('init', function () {
-    it('initialize the storage with config and default values', async function () {
+    it('initialize the storage with config and default values then subscribes to topic', async function () {
       // given
-      const featureToggles = new FeatureTogglesClient(storage);
+      const featureToggles = new FeatureTogglesClient(storage, undefined, topic);
 
       // when
       await featureToggles.init(config);
@@ -31,11 +43,15 @@ describe('Unit | Infrastructure | FeatureToggles | FeatureTogglesClient', functi
 
       const all = await featureToggles.all();
       expect(all).to.deep.equal({ myToggle1: false, myToggle2: true, myToggle3: 'foo' });
+
+      expect(topic.subscribe).to.have.been.calledOnce;
+      expect(topic.subscribe.firstCall.args).to.have.lengthOf(1);
+      expect(topic.subscribe.firstCall.firstArg).to.be.an.instanceOf(Function);
     });
 
     it('adds and removes in feature toggles storage from a new configuration ', async function () {
       // given
-      const featureToggles = new FeatureTogglesClient(storage);
+      const featureToggles = new FeatureTogglesClient(storage, undefined, topic);
       await featureToggles.init(config);
 
       // when
@@ -65,7 +81,7 @@ describe('Unit | Infrastructure | FeatureToggles | FeatureTogglesClient', functi
     context('when in test environement', function () {
       it('adds feature toggles with provided devDefaultValues.test', async function () {
         // given
-        const featureToggles = new FeatureTogglesClient(storage, 'test');
+        const featureToggles = new FeatureTogglesClient(storage, 'test', topic);
 
         // when
         await featureToggles.init({
@@ -87,7 +103,7 @@ describe('Unit | Infrastructure | FeatureToggles | FeatureTogglesClient', functi
     context('when in review app environement', function () {
       it('adds feature toggles with provided devDefaultValues.reviewApp', async function () {
         // given
-        const featureToggles = new FeatureTogglesClient(storage, 'reviewApp');
+        const featureToggles = new FeatureTogglesClient(storage, 'reviewApp', topic);
 
         // when
         await featureToggles.init({
@@ -110,7 +126,7 @@ describe('Unit | Infrastructure | FeatureToggles | FeatureTogglesClient', functi
   describe('get', function () {
     it('returns the value of a feature toggle', async function () {
       // given
-      const featureToggles = new FeatureTogglesClient(storage);
+      const featureToggles = new FeatureTogglesClient(storage, undefined, topic);
       await featureToggles.init(config);
 
       // when
@@ -124,7 +140,7 @@ describe('Unit | Infrastructure | FeatureToggles | FeatureTogglesClient', functi
 
     it('throws an error when feature toggle is not found', async function () {
       // given
-      const featureToggles = new FeatureTogglesClient(storage);
+      const featureToggles = new FeatureTogglesClient(storage, undefined, topic);
       await featureToggles.init(config);
 
       // when / then
@@ -135,9 +151,9 @@ describe('Unit | Infrastructure | FeatureToggles | FeatureTogglesClient', functi
   });
 
   describe('set', function () {
-    it('sets the value of a feature toggle', async function () {
+    it('sets the value of a feature toggle and publishes a message on topic', async function () {
       // given
-      const featureToggles = new FeatureTogglesClient(storage);
+      const featureToggles = new FeatureTogglesClient(storage, undefined, topic);
       await featureToggles.init(config);
 
       // when
@@ -146,11 +162,16 @@ describe('Unit | Infrastructure | FeatureToggles | FeatureTogglesClient', functi
 
       // then
       expect(myToggle1).to.equal(true);
+
+      expect(topic.publish).to.have.been.calledOnceWithExactly({
+        type: 'set',
+        key: 'myToggle1',
+      });
     });
 
     it('throws an error when feature toggle is not found', async function () {
       // given
-      const featureToggles = new FeatureTogglesClient(storage);
+      const featureToggles = new FeatureTogglesClient(storage, undefined, topic);
       await featureToggles.init(config);
 
       // when / then
@@ -160,10 +181,81 @@ describe('Unit | Infrastructure | FeatureToggles | FeatureTogglesClient', functi
     });
   });
 
+  describe('use', function () {
+    ['myToggle1', 'myToggle2', 'myToggle3'].forEach((key) => {
+      it(`returns a FeatureToggleRef tracking the value of "${key}"`, async function () {
+        // given
+        const featureToggles = new FeatureTogglesClient(storage, undefined, topic);
+        await featureToggles.init(config);
+
+        // when
+        const featureToggleRef = featureToggles.use(key);
+
+        // then
+        expect(featureToggleRef).to.be.an.instanceOf(FeatureToggleRef);
+        expect(featureToggleRef).to.have.property('value', config[key].defaultValue);
+      });
+    });
+
+    describe('FeatureToggleRef', function () {
+      const key = 'myToggle3';
+      let featureToggles, featureToggleRef;
+
+      beforeEach(async function () {
+        const pubSub = createPubSub();
+        featureToggles = new FeatureTogglesClient(storage, undefined, getTopic('feature-toggles', pubSub));
+        await featureToggles.init(config);
+        featureToggleRef = featureToggles.use(key);
+      });
+
+      describe('value', function () {
+        it('returns the up to date value of the feature toggle', async function () {
+          // given
+          const values = ['fizz', 'buzz', 'fizzbuzz'];
+
+          // when
+          const readValues = [];
+          for (const value of values) {
+            await featureToggles.set(key, value);
+            await setImmediate(); // let the event loop run pubsub
+            readValues.push(featureToggleRef.value);
+          }
+
+          // then
+          expect(readValues).to.deep.equal(values);
+        });
+      });
+
+      describe('watch', function () {
+        it('notifies new values of the feature toggle', async function () {
+          // given
+          const callback = sinon.stub();
+          const values = ['fizz', 'buzz', 'fizzbuzz'];
+
+          // when
+          const unwatch = featureToggleRef.watch(callback);
+          for (const value of values) {
+            await featureToggles.set(key, value);
+            await setImmediate(); // let the event loop run pubsub
+          }
+          unwatch();
+          await featureToggles.set(key, 'not received');
+          await setImmediate(); // let the event loop run pubsub
+
+          // then
+          expect(callback).to.have.been.calledThrice;
+          expect(callback.firstCall).to.have.been.calledWithExactly(values[0], config[key].defaultValue);
+          expect(callback.secondCall).to.have.been.calledWithExactly(values[1], values[0]);
+          expect(callback.thirdCall).to.have.been.calledWithExactly(values[2], values[1]);
+        });
+      });
+    });
+  });
+
   describe('all', function () {
     it('returns all feature toggles', async function () {
       // given
-      const featureToggles = new FeatureTogglesClient(storage);
+      const featureToggles = new FeatureTogglesClient(storage, undefined, topic);
       await featureToggles.init(config);
 
       // when
@@ -177,7 +269,7 @@ describe('Unit | Infrastructure | FeatureToggles | FeatureTogglesClient', functi
   describe('withTag', function () {
     it('returns all feature toggles with the specified tag', async function () {
       // given
-      const featureToggles = new FeatureTogglesClient(storage);
+      const featureToggles = new FeatureTogglesClient(storage, undefined, topic);
       await featureToggles.init(config);
 
       // when
@@ -191,7 +283,7 @@ describe('Unit | Infrastructure | FeatureToggles | FeatureTogglesClient', functi
   describe('resetDefaults', function () {
     it('resets all feature toggles to their default values', async function () {
       // given
-      const featureToggles = new FeatureTogglesClient(storage);
+      const featureToggles = new FeatureTogglesClient(storage, undefined, topic);
       await featureToggles.init(config);
       await featureToggles.set('myToggle1', true);
 
@@ -206,7 +298,7 @@ describe('Unit | Infrastructure | FeatureToggles | FeatureTogglesClient', functi
     context('when in test environement', function () {
       it('resets feature toggles with provided devDefaultValues.test', async function () {
         // given
-        const featureToggles = new FeatureTogglesClient(storage, 'test');
+        const featureToggles = new FeatureTogglesClient(storage, 'test', topic);
         await featureToggles.init({
           myToggle1: { description: 'Description 1', type: 'boolean', defaultValue: false },
           myToggle2: {
@@ -231,7 +323,7 @@ describe('Unit | Infrastructure | FeatureToggles | FeatureTogglesClient', functi
     context('when in review app environement', function () {
       it('resets feature toggles with provided devDefaultValues.reviewApp', async function () {
         // given
-        const featureToggles = new FeatureTogglesClient(storage, 'reviewApp');
+        const featureToggles = new FeatureTogglesClient(storage, 'reviewApp', topic);
         await featureToggles.init({
           myToggle1: { description: 'Description 1', type: 'boolean', defaultValue: false },
           myToggle2: {


### PR DESCRIPTION
## 🌱 Problème

La lecture des feature toggles est asynchrones, elle nécessite un appel à Redis.
Pour certaines portions de code synchrones ou appelées très fréquemment, cela peut poser problème.

D'autre part, il n'est pas possible d'observer la valeur d'un feature toggle et de réagir à son changement.

## 🐣 Proposition

Offrir une nouvelle API permettant de lire un feature toggle de manière synchrone, et d'observer sa valeur :

```js
const monFeatureToggle = featureToggle.use('monFeatureToggle');

// a few moments later...
if (monFeatureToggle.value) {
  // do something
}

// watch for changes
const unwatch = monFeatureToggle.watch((value, oldValue) => {
  // do something
});

// stop watching for changes
unwatch();
```

## 🌷 Remarques

N/A

## 🐝 Pour tester

N/A