### PR TITLE
[TECH] :recycle: Réduit l'utilisation de `lodash` dans le contexte de la certification

### DIFF
--- a/api/src/certification/enrolment/domain/models/SessionEnrolment.js
+++ b/api/src/certification/enrolment/domain/models/SessionEnrolment.js
@@ -54,11 +54,12 @@ export class SessionEnrolment {
   }
 
   #generateInvigilatorPassword() {
-    const newPassword = [];
-    for (let i = 0; i < INVIGILATOR_PASSWORD_LENGTH; i++) {
-      newPassword.push(INVIGILATOR_PASSWORD_CHARS[Math.floor(Math.random() * INVIGILATOR_PASSWORD_CHARS.length)]);
+    const chars = Array.from(INVIGILATOR_PASSWORD_CHARS);
+    for (let i = INVIGILATOR_PASSWORD_LENGTH; i >= 0; i--) {
+      const j = Math.floor(Math.random() * (chars.length - 1));
+      [chars[i], chars[j]] = [chars[j], chars[i]];
     }
-    return newPassword.join('');
+    return chars.slice(0, INVIGILATOR_PASSWORD_LENGTH).join('');
   }
 
   isSessionScheduledInThePast() {

--- a/api/src/certification/enrolment/domain/models/SessionEnrolment.js
+++ b/api/src/certification/enrolment/domain/models/SessionEnrolment.js
@@ -1,8 +1,6 @@
 /**
  * @typedef {import('./Candidate.js').Candidate} Candidate
  */
-import _ from 'lodash';
-
 import { CERTIFICATION_CENTER_TYPES } from '../../../../shared/domain/constants.js';
 import { SESSION_STATUSES } from '../../../shared/domain/constants.js';
 import { AlgorithmEngineVersion } from '../../../shared/domain/models/AlgorithmEngineVersion.js';
@@ -10,7 +8,7 @@ import { AlgorithmEngineVersion } from '../../../shared/domain/models/AlgorithmE
 const INVIGILATOR_PASSWORD_LENGTH = 6;
 const INVIGILATOR_PASSWORD_CHARS = '23456789bcdfghjkmpqrstvwxyBCDFGHJKMPQRSTVWXY!*?'.split('');
 
-class SessionEnrolment {
+export class SessionEnrolment {
   constructor({
     id,
     accessCode,
@@ -56,7 +54,11 @@ class SessionEnrolment {
   }
 
   #generateInvigilatorPassword() {
-    return _.sampleSize(INVIGILATOR_PASSWORD_CHARS, INVIGILATOR_PASSWORD_LENGTH).join('');
+    const newPassword = [];
+    for (let i = 0; i < INVIGILATOR_PASSWORD_LENGTH; i++) {
+      newPassword.push(INVIGILATOR_PASSWORD_CHARS[Math.floor(Math.random() * INVIGILATOR_PASSWORD_CHARS.length)]);
+    }
+    return newPassword.join('');
   }
 
   isSessionScheduledInThePast() {
@@ -65,8 +67,7 @@ class SessionEnrolment {
   }
 
   isCandidateAlreadyEnrolled({ candidates, candidatePersonalInfo, normalizeStringFnc }) {
-    const matchingCandidates = findMatchingCandidates({ candidates, candidatePersonalInfo, normalizeStringFnc });
-    return matchingCandidates.length > 0;
+    return this.findCandidatesByPersonalInfo({ candidates, candidatePersonalInfo, normalizeStringFnc }).length > 0;
   }
 
   /**
@@ -96,29 +97,25 @@ class SessionEnrolment {
     this.description = sessionData.description;
   }
 
-  findCandidatesByPersonalInfo({ candidates, candidatePersonalInfo, normalizeStringFnc }) {
-    return findMatchingCandidates({ candidates, candidatePersonalInfo, normalizeStringFnc });
+  findCandidatesByPersonalInfo({
+    candidates,
+    candidatePersonalInfo: { firstName, lastName, birthdate },
+    normalizeStringFnc,
+  }) {
+    const normalizedInputNames = {
+      lastName: normalizeStringFnc(lastName),
+      firstName: normalizeStringFnc(firstName),
+    };
+    return candidates.filter((enrolledCandidate) => {
+      const enrolledCandidatesNormalizedNames = {
+        lastName: normalizeStringFnc(enrolledCandidate.lastName),
+        firstName: normalizeStringFnc(enrolledCandidate.firstName),
+      };
+      return (
+        normalizedInputNames.lastName === enrolledCandidatesNormalizedNames.lastName &&
+        normalizedInputNames.firstName === enrolledCandidatesNormalizedNames.firstName &&
+        birthdate === enrolledCandidate.birthdate
+      );
+    });
   }
 }
-
-function findMatchingCandidates({
-  candidates,
-  candidatePersonalInfo: { firstName, lastName, birthdate },
-  normalizeStringFnc,
-}) {
-  const normalizedInputNames = {
-    lastName: normalizeStringFnc(lastName),
-    firstName: normalizeStringFnc(firstName),
-  };
-  return candidates.filter((enrolledCandidate) => {
-    const enrolledCandidatesNormalizedNames = {
-      lastName: normalizeStringFnc(enrolledCandidate.lastName),
-      firstName: normalizeStringFnc(enrolledCandidate.firstName),
-    };
-    return (
-      _.isEqual(normalizedInputNames, enrolledCandidatesNormalizedNames) && birthdate === enrolledCandidate.birthdate
-    );
-  });
-}
-
-export { SessionEnrolment };

--- a/api/src/certification/evaluation/domain/services/scoring/scoring-v2.js
+++ b/api/src/certification/evaluation/domain/services/scoring/scoring-v2.js
@@ -9,8 +9,6 @@
  * @typedef {import('../../../../session-management/domain/models/CertificationAssessment.js').CertificationAssessment} CertificationAssessment
  */
 
-import _ from 'lodash';
-
 import CertificationCancelled from '../../../../../../src/shared/domain/events/CertificationCancelled.js';
 import { AlgorithmEngineVersion } from '../../../../shared/domain/models/AlgorithmEngineVersion.js';
 import { AnswerCollectionForScoring } from '../../../../shared/domain/models/AnswerCollectionForScoring.js';
@@ -124,22 +122,33 @@ export const calculateCertificationAssessmentScore = async function ({
  */
 async function _getTestedCompetences({ userId, limitDate, version, placementProfileService }) {
   const placementProfile = await placementProfileService.getPlacementProfile({ userId, limitDate, version });
-  return _(placementProfile.userCompetences)
-    .filter((uc) => uc.isCertifiable())
-    .map((uc) => _.pick(uc, ['id', 'index', 'areaId', 'name', 'estimatedLevel', 'pixScore']))
-    .value();
+  const certifiableUserCompetences = placementProfile.userCompetences.filter((uc) => uc.isCertifiable());
+  return certifiableUserCompetences.map((cuc) => {
+    return {
+      id: cuc.id,
+      index: cuc.index,
+      areaId: cuc.areaId,
+      name: cuc.name,
+      estimatedLevel: cuc.estimatedLevel,
+      pixScore: cuc.pixScore,
+    };
+  });
 }
 
 function _selectAnswersMatchingCertificationChallenges(answers, certificationChallenges) {
-  return answers.filter(({ challengeId }) => _.some(certificationChallenges, { challengeId }));
+  return answers.filter(({ challengeId }) => certificationChallenges.some((cc) => cc.challengeId === challengeId));
 }
 
 function _selectChallengesMatchingCompetences(certificationChallenges, testedCompetences) {
-  return certificationChallenges.filter(({ competenceId }) => _.some(testedCompetences, { id: competenceId }));
+  return certificationChallenges.filter(({ competenceId }) => testedCompetences.some((e) => e.id === competenceId));
 }
 
 function _getSumScoreFromCertifiedCompetences(listCompetences) {
-  return _(listCompetences).map('obtainedScore').sum();
+  return listCompetences
+    .map((lc) => lc.obtainedScore)
+    .reduce((accumulator, currentValue) => {
+      return accumulator + currentValue;
+    }, 0);
 }
 
 /**
@@ -155,7 +164,7 @@ function _getCompetenceMarksWithCertifiedLevelAndScore(
   scoringService,
 ) {
   return listCompetences.map((competence) => {
-    const challengesForCompetence = _.filter(certificationChallenges, { competenceId: competence.id });
+    const challengesForCompetence = certificationChallenges.filter((cc) => cc.competenceId === competence.id);
     const answersForCompetence = _selectAnswersMatchingCertificationChallenges(answers, challengesForCompetence);
 
     CertificationContract.assertThatCompetenceHasAtLeastOneChallenge(challengesForCompetence, competence.index);

--- a/api/src/certification/results/domain/models/CertificationResult.js
+++ b/api/src/certification/results/domain/models/CertificationResult.js
@@ -132,8 +132,11 @@ export class CertificationResult {
   }
 
   getUniqComplementaryCertificationCourseResultLabels() {
-    const sortedLabel = this.complementaryCertificationCourseResults.map(({ label }) => label);
-    return [...new Set(Object.values(sortedLabel).sort())];
+    const sortedComplementaryCertifCourseResults = this.complementaryCertificationCourseResults.sort((a, b) => {
+      return a['id'] > b['id'] ? 1 : b['id'] > a['id'] ? -1 : 0;
+    });
+    const sortedLabels = sortedComplementaryCertifCourseResults.map(({ label }) => label);
+    return [...new Set(Object.values(sortedLabels))];
   }
 
   get isV3() {

--- a/api/src/certification/results/domain/models/CertificationResult.js
+++ b/api/src/certification/results/domain/models/CertificationResult.js
@@ -1,5 +1,3 @@
-import _ from 'lodash';
-
 import { AlgorithmEngineVersion } from '../../../shared/domain/models/AlgorithmEngineVersion.js';
 import { CompetenceMark } from '../../../shared/domain/models/CompetenceMark.js';
 import { ComplementaryCertificationCourseResult } from '../../../shared/domain/models/ComplementaryCertificationCourseResult.js';
@@ -134,14 +132,8 @@ export class CertificationResult {
   }
 
   getUniqComplementaryCertificationCourseResultLabels() {
-    return [
-      ...new Set(
-        _(this.complementaryCertificationCourseResults)
-          .orderBy('id')
-          .map(({ label }) => label)
-          .value(),
-      ),
-    ];
+    const sortedLabel = this.complementaryCertificationCourseResults.map(({ label }) => label);
+    return [...new Set(Object.values(sortedLabel).sort())];
   }
 
   get isV3() {

--- a/api/src/certification/results/domain/read-models/CertifiedBadge.js
+++ b/api/src/certification/results/domain/read-models/CertifiedBadge.js
@@ -1,6 +1,4 @@
-import _ from 'lodash';
-
-class CertifiedBadge {
+export class CertifiedBadge {
   constructor({ label, imageUrl, stickerUrl, isTemporaryBadge, message }) {
     this.label = label;
     this.imageUrl = imageUrl;
@@ -44,7 +42,11 @@ function _getLowestByLevel(complementaryCertificationCourseResults) {
   if (!complementaryCertificationCourseResults.every(({ acquired }) => acquired)) {
     return { acquired: false };
   }
-  return _(complementaryCertificationCourseResults).sortBy('level').head();
+  // eslint-disable-next-line no-unused-vars
+  const [lowestByLevel, ...tail] = complementaryCertificationCourseResults.sort((a, b) => {
+    return a['level'] > b['level'] ? 1 : b['level'] > a['level'] ? -1 : 0;
+  });
+  return lowestByLevel;
 }
 
 function _getAcquiredCertifiedBadgesDTOWithExternalJury(complementaryCertificationCourseResults) {
@@ -78,5 +80,3 @@ function _getAcquiredCertifiedBadgesDTOWithExternalJury(complementaryCertificati
     });
   }
 }
-
-export { CertifiedBadge };

--- a/api/src/certification/shared/domain/models/CertificationCourse.js
+++ b/api/src/certification/shared/domain/models/CertificationCourse.js
@@ -7,7 +7,6 @@
  */
 import JoiDate from '@joi/date';
 import BaseJoi from 'joi';
-import _ from 'lodash';
 
 import { EntityValidationError } from '../../../../shared/domain/errors.js';
 import { ABORT_REASONS } from '../constants/abort-reasons.js';
@@ -198,7 +197,7 @@ export class CertificationCourse {
 
   correctFirstName(modifiedFirstName) {
     const sanitizedString = _sanitizedString(modifiedFirstName);
-    if (_.isEmpty(sanitizedString)) {
+    if (_isEmpty(sanitizedString)) {
       throw new EntityValidationError({
         invalidAttributes: [{ attribute: 'firstName', message: "Candidate's first name must not be blank or empty" }],
       });
@@ -208,7 +207,7 @@ export class CertificationCourse {
 
   correctLastName(modifiedLastName) {
     const sanitizedString = _sanitizedString(modifiedLastName);
-    if (_.isEmpty(sanitizedString)) {
+    if (_isEmpty(sanitizedString)) {
       throw new EntityValidationError({
         invalidAttributes: [{ attribute: 'lastName', message: "Candidate's last name must not be blank or empty" }],
       });
@@ -218,14 +217,14 @@ export class CertificationCourse {
 
   correctBirthplace(modifiedBirthplace) {
     const sanitizedString = _sanitizedString(modifiedBirthplace);
-    if (!_.isEmpty(sanitizedString?.trim())) {
+    if (!_isEmpty(sanitizedString?.trim())) {
       this._birthplace = sanitizedString;
     }
   }
 
   correctSex(modifiedSex) {
     const sanitizedString = _sanitizedString(modifiedSex);
-    if (!_.isEmpty(sanitizedString) && !['M', 'F'].includes(sanitizedString)) {
+    if (!_isEmpty(sanitizedString) && !['M', 'F'].includes(sanitizedString)) {
       throw new EntityValidationError({
         invalidAttributes: [{ attribute: 'sex', message: "Candidate's sex must be M or F" }],
       });
@@ -374,4 +373,8 @@ function _sanitizedString(string) {
   const withUnifiedWithSpaces = trimmedString?.replace(multipleWhiteSpacesInARow, ' ');
 
   return withUnifiedWithSpaces;
+}
+
+function _isEmpty(obj) {
+  return [Object, Array].includes((obj || {}).constructor) && !Object.entries(obj || {}).length;
 }

--- a/api/src/certification/shared/domain/models/CertificationReport.js
+++ b/api/src/certification/shared/domain/models/CertificationReport.js
@@ -1,5 +1,4 @@
 import Joi from 'joi';
-import _ from 'lodash';
 
 import { InvalidCertificationReportForFinalization } from '../errors.js';
 
@@ -33,7 +32,7 @@ class CertificationReport {
     this.certificationCourseId = certificationCourseId;
     this.isCompleted = isCompleted;
     this.examinerComment = examinerComment;
-    if (_.isEmpty(_.trim(this.examinerComment))) {
+    if (!this.examinerComment?.trim()) {
       this.examinerComment = NO_EXAMINER_COMMENT;
     }
     this.abortReason = abortReason;

--- a/api/tests/certification/results/unit/domain/models/CertificationResult_test.js
+++ b/api/tests/certification/results/unit/domain/models/CertificationResult_test.js
@@ -358,11 +358,11 @@ describe('Unit | Domain | Models | CertificationResult', function () {
     it('should return an array of unique labels', function () {
       // given
       const complementaryCertificationCourseResults = [
-        domainBuilder.buildComplementaryCertificationCourseResult({ id: 28, label: 'Pix+ Edu 2nd degré' }),
-        domainBuilder.buildComplementaryCertificationCourseResult({ id: 1, label: 'CléA Numérique' }),
-        domainBuilder.buildComplementaryCertificationCourseResult({ id: 23, label: 'Pix+ Edu 1er degré' }),
-        domainBuilder.buildComplementaryCertificationCourseResult({ id: 2, label: 'CléA Numérique' }),
-        domainBuilder.buildComplementaryCertificationCourseResult({ id: 13, label: 'Pix+ Droit' }),
+        domainBuilder.buildComplementaryCertificationCourseResult({ label: 'CléA Numérique' }),
+        domainBuilder.buildComplementaryCertificationCourseResult({ label: 'Pix+ Droit' }),
+        domainBuilder.buildComplementaryCertificationCourseResult({ label: 'CléA Numérique' }),
+        domainBuilder.buildComplementaryCertificationCourseResult({ label: 'Pix+ Edu 1er degré' }),
+        domainBuilder.buildComplementaryCertificationCourseResult({ label: 'Pix+ Edu 2nd degré' }),
       ];
       const certificationResult = domainBuilder.buildCertificationResult({
         complementaryCertificationCourseResults,

--- a/api/tests/certification/results/unit/domain/models/CertificationResult_test.js
+++ b/api/tests/certification/results/unit/domain/models/CertificationResult_test.js
@@ -358,11 +358,11 @@ describe('Unit | Domain | Models | CertificationResult', function () {
     it('should return an array of unique labels', function () {
       // given
       const complementaryCertificationCourseResults = [
-        domainBuilder.buildComplementaryCertificationCourseResult({ label: 'CléA Numérique' }),
-        domainBuilder.buildComplementaryCertificationCourseResult({ label: 'Pix+ Droit' }),
-        domainBuilder.buildComplementaryCertificationCourseResult({ label: 'CléA Numérique' }),
-        domainBuilder.buildComplementaryCertificationCourseResult({ label: 'Pix+ Edu 1er degré' }),
-        domainBuilder.buildComplementaryCertificationCourseResult({ label: 'Pix+ Edu 2nd degré' }),
+        domainBuilder.buildComplementaryCertificationCourseResult({ id: 28, label: 'Pix+ Edu 2nd degré' }),
+        domainBuilder.buildComplementaryCertificationCourseResult({ id: 1, label: 'CléA Numérique' }),
+        domainBuilder.buildComplementaryCertificationCourseResult({ id: 23, label: 'Pix+ Edu 1er degré' }),
+        domainBuilder.buildComplementaryCertificationCourseResult({ id: 2, label: 'CléA Numérique' }),
+        domainBuilder.buildComplementaryCertificationCourseResult({ id: 13, label: 'Pix+ Droit' }),
       ];
       const certificationResult = domainBuilder.buildCertificationResult({
         complementaryCertificationCourseResults,


### PR DESCRIPTION
## 🌱 Problème

Nous utilisons une librairie externe (lodash) pour faire des manipulations que nous pourrions faire en JavaScript natif.

## 🐣 Proposition

Réduire l'utilisation de lodash

## 🌷 Remarques

Le tri des résultats de complémentaire pour l'export CSV a été modifié pour trier sur les labels plutôt que les ID. L'impact est  peut-être à vérifier  ?

## 🐝 Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
