### PR TITLE
[FEATURE] Cocher automatiquement le blocage lorsqu'on coche la gestion des places (PIX-22163)

### DIFF
--- a/admin/app/components/organizations/features-section.gjs
+++ b/admin/app/components/organizations/features-section.gjs
@@ -122,11 +122,17 @@ export default class OrganizationFeaturesSection extends Component {
         this.displayLearnerImportActivationDialog = true;
         this.learnerImportActivationConfirmed = false;
       }
-    } else {
-      this.form = lodashSet(this.form, key, !lodashGet(this.form, key));
-      if (key === 'features.PLACES_MANAGEMENT.active' && !this.form.features?.PLACES_MANAGEMENT?.active) {
-        this.form = lodashSet(this.form, 'features.PLACES_MANAGEMENT.params.enableMaximumPlacesLimit', false);
-      }
+      return;
+    }
+    this.form = lodashSet(this.form, key, !lodashGet(this.form, key));
+
+    if (key === 'features.PLACES_MANAGEMENT.active') {
+      const shouldPlacesLimitBeChecked = Boolean(this.form.features?.PLACES_MANAGEMENT?.active);
+      this.form = lodashSet(
+        this.form,
+        'features.PLACES_MANAGEMENT.params.enableMaximumPlacesLimit',
+        shouldPlacesLimitBeChecked,
+      );
     }
   }
 

--- a/admin/tests/integration/components/organizations/features-section-test.gjs
+++ b/admin/tests/integration/components/organizations/features-section-test.gjs
@@ -486,7 +486,7 @@ module('Integration | Component | organizations/features-section', function (hoo
       this.owner.register('service:access-control', AccessControlStub);
     });
 
-    test('it shows unchecked checkbox and no sub-checkbox when feature is inactive', async function (assert) {
+    test('it shows unchecked checkbox and disabled sub-checkbox when feature is inactive', async function (assert) {
       // given
       const onSubmit = onSubmitStub;
       const organization = EmberObject.create({
@@ -575,6 +575,30 @@ module('Integration | Component | organizations/features-section', function (hoo
 
       // then
       assert.false(
+        screen.getByLabelText(
+          t('components.organizations.information-section-view.features.ORGANIZATION_PLACES_LIMIT.label'),
+        ).checked,
+      );
+    });
+
+    test('it automatically checks the limit sub-checkbox when PLACES_MANAGEMENT is being checked', async function (assert) {
+      // given
+      const onSubmit = onSubmitStub;
+      const organization = EmberObject.create({
+        features: { PLACES_MANAGEMENT: { active: false, params: null } },
+      });
+
+      const screen = await render(
+        <template><FeaturesSection @organization={{organization}} @onSubmit={{onSubmit}} /></template>,
+      );
+
+      // when
+      await click(
+        screen.getByLabelText(t('components.organizations.information-section-view.features.PLACES_MANAGEMENT')),
+      );
+
+      // then
+      assert.true(
         screen.getByLabelText(
           t('components.organizations.information-section-view.features.ORGANIZATION_PLACES_LIMIT.label'),
         ).checked,


### PR DESCRIPTION
## 🌱 Problème
La fonctionnalité _Gestion des places_ (**PLACES_MANAGEMENT**) contient une sous fonctionnalité _Blocage de l'organisation en cas de dépassement des places_ (le param **enableMaximumPlacesLimit**) qu'il devient possible de cocher quand la fonctionnalité principale est cochée. On voudrait inciter les utilisateurs de Pix Admin à cocher le blocage d'une organisation lorsqu'ils cochent la gestion des places.

## 🐣 Proposition

Cocher automatiquement la sous-fonctionnalité de blocage lorsqu'on coche la fonctionnalité de gestion des places. Il reste possible de décocher le blocage si on ne souhaite que la gestion des places.

## 🌷 Remarques

RAS

## 🐝 Pour tester
Sur Pix Admin,
- aller sur la page de détail d'une organisation
- aller dans l'onglet _Fonctionnalités_
- cocher la fonctionnalité _Gestion des places_
- constater que lq sous-feature est maintenant active et automatiquement cochée
- constater qu'il est possible de la décocher
- essayer plusieurs scénarii, notamment de sauvegarder, annuler, aller sur une orga qui possède déjà la feature Gestion des places sans le blocage
