### PR TITLE
[TECH] Extraire les chai-custom-helpers de test-helper

### DIFF
--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -12,7 +12,6 @@ import chaiSorted from 'chai-sorted';
 import dayjs from 'dayjs';
 import localizedFormat from 'dayjs/plugin/localizedFormat.js';
 import iconv from 'iconv-lite';
-import _ from 'lodash';
 import MockDate from 'mockdate';
 import nock from 'nock';
 import sinon from 'sinon';
@@ -54,16 +53,17 @@ import { createTempFile, removeTempFile } from './tooling/temporary-file.js';
 
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
 
+// Init Dayjs configuration
 dayjs.extend(localizedFormat);
 
+// Extends Chai helpers
 chaiUse(chaiAsPromised);
 chaiUse(chaiSorted);
 chaiUse(sinonChai);
-
-_.each(customChaiHelpers, chaiUse);
-
 chaiUse(jobChai());
+Object.values(customChaiHelpers).forEach(chaiUse);
 
+// Init Database builders
 const databaseBuilder = await DatabaseBuilder.create({
   knex,
   beforeEmptyDatabase: () => {
@@ -83,8 +83,6 @@ databaseBuilder.factory.learningContent.injectNock(nock);
 nock.disableNetConnect();
 nock.enableNetConnect('localhost:9090');
 const EMPTY_BLANK_AND_NULL = ['', '\t \n', null];
-
-const { ROLES } = PIX_ADMIN;
 
 /* eslint-disable mocha/no-top-level-hooks */
 before(async function () {
@@ -249,7 +247,7 @@ async function insertUserWithRoleCertif() {
     lastName: 'Power',
     email: 'certif.power@example.net',
     password: 'Pix123',
-    role: ROLES.CERTIF,
+    role: PIX_ADMIN.ROLES.CERTIF,
   });
 
   await databaseBuilder.commit();

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -387,14 +387,6 @@ function catchErrSync(fn, ctx) {
 }
 
 chaiUse(function () {
-  Assertion.addMethod('exactlyContainInOrder', function (expectedElements) {
-    const errorMessage = `expect [${this._obj}] to exactly contain in order [${expectedElements}]`;
-
-    new Assertion(this._obj, errorMessage).to.deep.equal(expectedElements);
-  });
-});
-
-chaiUse(function () {
   Assertion.addMethod('equalWithGetter', function (expectedElement) {
     if (Array.isArray(expectedElement)) {
       expectedElement.forEach((element, index) => {

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -6,7 +6,7 @@ import querystring from 'node:querystring';
 import { Readable } from 'node:stream';
 import * as url from 'node:url';
 
-import { Assertion, AssertionError, expect, use as chaiUse, util as chaiUtil } from 'chai';
+import { AssertionError, expect, use as chaiUse, util as chaiUtil } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import chaiSorted from 'chai-sorted';
 import dayjs from 'dayjs';
@@ -385,27 +385,6 @@ function catchErrSync(fn, ctx) {
     throw new Error('Expected an error, but none was thrown.');
   };
 }
-
-chaiUse(function () {
-  Assertion.addMethod('equalWithGetter', function (expectedElement) {
-    if (Array.isArray(expectedElement)) {
-      expectedElement.forEach((element, index) => {
-        expect(this._obj[index]).equalWithGetter(element);
-      });
-    } else {
-      Object.keys(expectedElement).forEach((property) => {
-        if (Array.isArray(expectedElement[property])) {
-          expectedElement[property].forEach((subelement, index) => {
-            expect(this._obj[property][index]).equalWithGetter(subelement);
-          });
-        } else {
-          const errorMessage = `expect ${this._obj} with key ${property} to equal ${expectedElement[property]} (found ${this._obj[property]})`;
-          new Assertion(this._obj[property], errorMessage).to.deep.equal(expectedElement[property]);
-        }
-      });
-    }
-  });
-});
 
 async function mockLearningContent(learningContent) {
   const scope = databaseBuilder.factory.learningContent.build(learningContent);

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -6,7 +6,7 @@ import querystring from 'node:querystring';
 import { Readable } from 'node:stream';
 import * as url from 'node:url';
 
-import { AssertionError, expect, use as chaiUse, util as chaiUtil } from 'chai';
+import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import chaiSorted from 'chai-sorted';
 import dayjs from 'dayjs';
@@ -391,33 +391,6 @@ async function mockLearningContent(learningContent) {
   await databaseBuilder.commit();
   return scope;
 }
-
-// Inspired by what is done within chai project itself to test assertions
-// https://github.com/chaijs/chai/blob/main/test/bootstrap/index.js
-global.chaiErr = function globalErr(fn, val) {
-  if (chaiUtil.type(fn) !== 'Function') throw new AssertionError('Invalid fn');
-
-  try {
-    fn();
-  } catch (err) {
-    switch (chaiUtil.type(val).toLowerCase()) {
-      case 'undefined':
-        return;
-      case 'string':
-        return expect(err.message).to.equal(val);
-      case 'regexp':
-        return expect(err.message).to.match(val);
-      case 'object':
-        return Object.keys(val).forEach(function (key) {
-          expect(err).to.have.property(key).and.to.deep.equal(val[key]);
-        });
-    }
-
-    throw new AssertionError('Invalid val');
-  }
-
-  throw new AssertionError('Expected an error');
-};
 
 function mockAttestationStorage(attestation) {
   const template = fs.createReadStream(path.join(__dirname, 'attestation-template.pdf'));

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -387,13 +387,6 @@ function catchErrSync(fn, ctx) {
 }
 
 chaiUse(function () {
-  Assertion.addMethod('exactlyContain', function (expectedElements) {
-    const errorMessage = `expect [${this._obj}] to exactly contain [${expectedElements}]`;
-    new Assertion(this._obj, errorMessage).to.deep.have.members(expectedElements);
-  });
-});
-
-chaiUse(function () {
   Assertion.addMethod('exactlyContainInOrder', function (expectedElements) {
     const errorMessage = `expect [${this._obj}] to exactly contain in order [${expectedElements}]`;
 

--- a/api/tests/test-helper_test.js
+++ b/api/tests/test-helper_test.js
@@ -43,44 +43,4 @@ describe('Test helpers', function () {
       ).to.deep.equal([obj1, obj2]);
     });
   });
-
-  describe('#equalWithGetter', function () {
-    class A {
-      get name() {
-        return "i'm A";
-      }
-    }
-    class B {
-      get name() {
-        return "i'm B";
-      }
-      get A() {
-        return [new A()];
-      }
-    }
-
-    it('should expect on object', function () {
-      expect({ name: 'ho' }).equalWithGetter({ name: 'ho' });
-    });
-
-    it('should expect on array of object', function () {
-      expect([{ name: 'ho' }]).equalWithGetter([{ name: 'ho' }]);
-    });
-
-    it('should expect on class instance with getter', function () {
-      expect(new A()).equalWithGetter({ name: "i'm A" });
-    });
-
-    it('should expect on array of class instance with getter', function () {
-      expect([new A()]).equalWithGetter([{ name: "i'm A" }]);
-    });
-
-    it('should expect on nested class instance with getter', function () {
-      expect(new B()).equalWithGetter({ name: "i'm B", A: [{ name: "i'm A" }] });
-    });
-
-    it('should expect on array nested class instance with getter', function () {
-      expect([new B()]).equalWithGetter([{ name: "i'm B", A: [{ name: "i'm A" }] }]);
-    });
-  });
 });

--- a/api/tests/tooling/chai-custom-helpers/chai-custom-test-helper.js
+++ b/api/tests/tooling/chai-custom-helpers/chai-custom-test-helper.js
@@ -1,0 +1,30 @@
+import { AssertionError, expect, util } from 'chai';
+
+// Utility used to test Chai custom helpers
+//
+// Inspired by what is done within chai project itself to test assertions
+// https://github.com/chaijs/chai/blob/main/test/bootstrap/index.js
+export function expectChaiError(fn, val) {
+  if (util.type(fn) !== 'Function') throw new AssertionError('Invalid fn');
+
+  try {
+    fn();
+  } catch (err) {
+    switch (util.type(val).toLowerCase()) {
+      case 'undefined':
+        return;
+      case 'string':
+        return expect(err.message).to.equal(val);
+      case 'regexp':
+        return expect(err.message).to.match(val);
+      case 'object':
+        return Object.keys(val).forEach(function (key) {
+          expect(err).to.have.property(key).and.to.deep.equal(val[key]);
+        });
+    }
+
+    throw new AssertionError('Invalid val');
+  }
+
+  throw new AssertionError('Expected an error');
+}

--- a/api/tests/tooling/chai-custom-helpers/equal-with-getter.js
+++ b/api/tests/tooling/chai-custom-helpers/equal-with-getter.js
@@ -1,0 +1,22 @@
+import { Assertion, expect } from 'chai';
+
+export function equalWithGetter() {
+  Assertion.addMethod('equalWithGetter', function (expectedElement) {
+    if (Array.isArray(expectedElement)) {
+      expectedElement.forEach((element, index) => {
+        expect(this._obj[index]).equalWithGetter(element);
+      });
+    } else {
+      Object.keys(expectedElement).forEach((property) => {
+        if (Array.isArray(expectedElement[property])) {
+          expectedElement[property].forEach((subelement, index) => {
+            expect(this._obj[property][index]).equalWithGetter(subelement);
+          });
+        } else {
+          const errorMessage = `expect ${this._obj} with key ${property} to equal ${expectedElement[property]} (found ${this._obj[property]})`;
+          new Assertion(this._obj[property], errorMessage).to.deep.equal(expectedElement[property]);
+        }
+      });
+    }
+  });
+}

--- a/api/tests/tooling/chai-custom-helpers/exactly-contain-in-order.js
+++ b/api/tests/tooling/chai-custom-helpers/exactly-contain-in-order.js
@@ -1,0 +1,8 @@
+import { Assertion } from 'chai';
+
+export function exactlyContainInOrder() {
+  Assertion.addMethod('exactlyContainInOrder', function (expectedElements) {
+    const errorMessage = `expect [${this._obj}] to exactly contain in order [${expectedElements}]`;
+    new Assertion(this._obj, errorMessage).to.deep.equal(expectedElements);
+  });
+}

--- a/api/tests/tooling/chai-custom-helpers/exactly-contain.js
+++ b/api/tests/tooling/chai-custom-helpers/exactly-contain.js
@@ -1,0 +1,8 @@
+import { Assertion } from 'chai';
+
+export function exactlyContain() {
+  Assertion.addMethod('exactlyContain', function (expectedElements) {
+    const errorMessage = `expect [${this._obj}] to exactly contain [${expectedElements}]`;
+    new Assertion(this._obj, errorMessage).to.deep.have.members(expectedElements);
+  });
+}

--- a/api/tests/tooling/chai-custom-helpers/index.js
+++ b/api/tests/tooling/chai-custom-helpers/index.js
@@ -2,5 +2,6 @@ import { deepEqualArray } from './deep-equal-array.js';
 import { deepEqualInstance } from './deep-equal-instance.js';
 import { deepEqualInstanceOmitting } from './deep-equal-instance-omitting.js';
 import { exactlyContain } from './exactly-contain.js';
+import { exactlyContainInOrder } from './exactly-contain-in-order.js';
 
-export { deepEqualArray, deepEqualInstance, deepEqualInstanceOmitting, exactlyContain };
+export { deepEqualArray, deepEqualInstance, deepEqualInstanceOmitting, exactlyContain, exactlyContainInOrder };

--- a/api/tests/tooling/chai-custom-helpers/index.js
+++ b/api/tests/tooling/chai-custom-helpers/index.js
@@ -1,5 +1,6 @@
 import { deepEqualArray } from './deep-equal-array.js';
 import { deepEqualInstance } from './deep-equal-instance.js';
 import { deepEqualInstanceOmitting } from './deep-equal-instance-omitting.js';
+import { exactlyContain } from './exactly-contain.js';
 
-export { deepEqualArray, deepEqualInstance, deepEqualInstanceOmitting };
+export { deepEqualArray, deepEqualInstance, deepEqualInstanceOmitting, exactlyContain };

--- a/api/tests/tooling/chai-custom-helpers/index.js
+++ b/api/tests/tooling/chai-custom-helpers/index.js
@@ -1,7 +1,15 @@
 import { deepEqualArray } from './deep-equal-array.js';
 import { deepEqualInstance } from './deep-equal-instance.js';
 import { deepEqualInstanceOmitting } from './deep-equal-instance-omitting.js';
+import { equalWithGetter } from './equal-with-getter.js';
 import { exactlyContain } from './exactly-contain.js';
 import { exactlyContainInOrder } from './exactly-contain-in-order.js';
 
-export { deepEqualArray, deepEqualInstance, deepEqualInstanceOmitting, exactlyContain, exactlyContainInOrder };
+export {
+  deepEqualArray,
+  deepEqualInstance,
+  deepEqualInstanceOmitting,
+  equalWithGetter,
+  exactlyContain,
+  exactlyContainInOrder,
+};

--- a/api/tests/unit/tooling/chai-custom-helpers/deep-equal-array_test.js
+++ b/api/tests/unit/tooling/chai-custom-helpers/deep-equal-array_test.js
@@ -1,33 +1,34 @@
 import { domainBuilder, expect } from '../../../test-helper.js';
+import { expectChaiError } from '../../../tooling/chai-custom-helpers/chai-custom-test-helper.js';
 
 describe('Unit | chai-custom-helpers | deepEqualArray', function () {
   it('should fail assertion when compared objects are not arrays', function () {
-    global.chaiErr(function () {
+    expectChaiError(function () {
       expect([]).to.deepEqualArray('coucou');
     }, "expected 'String' to equal 'Array'");
-    global.chaiErr(function () {
+    expectChaiError(function () {
       const foo = 'bar';
       expect(foo).to.deepEqualArray([]);
     }, "expected 'String' to equal 'Array'");
   });
 
   it('should fail assertion when compared arrays have not the same length', function () {
-    global.chaiErr(function () {
+    expectChaiError(function () {
       expect([1, 2, 3]).to.deepEqualArray([1, 2]);
     }, 'expected 3 to equal 2');
   });
 
   it('should fail assertion when compared values of array are not of the same instance', function () {
-    global.chaiErr(function () {
+    expectChaiError(function () {
       expect([1]).to.deepEqualArray(['coucou']);
     }, "expected 'Number' to equal 'String'");
-    global.chaiErr(function () {
+    expectChaiError(function () {
       expect([domainBuilder.buildAnswer()]).to.deepEqualArray([domainBuilder.buildUser()]);
     }, "expected 'Answer' to equal 'User'");
   });
 
   it('should fail assertion when compared values of array have not the same content', function () {
-    global.chaiErr(function () {
+    expectChaiError(function () {
       expect([1]).to.deepEqualArray([3]);
     }, 'expected 1 to deeply equal 3');
   });

--- a/api/tests/unit/tooling/chai-custom-helpers/deep-equal-instance-omitting_test.js
+++ b/api/tests/unit/tooling/chai-custom-helpers/deep-equal-instance-omitting_test.js
@@ -1,4 +1,5 @@
 import { domainBuilder, expect } from '../../../test-helper.js';
+import { expectChaiError } from '../../../tooling/chai-custom-helpers/chai-custom-test-helper.js';
 
 describe('Unit | chai-custom-helpers | deepEqualInstanceOmitting', function () {
   it('should fail assertion when both objects are not of the same instance', function () {
@@ -8,10 +9,10 @@ describe('Unit | chai-custom-helpers | deepEqualInstanceOmitting', function () {
     const answerDTO = { ...answer };
 
     // when / then
-    global.chaiErr(function () {
+    expectChaiError(function () {
       expect(campaign).to.deepEqualInstanceOmitting(answer);
     }, "expected 'Campaign' to equal 'Answer'");
-    global.chaiErr(function () {
+    expectChaiError(function () {
       expect(answerDTO).to.deepEqualInstanceOmitting(answer);
     }, "expected 'Object' to equal 'Answer'");
   });
@@ -35,7 +36,7 @@ describe('Unit | chai-custom-helpers | deepEqualInstanceOmitting', function () {
     });
 
     // when/then
-    global.chaiErr(
+    expectChaiError(
       function () {
         expect(otherCompetence).to.deepEqualInstanceOmitting(competence);
       },
@@ -45,7 +46,7 @@ describe('Unit | chai-custom-helpers | deepEqualInstanceOmitting', function () {
         operator: 'deepStrictEqual',
       },
     );
-    global.chaiErr(
+    expectChaiError(
       function () {
         expect(anotherCompetence).to.deepEqualInstanceOmitting(competence);
       },

--- a/api/tests/unit/tooling/chai-custom-helpers/deep-equal-instance_test.js
+++ b/api/tests/unit/tooling/chai-custom-helpers/deep-equal-instance_test.js
@@ -1,4 +1,5 @@
 import { domainBuilder, expect } from '../../../test-helper.js';
+import { expectChaiError } from '../../../tooling/chai-custom-helpers/chai-custom-test-helper.js';
 
 describe('Unit | chai-custom-helpers | deepEqualInstance', function () {
   it('should fail assertion when both objects are not of the same instance', function () {
@@ -8,10 +9,10 @@ describe('Unit | chai-custom-helpers | deepEqualInstance', function () {
     const answerDTO = { ...answer };
 
     // when / then
-    global.chaiErr(function () {
+    expectChaiError(function () {
       expect(campaign).to.deepEqualInstance(answer);
     }, "expected 'Campaign' to equal 'Answer'");
-    global.chaiErr(function () {
+    expectChaiError(function () {
       expect(answerDTO).to.deepEqualInstance(answer);
     }, "expected 'Object' to equal 'Answer'");
   });
@@ -35,7 +36,7 @@ describe('Unit | chai-custom-helpers | deepEqualInstance', function () {
     });
 
     // when/then
-    global.chaiErr(
+    expectChaiError(
       function () {
         expect(otherCompetence).to.deepEqualInstance(competence);
       },
@@ -45,7 +46,7 @@ describe('Unit | chai-custom-helpers | deepEqualInstance', function () {
         operator: 'deepStrictEqual',
       },
     );
-    global.chaiErr(
+    expectChaiError(
       function () {
         expect(anotherCompetence).to.deepEqualInstance(competence);
       },

--- a/api/tests/unit/tooling/chai-custom-helpers/equal-with-getter_test.js
+++ b/api/tests/unit/tooling/chai-custom-helpers/equal-with-getter_test.js
@@ -1,0 +1,41 @@
+import { expect } from '../../../test-helper.js';
+
+describe('Unit | chai-custom-helpers | equalWithGetter', function () {
+  class A {
+    get name() {
+      return "i'm A";
+    }
+  }
+  class B {
+    get name() {
+      return "i'm B";
+    }
+    get A() {
+      return [new A()];
+    }
+  }
+
+  it('should expect on object', function () {
+    expect({ name: 'ho' }).equalWithGetter({ name: 'ho' });
+  });
+
+  it('should expect on array of object', function () {
+    expect([{ name: 'ho' }]).equalWithGetter([{ name: 'ho' }]);
+  });
+
+  it('should expect on class instance with getter', function () {
+    expect(new A()).equalWithGetter({ name: "i'm A" });
+  });
+
+  it('should expect on array of class instance with getter', function () {
+    expect([new A()]).equalWithGetter([{ name: "i'm A" }]);
+  });
+
+  it('should expect on nested class instance with getter', function () {
+    expect(new B()).equalWithGetter({ name: "i'm B", A: [{ name: "i'm A" }] });
+  });
+
+  it('should expect on array nested class instance with getter', function () {
+    expect([new B()]).equalWithGetter([{ name: "i'm B", A: [{ name: "i'm A" }] }]);
+  });
+});


### PR DESCRIPTION
## 🌱 Problème

Le fichier `test-helper.js` est un melting-pot de code. Il mélange différentes responsabilités pour toutes nos typologies de test (unitaires, intégration et acceptance) :
- étendre l'api des assertions chai, sinon...
- initialiser les mocks (hapi, nocks...)
- initialiser les helpers (database builder, knex...)
- initialiser les tests (`before`)
- nettoyer les ressources (`afterEach`, `after`)
- exposer des méthodes utilitaires
- exposer des constantes

Il est nécessaire de revoir ce fichier pour isoler les fonctions utilitaires de l'initialisation des tests. Le but final est d'avoir de chaines d'initialisation différentes entre les tests unitaires, d'intégration et d'acceptance.

## 🐣 Proposition

Cette PR se concentre uniquement sur le code des assertions chai définies dans `test-helper.js` et de les isoler dans le répertoire `api/tests/tooling/chai-custom-helpers`.

## 🌷 Remarques

N/A

## 🐝 Pour tester

La CI doit passer.
