### PR TITLE
[BUGFIX] S'assurer qu'un score de 0 a bien pour conséquence une certification rejetée pour cause de score trop bas

### DIFF
--- a/api/src/certification/evaluation/domain/models/Intervals.js
+++ b/api/src/certification/evaluation/domain/models/Intervals.js
@@ -25,7 +25,7 @@ export class Intervals {
 
   findIntervalIndexFromCapacity(capacity) {
     if (capacity < this.intervals[0].bounds.min) {
-      return 0;
+      return null;
     }
 
     for (const [index, { bounds }] of this.intervals.entries()) {
@@ -35,10 +35,6 @@ export class Intervals {
     }
 
     return this.intervals.length - 1;
-  }
-
-  isCapacityBelowMinimum(capacity) {
-    return capacity <= this.intervals[0].bounds.min;
   }
 
   isCapacityAboveMaximum(capacity) {

--- a/api/src/certification/evaluation/domain/models/ScoringSimulator.js
+++ b/api/src/certification/evaluation/domain/models/ScoringSimulator.js
@@ -31,12 +31,12 @@ function _calculateScore({ certificationScoringIntervals, capacity, intervalInde
   const MIN_PIX_SCORE = 0;
   const maximumReachableScore = MAX_REACHABLE_LEVEL * COMPETENCES_COUNT * PIX_COUNT_BY_LEVEL - 1;
 
-  if (certificationScoringIntervals.isCapacityBelowMinimum(capacity)) {
-    return MIN_PIX_SCORE;
-  }
-
   if (certificationScoringIntervals.isCapacityAboveMaximum(capacity)) {
     return maximumReachableScore;
+  }
+
+  if (intervalIndex === null) {
+    return MIN_PIX_SCORE;
   }
 
   const intervalMaximum = certificationScoringIntervals.max(intervalIndex);
@@ -53,9 +53,10 @@ function _calculateScore({ certificationScoringIntervals, capacity, intervalInde
 function _computeCompetences({ competencesForScoring, capacity }) {
   return competencesForScoring.map(({ intervals, competenceCode }) => {
     const competenceIntervals = new Intervals({ intervals });
+    const intervalForCompetence = competenceIntervals.findIntervalIndexFromCapacity(capacity);
     return {
       competenceCode,
-      level: intervals[competenceIntervals.findIntervalIndexFromCapacity(capacity)].competenceLevel,
+      level: intervalForCompetence ? intervals[intervalForCompetence].competenceLevel : 0,
     };
   });
 }

--- a/api/src/certification/evaluation/domain/models/ScoringV3Algorithm.js
+++ b/api/src/certification/evaluation/domain/models/ScoringV3Algorithm.js
@@ -74,15 +74,14 @@ export class ScoringV3Algorithm {
 
     const scoringIntervals = new Intervals({ intervals: certificationScoringIntervals });
 
-    if (scoringIntervals.isCapacityBelowMinimum(capacity)) {
-      return 0;
-    }
-
     if (scoringIntervals.isCapacityAboveMaximum(capacity)) {
       return maximumReachableScore;
     }
 
     const intervalIndex = scoringIntervals.findIntervalIndexFromCapacity(capacity);
+    if (intervalIndex === null) {
+      return 0;
+    }
     const intervalMaximum = scoringIntervals.max(intervalIndex);
     const intervalMinimum = scoringIntervals.min(intervalIndex);
     const meshes = Array.from(CORE_MESH_CONFIGURATION.values());
@@ -102,9 +101,6 @@ export class ScoringV3Algorithm {
   computeReachedMeshIndex({ capacity }) {
     const certificationScoringIntervals = this.v3CertificationScoring.intervals;
     const scoringIntervals = new Intervals({ intervals: certificationScoringIntervals });
-    if (scoringIntervals.isCapacityBelowMinimum(capacity)) {
-      return null;
-    }
     return scoringIntervals.findIntervalIndexFromCapacity(capacity);
   }
 

--- a/api/src/certification/evaluation/domain/services/scoring/create-v3-assessment-result.js
+++ b/api/src/certification/evaluation/domain/services/scoring/create-v3-assessment-result.js
@@ -65,7 +65,7 @@ export function createV3AssessmentResult({
     }
   }
 
-  if (reachedMeshIndex === null) {
+  if (pixScore === 0 || reachedMeshIndex === null) {
     return AssessmentResultFactory.buildRejectedDueToBelowMinimumMesh({
       pixScore,
       assessmentId,

--- a/api/tests/certification/evaluation/unit/domain/models/Intervals_test.js
+++ b/api/tests/certification/evaluation/unit/domain/models/Intervals_test.js
@@ -43,13 +43,23 @@ describe('Certification | Evaluation | Unit | Domain | Models | Intervals ', fun
   });
 
   describe('findIntervalIndexFromCapacity', function () {
-    describe('when the given capacity is inferior to the first interval minimum value', function () {
-      it('returns the index of the first interval', async function () {
+    describe('when the given capacity is strictly inferior to the first interval minimum value', function () {
+      it('returns null', async function () {
         const intervals = new Intervals({
           intervals: [{ bounds: { min: 1, max: 3 } }, { bounds: { min: 4, max: 7 } }],
         });
 
-        expect(intervals.findIntervalIndexFromCapacity(0)).to.equal(0);
+        expect(intervals.findIntervalIndexFromCapacity(0.99999)).to.be.null;
+      });
+    });
+
+    describe('when the given capacity is exactly the first interval minimum value', function () {
+      it('returns null', async function () {
+        const intervals = new Intervals({
+          intervals: [{ bounds: { min: 1, max: 3 } }, { bounds: { min: 4, max: 7 } }],
+        });
+
+        expect(intervals.findIntervalIndexFromCapacity(1)).to.equal(0);
       });
     });
 
@@ -71,20 +81,6 @@ describe('Certification | Evaluation | Unit | Domain | Models | Intervals ', fun
 
         expect(intervals.findIntervalIndexFromCapacity(2)).to.equal(0);
       });
-    });
-  });
-
-  describe('isCapacityBelowMinimum', function () {
-    it('returns true if the given capacity is inferior to the minimum value of the first interval', async function () {
-      const intervals = new Intervals({ intervals: [{ bounds: { min: 1, max: 3 } }, { bounds: { min: 4, max: 7 } }] });
-
-      expect(intervals.isCapacityBelowMinimum(0)).to.equal(true);
-    });
-
-    it('returns false if the given capacity is not inferior to the minimum value of the first interval', async function () {
-      const intervals = new Intervals({ intervals: [{ bounds: { min: 1, max: 3 } }, { bounds: { min: 4, max: 7 } }] });
-
-      expect(intervals.isCapacityBelowMinimum(7)).to.equal(false);
     });
   });
 

--- a/api/tests/certification/evaluation/unit/domain/models/ScoringSimulator_test.js
+++ b/api/tests/certification/evaluation/unit/domain/models/ScoringSimulator_test.js
@@ -183,7 +183,7 @@ describe('Certification | Evaluation | Unit | Domain | Models | ScoringSimulator
         ],
       },
     ].forEach(({ capacity, expectedScore, expectedCompetences }) => {
-      it(`returns the score ${expectedScore} and competences ${expectedCompetences}  when capacity is ${capacity}`, function () {
+      it(`returns the score ${expectedScore} and competences ${JSON.stringify(expectedCompetences)}  when capacity is ${capacity}`, function () {
         // given
         const certificationScoringIntervals = [
           { bounds: { max: -2, min: -8 }, meshLevel: 0 },

--- a/api/tests/certification/evaluation/unit/domain/services/scoring/create-v3-assessment-result_test.js
+++ b/api/tests/certification/evaluation/unit/domain/services/scoring/create-v3-assessment-result_test.js
@@ -215,6 +215,38 @@ describe('Unit | Certification | Evaluation | Domain | Services | Create V3 Asse
       });
 
       context('when at least minimum mesh is reached', function () {
+        context('there is a score and it is equal to 0', function () {
+          it('should return a rejected AssessmentResult with auto-jury comment', function () {
+            //when
+            const assessmentResult = createV3AssessmentResult({
+              toBeCancelled: false,
+              allAnswers: answers,
+              assessmentId: 123,
+              pixScore: 0,
+              capacity,
+              reachedMeshIndex: 0,
+              versionId,
+              status: AssessmentResult.status.REJECTED,
+              competenceMarks,
+              isRejectedForFraud: false,
+              isAbortReasonTechnical: false,
+              juryId: 123,
+              minimumAnswersRequiredToValidateACertification,
+            });
+
+            //then
+            const juryComment = domainBuilder.certification.shared.buildJuryComment.organization({
+              commentByAutoJury: AutoJuryCommentKeys.REJECTED_DUE_TO_ZERO_PIX_SCORE,
+            });
+            expect(assessmentResult.status).to.equal(AssessmentResult.status.REJECTED);
+            expect(assessmentResult.commentForOrganization).to.deep.equal(juryComment);
+            expect(assessmentResult.pixScore).to.equal(0);
+            expect(assessmentResult.competenceMarks).to.deep.equal([]);
+            expect(assessmentResult.capacity).to.equal(capacity);
+            expect(assessmentResult.reachedMeshIndex).to.equal(0);
+            expect(assessmentResult.versionId).to.equal(versionId);
+          });
+        });
         it('should return a standard AssessmentResult', function () {
           //when
           const assessmentResult = createV3AssessmentResult({


### PR DESCRIPTION
## 🌱 Problème

Lors d'un refacto, on a établit que dire que pixScore = 0 revient à dire reachedMeshIndex = null (donc création d'un assessment result rejetée pour score trop bas).

Or, la vérification explicite de pixScore === 0 a été retirée, hors, même pour une capacité excédant très très légèrement la borne minimum de la maille la plus basse, le simulateur nous sort aussi un score de 0.

## 🐣 Proposition

Remettre la vérification du pixScore, car c'était un aspect important établi par le métier de dire pixScore === 0 doit avoir pour conséquence une certif rejetée, même si la capacité est bien dans la première borne

## 🌷 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🐝 Pour tester
E2E ok :heavy_check_mark: 
