### PR TITLE
[TECH] Corriger le chargement des seeds

### DIFF
--- a/api/db/knexfile.js
+++ b/api/db/knexfile.js
@@ -1,4 +1,3 @@
-import { config } from '../src/shared/config.js';
 import { loadEnvFileIfExists } from '../src/shared/load-env-file-if-exists.js';
 import { buildPostgresEnvironment } from './utils/build-postgres-environment.js';
 
@@ -10,7 +9,7 @@ const baseConfiguration = {
   seedsDirectory: './seeds/',
   connection: {
     connectionString: process.env.DATABASE_URL,
-    application_name: config.infra.hostname,
+    application_name: process.env.HOSTNAME ?? 'pix-api',
     statement_timeout: parseInt(process.env.DATABASE_STATEMENT_TIMEOUT_MS, 10) || undefined,
     query_timeout: parseInt(process.env.DATABASE_QUERY_TIMEOUT_MS, 10) || undefined,
     idle_in_transaction_session_timeout:


### PR DESCRIPTION
## 🌱 Problème

Erreur au chargement des seeds en local.

```
The "password" argument must be of type string or an instance of ArrayBuffer, Buffer, TypedArray, or DataView. Received undefined
TypeError [ERR_INVALID_ARG_TYPE]: The "password" argument must be of type string or an instance of ArrayBuffer, Buffer, TypedArray, or DataView. Received undefined
    at check (node:internal/crypto/scrypt:83:14)
    at scrypt (node:internal/crypto/scrypt:46:13)
    at node:internal/util:513:21
    at new Promise (<anonymous>)
    at scrypt (node:internal/util:499:12)
    at Object.encrypt (file:///Users/benjamin_petetot/dev/work/pix/api/src/shared/domain/services/crypto-service.js:54:28)
    at async file:///Users/benjamin_petetot/dev/work/pix/api/db/database-builder/factory/build-lti-platform-registration.js:5:38
```

## 🐣 Proposition

Le problème vient d'une PR récente https://github.com/1024pix/pix/pull/15768

Dans le knexfile, on ne peut pas utiliser la `config`, il faut utiliser directement `process.env`

## 🐝 Pour tester

```
npm run db:seed
```