### PR TITLE
[FEATURE] Récupération des organisations de niveau N-1 d'une organisation parent (PIX-22043)

### DIFF
--- a/admin/app/routes/authenticated/organizations/get/network.js
+++ b/admin/app/routes/authenticated/organizations/get/network.js
@@ -15,7 +15,7 @@ export default class Network extends Route {
     }
   }
 
-  async model() {
+  model() {
     const organization = this.modelFor('authenticated.organizations.get');
     return {
       organization,

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -1527,7 +1527,7 @@
         "details": "Details",
         "features": "Features",
         "invitations": "Invitations",
-        "network": "Network {nbrOfChildren, plural, =1 {({nbrOfChildren} child)} other {({nbrOfChildren} children)}}",
+        "network": "Network {nbrOfChildren, plural, =0 {({nbrOfChildren} child)} =1 {({nbrOfChildren} child)} other {({nbrOfChildren} children)}}",
         "places": "Places",
         "tags": "Tags",
         "target-profiles": "Target profiles",

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -1536,7 +1536,7 @@
         "details": "Détails",
         "features": "Fonctionnalités",
         "invitations": "Invitations",
-        "network": "Réseau {nbrOfChildren, plural, =1 {({nbrOfChildren} fille)} other {({nbrOfChildren} filles)}}",
+        "network": "Réseau {nbrOfChildren, plural, =0 {({nbrOfChildren} fille)} =1 {({nbrOfChildren} fille)} other {({nbrOfChildren} filles)}}",
         "places": "Places",
         "tags": "Tags",
         "target-profiles": "Profils cibles",

--- a/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
@@ -85,8 +85,11 @@ const findExistingIds = async function ({ ids } = {}) {
 const findChildrenByParentOrganizationId = async function ({ parentOrganizationId }) {
   const knexConnection = DomainTransaction.getConnection();
   const children = await knexConnection(ORGANIZATIONS_TABLE_NAME)
-    .where({ parentOrganizationId })
-    .orderBy('name', 'ASC');
+    .join('fct_structures AS child_fs', 'child_fs.organization_id', `${ORGANIZATIONS_TABLE_NAME}.id`)
+    .join('fct_structures AS parent_fs', 'parent_fs.structure_id', 'child_fs.parent_structure_id')
+    .where('parent_fs.organization_id', parentOrganizationId)
+    .select(`${ORGANIZATIONS_TABLE_NAME}.*`)
+    .orderBy(`${ORGANIZATIONS_TABLE_NAME}.name`, 'ASC');
   return children.map(_toDomain);
 };
 

--- a/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
@@ -199,34 +199,38 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
         context(`when user has role ${role}`, function () {
           it('returns child organizations list with a 200 HTTP status code', async function () {
             // given
-            const userId = databaseBuilder.factory.buildUser.withRole({
-              role,
-            }).id;
-            const parentOrganizationId = databaseBuilder.factory.buildOrganization().id;
+            const userId = databaseBuilder.factory.buildUser.withRole({ role }).id;
 
-            const firstChildId =
-              databaseBuilder.factory.buildOrganization({
-                parentOrganizationId,
-              }).id + '';
-            const secondChildId =
-              databaseBuilder.factory.buildOrganization({
-                parentOrganizationId,
-              }).id + '';
+            const {
+              organization: parentOrganization,
+              structure: parentStructure,
+              network,
+            } = databaseBuilder.factory.buildNetworkAndHeadOrganization();
+
+            const { organization: firstChild } = databaseBuilder.factory.buildOrganizationInNetwork({
+              networkId: network.id,
+              parentStructureId: parentStructure.id,
+            });
+            const { organization: secondChild } = databaseBuilder.factory.buildOrganizationInNetwork({
+              networkId: network.id,
+              parentStructureId: parentStructure.id,
+            });
 
             await databaseBuilder.commit();
 
             const request = {
               method: 'GET',
-              url: `/api/admin/organizations/${parentOrganizationId}/children`,
+              url: `/api/admin/organizations/${parentOrganization.id}/children`,
               headers: generateAuthenticatedUserRequestHeaders({ userId }),
             };
+
             // when
             const response = await server.inject(request);
 
             // then
             expect(response.statusCode).to.equal(200);
             expect(response.result.data).to.have.lengthOf(2);
-            expect(_map(response.result.data, 'id')).to.have.members([firstChildId, secondChildId]);
+            expect(_map(response.result.data, 'id')).to.have.members([`${firstChild.id}`, `${secondChild.id}`]);
           });
         });
       });

--- a/api/tests/organizational-entities/integration/domain/usecases/find-children-organizations.usecase.test.js
+++ b/api/tests/organizational-entities/integration/domain/usecases/find-children-organizations.usecase.test.js
@@ -8,23 +8,32 @@ describe('Integration | Organizational Entities | Domain | UseCase | findChildre
   it('returns a list of children organizations', async function () {
     // given
     const organizationLearnerType = databaseBuilder.factory.buildOrganizationLearnerType();
-    const parentOrganizationId = databaseBuilder.factory.buildOrganization({
-      name: 'name_ok_1',
-      type: 'SCO',
-      externalId: '1234567A',
-      organizationLearnerTypeId: organizationLearnerType.id,
-    }).id;
+    const {
+      organization: parentOrganization,
+      structure: parentStructure,
+      network,
+    } = databaseBuilder.factory.buildNetworkAndHeadOrganization({
+      headOrganization: {
+        name: 'Parent Org',
+        type: 'SCO',
+        externalId: '1234567A',
+        organizationLearnerTypeId: organizationLearnerType.id,
+      },
+    });
 
-    const childOrganization = databaseBuilder.factory.buildOrganization({
-      name: 'First Child',
-      type: 'SCO',
-      parentOrganizationId,
-      organizationLearnerTypeId: organizationLearnerType.id,
+    const { organization: childOrganization } = databaseBuilder.factory.buildOrganizationInNetwork({
+      networkId: network.id,
+      parentStructureId: parentStructure.id,
+      organizationData: {
+        name: 'First Child',
+        type: 'SCO',
+        organizationLearnerTypeId: organizationLearnerType.id,
+      },
     });
 
     await databaseBuilder.commit();
 
-    const expectedChildOrganizations = new OrganizationForAdmin({
+    const expectedChildOrganization = new OrganizationForAdmin({
       ...childOrganization,
       organizationLearnerType: new OrganizationLearnerType({
         id: organizationLearnerType.id,
@@ -34,11 +43,11 @@ describe('Integration | Organizational Entities | Domain | UseCase | findChildre
 
     // when
     const childOrganizations = await usecases.findChildrenOrganizations({
-      parentOrganizationId,
+      parentOrganizationId: parentOrganization.id,
     });
 
     // then
-    expect(childOrganizations).to.deep.include.members([expectedChildOrganizations]);
+    expect(childOrganizations).to.deep.include.members([expectedChildOrganization]);
   });
 
   context('when parent organization does not exist', function () {

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/organization-for-admin.repository.test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/organization-for-admin.repository.test.js
@@ -715,36 +715,47 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
   });
 
   describe('#findChildrenByParentOrganizationId', function () {
-    let parentOrganizationId;
+    let parentOrganizationId, parentStructureId, networkId;
 
-    beforeEach(function () {
-      parentOrganizationId = databaseBuilder.factory.buildOrganization({
-        name: 'name_ok_1',
-        type: 'SCO',
-        externalId: '1234567A',
-      }).id;
+    beforeEach(async function () {
+      const {
+        organization: parentOrganization,
+        structure: parentStructure,
+        network,
+      } = databaseBuilder.factory.buildNetworkAndHeadOrganization({
+        headOrganization: { name: 'Parent Org', type: 'SCO', externalId: '1234567A' },
+      });
+      parentOrganizationId = parentOrganization.id;
+      parentStructureId = parentStructure.id;
+      networkId = network.id;
+      await databaseBuilder.commit();
     });
 
     context('when there is no child organization', function () {
       it('returns an empty array', async function () {
-        //given
-        //when
+        // given
+        // when
         const children = await repositories.organizationForAdminRepository.findChildrenByParentOrganizationId({
           parentOrganizationId,
         });
 
-        //then
+        // then
         expect(children).to.have.lengthOf(0);
       });
     });
 
     context('when there is at least one child organization', function () {
-      it('returns an array of organizations', async function () {
+      it('returns an array of OrganizationForAdmin instances ordered by name', async function () {
         // given
-        databaseBuilder.factory.buildOrganization({
-          name: 'First Child',
-          type: 'SCO',
-          parentOrganizationId,
+        databaseBuilder.factory.buildOrganizationInNetwork({
+          networkId,
+          parentStructureId,
+          organizationData: { name: 'Second Child', type: 'SCO' },
+        });
+        databaseBuilder.factory.buildOrganizationInNetwork({
+          networkId,
+          parentStructureId,
+          organizationData: { name: 'First Child', type: 'SCO' },
         });
 
         await databaseBuilder.commit();
@@ -755,9 +766,27 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
         });
 
         // then
-        expect(children.length).to.be.greaterThanOrEqual(1);
+        expect(children).to.have.lengthOf(2);
         expect(children[0]).to.be.instanceOf(OrganizationForAdmin);
-        expect(_.map(children, 'name')).to.have.members(['First Child']);
+        expect(_.map(children, 'name')).to.deep.equal(['First Child', 'Second Child']);
+      });
+    });
+
+    context('when an organization has a structure but no parent', function () {
+      it('does not return it', async function () {
+        // given
+        databaseBuilder.factory.buildOrganizationWithStructure({
+          organizationData: { name: 'Unrelated Org', type: 'SCO' },
+        });
+        await databaseBuilder.commit();
+
+        // when
+        const children = await repositories.organizationForAdminRepository.findChildrenByParentOrganizationId({
+          parentOrganizationId,
+        });
+
+        // then
+        expect(children).to.have.lengthOf(0);
       });
     });
   });


### PR DESCRIPTION
## 🌱 Problème

Pour faire suite à la duplication de l’onglet des organisations filles du 4.5.2, nous devons maintenant récupérer l’ensemble des organisations de niveau N-1 de l’organisation voulue.

## 🐣 Proposition

récupérer l’ensemble des organisations de niveau N-1 en utilisant le nouveau système de réseau



## 🐝 Pour tester
 - visiter https://admin-pr15780.review.pix.fr/organizations/153444/network
 - constater que les organisations N-1 s'affichent
