### PR TITLE
[FEATURE] Filtrer sur l'identifiant externe sur les participations d'une campagne dans PixOrga (PIX-20537).

### DIFF
--- a/api/db/database-builder/factory/build-campaign-participation.js
+++ b/api/db/database-builder/factory/build-campaign-participation.js
@@ -13,7 +13,7 @@ const buildCampaignParticipation = function ({
   sharedAt = new Date('2020-01-02'),
   userId,
   organizationLearnerId,
-  participantExternalId = 'participantExternalId',
+  participantExternalId,
   validatedSkillsCount,
   masteryRate,
   pixScore,
@@ -27,7 +27,7 @@ const buildCampaignParticipation = function ({
   organizationLearnerId =
     organizationLearnerId === undefined ? buildOrganizationLearner({ userId }).id : organizationLearnerId;
   campaignId = campaignId === undefined ? buildCampaign().id : campaignId;
-
+  participantExternalId = participantExternalId ?? `externalId-${id}`;
   const isShared = status === SHARED;
   sharedAt = isShared ? sharedAt : null;
 

--- a/api/src/prescription/campaign/application/campaign-detail-route.js
+++ b/api/src/prescription/campaign/application/campaign-detail-route.js
@@ -189,6 +189,7 @@ const register = async function (server) {
                 .empty(''),
               groups: [Joi.string(), Joi.array().items(Joi.string())],
               search: Joi.string().empty(''),
+              participantExternalId: Joi.string().empty(''),
             }).default({}),
           }),
         },

--- a/api/src/prescription/campaign/application/campaign-results-route.js
+++ b/api/src/prescription/campaign/application/campaign-results-route.js
@@ -67,6 +67,7 @@ const register = async function (server) {
               divisions: Joi.array().items(Joi.string()),
               groups: Joi.array().items(Joi.string()),
               search: Joi.string().empty(''),
+              participantExternalId: Joi.string().empty(''),
               certificability: Joi.string().empty(''),
             }).default({}),
             page: {

--- a/api/src/prescription/campaign/application/campaign-results-route.js
+++ b/api/src/prescription/campaign/application/campaign-results-route.js
@@ -28,6 +28,7 @@ const register = async function (server) {
               groups: Joi.array().items(Joi.string()),
               badges: Joi.array().items(Joi.number().integer()),
               unacquiredBadges: Joi.array().items(Joi.number().integer()),
+              participantExternalId: Joi.string().empty(''),
               stages: Joi.array().items(Joi.number().integer()),
               search: Joi.string().empty(''),
             }).default({}),

--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-assessment-participation-result-list-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-assessment-participation-result-list-repository.js
@@ -38,6 +38,7 @@ const getParticipantsResultList = (campaignId, filters) => {
     .modify(filterByAcquiredBadges, filters)
     .modify(filterByUnacquiredBadges, filters)
     .modify(filterByStage, filters)
+    .modify(filterByParticipantExternalId, filters)
     .orderByRaw('LOWER(??) ASC, LOWER(??) ASC', ['lastName', 'firstName']);
 };
 
@@ -97,6 +98,15 @@ const filterByDivisions = (queryBuilder, filters) => {
     queryBuilder.whereRaw('LOWER("view-active-organization-learners"."division") = ANY(:divisionsLowerCase)', {
       divisionsLowerCase,
     });
+  }
+};
+
+const filterByParticipantExternalId = (queryBuilder, filters) => {
+  if (filters.participantExternalId) {
+    queryBuilder.whereRaw('LOWER(??) LIKE ?', [
+      'campaign_participation_summaries.participantExternalId',
+      `%${filters.participantExternalId.trim().toLowerCase()}%`,
+    ]);
   }
 };
 

--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-participant-activity-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-participant-activity-repository.js
@@ -13,12 +13,15 @@ export class ParticipantActivityFilters {
   #groups;
   /** @type string[] */
   #divisions;
+  /** @type string */
+  #participantExternalId;
 
-  constructor({ status = null, search = null, groups = [], divisions = [] }) {
+  constructor({ status = null, search = null, groups = [], divisions = [], participantExternalId = null }) {
     this.#status = status;
     this.search = search;
     this.#groups = groups;
     this.#divisions = divisions;
+    this.#participantExternalId = participantExternalId;
   }
 
   get participationStatus() {
@@ -39,6 +42,10 @@ export class ParticipantActivityFilters {
 
   get showNotStarted() {
     return this.#status === 'NOT_STARTED';
+  }
+
+  get participantExternalId() {
+    return this.#participantExternalId;
   }
 }
 
@@ -107,7 +114,8 @@ function filterParticipations(queryBuilder, filters, knexConn) {
     .modify(filterByDivisions, filters, knexConn)
     .modify(filterByStatus, filters)
     .modify(filterByGroup, filters, knexConn)
-    .modify(filterBySearch, filters);
+    .modify(filterBySearch, filters)
+    .modify(filterByParticipantExternalId, filters);
 }
 
 function filterBySearch(queryBuilder, filters) {
@@ -138,6 +146,15 @@ function filterByStatus(queryBuilder, filters) {
 function filterByGroup(queryBuilder, filters, knexConn) {
   if (filters.groups) {
     queryBuilder.whereIn(knexConn.raw('LOWER("view-active-organization-learners"."group")'), filters.groups);
+  }
+}
+
+function filterByParticipantExternalId(queryBuilder, filters) {
+  if (filters.participantExternalId) {
+    queryBuilder.whereRaw('LOWER(??) LIKE ?', [
+      'campaign-participations.participantExternalId',
+      `%${filters.participantExternalId.trim().toLowerCase()}%`,
+    ]);
   }
 }
 

--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-participant-activity-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-participant-activity-repository.js
@@ -1,3 +1,4 @@
+import { CAMPAIGN_FEATURES } from '../../../../shared/domain/constants.js';
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { filterByFullName } from '../../../../shared/infrastructure/utils/filter-utils.js';
 import { fetchPage } from '../../../../shared/infrastructure/utils/knex-utils.js';
@@ -46,6 +47,15 @@ const campaignParticipantActivityRepository = {
     const knexConn = DomainTransaction.getConnection();
     const activityFilters = new ParticipantActivityFilters(filters);
 
+    const externalIdFeature = await knexConn('campaign-features')
+      .select('campaign-features.id')
+      .join('features', 'features.id', 'featureId')
+      .where({
+        campaignId,
+        'features.key': CAMPAIGN_FEATURES.EXTERNAL_ID.key,
+      })
+      .first();
+
     const query = knexConn('view-active-organization-learners')
       .select(
         'view-active-organization-learners.id AS organizationLearnerId',
@@ -77,7 +87,13 @@ const campaignParticipantActivityRepository = {
 
     const { results, pagination } = await fetchPage({ queryBuilder: query, paginationParams: page });
 
-    const campaignParticipantsActivities = results.map((result) => new CampaignParticipantActivity(result));
+    const campaignParticipantsActivities = results.map(
+      (result) =>
+        new CampaignParticipantActivity({
+          ...result,
+          participantExternalId: externalIdFeature ? result.participantExternalId : undefined,
+        }),
+    );
 
     return {
       campaignParticipantsActivities,

--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-profiles-collection-participation-summary-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-profiles-collection-participation-summary-repository.js
@@ -156,6 +156,12 @@ function _filterQuery(queryBuilder, filters, knexConn) {
   if (isBoolean(filters.certificability)) {
     queryBuilder.where('campaign-participations.isCertifiable', filters.certificability);
   }
+  if (filters.participantExternalId) {
+    queryBuilder.whereRaw('LOWER(??) LIKE ?', [
+      'campaign-participations.participantExternalId',
+      `%${filters.participantExternalId.trim().toLowerCase()}%`,
+    ]);
+  }
 }
 
 export { findPaginatedByCampaignId };

--- a/api/tests/prescription/campaign-participation/acceptance/application/campaign-participation-route_test.js
+++ b/api/tests/prescription/campaign-participation/acceptance/application/campaign-participation-route_test.js
@@ -584,7 +584,7 @@ describe('Acceptance | Campaign Participation | Application | Route', function (
             'can-retry': false,
             'can-reset': false,
             'is-disabled': false,
-            'participant-external-id': 'participantExternalId',
+            'participant-external-id': campaignParticipation.participantExternalId,
             'remaining-seconds-before-retrying': 3600 * 24 * 3,
             'shared-at': recentDate,
           },

--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -37,6 +37,7 @@ describe('Integration | Repository | Campaign Participation', function () {
           campaignId,
           status: STARTED,
           sharedAt: null,
+          participantExternalId: 'participantExternalId',
         });
 
         ke = databaseBuilder.factory.buildKnowledgeElement({
@@ -147,6 +148,7 @@ describe('Integration | Repository | Campaign Participation', function () {
           userId,
           status: STARTED,
           sharedAt: null,
+          participantExternalId: 'participantExternalId',
         });
         const knowledgeElement1 = domainBuilder.buildKnowledgeElement({
           userId,

--- a/api/tests/prescription/campaign/acceptance/application/campaign-detail-route_test.js
+++ b/api/tests/prescription/campaign/acceptance/application/campaign-detail-route_test.js
@@ -318,10 +318,21 @@ describe('Acceptance | API | campaign-detail-route', function () {
     let organizationLearner1;
     let organizationLearner2;
     let organizationLearner3;
+    let campaignParticipation2;
 
     beforeEach(async function () {
       const organizationId = databaseBuilder.factory.buildOrganization().id;
       campaign = databaseBuilder.factory.buildCampaign({ organizationId: organizationId });
+
+      const featureId = databaseBuilder.factory.buildFeature({
+        key: CAMPAIGN_FEATURES.EXTERNAL_ID.key,
+        description: CAMPAIGN_FEATURES.EXTERNAL_ID.description,
+      }).id;
+
+      databaseBuilder.factory.buildCampaignFeature({
+        campaignId: campaign.id,
+        featureId,
+      });
 
       userId = databaseBuilder.factory.buildUser().id;
       databaseBuilder.factory.buildMembership({ userId, organizationId: organizationId });
@@ -349,15 +360,18 @@ describe('Acceptance | API | campaign-detail-route', function () {
         sharedAt: new Date(2010, 1, 1),
         campaignId: campaign.id,
         organizationLearnerId: organizationLearner1.id,
+        participantExternalId: 'johnm',
       });
-      databaseBuilder.factory.buildCampaignParticipation({
+      campaignParticipation2 = databaseBuilder.factory.buildCampaignParticipation({
         campaignId: campaign.id,
         status: STARTED,
         organizationLearnerId: organizationLearner2.id,
+        participantExternalId: 'hollym',
       });
       databaseBuilder.factory.buildCampaignParticipation({
         campaignId: campaign.id,
         organizationLearnerId: organizationLearner3.id,
+        participantExternalId: 'marrym',
       });
 
       return databaseBuilder.commit();
@@ -448,6 +462,21 @@ describe('Acceptance | API | campaign-detail-route', function () {
       const participation = response.result.data[0].attributes;
       expect(response.result.data).to.have.lengthOf(1);
       expect(participation['first-name']).to.equal(organizationLearner3.firstName);
+    });
+
+    it('should return the campaign participant activity filtered by participantExternalId', async function () {
+      const options = {
+        method: 'GET',
+        url: `/api/campaigns/${campaign.id}/participants-activity?filter[participantExternalId]=hol`,
+        headers: generateAuthenticatedUserRequestHeaders({ userId }),
+      };
+
+      const response = await server.inject(options);
+
+      expect(response.statusCode).to.equal(200);
+      const participation = response.result.data[0].attributes;
+      expect(response.result.data).to.have.lengthOf(1);
+      expect(participation['participant-external-id']).to.equal(campaignParticipation2.participantExternalId);
     });
 
     it('should return 400 when status is not valid', async function () {

--- a/api/tests/prescription/campaign/integration/domain/usecases/find-paginated-campaign-participant-activities_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/find-paginated-campaign-participant-activities_test.js
@@ -18,7 +18,7 @@ describe('Integration | UseCase | find-paginated-campaign-participant-activities
     await databaseBuilder.commit();
   });
 
-  context('when requesting user is not allowed to access campaign informations', function () {
+  context('when requesting user is not allowed to access campaign information', function () {
     it('should throw a UserNotAuthorizedToAccessEntityError error', async function () {
       // when
       const error = await catchErr(usecases.findPaginatedCampaignParticipantActivities)({
@@ -36,7 +36,7 @@ describe('Integration | UseCase | find-paginated-campaign-participant-activities
     beforeEach(async function () {
       databaseBuilder.factory.buildMembership({ organizationId, userId });
       databaseBuilder.factory.buildCampaignParticipation({
-        participantExternalId: 'Ashitaka',
+        id: 1,
         campaignId,
         organizationLearnerId: organizationLearner.id,
         userId: organizationLearner.userId,
@@ -52,7 +52,7 @@ describe('Integration | UseCase | find-paginated-campaign-participant-activities
         page,
       });
       expect(campaignParticipantsActivities).lengthOf(1);
-      expect(campaignParticipantsActivities[0].participantExternalId).to.equal('Ashitaka');
+      expect(campaignParticipantsActivities[0].lastCampaignParticipationId).to.equal(1);
     });
   });
 
@@ -73,12 +73,12 @@ describe('Integration | UseCase | find-paginated-campaign-participant-activities
         organizationId,
       });
       databaseBuilder.factory.buildCampaignParticipation({
-        participantExternalId: 'Yubaba',
+        id: 1,
         campaignId,
         organizationLearnerId: organizationLearner1.id,
       });
       databaseBuilder.factory.buildCampaignParticipation({
-        participantExternalId: 'Meï',
+        id: 2,
         campaignId,
         organizationLearnerId: organizationLearner2.id,
       });
@@ -93,7 +93,7 @@ describe('Integration | UseCase | find-paginated-campaign-participant-activities
         filters: { divisions: ['6eme'] },
       });
 
-      expect(campaignParticipantsActivities[0].participantExternalId).to.equal('Yubaba');
+      expect(campaignParticipantsActivities[0].lastCampaignParticipationId).to.equal(1);
     });
 
     it('returns the campaignParticipantsActivities filtered by the search', async function () {

--- a/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-assessment-participation-result-list-repository_test.js
+++ b/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-assessment-participation-result-list-repository_test.js
@@ -1508,5 +1508,121 @@ describe('Integration | Repository | Campaign Assessment Participation Result Li
         expect(participations[1].firstName).to.equal('Saphira');
       });
     });
+
+    context('when there is a filter on the participant externalId', function () {
+      beforeEach(async function () {
+        // given
+        campaign = databaseBuilder.factory.buildAssessmentCampaignForSkills({}, [{ id: 'Skill1' }]);
+
+        await databaseBuilder.commit();
+
+        const learningContent = [
+          {
+            id: 'recArea1',
+            competences: [
+              {
+                id: 'recCompetence1',
+                tubes: [
+                  {
+                    id: 'recTube1',
+                    skills: [{ id: 'Skill1', name: '@Acquis1', challenges: [] }],
+                  },
+                ],
+              },
+            ],
+          },
+        ];
+        const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
+        await mockLearningContent(learningContentObjects);
+      });
+
+      it('returns all participants if the filter is empty', async function () {
+        // given
+        databaseBuilder.factory.buildAssessmentFromParticipation(
+          {
+            participantExternalId: 'The girl',
+            campaignId: campaign.id,
+          },
+          {
+            firstName: 'Saphira',
+            lastName: 'Eurasier',
+          },
+        );
+
+        await databaseBuilder.commit();
+
+        // when
+        const { participations } = await campaignAssessmentParticipationResultListRepository.findPaginatedByCampaignId({
+          campaignId: campaign.id,
+          filters: { participantExternalId: '' },
+        });
+
+        // then
+        expect(participations).to.have.lengthOf(1);
+      });
+
+      it('return Choupette participant when we search part of participant external Id', async function () {
+        // given
+        databaseBuilder.factory.buildAssessmentFromParticipation(
+          {
+            participantExternalId: 'The girl',
+            campaignId: campaign.id,
+          },
+          {
+            firstName: 'Choupette',
+            lastName: 'Eurasier',
+          },
+        );
+
+        databaseBuilder.factory.buildAssessmentFromParticipation(
+          {
+            participantExternalId: 'The boy',
+            campaignId: campaign.id,
+          },
+          {
+            firstName: 'Salto',
+            lastName: 'Irish terrier',
+          },
+        );
+
+        await databaseBuilder.commit();
+
+        // when
+        const { participations } = await campaignAssessmentParticipationResultListRepository.findPaginatedByCampaignId({
+          campaignId: campaign.id,
+          filters: { participantExternalId: 'girl' },
+        });
+
+        // then
+        expect(participations).to.have.lengthOf(1);
+        expect(participations[0].firstName).to.equal('Choupette');
+      });
+
+      it('return Choupette participant when search contains a space', async function () {
+        // given
+        databaseBuilder.factory.buildAssessmentFromParticipation(
+          {
+            participantExternalId: 'girl',
+            campaignId: campaign.id,
+          },
+          {
+            firstName: 'Choupette',
+            lastName: 'Eurasier',
+          },
+        );
+
+        await databaseBuilder.commit();
+
+        // when
+        const { participations } = await campaignAssessmentParticipationResultListRepository.findPaginatedByCampaignId({
+          campaignId: campaign.id,
+          filters: { participantExternalId: ' girl ' },
+        });
+
+        // then
+        expect(participations).to.have.lengthOf(1);
+        expect(participations[0].firstName).to.equal('Choupette');
+      });
+    });
   });
 });

--- a/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-participant-activity-repository_test.js
+++ b/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-participant-activity-repository_test.js
@@ -1,17 +1,18 @@
 import { campaignParticipantActivityRepository } from '../../../../../../src/prescription/campaign/infrastructure/repositories/campaign-participant-activity-repository.js';
 import { CampaignParticipationStatuses } from '../../../../../../src/prescription/shared/domain/constants.js';
+import { CAMPAIGN_FEATURES } from '../../../../../../src/shared/domain/constants.js';
 import { databaseBuilder, expect } from '../../../../../test-helper.js';
 
 const { STARTED, SHARED } = CampaignParticipationStatuses;
 
 describe('Integration | Repository | Campaign Participant activity', function () {
   describe('#findPaginatedByCampaignId', function () {
-    context('When there is participations for another campaign', function () {
+    context('When there is participation for another campaign', function () {
       it('Returns a participation activity for each participant of the given campaign', async function () {
         const campaign = databaseBuilder.factory.buildCampaign();
         const otherCampaign = databaseBuilder.factory.buildCampaign();
 
-        const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({
+        const organizationLearnerId1 = databaseBuilder.factory.buildOrganizationLearner({
           organizationId: campaign.organizationId,
         }).id;
         const organizationLearnerId2 = databaseBuilder.factory.buildOrganizationLearner({
@@ -19,18 +20,18 @@ describe('Integration | Repository | Campaign Participant activity', function ()
         }).id;
 
         databaseBuilder.factory.buildCampaignParticipation({
-          organizationLearnerId,
-          participantExternalId: 'The good',
+          id: 1,
+          organizationLearnerId: organizationLearnerId1,
           campaignId: campaign.id,
         });
         databaseBuilder.factory.buildCampaignParticipation({
-          organizationLearnerId,
-          participantExternalId: 'The bad',
+          id: 2,
+          organizationLearnerId: organizationLearnerId1,
           campaignId: otherCampaign.id,
         });
         databaseBuilder.factory.buildCampaignParticipation({
+          id: 3,
           organizationLearnerId: organizationLearnerId2,
-          participantExternalId: 'The ugly',
           campaignId: campaign.id,
         });
 
@@ -40,9 +41,11 @@ describe('Integration | Repository | Campaign Participant activity', function ()
           await campaignParticipantActivityRepository.findPaginatedByCampaignId({
             campaignId: campaign.id,
           });
-        const participantExternalIds = campaignParticipantsActivities.map((activity) => activity.participantExternalId);
+        const lastCampaignParticipationIds = campaignParticipantsActivities.map(
+          (activity) => activity.lastCampaignParticipationId,
+        );
 
-        expect(participantExternalIds).to.exactlyContain(['The good', 'The ugly']);
+        expect(lastCampaignParticipationIds).to.exactlyContain([1, 3]);
       });
     });
 
@@ -74,7 +77,7 @@ describe('Integration | Repository | Campaign Participant activity', function ()
       });
     });
 
-    context('When there are several participations for the same participant', function () {
+    context('When there are several participation for the same participant', function () {
       it('Returns one CampaignParticipantActivity with the most recent participation (isImproved = false)', async function () {
         // given
         const campaign = databaseBuilder.factory.buildCampaign();
@@ -85,7 +88,7 @@ describe('Integration | Repository | Campaign Participant activity', function ()
         });
 
         databaseBuilder.factory.buildCampaignParticipation({
-          participantExternalId: 'The bad',
+          id: 1,
           organizationLearnerId: learner.id,
           campaignId: campaign.id,
           status: SHARED,
@@ -94,7 +97,7 @@ describe('Integration | Repository | Campaign Participant activity', function ()
         });
 
         databaseBuilder.factory.buildCampaignParticipation({
-          participantExternalId: 'The good',
+          id: 2,
           campaignId: campaign.id,
           status: STARTED,
           userId: user.id,
@@ -112,7 +115,7 @@ describe('Integration | Repository | Campaign Participant activity', function ()
 
         //then
         expect(campaignParticipantsActivities).to.have.lengthOf(1);
-        expect(campaignParticipantsActivities[0].participantExternalId).to.equal('The good');
+        expect(campaignParticipantsActivities[0].lastCampaignParticipationId).to.equal(2);
         expect(campaignParticipantsActivities[0].participationCount).to.equal(2);
       });
 
@@ -183,6 +186,84 @@ describe('Integration | Repository | Campaign Participant activity', function ()
           });
         //then
         expect(campaignParticipantsActivities[0].lastCampaignParticipationId).to.equal(lastParticipation.id);
+      });
+    });
+
+    context('when the campaign has the EXTERNAL_ID campaign feature', function () {
+      it('should return the participantExternalIdentifier', async function () {
+        const campaign = databaseBuilder.factory.buildCampaign();
+
+        const featureId = databaseBuilder.factory.buildFeature({
+          key: CAMPAIGN_FEATURES.EXTERNAL_ID.key,
+          description: CAMPAIGN_FEATURES.EXTERNAL_ID.description,
+        }).id;
+
+        databaseBuilder.factory.buildCampaignFeature({
+          campaignId: campaign.id,
+          featureId,
+        });
+
+        const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId: campaign.organizationId,
+        }).id;
+        const organizationLearnerId2 = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId: campaign.organizationId,
+        }).id;
+
+        databaseBuilder.factory.buildCampaignParticipation({
+          organizationLearnerId,
+          participantExternalId: 'The good',
+          campaignId: campaign.id,
+        });
+        databaseBuilder.factory.buildCampaignParticipation({
+          organizationLearnerId: organizationLearnerId2,
+          participantExternalId: 'The ugly',
+          campaignId: campaign.id,
+        });
+
+        await databaseBuilder.commit();
+
+        const { campaignParticipantsActivities } =
+          await campaignParticipantActivityRepository.findPaginatedByCampaignId({
+            campaignId: campaign.id,
+          });
+        const participantExternalIds = campaignParticipantsActivities.map((activity) => activity.participantExternalId);
+
+        expect(participantExternalIds).to.exactlyContain(['The good', 'The ugly']);
+      });
+    });
+
+    context('when the campaign does not have the EXTERNAL_ID campaign feature', function () {
+      it('should not return the participantExternalIdentifier', async function () {
+        const campaign = databaseBuilder.factory.buildCampaign();
+
+        const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId: campaign.organizationId,
+        }).id;
+        const organizationLearnerId2 = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId: campaign.organizationId,
+        }).id;
+
+        databaseBuilder.factory.buildCampaignParticipation({
+          organizationLearnerId,
+          participantExternalId: 'The good',
+          campaignId: campaign.id,
+        });
+        databaseBuilder.factory.buildCampaignParticipation({
+          organizationLearnerId: organizationLearnerId2,
+          participantExternalId: 'The ugly',
+          campaignId: campaign.id,
+        });
+
+        await databaseBuilder.commit();
+
+        const { campaignParticipantsActivities } =
+          await campaignParticipantActivityRepository.findPaginatedByCampaignId({
+            campaignId: campaign.id,
+          });
+
+        expect(campaignParticipantsActivities.some(({ participantExternalId }) => participantExternalId !== undefined))
+          .to.be.false;
       });
     });
 
@@ -375,17 +456,17 @@ describe('Integration | Repository | Campaign Participant activity', function ()
         const campaign = databaseBuilder.factory.buildCampaign();
         databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
           { organizationId: campaign.organizationId, division: 'Good Guys Team' },
-          { participantExternalId: 'The good', campaignId: campaign.id },
+          { id: 1, campaignId: campaign.id },
         );
 
         databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
           { organizationId: campaign.organizationId, division: 'Bad Guys Team' },
-          { participantExternalId: 'The bad', campaignId: campaign.id },
+          { id: 2, campaignId: campaign.id },
         );
 
         databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
           { organizationId: campaign.organizationId, division: 'Ugly Guys Team' },
-          { participantExternalId: 'The ugly', campaignId: campaign.id },
+          { id: 3, campaignId: campaign.id },
         );
 
         await databaseBuilder.commit();
@@ -398,10 +479,12 @@ describe('Integration | Repository | Campaign Participant activity', function ()
             filters: { divisions: ['Good Guys Team', 'Ugly Guys Team'] },
           });
 
-        const participantExternalIds = campaignParticipantsActivities.map((result) => result.participantExternalId);
+        const lastCampaignParticipationIds = campaignParticipantsActivities.map(
+          (result) => result.lastCampaignParticipationId,
+        );
 
         // then
-        expect(participantExternalIds).to.exactlyContain(['The good', 'The ugly']);
+        expect(lastCampaignParticipationIds).to.exactlyContain([1, 3]);
         expect(pagination.rowCount).to.equal(2);
       });
     });
@@ -413,12 +496,12 @@ describe('Integration | Repository | Campaign Participant activity', function ()
 
         databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
           { organizationId: campaign.organizationId },
-          { participantExternalId: 'The good', campaignId: campaign.id, status: STARTED },
+          { id: 1, campaignId: campaign.id, status: STARTED },
         );
 
         databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
           { organizationId: campaign.organizationId },
-          { participantExternalId: 'The bad', campaignId: campaign.id, status: SHARED },
+          { id: 2, campaignId: campaign.id, status: SHARED },
         );
 
         await databaseBuilder.commit();
@@ -430,11 +513,13 @@ describe('Integration | Repository | Campaign Participant activity', function ()
             filters: { status: [STARTED] },
           });
 
-        const participantExternalIds = campaignParticipantsActivities.map((result) => result.participantExternalId);
+        const lastCampaignParticipationId = campaignParticipantsActivities.map(
+          (result) => result.lastCampaignParticipationId,
+        );
 
         // then
         expect(pagination.rowCount).to.equal(1);
-        expect(participantExternalIds).to.exactlyContain(['The good']);
+        expect(lastCampaignParticipationId).to.exactlyContain([1]);
       });
     });
 
@@ -587,17 +672,17 @@ describe('Integration | Repository | Campaign Participant activity', function ()
 
         databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
           { organizationId: campaign.organizationId, group: 'L1' },
-          { participantExternalId: 'The good', campaignId: campaign.id },
+          { id: 1, campaignId: campaign.id },
         );
 
         databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
           { organizationId: campaign.organizationId, group: 'T1' },
-          { participantExternalId: 'The bad', campaignId: campaign.id, status: 'STARTED' },
+          { id: 2, campaignId: campaign.id, status: 'STARTED' },
         );
 
         databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
           { organizationId: campaign.organizationId, group: 'T2' },
-          { participantExternalId: 'The ugly', campaignId: campaign.id, status: 'STARTED' },
+          { id: 3, campaignId: campaign.id, status: 'STARTED' },
         );
 
         await databaseBuilder.commit();
@@ -609,10 +694,12 @@ describe('Integration | Repository | Campaign Participant activity', function ()
             filters: { groups: ['L1', 'T2'] },
           });
 
-        const participantExternalIds = campaignParticipantsActivities.map((result) => result.participantExternalId);
+        const lastCampaignParticipationIds = campaignParticipantsActivities.map(
+          (result) => result.lastCampaignParticipationId,
+        );
 
         // then
-        expect(participantExternalIds).to.exactlyContain(['The good', 'The ugly']);
+        expect(lastCampaignParticipationIds).to.exactlyContain([1, 3]);
         expect(pagination.rowCount).to.equal(2);
       });
     });

--- a/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-participant-activity-repository_test.js
+++ b/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-participant-activity-repository_test.js
@@ -704,6 +704,115 @@ describe('Integration | Repository | Campaign Participant activity', function ()
       });
     });
 
+    context('when there is a filter on the participantExternalId', function () {
+      let campaign;
+
+      beforeEach(async function () {
+        // given
+        campaign = databaseBuilder.factory.buildCampaign();
+
+        const featureId = databaseBuilder.factory.buildFeature({
+          key: CAMPAIGN_FEATURES.EXTERNAL_ID.key,
+          description: CAMPAIGN_FEATURES.EXTERNAL_ID.description,
+        }).id;
+
+        databaseBuilder.factory.buildCampaignFeature({
+          campaignId: campaign.id,
+          featureId,
+        });
+
+        databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
+          {
+            organizationId: campaign.organizationId,
+          },
+          { campaignId: campaign.id, participantExternalId: 'Choupette' },
+        );
+
+        databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
+          {
+            organizationId: campaign.organizationId,
+          },
+          { campaignId: campaign.id, participantExternalId: 'Salto' },
+        );
+
+        await databaseBuilder.commit();
+      });
+
+      it('returns all participants if the filter is empty', async function () {
+        // when
+        const { pagination } = await campaignParticipantActivityRepository.findPaginatedByCampaignId({
+          campaignId: campaign.id,
+          filters: { participantExternalId: '' },
+        });
+
+        // then
+        expect(pagination.rowCount).to.equal(2);
+      });
+
+      it('return Choupette participant when we search the beginning of its participantExternalId', async function () {
+        // when
+        const { campaignParticipantsActivities, pagination } =
+          await campaignParticipantActivityRepository.findPaginatedByCampaignId({
+            campaignId: campaign.id,
+            filters: { participantExternalId: 'Chou' },
+          });
+
+        // then
+        expect(pagination.rowCount).to.equal(1);
+        expect(campaignParticipantsActivities[0].participantExternalId).to.equal('Choupette');
+      });
+
+      it('return Choupette participant when the participantExternalId search contains a space before', async function () {
+        // when
+        const { campaignParticipantsActivities, pagination } =
+          await campaignParticipantActivityRepository.findPaginatedByCampaignId({
+            campaignId: campaign.id,
+            filters: { participantExternalId: ' Cho' },
+          });
+
+        // then
+        expect(pagination.rowCount).to.equal(1);
+        expect(campaignParticipantsActivities[0].participantExternalId).to.equal('Choupette');
+      });
+
+      it('return Choupette participant when the participantExternalId search contains a space after', async function () {
+        // when
+        const { campaignParticipantsActivities, pagination } =
+          await campaignParticipantActivityRepository.findPaginatedByCampaignId({
+            campaignId: campaign.id,
+            filters: { participantExternalId: 'Cho ' },
+          });
+
+        // then
+        expect(pagination.rowCount).to.equal(1);
+        expect(campaignParticipantsActivities[0].participantExternalId).to.equal('Choupette');
+      });
+
+      it('return all participants when we search similar part of participantExternalId', async function () {
+        // given
+        databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
+          {
+            organizationId: campaign.organizationId,
+          },
+          { campaignId: campaign.id, participantExternalId: 'Choupi' },
+        );
+
+        await databaseBuilder.commit();
+
+        // when
+        const { campaignParticipantsActivities, pagination } =
+          await campaignParticipantActivityRepository.findPaginatedByCampaignId({
+            campaignId: campaign.id,
+            filters: { participantExternalId: 'Chou' },
+          });
+
+        // then
+        expect(pagination.rowCount).to.equal(2);
+        expect(campaignParticipantsActivities[0].participantExternalId).to.equal('Choupette');
+        expect(campaignParticipantsActivities[1].participantExternalId).to.equal('Choupi');
+      });
+    });
+
     context('pagination', function () {
       let campaign;
 

--- a/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-profiles-collection-participation-summary-repository_test.js
+++ b/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-profiles-collection-participation-summary-repository_test.js
@@ -1100,6 +1100,66 @@ describe('Integration | Repository | Campaign Profiles Collection Participation 
         expect(participantExternalIds).to.deep.equal(['Not certifiable']);
       });
     });
+
+    context('when there is a filter on the participant externalId', function () {
+      const emptyPagination = undefined;
+
+      beforeEach(async function () {
+        // given
+        databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
+          { organizationId, firstName: 'Saphira', lastName: 'Eurasier' },
+          { participantExternalId: 'the Girl', campaignId, isCertifiable: true },
+        );
+
+        databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
+          { organizationId, firstName: 'Choupette', lastName: 'Eurasier' },
+          { participantExternalId: 'the Boy', campaignId, isCertifiable: false },
+        );
+
+        await databaseBuilder.commit();
+      });
+
+      it('returns all participants if the filter is empty', async function () {
+        // when
+        const { data: participations } =
+          await campaignProfilesCollectionParticipationSummaryRepository.findPaginatedByCampaignId(
+            campaignId,
+            emptyPagination,
+            { participantExternalId: '' },
+          );
+
+        // then
+        expect(participations).to.have.lengthOf(2);
+      });
+
+      it('return Choupette participant when we search part of participant external Id', async function () {
+        // when
+        const { data: participations } =
+          await campaignProfilesCollectionParticipationSummaryRepository.findPaginatedByCampaignId(
+            campaignId,
+            emptyPagination,
+            { participantExternalId: 'boy' },
+          );
+
+        // then
+        expect(participations).to.have.lengthOf(1);
+        expect(participations[0].firstName).to.equal('Choupette');
+      });
+
+      it('return Choupette participant when search contains a space', async function () {
+        // when
+        const { data: participations } =
+          await campaignProfilesCollectionParticipationSummaryRepository.findPaginatedByCampaignId(
+            campaignId,
+            emptyPagination,
+            { participantExternalId: ' girl ' },
+          );
+
+        // then
+        expect(participations).to.have.lengthOf(1);
+        expect(participations[0].firstName).to.equal('Saphira');
+      });
+    });
   });
 });
 

--- a/orga/app/components/campaign/activity/participants-list.gjs
+++ b/orga/app/components/campaign/activity/participants-list.gjs
@@ -59,10 +59,12 @@ export default class ParticipantsList extends Component {
       @selectedStatus={{@selectedStatus}}
       @selectedGroups={{@selectedGroups}}
       @searchFilter={{@searchFilter}}
+      @participantExternalIdFilter={{@participantExternalIdFilter}}
       @rowCount={{@rowCount}}
       @isHiddenStages={{true}}
       @isHiddenBadges={{true}}
       @isHiddenCertificability={{true}}
+      @participantExternalIdLabel={{@campaign.externalIdLabel}}
       @onFilter={{@onFilter}}
       @onResetFilter={{@onResetFilter}}
     />

--- a/orga/app/components/campaign/filter/participation-filters.gjs
+++ b/orga/app/components/campaign/filter/participation-filters.gjs
@@ -59,7 +59,8 @@ export default class ParticipationFilters extends Component {
       (!this.displayStagesFilter || this.args.selectedStages.length === 0) &&
       (!this.displayBadgesFilter || this.args.selectedBadges.length === 0) &&
       (!this.displayBadgesFilter || this.args.selectedUnacquiredBadges.length === 0) &&
-      (!this.displayCertificabilityFilter || !this.args.selectedCertificability)
+      (!this.displayCertificabilityFilter || !this.args.selectedCertificability) &&
+      (!this.displayParticipantExternalIdFilter || !this.args.participantExternalIdFilter)
     );
   }
 
@@ -71,7 +72,8 @@ export default class ParticipationFilters extends Component {
       this.displayStatusFilter ||
       this.displayGroupsFilter ||
       this.displayCertificabilityFilter ||
-      this.displaySearchFilter
+      this.displaySearchFilter ||
+      this.displayParticipantExternalIdFilter
     );
   }
 
@@ -106,6 +108,10 @@ export default class ParticipationFilters extends Component {
 
   get displaySearchFilter() {
     return !this.args.isHiddenSearch;
+  }
+
+  get displayParticipantExternalIdFilter() {
+    return Boolean(this.args.participantExternalIdLabel);
   }
 
   get stageOptions() {
@@ -207,6 +213,18 @@ export default class ParticipationFilters extends Component {
             @triggerFiltering={{@onFilter}}
           >
             <:label>{{t "common.filters.fullname.label"}}</:label>
+          </PixSearchInput>
+        {{/if}}
+        {{#if this.displayParticipantExternalIdFilter}}
+          <PixSearchInput
+            @id="participantExternalId"
+            value={{@participantExternalIdFilter}}
+            @screenReaderOnly={{true}}
+            @placeholder={{@participantExternalIdLabel}}
+            @debounceTimeInMs={{debounceTime}}
+            @triggerFiltering={{@onFilter}}
+          >
+            <:label>{{t "common.filters.participantExternalId.label"}}</:label>
           </PixSearchInput>
         {{/if}}
         {{#if this.displayStagesFilter}}

--- a/orga/app/components/campaign/results/assessment-list.gjs
+++ b/orga/app/components/campaign/results/assessment-list.gjs
@@ -28,6 +28,7 @@ import ParticipationEvolutionIcon from './participation-evolution-icon';
       @isHiddenStatus={{true}}
       @onResetFilter={{@onResetFilter}}
       @onFilter={{@onFilter}}
+      @participantExternalIdLabel={{@campaign.externalIdLabel}}
     />
 
     <PixTable

--- a/orga/app/components/campaign/results/assessment-list.gjs
+++ b/orga/app/components/campaign/results/assessment-list.gjs
@@ -29,6 +29,7 @@ import ParticipationEvolutionIcon from './participation-evolution-icon';
       @onResetFilter={{@onResetFilter}}
       @onFilter={{@onFilter}}
       @participantExternalIdLabel={{@campaign.externalIdLabel}}
+      @participantExternalIdFilter={{@participantExternalIdFilter}}
     />
 
     <PixTable

--- a/orga/app/components/campaign/results/profile-list.gjs
+++ b/orga/app/components/campaign/results/profile-list.gjs
@@ -23,6 +23,8 @@ import ParticipationEvolutionIcon from './participation-evolution-icon';
       @selectedCertificability={{@selectedCertificability}}
       @rowCount={{@profiles.meta.rowCount}}
       @searchFilter={{@searchFilter}}
+      @participantExternalIdFilter={{@participantExternalIdFilter}}
+      @participantExternalIdLabel={{@campaign.externalIdLabel}}
       @onFilter={{@onFilter}}
       @onResetFilter={{@onReset}}
       @isHiddenStatus={{true}}

--- a/orga/app/controllers/authenticated/campaigns/campaign/activity.js
+++ b/orga/app/controllers/authenticated/campaigns/campaign/activity.js
@@ -17,6 +17,7 @@ export default class ActivityController extends Controller {
   @tracked campaign;
   @tracked participations;
   @tracked search = null;
+  @tracked participantExternalId = null;
 
   get isGarAuthenticationMethod() {
     return this.currentUser.isGarAuthenticationMethod;
@@ -45,6 +46,7 @@ export default class ActivityController extends Controller {
     this.status = null;
     this.groups = [];
     this.search = null;
+    this.participantExternalId = null;
   }
 
   @action

--- a/orga/app/controllers/authenticated/campaigns/campaign/assessment-results.js
+++ b/orga/app/controllers/authenticated/campaigns/campaign/assessment-results.js
@@ -13,6 +13,7 @@ export default class AssessmentResultsController extends Controller {
   @tracked groups = [];
   @tracked badges = [];
   @tracked unacquiredBadges = [];
+  @tracked participantExternalId = null;
   @tracked stages = [];
   @tracked search = null;
 
@@ -47,5 +48,6 @@ export default class AssessmentResultsController extends Controller {
 
     this.stages = [];
     this.search = null;
+    this.participantExternalId = null;
   }
 }

--- a/orga/app/controllers/authenticated/campaigns/campaign/profile-results.js
+++ b/orga/app/controllers/authenticated/campaigns/campaign/profile-results.js
@@ -10,6 +10,7 @@ export default class ProfilesController extends Controller {
   @tracked groups = [];
   @tracked search = null;
   @tracked certificability = null;
+  @tracked participantExternalId = null;
 
   @action
   goToProfilePage(campaignId, participation) {
@@ -29,5 +30,6 @@ export default class ProfilesController extends Controller {
     this.groups = [];
     this.search = null;
     this.certificability = null;
+    this.participantExternalId = null;
   }
 }

--- a/orga/app/routes/authenticated/campaigns/campaign/activity.js
+++ b/orga/app/routes/authenticated/campaigns/campaign/activity.js
@@ -24,21 +24,15 @@ export default class ActivityRoute extends Route {
     search: {
       refreshModel: true,
     },
+    participantExternalId: {
+      refreshModel: true,
+    },
   };
 
   async model(params) {
     const campaign = this.modelFor('authenticated.campaigns.campaign');
-    const participations = await this.fetchParticipantsActivity({ campaignId: campaign.id, ...params });
-
-    return {
-      campaign,
-      participations,
-    };
-  }
-
-  fetchParticipantsActivity(params) {
-    return this.store.query('campaign-participant-activity', {
-      campaignId: params.campaignId,
+    const participations = await this.store.query('campaign-participant-activity', {
+      campaignId: campaign.id,
       page: {
         number: params.pageNumber,
         size: params.pageSize,
@@ -48,8 +42,14 @@ export default class ActivityRoute extends Route {
         status: params.status,
         groups: params.groups,
         search: params.search,
+        participantExternalId: params.participantExternalId,
       },
     });
+
+    return {
+      campaign,
+      participations,
+    };
   }
 
   @action
@@ -62,12 +62,7 @@ export default class ActivityRoute extends Route {
 
   resetController(controller, isExiting) {
     if (isExiting) {
-      controller.pageNumber = 1;
-      controller.pageSize = 50;
-      controller.divisions = [];
-      controller.status = null;
-      controller.groups = [];
-      controller.search = null;
+      controller.resetFiltering();
     }
   }
 

--- a/orga/app/routes/authenticated/campaigns/campaign/assessment-results.js
+++ b/orga/app/routes/authenticated/campaigns/campaign/assessment-results.js
@@ -47,7 +47,23 @@ export default class AssessmentResultsRoute extends Route {
 
   async model(params) {
     const campaign = this.modelFor('authenticated.campaigns.campaign');
-    const participations = await this.fetchResultMinimalList({ campaignId: campaign.id, ...params });
+
+    const participations = await this.store.query('campaign-assessment-result-minimal', {
+      page: {
+        number: params.pageNumber,
+        size: params.pageSize,
+      },
+      filter: {
+        divisions: params.divisions,
+        groups: params.groups,
+        badges: params.badges,
+        unacquiredBadges: params.unacquiredBadges,
+        stages: params.stages,
+        search: params.search,
+        participantExternalId: params.participantExternalId,
+      },
+      campaignId: campaign.id,
+    });
 
     return {
       campaign,
@@ -62,36 +78,9 @@ export default class AssessmentResultsRoute extends Route {
     }
   }
 
-  fetchResultMinimalList(params) {
-    return this.store.query('campaign-assessment-result-minimal', {
-      page: {
-        number: params.pageNumber,
-        size: params.pageSize,
-      },
-      filter: {
-        divisions: params.divisions,
-        groups: params.groups,
-        badges: params.badges,
-        unacquiredBadges: params.unacquiredBadges,
-        stages: params.stages,
-        search: params.search,
-        participantExternalId: params.participantExternalId,
-      },
-      campaignId: params.campaignId,
-    });
-  }
-
   resetController(controller, isExiting) {
     if (isExiting) {
-      controller.pageNumber = 1;
-      controller.pageSize = 50;
-      controller.divisions = [];
-      controller.groups = [];
-      controller.badges = [];
-      controller.stages = [];
-      controller.unacquiredBadges = [];
-      controller.participantExternalId = null;
-      controller.search = null;
+      controller.resetFiltering();
     }
   }
 }

--- a/orga/app/routes/authenticated/campaigns/campaign/assessment-results.js
+++ b/orga/app/routes/authenticated/campaigns/campaign/assessment-results.js
@@ -31,6 +31,9 @@ export default class AssessmentResultsRoute extends Route {
     search: {
       refreshModel: true,
     },
+    participantExternalId: {
+      refreshModel: true,
+    },
   };
 
   beforeModel(transition) {
@@ -72,6 +75,7 @@ export default class AssessmentResultsRoute extends Route {
         unacquiredBadges: params.unacquiredBadges,
         stages: params.stages,
         search: params.search,
+        participantExternalId: params.participantExternalId,
       },
       campaignId: params.campaignId,
     });
@@ -86,6 +90,7 @@ export default class AssessmentResultsRoute extends Route {
       controller.badges = [];
       controller.stages = [];
       controller.unacquiredBadges = [];
+      controller.participantExternalId = null;
       controller.search = null;
     }
   }

--- a/orga/app/routes/authenticated/campaigns/campaign/profile-results.js
+++ b/orga/app/routes/authenticated/campaigns/campaign/profile-results.js
@@ -25,6 +25,7 @@ export default class ProfilesRoute extends Route {
     certificability: {
       refreshModel: true,
     },
+    participantExternalId: { refreshModel: true },
   };
 
   @action
@@ -45,27 +46,24 @@ export default class ProfilesRoute extends Route {
 
   async model(params) {
     const campaign = this.modelFor('authenticated.campaigns.campaign');
-    const profiles = await this.fetchProfileSummaries({ campaignId: campaign.id, ...params });
-    return {
-      campaign,
-      profiles,
-    };
-  }
-
-  fetchProfileSummaries(params) {
-    return this.store.query('campaign-profiles-collection-participation-summary', {
+    const profiles = await this.store.query('campaign-profiles-collection-participation-summary', {
       filter: {
-        campaignId: params.campaignId,
+        campaignId: campaign.id,
         divisions: params.divisions,
         groups: params.groups,
         search: params.search,
         certificability: params.certificability,
+        participantExternalId: params.participantExternalId,
       },
       page: {
         number: params.pageNumber,
         size: params.pageSize,
       },
     });
+    return {
+      campaign,
+      profiles,
+    };
   }
 
   resetController(controller, isExiting) {

--- a/orga/app/templates/authenticated/campaigns/campaign/activity.gjs
+++ b/orga/app/templates/authenticated/campaigns/campaign/activity.gjs
@@ -25,6 +25,7 @@ import EmptyState from 'pix-orga/components/campaign/empty-state';
       @selectedGroups={{@controller.groups}}
       @rowCount={{@model.participations.meta.rowCount}}
       @searchFilter={{@controller.search}}
+      @participantExternalIdFilter={{@controller.participantExternalId}}
       @onFilter={{@controller.triggerFiltering}}
       @onResetFilter={{@controller.resetFiltering}}
       @deleteCampaignParticipation={{@controller.deleteCampaignParticipation}}

--- a/orga/app/templates/authenticated/campaigns/campaign/assessment-results.gjs
+++ b/orga/app/templates/authenticated/campaigns/campaign/assessment-results.gjs
@@ -29,6 +29,7 @@ import AssessmentList from 'pix-orga/components/campaign/results/assessment-list
       @selectedBadges={{@controller.badges}}
       @selectedUnacquiredBadges={{@controller.unacquiredBadges}}
       @selectedStages={{@controller.stages}}
+      @selectedParticipantExternalId={{@controller.participantExternalId}}
       @searchFilter={{@controller.search}}
       @onClickParticipant={{@controller.goToAssessmentPage}}
       @onFilter={{@controller.triggerFiltering}}

--- a/orga/app/templates/authenticated/campaigns/campaign/assessment-results.gjs
+++ b/orga/app/templates/authenticated/campaigns/campaign/assessment-results.gjs
@@ -29,8 +29,8 @@ import AssessmentList from 'pix-orga/components/campaign/results/assessment-list
       @selectedBadges={{@controller.badges}}
       @selectedUnacquiredBadges={{@controller.unacquiredBadges}}
       @selectedStages={{@controller.stages}}
-      @selectedParticipantExternalId={{@controller.participantExternalId}}
       @searchFilter={{@controller.search}}
+      @participantExternalIdFilter={{@controller.participantExternalId}}
       @onClickParticipant={{@controller.goToAssessmentPage}}
       @onFilter={{@controller.triggerFiltering}}
       @onResetFilter={{@controller.resetFiltering}}

--- a/orga/app/templates/authenticated/campaigns/campaign/profile-results.gjs
+++ b/orga/app/templates/authenticated/campaigns/campaign/profile-results.gjs
@@ -11,6 +11,7 @@ import ProfileList from 'pix-orga/components/campaign/results/profile-list';
       @campaign={{@model.campaign}}
       @profiles={{@model.profiles}}
       @searchFilter={{@controller.search}}
+      @participantExternalIdFilter={{@controller.participantExternalId}}
       @selectedDivisions={{@controller.divisions}}
       @selectedGroups={{@controller.groups}}
       @selectedCertificability={{@controller.certificability}}

--- a/orga/tests/integration/components/campaign/filter/participation-filters-test.gjs
+++ b/orga/tests/integration/components/campaign/filter/participation-filters-test.gjs
@@ -1000,6 +1000,90 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
     });
   });
 
+  module('participantExternalId', function (hooks) {
+    hooks.beforeEach(function () {
+      class CurrentUserStub extends Service {
+        hasImportFeature = false;
+      }
+      this.owner.register('service:current-user', CurrentUserStub);
+    });
+    test('it should populate the participant external id input with correct value', async function (assert) {
+      const campaign = store.createRecord('campaign', {
+        id: '1',
+        name: 'campagne 1',
+      });
+      const filterValue = 'chichi';
+
+      const screen = await render(
+        <template>
+          <ParticipationFilters
+            @campaign={{campaign}}
+            @isHiddenStatus={{true}}
+            @isHiddenBadges={{true}}
+            @isHiddenDivisions={{true}}
+            @isHiddenGroups={{true}}
+            @onResetFilter={{noop}}
+            @onFilter={{noop}}
+            @participantExternalIdFilter={{filterValue}}
+            @participantExternalIdLabel="info externe"
+          />
+        </template>,
+      );
+
+      // then
+      assert.dom(screen.getByLabelText(t('common.filters.participantExternalId.label'))).hasValue('chichi');
+    });
+
+    test('it triggers the filter when a text is input', async function (assert) {
+      // given
+      const campaign = store.createRecord('campaign', {
+        id: campaignId,
+        name: 'campagne 1',
+        type: 'ASSESSMENT',
+        targetProfileHasStage: false,
+        stages: [],
+      });
+
+      const triggerFiltering = sinon.stub();
+
+      // when
+      await render(
+        <template>
+          <ParticipationFilters
+            @campaign={{campaign}}
+            @onFilter={{triggerFiltering}}
+            @participantExternalIdFilter=""
+            @participantExternalIdLabel="info externe"
+          />
+        </template>,
+      );
+      await fillByLabel(t('common.filters.participantExternalId.label'), 'Sal');
+
+      // then
+      assert.ok(triggerFiltering.calledWith('participantExternalId', 'Sal'));
+    });
+    test('it hides participantExternalId filter when not provided', async function (assert) {
+      // given
+      const campaign = store.createRecord('campaign', {
+        id: campaignId,
+        name: 'campagne 1',
+        type: 'ASSESSMENT',
+        targetProfileHasStage: false,
+        stages: [],
+      });
+
+      const triggerFiltering = sinon.stub();
+
+      // when
+      const screen = await render(
+        <template><ParticipationFilters @campaign={{campaign}} @onFilter={{triggerFiltering}} /></template>,
+      );
+
+      // then
+      assert.notOk(screen.queryByLabelText(t('common.filters.participantExternalId.label')));
+    });
+  });
+
   module('certificability', function (hooks) {
     hooks.beforeEach(function () {
       class CurrentUserStub extends Service {

--- a/orga/tests/unit/controllers/authenticated/campaigns/campaign/activity-test.js
+++ b/orga/tests/unit/controllers/authenticated/campaigns/campaign/activity-test.js
@@ -51,6 +51,7 @@ module('Unit | Controller | authenticated/campaigns/campaign/activity', function
       controller.status = 'SHARED';
       controller.groups = ['L3'];
       controller.search = 'Jean';
+      controller.participantExternalId = 'Jean';
 
       // when
       controller.resetFiltering();
@@ -61,6 +62,7 @@ module('Unit | Controller | authenticated/campaigns/campaign/activity', function
       assert.strictEqual(controller.status, null);
       assert.deepEqual(controller.groups, []);
       assert.strictEqual(controller.search, null);
+      assert.strictEqual(controller.participantExternalId, null);
     });
   });
 

--- a/orga/tests/unit/controllers/authenticated/campaigns/campaign/assessment-results-test.js
+++ b/orga/tests/unit/controllers/authenticated/campaigns/campaign/assessment-results-test.js
@@ -46,6 +46,7 @@ module('Unit | Controller | authenticated/campaigns/campaign/assessment-results'
       controller.set('badges', ['badge1']);
       controller.set('stages', ['stage1']);
       controller.set('search', 'dam');
+      controller.set('participantExternalId', 'external-id');
 
       //when
       controller.resetFiltering();
@@ -57,6 +58,7 @@ module('Unit | Controller | authenticated/campaigns/campaign/assessment-results'
       assert.deepEqual(controller.groups, []);
       assert.deepEqual(controller.badges, []);
       assert.deepEqual(controller.stages, []);
+      assert.strictEqual(controller.participantExternalId, null);
     });
   });
 

--- a/orga/tests/unit/controllers/authenticated/campaigns/campaign/profile-results-test.js
+++ b/orga/tests/unit/controllers/authenticated/campaigns/campaign/profile-results-test.js
@@ -45,6 +45,7 @@ module('Unit | Controller | authenticated/campaigns/campaign/profile-results', f
       controller.set('divisions', ['3eme']);
       controller.set('groups', ['M2']);
       controller.set('search', 'fra');
+      controller.set('participantExternalId', 'id123');
 
       //when
       controller.resetFiltering();
@@ -54,6 +55,7 @@ module('Unit | Controller | authenticated/campaigns/campaign/profile-results', f
       assert.deepEqual(controller.groups, []);
       assert.deepEqual(controller.search, null);
       assert.deepEqual(controller.pageNumber, null);
+      assert.deepEqual(controller.participantExternalId, null);
     });
   });
 

--- a/orga/tests/unit/routes/authenticated/campaigns/campaign/activity-test.js
+++ b/orga/tests/unit/routes/authenticated/campaigns/campaign/activity-test.js
@@ -1,0 +1,95 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module('Unit | Route | authenticated/campaigns/campaign/activity', function (hooks) {
+  setupTest(hooks);
+  let route, store;
+
+  hooks.beforeEach(function () {
+    route = this.owner.lookup('route:authenticated/campaigns/campaign/activity');
+    store = this.owner.lookup('service:store');
+  });
+
+  hooks.afterEach(function () {
+    sinon.restore();
+  });
+
+  module('model', function () {
+    test('should fetch data', async function (assert) {
+      //given
+      const campaignId = Symbol('CampaignId');
+      const pageNumber = Symbol('pageNumber');
+      const pageSize = Symbol('pageSize');
+      const divisions = Symbol('divisions');
+      const status = Symbol('status');
+      const groups = Symbol('groups');
+      const search = Symbol('search');
+      const participantExternalId = Symbol('participantExternalId');
+      const params = {
+        campaignId,
+        pageNumber,
+        pageSize,
+        divisions,
+        status,
+        groups,
+        search,
+        participantExternalId,
+      };
+
+      const campaign = { id: campaignId };
+      const modelForStub = sinon.stub(route, 'modelFor');
+      modelForStub.withArgs('authenticated.campaigns.campaign').returns(campaign);
+      const participationsSymbol = Symbol('CampaignParticipations');
+      sinon
+        .stub(store, 'query')
+        .withArgs('campaign-participant-activity', {
+          campaignId,
+          page: { number: pageNumber, size: pageSize },
+          filter: {
+            divisions,
+            status,
+            groups,
+            search,
+            participantExternalId,
+          },
+        })
+        .resolves(participationsSymbol);
+      //when
+      const result = await route.model(params);
+
+      //then
+      assert.deepEqual(result, { campaign: campaign, participations: participationsSymbol });
+    });
+  });
+
+  module('resetController', function () {
+    test('it should call resetFiltering method on controller, if isExiting is true', function (assert) {
+      const controller = {
+        resetFiltering: sinon.stub(),
+      };
+      const isExiting = true;
+
+      route.resetController(controller, isExiting);
+      assert.ok(controller.resetFiltering.calledOnce);
+    });
+    test('it should not call resetFiltering method on controller, if isExiting is false', function (assert) {
+      const controller = {
+        resetFiltering: sinon.stub(),
+      };
+      const isExiting = false;
+
+      route.resetController(controller, isExiting);
+      assert.ok(controller.resetFiltering.notCalled);
+    });
+  });
+
+  module('refreshModel', function () {
+    test('it should also call reload on parent model', function (assert) {
+      const reloadStub = sinon.stub();
+      sinon.stub(route, 'modelFor').returns({ reload: reloadStub });
+      route.refreshModel();
+      assert.ok(reloadStub.calledOnce);
+    });
+  });
+});

--- a/orga/tests/unit/routes/authenticated/campaigns/campaign/assessment-results-test.js
+++ b/orga/tests/unit/routes/authenticated/campaigns/campaign/assessment-results-test.js
@@ -13,12 +13,14 @@ module('Unit | Route | authenticated/campaigns/campaign/assessment-results', fun
     store = this.owner.lookup('service:store');
   });
 
-  module('fetchResultMinimalList', function (hooks) {
+  module('model', function (hooks) {
     hooks.beforeEach(function () {
       sinon.stub(store, 'query');
+      sinon.stub(route, 'modelFor');
     });
 
-    test('if finds summaries from stores', function (assert) {
+    test('if finds campaign-assessment-result-minimal from stores', async function (assert) {
+      const campaign = { id: Symbol('campaignId') };
       const params = {
         pageNumber: 1,
         pageSize: 2,
@@ -28,14 +30,16 @@ module('Unit | Route | authenticated/campaigns/campaign/assessment-results', fun
         unacquiredBadges: [],
         stages: [],
         search: null,
-        campaignId: 3,
+        participantExternalId: 123,
       };
+
       const expectedParticipations = [
         {
           id: 12,
         },
       ];
 
+      route.modelFor.withArgs('authenticated.campaigns.campaign').returns(campaign);
       store.query
         .withArgs('campaign-assessment-result-minimal', {
           page: {
@@ -49,103 +53,32 @@ module('Unit | Route | authenticated/campaigns/campaign/assessment-results', fun
             stages: params.stages,
             unacquiredBadges: params.unacquiredBadges,
             search: params.search,
+            participantExternalId: 123,
           },
-          campaignId: params.campaignId,
+          campaignId: campaign.id,
         })
-        .returns(expectedParticipations);
+        .resolves(expectedParticipations);
 
-      const participations = route.fetchResultMinimalList(params);
+      const data = await route.model(params);
 
-      assert.strictEqual(participations, expectedParticipations);
+      assert.deepEqual(data, { participations: expectedParticipations, campaign });
     });
   });
 
   module('resetController', function () {
     module('when isExiting is true', function () {
-      test('it reset pageNumber', function (assert) {
-        const controller = { pageNumber: 2 };
+      test('it call controller resetFiltering', function (assert) {
+        const controller = { resetFiltering: sinon.stub() };
         route.resetController(controller, true);
-        assert.strictEqual(controller.pageNumber, 1);
-      });
-
-      test('it reset pageSize', function (assert) {
-        const controller = { pageSize: 10 };
-        route.resetController(controller, true);
-        assert.strictEqual(controller.pageSize, 50);
-      });
-
-      test('it reset divisions', function (assert) {
-        const controller = { divisions: ['10'] };
-        route.resetController(controller, true);
-        assert.deepEqual(controller.divisions, []);
-      });
-
-      test('it reset groups', function (assert) {
-        const controller = { groups: ['10'] };
-        route.resetController(controller, true);
-        assert.deepEqual(controller.groups, []);
-      });
-
-      test('it reset badges', function (assert) {
-        const controller = { badges: ['10'] };
-        route.resetController(controller, true);
-        assert.deepEqual(controller.badges, []);
-      });
-
-      test('it reset stages', function (assert) {
-        const controller = { stages: ['10'] };
-        route.resetController(controller, true);
-        assert.deepEqual(controller.stages, []);
-      });
-
-      test('it reset search', function (assert) {
-        const controller = { search: 'Dalida' };
-        route.resetController(controller, true);
-        assert.deepEqual(controller.search, null);
+        assert.ok(controller.resetFiltering.calledOnce);
       });
     });
 
     module('when isExiting is false', function () {
-      test('it does not reset pageNumber', function (assert) {
-        const controller = { pageNumber: 2 };
+      test('it not call controller resetFiltering', function (assert) {
+        const controller = { resetFiltering: sinon.stub() };
         route.resetController(controller, false);
-        assert.strictEqual(controller.pageNumber, 2);
-      });
-
-      test('it does not reset pageSize', function (assert) {
-        const controller = { pageSize: 10 };
-        route.resetController(controller, false);
-        assert.strictEqual(controller.pageSize, 10);
-      });
-
-      test('it does not reset divisions', function (assert) {
-        const controller = { divisions: ['10'] };
-        route.resetController(controller, false);
-        assert.deepEqual(controller.divisions, ['10']);
-      });
-
-      test('it does not reset groups', function (assert) {
-        const controller = { groups: ['10'] };
-        route.resetController(controller, false);
-        assert.deepEqual(controller.groups, ['10']);
-      });
-
-      test('it does not reset badges', function (assert) {
-        const controller = { badges: ['10'] };
-        route.resetController(controller, false);
-        assert.deepEqual(controller.badges, ['10']);
-      });
-
-      test('it does not reset stages', function (assert) {
-        const controller = { stages: ['10'] };
-        route.resetController(controller, false);
-        assert.deepEqual(controller.stages, ['10']);
-      });
-
-      test('it does not reset search', function (assert) {
-        const controller = { search: 'Dalida' };
-        route.resetController(controller, false);
-        assert.deepEqual(controller.search, 'Dalida');
+        assert.ok(controller.resetFiltering.notCalled);
       });
     });
   });

--- a/orga/tests/unit/routes/authenticated/campaigns/campaign/profile-results-test.js
+++ b/orga/tests/unit/routes/authenticated/campaigns/campaign/profile-results-test.js
@@ -13,24 +13,25 @@ module('Unit | Route | authenticated/campaigns/campaign/profile-results', functi
     store = this.owner.lookup('service:store');
   });
 
-  module('fetchProfileSummaries', function (hooks) {
+  module('model', function (hooks) {
     hooks.beforeEach(function () {
       sinon.stub(store, 'query');
     });
 
-    test('if finds profile summaries from stores', function (assert) {
+    test('if finds profile summaries from stores', async function (assert) {
       const params = {
         pageNumber: 1,
         pageSize: 2,
         divisions: ['4eme'],
-        campaignId: 3,
+        participantExternalId: 'id123',
       };
       const expectedSummaries = [
         {
           id: 12,
         },
       ];
-
+      const campaign = { id: Symbol('campaign') };
+      sinon.stub(route, 'modelFor').withArgs('authenticated.campaigns.campaign').returns(campaign);
       store.query
         .withArgs('campaign-profiles-collection-participation-summary', {
           page: {
@@ -38,18 +39,19 @@ module('Unit | Route | authenticated/campaigns/campaign/profile-results', functi
             size: params.pageSize,
           },
           filter: {
+            campaignId: campaign.id,
             divisions: params.divisions,
             groups: params.groups,
-            campaignId: params.campaignId,
             search: params.search,
             certificability: params.certificability,
+            participantExternalId: params.participantExternalId,
           },
         })
-        .returns(expectedSummaries);
+        .resolves(expectedSummaries);
 
-      const summaries = route.fetchProfileSummaries(params);
+      const data = await route.model(params);
 
-      assert.strictEqual(summaries, expectedSummaries);
+      assert.deepEqual(data, { campaign, profiles: expectedSummaries });
     });
   });
 

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -234,6 +234,9 @@
         "label": "Search by groups",
         "placeholder": "Groups"
       },
+      "participantExternalId": {
+        "label": "Search by external id"
+      },
       "loading": "Loading...",
       "placeholder": "-- Select --",
       "title": "Filters"

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -234,10 +234,10 @@
         "label": "Search by groups",
         "placeholder": "Groups"
       },
+      "loading": "Loading...",
       "participantExternalId": {
         "label": "Search by external id"
       },
-      "loading": "Loading...",
       "placeholder": "-- Select --",
       "title": "Filters"
     },

--- a/orga/translations/es.json
+++ b/orga/translations/es.json
@@ -240,6 +240,9 @@
         "label": "Búsqueda por grupo",
         "placeholder": "Grupos"
       },
+      "participantExternalId": {
+        "label": "Búsqueda por ID externo"
+      },
       "loading": "Cargando...",
       "placeholder": "-- Selecciona --",
       "title": "Filtros"

--- a/orga/translations/es.json
+++ b/orga/translations/es.json
@@ -240,10 +240,10 @@
         "label": "Búsqueda por grupo",
         "placeholder": "Grupos"
       },
+      "loading": "Cargando...",
       "participantExternalId": {
         "label": "Búsqueda por ID externo"
       },
-      "loading": "Cargando...",
       "placeholder": "-- Selecciona --",
       "title": "Filtros"
     },

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -234,10 +234,10 @@
         "label": "Rechercher par groupes",
         "placeholder": "Groupes"
       },
+      "loading": "Chargement...",
       "participantExternalId": {
         "label": "Recherche sur l'identifiant externe"
       },
-      "loading": "Chargement...",
       "placeholder": "-- Sélectionner --",
       "title": "Filtres"
     },

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -234,6 +234,9 @@
         "label": "Rechercher par groupes",
         "placeholder": "Groupes"
       },
+      "participantExternalId": {
+        "label": "Recherche sur l'identifiant externe"
+      },
       "loading": "Chargement...",
       "placeholder": "-- Sélectionner --",
       "title": "Filtres"

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -235,10 +235,10 @@
         "label": "Zoeken op groepen",
         "placeholder": "Groepen"
       },
+      "loading": "Laden...",
       "participantExternalId": {
         "label": "Zoeken op extern identificatienummer"
       },
-      "loading": "Laden...",
       "placeholder": "-- Selecteer --",
       "title": "Filters"
     },

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -235,6 +235,9 @@
         "label": "Zoeken op groepen",
         "placeholder": "Groepen"
       },
+      "participantExternalId": {
+        "label": "Zoeken op extern identificatienummer"
+      },
       "loading": "Laden...",
       "placeholder": "-- Selecteer --",
       "title": "Filters"


### PR DESCRIPTION
## 🌱 Problème

Lorsqu’il consulte l’activité ou les résultats d’une campagne, le prescripteur ne peut pas rechercher un participant via son identifiant externe.

## 🐣 Proposition

Ajouter un champ de recherche sur l’identifiant externe sur les tableaux présents sur ces 2 pages. 

## 🌷 Remarques

On a modifié les seed pour pouvoir avece des external id différents selon les learner

## 🐝 Pour tester

- [ ] Aller sur la campagne `PROASSMUL`
- [ ] Filtrer les participations en fonction de l'externalId et utiliser la remise à zéro des filtres
- [ ] Cliquer sur l'onglet `Résultats`
- [ ] Filtrer les participations en fonction de l'externalId et utiliser la remise à zéro des filtres
- [ ] Aller sur l'onglet résultat de la campagne `PROCOLMUL`
- [ ] Filtrer les participations en fonction de l'externalId et utiliser la remise à zéro des filtres
