### PR TITLE
[TECH] Utilise un exécuteur sans infra pour les tests unitaires de la CI.

### DIFF
--- a/.circleci/jobs.yml
+++ b/.circleci/jobs.yml
@@ -563,7 +563,7 @@ jobs:
 
   api_unit_test:
     executor:
-      name: node-redis-postgres-s3-docker
+      name: node-docker
     working_directory: ~/pix/api
     steps:
       - run:
@@ -579,10 +579,6 @@ jobs:
           command: npm run test:api:unit
           environment:
             NODE_ENV: test
-            TEST_DATABASE_URL: postgres://circleci@localhost:5432/circleci
-            TEST_REDIS_URL: redis://localhost:6379
-            TEST_IMPORT_STORAGE_ENDPOINT: http://localhost:9090
-            TEST_IMPORT_STORAGE_BUCKET_NAME: pix-import-test
             MOCHA_FILE: /home/circleci/test-results/test-results.[hash].xml
             MOCHA_REPORTER: mocha-junit-reporter
           when: always


### PR DESCRIPTION
## 🌱 Problème

Les tests unitaires ne dépendent d'aucune autre infrastructure mais on utilise un exécuteur contenant Redis, S3 et Postgresql sur la CI.
Cela utilise plus de temps alors qu'on n'en a pas besoin.

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

## 🐣 Proposition

Utiliser le `node_executor` et supprimer les variables d'environnement inutiles.

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 🌷 Remarques

RAS

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🐝 Pour tester

Le job de test unitaire doit être vert sur la CI.

<!--
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc.
- [ ] Documentation de la fonctionnalité (lien)
-->
