### PR TITLE
[TECH] Déplacer ou supprimer les derniers helpers de test-helper.js

### DIFF
--- a/api/tests/devcomp/integration/application/trainings/training-route_test.js
+++ b/api/tests/devcomp/integration/application/trainings/training-route_test.js
@@ -3,7 +3,7 @@ import { trainingController } from '../../../../../src/devcomp/application/train
 import * as moduleUnderTest from '../../../../../src/devcomp/application/trainings/training-route.js';
 import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
 import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
-import { getAdminRoleStub } from '../../../../tooling/security-pre-handlers-helpers.js';
+import { getAdminRoleStub } from '../../../../tooling/mocks/security-pre-handlers.mock.js';
 
 describe('Integration | Devcomp | Application | Trainings | Router | training-router', function () {
   describe('GET /api/admin/trainings/${trainingId}', function () {

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -1,7 +1,5 @@
 import 'dayjs/locale/fr.js';
 
-import querystring from 'node:querystring';
-
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import chaiSorted from 'chai-sorted';
@@ -20,8 +18,6 @@ import { disconnect, knex } from '../db/knex-database-connection.js';
 import { createServer } from '../server.js';
 import { createMaddoServer } from '../server.maddo.js';
 import * as tutorialRepository from '../src/devcomp/infrastructure/repositories/tutorial-repository.js';
-import { ApplicationAccessToken } from '../src/identity-access-management/domain/models/ApplicationAccessToken.js';
-import { UserAccessToken } from '../src/identity-access-management/domain/models/UserAccessToken.js';
 import * as missionRepository from '../src/school/infrastructure/repositories/mission-repository.js';
 import { featureToggles } from '../src/shared/infrastructure/feature-toggles/index.js';
 import { JobClient } from '../src/shared/infrastructure/jobs/JobClient.js';
@@ -42,8 +38,15 @@ import { increaseCurrentTestTimeout } from './tooling/mocha-tools.js';
 import { mockAttestationStorage, mockAttestationStorageUpload } from './tooling/mocks/attestation-storage.mock.js';
 import { hFake } from './tooling/mocks/hapi.mock.js';
 import { HttpTestServer } from './tooling/server/http-test-server.js';
+import { catchErr, catchErrSync, preventStubsToBeCalledUnexpectedly } from './tooling/test-utils/error.js';
 import { createTempFile, isSameBinary, removeTempFile } from './tooling/test-utils/file.js';
+import {
+  generateAuthenticatedUserRequestHeaders,
+  generateInjectOptions,
+  generateValidRequestAuthorizationHeaderForApplication,
+} from './tooling/test-utils/http-server.js';
 import { parseNDJSON } from './tooling/test-utils/json.js';
+import { wait, waitForStreamFinalizationToBeDone } from './tooling/test-utils/wait.js';
 
 // Init Dayjs configuration
 dayjs.extend(localizedFormat);
@@ -64,19 +67,19 @@ const databaseBuilder = await DatabaseBuilder.create({
     increaseCurrentTestTimeout(2000);
   },
 });
+// TEMPORARY WORKAROUND
+databaseBuilder.factory.learningContent.injectNock(nock);
 
+// Init Datamart builders
 const datamartBuilder = await DatamartBuilder.create({
   knex: datamartKnex,
 });
 
-// TEMPORARY WORKAROUND
-databaseBuilder.factory.learningContent.injectNock(nock);
-
-nock.disableNetConnect();
-nock.enableNetConnect('localhost:9090');
-
 /* eslint-disable mocha/no-top-level-hooks */
 before(async function () {
+  nock.disableNetConnect();
+  nock.enableNetConnect('localhost:9090'); // Unmock S3 storage
+
   try {
     await JobClient.instance.initialize();
   } catch {
@@ -117,141 +120,12 @@ after(async function () {
   }
   return await disconnect();
 });
-
 /* eslint-enable mocha/no-top-level-hooks */
-
-/**
- * For acceptance tests. To be used as `const options = generateInjectOptions; await server.inject(options);`
- *
- * @param {Object} params
- * @param {string} params.url
- * @param {string} params.method
- * @param {Object} [params.payload]
- * @param {string} [params.locale]
- * @param {string} [params.audience]
- * @param {Object} [params.authorizationData] - data to generate an AccessToken, for example: { userId: 1234 }
- * @param {boolean} [params.urlEncodePayload]
- * @returns {Object} options
- */
-function generateInjectOptions({ url, method, payload, locale, audience, authorizationData, urlEncodePayload }) {
-  const options = {
-    url,
-    method,
-    headers: {
-      // cf. cookies = req.headers.cookie in @hapi/hapi/lib/route.js +369
-      ...(locale && { cookie: `locale=${locale}` }),
-      ...(audience && generateForwardedHeaders(audience)),
-    },
-  };
-
-  if (payload) {
-    if (urlEncodePayload) {
-      options.payload = querystring.stringify(payload);
-      options.headers['content-type'] = 'application/x-www-form-urlencoded';
-    } else {
-      options.payload = payload;
-    }
-  }
-
-  if (authorizationData) {
-    if (!audience) {
-      throw new Error('You must provide an audience parameter when providing authorizationData.');
-    }
-
-    const accessToken = UserAccessToken.generateUserToken({ ...authorizationData, audience }).accessToken;
-    options.headers.authorization = `Bearer ${accessToken}`;
-  }
-
-  return options;
-}
-
-/**
- * @param {Object} params
- * @param {number} params.userId
- * @param {string} params.source
- * @param {string} params.audience - an origin URL, for example: https://app.pix.org
- * @returns {Object} headers
- */
-function generateAuthenticatedUserRequestHeaders({
-  userId = 1234,
-  source = 'pix',
-  audience = 'https://app.pix.org',
-} = {}) {
-  const accessToken = UserAccessToken.generateUserToken({ userId, source, audience }).accessToken;
-
-  return {
-    ...generateForwardedHeaders(audience),
-    authorization: `Bearer ${accessToken}`,
-  };
-}
-
-/**
- * Generates HTTP X-Forwarded-Proto (XFP) headers.
- *
- * @param {string} audience - an origin URL, for example: https://app.pix.org
- * @returns {Object} headers
- */
-function generateForwardedHeaders(audience) {
-  const url = new URL(audience);
-  const protoHeader = url.protocol.slice(0, -1);
-  const hostHeader = url.hostname;
-
-  return { 'x-forwarded-proto': protoHeader, 'x-forwarded-host': hostHeader };
-}
-
-function generateValidRequestAuthorizationHeaderForApplication(clientId = 'client-id-name', source, scope = '') {
-  const accessToken = ApplicationAccessToken.generate({ clientId, source, scope });
-  return `Bearer ${accessToken}`;
-}
-
-function catchErr(promiseFn, ctx) {
-  return async (...args) => {
-    try {
-      await promiseFn.call(ctx, ...args);
-    } catch (err) {
-      return err;
-    }
-    throw new Error('Expected an error, but none was thrown.');
-  };
-}
-
-function catchErrSync(fn, ctx) {
-  return (...args) => {
-    try {
-      fn.call(ctx, ...args);
-    } catch (err) {
-      return err;
-    }
-    throw new Error('Expected an error, but none was thrown.');
-  };
-}
 
 async function mockLearningContent(learningContent) {
   const scope = databaseBuilder.factory.learningContent.build(learningContent);
   await databaseBuilder.commit();
   return scope;
-}
-
-const preventStubsToBeCalledUnexpectedly = (stubs) => {
-  for (const stub of stubs) {
-    stub.rejects(
-      new Error(
-        `Unexpected call to stub "${stub.toString()}" (whether because it should not have been called OR called with wrong arguments)`,
-      ),
-    );
-  }
-};
-
-function wait(ms) {
-  return new Promise((resolve) => {
-    setTimeout(() => {
-      resolve();
-    }, ms);
-  });
-}
-
-function waitForStreamFinalizationToBeDone() {
-  return wait(300);
 }
 
 // eslint-disable-next-line mocha/no-exports

--- a/api/tests/tooling/mocks/security-pre-handlers.mock.js
+++ b/api/tests/tooling/mocks/security-pre-handlers.mock.js
@@ -1,7 +1,7 @@
 import sinon from 'sinon';
 
-import { PIX_ADMIN } from '../../src/authorization/domain/constants.js';
-import { securityPreHandlers } from '../../src/shared/application/security-pre-handlers.js';
+import { PIX_ADMIN } from '../../../src/authorization/domain/constants.js';
+import { securityPreHandlers } from '../../../src/shared/application/security-pre-handlers.js';
 
 const getAdminRoleStub = (role) => {
   const pixAdminRole = PIX_ADMIN.ROLES[role];

--- a/api/tests/tooling/test-utils/error.js
+++ b/api/tests/tooling/test-utils/error.js
@@ -1,0 +1,31 @@
+export function catchErr(promiseFn, ctx) {
+  return async (...args) => {
+    try {
+      await promiseFn.call(ctx, ...args);
+    } catch (err) {
+      return err;
+    }
+    throw new Error('Expected an error, but none was thrown.');
+  };
+}
+
+export function catchErrSync(fn, ctx) {
+  return (...args) => {
+    try {
+      fn.call(ctx, ...args);
+    } catch (err) {
+      return err;
+    }
+    throw new Error('Expected an error, but none was thrown.');
+  };
+}
+
+export const preventStubsToBeCalledUnexpectedly = (stubs) => {
+  for (const stub of stubs) {
+    stub.rejects(
+      new Error(
+        `Unexpected call to stub "${stub.toString()}" (whether because it should not have been called OR called with wrong arguments)`,
+      ),
+    );
+  }
+};

--- a/api/tests/tooling/test-utils/http-server.js
+++ b/api/tests/tooling/test-utils/http-server.js
@@ -1,0 +1,89 @@
+import querystring from 'node:querystring';
+
+import { ApplicationAccessToken } from '../../../src/identity-access-management/domain/models/ApplicationAccessToken.js';
+import { UserAccessToken } from '../../../src/identity-access-management/domain/models/UserAccessToken.js';
+
+/**
+ * For acceptance tests. To be used as `const options = generateInjectOptions; await server.inject(options);`
+ *
+ * @param {Object} params
+ * @param {string} params.url
+ * @param {string} params.method
+ * @param {Object} [params.payload]
+ * @param {string} [params.locale]
+ * @param {string} [params.audience]
+ * @param {Object} [params.authorizationData] - data to generate an AccessToken, for example: { userId: 1234 }
+ * @param {boolean} [params.urlEncodePayload]
+ * @returns {Object} options
+ */
+export function generateInjectOptions({ url, method, payload, locale, audience, authorizationData, urlEncodePayload }) {
+  const options = {
+    url,
+    method,
+    headers: {
+      // cf. cookies = req.headers.cookie in @hapi/hapi/lib/route.js +369
+      ...(locale && { cookie: `locale=${locale}` }),
+      ...(audience && _generateForwardedHeaders(audience)),
+    },
+  };
+
+  if (payload) {
+    if (urlEncodePayload) {
+      options.payload = querystring.stringify(payload);
+      options.headers['content-type'] = 'application/x-www-form-urlencoded';
+    } else {
+      options.payload = payload;
+    }
+  }
+
+  if (authorizationData) {
+    if (!audience) {
+      throw new Error('You must provide an audience parameter when providing authorizationData.');
+    }
+
+    const accessToken = UserAccessToken.generateUserToken({ ...authorizationData, audience }).accessToken;
+    options.headers.authorization = `Bearer ${accessToken}`;
+  }
+
+  return options;
+}
+
+/**
+ * @param {Object} params
+ * @param {number} params.userId
+ * @param {string} params.source
+ * @param {string} params.audience - an origin URL, for example: https://app.pix.org
+ * @returns {Object} headers
+ */
+export function generateAuthenticatedUserRequestHeaders({
+  userId = 1234,
+  source = 'pix',
+  audience = 'https://app.pix.org',
+} = {}) {
+  const accessToken = UserAccessToken.generateUserToken({ userId, source, audience }).accessToken;
+
+  return {
+    ..._generateForwardedHeaders(audience),
+    authorization: `Bearer ${accessToken}`,
+  };
+}
+
+function _generateForwardedHeaders(audience) {
+  const url = new URL(audience);
+  const protoHeader = url.protocol.slice(0, -1);
+  const hostHeader = url.hostname;
+
+  return { 'x-forwarded-proto': protoHeader, 'x-forwarded-host': hostHeader };
+}
+
+/**
+ * Generate Authorization header for Client Application (MADDO)
+ * @param {string} clientId
+ * @param {string} source
+ * @param {string} scope
+ * @returns {string} authorization header
+ */
+export function generateValidRequestAuthorizationHeaderForApplication(clientId = 'client-id-name', source, scope = '') {
+  const accessToken = ApplicationAccessToken.generate({ clientId, source, scope });
+  return `Bearer ${accessToken}`;
+}

--- a/api/tests/tooling/test-utils/wait.js
+++ b/api/tests/tooling/test-utils/wait.js
@@ -1,0 +1,11 @@
+export function wait(ms) {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve();
+    }, ms);
+  });
+}
+
+export function waitForStreamFinalizationToBeDone() {
+  return wait(300);
+}

--- a/api/tests/unit/tooling/mocks/security-pre-handlers_test.js
+++ b/api/tests/unit/tooling/mocks/security-pre-handlers_test.js
@@ -1,8 +1,8 @@
-import { securityPreHandlers } from '../../../src/shared/application/security-pre-handlers.js';
-import { catchErrSync, expect, hFake, sinon } from '../../test-helper.js';
-import { getAdminRoleStub } from '../../tooling/security-pre-handlers-helpers.js';
+import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
+import { catchErrSync, expect, hFake, sinon } from '../../../test-helper.js';
+import { getAdminRoleStub } from '../../../tooling/mocks/security-pre-handlers.mock.js';
 
-describe('Unit | Tooling | SecurityPreHandlersHelpers', function () {
+describe('Unit | Tooling | Mocks | SecurityPreHandlersHelpers', function () {
   describe('#getAdminRoleStub', function () {
     it('should throw if role does not exist', function () {
       const error = catchErrSync(getAdminRoleStub)('WRONG_ROLE');

--- a/api/tests/unit/tooling/test-utils/error_test.js
+++ b/api/tests/unit/tooling/test-utils/error_test.js
@@ -1,6 +1,6 @@
 import { catchErr, expect } from '../../../test-helper.js';
 
-describe('Error test utils', function () {
+describe('Unit | Tooling | Test utils | Error', function () {
   describe('#catchErr', function () {
     it('returns the error thrown in the tested function', async function () {
       // given

--- a/api/tests/unit/tooling/test-utils/error_test.js
+++ b/api/tests/unit/tooling/test-utils/error_test.js
@@ -1,6 +1,6 @@
-import { catchErr, expect, parseJsonStream } from './test-helper.js';
+import { catchErr, expect } from '../../../test-helper.js';
 
-describe('Test helpers', function () {
+describe('Error test utils', function () {
   describe('#catchErr', function () {
     it('returns the error thrown in the tested function', async function () {
       // given
@@ -27,20 +27,6 @@ describe('Test helpers', function () {
 
       // then
       await expect(promise).to.be.rejectedWith('Expected an error, but none was thrown.');
-    });
-  });
-
-  describe('#parseJsonStream', function () {
-    it('should parse JSONStream data', function () {
-      const obj1 = { a: 1 };
-      const obj2 = { b: 2 };
-      const data = [JSON.stringify(obj1), JSON.stringify(obj2), ''].join('\n');
-
-      expect(
-        parseJsonStream({
-          result: data,
-        }),
-      ).to.deep.equal([obj1, obj2]);
     });
   });
 });

--- a/api/tests/unit/tooling/test-utils/json_test.js
+++ b/api/tests/unit/tooling/test-utils/json_test.js
@@ -1,7 +1,7 @@
 import { expect } from '../../../test-helper.js';
 import { parseNDJSON } from '../../../tooling/test-utils/json.js';
 
-describe('JSON test utils', function () {
+describe('Unit | Tooling | Test utils | JSON', function () {
   describe('parseNDJSON', function () {
     it('parses Newline Delimiter JSON data', function () {
       // given


### PR DESCRIPTION
## 🌱 Problème

Le fichier `test-helper.js` est un melting-pot de code. Il mélange différentes responsabilités pour toutes nos typologies de test (unitaires, intégration et acceptance) 

Il est nécessaire de revoir ce fichier pour isoler les fonctions utilitaires de l'initialisation des tests. Le but final est d'avoir de chaines d'initialisation différentes entre les tests unitaires, d'intégration et d'acceptance.

## 🐣 Proposition

Cette PR se concentre sur les fonctions restantes afin de les isoler dans les fichiers suivants: 
- `tests/tooling/test-utils/error.js`: `catchErr()`, `catchErrSync()`, `preventStubsToBeCalledUnexpectedly()`
- `tests/tooling/test-utils/http-server.js`: `generateInjectOptions()`, `generateAuthenticatedUserRequestHeaders()`, `generateValidRequestAuthorizationHeaderForApplication`
- `tests/tooling/test-utils/wait.js`: `wait()`, `waitForStreamFinalizationToBeDone()`
- `tests/tooling/mocks/security-pre-handlers.mock.js`: `getAdminRoleStub()`

Ces fonctions sont toujours ré-exportée (pour le moment) par le fichier `test-helper.js`

**Prochaines étapes :**
1. Voir ce qu'on fait de `mockLearningContent` (utiliser direct le `databaseBuilder`)
1. Enlever la "proxification" des libs globales : sinon , nock, expect, MockDate, utilitaires qui n'apporte rien
1. Séparer le setup des tests et les fonction de helpers/mocks... dans test-helpers.js  car on fait le setup quand on importe ce fichier de helpers.
1. Avoir des setup différents pour les tests unitaires et les tests d'intégration/acceptance. (On a pas besoin d'initialiser ou clean les BDD, redis, jobs... pour les tests unitaires)


## 🌷 Remarques

À noter que le fichier de test `tests/test-helper_test.js` n'était jamais exécuté dans la CI ou via les commandes de tests. Maintenant que les helpers sont isolés dans des fichiers à part et testés dans le dossier `tests/unit/tooling`, ils sont correctement exécutés.

## 🐝 Pour tester

La CI doit passer.
