### PR TITLE
[FEATURE] Supprimer toutes les invitations d'une organisation à l'archivage (PIX-22086)

### DIFF
--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -928,7 +928,7 @@
             "active-campaigns": "Ongoing campaigns will be archived",
             "active-members": "Active members will be deactivated",
             "linking": "You are no longer allowed to attach new members or send invitations",
-            "pending-invitations": "Pending invitations will be cancelled",
+            "pending-invitations": "All invitations (regardless of status) will be cancelled",
             "undone": "This action cannot be undone."
           }
         },

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -936,7 +936,7 @@
             "active-campaigns": "Les campagnes actives vont être archivées",
             "active-members": "Les membres actifs vont être désactivés",
             "linking": "Le rattachement et l'invitation de nouvelles personnes seront bloqués",
-            "pending-invitations": "Les invitations en attente vont être annulées",
+            "pending-invitations": "Toutes les invitations (peu importe le statut) seront supprimées",
             "undone": "Cette action est irréversible."
           }
         },

--- a/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
@@ -4,7 +4,6 @@ import { ORGANIZATION_FEATURE } from '../../../shared/domain/constants.js';
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { MissingAttributesError, NotFoundError } from '../../../shared/domain/errors.js';
 import { fetchPage } from '../../../shared/infrastructure/utils/knex-utils.js';
-import { OrganizationInvitation } from '../../../team/domain/models/OrganizationInvitation.js';
 import { OrganizationForAdmin } from '../../domain/models/OrganizationForAdmin.js';
 import { OrganizationLearnerType } from '../../domain/models/OrganizationLearnerType.js';
 import { Tag } from '../../domain/models/Tag.js';
@@ -13,6 +12,7 @@ const DATA_PROTECTION_OFFICERS_TABLE_NAME = 'data-protection-officers';
 const ORGANIZATION_FEATURES_TABLE_NAME = 'organization-features';
 const ORGANIZATION_TAGS_TABLE_NAME = 'organization-tags';
 const ORGANIZATIONS_TABLE_NAME = 'organizations';
+const ORGANIZATION_INVITATIONS_TABLE_NAME = 'organization-invitations';
 
 /**
  * @type {function}
@@ -34,9 +34,7 @@ const archive = async function ({ id, archivedBy, campaignApi, learnerApi }) {
 
   const archiveDate = new Date();
 
-  await knexConnection('organization-invitations')
-    .where({ organizationId: id, status: OrganizationInvitation.StatusType.PENDING })
-    .update({ status: OrganizationInvitation.StatusType.CANCELLED, updatedAt: archiveDate });
+  await knexConnection(ORGANIZATION_INVITATIONS_TABLE_NAME).where({ organizationId: id }).delete();
 
   await learnerApi.deleteOrganizationLearnerBeforeImportFeature({
     userId: archivedBy,

--- a/api/tests/organizational-entities/integration/domain/usecases/archive-organizations-in-batch.usecase.test.js
+++ b/api/tests/organizational-entities/integration/domain/usecases/archive-organizations-in-batch.usecase.test.js
@@ -21,7 +21,6 @@ describe('Integration | Organizational Entities | Domain | UseCase | archive-org
       const organization1 = databaseBuilder.factory.buildOrganization();
       databaseBuilder.factory.buildOrganizationInvitation({
         organizationId: organization1.id,
-        status: OrganizationInvitation.StatusType.PENDING,
       });
       databaseBuilder.factory.buildCampaign({
         organizationId: organization1.id,
@@ -35,7 +34,6 @@ describe('Integration | Organizational Entities | Domain | UseCase | archive-org
       const organization2 = databaseBuilder.factory.buildOrganization();
       databaseBuilder.factory.buildOrganizationInvitation({
         organizationId: organization2.id,
-        status: OrganizationInvitation.StatusType.PENDING,
       });
       databaseBuilder.factory.buildCampaign({
         organizationId: organization2.id,
@@ -60,17 +58,15 @@ describe('Integration | Organizational Entities | Domain | UseCase | archive-org
 
       // then
       await _assertOrganizationIsArchived({ archivedOrganizationId: organization1.id, user, archivedAt: now });
-      await _assertPendingInvitationsAreCanceled({
+      await _assertInvitationsAreDeleted({
         archivedOrganizationId: organization1.id,
-        updatedAt: now,
       });
       await _assertCampaignAreDeleted({ organizationId: organization1.id, archivedAt: now });
       await _assertMembershipAreDisabled({ organizationId: organization1.id, disabledAt: now });
 
       await _assertOrganizationIsArchived({ archivedOrganizationId: organization2.id, user, archivedAt: now });
-      await _assertPendingInvitationsAreCanceled({
+      await _assertInvitationsAreDeleted({
         archivedOrganizationId: organization2.id,
-        updatedAt: now,
       });
       await _assertCampaignAreDeleted({ organizationId: organization2.id, archivedAt: now });
       await _assertMembershipAreDisabled({ organizationId: organization2.id, disabledAt: now });
@@ -116,9 +112,8 @@ describe('Integration | Organizational Entities | Domain | UseCase | archive-org
         }),
       );
       await _assertOrganizationIsArchived({ archivedOrganizationId: organization1.id, user, archivedAt: now });
-      await _assertPendingInvitationsAreCanceled({
+      await _assertInvitationsAreDeleted({
         archivedOrganizationId: organization1.id,
-        updatedAt: now,
       });
       await _assertCampaignAreDeleted({ organizationId: organization1.id, archivedAt: now });
       await _assertMembershipAreDisabled({ organizationId: organization1.id, disabledAt: now });
@@ -137,13 +132,12 @@ async function _assertCampaignAreDeleted({ organizationId, archivedAt }) {
   expect(archivedCampaign1.deletedAt).to.deep.equal(archivedAt);
 }
 
-async function _assertPendingInvitationsAreCanceled({ archivedOrganizationId, updatedAt }) {
-  const archivedPendingOrganizationInvitation = await knex('organization-invitations')
-    .where({ organizationId: archivedOrganizationId })
-    .first();
+async function _assertInvitationsAreDeleted({ archivedOrganizationId }) {
+  const archivedOrganizationInvitations = await knex('organization-invitations').where({
+    organizationId: archivedOrganizationId,
+  });
 
-  expect(archivedPendingOrganizationInvitation.status).to.deep.equal(OrganizationInvitation.StatusType.CANCELLED);
-  expect(archivedPendingOrganizationInvitation.updatedAt).to.deep.equal(updatedAt);
+  expect(archivedOrganizationInvitations).to.be.empty;
 }
 
 async function _assertOrganizationIsArchived({ archivedOrganizationId, user, archivedAt }) {

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/organization-for-admin.repository.test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/organization-for-admin.repository.test.js
@@ -445,16 +445,18 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
 
   describe('#archive', function () {
     context('when the organization does exist', function () {
-      it('should cancel all pending invitations of a given organization', async function () {
+      it('should hard delete all invitations of a given organization regardless of status', async function () {
         // given
         const superAdminUserId = databaseBuilder.factory.buildUser.withRole().id;
+
         const pendingStatus = OrganizationInvitation.StatusType.PENDING;
         const cancelledStatus = OrganizationInvitation.StatusType.CANCELLED;
         const acceptedStatus = OrganizationInvitation.StatusType.ACCEPTED;
-        const organizationId = databaseBuilder.factory.buildOrganization().id;
 
-        databaseBuilder.factory.buildOrganizationInvitation({ id: 1, organizationId, status: pendingStatus });
-        databaseBuilder.factory.buildOrganizationInvitation({ id: 2, organizationId, status: pendingStatus });
+        const organizationId = databaseBuilder.factory.buildOrganization().id;
+        const otherOrganizationId = databaseBuilder.factory.buildOrganization().id;
+
+        databaseBuilder.factory.buildOrganizationInvitation({ organizationId, status: pendingStatus });
         databaseBuilder.factory.buildOrganizationInvitation({
           organizationId,
           status: acceptedStatus,
@@ -462,6 +464,11 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
         databaseBuilder.factory.buildOrganizationInvitation({
           organizationId,
           status: cancelledStatus,
+        });
+
+        databaseBuilder.factory.buildOrganizationInvitation({
+          organizationId: otherOrganizationId,
+          status: pendingStatus,
         });
 
         await databaseBuilder.commit();
@@ -473,30 +480,16 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
         });
 
         // then
-        const pendingInvitations = await knex('organization-invitations').where({
+        const organizationInvitations = await knex('organization-invitations').where({
           organizationId,
-          status: pendingStatus,
         });
-        expect(pendingInvitations).to.have.lengthOf(0);
 
-        const allCancelledInvitations = await knex('organization-invitations').where({
-          organizationId,
-          status: cancelledStatus,
+        const otherOrganizationInvitations = await knex('organization-invitations').where({
+          organizationId: otherOrganizationId,
         });
-        expect(allCancelledInvitations).to.have.lengthOf(3);
 
-        const newlyCancelledInvitations = await knex('organization-invitations').where({
-          organizationId,
-          status: cancelledStatus,
-          updatedAt: now,
-        });
-        expect(newlyCancelledInvitations).to.have.lengthOf(2);
-
-        const acceptedInvitations = await knex('organization-invitations').where({
-          organizationId,
-          status: acceptedStatus,
-        });
-        expect(acceptedInvitations).to.have.lengthOf(1);
+        expect(organizationInvitations).to.have.lengthOf(0);
+        expect(otherOrganizationInvitations).to.have.lengthOf(1);
       });
 
       it('should delete active campaigns of a given organization', async function () {


### PR DESCRIPTION
## 🌱 Problème

Actuellement, lorsqu'on archive une organisation, toutes les invitations au statut "Pending" sont annulées (statut "Cancelled). Or lorsqu'une organisation est archivée, l'historique des invitations n'est plus nécessaire.

## 🐣 Proposition

Supprimer toutes les invitations d'une organisation (acceptées, annulés et en attente) lorsqu'on l'archive.

## 🌷 Remarques

RAS

## 🐝 Pour tester
Sur Pix Admin:
- aller sur la page d'une organisation
- envoyer quelques invitations
- lancer cette requête en BDD sur la RA:
```sql
SELECT * FROM "organization-invitations" WHERE "organizationId" = <id>;
```
- constater qu'on a le bon nombre d'invitations créées
- archiver cette organisation
- relancer la requête SQL
- constater qu'aucun résultat n'est remonté
- on peut renouveler le test avec des statuts différents d'invitations (en acceptant ou en modifiant directement en base)
