### PR TITLE
[FEATURE] Ajouter un tag Tête de réseau sur la page de détail d'une organisation (PIX-22320)

### DIFF
--- a/admin/app/components/organizations/head-information.gjs
+++ b/admin/app/components/organizations/head-information.gjs
@@ -103,13 +103,6 @@ export default class HeadInformation extends Component {
         </div>
 
         <ul class="organization-tags-list">
-          {{#if this.hasChildren}}
-            <li>
-              <PixTag @color="success">
-                {{t "components.organizations.head-information.parent-organization"}}
-              </PixTag>
-            </li>
-          {{/if}}
           {{#if this.belongsToNetwork}}
             {{#if this.currentUser.adminMember.isSuperAdmin}}
               <PixTag class="organization__child-tag" @color="success">
@@ -118,18 +111,26 @@ export default class HeadInformation extends Component {
                   {{@organization.network.name}}
                 </LinkTo>
               </PixTag>
+              {{#if @organization.parentOrganizationId}}
+                <li>
+                  <PixTag class="organization__child-tag" @color="success">
+                    {{t "components.organizations.head-information.child-organization"}}
+                    <LinkTo @route="authenticated.organizations.get" @model={{@organization.parentOrganizationId}}>
+                      {{@organization.parentOrganizationName}}
+                    </LinkTo>
+                  </PixTag>
+                </li>
+              {{else}}
+                <li>
+                  <PixTag class="organization__child-tag" @color="success">
+                    {{t "components.organizations.head-information.head-organization-tag"}}
+
+                  </PixTag>
+                </li>
+              {{/if}}
             {{/if}}
           {{/if}}
-          {{#if @organization.parentOrganizationId}}
-            <li>
-              <PixTag class="organization__child-tag" @color="success">
-                {{t "components.organizations.head-information.child-organization"}}
-                <LinkTo @route="authenticated.organizations.get" @model={{@organization.parentOrganizationId}}>
-                  {{@organization.parentOrganizationName}}
-                </LinkTo>
-              </PixTag>
-            </li>
-          {{/if}}
+
           {{#if this.hasTags}}
             {{#each @organization.tags as |tag|}}
               <li>

--- a/admin/app/components/organizations/head-information.gjs
+++ b/admin/app/components/organizations/head-information.gjs
@@ -114,7 +114,7 @@ export default class HeadInformation extends Component {
               {{#if @organization.parentOrganizationId}}
                 <li>
                   <PixTag class="organization__child-tag" @color="success">
-                    {{t "components.organizations.head-information.child-organization"}}
+                    {{t "components.organizations.head-information.parent-organization-tag"}}
                     <LinkTo @route="authenticated.organizations.get" @model={{@organization.parentOrganizationId}}>
                       {{@organization.parentOrganizationName}}
                     </LinkTo>

--- a/admin/tests/integration/components/organizations/head-information-test.gjs
+++ b/admin/tests/integration/components/organizations/head-information-test.gjs
@@ -97,7 +97,7 @@ module('Integration | Component | organizations/header-information', function (h
         const screen = await render(<template><HeadInformation @organization={{organization}} /></template>);
 
         // then
-        assert.dom(screen.getByText(t('components.organizations.head-information.child-organization'))).exists();
+        assert.dom(screen.getByText(t('components.organizations.head-information.parent-organization-tag'))).exists();
         assert.dom(screen.getByRole('link', { name: 'Shibusen' })).exists();
       });
     });

--- a/admin/tests/integration/components/organizations/head-information-test.gjs
+++ b/admin/tests/integration/components/organizations/head-information-test.gjs
@@ -73,38 +73,24 @@ module('Integration | Component | organizations/header-information', function (h
       });
     });
 
-    module('when organization is parent', function () {
-      test('it should display parent label', async function (assert) {
-        //given
-        const store = this.owner.lookup('service:store');
-        const child = store.createRecord('organization', {
-          type: 'SCO',
-        });
-        const organization = store.createRecord('organization', {
-          type: 'SCO',
-          children: [child],
-        });
-
-        // when
-        const screen = await render(<template><HeadInformation @organization={{organization}} /></template>);
-
-        // then
-        assert.dom(screen.getByText(t('components.organizations.head-information.parent-organization'))).exists();
-      });
-    });
-
     module('when organization is child', function () {
       test('it displays child label and parent organization name', async function (assert) {
         //given
         const store = this.owner.lookup('service:store');
+        const network = store.push({
+          data: { id: '42', type: 'network', attributes: { name: 'Réseau Île-de-France' } },
+        });
+
         const parentOrganization = store.createRecord('organization', {
           id: '5',
           type: 'SCO',
+          network,
         });
         const organization = store.createRecord('organization', {
           type: 'SCO',
           parentOrganizationId: parentOrganization.id,
           parentOrganizationName: 'Shibusen',
+          network,
         });
 
         // when
@@ -116,28 +102,9 @@ module('Integration | Component | organizations/header-information', function (h
       });
     });
 
-    module('when organization is neither parent nor children', function () {
-      test('it displays no organization network label', async function (assert) {
-        //given
-        const store = this.owner.lookup('service:store');
-        const organization = store.createRecord('organization', {
-          type: 'SCO',
-          name: 'notParent',
-        });
-
-        // when
-        const screen = await render(<template><HeadInformation @organization={{organization}} /></template>);
-
-        // then
-        assert
-          .dom(screen.queryByText(t('components.organizations.head-information.parent-organization')))
-          .doesNotExist();
-      });
-    });
-
     module('when organization belongs to a network', function () {
       module('when user is not super admin', function () {
-        test('it does not display a tag with a link to the network', async function (assert) {
+        test('it does not display a network tag nor Head of network tag', async function (assert) {
           // given
           const currentUser = this.owner.lookup('service:currentUser');
           currentUser.adminMember = { isSuperAdmin: false };
@@ -145,13 +112,16 @@ module('Integration | Component | organizations/header-information', function (h
           const network = store.push({
             data: { id: '42', type: 'network', attributes: { name: 'Réseau Île-de-France' } },
           });
-          const organization = store.createRecord('organization', { network });
+          const headOrganization = store.createRecord('organization', { network });
 
           // when
-          const screen = await render(<template><HeadInformation @organization={{organization}} /></template>);
+          const screen = await render(<template><HeadInformation @organization={{headOrganization}} /></template>);
 
           // then
           assert.dom(screen.queryByRole('link', { name: 'Réseau Île-de-France' })).doesNotExist();
+          assert
+            .dom(screen.queryByText(t('components.organizations.head-information.head-organization-tag')))
+            .doesNotExist();
         });
       });
 
@@ -169,6 +139,25 @@ module('Integration | Component | organizations/header-information', function (h
 
           // then
           assert.dom(screen.getByRole('link', { name: 'Réseau Île-de-France' })).exists();
+        });
+
+        test('it displays Head of network tag if organization has no parent', async function (assert) {
+          //given
+          const store = this.owner.lookup('service:store');
+          const network = store.push({
+            data: { id: '42', type: 'network', attributes: { name: 'Réseau Île-de-France' } },
+          });
+
+          const organization = store.createRecord('organization', {
+            type: 'SCO',
+            network,
+          });
+
+          // when
+          const screen = await render(<template><HeadInformation @organization={{organization}} /></template>);
+
+          // then
+          assert.dom(screen.getByText(t('components.organizations.head-information.head-organization-tag'))).exists();
         });
       });
     });

--- a/admin/tests/integration/components/organizations/head-information-test.gjs
+++ b/admin/tests/integration/components/organizations/head-information-test.gjs
@@ -73,106 +73,95 @@ module('Integration | Component | organizations/header-information', function (h
       });
     });
 
-    module('when organization is child', function () {
-      test('it displays child label and parent organization name', async function (assert) {
-        //given
-        const store = this.owner.lookup('service:store');
-        const network = store.push({
-          data: { id: '42', type: 'network', attributes: { name: 'Réseau Île-de-France' } },
-        });
-
-        const parentOrganization = store.createRecord('organization', {
-          id: '5',
-          type: 'SCO',
-          network,
-        });
-        const organization = store.createRecord('organization', {
-          type: 'SCO',
-          parentOrganizationId: parentOrganization.id,
-          parentOrganizationName: 'Shibusen',
-          network,
-        });
-
-        // when
-        const screen = await render(<template><HeadInformation @organization={{organization}} /></template>);
-
-        // then
-        assert.dom(screen.getByText(t('components.organizations.head-information.parent-organization-tag'))).exists();
-        assert.dom(screen.getByRole('link', { name: 'Shibusen' })).exists();
-      });
-    });
-
-    module('when organization belongs to a network', function () {
-      module('when user is not super admin', function () {
-        test('it does not display a network tag nor Head of network tag', async function (assert) {
-          // given
-          const currentUser = this.owner.lookup('service:currentUser');
-          currentUser.adminMember = { isSuperAdmin: false };
-          const store = this.owner.lookup('service:store');
-          const network = store.push({
+    module('network tags', function () {
+      module('when organization belongs to a network', function (hooks) {
+        let network;
+        hooks.beforeEach(() => {
+          network = store.push({
             data: { id: '42', type: 'network', attributes: { name: 'Réseau Île-de-France' } },
           });
-          const headOrganization = store.createRecord('organization', { network });
+        });
+        module('when user is not super admin', function () {
+          test('it does not display a network tag nor Head of network tag', async function (assert) {
+            // given
+            const currentUser = this.owner.lookup('service:currentUser');
+            currentUser.adminMember = { isSuperAdmin: false };
+            const headOrganization = store.createRecord('organization', { network });
 
-          // when
-          const screen = await render(<template><HeadInformation @organization={{headOrganization}} /></template>);
+            // when
+            const screen = await render(<template><HeadInformation @organization={{headOrganization}} /></template>);
 
-          // then
-          assert.dom(screen.queryByRole('link', { name: 'Réseau Île-de-France' })).doesNotExist();
-          assert
-            .dom(screen.queryByText(t('components.organizations.head-information.head-organization-tag')))
-            .doesNotExist();
+            // then
+            assert.dom(screen.queryByRole('link', { name: 'Réseau Île-de-France' })).doesNotExist();
+            assert
+              .dom(screen.queryByText(t('components.organizations.head-information.head-organization-tag')))
+              .doesNotExist();
+          });
+        });
+
+        module('when user is super admin', function () {
+          test('it displays a tag with a link to the network', async function (assert) {
+            // given
+            const organization = store.createRecord('organization', { network });
+
+            // when
+            const screen = await render(<template><HeadInformation @organization={{organization}} /></template>);
+
+            // then
+            assert.dom(screen.getByRole('link', { name: 'Réseau Île-de-France' })).exists();
+          });
+
+          test('it displays parent tag with organization name as a link if organization is a child', async function (assert) {
+            //given
+            const parentOrganization = store.createRecord('organization', {
+              id: '5',
+              type: 'SCO',
+              network,
+            });
+            const organization = store.createRecord('organization', {
+              type: 'SCO',
+              parentOrganizationId: parentOrganization.id,
+              parentOrganizationName: 'Shibusen',
+              network,
+            });
+
+            // when
+            const screen = await render(<template><HeadInformation @organization={{organization}} /></template>);
+
+            // then
+            assert
+              .dom(screen.getByText(t('components.organizations.head-information.parent-organization-tag')))
+              .exists();
+            assert.dom(screen.getByRole('link', { name: 'Shibusen' })).exists();
+          });
+
+          test('it displays Head of network tag if organization has no parent', async function (assert) {
+            //given
+            const organization = store.createRecord('organization', {
+              type: 'SCO',
+              network,
+            });
+
+            // when
+            const screen = await render(<template><HeadInformation @organization={{organization}} /></template>);
+
+            // then
+            assert.dom(screen.getByText(t('components.organizations.head-information.head-organization-tag'))).exists();
+          });
         });
       });
 
-      module('when user is super admin', function () {
-        test('it displays a tag with a link to the network', async function (assert) {
+      module('when organization does not belong to a network', function () {
+        test('it does not display a network tag', async function (assert) {
           // given
-          const store = this.owner.lookup('service:store');
-          const network = store.push({
-            data: { id: '42', type: 'network', attributes: { name: 'Réseau Île-de-France' } },
-          });
-          const organization = store.createRecord('organization', { network });
+          const organization = store.createRecord('organization', { type: 'SCO' });
 
           // when
           const screen = await render(<template><HeadInformation @organization={{organization}} /></template>);
 
           // then
-          assert.dom(screen.getByRole('link', { name: 'Réseau Île-de-France' })).exists();
+          assert.dom(screen.queryByText(t('components.organizations.head-information.network'))).doesNotExist();
         });
-
-        test('it displays Head of network tag if organization has no parent', async function (assert) {
-          //given
-          const store = this.owner.lookup('service:store');
-          const network = store.push({
-            data: { id: '42', type: 'network', attributes: { name: 'Réseau Île-de-France' } },
-          });
-
-          const organization = store.createRecord('organization', {
-            type: 'SCO',
-            network,
-          });
-
-          // when
-          const screen = await render(<template><HeadInformation @organization={{organization}} /></template>);
-
-          // then
-          assert.dom(screen.getByText(t('components.organizations.head-information.head-organization-tag'))).exists();
-        });
-      });
-    });
-
-    module('when organization does not belong to a network', function () {
-      test('it does not display a network tag', async function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const organization = store.createRecord('organization', { type: 'SCO' });
-
-        // when
-        const screen = await render(<template><HeadInformation @organization={{organization}} /></template>);
-
-        // then
-        assert.dom(screen.queryByText(t('components.organizations.head-information.network'))).doesNotExist();
       });
     });
   });

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -907,14 +907,13 @@
         "required-fields-error": "Please fill in all required fields."
       },
       "head-information": {
-        "child-organization": "Parent:",
         "copy-id": "Copy ID",
         "head-organization-tag": "Head of network",
         "network": "Network:",
         "notifications": {
           "logo-update-success": "The organization logo has been updated successfully."
         },
-        "parent-organization": "Parent organization"
+        "parent-organization-tag": "Parent:"
       },
       "information-section-view": {
         "administration-team": "Administration team",

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -909,6 +909,7 @@
       "head-information": {
         "child-organization": "Parent:",
         "copy-id": "Copy ID",
+        "head-organization-tag": "Head of network",
         "network": "Network:",
         "notifications": {
           "logo-update-success": "The organization logo has been updated successfully."

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -917,6 +917,7 @@
       "head-information": {
         "child-organization": "Parent :",
         "copy-id": "Copier l'ID",
+        "head-organization-tag": "Tête de réseau",
         "network": "Réseau :",
         "notifications": {
           "logo-update-success": "Le logo de l'organisation a bien été mis à jour."

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -915,14 +915,13 @@
         "required-fields-error": "Veuillez remplir tous les champs obligatoires."
       },
       "head-information": {
-        "child-organization": "Parent :",
         "copy-id": "Copier l'ID",
         "head-organization-tag": "Tête de réseau",
         "network": "Réseau :",
         "notifications": {
           "logo-update-success": "Le logo de l'organisation a bien été mis à jour."
         },
-        "parent-organization": "Organisation mère"
+        "parent-organization-tag": "Parent :"
       },
       "information-section-view": {
         "administration-team": "Équipe en charge",


### PR DESCRIPTION
## 🌱 Problème

Avec le nouveau système de réseau sur plusieurs niveaux, il devient nécessaire de facilement identifier une organisation tête de réseau. Actuellement le seul moyen de le savoir est de le voir sur la page du réseau, ou de constater l'absence de tag _Parent_ sur cette organisation pour en déduire que c'est la tête de réseau (ce qui caractérise une organisation tête de réseau étant que celle-ci fait partie d'un réseau et n'a pas de parent)

## 🐣 Proposition

- Ajouter un tag explicite Tête de réseau

## 🌷 Remarques

- on en profite pour supprimer le tag _Organisation mère_ qui n'est maintenant plus pertinent dans le système de réseau multi-niveau
- comme tout le reste des tags relatifs aux réseaux, ceux-ci ne sont pour l'instant visibles qu'au Super Admin
- les tests du composant ont été ré-organisés pour désormais rassembler la gestion des tags relatifs au réseau

## 🐝 Pour tester
Sur Pix Admin, connecté en tant que Super Admin:
- aller sur la page d'un réseau
- naviguer vers la page de l'organisation tête de réseau
- constater le nouveau tag et la disparition de l'ancien tag _Organisation mère_
- visiter cette même organisation avec un autre rôle et constater l'absence de ce tag
