### PR TITLE
[TECH] Refacto pour utiliser plus efficacement le "versionId" présent au niveau du "certification-course" dans le code du bounded context "certification/evaluation"

### DIFF
--- a/api/src/certification/evaluation/domain/models/AssessmentSheet.js
+++ b/api/src/certification/evaluation/domain/models/AssessmentSheet.js
@@ -10,6 +10,7 @@ export class AssessmentSheet {
    * @param {number} params.certificationCourseId
    * @param {number} params.userId
    * @param {number} params.assessmentId
+   * @param {number} params.versionId
    * @param {string} params.lastChallengeId
    * @param {Assessment.statesOfLastQuestion} params.lastQuestionState
    * @param {Date} params.lastQuestionDate
@@ -25,6 +26,7 @@ export class AssessmentSheet {
     certificationCourseId,
     userId,
     assessmentId,
+    versionId,
     lastChallengeId,
     lastQuestionState,
     lastQuestionDate,
@@ -39,6 +41,7 @@ export class AssessmentSheet {
     this.certificationCourseId = certificationCourseId;
     this.userId = userId;
     this.assessmentId = assessmentId;
+    this.versionId = versionId;
     this.lastChallengeId = lastChallengeId;
     this.lastQuestionState = lastQuestionState;
     this.lastQuestionDate = lastQuestionDate;

--- a/api/src/certification/evaluation/domain/usecases/create-companion-alert.js
+++ b/api/src/certification/evaluation/domain/usecases/create-companion-alert.js
@@ -1,20 +1,17 @@
-import { withTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import {
   CertificationCompanionLiveAlert,
   CertificationCompanionLiveAlertStatus,
 } from '../../../shared/domain/models/CertificationCompanionLiveAlert.js';
 
-export const createCompanionAlert = withTransaction(
-  /**
-   * @param {object} params
-   * @param {number} params.assessmentId
-   * @param {import('./index.js').CertificationCompanionAlertRepository} params.certificationCompanionAlertRepository
-   **/
-  async function createCompanionAlert({ assessmentId, certificationCompanionAlertRepository }) {
-    const companionAlert = new CertificationCompanionLiveAlert({
-      assessmentId,
-      status: CertificationCompanionLiveAlertStatus.ONGOING,
-    });
-    await certificationCompanionAlertRepository.create(companionAlert);
-  },
-);
+/**
+ * @param {object} params
+ * @param {number} params.assessmentId
+ * @param {import('./index.js').CertificationCompanionAlertRepository} params.certificationCompanionAlertRepository
+ **/
+export async function createCompanionAlert({ assessmentId, certificationCompanionAlertRepository }) {
+  const companionAlert = new CertificationCompanionLiveAlert({
+    assessmentId,
+    status: CertificationCompanionLiveAlertStatus.ONGOING,
+  });
+  await certificationCompanionAlertRepository.create(companionAlert);
+}

--- a/api/src/certification/evaluation/domain/usecases/get-certification-course.js
+++ b/api/src/certification/evaluation/domain/usecases/get-certification-course.js
@@ -1,5 +1,4 @@
 /**
- * @typedef {import('./index.js').CertificationCandidateRepository} CertificationCandidateRepository
  * @typedef {import('./index.js').CertificationCourseRepository} CertificationCourseRepository
  * @typedef {import('./index.js').VersionRepository} VersionRepository
  */
@@ -7,31 +6,18 @@
 /**
  * @param {object} params
  * @param {number} params.certificationCourseId
- * @param {CertificationCandidateRepository} params.certificationCandidateRepository
  * @param {CertificationCourseRepository} params.certificationCourseRepository
  * @param {VersionRepository} params.versionRepository
  */
 const getCertificationCourse = async function ({
   certificationCourseId,
-  sharedCertificationCandidateRepository,
   certificationCourseRepository,
   versionRepository,
 }) {
   const certificationCourse = await certificationCourseRepository.get({ id: certificationCourseId });
 
   if (certificationCourse.isV3()) {
-    const candidate = await sharedCertificationCandidateRepository.getBySessionIdAndUserId({
-      sessionId: certificationCourse.getSessionId(),
-      userId: certificationCourse.getUserId(),
-    });
-
-    const scope = await certificationCourseRepository.getCertificationScope({ courseId: certificationCourseId });
-
-    const version = await versionRepository.getByScopeAndReconciliationDate({
-      scope,
-      reconciliationDate: candidate.reconciledAt,
-    });
-
+    const version = await versionRepository.getById(certificationCourse.versionId);
     certificationCourse.setNumberOfChallenges(version.challengesConfiguration.maximumAssessmentLength);
   }
 

--- a/api/src/certification/evaluation/domain/usecases/retrieve-last-or-create-certification-course.js
+++ b/api/src/certification/evaluation/domain/usecases/retrieve-last-or-create-certification-course.js
@@ -62,7 +62,7 @@ export const retrieveLastOrCreateCertificationCourse = async function ({
   const certificationCandidate = await sharedCertificationCandidateRepository.getBySessionIdAndUserId({
     userId,
     sessionId,
-  });
+  }); // normal candidate repo, voir où c'est utilisé
 
   _validateUserIsCertificationCandidate(certificationCandidate);
 

--- a/api/src/certification/evaluation/domain/usecases/save-certification-scoring-configuration.js
+++ b/api/src/certification/evaluation/domain/usecases/save-certification-scoring-configuration.js
@@ -2,15 +2,11 @@
  @typedef {import('./index.js').ScoringConfigurationRepository} ScoringConfigurationRepository
  */
 
-import { withTransaction } from '../../../../shared/domain/DomainTransaction.js';
-
-export const saveCertificationScoringConfiguration = withTransaction(
-  /**
-   * @param {object} params
-   * @param {object} params.configuration
-   * @param {ScoringConfigurationRepository} params.scoringConfigurationRepository
-   */
-  async ({ configuration, scoringConfigurationRepository }) => {
-    return scoringConfigurationRepository.saveCertificationScoringConfiguration({ configuration });
-  },
-);
+/**
+ * @param {object} params
+ * @param {object} params.configuration
+ * @param {ScoringConfigurationRepository} params.scoringConfigurationRepository
+ */
+export async function saveCertificationScoringConfiguration({ configuration, scoringConfigurationRepository }) {
+  return scoringConfigurationRepository.saveCertificationScoringConfiguration({ configuration });
+}

--- a/api/src/certification/evaluation/domain/usecases/save-competence-for-scoring-configuration.js
+++ b/api/src/certification/evaluation/domain/usecases/save-competence-for-scoring-configuration.js
@@ -2,15 +2,11 @@
  * @typedef {import('./index.js').ScoringConfigurationRepository} ScoringConfigurationRepository
  */
 
-import { withTransaction } from '../../../../shared/domain/DomainTransaction.js';
-
-export const saveCompetenceForScoringConfiguration = withTransaction(
-  /**
-   * @param {object} params
-   * @param {object} params.configuration
-   * @param {ScoringConfigurationRepository} params.scoringConfigurationRepository
-   */
-  async ({ configuration, scoringConfigurationRepository }) => {
-    return scoringConfigurationRepository.saveCompetenceForScoringConfiguration({ configuration });
-  },
-);
+/**
+ * @param {object} params
+ * @param {object} params.configuration
+ * @param {ScoringConfigurationRepository} params.scoringConfigurationRepository
+ */
+export async function saveCompetenceForScoringConfiguration({ configuration, scoringConfigurationRepository }) {
+  return scoringConfigurationRepository.saveCompetenceForScoringConfiguration({ configuration });
+}

--- a/api/src/certification/evaluation/domain/usecases/score-v3-certification.js
+++ b/api/src/certification/evaluation/domain/usecases/score-v3-certification.js
@@ -62,10 +62,7 @@ export async function scoreV3Certification({
     assessmentId: assessmentSheet.assessmentId,
   });
 
-  const version = await sharedVersionRepository.getByScopeAndReconciliationDate({
-    scope: candidate.subscriptionScope,
-    reconciliationDate: candidate.reconciledAt,
-  });
+  const version = await sharedVersionRepository.getById(assessmentSheet.versionId);
 
   await _verifyCertificationIsScorable({
     certificationCourseId: assessmentSheet.certificationCourseId,

--- a/api/src/certification/evaluation/infrastructure/repositories/assessment-sheet-repository.js
+++ b/api/src/certification/evaluation/infrastructure/repositories/assessment-sheet-repository.js
@@ -18,6 +18,7 @@ export async function findByCertificationCourseId(certificationCourseId) {
       state: 'assessments.state',
       assessmentUpdatedAt: 'assessments.updatedAt',
       certificationCourseUpdatedAt: 'certification-courses.updatedAt',
+      versionId: 'certification-courses.versionId',
     })
     .from('certification-courses')
     .join('assessments', 'assessments.certificationCourseId', 'certification-courses.id')

--- a/api/src/certification/session-management/domain/models/V3CertificationCourseDetailsForAdministration.js
+++ b/api/src/certification/session-management/domain/models/V3CertificationCourseDetailsForAdministration.js
@@ -14,6 +14,7 @@ export class V3CertificationCourseDetailsForAdministration {
     eduV3ExternalJuryResult,
     numberOfChallenges,
     certificationFramework,
+    versionId,
   }) {
     this.certificationCourseId = certificationCourseId;
     this.isRejectedForFraud = isRejectedForFraud;
@@ -29,6 +30,7 @@ export class V3CertificationCourseDetailsForAdministration {
     this.numberOfChallenges = numberOfChallenges;
     this.endedAt = endedAt;
     this.certificationFramework = certificationFramework;
+    this.versionId = versionId;
   }
 
   get reachedResultKey() {

--- a/api/src/certification/session-management/domain/usecases/get-v3-certification-course-details-for-administration.js
+++ b/api/src/certification/session-management/domain/usecases/get-v3-certification-course-details-for-administration.js
@@ -2,8 +2,6 @@ export const getV3CertificationCourseDetailsForAdministration = async ({
   certificationCourseId,
   competenceRepository,
   v3CertificationCourseDetailsForAdministrationRepository,
-  certificationCandidateRepository,
-  sharedCertificationCourseRepository,
   evaluationVersionRepository,
 }) => {
   const competences = await competenceRepository.list();
@@ -13,14 +11,7 @@ export const getV3CertificationCourseDetailsForAdministration = async ({
       certificationCourseId,
     });
 
-  const candidate = await certificationCandidateRepository.getByCertificationCourseId({ certificationCourseId });
-
-  const scope = await sharedCertificationCourseRepository.getCertificationScope({ courseId: certificationCourseId });
-
-  const version = await evaluationVersionRepository.getByScopeAndReconciliationDate({
-    scope,
-    reconciliationDate: candidate.reconciledAt,
-  });
+  const version = await evaluationVersionRepository.getById(courseDetails.versionId);
 
   courseDetails.numberOfChallenges = version.challengesConfiguration.maximumAssessmentLength;
 

--- a/api/src/certification/session-management/domain/usecases/index.js
+++ b/api/src/certification/session-management/domain/usecases/index.js
@@ -5,7 +5,6 @@ import * as flashAlgorithmService from '../../../evaluation/domain/services/algo
 import * as certificationBadgesService from '../../../shared/domain/services/certification-badges-service.js';
 import * as certificationCpfService from '../../../shared/domain/services/certification-cpf-service.js';
 import * as certificationCenterRepository from '../../../shared/infrastructure/repositories/certification-center-repository.js';
-import * as sharedCertificationCourseRepository from '../../../shared/infrastructure/repositories/certification-course-repository.js';
 import * as sharedSessionRepository from '../../../shared/infrastructure/repositories/session-repository.js';
 import * as evaluationVersionRepository from '../../../shared/infrastructure/repositories/version-repository.js';
 import {
@@ -133,7 +132,6 @@ const dependencies = {
   certificationIssueReportRepository,
   flashAlgorithmService,
   sessionPublicationService,
-  sharedCertificationCourseRepository,
   sharedSessionRepository,
   evaluationVersionRepository,
   userRepository,

--- a/api/src/certification/session-management/infrastructure/repositories/v3-certification-course-details-for-administration-repository.js
+++ b/api/src/certification/session-management/infrastructure/repositories/v3-certification-course-details-for-administration-repository.js
@@ -5,7 +5,7 @@ import { V3CertificationChallengeForAdministration } from '../../domain/models/V
 import { V3CertificationChallengeLiveAlertForAdministration } from '../../domain/models/V3CertificationChallengeLiveAlertForAdministration.js';
 import { V3CertificationCourseDetailsForAdministration } from '../../domain/models/V3CertificationCourseDetailsForAdministration.js';
 
-const getV3DetailsByCertificationCourseId = async function ({ certificationCourseId }) {
+export async function getV3DetailsByCertificationCourseId({ certificationCourseId }) {
   const knexConn = DomainTransaction.getConnection();
   const liveAlertsDTO = await knexConn('certification-challenge-live-alerts')
     .select({
@@ -41,6 +41,7 @@ const getV3DetailsByCertificationCourseId = async function ({ certificationCours
       eduV3ExternalJuryResult: 'assessment-results.eduV3ExternalJuryResult',
       endedAt: 'certification-courses.endedAt',
       certificationFramework: 'certification-courses.framework',
+      versionId: 'certification-courses.versionId',
     })
     .from('certification-courses')
     .leftJoin('assessments', 'assessments.certificationCourseId', 'certification-courses.id')
@@ -81,7 +82,7 @@ const getV3DetailsByCertificationCourseId = async function ({ certificationCours
     .orderBy('certification-challenges.createdAt', 'asc');
 
   return _toDomain({ certificationChallengesDetailsDTO, liveAlertsDTO, certificationCourseDTO });
-};
+}
 
 function _toDomain({ certificationChallengesDetailsDTO, liveAlertsDTO, certificationCourseDTO }) {
   const certificationChallengesForAdministration = certificationChallengesDetailsDTO.map(
@@ -104,8 +105,6 @@ function _toDomain({ certificationChallengesDetailsDTO, liveAlertsDTO, certifica
     certificationChallengesForAdministration,
   });
 }
-
-export { getV3DetailsByCertificationCourseId };
 
 function _certificationChallengeLiveAlertToDomain({ liveAlertsDTO, certificationChallengeDetailsDTO }) {
   const certificationChallengeLiveAlert = liveAlertsDTO.find(

--- a/api/src/certification/shared/infrastructure/repositories/certification-course-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/certification-course-repository.js
@@ -4,8 +4,6 @@ import { Assessment } from '../../../../shared/domain/models/Assessment.js';
 import { ComplementaryCertificationCourse } from '../../../session-management/domain/models/ComplementaryCertificationCourse.js';
 import { CertificationCourse } from '../../domain/models/CertificationCourse.js';
 import { CertificationIssueReport } from '../../domain/models/CertificationIssueReport.js';
-import { ComplementaryCertificationKeys } from '../../domain/models/ComplementaryCertificationKeys.js';
-import { getScopeByName, SCOPES } from '../../domain/models/Scopes.js';
 
 async function save({ certificationCourse }) {
   const knexConn = DomainTransaction.getConnection();
@@ -202,37 +200,11 @@ async function findCertificationCoursesBySessionId({ sessionId }) {
   return certificationCoursesDTO.map((certificationCourseDTO) => _toDomain({ certificationCourseDTO }));
 }
 
-/**
- * @param {object} params
- * @param {number} params.courseId
- * @returns {Promise<SCOPES>}
- */
-async function getCertificationScope({ courseId }) {
-  const knexConn = DomainTransaction.getConnection();
-
-  const result = await knexConn('complementary-certification-courses')
-    .select('complementary-certifications.key')
-    .where({ certificationCourseId: courseId })
-    .join(
-      'complementary-certifications',
-      'complementary-certifications.id',
-      'complementary-certification-courses.complementaryCertificationId',
-    )
-    .first();
-
-  if (result?.key && result.key !== ComplementaryCertificationKeys.CLEA) {
-    return getScopeByName(result.key);
-  }
-
-  return SCOPES.CORE;
-}
-
 export {
   findAllByUserId,
   findCertificationCoursesBySessionId,
   findOneCertificationCourseByUserIdAndSessionId,
   get,
-  getCertificationScope,
   getSessionId,
   isVerificationCodeAvailable,
   save,

--- a/api/tests/certification/evaluation/acceptance/application/certification-courses/certification-course-controller_test.js
+++ b/api/tests/certification/evaluation/acceptance/application/certification-courses/certification-course-controller_test.js
@@ -41,15 +41,16 @@ describe('Acceptance | API | Certification Course', function () {
 
       databaseBuilder.factory.buildCoreSubscription({ certificationCandidateId: candidateId });
 
-      databaseBuilder.factory.buildCertificationVersion({
+      const versionId = databaseBuilder.factory.buildCertificationVersion({
         startDate: new Date('2024-01-01'),
         expirationDate: null,
-      });
+      }).id;
 
       const certificationCourse = databaseBuilder.factory.buildCertificationCourse({
         sessionId: session.id,
         userId,
         version: AlgorithmEngineVersion.V3,
+        versionId,
       });
 
       databaseBuilder.factory.buildCertificationIssueReport({

--- a/api/tests/certification/evaluation/acceptance/application/certification-rescoring-route_test.js
+++ b/api/tests/certification/evaluation/acceptance/application/certification-rescoring-route_test.js
@@ -95,6 +95,7 @@ describe('Certification | Evaluation | Acceptance | Application |  certification
           version: AlgorithmEngineVersion.V3,
           createdAt: new Date('2025-01-01'),
           candidateId: certificationCandidate.id,
+          versionId: currentVersion.id,
         });
 
         const assessment = databaseBuilder.factory.buildAssessment({
@@ -242,6 +243,7 @@ describe('Certification | Evaluation | Acceptance | Application |  certification
           version: AlgorithmEngineVersion.V3,
           createdAt: new Date('2024-01-01'),
           candidateId: certificationCandidate.id,
+          versionId: archivedVersion.id,
         });
 
         const assessment = databaseBuilder.factory.buildAssessment({

--- a/api/tests/certification/evaluation/integration/domain/usecases/score-v3-certification_test.js
+++ b/api/tests/certification/evaluation/integration/domain/usecases/score-v3-certification_test.js
@@ -169,6 +169,7 @@ describe('Certification | Evaluation | Integration | Domain | Usecases | Score v
         createdAt: limitDate,
         version: AlgorithmEngineVersion.V3,
         candidateId,
+        versionId: certificationVersionId,
       }).id;
 
       completedCertificationAssessmentId = databaseBuilder.factory.buildAssessment({
@@ -390,6 +391,7 @@ describe('Certification | Evaluation | Integration | Domain | Usecases | Score v
         createdAt: limitDate,
         version: AlgorithmEngineVersion.V3,
         candidateId,
+        versionId: certificationVersionId,
       }).id;
 
       complementaryCertificationCourseId = databaseBuilder.factory.buildComplementaryCertificationCourse({

--- a/api/tests/certification/evaluation/integration/infrastructure/repositories/assessment-sheet-repository_test.js
+++ b/api/tests/certification/evaluation/integration/infrastructure/repositories/assessment-sheet-repository_test.js
@@ -4,9 +4,10 @@ import { databaseBuilder, expect } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 
 describe('Integration | Certification | Evaluation | Infrastructure | Repositories | AssessmentSheetRepository', function () {
-  let certificationCourseId, assessmentId, userId, answerData;
+  let certificationCourseId, assessmentId, userId, versionId, answerData;
   beforeEach(async function () {
     userId = databaseBuilder.factory.buildUser().id;
+    versionId = databaseBuilder.factory.buildCertificationVersion().id;
     certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
       abortReason: 'candidate',
       maxReachableLevelOnCertificationDate: 6,
@@ -14,6 +15,7 @@ describe('Integration | Certification | Evaluation | Infrastructure | Repositori
       userId,
       updatedAt: new Date('2022-02-22'),
       lastAnswerAt: new Date('2022-01-11'),
+      versionId,
     }).id;
     assessmentId = databaseBuilder.factory.buildAssessment({
       certificationCourseId,
@@ -50,6 +52,7 @@ describe('Integration | Certification | Evaluation | Infrastructure | Repositori
             lastQuestionState: Assessment.statesOfLastQuestion.TIMEOUT,
             certificationCourseUpdatedAt: new Date('2022-02-22'),
             lastAnswerAt: new Date('2022-01-11'),
+            versionId,
           }),
         );
       });
@@ -82,6 +85,7 @@ describe('Integration | Certification | Evaluation | Infrastructure | Repositori
         lastQuestionState: Assessment.statesOfLastQuestion.ASKED,
         certificationCourseUpdatedAt: new Date('2044-02-22'),
         lastAnswerAt: new Date('2044-01-11'),
+        versionId: 'somethingElse',
       });
 
       // when
@@ -104,6 +108,7 @@ describe('Integration | Certification | Evaluation | Infrastructure | Repositori
           lastQuestionState: Assessment.statesOfLastQuestion.TIMEOUT,
           certificationCourseUpdatedAt: new Date('2044-02-22'), // updated
           lastAnswerAt: new Date('2044-01-11'), // updated
+          versionId,
         }),
       );
     });

--- a/api/tests/certification/evaluation/unit/domain/usecases/get-certification-course_test.js
+++ b/api/tests/certification/evaluation/unit/domain/usecases/get-certification-course_test.js
@@ -1,14 +1,11 @@
 import { getCertificationCourse } from '../../../../../../src/certification/evaluation/domain/usecases/get-certification-course.js';
 import { AlgorithmEngineVersion } from '../../../../../../src/certification/shared/domain/models/AlgorithmEngineVersion.js';
-import { SCOPES } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
 import { domainBuilder, expect, sinon } from '../../../../../test-helper.js';
 
 describe('Unit | UseCase | get-certification-course', function () {
   let certificationCourse;
-  let candidate;
   let version;
 
-  let sharedCertificationCandidateRepository;
   let certificationCourseRepository;
   let versionRepository;
 
@@ -18,39 +15,29 @@ describe('Unit | UseCase | get-certification-course', function () {
       sessionId: 'session_id',
       userId: 'user_id',
       version: AlgorithmEngineVersion.V3,
+      versionId: 123,
     });
-
-    candidate = domainBuilder.certification.evaluation.buildCandidate({
-      reconciledAt: new Date('2024-01-15'),
-    });
-
-    sharedCertificationCandidateRepository = {
-      getBySessionIdAndUserId: sinon.stub(),
-    };
 
     certificationCourseRepository = {
       get: sinon.stub(),
-      getCertificationScope: sinon.stub(),
     };
 
     versionRepository = {
-      getByScopeAndReconciliationDate: sinon.stub(),
+      getById: sinon.stub(),
     };
 
     version = domainBuilder.certification.shared.buildVersion({
+      id: 123,
       challengesConfiguration: { maximumAssessmentLength: 42 },
     });
   });
 
   it('should get the certificationCourse with numberOfChallenges from version', async function () {
     certificationCourseRepository.get.withArgs({ id: certificationCourse.getId() }).resolves(certificationCourse);
-    sharedCertificationCandidateRepository.getBySessionIdAndUserId.resolves(candidate);
-    certificationCourseRepository.getCertificationScope.resolves(SCOPES.CORE);
-    versionRepository.getByScopeAndReconciliationDate.resolves(version);
+    versionRepository.getById.resolves(version);
 
     const actualCertificationCourse = await getCertificationCourse({
       certificationCourseId: certificationCourse.getId(),
-      sharedCertificationCandidateRepository,
       certificationCourseRepository,
       versionRepository,
     });
@@ -58,17 +45,7 @@ describe('Unit | UseCase | get-certification-course', function () {
     expect(certificationCourseRepository.get).to.have.been.calledOnceWithExactly({
       id: certificationCourse.getId(),
     });
-    expect(sharedCertificationCandidateRepository.getBySessionIdAndUserId).to.have.been.calledOnceWithExactly({
-      sessionId: certificationCourse.getSessionId(),
-      userId: certificationCourse.getUserId(),
-    });
-    expect(certificationCourseRepository.getCertificationScope).to.have.been.calledOnceWithExactly({
-      courseId: certificationCourse.getId(),
-    });
-    expect(versionRepository.getByScopeAndReconciliationDate).to.have.been.calledOnceWithExactly({
-      scope: SCOPES.CORE,
-      reconciliationDate: candidate.reconciledAt,
-    });
+    expect(versionRepository.getById).to.have.been.calledOnceWithExactly(123);
     expect(actualCertificationCourse.getNumberOfChallenges()).to.equal(42);
     expect(actualCertificationCourse.getId()).to.equal(certificationCourse.getId());
   });

--- a/api/tests/certification/evaluation/unit/domain/usecases/score-v3-certification_test.js
+++ b/api/tests/certification/evaluation/unit/domain/usecases/score-v3-certification_test.js
@@ -151,10 +151,10 @@ function stubCertificationCandidateRepository() {
 
 function stubSharedVersionRepository() {
   const sharedVersionRepository = {
-    getByScopeAndReconciliationDate: sinon.stub(),
+    getById: sinon.stub(),
   };
   const version = domainBuilder.certification.shared.buildVersion();
-  sharedVersionRepository.getByScopeAndReconciliationDate.resolves(version);
+  sharedVersionRepository.getById.resolves(version);
 
   return sharedVersionRepository;
 }

--- a/api/tests/certification/session-management/acceptance/application/cancellation-route_test.js
+++ b/api/tests/certification/session-management/acceptance/application/cancellation-route_test.js
@@ -158,6 +158,30 @@ describe('Certification | Session-management | Acceptance | Application | Routes
     context('when certification is v3', function () {
       it('should create a new cancelled assessment-result', async function () {
         // given
+        const versionId = databaseBuilder.factory.buildCertificationVersion({
+          startDate: new Date('2024-01-14'),
+          competencesScoringConfiguration: [
+            {
+              competence: 'index Compétence A',
+              values: [
+                {
+                  bounds: {
+                    max: 0,
+                    min: -5,
+                  },
+                  competenceLevel: 0,
+                },
+                {
+                  bounds: {
+                    max: 5,
+                    min: 0,
+                  },
+                  competenceLevel: 1,
+                },
+              ],
+            },
+          ],
+        }).id;
         const juryMember = databaseBuilder.factory.buildUser.withRole({ roles: PIX_ADMIN.ROLES.SUPER_ADMIN });
         const session = databaseBuilder.factory.buildSession({
           version: AlgorithmEngineVersion.V3,
@@ -178,6 +202,7 @@ describe('Certification | Session-management | Acceptance | Application | Routes
           createdAt: new Date('2024-01-15'),
           abortReason: 'technical',
           candidateId,
+          versionId,
         });
         const assessment = databaseBuilder.factory.buildAssessment({
           id: 456,
@@ -220,31 +245,6 @@ describe('Certification | Session-management | Acceptance | Application | Routes
           earnedPix: 16,
         });
 
-        databaseBuilder.factory.buildCertificationVersion({
-          startDate: new Date('2024-01-14'),
-          competencesScoringConfiguration: [
-            {
-              competence: 'index Compétence A',
-              values: [
-                {
-                  bounds: {
-                    max: 0,
-                    min: -5,
-                  },
-                  competenceLevel: 0,
-                },
-                {
-                  bounds: {
-                    max: 5,
-                    min: 0,
-                  },
-                  competenceLevel: 1,
-                },
-              ],
-            },
-          ],
-        });
-
         const options = {
           method: 'PATCH',
           url: '/api/admin/certification-courses/123/cancel',
@@ -283,6 +283,30 @@ describe('Certification | Session-management | Acceptance | Application | Routes
   describe('PATCH /api/admin/certification-courses/{certificationCourseId}/uncancel', function () {
     it('should uncancel the certification with a new assessment-result', async function () {
       // given
+      const versionId = databaseBuilder.factory.buildCertificationVersion({
+        startDate: new Date('2024-01-14'),
+        competencesScoringConfiguration: [
+          {
+            competence: 'index Compétence A',
+            values: [
+              {
+                bounds: {
+                  max: 0,
+                  min: -5,
+                },
+                competenceLevel: 0,
+              },
+              {
+                bounds: {
+                  max: 5,
+                  min: 0,
+                },
+                competenceLevel: 1,
+              },
+            ],
+          },
+        ],
+      }).id;
       const juryMember = databaseBuilder.factory.buildUser.withRole({ roles: PIX_ADMIN.ROLES.SUPER_ADMIN });
       const session = databaseBuilder.factory.buildSession({
         version: AlgorithmEngineVersion.V3,
@@ -303,6 +327,7 @@ describe('Certification | Session-management | Acceptance | Application | Routes
         createdAt: new Date('2024-01-15'),
         abortReason: 'candidate',
         candidateId,
+        versionId,
       });
       const assessment = databaseBuilder.factory.buildAssessment({
         id: 456,
@@ -344,31 +369,6 @@ describe('Certification | Session-management | Acceptance | Application | Routes
         competenceId: 'index Compétence A',
         userId: certificationCourse.userId,
         earnedPix: 16,
-      });
-
-      databaseBuilder.factory.buildCertificationVersion({
-        startDate: new Date('2024-01-14'),
-        competencesScoringConfiguration: [
-          {
-            competence: 'index Compétence A',
-            values: [
-              {
-                bounds: {
-                  max: 0,
-                  min: -5,
-                },
-                competenceLevel: 0,
-              },
-              {
-                bounds: {
-                  max: 5,
-                  min: 0,
-                },
-                competenceLevel: 1,
-              },
-            ],
-          },
-        ],
       });
 
       const options = {

--- a/api/tests/certification/session-management/acceptance/application/certification-course-route_test.js
+++ b/api/tests/certification/session-management/acceptance/application/certification-course-route_test.js
@@ -45,7 +45,7 @@ describe('Certification | Session Management | Acceptance | Application | Routes
         server = await createServer();
         const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
 
-        databaseBuilder.factory.buildCertificationVersion({
+        const versionId = databaseBuilder.factory.buildCertificationVersion({
           scope: 'CORE',
           startDate: new Date('2019-01-01'),
           expirationDate: null,
@@ -53,7 +53,7 @@ describe('Certification | Session Management | Acceptance | Application | Routes
             maximumAssessmentLength: 10,
             defaultCandidateCapacity: -3,
           },
-        });
+        }).id;
 
         databaseBuilder.factory.buildCertificationCpfCountry({
           code: '99100',
@@ -72,6 +72,7 @@ describe('Certification | Session Management | Acceptance | Application | Routes
           completedAt: new Date('2017-12-21T15:48:38Z'),
           sex: 'F',
           candidate: candidate.id,
+          versionId,
         });
         certificationCourseId = certificationCourse.id;
 
@@ -213,9 +214,9 @@ describe('Certification | Session Management | Acceptance | Application | Routes
           version: 3,
         });
 
-        databaseBuilder.factory.buildCertificationVersion({
+        const versionId = databaseBuilder.factory.buildCertificationVersion({
           startDate: new Date('2018-12-01T01:02:03Z'),
-        });
+        }).id;
 
         const candidateId = databaseBuilder.factory.buildCertificationCandidate({
           sessionId: session.id,
@@ -227,6 +228,7 @@ describe('Certification | Session Management | Acceptance | Application | Routes
           userId,
           version: 3,
           candidateId,
+          versionId,
         });
 
         const { assessment, assessmentResult } = await createSuccessfulCertificationCourse({
@@ -272,7 +274,9 @@ describe('Certification | Session Management | Acceptance | Application | Routes
     it('should create a new unrejected AssessmentResult', async function () {
       // given
       const userId = databaseBuilder.factory.buildUser.withRoleSuperAdmin().id;
-
+      const versionId = databaseBuilder.factory.buildCertificationVersion({
+        minimumAnswersRequiredToValidateACertification: 1,
+      }).id;
       const session = databaseBuilder.factory.buildSession({
         finalizedAt: new Date('2018-12-01T01:02:03Z'),
         version: AlgorithmEngineVersion.V3,
@@ -289,9 +293,8 @@ describe('Certification | Session Management | Acceptance | Application | Routes
         isRejectedForFraud: true,
         version: AlgorithmEngineVersion.V3,
         candidateId,
+        versionId,
       });
-
-      databaseBuilder.factory.buildCertificationVersion({ minimumAnswersRequiredToValidateACertification: 1 });
 
       const { assessment, assessmentResult } = await createSuccessfulCertificationCourse({
         candidateId,
@@ -403,7 +406,7 @@ describe('Certification | Session Management | Acceptance | Application | Routes
     let server;
 
     beforeEach(async function () {
-      databaseBuilder.factory.buildCertificationVersion({
+      const versionId = databaseBuilder.factory.buildCertificationVersion({
         scope: 'CORE',
         startDate: new Date('2020-01-01'),
         expirationDate: null,
@@ -411,7 +414,7 @@ describe('Certification | Session Management | Acceptance | Application | Routes
           maximumAssessmentLength: 10,
           defaultCandidateCapacity: -3,
         }),
-      });
+      }).id;
 
       const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
       const session = databaseBuilder.factory.buildSession();
@@ -425,6 +428,7 @@ describe('Certification | Session Management | Acceptance | Application | Routes
         sessionId: session.id,
         userId: superAdmin.id,
         candidateId,
+        versionId,
       });
       ({ certificationChallenges, assessmentResult } = await createSuccessfulCertificationCourse({
         candidateId,

--- a/api/tests/certification/session-management/acceptance/application/finalize-route_test.js
+++ b/api/tests/certification/session-management/acceptance/application/finalize-route_test.js
@@ -433,6 +433,7 @@ describe('Certification | Session Management | Acceptance | Application | Route 
             sessionId: session.id,
             completedAt: new Date(),
             version: AlgorithmEngineVersion.V3,
+            versionId: certificationVersionId,
           }).id;
           databaseBuilder.factory.buildCertificationCenterMembership({
             userId,
@@ -528,6 +529,7 @@ describe('Certification | Session Management | Acceptance | Application | Route 
             completedAt: null,
             version: AlgorithmEngineVersion.V3,
             candidateId,
+            versionId: certificationVersionId,
           }).id;
           databaseBuilder.factory.buildCertificationCenterMembership({
             userId,
@@ -646,6 +648,7 @@ describe('Certification | Session Management | Acceptance | Application | Route 
               completedAt: new Date(),
               version: AlgorithmEngineVersion.V3,
               candidateId,
+              versionId: certificationVersionId,
             }).id;
 
             const complementaryCertificationCourseId = databaseBuilder.factory.buildComplementaryCertificationCourse({
@@ -948,9 +951,9 @@ const _createSessionWithoutChallenge = async () => {
   const userId = databaseBuilder.factory.buildUser().id;
   const candidateUserId = databaseBuilder.factory.buildUser().id;
   const session = databaseBuilder.factory.buildSession({ version });
-  databaseBuilder.factory.buildCertificationVersion({
+  const versionId = databaseBuilder.factory.buildCertificationVersion({
     startDate: new Date('2024-01-01'),
-  });
+  }).id;
   databaseBuilder.factory.buildCertificationCenterMembership({
     userId,
     certificationCenterId: session.certificationCenterId,
@@ -968,6 +971,7 @@ const _createSessionWithoutChallenge = async () => {
     userId: candidateUserId,
     createdAt: new Date('2025-01-01'),
     candidateId,
+    versionId,
   }).id;
   const assessmentId = databaseBuilder.factory.buildAssessment({
     certificationCourseId,

--- a/api/tests/certification/session-management/integration/infrastructure/repositories/v3-certification-course-details-for-administration-repository_test.js
+++ b/api/tests/certification/session-management/integration/infrastructure/repositories/v3-certification-course-details-for-administration-repository_test.js
@@ -30,6 +30,7 @@ describe('Integration | Infrastructure | Repository | v3-certification-course-de
 
       const userId = databaseBuilder.factory.buildUser().id;
       const sessionId = databaseBuilder.factory.buildSession().id;
+      const versionId = databaseBuilder.factory.buildCertificationVersion({ scope: SCOPES.PIX_PLUS_DROIT }).id;
 
       databaseBuilder.factory.buildCertificationCourse({
         id: certificationCourseId,
@@ -40,6 +41,7 @@ describe('Integration | Infrastructure | Repository | v3-certification-course-de
         userId,
         sessionId,
         framework: certificationFramework,
+        versionId,
       });
       databaseBuilder.factory.buildCertificationChallenge({
         courseId: certificationCourseId,
@@ -58,8 +60,6 @@ describe('Integration | Infrastructure | Repository | v3-certification-course-de
         assessmentResultStatus,
         createdAt: new Date('2020-01-01'),
       });
-
-      const versionId = databaseBuilder.factory.buildCertificationVersion({ scope: SCOPES.PIX_PLUS_DROIT }).id;
 
       const lastAssessmentResultId = databaseBuilder.factory.buildAssessmentResult({
         pixScore,
@@ -114,6 +114,7 @@ describe('Integration | Infrastructure | Repository | v3-certification-course-de
         numberOfChallenges: null,
         certificationFramework,
         certificationChallengesForAdministration: [certificationChallengeForAdministration],
+        versionId,
       });
 
       expect(certificationChallenges).to.deep.equal(expectedCertificationCourseDetails);
@@ -127,7 +128,8 @@ describe('Integration | Infrastructure | Repository | v3-certification-course-de
       const thirdChallengeId = 'recCHAL123';
       const assessmentId = 78;
 
-      databaseBuilder.factory.buildCertificationCourse({ id: certificationCourseId });
+      const versionId = databaseBuilder.factory.buildCertificationVersion({ scope: SCOPES.PIX_PLUS_DROIT }).id;
+      databaseBuilder.factory.buildCertificationCourse({ id: certificationCourseId, versionId });
       databaseBuilder.factory.buildCertificationChallenge({
         courseId: certificationCourseId,
         challengeId: firstChallengeId,
@@ -241,6 +243,7 @@ describe('Integration | Infrastructure | Repository | v3-certification-course-de
           validatedLiveAlert: secondValidatedLiveAlert,
           competenceId: certificationChallenges.certificationChallengesForAdministration[1].competenceId,
           skillName: certificationChallenges.certificationChallengesForAdministration[1].skillName,
+          versionId,
         });
 
       const thirdCertificationChallengeForAdministration = domainBuilder.buildV3CertificationChallengeForAdministration(
@@ -249,6 +252,7 @@ describe('Integration | Infrastructure | Repository | v3-certification-course-de
           validatedLiveAlert: thirdValidatedLiveAlert,
           competenceId: certificationChallenges.certificationChallengesForAdministration[2].competenceId,
           skillName: certificationChallenges.certificationChallengesForAdministration[2].skillName,
+          versionId,
         },
       );
 
@@ -268,7 +272,8 @@ describe('Integration | Infrastructure | Repository | v3-certification-course-de
         const certificationCourseId = 123;
         const assessmentId = 78;
 
-        databaseBuilder.factory.buildCertificationCourse({ id: certificationCourseId });
+        const versionId = databaseBuilder.factory.buildCertificationVersion({ scope: SCOPES.PIX_PLUS_DROIT }).id;
+        databaseBuilder.factory.buildCertificationCourse({ id: certificationCourseId, versionId });
         databaseBuilder.factory.buildAssessment({
           id: assessmentId,
           certificationCourseId,

--- a/api/tests/certification/session-management/unit/domain/usecases/get-v3-certification-course-details-for-administration_test.js
+++ b/api/tests/certification/session-management/unit/domain/usecases/get-v3-certification-course-details-for-administration_test.js
@@ -13,8 +13,6 @@ describe('Unit | UseCase | get-certification-course-details-for-administration',
     const skillName = 'skillName';
     const competenceName = 'competenceName';
     const competenceIndex = '1.2';
-    const reconciledAt = new Date(2024, 1, 15);
-    const scope = 'scope';
     const numberOfChallenges = 64;
 
     const v3CertificationCourseDetailsForAdministrationRepository = {
@@ -25,16 +23,8 @@ describe('Unit | UseCase | get-certification-course-details-for-administration',
       list: sinon.stub(),
     };
 
-    const certificationCandidateRepository = {
-      getByCertificationCourseId: sinon.stub(),
-    };
-
-    const sharedCertificationCourseRepository = {
-      getCertificationScope: sinon.stub(),
-    };
-
     const evaluationVersionRepository = {
-      getByScopeAndReconciliationDate: sinon.stub(),
+      getById: sinon.stub(),
     };
 
     const competences = [
@@ -57,10 +47,7 @@ describe('Unit | UseCase | get-certification-course-details-for-administration',
       certificationCourseId,
       numberOfChallenges: null,
       certificationChallengesForAdministration: [challengeForAdministration],
-    });
-
-    const candidate = domainBuilder.buildCertificationCandidate({
-      reconciledAt,
+      versionId: 123,
     });
 
     const version = {
@@ -75,23 +62,13 @@ describe('Unit | UseCase | get-certification-course-details-for-administration',
 
     competenceRepository.list.resolves(competences);
 
-    certificationCandidateRepository.getByCertificationCourseId.withArgs({ certificationCourseId }).resolves(candidate);
-
-    sharedCertificationCourseRepository.getCertificationScope
-      .withArgs({ courseId: certificationCourseId })
-      .resolves(scope);
-
-    evaluationVersionRepository.getByScopeAndReconciliationDate
-      .withArgs({ scope, reconciliationDate: reconciledAt })
-      .resolves(version);
+    evaluationVersionRepository.getById.withArgs(123).resolves(version);
 
     // when
     const details = await getV3CertificationCourseDetailsForAdministration({
       certificationCourseId,
       v3CertificationCourseDetailsForAdministrationRepository,
       competenceRepository,
-      certificationCandidateRepository,
-      sharedCertificationCourseRepository,
       evaluationVersionRepository,
     });
 

--- a/api/tests/tooling/domain-builder/factory/build-certification-course.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-course.js
@@ -35,6 +35,7 @@ function buildCertificationCourse({
   isAdjustedForAccessibility = false,
   lang,
   framework = Frameworks.CORE,
+  versionId = 20,
 } = {}) {
   const certificationIssueReports = [];
   if (examinerComment && examinerComment !== '') {
@@ -81,6 +82,7 @@ function buildCertificationCourse({
     isAdjustedForAccessibility,
     lang,
     framework,
+    versionId,
   });
 }
 

--- a/api/tests/tooling/domain-builder/factory/build-v3-certification-course-details-for-administration.js
+++ b/api/tests/tooling/domain-builder/factory/build-v3-certification-course-details-for-administration.js
@@ -14,6 +14,7 @@ export const buildV3CertificationCourseDetailsForAdministration = ({
   eduV3ExternalJuryResult,
   numberOfChallenges,
   certificationFramework,
+  versionId,
 }) => {
   return new V3CertificationCourseDetailsForAdministration({
     certificationCourseId,
@@ -29,5 +30,6 @@ export const buildV3CertificationCourseDetailsForAdministration = ({
     certificationChallengesForAdministration,
     numberOfChallenges,
     certificationFramework,
+    versionId,
   });
 };

--- a/api/tests/tooling/domain-builder/factory/certification/evaluation/build-assessment-sheet.js
+++ b/api/tests/tooling/domain-builder/factory/certification/evaluation/build-assessment-sheet.js
@@ -17,6 +17,7 @@ export const buildAssessmentSheet = function ({
   certificationCourseUpdatedAt = new Date(),
   lastAnswerAt = new Date(),
   lastQuestionDate = new Date(),
+  versionId = 4,
   answers = [],
 } = {}) {
   return new AssessmentSheet({
@@ -32,6 +33,7 @@ export const buildAssessmentSheet = function ({
     certificationCourseUpdatedAt,
     lastAnswerAt,
     lastQuestionDate,
+    versionId,
     answers,
   });
 };


### PR DESCRIPTION
## 🌱 Problème

On a fait beaucoup de modifications de données récemment et on n'a pas trop pris le temps de les exploiter.

## 🐣 Proposition

Il s'agit de faire un petit tour du propriétaire pour voir comment on récupère la version du référentiel de certification pour un test de certif donné, et d'exploiter le fait de pouvoir trouver directement cette valeur au niveau du "certification-course", plutôt que de faire l'ancienne stratégie consistant à récupérer la date de réconciliation du candidat pour trouver la bonne version.

## 🌷 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🐝 Pour tester
Non rég tests e2e OK ✅ 
