### PR TITLE
[TECH] Ajouter la colonne lastAnswerAt à la table certification-courses (PIX-22323).

### DIFF
--- a/api/db/migrations/20260410122621_add-last-answer-at-into-certification-courses-table.js
+++ b/api/db/migrations/20260410122621_add-last-answer-at-into-certification-courses-table.js
@@ -1,0 +1,24 @@
+const TABLE_NAME = 'certification-courses';
+const COLUMN_NAME = 'lastAnswerAt';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dateTime(COLUMN_NAME).nullable().defaultTo(null).comment('Persist the date of the last certification answer');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## 🌱 Problème

Pour afficher une date de fin de certif dans Admin, aujourd'hui nous nous mélangeons facilement les pinceaux pour avoir la vraie date fiable.

Il est en effet compliqué de comprendre les deux colonnes `completedAt` et `endedAt` de la table `certification-courses`.

## 🐣 Proposition

Pour simplifier, nous voulons maintenant sauvegarder la date qui est vraiment utile : celle de la dernière réponse d'un utilisateur. 

Cela sera fait dans une nouvelle colonne `lastAnswerAt` qui est ajoutée ici dans la table `certification-courses`.

## 🐝 Pour tester

Lancer la migration en local.
