### PR TITLE
[BUGFIX] Renommer la clé de la feature du moteur de reco (PIX-22363)

### DIFF
--- a/api/db/migrations/20260414153434_add-update-recommendationEngine-feature-key.js
+++ b/api/db/migrations/20260414153434_add-update-recommendationEngine-feature-key.js
@@ -1,0 +1,28 @@
+import { CAMPAIGN_FEATURES } from '../../src/shared/domain/constants.js';
+
+const OLD_KEY = JSON.stringify(CAMPAIGN_FEATURES.RECOMMENDATION_ENGINE);
+const OLD_DESCRIPTION = "Permet d'indiquer si la campagne est concernée par le moteur de recommandations";
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex('features').where({ key: OLD_KEY }).update({
+    key: CAMPAIGN_FEATURES.RECOMMENDATION_ENGINE.key,
+    description: CAMPAIGN_FEATURES.RECOMMENDATION_ENGINE.description,
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex('features').where({ key: CAMPAIGN_FEATURES.RECOMMENDATION_ENGINE.key }).update({
+    key: OLD_KEY,
+    description: OLD_DESCRIPTION,
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## 🌱 Problème
Pour une raison obscure, la valeur de la `key` de la feature du moteur de reco n'est pas la bonne dans la table `features`. En regardant le script qui était passé, il contient une erreur, mais n'aurait jamais du pouvoir passer en integration. Comme dirait quelqu'un, le mystère reste total. 

## 🐣 Proposition
Faire un nouveau script de migration afin de mettre à jour la colonne `key` de la table `feature` avec bonne valeur.

## 🌷 Remarques
Mais quel mystère 

## 🐝 Pour tester
- Lancer la migration en local : `npm run db:reset`
- Avec son SGBD préféré, vérifier que la valeur de la `key` de la table `features` est bien`RECOMMENDATION_ENGINE`
- Les tests sont verts 
- Aller sur la RA
- Passer la campagne `SCOASSIMP` avec `learneremail1000_5@example.net`
- Constater dans le réseau que la camapgne a bien le flag `recommendation-engine` à `true`.
