### PR TITLE
[TECH] Crée une nouvelle méthode sur CombinedCourseDetails pour éviter d'appeler deux fois les requêtes du CombinedCourseDetailsService

### DIFF
--- a/api/src/quest/domain/models/CombinedCourse.js
+++ b/api/src/quest/domain/models/CombinedCourse.js
@@ -9,6 +9,8 @@ import { EntityValidationError } from '../../../shared/domain/errors.js';
 import { cryptoService as injectedCryptoService } from '../../../shared/domain/services/crypto-service.js';
 import { COMBINED_COURSE_ITEM_TYPES, CombinedCourseItem } from './CombinedCourseItem.js';
 import { CombinedCourseParticipationDetails } from './CombinedCourseParticipationDetails.js';
+import { DataForQuest } from './DataForQuest.js';
+import { Eligibility } from './Eligibility.js';
 import { TYPES } from './Requirement.js';
 
 const schema = Joi.object({
@@ -224,10 +226,24 @@ export class CombinedCourseDetails extends CombinedCourse {
     }
   }
 
-  generateItems({ recommendedModuleIdsForUser = [], dataForQuest, participation = null } = {}) {
-    this.items = [];
+  updateItemsFromPassages(passages) {
+    const updatedDataForQuest = new DataForQuest({
+      eligibility: new Eligibility({
+        organizationLearner: this.dataForQuest.eligibility.organizationLearner,
+        organization: this.dataForQuest.eligibility.organization,
+        campaignParticipations: this.dataForQuest.eligibility.campaignParticipations,
+        passages,
+      }),
+    });
+    this.#generateItems({
+      dataForQuest: updatedDataForQuest,
+      participation: this.participation,
+    });
+    return this;
+  }
+
+  #setParticipationStatus(participation) {
     this.participation = participation;
-    this.dataForQuest = dataForQuest;
 
     if (!this.participation) {
       this.status = CombinedCourseStatuses.NOT_STARTED;
@@ -237,6 +253,11 @@ export class CombinedCourseDetails extends CombinedCourse {
           ? CombinedCourseStatuses.STARTED
           : CombinedCourseStatuses.COMPLETED;
     }
+  }
+
+  #generateItems({ dataForQuest } = {}) {
+    this.items = [];
+    this.dataForQuest = dataForQuest;
 
     const targetProfileIdsThatNeedAFormationItem = [];
 
@@ -290,7 +311,7 @@ export class CombinedCourseDetails extends CombinedCourse {
           continue;
         }
 
-        const isRecommended = recommendedModuleIdsForUser.find(
+        const isRecommended = this.recommendedModuleIdsForUser.find(
           (recommendedModule) => recommendedModule.moduleId === module.id,
         );
 
@@ -309,6 +330,12 @@ export class CombinedCourseDetails extends CombinedCourse {
         }
       }
     }
+  }
+
+  setDataAndGenerateItems({ recommendedModuleIdsForUser = [], dataForQuest, participation = null } = {}) {
+    this.recommendedModuleIdsForUser = recommendedModuleIdsForUser;
+    this.#setParticipationStatus(participation);
+    this.#generateItems({ dataForQuest });
   }
 
   isSuccessful() {

--- a/api/src/quest/domain/services/combined-course-details-service.js
+++ b/api/src/quest/domain/services/combined-course-details-service.js
@@ -71,7 +71,7 @@ async function getCombinedCourseDetails({
     }
   }
 
-  combinedCourseDetails.generateItems({
+  combinedCourseDetails.setDataAndGenerateItems({
     participation,
     recommendedModuleIdsForUser,
     dataForQuest,
@@ -136,7 +136,7 @@ async function getCombinedCourseDetailsForMultipleLearners({
     const dataForQuest = dataForQuestByLearnerId.get(organizationLearnerId);
     const recommendedModuleIdsForUser = recommendedModulesByLearnerId.get(organizationLearnerId) ?? [];
 
-    combinedCourseDetails.generateItems({
+    combinedCourseDetails.setDataAndGenerateItems({
       participation,
       recommendedModuleIdsForUser,
       dataForQuest,

--- a/api/src/quest/domain/usecases/update-combined-course-progress.js
+++ b/api/src/quest/domain/usecases/update-combined-course-progress.js
@@ -26,24 +26,20 @@ export async function updateCombinedCourseProgress({
     combinedCourseDetails,
   });
 
-  const moduleToSynchronizeIds = combinedCourseDetailsBeforeUpdate.items
-    .filter((item) => item.type === COMBINED_COURSE_ITEM_TYPES.MODULE)
-    .map((item) => item.id);
-
   if (!combinedCourseDetailsBeforeUpdate.participation) {
     return null;
   }
 
-  await organizationLearnerParticipationRepository.synchronize({
+  const moduleToSynchronizeIds = combinedCourseDetailsBeforeUpdate.items
+    .filter((item) => item.type === COMBINED_COURSE_ITEM_TYPES.MODULE)
+    .map((item) => item.id);
+
+  const updatedPassages = await organizationLearnerParticipationRepository.synchronize({
     organizationLearnerId,
     moduleIds: moduleToSynchronizeIds,
   });
 
-  // TODO: remove this when we have a better way to handle this . it makes my hair stand on end
-  const updatedCombinedCourseDetails = await combinedCourseDetailsService.getCombinedCourseDetails({
-    organizationLearnerId,
-    combinedCourseDetails,
-  });
+  const updatedCombinedCourseDetails = combinedCourseDetailsBeforeUpdate.updateItemsFromPassages(updatedPassages);
 
   const isCombinedCourseCompleted = await updatedCombinedCourseDetails.items.every((item) => item.isCompleted);
 

--- a/api/src/quest/infrastructure/repositories/organization-learner-participation-repository.js
+++ b/api/src/quest/infrastructure/repositories/organization-learner-participation-repository.js
@@ -48,6 +48,8 @@ export const synchronize = async ({ organizationLearnerId, moduleIds, modulesApi
     .where('organizationLearnerId', organizationLearnerId)
     .whereIn('referenceId', moduleIds);
 
+  const updatedParticipations = [];
+
   for (const modulePassage of modulePassages) {
     const learnerParticipationModule = learnerParticipationsByModule.find(
       (learnerParticipation) => learnerParticipation.referenceId === modulePassage.id,
@@ -64,6 +66,8 @@ export const synchronize = async ({ organizationLearnerId, moduleIds, modulesApi
         moduleId: modulePassage.id,
       });
 
+    updatedParticipations.push(new OrganizationLearnerParticipation(organizationLearnerPassageParticipation));
+
     if (organizationLearnerParticipationId) {
       await knexConn('organization_learner_participations')
         .update(organizationLearnerPassageParticipation)
@@ -72,6 +76,8 @@ export const synchronize = async ({ organizationLearnerId, moduleIds, modulesApi
       await knexConn('organization_learner_participations').insert(organizationLearnerPassageParticipation);
     }
   }
+
+  return updatedParticipations;
 };
 
 export const deleteCombinedCourseParticipationByCombinedCourseIdAndOrganizationLearnerId = async ({

--- a/api/tests/quest/unit/domain/models/CombinedCourse_test.js
+++ b/api/tests/quest/unit/domain/models/CombinedCourse_test.js
@@ -3,12 +3,17 @@ import {
   CombinedCourseParticipationStatuses,
   CombinedCourseStatuses,
 } from '../../../../../src/prescription/shared/domain/constants.js';
-import { CombinedCourse } from '../../../../../src/quest/domain/models/CombinedCourse.js';
+import { CombinedCourse, CombinedCourseDetails } from '../../../../../src/quest/domain/models/CombinedCourse.js';
 import {
   COMBINED_COURSE_ITEM_TYPES,
   CombinedCourseItem,
 } from '../../../../../src/quest/domain/models/CombinedCourseItem.js';
 import { CombinedCourseParticipation } from '../../../../../src/quest/domain/models/CombinedCourseParticipation.js';
+import {
+  OrganizationLearnerParticipation,
+  OrganizationLearnerParticipationStatuses,
+  OrganizationLearnerParticipationTypes,
+} from '../../../../../src/quest/domain/models/OrganizationLearnerParticipation.js';
 import { domainBuilder, expect, sinon } from '../../../../test-helper.js';
 
 describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
@@ -149,7 +154,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
           ],
         });
 
-        combinedCourseDetails.generateItems({ participation, dataForQuest });
+        combinedCourseDetails.setDataAndGenerateItems({ participation, dataForQuest });
 
         // then
         expect(combinedCourseDetails.participationDetails).deep.equal({
@@ -205,7 +210,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
         });
 
         combinedCourseDetails.setRecommandableModuleIds([{ moduleId: 'ebcde1', targetProfileIds: [666] }]);
-        combinedCourseDetails.generateItems({ participation, dataForQuest });
+        combinedCourseDetails.setDataAndGenerateItems({ participation, dataForQuest });
 
         // then
         expect(combinedCourseDetails.participationDetails).deep.equal({
@@ -226,7 +231,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
       });
     });
 
-    describe('#generateItems', function () {
+    describe('#setDataAndGenerateItems', function () {
       describe('when item is type campaign', function () {
         it('returns a combined course item for provided campaign', async function () {
           // given
@@ -242,7 +247,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
             campaignParticipations: [{ campaignId: 2, status: CampaignParticipationStatuses.SHARED }],
           });
 
-          combinedCourseDetails.generateItems({ dataForQuest });
+          combinedCourseDetails.setDataAndGenerateItems({ dataForQuest });
 
           // then
           expect(combinedCourseDetails.items).to.deep.equal([
@@ -272,7 +277,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
             combinedCourseItems: [{ campaignId: 7 }],
           });
 
-          combinedCourseDetails.generateItems();
+          combinedCourseDetails.setDataAndGenerateItems();
 
           // then
           expect(combinedCourseDetails.items).to.deep.equal([
@@ -313,7 +318,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
           });
 
           await combinedCourseDetails.setEncryptedUrl();
-          combinedCourseDetails.generateItems({ dataForQuest });
+          combinedCourseDetails.setDataAndGenerateItems({ dataForQuest });
 
           // then
           expect(combinedCourseDetails.items).to.deep.equal([
@@ -356,7 +361,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
 
           await combinedCourseDetails.setEncryptedUrl();
           combinedCourseDetails.setRecommandableModuleIds(recommendableModuleIds);
-          combinedCourseDetails.generateItems({ dataForQuest });
+          combinedCourseDetails.setDataAndGenerateItems({ dataForQuest });
 
           // then
           expect(combinedCourseDetails.items).to.deep.equal([
@@ -400,7 +405,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
 
           await combinedCourseDetails.setEncryptedUrl();
           combinedCourseDetails.setRecommandableModuleIds(recommendableModuleIds);
-          combinedCourseDetails.generateItems({ recommendedModuleIdsForUser, dataForQuest });
+          combinedCourseDetails.setDataAndGenerateItems({ recommendedModuleIdsForUser, dataForQuest });
 
           // then
           expect(combinedCourseDetails.items).to.deep.equal([
@@ -446,7 +451,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
           });
 
           await combinedCourseDetails.setEncryptedUrl();
-          combinedCourseDetails.generateItems({ dataForQuest });
+          combinedCourseDetails.setDataAndGenerateItems({ dataForQuest });
 
           const [moduleItem] = combinedCourseDetails.items;
 
@@ -491,7 +496,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
               { moduleId: 'abcdef2', targetProfileIds: [888] },
             ]);
             await combinedCourseDetails.setEncryptedUrl();
-            combinedCourseDetails.generateItems({ dataForQuest });
+            combinedCourseDetails.setDataAndGenerateItems({ dataForQuest });
 
             // then
             expect(combinedCourseDetails.items).to.deep.equal([
@@ -551,7 +556,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
               { moduleId: 'abcdef2', targetProfileIds: [101] },
             ]);
             await combinedCourseDetails.setEncryptedUrl();
-            combinedCourseDetails.generateItems({ dataForQuest });
+            combinedCourseDetails.setDataAndGenerateItems({ dataForQuest });
 
             // then
             expect(combinedCourseDetails.items).to.deep.equal([
@@ -613,7 +618,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
               { moduleId: 'abcdef2', targetProfileIds: [888] },
             ]);
             await combinedCourseDetails.setEncryptedUrl();
-            combinedCourseDetails.generateItems();
+            combinedCourseDetails.setDataAndGenerateItems();
 
             // then
             expect(combinedCourseDetails.items).to.deep.equal([
@@ -670,7 +675,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
 
             combinedCourseDetails.setRecommandableModuleIds([{ moduleId: 'abcdef2', targetProfileIds: [888] }]);
             await combinedCourseDetails.setEncryptedUrl();
-            combinedCourseDetails.generateItems({ dataForQuest });
+            combinedCourseDetails.setDataAndGenerateItems({ dataForQuest });
 
             // then
             expect(combinedCourseDetails.items).to.deep.equal([
@@ -731,7 +736,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
         });
 
         await combinedCourseDetails.setEncryptedUrl();
-        combinedCourseDetails.generateItems({ dataForQuest });
+        combinedCourseDetails.setDataAndGenerateItems({ dataForQuest });
 
         // then
         expect(combinedCourseDetails.items).to.deep.equal([
@@ -790,7 +795,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
             ],
           });
 
-          combinedCourseDetails.generateItems({ dataForQuest });
+          combinedCourseDetails.setDataAndGenerateItems({ dataForQuest });
 
           const [campaignItem] = combinedCourseDetails.items;
 
@@ -815,7 +820,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
             ],
           });
 
-          combinedCourseDetails.generateItems({ dataForQuest });
+          combinedCourseDetails.setDataAndGenerateItems({ dataForQuest });
 
           const [campaignItem] = combinedCourseDetails.items;
 
@@ -862,7 +867,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
           { moduleId: 'abcde2', targetProfileIds: [888, 999] },
         ]);
 
-        combinedCourseDetails.generateItems({
+        combinedCourseDetails.setDataAndGenerateItems({
           dataForQuest,
           recommendedModuleIdsForUser: [
             { moduleId: 'abcde3' },
@@ -957,7 +962,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
 
           await combinedCourseDetails.setEncryptedUrl();
 
-          combinedCourseDetails.generateItems();
+          combinedCourseDetails.setDataAndGenerateItems();
 
           // then
           expect(combinedCourseDetails.status).to.deep.equal(CombinedCourseStatuses.NOT_STARTED);
@@ -981,7 +986,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
 
           await combinedCourseDetails.setEncryptedUrl();
 
-          combinedCourseDetails.generateItems({ participation: combinedCourseParticipation });
+          combinedCourseDetails.setDataAndGenerateItems({ participation: combinedCourseParticipation });
 
           // then
           expect(combinedCourseDetails.status).to.deep.equal(CombinedCourseStatuses.STARTED);
@@ -1003,11 +1008,76 @@ describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
 
           await combinedCourseDetails.setEncryptedUrl();
 
-          combinedCourseDetails.generateItems({ participation: combinedCourseParticipation });
+          combinedCourseDetails.setDataAndGenerateItems({ participation: combinedCourseParticipation });
 
           // then
           expect(combinedCourseDetails.status).to.deep.equal(CombinedCourseStatuses.COMPLETED);
         });
+      });
+    });
+
+    describe('#updateItemsFromPassages', function () {
+      it('should generate items and return an updated instance of Combined Course Details', async function () {
+        const combinedCourseDetails = domainBuilder.buildCombinedCourseDetails({
+          name,
+          code,
+          organizationId,
+          questId,
+          combinedCourseItems: [
+            { campaignId: 3, targetProfileId: 999 },
+            { moduleId: 'abc123' },
+            { moduleId: 'abcde1' },
+          ],
+          cryptoService,
+        });
+
+        const dataForQuest = domainBuilder.buildCombinedCourseDataForQuest({
+          campaignParticipations: [
+            { id: 1, campaignId: 3, targetProfileId: 999, status: CampaignParticipationStatuses.SHARED },
+          ],
+          passages: [
+            {
+              referenceId: 'abc123',
+              isTerminated: false,
+            },
+            {
+              referenceId: 'abcde1',
+              isTerminated: false,
+            },
+          ],
+        });
+
+        combinedCourseDetails.setDataAndGenerateItems({ dataForQuest });
+
+        await combinedCourseDetails.setEncryptedUrl();
+
+        const passages = [
+          new OrganizationLearnerParticipation({
+            organizationLearnerId: 123,
+            type: OrganizationLearnerParticipationTypes.PASSAGE,
+            referenceId: 'abc123',
+            status: OrganizationLearnerParticipationStatuses.COMPLETED,
+          }),
+          new OrganizationLearnerParticipation({
+            organizationLearnerId: 456,
+            type: OrganizationLearnerParticipationTypes.PASSAGE,
+            referenceId: 'abcde1',
+            status: OrganizationLearnerParticipationStatuses.NOT_STARTED,
+          }),
+        ];
+        const result = combinedCourseDetails.updateItemsFromPassages(passages);
+
+        expect(result).to.be.instanceOf(CombinedCourseDetails);
+        expect(result.items[0]).to.be.instanceOf(CombinedCourseItem);
+        expect(result.items[0].type).to.equal(COMBINED_COURSE_ITEM_TYPES.CAMPAIGN);
+        expect(result.items[0].isCompleted).to.be.true;
+
+        expect(result.items[1]).to.be.instanceOf(CombinedCourseItem);
+        expect(result.items[2]).to.be.instanceOf(CombinedCourseItem);
+        expect(result.items[1].id).to.equal('abc123');
+        expect(result.items[2].id).to.equal('abcde1');
+        expect(result.items[1].isCompleted).to.be.true;
+        expect(result.items[2].isCompleted).to.be.false;
       });
     });
   });

--- a/api/tests/quest/unit/infrastructure/serializers/combined-course-serializer_test.js
+++ b/api/tests/quest/unit/infrastructure/serializers/combined-course-serializer_test.js
@@ -13,7 +13,7 @@ describe('Quest | Unit | Infrastructure | Serializers | combined-course', functi
       combinedCourseItems: [{ campaignId: 1 }, { moduleId: 7 }],
     });
     await combinedCourseDetails.setEncryptedUrl();
-    combinedCourseDetails.generateItems();
+    combinedCourseDetails.setDataAndGenerateItems();
     // when
     const serializedCombinedCourse = combinedCourseSerializer.serialize(combinedCourseDetails);
 


### PR DESCRIPTION
## 🌱 Problème
Lors du chargement de la page du parcours combiné, on a deux fois un appel au combinedCourseDetailsService.getCombinedCourseDetails(); qui fait notamment des requêtes très coûteuses en CPU (findByCampaignParticipationId, par exemple). 

## 🐣 Proposition
On crée une nouvelle méthode updateItemsFromPassages qui permet de ne pas rejouer les trois requêtes du service et qui utilise la logique métier de CombinedCourseDetails.

## 🐝 Pour tester
Se connecter avec attestation-blank@example.net
Jouer un parcours combiné avec le code MAXICOMBI.
Vérifier que les modules se débloquent bien à l'issue de la campagne de diagnostic.
Vérifier qu'on a l'écran "Félicitations" à la fin du parcours.