### PR TITLE
[TECH] Ajouter des logs de timing aux erreurs OIDC (PIX-22335)

### DIFF
--- a/api/src/identity-access-management/domain/services/oidc-authentication-service.js
+++ b/api/src/identity-access-management/domain/services/oidc-authentication-service.js
@@ -122,12 +122,15 @@ export class OidcAuthenticationService {
   async initializeClientConfig() {
     if (this.#openidClientConfig) return;
 
+    let startDate;
+
     try {
       const metadata = {
         client_secret: this.clientSecret,
         ...this.openidClientExtraMetadata,
       };
 
+      startDate = new Date();
       this.#openidClientConfig = await this.#openidClient.discovery(
         new URL(this.openidConfigurationUrl),
         this.clientId,
@@ -138,11 +141,14 @@ export class OidcAuthenticationService {
         data: { organizationName: this.organizationName },
         error,
         event: 'initialize-client-config',
+        startDate,
       });
     }
   }
 
   getAuthorizationUrl() {
+    let startDate;
+
     try {
       const state = randomUUID();
       const nonce = randomUUID();
@@ -154,6 +160,7 @@ export class OidcAuthenticationService {
         ...this.extraAuthorizationUrlParameters,
       };
 
+      startDate = new Date();
       const redirectTarget = this.#openidClient.buildAuthorizationUrl(this.#openidClientConfig, parameters);
 
       return { redirectTarget, state, nonce };
@@ -162,12 +169,15 @@ export class OidcAuthenticationService {
         data: { organizationName: this.organizationName },
         error,
         event: 'generate-authorization-url',
+        startDate,
       });
       throw new OidcError({ message: error.message });
     }
   }
 
   async exchangeCodeForTokens({ code, state, iss, nonce, sessionState }) {
+    let startDate;
+
     try {
       const currentUrl = new URL(this.redirectUri);
       if (code) currentUrl.searchParams.append('code', code);
@@ -177,6 +187,7 @@ export class OidcAuthenticationService {
 
       const checks = { expectedNonce: nonce, expectedState: sessionState };
 
+      startDate = new Date();
       const tokenResponse = await this.#openidClient.authorizationCodeGrant(
         this.#openidClientConfig,
         currentUrl,
@@ -194,6 +205,7 @@ export class OidcAuthenticationService {
         data: { code, nonce, organizationName: this.organizationName, sessionState, state, iss },
         error,
         event: 'exchange-code-for-tokens',
+        startDate,
       });
       throw new OidcError({ message: error.message });
     }
@@ -275,7 +287,10 @@ export class OidcAuthenticationService {
       parameters.post_logout_redirect_uri = this.postLogoutRedirectUri;
     }
 
+    let startDate;
+
     try {
+      startDate = new Date();
       const endSessionUrl = this.#openidClient.buildEndSessionUrl(this.#openidClientConfig, parameters);
 
       await this.sessionTemporaryStorage.delete(key);
@@ -286,6 +301,7 @@ export class OidcAuthenticationService {
         data: { organizationName: this.organizationName },
         error,
         event: 'get-redirect-logout-url',
+        startDate,
       });
       throw new OidcError({ message: error.message });
     }
@@ -293,14 +309,17 @@ export class OidcAuthenticationService {
 
   async _getUserInfoFromEndpoint({ accessToken, expectedSubject }) {
     let userInfo;
+    let startDate;
 
     try {
+      startDate = new Date();
       userInfo = await this.#openidClient.fetchUserInfo(this.#openidClientConfig, accessToken, expectedSubject);
     } catch (error) {
       _monitorOidcError(error.message, {
         data: { organizationName: this.organizationName },
         error,
         event: 'get-user-info-from-endpoint',
+        startDate,
       });
       throw new OidcError({ message: error.message });
     }
@@ -328,7 +347,7 @@ export class OidcAuthenticationService {
   }
 }
 
-function _monitorOidcError(message, { data, error, event }) {
+function _monitorOidcError(message, { data, error, event, startDate }) {
   const monitoringData = {
     message,
     context: 'oidc',
@@ -345,6 +364,10 @@ function _monitorOidcError(message, { data, error, event }) {
       ...(error.error_uri && { errorUri: error.error_uri }),
       ...(error.response && { response: error.response }),
     };
+  }
+
+  if (startDate) {
+    monitoringData.duration = new Date() - startDate;
   }
 
   logger.error(monitoringData);

--- a/api/tests/identity-access-management/unit/domain/services/oidc-authentication-service.test.js
+++ b/api/tests/identity-access-management/unit/domain/services/oidc-authentication-service.test.js
@@ -19,10 +19,17 @@ const MOCK_OIDC_PROVIDER_CONFIG = Symbol('config');
 
 describe('Unit | Domain | Services | oidc-authentication-service', function () {
   let openidClient;
+  let clock;
 
   beforeEach(function () {
-    openidClient = createOpenIdClientMock(MOCK_OIDC_PROVIDER_CONFIG);
+    clock = sinon.useFakeTimers({ toFake: ['Date'] });
     sinon.stub(logger, 'error');
+
+    openidClient = createOpenIdClientMock(MOCK_OIDC_PROVIDER_CONFIG);
+  });
+
+  afterEach(function () {
+    clock.restore();
   });
 
   describe('constructor', function () {
@@ -252,8 +259,12 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
           get: sinon.stub().resolves(idToken),
           delete: sinon.stub().resolves(),
         };
+
         const errorThrown = new Error('Fails to generate endSessionUrl');
-        openidClient.buildEndSessionUrl.throws(errorThrown);
+        openidClient.buildEndSessionUrl.callsFake(() => {
+          clock.tick(2000);
+          throw errorThrown;
+        });
 
         const oidcAuthenticationService = new OidcAuthenticationService(settings.oidcExampleNet, {
           sessionTemporaryStorage,
@@ -281,6 +292,11 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
           event: 'get-redirect-logout-url',
           message: errorThrown.message,
           team: 'acces',
+          duration: sinon.match.number.and(
+            sinon.match((val) => {
+              return val >= 2000;
+            }),
+          ),
         });
       });
     });
@@ -346,12 +362,14 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         const iss = 'https://issuer.url';
         const sessionState = 'sessionState';
         const state = 'state';
-        const errorThrown = new Error('Fails to get tokens');
 
+        const errorThrown = new Error('Fails to get tokens');
         errorThrown.error_uri = '/oauth2/token';
         errorThrown.response = 'api call response here';
-
-        openidClient.authorizationCodeGrant.rejects(errorThrown);
+        openidClient.authorizationCodeGrant.callsFake(() => {
+          clock.tick(2000);
+          throw errorThrown;
+        });
 
         const oidcAuthenticationService = new OidcAuthenticationService(
           {
@@ -395,6 +413,11 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
           event: 'exchange-code-for-tokens',
           message: errorThrown.message,
           team: 'acces',
+          duration: sinon.match.number.and(
+            sinon.match((val) => {
+              return val >= 2000;
+            }),
+          ),
         });
       });
     });
@@ -448,9 +471,12 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         const identityProvider = 'identityProvider';
         const redirectUri = 'https://example.org/please-redirect-to-me';
         const openidConfigurationUrl = 'https://example.org/oidc-provider-configuration';
-        const errorThrown = new Error('Fails to generate authorization url');
 
-        openidClient.buildAuthorizationUrl.throws(errorThrown);
+        const errorThrown = new Error('Fails to generate authorization url');
+        openidClient.buildAuthorizationUrl.callsFake(() => {
+          clock.tick(2000);
+          throw errorThrown;
+        });
 
         const oidcAuthenticationService = new OidcAuthenticationService(
           {
@@ -482,6 +508,11 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
           event: 'generate-authorization-url',
           message: errorThrown.message,
           team: 'acces',
+          duration: sinon.match.number.and(
+            sinon.match((val) => {
+              return val >= 2000;
+            }),
+          ),
         });
       });
     });
@@ -742,9 +773,12 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         const identityProvider = 'identityProvider';
         const redirectUri = 'https://example.org/please-redirect-to-me';
         const openidConfigurationUrl = 'https://example.org/oidc-provider-configuration';
-        const errorThrown = new Error('Fails to get user info');
 
-        openidClient.fetchUserInfo.rejects(errorThrown);
+        const errorThrown = new Error('Fails to get user info');
+        openidClient.fetchUserInfo.callsFake(() => {
+          clock.tick(2000);
+          throw errorThrown;
+        });
 
         const oidcAuthenticationService = new OidcAuthenticationService(
           {
@@ -776,6 +810,11 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
           },
           event: 'get-user-info-from-endpoint',
           team: 'acces',
+          duration: sinon.match.number.and(
+            sinon.match((val) => {
+              return val >= 2000;
+            }),
+          ),
         });
       });
     });


### PR DESCRIPTION
## 🌱 Problème

Dans la continuité de #14538 on souhaite ajouter en plus l’information de durée que prennent les requêtes OIDC.

## 🐣 Proposition

Ajouter une propriété `duration` dans les logs produit par la fonction `_monitorOidcError`.

## 🌷 Remarques

RAS

## 🐝 Pour tester

### Tests de non-régression

En local tester qu’il n’y a pas de régression en se connectant par OIDC à une application Front, soit Pix App, soit Pix Orga, soit Pix Admin.

### Tests sur la présence de la durée dans les logs d’erreur

En local tester que le monitoring des erreurs OIDC est bien augmenté avec une propriété `duration`.

1. Dans le fichier `api/src/identity-access-management/domain/services/oidc-authentication-service.js` modifier la fonction `initializeClientConfig` en y ajoutant une erreur comme ci-dessous : 
   ```javascript

    try {
      const metadata = {
        client_secret: this.clientSecret,
        ...this.openidClientExtraMetadata,
      };

      startDate = new Date();

      await new Promise((resolve) => setTimeout(() => resolve(), 3000));
      throw new Error('Error from test');

      // this.#openidClientConfig = await this.#openidClient.discovery(
      //   new URL(this.openidConfigurationUrl),
      //   this.clientId,
      //   metadata,
      // );
    } catch (error) {
      _monitorOidcError(`Failed init for OIDC Provider "${this.identityProvider}"`, {
        data: { organizationName: this.organizationName },
        error,
        event: 'initialize-client-config',
        startDate,
      });
    }
   ```
2. Sur Pix App, sans être authentifié, aller sur `Se connecter avec France Travail` ou sur n’importe quelle autre organisation
3. Constater qu’une erreur est loggée dans le terminal avec une propriété `duration` d’une valeur de `3000` ms ou un peu plus (par exemple `3002`).

