### PR TITLE
[TECH] Rendre la colonne label de la table attestations non nullable (PIX-22297)

### DIFF
--- a/api/db/migrations/20260417140721_make-attestation-label-not-nullable.js
+++ b/api/db/migrations/20260417140721_make-attestation-label-not-nullable.js
@@ -1,0 +1,24 @@
+const TABLE_NAME = 'attestations';
+const COLUMN_NAME = 'label';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.string(COLUMN_NAME).notNullable().alter();
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.string(COLUMN_NAME).nullable().alter();
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## 🌱 Problème

Actuellement, la colonne label est nullable en db. Cela a permis d'ajouter la colonne et de faire le rattrapage des attestations existantes.

## 🐣 Proposition

Maintenant que les attestations ont été rattrapées, on ajoute cette contrainte afin de garantir l'intégrité de la table.

## 🌷 Remarques

RAS

## 🐝 Pour tester

Ouvrir Postgres : `\d attestations` -> la colonne label n'a pas la notion "not nullable".

Api : `npm run db:migrate`

Postgres : `\d attestations` -> la colonne label a la notion "not nullable".
