### PR TITLE
[TECH] Revoir le composant DescriptionList de PixAdmin (PIX-22455).

### DIFF
--- a/admin/app/components/autonomous-courses/view-autonomous-course.gjs
+++ b/admin/app/components/autonomous-courses/view-autonomous-course.gjs
@@ -55,14 +55,11 @@ export default class ViewAutonomousCourse extends Component {
   <template>
     <DescriptionList>
 
-      <DescriptionList.Divider />
-
       {{#each this.displayedAttributes as |attribute|}}
         <DescriptionList.Item @label={{attribute.label}}>
           {{attribute.value}}
         </DescriptionList.Item>
 
-        <DescriptionList.Divider />
       {{/each}}
 
       <DescriptionList.Item @label={{t "components.autonomous-courses.view.labels.custom-landing-page"}}>
@@ -70,8 +67,6 @@ export default class ViewAutonomousCourse extends Component {
           <SafeMarkdownToHtml @markdown={{@autonomousCourse.customLandingPageText}} />
         </blockquote>
       </DescriptionList.Item>
-
-      <DescriptionList.Divider />
 
       <DescriptionList.Item
         @label={{t "components.autonomous-courses.view.link-title"}}
@@ -95,7 +90,6 @@ export default class ViewAutonomousCourse extends Component {
         </PixTooltip>
       </DescriptionList.Item>
 
-      <DescriptionList.Divider />
     </DescriptionList>
   </template>
 }

--- a/admin/app/components/badges/badge.gjs
+++ b/admin/app/components/badges/badge.gjs
@@ -202,31 +202,21 @@ export default class Badge extends Component {
             <div>
               <DescriptionList>
 
-                <DescriptionList.Divider />
-
                 <DescriptionList.Item @label="ID">
                   {{@badge.id}}
                 </DescriptionList.Item>
-
-                <DescriptionList.Divider />
 
                 <DescriptionList.Item @label="Clé">
                   {{@badge.key}}
                 </DescriptionList.Item>
 
-                <DescriptionList.Divider />
-
                 <DescriptionList.Item @label="Nom du badge">
                   {{@badge.title}}
                 </DescriptionList.Item>
 
-                <DescriptionList.Divider />
-
                 <DescriptionList.Item @label="Url de l'image">
                   {{@badge.imageUrl}}
                 </DescriptionList.Item>
-
-                <DescriptionList.Divider />
 
                 <DescriptionList.Item @label="Message">
                   <blockquote>
@@ -234,13 +224,9 @@ export default class Badge extends Component {
                   </blockquote>
                 </DescriptionList.Item>
 
-                <DescriptionList.Divider />
-
                 <DescriptionList.Item @label="Message alternatif">
                   {{@badge.altMessage}}
                 </DescriptionList.Item>
-
-                <DescriptionList.Divider />
 
               </DescriptionList>
 

--- a/admin/app/components/certification-centers/information-view.gjs
+++ b/admin/app/components/certification-centers/information-view.gjs
@@ -76,19 +76,14 @@ export default class InformationView extends Component {
     {{/if}}
 
     <DescriptionList>
-      <DescriptionList.Divider />
 
       <DescriptionList.Item @label={{t "pages.certification-centers.information-view.list.type"}}>
         {{@certificationCenter.typeLabel}}
       </DescriptionList.Item>
 
-      <DescriptionList.Divider />
-
       <DescriptionList.Item @label={{t "pages.certification-centers.information-view.list.external-id"}}>
         {{@certificationCenter.externalId}}
       </DescriptionList.Item>
-
-      <DescriptionList.Divider />
 
       <DescriptionList.ItemWithHTMLElement>
         <:label>
@@ -113,8 +108,6 @@ export default class InformationView extends Component {
         </:value>
       </DescriptionList.ItemWithHTMLElement>
 
-      <DescriptionList.Divider />
-
       <DescriptionList.Item @label={{t "pages.certification-centers.information-view.habilitations.title"}}>
         <ul class="certification-center-information-display__habilitations-list">
           {{#each this.availableHabilitations as |habilitation|}}
@@ -126,8 +119,6 @@ export default class InformationView extends Component {
           {{/each}}
         </ul>
       </DescriptionList.Item>
-
-      <DescriptionList.Divider />
 
     </DescriptionList>
 

--- a/admin/app/components/certifications/certification/comments.gjs
+++ b/admin/app/components/certifications/certification/comments.gjs
@@ -39,25 +39,18 @@ export default class Comments extends Component {
     <PixBlock @variant="admin">
       <h2 class="certification-information__title">Commentaires jury</h2>
       <DescriptionList>
-        <DescriptionList.Divider />
 
         <DescriptionList.Item @label="Pour le candidat">
           {{@certification.commentForCandidate}}
         </DescriptionList.Item>
 
-        <DescriptionList.Divider />
-
         <DescriptionList.Item @label="Pour l'organisation">
           {{@certification.commentForOrganization}}
         </DescriptionList.Item>
 
-        <DescriptionList.Divider />
-
         <DescriptionList.Item @label="Identifiant jury">
           {{@certification.juryId}}
         </DescriptionList.Item>
-
-        <DescriptionList.Divider />
 
         {{#if this.isEditingJuryComment}}
           <DescriptionList.ItemWithHTMLElement>
@@ -78,7 +71,6 @@ export default class Comments extends Component {
           </DescriptionList.Item>
         {{/if}}
 
-        <DescriptionList.Divider />
       </DescriptionList>
 
       {{#if this.isEditingJuryComment}}

--- a/admin/app/components/certifications/certification/informations/candidate.gjs
+++ b/admin/app/components/certifications/certification/informations/candidate.gjs
@@ -43,55 +43,39 @@ export default class CertificationInformationCandidate extends Component {
       <h2 class="certification-information__title">Candidat</h2>
 
       <DescriptionList>
-        <DescriptionList.Divider />
 
         <DescriptionList.Item @label="Prénom">
           {{@certification.firstName}}
         </DescriptionList.Item>
 
-        <DescriptionList.Divider />
-
         <DescriptionList.Item @label="Nom de famille">
           {{@certification.lastName}}
         </DescriptionList.Item>
-
-        <DescriptionList.Divider />
 
         <DescriptionList.Item @label="Date de naissance">
           {{if @certification.birthdate (formatDate @certification.birthdate) ""}}
         </DescriptionList.Item>
 
-        <DescriptionList.Divider />
-
         <DescriptionList.Item @label="Sexe">
           {{@certification.sex}}
         </DescriptionList.Item>
-
-        <DescriptionList.Divider />
 
         <DescriptionList.Item @label="Commune de naissance">
           {{@certification.birthplace}}
         </DescriptionList.Item>
 
-        <DescriptionList.Divider />
-
         <DescriptionList.Item @label="Code postal de naissance">
           {{@certification.birthPostalCode}}
         </DescriptionList.Item>
-
-        <DescriptionList.Divider />
 
         <DescriptionList.Item @label="Code INSEE de naissance">
           {{@certification.birthInseeCode}}
         </DescriptionList.Item>
 
-        <DescriptionList.Divider />
-
         <DescriptionList.Item @label="Pays de naissance">
           {{@certification.birthCountry}}
         </DescriptionList.Item>
 
-        <DescriptionList.Divider />
       </DescriptionList>
 
       <PixButton

--- a/admin/app/components/certifications/certification/informations/state.gjs
+++ b/admin/app/components/certifications/certification/informations/state.gjs
@@ -15,7 +15,6 @@ import { DescriptionList } from 'pix-admin/components/ui/description-list';
     </h2>
 
     <DescriptionList data-testid="pw-certification-state-description-list">
-      <DescriptionList.Divider />
 
       <DescriptionList.Item @label="Session">
         <LinkTo @route="authenticated.sessions.session" @model={{@session.id}}>
@@ -23,36 +22,25 @@ import { DescriptionList } from 'pix-admin/components/ui/description-list';
         </LinkTo>
       </DescriptionList.Item>
 
-      <DescriptionList.Divider />
-
       <DescriptionList.Item @label="Certification">
         {{@certification.certificationType}}
       </DescriptionList.Item>
-
-      <DescriptionList.Divider />
 
       <DescriptionList.Item @label="Statut">
         {{@certification.statusLabelAndValue.label}}
       </DescriptionList.Item>
 
-      <DescriptionList.Divider />
-
       <DescriptionList.Item @label="Créée le">
         {{@certification.creationDate}}
       </DescriptionList.Item>
-
-      <DescriptionList.Divider />
 
       <DescriptionList.Item @label="Terminée le">
         {{@certification.completionDate}}
       </DescriptionList.Item>
 
-      <DescriptionList.Divider />
-
       <DescriptionList.Item @label="Résultat">
         {{@certification.result}}
       </DescriptionList.Item>
-      <DescriptionList.Divider />
     </DescriptionList>
   </PixBlock>
 </template>

--- a/admin/app/components/combined-course-blueprints/details.gjs
+++ b/admin/app/components/combined-course-blueprints/details.gjs
@@ -37,13 +37,9 @@ export default class Details extends Component {
 
             <DescriptionList>
 
-              <DescriptionList.Divider />
-
               <DescriptionList.Item @label={{t "components.combined-course-blueprints.labels.itemId"}}>
                 {{@model.id}}
               </DescriptionList.Item>
-
-              <DescriptionList.Divider />
 
               <DescriptionList.Item @label={{t "components.combined-course-blueprints.labels.internal-name"}}>
                 {{@model.internalName}}
@@ -53,20 +49,15 @@ export default class Details extends Component {
                 {{@model.name}}
               </DescriptionList.Item>
 
-              <DescriptionList.Divider />
-
               <DescriptionList.Item @label={{t "components.combined-course-blueprints.labels.created-at"}}>
                 {{formatDate @model.createdAt}}
               </DescriptionList.Item>
-
-              <DescriptionList.Divider />
 
               <DescriptionList.Item @label={{t "components.combined-course-blueprints.labels.attestation"}}>
                 <SafeMarkdownToHtml @markdown={{@model.attestationLabel}} />
               </DescriptionList.Item>
 
               {{#if @model.description}}
-                <DescriptionList.Divider />
 
                 <DescriptionList.Item @label={{t "components.combined-course-blueprints.labels.description"}}>
                   <SafeMarkdownToHtml @markdown={{@model.description}} />
@@ -74,11 +65,9 @@ export default class Details extends Component {
               {{/if}}
 
               {{#if @model.illustration}}
-                <DescriptionList.Divider />
                 <DescriptionList.Item @label={{t "components.combined-course-blueprints.labels.illustration"}}>
                   <img src={{@model.illustration}} alt="" />
                 </DescriptionList.Item>
-                <DescriptionList.Divider />
               {{/if}}
 
             </DescriptionList>

--- a/admin/app/components/networks/information-view.gjs
+++ b/admin/app/components/networks/information-view.gjs
@@ -9,8 +9,6 @@ import { DescriptionList } from 'pix-admin/components/ui/description-list';
       {{@network.headOrganization.name}}
     </DescriptionList.Item>
 
-    <DescriptionList.Divider />
-
     <DescriptionList.Item
       @label={{t "components.networks.information-view.head-organization-id"}}
       @labelClass="network__information-view__head-organization-id__label"
@@ -27,6 +25,5 @@ import { DescriptionList } from 'pix-admin/components/ui/description-list';
       />
     </DescriptionList.Item>
 
-    <DescriptionList.Divider />
   </DescriptionList>
 </template>

--- a/admin/app/components/sessions/session-informations.gjs
+++ b/admin/app/components/sessions/session-informations.gjs
@@ -51,8 +51,6 @@ import JuryComment from './jury-comment';
           {{@sessionModel.accessCode}}
         </DescriptionList.Item>
 
-        <DescriptionList.Divider />
-
         <DescriptionList.Item @label={{t "pages.sessions.informations.labels.status"}}>
           {{@sessionModel.displayStatus}}
         </DescriptionList.Item>
@@ -78,8 +76,6 @@ import JuryComment from './jury-comment';
             {{formatDate @sessionModel.resultsSentToPrescriberAt}}
           </DescriptionList.Item>
         {{/if}}
-
-        <DescriptionList.Divider />
 
         <DescriptionList.Item @label={{t "pages.sessions.informations.labels.started-certifications"}}>
           {{@sessionModel.numberOfStartedCertifications}}
@@ -115,8 +111,6 @@ import JuryComment from './jury-comment';
             </DescriptionList.Item>
           {{/if}}
         {{/if}}
-
-        <DescriptionList.Divider />
 
       </DescriptionList>
 

--- a/admin/app/components/target-profiles/target-profile.gjs
+++ b/admin/app/components/target-profiles/target-profile.gjs
@@ -209,13 +209,9 @@ export default class TargetProfile extends Component {
 
           <DescriptionList>
 
-            <DescriptionList.Divider />
-
             <DescriptionList.Item @label={{t "pages.target-profiles.label.id"}}>
               {{@model.id}}
             </DescriptionList.Item>
-
-            <DescriptionList.Divider />
 
             <DescriptionList.Item @label={{t "pages.target-profiles.label.name"}}>
               {{@model.internalName}}
@@ -225,34 +221,23 @@ export default class TargetProfile extends Component {
               {{@model.name}}
             </DescriptionList.Item>
 
-            <DescriptionList.Divider />
-
             <DescriptionList.Item @label={{t "pages.target-profiles.label.estimated-time"}}>
               {{this.estimatedTimeLabel}}
               {{t "pages.target-profiles.label.estimated-time-experimental"}}
             </DescriptionList.Item>
 
-            <DescriptionList.Divider />
-
-            <DescriptionList.Divider />
-
             <DescriptionList.Item @label={{t "pages.target-profiles.label.created-at"}}>
               {{formatDate @model.createdAt}}
             </DescriptionList.Item>
-
-            <DescriptionList.Divider />
 
             <DescriptionList.Item @label={{t "pages.target-profiles.label.outdated"}}>
               {{this.displayBooleanState this.isOutdated}}
             </DescriptionList.Item>
 
-            <DescriptionList.Divider />
-
             <DescriptionList.Item @label={{t "pages.target-profiles.label.simplified-access"}}>
               {{this.displayBooleanState this.isSimplifiedAccess}}
             </DescriptionList.Item>
 
-            <DescriptionList.Divider />
             {{#if this.hasLinkedCampaign}}
               <DescriptionList.Item @label={{t "pages.target-profiles.label.link-campaign"}}>
                 {{t "common.words.yes"}}
@@ -268,20 +253,15 @@ export default class TargetProfile extends Component {
               </DescriptionList.Item>
             {{/if}}
 
-            <DescriptionList.Divider />
-
             <DescriptionList.Item @label={{t "pages.target-profiles.resettable-checkbox.label"}}>
               {{this.displayBooleanState this.areKnowledgeElementsResettable}}
             </DescriptionList.Item>
-
-            <DescriptionList.Divider />
 
             <DescriptionList.Item @label={{t "pages.target-profiles.tubes-count"}}>
               {{@model.tubesCount}}
             </DescriptionList.Item>
 
             {{#if @model.description}}
-              <DescriptionList.Divider />
 
               <DescriptionList.Item @label="Description">
                 <SafeMarkdownToHtml @markdown={{@model.description}} />
@@ -289,14 +269,11 @@ export default class TargetProfile extends Component {
             {{/if}}
 
             {{#if @model.comment}}
-              <DescriptionList.Divider />
 
               <DescriptionList.Item @label="Commentaire (usage interne)">
                 <SafeMarkdownToHtml @markdown={{@model.comment}} />
               </DescriptionList.Item>
             {{/if}}
-
-            <DescriptionList.Divider />
 
           </DescriptionList>
 

--- a/admin/app/components/trainings/training-details-card.gjs
+++ b/admin/app/components/trainings/training-details-card.gjs
@@ -32,8 +32,6 @@ export default class TrainingDetailsCard extends Component {
     <div class="training-details-card__content">
       <DescriptionList>
 
-        <DescriptionList.Divider />
-
         <DescriptionList.Item @label={{t "pages.trainings.training.details.title"}}>
           {{@training.title}}
         </DescriptionList.Item>
@@ -49,25 +47,17 @@ export default class TrainingDetailsCard extends Component {
           </a>
         </DescriptionList.Item>
 
-        <DescriptionList.Divider />
-
         <DescriptionList.Item @label={{t "pages.trainings.training.details.contentType"}}>
           {{@training.type}}
         </DescriptionList.Item>
-
-        <DescriptionList.Divider />
 
         <DescriptionList.Item @label={{t "pages.trainings.training.details.duration"}}>
           {{this.formattedDuration}}
         </DescriptionList.Item>
 
-        <DescriptionList.Divider />
-
         <DescriptionList.Item @label={{t "pages.trainings.training.details.locales" count=@training.locales.length}}>
           {{this.formattedLocales}}
         </DescriptionList.Item>
-
-        <DescriptionList.Divider />
 
         <DescriptionList.Item @label={{t "pages.trainings.training.details.editorName"}}>
           {{@training.editorName}}
@@ -84,8 +74,6 @@ export default class TrainingDetailsCard extends Component {
           </a>
         </DescriptionList.Item>
 
-        <DescriptionList.Divider />
-
         <DescriptionList.Item @label={{t "pages.trainings.training.details.status"}}>
           {{if
             @training.isRecommendable
@@ -93,8 +81,6 @@ export default class TrainingDetailsCard extends Component {
             (t "pages.trainings.training.details.status-label.disabled")
           }}
         </DescriptionList.Item>
-
-        <DescriptionList.Divider />
 
       </DescriptionList>
       <div class="training-details-card__editor-logo">

--- a/admin/app/components/ui/description-list.gjs
+++ b/admin/app/components/ui/description-list.gjs
@@ -1,19 +1,15 @@
 export const DescriptionList = <template>
-  <dl class="description-list" ...attributes>{{yield}}</dl>
+  <div class="description-list-container" ...attributes>
+    <dl class="description-list">{{yield}}</dl>
+  </div>
 </template>;
 
 DescriptionList.Item = <template>
-  <div ...attributes>
-    <dt class={{@labelClass}}>{{@label}}</dt>
-    <dd class={{@valueClass}}>{{yield}}</dd>
-  </div>
+  <dt class={{@labelClass}}>{{@label}}</dt>
+  <dd class={{@valueClass}}>{{yield}}</dd>
 </template>;
 
 DescriptionList.ItemWithHTMLElement = <template>
-  <div ...attributes>
-    <dt class={{@labelClass}}>{{yield to="label"}}</dt>
-    <dd class={{@valueClass}}>{{yield to="value"}}</dd>
-  </div>
+  <dt class={{@labelClass}}>{{yield to="label"}}</dt>
+  <dd class={{@valueClass}}>{{yield to="value"}}</dd>
 </template>;
-
-DescriptionList.Divider = <template><div class="description-list__divider" /></template>;

--- a/admin/app/components/users/user-overview.gjs
+++ b/admin/app/components/users/user-overview.gjs
@@ -295,7 +295,6 @@ export default class UserOverview extends Component {
           {{/if}}
 
           <DescriptionList aria-label="Informations utilisateur">
-            <DescriptionList.Divider />
 
             <DescriptionList.Item @label="Prénom">{{@user.firstName}}</DescriptionList.Item>
             <DescriptionList.Item @label="Nom">{{@user.lastName}}</DescriptionList.Item>
@@ -306,8 +305,6 @@ export default class UserOverview extends Component {
                 {{formatDate @user.createdAt}}
               {{/if}}
             </DescriptionList.Item>
-
-            <DescriptionList.Divider />
 
             <DescriptionList.Item @label="Adresse e-mail" @valueClass="user-overview-section__copy-item">
               {{@user.email}}
@@ -331,8 +328,6 @@ export default class UserOverview extends Component {
               {{#if this.hasSsoAuthentication}}{{t "common.words.yes"}}{{else}}{{t "common.words.no"}}{{/if}}
             </DescriptionList.Item>
 
-            <DescriptionList.Divider />
-
             <DescriptionList.Item @label="Tentatives de connexion en erreur">
               {{if @user.userLogin.failureCount @user.userLogin.failureCount 0}}
             </DescriptionList.Item>
@@ -354,7 +349,6 @@ export default class UserOverview extends Component {
               {{/if}}
             </DescriptionList.Item>
 
-            <DescriptionList.Divider />
           </DescriptionList>
 
           {{#if this.accessControl.hasAccessToUsersActionsScope}}

--- a/admin/app/styles/components/ui/description-list.scss
+++ b/admin/app/styles/components/ui/description-list.scss
@@ -1,49 +1,52 @@
 @use 'pix-design-tokens/breakpoints';
 @use 'pix-design-tokens/typography';
 
-/* stylelint-disable custom-property-pattern */
+.description-list-container {
+  container-type: inline-size;
+}
+
 .description-list {
-  display: flex;
-  flex-direction: column;
+  @extend %pix-body-s;
 
-  > div {
-    @extend %pix-body-s;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  margin-block: var(--pix-spacing-3x);
+  border-bottom: 1px solid var(--pix-primary-100);
 
-    display: grid;
-    grid-template-columns: repeat(5, minmax(0, 1fr));
-    gap: var(--pix-spacing-3x);
+  dt, dd {
+    padding-block: var(--pix-spacing-3x);
+    border-top: 1px solid var(--pix-primary-100);
+  }
+
+  dt {
+    @extend %pix-title-xxs;
+
+    padding-right: var(--pix-spacing-4x);
+    font-weight: var(--pix-font-bold);
+    /* stylelint-disable custom-property-pattern */
+    font-family: var(--_pix-font-family-title);
+  }
+
+  dd {
+    a {
+      color: var(--pix-primary-500);
+      text-decoration: underline;
+    }
+  }
+}
+
+@container (max-width: 30rem)  {
+  .description-list {
+    display: block;
 
     dt {
-      font-weight: var(--pix-font-bold);
-      font-family: var(--_pix-font-family-title);
+      padding-right: 0;
+      padding-bottom: var(--pix-spacing-1x);
     }
 
     dd {
-      grid-column: span 4 / span 3;
-
-      a {
-        color: var(--pix-primary-500);
-        text-decoration: underline;
-      }
+      padding-top: 0;
+      border-top: none;
     }
-  }
-
-  @include breakpoints.device-is('mobile'){
-    gap: var(--pix-spacing-1x);
-
-    > div {
-      display: flex;
-      flex-direction: column;
-      gap: 0;
-
-      dd {
-        grid-column: auto;
-      }
-    }
-  }
-
-  &__divider {
-    margin: var(--pix-spacing-3x) 0;
-    border-top: 1px solid var(--pix-primary-100);
   }
 }


### PR DESCRIPTION
## 🌱 Problème

- Le composant n'avait pas besoin d'exploser de Divider pour gérer la séparation visuelle des lignes
- La grille pouvait être gérée plus facilement

## 🐣 Proposition

Revoir le style du composant DescriptionList de PixAdmin.

## 🐝 Pour tester

Visualiser le composant dans les différentes pages PixAdmin où les `DescriptionList.Divider` ont été supprimés.
