### PR TITLE
[TECH] :recycle: Réduit l'utilisation de `lodash`

### DIFF
--- a/api/src/certification/enrolment/domain/services/certification-candidates-ods-service.js
+++ b/api/src/certification/enrolment/domain/services/certification-candidates-ods-service.js
@@ -11,9 +11,7 @@ import * as readOdsUtils from '../../infrastructure/utils/ods/read-ods-utils.js'
 import { Candidate } from '../models/Candidate.js';
 import { Subscription } from '../models/Subscription.js';
 
-export { extractCertificationCandidatesFromCandidatesImportSheet };
-
-async function extractCertificationCandidatesFromCandidatesImportSheet({
+export async function extractCertificationCandidatesFromCandidatesImportSheet({
   i18n,
   session,
   isSco,

--- a/api/src/certification/enrolment/infrastructure/candidates-import/candidates-import-transformation-structures.js
+++ b/api/src/certification/enrolment/infrastructure/candidates-import/candidates-import-transformation-structures.js
@@ -1,5 +1,3 @@
-import _ from 'lodash';
-
 import { convertDateValue } from '../../../../shared/infrastructure/utils/date-utils.js';
 
 // These are transformation structures. They provide all the necessary info
@@ -75,8 +73,7 @@ const _getTransformationsStruct = (translate) => [
   },
 ];
 
-// ALL
-function getTransformationStructsForPixCertifCandidatesImport({ i18n, habilitations, isSco }) {
+export function getTransformationStructsForPixCertifCandidatesImport({ i18n, habilitations, isSco }) {
   const translate = i18n.__;
   const transformationStruct = _getTransformationsStruct(translate);
 
@@ -115,19 +112,23 @@ function _includeBillingColumns({ transformationStruct, translate }) {
   });
 }
 
+function _isEmpty(obj) {
+  return [Object, Array].includes((obj || {}).constructor) && !Object.entries(obj || {}).length;
+}
+
 function _toNotEmptyTrimmedStringOrNull(val) {
-  const value = _.toString(val);
-  const trimmedValue = _.trim(value);
-  return _.isEmpty(trimmedValue) ? null : trimmedValue;
+  const value = String(val ?? '');
+  const trimmedValue = value.trim();
+  return _isEmpty(trimmedValue) ? null : trimmedValue;
 }
 
 function _toNonZeroValueOrNull(val) {
-  const value = _.toNumber(val);
-  return _.isNaN(value) ? null : value === 0 ? null : value;
+  const value = Number(val);
+  return Number.isNaN(value) ? null : value === 0 ? null : value;
 }
 
 function _getHeadersFromTransformationStruct(transformationStruct) {
-  return _.map(transformationStruct, 'header');
+  return transformationStruct.map((ts) => ts.header);
 }
 
 function _toBooleanIfValueEqualsOuiOrNull({ val, translate }) {
@@ -135,5 +136,3 @@ function _toBooleanIfValueEqualsOuiOrNull({ val, translate }) {
 
   return val?.toUpperCase() === yesTranslation.toUpperCase() ? true : null;
 }
-
-export { getTransformationStructsForPixCertifCandidatesImport };

--- a/api/src/certification/enrolment/infrastructure/candidates-import/fill-candidates-import-sheet.js
+++ b/api/src/certification/enrolment/infrastructure/candidates-import/fill-candidates-import-sheet.js
@@ -180,7 +180,7 @@ function _getCandidatesImportTemplatePath() {
 }
 
 function _certificationCandidatesToCandidatesData({ enrolledCandidates, certificationCenterHabilitations, i18n }) {
-  return _.map(enrolledCandidates, (enrolledCandidate, index) => {
+  return enrolledCandidates.map((enrolledCandidate, index) => {
     return CandidateData.fromEnrolledCandidateAndCandidateNumber({
       enrolledCandidate,
       certificationCenterHabilitations,

--- a/api/src/certification/enrolment/infrastructure/utils/ods/read-ods-utils.js
+++ b/api/src/certification/enrolment/infrastructure/utils/ods/read-ods-utils.js
@@ -15,7 +15,7 @@ async function getContentXml({ odsFilePath }) {
 
 async function extractTableDataFromOdsFile({ odsBuffer, tableHeaderTargetPropertyMap }) {
   const sheetDataRows = await getSheetDataRowsFromOdsBuffer({ odsBuffer });
-  const tableHeaders = _.map(tableHeaderTargetPropertyMap, 'header');
+  const tableHeaders = tableHeaderTargetPropertyMap.map((tt) => tt.header);
   const sheetHeaderRow = _findHeaderRow(sheetDataRows, tableHeaders);
   if (!sheetHeaderRow) {
     throw new UnprocessableEntityError('Table headers not found');
@@ -69,8 +69,8 @@ function _findHeaderRow(sheetDataRows, tableHeaders) {
 
 function _allHeadersValuesAreInTheRow(row, headers) {
   const cellValuesInRow = _.values(row);
-  const strippedCellValuesInRow = _.map(cellValuesInRow, _removeNewlineCharacters);
-  const strippedHeaders = _.map(headers, _removeNewlineCharacters);
+  const strippedCellValuesInRow = cellValuesInRow.map(_removeNewlineCharacters);
+  const strippedHeaders = headers.map(_removeNewlineCharacters);
   const headersInRow = _.intersection(strippedCellValuesInRow, strippedHeaders);
   return headersInRow.length === headers.length;
 }
@@ -84,7 +84,7 @@ function _mapSheetHeadersWithProperties(sheetHeaderRow, tableHeaderTargetPropert
 }
 
 function _findTargetPropertiesByHeader(tableHeaderTargetPropertyMap, header) {
-  const mapWithSanitizedHeaders = _.map(tableHeaderTargetPropertyMap, (obj) => ({
+  const mapWithSanitizedHeaders = tableHeaderTargetPropertyMap.map((obj) => ({
     ...obj,
     header: _removeNewlineCharacters(obj.header),
   }));

--- a/api/src/certification/results/domain/models/CertificationResult.js
+++ b/api/src/certification/results/domain/models/CertificationResult.js
@@ -64,8 +64,7 @@ export class CertificationResult {
   static from({ certificationResultDTO }) {
     const certificationStatus = certificationResultDTO?.assessmentResultStatus ?? CertificationResult.status.STARTED;
     const competenceMarkDTOs = certificationResultDTO.competenceMarks.filter(Boolean);
-    const competencesWithMark = _.map(
-      competenceMarkDTOs,
+    const competencesWithMark = competenceMarkDTOs.map(
       (competenceMarkDTO) =>
         new CompetenceMark({
           ...competenceMarkDTO,

--- a/api/src/certification/session-management/domain/models/CertificationAssessment.js
+++ b/api/src/certification/session-management/domain/models/CertificationAssessment.js
@@ -143,7 +143,7 @@ export class CertificationAssessment {
 
   findAnswersAndChallengesForCertifiableBadgeKey(certifiableBadgeKey) {
     const certificationChallengesForBadge = _.filter(this.certificationChallenges, { certifiableBadgeKey });
-    const challengeIds = _.map(certificationChallengesForBadge, 'challengeId');
+    const challengeIds = certificationChallengesForBadge.map((ccfb) => ccfb.challengeId);
     const answersForBadge = this.certificationAnswersByDate.filter(({ challengeId }) =>
       _.includes(challengeIds, challengeId),
     );

--- a/api/src/certification/session-management/domain/read-models/CertificationDetails.js
+++ b/api/src/certification/session-management/domain/read-models/CertificationDetails.js
@@ -3,7 +3,7 @@ import _ from 'lodash';
 import { AnswerCollectionForScoring } from '../../../shared/domain/models/AnswerCollectionForScoring.js';
 import { ReproducibilityRate } from '../../../shared/domain/models/ReproducibilityRate.js';
 
-class CertificationDetails {
+export class CertificationDetails {
   constructor({
     id,
     userId,
@@ -71,7 +71,7 @@ function _buildCompetencesWithMark({ competenceMarks, placementProfile }) {
     return;
   }
 
-  return _.map(competenceMarks, (competenceMark) => {
+  return competenceMarks.map((competenceMark) => {
     const userCompetence = placementProfile.getUserCompetence(competenceMark.competenceId);
 
     return {
@@ -88,23 +88,20 @@ function _buildCompetencesWithMark({ competenceMarks, placementProfile }) {
 }
 
 function _buildListChallengesAndAnswers({ certificationAssessment, competencesWithMark }) {
-  const answeredChallengesAndAnswers = _.map(
-    certificationAssessment.certificationAnswersByDate,
-    (certificationAnswer) => {
-      const challengeForAnswer = certificationAssessment.getCertificationChallenge(certificationAnswer.challengeId);
-      const competenceIndex = _getCompetenceIndexForChallenge(challengeForAnswer, competencesWithMark);
+  const answeredChallengesAndAnswers = certificationAssessment.certificationAnswersByDate.map((certificationAnswer) => {
+    const challengeForAnswer = certificationAssessment.getCertificationChallenge(certificationAnswer.challengeId);
+    const competenceIndex = _getCompetenceIndexForChallenge(challengeForAnswer, competencesWithMark);
 
-      return {
-        challengeId: challengeForAnswer.challengeId,
-        competence: competenceIndex,
-        isNeutralized: challengeForAnswer.isNeutralized,
-        hasBeenSkippedAutomatically: false,
-        result: certificationAnswer.result.status,
-        skill: challengeForAnswer.associatedSkillName,
-        value: certificationAnswer.value,
-      };
-    },
-  );
+    return {
+      challengeId: challengeForAnswer.challengeId,
+      competence: competenceIndex,
+      isNeutralized: challengeForAnswer.isNeutralized,
+      hasBeenSkippedAutomatically: false,
+      result: certificationAnswer.result.status,
+      skill: challengeForAnswer.associatedSkillName,
+      value: certificationAnswer.value,
+    };
+  });
 
   const unansweredChallengesAndAnswers = _(certificationAssessment.certificationChallenges)
     .map((challenge) => {
@@ -136,5 +133,3 @@ function _getCompetenceIndexForChallenge(certificationChallenge, competencesWith
   const competenceWithMark = _.find(competencesWithMark, { id: certificationChallenge.competenceId });
   return competenceWithMark ? competenceWithMark.index : '';
 }
-
-export { CertificationDetails };

--- a/api/src/certification/session-management/infrastructure/repositories/course-assessment-result-repository.js
+++ b/api/src/certification/session-management/infrastructure/repositories/course-assessment-result-repository.js
@@ -1,5 +1,3 @@
-import _ from 'lodash';
-
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { AssessmentResult } from '../../../../shared/domain/models/AssessmentResult.js';
 import { CompetenceMark } from '../../../shared/domain/models/CompetenceMark.js';
@@ -7,7 +5,7 @@ import { JuryComment, JuryCommentContexts } from '../../../shared/domain/models/
 
 function _toDomain({ assessmentResultDTO, competencesMarksDTO }) {
   const competenceMarks = competencesMarksDTO.map((competenceMark) => new CompetenceMark(competenceMark));
-  const reproducibilityRateAsNumber = _.toNumber(assessmentResultDTO.reproducibilityRate) ?? null;
+  const reproducibilityRateAsNumber = Number(assessmentResultDTO.reproducibilityRate);
   const commentForOrganization = new JuryComment({
     commentByAutoJury: assessmentResultDTO.commentByAutoJury,
     fallbackComment: assessmentResultDTO.commentForOrganization,

--- a/api/tests/certification/enrolment/integration/infrastructure/ods/read-ods-utils_test.js
+++ b/api/tests/certification/enrolment/integration/infrastructure/ods/read-ods-utils_test.js
@@ -76,6 +76,7 @@ describe('Integration | Shared | Infrastructure | Utils | Ods | read-ods-utils',
         // when
         const result = await catchErr(extractTableDataFromOdsFile)({
           odsBuffer: alteredBuffer,
+          tableHeaderTargetPropertyMap: TRANSFORM_STRUCT,
         });
 
         // then


### PR DESCRIPTION
## 🌱 Problème

Nous utilisons la librairie externe `lodash`. Ça crée une dépendance et une fragilité. Beaucoup de fonction proposée pourrait être remplacé par un usage natif.

## 🐣 Proposition

Remplacer l'utilisation de fonction `lodash` par du JavaScript natif.

## 🌷 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🐝 Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
