### PR TITLE
[DOC] Créer le fichier CLAUDE.md du bounded context DevComp (PIX-22364)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ Notamment, dans Autres, vous pouvez trouver :
 
 Nom | Usage
 --- | ---
-DOCS | PR relative à de la documentation
+DOC | PR relative à de la documentation
 POC | PR relative à des Proofs of concept, ne doit pas être mergé
 
 Le titre de la PR originel (et donc son tag) reste dans tous les cas affiché dans chaque ligne du CHANGELOG.

--- a/api/src/devcomp/.gitignore
+++ b/api/src/devcomp/.gitignore
@@ -1,0 +1,1 @@
+!CLAUDE.md

--- a/api/src/devcomp/CLAUDE.md
+++ b/api/src/devcomp/CLAUDE.md
@@ -1,0 +1,77 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Purpose
+
+**Devcomp** (Développement de Compétences) manages interactive learning modules and trainings. It covers:
+- **Modules** — interactive learning content stored as JSON files, delivered through grains and elements
+- **Passages** — user sessions tracking progress through a module
+- **Trainings** — curated resources (modules, external links) tied to target profiles and recommendation triggers
+- **Tutorials** — supplementary learning content users can save and rate
+- **Recommendations** — trigger-based engine suggesting trainings based on user competency levels
+
+## Commands
+
+From `api/`:
+```bash
+# Run all devcomp tests
+npm run test:api:unit -- --grep devcomp
+
+# Run a specific test file
+npm run test:api:path -- tests/devcomp/unit/domain/usecases/get-module_test.js
+
+# Validate module JSON files
+npm run modulix:test
+
+# Load only DevComp seeds (faster local DB reset)
+export SEEDS_CONTEXT=DEVCOMP
+npm run db:reset
+```
+
+## Architecture
+
+### Module content
+
+Modules are stored as JSON files in `infrastructure/datasources/learning-content/modules/` (72 modules). They are loaded at startup into an in-memory datasource (`module-datasource.js`) and never persisted to the database. A SHA256 hash of the content serves as the module version.
+
+The `ModuleFactory` (`infrastructure/factories/module-factory.js`) recursively builds the full domain object tree: `Module → Sections → Grains → Components → Elements`. Element type dispatch happens here.
+
+### Element types
+
+Elements are either **non-answerable** (Text, Video, Audio, Image, Separator, Expand…) or **answerable** (QCM, QCU, QCUDeclarative, QCUDiscovery, QROCM, Embed, Flashcards, QAB). Answerable elements have an `assess()` method and a corresponding `Validator*` class in `domain/models/validator/`.
+
+### Passage lifecycle
+
+1. `createPassage()` — creates a DB row, returns a `Passage` with `id`, `moduleId`, `userId`
+2. `verifyAndSaveAnswer()` — delegates to `ElementAnswer` which calls `element.assess()`; saves result
+3. `recordPassageEvents()` — stores typed events (`PassageEvent` subclasses) with `sequenceNumber` and `contentHash` (the module version hash)
+4. `terminatePassage()` — sets `terminatedAt`
+
+### Training recommendation
+
+`TrainingTrigger` has type `PREREQUISITE` or `GOAL` and a skill threshold. `isFulfilled()` checks knowledge elements against that threshold. `Training.shouldBeObtained()` iterates triggers to determine if a training applies. The recommendation event flow goes through `handleTrainingRecommendation()`.
+
+### Cross-context integration
+
+Devcomp imports external repositories by name (injected via DI) from:
+- `prescription` context — campaigns, target profiles
+- `shared` context — knowledge elements, skills, tubes
+- `identity-access-management` context — users
+
+These are never imported directly; they arrive as injected parameters.
+
+### Domain errors
+
+Defined in `domain/errors.js`: `ModuleDoesNotExistError`, `PassageDoesNotExistError`, `PassageTerminatedError`, `ModuleInstantiationError`, `ElementInstantiationError`.
+
+## Key files
+
+| Concern | Path |
+|---|---|
+| Route registration | `routes.js` |
+| Usecase DI wiring | `domain/usecases/index.js` |
+| Repository exports | `infrastructure/repositories/index.js` |
+| Module datasource | `infrastructure/datasources/learning-content/module-datasource.js` |
+| Module factory | `infrastructure/factories/module-factory.js` |
+| Domain errors | `domain/errors.js` |

--- a/api/src/devcomp/CLAUDE.md
+++ b/api/src/devcomp/CLAUDE.md
@@ -5,6 +5,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Purpose
 
 **Devcomp** (Développement de Compétences) manages interactive learning modules and trainings. It covers:
+
 - **Modules** — interactive learning content stored as JSON files, delivered through grains and elements
 - **Passages** — user sessions tracking progress through a module
 - **Trainings** — curated resources (modules, external links) tied to target profiles and recommendation triggers
@@ -14,6 +15,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Commands
 
 From `api/`:
+
 ```bash
 # Run all devcomp tests
 npm run test:api:unit -- --grep devcomp
@@ -55,6 +57,7 @@ Elements are either **non-answerable** (Text, Video, Audio, Image, Separator, Ex
 ### Cross-context integration
 
 Devcomp imports external repositories by name (injected via DI) from:
+
 - `prescription` context — campaigns, target profiles
 - `shared` context — knowledge elements, skills, tubes
 - `identity-access-management` context — users
@@ -67,11 +70,11 @@ Defined in `domain/errors.js`: `ModuleDoesNotExistError`, `PassageDoesNotExistEr
 
 ## Key files
 
-| Concern | Path |
-|---|---|
-| Route registration | `routes.js` |
-| Usecase DI wiring | `domain/usecases/index.js` |
-| Repository exports | `infrastructure/repositories/index.js` |
-| Module datasource | `infrastructure/datasources/learning-content/module-datasource.js` |
-| Module factory | `infrastructure/factories/module-factory.js` |
-| Domain errors | `domain/errors.js` |
+| Concern            | Path                                                               |
+| ------------------ | ------------------------------------------------------------------ |
+| Route registration | `routes.js`                                                        |
+| Usecase DI wiring  | `domain/usecases/index.js`                                         |
+| Repository exports | `infrastructure/repositories/index.js`                             |
+| Module datasource  | `infrastructure/datasources/learning-content/module-datasource.js` |
+| Module factory     | `infrastructure/factories/module-factory.js`                       |
+| Domain errors      | `domain/errors.js`                                                 |


### PR DESCRIPTION
## 🌱 Problème

Chaque membre de l'équipe DevComp crée aujourd’hui un CLAUDE.md avant. Il serait plus intéressant (et plus économique) de partager ce fichier ente tous les membres de l'équipe. Mais le fichier à la racine est aujourd’hui gitignoré car dans le cadre de l’expérience on ne veut pas qu’une équipe impose ses pratiques aux autres.

## 🐣 Proposition

- Ajouter un fichier CLAUDE.md dans Confluence (charge à chaque membre de l'équipe de le copier dans dépôt local)
- Ajouter un fichier CLAUDE.md dans `api/src/devcomp` concernant uniquement le bounded context “devcomp” et qui peut donc être commité

## 🌷 Remarques

Une correction a été apportée au guide de contribution (CONTRIBUTING.md) qui mentionnait le tag de PR "DOCS" là où la github action de validation des titres de titres de PR attendait "DOC".

https://github.com/1024pix/pix-actions/blob/main/check-pr-title/action.yml

## 🐝 Pour tester

- Relire https://1024pix.atlassian.net/wiki/x/AQB6ZQE 
- Relire [`api/src/devcomp/CLAUDE.md`](https://github.com/1024pix/pix/pull/15850/changes/9375549f2d5dbb17e1095ebaa04eee632f20d67d#diff-de2a153873ad46f80ee0c6de13be0212896620f4e6ccbf271c94d3ea90bfbad7)
