### PR TITLE
[TECH] Supprimer la colonne content de la table des schémas de parcours (PIX-22213)

### DIFF
--- a/api/db/migrations/20260408132324_drop_combined_course_content_column.js
+++ b/api/db/migrations/20260408132324_drop_combined_course_content_column.js
@@ -1,0 +1,28 @@
+const TABLE_NAME = 'combined_course_blueprints';
+const COLUMN_NAME = 'content';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn('content');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table
+      .json(COLUMN_NAME)
+      .comment(
+        'list of combined courses requirements to fulfill. JSON array : [{type: "evaluation", value: targetProfileId}, {type: "module", value: moduleShortId}]',
+      );
+  });
+};
+
+export { down, up };

--- a/api/src/quest/infrastructure/repositories/combined-course-blueprint-repository.js
+++ b/api/src/quest/infrastructure/repositories/combined-course-blueprint-repository.js
@@ -140,7 +140,6 @@ function _buildSelectFields(knexConn) {
     internalName: 'combined_course_blueprints.internalName',
     description: 'combined_course_blueprints.description',
     illustration: 'combined_course_blueprints.illustration',
-    content: 'combined_course_blueprints.content',
     createdAt: 'combined_course_blueprints.createdAt',
     updatedAt: 'combined_course_blueprints.updatedAt',
     organizationIds: knexConn.raw(`array_remove(array_agg("combined_course_blueprint_shares"."organizationId"), NULL)`),


### PR DESCRIPTION
## 🌱 Problème

La colonne content subsiste encore en base alors qu'elle n'est plus utilisée, et que plus aucune écriture n'est faite dedans.

## 🐣 Proposition

On supprimer la colonne content

## 🌷 Remarques

Nous avons oublié de retirer content des champs récupérés par les select au niveau du repository de `combined-course-blueprint` . Cette PR embarque donc ce correctif également.

## 🐝 Pour tester

CI au vert

Tester un rollback latest sur la RA, pour vérifier que la migration peut être annulée sans souci.
