### PR TITLE
[FEATURE] Permettre un fallback au niveau des épreuves  (PIX-22277).

### DIFF
--- a/api/src/evaluation/domain/services/algorithm-methods/smart-random.js
+++ b/api/src/evaluation/domain/services/algorithm-methods/smart-random.js
@@ -1,3 +1,4 @@
+import { fallbackChallengeLocales } from '../../../../shared/domain/services/locale-service.js';
 import { STEPS_NAMES } from '../../models/SmartRandomStep.js';
 import { logStep } from '../smart-random-log-service.js';
 import { computeTubesFromSkills } from '../tube-service.js';
@@ -81,11 +82,13 @@ const findFirstChallenge = ({ knowledgeElements, targetSkills, tubes }) => {
   return { possibleSkillsForNextChallenge: availableSkills, levelEstimated: 2 };
 };
 
-const getSkillsWithAddedInformations = ({ targetSkills, filteredChallenges, locale }) =>
-  targetSkills.map((skill) => {
-    const challenges = filteredChallenges.filter(
-      (challenge) => challenge.skill.id === skill.id && challenge.locales.includes(locale),
-    );
+const getSkillsWithAddedInformations = ({ targetSkills, filteredChallenges, locale }) => {
+  const locales = fallbackChallengeLocales(locale);
+
+  return targetSkills.map((skill) => {
+    const challenges = filteredChallenges.filter((challenge) => {
+      return challenge.skill.id === skill.id && challenge.locales.some(locale => locales.includes(locale));
+    });
     const [firstChallenge] = challenges;
 
     skill.challenges = challenges;
@@ -94,6 +97,7 @@ const getSkillsWithAddedInformations = ({ targetSkills, filteredChallenges, loca
 
     return skill;
   });
+};
 
 const removeChallengesWithAnswer = ({ challenges, allAnswers }) => {
   const challengeIdsWithAnswer = allAnswers.map((answer) => answer.challengeId);

--- a/api/src/evaluation/domain/services/algorithm-methods/smart-random.js
+++ b/api/src/evaluation/domain/services/algorithm-methods/smart-random.js
@@ -87,7 +87,7 @@ const getSkillsWithAddedInformations = ({ targetSkills, filteredChallenges, loca
 
   return targetSkills.map((skill) => {
     const challenges = filteredChallenges.filter((challenge) => {
-      return challenge.skill.id === skill.id && challenge.locales.some(locale => locales.includes(locale));
+      return challenge.skill.id === skill.id && challenge.locales.some((locale) => locales.includes(locale));
     });
     const [firstChallenge] = challenges;
 

--- a/api/src/evaluation/domain/services/pick-challenge-service.js
+++ b/api/src/evaluation/domain/services/pick-challenge-service.js
@@ -1,5 +1,7 @@
 import hashInt from 'hash-int';
 
+import { fallbackChallengeLocales } from '../../../shared/domain/services/locale-service.js';
+
 const NON_EXISTING_ITEM = null;
 const VALIDATED_STATUS = 'validé';
 
@@ -17,14 +19,21 @@ const pickChallenge = ({ skills, randomSeed, locale }) => {
 export const pickChallengeService = { pickChallenge };
 
 const pickLocaleChallengeAtIndex = (challenges, locale, index) => {
-  const localeChallenges = challenges.filter((challenge) => challenge.locales.includes(locale));
-  const possibleChallenges = findPreferablyValidatedChallenges(localeChallenges);
+  const locales = fallbackChallengeLocales(locale);
+  const localeChallenges = challenges.filter((challenge) =>
+    challenge.locales.some((locale) => locales.includes(locale)),
+  );
+  const possibleChallenges = findPreferablyValidatedChallengesWithLocale(localeChallenges, locale);
   return possibleChallenges.length ? pickChallengeAtIndex(possibleChallenges, index) : null;
 };
 
 const pickChallengeAtIndex = (challenges, index) => challenges[index % challenges.length];
 
-const findPreferablyValidatedChallenges = (localeChallenges) => {
+const findPreferablyValidatedChallengesWithLocale = (localeChallenges, locale) => {
   const validatedChallenges = localeChallenges.filter((challenge) => challenge.status === VALIDATED_STATUS);
-  return validatedChallenges.length > 0 ? validatedChallenges : localeChallenges;
+  const preferablyValidatedChallenges = validatedChallenges.length > 0 ? validatedChallenges : localeChallenges;
+  const challengesWithGivenLocale = preferablyValidatedChallenges.filter((challenge) => {
+    challenge.locales.includes(locale);
+  });
+  return challengesWithGivenLocale.length > 0 ? challengesWithGivenLocale : preferablyValidatedChallenges;
 };

--- a/api/tests/evaluation/unit/domain/services/pick-challenge-service_test.js
+++ b/api/tests/evaluation/unit/domain/services/pick-challenge-service_test.js
@@ -24,8 +24,8 @@ describe('Unit | Service | PickChallengeService', function () {
       frenchSpokenChallenge = domainBuilder.buildChallenge({ locales: [FRENCH_SPOKEN] });
       otherFrenchSpokenChallenge = domainBuilder.buildChallenge({ locales: [FRENCH_SPOKEN] });
       frenchChallenge = domainBuilder.buildChallenge({ locales: [FRENCH_FRANCE] });
-      validatedChallenge = domainBuilder.buildChallenge({ status: 'validé' });
-      archivedChallenge = domainBuilder.buildChallenge({ status: 'archivé' });
+      validatedChallenge = domainBuilder.buildChallenge({ status: 'validé', locales: [FRENCH_SPOKEN] });
+      archivedChallenge = domainBuilder.buildChallenge({ status: 'archivé', locales: [FRENCH_SPOKEN] });
     });
 
     context('when challenge in selected locale exists', function () {
@@ -139,6 +139,64 @@ describe('Unit | Service | PickChallengeService', function () {
         expect(challenges).to.contains(challengeTwoForSkillOne);
         expect(challenges).to.contains(challengeOneForSkillTwo);
         expect(challenges).to.contains(challengeTwoForSkillTwo);
+      });
+    });
+
+    context('user locale has country code', function () {
+      let archivedChallenge_fr_fr, validatedChallenge_fr, validatedChallenge_fr_fr, locale;
+      beforeEach(function () {
+        validatedChallenge_fr = domainBuilder.buildChallenge({ status: 'validé', locales: [FRENCH_SPOKEN] });
+        validatedChallenge_fr_fr = domainBuilder.buildChallenge({ status: 'validé', locales: [FRENCH_FRANCE] });
+        archivedChallenge_fr_fr = domainBuilder.buildChallenge({ status: 'archivé', locales: [FRENCH_FRANCE] });
+        locale = FRENCH_FRANCE;
+      });
+
+      context('when there are many challenges with different locales', function () {
+        it('should prioritize challenge with an exact matching locale', function () {
+          // given
+          const skills = [{ challenges: [validatedChallenge_fr_fr, validatedChallenge_fr] }];
+
+          // when
+          const challenge = pickChallengeService.pickChallenge({
+            skills,
+            randomSeed,
+            locale,
+          });
+
+          // then
+          expect(challenge).to.equal(validatedChallenge_fr_fr);
+        });
+        it('should prioritize a validated challenge matching the language instead of an archived challenge with an exact matching locale', function () {
+          // given
+          const skills = [{ challenges: [archivedChallenge_fr_fr, validatedChallenge_fr] }];
+
+          // when
+          const challenge = pickChallengeService.pickChallenge({
+            skills,
+            randomSeed,
+            locale,
+          });
+
+          // then
+          expect(challenge).to.equal(validatedChallenge_fr);
+        });
+      });
+
+      context('when there are only challenges with locales without country code', function () {
+        it('should return challenge without country code', function () {
+          // given
+          const skills = [{ challenges: [validatedChallenge_fr] }];
+
+          // when
+          const challenge = pickChallengeService.pickChallenge({
+            skills,
+            randomSeed,
+            locale,
+          });
+
+          // then
+          expect(challenge).to.equal(validatedChallenge_fr);
+        });
       });
     });
   });

--- a/api/tests/evaluation/unit/domain/services/smart-random/smart-random_test.js
+++ b/api/tests/evaluation/unit/domain/services/smart-random/smart-random_test.js
@@ -771,5 +771,35 @@ describe('Integration | Domain | Algorithm-methods | SmartRandom', function () {
         expect(possibleSkillsForNextChallengeInEnglish[0].name).to.be.equal('@info2');
       });
     });
+
+    context('when user locale is `fr-fr`', function () {
+      beforeEach(function () {
+        locale = 'fr-fr';
+      });
+
+      it('should return fr-fr and fr challenges', function () {
+        targetSkills = [web1, cnil1];
+        const challengeCnil_1_fr_fr = domainBuilder.buildChallenge({
+          id: 'recweb1_2',
+          skill: cnil1,
+          locales: ['fr-fr'],
+        });
+        challenges = [challengeCnil_1_fr_fr, challengeWeb_1];
+
+        const { possibleSkillsForNextChallenge } = SmartRandom.getPossibleSkillsForNextChallenge({
+          targetSkills,
+          challenges,
+          knowledgeElements: [],
+          lastAnswer,
+          allAnswers,
+          locale,
+        });
+
+        // then
+        expect(possibleSkillsForNextChallenge.length).to.be.equal(2);
+        expect(possibleSkillsForNextChallenge[0].id).to.be.equal(web1.id);
+        expect(possibleSkillsForNextChallenge[1].id).to.be.equal(cnil1.id);
+      });
+    });
   });
 });

--- a/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-for-campaign-assessment_test.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-for-campaign-assessment_test.js
@@ -4,6 +4,7 @@ import {
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
+  generateInjectOptions,
   knex,
   learningContentBuilder,
   mockLearningContent,
@@ -41,19 +42,21 @@ const learningContent = [
               {
                 id: skillWeb2Id,
                 nom: '@web2',
-                challenges: [{ id: firstChallengeId, alpha: 2.8, delta: 1.1, langues: ['Franco Français'] }],
+                challenges: [{ id: firstChallengeId, langues: ['Franco Français'] }],
               },
               {
                 id: skillWeb3Id,
                 nom: '@web3',
-                challenges: [{ id: secondChallengeId, langues: ['Franco Français'], alpha: -1.2, delta: 3.3 }],
+                challenges: [{ id: secondChallengeId, langues: ['Franco Français'] }],
               },
               {
                 id: skillWeb1Id,
                 nom: '@web1',
                 challenges: [
-                  { id: thirdChallengeId, alpha: -0.2, delta: 2.7, langues: ['Franco Français'] },
-                  { id: otherChallengeId, alpha: -0.2, delta: -0.4, langues: ['Franco Français'] },
+                  { id: thirdChallengeId, langues: ['Franco Français'] },
+                  { id: otherChallengeId, langues: ['Franco Français'] },
+                  { id: 'germanATChallengeId', statut: 'archivé', langues: ['Germano Autrichien'] },
+                  { id: 'germanChallengeId_web1', langues: ['Allemand'] },
                 ],
               },
             ],
@@ -131,11 +134,35 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-campai
         expect(assessmentsInDb.lastQuestionDate).to.deep.equal(lastQuestionDate);
         expect(response.result.data.id).to.equal(assessmentId.toString());
         expect(response.result.data.relationships['next-challenge'].data.id).to.be.oneOf([
-          firstChallengeId,
-          secondChallengeId,
           thirdChallengeId,
           otherChallengeId,
         ]);
+      });
+
+      context('When user locale is de-AT', function () {
+        it('should return german validated challenge', async function () {
+          // given
+          const options = generateInjectOptions({
+            url: `/api/assessments/${assessmentId}`,
+            method: 'GET',
+            locale: 'de-AT',
+            audience: ' https://app.pix.org',
+            authorizationData: { userId: userId },
+            // headers: generateAuthenticatedUserRequestHeaders({ userId }),
+          });
+
+          const lastQuestionDate = new Date();
+
+          // when
+          const response = await server.inject(options);
+
+          // then
+
+          const assessmentsInDb = await knex('assessments').where('id', assessmentId).first('lastQuestionDate');
+          expect(assessmentsInDb.lastQuestionDate).to.deep.equal(lastQuestionDate);
+          expect(response.result.data.id).to.equal(assessmentId.toString());
+          expect(response.result.data.relationships['next-challenge'].data.id).to.be.equal('germanChallengeId_web1');
+        });
       });
     });
   });

--- a/api/tests/tooling/learning-content-builder/build-learning-content.js
+++ b/api/tests/tooling/learning-content-builder/build-learning-content.js
@@ -166,6 +166,12 @@ function _convertLanguesToLocales(langues) {
     if (langue === 'Anglais') {
       return ENGLISH_SPOKEN;
     }
+    if (langue === 'Germano Autrichien') {
+      return 'de-AT';
+    }
+    if (langue === 'Allemand') {
+      return 'de';
+    }
   });
 }
 


### PR DESCRIPTION
## 🌱 Problème

Nous voulons pouvoir jouer des épreuve de notre langue si nous ne trouvons pas d'épreuve dans notre locale dans le cadre d'une campagne.

## 🐣 Proposition

Permettre de jouer des épreuves de notre langue si nous ne trouvons pas d'épreuve dans notre locale  lors de la recherche des prochaines épreuves dans le cadre campagne.

## 🌷 Remarques

RAS

## 🐝 Pour tester

Créer une campagne avec des acquis ne possédant que des épreuves dans la langue et d'autre acquis ne possédant que des épreuve dans notre locale.
Jouer cette campagne et constater qu'on joue bien les épreuves provenant des deux type d'acquis.
