### PR TITLE
[FEATURE] Autoriser le scoring des certification Pix + Droit et Pro santé (PIX-22315)

### DIFF
--- a/api/src/certification/evaluation/domain/models/Candidate.js
+++ b/api/src/certification/evaluation/domain/models/Candidate.js
@@ -33,10 +33,6 @@ export class Candidate {
     return this.subscriptionScope === SCOPES.CORE && !this.hasCleaSubscription;
   }
 
-  get isScorable() {
-    return this.subscriptionScope === SCOPES.CORE || this.subscriptionScope.includes('EDU_');
-  }
-
   #validate() {
     const { error } = Candidate.#schema.validate(this, { allowUnknown: false });
     if (error) {

--- a/api/src/certification/evaluation/domain/services/scoring/scoring-v3.js
+++ b/api/src/certification/evaluation/domain/services/scoring/scoring-v3.js
@@ -49,13 +49,6 @@ export function handleV3CertificationScoring({
   cleaScoringCriteria,
   scoringDegradationService,
 }) {
-  if (!candidate.isScorable) {
-    return {
-      coreAssessmentResult: null,
-      doubleCertificationScoring: null,
-    };
-  }
-
   const scoringV3Algorithm = new ScoringV3Algorithm({
     algorithm,
     allAnswers: [...assessmentSheet.answers],

--- a/api/tests/certification/evaluation/unit/domain/models/Candidate_test.js
+++ b/api/tests/certification/evaluation/unit/domain/models/Candidate_test.js
@@ -47,25 +47,6 @@ describe('Certification | Evaluation | Unit | Domain | Models | Candidate', func
     });
   });
 
-  context('#get isScorable', function () {
-    [
-      { subscriptionScope: SCOPES.CORE, isScorable: true },
-      { subscriptionScope: SCOPES.PIX_PLUS_EDU_1ER_DEGRE, isScorable: true },
-      { subscriptionScope: SCOPES.PIX_PLUS_EDU_2ND_DEGRE, isScorable: true },
-      { subscriptionScope: SCOPES.PIX_PLUS_EDU_CPE, isScorable: true },
-      { subscriptionScope: SCOPES.PIX_PLUS_DROIT, isScorable: false },
-      { subscriptionScope: SCOPES.PIX_PLUS_PRO_SANTE, isScorable: false },
-    ].forEach(({ subscriptionScope, isScorable }) => {
-      it(`should return ${isScorable} when candidate has subscribed to ${subscriptionScope} certification`, function () {
-        const candidate = domainBuilder.certification.evaluation.buildCandidate({
-          subscriptionScope: subscriptionScope,
-        });
-
-        expect(candidate.isScorable).to.equal(isScorable);
-      });
-    });
-  });
-
   context('#get hasOnlyCoreSubscription', function () {
     it('should return true when candidate has solely subscribed to CORE certification', function () {
       const candidate = domainBuilder.certification.evaluation.buildCandidate({

--- a/api/tests/certification/evaluation/unit/domain/services/scoring/scoring-v3_test.js
+++ b/api/tests/certification/evaluation/unit/domain/services/scoring/scoring-v3_test.js
@@ -196,120 +196,100 @@ describe('Unit | Certification | Evaluation | Domain | Services | Scoring V3', f
     });
 
     context('when scoring a Pix + scoped certification', function () {
-      context('when Pix + is EDU', function () {
-        it('should return an AssessmentResult without pixScore', function () {
-          // given
-          const assessmentId = 1214;
-          const certificationCourseId = 1234;
+      it('should return an AssessmentResult without pixScore', function () {
+        // given
+        const assessmentId = 1214;
+        const certificationCourseId = 1234;
 
-          const candidate = domainBuilder.certification.evaluation.buildCandidate({
-            subscriptionScope: SCOPES.PIX_PLUS_EDU_1ER_DEGRE,
-            hasCleaSubscription: false,
-            reconciledAt: new Date('2021-01-01'),
-          });
-          const assessmentSheet = domainBuilder.certification.evaluation.buildAssessmentSheet({
-            assessmentId,
-            certificationCourseId,
-          });
-
-          const event = new CertificationCompletedJob({
-            certificationCourseId,
-          });
-
-          const v3CertificationScoring = domainBuilder.buildV3CertificationScoring();
-          const challenges = generateChallengeList({
-            length: maximumAssessmentLength,
-          });
-          const { answers } = _buildDataFromAnsweredChallenges(challenges);
-
-          assessmentSheet.answers = answers;
-
-          // when
-          const score = handleV3CertificationScoring({
-            event,
-            assessmentSheet,
-            candidate,
-            allChallenges: challenges,
-            askedChallengesWithoutLiveAlerts: challenges,
-            algorithm,
-            v3CertificationScoring,
-            cleaScoringCriteria: null,
-            scoringDegradationService,
-          });
-
-          // then
-          expect(score.coreAssessmentResult).to.be.instanceOf(AssessmentResult);
-          expect(score.coreAssessmentResult.competenceMarks).to.have.lengthOf(0);
-          expect(score.coreAssessmentResult.pixScore).to.be.null;
-          expect(score.doubleCertificationScoring).to.be.null;
+        const candidate = domainBuilder.certification.evaluation.buildCandidate({
+          subscriptionScope: SCOPES.PIX_PLUS_PRO_SANTE,
+          hasCleaSubscription: false,
+          reconciledAt: new Date('2021-01-01'),
+        });
+        const assessmentSheet = domainBuilder.certification.evaluation.buildAssessmentSheet({
+          assessmentId,
+          certificationCourseId,
         });
 
-        it('should return a REJECTED AssessmentResult when capacity is not included in any mesh', function () {
-          // given
-          const assessmentId = 1214;
-          const certificationCourseId = 1234;
-
-          const candidate = domainBuilder.certification.evaluation.buildCandidate({
-            subscriptionScope: SCOPES.PIX_PLUS_EDU_1ER_DEGRE,
-            hasCleaSubscription: false,
-            reconciledAt: new Date('2021-01-01'),
-          });
-          const assessmentSheet = domainBuilder.certification.evaluation.buildAssessmentSheet({
-            assessmentId,
-            certificationCourseId,
-          });
-
-          const event = new CertificationCompletedJob({
-            certificationCourseId,
-          });
-
-          const v3CertificationScoring = domainBuilder.buildV3CertificationScoring({
-            certificationScoringConfiguration: [
-              { bounds: { max: 20, min: 10 }, meshLevel: 0 },
-              { bounds: { max: 30, min: 20 }, meshLevel: 1 },
-            ],
-          });
-          const challenges = generateChallengeList({
-            length: maximumAssessmentLength,
-          });
-          const { answers } = _buildDataFromAnsweredChallenges(challenges);
-
-          assessmentSheet.answers = answers;
-
-          // when
-          const score = handleV3CertificationScoring({
-            event,
-            assessmentSheet,
-            candidate,
-            allChallenges: challenges,
-            askedChallengesWithoutLiveAlerts: challenges,
-            algorithm,
-            v3CertificationScoring,
-            cleaScoringCriteria: null,
-            scoringDegradationService,
-          });
-
-          // then
-          expect(score.coreAssessmentResult.status).to.equal(AssessmentResult.status.REJECTED);
+        const event = new CertificationCompletedJob({
+          certificationCourseId,
         });
+
+        const v3CertificationScoring = domainBuilder.buildV3CertificationScoring();
+        const challenges = generateChallengeList({
+          length: maximumAssessmentLength,
+        });
+        const { answers } = _buildDataFromAnsweredChallenges(challenges);
+
+        assessmentSheet.answers = answers;
+
+        // when
+        const score = handleV3CertificationScoring({
+          event,
+          assessmentSheet,
+          candidate,
+          allChallenges: challenges,
+          askedChallengesWithoutLiveAlerts: challenges,
+          algorithm,
+          v3CertificationScoring,
+          cleaScoringCriteria: null,
+          scoringDegradationService,
+        });
+
+        // then
+        expect(score.coreAssessmentResult).to.be.instanceOf(AssessmentResult);
+        expect(score.coreAssessmentResult.competenceMarks).to.have.lengthOf(0);
+        expect(score.coreAssessmentResult.pixScore).to.be.null;
+        expect(score.doubleCertificationScoring).to.be.null;
       });
 
-      context('when Pix + is not EDU', function () {
-        it('should return undefined because no scoring occurred', function () {
-          const candidate = domainBuilder.certification.evaluation.buildCandidate({
-            subscriptionScope: SCOPES.PIX_PLUS_DROIT,
-            hasCleaSubscription: false,
-          });
+      it('should return a REJECTED AssessmentResult when capacity is not included in any mesh', function () {
+        // given
+        const assessmentId = 1214;
+        const certificationCourseId = 1234;
 
-          const hasScored = handleV3CertificationScoring({
-            candidate,
-          });
-
-          expect(hasScored).to.deep.equal({
-            coreAssessmentResult: null,
-            doubleCertificationScoring: null,
-          });
+        const candidate = domainBuilder.certification.evaluation.buildCandidate({
+          subscriptionScope: SCOPES.PIX_PLUS_EDU_1ER_DEGRE,
+          hasCleaSubscription: false,
+          reconciledAt: new Date('2021-01-01'),
         });
+        const assessmentSheet = domainBuilder.certification.evaluation.buildAssessmentSheet({
+          assessmentId,
+          certificationCourseId,
+        });
+
+        const event = new CertificationCompletedJob({
+          certificationCourseId,
+        });
+
+        const v3CertificationScoring = domainBuilder.buildV3CertificationScoring({
+          certificationScoringConfiguration: [
+            { bounds: { max: 20, min: 10 }, meshLevel: 0 },
+            { bounds: { max: 30, min: 20 }, meshLevel: 1 },
+          ],
+        });
+        const challenges = generateChallengeList({
+          length: maximumAssessmentLength,
+        });
+        const { answers } = _buildDataFromAnsweredChallenges(challenges);
+
+        assessmentSheet.answers = answers;
+
+        // when
+        const score = handleV3CertificationScoring({
+          event,
+          assessmentSheet,
+          candidate,
+          allChallenges: challenges,
+          askedChallengesWithoutLiveAlerts: challenges,
+          algorithm,
+          v3CertificationScoring,
+          cleaScoringCriteria: null,
+          scoringDegradationService,
+        });
+
+        // then
+        expect(score.coreAssessmentResult.status).to.equal(AssessmentResult.status.REJECTED);
       });
     });
   });


### PR DESCRIPTION
## 🌱 Problème

Maintenant que les mailles droit et pro santé sont définies, il n'y a plus de raison de bloquer le scoring de ces certifications

## 🐣 Proposition

Débloquer le scoring des certifications droit et pro santé v3 :sparkles: 

## 🌷 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🐝 Pour tester
Passer une certif droit ou pro santé, et vérifier le scoring en bdd
