### PR TITLE
[BUGFIX] Corriger les décalages entre les blocages effectifs de comptes et les informations affichées aux utilisateurs (PIX-18309)

### DIFF
--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -20,7 +20,7 @@
       "bad-request-error": "The data entered was not in the correct format.",
       "gateway-timeout-error": "The service is being slow. Please try again later.",
       "internal-server-error": "An error occurred, our teams are working on finding a solution. Please try again later.",
-      "login-unauthorized-error": "There was an error in the email address or username/password entered.",
+      "login-unauthorized-error": "The email address or username and/or password you entered are incorrect.",
       "login-user-blocked-error": "Your account has reached the maximum number of failed login attempts and has been temporarily blocked. Please '<'a href=\"{url}\"'>'contact us'</a>' to unblock it.",
       "login-user-temporary-blocked-error": "You have reached too many failed login attempts. Please try again later or '<'a href=\"{url}\"'>'reset your password here'</a>'.",
       "organization-not-found-error": "The organization \"{organizationId}\" does not exist.",

--- a/api/src/identity-access-management/domain/models/UserLogin.js
+++ b/api/src/identity-access-management/domain/models/UserLogin.js
@@ -26,12 +26,13 @@ class UserLogin {
     if (this.failureCount > config.login.blockingLimitFailureCount) {
       return 0;
     }
-    return config.login.blockingLimitFailureCount - this.failureCount + 1;
+
+    return config.login.blockingLimitFailureCount - this.failureCount;
   }
 
   get shouldWarnRemainingAttempts() {
     const warnLimit = config.login.temporaryBlockingThresholdFailureCount;
-    return this.remainingAttempts >= 0 && this.remainingAttempts <= warnLimit;
+    return this.remainingAttempts > 0 && this.remainingAttempts <= warnLimit;
   }
 
   incrementFailureCount() {

--- a/api/src/identity-access-management/domain/models/UserLogin.js
+++ b/api/src/identity-access-management/domain/models/UserLogin.js
@@ -31,8 +31,8 @@ class UserLogin {
   }
 
   get shouldWarnRemainingAttempts() {
-    const warnLimit = config.login.temporaryBlockingThresholdFailureCount;
-    return this.remainingAttempts > 0 && this.remainingAttempts <= warnLimit;
+    const warningThreshold = config.login.temporaryBlockingThresholdFailureCount;
+    return this.remainingAttempts > 0 && this.remainingAttempts <= warningThreshold;
   }
 
   incrementFailureCount() {

--- a/api/src/identity-access-management/domain/services/pix-authentication-service.js
+++ b/api/src/identity-access-management/domain/services/pix-authentication-service.js
@@ -52,7 +52,7 @@ async function getUserByUsernameAndPassword({
       }
 
       throw new PasswordNotMatching({
-        remainingAttempts: userLogin.shouldWarnRemainingAttempts ? userLogin.remainingAttempts : null,
+        remainingAttempts: userLogin.shouldWarnRemainingAttempts && userLogin.remainingAttempts,
         isLoginFailureWithUsername,
       });
     }

--- a/api/src/identity-access-management/domain/services/pix-authentication-service.js
+++ b/api/src/identity-access-management/domain/services/pix-authentication-service.js
@@ -1,3 +1,4 @@
+import { UserIsBlocked, UserIsTemporaryBlocked } from '../../../shared/domain/errors.js';
 import { cryptoService } from '../../../shared/domain/services/crypto-service.js';
 import * as userLoginRepository from '../../../shared/infrastructure/repositories/user-login-repository.js';
 import { PasswordNotMatching } from '../errors.js';
@@ -39,9 +40,20 @@ async function getUserByUsernameAndPassword({
 
       await dependencies.userLoginRepository.update(userLogin);
 
+      const isLoginFailureWithUsername = username === foundUser.username;
+
+      if (userLogin.isUserMarkedAsBlocked()) {
+        throw new UserIsBlocked({ isLoginFailureWithUsername });
+      } else if (userLogin.isUserMarkedAsTemporaryBlocked()) {
+        throw new UserIsTemporaryBlocked({
+          isLoginFailureWithUsername,
+          blockingDurationMs: userLogin.computeBlockingDurationMs(),
+        });
+      }
+
       throw new PasswordNotMatching({
         remainingAttempts: userLogin.shouldWarnRemainingAttempts ? userLogin.remainingAttempts : null,
-        isLoginFailureWithUsername: username === foundUser.username,
+        isLoginFailureWithUsername,
       });
     }
 

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -546,6 +546,13 @@ const configuration = (function () {
 
     config.baseUrl = 'https://api.test.pix.fr';
 
+    config.login = {
+      temporaryBlockingThresholdFailureCount: 10,
+      temporaryBlockingBaseTimeMs: ms('2m'),
+      blockingLimitFailureCount: 30,
+      emailConnectionWarningPeriod: ms('1y'),
+    };
+
     config.oidcExampleNet = {
       clientId: 'client',
       clientSecret: 'secret',

--- a/api/tests/identity-access-management/acceptance/application/token.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/token.route.test.js
@@ -196,7 +196,7 @@ describe('Acceptance | Identity Access Management | Route | Token', function () 
 
     context('User blocking', function () {
       context('when user fails to authenticate for the threshold failure count', function () {
-        it('replies an unauthorized error and blocks the user for the blocking time', async function () {
+        it('replies a forbidden error and blocks the user for the blocking time', async function () {
           // given
           const userId = databaseBuilder.factory.buildUser.withRawPassword({
             email: 'email@without.mb',
@@ -218,14 +218,14 @@ describe('Acceptance | Identity Access Management | Route | Token', function () 
           const { statusCode } = await server.inject(options);
 
           // then
-          expect(statusCode).to.equal(401);
+          expect(statusCode).to.equal(403);
           const userLogin = await knex('user-logins').where({ userId }).first();
           expect(userLogin.failureCount).to.equal(10);
           expect(userLogin.temporaryBlockedUntil).to.exist;
         });
       });
 
-      context('when user successfully authenticate but still blocked', function () {
+      context('when user successfully authenticates but is still blocked', function () {
         it('replies a forbidden error and keep on blocking the user for the blocking time', async function () {
           // given
           const userId = databaseBuilder.factory.buildUser.withRawPassword({

--- a/api/tests/identity-access-management/integration/domain/services/pix-authentication-service.test.js
+++ b/api/tests/identity-access-management/integration/domain/services/pix-authentication-service.test.js
@@ -2,7 +2,7 @@ import { PasswordNotMatching } from '../../../../../src/identity-access-manageme
 import { User } from '../../../../../src/identity-access-management/domain/models/User.js';
 import { pixAuthenticationService } from '../../../../../src/identity-access-management/domain/services/pix-authentication-service.js';
 import * as userRepository from '../../../../../src/identity-access-management/infrastructure/repositories/user.repository.js';
-import { UserNotFoundError } from '../../../../../src/shared/domain/errors.js';
+import { UserIsBlocked, UserIsTemporaryBlocked, UserNotFoundError } from '../../../../../src/shared/domain/errors.js';
 import * as userLoginRepository from '../../../../../src/shared/infrastructure/repositories/user-login-repository.js';
 import { catchErr, databaseBuilder, expect, sinon } from '../../../../test-helper.js';
 
@@ -140,7 +140,7 @@ describe('Integration | Identity Access Management | Domain | Services | pix-aut
         });
 
         context('When user failed to login with username multiple times', function () {
-          it('throws PasswordNotMatching error and block temporarily the user', async function () {
+          it('throws UserIsTemporaryBlocked error and block temporarily the user', async function () {
             // given
             databaseBuilder.factory.buildUserLogin({
               userId: user.id,
@@ -161,9 +161,7 @@ describe('Integration | Identity Access Management | Domain | Services | pix-aut
             expect(userLogin.failureCount).to.equal(10);
             expect(userLogin.temporaryBlockedUntil).not.to.be.null;
 
-            expect(error).to.be.an.instanceof(PasswordNotMatching);
-            expect(error.meta.remainingAttempts).to.be.null;
-            expect(error.meta.isLoginFailureWithUsername).to.be.true;
+            expect(error).to.be.an.instanceof(UserIsTemporaryBlocked);
           });
 
           context('When less than 10 attempts remaining before blocking', function () {
@@ -191,7 +189,7 @@ describe('Integration | Identity Access Management | Domain | Services | pix-aut
         });
 
         context('When user failure count reaches the blocking limit', function () {
-          it('throws PasswordNotMatching error and block the user', async function () {
+          it('throws UserIsBlocked error and block the user', async function () {
             // given
             databaseBuilder.factory.buildUserLogin({
               userId: user.id,
@@ -211,8 +209,7 @@ describe('Integration | Identity Access Management | Domain | Services | pix-aut
             const userLogin = await userLoginRepository.findByUserId(user.id);
             expect(userLogin.blockedUntil).not.to.be.null;
 
-            expect(error).to.be.an.instanceof(PasswordNotMatching);
-            expect(error.meta.remainingAttempts).to.equal(0);
+            expect(error).to.be.an.instanceof(UserIsBlocked);
           });
         });
       });

--- a/api/tests/identity-access-management/integration/domain/services/pix-authentication-service.test.js
+++ b/api/tests/identity-access-management/integration/domain/services/pix-authentication-service.test.js
@@ -183,7 +183,7 @@ describe('Integration | Identity Access Management | Domain | Services | pix-aut
 
               // then
               expect(error).to.be.an.instanceof(PasswordNotMatching);
-              expect(error.meta.remainingAttempts).to.be.equal(9);
+              expect(error.meta.remainingAttempts).to.be.equal(8); // 30 - (21 + 1) = 8
             });
           });
         });

--- a/api/tests/unit/domain/models/UserLogin_test.js
+++ b/api/tests/unit/domain/models/UserLogin_test.js
@@ -24,13 +24,25 @@ describe('Unit | Domain | Models | UserLogin', function () {
       const remainingAttempts = userLogin.remainingAttempts;
 
       // then
-      expect(remainingAttempts).to.equal(blockingLimitFailureCount + 1);
+      expect(remainingAttempts).to.equal(blockingLimitFailureCount);
     });
 
     it('returns 0 when failure count is greater than blocking limit', function () {
       // given
       const { blockingLimitFailureCount } = config.login;
       const userLogin = new UserLogin({ userId: 666, failureCount: blockingLimitFailureCount + 1 });
+
+      // when
+      const remainingAttempts = userLogin.remainingAttempts;
+
+      // then
+      expect(remainingAttempts).to.equal(0);
+    });
+
+    it('returns 0 when failure count is equal to blocking limit', function () {
+      // given
+      const { blockingLimitFailureCount } = config.login;
+      const userLogin = new UserLogin({ userId: 666, failureCount: blockingLimitFailureCount });
 
       // when
       const remainingAttempts = userLogin.remainingAttempts;

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -69,7 +69,7 @@
       },
       "gateway-timeout-error": "The service is being slow. Please try again later.",
       "internal-server-error": "An error occurred, our teams are working on finding a solution. Please try again later.",
-      "login-unauthorized-error": "There was an error in the email address or password entered.",
+      "login-unauthorized-error": "The email address and/or password you entered are incorrect.",
       "login-user-blocked-error": "Your account has reached the maximum number of failed login attempts and has been temporarily blocked. Please '<'a href=\"{url}\"'>'contact us'</a>' to unblock it.",
       "login-user-temporary-blocked-error": "You have reached too many failed login attempts. Please try again later or '<'a href=\"{url}\"'>'reset your password here'</a>'."
     },

--- a/mon-pix/app/components/authentication/login-form.gjs
+++ b/mon-pix/app/components/authentication/login-form.gjs
@@ -83,7 +83,7 @@ export default class LoginForm extends Component {
       return this._updateExpiredPassword(passwordResetToken);
     }
 
-    if (['MISSING_OR_INVALID_CREDENTIALS', 'USER_IS_TEMPORARY_BLOCKED'].includes(error?.code)) {
+    if (['MISSING_OR_INVALID_CREDENTIALS', 'USER_IS_TEMPORARY_BLOCKED', 'USER_IS_BLOCKED'].includes(error?.code)) {
       this.password = null;
     }
 

--- a/mon-pix/app/components/authentication/oidc-signup-or-login.gjs
+++ b/mon-pix/app/components/authentication/oidc-signup-or-login.gjs
@@ -201,7 +201,7 @@ export default class OidcSignupOrLoginComponent extends Component {
       const errors = get(responseError, 'errors');
       const error = Array.isArray(errors) && errors.length > 0 ? errors[0] : null;
 
-      if (['MISSING_OR_INVALID_CREDENTIALS', 'USER_IS_TEMPORARY_BLOCKED'].includes(error?.code)) {
+      if (['MISSING_OR_INVALID_CREDENTIALS', 'USER_IS_TEMPORARY_BLOCKED', 'USER_IS_BLOCKED'].includes(error?.code)) {
         this.password = null;
       }
 

--- a/mon-pix/app/components/routes/login-form.gjs
+++ b/mon-pix/app/components/routes/login-form.gjs
@@ -148,7 +148,7 @@ export default class LoginForm extends Component {
     const error = errorsApi?.responseJSON || errorsApi;
     const errorCode = get(error, 'errors[0].code');
 
-    if (['MISSING_OR_INVALID_CREDENTIALS', 'USER_IS_TEMPORARY_BLOCKED'].includes(errorCode)) {
+    if (['MISSING_OR_INVALID_CREDENTIALS', 'USER_IS_TEMPORARY_BLOCKED', 'USER_IS_BLOCKED'].includes(errorCode)) {
       this.password = null;
       this.errorMessage = this.errorMessages.getAuthenticationErrorMessage(error);
     } else if (errorCode === 'UNEXPECTED_USER_ACCOUNT') {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -57,10 +57,10 @@
       "bad-request-error": "The data entered was not in the correct format.",
       "gateway-timeout-error": "The service is being slow. Please try again later.",
       "internal-server-error": "An error occurred, our teams are working on finding a solution. Please try again later.",
-      "login-unauthorized-error": "There was an error in the email address or username/password entered.",
+      "login-unauthorized-error": "The email address or username and/or password you entered are incorrect.",
       "login-unauthorized-remaining-attempts-error": "Warning: you have {remainingAttempts, plural, =0 {0 attempts} =1 {1 attempt} other {# attempts}} left before your Pix account is permanently blocked.",
       "login-unauthorized-remaining-attempts-with-user-name-error": "Warning: you have {remainingAttempts, plural, =0 {0 attempts} =1 {1 attempt} other {# attempts}} left before your Pix account is permanently blocked.'<br>'If you forget your password, '<strong>'contact your teacher'</strong>' to reset your password and/or recover your login.",
-      "login-unauthorized-with-user-name-error": "There was an error in the email address or username/password entered.'<br>'If you forget your password, '<strong>'contact your teacher'</strong>' to reset your password and/or recover your login.",
+      "login-unauthorized-with-user-name-error": "The email address or username and/or password you entered are incorrect.'<br>'If you forget your password, '<strong>'contact your teacher'</strong>' to reset your password and/or recover your login.",
       "login-unexpected-error": "Unable to connect. Please try again in a few moments. If the problem persists, '<'a href=\"{supportHomeUrl}\" target=\"blank\"'>'please contact us via the help center'</a>'.",
       "login-user-blocked-error": "Your account has reached the maximum number of failed login attempts and has been blocked. Please '<'a href=\"{url}\"'>'contact us'</a>' to unblock it.",
       "login-user-blocked-with-username-error": "Your account has been locked because you have made too many login attempts. To unlock it, please  '<strong>'contact your teacher'</strong>'; if they are unavailable, '<'a href=\"{url}\"'>'please contact us'</a>'.",
@@ -1870,7 +1870,7 @@
         "error-message": "Please agree to the terms and conditions of use.",
         "expired-authentication-key": "Your authentication demand has expired.",
         "invalid-email": "Your email address is invalid.",
-        "login-unauthorized-error": "There was an error in the email address or password entered.",
+        "login-unauthorized-error": "The email address and/or password you entered are incorrect.",
         "password-reset-token-invalid-or-expired": "Too much time has elapsed to validate your new password. Return to the login page to re-enter your username and temporary password."
       },
       "login-form": {

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -201,10 +201,10 @@
       "default": "An error has occurred. Please try again or contact the support.",
       "expired-authentication-key": "Your authentication demand has expired.",
       "internal-server-error": "An error occurred, our teams are working on finding a solution. Please try again later.",
-      "login-unauthorized-error": "There was an error in the email address or username/password entered.",
+      "login-unauthorized-error": "The email address or username and/or password you entered are incorrect.",
       "login-unauthorized-remaining-attempts-error": "Warning: you have {remainingAttempts, plural, =0 {0 attempts} =1 {1 attempt} other {# attempts}} left before your Pix account is permanently blocked.",
       "login-unauthorized-remaining-attempts-with-user-name-error": "Warning: you have {remainingAttempts, plural, =0 {0 attempts} =1 {1 attempt} other {# attempts}} left before your Pix account is permanently blocked.'<br>'If you forget your password, '<strong>'contact your teacher'</strong>' to reset your password and/or recover your login.",
-      "login-unauthorized-with-user-name-error": "There was an error in the email address or username/password entered.'<br>'If you forget your password, '<strong>'contact your teacher'</strong>' to reset your password and/or recover your login.",
+      "login-unauthorized-with-user-name-error": "The email address or username and/or password you entered are incorrect.'<br>'If you forget your password, '<strong>'contact your teacher'</strong>' to reset your password and/or recover your login.",
       "login-unexpected-error": "Unable to connect. Please try again in a few moments. If the problem persists, '<'a href=\"{supportHomeUrl}\" target=\"blank\"'>'please contact us via the help center'</a>'.",
       "login-user-blocked-error": "Your account has reached the maximum number of failed login attempts and has been blocked. Please '<'a href=\"{url}\"'>'contact us'</a>' to unblock it.",
       "login-user-temporary-blocked-error": "You have made too many login attempts, your Pix account is temporarily blocked for {blockingDurationMinutes} minutes. Try again later or click on '<'a href=\"{url}\"'>'forgotten password'</a>' to reset it.",
@@ -1163,7 +1163,7 @@
         "empty-password": "You have not entered your password.",
         "invalid-email": "Your email address is invalid.",
         "status": {
-          "404": "There was an error in the email address or password entered.",
+          "404": "The email address and/or password you entered are incorrect.",
           "409": "This invitation has been already accepted or cancelled."
         }
       },


### PR DESCRIPTION
## 🌱 Problème

Pour les connexions par login + mot-de-passe, il y a des décalages entre les blocages effectifs de comptes et les informations affichées aux utilisateurs, juste après qu’ils appuient sur le bouton _« Je me connecte »_. Il y a notamment un décalage des informations affichées concernant le nombre de tentatives restantes avant de bloquer définitivement un compte, ce qui favorise le blocage définitif de leur compte aux utilisateurs.

On s’en rend facilement compte en recette et sur les RA où les variables d’environnement de blocage sont configurées avec des valeurs plus petites qu’en production qui permettent de ne pas attendre des dizaines de minutes et de ne pas perdre le compte précis du compte des tentatives auxquelles on se trouve :
```shell
LOGIN_TEMPORARY_BLOCKING_THRESHOLD_FAILURE_COUNT=3
LOGIN_TEMPORARY_BLOCKING_BASE_TIME=30s
LOGIN_BLOCKING_LIMIT_FAILURE_COUNT=9
```

:boom: Avec cette configuration on affiche à l’utilisateur le message de blocage temporaire uniquement lors de la 4ème tentative erronée successive, et on affiche à l’utilisateur le message qu’il lui reste 1 tentative alors que son compte est déjà bloqué définitivement.

## 🐣 Proposition

### Utilisateurs informés en décalé

Il y a un problème depuis le début avec le code concernant le blocage des comptes : l’information du compte bloqué temporairement ou bloqué définitivement n’est pas affichée à l’utilisateur lors de la tentative d’authentification elle-même mais uniquement par le `securityPreHandler` `checkIfUserIsBlocked` lors de la tentative suivante. Les utilisateurs sont donc informés … mais trop tard, après que le compte ait été bloqué (temporairement ou définitivement) !

→ Utiliser `throw new UserIsBlocked` et `throw new UserIsTemporaryBlocked` dans le `pixAuthenticationService`.

### Mauvaise valeur pour le nombre de tentatives restantes

De plus la valeur du `remainingAttempts` calculée est erronée.

→ Corriger le calcul de cette valeur

## 🌷 Remarques

### Réinitialisation du champ de saisie de mot de passe lorsque compte bloqué définitivement

On en profite pour réinitialiser le champ de saisie de mot de passe lorsque le compte utilisateur est bloqué définitivement. De cette manière on évite que les utilisateurs appuient rageusement sur le bouton de connexion en sollicitant inutilement l’API.

### Amélioration de traductions “en”

On en profite pour améliorer les 2 traductions en anglais ci-dessous qui parlent d’erreur alors que ce ne sont pas des erreurs.

Remplacer :

> There was an error in the email address or username/password entered.

et :

> There was an error in the email address or password entered.

Respectivement par : 

> The email address or username and/or password you entered are incorrect.

et : 

> The email address and/or password you entered are incorrect.

## 🐝 Pour tester

Réaliser un blocage de compte jusqu’au blocage définitif, en prenant bien note du nombre de tentatives où vous vous trouvez, et en vérifiant que vous passez bien par les étapes suivantes :
* Affichage immédiat du blocage temporaire dès qu’il survient (cf. copie d’écran correspondante ci-après)
* Affichage correct de l’avertissement d’avant-dernière tentative (cf. copie d’écran correspondante ci-après)
* Affichage correct de l’avertissement de dernière tentative (cf. copie d’écran correspondante ci-après)
* Affichage immédiat du blocage définitif dès qu’il survient (cf. copie d’écran correspondante ci-après)

ℹ️ La configuration est la suivante en RA (si vous testez en local, mettre la configuration suivante pour pouvoir se rendre compte de manière sûre et efficace) :

```shell
LOGIN_TEMPORARY_BLOCKING_THRESHOLD_FAILURE_COUNT=3
LOGIN_TEMPORARY_BLOCKING_BASE_TIME=30s
LOGIN_BLOCKING_LIMIT_FAILURE_COUNT=9
```

ℹ️ Réaliser les mêmes étapes sur la RA (ou en local) et sur `dev` (ou en recette) pour mieux noter les décalages.

---

### Affichage immédiat du blocage temporaire dès qu’il survient

<img width="498" height="580" alt="Connexion_Pix-1" src="https://github.com/user-attachments/assets/fe9e4eee-a63b-4a86-bbfc-0611494ea1e1" />

---

### Affichage correct de l’avertissement d’avant-dernière tentative

<img width="498" height="580" alt="Connexion_Pix-2" src="https://github.com/user-attachments/assets/54006251-ba06-4bcb-b068-440328ecd53a" />

---

### Affichage correct de l’avertissement de dernière tentative

<img width="498" height="580" alt="Connexion_Pix-3" src="https://github.com/user-attachments/assets/3b9d665b-df70-474c-ae89-49e51ad6cffc" />

---

### Affichage immédiat du blocage définitif dès qu’il survient 

<img width="498" height="580" alt="Connexion_Pix-4" src="https://github.com/user-attachments/assets/b618ce09-e4ff-4f4e-9fdc-25b4ee5f81f8" />

