### PR TITLE
[TECH] Ajout d'un test E2E pour l'inscription SCO en certif (PIX-22370).

### DIFF
--- a/.circleci/jobs.yml
+++ b/.circleci/jobs.yml
@@ -406,7 +406,6 @@ workflows:
           requires:
             - api_install
             - mon_pix_install
-            - orga_install
             - certif_install
             - admin_install
           filters:
@@ -1271,11 +1270,6 @@ jobs:
             IS_RUNNING_PLAYWRIGHT: 'true'
             PIX_ADMIN_LOGIN_FROM_PASSWORD_ENABLED: 'true'
       - run:
-          name: Start Pix Orga
-          working_directory: ~/pix/orga
-          command: npx ember serve --path=./dist --proxy=http://localhost:3000
-          background: true
-      - run:
           name: Start Pix App
           working_directory: ~/pix/mon-pix
           command: npx ember serve --path=./dist --proxy=http://localhost:3000
@@ -1320,7 +1314,6 @@ jobs:
           environment:
             PIX_API_PORT: 3000
             PIX_APP_URL: http://localhost:4200
-            PIX_ORGA_URL: http://localhost:4201
             PIX_ADMIN_URL: http://localhost:4202
             PIX_CERTIF_URL: http://localhost:4203
             DATABASE_URL: 'postgres://circleci@localhost:5432/circleci'

--- a/high-level-tests/e2e-playwright/fixtures/certification/logged-pages.ts
+++ b/high-level-tests/e2e-playwright/fixtures/certification/logged-pages.ts
@@ -6,7 +6,7 @@ import { AUTH_DIR, Credentials, HAR_DIR, saveStorageState, shouldRecordHAR } fro
 import { buildCandidate, buildPixAdminUser, buildPixCertifUser } from '../../helpers/certification/builders/index.ts';
 import { pixCertifiableUserData } from '../../helpers/certification/data.ts';
 import { PIX_ADMIN_CERTIF_DATA, PIX_CERTIF_PRO_DATA, PIX_CERTIF_SCO_DATA } from '../../helpers/certification/data.ts';
-import { getCleaTargetProfileId } from '../../helpers/certification/db.ts';
+import { getCleaTargetProfileId, getOrganizationIdForScoUser } from '../../helpers/certification/db.ts';
 import { PixAdminUserData, PixCertifiableUserData, PixCertifUserData } from '../../helpers/certification/types.ts';
 import { knex } from '../../helpers/db.ts';
 import { test as sharedTest } from '../index.ts';
@@ -126,6 +126,7 @@ export const loggedPagesFixtures = sharedTest.extend<
       userDataMap.set(PIX_CERTIF_SCO_DATA.email, userData);
 
       // certifiable users
+      const organizationScoId = await getOrganizationIdForScoUser(id);
       for (const certifiableUserData of pixCertifiableUserData) {
         id = nextId();
         email = buildUniqueEmailFromId(id, certifiableUserData.email);
@@ -134,7 +135,7 @@ export const loggedPagesFixtures = sharedTest.extend<
           id,
           email,
         } as PixCertifiableUserData;
-        await buildCandidate(knex, userData as PixCertifiableUserData);
+        await buildCandidate(knex, userData as PixCertifiableUserData, organizationScoId);
         userDataMap.set(certifiableUserData.email, userData);
       }
       await use(userDataMap);

--- a/high-level-tests/e2e-playwright/fixtures/certification/logged-pages.ts
+++ b/high-level-tests/e2e-playwright/fixtures/certification/logged-pages.ts
@@ -7,7 +7,7 @@ import { buildPixAdminUser, buildPixCertifUser } from '../../helpers/certificati
 import { pixCertifiableUserData } from '../../helpers/certification/data.ts';
 import { PixAdminUserData, PixCertifiableUserData, PixCertifUserData } from '../../helpers/certification/types.ts';
 import { knex } from '../../helpers/db.ts';
-import { CERTIFICATIONS_DATA } from '../../helpers/db-data.ts';
+import { CERTIFICATIONS_DATA, PIX_CERTIF_SCO_DATA } from '../../helpers/db-data.ts';
 import {
   ChallengePage,
   FinalCheckpointPage,
@@ -137,27 +137,9 @@ export const loggedPagesFixtures = sharedTest.extend<
     { scope: 'worker' },
   ],
   pixCertifScoUserData: [
-    async ({ nextId }, use) => {
-      const nextUserId = nextId();
-      const certifScoUserData: PixCertifUserData = {
-        id: nextUserId,
-        firstName: 'pixCertifSco',
-        lastName: `pixCertifSco${nextUserId}`,
-        email: `pix-certif-pro-${nextUserId}@example.net`,
-        rawPassword: 'pix123',
-        certificationCenters: [
-          {
-            type: 'SCO',
-            externalId: `CERTIFSCO${nextUserId}`,
-            habilitations: [],
-            withOrganization: {
-              isManagingStudents: true,
-            },
-          },
-        ],
-      };
-      await buildPixCertifUser(knex, certifScoUserData);
-      await use(certifScoUserData);
+    // eslint-disable-next-line no-empty-pattern
+    async ({}, use) => {
+      await use(PIX_CERTIF_SCO_DATA);
     },
     { scope: 'worker' },
   ],
@@ -215,7 +197,7 @@ export const loggedPagesFixtures = sharedTest.extend<
     async ({ browser, pixCertifScoUserData }, use) => {
       const credentials = {
         id: pixCertifScoUserData.id,
-        label: `pix-certif-pro-${pixCertifScoUserData.id}`,
+        label: `pix-certif-sco-${pixCertifScoUserData.id}`,
         firstName: pixCertifScoUserData.firstName,
         lastName: pixCertifScoUserData.lastName,
         email: pixCertifScoUserData.email,

--- a/high-level-tests/e2e-playwright/fixtures/certification/logged-pages.ts
+++ b/high-level-tests/e2e-playwright/fixtures/certification/logged-pages.ts
@@ -3,12 +3,12 @@ import path from 'node:path';
 import { Browser, type BrowserContext, Page } from '@playwright/test';
 
 import { AUTH_DIR, Credentials, HAR_DIR, saveStorageState, shouldRecordHAR } from '../../helpers/auth.ts';
-import { buildPixAdminUser } from '../../helpers/certification/builders/index.ts';
+import { buildCandidate, buildPixAdminUser, buildPixCertifUser } from '../../helpers/certification/builders/index.ts';
 import { pixCertifiableUserData } from '../../helpers/certification/data.ts';
-import { PIX_ADMIN_CERTIF_DATA } from '../../helpers/certification/data.ts';
+import { PIX_ADMIN_CERTIF_DATA, PIX_CERTIF_PRO_DATA, PIX_CERTIF_SCO_DATA } from '../../helpers/certification/data.ts';
+import { getCleaTargetProfileId } from '../../helpers/certification/db.ts';
 import { PixAdminUserData, PixCertifiableUserData, PixCertifUserData } from '../../helpers/certification/types.ts';
 import { knex } from '../../helpers/db.ts';
-import { PIX_CERTIF_PRO_DATA, PIX_CERTIF_SCO_DATA } from '../../helpers/db-data.ts';
 import { test as sharedTest } from '../index.ts';
 
 const pixAppBrowserContextsPerUser = new Map<number, BrowserContext>();
@@ -21,13 +21,12 @@ export const loggedPagesFixtures = sharedTest.extend<
     pixCertifProPage: Page;
     pixCertifScoPage: Page;
     pixCertifInvigilatorPage: Page;
-    getCertifiableUserData: (i: number) => Promise<PixCertifiableUserData>;
+    getCertifiableUserData: (firstName: string) => Promise<PixCertifiableUserData>;
   },
   // worker scoped fixtures (run max once per worker)
   {
     nextId: () => number;
-    userDataMap: Map<object, object>;
-    certifiableUserDatas: PixCertifiableUserData[];
+    userDataMap: Map<string, object>;
     pixCertifProUserData: PixCertifUserData;
     pixCertifScoUserData: PixCertifUserData;
     pixAdminRoleCertifUserData: PixAdminUserData;
@@ -62,16 +61,11 @@ export const loggedPagesFixtures = sharedTest.extend<
     await use(page);
     await page.close();
   },
-  // eslint-disable-next-line no-empty-pattern
-  getCertifiableUserData: async ({}, use) => {
-    const getByIndex = async (index: number) => {
-      const users = await knex('users').whereILike('email', 'pix-app-user-%').orderBy('id');
-      return {
-        ...users[index],
-        ...pixCertifiableUserData[index],
-      };
+  getCertifiableUserData: async ({ userDataMap }, use) => {
+    const getByFirstName = async (searchedEmail: string) => {
+      return userDataMap.get(searchedEmail) as PixCertifiableUserData;
     };
-    await use(getByIndex);
+    await use(getByFirstName);
   },
   nextId: [
     // eslint-disable-next-line no-empty-pattern
@@ -97,36 +91,71 @@ export const loggedPagesFixtures = sharedTest.extend<
   userDataMap: [
     async ({ nextId }, use) => {
       const userDataMap = new Map();
-      const id = nextId();
-      const email = buildUniqueEmailFromId(id, PIX_ADMIN_CERTIF_DATA.email);
-      const adminUserData = {
+      const cleaTargetProfileId = await getCleaTargetProfileId();
+      // admin
+      let id = nextId();
+      let email = buildUniqueEmailFromId(id, PIX_ADMIN_CERTIF_DATA.email);
+      let userData: unknown = {
         ...PIX_ADMIN_CERTIF_DATA,
         id,
         email,
       } as PixAdminUserData;
-      await buildPixAdminUser(knex, adminUserData);
-      userDataMap.set(PIX_ADMIN_CERTIF_DATA, adminUserData);
+      await buildPixAdminUser(knex, userData as PixAdminUserData);
+      userDataMap.set(PIX_ADMIN_CERTIF_DATA.email, userData);
+
+      // pix certif pro
+      id = nextId();
+      email = buildUniqueEmailFromId(id, PIX_CERTIF_PRO_DATA.email);
+      userData = {
+        ...PIX_CERTIF_PRO_DATA,
+        id,
+        email,
+      } as PixCertifUserData;
+      await buildPixCertifUser(knex, userData as PixCertifUserData, cleaTargetProfileId);
+      userDataMap.set(PIX_CERTIF_PRO_DATA.email, userData);
+
+      // pix certif sco
+      id = nextId();
+      email = buildUniqueEmailFromId(id, PIX_CERTIF_SCO_DATA.email);
+      userData = {
+        ...PIX_CERTIF_SCO_DATA,
+        id,
+        email,
+      } as PixCertifUserData;
+      await buildPixCertifUser(knex, userData as PixCertifUserData, cleaTargetProfileId);
+      userDataMap.set(PIX_CERTIF_SCO_DATA.email, userData);
+
+      // certifiable users
+      for (const certifiableUserData of pixCertifiableUserData) {
+        id = nextId();
+        email = buildUniqueEmailFromId(id, certifiableUserData.email);
+        userData = {
+          ...certifiableUserData,
+          id,
+          email,
+        } as PixCertifiableUserData;
+        await buildCandidate(knex, userData as PixCertifiableUserData);
+        userDataMap.set(certifiableUserData.email, userData);
+      }
       await use(userDataMap);
     },
     { scope: 'worker' },
   ],
   pixCertifProUserData: [
-    // eslint-disable-next-line no-empty-pattern
-    async ({}, use) => {
-      await use(PIX_CERTIF_PRO_DATA);
+    async ({ userDataMap }, use) => {
+      await use(userDataMap.get(PIX_CERTIF_PRO_DATA.email) as PixCertifUserData);
     },
     { scope: 'worker' },
   ],
   pixCertifScoUserData: [
-    // eslint-disable-next-line no-empty-pattern
-    async ({}, use) => {
-      await use(PIX_CERTIF_SCO_DATA);
+    async ({ userDataMap }, use) => {
+      await use(userDataMap.get(PIX_CERTIF_SCO_DATA.email) as PixCertifUserData);
     },
     { scope: 'worker' },
   ],
   pixAdminRoleCertifUserData: [
     async ({ userDataMap }, use) => {
-      await use(userDataMap.get(PIX_ADMIN_CERTIF_DATA) as PixAdminUserData);
+      await use(userDataMap.get(PIX_ADMIN_CERTIF_DATA.email) as PixAdminUserData);
     },
     { scope: 'worker' },
   ],

--- a/high-level-tests/e2e-playwright/fixtures/certification/logged-pages.ts
+++ b/high-level-tests/e2e-playwright/fixtures/certification/logged-pages.ts
@@ -18,7 +18,6 @@ export const loggedPagesFixtures = sharedTest.extend<
     pixCertifProPage: Page;
     pixCertifScoPage: Page;
     pixCertifInvigilatorPage: Page;
-    pixOrgaProPage: Page;
     getCertifiableUserData: (i: number) => Promise<PixCertifiableUserData>;
   },
   {
@@ -29,7 +28,6 @@ export const loggedPagesFixtures = sharedTest.extend<
     pixAdminRoleCertifWorkerContext: BrowserContext;
     pixCertifProWorkerContext: BrowserContext;
     pixCertifScoWorkerContext: BrowserContext;
-    pixOrgaProWorkerContext: BrowserContext;
     pixAppCertifiableUserContext: (p: PixCertifiableUserData) => Promise<BrowserContext>;
     pixAppCertifiableUserPage: (p: PixCertifiableUserData) => Promise<Page>;
   }
@@ -37,12 +35,6 @@ export const loggedPagesFixtures = sharedTest.extend<
   pixAdminRoleCertifPage: async ({ pixAdminRoleCertifWorkerContext }, use) => {
     const page = await pixAdminRoleCertifWorkerContext.newPage();
     await page.goto(process.env.PIX_ADMIN_URL!);
-    await use(page);
-    await page.close();
-  },
-  pixOrgaProPage: async ({ pixOrgaProWorkerContext }, use) => {
-    const page = await pixOrgaProWorkerContext.newPage();
-    await page.goto(process.env.PIX_ORGA_URL!);
     await use(page);
     await page.close();
   },
@@ -161,23 +153,6 @@ export const loggedPagesFixtures = sharedTest.extend<
         email: pixCertifScoUserData.email,
         rawPassword: pixCertifScoUserData.rawPassword,
         appUrl: process.env.PIX_CERTIF_URL!,
-      };
-      const context = await setupContext(browser, credentials);
-      await use(context);
-      await context.close();
-    },
-    { scope: 'worker' },
-  ],
-  pixOrgaProWorkerContext: [
-    async ({ browser, pixCertifProUserData }, use) => {
-      const credentials = {
-        id: pixCertifProUserData.id,
-        label: `pix-orga-pro-${pixCertifProUserData.id}`,
-        firstName: pixCertifProUserData.firstName,
-        lastName: pixCertifProUserData.lastName,
-        email: pixCertifProUserData.email,
-        rawPassword: pixCertifProUserData.rawPassword,
-        appUrl: process.env.PIX_ORGA_URL!,
       };
       const context = await setupContext(browser, credentials);
       await use(context);

--- a/high-level-tests/e2e-playwright/fixtures/certification/logged-pages.ts
+++ b/high-level-tests/e2e-playwright/fixtures/certification/logged-pages.ts
@@ -8,7 +8,6 @@ import { pixCertifiableUserData } from '../../helpers/certification/data.ts';
 import { PixAdminUserData, PixCertifiableUserData, PixCertifUserData } from '../../helpers/certification/types.ts';
 import { knex } from '../../helpers/db.ts';
 import { CERTIFICATIONS_DATA } from '../../helpers/db-data.ts';
-import { createUserInDB } from '../../helpers/db-utils.ts';
 import {
   ChallengePage,
   FinalCheckpointPage,
@@ -66,9 +65,14 @@ export const loggedPagesFixtures = sharedTest.extend<
     await use(page);
     await page.close();
   },
-  getCertifiableUserData: async ({ certifiableUserDatas }, use) => {
+  // eslint-disable-next-line no-empty-pattern
+  getCertifiableUserData: async ({}, use) => {
     const getByIndex = async (index: number) => {
-      return certifiableUserDatas[index];
+      const users = await knex('users').whereILike('email', 'pix-app-user-%').orderBy('id');
+      return {
+        ...users[index],
+        ...pixCertifiableUserData[index],
+      };
     };
     await use(getByIndex);
   },
@@ -90,32 +94,6 @@ export const loggedPagesFixtures = sharedTest.extend<
       const nextId: () => number = () => generatorInstance.next().value!;
 
       await use(nextId);
-    },
-    { scope: 'worker' },
-  ],
-  certifiableUserDatas: [
-    async ({ nextId }, use) => {
-      const userDatas = [];
-      let nextUserId = nextId();
-      for (const userData of pixCertifiableUserData) {
-        const finalUserData = {
-          ...userData,
-          id: nextUserId,
-          email: `pix-app-user-${nextUserId}-0@example.net`,
-        };
-        userDatas.push(finalUserData);
-        await createUserInDB(
-          {
-            ...finalUserData,
-            cgu: true,
-            pixCertifTermsOfServiceAccepted: true,
-            mustValidateTermsOfService: false,
-          },
-          knex,
-        );
-        nextUserId = nextId();
-      }
-      await use(userDatas);
     },
     { scope: 'worker' },
   ],

--- a/high-level-tests/e2e-playwright/fixtures/certification/logged-pages.ts
+++ b/high-level-tests/e2e-playwright/fixtures/certification/logged-pages.ts
@@ -3,19 +3,11 @@ import path from 'node:path';
 import { Browser, type BrowserContext, Page } from '@playwright/test';
 
 import { AUTH_DIR, Credentials, HAR_DIR, saveStorageState, shouldRecordHAR } from '../../helpers/auth.ts';
-import { buildPixAdminUser, buildPixCertifUser } from '../../helpers/certification/builders/index.ts';
 import { pixCertifiableUserData } from '../../helpers/certification/data.ts';
 import { PixAdminUserData, PixCertifiableUserData, PixCertifUserData } from '../../helpers/certification/types.ts';
 import { knex } from '../../helpers/db.ts';
-import { CERTIFICATIONS_DATA, PIX_CERTIF_SCO_DATA } from '../../helpers/db-data.ts';
-import {
-  ChallengePage,
-  FinalCheckpointPage,
-  IntermediateCheckpointPage,
-  StartCampaignPage,
-} from '../../pages/pix-app/index.ts';
-import { PixOrgaPage } from '../../pages/pix-orga/index.ts';
-import { expect, test as sharedTest } from '../index.ts';
+import { PIX_ADMIN_CERTIF_DATA, PIX_CERTIF_PRO_DATA, PIX_CERTIF_SCO_DATA } from '../../helpers/db-data.ts';
+import { test as sharedTest } from '../index.ts';
 
 const pixAppBrowserContextsPerUser = new Map<number, BrowserContext>();
 const pixAppPages: Page[] = [];
@@ -30,7 +22,6 @@ export const loggedPagesFixtures = sharedTest.extend<
     getCertifiableUserData: (i: number) => Promise<PixCertifiableUserData>;
   },
   {
-    nextId: () => number;
     certifiableUserDatas: PixCertifiableUserData[];
     pixCertifProUserData: PixCertifUserData;
     pixCertifScoUserData: PixCertifUserData;
@@ -41,7 +32,6 @@ export const loggedPagesFixtures = sharedTest.extend<
     pixOrgaProWorkerContext: BrowserContext;
     pixAppCertifiableUserContext: (p: PixCertifiableUserData) => Promise<BrowserContext>;
     pixAppCertifiableUserPage: (p: PixCertifiableUserData) => Promise<Page>;
-    makeUserCertifiableAndReadyForClea: (p: Page) => Promise<void>;
   }
 >({
   pixAdminRoleCertifPage: async ({ pixAdminRoleCertifWorkerContext }, use) => {
@@ -85,7 +75,7 @@ export const loggedPagesFixtures = sharedTest.extend<
     };
     await use(getByIndex);
   },
-  nextId: [
+  /*nextId: [
     // eslint-disable-next-line no-empty-pattern
     async ({}, use, workerInfo) => {
       const shardOffset = (workerInfo.config.shard?.current ?? 0) * 100;
@@ -105,34 +95,11 @@ export const loggedPagesFixtures = sharedTest.extend<
       await use(nextId);
     },
     { scope: 'worker' },
-  ],
+  ],*/
   pixCertifProUserData: [
-    async ({ nextId }, use) => {
-      const nextUserId = nextId();
-      const certifProUserData: PixCertifUserData = {
-        id: nextUserId,
-        firstName: 'pixCertifPro',
-        lastName: `pixCertifPro${nextUserId}`,
-        email: `pix-certif-pro-${nextUserId}@example.net`,
-        rawPassword: 'pix123',
-        certificationCenters: [
-          {
-            type: 'PRO',
-            externalId: `CERTIFPRO${nextUserId}`,
-            habilitations: [
-              CERTIFICATIONS_DATA.CLEA,
-              CERTIFICATIONS_DATA.EDU_1ER_DEGRE,
-              CERTIFICATIONS_DATA.DROIT,
-              CERTIFICATIONS_DATA.PRO_SANTE,
-            ],
-            withOrganization: {
-              isManagingStudents: false,
-            },
-          },
-        ],
-      };
-      await buildPixCertifUser(knex, certifProUserData);
-      await use(certifProUserData);
+    // eslint-disable-next-line no-empty-pattern
+    async ({}, use) => {
+      await use(PIX_CERTIF_PRO_DATA);
     },
     { scope: 'worker' },
   ],
@@ -144,18 +111,9 @@ export const loggedPagesFixtures = sharedTest.extend<
     { scope: 'worker' },
   ],
   pixAdminRoleCertifUserData: [
-    async ({ nextId }, use) => {
-      const nextUserId = nextId();
-      const adminUserData: PixAdminUserData = {
-        id: nextUserId,
-        firstName: 'pixAdminRoleCertif',
-        lastName: `pixAdminRoleCertif${nextUserId}`,
-        email: `pix-admin-role-certif-${nextUserId}@example.net`,
-        rawPassword: 'pix123',
-        role: 'CERTIF',
-      };
-      await buildPixAdminUser(knex, adminUserData);
-      await use(adminUserData);
+    // eslint-disable-next-line no-empty-pattern
+    async ({}, use) => {
+      await use(PIX_ADMIN_CERTIF_DATA as PixAdminUserData);
     },
     { scope: 'worker' },
   ],
@@ -228,7 +186,7 @@ export const loggedPagesFixtures = sharedTest.extend<
     { scope: 'worker' },
   ],
   pixAppCertifiableUserContext: [
-    async ({ browser, makeUserCertifiableAndReadyForClea }, use) => {
+    async ({ browser }, use) => {
       const createContextForUser = async (certifiableUserData: PixCertifiableUserData) => {
         if (pixAppBrowserContextsPerUser.has(certifiableUserData.id)) {
           return pixAppBrowserContextsPerUser.get(certifiableUserData.id)!;
@@ -244,9 +202,6 @@ export const loggedPagesFixtures = sharedTest.extend<
         };
         const context = await setupContext(browser, credentials);
         pixAppBrowserContextsPerUser.set(certifiableUserData.id, context);
-        const page = await context.newPage();
-        await makeUserCertifiableAndReadyForClea(page);
-        await page.close();
         return context;
       };
       await use(createContextForUser);
@@ -277,48 +232,6 @@ export const loggedPagesFixtures = sharedTest.extend<
       for (const page of pixAppPages) {
         await page.close();
       }
-    },
-    { scope: 'worker' },
-  ],
-  makeUserCertifiableAndReadyForClea: [
-    async ({ pixOrgaProWorkerContext }, use) => {
-      const prepareUser = async (pixApp: Page) => {
-        const pixOrgaProPage = await pixOrgaProWorkerContext.newPage();
-        await pixOrgaProPage.goto(process.env.PIX_ORGA_URL!);
-        const pixOrgaPage = new PixOrgaPage(pixOrgaProPage);
-        let campaignCode: string | null;
-        await sharedTest.step('creates the CLEA campaign', async () => {
-          await pixOrgaProPage.getByRole('link', { name: 'Campagnes', exact: true }).click();
-          await pixOrgaProPage.getByRole('link', { name: 'Créer une campagne' }).click();
-          await pixOrgaPage.createEvaluationCampaign({
-            campaignName: 'CLEA campagne',
-            targetProfileName: 'Parcours complet CléA numérique',
-          });
-          campaignCode = await pixOrgaProPage.locator('dd.campaign-header-title__campaign-code > span').textContent();
-        });
-
-        await sharedTest.step('user enters campaign and answers correctly all the way to the end', async () => {
-          await pixApp.goto(process.env.PIX_APP_URL!);
-          await pixApp.getByRole('link', { name: "J'ai un code" }).click();
-          const startCampaignPage = new StartCampaignPage(pixApp);
-          await startCampaignPage.goToFirstChallenge(campaignCode as string);
-          while (!pixApp.url().includes('finalCheckpoint=true')) {
-            const challengePage = new ChallengePage(pixApp);
-            await challengePage.setRightOrWrongAnswer(true);
-            await challengePage.validateAnswer();
-            if (pixApp.url().includes('/checkpoint') && !pixApp.url().includes('finalCheckpoint=true')) {
-              const checkpointPage = new IntermediateCheckpointPage(pixApp);
-              await checkpointPage.goNext();
-            }
-          }
-          const finalCheckpointPage = new FinalCheckpointPage(pixApp);
-          await finalCheckpointPage.goToResults();
-          await expect(
-            pixApp.getByRole('paragraph').filter({ hasText: 'Vos résultats ont été envoyés' }),
-          ).toBeVisible();
-        });
-      };
-      await use(prepareUser);
     },
     { scope: 'worker' },
   ],

--- a/high-level-tests/e2e-playwright/fixtures/certification/logged-pages.ts
+++ b/high-level-tests/e2e-playwright/fixtures/certification/logged-pages.ts
@@ -24,6 +24,7 @@ export const loggedPagesFixtures = sharedTest.extend<
   {
     pixAdminRoleCertifPage: Page;
     pixCertifProPage: Page;
+    pixCertifScoPage: Page;
     pixCertifInvigilatorPage: Page;
     pixOrgaProPage: Page;
     getCertifiableUserData: (i: number) => Promise<PixCertifiableUserData>;
@@ -32,9 +33,11 @@ export const loggedPagesFixtures = sharedTest.extend<
     nextId: () => number;
     certifiableUserDatas: PixCertifiableUserData[];
     pixCertifProUserData: PixCertifUserData;
+    pixCertifScoUserData: PixCertifUserData;
     pixAdminRoleCertifUserData: PixAdminUserData;
     pixAdminRoleCertifWorkerContext: BrowserContext;
     pixCertifProWorkerContext: BrowserContext;
+    pixCertifScoWorkerContext: BrowserContext;
     pixOrgaProWorkerContext: BrowserContext;
     pixAppCertifiableUserContext: (p: PixCertifiableUserData) => Promise<BrowserContext>;
     pixAppCertifiableUserPage: (p: PixCertifiableUserData) => Promise<Page>;
@@ -55,6 +58,12 @@ export const loggedPagesFixtures = sharedTest.extend<
   },
   pixCertifProPage: async ({ pixCertifProWorkerContext }, use) => {
     const page = await pixCertifProWorkerContext.newPage();
+    await page.goto(process.env.PIX_CERTIF_URL!);
+    await use(page);
+    await page.close();
+  },
+  pixCertifScoPage: async ({ pixCertifScoWorkerContext }, use) => {
+    const page = await pixCertifScoWorkerContext.newPage();
     await page.goto(process.env.PIX_CERTIF_URL!);
     await use(page);
     await page.close();
@@ -127,6 +136,31 @@ export const loggedPagesFixtures = sharedTest.extend<
     },
     { scope: 'worker' },
   ],
+  pixCertifScoUserData: [
+    async ({ nextId }, use) => {
+      const nextUserId = nextId();
+      const certifScoUserData: PixCertifUserData = {
+        id: nextUserId,
+        firstName: 'pixCertifSco',
+        lastName: `pixCertifSco${nextUserId}`,
+        email: `pix-certif-pro-${nextUserId}@example.net`,
+        rawPassword: 'pix123',
+        certificationCenters: [
+          {
+            type: 'SCO',
+            externalId: `CERTIFSCO${nextUserId}`,
+            habilitations: [],
+            withOrganization: {
+              isManagingStudents: true,
+            },
+          },
+        ],
+      };
+      await buildPixCertifUser(knex, certifScoUserData);
+      await use(certifScoUserData);
+    },
+    { scope: 'worker' },
+  ],
   pixAdminRoleCertifUserData: [
     async ({ nextId }, use) => {
       const nextUserId = nextId();
@@ -169,6 +203,23 @@ export const loggedPagesFixtures = sharedTest.extend<
         lastName: pixCertifProUserData.lastName,
         email: pixCertifProUserData.email,
         rawPassword: pixCertifProUserData.rawPassword,
+        appUrl: process.env.PIX_CERTIF_URL!,
+      };
+      const context = await setupContext(browser, credentials);
+      await use(context);
+      await context.close();
+    },
+    { scope: 'worker' },
+  ],
+  pixCertifScoWorkerContext: [
+    async ({ browser, pixCertifScoUserData }, use) => {
+      const credentials = {
+        id: pixCertifScoUserData.id,
+        label: `pix-certif-pro-${pixCertifScoUserData.id}`,
+        firstName: pixCertifScoUserData.firstName,
+        lastName: pixCertifScoUserData.lastName,
+        email: pixCertifScoUserData.email,
+        rawPassword: pixCertifScoUserData.rawPassword,
         appUrl: process.env.PIX_CERTIF_URL!,
       };
       const context = await setupContext(browser, credentials);

--- a/high-level-tests/e2e-playwright/fixtures/certification/logged-pages.ts
+++ b/high-level-tests/e2e-playwright/fixtures/certification/logged-pages.ts
@@ -3,16 +3,19 @@ import path from 'node:path';
 import { Browser, type BrowserContext, Page } from '@playwright/test';
 
 import { AUTH_DIR, Credentials, HAR_DIR, saveStorageState, shouldRecordHAR } from '../../helpers/auth.ts';
+import { buildPixAdminUser } from '../../helpers/certification/builders/index.ts';
 import { pixCertifiableUserData } from '../../helpers/certification/data.ts';
+import { PIX_ADMIN_CERTIF_DATA } from '../../helpers/certification/data.ts';
 import { PixAdminUserData, PixCertifiableUserData, PixCertifUserData } from '../../helpers/certification/types.ts';
 import { knex } from '../../helpers/db.ts';
-import { PIX_ADMIN_CERTIF_DATA, PIX_CERTIF_PRO_DATA, PIX_CERTIF_SCO_DATA } from '../../helpers/db-data.ts';
+import { PIX_CERTIF_PRO_DATA, PIX_CERTIF_SCO_DATA } from '../../helpers/db-data.ts';
 import { test as sharedTest } from '../index.ts';
 
 const pixAppBrowserContextsPerUser = new Map<number, BrowserContext>();
 const pixAppPages: Page[] = [];
 
 export const loggedPagesFixtures = sharedTest.extend<
+  // test scoped fixtures
   {
     pixAdminRoleCertifPage: Page;
     pixCertifProPage: Page;
@@ -20,7 +23,10 @@ export const loggedPagesFixtures = sharedTest.extend<
     pixCertifInvigilatorPage: Page;
     getCertifiableUserData: (i: number) => Promise<PixCertifiableUserData>;
   },
+  // worker scoped fixtures (run max once per worker)
   {
+    nextId: () => number;
+    userDataMap: Map<object, object>;
     certifiableUserDatas: PixCertifiableUserData[];
     pixCertifProUserData: PixCertifUserData;
     pixCertifScoUserData: PixCertifUserData;
@@ -67,7 +73,7 @@ export const loggedPagesFixtures = sharedTest.extend<
     };
     await use(getByIndex);
   },
-  /*nextId: [
+  nextId: [
     // eslint-disable-next-line no-empty-pattern
     async ({}, use, workerInfo) => {
       const shardOffset = (workerInfo.config.shard?.current ?? 0) * 100;
@@ -87,7 +93,23 @@ export const loggedPagesFixtures = sharedTest.extend<
       await use(nextId);
     },
     { scope: 'worker' },
-  ],*/
+  ],
+  userDataMap: [
+    async ({ nextId }, use) => {
+      const userDataMap = new Map();
+      const id = nextId();
+      const email = buildUniqueEmailFromId(id, PIX_ADMIN_CERTIF_DATA.email);
+      const adminUserData = {
+        ...PIX_ADMIN_CERTIF_DATA,
+        id,
+        email,
+      } as PixAdminUserData;
+      await buildPixAdminUser(knex, adminUserData);
+      userDataMap.set(PIX_ADMIN_CERTIF_DATA, adminUserData);
+      await use(userDataMap);
+    },
+    { scope: 'worker' },
+  ],
   pixCertifProUserData: [
     // eslint-disable-next-line no-empty-pattern
     async ({}, use) => {
@@ -103,9 +125,8 @@ export const loggedPagesFixtures = sharedTest.extend<
     { scope: 'worker' },
   ],
   pixAdminRoleCertifUserData: [
-    // eslint-disable-next-line no-empty-pattern
-    async ({}, use) => {
-      await use(PIX_ADMIN_CERTIF_DATA as PixAdminUserData);
+    async ({ userDataMap }, use) => {
+      await use(userDataMap.get(PIX_ADMIN_CERTIF_DATA) as PixAdminUserData);
     },
     { scope: 'worker' },
   ],
@@ -228,4 +249,9 @@ async function setupContext(browser: Browser, credentials: Credentials) {
     recordHar,
     permissions: ['clipboard-read', 'clipboard-write'],
   });
+}
+
+function buildUniqueEmailFromId(id: number, email: string) {
+  const [username, domain] = email.split('@');
+  return `${username}${id}@${domain}`;
 }

--- a/high-level-tests/e2e-playwright/helpers/certification/builders/build-candidate.ts
+++ b/high-level-tests/e2e-playwright/helpers/certification/builders/build-candidate.ts
@@ -1,10 +1,14 @@
 import { Knex } from 'knex';
 
 import { CERTIFICATIONS_DATA } from '../../db-data.ts';
-import { createOrganizationLearnerInDb, createUserInDB } from '../../db-utils.ts';
+import { createOrganizationLearnerInDB, createUserInDB } from '../../db-utils.ts';
 import { PixCertifiableUserData } from '../types.ts';
 
-export async function buildCandidate(knex: Knex, userData: PixCertifiableUserData): Promise<void> {
+export async function buildCandidate(
+  knex: Knex,
+  userData: PixCertifiableUserData,
+  organizationScoId: number,
+): Promise<void> {
   const finalUserData = {
     ...userData,
     cgu: true,
@@ -13,24 +17,21 @@ export async function buildCandidate(knex: Knex, userData: PixCertifiableUserDat
   };
   await createUserInDB(finalUserData, knex);
 
-  const organizationIds = await knex('organizations').pluck('id');
-  for (const organizationId of organizationIds) {
-    const organizationLearnerId = await createOrganizationLearnerInDb(
-      {
-        organizationId,
-        userId: userData.id,
-        firstName: finalUserData.firstName,
-        lastName: finalUserData.lastName,
-        birthdate: finalUserData.birthdate,
-        birthCountryCode: '100',
-        birthCity: finalUserData.birthCity,
-        sex: finalUserData.sex,
-      },
-      knex,
-    );
+  const organizationLearnerId = await createOrganizationLearnerInDB(
+    {
+      organizationId: organizationScoId,
+      userId: userData.id,
+      firstName: finalUserData.firstName,
+      lastName: finalUserData.lastName,
+      birthdate: finalUserData.birthdate,
+      birthCountryCode: '100',
+      isDisabled: false,
+      nationalStudentId: `${finalUserData.firstName}${userData.id}`,
+    },
+    knex,
+  );
 
-    await makeUserReadyForCleaAndCertifiable(knex, organizationId, userData.id, organizationLearnerId);
-  }
+  await makeUserReadyForCleaAndCertifiable(knex, organizationScoId, userData.id, organizationLearnerId);
 }
 
 async function makeUserReadyForCleaAndCertifiable(

--- a/high-level-tests/e2e-playwright/helpers/certification/builders/build-candidate.ts
+++ b/high-level-tests/e2e-playwright/helpers/certification/builders/build-candidate.ts
@@ -2,25 +2,23 @@ import { Knex } from 'knex';
 
 import { CERTIFICATIONS_DATA } from '../../db-data.ts';
 import { createOrganizationLearnerInDb, createUserInDB } from '../../db-utils.ts';
-import { pixCertifiableUserData } from '../data.ts';
+import { PixCertifiableUserData } from '../types.ts';
 
-export async function buildCandidates(knex: Knex, organizationId: number): Promise<void> {
-  let userId = 1_000_000_000;
-  for (const userData of pixCertifiableUserData) {
-    const finalUserData = {
-      ...userData,
-      id: userId,
-      email: `pix-app-user-${userId}-0@example.net`,
-      cgu: true,
-      pixCertifTermsOfServiceAccepted: true,
-      mustValidateTermsOfService: false,
-    };
-    await createUserInDB(finalUserData, knex);
+export async function buildCandidate(knex: Knex, userData: PixCertifiableUserData): Promise<void> {
+  const finalUserData = {
+    ...userData,
+    cgu: true,
+    pixCertifTermsOfServiceAccepted: true,
+    mustValidateTermsOfService: false,
+  };
+  await createUserInDB(finalUserData, knex);
 
+  const organizationIds = await knex('organizations').pluck('id');
+  for (const organizationId of organizationIds) {
     const organizationLearnerId = await createOrganizationLearnerInDb(
       {
         organizationId,
-        userId,
+        userId: userData.id,
         firstName: finalUserData.firstName,
         lastName: finalUserData.lastName,
         birthdate: finalUserData.birthdate,
@@ -31,9 +29,7 @@ export async function buildCandidates(knex: Knex, organizationId: number): Promi
       knex,
     );
 
-    await makeUserReadyForCleaAndCertifiable(knex, organizationId, userId, organizationLearnerId);
-
-    userId++;
+    await makeUserReadyForCleaAndCertifiable(knex, organizationId, userData.id, organizationLearnerId);
   }
 }
 

--- a/high-level-tests/e2e-playwright/helpers/certification/builders/build-candidates.ts
+++ b/high-level-tests/e2e-playwright/helpers/certification/builders/build-candidates.ts
@@ -1,5 +1,6 @@
 import { Knex } from 'knex';
 
+import { CERTIFICATIONS_DATA } from '../../db-data.ts';
 import { createOrganizationLearnerInDb, createUserInDB } from '../../db-utils.ts';
 import { pixCertifiableUserData } from '../data.ts';
 
@@ -16,7 +17,7 @@ export async function buildCandidates(knex: Knex, organizationId: number): Promi
     };
     await createUserInDB(finalUserData, knex);
 
-    await createOrganizationLearnerInDb(
+    const organizationLearnerId = await createOrganizationLearnerInDb(
       {
         organizationId,
         userId,
@@ -30,6 +31,52 @@ export async function buildCandidates(knex: Knex, organizationId: number): Promi
       knex,
     );
 
+    await makeUserReadyForCleaAndCertifiable(knex, organizationId, userId, organizationLearnerId);
+
     userId++;
   }
+}
+
+async function makeUserReadyForCleaAndCertifiable(
+  knex: Knex,
+  organizationId: number,
+  userId: number,
+  organizationLearnerId: number,
+) {
+  const [campaignId] = await knex('campaigns').pluck('id').where({ organizationId });
+  const skillIds = await knex('campaign_skills').pluck('skillId').where({ campaignId });
+  const [{ id: campaignParticipationId }] = await knex('campaign-participations')
+    .insert({
+      campaignId,
+      sharedAt: new Date(),
+      userId,
+      validatedSkillsCount: skillIds.length,
+      isImproved: false,
+      masteryRate: 1,
+      pixScore: 875,
+      status: 'SHARED',
+      organizationLearnerId,
+      isCertifiable: true,
+    })
+    .returning('id');
+  const [badgeId] = await knex('badges').pluck('id').where({ key: CERTIFICATIONS_DATA.CLEA });
+  await knex('badge-acquisitions').insert({
+    userId,
+    campaignParticipationId,
+    badgeId,
+  });
+  const keData = [];
+  const skillData = await knex('learningcontent.skills').select(['id', 'competenceId', 'pixValue']);
+  const skillMap = new Map(skillData.map((s) => [s.id, { competenceId: s.competenceId, earnedPix: s.pixValue }]));
+  for (const skillId of skillIds) {
+    keData.push({
+      source: 'direct',
+      status: 'validated',
+      skillId,
+      earnedPix: skillMap.get(skillId)?.earnedPix,
+      userId,
+      competenceId: skillMap.get(skillId)?.competenceId,
+    });
+  }
+  await knex('knowledge-elements').insert(keData);
 }

--- a/high-level-tests/e2e-playwright/helpers/certification/builders/build-candidates.ts
+++ b/high-level-tests/e2e-playwright/helpers/certification/builders/build-candidates.ts
@@ -3,7 +3,7 @@ import { Knex } from 'knex';
 import { createOrganizationLearnerInDb, createUserInDB } from '../../db-utils.ts';
 import { pixCertifiableUserData } from '../data.ts';
 
-export async function buildCertifiableUsers(knex: Knex, organizationId: number): Promise<void> {
+export async function buildCandidates(knex: Knex, organizationId: number): Promise<void> {
   let userId = 1_000_000_000;
   for (const userData of pixCertifiableUserData) {
     const finalUserData = {

--- a/high-level-tests/e2e-playwright/helpers/certification/builders/build-certifiable-users.ts
+++ b/high-level-tests/e2e-playwright/helpers/certification/builders/build-certifiable-users.ts
@@ -1,0 +1,28 @@
+import { Knex } from 'knex';
+
+import { createUserInDB } from '../../db-utils.ts';
+import { pixCertifiableUserData } from '../data.ts';
+
+export async function buildCertifiableUsers(knex: Knex) {
+  let userId = 1_000_000_000;
+  for (const userData of pixCertifiableUserData) {
+    const finalUserData = {
+      ...userData,
+      id: userId,
+      email: `pix-app-user-${userId}-0@example.net`,
+    };
+    await createUserInDB(
+      {
+        ...finalUserData,
+        cgu: true,
+        pixCertifTermsOfServiceAccepted: true,
+        mustValidateTermsOfService: false,
+      },
+      knex,
+    );
+
+    userId++;
+  }
+
+  return knex('users').whereILike('email', 'pix-app-user-%').orderBy('id');
+}

--- a/high-level-tests/e2e-playwright/helpers/certification/builders/build-certifiable-users.ts
+++ b/high-level-tests/e2e-playwright/helpers/certification/builders/build-certifiable-users.ts
@@ -17,7 +17,16 @@ export async function buildCertifiableUsers(knex: Knex, organizationId: number):
     await createUserInDB(finalUserData, knex);
 
     await createOrganizationLearnerInDb(
-      { organizationId, userId, firstName: finalUserData.firstName, lastName: finalUserData.lastName },
+      {
+        organizationId,
+        userId,
+        firstName: finalUserData.firstName,
+        lastName: finalUserData.lastName,
+        birthdate: finalUserData.birthdate,
+        birthCountryCode: '100',
+        birthCity: finalUserData.birthCity,
+        sex: finalUserData.sex,
+      },
       knex,
     );
 

--- a/high-level-tests/e2e-playwright/helpers/certification/builders/build-certifiable-users.ts
+++ b/high-level-tests/e2e-playwright/helpers/certification/builders/build-certifiable-users.ts
@@ -17,7 +17,7 @@ export async function buildCertifiableUsers(knex: Knex, organizationId: number):
     await createUserInDB(finalUserData, knex);
 
     await createOrganizationLearnerInDb(
-      { organizationId, firstName: finalUserData.firstName, lastName: finalUserData.lastName },
+      { organizationId, userId, firstName: finalUserData.firstName, lastName: finalUserData.lastName },
       knex,
     );
 

--- a/high-level-tests/e2e-playwright/helpers/certification/builders/build-certifiable-users.ts
+++ b/high-level-tests/e2e-playwright/helpers/certification/builders/build-certifiable-users.ts
@@ -1,28 +1,26 @@
 import { Knex } from 'knex';
 
-import { createUserInDB } from '../../db-utils.ts';
+import { createOrganizationLearnerInDb, createUserInDB } from '../../db-utils.ts';
 import { pixCertifiableUserData } from '../data.ts';
 
-export async function buildCertifiableUsers(knex: Knex) {
+export async function buildCertifiableUsers(knex: Knex, organizationId: number): Promise<void> {
   let userId = 1_000_000_000;
   for (const userData of pixCertifiableUserData) {
     const finalUserData = {
       ...userData,
       id: userId,
       email: `pix-app-user-${userId}-0@example.net`,
+      cgu: true,
+      pixCertifTermsOfServiceAccepted: true,
+      mustValidateTermsOfService: false,
     };
-    await createUserInDB(
-      {
-        ...finalUserData,
-        cgu: true,
-        pixCertifTermsOfServiceAccepted: true,
-        mustValidateTermsOfService: false,
-      },
+    await createUserInDB(finalUserData, knex);
+
+    await createOrganizationLearnerInDb(
+      { organizationId, firstName: finalUserData.firstName, lastName: finalUserData.lastName },
       knex,
     );
 
     userId++;
   }
-
-  return knex('users').whereILike('email', 'pix-app-user-%').orderBy('id');
 }

--- a/high-level-tests/e2e-playwright/helpers/certification/builders/build-clea-data.ts
+++ b/high-level-tests/e2e-playwright/helpers/certification/builders/build-clea-data.ts
@@ -3,7 +3,7 @@ import { Knex } from 'knex';
 import { createTargetProfileInDB, createTargetProfileTubesInDB } from '../../db.ts';
 import { CERTIFICATIONS_DATA } from '../../db-data.ts';
 
-export async function buildCleaData(knex: Knex) {
+export async function buildCleaData(knex: Knex): Promise<number> {
   const { id: cleaCertificationId } = await knex('complementary-certifications')
     .select('id')
     .where({ key: CERTIFICATIONS_DATA.CLEA })
@@ -41,6 +41,7 @@ export async function buildCleaData(knex: Knex) {
     createdAt: new Date('2021-01-01'),
     minimumEarnedPix: 256,
   });
+  return cleaTargetProfileId;
 }
 
 async function buildTargetProfile(knex: Knex) {

--- a/high-level-tests/e2e-playwright/helpers/certification/builders/build-pix-admin-user.ts
+++ b/high-level-tests/e2e-playwright/helpers/certification/builders/build-pix-admin-user.ts
@@ -18,4 +18,5 @@ export async function buildPixAdminUser(knex: Knex, userData: PixAdminUserData) 
     knex,
   );
   await knex('pix-admin-roles').insert({ userId: adminUserId, role: userData.role });
+  return adminUserId;
 }

--- a/high-level-tests/e2e-playwright/helpers/certification/builders/build-pix-certif-user.ts
+++ b/high-level-tests/e2e-playwright/helpers/certification/builders/build-pix-certif-user.ts
@@ -9,7 +9,9 @@ import {
 } from '../../db-utils.ts';
 import { PixCertifUserData } from '../types.ts';
 
-export async function buildPixCertifUser(knex: Knex, userData: PixCertifUserData) {
+const CLEA_SKILLS_CACHE: string[] = [];
+
+export async function buildPixCertifUser(knex: Knex, userData: PixCertifUserData, cleaTargetProfileId: number) {
   let organizationId;
   const certificationUserId = await createUserInDB(
     {
@@ -54,7 +56,36 @@ export async function buildPixCertifUser(knex: Knex, userData: PixCertifUserData
       for (const targetProfileId of allTargetProfileIds) {
         await knex('target-profile-shares').insert({ targetProfileId, organizationId });
       }
+      await createCleaCampaign(knex, organizationId, certificationUserId, cleaTargetProfileId);
     }
   }
   return organizationId;
+}
+
+async function createCleaCampaign(knex: Knex, organizationId: number, userId: number, cleaTargetProfileId: number) {
+  const [{ id: campaignId }] = await knex('campaigns')
+    .insert({
+      name: 'Campagne CLEA',
+      code: `CLEACODE${organizationId}`,
+      organizationId,
+      creatorId: userId,
+      targetProfileId: cleaTargetProfileId,
+      type: 'ASSESSMENT',
+      ownerId: userId,
+    })
+    .returning('id');
+
+  if (CLEA_SKILLS_CACHE.length === 0) {
+    const targetProfileTubes = await knex('target-profile_tubes').select(['level', 'tubeId']).where({
+      targetProfileId: cleaTargetProfileId,
+    });
+    for (const { level, tubeId } of targetProfileTubes) {
+      const skillIdsForTube = await knex('learningcontent.skills')
+        .pluck('id')
+        .where({ tubeId })
+        .andWhere('level', '<=', level);
+      CLEA_SKILLS_CACHE.push(...skillIdsForTube);
+    }
+  }
+  await knex('campaign_skills').insert(CLEA_SKILLS_CACHE.map((skillId) => ({ skillId, campaignId })));
 }

--- a/high-level-tests/e2e-playwright/helpers/certification/builders/build-pix-certif-user.ts
+++ b/high-level-tests/e2e-playwright/helpers/certification/builders/build-pix-certif-user.ts
@@ -12,7 +12,6 @@ import { PixCertifUserData } from '../types.ts';
 const CLEA_SKILLS_CACHE: string[] = [];
 
 export async function buildPixCertifUser(knex: Knex, userData: PixCertifUserData, cleaTargetProfileId: number | null) {
-  let organizationId;
   const certificationUserId = await createUserInDB(
     {
       firstName: userData.firstName,
@@ -27,10 +26,11 @@ export async function buildPixCertifUser(knex: Knex, userData: PixCertifUserData
     knex,
   );
   for (const certificationCenter of userData.certificationCenters) {
+    const finalExternalId = `${certificationCenter.externalId}_${certificationUserId}`;
     const certificationCenterId = await createCertificationCenterInDB(
       {
         type: certificationCenter.type,
-        externalId: certificationCenter.externalId,
+        externalId: finalExternalId,
       },
       knex,
     );
@@ -39,9 +39,9 @@ export async function buildPixCertifUser(knex: Knex, userData: PixCertifUserData
       await createCertificationCenterHabilitationInDB({ certificationCenterId, key: habilitationKey }, knex);
     }
     if (certificationCenter.withOrganization) {
-      organizationId = await createOrganizationInDB({
+      const organizationId = await createOrganizationInDB({
         type: certificationCenter.type,
-        externalId: certificationCenter.externalId,
+        externalId: finalExternalId,
         isManagingStudents: certificationCenter.withOrganization.isManagingStudents,
       });
       await createOrganizationMembershipInDB(certificationUserId, organizationId, 'MEMBER');
@@ -54,7 +54,6 @@ export async function buildPixCertifUser(knex: Knex, userData: PixCertifUserData
       }
     }
   }
-  return organizationId;
 }
 
 async function createCleaCampaign(knex: Knex, organizationId: number, userId: number, cleaTargetProfileId: number) {

--- a/high-level-tests/e2e-playwright/helpers/certification/builders/build-pix-certif-user.ts
+++ b/high-level-tests/e2e-playwright/helpers/certification/builders/build-pix-certif-user.ts
@@ -10,6 +10,7 @@ import {
 import { PixCertifUserData } from '../types.ts';
 
 export async function buildPixCertifUser(knex: Knex, userData: PixCertifUserData) {
+  let organizationId;
   const certificationUserId = await createUserInDB(
     {
       firstName: userData.firstName,
@@ -43,7 +44,7 @@ export async function buildPixCertifUser(knex: Knex, userData: PixCertifUserData
         userId: certificationUserId,
         acceptedAt: someDate,
       });
-      const organizationId = await createOrganizationInDB({
+      organizationId = await createOrganizationInDB({
         type: certificationCenter.type,
         externalId: certificationCenter.externalId,
         isManagingStudents: certificationCenter.withOrganization.isManagingStudents,
@@ -55,4 +56,5 @@ export async function buildPixCertifUser(knex: Knex, userData: PixCertifUserData
       }
     }
   }
+  return organizationId;
 }

--- a/high-level-tests/e2e-playwright/helpers/certification/builders/build-pix-certif-user.ts
+++ b/high-level-tests/e2e-playwright/helpers/certification/builders/build-pix-certif-user.ts
@@ -11,7 +11,7 @@ import { PixCertifUserData } from '../types.ts';
 
 const CLEA_SKILLS_CACHE: string[] = [];
 
-export async function buildPixCertifUser(knex: Knex, userData: PixCertifUserData, cleaTargetProfileId: number) {
+export async function buildPixCertifUser(knex: Knex, userData: PixCertifUserData, cleaTargetProfileId: number | null) {
   let organizationId;
   const certificationUserId = await createUserInDB(
     {
@@ -39,13 +39,6 @@ export async function buildPixCertifUser(knex: Knex, userData: PixCertifUserData
       await createCertificationCenterHabilitationInDB({ certificationCenterId, key: habilitationKey }, knex);
     }
     if (certificationCenter.withOrganization) {
-      const { id: legalDocumentVersionId } = await knex('legal-document-versions').select('id').first();
-      const someDate = new Date('2025-07-09');
-      await knex('legal-document-version-user-acceptances').insert({
-        legalDocumentVersionId,
-        userId: certificationUserId,
-        acceptedAt: someDate,
-      });
       organizationId = await createOrganizationInDB({
         type: certificationCenter.type,
         externalId: certificationCenter.externalId,
@@ -56,7 +49,9 @@ export async function buildPixCertifUser(knex: Knex, userData: PixCertifUserData
       for (const targetProfileId of allTargetProfileIds) {
         await knex('target-profile-shares').insert({ targetProfileId, organizationId });
       }
-      await createCleaCampaign(knex, organizationId, certificationUserId, cleaTargetProfileId);
+      if (cleaTargetProfileId) {
+        await createCleaCampaign(knex, organizationId, certificationUserId, cleaTargetProfileId);
+      }
     }
   }
   return organizationId;

--- a/high-level-tests/e2e-playwright/helpers/certification/builders/index.ts
+++ b/high-level-tests/e2e-playwright/helpers/certification/builders/index.ts
@@ -1,4 +1,4 @@
-export { buildCertifiableUsers } from './build-certifiable-users.ts';
+export { buildCandidates } from './build-candidates.ts';
 export { buildCleaData } from './build-clea-data.ts';
 export { buildCoreVersion } from './build-core-version.ts';
 export { buildCpfData } from './build-cpf-data.ts';

--- a/high-level-tests/e2e-playwright/helpers/certification/builders/index.ts
+++ b/high-level-tests/e2e-playwright/helpers/certification/builders/index.ts
@@ -1,4 +1,4 @@
-export { buildCandidates } from './build-candidates.ts';
+export { buildCandidate } from './build-candidate.ts';
 export { buildCleaData } from './build-clea-data.ts';
 export { buildCoreVersion } from './build-core-version.ts';
 export { buildCpfData } from './build-cpf-data.ts';

--- a/high-level-tests/e2e-playwright/helpers/certification/builders/index.ts
+++ b/high-level-tests/e2e-playwright/helpers/certification/builders/index.ts
@@ -1,3 +1,4 @@
+export { buildCertifiableUsers } from './build-certifiable-users.ts';
 export { buildCleaData } from './build-clea-data.ts';
 export { buildCoreVersion } from './build-core-version.ts';
 export { buildCpfData } from './build-cpf-data.ts';

--- a/high-level-tests/e2e-playwright/helpers/certification/data.ts
+++ b/high-level-tests/e2e-playwright/helpers/certification/data.ts
@@ -4,6 +4,7 @@ export const pixCertifiableUserData = [
   {
     firstName: 'Buffy',
     lastName: 'Summers',
+    email: 'buffy.summers@example.net',
     rawPassword: 'pix123',
     sex: 'F',
     birthdate: '1981-01-19',
@@ -17,6 +18,7 @@ export const pixCertifiableUserData = [
   {
     firstName: 'Rupert',
     lastName: 'Giles',
+    email: 'rupert.giles@example.net',
     rawPassword: 'pix123',
     sex: 'M',
     birthdate: '1955-02-22',
@@ -30,6 +32,7 @@ export const pixCertifiableUserData = [
   {
     firstName: 'Cordelia',
     lastName: 'Chase',
+    email: 'cordelia.chase@example.net',
     rawPassword: 'pix123',
     sex: 'F',
     birthdate: '1981-08-05',
@@ -43,6 +46,7 @@ export const pixCertifiableUserData = [
   {
     firstName: 'Willow',
     lastName: 'Rosenberg',
+    email: 'willow.rosenberg@example.net',
     rawPassword: 'pix123',
     sex: 'F',
     birthdate: '1983-12-15',
@@ -56,6 +60,7 @@ export const pixCertifiableUserData = [
   {
     firstName: 'Riley',
     lastName: 'Finn',
+    email: 'riley.finn@example.net',
     rawPassword: 'pix123',
     sex: 'M',
     birthdate: '1981-09-29',
@@ -69,6 +74,7 @@ export const pixCertifiableUserData = [
   {
     firstName: 'Xander',
     lastName: 'Harris',
+    email: 'xander.harris@example.net',
     rawPassword: 'pix123',
     sex: 'M',
     birthdate: '1981-01-08',
@@ -82,6 +88,7 @@ export const pixCertifiableUserData = [
   {
     firstName: 'William',
     lastName: 'Pratt',
+    email: 'william.pratt@example.net',
     rawPassword: 'pix123',
     sex: 'M',
     birthdate: '1853-05-10',

--- a/high-level-tests/e2e-playwright/helpers/certification/data.ts
+++ b/high-level-tests/e2e-playwright/helpers/certification/data.ts
@@ -1,3 +1,5 @@
+import { CERTIFICATIONS_DATA } from '../db-data.ts';
+
 export const pixCertifiableUserData = [
   {
     firstName: 'Buffy',
@@ -91,3 +93,50 @@ export const pixCertifiableUserData = [
     postalCode: '66000',
   },
 ];
+
+export const PIX_ADMIN_CERTIF_DATA = {
+  firstName: 'pixAdminRoleCertif',
+  lastName: `pixAdminRoleCertif`,
+  email: `pix-admin-role-certif@example.net`,
+  rawPassword: 'pix123',
+  role: 'CERTIF',
+};
+
+export const PIX_CERTIF_PRO_DATA = {
+  firstName: 'PixCertif',
+  lastName: 'CentrePRO',
+  email: 'pix-certif_pro@example.net',
+  rawPassword: 'pix123',
+  certificationCenters: [
+    {
+      type: 'PRO',
+      externalId: 'CERTIFPRO',
+      habilitations: [
+        CERTIFICATIONS_DATA.CLEA,
+        CERTIFICATIONS_DATA.EDU_1ER_DEGRE,
+        CERTIFICATIONS_DATA.DROIT,
+        CERTIFICATIONS_DATA.PRO_SANTE,
+      ],
+      withOrganization: {
+        isManagingStudents: false,
+      },
+    },
+  ],
+};
+
+export const PIX_CERTIF_SCO_DATA = {
+  firstName: 'PixCertif',
+  lastName: 'CentreSCO',
+  email: 'pix-certif_sco@example.net',
+  rawPassword: 'pix123',
+  certificationCenters: [
+    {
+      type: 'SCO',
+      externalId: 'CERTIFSCO',
+      habilitations: [],
+      withOrganization: {
+        isManagingStudents: true,
+      },
+    },
+  ],
+};

--- a/high-level-tests/e2e-playwright/helpers/certification/db.ts
+++ b/high-level-tests/e2e-playwright/helpers/certification/db.ts
@@ -1,17 +1,15 @@
 import { knex } from '../db.ts';
-import { PIX_ADMIN_CERTIF_DATA, PIX_CERTIF_PRO_DATA, PIX_CERTIF_SCO_DATA } from '../db-data.ts';
+import { PIX_CERTIF_PRO_DATA, PIX_CERTIF_SCO_DATA } from '../db-data.ts';
 import {
   buildCandidates,
   buildCleaData,
   buildCoreVersion,
   buildCpfData,
-  buildPixAdminUser,
   buildPixCertifUser,
   buildPixPlusDroitData,
   buildPixPlusEduData,
   buildPixPlusProSanteData,
 } from './builders/index.ts';
-import { PixAdminUserData } from './types.ts';
 
 export async function buildCertificationData() {
   // Use a PG mutex to solve the shard concurrency
@@ -30,7 +28,6 @@ export async function buildCertificationData() {
   await buildPixCertifUser(knex, PIX_CERTIF_PRO_DATA, cleaTargetProfileId);
   const organizationId = await buildPixCertifUser(knex, PIX_CERTIF_SCO_DATA, cleaTargetProfileId);
   await buildCandidates(knex, organizationId);
-  await buildPixAdminUser(knex, PIX_ADMIN_CERTIF_DATA as PixAdminUserData);
 }
 
 export async function changeCandidateAnswers(certificationId: number, rightWrongAnswersPattern: boolean[]) {

--- a/high-level-tests/e2e-playwright/helpers/certification/db.ts
+++ b/high-level-tests/e2e-playwright/helpers/certification/db.ts
@@ -1,26 +1,29 @@
 import { knex } from '../db.ts';
-import { PIX_CERTIF_PRO_DATA, PIX_CERTIF_SCO_DATA } from '../db-data.ts';
+import { PIX_ADMIN_CERTIF_DATA, PIX_CERTIF_PRO_DATA, PIX_CERTIF_SCO_DATA } from '../db-data.ts';
 import {
   buildCandidates,
   buildCleaData,
   buildCoreVersion,
   buildCpfData,
+  buildPixAdminUser,
   buildPixCertifUser,
   buildPixPlusDroitData,
   buildPixPlusEduData,
   buildPixPlusProSanteData,
 } from './builders/index.ts';
+import { PixAdminUserData } from './types.ts';
 
 export async function buildCertificationData() {
   await buildCpfData(knex);
   await buildCoreVersion(knex);
-  await buildCleaData(knex);
+  const cleaTargetProfileId = await buildCleaData(knex);
   await buildPixPlusEduData(knex);
   await buildPixPlusDroitData(knex);
   await buildPixPlusProSanteData(knex);
-  await buildPixCertifUser(knex, PIX_CERTIF_PRO_DATA);
-  const organizationId = await buildPixCertifUser(knex, PIX_CERTIF_SCO_DATA);
+  await buildPixCertifUser(knex, PIX_CERTIF_PRO_DATA, cleaTargetProfileId);
+  const organizationId = await buildPixCertifUser(knex, PIX_CERTIF_SCO_DATA, cleaTargetProfileId);
   await buildCandidates(knex, organizationId);
+  await buildPixAdminUser(knex, PIX_ADMIN_CERTIF_DATA as PixAdminUserData);
 }
 
 export async function changeCandidateAnswers(certificationId: number, rightWrongAnswersPattern: boolean[]) {

--- a/high-level-tests/e2e-playwright/helpers/certification/db.ts
+++ b/high-level-tests/e2e-playwright/helpers/certification/db.ts
@@ -1,7 +1,7 @@
 import { knex } from '../db.ts';
 import { PIX_CERTIF_PRO_DATA, PIX_CERTIF_SCO_DATA } from '../db-data.ts';
 import {
-  buildCertifiableUsers,
+  buildCandidates,
   buildCleaData,
   buildCoreVersion,
   buildCpfData,
@@ -20,7 +20,7 @@ export async function buildCertificationData() {
   await buildPixPlusProSanteData(knex);
   await buildPixCertifUser(knex, PIX_CERTIF_PRO_DATA);
   const organizationId = await buildPixCertifUser(knex, PIX_CERTIF_SCO_DATA);
-  await buildCertifiableUsers(knex, organizationId);
+  await buildCandidates(knex, organizationId);
 }
 
 export async function changeCandidateAnswers(certificationId: number, rightWrongAnswersPattern: boolean[]) {

--- a/high-level-tests/e2e-playwright/helpers/certification/db.ts
+++ b/high-level-tests/e2e-playwright/helpers/certification/db.ts
@@ -1,11 +1,9 @@
 import { knex } from '../db.ts';
-import { PIX_CERTIF_PRO_DATA, PIX_CERTIF_SCO_DATA } from '../db-data.ts';
+import { CERTIFICATIONS_DATA } from '../db-data.ts';
 import {
-  buildCandidates,
   buildCleaData,
   buildCoreVersion,
   buildCpfData,
-  buildPixCertifUser,
   buildPixPlusDroitData,
   buildPixPlusEduData,
   buildPixPlusProSanteData,
@@ -21,13 +19,10 @@ export async function buildCertificationData() {
   }
   await buildCpfData(knex);
   await buildCoreVersion(knex);
-  const cleaTargetProfileId = await buildCleaData(knex);
+  await buildCleaData(knex);
   await buildPixPlusEduData(knex);
   await buildPixPlusDroitData(knex);
   await buildPixPlusProSanteData(knex);
-  await buildPixCertifUser(knex, PIX_CERTIF_PRO_DATA, cleaTargetProfileId);
-  const organizationId = await buildPixCertifUser(knex, PIX_CERTIF_SCO_DATA, cleaTargetProfileId);
-  await buildCandidates(knex, organizationId);
 }
 
 export async function changeCandidateAnswers(certificationId: number, rightWrongAnswersPattern: boolean[]) {
@@ -42,4 +37,9 @@ export async function changeCandidateAnswers(certificationId: number, rightWrong
     const nextResult = rightWrongAnswersPattern[i % rightWrongAnswersPattern.length] ? 'ok' : 'ko';
     await knex('answers').update('result', nextResult).where('answers.id', answerId);
   }
+}
+
+export async function getCleaTargetProfileId() {
+  const [id] = await knex('badges').pluck('targetProfileId').where({ key: CERTIFICATIONS_DATA.CLEA });
+  return id;
 }

--- a/high-level-tests/e2e-playwright/helpers/certification/db.ts
+++ b/high-level-tests/e2e-playwright/helpers/certification/db.ts
@@ -1,5 +1,5 @@
 import { knex } from '../db.ts';
-import { PIX_CERTIF_PRO_DATA } from '../db-data.ts';
+import { PIX_CERTIF_PRO_DATA, PIX_CERTIF_SCO_DATA } from '../db-data.ts';
 import {
   buildCertifiableUsers,
   buildCleaData,
@@ -19,7 +19,7 @@ export async function buildCertificationData() {
   await buildPixPlusDroitData(knex);
   await buildPixPlusProSanteData(knex);
   await buildPixCertifUser(knex, PIX_CERTIF_PRO_DATA);
-  const organizationId = await buildPixCertifUser(knex, PIX_CERTIF_PRO_DATA);
+  const organizationId = await buildPixCertifUser(knex, PIX_CERTIF_SCO_DATA);
   await buildCertifiableUsers(knex, organizationId);
 }
 

--- a/high-level-tests/e2e-playwright/helpers/certification/db.ts
+++ b/high-level-tests/e2e-playwright/helpers/certification/db.ts
@@ -14,6 +14,13 @@ import {
 import { PixAdminUserData } from './types.ts';
 
 export async function buildCertificationData() {
+  // Use a PG mutex to solve the shard concurrency
+  // This data should only be inserted once
+  await knex.raw('SELECT pg_advisory_lock(12345)');
+  const res = await knex('certification_versions').pluck('id');
+  if (res.length > 0) {
+    return;
+  }
   await buildCpfData(knex);
   await buildCoreVersion(knex);
   const cleaTargetProfileId = await buildCleaData(knex);

--- a/high-level-tests/e2e-playwright/helpers/certification/db.ts
+++ b/high-level-tests/e2e-playwright/helpers/certification/db.ts
@@ -12,7 +12,6 @@ import {
 } from './builders/index.ts';
 
 export async function buildCertificationData() {
-  await buildCertifiableUsers(knex);
   await buildCpfData(knex);
   await buildCoreVersion(knex);
   await buildCleaData(knex);
@@ -20,6 +19,8 @@ export async function buildCertificationData() {
   await buildPixPlusDroitData(knex);
   await buildPixPlusProSanteData(knex);
   await buildPixCertifUser(knex, PIX_CERTIF_PRO_DATA);
+  const organizationId = await buildPixCertifUser(knex, PIX_CERTIF_PRO_DATA);
+  await buildCertifiableUsers(knex, organizationId);
 }
 
 export async function changeCandidateAnswers(certificationId: number, rightWrongAnswersPattern: boolean[]) {

--- a/high-level-tests/e2e-playwright/helpers/certification/db.ts
+++ b/high-level-tests/e2e-playwright/helpers/certification/db.ts
@@ -43,3 +43,8 @@ export async function getCleaTargetProfileId() {
   const [id] = await knex('badges').pluck('targetProfileId').where({ key: CERTIFICATIONS_DATA.CLEA });
   return id;
 }
+
+export async function getOrganizationIdForScoUser(pixCertifUserId: number) {
+  const [id] = await knex('memberships').pluck('organizationId').where({ userId: pixCertifUserId });
+  return id;
+}

--- a/high-level-tests/e2e-playwright/helpers/certification/db.ts
+++ b/high-level-tests/e2e-playwright/helpers/certification/db.ts
@@ -1,6 +1,7 @@
 import { knex } from '../db.ts';
 import { PIX_CERTIF_PRO_DATA } from '../db-data.ts';
 import {
+  buildCertifiableUsers,
   buildCleaData,
   buildCoreVersion,
   buildCpfData,
@@ -11,6 +12,7 @@ import {
 } from './builders/index.ts';
 
 export async function buildCertificationData() {
+  await buildCertifiableUsers(knex);
   await buildCpfData(knex);
   await buildCoreVersion(knex);
   await buildCleaData(knex);

--- a/high-level-tests/e2e-playwright/helpers/db-data.ts
+++ b/high-level-tests/e2e-playwright/helpers/db-data.ts
@@ -57,13 +57,13 @@ export const CERTIFICATIONS_DATA = {
   PRO_SANTE: 'PRO_SANTE',
 };
 
-export const PIX_ADMIN_SUPPORT_DATA = {
-  id: 1_000_008,
-  firstName: 'PixAdmin',
-  lastName: 'RoleSupport',
-  email: 'pix-admin_rolesupport@example.net',
+export const PIX_ADMIN_CERTIF_DATA = {
+  id: 1_000_004,
+  firstName: 'pixAdminRoleCertif',
+  lastName: `pixAdminRoleCertif`,
+  email: `pix-admin-role-certif@example.net`,
   rawPassword: 'pix123',
-  role: 'SUPPORT',
+  role: 'CERTIF',
 };
 
 export const PIX_CERTIF_PRO_DATA = {
@@ -105,4 +105,13 @@ export const PIX_CERTIF_SCO_DATA = {
       },
     },
   ],
+};
+
+export const PIX_ADMIN_SUPPORT_DATA = {
+  id: 1_000_008,
+  firstName: 'PixAdmin',
+  lastName: 'RoleSupport',
+  email: 'pix-admin_rolesupport@example.net',
+  rawPassword: 'pix123',
+  role: 'SUPPORT',
 };

--- a/high-level-tests/e2e-playwright/helpers/db-data.ts
+++ b/high-level-tests/e2e-playwright/helpers/db-data.ts
@@ -88,3 +88,21 @@ export const PIX_CERTIF_PRO_DATA = {
     },
   ],
 };
+
+export const PIX_CERTIF_SCO_DATA = {
+  id: 1_000_006,
+  firstName: 'PixCertif',
+  lastName: 'CentreSCO',
+  email: 'pix-certif_sco@example.net',
+  rawPassword: 'pix123',
+  certificationCenters: [
+    {
+      type: 'SCO',
+      externalId: 'CERTIFSCO',
+      habilitations: [],
+      withOrganization: {
+        isManagingStudents: true,
+      },
+    },
+  ],
+};

--- a/high-level-tests/e2e-playwright/helpers/db-data.ts
+++ b/high-level-tests/e2e-playwright/helpers/db-data.ts
@@ -57,15 +57,6 @@ export const CERTIFICATIONS_DATA = {
   PRO_SANTE: 'PRO_SANTE',
 };
 
-export const PIX_ADMIN_CERTIF_DATA = {
-  id: 1_000_004,
-  firstName: 'pixAdminRoleCertif',
-  lastName: `pixAdminRoleCertif`,
-  email: `pix-admin-role-certif@example.net`,
-  rawPassword: 'pix123',
-  role: 'CERTIF',
-};
-
 export const PIX_CERTIF_PRO_DATA = {
   id: 1_000_005,
   firstName: 'PixCertif',
@@ -84,24 +75,6 @@ export const PIX_CERTIF_PRO_DATA = {
       ],
       withOrganization: {
         isManagingStudents: false,
-      },
-    },
-  ],
-};
-
-export const PIX_CERTIF_SCO_DATA = {
-  id: 1_000_006,
-  firstName: 'PixCertif',
-  lastName: 'CentreSCO',
-  email: 'pix-certif_sco@example.net',
-  rawPassword: 'pix123',
-  certificationCenters: [
-    {
-      type: 'SCO',
-      externalId: 'CERTIFSCO',
-      habilitations: [],
-      withOrganization: {
-        isManagingStudents: true,
       },
     },
   ],

--- a/high-level-tests/e2e-playwright/helpers/db-utils.ts
+++ b/high-level-tests/e2e-playwright/helpers/db-utils.ts
@@ -85,7 +85,7 @@ export async function createOrganizationLearnerInDB(
   knex: Knex,
 ) {
   const someDate = new Date();
-  return await knex('organization-learners')
+  const [{ id: organizationLearnerId }] = await knex('organization-learners')
     .insert({
       firstName,
       lastName,
@@ -98,6 +98,7 @@ export async function createOrganizationLearnerInDB(
       updatedAt: someDate,
     })
     .returning('*');
+  return organizationLearnerId;
 }
 
 export async function createCertificationCenterInDB(

--- a/high-level-tests/e2e-playwright/helpers/db-utils.ts
+++ b/high-level-tests/e2e-playwright/helpers/db-utils.ts
@@ -70,6 +70,9 @@ export async function createOrganizationLearnerInDB(
     lastName,
     userId,
     birthdate,
+    birthCountryCode = '100',
+    birthCity = 'Perpignan',
+    sex = 'F',
     organizationId,
     nationalStudentId,
     isDisabled,
@@ -78,6 +81,9 @@ export async function createOrganizationLearnerInDB(
     lastName: string;
     userId?: number;
     birthdate?: string;
+    birthCountryCode?: string;
+    birthCity?: string;
+    sex?: string;
     nationalStudentId: string;
     organizationId: number;
     isDisabled: boolean;
@@ -91,6 +97,9 @@ export async function createOrganizationLearnerInDB(
       lastName,
       userId: userId ?? null,
       birthdate: birthdate ?? null,
+      birthCountryCode,
+      birthCity,
+      sex,
       isDisabled,
       nationalStudentId,
       organizationId,

--- a/high-level-tests/e2e-playwright/helpers/db.ts
+++ b/high-level-tests/e2e-playwright/helpers/db.ts
@@ -16,7 +16,7 @@ import {
   createCertificationCenterInDB,
   createCertificationCenterMembershipInDB,
   createOrganizationLearnerInDB,
-  createUserInDB
+  createUserInDB,
 } from './db-utils.ts';
 
 export const knex = Knex({ client: 'postgresql', connection: process.env.DATABASE_URL });

--- a/high-level-tests/e2e-playwright/helpers/db.ts
+++ b/high-level-tests/e2e-playwright/helpers/db.ts
@@ -4,13 +4,19 @@ import Knex from 'knex';
 import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../api/src/identity-access-management/domain/constants/identity-providers.js';
 // @ts-expect-error AuthenticationMethod from API project
 import { AuthenticationMethod } from '../../../api/src/identity-access-management/domain/models/AuthenticationMethod.js';
-import { buildCertificationData } from './certification/db.ts';
-import { PIX_ADMIN_SUPPORT_DATA, PIX_APP_USER_DATA, PIX_ORGA_ADMIN_DATA, PIX_ORGA_MEMBER_DATA } from './db-data.js';
+import { buildCoreVersion, buildCpfData, buildPixCertifUser } from './certification/builders/index.ts';
+import {
+  PIX_ADMIN_SUPPORT_DATA,
+  PIX_APP_USER_DATA,
+  PIX_CERTIF_PRO_DATA,
+  PIX_ORGA_ADMIN_DATA,
+  PIX_ORGA_MEMBER_DATA,
+} from './db-data.js';
 import {
   createCertificationCenterInDB,
   createCertificationCenterMembershipInDB,
   createOrganizationLearnerInDB,
-  createUserInDB,
+  createUserInDB
 } from './db-utils.ts';
 
 export const knex = Knex({ client: 'postgresql', connection: process.env.DATABASE_URL });
@@ -20,7 +26,9 @@ export async function buildStaticData() {
   if (!hasDataAlreadyBeenBuilt) {
     await buildAuthenticatedUsers();
     await buildTargetProfiles();
-    await buildCertificationData();
+    await buildCpfData(knex);
+    await buildCoreVersion(knex);
+    await buildPixCertifUser(knex, PIX_CERTIF_PRO_DATA, null);
   }
 }
 
@@ -481,7 +489,9 @@ export async function createTargetProfileInDB(name: string) {
     targetProfileId: id,
     organizationId,
   }));
-  await knex('target-profile-shares').insert(targetProfileSharesToInsert);
+  if (targetProfileSharesToInsert.length > 0) {
+    await knex('target-profile-shares').insert(targetProfileSharesToInsert);
+  }
   return id;
 }
 

--- a/high-level-tests/e2e-playwright/pages/pix-certif/SessionManagementPage.ts
+++ b/high-level-tests/e2e-playwright/pages/pix-certif/SessionManagementPage.ts
@@ -43,9 +43,15 @@ export class SessionManagementPage {
   }
 
   async goToEnrollCandidateForm() {
-    await this.page.getByRole('link', { name: 'Candidats' }).click();
+    await this.page.getByRole('link', { name: /^Candidats/ }).click();
     await this.page.waitForURL(/\/sessions\/\d+\/candidats$/);
     await this.page.getByRole('button', { name: 'Inscrire un candidat' }).click();
+  }
+
+  async goToEnrollScoCandidateForm() {
+    await this.page.getByRole('link', { name: /^Candidats/ }).click();
+    await this.page.waitForURL(/\/sessions\/\d+\/candidats$/);
+    await this.page.getByRole('link', { name: 'Inscrire des candidats' }).click();
   }
 
   async goToFinalizeSession() {
@@ -124,8 +130,13 @@ export class SessionManagementPage {
     }
   }
 
+  async addScoCandidate({ firstName, lastName }: { firstName: string; lastName: string }) {
+    await this.page.getByLabel(`Sélectionner le candidat ${firstName} ${lastName}`).click();
+    await this.page.getByRole('button', { name: 'Inscrire' }).click();
+  }
+
   async getEnrolledCandidatesData() {
-    await this.page.getByRole('link', { name: 'Candidats' }).click();
+    await this.page.getByRole('link', { name: /^Candidats/ }).click();
     await this.page.waitForURL(/\/sessions\/\d+\/candidats$/);
     const table = this.page.locator('table');
     const headers = await table.locator('thead th').allTextContents();
@@ -148,7 +159,7 @@ export class SessionManagementPage {
   }
 
   async importOdsFile(filePath: string) {
-    await this.page.getByRole('link', { name: 'Candidats' }).click();
+    await this.page.getByRole('link', { name: /^Candidats/ }).click();
     await this.page.waitForURL(/\/sessions\/\d+\/candidats$/);
     await this.page.getByLabel('Importer (.ods)').setInputFiles(filePath);
   }

--- a/high-level-tests/e2e-playwright/playwright.config.certif.ts
+++ b/high-level-tests/e2e-playwright/playwright.config.certif.ts
@@ -4,6 +4,7 @@ import sharedConfig, { App, isCI, reuseExistingApps, setupWebServer } from './pl
 
 export default defineConfig({
   ...sharedConfig,
+  globalSetup: './tests/recette-certif/global-setup',
   timeout: 80_000,
   projects: [
     {
@@ -14,16 +15,10 @@ export default defineConfig({
   ],
 
   webServer: isCI
-    ? [
-        setupWebServer(App.PIX_APP, true),
-        setupWebServer(App.PIX_ORGA, true),
-        setupWebServer(App.PIX_CERTIF, true),
-        setupWebServer(App.PIX_ADMIN, true),
-      ]
+    ? [setupWebServer(App.PIX_APP, true), setupWebServer(App.PIX_CERTIF, true), setupWebServer(App.PIX_ADMIN, true)]
     : [
         setupWebServer(App.PIX_API, false),
         setupWebServer(App.PIX_APP, reuseExistingApps),
-        setupWebServer(App.PIX_ORGA, reuseExistingApps),
         setupWebServer(App.PIX_CERTIF, reuseExistingApps),
         setupWebServer(App.PIX_ADMIN, reuseExistingApps),
       ],

--- a/high-level-tests/e2e-playwright/playwright.config.prescription.ts
+++ b/high-level-tests/e2e-playwright/playwright.config.prescription.ts
@@ -4,6 +4,7 @@ import sharedConfig, { App, isCI, reuseExistingApps, setupWebServer } from './pl
 
 export default defineConfig({
   ...sharedConfig,
+  globalSetup: './global-setup',
   projects: [
     {
       name: 'recette prescription - setup base data for anonymization',

--- a/high-level-tests/e2e-playwright/playwright.config.shared.ts
+++ b/high-level-tests/e2e-playwright/playwright.config.shared.ts
@@ -11,7 +11,6 @@ export const reuseExistingApps = process.env.REUSE_EXISTING_APPS === 'true';
 
 // See https://playwright.dev/docs/test-configuration
 export default defineConfig({
-  globalSetup: './global-setup',
   outputDir: `${playwrightFolder}/output`,
   forbidOnly: isCI,
   retries: 0,

--- a/high-level-tests/e2e-playwright/playwright.config.ts
+++ b/high-level-tests/e2e-playwright/playwright.config.ts
@@ -4,6 +4,7 @@ import sharedConfig, { App, isCI, reuseExistingApps, setupWebServer } from './pl
 
 export default defineConfig({
   ...sharedConfig,
+  globalSetup: './global-setup',
   projects: [
     {
       name: 'login',

--- a/high-level-tests/e2e-playwright/tests/recette-certif/enrolment/INDIVIDUAL_ENROLMENT.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/enrolment/INDIVIDUAL_ENROLMENT.spec.ts
@@ -32,11 +32,11 @@ test(
     testRef,
   }) => {
     test.slow();
-    const userDataCoreSubscription = await getCertifiableUserData(0);
-    const userDataCleaSubscription = await getCertifiableUserData(1);
-    const userDataEduSubscription = await getCertifiableUserData(2);
-    const userDataDroitSubscription = await getCertifiableUserData(3);
-    const userDataProSanteSubscription = await getCertifiableUserData(4);
+    const userDataCoreSubscription = await getCertifiableUserData('buffy.summers@example.net');
+    const userDataCleaSubscription = await getCertifiableUserData('rupert.giles@example.net');
+    const userDataEduSubscription = await getCertifiableUserData('cordelia.chase@example.net');
+    const userDataDroitSubscription = await getCertifiableUserData('willow.rosenberg@example.net');
+    const userDataProSanteSubscription = await getCertifiableUserData('riley.finn@example.net');
     await pixCertifProPage.goto(process.env.PIX_CERTIF_URL!);
 
     let sessionNumber = '',

--- a/high-level-tests/e2e-playwright/tests/recette-certif/enrolment/MASS_IMPORT_ENROLMENT.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/enrolment/MASS_IMPORT_ENROLMENT.spec.ts
@@ -36,11 +36,11 @@ test(
     testRef,
   }) => {
     test.slow();
-    const userDataCoreSubscription = await getCertifiableUserData(0);
-    const userDataCleaSubscription = await getCertifiableUserData(1);
-    const userDataEduSubscription = await getCertifiableUserData(2);
-    const userDataDroitSubscription = await getCertifiableUserData(3);
-    const userDataProSanteSubscription = await getCertifiableUserData(4);
+    const userDataCoreSubscription = await getCertifiableUserData('buffy.summers@example.net');
+    const userDataCleaSubscription = await getCertifiableUserData('rupert.giles@example.net');
+    const userDataEduSubscription = await getCertifiableUserData('cordelia.chase@example.net');
+    const userDataDroitSubscription = await getCertifiableUserData('willow.rosenberg@example.net');
+    const userDataProSanteSubscription = await getCertifiableUserData('riley.finn@example.net');
     await pixCertifProPage.goto(process.env.PIX_CERTIF_URL!);
 
     let sessionNumber = '',

--- a/high-level-tests/e2e-playwright/tests/recette-certif/enrolment/ODS_FILE_ENROLMENT.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/enrolment/ODS_FILE_ENROLMENT.spec.ts
@@ -38,11 +38,11 @@ test(
     testRef,
   }) => {
     test.slow();
-    const userDataCoreSubscription = await getCertifiableUserData(0);
-    const userDataCleaSubscription = await getCertifiableUserData(1);
-    const userDataEduSubscription = await getCertifiableUserData(2);
-    const userDataDroitSubscription = await getCertifiableUserData(3);
-    const userDataProSanteSubscription = await getCertifiableUserData(4);
+    const userDataCoreSubscription = await getCertifiableUserData('buffy.summers@example.net');
+    const userDataCleaSubscription = await getCertifiableUserData('rupert.giles@example.net');
+    const userDataEduSubscription = await getCertifiableUserData('cordelia.chase@example.net');
+    const userDataDroitSubscription = await getCertifiableUserData('willow.rosenberg@example.net');
+    const userDataProSanteSubscription = await getCertifiableUserData('riley.finn@example.net');
     await pixCertifProPage.goto(process.env.PIX_CERTIF_URL!);
 
     let sessionNumber = '',

--- a/high-level-tests/e2e-playwright/tests/recette-certif/enrolment/SCO_INDIVIDUAL_ENROLMENT.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/enrolment/SCO_INDIVIDUAL_ENROLMENT.spec.ts
@@ -1,0 +1,142 @@
+import { expect, test } from '../../../fixtures/certification/index.ts';
+import { checkSessionInformationAndExpectSuccess } from '../../../helpers/certification/utils.ts';
+import { HomePage as AdminHomePage } from '../../../pages/pix-admin/index.ts';
+import { SessionListPage, SessionManagementPage } from '../../../pages/pix-certif/index.ts';
+
+const testRef = 'SCO_INDIVIDUAL_ENROLMENT';
+
+test(`${testRef} - Enroll candidate through individual enrolment modal`, async ({
+  pixCertifScoPage,
+  pixAdminRoleCertifPage,
+  getCertifiableUserData,
+  pixAppCertifiableUserPage,
+  passManyCertificationExams,
+}) => {
+  test.slow();
+  const userDataCoreSubscription = await getCertifiableUserData(0);
+  await pixCertifScoPage.goto(process.env.PIX_CERTIF_URL!);
+
+  let sessionNumber = '',
+    accessCode = '',
+    invigilatorCode = '';
+  const sessionManagementPage = await test.step('Create session', async () => {
+    const sessionListPage = new SessionListPage(pixCertifScoPage);
+    const sessionCreationPage = await sessionListPage.goToCreateSession();
+    const sessionManagementPage = await sessionCreationPage.createSession({
+      address: `address ${testRef}`,
+      room: `room ${testRef}`,
+      examiner: `examiner ${testRef}`,
+      hour: '09',
+      minute: '05',
+    });
+
+    const sessionData = await sessionManagementPage.getSessionData();
+    sessionNumber = sessionData.sessionNumber;
+    accessCode = sessionData.accessCode;
+    invigilatorCode = sessionData.invigilatorCode;
+    return sessionManagementPage;
+  });
+
+  await test.step('Enroll candidate to CORE exam', async () => {
+    await sessionManagementPage.goToEnrollScoCandidateForm();
+    await sessionManagementPage.addScoCandidate({
+      firstName: userDataCoreSubscription.firstName,
+      lastName: userDataCoreSubscription.lastName,
+    });
+    const enrolledCandidatesSoFar = await sessionManagementPage.getEnrolledCandidatesData();
+    expect(enrolledCandidatesSoFar).toMatchObject([
+      {
+        'Nom de naissance': userDataCoreSubscription.lastName,
+        Prénom: userDataCoreSubscription.firstName,
+        'Date de naissance':
+          userDataCoreSubscription.birthDay +
+          '/' +
+          userDataCoreSubscription.birthMonth +
+          '/' +
+          userDataCoreSubscription.birthYear,
+        'Certification sélectionnée': 'Certification Pix',
+      },
+    ]);
+  });
+
+  await test.step('Check enrolled candidate', async () => {
+    const enrolledCandidates = await sessionManagementPage.getEnrolledCandidatesData();
+    expect(enrolledCandidates).toHaveLength(1);
+    const coreEnrolled = enrolledCandidates.find(
+      (enrolled) => enrolled['Prénom'] === userDataCoreSubscription.firstName,
+    );
+    expect(coreEnrolled).toMatchObject({
+      'Nom de naissance': userDataCoreSubscription.lastName,
+      Prénom: userDataCoreSubscription.firstName,
+      'Date de naissance':
+        userDataCoreSubscription.birthDay +
+        '/' +
+        userDataCoreSubscription.birthMonth +
+        '/' +
+        userDataCoreSubscription.birthYear,
+      'Certification sélectionnée': 'Certification Pix',
+    });
+  });
+
+  const pixAppCorePage = await pixAppCertifiableUserPage(userDataCoreSubscription);
+  await test.step('Candidates passes the exam', async () => {
+    await passManyCertificationExams({
+      examsData: [
+        {
+          certifiableUserData: userDataCoreSubscription,
+          rightWrongAnswersSequence: [true],
+          pixAppPage: pixAppCorePage,
+        },
+      ],
+      sessionNumber,
+      accessCode,
+      invigilatorCode,
+    });
+  });
+
+  await test.step('Finalization by marking technical issues on all candidates', async () => {
+    const sessionManagementPage = new SessionManagementPage(pixCertifScoPage);
+    const sessionFinalizationPage = await sessionManagementPage.goToFinalizeSession();
+    await expect(pixCertifScoPage.getByText(userDataCoreSubscription.firstName)).toBeVisible();
+    await sessionFinalizationPage.markTechnicalIssueFor(userDataCoreSubscription.lastName);
+
+    await sessionFinalizationPage.finalizeSession();
+  });
+
+  const adminHomepage = new AdminHomePage(pixAdminRoleCertifPage);
+  await test.step('Check candidates did pass what they enrolled for', async () => {
+    const sessionsMainPage = await adminHomepage.goToCertificationSessionsTab();
+    const sessionPage = await sessionsMainPage.goToSessionToPublishInfo(sessionNumber);
+
+    await test.step('Check session information', async () => {
+      await checkSessionInformationAndExpectSuccess(sessionPage, {
+        address: `address ${testRef}`,
+        room: `room ${testRef}`,
+        invigilatorName: `examiner ${testRef}`,
+        status: 'Finalisée',
+        nbStartedCertifications: 0,
+        nbIssueReportsUnsolved: 0,
+        nbIssueReports: 0,
+        nbCertificationsInError: 0,
+      });
+    });
+
+    await pixAdminRoleCertifPage
+      .getByRole('link', { name: 'Liste des certifications de la session', exact: true })
+      .click();
+    await test.step('Check certification information', async () => {
+      const certificationListPage = await sessionPage.goToCertificationListPage();
+      const certificationData = await certificationListPage.getCertificationData();
+      expect(certificationData.length).toBe(1);
+      const coreData = certificationData.find((data) => data['Prénom'] === userDataCoreSubscription.firstName);
+      expect(coreData).toMatchObject({
+        Prénom: userDataCoreSubscription.firstName,
+        Nom: userDataCoreSubscription.lastName,
+        Statut: 'Annulée',
+        Résultats: '55 Pix',
+        'Signalements impactants non résolus': '',
+        'Certification passée': 'Pix Cœur',
+      });
+    });
+  });
+});

--- a/high-level-tests/e2e-playwright/tests/recette-certif/enrolment/SCO_INDIVIDUAL_ENROLMENT.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/enrolment/SCO_INDIVIDUAL_ENROLMENT.spec.ts
@@ -13,7 +13,7 @@ test(`${testRef} - Enroll candidate through individual enrolment modal`, async (
   passManyCertificationExams,
 }) => {
   test.slow();
-  const userDataCoreSubscription = await getCertifiableUserData(0);
+  const userDataCoreSubscription = await getCertifiableUserData('buffy.summers@example.net');
   await pixCertifScoPage.goto(process.env.PIX_CERTIF_URL!);
 
   let sessionNumber = '',

--- a/high-level-tests/e2e-playwright/tests/recette-certif/evaluation/EVAL_ENDED_BY_FINALIZATION_RELOADING.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/evaluation/EVAL_ENDED_BY_FINALIZATION_RELOADING.spec.ts
@@ -31,7 +31,7 @@ test(
     pixAppCertifiableUserPage,
     testRef,
   }) => {
-    const certifiableUserData = await getCertifiableUserData(0);
+    const certifiableUserData = await getCertifiableUserData('buffy.summers@example.net');
     const pixAppCertifiablePage = await pixAppCertifiableUserPage(certifiableUserData);
     const { sessionNumber } = await enrollCandidateAndPassExam({
       testRef,

--- a/high-level-tests/e2e-playwright/tests/recette-certif/evaluation/EVAL_ENDED_BY_FINALIZATION_SKIP.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/evaluation/EVAL_ENDED_BY_FINALIZATION_SKIP.spec.ts
@@ -32,7 +32,7 @@ test(
     pixAppCertifiableUserPage,
     testRef,
   }) => {
-    const certifiableUserData = await getCertifiableUserData(0);
+    const certifiableUserData = await getCertifiableUserData('buffy.summers@example.net');
     const pixAppCertifiablePage = await pixAppCertifiableUserPage(certifiableUserData);
     const { sessionNumber } = await enrollCandidateAndPassExam({
       testRef,

--- a/high-level-tests/e2e-playwright/tests/recette-certif/evaluation/EVAL_ENDED_BY_INVIGILATOR_RELOADING.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/evaluation/EVAL_ENDED_BY_INVIGILATOR_RELOADING.spec.ts
@@ -31,7 +31,7 @@ test(
     getCertifiableUserData,
     testRef,
   }) => {
-    const certifiableUserData = await getCertifiableUserData(0);
+    const certifiableUserData = await getCertifiableUserData('buffy.summers@example.net');
     const pixAppCertifiablePage = await pixAppCertifiableUserPage(certifiableUserData);
     const { sessionNumber, invigilatorOverviewPage } = await enrollCandidateAndPassExam({
       testRef,

--- a/high-level-tests/e2e-playwright/tests/recette-certif/evaluation/EVAL_ENDED_BY_INVIGILATOR_SKIP.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/evaluation/EVAL_ENDED_BY_INVIGILATOR_SKIP.spec.ts
@@ -32,7 +32,7 @@ test(
     pixAppCertifiableUserPage,
     testRef,
   }) => {
-    const certifiableUserData = await getCertifiableUserData(0);
+    const certifiableUserData = await getCertifiableUserData('buffy.summers@example.net');
     const pixAppCertifiablePage = await pixAppCertifiableUserPage(certifiableUserData);
     const { sessionNumber, invigilatorOverviewPage } = await enrollCandidateAndPassExam({
       testRef,

--- a/high-level-tests/e2e-playwright/tests/recette-certif/global-setup.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/global-setup.ts
@@ -1,0 +1,22 @@
+import * as path from 'node:path';
+
+import * as fs from 'fs/promises';
+
+import { AUTH_DIR } from '../../helpers/auth.ts';
+import { buildCertificationData } from '../../helpers/certification/db.ts';
+const shouldRecordHAR = process.env.RECORD_HAR === 'true';
+const HAR_DIR = path.resolve(import.meta.dirname, '../.har-record');
+
+export default async function globalSetup() {
+  try {
+    if (shouldRecordHAR) {
+      await fs.mkdir(HAR_DIR, { recursive: true });
+    }
+    await fs.mkdir(AUTH_DIR, { recursive: true });
+    await buildCertificationData();
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('❌ Global setup failed:', error);
+    process.exit(1);
+  }
+}

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/clea/PRO_CLEA_0OK-32KO.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/clea/PRO_CLEA_0OK-32KO.spec.ts
@@ -39,7 +39,7 @@ test(
     snapshotPath,
     csvResultPath,
   }) => {
-    const certifiableUserData = await getCertifiableUserData(0);
+    const certifiableUserData = await getCertifiableUserData('buffy.summers@example.net');
     const pixAppCertifiablePage = await pixAppCertifiableUserPage(certifiableUserData);
     const { sessionNumber, certificationNumber, certificationCenterName } = await enrollCandidateAndPassExam({
       testRef,

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/clea/PRO_CLEA_1OK-0KO_EndedByFinalization_Abandonment.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/clea/PRO_CLEA_1OK-0KO_EndedByFinalization_Abandonment.spec.ts
@@ -38,7 +38,7 @@ test(
     snapshotPath,
     csvResultPath,
   }) => {
-    const certifiableUserData = await getCertifiableUserData(0);
+    const certifiableUserData = await getCertifiableUserData('buffy.summers@example.net');
     const pixAppCertifiablePage = await pixAppCertifiableUserPage(certifiableUserData);
     const { sessionNumber, certificationNumber, certificationCenterName } = await enrollCandidateAndPassExam({
       testRef,

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/clea/PRO_CLEA_1OK-0KO_EndedByFinalization_TechnicalIssue.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/clea/PRO_CLEA_1OK-0KO_EndedByFinalization_TechnicalIssue.spec.ts
@@ -38,7 +38,7 @@ test(
     snapshotPath,
     csvResultPath,
   }) => {
-    const certifiableUserData = await getCertifiableUserData(0);
+    const certifiableUserData = await getCertifiableUserData('buffy.summers@example.net');
     const pixAppCertifiablePage = await pixAppCertifiableUserPage(certifiableUserData);
     const { sessionNumber, certificationNumber, certificationCenterName } = await enrollCandidateAndPassExam({
       testRef,

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/clea/PRO_CLEA_1OK-0KO_EndedByInvigilator_Abandonment.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/clea/PRO_CLEA_1OK-0KO_EndedByInvigilator_Abandonment.spec.ts
@@ -38,7 +38,7 @@ test(
     snapshotPath,
     csvResultPath,
   }) => {
-    const certifiableUserData = await getCertifiableUserData(0);
+    const certifiableUserData = await getCertifiableUserData('buffy.summers@example.net');
     const pixAppCertifiablePage = await pixAppCertifiableUserPage(certifiableUserData);
     const { sessionNumber, invigilatorOverviewPage, certificationNumber, certificationCenterName } =
       await enrollCandidateAndPassExam({

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/clea/PRO_CLEA_1OK-0KO_EndedByInvigilator_TechnicalIssue.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/clea/PRO_CLEA_1OK-0KO_EndedByInvigilator_TechnicalIssue.spec.ts
@@ -38,7 +38,7 @@ test(
     snapshotPath,
     csvResultPath,
   }) => {
-    const certifiableUserData = await getCertifiableUserData(0);
+    const certifiableUserData = await getCertifiableUserData('buffy.summers@example.net');
     const pixAppCertifiablePage = await pixAppCertifiableUserPage(certifiableUserData);
     const { sessionNumber, invigilatorOverviewPage, certificationNumber, certificationCenterName } =
       await enrollCandidateAndPassExam({

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/clea/PRO_CLEA_32OK-0KO.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/clea/PRO_CLEA_32OK-0KO.spec.ts
@@ -41,7 +41,7 @@ test(
     csvResultPath,
     certificateBasePath,
   }) => {
-    const certifiableUserData = await getCertifiableUserData(0);
+    const certifiableUserData = await getCertifiableUserData('buffy.summers@example.net');
     const pixAppCertifiablePage = await pixAppCertifiableUserPage(certifiableUserData);
     const { sessionNumber, certificationNumber, certificationCenterName } = await enrollCandidateAndPassExam({
       testRef,

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/clea/PRO_CLEA_32OK-0KO_Rescore.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/clea/PRO_CLEA_32OK-0KO_Rescore.spec.ts
@@ -43,7 +43,7 @@ test(
     csvResultPath,
     certificateBasePath,
   }) => {
-    const certifiableUserData = await getCertifiableUserData(0);
+    const certifiableUserData = await getCertifiableUserData('buffy.summers@example.net');
     const pixAppCertifiablePage = await pixAppCertifiableUserPage(certifiableUserData);
     const { sessionNumber, certificationNumber, certificationCenterName } = await enrollCandidateAndPassExam({
       testRef,

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/core/PRO_CORE_0OK-32KO.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/core/PRO_CORE_0OK-32KO.spec.ts
@@ -38,7 +38,7 @@ test(
     snapshotPath,
     csvResultPath,
   }) => {
-    const certifiableUserData = await getCertifiableUserData(0);
+    const certifiableUserData = await getCertifiableUserData('buffy.summers@example.net');
     const pixAppCertifiablePage = await pixAppCertifiableUserPage(certifiableUserData);
     const { sessionNumber, certificationNumber, certificationCenterName } = await enrollCandidateAndPassExam({
       testRef,

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/core/PRO_CORE_1OK-0KO_EndedByFinalization_Abandonment.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/core/PRO_CORE_1OK-0KO_EndedByFinalization_Abandonment.spec.ts
@@ -37,7 +37,7 @@ test(
     snapshotPath,
     csvResultPath,
   }) => {
-    const certifiableUserData = await getCertifiableUserData(0);
+    const certifiableUserData = await getCertifiableUserData('buffy.summers@example.net');
     const pixAppCertifiablePage = await pixAppCertifiableUserPage(certifiableUserData);
     const { sessionNumber, certificationNumber, certificationCenterName } = await enrollCandidateAndPassExam({
       testRef,

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/core/PRO_CORE_1OK-0KO_EndedByFinalization_TechnicalIssue.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/core/PRO_CORE_1OK-0KO_EndedByFinalization_TechnicalIssue.spec.ts
@@ -37,7 +37,7 @@ test(
     snapshotPath,
     csvResultPath,
   }) => {
-    const certifiableUserData = await getCertifiableUserData(0);
+    const certifiableUserData = await getCertifiableUserData('buffy.summers@example.net');
     const pixAppCertifiablePage = await pixAppCertifiableUserPage(certifiableUserData);
     const { sessionNumber, certificationNumber, certificationCenterName } = await enrollCandidateAndPassExam({
       testRef,

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/core/PRO_CORE_1OK-0KO_EndedByInvigilator_Abandonment.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/core/PRO_CORE_1OK-0KO_EndedByInvigilator_Abandonment.spec.ts
@@ -37,7 +37,7 @@ test(
     snapshotPath,
     csvResultPath,
   }) => {
-    const certifiableUserData = await getCertifiableUserData(0);
+    const certifiableUserData = await getCertifiableUserData('buffy.summers@example.net');
     const pixAppCertifiablePage = await pixAppCertifiableUserPage(certifiableUserData);
     const { sessionNumber, invigilatorOverviewPage, certificationNumber, certificationCenterName } =
       await enrollCandidateAndPassExam({

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/core/PRO_CORE_1OK-0KO_EndedByInvigilator_TechnicalIssue.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/core/PRO_CORE_1OK-0KO_EndedByInvigilator_TechnicalIssue.spec.ts
@@ -37,7 +37,7 @@ test(
     snapshotPath,
     csvResultPath,
   }) => {
-    const certifiableUserData = await getCertifiableUserData(0);
+    const certifiableUserData = await getCertifiableUserData('buffy.summers@example.net');
     const pixAppCertifiablePage = await pixAppCertifiableUserPage(certifiableUserData);
     const { sessionNumber, invigilatorOverviewPage, certificationNumber, certificationCenterName } =
       await enrollCandidateAndPassExam({

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/core/PRO_CORE_24OK-0KO_EndedByFinalization_Abandonment.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/core/PRO_CORE_24OK-0KO_EndedByFinalization_Abandonment.spec.ts
@@ -39,7 +39,7 @@ test(
     csvResultPath,
     certificateBasePath,
   }) => {
-    const certifiableUserData = await getCertifiableUserData(0);
+    const certifiableUserData = await getCertifiableUserData('buffy.summers@example.net');
     const pixAppCertifiablePage = await pixAppCertifiableUserPage(certifiableUserData);
     const { sessionNumber, certificationNumber, certificationCenterName } = await enrollCandidateAndPassExam({
       testRef,

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/core/PRO_CORE_24OK-0KO_EndedByFinalization_TechnicalIssue.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/core/PRO_CORE_24OK-0KO_EndedByFinalization_TechnicalIssue.spec.ts
@@ -39,7 +39,7 @@ test(
     csvResultPath,
     certificateBasePath,
   }) => {
-    const certifiableUserData = await getCertifiableUserData(0);
+    const certifiableUserData = await getCertifiableUserData('buffy.summers@example.net');
     const pixAppCertifiablePage = await pixAppCertifiableUserPage(certifiableUserData);
     const { sessionNumber, certificationNumber, certificationCenterName } = await enrollCandidateAndPassExam({
       testRef,

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/core/PRO_CORE_24OK-0KO_EndedByInvigilator_Abandonment.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/core/PRO_CORE_24OK-0KO_EndedByInvigilator_Abandonment.spec.ts
@@ -39,7 +39,7 @@ test(
     csvResultPath,
     certificateBasePath,
   }) => {
-    const certifiableUserData = await getCertifiableUserData(0);
+    const certifiableUserData = await getCertifiableUserData('buffy.summers@example.net');
     const pixAppCertifiablePage = await pixAppCertifiableUserPage(certifiableUserData);
     const { sessionNumber, invigilatorOverviewPage, certificationNumber, certificationCenterName } =
       await enrollCandidateAndPassExam({

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/core/PRO_CORE_24OK-0KO_EndedByInvigilator_TechnicalIssue.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/core/PRO_CORE_24OK-0KO_EndedByInvigilator_TechnicalIssue.spec.ts
@@ -39,7 +39,7 @@ test(
     csvResultPath,
     certificateBasePath,
   }) => {
-    const certifiableUserData = await getCertifiableUserData(0);
+    const certifiableUserData = await getCertifiableUserData('buffy.summers@example.net');
     const pixAppCertifiablePage = await pixAppCertifiableUserPage(certifiableUserData);
     const { sessionNumber, invigilatorOverviewPage, certificationNumber, certificationCenterName } =
       await enrollCandidateAndPassExam({

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/core/PRO_CORE_32OK-0KO.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/core/PRO_CORE_32OK-0KO.spec.ts
@@ -40,7 +40,7 @@ test(
     csvResultPath,
     certificateBasePath,
   }) => {
-    const certifiableUserData = await getCertifiableUserData(0);
+    const certifiableUserData = await getCertifiableUserData('buffy.summers@example.net');
     const pixAppCertifiablePage = await pixAppCertifiableUserPage(certifiableUserData);
     const { sessionNumber, certificationNumber, certificationCenterName } = await enrollCandidateAndPassExam({
       testRef,

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/core/PRO_CORE_32OK-0KO_Rescore.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/core/PRO_CORE_32OK-0KO_Rescore.spec.ts
@@ -42,7 +42,7 @@ test(
     csvResultPath,
     certificateBasePath,
   }) => {
-    const certifiableUserData = await getCertifiableUserData(0);
+    const certifiableUserData = await getCertifiableUserData('buffy.summers@example.net');
     const pixAppCertifiablePage = await pixAppCertifiableUserPage(certifiableUserData);
     const { sessionNumber, certificationNumber, certificationCenterName } = await enrollCandidateAndPassExam({
       testRef,

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/core/PRO_CORE_32OK-0KO_Uncancelled.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/core/PRO_CORE_32OK-0KO_Uncancelled.spec.ts
@@ -44,7 +44,7 @@ test(
     csvResultPath,
     certificateBasePath,
   }) => {
-    const certifiableUserData = await getCertifiableUserData(0);
+    const certifiableUserData = await getCertifiableUserData('buffy.summers@example.net');
     const pixAppCertifiablePage = await pixAppCertifiableUserPage(certifiableUserData);
     const { sessionNumber, certificationNumber, certificationCenterName } = await enrollCandidateAndPassExam({
       testRef,

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/core/PRO_CORE_32OK-0KO_Unrejected.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/core/PRO_CORE_32OK-0KO_Unrejected.spec.ts
@@ -44,7 +44,7 @@ test(
     csvResultPath,
     certificateBasePath,
   }) => {
-    const certifiableUserData = await getCertifiableUserData(0);
+    const certifiableUserData = await getCertifiableUserData('buffy.summers@example.net');
     const pixAppCertifiablePage = await pixAppCertifiableUserPage(certifiableUserData);
     const { sessionNumber, certificationNumber, certificationCenterName } = await enrollCandidateAndPassExam({
       testRef,

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/droit/DROIT_0OK-32KO.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/droit/DROIT_0OK-32KO.spec.ts
@@ -34,7 +34,7 @@ test(
     testRef,
     snapshotPath,
   }) => {
-    const certifiableUserData = await getCertifiableUserData(0);
+    const certifiableUserData = await getCertifiableUserData('buffy.summers@example.net');
     const pixAppCertifiablePage = await pixAppCertifiableUserPage(certifiableUserData);
     const { sessionNumber, certificationNumber } = await enrollCandidateAndPassExam({
       testRef,

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/droit/DROIT_1OK-0KO_EndedByFinalization_Abandonment.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/droit/DROIT_1OK-0KO_EndedByFinalization_Abandonment.spec.ts
@@ -33,7 +33,7 @@ test(
     testRef,
     snapshotPath,
   }) => {
-    const certifiableUserData = await getCertifiableUserData(0);
+    const certifiableUserData = await getCertifiableUserData('buffy.summers@example.net');
     const pixAppCertifiablePage = await pixAppCertifiableUserPage(certifiableUserData);
     const { sessionNumber } = await enrollCandidateAndPassExam({
       testRef,

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/droit/DROIT_1OK-0KO_EndedByFinalization_TechnicalIssue.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/droit/DROIT_1OK-0KO_EndedByFinalization_TechnicalIssue.spec.ts
@@ -33,7 +33,7 @@ test(
     testRef,
     snapshotPath,
   }) => {
-    const certifiableUserData = await getCertifiableUserData(0);
+    const certifiableUserData = await getCertifiableUserData('buffy.summers@example.net');
     const pixAppCertifiablePage = await pixAppCertifiableUserPage(certifiableUserData);
     const { sessionNumber } = await enrollCandidateAndPassExam({
       testRef,

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/droit/DROIT_1OK-0KO_EndedByInvigilator_Abandonment.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/droit/DROIT_1OK-0KO_EndedByInvigilator_Abandonment.spec.ts
@@ -33,7 +33,7 @@ test(
     testRef,
     snapshotPath,
   }) => {
-    const certifiableUserData = await getCertifiableUserData(0);
+    const certifiableUserData = await getCertifiableUserData('buffy.summers@example.net');
     const pixAppCertifiablePage = await pixAppCertifiableUserPage(certifiableUserData);
     const { sessionNumber, invigilatorOverviewPage } = await enrollCandidateAndPassExam({
       testRef,

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/droit/DROIT_1OK-0KO_EndedByInvigilator_TechnicalIssue.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/droit/DROIT_1OK-0KO_EndedByInvigilator_TechnicalIssue.spec.ts
@@ -33,7 +33,7 @@ test(
     testRef,
     snapshotPath,
   }) => {
-    const certifiableUserData = await getCertifiableUserData(0);
+    const certifiableUserData = await getCertifiableUserData('buffy.summers@example.net');
     const pixAppCertifiablePage = await pixAppCertifiableUserPage(certifiableUserData);
     const { sessionNumber, invigilatorOverviewPage } = await enrollCandidateAndPassExam({
       testRef,

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/droit/DROIT_32OK-0KO.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/droit/DROIT_32OK-0KO.spec.ts
@@ -34,7 +34,7 @@ test(
     testRef,
     snapshotPath,
   }) => {
-    const certifiableUserData = await getCertifiableUserData(0);
+    const certifiableUserData = await getCertifiableUserData('buffy.summers@example.net');
     const pixAppCertifiablePage = await pixAppCertifiableUserPage(certifiableUserData);
     const { sessionNumber, certificationNumber } = await enrollCandidateAndPassExam({
       testRef,

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/droit/DROIT_32OK-0KO_RejectForFraud.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/droit/DROIT_32OK-0KO_RejectForFraud.spec.ts
@@ -35,7 +35,7 @@ test(
     testRef,
     snapshotPath,
   }) => {
-    const certifiableUserData = await getCertifiableUserData(0);
+    const certifiableUserData = await getCertifiableUserData('buffy.summers@example.net');
     const pixAppCertifiablePage = await pixAppCertifiableUserPage(certifiableUserData);
     const { sessionNumber, certificationNumber } = await enrollCandidateAndPassExam({
       testRef,

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/droit/DROIT_32OK-0KO_Rescore.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/droit/DROIT_32OK-0KO_Rescore.spec.ts
@@ -36,7 +36,7 @@ test(
     testRef,
     snapshotPath,
   }) => {
-    const certifiableUserData = await getCertifiableUserData(0);
+    const certifiableUserData = await getCertifiableUserData('buffy.summers@example.net');
     const pixAppCertifiablePage = await pixAppCertifiableUserPage(certifiableUserData);
     const { sessionNumber, certificationNumber } = await enrollCandidateAndPassExam({
       testRef,

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/edu/EDU_0OK-32KO.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/edu/EDU_0OK-32KO.spec.ts
@@ -40,7 +40,7 @@ test(
     snapshotPath,
     csvResultPath,
   }) => {
-    const certifiableUserData = await getCertifiableUserData(0);
+    const certifiableUserData = await getCertifiableUserData('buffy.summers@example.net');
     const pixAppCertifiablePage = await pixAppCertifiableUserPage(certifiableUserData);
     const { sessionNumber, certificationNumber, certificationCenterName } = await enrollCandidateAndPassExam({
       testRef,

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/edu/EDU_1OK-0KO_EndedByFinalization_Abandonment.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/edu/EDU_1OK-0KO_EndedByFinalization_Abandonment.spec.ts
@@ -39,7 +39,7 @@ test(
     snapshotPath,
     csvResultPath,
   }) => {
-    const certifiableUserData = await getCertifiableUserData(0);
+    const certifiableUserData = await getCertifiableUserData('buffy.summers@example.net');
     const pixAppCertifiablePage = await pixAppCertifiableUserPage(certifiableUserData);
     const { sessionNumber, certificationNumber, certificationCenterName } = await enrollCandidateAndPassExam({
       testRef,

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/edu/EDU_1OK-0KO_EndedByFinalization_TechnicalIssue.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/edu/EDU_1OK-0KO_EndedByFinalization_TechnicalIssue.spec.ts
@@ -39,7 +39,7 @@ test(
     snapshotPath,
     csvResultPath,
   }) => {
-    const certifiableUserData = await getCertifiableUserData(0);
+    const certifiableUserData = await getCertifiableUserData('buffy.summers@example.net');
     const pixAppCertifiablePage = await pixAppCertifiableUserPage(certifiableUserData);
     const { sessionNumber, certificationCenterName, certificationNumber } = await enrollCandidateAndPassExam({
       testRef,

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/edu/EDU_1OK-0KO_EndedByInvigilator_Abandonment.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/edu/EDU_1OK-0KO_EndedByInvigilator_Abandonment.spec.ts
@@ -39,7 +39,7 @@ test(
     snapshotPath,
     csvResultPath,
   }) => {
-    const certifiableUserData = await getCertifiableUserData(0);
+    const certifiableUserData = await getCertifiableUserData('buffy.summers@example.net');
     const pixAppCertifiablePage = await pixAppCertifiableUserPage(certifiableUserData);
     const { sessionNumber, invigilatorOverviewPage, certificationNumber, certificationCenterName } =
       await enrollCandidateAndPassExam({

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/edu/EDU_1OK-0KO_EndedByInvigilator_TechnicalIssue.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/edu/EDU_1OK-0KO_EndedByInvigilator_TechnicalIssue.spec.ts
@@ -39,7 +39,7 @@ test(
     snapshotPath,
     csvResultPath,
   }) => {
-    const certifiableUserData = await getCertifiableUserData(0);
+    const certifiableUserData = await getCertifiableUserData('buffy.summers@example.net');
     const pixAppCertifiablePage = await pixAppCertifiableUserPage(certifiableUserData);
     const { sessionNumber, invigilatorOverviewPage, certificationNumber, certificationCenterName } =
       await enrollCandidateAndPassExam({

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/edu/EDU_32OK-0KO.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/edu/EDU_32OK-0KO.spec.ts
@@ -40,7 +40,7 @@ test(
     snapshotPath,
     csvResultPath,
   }) => {
-    const certifiableUserData = await getCertifiableUserData(0);
+    const certifiableUserData = await getCertifiableUserData('buffy.summers@example.net');
     const pixAppCertifiablePage = await pixAppCertifiableUserPage(certifiableUserData);
     const { sessionNumber, certificationNumber, certificationCenterName } = await enrollCandidateAndPassExam({
       testRef,

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/edu/EDU_32OK-0KO_RejectForFraud.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/edu/EDU_32OK-0KO_RejectForFraud.spec.ts
@@ -41,7 +41,7 @@ test(
     snapshotPath,
     csvResultPath,
   }) => {
-    const certifiableUserData = await getCertifiableUserData(0);
+    const certifiableUserData = await getCertifiableUserData('buffy.summers@example.net');
     const pixAppCertifiablePage = await pixAppCertifiableUserPage(certifiableUserData);
     const { sessionNumber, certificationNumber, certificationCenterName } = await enrollCandidateAndPassExam({
       testRef,

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/edu/EDU_32OK-0KO_Rescore.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/edu/EDU_32OK-0KO_Rescore.spec.ts
@@ -42,7 +42,7 @@ test(
     snapshotPath,
     csvResultPath,
   }) => {
-    const certifiableUserData = await getCertifiableUserData(0);
+    const certifiableUserData = await getCertifiableUserData('buffy.summers@example.net');
     const pixAppCertifiablePage = await pixAppCertifiableUserPage(certifiableUserData);
     const { sessionNumber, certificationNumber, certificationCenterName } = await enrollCandidateAndPassExam({
       testRef,

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/pro-sante/PRO-SANTE_0OK-32KO.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/pro-sante/PRO-SANTE_0OK-32KO.spec.ts
@@ -34,7 +34,7 @@ test(
     testRef,
     snapshotPath,
   }) => {
-    const certifiableUserData = await getCertifiableUserData(0);
+    const certifiableUserData = await getCertifiableUserData('buffy.summers@example.net');
     const pixAppCertifiablePage = await pixAppCertifiableUserPage(certifiableUserData);
     const { sessionNumber, certificationNumber } = await enrollCandidateAndPassExam({
       testRef,

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/pro-sante/PRO-SANTE_1OK-0KO_EndedByFinalization_Abandonment.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/pro-sante/PRO-SANTE_1OK-0KO_EndedByFinalization_Abandonment.spec.ts
@@ -33,7 +33,7 @@ test(
     testRef,
     snapshotPath,
   }) => {
-    const certifiableUserData = await getCertifiableUserData(0);
+    const certifiableUserData = await getCertifiableUserData('buffy.summers@example.net');
     const pixAppCertifiablePage = await pixAppCertifiableUserPage(certifiableUserData);
     const { sessionNumber } = await enrollCandidateAndPassExam({
       testRef,

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/pro-sante/PRO-SANTE_1OK-0KO_EndedByFinalization_TechnicalIssue.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/pro-sante/PRO-SANTE_1OK-0KO_EndedByFinalization_TechnicalIssue.spec.ts
@@ -33,7 +33,7 @@ test(
     testRef,
     snapshotPath,
   }) => {
-    const certifiableUserData = await getCertifiableUserData(0);
+    const certifiableUserData = await getCertifiableUserData('buffy.summers@example.net');
     const pixAppCertifiablePage = await pixAppCertifiableUserPage(certifiableUserData);
     const { sessionNumber } = await enrollCandidateAndPassExam({
       testRef,

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/pro-sante/PRO-SANTE_1OK-0KO_EndedByInvigilator_Abandonment.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/pro-sante/PRO-SANTE_1OK-0KO_EndedByInvigilator_Abandonment.spec.ts
@@ -33,7 +33,7 @@ test(
     testRef,
     snapshotPath,
   }) => {
-    const certifiableUserData = await getCertifiableUserData(0);
+    const certifiableUserData = await getCertifiableUserData('buffy.summers@example.net');
     const pixAppCertifiablePage = await pixAppCertifiableUserPage(certifiableUserData);
     const { sessionNumber, invigilatorOverviewPage } = await enrollCandidateAndPassExam({
       testRef,

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/pro-sante/PRO-SANTE_1OK-0KO_EndedByInvigilator_TechnicalIssue.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/pro-sante/PRO-SANTE_1OK-0KO_EndedByInvigilator_TechnicalIssue.spec.ts
@@ -33,7 +33,7 @@ test(
     testRef,
     snapshotPath,
   }) => {
-    const certifiableUserData = await getCertifiableUserData(0);
+    const certifiableUserData = await getCertifiableUserData('buffy.summers@example.net');
     const pixAppCertifiablePage = await pixAppCertifiableUserPage(certifiableUserData);
     const { sessionNumber, invigilatorOverviewPage } = await enrollCandidateAndPassExam({
       testRef,

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/pro-sante/PRO-SANTE_32OK-0KO.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/pro-sante/PRO-SANTE_32OK-0KO.spec.ts
@@ -35,7 +35,7 @@ test(
     waitForScoringJobToBeCompleted,
     snapshotHandler,
   }) => {
-    const certifiableUserData = await getCertifiableUserData(0);
+    const certifiableUserData = await getCertifiableUserData('buffy.summers@example.net');
     const pixAppCertifiablePage = await pixAppCertifiableUserPage(certifiableUserData);
     const { sessionNumber, certificationNumber } = await enrollCandidateAndPassExam({
       testRef,

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/pro-sante/PRO-SANTE_32OK-0KO_RejectForFraud.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/pro-sante/PRO-SANTE_32OK-0KO_RejectForFraud.spec.ts
@@ -36,7 +36,7 @@ test(
     waitForScoringJobToBeCompleted,
     snapshotHandler,
   }) => {
-    const certifiableUserData = await getCertifiableUserData(0);
+    const certifiableUserData = await getCertifiableUserData('buffy.summers@example.net');
     const pixAppCertifiablePage = await pixAppCertifiableUserPage(certifiableUserData);
     const { sessionNumber, certificationNumber } = await enrollCandidateAndPassExam({
       testRef,

--- a/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/pro-sante/PRO-SANTE_32OK-0KO_Rescore.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/results/pix-plus/pro-sante/PRO-SANTE_32OK-0KO_Rescore.spec.ts
@@ -37,7 +37,7 @@ test(
     waitForScoringJobToBeCompleted,
     snapshotHandler,
   }) => {
-    const certifiableUserData = await getCertifiableUserData(0);
+    const certifiableUserData = await getCertifiableUserData('buffy.summers@example.net');
     const pixAppCertifiablePage = await pixAppCertifiableUserPage(certifiableUserData);
     const { sessionNumber, certificationNumber } = await enrollCandidateAndPassExam({
       testRef,


### PR DESCRIPTION
## 🌱 Problème

Nous ne dispons à l'heure actuelle que de tests E2E liés au PRO.

## 🐣 Proposition

Afin de ne ne pas avoir à recette indéfiniment le SCO, on ajoute un E2E lié à l'inscription SCO.
Le reste du process de certif ne change pas entre les deux types.

## 🌷 Remarques

L'instanciation de l'application front orga pour les tests E2E de recette certif est supprimée dans cette PR.

## 🐝 Pour tester

Tests verts.
