### PR TITLE
[BUGFIX] Ne pas mettre à jour le createdAt lors de la mise à jour des DPO (PIX-22393)

### DIFF
--- a/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
@@ -382,7 +382,7 @@ async function _addOrUpdateDataProtectionOfficer(knexConn, dataProtectionOfficer
   await knexConn(DATA_PROTECTION_OFFICERS_TABLE_NAME)
     .insert(dataProtectionOfficer)
     .onConflict('organizationId')
-    .merge();
+    .merge(['firstName', 'lastName', 'email', 'updatedAt']);
 }
 
 async function _addTags(knexConn, organizationTags) {

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/organization-for-admin.repository.test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/organization-for-admin.repository.test.js
@@ -1747,19 +1747,21 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
       expect(dataProtectionOfficerCreated.email).to.equal('iron@man.fr');
     });
 
-    it('should update data protection officer', async function () {
+    it('should update data protection officer but not the createdAt', async function () {
       // given
       const userId = databaseBuilder.factory.buildUser({ firstName: 'Spider', lastName: 'Man' }).id;
       const organization = databaseBuilder.factory.buildOrganization({
         name: 'super orga',
         createdBy: userId,
       });
-
+      const date = new Date('1992-07-07');
       databaseBuilder.factory.buildDataProtectionOfficer.withOrganizationId({
         organizationId: organization.id,
         firstName: 'Tony',
         lastName: 'Stark',
         email: 'tony@stark.com',
+        createdAt: date,
+        updatedAt: date,
       });
 
       await databaseBuilder.commit();
@@ -1784,6 +1786,8 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
       expect(dataProtectionOfficerUpdated.firstName).to.equal('Iron');
       expect(dataProtectionOfficerUpdated.lastName).to.equal('Man');
       expect(dataProtectionOfficerUpdated.email).to.equal('iron@man.fr');
+      expect(dataProtectionOfficerUpdated.createdAt).to.deep.equal(date);
+      expect(dataProtectionOfficerUpdated.updatedAt).to.not.deep.equal(date);
     });
 
     it('should add tags', async function () {


### PR DESCRIPTION
## 🌱 Problème
On a constaté un petit bug, lorsque l'on mets à jour une information du DPO, on mets également à jour la date dans le champs "createdAt". Ce qui ne devrait évidemment pas arriver.

## 🐣 Proposition
Dans le cas ou la ligne dans DPO existe déjà, alors on veut juste remplacer les infos "firstname, lastname et email"

## 🌷 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🐝 Pour tester
- PixAdmin
- Modifier les infos d'un DPO sur une organisation
- Constater en BDD que la date du updatedAt à bien été mise à jour, mais pas celle du createdAt
