### PR TITLE
Security: Session restoration accepts any non-empty token without validating expiration or claims

### DIFF
--- a/admin/app/authenticators/oidc.js
+++ b/admin/app/authenticators/oidc.js
@@ -60,9 +60,24 @@ export default class OidcAuthenticator extends BaseAuthenticator {
 
   restore(data) {
     return new Promise((resolve, reject) => {
-      if (!isEmpty(data['access_token'])) {
-        resolve(data);
+      const accessToken = data['access_token'];
+
+      if (isEmpty(accessToken)) {
+        reject();
+        return;
       }
+
+      try {
+        const decodedAccessToken = jwtDecode(accessToken);
+        const nowInSeconds = Math.floor(Date.now() / 1000);
+
+        if (typeof decodedAccessToken.exp === 'number' && decodedAccessToken.exp > nowInSeconds) {
+          resolve(data);
+          return;
+        }
+      } catch {
+      }
+
       reject();
     });
   }


### PR DESCRIPTION
## Summary

Security: Session restoration accepts any non-empty token without validating expiration or claims

## Problem

**Severity**: `Medium` | **File**: `admin/app/authenticators/oidc.js:L67`

The OIDC authenticator restores a session if `access_token` is merely non-empty. It does not validate JWT expiration (`exp`), issuer (`iss`), audience (`aud`), or token format before restoring local authenticated state. This can keep a client session alive with expired or malformed tokens until API calls fail, and may weaken client-side auth-state guarantees.

## Solution

During `restore`, decode and validate token claims (at minimum `exp`, and preferably `iss`/`aud`) before resolving. Reject expired/invalid tokens and force re-authentication. Consider centralizing token validation in the session/auth service.

## Changes

- `admin/app/authenticators/oidc.js` (modified)