### PR TITLE
[FEATURE] Ajouter la route qui récupère les informations du catalogue sur PixOrga (PIX-22207).

### DIFF
--- a/api/config/feature-toggles-config.js
+++ b/api/config/feature-toggles-config.js
@@ -48,6 +48,13 @@ export default {
     defaultValue: false,
     tags: ['modulix', 'team-contenu', 'llm', 'embed', 'pix-app'],
   },
+  displayCatalogue: {
+    type: 'boolean',
+    description: 'Enable course catalogue page for organizations',
+    defaultValue: false,
+    devDefaultValues: { test: true, reviewApp: true },
+    tags: ['frontend', 'team-prescription', 'pix-orga'],
+  },
   isSurveyEnabledForCombinedCourses: {
     type: 'boolean',
     description: 'Enables survey button at the end of the combined courses',

--- a/api/src/prescription/target-profile/infrastructure/repositories/target-profile-repository.js
+++ b/api/src/prescription/target-profile/infrastructure/repositories/target-profile-repository.js
@@ -1,7 +1,6 @@
 import { Badge } from '../../../../evaluation/domain/models/Badge.js';
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
-import { NotFoundError } from '../../../../shared/domain/errors.js';
-import { ObjectValidationError } from '../../../../shared/domain/errors.js';
+import { NotFoundError, ObjectValidationError } from '../../../../shared/domain/errors.js';
 import { TargetProfile } from '../../../../shared/domain/models/TargetProfile.js';
 import * as skillRepository from '../../../../shared/infrastructure/repositories/skill-repository.js';
 
@@ -64,6 +63,25 @@ const hasTubesWithLevels = async function ({ targetProfileId, tubesWithLevels })
   }
 };
 
+const findTubeIdsByTargetProfileIds = async (targetProfileIds) => {
+  const knexConn = DomainTransaction.getConnection();
+  return knexConn('target-profile_tubes')
+    .select('targetProfileId', 'tubeId')
+    .whereIn('targetProfileId', targetProfileIds);
+};
+
+const findSharedByOrganizationId = async (organizationId) =>
+  DomainTransaction.getConnection()('target-profiles')
+    .join('target-profile-shares', 'target-profiles.id', 'target-profile-shares.targetProfileId')
+    .where('target-profile-shares.organizationId', organizationId)
+    .select(
+      'target-profiles.id',
+      'target-profiles.name',
+      'target-profiles.category',
+      'target-profiles.isSimplifiedAccess',
+      'target-profiles.createdAt',
+    );
+
 const findSkillsByIds = async function ({ targetProfileIds, dependencies = { skillRepository } }) {
   const knexConn = DomainTransaction.getConnection();
 
@@ -83,4 +101,12 @@ const findSkillsByIds = async function ({ targetProfileIds, dependencies = { ski
   return skillData;
 };
 
-export { findByIds, findOrganizationIds, findSkillsByIds, get, hasTubesWithLevels };
+export {
+  findByIds,
+  findOrganizationIds,
+  findSharedByOrganizationId,
+  findSkillsByIds,
+  findTubeIdsByTargetProfileIds,
+  get,
+  hasTubesWithLevels,
+};

--- a/api/src/quest/application/combined-course-controller.js
+++ b/api/src/quest/application/combined-course-controller.js
@@ -1,7 +1,10 @@
 import { createReadStream } from 'node:fs';
 
 import { getDataBuffer } from '../../prescription/learner-management/infrastructure/utils/bufferize/get-data-buffer.js';
-import { extractUserIdFromRequest } from '../../shared/infrastructure/utils/request-response-utils.js';
+import {
+  extractUserIdFromRequest,
+  getChallengeLocale,
+} from '../../shared/infrastructure/utils/request-response-utils.js';
 import { usecases } from '../domain/usecases/index.js';
 import * as campaignTypeCombinedCourseSerializer from '../infrastructure/serializers/campaign-type-combined-course-serializer.js';
 import * as combinedCourseDetailsSerializer from '../infrastructure/serializers/combined-course-details-serializer.js';
@@ -10,6 +13,7 @@ import * as combinedCourseParticipationDetailSerializer from '../infrastructure/
 import * as combinedCourseParticipationSerializer from '../infrastructure/serializers/combined-course-participation-serializer.js';
 import * as combinedCourseSerializer from '../infrastructure/serializers/combined-course-serializer.js';
 import * as combinedCourseStatisticsSerializer from '../infrastructure/serializers/combined-course-statistics-serializer.js';
+import * as courseSerializer from '../infrastructure/serializers/course-serializer.js';
 
 const getByCode = async function (request, _, dependencies = { combinedCourseSerializer }) {
   const { code } = request.query.filter;
@@ -124,6 +128,14 @@ const createCombinedCourse = async function (request, h, dependencies = { campai
     .created();
 };
 
+const getCourseByOrganizationId = async (request, _, dependencies = { courseSerializer }) => {
+  const { organizationId } = request.params;
+  const locale = getChallengeLocale(request);
+  const courseItems = await usecases.getCourseByOrganizationId({ organizationId, locale });
+
+  return dependencies.courseSerializer.serialize(courseItems);
+};
+
 const combinedCourseController = {
   getByCode,
   getById,
@@ -135,6 +147,7 @@ const combinedCourseController = {
   reassessStatus,
   createCombinedCourses,
   createCombinedCourse,
+  getCourseByOrganizationId,
 };
 
 export { combinedCourseController };

--- a/api/src/quest/application/combined-course-route.js
+++ b/api/src/quest/application/combined-course-route.js
@@ -11,6 +11,7 @@ import { MAX_FILE_SIZE_UPLOAD } from '../../shared/domain/constants.js';
 import { identifiersType } from '../../shared/domain/types/identifiers-type.js';
 import { jwtOptionalUserAuthenticationStrategyName } from '../../shared/infrastructure/authentication-strategy-names.js';
 import { combinedCourseController } from './combined-course-controller.js';
+import { checkDisplayCatalogueIsEnabled } from './pre-handlers/display-catalogue.js';
 
 const register = async function (server) {
   server.route([
@@ -33,6 +34,26 @@ const register = async function (server) {
         },
         notes: ['- Récupération du parcours combiné dont le code est spécifié dans les filtres de la requête'],
         tags: ['api', 'quest'],
+      },
+    },
+    {
+      method: 'GET',
+      path: '/api/organizations/{organizationId}/courses',
+      config: {
+        pre: [
+          { method: checkDisplayCatalogueIsEnabled },
+          { method: securityPreHandlers.checkUserBelongsToOrganization },
+        ],
+        handler: combinedCourseController.getCourseByOrganizationId,
+        validate: {
+          params: Joi.object({
+            organizationId: identifiersType.organizationId,
+          }),
+        },
+        notes: [
+          "- Récupération du catalogue de parcours liés à l'organisation (blueprints + profils cibles partagés avec l'organisation)",
+        ],
+        tags: ['api', 'quest', 'courses', 'target-profiles', 'catalogue', 'orga'],
       },
     },
     {

--- a/api/src/quest/application/pre-handlers/display-catalogue.js
+++ b/api/src/quest/application/pre-handlers/display-catalogue.js
@@ -1,0 +1,12 @@
+import { HttpErrors } from '../../../shared/application/http-errors.js';
+import { featureToggles } from '../../../shared/infrastructure/feature-toggles/index.js';
+import * as errorSerializer from '../../../shared/infrastructure/serializers/jsonapi/error-serializer.js';
+
+export async function checkDisplayCatalogueIsEnabled(request, h) {
+  const isEnabled = await featureToggles.get('displayCatalogue');
+  if (isEnabled) {
+    return h.response(true);
+  }
+  const error = new HttpErrors.NotFoundError();
+  return h.response(errorSerializer.serialize(error)).code(error.status).takeover();
+}

--- a/api/src/quest/domain/models/CourseItem.js
+++ b/api/src/quest/domain/models/CourseItem.js
@@ -1,0 +1,19 @@
+export const COURSE_ITEM_TYPES = {
+  TARGET_PROFILE: 'targetProfile',
+  BLUEPRINT: 'blueprint',
+};
+
+export class CourseItem {
+  constructor({ id, name, type, nbTubes, nbModules, category, isSimplifiedAccess, areas, competences, createdAt }) {
+    this.id = id;
+    this.createdAt = createdAt ?? null;
+    this.name = name;
+    this.type = type;
+    this.nbTubes = nbTubes ?? null;
+    this.nbModules = nbModules ?? null;
+    this.category = category ?? null;
+    this.isSimplifiedAccess = isSimplifiedAccess ?? null;
+    this.areas = areas ?? [];
+    this.competences = competences ?? [];
+  }
+}

--- a/api/src/quest/domain/usecases/get-course-by-organization-id.js
+++ b/api/src/quest/domain/usecases/get-course-by-organization-id.js
@@ -1,0 +1,2 @@
+export const getCourseByOrganizationId = ({ organizationId, locale, courseRepository }) =>
+  courseRepository.findByOrganizationId({ organizationId, locale });

--- a/api/src/quest/domain/usecases/index.js
+++ b/api/src/quest/domain/usecases/index.js
@@ -40,6 +40,7 @@ const dependencies = {
   organizationLearnerRepository,
   organizationLearnerPrescriptionRepository,
   combinedCourseBlueprintRepository,
+  courseRepository: repositories.courseRepository,
   campaignParticipationRepository: repositories.campaignParticipationRepository,
   codeGenerator,
   logger,
@@ -67,6 +68,7 @@ import getCombinedCourseById from './get-combined-course-by-id.js';
 import { getCombinedCourseParticipationById } from './get-combined-course-participation-by-id.js';
 import { getCombinedCourseStatistics } from './get-combined-course-statistics.js';
 import getCombinedCoursesByOrganizationId from './get-combined-courses-by-organization-id.js';
+import { getCourseByOrganizationId } from './get-course-by-organization-id.js';
 import { getQuestResultsForCampaignParticipation } from './get-quest-results-for-campaign-participation.js';
 import { getVerifiedCode } from './get-verified-code.js';
 import { rewardUser } from './reward-user.js';
@@ -103,6 +105,7 @@ const usecasesWithoutInjectedDependencies = {
   deleteAndAnonymizeParticipationsForALearnerId,
   updateCombinedCourses,
   findOrganizationAttestations,
+  getCourseByOrganizationId,
 };
 
 const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);

--- a/api/src/quest/infrastructure/repositories/combined-course-blueprint-repository.js
+++ b/api/src/quest/infrastructure/repositories/combined-course-blueprint-repository.js
@@ -3,6 +3,7 @@ import difference from 'lodash/difference.js';
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../shared/domain/errors.js';
 import { CombinedCourseBlueprint } from '../../domain/models/CombinedCourseBlueprint.js';
+import { Quest } from '../../domain/models/Quest.js';
 import * as questRepository from './quest-repository.js';
 
 /**
@@ -105,17 +106,38 @@ export async function findById({ id }) {
 
 export async function findByOrganizationId({ organizationId }) {
   const knexConn = DomainTransaction.getConnection();
-  const results = await knexConn('combined_course_blueprints')
-    .select(_buildSelectFields(knexConn))
+  const combinedCoursesWithQuests = await knexConn('combined_course_blueprints')
+    .select({
+      ..._buildSelectFields(knexConn),
+      questRewardId: 'quests.rewardId',
+      questRewardType: 'quests.rewardType',
+      questEligibilityRequirements: 'quests.eligibilityRequirements',
+      questSuccessRequirements: 'quests.successRequirements',
+      questCreatedAt: 'quests.createdAt',
+      questUpdatedAt: 'quests.updatedAt',
+    })
     .join(
       'combined_course_blueprint_shares',
       'combined_course_blueprints.id',
       'combined_course_blueprint_shares.combinedCourseBlueprintId',
     )
+    .join('quests', 'quests.id', 'combined_course_blueprints.questId')
     .where({ organizationId })
-    .groupBy('combined_course_blueprints.id')
+    .groupBy('combined_course_blueprints.id', 'quests.id')
     .orderBy('combined_course_blueprints.id');
-  return results.map((result) => _toDomain(result));
+
+  return combinedCoursesWithQuests.map((result) => {
+    const quest = new Quest({
+      id: result.questId,
+      rewardId: result.questRewardId,
+      rewardType: result.questRewardType,
+      eligibilityRequirements: result.questEligibilityRequirements,
+      successRequirements: result.questSuccessRequirements,
+      createdAt: result.questCreatedAt,
+      updatedAt: result.questUpdatedAt,
+    });
+    return _toDomain(result, quest);
+  });
 }
 
 function _toDomain(rawData, quest) {

--- a/api/src/quest/infrastructure/repositories/course-repository.js
+++ b/api/src/quest/infrastructure/repositories/course-repository.js
@@ -1,0 +1,146 @@
+import * as targetProfileRepository from '../../../prescription/target-profile/infrastructure/repositories/target-profile-repository.js';
+import * as areaRepository from '../../../shared/infrastructure/repositories/area-repository.js';
+import * as competenceRepository from '../../../shared/infrastructure/repositories/competence-repository.js';
+import * as tubeRepository from '../../../shared/infrastructure/repositories/tube-repository.js';
+import { COURSE_ITEM_TYPES, CourseItem } from '../../domain/models/CourseItem.js';
+import * as combinedCourseBlueprintRepository from './combined-course-blueprint-repository.js';
+
+export const findByOrganizationId = async ({ organizationId, locale }) => {
+  const [blueprints, sharedTargetProfiles] = await Promise.all([
+    combinedCourseBlueprintRepository.findByOrganizationId({ organizationId }),
+    targetProfileRepository.findSharedByOrganizationId(organizationId),
+  ]);
+
+  const allTargetProfileIds = [
+    ...new Set([
+      ...blueprints.flatMap((blueprint) => blueprint.targetProfileIds),
+      ...sharedTargetProfiles.map((tp) => tp.id),
+    ]),
+  ];
+
+  const tubeRows =
+    allTargetProfileIds.length > 0
+      ? await targetProfileRepository.findTubeIdsByTargetProfileIds(allTargetProfileIds)
+      : [];
+
+  const tubeIdsByTargetProfileId = groupTubeIdsByTargetProfileId(tubeRows);
+
+  const blueprintRows = blueprints.map((blueprint) => buildBlueprintRow(blueprint, tubeIdsByTargetProfileId));
+  const targetProfileRows = sharedTargetProfiles.map((tp) => buildTargetProfileRow(tp, tubeIdsByTargetProfileId));
+
+  const blueprintRowsById = new Map(blueprintRows.map((row) => [row.id, row]));
+  const targetProfileRowsById = new Map(targetProfileRows.map((row) => [row.id, row]));
+
+  const allRows = new Map([...blueprintRowsById, ...targetProfileRowsById]);
+  const { areasByCompetenceId, competencesByTubeId } = await resolveLearningContent(allRows, locale);
+
+  const toItem = (type) => (row) =>
+    new CourseItem({
+      id: row.id,
+      name: row.name,
+      type,
+      nbTubes: row.nbTubes,
+      nbModules: row.nbModules,
+      category: row.category,
+      isSimplifiedAccess: row.isSimplifiedAccess,
+      areas: resolveAreas(row, competencesByTubeId, areasByCompetenceId),
+      competences: resolveCompetences(row, competencesByTubeId),
+      createdAt: row.createdAt,
+    });
+
+  const blueprintItems = [...blueprintRowsById.values()].map(toItem(COURSE_ITEM_TYPES.BLUEPRINT));
+  const targetProfileItems = [...targetProfileRowsById.values()].map(toItem(COURSE_ITEM_TYPES.TARGET_PROFILE));
+
+  return [...blueprintItems, ...targetProfileItems].sort(compareByNameThenByDate);
+};
+
+const compareByNameThenByDate = (a, b) => {
+  const nameComparison = a.name.localeCompare(b.name);
+  if (nameComparison !== 0) return nameComparison;
+  return new Date(b.createdAt) - new Date(a.createdAt);
+};
+
+const groupTubeIdsByTargetProfileId = (tubeRows) => {
+  const map = new Map();
+  for (const { targetProfileId, tubeId } of tubeRows) {
+    if (!map.has(targetProfileId)) map.set(targetProfileId, []);
+    map.get(targetProfileId).push(tubeId);
+  }
+  return map;
+};
+
+const buildBlueprintRow = (blueprint, tubeIdsByTargetProfileId) => {
+  const uniqueTubeIds = [
+    ...new Set(blueprint.targetProfileIds.flatMap((id) => tubeIdsByTargetProfileId.get(id) ?? [])),
+  ];
+  return {
+    id: blueprint.id,
+    name: blueprint.name,
+    createdAt: blueprint.createdAt,
+    nbTubes: uniqueTubeIds.length,
+    nbModules: blueprint.moduleIds.length,
+    tubeIds: uniqueTubeIds,
+    category: null,
+    isSimplifiedAccess: null,
+  };
+};
+
+const buildTargetProfileRow = (targetProfile, tubeIdsByTargetProfileId) => {
+  const tubeIds = tubeIdsByTargetProfileId.get(targetProfile.id) ?? [];
+  return {
+    id: targetProfile.id,
+    name: targetProfile.name,
+    createdAt: targetProfile.createdAt,
+    nbTubes: tubeIds.length,
+    nbModules: null,
+    tubeIds,
+    category: targetProfile.category,
+    isSimplifiedAccess: targetProfile.isSimplifiedAccess,
+  };
+};
+
+const resolveLearningContent = async (rowsById, locale) => {
+  const allTubeIds = [...new Set([...rowsById.values()].flatMap((row) => row.tubeIds))];
+
+  if (allTubeIds.length === 0) {
+    return { areasByCompetenceId: new Map(), competencesByTubeId: new Map() };
+  }
+
+  const tubes = await tubeRepository.findByRecordIds(allTubeIds, locale);
+
+  const uniqueCompetenceIds = [...new Set(tubes.map((tube) => tube.competenceId))];
+  const competences = await competenceRepository.findByRecordIds({ competenceIds: uniqueCompetenceIds, locale });
+
+  const uniqueAreaIds = [...new Set(competences.map((competence) => competence.areaId))];
+  const areas = await areaRepository.findByRecordIds({ areaIds: uniqueAreaIds, locale });
+
+  const competencesByTubeId = new Map(
+    tubes.map((tube) => [tube.id, competences.find((competence) => competence.id === tube.competenceId)]),
+  );
+
+  const areasByCompetenceId = new Map(
+    competences.map((competence) => [competence.id, areas.find((area) => area.id === competence.areaId)]),
+  );
+
+  return { areasByCompetenceId, competencesByTubeId };
+};
+
+const uniqueById = (items) => {
+  const seen = new Set();
+  return items.filter((item) => {
+    if (seen.has(item.id)) return false;
+    seen.add(item.id);
+    return true;
+  });
+};
+
+const resolveCompetences = (row, competencesByTubeId) => {
+  const uniqueCompetences = uniqueById(row.tubeIds.map((tubeId) => competencesByTubeId.get(tubeId)));
+  return uniqueCompetences.map((competence) => competence.name);
+};
+
+const resolveAreas = (row, competencesByTubeId, areasByCompetenceId) => {
+  const uniqueCompetences = uniqueById(row.tubeIds.map((tubeId) => competencesByTubeId.get(tubeId)));
+  const uniqueAreas = uniqueById(uniqueCompetences.map((competence) => areasByCompetenceId.get(competence.id)));
+  return uniqueAreas.map((area) => area.title);
+};

--- a/api/src/quest/infrastructure/repositories/index.js
+++ b/api/src/quest/infrastructure/repositories/index.js
@@ -21,6 +21,7 @@ import * as combinedCourseDetailsRepository from './combined-course-details-repo
 import * as combinedCourseParticipantRepository from './combined-course-participant-repository.js';
 import * as combinedCourseParticipationRepository from './combined-course-participation-repository.js';
 import * as combinedCourseRepository from './combined-course-repository.js';
+import * as courseRepository from './course-repository.js';
 import * as eligibilityRepository from './eligibility-repository.js';
 import * as moduleRepository from './module-repository.js';
 import * as organizationLearnerParticipationRepository from './organization-learner-participation-repository.js';
@@ -43,6 +44,7 @@ const repositoriesWithoutInjectedDependencies = {
   questRepository,
   campaignRepository,
   combinedCourseRepository,
+  courseRepository,
   combinedCourseDetailsRepository,
   combinedCourseParticipantRepository,
   combinedCourseParticipationRepository,

--- a/api/src/quest/infrastructure/serializers/course-serializer.js
+++ b/api/src/quest/infrastructure/serializers/course-serializer.js
@@ -1,0 +1,11 @@
+import jsonapiSerializer from 'jsonapi-serializer';
+
+const { Serializer } = jsonapiSerializer;
+
+const serialize = function (courseItems) {
+  return new Serializer('courses', {
+    attributes: ['name', 'type', 'nbTubes', 'nbModules', 'category', 'isSimplifiedAccess', 'areas', 'competences'],
+  }).serialize(courseItems);
+};
+
+export { serialize };

--- a/api/tests/prescription/target-profile/integration/infrastructure/repositories/target-profile-repository_test.js
+++ b/api/tests/prescription/target-profile/integration/infrastructure/repositories/target-profile-repository_test.js
@@ -155,6 +155,84 @@ describe('Integration | Repository | Target-profile', function () {
     });
   });
 
+  describe('#findTubeIdsByTargetProfileIds', function () {
+    it('returns tube rows for all given target profile ids', async function () {
+      // given
+      const targetProfileId1 = databaseBuilder.factory.buildTargetProfile().id;
+      databaseBuilder.factory.buildTargetProfileTube({ targetProfileId: targetProfileId1, tubeId: 'tube1' });
+      databaseBuilder.factory.buildTargetProfileTube({ targetProfileId: targetProfileId1, tubeId: 'tube2' });
+
+      const targetProfileId2 = databaseBuilder.factory.buildTargetProfile().id;
+      databaseBuilder.factory.buildTargetProfileTube({ targetProfileId: targetProfileId2, tubeId: 'tube3' });
+
+      await databaseBuilder.commit();
+
+      // when
+      const result = await targetProfileRepository.findTubeIdsByTargetProfileIds([targetProfileId1, targetProfileId2]);
+
+      // then
+      expect(result).to.deep.members([
+        { targetProfileId: targetProfileId1, tubeId: 'tube1' },
+        { targetProfileId: targetProfileId1, tubeId: 'tube2' },
+        { targetProfileId: targetProfileId2, tubeId: 'tube3' },
+      ]);
+    });
+
+    it('does not return tubes from other target profiles', async function () {
+      // given
+      const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+      const otherTargetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+      databaseBuilder.factory.buildTargetProfileTube({ targetProfileId: otherTargetProfileId, tubeId: 'tube1' });
+      await databaseBuilder.commit();
+
+      // when
+      const result = await targetProfileRepository.findTubeIdsByTargetProfileIds([targetProfileId]);
+
+      // then
+      expect(result).to.deep.equal([]);
+    });
+  });
+
+  describe('#findSharedByOrganizationId', function () {
+    it('returns target profiles shared with the organization', async function () {
+      // given
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      const targetProfile = databaseBuilder.factory.buildTargetProfile({
+        name: 'Mon profil',
+        category: 'SUBJECT',
+        isSimplifiedAccess: false,
+      });
+      databaseBuilder.factory.buildTargetProfileShare({ targetProfileId: targetProfile.id, organizationId });
+      await databaseBuilder.commit();
+
+      // when
+      const result = await targetProfileRepository.findSharedByOrganizationId(organizationId);
+
+      // then
+      expect(result).to.have.lengthOf(1);
+      expect(result[0].id).to.equal(targetProfile.id);
+      expect(result[0].name).to.equal('Mon profil');
+      expect(result[0].category).to.equal('SUBJECT');
+      expect(result[0].isSimplifiedAccess).to.equal(false);
+      expect(result[0].createdAt).to.be.instanceOf(Date);
+    });
+
+    it('does not return target profiles not shared with the organization', async function () {
+      // given
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      const otherOrganizationId = databaseBuilder.factory.buildOrganization().id;
+      const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+      databaseBuilder.factory.buildTargetProfileShare({ targetProfileId, organizationId: otherOrganizationId });
+      await databaseBuilder.commit();
+
+      // when
+      const result = await targetProfileRepository.findSharedByOrganizationId(organizationId);
+
+      // then
+      expect(result).to.deep.equal([]);
+    });
+  });
+
   describe('#findSkillsByIds', function () {
     let firstTargetProfilId, secondTargetProfilId, thirdTargetProfilId;
 

--- a/api/tests/quest/acceptance/application/course-route_test.js
+++ b/api/tests/quest/acceptance/application/course-route_test.js
@@ -1,0 +1,111 @@
+import { COURSE_ITEM_TYPES } from '../../../../src/quest/domain/models/CourseItem.js';
+import { featureToggles } from '../../../../src/shared/infrastructure/feature-toggles/index.js';
+import {
+  createServer,
+  databaseBuilder,
+  expect,
+  generateAuthenticatedUserRequestHeaders,
+} from '../../../test-helper.js';
+
+describe('Quest | Acceptance | Application | Course catalogue Route', function () {
+  let server;
+
+  beforeEach(async function () {
+    server = await createServer();
+  });
+
+  describe('GET /api/organizations/{organizationId}/courses', function () {
+    context('when user belongs to the organization', function () {
+      it('returns 200 with target profiles from blueprints and shares', async function () {
+        // given
+        const userId = databaseBuilder.factory.buildUser().id;
+        const organizationId = databaseBuilder.factory.buildOrganization().id;
+        databaseBuilder.factory.buildMembership({ userId, organizationId });
+
+        const targetProfileFromShare = databaseBuilder.factory.buildTargetProfile({ name: 'Profil partagé' });
+        databaseBuilder.factory.buildTargetProfileShare({ targetProfileId: targetProfileFromShare.id, organizationId });
+
+        await databaseBuilder.commit();
+
+        // when
+        const response = await server.inject({
+          method: 'GET',
+          url: `/api/organizations/${organizationId}/courses`,
+          headers: generateAuthenticatedUserRequestHeaders({ userId }),
+        });
+
+        // then
+        expect(response.statusCode).to.equal(200);
+        const data = response.result.data;
+        expect(data).to.have.lengthOf(1);
+        expect(data[0].attributes.type).to.equal(COURSE_ITEM_TYPES.TARGET_PROFILE);
+        expect(Number(data[0].id)).to.equal(targetProfileFromShare.id);
+        expect(data[0].attributes.name).to.equal('Profil partagé');
+      });
+    });
+
+    context('when displayCatalogue feature toggle is disabled', function () {
+      beforeEach(async function () {
+        await featureToggles.set('displayCatalogue', false);
+      });
+
+      afterEach(async function () {
+        await featureToggles.set('displayCatalogue', true);
+      });
+
+      it('returns 404', async function () {
+        // given
+        const userId = databaseBuilder.factory.buildUser().id;
+        const organizationId = databaseBuilder.factory.buildOrganization().id;
+        databaseBuilder.factory.buildMembership({ userId, organizationId });
+        await databaseBuilder.commit();
+
+        // when
+        const response = await server.inject({
+          method: 'GET',
+          url: `/api/organizations/${organizationId}/courses`,
+          headers: generateAuthenticatedUserRequestHeaders({ userId }),
+        });
+
+        // then
+        expect(response.statusCode).to.equal(404);
+      });
+    });
+
+    context('when user does not belong to the organization', function () {
+      it('returns 403', async function () {
+        // given
+        const userId = databaseBuilder.factory.buildUser().id;
+        const organizationId = databaseBuilder.factory.buildOrganization().id;
+        await databaseBuilder.commit();
+
+        // when
+        const response = await server.inject({
+          method: 'GET',
+          url: `/api/organizations/${organizationId}/courses`,
+          headers: generateAuthenticatedUserRequestHeaders({ userId }),
+        });
+
+        // then
+        expect(response.statusCode).to.equal(403);
+      });
+    });
+
+    context('when user is not authenticated', function () {
+      it('returns 401', async function () {
+        // given
+        const organizationId = databaseBuilder.factory.buildOrganization().id;
+        await databaseBuilder.commit();
+
+        // when
+        const response = await server.inject({
+          method: 'GET',
+          url: `/api/organizations/${organizationId}/courses`,
+        });
+
+        // then
+        expect(response.statusCode).to.equal(401);
+      });
+    });
+  });
+});

--- a/api/tests/quest/acceptance/application/course-route_test.js
+++ b/api/tests/quest/acceptance/application/course-route_test.js
@@ -1,11 +1,7 @@
+import { createServer } from '../../../../server.js';
 import { COURSE_ITEM_TYPES } from '../../../../src/quest/domain/models/CourseItem.js';
 import { featureToggles } from '../../../../src/shared/infrastructure/feature-toggles/index.js';
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../test-helper.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../test-helper.js';
 
 describe('Quest | Acceptance | Application | Course catalogue Route', function () {
   let server;

--- a/api/tests/quest/integration/infrastructure/repositories/combined-course-blueprint-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/combined-course-blueprint-repository_test.js
@@ -303,8 +303,8 @@ describe('Quest | Integration | Repository | combined-course-blueprint', functio
 
       //then
       expect(result.length).to.equal(2);
-      expect(result[0]).to.deep.equal({ ...expectedCombinedCourseBlueprint, quest: null });
-      expect(result[1]).to.deep.equal({ ...expectedCombinedCourseBlueprint2, quest: null });
+      expect(result[0]).to.deep.equal(expectedCombinedCourseBlueprint);
+      expect(result[1]).to.deep.equal(expectedCombinedCourseBlueprint2);
     });
 
     it('should return an empty array when the organization is not found', async function () {

--- a/api/tests/quest/integration/infrastructure/repositories/course-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/course-repository_test.js
@@ -1,7 +1,7 @@
 import { CombinedCourseBlueprint } from '../../../../../src/quest/domain/models/CombinedCourseBlueprint.js';
 import { COURSE_ITEM_TYPES, CourseItem } from '../../../../../src/quest/domain/models/CourseItem.js';
 import * as courseRepository from '../../../../../src/quest/infrastructure/repositories/course-repository.js';
-import { databaseBuilder, expect, mockLearningContent } from '../../../../test-helper.js';
+import { databaseBuilder, expect } from '../../../../test-helper.js';
 
 describe('Quest | Integration | Repository | course-repository', function () {
   describe('#findByOrganizationId', function () {
@@ -53,9 +53,8 @@ describe('Quest | Integration | Repository | course-repository', function () {
         organizationId,
         combinedCourseBlueprintId: blueprint.id,
       });
-      await databaseBuilder.commit();
 
-      await mockLearningContent({
+      const learningContent = {
         tubes: [
           { id: 'tube1', competenceId: 'recComp1' },
           { id: 'tube2', competenceId: 'recComp1' },
@@ -66,7 +65,10 @@ describe('Quest | Integration | Repository | course-repository', function () {
           { id: 'recComp2', areaId: 'recArea1', name_i18n: { fr: 'Comp2' }, index: '1.2', origin: 'Pix' },
         ],
         areas: [{ id: 'recArea1', title_i18n: { fr: 'Area1' }, competenceIds: ['recComp1', 'recComp2'] }],
-      });
+      };
+      databaseBuilder.factory.learningContent.build(learningContent);
+
+      await databaseBuilder.commit();
 
       // when
       const result = await courseRepository.findByOrganizationId({ organizationId });
@@ -111,16 +113,18 @@ describe('Quest | Integration | Repository | course-repository', function () {
       databaseBuilder.factory.buildTargetProfileTube({ targetProfileId, tubeId: 'tube1' });
       databaseBuilder.factory.buildTargetProfileTube({ targetProfileId, tubeId: 'tube2' });
       databaseBuilder.factory.buildTargetProfileShare({ targetProfileId, organizationId });
-      await databaseBuilder.commit();
 
-      await mockLearningContent({
+      const learningContent = {
         tubes: [
           { id: 'tube1', competenceId: 'recComp1' },
           { id: 'tube2', competenceId: 'recComp1' },
         ],
         competences: [{ id: 'recComp1', areaId: 'recArea1', name_i18n: { fr: 'Comp1' }, index: '1.1', origin: 'Pix' }],
         areas: [{ id: 'recArea1', title_i18n: { fr: 'Area1' }, competenceIds: ['recComp1'] }],
-      });
+      };
+      databaseBuilder.factory.learningContent.build(learningContent);
+
+      await databaseBuilder.commit();
 
       // when
       const result = await courseRepository.findByOrganizationId({ organizationId });
@@ -142,15 +146,17 @@ describe('Quest | Integration | Repository | course-repository', function () {
       const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
       databaseBuilder.factory.buildTargetProfileTube({ targetProfileId, tubeId: 'recTube1' });
       databaseBuilder.factory.buildTargetProfileShare({ targetProfileId, organizationId });
-      await databaseBuilder.commit();
 
-      await mockLearningContent({
+      const learningContent = {
         areas: [{ id: 'recAreaA', title_i18n: { fr: 'Information et données' }, competenceIds: ['recCompA'] }],
         competences: [
           { id: 'recCompA', name_i18n: { fr: 'Mener une recherche' }, areaId: 'recAreaA', index: '1.1', origin: 'Pix' },
         ],
         tubes: [{ id: 'recTube1', competenceId: 'recCompA' }],
-      });
+      };
+      databaseBuilder.factory.learningContent.build(learningContent);
+
+      await databaseBuilder.commit();
 
       // when
       const result = await courseRepository.findByOrganizationId({ organizationId, locale: 'fr' });
@@ -178,9 +184,8 @@ describe('Quest | Integration | Repository | course-repository', function () {
         organizationId,
         combinedCourseBlueprintId: blueprint.id,
       });
-      await databaseBuilder.commit();
 
-      await mockLearningContent({
+      const learningContent = {
         areas: [
           { id: 'recAreaA', title_i18n: { fr: 'Information et données' }, competenceIds: ['recCompA'] },
           { id: 'recAreaB', title_i18n: { fr: 'Communication et collaboration' }, competenceIds: ['recCompB'] },
@@ -193,7 +198,10 @@ describe('Quest | Integration | Repository | course-repository', function () {
           { id: 'recTube1', competenceId: 'recCompA' },
           { id: 'recTube2', competenceId: 'recCompB' },
         ],
-      });
+      };
+      databaseBuilder.factory.learningContent.build(learningContent);
+
+      await databaseBuilder.commit();
 
       // when
       const result = await courseRepository.findByOrganizationId({ organizationId, locale: 'fr' });

--- a/api/tests/quest/integration/infrastructure/repositories/course-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/course-repository_test.js
@@ -1,0 +1,264 @@
+import { CombinedCourseBlueprint } from '../../../../../src/quest/domain/models/CombinedCourseBlueprint.js';
+import { COURSE_ITEM_TYPES, CourseItem } from '../../../../../src/quest/domain/models/CourseItem.js';
+import * as courseRepository from '../../../../../src/quest/infrastructure/repositories/course-repository.js';
+import { databaseBuilder, expect, mockLearningContent } from '../../../../test-helper.js';
+
+describe('Quest | Integration | Repository | course-repository', function () {
+  describe('#findByOrganizationId', function () {
+    it('returns blueprints shared with the organization', async function () {
+      // given
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+      const questId = databaseBuilder.factory.buildQuest({
+        successRequirements: [CombinedCourseBlueprint.buildRequirementForCombinedCourse({ targetProfileId }).toDTO()],
+      }).id;
+      const blueprint = databaseBuilder.factory.buildCombinedCourseBlueprint({ questId, name: 'BleuImprimer' });
+      databaseBuilder.factory.buildCombinedCourseBlueprintShare({
+        organizationId,
+        combinedCourseBlueprintId: blueprint.id,
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const result = await courseRepository.findByOrganizationId({ organizationId });
+
+      // then
+      expect(result).to.have.lengthOf(1);
+      expect(result[0]).to.be.instanceOf(CourseItem);
+      expect(result[0].id).to.equal(blueprint.id);
+      expect(result[0].name).to.equal('BleuImprimer');
+      expect(result[0].type).to.equal(COURSE_ITEM_TYPES.BLUEPRINT);
+    });
+
+    it('aggregates tubes from all target profiles in the blueprint quest as nbTubes', async function () {
+      // given
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+
+      const targetProfileId1 = databaseBuilder.factory.buildTargetProfile().id;
+      databaseBuilder.factory.buildTargetProfileTube({ targetProfileId: targetProfileId1, tubeId: 'tube1' });
+      databaseBuilder.factory.buildTargetProfileTube({ targetProfileId: targetProfileId1, tubeId: 'tube2' });
+
+      const targetProfileId2 = databaseBuilder.factory.buildTargetProfile().id;
+      databaseBuilder.factory.buildTargetProfileTube({ targetProfileId: targetProfileId2, tubeId: 'tube3' });
+
+      const questId = databaseBuilder.factory.buildQuest({
+        successRequirements: [
+          CombinedCourseBlueprint.buildRequirementForCombinedCourse({ targetProfileId: targetProfileId1 }).toDTO(),
+          CombinedCourseBlueprint.buildRequirementForCombinedCourse({ targetProfileId: targetProfileId2 }).toDTO(),
+        ],
+      }).id;
+
+      const blueprint = databaseBuilder.factory.buildCombinedCourseBlueprint({ questId });
+      databaseBuilder.factory.buildCombinedCourseBlueprintShare({
+        organizationId,
+        combinedCourseBlueprintId: blueprint.id,
+      });
+      await databaseBuilder.commit();
+
+      await mockLearningContent({
+        tubes: [
+          { id: 'tube1', competenceId: 'recComp1' },
+          { id: 'tube2', competenceId: 'recComp1' },
+          { id: 'tube3', competenceId: 'recComp2' },
+        ],
+        competences: [
+          { id: 'recComp1', areaId: 'recArea1', name_i18n: { fr: 'Comp1' }, index: '1.1', origin: 'Pix' },
+          { id: 'recComp2', areaId: 'recArea1', name_i18n: { fr: 'Comp2' }, index: '1.2', origin: 'Pix' },
+        ],
+        areas: [{ id: 'recArea1', title_i18n: { fr: 'Area1' }, competenceIds: ['recComp1', 'recComp2'] }],
+      });
+
+      // when
+      const result = await courseRepository.findByOrganizationId({ organizationId });
+
+      // then
+      expect(result[0].nbTubes).to.equal(3);
+    });
+
+    it('counts passages requirements in the quest as nbModules for blueprints', async function () {
+      // given
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+      const questId = databaseBuilder.factory.buildQuest({
+        successRequirements: [
+          CombinedCourseBlueprint.buildRequirementForCombinedCourse({ targetProfileId }).toDTO(),
+          CombinedCourseBlueprint.buildRequirementForCombinedCourse({ moduleId: 'module-abc' }).toDTO(),
+          CombinedCourseBlueprint.buildRequirementForCombinedCourse({ moduleId: 'module-def' }).toDTO(),
+        ],
+      }).id;
+      const blueprint = databaseBuilder.factory.buildCombinedCourseBlueprint({ questId });
+      databaseBuilder.factory.buildCombinedCourseBlueprintShare({
+        organizationId,
+        combinedCourseBlueprintId: blueprint.id,
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const result = await courseRepository.findByOrganizationId({ organizationId });
+
+      // then
+      expect(result[0].nbModules).to.equal(2);
+    });
+
+    it('returns target profiles shared with the organization via target-profile-shares', async function () {
+      // given
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      const targetProfileId = databaseBuilder.factory.buildTargetProfile({
+        name: 'Profil partagé',
+        category: 'SUBJECT',
+        isSimplifiedAccess: false,
+      }).id;
+      databaseBuilder.factory.buildTargetProfileTube({ targetProfileId, tubeId: 'tube1' });
+      databaseBuilder.factory.buildTargetProfileTube({ targetProfileId, tubeId: 'tube2' });
+      databaseBuilder.factory.buildTargetProfileShare({ targetProfileId, organizationId });
+      await databaseBuilder.commit();
+
+      await mockLearningContent({
+        tubes: [
+          { id: 'tube1', competenceId: 'recComp1' },
+          { id: 'tube2', competenceId: 'recComp1' },
+        ],
+        competences: [{ id: 'recComp1', areaId: 'recArea1', name_i18n: { fr: 'Comp1' }, index: '1.1', origin: 'Pix' }],
+        areas: [{ id: 'recArea1', title_i18n: { fr: 'Area1' }, competenceIds: ['recComp1'] }],
+      });
+
+      // when
+      const result = await courseRepository.findByOrganizationId({ organizationId });
+
+      // then
+      expect(result).to.have.lengthOf(1);
+      expect(result[0]).to.be.instanceOf(CourseItem);
+      expect(result[0].id).to.equal(targetProfileId);
+      expect(result[0].name).to.equal('Profil partagé');
+      expect(result[0].type).to.equal(COURSE_ITEM_TYPES.TARGET_PROFILE);
+      expect(result[0].nbTubes).to.equal(2);
+      expect(result[0].category).to.equal('SUBJECT');
+      expect(result[0].isSimplifiedAccess).to.equal(false);
+    });
+
+    it('resolves areas and competences from learning content for a TARGET_PROFILE item', async function () {
+      // given
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+      databaseBuilder.factory.buildTargetProfileTube({ targetProfileId, tubeId: 'recTube1' });
+      databaseBuilder.factory.buildTargetProfileShare({ targetProfileId, organizationId });
+      await databaseBuilder.commit();
+
+      await mockLearningContent({
+        areas: [{ id: 'recAreaA', title_i18n: { fr: 'Information et données' }, competenceIds: ['recCompA'] }],
+        competences: [
+          { id: 'recCompA', name_i18n: { fr: 'Mener une recherche' }, areaId: 'recAreaA', index: '1.1', origin: 'Pix' },
+        ],
+        tubes: [{ id: 'recTube1', competenceId: 'recCompA' }],
+      });
+
+      // when
+      const result = await courseRepository.findByOrganizationId({ organizationId, locale: 'fr' });
+
+      // then
+      expect(result[0].areas).to.deep.equal(['Information et données']);
+      expect(result[0].competences).to.deep.equal(['Mener une recherche']);
+    });
+
+    it('resolves areas and competences aggregated from all target profiles in the quest for a BLUEPRINT item', async function () {
+      // given
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      const targetProfileId1 = databaseBuilder.factory.buildTargetProfile().id;
+      databaseBuilder.factory.buildTargetProfileTube({ targetProfileId: targetProfileId1, tubeId: 'recTube1' });
+      const targetProfileId2 = databaseBuilder.factory.buildTargetProfile().id;
+      databaseBuilder.factory.buildTargetProfileTube({ targetProfileId: targetProfileId2, tubeId: 'recTube2' });
+      const questId = databaseBuilder.factory.buildQuest({
+        successRequirements: [
+          CombinedCourseBlueprint.buildRequirementForCombinedCourse({ targetProfileId: targetProfileId1 }).toDTO(),
+          CombinedCourseBlueprint.buildRequirementForCombinedCourse({ targetProfileId: targetProfileId2 }).toDTO(),
+        ],
+      }).id;
+      const blueprint = databaseBuilder.factory.buildCombinedCourseBlueprint({ questId });
+      databaseBuilder.factory.buildCombinedCourseBlueprintShare({
+        organizationId,
+        combinedCourseBlueprintId: blueprint.id,
+      });
+      await databaseBuilder.commit();
+
+      await mockLearningContent({
+        areas: [
+          { id: 'recAreaA', title_i18n: { fr: 'Information et données' }, competenceIds: ['recCompA'] },
+          { id: 'recAreaB', title_i18n: { fr: 'Communication et collaboration' }, competenceIds: ['recCompB'] },
+        ],
+        competences: [
+          { id: 'recCompA', name_i18n: { fr: 'Mener une recherche' }, areaId: 'recAreaA', index: '1.1', origin: 'Pix' },
+          { id: 'recCompB', name_i18n: { fr: 'Interagir' }, areaId: 'recAreaB', index: '2.1', origin: 'Pix' },
+        ],
+        tubes: [
+          { id: 'recTube1', competenceId: 'recCompA' },
+          { id: 'recTube2', competenceId: 'recCompB' },
+        ],
+      });
+
+      // when
+      const result = await courseRepository.findByOrganizationId({ organizationId, locale: 'fr' });
+
+      // then
+      expect(result[0].areas).to.deep.equal(['Information et données', 'Communication et collaboration']);
+      expect(result[0].competences).to.deep.equal(['Mener une recherche', 'Interagir']);
+    });
+
+    it('does not return target profiles not shared with the organizations', async function () {
+      // given
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      const otherOrganizationId = databaseBuilder.factory.buildOrganization().id;
+      const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+      databaseBuilder.factory.buildTargetProfileShare({ targetProfileId, organizationId: otherOrganizationId });
+      await databaseBuilder.commit();
+
+      // when
+      const result = await courseRepository.findByOrganizationId({ organizationId });
+
+      // then
+      expect(result).to.have.lengthOf(0);
+    });
+
+    it('does not return blueprints not shared with the organization', async function () {
+      // given
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      databaseBuilder.factory.buildCombinedCourseBlueprint();
+      await databaseBuilder.commit();
+
+      // when
+      const result = await courseRepository.findByOrganizationId({ organizationId });
+
+      // then
+      expect(result).to.have.lengthOf(0);
+    });
+
+    it('returns items sorted by name ascending then createdAt descending', async function () {
+      // given
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      const now = new Date();
+      const earlier = new Date(now.getTime() - 10000);
+
+      const targetProfileZebre = databaseBuilder.factory.buildTargetProfile({ name: 'Zoulou', createdAt: now }).id;
+      const targetProfileAlphaEarlier = databaseBuilder.factory.buildTargetProfile({
+        name: 'Alpha',
+        createdAt: earlier,
+      }).id;
+      const targetProfileAlphaNow = databaseBuilder.factory.buildTargetProfile({ name: 'Alpha', createdAt: now }).id;
+
+      databaseBuilder.factory.buildTargetProfileShare({ targetProfileId: targetProfileZebre, organizationId });
+      databaseBuilder.factory.buildTargetProfileShare({ targetProfileId: targetProfileAlphaEarlier, organizationId });
+      databaseBuilder.factory.buildTargetProfileShare({ targetProfileId: targetProfileAlphaNow, organizationId });
+      await databaseBuilder.commit();
+
+      // when
+      const result = await courseRepository.findByOrganizationId({ organizationId });
+
+      // then
+      expect(result).to.have.lengthOf(3);
+      expect(result[0].name).to.equal('Alpha');
+      expect(result[0].createdAt.getTime()).to.equal(now.getTime());
+      expect(result[1].name).to.equal('Alpha');
+      expect(result[1].createdAt.getTime()).to.equal(earlier.getTime());
+      expect(result[2].name).to.equal('Zoulou');
+    });
+  });
+});

--- a/api/tests/quest/unit/application/pre-handlers/display-catalogue_test.js
+++ b/api/tests/quest/unit/application/pre-handlers/display-catalogue_test.js
@@ -1,0 +1,30 @@
+import { checkDisplayCatalogueIsEnabled } from '../../../../../src/quest/application/pre-handlers/display-catalogue.js';
+import { featureToggles } from '../../../../../src/shared/infrastructure/feature-toggles/index.js';
+import { expect, hFake } from '../../../../test-helper.js';
+
+describe('Quest | Unit | Application | PreHandlers', function () {
+  describe('#checkDisplayCatalogueIsEnabled', function () {
+    context('when feature toggle is enabled', function () {
+      it('should authorize access', async function () {
+        await featureToggles.set('displayCatalogue', true);
+
+        const response = await checkDisplayCatalogueIsEnabled({}, hFake);
+
+        expect(response.source).to.be.true;
+      });
+    });
+
+    context('when feature toggle is disabled', function () {
+      it('should not authorize access and return 404', async function () {
+        await featureToggles.set('displayCatalogue', false);
+
+        const response = await checkDisplayCatalogueIsEnabled({}, hFake);
+
+        expect(response.statusCode).to.equal(404);
+        expect(response.source).to.deep.equal({
+          errors: [{ status: '404', title: 'Not Found' }],
+        });
+      });
+    });
+  });
+});

--- a/api/tests/quest/unit/infrastructure/serializers/course-serializer_test.js
+++ b/api/tests/quest/unit/infrastructure/serializers/course-serializer_test.js
@@ -1,0 +1,79 @@
+import { COURSE_ITEM_TYPES, CourseItem } from '../../../../../src/quest/domain/models/CourseItem.js';
+import * as courseSerializer from '../../../../../src/quest/infrastructure/serializers/course-serializer.js';
+import { expect } from '../../../../test-helper.js';
+
+describe('Quest | Unit | Infrastructure | Serializers | course', function () {
+  describe('#serialize', function () {
+    it('serializes an array of CourseItems', function () {
+      // given
+      const courseItems = [
+        new CourseItem({
+          id: 1,
+          name: 'Blueprint A',
+          type: COURSE_ITEM_TYPES.BLUEPRINT,
+          nbTubes: 7,
+          nbModules: 3,
+          category: null,
+          isSimplifiedAccess: null,
+          areas: ['Information et données'],
+          competences: ['Mener une recherche'],
+        }),
+        new CourseItem({
+          id: 2,
+          name: 'Profil cible B',
+          type: COURSE_ITEM_TYPES.TARGET_PROFILE,
+          nbTubes: 5,
+          category: 'PREDEFINED',
+          isSimplifiedAccess: true,
+          areas: ['Information et données'],
+          competences: ['Mener une recherche'],
+        }),
+      ];
+
+      // when
+      const serialized = courseSerializer.serialize(courseItems);
+
+      // then
+      expect(serialized).to.deep.equal({
+        data: [
+          {
+            id: '1',
+            type: 'courses',
+            attributes: {
+              name: 'Blueprint A',
+              type: COURSE_ITEM_TYPES.BLUEPRINT,
+              'nb-tubes': 7,
+              'nb-modules': 3,
+              category: null,
+              'is-simplified-access': null,
+              areas: ['Information et données'],
+              competences: ['Mener une recherche'],
+            },
+          },
+          {
+            id: '2',
+            type: 'courses',
+            attributes: {
+              name: 'Profil cible B',
+              type: COURSE_ITEM_TYPES.TARGET_PROFILE,
+              'nb-tubes': 5,
+              'nb-modules': null,
+              category: 'PREDEFINED',
+              'is-simplified-access': true,
+              areas: ['Information et données'],
+              competences: ['Mener une recherche'],
+            },
+          },
+        ],
+      });
+    });
+
+    it('serializes an empty array', function () {
+      // when
+      const serialized = courseSerializer.serialize([]);
+
+      // then
+      expect(serialized).to.deep.equal({ data: [] });
+    });
+  });
+});

--- a/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
+++ b/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
@@ -23,6 +23,7 @@ describe('Acceptance | Shared | Application | Controller | feature-toggle', func
           attributes: {
             'dynamic-feature-toggle-system': false,
             'disabled-locales-in-frontend': [],
+            'display-catalogue': true,
             'is-async-quest-rewarding-calculation-enabled': false,
             'is-survey-enabled-for-combined-courses': true,
             'is-quest-enabled': true,


### PR DESCRIPTION
## 🌱 Problème

y'a pas de problème c'est une nouvelle feature

## 🐣 Proposition

Ajouter une route pour récupérer les informations du catalogue afin que le prescripteur puisse voir en détail toutes les possibilités qu'il a pour créer un parcours.

## 🌷 Remarques

il fait beau

## 🐝 Pour tester

```sh
ORG_ID=1005
URL=https://api-pr15907.review.pix.fr/api

TOKEN=$(curl -s ${URL}/token \
  -H 'Accept: */*' \
  -H 'Accept-Language: fr-FR,fr;q=0.9,en-US;q=0.8,en;q=0.7,ru-FR;q=0.6,ru;q=0.5' \
  -H 'Cache-Control: no-cache' \
  -H 'Connection: keep-alive' \
  -H 'Content-Type: application/x-www-form-urlencoded' \
  -H 'Pragma: no-cache' \
  --data-raw 'grant_type=password&username=admin-orga%40example.net&password=pix123' \
  | jq -r '.access_token')

curl -s ${URL}/organizations/${ORG_ID}/courses \
  -H "Authorization: Bearer ${TOKEN}" \
  | jq .
```
