### PR TITLE
[FEATURE] Ajouter les étapes EDU et l'hexagone dans le certificat Pix plus (PIX-22137).

### DIFF
--- a/mon-pix/app/components/certifications/candidate-certificate/v3-pix-plus-certificate.gjs
+++ b/mon-pix/app/components/certifications/candidate-certificate/v3-pix-plus-certificate.gjs
@@ -1,5 +1,6 @@
 import PixBlock from '@1024pix/pix-ui/components/pix-block';
 import PixIcon from '@1024pix/pix-ui/components/pix-icon';
+import PixStepper from '@1024pix/pix-ui/components/pix-stepper';
 import PixTag from '@1024pix/pix-ui/components/pix-tag';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
@@ -9,12 +10,8 @@ import { t } from 'ember-intl';
 export default class PixPlusCertificate extends Component {
   @service intl;
 
-  get certificationFrameworkKey() {
-    if (this.args.certificate.certificationFramework.toLowerCase().includes('edu')) {
-      return 'EDU';
-    } else {
-      return this.args.certificate.certificationFramework.toUpperCase();
-    }
+  get isEduCertification() {
+    return this.args.certificate.certificationFramework.includes('EDU');
   }
 
   get certificationFrameworkLabel() {
@@ -26,11 +23,9 @@ export default class PixPlusCertificate extends Component {
   }
 
   get frameworkTranslations() {
-    const certificationFramework = this.args.certificate.certificationFramework;
-
-    const prefix = certificationFramework.includes('EDU')
+    const prefix = this.isEduCertification
       ? 'pages.certificate.frameworks.EDU'
-      : `pages.user-certifications.frameworks.${certificationFramework}`;
+      : `pages.user-certifications.frameworks.${this.args.certificate.certificationFramework}`;
 
     return {
       status: this.intl.t(`${prefix}.status`),
@@ -38,6 +33,14 @@ export default class PixPlusCertificate extends Component {
       resultsInfos: this.intl.t(`${prefix}.results-infos`, { htmlSafe: true }),
       resultsSubTitle: this.intl.t(`${prefix}.results-sub-title`, { htmlSafe: true }),
     };
+  }
+
+  get steps() {
+    return [
+      { title: this.intl.t('pages.certificate.frameworks.EDU.steps.1') },
+      { title: this.intl.t('pages.certificate.frameworks.EDU.steps.2', { htmlSafe: true }) },
+      { title: this.intl.t('pages.certificate.frameworks.EDU.steps.3') },
+    ];
   }
 
   <template>
@@ -52,6 +55,10 @@ export default class PixPlusCertificate extends Component {
           <strong>{{this.frameworkTranslations.status}}</strong>
           {{this.frameworkTranslations.subTitle}}
         </h2>
+
+        {{#if this.isEduCertification}}
+          <PixStepper class="v3-pix-plus-certificate__stepper" @steps={{this.steps}} @currentStep={{2}} />
+        {{/if}}
 
         <div class="v3-pix-plus-certificate__details">
           <p>
@@ -78,7 +85,10 @@ export default class PixPlusCertificate extends Component {
           </dl>
         </div>
       </div>
-      <div>
+      <div class="v3-pix-plus-certificate__score">
+        <div class="v3-pix-plus-certificate-score__hexagon">
+          <strong class="dash">-</strong>
+        </div>
         <PixTag @color="green">{{this.reachedMeshLabel}}</PixTag>
       </div>
     </PixBlock>

--- a/mon-pix/app/styles/components/user-certifications/v3-pix-plus-certificate.scss
+++ b/mon-pix/app/styles/components/user-certifications/v3-pix-plus-certificate.scss
@@ -42,10 +42,15 @@
   }
 }
 
+.v3-pix-plus-certificate__stepper {
+  max-width: 30rem;
+  margin-top: var(--pix-spacing-8x);
+}
+
 .v3-pix-plus-certificate__details {
   @extend %pix-body-s;
 
-  margin-top: var(--pix-spacing-6x);
+  margin-top: var(--pix-spacing-8x);
 
   dl {
     margin-top: var(--pix-spacing-6x);
@@ -59,6 +64,32 @@
   dd::after {
     display: block;
     content: '';
+  }
+}
+
+.v3-pix-plus-certificate__score {
+  text-align: center;
+}
+
+.v3-pix-plus-certificate-score__hexagon {
+  position: relative;
+  width: 11rem;
+  height: 12rem;
+  margin-bottom: var(--pix-spacing-1x);
+  background-image: url('/images/certificate/pix-plus-hexagon-validated.svg');
+  background-repeat: no-repeat;
+  background-position: center center;
+  background-size: contain;
+
+  .dash {
+    @extend %pix-title-l;
+
+    position: absolute;
+    top: 50%;
+    left: 0;
+    width: 100%;
+    color: var(--pix-certif-500);
+    transform: translateY(-50%);
   }
 }
 

--- a/mon-pix/tests/integration/components/certifications/candidate-certificate/v3-pix-plus-certificate-test.gjs
+++ b/mon-pix/tests/integration/components/certifications/candidate-certificate/v3-pix-plus-certificate-test.gjs
@@ -8,32 +8,85 @@ import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 module('Integration | Component | Certifications | Candidate certificate | v3-pix-plus-certificate', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('it displays candidate information for an EDU framework', async function (assert) {
-    // given
-    const store = this.owner.lookup('service:store');
-    const certification = store.createRecord('certification', {
-      birthdate: '2000-01-22',
-      birthplace: 'Paris',
-      firstName: 'Jean',
-      lastName: 'Doe',
-      certificationDate: new Date('2026-02-15T10:00:00Z'),
-      deliveredAt: new Date('2026-02-20T10:00:00Z'),
-      certificationCenter: 'Université de Lyon',
-      certificationFramework: 'EDU_1ER_DEGRE',
+  module('for all pix-plus v3', function () {
+    test('it displays results information', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const certification = store.createRecord('certification', {
+        birthdate: '2000-01-22',
+        birthplace: 'Paris',
+        firstName: 'Jean',
+        lastName: 'Doe',
+        certificationDate: new Date('2026-02-15T10:00:00Z'),
+        deliveredAt: new Date('2026-02-20T10:00:00Z'),
+        certificationCenter: 'Université de Lyon',
+        certificationFramework: 'EDU_1ER_DEGRE',
+      });
+      this.set('certification', certification);
+
+      // when
+      const screen = await render(hbs`
+          <Certifications::CandidateCertificate::v3PixPlusCertificate @certificate={{this.certification}} />`);
+
+      // then
+      assert.dom(screen.getAllByText(t('pages.certificate.frameworks.EDU.status'))[0]).exists();
+      assert.dom(screen.getByText(`${t('pages.certificate.candidate')} Jean Doe`)).exists();
+      assert.dom(screen.getByText('Université de Lyon')).exists();
+      assert.dom(screen.getByText('15/02/2026')).exists();
+      assert.dom(screen.getByText('20/02/2026')).exists();
+      assert.dom(screen.getByText(t('pages.user-certifications.meshes.EDU_1ER_DEGRE.0'))).exists();
+      assert.dom(screen.getByRole('heading', { level: 3, name: t('pages.certificate.results.title') })).exists();
+      assert.dom('.v3-pix-plus-certificate-score__hexagon').exists();
     });
-    this.set('certification', certification);
+  });
 
-    // when
-    const screen = await render(hbs`
-        <Certifications::CandidateCertificate::v3PixPlusCertificate @certificate={{this.certification}} />`);
+  module('for an EDU framework', function () {
+    test('it displays the stepper', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const certification = store.createRecord('certification', {
+        birthdate: '2000-01-22',
+        birthplace: 'Paris',
+        firstName: 'Jean',
+        lastName: 'Doe',
+        certificationDate: new Date('2026-02-15T10:00:00Z'),
+        deliveredAt: new Date('2026-02-20T10:00:00Z'),
+        certificationCenter: 'Université de Lyon',
+        certificationFramework: 'EDU_1ER_DEGRE',
+      });
+      this.set('certification', certification);
 
-    // then
-    assert.dom(screen.getAllByText(t('pages.certificate.frameworks.EDU.status'))[0]).exists();
-    assert.dom(screen.getByText(`${t('pages.certificate.candidate')} Jean Doe`)).exists();
-    assert.dom(screen.getByText('Université de Lyon')).exists();
-    assert.dom(screen.getByText('15/02/2026')).exists();
-    assert.dom(screen.getByText('20/02/2026')).exists();
-    assert.dom(screen.getByText(t('pages.user-certifications.meshes.EDU_1ER_DEGRE.0'))).exists();
-    assert.dom(screen.getByRole('heading', { level: 3, name: t('pages.certificate.results.title') })).exists();
+      // when
+      const screen = await render(hbs`
+          <Certifications::CandidateCertificate::v3PixPlusCertificate @certificate={{this.certification}} />`);
+
+      // then
+      assert.dom(screen.getByText(t('pages.certificate.frameworks.EDU.steps.1'))).exists();
+    });
+  });
+
+  module('for a non-EDU framework', function () {
+    test('it does not display the stepper ', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const certification = store.createRecord('certification', {
+        birthdate: '2000-01-22',
+        birthplace: 'Paris',
+        firstName: 'Jean',
+        lastName: 'Doe',
+        certificationDate: new Date('2026-02-15T10:00:00Z'),
+        deliveredAt: new Date('2026-02-20T10:00:00Z'),
+        certificationCenter: 'Université de Lyon',
+        certificationFramework: 'PRO_SANTE',
+      });
+      this.set('certification', certification);
+
+      // when
+      const screen = await render(hbs`
+          <Certifications::CandidateCertificate::v3PixPlusCertificate @certificate={{this.certification}} />`);
+
+      // then
+      assert.dom(screen.queryByText(t('pages.certificate.frameworks.EDU.steps.1'))).doesNotExist();
+    });
   });
 });

--- a/mon-pix/translations/de.json
+++ b/mon-pix/translations/de.json
@@ -691,6 +691,11 @@
         "EDU": {
           "results-infos": "'<p>'Die Zertifizierung erfolgt in zwei Stufen:'</p><ol><li>'Pix-Prüfung: gerade abgeschlossen.'</li><li>'Mündliche Prüfung: außerhalb von Pix vor einer Jury organisiert.'</li></ol><p>'Am Ende der mündlichen Prüfung wird Ihr endgültiges Zertifizierungsniveau vergeben (Experte, Fortgeschritten usw.).'<br/>'Wenden Sie sich an Ihr Zertifizierungszentrum, um die mündliche Prüfung zu organisieren.'</p>'",
           "status": "Gültiges Zertifikat",
+          "steps": {
+            "1": "Pix-Teil",
+            "2": "Berufspraktischer'<br/>'Teil",
+            "3": "Endergebnis"
+          },
           "sub-title": "Der Kandidat ist für die 2. Stufe zugelassen!"
         }
       },

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -692,6 +692,11 @@
         "EDU": {
           "results-infos": "'<p>'The certification takes place in two stages:'</p><ol><li>'Pix assessment: just completed.'</li><li>'Oral assessment: organised outside of Pix before a panel.'</li></ol><p>'At the end of the oral, your final certification level will be awarded (Expert, Advanced, etc.).'<br/>'Contact your certification centre to organise the oral assessment.'</p>'",
           "status": "Valid certificate",
+          "steps": {
+            "1": "Pix component",
+            "2": "Professional'<br/>'practice component",
+            "3": "Final result"
+          },
           "sub-title": "The candidate is eligible for the 2nd stage!"
         }
       },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -693,6 +693,11 @@
           "results-infos": "'<p>'La certification se déroule en deux étapes&nbsp;:'</p><ol><li>'Volet Pix&nbsp;: il/elle vient de le passer.'</li><li>'Volet de pratique professionnelle&nbsp;: organisé en dehors de Pix devant un jury.'</li></ol><p>'À l'issue de ce 2'<sup>'ème'</sup>' volet, le niveau de la certification Pix+ Edu  du/de la candidat(e) sera attribué (Avancé ou Expert).'</p>'",
           "results-sub-title": "Le/la candidat(e) est admissible au volet 2 de pratique professionnelle de la certification Pix+ Édu !",
           "status": "Certificat valide",
+          "steps": {
+            "1": "Volet Pix",
+            "2": "Volet pratique'<br/>'professionnelle",
+            "3": "Résultat final"
+          },
           "sub-title": "Le/la candidat(e) est admissible au volet 2 de pratique professionnelle !"
         }
       },

--- a/mon-pix/translations/it.json
+++ b/mon-pix/translations/it.json
@@ -692,6 +692,11 @@
         "EDU": {
           "results-infos": "'<p>'La certificazione si svolge in due fasi:'</p><ol><li>'Prova Pix: appena completata.'</li><li>'Prova orale: organizzata al di fuori di Pix davanti a una giuria.'</li></ol><p>'Al termine dell'orale, verrà assegnato il livello di certificazione definitivo (Esperto, Avanzato, ecc.).'<br/>'Contattate il vostro centro di certificazione per organizzare la prova orale.'</p>'",
           "status": "Certificato valido",
+          "steps": {
+            "1": "Sezione Pix",
+            "2": "Sezione pratica'<br/>'professionale",
+            "3": "Risultato finale"
+          },
           "sub-title": "Il candidato è ammesso alla 2ª fase!"
         }
       },

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -693,6 +693,11 @@
         "EDU": {
           "results-infos": "'<p>'De certificering verloopt in twee fasen:'</p><ol><li>'Pix-toets: zojuist afgelegd.'</li><li>'Mondeling examen: buiten Pix georganiseerd voor een jury.'</li></ol><p>'Na afloop van het mondeling wordt uw definitieve certificeringsniveau toegekend (Expert, Gevorderd, enz.).'<br/>'Neem contact op met uw certificeringscentrum om het mondeling examen te organiseren.'</p>'",
           "status": "Geldig certificaat",
+          "steps": {
+            "1": "Pix-onderdeel",
+            "2": "Beroepspraktijk'<br/>'onderdeel",
+            "3": "Eindresultaat"
+          },
           "sub-title": "De kandidaat is toegelaten tot de 2e fase!"
         }
       },


### PR DESCRIPTION
## 🌱 Problème

Le MVP Pix+ Edu étant livré, nous pouvons désormais finaliser la page du vérificateur du volet 1 Pix+ Edu notamment pour en améliorer le design.

## 🐣 Proposition

- Rajout du stepper pour rendre plus visuel l'étape à laquelle se trouve le candidat.
- Rajout de l’hexagone vert à droite.

## 🐝 Pour tester

Vérifier la certification Pix+ Edu d'un des candidats des seeds [ici](https://app-pr15908.review.pix.fr/verification-certificat).
(Ex : `P-14256133`)
