### PR TITLE
[TECH] Mettre à jour les infos des dépôts Ubuntu avant d'installer les navigateurs pour les tests fronts

### DIFF
--- a/.circleci/jobs.yml
+++ b/.circleci/jobs.yml
@@ -256,7 +256,7 @@ commands:
       app_name:
         type: string
     steps:
-      - run: sudo rm -rf /var/lib/apt/lists/*
+      - run: sudo apt-get update -y
       - browser-tools/install-chrome
       - attach_workspace:
           at: ~/pix
@@ -969,7 +969,7 @@ jobs:
             if [[ "$CIRCLE_BRANCH" != "dev" ]] && [[ "<< pipeline.parameters.run-mon-pix >>" == "false" ]] && [[ "<< pipeline.parameters.run-api >>" == "false" ]] && [[ "<< pipeline.parameters.run-e2e-cypress >>" == "false" ]]; then
               circleci step halt
             fi
-      - run: sudo rm -rf /var/lib/apt/lists/*
+      - run: sudo apt-get update -y
       - browser-tools/install-chrome
       - run:
           name: Manual safety start of X11 server
@@ -1050,7 +1050,7 @@ jobs:
             if [[ "$CIRCLE_BRANCH" != "dev" ]] && [[ "<< pipeline.parameters.run-orga >>" == "false" ]] && [[ "<< pipeline.parameters.run-api >>" == "false" ]] && [[ "<< pipeline.parameters.run-e2e-cypress >>" == "false" ]]; then
               circleci step halt
             fi
-      - run: sudo rm -rf /var/lib/apt/lists/*
+      - run: sudo apt-get update -y
       - browser-tools/install-chrome
       - run:
           name: Manual safety start of X11 server


### PR DESCRIPTION
## 🌱 Problème

Y'a parfois désynchro entre les infos des dépôts et les infos en local dans l'orbe.

## 🐣 Proposition

Une solution précédente avait été tout supprimer pour être sûr de ne pas avoir d'infos corrompues.
On peut aussi faire un update nous-mêmes

`apt-get update -y`

## 🌷 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🐝 Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
