### PR TITLE
[TECH] Ajoute une API interne pour corriger une réponse apportée par un utilisateur

### DIFF
--- a/api/src/evaluation/application/api/correction-api.js
+++ b/api/src/evaluation/application/api/correction-api.js
@@ -1,0 +1,32 @@
+import * as correctionService from '../../domain/services/correction-service.js';
+
+/**
+ * @function
+ * @name correctAnswer
+ *
+ * @param {Object} params
+ * @param {Challenge} params.challenge
+ * @param {Answer} params.answer
+ * @param {boolean} params.hasChallengeBeenFocusedOut
+ * @param {boolean} params.isCertificationEvaluation
+ * @param {boolean} [params.accessibilityAdjustmentNeeded=false]
+ * @param {boolean} [params.forceOKAnswer=false]
+ * @returns {Answer} corrected answer
+ */
+export function correctAnswer({
+  challenge,
+  answer,
+  hasChallengeBeenFocusedOut,
+  isCertificationEvaluation,
+  accessibilityAdjustmentNeeded = false,
+  forceOKAnswer = false,
+}) {
+  return correctionService.evaluateAnswer({
+    challenge,
+    answer,
+    hasChallengeBeenFocusedOut,
+    isCertificationEvaluation,
+    accessibilityAdjustmentNeeded,
+    forceOKAnswer,
+  });
+}

--- a/api/src/evaluation/application/api/correction-api.js
+++ b/api/src/evaluation/application/api/correction-api.js
@@ -7,6 +7,7 @@ import * as correctionService from '../../domain/services/correction-service.js'
  * @param {Object} params
  * @param {Challenge} params.challenge
  * @param {Answer} params.answer
+ * @param {boolean} params.challengeSubmittedAt
  * @param {boolean} params.hasChallengeBeenFocusedOut
  * @param {boolean} params.isCertificationEvaluation
  * @param {boolean} [params.accessibilityAdjustmentNeeded=false]
@@ -17,6 +18,7 @@ export function correctAnswer({
   challenge,
   answer,
   hasChallengeBeenFocusedOut,
+  challengeSubmittedAt,
   isCertificationEvaluation,
   accessibilityAdjustmentNeeded = false,
   forceOKAnswer = false,
@@ -24,6 +26,7 @@ export function correctAnswer({
   return correctionService.evaluateAnswer({
     challenge,
     answer,
+    challengeSubmittedAt,
     hasChallengeBeenFocusedOut,
     isCertificationEvaluation,
     accessibilityAdjustmentNeeded,

--- a/api/src/evaluation/domain/services/correction-service.js
+++ b/api/src/evaluation/domain/services/correction-service.js
@@ -5,6 +5,7 @@ import { ValidatorAlwaysOK } from '../models/ValidatorAlwaysOK.js';
 export function evaluateAnswer({
   challenge,
   answer,
+  challengeSubmittedAt,
   hasChallengeBeenFocusedOut,
   isCertificationEvaluation,
   accessibilityAdjustmentNeeded,
@@ -19,7 +20,7 @@ export function evaluateAnswer({
   }
 
   try {
-    return examiner.evaluate({
+    const correctedAnswer = examiner.evaluate({
       answer,
       challengeFormat: challenge.format,
       isFocusedChallenge: challenge.focused,
@@ -27,6 +28,10 @@ export function evaluateAnswer({
       isCertificationEvaluation,
       accessibilityAdjustmentNeeded,
     });
+
+    const now = new Date();
+    correctedAnswer.setTimeSpentFrom({ now, lastQuestionDate: challengeSubmittedAt || now });
+    return correctedAnswer;
   } catch {
     throw new AnswerEvaluationError(challenge);
   }

--- a/api/src/evaluation/domain/services/correction-service.js
+++ b/api/src/evaluation/domain/services/correction-service.js
@@ -5,7 +5,8 @@ import { ValidatorAlwaysOK } from '../models/ValidatorAlwaysOK.js';
 export function evaluateAnswer({
   challenge,
   answer,
-  assessment,
+  hasChallengeBeenFocusedOut,
+  isCertificationEvaluation,
   accessibilityAdjustmentNeeded,
   forceOKAnswer = false,
 }) {
@@ -22,8 +23,8 @@ export function evaluateAnswer({
       answer,
       challengeFormat: challenge.format,
       isFocusedChallenge: challenge.focused,
-      hasLastQuestionBeenFocusedOut: assessment.hasLastQuestionBeenFocusedOut,
-      isCertificationEvaluation: assessment.isCertification(),
+      hasLastQuestionBeenFocusedOut: hasChallengeBeenFocusedOut,
+      isCertificationEvaluation,
       accessibilityAdjustmentNeeded,
     });
   } catch {

--- a/api/src/evaluation/domain/usecases/save-and-correct-answer-for-campaign.js
+++ b/api/src/evaluation/domain/usecases/save-and-correct-answer-for-campaign.js
@@ -42,7 +42,8 @@ export async function saveAndCorrectAnswerForCampaign({
   const correctedAnswer = correctionService.evaluateAnswer({
     challenge,
     answer,
-    assessment,
+    hasChallengeBeenFocusedOut: assessment.hasLastQuestionBeenFocusedOut,
+    isCertificationEvaluation: assessment.isCertification(),
     accessibilityAdjustmentNeeded: false,
     forceOKAnswer,
   });

--- a/api/src/evaluation/domain/usecases/save-and-correct-answer-for-campaign.js
+++ b/api/src/evaluation/domain/usecases/save-and-correct-answer-for-campaign.js
@@ -42,14 +42,12 @@ export async function saveAndCorrectAnswerForCampaign({
   const correctedAnswer = correctionService.evaluateAnswer({
     challenge,
     answer,
+    challengeSubmittedAt: assessment.lastQuestionDate,
     hasChallengeBeenFocusedOut: assessment.hasLastQuestionBeenFocusedOut,
     isCertificationEvaluation: assessment.isCertification(),
     accessibilityAdjustmentNeeded: false,
     forceOKAnswer,
   });
-  const now = new Date();
-  const lastQuestionDate = assessment.lastQuestionDate || now;
-  correctedAnswer.setTimeSpentFrom({ now, lastQuestionDate });
 
   let savedAnswer;
   if (assessment.isSmartRandom()) {

--- a/api/src/evaluation/domain/usecases/save-and-correct-answer-for-campaign.js
+++ b/api/src/evaluation/domain/usecases/save-and-correct-answer-for-campaign.js
@@ -44,7 +44,7 @@ export async function saveAndCorrectAnswerForCampaign({
     answer,
     challengeSubmittedAt: assessment.lastQuestionDate,
     hasChallengeBeenFocusedOut: assessment.hasLastQuestionBeenFocusedOut,
-    isCertificationEvaluation: assessment.isCertification(),
+    isCertificationEvaluation: false,
     accessibilityAdjustmentNeeded: false,
     forceOKAnswer,
   });

--- a/api/src/evaluation/domain/usecases/save-and-correct-answer-for-certification.js
+++ b/api/src/evaluation/domain/usecases/save-and-correct-answer-for-certification.js
@@ -56,7 +56,7 @@ export async function saveAndCorrectAnswerForCertification({
     answer,
     challengeSubmittedAt: assessment.lastQuestionDate,
     hasChallengeBeenFocusedOut: assessment.hasLastQuestionBeenFocusedOut,
-    isCertificationEvaluation: assessment.isCertification(),
+    isCertificationEvaluation: true,
     accessibilityAdjustmentNeeded: certificationCandidate.accessibilityAdjustmentNeeded,
     forceOKAnswer,
   });

--- a/api/src/evaluation/domain/usecases/save-and-correct-answer-for-certification.js
+++ b/api/src/evaluation/domain/usecases/save-and-correct-answer-for-certification.js
@@ -54,14 +54,12 @@ export async function saveAndCorrectAnswerForCertification({
   const correctedAnswer = correctionService.evaluateAnswer({
     challenge,
     answer,
+    challengeSubmittedAt: assessment.lastQuestionDate,
     hasChallengeBeenFocusedOut: assessment.hasLastQuestionBeenFocusedOut,
     isCertificationEvaluation: assessment.isCertification(),
     accessibilityAdjustmentNeeded: certificationCandidate.accessibilityAdjustmentNeeded,
     forceOKAnswer,
   });
-  const now = new Date();
-  const lastQuestionDate = assessment.lastQuestionDate || now;
-  correctedAnswer.setTimeSpentFrom({ now, lastQuestionDate });
 
   const answerSaved = await answerRepository.save({ answer: correctedAnswer });
   answerSaved.levelup = {};

--- a/api/src/evaluation/domain/usecases/save-and-correct-answer-for-certification.js
+++ b/api/src/evaluation/domain/usecases/save-and-correct-answer-for-certification.js
@@ -54,7 +54,8 @@ export async function saveAndCorrectAnswerForCertification({
   const correctedAnswer = correctionService.evaluateAnswer({
     challenge,
     answer,
-    assessment,
+    hasChallengeBeenFocusedOut: assessment.hasLastQuestionBeenFocusedOut,
+    isCertificationEvaluation: assessment.isCertification(),
     accessibilityAdjustmentNeeded: certificationCandidate.accessibilityAdjustmentNeeded,
     forceOKAnswer,
   });

--- a/api/src/evaluation/domain/usecases/save-and-correct-answer-for-competence-evaluation.js
+++ b/api/src/evaluation/domain/usecases/save-and-correct-answer-for-competence-evaluation.js
@@ -39,14 +39,12 @@ export async function saveAndCorrectAnswerForCompetenceEvaluation({
   const correctedAnswer = correctionService.evaluateAnswer({
     challenge,
     answer,
+    challengeSubmittedAt: assessment.lastQuestionDate,
     hasChallengeBeenFocusedOut: assessment.hasLastQuestionBeenFocusedOut,
     isCertificationEvaluation: assessment.isCertification(),
     accessibilityAdjustmentNeeded: false,
     forceOKAnswer,
   });
-  const now = new Date();
-  const lastQuestionDate = assessment.lastQuestionDate || now;
-  correctedAnswer.setTimeSpentFrom({ now, lastQuestionDate });
 
   const targetSkills = await skillRepository.findActiveByCompetenceId(assessment.competenceId);
   const knowledgeElementsBefore = await knowledgeElementRepository.findUniqByUserId({ userId });

--- a/api/src/evaluation/domain/usecases/save-and-correct-answer-for-competence-evaluation.js
+++ b/api/src/evaluation/domain/usecases/save-and-correct-answer-for-competence-evaluation.js
@@ -41,7 +41,7 @@ export async function saveAndCorrectAnswerForCompetenceEvaluation({
     answer,
     challengeSubmittedAt: assessment.lastQuestionDate,
     hasChallengeBeenFocusedOut: assessment.hasLastQuestionBeenFocusedOut,
-    isCertificationEvaluation: assessment.isCertification(),
+    isCertificationEvaluation: false,
     accessibilityAdjustmentNeeded: false,
     forceOKAnswer,
   });

--- a/api/src/evaluation/domain/usecases/save-and-correct-answer-for-competence-evaluation.js
+++ b/api/src/evaluation/domain/usecases/save-and-correct-answer-for-competence-evaluation.js
@@ -39,7 +39,8 @@ export async function saveAndCorrectAnswerForCompetenceEvaluation({
   const correctedAnswer = correctionService.evaluateAnswer({
     challenge,
     answer,
-    assessment,
+    hasChallengeBeenFocusedOut: assessment.hasLastQuestionBeenFocusedOut,
+    isCertificationEvaluation: assessment.isCertification(),
     accessibilityAdjustmentNeeded: false,
     forceOKAnswer,
   });

--- a/api/src/evaluation/domain/usecases/save-and-correct-answer-for-demo-and-preview.js
+++ b/api/src/evaluation/domain/usecases/save-and-correct-answer-for-demo-and-preview.js
@@ -23,6 +23,8 @@ export async function saveAndCorrectAnswerForDemoAndPreview({
   const correctedAnswer = correctionService.evaluateAnswer({
     challenge,
     answer,
+    hasChallengeBeenFocusedOut: assessment.hasLastQuestionBeenFocusedOut,
+    isCertificationEvaluation: assessment.isCertification(),
     assessment,
     accessibilityAdjustmentNeeded: false,
     forceOKAnswer,

--- a/api/src/evaluation/domain/usecases/save-and-correct-answer-for-demo-and-preview.js
+++ b/api/src/evaluation/domain/usecases/save-and-correct-answer-for-demo-and-preview.js
@@ -23,15 +23,13 @@ export async function saveAndCorrectAnswerForDemoAndPreview({
   const correctedAnswer = correctionService.evaluateAnswer({
     challenge,
     answer,
+    challengeSubmittedAt: assessment.lastQuestionDate,
     hasChallengeBeenFocusedOut: assessment.hasLastQuestionBeenFocusedOut,
     isCertificationEvaluation: assessment.isCertification(),
     assessment,
     accessibilityAdjustmentNeeded: false,
     forceOKAnswer,
   });
-  const now = new Date();
-  const lastQuestionDate = assessment.lastQuestionDate || now;
-  correctedAnswer.setTimeSpentFrom({ now, lastQuestionDate });
 
   const answerSaved = await answerRepository.save({ answer: correctedAnswer });
   answerSaved.levelup = {};

--- a/api/src/evaluation/domain/usecases/save-and-correct-answer-for-demo-and-preview.js
+++ b/api/src/evaluation/domain/usecases/save-and-correct-answer-for-demo-and-preview.js
@@ -25,8 +25,7 @@ export async function saveAndCorrectAnswerForDemoAndPreview({
     answer,
     challengeSubmittedAt: assessment.lastQuestionDate,
     hasChallengeBeenFocusedOut: assessment.hasLastQuestionBeenFocusedOut,
-    isCertificationEvaluation: assessment.isCertification(),
-    assessment,
+    isCertificationEvaluation: false,
     accessibilityAdjustmentNeeded: false,
     forceOKAnswer,
   });

--- a/api/tests/evaluation/unit/application/api/correction-api_test.js
+++ b/api/tests/evaluation/unit/application/api/correction-api_test.js
@@ -1,9 +1,20 @@
 import * as correctionApi from '../../../../../src/evaluation/application/api/correction-api.js';
 import { Answer } from '../../../../../src/evaluation/domain/models/Answer.js';
-import { domainBuilder, expect } from '../../../../test-helper.js';
+import { domainBuilder, expect, sinon } from '../../../../test-helper.js';
 
 describe('Evaluation | Unit | Application | API | correction-api', function () {
   describe('#correctAnswer', function () {
+    const now = new Date('2025-06-15T12:00:00Z');
+    let clock;
+
+    beforeEach(function () {
+      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+    });
+
+    afterEach(function () {
+      clock.restore();
+    });
+
     it('corrects the answer and return the corrected versions of the answer', async function () {
       // given
       const challenge = domainBuilder.buildChallenge();
@@ -13,16 +24,18 @@ describe('Evaluation | Unit | Application | API | correction-api', function () {
       const accessibilityAdjustmentNeeded = false;
 
       // when
-      const a = correctionApi.correctAnswer({
+      const correctedAnswer = correctionApi.correctAnswer({
         challenge,
         answer,
+        challengeSubmittedAt: new Date('2025-06-15T11:30:00Z'),
         hasChallengeBeenFocusedOut,
         isCertificationEvaluation,
         accessibilityAdjustmentNeeded,
       });
 
       // then
-      expect(a).to.be.an.instanceOf(Answer);
+      expect(correctedAnswer).to.be.an.instanceOf(Answer);
+      expect(correctedAnswer.timeSpent).to.equal(1800); // 30 minutes
     });
   });
 });

--- a/api/tests/evaluation/unit/application/api/correction-api_test.js
+++ b/api/tests/evaluation/unit/application/api/correction-api_test.js
@@ -1,0 +1,28 @@
+import * as correctionApi from '../../../../../src/evaluation/application/api/correction-api.js';
+import { Answer } from '../../../../../src/evaluation/domain/models/Answer.js';
+import { domainBuilder, expect } from '../../../../test-helper.js';
+
+describe('Evaluation | Unit | Application | API | correction-api', function () {
+  describe('#correctAnswer', function () {
+    it('corrects the answer and return the corrected versions of the answer', async function () {
+      // given
+      const challenge = domainBuilder.buildChallenge();
+      const answer = domainBuilder.buildAnswer({ userId: 123 });
+      const hasChallengeBeenFocusedOut = false;
+      const isCertificationEvaluation = true;
+      const accessibilityAdjustmentNeeded = false;
+
+      // when
+      const a = correctionApi.correctAnswer({
+        challenge,
+        answer,
+        hasChallengeBeenFocusedOut,
+        isCertificationEvaluation,
+        accessibilityAdjustmentNeeded,
+      });
+
+      // then
+      expect(a).to.be.an.instanceOf(Answer);
+    });
+  });
+});

--- a/api/tests/evaluation/unit/domain/services/correction-service_test.js
+++ b/api/tests/evaluation/unit/domain/services/correction-service_test.js
@@ -9,11 +9,18 @@ describe('Unit | Domain | Service | correction-service', function () {
         // given
         const challenge = domainBuilder.buildChallenge();
         const answer = domainBuilder.buildAnswer();
-        const assessment = domainBuilder.buildAssessment();
+        const hasChallengeBeenFocusedOut = false;
+        const isCertificationEvaluation = true;
         const accessibilityAdjustmentNeeded = false;
 
         // when
-        const a = evaluateAnswer({ challenge, answer, assessment, accessibilityAdjustmentNeeded });
+        const a = evaluateAnswer({
+          challenge,
+          answer,
+          hasChallengeBeenFocusedOut,
+          isCertificationEvaluation,
+          accessibilityAdjustmentNeeded,
+        });
 
         // then
         expect(a).to.be.an.instanceOf(Answer);
@@ -27,14 +34,16 @@ describe('Unit | Domain | Service | correction-service', function () {
         const answer = domainBuilder.buildAnswer({
           value: 'Some random value',
         });
-        const assessment = domainBuilder.buildAssessment();
+        const hasChallengeBeenFocusedOut = false;
+        const isCertificationEvaluation = true;
         const accessibilityAdjustmentNeeded = false;
 
         // when
         const correctedAnswer = evaluateAnswer({
           challenge,
           answer,
-          assessment,
+          hasChallengeBeenFocusedOut,
+          isCertificationEvaluation,
           accessibilityAdjustmentNeeded,
           forceOKAnswer: true,
         });

--- a/api/tests/evaluation/unit/domain/services/correction-service_test.js
+++ b/api/tests/evaluation/unit/domain/services/correction-service_test.js
@@ -1,8 +1,19 @@
 import { Answer } from '../../../../../src/evaluation/domain/models/Answer.js';
 import { evaluateAnswer } from '../../../../../src/evaluation/domain/services/correction-service.js';
-import { domainBuilder, expect } from '../../../../test-helper.js';
+import { domainBuilder, expect, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Domain | Service | correction-service', function () {
+  const now = new Date('2025-06-15T12:00:00Z');
+  let clock;
+
+  beforeEach(function () {
+    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+  });
+
+  afterEach(function () {
+    clock.restore();
+  });
+
   describe('#evaluateAnswer', function () {
     context('when answer evaluation succeeds without forcing OK answer', function () {
       it('should return the corrected answer', function () {
@@ -51,6 +62,59 @@ describe('Unit | Domain | Service | correction-service', function () {
         // then
         expect(correctedAnswer).to.be.an.instanceOf(Answer);
         expect(correctedAnswer.isOk()).to.be.true;
+      });
+    });
+
+    context('when a challengeSubmittedAt is provided', function () {
+      it('should compute the time spent on the challenge', function () {
+        // given
+        const challenge = domainBuilder.buildChallenge();
+        const answer = domainBuilder.buildAnswer({
+          value: 'Some random value',
+        });
+        const hasChallengeBeenFocusedOut = false;
+        const isCertificationEvaluation = true;
+        const accessibilityAdjustmentNeeded = false;
+
+        // when
+        const correctedAnswer = evaluateAnswer({
+          challenge,
+          answer,
+          challengeSubmittedAt: new Date('2025-06-15T11:30:00Z'),
+          hasChallengeBeenFocusedOut,
+          isCertificationEvaluation,
+          accessibilityAdjustmentNeeded,
+        });
+
+        // then
+        expect(correctedAnswer).to.be.an.instanceOf(Answer);
+        expect(correctedAnswer.timeSpent).to.equal(1800); // 30 minutes
+      });
+    });
+
+    context('when a challengeSubmittedAt is not provided', function () {
+      it('should compute a zero-ish time spent', function () {
+        // given
+        const challenge = domainBuilder.buildChallenge();
+        const answer = domainBuilder.buildAnswer({
+          value: 'Some random value',
+        });
+        const hasChallengeBeenFocusedOut = false;
+        const isCertificationEvaluation = true;
+        const accessibilityAdjustmentNeeded = false;
+
+        // when
+        const correctedAnswer = evaluateAnswer({
+          challenge,
+          answer,
+          hasChallengeBeenFocusedOut,
+          isCertificationEvaluation,
+          accessibilityAdjustmentNeeded,
+        });
+
+        // then
+        expect(correctedAnswer).to.be.an.instanceOf(Answer);
+        expect(correctedAnswer.timeSpent).to.equal(0);
       });
     });
   });


### PR DESCRIPTION
## 🌱 Problème

On prévoit de déplacer le code déclenché lorsqu'une réponse est apportée en certif dans le bounded context de certification correspondant.
Ce code se sert du `correctionService` pour corriger la réponse. On ne souhaitera pas faire d'import qui viole la loi d'isolation des bounded contexts

## 🐣 Proposition

On expose une API interne dans le bounded context `evaluation` qui permet de faire corriger une épreuve par un utilisateur externe au contexte.

## 🌷 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🐝 Pour tester
Non régression du passage dépreuves et de l'évaluation vrai/faux
