### PR TITLE
[FEATURE] Permettre à l'équipe métier de re-scorer une certification tant qu'elle n'est ni publiée ni dans une session non finalisée (PIX-22292)

### DIFF
--- a/admin/app/components/certifications/certification/informations/global-actions.gjs
+++ b/admin/app/components/certifications/certification/informations/global-actions.gjs
@@ -50,7 +50,7 @@ export default class CertificationInformationGlobalActions extends Component {
   }
 
   get displayRescoringCertificationButton() {
-    return this.canPerformCertificationActions;
+    return Boolean(!this.args.certification.isPublished && this.args.session.finalizedAt);
   }
 
   @action

--- a/admin/tests/integration/components/certifications/certification/informations/global-actions-test.gjs
+++ b/admin/tests/integration/components/certifications/certification/informations/global-actions-test.gjs
@@ -817,7 +817,7 @@ module('Integration | Component | Certifications | Certification | Information |
         });
       });
       module('when certification has no status, session is finalized and not published', function () {
-        test('should display a cancel button', async function (assert) {
+        test('should display a rescore button', async function (assert) {
           // given
           const certification = store.createRecord('certification', {
             userId: 1,
@@ -835,11 +835,9 @@ module('Integration | Component | Certifications | Certification | Information |
             .exists();
         });
       });
-    });
 
-    module('when should not display', function () {
       module('when certification status is cancelled', function () {
-        test('should not display a rescoring button', async function (assert) {
+        test('should display a rescoring button', async function (assert) {
           // given
           const certification = store.createRecord('certification', {
             userId: 1,
@@ -854,12 +852,12 @@ module('Integration | Component | Certifications | Certification | Information |
           // then
           assert
             .dom(screen.queryByRole('button', { name: t('components.certifications.global-actions.rescoring.button') }))
-            .doesNotExist();
+            .exists();
         });
       });
 
       module('when certification status is rejected', function () {
-        test('should not display a rescoring button', async function (assert) {
+        test('should display a rescoring button', async function (assert) {
           // given
           const certification = store.createRecord('certification', {
             userId: 1,
@@ -874,10 +872,12 @@ module('Integration | Component | Certifications | Certification | Information |
           // then
           assert
             .dom(screen.queryByRole('button', { name: t('components.certifications.global-actions.rescoring.button') }))
-            .doesNotExist();
+            .exists();
         });
       });
+    });
 
+    module('when should not display', function () {
       module('when session is not finalized', function () {
         test('should not display a rescoring button', async function (assert) {
           // given

--- a/api/src/certification/evaluation/application/certification-rescoring-controller.js
+++ b/api/src/certification/evaluation/application/certification-rescoring-controller.js
@@ -14,15 +14,6 @@ const rescoreCertification = async function (
   const certificationCourseId = request.params.certificationCourseId;
 
   const certificationCourse = await dependencies.certificationCourseRepository.get({ id: certificationCourseId });
-
-  const latestAssessmentResult = await dependencies.courseAssessmentResultRepository.getLatestAssessmentResult({
-    certificationCourseId,
-  });
-
-  if (_isAssessmentResultNotRescorable(latestAssessmentResult)) {
-    throw new CertificationRescoringNotAllowedError();
-  }
-
   if (AlgorithmEngineVersion.isV3(certificationCourse.getVersion())) {
     await usecases.scoreV3Certification({
       certificationCourseId,
@@ -31,6 +22,13 @@ const rescoreCertification = async function (
   }
 
   if (AlgorithmEngineVersion.isV2(certificationCourse.getVersion())) {
+    const latestAssessmentResult = await dependencies.courseAssessmentResultRepository.getLatestAssessmentResult({
+      certificationCourseId,
+    });
+
+    if (_isAssessmentResultNotRescorable(latestAssessmentResult)) {
+      throw new CertificationRescoringNotAllowedError();
+    }
     await usecases.rescoreV2Certification({
       event: new CertificationRescored({ certificationCourseId, juryId }),
     });


### PR DESCRIPTION
## 🌱 Problème

Selon le statut des certifications, certaines actions sont possibles de la part du jury Pix dans Pix Admin annuler manuellement la certification, rejeter manuellement une certification ou encore re-scorer la certification.

Dans certains cas, l’affichage de ces boutons d’actions ne fait pas sens d’un point de vue métier. Exemple : le bouton d’annulation ou de rejet manuel pour une certification déjà rejetée ou annulée automatiquement pour nombre de réponses insuffisante pour certifier le candidat

Le bouton de rescoring est actuellement soumis aux mêmes restrictions (il ne s’affiche que pour les certifications validées ou en erreur) alors qu’on peut avoir besoin de re-scorer une certification quelque soit son statut (même rejetée ou annulée automatiquement) dans plusieurs cas : bug, modification des mailles, ou toute autre raison.

## 🐣 Proposition

Faire apparaître le bouton de rescoring sur la page de détail d’une certification dans Pix Admin dès que la session à laquelle elle appartient est finalisée et tant que celle-ci n’est pas publiée

## 🌷 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🐝 Pour tester

