### PR TITLE
[TECH] Baisser le nombre de tentatives de réexécution du job de scoring en cas d'échec

### DIFF
--- a/api/src/certification/evaluation/infrastructure/repositories/jobs/certification-completed-job-repository.js
+++ b/api/src/certification/evaluation/infrastructure/repositories/jobs/certification-completed-job-repository.js
@@ -8,7 +8,7 @@ class CertificationCompletedJobRepository extends JobRepository {
   constructor() {
     super({
       name: CertificationCompletedJob.name,
-      retry: JobRetry.STANDARD_RETRY,
+      retry: JobRetry.FEW_RETRY,
       priority: JobPriority.HIGH,
     });
   }

--- a/api/tests/certification/evaluation/integration/infrastructure/repositories/jobs/certification-completed-job-repository_test.js
+++ b/api/tests/certification/evaluation/integration/infrastructure/repositories/jobs/certification-completed-job-repository_test.js
@@ -19,7 +19,7 @@ describe('Integration | Repository | Jobs | CertificationCompletedJobRepository'
 
       // then
       await expect(CertificationCompletedJob.name).to.have.been.performed.withJob({
-        retryLimit: 10,
+        retryLimit: 2,
         retryDelay: 30,
         retryBackoff: true,
         priority: JobPriority.HIGH,


### PR DESCRIPTION
## 🌱 Problème
En cas de pb de scoring, l'info est déjà claire sur notre channel. De plus, souvent lorsqu'il y a un pb de scoring, réessayer ne sert à rien (la certif est dans un état KO).

## 🐣 Proposition

Baisser le nombre de tentatives à 2

Enfin, si un scoring est nécessaire, même si on a épuisé toutes les tentatives, il reste toujours PixAdmin 😉 

## 🌷 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🐝 Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
