### PR TITLE
[TECH] Vide les caches d'index des paquets ubuntu avant installation du navigateur par le script browser-tools pour éviter les problèmes de désynchro avec les miroirs Ubuntu

### DIFF
--- a/.circleci/jobs.yml
+++ b/.circleci/jobs.yml
@@ -256,6 +256,7 @@ commands:
       app_name:
         type: string
     steps:
+      - run: sudo rm -rf /var/lib/apt/lists/*
       - browser-tools/install-chrome
       - attach_workspace:
           at: ~/pix
@@ -968,6 +969,7 @@ jobs:
             if [[ "$CIRCLE_BRANCH" != "dev" ]] && [[ "<< pipeline.parameters.run-mon-pix >>" == "false" ]] && [[ "<< pipeline.parameters.run-api >>" == "false" ]] && [[ "<< pipeline.parameters.run-e2e-cypress >>" == "false" ]]; then
               circleci step halt
             fi
+      - run: sudo rm -rf /var/lib/apt/lists/*
       - browser-tools/install-chrome
       - run:
           name: Manual safety start of X11 server
@@ -1048,6 +1050,7 @@ jobs:
             if [[ "$CIRCLE_BRANCH" != "dev" ]] && [[ "<< pipeline.parameters.run-orga >>" == "false" ]] && [[ "<< pipeline.parameters.run-api >>" == "false" ]] && [[ "<< pipeline.parameters.run-e2e-cypress >>" == "false" ]]; then
               circleci step halt
             fi
+      - run: sudo rm -rf /var/lib/apt/lists/*
       - browser-tools/install-chrome
       - run:
           name: Manual safety start of X11 server


### PR DESCRIPTION
## 🌱 Problème

Depuis hier les jobs CircleCI qui impliquent l'installation d'un navigateur, en utilisant le script fourni par l'orbe `browser-tools`, sont régulièrement en erreur. L'erreur semble être un mismatch de checksum entre ce qu'on télécharge et le checksum attendu d'après le miroir pour les paquets ubuntu.

## 🐣 Proposition

Lorsque Ubuntu fait des mises à jour, il met aussi à jour les metadata des serveurs pour mettre notamment les checksums des paquets. Ces modifications doivent être répercutées aussi au niveau des serveurs miroirs. Mais parfois, le temps que ce soit mis à jour y'a une désynchro.
Quand notre job veut mettre à jour les metadata du package via `apt-get update`, il reçoit un fichier qui ne matche pas avec les metadata attendues par celles du serveur.

Je propose qu'on force le nettoyage des metadata de l'orbe pour virer toutes données désynchro ou corrompues, ainsi le apt-get update fait par le script browser-tools n'a pas de cache potentiellement corrompu

## 🌷 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🐝 Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
