### PR TITLE
[TECH] S'assurer que les envois répétés de signaux de fermeture d'API ne déclenchent pas plusieurs fois les opérations d'extinction

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -15,6 +15,7 @@ import { validateEnvironmentVariables } from './src/shared/infrastructure/valida
 validateEnvironmentVariables(configSchema);
 
 let server;
+let isShuttingDown = false;
 
 async function _setupEcosystem() {
   /*
@@ -38,6 +39,10 @@ const start = async function () {
 };
 
 async function _exitOnSignal(signal) {
+  if (isShuttingDown) {
+    return;
+  }
+  isShuttingDown = true;
   logger.info(`Received signal: ${signal}.`);
   logger.info('Stopping HAPI server...');
   await server.stop({ timeout: 30000 });

--- a/api/index.maddo.js
+++ b/api/index.maddo.js
@@ -9,6 +9,7 @@ import { validateEnvironmentVariables } from './src/shared/infrastructure/valida
 validateEnvironmentVariables(configSchema);
 
 let server;
+let isShuttingDown = false;
 
 const start = async function () {
   server = await createMaddoServer();
@@ -16,6 +17,10 @@ const start = async function () {
 };
 
 async function _exitOnSignal(signal) {
+  if (isShuttingDown) {
+    return;
+  }
+  isShuttingDown = true;
   logger.info(`Received signal: ${signal}.`);
   logger.info('Stopping HAPI server...');
   await server.stop({ timeout: 30000 });

--- a/api/tests/certification/session-management/unit/domain/models/CertificationAssessment_test.js
+++ b/api/tests/certification/session-management/unit/domain/models/CertificationAssessment_test.js
@@ -771,12 +771,15 @@ describe('Unit | Domain | Models | CertificationAssessment', function () {
         certificationAnswersByDate: [
           domainBuilder.buildAnswer({
             challengeId: 'rec123',
+            createdAt: new Date('2020-01-01'),
           }),
           domainBuilder.buildAnswer({
             challengeId: 'rec456',
+            createdAt: new Date('2020-02-02'),
           }),
           domainBuilder.buildAnswer({
             challengeId: 'rec789',
+            createdAt: new Date('2020-03-03'),
           }),
         ],
       });
@@ -788,6 +791,7 @@ describe('Unit | Domain | Models | CertificationAssessment', function () {
       expect(certificationAssessmentAnswer).to.deep.equal(
         domainBuilder.buildAnswer({
           challengeId: 'rec456',
+          createdAt: new Date('2020-02-02'),
         }),
       );
     });


### PR DESCRIPTION
## 🌱 Problème

Selon les environnements, les OS, les containers, etc, lorsqu'on tue l'API via un signal (type SIGINT ou SIGTERM par exemple), il peut arriver que le signal soit émis plusieurs fois.
Aujourd'hui, cela fait planter l'extinction de l'API car le JobClient de PGBoss lance deux fois ses fonctions d'arrêt.

<img width="1175" height="397" alt="image" src="https://github.com/user-attachments/assets/e7669c8c-b6ff-42e5-98b8-1c506ba97bf8" />


## 🐣 Proposition

S'assurer de ne lancer qu'une seule fois les opérations d'extinction à l'aide d'un flag (j'ai copié worker.js malgré moi quand j'ai fait le tour du propriétaire, au nom de variable près 😄 )

## 🌷 Remarques

Fait pour l'API + Maddo. Pour le worker c'était déjà fait

## 🐝 Pour tester

lancer l'API en local, faire CTRL+C et constater un arrêt gracieux de l'API
