### PR TITLE
[BUGFIX] Corriger l'affichage de la liste des participants pour les organisations non SUP/SCO (PIX-22275).

### DIFF
--- a/orga/app/components/organization-participant/list.gjs
+++ b/orga/app/components/organization-participant/list.gjs
@@ -12,7 +12,7 @@ import { LinkTo } from '@ember/routing';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { t } from 'ember-intl';
+import { formatDate, t } from 'ember-intl';
 import { eq, not } from 'ember-truth-helpers';
 
 import { getColumnName } from '../../helpers/import-format.js';
@@ -46,10 +46,6 @@ export default class List extends Component {
   @service intl;
   @service locale;
 
-  displayDate(date) {
-    return this.intl.formatDate(date);
-  }
-
   @action
   getExtraColumnRowValue(extraColumnName, participant) {
     const extraColumnValue = participant.extraColumns[extraColumnName];
@@ -60,7 +56,7 @@ export default class List extends Component {
     if (!extraColumnValue) return '';
 
     if (!isNaN(new Date(extraColumnValue).getTime())) {
-      return this.displayDate(extraColumnValue);
+      return this.intl.formatDate(extraColumnValue);
     }
 
     return extraColumnValue;
@@ -344,7 +340,7 @@ export default class List extends Component {
                 <:cell>
                   {{#if participant.lastParticipationDate}}
                     <div class="organization-participant__align-element">
-                      <span>{{this.displayDate participant.lastParticipationDate}}</span>
+                      <span>{{formatDate participant.lastParticipationDate}}</span>
                       <LastParticipationDateTooltip
                         @id={{participant.id}}
                         @campaignName={{participant.campaignName}}

--- a/orga/tests/integration/components/organization-participant/list-test.gjs
+++ b/orga/tests/integration/components/organization-participant/list-test.gjs
@@ -191,11 +191,13 @@ module('Integration | Component | OrganizationParticipant | List', function (hoo
         {
           lastName: 'La Terreur',
           firstName: 'Gigi',
+          lastParticipationDate: null,
           id: 34,
         },
         {
           lastName: "L'asticot",
           firstName: 'Gogo',
+          lastParticipationDate: new Date('2024-01-05'),
           id: 56,
         },
       ];
@@ -216,6 +218,37 @@ module('Integration | Component | OrganizationParticipant | List', function (hoo
       // then
       // row include heading line
       assert.strictEqual(screen.getAllByRole('row').length, 3);
+    });
+
+    module('lastParticipationDate', function () {
+      test('it should display participation date', async function (assert) {
+        // given
+        const intl = this.owner.lookup('service:intl');
+        const participants = [
+          {
+            lastName: 'La Terreur',
+            firstName: 'Gigi',
+            lastParticipationDate: '2024-01-04',
+            id: 34,
+          },
+        ];
+
+        // when
+        const screen = await render(
+          <template>
+            <List
+              @participants={{participants}}
+              @triggerFiltering={{noop}}
+              @onClickLearner={{noop}}
+              @fullName={{fullNameFilter}}
+              @certificabilityFilter={{certificabilityFilter}}
+            />
+          </template>,
+        );
+
+        // then
+        assert.ok(screen.getByRole('cell', { name: intl.formatDate('2024-01-04') }));
+      });
     });
 
     module('custom row', function () {


### PR DESCRIPTION
## 🌱 Problème

il manquait un tests sur le format de date dans la page des participants d'une organisation générique. Qui a eu un petit effet boule de neige suite à la PR tech de suppression de dayjs

## 🐣 Proposition

Ajouter un tests validant que l'affichage et correct. et effectuer la correction

## 🌷 Remarques

RAS

## 🐝 Pour tester
- [ ] Aller sur la page participant de l'organisation ProClassic
- [ ] Vérifier le bon affichage de tout les participants de l'organisation
- [ ] Mettez votre petite coche