### PR TITLE
[BUGFIX] Corriger l'initialisation des buckets S3 dans l'image docker

### DIFF
--- a/.circleci/jobs.yml
+++ b/.circleci/jobs.yml
@@ -92,7 +92,7 @@ executors:
       - image: redis:7.2.11-alpine
       - image: adobe/s3mock:5.0.0
         environment:
-          - initialBuckets=pix-import-test
+          - COM_ADOBE_TESTING_S3MOCK_STORE_INITIAL_BUCKETS=pix-import-test
     resource_class: small
   node-redis-postgres-s3-docker-medium:
     parameters:
@@ -109,7 +109,7 @@ executors:
       - image: redis:7.2.11-alpine
       - image: adobe/s3mock:5.0.0
         environment:
-          - initialBuckets=pix-import-test
+          - COM_ADOBE_TESTING_S3MOCK_STORE_INITIAL_BUCKETS=pix-import-test
     resource_class: medium
   node-redis-postgres-s3-docker-large:
     parameters:
@@ -126,7 +126,7 @@ executors:
       - image: redis:7.2.11-alpine
       - image: adobe/s3mock:5.0.0
         environment:
-          - initialBuckets=pix-import-test
+          - COM_ADOBE_TESTING_S3MOCK_STORE_INITIAL_BUCKETS=pix-import-test
     resource_class: large
   node-browsers-docker:
     parameters:

--- a/compose.yaml
+++ b/compose.yaml
@@ -17,7 +17,7 @@ services:
     image: adobe/s3mock:5.0.0
     container_name: pix-api-s3
     environment:
-      - initialBuckets=pix-import-dev, pix-import-test, pix-attestations-dev, pix-attestations-test
+      - COM_ADOBE_TESTING_S3MOCK_STORE_INITIAL_BUCKETS=pix-import-dev, pix-import-test, pix-attestations-dev, pix-attestations-test
     ports:
       - '${PIX_S3_PORT:-9090}:9090'
 

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -21,7 +21,7 @@ services:
     image: adobe/s3mock:5.0.0
     container_name: pix-api-s3
     environment:
-      - initialBuckets=pix-import-dev,pix-import-test,pix-attestations-dev
+      - COM_ADOBE_TESTING_S3MOCK_STORE_INITIAL_BUCKETS=pix-import-dev,pix-import-test,pix-attestations-dev
     ports:
       - '${PIX_S3_PORT:-9090}:9090'
 
@@ -36,7 +36,7 @@ services:
     volumes:
       - .env:/code/.env
     ports:
-      - "3000:3000"
+      - '3000:3000'
 
   orga:
     image: pix/orga
@@ -46,7 +46,7 @@ services:
       dockerfile: ../docker/dockerfiles/Dockerfile.ember
       context: ../orga
     ports:
-      - "4201:80"
+      - '4201:80'
     volumes:
       - ./dockerfiles/config/ember-nginx.conf:/etc/nginx/conf.d/default.conf
 
@@ -58,7 +58,7 @@ services:
       dockerfile: ../docker/dockerfiles/Dockerfile.ember
       context: ../admin/
     ports:
-      - "4202:80"
+      - '4202:80'
     volumes:
       - ./dockerfiles/config/ember-nginx.conf:/etc/nginx/conf.d/default.conf
 
@@ -70,7 +70,7 @@ services:
       dockerfile: ../docker/dockerfiles/Dockerfile.ember
       context: ../certif/
     ports:
-      - "4203:80"
+      - '4203:80'
     volumes:
       - ./dockerfiles/config/ember-nginx.conf:/etc/nginx/conf.d/default.conf
 
@@ -82,6 +82,6 @@ services:
       dockerfile: ../docker/dockerfiles/Dockerfile.ember
       context: ../mon-pix/
     ports:
-      - "4200:80"
+      - '4200:80'
     volumes:
       - ./dockerfiles/config/ember-nginx.conf:/etc/nginx/conf.d/default.conf


### PR DESCRIPTION
## 🌱 Problème

Des tests d'acceptance de l'api échouent sur dev, suite à la mise à jour de l'image docker de s3mock.

## 🐣 Proposition

La version 5 de l'image docker s3mock change le nom de la variable pour initialiser le bucket.
https://github.com/adobe/S3Mock?tab=readme-ov-file#4x-to-5x-current

## 🌷 Remarques

N/A

## 🐝 Pour tester

Les tests d'acceptance de l'API doivent passer.