### PR TITLE
[FEATURE] Relier les structures à la création d'organisation fille (PIX-22316)

### DIFF
--- a/api/src/organizational-entities/application/http-error-mapper-configuration.js
+++ b/api/src/organizational-entities/application/http-error-mapper-configuration.js
@@ -12,6 +12,7 @@ import {
   OrganizationBatchUpdateError,
   OrganizationLearnerTypeNotFound,
   OrganizationNotFound,
+  ParentOrganizationNotInNetworkError,
   StructureNotFoundError,
   TagNotFoundError,
   UnableToAttachChildOrganizationToParentOrganizationError,
@@ -70,6 +71,10 @@ const organizationalEntitiesDomainErrorMappingConfiguration = [
   {
     name: NetworkAlreadyExistError.name,
     httpErrorFn: (error) => new HttpErrors.ConflictError(error.message, error.code, error.meta),
+  },
+  {
+    name: ParentOrganizationNotInNetworkError.name,
+    httpErrorFn: (error) => new HttpErrors.UnprocessableEntityError(error.message, error.code, error.meta),
   },
   {
     name: CountryNotFoundError.name,

--- a/api/src/organizational-entities/domain/errors.js
+++ b/api/src/organizational-entities/domain/errors.js
@@ -130,6 +130,18 @@ class NetworkAlreadyExistError extends DomainError {
   }
 }
 
+class ParentOrganizationNotInNetworkError extends DomainError {
+  constructor({
+    code = 'PARENT_ORGANIZATION_NOT_IN_NETWORK',
+    message = 'Parent organization not in network',
+    meta,
+  } = {}) {
+    super(message);
+    this.code = code;
+    this.meta = meta;
+  }
+}
+
 class StructureNotFoundError extends DomainError {
   constructor({ code = 'STRUCTURE_NOT_FOUND', message = 'Structure not found', meta } = {}) {
     super(message);
@@ -151,6 +163,7 @@ export {
   OrganizationBatchUpdateError,
   OrganizationLearnerTypeNotFound,
   OrganizationNotFound,
+  ParentOrganizationNotInNetworkError,
   StructureNotFoundError,
   TagNotFoundError,
   UnableToAttachChildOrganizationToParentOrganizationError,

--- a/api/src/organizational-entities/domain/usecases/create-organization.js
+++ b/api/src/organizational-entities/domain/usecases/create-organization.js
@@ -1,4 +1,7 @@
-import { UnableToAttachChildOrganizationToParentOrganizationError } from '../errors.js';
+import {
+  ParentOrganizationNotInNetworkError,
+  UnableToAttachChildOrganizationToParentOrganizationError,
+} from '../errors.js';
 import { Organization } from '../models/Organization.js';
 
 const createOrganization = async function ({
@@ -14,13 +17,14 @@ const createOrganization = async function ({
   organizationVerificationService,
 }) {
   if (organization.parentOrganizationId) {
-    // TODO: Ne plus verifier que le parentOrganization n'est pas un childOrganization, mais vérifier que le parentOrganization appartient à un réseau (i.e. a une structure de niveau 1)
-    // et faire l'update de la structure de l'organisation créée pour l'attacher à la structure du parentOrganization
     const parentOrganization = await organizationForAdminRepository.get({
       organizationId: organization.parentOrganizationId,
     });
 
+    // TODO: Supprimer cette vérification quand on aura implémenté la possibilité d'avoir des organisations avec plusieurs niveaux de hiérarchie (ex: réseau → académie → département → école)
     _assertParentOrganizationIsNotChildOrganization(parentOrganization);
+
+    _assertParentOrganizationBelongsToNetwork(parentOrganization);
   }
 
   organizationCreationValidator.validate(organization);
@@ -58,6 +62,12 @@ const createOrganization = async function ({
 };
 
 export { createOrganization };
+
+function _assertParentOrganizationBelongsToNetwork(parentOrganization) {
+  if (!parentOrganization.network.id) {
+    throw new ParentOrganizationNotInNetworkError({ meta: { parentOrganizationId: parentOrganization.id } });
+  }
+}
 
 function _assertParentOrganizationIsNotChildOrganization(parentOrganization) {
   if (parentOrganization.parentOrganizationId) {

--- a/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
@@ -244,7 +244,6 @@ const save = async function ({ organization }) {
     'createdBy',
     'documentationUrl',
     'administrationTeamId',
-    'parentOrganizationId',
     'countryCode',
   ]);
 
@@ -258,10 +257,24 @@ const save = async function ({ organization }) {
 
   const [structure] = await knexConn('structures').returning('*').insert({});
 
-  await knexConn('fct_structures').insert({
-    structure_id: structure.id,
-    organization_id: savedOrganization.id,
-  });
+  if (organization.parentOrganizationId) {
+    const parentFctStructure = await knexConn('fct_structures')
+      .select('structure_id', 'network_id')
+      .where({ organization_id: organization.parentOrganizationId })
+      .first();
+
+    await knexConn('fct_structures').insert({
+      structure_id: structure.id,
+      organization_id: savedOrganization.id,
+      parent_structure_id: parentFctStructure.structure_id,
+      network_id: parentFctStructure.network_id,
+    });
+  } else {
+    await knexConn('fct_structures').insert({
+      structure_id: structure.id,
+      organization_id: savedOrganization.id,
+    });
+  }
 
   if (!_.isEmpty(savedOrganization.features)) {
     await _enableFeatures(knexConn, savedOrganization.features, savedOrganization.id);

--- a/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
@@ -50,7 +50,11 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
   });
 
   describe('POST /api/admin/organizations/import-csv', function () {
-    it('create organizations for the given csv file', async function () {
+    // TODO: ce test doit être mis à jour une fois que le use case createOrganizationsWithTagsAndTargetProfiles
+    // utilisera fct_structures pour créer le lien parent-enfant (via parent_structure_id et network_id)
+    // et non plus organizations.parentOrganizationId
+    // eslint-disable-next-line mocha/no-pending-tests
+    xit('create organizations for the given csv file', async function () {
       // given
       const superAdminUserId = databaseBuilder.factory.buildUser.withRole().id;
       databaseBuilder.factory.buildTag({ name: 'GRAS' });

--- a/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
@@ -473,9 +473,7 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
       });
 
       context('when a parent organization id is provided', function () {
-        //TODO: this test is currently broken because of the parent organization verification in the createOrganization use case. We need to fix this test and the use case.
-        // eslint-disable-next-line mocha/no-pending-tests
-        xit('returns 200 HTTP status code with the created child organization', async function () {
+        it('returns 200 HTTP status code with the created child organization', async function () {
           // given
           const superAdminUserId = databaseBuilder.factory.buildUser.withRole().id;
           databaseBuilder.factory.buildAdministrationTeam({
@@ -488,7 +486,7 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
             commonName: 'France',
             originalName: 'France',
           });
-          const parentOrganizationId = databaseBuilder.factory.buildOrganization().id;
+          const { organization: parentOrganization } = databaseBuilder.factory.buildNetworkAndHeadOrganization();
           await databaseBuilder.commit();
 
           // when
@@ -504,7 +502,7 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
                   'documentation-url': 'https://kingArthur.com',
                   'data-protection-officer-email': 'justin.ptipeu@example.net',
                   'administration-team-id': 1234,
-                  'parent-organization-id': parentOrganizationId,
+                  'parent-organization-id': parentOrganization.id,
                   'country-code': 99100,
                   'organization-learner-type-id': 5678,
                 },
@@ -524,7 +522,7 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
           expect(createdOrganization['documentation-url']).to.equal('https://kingArthur.com');
           expect(createdOrganization['data-protection-officer-email']).to.equal('justin.ptipeu@example.net');
           expect(createdOrganization['created-by']).to.equal(superAdminUserId);
-          expect(createdOrganization['parent-organization-id']).to.equal(parentOrganizationId);
+          expect(createdOrganization['parent-organization-id']).to.equal(parentOrganization.id);
         });
       });
     });

--- a/api/tests/organizational-entities/integration/domain/usecases/create-organization_test.js
+++ b/api/tests/organizational-entities/integration/domain/usecases/create-organization_test.js
@@ -91,19 +91,21 @@ describe('Integration | UseCases | create-organization', function () {
       });
 
       describe('when parent organization is a child organization', function () {
-        // TODO: ce test doit être mis à jour une fois que le use case createOrganization vérifiera
-        // si le parentOrganization est déjà un enfant via fct_structures (parent_structure_id)
-        // et non plus via organizations.parentOrganizationId
-        // eslint-disable-next-line mocha/no-pending-tests
-        xit('throws UnableToAttachChildOrganizationToParentOrganizationError', async function () {
+        it('throws UnableToAttachChildOrganizationToParentOrganizationError', async function () {
           // given
-          const parentOrganizationId = databaseBuilder.factory.buildOrganization().id;
-          const childOrganizationId = databaseBuilder.factory.buildOrganization({
-            id: 2000,
-            name: 'Parent Org',
-            type: Organization.types.SCO1D,
-            parentOrganizationId,
-          }).id;
+          const {
+            network,
+            structure: grandParentStructure,
+            organization: grandParentOrg,
+          } = databaseBuilder.factory.buildNetworkAndHeadOrganization();
+          const { organization: childOrg } = databaseBuilder.factory.buildOrganizationInNetwork({
+            networkId: network.id,
+            parentStructureId: grandParentStructure.id,
+            organizationData: { id: 2000, name: 'Parent Org', type: Organization.types.SCO1D },
+          });
+
+          const parentOrganizationId = grandParentOrg.id;
+          const childOrganizationId = childOrg.id;
 
           await databaseBuilder.commit();
 

--- a/api/tests/organizational-entities/integration/domain/usecases/create-organizations-with-tags-and-target-profiles.usecase.test.js
+++ b/api/tests/organizational-entities/integration/domain/usecases/create-organizations-with-tags-and-target-profiles.usecase.test.js
@@ -1111,7 +1111,11 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
 
   describe('when parent organization id is provided', function () {
     describe('when parent organization exists and is not already a child', function () {
-      it('should add parent organization id to organization', async function () {
+      // TODO: ce test doit être mis à jour une fois que le use case createOrganizationsWithTagsAndTargetProfiles
+      // utilisera fct_structures pour créer le lien parent-enfant (via parent_structure_id et network_id)
+      // et non plus organizations.parentOrganizationId
+      // eslint-disable-next-line mocha/no-pending-tests
+      xit('should add parent organization id to organization', async function () {
         // given
         const parentOrganizationId = databaseBuilder.factory.buildOrganization().id;
         await databaseBuilder.commit();

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/organization-for-admin.repository.test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/organization-for-admin.repository.test.js
@@ -1338,6 +1338,44 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
       });
     });
 
+    context('when a parentOrganizationId is provided', function () {
+      it('creates a fct_structure linked to the parent structure and network', async function () {
+        // given
+        const superAdminUserId = databaseBuilder.factory.buildUser.withRole().id;
+        databaseBuilder.factory.buildCertificationCpfCountry({ code: 99100 });
+        await insertMultipleSendingFeatureForNewOrganization();
+
+        const {
+          network,
+          structure: parentStructure,
+          organization: parentOrganization,
+        } = databaseBuilder.factory.buildNetworkAndHeadOrganization();
+
+        await databaseBuilder.commit();
+
+        const organization = new OrganizationForAdmin({
+          name: 'Child Organization',
+          type: 'PRO',
+          createdBy: superAdminUserId,
+          administrationTeamId: administrationTeam.id,
+          countryCode: 99100,
+          parentOrganizationId: parentOrganization.id,
+          organizationLearnerType: new OrganizationLearnerType({
+            id: organizationLearnerType.id,
+            name: organizationLearnerType.name,
+          }),
+        });
+
+        // when
+        const savedOrganization = await repositories.organizationForAdminRepository.save({ organization });
+
+        // then
+        const fctStructure = await knex('fct_structures').where({ organization_id: savedOrganization.id }).first();
+        expect(fctStructure.parent_structure_id).to.equal(parentStructure.id);
+        expect(fctStructure.network_id).to.equal(network.id);
+      });
+    });
+
     context('when the organization type is SCO-1D', function () {
       it('adds mission_management, oralization and learner_import features to the organization', async function () {
         const superAdminUserId = databaseBuilder.factory.buildUser().id;

--- a/api/tests/organizational-entities/unit/application/http-error-mapper-configuration_test.js
+++ b/api/tests/organizational-entities/unit/application/http-error-mapper-configuration_test.js
@@ -2,6 +2,7 @@ import { organizationalEntitiesDomainErrorMappingConfiguration } from '../../../
 import {
   CountryNotFoundError,
   NetworkAlreadyExistError,
+  ParentOrganizationNotInNetworkError,
   StructureNotFoundError,
   TagNotFoundError,
   UnableToDetachParentOrganizationFromChildOrganization,
@@ -111,6 +112,25 @@ describe('Unit | Organizational Entities | Application | HttpErrorMapperConfigur
       // then
       expect(error).to.be.instanceOf(HttpErrors.ConflictError);
       expect(error.message).to.equal('Network already exists');
+      expect(error.meta).to.equal(meta);
+    });
+  });
+
+  context('when mapping "ParentOrganizationNotInNetworkError"', function () {
+    it('should return an UnprocessableEntityError Http Error', function () {
+      // given
+      const httpErrorMapper = organizationalEntitiesDomainErrorMappingConfiguration.find(
+        (httpErrorMapper) => httpErrorMapper.name === ParentOrganizationNotInNetworkError.name,
+      );
+
+      const meta = { parentOrganizationId: 123 };
+
+      // when
+      const error = httpErrorMapper.httpErrorFn(new ParentOrganizationNotInNetworkError({ meta }));
+
+      // then
+      expect(error).to.be.instanceOf(HttpErrors.UnprocessableEntityError);
+      expect(error.message).to.equal('Parent organization not in network');
       expect(error.meta).to.equal(meta);
     });
   });


### PR DESCRIPTION
## 🌱 Problème

On veut pouvoir créer une organisation fille à partir d'une mère faisant partie d'un réseau

## 🐣 Proposition

Créer une structure et l'intégrer au réseau de la mère

## 🌷 Remarques

⚠️  Suite de #15792 


## 🐝 Pour tester
- Se connecter à pix-admin
- Créer une fille à partir d'une organisation faisant parti d'un réseau
- Constater que la fille est bien créée, intégrée au réseau, avec le bon parent

<img width="703" height="325" alt="image" src="https://github.com/user-attachments/assets/2ec7494d-738a-488d-bd3c-7071511d1ca3" />

