### PR TITLE
[FEATURE] Créer la page de résultat pour le moteur de recommandation (Pix 22214)

### DIFF
--- a/api/db/seeds/data/team-devcomp/build-campaigns.js
+++ b/api/db/seeds/data/team-devcomp/build-campaigns.js
@@ -33,6 +33,7 @@ async function _createScoCampaigns(databaseBuilder, trainingIds, participantCoun
       profileDistribution: { beginner: 1, perfect: 1, blank: 1 },
       recommendedTrainingsIds: trainingIds,
     },
+    recommendationEngine: true,
   });
 }
 

--- a/api/db/seeds/data/team-evaluation/data-builder.js
+++ b/api/db/seeds/data/team-evaluation/data-builder.js
@@ -123,6 +123,27 @@ async function createCoreTargetProfile(databaseBuilder) {
     isAlwaysVisible: true,
     configBadge,
   });
+  await tooling.targetProfile.createBadge({
+    databaseBuilder,
+    targetProfileId,
+    cappedTubesDTO,
+    badgeId: 702,
+    altMessage: '1 RT certifiable, acquis',
+    imageUrl: 'https://assets.pix.org/badges/Pix_plus_Edu-2-Confirme-certif.svg',
+    message: '1 RT certifiable, acquis',
+    title: '1 RT certifiable, acquis',
+    key: 'SOME_KEY_FOR_RT_702',
+    isCertifiable: true,
+    isAlwaysVisible: true,
+    configBadge: {
+      criteria: [
+        {
+          scope: 'CampaignParticipation',
+          threshold: 0,
+        },
+      ],
+    },
+  });
   await tooling.targetProfile.createStages({
     databaseBuilder,
     targetProfileId,
@@ -160,5 +181,6 @@ async function createAssessmentCampaign(databaseBuilder) {
     configCampaign: {
       participantCount: 30,
     },
+    recommendationEngine: true,
   });
 }

--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine/acquired-badges-compact.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine/acquired-badges-compact.gjs
@@ -1,0 +1,35 @@
+import Component from '@glimmer/component';
+import { t } from 'ember-intl';
+
+const MAX_VISIBLE_BADGES = 2;
+
+export default class AcquiredBadgesCompact extends Component {
+  get visibleBadges() {
+    return this.args.acquiredBadges.slice(0, MAX_VISIBLE_BADGES);
+  }
+
+  get overflowCount() {
+    return Math.max(0, this.args.acquiredBadges.length - MAX_VISIBLE_BADGES);
+  }
+
+  <template>
+    <ul class="acquired-badges-compact" aria-label={{t "pages.skill-review.hero.acquired-badges-title"}}>
+      {{#each this.visibleBadges as |badge|}}
+        <li class="acquired-badges-compact__item">
+          <img
+            class="acquired-badges-compact__icon"
+            src={{badge.imageUrl}}
+            alt={{badge.altMessage}}
+            title={{badge.title}}
+          />
+        </li>
+      {{/each}}
+      {{#if this.overflowCount}}
+        <li class="acquired-badges-compact__overflow" aria-hidden="true">
+          <span class="sr-only"> {{t "pages.skill-review.hero.hidden-badges" count=this.overflowCount}} </span>
+          +{{this.overflowCount}}
+        </li>
+      {{/if}}
+    </ul>
+  </template>
+}

--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine/index.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine/index.gjs
@@ -88,7 +88,7 @@ export default class EvaluationResultsHeroRecommendationEngine extends Component
             />
             <div class="evaluation-results-hero-recommendation-engine__stars-text" aria-hidden="true">
               {{t
-                "pages.skill-review.stage.starsAcquired"
+                "pages.skill-review.stage.recommendedEngine.starsAcquired"
                 acquired=this.reachedStage.acquired
                 total=this.reachedStage.total
               }}

--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine/index.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine/index.gjs
@@ -1,0 +1,254 @@
+import PixButton from '@1024pix/pix-ui/components/pix-button';
+import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
+import PixStars from '@1024pix/pix-ui/components/pix-stars';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import dayjs from 'dayjs';
+import CustomParseFormat from 'dayjs/plugin/customParseFormat';
+import LocalizedFormat from 'dayjs/plugin/localizedFormat';
+import { t } from 'ember-intl';
+import or from 'ember-truth-helpers/helpers/or';
+import AcquiredBadges from 'mon-pix/components/campaigns/assessment/results/evaluation-results-hero/acquired-badges';
+import AttestationResult
+  from 'mon-pix/components/campaigns/assessment/results/evaluation-results-hero/attestation-result';
+import CustomOrganizationBlock
+  from 'mon-pix/components/campaigns/assessment/results/evaluation-results-hero/custom-organization-block';
+import RetryOrResetBlock
+  from 'mon-pix/components/campaigns/assessment/results/evaluation-results-hero/retry-or-reset-block';
+import ENV from 'mon-pix/config/environment';
+
+import MarkdownToHtml from '../../../../markdown-to-html';
+
+dayjs.extend(LocalizedFormat);
+dayjs.extend(CustomParseFormat);
+
+export default class EvaluationResultsHeroRecommendationEngine extends Component {
+  @service currentUser;
+
+  @service pixMetrics;
+  @service router;
+  @service store;
+  @service tabManager;
+  @service featureToggles;
+
+  @tracked hasGlobalError = false;
+  @tracked isButtonLoading = false;
+
+  get masteryRatePercentage() {
+    return Math.round(this.args.campaignParticipationResult.masteryRate * 100);
+  }
+
+  get hasStagesStars() {
+    return (
+      this.args.campaignParticipationResult.hasReachedStage &&
+      this.args.campaignParticipationResult.reachedStage.totalStage > 1
+    );
+  }
+
+  get reachedStage() {
+    return {
+      acquired: this.args.campaignParticipationResult.reachedStage.reachedStage - 1,
+      total: this.args.campaignParticipationResult.reachedStage.totalStage - 1,
+    };
+  }
+
+  get isCampaignAutonomousCourse() {
+    return this.args.campaign.organizationId === ENV.APP.AUTONOMOUS_COURSES_ORGANIZATION_ID;
+  }
+
+  get showCustomOrganizationBlock() {
+    return this.args.campaign.customResultPageText || this.args.campaign.hasCustomResultPageButton;
+  }
+
+  get displayQuestResult() {
+    return (
+      this.featureToggles.featureToggles?.isQuestEnabled && !this.currentUser.user.isAnonymous && this.hasQuestResults
+    );
+  }
+
+  get isUserAnonymous() {
+    return this.currentUser?.user?.isAnonymous;
+  }
+
+  get hasQuestResults() {
+    return this.args.questResults && this.args.questResults.length > 0;
+  }
+
+  get sharedAtDate() {
+    return dayjs(this.args.campaignParticipationResult.sharedAt).format('LL');
+  }
+
+  get sharedAtTime() {
+    return dayjs(this.args.campaignParticipationResult.sharedAt).format('LT');
+  }
+
+  @action handleSeeTrainingsClick() {
+    this.args.showTrainings();
+  }
+
+  @action setGlobalError(value) {
+    this.hasGlobalError = value;
+  }
+
+  @action handleBackToHomepageDisplay() {
+    this.pixMetrics.trackEvent("Affichage du bouton 'Revenir à la page d'accueil'", {
+      disabled: true,
+      category: 'Fin de parcours',
+      action: 'Sortie de parcours',
+    });
+  }
+
+  @action handleBackToHomepageClick() {
+    this.pixMetrics.trackEvent("Clic sur le bouton 'Revenir à la page d'accueil'", {
+      disabled: true,
+      category: 'Fin de parcours',
+      action: 'Sortie de parcours',
+    });
+  }
+
+  @action handleSignUpClick() {
+    this.pixMetrics.trackEvent('CampaignResultSignUpFromAnonymousUserClick');
+  }
+
+  <template>
+    <div class="evaluation-results-hero-recommendation-engine">
+      <div class="evaluation-results-hero-recommendation-engine__results">
+        <p class="evaluation-results-hero-recommendation-engine-results__percent">
+          ENGINE
+          <strong>{{this.masteryRatePercentage}}<span>%</span></strong>
+          <span>{{t "pages.skill-review.hero.mastery-rate"}}</span>
+        </p>
+        <!-- affichage des paliers sur la maquette, donc on garde-->
+        {{#if this.hasStagesStars}}
+          <PixStars
+            class="evaluation-results-hero-recommendation-engine-results__stars"
+            @count={{this.reachedStage.acquired}}
+            @total={{this.reachedStage.total}}
+            @alt={{t
+              "pages.skill-review.stage.starsAcquired"
+              acquired=this.reachedStage.acquired
+              total=this.reachedStage.total
+            }}
+            @color="yellow"
+          />
+
+          <div class="evaluation-results-hero-recommendation-engine-results__stars-text" role="presentation">
+            {{t
+              "pages.skill-review.stage.starsAcquired"
+              acquired=this.reachedStage.acquired
+              total=this.reachedStage.total
+            }}
+          </div>
+        {{/if}}
+
+        <!-- Pas sur les maquettes, on peut commenter-->
+        {{!--        {{#if this.displayQuestResult}}
+        <AttestationResult @results={{@questResults}} @onError={{fn this.setGlobalError true}} />
+        {{/if}}
+        --}}
+
+      </div>
+      <div class="evaluation-results-hero-recommendation-engine__details">
+        <!-- On garde, Merci Elodie ... au lieu de Bonjour Elodie -->
+        <h2 class="evaluation-results-hero-recommendation-engine-details__title">
+          {{t "pages.skill-review.hero.thanks" name=this.currentUser.user.firstName}}
+        </h2>
+
+        {{#if @campaignParticipationResult.hasReachedStage}}
+          <!-- ???? dans la maquette, on ne sait pas ce qui correspond à cela -->
+          <div class="evaluation-results-hero-recommendation-engine-details__stage-message">
+            <MarkdownToHtml @isInline={{true}} @markdown={{@campaignParticipationResult.reachedStage.title}} />
+            <MarkdownToHtml @isInline={{true}} @markdown={{@campaignParticipationResult.reachedStage.message}} />
+          </div>
+        {{/if}}
+
+        {{#unless (or @campaign.isForAbsoluteNovice this.isCampaignAutonomousCourse)}}
+          <!-- On ne garde pas pour le mvp -->
+          <PixNotificationAlert
+            class="evaluation-results-hero-recommendation-engine-results__shared-message"
+            @type="success"
+            @withIcon={{true}}
+          >
+            {{t "pages.skill-review.hero.shared-message" date=this.sharedAtDate time=this.sharedAtTime}}
+          </PixNotificationAlert>
+
+          {{#if @hasTrainings}}
+            <!-- On ne garde pas pour le mvp -->
+            <p class="evaluation-results-hero-recommendation-engine-details__explanations">
+              {{t "pages.skill-review.hero.explanations.trainings"}}
+            </p>
+          {{/if}}
+        {{/unless}}
+
+        <div class="evaluation-results-hero-recommendation-engine-details__actions">
+          <!-- A priori les utilisateurs sont forcément connectés, donc ça ne rentre PAS dans le MVP -->
+          {{#if (or @campaign.isForAbsoluteNovice this.isCampaignAutonomousCourse)}}
+            {{#unless @campaign.hasCustomResultPageButton}}
+              {{#if this.isUserAnonymous}}
+                <p>{{t "pages.signup.save-progress-message"}}</p>
+                <PixButtonLink @route="inscription" @size="large" onclick={{this.handleSignUpClick}}>
+                  {{t "pages.signup.actions.sign-up-on-pix"}}
+                </PixButtonLink>
+              {{else}}
+                {{this.handleBackToHomepageDisplay}}
+                <PixButtonLink @route="authentication.login" @size="large" onclick={{this.handleBackToHomepageClick}}>
+                  {{t "navigation.back-to-homepage"}}
+                </PixButtonLink>
+              {{/if}}
+            {{/unless}}
+          {{else}}
+
+            {{#if this.isUserAnonymous}}
+              <p>{{t "pages.signup.save-progress-message"}}</p>
+              <PixButtonLink @route="inscription" @size="large" onclick={{this.handleSignUpClick}}>
+                {{t "pages.signup.actions.sign-up-on-pix"}}
+              </PixButtonLink>
+            {{/if}}
+            {{#if @hasTrainings}}
+              <PixButton @triggerAction={{this.handleSeeTrainingsClick}} @size="large">
+                {{t "pages.skill-review.hero.see-trainings"}}
+              </PixButton>
+            {{else}}
+              {{#unless (or @campaign.hasCustomResultPageButton this.isUserAnonymous)}}
+                {{this.handleBackToHomepageDisplay}}
+                <PixButtonLink @route="authentication.login" @size="large" onclick={{this.handleBackToHomepageClick}}>
+                  {{t "navigation.back-to-homepage"}}
+                </PixButtonLink>
+              {{/unless}}
+            {{/if}}
+          {{/if}}
+
+          {{#if this.hasGlobalError}}
+            <!-- Demander à Elodie le rendu quand on affiche une erreur -->
+            <div class="evaluation-results-hero-recommendation-engine-results__actions-error">
+              <PixNotificationAlert @type="error" @withIcon={{true}}>
+                {{t "pages.skill-review.error"}}
+              </PixNotificationAlert>
+            </div>
+          {{/if}}
+        </div>
+
+        {{#if @campaignParticipationResult.acquiredBadges.length}}
+          <!-- On garde en changeant le rendu -->
+          <AcquiredBadges @acquiredBadges={{@campaignParticipationResult.acquiredBadges}} />
+        {{/if}}
+
+        {{#if this.showCustomOrganizationBlock}}
+          <!-- On enlève pour le mvp -->
+          <CustomOrganizationBlock
+            @campaign={{@campaign}}
+            @campaignParticipationResult={{@campaignParticipationResult}}
+          />
+        {{/if}}
+      </div>
+
+      <!-- Ne semble PAS dans le MVP -->
+      {{#if (or @campaignParticipationResult.canRetry @campaignParticipationResult.canReset)}}
+        <RetryOrResetBlock @campaign={{@campaign}} @campaignParticipationResult={{@campaignParticipationResult}} />
+      {{/if}}
+    </div>
+  </template>
+}

--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine/index.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine/index.gjs
@@ -1,41 +1,16 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
-import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
 import PixStars from '@1024pix/pix-ui/components/pix-stars';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
-import { tracked } from '@glimmer/tracking';
-import dayjs from 'dayjs';
-import CustomParseFormat from 'dayjs/plugin/customParseFormat';
-import LocalizedFormat from 'dayjs/plugin/localizedFormat';
 import { t } from 'ember-intl';
-import or from 'ember-truth-helpers/helpers/or';
-import AcquiredBadges from 'mon-pix/components/campaigns/assessment/results/evaluation-results-hero/acquired-badges';
-import AttestationResult
-  from 'mon-pix/components/campaigns/assessment/results/evaluation-results-hero/attestation-result';
-import CustomOrganizationBlock
-  from 'mon-pix/components/campaigns/assessment/results/evaluation-results-hero/custom-organization-block';
-import RetryOrResetBlock
-  from 'mon-pix/components/campaigns/assessment/results/evaluation-results-hero/retry-or-reset-block';
-import ENV from 'mon-pix/config/environment';
 
-import MarkdownToHtml from '../../../../markdown-to-html';
-
-dayjs.extend(LocalizedFormat);
-dayjs.extend(CustomParseFormat);
+import AcquiredBadgesCompact from './acquired-badges-compact';
 
 export default class EvaluationResultsHeroRecommendationEngine extends Component {
   @service currentUser;
-
   @service pixMetrics;
-  @service router;
-  @service store;
-  @service tabManager;
-  @service featureToggles;
-
-  @tracked hasGlobalError = false;
-  @tracked isButtonLoading = false;
 
   get masteryRatePercentage() {
     return Math.round(this.args.campaignParticipationResult.masteryRate * 100);
@@ -55,50 +30,23 @@ export default class EvaluationResultsHeroRecommendationEngine extends Component
     };
   }
 
-  get isCampaignAutonomousCourse() {
-    return this.args.campaign.organizationId === ENV.APP.AUTONOMOUS_COURSES_ORGANIZATION_ID;
-  }
-
-  get showCustomOrganizationBlock() {
-    return this.args.campaign.customResultPageText || this.args.campaign.hasCustomResultPageButton;
-  }
-
-  get displayQuestResult() {
-    return (
-      this.featureToggles.featureToggles?.isQuestEnabled && !this.currentUser.user.isAnonymous && this.hasQuestResults
-    );
-  }
-
   get isUserAnonymous() {
     return this.currentUser?.user?.isAnonymous;
-  }
-
-  get hasQuestResults() {
-    return this.args.questResults && this.args.questResults.length > 0;
-  }
-
-  get sharedAtDate() {
-    return dayjs(this.args.campaignParticipationResult.sharedAt).format('LL');
-  }
-
-  get sharedAtTime() {
-    return dayjs(this.args.campaignParticipationResult.sharedAt).format('LT');
   }
 
   @action handleSeeTrainingsClick() {
     this.args.showTrainings();
   }
 
-  @action setGlobalError(value) {
-    this.hasGlobalError = value;
-  }
-
   @action handleBackToHomepageDisplay() {
-    this.pixMetrics.trackEvent("Affichage du bouton 'Revenir à la page d'accueil'", {
-      disabled: true,
-      category: 'Fin de parcours',
-      action: 'Sortie de parcours',
-    });
+    this.pixMetrics.trackEvent(
+      "Affichage du bouton 'Revenir à la page d'accueil dans le cadre du moteur de recommandation'",
+      {
+        disabled: true,
+        category: 'Fin de parcours',
+        action: 'Sortie de parcours',
+      },
+    );
   }
 
   @action handleBackToHomepageClick() {
@@ -109,146 +57,67 @@ export default class EvaluationResultsHeroRecommendationEngine extends Component
     });
   }
 
-  @action handleSignUpClick() {
-    this.pixMetrics.trackEvent('CampaignResultSignUpFromAnonymousUserClick');
-  }
-
   <template>
     <div class="evaluation-results-hero-recommendation-engine">
-      <div class="evaluation-results-hero-recommendation-engine__results">
-        <p class="evaluation-results-hero-recommendation-engine-results__percent">
-          ENGINE
-          <strong>{{this.masteryRatePercentage}}<span>%</span></strong>
-          <span>{{t "pages.skill-review.hero.mastery-rate"}}</span>
-        </p>
-        <!-- affichage des paliers sur la maquette, donc on garde-->
-        {{#if this.hasStagesStars}}
-          <PixStars
-            class="evaluation-results-hero-recommendation-engine-results__stars"
-            @count={{this.reachedStage.acquired}}
-            @total={{this.reachedStage.total}}
-            @alt={{t
-              "pages.skill-review.stage.starsAcquired"
-              acquired=this.reachedStage.acquired
-              total=this.reachedStage.total
-            }}
-            @color="yellow"
-          />
-
-          <div class="evaluation-results-hero-recommendation-engine-results__stars-text" role="presentation">
-            {{t
-              "pages.skill-review.stage.starsAcquired"
-              acquired=this.reachedStage.acquired
-              total=this.reachedStage.total
-            }}
-          </div>
-        {{/if}}
-
-        <!-- Pas sur les maquettes, on peut commenter-->
-        {{!--        {{#if this.displayQuestResult}}
-        <AttestationResult @results={{@questResults}} @onError={{fn this.setGlobalError true}} />
-        {{/if}}
-        --}}
-
-      </div>
-      <div class="evaluation-results-hero-recommendation-engine__details">
-        <!-- On garde, Merci Elodie ... au lieu de Bonjour Elodie -->
-        <h2 class="evaluation-results-hero-recommendation-engine-details__title">
+      <div class="evaluation-results-hero-recommendation-engine__content">
+        <h2 class="evaluation-results-hero-recommendation-engine__title">
           {{t "pages.skill-review.hero.thanks" name=this.currentUser.user.firstName}}
         </h2>
 
-        {{#if @campaignParticipationResult.hasReachedStage}}
-          <!-- ???? dans la maquette, on ne sait pas ce qui correspond à cela -->
-          <div class="evaluation-results-hero-recommendation-engine-details__stage-message">
-            <MarkdownToHtml @isInline={{true}} @markdown={{@campaignParticipationResult.reachedStage.title}} />
-            <MarkdownToHtml @isInline={{true}} @markdown={{@campaignParticipationResult.reachedStage.message}} />
+        <p class="evaluation-results-hero-recommendation-engine__percent">
+          <strong class="evaluation-results-hero-recommendation-engine__percent-value">
+            {{this.masteryRatePercentage}}<span class="evaluation-results-hero-recommendation-engine__percent-unit">
+              %</span>
+          </strong>
+          <span class="evaluation-results-hero-recommendation-engine__percent-label">{{t
+              "pages.skill-review.hero.mastery-rate"
+            }}</span>
+        </p>
+
+        {{#if this.hasStagesStars}}
+          <div class="evaluation-results-hero-recommendation-engine__stars">
+            <PixStars
+              @count={{this.reachedStage.acquired}}
+              @total={{this.reachedStage.total}}
+              @alt={{t
+                "pages.skill-review.stage.starsAcquired"
+                acquired=this.reachedStage.acquired
+                total=this.reachedStage.total
+              }}
+              @color="yellow"
+            />
+            <div class="evaluation-results-hero-recommendation-engine__stars-text" aria-hidden="true">
+              {{t
+                "pages.skill-review.stage.starsAcquired"
+                acquired=this.reachedStage.acquired
+                total=this.reachedStage.total
+              }}
+            </div>
           </div>
         {{/if}}
 
-        {{#unless (or @campaign.isForAbsoluteNovice this.isCampaignAutonomousCourse)}}
-          <!-- On ne garde pas pour le mvp -->
-          <PixNotificationAlert
-            class="evaluation-results-hero-recommendation-engine-results__shared-message"
-            @type="success"
-            @withIcon={{true}}
-          >
-            {{t "pages.skill-review.hero.shared-message" date=this.sharedAtDate time=this.sharedAtTime}}
-          </PixNotificationAlert>
+        {{#if @campaignParticipationResult.acquiredBadges.length}}
+          <AcquiredBadgesCompact @acquiredBadges={{@campaignParticipationResult.acquiredBadges}} />
+        {{/if}}
 
+        <div class="evaluation-results-hero-recommendation-engine__actions">
           {{#if @hasTrainings}}
-            <!-- On ne garde pas pour le mvp -->
-            <p class="evaluation-results-hero-recommendation-engine-details__explanations">
-              {{t "pages.skill-review.hero.explanations.trainings"}}
-            </p>
-          {{/if}}
-        {{/unless}}
-
-        <div class="evaluation-results-hero-recommendation-engine-details__actions">
-          <!-- A priori les utilisateurs sont forcément connectés, donc ça ne rentre PAS dans le MVP -->
-          {{#if (or @campaign.isForAbsoluteNovice this.isCampaignAutonomousCourse)}}
-            {{#unless @campaign.hasCustomResultPageButton}}
-              {{#if this.isUserAnonymous}}
-                <p>{{t "pages.signup.save-progress-message"}}</p>
-                <PixButtonLink @route="inscription" @size="large" onclick={{this.handleSignUpClick}}>
-                  {{t "pages.signup.actions.sign-up-on-pix"}}
-                </PixButtonLink>
-              {{else}}
-                {{this.handleBackToHomepageDisplay}}
-                <PixButtonLink @route="authentication.login" @size="large" onclick={{this.handleBackToHomepageClick}}>
-                  {{t "navigation.back-to-homepage"}}
-                </PixButtonLink>
-              {{/if}}
-            {{/unless}}
+            <PixButton @triggerAction={{this.handleSeeTrainingsClick}} @size="medium" @variant="secondary">
+              {{t "pages.skill-review.hero.see-trainings"}}
+            </PixButton>
           {{else}}
-
-            {{#if this.isUserAnonymous}}
-              <p>{{t "pages.signup.save-progress-message"}}</p>
-              <PixButtonLink @route="inscription" @size="large" onclick={{this.handleSignUpClick}}>
-                {{t "pages.signup.actions.sign-up-on-pix"}}
-              </PixButtonLink>
-            {{/if}}
-            {{#if @hasTrainings}}
-              <PixButton @triggerAction={{this.handleSeeTrainingsClick}} @size="large">
-                {{t "pages.skill-review.hero.see-trainings"}}
-              </PixButton>
-            {{else}}
-              {{#unless (or @campaign.hasCustomResultPageButton this.isUserAnonymous)}}
-                {{this.handleBackToHomepageDisplay}}
-                <PixButtonLink @route="authentication.login" @size="large" onclick={{this.handleBackToHomepageClick}}>
-                  {{t "navigation.back-to-homepage"}}
-                </PixButtonLink>
-              {{/unless}}
-            {{/if}}
-          {{/if}}
-
-          {{#if this.hasGlobalError}}
-            <!-- Demander à Elodie le rendu quand on affiche une erreur -->
-            <div class="evaluation-results-hero-recommendation-engine-results__actions-error">
-              <PixNotificationAlert @type="error" @withIcon={{true}}>
-                {{t "pages.skill-review.error"}}
-              </PixNotificationAlert>
-            </div>
+            {{this.handleBackToHomepageDisplay}}
+            <PixButtonLink
+              @route="authentication.login"
+              @size="small"
+              @variant="secondary-white"
+              onclick={{this.handleBackToHomepageClick}}
+            >
+              {{t "navigation.back-to-homepage"}}
+            </PixButtonLink>
           {{/if}}
         </div>
-
-        {{#if @campaignParticipationResult.acquiredBadges.length}}
-          <!-- On garde en changeant le rendu -->
-          <AcquiredBadges @acquiredBadges={{@campaignParticipationResult.acquiredBadges}} />
-        {{/if}}
-
-        {{#if this.showCustomOrganizationBlock}}
-          <!-- On enlève pour le mvp -->
-          <CustomOrganizationBlock
-            @campaign={{@campaign}}
-            @campaignParticipationResult={{@campaignParticipationResult}}
-          />
-        {{/if}}
       </div>
-
-      <!-- Ne semble PAS dans le MVP -->
-      {{#if (or @campaignParticipationResult.canRetry @campaignParticipationResult.canReset)}}
-        <RetryOrResetBlock @campaign={{@campaign}} @campaignParticipationResult={{@campaignParticipationResult}} />
-      {{/if}}
     </div>
   </template>
 }

--- a/mon-pix/app/components/routes/campaigns/assessment/evaluation-results-recommendation-engine.gjs
+++ b/mon-pix/app/components/routes/campaigns/assessment/evaluation-results-recommendation-engine.gjs
@@ -1,0 +1,85 @@
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { t } from 'ember-intl';
+
+import EvaluationResultsHeroRecommendationEngine
+  from '../../../campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine';
+import EvaluationResultsTabs from '../../../campaigns/assessment/results/evaluation-results-tabs';
+import QuitResults from '../../../campaigns/assessment/results/quit-results';
+
+export default class EvaluationResultsRecommendationEngine extends Component {
+  @service tabManager;
+  // eslint-disable-next-line ember/no-tracked-properties-from-args
+  @tracked showEvaluationResultsModal = this.args.model.showTrainings;
+
+  get hasTrainings() {
+    return Boolean(this.trainings.length);
+  }
+
+  get trainingsForModal() {
+    const MAX_TRAININGS_MODAL_DISPLAYED = 3;
+    return this.trainings.slice(0, MAX_TRAININGS_MODAL_DISPLAYED);
+  }
+
+  get trainings() {
+    if (this.args.model.campaign.isPartOfCombinedCourse) {
+      return [];
+    } else {
+      return this.args.model.trainings;
+    }
+  }
+
+  @action
+  showTrainings() {
+    const tabElement = document.querySelector('[role="tablist"]');
+    const tabElementTopPosition = tabElement.getBoundingClientRect().top;
+
+    window.scrollTo({
+      top: tabElementTopPosition,
+      behavior: 'smooth',
+    });
+
+    this.tabManager.setActiveTab(2);
+  }
+
+  @action
+  shareResults() {
+    if (this.args.model.campaign.isPartOfCombinedCourse) {
+      return;
+    }
+    this.showEvaluationResultsModal = true;
+  }
+
+  @action
+  closeModal() {
+    this.showEvaluationResultsModal = false;
+  }
+
+  <template>
+    <main role="main" class="evaluation-results-recommendation-engine">
+      <header class="evaluation-results__header">
+        <img class="evaluation-results-header__logo" src="/images/pix-logo-dark.svg" alt="{{t 'common.pix'}}" />
+        <h1 class="evaluation-results-header__title">
+          <span>{{@model.campaign.title}}</span>
+          <span class="sr-only">{{t "pages.skill-review.abstract-title"}}</span>
+        </h1>
+        <QuitResults />
+      </header>
+      <EvaluationResultsHeroRecommendationEngine
+        @campaign={{@model.campaign}}
+        @campaignParticipationResult={{@model.campaignParticipationResult}}
+        @questResults={{@model.questResults}}
+        @hasTrainings={{this.hasTrainings}}
+        @showTrainings={{this.showTrainings}}
+      />
+      <EvaluationResultsTabs
+        @campaign={{@model.campaign}}
+        @campaignParticipationResult={{@model.campaignParticipationResult}}
+        @questResults={{@model.questResults}}
+        @trainings={{this.trainings}}
+      />
+    </main>
+  </template>
+}

--- a/mon-pix/app/components/routes/campaigns/assessment/evaluation-results-recommendation-engine.gjs
+++ b/mon-pix/app/components/routes/campaigns/assessment/evaluation-results-recommendation-engine.gjs
@@ -1,26 +1,17 @@
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
-import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 
-import EvaluationResultsHeroRecommendationEngine
-  from '../../../campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine';
 import EvaluationResultsTabs from '../../../campaigns/assessment/results/evaluation-results-tabs';
 import QuitResults from '../../../campaigns/assessment/results/quit-results';
+import EvaluationResultsHeroRecommendationEngine from '../../../campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine';
 
 export default class EvaluationResultsRecommendationEngine extends Component {
   @service tabManager;
-  // eslint-disable-next-line ember/no-tracked-properties-from-args
-  @tracked showEvaluationResultsModal = this.args.model.showTrainings;
 
   get hasTrainings() {
     return Boolean(this.trainings.length);
-  }
-
-  get trainingsForModal() {
-    const MAX_TRAININGS_MODAL_DISPLAYED = 3;
-    return this.trainings.slice(0, MAX_TRAININGS_MODAL_DISPLAYED);
   }
 
   get trainings() {
@@ -42,19 +33,6 @@ export default class EvaluationResultsRecommendationEngine extends Component {
     });
 
     this.tabManager.setActiveTab(2);
-  }
-
-  @action
-  shareResults() {
-    if (this.args.model.campaign.isPartOfCombinedCourse) {
-      return;
-    }
-    this.showEvaluationResultsModal = true;
-  }
-
-  @action
-  closeModal() {
-    this.showEvaluationResultsModal = false;
   }
 
   <template>

--- a/mon-pix/app/models/campaign.js
+++ b/mon-pix/app/models/campaign.js
@@ -26,6 +26,7 @@ export default class Campaign extends Model {
   @attr('string') customResultPageButtonText;
   @attr('string') customResultPageButtonUrl;
   @attr('boolean') multipleSendings;
+  @attr('boolean') recommendationEngine;
 
   @attr('boolean') isReconciliationRequired;
   @attr() reconciliationFields;

--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -181,6 +181,7 @@ of an adaptative/mobile-first approach — refactoring is welcome here */
 @use 'pages/course-error' as *;
 @use 'pages/error' as *;
 @use 'pages/evaluation-results' as *;
+@use 'pages/evaluation-results-recommendation-engine' as *;
 @use 'pages/fill-in-campaign-code' as *;
 @use 'pages/fill-in-certificate-verification-code' as *;
 @use 'pages/fill-in-participant-external-id' as *;

--- a/mon-pix/app/styles/components/campaigns/assessment/results/recommendation-engine/acquired-badges-compact.scss
+++ b/mon-pix/app/styles/components/campaigns/assessment/results/recommendation-engine/acquired-badges-compact.scss
@@ -1,0 +1,32 @@
+@use 'pix-design-tokens/typography';
+@use 'pix-design-tokens/colors';
+
+.acquired-badges-compact {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  margin: 0;
+  padding: 0;
+
+  &__item {
+    display: flex;
+  }
+
+  &__icon {
+    width: 3.5rem;
+    height: 3.5rem;
+  }
+
+  &__overflow {
+    @extend %pix-body-s;
+
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 3.5rem;
+    height: 3.5rem;
+    color: var(--pix-primary-300);
+    font-weight: var(--pix-font-bold);
+    background: url('/images/background/badge-overflow.svg') center no-repeat;
+  }
+}

--- a/mon-pix/app/styles/components/campaigns/index.scss
+++ b/mon-pix/app/styles/components/campaigns/index.scss
@@ -2,4 +2,5 @@
 @use 'assessment/results/evaluation-results-tabs/results-details';
 @use 'assessment/results/evaluation-results-tabs/rewards';
 @use 'assessment/results/evaluation-results-tabs/trainings';
+@use 'assessment/results/recommendation-engine/acquired-badges-compact';
 @use 'invited/learner-reconciliation';

--- a/mon-pix/app/styles/pages/_evaluation-results-recommendation-engine.scss
+++ b/mon-pix/app/styles/pages/_evaluation-results-recommendation-engine.scss
@@ -1,299 +1,73 @@
 @use 'pix-design-tokens/typography';
+@use "pix-design-tokens/colors";
 
 .evaluation-results-hero-recommendation-engine {
-  min-height: 100dvh;
-  padding: var(--pix-spacing-12x) var(--pix-spacing-4x);
-  color: var(--pix-neutral-900);
-  background-color: var(--pix-primary-10);
-}
-
-/**
- * Evaluation Results Header
- */
-.evaluation-results-hero-recommendation-engine__header {
-  display: flex;
-  align-items: center;
-  max-width: 1280px;
-  margin: 0 auto var(--pix-spacing-8x);
-}
-
-.evaluation-results-hero-recommendation-engine-header__logo {
-  height: 2.75rem;
-}
-
-.evaluation-results-hero-recommendation-engine-header__title {
-  @extend %pix-body-l;
-
-  display: flex;
-  align-items: center;
-
-  &::before {
-    width: 1px;
-    height: 2rem;
-    margin: 0 var(--pix-spacing-4x);
-    background-color: currentcolor;
-    content: '';
-  }
-}
-
-.evaluation-results-hero-recommendation-engine-header__back-link {
-  @extend %pix-body-l;
-
-  margin-left: auto;
-  font-weight: var(--pix-font-medium);
-
-  &::after {
-    margin-left: var(--pix-spacing-2x);
-    font-size: 1rem;
-    content: '✕';
-    -webkit-text-stroke: 2px currentcolor;
-  }
-}
-
-/**
- * Evaluation Results Hero
- */
-.evaluation-results-hero-recommendation-engine-hero {
   display: flex;
   flex-wrap: wrap;
   gap: var(--pix-spacing-10x);
-  justify-content: stretch;
+  justify-content: space-between;
   max-width: 80rem;
   margin: 0 auto var(--pix-spacing-10x);
-  padding: var(--pix-spacing-6x);
-  background-color: var(--pix-neutral-0);
-  border: 1px solid var(--pix-neutral-100);
-  border-radius: 1.5rem;
-}
+  padding: var(--pix-spacing-10x) 15%;
+  color: var(--pix-neutral-0);
+  background: var(--pix-gradient-default-dark);
+  border-radius: var(--radius-5x, 20px);
 
-// Results
-.evaluation-results-hero-recommendation-engine-hero__results {
-  flex: 1;
-  min-width: min(20rem, 100%);
-  padding: var(--pix-spacing-4x) var(--pix-spacing-6x) 9rem;
-  text-align: center;
-  background-color: var(--pix-primary-10);
-  background-image: url('/images/illustrations/fusee-results.svg');
-  background-repeat: no-repeat;
-  background-position: left bottom;
-  background-size: auto 7rem;
-  border-radius: 1rem;
-}
+  &__content {
+    display: flex;
+    flex-direction: column;
+    gap: var(--pix-spacing-4x);
+    min-width: min(28rem, 100%);
+  }
 
-.evaluation-results-hero-recommendation-engine-hero-results__percent {
-  @extend %pix-title-xs;
+  &__title {
+    @extend %pix-title-s;
 
-  color: var(--pix-primary-700);
-  font-weight: var(--pix-font-bold);
+    color: var(--pix-neutral-0);
+  }
 
-  strong {
+  &__percent {
+    @extend %pix-subtitle-s;
+
+    color: var(--pix-neutral-0);
+    font-weight: 500;
+    line-height: 2rem;
+  }
+
+  &__percent-value {
     display: block;
-    font-size: 4.5rem;
-    line-height: 5.5rem;
+    font-size: 3rem;
+  }
 
-    span {
-      margin-left: 0.1em;
-      font-size: 3.5rem;
-      line-height: 0;
-      vertical-align: -0.1em;
+  &__percent-unit {
+    margin-left: var(--pix-spacing-2x);
+    font-size: 2.5rem;
+  }
+
+  &__stars {
+    display: flex;
+    flex-direction: row;
+    gap: var(--pix-spacing-3x);
+    align-items: center;
+
+    .pix-stars {
+      gap: var(--pix-spacing-1x);
+      height: var(--pix-spacing-6x);
     }
   }
-}
 
-// Details
-.evaluation-results-hero-recommendation-engine-hero__details {
-  flex: 4;
-  min-width: min(25rem, 100%);
-}
+  &__stars-text {
+    @extend %pix-body-s;
 
-.evaluation-results-hero-recommendation-engine-hero-details__title {
-  @extend %pix-title-m;
+    color: var(--pix-neutral-0);
+  }
 
-  margin-bottom: var(--pix-spacing-4x);
-}
-
-.evaluation-results-hero-recommendation-engine-hero-results__stars {
-  margin-block: var(--pix-spacing-6x) var(--pix-spacing-3x);
-  justify-content: center;
-}
-
-.evaluation-results-hero-recommendation-engine-hero-details__stage-message {
-  @extend %pix-body-l;
-
-  margin-bottom: var(--pix-spacing-4x);
-
-  &:not(:last-child)::after {
-    display: block;
-    height: 1px;
-    background-color: var(--pix-neutral-100);
-    content: '';
-    margin-block: var(--pix-spacing-4x);
+  &__actions {
+    display: flex;
+    flex-direction: column;
+    flex-wrap: wrap;
+    gap: var(--pix-spacing-4x);
+    align-items: flex-start;
   }
 }
 
-.evaluation-results-hero-recommendation-engine-hero-results__shared-message {
-  display: inline-flex;
-  margin-bottom: var(--pix-spacing-4x);
-}
-
-.evaluation-results-hero-recommendation-engine-hero-details__explanations {
-  @extend %pix-body-s;
-
-  font-weight: var(--pix-font-bold);
-}
-
-.evaluation-results-hero-recommendation-engine-hero-details__actions {
-  display: flex;
-  flex-direction: column;
-  flex-wrap: wrap;
-  gap: var(--pix-spacing-6x);
-  align-items: flex-start;
-  margin-top: var(--pix-spacing-6x);
-}
-
-.evaluation-results-hero-recommendation-engine-hero-results__actions-error {
-  width: 100%;
-
-  & > * {
-    display: inline-flex;
-  }
-}
-
-// Acquired badges
-.evaluation-results-hero-recommendation-engine-hero-details__acquired-badges-title {
-  @extend %pix-title-xs;
-
-  margin-block: var(--pix-spacing-8x) var(--pix-spacing-4x);
-}
-
-.evaluation-results-hero-recommendation-engine-hero-details__acquired-badges {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(min(12rem, 100%), 1fr));
-  gap: var(--pix-spacing-6x);
-
-  .image-container {
-    position: relative;
-    padding: var(--pix-spacing-4x);
-    overflow: hidden;
-    background-color: var(--pix-neutral-20);
-    border-radius: 0.5rem;
-  }
-
-  img {
-    display: block;
-    height: 5rem;
-    margin: 0 auto;
-  }
-
-  .certifiable-label {
-    @extend %pix-title-xs;
-
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    width: 100%;
-    color: var(--pix-success-700);
-    font-size: 0.8125rem;
-    line-height: 1.75rem;
-    text-align: center;
-    text-transform: uppercase;
-    background-color: var(--pix-success-100);
-  }
-
-  .badge-name {
-    @extend %pix-body-m;
-
-    margin-top: var(--pix-spacing-2x);
-    text-align: center;
-  }
-}
-
-// Custom organization block
-.evaluation-results-hero-recommendation-engine-hero__organization-block,
-.evaluation-results-hero-recommendation-engine-hero__retry {
-  flex-basis: 100%;
-  padding-top: var(--pix-spacing-10x);
-  border-top: 1px solid var(--pix-neutral-100);
-}
-
-.evaluation-results-hero-recommendation-engine-hero-organization-block {
-  &__link {
-    width: fit-content;
-  }
-
-  &__message {
-    margin-bottom: var(--pix-spacing-4x);
-  }
-}
-
-// Retry or reset block
-.evaluation-results-hero-recommendation-engine-hero__retry {
-  display: grid;
-  grid-template-columns: 1fr min(250px, 25%);
-  gap: var(--pix-spacing-10x);
-
-  &::after {
-    background-image: url('/images/illustrations/results/retry-assessment.svg');
-    background-repeat: no-repeat;
-    background-position: center;
-    background-size: contain;
-    content: '';
-  }
-
-  @media (max-width: 767px) {
-    display: block;
-
-    &::after {
-      content: none;
-    }
-  }
-}
-
-.evaluation-results-hero-recommendation-engine-hero-retry__title {
-  @extend %pix-title-l;
-
-  color: var(--pix-neutral-900);
-}
-
-.evaluation-results-hero-recommendation-engine-hero-retry__description {
-  @extend %pix-title-xs;
-
-  margin-top: var(--pix-spacing-1x);
-  color: var(--pix-neutral-500);
-}
-
-.evaluation-results-hero-recommendation-engine-hero-retry__actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--pix-spacing-4x);
-  align-items: center;
-  margin-block: var(--pix-spacing-4x);
-  padding-block: var(--pix-spacing-1x);
-}
-
-.evaluation-results-hero-recommendation-engine-hero-retry__soon-title {
-  @extend %pix-body-m;
-
-  margin-bottom: var(--pix-spacing-4x);
-}
-
-/**
- * Evaluation Results Tabs
- */
-.evaluation-results-hero-recommendation-engine-tabs {
-  max-width: 66rem;
-  margin: 0 auto;
-}
-
-.evaluation-results-hero-recommendation-engine-tab__title {
-  @extend %pix-title-s;
-
-  margin-top: var(--pix-spacing-10x);
-}
-
-.evaluation-results-hero-recommendation-engine-tab__description {
-  @extend %pix-body-m;
-
-  margin-top: var(--pix-spacing-2x);
-  color: var(--pix-neutral-500);
-}

--- a/mon-pix/app/styles/pages/_evaluation-results-recommendation-engine.scss
+++ b/mon-pix/app/styles/pages/_evaluation-results-recommendation-engine.scss
@@ -1,0 +1,299 @@
+@use 'pix-design-tokens/typography';
+
+.evaluation-results-hero-recommendation-engine {
+  min-height: 100dvh;
+  padding: var(--pix-spacing-12x) var(--pix-spacing-4x);
+  color: var(--pix-neutral-900);
+  background-color: var(--pix-primary-10);
+}
+
+/**
+ * Evaluation Results Header
+ */
+.evaluation-results-hero-recommendation-engine__header {
+  display: flex;
+  align-items: center;
+  max-width: 1280px;
+  margin: 0 auto var(--pix-spacing-8x);
+}
+
+.evaluation-results-hero-recommendation-engine-header__logo {
+  height: 2.75rem;
+}
+
+.evaluation-results-hero-recommendation-engine-header__title {
+  @extend %pix-body-l;
+
+  display: flex;
+  align-items: center;
+
+  &::before {
+    width: 1px;
+    height: 2rem;
+    margin: 0 var(--pix-spacing-4x);
+    background-color: currentcolor;
+    content: '';
+  }
+}
+
+.evaluation-results-hero-recommendation-engine-header__back-link {
+  @extend %pix-body-l;
+
+  margin-left: auto;
+  font-weight: var(--pix-font-medium);
+
+  &::after {
+    margin-left: var(--pix-spacing-2x);
+    font-size: 1rem;
+    content: '✕';
+    -webkit-text-stroke: 2px currentcolor;
+  }
+}
+
+/**
+ * Evaluation Results Hero
+ */
+.evaluation-results-hero-recommendation-engine-hero {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--pix-spacing-10x);
+  justify-content: stretch;
+  max-width: 80rem;
+  margin: 0 auto var(--pix-spacing-10x);
+  padding: var(--pix-spacing-6x);
+  background-color: var(--pix-neutral-0);
+  border: 1px solid var(--pix-neutral-100);
+  border-radius: 1.5rem;
+}
+
+// Results
+.evaluation-results-hero-recommendation-engine-hero__results {
+  flex: 1;
+  min-width: min(20rem, 100%);
+  padding: var(--pix-spacing-4x) var(--pix-spacing-6x) 9rem;
+  text-align: center;
+  background-color: var(--pix-primary-10);
+  background-image: url('/images/illustrations/fusee-results.svg');
+  background-repeat: no-repeat;
+  background-position: left bottom;
+  background-size: auto 7rem;
+  border-radius: 1rem;
+}
+
+.evaluation-results-hero-recommendation-engine-hero-results__percent {
+  @extend %pix-title-xs;
+
+  color: var(--pix-primary-700);
+  font-weight: var(--pix-font-bold);
+
+  strong {
+    display: block;
+    font-size: 4.5rem;
+    line-height: 5.5rem;
+
+    span {
+      margin-left: 0.1em;
+      font-size: 3.5rem;
+      line-height: 0;
+      vertical-align: -0.1em;
+    }
+  }
+}
+
+// Details
+.evaluation-results-hero-recommendation-engine-hero__details {
+  flex: 4;
+  min-width: min(25rem, 100%);
+}
+
+.evaluation-results-hero-recommendation-engine-hero-details__title {
+  @extend %pix-title-m;
+
+  margin-bottom: var(--pix-spacing-4x);
+}
+
+.evaluation-results-hero-recommendation-engine-hero-results__stars {
+  margin-block: var(--pix-spacing-6x) var(--pix-spacing-3x);
+  justify-content: center;
+}
+
+.evaluation-results-hero-recommendation-engine-hero-details__stage-message {
+  @extend %pix-body-l;
+
+  margin-bottom: var(--pix-spacing-4x);
+
+  &:not(:last-child)::after {
+    display: block;
+    height: 1px;
+    background-color: var(--pix-neutral-100);
+    content: '';
+    margin-block: var(--pix-spacing-4x);
+  }
+}
+
+.evaluation-results-hero-recommendation-engine-hero-results__shared-message {
+  display: inline-flex;
+  margin-bottom: var(--pix-spacing-4x);
+}
+
+.evaluation-results-hero-recommendation-engine-hero-details__explanations {
+  @extend %pix-body-s;
+
+  font-weight: var(--pix-font-bold);
+}
+
+.evaluation-results-hero-recommendation-engine-hero-details__actions {
+  display: flex;
+  flex-direction: column;
+  flex-wrap: wrap;
+  gap: var(--pix-spacing-6x);
+  align-items: flex-start;
+  margin-top: var(--pix-spacing-6x);
+}
+
+.evaluation-results-hero-recommendation-engine-hero-results__actions-error {
+  width: 100%;
+
+  & > * {
+    display: inline-flex;
+  }
+}
+
+// Acquired badges
+.evaluation-results-hero-recommendation-engine-hero-details__acquired-badges-title {
+  @extend %pix-title-xs;
+
+  margin-block: var(--pix-spacing-8x) var(--pix-spacing-4x);
+}
+
+.evaluation-results-hero-recommendation-engine-hero-details__acquired-badges {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(min(12rem, 100%), 1fr));
+  gap: var(--pix-spacing-6x);
+
+  .image-container {
+    position: relative;
+    padding: var(--pix-spacing-4x);
+    overflow: hidden;
+    background-color: var(--pix-neutral-20);
+    border-radius: 0.5rem;
+  }
+
+  img {
+    display: block;
+    height: 5rem;
+    margin: 0 auto;
+  }
+
+  .certifiable-label {
+    @extend %pix-title-xs;
+
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    color: var(--pix-success-700);
+    font-size: 0.8125rem;
+    line-height: 1.75rem;
+    text-align: center;
+    text-transform: uppercase;
+    background-color: var(--pix-success-100);
+  }
+
+  .badge-name {
+    @extend %pix-body-m;
+
+    margin-top: var(--pix-spacing-2x);
+    text-align: center;
+  }
+}
+
+// Custom organization block
+.evaluation-results-hero-recommendation-engine-hero__organization-block,
+.evaluation-results-hero-recommendation-engine-hero__retry {
+  flex-basis: 100%;
+  padding-top: var(--pix-spacing-10x);
+  border-top: 1px solid var(--pix-neutral-100);
+}
+
+.evaluation-results-hero-recommendation-engine-hero-organization-block {
+  &__link {
+    width: fit-content;
+  }
+
+  &__message {
+    margin-bottom: var(--pix-spacing-4x);
+  }
+}
+
+// Retry or reset block
+.evaluation-results-hero-recommendation-engine-hero__retry {
+  display: grid;
+  grid-template-columns: 1fr min(250px, 25%);
+  gap: var(--pix-spacing-10x);
+
+  &::after {
+    background-image: url('/images/illustrations/results/retry-assessment.svg');
+    background-repeat: no-repeat;
+    background-position: center;
+    background-size: contain;
+    content: '';
+  }
+
+  @media (max-width: 767px) {
+    display: block;
+
+    &::after {
+      content: none;
+    }
+  }
+}
+
+.evaluation-results-hero-recommendation-engine-hero-retry__title {
+  @extend %pix-title-l;
+
+  color: var(--pix-neutral-900);
+}
+
+.evaluation-results-hero-recommendation-engine-hero-retry__description {
+  @extend %pix-title-xs;
+
+  margin-top: var(--pix-spacing-1x);
+  color: var(--pix-neutral-500);
+}
+
+.evaluation-results-hero-recommendation-engine-hero-retry__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--pix-spacing-4x);
+  align-items: center;
+  margin-block: var(--pix-spacing-4x);
+  padding-block: var(--pix-spacing-1x);
+}
+
+.evaluation-results-hero-recommendation-engine-hero-retry__soon-title {
+  @extend %pix-body-m;
+
+  margin-bottom: var(--pix-spacing-4x);
+}
+
+/**
+ * Evaluation Results Tabs
+ */
+.evaluation-results-hero-recommendation-engine-tabs {
+  max-width: 66rem;
+  margin: 0 auto;
+}
+
+.evaluation-results-hero-recommendation-engine-tab__title {
+  @extend %pix-title-s;
+
+  margin-top: var(--pix-spacing-10x);
+}
+
+.evaluation-results-hero-recommendation-engine-tab__description {
+  @extend %pix-body-m;
+
+  margin-top: var(--pix-spacing-2x);
+  color: var(--pix-neutral-500);
+}

--- a/mon-pix/app/templates/campaigns/assessment/results.gjs
+++ b/mon-pix/app/templates/campaigns/assessment/results.gjs
@@ -1,8 +1,14 @@
 import t from 'ember-intl/helpers/t';
 import pageTitle from 'ember-page-title/helpers/page-title';
 import EvaluationResults from 'mon-pix/components/routes/campaigns/assessment/evaluation-results';
+import EvaluationResultsRecommendationEngine
+  from 'mon-pix/components/routes/campaigns/assessment/evaluation-results-recommendation-engine';
+
 <template>
   {{pageTitle (t "pages.skill-review.title")}}
-
-  <EvaluationResults @model={{@model}} />
+  {{#if @model.campaign.recommendationEngine}}
+    <EvaluationResultsRecommendationEngine @model={{@model}} />
+  {{else}}
+    <EvaluationResults @model={{@model}} />
+  {{/if}}
 </template>

--- a/mon-pix/app/templates/campaigns/assessment/results.gjs
+++ b/mon-pix/app/templates/campaigns/assessment/results.gjs
@@ -1,8 +1,7 @@
 import t from 'ember-intl/helpers/t';
 import pageTitle from 'ember-page-title/helpers/page-title';
 import EvaluationResults from 'mon-pix/components/routes/campaigns/assessment/evaluation-results';
-import EvaluationResultsRecommendationEngine
-  from 'mon-pix/components/routes/campaigns/assessment/evaluation-results-recommendation-engine';
+import EvaluationResultsRecommendationEngine from 'mon-pix/components/routes/campaigns/assessment/evaluation-results-recommendation-engine';
 
 <template>
   {{pageTitle (t "pages.skill-review.title")}}

--- a/mon-pix/public/images/background/badge-overflow.svg
+++ b/mon-pix/public/images/background/badge-overflow.svg
@@ -1,0 +1,17 @@
+<svg width="47" height="52" viewBox="0 0 47 52" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_d_1875_29895)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M24.3957 1.33332C23.6329 0.888894 22.3887 0.888894 21.626 1.33332L3.98983 11.596C2.64413 12.3796 1.54785 14.2947 1.54785 15.8619V35.1592C1.54785 36.729 2.64413 38.6415 3.98983 39.4251L21.278 49.486C21.7565 49.7638 22.3829 49.9041 23.0123 49.9041C23.6387 49.9041 24.2652 49.7638 24.7437 49.486L42.0319 39.4251C43.3776 38.6415 44.4709 36.729 44.4709 35.1592V15.8619C44.4709 14.2947 43.3776 12.3796 42.0319 11.596L24.3957 1.33332Z" fill="#F7F5FF"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M24.3957 1.33332C23.6329 0.888894 22.3887 0.888894 21.626 1.33332L3.98983 11.596C2.64413 12.3796 1.54785 14.2947 1.54785 15.8619V35.1592C1.54785 36.729 2.64413 38.6415 3.98983 39.4251L21.278 49.486C21.7565 49.7638 22.3829 49.9041 23.0123 49.9041C23.6387 49.9041 24.2652 49.7638 24.7437 49.486L42.0319 39.4251C43.3776 38.6415 44.4709 36.729 44.4709 35.1592V15.8619C44.4709 14.2947 43.3776 12.3796 42.0319 11.596L24.3957 1.33332Z" stroke="#F7F5FF" stroke-width="2"/>
+</g>
+<defs>
+<filter id="filter0_d_1875_29895" x="-9.36389e-05" y="0" width="46.0187" height="52.0002" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="0.547945"/>
+<feGaussianBlur stdDeviation="0.273973"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.0705882 0 0 0 0 0.639216 0 0 0 0 1 0 0 0 0.5 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_1875_29895"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_1875_29895" result="shape"/>
+</filter>
+</defs>
+</svg>

--- a/mon-pix/tests/acceptance/campaigns/campaign-results-recommendation-engine-test.js
+++ b/mon-pix/tests/acceptance/campaigns/campaign-results-recommendation-engine-test.js
@@ -1,0 +1,112 @@
+import { visit } from '@1024pix/ember-testing-library';
+import { currentURL } from '@ember/test-helpers';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { setupApplicationTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+import { authenticate } from '../../helpers/authentication';
+import setupIntl from '../../helpers/setup-intl';
+
+module('Acceptance | Campaigns | Results | Recommendation Engine', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+  setupIntl(hooks);
+
+  let user;
+  let campaignParticipation;
+
+  hooks.beforeEach(function () {
+    user = server.create('user', 'withEmail');
+  });
+
+  module('when campaign has recommendationEngine enabled', function (hooks) {
+    let campaign;
+
+    hooks.beforeEach(async function () {
+      campaign = server.create('campaign', { isArchived: false, organizationId: 123, recommendationEngine: true });
+      campaignParticipation = server.create('campaign-participation', { campaign });
+
+      await authenticate(user);
+
+      const competenceResult = server.create('competence-result', {
+        name: 'Competence Nom',
+        masteryPercentage: 75,
+      });
+      server.create('campaign-participation-result', {
+        id: campaignParticipation.id,
+        competenceResults: [competenceResult],
+        masteryRate: 0.75,
+        masteryPercentage: 75,
+      });
+    });
+
+    test('should access the results page at the expected URL', async function (assert) {
+      // when
+      await visit(`/campagnes/${campaign.code}/evaluation/resultats`);
+
+      // then
+      assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/evaluation/resultats`);
+    });
+
+    test('should display the recommendation engine results page', async function (assert) {
+      // when
+      await visit(`/campagnes/${campaign.code}/evaluation/resultats`);
+
+      // then
+      assert.dom('.evaluation-results-recommendation-engine').exists();
+    });
+
+    test('should not display the standard results page', async function (assert) {
+      // when
+      await visit(`/campagnes/${campaign.code}/evaluation/resultats`);
+
+      // then
+      assert.dom('.evaluation-results:not(.evaluation-results-recommendation-engine)').doesNotExist();
+    });
+  });
+
+  module('when campaign does not have recommendationEngine enabled', function (hooks) {
+    let campaign;
+
+    hooks.beforeEach(async function () {
+      campaign = server.create('campaign', { isArchived: false, organizationId: 123, recommendationEngine: false });
+      campaignParticipation = server.create('campaign-participation', { campaign });
+
+      await authenticate(user);
+
+      const competenceResult = server.create('competence-result', {
+        name: 'Competence Nom',
+        masteryPercentage: 75,
+      });
+      server.create('campaign-participation-result', {
+        id: campaignParticipation.id,
+        competenceResults: [competenceResult],
+        masteryPercentage: 75,
+      });
+    });
+
+    test('should access the results page at the expected URL', async function (assert) {
+      // when
+      await visit(`/campagnes/${campaign.code}/evaluation/resultats`);
+
+      // then
+      assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/evaluation/resultats`);
+    });
+
+    test('should display the standard results page', async function (assert) {
+      // when
+      await visit(`/campagnes/${campaign.code}/evaluation/resultats`);
+
+      // then
+      assert.dom('.evaluation-results').exists();
+    });
+
+    test('should not display the recommendation engine results page', async function (assert) {
+      // when
+      await visit(`/campagnes/${campaign.code}/evaluation/resultats`);
+
+      // then
+      assert.dom('.evaluation-results-recommendation-engine').doesNotExist();
+    });
+  });
+});

--- a/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine/acquired-badges-compact-test.gjs
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine/acquired-badges-compact-test.gjs
@@ -1,0 +1,82 @@
+import { render } from '@1024pix/ember-testing-library';
+import AcquiredBadgesCompact from 'mon-pix/components/campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine/acquired-badges-compact';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../../../../helpers/setup-intl-rendering';
+
+module(
+  'Integration | Components | Campaigns | Assessment | ResultsRecommendationEngine | EvaluationResultsHeroRecommendationEngine | AcquiredBadgesCompact',
+  function (hooks) {
+    setupIntlRenderingTest(hooks);
+
+    module('when there are 2 badges or fewer', function () {
+      test('it displays all badge icons', async function (assert) {
+        // given
+        const badges = [
+          { altMessage: 'Badge 1', imageUrl: '/images/background/hexa-pix.svg', title: 'Badge 1' },
+          { altMessage: 'Badge 2', imageUrl: '/images/background/hexa-pix.svg', title: 'Badge 2' },
+        ];
+
+        // when
+        const screen = await render(<template><AcquiredBadgesCompact @acquiredBadges={{badges}} /></template>);
+
+        // then
+        assert.dom(screen.getByRole('img', { name: 'Badge 1' })).exists();
+        assert.dom(screen.getByRole('img', { name: 'Badge 2' })).exists();
+        assert.strictEqual(screen.getAllByRole('listitem').length, 2);
+      });
+
+      test('it does not display an overflow counter', async function (assert) {
+        // given
+        const badges = [
+          { altMessage: 'Badge 1', imageUrl: '/images/background/hexa-pix.svg', title: 'Badge 1' },
+          { altMessage: 'Badge 2', imageUrl: '/images/background/hexa-pix.svg', title: 'Badge 2' },
+        ];
+
+        // when
+        const screen = await render(<template><AcquiredBadgesCompact @acquiredBadges={{badges}} /></template>);
+
+        // then
+        assert.dom(screen.queryByText('+0')).doesNotExist();
+        assert.strictEqual(screen.getAllByRole('listitem').length, 2);
+      });
+    });
+
+    module('when there are more than 2 badges', function () {
+      test('it displays only the first 2 badge icons', async function (assert) {
+        // given
+        const badges = [
+          { altMessage: 'Badge 1', imageUrl: '/images/background/hexa-pix.svg', title: 'Badge 1' },
+          { altMessage: 'Badge 2', imageUrl: '/images/background/hexa-pix.svg', title: 'Badge 2' },
+          { altMessage: 'Badge 3', imageUrl: '/images/background/hexa-pix.svg', title: 'Badge 3' },
+          { altMessage: 'Badge 4', imageUrl: '/images/background/hexa-pix.svg', title: 'Badge 4' },
+        ];
+
+        // when
+        const screen = await render(<template><AcquiredBadgesCompact @acquiredBadges={{badges}} /></template>);
+
+        // then
+        assert.dom(screen.getByRole('img', { name: 'Badge 1' })).exists();
+        assert.dom(screen.getByRole('img', { name: 'Badge 2' })).exists();
+        assert.dom(screen.queryByRole('img', { name: 'Badge 3' })).doesNotExist();
+        assert.dom(screen.queryByRole('img', { name: 'Badge 4' })).doesNotExist();
+      });
+
+      test('it displays an overflow counter with the remaining count', async function (assert) {
+        // given
+        const badges = [
+          { altMessage: 'Badge 1', imageUrl: '/images/background/hexa-pix.svg', title: 'Badge 1' },
+          { altMessage: 'Badge 2', imageUrl: '/images/background/hexa-pix.svg', title: 'Badge 2' },
+          { altMessage: 'Badge 3', imageUrl: '/images/background/hexa-pix.svg', title: 'Badge 3' },
+          { altMessage: 'Badge 4', imageUrl: '/images/background/hexa-pix.svg', title: 'Badge 4' },
+        ];
+
+        // when
+        const screen = await render(<template><AcquiredBadgesCompact @acquiredBadges={{badges}} /></template>);
+
+        // then
+        assert.dom(screen.getByText('+2')).exists();
+      });
+    });
+  },
+);

--- a/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine/index-test.gjs
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine/index-test.gjs
@@ -1,0 +1,235 @@
+import { render } from '@1024pix/ember-testing-library';
+import { t } from 'ember-intl/test-support';
+import EvaluationResultsHeroRecommendationEngine from 'mon-pix/components/campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine/index';
+import { module, test } from 'qunit';
+
+import { stubCurrentUserService } from '../../../../../../helpers/service-stubs';
+import setupIntlRenderingTest from '../../../../../../helpers/setup-intl-rendering';
+
+module(
+  'Integration | Components | Campaigns | Assessment | ResultsRecommendationEngine | EvaluationResultsHeroRecommendationEngine',
+  function (hooks) {
+    setupIntlRenderingTest(hooks);
+
+    module('global behaviour', function (hooks) {
+      let screen;
+
+      hooks.beforeEach(async function () {
+        // given
+        const campaign = { organizationId: 1 };
+        const campaignParticipationResult = { masteryRate: 0.755 };
+        stubCurrentUserService(this.owner, { id: 1, firstName: 'Hermione' });
+
+        // when
+        screen = await render(
+          <template>
+            <EvaluationResultsHeroRecommendationEngine
+              @campaign={{campaign}}
+              @campaignParticipationResult={{campaignParticipationResult}}
+            />
+          </template>,
+        );
+      });
+
+      test('it displays a congratulation title', async function (assert) {
+        // then
+        assert
+          .dom(screen.getByRole('heading', { name: t('pages.skill-review.hero.thanks', { name: 'Hermione' }) }))
+          .exists();
+      });
+
+      test('it displays a rounded mastery rate', async function (assert) {
+        // then
+        const masteryRateElementWithoutWhiteSpaceTrimmed = screen.getByText('76').textContent.replace(/\s/g, '').trim();
+        assert.strictEqual(masteryRateElementWithoutWhiteSpaceTrimmed, '76%');
+        assert.dom(screen.getByText(t('pages.skill-review.hero.mastery-rate'))).exists();
+      });
+    });
+
+    module('stages', function () {
+      module('when there are multiple stages', function () {
+        test('it displays reached stage stars', async function (assert) {
+          // given
+          const campaign = { organizationId: 1 };
+          const campaignParticipationResult = {
+            hasReachedStage: true,
+            reachedStage: { reachedStage: 4, totalStage: 5 },
+          };
+
+          // when
+          const screen = await render(
+            <template>
+              <EvaluationResultsHeroRecommendationEngine
+                @campaign={{campaign}}
+                @campaignParticipationResult={{campaignParticipationResult}}
+              />
+            </template>,
+          );
+
+          // then
+          const stars = { acquired: 3, total: 4 };
+          assert.dom(screen.getByText(t('pages.skill-review.stage.starsAcquired', stars))).exists();
+          assert.dom(screen.getByText(t('pages.skill-review.stage.recommendedEngine.starsAcquired', stars))).exists();
+        });
+      });
+
+      module('when there is only one stage', function () {
+        test('it does not display stars', async function (assert) {
+          // given
+          const campaign = { organizationId: 1 };
+          const campaignParticipationResult = {
+            hasReachedStage: true,
+            reachedStage: { reachedStage: 1, totalStage: 1 },
+          };
+
+          // when
+          const screen = await render(
+            <template>
+              <EvaluationResultsHeroRecommendationEngine
+                @campaign={{campaign}}
+                @campaignParticipationResult={{campaignParticipationResult}}
+              />
+            </template>,
+          );
+
+          // then
+          const stars = { acquired: 0, total: 0 };
+          assert.dom(screen.queryByText(t('pages.skill-review.stage.starsAcquired', stars))).doesNotExist();
+        });
+      });
+
+      module('when there is no stage', function () {
+        test('it does not display stars', async function (assert) {
+          // given
+          const campaign = { organizationId: 1 };
+          const campaignParticipationResult = { hasReachedStage: false };
+
+          // when
+          const screen = await render(
+            <template>
+              <EvaluationResultsHeroRecommendationEngine
+                @campaign={{campaign}}
+                @campaignParticipationResult={{campaignParticipationResult}}
+              />
+            </template>,
+          );
+
+          // then
+          assert
+            .dom(screen.queryByText(t('pages.skill-review.stage.starsAcquired', { acquired: 0, total: 0 })))
+            .doesNotExist();
+        });
+      });
+    });
+
+    module('acquired badges', function () {
+      module('when there is at least one acquired badge', function () {
+        test('it displays the compact badges list', async function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          const acquiredBadge = store.createRecord('campaign-participation-badge', {
+            isAcquired: true,
+            altMessage: 'Badge alt text',
+            imageUrl: '/images/background/hexa-pix.svg',
+          });
+          const campaignParticipationResult = store.createRecord('campaign-participation-result', {
+            campaignParticipationBadges: [acquiredBadge],
+          });
+          const campaign = { organizationId: 1 };
+
+          // when
+          const screen = await render(
+            <template>
+              <EvaluationResultsHeroRecommendationEngine
+                @campaign={{campaign}}
+                @campaignParticipationResult={{campaignParticipationResult}}
+              />
+            </template>,
+          );
+
+          // then
+          assert.dom(screen.getByRole('img', { name: 'Badge alt text' })).exists();
+        });
+      });
+
+      module('when there is no acquired badge', function () {
+        test('it does not display the badges list', async function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          const notAcquiredBadge = store.createRecord('campaign-participation-badge', { isAcquired: false });
+          const campaignParticipationResult = store.createRecord('campaign-participation-result', {
+            campaignParticipationBadges: [notAcquiredBadge],
+          });
+          const campaign = { organizationId: 1 };
+
+          // when
+          const screen = await render(
+            <template>
+              <EvaluationResultsHeroRecommendationEngine
+                @campaign={{campaign}}
+                @campaignParticipationResult={{campaignParticipationResult}}
+              />
+            </template>,
+          );
+
+          // then
+          assert.dom(screen.queryByRole('list')).doesNotExist();
+        });
+      });
+    });
+
+    module('when campaign is a regular campaign', function () {
+      module('when there are trainings', function () {
+        test('it displays a see-trainings button', async function (assert) {
+          // given
+          stubCurrentUserService(this.owner, { firstName: 'Hermione' });
+          const campaign = { organizationId: 1 };
+          const campaignParticipationResult = { masteryRate: 0.75 };
+
+          // when
+          const screen = await render(
+            <template>
+              <EvaluationResultsHeroRecommendationEngine
+                @campaign={{campaign}}
+                @campaignParticipationResult={{campaignParticipationResult}}
+                @hasTrainings={{true}}
+              />
+            </template>,
+          );
+
+          // then
+          assert.dom(screen.getByRole('button', { name: t('pages.skill-review.hero.see-trainings') })).exists();
+          assert.dom(screen.queryByRole('link', { name: t('navigation.back-to-homepage') })).doesNotExist();
+        });
+      });
+
+      module('when there are no trainings', function () {
+        module('when there is no custom result page button', function () {
+          test('it displays a back-to-homepage link', async function (assert) {
+            // given
+            stubCurrentUserService(this.owner, { firstName: 'Hermione' });
+            const campaign = { organizationId: 1, hasCustomResultPageButton: false };
+            const campaignParticipationResult = { masteryRate: 0.75 };
+
+            // when
+            const screen = await render(
+              <template>
+                <EvaluationResultsHeroRecommendationEngine
+                  @campaign={{campaign}}
+                  @campaignParticipationResult={{campaignParticipationResult}}
+                  @hasTrainings={{false}}
+                />
+              </template>,
+            );
+
+            // then
+            assert.dom(screen.getByRole('link', { name: t('navigation.back-to-homepage') })).exists();
+            assert
+              .dom(screen.queryByRole('button', { name: t('pages.skill-review.hero.see-trainings') }))
+              .doesNotExist();
+          });
+        });
+      });
+    });
+  },
+);

--- a/mon-pix/translations/de.json
+++ b/mon-pix/translations/de.json
@@ -2154,6 +2154,7 @@
         "explanations": {
           "trainings": "Um sich weiterzuentwickeln, entdecken Sie unsere Bildungsempfehlungen und finden Sie heraus, welcher Kurs am besten zu Ihnen passt."
         },
+        "hidden-badges": "{ count, plural, =1 {weiteres erworbenes Badge nicht angezeigt} other {weitere erworbene Badges nicht angezeigt} }",
         "mastery-rate": "Erfolgsquote bei Fragen",
         "retry": {
           "actions": {
@@ -2204,6 +2205,9 @@
       "stage": {
         "caption": "Details zu Ihren Ergebnissen in Form von Prozenten und Sternen auf der Grundlage von Fähigkeiten",
         "masteryPercentage": "{rate, number, ::percent} des Erfolgs",
+        "recommendedEngine": {
+          "starsAcquired": "{acquired} / {total, plural, =0 {Stern} =1 {# Stern} other {# Sterne}}"
+        },
         "starsAcquired": "{acquired, plural, =0 {kein Stern erworben} =1 {# Stern erworben} other {# Sterne erworben}} auf {total}.",
         "title": "Details zu den Fähigkeiten"
       },

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -2154,6 +2154,7 @@
         "explanations": {
           "trainings": "To help you progress, discover our training recommendations and find the ones that suit you best."
         },
+        "hidden-badges": "{ count, plural, =1 {additional badge earned not displayed} other {additional badges earned not displayed} }",
         "mastery-rate": "of success in questions",
         "retry": {
           "actions": {
@@ -2204,6 +2205,9 @@
       "stage": {
         "caption": "Details of your results in percentage and stars according to competences",
         "masteryPercentage": "Success rate: {rate, number, ::percent}",
+        "recommendedEngine": {
+          "starsAcquired": "{acquired} / {total, plural, =0 {star} =1 {# star} other {# stars}}"
+        },
         "starsAcquired": "{acquired, plural, =0 {no star} =1 {# star} other {# stars}} acquired out of {total}",
         "title": "Competence results details"
       },

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -2136,6 +2136,7 @@
         "explanations": {
           "trainings": "Para ayudarle a progresar, eche un vistazo a nuestros cursos de formación recomendados y encuentre los que más le convienen."
         },
+        "hidden-badges": "{ count, plural, =1 {insignia adicional obtenida no mostrada} other {insignias adicionales obtenidas no mostradas} }",
         "mastery-rate": "de éxito en las preguntas",
         "retry": {
           "actions": {
@@ -2186,6 +2187,9 @@
       "stage": {
         "caption": "Detalles de tus resultados en porcentaje y estrellas según las competencias",
         "masteryPercentage": "{rate, number, ::percent} de éxito",
+        "recommendedEngine": {
+          "starsAcquired": "{acquired} / {total, plural, =0 {estrella} =1 {# estrella} other {# estrellas}}"
+        },
         "starsAcquired": "{acquired, plural, =0 {ninguna estrella obtenida} =1 {# estrella obtenida} other {# estrellas obtenidas}} de {total}",
         "title": "Detalles de las competencias"
       },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -2155,6 +2155,7 @@
         "explanations": {
           "trainings": "Pour progresser, découvrez nos recommandations de formations et trouvez celles qui vous conviennent le mieux."
         },
+        "hidden-badges": "{ count, plural, =1 {badge supplémentaire acquis non affiché} other {badges supplémentaires acquis non affichés} }",
         "mastery-rate": "de réussite aux questions",
         "retry": {
           "actions": {
@@ -2205,6 +2206,9 @@
       "stage": {
         "caption": "Détails de vos résultats sous forme de pourcentage et d'étoiles en fonction des compétences",
         "masteryPercentage": "{rate, number, ::percent} de réussite",
+        "recommendedEngine": {
+          "starsAcquired": "{acquired}/{total, plural, =0 {étoile} =1 {# étoile} other {# étoiles}}"
+        },
         "starsAcquired": "{acquired, plural, =0 {aucune étoile acquise} =1 {# étoile acquise} other {# étoiles acquises}} sur {total}",
         "title": "Détails des compétences"
       },

--- a/mon-pix/translations/it.json
+++ b/mon-pix/translations/it.json
@@ -2147,6 +2147,7 @@
         "explanations": {
           "trainings": "Per aiutarvi a progredire, date un'occhiata ai nostri corsi di formazione consigliati e trovate quelli più adatti a voi."
         },
+        "hidden-badges": "{ count, plural, =1 {badge aggiuntivo ottenuto non visualizzato} other {badge aggiuntivi ottenuti non visualizzati} }",
         "mastery-rate": "di successo nelle domande",
         "retry": {
           "actions": {
@@ -2197,6 +2198,9 @@
       "stage": {
         "caption": "I dettagli dei vostri risultati sotto forma di percentuali e stelle in base alle competenze",
         "masteryPercentage": "{rate, number, ::percent} di successo",
+        "recommendedEngine": {
+          "starsAcquired": "{acquired} / {total, plural, =0 {stella} =1 {# stella} other {# stelle}}"
+        },
         "starsAcquired": "{acquired, plural, =0 {nessuna stella acquisita} =1 {# stelle acquisite} other {# stelle acquisite}} su {total}.",
         "title": "Dettagli sulle competenze"
       },

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -2145,6 +2145,7 @@
         "explanations": {
           "trainings": "Om je verder te helpen, kun je onze aanbevolen opleidingen bekijken en de opleidingen vinden die het beste bij je passen."
         },
+        "hidden-badges": "{ count, plural, =1 {extra behaald badge niet weergegeven} other {extra behaalde badges niet weergegeven} }",
         "mastery-rate": "van succes in vragen",
         "retry": {
           "actions": {
@@ -2195,6 +2196,9 @@
       "stage": {
         "caption": "Details van je resultaten in de vorm van percentages en sterren volgens vaardigheden",
         "masteryPercentage": "{rate, number, ::percent} succes",
+        "recommendedEngine": {
+          "starsAcquired": "{acquired} / {total, plural, =0 {ster} =1 {# ster} other {# sterren}}"
+        },
         "starsAcquired": "{acquired, plural, =0 {geen sterren verworven} other {# ster verworven}} op {total}",
         "title": "Vaardigheden"
       },


### PR DESCRIPTION
 # 🌱 Problème                                                                                                                     
                                                                                                                                  
  Les campagnes utilisant le moteur de recommandation affichaient la même page de résultats que les campagnes classiques. Il manquait une page de résultats adaptée à ce nouveau parcours.
Maquette dispo ici : https://www.figma.com/design/2Y1qXAJ9uKluadgbUQaknZ/Moteur-de-Recommandation?node-id=1314-52479&m=dev                                                                   
                                                                                                                                  
# 🐣 Proposition                                                                                                                  
  - Créer une nouvelle page de résultats dédiée aux campagnes avec le moteur de recommandation                                    
  (evaluation-results-recommendation-engine)
  - Afficher cette page conditionnellement via l'attribut `recommendationEngine` du modèle campaign                                 
  - Créer le composant acquired-badges-compact pour afficher les badges obtenus de manière compacte                               
  - Mettre à jour le wording des étoiles dans toutes les langues                                                                  
  - Mettre à jour le seed devcomp pour activer le moteur de recommandation en local
        
 Dans d'autres tickets, on fera
- l'affichage du bloc "commentaire"
- l'affichage des CF recommandés                                       
                                                                                                                                  
# 🐝 Pour tester                                                                                                                  
                                                                                                                                  
  1. Ouvrir [pixApp](https://app-pr15893.review.pix.fr/connexion)                                                     
  2. Se connecter avec perfect-profile-user@example.net (mdp : pix123)                                                                          
  4. Accéder à la campagne EVAL12345 avec le moteur de recommandation activé (seed mis à jour)                                             
  5. Terminer la campagne et constater que la nouvelle page de résultats s'affiche                                                
  6. Vérifier que les campagnes classiques affichent toujours l'ancienne page de résultats