### PR TITLE
[BUGFIX] Corriger le calcul de la durée en millisecondes du CpfExportBuilderJobController

### DIFF
--- a/api/src/certification/session-management/application/jobs/cpf-export-builder-job-controller.js
+++ b/api/src/certification/session-management/application/jobs/cpf-export-builder-job-controller.js
@@ -68,5 +68,5 @@ export class CpfExportBuilderJobController extends JobController {
 }
 
 function _getTimeInSec(start) {
-  return Math.floor((new Date().getTime() - start) / 1024);
+  return Math.floor((new Date().getTime() - start) / 1000);
 }


### PR DESCRIPTION
## 🌱 Problème

Il y a une division par `1024` au lieu de `1000` pour obtenir des millisecondes.

## 🐣 Proposition

Réaliser une division par `1000` pour obtenir des millisecondes.

## 🌷 Remarques

RAS

## 🐝 Pour tester

Vérifier que la CI passe et faire un test fonctionnel sur avec un job d’export CPF.