### PR TITLE
[TECH] Remplacer des test-helpers par des database-builder

### DIFF
--- a/api/db/database-builder/factory/build-feature.js
+++ b/api/db/database-builder/factory/build-feature.js
@@ -1,16 +1,26 @@
+import { ORGANIZATION_FEATURE } from '../../../src/shared/domain/constants.js';
 import { databaseBuffer } from '../database-buffer.js';
+import { buildOrganizationLearnerImportFormat } from './build-organization-learner-import-format.js';
 
 const buildFeature = function buildFeature({ id = databaseBuffer.getNextId(), key, description } = {}) {
-  const values = {
-    id,
-    key,
-    description,
-  };
+  const values = { id, key, description };
 
-  return databaseBuffer.pushInsertable({
-    tableName: 'features',
-    values,
+  return databaseBuffer.pushInsertable({ tableName: 'features', values });
+};
+
+buildFeature.pixJuniorFeatures = function buildPixJuniorFeatures() {
+  const features = [
+    ORGANIZATION_FEATURE.LEARNER_IMPORT,
+    ORGANIZATION_FEATURE.MISSIONS_MANAGEMENT,
+    ORGANIZATION_FEATURE.ORALIZATION_MANAGED_BY_PRESCRIBER,
+  ].map(({ key, description }) => {
+    const values = { id: databaseBuffer.getNextId(), key, description };
+    databaseBuffer.pushInsertable({ tableName: 'features', values });
   });
+
+  buildOrganizationLearnerImportFormat({ name: ORGANIZATION_FEATURE.LEARNER_IMPORT.FORMAT.ONDE });
+
+  return features;
 };
 
 export { buildFeature };

--- a/api/db/database-builder/factory/build-user.js
+++ b/api/db/database-builder/factory/build-user.js
@@ -224,7 +224,7 @@ buildUser.anonymous = function buildUserAnonymous({
   });
 };
 
-buildUser.withRole = function buildUserWithRole({
+function buildUserWithRole({
   id = databaseBuffer.getNextId(),
   firstName = 'Billy',
   lastName = 'TheKid',
@@ -277,7 +277,10 @@ buildUser.withRole = function buildUserWithRole({
   buildPixAdminRole({ userId: user.id, role, disabledAt, createdAt, updatedAt });
 
   return user;
-};
+}
+
+buildUser.withRole = buildUserWithRole;
+buildUser.withRoleSuperAdmin = (args) => buildUserWithRole({ ...args, role: ROLES.SUPER_ADMIN });
 
 buildUser.withMembership = function buildUserWithMemberships({
   id = databaseBuffer.getNextId(),

--- a/api/db/database-builder/factory/build-user.js
+++ b/api/db/database-builder/factory/build-user.js
@@ -281,6 +281,7 @@ function buildUserWithRole({
 
 buildUser.withRole = buildUserWithRole;
 buildUser.withRoleSuperAdmin = (args) => buildUserWithRole({ ...args, role: ROLES.SUPER_ADMIN });
+buildUser.withRoleCertif = (args) => buildUserWithRole({ ...args, role: ROLES.CERTIF });
 
 buildUser.withMembership = function buildUserWithMemberships({
   id = databaseBuffer.getNextId(),

--- a/api/tests/acceptance/application/certification-centers/certification-center-controller_test.js
+++ b/api/tests/acceptance/application/certification-centers/certification-center-controller_test.js
@@ -5,7 +5,6 @@ import {
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
-  insertUserWithRoleSuperAdmin,
   knex,
 } from '../../../test-helper.js';
 
@@ -14,7 +13,6 @@ describe('Acceptance | API | Certification Center', function () {
 
   beforeEach(async function () {
     server = await createServer();
-    await insertUserWithRoleSuperAdmin();
   });
 
   describe('GET /api/certification-centers/{certificationCenterId}/sessions/{sessionId}/divisions', function () {
@@ -53,6 +51,7 @@ describe('Acceptance | API | Certification Center', function () {
     context('when certification center membership is linked to the certification center', function () {
       it('should return 200 HTTP status', async function () {
         // given
+        const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
         const certificationCenter = databaseBuilder.factory.buildCertificationCenter();
         const user1 = databaseBuilder.factory.buildUser();
         databaseBuilder.factory.buildCertificationCenterMembership({
@@ -63,7 +62,7 @@ describe('Acceptance | API | Certification Center', function () {
 
         // when
         const response = await server.inject({
-          headers: generateAuthenticatedUserRequestHeaders(),
+          headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
           method: 'GET',
           url: `/api/admin/certification-centers/${certificationCenter.id}/certification-center-memberships`,
         });
@@ -74,6 +73,7 @@ describe('Acceptance | API | Certification Center', function () {
 
       it('should return certification center memberships', async function () {
         // given
+        const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
         const certificationCenter = databaseBuilder.factory.buildCertificationCenter();
         const user1 = databaseBuilder.factory.buildUser();
         const user2 = databaseBuilder.factory.buildUser();
@@ -89,7 +89,7 @@ describe('Acceptance | API | Certification Center', function () {
 
         // when
         const response = await server.inject({
-          headers: generateAuthenticatedUserRequestHeaders(),
+          headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
           method: 'GET',
           url: `/api/admin/certification-centers/${certificationCenter.id}/certification-center-memberships`,
         });

--- a/api/tests/acceptance/application/organizations/organization-controller_test.js
+++ b/api/tests/acceptance/application/organizations/organization-controller_test.js
@@ -5,8 +5,6 @@ import {
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
-  insertMultipleSendingFeatureForNewOrganization,
-  insertUserWithRoleSuperAdmin,
 } from '../../../test-helper.js';
 
 const { map: _map } = lodash;
@@ -16,8 +14,6 @@ describe('Acceptance | Application | organization-controller', function () {
 
   beforeEach(async function () {
     server = await createServer();
-    await insertUserWithRoleSuperAdmin();
-    await insertMultipleSendingFeatureForNewOrganization();
   });
 
   describe('GET /api/organizations/{id}/campaigns', function () {

--- a/api/tests/acceptance/application/users/users-controller-get-user-profile-for-admin_test.js
+++ b/api/tests/acceptance/application/users/users-controller-get-user-profile-for-admin_test.js
@@ -4,7 +4,6 @@ import {
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
-  insertUserWithRoleSuperAdmin,
   mockLearningContent,
 } from '../../../test-helper.js';
 
@@ -95,8 +94,10 @@ describe('Acceptance | Controller | users-controller-get-user-profile-for-admin'
 
     describe('Success case', function () {
       beforeEach(async function () {
-        const superAdmin = await insertUserWithRoleSuperAdmin();
-        options.headers = generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id });
+        const superAdminUser = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
+        await databaseBuilder.commit();
+
+        options.headers = generateAuthenticatedUserRequestHeaders({ userId: superAdminUser.id });
 
         await mockLearningContent(learningContent);
 

--- a/api/tests/announcements/acceptance/application/announcement-route_test.js
+++ b/api/tests/announcements/acceptance/application/announcement-route_test.js
@@ -4,7 +4,6 @@ import {
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
-  insertUserWithRoleSuperAdmin,
   knex,
 } from '../../../test-helper.js';
 
@@ -47,8 +46,9 @@ describe('Acceptance | Router | announcement-route', function () {
       let headers;
 
       beforeEach(async function () {
-        await insertUserWithRoleSuperAdmin();
-        headers = generateAuthenticatedUserRequestHeaders({ userId: 1234 });
+        const superAdminUser = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
+        await databaseBuilder.commit();
+        headers = generateAuthenticatedUserRequestHeaders({ userId: superAdminUser.id });
       });
 
       it('should return 400 when content contains an unsupported locale key', async function () {

--- a/api/tests/certification/complementary-certification/acceptance/application/attach-target-profile-controller_test.js
+++ b/api/tests/certification/complementary-certification/acceptance/application/attach-target-profile-controller_test.js
@@ -5,7 +5,6 @@ import {
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
-  insertUserWithRoleSuperAdmin,
   knex,
 } from '../../../../test-helper.js';
 
@@ -21,7 +20,7 @@ describe('Acceptance | Controller | Complementary certification | attach-target-
   describe('PUT /admin/complementary-certifications/{complementaryCertificationId}/badges/', function () {
     it('should return an OK status after saving in database', async function () {
       // given
-      const superAdmin = await insertUserWithRoleSuperAdmin();
+      const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
       const complementaryCertification = databaseBuilder.factory.buildComplementaryCertification({
         id: 52,
         key: 'Pix+ key',

--- a/api/tests/certification/configuration/acceptance/application/certification-framework-route_test.js
+++ b/api/tests/certification/configuration/acceptance/application/certification-framework-route_test.js
@@ -6,7 +6,6 @@ import {
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
-  insertUserWithRoleSuperAdmin,
   knex,
   mockLearningContent,
   sinon,
@@ -15,15 +14,17 @@ import { buildLearningContent as learningContentBuilder } from '../../../../tool
 
 describe('Acceptance | Application | Certification | ComplementaryCertification | certification-framework-route', function () {
   let server;
+  let superAdmin;
 
   beforeEach(async function () {
     server = await createServer();
+    superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
+    await databaseBuilder.commit();
   });
 
   describe('GET /api/admin/certification-frameworks', function () {
     it('should return 200 HTTP status code with all frameworks', async function () {
       // given
-      const superAdmin = await insertUserWithRoleSuperAdmin();
       const options = {
         method: 'GET',
         url: '/api/admin/certification-frameworks',
@@ -109,8 +110,6 @@ describe('Acceptance | Application | Certification | ComplementaryCertification 
   describe('GET /api/admin/certification-frameworks/{scope}/active-consolidated-framework', function () {
     it('should return the active consolidated framework', async function () {
       // given
-      const superAdmin = await insertUserWithRoleSuperAdmin();
-
       const minimalLearningContent = [
         {
           id: 'recAreaCore',
@@ -195,8 +194,6 @@ describe('Acceptance | Application | Certification | ComplementaryCertification 
   describe('GET /api/admin/certification-frameworks/{scope}/framework-history', function () {
     it('should return the framework history for given scope ordered by start date descending', async function () {
       // given
-      const superAdmin = await insertUserWithRoleSuperAdmin();
-
       const newerVersion = databaseBuilder.factory.buildCertificationVersion({
         scope: SCOPES.CORE,
         startDate: new Date('2025-01-11'),
@@ -251,8 +248,6 @@ describe('Acceptance | Application | Certification | ComplementaryCertification 
 
     it('should return 201 HTTP status code and create a new framework', async function () {
       // given
-      const superAdmin = await insertUserWithRoleSuperAdmin();
-
       const tubeId = 'myTubeId';
       const skill = databaseBuilder.factory.learningContent.buildSkill({
         tubeId,
@@ -330,8 +325,6 @@ describe('Acceptance | Application | Certification | ComplementaryCertification 
 
     it('should create a new version and expire the previous one when a version already exists', async function () {
       // given
-      const superAdmin = await insertUserWithRoleSuperAdmin();
-
       const existingVersionStartDate = new Date('2024-01-01');
       const existingVersion = databaseBuilder.factory.buildCertificationVersion({
         scope: SCOPES.CORE,

--- a/api/tests/certification/configuration/acceptance/application/certification-version-route_test.js
+++ b/api/tests/certification/configuration/acceptance/application/certification-version-route_test.js
@@ -6,21 +6,21 @@ import {
   domainBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
-  insertUserWithRoleSuperAdmin,
   knex,
 } from '../../../../test-helper.js';
 
 describe('Acceptance | Certification | Configuration | API | certification-version-route', function () {
   let server;
+  let superAdmin;
 
   beforeEach(async function () {
     server = await createServer();
+    superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
+    await databaseBuilder.commit();
   });
 
   describe('GET /api/admin/certification-versions/{scope}/active', function () {
     it('should get the active certification version for a given scope and return 200', async function () {
-      const superAdmin = await insertUserWithRoleSuperAdmin();
-
       const challengesConfiguration = domainBuilder.buildFlashAlgorithmConfiguration({
         maximumAssessmentLength: 20,
         limitToOneQuestionPerTube: false,
@@ -57,10 +57,6 @@ describe('Acceptance | Certification | Configuration | API | certification-versi
     });
 
     it('should return 404 when no active version exists for the scope', async function () {
-      const superAdmin = await insertUserWithRoleSuperAdmin();
-
-      await databaseBuilder.commit();
-
       const options = {
         method: 'GET',
         url: `/api/admin/certification-versions/${SCOPES.CORE}/active`,
@@ -75,8 +71,6 @@ describe('Acceptance | Certification | Configuration | API | certification-versi
 
   describe('PATCH /api/admin/certification-versions/{certificationVersionId}', function () {
     it('should update a certification version and return 204', async function () {
-      const superAdmin = await insertUserWithRoleSuperAdmin();
-
       const initialChallengesConfiguration = domainBuilder.buildFlashAlgorithmConfiguration({
         maximumAssessmentLength: 20,
         challengesBetweenSameCompetence: 0,

--- a/api/tests/certification/configuration/acceptance/application/complementary-certification-route_test.js
+++ b/api/tests/certification/configuration/acceptance/application/complementary-certification-route_test.js
@@ -7,7 +7,6 @@ import {
   datamartBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
-  insertUserWithRoleSuperAdmin,
   knex,
 } from '../../../../test-helper.js';
 
@@ -21,7 +20,7 @@ describe('Certification | Configuration | Acceptance | API | complementary-certi
   describe('GET /api/admin/complementary-certifications/', function () {
     it('should return 200 HTTP status code', async function () {
       // given
-      const superAdmin = await insertUserWithRoleSuperAdmin();
+      const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
       const options = {
         method: 'GET',
         url: '/api/admin/complementary-certifications',
@@ -74,7 +73,7 @@ describe('Certification | Configuration | Acceptance | API | complementary-certi
     context('when no search term provided', function () {
       it('should return 200 HTTP status code', async function () {
         // given
-        const superAdmin = await insertUserWithRoleSuperAdmin();
+        const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
         const options = {
           method: 'GET',
           url: '/api/admin/complementary-certifications/attachable-target-profiles',
@@ -110,7 +109,7 @@ describe('Certification | Configuration | Acceptance | API | complementary-certi
     context('when a search term is provided', function () {
       it('should return 200 HTTP status code', async function () {
         // given
-        const superAdmin = await insertUserWithRoleSuperAdmin();
+        const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
         const options = {
           method: 'GET',
           url: '/api/admin/complementary-certifications/attachable-target-profiles?searchTerm=that%20way',
@@ -153,7 +152,7 @@ describe('Certification | Configuration | Acceptance | API | complementary-certi
     it('should return 200 HTTP status code', async function () {
       // given
       const server = await createServer();
-      const superAdmin = await insertUserWithRoleSuperAdmin();
+      const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
       const attachedAt = new Date('2019-01-01');
 
       databaseBuilder.factory.buildComplementaryCertification({
@@ -254,7 +253,7 @@ describe('Certification | Configuration | Acceptance | API | complementary-certi
   describe('PATCH /api/admin/complementary-certifications/{complementaryCertificationKey}/consolidated-framework', function () {
     it('should return 200 HTTP status code and update framework with calibration', async function () {
       // given
-      const superAdmin = await insertUserWithRoleSuperAdmin();
+      const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
 
       const complementaryCertification = databaseBuilder.factory.buildComplementaryCertification();
       const certificationVersion = databaseBuilder.factory.buildCertificationVersion({

--- a/api/tests/certification/configuration/acceptance/application/sco-blocked-access-dates-route_test.js
+++ b/api/tests/certification/configuration/acceptance/application/sco-blocked-access-dates-route_test.js
@@ -4,7 +4,6 @@ import {
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
-  insertUserWithRoleSuperAdmin,
   knex,
 } from '../../../../test-helper.js';
 
@@ -18,15 +17,16 @@ describe('Certification | Configuration | Acceptance | API | sco-blocked-access-
   describe('PATCH /api/admin/sco-blocked-access-dates', function () {
     it('should return 200 HTTP status code when updating valid entry', async function () {
       // given
-      const superAdmin = await insertUserWithRoleSuperAdmin();
+      const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
+      databaseBuilder.factory.buildDefaultScoBlockedAccessDates();
+      await databaseBuilder.commit();
+
       const options = {
         method: 'PATCH',
         url: '/api/admin/sco-blocked-access-dates/LYCEE',
         headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
         payload: { data: { attributes: { value: '2025-12-15' } } },
       };
-      databaseBuilder.factory.buildDefaultScoBlockedAccessDates();
-      await databaseBuilder.commit();
 
       // when
       const response = await server.inject(options);
@@ -40,7 +40,9 @@ describe('Certification | Configuration | Acceptance | API | sco-blocked-access-
     });
     it('should return 404 HTTP status code when updating invalid entry', async function () {
       // given
-      const superAdmin = await insertUserWithRoleSuperAdmin();
+      const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
+      await databaseBuilder.commit();
+
       const options = {
         method: 'PATCH',
         url: '/api/admin/sco-blocked-access-dates/LYCEE',
@@ -59,18 +61,18 @@ describe('Certification | Configuration | Acceptance | API | sco-blocked-access-
   describe('GET /api/admin/sco-blocked-access-dates', function () {
     it('should return 200 HTTP status code and values', async function () {
       // given
-      const superAdmin = await insertUserWithRoleSuperAdmin();
-      const options = {
-        method: 'GET',
-        url: '/api/admin/sco-blocked-access-dates',
-        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
-      };
-
+      const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
       const collegeReopeningDate = new Date('2025-10-23');
       const lyceeReopeningDate = new Date('2025-12-23');
       databaseBuilder.factory.buildCollegeScoBlockedAccessDate(collegeReopeningDate);
       databaseBuilder.factory.buildLyceeScoBlockedAccessDate(lyceeReopeningDate);
       await databaseBuilder.commit();
+
+      const options = {
+        method: 'GET',
+        url: '/api/admin/sco-blocked-access-dates',
+        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
+      };
 
       // when
       const response = await server.inject(options);

--- a/api/tests/certification/configuration/acceptance/application/sco-whitelist-route_test.js
+++ b/api/tests/certification/configuration/acceptance/application/sco-whitelist-route_test.js
@@ -5,7 +5,6 @@ import {
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
-  insertUserWithRoleSuperAdmin,
   knex,
 } from '../../../../test-helper.js';
 
@@ -19,7 +18,7 @@ describe('Certification | Configuration | Acceptance | API | sco-whitelist-route
   describe('POST /api/admin/sco-whitelist', function () {
     it('should return 201 HTTP status code', async function () {
       // given
-      const superAdmin = await insertUserWithRoleSuperAdmin();
+      const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
       const buffer = 'externalId\next1\next2';
       const options = {
         method: 'POST',
@@ -58,7 +57,7 @@ describe('Certification | Configuration | Acceptance | API | sco-whitelist-route
     it('should rollback if invalid whitelist given', async function () {
       // given
       const thisExternalIdCannotBeWhitelisted = 'NOT_A_SCO_EXTERNAL_ID';
-      const superAdmin = await insertUserWithRoleSuperAdmin();
+      const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
       const buffer = `externalId\next1\n${thisExternalIdCannotBeWhitelisted}`;
       const options = {
         method: 'POST',
@@ -108,7 +107,7 @@ describe('Certification | Configuration | Acceptance | API | sco-whitelist-route
     it('should return 200 HTTP status code and whitelist as CSV', async function () {
       // given
       const BOM_CHAR = '\ufeff';
-      const superAdmin = await insertUserWithRoleSuperAdmin();
+      const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
       const options = {
         method: 'GET',
         url: '/api/admin/sco-whitelist',

--- a/api/tests/certification/enrolment/acceptance/application/certification-candidate-route_test.js
+++ b/api/tests/certification/enrolment/acceptance/application/certification-candidate-route_test.js
@@ -12,7 +12,6 @@ import {
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
-  insertUserWithRoleSuperAdmin,
   knex,
 } from '../../../../test-helper.js';
 
@@ -459,7 +458,7 @@ describe('Certification | Enrolment | Acceptance | Application | Routes | certif
   describe('GET /api/admin/certification-candidates/{certificationCandidateId}/timeline', function () {
     it('should respond with a 200 and timeline', async function () {
       // given
-      const superAdmin = await insertUserWithRoleSuperAdmin();
+      const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
       const sessionId = databaseBuilder.factory.buildSession().id;
       const candidateUserId = databaseBuilder.factory.buildUser().id;
       const createdAt = dayjs().toDate();

--- a/api/tests/certification/enrolment/acceptance/application/certification-center-controller_test.js
+++ b/api/tests/certification/enrolment/acceptance/application/certification-center-controller_test.js
@@ -5,7 +5,6 @@ import {
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
-  insertUserWithRoleSuperAdmin,
 } from '../../../../test-helper.js';
 
 describe('Acceptance | API | Certification Center', function () {
@@ -13,7 +12,6 @@ describe('Acceptance | API | Certification Center', function () {
 
   beforeEach(async function () {
     server = await createServer();
-    await insertUserWithRoleSuperAdmin();
   });
 
   describe('GET /api/certification-centers/{certificationCenterId}/sessions/{sessionId}/students', function () {

--- a/api/tests/certification/results/acceptance/application/certificate-route_test.js
+++ b/api/tests/certification/results/acceptance/application/certificate-route_test.js
@@ -18,7 +18,6 @@ import {
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
-  insertUserWithRoleSuperAdmin,
   learningContentBuilder,
   mockLearningContent,
 } from '../../../../test-helper.js';
@@ -851,7 +850,7 @@ describe('Certification | Results | Acceptance | Application | Certification', f
     context('when the session version is V2', function () {
       it('should return 200 HTTP status code and the certification', async function () {
         // given
-        const superAdmin = await insertUserWithRoleSuperAdmin();
+        const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
         const { session } = await _buildDatabaseForV2Certification({ userId: superAdmin.id });
         await databaseBuilder.commit();
 
@@ -877,8 +876,8 @@ describe('Certification | Results | Acceptance | Application | Certification', f
     context('when the session version is V3', function () {
       it('should return 200 HTTP status code and the certification', async function () {
         // given
-        const superAdmin = await insertUserWithRoleSuperAdmin();
-        const { session, userId } = await _buildDatabaseForV2Certification({ userId: superAdmin.id });
+        const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
+        const { session } = await _buildDatabaseForV2Certification({ userId: superAdmin.id });
         await databaseBuilder.commit();
 
         const server = await createServer();
@@ -887,7 +886,7 @@ describe('Certification | Results | Acceptance | Application | Certification', f
         const response = await server.inject({
           method: 'GET',
           url: `/api/admin/sessions/${session.id}/attestations`,
-          headers: generateAuthenticatedUserRequestHeaders({ userId }),
+          headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
         });
 
         // then

--- a/api/tests/certification/results/acceptance/application/certification-results-route_test.js
+++ b/api/tests/certification/results/acceptance/application/certification-results-route_test.js
@@ -7,7 +7,6 @@ import {
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
-  insertUserWithRoleSuperAdmin,
 } from '../../../../test-helper.js';
 
 describe('Certification | Results | Acceptance | Application | Routes | certification results', function () {
@@ -200,12 +199,12 @@ describe('Certification | Results | Acceptance | Application | Routes | certific
           payload: {},
         };
         const server = await createServer();
-        await insertUserWithRoleSuperAdmin();
+        const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
         databaseBuilder.factory.buildSession({ id: 121 });
         await databaseBuilder.commit();
 
         // when
-        options.headers = generateAuthenticatedUserRequestHeaders();
+        options.headers = generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id });
         const response = await server.inject(options);
 
         // then
@@ -223,7 +222,6 @@ describe('Certification | Results | Acceptance | Application | Routes | certific
           payload: {},
         };
         const server = await createServer();
-        await insertUserWithRoleSuperAdmin();
 
         // when
         options.headers = generateAuthenticatedUserRequestHeaders({ userId: 1111 });
@@ -244,7 +242,6 @@ describe('Certification | Results | Acceptance | Application | Routes | certific
           payload: {},
         };
         const server = await createServer();
-        await insertUserWithRoleSuperAdmin();
 
         // when
         options.headers = {};

--- a/api/tests/certification/results/acceptance/application/organization-route_test.js
+++ b/api/tests/certification/results/acceptance/application/organization-route_test.js
@@ -2,12 +2,7 @@ import { createServer } from '../../../../../server.js';
 import { AutoJuryCommentKeys } from '../../../../../src/certification/shared/domain/models/JuryComment.js';
 import { AssessmentResult } from '../../../../../src/shared/domain/models/AssessmentResult.js';
 import { Membership } from '../../../../../src/shared/domain/models/Membership.js';
-import {
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-  insertUserWithRoleSuperAdmin,
-} from '../../../../test-helper.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../../test-helper.js';
 
 describe('Certification | Results | Acceptance | Application | Routes | organization', function () {
   const BOM_CHAR = '\ufeff';
@@ -15,7 +10,6 @@ describe('Certification | Results | Acceptance | Application | Routes | organiza
 
   beforeEach(async function () {
     server = await createServer();
-    await insertUserWithRoleSuperAdmin();
   });
 
   describe('GET /api/organizations/{organizationId}/certification-results', function () {

--- a/api/tests/certification/session-management/acceptance/application/cancellation-route_test.js
+++ b/api/tests/certification/session-management/acceptance/application/cancellation-route_test.js
@@ -8,7 +8,6 @@ import {
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
-  insertUserWithRoleSuperAdmin,
   knex,
   learningContentBuilder,
   mockLearningContent,
@@ -124,7 +123,6 @@ describe('Certification | Session-management | Acceptance | Application | Routes
           url: '/api/admin/certification-courses/123/cancel',
           headers: generateAuthenticatedUserRequestHeaders({ userId: juryMember.id }),
         };
-        await insertUserWithRoleSuperAdmin();
         await databaseBuilder.commit();
 
         // when
@@ -246,7 +244,6 @@ describe('Certification | Session-management | Acceptance | Application | Routes
           url: '/api/admin/certification-courses/123/cancel',
           headers: generateAuthenticatedUserRequestHeaders({ userId: juryMember.id }),
         };
-        await insertUserWithRoleSuperAdmin();
         await databaseBuilder.commit();
 
         // when
@@ -370,7 +367,6 @@ describe('Certification | Session-management | Acceptance | Application | Routes
         url: '/api/admin/certification-courses/123/uncancel',
         headers: generateAuthenticatedUserRequestHeaders({ userId: juryMember.id }),
       };
-      await insertUserWithRoleSuperAdmin();
       await databaseBuilder.commit();
 
       // when

--- a/api/tests/certification/session-management/acceptance/application/certification-course-route_test.js
+++ b/api/tests/certification/session-management/acceptance/application/certification-course-route_test.js
@@ -8,7 +8,6 @@ import {
   domainBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
-  insertUserWithRoleSuperAdmin,
   knex,
 } from '../../../../test-helper.js';
 import { createSuccessfulCertificationCourse } from '../../../shared/fixtures/certification-course.js';
@@ -44,7 +43,7 @@ describe('Certification | Session Management | Acceptance | Application | Routes
 
       beforeEach(async function () {
         server = await createServer();
-        await insertUserWithRoleSuperAdmin();
+        const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
 
         databaseBuilder.factory.buildCertificationVersion({
           scope: 'CORE',
@@ -84,7 +83,7 @@ describe('Certification | Session Management | Acceptance | Application | Routes
         });
 
         options = {
-          headers: generateAuthenticatedUserRequestHeaders(),
+          headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
           method: 'PATCH',
           url: `/api/admin/certification-courses/${certificationCourseId}`,
           payload: {
@@ -151,7 +150,7 @@ describe('Certification | Session Management | Acceptance | Application | Routes
     describe('when certification is V2', function () {
       it('should create a new rejected AssessmentResult', async function () {
         // given
-        const userId = (await insertUserWithRoleSuperAdmin()).id;
+        const userId = databaseBuilder.factory.buildUser.withRoleSuperAdmin().id;
 
         const session = databaseBuilder.factory.buildSession({
           finalizedAt: new Date('2018-12-01T01:02:03Z'),
@@ -203,7 +202,7 @@ describe('Certification | Session Management | Acceptance | Application | Routes
     describe('when certification is V3', function () {
       it('should create a new rejected AssessmentResult', async function () {
         // given
-        const userId = (await insertUserWithRoleSuperAdmin()).id;
+        const userId = databaseBuilder.factory.buildUser.withRoleSuperAdmin().id;
 
         const session = databaseBuilder.factory.buildSession({
           finalizedAt: new Date('2018-12-01T01:02:03Z'),
@@ -266,7 +265,7 @@ describe('Certification | Session Management | Acceptance | Application | Routes
   describe('PATCH /api/admin/certification-courses/{certificationCourseId}/unreject', function () {
     it('should create a new unrejected AssessmentResult', async function () {
       // given
-      const userId = (await insertUserWithRoleSuperAdmin()).id;
+      const userId = databaseBuilder.factory.buildUser.withRoleSuperAdmin().id;
 
       const session = databaseBuilder.factory.buildSession({
         finalizedAt: new Date('2018-12-01T01:02:03Z'),
@@ -340,13 +339,15 @@ describe('Certification | Session Management | Acceptance | Application | Routes
         certificationCourseId,
         lastAssessmentResultId: assessmentResultId,
       });
+      const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
+      await databaseBuilder.commit();
 
       server = await createServer();
 
       options = {
         method: 'POST',
         url: `/api/admin/certification-courses/${certificationCourseId}/assessment-results`,
-        headers: generateAuthenticatedUserRequestHeaders(),
+        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
         payload: {
           data: {
             attributes: {
@@ -355,7 +356,6 @@ describe('Certification | Session Management | Acceptance | Application | Routes
           },
         },
       };
-      return insertUserWithRoleSuperAdmin();
     });
 
     it('should respond with a 403 - forbidden access - if user has not role Super Admin', async function () {
@@ -401,16 +401,16 @@ describe('Certification | Session Management | Acceptance | Application | Routes
         }),
       });
 
-      const user = await insertUserWithRoleSuperAdmin();
+      const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
       const session = databaseBuilder.factory.buildSession();
       certificationCourse = databaseBuilder.factory.buildCertificationCourse({
         version: 3,
         sessionId: session.id,
-        userId: user.id,
+        userId: superAdmin.id,
       });
       ({ certificationChallenges, assessmentResult } = await createSuccessfulCertificationCourse({
         sessionId: session.id,
-        userId: user.id,
+        userId: superAdmin.id,
         certificationCourse,
       }));
       await databaseBuilder.commit();
@@ -420,7 +420,7 @@ describe('Certification | Session Management | Acceptance | Application | Routes
       options = {
         method: 'GET',
         url: `/api/admin/certification-courses-v3/${certificationCourse.id}/details`,
-        headers: generateAuthenticatedUserRequestHeaders({ userId: user.id }),
+        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
       };
     });
 
@@ -509,6 +509,8 @@ describe('Certification | Session Management | Acceptance | Application | Routes
         eduV3ExternalJuryResult: null,
         commentByJury: null,
       });
+
+      const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
       await databaseBuilder.commit();
 
       server = await createServer();
@@ -516,7 +518,7 @@ describe('Certification | Session Management | Acceptance | Application | Routes
       options = {
         method: 'POST',
         url: `/api/admin/certification-courses/${certificationCourseFromDB.id}/edu-v3-external-jury-result`,
-        headers: generateAuthenticatedUserRequestHeaders(),
+        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
         payload: {
           data: {
             attributes: {
@@ -525,7 +527,6 @@ describe('Certification | Session Management | Acceptance | Application | Routes
           },
         },
       };
-      return insertUserWithRoleSuperAdmin();
     });
 
     it('should save edu v3 external jury result in database and return the refreshed certification', async function () {

--- a/api/tests/certification/session-management/acceptance/application/certification-details-route_test.js
+++ b/api/tests/certification/session-management/acceptance/application/certification-details-route_test.js
@@ -3,7 +3,6 @@ import {
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
-  insertUserWithRoleSuperAdmin,
   learningContentBuilder,
   mockLearningContent,
 } from '../../../../test-helper.js';
@@ -19,11 +18,13 @@ describe('Certification | Session Management | Acceptance | Application | Routes
     context('when certification match an existing scoring rule', function () {
       it('Should respond with a status 200', async function () {
         // given
-        await insertUserWithRoleSuperAdmin();
+        const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
+        await databaseBuilder.commit();
+
         const options = {
           method: 'GET',
           url: '/api/admin/certifications/1234/details',
-          headers: generateAuthenticatedUserRequestHeaders(),
+          headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
         };
 
         const learningContent = [

--- a/api/tests/certification/session-management/acceptance/application/certification-issue-report-controller_test.js
+++ b/api/tests/certification/session-management/acceptance/application/certification-issue-report-controller_test.js
@@ -3,7 +3,6 @@ import {
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
-  insertUserWithRoleSuperAdmin,
   knex,
 } from '../../../../test-helper.js';
 
@@ -39,7 +38,7 @@ describe('Acceptance | Controller | certification-issue-report-controller', func
       // given
       const server = await createServer();
       const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
-      const superAdmin = await insertUserWithRoleSuperAdmin();
+      const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
       const sessionId = databaseBuilder.factory.buildSession({ certificationCenterId }).id;
       const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({ sessionId }).id;
       const certificationIssueReportId = databaseBuilder.factory.buildCertificationIssueReport({

--- a/api/tests/certification/session-management/acceptance/application/complementary-certification-course-results-controller_test.js
+++ b/api/tests/certification/session-management/acceptance/application/complementary-certification-course-results-controller_test.js
@@ -4,7 +4,6 @@ import {
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
-  insertUserWithRoleSuperAdmin,
 } from '../../../../test-helper.js';
 
 describe('Certification | Session-management | Acceptance | complementary-certification-course-results-controller', function () {
@@ -53,13 +52,13 @@ describe('Certification | Session-management | Acceptance | complementary-certif
         source: ComplementaryCertificationCourseResult.sources.PIX,
       });
 
+      const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
       await databaseBuilder.commit();
 
-      const userId = (await insertUserWithRoleSuperAdmin()).id;
       const options = {
         method: 'POST',
         url: '/api/admin/complementary-certification-course-results',
-        headers: generateAuthenticatedUserRequestHeaders({ userId }),
+        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
         payload: {
           data: {
             attributes: {

--- a/api/tests/certification/session-management/acceptance/application/finalized-session-controller_test.js
+++ b/api/tests/certification/session-management/acceptance/application/finalized-session-controller_test.js
@@ -3,15 +3,15 @@ import {
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
-  insertUserWithRoleSuperAdmin,
 } from '../../../../test-helper.js';
 
 describe('Certification | Session-management | Acceptance | Application | finalized-session-controller', function () {
-  let server, options;
+  let server, options, superAdmin;
 
   beforeEach(async function () {
     server = await createServer();
-    await insertUserWithRoleSuperAdmin();
+    superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
+    await databaseBuilder.commit();
   });
 
   describe('GET /api/admin/sessions/to-publish', function () {
@@ -37,7 +37,7 @@ describe('Certification | Session-management | Acceptance | Application | finali
 
     context('When user is authorized', function () {
       beforeEach(function () {
-        options.headers = generateAuthenticatedUserRequestHeaders();
+        options.headers = generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id });
       });
 
       it('should return a 200 status code response with JSON API serialized', async function () {
@@ -90,7 +90,7 @@ describe('Certification | Session-management | Acceptance | Application | finali
           method: 'GET',
           url: '/api/admin/sessions/with-required-action',
           payload: {},
-          headers: generateAuthenticatedUserRequestHeaders(),
+          headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
         };
 
         // when
@@ -125,7 +125,7 @@ describe('Certification | Session-management | Acceptance | Application | finali
             method: 'GET',
             url: '/api/admin/sessions/with-required-action?filter[version]=3',
             payload: {},
-            headers: generateAuthenticatedUserRequestHeaders(),
+            headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
           };
 
           // when

--- a/api/tests/certification/session-management/acceptance/application/jury-certification-route_test.js
+++ b/api/tests/certification/session-management/acceptance/application/jury-certification-route_test.js
@@ -6,7 +6,6 @@ import {
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
-  insertUserWithRoleSuperAdmin,
 } from '../../../../test-helper.js';
 
 describe('Certification | Session Management | Acceptance | Application | Routes | jury-certification', function () {
@@ -115,12 +114,12 @@ describe('Certification | Session Management | Acceptance | Application | Routes
         competenceId: 'recComp25',
         assessmentResultId: 456,
       });
-      const user = await insertUserWithRoleSuperAdmin();
+      const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
       await databaseBuilder.commit();
       const options = {
         method: 'GET',
         url: '/api/admin/certifications/123',
-        headers: generateAuthenticatedUserRequestHeaders({ userId: user.id }),
+        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
       };
 
       // when

--- a/api/tests/certification/session-management/acceptance/application/jury-comment-route_test.js
+++ b/api/tests/certification/session-management/acceptance/application/jury-comment-route_test.js
@@ -3,7 +3,6 @@ import {
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
-  insertUserWithRoleSuperAdmin,
 } from '../../../../test-helper.js';
 
 describe('Certification | Session Management | Acceptance | Application | Routes| jury-comment', function () {
@@ -11,8 +10,10 @@ describe('Certification | Session Management | Acceptance | Application | Routes
     it('should respond with 204', async function () {
       // given
       const server = await createServer();
-      await insertUserWithRoleSuperAdmin();
+      const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
       const session = databaseBuilder.factory.buildSession();
+      await databaseBuilder.commit();
+
       const options = {
         method: 'PUT',
         payload: {
@@ -22,10 +23,9 @@ describe('Certification | Session Management | Acceptance | Application | Routes
             },
           },
         },
-        headers: generateAuthenticatedUserRequestHeaders(),
+        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
         url: `/api/admin/sessions/${session.id}/comment`,
       };
-      await databaseBuilder.commit();
 
       // when
       const response = await server.inject(options);
@@ -39,11 +39,12 @@ describe('Certification | Session Management | Acceptance | Application | Routes
     it('should respond with 204', async function () {
       // given
       const server = await createServer();
-      await insertUserWithRoleSuperAdmin();
+      const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
       const session = databaseBuilder.factory.buildSession();
       await databaseBuilder.commit();
+
       const options = {
-        headers: generateAuthenticatedUserRequestHeaders(),
+        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
         method: 'DELETE',
         url: `/api/admin/sessions/${session.id}/comment`,
       };

--- a/api/tests/certification/session-management/acceptance/application/session-route_test.js
+++ b/api/tests/certification/session-management/acceptance/application/session-route_test.js
@@ -3,7 +3,6 @@ import {
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
-  insertUserWithRoleSuperAdmin,
 } from '../../../../test-helper.js';
 
 describe('Certification | Session Management | Acceptance | Application | Route | Session', function () {
@@ -11,7 +10,6 @@ describe('Certification | Session Management | Acceptance | Application | Route 
 
   beforeEach(async function () {
     server = await createServer();
-    await insertUserWithRoleSuperAdmin();
   });
 
   describe('GET /api/admin/sessions', function () {
@@ -28,8 +26,10 @@ describe('Certification | Session Management | Acceptance | Application | Route 
     });
 
     context('when user is Super Admin', function () {
-      beforeEach(function () {
-        options.headers = generateAuthenticatedUserRequestHeaders();
+      beforeEach(async function () {
+        const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
+        await databaseBuilder.commit();
+        options.headers = generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id });
       });
 
       it('should return a 200 status code response with JSON API serialized', async function () {
@@ -146,8 +146,10 @@ describe('Certification | Session Management | Acceptance | Application | Route 
     });
 
     context('when user is Super Admin', function () {
-      beforeEach(function () {
-        options.headers = generateAuthenticatedUserRequestHeaders();
+      beforeEach(async function () {
+        const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
+        await databaseBuilder.commit();
+        options.headers = generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id });
       });
 
       it('should return a 200 status code response with JSON API serialized', async function () {

--- a/api/tests/certification/session-management/acceptance/application/update-cpf-import-status-controller_test.js
+++ b/api/tests/certification/session-management/acceptance/application/update-cpf-import-status-controller_test.js
@@ -4,9 +4,9 @@ import * as url from 'node:url';
 
 import {
   createServer,
+  databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
-  insertUserWithRoleSuperAdmin,
   nock,
 } from '../../../../test-helper.js';
 
@@ -44,7 +44,9 @@ describe('Acceptance | Controller | Session | update-cpf-import-status-controlle
   describe('PUT /api/admin/cpf/receipts', function () {
     it('should return an OK (200) status', async function () {
       // given
-      const superAdmin = await insertUserWithRoleSuperAdmin();
+      const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
+      await databaseBuilder.commit();
+
       const options = {
         method: 'PUT',
         url: '/api/admin/cpf/receipts',

--- a/api/tests/devcomp/acceptance/application/modules-metadata/module-metadata-route_test.js
+++ b/api/tests/devcomp/acceptance/application/modules-metadata/module-metadata-route_test.js
@@ -3,7 +3,6 @@ import {
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
-  insertUserWithRoleSuperAdmin,
 } from '../../../../test-helper.js';
 
 describe('Acceptance | Controller | Modules Metadata | Route', function () {
@@ -17,7 +16,7 @@ describe('Acceptance | Controller | Modules Metadata | Route', function () {
     context('when modules exists', function () {
       it('should return modules metadata', async function () {
         // given
-        const superAdmin = await insertUserWithRoleSuperAdmin();
+        const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
         await databaseBuilder.commit();
 
         const options = {

--- a/api/tests/devcomp/acceptance/application/trainings/training-route_test.js
+++ b/api/tests/devcomp/acceptance/application/trainings/training-route_test.js
@@ -3,7 +3,6 @@ import {
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
-  insertUserWithRoleSuperAdmin,
   knex,
   learningContentBuilder,
   mockLearningContent,
@@ -72,7 +71,7 @@ describe('Acceptance | Controller | training-controller', function () {
 
     it('should get a training with the specific id', async function () {
       // given
-      const superAdmin = await insertUserWithRoleSuperAdmin();
+      const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
       databaseBuilder.factory.buildTraining();
       const { id: trainingId, ...trainingAttributes } = databaseBuilder.factory.buildTraining();
       const trainingTrigger = databaseBuilder.factory.buildTrainingTrigger({ trainingId });
@@ -148,7 +147,8 @@ describe('Acceptance | Controller | training-controller', function () {
   describe('POST /api/admin/trainings', function () {
     it('should create a new training and response with a 201', async function () {
       // given
-      const superAdmin = await insertUserWithRoleSuperAdmin();
+      const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
+      await databaseBuilder.commit();
 
       const expectedResponse = {
         type: 'trainings',
@@ -204,7 +204,7 @@ describe('Acceptance | Controller | training-controller', function () {
   describe('POST /api/admin/trainings/{trainingId}/duplicate', function () {
     it('should duplicate an existing training and response with a 201', async function () {
       // given
-      const superAdmin = await insertUserWithRoleSuperAdmin();
+      const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
       const training = databaseBuilder.factory.buildTraining();
       await databaseBuilder.commit();
 
@@ -227,7 +227,7 @@ describe('Acceptance | Controller | training-controller', function () {
     describe('nominal case', function () {
       it('should update training and response with a 200', async function () {
         // given
-        const superAdmin = await insertUserWithRoleSuperAdmin();
+        const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
         const training = databaseBuilder.factory.buildTraining();
         await databaseBuilder.commit();
         const locales = ['fr', 'fr-fr'];
@@ -314,7 +314,7 @@ describe('Acceptance | Controller | training-controller', function () {
 
     it('should delete trigger related to training', async function () {
       // given
-      const superAdmin = await insertUserWithRoleSuperAdmin();
+      const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
       const training = databaseBuilder.factory.buildTraining();
       const trainingTrigger = databaseBuilder.factory.buildTrainingTrigger({
         trainingId: training.id,
@@ -352,7 +352,7 @@ describe('Acceptance | Controller | training-controller', function () {
     describe('nominal case', function () {
       it('should find training summaries and respond with a 200', async function () {
         // given
-        const superAdmin = await insertUserWithRoleSuperAdmin();
+        const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
         const training = databaseBuilder.factory.buildTraining();
         await databaseBuilder.commit();
 
@@ -445,7 +445,7 @@ describe('Acceptance | Controller | training-controller', function () {
 
     it('should update training trigger', async function () {
       // given
-      const superAdmin = await insertUserWithRoleSuperAdmin();
+      const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
       const trainingId = databaseBuilder.factory.buildTraining().id;
       const tube = { tubeId: 'recTube0_0', level: 2 };
       await databaseBuilder.commit();
@@ -500,7 +500,7 @@ describe('Acceptance | Controller | training-controller', function () {
   describe('GET /api/admin/trainings/{trainingId}/target-profile-summaries', function () {
     it('should get target-profile-summaries related to training id', async function () {
       // given
-      const superAdmin = await insertUserWithRoleSuperAdmin();
+      const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
       const training = databaseBuilder.factory.buildTraining();
       const targetProfile = databaseBuilder.factory.buildTargetProfile({
         id: 1,
@@ -543,14 +543,13 @@ describe('Acceptance | Controller | training-controller', function () {
   });
 
   describe('POST /api/admin/trainings/{id}/attach-target-profiles', function () {
-    let userId;
+    let superAdmin;
     let trainingId;
     let alreadyAttachedTargetProfileId;
     let toAttachTargetProfileId;
 
     beforeEach(async function () {
-      const adminUser = await insertUserWithRoleSuperAdmin();
-      userId = adminUser.id;
+      superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
       trainingId = databaseBuilder.factory.buildTraining().id;
       alreadyAttachedTargetProfileId = databaseBuilder.factory.buildTargetProfile().id;
       toAttachTargetProfileId = databaseBuilder.factory.buildTargetProfile().id;
@@ -567,7 +566,7 @@ describe('Acceptance | Controller | training-controller', function () {
         const options = {
           method: 'POST',
           url: `/api/admin/trainings/${trainingId}/attach-target-profiles`,
-          headers: generateAuthenticatedUserRequestHeaders({ userId }),
+          headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
           payload: {
             'target-profile-ids': [alreadyAttachedTargetProfileId, toAttachTargetProfileId],
           },
@@ -590,8 +589,7 @@ describe('Acceptance | Controller | training-controller', function () {
   describe('DELETE /api/admin/trainings/{trainingId}/target-profiles/{targetProfileId}', function () {
     it('should detach target profile from given training', async function () {
       // given
-      const adminUser = await insertUserWithRoleSuperAdmin();
-      const userId = adminUser.id;
+      const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
       const trainingId = databaseBuilder.factory.buildTraining().id;
       const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
       databaseBuilder.factory.buildTargetProfileTraining({
@@ -603,7 +601,7 @@ describe('Acceptance | Controller | training-controller', function () {
       const options = {
         method: 'DELETE',
         url: `/api/admin/trainings/${trainingId}/target-profiles/${targetProfileId}`,
-        headers: generateAuthenticatedUserRequestHeaders({ userId }),
+        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
       };
 
       // when

--- a/api/tests/evaluation/acceptance/application/autonomous-courses/autonomous-course-controller_test.js
+++ b/api/tests/evaluation/acceptance/application/autonomous-courses/autonomous-course-controller_test.js
@@ -4,7 +4,6 @@ import {
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
-  insertUserWithRoleSuperAdmin,
   knex,
   learningContentBuilder,
   mockLearningContent,
@@ -194,7 +193,7 @@ describe('Acceptance | API | Autonomous Course', function () {
 
     it('should get a autonomous course with the specific id', async function () {
       // given
-      const superAdmin = await insertUserWithRoleSuperAdmin();
+      const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
       const { id: autonomousCourseId, ...autonomousCourseAttributes } = databaseBuilder.factory.buildCampaign({
         name: 'Nom interne parcours autonome',
         title: 'Nom externe parcours autonome',
@@ -254,7 +253,7 @@ describe('Acceptance | API | Autonomous Course', function () {
 
     it('should update the autonomous course', async function () {
       // given
-      const superAdmin = await insertUserWithRoleSuperAdmin();
+      const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
       const { id: autonomousCourseId } = databaseBuilder.factory.buildCampaign({
         name: 'Nom interne parcours autonome',
         title: 'Nom externe parcours autonome',

--- a/api/tests/evaluation/acceptance/application/badge-criteria/badge-criteria-controller_test.js
+++ b/api/tests/evaluation/acceptance/application/badge-criteria/badge-criteria-controller_test.js
@@ -3,7 +3,6 @@ import {
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
-  insertUserWithRoleSuperAdmin,
   knex,
 } from '../../../../test-helper.js';
 
@@ -17,7 +16,7 @@ describe('Acceptance | API | Badge Criteria', function () {
   describe('PATCH /api/admin/badge-criteria/{badgeCriterionId}', function () {
     it('should update the badge criterion', async function () {
       // given
-      const superAdmin = await insertUserWithRoleSuperAdmin();
+      const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
       const initialBadgeCriterion = databaseBuilder.factory.buildBadgeCriterion({
         name: 'old name',
         threshold: 10,

--- a/api/tests/identity-access-management/acceptance/application/anonymization.admin.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/anonymization.admin.route.test.js
@@ -3,7 +3,6 @@ import {
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
-  insertUserWithRoleSuperAdmin,
 } from '../../../test-helper.js';
 
 describe('Acceptance | Identity Access Management | Application | Route | Admin | Anonymization', function () {
@@ -17,7 +16,7 @@ describe('Acceptance | Identity Access Management | Application | Route | Admin 
     context('when a CSV file is loaded', function () {
       it('responds with a 200 and serialized payload', async function () {
         // given
-        const user = await insertUserWithRoleSuperAdmin();
+        const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
 
         const userId1 = databaseBuilder.factory.buildUser().id;
         const userId2 = databaseBuilder.factory.buildUser().id;
@@ -45,7 +44,7 @@ describe('Acceptance | Identity Access Management | Application | Route | Admin 
 
         const options = {
           method: 'POST',
-          headers: generateAuthenticatedUserRequestHeaders({ userId: user.id }),
+          headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
           url: '/api/admin/anonymize/gar',
           payload: input,
         };
@@ -69,13 +68,12 @@ describe('Acceptance | Identity Access Management | Application | Route | Admin 
   describe('GET /api/admin/anonymize/gar/template', function () {
     it('responds with a 200 and serialized payload', async function () {
       // given
-      const user = await insertUserWithRoleSuperAdmin();
-
+      const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
       await databaseBuilder.commit();
 
       const options = {
         method: 'GET',
-        headers: generateAuthenticatedUserRequestHeaders({ userId: user.id }),
+        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
         url: '/api/admin/anonymize/gar/template',
       };
 

--- a/api/tests/identity-access-management/acceptance/application/oidc-provider.admin.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/oidc-provider.admin.route.test.js
@@ -7,7 +7,6 @@ import {
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
-  insertUserWithRoleSuperAdmin,
   knex,
 } from '../../../test-helper.js';
 import { createMockedTestOidcProviders } from '../../../tooling/openid-client/openid-client-mocks.js';
@@ -20,7 +19,9 @@ describe('Acceptance | Identity Access Management | Route | Admin | oidc-provide
       // given
       server = await createServer();
 
-      const superAdmin = await insertUserWithRoleSuperAdmin();
+      const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
+      await databaseBuilder.commit();
+
       const payload = [
         {
           application: 'orga',
@@ -83,7 +84,9 @@ describe('Acceptance | Identity Access Management | Route | Admin | oidc-provide
       await createMockedTestOidcProviders([{ application: 'admin', applicationTld: '.fr' }]);
       server = await createServer();
 
-      const superAdmin = await insertUserWithRoleSuperAdmin();
+      const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
+      await databaseBuilder.commit();
+
       const options = {
         method: 'GET',
         url: '/api/admin/oidc/identity-providers',
@@ -133,7 +136,9 @@ describe('Acceptance | Identity Access Management | Route | Admin | oidc-provide
         ]);
         server = await createServer();
 
-        const superAdmin = await insertUserWithRoleSuperAdmin();
+        const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
+        await databaseBuilder.commit();
+
         const options = {
           method: 'GET',
           url: '/api/admin/oidc/identity-providers',

--- a/api/tests/identity-access-management/acceptance/application/user/user.admin.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/user/user.admin.route.test.js
@@ -5,7 +5,6 @@ import {
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
-  insertUserWithRoleSuperAdmin,
   knex,
   sinon,
 } from '../../../../test-helper.js';
@@ -22,7 +21,7 @@ describe('Acceptance | Identity Access Management | Application | Route | Admin 
       // given
       const userId = databaseBuilder.factory.buildUser.withRawPassword().id;
       const userLoginId = databaseBuilder.factory.buildUserLogin({ userId }).id;
-      const superAdmin = await insertUserWithRoleSuperAdmin();
+      const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
       await databaseBuilder.commit();
 
       // when
@@ -60,14 +59,16 @@ describe('Acceptance | Identity Access Management | Application | Route | Admin 
       context('When filters match a list of users', function () {
         it('retrieves this list of users', async function () {
           // given
-          const user = await insertUserWithRoleSuperAdmin();
+          const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
+          await databaseBuilder.commit();
+
           const params =
             '?filter[firstName]=Ann' + '&page[number]=1&page[size]=25' + `&queryType=${QUERY_TYPES.EXACT_QUERY}`;
 
           requestOptions = {
             method: 'GET',
             url: `/api/admin/users${params}`,
-            headers: generateAuthenticatedUserRequestHeaders({ userId: user.id }),
+            headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
           };
           // when
           const response = await server.inject(requestOptions);
@@ -84,14 +85,16 @@ describe('Acceptance | Identity Access Management | Application | Route | Admin 
       context('When filters match a list of users', function () {
         it('retrieves this list of users', async function () {
           // given
-          const user = await insertUserWithRoleSuperAdmin();
+          const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
+          await databaseBuilder.commit();
+
           const params =
             '?filter[firstName]=Ann' + '&page[number]=1&page[size]=25' + `&queryType=${QUERY_TYPES.CONTAINS}`;
 
           requestOptions = {
             method: 'GET',
             url: `/api/admin/users${params}`,
-            headers: generateAuthenticatedUserRequestHeaders({ userId: user.id }),
+            headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
           };
           // when
           const response = await server.inject(requestOptions);
@@ -105,10 +108,12 @@ describe('Acceptance | Identity Access Management | Application | Route | Admin 
   });
 
   describe('PATCH /api/admin/users', function () {
-    let user;
+    let superAdmin, user;
 
     beforeEach(async function () {
-      user = await insertUserWithRoleSuperAdmin();
+      superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
+      user = databaseBuilder.factory.buildUser({ firstName: 'Ann' });
+      await databaseBuilder.commit();
     });
 
     it('replies with 200 status code, when user details are updated', async function () {
@@ -116,7 +121,7 @@ describe('Acceptance | Identity Access Management | Application | Route | Admin 
       const options = {
         method: 'PATCH',
         url: `/api/admin/users/${user.id}`,
-        headers: generateAuthenticatedUserRequestHeaders({ userId: user.id }),
+        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
         payload: {
           data: {
             id: user.id,
@@ -137,7 +142,7 @@ describe('Acceptance | Identity Access Management | Application | Route | Admin 
 
       // then
       expect(response.statusCode).to.equal(200);
-      expect(response.result.data.id).to.equal('1234');
+      expect(response.result.data.id).to.equal(String(user.id));
       expect(response.result.data.type).to.equal('users');
       expect(response.result.data.attributes.email).to.equal('emailUpdated@example.net');
       expect(response.result.data.relationships['organization-learners']).to.not.be.undefined;
@@ -149,10 +154,10 @@ describe('Acceptance | Identity Access Management | Application | Route | Admin 
         // given
         const options = {
           method: 'PATCH',
-          url: `/api/admin/users/${user.id}`,
+          url: `/api/admin/users/${superAdmin.id}`,
           payload: {
             data: {
-              id: user.id,
+              id: superAdmin.id,
               attributes: {
                 firstName: 'firstNameUpdated',
                 lastName: 'lastNameUpdated',
@@ -170,17 +175,17 @@ describe('Acceptance | Identity Access Management | Application | Route | Admin 
       });
 
       it('replies with forbidden error', async function () {
-        user = databaseBuilder.factory.buildUser({ email: 'partial.update@example.net' });
+        superAdmin = databaseBuilder.factory.buildUser({ email: 'partial.update@example.net' });
         await databaseBuilder.commit();
 
         // given
         const options = {
           method: 'PATCH',
-          url: `/api/admin/users/${user.id}`,
-          headers: generateAuthenticatedUserRequestHeaders({ userId: user.id }),
+          url: `/api/admin/users/${superAdmin.id}`,
+          headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
           payload: {
             data: {
-              id: user.id,
+              id: superAdmin.id,
               attributes: {
                 'first-name': 'firstNameUpdated',
                 'last-name': 'lastNameUpdated',
@@ -201,15 +206,12 @@ describe('Acceptance | Identity Access Management | Application | Route | Admin 
 
   describe('GET /admin/users/{id}', function () {
     let clock;
-    let server;
 
     beforeEach(async function () {
       clock = sinon.useFakeTimers({
         now: Date.now(),
         toFake: ['Date'],
       });
-
-      server = await createServer();
     });
 
     afterEach(function () {
@@ -240,7 +242,8 @@ describe('Acceptance | Identity Access Management | Application | Route | Admin 
     describe('Success case', function () {
       it('returns 200 and user serialized', async function () {
         // given
-        const superAdmin = await insertUserWithRoleSuperAdmin();
+        const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
+        await databaseBuilder.commit();
 
         const user = databaseBuilder.factory.buildUser({ username: 'brice.glace0712', locale: 'fr-FR' });
         const blockedAt = new Date('2022-12-07');
@@ -348,7 +351,7 @@ describe('Acceptance | Identity Access Management | Application | Route | Admin 
       describe('When user has a learner without firstName and lastName (ex: from a simplified campaign)', function () {
         it('returns 200', async function () {
           // given
-          const superAdmin = await insertUserWithRoleSuperAdmin();
+          const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
           const user = databaseBuilder.factory.buildUser();
           databaseBuilder.factory.buildOrganizationLearner({ firstName: '', lastName: '', userId: user.id });
           await databaseBuilder.commit();
@@ -368,7 +371,6 @@ describe('Acceptance | Identity Access Management | Application | Route | Admin 
   });
 
   describe('POST /admin/users/{id}/anonymize', function () {
-    let server;
     let superAdmin;
     let response;
     let userId;
@@ -376,10 +378,8 @@ describe('Acceptance | Identity Access Management | Application | Route | Admin 
     let organizationId;
 
     beforeEach(async function () {
-      server = await createServer();
-      superAdmin = await insertUserWithRoleSuperAdmin();
-      const user = databaseBuilder.factory.buildUser.withRawPassword();
-      userId = user.id;
+      superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
+      userId = databaseBuilder.factory.buildUser.withRawPassword().id;
       organizationId = databaseBuilder.factory.buildOrganization().id;
       databaseBuilder.factory.buildMembership({
         organizationId,
@@ -390,9 +390,7 @@ describe('Acceptance | Identity Access Management | Application | Route | Admin 
         certificationCenterId,
         userId: userId,
       });
-
       databaseBuilder.factory.buildOrganizationLearner({ userId, organizationId });
-
       await databaseBuilder.commit();
 
       response = await server.inject({
@@ -415,7 +413,7 @@ describe('Acceptance | Identity Access Management | Application | Route | Admin 
       expect(updatedUserAttributes.username).to.be.null;
 
       expect(updatedUserAttributes['has-been-anonymised']).to.be.true;
-      expect(updatedUserAttributes['anonymised-by-full-name']).to.equal('Super Papa');
+      expect(updatedUserAttributes['anonymised-by-full-name']).to.equal('Billy TheKid');
       expect(updatedUserAttributes['updated-at']).to.exist;
     });
 
@@ -443,8 +441,7 @@ describe('Acceptance | Identity Access Management | Application | Route | Admin 
   describe('POST /api/users/{id}/add-pix-authentication-method', function () {
     it('returns 201 HTTP status code', async function () {
       // given
-      const server = await createServer();
-      const superAdmin = await insertUserWithRoleSuperAdmin();
+      const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
       const user = databaseBuilder.factory.buildUser({ email: null });
       await databaseBuilder.commit();
 
@@ -471,19 +468,17 @@ describe('Acceptance | Identity Access Management | Application | Route | Admin 
   });
 
   describe('POST /api/admin/users/{id}/remove-authentication', function () {
-    let server;
     let user;
     let options;
 
     beforeEach(async function () {
-      server = await createServer();
       user = databaseBuilder.factory.buildUser({ username: 'jhn.doe0101', email: null });
       databaseBuilder.factory.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({
         userId: user.id,
       });
       databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider({ userId: user.id });
 
-      const superAdmin = await insertUserWithRoleSuperAdmin();
+      const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
       options = {
         method: 'POST',
         url: `/api/admin/users/${user.id}/remove-authentication`,
@@ -531,12 +526,10 @@ describe('Acceptance | Identity Access Management | Application | Route | Admin 
   });
 
   describe('POST /api/admin/users/{userId}/authentication-methods/{authenticationMethodId}', function () {
-    let server;
     let superAdmin;
 
     beforeEach(async function () {
-      server = await createServer();
-      superAdmin = await insertUserWithRoleSuperAdmin();
+      superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
     });
 
     it('returns 204 HTTP status code', async function () {

--- a/api/tests/organizational-entities/acceptance/application/administration-team/administration-team.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/administration-team/administration-team.admin.route.test.js
@@ -3,7 +3,6 @@ import {
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
-  insertUserWithRoleSuperAdmin,
 } from '../../../../test-helper.js';
 
 describe('Acceptance | Organizational Entities | Application | Route | Admin | AdministrationTeam', function () {
@@ -13,14 +12,19 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | A
       const server = await createServer();
       const team1 = databaseBuilder.factory.buildAdministrationTeam({ name: 'Team1' });
       const team2 = databaseBuilder.factory.buildAdministrationTeam({ name: 'Team2' });
+      const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
       await databaseBuilder.commit();
-      const userId = (await insertUserWithRoleSuperAdmin()).id;
-      const options = {
+
+      // when
+      const response = await server.inject({
         method: 'GET',
         url: '/api/admin/administration-teams',
-        headers: generateAuthenticatedUserRequestHeaders({ userId }),
-      };
-      const expectedTeams = [
+        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
+      });
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result.data).to.deep.equal([
         {
           attributes: {
             name: team1.name,
@@ -35,14 +39,7 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | A
           id: team2.id.toString(),
           type: 'administration-teams',
         },
-      ];
-
-      // when
-      const response = await server.inject(options);
-
-      // then
-      expect(response.statusCode).to.equal(200);
-      expect(response.result.data).to.deep.equal(expectedTeams);
+      ]);
     });
   });
 });

--- a/api/tests/organizational-entities/acceptance/application/certification-center/certification-center.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/certification-center/certification-center.admin.route.test.js
@@ -3,16 +3,16 @@ import {
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
-  insertUserWithRoleSuperAdmin,
   knex,
 } from '../../../../test-helper.js';
 
 describe('Acceptance | Organization Entities | Admin | Route | Certification Centers', function () {
-  let adminMember, request, server;
+  let superAdmin, request, server;
 
   beforeEach(async function () {
     server = await createServer();
-    adminMember = await insertUserWithRoleSuperAdmin();
+    superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
+    await databaseBuilder.commit();
   });
 
   describe('GET /api/admin/certification-centers', function () {
@@ -25,7 +25,7 @@ describe('Acceptance | Organization Entities | Admin | Route | Certification Cen
 
     context('when user is Super Admin', function () {
       beforeEach(function () {
-        request.headers = generateAuthenticatedUserRequestHeaders();
+        request.headers = generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id });
       });
 
       it('returns a list of certificationCenter, with their name and id', async function () {
@@ -157,7 +157,7 @@ describe('Acceptance | Organization Entities | Admin | Route | Certification Cen
         const response = await server.inject({
           method: 'POST',
           url: '/api/admin/certification-centers',
-          headers: generateAuthenticatedUserRequestHeaders(),
+          headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
           payload: {
             data: {
               type: 'certification-center',
@@ -248,7 +248,7 @@ describe('Acceptance | Organization Entities | Admin | Route | Certification Cen
 
     context('when user is Super Admin', function () {
       beforeEach(function () {
-        request.headers = generateAuthenticatedUserRequestHeaders();
+        request.headers = generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id });
       });
 
       it('returns 200 HTTP status', async function () {
@@ -354,7 +354,7 @@ describe('Acceptance | Organization Entities | Admin | Route | Certification Cen
 
         // when
         const { result, statusCode } = await server.inject({
-          headers: generateAuthenticatedUserRequestHeaders({ userId: adminMember.id }),
+          headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
           method: 'PATCH',
           payload: {
             data: {
@@ -399,21 +399,21 @@ describe('Acceptance | Organization Entities | Admin | Route | Certification Cen
       const response = await server.inject({
         method: 'POST',
         url: `/api/admin/certification-centers/${certificationCenterId}/archive`,
-        headers: generateAuthenticatedUserRequestHeaders({ userId: adminMember.id }),
+        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
       });
 
       // then
       expect(response.statusCode).to.equal(204);
 
       const archivedCenter = await knex('certification-centers').where({ id: certificationCenterId }).first();
-      expect(archivedCenter.archivedBy).to.deep.equal(adminMember.id);
+      expect(archivedCenter.archivedBy).to.deep.equal(superAdmin.id);
       expect(archivedCenter.archivedAt).to.be.instanceOf(Date);
       expect(archivedCenter.archivedAt).not.to.deep.equal(previousUpdate);
 
       const disabledMembership = await knex('certification-center-memberships')
         .where({ certificationCenterId })
         .first();
-      expect(disabledMembership.updatedByUserId).to.equal(adminMember.id);
+      expect(disabledMembership.updatedByUserId).to.equal(superAdmin.id);
       expect(disabledMembership.disabledAt).to.deep.equal(archivedCenter.archivedAt);
 
       const cancelledInvitation = await knex('certification-center-invitations')
@@ -429,7 +429,7 @@ describe('Acceptance | Organization Entities | Admin | Route | Certification Cen
       // given
       const options = {
         method: 'GET',
-        headers: generateAuthenticatedUserRequestHeaders({ userId: adminMember.id }),
+        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
         url: '/api/admin/certification-centers/batch-archive/template',
       };
 
@@ -462,7 +462,7 @@ describe('Acceptance | Organization Entities | Admin | Route | Certification Cen
         const response = await server.inject({
           method: 'POST',
           url: `/api/admin/certification-centers/batch-archive`,
-          headers: generateAuthenticatedUserRequestHeaders({ userId: adminMember.id }),
+          headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
           payload: buffer,
         });
 
@@ -475,8 +475,8 @@ describe('Acceptance | Organization Entities | Admin | Route | Certification Cen
           .first();
 
         expect(response.statusCode).to.equal(204);
-        expect(archivedCertificationCenter1.archivedBy).to.deep.equal(adminMember.id);
-        expect(archivedCertificationCenter2.archivedBy).to.deep.equal(adminMember.id);
+        expect(archivedCertificationCenter1.archivedBy).to.deep.equal(superAdmin.id);
+        expect(archivedCertificationCenter2.archivedBy).to.deep.equal(superAdmin.id);
         expect(archivedCertificationCenter1.archivedAt).not.to.be.null;
         expect(archivedCertificationCenter2.archivedAt).not.to.be.null;
       });
@@ -509,7 +509,7 @@ describe('Acceptance | Organization Entities | Admin | Route | Certification Cen
         const response = await server.inject({
           method: 'POST',
           url: `/api/admin/certification-centers/batch-archive`,
-          headers: generateAuthenticatedUserRequestHeaders({ userId: adminMember.id }),
+          headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
           payload: buffer,
         });
 
@@ -527,8 +527,8 @@ describe('Acceptance | Organization Entities | Admin | Route | Certification Cen
           currentLine: 3,
           totalLines: 4,
         });
-        expect(archivedCertificationCenter1.archivedBy).to.deep.equal(adminMember.id);
-        expect(archivedCertificationCenter2.archivedBy).to.deep.equal(adminMember.id);
+        expect(archivedCertificationCenter1.archivedBy).to.deep.equal(superAdmin.id);
+        expect(archivedCertificationCenter2.archivedBy).to.deep.equal(superAdmin.id);
         expect(archivedCertificationCenter1.archivedAt).not.to.be.null;
         expect(archivedCertificationCenter2.archivedAt).not.to.be.null;
       });
@@ -539,7 +539,7 @@ describe('Acceptance | Organization Entities | Admin | Route | Certification Cen
         const options = {
           method: 'POST',
           url: '/api/admin/certification-centers/batch-archive',
-          headers: generateAuthenticatedUserRequestHeaders({ userId: adminMember.id }),
+          headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
           payload: buffer,
         };
 

--- a/api/tests/organizational-entities/acceptance/application/network/network.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/network/network.admin.route.test.js
@@ -3,7 +3,6 @@ import {
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
-  insertUserWithRoleSuperAdmin,
   knex,
 } from '../../../../test-helper.js';
 
@@ -12,7 +11,7 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | N
   let server;
 
   beforeEach(async function () {
-    superAdmin = await insertUserWithRoleSuperAdmin();
+    superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
     await databaseBuilder.commit();
 
     server = await createServer();
@@ -28,7 +27,7 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | N
       const options = {
         method: 'GET',
         url: '/api/admin/networks',
-        headers: generateAuthenticatedUserRequestHeaders(superAdmin),
+        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
       };
       const expectedNetworks = [
         {
@@ -69,7 +68,7 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | N
       const options = {
         method: 'GET',
         url: '/api/admin/networks/1',
-        headers: generateAuthenticatedUserRequestHeaders(superAdmin),
+        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
       };
       const expectedNetwork = {
         attributes: {
@@ -101,7 +100,7 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | N
       const request = {
         method: 'PATCH',
         url: `/api/admin/networks/${network.id}`,
-        headers: generateAuthenticatedUserRequestHeaders(superAdmin),
+        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
         payload: {
           data: {
             attributes: {
@@ -130,7 +129,7 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | N
       const options = {
         method: 'GET',
         url: '/api/admin/networks?filter[name]=Bretagne',
-        headers: generateAuthenticatedUserRequestHeaders(superAdmin),
+        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
       };
 
       // when
@@ -153,7 +152,7 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | N
       const request = {
         method: 'POST',
         url: '/api/admin/networks',
-        headers: generateAuthenticatedUserRequestHeaders(superAdmin),
+        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
         payload: {
           data: {
             attributes: {

--- a/api/tests/organizational-entities/acceptance/application/organization-learner-type/organization-learner-type.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/organization-learner-type/organization-learner-type.admin.route.test.js
@@ -3,7 +3,6 @@ import {
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
-  insertUserWithRoleSuperAdmin,
 } from '../../../../test-helper.js';
 
 describe('Acceptance | Organizational Entities | Application | Route | Admin | OrganizationLearnerTypes', function () {
@@ -19,14 +18,19 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
         id: 456,
         name: 'Public 2',
       });
+      const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
       await databaseBuilder.commit();
-      const userId = (await insertUserWithRoleSuperAdmin()).id;
-      const options = {
+
+      // when
+      const response = await server.inject({
         method: 'GET',
         url: '/api/admin/organization-learner-types',
-        headers: generateAuthenticatedUserRequestHeaders({ userId }),
-      };
-      const expectedOrganizationLearnerTypes = [
+        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
+      });
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result.data).to.deep.equal([
         {
           attributes: {
             name: organizationLearnerType1.name,
@@ -41,14 +45,7 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
           id: '456',
           type: 'organization-learner-types',
         },
-      ];
-
-      // when
-      const response = await server.inject(options);
-
-      // then
-      expect(response.statusCode).to.equal(200);
-      expect(response.result.data).to.deep.equal(expectedOrganizationLearnerTypes);
+      ]);
     });
   });
 });

--- a/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
@@ -11,7 +11,6 @@ import {
   expect,
   generateAuthenticatedUserRequestHeaders,
   insertMultipleSendingFeatureForNewOrganization,
-  insertUserWithRoleSuperAdmin,
   knex,
 } from '../../../../test-helper.js';
 
@@ -23,7 +22,7 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
   let server;
 
   beforeEach(async function () {
-    superAdmin = await insertUserWithRoleSuperAdmin();
+    superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
     await insertMultipleSendingFeatureForNewOrganization();
     await databaseBuilder.commit();
 
@@ -414,7 +413,7 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
         method: 'POST',
         url: '/api/admin/organizations',
         payload,
-        headers: generateAuthenticatedUserRequestHeaders(),
+        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
       };
     });
 
@@ -894,7 +893,7 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
         method: 'PATCH',
         url: `/api/admin/organizations/${organization.id}`,
         payload,
-        headers: generateAuthenticatedUserRequestHeaders(),
+        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
       };
 
       // when
@@ -1565,7 +1564,7 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
       const options = {
         method: 'GET',
         url: `/api/admin/organizations/${organizationId}/places-statistics`,
-        headers: generateAuthenticatedUserRequestHeaders({ superAdmin }),
+        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
       };
 
       // when

--- a/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
@@ -10,7 +10,6 @@ import {
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
-  insertMultipleSendingFeatureForNewOrganization,
   knex,
 } from '../../../../test-helper.js';
 
@@ -23,7 +22,7 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
 
   beforeEach(async function () {
     superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
-    await insertMultipleSendingFeatureForNewOrganization();
+    databaseBuilder.factory.buildFeature(ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT);
     await databaseBuilder.commit();
 
     server = await createServer();

--- a/api/tests/organizational-entities/acceptance/application/tag/tag.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/tag/tag.admin.route.test.js
@@ -6,7 +6,6 @@ import {
   expect,
   generateAuthenticatedUserRequestHeaders,
   insertUserWithRoleCertif,
-  insertUserWithRoleSuperAdmin,
 } from '../../../../test-helper.js';
 
 describe('Acceptance | Organizational Entities | Application | Route | Admin | Tag', function () {
@@ -16,14 +15,13 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | T
       const server = await createServer();
       const tag1 = databaseBuilder.factory.buildTag({ name: 'TAG1' });
       const tag2 = databaseBuilder.factory.buildTag({ name: 'TAG2' });
+      const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
       await databaseBuilder.commit();
-
-      const userId = (await insertUserWithRoleSuperAdmin()).id;
 
       const options = {
         method: 'GET',
         url: '/api/admin/tags',
-        headers: generateAuthenticatedUserRequestHeaders({ userId }),
+        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
       };
 
       const expectedTags = [
@@ -77,9 +75,8 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | T
         // given
         const tagName = 'SUPER TAG';
         const server = await createServer();
+        const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
         await databaseBuilder.commit();
-
-        const userId = (await insertUserWithRoleSuperAdmin()).id;
 
         // when
         const response = await server.inject({
@@ -93,7 +90,7 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | T
               },
             },
           },
-          headers: generateAuthenticatedUserRequestHeaders({ userId }),
+          headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
         });
 
         // then
@@ -153,15 +150,14 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | T
           _buildOrganizationTags(organization.id, tagIds);
         }
 
+        const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
         await databaseBuilder.commit();
-
-        const userId = (await insertUserWithRoleSuperAdmin()).id;
 
         // when
         const { statusCode, result } = await server.inject({
           method: 'GET',
           url: `/api/admin/tags/${basedTag.id}/recently-used`,
-          headers: generateAuthenticatedUserRequestHeaders({ userId }),
+          headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
         });
 
         // then

--- a/api/tests/organizational-entities/acceptance/application/tag/tag.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/tag/tag.admin.route.test.js
@@ -5,7 +5,6 @@ import {
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
-  insertUserWithRoleCertif,
 } from '../../../../test-helper.js';
 
 describe('Acceptance | Organizational Entities | Application | Route | Admin | Tag', function () {
@@ -185,15 +184,14 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | T
           _buildOrganizationTags(organization.id, tagIds);
         }
 
+        const adminCertif = databaseBuilder.factory.buildUser.withRoleCertif();
         await databaseBuilder.commit();
-
-        const userId = (await insertUserWithRoleCertif()).id;
 
         // when
         const { statusCode } = await server.inject({
           method: 'GET',
           url: `/api/admin/tags/${basedTag.id}/recently-used`,
-          headers: generateAuthenticatedUserRequestHeaders({ userId }),
+          headers: generateAuthenticatedUserRequestHeaders({ userId: adminCertif.id }),
         });
 
         // then

--- a/api/tests/organizational-entities/integration/domain/usecases/create-organization_test.js
+++ b/api/tests/organizational-entities/integration/domain/usecases/create-organization_test.js
@@ -14,7 +14,6 @@ import {
   databaseBuilder,
   expect,
   insertMultipleSendingFeatureForNewOrganization,
-  insertPixJuniorFeatureForNewOrganization,
 } from '../../../../test-helper.js';
 
 describe('Integration | UseCases | create-organization', function () {
@@ -243,7 +242,8 @@ describe('Integration | UseCases | create-organization', function () {
   describe('junior organization', function () {
     it('returns newly created organization', async function () {
       // given
-      await insertPixJuniorFeatureForNewOrganization();
+      databaseBuilder.factory.buildFeature.pixJuniorFeatures();
+      await databaseBuilder.commit();
 
       const organization = new OrganizationForAdmin({
         name: 'ACME',

--- a/api/tests/organizational-entities/integration/domain/usecases/create-organization_test.js
+++ b/api/tests/organizational-entities/integration/domain/usecases/create-organization_test.js
@@ -8,13 +8,9 @@ import { Organization } from '../../../../../src/organizational-entities/domain/
 import { OrganizationForAdmin } from '../../../../../src/organizational-entities/domain/models/OrganizationForAdmin.js';
 import { OrganizationLearnerType } from '../../../../../src/organizational-entities/domain/models/OrganizationLearnerType.js';
 import { usecases } from '../../../../../src/organizational-entities/domain/usecases/index.js';
+import { ORGANIZATION_FEATURE } from '../../../../../src/shared/domain/constants.js';
 import { EntityValidationError, NotFoundError } from '../../../../../src/shared/domain/errors.js';
-import {
-  catchErr,
-  databaseBuilder,
-  expect,
-  insertMultipleSendingFeatureForNewOrganization,
-} from '../../../../test-helper.js';
+import { catchErr, databaseBuilder, expect } from '../../../../test-helper.js';
 
 describe('Integration | UseCases | create-organization', function () {
   let superAdminUserId;
@@ -29,7 +25,7 @@ describe('Integration | UseCases | create-organization', function () {
       originalName: 'France',
     });
 
-    await insertMultipleSendingFeatureForNewOrganization();
+    databaseBuilder.factory.buildFeature(ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT);
     await databaseBuilder.commit();
   });
 

--- a/api/tests/organizational-entities/integration/domain/usecases/create-organizations-with-tags-and-target-profiles.usecase.test.js
+++ b/api/tests/organizational-entities/integration/domain/usecases/create-organizations-with-tags-and-target-profiles.usecase.test.js
@@ -16,13 +16,7 @@ import {
 } from '../../../../../src/shared/domain/errors.js';
 import { EntityValidationError } from '../../../../../src/shared/domain/errors.js';
 import { Membership } from '../../../../../src/shared/domain/models/Membership.js';
-import {
-  catchErr,
-  databaseBuilder,
-  expect,
-  insertMultipleSendingFeatureForNewOrganization,
-  knex,
-} from '../../../../test-helper.js';
+import { catchErr, databaseBuilder, expect, knex } from '../../../../test-helper.js';
 
 const { omit } = lodash;
 
@@ -52,7 +46,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
     ondeImportFormat = databaseBuilder.factory.buildOrganizationLearnerImportFormat({
       name: ORGANIZATION_FEATURE.LEARNER_IMPORT.FORMAT.ONDE,
     });
-    byDefaultFeatureId = await insertMultipleSendingFeatureForNewOrganization();
+    byDefaultFeatureId = databaseBuilder.factory.buildFeature(ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT).id;
 
     userId = databaseBuilder.factory.buildUser().id;
     await databaseBuilder.commit();

--- a/api/tests/organizational-entities/integration/domain/usecases/detach-parent-organization-from-organization.usecase.test.js
+++ b/api/tests/organizational-entities/integration/domain/usecases/detach-parent-organization-from-organization.usecase.test.js
@@ -1,16 +1,13 @@
 import { UnableToDetachParentOrganizationFromChildOrganization } from '../../../../../src/organizational-entities/domain/errors.js';
 import { usecases } from '../../../../../src/organizational-entities/domain/usecases/index.js';
+import { ORGANIZATION_FEATURE } from '../../../../../src/shared/domain/constants.js';
 import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
-import {
-  databaseBuilder,
-  expect,
-  insertMultipleSendingFeatureForNewOrganization,
-  knex,
-} from '../../../../test-helper.js';
+import { databaseBuilder, expect, knex } from '../../../../test-helper.js';
 
 describe('Integration | UseCases | detach-parent-organization-from-organization', function () {
   beforeEach(async function () {
-    await insertMultipleSendingFeatureForNewOrganization();
+    databaseBuilder.factory.buildFeature(ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT);
+    await databaseBuilder.commit();
   });
   // TODO: ce test doit être mis à jour une fois que le use case detachParentOrganizationFromOrganization
   // utilisera fct_structures pour détecter le lien parent (via parent_structure_id)

--- a/api/tests/organizational-entities/integration/domain/usecases/get-organization-details.usecase.test.js
+++ b/api/tests/organizational-entities/integration/domain/usecases/get-organization-details.usecase.test.js
@@ -1,6 +1,6 @@
 import { OrganizationForAdmin } from '../../../../../src/organizational-entities/domain/models/OrganizationForAdmin.js';
 import { usecases } from '../../../../../src/organizational-entities/domain/usecases/index.js';
-import { databaseBuilder, expect, insertUserWithRoleSuperAdmin } from '../../../../test-helper.js';
+import { databaseBuilder, expect } from '../../../../test-helper.js';
 
 describe('Integration | Organizational Entities | Domain | UseCase | get-organization-details', function () {
   it('should return the Organization matching the given organization ID', async function () {
@@ -11,7 +11,7 @@ describe('Integration | Organizational Entities | Domain | UseCase | get-organiz
       commonName: 'France',
       originalName: 'France',
     });
-    const superAdminUser = await insertUserWithRoleSuperAdmin();
+    const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
     const organization = databaseBuilder.factory.buildOrganization({
       type: 'SCO',
       name: 'Organization of the dark side',
@@ -22,7 +22,7 @@ describe('Integration | Organizational Entities | Domain | UseCase | get-organiz
       isManagingStudents: 'true',
       email: 'sco.generic.account@example.net',
       documentationUrl: 'https://pix.fr/',
-      createdBy: superAdminUser.id,
+      createdBy: superAdmin.id,
       createdAt: dateNow,
       showNPS: true,
       formNPSUrl: 'https://pix.fr/',
@@ -44,13 +44,13 @@ describe('Integration | Organizational Entities | Domain | UseCase | get-organiz
   context('when country is not found', function () {
     it('should return the Organization without country name', async function () {
       // given
-      const superAdminUser = await insertUserWithRoleSuperAdmin();
+      const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
       const organization = databaseBuilder.factory.buildOrganization({
         type: 'SCO',
         name: 'Organization of the dark side',
         externalId: '100',
         countryCode: 99999,
-        createdBy: superAdminUser.id,
+        createdBy: superAdmin.id,
       });
 
       await databaseBuilder.commit();
@@ -66,12 +66,12 @@ describe('Integration | Organizational Entities | Domain | UseCase | get-organiz
   context('when the organization is a SCO-1D type', function () {
     it('should return the code for the given organizationId', async function () {
       // given
-      const superAdminUser = await insertUserWithRoleSuperAdmin();
+      const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
       const organization = databaseBuilder.factory.buildOrganization({
         type: 'SCO-1D',
         name: 'Organization of the dark side',
         externalId: '100',
-        createdBy: superAdminUser.id,
+        createdBy: superAdmin.id,
       });
 
       databaseBuilder.factory.buildSchool({

--- a/api/tests/organizational-entities/integration/domain/usecases/update-organization-information.usecase_test.js
+++ b/api/tests/organizational-entities/integration/domain/usecases/update-organization-information.usecase_test.js
@@ -11,7 +11,6 @@ import {
   databaseBuilder,
   domainBuilder,
   expect,
-  insertLearnerImportFeatureForNewOrganization,
   insertMultipleSendingFeatureForNewOrganization,
   knex,
 } from '../../../../test-helper.js';
@@ -70,9 +69,8 @@ describe('Integration | Organizational Entities | Domain | UseCases | update-org
   context('features', function () {
     let organizationId;
     beforeEach(async function () {
-      await insertLearnerImportFeatureForNewOrganization();
+      databaseBuilder.factory.buildFeature.pixJuniorFeatures();
       organizationId = databaseBuilder.factory.buildOrganization().id;
-
       await databaseBuilder.commit();
     });
     context('Activating learner import format', function () {

--- a/api/tests/organizational-entities/integration/domain/usecases/update-organization-information.usecase_test.js
+++ b/api/tests/organizational-entities/integration/domain/usecases/update-organization-information.usecase_test.js
@@ -6,20 +6,13 @@ import {
 import { OrganizationForAdmin } from '../../../../../src/organizational-entities/domain/models/OrganizationForAdmin.js';
 import { usecases } from '../../../../../src/organizational-entities/domain/usecases/index.js';
 import { ORGANIZATION_FEATURE } from '../../../../../src/shared/domain/constants.js';
-import {
-  catchErr,
-  databaseBuilder,
-  domainBuilder,
-  expect,
-  insertMultipleSendingFeatureForNewOrganization,
-  knex,
-} from '../../../../test-helper.js';
+import { catchErr, databaseBuilder, domainBuilder, expect, knex } from '../../../../test-helper.js';
 
 describe('Integration | Organizational Entities | Domain | UseCases | update-organization', function () {
   let adminUserId;
   beforeEach(async function () {
     adminUserId = databaseBuilder.factory.buildUser().id;
-    await insertMultipleSendingFeatureForNewOrganization();
+    databaseBuilder.factory.buildFeature(ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT);
   });
 
   it('updates organization information', async function () {

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/organization-for-admin.repository.test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/organization-for-admin.repository.test.js
@@ -6,15 +6,7 @@ import { repositories } from '../../../../../src/organizational-entities/infrast
 import { ORGANIZATION_FEATURE } from '../../../../../src/shared/domain/constants.js';
 import { MissingAttributesError, NotFoundError } from '../../../../../src/shared/domain/errors.js';
 import { OrganizationInvitation } from '../../../../../src/team/domain/models/OrganizationInvitation.js';
-import {
-  catchErr,
-  databaseBuilder,
-  domainBuilder,
-  expect,
-  insertMultipleSendingFeatureForNewOrganization,
-  knex,
-  sinon,
-} from '../../../../test-helper.js';
+import { catchErr, databaseBuilder, domainBuilder, expect, knex, sinon } from '../../../../test-helper.js';
 
 describe('Integration | Organizational Entities | Infrastructure | Repository | organization-for-admin', function () {
   let clock, byDefaultFeatureId, administrationTeam, organizationLearnerType, domainOrganizationLearnerType;
@@ -1270,7 +1262,7 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
       databaseBuilder.factory.buildCertificationCpfCountry({
         code: 99100,
       });
-      await insertMultipleSendingFeatureForNewOrganization();
+      databaseBuilder.factory.buildFeature(ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT);
 
       await databaseBuilder.commit();
 
@@ -1305,7 +1297,7 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
       databaseBuilder.factory.buildCertificationCpfCountry({
         code: 99100,
       });
-      await insertMultipleSendingFeatureForNewOrganization();
+      databaseBuilder.factory.buildFeature(ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT);
 
       await databaseBuilder.commit();
 
@@ -1343,7 +1335,7 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
         // given
         const superAdminUserId = databaseBuilder.factory.buildUser.withRole().id;
         databaseBuilder.factory.buildCertificationCpfCountry({ code: 99100 });
-        await insertMultipleSendingFeatureForNewOrganization();
+        databaseBuilder.factory.buildFeature(ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT);
 
         const {
           network,
@@ -1391,7 +1383,7 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
         const organizationLearnerImportOndeFormat = databaseBuilder.factory.buildOrganizationLearnerImportFormat({
           name: 'ONDE',
         });
-        byDefaultFeatureId = await insertMultipleSendingFeatureForNewOrganization();
+        byDefaultFeatureId = databaseBuilder.factory.buildFeature(ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT).id;
 
         await databaseBuilder.commit();
 
@@ -1407,9 +1399,7 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
         const savedOrganization = await repositories.organizationForAdminRepository.save({ organization });
 
         const savedOrganizationFeatures = await knex('organization-features')
-          .where({
-            organizationId: savedOrganization.id,
-          })
+          .where({ organizationId: savedOrganization.id })
           .whereNot({ featureId: byDefaultFeatureId });
 
         expect(savedOrganizationFeatures).to.have.lengthOf(3);
@@ -1433,7 +1423,7 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
 
   describe('#update', function () {
     beforeEach(async function () {
-      byDefaultFeatureId = await insertMultipleSendingFeatureForNewOrganization();
+      byDefaultFeatureId = databaseBuilder.factory.buildFeature(ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT).id;
     });
 
     it('updates organization detail', async function () {

--- a/api/tests/prescription/campaign-participation/acceptance/application/campaign-participation-route_test.js
+++ b/api/tests/prescription/campaign-participation/acceptance/application/campaign-participation-route_test.js
@@ -8,7 +8,6 @@ import {
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
-  insertUserWithRoleSuperAdmin,
   knex,
   learningContentBuilder,
   mockLearningContent,
@@ -78,7 +77,7 @@ describe('Acceptance | Campaign Participation | Application | Route', function (
   describe('DELETE /api/admin/campaigns/{campaignId}/campaign-participations/{campaignParticipationId}', function () {
     it('should return 204 HTTP status code', async function () {
       // given
-      const superAdmin = await insertUserWithRoleSuperAdmin();
+      const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
       const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation();
       await databaseBuilder.commit();
 
@@ -314,8 +313,7 @@ describe('Acceptance | Campaign Participation | Application | Route', function (
 
   describe('PATCH /api/admin/campaign-participations/{id}', function () {
     it('should update the participant external id', async function () {
-      const superAdmin = await insertUserWithRoleSuperAdmin();
-
+      const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
       const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
         participantExternalId: 'Maitre Yoda',
         campaignId,

--- a/api/tests/prescription/campaign/acceptance/application/campaign-administration-route_test.js
+++ b/api/tests/prescription/campaign/acceptance/application/campaign-administration-route_test.js
@@ -6,7 +6,6 @@ import {
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
-  insertUserWithRoleSuperAdmin,
   knex,
   learningContentBuilder,
   mockLearningContent,
@@ -232,11 +231,12 @@ describe('Acceptance | API | campaign-administration-route', function () {
   describe('GET /api/admin/campaigns/template', function () {
     it('responds with a 200', async function () {
       // given
-      const admin = await insertUserWithRoleSuperAdmin();
+      const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
       await databaseBuilder.commit();
+
       const options = {
         method: 'GET',
-        headers: generateAuthenticatedUserRequestHeaders({ userId: admin.id }),
+        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
         url: '/api/admin/campaigns/template',
       };
 
@@ -253,7 +253,7 @@ describe('Acceptance | API | campaign-administration-route', function () {
       let userId;
 
       beforeEach(async function () {
-        userId = databaseBuilder.factory.buildUser.withRole({ role: ROLES.SUPER_ADMIN }).id;
+        userId = databaseBuilder.factory.buildUser.withRoleSuperAdmin().id;
         await databaseBuilder.commit();
       });
 
@@ -311,7 +311,7 @@ describe('Acceptance | API | campaign-administration-route', function () {
 
   describe('POST /api/admin/campaigns/swap-codes', function () {
     it('it swap campaign code', async function () {
-      const userId = databaseBuilder.factory.buildUser.withRole({ role: ROLES.SUPER_ADMIN }).id;
+      const userId = databaseBuilder.factory.buildUser.withRoleSuperAdmin().id;
       const organizationId = databaseBuilder.factory.buildOrganization().id;
       const firstCampaignId = databaseBuilder.factory.buildCampaign({ code: 'ABC', organizationId }).id;
       const secondCampaignId = databaseBuilder.factory.buildCampaign({ code: 'EFG', organizationId }).id;
@@ -338,7 +338,7 @@ describe('Acceptance | API | campaign-administration-route', function () {
     it('should return the updated campaign', async function () {
       // given
       const campaign = databaseBuilder.factory.buildCampaign({ name: 'odlName', multipleSendings: false });
-      const user = databaseBuilder.factory.buildUser.withRole({ role: ROLES.SUPER_ADMIN });
+      const user = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
       await databaseBuilder.commit();
 
       // when
@@ -370,7 +370,7 @@ describe('Acceptance | API | campaign-administration-route', function () {
 
   describe('PATCH /api/admin/campaigns/{campaignId}/update-code', function () {
     it('it updates campaign code', async function () {
-      const userId = databaseBuilder.factory.buildUser.withRole({ role: ROLES.SUPER_ADMIN }).id;
+      const userId = databaseBuilder.factory.buildUser.withRoleSuperAdmin().id;
       const campaignId = databaseBuilder.factory.buildCampaign({ code: 'ABCEFG123' }).id;
       await databaseBuilder.commit();
       const payload = {
@@ -481,7 +481,7 @@ describe('Acceptance | API | campaign-administration-route', function () {
     let userId;
 
     beforeEach(async function () {
-      userId = databaseBuilder.factory.buildUser.withRole({ role: ROLES.SUPER_ADMIN }).id;
+      userId = databaseBuilder.factory.buildUser.withRoleSuperAdmin().id;
       await databaseBuilder.commit();
     });
 

--- a/api/tests/prescription/learner-management/acceptance/application/organization-learners-route_test.js
+++ b/api/tests/prescription/learner-management/acceptance/application/organization-learners-route_test.js
@@ -8,7 +8,6 @@ import {
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
-  insertUserWithRoleSuperAdmin,
 } from '../../../../test-helper.js';
 
 describe('Acceptance | Prescription | learner management | Application | organization-learners-management', function () {
@@ -22,7 +21,7 @@ describe('Acceptance | Prescription | learner management | Application | organiz
     context('When user has the role SUPER_ADMIN and organization learner can be dissociated', function () {
       it('should return an 204 status after having successfully dissociated user from organizationLearner', async function () {
         const organizationId = databaseBuilder.factory.buildOrganization({ isManagingStudents: true }).id;
-        const superAdmin = await insertUserWithRoleSuperAdmin();
+        const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
         const userId = databaseBuilder.factory.buildUser().id;
         const organizationLearner = databaseBuilder.factory.buildOrganizationLearner({ organizationId, userId });
 

--- a/api/tests/prescription/organization-learner/acceptance/application/organization-learners-route_test.js
+++ b/api/tests/prescription/organization-learner/acceptance/application/organization-learners-route_test.js
@@ -7,7 +7,6 @@ import {
   datamartBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
-  insertUserWithRoleSuperAdmin,
   mockAttestationStorage,
 } from '../../../../test-helper.js';
 
@@ -16,7 +15,6 @@ describe('Prescription | Organization Learner | Acceptance | Application | Organ
 
   beforeEach(async function () {
     server = await createServer();
-    await insertUserWithRoleSuperAdmin();
   });
 
   describe('GET /api/organizations/{organizationId}/attestations/{attestationKey}', function () {

--- a/api/tests/prescription/organization-learner/acceptance/learner-list-route_test.js
+++ b/api/tests/prescription/organization-learner/acceptance/learner-list-route_test.js
@@ -4,7 +4,6 @@ import {
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
-  insertUserWithRoleSuperAdmin,
 } from '../../../test-helper.js';
 
 describe('Acceptance | Application | learner-list-route', function () {
@@ -12,7 +11,6 @@ describe('Acceptance | Application | learner-list-route', function () {
 
   beforeEach(async function () {
     server = await createServer();
-    await insertUserWithRoleSuperAdmin();
   });
 
   describe('GET /api/organizations/{organizationId}/participants', function () {

--- a/api/tests/prescription/organization-learner/acceptance/sco-learner-list-route_test.js
+++ b/api/tests/prescription/organization-learner/acceptance/sco-learner-list-route_test.js
@@ -4,7 +4,6 @@ import {
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
-  insertUserWithRoleSuperAdmin,
 } from '../../../test-helper.js';
 
 describe('Acceptance | Application | sco-leaner-list-route', function () {
@@ -12,7 +11,6 @@ describe('Acceptance | Application | sco-leaner-list-route', function () {
 
   beforeEach(async function () {
     server = await createServer();
-    await insertUserWithRoleSuperAdmin();
   });
 
   describe('GET /api/organizations/{id}/sco-participants', function () {

--- a/api/tests/prescription/organization-learner/acceptance/sup-learner-list-route_test.js
+++ b/api/tests/prescription/organization-learner/acceptance/sup-learner-list-route_test.js
@@ -3,7 +3,6 @@ import {
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
-  insertUserWithRoleSuperAdmin,
 } from '../../../test-helper.js';
 
 describe('Acceptance | Application | sup-leaner-list-route', function () {
@@ -11,7 +10,6 @@ describe('Acceptance | Application | sup-leaner-list-route', function () {
 
   beforeEach(async function () {
     server = await createServer();
-    await insertUserWithRoleSuperAdmin();
   });
 
   describe('GET /api/organizations/{id}/sup-participants', function () {

--- a/api/tests/prescription/organization-place/acceptance/application/create-organization-places-lot_test.js
+++ b/api/tests/prescription/organization-place/acceptance/application/create-organization-places-lot_test.js
@@ -5,7 +5,6 @@ import {
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
-  insertUserWithRoleSuperAdmin,
 } from '../../../../test-helper.js';
 
 describe('Acceptance | Route | Create Organization Places Lot', function () {
@@ -14,7 +13,7 @@ describe('Acceptance | Route | Create Organization Places Lot', function () {
       // given
       const server = await createServer();
 
-      const adminUser = await insertUserWithRoleSuperAdmin();
+      const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
       const placeManagementFeature = databaseBuilder.factory.buildFeature({
         key: ORGANIZATION_FEATURE.PLACES_MANAGEMENT.key,
       });
@@ -31,7 +30,7 @@ describe('Acceptance | Route | Create Organization Places Lot', function () {
       const options = {
         method: 'POST',
         url: `/api/admin/organizations/${organizationId}/places`,
-        headers: generateAuthenticatedUserRequestHeaders({ userId: adminUser.id }),
+        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
         payload: {
           data: {
             attributes: {

--- a/api/tests/prescription/organization-place/acceptance/application/delete-organization-places-lot_test.js
+++ b/api/tests/prescription/organization-place/acceptance/application/delete-organization-places-lot_test.js
@@ -3,7 +3,6 @@ import {
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
-  insertUserWithRoleSuperAdmin,
 } from '../../../../test-helper.js';
 
 describe('Acceptance | Route | Delete Organizations Places Lot', function () {
@@ -12,13 +11,13 @@ describe('Acceptance | Route | Delete Organizations Places Lot', function () {
       // given
       const server = await createServer();
 
-      const adminUser = await insertUserWithRoleSuperAdmin();
+      const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
       const organizationPlace = databaseBuilder.factory.buildOrganizationPlace();
 
       const options = {
         method: 'DELETE',
         url: `/api/admin/organizations/${organizationPlace.organizationId}/places/${organizationPlace.id}`,
-        headers: generateAuthenticatedUserRequestHeaders({ userId: adminUser.id }),
+        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
       };
 
       await databaseBuilder.commit();
@@ -33,13 +32,13 @@ describe('Acceptance | Route | Delete Organizations Places Lot', function () {
       // given
       const server = await createServer();
 
-      const adminUser = await insertUserWithRoleSuperAdmin();
+      const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
       const organizationPlace = databaseBuilder.factory.buildOrganizationPlace();
 
       const options = {
         method: 'DELETE',
         url: `/api/admin/organizations/${organizationPlace.organizationId}/places/123156`,
-        headers: generateAuthenticatedUserRequestHeaders({ userId: adminUser.id }),
+        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
       };
 
       await databaseBuilder.commit();
@@ -54,16 +53,16 @@ describe('Acceptance | Route | Delete Organizations Places Lot', function () {
       // given
       const server = await createServer();
 
-      const adminUser = await insertUserWithRoleSuperAdmin();
+      const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
       const organizationPlace = databaseBuilder.factory.buildOrganizationPlace({
         deletedAt: new Date(),
-        deletedBy: adminUser.id,
+        deletedBy: superAdmin.id,
       });
 
       const options = {
         method: 'DELETE',
         url: `/api/admin/organizations/${organizationPlace.organizationId}/places/${organizationPlace.id}`,
-        headers: generateAuthenticatedUserRequestHeaders({ userId: adminUser.id }),
+        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
       };
 
       await databaseBuilder.commit();

--- a/api/tests/prescription/organization-place/acceptance/application/find-organization-places_test.js
+++ b/api/tests/prescription/organization-place/acceptance/application/find-organization-places_test.js
@@ -4,7 +4,6 @@ import {
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
-  insertUserWithRoleSuperAdmin,
 } from '../../../../test-helper.js';
 
 describe('Acceptance | Route | Find Organization Places', function () {
@@ -13,7 +12,7 @@ describe('Acceptance | Route | Find Organization Places', function () {
       // given
       const server = await createServer();
 
-      const adminUser = await insertUserWithRoleSuperAdmin();
+      const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
       const organizationId = databaseBuilder.factory.buildOrganization().id;
       databaseBuilder.factory.buildOrganizationPlace({
         organizationId,
@@ -22,13 +21,13 @@ describe('Acceptance | Route | Find Organization Places', function () {
         expirationDate: new Date('2021-01-01'),
         reference: 'Godzilla',
         category: organizationPlacesLotCategories.FULL_RATE,
-        createdBy: adminUser.id,
+        createdBy: superAdmin.id,
       });
 
       const options = {
         method: 'GET',
         url: `/api/admin/organizations/${organizationId}/places`,
-        headers: generateAuthenticatedUserRequestHeaders({ userId: adminUser.id }),
+        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
       };
 
       await databaseBuilder.commit();
@@ -44,17 +43,17 @@ describe('Acceptance | Route | Find Organization Places', function () {
       // given
       const server = await createServer();
 
-      const adminUser = await insertUserWithRoleSuperAdmin();
+      const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
       const organizationId = databaseBuilder.factory.buildOrganization().id;
       const place = databaseBuilder.factory.buildOrganizationPlace({
         organizationId,
-        createdBy: adminUser.id,
+        createdBy: superAdmin.id,
       });
 
       const options = {
         method: 'GET',
         url: `/api/admin/organizations/${organizationId}/places`,
-        headers: generateAuthenticatedUserRequestHeaders({ userId: adminUser.id }),
+        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
       };
 
       await databaseBuilder.commit();

--- a/api/tests/prescription/target-profile/acceptance/application/target-profile-route_test.js
+++ b/api/tests/prescription/target-profile/acceptance/application/target-profile-route_test.js
@@ -3,7 +3,6 @@ import {
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
-  insertUserWithRoleSuperAdmin,
   learningContentBuilder,
   mockLearningContent,
 } from '../../../../test-helper.js';
@@ -13,7 +12,6 @@ describe('Acceptance | Route | target-profile', function () {
 
   beforeEach(async function () {
     server = await createServer();
-    await insertUserWithRoleSuperAdmin();
   });
 
   describe('GET /api/organizations/{organizationId}/target-profiles', function () {

--- a/api/tests/profile/acceptance/application/attestation-route_test.js
+++ b/api/tests/profile/acceptance/application/attestation-route_test.js
@@ -3,7 +3,6 @@ import {
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
-  insertUserWithRoleSuperAdmin,
   mockAttestationStorage,
 } from '../../../test-helper.js';
 
@@ -17,14 +16,14 @@ describe('Profile | Acceptance | Application | Attestation Route ', function () 
   describe('GET /api/admin/attestations', function () {
     it('should return 200 with the list of attestations', async function () {
       // given
-      const adminUser = await insertUserWithRoleSuperAdmin();
+      const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
       databaseBuilder.factory.buildAttestation({ key: 'PARENTHOOD' });
       databaseBuilder.factory.buildAttestation({ key: 'SIXTH_GRADE' });
       await databaseBuilder.commit();
 
       const options = {
         method: 'GET',
-        headers: generateAuthenticatedUserRequestHeaders({ userId: adminUser.id }),
+        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
         url: '/api/admin/attestations',
       };
 

--- a/api/tests/quest/acceptance/application/combined-course-blueprint-route_test.js
+++ b/api/tests/quest/acceptance/application/combined-course-blueprint-route_test.js
@@ -5,7 +5,6 @@ import {
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
-  insertUserWithRoleSuperAdmin,
 } from '../../../test-helper.js';
 
 describe('Quest | Acceptance | Application | Combined course blueprint Route ', function () {
@@ -19,8 +18,7 @@ describe('Quest | Acceptance | Application | Combined course blueprint Route ', 
     context('when user is admin ', function () {
       it('should return the list of combined course blueprints', async function () {
         // given
-        const adminUser = await insertUserWithRoleSuperAdmin();
-
+        const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
         databaseBuilder.factory.buildCombinedCourseBlueprint();
         databaseBuilder.factory.buildCombinedCourseBlueprint();
         await databaseBuilder.commit();
@@ -28,7 +26,7 @@ describe('Quest | Acceptance | Application | Combined course blueprint Route ', 
         const options = {
           method: 'GET',
           url: `/api/admin/combined-course-blueprints`,
-          headers: generateAuthenticatedUserRequestHeaders({ userId: adminUser.id }),
+          headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
         };
 
         // when
@@ -46,8 +44,7 @@ describe('Quest | Acceptance | Application | Combined course blueprint Route ', 
       it('should create a combined course blueprint', async function () {
         // given
         databaseBuilder.factory.buildAttestation({ key: ATTESTATIONS.SIXTH_GRADE });
-        const adminUser = await insertUserWithRoleSuperAdmin();
-
+        const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
         await databaseBuilder.commit();
 
         const payload = {
@@ -66,7 +63,7 @@ describe('Quest | Acceptance | Application | Combined course blueprint Route ', 
         const options = {
           method: 'POST',
           url: `/api/admin/combined-course-blueprints`,
-          headers: generateAuthenticatedUserRequestHeaders({ userId: adminUser.id }),
+          headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
           payload,
         };
 
@@ -84,15 +81,14 @@ describe('Quest | Acceptance | Application | Combined course blueprint Route ', 
     context('when user is admin ', function () {
       it('should return combined course blueprint for given id', async function () {
         // given
-        const adminUser = await insertUserWithRoleSuperAdmin();
-
+        const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
         const combinedCourseBlueprint = databaseBuilder.factory.buildCombinedCourseBlueprint();
         await databaseBuilder.commit();
 
         const options = {
           method: 'GET',
           url: `/api/admin/combined-course-blueprints/${combinedCourseBlueprint.id}`,
-          headers: generateAuthenticatedUserRequestHeaders({ userId: adminUser.id }),
+          headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
         };
 
         // when
@@ -110,8 +106,7 @@ describe('Quest | Acceptance | Application | Combined course blueprint Route ', 
     context('when user is admin ', function () {
       it('should detach a combined course blueprint from organization', async function () {
         // given
-        const adminUser = await insertUserWithRoleSuperAdmin();
-
+        const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
         const { combinedCourseBlueprintId, organizationId } =
           databaseBuilder.factory.buildCombinedCourseBlueprintShare();
         await databaseBuilder.commit();
@@ -119,7 +114,7 @@ describe('Quest | Acceptance | Application | Combined course blueprint Route ', 
         const options = {
           method: 'DELETE',
           url: `/api/admin/combined-course-blueprints/${combinedCourseBlueprintId}/organizations/${organizationId}`,
-          headers: generateAuthenticatedUserRequestHeaders({ userId: adminUser.id }),
+          headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
         };
 
         // when
@@ -135,8 +130,7 @@ describe('Quest | Acceptance | Application | Combined course blueprint Route ', 
     context('when user is admin ', function () {
       it('should attach a combined course blueprint to one or several organizations', async function () {
         // given
-        const adminUser = await insertUserWithRoleSuperAdmin();
-
+        const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
         const combinedCourseBlueprintId = databaseBuilder.factory.buildCombinedCourseBlueprint().id;
         const alreadyAttachedOrganization = databaseBuilder.factory.buildOrganization();
 
@@ -161,7 +155,7 @@ describe('Quest | Acceptance | Application | Combined course blueprint Route ', 
         const options = {
           method: 'POST',
           url: `/api/admin/combined-course-blueprints/${combinedCourseBlueprintId}/organizations`,
-          headers: generateAuthenticatedUserRequestHeaders({ userId: adminUser.id }),
+          headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
           payload,
         };
 

--- a/api/tests/quest/acceptance/application/quest-route_test.js
+++ b/api/tests/quest/acceptance/application/quest-route_test.js
@@ -10,7 +10,6 @@ import {
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
-  insertUserWithRoleSuperAdmin,
   knex,
 } from '../../../test-helper.js';
 
@@ -101,11 +100,12 @@ describe('Quest | Acceptance | Application | Quest Route ', function () {
   describe('GET /api/admin/quests/template', function () {
     it('responds with a 200', async function () {
       // given
-      const admin = await insertUserWithRoleSuperAdmin();
+      const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
       await databaseBuilder.commit();
+
       const options = {
         method: 'GET',
-        headers: generateAuthenticatedUserRequestHeaders({ userId: admin.id }),
+        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
         url: '/api/admin/quests/template',
       };
 
@@ -120,7 +120,7 @@ describe('Quest | Acceptance | Application | Quest Route ', function () {
   describe('POST /api/admin/quests', function () {
     it('responds with a 204 - no content', async function () {
       // given
-      const admin = await insertUserWithRoleSuperAdmin();
+      const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
       await databaseBuilder.commit();
       // TODO j'ai l'impression qu'en séparateur en ; il capte pas les différents headers
       const input = `Quest ID,Json configuration for quest
@@ -128,7 +128,7 @@ describe('Quest | Acceptance | Application | Quest Route ', function () {
 
       const options = {
         method: 'POST',
-        headers: generateAuthenticatedUserRequestHeaders({ userId: admin.id }),
+        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
         url: '/api/admin/quests',
         payload: iconv.encode(input, 'UTF-8'),
       };

--- a/api/tests/shared/acceptance/application/assessments/assessment-controller-auto-validate-next-challenge_test.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-controller-auto-validate-next-challenge_test.js
@@ -5,7 +5,6 @@ import {
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
-  insertUserWithRoleSuperAdmin,
   knex,
   learningContentBuilder,
   mockLearningContent,
@@ -64,16 +63,15 @@ describe('Acceptance | API | assessment-controller-auto-validate-next-challenge'
   });
 
   describe('POST /api/admin/assessments/:id/always-ok-validate-next-challenge', function () {
-    let userId;
+    let superAdmin;
 
     beforeEach(async function () {
-      const user = await insertUserWithRoleSuperAdmin();
-      userId = user.id;
+      superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
       assessmentId = databaseBuilder.factory.buildAssessment({
         state: Assessment.states.STARTED,
         type: Assessment.types.PREVIEW,
         lastChallengeId,
-        userId,
+        userId: superAdmin.id,
       }).id;
       await databaseBuilder.commit();
     });
@@ -83,7 +81,7 @@ describe('Acceptance | API | assessment-controller-auto-validate-next-challenge'
       const response = await server.inject({
         method: 'POST',
         url: `/api/admin/assessments/${assessmentId}/always-ok-validate-next-challenge`,
-        headers: generateAuthenticatedUserRequestHeaders({ userId }),
+        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
       });
 
       // then

--- a/api/tests/shared/acceptance/application/badges/badge-controller_test.js
+++ b/api/tests/shared/acceptance/application/badges/badge-controller_test.js
@@ -3,15 +3,15 @@ import {
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
-  insertUserWithRoleSuperAdmin,
 } from '../../../../test-helper.js';
 
 describe('Acceptance | API | Badges', function () {
-  let server, options, userId, badge;
+  let server, options, badge, superAdmin;
 
   beforeEach(async function () {
     server = await createServer();
-    userId = (await insertUserWithRoleSuperAdmin()).id;
+    superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
+    await databaseBuilder.commit();
   });
 
   describe('PATCH /api/admin/badges/{id}', function () {
@@ -26,7 +26,6 @@ describe('Acceptance | API | Badges', function () {
         isCertifiable: false,
         isAlwaysVisible: true,
       });
-
       await databaseBuilder.commit();
     });
 
@@ -45,7 +44,7 @@ describe('Acceptance | API | Badges', function () {
       options = {
         method: 'PATCH',
         url: `/api/admin/badges/${badge.id}`,
-        headers: generateAuthenticatedUserRequestHeaders({ userId }),
+        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
         payload: {
           data: {
             type: 'badges',
@@ -79,7 +78,7 @@ describe('Acceptance | API | Badges', function () {
       options = {
         method: 'DELETE',
         url: `/api/admin/badges/${badge.id}`,
-        headers: generateAuthenticatedUserRequestHeaders({ userId }),
+        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
       };
 
       // when
@@ -92,13 +91,13 @@ describe('Acceptance | API | Badges', function () {
     it('should not delete the existing badge if associated to a badge acquisition', async function () {
       // given
       badge = databaseBuilder.factory.buildBadge({ id: 1 });
-      databaseBuilder.factory.buildBadgeAcquisition({ badgeId: badge.id, userId });
+      databaseBuilder.factory.buildBadgeAcquisition({ badgeId: badge.id, userId: superAdmin.id });
       await databaseBuilder.commit();
 
       options = {
         method: 'DELETE',
         url: `/api/admin/badges/${badge.id}`,
-        headers: generateAuthenticatedUserRequestHeaders({ userId }),
+        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
       };
 
       // when

--- a/api/tests/team/acceptance/application/admin-member/admin-member.route.test.js
+++ b/api/tests/team/acceptance/application/admin-member/admin-member.route.test.js
@@ -4,7 +4,6 @@ import {
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
-  insertUserWithRoleSuperAdmin,
 } from '../../../../test-helper.js';
 
 const { ROLES } = PIX_ADMIN;
@@ -13,14 +12,13 @@ describe('Acceptance | Team | Route | Admin-member', function () {
   describe('GET /api/admin/admin-members/me', function () {
     it('should return 200 http status code', async function () {
       // given
-      databaseBuilder.factory.buildUser.withRole();
-      const admin = await insertUserWithRoleSuperAdmin();
+      const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
       await databaseBuilder.commit();
       const server = await createServer();
 
       // when
       const response = await server.inject({
-        headers: generateAuthenticatedUserRequestHeaders({ userId: admin.id }),
+        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
         method: 'GET',
         url: '/api/admin/admin-members/me',
       });

--- a/api/tests/team/acceptance/application/certification-center-invitation/certification-center-invitation.admin.route.test.js
+++ b/api/tests/team/acceptance/application/certification-center-invitation/certification-center-invitation.admin.route.test.js
@@ -4,7 +4,6 @@ import {
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
-  insertUserWithRoleSuperAdmin,
   sinon,
 } from '../../../../test-helper.js';
 
@@ -18,8 +17,7 @@ describe('Acceptance | Team | Application | Route | Admin | Certification Center
   describe('GET /api/admin/certification-centers/{certificationCenterId}/invitations', function () {
     it('should return 200 HTTP status code and the list of invitations', async function () {
       // given
-      const adminUser = await insertUserWithRoleSuperAdmin();
-
+      const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
       const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
       const now = new Date();
       const certificationCenterInvitation1 = databaseBuilder.factory.buildCertificationCenterInvitation({
@@ -46,7 +44,7 @@ describe('Acceptance | Team | Application | Route | Admin | Certification Center
       const response = await server.inject({
         method: 'GET',
         url: `/api/admin/certification-centers/${certificationCenterId}/invitations`,
-        headers: generateAuthenticatedUserRequestHeaders({ userId: adminUser.id }),
+        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
       });
 
       // then
@@ -94,13 +92,13 @@ describe('Acceptance | Team | Application | Route | Admin | Certification Center
 
     it('returns 201 HTTP status code with created invitation', async function () {
       // given
-      const adminMember = await insertUserWithRoleSuperAdmin();
+      const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
       const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
       await databaseBuilder.commit();
 
       // when
       const { result, statusCode } = await server.inject({
-        headers: generateAuthenticatedUserRequestHeaders({ userId: adminMember.id }),
+        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
         method: 'POST',
         payload: {
           data: {
@@ -130,7 +128,7 @@ describe('Acceptance | Team | Application | Route | Admin | Certification Center
   describe('DELETE /api/admin/certification-centers/{id}/invitations/{certificationCenterInvitationId}', function () {
     it('should return 204 HTTP status code', async function () {
       // given
-      const adminMember = await insertUserWithRoleSuperAdmin();
+      const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
       const certificationCenterInvitation = databaseBuilder.factory.buildCertificationCenterInvitation({
         certificationCenterId: databaseBuilder.factory.buildCertificationCenter().id,
         status: CertificationCenterInvitation.StatusType.PENDING,
@@ -142,7 +140,7 @@ describe('Acceptance | Team | Application | Route | Admin | Certification Center
       const response = await server.inject({
         method: 'DELETE',
         url: `/api/admin/certification-center-invitations/${certificationCenterInvitation.id}`,
-        headers: generateAuthenticatedUserRequestHeaders({ userId: adminMember.id }),
+        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
       });
 
       // then

--- a/api/tests/team/acceptance/application/organization-invitations/organization-invitation.admin.route.test.js
+++ b/api/tests/team/acceptance/application/organization-invitations/organization-invitation.admin.route.test.js
@@ -5,7 +5,6 @@ import {
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
-  insertOrganizationUserWithRoleAdmin,
 } from '../../../../../tests/test-helper.js';
 
 describe('Acceptance | Team | Route | Admin | organization-invitation', function () {
@@ -78,7 +77,7 @@ describe('Acceptance | Team | Route | Admin | organization-invitation', function
       const server = await createServer();
 
       const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
-      const { organization } = await insertOrganizationUserWithRoleAdmin();
+      const organization = databaseBuilder.factory.buildOrganization();
       const invitation = databaseBuilder.factory.buildOrganizationInvitation({
         organizationId: organization.id,
         status: OrganizationInvitation.StatusType.PENDING,

--- a/api/tests/team/acceptance/application/organization-invitations/organization-invitation.admin.route.test.js
+++ b/api/tests/team/acceptance/application/organization-invitations/organization-invitation.admin.route.test.js
@@ -6,7 +6,6 @@ import {
   expect,
   generateAuthenticatedUserRequestHeaders,
   insertOrganizationUserWithRoleAdmin,
-  insertUserWithRoleSuperAdmin,
 } from '../../../../../tests/test-helper.js';
 
 describe('Acceptance | Team | Route | Admin | organization-invitation', function () {
@@ -15,7 +14,7 @@ describe('Acceptance | Team | Route | Admin | organization-invitation', function
       it('returns the matching organization-invitations as JSON API', async function () {
         // given
         const server = await createServer();
-        const adminMember = await insertUserWithRoleSuperAdmin();
+        const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
         const organizationId = databaseBuilder.factory.buildOrganization().id;
         databaseBuilder.factory.buildOrganizationInvitation({
           organizationId,
@@ -27,7 +26,7 @@ describe('Acceptance | Team | Route | Admin | organization-invitation', function
         const response = await server.inject({
           method: 'GET',
           url: `/api/admin/organizations/${organizationId}/invitations`,
-          headers: generateAuthenticatedUserRequestHeaders({ userId: adminMember.id }),
+          headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
         });
 
         // then
@@ -78,7 +77,7 @@ describe('Acceptance | Team | Route | Admin | organization-invitation', function
       // given
       const server = await createServer();
 
-      const adminMember = await insertUserWithRoleSuperAdmin();
+      const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
       const { organization } = await insertOrganizationUserWithRoleAdmin();
       const invitation = databaseBuilder.factory.buildOrganizationInvitation({
         organizationId: organization.id,
@@ -88,7 +87,7 @@ describe('Acceptance | Team | Route | Admin | organization-invitation', function
       const options = {
         method: 'DELETE',
         url: `/api/admin/organizations/${organization.id}/invitations/${invitation.id}`,
-        headers: generateAuthenticatedUserRequestHeaders({ userId: adminMember.id }),
+        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
       };
 
       await databaseBuilder.commit();
@@ -106,7 +105,7 @@ describe('Acceptance | Team | Route | Admin | organization-invitation', function
       // given
       const server = await createServer();
 
-      const superAdmin = await insertUserWithRoleSuperAdmin();
+      const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
       const organization = databaseBuilder.factory.buildOrganization();
 
       const payload = {

--- a/api/tests/team/acceptance/application/organization-invitations/organization-invitation.route.test.js
+++ b/api/tests/team/acceptance/application/organization-invitations/organization-invitation.route.test.js
@@ -8,7 +8,6 @@ import {
   expect,
   generateAuthenticatedUserRequestHeaders,
   generateInjectOptions,
-  insertOrganizationUserWithRoleAdmin,
   knex,
   sinon,
 } from '../../../../../tests/test-helper.js';
@@ -600,19 +599,24 @@ describe('Acceptance | Team | Application | Controller | organization-invitation
       // given
       const server = await createServer();
 
-      const { adminUser, organization } = await insertOrganizationUserWithRoleAdmin();
+      const adminUser = databaseBuilder.factory.buildUser();
+      const organization = databaseBuilder.factory.buildOrganization();
+      databaseBuilder.factory.buildMembership({
+        userId: adminUser.id,
+        organizationId: organization.id,
+        organizationRole: Membership.roles.ADMIN,
+      });
       const invitation = databaseBuilder.factory.buildOrganizationInvitation({
         organizationId: organization.id,
         status: OrganizationInvitation.StatusType.PENDING,
       });
+      await databaseBuilder.commit();
 
       const options = {
         method: 'DELETE',
         url: `/api/organizations/${organization.id}/invitations/${invitation.id}`,
         headers: generateAuthenticatedUserRequestHeaders({ userId: adminUser.id }),
       };
-
-      await databaseBuilder.commit();
 
       // when
       const response = await server.inject(options);

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -232,25 +232,6 @@ async function insertMultipleSendingFeatureForNewOrganization() {
   return feature.id;
 }
 
-async function insertLearnerImportFeatureForNewOrganization() {
-  const featureId = databaseBuilder.factory.buildFeature(ORGANIZATION_FEATURE.LEARNER_IMPORT).id;
-  databaseBuilder.factory.buildOrganizationLearnerImportFormat({
-    name: ORGANIZATION_FEATURE.LEARNER_IMPORT.FORMAT.ONDE,
-  });
-  await databaseBuilder.commit();
-  return featureId;
-}
-
-async function insertPixJuniorFeatureForNewOrganization() {
-  databaseBuilder.factory.buildFeature(ORGANIZATION_FEATURE.LEARNER_IMPORT);
-  databaseBuilder.factory.buildFeature(ORGANIZATION_FEATURE.MISSIONS_MANAGEMENT);
-  databaseBuilder.factory.buildFeature(ORGANIZATION_FEATURE.ORALIZATION_MANAGED_BY_PRESCRIBER);
-  databaseBuilder.factory.buildOrganizationLearnerImportFormat({
-    name: ORGANIZATION_FEATURE.LEARNER_IMPORT.FORMAT.ONDE,
-  });
-  await databaseBuilder.commit();
-}
-
 // Hapi
 const hFake = {
   response(source) {
@@ -409,9 +390,7 @@ export {
   getFakeAttestationTemplate,
   hFake,
   HttpTestServer,
-  insertLearnerImportFeatureForNewOrganization,
   insertMultipleSendingFeatureForNewOrganization,
-  insertPixJuniorFeatureForNewOrganization,
   knex,
   learningContentBuilder,
   mockAttestationStorage,

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -29,7 +29,6 @@ import { ApplicationAccessToken } from '../src/identity-access-management/domain
 import { UserAccessToken } from '../src/identity-access-management/domain/models/UserAccessToken.js';
 import { UserReconciliationSamlIdToken } from '../src/identity-access-management/domain/models/UserReconciliationSamlIdToken.js';
 import * as missionRepository from '../src/school/infrastructure/repositories/mission-repository.js';
-import { ORGANIZATION_FEATURE } from '../src/shared/domain/constants.js';
 import { featureToggles } from '../src/shared/infrastructure/feature-toggles/index.js';
 import { JobClient } from '../src/shared/infrastructure/jobs/JobClient.js';
 import { clearMutex, quitMutex } from '../src/shared/infrastructure/mutex/RedisMutex.js';
@@ -224,14 +223,6 @@ function generateIdTokenForExternalUser(externalUser) {
   return UserReconciliationSamlIdToken.generate(externalUser);
 }
 
-// We insert a multiple sending feature by default for each new organization created.
-// It is under feature for now because we want to be able to deactivate it when asked.
-async function insertMultipleSendingFeatureForNewOrganization() {
-  const feature = databaseBuilder.factory.buildFeature(ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT);
-  await databaseBuilder.commit();
-  return feature.id;
-}
-
 // Hapi
 const hFake = {
   response(source) {
@@ -390,7 +381,6 @@ export {
   getFakeAttestationTemplate,
   hFake,
   HttpTestServer,
-  insertMultipleSendingFeatureForNewOrganization,
   knex,
   learningContentBuilder,
   mockAttestationStorage,

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -24,7 +24,6 @@ import { DatabaseBuilder } from '../db/database-builder/database-builder.js';
 import { disconnect, knex } from '../db/knex-database-connection.js';
 import { createServer } from '../server.js';
 import { createMaddoServer } from '../server.maddo.js';
-import { PIX_ADMIN } from '../src/authorization/domain/constants.js';
 import * as tutorialRepository from '../src/devcomp/infrastructure/repositories/tutorial-repository.js';
 import { ApplicationAccessToken } from '../src/identity-access-management/domain/models/ApplicationAccessToken.js';
 import { UserAccessToken } from '../src/identity-access-management/domain/models/UserAccessToken.js';
@@ -224,21 +223,6 @@ function generateValidRequestAuthorizationHeaderForApplication(clientId = 'clien
 
 function generateIdTokenForExternalUser(externalUser) {
   return UserReconciliationSamlIdToken.generate(externalUser);
-}
-
-async function insertUserWithRoleCertif() {
-  const user = databaseBuilder.factory.buildUser.withRole({
-    id: 1234,
-    firstName: 'Certif',
-    lastName: 'Power',
-    email: 'certif.power@example.net',
-    password: 'Pix123',
-    role: PIX_ADMIN.ROLES.CERTIF,
-  });
-
-  await databaseBuilder.commit();
-
-  return user;
 }
 
 async function insertOrganizationUserWithRoleAdmin() {
@@ -444,7 +428,6 @@ export {
   insertMultipleSendingFeatureForNewOrganization,
   insertOrganizationUserWithRoleAdmin,
   insertPixJuniorFeatureForNewOrganization,
-  insertUserWithRoleCertif,
   knex,
   learningContentBuilder,
   mockAttestationStorage,

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -30,7 +30,6 @@ import { UserAccessToken } from '../src/identity-access-management/domain/models
 import { UserReconciliationSamlIdToken } from '../src/identity-access-management/domain/models/UserReconciliationSamlIdToken.js';
 import * as missionRepository from '../src/school/infrastructure/repositories/mission-repository.js';
 import { ORGANIZATION_FEATURE } from '../src/shared/domain/constants.js';
-import { Membership } from '../src/shared/domain/models/Membership.js';
 import { featureToggles } from '../src/shared/infrastructure/feature-toggles/index.js';
 import { JobClient } from '../src/shared/infrastructure/jobs/JobClient.js';
 import { clearMutex, quitMutex } from '../src/shared/infrastructure/mutex/RedisMutex.js';
@@ -225,20 +224,6 @@ function generateIdTokenForExternalUser(externalUser) {
   return UserReconciliationSamlIdToken.generate(externalUser);
 }
 
-async function insertOrganizationUserWithRoleAdmin() {
-  const adminUser = databaseBuilder.factory.buildUser();
-  const organization = databaseBuilder.factory.buildOrganization();
-  databaseBuilder.factory.buildMembership({
-    userId: adminUser.id,
-    organizationId: organization.id,
-    organizationRole: Membership.roles.ADMIN,
-  });
-
-  await databaseBuilder.commit();
-
-  return { adminUser, organization };
-}
-
 // We insert a multiple sending feature by default for each new organization created.
 // It is under feature for now because we want to be able to deactivate it when asked.
 async function insertMultipleSendingFeatureForNewOrganization() {
@@ -426,7 +411,6 @@ export {
   HttpTestServer,
   insertLearnerImportFeatureForNewOrganization,
   insertMultipleSendingFeatureForNewOrganization,
-  insertOrganizationUserWithRoleAdmin,
   insertPixJuniorFeatureForNewOrganization,
   knex,
   learningContentBuilder,

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -226,20 +226,6 @@ function generateIdTokenForExternalUser(externalUser) {
   return UserReconciliationSamlIdToken.generate(externalUser);
 }
 
-async function insertUserWithRoleSuperAdmin() {
-  const user = databaseBuilder.factory.buildUser.withRole({
-    id: 1234,
-    firstName: 'Super',
-    lastName: 'Papa',
-    email: 'super.papa@example.net',
-    password: 'Password123',
-  });
-
-  await databaseBuilder.commit();
-
-  return user;
-}
-
 async function insertUserWithRoleCertif() {
   const user = databaseBuilder.factory.buildUser.withRole({
     id: 1234,
@@ -459,7 +445,6 @@ export {
   insertOrganizationUserWithRoleAdmin,
   insertPixJuniorFeatureForNewOrganization,
   insertUserWithRoleCertif,
-  insertUserWithRoleSuperAdmin,
   knex,
   learningContentBuilder,
   mockAttestationStorage,


### PR DESCRIPTION
## 🌱 Problème

Le fichier `test-helper.js` est un melting-pot de code. Il mélange différentes responsabilités pour toutes nos typologies de test (unitaires, intégration et acceptance) :
- étendre l'api des assertions chai, sinon...
- initialiser les mocks (hapi, nocks...)
- initialiser les helpers (database builder, knex...)
- initialiser les tests (`before`)
- nettoyer les ressources (`afterEach`, `after`)
- exposer des méthodes utilitaires
- exposer des constantes

Il est nécessaire de revoir ce fichier pour isoler les fonctions utilitaires de l'initialisation des tests. Le but final est d'avoir de chaines d'initialisation différentes entre les tests unitaires, d'intégration et d'acceptance.

## 🐣 Proposition

Le but de cette PR est de **sortir les `database-builder` définis dans le fichier `test-helper.js` pour créer de la données** et de les remplacer par des `traits` dans les factory du `database-builder`:
```diff
- await insertUserWithRoleSuperAdmin();
+ databaseBuilder.factory.buildUser.withRoleSuperAdmin(); 

- await insertUserWithRoleCertif();
+ databaseBuilder.factory.buildUser.withRoleCertif(); 

- await insertOrganizationUserWithRoleAdmin();
+ // remplacé par des `databaseBuilder.factory.xxx`

- await insertPixJuniorFeatureForNewOrganization();
+ databaseBuilder.factory.buildFeature.pixJuniorFeatures()

- await insertMultipleSendingFeatureForNewOrganization();
+ // remplacé par des `databaseBuilder.factory.xxx`
```

## 🌷 Remarques

**La revue peut se faire commit par commit.**

## 🐝 Pour tester

La CI doit passer.
