### PR TITLE
[FEATURE] Rendre obligatoire le questId sur combined-course-blueprints (PIX-21724)

### DIFF
--- a/api/db/migrations/20260417135957_make-questId-mandatory-on-combined-course-blueprints.js
+++ b/api/db/migrations/20260417135957_make-questId-mandatory-on-combined-course-blueprints.js
@@ -1,0 +1,24 @@
+const TABLE_NAME = 'combined_course_blueprints';
+const COLUMN_NAME = 'questId';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.integer(COLUMN_NAME).notNullable().alter();
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.integer(COLUMN_NAME).nullable().alter();
+  });
+};
+
+export { down, up };

--- a/api/tests/quest/integration/infrastructure/repositories/combined-course-blueprint-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/combined-course-blueprint-repository_test.js
@@ -165,50 +165,6 @@ describe('Quest | Integration | Repository | combined-course-blueprint', functio
         },
       ]);
     });
-
-    it('should attach a new quest to combined course blueprint when none', async function () {
-      // given
-      const combinedCourseBlueprintInDb = databaseBuilder.factory.buildCombinedCourseBlueprint({
-        questId: null,
-      });
-
-      const combinedCourseBlueprint = CombinedCourseBlueprint.buildWithQuest({
-        adminCombinedCourseBlueprint: new AdminCombinedCourseBlueprint({
-          id: combinedCourseBlueprintInDb.id,
-          name: 'Combined course IA',
-          internalName: 'Ia combined course blueprint',
-          description: "L'ia c'est magique",
-          illustration: 'illustration/ia.svg',
-          content: AdminCombinedCourseBlueprint.buildContentItems([{ moduleShortId: '6a68bf32' }]),
-          organizationIds: [],
-        }),
-        modulesByShortId: { '6a68bf32': [{ id: '6282925d-4775-4bca-b513-4c3009ec5886' }] },
-      });
-
-      await databaseBuilder.commit();
-
-      // when
-      await combinedCourseBluePrintRepository.save({
-        combinedCourseBlueprint,
-      });
-
-      // then
-      const results = await combinedCourseBluePrintRepository.findAll();
-      expect(results).lengthOf(1);
-      expect(results[0].quest.toDTO().successRequirements).deep.equal([
-        {
-          comparison: REQUIREMENT_COMPARISONS.ALL,
-          requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
-          data: {
-            isTerminated: { comparison: CRITERION_COMPARISONS.EQUAL, data: true },
-            moduleId: {
-              comparison: CRITERION_COMPARISONS.EQUAL,
-              data: '6282925d-4775-4bca-b513-4c3009ec5886',
-            },
-          },
-        },
-      ]);
-    });
   });
 
   describe('#findAll', function () {


### PR DESCRIPTION
## 🌱 Problème
On a joué un script de rattrapage pour remplir les colonnes questId qui étaient nulles sur les blueprints.
Maintenant, le questId doit être obligatoire sur les combined course blueprints.

## 🐣 Proposition
On ajoute une contrainte "not nullable" sur le champ questId.


## 🐝 Pour tester
npm run db:rollback:latest
npm run db:migrate
\d combined_course_blueprints
Vérifier que "questId" n'est pas nullable
