### PR TITLE
[TECH] Corrige les ralentissements de la CI en utilisant une image dispo sur le Dockerhub prête pour Playwright

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,15 @@ workflows:
           base-revision: dev
           config-path: .circleci/jobs.yml
           mapping: |
+            .circleci/.*                        run-api               true
+            .circleci/.*                        run-mon-pix           true
+            .circleci/.*                        run-orga              true
+            .circleci/.*                        run-certif            true
+            .circleci/.*                        run-admin             true
+            .circleci/.*                        run-junior            true
+            .circleci/.*                        run-audit-logger      true
+            .circleci/.*                        run-e2e-playwright    true
+            .circleci/.*                        run-e2e-cypress       true
             api/.*                              run-api               true
             mon-pix/.*                          run-mon-pix           true
             orga/.*                             run-orga              true

--- a/.circleci/jobs.yml
+++ b/.circleci/jobs.yml
@@ -95,7 +95,7 @@ executors:
       - image: adobe/s3mock:5.0.0
         environment:
           COM_ADOBE_TESTING_S3MOCK_STORE_INITIAL_BUCKETS: pix-import-test
-    resource_class: small
+    resource_class: medium
   node-browsers-docker:
     parameters:
       node-version:
@@ -106,7 +106,7 @@ executors:
       - image: cimg/node:<<parameters.node-version>>-browsers
         environment:
           JOBS: 2
-    resource_class: small
+    resource_class: medium
   node-browsers-redis-postgres-docker:
     parameters:
       node-version:
@@ -137,7 +137,7 @@ executors:
           POSTGRES_USER: circleci
           POSTGRES_HOST_AUTH_METHOD: trust
           POSTGRES_INITDB_ARGS: "--nosync"
-    resource_class: small
+    resource_class: medium
   playwright-executor-medium:
     docker:
       - image: mcr.microsoft.com/playwright:v1.57.0-noble

--- a/.circleci/jobs.yml
+++ b/.circleci/jobs.yml
@@ -118,6 +118,7 @@ executors:
         environment:
           POSTGRES_USER: circleci
           POSTGRES_HOST_AUTH_METHOD: trust
+          POSTGRES_INITDB_ARGS: "--nosync"
       - image: redis:7.2.11-alpine
     resource_class: medium
   node-postgres-docker:
@@ -132,6 +133,7 @@ executors:
         environment:
           POSTGRES_USER: circleci
           POSTGRES_HOST_AUTH_METHOD: trust
+          POSTGRES_INITDB_ARGS: "--nosync"
     resource_class: small
   playwright-executor-medium:
     docker:

--- a/.circleci/jobs.yml
+++ b/.circleci/jobs.yml
@@ -2,7 +2,7 @@
 #
 #
 # Caching notes:
-# - cache is immutable; increment `v7-` prefix to flush it
+# - cache is immutable; increment `v8-` prefix to flush it
 # - we cache `~/.npm` (not node_modules, which is erased by npm ci)
 # - cache key is based on concatenated package.json + package-lock.json checksum
 #
@@ -94,40 +94,6 @@ executors:
         environment:
           - COM_ADOBE_TESTING_S3MOCK_STORE_INITIAL_BUCKETS=pix-import-test
     resource_class: small
-  node-redis-postgres-s3-docker-medium:
-    parameters:
-      node-version:
-        # renovate datasource=node-version depName=node
-        default: 24.14.1
-        type: string
-    docker:
-      - image: cimg/node:<<parameters.node-version>>
-      - image: postgres:16.9-alpine
-        environment:
-          POSTGRES_USER: circleci
-          POSTGRES_HOST_AUTH_METHOD: trust
-      - image: redis:7.2.11-alpine
-      - image: adobe/s3mock:5.0.0
-        environment:
-          - COM_ADOBE_TESTING_S3MOCK_STORE_INITIAL_BUCKETS=pix-import-test
-    resource_class: medium
-  node-redis-postgres-s3-docker-large:
-    parameters:
-      node-version:
-        # renovate datasource=node-version depName=node
-        default: 24.14.1
-        type: string
-    docker:
-      - image: cimg/node:<<parameters.node-version>>
-      - image: postgres:16.9-alpine
-        environment:
-          POSTGRES_USER: circleci
-          POSTGRES_HOST_AUTH_METHOD: trust
-      - image: redis:7.2.11-alpine
-      - image: adobe/s3mock:5.0.0
-        environment:
-          - COM_ADOBE_TESTING_S3MOCK_STORE_INITIAL_BUCKETS=pix-import-test
-    resource_class: large
   node-browsers-docker:
     parameters:
       node-version:
@@ -166,6 +132,37 @@ executors:
           POSTGRES_USER: circleci
           POSTGRES_HOST_AUTH_METHOD: trust
     resource_class: small
+  playwright-executor-medium:
+    docker:
+      - image: mcr.microsoft.com/playwright:v1.57.0-noble
+        environment:
+          PLAYWRIGHT_BROWSERS_PATH: /ms-playwright
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+      - image: postgres:16.9-alpine
+        environment:
+          POSTGRES_USER: circleci
+          POSTGRES_HOST_AUTH_METHOD: trust # POSTGRES_INITDB_ARGS: "--nosync" Speed up DB init et en desspis tmpfs: - /var/lib/postgresql/data # Run DB in RAM
+      - image: redis:7.2.11-alpine
+      - image: adobe/s3mock:5.0.0
+        environment:
+          - COM_ADOBE_TESTING_S3MOCK_STORE_INITIAL_BUCKETS=pix-import-test
+    resource_class: medium
+
+  playwright-executor-large:
+    docker:
+      - image: mcr.microsoft.com/playwright:v1.57.0-noble
+        environment:
+          PLAYWRIGHT_BROWSERS_PATH: /ms-playwright
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+      - image: postgres:16.9-alpine
+        environment:
+          POSTGRES_USER: circleci
+          POSTGRES_HOST_AUTH_METHOD: trust
+      - image: redis:7.2.11-alpine
+      - image: adobe/s3mock:5.0.0
+        environment:
+          - COM_ADOBE_TESTING_S3MOCK_STORE_INITIAL_BUCKETS=pix-import-test
+    resource_class: large
 
 # ---------------------------------------------------------------------------
 # Commands (reusable step sequences)
@@ -180,10 +177,10 @@ commands:
       - run: cat package*.json > cachekey
       - restore_cache:
           keys:
-            - v7-<<parameters.cache_key>>-npm-{{ checksum "cachekey" }}
+            - v8-<<parameters.cache_key>>-npm-{{ checksum "cachekey" }}
       - run: npm ci
       - save_cache:
-          key: v7-<<parameters.cache_key>>-npm-{{ checksum "cachekey" }}
+          key: v8-<<parameters.cache_key>>-npm-{{ checksum "cachekey" }}
           paths:
             - ~/.npm
 
@@ -195,11 +192,11 @@ commands:
       - run: cat package*.json > cachekey
       - restore_cache:
           keys:
-            - v7-<<parameters.cache_key>>-npm-{{ checksum "cachekey" }}
+            - v8-<<parameters.cache_key>>-npm-{{ checksum "cachekey" }}
       - run: npm ci
       - run: npx cypress install
       - save_cache:
-          key: v7-<<parameters.cache_key>>-npm-{{ checksum "cachekey" }}
+          key: v8-<<parameters.cache_key>>-npm-{{ checksum "cachekey" }}
           paths:
             - ~/.npm
 
@@ -986,7 +983,7 @@ jobs:
           command: cat package*.json > cachekey
       - restore_cache:
           keys:
-            - v7-api-npm-{{ checksum "~/pix/api/cachekey" }}
+            - v8-api-npm-{{ checksum "~/pix/api/cachekey" }}
       - run:
           name: Install Pix API
           working_directory: ~/pix/api
@@ -1066,7 +1063,7 @@ jobs:
           command: cat package*.json > cachekey
       - restore_cache:
           keys:
-            - v7-api-npm-{{ checksum "~/pix/api/cachekey" }}
+            - v8-api-npm-{{ checksum "~/pix/api/cachekey" }}
       - run:
           name: Install Pix API
           working_directory: ~/pix/api
@@ -1117,7 +1114,7 @@ jobs:
 
   e2e_playwright_test:
     executor:
-      name: node-redis-postgres-s3-docker-medium
+      name: playwright-executor-medium
     working_directory: ~/pix/high-level-tests/e2e-playwright
     parallelism: 4
     steps:
@@ -1136,10 +1133,7 @@ jobs:
           command: cat package*.json > cachekey
       - restore_cache:
           keys:
-            - v7-api-npm-{{ checksum "~/pix/api/cachekey" }}
-      - run:
-          name: Install Playwright Browser
-          command: npx playwright install --with-deps chromium
+            - v8-api-npm-{{ checksum "~/pix/api/cachekey" }}
       - run:
           name: Install Pix API
           working_directory: ~/pix/api
@@ -1227,7 +1221,7 @@ jobs:
 
   e2e_playwright_test_recette_certif:
     executor:
-      name: node-redis-postgres-s3-docker-large
+      name: playwright-executor-large
     working_directory: ~/pix/high-level-tests/e2e-playwright
     parallelism: 4
     steps:
@@ -1236,17 +1230,14 @@ jobs:
       - run: cat package*.json > cachekey
       - restore_cache:
           keys:
-            - v7-playwright-npm-{{ checksum "cachekey" }}
+            - v8-playwright-npm-{{ checksum "cachekey" }}
       - run: npm ci
       - run:
           working_directory: ~/pix/api
           command: cat package*.json > cachekey
       - restore_cache:
           keys:
-            - v7-api-npm-{{ checksum "~/pix/api/cachekey" }}
-      - run:
-          name: Install Playwright Browser
-          command: npx playwright install --with-deps chromium
+            - v8-api-npm-{{ checksum "~/pix/api/cachekey" }}
       - run:
           name: Install Pix API
           working_directory: ~/pix/api

--- a/.circleci/jobs.yml
+++ b/.circleci/jobs.yml
@@ -89,10 +89,11 @@ executors:
         environment:
           POSTGRES_USER: circleci
           POSTGRES_HOST_AUTH_METHOD: trust
+          POSTGRES_INITDB_ARGS: "--nosync"
       - image: redis:7.2.11-alpine
       - image: adobe/s3mock:5.0.0
         environment:
-          - COM_ADOBE_TESTING_S3MOCK_STORE_INITIAL_BUCKETS=pix-import-test
+          COM_ADOBE_TESTING_S3MOCK_STORE_INITIAL_BUCKETS: pix-import-test
     resource_class: small
   node-browsers-docker:
     parameters:
@@ -141,13 +142,13 @@ executors:
       - image: postgres:16.9-alpine
         environment:
           POSTGRES_USER: circleci
-          POSTGRES_HOST_AUTH_METHOD: trust # POSTGRES_INITDB_ARGS: "--nosync" Speed up DB init et en desspis tmpfs: - /var/lib/postgresql/data # Run DB in RAM
+          POSTGRES_HOST_AUTH_METHOD: trust
+          POSTGRES_INITDB_ARGS: "--nosync"
       - image: redis:7.2.11-alpine
       - image: adobe/s3mock:5.0.0
         environment:
-          - COM_ADOBE_TESTING_S3MOCK_STORE_INITIAL_BUCKETS=pix-import-test
+          COM_ADOBE_TESTING_S3MOCK_STORE_INITIAL_BUCKETS: "pix-import-test"
     resource_class: medium
-
   playwright-executor-large:
     docker:
       - image: mcr.microsoft.com/playwright:v1.57.0-noble
@@ -158,10 +159,11 @@ executors:
         environment:
           POSTGRES_USER: circleci
           POSTGRES_HOST_AUTH_METHOD: trust
+          POSTGRES_INITDB_ARGS: "--nosync"
       - image: redis:7.2.11-alpine
       - image: adobe/s3mock:5.0.0
         environment:
-          - COM_ADOBE_TESTING_S3MOCK_STORE_INITIAL_BUCKETS=pix-import-test
+          COM_ADOBE_TESTING_S3MOCK_STORE_INITIAL_BUCKETS: "pix-import-test"
     resource_class: large
 
 # ---------------------------------------------------------------------------

--- a/.circleci/jobs.yml
+++ b/.circleci/jobs.yml
@@ -86,6 +86,7 @@ executors:
     docker:
       - image: cimg/node:<<parameters.node-version>>
       - image: postgres:16.9-alpine
+        command: [ "postgres", "-c", "fsync=off", "-c", "full_page_writes=off" ]
         environment:
           POSTGRES_USER: circleci
           POSTGRES_HOST_AUTH_METHOD: trust
@@ -115,6 +116,7 @@ executors:
     docker:
       - image: cimg/node:<<parameters.node-version>>-browsers
       - image: postgres:16.9-alpine
+        command: [ "postgres", "-c", "fsync=off", "-c", "full_page_writes=off" ]
         environment:
           POSTGRES_USER: circleci
           POSTGRES_HOST_AUTH_METHOD: trust
@@ -130,6 +132,7 @@ executors:
     docker:
       - image: cimg/node:<<parameters.node-version>>
       - image: postgres:16.9-alpine
+        command: [ "postgres", "-c", "fsync=off", "-c", "full_page_writes=off" ]
         environment:
           POSTGRES_USER: circleci
           POSTGRES_HOST_AUTH_METHOD: trust
@@ -142,6 +145,7 @@ executors:
           PLAYWRIGHT_BROWSERS_PATH: /ms-playwright
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
       - image: postgres:16.9-alpine
+        command: [ "postgres", "-c", "fsync=off", "-c", "full_page_writes=off" ]
         environment:
           POSTGRES_USER: circleci
           POSTGRES_HOST_AUTH_METHOD: trust
@@ -158,6 +162,7 @@ executors:
           PLAYWRIGHT_BROWSERS_PATH: /ms-playwright
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
       - image: postgres:16.9-alpine
+        command: [ "postgres", "-c", "fsync=off", "-c", "full_page_writes=off" ]
         environment:
           POSTGRES_USER: circleci
           POSTGRES_HOST_AUTH_METHOD: trust


### PR DESCRIPTION
## 🌱 Problème

Pour la mise en place de l'environnement Playwright, on partait d'une image nue puis on installait playwright ainsi que le chromium headless. Cela déclenche bcp de téléchargements et d'installations sur l'OS.
Lorsque la vitesse de téléchargement sur les containers de la CI est à la ramasse (parce qu'on se fait limiter ? parce que pas de chance ?), on a des jobs qui durent 30 ou 40 minutes (car on met 25 minutes à télécharger et installer des trucs).

Aussi, depuis les améliorations faites sur le fait de ne pas lancer les jobs pour lesquels aucun des fichiers modifiés par la PR ne concerne un projet, on a nécessairement un peu économisé en crédits CircleCI. Je pense que ça peut être bien de passer certains executors en `medium`, car depuis on a des exécuteurs un peu caisson (s3 + pg + node +/ browser). Je pense que pas mal de flaky en mode `after each hook timeout` sont dûs au container un peu trop faiblard.

## 🐣 Proposition

- Corriger le `config.yml` pour déclencher les jobs sur la CI lorsque les fichiers de config CircleCI sont modifiés
- Utiliser l'image mise à dispo par Microsoft via le DockerHub pour run Playwright (avec navigateurs et tout déjà installés)
- Petites modifications sur la config PG pour aller plus vite (en gros ne pas écrire de fichiers de logs ou WAL pour assurer la consistency de la DB). Ce sont des configurations loin d'être indispensables en environnement hors production, et ça accélère le boot + opérations d'écriture.
- Passage de certains executors sur des tailles medium

## 🌷 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🐝 Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
