### PR TITLE
[FEATURE] Ajout du champ application_name dans le knexfile (PIX-22248)

### DIFF
--- a/api/db/knexfile.js
+++ b/api/db/knexfile.js
@@ -1,3 +1,4 @@
+import { config } from '../src/shared/config.js';
 import { loadEnvFileIfExists } from '../src/shared/load-env-file-if-exists.js';
 import { buildPostgresEnvironment } from './utils/build-postgres-environment.js';
 
@@ -9,6 +10,7 @@ const baseConfiguration = {
   seedsDirectory: './seeds/',
   connection: {
     connectionString: process.env.DATABASE_URL,
+    application_name: config.infra.hostname || 'api',
     statement_timeout: parseInt(process.env.DATABASE_STATEMENT_TIMEOUT_MS, 10) || undefined,
     query_timeout: parseInt(process.env.DATABASE_QUERY_TIMEOUT_MS, 10) || undefined,
     idle_in_transaction_session_timeout:

--- a/api/db/knexfile.js
+++ b/api/db/knexfile.js
@@ -10,7 +10,7 @@ const baseConfiguration = {
   seedsDirectory: './seeds/',
   connection: {
     connectionString: process.env.DATABASE_URL,
-    application_name: config.infra.hostname || 'api',
+    application_name: config.infra.hostname,
     statement_timeout: parseInt(process.env.DATABASE_STATEMENT_TIMEOUT_MS, 10) || undefined,
     query_timeout: parseInt(process.env.DATABASE_QUERY_TIMEOUT_MS, 10) || undefined,
     idle_in_transaction_session_timeout:

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -326,7 +326,7 @@ const configuration = (function () {
     infra: {
       appName: process.env.APP,
       containerName: process.env.CONTAINER,
-      hostname: process.env.HOSTNAME,
+      hostname: process.env.HOSTNAME || 'pix-api',
       concurrencyForHeavyOperations: _getNumber(process.env.INFRA_CONCURRENCY_HEAVY_OPERATIONS, 2),
       chunkSizeForCampaignResultProcessing: _getNumber(process.env.INFRA_CHUNK_SIZE_CAMPAIGN_RESULT_PROCESSING, 10),
       chunkSizeForOrganizationLearnerDataProcessing: _getNumber(


### PR DESCRIPTION
## 🌱 Problème

Ajouter le champ application_name dans le knexfile afin de pouvoir identifier la provenance de la connexion Knex dans PostgreSQL.

## 🐣 Proposition

Cette modification permet de voir plus précisément l’état des connexions Knex dans la table pg_stat_activity par container.

## 🌷 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🐝 Pour tester

Verifier dans le postgres de la review app la table `pg_stat_activity` avec la commande suivante: 

```
SELECT application_name, state, count(*)
FROM pg_stat_activity
GROUP BY application_name, state;
```

La colomne `application_name` contient la valeur `pix-api-*-web-*`.
