### PR TITLE
[FEATURE] Afficher les labels d'attestation dans les fronts de Pix Admin et Pix Orga (PIX-22281)

### DIFF
--- a/admin/app/components/combined-course-blueprints/details.gjs
+++ b/admin/app/components/combined-course-blueprints/details.gjs
@@ -62,7 +62,7 @@ export default class Details extends Component {
               <DescriptionList.Divider />
 
               <DescriptionList.Item @label={{t "components.combined-course-blueprints.labels.attestation"}}>
-                <SafeMarkdownToHtml @markdown={{@model.attestationKey}} />
+                <SafeMarkdownToHtml @markdown={{@model.attestationLabel}} />
               </DescriptionList.Item>
 
               {{#if @model.description}}

--- a/admin/app/components/combined-course-blueprints/select-attestation.gjs
+++ b/admin/app/components/combined-course-blueprints/select-attestation.gjs
@@ -4,7 +4,7 @@ import { t } from 'ember-intl';
 
 export default class SelectAttestation extends Component {
   get attestationsOptions() {
-    return this.args.attestations?.map((attestation) => ({ value: attestation.key, label: attestation.key })) ?? [];
+    return this.args.attestations?.map((attestation) => ({ value: attestation.key, label: attestation.label })) ?? [];
   }
 
   <template>

--- a/admin/app/components/organizations/features-section.gjs
+++ b/admin/app/components/organizations/features-section.gjs
@@ -56,9 +56,7 @@ export default class OrganizationFeaturesSection extends Component {
   get attestationOptions() {
     return this.attestations.map((attestation) => ({
       value: attestation.key,
-      label: this.intl.t(
-        `components.organizations.information-section-view.features.attestation-list.${attestation.key}`,
-      ),
+      label: attestation.label,
     }));
   }
 

--- a/admin/app/models/attestation.js
+++ b/admin/app/models/attestation.js
@@ -4,4 +4,5 @@ export default class Attestation extends Model {
   @attr('string') templateName;
   @attr('string') key;
   @attr() file;
+  @attr('string') label;
 }

--- a/admin/app/models/combined-course-blueprint.js
+++ b/admin/app/models/combined-course-blueprint.js
@@ -5,7 +5,7 @@ export default class CombinedCourseBlueprint extends Model {
   @attr('string') internalName;
   @attr('string') illustration;
   @attr('string') description;
-  @attr('string') attestationKey;
+  @attr('string') attestationLabel;
   @attr({ type: 'date', defaultValue: () => undefined }) createdAt;
   @attr({ defaultValue: () => [] }) content;
 }

--- a/admin/tests/integration/components/combined-course-blueprints/details-test.gjs
+++ b/admin/tests/integration/components/combined-course-blueprints/details-test.gjs
@@ -21,7 +21,7 @@ module('Integration | Component | CombinedCourseBlueprints::Details', function (
       name: 'Parcours apprenant',
       description: 'Mon super parcours apprenant',
       illustration: 'http://pix.fr/mon-illu.png',
-      attestationKey: 'SIXTH_GRADE',
+      attestationLabel: '6ème',
       content: [
         { type: 'module', value: 'abc-123' },
         { type: 'evaluation', value: 123 },
@@ -36,7 +36,7 @@ module('Integration | Component | CombinedCourseBlueprints::Details', function (
     assert.ok(screen.getByRole('heading', { name: 'Modèle de parcours apprenant' }));
     assert.ok(screen.getByText('Parcours apprenant'));
     assert.ok(screen.getByText('25/12/2025'));
-    assert.ok(screen.getByText('SIXTH_GRADE'));
+    assert.ok(screen.getByText('6ème'));
     assert.ok(screen.getByText('Mon super parcours apprenant'));
     assert.ok(screen.getByText('Module - abc-123', { exact: false }));
     assert.ok(screen.getByText('Profil cible - 123', { exact: false }));

--- a/admin/tests/integration/components/combined-course-blueprints/form-test.gjs
+++ b/admin/tests/integration/components/combined-course-blueprints/form-test.gjs
@@ -27,7 +27,10 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
 
     sinon.stub(store, 'createRecord').withArgs('combined-course-blueprint').returns(blueprintStub);
     const findRecordStub = sinon.stub(store, 'findRecord');
-    const attestations = [{ key: 'PARENTHOOD' }, { key: 'SIXTH_GRADE' }];
+    const attestations = [
+      { key: 'PARENTHOOD', label: 'Parentalite' },
+      { key: 'SIXTH_GRADE', label: '6eme' },
+    ];
     findRecordStub.withArgs('module', 'module-123').resolves({ title: 'module 123' });
     findRecordStub.withArgs('target-profile', '1').resolves({ internalName: 'super pc' });
 
@@ -64,7 +67,7 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
 
     await screen.findByRole('listbox');
 
-    await click(screen.getByRole('option', { name: 'PARENTHOOD' }));
+    await click(screen.getByRole('option', { name: 'Parentalite' }));
 
     await click(screen.getByRole('button', { name: t('components.combined-course-blueprints.create.createButton') }));
 

--- a/admin/tests/integration/components/combined-course-blueprints/select-attestation-test.gjs
+++ b/admin/tests/integration/components/combined-course-blueprints/select-attestation-test.gjs
@@ -10,20 +10,27 @@ module('Integration | Component | CombinedCourseBlueprints::SelectAttestation', 
   setupIntlRenderingTest(hooks);
 
   test('it should display every attestation available in select options', async function (assert) {
-    const attestations = [{ key: 'KEY_1' }, { key: 'KEY_2' }];
+    const attestations = [
+      { key: 'KEY_1', label: 'Attestation 1' },
+      { key: 'KEY_2', label: 'Attestation 2' },
+    ];
+
     const screen = await render(<template><SelectAttestation @attestations={{attestations}} /></template>);
     await click(
       screen.getByRole('button', { name: t('components.combined-course-blueprints.attestation.select-label') }),
     );
     await screen.findByRole('listbox');
 
-    assert.ok(screen.getByRole('option', { name: 'KEY_1' }));
-    assert.ok(screen.getByRole('option', { name: 'KEY_2' }));
+    assert.ok(screen.getByRole('option', { name: 'Attestation 1' }));
+    assert.ok(screen.getByRole('option', { name: 'Attestation 2' }));
   });
 
   test('it should select an attestation', async function (assert) {
     const onChangeStub = sinon.stub();
-    const attestations = [{ key: 'KEY_1' }, { key: 'KEY_2' }];
+    const attestations = [
+      { key: 'KEY_1', label: 'Attestation 1' },
+      { key: 'KEY_2', label: 'Attestation 2' },
+    ];
     const screen = await render(
       <template><SelectAttestation @attestations={{attestations}} @onChange={{onChangeStub}} /></template>,
     );
@@ -32,7 +39,7 @@ module('Integration | Component | CombinedCourseBlueprints::SelectAttestation', 
     );
     await screen.findByRole('listbox');
 
-    await click(screen.getByRole('option', { name: 'KEY_1' }));
+    await click(screen.getByRole('option', { name: 'Attestation 1' }));
 
     assert.ok(onChangeStub.calledWithExactly('KEY_1'));
   });

--- a/admin/tests/integration/components/organizations/features-section-test.gjs
+++ b/admin/tests/integration/components/organizations/features-section-test.gjs
@@ -27,8 +27,8 @@ module('Integration | Component | organizations/features-section', function (hoo
     findAllStub
       .withArgs('attestation')
       .resolves([
-        store.createRecord('attestation', { id: '1', key: 'PARENTHOOD' }),
-        store.createRecord('attestation', { id: '2', key: 'SIXTH_GRADE' }),
+        store.createRecord('attestation', { id: '1', key: 'PARENTHOOD', label: 'Parentalité' }),
+        store.createRecord('attestation', { id: '2', key: 'SIXTH_GRADE', label: '6ème' }),
       ]);
 
     class AccessControlStub extends Service {
@@ -339,6 +339,31 @@ module('Integration | Component | organizations/features-section', function (hoo
           }),
         )
         .exists();
+    });
+
+    test('it displays attestation labels after clicking on PixMultiSelect', async function (assert) {
+      // given
+      const onSubmit = onSubmitStub;
+      const organization = EmberObject.create({
+        features: { ATTESTATIONS_MANAGEMENT: { active: true, params: ['PARENTHOOD'] } },
+      });
+
+      // when
+      const screen = await render(
+        <template><FeaturesSection @organization={{organization}} @onSubmit={{onSubmit}} /></template>,
+      );
+
+      await click(
+        screen.getByRole('button', {
+          name: new RegExp(t('components.organizations.editing.attestations.selector.label')),
+        }),
+      );
+
+      await screen.findAllByRole('menuitem');
+
+      //then
+      assert.ok(screen.getByRole('menuitem', { name: 'Parentalité' }));
+      assert.ok(screen.getByRole('menuitem', { name: '6ème' }));
     });
 
     test('it disables the PixMultiSelect when user has no access', async function (assert) {

--- a/admin/tests/unit/serializers/combined-course-blueprint-test.js
+++ b/admin/tests/unit/serializers/combined-course-blueprint-test.js
@@ -16,7 +16,7 @@ module('Unit | Serializer | combined-course-blueprint', function (hooks) {
           label: 'Profil cilble 1',
         },
       ],
-      attestationKey: 'attestationKey',
+      attestationLabel: 'Label attestation',
     });
 
     const serializedRecord = record.serialize();
@@ -37,7 +37,7 @@ module('Unit | Serializer | combined-course-blueprint', function (hooks) {
                 value: 1,
               },
             ],
-            'attestation-key': 'attestationKey',
+            'attestation-label': 'Label attestation',
           },
         },
       },

--- a/api/db/database-builder/factory/build-attestation.js
+++ b/api/db/database-builder/factory/build-attestation.js
@@ -7,12 +7,14 @@ const buildAttestation = function ({
   createdAt = new Date(),
   templateName = '6eme-pdf',
   key = ATTESTATIONS.SIXTH_GRADE,
+  label = '6ème',
 } = {}) {
   const values = {
     id,
     createdAt,
     templateName,
     key,
+    label,
   };
 
   return databaseBuffer.pushInsertable({

--- a/api/db/seeds/data/team-prescription/build-quests.js
+++ b/api/db/seeds/data/team-prescription/build-quests.js
@@ -33,6 +33,7 @@ async function buildParenthoodQuest(databaseBuilder) {
   const { id: rewardId } = databaseBuilder.factory.buildAttestation({
     templateName: 'parenthood-attestation-template',
     key: ATTESTATIONS.PARENTHOOD,
+    label: 'Parentalité',
   });
 
   const cappedTubes = await knex('target-profile_tubes')
@@ -414,6 +415,7 @@ export const buildQuests = async (databaseBuilder) => {
   const { id: rewardId } = databaseBuilder.factory.buildAttestation({
     templateName: 'sixth-grade-attestation-template',
     key: ATTESTATIONS.SIXTH_GRADE,
+    label: '6ème',
   });
 
   // Create quests
@@ -464,21 +466,45 @@ export const buildQuests = async (databaseBuilder) => {
   });
 
   const attestationsData = [
-    { templateName: 'edu-incontournables-attestation-template', key: 'EDUINCONTOURNABLES' },
-    { templateName: 'edu-documents-attestation-template', key: 'EDUDOC' },
-    { templateName: 'edu-veille-attestation-template', key: 'EDUVEILLE' },
-    { templateName: 'edu-culture-numerique-attestation-template', key: 'EDUCULTURENUM' },
-    { templateName: 'edu-ressources-attestation-template', key: 'EDURESSOURCES' },
-    { templateName: 'edu-supports-attestation-template', key: 'EDUSUPPORT' },
-    { templateName: 'edu-securite-attestation-template', key: 'EDUSECU' },
-    { templateName: 'edu-collaborer-attestation-template', key: 'EDUCOLLAB' },
-    { templateName: 'edu-ia-attestation-template', key: 'EDUIA' },
-    { templateName: 'minarm-attestation-template', key: 'MINARM' },
-    { templateName: 'mdp-bureautique-attestation-template', key: 'MAIRIEBUREAU' },
+    {
+      templateName: 'edu-incontournables-attestation-template',
+      key: 'EDUINCONTOURNABLES',
+      label: 'Pix+Edu - Les incontournables',
+    },
+    { templateName: 'edu-documents-attestation-template', key: 'EDUDOC', label: 'Pix+Edu - Adapter les documents' },
+    { templateName: 'edu-veille-attestation-template', key: 'EDUVEILLE', label: 'Pix+Edu - Réaliser une veille' },
+    {
+      templateName: 'edu-culture-numerique-attestation-template',
+      key: 'EDUCULTURENUM',
+      label: 'Pix+Edu - Culture numérique',
+    },
+    {
+      templateName: 'edu-ressources-attestation-template',
+      key: 'EDURESSOURCES',
+      label: 'Pix+Edu - Gestion et partage de ressources',
+    },
+    {
+      templateName: 'edu-supports-attestation-template',
+      key: 'EDUSUPPORT',
+      label: 'Pix+Edu - Créer des supports pédagogiques',
+    },
+    { templateName: 'edu-securite-attestation-template', key: 'EDUSECU', label: 'Pix+Edu - Numérique et sécurité' },
+    {
+      templateName: 'edu-collaborer-attestation-template',
+      key: 'EDUCOLLAB',
+      label: 'Pix+Edu - Communiquer collaborer',
+    },
+    { templateName: 'edu-ia-attestation-template', key: 'EDUIA', label: 'Pix+Edu - Données, algorithmes et IA' },
+    { templateName: 'minarm-attestation-template', key: 'MINARM', label: 'Socle numérique' },
+    {
+      templateName: 'mdp-bureautique-attestation-template',
+      key: 'MAIRIEBUREAU',
+      label: 'Mairie de Paris - Fondamentaux bureautiques',
+    },
   ];
 
-  const educationAttestations = attestationsData.map(({ templateName, key }) =>
-    databaseBuilder.factory.buildAttestation({ templateName, key }),
+  const educationAttestations = attestationsData.map(({ templateName, key, label }) =>
+    databaseBuilder.factory.buildAttestation({ templateName, key, label }),
   );
 
   // Create user with all available attestations

--- a/api/src/profile/domain/models/Attestation.js
+++ b/api/src/profile/domain/models/Attestation.js
@@ -1,8 +1,9 @@
 export class Attestation {
-  constructor({ id, templateName, key, createdAt } = {}) {
+  constructor({ id, templateName, key, createdAt, label } = {}) {
     this.id = id;
     this.templateName = templateName;
     this.key = key;
     this.createdAt = createdAt;
+    this.label = label;
   }
 }

--- a/api/src/profile/infrastructure/serializers/jsonapi/attestation-serializer.js
+++ b/api/src/profile/infrastructure/serializers/jsonapi/attestation-serializer.js
@@ -4,7 +4,7 @@ const { Serializer } = jsonapiSerializer;
 
 const serialize = function (attestations) {
   return new Serializer('attestation', {
-    attributes: ['key'],
+    attributes: ['key', 'label'],
   }).serialize(attestations);
 };
 

--- a/api/src/quest/application/attestation-controller.js
+++ b/api/src/quest/application/attestation-controller.js
@@ -1,5 +1,6 @@
 import { Readable } from 'node:stream';
 
+import * as attestationSerializer from '../../profile/infrastructure/serializers/jsonapi/attestation-serializer.js';
 import { BadRequestError } from '../../shared/application/http-errors.js';
 import { usecases } from '../domain/usecases/index.js';
 
@@ -16,10 +17,17 @@ const save = async (request, h) => {
     templateFile,
     templateKey: attestation.templateKey,
     templateName: attestation.templateName,
+    label: attestation.label,
   });
   return h.response().code(204);
 };
 
-const attestationController = { save };
+const findAllByOrganizationId = async (request, _, dependencies = { attestationSerializer }) => {
+  const organizationId = request.params['organizationId'];
+  const attestations = await usecases.findOrganizationAttestations({ organizationId });
+  return dependencies.attestationSerializer.serialize(attestations);
+};
+
+const attestationController = { save, findAllByOrganizationId };
 
 export { attestationController };

--- a/api/src/quest/application/attestation-route.js
+++ b/api/src/quest/application/attestation-route.js
@@ -1,6 +1,7 @@
 import Joi from 'joi';
 
 import { securityPreHandlers } from '../../shared/application/security-pre-handlers.js';
+import { ORGANIZATION_FEATURE } from '../../shared/domain/constants.js';
 import { attestationController } from './attestation-controller.js';
 
 const MAX_FILE_SIZE_UPLOAD = 1048576 * 1; // 1Mb
@@ -28,6 +29,7 @@ const register = async function (server) {
             templateKey: Joi.string().required(),
             templateName: Joi.string().required(),
             templateFile: Joi.any().required(),
+            label: Joi.string().required(),
           }).required(),
         },
         payload: {
@@ -39,6 +41,30 @@ const register = async function (server) {
         handler: attestationController.save,
         notes: ["- Creation d'une attestation"],
         tags: ['api', 'attestation'],
+      },
+    },
+    {
+      method: 'GET',
+      path: '/api/organizations/{organizationId}/attestations',
+      config: {
+        pre: [
+          {
+            method: securityPreHandlers.checkUserBelongsToOrganization,
+            assign: 'checkUserBelongsToOrganization',
+          },
+          {
+            method: securityPreHandlers.makeCheckOrganizationHasFeature(
+              ORGANIZATION_FEATURE.ATTESTATIONS_MANAGEMENT.key,
+            ),
+            assign: 'makeCheckOrganizationHasFeature',
+          },
+        ],
+        handler: attestationController.findAllByOrganizationId,
+        tags: ['api', 'organizations'],
+        notes: [
+          'Cette route est restreinte aux utilisateurs authentifiés',
+          'Elle retourne les attestations rattachées à l’organisation.',
+        ],
       },
     },
   ]);

--- a/api/src/quest/domain/models/AdminCombinedCourseBlueprint.js
+++ b/api/src/quest/domain/models/AdminCombinedCourseBlueprint.js
@@ -11,6 +11,7 @@ export class AdminCombinedCourseBlueprint {
     illustration,
     content,
     attestationKey,
+    attestationLabel,
     createdAt,
     updatedAt,
     organizationIds = [],
@@ -23,6 +24,7 @@ export class AdminCombinedCourseBlueprint {
     this.organizationIds = organizationIds;
     this.content = content;
     this.attestationKey = attestationKey;
+    this.attestationLabel = attestationLabel;
     this.createdAt = createdAt;
     this.updatedAt = updatedAt;
   }
@@ -36,7 +38,7 @@ export class AdminCombinedCourseBlueprint {
     return Joi.attempt(data, contentSchema);
   }
 
-  static buildFromBlueprint({ combinedCourseBlueprint, modulesById, attestationKey }) {
+  static buildFromBlueprint({ combinedCourseBlueprint, modulesById, attestationLabel }) {
     const items = combinedCourseBlueprint.quest.successRequirements.map((requirement) => {
       if (requirement.requirement_type === REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS) {
         return { targetProfileId: requirement.data.targetProfileId.data };
@@ -47,7 +49,7 @@ export class AdminCombinedCourseBlueprint {
     });
 
     const content = AdminCombinedCourseBlueprint.buildContentItems(items);
-    return new AdminCombinedCourseBlueprint({ ...combinedCourseBlueprint, content, attestationKey });
+    return new AdminCombinedCourseBlueprint({ ...combinedCourseBlueprint, content, attestationLabel });
   }
 }
 

--- a/api/src/quest/domain/models/Attestation.js
+++ b/api/src/quest/domain/models/Attestation.js
@@ -1,8 +1,9 @@
 export class Attestation {
-  constructor({ id, templateName, key, createdAt }) {
+  constructor({ id, templateName, key, createdAt, label }) {
     this.id = id;
     this.templateName = templateName;
     this.key = key;
     this.createdAt = createdAt;
+    this.label = label;
   }
 }

--- a/api/src/quest/domain/usecases/create-attestation.js
+++ b/api/src/quest/domain/usecases/create-attestation.js
@@ -1,3 +1,3 @@
-export const createAttestation = async ({ templateKey, templateName, templateFile, attestationRepository }) => {
-  await attestationRepository.save({ templateKey, templateName, templateFile });
+export const createAttestation = async ({ templateKey, templateName, templateFile, label, attestationRepository }) => {
+  await attestationRepository.save({ templateKey, templateName, templateFile, label });
 };

--- a/api/src/quest/domain/usecases/find-organization-attestations.js
+++ b/api/src/quest/domain/usecases/find-organization-attestations.js
@@ -1,0 +1,3 @@
+export const findOrganizationAttestations = async ({ organizationId, attestationRepository }) => {
+  return attestationRepository.findAllByOrganizationId({ organizationId });
+};

--- a/api/src/quest/domain/usecases/get-combined-course-blueprint-by-id.js
+++ b/api/src/quest/domain/usecases/get-combined-course-blueprint-by-id.js
@@ -25,6 +25,6 @@ export const getCombinedCourseBlueprintById = async ({
   return AdminCombinedCourseBlueprint.buildFromBlueprint({
     combinedCourseBlueprint,
     modulesById,
-    attestationKey: attestation.key,
+    attestationLabel: attestation.label,
   });
 };

--- a/api/src/quest/domain/usecases/index.js
+++ b/api/src/quest/domain/usecases/index.js
@@ -60,6 +60,7 @@ import { findCombinedCourseBlueprints } from './find-combined-course-blueprints.
 import { findCombinedCourseByCampaignId } from './find-combined-course-by-campaign-id.js';
 import { findCombinedCourseByModuleIdAndUserId } from './find-combined-course-by-moduleId-and-user-id.js';
 import { findCombinedCourseParticipations } from './find-combined-course-participations.js';
+import { findOrganizationAttestations } from './find-organization-attestations.js';
 import { getCombinedCourseBlueprintById } from './get-combined-course-blueprint-by-id.js';
 import { getCombinedCourseByCode } from './get-combined-course-by-code.js';
 import getCombinedCourseById from './get-combined-course-by-id.js';
@@ -101,6 +102,7 @@ const usecasesWithoutInjectedDependencies = {
   findByOrganizationId,
   deleteAndAnonymizeParticipationsForALearnerId,
   updateCombinedCourses,
+  findOrganizationAttestations,
 };
 
 const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);

--- a/api/src/quest/infrastructure/repositories/attestation-repository.js
+++ b/api/src/quest/infrastructure/repositories/attestation-repository.js
@@ -1,17 +1,19 @@
+import { ORGANIZATION_FEATURE } from '../../../shared/domain/constants.js';
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { AlreadyExistingEntityError } from '../../../shared/domain/errors.js';
 import * as knexUtils from '../../../shared/infrastructure/utils/knex-utils.js';
 import { REWARD_TYPES } from '../../domain/constants.js';
+import { Attestation } from '../../domain/models/Attestation.js';
 
 const ATTESTATION_KEY_UNIQUE_CONSTRAINT = 'attestations_key_unique';
 const DUPLICATE_ATTESTATION_KEY = 'DUPLICATE_ATTESTATION_KEY';
 
-export const save = async ({ templateName, templateKey, templateFile, attestationStorage }) => {
+export const save = async ({ templateName, templateKey, templateFile, label, attestationStorage }) => {
   await DomainTransaction.execute(async () => {
     const knexConn = DomainTransaction.getConnection();
 
     try {
-      await knexConn('attestations').insert({ key: templateKey, templateName });
+      await knexConn('attestations').insert({ key: templateKey, templateName, label });
       await attestationStorage.startUpload({ filename: `${templateName}.pdf`, readableStream: templateFile });
     } catch (error) {
       if (knexUtils.isUniqConstraintViolated(error) && error.constraint === ATTESTATION_KEY_UNIQUE_CONSTRAINT) {
@@ -20,6 +22,24 @@ export const save = async ({ templateName, templateKey, templateFile, attestatio
       throw error;
     }
   });
+};
+
+export const findAllByOrganizationId = async ({ organizationId }) => {
+  const knexConn = DomainTransaction.getConnection();
+
+  const organizationAttestationManagementFeature = await knexConn('organization-features')
+    .select('params')
+    .where('featureId', (qb) => {
+      qb.select('id').from('features').where('key', ORGANIZATION_FEATURE.ATTESTATIONS_MANAGEMENT.key).first();
+    })
+    .andWhere('organizationId', organizationId)
+    .first();
+
+  const attestations = await knexConn('attestations')
+    .select('id', 'key', 'label')
+    .whereIn('key', organizationAttestationManagementFeature.params);
+
+  return attestations.map((attestation) => new Attestation(attestation));
 };
 
 export const getByRewardId = async ({ rewardId, rewardApi }) => {

--- a/api/src/quest/infrastructure/serializers/admin-combined-course-blueprint-serializer.js
+++ b/api/src/quest/infrastructure/serializers/admin-combined-course-blueprint-serializer.js
@@ -14,7 +14,7 @@ const serialize = function (adminCombinedCourseBlueprint) {
       'content',
       'createdAt',
       'updatedAt',
-      'attestationKey',
+      'attestationLabel',
     ],
   }).serialize(adminCombinedCourseBlueprint);
 };

--- a/api/tests/profile/acceptance/application/attestation-route_test.js
+++ b/api/tests/profile/acceptance/application/attestation-route_test.js
@@ -17,8 +17,8 @@ describe('Profile | Acceptance | Application | Attestation Route ', function () 
     it('should return 200 with the list of attestations', async function () {
       // given
       const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
-      databaseBuilder.factory.buildAttestation({ key: 'PARENTHOOD' });
-      databaseBuilder.factory.buildAttestation({ key: 'SIXTH_GRADE' });
+      databaseBuilder.factory.buildAttestation({ key: 'PARENTHOOD', label: 'Parentalité' });
+      databaseBuilder.factory.buildAttestation({ key: 'SIXTH_GRADE', label: '6ème' });
       await databaseBuilder.commit();
 
       const options = {
@@ -33,10 +33,6 @@ describe('Profile | Acceptance | Application | Attestation Route ', function () 
       // then
       expect(response.statusCode).to.equal(200);
       expect(response.result.data).to.have.lengthOf(2);
-      expect(response.result.data.map(({ attributes }) => attributes.key)).to.include.members([
-        'PARENTHOOD',
-        'SIXTH_GRADE',
-      ]);
     });
   });
 

--- a/api/tests/profile/integration/infrastructure/repositories/attestation-repository_test.js
+++ b/api/tests/profile/integration/infrastructure/repositories/attestation-repository_test.js
@@ -10,8 +10,8 @@ describe('Profile | Integration | Infrastructure | Repository | Attestation', fu
   describe('#findAll', function () {
     it('should return all attestations', async function () {
       // given
-      databaseBuilder.factory.buildAttestation({ key: 'PARENTHOOD' });
-      databaseBuilder.factory.buildAttestation({ key: 'SIXTH_GRADE' });
+      databaseBuilder.factory.buildAttestation({ key: 'PARENTHOOD', label: 'Parentalité' });
+      databaseBuilder.factory.buildAttestation({ key: 'SIXTH_GRADE', label: '6ème' });
       await databaseBuilder.commit();
 
       // when
@@ -21,6 +21,7 @@ describe('Profile | Integration | Infrastructure | Repository | Attestation', fu
       expect(result).to.have.lengthOf(2);
       expect(result[0]).to.be.an.instanceof(Attestation);
       expect(result.map((a) => a.key)).to.include.members(['PARENTHOOD', 'SIXTH_GRADE']);
+      expect(result.map((a) => a.label)).to.include.members(['Parentalité', '6ème']);
     });
 
     it('should return an empty array when there are no attestations', async function () {
@@ -45,7 +46,7 @@ describe('Profile | Integration | Infrastructure | Repository | Attestation', fu
       // then
 
       expect(result).to.be.an.instanceof(Attestation);
-      expect(result.templateName).to.equal(templateName);
+      expect(result).to.deep.equal(attestation);
     });
 
     it('should return null if no attestation exist for given key', async function () {

--- a/api/tests/profile/unit/infrastructure/serializers/jsonapi/attestation-serializer_test.js
+++ b/api/tests/profile/unit/infrastructure/serializers/jsonapi/attestation-serializer_test.js
@@ -7,8 +7,8 @@ describe('Profile | Unit | Serializer | JSONAPI | attestation', function () {
     it('should convert attestation objects into JSON API data', function () {
       // when
       const json = serializer.serialize([
-        new Attestation({ id: 1, key: 'PARENTHOOD', templateName: 'template-parenthood' }),
-        new Attestation({ id: 2, key: 'SIXTH_GRADE', templateName: 'template-sixth-grade' }),
+        new Attestation({ id: 1, key: 'PARENTHOOD', templateName: 'template-parenthood', label: 'Parentalité' }),
+        new Attestation({ id: 2, key: 'SIXTH_GRADE', templateName: 'template-sixth-grade', label: '6ème' }),
       ]);
 
       // then
@@ -19,6 +19,7 @@ describe('Profile | Unit | Serializer | JSONAPI | attestation', function () {
             id: '1',
             attributes: {
               key: 'PARENTHOOD',
+              label: 'Parentalité',
             },
           },
           {
@@ -26,6 +27,7 @@ describe('Profile | Unit | Serializer | JSONAPI | attestation', function () {
             id: '2',
             attributes: {
               key: 'SIXTH_GRADE',
+              label: '6ème',
             },
           },
         ],

--- a/api/tests/quest/acceptance/application/attestation-route_test.js
+++ b/api/tests/quest/acceptance/application/attestation-route_test.js
@@ -1,6 +1,7 @@
 import FormData from 'form-data';
 
 import { PIX_ADMIN } from '../../../../src/authorization/domain/constants.js';
+import { ORGANIZATION_FEATURE } from '../../../../src/shared/domain/constants.js';
 import {
   createServer,
   databaseBuilder,
@@ -30,6 +31,7 @@ describe('Quest | Acceptance | Application | Attestation Route ', function () {
         it('creates attestation', async function () {
           const templateKey = 'key';
           const templateName = 'name';
+          const label = 'label';
 
           const formData = new FormData();
           formData.append('templateKey', templateKey);
@@ -39,6 +41,7 @@ describe('Quest | Acceptance | Application | Attestation Route ', function () {
             filename: 'attestation-template.pdf',
             contentType: 'application/pdf',
           });
+          formData.append('label', label);
           mockAttestationStorageUpload({ attestation: { templateName } });
           const options = {
             method: 'POST',
@@ -87,6 +90,51 @@ describe('Quest | Acceptance | Application | Attestation Route ', function () {
           // then
           expect(response.statusCode).to.equal(400);
         });
+      });
+    });
+  });
+
+  describe('GET /api/organizations/${organizationId}/attestations', function () {
+    context('when user has one of the authorized roles', function () {
+      let user;
+      let organization;
+
+      beforeEach(async function () {
+        user = databaseBuilder.factory.buildUser();
+        organization = databaseBuilder.factory.buildOrganization({
+          credit: 5,
+          isManagingStudents: true,
+        });
+        databaseBuilder.factory.buildMembership({ organizationId: organization.id, userId: user.id });
+        databaseBuilder.factory.buildUserOrgaSettings({
+          currentOrganizationId: organization.id,
+          userId: user.id,
+        });
+
+        databaseBuilder.factory.buildAttestation({ key: 'SIXTH_GRADE', label: '6ème' });
+        const attestationFeature = databaseBuilder.factory.buildFeature(ORGANIZATION_FEATURE.ATTESTATIONS_MANAGEMENT);
+        databaseBuilder.factory.buildOrganizationFeature({
+          organizationId: organization.id,
+          featureId: attestationFeature.id,
+          params: JSON.stringify(['SIXTH_GRADE']),
+        });
+
+        await databaseBuilder.commit();
+      });
+
+      it('retrieves all attestations from an organization', async function () {
+        // given
+        const options = {
+          method: 'GET',
+          url: `/api/organizations/${organization.id}/attestations`,
+          headers: generateAuthenticatedUserRequestHeaders({ userId: user.id }),
+        };
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(200);
       });
     });
   });

--- a/api/tests/quest/integration/domain/usecases/create-attestation_test.js
+++ b/api/tests/quest/integration/domain/usecases/create-attestation_test.js
@@ -8,10 +8,11 @@ describe('Integration | Attestation | Domain | UseCases | create-attestation', f
     const templateKey = 'key';
     const templateName = 'name';
     const templateFile = await AttestationTemplateFixture.getFile();
+    const label = 'label';
     mockAttestationStorageUpload({ attestation: { templateName } });
 
     // when
-    await usecases.createAttestation({ templateKey, templateName, templateFile });
+    await usecases.createAttestation({ templateKey, templateName, templateFile, label });
 
     // then
     const result = await knex('attestations').where('key', templateKey);
@@ -19,5 +20,6 @@ describe('Integration | Attestation | Domain | UseCases | create-attestation', f
     expect(result.length).to.equal(1);
     expect(result[0].key).to.equal(templateKey);
     expect(result[0].templateName).to.equal(templateName);
+    expect(result[0].label).to.equal(label);
   });
 });

--- a/api/tests/quest/integration/domain/usecases/get-combined-course-blueprint-by-id_test.js
+++ b/api/tests/quest/integration/domain/usecases/get-combined-course-blueprint-by-id_test.js
@@ -21,7 +21,7 @@ describe('Integration | Quest | Domain | UseCases | get-combined-course-blueprin
     //given
     const { id: targetProfileId } = await databaseBuilder.factory.buildTargetProfile({ name: 'Mon profil cible' });
 
-    const { id: rewardId, key: attestationKey } = await databaseBuilder.factory.buildAttestation();
+    const { id: rewardId, label: attestationLabel } = await databaseBuilder.factory.buildAttestation();
 
     const quest = databaseBuilder.factory.buildQuest({
       rewardType: REWARD_TYPES.ATTESTATION,
@@ -56,7 +56,7 @@ describe('Integration | Quest | Domain | UseCases | get-combined-course-blueprin
       createdAt: now,
       updatedAt: now,
       organizationIds: [],
-      attestationKey,
+      attestationLabel,
     });
     expect(adminCombinedCourseBlueprint.content).to.deep.equal(
       AdminCombinedCourseBlueprint.buildContentItems([{ targetProfileId }, { moduleShortId: 'e074af34' }]),

--- a/api/tests/quest/integration/infrastructure/repositories/attestation-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/attestation-repository_test.js
@@ -1,5 +1,7 @@
+import { Attestation } from '../../../../../src/quest/domain/models/Attestation.js';
 import * as attestationRepository from '../../../../../src/quest/infrastructure/repositories/attestation-repository.js';
 import { AttestationStorage } from '../../../../../src/quest/infrastructure/storage/attestation-storage.js';
+import { ORGANIZATION_FEATURE } from '../../../../../src/shared/domain/constants.js';
 import { AlreadyExistingEntityError } from '../../../../../src/shared/domain/errors.js';
 import { S3UploadError } from '../../../../../src/shared/domain/errors.js';
 import { catchErr, databaseBuilder, expect, knex, mockAttestationStorageUpload } from '../../../../test-helper.js';
@@ -11,6 +13,7 @@ describe('Quest | Integration | Repository | attestation', function () {
       const templateName = 'name';
       const templateKey = 'key';
       const templateFile = await AttestationTemplateFixture.getFile();
+      const label = 'label';
 
       //when
       const storageMock = mockAttestationStorageUpload({ attestation: { templateName } });
@@ -20,6 +23,7 @@ describe('Quest | Integration | Repository | attestation', function () {
         templateKey,
         templateFile,
         attestationStorage: AttestationStorage.createClient(),
+        label,
       });
 
       // then
@@ -29,12 +33,14 @@ describe('Quest | Integration | Repository | attestation', function () {
       expect(results.length).to.equal(1);
       expect(results[0].key).to.equal(templateKey);
       expect(results[0].templateName).to.equal(templateName);
+      expect(results[0].label).to.equal(label);
     });
 
     it('should not save attestation in db if file upload failed', async function () {
       const templateName = 'name';
       const templateKey = 'key';
       const templateFile = await AttestationTemplateFixture.getFile();
+      const label = 'label';
 
       //when
       const storageMock = mockAttestationStorageUpload({ attestation: { templateName }, isFailed: true });
@@ -42,6 +48,7 @@ describe('Quest | Integration | Repository | attestation', function () {
         templateName,
         templateKey,
         templateFile,
+        label,
         attestationStorage: AttestationStorage.createClient(),
       });
 
@@ -57,8 +64,9 @@ describe('Quest | Integration | Repository | attestation', function () {
       const templateName = 'name';
       const templateKey = 'key';
       const templateFile = await AttestationTemplateFixture.getFile();
+      const label = 'label';
 
-      databaseBuilder.factory.buildAttestation({ key: templateKey, templateName: 'anotherTemplateName' });
+      databaseBuilder.factory.buildAttestation({ key: templateKey, templateName: 'anotherTemplateName', label });
       await databaseBuilder.commit();
 
       //when
@@ -66,6 +74,7 @@ describe('Quest | Integration | Repository | attestation', function () {
         templateName,
         templateKey,
         templateFile,
+        label,
         attestationStorage: null,
       });
 
@@ -75,6 +84,55 @@ describe('Quest | Integration | Repository | attestation', function () {
       expect(results.length).to.equal(1);
       expect(results[0].templateName).to.equal('anotherTemplateName');
       expect(error).to.be.instanceOf(AlreadyExistingEntityError);
+    });
+  });
+  describe('#findAllByOrganizationId', function () {
+    it('should retrieve attestations by organization id', async function () {
+      const attestation1 = databaseBuilder.factory.buildAttestation({
+        key: 'key',
+        templateName: 'templateName',
+        label: 'label',
+      });
+      const attestation2 = databaseBuilder.factory.buildAttestation({
+        key: 'key2',
+        templateName: 'templateName2',
+        label: 'label2',
+      });
+      databaseBuilder.factory.buildAttestation({
+        key: 'key3',
+        templateName: 'templateName3',
+        label: 'label3',
+      });
+
+      const organization = databaseBuilder.factory.buildOrganization();
+      const attestationFeature = databaseBuilder.factory.buildFeature(ORGANIZATION_FEATURE.ATTESTATIONS_MANAGEMENT);
+      databaseBuilder.factory.buildOrganizationFeature({
+        organizationId: organization.id,
+        featureId: attestationFeature.id,
+        params: JSON.stringify(['key', 'key2']),
+      });
+
+      await databaseBuilder.commit();
+
+      //when
+      const results = await attestationRepository.findAllByOrganizationId({
+        organizationId: organization.id,
+      });
+
+      //then
+
+      expect(results).to.deep.equal([
+        new Attestation({
+          id: attestation1.id,
+          key: attestation1.key,
+          label: attestation1.label,
+        }),
+        new Attestation({
+          id: attestation2.id,
+          key: attestation2.key,
+          label: attestation2.label,
+        }),
+      ]);
     });
   });
 });

--- a/api/tests/quest/unit/application/attestation-route_test.js
+++ b/api/tests/quest/unit/application/attestation-route_test.js
@@ -3,6 +3,7 @@ import FormData from 'form-data';
 import { attestationController } from '../../../../src/quest/application/attestation-controller.js';
 import * as attestationRoute from '../../../../src/quest/application/attestation-route.js';
 import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
+import { ORGANIZATION_FEATURE } from '../../../../src/shared/domain/constants.js';
 import { expect, generateAuthenticatedUserRequestHeaders, HttpTestServer, sinon } from '../../../test-helper.js';
 import { AttestationTemplateFixture } from '../../../tooling/fixtures/index.js';
 
@@ -21,6 +22,7 @@ describe('Quest | Unit | Routes | Attestation Route', function () {
         formData.append('templateKey', 'my_key');
         formData.append('templateName', 'my_name');
         formData.append('templateFile', await AttestationTemplateFixture.getFile());
+        formData.append('label', 'attestation label');
 
         const headers = {
           ...formData.getHeaders(),
@@ -50,6 +52,7 @@ describe('Quest | Unit | Routes | Attestation Route', function () {
         const formData = new FormData();
         formData.append('templateName', 'my_name');
         formData.append('templateFile', await AttestationTemplateFixture.getFile());
+        formData.append('label', 'label');
 
         const headers = {
           ...formData.getHeaders(),
@@ -72,6 +75,31 @@ describe('Quest | Unit | Routes | Attestation Route', function () {
 
         const formData = new FormData();
         formData.append('templateKey', 'key');
+        formData.append('templateFile', await AttestationTemplateFixture.getFile());
+        formData.append('label', 'label');
+
+        const headers = {
+          ...formData.getHeaders(),
+          ...generateAuthenticatedUserRequestHeaders({ userId: 132 }),
+        };
+        const payload = formData.getBuffer();
+
+        // when
+        const response = await httpTestServer.request('POST', '/api/admin/attestations', payload, null, headers);
+
+        //then
+        expect(response.statusCode).to.equal(400);
+      });
+      it('should fail when label is missing', async function () {
+        sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
+        sinon.stub(attestationController, 'save').resolves('ok');
+
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(attestationRoute);
+
+        const formData = new FormData();
+        formData.append('templateKey', 'key');
+        formData.append('templateName', 'my_name');
         formData.append('templateFile', await AttestationTemplateFixture.getFile());
 
         const headers = {
@@ -96,6 +124,7 @@ describe('Quest | Unit | Routes | Attestation Route', function () {
         const formData = new FormData();
         formData.append('templateName', 'name');
         formData.append('templateKey', 'key');
+        formData.append('label', 'label');
 
         const headers = {
           ...formData.getHeaders(),
@@ -109,6 +138,67 @@ describe('Quest | Unit | Routes | Attestation Route', function () {
         //then
         expect(response.statusCode).to.equal(400);
       });
+    });
+  });
+  describe('GET /api/organizations/{organizationId}/attestations', function () {
+    it('should fail if user is not a member of the organization', async function () {
+      sinon
+        .stub(securityPreHandlers, 'checkUserBelongsToOrganization')
+        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+
+      const organizationId = 123;
+
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(attestationRoute);
+
+      const headers = {
+        ...generateAuthenticatedUserRequestHeaders({ userId: 132 }),
+      };
+
+      const response = await httpTestServer.request(
+        'GET',
+        `/api/organizations/${organizationId}/attestations`,
+        null,
+        null,
+        headers,
+      );
+
+      expect(securityPreHandlers.checkUserBelongsToOrganization).to.have.been.calledOnce;
+      expect(response.statusCode).to.equal(403);
+    });
+
+    it('should fail if organization does not have attestation management feature', async function () {
+      sinon.stub(securityPreHandlers, 'checkUserBelongsToOrganization').callsFake((request, h) => h.response(true));
+      sinon.stub(securityPreHandlers, 'makeCheckOrganizationHasFeature').callsFake(
+        () => (request, h) =>
+          h
+            .response({ errors: new Error('forbidden') })
+            .code(403)
+            .takeover(),
+      );
+
+      const organizationId = 123;
+
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(attestationRoute);
+
+      const headers = {
+        ...generateAuthenticatedUserRequestHeaders({ userId: 132 }),
+      };
+
+      const response = await httpTestServer.request(
+        'GET',
+        `/api/organizations/${organizationId}/attestations`,
+        null,
+        null,
+        headers,
+      );
+
+      expect(securityPreHandlers.checkUserBelongsToOrganization).to.have.been.calledOnce;
+      expect(securityPreHandlers.makeCheckOrganizationHasFeature).to.have.been.calledOnceWithExactly(
+        ORGANIZATION_FEATURE.ATTESTATIONS_MANAGEMENT.key,
+      );
+      expect(response.statusCode).to.equal(403);
     });
   });
 });

--- a/api/tests/quest/unit/domain/models/AdminCombinedCourseBlueprint_test.js
+++ b/api/tests/quest/unit/domain/models/AdminCombinedCourseBlueprint_test.js
@@ -18,6 +18,7 @@ describe('Quest | Unit | Domain | Models | AdminCombinedCourseBlueprint ', funct
         illustration: 'illustration',
         content: AdminCombinedCourseBlueprint.buildContentItems([{ moduleShortId: '123' }]),
         attestationKey: ATTESTATIONS.PARENTHOOD,
+        attestationLabel: 'Parentalité',
         createdAt: new Date(),
         updatedAt: new Date(),
         organizationIds: [],
@@ -71,7 +72,7 @@ describe('Quest | Unit | Domain | Models | AdminCombinedCourseBlueprint ', funct
       const readyToSerialize = AdminCombinedCourseBlueprint.buildFromBlueprint({
         combinedCourseBlueprint,
         modulesById: { 'completeId-az-123': [{ shortId: 'az-123' }] },
-        attestationKey: 'PARENTHOOD',
+        attestationLabel: 'Parentalité',
       });
 
       // then
@@ -79,7 +80,7 @@ describe('Quest | Unit | Domain | Models | AdminCombinedCourseBlueprint ', funct
         new AdminCombinedCourseBlueprint({
           ...combinedCourseBlueprint,
           content: expectedContent,
-          attestationKey: 'PARENTHOOD',
+          attestationLabel: 'Parentalité',
         }),
       );
     });

--- a/api/tests/quest/unit/infrastructure/repositories/attestation-repository_test.js
+++ b/api/tests/quest/unit/infrastructure/repositories/attestation-repository_test.js
@@ -10,14 +10,22 @@ describe('Quest | Unit | Infrastructure | Repositories | attestation-repository'
     rewardApiStub = {
       getByIdAndType: sinon
         .stub()
-        .resolves(new Attestation({ id: 1, templateName: 'templateName', key: 'KEY', createdAt: now })),
+        .resolves(
+          new Attestation({ id: 1, templateName: 'templateName', key: 'KEY', label: 'attestation', createdAt: now }),
+        ),
     };
   });
   describe('#getByRewardId', function () {
     it('should return an attestation key if reward id exists', async function () {
       const result = await attestationRepository.getByRewardId({ rewardId: 1, rewardApi: rewardApiStub });
       expect(result).to.be.instanceOf(Attestation);
-      expect(result).to.deep.equal({ id: 1, templateName: 'templateName', key: 'KEY', createdAt: now });
+      expect(result).to.deep.equal({
+        id: 1,
+        templateName: 'templateName',
+        key: 'KEY',
+        label: 'attestation',
+        createdAt: now,
+      });
     });
   });
 });

--- a/api/tests/quest/unit/infrastructure/serializers/admin-combined-course-blueprint-serializer_test.js
+++ b/api/tests/quest/unit/infrastructure/serializers/admin-combined-course-blueprint-serializer_test.js
@@ -18,7 +18,8 @@ describe('Quest | Unit | Infrastructure | Serializers | admin-combined-course-bl
         { moduleShortId: 'mon-module' },
         { targetProfileId: 123 },
       ]),
-      attestationKey: 'PARENTHOOD',
+      attestationKey: 'SIXTH_GRADE',
+      attestationLabel: '6ème',
       organizationIds: [],
     });
 
@@ -46,7 +47,7 @@ describe('Quest | Unit | Infrastructure | Serializers | admin-combined-course-bl
           ],
           'created-at': adminCombinedCourseBlueprint.createdAt,
           'updated-at': adminCombinedCourseBlueprint.updatedAt,
-          'attestation-key': 'PARENTHOOD',
+          'attestation-label': '6ème',
         },
         type: 'combined-course-blueprints',
         id: '1',
@@ -104,6 +105,7 @@ describe('Quest | Unit | Infrastructure | Serializers | admin-combined-course-bl
         },
       ],
       attestationKey: 'SIXTH_GRADE',
+      attestationLabel: undefined,
       organizationIds: [],
       createdAt: date,
       updatedAt: date,

--- a/api/tests/quest/unit/infrastructure/serializers/quest-result-serializer_test.js
+++ b/api/tests/quest/unit/infrastructure/serializers/quest-result-serializer_test.js
@@ -9,7 +9,13 @@ describe('Quest | Unit | Infrastructure | Serializers | quest-result', function 
     const questResult = new QuestResult({
       id: 1,
       obtained: true,
-      reward: new Attestation({ id: 10, key: 'MY_KEY', templateName: 'my-key', createdAt: new Date('2020-10-10') }),
+      reward: new Attestation({
+        id: 10,
+        key: 'MY_KEY',
+        templateName: 'my-key',
+        label: 'attestation',
+        createdAt: new Date('2020-10-10'),
+      }),
       profileRewardId: 1,
     });
 
@@ -23,7 +29,13 @@ describe('Quest | Unit | Infrastructure | Serializers | quest-result', function 
         id: '1',
         attributes: {
           obtained: true,
-          reward: { id: 10, templateName: 'my-key', key: 'MY_KEY', createdAt: new Date('2020-10-10') },
+          reward: {
+            id: 10,
+            templateName: 'my-key',
+            key: 'MY_KEY',
+            label: 'attestation',
+            createdAt: new Date('2020-10-10'),
+          },
           'profile-reward-id': 1,
         },
       },

--- a/api/tests/shared/integration/infrastructure/utils/knex-utils_test.js
+++ b/api/tests/shared/integration/infrastructure/utils/knex-utils_test.js
@@ -1,23 +1,29 @@
-import _ from 'lodash';
-
 import { DomainTransaction } from '../../../../../src/shared/domain/DomainTransaction.js';
 import {
   batchUpdate,
   DEFAULT_PAGINATION,
   fetchPage,
 } from '../../../../../src/shared/infrastructure/utils/knex-utils.js';
-import { databaseBuilder, expect, knex } from '../../../../test-helper.js';
+import { expect, knex } from '../../../../test-helper.js';
 
 describe('Integration | Infrastructure | Utils | Knex utils', function () {
   describe('fetchPage', function () {
+    beforeEach(async function () {
+      await knex.schema.dropTableIfExists('fetch_page_test');
+      await knex.schema.createTable('fetch_page_test', (table) => {
+        table.increments('id').primary();
+        table.text('key');
+      });
+    });
+
     it('should fetch the given page and return results and pagination data', async function () {
       // given
       const letterA = 'a'.charCodeAt(0);
-      _.times(5, (index) => databaseBuilder.factory.buildCampaign({ name: `${String.fromCharCode(letterA + index)}` }));
-      await databaseBuilder.commit();
+      const rows = Array.from({ length: 5 }, (_, index) => ({ key: String.fromCharCode(letterA + index) }));
+      await knex('fetch_page_test').insert(rows);
 
       // when
-      const query = knex.select('name').from('campaigns').orderBy('name', 'ASC');
+      const query = knex.select('key').from('fetch_page_test').orderBy('key', 'ASC');
       const { results, pagination } = await fetchPage({
         queryBuilder: query,
         paginationParams: { number: 2, size: 2 },
@@ -25,7 +31,7 @@ describe('Integration | Infrastructure | Utils | Knex utils', function () {
 
       // then
       expect(results).to.have.lengthOf(2);
-      expect(results.map((result) => result.name)).exactlyContainInOrder(['c', 'd']);
+      expect(results.map((result) => result.key)).exactlyContainInOrder(['c', 'd']);
       expect(pagination).to.deep.equal({
         page: 2,
         pageSize: 2,
@@ -36,21 +42,22 @@ describe('Integration | Infrastructure | Utils | Knex utils', function () {
 
     it('should correctly count rowCount with a distinct in the select clause', async function () {
       // given
-      databaseBuilder.factory.buildCampaign({ name: 'DoublonA' });
-      databaseBuilder.factory.buildCampaign({ name: 'DoublonA' });
-      databaseBuilder.factory.buildCampaign({ name: 'DoublonB' });
-      databaseBuilder.factory.buildCampaign({ name: 'DoublonB' });
-      await databaseBuilder.commit();
+      await knex('fetch_page_test').insert([
+        { key: 'DoublonA' },
+        { key: 'DoublonA' },
+        { key: 'DoublonB' },
+        { key: 'DoublonB' },
+      ]);
 
       // when
-      const query = knex.distinct('name').from('campaigns');
+      const query = knex.distinct('key').from('fetch_page_test');
       const { results, pagination } = await fetchPage({
         queryBuilder: query,
       });
 
       // then
       expect(results).to.have.lengthOf(2);
-      expect(results.map((result) => result.name)).exactlyContain(['DoublonA', 'DoublonB']);
+      expect(results.map((result) => result.key)).exactlyContain(['DoublonA', 'DoublonB']);
       expect(pagination.rowCount).to.equal(2);
     });
 
@@ -60,11 +67,11 @@ describe('Integration | Infrastructure | Utils | Knex utils', function () {
         const pageNumber = 2;
         const pageSize = 1;
         const total = 3;
-        _.times(total, (index) => databaseBuilder.factory.buildCampaign({ name: `c-${index}` }));
-        await databaseBuilder.commit();
+        const rows = Array.from({ length: total }, (_, index) => ({ key: `key-${index}` }));
+        await knex('fetch_page_test').insert(rows);
 
         // when
-        const query = knex.select('name').from('campaigns');
+        const query = knex.select('key').from('fetch_page_test');
         const { results, pagination } = await fetchPage({
           queryBuilder: query,
           paginationParams: { number: pageNumber, size: pageSize },
@@ -80,11 +87,11 @@ describe('Integration | Infrastructure | Utils | Knex utils', function () {
         const pageNumber = 10000;
         const pageSize = 1;
         const total = 3;
-        _.times(total, (index) => databaseBuilder.factory.buildCampaign({ name: `c-${index}` }));
-        await databaseBuilder.commit();
+        const rows = Array.from({ length: total }, (_, index) => ({ key: `key-${index}` }));
+        await knex('fetch_page_test').insert(rows);
 
         // when
-        const query = knex.select('name').from('campaigns');
+        const query = knex.select('key').from('fetch_page_test');
         const { results, pagination } = await fetchPage({
           queryBuilder: query,
           paginationParams: { number: pageNumber, size: pageSize },
@@ -100,11 +107,11 @@ describe('Integration | Infrastructure | Utils | Knex utils', function () {
         const pageNumber = 0;
         const pageSize = 1;
         const total = 3;
-        _.times(total, (index) => databaseBuilder.factory.buildCampaign({ name: `c-${index}` }));
-        await databaseBuilder.commit();
+        const rows = Array.from({ length: total }, (_, index) => ({ key: `key-${index}` }));
+        await knex('fetch_page_test').insert(rows);
 
         // when
-        const query = knex.select('name').from('campaigns');
+        const query = knex.select('key').from('fetch_page_test');
         const { results, pagination } = await fetchPage({
           queryBuilder: query,
           paginationParams: { number: pageNumber, size: pageSize },
@@ -119,11 +126,11 @@ describe('Integration | Infrastructure | Utils | Knex utils', function () {
         // given
         const pageSize = 1;
         const total = 1;
-        _.times(total, (index) => databaseBuilder.factory.buildCampaign({ name: `c-${index}` }));
-        await databaseBuilder.commit();
+        const rows = Array.from({ length: total }, (_, index) => ({ key: `key-${index}` }));
+        await knex('fetch_page_test').insert(rows);
 
         // when
-        const query = knex.select('name').from('campaigns');
+        const query = knex.select('key').from('fetch_page_test');
         const { results, pagination } = await fetchPage({
           queryBuilder: query,
           paginationParams: { size: pageSize },
@@ -141,11 +148,11 @@ describe('Integration | Infrastructure | Utils | Knex utils', function () {
         const pageNumber = 1;
         const pageSize = 2;
         const total = 3;
-        _.times(total, (index) => databaseBuilder.factory.buildCampaign({ name: `c-${index}` }));
-        await databaseBuilder.commit();
+        const rows = Array.from({ length: total }, (_, index) => ({ key: `key-${index}` }));
+        await knex('fetch_page_test').insert(rows);
 
         // when
-        const query = knex.select('name').from('campaigns');
+        const query = knex.select('key').from('fetch_page_test');
         const { results, pagination } = await fetchPage({
           queryBuilder: query,
           paginationParams: { number: pageNumber, size: pageSize },
@@ -161,11 +168,11 @@ describe('Integration | Infrastructure | Utils | Knex utils', function () {
         const pageNumber = 1;
         const total = 3;
         const pageSize = 6;
-        _.times(total, (index) => databaseBuilder.factory.buildCampaign({ name: `c-${index}` }));
-        await databaseBuilder.commit();
+        const rows = Array.from({ length: total }, (_, index) => ({ key: `key-${index}` }));
+        await knex('fetch_page_test').insert(rows);
 
         // when
-        const query = knex.select('name').from('campaigns');
+        const query = knex.select('key').from('fetch_page_test');
         const { results, pagination } = await fetchPage({
           queryBuilder: query,
           paginationParams: { number: pageNumber, size: pageSize },
@@ -181,11 +188,11 @@ describe('Integration | Infrastructure | Utils | Knex utils', function () {
         const pageNumber = 1000;
         const pageSize = 5;
         const total = 1;
-        _.times(total, (index) => databaseBuilder.factory.buildCampaign({ name: `c-${index}` }));
-        await databaseBuilder.commit();
+        const rows = Array.from({ length: total }, (_, index) => ({ key: `key-${index}` }));
+        await knex('fetch_page_test').insert(rows);
 
         // when
-        const query = knex.select('name').from('campaigns');
+        const query = knex.select('key').from('fetch_page_test');
         const { results, pagination } = await fetchPage({
           queryBuilder: query,
           paginationParams: { number: pageNumber, size: pageSize },
@@ -200,11 +207,11 @@ describe('Integration | Infrastructure | Utils | Knex utils', function () {
         // given
         const pageNumber = 1;
         const total = DEFAULT_PAGINATION.PAGE_SIZE + 1;
-        _.times(total, (index) => databaseBuilder.factory.buildCampaign({ name: `c-${index}` }));
-        await databaseBuilder.commit();
+        const rows = Array.from({ length: total }, (_, index) => ({ key: `key-${index}` }));
+        await knex('fetch_page_test').insert(rows);
 
         // when
-        const query = knex.select('name').from('campaigns');
+        const query = knex.select('key').from('fetch_page_test');
         const { results, pagination } = await fetchPage({
           queryBuilder: query,
           paginationParams: { number: pageNumber },
@@ -222,11 +229,11 @@ describe('Integration | Infrastructure | Utils | Knex utils', function () {
         const pageNumber = 1;
         const pageSize = 3;
         const total = 5;
-        _.times(total, (index) => databaseBuilder.factory.buildCampaign({ name: `c-${index}` }));
-        await databaseBuilder.commit();
+        const rows = Array.from({ length: total }, (_, index) => ({ key: `key-${index}` }));
+        await knex('fetch_page_test').insert(rows);
 
         // when
-        const query = knex.select('name').from('campaigns');
+        const query = knex.select('key').from('fetch_page_test');
         const { results, pagination } = await fetchPage({
           queryBuilder: query,
           paginationParams: { number: pageNumber, size: pageSize },
@@ -242,11 +249,11 @@ describe('Integration | Infrastructure | Utils | Knex utils', function () {
         const pageNumber = 100000;
         const pageSize = 2;
         const total = 3;
-        _.times(total, (index) => databaseBuilder.factory.buildCampaign({ name: `c-${index}` }));
-        await databaseBuilder.commit();
+        const rows = Array.from({ length: total }, (_, index) => ({ key: `key-${index}` }));
+        await knex('fetch_page_test').insert(rows);
 
         // when
-        const query = knex.select('name').from('campaigns');
+        const query = knex.select('key').from('fetch_page_test');
         const { results, pagination } = await fetchPage({
           queryBuilder: query,
           paginationParams: { number: pageNumber, size: pageSize },
@@ -264,11 +271,11 @@ describe('Integration | Infrastructure | Utils | Knex utils', function () {
         const pageNumber = 1;
         const pageSize = 2;
         const total = 10;
-        _.times(total, (index) => databaseBuilder.factory.buildCampaign({ name: `c-${index}` }));
-        await databaseBuilder.commit();
+        const rows = Array.from({ length: total }, (_, index) => ({ key: `key-${index}` }));
+        await knex('fetch_page_test').insert(rows);
 
         // when
-        const query = knex.select('name').from('campaigns');
+        const query = knex.select('key').from('fetch_page_test');
         const { results, pagination } = await fetchPage({
           queryBuilder: query,
           paginationParams: { number: pageNumber, size: pageSize },
@@ -284,11 +291,11 @@ describe('Integration | Infrastructure | Utils | Knex utils', function () {
         const pageNumber = 1;
         const pageSize = 2;
         const total = 3;
-        _.times(total, (index) => databaseBuilder.factory.buildCampaign({ name: `c-${index}` }));
-        await databaseBuilder.commit();
+        const rows = Array.from({ length: total }, (_, index) => ({ key: `key-${index}` }));
+        await knex('fetch_page_test').insert(rows);
 
         // when
-        const query = knex.select('name').from('campaigns');
+        const query = knex.select('key').from('fetch_page_test');
         const { results, pagination } = await fetchPage({
           queryBuilder: query,
           paginationParams: { number: pageNumber, size: pageSize },
@@ -304,11 +311,11 @@ describe('Integration | Infrastructure | Utils | Knex utils', function () {
         const pageNumber = 100000;
         const pageSize = 2;
         const total = 3;
-        _.times(total, (index) => databaseBuilder.factory.buildCampaign({ name: `c-${index}` }));
-        await databaseBuilder.commit();
+        const rows = Array.from({ length: total }, (_, index) => ({ key: `key-${index}` }));
+        await knex('fetch_page_test').insert(rows);
 
         // when
-        const query = knex.select('name').from('campaigns');
+        const query = knex.select('key').from('fetch_page_test');
         const { results, pagination } = await fetchPage({
           queryBuilder: query,
           paginationParams: { number: pageNumber, size: pageSize },
@@ -323,48 +330,32 @@ describe('Integration | Infrastructure | Utils | Knex utils', function () {
     context('transaction compliant', function () {
       it('should use the transaction given in parameters', async function () {
         // given
-        _.times(10, (index) => databaseBuilder.factory.buildFeature({ key: `feature-${index}` }));
-        await databaseBuilder.commit();
+        const rows = Array.from({ length: 10 }, (_, index) => ({ key: `key-${index}` }));
+        await knex('fetch_page_test').insert(rows);
         let hasReachedEndOfTest = false;
         try {
           await DomainTransaction.execute(async () => {
             // inserting rows within transaction
             const knexConn = DomainTransaction.getConnection();
-            await knexConn('features').insert([
-              {
-                key: 'z_autreFeature1TRX',
-              },
-              {
-                key: 'z_autreFeature2TRX',
-              },
-              {
-                key: 'z_autreFeature3TRX',
-              },
+            await knexConn('fetch_page_test').insert([
+              { key: 'z_key1TRX' },
+              { key: 'z_key2TRX' },
+              { key: 'z_key3TRX' },
             ]);
             // inserting rows outside of the transaction
-            await knex('features').insert([
-              {
-                key: 'z_autreFeature1',
-              },
-              {
-                key: 'z_autreFeature2',
-              },
-              {
-                key: 'z_autreFeature3',
-              },
-            ]);
+            await knex('fetch_page_test').insert([{ key: 'z_key1' }, { key: 'z_key2' }, { key: 'z_key3' }]);
 
             // when
             const { results: resultsInTrx, pagination: paginationInTrx } = await fetchPage({
-              queryBuilder: knex.select('key').from('features').orderBy('key'),
+              queryBuilder: knex.select('key').from('fetch_page_test').orderBy('key'),
               paginationParams: { number: 3, size: 5 },
             });
             expect(resultsInTrx, 'results within the transaction').to.deep.equal([
-              { key: 'z_autreFeature1' },
-              { key: 'z_autreFeature1TRX' },
-              { key: 'z_autreFeature2' },
-              { key: 'z_autreFeature2TRX' },
-              { key: 'z_autreFeature3' },
+              { key: 'z_key1' },
+              { key: 'z_key1TRX' },
+              { key: 'z_key2' },
+              { key: 'z_key2TRX' },
+              { key: 'z_key3' },
             ]);
             expect(paginationInTrx).to.deep.equal({
               page: 3,
@@ -381,13 +372,13 @@ describe('Integration | Infrastructure | Utils | Knex utils', function () {
           }
           // when
           const { results, pagination } = await fetchPage({
-            queryBuilder: knex.select('key').from('features').orderBy('key'),
+            queryBuilder: knex.select('key').from('fetch_page_test').orderBy('key'),
             paginationParams: { number: 3, size: 5 },
           });
           expect(results, 'results outside the rollbacked transaction').to.deep.equal([
-            { key: 'z_autreFeature1' },
-            { key: 'z_autreFeature2' },
-            { key: 'z_autreFeature3' },
+            { key: 'z_key1' },
+            { key: 'z_key2' },
+            { key: 'z_key3' },
           ]);
           expect(pagination).to.deep.equal({
             page: 3,
@@ -401,16 +392,13 @@ describe('Integration | Infrastructure | Utils | Knex utils', function () {
 
     context('custom count query builder', function () {
       it('should use the custom query builder to count rows', async function () {
-        // Deliberately dumb request
-        // Asking for features, but returning the count of organizations
         // given
-        _.times(10, (index) => databaseBuilder.factory.buildFeature({ key: `feature-${index}` }));
-        _.times(20, (index) => databaseBuilder.factory.buildOrganization({ name: `orga-${index}` }));
-        await databaseBuilder.commit();
+        const rows = Array.from({ length: 20 }, (_, index) => ({ key: `key-${index}` }));
+        await knex('fetch_page_test').insert(rows);
 
         // when
-        const query = knex.select('key').from('features').orderBy('key');
-        const countQuery = knex('organizations').count('*', { as: 'row_count' });
+        const query = knex.select('key').from('fetch_page_test').where('key', 'like', 'key-1%').orderBy('key');
+        const countQuery = knex('fetch_page_test').count('*', { as: 'row_count' });
         const { results, pagination } = await fetchPage({
           queryBuilder: query,
           paginationParams: { number: 1, size: 5 },
@@ -419,11 +407,11 @@ describe('Integration | Infrastructure | Utils | Knex utils', function () {
 
         // then
         expect(results).to.deep.equal([
-          { key: 'feature-0' },
-          { key: 'feature-1' },
-          { key: 'feature-2' },
-          { key: 'feature-3' },
-          { key: 'feature-4' },
+          { key: 'key-1' },
+          { key: 'key-10' },
+          { key: 'key-11' },
+          { key: 'key-12' },
+          { key: 'key-13' },
         ]);
         expect(pagination).to.deep.equal({
           page: 1,
@@ -436,59 +424,46 @@ describe('Integration | Infrastructure | Utils | Knex utils', function () {
 
     context('transaction + custom count query builder', function () {
       it('should use the transaction given in parameters also for the custom count query builder', async function () {
-        // Deliberately dumb request
-        // Asking for features, but returning the count of attestations
         // given
-        _.times(5, (index) => databaseBuilder.factory.buildFeature({ key: `feature-${index}` }));
-        _.times(10, (index) => databaseBuilder.factory.buildAttestation({ key: `attestation-${index}` }));
-        await databaseBuilder.commit();
+        const queryRows = Array.from({ length: 5 }, (_, index) => ({ key: `query-${index}` }));
+        const countRows = Array.from({ length: 10 }, (_, index) => ({ key: `count-${index}` }));
+        await knex('fetch_page_test').insert([...queryRows, ...countRows]);
         let hasReachedEndOfTest = false;
         try {
           await DomainTransaction.execute(async () => {
             // add rows within transaction
             const knexConn = DomainTransaction.getConnection();
-            await knexConn('features').insert([
-              {
-                key: 'z_autreFeature1TRX',
-              },
-            ]);
-            await knexConn('attestations').insert([
-              {
-                key: 'z_autreAttestation1TRX',
-              },
-            ]);
+            await knexConn('fetch_page_test').insert([{ key: 'z_query1TRX' }]);
+            await knexConn('fetch_page_test').insert([{ key: 'count-TRX' }]);
             // add rows outside transaction
-            await knex('features').insert([
-              {
-                key: 'z_autreFeature1',
-              },
+            await knex('fetch_page_test').insert([{ key: 'z_query1' }]);
+            await knex('fetch_page_test').insert([
+              { key: 'count-outside1' },
+              { key: 'count-outside2' },
+              { key: 'count-outside3' },
             ]);
-            await knex('attestations').insert([
-              {
-                key: 'z_autreAttestation1',
-              },
-              {
-                key: 'z_autreAttestation2',
-              },
-              {
-                key: 'z_autreAttestation3',
-              },
-            ]);
-            const queryInTrx = knex.select('key').from('features').orderBy('key');
-            const countQueryBuilderInTrx = knex('attestations').count('*', { as: 'row_count' });
+            const queryInTrx = knex
+              .select('key')
+              .from('fetch_page_test')
+              .where('key', 'like', 'query-%')
+              .orWhere('key', 'like', 'z_query%')
+              .orderBy('key');
+            const countQueryBuilderInTrx = knex('fetch_page_test')
+              .where('key', 'like', 'count-%')
+              .count('*', { as: 'row_count' });
             const { results: resultsInTrx, pagination: paginationInTrx } = await fetchPage({
               queryBuilder: queryInTrx,
               paginationParams: { number: 2, size: 5 },
               countQueryBuilder: countQueryBuilderInTrx,
             });
             expect(resultsInTrx, 'results within the transaction for page 2').to.deep.equal([
-              { key: 'z_autreFeature1' },
-              { key: 'z_autreFeature1TRX' },
+              { key: 'z_query1' },
+              { key: 'z_query1TRX' },
             ]);
             expect(paginationInTrx).to.deep.equal({
               page: 2,
               pageSize: 5,
-              rowCount: 14, // attestations count in trx
+              rowCount: 14, // count-0..9 + count-TRX + count-outside1..3
               pageCount: 3,
             });
             hasReachedEndOfTest = true;
@@ -498,20 +473,23 @@ describe('Integration | Infrastructure | Utils | Knex utils', function () {
           if (!hasReachedEndOfTest) {
             throw err;
           }
-          const query = knex.select('key').from('features').orderBy('key');
-          const countQuery = knex('attestations').count('*', { as: 'row_count' });
+          const query = knex
+            .select('key')
+            .from('fetch_page_test')
+            .where('key', 'like', 'query-%')
+            .orWhere('key', 'like', 'z_query%')
+            .orderBy('key');
+          const countQuery = knex('fetch_page_test').where('key', 'like', 'count-%').count('*', { as: 'row_count' });
           const { results, pagination } = await fetchPage({
             queryBuilder: query,
             paginationParams: { number: 2, size: 5 },
             countQueryBuilder: countQuery,
           });
-          expect(results, 'results outside the rollbacked transaction for page 2').to.deep.equal([
-            { key: 'z_autreFeature1' },
-          ]);
+          expect(results, 'results outside the rollbacked transaction for page 2').to.deep.equal([{ key: 'z_query1' }]);
           expect(pagination).to.deep.equal({
             page: 2,
             pageSize: 5,
-            rowCount: 13, // attestations count in trx
+            rowCount: 13, // count-0..9 + count-outside1..3
             pageCount: 3,
           });
         }

--- a/orga/app/adapters/attestation.js
+++ b/orga/app/adapters/attestation.js
@@ -1,0 +1,8 @@
+import ApplicationAdapter from './application';
+
+export default class AttestationAdapter extends ApplicationAdapter {
+  urlForFindAll(_, { adapterOptions }) {
+    const { organizationId } = adapterOptions;
+    return `${this.host}/${this.namespace}/organizations/${organizationId}/attestations`;
+  }
+}

--- a/orga/app/components/attestations.gjs
+++ b/orga/app/components/attestations.gjs
@@ -21,23 +21,19 @@ export default class Attestations extends Component {
 
   get displaySixthGrade() {
     return (
-      this.currentUser.prescriber.availableAttestations.includes(SIXTH_GRADE_ATTESTATION_KEY) &&
+      this.args.availableAttestations.some((attestation) => attestation.key === SIXTH_GRADE_ATTESTATION_KEY) &&
       this.args.divisions != undefined
     );
   }
 
-  get attestationName() {
-    return this.intl.t('pages.attestations.' + this.args.attestationKey);
-  }
-
   get availableAttestations() {
     if (this.displaySixthGrade) {
-      const attestations = this.currentUser.prescriber.availableAttestations.filter(
-        (attestation) => attestation != SIXTH_GRADE_ATTESTATION_KEY,
+      const attestations = this.args.availableAttestations.filter(
+        (attestation) => attestation.key != SIXTH_GRADE_ATTESTATION_KEY,
       );
       return attestations;
     }
-    return this.currentUser.prescriber.availableAttestations;
+    return this.args.availableAttestations;
   }
 
   get displayAttestations() {
@@ -65,7 +61,7 @@ export default class Attestations extends Component {
       {{#if this.displayAttestations}}
         <OtherAttestations
           @attestations={{this.availableAttestations}}
-          @selectedAttestation={{@attestationKey}}
+          @selectedAttestation={{@currentAttestation.key}}
           @onFilter={{@onFilter}}
           @onSubmit={{@onSubmit}}
         />
@@ -74,7 +70,7 @@ export default class Attestations extends Component {
 
     <section class="attestation-page__list">
       <h2 class="attestations-page__section-title attestations-page__section-title--list">
-        {{t "pages.attestations.section.list" attestationName=this.attestationName}}
+        {{t "pages.attestations.section.list" attestationName=@currentAttestation.label}}
       </h2>
       <List
         @participantStatuses={{@participantStatuses}}
@@ -94,8 +90,8 @@ class OtherAttestations extends Component {
 
   get options() {
     return this.args.attestations.map((attestation) => ({
-      value: attestation,
-      label: this.intl.t('pages.attestations.' + attestation),
+      value: attestation.key,
+      label: attestation.label,
     }));
   }
 

--- a/orga/app/models/attestation-participant-status.js
+++ b/orga/app/models/attestation-participant-status.js
@@ -5,4 +5,5 @@ export default class AttestationParticipantStatus extends Model {
   @attr('string') lastName;
   @attr('string') division;
   @attr('date') obtainedAt;
+  @attr('string') attestationKey;
 }

--- a/orga/app/models/attestation.js
+++ b/orga/app/models/attestation.js
@@ -1,0 +1,6 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class Attestations extends Model {
+  @attr('string') label;
+  @attr('string') key;
+}

--- a/orga/app/models/prescriber.js
+++ b/orga/app/models/prescriber.js
@@ -54,10 +54,6 @@ export default class Prescriber extends Model {
     return this.features[Prescriber.featureList.ATTESTATIONS_MANAGEMENT]?.active;
   }
 
-  get availableAttestations() {
-    return this.features[Prescriber.featureList.ATTESTATIONS_MANAGEMENT]?.params ?? [];
-  }
-
   get missionsManagement() {
     return this.features[Prescriber.featureList.MISSIONS_MANAGEMENT]?.active;
   }

--- a/orga/app/routes/authenticated/attestations.js
+++ b/orga/app/routes/authenticated/attestations.js
@@ -35,8 +35,12 @@ export default class AuthenticatedAttestationsRoute extends Route {
   }
 
   async model(params) {
-    const attestationKey = params.attestationKey ?? this.currentUser.prescriber.availableAttestations[0];
     const organizationId = this.currentUser.organization.id;
+
+    const availableAttestations = await this.store.findAll('attestation', { adapterOptions: { organizationId } });
+    const attestationKey = params.attestationKey ?? availableAttestations[0].key;
+    const currentAttestation = availableAttestations.find((attestation) => attestationKey === attestation.key);
+
     const attestationParticipantStatuses = await this.store.query('attestation-participant-status', {
       organizationId,
       attestationKey,
@@ -50,9 +54,6 @@ export default class AuthenticatedAttestationsRoute extends Route {
         size: params.pageSize,
       },
     });
-
-    const availableAttestations = await this.store.findAll('attestation', { adapterOptions: { organizationId } });
-    const currentAttestation = availableAttestations.find((attestation) => attestationKey === attestation.key);
 
     if (this.currentUser.organization.isManagingStudents) {
       const divisions = await this.currentUser.organization.divisions;

--- a/orga/app/routes/authenticated/attestations.js
+++ b/orga/app/routes/authenticated/attestations.js
@@ -51,13 +51,16 @@ export default class AuthenticatedAttestationsRoute extends Route {
       },
     });
 
+    const availableAttestations = await this.store.findAll('attestation', { adapterOptions: { organizationId } });
+    const currentAttestation = availableAttestations.find((attestation) => attestationKey === attestation.key);
+
     if (this.currentUser.organization.isManagingStudents) {
       const divisions = await this.currentUser.organization.divisions;
       const options = divisions.map(({ name }) => ({ label: name, value: name }));
-      return { options, attestationParticipantStatuses, attestationKey };
+      return { options, attestationParticipantStatuses, currentAttestation, availableAttestations };
     }
 
-    return { attestationParticipantStatuses, attestationKey };
+    return { attestationParticipantStatuses, currentAttestation, availableAttestations };
   }
 
   resetController(controller, isExiting) {

--- a/orga/app/templates/authenticated/attestations.gjs
+++ b/orga/app/templates/authenticated/attestations.gjs
@@ -6,7 +6,7 @@ import Attestations from 'pix-orga/components/attestations';
 
   <div class="attestations-page">
     <Attestations
-      @attestationKey={{@model.attestationKey}}
+      @currentAttestation={{@model.currentAttestation}}
       @participantStatuses={{@model.attestationParticipantStatuses}}
       @divisions={{@model.options}}
       @onSubmit={{@controller.downloadAttestations}}
@@ -15,6 +15,7 @@ import Attestations from 'pix-orga/components/attestations';
       @searchFilter={{@controller.search}}
       @statusesFilter={{@controller.statuses}}
       @divisionsFilter={{@controller.divisions}}
+      @availableAttestations={{@model.availableAttestations}}
     />
   </div>
 </template>

--- a/orga/tests/acceptance/attestations-test.js
+++ b/orga/tests/acceptance/attestations-test.js
@@ -10,6 +10,8 @@ import setupIntl from '../helpers/setup-intl';
 import { createPrescriberByUser, createUserManagingStudents } from '../helpers/test-init';
 
 module('Acceptance | Attestations', function (hooks) {
+  let prescriber;
+
   setupApplicationTest(hooks);
   setupMirage(hooks);
   setupIntl(hooks);
@@ -34,27 +36,31 @@ module('Acceptance | Attestations', function (hooks) {
         name: '5eme',
       });
       server.create('member-identity', { id: user.id, firstName: user.firstName, lastName: user.lastName });
+      server.create('attestation', {
+        label: '6eme',
+        key: 'SIXTH_GRADE',
+      });
       server.create('attestation-participant-status', {
         firstName: 'Jean',
         lastName: 'LastName1',
         obtainedAt: null,
         division: '6eme',
+        attestationKey: 'SIXTH_GRADE',
       });
       server.create('attestation-participant-status', {
         firstName: 'Eude',
         lastName: 'LastName2',
         obtainedAt: '2024-01-01',
         division: '5eme',
+        attestationKey: 'SIXTH_GRADE',
       });
-      const prescriber = createPrescriberByUser({ user });
+      prescriber = createPrescriberByUser({ user });
       prescriber.features = {
         ...prescriber.features,
         ATTESTATIONS_MANAGEMENT: { active: true, params: ['SIXTH_GRADE'] },
       };
       await authenticateSession(user.id);
     });
-
-    hooks.afterEach(function () {});
 
     test('it should be accessible for an authenticated prescriber', async function (assert) {
       // when
@@ -135,6 +141,37 @@ module('Acceptance | Attestations', function (hooks) {
         // then
         assert.ok(screen.getByRole('cell', { name: 'Jean' }));
         assert.notOk(screen.queryByRole('cell', { name: 'Eude' }));
+      });
+
+      test('should be possible to filter by attestation name', async function (assert) {
+        // given
+        prescriber.features.ATTESTATIONS_MANAGEMENT = {
+          active: true,
+          params: ['SIXTH_GRADE', 'ATTESTATION_KEY_1'],
+        };
+        server.create('attestation', {
+          label: 'Label attestation',
+          key: 'ATTESTATION_KEY_1',
+        });
+        server.create('attestation-participant-status', {
+          firstName: 'Claude',
+          lastName: 'LastName2',
+          obtainedAt: '2024-01-01',
+          division: '5eme',
+          attestationKey: 'ATTESTATION_KEY_1',
+        });
+        const screen = await visit('/attestations');
+
+        // when
+        await click(screen.getByLabelText(t('pages.attestations.select-label')));
+
+        await screen.findByRole('listbox');
+
+        await click(screen.getByRole('option', { name: 'Label attestation' }));
+
+        // then
+        assert.notOk(screen.queryByRole('cell', { name: 'Jean' }));
+        assert.ok(screen.getByRole('cell', { name: 'Claude' }));
       });
 
       module('when prescriber click on reset filters', function () {

--- a/orga/tests/integration/components/attestations_test.gjs
+++ b/orga/tests/integration/components/attestations_test.gjs
@@ -1,5 +1,4 @@
 import { render } from '@1024pix/ember-testing-library';
-import Service from '@ember/service';
 import { click } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import Attestations, {
@@ -13,26 +12,29 @@ import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 
 module('Integration | Component | Attestations', function (hooks) {
   setupIntlRenderingTest(hooks);
-
-  hooks.beforeEach(function () {
-    class CurrentUserStub extends Service {
-      prescriber = { availableAttestations: [SIXTH_GRADE_ATTESTATION_KEY] };
-    }
-
-    this.owner.register('service:current-user', CurrentUserStub);
-  });
+  const availableAttestations = [{ key: SIXTH_GRADE_ATTESTATION_KEY, label: '6ème' }];
 
   module('when organization has divisions, SIXTH_GRADE attestation and another attestation', function () {
     test('it displays both way to download attestations', async function (assert) {
       // given
       const noop = sinon.stub();
-      const currentUser = this.owner.lookup('service:current-user');
-      currentUser.prescriber.availableAttestations = [SIXTH_GRADE_ATTESTATION_KEY, PARENTHOOD_ATTESTATION_KEY];
+      const availableAttestations2 = [
+        { key: SIXTH_GRADE_ATTESTATION_KEY, label: '6ème' },
+        { key: PARENTHOOD_ATTESTATION_KEY, label: 'Parentalité' },
+      ];
+
       const divisions = [];
 
       // when
       const screen = await render(
-        <template><Attestations @divisions={{divisions}} @onSubmit={{noop}} @onFilter={{noop}} /></template>,
+        <template>
+          <Attestations
+            @divisions={{divisions}}
+            @onSubmit={{noop}}
+            @onFilter={{noop}}
+            @availableAttestations={{availableAttestations2}}
+          />
+        </template>,
       );
 
       // then
@@ -49,7 +51,14 @@ module('Integration | Component | Attestations', function (hooks) {
 
       // when
       const screen = await render(
-        <template><Attestations @divisions={{divisions}} @onSubmit={{onSubmit}} @onFilter={{noop}} /></template>,
+        <template>
+          <Attestations
+            @divisions={{divisions}}
+            @onSubmit={{onSubmit}}
+            @onFilter={{noop}}
+            @availableAttestations={{availableAttestations}}
+          />
+        </template>,
       );
 
       // then
@@ -65,7 +74,14 @@ module('Integration | Component | Attestations', function (hooks) {
 
       // when
       const screen = await render(
-        <template><Attestations @divisions={{divisions}} @onSubmit={{noop}} @onFilter={{noop}} /></template>,
+        <template>
+          <Attestations
+            @divisions={{divisions}}
+            @onSubmit={{noop}}
+            @onFilter={{noop}}
+            @availableAttestations={{availableAttestations}}
+          />
+        </template>,
       );
 
       // then
@@ -84,7 +100,14 @@ module('Integration | Component | Attestations', function (hooks) {
 
       // when
       const screen = await render(
-        <template><Attestations @divisions={{divisions}} @onSubmit={{onSubmit}} @onFilter={{noop}} /></template>,
+        <template>
+          <Attestations
+            @divisions={{divisions}}
+            @onSubmit={{onSubmit}}
+            @onFilter={{noop}}
+            @availableAttestations={{availableAttestations}}
+          />
+        </template>,
       );
 
       const multiSelect = await screen.getByRole('button', { name: t('pages.attestations.select-divisions-label') });
@@ -114,7 +137,14 @@ module('Integration | Component | Attestations', function (hooks) {
       // when
 
       const screen = await render(
-        <template><Attestations @divisions={{divisions}} @onSubmit={{noop}} @onFilter={{noop}} /></template>,
+        <template>
+          <Attestations
+            @divisions={{divisions}}
+            @onSubmit={{noop}}
+            @onFilter={{noop}}
+            @availableAttestations={{availableAttestations}}
+          />
+        </template>,
       );
       // then
       assert.notOk(screen.queryByRole('button', { name: t('pages.attestations.select-divisions-label') }));
@@ -128,6 +158,7 @@ module('Integration | Component | Attestations', function (hooks) {
       // given
       const noop = sinon.stub();
       const onSubmit = sinon.stub();
+      const currentAttestation = { label: '6ème', key: SIXTH_GRADE_ATTESTATION_KEY };
 
       const divisions = undefined;
 
@@ -135,10 +166,11 @@ module('Integration | Component | Attestations', function (hooks) {
       const screen = await render(
         <template>
           <Attestations
-            @attestationKey={{SIXTH_GRADE_ATTESTATION_KEY}}
+            @currentAttestation={{currentAttestation}}
             @divisions={{divisions}}
             @onSubmit={{onSubmit}}
             @onFilter={{noop}}
+            @availableAttestations={{availableAttestations}}
           />
         </template>,
       );
@@ -150,9 +182,7 @@ module('Integration | Component | Attestations', function (hooks) {
       const select = await screen.getByLabelText(t('pages.attestations.select-label'));
       await click(select);
 
-      const firstOption = await screen.findByRole('option', {
-        name: t('pages.attestations.' + SIXTH_GRADE_ATTESTATION_KEY),
-      });
+      const firstOption = await screen.findByRole('option', { name: '6ème' });
       await click(firstOption);
 
       await click(downloadButton);

--- a/orga/tests/mirage/models.js
+++ b/orga/tests/mirage/models.js
@@ -6,6 +6,7 @@ export default {
   area: Model.extend({
     competences: hasMany('competence'),
   }),
+  attestation: Model.extend(),
   attestationParticipantStatus: Model.extend(),
   availableCampaignParticipation: Model.extend(),
   badge: Model.extend(),

--- a/orga/tests/mirage/routes.js
+++ b/orga/tests/mirage/routes.js
@@ -598,6 +598,8 @@ export default function routes() {
         match = match && (learner.firstName.includes(search) || learner.lastName.includes(search));
       }
 
+      match = match && learner.attestationKey === request.params.attestationKey;
+
       return match;
     }).models;
 
@@ -619,6 +621,10 @@ export default function routes() {
 
   this.patch('/organizations/:organizationId/organization-learners/:learnerId', function () {
     return new Response(204);
+  });
+
+  this.get('/organizations/:organizationId/attestations', function (schema) {
+    return schema.attestations.all();
   });
 
   this.get('/organizations/:organizationId/place-statistics', function (schema, request) {

--- a/orga/tests/unit/models/prescriber-test.js
+++ b/orga/tests/unit/models/prescriber-test.js
@@ -301,48 +301,4 @@ module('Unit | Model | prescriber', function (hooks) {
       assert.false(hasCoverRateFeature);
     });
   });
-
-  module('#availableAttestations', function () {
-    test('it returns attestation keys when feature is enabled', function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const model = store.createRecord('prescriber', {
-        features: { ['ATTESTATIONS_MANAGEMENT']: { active: true, params: ['SIXTH_GRADE', 'PARENTHOOD'] } },
-      });
-
-      // when
-      const { availableAttestations } = model;
-
-      // then
-      assert.deepEqual(availableAttestations, ['SIXTH_GRADE', 'PARENTHOOD']);
-    });
-
-    test('it returns empty array when feature is disabled', function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const model = store.createRecord('prescriber', {
-        features: { ['ATTESTATIONS_MANAGEMENT']: { active: false, params: null } },
-      });
-
-      // when
-      const { availableAttestations } = model;
-
-      // then
-      assert.deepEqual(availableAttestations, []);
-    });
-
-    test('it returns empty array when feature is not present', function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const model = store.createRecord('prescriber', {
-        features: {},
-      });
-
-      // when
-      const { availableAttestations } = model;
-
-      // then
-      assert.deepEqual(availableAttestations, []);
-    });
-  });
 });

--- a/orga/tests/unit/routes/authenticated/attestations-test.js
+++ b/orga/tests/unit/routes/authenticated/attestations-test.js
@@ -54,6 +54,7 @@ module('Unit | Route | authenticated/attestations', function (hooks) {
       // given
       const divisions = [{ name: '3èmeA' }, { name: '2ndE' }];
       const attestationParticipantStatuses = Symbol('expected-attestations');
+      const attestations = [{ label: 'attestation 1', key: 'MY_KEY' }];
       class CurrentUserStub extends Service {
         canAccessAttestationsPage = true;
         organization = {
@@ -68,12 +69,15 @@ module('Unit | Route | authenticated/attestations', function (hooks) {
 
       const findRecordStub = sinon.stub();
       const queryStub = sinon.stub();
+      const findAllStub = sinon.stub();
       class StoreStub extends Service {
         findRecord = findRecordStub;
         query = queryStub;
+        findAll = findAllStub;
       }
 
       queryStub.resolves(attestationParticipantStatuses);
+      findAllStub.resolves(attestations);
 
       this.owner.register('service:current-user', CurrentUserStub);
       this.owner.register('service:store', StoreStub);
@@ -86,7 +90,8 @@ module('Unit | Route | authenticated/attestations', function (hooks) {
       // then
       assert.deepEqual(actualOptions, {
         attestationParticipantStatuses,
-        attestationKey: 'MY_KEY',
+        availableAttestations: attestations,
+        currentAttestation: { key: 'MY_KEY', label: 'attestation 1' },
         options: [
           {
             label: '3èmeA',
@@ -104,6 +109,11 @@ module('Unit | Route | authenticated/attestations', function (hooks) {
       // given
       const divisions = [{ name: '3èmeA' }, { name: '2ndE' }];
       const attestationParticipantStatuses = Symbol('expected-attestations');
+      const attestations = [
+        { label: 'attestation 1', key: 'MY_KEY' },
+        { label: 'attestation 2', key: 'MY_OTHER_KEY' },
+      ];
+
       class CurrentUserStub extends Service {
         canAccessAttestationsPage = true;
         organization = {
@@ -118,12 +128,15 @@ module('Unit | Route | authenticated/attestations', function (hooks) {
 
       const findRecordStub = sinon.stub();
       const queryRecord = sinon.stub();
+      const findAllStub = sinon.stub();
       class StoreStub extends Service {
         findRecord = findRecordStub;
         query = queryRecord;
+        findAll = findAllStub;
       }
 
       queryRecord.resolves(attestationParticipantStatuses);
+      findAllStub.resolves(attestations);
 
       this.owner.register('service:current-user', CurrentUserStub);
       this.owner.register('service:store', StoreStub);
@@ -134,13 +147,21 @@ module('Unit | Route | authenticated/attestations', function (hooks) {
       const actualOptions = await route.model({ statuses: [] });
 
       // then
-      assert.deepEqual(actualOptions, { attestationParticipantStatuses, attestationKey: 'MY_OTHER_KEY' });
+      assert.deepEqual(actualOptions, {
+        attestationParticipantStatuses,
+        availableAttestations: attestations,
+        currentAttestation: { key: 'MY_OTHER_KEY', label: 'attestation 2' },
+      });
     });
 
     test('it should call the store with the first available attestation key', async function (assert) {
       // given
       const divisions = [{ name: '3èmeA' }, { name: '2ndE' }];
       const attestationParticipantStatuses = Symbol('expected-attestations');
+      const attestations = [
+        { label: 'attestation 1', key: 'MY_KEY' },
+        { label: 'attestation 2', key: 'MY_OTHER_KEY' },
+      ];
       class CurrentUserStub extends Service {
         canAccessAttestationsPage = true;
         organization = {
@@ -155,12 +176,15 @@ module('Unit | Route | authenticated/attestations', function (hooks) {
 
       const findRecordStub = sinon.stub();
       const queryRecord = sinon.stub();
+      const findAllStub = sinon.stub();
       class StoreStub extends Service {
         findRecord = findRecordStub;
         query = queryRecord;
+        findAll = findAllStub;
       }
 
       queryRecord.resolves(attestationParticipantStatuses);
+      findAllStub.resolves(attestations);
 
       this.owner.register('service:current-user', CurrentUserStub);
       this.owner.register('service:store', StoreStub);
@@ -192,6 +216,10 @@ module('Unit | Route | authenticated/attestations', function (hooks) {
       // given
       const divisions = [{ name: '3èmeA' }, { name: '2ndE' }];
       const attestationParticipantStatuses = Symbol('expected-attestations');
+      const attestations = [
+        { label: 'attestation 1', key: 'MY_KEY' },
+        { label: 'attestation 2', key: 'MY_OTHER_KEY' },
+      ];
       class CurrentUserStub extends Service {
         canAccessAttestationsPage = true;
         organization = {
@@ -206,12 +234,15 @@ module('Unit | Route | authenticated/attestations', function (hooks) {
 
       const findRecordStub = sinon.stub();
       const queryRecord = sinon.stub();
+      const findAllStub = sinon.stub();
       class StoreStub extends Service {
         findRecord = findRecordStub;
         query = queryRecord;
+        findAll = findAllStub;
       }
 
       queryRecord.resolves(attestationParticipantStatuses);
+      findAllStub.resolves(attestations);
 
       this.owner.register('service:current-user', CurrentUserStub);
       this.owner.register('service:store', StoreStub);

--- a/orga/tests/unit/routes/authenticated/attestations-test.js
+++ b/orga/tests/unit/routes/authenticated/attestations-test.js
@@ -30,9 +30,6 @@ module('Unit | Route | authenticated/attestations', function (hooks) {
       // given
       class CurrentUserStub extends Service {
         canAccessAttestationsPage = true;
-        prescriber = {
-          availableAttestations: [],
-        };
       }
 
       this.owner.register('service:current-user', CurrentUserStub);
@@ -61,9 +58,6 @@ module('Unit | Route | authenticated/attestations', function (hooks) {
           id: 12345,
           divisions,
           isManagingStudents: true,
-        };
-        prescriber = {
-          availableAttestations: ['MY_KEY'],
         };
       }
 
@@ -121,14 +115,11 @@ module('Unit | Route | authenticated/attestations', function (hooks) {
           divisions,
           isManagingStudents: false,
         };
-        prescriber = {
-          availableAttestations: ['MY_OTHER_KEY', 'MY_KEY'],
-        };
       }
 
       const findRecordStub = sinon.stub();
       const queryRecord = sinon.stub();
-      const findAllStub = sinon.stub();
+      const findAllStub = sinon.stub().resolves(attestations);
       class StoreStub extends Service {
         findRecord = findRecordStub;
         query = queryRecord;
@@ -150,7 +141,19 @@ module('Unit | Route | authenticated/attestations', function (hooks) {
       assert.deepEqual(actualOptions, {
         attestationParticipantStatuses,
         availableAttestations: attestations,
-        currentAttestation: { key: 'MY_OTHER_KEY', label: 'attestation 2' },
+        currentAttestation: { key: 'MY_KEY', label: 'attestation 1' },
+      });
+      assert.notPropContains(actualOptions, {
+        options: [
+          {
+            label: '3èmeA',
+            value: '3èmeA',
+          },
+          {
+            label: '2ndE',
+            value: '2ndE',
+          },
+        ],
       });
     });
 
@@ -168,9 +171,6 @@ module('Unit | Route | authenticated/attestations', function (hooks) {
           id: 12345,
           divisions,
           isManagingStudents: false,
-        };
-        prescriber = {
-          availableAttestations: ['MY_OTHER_KEY', 'MY_KEY'],
         };
       }
 
@@ -198,7 +198,7 @@ module('Unit | Route | authenticated/attestations', function (hooks) {
       assert.ok(
         queryRecord.calledOnceWithExactly('attestation-participant-status', {
           organizationId: 12345,
-          attestationKey: 'MY_OTHER_KEY',
+          attestationKey: 'MY_KEY',
           filter: {
             statuses: [],
             divisions: undefined,
@@ -212,7 +212,7 @@ module('Unit | Route | authenticated/attestations', function (hooks) {
       );
     });
 
-    test('it should call the store with available params', async function (assert) {
+    test('it should call the attestation-participant-status store with model params in the correct format', async function (assert) {
       // given
       const divisions = [{ name: '3èmeA' }, { name: '2ndE' }];
       const attestationParticipantStatuses = Symbol('expected-attestations');
@@ -226,9 +226,6 @@ module('Unit | Route | authenticated/attestations', function (hooks) {
           id: 12345,
           divisions,
           isManagingStudents: false,
-        };
-        prescriber = {
-          availableAttestations: ['MY_OTHER_KEY', 'MY_KEY'],
         };
       }
 


### PR DESCRIPTION
## 🌱 Problème

Les labels d'attestations proviennent actuellement de traductions en durs dans les fichiers de Pix.
Nous avons ajouté depuis une colonne label dans la table attestation pour permettre une meilleure gestion des attestations.

## 🐣 Proposition

On remplace les traductions par ce champ label partout où c'est utilisé dans le code.

## 🌷 Remarques

On en a profité pour faire un commit de refactor sur le test de l'util fetchPage qui utilisait de vraies tables et à qui on fait créer une table fictive désormais, dans le scope du test.

## 🐝 Pour tester

PixOrga
Aller sur SCO SIECLE -> cliquer sur "Attestations" -> voir qu'on a bien les divisions dans le select.
Aller sur une organisation pro qui a la page Attestations -> voir qu'on a des propositions dans un select avec des labels (comme "Mairie de Paris - Office software fundamentals" ou "Socle numérique"). 
Vérifier qu'on peut bien télécharger lesdites attestations.
Vérifier que les filtres pour les participants sont OK.

PixAdmin
Aller sur la page  de création des schémas de parcours combinés, vérifier qu'on peut rattacher une attestation en sélectionnant son nom.
Aller sur la page "Organisations" -> onglet Fonctionnalités -> essayer d'ajouter une attestation à une organisation.


