### PR TITLE
[BUGFIX] Corriger la validation des éléments Text

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/validation/element/text-schema.js
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/validation/element/text-schema.js
@@ -9,7 +9,7 @@ const textElementSchema = Joi.object({
     .valid(' ', 'context', 'did-you-know', 'further-information', 'tip')
     .required()
     .description("Tag qui s'affiche au dessus du texte. Champ facultatif (laisser vide si pas de tag souhaité)"),
-  content: htmlSchema,
+  content: htmlSchema.required(),
 }).required();
 
 export { textElementSchema };


### PR DESCRIPTION
## Problème

Il y a une incohérence entre la validation de la propriété content de l'élément Text : 

```
assertNotNullOrUndefined(content, 'The content is required for a text');
```

et le schema Joi pour cette même propriété :

```
  content: htmlSchema,
```

Elle n’est obligatoire que dans le premier cas, ce qui fait qu’elle n’apparaît pas dans Modulix Editor (pour lequel tous les champs doivent être required dans le schema Joi sans quoi ils peuvent ne pas apparaître).

Une des conséquences est que le message d’erreur renvoyé par le script modulix:test n’est pas clair, car l’erreur est déclenchée par le modèle et non par Joi.

<img width="653" height="500" alt="image" src="https://github.com/user-attachments/assets/42e3576d-ef33-4e5e-b82a-820157d60b40" />


## Solution

Rendre les deux propriété cohérentes en ajoutant required() au schema Joi.

## Remarques


> [!CAUTION]
> Le deuxième commit permet de tester l'erreur de validation dans la CI (tout comme le label contribution-modulix), il est à supprimer avant le merge.

## Comment tester

Constater que la CI échoue et que le message d'erreur mentionne le chemin vers l'élément invalide.