### PR TITLE
[FEATURE] Ajout du label au formulaire de création d'attestation (PIX-22301)

### DIFF
--- a/admin/app/components/administration/common/create-attestations.gjs
+++ b/admin/app/components/administration/common/create-attestations.gjs
@@ -2,6 +2,7 @@ import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixButtonUpload from '@1024pix/pix-ui/components/pix-button-upload';
 import PixInput from '@1024pix/pix-ui/components/pix-input';
 import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
+import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
@@ -19,6 +20,7 @@ export default class CreateAttestations extends Component {
   @service requestManager;
 
   @tracked file;
+  @tracked label;
   @tracked templateKey;
   @tracked templateName;
 
@@ -34,13 +36,8 @@ export default class CreateAttestations extends Component {
   }
 
   @action
-  async onTemplateKeyChange(event) {
-    this.templateKey = event.target.value;
-  }
-
-  @action
-  async onTemplateNameChange(event) {
-    this.templateName = event.target.value;
+  async onInputChange(fieldName, event) {
+    this[fieldName] = event.target.value;
   }
 
   @action
@@ -49,6 +46,7 @@ export default class CreateAttestations extends Component {
     try {
       const formData = new FormData();
 
+      formData.append('label', this.label);
       formData.append('templateKey', this.templateKey);
       formData.append('templateName', this.templateName);
       formData.append('templateFile', this.file);
@@ -63,29 +61,31 @@ export default class CreateAttestations extends Component {
         message: this.intl.t('components.administration.create-attestations.notifications.success'),
       });
     } catch (error) {
-      if (error.status === 413) {
-        this.pixToast.sendErrorNotification({
-          message: this.intl.t('components.administration.create-attestations.notifications.error.payload-too-large'),
-        });
-      } else if (error.code === 'S3_UPLOAD_ERROR') {
-        this.pixToast.sendErrorNotification({
-          message: this.intl.t('components.administration.create-attestations.notifications.error.s3-upload-error'),
-        });
-      } else if (error.code === 'DUPLICATE_ATTESTATION_KEY') {
-        this.pixToast.sendErrorNotification({
-          message: this.intl.t(
-            'components.administration.create-attestations.notifications.error.duplicate-attestation-key',
-          ),
-        });
-      } else if (error.status === 400 && error.code === 'WRONG_FILE_FORMAT') {
-        this.pixToast.sendErrorNotification({
-          message: this.intl.t('components.administration.create-attestations.notifications.error.wrong-file-format'),
-        });
-      } else {
-        this.pixToast.sendErrorNotification({
-          message: this.intl.t('components.administration.create-attestations.notifications.error.generic-error'),
-        });
-      }
+      error.errors.forEach((error) => {
+        if (error.status === 413) {
+          this.pixToast.sendErrorNotification({
+            message: this.intl.t('components.administration.create-attestations.notifications.error.payload-too-large'),
+          });
+        } else if (error.code === 'S3_UPLOAD_ERROR') {
+          this.pixToast.sendErrorNotification({
+            message: this.intl.t('components.administration.create-attestations.notifications.error.s3-upload-error'),
+          });
+        } else if (error.code === 'DUPLICATE_ATTESTATION_KEY') {
+          this.pixToast.sendErrorNotification({
+            message: this.intl.t(
+              'components.administration.create-attestations.notifications.error.duplicate-attestation-key',
+            ),
+          });
+        } else if (error.status === 400 && error.code === 'WRONG_FILE_FORMAT') {
+          this.pixToast.sendErrorNotification({
+            message: this.intl.t('components.administration.create-attestations.notifications.error.wrong-file-format'),
+          });
+        } else {
+          this.pixToast.sendErrorNotification({
+            message: this.intl.t('common.notifications.generic-error'),
+          });
+        }
+      });
     }
   }
 
@@ -99,8 +99,16 @@ export default class CreateAttestations extends Component {
       >
         <PixInput
           required="true"
+          @value={{this.label}}
+          {{on "input" (fn this.onInputChange "label")}}
+          @requiredLabel="Champ obligatoire"
+        >
+          <:label>{{t "components.administration.create-attestations.label"}} </:label>
+        </PixInput>
+        <PixInput
+          required="true"
           @value={{this.templateKey}}
-          {{on "input" this.onTemplateKeyChange}}
+          {{on "input" (fn this.onInputChange "templateKey")}}
           @requiredLabel="Champ obligatoire"
         >
           <:label>{{t "components.administration.create-attestations.template-key"}} </:label>
@@ -108,7 +116,7 @@ export default class CreateAttestations extends Component {
         <PixInput
           required="true"
           @value={{this.templateName}}
-          {{on "input" this.onTemplateNameChange}}
+          {{on "input" (fn this.onInputChange "templateName")}}
           @requiredLabel="Champ obligatoire"
         >
           <:label>{{t "components.administration.create-attestations.template-name"}} </:label>

--- a/admin/tests/integration/components/administration/common/create-attestations-test.gjs
+++ b/admin/tests/integration/components/administration/common/create-attestations-test.gjs
@@ -34,6 +34,7 @@ module('Integration | Component | administration/create-attestations', function 
       });
 
       await triggerEvent(inputFile, 'change', { files: [file] });
+      await fillByLabel(t('components.administration.create-attestations.label'), 'label', { exact: false });
       await fillByLabel(t('components.administration.create-attestations.template-key'), 'key', { exact: false });
       await fillByLabel(t('components.administration.create-attestations.template-name'), 'name', { exact: false });
 
@@ -54,6 +55,7 @@ module('Integration | Component | administration/create-attestations', function 
       });
 
       await triggerEvent(inputFile, 'change', { files: [file] });
+      await fillByLabel(t('components.administration.create-attestations.label'), 'label', { exact: false });
       await fillByLabel(t('components.administration.create-attestations.template-key'), 'key', { exact: false });
       await fillByLabel(t('components.administration.create-attestations.template-name'), 'name', { exact: false });
 
@@ -72,13 +74,14 @@ module('Integration | Component | administration/create-attestations', function 
         name: t('components.administration.create-attestations.submit-button'),
       });
 
+      await fillByLabel(t('components.administration.create-attestations.label'), 'label', { exact: false });
       await fillByLabel(t('components.administration.create-attestations.template-key'), 'key', { exact: false });
       await fillByLabel(t('components.administration.create-attestations.template-name'), 'name', { exact: false });
 
       assert.dom(submit).hasAttribute('aria-disabled');
     });
 
-    test('it should disable submit button if no key or name', async function (assert) {
+    test('it should disable submit button if no label, no key or no name', async function (assert) {
       const screen = await render(
         <template><CreateAttestations /><PixToastContainer @closeButtonAriaLabel="Close" /></template>,
       );
@@ -123,7 +126,7 @@ module('Integration | Component | administration/create-attestations', function 
     ].forEach(({ name, status, code, translationKey }) => {
       test(`it should display ${name} error`, async function (assert) {
         // given
-        requestManagerService.request.rejects({ status, code });
+        requestManagerService.request.rejects({ errors: [{ status, code }] });
 
         const screen = await render(
           <template><CreateAttestations /><PixToastContainer @closeButtonAriaLabel="Close" /></template>,
@@ -135,6 +138,7 @@ module('Integration | Component | administration/create-attestations', function 
         });
 
         await triggerEvent(inputFile, 'change', { files: [file] });
+        await fillByLabel(t('components.administration.create-attestations.label'), 'label', { exact: false });
         await fillByLabel(t('components.administration.create-attestations.template-key'), 'key', { exact: false });
         await fillByLabel(t('components.administration.create-attestations.template-name'), 'name', { exact: false });
 

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -212,6 +212,7 @@
       },
       "create-attestations": {
         "description": "Ask for expert help if needed",
+        "label": "Label",
         "notifications": {
           "error": {
             "S3-upload-error": "File import error.",

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -219,6 +219,7 @@
       },
       "create-attestations": {
         "description": "Sollicitez un spécialiste des attestations",
+        "label": "Label",
         "notifications": {
           "error": {
             "duplicate-attestation-key": "Une attestation avec cette clé existe déjà.",


### PR DESCRIPTION
## 🌱 Problème

Un champ label a été ajouté pour les attestations, mais on ne pouvait pas encore le remplir via le formulaire de création d'attestation d'admin.

## 🐣 Proposition

Ajouter un champ label dans le formulaire de création d'attestation.

## 🌷 Remarques

On gérait mal les cas d'erreurs du formulaire, on a donc modifié cette gestion et le test en conséquence.

## 🐝 Pour tester

Se rendre sur Pix Admin -> Administration -> Commun -> Création d'attestation
Créer une attestation
Vérifier qu'un message de succès remonte
Tenter de renvoyer le formulaire avec les mêmes données (la `key` surtout)
Un message d'erreur indiquant que la `key` existe déjà doit apparaître
Vérifier en base que l'attestation existe