### PR TITLE
[TECH] Ajouter un script pour rétroremplir la colonne "lastAnswerAt" de la table "certification-courses" (PIX-22325)

### DIFF
--- a/api/scripts/certification/fill-last-answer-at-column.js
+++ b/api/scripts/certification/fill-last-answer-at-column.js
@@ -1,0 +1,96 @@
+import { setTimeout } from 'node:timers/promises';
+
+import { knex } from '../../db/knex-database-connection.js';
+import { Script } from '../../src/shared/application/scripts/script.js';
+import { ScriptRunner } from '../../src/shared/application/scripts/script-runner.js';
+import { DomainTransaction } from '../../src/shared/domain/DomainTransaction.js';
+import { batchUpdate } from '../../src/shared/infrastructure/utils/knex-utils.js';
+
+export class FillLastAnswerAtColumn extends Script {
+  constructor() {
+    super({
+      description: 'Retro-fill the "lastAnswerAt" column in "certification-courses" table',
+      permanent: false,
+      options: {
+        dryRun: {
+          type: 'boolean',
+          describe: 'Run the script without making any database changes',
+          default: true,
+        },
+        throttleDelay: {
+          type: 'number',
+          describe: 'The throttle delay',
+          default: 200,
+        },
+        chunkSize: {
+          type: 'number',
+          describe: 'Number of certifications handled at the same time',
+          default: 2000,
+        },
+        startId: {
+          type: 'number',
+          describe: 'ID of the certification on which we start the process',
+          default: 1,
+        },
+      },
+    });
+  }
+
+  async handle({ logger, options }) {
+    const { dryRun, chunkSize, throttleDelay, startId } = options;
+    logger.info(`Script execution started with options ${JSON.stringify(options)}`);
+    let cntTotalCertificationsHandled = 0;
+    let currentStartId = startId;
+    const [{ max }] = await knex('certification-courses').max('id');
+    let certificationDataToProcess = await findNextCertificationsToProcess(currentStartId, chunkSize);
+    while (currentStartId <= max) {
+      try {
+        await DomainTransaction.execute(async () => {
+          if (certificationDataToProcess.length > 0) {
+            await batchUpdate({
+              schema: 'public',
+              tableName: 'certification-courses',
+              primaryKeyName: 'id',
+              rows: certificationDataToProcess,
+              chunkSize,
+            });
+            if (dryRun) {
+              throw new Error('DRYRUN');
+            }
+          }
+        });
+      } catch (error) {
+        if (!error?.message?.includes('DRYRUN')) {
+          logger.error(`An error happened in batch ${currentStartId} - ${currentStartId + chunkSize - 1} : ${error}`);
+          logger.info(
+            `Script interrupted. Number of certifications processed so far : ${cntTotalCertificationsHandled}`,
+          );
+          throw error;
+        }
+      }
+      logger.info(`Batch from ${currentStartId} to ${currentStartId + chunkSize - 1} done`);
+      cntTotalCertificationsHandled += certificationDataToProcess.length;
+      currentStartId += chunkSize;
+      certificationDataToProcess = await findNextCertificationsToProcess(currentStartId, chunkSize);
+      await setTimeout(throttleDelay);
+    }
+    logger.info(`Script finished. Number of certifications processed : ${cntTotalCertificationsHandled}, youpi`);
+  }
+}
+
+async function findNextCertificationsToProcess(startId, chunkSize) {
+  const results = await knex.raw(
+    `
+        SELECT DISTINCT ON ("cc"."id") "cc"."id", "ans"."createdAt" AS "lastAnswerAt"
+        FROM "certification-courses" AS "cc"
+        LEFT JOIN "assessments" AS "ass" ON "ass"."certificationCourseId" = "cc"."id"
+        LEFT JOIN "answers" AS "ans" ON "ans"."assessmentId" = "ass"."id"
+        WHERE "cc"."id" >= ? AND "cc"."id" < ?
+        ORDER BY "cc"."id" ASC, "ans"."createdAt" DESC
+    `,
+    [startId, startId + chunkSize],
+  );
+  return results.rows;
+}
+
+await ScriptRunner.execute(import.meta.url, FillLastAnswerAtColumn);

--- a/api/scripts/certification/fill-last-answer-at-column.js
+++ b/api/scripts/certification/fill-last-answer-at-column.js
@@ -40,7 +40,6 @@ export class FillLastAnswerAtColumn extends Script {
     const { dryRun, chunkSize, throttleDelay, startId } = options;
     logger.info(`Script execution started with options ${JSON.stringify(options)}`);
     let cntTotalCertificationsHandled = 0;
-    let cntTotalCertificationsUpdated = 0;
     let currentStartId = startId;
     const [{ max }] = await knex('certification-courses').max('id');
     let certificationDataToProcess = await findNextCertificationsToProcess(currentStartId, chunkSize);
@@ -55,9 +54,6 @@ export class FillLastAnswerAtColumn extends Script {
               rows: certificationDataToProcess,
               chunkSize,
             });
-            cntTotalCertificationsUpdated += certificationDataToProcess.filter((data) =>
-              Boolean(data.lastAnswerAt),
-            ).length;
             if (dryRun) {
               throw new Error('DRYRUN');
             }
@@ -78,9 +74,7 @@ export class FillLastAnswerAtColumn extends Script {
       certificationDataToProcess = await findNextCertificationsToProcess(currentStartId, chunkSize);
       await setTimeout(throttleDelay);
     }
-    logger.info(
-      `Script finished. Number of certifications processed : ${cntTotalCertificationsHandled}, number of certifications updated with a lastAnswer date : ${cntTotalCertificationsUpdated}, youpi`,
-    );
+    logger.info(`Script finished. Number of certifications processed : ${cntTotalCertificationsHandled}, youpi`);
   }
 }
 
@@ -89,8 +83,8 @@ async function findNextCertificationsToProcess(startId, chunkSize) {
     `
         SELECT DISTINCT ON ("cc"."id") "cc"."id", "ans"."createdAt" AS "lastAnswerAt"
         FROM "certification-courses" AS "cc"
-        LEFT JOIN "assessments" AS "ass" ON "ass"."certificationCourseId" = "cc"."id"
-        LEFT JOIN "answers" AS "ans" ON "ans"."assessmentId" = "ass"."id"
+        JOIN "assessments" AS "ass" ON "ass"."certificationCourseId" = "cc"."id"
+        JOIN "answers" AS "ans" ON "ans"."assessmentId" = "ass"."id"
         WHERE "cc"."id" >= ? AND "cc"."id" < ?
         ORDER BY "cc"."id" ASC, "ans"."createdAt" DESC
     `,

--- a/api/scripts/certification/fill-last-answer-at-column.js
+++ b/api/scripts/certification/fill-last-answer-at-column.js
@@ -40,6 +40,7 @@ export class FillLastAnswerAtColumn extends Script {
     const { dryRun, chunkSize, throttleDelay, startId } = options;
     logger.info(`Script execution started with options ${JSON.stringify(options)}`);
     let cntTotalCertificationsHandled = 0;
+    let cntTotalCertificationsUpdated = 0;
     let currentStartId = startId;
     const [{ max }] = await knex('certification-courses').max('id');
     let certificationDataToProcess = await findNextCertificationsToProcess(currentStartId, chunkSize);
@@ -54,6 +55,9 @@ export class FillLastAnswerAtColumn extends Script {
               rows: certificationDataToProcess,
               chunkSize,
             });
+            cntTotalCertificationsUpdated += certificationDataToProcess.filter((data) =>
+              Boolean(data.lastAnswerAt),
+            ).length;
             if (dryRun) {
               throw new Error('DRYRUN');
             }
@@ -74,7 +78,9 @@ export class FillLastAnswerAtColumn extends Script {
       certificationDataToProcess = await findNextCertificationsToProcess(currentStartId, chunkSize);
       await setTimeout(throttleDelay);
     }
-    logger.info(`Script finished. Number of certifications processed : ${cntTotalCertificationsHandled}, youpi`);
+    logger.info(
+      `Script finished. Number of certifications processed : ${cntTotalCertificationsHandled}, number of certifications updated with a lastAnswer date : ${cntTotalCertificationsUpdated}, youpi`,
+    );
   }
 }
 

--- a/api/scripts/certification/fill-last-answer-at-column.js
+++ b/api/scripts/certification/fill-last-answer-at-column.js
@@ -81,12 +81,20 @@ export class FillLastAnswerAtColumn extends Script {
 async function findNextCertificationsToProcess(startId, chunkSize) {
   const results = await knex.raw(
     `
-        SELECT DISTINCT ON ("cc"."id") "cc"."id", "ans"."createdAt" AS "lastAnswerAt"
-        FROM "certification-courses" AS "cc"
-        JOIN "assessments" AS "ass" ON "ass"."certificationCourseId" = "cc"."id"
-        JOIN "answers" AS "ans" ON "ans"."assessmentId" = "ass"."id"
-        WHERE "cc"."id" >= ? AND "cc"."id" < ?
-        ORDER BY "cc"."id" ASC, "ans"."createdAt" DESC
+      SELECT
+        cc.id,
+        latest_ans."lastAnswerAt"
+      FROM "certification-courses" AS cc
+      CROSS JOIN LATERAL (
+        SELECT ans."createdAt" AS "lastAnswerAt"
+        FROM "assessments" AS ass
+        JOIN "answers" AS ans ON ans."assessmentId" = ass.id
+        WHERE ass."certificationCourseId" = cc.id
+        ORDER BY ans."createdAt" DESC
+        LIMIT 1
+      ) AS latest_ans
+      WHERE cc.id >= ? AND cc.id < ?
+      ORDER BY cc.id ASC
     `,
     [startId, startId + chunkSize],
   );

--- a/api/tests/certification/evaluation/unit/domain/models/AssessmentSheet_test.js
+++ b/api/tests/certification/evaluation/unit/domain/models/AssessmentSheet_test.js
@@ -235,6 +235,7 @@ describe('Certification | Evaluation | Unit | Domain | Models | AssessmentSheet'
         isRejectedForFraud: true,
         answers: [domainBuilder.buildAnswer()],
         assessmentUpdatedAt: new Date('2022-01-01'),
+        lastQuestionDate: new Date('2021-09-09'),
       };
     });
 

--- a/api/tests/certification/scripts/fill-last-answer-at-column_test.js
+++ b/api/tests/certification/scripts/fill-last-answer-at-column_test.js
@@ -72,7 +72,9 @@ describe('Certification | Scripts | fill lastAnswerAt column', function () {
       expect(logger.info).to.have.been.calledWith(
         `Script execution started with options {"dryRun":true,"throttleDelay":5,"chunkSize":2,"startId":${certificationCourseWithoutAssessmentId - 1}}`,
       );
-      expect(logger.info).to.have.been.calledWith('Script finished. Number of certifications processed : 4, youpi');
+      expect(logger.info).to.have.been.calledWith(
+        'Script finished. Number of certifications processed : 4, number of certifications updated with a lastAnswer date : 2, youpi',
+      );
       expect(logger.error).to.not.have.been.called;
     });
   });
@@ -108,7 +110,9 @@ describe('Certification | Scripts | fill lastAnswerAt column', function () {
         expect(logger.info).to.have.been.calledWith(
           `Script execution started with options {"dryRun":false,"throttleDelay":5,"chunkSize":2,"startId":${certificationCourseWithoutAssessmentId - 1}}`,
         );
-        expect(logger.info).to.have.been.calledWith('Script finished. Number of certifications processed : 4, youpi');
+        expect(logger.info).to.have.been.calledWith(
+          'Script finished. Number of certifications processed : 4, number of certifications updated with a lastAnswer date : 2, youpi',
+        );
         expect(logger.error).to.not.have.been.called;
       });
     });

--- a/api/tests/certification/scripts/fill-last-answer-at-column_test.js
+++ b/api/tests/certification/scripts/fill-last-answer-at-column_test.js
@@ -72,9 +72,7 @@ describe('Certification | Scripts | fill lastAnswerAt column', function () {
       expect(logger.info).to.have.been.calledWith(
         `Script execution started with options {"dryRun":true,"throttleDelay":5,"chunkSize":2,"startId":${certificationCourseWithoutAssessmentId - 1}}`,
       );
-      expect(logger.info).to.have.been.calledWith(
-        'Script finished. Number of certifications processed : 4, number of certifications updated with a lastAnswer date : 2, youpi',
-      );
+      expect(logger.info).to.have.been.calledWith('Script finished. Number of certifications processed : 2, youpi');
       expect(logger.error).to.not.have.been.called;
     });
   });
@@ -110,9 +108,7 @@ describe('Certification | Scripts | fill lastAnswerAt column', function () {
         expect(logger.info).to.have.been.calledWith(
           `Script execution started with options {"dryRun":false,"throttleDelay":5,"chunkSize":2,"startId":${certificationCourseWithoutAssessmentId - 1}}`,
         );
-        expect(logger.info).to.have.been.calledWith(
-          'Script finished. Number of certifications processed : 4, number of certifications updated with a lastAnswer date : 2, youpi',
-        );
+        expect(logger.info).to.have.been.calledWith('Script finished. Number of certifications processed : 2, youpi');
         expect(logger.error).to.not.have.been.called;
       });
     });
@@ -120,7 +116,10 @@ describe('Certification | Scripts | fill lastAnswerAt column', function () {
     context('when an error occurs during the process', function () {
       it('persists only the batches before the error occurs', async function () {
         const sabotageHook = (queryData) => {
-          if (queryData.bindings?.[0] === certificationCourseWithoutAnswerId && queryData.bindings?.[1] === null) {
+          if (
+            queryData.bindings?.[0] === certificationCourseWithAnswers2Id &&
+            queryData.bindings?.[1] instanceof Date
+          ) {
             throw new Error('SABOTAGING_TO_TRIGGER_ROLLBACK');
           } else {
             knex.once('query', sabotageHook);
@@ -133,7 +132,7 @@ describe('Certification | Scripts | fill lastAnswerAt column', function () {
           options: {
             dryRun: false,
             throttleDelay: 5,
-            chunkSize: 2,
+            chunkSize: 1,
             startId: certificationCourseWithoutAssessmentId - 1,
           },
         });
@@ -155,10 +154,10 @@ describe('Certification | Scripts | fill lastAnswerAt column', function () {
         expect(lastAnswerAtValues[2]).to.be.null;
         expect(lastAnswerAtValues[3]).to.deep.equal(new Date('2022-12-25')); // old date not updated
         expect(logger.info).to.have.been.calledWith(
-          `Script execution started with options {"dryRun":false,"throttleDelay":5,"chunkSize":2,"startId":${certificationCourseWithoutAssessmentId - 1}}`,
+          `Script execution started with options {"dryRun":false,"throttleDelay":5,"chunkSize":1,"startId":${certificationCourseWithoutAssessmentId - 1}}`,
         );
         expect(logger.info).to.have.been.calledWith(
-          'Script interrupted. Number of certifications processed so far : 2',
+          'Script interrupted. Number of certifications processed so far : 1',
         );
         expect(logger.error).to.have.been.calledWithMatch('Error: SABOTAGING_TO_TRIGGER_ROLLBACK');
       });

--- a/api/tests/certification/scripts/fill-last-answer-at-column_test.js
+++ b/api/tests/certification/scripts/fill-last-answer-at-column_test.js
@@ -1,0 +1,163 @@
+import { FillLastAnswerAtColumn } from '../../../scripts/certification/fill-last-answer-at-column.js';
+import { catchErr, databaseBuilder, expect, knex, sinon } from '../../test-helper.js';
+
+describe('Certification | Scripts | fill lastAnswerAt column', function () {
+  let certificationCourseWithoutAssessmentId,
+    certificationCourseWithoutAnswerId,
+    certificationCourseWithAnswers1Id,
+    certificationCourseWithAnswers2Id,
+    script;
+  let logger;
+  beforeEach(function () {
+    script = new FillLastAnswerAtColumn();
+    logger = {
+      info: sinon.stub(),
+      error: sinon.stub(),
+    };
+
+    certificationCourseWithoutAssessmentId = databaseBuilder.factory.buildCertificationCourse({
+      lastAnswerAt: null,
+    }).id;
+
+    certificationCourseWithAnswers1Id = databaseBuilder.factory.buildCertificationCourse({
+      lastAnswerAt: null,
+    }).id;
+    let assessmentId = databaseBuilder.factory.buildAssessment({
+      certificationCourseId: certificationCourseWithAnswers1Id,
+    }).id;
+    databaseBuilder.factory.buildAnswer({ assessmentId, createdAt: new Date('2024-01-01') });
+    databaseBuilder.factory.buildAnswer({ assessmentId, createdAt: new Date('2025-01-01') });
+    databaseBuilder.factory.buildAnswer({ assessmentId, createdAt: new Date('2023-01-01') });
+
+    certificationCourseWithoutAnswerId = databaseBuilder.factory.buildCertificationCourse({
+      lastAnswerAt: null,
+    }).id;
+    databaseBuilder.factory.buildAssessment({ certificationCourseId: certificationCourseWithoutAnswerId });
+
+    certificationCourseWithAnswers2Id = databaseBuilder.factory.buildCertificationCourse({
+      lastAnswerAt: new Date('2022-12-25'),
+    }).id;
+    assessmentId = databaseBuilder.factory.buildAssessment({
+      certificationCourseId: certificationCourseWithAnswers2Id,
+    }).id;
+    databaseBuilder.factory.buildAnswer({ assessmentId, createdAt: new Date('2024-05-05') });
+    databaseBuilder.factory.buildAnswer({ assessmentId, createdAt: new Date('2025-05-05') });
+    databaseBuilder.factory.buildAnswer({ assessmentId, createdAt: new Date('2023-05-05') });
+
+    return databaseBuilder.commit();
+  });
+
+  context('dryRun ON', function () {
+    it('does not persist the changes', async function () {
+      await script.handle({
+        logger,
+        options: { dryRun: true, throttleDelay: 5, chunkSize: 2, startId: certificationCourseWithoutAssessmentId - 1 },
+      });
+
+      const lastAnswerAtValues = await knex
+        .pluck('lastAnswerAt')
+        .from('certification-courses')
+        .whereIn('id', [
+          certificationCourseWithoutAssessmentId,
+          certificationCourseWithoutAnswerId,
+          certificationCourseWithAnswers1Id,
+          certificationCourseWithAnswers2Id,
+        ])
+        .orderBy('id');
+      expect(lastAnswerAtValues).to.have.lengthOf(4);
+      expect(lastAnswerAtValues[0]).to.be.null;
+      expect(lastAnswerAtValues[1]).to.be.null;
+      expect(lastAnswerAtValues[2]).to.be.null;
+      expect(lastAnswerAtValues[3]).to.deep.equal(new Date('2022-12-25'));
+      expect(logger.info).to.have.been.calledWith(
+        `Script execution started with options {"dryRun":true,"throttleDelay":5,"chunkSize":2,"startId":${certificationCourseWithoutAssessmentId - 1}}`,
+      );
+      expect(logger.info).to.have.been.calledWith('Script finished. Number of certifications processed : 4, youpi');
+      expect(logger.error).to.not.have.been.called;
+    });
+  });
+
+  context('dryRun OFF', function () {
+    context('when there are no errors', function () {
+      it('persists all the changes', async function () {
+        await script.handle({
+          logger,
+          options: {
+            dryRun: false,
+            throttleDelay: 5,
+            chunkSize: 2,
+            startId: certificationCourseWithoutAssessmentId - 1,
+          },
+        });
+
+        const lastAnswerAtValues = await knex
+          .pluck('lastAnswerAt')
+          .from('certification-courses')
+          .whereIn('id', [
+            certificationCourseWithoutAssessmentId,
+            certificationCourseWithoutAnswerId,
+            certificationCourseWithAnswers1Id,
+            certificationCourseWithAnswers2Id,
+          ])
+          .orderBy('id');
+        expect(lastAnswerAtValues).to.have.lengthOf(4);
+        expect(lastAnswerAtValues[0]).to.be.null;
+        expect(lastAnswerAtValues[1]).to.deep.equal(new Date('2025-01-01'));
+        expect(lastAnswerAtValues[2]).to.be.null;
+        expect(lastAnswerAtValues[3]).to.deep.equal(new Date('2025-05-05'));
+        expect(logger.info).to.have.been.calledWith(
+          `Script execution started with options {"dryRun":false,"throttleDelay":5,"chunkSize":2,"startId":${certificationCourseWithoutAssessmentId - 1}}`,
+        );
+        expect(logger.info).to.have.been.calledWith('Script finished. Number of certifications processed : 4, youpi');
+        expect(logger.error).to.not.have.been.called;
+      });
+    });
+
+    context('when an error occurs during the process', function () {
+      it('persists only the batches before the error occurs', async function () {
+        const sabotageHook = (queryData) => {
+          if (queryData.bindings?.[0] === certificationCourseWithoutAnswerId && queryData.bindings?.[1] === null) {
+            throw new Error('SABOTAGING_TO_TRIGGER_ROLLBACK');
+          } else {
+            knex.once('query', sabotageHook);
+          }
+        };
+        knex.once('query', sabotageHook);
+
+        const err = await catchErr(script.handle)({
+          logger,
+          options: {
+            dryRun: false,
+            throttleDelay: 5,
+            chunkSize: 2,
+            startId: certificationCourseWithoutAssessmentId - 1,
+          },
+        });
+
+        expect(err.message).to.equal('SABOTAGING_TO_TRIGGER_ROLLBACK');
+        const lastAnswerAtValues = await knex
+          .pluck('lastAnswerAt')
+          .from('certification-courses')
+          .whereIn('id', [
+            certificationCourseWithoutAssessmentId,
+            certificationCourseWithoutAnswerId,
+            certificationCourseWithAnswers1Id,
+            certificationCourseWithAnswers2Id,
+          ])
+          .orderBy('id');
+        expect(lastAnswerAtValues).to.have.lengthOf(4);
+        expect(lastAnswerAtValues[0]).to.be.null;
+        expect(lastAnswerAtValues[1]).to.deep.equal(new Date('2025-01-01'));
+        expect(lastAnswerAtValues[2]).to.be.null;
+        expect(lastAnswerAtValues[3]).to.deep.equal(new Date('2022-12-25')); // old date not updated
+        expect(logger.info).to.have.been.calledWith(
+          `Script execution started with options {"dryRun":false,"throttleDelay":5,"chunkSize":2,"startId":${certificationCourseWithoutAssessmentId - 1}}`,
+        );
+        expect(logger.info).to.have.been.calledWith(
+          'Script interrupted. Number of certifications processed so far : 2',
+        );
+        expect(logger.error).to.have.been.calledWithMatch('Error: SABOTAGING_TO_TRIGGER_ROLLBACK');
+      });
+    });
+  });
+});


### PR DESCRIPTION
## 🌱 Problème

On a ajouté une nouvelle colonne "lastAnswerAt" dans la table "certification-courses". Il faut la rétro-remplir.

## 🐣 Proposition

Faire un script de rétroremplissage. Ce script part de la toute première certif et parcourt toutes les certifications jusqu'à la fin

## 🌷 Remarques

A faire exécuter que lorsque le remplissage naturel sera en prod

## 🐝 Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
