### PR TITLE
[TECH] Réparer les versions de certifs dans les seeds (PIX-22389).

### DIFF
--- a/api/db/seeds/data/team-certification/shared/common-certification-versions.js
+++ b/api/db/seeds/data/team-certification/shared/common-certification-versions.js
@@ -276,13 +276,22 @@ export class CommonCertificationVersions {
   /**
    * @param {Object} params
    * @param {Knex} params.databaseBuilder
+   * @param {string} params.fromLcmsFrameworkName
+   * @param {SCOPES} params.toFrameworkScope
+   * @param {number} [params.minimumAnswersRequiredToValidateACertification]
    * @returns {Promise<number>}
    */
-  static async #createActiveFrameworkVersion({ databaseBuilder, fromLcmsFrameworkName, toFrameworkScope }) {
+  static async #createActiveFrameworkVersion({
+    databaseBuilder,
+    fromLcmsFrameworkName,
+    toFrameworkScope,
+    minimumAnswersRequiredToValidateACertification,
+  }) {
     const tubeIds = await this.#getTubeIdsByFramework({ frameworkName: fromLcmsFrameworkName });
     const currentVersionId = await configurationUsecases.createCertificationVersion({
       scope: toFrameworkScope,
       tubeIds,
+      minimumAnswersRequiredToValidateACertification,
     });
 
     await this.#forceConfigurations({

--- a/api/src/certification/configuration/domain/usecases/create-certification-version.js
+++ b/api/src/certification/configuration/domain/usecases/create-certification-version.js
@@ -23,13 +23,26 @@ export const createCertificationVersion = withTransaction(
    * @param {object} params
    * @param {SCOPES} params.scope
    * @param {Array<string>} params.tubeIds
+   * @param {number} [params.minimumAnswersRequiredToValidateACertification]
    * @param {TubeRepository} params.tubeRepository
    * @param {SkillRepository} params.skillRepository
    * @param {ChallengeRepository} params.challengeRepository
    * @param {VersionRepository} params.versionRepository
    */
-  async ({ scope, tubeIds, tubeRepository, skillRepository, challengeRepository, versionRepository }) => {
-    const version = await _buildNewVersion({ scope, versionRepository });
+  async ({
+    scope,
+    tubeIds,
+    minimumAnswersRequiredToValidateACertification,
+    tubeRepository,
+    skillRepository,
+    challengeRepository,
+    versionRepository,
+  }) => {
+    const version = await _buildNewVersion({
+      scope,
+      minimumAnswersRequiredToValidateACertification,
+      versionRepository,
+    });
     const challenges = await _getChallengesForTubes({ tubeIds, tubeRepository, skillRepository, challengeRepository });
     return versionRepository.create({ version, challenges });
   },
@@ -38,9 +51,10 @@ export const createCertificationVersion = withTransaction(
 /**
  * @param {object} params
  * @param {SCOPES} params.scope
+ * @param {number} [params.minimumAnswersRequiredToValidateACertification]
  * @param {VersionRepository} params.versionRepository
  */
-const _buildNewVersion = async ({ scope, versionRepository }) => {
+const _buildNewVersion = async ({ scope, minimumAnswersRequiredToValidateACertification, versionRepository }) => {
   const currentVersion = await versionRepository.findActiveByScope({ scope });
 
   if (!currentVersion) {
@@ -49,7 +63,8 @@ const _buildNewVersion = async ({ scope, versionRepository }) => {
       startDate: dayjs().toDate(),
       expirationDate: null,
       assessmentDuration: DEFAULT_SESSION_DURATION_MINUTES,
-      minimumAnswersRequiredToValidateACertification: DEFAULT_MINIMUM_ANSWERS_REQUIRED_TO_VALIDATE_A_CERTIFICATION,
+      minimumAnswersRequiredToValidateACertification:
+        minimumAnswersRequiredToValidateACertification ?? DEFAULT_MINIMUM_ANSWERS_REQUIRED_TO_VALIDATE_A_CERTIFICATION,
       challengesConfiguration: new FlashAssessmentAlgorithmConfiguration({
         challengesBetweenSameCompetence: 0,
         maximumAssessmentLength: 32,
@@ -75,7 +90,8 @@ const _buildNewVersion = async ({ scope, versionRepository }) => {
     startDate: transitionDate,
     expirationDate: null,
     assessmentDuration: currentVersion.assessmentDuration,
-    minimumAnswersRequiredToValidateACertification: currentVersion.minimumAnswersRequiredToValidateACertification,
+    minimumAnswersRequiredToValidateACertification:
+      minimumAnswersRequiredToValidateACertification ?? currentVersion.minimumAnswersRequiredToValidateACertification,
     challengesConfiguration: currentVersion.challengesConfiguration,
   });
 };

--- a/api/src/certification/configuration/infrastructure/repositories/version-repository.js
+++ b/api/src/certification/configuration/infrastructure/repositories/version-repository.js
@@ -73,6 +73,7 @@ export async function create({ version, challenges }) {
       startDate: version.startDate,
       expirationDate: version.expirationDate,
       assessmentDuration: version.assessmentDuration,
+      minimumAnswersRequiredToValidateACertification: version.minimumAnswersRequiredToValidateACertification,
       globalScoringConfiguration: version.globalScoringConfiguration
         ? JSON.stringify(version.globalScoringConfiguration)
         : null,


### PR DESCRIPTION
## 🌱 Problème

L'ajout de la propriété obligatoire `minimumAnswersRequiredToValidateACertification` dans le modèle `Version` a créé une régression lors de la création de nouvelles versions de certification via les seeds et le usecase associé.

## 🐣 Proposition

* **Repository** : Mise à jour de `version-repository.js` pour inclure la colonne `minimumAnswersRequiredToValidateACertification` dans les requêtes insert.
* **Usecase** : Évolution de `createCertificationVersion` pour accepter `minimumAnswersRequiredToValidateACertification` en paramètre optionnel. S'il n'est pas fourni, le usecase utilise la valeur de la version précédente (si elle existe) ou la valeur par défaut du domaine (20).
* **Seeds** : Mise à jour de la méthode `#createActiveFrameworkVersion` dans `common-certification-versions.js` pour supporter ce nouveau paramètre.

## 🐝 Pour tester

✅ Lancer les seeds en local
