### PR TITLE
[TECH] Répare la configuration eslint sur les fichiers gjs de Pix Orga.

### DIFF
--- a/orga/eslint.config.mjs
+++ b/orga/eslint.config.mjs
@@ -1,6 +1,5 @@
 import pixRecommendedConfig from '@1024pix/eslint-plugin/config';
 import babelParser from '@babel/eslint-parser';
-import emberParser from 'ember-eslint-parser';
 import emberRecommendedConfig from 'eslint-plugin-ember/configs/recommended';
 import emberGjsRecommendedConfig from 'eslint-plugin-ember/configs/recommended-gjs';
 import i18nJsonPlugin from 'eslint-plugin-i18n-json';
@@ -26,15 +25,10 @@ const nodeFiles = [
   'server/**/*.js',
 ];
 
-const emberPatchedParser = Object.assign(
-  {
-    meta: {
-      name: 'ember-eslint-parser',
-      version: '*',
-    },
-  },
-  emberParser,
-);
+// Reuse the same ember-eslint-parser instance that emberGjsRecommendedConfig uses internally,
+// so that the parser and the noop processor (which coordinate via a shared Set) stay in sync.
+const gjsParserConfig = emberGjsRecommendedConfig.find((c) => c.languageOptions?.parser);
+const emberParser = gjsParserConfig?.languageOptions?.parser;
 
 export default [
   ...pixRecommendedConfig,
@@ -71,8 +65,18 @@ export default [
   {
     files: ['**/*.gjs'],
     languageOptions: {
-      parser: emberPatchedParser,
+      parser: emberParser,
       sourceType: 'module',
+    },
+  },
+  {
+    files: ['tests/**/*.js', 'tests/**/*.gjs'],
+
+    languageOptions: {
+      globals: {
+        ...globals.embertest,
+        server: false,
+      },
     },
   },
   {


### PR DESCRIPTION
## 🌱 Problème

Lorsqu'on lance la tâche `npm run lint` sur Pix Orga on constate 399 warnings indiquant que la configuration eslint des fichiers gjs est invalide.
Cela laisse à penser que les fichiers gjs ne sont plus lintés.

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

## 🐣 Proposition

On applique la même configuration pour les fichiers gjs que celle, fonctionnelle, de Pix Admin.

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 🌷 Remarques

RAS

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🐝 Pour tester

Vérifier qu'aucun warning n'est affiché dans le résultat de `orga_lint` sur la CI.

<!--
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc.
- [ ] Documentation de la fonctionnalité (lien)
-->
