### PR TITLE
[FEATURE] Supprimer "points clés" des tags d'un text-element (pix-22247)

### DIFF
--- a/api/src/devcomp/domain/models/element/Text.js
+++ b/api/src/devcomp/domain/models/element/Text.js
@@ -6,7 +6,6 @@ const TextTagEnumValues = Object.freeze({
   CONTEXT: 'context',
   DID_YOU_KNOW: 'did-you-know',
   FURTHER_INFORMATION: 'further-information',
-  KEY_POINTS: 'key-points',
   TIP: 'tip',
 });
 
@@ -18,7 +17,7 @@ class Text extends Element {
     assertEnumValue(
       TextTagEnumValues,
       tag,
-      "The tag value must be one of: ' ', 'context', 'did-you-know', 'further-information', 'key-points', 'tip'",
+      "The tag value must be one of: ' ', 'context', 'did-you-know', 'further-information', 'tip'",
     );
 
     this.content = content;

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
@@ -26,15 +26,6 @@
             {
               "type": "element",
               "element": {
-                "id": "ffc22686-e788-415b-a456-a5a691687b2c",
-                "type": "text",
-                "tag": "key-points",
-                "content": "<p>Ceci&nbsp;est un contenu avec le tag \"Points clés\".</p>"
-              }
-            },
-            {
-              "type": "element",
-              "element": {
                 "id": "d5e369ec-2a5e-4692-ac46-5be5a49f2acd",
                 "type": "text",
                 "tag": "context",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/validation/element/text-schema.js
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/validation/element/text-schema.js
@@ -6,7 +6,7 @@ const textElementSchema = Joi.object({
   id: uuidSchema,
   type: Joi.string().valid('text').required(),
   tag: Joi.string()
-    .valid(' ', 'context', 'did-you-know', 'further-information', 'key-points', 'tip')
+    .valid(' ', 'context', 'did-you-know', 'further-information', 'tip')
     .required()
     .description("Tag qui s'affiche au dessus du texte. Champ facultatif (laisser vide si pas de tag souhaité)"),
   content: htmlSchema,

--- a/api/tests/devcomp/unit/domain/models/element/Text_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/Text_test.js
@@ -16,7 +16,7 @@ describe('Unit | Devcomp | Domain | Models | Element | Text', function () {
     });
 
     it('should accept all valid tag values', function () {
-      const validTags = [' ', 'context', 'did-you-know', 'further-information', 'key-points', 'tip'];
+      const validTags = [' ', 'context', 'did-you-know', 'further-information', 'tip'];
 
       for (const tag of validTags) {
         const text = new Text({ id: 'id', content: 'content', tag });
@@ -55,7 +55,7 @@ describe('Unit | Devcomp | Domain | Models | Element | Text', function () {
       // then
       expect(error).to.be.instanceOf(TypeError);
       expect(error.message).to.equal(
-        "The tag value must be one of: ' ', 'context', 'did-you-know', 'further-information', 'key-points', 'tip'",
+        "The tag value must be one of: ' ', 'context', 'did-you-know', 'further-information', 'tip'",
       );
     });
   });

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js
@@ -461,7 +461,7 @@ describe('Unit | Infrastructure | Datasources | Learning Content | Module Dataso
         const sample = {
           id: randomUUID(),
           type: 'text',
-          tag: 'key-points',
+          tag: 'tip',
           content: "<p>Ceci est un texte qui accepte de l'HTML.</p>",
         };
 
@@ -476,7 +476,7 @@ describe('Unit | Infrastructure | Datasources | Learning Content | Module Dataso
 
     describe('for text element', function () {
       it('should validate all tag values', async function () {
-        const validTags = [' ', 'context', 'did-you-know', 'further-information', 'key-points', 'tip'];
+        const validTags = [' ', 'context', 'did-you-know', 'further-information', 'tip'];
 
         for (const tag of validTags) {
           try {


### PR DESCRIPTION
## 🌱 Problème

L'illustration "clé" doit être affichée sur tous les grains de type `short-lesson` en même temps que le tag "points-clés". Or, si le c'est le `TextElement` à l'intérieur qui porte l'information du tag, on peut ne pas savoir au niveau du grain qu'il faut afficher l'information.

On ne veut plus de ce tag dans un `TextElement`. Il sera par défaut affiché au-dessus de chaque grain `short-lesson`.



## 🐣 Proposition

Le supprimer de l'énumération côté API, dans les valeurs `valid()`du schema Joi.

## 🌷 Remarques

RAS

## 🐝 Pour tester

- Ouvrir modulix editor localement
- Modifier, dans le fichier `ìndex.js`, la liste `schemaUrls`, en ajoutant en premier : `https://api-pr15810.review.pix.fr/api/module-schema/module-json-schema.json`
- Lancer Modulix-editor
- Afficher un élément text et constater qu'on ne peut plus sélectionner "key-points" comme tag
