### PR TITLE
[TECH] Modifier le lien de la documentation de certification sur la banner warning (PIX-22349).

### DIFF
--- a/orga/app/components/banner/certification.gjs
+++ b/orga/app/components/banner/certification.gjs
@@ -24,7 +24,7 @@ export default class InformationBanner extends Component {
       <PixNotificationAlert @type="warning" @withIcon={{true}}>
         {{t
           "banners.certification.message"
-          documentationLink="https://cloud.pix.fr/s/DEarDXyxFxM78ps"
+          documentationLink="https://cloud.pix.fr/s/EGzJMjHfkGdCG3d"
           linkClasses="link link--banner link--bold link--underlined"
           htmlSafe=true
           year=this.year

--- a/orga/tests/integration/components/banner/certification-test.gjs
+++ b/orga/tests/integration/components/banner/certification-test.gjs
@@ -46,7 +46,7 @@ module('Integration | Component | Banner::Certification', function (hooks) {
         const link = screen.getByRole('link', { name: 'finaliser les sessions dans Pix Certif' });
 
         // then
-        assert.strictEqual(link.href, 'https://cloud.pix.fr/s/DEarDXyxFxM78ps');
+        assert.strictEqual(link.href, 'https://cloud.pix.fr/s/EGzJMjHfkGdCG3d');
       });
     });
 


### PR DESCRIPTION
## 🌱 Problème

Le lien est cassé sur la banner de certif

## 🐣 Proposition

la corriger

## 🌷 Remarques

RAS

## 🐝 Pour tester

Vérifier que sur les organisations sco isManaging student que le lient sur la documentation de certification fonctionne.