### PR TITLE
[TECH] Mettre en place une redirection pour des campagnes France Travail (PIX-22413)

### DIFF
--- a/mon-pix/servers.conf.erb
+++ b/mon-pix/servers.conf.erb
@@ -161,6 +161,10 @@ server {
 
   <% end %>
 
+  # Redirections pour France Travail (PIX-22413)
+  rewrite ^/campagnes/PIXRPEXP1$ <%= ENV['POLE_EMPLOI_AFTER_LOGOUT_URI'] %>campagnes/PIXRPENUM redirect;
+  rewrite ^/campagnes/PIXEMPLOI$ <%= ENV['POLE_EMPLOI_AFTER_LOGOUT_URI'] %>campagnes/PIXRPENUM redirect;
+
   add_header X-Content-Type-Options "nosniff";
   add_header X-Frame-Options "SAMEORIGIN";
   add_header X-XSS-Protection 1;


### PR DESCRIPTION
## 🌱 Problème
France Travail va remplacer la campagne principale PIXEMPLOI par une nouvelle campagne PIXRPENUM. Cependant, ce code campagne a été largement partagé aux demandeurs d'emploi et souhaite pouvoir les rediriger sur la nouvelle campagne. 

## 🐣 Proposition
Mettre en place une redirection pour des campagnes France Travail

## 🐝 Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
