### PR TITLE
[FEATURE] Changer la durée de validité du code de vérification d'e-mail (PIX-22065).

### DIFF
--- a/api/sample.env
+++ b/api/sample.env
@@ -1111,7 +1111,13 @@ ATTESTATIONS_STORAGE_ENDPOINT=http://localhost:9090
 ATTESTATIONS_STORAGE_REGION=pix
 ATTESTATIONS_STORAGE_BUCKET_NAME=pix-attestations-dev
 
-
+## =====
+## ADD AND UPDATE EMAIL VALIDATION CODE LIFESPAN
+## =====
+# presence: optional
+# type: string
+# sample: EMAIL_VALIDATION_CODE_LIFESPAN=1h
+EMAIL_VALIDATION_CODE_LIFESPAN=1h
 
 # presence: required
 # type: string

--- a/api/src/identity-access-management/infrastructure/repositories/user-email.repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/user-email.repository.js
@@ -3,7 +3,7 @@ import { temporaryStorage } from '../../../shared/infrastructure/key-value-stora
 import { EmailModificationDemand } from '../../domain/models/EmailModificationDemand.js';
 const verifyEmailTemporaryStorage = temporaryStorage.withPrefix('verify-email:');
 
-const EXPIRATION_DELAY_SECONDS = config.temporaryStorage.expirationDelaySeconds;
+const EXPIRATION_DELAY_SECONDS = config.temporaryStorageForEmailValidationCode.expirationDelaySeconds;
 
 /**
  *

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -517,6 +517,9 @@ const configuration = (function () {
     temporaryStorageForEmailValidationDemands: {
       expirationDelaySeconds: ms(process.env.EMAIL_VALIDATION_DEMAND_TEMPORARY_STORAGE_LIFESPAN || '3d') / 1000,
     },
+    temporaryStorageForEmailValidationCode: {
+      expirationDelaySeconds: ms(process.env.EMAIL_VALIDATION_CODE_LIFESPAN || '1h') / 1000,
+    },
     temporaryStorageForAnonymousUserTokens: {
       expirationDelaySeconds: ms(process.env.ANONYMOUS_USER_TOKEN_TEMPORARY_STORAGE_LIFESPAN || '1d') / 1000,
     },

--- a/mon-pix/translations/de.json
+++ b/mon-pix/translations/de.json
@@ -2389,7 +2389,7 @@
           "unknown-error": "Es ist ein Fehler aufgetreten. Bitte versuchen Sie es noch einmal oder wenden Sie sich an den Support."
         },
         "send-back-the-code": "mir den Code zurückschicken",
-        "time-code-validation": "Der empfangene Code ist 10 Minuten lang gültig",
+        "time-code-validation": "Der erhaltene Code ist eine Stunde lang gültig",
         "title": "Überprüfung Ihrer E-Mail-Adresse",
         "update-successful": "Ihre E-Mail-Adresse wurde geändert!",
         "validate-new-email": "Neue E-Mail bestätigen"

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -2389,7 +2389,7 @@
           "unknown-error": "An error has occurred. Please try again or contact the support."
         },
         "send-back-the-code": "Send the code again",
-        "time-code-validation": "The code received is valid for 10 minutes",
+        "time-code-validation": "The code received is valid for one hour",
         "title": "Verify your email address",
         "update-successful": "Your email address has been changed!",
         "validate-new-email": "Validate new email"

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -2371,7 +2371,7 @@
           "unknown-error": "Se ha producido un error. Vuelve a intentarlo o ponte en contacto con el servicio de asistencia."
         },
         "send-back-the-code": "volver a enviarme el código",
-        "time-code-validation": "El código recibido es válido durante 10 minutos",
+        "time-code-validation": "El código recibido es válido durante una hora",
         "title": "Comprobación de tu dirección de correo electrónico",
         "update-successful": "Tu dirección de correo electrónico ha sido modificada.",
         "validate-new-email": "Validar nuevo correo electrónico"

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -2390,7 +2390,7 @@
           "unknown-error": "Une erreur est survenue. Veuillez recommencer ou contacter le support."
         },
         "send-back-the-code": "me renvoyer le code",
-        "time-code-validation": "Le code reçu est valide pendant 10 minutes",
+        "time-code-validation": "Le code reçu est valide pendant une heure",
         "title": "Vérification de votre adresse e-mail",
         "update-successful": "Votre adresse e-mail a été changée !",
         "validate-new-email": "Valider ma nouvelle adresse e-mail"

--- a/mon-pix/translations/it.json
+++ b/mon-pix/translations/it.json
@@ -2382,7 +2382,7 @@
           "unknown-error": "Si è verificato un errore. Riprovare o contattare l'assistenza."
         },
         "send-back-the-code": "inviami il codice",
-        "time-code-validation": "Il codice ricevuto è valido per 10 minuti",
+        "time-code-validation": "Il codice ricevuto è valido per un'ora",
         "title": "Controllo dell'indirizzo e-mail",
         "update-successful": "Il tuo indirizzo e-mail è stato modificato!",
         "validate-new-email": "Conferma nuovo indirizzo e-mail"

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -2380,7 +2380,7 @@
           "unknown-error": "Er is een fout opgetreden. Probeer het opnieuw of neem contact op met de klantenservice."
         },
         "send-back-the-code": "stuur me de code",
-        "time-code-validation": "De ontvangen code is 10 minuten geldig",
+        "time-code-validation": "De ontvangen code is één uur geldig",
         "title": "Je e-mailadres controleren",
         "update-successful": "Je e-mailadres is gewijzigd!",
         "validate-new-email": "Valideer nieuw e-mailadres"


### PR DESCRIPTION
## 🌱 Problème
On passe la durée de vie du code de vérification une heure par défaut dans tous les usages : 
- Modification d’email
- Ajout de méthode de connexion email et mot de passe

La modification doit être faite au niveau de l’enregistrement dans la base redis et dans le frontend (message affiché sur l'écran de saisie du code)

## 🐣 Proposition
Ajouter une nouvelle variable d'environnement EMAIL_VALIDATION_CODE_LIFESPAN dont la valeur par défaut est une heure.

## 🌷 Remarques
Dans le cas d'une modification d'email réussie, deux notifications de succès apparaissent l'une au-dessus de l'autre (adresse e-mail vérifiée et adresse e-mail modifiée avec succès). On ajoute un margin-top par souci de rendu esthétique.

## 🐝 Pour tester
- Modifier la valeur de la variable d'env EMAIL_VALIDATION_CODE_LIFESPAN à un délai court (15s par exemple) 
- Se connecter à Pix App avec un utilisateur SSO
- Aller sur Mon compte > Méthodes de connexion
- Ajouter une adresse e-mail : Renseigner son mail et un mot de passe valide
- Attendre le délai de 15 secondes avant de renseigner le code reçu et d'appuyer sur Valider ma nouvelle adresse e-mail
- Constater qu'une erreur "Code plus valide" apparait