### PR TITLE
[TECH] Ajouter un script pour rattraper pour ajouter le commentaire aux certifications scorées Pix+Edu non admissibles (PIX-22377).

### DIFF
--- a/api/scripts/certification/fill-edu-v3-not-eligible-auto-comment.js
+++ b/api/scripts/certification/fill-edu-v3-not-eligible-auto-comment.js
@@ -1,0 +1,65 @@
+import { knex } from '../../db/knex-database-connection.js';
+import { AutoJuryCommentKeys } from '../../src/certification/shared/domain/models/JuryComment.js';
+import { Script } from '../../src/shared/application/scripts/script.js';
+import { ScriptRunner } from '../../src/shared/application/scripts/script-runner.js';
+import { AssessmentResult } from '../../src/shared/domain/models/AssessmentResult.js';
+
+export class FillEduV3NotEligibleAutoComment extends Script {
+  constructor() {
+    super({
+      description: 'Retro-fill the "commentByAutoJury" column for rejected Pix+Edu v3 in "assessment-results" table',
+      permanent: false,
+      options: {
+        dryRun: {
+          type: 'boolean',
+          describe: 'Run the script without making any database changes',
+          default: true,
+        },
+        versions: {
+          type: 'string',
+          describe: 'Comma-separated list of complementary certification version IDs to target',
+          demandOption: true,
+        },
+      },
+    });
+  }
+
+  async handle({ logger, options }) {
+    const { dryRun, versions } = options;
+    const eduV3Versions = versions.split(',').map(Number);
+    logger.info(`Script execution started with versions: ${eduV3Versions}`);
+
+    const trx = await knex.transaction();
+    try {
+      const assessmentResultsToBeFilled = await trx('assessment-results')
+        .pluck('id')
+        .whereIn('versionId', eduV3Versions)
+        .where({
+          status: AssessmentResult.status.REJECTED,
+          reachedMeshIndex: null,
+          commentByAutoJury: null,
+        });
+
+      logger.info(`Number of Edu v3 assessment-results to be filled: ${assessmentResultsToBeFilled.length}`);
+
+      await trx('assessment-results').whereIn('id', assessmentResultsToBeFilled).update({
+        commentByAutoJury: AutoJuryCommentKeys.REJECTED_EDU_NOT_ELIGIBLE,
+      });
+
+      if (dryRun) {
+        await trx.rollback();
+        logger.info(`${assessmentResultsToBeFilled.length} would have been updated`);
+        return;
+      }
+
+      await trx.commit();
+      logger.info(`${assessmentResultsToBeFilled.length} have been successfully updated`);
+      return;
+    } catch (error) {
+      await trx.rollback();
+      throw error;
+    }
+  }
+}
+
+await ScriptRunner.execute(import.meta.url, FillEduV3NotEligibleAutoComment);

--- a/api/tests/certification/scripts/fill-edu-v3-not-eligible-auto-comment_test.js
+++ b/api/tests/certification/scripts/fill-edu-v3-not-eligible-auto-comment_test.js
@@ -1,0 +1,144 @@
+import { FillEduV3NotEligibleAutoComment } from '../../../scripts/certification/fill-edu-v3-not-eligible-auto-comment.js';
+import { AutoJuryCommentKeys } from '../../../src/certification/shared/domain/models/JuryComment.js';
+import { SCOPES } from '../../../src/certification/shared/domain/models/Scopes.js';
+import { AssessmentResult } from '../../../src/shared/domain/models/AssessmentResult.js';
+import { catchErr, databaseBuilder, expect, knex, sinon } from '../../test-helper.js';
+
+describe('Certification | Scripts | fill edu v3 not eligible auto comment', function () {
+  let assessmentResultToBeFilled, eduVersion, script;
+  let logger;
+
+  beforeEach(function () {
+    script = new FillEduV3NotEligibleAutoComment();
+    logger = {
+      info: sinon.stub(),
+      error: sinon.stub(),
+    };
+
+    eduVersion = databaseBuilder.factory.buildCertificationVersion({
+      scope: SCOPES.PIX_PLUS_EDU_CPE,
+    });
+
+    assessmentResultToBeFilled = databaseBuilder.factory.buildAssessmentResult({
+      versionId: eduVersion.id,
+      status: AssessmentResult.status.REJECTED,
+      reachedMeshIndex: null,
+      commentByAutoJury: null,
+    }).id;
+
+    // Validated AssessmentResult
+    databaseBuilder.factory.buildAssessmentResult({
+      versionId: eduVersion.id,
+      status: AssessmentResult.status.VALIDATED,
+      reachedMeshIndex: 0,
+      commentByAutoJury: null,
+    }).id;
+
+    // Rejected AssessmentResult with already an auto-comment
+    databaseBuilder.factory.buildAssessmentResult({
+      versionId: eduVersion.id,
+      status: AssessmentResult.status.REJECTED,
+      reachedMeshIndex: null,
+      commentByAutoJury: AutoJuryCommentKeys.REJECTED_DUE_TO_LACK_OF_ANSWERS,
+    }).id;
+
+    // Rejected AssessmentResult from a non-EDU version
+    const version = databaseBuilder.factory.buildCertificationVersion({
+      scope: SCOPES.PIX_PLUS_DROIT,
+    });
+    databaseBuilder.factory.buildAssessmentResult({
+      versionId: version.id,
+      status: AssessmentResult.status.REJECTED,
+      reachedMeshIndex: null,
+      commentByAutoJury: null,
+    }).id;
+
+    return databaseBuilder.commit();
+  });
+
+  context('dryRun ON', function () {
+    it('does not persist the changes', async function () {
+      const rowsToFill = await knex('assessment-results').pluck('id').whereIn('versionId', [eduVersion.id]).where({
+        status: AssessmentResult.status.REJECTED,
+        reachedMeshIndex: null,
+        commentByAutoJury: null,
+      });
+
+      await script.handle({
+        logger,
+        options: { dryRun: true, versions: `${eduVersion.id}` },
+      });
+
+      const filledRows = await knex('assessment-results').whereIn('id', rowsToFill);
+
+      expect(rowsToFill).to.have.lengthOf(1);
+      expect(rowsToFill[0]).to.equal(assessmentResultToBeFilled);
+
+      expect(filledRows).to.have.lengthOf(1);
+      expect(filledRows[0].commentByAutoJury).to.be.null;
+
+      expect(logger.info).to.have.been.calledWith(`Script execution started with versions: ${eduVersion.id}`);
+      expect(logger.info).to.have.been.calledWith(
+        `Number of Edu v3 assessment-results to be filled: ${filledRows.length}`,
+      );
+      expect(logger.info).to.have.been.calledWith(`${filledRows.length} would have been updated`);
+      expect(logger.error).to.not.have.been.called;
+    });
+  });
+
+  context('dryRun OFF', function () {
+    context('when there are no errors', function () {
+      it('persists all the changes', async function () {
+        const rowsToFill = await knex('assessment-results').pluck('id').whereIn('versionId', [eduVersion.id]).where({
+          status: AssessmentResult.status.REJECTED,
+          reachedMeshIndex: null,
+          commentByAutoJury: null,
+        });
+
+        await script.handle({
+          logger,
+          options: { dryRun: false, versions: `${eduVersion.id}` },
+        });
+
+        const filledRows = await knex('assessment-results').whereIn('id', rowsToFill);
+
+        expect(filledRows).to.have.lengthOf(1);
+        expect(filledRows[0].id).to.equal(assessmentResultToBeFilled);
+        expect(filledRows[0].commentByAutoJury).to.equal(AutoJuryCommentKeys.REJECTED_EDU_NOT_ELIGIBLE);
+
+        expect(logger.info).to.have.been.calledWith(`Script execution started with versions: ${eduVersion.id}`);
+        expect(logger.info).to.have.been.calledWith(
+          `Number of Edu v3 assessment-results to be filled: ${filledRows.length}`,
+        );
+        expect(logger.info).to.have.been.calledWith(`${filledRows.length} have been successfully updated`);
+        expect(logger.error).to.not.have.been.called;
+      });
+    });
+
+    context('when an error occurs during the process', function () {
+      it('rolls back all changes', async function () {
+        const sabotageHook = (queryData) => {
+          if (queryData.method === 'update') {
+            throw new Error('SABOTAGING_TO_TRIGGER_ROLLBACK');
+          } else {
+            knex.once('query', sabotageHook);
+          }
+        };
+        knex.once('query', sabotageHook);
+
+        const err = await catchErr(
+          script.handle,
+          script,
+        )({
+          logger,
+          options: { dryRun: false, versions: `${eduVersion.id}` },
+        });
+
+        expect(err.message).to.equal('SABOTAGING_TO_TRIGGER_ROLLBACK');
+
+        const unchangedRows = await knex('assessment-results').where({ id: assessmentResultToBeFilled });
+        expect(unchangedRows[0].commentByAutoJury).to.be.null;
+      });
+    });
+  });
+});


### PR DESCRIPTION
## 🌱 Problème

Dans [cette PR](https://github.com/1024pix/pix/pull/15868), nous ajoutons une clé de commentaire auto-jury pour les certifications Pix+ Edu v3 qui n'ont pas un score suffisant pour être admissible.

Cela fonctionne pour les nouveaux passages de certif, mais pas ceux qui ont été scorés.

## 🐣 Proposition

Créer un script pour ajouter le commentaire aux certifications déjà scorées avec un résultat non admissibles.

## 🐝 Pour tester

- En local, avoir un `assessment-result` d'une certif v3 Pix+ Edu avec un `status = "rejected"`, un `reachedMeshIndex = null` et `commentByAutoJury = null`.
- Récupérer l'ID de la version de cet  assessment-result
- Lancer le script en local : 
```shell
LOG_ENABLED=true LOG_LEVEL=info node scripts/certification/fill-edu-v3-not-eligible-auto-comment.js --dryRun=true --versions=EDU_VERSION_ID         
``` 
Constater que la ligne n'a pas été impactée en dryRun.

- Relancer en `--dryRun=false` et constater que le commentaire a bien été ajouté en BDD dans la colonne `commentByAutoJury`.