### PR TITLE
[FEATURE] Remplir la colonne "lastAnswerAt" de la table "certification-courses" à chaque réponse apportée par le candidat

### DIFF
--- a/api/db/database-builder/factory/build-certification-course.js
+++ b/api/db/database-builder/factory/build-certification-course.js
@@ -33,6 +33,7 @@ const buildCertificationCourse = function ({
   versionId = null,
   candidateId = null,
   framework = Frameworks.CORE,
+  lastAnswerAt = null,
 } = {}) {
   userId = _.isUndefined(userId) ? buildUser().id : userId;
   sessionId = _.isUndefined(sessionId) ? buildSession().id : sessionId;
@@ -63,6 +64,7 @@ const buildCertificationCourse = function ({
     versionId,
     candidateId,
     framework,
+    lastAnswerAt,
   };
   return databaseBuffer.pushInsertable({
     tableName: 'certification-courses',

--- a/api/src/certification/evaluation/domain/models/AssessmentSheet.js
+++ b/api/src/certification/evaluation/domain/models/AssessmentSheet.js
@@ -86,9 +86,8 @@ export class AssessmentSheet {
     return this.lastQuestionState === STATES_OF_LAST_QUESTION.FOCUSEDOUT;
   }
 
-  refreshLastAnswerTimestamp() {
-    const now = new Date();
-    this.lastAnswerAt = now;
-    this.certificationCourseUpdatedAt = now;
+  refreshLastAnswerTimestamp(refreshDate) {
+    this.lastAnswerAt = refreshDate;
+    this.certificationCourseUpdatedAt = refreshDate;
   }
 }

--- a/api/src/certification/evaluation/domain/models/AssessmentSheet.js
+++ b/api/src/certification/evaluation/domain/models/AssessmentSheet.js
@@ -17,6 +17,8 @@ export class AssessmentSheet {
    * @param {boolean} params.isRejectedForFraud
    * @param {Assessment.states} params.state
    * @param {Date} params.assessmentUpdatedAt
+   * @param {Date} params.certificationCourseUpdatedAt
+   * @param {Date} params.lastAnswerAt
    * @param {Answer[]} params.answers
    */
   constructor({
@@ -30,6 +32,8 @@ export class AssessmentSheet {
     isRejectedForFraud,
     state,
     assessmentUpdatedAt,
+    certificationCourseUpdatedAt,
+    lastAnswerAt,
     answers,
   }) {
     this.certificationCourseId = certificationCourseId;
@@ -42,6 +46,8 @@ export class AssessmentSheet {
     this.isRejectedForFraud = isRejectedForFraud;
     this.state = state;
     this.assessmentUpdatedAt = assessmentUpdatedAt;
+    this.certificationCourseUpdatedAt = certificationCourseUpdatedAt;
+    this.lastAnswerAt = lastAnswerAt;
     this.answers = answers;
   }
 

--- a/api/src/certification/evaluation/domain/models/AssessmentSheet.js
+++ b/api/src/certification/evaluation/domain/models/AssessmentSheet.js
@@ -85,4 +85,10 @@ export class AssessmentSheet {
   hasLastQuestionBeenFocusedOut() {
     return this.lastQuestionState === STATES_OF_LAST_QUESTION.FOCUSEDOUT;
   }
+
+  refreshLastAnswerTimestamp() {
+    const now = new Date();
+    this.lastAnswerAt = now;
+    this.certificationCourseUpdatedAt = now;
+  }
 }

--- a/api/src/certification/evaluation/domain/models/AssessmentSheet.js
+++ b/api/src/certification/evaluation/domain/models/AssessmentSheet.js
@@ -16,7 +16,7 @@ export class AssessmentSheet {
    * @param {ABORT_REASONS} params.abortReason
    * @param {boolean} params.isRejectedForFraud
    * @param {Assessment.states} params.state
-   * @param {Date} params.updatedAt
+   * @param {Date} params.assessmentUpdatedAt
    * @param {Answer[]} params.answers
    */
   constructor({
@@ -29,7 +29,7 @@ export class AssessmentSheet {
     abortReason,
     isRejectedForFraud,
     state,
-    updatedAt,
+    assessmentUpdatedAt,
     answers,
   }) {
     this.certificationCourseId = certificationCourseId;
@@ -41,7 +41,7 @@ export class AssessmentSheet {
     this.abortReason = abortReason;
     this.isRejectedForFraud = isRejectedForFraud;
     this.state = state;
-    this.updatedAt = updatedAt;
+    this.assessmentUpdatedAt = assessmentUpdatedAt;
     this.answers = answers;
   }
 
@@ -56,7 +56,7 @@ export class AssessmentSheet {
   complete() {
     if (this.state === STATES.STARTED) {
       this.state = STATES.COMPLETED;
-      this.updatedAt = new Date();
+      this.assessmentUpdatedAt = new Date();
     }
   }
 

--- a/api/src/certification/evaluation/domain/usecases/evaluate-and-save-answer.js
+++ b/api/src/certification/evaluation/domain/usecases/evaluate-and-save-answer.js
@@ -1,4 +1,5 @@
 import { EmptyAnswerError } from '../../../../evaluation/domain/errors.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import {
   CertificationEndedByFinalizationError,
   CertificationEndedByInvigilatorError,
@@ -50,9 +51,14 @@ export async function evaluateAndSaveAnswer({
     forceOKAnswer,
   });
 
-  const answerSaved = await answerRepository.save({ answer: correctedAnswer });
-  answerSaved.levelup = {};
-  return answerSaved;
+  return DomainTransaction.execute(async () => {
+    const answerSaved = await answerRepository.save({ answer: correctedAnswer });
+    assessmentSheet.refreshLastAnswerTimestamp();
+    await assessmentSheetRepository.update(assessmentSheet);
+
+    answerSaved.levelup = {};
+    return answerSaved;
+  });
 }
 
 function checkIfAnswerIsAdmissible({ assessmentSheet, answer, userId }) {

--- a/api/src/certification/evaluation/domain/usecases/evaluate-and-save-answer.js
+++ b/api/src/certification/evaluation/domain/usecases/evaluate-and-save-answer.js
@@ -53,7 +53,7 @@ export async function evaluateAndSaveAnswer({
 
   return DomainTransaction.execute(async () => {
     const answerSaved = await answerRepository.save({ answer: correctedAnswer });
-    assessmentSheet.refreshLastAnswerTimestamp();
+    assessmentSheet.refreshLastAnswerTimestamp(answerSaved.createdAt);
     await assessmentSheetRepository.update(assessmentSheet);
 
     answerSaved.levelup = {};

--- a/api/src/certification/evaluation/infrastructure/repositories/assessment-sheet-repository.js
+++ b/api/src/certification/evaluation/infrastructure/repositories/assessment-sheet-repository.js
@@ -12,10 +12,12 @@ export async function findByCertificationCourseId(certificationCourseId) {
       lastChallengeId: 'assessments.lastChallengeId',
       lastQuestionDate: 'assessments.lastQuestionDate',
       lastQuestionState: 'assessments.lastQuestionState',
+      lastAnswerAt: 'certification-courses.lastAnswerAt',
       abortReason: 'certification-courses.abortReason',
       isRejectedForFraud: 'certification-courses.isRejectedForFraud',
       state: 'assessments.state',
       assessmentUpdatedAt: 'assessments.updatedAt',
+      certificationCourseUpdatedAt: 'certification-courses.updatedAt',
     })
     .from('certification-courses')
     .join('assessments', 'assessments.certificationCourseId', 'certification-courses.id')

--- a/api/src/certification/evaluation/infrastructure/repositories/assessment-sheet-repository.js
+++ b/api/src/certification/evaluation/infrastructure/repositories/assessment-sheet-repository.js
@@ -41,5 +41,11 @@ export async function update(assessmentSheet) {
       updatedAt: assessmentSheet.assessmentUpdatedAt,
       state: assessmentSheet.state,
     })
-    .where('assessments.id', '=', assessmentSheet.assessmentId);
+    .where({ id: assessmentSheet.assessmentId });
+  await knexConn('certification-courses')
+    .update({
+      updatedAt: assessmentSheet.certificationCourseUpdatedAt,
+      lastAnswerAt: assessmentSheet.lastAnswerAt,
+    })
+    .where({ id: assessmentSheet.certificationCourseId });
 }

--- a/api/src/certification/evaluation/infrastructure/repositories/assessment-sheet-repository.js
+++ b/api/src/certification/evaluation/infrastructure/repositories/assessment-sheet-repository.js
@@ -15,7 +15,7 @@ export async function findByCertificationCourseId(certificationCourseId) {
       abortReason: 'certification-courses.abortReason',
       isRejectedForFraud: 'certification-courses.isRejectedForFraud',
       state: 'assessments.state',
-      updatedAt: 'assessments.updatedAt',
+      assessmentUpdatedAt: 'assessments.updatedAt',
     })
     .from('certification-courses')
     .join('assessments', 'assessments.certificationCourseId', 'certification-courses.id')
@@ -36,7 +36,7 @@ export async function update(assessmentSheet) {
   const knexConn = DomainTransaction.getConnection();
   await knexConn('assessments')
     .update({
-      updatedAt: assessmentSheet.updatedAt,
+      updatedAt: assessmentSheet.assessmentUpdatedAt,
       state: assessmentSheet.state,
     })
     .where('assessments.id', '=', assessmentSheet.assessmentId);

--- a/api/src/evaluation/domain/models/Answer.js
+++ b/api/src/evaluation/domain/models/Answer.js
@@ -5,6 +5,7 @@ import { AnswerStatus } from '../../../shared/domain/models/AnswerStatus.js';
 class Answer {
   constructor({
     id,
+    createdAt,
     result,
     resultDetails,
     timeout,
@@ -16,6 +17,7 @@ class Answer {
     timeSpent,
   } = {}) {
     this.id = id;
+    this.createdAt = createdAt;
     // XXX result property should not be auto-created from result to an AnswerStatus Object
     this.result = AnswerStatus.from(result);
     this.resultDetails = resultDetails;

--- a/api/src/shared/infrastructure/repositories/answer-repository.js
+++ b/api/src/shared/infrastructure/repositories/answer-repository.js
@@ -14,6 +14,7 @@ const COLUMNS = Object.freeze([
   'assessmentId',
   'challengeId',
   'timeSpent',
+  'createdAt',
 ]);
 
 export async function get(id) {

--- a/api/tests/certification/evaluation/integration/domain/usecases/evaluate-and-save-answer_test.js
+++ b/api/tests/certification/evaluation/integration/domain/usecases/evaluate-and-save-answer_test.js
@@ -9,7 +9,7 @@ import {
   ForbiddenAccess,
   NotFoundError,
 } from '../../../../../../src/shared/domain/errors.js';
-import { catchErr, databaseBuilder, domainBuilder, expect, knex } from '../../../../../test-helper.js';
+import { catchErr, databaseBuilder, domainBuilder, expect, knex, sinon } from '../../../../../test-helper.js';
 
 const { evaluateAndSaveAnswer } = usecases;
 
@@ -17,8 +17,11 @@ describe('Certification | Evaluation | Integration | Domain | UseCase | evaluate
   const STATES = domainBuilder.certification.evaluation.buildAssessmentSheet.STATES;
   const STATES_OF_LAST_QUESTION = domainBuilder.certification.evaluation.buildAssessmentSheet.STATES_OF_LAST_QUESTION;
   const challengeIdToAnswer = 'expectedChallengeToBeAnswered';
+  const now = new Date();
+  let clock;
 
   beforeEach(function () {
+    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
     databaseBuilder.factory.learningContent.buildSkill({
       id: 'someSkillId',
     });
@@ -28,6 +31,10 @@ describe('Certification | Evaluation | Integration | Domain | UseCase | evaluate
       skillId: 'someSkillId',
     });
     return databaseBuilder.commit();
+  });
+
+  afterEach(async function () {
+    clock.restore();
   });
 
   context('when certification does not exist', function () {
@@ -220,6 +227,19 @@ describe('Certification | Evaluation | Integration | Domain | UseCase | evaluate
               expect(Boolean(answerExistsInDB)).to.be.true;
               const keInDB = await knex('knowledge-elements').pluck('id');
               expect(keInDB).to.have.length(0);
+            });
+
+            it('updates the lastAnswerAt date', async function () {
+              await evaluateAndSaveAnswer({
+                certificationCourseId,
+                userId,
+                answer: currentAnswer,
+              });
+
+              const [lastAnswerAt] = await knex('certification-courses')
+                .pluck('lastAnswerAt')
+                .where({ id: certificationCourseId });
+              expect(lastAnswerAt).to.deep.equal(now);
             });
           });
         });

--- a/api/tests/certification/evaluation/integration/domain/usecases/evaluate-and-save-answer_test.js
+++ b/api/tests/certification/evaluation/integration/domain/usecases/evaluate-and-save-answer_test.js
@@ -9,7 +9,7 @@ import {
   ForbiddenAccess,
   NotFoundError,
 } from '../../../../../../src/shared/domain/errors.js';
-import { catchErr, databaseBuilder, domainBuilder, expect, knex, sinon } from '../../../../../test-helper.js';
+import { catchErr, databaseBuilder, domainBuilder, expect, knex } from '../../../../../test-helper.js';
 
 const { evaluateAndSaveAnswer } = usecases;
 
@@ -17,11 +17,8 @@ describe('Certification | Evaluation | Integration | Domain | UseCase | evaluate
   const STATES = domainBuilder.certification.evaluation.buildAssessmentSheet.STATES;
   const STATES_OF_LAST_QUESTION = domainBuilder.certification.evaluation.buildAssessmentSheet.STATES_OF_LAST_QUESTION;
   const challengeIdToAnswer = 'expectedChallengeToBeAnswered';
-  const now = new Date();
-  let clock;
 
   beforeEach(function () {
-    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
     databaseBuilder.factory.learningContent.buildSkill({
       id: 'someSkillId',
     });
@@ -31,10 +28,6 @@ describe('Certification | Evaluation | Integration | Domain | UseCase | evaluate
       skillId: 'someSkillId',
     });
     return databaseBuilder.commit();
-  });
-
-  afterEach(async function () {
-    clock.restore();
   });
 
   context('when certification does not exist', function () {
@@ -229,17 +222,18 @@ describe('Certification | Evaluation | Integration | Domain | UseCase | evaluate
               expect(keInDB).to.have.length(0);
             });
 
-            it('updates the lastAnswerAt date', async function () {
-              await evaluateAndSaveAnswer({
+            it('updates the lastAnswerAt date to answer creation date', async function () {
+              const evaluatedAnswer = await evaluateAndSaveAnswer({
                 certificationCourseId,
                 userId,
                 answer: currentAnswer,
               });
 
+              const [answerCreatedAt] = await knex('answers').pluck('createdAt').where({ id: evaluatedAnswer.id });
               const [lastAnswerAt] = await knex('certification-courses')
                 .pluck('lastAnswerAt')
                 .where({ id: certificationCourseId });
-              expect(lastAnswerAt).to.deep.equal(now);
+              expect(lastAnswerAt).to.deep.equal(answerCreatedAt);
             });
           });
         });

--- a/api/tests/certification/evaluation/integration/infrastructure/repositories/assessment-sheet-repository_test.js
+++ b/api/tests/certification/evaluation/integration/infrastructure/repositories/assessment-sheet-repository_test.js
@@ -40,7 +40,7 @@ describe('Integration | Certification | Evaluation | Infrastructure | Repositori
             abortReason: 'candidate',
             isRejectedForFraud: true,
             state: Assessment.states.COMPLETED,
-            updatedAt: new Date('2023-10-05'),
+            assessmentUpdatedAt: new Date('2023-10-05'),
             answers: [domainBuilder.buildAnswer(answerData)],
             lastChallengeId: 'nextChallengeIdToAnswer',
             lastQuestionDate: new Date('2024-11-07'),
@@ -70,7 +70,7 @@ describe('Integration | Certification | Evaluation | Infrastructure | Repositori
         abortReason: 'technical',
         isRejectedForFraud: false,
         state: Assessment.states.STARTED,
-        updatedAt: new Date('2024-05-11'),
+        assessmentUpdatedAt: new Date('2024-05-11'),
         answers: [],
       });
 
@@ -87,7 +87,7 @@ describe('Integration | Certification | Evaluation | Infrastructure | Repositori
           abortReason: 'candidate',
           isRejectedForFraud: true,
           state: Assessment.states.STARTED,
-          updatedAt: new Date('2024-05-11'),
+          assessmentUpdatedAt: new Date('2024-05-11'),
           answers: [domainBuilder.buildAnswer(answerData)],
           lastChallengeId: 'nextChallengeIdToAnswer',
           lastQuestionDate: new Date('2024-11-07'),

--- a/api/tests/certification/evaluation/integration/infrastructure/repositories/assessment-sheet-repository_test.js
+++ b/api/tests/certification/evaluation/integration/infrastructure/repositories/assessment-sheet-repository_test.js
@@ -12,6 +12,8 @@ describe('Integration | Certification | Evaluation | Infrastructure | Repositori
       maxReachableLevelOnCertificationDate: 6,
       isRejectedForFraud: true,
       userId,
+      updatedAt: new Date('2022-02-22'),
+      lastAnswerAt: new Date('2022-01-11'),
     }).id;
     assessmentId = databaseBuilder.factory.buildAssessment({
       certificationCourseId,
@@ -45,6 +47,8 @@ describe('Integration | Certification | Evaluation | Infrastructure | Repositori
             lastChallengeId: 'nextChallengeIdToAnswer',
             lastQuestionDate: new Date('2024-11-07'),
             lastQuestionState: Assessment.statesOfLastQuestion.TIMEOUT,
+            certificationCourseUpdatedAt: new Date('2022-02-22'),
+            lastAnswerAt: new Date('2022-01-11'),
           }),
         );
       });
@@ -72,6 +76,11 @@ describe('Integration | Certification | Evaluation | Infrastructure | Repositori
         state: Assessment.states.STARTED,
         assessmentUpdatedAt: new Date('2024-05-11'),
         answers: [],
+        lastChallengeId: 'somethingElse',
+        lastQuestionDate: new Date('2033-10-07'),
+        lastQuestionState: Assessment.statesOfLastQuestion.ASKED,
+        certificationCourseUpdatedAt: new Date('2044-02-22'),
+        lastAnswerAt: new Date('2044-01-11'),
       });
 
       // when
@@ -92,6 +101,8 @@ describe('Integration | Certification | Evaluation | Infrastructure | Repositori
           lastChallengeId: 'nextChallengeIdToAnswer',
           lastQuestionDate: new Date('2024-11-07'),
           lastQuestionState: Assessment.statesOfLastQuestion.TIMEOUT,
+          certificationCourseUpdatedAt: new Date('2022-02-22'),
+          lastAnswerAt: new Date('2022-01-11'),
         }),
       );
     });

--- a/api/tests/certification/evaluation/integration/infrastructure/repositories/assessment-sheet-repository_test.js
+++ b/api/tests/certification/evaluation/integration/infrastructure/repositories/assessment-sheet-repository_test.js
@@ -27,6 +27,7 @@ describe('Integration | Certification | Evaluation | Infrastructure | Repositori
     answerData = databaseBuilder.factory.buildAnswer({ assessmentId, result: 'ok' });
     await databaseBuilder.commit();
   });
+
   describe('#findByCertificationCourseId', function () {
     context('when the certification course exists', function () {
       it('should return the assessment sheet', async function () {
@@ -66,7 +67,7 @@ describe('Integration | Certification | Evaluation | Infrastructure | Repositori
   });
 
   describe('#update', function () {
-    it('should update only the state and the updatedAt date of the assessment the assessment sheet', async function () {
+    it('should update only allowed fields of the assessment the assessment sheet', async function () {
       // given
       const assessmentSheetToUpdate = domainBuilder.certification.evaluation.buildAssessmentSheet({
         certificationCourseId,
@@ -95,14 +96,14 @@ describe('Integration | Certification | Evaluation | Infrastructure | Repositori
           userId,
           abortReason: 'candidate',
           isRejectedForFraud: true,
-          state: Assessment.states.STARTED,
-          assessmentUpdatedAt: new Date('2024-05-11'),
+          state: Assessment.states.STARTED, // updated
+          assessmentUpdatedAt: new Date('2024-05-11'), // updated
           answers: [domainBuilder.buildAnswer(answerData)],
           lastChallengeId: 'nextChallengeIdToAnswer',
           lastQuestionDate: new Date('2024-11-07'),
           lastQuestionState: Assessment.statesOfLastQuestion.TIMEOUT,
-          certificationCourseUpdatedAt: new Date('2022-02-22'),
-          lastAnswerAt: new Date('2022-01-11'),
+          certificationCourseUpdatedAt: new Date('2044-02-22'), // updated
+          lastAnswerAt: new Date('2044-01-11'), // updated
         }),
       );
     });

--- a/api/tests/certification/evaluation/unit/domain/models/AssessmentSheet_test.js
+++ b/api/tests/certification/evaluation/unit/domain/models/AssessmentSheet_test.js
@@ -45,11 +45,11 @@ describe('Certification | Evaluation | Unit | Domain | Models | AssessmentSheet'
       clock.restore();
     });
 
-    it(`should update state and updatedAt when assessment sheet is in state ${STATES.STARTED}`, function () {
+    it(`should update state and assessmentUpdatedAt when assessment sheet is in state ${STATES.STARTED}`, function () {
       const assessmentSheet = domainBuilder.certification.evaluation.buildAssessmentSheet({
         ...assessmentSheetBaseData,
         state: STATES.STARTED,
-        updatedAt: new Date('2021-10-29'),
+        assessmentUpdatedAt: new Date('2021-10-29'),
       });
       assessmentSheet.complete();
 
@@ -57,7 +57,7 @@ describe('Certification | Evaluation | Unit | Domain | Models | AssessmentSheet'
         domainBuilder.certification.evaluation.buildAssessmentSheet({
           ...assessmentSheetBaseData,
           state: STATES.COMPLETED,
-          updatedAt: now,
+          assessmentUpdatedAt: now,
         }),
       );
     });
@@ -69,7 +69,7 @@ describe('Certification | Evaluation | Unit | Domain | Models | AssessmentSheet'
           const assessmentSheet = domainBuilder.certification.evaluation.buildAssessmentSheet({
             ...assessmentSheetBaseData,
             state,
-            updatedAt: new Date('2021-10-29'),
+            assessmentUpdatedAt: new Date('2021-10-29'),
           });
           assessmentSheet.complete();
 
@@ -77,7 +77,7 @@ describe('Certification | Evaluation | Unit | Domain | Models | AssessmentSheet'
             domainBuilder.certification.evaluation.buildAssessmentSheet({
               ...assessmentSheetBaseData,
               state,
-              updatedAt: new Date('2021-10-29'),
+              assessmentUpdatedAt: new Date('2021-10-29'),
             }),
           );
         });

--- a/api/tests/certification/evaluation/unit/domain/models/AssessmentSheet_test.js
+++ b/api/tests/certification/evaluation/unit/domain/models/AssessmentSheet_test.js
@@ -225,8 +225,7 @@ describe('Certification | Evaluation | Unit | Domain | Models | AssessmentSheet'
   });
 
   context('#refreshLastAnswerTimestamp', function () {
-    let clock, assessmentSheetBaseData;
-    const now = new Date();
+    let assessmentSheetBaseData;
 
     beforeEach(function () {
       assessmentSheetBaseData = {
@@ -237,49 +236,24 @@ describe('Certification | Evaluation | Unit | Domain | Models | AssessmentSheet'
         answers: [domainBuilder.buildAnswer()],
         assessmentUpdatedAt: new Date('2022-01-01'),
       };
-      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
     });
 
-    afterEach(async function () {
-      clock.restore();
-    });
-
-    it('should update lastAnswerAt and certificationCourseUpdatedAt ', function () {
+    it('should update lastAnswerAt and certificationCourseUpdatedAt to provided date', function () {
+      const someDate = new Date('2044-05-05');
       const assessmentSheet = domainBuilder.certification.evaluation.buildAssessmentSheet({
         ...assessmentSheetBaseData,
         lastAnswerAt: new Date('2023-03-03'),
         certificationCourseUpdatedAt: new Date('2024-04-04'),
       });
-      assessmentSheet.refreshLastAnswerTimestamp();
+      assessmentSheet.refreshLastAnswerTimestamp(someDate);
 
       expect(assessmentSheet).to.deepEqualInstance(
         domainBuilder.certification.evaluation.buildAssessmentSheet({
           ...assessmentSheetBaseData,
-          lastAnswerAt: now,
-          certificationCourseUpdatedAt: now,
+          lastAnswerAt: someDate,
+          certificationCourseUpdatedAt: someDate,
         }),
       );
     });
-
-    Object.values(STATES)
-      .filter((state) => state !== STATES.STARTED)
-      .forEach((state) => {
-        it(`should do nothing state is ${state}`, async function () {
-          const assessmentSheet = domainBuilder.certification.evaluation.buildAssessmentSheet({
-            ...assessmentSheetBaseData,
-            state,
-            assessmentUpdatedAt: new Date('2021-10-29'),
-          });
-          assessmentSheet.complete();
-
-          expect(assessmentSheet).to.deepEqualInstance(
-            domainBuilder.certification.evaluation.buildAssessmentSheet({
-              ...assessmentSheetBaseData,
-              state,
-              assessmentUpdatedAt: new Date('2021-10-29'),
-            }),
-          );
-        });
-      });
   });
 });

--- a/api/tests/certification/evaluation/unit/domain/models/AssessmentSheet_test.js
+++ b/api/tests/certification/evaluation/unit/domain/models/AssessmentSheet_test.js
@@ -223,4 +223,63 @@ describe('Certification | Evaluation | Unit | Domain | Models | AssessmentSheet'
         });
       });
   });
+
+  context('#refreshLastAnswerTimestamp', function () {
+    let clock, assessmentSheetBaseData;
+    const now = new Date();
+
+    beforeEach(function () {
+      assessmentSheetBaseData = {
+        certificationCourseId: 123,
+        assessmentId: 456,
+        abortReason: 'candidate',
+        isRejectedForFraud: true,
+        answers: [domainBuilder.buildAnswer()],
+        assessmentUpdatedAt: new Date('2022-01-01'),
+      };
+      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+    });
+
+    afterEach(async function () {
+      clock.restore();
+    });
+
+    it('should update lastAnswerAt and certificationCourseUpdatedAt ', function () {
+      const assessmentSheet = domainBuilder.certification.evaluation.buildAssessmentSheet({
+        ...assessmentSheetBaseData,
+        lastAnswerAt: new Date('2023-03-03'),
+        certificationCourseUpdatedAt: new Date('2024-04-04'),
+      });
+      assessmentSheet.refreshLastAnswerTimestamp();
+
+      expect(assessmentSheet).to.deepEqualInstance(
+        domainBuilder.certification.evaluation.buildAssessmentSheet({
+          ...assessmentSheetBaseData,
+          lastAnswerAt: now,
+          certificationCourseUpdatedAt: now,
+        }),
+      );
+    });
+
+    Object.values(STATES)
+      .filter((state) => state !== STATES.STARTED)
+      .forEach((state) => {
+        it(`should do nothing state is ${state}`, async function () {
+          const assessmentSheet = domainBuilder.certification.evaluation.buildAssessmentSheet({
+            ...assessmentSheetBaseData,
+            state,
+            assessmentUpdatedAt: new Date('2021-10-29'),
+          });
+          assessmentSheet.complete();
+
+          expect(assessmentSheet).to.deepEqualInstance(
+            domainBuilder.certification.evaluation.buildAssessmentSheet({
+              ...assessmentSheetBaseData,
+              state,
+              assessmentUpdatedAt: new Date('2021-10-29'),
+            }),
+          );
+        });
+      });
+  });
 });

--- a/api/tests/certification/session-management/unit/domain/usecases/process-auto-jury_test.js
+++ b/api/tests/certification/session-management/unit/domain/usecases/process-auto-jury_test.js
@@ -303,6 +303,7 @@ describe('Unit | UseCase | process-auto-jury', function () {
           createdAt: new Date('2020-01-02'),
         });
         const answeredChallenge = domainBuilder.buildAnswer({
+          createdAt: new Date('2020-01-01'),
           challengeId: challengeNotToBeConsideredAsSkipped.challengeId,
         });
         const certificationAssessment = domainBuilder.buildCertificationAssessment({
@@ -350,6 +351,7 @@ describe('Unit | UseCase | process-auto-jury', function () {
           certificationAnswersByDate: [
             domainBuilder.buildAnswer({
               id: 123,
+              createdAt: new Date('2020-01-01'),
               result: 'ok',
               resultDetails: null,
               timeout: null,

--- a/api/tests/certification/shared/fixtures/certification-course.js
+++ b/api/tests/certification/shared/fixtures/certification-course.js
@@ -96,6 +96,7 @@ const buildCertificationChallengesFromChallenges = ({ challenges, certificationC
 const buildOkAnswersFromChallenges = ({ challenges, assessment }) => {
   return challenges.map((challenge) => {
     const answer = domainBuilder.buildAnswer({
+      createdAt: new Date('2020-01-01'),
       assessmentId: assessment.id,
       challengeId: challenge.id,
       result: AnswerStatus.OK,

--- a/api/tests/evaluation/unit/domain/models/Answer_test.js
+++ b/api/tests/evaluation/unit/domain/models/Answer_test.js
@@ -8,6 +8,7 @@ describe('Unit | Domain | Models | Answer', function () {
       // given
       const rawData = {
         id: 2,
+        createdAt: new Date('2020-01-01'),
         value: 'Avast, Norton',
         result: 'ok',
         resultDetails: 'champs1 : ok \n champs2 : ko',
@@ -21,6 +22,7 @@ describe('Unit | Domain | Models | Answer', function () {
 
       const expectedAnswer = {
         id: 2,
+        createdAt: new Date('2020-01-01'),
         value: 'Avast, Norton',
         result: { status: 'ok' },
         resultDetails: 'champs1 : ok \n champs2 : ko',

--- a/api/tests/shared/integration/infrastructure/repositories/answer-repository_test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/answer-repository_test.js
@@ -108,6 +108,7 @@ describe('Integration | Repository | answerRepository', function () {
       // given
       const olderAnswer = domainBuilder.buildAnswer({
         id: 1,
+        createdAt: new Date('2020-01-01'),
         result: AnswerStatus.OK,
         resultDetails: 'some details',
         timeout: 456,
@@ -187,6 +188,7 @@ describe('Integration | Repository | answerRepository', function () {
         // given
         const firstAnswer = domainBuilder.buildAnswer({
           id: 1,
+          createdAt: new Date('2019-01-01'),
           result: AnswerStatus.OK,
           resultDetails: 'some details',
           timeout: 456,
@@ -197,6 +199,7 @@ describe('Integration | Repository | answerRepository', function () {
         });
         const secondAnswer = domainBuilder.buildAnswer({
           id: 2,
+          createdAt: new Date('2020-01-01'),
           result: AnswerStatus.KO,
           resultDetails: 'some details',
           timeout: null,
@@ -206,8 +209,8 @@ describe('Integration | Repository | answerRepository', function () {
           timeSpent: 20,
         });
         databaseBuilder.factory.buildAssessment({ id: 123 });
-        databaseBuilder.factory.buildAnswer({ ...secondAnswer, result: 'ko', createdAt: new Date('2020-01-01') });
-        databaseBuilder.factory.buildAnswer({ ...firstAnswer, result: 'ok', createdAt: new Date('2019-01-01') });
+        databaseBuilder.factory.buildAnswer({ ...secondAnswer, result: 'ko' });
+        databaseBuilder.factory.buildAnswer({ ...firstAnswer, result: 'ok' });
         databaseBuilder.factory.buildAnswer();
         await databaseBuilder.commit();
 
@@ -225,19 +228,21 @@ describe('Integration | Repository | answerRepository', function () {
         const challengeId = 'recChallenge123';
         const olderAnswer = domainBuilder.buildAnswer({
           id: 1,
+          createdAt: new Date('2018-01-01'),
           assessmentId: 123,
           result: AnswerStatus.KO,
           challengeId,
         });
         const recentAnswer = domainBuilder.buildAnswer({
           id: 2,
+          createdAt: new Date('2020-01-01'),
           assessmentId: 123,
           result: AnswerStatus.KO,
           challengeId,
         });
         databaseBuilder.factory.buildAssessment({ id: 123 });
-        databaseBuilder.factory.buildAnswer({ ...recentAnswer, result: 'ko', createdAt: new Date('2020-01-01') });
-        databaseBuilder.factory.buildAnswer({ ...olderAnswer, result: 'ko', createdAt: new Date('2018-01-01') });
+        databaseBuilder.factory.buildAnswer({ ...recentAnswer, result: 'ko' });
+        databaseBuilder.factory.buildAnswer({ ...olderAnswer, result: 'ko' });
         databaseBuilder.factory.buildAnswer();
         await databaseBuilder.commit();
 

--- a/api/tests/tooling/domain-builder/factory/build-answer.js
+++ b/api/tests/tooling/domain-builder/factory/build-answer.js
@@ -3,6 +3,7 @@ import { AnswerStatus } from '../../../../src/shared/domain/models/AnswerStatus.
 
 function buildAnswer({
   id = 123,
+  createdAt = new Date(),
   result = AnswerStatus.OK,
   resultDetails = null,
   timeout = null,
@@ -14,6 +15,7 @@ function buildAnswer({
 } = {}) {
   return new Answer({
     id,
+    createdAt,
     result,
     resultDetails,
     timeout,

--- a/api/tests/tooling/domain-builder/factory/certification/evaluation/build-assessment-sheet.js
+++ b/api/tests/tooling/domain-builder/factory/certification/evaluation/build-assessment-sheet.js
@@ -13,7 +13,7 @@ export const buildAssessmentSheet = function ({
   isRejectedForFraud = false,
   state = STATES.COMPLETED,
   lastQuestionState = STATES_OF_LAST_QUESTION.ASKED,
-  updatedAt = new Date(),
+  assessmentUpdatedAt = new Date(),
   lastQuestionDate = new Date(),
   answers = [],
 } = {}) {
@@ -26,7 +26,7 @@ export const buildAssessmentSheet = function ({
     isRejectedForFraud,
     state,
     lastQuestionState,
-    updatedAt,
+    assessmentUpdatedAt,
     lastQuestionDate,
     answers,
   });

--- a/api/tests/tooling/domain-builder/factory/certification/evaluation/build-assessment-sheet.js
+++ b/api/tests/tooling/domain-builder/factory/certification/evaluation/build-assessment-sheet.js
@@ -14,6 +14,8 @@ export const buildAssessmentSheet = function ({
   state = STATES.COMPLETED,
   lastQuestionState = STATES_OF_LAST_QUESTION.ASKED,
   assessmentUpdatedAt = new Date(),
+  certificationCourseUpdatedAt = new Date(),
+  lastAnswerAt = new Date(),
   lastQuestionDate = new Date(),
   answers = [],
 } = {}) {
@@ -27,6 +29,8 @@ export const buildAssessmentSheet = function ({
     state,
     lastQuestionState,
     assessmentUpdatedAt,
+    certificationCourseUpdatedAt,
+    lastAnswerAt,
     lastQuestionDate,
     answers,
   });


### PR DESCRIPTION
## 🌱 Problème
On a ajouté une colonne pour indique la date de dernière réponse apportée lors d'un test de certification. Il faut maintenant la remplir.

## 🐣 Proposition

Remplir la colonne avec la même valeur que le `createdAt` de la réponse enregistrée

## 🌷 Remarques

Fun fact pas trop fun :
j'ai voulu vérifier que ça marchait en local donc j'ai fait ça (ne pas faire en prod obviously) :
`select "lastAnswerAt", answers.id from "certification-courses" left join answers on answers."createdAt" = "certification-courses"."lastAnswerAt"`

ce qui m'a retourné 0 résultats (donc j'étais bien triste) et en fait c'est parce que les deux dates ne sont (malgré les efforts dans le code) pas exactement les mêmes.

- ajout d'une answer en BDD -> PG définit le createdAt lui-même avec une précision de 6 digits
- récupération de cet info via knex -> perte de précision, en JS cette valeur est réduite à 3 digits



## 🐝 Pour tester
e2e ✅  puis vérifier que la date est bien inscrite après chaque réponse apportée
