### PR TITLE
[TECH] Remplir la colonne lastAnswerAt lors du seeding de la BDD (PIX-22362).

### DIFF
--- a/api/db/seeds/data/team-certification/tools/publish-session-with-validated-certification.js
+++ b/api/db/seeds/data/team-certification/tools/publish-session-with-validated-certification.js
@@ -68,6 +68,9 @@ export default async function publishSessionWithValidatedCertification({
       challengeDate = challengeDate.add(`${timePad++ % 60}`, 'seconds');
       return challengeDate;
     };
+
+    let lastAnswerCreatedAt;
+
     for (const simulatedChallenge of simulatedCertification) {
       databaseBuilder.factory.buildCertificationChallenge({
         associatedSkillName: simulatedChallenge.challenge.skill.name,
@@ -95,9 +98,15 @@ export default async function publishSessionWithValidatedCertification({
         resultDetails: 'dummy value',
         timeSpent: 10,
       });
+
+      lastAnswerCreatedAt = getNewSecondPad();
     }
 
     await databaseBuilder.commit();
+
+    await knex('certification-courses')
+      .where('id', certificationCourse._id)
+      .update({ lastAnswerAt: lastAnswerCreatedAt.toDate() });
 
     const report = new CertificationReport({
       certificationCourseId: certificationCourse._id,


### PR DESCRIPTION
## 🌱 Problème

Aujourd'hui lorsqu'on fait un `npm run db:seed`, on ne remplit pas la nouvelle colonne `certification-courses.lastAnswerAt`.

## 🐣 Proposition

Modifier les seeds.

## 🐝 Pour tester

Lancer en local et vérifier que la colonne est bien remplie.
