### PR TITLE
[FEATURE] Utiliser le système des réseaux dans la création d'organisations en masse (PIX-22116)

### DIFF
--- a/admin/app/components/administration/deployment/organizations-import.gjs
+++ b/admin/app/components/administration/deployment/organizations-import.gjs
@@ -1,6 +1,7 @@
 import PixButtonUpload from '@1024pix/pix-ui/components/pix-button-upload';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
+import { htmlSafe } from '@ember/template';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 
@@ -35,6 +36,19 @@ export default class OrganizationsImport extends Component {
           case 'MISSING_REQUIRED_FIELD_NAMES':
             this.pixToast.sendErrorNotification({ message: `${error.meta}` });
             break;
+          case 'PARENT_ORGANIZATION_NOT_IN_NETWORK': {
+            const message = [
+              `${this.intl.t('components.administration.organizations-import.notifications.errors.no-organization-created')}`,
+              `${this.intl.t('components.administration.organizations-import.notifications.errors.error-location', { errorLine: error.meta.currentLine, errorField: '"parentOrganizationId"' })}`,
+              this.intl.t(
+                'components.administration.organizations-import.notifications.errors.PARENT_ORGANIZATION_NOT_IN_NETWORK',
+                { parentOrganizationId: error.meta.parentOrganizationId },
+              ),
+            ];
+
+            this.pixToast.sendErrorNotification({ message: htmlSafe(message.join('<br>')) });
+            break;
+          }
           default:
             this.pixToast.sendErrorNotification({ message: error.detail });
         }

--- a/admin/tests/integration/components/administration/deployment/organizations-import-test.gjs
+++ b/admin/tests/integration/components/administration/deployment/organizations-import-test.gjs
@@ -50,31 +50,90 @@ module('Integration | Component |  administration/organizations-import', functio
   });
 
   module('when import fails', function () {
-    test('it displays an error notification', async function (assert) {
-      // given
-      this.server.post(
-        '/admin/organizations/import-csv',
-        () =>
-          new Response(
-            412,
-            {},
-            { errors: [{ status: '412', title: "Un soucis avec l'import", code: '412', detail: 'Erreur d’import' }] },
+    module('when response error contains no errors property', function () {
+      test('it displays a generic error notification', async function (assert) {
+        // given
+        const file = new Blob(['foo'], { type: `valid-file` });
+        class NotificationsStub extends Service {
+          sendErrorNotification = notificationErrorStub;
+        }
+        this.owner.register('service:pixToast', NotificationsStub);
+
+        saveAdapterStub.withArgs([file]).rejects();
+
+        // when
+        const screen = await render(<template><OrganizationsImport /></template>);
+        const input = await screen.findByLabelText(t('components.administration.organizations-import.upload-button'));
+        await triggerEvent(input, 'change', { files: [file] });
+
+        // then
+        assert.ok(notificationErrorStub.calledWithExactly({ message: t('common.notifications.generic-error') }));
+      });
+    });
+
+    module('when error code is "PARENT_ORGANIZATION_NOT_IN_NETWORK"', function () {
+      test('it displays a correct error notification', async function (assert) {
+        // given
+        const file = new Blob(['foo'], { type: `valid-file` });
+        class NotificationsStub extends Service {
+          sendErrorNotification = notificationErrorStub;
+        }
+        this.owner.register('service:pixToast', NotificationsStub);
+
+        saveAdapterStub.withArgs([file]).rejects({
+          errors: [
+            { code: 'PARENT_ORGANIZATION_NOT_IN_NETWORK', meta: { parentOrganizationId: 1234, currentLine: 2 } },
+          ],
+        });
+
+        // when
+        const screen = await render(<template><OrganizationsImport /></template>);
+        const input = await screen.findByLabelText(t('components.administration.organizations-import.upload-button'));
+        await triggerEvent(input, 'change', { files: [file] });
+
+        // then
+        assert.ok(notificationErrorStub.calledOnce);
+        const [{ message }] = notificationErrorStub.firstCall.args;
+        const errorMessage = message.toString();
+
+        assert.true(
+          errorMessage.includes(
+            t('components.administration.organizations-import.notifications.errors.no-organization-created'),
           ),
-        412,
-      );
-      const file = new Blob(['foo'], { type: `valid-file` });
-      class NotificationsStub extends Service {
-        sendErrorNotification = notificationErrorStub;
-      }
-      this.owner.register('service:pixToast', NotificationsStub);
+        );
+        assert.true(errorMessage.includes('parentOrganizationId'));
+        assert.true(errorMessage.includes('1234'));
+        assert.true(errorMessage.includes('2'));
+      });
+    });
 
-      // when
-      const screen = await render(<template><OrganizationsImport /></template>);
-      const input = await screen.findByLabelText(t('components.administration.organizations-import.upload-button'));
-      await triggerEvent(input, 'change', { files: [file] });
+    module('when error code is "MISSING_REQUIRED_FIELD_NAMES"', function () {
+      test('it displays the correct error notification', async function (assert) {
+        // given
+        const file = new Blob(['foo'], { type: `valid-file` });
+        class NotificationsStub extends Service {
+          sendErrorNotification = notificationErrorStub;
+        }
+        this.owner.register('service:pixToast', NotificationsStub);
 
-      // then
-      assert.ok(notificationErrorStub.called);
+        const error = { code: 'MISSING_REQUIRED_FIELD_NAMES', meta: "Erreur lors de l'import." };
+
+        saveAdapterStub.withArgs([file]).rejects({
+          errors: [error],
+        });
+
+        // when
+        const screen = await render(<template><OrganizationsImport /></template>);
+        const input = await screen.findByLabelText(t('components.administration.organizations-import.upload-button'));
+        await triggerEvent(input, 'change', { files: [file] });
+
+        // then
+        assert.ok(notificationErrorStub.calledOnce);
+        const [{ message }] = notificationErrorStub.firstCall.args;
+        const errorMessage = message.toString();
+
+        assert.true(errorMessage.includes(error.meta.toString()));
+      });
     });
   });
 });

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -277,6 +277,11 @@
       "organizations-import": {
         "description": "Existing organizations will not be changed.",
         "notifications": {
+          "errors": {
+            "PARENT_ORGANIZATION_NOT_IN_NETWORK": " Organization {parentOrganizationId} is not part of a network.",
+            "error-location": "Error on line {errorLine}, in the field {errorField}.",
+            "no-organization-created": "No organisation has been created."
+          },
           "success": "{ count, plural, one {One organization has been successfully created.} other {{ count } organizations have been successfully created.}}"
         },
         "title": "Mass creation of organizations",

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -284,6 +284,11 @@
       "organizations-import": {
         "description": "Les organisations déjà existantes ne seront pas modifiées.",
         "notifications": {
+          "errors": {
+            "PARENT_ORGANIZATION_NOT_IN_NETWORK": " L'organisation {parentOrganizationId} ne fait pas partie d'un réseau.",
+            "error-location": "Erreur sur la ligne {errorLine}, dans le champ {errorField}.",
+            "no-organization-created": "Aucune organisation n'a été créée."
+          },
           "success": "{ count, plural, one {Une organisation a bien été créée.} other {{ count } organisations ont bien été créées.}}"
         },
         "title": "Création d'organisations en masse",

--- a/api/src/organizational-entities/domain/usecases/create-organizations-with-tags-and-target-profiles.usecase.js
+++ b/api/src/organizational-entities/domain/usecases/create-organizations-with-tags-and-target-profiles.usecase.js
@@ -14,7 +14,7 @@ import * as codeGenerator from '../../../shared/domain/services/code-generator.j
 import { CONCURRENCY_HEAVY_OPERATIONS } from '../../../shared/infrastructure/constants.js';
 import { logger } from '../../../shared/infrastructure/utils/logger.js';
 import { PromiseUtils } from '../../../shared/infrastructure/utils/promise-utils.js';
-import { UnableToAttachChildOrganizationToParentOrganizationError } from '../errors.js';
+import { ParentOrganizationNotInNetworkError } from '../errors.js';
 import { Organization } from '../models/Organization.js';
 import { OrganizationForAdmin } from '../models/OrganizationForAdmin.js';
 import { OrganizationLearnerType } from '../models/OrganizationLearnerType.js';
@@ -102,7 +102,7 @@ async function _createOrganizations({
   organizationLearnerTypeRepository,
   organizationVerificationService,
 }) {
-  return PromiseUtils.mapSeries(transformedOrganizationsData, async (organizationToCreate) => {
+  return PromiseUtils.mapSeries(transformedOrganizationsData, async (organizationToCreate, index) => {
     const { administrationTeamId, parentOrganizationId, countryCode, organizationLearnerType } =
       organizationToCreate.organization;
 
@@ -112,13 +112,15 @@ async function _createOrganizations({
     );
 
     if (parentOrganizationId) {
-      const organization = await organizationForAdminRepository.get({
+      const parentOrganization = await organizationForAdminRepository.get({
         organizationId: parentOrganizationId,
       });
 
-      // TODO: _assertOrganizationIsNotChildOrganization doit vérifier via fct_structures (parent_structure_id)
-      // et non organizations.parentOrganizationId. Également mettre à jour fct_structures lors de la création.
-      _assertOrganizationIsNotChildOrganization(organization);
+      if (!parentOrganization.network?.id) {
+        throw new ParentOrganizationNotInNetworkError({
+          meta: { parentOrganizationId: parentOrganization.id, currentLine: index + 1 },
+        });
+      }
     }
 
     await organizationVerificationService.checkCountryExists(countryCode, countryRepository);
@@ -154,19 +156,6 @@ async function _createOrganizations({
       throw new DomainError(error.message);
     }
   });
-}
-
-function _assertOrganizationIsNotChildOrganization(organization) {
-  if (organization.parentOrganizationId) {
-    throw new UnableToAttachChildOrganizationToParentOrganizationError({
-      code: 'UNABLE_TO_ATTACH_CHILD_ORGANIZATION_TO_ANOTHER_CHILD_ORGANIZATION',
-      message: 'Unable to attach child organization to parent organization which is also a child organization',
-      meta: {
-        grandParentOrganizationId: organization.parentOrganizationId,
-        parentOrganizationId: organization.id,
-      },
-    });
-  }
 }
 
 function _transformOrganizationsCsvData(organizationsCsvData) {

--- a/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
@@ -44,11 +44,7 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
   });
 
   describe('POST /api/admin/organizations/import-csv', function () {
-    // TODO: ce test doit être mis à jour une fois que le use case createOrganizationsWithTagsAndTargetProfiles
-    // utilisera fct_structures pour créer le lien parent-enfant (via parent_structure_id et network_id)
-    // et non plus organizations.parentOrganizationId
-    // eslint-disable-next-line mocha/no-pending-tests
-    xit('create organizations for the given csv file', async function () {
+    it('create organizations for the given csv file', async function () {
       // given
       const superAdminUserId = databaseBuilder.factory.buildUser.withRole().id;
       databaseBuilder.factory.buildTag({ name: 'GRAS' });
@@ -61,11 +57,14 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
         commonName: 'France',
         originalName: 'France',
       });
-      const organizationId = databaseBuilder.factory.buildOrganization().id;
-      const parentOrganizationId = databaseBuilder.factory.buildOrganization().id;
+      const { organization } = databaseBuilder.factory.buildOrganizationWithStructure();
+
+      const { network, organization: parentOrganization } = databaseBuilder.factory.buildNetworkAndHeadOrganization();
+      const parentOrganizationId = parentOrganization.id;
+
       const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
       databaseBuilder.factory.buildTargetProfileShare({
-        organizationId,
+        organizationId: organization.id,
         targetProfileId,
       });
       const organizationLearnerTypeId = databaseBuilder.factory.buildOrganizationLearnerType().id;
@@ -104,7 +103,6 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
         documentationUrl: 'url.com',
         identityProviderForCampaigns: null,
         isManagingStudents: true,
-        parentOrganizationId: null,
         countryCode: 99100,
         organizationLearnerTypeId,
       });
@@ -119,7 +117,6 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
         createdBy: superAdminUserId,
         identityProviderForCampaigns: null,
         isManagingStudents: false,
-        parentOrganizationId,
         countryCode: 99100,
         organizationLearnerTypeId,
       });
@@ -142,6 +139,38 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
         organizationId: firstOrganizationCreated.id,
       });
       expect(firstOrganizationTags).to.have.lengthOf(2);
+
+      const firstOrganizationNetworkAttachment = await knex
+        .select({
+          organizationId: 'fctChild.organization_id',
+          networkId: 'fctChild.network_id',
+          parentOrganizationId: 'fctParent.organization_id',
+        })
+        .from('fct_structures AS fctChild')
+        .leftJoin('fct_structures AS fctParent', 'fctParent.structure_id', 'fctChild.parent_structure_id')
+        .where({
+          'fctChild.organization_id': firstOrganizationCreated.id,
+        })
+        .first();
+
+      expect(firstOrganizationNetworkAttachment.parentOrganizationId).to.be.null;
+      expect(firstOrganizationNetworkAttachment.networkId).to.be.null;
+
+      const secondOrganizationNetworkAttachment = await knex
+        .select({
+          organizationId: 'fctChild.organization_id',
+          networkId: 'fctChild.network_id',
+          parentOrganizationId: 'fctParent.organization_id',
+        })
+        .from('fct_structures AS fctChild')
+        .leftJoin('fct_structures AS fctParent', 'fctParent.structure_id', 'fctChild.parent_structure_id')
+        .where({
+          'fctChild.organization_id': secondOrganizationCreated.id,
+        })
+        .first();
+
+      expect(secondOrganizationNetworkAttachment.parentOrganizationId).to.equal(parentOrganizationId);
+      expect(secondOrganizationNetworkAttachment.networkId).to.equal(network.id);
     });
   });
 

--- a/api/tests/organizational-entities/integration/domain/usecases/create-organizations-with-tags-and-target-profiles.usecase.test.js
+++ b/api/tests/organizational-entities/integration/domain/usecases/create-organizations-with-tags-and-target-profiles.usecase.test.js
@@ -4,7 +4,7 @@ import {
   AdministrationTeamNotFound,
   CountryNotFoundError,
   OrganizationLearnerTypeNotFound,
-  UnableToAttachChildOrganizationToParentOrganizationError,
+  ParentOrganizationNotInNetworkError,
 } from '../../../../../src/organizational-entities/domain/errors.js';
 import { usecases } from '../../../../../src/organizational-entities/domain/usecases/index.js';
 import { ORGANIZATION_FEATURE } from '../../../../../src/shared/domain/constants.js';
@@ -1105,14 +1105,16 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
   });
 
   describe('when parent organization id is provided', function () {
-    describe('when parent organization exists and is not already a child', function () {
-      // TODO: ce test doit être mis à jour une fois que le use case createOrganizationsWithTagsAndTargetProfiles
-      // utilisera fct_structures pour créer le lien parent-enfant (via parent_structure_id et network_id)
-      // et non plus organizations.parentOrganizationId
-      // eslint-disable-next-line mocha/no-pending-tests
-      xit('should add parent organization id to organization', async function () {
+    describe('when parent organization exists and is part of a network', function () {
+      it('should attach organization to parent and network', async function () {
         // given
-        const parentOrganizationId = databaseBuilder.factory.buildOrganization().id;
+        const {
+          network,
+          organization: parentOrganization,
+          structure: parentStructure,
+        } = databaseBuilder.factory.buildNetworkAndHeadOrganization({
+          name: 'Réseau SCO',
+        });
         await databaseBuilder.commit();
 
         const organizations = [
@@ -1123,7 +1125,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
             locale: 'fr-fr',
             createdBy: userId,
             administrationTeamId,
-            parentOrganizationId,
+            parentOrganizationId: parentOrganization.id,
             countryCode,
             organizationLearnerTypeId,
           },
@@ -1134,8 +1136,15 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
           organizations,
         });
 
+        const createdOrganizationsIds = createdOrganizations.map((createdOrganization) => createdOrganization.id);
+
+        const createdOrganizationsInDB = await knex('organizations')
+          .join('fct_structures', 'organizations.id', 'fct_structures.organization_id')
+          .whereIn('id', createdOrganizationsIds);
+
         // then
-        expect(createdOrganizations[0].parentOrganizationId).to.deep.equal(parentOrganizationId);
+        expect(createdOrganizationsInDB[0].network_id).to.deep.equal(network.id);
+        expect(createdOrganizationsInDB[0].parent_structure_id).to.deep.equal(parentStructure.id);
       });
     });
 
@@ -1166,19 +1175,13 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
       });
     });
 
-    describe('when parent organization is already a child', function () {
-      // TODO: ce test doit être mis à jour une fois que le use case createOrganizationsWithTagsAndTargetProfiles
-      // vérifiera si le parentOrganization est déjà un enfant via fct_structures (parent_structure_id)
-      // et non plus via organizations.parentOrganizationId
-      // eslint-disable-next-line mocha/no-pending-tests
-      xit('should throw', async function () {
+    describe('when parent organization is not part of a network', function () {
+      it('should throw ParentOrganizationNotInNetworkError error', async function () {
         // given
-        const grandParentOrganizationId = databaseBuilder.factory.buildOrganization().id;
-        const parentOrganizationId = databaseBuilder.factory.buildOrganization({
-          parentOrganizationId: grandParentOrganizationId,
-        }).id;
+        const { organization: parentOrganization } = databaseBuilder.factory.buildOrganizationWithStructure();
 
         await databaseBuilder.commit();
+
         const organizations = [
           {
             type: 'SCO',
@@ -1187,7 +1190,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
             locale: 'fr-fr',
             createdBy: userId,
             administrationTeamId,
-            parentOrganizationId,
+            parentOrganizationId: parentOrganization.id,
             countryCode,
             organizationLearnerTypeId,
           },
@@ -1199,7 +1202,8 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
         });
 
         // then
-        expect(error).to.be.instanceOf(UnableToAttachChildOrganizationToParentOrganizationError);
+        expect(error).to.be.instanceOf(ParentOrganizationNotInNetworkError);
+        expect(error.meta).to.deep.equal({ parentOrganizationId: parentOrganization.id, currentLine: 1 });
       });
     });
   });

--- a/api/tests/organizational-entities/integration/domain/usecases/detach-parent-organization-from-organization.usecase.test.js
+++ b/api/tests/organizational-entities/integration/domain/usecases/detach-parent-organization-from-organization.usecase.test.js
@@ -9,9 +9,7 @@ describe('Integration | UseCases | detach-parent-organization-from-organization'
     databaseBuilder.factory.buildFeature(ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT);
     await databaseBuilder.commit();
   });
-  // TODO: ce test doit être mis à jour une fois que le use case detachParentOrganizationFromOrganization
-  // utilisera fct_structures pour détecter le lien parent (via parent_structure_id)
-  // et mettra à jour fct_structures lors du détachement (et non plus organizations.parentOrganizationId)
+  // TODO: ce test doit être mis à jour une fois qu'il sera décidé de l'impact du détachement d'organisation
   // eslint-disable-next-line mocha/no-pending-tests
   xit('should detach parent organization from child organization', async function () {
     // given


### PR DESCRIPTION
## 🌱 Problème
Dans la création en masse d'organisations via import CSV, on utilise toujours l'ancien système de relation parent/enfant. De plus, un seul niveau de parentalité est possible.

## 🐣 Proposition

Côté API:
- supprimer la contrainte qui empêche de créer des orgas sur plusieurs niveaux
- vérifier que l'orga que l'on veut rattacher comme parent fait partie d'un réseau

Côté front-end
- afficher un message d'erreur clair si l'organisation parente ne fait pas partie d'un réseau

## 🌷 Remarques

## 🐝 Pour tester
Dans Pix Admin, connecté en super admin
- aller sur l'onglet Administration -> Déploiement
- préparer un fichier de création d'organisations en masse en spécifiant un parentOrganizationId faisant partie d'un réseau et ayant elle-même un parent (Académie de Lille par exemple)
- importer ce fichier
- constater que les orgas ont bien été créées

Pour les cas d'erreur
- renseigner dans le fichier un id d'orga ne faisant pas partie d'un réseau
- constater le message d'erreur et que les orgas n'ont pas été créées
