### PR TITLE
[FEATURE] Supprimer la colonne parentOrganizationId du CSV de modification d'organisations en masse (PIX-22386)

### DIFF
--- a/admin/app/components/administration/deployment/update-organizations-in-batch.gjs
+++ b/admin/app/components/administration/deployment/update-organizations-in-batch.gjs
@@ -47,13 +47,6 @@ export default class UpdateOrganizationsInBatch extends Component {
               error.meta,
             ),
           });
-        } else if (error.code === 'UNABLE_TO_ATTACH_CHILD_ORGANIZATION_TO_PARENT_ORGANIZATION') {
-          return this.pixToast.sendErrorNotification({
-            message: this.intl.t(
-              'components.administration.update-organizations-in-batch.notifications.errors.parent-organization-not-found',
-              error.meta,
-            ),
-          });
         } else if (error.code === 'DPO_EMAIL_INVALID') {
           return this.pixToast.sendErrorNotification({
             message: this.intl.t(

--- a/admin/tests/integration/components/administration/deployment/update-organizations-in-batch-test.gjs
+++ b/admin/tests/integration/components/administration/deployment/update-organizations-in-batch-test.gjs
@@ -80,42 +80,6 @@ module('Integration | Component |  administration/update-organizations-in-batch'
       );
     });
 
-    test('it displays an error when parent organization not found', async function (assert) {
-      // given
-      window.fetch.resolves(
-        fetchResponse({
-          body: {
-            errors: [
-              {
-                code: 'UNABLE_TO_ATTACH_CHILD_ORGANIZATION_TO_PARENT_ORGANIZATION',
-                meta: { organizationId: '123' },
-              },
-            ],
-          },
-          status: 409,
-        }),
-      );
-
-      // when
-      const screen = await render(
-        <template><UpdateOrganizationsInBatch /><PixToastContainer @closeButtonAriaLabel="Close" /></template>,
-      );
-      const input = await screen.findByLabelText(
-        t('components.administration.update-organizations-in-batch.upload-button'),
-      );
-      await triggerEvent(input, 'change', { files: [file] });
-
-      // then
-      assert.ok(
-        await screen.findByText(
-          t(
-            'components.administration.update-organizations-in-batch.notifications.errors.parent-organization-not-found',
-            { organizationId: '123' },
-          ),
-        ),
-      );
-    });
-
     test('it displays an error when DPO email invalid', async function (assert) {
       // given
       window.fetch.resolves(

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -321,8 +321,7 @@
           "errors": {
             "data-protection-email-invalid": "DPO email format invalid \"{value}\" for the organization \"{organizationId}\".",
             "organization-batch-update-error": "An error occurred for organization \"{organizationId}\".",
-            "organization-not-found": "Organization id not found: \"{organizationId}\".",
-            "parent-organization-not-found": "Parent organization for \"{organizationId}\" not found."
+            "organization-not-found": "Organization id not found: \"{organizationId}\"."
           },
           "success": "The organisations have been modified."
         },

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -328,8 +328,7 @@
           "errors": {
             "data-protection-email-invalid": "Le format de l'email du DPO est incorrect \"{value}\" pour l'organisation \"{organizationId}\".",
             "organization-batch-update-error": "Une erreur s'est produite sur l'organisation \"{organizationId}\".",
-            "organization-not-found": "Identifiant non trouvé pour l'organisation \"{organizationId}\".",
-            "parent-organization-not-found": "L'organisation parente de l'organisation \"{organizationId}\" non trouvée en base de données."
+            "organization-not-found": "Identifiant non trouvé pour l'organisation \"{organizationId}\"."
           },
           "success": "Les organisations ont bien été modifiées."
         },

--- a/api/src/organizational-entities/domain/constants.js
+++ b/api/src/organizational-entities/domain/constants.js
@@ -16,10 +16,6 @@ export const ORGANIZATIONS_UPDATE_HEADER = {
       property: 'externalId',
     }),
     new CsvColumn({
-      name: 'Organization Parent ID',
-      property: 'parentOrganizationId',
-    }),
-    new CsvColumn({
       name: 'Organization Identity Provider Code',
       property: 'identityProviderForCampaigns',
     }),

--- a/api/src/organizational-entities/domain/models/OrganizationForAdmin.js
+++ b/api/src/organizational-entities/domain/models/OrganizationForAdmin.js
@@ -202,8 +202,6 @@ class OrganizationForAdmin {
     if (organizationBatchUpdateDto.provinceCode) this.provinceCode = organizationBatchUpdateDto.provinceCode;
     if (organizationBatchUpdateDto.identityProviderForCampaigns)
       this.identityProviderForCampaigns = organizationBatchUpdateDto.identityProviderForCampaigns;
-    if (organizationBatchUpdateDto.parentOrganizationId)
-      this.parentOrganizationId = organizationBatchUpdateDto.parentOrganizationId;
 
     const dataProtectionOfficer = {
       firstName: this.dataProtectionOfficer.firstName,

--- a/api/src/organizational-entities/domain/usecases/update-organizations-in-batch.usecase.js
+++ b/api/src/organizational-entities/domain/usecases/update-organizations-in-batch.usecase.js
@@ -14,7 +14,6 @@ import {
   OrganizationBatchUpdateError,
   OrganizationLearnerTypeNotFound,
   OrganizationNotFound,
-  UnableToAttachChildOrganizationToParentOrganizationError,
 } from '../errors.js';
 
 /**
@@ -38,22 +37,19 @@ export const updateOrganizationsInBatch = withTransaction(
     if (dtos.length === 0) return;
 
     const organizationIds = new Set();
-    const parentOrganizationIds = new Set();
     const administrationTeamIds = new Set();
     const countryCodes = new Set();
     const organizationLearnerTypeIds = new Set();
 
     for (const dto of dtos) {
       organizationIds.add(dto.id);
-      if (dto.parentOrganizationId) parentOrganizationIds.add(dto.parentOrganizationId);
       if (dto.administrationTeamId) administrationTeamIds.add(dto.administrationTeamId);
       if (dto.countryCode) countryCodes.add(dto.countryCode);
       if (dto.organizationLearnerTypeId) organizationLearnerTypeIds.add(dto.organizationLearnerTypeId);
     }
 
-    const existingOrganizationIds = await _toExistingSet(
-      Array.from(new Set([...organizationIds, ...parentOrganizationIds])),
-      (ids) => organizationForAdminRepository.findExistingIds({ ids }),
+    const existingOrganizationIds = await _toExistingSet(Array.from(new Set([...organizationIds])), (ids) =>
+      organizationForAdminRepository.findExistingIds({ ids }),
     );
 
     const existingAdministrationTeamIds = await _toExistingSet(Array.from(administrationTeamIds), (ids) =>
@@ -95,15 +91,6 @@ function _validateAllDtos(
     if (!existingOrganizationIds.has(String(dto.id))) {
       throw new OrganizationNotFound({
         meta: { organizationId: dto.id },
-      });
-    }
-
-    if (dto.parentOrganizationId && !existingOrganizationIds.has(String(dto.parentOrganizationId))) {
-      throw new UnableToAttachChildOrganizationToParentOrganizationError({
-        meta: {
-          organizationId: dto.id,
-          value: dto.parentOrganizationId,
-        },
       });
     }
 

--- a/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
@@ -1394,8 +1394,8 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
       it('responds with a 204 - no content', async function () {
         // given
         const input = `${ORGANIZATIONS_UPDATE_HEADER.columns.map(({ name }) => name).join(';')}
-      ${firstOrganization.id};MSFT;12;;OIDC_EXAMPLE_NET;https://doc.url;;Troisjour;Adam;;1234;99500;
-      ${otherOrganization.id};APPL;;;;;;;Cali;;1234;99500;`;
+      ${firstOrganization.id};MSFT;12;OIDC_EXAMPLE_NET;https://doc.url;;Troisjour;Adam;;1234;99500;
+      ${otherOrganization.id};APPL;;;;;;Cali;;1234;99500;`;
 
         const options = {
           method: 'POST',

--- a/api/tests/organizational-entities/integration/application/organization/organization.admin.route.test.js
+++ b/api/tests/organizational-entities/integration/application/organization/organization.admin.route.test.js
@@ -9,7 +9,6 @@ import {
   OrganizationBatchUpdateError,
   OrganizationNotFound,
   TagNotFoundError,
-  UnableToAttachChildOrganizationToParentOrganizationError,
 } from '../../../../../src/organizational-entities/domain/errors.js';
 import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
 import { CsvImportError, NotFoundError } from '../../../../../src/shared/domain/errors.js';
@@ -201,21 +200,6 @@ describe('Integration | Organizational Entities | Application | Route | Admin | 
 
           // then
           expect(response.statusCode).to.equal(404);
-        });
-      });
-
-      context('when it is not able to link to the parent organization', function () {
-        it('returns a 409 HTTP status code', async function () {
-          // given
-          organizationAdminController.updateOrganizationsInBatch.rejects(
-            new UnableToAttachChildOrganizationToParentOrganizationError(),
-          );
-
-          // when
-          const response = await httpTestServer.request(method, url, payload);
-
-          // then
-          expect(response.statusCode).to.equal(409);
         });
       });
 

--- a/api/tests/organizational-entities/integration/domain/usecases/update-organizations-in-batch.usecase.test.js
+++ b/api/tests/organizational-entities/integration/domain/usecases/update-organizations-in-batch.usecase.test.js
@@ -5,7 +5,6 @@ import {
   DpoEmailInvalid,
   OrganizationLearnerTypeNotFound,
   OrganizationNotFound,
-  UnableToAttachChildOrganizationToParentOrganizationError,
 } from '../../../../../src/organizational-entities/domain/errors.js';
 import { usecases } from '../../../../../src/organizational-entities/domain/usecases/index.js';
 import { ORGANIZATION_FEATURE } from '../../../../../src/shared/domain/constants.js';
@@ -80,8 +79,8 @@ describe('Integration | Organizational Entities | Domain | UseCase | update-orga
       // given
       const headers = ORGANIZATIONS_UPDATE_HEADER.columns.map(({ name }) => name).join(';');
       const fileData = `${headers}
-      ${organization1.id};;12;;OIDC_EXAMPLE_NET;https://doc.url;;Troisjour;Adam;foo@email.com;1234;99100;12
-      ${organization2.id};New Name;;;;;;;Cali;;5678;99100;34`;
+      ${organization1.id};;12;OIDC_EXAMPLE_NET;https://doc.url;;Troisjour;Adam;foo@email.com;1234;99100;12
+      ${organization2.id};New Name;;;;;;Cali;;5678;99100;34`;
       filePath = await createTempFile('test.csv', fileData);
 
       // when
@@ -120,7 +119,7 @@ describe('Integration | Organizational Entities | Domain | UseCase | update-orga
       // given
       const headers = ORGANIZATIONS_UPDATE_HEADER.columns.map(({ name }) => name).join(';');
       const fileData = `${headers}
-      999999;;12;;OIDC_EXAMPLE_NET;https://doc.url;;Troisjour;Adam;;1234;;`;
+      999999;;12;OIDC_EXAMPLE_NET;https://doc.url;;Troisjour;Adam;;1234;;`;
       filePath = await createTempFile('test.csv', fileData);
 
       // when
@@ -138,7 +137,7 @@ describe('Integration | Organizational Entities | Domain | UseCase | update-orga
 
       const headers = ORGANIZATIONS_UPDATE_HEADER.columns.map(({ name }) => name).join(';');
       const fileData = `${headers}
-      ${organization.id};;12;;OIDC_EXAMPLE_NET;https://doc.url;;Troisjour;Adam;;1234;;`;
+      ${organization.id};;12;OIDC_EXAMPLE_NET;https://doc.url;;Troisjour;Adam;;1234;;`;
       filePath = await createTempFile('test.csv', fileData);
 
       // when
@@ -156,7 +155,7 @@ describe('Integration | Organizational Entities | Domain | UseCase | update-orga
 
       const headers = ORGANIZATIONS_UPDATE_HEADER.columns.map(({ name }) => name).join(';');
       const fileData = `${headers}
-      ${organization.id};;12;;OIDC_EXAMPLE_NET;https://doc.url;;Troisjour;Adam;;;99999;`;
+      ${organization.id};;12;OIDC_EXAMPLE_NET;https://doc.url;;Troisjour;Adam;;;99999;`;
       filePath = await createTempFile('test.csv', fileData);
 
       // when
@@ -175,7 +174,7 @@ describe('Integration | Organizational Entities | Domain | UseCase | update-orga
 
         const headers = ORGANIZATIONS_UPDATE_HEADER.columns.map(({ name }) => name).join(';');
         const fileData = `${headers}
-        ${organization.id};;12;;OIDC_EXAMPLE_NET;https://doc.url;;Troisjour;Adam;;;;`;
+        ${organization.id};;12;OIDC_EXAMPLE_NET;https://doc.url;;Troisjour;Adam;;;;`;
         filePath = await createTempFile('test.csv', fileData);
 
         // when
@@ -195,7 +194,7 @@ describe('Integration | Organizational Entities | Domain | UseCase | update-orga
 
         const headers = ORGANIZATIONS_UPDATE_HEADER.columns.map(({ name }) => name).join(';');
         const fileData = `${headers}
-        ${organization.id};;12;;OIDC_EXAMPLE_NET;https://doc.url;;Troisjour;Adam;foo@email.com;;;`;
+        ${organization.id};;12;OIDC_EXAMPLE_NET;https://doc.url;;Troisjour;Adam;foo@email.com;;;`;
         filePath = await createTempFile('test.csv', fileData);
 
         // when
@@ -209,26 +208,6 @@ describe('Integration | Organizational Entities | Domain | UseCase | update-orga
       });
     });
 
-    context('when parent organization does not exist', function () {
-      it('throws an UnableToAttachChildOrganizationToParentOrganizationError', async function () {
-        // given
-        const organization = databaseBuilder.factory.buildOrganization({ externalId: 999 });
-        await databaseBuilder.commit();
-
-        const headers = ORGANIZATIONS_UPDATE_HEADER.columns.map(({ name }) => name).join(';');
-        const fileData = `${headers}
-        ${organization.id};;12;999999;OIDC_EXAMPLE_NET;https://doc.url;;Troisjour;Adam;;1234;;`;
-        filePath = await createTempFile('test.csv', fileData);
-
-        // when
-        const error = await catchErr(usecases.updateOrganizationsInBatch)({ filePath });
-
-        // then
-        expect(error).to.be.instanceOf(UnableToAttachChildOrganizationToParentOrganizationError);
-        expect(error.meta.organizationId).to.equal(`${organization.id}`);
-      });
-    });
-
     context('when DPO email is not valid', function () {
       it('throws a DpoEmailInvalid', async function () {
         // given
@@ -237,7 +216,7 @@ describe('Integration | Organizational Entities | Domain | UseCase | update-orga
 
         const headers = ORGANIZATIONS_UPDATE_HEADER.columns.map(({ name }) => name).join(';');
         const fileData = `${headers}
-        ${organization.id};;12;;OIDC_EXAMPLE_NET;https://doc.url;;Troisjour;Adam;foo;;;`;
+        ${organization.id};;12;OIDC_EXAMPLE_NET;https://doc.url;;Troisjour;Adam;foo;;;`;
         filePath = await createTempFile('test.csv', fileData);
 
         // when
@@ -260,7 +239,7 @@ describe('Integration | Organizational Entities | Domain | UseCase | update-orga
 
       const headers = ORGANIZATIONS_UPDATE_HEADER.columns.map(({ name }) => name).join(';');
       const fileData = `${headers}
-      ${organization.id};;12;;OIDC_EXAMPLE_NET;https://doc.url;;Troisjour;Adam;;;;5678`;
+      ${organization.id};;12;OIDC_EXAMPLE_NET;https://doc.url;;Troisjour;Adam;;;;5678`;
       filePath = await createTempFile('test.csv', fileData);
 
       // when

--- a/api/tests/organizational-entities/unit/domain/models/OrganizationForAdmin_test.js
+++ b/api/tests/organizational-entities/unit/domain/models/OrganizationForAdmin_test.js
@@ -1064,22 +1064,6 @@ describe('Unit | Organizational Entities | Domain | Model | OrganizationForAdmin
       expect(organizationToUpdate).to.deep.equal(expectedOrganization);
     });
 
-    it('updates the organization parent identifier', function () {
-      // given
-      const parentOrganizationId = '1024';
-      const organizationToUpdate = domainBuilder.buildOrganizationForAdmin();
-
-      // when
-      organizationToUpdate.updateFromOrganizationBatchUpdateDto(
-        new OrganizationBatchUpdateDTO({ id: '1', parentOrganizationId }),
-      );
-
-      // then
-      const expectedOrganization = domainBuilder.buildOrganizationForAdmin({ parentOrganizationId });
-      expect(organizationToUpdate.parentOrganizationId).to.equal(parentOrganizationId);
-      expect(organizationToUpdate).to.deep.equal(expectedOrganization);
-    });
-
     it('updates the organization data protection officer first name', function () {
       // given
       const dataProtectionOfficerFirstName = 'Adam';

--- a/api/tests/organizational-entities/unit/domain/usecases/update-organizations-in-batch.usecase.test.js
+++ b/api/tests/organizational-entities/unit/domain/usecases/update-organizations-in-batch.usecase.test.js
@@ -15,7 +15,7 @@ describe('Unit | Organizational Entities | Domain | UseCase | update-organizatio
     organizationLearnerTypeRepository;
 
   const csvHeaders =
-    'Organization ID;Organization Name;Organization External ID;Organization Parent ID;Organization Identity Provider Code;Organization Documentation URL;Organization Province Code;DPO Last Name;DPO First Name;DPO E-mail;Administration Team ID;Country Code';
+    'Organization ID;Organization Name;Organization External ID;Organization Identity Provider Code;Organization Documentation URL;Organization Province Code;DPO Last Name;DPO First Name;DPO E-mail;Administration Team ID;Country Code';
 
   beforeEach(function () {
     sinon.stub(DomainTransaction, 'execute').callsFake((callback) => {
@@ -76,13 +76,13 @@ describe('Unit | Organizational Entities | Domain | UseCase | update-organizatio
       it('throws an OrganizationBatchUpdateError', async function () {
         // given
         const fileData = `${csvHeaders}
-        1;;12;2;OIDC_EXAMPLE_NET;https://doc.url;;Troisjour;Adam;;1234;
+        1;;12;OIDC_EXAMPLE_NET;https://doc.url;;Troisjour;Adam;;1234;
         `;
         filePath = await createTempFile('test.csv', fileData);
         organizationForAdminRepository.exist.resolves(true);
         organizationForAdminRepository.get.onCall(0).resolves(domainBuilder.buildOrganizationForAdmin({ id: 1 }));
         organizationForAdminRepository.update.rejects('Unexpected error');
-        organizationForAdminRepository.findExistingIds.resolves(['1', '2']);
+        organizationForAdminRepository.findExistingIds.resolves(['1']);
         administrationTeamRepository.findExistingIds.resolves(['1234']);
         countryRepository.findExistingCodes.resolves(['99100']);
         organizationLearnerTypeRepository.findExistingIds.resolves([]);


### PR DESCRIPTION
## 🌱 Problème

Avec le nouveau système de réseaux, la modification du parent d'une organisation ne peut plus se faire aussi facilement. Cela reviendrait à rattacher une organisation à un autre réseau mais que faire si cette organisation a elle-même des enfants ? Rattacher toute la grappe ? On voit que cette fonctionnalité demande davantage de réflexions sur les règles métier.

## 🐣 Proposition

En attendant de creuser le sujet, on décide de supprimer la possibilité de modifier le parent d'une organisation dans la modification d'organisation en masse.

## 🌷 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🐝 Pour tester
Sur Pix Admin:
- aller sur Administration -> Déploiement
- télécharger le template de modification en masse d'organisations
- constater l'absence de la colonne parentOrganizationId
- tenter de modifier des orgas via le CSV pour vérifier la non régression
- tenter d'importer un ancien template avec la colonne parentOrganizationId
- constater une erreur