### PR TITLE
[FEATURE] Supprimer le logo République Française sur Pix App (PIX-22339)

### DIFF
--- a/mon-pix/app/components/footer/index.gjs
+++ b/mon-pix/app/components/footer/index.gjs
@@ -15,13 +15,6 @@ export default class Footer extends Component {
   <template>
     <footer id="footer" class="footer" role="contentinfo">
       <div class="footer__logos">
-        {{#if this.currentDomain.isFranceDomain}}
-          <img
-            src="/images/logo/logo-de-la-republique-francaise.svg"
-            class="footer__logos--french-republic-logo"
-            alt="{{t 'common.french-republic'}}"
-          />
-        {{/if}}
         <img src="/images/pix-logo.svg" class="footer__logos--pix-logo" alt={{t "common.pix"}} />
         <div class="copyrights">
           <span>{{t "navigation.copyrights"}} {{this.currentYear}} {{t "navigation.pix"}}</span>

--- a/mon-pix/app/components/global/app-navigation.gjs
+++ b/mon-pix/app/components/global/app-navigation.gjs
@@ -34,13 +34,6 @@ export default class AppNavigation extends Component {
       @closeLabel={{t "navigation.nav-bar.close"}}
     >
       <:brand>
-        {{#if this.currentDomain.isFranceDomain}}
-          <img
-            class="app-navigation__logo-republique-fr"
-            src="/images/logo/logo-de-la-republique-francaise-blanc.svg"
-            alt={{t "common.french-republic"}}
-          />
-        {{/if}}
         <PixLogo @color="white" />
       </:brand>
       <:navElements>

--- a/mon-pix/app/components/inaccessible-campaign.gjs
+++ b/mon-pix/app/components/inaccessible-campaign.gjs
@@ -1,40 +1,22 @@
 import PixBlock from '@1024pix/pix-ui/components/pix-block';
 import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
-import { service } from '@ember/service';
-import Component from '@glimmer/component';
 import t from 'ember-intl/helpers/t';
 
-export default class InaccessibleCampaign extends Component {
-  <template>
-    <PixBlock ...attributes>
-      <div class="campaign-landing-page__start__image__container">
-        <div class="campaign-landing-page__pix-logo">
-          <img class="campaign-landing-page__image" src="/images/pix-logo.svg" alt="{{t 'navigation.pix'}}" />
-        </div>
-        {{#if this.shouldShowTheMarianneLogo}}
-          <div class="campaign-landing-page__marianne-logo">
-            <img
-              class="campaign-landing-page__image"
-              src="/images/logo/logo-de-la-republique-francaise.svg"
-              alt="{{t 'common.french-republic'}}"
-            />
-          </div>
-        {{/if}}
+<template>
+  <PixBlock ...attributes>
+    <div class="campaign-landing-page__start__image__container">
+      <div class="campaign-landing-page__pix-logo">
+        <img class="campaign-landing-page__image" src="/images/pix-logo.svg" alt="{{t 'navigation.pix'}}" />
       </div>
-      <div class="campaign-landing-page-error">
-        <h1 class="campaign-landing-page-error__title">{{yield}}</h1>
-        {{#if (has-block "content")}}
-          {{yield to="content"}}
-        {{/if}}
-        <PixButtonLink @route="authenticated" class="campaign-landing-page__error-button">
-          {{t "navigation.back-to-profile"}}
-        </PixButtonLink>
-      </div>
-    </PixBlock>
-  </template>
-  @service currentDomain;
-
-  get shouldShowTheMarianneLogo() {
-    return this.currentDomain.isFranceDomain;
-  }
-}
+    </div>
+    <div class="campaign-landing-page-error">
+      <h1 class="campaign-landing-page-error__title">{{yield}}</h1>
+      {{#if (has-block "content")}}
+        {{yield to="content"}}
+      {{/if}}
+      <PixButtonLink @route="authenticated" class="campaign-landing-page__error-button">
+        {{t "navigation.back-to-profile"}}
+      </PixButtonLink>
+    </div>
+  </PixBlock>
+</template>

--- a/mon-pix/app/controllers/courses/start-error.js
+++ b/mon-pix/app/controllers/courses/start-error.js
@@ -1,10 +1,3 @@
 import Controller from '@ember/controller';
-import { service } from '@ember/service';
 
-export default class CoursesStartErrorController extends Controller {
-  @service currentDomain;
-
-  get shouldShowTheMarianneLogo() {
-    return this.currentDomain.isFranceDomain;
-  }
-}
+export default class CoursesStartErrorController extends Controller {}

--- a/mon-pix/app/styles/components/_footer.scss
+++ b/mon-pix/app/styles/components/_footer.scss
@@ -24,10 +24,6 @@
   gap: 1em;
   align-items: center;
 
-  &--french-republic-logo {
-    height: 3.375rem;
-  }
-
   &--pix-logo {
     height: 3rem;
   }

--- a/mon-pix/app/styles/components/_navbar-mobile-header.scss
+++ b/mon-pix/app/styles/components/_navbar-mobile-header.scss
@@ -29,14 +29,3 @@
     margin-left: auto;
   }
 }
-
-.navbar-mobile-header-logo {
-
-  &__marianne {
-
-    > img {
-      height: 45px;
-      margin-left: 12px;
-    }
-  }
-}

--- a/mon-pix/app/styles/pages/_campaign-landing-page.scss
+++ b/mon-pix/app/styles/pages/_campaign-landing-page.scss
@@ -39,10 +39,6 @@
   margin: auto;
 }
 
-.campaign-landing-page__pix-logo .campaign-landing-page__marianne-logo {
-  flex-direction: row;
-}
-
 .campaign-landing-page__image {
   height: 42px;
 

--- a/mon-pix/app/styles/pages/_course-error.scss
+++ b/mon-pix/app/styles/pages/_course-error.scss
@@ -20,10 +20,6 @@
   height: 70px;
 }
 
-.course-error-page__pix-logo .course-error-page__marianne-logo {
-  flex-direction: row;
-}
-
 .course-error-page__error-text {
   @extend %pix-body-m;
 

--- a/mon-pix/app/templates/campaigns-error.gjs
+++ b/mon-pix/app/templates/campaigns-error.gjs
@@ -1,5 +1,6 @@
 import t from 'ember-intl/helpers/t';
 import InaccessibleCampaign from 'mon-pix/components/inaccessible-campaign';
+
 <template>
   <InaccessibleCampaign>
     {{t "pages.campaign.errors.not-accessible"}}

--- a/mon-pix/app/templates/courses/start-error.gjs
+++ b/mon-pix/app/templates/courses/start-error.gjs
@@ -8,15 +8,6 @@ import t from 'ember-intl/helpers/t';
         <div class="course-error-page__pix-logo">
           <img class="course-error-page__image" src="/images/pix-logo.svg" alt="{{t 'navigation.pix'}}" />
         </div>
-        {{#if @controller.shouldShowTheMarianneLogo}}
-          <div class="course-error-page__marianne-logo">
-            <img
-              class="course-error-page__image"
-              src="/images/logo/logo-de-la-republique-francaise.svg"
-              alt="{{t 'common.french-republic'}}"
-            />
-          </div>
-        {{/if}}
       </div>
       <div class="course-error-page__error-text">
         <h1 class="course-error-page__error-text title">{{t "pages.course.errors.not-accessible"}}</h1>

--- a/mon-pix/tests/integration/components/footer/footer-test.js
+++ b/mon-pix/tests/integration/components/footer/footer-test.js
@@ -2,7 +2,6 @@ import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 import { t } from 'ember-intl/test-support';
 import { module, test } from 'qunit';
-import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
@@ -26,30 +25,5 @@ module('Integration | Component | Footer', function (hooks) {
 
     assert.dom(screen.getByAltText(t('common.pix'))).exists();
     assert.dom(screen.getByText(`${t('navigation.copyrights')} ${new Date().getFullYear()} Pix`)).exists();
-  });
-
-  module('when url does not have frenchDomainExtension', function () {
-    test('does not display marianne logo', async function (assert) {
-      // when
-      const screen = await render(hbs`<Footer />`);
-
-      // then
-      assert.dom(screen.queryByAltText(t('common.french-republic'))).doesNotExist();
-    });
-  });
-
-  module('when url does have frenchDomainExtension', function (hooks) {
-    hooks.beforeEach(function () {
-      const domainService = this.owner.lookup('service:currentDomain');
-      sinon.stub(domainService, 'getExtension').returns('fr');
-    });
-
-    test('displays marianne logo', async function (assert) {
-      // when
-      const screen = await render(hbs`<Footer />`);
-
-      // then
-      assert.dom(screen.getByAltText(t('common.french-republic'))).exists();
-    });
   });
 });

--- a/mon-pix/tests/integration/components/global/app-navigation-test.gjs
+++ b/mon-pix/tests/integration/components/global/app-navigation-test.gjs
@@ -3,7 +3,6 @@ import Service from '@ember/service';
 import { t } from 'ember-intl/test-support';
 import AppNavigation from 'mon-pix/components/global/app-navigation';
 import { module, test } from 'qunit';
-import sinon from 'sinon';
 
 import { stubCurrentUserService } from '../../../helpers/service-stubs';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
@@ -11,33 +10,17 @@ import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 module('Integration | Component | Global | App Navigation', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  module('logos', function () {
-    module('when it is not the french domain', function () {
-      test('it should only display the Pix logo', async function (assert) {
-        // when
-        const screen = await render(<template><AppNavigation /></template>);
+  module('logo', function () {
+    test('it displays the Pix logo with a link to homepage', async function (assert) {
+      // when
+      const screen = await render(<template><AppNavigation /></template>);
 
-        // then
-        assert.strictEqual(screen.getAllByRole('img').length, 1);
+      // then
+      assert.strictEqual(screen.getAllByRole('img').length, 1);
 
-        const homepageLink = screen.getByRole('link', { name: t('navigation.homepage') });
-        const pixLogo = within(homepageLink).getByRole('img');
-        assert.dom(pixLogo).exists();
-      });
-    });
-
-    module('when it is the french domain', function () {
-      test('it should only display the Pix logo', async function (assert) {
-        // given
-        const domainService = this.owner.lookup('service:currentDomain');
-        sinon.stub(domainService, 'getExtension').returns('fr');
-
-        // when
-        const screen = await render(<template><AppNavigation /></template>);
-
-        // then
-        assert.strictEqual(screen.getAllByRole('img').length, 2);
-      });
+      const homepageLink = screen.getByRole('link', { name: t('navigation.homepage') });
+      const pixLogo = within(homepageLink).getByRole('img');
+      assert.dom(pixLogo).exists();
     });
   });
 

--- a/mon-pix/tests/integration/components/inaccessible-campaign-test.js
+++ b/mon-pix/tests/integration/components/inaccessible-campaign-test.js
@@ -4,30 +4,18 @@
 import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
-import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 
 module('Integration | Component | inaccessible-campaign', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('should not display marianne logo when url does not have frenchDomainExtension', async function (assert) {
+  test('renders component with a title', async function (assert) {
     // when
-    await render(hbs`<InaccessibleCampaign />`);
+    const screen = await render(hbs`{{! template-lint-disable no-bare-strings }}
+<InaccessibleCampaign>Some title</InaccessibleCampaign>`);
 
     // then
-    assert.dom('.campaign-landing-page__marianne-logo').doesNotExist();
-  });
-
-  test('should display marianne logo when url does have frenchDomainExtension', async function (assert) {
-    // given
-    const domainService = this.owner.lookup('service:currentDomain');
-    sinon.stub(domainService, 'getExtension').returns('fr');
-
-    // when
-    await render(hbs`<InaccessibleCampaign />`);
-
-    // then
-    assert.dom('.campaign-landing-page__marianne-logo').exists();
+    assert.dom(screen.getByRole('heading', { name: 'Some title' })).exists();
   });
 });

--- a/mon-pix/translations/de.json
+++ b/mon-pix/translations/de.json
@@ -111,7 +111,6 @@
       "visible-password": "Passwort anzeigen"
     },
     "french-education-ministry": "Ministerium für Bildung und Jugend. Freiheit Gleichheit Brüderlichkeit",
-    "french-republic": "Französische Republik. Freiheit, Gleichheit, Brüderlichkeit.",
     "languages": {
       "en": "Englisch",
       "fr": "Französisch",

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -111,7 +111,6 @@
       "visible-password": "Show password"
     },
     "french-education-ministry": "Ministry of national education and youth",
-    "french-republic": "French Republic. Liberty, equality, fraternity.",
     "languages": {
       "en": "English",
       "fr": "French",

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -111,7 +111,6 @@
       "visible-password": "Mostrar la contraseña"
     },
     "french-education-ministry": "Ministerio francés de Educación y Juventud. Libertad igualdad fraternidad",
-    "french-republic": "República Francesa. Libertad, igualdad, fraternidad.",
     "languages": {
       "en": "Inglés",
       "fr": "Francés",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -111,7 +111,6 @@
       "visible-password": "Afficher le mot de passe"
     },
     "french-education-ministry": "Ministère de l'éducation nationale et de la jeunesse. Liberté égalité fraternité",
-    "french-republic": "République française. Liberté, égalité, fraternité.",
     "languages": {
       "en": "Anglais",
       "fr": "Français",

--- a/mon-pix/translations/it.json
+++ b/mon-pix/translations/it.json
@@ -111,7 +111,6 @@
       "visible-password": "Visualizzazione della password"
     },
     "french-education-ministry": "Ministero dell'Istruzione e della Gioventù. Libertà uguaglianza fraternità",
-    "french-republic": "Repubblica francese. Libertà, uguaglianza, fraternità.",
     "languages": {
       "en": "Inglese",
       "fr": "Francese",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -111,7 +111,6 @@
       "visible-password": "Wachtwoord tonen"
     },
     "french-education-ministry": "Ministerie van Onderwijs en Jeugdzaken. Vrijheid gelijkheid broederschap",
-    "french-republic": "Franse Republiek. Vrijheid, gelijkheid, broederschap.",
     "languages": {
       "en": "Engels",
       "fr": "Frans",


### PR DESCRIPTION
## 🌱 Problème

Il faut réaliser la sortie de la charte graphique de l'État et le logo de la République Française est présente dans certaines templates et composants.

<img width="1440" height="785" alt="Capture_d’écran_2026-04-13_à_16 29 00" src="https://github.com/user-attachments/assets/76599458-6138-4b86-92b7-09467b59ee38" />

<img width="1440" height="785" alt="Capture_d’écran_2026-04-13_à_16 29 24" src="https://github.com/user-attachments/assets/a28896d1-ee2a-4fff-8a31-8b382b6b8396" />

## 🐣 Proposition

Sur PixApp du domaine .fr, il faudrait supprimer le logo en question dans la barre de navigation à gauche et dans le footer (cf captures d'écran).

## 🌷 Remarques

RAS

## 🐝 Pour tester

1. Faire des recherches dans le code pour vérifier qu’il y a plus de trace de logo de la République Française : 
   ```shell
   git grep -i republique|grep french
   git grep -i marianne
   ```
2. Aller sur Pix App `.fr`
3. Se connecter
4. Constater que le logo de la république française n’apparait plus