### PR TITLE
[FEATURE] Créer un script pour activer la feature pour une liste de campagnes (PIX-22217)

### DIFF
--- a/api/src/prescription/scripts/enable-recommendation-engine-feature-for-campaigns.js
+++ b/api/src/prescription/scripts/enable-recommendation-engine-feature-for-campaigns.js
@@ -1,0 +1,84 @@
+import { commaSeparatedNumberParser } from '../../shared/application/scripts/parsers.js';
+import { Script } from '../../shared/application/scripts/script.js';
+import { ScriptRunner } from '../../shared/application/scripts/script-runner.js';
+import { CAMPAIGN_FEATURES } from '../../shared/domain/constants.js';
+import { DomainTransaction } from '../../shared/domain/DomainTransaction.js';
+
+export class EnableRecommendationEngineFeatureForCampaignsScript extends Script {
+  constructor() {
+    super({
+      description: 'Enables the RECOMMENDATION_ENGINE feature for given campaign IDs',
+      permanent: false,
+      options: {
+        campaignIds: {
+          type: 'string',
+          describe: 'a list of comma separated campaign ids',
+          demandOption: true,
+          coerce: commaSeparatedNumberParser(),
+        },
+        dryRun: {
+          type: 'boolean',
+          describe: 'Run the script without making any database changes',
+          default: false,
+        },
+      },
+    });
+  }
+
+  async handle({ options, logger }) {
+    await DomainTransaction.execute(async () => {
+      const knexConn = DomainTransaction.getConnection();
+
+      const inexistingCampaignIds = [];
+      const campaignIdsWithAlreadyEnabledFeature = [];
+      const campaignIdsWithEnabledFeature = [];
+
+      const feature = await knexConn('features').where({ key: CAMPAIGN_FEATURES.RECOMMENDATION_ENGINE.key }).first();
+      if (!feature) {
+        throw new Error(`Feature ${CAMPAIGN_FEATURES.RECOMMENDATION_ENGINE.key} not found in features table`);
+      }
+
+      for (const campaignId of options.campaignIds) {
+        const campaign = await knexConn('campaigns').where({ id: campaignId }).first();
+
+        if (!campaign) {
+          inexistingCampaignIds.push(campaignId);
+          continue;
+        }
+
+        const existingCampaignFeature = await knexConn('campaign-features')
+          .where({ campaignId, featureId: feature.id })
+          .first();
+
+        if (existingCampaignFeature) {
+          campaignIdsWithAlreadyEnabledFeature.push(campaignId);
+          continue;
+        }
+
+        await knexConn('campaign-features').insert({ featureId: feature.id, campaignId, params: {} });
+        campaignIdsWithEnabledFeature.push(campaignId);
+      }
+
+      logger.info(
+        `${inexistingCampaignIds.length} campaign(s) not found: ${inexistingCampaignIds.length > 0 ? inexistingCampaignIds.join(', ') : ''}`,
+      );
+      logger.info(
+        `${campaignIdsWithAlreadyEnabledFeature.length} campaign(s) already had the feature enabled: ${campaignIdsWithAlreadyEnabledFeature.length > 0 ? campaignIdsWithAlreadyEnabledFeature.join(', ') : 'no campaign impacted'}`,
+      );
+      logger.info(
+        `${campaignIdsWithEnabledFeature.length} campaign(s) newly enabled: ${campaignIdsWithEnabledFeature.length > 0 ? campaignIdsWithEnabledFeature.join(', ') : 'no campaign impacted'}`,
+      );
+
+      if (options.dryRun) {
+        await knexConn.rollback();
+        logger.info('ROLLBACK: no changes were persisted (dry run)');
+        logger.info('remove --dryRun to persist changes');
+        return;
+      }
+
+      logger.info('COMMIT: changes persisted');
+    });
+  }
+}
+
+await ScriptRunner.execute(import.meta.url, EnableRecommendationEngineFeatureForCampaignsScript);

--- a/api/tests/prescription/scripts/integration/enable-recommendation-engine-feature-for-campaigns_test.js
+++ b/api/tests/prescription/scripts/integration/enable-recommendation-engine-feature-for-campaigns_test.js
@@ -1,0 +1,144 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { EnableRecommendationEngineFeatureForCampaignsScript } from '../../../../src/prescription/scripts/enable-recommendation-engine-feature-for-campaigns.js';
+import { CAMPAIGN_FEATURES } from '../../../../src/shared/domain/constants.js';
+import { databaseBuilder, knex } from '../../../test-helper.js';
+
+describe('EnableRecommendationEngineFeatureForCampaignsScript', function () {
+  describe('Options', function () {
+    it('has the correct options', function () {
+      const script = new EnableRecommendationEngineFeatureForCampaignsScript();
+      const { options } = script.metaInfo;
+
+      expect(options.campaignIds).to.deep.include({
+        type: 'string',
+        describe: 'a list of comma separated campaign ids',
+        demandOption: true,
+      });
+
+      expect(options.dryRun).to.deep.include({
+        type: 'boolean',
+        describe: 'Run the script without making any database changes',
+        default: false,
+      });
+    });
+
+    it('parses list of campaignIds', async function () {
+      const ids = '1,2,3';
+      const script = new EnableRecommendationEngineFeatureForCampaignsScript();
+      const { options } = script.metaInfo;
+      const parsedData = await options.campaignIds.coerce(ids);
+
+      expect(parsedData).to.deep.equals([1, 2, 3]);
+    });
+  });
+
+  describe('Handle', function () {
+    let script;
+    let logger;
+    let featureId;
+
+    beforeEach(async function () {
+      script = new EnableRecommendationEngineFeatureForCampaignsScript();
+      logger = { info: sinon.spy(), error: sinon.spy() };
+      featureId = databaseBuilder.factory.buildFeature(CAMPAIGN_FEATURES.RECOMMENDATION_ENGINE).id;
+      await databaseBuilder.commit();
+    });
+
+    context('when not in dryRun', function () {
+      it('adds non-existing campaign id to the inexisting list', async function () {
+        // when
+        await script.handle({ options: { campaignIds: [999999], dryRun: false }, logger });
+
+        // then
+        const campaignFeatures = await knex('campaign-features').where({ featureId });
+        expect(campaignFeatures).to.have.lengthOf(0);
+        expect(logger.info.calledWithMatch('1 campaign(s) not found')).to.be.true;
+      });
+
+      it('adds campaign id with already enabled feature to the already-enabled campaigns list', async function () {
+        // given
+        const campaign = databaseBuilder.factory.buildCampaign();
+        databaseBuilder.factory.buildCampaignFeature({ campaignId: campaign.id, featureId, params: {} });
+        await databaseBuilder.commit();
+
+        // when
+        await script.handle({ options: { campaignIds: [campaign.id], dryRun: false }, logger });
+
+        // then
+        const campaignFeatures = await knex('campaign-features').where({ campaignId: campaign.id, featureId });
+        expect(campaignFeatures).to.have.lengthOf(1);
+        expect(logger.info.calledWithMatch('1 campaign(s) already had the feature enabled')).to.be.true;
+      });
+
+      it('inserts a campaign-feature record and adds campaign id to the newly-enabled list', async function () {
+        // given
+        const campaign = databaseBuilder.factory.buildCampaign();
+        await databaseBuilder.commit();
+
+        // when
+        await script.handle({ options: { campaignIds: [campaign.id], dryRun: false }, logger });
+
+        // then
+        const campaignFeatures = await knex('campaign-features').where({ campaignId: campaign.id, featureId });
+        expect(campaignFeatures).to.have.lengthOf(1);
+        expect(campaignFeatures[0].params).to.deep.equal({});
+        expect(logger.info.calledWithMatch('1 campaign(s) newly enabled')).to.be.true;
+      });
+
+      it('handles all three cases in a single call', async function () {
+        // given
+        const existingCampaign = databaseBuilder.factory.buildCampaign();
+        databaseBuilder.factory.buildCampaignFeature({ campaignId: existingCampaign.id, featureId, params: {} });
+        const newCampaign = databaseBuilder.factory.buildCampaign();
+        await databaseBuilder.commit();
+
+        const inexistingId = 999999;
+
+        // when
+        await script.handle({
+          options: { campaignIds: [inexistingId, existingCampaign.id, newCampaign.id], dryRun: false },
+          logger,
+        });
+
+        // then
+        expect(logger.info.calledWithMatch('1 campaign(s) not found')).to.be.true;
+        expect(logger.info.calledWithMatch('1 campaign(s) already had the feature enabled')).to.be.true;
+        expect(logger.info.calledWithMatch('1 campaign(s) newly enabled')).to.be.true;
+
+        const newCampaignFeatures = await knex('campaign-features').where({ campaignId: newCampaign.id, featureId });
+        expect(newCampaignFeatures).to.have.lengthOf(1);
+      });
+    });
+
+    context('when dryRun is present', function () {
+      it('does not persist any database changes', async function () {
+        // given
+        const campaign = databaseBuilder.factory.buildCampaign();
+        await databaseBuilder.commit();
+
+        // when
+        await script.handle({ options: { campaignIds: [campaign.id], dryRun: true }, logger });
+
+        // then
+        const campaignFeatures = await knex('campaign-features').where({ campaignId: campaign.id, featureId });
+        expect(campaignFeatures).to.have.lengthOf(0);
+        expect(logger.info.calledWithMatch('1 campaign(s) newly enabled')).to.be.true;
+        expect(logger.info.calledWithMatch('ROLLBACK')).to.be.true;
+      });
+
+      it('logs that changes were not persisted and how to persist them', async function () {
+        // given
+        const campaign = databaseBuilder.factory.buildCampaign();
+        await databaseBuilder.commit();
+
+        // when
+        await script.handle({ options: { campaignIds: [campaign.id], dryRun: true }, logger });
+
+        // then
+        expect(logger.info.calledWithMatch('remove --dryRun to persist changes')).to.be.true;
+      });
+    });
+  });
+});


### PR DESCRIPTION
## 🌱 Problème
Une nouvelle feature `RECOMMENDATION_ENGINE` va être disponible pour les campagnes. Mais on souhaite pouvoir l'activer pour plusieurs campagnes.

## 🐣 Proposition
Ajouter un script qui active la feature `RECOMMENDATION_ENGINE` pour une liste de `campaignIds`

## 🌷 Remarques
La [PR](https://github.com/1024pix/pix/pull/15775) Doit être mergée avant  => Done

## 🐝 Pour tester
- faire un `npm run db:reset`

=> Lancer 2 fois le script en DRYRUN, depuis le dossier `/api`

`LOG_ENABLED=true node src/prescription/scripts/enable-recommendation-engine-feature-for-campaigns.js --campaignIds=1212,121221,442,5000,5001,1 --dryRun`

Sachant que seules les campagnes 1,5000 et 5001 existent, constater que les logs sont cohérents et affichent les mêmes résultats lors des 2 runs

=> Lancer le script 2 fois

`LOG_ENABLED=true node src/prescription/scripts/enable-recommendation-engine-feature-for-campaigns.js --campaignIds=1212,121221,442,5000,5001,1`.

Constater :
- Lors de la première execution, l'activation de la feature pour les campagnes 5000,5001,1
- Lors de la deuxième execution, aucune des campagnes n'est modifiée
