### PR TITLE
[TECH] Utiliser le databaseBuilder au lieu du mockLearningContent

### DIFF
--- a/api/tests/acceptance/application/scenario-simulator/scenario-simulator-controller_test.js
+++ b/api/tests/acceptance/application/scenario-simulator/scenario-simulator-controller_test.js
@@ -4,7 +4,6 @@ import {
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
-  mockLearningContent,
   parseNDJSON,
 } from '../../../test-helper.js';
 
@@ -35,7 +34,6 @@ describe('Acceptance | Controller | scenario-simulator-controller', function () 
     });
 
     adminAuthorizationHeaders = generateAuthenticatedUserRequestHeaders({ userId: adminId });
-    await databaseBuilder.commit();
 
     validPayload = {
       capacity: 4.5,
@@ -180,7 +178,8 @@ describe('Acceptance | Controller | scenario-simulator-controller', function () 
       versionId: version.id,
     });
 
-    await mockLearningContent(learningContent);
+    databaseBuilder.factory.learningContent.build(learningContent);
+    await databaseBuilder.commit();
 
     server = await createServer();
   });

--- a/api/tests/acceptance/application/users/users-controller-get-user-profile-for-admin_test.js
+++ b/api/tests/acceptance/application/users/users-controller-get-user-profile-for-admin_test.js
@@ -4,7 +4,6 @@ import {
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
-  mockLearningContent,
 } from '../../../test-helper.js';
 
 describe('Acceptance | Controller | users-controller-get-user-profile-for-admin', function () {
@@ -95,11 +94,10 @@ describe('Acceptance | Controller | users-controller-get-user-profile-for-admin'
     describe('Success case', function () {
       beforeEach(async function () {
         const superAdminUser = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
-        await databaseBuilder.commit();
 
         options.headers = generateAuthenticatedUserRequestHeaders({ userId: superAdminUser.id });
 
-        await mockLearningContent(learningContent);
+        databaseBuilder.factory.learningContent.build(learningContent);
 
         knowledgeElement = databaseBuilder.factory.buildKnowledgeElement({
           userId,

--- a/api/tests/acceptance/application/users/users-controller-get-user-profile_test.js
+++ b/api/tests/acceptance/application/users/users-controller-get-user-profile_test.js
@@ -4,7 +4,6 @@ import {
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
-  mockLearningContent,
 } from '../../../test-helper.js';
 
 describe('Acceptance | Controller | users-controller-get-user-profile', function () {
@@ -97,7 +96,7 @@ describe('Acceptance | Controller | users-controller-get-user-profile', function
       beforeEach(async function () {
         options.headers = generateAuthenticatedUserRequestHeaders({ userId });
 
-        await mockLearningContent(learningContent);
+        databaseBuilder.factory.learningContent.build(learningContent);
 
         knowledgeElement = databaseBuilder.factory.buildKnowledgeElement({
           userId,

--- a/api/tests/acceptance/application/users/users-controller-reset-scorecard_test.js
+++ b/api/tests/acceptance/application/users/users-controller-reset-scorecard_test.js
@@ -8,7 +8,6 @@ import {
   generateAuthenticatedUserRequestHeaders,
   knex,
   learningContentBuilder,
-  mockLearningContent,
   sinon,
 } from '../../../test-helper.js';
 
@@ -50,7 +49,6 @@ describe('Acceptance | Controller | users-controller-reset-scorecard', function 
 
   beforeEach(async function () {
     userId = databaseBuilder.factory.buildUser().id;
-    await databaseBuilder.commit();
 
     options = {
       method: 'POST',
@@ -100,7 +98,8 @@ describe('Acceptance | Controller | users-controller-reset-scorecard', function 
       },
     ];
     const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
-    await mockLearningContent(learningContentObjects);
+    databaseBuilder.factory.learningContent.build(learningContentObjects);
+    await databaseBuilder.commit();
 
     server = await createServer();
   });

--- a/api/tests/certification/configuration/acceptance/application/certification-framework-route_test.js
+++ b/api/tests/certification/configuration/acceptance/application/certification-framework-route_test.js
@@ -7,7 +7,6 @@ import {
   expect,
   generateAuthenticatedUserRequestHeaders,
   knex,
-  mockLearningContent,
   sinon,
 } from '../../../../test-helper.js';
 import { buildLearningContent as learningContentBuilder } from '../../../../tooling/learning-content-builder/index.js';
@@ -135,7 +134,7 @@ describe('Acceptance | Application | Certification | ComplementaryCertification 
       ];
 
       const learningContentObjects = learningContentBuilder.fromAreas(minimalLearningContent);
-      await mockLearningContent(learningContentObjects);
+      databaseBuilder.factory.learningContent.build(learningContentObjects);
 
       const certificationVersion = databaseBuilder.factory.buildCertificationVersion({
         scope: SCOPES.CORE,

--- a/api/tests/certification/enrolment/acceptance/application/session-route_test.js
+++ b/api/tests/certification/enrolment/acceptance/application/session-route_test.js
@@ -8,7 +8,6 @@ import {
   generateAuthenticatedUserRequestHeaders,
   knex,
   learningContentBuilder,
-  mockLearningContent,
 } from '../../../../test-helper.js';
 
 describe('Certification | Enrolment | Acceptance | Routes | session-route', function () {
@@ -350,7 +349,8 @@ describe('Certification | Enrolment | Acceptance | Routes | session-route', func
         },
       ];
       const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
-      await mockLearningContent(learningContentObjects);
+      databaseBuilder.factory.learningContent.build(learningContentObjects);
+      await databaseBuilder.commit();
     });
 
     context('not SCO / isManagingStudents', function () {

--- a/api/tests/certification/enrolment/acceptance/application/subscription-route_test.js
+++ b/api/tests/certification/enrolment/acceptance/application/subscription-route_test.js
@@ -5,7 +5,6 @@ import {
   expect,
   generateAuthenticatedUserRequestHeaders,
   learningContentBuilder,
-  mockLearningContent,
 } from '../../../../test-helper.js';
 
 describe('Certification | Enrolment | Acceptance | Application | Routes | subscription', function () {
@@ -15,7 +14,7 @@ describe('Certification | Enrolment | Acceptance | Application | Routes | subscr
       const server = await createServer();
 
       const learningContent = _buildLearningContent();
-      await mockLearningContent(learningContent);
+      databaseBuilder.factory.learningContent.build(learningContent);
 
       const userId = databaseBuilder.factory.buildUser().id;
 

--- a/api/tests/certification/enrolment/acceptance/application/user-route_test.js
+++ b/api/tests/certification/enrolment/acceptance/application/user-route_test.js
@@ -6,7 +6,6 @@ import {
   expect,
   generateAuthenticatedUserRequestHeaders,
   learningContentBuilder,
-  mockLearningContent,
 } from '../../../../test-helper.js';
 
 describe('Certification | Enrolment | Acceptance | Routes | User', function () {
@@ -176,7 +175,7 @@ describe('Certification | Enrolment | Acceptance | Routes | User', function () {
         ],
       },
     ]);
-    await mockLearningContent(learningContent);
+    databaseBuilder.factory.learningContent.build(learningContent);
 
     learningContent.skills.forEach(({ id: skillId, competenceId }) => {
       databaseBuilder.factory.buildKnowledgeElement({ userId: user.id, earnedPix: 10, competenceId, skillId });

--- a/api/tests/certification/evaluation/acceptance/answer-route_test.js
+++ b/api/tests/certification/evaluation/acceptance/answer-route_test.js
@@ -4,7 +4,6 @@ import {
   expect,
   generateAuthenticatedUserRequestHeaders,
   knex,
-  mockLearningContent,
 } from '../../../test-helper.js';
 
 describe('Certification | Evaluation | Acceptance | answer-route', function () {
@@ -162,7 +161,8 @@ async function _buildLearningContent() {
       },
     ],
   };
-  await mockLearningContent(learningContent);
+  databaseBuilder.factory.learningContent.build(learningContent);
+  await databaseBuilder.commit();
 
   return {
     competenceId,

--- a/api/tests/certification/evaluation/acceptance/application/certification-courses/index_test.js
+++ b/api/tests/certification/evaluation/acceptance/application/certification-courses/index_test.js
@@ -6,7 +6,6 @@ import {
   generateInjectOptions,
   knex,
   learningContentBuilder,
-  mockLearningContent,
 } from '../../../../../test-helper.js';
 
 describe('Acceptance | Route | Certification Courses', function () {
@@ -221,12 +220,11 @@ describe('Acceptance | Route | Certification Courses', function () {
           },
         ];
         const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
-        await mockLearningContent(learningContentObjects);
+        databaseBuilder.factory.learningContent.build(learningContentObjects);
       });
 
       it('should create a certification course in database', async function () {
         // given
-
         databaseBuilder.factory.buildUser({ id: 1 });
         databaseBuilder.factory.buildSession({ id: 2, accessCode: 'FMKP39' });
         const candidate = databaseBuilder.factory.buildCertificationCandidate({

--- a/api/tests/certification/evaluation/acceptance/scoring-and-capacity-simulator-route_test.js
+++ b/api/tests/certification/evaluation/acceptance/scoring-and-capacity-simulator-route_test.js
@@ -5,7 +5,6 @@ import {
   expect,
   generateAuthenticatedUserRequestHeaders,
   learningContentBuilder,
-  mockLearningContent,
 } from '../../../test-helper.js';
 
 describe('Certification | Evaluation | Acceptance | scoring-and-capacity-simulator-route', function () {
@@ -451,7 +450,7 @@ describe('Certification | Evaluation | Acceptance | scoring-and-capacity-simulat
             },
           ];
           const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
-          await mockLearningContent(learningContentObjects);
+          databaseBuilder.factory.learningContent.build(learningContentObjects);
 
           const superAdmin = databaseBuilder.factory.buildUser.withRole({
             role: PIX_ADMIN.ROLES.SUPER_ADMIN,

--- a/api/tests/certification/evaluation/integration/domain/usecases/score-v3-certification_test.js
+++ b/api/tests/certification/evaluation/integration/domain/usecases/score-v3-certification_test.js
@@ -5,14 +5,7 @@ import { Frameworks } from '../../../../../../src/certification/shared/domain/mo
 import { DomainTransaction } from '../../../../../../src/shared/domain/DomainTransaction.js';
 import { Assessment } from '../../../../../../src/shared/domain/models/Assessment.js';
 import { FRENCH_SPOKEN } from '../../../../../../src/shared/domain/services/locale-service.js';
-import {
-  catchErr,
-  databaseBuilder,
-  expect,
-  knex,
-  learningContentBuilder,
-  mockLearningContent,
-} from '../../../../../test-helper.js';
+import { catchErr, databaseBuilder, expect, knex, learningContentBuilder } from '../../../../../test-helper.js';
 
 const challengeParams = {
   alpha: 1,
@@ -22,6 +15,7 @@ const challengeParams = {
 
 describe('Certification | Evaluation | Integration | Domain | Usecases | Score v3 certification', function () {
   let certificationVersionId;
+
   beforeEach(async function () {
     const learningContent = [
       {
@@ -138,7 +132,7 @@ describe('Certification | Evaluation | Integration | Domain | Usecases | Score v
       },
     ];
     const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
-    await mockLearningContent(learningContentObjects);
+    databaseBuilder.factory.learningContent.build(learningContentObjects);
 
     certificationVersionId = databaseBuilder.factory.buildCertificationVersion({
       challengesConfiguration: { maximumAssessmentLength: 10 },
@@ -150,6 +144,7 @@ describe('Certification | Evaluation | Integration | Domain | Usecases | Score v
 
   context('when certification is a Pix Core', function () {
     let certifiableUserId, certificationCourseId, completedCertificationAssessmentId;
+
     beforeEach(async function () {
       const limitDate = new Date('2020-01-01T00:00:00Z');
       certifiableUserId = databaseBuilder.factory.buildUser().id;

--- a/api/tests/certification/results/acceptance/application/certificate-route_test.js
+++ b/api/tests/certification/results/acceptance/application/certificate-route_test.js
@@ -19,7 +19,6 @@ import {
   expect,
   generateAuthenticatedUserRequestHeaders,
   learningContentBuilder,
-  mockLearningContent,
 } from '../../../../test-helper.js';
 
 describe('Certification | Results | Acceptance | Application | Certification', function () {
@@ -212,7 +211,8 @@ describe('Certification | Results | Acceptance | Application | Certification', f
       },
     ];
     const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
-    await mockLearningContent(learningContentObjects);
+    databaseBuilder.factory.learningContent.build(learningContentObjects);
+    await databaseBuilder.commit();
   });
 
   describe('GET /api/certifications/{certificationCourseId}', function () {

--- a/api/tests/certification/results/integration/infrastructure/repositories/certificate-repository_test.js
+++ b/api/tests/certification/results/integration/infrastructure/repositories/certificate-repository_test.js
@@ -11,7 +11,6 @@ import {
   domainBuilder,
   expect,
   learningContentBuilder,
-  mockLearningContent,
 } from '../../../../../test-helper.js';
 
 describe('Integration | Infrastructure | Repository | Certification', function () {
@@ -194,7 +193,7 @@ describe('Integration | Infrastructure | Repository | Certification', function (
     it('should take into account the latest validated assessment result of a student', async function () {
       // given
       const learningContentObjects = learningContentBuilder.fromAreas(minimalLearningContent);
-      await mockLearningContent(learningContentObjects);
+      databaseBuilder.factory.learningContent.build(learningContentObjects);
       const certificationAttestationData = {
         id: 123,
         firstName: 'Sarah Mi',
@@ -241,7 +240,7 @@ describe('Integration | Infrastructure | Repository | Certification', function (
       it('should return a CertificationAttestation', async function () {
         // given
         const learningContentObjects = learningContentBuilder.fromAreas(minimalLearningContent);
-        await mockLearningContent(learningContentObjects);
+        databaseBuilder.factory.learningContent.build(learningContentObjects);
 
         const certificationAttestationData = {
           id: 123,
@@ -359,7 +358,8 @@ describe('Integration | Infrastructure | Repository | Certification', function (
         const learningContentObjects = learningContentBuilder.fromAreas([
           { ...area1, title_i18n: { fr: area1.title } },
         ]);
-        await mockLearningContent(learningContentObjects);
+        databaseBuilder.factory.learningContent.build(learningContentObjects);
+        await databaseBuilder.commit();
 
         // when
         const certificationAttestation = await certificateRepository.getCertificate({
@@ -379,7 +379,7 @@ describe('Integration | Infrastructure | Repository | Certification', function (
         it(`should get the certified badge images when the certifications were acquired`, async function () {
           // given
           const learningContentObjects = learningContentBuilder.fromAreas(minimalLearningContent);
-          await mockLearningContent(learningContentObjects);
+          databaseBuilder.factory.learningContent.build(learningContentObjects);
           const certificationAttestationData = {
             id: 123,
             firstName: 'Sarah Mi',
@@ -573,7 +573,8 @@ describe('Integration | Infrastructure | Repository | Certification', function (
         const learningContentObjects = learningContentBuilder.fromAreas([
           { ...area1, title_i18n: { fr: area1.title } },
         ]);
-        await mockLearningContent(learningContentObjects);
+        databaseBuilder.factory.learningContent.build(learningContentObjects);
+        await databaseBuilder.commit();
 
         // when
         const certificationAttestation = await certificateRepository.getCertificate({
@@ -608,7 +609,7 @@ describe('Integration | Infrastructure | Repository | Certification', function (
         it('should return a V3Certificate with EDU globalLevel', async function () {
           // given
           const learningContentObjects = learningContentBuilder.fromAreas(minimalLearningContent);
-          await mockLearningContent(learningContentObjects);
+          databaseBuilder.factory.learningContent.build(learningContentObjects);
 
           const certificationAttestationData = {
             id: 123,
@@ -733,7 +734,7 @@ describe('Integration | Infrastructure | Repository | Certification', function (
       it('should return a Certificate', async function () {
         // given
         const learningContentObjects = learningContentBuilder.fromAreas(minimalLearningContent);
-        await mockLearningContent(learningContentObjects);
+        databaseBuilder.factory.learningContent.build(learningContentObjects);
 
         const certificationAttestationData = {
           id: 123,
@@ -783,7 +784,7 @@ describe('Integration | Infrastructure | Repository | Certification', function (
     it('should return an empty array when there are no certification attestations for given organization', async function () {
       // given
       const learningContentObjects = learningContentBuilder.fromAreas(minimalLearningContent);
-      await mockLearningContent(learningContentObjects);
+      databaseBuilder.factory.learningContent.build(learningContentObjects);
       databaseBuilder.factory.buildOrganization({ id: 123, type: 'SCO', isManagingStudents: true });
       databaseBuilder.factory.buildOrganization({ id: 456, type: 'SCO', isManagingStudents: true });
       const certificationAttestationData = {
@@ -831,7 +832,7 @@ describe('Integration | Infrastructure | Repository | Certification', function (
     it('should return an empty array when the organization is not SCO IS MANAGING STUDENTS', async function () {
       // given
       const learningContentObjects = learningContentBuilder.fromAreas(minimalLearningContent);
-      await mockLearningContent(learningContentObjects);
+      databaseBuilder.factory.learningContent.build(learningContentObjects);
       databaseBuilder.factory.buildOrganization({ id: 123, type: 'SUP', isManagingStudents: false });
       const certificationAttestationData = {
         id: 123,
@@ -878,7 +879,7 @@ describe('Integration | Infrastructure | Repository | Certification', function (
     it('should return an empty array when the certification does not belong to an organization learner in the right division', async function () {
       // given
       const learningContentObjects = learningContentBuilder.fromAreas(minimalLearningContent);
-      await mockLearningContent(learningContentObjects);
+      databaseBuilder.factory.learningContent.build(learningContentObjects);
       databaseBuilder.factory.buildOrganization({ id: 123, type: 'SCO', isManagingStudents: true });
       const certificationAttestationData = {
         id: 123,
@@ -925,7 +926,7 @@ describe('Integration | Infrastructure | Repository | Certification', function (
     it('should not return certifications that have no validated assessment-result', async function () {
       // given
       const learningContentObjects = learningContentBuilder.fromAreas(minimalLearningContent);
-      await mockLearningContent(learningContentObjects);
+      databaseBuilder.factory.learningContent.build(learningContentObjects);
       databaseBuilder.factory.buildOrganization({ id: 123, type: 'SCO', isManagingStudents: true });
       const certificationAttestationData = {
         id: 123,
@@ -972,7 +973,7 @@ describe('Integration | Infrastructure | Repository | Certification', function (
     it('should not return cancelled certifications', async function () {
       // given
       const learningContentObjects = learningContentBuilder.fromAreas(minimalLearningContent);
-      await mockLearningContent(learningContentObjects);
+      databaseBuilder.factory.learningContent.build(learningContentObjects);
       databaseBuilder.factory.buildOrganization({ id: 123, type: 'SCO', isManagingStudents: true });
       const certificationAttestationData = {
         id: 123,
@@ -1019,7 +1020,7 @@ describe('Integration | Infrastructure | Repository | Certification', function (
     it('should not return non published certifications', async function () {
       // given
       const learningContentObjects = learningContentBuilder.fromAreas(minimalLearningContent);
-      await mockLearningContent(learningContentObjects);
+      databaseBuilder.factory.learningContent.build(learningContentObjects);
       databaseBuilder.factory.buildOrganization({ id: 123, type: 'SCO', isManagingStudents: true });
       const certificationAttestationData = {
         id: 123,
@@ -1066,7 +1067,7 @@ describe('Integration | Infrastructure | Repository | Certification', function (
     it('should return an array of certification attestations ordered by last name, first name', async function () {
       // given
       const learningContentObjects = learningContentBuilder.fromAreas(minimalLearningContent);
-      await mockLearningContent(learningContentObjects);
+      databaseBuilder.factory.learningContent.build(learningContentObjects);
       databaseBuilder.factory.buildOrganization({ id: 123, type: 'SCO', isManagingStudents: true });
       const certificationAttestationDataA = {
         id: 456,
@@ -1187,7 +1188,7 @@ describe('Integration | Infrastructure | Repository | Certification', function (
     it('should ignore disabled shooling-registrations', async function () {
       // given
       const learningContentObjects = learningContentBuilder.fromAreas(minimalLearningContent);
-      await mockLearningContent(learningContentObjects);
+      databaseBuilder.factory.learningContent.build(learningContentObjects);
       databaseBuilder.factory.buildOrganization({ id: 123, type: 'SCO', isManagingStudents: true });
       const certificationAttestationDataA = {
         id: 456,
@@ -1314,7 +1315,7 @@ describe('Integration | Infrastructure | Repository | Certification', function (
       it('should take into account the latest valid certification', async function () {
         // given
         const learningContentObjects = learningContentBuilder.fromAreas(minimalLearningContent);
-        await mockLearningContent(learningContentObjects);
+        databaseBuilder.factory.learningContent.build(learningContentObjects);
         databaseBuilder.factory.buildOrganization({ id: 123, type: 'SCO', isManagingStudents: true });
         const certificationAttestationData = {
           id: 123,
@@ -1406,7 +1407,7 @@ describe('Integration | Infrastructure | Repository | Certification', function (
     it('should take into account the latest certification of an organization learner', async function () {
       // given
       const learningContentObjects = learningContentBuilder.fromAreas(minimalLearningContent);
-      await mockLearningContent(learningContentObjects);
+      databaseBuilder.factory.learningContent.build(learningContentObjects);
       databaseBuilder.factory.buildOrganization({ id: 123, type: 'SCO', isManagingStudents: true });
       const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({
         organizationId: 123,
@@ -1713,7 +1714,8 @@ describe('Integration | Infrastructure | Repository | Certification', function (
     it('should return a PrivateCertificate', async function () {
       // given
       const learningContentObjects = learningContentBuilder.fromAreas(minimalLearningContent);
-      await mockLearningContent(learningContentObjects);
+      databaseBuilder.factory.learningContent.build(learningContentObjects);
+      await databaseBuilder.commit();
 
       const userId = databaseBuilder.factory.buildUser().id;
       const privateCertificateData = {
@@ -1750,7 +1752,8 @@ describe('Integration | Infrastructure | Repository | Certification', function (
       it('should return a PrivateCertificate with matching key', async function () {
         // given
         const learningContentObjects = learningContentBuilder.fromAreas(minimalLearningContent);
-        await mockLearningContent(learningContentObjects);
+        databaseBuilder.factory.learningContent.build(learningContentObjects);
+        await databaseBuilder.commit();
 
         const userId = databaseBuilder.factory.buildUser().id;
         const privateCertificateData = {
@@ -1872,7 +1875,8 @@ describe('Integration | Infrastructure | Repository | Certification', function (
             ],
           },
         ]);
-        await mockLearningContent(learningContentObjects);
+        databaseBuilder.factory.learningContent.build(learningContentObjects);
+        await databaseBuilder.commit();
 
         // when
         const privateCertificate = await certificateRepository.getPrivateCertificate(certificationCourseId, {
@@ -1982,7 +1986,8 @@ describe('Integration | Infrastructure | Repository | Certification', function (
             ],
           },
         ]);
-        await mockLearningContent(learningContentObjects);
+        databaseBuilder.factory.learningContent.build(learningContentObjects);
+        await databaseBuilder.commit();
 
         // when
         const privateCertificate = await certificateRepository.getPrivateCertificate(certificationCourseId, {
@@ -2030,7 +2035,7 @@ describe('Integration | Infrastructure | Repository | Certification', function (
         }).id;
 
         const learningContentObjects = learningContentBuilder.fromAreas(minimalLearningContent);
-        await mockLearningContent(learningContentObjects);
+        databaseBuilder.factory.learningContent.build(learningContentObjects);
 
         const userId = databaseBuilder.factory.buildUser().id;
         const privateCertificateData = {
@@ -2416,7 +2421,8 @@ describe('Integration | Infrastructure | Repository | Certification', function (
             ],
           },
         ]);
-        await mockLearningContent(learningContentObjects);
+        databaseBuilder.factory.learningContent.build(learningContentObjects);
+        await databaseBuilder.commit();
 
         // when
         const shareableCertificate = await certificateRepository.getShareableCertificate({
@@ -2527,7 +2533,8 @@ describe('Integration | Infrastructure | Repository | Certification', function (
             ],
           },
         ]);
-        await mockLearningContent(learningContentObjects);
+        databaseBuilder.factory.learningContent.build(learningContentObjects);
+        await databaseBuilder.commit();
 
         // when
         const shareableCertificate = await certificateRepository.getShareableCertificate({
@@ -2576,7 +2583,7 @@ describe('Integration | Infrastructure | Repository | Certification', function (
         }).id;
 
         const learningContentObjects = learningContentBuilder.fromAreas(minimalLearningContent);
-        await mockLearningContent(learningContentObjects);
+        databaseBuilder.factory.learningContent.build(learningContentObjects);
         const userId = databaseBuilder.factory.buildUser().id;
         const shareableCertificateData = {
           id: 123,

--- a/api/tests/certification/session-management/acceptance/application/cancellation-route_test.js
+++ b/api/tests/certification/session-management/acceptance/application/cancellation-route_test.js
@@ -10,7 +10,6 @@ import {
   generateAuthenticatedUserRequestHeaders,
   knex,
   learningContentBuilder,
-  mockLearningContent,
 } from '../../../../test-helper.js';
 
 describe('Certification | Session-management | Acceptance | Application | Routes | cancellation', function () {
@@ -54,7 +53,8 @@ describe('Certification | Session-management | Acceptance | Application | Routes
     ];
 
     const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
-    await mockLearningContent(learningContentObjects);
+    databaseBuilder.factory.learningContent.build(learningContentObjects);
+    await databaseBuilder.commit();
   });
 
   describe('PATCH /api/admin/certification-courses/{certificationCourseId}/cancel', function () {

--- a/api/tests/certification/session-management/acceptance/application/certification-details-route_test.js
+++ b/api/tests/certification/session-management/acceptance/application/certification-details-route_test.js
@@ -4,7 +4,6 @@ import {
   expect,
   generateAuthenticatedUserRequestHeaders,
   learningContentBuilder,
-  mockLearningContent,
 } from '../../../../test-helper.js';
 
 describe('Certification | Session Management | Acceptance | Application | Routes | certification-details', function () {
@@ -51,7 +50,7 @@ describe('Certification | Session Management | Acceptance | Application | Routes
         ];
 
         const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
-        await mockLearningContent(learningContentObjects);
+        databaseBuilder.factory.learningContent.build(learningContentObjects);
 
         const sessionId = databaseBuilder.factory.buildSession().id;
         const userId = databaseBuilder.factory.buildUser().id;

--- a/api/tests/certification/session-management/acceptance/application/finalize-route_test.js
+++ b/api/tests/certification/session-management/acceptance/application/finalize-route_test.js
@@ -14,7 +14,6 @@ import {
   generateAuthenticatedUserRequestHeaders,
   knex,
   learningContentBuilder,
-  mockLearningContent,
 } from '../../../../test-helper.js';
 
 const examinerGlobalComment = 'It was a fine session my dear';
@@ -926,12 +925,10 @@ const _createSession = async ({ version = 2 } = {}) => {
     },
   ];
   const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
-  await mockLearningContent(learningContentObjects);
+  databaseBuilder.factory.learningContent.build(learningContentObjects);
+  await databaseBuilder.commit();
 
-  return {
-    session,
-    options,
-  };
+  return { session, options };
 };
 
 const _createSessionWithoutChallenge = async () => {
@@ -947,7 +944,7 @@ const _createSessionWithoutChallenge = async () => {
     },
   ];
   const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
-  await mockLearningContent(learningContentObjects);
+  databaseBuilder.factory.learningContent.build(learningContentObjects);
 
   const userId = databaseBuilder.factory.buildUser().id;
   const candidateUserId = databaseBuilder.factory.buildUser().id;

--- a/api/tests/certification/session-management/integration/domain/usecases/register-publishable-session_test.js
+++ b/api/tests/certification/session-management/integration/domain/usecases/register-publishable-session_test.js
@@ -7,7 +7,6 @@ import {
   expect,
   knex,
   learningContentBuilder,
-  mockLearningContent,
 } from '../../../../../test-helper.js';
 
 describe('Certification | Session Management | Integration | Domain | UseCase | register-publishable-session ', function () {
@@ -378,7 +377,7 @@ describe('Certification | Session Management | Integration | Domain | UseCase | 
       },
     ];
     const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
-    await mockLearningContent(learningContentObjects);
+    databaseBuilder.factory.learningContent.build(learningContentObjects);
 
     await databaseBuilder.commit();
   });

--- a/api/tests/certification/shared/integration/domain/services/certification-badges-service_test.js
+++ b/api/tests/certification/shared/integration/domain/services/certification-badges-service_test.js
@@ -1,12 +1,6 @@
 import * as certificationBadgesService from '../../../../../../src/certification/shared/domain/services/certification-badges-service.js';
 import { DomainTransaction } from '../../../../../../src/shared/domain/DomainTransaction.js';
-import {
-  databaseBuilder,
-  domainBuilder,
-  expect,
-  learningContentBuilder,
-  mockLearningContent,
-} from '../../../../../test-helper.js';
+import { databaseBuilder, domainBuilder, expect, learningContentBuilder } from '../../../../../test-helper.js';
 
 const listSkill = ['web1', 'web2', 'web3', 'web4'];
 const learningContent = [
@@ -98,7 +92,8 @@ describe('Integration | Service | Certification-Badges Service', function () {
       });
       await databaseBuilder.commit();
       const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
-      await mockLearningContent(learningContentObjects);
+      databaseBuilder.factory.learningContent.build(learningContentObjects);
+      await databaseBuilder.commit();
 
       // when
       const badgeAcquisitions = await DomainTransaction.execute(async () => {
@@ -160,7 +155,8 @@ describe('Integration | Service | Certification-Badges Service', function () {
           });
           await databaseBuilder.commit();
           const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
-          await mockLearningContent(learningContentObjects);
+          databaseBuilder.factory.learningContent.build(learningContentObjects);
+          await databaseBuilder.commit();
 
           // when
           const badgeAcquisitions = await DomainTransaction.execute(async () => {
@@ -222,7 +218,8 @@ describe('Integration | Service | Certification-Badges Service', function () {
           });
           await databaseBuilder.commit();
           const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
-          await mockLearningContent(learningContentObjects);
+          databaseBuilder.factory.learningContent.build(learningContentObjects);
+          await databaseBuilder.commit();
 
           // when
           const badgeAcquisitions = await DomainTransaction.execute(async () => {

--- a/api/tests/certification/shared/integration/infrastructure/repositories/certification-assessment-repository_test.js
+++ b/api/tests/certification/shared/integration/infrastructure/repositories/certification-assessment-repository_test.js
@@ -7,7 +7,7 @@ import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
 import { AnswerStatus } from '../../../../../../src/shared/domain/models/AnswerStatus.js';
 import { Assessment } from '../../../../../../src/shared/domain/models/Assessment.js';
 import { Challenge } from '../../../../../../src/shared/domain/models/Challenge.js';
-import { catchErr, databaseBuilder, expect, mockLearningContent } from '../../../../../test-helper.js';
+import { catchErr, databaseBuilder, expect } from '../../../../../test-helper.js';
 
 describe('Integration | Infrastructure | Repositories | certification-assessment-repository', function () {
   beforeEach(async function () {
@@ -83,7 +83,8 @@ describe('Integration | Infrastructure | Repositories | certification-assessment
         },
       ],
     };
-    await mockLearningContent(learningContent);
+    databaseBuilder.factory.learningContent.build(learningContent);
+    await databaseBuilder.commit();
   });
 
   describe('#getByCertificationCourseId', function () {

--- a/api/tests/devcomp/acceptance/application/trainings/training-route_test.js
+++ b/api/tests/devcomp/acceptance/application/trainings/training-route_test.js
@@ -5,7 +5,6 @@ import {
   generateAuthenticatedUserRequestHeaders,
   knex,
   learningContentBuilder,
-  mockLearningContent,
 } from '../../../../test-helper.js';
 
 describe('Acceptance | Controller | training-controller', function () {
@@ -66,7 +65,8 @@ describe('Acceptance | Controller | training-controller', function () {
       ];
 
       const learningContentObjects = learningContentBuilder(learningContent);
-      await mockLearningContent(learningContentObjects);
+      databaseBuilder.factory.learningContent.build(learningContentObjects);
+      await databaseBuilder.commit();
     });
 
     it('should get a training with the specific id', async function () {
@@ -440,7 +440,8 @@ describe('Acceptance | Controller | training-controller', function () {
       ];
 
       const learningContentObjects = learningContentBuilder(learningContent);
-      await mockLearningContent(learningContentObjects);
+      databaseBuilder.factory.learningContent.build(learningContentObjects);
+      await databaseBuilder.commit();
     });
 
     it('should update training trigger', async function () {

--- a/api/tests/devcomp/acceptance/application/tutorial-evaluations/tutorial-evaluations-controller_test.js
+++ b/api/tests/devcomp/acceptance/application/tutorial-evaluations/tutorial-evaluations-controller_test.js
@@ -4,7 +4,6 @@ import {
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
-  mockLearningContent,
 } from '../../../../test-helper.js';
 
 describe('Acceptance | Controller | tutorial-evaluations-controller', function () {
@@ -33,9 +32,9 @@ describe('Acceptance | Controller | tutorial-evaluations-controller', function (
       email: 'classic.papa@example.net',
       password: 'abcd1234',
     });
-    await databaseBuilder.commit();
 
-    await mockLearningContent(learningContent);
+    databaseBuilder.factory.learningContent.build(learningContent);
+    await databaseBuilder.commit();
   });
 
   describe('PUT /api/users/tutorials/{tutorialId}/evaluate', function () {

--- a/api/tests/devcomp/acceptance/application/user-tutorials/user-tutorials-controller_test.js
+++ b/api/tests/devcomp/acceptance/application/user-tutorials/user-tutorials-controller_test.js
@@ -5,7 +5,6 @@ import {
   expect,
   generateAuthenticatedUserRequestHeaders,
   learningContentBuilder,
-  mockLearningContent,
 } from '../../../../test-helper.js';
 
 describe('Acceptance | Controller | user-tutorial-controller', function () {
@@ -55,7 +54,8 @@ describe('Acceptance | Controller | user-tutorial-controller', function () {
         headers: generateAuthenticatedUserRequestHeaders({ userId }),
       };
 
-      await mockLearningContent(learningContent);
+      databaseBuilder.factory.learningContent.build(learningContent);
+      await databaseBuilder.commit();
     });
 
     describe('nominal case', function () {
@@ -274,7 +274,7 @@ describe('Acceptance | Controller | user-tutorial-controller', function () {
     describe('nominal case', function () {
       it('should respond with a 200 and return tutorials saved for user', async function () {
         // given
-        await mockLearningContent(learningContentObjects);
+        databaseBuilder.factory.learningContent.build(learningContentObjects);
 
         databaseBuilder.factory.buildUserSavedTutorial({
           id: 101,
@@ -329,7 +329,7 @@ describe('Acceptance | Controller | user-tutorial-controller', function () {
 
       it('should respond with a 200 and return tutorials recommended for user', async function () {
         // given
-        await mockLearningContent(learningContentObjects);
+        databaseBuilder.factory.learningContent.build(learningContentObjects);
 
         databaseBuilder.factory.buildKnowledgeElement({
           userId,
@@ -471,7 +471,8 @@ describe('Acceptance | Controller | user-tutorial-controller', function () {
         headers: generateAuthenticatedUserRequestHeaders({ userId }),
       };
 
-      await mockLearningContent(learningContent);
+      databaseBuilder.factory.learningContent.build(learningContent);
+      await databaseBuilder.commit();
     });
 
     describe('nominal case', function () {

--- a/api/tests/devcomp/integration/infrastructure/repositories/training-repository_test.js
+++ b/api/tests/devcomp/integration/infrastructure/repositories/training-repository_test.js
@@ -9,14 +9,7 @@ import { TrainingTriggerForAdmin } from '../../../../../src/devcomp/domain/read-
 import { UserRecommendedTraining } from '../../../../../src/devcomp/domain/read-models/UserRecommendedTraining.js';
 import * as trainingRepository from '../../../../../src/devcomp/infrastructure/repositories/training-repository.js';
 import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
-import {
-  catchErr,
-  databaseBuilder,
-  domainBuilder,
-  expect,
-  knex,
-  mockLearningContent,
-} from '../../../../test-helper.js';
+import { catchErr, databaseBuilder, domainBuilder, expect, knex } from '../../../../test-helper.js';
 
 describe('Integration | Repository | training-repository', function () {
   describe('#get', function () {
@@ -114,7 +107,8 @@ describe('Integration | Repository | training-repository', function () {
           },
         ],
       };
-      await mockLearningContent(learningContent);
+      databaseBuilder.factory.learningContent.build(learningContent);
+      await databaseBuilder.commit();
     });
 
     it('should throw an error when training does not exist', async function () {
@@ -409,7 +403,8 @@ describe('Integration | Repository | training-repository', function () {
           },
         ],
       };
-      await mockLearningContent(learningContent);
+      databaseBuilder.factory.learningContent.build(learningContent);
+      await databaseBuilder.commit();
     });
 
     it('should find trainings by campaignParticipationId and locale', async function () {

--- a/api/tests/devcomp/integration/infrastructure/repositories/training-trigger-repository_test.js
+++ b/api/tests/devcomp/integration/infrastructure/repositories/training-trigger-repository_test.js
@@ -13,7 +13,6 @@ import {
   expect,
   knex,
   learningContentBuilder,
-  mockLearningContent,
   sinon,
 } from '../../../../test-helper.js';
 
@@ -103,7 +102,8 @@ describe('Integration | Repository | training-trigger-repository', function () {
       },
     ];
     const learningContentObjects = learningContentBuilder(learningContent);
-    await mockLearningContent(learningContentObjects);
+    databaseBuilder.factory.learningContent.build(learningContentObjects);
+    await databaseBuilder.commit();
   });
 
   describe('#createOrUpdate', function () {

--- a/api/tests/evaluation/acceptance/application/answers/answer-controller-get-correction_test.js
+++ b/api/tests/evaluation/acceptance/application/answers/answer-controller-get-correction_test.js
@@ -4,7 +4,6 @@ import {
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
-  mockLearningContent,
 } from '../../../../test-helper.js';
 
 const buildOptions = (answerId, userId) => ({
@@ -182,8 +181,9 @@ describe('Acceptance | Controller | answer-controller-get-correction', function 
         userId,
         tutorialId: 'french-tutorial-id',
       });
+
+      databaseBuilder.factory.learningContent.build(learningContent);
       await databaseBuilder.commit();
-      await mockLearningContent(learningContent);
     });
 
     context('when Accept-Language header is specified', function () {

--- a/api/tests/evaluation/acceptance/application/answers/answer-controller-save_test.js
+++ b/api/tests/evaluation/acceptance/application/answers/answer-controller-save_test.js
@@ -12,7 +12,6 @@ import {
   generateAuthenticatedUserRequestHeaders,
   generateInjectOptions,
   knex,
-  mockLearningContent,
 } from '../../../../test-helper.js';
 
 describe('Acceptance | Controller | answer-controller-save', function () {
@@ -83,7 +82,8 @@ describe('Acceptance | Controller | answer-controller-save', function () {
             },
           ],
         };
-        await mockLearningContent(learningContent);
+        databaseBuilder.factory.learningContent.build(learningContent);
+        await databaseBuilder.commit();
 
         postAnswersOptionsPayload = {
           data: {
@@ -382,7 +382,8 @@ describe('Acceptance | Controller | answer-controller-save', function () {
             },
           ],
         };
-        await mockLearningContent(learningContent);
+        databaseBuilder.factory.learningContent.build(learningContent);
+        await databaseBuilder.commit();
 
         postAnswersOptions = {
           method: 'POST',
@@ -460,7 +461,8 @@ describe('Acceptance | Controller | answer-controller-save', function () {
             },
           ],
         };
-        await mockLearningContent(learningContent);
+        databaseBuilder.factory.learningContent.build(learningContent);
+        await databaseBuilder.commit();
 
         postAnswersOptions = {
           method: 'POST',

--- a/api/tests/evaluation/acceptance/application/assessments/assessment-controller_test.js
+++ b/api/tests/evaluation/acceptance/application/assessments/assessment-controller_test.js
@@ -26,7 +26,6 @@ import {
   generateAuthenticatedUserRequestHeaders,
   knex,
   learningContentBuilder,
-  mockLearningContent,
   nock,
   sinon,
   waitForStreamFinalizationToBeDone,
@@ -404,7 +403,7 @@ describe('Acceptance | Controller | assessment-controller', function () {
 
   beforeEach(async function () {
     const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
-    await mockLearningContent(learningContentObjects);
+    databaseBuilder.factory.learningContent.build(learningContentObjects);
 
     server = await createServer();
 

--- a/api/tests/evaluation/acceptance/application/autonomous-courses/autonomous-course-controller_test.js
+++ b/api/tests/evaluation/acceptance/application/autonomous-courses/autonomous-course-controller_test.js
@@ -6,7 +6,6 @@ import {
   generateAuthenticatedUserRequestHeaders,
   knex,
   learningContentBuilder,
-  mockLearningContent,
   sinon,
 } from '../../../../test-helper.js';
 
@@ -42,7 +41,8 @@ describe('Acceptance | API | Autonomous Course', function () {
       },
     ];
     const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
-    await mockLearningContent(learningContentObjects);
+    databaseBuilder.factory.learningContent.build(learningContentObjects);
+    await databaseBuilder.commit();
   });
 
   describe('POST /api/autonomous-course', function () {

--- a/api/tests/evaluation/acceptance/application/competence-evaluations/competence-evaluation-controller_test.js
+++ b/api/tests/evaluation/acceptance/application/competence-evaluations/competence-evaluation-controller_test.js
@@ -6,7 +6,6 @@ import {
   generateAuthenticatedUserRequestHeaders,
   knex,
   learningContentBuilder,
-  mockLearningContent,
 } from '../../../../test-helper.js';
 
 describe('Acceptance | API | Competence Evaluations', function () {
@@ -37,7 +36,8 @@ describe('Acceptance | API | Competence Evaluations', function () {
         ];
 
         const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
-        await mockLearningContent(learningContentObjects);
+        databaseBuilder.factory.learningContent.build(learningContentObjects);
+        await databaseBuilder.commit();
       });
 
       context('and competence exists', function () {

--- a/api/tests/evaluation/acceptance/application/courses/course-controller_test.js
+++ b/api/tests/evaluation/acceptance/application/courses/course-controller_test.js
@@ -1,9 +1,9 @@
 import {
   createServer,
+  databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
   learningContentBuilder,
-  mockLearningContent,
 } from '../../../../test-helper.js';
 
 describe('Acceptance | API | Courses', function () {
@@ -56,7 +56,8 @@ describe('Acceptance | API | Courses', function () {
       ];
 
       const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
-      await mockLearningContent(learningContentObjects);
+      databaseBuilder.factory.learningContent.build(learningContentObjects);
+      await databaseBuilder.commit();
     });
 
     context('when the course exists', function () {

--- a/api/tests/evaluation/acceptance/application/progressions/progression-controller_test.js
+++ b/api/tests/evaluation/acceptance/application/progressions/progression-controller_test.js
@@ -4,7 +4,6 @@ import {
   expect,
   generateAuthenticatedUserRequestHeaders,
   learningContentBuilder,
-  mockLearningContent,
 } from '../../../../test-helper.js';
 
 describe('Acceptance | API | Progressions', function () {
@@ -42,7 +41,7 @@ describe('Acceptance | API | Progressions', function () {
       ];
 
       const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
-      await mockLearningContent(learningContentObjects);
+      databaseBuilder.factory.learningContent.build(learningContentObjects);
 
       userId = databaseBuilder.factory.buildUser({}).id;
       const campaignId = databaseBuilder.factory.buildCampaign({ name: 'Campaign' }).id;

--- a/api/tests/evaluation/acceptance/application/scorecards/scorecard-controller_test.js
+++ b/api/tests/evaluation/acceptance/application/scorecards/scorecard-controller_test.js
@@ -5,7 +5,6 @@ import {
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
-  mockLearningContent,
 } from '../../../../test-helper.js';
 
 describe('Acceptance | Controller | scorecard-controller', function () {
@@ -100,8 +99,8 @@ describe('Acceptance | Controller | scorecard-controller', function () {
   beforeEach(async function () {
     server = await createServer();
     databaseBuilder.factory.buildUser({ id: userId });
+    databaseBuilder.factory.learningContent.build(learningContent);
     await databaseBuilder.commit();
-    await mockLearningContent(learningContent);
   });
 
   describe('GET /scorecards/{id}', function () {

--- a/api/tests/evaluation/acceptance/application/stage-collections/stage-collection-controller_test.js
+++ b/api/tests/evaluation/acceptance/application/stage-collections/stage-collection-controller_test.js
@@ -4,7 +4,6 @@ import {
   expect,
   generateAuthenticatedUserRequestHeaders,
   learningContentBuilder,
-  mockLearningContent,
 } from '../../../../test-helper.js';
 
 describe('Acceptance | Controller | stage-collection', function () {
@@ -18,7 +17,8 @@ describe('Acceptance | Controller | stage-collection', function () {
     beforeEach(async function () {
       const learningContent = [{ id: 'recArea0', competences: [] }];
       const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
-      await mockLearningContent(learningContentObjects);
+      databaseBuilder.factory.learningContent.build(learningContentObjects);
+      await databaseBuilder.commit();
     });
 
     context('when the target-profile is not linked to a campaign', function () {

--- a/api/tests/evaluation/acceptance/application/stages/stage-controller_test.js
+++ b/api/tests/evaluation/acceptance/application/stages/stage-controller_test.js
@@ -5,7 +5,6 @@ import {
   generateAuthenticatedUserRequestHeaders,
   knex,
   learningContentBuilder,
-  mockLearningContent,
 } from '../../../../test-helper.js';
 
 describe('Acceptance | API | Stages', function () {
@@ -29,7 +28,8 @@ describe('Acceptance | API | Stages', function () {
       },
     ];
     const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
-    await mockLearningContent(learningContentObjects);
+    databaseBuilder.factory.learningContent.build(learningContentObjects);
+    await databaseBuilder.commit();
   });
 
   describe('PATCH /api/admin/stages/{id}', function () {

--- a/api/tests/evaluation/integration/application/smart-random-simulator/smart-random-simulator-controller_test.js
+++ b/api/tests/evaluation/integration/application/smart-random-simulator/smart-random-simulator-controller_test.js
@@ -1,6 +1,6 @@
 import { smartRandomSimulatorController } from '../../../../../src/evaluation/application/smart-random-simulator/smart-random-simulator-controller.js';
 import { getSmartRandomLog } from '../../../../../src/evaluation/domain/services/smart-random-log-service.js';
-import { expect, hFake, mockLearningContent } from '../../../../test-helper.js';
+import { databaseBuilder, expect, hFake } from '../../../../test-helper.js';
 
 const request = {
   payload: {
@@ -55,7 +55,8 @@ describe('Integration | Application | Smart Random Simulator', function () {
         thematics: [],
         tubes: [{ id: 'tubeId1' }],
       };
-      await mockLearningContent(learningContent);
+      databaseBuilder.factory.learningContent.build(learningContent);
+      await databaseBuilder.commit();
     });
 
     it('should empty smart random log after execution', async function () {

--- a/api/tests/evaluation/integration/application/stage-collections/stage-collection-controller_test.js
+++ b/api/tests/evaluation/integration/application/stage-collections/stage-collection-controller_test.js
@@ -1,6 +1,6 @@
 import { stageCollectionController } from '../../../../../src/evaluation/application/stage-collections/stage-collection-controller.js';
 import * as stageCollectionRepository from '../../../../../src/evaluation/infrastructure/repositories/stage-collection-repository.js';
-import { databaseBuilder, expect, hFake, mockLearningContent } from '../../../../test-helper.js';
+import { databaseBuilder, expect, hFake } from '../../../../test-helper.js';
 
 describe('Integration | Application | stage-collection-controller', function () {
   context('update', function () {
@@ -11,7 +11,8 @@ describe('Integration | Application | stage-collection-controller', function () 
         thematics: [],
         tubes: [{ id: 'tubeId1' }],
       };
-      await mockLearningContent(learningContent);
+      databaseBuilder.factory.learningContent.build(learningContent);
+      await databaseBuilder.commit();
     });
 
     it('should modify stage collection according to the request', async function () {

--- a/api/tests/evaluation/integration/domain/usecases/create-badge_test.js
+++ b/api/tests/evaluation/integration/domain/usecases/create-badge_test.js
@@ -10,7 +10,7 @@ import {
   MissingBadgeCriterionError,
   NotFoundError,
 } from '../../../../../src/shared/domain/errors.js';
-import { catchErr, databaseBuilder, expect, knex, mockLearningContent, sinon } from '../../../../test-helper.js';
+import { catchErr, databaseBuilder, expect, knex, sinon } from '../../../../test-helper.js';
 
 describe('Integration | UseCases | create-badge', function () {
   let targetProfileId;
@@ -24,7 +24,7 @@ describe('Integration | UseCases | create-badge', function () {
       skills: [{ id: 'recSkill1' }],
     };
 
-    await mockLearningContent(learningContent);
+    databaseBuilder.factory.learningContent.build(learningContent);
 
     targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
     databaseBuilder.factory.buildTargetProfileTube({ tubeId: 'monTubeA', level: 2, targetProfileId });

--- a/api/tests/evaluation/integration/domain/usecases/handle-stage-acquisition_test.js
+++ b/api/tests/evaluation/integration/domain/usecases/handle-stage-acquisition_test.js
@@ -4,14 +4,7 @@ import { CampaignTypes } from '../../../../../src/prescription/shared/domain/con
 import { KnowledgeElementCollection } from '../../../../../src/prescription/shared/domain/models/KnowledgeElementCollection.js';
 import { DomainTransaction } from '../../../../../src/shared/domain/DomainTransaction.js';
 import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
-import {
-  databaseBuilder,
-  domainBuilder,
-  expect,
-  knex,
-  learningContentBuilder,
-  mockLearningContent,
-} from '../../../../test-helper.js';
+import { databaseBuilder, domainBuilder, expect, knex, learningContentBuilder } from '../../../../test-helper.js';
 
 describe('Evaluation | Integration | Usecase | Handle Stage Acquisition', function () {
   let userId, assessment, stages, campaignParticipationId, targetProfileId, listSkill, learningContent;
@@ -102,7 +95,8 @@ describe('Evaluation | Integration | Usecase | Handle Stage Acquisition', functi
           campaign: domainBuilder.buildCampaign(campaignDTO),
         });
 
-        await mockLearningContent(learningContentBuilder(learningContent));
+        databaseBuilder.factory.learningContent.build(learningContentBuilder(learningContent));
+        await databaseBuilder.commit();
       });
       context('When campaignParticipation is not available', function () {
         it('should not throw', async function () {
@@ -312,7 +306,8 @@ describe('Evaluation | Integration | Usecase | Handle Stage Acquisition', functi
           campaign: domainBuilder.buildCampaign(campaignDTO),
         });
 
-        await mockLearningContent(learningContentBuilder(learningContent));
+        databaseBuilder.factory.learningContent.build(learningContentBuilder(learningContent));
+        await databaseBuilder.commit();
       });
 
       context('when some KEs are acquired', function () {

--- a/api/tests/evaluation/integration/domain/usecases/save-autonomous-course_test.js
+++ b/api/tests/evaluation/integration/domain/usecases/save-autonomous-course_test.js
@@ -10,7 +10,6 @@ import {
   domainBuilder,
   expect,
   learningContentBuilder,
-  mockLearningContent,
   sinon,
 } from '../../../../test-helper.js';
 
@@ -18,15 +17,12 @@ describe('Integration | Usecases | Save autonomous course', function () {
   beforeEach(async function () {
     sinon.stub(constants, 'AUTONOMOUS_COURSES_ORGANIZATION_ID').value(777);
 
-    databaseBuilder.factory.buildTargetProfile({
-      id: 1,
-    });
-
-    await databaseBuilder.commit();
+    databaseBuilder.factory.buildTargetProfile({ id: 1 });
 
     const learningContent = domainBuilder.buildCampaignLearningContent.withSimpleContent();
     const learningContentObjects = learningContentBuilder([learningContent]);
-    await mockLearningContent(learningContentObjects);
+    databaseBuilder.factory.learningContent.build(learningContentObjects);
+    await databaseBuilder.commit();
   });
 
   context('when target-profile does not exist', function () {

--- a/api/tests/evaluation/integration/domain/usecases/update-badge_test.js
+++ b/api/tests/evaluation/integration/domain/usecases/update-badge_test.js
@@ -1,7 +1,7 @@
 import { Badge } from '../../../../../src/evaluation/domain/models/Badge.js';
 import { updateBadge } from '../../../../../src/evaluation/domain/usecases/update-badge.js';
 import * as badgeRepository from '../../../../../src/evaluation/infrastructure/repositories/badge-repository.js';
-import { catchErr, databaseBuilder, expect, mockLearningContent } from '../../../../test-helper.js';
+import { catchErr, databaseBuilder, expect } from '../../../../test-helper.js';
 
 describe('Integration | UseCases | create-badge', function () {
   let targetProfileId;
@@ -13,7 +13,7 @@ describe('Integration | UseCases | create-badge', function () {
       skills: [{ id: 'recSkill1' }],
     };
 
-    await mockLearningContent(learningContent);
+    databaseBuilder.factory.learningContent.build(learningContent);
 
     targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
     databaseBuilder.factory.buildTargetProfileTube({ tubeId: 'monTubeA', level: 2, targetProfileId });

--- a/api/tests/evaluation/integration/infrastructure/repositories/autonomous-course-repository_test.js
+++ b/api/tests/evaluation/integration/infrastructure/repositories/autonomous-course-repository_test.js
@@ -1,7 +1,7 @@
 import { AutonomousCourse } from '../../../../../src/evaluation/domain/models/AutonomousCourse.js';
 import { repositories } from '../../../../../src/evaluation/infrastructure/repositories/index.js';
 import { constants } from '../../../../../src/shared/domain/constants.js';
-import { databaseBuilder, expect, knex, mockLearningContent, sinon } from '../../../../test-helper.js';
+import { databaseBuilder, expect, knex, sinon } from '../../../../test-helper.js';
 
 describe('Integration | Repository | Autonomous Course', function () {
   describe('#save', function () {
@@ -95,7 +95,7 @@ describe('Integration | Repository | Autonomous Course', function () {
             },
           ],
         };
-        await mockLearningContent(learningContent);
+        databaseBuilder.factory.learningContent.build(learningContent);
         sinon.stub(constants, 'AUTONOMOUS_COURSES_ORGANIZATION_ID').value(777);
         const { id: organizationId } = databaseBuilder.factory.buildOrganization({
           id: constants.AUTONOMOUS_COURSES_ORGANIZATION_ID,

--- a/api/tests/evaluation/integration/scripts/add-multiple-level-stages.test.js
+++ b/api/tests/evaluation/integration/scripts/add-multiple-level-stages.test.js
@@ -1,14 +1,7 @@
 import * as url from 'node:url';
 
 import { AddMultipleLevelStagesScript } from '../../../../src/evaluation/scripts/add-multiple-level-stages.js';
-import {
-  databaseBuilder,
-  expect,
-  knex,
-  learningContentBuilder,
-  mockLearningContent,
-  sinon,
-} from '../../../test-helper.js';
+import { databaseBuilder, expect, knex, learningContentBuilder, sinon } from '../../../test-helper.js';
 
 const currentDirectory = url.fileURLToPath(new URL('.', import.meta.url));
 
@@ -86,7 +79,7 @@ describe('Integration | Evaluation | Scripts | add-multiple-level-stages-script'
         },
       ];
       const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
-      await mockLearningContent(learningContentObjects);
+      databaseBuilder.factory.learningContent.build(learningContentObjects);
 
       const targetProfile = databaseBuilder.factory.buildTargetProfile();
       databaseBuilder.factory.buildTargetProfileTube({ tubeId: 'recTube0_0', targetProfileId: targetProfile.id });

--- a/api/tests/integration/scripts/data-generation/generate-certif-cli_test.js
+++ b/api/tests/integration/scripts/data-generation/generate-certif-cli_test.js
@@ -6,7 +6,7 @@ import {
   main,
 } from '../../../../scripts/data-generation/generate-certif-cli.js';
 import { CampaignTypes } from '../../../../src/prescription/shared/domain/constants.js';
-import { expect, knex, mockLearningContent } from '../../../test-helper.js';
+import { databaseBuilder, expect, knex } from '../../../test-helper.js';
 
 // FIXME Too hard to edit \o/
 describe('Integration | Scripts | generate-certif-cli.js', function () {
@@ -24,7 +24,8 @@ describe('Integration | Scripts | generate-certif-cli.js', function () {
       skills: [{ tubeId: 'xxx', skillId: 'yyy', status: 'actif' }],
       challenges: [],
     };
-    await mockLearningContent(learningContent);
+    databaseBuilder.factory.learningContent.build(learningContent);
+    await databaseBuilder.commit();
   });
 
   afterEach(function () {

--- a/api/tests/learning-content/acceptance/application/frameworks-controller_test.js
+++ b/api/tests/learning-content/acceptance/application/frameworks-controller_test.js
@@ -3,7 +3,6 @@ import {
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
-  mockLearningContent,
 } from '../../../test-helper.js';
 
 describe('Acceptance | Controller | frameworks-controller', function () {
@@ -192,8 +191,8 @@ describe('Acceptance | Controller | frameworks-controller', function () {
 
       beforeEach(async function () {
         userId = databaseBuilder.factory.buildUser().id;
+        databaseBuilder.factory.learningContent.build(learningContent);
         await databaseBuilder.commit();
-        await mockLearningContent(learningContent);
       });
 
       it('should return response code 200', async function () {
@@ -269,7 +268,6 @@ describe('Acceptance | Controller | frameworks-controller', function () {
 
     beforeEach(function () {
       user = databaseBuilder.factory.buildUser.withRole();
-      return databaseBuilder.commit();
     });
 
     it('should return the areas in the framework', async function () {
@@ -440,7 +438,9 @@ describe('Acceptance | Controller | frameworks-controller', function () {
           },
         ],
       };
-      await mockLearningContent(learningContent);
+      databaseBuilder.factory.learningContent.build(learningContent);
+      await databaseBuilder.commit();
+
       const options = {
         method: 'GET',
         url: `/api/admin/frameworks/fmk1/areas`,

--- a/api/tests/prescription/campaign-participation/acceptance/application/campaign-participation-route_test.js
+++ b/api/tests/prescription/campaign-participation/acceptance/application/campaign-participation-route_test.js
@@ -10,7 +10,6 @@ import {
   generateAuthenticatedUserRequestHeaders,
   knex,
   learningContentBuilder,
-  mockLearningContent,
   sinon,
 } from '../../../../test-helper.js';
 
@@ -48,7 +47,8 @@ describe('Acceptance | Campaign Participation | Application | Route', function (
   describe('GET /api/campaigns/{campaignId}/profiles-collection-participations/{campaignParticipationId}', function () {
     beforeEach(async function () {
       const learningObjects = learningContentBuilder.fromAreas([]);
-      await mockLearningContent(learningObjects);
+      databaseBuilder.factory.learningContent.build(learningObjects);
+      await databaseBuilder.commit();
     });
 
     it('should return the campaign profile as JSONAPI', async function () {
@@ -117,8 +117,6 @@ describe('Acceptance | Campaign Participation | Application | Route', function (
         campaignParticipationId: campaignParticipation.id,
       });
 
-      await databaseBuilder.commit();
-
       const learningContent = [
         {
           id: 'recArea1',
@@ -164,7 +162,8 @@ describe('Acceptance | Campaign Participation | Application | Route', function (
         },
       ];
       const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
-      await mockLearningContent(learningContentObjects);
+      databaseBuilder.factory.learningContent.build(learningContentObjects);
+      await databaseBuilder.commit();
     });
 
     it('should return 200', async function () {
@@ -249,7 +248,8 @@ describe('Acceptance | Campaign Participation | Application | Route', function (
         },
       ];
       const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
-      await mockLearningContent(learningContentObjects);
+      databaseBuilder.factory.learningContent.build(learningContentObjects);
+      await databaseBuilder.commit();
     });
 
     it('should return the assessment participation results', async function () {
@@ -284,7 +284,8 @@ describe('Acceptance | Campaign Participation | Application | Route', function (
   describe('GET /api/campaigns/{campaignId}/organization-learners/{organizationLearnerId}/participations', function () {
     beforeEach(async function () {
       const learningObjects = learningContentBuilder.fromAreas([]);
-      await mockLearningContent(learningObjects);
+      databaseBuilder.factory.learningContent.build(learningObjects);
+      await databaseBuilder.commit();
     });
 
     it('should return the campaign profile as JSONAPI', async function () {
@@ -561,7 +562,7 @@ describe('Acceptance | Campaign Participation | Application | Route', function (
         },
       ];
       const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
-      await mockLearningContent(learningContentObjects);
+      databaseBuilder.factory.learningContent.build(learningContentObjects);
       await databaseBuilder.commit();
     });
     afterEach(function () {

--- a/api/tests/prescription/campaign-participation/acceptance/application/learner-participation-route_test.js
+++ b/api/tests/prescription/campaign-participation/acceptance/application/learner-participation-route_test.js
@@ -14,7 +14,6 @@ import {
   generateAuthenticatedUserRequestHeaders,
   knex,
   learningContentBuilder,
-  mockLearningContent,
 } from '../../../../test-helper.js';
 import { buildLearningContent } from '../../../../tooling/learning-content-builder/build-learning-content.js';
 
@@ -56,7 +55,8 @@ describe('Acceptance | Routes | Campaign Participations', function () {
         },
       ];
       const learningObjects = learningContentBuilder.fromAreas(learningContent);
-      await mockLearningContent(learningObjects);
+      databaseBuilder.factory.learningContent.build(learningObjects);
+      await databaseBuilder.commit();
 
       options = {
         method: 'PATCH',
@@ -197,7 +197,7 @@ describe('Acceptance | Routes | Campaign Participations', function () {
       area.competences = [competence];
       framework.areas = [area];
       const learningContent = buildLearningContent([framework]);
-      await mockLearningContent(learningContent);
+      databaseBuilder.factory.learningContent.build(learningContent);
 
       await databaseBuilder.commit();
     });
@@ -311,7 +311,7 @@ describe('Acceptance | Routes | Campaign Participations', function () {
     };
 
     beforeEach(async function () {
-      await mockLearningContent(learningContent);
+      databaseBuilder.factory.learningContent.build(learningContent);
       userId = 100;
       databaseBuilder.factory.buildUser({ id: userId });
       const campaign = databaseBuilder.factory.buildCampaign();

--- a/api/tests/prescription/campaign-participation/integration/domain/usecases/get-campaign-assessment-participation_test.js
+++ b/api/tests/prescription/campaign-participation/integration/domain/usecases/get-campaign-assessment-participation_test.js
@@ -7,7 +7,7 @@ import {
 import { constants } from '../../../../../../src/shared/domain/constants.js';
 import { Assessment } from '../../../../../../src/shared/domain/models/Assessment.js';
 import { KnowledgeElement } from '../../../../../../src/shared/domain/models/KnowledgeElement.js';
-import { databaseBuilder, expect, mockLearningContent, sinon } from '../../../../../test-helper.js';
+import { databaseBuilder, expect, sinon } from '../../../../../test-helper.js';
 
 describe('Integration | UseCase | get-campaign-assessment-participation', function () {
   let campaignId, targetProfileId, organizationLearner, organizationId;
@@ -69,7 +69,7 @@ describe('Integration | UseCase | get-campaign-assessment-participation', functi
       ],
     };
 
-    await mockLearningContent(learningContent);
+    databaseBuilder.factory.learningContent.build(learningContent);
 
     organizationId = databaseBuilder.factory.buildOrganization().id;
     organizationLearner = databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({

--- a/api/tests/prescription/campaign-participation/integration/domain/usecases/get-campaign-profile_test.js
+++ b/api/tests/prescription/campaign-participation/integration/domain/usecases/get-campaign-profile_test.js
@@ -1,15 +1,13 @@
 import { usecases } from '../../../../../../src/prescription/campaign-participation/domain/usecases/index.js';
 import { FRENCH_SPOKEN } from '../../../../../../src/shared/domain/services/locale-service.js';
-import { databaseBuilder, expect, mockLearningContent } from '../../../../../test-helper.js';
+import { databaseBuilder, expect } from '../../../../../test-helper.js';
 
 describe('Integration | UseCase | get-campaign-profile', function () {
   const locale = FRENCH_SPOKEN;
 
-  beforeEach(async function () {
-    await mockLearningContent({ competences: [], areas: [], skills: [] });
-  });
-
   it('should return the campaign profile', async function () {
+    databaseBuilder.factory.learningContent.build({ competences: [], areas: [], skills: [] });
+
     const organizationId = databaseBuilder.factory.buildOrganization().id;
     const campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
     const userId = databaseBuilder.factory.buildUser({ organizationId }).id;

--- a/api/tests/prescription/campaign-participation/integration/domain/usecases/send-shared-participation-results-to-pole-emploi_test.js
+++ b/api/tests/prescription/campaign-participation/integration/domain/usecases/send-shared-participation-results-to-pole-emploi_test.js
@@ -1,11 +1,5 @@
 import { usecases } from '../../../../../../src/prescription/campaign-participation/domain/usecases/index.js';
-import {
-  databaseBuilder,
-  expect,
-  knex,
-  learningContentBuilder,
-  mockLearningContent,
-} from '../../../../../test-helper.js';
+import { databaseBuilder, expect, knex, learningContentBuilder } from '../../../../../test-helper.js';
 
 describe('Integration | Domain | UseCases | send-shared-participation-results-to-pole-emploi', function () {
   let campaignParticipationId, userId;
@@ -22,7 +16,7 @@ describe('Integration | Domain | UseCases | send-shared-participation-results-to
     campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({ campaignId, userId }).id;
     databaseBuilder.factory.buildAssessment({ campaignParticipationId, userId });
     const learningContentObjects = learningContentBuilder.fromAreas([]);
-    await mockLearningContent(learningContentObjects);
+    databaseBuilder.factory.learningContent.build(learningContentObjects);
     return databaseBuilder.commit();
   });
 

--- a/api/tests/prescription/campaign-participation/integration/domain/usecases/send-started-participation-results-to-pole-emploi_test.js
+++ b/api/tests/prescription/campaign-participation/integration/domain/usecases/send-started-participation-results-to-pole-emploi_test.js
@@ -1,11 +1,5 @@
 import { usecases } from '../../../../../../src/prescription/campaign-participation/domain/usecases/index.js';
-import {
-  databaseBuilder,
-  expect,
-  knex,
-  learningContentBuilder,
-  mockLearningContent,
-} from '../../../../../test-helper.js';
+import { databaseBuilder, expect, knex, learningContentBuilder } from '../../../../../test-helper.js';
 
 describe('Integration | Application | send-started-participation-results-to-pole-emploi', function () {
   let campaignParticipationId, userId;
@@ -22,7 +16,7 @@ describe('Integration | Application | send-started-participation-results-to-pole
     campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({ campaignId, userId }).id;
     databaseBuilder.factory.buildAssessment({ campaignParticipationId, userId });
     const learningContentObjects = learningContentBuilder.fromAreas([]);
-    await mockLearningContent(learningContentObjects);
+    databaseBuilder.factory.learningContent.build(learningContentObjects);
     return databaseBuilder.commit();
   });
 

--- a/api/tests/prescription/campaign-participation/integration/domain/usecases/start-campaign-participation_test.js
+++ b/api/tests/prescription/campaign-participation/integration/domain/usecases/start-campaign-participation_test.js
@@ -1,14 +1,12 @@
 import { usecases } from '../../../../../../src/prescription/campaign-participation/domain/usecases/index.js';
 import { DomainTransaction } from '../../../../../../src/shared/domain/DomainTransaction.js';
-import { databaseBuilder, expect, mockLearningContent } from '../../../../../test-helper.js';
+import { databaseBuilder, expect } from '../../../../../test-helper.js';
 
 describe('Integration | UseCases | startCampaignParticipation', function () {
   it('start a new participation', async function () {
     const { id: campaignId } = databaseBuilder.factory.buildCampaign({ type: 'PROFILES_COLLECTION' });
     const { id: userId } = databaseBuilder.factory.buildUser();
-    await mockLearningContent({
-      skills: [],
-    });
+    databaseBuilder.factory.learningContent.build({ skills: [] });
     await databaseBuilder.commit();
     const campaignParticipation = { campaignId };
 

--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-assessment-participation-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-assessment-participation-repository_test.js
@@ -4,7 +4,7 @@ import * as campaignAssessmentParticipationRepository from '../../../../../../sr
 import { CampaignParticipationStatuses } from '../../../../../../src/prescription/shared/domain/constants.js';
 import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
 import { Assessment } from '../../../../../../src/shared/domain/models/Assessment.js';
-import { catchErr, databaseBuilder, expect, mockLearningContent } from '../../../../../test-helper.js';
+import { catchErr, databaseBuilder, expect } from '../../../../../test-helper.js';
 
 const { STARTED } = CampaignParticipationStatuses;
 
@@ -27,7 +27,7 @@ describe('Integration | Repository | Campaign Assessment Participation', functio
       beforeEach(async function () {
         const skill1 = { id: 'skill1' };
         const skill2 = { id: 'skill2' };
-        await mockLearningContent({ skills: [skill1, skill2] });
+        databaseBuilder.factory.learningContent.build({ skills: [skill1, skill2] });
         campaignId = databaseBuilder.factory.buildAssessmentCampaign({}).id;
 
         const assessment = databaseBuilder.factory.buildAssessmentFromParticipation(
@@ -87,7 +87,7 @@ describe('Integration | Repository | Campaign Assessment Participation', functio
       beforeEach(async function () {
         skill1 = { id: 'skill1', status: 'actif' };
         const skill2 = { id: 'skill2', status: 'actif' };
-        await mockLearningContent({ skills: [skill1, skill2] });
+        databaseBuilder.factory.learningContent.build({ skills: [skill1, skill2] });
         campaignId = databaseBuilder.factory.buildAssessmentCampaign({}, [skill1, skill2]).id;
 
         campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
@@ -123,7 +123,7 @@ describe('Integration | Repository | Campaign Assessment Participation', functio
 
       beforeEach(async function () {
         const skill = { id: 'skill', status: 'actif' };
-        await mockLearningContent({ skills: [skill] });
+        databaseBuilder.factory.learningContent.build({ skills: [skill] });
         const otherOrganizationId = databaseBuilder.factory.buildOrganization().id;
         const organizationId = databaseBuilder.factory.buildOrganization().id;
         campaignId = databaseBuilder.factory.buildAssessmentCampaignForSkills({ organizationId }, [skill]).id;
@@ -175,7 +175,7 @@ describe('Integration | Repository | Campaign Assessment Participation', functio
     context('When something is wrong with a campaign participations', function () {
       it('throw a NotFoundError when campaign participation does not exist', async function () {
         const skill1 = { id: 'skill1', status: 'actif' };
-        await mockLearningContent({ skills: [skill1] });
+        databaseBuilder.factory.learningContent.build({ skills: [skill1] });
 
         campaignId = databaseBuilder.factory.buildAssessmentCampaign({}, [skill1]).id;
 
@@ -191,7 +191,7 @@ describe('Integration | Repository | Campaign Assessment Participation', functio
 
       it('throw a NotFoundError when campaign participation is deleted', async function () {
         const skill1 = { id: 'skill1', status: 'actif' };
-        await mockLearningContent({ skills: [skill1] });
+        databaseBuilder.factory.learningContent.build({ skills: [skill1] });
 
         campaignId = databaseBuilder.factory.buildAssessmentCampaign({}, [skill1]).id;
         campaignParticipationId = databaseBuilder.factory.buildAssessmentFromParticipation({

--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-assessment-participation-result-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-assessment-participation-result-repository_test.js
@@ -3,7 +3,7 @@ import { KnowledgeElementCollection } from '../../../../../../src/prescription/s
 import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
 import { KnowledgeElement } from '../../../../../../src/shared/domain/models/KnowledgeElement.js';
 import { ENGLISH_SPOKEN, FRENCH_SPOKEN } from '../../../../../../src/shared/domain/services/locale-service.js';
-import { catchErr, databaseBuilder, expect, mockLearningContent } from '../../../../../test-helper.js';
+import { catchErr, databaseBuilder, expect } from '../../../../../test-helper.js';
 
 describe('Integration | Repository | Campaign Assessment Participation Result', function () {
   describe('#getByCampaignIdAndCampaignParticipationId', function () {
@@ -74,7 +74,7 @@ describe('Integration | Repository | Campaign Assessment Participation Result', 
         challenges: [],
       };
 
-      await mockLearningContent(learningContent);
+      databaseBuilder.factory.learningContent.build(learningContent);
       return databaseBuilder.commit();
     });
 

--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-overview-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-overview-repository_test.js
@@ -12,13 +12,7 @@ import {
 } from '../../../../../../src/quest/domain/models/OrganizationLearnerParticipation.js';
 import { constants } from '../../../../../../src/shared/domain/constants.js';
 import { Assessment } from '../../../../../../src/shared/domain/models/Assessment.js';
-import {
-  databaseBuilder,
-  expect,
-  learningContentBuilder,
-  mockLearningContent,
-  sinon,
-} from '../../../../../test-helper.js';
+import { databaseBuilder, expect, learningContentBuilder, sinon } from '../../../../../test-helper.js';
 
 const { campaignParticipationOverviewFactory } = databaseBuilder.factory;
 
@@ -52,7 +46,7 @@ describe('Integration | Repository | Campaign Participation Overview', function 
       },
     ];
     const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
-    await mockLearningContent(learningContentObjects);
+    databaseBuilder.factory.learningContent.build(learningContentObjects);
     targetProfile = databaseBuilder.factory.buildTargetProfile();
     databaseBuilder.factory.buildStage({ targetProfileId: targetProfile.id });
     await databaseBuilder.commit();

--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-profile-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-profile-repository_test.js
@@ -2,7 +2,7 @@ import * as CampaignProfileRepository from '../../../../../../src/prescription/c
 import { PIX_COUNT_BY_LEVEL } from '../../../../../../src/shared/domain/constants.js';
 import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
 import { ENGLISH_SPOKEN, FRENCH_SPOKEN } from '../../../../../../src/shared/domain/services/locale-service.js';
-import { catchErr, databaseBuilder, expect, mockLearningContent } from '../../../../../test-helper.js';
+import { catchErr, databaseBuilder, expect } from '../../../../../test-helper.js';
 
 describe('Integration | Repository | CampaignProfileRepository', function () {
   const locale = FRENCH_SPOKEN;
@@ -10,7 +10,8 @@ describe('Integration | Repository | CampaignProfileRepository', function () {
   describe('#findProfile', function () {
     context('campaign participation infos', function () {
       beforeEach(async function () {
-        await mockLearningContent({ areas: [], competences: [], skills: [] });
+        databaseBuilder.factory.learningContent.build({ areas: [], competences: [], skills: [] });
+        await databaseBuilder.commit();
       });
 
       it('return the creation date, the sharing date and the participantExternalId', async function () {
@@ -77,11 +78,9 @@ describe('Integration | Repository | CampaignProfileRepository', function () {
     });
 
     context('organization learner infos', function () {
-      beforeEach(async function () {
-        await mockLearningContent({ areas: [], competences: [], skills: [] });
-      });
-
       it('return the first name and last name of the organization learner', async function () {
+        databaseBuilder.factory.learningContent.build({ areas: [], competences: [], skills: [] });
+
         const organizationId = databaseBuilder.factory.buildOrganization().id;
         const campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
         const campaignParticipation = databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
@@ -156,7 +155,8 @@ describe('Integration | Repository | CampaignProfileRepository', function () {
           ],
         };
 
-        await mockLearningContent(learningContent);
+        databaseBuilder.factory.learningContent.build(learningContent);
+        await databaseBuilder.commit();
       });
 
       it('return the number of competences', async function () {
@@ -262,11 +262,10 @@ describe('Integration | Repository | CampaignProfileRepository', function () {
     });
 
     context('when there is no campaign-participation with the given id', function () {
-      beforeEach(async function () {
-        await mockLearningContent({ areas: [], competences: [], skills: [] });
-      });
-
       it('throws an NotFoundError error', async function () {
+        databaseBuilder.factory.learningContent.build({ areas: [], competences: [], skills: [] });
+        await databaseBuilder.commit();
+
         const error = await catchErr(CampaignProfileRepository.findProfile)({
           campaignId: 1,
           campaignParticipationId: 2,
@@ -279,16 +278,12 @@ describe('Integration | Repository | CampaignProfileRepository', function () {
     });
 
     context('when there is no campaign-participation with the given id for the given campaign', function () {
-      beforeEach(async function () {
-        await mockLearningContent({ areas: [], competences: [], skills: [] });
-      });
-
       it('throws an NotFoundError error', async function () {
+        databaseBuilder.factory.learningContent.build({ areas: [], competences: [], skills: [] });
         const campaignId = databaseBuilder.factory.buildCampaign({ id: 1 }).id;
-
         const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({ id: 3, campaignId }).id;
-
         await databaseBuilder.commit();
+
         const error = await catchErr(CampaignProfileRepository.findProfile)({
           campaignId: 2,
           campaignParticipationId,
@@ -301,19 +296,15 @@ describe('Integration | Repository | CampaignProfileRepository', function () {
     });
 
     context('when the campaign-participation is deleted with the given id for the given campaign', function () {
-      beforeEach(async function () {
-        await mockLearningContent({ areas: [], competences: [], skills: [] });
-      });
-
       it('throws a NotFoundError error', async function () {
+        databaseBuilder.factory.learningContent.build({ areas: [], competences: [], skills: [] });
         const campaignId = databaseBuilder.factory.buildCampaign().id;
-
         const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
           campaignId,
           deletedAt: new Date('2022-01-01'),
         }).id;
-
         await databaseBuilder.commit();
+
         const error = await catchErr(CampaignProfileRepository.findProfile)({
           campaignId,
           campaignParticipationId,

--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/participant-results-shared-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/participant-results-shared-repository_test.js
@@ -1,7 +1,7 @@
 import { participantResultsSharedRepository } from '../../../../../../src/prescription/campaign-participation/infrastructure/repositories/participant-results-shared-repository.js';
 import { CampaignTypes } from '../../../../../../src/prescription/shared/domain/constants.js';
 import { MAX_REACHABLE_PIX_BY_COMPETENCE } from '../../../../../../src/shared/domain/constants.js';
-import { databaseBuilder, expect, knex, mockLearningContent } from '../../../../../test-helper.js';
+import { databaseBuilder, expect, knex } from '../../../../../test-helper.js';
 
 describe('Integration | Repository | Campaign Participant Result Shared Repository', function () {
   describe('#save', function () {
@@ -95,13 +95,12 @@ describe('Integration | Repository | Campaign Participant Result Shared Reposito
           { skillId: 'skill_3', status: 'validated', earnedPix: 1 },
         ]);
 
-        await databaseBuilder.commit();
-
         const learningContent = {
           skills: [{ id: 'skill_1' }, { id: 'skill_2' }, { id: 'skill_3' }],
           competences: [],
         };
-        await mockLearningContent(learningContent);
+        databaseBuilder.factory.learningContent.build(learningContent);
+        await databaseBuilder.commit();
 
         //when
         const participantResultsShared = await participantResultsSharedRepository.get(participation.id);
@@ -123,8 +122,6 @@ describe('Integration | Repository | Campaign Participant Result Shared Reposito
           { skillId: 'skill_5', competenceId: 'competence_5', status: 'invalidated', earnedPix: 0 },
         ]);
 
-        await databaseBuilder.commit();
-
         const learningContent = {
           skills: [
             { id: 'skill_1', competenceId: 'competence_1' },
@@ -141,7 +138,8 @@ describe('Integration | Repository | Campaign Participant Result Shared Reposito
             { id: 'competence_5', origin: 'Pix' },
           ],
         };
-        await mockLearningContent(learningContent);
+        databaseBuilder.factory.learningContent.build(learningContent);
+        await databaseBuilder.commit();
 
         //when
         const participantResultsShared = await participantResultsSharedRepository.get(participation.id);
@@ -160,8 +158,6 @@ describe('Integration | Repository | Campaign Participant Result Shared Reposito
           { skillId: 'skill_5', competenceId: 'competence_5', status: 'validated', earnedPix: 12 },
         ]);
 
-        await databaseBuilder.commit();
-
         const learningContent = {
           skills: [
             { id: 'skill_1', competenceId: 'competence_1' },
@@ -178,7 +174,8 @@ describe('Integration | Repository | Campaign Participant Result Shared Reposito
             { id: 'competence_5', origin: 'Pix' },
           ],
         };
-        await mockLearningContent(learningContent);
+        databaseBuilder.factory.learningContent.build(learningContent);
+        await databaseBuilder.commit();
 
         //when
         const participantResultsShared = await participantResultsSharedRepository.get(participation.id);
@@ -199,8 +196,6 @@ describe('Integration | Repository | Campaign Participant Result Shared Reposito
           { skillId: 'skill_3', status: 'validated', earnedPix: 1 },
         ]);
 
-        await databaseBuilder.commit();
-
         const learningContent = {
           skills: [
             { id: 'skill_1', status: 'actif' },
@@ -209,7 +204,8 @@ describe('Integration | Repository | Campaign Participant Result Shared Reposito
           ],
           competences: [],
         };
-        await mockLearningContent(learningContent);
+        databaseBuilder.factory.learningContent.build(learningContent);
+        await databaseBuilder.commit();
 
         //when
         const participantResultsShared = await participantResultsSharedRepository.get(participation.id);
@@ -232,8 +228,6 @@ describe('Integration | Repository | Campaign Participant Result Shared Reposito
             { skillId: 'skill_3', status: 'validated', earnedPix: 5 },
           ]);
 
-          await databaseBuilder.commit();
-
           const learningContent = {
             skills: [
               { id: 'skill_1', status: 'actif' },
@@ -242,7 +236,8 @@ describe('Integration | Repository | Campaign Participant Result Shared Reposito
             ],
             competences: [],
           };
-          await mockLearningContent(learningContent);
+          databaseBuilder.factory.learningContent.build(learningContent);
+          await databaseBuilder.commit();
 
           //when
           const participantResultsShared = await participantResultsSharedRepository.get(participation.id);
@@ -265,8 +260,6 @@ describe('Integration | Repository | Campaign Participant Result Shared Reposito
             { skillId: 'skill_3', status: 'invalidated', earnedPix: 0 },
           ]);
 
-          await databaseBuilder.commit();
-
           const learningContent = {
             skills: [
               { id: 'skill_1', status: 'actif' },
@@ -275,7 +268,8 @@ describe('Integration | Repository | Campaign Participant Result Shared Reposito
             ],
             competences: [],
           };
-          await mockLearningContent(learningContent);
+          databaseBuilder.factory.learningContent.build(learningContent);
+          await databaseBuilder.commit();
 
           //when
           const participantResultsShared = await participantResultsSharedRepository.get(participation.id);
@@ -300,8 +294,6 @@ describe('Integration | Repository | Campaign Participant Result Shared Reposito
           { skillId: 'skill_5', competenceId: 'competence_5', status: 'validated', earnedPix: 12 },
         ]);
 
-        await databaseBuilder.commit();
-
         const learningContent = {
           skills: [
             { id: 'skill_1', competenceId: 'competence_1', status: 'actif' },
@@ -318,7 +310,8 @@ describe('Integration | Repository | Campaign Participant Result Shared Reposito
             { id: 'competence_5', origin: 'Pix' },
           ],
         };
-        await mockLearningContent(learningContent);
+        databaseBuilder.factory.learningContent.build(learningContent);
+        await databaseBuilder.commit();
 
         //when
         const participantResultsShared = await participantResultsSharedRepository.get(participation.id);
@@ -336,10 +329,9 @@ describe('Integration | Repository | Campaign Participant Result Shared Reposito
         { skillId: 'skill_1', status: 'validated', earnedPix: 1 },
       ]);
 
-      await databaseBuilder.commit();
-
       const learningContent = { skills: [{ id: 'skill_1', status: 'actif' }], competences: [] };
-      await mockLearningContent(learningContent);
+      databaseBuilder.factory.learningContent.build(learningContent);
+      await databaseBuilder.commit();
 
       //when
       const participantResultsShared = await participantResultsSharedRepository.get(participation.id);

--- a/api/tests/prescription/campaign/acceptance/application/campaign-administration-route_test.js
+++ b/api/tests/prescription/campaign/acceptance/application/campaign-administration-route_test.js
@@ -8,7 +8,6 @@ import {
   generateAuthenticatedUserRequestHeaders,
   knex,
   learningContentBuilder,
-  mockLearningContent,
 } from '../../../../test-helper.js';
 
 const { ROLES } = PIX_ADMIN;
@@ -33,8 +32,6 @@ describe('Acceptance | API | campaign-administration-route', function () {
         targetProfileId: targetProfile.id,
       });
 
-      await databaseBuilder.commit();
-
       const learningContent = [
         {
           id: 'recArea1',
@@ -57,7 +54,8 @@ describe('Acceptance | API | campaign-administration-route', function () {
         },
       ];
       const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
-      await mockLearningContent(learningContentObjects);
+      databaseBuilder.factory.learningContent.build(learningContentObjects);
+      await databaseBuilder.commit();
 
       // when
       const payload = {
@@ -162,7 +160,6 @@ describe('Acceptance | API | campaign-administration-route', function () {
       });
 
       const anotherUserId = databaseBuilder.factory.buildUser().id;
-      await databaseBuilder.commit();
 
       const learningContent = [
         {
@@ -186,7 +183,8 @@ describe('Acceptance | API | campaign-administration-route', function () {
         },
       ];
       const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
-      await mockLearningContent(learningContentObjects);
+      databaseBuilder.factory.learningContent.build(learningContentObjects);
+      await databaseBuilder.commit();
 
       // when
       const payload = {

--- a/api/tests/prescription/campaign/acceptance/application/campaign-detail-route_test.js
+++ b/api/tests/prescription/campaign/acceptance/application/campaign-detail-route_test.js
@@ -8,7 +8,6 @@ import {
   expect,
   generateAuthenticatedUserRequestHeaders,
   learningContentBuilder,
-  mockLearningContent,
 } from '../../../../test-helper.js';
 
 const { STARTED } = CampaignParticipationStatuses;
@@ -76,8 +75,6 @@ describe('Acceptance | API | campaign-detail-route', function () {
       options.headers = generateAuthenticatedUserRequestHeaders({ userId });
       options.url = `/api/campaigns/${campaign.id}`;
 
-      await databaseBuilder.commit();
-
       const learningContent = [
         {
           competences: [
@@ -96,7 +93,8 @@ describe('Acceptance | API | campaign-detail-route', function () {
         },
       ];
       const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
-      await mockLearningContent(learningContentObjects);
+      databaseBuilder.factory.learningContent.build(learningContentObjects);
+      await databaseBuilder.commit();
     });
 
     it('should return the campaign by id', async function () {
@@ -168,8 +166,6 @@ describe('Acceptance | API | campaign-detail-route', function () {
       options.headers = generateAuthenticatedUserRequestHeaders({ userId });
       options.url = `/api/campaigns/${campaign.id}/csv-profiles-collection-results`;
 
-      await databaseBuilder.commit();
-
       const learningContent = [
         {
           id: 'recArea1',
@@ -200,7 +196,8 @@ describe('Acceptance | API | campaign-detail-route', function () {
       ];
 
       const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
-      await mockLearningContent(learningContentObjects);
+      databaseBuilder.factory.learningContent.build(learningContentObjects);
+      await databaseBuilder.commit();
     });
 
     it('should return csv file with statusCode 200', async function () {
@@ -254,8 +251,6 @@ describe('Acceptance | API | campaign-detail-route', function () {
       options.headers = generateAuthenticatedUserRequestHeaders({ userId });
       options.url = `/api/campaigns/${campaign.id}/csv-assessment-results`;
 
-      await databaseBuilder.commit();
-
       const learningContent = [
         {
           id: 'recArea1',
@@ -286,7 +281,8 @@ describe('Acceptance | API | campaign-detail-route', function () {
       ];
 
       const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
-      await mockLearningContent(learningContentObjects);
+      databaseBuilder.factory.learningContent.build(learningContentObjects);
+      await databaseBuilder.commit();
     });
 
     it('should return csv file with statusCode 200', async function () {

--- a/api/tests/prescription/campaign/acceptance/application/campaign-results-route_test.js
+++ b/api/tests/prescription/campaign/acceptance/application/campaign-results-route_test.js
@@ -6,7 +6,6 @@ import {
   expect,
   generateAuthenticatedUserRequestHeaders,
   learningContentBuilder,
-  mockLearningContent,
 } from '../../../../test-helper.js';
 
 describe('Acceptance | API | campaign-results-route', function () {
@@ -28,7 +27,6 @@ describe('Acceptance | API | campaign-results-route', function () {
     beforeEach(async function () {
       userId = databaseBuilder.factory.buildUser().id;
       const organization = databaseBuilder.factory.buildOrganization();
-
       databaseBuilder.factory.buildMembership({ userId, organizationId: organization.id });
 
       const skill = { id: 'Skill1', name: '@Acquis1', challenges: [] };
@@ -50,7 +48,7 @@ describe('Acceptance | API | campaign-results-route', function () {
       ];
 
       const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
-      await mockLearningContent(learningContentObjects);
+      databaseBuilder.factory.learningContent.build(learningContentObjects);
 
       campaign = databaseBuilder.factory.buildAssessmentCampaignForSkills({ organizationId: organization.id }, [skill]);
 
@@ -140,7 +138,8 @@ describe('Acceptance | API | campaign-results-route', function () {
       ];
 
       const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
-      await mockLearningContent(learningContentObjects);
+      databaseBuilder.factory.learningContent.build(learningContentObjects);
+      await databaseBuilder.commit();
     });
 
     context('Division filter', function () {
@@ -580,8 +579,6 @@ describe('Acceptance | API | campaign-results-route', function () {
         snapshot: new KnowledgeElementCollection([ke]).toSnapshot(),
       });
 
-      await databaseBuilder.commit();
-
       const learningContent = [
         {
           id: 'recArea1',
@@ -616,7 +613,8 @@ describe('Acceptance | API | campaign-results-route', function () {
         },
       ];
       const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
-      await mockLearningContent(learningContentObjects);
+      databaseBuilder.factory.learningContent.build(learningContentObjects);
+      await databaseBuilder.commit();
     });
 
     it('should return campaign collective result with status code 200', async function () {

--- a/api/tests/prescription/campaign/acceptance/application/campaign-stats-route_test.js
+++ b/api/tests/prescription/campaign/acceptance/application/campaign-stats-route_test.js
@@ -4,7 +4,6 @@ import {
   expect,
   generateAuthenticatedUserRequestHeaders,
   learningContentBuilder,
-  mockLearningContent,
 } from '../../../../test-helper.js';
 
 describe('Acceptance | API | Campaign Stats Route', function () {
@@ -42,7 +41,7 @@ describe('Acceptance | API | Campaign Stats Route', function () {
           ],
         },
       ]);
-      await mockLearningContent(learningContentObjects);
+      databaseBuilder.factory.learningContent.build(learningContentObjects);
 
       const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
       const stage1 = databaseBuilder.factory.buildStage({

--- a/api/tests/prescription/campaign/integration/domain/usecases/create-campaign_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/create-campaign_test.js
@@ -10,7 +10,7 @@ import { CampaignTypes } from '../../../../../../src/prescription/shared/domain/
 import { CAMPAIGN_FEATURES, ORGANIZATION_FEATURE } from '../../../../../../src/shared/domain/constants.js';
 import * as codeGenerator from '../../../../../../src/shared/domain/services/code-generator.js';
 import * as accessCodeRepository from '../../../../../../src/shared/infrastructure/repositories/access-code-repository.js';
-import { catchErr, databaseBuilder, expect, knex, mockLearningContent } from '../../../../../test-helper.js';
+import { catchErr, databaseBuilder, expect, knex } from '../../../../../test-helper.js';
 
 describe('Integration | UseCases | create-campaign', function () {
   let userId;
@@ -34,13 +34,9 @@ describe('Integration | UseCases | create-campaign', function () {
       userId,
     });
 
+    const learningContent = { skills: [{ id: 'recSkill1' }] };
+    databaseBuilder.factory.learningContent.build(learningContent);
     await databaseBuilder.commit();
-
-    const learningContent = {
-      skills: [{ id: 'recSkill1' }],
-    };
-
-    await mockLearningContent(learningContent);
   });
 
   it('should save a new campaign of type PROFILES_COLLECTION', async function () {
@@ -168,7 +164,7 @@ describe('Integration | UseCases | create-campaign', function () {
           },
         ],
       };
-      await mockLearningContent(learningContent);
+      databaseBuilder.factory.learningContent.build(learningContent);
 
       databaseBuilder.factory.buildTargetProfileTube({ targetProfileId, tubeId: 'recTube1', level: 2 });
       await databaseBuilder.commit();
@@ -261,7 +257,7 @@ describe('Integration | UseCases | create-campaign', function () {
           },
         ],
       };
-      await mockLearningContent(learningContent);
+      databaseBuilder.factory.learningContent.build(learningContent);
 
       databaseBuilder.factory.buildTargetProfileTube({ targetProfileId, tubeId: 'recTube1', level: 2 });
       await databaseBuilder.commit();

--- a/api/tests/prescription/campaign/integration/domain/usecases/find-assessment-participation-result-list_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/find-assessment-participation-result-list_test.js
@@ -1,5 +1,5 @@
 import { usecases } from '../../../../../../src/prescription/campaign/domain/usecases/index.js';
-import { databaseBuilder, expect, mockLearningContent } from '../../../../../test-helper.js';
+import { databaseBuilder, expect } from '../../../../../test-helper.js';
 
 describe('Integration | UseCase | find-assessment-participation-result-list', function () {
   let organizationId;
@@ -28,7 +28,7 @@ describe('Integration | UseCase | find-assessment-participation-result-list', fu
     const participant2 = { firstName: 'Tonari', lastName: 'No Totoro' };
     databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(participant2, participation2);
 
-    await mockLearningContent({
+    databaseBuilder.factory.learningContent.build({
       skills: [skill],
       tubes: [],
       thematics: [],

--- a/api/tests/prescription/campaign/integration/domain/usecases/find-campaign-profiles-collection-participation-summaries_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/find-campaign-profiles-collection-participation-summaries_test.js
@@ -1,5 +1,5 @@
 import { usecases } from '../../../../../../src/prescription/campaign/domain/usecases/index.js';
-import { databaseBuilder, expect, mockLearningContent } from '../../../../../test-helper.js';
+import { databaseBuilder, expect } from '../../../../../test-helper.js';
 
 describe('Integration | UseCase | find-campaign-profiles-collection-participation-summaries', function () {
   let organizationId;
@@ -15,7 +15,7 @@ describe('Integration | UseCase | find-campaign-profiles-collection-participatio
 
     databaseBuilder.factory.buildMembership({ organizationId, userId });
 
-    await mockLearningContent({ skills: [], tubes: [], competences: [], areas: [] });
+    databaseBuilder.factory.learningContent.build({ skills: [], tubes: [], competences: [], areas: [] });
 
     await databaseBuilder.commit();
   });

--- a/api/tests/prescription/campaign/integration/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
@@ -11,7 +11,7 @@ import { CAMPAIGN_FEATURES, ORGANIZATION_FEATURE } from '../../../../../../src/s
 import { Assessment } from '../../../../../../src/shared/domain/models/Assessment.js';
 import { KnowledgeElement } from '../../../../../../src/shared/domain/models/KnowledgeElement.js';
 import { getI18n } from '../../../../../../src/shared/infrastructure/i18n/i18n.js';
-import { databaseBuilder, domainBuilder, expect, mockLearningContent, sinon } from '../../../../../test-helper.js';
+import { databaseBuilder, domainBuilder, expect, sinon } from '../../../../../test-helper.js';
 
 describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-results-to-stream', function () {
   describe('#startWritingCampaignAssessmentResultsToStream', function () {
@@ -81,7 +81,8 @@ describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-r
         ],
         challenges: [],
       };
-      await mockLearningContent(learningContent);
+      databaseBuilder.factory.learningContent.build(learningContent);
+      await databaseBuilder.commit();
 
       writableStream = new PassThrough();
     });

--- a/api/tests/prescription/campaign/integration/domain/usecases/statistics/get-campaign-participations-counts-by-stage_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/statistics/get-campaign-participations-counts-by-stage_test.js
@@ -4,13 +4,7 @@ import {
   NoStagesForCampaign,
   UserNotAuthorizedToAccessEntityError,
 } from '../../../../../../../src/shared/domain/errors.js';
-import {
-  catchErr,
-  databaseBuilder,
-  expect,
-  learningContentBuilder,
-  mockLearningContent,
-} from '../../../../../../test-helper.js';
+import { catchErr, databaseBuilder, expect, learningContentBuilder } from '../../../../../../test-helper.js';
 
 describe('Integration | UseCase | get-campaign-participations-counts-by-stage', function () {
   let organizationId;
@@ -46,7 +40,7 @@ describe('Integration | UseCase | get-campaign-participations-counts-by-stage', 
         ],
       },
     ]);
-    await mockLearningContent(learningContentObjects);
+    databaseBuilder.factory.learningContent.build(learningContentObjects);
 
     const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
 

--- a/api/tests/prescription/campaign/integration/domain/usecases/update-campaign-details_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/update-campaign-details_test.js
@@ -5,7 +5,7 @@ import {
 import { Campaign } from '../../../../../../src/prescription/campaign/domain/models/Campaign.js';
 import { usecases } from '../../../../../../src/prescription/campaign/domain/usecases/index.js';
 import { CampaignParticipationStatuses } from '../../../../../../src/prescription/shared/domain/constants.js';
-import { catchErr, databaseBuilder, expect, knex, mockLearningContent } from '../../../../../test-helper.js';
+import { catchErr, databaseBuilder, expect, knex } from '../../../../../test-helper.js';
 
 const { SHARED } = CampaignParticipationStatuses;
 
@@ -41,13 +41,9 @@ describe('Integration | UseCases | update-campaign-details', function () {
 
     campaignId = campaign.id;
 
+    const learningContent = { skills: [{ id: 'recSkill1' }] };
+    databaseBuilder.factory.learningContent.build(learningContent);
     await databaseBuilder.commit();
-
-    const learningContent = {
-      skills: [{ id: 'recSkill1' }],
-    };
-
-    await mockLearningContent(learningContent);
   });
 
   it('should update campaign', async function () {

--- a/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-administration-repository_test.js
+++ b/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-administration-repository_test.js
@@ -6,7 +6,7 @@ import * as campaignAdministrationRepository from '../../../../../../src/prescri
 import { deleteExternalIdLabelFromCampaigns } from '../../../../../../src/prescription/campaign/infrastructure/repositories/campaign-administration-repository.js';
 import { CampaignExternalIdTypes, CampaignTypes } from '../../../../../../src/prescription/shared/domain/constants.js';
 import { CAMPAIGN_FEATURES } from '../../../../../../src/shared/domain/constants.js';
-import { catchErr, databaseBuilder, expect, knex, mockLearningContent, sinon } from '../../../../../test-helper.js';
+import { catchErr, databaseBuilder, expect, knex, sinon } from '../../../../../test-helper.js';
 
 describe('Integration | Repository | Campaign Administration', function () {
   describe('#findByIds', function () {
@@ -189,7 +189,7 @@ describe('Integration | Repository | Campaign Administration', function () {
               },
             ],
           };
-          await mockLearningContent(learningContent);
+          databaseBuilder.factory.learningContent.build(learningContent);
 
           databaseBuilder.factory.buildTargetProfileTube({ targetProfileId, tubeId: 'recTube1', level: 2 });
           databaseBuilder.factory.buildTargetProfileTube({ targetProfileId, tubeId: 'recTube2', level: 8 });
@@ -366,7 +366,7 @@ describe('Integration | Repository | Campaign Administration', function () {
               },
             ],
           };
-          await mockLearningContent(learningContent);
+          databaseBuilder.factory.learningContent.build(learningContent);
 
           databaseBuilder.factory.buildTargetProfileTube({ targetProfileId, tubeId: 'recTube1', level: 2 });
           databaseBuilder.factory.buildTargetProfileTube({ targetProfileId, tubeId: 'recTube2', level: 8 });

--- a/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-assessment-participation-result-list-repository_test.js
+++ b/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-assessment-participation-result-list-repository_test.js
@@ -3,7 +3,7 @@ import {
   CampaignParticipationStatuses,
   CampaignTypes,
 } from '../../../../../../src/prescription/shared/domain/constants.js';
-import { databaseBuilder, expect, learningContentBuilder, mockLearningContent } from '../../../../../test-helper.js';
+import { databaseBuilder, expect, learningContentBuilder } from '../../../../../test-helper.js';
 const { STARTED } = CampaignParticipationStatuses;
 const { buildCampaign, buildStage, buildStageAcquisition, buildCampaignParticipation } = databaseBuilder.factory;
 
@@ -36,8 +36,6 @@ describe('Integration | Repository | Campaign Assessment Participation Result Li
           participantExternalId: 'The ugly',
         });
 
-        await databaseBuilder.commit();
-
         const learningContent = [
           {
             id: 'recArea1',
@@ -55,7 +53,8 @@ describe('Integration | Repository | Campaign Assessment Participation Result Li
           },
         ];
         const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
-        await mockLearningContent(learningContentObjects);
+        databaseBuilder.factory.learningContent.build(learningContentObjects);
+        await databaseBuilder.commit();
       });
 
       it('returns the list of participations shared for the given campaign', async function () {
@@ -106,7 +105,8 @@ describe('Integration | Repository | Campaign Assessment Participation Result Li
           },
         ];
         const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
-        await mockLearningContent(learningContentObjects);
+        databaseBuilder.factory.learningContent.build(learningContentObjects);
+        await databaseBuilder.commit();
       });
 
       it('returns the list of participations shared for the given campaign', async function () {
@@ -206,7 +206,6 @@ describe('Integration | Repository | Campaign Assessment Participation Result Li
             campaignId: campaign.id,
           },
         );
-        await databaseBuilder.commit();
 
         const learningContent = [
           {
@@ -225,7 +224,8 @@ describe('Integration | Repository | Campaign Assessment Participation Result Li
           },
         ];
         const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
-        await mockLearningContent(learningContentObjects);
+        databaseBuilder.factory.learningContent.build(learningContentObjects);
+        await databaseBuilder.commit();
       });
 
       it('returns the name from the organization learner', async function () {
@@ -265,7 +265,7 @@ describe('Integration | Repository | Campaign Assessment Participation Result Li
 
         databaseBuilder.factory.buildBadgeAcquisition({ userId, badgeId: badge1Id, campaignParticipationId });
         databaseBuilder.factory.buildBadgeAcquisition({ userId, badgeId: badge2Id });
-        await databaseBuilder.commit();
+
         const learningContent = [
           {
             id: 'recArea1',
@@ -283,7 +283,8 @@ describe('Integration | Repository | Campaign Assessment Participation Result Li
           },
         ];
         const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
-        await mockLearningContent(learningContentObjects);
+        databaseBuilder.factory.learningContent.build(learningContentObjects);
+        await databaseBuilder.commit();
       });
 
       it('returns acquired badges during the campaign', async function () {
@@ -312,7 +313,6 @@ describe('Integration | Repository | Campaign Assessment Participation Result Li
           deletedAt: new Date('2022-03-31'),
           deletedBy: userId,
         });
-        await databaseBuilder.commit();
 
         const learningContent = [
           {
@@ -331,7 +331,8 @@ describe('Integration | Repository | Campaign Assessment Participation Result Li
           },
         ];
         const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
-        await mockLearningContent(learningContentObjects);
+        databaseBuilder.factory.learningContent.build(learningContentObjects);
+        await databaseBuilder.commit();
       });
 
       it('does not return deleted participations', async function () {
@@ -359,7 +360,6 @@ describe('Integration | Repository | Campaign Assessment Participation Result Li
           masteryRate: 0.33,
         });
 
-        await databaseBuilder.commit();
         const learningContent = [
           {
             id: 'recArea1',
@@ -377,7 +377,8 @@ describe('Integration | Repository | Campaign Assessment Participation Result Li
           },
         ];
         const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
-        await mockLearningContent(learningContentObjects);
+        databaseBuilder.factory.learningContent.build(learningContentObjects);
+        await databaseBuilder.commit();
       });
 
       it('computes the mastery percentage', async function () {
@@ -578,8 +579,6 @@ describe('Integration | Repository | Campaign Assessment Participation Result Li
           true,
         );
 
-        await databaseBuilder.commit();
-
         const learningContent = [
           {
             id: 'recArea1',
@@ -597,7 +596,8 @@ describe('Integration | Repository | Campaign Assessment Participation Result Li
           },
         ];
         const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
-        await mockLearningContent(learningContentObjects);
+        databaseBuilder.factory.learningContent.build(learningContentObjects);
+        await databaseBuilder.commit();
 
         // when
         const { participations } = await campaignAssessmentParticipationResultListRepository.findPaginatedByCampaignId({
@@ -621,8 +621,6 @@ describe('Integration | Repository | Campaign Assessment Participation Result Li
         databaseBuilder.factory.buildAssessmentFromParticipation(participation);
         databaseBuilder.factory.buildAssessmentFromParticipation(participation);
 
-        await databaseBuilder.commit();
-
         const learningContent = [
           {
             id: 'recArea1',
@@ -640,7 +638,8 @@ describe('Integration | Repository | Campaign Assessment Participation Result Li
           },
         ];
         const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
-        await mockLearningContent(learningContentObjects);
+        databaseBuilder.factory.learningContent.build(learningContentObjects);
+        await databaseBuilder.commit();
       });
 
       it('should return paginated campaign participations based on the given size and number', async function () {
@@ -736,8 +735,6 @@ describe('Integration | Repository | Campaign Assessment Participation Result Li
           division: 'Ugly Guys Team',
         });
 
-        await databaseBuilder.commit();
-
         const learningContent = [
           {
             id: 'recArea1',
@@ -755,7 +752,8 @@ describe('Integration | Repository | Campaign Assessment Participation Result Li
           },
         ];
         const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
-        await mockLearningContent(learningContentObjects);
+        databaseBuilder.factory.learningContent.build(learningContentObjects);
+        await databaseBuilder.commit();
 
         // when
         const { participations } = await campaignAssessmentParticipationResultListRepository.findPaginatedByCampaignId({
@@ -1086,7 +1084,8 @@ describe('Integration | Repository | Campaign Assessment Participation Result Li
           },
         ];
         const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
-        await mockLearningContent(learningContentObjects);
+        databaseBuilder.factory.learningContent.build(learningContentObjects);
+        await databaseBuilder.commit();
       });
 
       it('retrieves participants who have reached the specified stage', async function () {
@@ -1186,8 +1185,6 @@ describe('Integration | Repository | Campaign Assessment Participation Result Li
           group: 'Adoptive Brother',
         });
 
-        await databaseBuilder.commit();
-
         const learningContent = [
           {
             id: 'recArea1',
@@ -1205,7 +1202,8 @@ describe('Integration | Repository | Campaign Assessment Participation Result Li
           },
         ];
         const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
-        await mockLearningContent(learningContentObjects);
+        databaseBuilder.factory.learningContent.build(learningContentObjects);
+        await databaseBuilder.commit();
 
         // when
         const { participations } = await campaignAssessmentParticipationResultListRepository.findPaginatedByCampaignId({
@@ -1244,7 +1242,8 @@ describe('Integration | Repository | Campaign Assessment Participation Result Li
           },
         ];
         const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
-        await mockLearningContent(learningContentObjects);
+        databaseBuilder.factory.learningContent.build(learningContentObjects);
+        await databaseBuilder.commit();
       });
 
       it('returns all participants if the filter is empty', async function () {
@@ -1514,8 +1513,6 @@ describe('Integration | Repository | Campaign Assessment Participation Result Li
         // given
         campaign = databaseBuilder.factory.buildAssessmentCampaignForSkills({}, [{ id: 'Skill1' }]);
 
-        await databaseBuilder.commit();
-
         const learningContent = [
           {
             id: 'recArea1',
@@ -1533,7 +1530,8 @@ describe('Integration | Repository | Campaign Assessment Participation Result Li
           },
         ];
         const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
-        await mockLearningContent(learningContentObjects);
+        databaseBuilder.factory.learningContent.build(learningContentObjects);
+        await databaseBuilder.commit();
       });
 
       it('returns all participants if the filter is empty', async function () {

--- a/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-report-repository_test.js
+++ b/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-report-repository_test.js
@@ -10,7 +10,7 @@ import {
 } from '../../../../../../src/prescription/shared/domain/constants.js';
 import { CAMPAIGN_FEATURES } from '../../../../../../src/shared/domain/constants.js';
 import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
-import { catchErr, databaseBuilder, expect, mockLearningContent } from '../../../../../test-helper.js';
+import { catchErr, databaseBuilder, expect } from '../../../../../test-helper.js';
 
 const { STARTED, SHARED } = CampaignParticipationStatuses;
 
@@ -24,7 +24,7 @@ describe('Integration | Repository | Campaign-Report', function () {
           ownerId: creator.id,
           multipleSendings: false,
         });
-        await mockLearningContent({ skills: [] });
+        databaseBuilder.factory.learningContent.build({ skills: [] });
 
         await databaseBuilder.commit();
         const result = await campaignReportRepository.get(campaign.id);
@@ -63,7 +63,7 @@ describe('Integration | Repository | Campaign-Report', function () {
           },
         });
 
-        await mockLearningContent({ skills: [] });
+        databaseBuilder.factory.learningContent.build({ skills: [] });
 
         await databaseBuilder.commit();
         const result = await campaignReportRepository.get(campaign.id);

--- a/api/tests/prescription/campaign/integration/infrastructure/repositories/stage-collection-repository_test.js
+++ b/api/tests/prescription/campaign/integration/infrastructure/repositories/stage-collection-repository_test.js
@@ -1,5 +1,5 @@
 import * as stageCollectionRepository from '../../../../../../src/prescription/campaign/infrastructure/repositories/stage-collection-repository.js';
-import { databaseBuilder, expect, learningContentBuilder, mockLearningContent } from '../../../../../test-helper.js';
+import { databaseBuilder, expect, learningContentBuilder } from '../../../../../test-helper.js';
 
 const competenceId = 'recCompetence';
 const learningContent = [
@@ -50,7 +50,7 @@ describe('Integration | Infrastructure | Repository | stage-collection-repositor
 
     beforeEach(async function () {
       const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
-      await mockLearningContent(learningContentObjects);
+      databaseBuilder.factory.learningContent.build(learningContentObjects);
       targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
       campaignId = databaseBuilder.factory.buildCampaign({ type: 'ASSESSMENT', targetProfileId }).id;
       databaseBuilder.factory.buildCampaignSkill({ skillId: 'skillWeb1', campaignId });

--- a/api/tests/prescription/scripts/integration/insert-missing-pole-emploi-sending-from-date_test.js
+++ b/api/tests/prescription/scripts/integration/insert-missing-pole-emploi-sending-from-date_test.js
@@ -5,14 +5,7 @@ import { PoleEmploiSending } from '../../../../src/prescription/campaign-partici
 import { insertMissingPoleEmploiSendingFromDate } from '../../../../src/prescription/scripts/insert-missing-pole-emploi-sending-from-date.js';
 import { CampaignParticipationStatuses, CampaignTypes } from '../../../../src/prescription/shared/domain/constants.js';
 import { Assessment } from '../../../../src/shared/domain/models/Assessment.js';
-import {
-  catchErr,
-  databaseBuilder,
-  expect,
-  knex,
-  learningContentBuilder,
-  mockLearningContent,
-} from '../../../test-helper.js';
+import { catchErr, databaseBuilder, expect, knex, learningContentBuilder } from '../../../test-helper.js';
 
 describe('Script | Prod | Delete Organization Learners From Organization', function () {
   describe('#insertMissingPoleEmploiSendingFromDate', function () {
@@ -41,7 +34,8 @@ describe('Script | Prod | Delete Organization Learners From Organization', funct
       ];
 
       const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
-      await mockLearningContent(learningContentObjects);
+      databaseBuilder.factory.learningContent.build(learningContentObjects);
+      await databaseBuilder.commit();
     });
 
     context('validation', function () {

--- a/api/tests/prescription/target-profile/acceptance/application/admin-target-profile-route_test.js
+++ b/api/tests/prescription/target-profile/acceptance/application/admin-target-profile-route_test.js
@@ -7,7 +7,6 @@ import {
   knex,
   learningContentBuilder,
   MockDate,
-  mockLearningContent,
 } from '../../../../test-helper.js';
 
 describe('Acceptance | TargetProfile | Application | Route | admin-target-profile', function () {
@@ -59,7 +58,8 @@ describe('Acceptance | TargetProfile | Application | Route | admin-target-profil
     };
 
     beforeEach(async function () {
-      await mockLearningContent(learningContent);
+      databaseBuilder.factory.learningContent.build(learningContent);
+      await databaseBuilder.commit();
     });
 
     describe('when there is no tube to update', function () {
@@ -176,7 +176,8 @@ describe('Acceptance | TargetProfile | Application | Route | admin-target-profil
     };
 
     beforeEach(async function () {
-      await mockLearningContent(learningContent);
+      databaseBuilder.factory.learningContent.build(learningContent);
+      await databaseBuilder.commit();
       user = databaseBuilder.factory.buildUser.withRole();
     });
 
@@ -378,7 +379,7 @@ describe('Acceptance | TargetProfile | Application | Route | admin-target-profil
           ],
         },
       ]);
-      await mockLearningContent(learningContent);
+      databaseBuilder.factory.learningContent.build(learningContent);
 
       targetProfileId = databaseBuilder.factory.buildTargetProfile({ name: 'Roxane est très jolie' }).id;
       databaseBuilder.factory.buildTargetProfileTube({ targetProfileId, tubeId: 'recTube2', level: 2 });

--- a/api/tests/prescription/target-profile/acceptance/application/target-profile-route_test.js
+++ b/api/tests/prescription/target-profile/acceptance/application/target-profile-route_test.js
@@ -4,7 +4,6 @@ import {
   expect,
   generateAuthenticatedUserRequestHeaders,
   learningContentBuilder,
-  mockLearningContent,
 } from '../../../../test-helper.js';
 
 describe('Acceptance | Route | target-profile', function () {
@@ -33,7 +32,7 @@ describe('Acceptance | Route | target-profile', function () {
           },
         ];
         const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
-        await mockLearningContent(learningContentObjects);
+        databaseBuilder.factory.learningContent.build(learningContentObjects);
 
         user = databaseBuilder.factory.buildUser({});
         linkedOrganization = databaseBuilder.factory.buildOrganization({});
@@ -272,8 +271,8 @@ describe('Acceptance | Route | target-profile', function () {
         tubeId: 'tubeFrance1_1_1_1',
       });
 
+      databaseBuilder.factory.learningContent.build(learningContent);
       await databaseBuilder.commit();
-      await mockLearningContent(learningContent);
     });
 
     it('should return response code 200', async function () {

--- a/api/tests/prescription/target-profile/integration/infrastructure/repositories/target-profile-administration-repository_test.js
+++ b/api/tests/prescription/target-profile/integration/infrastructure/repositories/target-profile-administration-repository_test.js
@@ -13,7 +13,6 @@ import {
   expect,
   knex,
   learningContentBuilder,
-  mockLearningContent,
   sinon,
 } from '../../../../../test-helper.js';
 
@@ -61,7 +60,7 @@ describe('Integration | Repository | Target-profile', function () {
           tubeId: 'recTube3',
           level: 8,
         });
-        await databaseBuilder.commit();
+
         const learningContent = {
           areas: [
             {
@@ -108,7 +107,8 @@ describe('Integration | Repository | Target-profile', function () {
             },
           ],
         };
-        await mockLearningContent(learningContent);
+        databaseBuilder.factory.learningContent.build(learningContent);
+        await databaseBuilder.commit();
 
         // when
         const err = await catchErr(targetProfileAdministrationRepository.get)({ id: 1 });
@@ -202,7 +202,6 @@ describe('Integration | Repository | Target-profile', function () {
             { id: 'recTube3', level: 3 },
           ]),
         });
-        await databaseBuilder.commit();
 
         datamartBuilder.factory.buildTargetProfileCourseDuration({
           targetProfileId: targetProfileDB.id,
@@ -363,7 +362,8 @@ describe('Integration | Repository | Target-profile', function () {
             },
           ],
         };
-        await mockLearningContent(learningContent);
+        databaseBuilder.factory.learningContent.build(learningContent);
+        await databaseBuilder.commit();
 
         // when
         const actualTargetProfile = await targetProfileAdministrationRepository.get({ id: targetProfileDB.id });
@@ -511,7 +511,7 @@ describe('Integration | Repository | Target-profile', function () {
           tubeId: 'recTube1',
           level: 4,
         });
-        await databaseBuilder.commit();
+
         const learningContent = {
           areas: [
             {
@@ -575,7 +575,8 @@ describe('Integration | Repository | Target-profile', function () {
             },
           ],
         };
-        await mockLearningContent(learningContent);
+        databaseBuilder.factory.learningContent.build(learningContent);
+        await databaseBuilder.commit();
 
         // when
         const actualTargetProfile = await targetProfileAdministrationRepository.get({ id: 1, locale: 'en' });
@@ -656,7 +657,6 @@ describe('Integration | Repository | Target-profile', function () {
             tubeId: 'recTube1',
             level: 4,
           });
-          await databaseBuilder.commit();
 
           const learningContent = {
             areas: [
@@ -717,7 +717,8 @@ describe('Integration | Repository | Target-profile', function () {
               },
             ],
           };
-          await mockLearningContent(learningContent);
+          databaseBuilder.factory.learningContent.build(learningContent);
+          await databaseBuilder.commit();
 
           // when
           const actualTargetProfile = await targetProfileAdministrationRepository.get({ id: targetProfileDB.id });
@@ -734,11 +735,11 @@ describe('Integration | Repository | Target-profile', function () {
         // given
         const { id } = databaseBuilder.factory.buildTargetProfile();
         databaseBuilder.factory.buildCampaign({ targetProfileId: id });
-        await databaseBuilder.commit();
 
         const learningContent = domainBuilder.buildCampaignLearningContent.withSimpleContent();
         const learningContentObjects = learningContentBuilder([learningContent]);
-        await mockLearningContent(learningContentObjects);
+        databaseBuilder.factory.learningContent.build(learningContentObjects);
+        await databaseBuilder.commit();
 
         // when
         const actualTargetProfile = await targetProfileAdministrationRepository.get({ id });
@@ -756,7 +757,7 @@ describe('Integration | Repository | Target-profile', function () {
 
           const learningContent = domainBuilder.buildCampaignLearningContent.withSimpleContent();
           const learningContentObjects = learningContentBuilder([learningContent]);
-          await mockLearningContent(learningContentObjects);
+          databaseBuilder.factory.learningContent.build(learningContentObjects);
 
           const { id: organizationId } = databaseBuilder.factory.buildOrganization({
             id: constants.AUTONOMOUS_COURSES_ORGANIZATION_ID,
@@ -788,7 +789,7 @@ describe('Integration | Repository | Target-profile', function () {
 
           const learningContent = domainBuilder.buildCampaignLearningContent.withSimpleContent();
           const learningContentObjects = learningContentBuilder([learningContent]);
-          await mockLearningContent(learningContentObjects);
+          databaseBuilder.factory.learningContent.build(learningContentObjects);
 
           const { id: organizationId } = databaseBuilder.factory.buildOrganization({ id: 9999 });
 

--- a/api/tests/school/acceptance/application/assessments/activity-answer-controller_test.js
+++ b/api/tests/school/acceptance/application/assessments/activity-answer-controller_test.js
@@ -1,5 +1,5 @@
 import { Activity } from '../../../../../src/school/domain/models/Activity.js';
-import { createServer, databaseBuilder, expect, mockLearningContent } from '../../../../test-helper.js';
+import { createServer, databaseBuilder, expect } from '../../../../test-helper.js';
 import * as learningContentBuilder from '../../../../tooling/learning-content-builder/index.js';
 
 describe('Acceptance | Controller | activity-answer-controller', function () {
@@ -66,7 +66,8 @@ describe('Acceptance | Controller | activity-answer-controller', function () {
           skills: [skill],
         };
 
-        await mockLearningContent(learningContent);
+        databaseBuilder.factory.learningContent.build(learningContent);
+        await databaseBuilder.commit();
 
         const payload = {
           data: {
@@ -123,7 +124,7 @@ describe('Acceptance | Controller | activity-answer-controller', function () {
 });
 
 async function mockLearningContentForMission(missionId) {
-  await mockLearningContent({
+  databaseBuilder.factory.learningContent.build({
     skills: [
       learningContentBuilder.buildSkill({
         id: 'skill_id',
@@ -148,4 +149,5 @@ async function mockLearningContentForMission(missionId) {
       }),
     ],
   });
+  await databaseBuilder.commit();
 }

--- a/api/tests/school/acceptance/application/assessments/assessment-controller_test.js
+++ b/api/tests/school/acceptance/application/assessments/assessment-controller_test.js
@@ -1,5 +1,5 @@
 import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
-import { createServer, databaseBuilder, expect, knex, mockLearningContent } from '../../../../test-helper.js';
+import { createServer, databaseBuilder, expect, knex } from '../../../../test-helper.js';
 import * as learningContentBuilder from '../../../../tooling/learning-content-builder/index.js';
 
 describe('Acceptance | Controller | assessment-controller', function () {
@@ -65,15 +65,9 @@ describe('Acceptance | Controller | assessment-controller', function () {
 
       it('should create a mission-assessment and return it', async function () {
         const learner = databaseBuilder.factory.buildOrganizationLearner();
-        await databaseBuilder.commit();
-
         const mission = learningContentBuilder.buildMission();
-
-        const learningContent = {
-          missions: [mission],
-        };
-
-        await mockLearningContent(learningContent);
+        databaseBuilder.factory.learningContent.build({ missions: [mission] });
+        await databaseBuilder.commit();
 
         const postAssessmentRequest = {
           method: 'POST',
@@ -111,12 +105,7 @@ describe('Acceptance | Controller | assessment-controller', function () {
     context('when there is an assessment in progress for given organization-learner and mission', function () {
       it('should retrieve the mission-assessment and return it', async function () {
         const mission = learningContentBuilder.buildMission();
-
-        const learningContent = {
-          missions: [mission],
-        };
-
-        await mockLearningContent(learningContent);
+        databaseBuilder.factory.learningContent.build({ missions: [mission] });
 
         const learner = databaseBuilder.factory.buildOrganizationLearner();
         const missionAssessment = databaseBuilder.factory.buildMissionAssessment({

--- a/api/tests/school/acceptance/application/challenge-route_test.js
+++ b/api/tests/school/acceptance/application/challenge-route_test.js
@@ -1,4 +1,4 @@
-import { createServer, expect, mockLearningContent } from '../../../test-helper.js';
+import { createServer, databaseBuilder, expect } from '../../../test-helper.js';
 import * as learningContentBuilder from '../../../tooling/learning-content-builder/index.js';
 
 describe('Integration | Controller | challenge-controller', function () {
@@ -15,10 +15,11 @@ describe('Integration | Controller | challenge-controller', function () {
       });
       const skill = learningContentBuilder.buildSkill({ id: challenge.skillId });
 
-      await mockLearningContent({
+      databaseBuilder.factory.learningContent.build({
         challenges: [challenge],
         skills: [skill],
       });
+      await databaseBuilder.commit();
 
       const expectedResult = ['Jean-michel va à la \n', '\n plage pour manger un gateau'];
 

--- a/api/tests/school/integration/domain/services/correct-answer_test.js
+++ b/api/tests/school/integration/domain/services/correct-answer_test.js
@@ -10,14 +10,7 @@ import { Examiner } from '../../../../../src/shared/domain/models/Examiner.js';
 import { Validation } from '../../../../../src/shared/domain/models/Validation.js';
 import * as assessmentRepository from '../../../../../src/shared/infrastructure/repositories/assessment-repository.js';
 import * as challengeRepository from '../../../../../src/shared/infrastructure/repositories/challenge-repository.js';
-import {
-  catchErr,
-  databaseBuilder,
-  domainBuilder,
-  expect,
-  knex,
-  mockLearningContent,
-} from '../../../../test-helper.js';
+import { catchErr, databaseBuilder, domainBuilder, expect, knex } from '../../../../test-helper.js';
 import * as learningContentBuilder from '../../../../tooling/learning-content-builder/index.js';
 
 describe('Integration | UseCases | correct-answer', function () {
@@ -41,7 +34,7 @@ describe('Integration | UseCases | correct-answer', function () {
           skills: [skill],
         };
 
-        await mockLearningContent(learningContent);
+        databaseBuilder.factory.learningContent.build(learningContent);
 
         assessment = databaseBuilder.factory.buildAssessment({
           state: Assessment.states.STARTED,
@@ -203,7 +196,8 @@ describe('Integration | UseCases | correct-answer', function () {
         challenges: [challenge],
         skills: [skill],
       };
-      await mockLearningContent(learningContent);
+      databaseBuilder.factory.learningContent.build(learningContent);
+      await databaseBuilder.commit();
 
       const assessmentId = 10;
       const activityAnswer = domainBuilder.buildActivityAnswer({

--- a/api/tests/school/integration/domain/services/init-mission-activity_test.js
+++ b/api/tests/school/integration/domain/services/init-mission-activity_test.js
@@ -4,7 +4,7 @@ import * as activityRepository from '../../../../../src/school/infrastructure/re
 import * as missionAssessmentRepository from '../../../../../src/school/infrastructure/repositories/mission-assessment-repository.js';
 import * as missionRepository from '../../../../../src/school/infrastructure/repositories/mission-repository.js';
 import * as assessmentRepository from '../../../../../src/shared/infrastructure/repositories/assessment-repository.js';
-import { databaseBuilder, domainBuilder, expect, knex, mockLearningContent } from '../../../../test-helper.js';
+import { databaseBuilder, domainBuilder, expect, knex } from '../../../../test-helper.js';
 import * as learningContentBuilder from '../../../../tooling/learning-content-builder/index.js';
 
 describe('Integration | Usecase | init-mission-activity', function () {
@@ -44,11 +44,11 @@ describe('Integration | Usecase | init-mission-activity', function () {
             level: Activity.levels.CHALLENGE,
             status: Activity.status.SUCCEEDED,
           });
-          await databaseBuilder.commit();
 
-          await mockLearningContent({
+          databaseBuilder.factory.learningContent.build({
             missions: [learningContentBuilder.buildMission({ id: missionId })],
           });
+          await databaseBuilder.commit();
 
           const lastActivity = domainBuilder.buildActivity(dbActivity);
 
@@ -94,11 +94,10 @@ describe('Integration | Usecase | init-mission-activity', function () {
             status: Activity.status.SUCCEEDED,
             createdAt: new Date('2024-04-03'),
           });
-          await databaseBuilder.commit();
 
           const lastActivity = domainBuilder.buildActivity(tutorialActivity);
 
-          await mockLearningContent({
+          databaseBuilder.factory.learningContent.build({
             missions: [
               learningContentBuilder.buildMission({
                 id: missionId,
@@ -115,6 +114,7 @@ describe('Integration | Usecase | init-mission-activity', function () {
               }),
             ],
           });
+          await databaseBuilder.commit();
 
           const currentActivity = await initMissionActivity({
             lastActivity,
@@ -148,11 +148,10 @@ describe('Integration | Usecase | init-mission-activity', function () {
             status: Activity.status.SUCCEEDED,
             createdAt: new Date('2024-04-01'),
           });
-          await databaseBuilder.commit();
 
           const lastActivity = domainBuilder.buildActivity(firstStepValidationActivity);
 
-          await mockLearningContent({
+          databaseBuilder.factory.learningContent.build({
             missions: [
               learningContentBuilder.buildMission({
                 id: missionId,
@@ -169,6 +168,7 @@ describe('Integration | Usecase | init-mission-activity', function () {
               }),
             ],
           });
+          await databaseBuilder.commit();
 
           const currentActivity = await initMissionActivity({
             lastActivity,
@@ -195,9 +195,8 @@ describe('Integration | Usecase | init-mission-activity', function () {
       it('should create activity', async function () {
         const missionId = 12;
         const { assessmentId } = databaseBuilder.factory.buildMissionAssessment({ missionId });
-        await databaseBuilder.commit();
 
-        await mockLearningContent({
+        databaseBuilder.factory.learningContent.build({
           missions: [
             learningContentBuilder.buildMission({
               id: missionId,
@@ -214,6 +213,7 @@ describe('Integration | Usecase | init-mission-activity', function () {
             }),
           ],
         });
+        await databaseBuilder.commit();
 
         const currentActivity = await initMissionActivity({
           lastActivity: undefined,

--- a/api/tests/school/integration/domain/services/update-current-activity_test.js
+++ b/api/tests/school/integration/domain/services/update-current-activity_test.js
@@ -5,7 +5,7 @@ import * as activityRepository from '../../../../../src/school/infrastructure/re
 import * as missionAssessmentRepository from '../../../../../src/school/infrastructure/repositories/mission-assessment-repository.js';
 import * as missionRepository from '../../../../../src/school/infrastructure/repositories/mission-repository.js';
 import { AnswerStatus } from '../../../../../src/shared/domain/models/AnswerStatus.js';
-import { databaseBuilder, expect, knex, mockLearningContent } from '../../../../test-helper.js';
+import { databaseBuilder, expect, knex } from '../../../../test-helper.js';
 import * as learningContentBuilder from '../../../../tooling/learning-content-builder/index.js';
 
 describe('Integration | UseCase | update current activity', function () {
@@ -13,9 +13,7 @@ describe('Integration | UseCase | update current activity', function () {
     context('when activity is not finished', function () {
       [
         { message: 'correctly answered', result: AnswerStatus.statuses.OK },
-
         { message: 'wrongly answered', result: AnswerStatus.statuses.KO },
-
         { message: 'skipped', result: AnswerStatus.statuses.SKIPPED },
       ].forEach(({ message, result }) =>
         it(`should not update current activity status when challenge is ${message}`, async function () {
@@ -32,9 +30,7 @@ describe('Integration | UseCase | update current activity', function () {
             result,
           });
 
-          await databaseBuilder.commit();
-
-          await mockLearningContent({
+          databaseBuilder.factory.learningContent.build({
             missions: [
               learningContentBuilder.buildMission({
                 id: missionId,
@@ -48,6 +44,7 @@ describe('Integration | UseCase | update current activity', function () {
               }),
             ],
           });
+          await databaseBuilder.commit();
 
           const currentActivity = await updateCurrentActivity({
             assessmentId,
@@ -94,9 +91,7 @@ describe('Integration | UseCase | update current activity', function () {
             createdAt: new Date('2020-01-01T10:01:00Z'),
           });
 
-          await databaseBuilder.commit();
-
-          await mockLearningContent({
+          databaseBuilder.factory.learningContent.build({
             missions: [
               learningContentBuilder.buildMission({
                 id: missionId,
@@ -110,6 +105,7 @@ describe('Integration | UseCase | update current activity', function () {
               }),
             ],
           });
+          await databaseBuilder.commit();
 
           const currentActivity = await updateCurrentActivity({
             assessmentId,
@@ -144,7 +140,7 @@ describe('Integration | UseCase | update current activity', function () {
           result: AnswerStatus.statuses.KO,
         });
 
-        await mockLearningContent({
+        databaseBuilder.factory.learningContent.build({
           missions: [
             learningContentBuilder.buildMission({
               id: missionId,
@@ -192,9 +188,7 @@ describe('Integration | UseCase | update current activity', function () {
             result: AnswerStatus.statuses.OK,
           });
 
-          await databaseBuilder.commit();
-
-          await mockLearningContent({
+          databaseBuilder.factory.learningContent.build({
             missions: [
               learningContentBuilder.buildMission({
                 id: missionId,
@@ -208,6 +202,7 @@ describe('Integration | UseCase | update current activity', function () {
               }),
             ],
           });
+          await databaseBuilder.commit();
 
           const currentActivity = await updateCurrentActivity({
             assessmentId,
@@ -245,9 +240,7 @@ describe('Integration | UseCase | update current activity', function () {
             result: AnswerStatus.statuses.OK,
           });
 
-          await databaseBuilder.commit();
-
-          await mockLearningContent({
+          databaseBuilder.factory.learningContent.build({
             missions: [
               learningContentBuilder.buildMission({
                 id: missionId,
@@ -261,6 +254,7 @@ describe('Integration | UseCase | update current activity', function () {
               }),
             ],
           });
+          await databaseBuilder.commit();
 
           const currentActivity = await updateCurrentActivity({
             assessmentId,
@@ -299,9 +293,7 @@ describe('Integration | UseCase | update current activity', function () {
             createdAt: new Date('2020-01-01T10:01:00Z'),
           });
 
-          await databaseBuilder.commit();
-
-          await mockLearningContent({
+          databaseBuilder.factory.learningContent.build({
             missions: [
               learningContentBuilder.buildMission({
                 id: missionId,
@@ -315,6 +307,7 @@ describe('Integration | UseCase | update current activity', function () {
               }),
             ],
           });
+          await databaseBuilder.commit();
 
           const currentActivity = await updateCurrentActivity({
             assessmentId,
@@ -346,9 +339,8 @@ describe('Integration | UseCase | update current activity', function () {
           challengeId: 'va_challenge_id',
           result: AnswerStatus.statuses.SKIPPED,
         });
-        await databaseBuilder.commit();
 
-        await mockLearningContent({
+        databaseBuilder.factory.learningContent.build({
           missions: [
             learningContentBuilder.buildMission({
               id: missionId,
@@ -362,6 +354,7 @@ describe('Integration | UseCase | update current activity', function () {
             }),
           ],
         });
+        await databaseBuilder.commit();
 
         const currentActivity = await updateCurrentActivity({
           assessmentId,

--- a/api/tests/school/integration/domain/usecases/correct-preview-answer_test.js
+++ b/api/tests/school/integration/domain/usecases/correct-preview-answer_test.js
@@ -3,7 +3,7 @@ import { correctPreviewAnswer } from '../../../../../src/school/domain/usecases/
 import { AnswerStatus } from '../../../../../src/shared/domain/models/AnswerStatus.js';
 import { Examiner } from '../../../../../src/shared/domain/models/Examiner.js';
 import * as challengeRepository from '../../../../../src/shared/infrastructure/repositories/challenge-repository.js';
-import { domainBuilder, expect, knex, mockLearningContent } from '../../../../test-helper.js';
+import { databaseBuilder, domainBuilder, expect, knex } from '../../../../test-helper.js';
 import * as learningContentBuilder from '../../../../tooling/learning-content-builder/index.js';
 
 describe('Integration | UseCases | correct-preview-answer', function () {
@@ -21,7 +21,8 @@ describe('Integration | UseCases | correct-preview-answer', function () {
       skills: [skill],
     };
 
-    await mockLearningContent(learningContent);
+    databaseBuilder.factory.learningContent.build(learningContent);
+    await databaseBuilder.commit();
 
     const alwaysTrueExaminer = new Examiner({ validator: new ValidatorAlwaysOK() });
 

--- a/api/tests/school/integration/domain/usecases/get-next-challenge_test.js
+++ b/api/tests/school/integration/domain/usecases/get-next-challenge_test.js
@@ -8,7 +8,7 @@ import * as missionRepository from '../../../../../src/school/infrastructure/rep
 import { Challenge } from '../../../../../src/shared/domain/models/Challenge.js';
 import * as assessmentRepository from '../../../../../src/shared/infrastructure/repositories/assessment-repository.js';
 import * as challengeRepository from '../../../../../src/shared/infrastructure/repositories/challenge-repository.js';
-import { databaseBuilder, expect, knex, mockLearningContent } from '../../../../test-helper.js';
+import { databaseBuilder, expect, knex } from '../../../../test-helper.js';
 import * as learningContentBuilder from '../../../../tooling/learning-content-builder/index.js';
 
 describe('Integration | School | Usecase | get-next-challenge', function () {
@@ -64,9 +64,7 @@ describe('Integration | School | Usecase | get-next-challenge', function () {
           challengeId: 'first_va_challenge_on_step_1_id',
         });
 
-        await databaseBuilder.commit();
-
-        await mockLearningContent({
+        databaseBuilder.factory.learningContent.build({
           challenges: [
             learningContentBuilder.buildChallenge({ id: 'second_va_challenge_on_step_2_id', skillId: 'skill_id' }),
           ],
@@ -87,6 +85,7 @@ describe('Integration | School | Usecase | get-next-challenge', function () {
             }),
           ],
         });
+        await databaseBuilder.commit();
 
         const challenge = await getNextChallenge({
           assessmentId,
@@ -126,9 +125,7 @@ describe('Integration | School | Usecase | get-next-challenge', function () {
           challengeId: 'first_va_challenge_id',
         });
 
-        await databaseBuilder.commit();
-
-        await mockLearningContent({
+        databaseBuilder.factory.learningContent.build({
           challenges: [learningContentBuilder.buildChallenge({ id: 'second_va_challenge_id', skillId: 'skill_id' })],
           skills: [learningContentBuilder.buildSkill({ id: 'skill_id' })],
           missions: [
@@ -144,6 +141,7 @@ describe('Integration | School | Usecase | get-next-challenge', function () {
             }),
           ],
         });
+        await databaseBuilder.commit();
 
         const challenge = await getNextChallenge({
           assessmentId,

--- a/api/tests/school/integration/domain/usecases/handle-activity-answer_test.js
+++ b/api/tests/school/integration/domain/usecases/handle-activity-answer_test.js
@@ -11,14 +11,7 @@ import { Examiner } from '../../../../../src/shared/domain/models/Examiner.js';
 import { Validation } from '../../../../../src/shared/domain/models/Validation.js';
 import * as assessmentRepository from '../../../../../src/shared/infrastructure/repositories/assessment-repository.js';
 import * as challengeRepository from '../../../../../src/shared/infrastructure/repositories/challenge-repository.js';
-import {
-  catchErr,
-  databaseBuilder,
-  domainBuilder,
-  expect,
-  knex,
-  mockLearningContent,
-} from '../../../../test-helper.js';
+import { catchErr, databaseBuilder, domainBuilder, expect, knex } from '../../../../test-helper.js';
 import * as learningContentBuilder from '../../../../tooling/learning-content-builder/index.js';
 
 describe('Integration | UseCase | handle activity answer', function () {
@@ -51,7 +44,6 @@ describe('Integration | UseCase | handle activity answer', function () {
           createdAt: new Date(),
           stepIndex: 0,
         });
-        await databaseBuilder.commit();
 
         await mockLearningContentForMission(missionId);
 
@@ -93,7 +85,6 @@ describe('Integration | UseCase | handle activity answer', function () {
           stepIndex: 0,
           createdAt: new Date(),
         });
-        await databaseBuilder.commit();
 
         await mockLearningContentForMission(missionId);
 
@@ -135,8 +126,6 @@ describe('Integration | UseCase | handle activity answer', function () {
           status: Activity.status.STARTED,
           stepIndex: 0,
         });
-
-        await databaseBuilder.commit();
 
         await mockLearningContentForMission(missionId);
 
@@ -183,8 +172,6 @@ describe('Integration | UseCase | handle activity answer', function () {
             activityId: activity.id,
           });
 
-          await databaseBuilder.commit();
-
           await mockLearningContentForMission(missionId);
 
           await handleActivityAnswer({
@@ -225,7 +212,6 @@ describe('Integration | UseCase | handle activity answer', function () {
             stepIndex: 0,
             createdAt: new Date(),
           });
-          await databaseBuilder.commit();
 
           await mockLearningContentForMission(missionId);
 
@@ -270,8 +256,6 @@ describe('Integration | UseCase | handle activity answer', function () {
           createdAt: new Date(),
         });
 
-        await databaseBuilder.commit();
-
         await mockLearningContentForMission(missionId);
 
         await handleActivityAnswer({
@@ -312,7 +296,6 @@ describe('Integration | UseCase | handle activity answer', function () {
           stepIndex: 0,
           createdAt: new Date(),
         });
-        await databaseBuilder.commit();
 
         await mockLearningContentForMission(missionId);
 
@@ -361,8 +344,6 @@ describe('Integration | UseCase | handle activity answer', function () {
           stepIndex: 0,
         });
 
-        await databaseBuilder.commit();
-
         await mockLearningContentForMission(missionId);
 
         await handleActivityAnswer({
@@ -404,8 +385,7 @@ describe('Integration | UseCase | handle activity answer', function () {
       stepIndex: 0,
     });
 
-    await databaseBuilder.commit();
-    await mockLearningContent({
+    databaseBuilder.factory.learningContent.build({
       skills: [
         learningContentBuilder.buildSkill({
           id: 'skill_id',
@@ -418,6 +398,7 @@ describe('Integration | UseCase | handle activity answer', function () {
         }),
       ],
     });
+    await databaseBuilder.commit();
 
     await catchErr(handleActivityAnswer)({
       activityAnswer,
@@ -445,7 +426,7 @@ async function expectStatesAndLevel({ assessmentId, activityLevel, activityStatu
 }
 
 async function mockLearningContentForMission(missionId) {
-  await mockLearningContent({
+  databaseBuilder.factory.learningContent.build({
     skills: [
       learningContentBuilder.buildSkill({
         id: 'skill_id',
@@ -488,4 +469,5 @@ async function mockLearningContentForMission(missionId) {
       }),
     ],
   });
+  await databaseBuilder.commit();
 }

--- a/api/tests/school/integration/domain/usecases/play-mission_test.js
+++ b/api/tests/school/integration/domain/usecases/play-mission_test.js
@@ -4,14 +4,7 @@ import { Activity } from '../../../../../src/school/domain/models/Activity.js';
 import { Assessment } from '../../../../../src/school/domain/models/Assessment.js';
 import { usecases } from '../../../../../src/school/domain/usecases/index.js';
 import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
-import {
-  catchErr,
-  databaseBuilder,
-  domainBuilder,
-  expect,
-  knex,
-  mockLearningContent,
-} from '../../../../test-helper.js';
+import { catchErr, databaseBuilder, domainBuilder, expect, knex } from '../../../../test-helper.js';
 import * as learningContentBuilder from '../../../../tooling/learning-content-builder/index.js';
 
 describe('Integration | UseCases | play-mission', function () {
@@ -20,9 +13,8 @@ describe('Integration | UseCases | play-mission', function () {
   context('when no assessment is started for learner and mission', function () {
     it('should save a new assessment for Pix1D', async function () {
       const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner().id;
-      await databaseBuilder.commit();
 
-      await mockLearningContent({
+      databaseBuilder.factory.learningContent.build({
         missions: [
           learningContentBuilder.buildMission({
             id: missionId,
@@ -37,6 +29,7 @@ describe('Integration | UseCases | play-mission', function () {
           }),
         ],
       });
+      await databaseBuilder.commit();
 
       const result = await usecases.playMission({
         missionId,
@@ -55,9 +48,8 @@ describe('Integration | UseCases | play-mission', function () {
 
     it('should save a new mission assessment', async function () {
       const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner().id;
-      await databaseBuilder.commit();
 
-      await mockLearningContent({
+      databaseBuilder.factory.learningContent.build({
         missions: [
           learningContentBuilder.buildMission({
             id: missionId,
@@ -72,6 +64,7 @@ describe('Integration | UseCases | play-mission', function () {
           }),
         ],
       });
+      await databaseBuilder.commit();
 
       const result = await usecases.playMission({
         missionId,
@@ -89,9 +82,8 @@ describe('Integration | UseCases | play-mission', function () {
 
     it('should save an activity', async function () {
       const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner().id;
-      await databaseBuilder.commit();
 
-      await mockLearningContent({
+      databaseBuilder.factory.learningContent.build({
         missions: [
           learningContentBuilder.buildMission({
             id: missionId,
@@ -106,6 +98,7 @@ describe('Integration | UseCases | play-mission', function () {
           }),
         ],
       });
+      await databaseBuilder.commit();
 
       const result = await usecases.playMission({
         missionId,
@@ -123,9 +116,8 @@ describe('Integration | UseCases | play-mission', function () {
 
     it('should return the school assessment', async function () {
       const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner().id;
-      await databaseBuilder.commit();
 
-      await mockLearningContent({
+      databaseBuilder.factory.learningContent.build({
         missions: [
           learningContentBuilder.buildMission({
             id: missionId,
@@ -140,6 +132,7 @@ describe('Integration | UseCases | play-mission', function () {
           }),
         ],
       });
+      await databaseBuilder.commit();
 
       const assessment = await usecases.playMission({
         missionId,

--- a/api/tests/shared/acceptance/application/assessments/assessment-controller-auto-validate-next-challenge_test.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-controller-auto-validate-next-challenge_test.js
@@ -7,7 +7,6 @@ import {
   generateAuthenticatedUserRequestHeaders,
   knex,
   learningContentBuilder,
-  mockLearningContent,
 } from '../../../../test-helper.js';
 
 const lastChallengeAnswer = 'last challenge answer';
@@ -55,7 +54,8 @@ describe('Acceptance | API | assessment-controller-auto-validate-next-challenge'
 
     server = await createServer();
     const learningContentObjects = learningContentBuilder(learningContent);
-    await mockLearningContent(learningContentObjects);
+    databaseBuilder.factory.learningContent.build(learningContentObjects);
+    await databaseBuilder.commit();
   });
 
   afterEach(function () {

--- a/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-for-campaign-assessment_test.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-for-campaign-assessment_test.js
@@ -7,7 +7,6 @@ import {
   generateInjectOptions,
   knex,
   learningContentBuilder,
-  mockLearningContent,
   sinon,
 } from '../../../../test-helper.js';
 
@@ -73,7 +72,8 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-campai
   beforeEach(async function () {
     server = await createServer();
     const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
-    await mockLearningContent(learningContentObjects);
+    databaseBuilder.factory.learningContent.build(learningContentObjects);
+    await databaseBuilder.commit();
   });
 
   describe('GET /api/assessments/:assessment_id', function () {

--- a/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-for-certification_test.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-for-certification_test.js
@@ -10,7 +10,6 @@ import {
   generateAuthenticatedUserRequestHeaders,
   knex,
   learningContentBuilder,
-  mockLearningContent,
   sinon,
 } from '../../../../test-helper.js';
 
@@ -74,7 +73,8 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-certif
   beforeEach(async function () {
     server = await createServer();
     const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
-    await mockLearningContent(learningContentObjects);
+    databaseBuilder.factory.learningContent.build(learningContentObjects);
+    await databaseBuilder.commit();
   });
 
   describe('GET /api/assessments/:assessment_id', function () {

--- a/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-for-competence-evaluation_test.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-for-competence-evaluation_test.js
@@ -7,7 +7,6 @@ import {
   generateAuthenticatedUserRequestHeaders,
   knex,
   learningContentBuilder,
-  mockLearningContent,
   sinon,
 } from '../../../../test-helper.js';
 
@@ -71,7 +70,8 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-compet
   beforeEach(async function () {
     server = await createServer();
     const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
-    await mockLearningContent(learningContentObjects);
+    databaseBuilder.factory.learningContent.build(learningContentObjects);
+    await databaseBuilder.commit();
   });
 
   describe('GET /api/assessments/:assessment_id', function () {

--- a/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-for-demo_test.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-for-demo_test.js
@@ -1,11 +1,5 @@
 import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  learningContentBuilder,
-  mockLearningContent,
-} from '../../../../test-helper.js';
+import { createServer, databaseBuilder, expect, learningContentBuilder } from '../../../../test-helper.js';
 
 describe('Acceptance | API | assessment-controller-get-next-challenge-for-demo', function () {
   let server;
@@ -48,7 +42,8 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-demo',
     ];
 
     const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
-    await mockLearningContent(learningContentObjects);
+    databaseBuilder.factory.learningContent.build(learningContentObjects);
+    await databaseBuilder.commit();
   });
 
   describe('(demo) GET /api/assessments/:assessment_id', function () {

--- a/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-locale-management.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-locale-management.js
@@ -6,7 +6,6 @@ import {
   expect,
   generateAuthenticatedUserRequestHeaders,
   learningContentBuilder,
-  mockLearningContent,
 } from '../../../../test-helper.js';
 
 const competenceId = 'recCompetence';
@@ -69,7 +68,7 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-locale-man
       context('when there is one challenge in the accepted language (fr-fr)', function () {
         beforeEach(async function () {
           const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
-          await mockLearningContent(learningContentObjects);
+          databaseBuilder.factory.learningContent.build(learningContentObjects);
 
           databaseBuilder.factory.buildUser({ id: userId });
           databaseBuilder.factory.buildAssessment({

--- a/api/tests/shared/acceptance/application/assessments/assessment-controller-get_test.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-controller-get_test.js
@@ -6,7 +6,6 @@ import {
   expect,
   generateAuthenticatedUserRequestHeaders,
   learningContentBuilder,
-  mockLearningContent,
 } from '../../../../test-helper.js';
 
 describe('Acceptance | API | assessment-controller-get', function () {
@@ -266,7 +265,7 @@ describe('Acceptance | API | assessment-controller-get', function () {
           },
         ];
         const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
-        await mockLearningContent(learningContentObjects);
+        databaseBuilder.factory.learningContent.build(learningContentObjects);
 
         const assessmentId = databaseBuilder.factory.buildAssessment({
           userId: null,
@@ -354,7 +353,7 @@ describe('Acceptance | API | assessment-controller-get', function () {
           },
         ];
         const learningContentObjects = learningContentBuilder(learningContent);
-        await mockLearningContent(learningContentObjects);
+        databaseBuilder.factory.learningContent.build(learningContentObjects);
 
         const userId = databaseBuilder.factory.buildUser().id;
         const assessmentId = databaseBuilder.factory.buildAssessment({

--- a/api/tests/shared/acceptance/application/assessments/assessment-controller-pause-assessment_test.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-controller-pause-assessment_test.js
@@ -5,7 +5,6 @@ import {
   expect,
   generateAuthenticatedUserRequestHeaders,
   knex,
-  mockLearningContent,
 } from '../../../../test-helper.js';
 
 describe('Acceptance | API | assessment-controller-pause-assessment', function () {
@@ -56,7 +55,7 @@ describe('Acceptance | API | assessment-controller-pause-assessment', function (
         },
       };
 
-      await mockLearningContent(learningContent);
+      databaseBuilder.factory.learningContent.build(learningContent);
       return databaseBuilder.commit();
     });
 

--- a/api/tests/shared/acceptance/application/assessments/assessment-controller-update-last-challenge-state_test.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-controller-update-last-challenge-state_test.js
@@ -6,7 +6,6 @@ import {
   generateAuthenticatedUserRequestHeaders,
   knex,
   learningContentBuilder,
-  mockLearningContent,
 } from '../../../../test-helper.js';
 
 const competenceId = 'recCompetence';
@@ -57,7 +56,8 @@ describe('Acceptance | API | assessment-controller-update-last-challenge-state',
   beforeEach(async function () {
     server = await createServer();
     const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
-    await mockLearningContent(learningContentObjects);
+    databaseBuilder.factory.learningContent.build(learningContentObjects);
+    await databaseBuilder.commit();
   });
 
   describe('PATCH /api/assessments/{id}/last-challenge-state/{state}', function () {

--- a/api/tests/shared/acceptance/application/challenges/challenge-controller_test.js
+++ b/api/tests/shared/acceptance/application/challenges/challenge-controller_test.js
@@ -1,4 +1,4 @@
-import { createServer, expect, learningContentBuilder, mockLearningContent } from '../../../../test-helper.js';
+import { createServer, databaseBuilder, expect, learningContentBuilder } from '../../../../test-helper.js';
 
 describe('Acceptance | API | ChallengeController', function () {
   let server;
@@ -51,7 +51,8 @@ describe('Acceptance | API | ChallengeController', function () {
         },
       ];
       const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
-      await mockLearningContent(learningContentObjects);
+      databaseBuilder.factory.learningContent.build(learningContentObjects);
+      await databaseBuilder.commit();
     });
 
     const options = {

--- a/api/tests/shared/integration/infrastructure/lcms-client_test.js
+++ b/api/tests/shared/integration/infrastructure/lcms-client_test.js
@@ -1,6 +1,6 @@
 import { config } from '../../../../src/shared/config.js';
 import { lcmsClient } from '../../../../src/shared/infrastructure/lcms-client.js';
-import { catchErr, expect, mockLearningContent, nock } from '../../../test-helper.js';
+import { catchErr, databaseBuilder, expect, nock } from '../../../test-helper.js';
 
 describe('Integration | Infrastructure | LCMS Client', function () {
   describe('#getRelease', function () {
@@ -18,7 +18,8 @@ describe('Integration | Infrastructure | LCMS Client', function () {
       it('calls LCMS API to get learning content latest release', async function () {
         // given
         const learningContent = { models: [{ id: 'fromLatestRelease' }] };
-        const lcmsCall = await mockLearningContent(learningContent);
+        const lcmsCall = databaseBuilder.factory.learningContent.build(learningContent);
+        await databaseBuilder.commit();
 
         // when
         const response = await lcmsClient.getRelease();

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -122,12 +122,6 @@ after(async function () {
 });
 /* eslint-enable mocha/no-top-level-hooks */
 
-async function mockLearningContent(learningContent) {
-  const scope = databaseBuilder.factory.learningContent.build(learningContent);
-  await databaseBuilder.commit();
-  return scope;
-}
-
 // eslint-disable-next-line mocha/no-exports
 export {
   catchErr,
@@ -152,7 +146,6 @@ export {
   mockAttestationStorage,
   mockAttestationStorageUpload,
   MockDate,
-  mockLearningContent,
   nock,
   parseNDJSON,
   preventStubsToBeCalledUnexpectedly,


### PR DESCRIPTION
## 🌱 Problème

Pour la suite de la simplification du fichier `test-helper.js`, la fonction `mockLearningContent(learningContent)` apporte très peu actuellement, elle ne fait qu'un alias au `databaseBuilder.factory.learningContent`.

## 🐣 Proposition

Utiliser directement le `databaseBuilder.factory.learningContent` dans les tests, comme pour les autres factory, ce qui fait plus cohérence dans la base de code : 

```diff
- await mockLearningContent(learningContent);
+ databaseBuilder.factory.learningContent.build(learningContent);
+ await databaseBuilder.commit(); // uniquement quand nécessaire
```

**À noter**
- Que l'on utilisait déjà `databaseBuilder.factory.learningContent.build` à de nombreux endroits dans les tests.
- Que l'on faisait plusieurs `await databaseBuilder.commit();` non nécessaires dans beaucoup de tests.

## 🌷 Remarques

Maintenant dans le fichier `test-helper.js` on a : 
- Le setup global à tous les tests
- La proxification des libs et utilitaires de tests

La prochaine étape sera d'enlever la proxification de certaines libs et utilitaires de tests.

## 🐝 Pour tester

La CI doit passer.
