### PR TITLE
[TECH] remplacer ember-cli-notifications par le service pixToast (PIX-22394)

### DIFF
--- a/orga/app/components/campaign/header/archived-banner.gjs
+++ b/orga/app/components/campaign/header/archived-banner.gjs
@@ -17,7 +17,7 @@ export default class CampaignArchivedBanner extends Component {
       const campaign = this.store.peekRecord('campaign', this.args.campaign.id);
       await campaign.unarchive();
     } catch {
-      this.notifications.sendError(this.intl.t('api-error-messages.global'));
+      this.pixToast.sendErrorNotification({ message: this.intl.t('api-error-messages.global') });
     }
   }
 

--- a/orga/app/components/campaign/header/tabs.gjs
+++ b/orga/app/components/campaign/header/tabs.gjs
@@ -29,7 +29,7 @@ export default class CampaignTabs extends Component {
       await this.fileSaver.save({ url: this.args.campaign.urlToResult, token });
       this.pixMetrics.trackEvent(EVENT_NAME.CAMPAIGN.EXPORT_DATA_CLICK);
     } catch {
-      this.notifications.sendError(this.intl.t('api-error-messages.global'));
+      this.pixToast.sendErrorNotification({ message: this.intl.t('api-error-messages.global') });
     }
   }
 

--- a/orga/app/components/campaign/list.gjs
+++ b/orga/app/components/campaign/list.gjs
@@ -62,11 +62,11 @@ export default class List extends Component {
       });
       this.args.onDeleteCampaigns();
     } catch {
-      this.notifications.sendError(
-        this.intl.t('pages.campaigns-list.action-bar.error-message', {
+      this.pixToast.sendErrorNotification({
+        message: this.intl.t('pages.campaigns-list.action-bar.error-message', {
           count: selectedCampaigns.length,
         }),
-      );
+      });
     }
   }
 

--- a/orga/app/components/campaign/list.gjs
+++ b/orga/app/components/campaign/list.gjs
@@ -33,7 +33,7 @@ export default class List extends Component {
   @service intl;
   @service locale;
   @service store;
-  @service notifications;
+  @service pixToast;
   @tracked showDeletionModal = false;
 
   get canDelete() {
@@ -55,11 +55,11 @@ export default class List extends Component {
     try {
       this.toggleDeletionModal();
       await this.store.adapterFor('campaign').delete(this.args.organizationId, campaignIds);
-      this.notifications.sendSuccess(
-        this.intl.t('pages.campaigns-list.action-bar.success-message', {
+      this.pixToast.sendSuccessNotification({
+        message: this.intl.t('pages.campaigns-list.action-bar.success-message', {
           count: selectedCampaigns.length,
         }),
-      );
+      });
       this.args.onDeleteCampaigns();
     } catch {
       this.notifications.sendError(

--- a/orga/app/components/campaign/settings/view.gjs
+++ b/orga/app/components/campaign/settings/view.gjs
@@ -95,7 +95,7 @@ export default class CampaignView extends Component {
       const campaign = this.store.peekRecord('campaign', campaignId);
       await campaign.archive();
     } catch {
-      this.notifications.sendError(this.intl.t('api-error-messages.global'));
+      this.pixToast.sendErrorNotification({ message: this.intl.t('api-error-messages.global') });
     }
   }
 

--- a/orga/app/components/campaign/update-form.gjs
+++ b/orga/app/components/campaign/update-form.gjs
@@ -66,11 +66,11 @@ export default class UpdateForm extends Component {
   _handleErrors(errorResponse) {
     const errors = errorResponse.errors;
     if (!errors) {
-      return this.notifications.sendError(this.intl.t('api-error-messages.global'));
+      this.pixToast.sendErrorNotification({ message: this.intl.t('api-error-messages.global') });
     }
     return errorResponse.errors.forEach((error) => {
       if (error.status !== '422') {
-        return this.notifications.sendError(this.intl.t('api-error-messages.global'));
+        return this.pixToast.sendErrorNotification({ message: this.intl.t('api-error-messages.global') });
       }
     });
   }

--- a/orga/app/components/sco-organization-participant/list.gjs
+++ b/orga/app/components/sco-organization-participant/list.gjs
@@ -33,7 +33,7 @@ function stopPropagation(event) {
 
 export default class ScoList extends Component {
   @service currentUser;
-  @service notifications;
+  @service pixToast;
   @service intl;
   @service locale;
   @service store;
@@ -155,9 +155,9 @@ export default class ScoList extends Component {
       });
       this.closeResetPasswordModal();
       resetSelectedStudents();
-      this.notifications.sendSuccess(
-        this.intl.t('pages.sco-organization-participants.messages.password-reset-success'),
-      );
+      this.pixToast.sendSuccessNotification({
+        message: this.intl.t('pages.sco-organization-participants.messages.password-reset-success'),
+      });
       await this.args.refreshValues();
     } catch (fetchErrors) {
       const error = Array.isArray(fetchErrors) && fetchErrors.length > 0 && fetchErrors[0];

--- a/orga/app/components/sco-organization-participant/list.gjs
+++ b/orga/app/components/sco-organization-participant/list.gjs
@@ -181,7 +181,7 @@ export default class ScoList extends Component {
         default:
           errorMessage = this.intl.t(this._getI18nKeyByStatus(error.status));
       }
-      this.notifications.sendError(errorMessage);
+      this.pixToast.sendErrorNotification({ message: errorMessage });
     }
   }
 

--- a/orga/app/components/sco-organization-participant/manage-authentication-method-modal.gjs
+++ b/orga/app/components/sco-organization-participant/manage-authentication-method-modal.gjs
@@ -34,7 +34,7 @@ export default class ManageAuthenticationMethodModal extends Component {
       this.generatedPassword = dependentUser.generatedPassword;
       this.isUniquePasswordVisible = !this.isUniquePasswordVisible;
     } catch {
-      this.notifications.sendError(this._t('error.unexpected'));
+      this.pixToast.sendErrorNotification({ message: this._t('error.unexpected') });
     }
   }
 
@@ -56,7 +56,7 @@ export default class ManageAuthenticationMethodModal extends Component {
       }
     } catch (response) {
       const errorDetail = response?.errors[0]?.detail ?? this.defaultErrorMessage;
-      this.notifications.sendError(errorDetail);
+      this.pixToast.sendErrorNotification({ message: errorDetail });
     }
   }
 
@@ -92,7 +92,7 @@ export default class ManageAuthenticationMethodModal extends Component {
         default:
           errorMessage = this.intl.t(this._getI18nKeyByStatus(error.status));
       }
-      this.notifications.sendError(errorMessage);
+      this.pixToast.sendErrorNotification({ message: errorMessage });
     }
   }
 

--- a/orga/app/components/sco-organization-participant/manage-authentication-method-modal.gjs
+++ b/orga/app/components/sco-organization-participant/manage-authentication-method-modal.gjs
@@ -12,7 +12,7 @@ import CopyPasteButton from '../copy-paste-button';
 
 export default class ManageAuthenticationMethodModal extends Component {
   @service store;
-  @service notifications;
+  @service pixToast;
   @service intl;
 
   @tracked isUniquePasswordVisible = false;
@@ -69,11 +69,11 @@ export default class ManageAuthenticationMethodModal extends Component {
         organizationId: this.args.organizationId,
         organizationLearnerId: this.args.student.id,
       });
-      this.notifications.sendSuccess(
-        this.intl.t(
+      this.pixToast.sendSuccessNotification({
+        message: this.intl.t(
           'pages.sco-organization-participants.manage-authentication-method-modal.section.unblock.success-notification',
         ),
-      );
+      });
       await this.args.refreshValues();
     } catch (fetchErrors) {
       const error = Array.isArray(fetchErrors) && fetchErrors.length > 0 && fetchErrors[0];

--- a/orga/app/components/sup-organization-participant/modal/edit-student-number-modal.gjs
+++ b/orga/app/components/sup-organization-participant/modal/edit-student-number-modal.gjs
@@ -9,7 +9,7 @@ import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 
 export default class EditStudentNumberModal extends Component {
-  @service notifications;
+  @service pixToast;
   @service intl;
 
   @tracked error = null;
@@ -29,12 +29,12 @@ export default class EditStudentNumberModal extends Component {
     }
     try {
       await this.args.onSubmit(validatedStudentNumber);
-      this.notifications.sendSuccess(
-        this.intl.t('pages.sup-organization-participants.edit-student-number-modal.form.success', {
+      this.pixToast.sendSuccessNotification({
+        message: this.intl.t('pages.sup-organization-participants.edit-student-number-modal.form.success', {
           firstName: this.args.student.firstName,
           lastName: this.args.student.lastName,
         }),
-      );
+      });
       this.close();
     } catch (errorResponse) {
       this._handleError(errorResponse);

--- a/orga/app/components/team/invitations-list-item.gjs
+++ b/orga/app/components/team/invitations-list-item.gjs
@@ -34,7 +34,7 @@ export default class InvitationsListItem extends Component {
         message: this.intl.t('pages.team-new.success.invitation', { email: organizationInvitation.email }),
       });
     } catch {
-      this.notifications.sendError(this.intl.t('api-error-messages.global'));
+      this.pixToast.sendErrorNotification({ message: this.intl.t('api-error-messages.global') });
     } finally {
       setTimeout(() => {
         this.isResending = false;

--- a/orga/app/components/team/invitations-list-item.gjs
+++ b/orga/app/components/team/invitations-list-item.gjs
@@ -11,7 +11,7 @@ import ENV from 'pix-orga/config/environment';
 
 export default class InvitationsListItem extends Component {
   @service store;
-  @service notifications;
+  @service pixToast;
   @service currentUser;
   @service intl;
 
@@ -30,9 +30,9 @@ export default class InvitationsListItem extends Component {
         },
       });
 
-      this.notifications.sendSuccess(
-        this.intl.t('pages.team-new.success.invitation', { email: organizationInvitation.email }),
-      );
+      this.pixToast.sendSuccessNotification({
+        message: this.intl.t('pages.team-new.success.invitation', { email: organizationInvitation.email }),
+      });
     } catch {
       this.notifications.sendError(this.intl.t('api-error-messages.global'));
     } finally {

--- a/orga/app/components/team/invitations-list.gjs
+++ b/orga/app/components/team/invitations-list.gjs
@@ -7,7 +7,7 @@ import InvitationsListItem from './invitations-list-item';
 
 export default class TeamInvitationsListComponent extends Component {
   @service store;
-  @service notifications;
+  @service pixToast;
   @service currentUser;
   @service intl;
 
@@ -21,7 +21,9 @@ export default class TeamInvitationsListComponent extends Component {
         adapterOptions: { organizationInvitationId: organizationInvitation.id, organizationId },
       });
 
-      this.notifications.sendSuccess(this.intl.t('pages.team-invitations.invitation-cancelled-succeed-message'));
+      this.pixToast.sendSuccessNotification({
+        message: this.intl.t('pages.team-invitations.invitation-cancelled-succeed-message'),
+      });
     } catch {
       this.notifications.sendError(this.intl.t('api-error-messages.global'));
     }

--- a/orga/app/components/team/invitations-list.gjs
+++ b/orga/app/components/team/invitations-list.gjs
@@ -25,7 +25,7 @@ export default class TeamInvitationsListComponent extends Component {
         message: this.intl.t('pages.team-invitations.invitation-cancelled-succeed-message'),
       });
     } catch {
-      this.notifications.sendError(this.intl.t('api-error-messages.global'));
+      this.pixToast.sendErrorNotification({ message: this.intl.t('api-error-messages.global') });
     }
   }
   <template>

--- a/orga/app/components/team/members-list-item.gjs
+++ b/orga/app/components/team/members-list-item.gjs
@@ -19,7 +19,7 @@ const ARIA_LABEL_ADMIN_TRANSLATION = 'pages.team-members.actions.select-role.opt
 
 export default class MembersListItem extends Component {
   @service currentUser;
-  @service notifications;
+  @service pixToast;
   @service intl;
   @service session;
 
@@ -83,7 +83,9 @@ export default class MembersListItem extends Component {
 
     try {
       await membership.save();
-      this.notifications.sendSuccess(this.intl.t('pages.team-members.notifications.change-member-role.success'));
+      this.pixToast.sendSuccessNotification({
+        message: this.intl.t('pages.team-members.notifications.change-member-role.success'),
+      });
     } catch {
       membership.rollbackAttributes();
       this.notifications.sendError(this.intl.t('pages.team-members.notifications.change-member-role.error'));
@@ -124,9 +126,12 @@ export default class MembersListItem extends Component {
       const memberLastName = membership.user.get('lastName');
 
       await this.args.onRemoveMember(membership);
-      this.notifications.sendSuccess(
-        this.intl.t('pages.team-members.notifications.remove-membership.success', { memberFirstName, memberLastName }),
-      );
+      this.pixToast.sendSuccessNotification({
+        message: this.intl.t('pages.team-members.notifications.remove-membership.success', {
+          memberFirstName,
+          memberLastName,
+        }),
+      });
     } catch {
       this.notifications.sendError(this.intl.t('pages.team-members.notifications.remove-membership.error'));
     } finally {
@@ -139,11 +144,11 @@ export default class MembersListItem extends Component {
     try {
       const membership = this.args.membership;
       await this.args.onLeaveOrganization(membership);
-      this.notifications.sendSuccess(
-        this.intl.t('pages.team-members.notifications.leave-organization.success', {
+      this.pixToast.sendSuccessNotification({
+        message: this.intl.t('pages.team-members.notifications.leave-organization.success', {
           organizationName: this.currentUserOrganizationName,
         }),
-      );
+      });
       await this.session.waitBeforeInvalidation(5000);
       this.session.invalidate();
     } catch {

--- a/orga/app/components/team/members-list-item.gjs
+++ b/orga/app/components/team/members-list-item.gjs
@@ -88,7 +88,9 @@ export default class MembersListItem extends Component {
       });
     } catch {
       membership.rollbackAttributes();
-      this.notifications.sendError(this.intl.t('pages.team-members.notifications.change-member-role.error'));
+      this.pixToast.sendErrorNotification({
+        message: this.intl.t('pages.team-members.notifications.change-member-role.error'),
+      });
     }
   }
 
@@ -133,7 +135,9 @@ export default class MembersListItem extends Component {
         }),
       });
     } catch {
-      this.notifications.sendError(this.intl.t('pages.team-members.notifications.remove-membership.error'));
+      this.pixToast.sendErrorNotification({
+        message: this.intl.t('pages.team-members.notifications.remove-membership.error'),
+      });
     } finally {
       this.closeRemoveMembershipModal();
     }
@@ -152,7 +156,9 @@ export default class MembersListItem extends Component {
       await this.session.waitBeforeInvalidation(5000);
       this.session.invalidate();
     } catch {
-      this.notifications.sendError(this.intl.t('pages.team-members.notifications.leave-organization.error'));
+      this.pixToast.sendErrorNotification({
+        message: this.intl.t('pages.team-members.notifications.leave-organization.error'),
+      });
     } finally {
       this.closeLeaveOrganizationModal();
     }

--- a/orga/app/components/ui/edit-participant-name-modal.gjs
+++ b/orga/app/components/ui/edit-participant-name-modal.gjs
@@ -9,7 +9,7 @@ import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 
 export default class EditParticipantNameModal extends Component {
-  @service notifications;
+  @service pixToast;
   @service intl;
   @service store;
   @service currentUser;
@@ -79,7 +79,7 @@ export default class EditParticipantNameModal extends Component {
       this.notifications.success(this.intl.t('components.ui.edit-participant-name-modal.success-message'));
       this.args.onClose();
     } catch {
-      this.notifications.error(this.intl.t('api-error-messages.global'));
+      this.pixToast.sendErrorNotification({ message: this.intl.t('api-error-messages.global') });
     } finally {
       this.isLoading = false;
     }

--- a/orga/app/components/ui/edit-participant-name-modal.gjs
+++ b/orga/app/components/ui/edit-participant-name-modal.gjs
@@ -57,7 +57,9 @@ export default class EditParticipantNameModal extends Component {
       return;
     }
     if (!this.hasChanges) {
-      this.notifications.success(this.intl.t('components.ui.edit-participant-name-modal.success-message'));
+      this.pixToast.sendSuccessNotification({
+        message: this.intl.t('components.ui.edit-participant-name-modal.success-message'),
+      });
       return this.args.onClose();
     }
 
@@ -76,7 +78,9 @@ export default class EditParticipantNameModal extends Component {
       this.args.participant.firstName = this.firstName.trim();
       this.args.participant.lastName = this.lastName.trim();
 
-      this.notifications.success(this.intl.t('components.ui.edit-participant-name-modal.success-message'));
+      this.pixToast.sendSuccessNotification({
+        message: this.intl.t('components.ui.edit-participant-name-modal.success-message'),
+      });
       this.args.onClose();
     } catch {
       this.pixToast.sendErrorNotification({ message: this.intl.t('api-error-messages.global') });

--- a/orga/app/controllers/authenticated/attestations.js
+++ b/orga/app/controllers/authenticated/attestations.js
@@ -48,7 +48,7 @@ export default class AuthenticatedAttestationsController extends Controller {
         noContentMessageNotification: noAttestationMessageNotification,
       });
     } catch (error) {
-      this.notifications.sendError(error.message, { autoClear: false });
+      this.pixToast.sendErrorNotification({ message: error.message });
     }
   }
 

--- a/orga/app/controllers/authenticated/campaigns/campaign/activity.js
+++ b/orga/app/controllers/authenticated/campaigns/campaign/activity.js
@@ -6,7 +6,7 @@ import { tracked } from '@glimmer/tracking';
 export default class ActivityController extends Controller {
   @service currentUser;
   @service intl;
-  @service notifications;
+  @service pixToast;
   @service router;
 
   @tracked pageNumber = 1;
@@ -57,7 +57,9 @@ export default class ActivityController extends Controller {
         },
       });
       this.send('refreshModel');
-      this.notifications.sendSuccess(this.intl.t('pages.campaign-activity.delete-participation-modal.success'));
+      this.pixToast.sendSuccessNotification({
+        message: this.intl.t('pages.campaign-activity.delete-participation-modal.success'),
+      });
     } catch {
       this.notifications.sendError(this.intl.t('pages.campaign-activity.delete-participation-modal.error'));
     }

--- a/orga/app/controllers/authenticated/campaigns/campaign/activity.js
+++ b/orga/app/controllers/authenticated/campaigns/campaign/activity.js
@@ -61,7 +61,9 @@ export default class ActivityController extends Controller {
         message: this.intl.t('pages.campaign-activity.delete-participation-modal.success'),
       });
     } catch {
-      this.notifications.sendError(this.intl.t('pages.campaign-activity.delete-participation-modal.error'));
+      this.pixToast.sendErrorNotification({
+        message: this.intl.t('pages.campaign-activity.delete-participation-modal.error'),
+      });
     }
   }
 }

--- a/orga/app/controllers/authenticated/campaigns/new.js
+++ b/orga/app/controllers/authenticated/campaigns/new.js
@@ -22,7 +22,7 @@ export default class NewController extends Controller {
     } catch (errorResponse) {
       errorResponse.errors.forEach((error) => {
         if (error.status === '500') {
-          this.notifications.sendError(this.intl.t('api-error-messages.global'));
+          this.pixToast.sendErrorNotification({ message: this.intl.t('api-error-messages.global') });
         }
       });
       this.errors = this.model.campaign.errors;

--- a/orga/app/controllers/authenticated/campaigns/new.js
+++ b/orga/app/controllers/authenticated/campaigns/new.js
@@ -6,7 +6,7 @@ import { tracked } from '@glimmer/tracking';
 export default class NewController extends Controller {
   @service router;
   @service store;
-  @service notifications;
+  @service pixToast;
   @service intl;
 
   @tracked errors;
@@ -15,7 +15,7 @@ export default class NewController extends Controller {
 
   @action
   async createCampaign() {
-    this.notifications.clearAll();
+    this.pixToast.removeAllNotifications();
     this.errors = null;
     try {
       await this.model.campaign.save();

--- a/orga/app/controllers/authenticated/certifications.js
+++ b/orga/app/controllers/authenticated/certifications.js
@@ -8,7 +8,7 @@ export default class AuthenticatedCertificationsController extends Controller {
   @service fileSaver;
   @service session;
   @service currentUser;
-  @service notifications;
+  @service pixToast;
   @service intl;
   @service locale;
 
@@ -53,7 +53,7 @@ export default class AuthenticatedCertificationsController extends Controller {
           { autoClear: false },
         );
       } else {
-        this.notifications.sendError(error.message, { autoClear: false });
+        this.pixToast.sendErrorNotification({ message: error.message });
       }
     }
   }
@@ -90,7 +90,7 @@ export default class AuthenticatedCertificationsController extends Controller {
           { autoClear: false },
         );
       } else {
-        this.notifications.sendError(error.message, { autoClear: false });
+        this.pixToast.sendErrorNotification({ message: error.message });
       }
     }
   }

--- a/orga/app/controllers/authenticated/certifications.js
+++ b/orga/app/controllers/authenticated/certifications.js
@@ -48,10 +48,9 @@ export default class AuthenticatedCertificationsController extends Controller {
       await this.fileSaver.save({ url, token });
     } catch (error) {
       if (_isErrorNotFound(error)) {
-        this.notifications.info(
-          this.intl.t('pages.certifications.errors.no-results', { selectedDivision: this.selectedDivision }),
-          { autoClear: false },
-        );
+        this.pixToast.sendInformationNotification({
+          message: this.intl.t('pages.certifications.errors.no-results', { selectedDivision: this.selectedDivision }),
+        });
       } else {
         this.pixToast.sendErrorNotification({ message: error.message });
       }
@@ -79,16 +78,16 @@ export default class AuthenticatedCertificationsController extends Controller {
       await this.fileSaver.save({ url, token });
     } catch (error) {
       if (_isErrorNotFound(error)) {
-        this.notifications.info(
-          this.intl.t('pages.certifications.errors.no-results', { selectedDivision: this.selectedDivision }),
-          { autoClear: false },
-        );
+        this.pixToast.sendInformationNotification({
+          message: this.intl.t('pages.certifications.errors.no-results', { selectedDivision: this.selectedDivision }),
+        });
       }
       if (_isErrorNoResults(error)) {
-        this.notifications.info(
-          this.intl.t('pages.certifications.errors.no-certificates', { selectedDivision: this.selectedDivision }),
-          { autoClear: false },
-        );
+        this.pixToast.sendInformationNotification({
+          message: this.intl.t('pages.certifications.errors.no-certificates', {
+            selectedDivision: this.selectedDivision,
+          }),
+        });
       } else {
         this.pixToast.sendErrorNotification({ message: error.message });
       }

--- a/orga/app/controllers/authenticated/organization-participants/list.js
+++ b/orga/app/controllers/authenticated/organization-participants/list.js
@@ -9,7 +9,7 @@ export default class ListController extends Controller {
   @service currentUser;
   @service router;
   @service store;
-  @service notifications;
+  @service pixToast;
   @service intl;
 
   @tracked pageNumber = 1;
@@ -125,13 +125,13 @@ export default class ListController extends Controller {
         listLearners.map(({ id }) => id),
       );
       this.send('refreshModel');
-      this.notifications.sendSuccess(
-        this.intl.t('pages.organization-participants.action-bar.success-message', {
+      this.pixToast.sendSuccessNotification({
+        message: this.intl.t('pages.organization-participants.action-bar.success-message', {
           count: listLearners.length,
           firstname: listLearners[0].firstName,
           lastname: listLearners[0].lastName,
         }),
-      );
+      });
     } catch {
       this.notifications.sendError(
         this.intl.t('pages.organization-participants.action-bar.error-message', {

--- a/orga/app/controllers/authenticated/organization-participants/list.js
+++ b/orga/app/controllers/authenticated/organization-participants/list.js
@@ -133,13 +133,13 @@ export default class ListController extends Controller {
         }),
       });
     } catch {
-      this.notifications.sendError(
-        this.intl.t('pages.organization-participants.action-bar.error-message', {
+      this.pixToast.sendErrorNotification({
+        message: this.intl.t('pages.organization-participants.action-bar.error-message', {
           count: listLearners.length,
           firstname: listLearners[0].firstName,
           lastname: listLearners[0].lastName,
         }),
-      );
+      });
     }
   }
 }

--- a/orga/app/controllers/authenticated/sup-organization-participants/list.js
+++ b/orga/app/controllers/authenticated/sup-organization-participants/list.js
@@ -7,7 +7,7 @@ export default class ListController extends Controller {
   @service router;
   @service store;
   @service currentUser;
-  @service notifications;
+  @service pixToast;
   @service intl;
   @tracked search = null;
   @tracked studentNumber = null;
@@ -68,13 +68,13 @@ export default class ListController extends Controller {
         listLearners.map(({ id }) => id),
       );
 
-      this.notifications.sendSuccess(
-        this.intl.t('pages.sup-organization-participants.action-bar.success-message', {
+      this.pixToast.sendSuccessNotification({
+        message: this.intl.t('pages.sup-organization-participants.action-bar.success-message', {
           count: listLearners.length,
           firstname: listLearners[0].firstName,
           lastname: listLearners[0].lastName,
         }),
-      );
+      });
 
       this.send('refreshModel');
     } catch {

--- a/orga/app/controllers/authenticated/sup-organization-participants/list.js
+++ b/orga/app/controllers/authenticated/sup-organization-participants/list.js
@@ -78,13 +78,13 @@ export default class ListController extends Controller {
 
       this.send('refreshModel');
     } catch {
-      this.notifications.sendError(
-        this.intl.t('pages.sup-organization-participants.action-bar.error-message', {
+      this.pixToast.sendErrorNotification({
+        message: this.intl.t('pages.sup-organization-participants.action-bar.error-message', {
           count: listLearners.length,
           firstname: listLearners[0].firstName,
           lastname: listLearners[0].lastName,
         }),
-      );
+      });
     }
   }
 }

--- a/orga/app/controllers/authenticated/team/new.js
+++ b/orga/app/controllers/authenticated/team/new.js
@@ -5,7 +5,7 @@ import { tracked } from '@glimmer/tracking';
 
 export default class NewController extends Controller {
   @service intl;
-  @service notifications;
+  @service pixToast;
   @service store;
   @service currentUser;
   @service router;

--- a/orga/app/controllers/authenticated/team/new.js
+++ b/orga/app/controllers/authenticated/team/new.js
@@ -80,7 +80,7 @@ export default class NewController extends Controller {
     }
 
     const uniqueErrorMessages = new Set(errorMessages);
-    uniqueErrorMessages.forEach((errorMessage) => this.notifications.sendError(errorMessage));
+    uniqueErrorMessages.forEach((errorMessage) => this.pixToast.sendErrorNotification({ message: errorMessage }));
   }
 }
 

--- a/orga/app/controllers/authenticated/team/new.js
+++ b/orga/app/controllers/authenticated/team/new.js
@@ -16,7 +16,7 @@ export default class NewController extends Controller {
   async createOrganizationInvitation(event) {
     event.preventDefault();
     this.isLoading = true;
-    this.notifications.removeAllNotifications();
+    this.pixToast.removeAllNotifications();
     const emails = this.model.email.split(',');
 
     try {

--- a/orga/app/controllers/authenticated/team/new.js
+++ b/orga/app/controllers/authenticated/team/new.js
@@ -16,7 +16,7 @@ export default class NewController extends Controller {
   async createOrganizationInvitation(event) {
     event.preventDefault();
     this.isLoading = true;
-    this.notifications.clearAll();
+    this.notifications.removeAllNotifications();
     const emails = this.model.email.split(',');
 
     try {
@@ -33,7 +33,7 @@ export default class NewController extends Controller {
         emails.length > 1
           ? this.intl.t('pages.team-new.success.multiple-invitations')
           : this.intl.t('pages.team-new.success.invitation', { email: emails[0] });
-      this.notifications.sendSuccess(message);
+      this.pixToast.sendSuccessNotification({ message: message });
     } catch (error) {
       this._handleResponseError(error);
     }

--- a/orga/app/services/file-saver.js
+++ b/orga/app/services/file-saver.js
@@ -19,7 +19,7 @@ export default class FileSaverService extends Service {
     const response = await fetcher({ url, token, acceptLanguage });
 
     if (response.status === 204) {
-      this.notifications.sendWarning(noContentMessageNotification);
+      this.pixToast.sendWarningNotifications({ message: noContentMessageNotification });
       return;
     }
 

--- a/orga/app/services/file-saver.js
+++ b/orga/app/services/file-saver.js
@@ -2,7 +2,7 @@ import Service from '@ember/service';
 import { service } from '@ember/service';
 
 export default class FileSaverService extends Service {
-  @service notifications;
+  @service pixToast;
   @service intl;
   @service locale;
 


### PR DESCRIPTION

## 🌱 Problème

ember-cli-notifications empèche le build avec vite à cause d'un import de fichier css avec un chemin 
qui repose sur les auto-imports

## 🐣 Proposition

on remplace le service notification par le service pixToast qui offre le meme fonctionnalité

## 🌷 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🐝 Pour tester

ca va être long :D
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
