### PR TITLE
[TECH] Supprimer ember-dayjs (PIX-22432)

### DIFF
--- a/orga/app/components/banner/certification.gjs
+++ b/orga/app/components/banner/certification.gjs
@@ -7,16 +7,16 @@ import ENV from 'pix-orga/config/environment';
 export default class InformationBanner extends Component {
   @service currentUser;
   @service router;
-  @service dayjs;
+  @service intl;
 
   get displayCertificationBanner() {
     const timeToDisplay = ENV.APP.CERTIFICATION_BANNER_DISPLAY_DATES.split(' ');
-    const actualMonth = this.dayjs.self().format('MM');
+    const actualMonth = this.intl.formatDate(new Date(), { month: '2-digit' });
     return this.currentUser.isSCOManagingStudents && timeToDisplay.includes(actualMonth);
   }
 
   get year() {
-    return this.dayjs.self().format('YYYY');
+    return this.intl.formatDate(new Date(), { year: 'numeric' });
   }
 
   <template>

--- a/orga/app/components/campaign/charts/participants-by-day.gjs
+++ b/orga/app/components/campaign/charts/participants-by-day.gjs
@@ -1,6 +1,7 @@
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
+import dayjs from 'dayjs';
 import { formatDate, t } from 'ember-intl';
 import { maxBy, minBy } from 'pix-orga/utils/collection';
 
@@ -13,7 +14,6 @@ import ParticipantsByDayLoader from './participants-by-day-loader';
 export default class ParticipantsByDay extends Component {
   @service store;
   @service intl;
-  @service dayjs;
   @service locale;
 
   @tracked days = 0;
@@ -30,9 +30,10 @@ export default class ParticipantsByDay extends Component {
         response.data.attributes;
 
       if (startedParticipations.length > 0) {
-        this.days = this.dayjs
-          .self(startedParticipations[startedParticipations.length - 1].day)
-          .diff(this.dayjs.self(startedParticipations[0].day), 'days');
+        this.days = dayjs(startedParticipations[startedParticipations.length - 1].day).diff(
+          dayjs(startedParticipations[0].day),
+          'days',
+        );
       }
 
       const { startedDatasets, sharedDatasets } = this._normalizeDatasets(startedParticipations, sharedParticipations);

--- a/orga/app/components/import-information-banner.gjs
+++ b/orga/app/components/import-information-banner.gjs
@@ -6,13 +6,12 @@ import dayjs from 'dayjs';
 
 export default class ImportBanner extends Component {
   @service intl;
-  @service dayjs;
 
   get displayBanner() {
     if (!this.args.importDetail) {
       return false;
     }
-    return this.dayjs.self().diff(this.args.importDetail.updatedAt, 'day') < 15;
+    return dayjs().diff(this.args.importDetail.updatedAt, 'day') < 15;
   }
 
   get bannerType() {

--- a/orga/app/components/tube/list.gjs
+++ b/orga/app/components/tube/list.gjs
@@ -16,7 +16,6 @@ import Tube from './tube';
 
 export default class TubeList extends Component {
   @tracked selectedTubeIds = [];
-  @service dayjs;
   @service pixMetrics;
 
   @action
@@ -96,7 +95,7 @@ export default class TubeList extends Component {
   }
 
   get formattedCurrentDate() {
-    return this.dayjs.self().format('YYYY-MM-DD-HHmm');
+    return new Date().toISOString().replace('T', '-').replaceAll(':', '').substring(0, 15);
   }
 
   get downloadURL() {

--- a/orga/app/services/locale.js
+++ b/orga/app/services/locale.js
@@ -5,6 +5,7 @@
 import { getOwner } from '@ember/application';
 import Service, { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
+import dayjs from 'dayjs';
 import LanguageDetector from 'i18next-browser-languagedetector';
 import ENV from 'pix-orga/config/environment';
 
@@ -96,18 +97,14 @@ export default class LocaleService extends Service {
 
     this.intl.setLocale([nearestLocale, language, DEFAULT_LANGUAGE]);
 
-    // dayjsService may not be available for the different front apps
-    const dayjsService = getOwner(this).lookup('service:dayjs');
-    if (dayjsService) {
-      // dayjs supports locale fallback to baseLocale, but dayjsService does not
-      dayjsService.setLocale(language);
-    }
-
     // metricsService may not be available for the different front apps
     const metricsService = getOwner(this).lookup('service:metrics');
     if (metricsService) {
       metricsService.context.locale = nearestLocale;
     }
+
+    // temporary before removing dayjs
+    return import(`dayjs/locale/${language}.js`).then(() => dayjs.locale(language));
   }
 
   setBestLocale({ queryParams }) {

--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -42,7 +42,6 @@
         "ember-click-outside": "^6.1.1",
         "ember-cookies": "^1.3.0",
         "ember-data": "^5.3.3",
-        "ember-dayjs": "^0.12.4",
         "ember-eslint-parser": "^0.9.0",
         "ember-exam": "10.1.0",
         "ember-inflector": "^6.0.0",
@@ -15059,24 +15058,6 @@
         "qunit": {
           "optional": true
         }
-      }
-    },
-    "node_modules/ember-dayjs": {
-      "version": "0.12.4",
-      "resolved": "https://registry.npmjs.org/ember-dayjs/-/ember-dayjs-0.12.4.tgz",
-      "integrity": "sha512-Avslpo+hNGBPcYYiIVMk4l+erChT7YWfeEghpBx0Q9wVN3HHpu2h2nI0r5ckeOea4OM3IL8oUBiQcO9NsHm5Qw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@embroider/addon-shim": "^1.8.9",
-        "@embroider/macros": "^1.16.1",
-        "dayjs": "^1.11.11"
-      },
-      "engines": {
-        "node": "14.* || 16.* || >= 18"
-      },
-      "peerDependencies": {
-        "ember-source": "^3.28.0 || ^4.0.0 || ^5.0.0"
       }
     },
     "node_modules/ember-eslint-parser": {

--- a/orga/package.json
+++ b/orga/package.json
@@ -82,7 +82,6 @@
     "ember-click-outside": "^6.1.1",
     "ember-cookies": "^1.3.0",
     "ember-data": "^5.3.3",
-    "ember-dayjs": "^0.12.4",
     "ember-eslint-parser": "^0.9.0",
     "ember-exam": "10.1.0",
     "ember-inflector": "^6.0.0",

--- a/orga/tests/acceptance/certifications-test.js
+++ b/orga/tests/acceptance/certifications-test.js
@@ -14,36 +14,34 @@ module('Acceptance | Certifications page', function (hooks) {
   hooks.beforeEach(async () => {
     const user = createUserManagingStudents('ADMIN');
     createPrescriberByUser({ user });
-
     await authenticateSession(user.id);
   });
 
+  hooks.afterEach(function () {
+    sinon.restore();
+  });
+
   module('When user arrives on certifications page', function (hooks) {
-    let dayjs;
     hooks.afterEach(function () {
       sinon.restore();
     });
 
     test('should display certification banner when it is time to', async function (assert) {
-      dayjs = this.owner.lookup('service:dayjs');
-      sinon.stub(dayjs.self.prototype, 'format').returns('04');
+      sinon.useFakeTimers({ now: new Date('2001-04-01T10:42:00Z'), shouldAdvanceTime: true });
 
       // given / when
       await visit('/certifications');
-
       // then
-      assert.ok('.pix-banner');
+      assert.ok('.pix-notification-alert');
     });
 
     test('should not show any banner outside certification period', async function (assert) {
-      dayjs = this.owner.lookup('service:dayjs');
-      sinon.stub(dayjs.self.prototype, 'format').returns('10');
-
+      sinon.useFakeTimers({ now: new Date('2001-10-01T10:42:00Z'), shouldAdvanceTime: true });
       // given / when
       await visit('/certifications');
 
       // then
-      assert.dom('.pix-banner').doesNotExist();
+      assert.dom('.pix-notification-alert ').doesNotExist();
     });
 
     module('When organizations has no students imported yet', function () {

--- a/orga/tests/integration/components/banner/certification-test.gjs
+++ b/orga/tests/integration/components/banner/certification-test.gjs
@@ -10,11 +10,8 @@ module('Integration | Component | Banner::Certification', function (hooks) {
   setupIntlRenderingTest(hooks);
 
   module('When it is certification period', function (hooks) {
-    let dayjs;
-
     hooks.beforeEach(function () {
-      dayjs = this.owner.lookup('service:dayjs');
-      sinon.stub(dayjs.self.prototype, 'format').withArgs('MM').returns('04').withArgs('YYYY').returns('2001');
+      sinon.useFakeTimers({ now: new Date('2001-04-01T10:42:00Z') });
     });
 
     hooks.afterEach(function () {

--- a/orga/tests/integration/components/tube/list-test.gjs
+++ b/orga/tests/integration/components/tube/list-test.gjs
@@ -9,9 +9,9 @@ module('Integration | Component | tube:list', function (hooks) {
   setupIntlRenderingTest(hooks);
   let allFrameworks;
   const MOCK_TODAY = '2020-08-05-1152';
-  let dayjs;
 
   hooks.beforeEach(function () {
+    sinon.useFakeTimers({ now: new Date('2020-08-05T11:52:00Z') });
     const tubesPix = [
       {
         id: 'tubeId1Pix',
@@ -107,8 +107,6 @@ module('Integration | Component | tube:list', function (hooks) {
         },
       },
     ];
-    dayjs = this.owner.lookup('service:dayjs');
-    sinon.stub(dayjs.self.prototype, 'format').returns(MOCK_TODAY);
   });
 
   hooks.afterEach(function () {

--- a/orga/tests/unit/services/locale-test.js
+++ b/orga/tests/unit/services/locale-test.js
@@ -3,6 +3,7 @@
 // and propagate the changes in the copies in all the fronts
 
 import Service from '@ember/service';
+import dayjs from 'dayjs';
 import { setupTest } from 'ember-qunit';
 import ENV from 'pix-orga/config/environment';
 import { module, test } from 'qunit';
@@ -18,7 +19,6 @@ module('Unit | Services | locale', function (hooks) {
   let localeService;
   let currentDomainService;
   let metricsService;
-  let dayjsService;
 
   hooks.beforeEach(function () {
     localeService = this.owner.lookup('service:locale');
@@ -33,11 +33,7 @@ module('Unit | Services | locale', function (hooks) {
     this.owner.register('service:metrics', metricsServiceStub);
     metricsService = this.owner.lookup('service:metrics');
 
-    class dayjsServiceStub extends Service {
-      setLocale = sinon.stub();
-    }
-    this.owner.register('service:dayjs', dayjsServiceStub);
-    dayjsService = this.owner.lookup('service:dayjs');
+    // sinon.stub(dayjs, 'locale');
   });
 
   module('currentLocale', function () {
@@ -116,23 +112,24 @@ module('Unit | Services | locale', function (hooks) {
   });
 
   module('setCurrentLocale', function () {
-    test('set app locale in the cookies', function (assert) {
+    test('set app locale in the cookies', async function (assert) {
       // given
       const intlService = this.owner.lookup('service:intl');
+      sinon.stub(dayjs, 'locale');
       sinon.stub(intlService, 'setLocale');
       const cookiesService = this.owner.lookup('service:cookies');
       sinon.stub(cookiesService, 'write');
       const locale = 'nl-BE';
 
       // when
-      localeService.setCurrentLocale(locale);
+      await localeService.setCurrentLocale(locale);
 
       // then
       const currentLocale = localeService.currentLocale;
       assert.strictEqual(currentLocale, 'nl-BE');
       sinon.assert.calledWith(cookiesService.write, 'locale', 'nl-BE');
       sinon.assert.calledWith(intlService.setLocale, ['nl-BE', 'nl', 'fr']);
-      sinon.assert.calledWith(dayjsService.setLocale, 'nl');
+      sinon.assert.calledWith(dayjs.locale, 'nl');
       assert.strictEqual(metricsService.context.locale, 'nl-BE');
     });
   });


### PR DESCRIPTION

## 🌱 Problème
Dans une précendente PR, on avaitsuppirmer l'utilisation des helper ember-dayjs.


## 🐣 Proposition

Maintenant on supprimer les dernière utilisation du service pour pouvoir supprimer complètement le paquet
afin de pouvoir passer sous vite
<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 🌷 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🐝 Pour tester
- [x] page de certification (affichage du bandeau selon la date)
- [x] page activité de campagne assessment 
- [x] changer la langue et voir que l'affichage des chart se met à jour
- [x] Affichage de la bannière d'import suite à un import (la banniere ne doit pas s'afficher si l'import est plus ancien que 15jours)
- [x] Téléchargement d'une liste de sujets  (le nom du fichier contient une date)
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
