### PR TITLE
[BUGFIX] Réparer les timezones de 2 dates de PixCertif (PIX-22272).

### DIFF
--- a/certif/app/components/session-supervising/candidate-in-list.gjs
+++ b/certif/app/components/session-supervising/candidate-in-list.gjs
@@ -9,7 +9,6 @@ import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import dayjs from 'dayjs';
-import utc from 'dayjs/plugin/utc';
 import t from 'ember-intl/helpers/t';
 import Content from 'pix-certif/components/dropdown/content';
 import Item from 'pix-certif/components/dropdown/item';
@@ -21,8 +20,6 @@ import formatPercentage from 'pix-certif/helpers/format-percentage';
 
 import dayjsUtcFormatHelper from '../../helpers/dayjs-utc-format';
 import { dayjsUtcFormat } from '../../helpers/dayjs-utc-format';
-
-dayjs.extend(utc);
 
 const Modals = {
   Confirmation: 'Confirmation',
@@ -132,17 +129,17 @@ export default class CandidateInList extends Component {
   }
 
   get candidateStartTime() {
-    return dayjsUtcFormat([this.args.candidate.startDateTime, 'HH:mm'], {});
+    return dayjs(this.args.candidate.startDateTime).format('HH:mm');
   }
 
   get candidateTheoricalEndDateTime() {
     const pixPlusDuration = this._getPixPlusDurationInMinutes();
 
     if (pixPlusDuration !== null) {
-      return dayjs.utc(this.args.candidate.startDateTime).add(pixPlusDuration, 'minute').format('HH:mm');
+      return dayjs(this.args.candidate.startDateTime).add(pixPlusDuration, 'minute').format('HH:mm');
     }
 
-    return dayjsUtcFormat([this.args.candidate.theoricalEndDateTime, 'HH:mm'], {});
+    return dayjs(this.args.candidate.theoricalEndDateTime).format('HH:mm');
   }
 
   get currentLiveAlertLabel() {

--- a/certif/app/components/team/invitations-list.gjs
+++ b/certif/app/components/team/invitations-list.gjs
@@ -3,72 +3,79 @@ import PixTable from '@1024pix/pix-ui/components/pix-table';
 import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
 import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
 import { fn } from '@ember/helper';
+import Component from '@glimmer/component';
+import dayjs from 'dayjs';
 import t from 'ember-intl/helpers/t';
 
-import dayjsUtcFormat from '../../helpers/dayjs-utc-format';
+export default class InvitationsList extends Component {
+  formatDateTime(value) {
+    if (!value) return null;
+    return dayjs(value).format('DD/MM/YYYY [-] HH:mm');
+  }
 
-<template>
-  {{#if @invitations}}
-    <PixTable @data={{@invitations}} @variant='certif' @caption={{t 'pages.team-invitations.table.caption'}}>
-      <:columns as |invitation context|>
-        <PixTableColumn @context={{context}}>
-          <:header>
-            {{t 'pages.team-invitations.table.labels.email-address'}}
-          </:header>
-          <:cell>
-            {{invitation.email}}
-          </:cell>
-        </PixTableColumn>
-        <PixTableColumn @context={{context}}>
-          <:header>
-            {{t 'pages.team-invitations.table.labels.last-sending-date'}}
-          </:header>
-          <:cell>
-            {{dayjsUtcFormat invitation.updatedAt 'DD/MM/YYYY [-] HH:mm'}}
-          </:cell>
-        </PixTableColumn>
-        <PixTableColumn @context={{context}}>
-          <:header>
-            {{t 'pages.team-invitations.table.labels.actions'}}
-          </:header>
-          <:cell>
-            <div class='invitations-list__actions'>
-              <PixTooltip @isInline={{true}}>
-                <:triggerElement>
-                  <PixIconButton
-                    @ariaLabel={{t 'pages.team-invitations.actions.resend-invitation'}}
-                    @iconName='refresh'
-                    @triggerAction={{fn @onResendInvitationButtonClicked invitation}}
-                    disabled={{invitation.isResendingInvitation}}
-                    aria-disabled={{invitation.isResendingInvitation}}
-                  />
-                </:triggerElement>
-                <:tooltip>
-                  {{t 'pages.team-invitations.actions.resend-invitation'}}
-                </:tooltip>
-              </PixTooltip>
+  <template>
+    {{#if @invitations}}
+      <PixTable @data={{@invitations}} @variant='certif' @caption={{t 'pages.team-invitations.table.caption'}}>
+        <:columns as |invitation context|>
+          <PixTableColumn @context={{context}}>
+            <:header>
+              {{t 'pages.team-invitations.table.labels.email-address'}}
+            </:header>
+            <:cell>
+              {{invitation.email}}
+            </:cell>
+          </PixTableColumn>
+          <PixTableColumn @context={{context}}>
+            <:header>
+              {{t 'pages.team-invitations.table.labels.last-sending-date'}}
+            </:header>
+            <:cell>
+              {{this.formatDateTime invitation.updatedAt}}
+            </:cell>
+          </PixTableColumn>
+          <PixTableColumn @context={{context}}>
+            <:header>
+              {{t 'pages.team-invitations.table.labels.actions'}}
+            </:header>
+            <:cell>
+              <div class='invitations-list__actions'>
+                <PixTooltip @isInline={{true}}>
+                  <:triggerElement>
+                    <PixIconButton
+                      @ariaLabel={{t 'pages.team-invitations.actions.resend-invitation'}}
+                      @iconName='refresh'
+                      @triggerAction={{fn @onResendInvitationButtonClicked invitation}}
+                      disabled={{invitation.isResendingInvitation}}
+                      aria-disabled={{invitation.isResendingInvitation}}
+                    />
+                  </:triggerElement>
+                  <:tooltip>
+                    {{t 'pages.team-invitations.actions.resend-invitation'}}
+                  </:tooltip>
+                </PixTooltip>
 
-              <PixTooltip @isInline={{true}}>
-                <:triggerElement>
-                  <PixIconButton
-                    @ariaLabel={{t 'pages.team-invitations.actions.cancel-invitation'}}
-                    @iconName='delete'
-                    @plainIcon={{true}}
-                    @triggerAction={{fn @onCancelInvitationButtonClicked invitation}}
-                  />
-                </:triggerElement>
-                <:tooltip>
-                  {{t 'pages.team-invitations.actions.cancel-invitation'}}
-                </:tooltip>
-              </PixTooltip>
-            </div>
-          </:cell>
-        </PixTableColumn>
-      </:columns>
-    </PixTable>
-  {{else}}
-    <div class='table__empty content-text'>
-      {{t 'common.labels.table.empty-result'}}
-    </div>
-  {{/if}}
-</template>
+                <PixTooltip @isInline={{true}}>
+                  <:triggerElement>
+                    <PixIconButton
+                      @ariaLabel={{t 'pages.team-invitations.actions.cancel-invitation'}}
+                      @iconName='delete'
+                      @plainIcon={{true}}
+                      @triggerAction={{fn @onCancelInvitationButtonClicked invitation}}
+                    />
+                  </:triggerElement>
+                  <:tooltip>
+                    {{t 'pages.team-invitations.actions.cancel-invitation'}}
+                  </:tooltip>
+                </PixTooltip>
+              </div>
+            </:cell>
+          </PixTableColumn>
+        </:columns>
+      </PixTable>
+    {{else}}
+      <div class='table__empty content-text'>
+        {{t 'common.labels.table.empty-result'}}
+      </div>
+    {{/if}}
+  </template>
+}


### PR DESCRIPTION
## 🌱 Problème

Dans la PR https://github.com/1024pix/pix/pull/15728, 2 dates ont été converties à tort à l'heure UTC : 
- l'heure de début de certif d'un candidat dans l'écran de surveillant
- l'heure de modification d'une invitation dans l'écran "équipe"

## 🐣 Proposition

Modifier ces dates pour quelles soient à l'heure du navigateur.

## 🐝 Pour tester

Vérifier ces heures en RA
