### PR TITLE
[FEATURE] Rendre le contenu de l'e-mail de vérification de changement d’e-mail générique (PIX-21991)

### DIFF
--- a/api/translations/de.json
+++ b/api/translations/de.json
@@ -524,7 +524,7 @@
   },
   "verification-code-email": {
     "body": {
-      "context": "Sie möchten eine Änderung Ihrer E-Mail-Adresse in Ihrem Konto vornehmen. Um fortzufahren, geben Sie auf Pix den folgenden Code ein:",
+      "context": "Um deine E-Mail-Adresse zu bestätigen, kannst du den folgenden Code auf Pix eingeben:",
       "doNotAnswer": "Dies ist eine automatische E-Mail, bitte antworten Sie nicht darauf",
       "greeting": "Hallo,",
       "moreOn": "Mehr über",

--- a/api/translations/en.json
+++ b/api/translations/en.json
@@ -525,7 +525,7 @@
   },
   "verification-code-email": {
     "body": {
-      "context": "You’ve requested to change the email address linked to your account. To continue, enter the following verification code on Pix:",
+      "context": "To verify your email address, you can enter the following code on Pix:",
       "doNotAnswer": "This is an automated email message, please do not reply.",
       "greeting": "Hi,",
       "moreOn": "More on",

--- a/api/translations/es.json
+++ b/api/translations/es.json
@@ -510,7 +510,7 @@
   },
   "verification-code-email": {
     "body": {
-      "context": "Deseas cambiar la dirección de correo electrónico de tu cuenta. Para continuar, introduce el siguiente código en Pix:",
+      "context": "Para verificar tu dirección de correo electrónico, puedes introducir el siguiente código en Pix:",
       "doNotAnswer": "Este es un correo electrónico automático, por favor, no respondas directamente.",
       "greeting": "Hola:",
       "moreOn": "Más información sobre",

--- a/api/translations/fr.json
+++ b/api/translations/fr.json
@@ -585,7 +585,7 @@
   },
   "verification-code-email": {
     "body": {
-      "context": "Vous souhaitez faire une modification de votre adresse e-mail sur votre compte. Pour continuer, entrez le code suivant sur Pix :",
+      "context": "Pour vérifier votre adresse e-mail, vous pouvez entrer le code suivant sur Pix :",
       "doNotAnswer": "Ceci est un e-mail automatique, merci de ne pas y répondre",
       "greeting": "Bonjour,",
       "moreOn": "En savoir plus sur",

--- a/api/translations/it.json
+++ b/api/translations/it.json
@@ -524,7 +524,7 @@
   },
   "verification-code-email": {
     "body": {
-      "context": "Desidera modificare l'indirizzo e-mail del suo account. Per continuare, inserire il seguente codice in Pix :",
+      "context": "Per verificare il tuo indirizzo e-mail, puoi inserire il seguente codice su Pix:",
       "doNotAnswer": "Questa è un'e-mail automatica, non rispondete.",
       "greeting": "Salve,",
       "moreOn": "Per saperne di più",

--- a/api/translations/nl.json
+++ b/api/translations/nl.json
@@ -510,7 +510,7 @@
   },
   "verification-code-email": {
     "body": {
-      "context": "Je wilt je e-mailadres op je account wijzigen. Voer de volgende code in bij Pix om verder te gaan:",
+      "context": "Om je e-mailadres te verifiëren, kun je de volgende code invoeren op Pix:",
       "doNotAnswer": "Dit is een automatische e-mail, antwoord niet.",
       "greeting": "Hallo,",
       "moreOn": "Ontdek meer over",


### PR DESCRIPTION
## 🌱 Problème

On veut utiliser le template existant d’envoi de code de vérification également pour l’ajout d'une méthode de connexion (e-mail + mdp) sur un compte utilisateur disposant seulement d'un SSO pour se connecter.

## 🐣 Proposition

Modifier le texte pour qu’il soit générique et applicable aux 2 situations d’utilisation :
* Modification de l’adresse e-mail
* **Ajout d’une méthode de connexion email + mdp utilisateurices SSO**

Ancien texte : 
> Vous souhaitez faire une modification de votre adresse e-mail sur votre compte. Pour continuer, entrez le code suivant sur Pix :

Nouveau texte :
> Pour vérifier votre adresse e-mail, vous pouvez entrer le code suivant sur Pix :

## 🌷 Remarques

RAS

## 🐝 Pour tester

L’envoi des emails de notification a été activé dans la RA avec la configuration suivante + redémarrage : 
```shell
MAILING_ENABLED=true
```

Réaliser une modification d’adresse email et vérifier que le texte contenu dans l’email de vérification est bien conforme au nouveau texte souhaité : 
1. Aller dans _« Mon compte »_
2. Aller dans _« Mes méthodes de connexion »_
3. Actionner le bouton « Modifier »
4. Spécifier une nouvelle adresse email
5. Actionner le bouton _« Recevoir un code de vérification »_
6. Vérifier le texte de l’email de vérification reçu