### PR TITLE
[TECH] Ajoute le domaine de la route dans les logs SQL.

### DIFF
--- a/api/db/knex-extensions.js
+++ b/api/db/knex-extensions.js
@@ -31,8 +31,7 @@ export function configureGlobalExtensions() {
   QueryBuilder.prototype.toSQL = function () {
     const ret = originalToSQL.apply(this);
     const request = getInContext('request');
-    const comments = [['path', request?.route?.path]].map((comment) => comment.join(': ')).join(' ');
-    ret.sql = `/* ${comments} */ `.concat(ret.sql);
+    ret.sql = `/* path:${request?.route?.path} | routeDomain:${request?.route?.realm?.plugin} */ `.concat(ret.sql);
     return ret;
   };
 }


### PR DESCRIPTION
## 🌱 Problème

Les logs SQL affichent le path de la route à l'origine de la requête SQL mais n'affichent pas le domaine. Cela empêchent de trier / grouper les logs par équipe responsable.

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

## 🐣 Proposition

On ajoute en commentaire de la requête SQL le `routeDomain` qui contient le nom du domaine de la requête appelante.

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 🌷 Remarques

RAS
<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🐝 Pour tester

Faire des appels d'API (via Pix App par exemple) et vérifier que les logs de PG affichent le path et le routeDomain.

<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
