### PR TITLE
[TECH] Autoriser une chaîne vide sur un champ uri (PIX-22390) 

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/conversion/joi-to-json-schema.js
+++ b/api/src/devcomp/infrastructure/datasources/conversion/joi-to-json-schema.js
@@ -93,7 +93,19 @@ function convertString(joiStringDescribedSchema) {
     }
   }
 
-  return handleNonStandardStringProperties(joiStringDescribedSchema, jsonSchema);
+  const processedSchema = handleNonStandardStringProperties(joiStringDescribedSchema, jsonSchema);
+
+  const allowsEmptyString = joiStringDescribedSchema.allow?.includes('');
+  if (processedSchema.format === 'uri' && allowsEmptyString) {
+    const schemaWithoutFormat = { ...processedSchema };
+    Reflect.deleteProperty(schemaWithoutFormat, 'format');
+    return {
+      ...schemaWithoutFormat,
+      anyOf: [{ format: 'uri' }, { maxLength: 0 }],
+    };
+  }
+
+  return processedSchema;
 }
 
 function handleNonStandardStringProperties(joiStringDescribedSchema, jsonSchema) {

--- a/api/tests/devcomp/unit/infrastructure/datasources/conversion/joi-to-json-schema_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/conversion/joi-to-json-schema_test.js
@@ -55,6 +55,16 @@ describe('Unit | Infrastructure | Datasources | Conversion | joi-to-json-schema'
       expect(jsonSchema).to.deep.equal({ type: 'string', format: 'uri', options: null });
     });
 
+    it("should convert Joi.string.uri.allow('') to JSON Schema with anyOf allowing URI or empty string", function () {
+      const joiSchema = Joi.string().uri().allow('');
+      const jsonSchema = convertJoiToJsonSchema(joiSchema);
+      expect(jsonSchema).to.deep.equal({
+        type: 'string',
+        options: null,
+        anyOf: [{ format: 'uri' }, { maxLength: 0 }],
+      });
+    });
+
     it('should convert Joi.string.guid to JSON Schema with format uuid', function () {
       const joiSchema = Joi.string().guid({ version: 'uuidv4' });
       const jsonSchema = convertJoiToJsonSchema(joiSchema);


### PR DESCRIPTION
## 🌱 Problème

Actuellement, le script de conversion en JSON schéma ne gère pas bien les champs avec le format suivant : `Joi.string().uri().allow('')`

Dans ce cas là, on aura un objet de type `{"type": "string", "format": "uri", options: null}` sans mention de la chaîne vide. Cela fonctionne pas sur les outils qui valident le json d'un module uniquement à partir du schéma (ex: monaco-editor).

## 🐣 Proposition
Ajouter cette fonctionnalité

## 🌷 Remarques

On pourra par la suite mettre en place Monaco Editor sur Modulix Editor

## 🐝 Pour tester
CI au vert ✅ 
