### PR TITLE
[FEATURE] Ajutement de la longueur des input phrase (PIX-22051)

### DIFF
--- a/junior/app/components/challenge/content/qrocm.gjs
+++ b/junior/app/components/challenge/content/qrocm.gjs
@@ -137,6 +137,7 @@ export default class Qrocm extends Component {
                   @type="text"
                   @id="{{block.input}}"
                   name={{block.randomName}}
+                  @isFullWidth={{true}}
                   autocomplete="nope"
                   placeholder={{block.placeholder}}
                   aria-label={{block.ariaLabel}}


### PR DESCRIPTION
## 🌱 Problème

L'input est trop petit.
<img width="1072" height="353" alt="image" src="https://github.com/user-attachments/assets/2ea237e9-4894-4d8d-8621-c30c1af307a5" />

## 🐣 Proposition

Agrandir l'input

## 🌷 Remarques

RAS

## 🐝 Pour tester
Avec ninca c'est compliqué de tester. mais en local il est possible de voir ca [ici](http://localhost:4205/challenges/challenge2h7mqWp4DNI9QJ/preview)

résultat attendu ci-dessous
<img width="1072" height="353" alt="image" src="https://github.com/user-attachments/assets/d5680163-b44e-4e32-90f1-289fb9b8c6f2" />