### PR TITLE
[FEATURE] Autoriser la création d'une organisation fille à partir d'une organisation fille (PIX-22047)

### DIFF
--- a/admin/app/components/organizations/network/actions-section.gjs
+++ b/admin/app/components/organizations/network/actions-section.gjs
@@ -9,17 +9,10 @@ import AttachChildForm from './attach-child-form';
 export default class ActionsSection extends Component {
   @service accessControl;
 
-  get canCreateChildOrganization() {
-    return (
-      this.accessControl.hasAccessToAttachChildOrganizationActionsScope &&
-      !!this.args.organization.belongsTo('network').id()
-    );
-  }
-
   <template>
     <section class="page-section">
       <div class="content-text content-text--small organization-network__actions-section">
-        {{#if this.canCreateChildOrganization}}
+        {{#if this.accessControl.hasAccessToAttachChildOrganizationActionsScope}}
           <PixButtonLink
             @iconBefore="add"
             @variant="secondary"

--- a/admin/app/components/organizations/network/actions-section.gjs
+++ b/admin/app/components/organizations/network/actions-section.gjs
@@ -20,14 +20,12 @@ export default class ActionsSection extends Component {
     <section class="page-section">
       <div class="content-text content-text--small organization-network__actions-section">
         {{#if this.canCreateChildOrganization}}
-          {{#unless @organization.parentOrganizationId}}
-            <PixButtonLink
-              @iconBefore="add"
-              @variant="secondary"
-              @route="authenticated.organizations.new"
-              @query={{hash parentOrganizationId=@organization.id parentOrganizationName=@organization.name}}
-            >{{t "components.organizations.network.create-child-organization-button"}}</PixButtonLink>
-          {{/unless}}
+          <PixButtonLink
+            @iconBefore="add"
+            @variant="secondary"
+            @route="authenticated.organizations.new"
+            @query={{hash parentOrganizationId=@organization.id parentOrganizationName=@organization.name}}
+          >{{t "components.organizations.network.create-child-organization-button"}}</PixButtonLink>
         {{/if}}
 
         {{#if this.accessControl.hasAccessToAttachChildOrganizationActionsScope}}

--- a/admin/tests/integration/components/organizations/network/actions-section-test.gjs
+++ b/admin/tests/integration/components/organizations/network/actions-section-test.gjs
@@ -23,13 +23,11 @@ module('Integration | Component | organizations/network/actions-section', functi
       this.owner.register('service:access-control', AccessControlStub);
     });
 
-    test('it should display create child organization button when user is superAdmin and organization belongs to a network', async function (assert) {
+    test('it should display create child organization button when user is superAdmin', async function (assert) {
       // given
-      const network = store.createRecord('network', { id: '10', name: 'Réseau Test' });
       const organization = store.createRecord('organization', {
         id: '1',
         name: 'Orga 1',
-        network,
       });
 
       const onAttachChildSubmitFormStub = sinon.stub();
@@ -53,29 +51,6 @@ module('Integration | Component | organizations/network/actions-section', functi
       }
       this.owner.register('service:access-control', AccessControlStub);
 
-      const network = store.createRecord('network', { id: '10', name: 'Réseau Test' });
-      const organization = store.createRecord('organization', {
-        id: '1',
-        name: 'Orga 1',
-        network,
-      });
-
-      const onAttachChildSubmitFormStub = sinon.stub();
-
-      // when
-      const screen = await render(
-        <template>
-          <ActionsSection @organization={{organization}} @onAttachChildSubmitForm={{onAttachChildSubmitFormStub}} />
-        </template>,
-      );
-
-      assert.notOk(
-        screen.queryByRole('link', { name: t('components.organizations.network.create-child-organization-button') }),
-      );
-    });
-
-    test('it should not display create child organization button when organization does not belong to a network', async function (assert) {
-      // given
       const organization = store.createRecord('organization', {
         id: '1',
         name: 'Orga 1',

--- a/admin/tests/integration/components/organizations/network/actions-section-test.gjs
+++ b/admin/tests/integration/components/organizations/network/actions-section-test.gjs
@@ -46,33 +46,6 @@ module('Integration | Component | organizations/network/actions-section', functi
       );
     });
 
-    test('it should not display create child organization button if organization is already a child', async function (assert) {
-      // given
-      const network = store.createRecord('network', { id: '10', name: 'Réseau Test' });
-      const childOrganization = store.createRecord('organization', {
-        id: '2',
-        name: 'Orga 2',
-        parentOrganizationId: '1234',
-        network,
-      });
-
-      const onAttachChildSubmitFormStub = sinon.stub();
-
-      // when
-      const screen = await render(
-        <template>
-          <ActionsSection
-            @organization={{childOrganization}}
-            @onAttachChildSubmitForm={{onAttachChildSubmitFormStub}}
-          />
-        </template>,
-      );
-
-      assert.notOk(
-        screen.queryByRole('link', { name: t('components.organizations.network.create-child-organization-button') }),
-      );
-    });
-
     test('it should not display create child organization button when user is not superAdmin', async function (assert) {
       // given
       class AccessControlStub extends Service {

--- a/api/src/organizational-entities/domain/usecases/create-organization.js
+++ b/api/src/organizational-entities/domain/usecases/create-organization.js
@@ -1,7 +1,4 @@
-import {
-  ParentOrganizationNotInNetworkError,
-  UnableToAttachChildOrganizationToParentOrganizationError,
-} from '../errors.js';
+import { ParentOrganizationNotInNetworkError } from '../errors.js';
 import { Organization } from '../models/Organization.js';
 
 const createOrganization = async function ({
@@ -20,9 +17,6 @@ const createOrganization = async function ({
     const parentOrganization = await organizationForAdminRepository.get({
       organizationId: organization.parentOrganizationId,
     });
-
-    // TODO: Supprimer cette vérification quand on aura implémenté la possibilité d'avoir des organisations avec plusieurs niveaux de hiérarchie (ex: réseau → académie → département → école)
-    _assertParentOrganizationIsNotChildOrganization(parentOrganization);
 
     _assertParentOrganizationBelongsToNetwork(parentOrganization);
   }
@@ -66,18 +60,5 @@ export { createOrganization };
 function _assertParentOrganizationBelongsToNetwork(parentOrganization) {
   if (!parentOrganization.network.id) {
     throw new ParentOrganizationNotInNetworkError({ meta: { parentOrganizationId: parentOrganization.id } });
-  }
-}
-
-function _assertParentOrganizationIsNotChildOrganization(parentOrganization) {
-  if (parentOrganization.parentOrganizationId) {
-    throw new UnableToAttachChildOrganizationToParentOrganizationError({
-      code: 'UNABLE_TO_ATTACH_CHILD_ORGANIZATION_TO_ANOTHER_CHILD_ORGANIZATION',
-      message: 'Unable to attach child organization to parent organization which is also a child organization',
-      meta: {
-        grandParentOrganizationId: parentOrganization.parentOrganizationId,
-        parentOrganizationId: parentOrganization.id,
-      },
-    });
   }
 }

--- a/api/tests/organizational-entities/integration/domain/usecases/create-organization_test.js
+++ b/api/tests/organizational-entities/integration/domain/usecases/create-organization_test.js
@@ -2,7 +2,6 @@ import {
   AdministrationTeamNotFound,
   CountryNotFoundError,
   OrganizationLearnerTypeNotFound,
-  UnableToAttachChildOrganizationToParentOrganizationError,
 } from '../../../../../src/organizational-entities/domain/errors.js';
 import { Organization } from '../../../../../src/organizational-entities/domain/models/Organization.js';
 import { OrganizationForAdmin } from '../../../../../src/organizational-entities/domain/models/OrganizationForAdmin.js';
@@ -82,52 +81,6 @@ describe('Integration | UseCases | create-organization', function () {
 
           // then
           expect(error).to.deep.equal(new NotFoundError('Not found organization for ID 9999'));
-        });
-      });
-
-      describe('when parent organization is a child organization', function () {
-        it('throws UnableToAttachChildOrganizationToParentOrganizationError', async function () {
-          // given
-          const {
-            network,
-            structure: grandParentStructure,
-            organization: grandParentOrg,
-          } = databaseBuilder.factory.buildNetworkAndHeadOrganization();
-          const { organization: childOrg } = databaseBuilder.factory.buildOrganizationInNetwork({
-            networkId: network.id,
-            parentStructureId: grandParentStructure.id,
-            organizationData: { id: 2000, name: 'Parent Org', type: Organization.types.SCO1D },
-          });
-
-          const parentOrganizationId = grandParentOrg.id;
-          const childOrganizationId = childOrg.id;
-
-          await databaseBuilder.commit();
-
-          const organization = new OrganizationForAdmin({
-            name: 'ACME',
-            type: 'PRO',
-            documentationUrl: 'https://pix.fr',
-            createdBy: superAdminUserId,
-            administrationTeamId: 1234,
-            parentOrganizationId: childOrganizationId,
-            countryCode: 99100,
-          });
-
-          // when
-          const error = await catchErr(usecases.createOrganization)({ organization });
-
-          // then
-          expect(error).to.deep.equal(
-            new UnableToAttachChildOrganizationToParentOrganizationError({
-              code: 'UNABLE_TO_ATTACH_CHILD_ORGANIZATION_TO_ANOTHER_CHILD_ORGANIZATION',
-              message: 'Unable to attach child organization to parent organization which is also a child organization',
-              meta: {
-                grandParentOrganizationId: parentOrganizationId,
-                parentOrganizationId: childOrganizationId,
-              },
-            }),
-          );
         });
       });
     });


### PR DESCRIPTION
## 🌱 Problème

Avec l'ancien système de rattachement d'organisations fille à une mère, un seul niveau était autorisé. Dans notre nouveau système de réseaux d'organisations, on veut avoir plusieurs niveaux de filles, sans limite.

## 🐣 Proposition

Supprimer les contraintes actuelles qui empêchent de créer une organisation fille à partir d'une organisation déjà elle-même fille.
- côté front: supprimer la condition qui cache le bouton Créer une organisation fille si l'orga est déjà fille
- côté API: supprimer la vérification qui jette une erreur si le parent de l'organisation que l'on souhaite créer a elle-même un parent.

## 🌷 Remarques

Le dernier commit propose de supprimer côté front la condition d'affichage du bouton Créer une orga fille selon laquelle l'organisation actuelle doit faire partie d'un réseau. C'est une condition importante côté API mais côté front, la page sur laquelle se situe ce bouton (l'onglet Réseau) n'est de toutes façons pas accessible si l'organisation ne fait pas partie d'un réseau. Ce bouton n'étant utilisé que sur cette page, cette condition paraît redondante.

## 🐝 Pour tester

Dans Pix Admin, connecté en tant que Super Admin:
- aller sur la page d'une organisation faisant partie d'un réseau
- sur l'onglet **Réseau**, constater la présence du bouton **Créer une organisation fille** même si l'orga est déjà fille
- cliquer sur ce bouton pour créer la fille
- après avoir été redirigé vers la page de l'orga nouvellement créée, naviguer sur la page de la mère (via le tag _Parent_) et constater que la fille nouvellement créée est bien dans la liste des orgas filles de la mère
