### PR TITLE
[TECH] Ne plus remonter de 500 lors d'une réponse à un assessment sur une participation supprimée (PIX-22314).

### DIFF
--- a/api/src/shared/domain/usecases/update-assessment-with-next-challenge.js
+++ b/api/src/shared/domain/usecases/update-assessment-with-next-challenge.js
@@ -1,3 +1,4 @@
+import { CampaignParticipationDeletedError } from '../../../prescription/campaign-participation/domain/errors.js';
 import { logger } from '../../infrastructure/utils/logger.js';
 import { AssessmentEndedError, AssessmentLackOfChallengesError, NotFoundError } from '../errors.js';
 
@@ -49,6 +50,10 @@ export async function updateAssessmentWithNextChallenge({
     }
 
     if (assessment.isForCampaign() && assessment.isStarted()) {
+      if (!assessment.campaignParticipationId)
+        throw new CampaignParticipationDeletedError(
+          `Cannot continue assessement: ${assessmentId} on deleted participation`,
+        );
       if (assessment.isForExamCampaign()) {
         const progression = await evaluationUsecases.getProgression({
           progressionId: assessmentId.toString(),
@@ -58,6 +63,7 @@ export async function updateAssessmentWithNextChallenge({
       }
       nextChallenge = await evaluationUsecases.getNextChallengeForCampaignAssessment({ assessment, locale });
     }
+
     if (assessment.isCompetenceEvaluation()) {
       assessment.title = await competenceRepository.getCompetenceName({ id: assessment.competenceId, locale });
       if (assessment.isStarted()) {

--- a/api/tests/shared/unit/domain/usecases/update-assessment-with-next-challenge_test.js
+++ b/api/tests/shared/unit/domain/usecases/update-assessment-with-next-challenge_test.js
@@ -1,3 +1,4 @@
+import { CampaignParticipationDeletedError } from '../../../../../src/prescription/campaign-participation/domain/errors.js';
 import { CampaignTypes } from '../../../../../src/prescription/shared/domain/constants.js';
 import {
   AssessmentEndedError,
@@ -266,6 +267,7 @@ describe('Shared | Unit | Domain | Use Cases | get-next-challenge', function () 
           assessment = domainBuilder.buildAssessment({
             state: Assessment.states.STARTED,
             type: Assessment.types.CAMPAIGN,
+            campaignParticipationId: 165465,
             answers: [],
           });
           assessmentRepository_getWithAnswersStub.withArgs(assessmentId).resolves(assessment);
@@ -283,6 +285,23 @@ describe('Shared | Unit | Domain | Use Cases | get-next-challenge', function () 
 
           expect(assessmentWithNextChallenge.nextChallenge).to.deepEqualInstance(challenge);
           expect(globalProgression).to.be.null;
+        });
+
+        it('throw an error when campaignParticipationId is missing', async function () {
+          const deletedParticipationAssessment = domainBuilder.buildAssessment({
+            state: Assessment.states.STARTED,
+            type: Assessment.types.CAMPAIGN,
+            campaignParticipationId: null,
+            answers: [],
+          });
+          assessmentRepository_updateLastQuestionDateStub.resolves();
+          assessmentRepository_updateWhenNewChallengeIsAskedStub.resolves();
+          assessmentRepository_getWithAnswersStub.withArgs(assessmentId).resolves(deletedParticipationAssessment);
+          const error = await catchErr(updateAssessmentWithNextChallenge)(dependencies);
+
+          expect(error).instanceOf(CampaignParticipationDeletedError);
+          expect(evaluationUsecases_getProgressionStub.called).false;
+          expect(evaluationUsecases_getNextChallengeForCampaignAssessmentStub.called).false;
         });
 
         context('when there is no more challenge', function () {
@@ -305,6 +324,7 @@ describe('Shared | Unit | Domain | Use Cases | get-next-challenge', function () 
               id: 1234,
               state: Assessment.states.STARTED,
               type: Assessment.types.CAMPAIGN,
+              campaignParticipationId: 165465,
               campaign: domainBuilder.buildCampaign({
                 type: CampaignTypes.EXAM,
               }),


### PR DESCRIPTION
## 🌱 Problème

Lorsqu'un prescrit passe une campagne ET que celle ci est supprimé pendant son parcours. il en resulte une suppression de la campaignParticipationId de l'assessment. une erreur violente est projeté sur l'écran de l'utilisateur sans comprendre pourquoi. 

DataDog s'emballe. **breath**

## 🐣 Proposition

rejeter une erreur lorsque la participation n'est plus disponible au moment de l'assessment. 

## 🌷 Remarques

RAS

## 🐝 Pour tester

- [x] Commencer une participation sur PROASSMUL par exemple. 
- [x] Aller sur PixOrga -> supprimer la campagne
- [x] Tenter de répondre à une nouvelle question
- [x] Ce n'est plus une erreur 500 ouf merci mon dieu. 