### PR TITLE
[FEATURE] Ajouter une route pour récupérer les données des filtres pour une organisations sur leur prescrits (PIX-22226).

### DIFF
--- a/api/src/prescription/learner-management/application/organization-learners-controller.js
+++ b/api/src/prescription/learner-management/application/organization-learners-controller.js
@@ -1,5 +1,6 @@
 import { CLIENTS, PIX_ADMIN, PIX_ORGA } from '../../../authorization/domain/constants.js';
 import { usecases } from '../domain/usecases/index.js';
+import * as organizationLearnerFilterSerializer from '../infrastructure/serializers/jsonapi/organization-learner-filter-serializer.js';
 import * as scoOrganizationLearnerSerializer from '../infrastructure/serializers/jsonapi/sco-organization-learner-serializer.js';
 
 const deleteOrganizationLearners = async function (request, h) {
@@ -90,10 +91,21 @@ const updateOrganizationLearnerName = async function (request, h) {
   return h.response().code(204);
 };
 
+const getOrganizationLearnerFilters = async function (
+  request,
+  _,
+  dependencies = { organizationLearnerFilterSerializer },
+) {
+  const organizationId = request.params.organizationId;
+  const filters = await usecases.getOrganizationLearnerFilters({ organizationId });
+  return dependencies.organizationLearnerFilterSerializer.serialize(filters);
+};
+
 const organizationLearnersController = {
   reconcileCommonOrganizationLearner,
   deleteOrganizationLearners,
   deleteOrganizationLearnerFromAdmin,
+  getOrganizationLearnerFilters,
   importOrganizationLearnerFromFeature,
   dissociate,
   reconcileScoOrganizationLearnerAutomatically,

--- a/api/src/prescription/learner-management/application/organization-learners-route.js
+++ b/api/src/prescription/learner-management/application/organization-learners-route.js
@@ -10,6 +10,28 @@ import { organizationLearnersController } from './organization-learners-controll
 const register = async (server) => {
   server.route([
     {
+      method: 'GET',
+      path: '/api/organizations/{organizationId}/organization-learners/filters',
+      config: {
+        pre: [
+          {
+            method: securityPreHandlers.checkUserBelongsToOrganization,
+          },
+        ],
+        validate: {
+          params: Joi.object({
+            organizationId: identifiersType.organizationId,
+          }),
+        },
+        handler: organizationLearnersController.getOrganizationLearnerFilters,
+        notes: [
+          "- **Cette route est restreinte aux utilisateurs authentifiés membres de l'organisation**\n" +
+            "- Elle retourne les filtres disponibles pour les participants de l'organisation.",
+        ],
+        tags: ['api', 'organization-learners'],
+      },
+    },
+    {
       method: 'DELETE',
       path: '/api/organizations/{organizationId}/organization-learners',
       config: {

--- a/api/src/prescription/learner-management/domain/models/ImportOrganizationLearnerSet.js
+++ b/api/src/prescription/learner-management/domain/models/ImportOrganizationLearnerSet.js
@@ -257,13 +257,15 @@ class ImportOrganizationLearnerSet {
     return this.#columnMapping
       .filter((header) => header.config?.displayable?.filterable?.type === 'list')
       .map((header) => {
-        const attributeName = header.config?.property ?? header.config?.mappingColumn ?? header.name;
+        const key = header.config?.property ?? header.config?.mappingColumn ?? header.name;
         const isProperty = Boolean(header.config?.property);
+
+        const attributeName = header.config.displayable.name;
 
         const values = [
           ...new Set(
             this.#learners
-              .map((learner) => (isProperty ? learner[attributeName] : learner.attributes?.[attributeName]))
+              .map((learner) => (isProperty ? learner[key] : learner.attributes?.[key]))
               .filter((value) => value != null),
           ),
         ];

--- a/api/src/prescription/learner-management/domain/usecases/get-organization-learner-filters.js
+++ b/api/src/prescription/learner-management/domain/usecases/get-organization-learner-filters.js
@@ -1,0 +1,5 @@
+const getOrganizationLearnerFilters = async function ({ organizationId, organizationLearnerFilterRepository }) {
+  return organizationLearnerFilterRepository.findByOrganizationId(organizationId);
+};
+
+export { getOrganizationLearnerFilters };

--- a/api/src/prescription/learner-management/domain/usecases/index.js
+++ b/api/src/prescription/learner-management/domain/usecases/index.js
@@ -84,6 +84,7 @@ import { findOrganizationLearnersBeforeImportFeature } from './find-organization
 import { getDeltaOrganizationLearnerIds } from './get-delta-organization-learner-ids.js';
 import { getOrganizationImport } from './get-organization-import.js';
 import { getOrganizationImportStatus } from './get-organization-import-status.js';
+import { getOrganizationLearnerFilters } from './get-organization-learner-filters.js';
 import { getOrganizationLearnersCsvTemplate } from './get-organization-learners-csv-template.js';
 import { handlePayloadTooLargeError } from './handle-payload-too-large-error.js';
 import { hasBeenLearner } from './has-been-learner.js';
@@ -114,6 +115,7 @@ const usecasesWithoutInjectedDependencies = {
   deleteOrganizationLearners,
   dissociateUserFromOrganizationLearner,
   findAllOrganizationLearnerImportFormats,
+  getOrganizationLearnerFilters,
   findOrganizationLearnersBeforeImportFeature,
   getDeltaOrganizationLearnerIds,
   getOrganizationImportStatus,

--- a/api/src/prescription/learner-management/infrastructure/repositories/organization-learner-filter-repository.js
+++ b/api/src/prescription/learner-management/infrastructure/repositories/organization-learner-filter-repository.js
@@ -1,6 +1,7 @@
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { UnicityConstraintError } from '../../../../shared/domain/errors.js';
 import * as knexUtils from '../../../../shared/infrastructure/utils/knex-utils.js';
+import { CommonOrganizationLearnerFilter } from '../../domain/models/CommonOrganizationLearnerFilter.js';
 
 const deleteOrganizationLearnerFiltersFromOrganizationId = async function (organizationId) {
   const knexConn = DomainTransaction.getConnection();
@@ -24,4 +25,19 @@ const saveOrganizationLearnerFilters = async function (organizationLearnerFilter
   }
 };
 
-export { deleteOrganizationLearnerFiltersFromOrganizationId, saveOrganizationLearnerFilters };
+const findByOrganizationId = async function (organizationId) {
+  const knexConn = DomainTransaction.getConnection();
+  const rows = await knexConn('organization_learner_filters')
+    .where('organization_id', organizationId)
+    .select('organization_id', 'attribute_name', 'values');
+  return rows.map(
+    (row) =>
+      new CommonOrganizationLearnerFilter({
+        organizationId: row.organization_id,
+        attributeName: row.attribute_name,
+        values: row.values,
+      }),
+  );
+};
+
+export { deleteOrganizationLearnerFiltersFromOrganizationId, findByOrganizationId, saveOrganizationLearnerFilters };

--- a/api/src/prescription/learner-management/infrastructure/serializers/jsonapi/organization-learner-filter-serializer.js
+++ b/api/src/prescription/learner-management/infrastructure/serializers/jsonapi/organization-learner-filter-serializer.js
@@ -1,0 +1,12 @@
+import jsonapiSerializer from 'jsonapi-serializer';
+
+const { Serializer } = jsonapiSerializer;
+
+const serialize = function (filters) {
+  return new Serializer('organization-learner-filters', {
+    id: 'attributeName',
+    attributes: ['attributeName', 'values'],
+  }).serialize(filters);
+};
+
+export { serialize };

--- a/api/src/prescription/organization-learner/infrastructure/repositories/organization-participant-repository.js
+++ b/api/src/prescription/organization-learner/infrastructure/repositories/organization-participant-repository.js
@@ -166,7 +166,13 @@ function _filterByAttributes(queryBuilder, filters = {}) {
   if (!keys.length) return;
 
   keys.forEach((key) => {
-    queryBuilder.whereRaw(`?? LIKE ?`, [key, '%' + filters[key] + '%']);
+    const searchValue = filters[key];
+
+    if (Array.isArray(searchValue)) {
+      queryBuilder.whereIn(key, filters[key]);
+    } else {
+      queryBuilder.whereRaw(`?? LIKE ?`, [key, '%' + filters[key] + '%']);
+    }
   });
 }
 

--- a/api/src/team/infrastructure/serializers/jsonapi/prescriber-serializer.js
+++ b/api/src/team/infrastructure/serializers/jsonapi/prescriber-serializer.js
@@ -70,6 +70,7 @@ const serialize = function (prescriber) {
           'schoolCode',
           'combinedCourses',
           'sessionExpirationDate',
+          'learnerFiltersOptions',
         ],
         memberships: {
           ref: 'id',
@@ -151,6 +152,16 @@ const serialize = function (prescriber) {
           relationshipLinks: {
             related: function (record, current, parent) {
               return `/api/organizations/${parent.id}/combined-courses`;
+            },
+          },
+        },
+        learnerFiltersOptions: {
+          ref: 'id',
+          ignoreRelationshipData: true,
+          nullIfMissing: true,
+          relationshipLinks: {
+            related: function (record, current, parent) {
+              return `/api/organizations/${parent.id}/organization-learners/filters`;
             },
           },
         },

--- a/api/tests/prescription/learner-management/acceptance/application/organization-learners-route_test.js
+++ b/api/tests/prescription/learner-management/acceptance/application/organization-learners-route_test.js
@@ -17,6 +17,35 @@ describe('Acceptance | Prescription | learner management | Application | organiz
     server = await createServer();
   });
 
+  describe('GET /api/organizations/{organizationId}/organization-learners/filters', function () {
+    it('should return 200 with filters when user is a member of the organization', async function () {
+      // given
+      const organization = databaseBuilder.factory.buildOrganization();
+      const user = databaseBuilder.factory.buildUser();
+      databaseBuilder.factory.buildMembership({ organizationId: organization.id, userId: user.id });
+      databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearnerFilter({
+        organizationId: organization.id,
+        attributeName: 'division',
+        values: ['6A', '6B'],
+      });
+
+      await databaseBuilder.commit();
+
+      const options = {
+        method: 'GET',
+        url: `/api/organizations/${organization.id}/organization-learners/filters`,
+        headers: generateAuthenticatedUserRequestHeaders({ userId: user.id }),
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result.data[0].type).to.equal('organization-learner-filters');
+    });
+  });
+
   describe('DELETE /api/admin/organization-learners/{id}/association', function () {
     context('When user has the role SUPER_ADMIN and organization learner can be dissociated', function () {
       it('should return an 204 status after having successfully dissociated user from organizationLearner', async function () {

--- a/api/tests/prescription/learner-management/integration/domain/usecases/get-organization-learner-filters_test.js
+++ b/api/tests/prescription/learner-management/integration/domain/usecases/get-organization-learner-filters_test.js
@@ -1,0 +1,49 @@
+import { usecases } from '../../../../../../src/prescription/learner-management/domain/usecases/index.js';
+import { databaseBuilder, expect } from '../../../../../test-helper.js';
+
+describe('Integration | UseCase | Learner Management | get-organization-learner-filters', function () {
+  it('should return the filters for the given organization', async function () {
+    // given
+    const organizationId = databaseBuilder.factory.buildOrganization().id;
+
+    databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearnerFilter({
+      organizationId,
+      attributeName: 'division',
+      values: ['6A', '6B'],
+    });
+    databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearnerFilter({
+      organizationId,
+      attributeName: 'status',
+      values: ['active', 'inactive'],
+    });
+
+    await databaseBuilder.commit();
+
+    // when
+    const result = await usecases.getOrganizationLearnerFilters({ organizationId });
+
+    // then
+    expect(result).lengthOf(2);
+    expect(result.map((r) => r.attributeName)).to.have.members(['division', 'status']);
+  });
+
+  it('should not return filters from another organization', async function () {
+    // given
+    const organizationId = databaseBuilder.factory.buildOrganization().id;
+    const anotherOrganizationId = databaseBuilder.factory.buildOrganization().id;
+
+    databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearnerFilter({
+      organizationId: anotherOrganizationId,
+      attributeName: 'division',
+      values: ['6A'],
+    });
+
+    await databaseBuilder.commit();
+
+    // when
+    const result = await usecases.getOrganizationLearnerFilters({ organizationId });
+
+    // then
+    expect(result).lengthOf(0);
+  });
+});

--- a/api/tests/prescription/learner-management/integration/domain/usecases/import-from-feature/save-organization-learners-file_test.js
+++ b/api/tests/prescription/learner-management/integration/domain/usecases/import-from-feature/save-organization-learners-file_test.js
@@ -31,6 +31,7 @@ describe('Integration | Infrastructure | Jobs | ImportSupOrganizationLearnersJob
             name: 'Classe',
             config: {
               displayable: {
+                name: 'MY_KEY',
                 filterable: {
                   type: 'list',
                 },
@@ -97,7 +98,7 @@ O-Ren;Ishii;5B;01/02/1980`,
     const filters = await knex('organization_learner_filters').where('organization_id', organizationId);
 
     expect(filters).lengthOf(1);
-    expect(filters[0].attribute_name).equal('Classe');
+    expect(filters[0].attribute_name).equal('MY_KEY');
     expect(filters[0].values).deep.equal(['5B', '6A']);
   });
 });

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/organization-learner-filter-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/organization-learner-filter-repository_test.js
@@ -50,6 +50,65 @@ describe('Integration | Repository | Organization Learner Management | Organizat
     });
   });
 
+  describe('#findByOrganizationId', function () {
+    it('should return filters for the given organization', async function () {
+      // given
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+
+      databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearnerFilter({
+        organizationId,
+        attributeName: 'division',
+        values: ['6A', '6B'],
+      });
+      databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearnerFilter({
+        organizationId,
+        attributeName: 'status',
+        values: ['active', 'inactive'],
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const result = await organizationLearnerFilterRepository.findByOrganizationId(organizationId);
+
+      // then
+      expect(result).lengthOf(2);
+      expect(result.map((r) => r.attributeName)).to.have.members(['division', 'status']);
+    });
+
+    it('should not return filters from another organization', async function () {
+      // given
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      const anotherOrganizationId = databaseBuilder.factory.buildOrganization().id;
+
+      databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearnerFilter({
+        organizationId: anotherOrganizationId,
+        attributeName: 'division',
+        values: ['6A'],
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const result = await organizationLearnerFilterRepository.findByOrganizationId(organizationId);
+
+      // then
+      expect(result).lengthOf(0);
+    });
+
+    it('should return an empty array when no filters exist for the organization', async function () {
+      // given
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      await databaseBuilder.commit();
+
+      // when
+      const result = await organizationLearnerFilterRepository.findByOrganizationId(organizationId);
+
+      // then
+      expect(result).lengthOf(0);
+    });
+  });
+
   describe('#saveOrganizationLearnerFilters', function () {
     it('save organization learner filter', async function () {
       // given

--- a/api/tests/prescription/learner-management/unit/application/organization-learners-controller_test.js
+++ b/api/tests/prescription/learner-management/unit/application/organization-learners-controller_test.js
@@ -61,6 +61,30 @@ describe('Unit | Prescription | Learner Management | Application | organization-
     });
   });
 
+  describe('#getOrganizationLearnerFilters', function () {
+    it('should call usecase and serialize result', async function () {
+      // given
+      const organizationId = Symbol('organizationId');
+      const filters = Symbol('filters');
+      const serialized = Symbol('serialized');
+
+      sinon.stub(usecases, 'getOrganizationLearnerFilters').resolves(filters);
+      const organizationLearnerFilterSerializer = { serialize: sinon.stub().returns(serialized) };
+
+      const request = { params: { organizationId } };
+
+      // when
+      const response = await organizationLearnersController.getOrganizationLearnerFilters(request, hFake, {
+        organizationLearnerFilterSerializer,
+      });
+
+      // then
+      expect(usecases.getOrganizationLearnerFilters).to.have.been.calledWithExactly({ organizationId });
+      expect(organizationLearnerFilterSerializer.serialize).to.have.been.calledWithExactly(filters);
+      expect(response).to.equal(serialized);
+    });
+  });
+
   describe('#deleteOrganizationLearnerFromAdmin', function () {
     let deleteOrganizationLearnersStub;
 

--- a/api/tests/prescription/learner-management/unit/application/organization-learners-route_test.js
+++ b/api/tests/prescription/learner-management/unit/application/organization-learners-route_test.js
@@ -4,6 +4,37 @@ import { securityPreHandlers } from '../../../../../src/shared/application/secur
 import { expect, generateAuthenticatedUserRequestHeaders, HttpTestServer, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Prescription | learner management | Application | Router | organization-learner-router', function () {
+  describe('GET /api/organizations/{organizationId}/organization-learners/filters', function () {
+    it('should call checkUserBelongsToOrganization and the controller', async function () {
+      // given
+      sinon.stub(securityPreHandlers, 'checkUserBelongsToOrganization').callsFake((request, h) => h.response(true));
+      sinon
+        .stub(organizationLearnersController, 'getOrganizationLearnerFilters')
+        .callsFake((request, h) => h.response('ok').code(200));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      await httpTestServer.request('GET', '/api/organizations/1/organization-learners/filters');
+
+      // then
+      sinon.assert.calledOnce(securityPreHandlers.checkUserBelongsToOrganization);
+      sinon.assert.calledOnce(organizationLearnersController.getOrganizationLearnerFilters);
+    });
+
+    it('should return 400 when organizationId is not a number', async function () {
+      // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      const response = await httpTestServer.request('GET', '/api/organizations/ABC/organization-learners/filters');
+
+      // then
+      expect(response.statusCode).to.equal(400);
+    });
+  });
+
   describe('DELETE /api/admin/organizations/{organizationId}/organization-learners/{organizationLearnerId}', function () {
     it('should call right handler before calling controller', async function () {
       // given

--- a/api/tests/prescription/learner-management/unit/domain/models/ImportOrganizationLearnerSet_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/models/ImportOrganizationLearnerSet_test.js
@@ -981,7 +981,7 @@ describe('Unit | Models | ImportOrganizationLearnerSet', function () {
       ]);
 
       expect(learnerSet.filtersAvailableValues).to.deep.equal([
-        { organizationId: 123, attributeName: 'group', values: ['A', 'B'] },
+        { organizationId: 123, attributeName: 'division', values: ['A', 'B'] },
       ]);
     });
 
@@ -1009,8 +1009,8 @@ describe('Unit | Models | ImportOrganizationLearnerSet', function () {
       ]);
 
       expect(learnerSet.filtersAvailableValues).to.deep.equal([
-        { organizationId: 123, attributeName: 'group', values: ['A', 'B'] },
-        { organizationId: 123, attributeName: 'status', values: ['active', 'inactive'] },
+        { organizationId: 123, attributeName: 'division', values: ['A', 'B'] },
+        { organizationId: 123, attributeName: 'statut', values: ['active', 'inactive'] },
       ]);
     });
 
@@ -1029,7 +1029,7 @@ describe('Unit | Models | ImportOrganizationLearnerSet', function () {
       learnerSet.addLearners([{ ...learnerAttributes, CATEGORY: 'Solo' }]);
 
       expect(learnerSet.filtersAvailableValues).to.deep.equal([
-        { organizationId: 123, attributeName: 'catégorie', values: ['Solo'] },
+        { organizationId: 123, attributeName: 'division', values: ['Solo'] },
       ]);
     });
 
@@ -1051,7 +1051,7 @@ describe('Unit | Models | ImportOrganizationLearnerSet', function () {
       ]);
 
       expect(learnerSet.filtersAvailableValues).to.deep.equal([
-        { organizationId: 123, attributeName: 'firstName', values: ['Tomie', 'Mieto'] },
+        { organizationId: 123, attributeName: 'Prénom', values: ['Tomie', 'Mieto'] },
       ]);
     });
   });

--- a/api/tests/prescription/organization-learner/integration/infrastructure/repositories/organization-participant-repository_test.js
+++ b/api/tests/prescription/organization-learner/integration/infrastructure/repositories/organization-participant-repository_test.js
@@ -2466,31 +2466,62 @@ describe('Integration | Infrastructure | Repository | OrganizationParticipant', 
 
     context('when we are filtering', function () {
       context('extra filters', function () {
-        it('returns the participants which match by an attribute', async function () {
-          // given
-          databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
-            organizationId,
-            attributes: { classe: '3ème' },
-          });
-          const { id: id2 } = databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
-            organizationId,
-            attributes: { classe: '6ème' },
-          });
-
-          await databaseBuilder.commit();
-
-          // when
-          const { organizationParticipants } =
-            await organizationParticipantRepository.findPaginatedFilteredImportedParticipants({
+        context('string case', function () {
+          it('returns the participants which match by an attribute like', async function () {
+            // given
+            databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
               organizationId,
-              extraColumns: [{ key: 'classe', name: 'CLASSE' }],
-              extraFilters: { CLASSE: '6ème' },
+              attributes: { classe: '3ème' },
+            });
+            const { id: id2 } = databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
+              organizationId,
+              attributes: { classe: '6ème' },
             });
 
-          const ids = organizationParticipants.map(({ id }) => id);
+            await databaseBuilder.commit();
 
-          // then
-          expect(ids).to.exactlyContain([id2]);
+            // when
+            const { organizationParticipants } =
+              await organizationParticipantRepository.findPaginatedFilteredImportedParticipants({
+                organizationId,
+                extraColumns: [{ key: 'classe', name: 'CLASSE' }],
+                extraFilters: { CLASSE: '6è' },
+              });
+
+            const ids = organizationParticipants.map(({ id }) => id);
+
+            // then
+            expect(ids).to.exactlyContain([id2]);
+          });
+        });
+
+        context('array case', function () {
+          it('returns the participants which match by an attribute like', async function () {
+            // given
+            const { id: id1 } = databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
+              organizationId,
+              attributes: { classe: '3ème' },
+            });
+            databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
+              organizationId,
+              attributes: { classe: '6ème' },
+            });
+
+            await databaseBuilder.commit();
+
+            // when
+            const { organizationParticipants } =
+              await organizationParticipantRepository.findPaginatedFilteredImportedParticipants({
+                organizationId,
+                extraColumns: [{ key: 'classe', name: 'CLASSE' }],
+                extraFilters: { CLASSE: ['3ème', '5ème'] },
+              });
+
+            const ids = organizationParticipants.map(({ id }) => id);
+
+            // then
+            expect(ids).to.exactlyContain([id1]);
+          });
         });
       });
 

--- a/api/tests/team/acceptance/application/prescriber-informations.controller.test.js
+++ b/api/tests/team/acceptance/application/prescriber-informations.controller.test.js
@@ -106,6 +106,11 @@ describe('Acceptance | Team | Application | Controller | prescriber-informations
                 related: `/api/organizations/${organization.id}/target-profiles`,
               },
             },
+            'learner-filters-options': {
+              links: {
+                related: `/api/organizations/${organization.id}/organization-learners/filters`,
+              },
+            },
           },
         },
         {

--- a/api/tests/team/unit/infrastructure/serializers/jsonapi/prescriber-serializer_test.js
+++ b/api/tests/team/unit/infrastructure/serializers/jsonapi/prescriber-serializer_test.js
@@ -324,6 +324,11 @@ function createExpectedPrescriberSerializedWithOneMoreField({
               related: `/api/organizations/${organization.id}/combined-course-blueprints`,
             },
           },
+          'learner-filters-options': {
+            links: {
+              related: `/api/organizations/${organization.id}/organization-learners/filters`,
+            },
+          },
         },
       },
       {
@@ -446,6 +451,11 @@ function createExpectedPrescriberSerialized({ prescriber, membership, userOrgaSe
           'combined-course-blueprints': {
             links: {
               related: `/api/organizations/${organization.id}/combined-course-blueprints`,
+            },
+          },
+          'learner-filters-options': {
+            links: {
+              related: `/api/organizations/${organization.id}/organization-learners/filters`,
             },
           },
         },

--- a/orga/app/components/organization-participant/learner-filters.gjs
+++ b/orga/app/components/organization-participant/learner-filters.gjs
@@ -1,6 +1,7 @@
 import PixFilterBanner from '@1024pix/pix-ui/components/pix-filter-banner';
 import PixSearchInput from '@1024pix/pix-ui/components/pix-search-input';
 import { get } from '@ember/helper';
+import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
@@ -44,6 +45,18 @@ export default class LearnerFilters extends Component {
       : this.intl.t('pages.organization-participants.filters.participations-count', { count: this.args.learnersCount });
   }
 
+  @action
+  hasFilterOptions(columnName) {
+    return this.args?.customFiltersOptions?.find(({ attributeName }) => attributeName === columnName) ?? false;
+  }
+
+  @action
+  customFilterOptions(columnName) {
+    return this.args.customFiltersOptions
+      .find(({ attributeName }) => attributeName === columnName)
+      .values.map((option) => ({ label: option, value: option }));
+  }
+
   <template>
     <PixFilterBanner
       @title={{t "common.filters.title"}}
@@ -78,16 +91,28 @@ export default class LearnerFilters extends Component {
       {{#each @customFilters as |customFilter|}}
         {{#let (t (getColumnName customFilter)) as |columnName|}}
 
-          <PixSearchInput
-            @id="extraFilters.{{customFilter}}"
-            value={{get @customFiltersValues customFilter}}
-            @screenReaderOnly={{true}}
-            @placeholder={{columnName}}
-            @debounceTimeInMs={{debounceTime}}
-            @triggerFiltering={{@onTriggerFiltering}}
-          >
-            <:label>{{columnName}}</:label>
-          </PixSearchInput>
+          {{#if (this.hasFilterOptions customFilter)}}
+            <UiMultiSelectFilter
+              @field="extraFilters.{{customFilter}}"
+              @label={{columnName}}
+              @placeholder={{columnName}}
+              @onSelect={{@onTriggerFiltering}}
+              @selectedOption={{get @customFiltersValues customFilter}}
+              @options={{this.customFilterOptions customFilter}}
+              @emptyMessage=""
+            />
+          {{else}}
+            <PixSearchInput
+              @id="extraFilters.{{customFilter}}"
+              value={{get @customFiltersValues customFilter}}
+              @screenReaderOnly={{true}}
+              @placeholder={{columnName}}
+              @debounceTimeInMs={{debounceTime}}
+              @triggerFiltering={{@onTriggerFiltering}}
+            >
+              <:label>{{columnName}}</:label>
+            </PixSearchInput>
+          {{/if}}
         {{/let}}
       {{/each}}
     </PixFilterBanner>

--- a/orga/app/components/organization-participant/list.gjs
+++ b/orga/app/components/organization-participant/list.gjs
@@ -401,6 +401,7 @@ export default class List extends Component {
 
         <Filters
           @destinationId={{filtersId}}
+          @customFiltersOptions={{@customFiltersOptions}}
           @learnersCount={{@participants.meta.rowCount}}
           @fullName={{@fullName}}
           @customFilters={{this.customFilters}}
@@ -456,6 +457,7 @@ const Filters = <template>
   <InElement @destinationId={{@destinationId}}>
     <LearnerFilters
       @learnersCount={{@learnersCount}}
+      @customFiltersOptions={{@customFiltersOptions}}
       @fullName={{@fullName}}
       @customFilters={{@customFilters}}
       @customFiltersValues={{@customFiltersValues}}

--- a/orga/app/models/organization-learner-filter.js
+++ b/orga/app/models/organization-learner-filter.js
@@ -1,0 +1,6 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class OrganizationLearnerFilter extends Model {
+  @attr('string') attributeName;
+  @attr() values;
+}

--- a/orga/app/models/organization.js
+++ b/orga/app/models/organization.js
@@ -18,6 +18,7 @@ export default class Organization extends Model {
   @hasMany('combined-course-blueprint', { async: true, inverse: null }) combinedCourseBlueprints;
   @hasMany('organization-invitation', { async: true, inverse: 'organization' }) organizationInvitations;
   @hasMany('group', { async: true, inverse: null }) groups;
+  @hasMany('organization-learner-filter', { async: true, inverse: null }) learnerFiltersOptions;
   @hasMany('division', { async: true, inverse: null }) divisions;
   @belongsTo('participation-statistic', { async: true, inverse: null }) participationStatistics;
 

--- a/orga/app/routes/authenticated/organization-participants/list.js
+++ b/orga/app/routes/authenticated/organization-participants/list.js
@@ -23,7 +23,8 @@ export default class ListRoute extends Route {
   async model(params) {
     paramsValidator.validateCertificabilityParams(params);
 
-    return this.store.query('organization-participant', {
+    const customFiltersOptions = await this.currentUser.organization.learnerFiltersOptions;
+    const participantList = await this.store.query('organization-participant', {
       filter: {
         organizationId: this.currentUser.organization.id,
         fullName: params.fullName,
@@ -41,6 +42,8 @@ export default class ListRoute extends Route {
         size: params.pageSize,
       },
     });
+
+    return { participantList, customFiltersOptions };
   }
 
   resetController(controller, isExiting) {

--- a/orga/app/templates/authenticated/organization-participants/list.gjs
+++ b/orga/app/templates/authenticated/organization-participants/list.gjs
@@ -7,14 +7,15 @@ import NoParticipantPanel from 'pix-orga/components/organization-participant/no-
   {{pageTitle (t "pages.organization-participants.page-title")}}
 
   <div class="organization-participant-list-page">
-    <Header @participantCount={{@model.meta.participantCount}} />
+    <Header @participantCount={{@model.participantList.meta.participantCount}} />
 
-    {{#if @model.meta.participantCount}}
+    {{#if @model.participantList.meta.participantCount}}
       <List
-        @participants={{@model}}
+        @participants={{@model.participantList}}
         @triggerFiltering={{@controller.triggerFiltering}}
         @onResetFilter={{@controller.resetFilters}}
         @customFiltersValues={{@controller.decodedExtraFilters}}
+        @customFiltersOptions={{@model.customFiltersOptions}}
         @fullName={{@controller.fullName}}
         @certificabilityFilter={{@controller.certificability}}
         @onClickLearner={{@controller.goToLearnerPage}}

--- a/orga/tests/integration/components/organization-participant/list-test.gjs
+++ b/orga/tests/integration/components/organization-participant/list-test.gjs
@@ -455,58 +455,105 @@ module('Integration | Component | OrganizationParticipant | List', function (hoo
           }
           this.owner.register('service:current-user', CurrentUserStub);
           participants.meta = {
-            customFilters: ['classe'],
+            customFilters: ['COMMON_DIVISION'],
             headingCustomColumns: [],
           };
         });
 
-        test('it should display custom filters', async function (assert) {
-          // given
+        module('input text filter', function () {
+          test('it should trigger filtering with custom filters', async function (assert) {
+            // given
+            const triggerFiltering = sinon.stub();
 
-          const customFiltersValues = { classe: 'Troisième' };
-          // when
-          const screen = await render(
-            <template>
-              <List
-                @participants={{participants}}
-                @triggerFiltering={{noop}}
-                @onClickLearner={{noop}}
-                @fullName={{fullNameFilter}}
-                @customFiltersValues={{customFiltersValues}}
-                @certificabilityFilter={{certificabilityFilter}}
-              />
-            </template>,
-          );
+            const customFiltersValues = { COMMON_DIVISION: '' };
 
-          // then
-          assert.ok(screen.getByLabelText(t('classe')));
+            await render(
+              <template>
+                <List
+                  @participants={{participants}}
+                  @triggerFiltering={{triggerFiltering}}
+                  @onClickLearner={{noop}}
+                  @fullName={{fullNameFilter}}
+                  @customFiltersValues={{customFiltersValues}}
+                  @certificabilityFilter={{certificabilityFilter}}
+                />
+              </template>,
+            );
+
+            // when
+            await fillByLabel(t('common.import.field.division'), 'CP');
+
+            // then
+            assert.ok(triggerFiltering.calledWith('extraFilters.COMMON_DIVISION', 'CP'));
+          });
         });
-        test('it should trigger filtering with custom filters', async function (assert) {
-          // given
-          const triggerFiltering = sinon.stub();
 
-          const customFiltersValues = { classe: '' };
+        module('multi select filter', function () {
+          test('it should trigger filtering with custom filters', async function (assert) {
+            // given
+            const triggerFiltering = sinon.stub();
 
-          await render(
-            <template>
-              <List
-                @participants={{participants}}
-                @triggerFiltering={{triggerFiltering}}
-                @onClickLearner={{noop}}
-                @fullName={{fullNameFilter}}
-                @customFiltersValues={{customFiltersValues}}
-                @certificabilityFilter={{certificabilityFilter}}
-              />
-            </template>,
-          );
+            const customFiltersValues = { COMMON_DIVISION: '' };
+            const customFiltersOptions = [{ attributeName: 'COMMON_DIVISION', values: ['Troisième', 'Quatrième'] }];
 
-          // when
-          await fillByLabel(t('classe'), 'CP');
+            const screen = await render(
+              <template>
+                <List
+                  @participants={{participants}}
+                  @triggerFiltering={{triggerFiltering}}
+                  @onClickLearner={{noop}}
+                  @fullName={{fullNameFilter}}
+                  @customFiltersValues={{customFiltersValues}}
+                  @customFiltersOptions={{customFiltersOptions}}
+                  @certificabilityFilter={{certificabilityFilter}}
+                />
+              </template>,
+            );
 
-          // then
-          assert.ok(triggerFiltering.calledWith('extraFilters.classe', 'CP'));
+            // when
+            await click(screen.getByRole('button', { name: t('common.import.field.division') }));
+
+            await screen.findByRole('menu');
+
+            await click(screen.getByRole('checkbox', { name: 'Troisième' }));
+
+            // then
+            assert.ok(triggerFiltering.calledWith('extraFilters.COMMON_DIVISION', ['Troisième']));
+          });
+
+          test('it should prefill data on custom filters', async function (assert) {
+            // given
+            const triggerFiltering = sinon.stub();
+
+            const customFiltersValues = { COMMON_DIVISION: 'Quatrième' };
+            const customFiltersOptions = [{ attributeName: 'COMMON_DIVISION', values: ['Troisième', 'Quatrième'] }];
+
+            const screen = await render(
+              <template>
+                <List
+                  @participants={{participants}}
+                  @triggerFiltering={{triggerFiltering}}
+                  @onClickLearner={{noop}}
+                  @fullName={{fullNameFilter}}
+                  @customFiltersValues={{customFiltersValues}}
+                  @customFiltersOptions={{customFiltersOptions}}
+                  @certificabilityFilter={{certificabilityFilter}}
+                />
+              </template>,
+            );
+
+            // when
+            await click(screen.getByRole('button', { name: t('common.import.field.division') }));
+
+            await screen.findByRole('menu');
+
+            // then
+            assert.dom(screen.getByRole('checkbox', { name: 'Quatrième' })).isChecked();
+            assert.dom(screen.getByRole('checkbox', { name: 'Troisième' })).isNotChecked();
+          });
         });
       });
+
       module('when import feature is disabled', function (hooks) {
         const participants = [];
         hooks.beforeEach(function () {
@@ -515,14 +562,14 @@ module('Integration | Component | OrganizationParticipant | List', function (hoo
           }
           this.owner.register('service:current-user', CurrentUserStub);
           participants.meta = {
-            customFilters: ['classe'],
+            customFilters: ['COMMON_DIVISION'],
           };
         });
 
         test('it should not display custom filters', async function (assert) {
           // given
 
-          const customFiltersValues = { classe: 'Troisième' };
+          const customFiltersValues = { COMMON_DIVISION: 'Troisième' };
           // when
           const screen = await render(
             <template>
@@ -538,7 +585,7 @@ module('Integration | Component | OrganizationParticipant | List', function (hoo
           );
 
           // then
-          assert.notOk(screen.queryByLabelText(t('classe')));
+          assert.notOk(screen.queryByLabelText(t('common.import.field.division')));
         });
       });
     });

--- a/orga/tests/unit/routes/authenticated/organization-participants/list-test.js
+++ b/orga/tests/unit/routes/authenticated/organization-participants/list-test.js
@@ -20,6 +20,7 @@ module('Unit | Route | authenticated/organization-participants/list', function (
   const divisionSortSymbol = Symbol('divisionSort');
   const pageNumberSymbol = Symbol('pageNumber');
   const pageSizeSymbol = Symbol('pageSize');
+  const learnerFiltersOptionsSymbol = Symbol('learnerFiltersOptions');
 
   const params = {
     fullName: fullNameSymbol,
@@ -38,7 +39,12 @@ module('Unit | Route | authenticated/organization-participants/list', function (
   hooks.beforeEach(function () {
     route = this.owner.lookup('route:authenticated/organization-participants/list');
     store = this.owner.lookup('service:store');
-    route.currentUser = { organization: { id: Symbol('organization-id') } };
+    route.currentUser = {
+      organization: {
+        id: Symbol('organization-id'),
+        learnerFiltersOptions: Promise.resolve(learnerFiltersOptionsSymbol),
+      },
+    };
     sinon
       .stub(extraFilterSerializer, 'decodeExtraFilters')
       .withArgs(extraFiltersSymbol)
@@ -70,10 +76,10 @@ module('Unit | Route | authenticated/organization-participants/list', function (
 
   test('should return participant model', async function (assert) {
     // when
-    const participants = await route.model(params);
-
+    const { participantList, customFiltersOptions } = await route.model(params);
     // then
-    assert.strictEqual(participants, organizationParticipantSymbol);
+    assert.strictEqual(participantList, organizationParticipantSymbol);
+    assert.strictEqual(customFiltersOptions, learnerFiltersOptionsSymbol);
   });
 
   test('should resetController on exiting', function (assert) {


### PR DESCRIPTION
## 🌱 Problème

Actuellement sur les imports à format il était impossible côté front de récupérer les données que l'on souhaite afficher dans la liste d'un select/multiselect pour pouvoir filtrer le tableau.

## 🐣 Proposition

Comme les PR précedentes pour ajouter les données valable dans la liste des filtres est dipsonible. il nous reste à écrire la route et l'utiliser côté Front dans le cas ou des données subsistes.
 
## 🌷 Remarques

RAS

## 🐝 Pour tester
- [x] insérer un import à format avec un filter de type list ( Fregata a tout hasard )
- [x] Activer l'import à format Fregate sur l'organisation fregata 
- [x] Importer des eleves via notre referentiel de csv valide
- [x] aller sur PixOrga dans la liste des participants et vérifier que le filtre classe est bien chargé avec un multiselect qui permet de filtrer dans la liste. 

Voilà bisous