### PR TITLE
[FEATURE] Gestion de l'erreur "manque de challenges" en certification (PIX-22290)

### DIFF
--- a/api/src/certification/evaluation/application/api/certification-evaluation-api.js
+++ b/api/src/certification/evaluation/application/api/certification-evaluation-api.js
@@ -11,9 +11,14 @@
  * @typedef {import ('../../../../shared/domain/errors.js').AssessmentLackOfChallengesError} AssessmentLackOfChallengesError
  * @typedef {import ('../../../../shared/domain/models/Challenge.js').Challenge} Challenge
  */
-import { withTransaction } from '../../../../shared/domain/DomainTransaction.js';
+import { DomainTransaction, withTransaction } from '../../../../shared/domain/DomainTransaction.js';
+import { Assessment } from '../../../../shared/domain/models/Assessment.js';
 import { usecases } from '../../domain/usecases/index.js';
 import * as assessmentRepository from '../../infrastructure/repositories/assessment-repository.js';
+import * as certificationCourseRepository from '../../../shared/infrastructure/repositories/certification-course-repository.js';
+import { AssessmentLackOfChallengesError } from '../../../../shared/domain/errors.js';
+import { logger } from '../../../../shared/infrastructure/utils/logger.js';
+import { ABORT_REASONS } from '../../../shared/domain/constants/abort-reasons.js';
 
 /**
  * @function
@@ -52,19 +57,42 @@ export const rescoreV2Certification = async ({ event }) => {
  * @throws {AssessmentEndedError} test ended or no next challenge available
  * @throws {AssessmentLackOfChallengesError} no eligible challenges remaining before reaching maximum assessment length
  */
-export const selectNextCertificationChallenge = withTransaction(
+export const selectNextCertificationChallenge =
   async ({
     assessmentId,
     locale,
     dependencies = {
       assessmentRepository,
+      certificationCourseRepository,
     },
   }) => {
     const assessment = await dependencies.assessmentRepository.get(assessmentId);
+    try {
+      return await DomainTransaction.execute(async () => {
+        return await usecases.getNextChallenge({ assessment, locale });
+      });
+    } catch (error) {
+      if (error instanceof AssessmentLackOfChallengesError) {
+        logger.warn(
+          {
+            assessmentId: assessment.id,
+            numberOfAnswers: error.numberOfAnswers,
+            maximumAssessmentLength: error.maximumAssessmentLength,
+          },
+          'Assessment ended prematurely: no challenge remaining before reaching maximum assessment length',
+        );
 
-    return usecases.getNextChallenge({ assessment, locale });
-  },
-);
+        await DomainTransaction.execute(async () => {
+          const certificationCourse = await certificationCourseRepository.get({ id: assessment.certificationCourseId });
+          certificationCourse.abort(ABORT_REASONS.TECHNICAL);
+          await certificationCourseRepository.update({ certificationCourse });
+          await dependencies.assessmentRepository.updateStateById(assessment.id, Assessment.states.ABORTED)
+        });
+        throw error;
+      }
+    }
+  }
+
 
 /**
  * @function

--- a/api/src/certification/evaluation/domain/models/FlashAssessmentAlgorithm.js
+++ b/api/src/certification/evaluation/domain/models/FlashAssessmentAlgorithm.js
@@ -25,13 +25,14 @@ class FlashAssessmentAlgorithm {
    * @param {FlashAlgorithmImplementation} params.flashAlgorithmImplementation
    * @param {FlashAssessmentAlgorithmConfiguration} params.configuration
    */
-  constructor({ flashAlgorithmImplementation, configuration }) {
+  constructor({ flashAlgorithmImplementation, configuration, minimumAnswersRequiredToValidateACertification }) {
     /**
      * @private
      * @type {FlashAssessmentAlgorithmConfiguration}
      */
     this._configuration = configuration;
     this.flashAlgorithmImplementation = flashAlgorithmImplementation;
+    this.minimumAnswersRequiredToValidateACertification = minimumAnswersRequiredToValidateACertification;
 
     this.ruleEngine = new FlashAssessmentAlgorithmRuleEngine(availableRules, {
       limitToOneQuestionPerTube: configuration.limitToOneQuestionPerTube,
@@ -69,6 +70,7 @@ class FlashAssessmentAlgorithm {
       throw new AssessmentLackOfChallengesError({
         numberOfAnswers: assessmentAnswers?.length,
         maximumAssessmentLength,
+        minimumAnswersRequiredToValidateACertification: this.minimumAnswersRequiredToValidateACertification,
       });
     }
 

--- a/api/src/certification/evaluation/domain/usecases/get-next-challenge.js
+++ b/api/src/certification/evaluation/domain/usecases/get-next-challenge.js
@@ -96,6 +96,7 @@ const getNextChallenge = async function ({
   const assessmentAlgorithm = new FlashAssessmentAlgorithm({
     flashAlgorithmImplementation: flashAlgorithmService,
     configuration: version.challengesConfiguration,
+    minimumAnswersRequiredToValidateACertification: version.minimumAnswersRequiredToValidateACertification,
   });
   const possibleChallenges = assessmentAlgorithm.getPossibleNextChallenges({
     assessmentAnswers: allAnswers,

--- a/api/src/certification/evaluation/infrastructure/repositories/assessment-repository.js
+++ b/api/src/certification/evaluation/infrastructure/repositories/assessment-repository.js
@@ -28,4 +28,11 @@ const updateWhenNewChallengeIsAsked = async function (assessment) {
   });
 };
 
-export { get, updateLastQuestionDate, updateWhenNewChallengeIsAsked };
+const updateStateById = async function (assessmentId, state) {
+  const knexConn = DomainTransaction.getConnection();
+  return knexConn('assessments')
+    .where({ id: assessmentId })
+    .update({ state });
+}
+
+export { get, updateLastQuestionDate, updateWhenNewChallengeIsAsked, updateStateById };

--- a/api/src/certification/shared/domain/models/Version.js
+++ b/api/src/certification/shared/domain/models/Version.js
@@ -10,6 +10,7 @@ export class Version {
     scope: Joi.string()
       .required()
       .valid(...Object.values(SCOPES)),
+    minimumAnswersRequiredToValidateACertification: Joi.number().min(0).required(),
     challengesConfiguration: Joi.object().instance(FlashAssessmentAlgorithmConfiguration).required(),
   });
 
@@ -19,9 +20,10 @@ export class Version {
    * @param {SCOPES} params.scope - Certification scope (CORE, DROIT, etc.)
    * @param {FlashAssessmentAlgorithmConfiguration} params.challengesConfiguration - Challenges configuration
    */
-  constructor({ id, scope, challengesConfiguration }) {
+  constructor({ id, scope, minimumAnswersRequiredToValidateACertification, challengesConfiguration }) {
     this.id = id;
     this.scope = scope;
+    this.minimumAnswersRequiredToValidateACertification = minimumAnswersRequiredToValidateACertification;
     this.challengesConfiguration = challengesConfiguration;
     this.#validate();
   }

--- a/api/src/certification/shared/infrastructure/repositories/version-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/version-repository.js
@@ -36,7 +36,7 @@ export const getByScopeAndReconciliationDate = async ({ scope, reconciliationDat
   const knexConn = DomainTransaction.getConnection();
 
   const versionData = await knexConn('certification_versions')
-    .select('id', 'scope', 'challengesConfiguration')
+    .select('id', 'scope', 'minimumAnswersRequiredToValidateACertification', 'challengesConfiguration')
     .where({ scope })
     .andWhere('startDate', '<=', reconciliationDate)
     .andWhere((queryBuilder) => {
@@ -52,10 +52,11 @@ export const getByScopeAndReconciliationDate = async ({ scope, reconciliationDat
   return _toDomain(versionData);
 };
 
-const _toDomain = ({ id, scope, challengesConfiguration }) => {
+const _toDomain = ({ id, scope, minimumAnswersRequiredToValidateACertification, challengesConfiguration }) => {
   return new Version({
     id,
     scope,
+    minimumAnswersRequiredToValidateACertification,
     challengesConfiguration: new FlashAssessmentAlgorithmConfiguration({
       maximumAssessmentLength: challengesConfiguration.maximumAssessmentLength,
       challengesBetweenSameCompetence: challengesConfiguration.challengesBetweenSameCompetence,

--- a/api/src/shared/application/error-manager.js
+++ b/api/src/shared/application/error-manager.js
@@ -138,6 +138,9 @@ function _mapToHttpError(error) {
   if (error instanceof SharedDomainErrors.AlreadyRegisteredEmailError) {
     return new HttpErrors.BadRequestError(error.message, error.code);
   }
+  if (error instanceof SharedDomainErrors.AssessmentLackOfChallengesError) {
+    return new HttpErrors.UnprocessableEntityError(error.message, 'ASSESSMENT_LACK_OF_CHALLENGES');
+  }
   if (error instanceof SharedDomainErrors.AssessmentEndedError) {
     return new HttpErrors.BaseHttpError(error.message);
   }

--- a/api/src/shared/application/error-manager.js
+++ b/api/src/shared/application/error-manager.js
@@ -140,7 +140,7 @@ function _mapToHttpError(error) {
   }
   if (error instanceof SharedDomainErrors.AssessmentLackOfChallengesError) {
     return new HttpErrors.UnprocessableEntityError(error.message, 'ASSESSMENT_LACK_OF_CHALLENGES', {
-      numberOfAnswers: error.numberOfAnswers,
+      isToBeCancelled: error.isToBeCancelled,
     });
   }
   if (error instanceof SharedDomainErrors.AssessmentEndedError) {

--- a/api/src/shared/application/error-manager.js
+++ b/api/src/shared/application/error-manager.js
@@ -139,7 +139,9 @@ function _mapToHttpError(error) {
     return new HttpErrors.BadRequestError(error.message, error.code);
   }
   if (error instanceof SharedDomainErrors.AssessmentLackOfChallengesError) {
-    return new HttpErrors.UnprocessableEntityError(error.message, 'ASSESSMENT_LACK_OF_CHALLENGES');
+    return new HttpErrors.UnprocessableEntityError(error.message, 'ASSESSMENT_LACK_OF_CHALLENGES', {
+      numberOfAnswers: error.numberOfAnswers,
+    });
   }
   if (error instanceof SharedDomainErrors.AssessmentEndedError) {
     return new HttpErrors.BaseHttpError(error.message);

--- a/api/src/shared/domain/errors.js
+++ b/api/src/shared/domain/errors.js
@@ -38,7 +38,7 @@ class AssessmentEndedError extends DomainError {
   }
 }
 
-class AssessmentLackOfChallengesError extends AssessmentEndedError {
+class AssessmentLackOfChallengesError extends DomainError {
   constructor({ numberOfAnswers, maximumAssessmentLength, minimumAnswersRequiredToValidateACertification } = {}) {
     super(`No eligible challenges remaining. ${numberOfAnswers} answers (minimum was ${minimumAnswersRequiredToValidateACertification} and maximum was ${maximumAssessmentLength})`);
     this.numberOfAnswers = numberOfAnswers;

--- a/api/src/shared/domain/errors.js
+++ b/api/src/shared/domain/errors.js
@@ -39,10 +39,11 @@ class AssessmentEndedError extends DomainError {
 }
 
 class AssessmentLackOfChallengesError extends AssessmentEndedError {
-  constructor({ numberOfAnswers, maximumAssessmentLength } = {}) {
-    super(`No eligible challenges remaining. ${numberOfAnswers} answers (maximum was ${maximumAssessmentLength})`);
+  constructor({ numberOfAnswers, maximumAssessmentLength, minimumAnswersRequiredToValidateACertification } = {}) {
+    super(`No eligible challenges remaining. ${numberOfAnswers} answers (minimum was ${minimumAnswersRequiredToValidateACertification} and maximum was ${maximumAssessmentLength})`);
     this.numberOfAnswers = numberOfAnswers;
     this.maximumAssessmentLength = maximumAssessmentLength;
+    this.isToBeCancelled = numberOfAnswers < minimumAnswersRequiredToValidateACertification;
   }
 }
 

--- a/api/src/shared/domain/models/Assessment.js
+++ b/api/src/shared/domain/models/Assessment.js
@@ -107,6 +107,10 @@ class Assessment {
     this.state = Assessment.states.COMPLETED;
   }
 
+  setAborted() {
+    this.state = Assessment.states.ABORTED;
+  }
+
   start() {
     this.state = Assessment.states.STARTED;
   }

--- a/api/src/shared/domain/usecases/index.js
+++ b/api/src/shared/domain/usecases/index.js
@@ -1,6 +1,7 @@
 import * as complementaryCertificationBadgeRepository from '../../../certification/configuration/infrastructure/repositories/complementary-certification-badge-repository.js';
 import * as certificationChallengeLiveAlertRepository from '../../../certification/shared/infrastructure/repositories/certification-challenge-live-alert-repository.js';
 import * as certificationCompanionAlertRepository from '../../../certification/shared/infrastructure/repositories/certification-companion-alert-repository.js';
+import * as certificationCourseRepository from '../../../certification/shared/infrastructure/repositories/certification-course-repository.js';
 import { evaluationUsecases } from '../../../evaluation/domain/usecases/index.js';
 import * as badgeRepository from '../../../evaluation/infrastructure/repositories/badge-repository.js';
 import * as answerRepository from '../../infrastructure/repositories/answer-repository.js';
@@ -14,6 +15,7 @@ import { injectDependencies } from '../../infrastructure/utils/dependency-inject
 const dependencies = {
   assessmentRepository,
   certificationCompanionAlertRepository,
+  certificationCourseRepository,
   competenceRepository,
   answerRepository,
   courseRepository,

--- a/api/src/shared/domain/usecases/update-assessment-with-next-challenge.js
+++ b/api/src/shared/domain/usecases/update-assessment-with-next-challenge.js
@@ -1,4 +1,5 @@
 import { CampaignParticipationDeletedError } from '../../../prescription/campaign-participation/domain/errors.js';
+import { ABORT_REASONS } from '../../../certification/shared/domain/constants/abort-reasons.js';
 import { logger } from '../../infrastructure/utils/logger.js';
 import { AssessmentEndedError, AssessmentLackOfChallengesError, NotFoundError } from '../errors.js';
 
@@ -9,6 +10,7 @@ export async function updateAssessmentWithNextChallenge({
   evaluationUsecases,
   assessmentRepository,
   certificationEvaluationRepository,
+  certificationCourseRepository,
   courseRepository,
   competenceRepository,
   certificationChallengeLiveAlertRepository,
@@ -84,6 +86,10 @@ export async function updateAssessmentWithNextChallenge({
         },
         'Assessment ended prematurely: no challenge remaining before reaching maximum assessment length',
       );
+      await _abortCertificationCourseForTechnicalReason({
+        certificationCourseId: assessment.certificationCourseId,
+        certificationCourseRepository,
+      });
       throw error;
     } else if (error instanceof AssessmentEndedError) {
       nextChallenge = null;
@@ -111,4 +117,10 @@ export async function updateAssessmentWithNextChallenge({
     assessment,
     globalProgression,
   };
+}
+
+async function _abortCertificationCourseForTechnicalReason({ certificationCourseId, certificationCourseRepository }) {
+  const certificationCourse = await certificationCourseRepository.get({ id: certificationCourseId });
+  certificationCourse.abort(ABORT_REASONS.TECHNICAL);
+  await certificationCourseRepository.update({ certificationCourse });
 }

--- a/api/src/shared/domain/usecases/update-assessment-with-next-challenge.js
+++ b/api/src/shared/domain/usecases/update-assessment-with-next-challenge.js
@@ -84,7 +84,7 @@ export async function updateAssessmentWithNextChallenge({
         },
         'Assessment ended prematurely: no challenge remaining before reaching maximum assessment length',
       );
-      nextChallenge = null;
+      throw error;
     } else if (error instanceof AssessmentEndedError) {
       nextChallenge = null;
     } else {

--- a/api/src/shared/domain/usecases/update-assessment-with-next-challenge.js
+++ b/api/src/shared/domain/usecases/update-assessment-with-next-challenge.js
@@ -1,7 +1,6 @@
 import { CampaignParticipationDeletedError } from '../../../prescription/campaign-participation/domain/errors.js';
-import { ABORT_REASONS } from '../../../certification/shared/domain/constants/abort-reasons.js';
 import { logger } from '../../infrastructure/utils/logger.js';
-import { AssessmentEndedError, AssessmentLackOfChallengesError, NotFoundError } from '../errors.js';
+import { AssessmentEndedError, NotFoundError } from '../errors.js';
 
 export async function updateAssessmentWithNextChallenge({
   assessmentId,
@@ -10,7 +9,6 @@ export async function updateAssessmentWithNextChallenge({
   evaluationUsecases,
   assessmentRepository,
   certificationEvaluationRepository,
-  certificationCourseRepository,
   courseRepository,
   competenceRepository,
   certificationChallengeLiveAlertRepository,
@@ -77,21 +75,7 @@ export async function updateAssessmentWithNextChallenge({
       }
     }
   } catch (error) {
-    if (error instanceof AssessmentLackOfChallengesError) {
-      logger.warn(
-        {
-          assessmentId: assessment.id,
-          numberOfAnswers: error.numberOfAnswers,
-          maximumAssessmentLength: error.maximumAssessmentLength,
-        },
-        'Assessment ended prematurely: no challenge remaining before reaching maximum assessment length',
-      );
-      await _abortCertificationCourseForTechnicalReason({
-        certificationCourseId: assessment.certificationCourseId,
-        certificationCourseRepository,
-      });
-      throw error;
-    } else if (error instanceof AssessmentEndedError) {
+    if (error instanceof AssessmentEndedError) {
       nextChallenge = null;
     } else {
       logger.error(
@@ -117,10 +101,4 @@ export async function updateAssessmentWithNextChallenge({
     assessment,
     globalProgression,
   };
-}
-
-async function _abortCertificationCourseForTechnicalReason({ certificationCourseId, certificationCourseRepository }) {
-  const certificationCourse = await certificationCourseRepository.get({ id: certificationCourseId });
-  certificationCourse.abort(ABORT_REASONS.TECHNICAL);
-  await certificationCourseRepository.update({ certificationCourse });
 }

--- a/api/tests/certification/shared/integration/infrastructure/repositories/version-repository_test.js
+++ b/api/tests/certification/shared/integration/infrastructure/repositories/version-repository_test.js
@@ -56,6 +56,7 @@ describe('Integration | Certification | Evaluation | Infrastructure | Repository
         startDate: new Date('2025-01-01'),
         expirationDate: new Date('2025-05-31'),
         assessmentDuration: 90,
+        minimumAnswersRequiredToValidateACertification: 1,
         globalScoringConfiguration: [{ config: 'old' }],
         competencesScoringConfiguration: [{ config: 'old' }],
         challengesConfiguration: domainBuilder.buildFlashAlgorithmConfiguration({ defaultCandidateCapacity: 2 }),
@@ -69,6 +70,7 @@ describe('Integration | Certification | Evaluation | Infrastructure | Repository
         startDate: new Date('2025-06-01'),
         expirationDate: null,
         assessmentDuration: 120,
+        minimumAnswersRequiredToValidateACertification: 2,
         globalScoringConfiguration: [{ config: 'current' }],
         competencesScoringConfiguration: [{ config: 'current' }],
         challengesConfiguration: expectedChallengeConf,
@@ -79,6 +81,7 @@ describe('Integration | Certification | Evaluation | Infrastructure | Repository
         startDate: new Date('2025-07-01'),
         expirationDate: null,
         assessmentDuration: 150,
+        minimumAnswersRequiredToValidateACertification: 3,
         globalScoringConfiguration: [{ config: 'future' }],
         competencesScoringConfiguration: [{ config: 'future' }],
         challengesConfiguration: domainBuilder.buildFlashAlgorithmConfiguration({ defaultCandidateCapacity: 1 }),
@@ -96,6 +99,7 @@ describe('Integration | Certification | Evaluation | Infrastructure | Repository
       expect(result).to.be.instanceOf(Version);
       expect(result.id).to.equal(expectedVersionId);
       expect(result.scope).to.equal(scope);
+      expect(result.minimumAnswersRequiredToValidateACertification).to.equal(2);
       expect(result.challengesConfiguration).to.deep.equal(expectedChallengeConf);
     });
 
@@ -111,6 +115,7 @@ describe('Integration | Certification | Evaluation | Infrastructure | Repository
         startDate: new Date('2025-05-01'),
         expirationDate: null,
         assessmentDuration: 100,
+        minimumAnswersRequiredToValidateACertification: 1,
         globalScoringConfiguration: [{ target: 'scope' }],
         competencesScoringConfiguration: null,
         challengesConfiguration: expectedChallengeConf,
@@ -121,6 +126,7 @@ describe('Integration | Certification | Evaluation | Infrastructure | Repository
         startDate: new Date('2025-06-10'),
         expirationDate: null,
         assessmentDuration: 150,
+        minimumAnswersRequiredToValidateACertification: 2,
         globalScoringConfiguration: [{ other: 'scope' }],
         competencesScoringConfiguration: null,
         challengesConfiguration: domainBuilder.buildFlashAlgorithmConfiguration({ defaultCandidateCapacity: -3 }),
@@ -138,6 +144,7 @@ describe('Integration | Certification | Evaluation | Infrastructure | Repository
       expect(result).to.be.instanceOf(Version);
       expect(result.id).to.equal(expectedVersionId);
       expect(result.scope).to.equal(targetScope);
+      expect(result.minimumAnswersRequiredToValidateACertification).to.equal(1);
       expect(result.challengesConfiguration).to.deep.equal(expectedChallengeConf);
     });
 
@@ -153,6 +160,7 @@ describe('Integration | Certification | Evaluation | Infrastructure | Repository
           startDate: reconciliationDate,
           expirationDate: null,
           assessmentDuration: 100,
+          minimumAnswersRequiredToValidateACertification: 1,
           globalScoringConfiguration: null,
           competencesScoringConfiguration: null,
           challengesConfiguration: expectedChallengeConf,
@@ -169,6 +177,7 @@ describe('Integration | Certification | Evaluation | Infrastructure | Repository
         // then
         expect(result).to.be.instanceOf(Version);
         expect(result.id).to.equal(expectedVersionId);
+        expect(result.minimumAnswersRequiredToValidateACertification).to.equal(1);
         expect(result.challengesConfiguration).to.deep.equal(expectedChallengeConf);
       });
     });

--- a/api/tests/certification/shared/unit/domain/models/FlashAssessmentAlgorithm_test.js
+++ b/api/tests/certification/shared/unit/domain/models/FlashAssessmentAlgorithm_test.js
@@ -60,7 +60,7 @@ describe('Unit | Domain | Models | FlashAssessmentAlgorithm', function () {
       });
     });
 
-    context('when user has answered to the maximun number of questions', function () {
+    context('when user has answered to the maximum number of questions', function () {
       it('should throw an AssessmentEndedError', function () {
         // then
         const assessmentAnswers = [domainBuilder.buildAnswer({ id: 1 }), domainBuilder.buildAnswer({ id: 2 })];
@@ -251,6 +251,7 @@ describe('Unit | Domain | Models | FlashAssessmentAlgorithm', function () {
             maximumAssessmentLength: 32,
             limitToOneQuestionPerTube: true,
           }),
+          minimumAnswersRequiredToValidateACertification: 20,
         });
 
         const skill1 = domainBuilder.buildSkill({ id: 'skill1', tubeId: 'tube1' });
@@ -286,6 +287,7 @@ describe('Unit | Domain | Models | FlashAssessmentAlgorithm', function () {
         // then
         expect(error).to.be.instanceOf(AssessmentLackOfChallengesError);
         expect(error.numberOfAnswers).to.equal(1);
+        expect(error.minimumAnswersRequiredToValidateACertification).to.equal(20);
         expect(error.maximumAssessmentLength).to.equal(32);
       });
     });

--- a/api/tests/certification/shared/unit/domain/models/Version_test.js
+++ b/api/tests/certification/shared/unit/domain/models/Version_test.js
@@ -11,6 +11,7 @@ describe('Unit | Certification | Evaluation | Domain | Models | Version', functi
       const versionData = {
         id: 123,
         scope: SCOPES.CORE,
+        minimumAnswersRequiredToValidateACertification: 20,
         challengesConfiguration: new FlashAssessmentAlgorithmConfiguration({
           challengesBetweenSameCompetence: 0,
           maximumAssessmentLength: 10,
@@ -29,6 +30,7 @@ describe('Unit | Certification | Evaluation | Domain | Models | Version', functi
       expect(version).to.be.instanceOf(Version);
       expect(version.id).to.equal(123);
       expect(version.scope).to.equal(SCOPES.CORE);
+      expect(version.minimumAnswersRequiredToValidateACertification).to.equal(20);
       expect(version.challengesConfiguration).to.deep.equal(
         new FlashAssessmentAlgorithmConfiguration({
           challengesBetweenSameCompetence: 0,
@@ -47,6 +49,7 @@ describe('Unit | Certification | Evaluation | Domain | Models | Version', functi
       const versionData = {
         id: 456,
         scope: SCOPES.PIX_PLUS_DROIT,
+        minimumAnswersRequiredToValidateACertification: 20,
         challengesConfiguration: new FlashAssessmentAlgorithmConfiguration({
           challengesBetweenSameCompetence: 0,
           maximumAssessmentLength: 10,
@@ -65,6 +68,7 @@ describe('Unit | Certification | Evaluation | Domain | Models | Version', functi
       expect(version).to.be.instanceOf(Version);
       expect(version.id).to.equal(456);
       expect(version.scope).to.equal(SCOPES.PIX_PLUS_DROIT);
+      expect(version.minimumAnswersRequiredToValidateACertification).to.equal(20);
       expect(version.challengesConfiguration).to.deep.equal(
         new FlashAssessmentAlgorithmConfiguration({
           challengesBetweenSameCompetence: 0,
@@ -82,33 +86,8 @@ describe('Unit | Certification | Evaluation | Domain | Models | Version', functi
       // given
       const invalidData = {
         scope: SCOPES.CORE,
-      };
-
-      // when
-      const error = catchErrSync(() => new Version(invalidData))();
-
-      // then
-      expect(error).to.be.instanceOf(EntityValidationError);
-    });
-
-    it('should throw an EntityValidationError when scope is missing', function () {
-      // given
-      const invalidData = {
-        id: 123,
-      };
-
-      // when
-      const error = catchErrSync(() => new Version(invalidData))();
-
-      // then
-      expect(error).to.be.instanceOf(EntityValidationError);
-    });
-
-    it('should throw an EntityValidationError when scope is invalid', function () {
-      // given
-      const invalidData = {
-        id: 123,
-        scope: 'INVALID_SCOPE',
+        minimumAnswersRequiredToValidateACertification: 123,
+        challengesConfiguration: { config: 'test' },
       };
 
       // when
@@ -123,7 +102,68 @@ describe('Unit | Certification | Evaluation | Domain | Models | Version', functi
       const invalidData = {
         id: 'not-a-number',
         scope: SCOPES.CORE,
+        minimumAnswersRequiredToValidateACertification: 123,
         challengesConfiguration: { config: 'test' },
+      };
+
+      // when
+      const error = catchErrSync(() => new Version(invalidData))();
+
+      // then
+      expect(error).to.be.instanceOf(EntityValidationError);
+    });
+
+    it('should throw an EntityValidationError when scope is missing', function () {
+      // given
+      const invalidData = {
+        id: 123,
+        minimumAnswersRequiredToValidateACertification: 123,
+        challengesConfiguration: { config: 'test' }
+      };
+
+      // when
+      const error = catchErrSync(() => new Version(invalidData))();
+
+      // then
+      expect(error).to.be.instanceOf(EntityValidationError);
+    });
+
+    it('should throw an EntityValidationError when minimumAnswersRequiredToValidateACertification is missing', function () {
+      // given
+      const invalidData = {
+        id: 123,
+        scope: SCOPES.CORE,
+        challengesConfiguration: { config: 'test' }
+      };
+
+      // when
+      const error = catchErrSync(() => new Version(invalidData))();
+
+      // then
+      expect(error).to.be.instanceOf(EntityValidationError);
+    });
+
+    it('should throw an EntityValidationError when minimumAnswersRequiredToValidateACertification is not a number', function () {
+      // given
+      const invalidData = {
+        id: 123,
+        scope: SCOPES.CORE,
+        minimumAnswersRequiredToValidateACertification: 'not-a-number',
+        challengesConfiguration: { config: 'test' }
+      };
+
+      // when
+      const error = catchErrSync(() => new Version(invalidData))();
+
+      // then
+      expect(error).to.be.instanceOf(EntityValidationError);
+    });
+
+    it('should throw an EntityValidationError when scope is invalid', function () {
+      // given
+      const invalidData = {
+        id: 123,
+        scope: 'INVALID_SCOPE',
       };
 
       // when

--- a/api/tests/shared/unit/application/error-manager_test.js
+++ b/api/tests/shared/unit/application/error-manager_test.js
@@ -259,7 +259,7 @@ describe('Shared | Unit | Application | ErrorManager', function () {
       expect(HttpErrors.UnprocessableEntityError).to.have.been.calledWithExactly(
         error.message,
         'ASSESSMENT_LACK_OF_CHALLENGES',
-        { numberOfAnswers: error.numberOfAnswers },
+        { isToBeCancelled: error.isToBeCancelled },
       );
     });
 

--- a/api/tests/shared/unit/application/error-manager_test.js
+++ b/api/tests/shared/unit/application/error-manager_test.js
@@ -6,6 +6,7 @@ import { UnableToAttachChildOrganizationToParentOrganizationError } from '../../
 import { domainErrorMapper } from '../../../../src/shared/application/domain-error-mapper.js';
 import { handle } from '../../../../src/shared/application/error-manager.js';
 import { HttpErrors, UnauthorizedError } from '../../../../src/shared/application/http-errors.js';
+import { AssessmentLackOfChallengesError } from '../../../../src/shared/domain/errors.js';
 import {
   AccountRecoveryDemandExpired,
   AlreadyRegisteredEmailAndUsernameError,
@@ -243,6 +244,23 @@ describe('Shared | Unit | Application | ErrorManager', function () {
 
       // then
       expect(HttpErrors.ForbiddenError).to.have.been.calledWithExactly(error.message, error.code);
+    });
+
+    it('should instantiate UnprocessableEntityError when AssessmentLackOfChallengesError', async function () {
+      // given
+      const error = new AssessmentLackOfChallengesError({ numberOfAnswers: 5, maximumAssessmentLength: 32 });
+      sinon.stub(HttpErrors, 'UnprocessableEntityError');
+      const params = { request: {}, h: hFake, error };
+
+      // when
+      handle(params.request, params.h, params.error);
+
+      // then
+      expect(HttpErrors.UnprocessableEntityError).to.have.been.calledWithExactly(
+        error.message,
+        'ASSESSMENT_LACK_OF_CHALLENGES',
+        { numberOfAnswers: error.numberOfAnswers },
+      );
     });
 
     it('should instantiate UnprocessableEntityError when AdminMemberError', async function () {

--- a/api/tests/shared/unit/domain/models/Assessment_test.js
+++ b/api/tests/shared/unit/domain/models/Assessment_test.js
@@ -57,6 +57,21 @@ describe('Unit | Domain | Models | Assessment', function () {
     });
   });
 
+  describe('#setAborted', function () {
+    it('should return the same object with state aborted', function () {
+      // given
+      const assessment = new Assessment({ state: 'started', userId: 2 });
+
+      // when
+      assessment.setAborted();
+
+      // then
+      expect(assessment.state).to.be.equal('aborted');
+      expect(assessment.userId).to.be.equal(2);
+    });
+  });
+
+
   describe('#detachCampaignParticipation', function () {
     let clock, now;
 

--- a/api/tests/shared/unit/domain/usecases/update-assessment-with-next-challenge_test.js
+++ b/api/tests/shared/unit/domain/usecases/update-assessment-with-next-challenge_test.js
@@ -25,6 +25,8 @@ describe('Shared | Unit | Domain | Use Cases | get-next-challenge', function () 
     let competenceRepository_getCompetenceNameStub;
     let certificationChallengeLiveAlertRepository_getByAssessmentIdStub;
     let certificationCompanionAlertRepository_getAllByAssessmentIdStub;
+    let certificationCourseRepository_getStub;
+    let certificationCourseRepository_updateStub;
 
     beforeEach(function () {
       userId = 'someUserId';
@@ -49,6 +51,8 @@ describe('Shared | Unit | Domain | Use Cases | get-next-challenge', function () 
       competenceRepository_getCompetenceNameStub = sinon.stub().named('getCompetenceName');
       certificationChallengeLiveAlertRepository_getByAssessmentIdStub = sinon.stub().named('getChallengeLiveAlerts');
       certificationCompanionAlertRepository_getAllByAssessmentIdStub = sinon.stub().named('getCompanionLiveAlerts');
+      certificationCourseRepository_getStub = sinon.stub().named('certificationCourseRepository.get');
+      certificationCourseRepository_updateStub = sinon.stub().named('certificationCourseRepository.update');
       preventStubsToBeCalledUnexpectedly([
         assessmentRepository_getWithAnswersStub,
         assessmentRepository_updateLastQuestionDateStub,
@@ -63,6 +67,8 @@ describe('Shared | Unit | Domain | Use Cases | get-next-challenge', function () 
         competenceRepository_getCompetenceNameStub,
         certificationChallengeLiveAlertRepository_getByAssessmentIdStub,
         certificationCompanionAlertRepository_getAllByAssessmentIdStub,
+        certificationCourseRepository_getStub,
+        certificationCourseRepository_updateStub,
       ]);
 
       const assessmentRepository = {
@@ -98,6 +104,11 @@ describe('Shared | Unit | Domain | Use Cases | get-next-challenge', function () 
         getAllByAssessmentId: certificationCompanionAlertRepository_getAllByAssessmentIdStub,
       };
 
+      const certificationCourseRepository = {
+        get: certificationCourseRepository_getStub,
+        update: certificationCourseRepository_updateStub,
+      };
+
       dependencies = {
         assessmentId,
         userId,
@@ -105,6 +116,7 @@ describe('Shared | Unit | Domain | Use Cases | get-next-challenge', function () 
         evaluationUsecases,
         assessmentRepository,
         certificationEvaluationRepository,
+        certificationCourseRepository,
         courseRepository,
         competenceRepository,
         certificationChallengeLiveAlertRepository,
@@ -466,21 +478,42 @@ describe('Shared | Unit | Domain | Use Cases | get-next-challenge', function () 
         });
 
         context('when the referential is exhausted before reaching maximum assessment length', function () {
-          it('should return an assessment with no nextChallenge', async function () {
+          it('should throw an AssessmentLackOfChallengesError', async function () {
             // given
+            const certificationCourse = domainBuilder.buildCertificationCourse({
+              id: assessment.certificationCourseId,
+            });
             certificationEvaluationRepository_selectNextCertificationChallengeStub.rejects(
               new AssessmentLackOfChallengesError({ numberOfAnswers: 27, maximumAssessmentLength: 32 }),
             );
+            certificationCourseRepository_getStub.resolves(certificationCourse);
+            certificationCourseRepository_updateStub.resolves();
 
             // when
-            const { assessment: assessmentWithoutChallenge, globalProgression } =
-              await updateAssessmentWithNextChallenge(dependencies);
+            const error = await catchErr(updateAssessmentWithNextChallenge)(dependencies);
 
             // then
-            expect(assessmentWithoutChallenge.nextChallenge).to.be.null;
-            expect(assessmentWithoutChallenge.challengeLiveAlerts).to.deep.equal([certificationChallengeLiveAlert]);
-            expect(assessmentWithoutChallenge.companionLiveAlerts).to.deep.equal([certificationCompanionLiveAlert]);
-            expect(globalProgression).to.be.null;
+            expect(error).to.be.instanceOf(AssessmentLackOfChallengesError);
+          });
+
+          it('should abort the certification course with technical reason', async function () {
+            // given
+            const certificationCourse = domainBuilder.buildCertificationCourse({
+              id: assessment.certificationCourseId,
+            });
+            certificationEvaluationRepository_selectNextCertificationChallengeStub.rejects(
+              new AssessmentLackOfChallengesError({ numberOfAnswers: 27, maximumAssessmentLength: 32 }),
+            );
+            certificationCourseRepository_getStub.resolves(certificationCourse);
+            certificationCourseRepository_updateStub.resolves();
+
+            // when
+            await catchErr(updateAssessmentWithNextChallenge)(dependencies);
+
+            // then
+            expect(certificationCourseRepository_updateStub).to.have.been.calledOnce;
+            const updatedCourse = certificationCourseRepository_updateStub.firstCall.args[0].certificationCourse;
+            expect(updatedCourse.toDTO().abortReason).to.equal('technical');
           });
         });
 

--- a/certif/app/components/session-finalization/uncompleted-reports-information-step.gjs
+++ b/certif/app/components/session-finalization/uncompleted-reports-information-step.gjs
@@ -20,6 +20,14 @@ export default class UncompletedReportsInformationStep extends Component {
   @tracked showIssueReportsModal = false;
   @service intl;
 
+  _initialAbortReasons = new Map(
+    this.args.certificationReports.map((report) => [report.id, report.abortReason]),
+  );
+
+  isAbortReasonPreFilled = (report) => {
+    return Boolean(this._initialAbortReasons.get(report.id));
+  };
+
   get certificationReportsAreNotEmpty() {
     return this.args.certificationReports.length !== 0;
   }
@@ -184,20 +192,34 @@ export default class UncompletedReportsInformationStep extends Component {
               </div>
             </:header>
             <:cell>
-              <PixSelect
-                @screenReaderOnly='true'
-                @id={{concat 'finalization-report-abort-reason__select' report.id}}
-                @placeholder='-- {{t "common.actions.choose"}} --'
-                @onChange={{fn @onChangeAbortReason report}}
-                @hideDefaultOption={{true}}
-                @value={{report.abortReason}}
-                required='required'
-                @options={{this.abortOptions}}
+              <PixTooltip
+                @id={{concat 'finalization-report-abort-reason__tooltip' report.id}}
+                @isLight={{true}}
+                @hide={{if (this.isAbortReasonPreFilled report) false true}}
               >
-                <:label>{{t
-                    'pages.session-finalization.reporting.uncompleted-reports-information.table.labels.abandonment-reason-label'
-                  }}</:label>
-              </PixSelect>
+                <:triggerElement>
+                  <PixSelect
+                    @screenReaderOnly='true'
+                    @id={{concat 'finalization-report-abort-reason__select' report.id}}
+                    @placeholder='-- {{t "common.actions.choose"}} --'
+                    @onChange={{fn @onChangeAbortReason report}}
+                    @hideDefaultOption={{true}}
+                    @value={{report.abortReason}}
+                    @isDisabled={{this.isAbortReasonPreFilled report}}
+                    required='required'
+                    @options={{this.abortOptions}}
+                  >
+                    <:label>{{t
+                        'pages.session-finalization.reporting.uncompleted-reports-information.table.labels.abandonment-reason-label'
+                      }}</:label>
+                  </PixSelect>
+                </:triggerElement>
+                <:tooltip>
+                  {{t
+                    'pages.session-finalization.reporting.uncompleted-reports-information.table.tooltip.technical-problem-auto-detected'
+                  }}
+                </:tooltip>
+              </PixTooltip>
             </:cell>
           </PixTableColumn>
         </:columns>

--- a/certif/tests/integration/components/session-finalization/uncompleted-reports-information-step-test.js
+++ b/certif/tests/integration/components/session-finalization/uncompleted-reports-information-step-test.js
@@ -350,4 +350,65 @@ module('Integration | Component | SessionFinalization::UncompletedReportsInforma
       });
     });
   });
+
+  module('when abort reason is already set', function () {
+    test('the select is disabled and the tooltip is visible', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const certificationReport = store.createRecord('certification-report', {
+        certificationCourseId: 1234,
+        firstName: 'Alice',
+        lastName: 'Alister',
+        abortReason: 'technical',
+        certificationIssueReports: [],
+      });
+
+      this.set('certificationReports', [certificationReport]);
+      this.set('abort', sinon.stub());
+
+      // when
+      const screen = await renderScreen(hbs`<SessionFinalization::UncompletedReportsInformationStep
+  @certificationReports={{this.certificationReports}}
+  @onChangeAbortReason={{this.abort}}
+/>`);
+
+      // then
+      assert.dom(screen.getByRole('combobox', { name: "Sélectionner la raison de l'abandon" })).isDisabled();
+      assert
+        .dom(
+          screen.getByText(
+            t(
+              'pages.session-finalization.reporting.uncompleted-reports-information.table.tooltip.technical-problem-auto-detected',
+            ),
+          ),
+        )
+        .exists();
+    });
+  });
+
+  module('when abort reason is not set', function () {
+    test('the select is enabled', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const certificationReport = store.createRecord('certification-report', {
+        certificationCourseId: 1234,
+        firstName: 'Alice',
+        lastName: 'Alister',
+        abortReason: null,
+        certificationIssueReports: [],
+      });
+
+      this.set('certificationReports', [certificationReport]);
+      this.set('abort', sinon.stub());
+
+      // when
+      const screen = await renderScreen(hbs`<SessionFinalization::UncompletedReportsInformationStep
+  @certificationReports={{this.certificationReports}}
+  @onChangeAbortReason={{this.abort}}
+/>`);
+
+      // then
+      assert.dom(screen.getByRole('combobox', { name: "Sélectionner la raison de l'abandon" })).isNotDisabled();
+    });
+  });
 });

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -438,8 +438,9 @@
                 "enough-time-description": "The candidate didn’t have enough time to answer all the questions",
                 "left-deliberately-description": "The candidate left deliberately before the end of the exam"
               },
-              "extra-information": "Reason for abandonment's description",
-              "technical-problem-description": "The candidate encountered a technical problem that prevented him from finishing his exam"
+              "extra-information": "Reason for abandonment’s description",
+              "technical-problem-description": "The candidate encountered a technical problem that prevented him from finishing his exam",
+              "technical-problem-auto-detected": "A technical problem was automatically detected during the certification"
             }
           }
         }

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -435,11 +435,12 @@
             },
             "tooltip": {
               "abandonment": {
-                "enough-time-description": "Le candidat n'a pas eu le temps de répondre à toutes ses questions",
+                "enough-time-description": "Le candidat n’a pas eu le temps de répondre à toutes ses questions",
                 "left-deliberately-description": "Le candidat est parti volontairement avant la fin du test"
               },
-              "extra-information": "Description de la raison de l'abandon",
-              "technical-problem-description": "Le candidat a rencontré un problème technique l'empêchant de poursuivre son test jusqu’à la fin"
+              "extra-information": "Description de la raison de l’abandon",
+              "technical-problem-description": "Le candidat a rencontré un problème technique l’empêchant de poursuivre son test jusqu’à la fin",
+              "technical-problem-auto-detected": "Un problème technique a été détecté automatiquement durant la certification"
             }
           }
         }

--- a/mon-pix/app/components/certifications/certification-technical-error.gjs
+++ b/mon-pix/app/components/certifications/certification-technical-error.gjs
@@ -1,0 +1,55 @@
+import PixBlock from '@1024pix/pix-ui/components/pix-block';
+import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import PixIcon from '@1024pix/pix-ui/components/pix-icon';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import t from 'ember-intl/helpers/t';
+import CertificationBanner from 'mon-pix/components/certification-banner';
+
+export default class CertificationTechnicalError extends Component {
+  @service currentUser;
+
+  <template>
+    <CertificationBanner @certificationNumber={{@certificationNumber}} />
+
+    <PixBlock class="certification-technical-error">
+      <div class="certification-technical-error__finished-test">
+        <div class="certification-technical-error-finished-test__candidate">
+          <p class="certification-technical-error-candidate__name">
+            <PixIcon @name="userCircle" @plainIcon={{true}} @ariaHidden={{true}} />
+            {{this.currentUser.user.fullName}}
+          </p>
+          <h1 class="certification-technical-error-candidate__title">{{t "pages.certification-technical-error.candidate.title"}}</h1>
+          <p class="certification-technical-error-candidate__message">
+            {{t "pages.certification-technical-error.candidate.message"}}
+          </p>
+          <PixButtonLink @route="logout" @variant="primary">
+            {{t "pages.certification-technical-error.candidate.disconnect"}}
+          </PixButtonLink>
+          <p class="certification-technical-error-candidate__disconnect-tip">
+            {{t "pages.certification-technical-error.candidate.disconnect-tip"}}
+          </p>
+        </div>
+      </div>
+
+      <div class="certification-technical-error__results">
+        {{#if @isToBeCancelled}}
+          <h2 class="certification-technical-error-results__disclaimer">
+            {{t "pages.certification-technical-error.candidate.cancelled.disclaimer"}}
+          </h2>
+          <p class="certification-technical-error-results__title">
+            {{t "pages.certification-technical-error.candidate.cancelled.title"}}
+          </p>
+          <p class="certification-technical-error-results__steps">{{t "pages.certification-technical-error.candidate.cancelled.step-1"}}</p>
+        {{else}}
+          <h2 class="certification-technical-error-results__disclaimer">{{t "pages.certification-ender.results.disclaimer"}}</h2>
+          <p class="certification-technical-error-results__title">
+            {{t "pages.certification-ender.results.title"}}
+          </p>
+          <p class="certification-technical-error-results__steps">{{t "pages.certification-ender.results.step-1"}}</p>
+          <p class="certification-technical-error-results__steps">{{t "pages.certification-ender.results.step-2"}}</p>
+        {{/if}}
+      </div>
+    </PixBlock>
+  </template>
+}

--- a/mon-pix/app/controllers/assessments/challenge.js
+++ b/mon-pix/app/controllers/assessments/challenge.js
@@ -18,6 +18,15 @@ export default class ChallengeController extends Controller {
   @service currentUser;
   @service focusedCertificationChallengeWarningManager;
   @service pixMetrics;
+  @service certificationTechnicalError;
+
+  get hasCertificationTechnicalError() {
+    return this.certificationTechnicalError.hasError;
+  }
+
+  get isCertificationtoBeCancelled() {
+    return this.certificationTechnicalError.isToBeCancelled;
+  }
 
   @tracked newLevel = null;
   @tracked competenceLeveled = null;

--- a/mon-pix/app/routes/assessments/resume.js
+++ b/mon-pix/app/routes/assessments/resume.js
@@ -2,10 +2,10 @@ import { action } from '@ember/object';
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
 import ENV from 'mon-pix/config/environment';
-
 export default class ResumeRoute extends Route {
   @service store;
   @service router;
+  @service certificationTechnicalError;
 
   hasSeenCheckpoint = false;
   campaignCode = null;
@@ -44,6 +44,16 @@ export default class ResumeRoute extends Route {
     }
 
     return this._resumeAssessmentWithoutCheckpoint(assessment);
+  }
+
+  @action
+  error(error) {
+    if (error.errors?.[0]?.code === 'ASSESSMENT_LACK_OF_CHALLENGES') {
+      const isToBeCancelled = error.errors[0].meta?.isToBeCancelled ?? false;
+      this.certificationTechnicalError.setError({ isToBeCancelled });
+      return false;
+    }
+    return true;
   }
 
   @action

--- a/mon-pix/app/services/certification-technical-error.js
+++ b/mon-pix/app/services/certification-technical-error.js
@@ -1,0 +1,17 @@
+import Service from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+
+export default class CertificationTechnicalErrorService extends Service {
+  @tracked hasError = false;
+  @tracked isToBeCancelled = false;
+
+  setError({ isToBeCancelled }) {
+    this.hasError = true;
+    this.isToBeCancelled = isToBeCancelled;
+  }
+
+  reset() {
+    this.hasError = false;
+    this.isToBeCancelled = false;
+  }
+}

--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -42,6 +42,7 @@
 @use 'components/certifications/shareable-certificate/v3-certificate' as *;
 @use 'components/certifications/shareable-certificate/v2-certificate' as *;
 @use 'components/certifications/certification-ender' as *;
+@use 'components/certifications/certification-technical-error' as *;
 @use 'components/combined-courses' as *;
 @use '../components/routes/combined-courses/process-custom-passages' as *;
 @use 'components/communication-banner' as *;

--- a/mon-pix/app/styles/components/certifications/certification-technical-error.scss
+++ b/mon-pix/app/styles/components/certifications/certification-technical-error.scss
@@ -1,0 +1,119 @@
+@use 'pix-design-tokens/breakpoints';
+@use 'pix-design-tokens/typography';
+
+.certification-technical-error {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pix-spacing-10x);
+  align-items: flex-start;
+  justify-content: center;
+  max-width: 990px;
+  margin: -150px auto;
+  overflow: hidden;
+
+  @include breakpoints.device-is('tablet') {
+    gap: var(--pix-spacing-6x);
+  }
+
+  &__finished-test {
+    @include breakpoints.device-is('tablet') {
+      display: flex;
+      align-items: center;
+      justify-content: space-around;
+    }
+  }
+
+  &__results {
+    display: flex;
+    flex-direction: column;
+    padding: var(--pix-spacing-4x) var(--pix-spacing-6x);
+    background-color: var(--pix-neutral-20);
+    border-radius: 10px;
+
+    @include breakpoints.device-is('tablet') {
+      padding: var(--pix-spacing-6x) var(--pix-spacing-12x);
+    }
+  }
+}
+
+.certification-technical-error-finished-test {
+  &__image {
+    display: block;
+    height: 168px;
+    margin: auto;
+
+    @include breakpoints.device-is('tablet') {
+      order: 2;
+      height: 250px;
+      margin: 0;
+    }
+  }
+
+  &__candidate {
+    display: flex;
+    flex-direction: column;
+    gap: var(--pix-spacing-2x);
+    align-items: center;
+    margin-top: var(--pix-spacing-4x);
+    text-align: center;
+
+    @include breakpoints.device-is('tablet') {
+      align-items: flex-start;
+      order: 1;
+      width: 55%;
+      text-align: left;
+    }
+  }
+}
+
+.certification-technical-error-candidate {
+  &__name {
+    display: flex;
+    gap: var(--pix-spacing-1x);
+    color: var(--pix-neutral-500);
+
+    @extend %pix-body-l;
+  }
+
+  &__title {
+    color: var(--pix-neutral-700);
+
+    @extend %pix-title-l;
+  }
+
+  &__message {
+    color: var(--pix-neutral-500);
+
+    @extend %pix-body-s;
+  }
+
+  &__disconnect-tip {
+    padding-top: var(--pix-spacing-3x);
+    color: var(--pix-neutral-500);
+
+    @extend %pix-body-s;
+  }
+}
+
+.certification-technical-error-results {
+  &__disclaimer {
+    margin-bottom: var(--pix-spacing-2x);
+    color: var(--pix-neutral-700);
+    text-transform: uppercase;
+
+    @extend %pix-title-xs;
+  }
+
+  &__title {
+    margin-bottom: 6px;
+    color: var(--pix-neutral-900);
+
+    @extend %pix-body-l;
+  }
+
+  &__steps {
+    color: var(--pix-neutral-500);
+
+    @extend %pix-body-s;
+  }
+}

--- a/mon-pix/app/templates/assessments/challenge.gjs
+++ b/mon-pix/app/templates/assessments/challenge.gjs
@@ -2,6 +2,7 @@ import t from 'ember-intl/helpers/t';
 import pageTitle from 'ember-page-title/helpers/page-title';
 import AssessmentBanner from 'mon-pix/components/assessment-banner';
 import CertificationBanner from 'mon-pix/components/certification-banner';
+import CertificationTechnicalError from 'mon-pix/components/certifications/certification-technical-error';
 import Content from 'mon-pix/components/challenge/content';
 import FocusedCertificationChallengeInstructions from 'mon-pix/components/focused-certification-challenge-instructions';
 import LevelupNotif from 'mon-pix/components/levelup-notif';
@@ -9,6 +10,13 @@ import ProgressBar from 'mon-pix/components/progress-bar';
 import TimedChallengeInstructions from 'mon-pix/components/timed-challenge-instructions';
 <template>
   {{pageTitle @controller.pageTitle}}
+
+  {{#if @controller.hasCertificationTechnicalError}}
+    <CertificationTechnicalError
+      @certificationNumber={{@model.assessment.certificationNumber}}
+      @isToBeCancelled={{@controller.isCertificationtoBeCancelled}}
+    />
+  {{else}}
 
   {{#if @controller.couldDisplayInfoAlert}}
     <div
@@ -117,5 +125,6 @@ import TimedChallengeInstructions from 'mon-pix/components/timed-challenge-instr
 
   {{#if @controller.showLevelup}}
     <LevelupNotif @level={{@controller.newLevel}} @competenceName={{@controller.competenceLeveled}} />
+  {{/if}}
   {{/if}}
 </template>

--- a/mon-pix/tests/integration/components/certifications/certification-technical-error-test.js
+++ b/mon-pix/tests/integration/components/certifications/certification-technical-error-test.js
@@ -1,0 +1,88 @@
+import { render as renderScreen } from '@1024pix/ember-testing-library';
+import { hbs } from 'ember-cli-htmlbars';
+import { t } from 'ember-intl/test-support';
+import { module, test } from 'qunit';
+
+import { stubCurrentUserService } from '../../../helpers/service-stubs';
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Certifications | CertificationTechnicalError', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('should display the current user name', async function (assert) {
+    // given
+    stubCurrentUserService(this.owner, { firstName: 'Jim', lastName: 'Halpert' });
+
+    // when
+    const screen = await renderScreen(hbs`<Certifications::CertificationTechnicalError />`);
+
+    // then
+    assert.ok(screen.getByText('Jim Halpert'));
+  });
+
+  test('should display the certification number', async function (assert) {
+    // given
+    this.certificationNumber = 1234;
+
+    // when
+    const screen = await renderScreen(
+      hbs`<Certifications::CertificationTechnicalError @certificationNumber={{this.certificationNumber}} />`,
+    );
+
+    // then
+    assert.ok(screen.getByText(1234));
+  });
+
+  test('should display the candidate title and message', async function (assert) {
+    // when
+    const screen = await renderScreen(hbs`<Certifications::CertificationTechnicalError />`);
+
+    // then
+    assert.ok(screen.getByText(t('pages.certification-technical-error.candidate.title')));
+    assert.ok(screen.getByText(t('pages.certification-technical-error.candidate.message')));
+  });
+
+  module('when @isToBeCancelled is true', function () {
+    test('should display the cancelled message', async function (assert) {
+      // when
+      const screen = await renderScreen(
+        hbs`<Certifications::CertificationTechnicalError @isToBeCancelled={{true}} />`,
+      );
+
+      // then
+      assert.ok(screen.getByText(t('pages.certification-technical-error.candidate.cancelled')));
+    });
+
+    test('should not display the results block', async function (assert) {
+      // when
+      const screen = await renderScreen(
+        hbs`<Certifications::CertificationTechnicalError @isToBeCancelled={{true}} />`,
+      );
+
+      // then
+      assert.dom(screen.queryByText(t('pages.certification-ender.results.disclaimer'))).doesNotExist();
+    });
+  });
+
+  module('when @isToBeCancelled is false', function () {
+    test('should display the results block', async function (assert) {
+      // when
+      const screen = await renderScreen(
+        hbs`<Certifications::CertificationTechnicalError @isToBeCancelled={{false}} />`,
+      );
+
+      // then
+      assert.ok(screen.getByText(t('pages.certification-ender.results.disclaimer')));
+    });
+
+    test('should not display the cancelled message', async function (assert) {
+      // when
+      const screen = await renderScreen(
+        hbs`<Certifications::CertificationTechnicalError @isToBeCancelled={{false}} />`,
+      );
+
+      // then
+      assert.dom(screen.queryByText(t('pages.certification-technical-error.candidate.cancelled'))).doesNotExist();
+    });
+  });
+});

--- a/mon-pix/tests/unit/controllers/assessments/challenge-test.js
+++ b/mon-pix/tests/unit/controllers/assessments/challenge-test.js
@@ -335,4 +335,40 @@ module('Unit | Controller | Assessments | Challenge', function (hooks) {
       assert.ok(controller.model.assessment.reload.calledOnce);
     });
   });
+
+  module('#hasCertificationTechnicalError', function (hooks) {
+    hooks.beforeEach(function () {
+      const certificationTechnicalErrorService = Service.create({ hasError: false });
+      this.owner.register('service:certification-technical-error', certificationTechnicalErrorService, {
+        instantiate: false,
+      });
+      controller = this.owner.lookup('controller:assessments/challenge');
+    });
+
+    test('returns the hasError value from the service', function (assert) {
+      // given
+      controller.certificationTechnicalError.hasError = true;
+
+      // then
+      assert.true(controller.hasCertificationTechnicalError);
+    });
+  });
+
+  module('#isCertificationtoBeCancelled', function (hooks) {
+    hooks.beforeEach(function () {
+      const certificationTechnicalErrorService = Service.create({ isToBeCancelled: false });
+      this.owner.register('service:certification-technical-error', certificationTechnicalErrorService, {
+        instantiate: false,
+      });
+      controller = this.owner.lookup('controller:assessments/challenge');
+    });
+
+    test('returns the isToBeCancelled value from the service', function (assert) {
+      // given
+      controller.certificationTechnicalError.isToBeCancelled = true;
+
+      // then
+      assert.true(controller.isCertificationtoBeCancelled);
+    });
+  });
 });

--- a/mon-pix/tests/unit/routes/assessments/resume-test.js
+++ b/mon-pix/tests/unit/routes/assessments/resume-test.js
@@ -1,4 +1,5 @@
 import EmberObject from '@ember/object';
+import Service from '@ember/service';
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
@@ -237,6 +238,57 @@ module('Unit | Route | Assessments | Resume', function (hooks) {
             assert.ok(true);
           });
         });
+      });
+    });
+  });
+
+  module('#error', function (hooks) {
+    let certificationTechnicalErrorService;
+
+    hooks.beforeEach(function () {
+      certificationTechnicalErrorService = Service.create({ setError: sinon.stub() });
+      this.owner.register('service:certification-technical-error', certificationTechnicalErrorService, {
+        instantiate: false,
+      });
+      route = this.owner.lookup('route:assessments.resume');
+    });
+
+    module('when error code is ASSESSMENT_LACK_OF_CHALLENGES', function () {
+      test('calls certificationTechnicalError.setError with isToBeCancelled', function (assert) {
+        // given
+        const error = { errors: [{ code: 'ASSESSMENT_LACK_OF_CHALLENGES', meta: { isToBeCancelled: true } }] };
+
+        // when
+        const result = route.error(error);
+
+        // then
+        sinon.assert.calledWith(certificationTechnicalErrorService.setError, { isToBeCancelled: true });
+        assert.false(result);
+      });
+
+      test('defaults isToBeCancelled to false when meta is absent', function (assert) {
+        // given
+        const error = { errors: [{ code: 'ASSESSMENT_LACK_OF_CHALLENGES' }] };
+
+        // when
+        route.error(error);
+
+        // then
+        sinon.assert.calledWith(certificationTechnicalErrorService.setError, { isToBeCancelled: false });
+        assert.ok(true);
+      });
+    });
+
+    module('when error code is something else', function () {
+      test('returns true to propagate the error', function (assert) {
+        // given
+        const error = { errors: [{ code: 'SOME_OTHER_ERROR' }] };
+
+        // when
+        const result = route.error(error);
+
+        // then
+        assert.true(result);
       });
     });
   });

--- a/mon-pix/tests/unit/services/certification-technical-error-test.js
+++ b/mon-pix/tests/unit/services/certification-technical-error-test.js
@@ -1,0 +1,44 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Unit | Service | certification-technical-error', function (hooks) {
+  setupTest(hooks);
+
+  let service;
+
+  hooks.beforeEach(function () {
+    service = this.owner.lookup('service:certification-technical-error');
+  });
+
+  module('#setError', function () {
+    test('sets hasError to true', function (assert) {
+      // when
+      service.setError({ isToBeCancelled: false });
+
+      // then
+      assert.true(service.hasError);
+    });
+
+    test('sets isToBeCancelled from the argument', function (assert) {
+      // when
+      service.setError({ isToBeCancelled: true });
+
+      // then
+      assert.true(service.isToBeCancelled);
+    });
+  });
+
+  module('#reset', function () {
+    test('resets hasError and isToBeCancelled to false', function (assert) {
+      // given
+      service.setError({ isToBeCancelled: true });
+
+      // when
+      service.reset();
+
+      // then
+      assert.false(service.hasError);
+      assert.false(service.isToBeCancelled);
+    });
+  });
+});

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -750,6 +750,19 @@
         "title": "How can I view and share my certification results?"
       }
     },
+    "certification-technical-error": {
+      "candidate": {
+        "cancelled": {
+          "disclaimer": "This certification will be cancelled due to the technical problem encountered.",
+          "title": "How can I retake my certification ?",
+          "step-1": "We invite you to consult your certification center to schedule a retake."
+        },
+        "disconnect": "Log out of my account",
+        "disconnect-tip": "If this is not your computer, please remember to log out.",
+        "message": "Your certification test has ended due to a technical problem. You can no longer answer questions.",
+        "title": "An error has occurred"
+      }
+    },
     "certification-frameworks": {
       "CLEA": "CLéA Numérique",
       "CORE": "Pix certification",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -751,6 +751,19 @@
         "title": "Comment consulter et partager mes résultats de certification ?"
       }
     },
+    "certification-technical-error": {
+      "candidate": {
+        "cancelled": {
+          "disclaimer": "Cette certification sera annulée en raison du problème technique rencontré.",
+          "title": "Comment repasser ma certification ?",
+          "step-1": "Nous vous invitons à vous rapprocher de votre centre de certification pour convenir d’un rattrapage."
+        },
+        "disconnect": "Déconnecter mon compte",
+        "disconnect-tip": "Si cet ordinateur n'est pas le vôtre, pensez à vous déconnecter.",
+        "message": "Votre test de certification a pris fin en raison d'un problème technique. Vous ne pouvez plus continuer de répondre aux questions.",
+        "title": "Une erreur est survenue"
+      }
+    },
     "certification-frameworks": {
       "CLEA": "CLéA Numérique",
       "CORE": "Certification Pix",


### PR DESCRIPTION
## 🌱 Problème

À chaque réponse, l’algorithme de déroulé de certification v3 est sensé proposer une nouvelle question en adaptant le niveau de difficulté pour déterminer au mieux la capacité du candidat.

Actuellement, toutes les certifications (Pix transverse, CléA, Pix+) comportent 32 questions. Pour terminer son test, le candidat est sensé répondre à 32 questions, ni plus, ni moins.

Il arrive que l’algorithme ne trouve plus de questions à poser au candidat alors qu’il n’a pourtant pas posé les 32 questions requises.

Dans ces cas, le candidat ne voit pourtant aucune erreur. L'écran de fin de test s’affiche pour lui dire que tout s’est bien passé et que son test est terminé alors même qu’il n’a pas pu répondre à toutes les questions de sa certification (voir même qu’il n’a pas répondu au nombre minimal requis pour pouvoir être certifié).

## 🐣 Proposition

Si l'erreur est levée, alors on affiche un écran d'erreur pertinent au candidat, on enregistre en base de donnée le fait que le candidat à rencontré un problème technique (abort_reason technical) et on bloque la main au surveillant pour changer cette valeur lors de la finalisation 

## 🌷 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🐝 Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
