### PR TITLE
[FEATURE] Ajoute une colonne "label" à la table attestations et la remplit (PIX-22280)

### DIFF
--- a/api/db/migrations/20260408151704_add-label-column-on-attestations.js
+++ b/api/db/migrations/20260408151704_add-label-column-on-attestations.js
@@ -1,0 +1,46 @@
+const TABLE_NAME = 'attestations';
+const COLUMN_NAME = 'label';
+
+const keyAndLabelPairs = [
+  { key: 'EDUCOLLAB', label: 'Pix+Edu - Communiquer collaborer' },
+  { key: 'EDUCULTURENUM', label: 'Pix+Edu - Culture numérique' },
+  { key: 'EDUDOC', label: 'Pix+Edu - Adapter les documents' },
+  { key: 'EDUIA', label: 'Pix+Edu - Données, algorithmes et IA' },
+  { key: 'EDUINCONTOURNABLES', label: 'Pix+Edu - Les incontournables' },
+  { key: 'EDURESSOURCES', label: 'Pix+Edu - Gestion et partage de ressources' },
+  { key: 'EDUSECU', label: 'Pix+Edu - Numérique et sécurité' },
+  { key: 'EDUSUPPORT', label: 'Pix+Edu - Créer des supports pédagogiques' },
+  { key: 'EDUVEILLE', label: 'Pix+Edu - Réaliser une veille' },
+  { key: 'MAIRIEBUREAU', label: 'Mairie de Paris - Fondamentaux bureautiques' },
+  { key: 'MINARM', label: 'Socle numérique' },
+  { key: 'PARENTHOOD', label: 'Attestation de sensibilisation au numérique' },
+  { key: 'SIXTH_GRADE', label: 'Attestation de sensibilisation au numérique' },
+];
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.string(COLUMN_NAME).defaultTo(null).comment('Name used to display attestations');
+  });
+
+  for (const { label, key } of keyAndLabelPairs) {
+    await knex(TABLE_NAME)
+      .update({ [`${COLUMN_NAME}`]: label })
+      .where('key', key);
+  }
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## 🌱 Problème
A plusieurs endroits dans Admin et Orga, on vient rendre lisible le nom de l'attestation à l'aide de clés de traductions, ce qui rend le système difficile à maintenir si on ajoute de nouvelles attestations (y compris si on veut les internationaliser). Quand on veut attacher une attestation à un blueprint, cela rend l'envoi du formulaire compliqué. 

## 🐣 Proposition
On a choisi de faire migration + insertion de données dans la même PR car le nombre de lignes concernées est faible (13).

On ajoute une colonne "label" à la table attestations, qui correspond à un nom directement lisible par l'utilisateur.
On la rendra non nullable dans un second temps.

## 🐝 Pour tester
npm run db:rollback:latest
-> la colonne est supprimée 
npm run db:migrate
-> la colonne "label" est remplie correctement pour les 13 lignes de la table