### PR TITLE
[BUGFIX] Corrige la mise à jour de campagnes dans le cadre des Parcours Apprenants (PIX-22033).

### DIFF
--- a/api/src/prescription/campaign/domain/validators/campaign-update-validator.js
+++ b/api/src/prescription/campaign/domain/validators/campaign-update-validator.js
@@ -84,7 +84,7 @@ const campaignValidationJoiSchema = Joi.object({
     is: Joi.string().required().valid(CampaignTypes.PROFILES_COLLECTION),
     then: Joi.valid(null),
     otherwise: Joi.when('customResultPageButtonText', {
-      then: Joi.string().uri().required(),
+      then: Joi.string().uri({ allowRelative: true }).required(),
       otherwise: Joi.string().allow(null).default(null),
     }),
   }).messages({

--- a/api/tests/prescription/campaign/unit/domain/validators/campaign-update-validator_test.js
+++ b/api/tests/prescription/campaign/unit/domain/validators/campaign-update-validator_test.js
@@ -567,6 +567,18 @@ describe('Unit | Domain | Validators | campaign-validator', function () {
         expect(() => campaignUpdateValidator.validate(campaign)).to.not.throw();
       });
 
+      it('should resolve when it is a relative url', function () {
+        // given
+        const campaign = {
+          ...campaignOfTypeAssessment,
+          customResultPageButtonText: 'some text',
+          customResultPageButtonUrl: '/a/relative/url',
+        };
+
+        // when/then
+        expect(() => campaignUpdateValidator.validate(campaign)).to.not.throw();
+      });
+
       it('should reject with error when it is not a url', function () {
         // given
         const expectedError = {


### PR DESCRIPTION
## 🌱 Problème

Le renommage d'une campagne incluse dans un Parcours Apprenant affiche l'erreur "L'URL du bouton doit être une URL complète et valide."

Après investigation, cette erreur est due à une validation de l'URL qui attend une URL absolue, alors que les URL de Parcours Apprenant sont des URL relatives.

## 🐣 Proposition

Ajouter le paramètre `{ allowRelative: true}` à la définition de Joi.

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 🌷 Remarques

RAS

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🐝 Pour tester

Dans Pix Admin, se rendre sur l'onglet Organisations.
Sélectionner une organisation qui a des Parcours Apprenants (par exemple, la n°10005).
Afficher la liste des Campagnes.
Sélectionner une campagne sans code (cela correspond à une campagne liée à un Parcours Apprenant).
Modifier le titre de la campagne.
Valider la modification.
Vérifier qu'aucune erreur n'est affichée.

<!--
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc.
- [ ] Documentation de la fonctionnalité (lien)
-->
