### PR TITLE
[TECH] Ne plus importer certains utilitaires depuis test-helper.js

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -101,7 +101,6 @@
         "knip": "^6.0.0",
         "mocha": "^11.7.5",
         "mocha-junit-reporter": "^2.2.1",
-        "mockdate": "^3.0.5",
         "nock": "^14.0.0",
         "nodemon": "^3.0.0",
         "npm-run-all2": "^8.0.0",
@@ -9933,13 +9932,6 @@
       "engines": {
         "node": ">=12"
       }
-    },
-    "node_modules/mockdate": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/mockdate/-/mockdate-3.0.5.tgz",
-      "integrity": "sha512-iniQP4rj1FhBdBYS/+eQv7j1tadJ9lJtdzgOpvsOHng/GbcDh2Fhdeq+ZRldrPYdXvCyfFUmFeEwEGXZB5I/AQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/moment": {
       "version": "2.30.1",

--- a/api/package.json
+++ b/api/package.json
@@ -182,7 +182,6 @@
     "knip": "^6.0.0",
     "mocha": "^11.7.5",
     "mocha-junit-reporter": "^2.2.1",
-    "mockdate": "^3.0.5",
     "nock": "^14.0.0",
     "nodemon": "^3.0.0",
     "npm-run-all2": "^8.0.0",

--- a/api/tests/acceptance/application/scenario-simulator/scenario-simulator-controller_test.js
+++ b/api/tests/acceptance/application/scenario-simulator/scenario-simulator-controller_test.js
@@ -4,8 +4,8 @@ import {
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
-  parseNDJSON,
 } from '../../../test-helper.js';
+import { parseNDJSON } from '../../../tooling/test-utils/json.js';
 
 const {
   ROLES: { SUPER_ADMIN },

--- a/api/tests/certification/configuration/unit/domain/models/Center_test.js
+++ b/api/tests/certification/configuration/unit/domain/models/Center_test.js
@@ -1,7 +1,8 @@
 import { Center } from '../../../../../../src/certification/configuration/domain/models/Center.js';
 import { CenterTypes } from '../../../../../../src/certification/configuration/domain/models/CenterTypes.js';
 import { EntityValidationError } from '../../../../../../src/shared/domain/errors.js';
-import { catchErrSync, expect } from '../../../../../test-helper.js';
+import { expect } from '../../../../../test-helper.js';
+import { catchErrSync } from '../../../../../tooling/test-utils/error.js';
 
 describe('Unit | Certification | Configuration | Domain | Models | Center', function () {
   it('should build a Center', function () {

--- a/api/tests/certification/configuration/unit/domain/models/CertificationFrameworksChallenge_test.js
+++ b/api/tests/certification/configuration/unit/domain/models/CertificationFrameworksChallenge_test.js
@@ -1,7 +1,8 @@
 import { CertificationFrameworksChallenge } from '../../../../../../src/certification/configuration/domain/models/CertificationFrameworksChallenge.js';
 import { ActiveCalibratedChallenge } from '../../../../../../src/certification/configuration/domain/read-models/ActiveCalibratedChallenge.js';
 import { EntityValidationError } from '../../../../../../src/shared/domain/errors.js';
-import { catchErrSync, domainBuilder, expect } from '../../../../../test-helper.js';
+import { domainBuilder, expect } from '../../../../../test-helper.js';
+import { catchErrSync } from '../../../../../tooling/test-utils/error.js';
 
 describe('Certification | Configuration | Unit | Domain | Models | CertificationFrameworksChallenge', function () {
   describe('#calibrate', function () {

--- a/api/tests/certification/configuration/unit/infrastructure/serializers/csv/sco-whitelist-csv-parser_test.js
+++ b/api/tests/certification/configuration/unit/infrastructure/serializers/csv/sco-whitelist-csv-parser_test.js
@@ -1,13 +1,14 @@
 import { extractExternalIds } from '../../../../../../../src/certification/configuration/infrastructure/serializers/csv/sco-whitelist-csv-parser.js';
 import { FileValidationError } from '../../../../../../../src/shared/domain/errors.js';
-import { catchErr, createTempFile, expect, removeTempFile } from '../../../../../../test-helper.js';
+import { catchErr, expect } from '../../../../../../test-helper.js';
+import { createTempFile, removeTempFile } from '../../../../../../tooling/test-utils/file.js';
 
 describe('Integration | Serializer | CSV | Certification | Configuration | sco-whitelist-csv-parser', function () {
   describe('#extractExternalIds', function () {
     let file;
 
-    afterEach(function () {
-      removeTempFile(file);
+    afterEach(async function () {
+      await removeTempFile(file);
     });
 
     context('when the file is correctly parsed', function () {

--- a/api/tests/certification/enrolment/unit/domain/models/Candidate_test.js
+++ b/api/tests/certification/enrolment/unit/domain/models/Candidate_test.js
@@ -6,7 +6,8 @@ import { ComplementaryCertificationKeys } from '../../../../../../src/certificat
 import { Frameworks } from '../../../../../../src/certification/shared/domain/models/Frameworks.js';
 import { CertificationCandidatesError } from '../../../../../../src/shared/domain/errors.js';
 import { getI18n } from '../../../../../../src/shared/infrastructure/i18n/i18n.js';
-import { catchErr, catchErrSync, domainBuilder, expect } from '../../../../../test-helper.js';
+import { domainBuilder, expect } from '../../../../../test-helper.js';
+import { catchErr, catchErrSync } from '../../../../../tooling/test-utils/error.js';
 const FIRST_NAME_ERROR_CODE = CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_FIRST_NAME_REQUIRED.code;
 const LAST_NAME_ERROR_CODE = CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_LAST_NAME_REQUIRED.code;
 const BIRTHDATE_ERROR_CODE = CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTHDATE_REQUIRED.code;

--- a/api/tests/certification/enrolment/unit/domain/models/Habilitation_test.js
+++ b/api/tests/certification/enrolment/unit/domain/models/Habilitation_test.js
@@ -1,6 +1,7 @@
 import { Habilitation } from '../../../../../../src/certification/enrolment/domain/models/Habilitation.js';
 import { EntityValidationError } from '../../../../../../src/shared/domain/errors.js';
-import { catchErrSync, expect } from '../../../../../test-helper.js';
+import { expect } from '../../../../../test-helper.js';
+import { catchErrSync } from '../../../../../tooling/test-utils/error.js';
 
 describe('Unit | Certification | Enrolment | Domain | Models | Habilitation', function () {
   it('should build an Habilitation', function () {

--- a/api/tests/certification/enrolment/unit/domain/models/Subscription_test.js
+++ b/api/tests/certification/enrolment/unit/domain/models/Subscription_test.js
@@ -1,7 +1,8 @@
 import { Subscription } from '../../../../../../src/certification/enrolment/domain/models/Subscription.js';
 import { SUBSCRIPTION_TYPES } from '../../../../../../src/certification/shared/domain/constants.js';
 import { ComplementaryCertificationKeys } from '../../../../../../src/certification/shared/domain/models/ComplementaryCertificationKeys.js';
-import { catchErrSync, domainBuilder, expect } from '../../../../../test-helper.js';
+import { domainBuilder, expect } from '../../../../../test-helper.js';
+import { catchErrSync } from '../../../../../tooling/test-utils/error.js';
 
 describe('Unit | Certification | Enrolment | Domain | Models | Subscription', function () {
   let certificationCandidate;

--- a/api/tests/certification/enrolment/unit/domain/models/timeline/CandidateTimeline_test.js
+++ b/api/tests/certification/enrolment/unit/domain/models/timeline/CandidateTimeline_test.js
@@ -3,7 +3,8 @@ import dayjs from 'dayjs';
 import { CandidateTimeline } from '../../../../../../../src/certification/enrolment/domain/models/timeline/CandidateTimeline.js';
 import { TimelineEvent } from '../../../../../../../src/certification/enrolment/domain/models/timeline/TimelineEvent.js';
 import { EntityValidationError } from '../../../../../../../src/shared/domain/errors.js';
-import { catchErrSync, expect } from '../../../../../../test-helper.js';
+import { expect } from '../../../../../../test-helper.js';
+import { catchErrSync } from '../../../../../../tooling/test-utils/error.js';
 
 describe('Unit | Certification | Enrolment | Domain | Models | CandidateTimeline', function () {
   it('should create a timeline', function () {

--- a/api/tests/certification/enrolment/unit/domain/models/timeline/TimelineEvent_test.js
+++ b/api/tests/certification/enrolment/unit/domain/models/timeline/TimelineEvent_test.js
@@ -1,6 +1,7 @@
 import { TimelineEvent } from '../../../../../../../src/certification/enrolment/domain/models/timeline/TimelineEvent.js';
 import { EntityValidationError } from '../../../../../../../src/shared/domain/errors.js';
-import { catchErrSync, expect } from '../../../../../../test-helper.js';
+import { expect } from '../../../../../../test-helper.js';
+import { catchErrSync } from '../../../../../../tooling/test-utils/error.js';
 
 describe('Unit | Certification | Enrolment | Domain | Models | TimelineEvent', function () {
   it('should create a timeline event', function () {

--- a/api/tests/certification/evaluation/integration/application/scenario-simulator-controller_test.js
+++ b/api/tests/certification/evaluation/integration/application/scenario-simulator-controller_test.js
@@ -3,7 +3,8 @@ import pickChallengeService from '../../../../../src/certification/evaluation/do
 import { usecases } from '../../../../../src/certification/evaluation/domain/usecases/index.js';
 import { pickAnswerStatusService } from '../../../../../src/certification/shared/domain/services/pick-answer-status-service.js';
 import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
-import { domainBuilder, expect, HttpTestServer, parseNDJSON, sinon } from '../../../../test-helper.js';
+import { domainBuilder, expect, HttpTestServer, sinon } from '../../../../test-helper.js';
+import { parseNDJSON } from '../../../../tooling/test-utils/json.js';
 
 describe('Integration | Application | scenario-simulator-controller', function () {
   let httpTestServer;

--- a/api/tests/certification/evaluation/unit/domain/models/Candidate_test.js
+++ b/api/tests/certification/evaluation/unit/domain/models/Candidate_test.js
@@ -1,7 +1,8 @@
 import { Candidate } from '../../../../../../src/certification/evaluation/domain/models/Candidate.js';
 import { Frameworks } from '../../../../../../src/certification/shared/domain/models/Frameworks.js';
 import { EntityValidationError } from '../../../../../../src/shared/domain/errors.js';
-import { catchErrSync, expect } from '../../../../../test-helper.js';
+import { expect } from '../../../../../test-helper.js';
+import { catchErrSync } from '../../../../../tooling/test-utils/error.js';
 
 describe('Certification | Evaluation | Unit | Domain | Models | Candidate', function () {
   context('#constructor', function () {

--- a/api/tests/certification/session-management/integration/domain/usecases/process-auto-jury_test.js
+++ b/api/tests/certification/session-management/integration/domain/usecases/process-auto-jury_test.js
@@ -1,14 +1,8 @@
 import { CertificationJuryDone } from '../../../../../../src/certification/session-management/domain/events/CertificationJuryDone.js';
 import { usecases } from '../../../../../../src/certification/session-management/domain/usecases/index.js';
 import { Assessment } from '../../../../../../src/shared/domain/models/Assessment.js';
-import {
-  databaseBuilder,
-  domainBuilder,
-  expect,
-  knex,
-  preventStubsToBeCalledUnexpectedly,
-  sinon,
-} from '../../../../../test-helper.js';
+import { databaseBuilder, domainBuilder, expect, knex, sinon } from '../../../../../test-helper.js';
+import { preventStubsToBeCalledUnexpectedly } from '../../../../../tooling/test-utils/error.js';
 
 describe('Certification | Session Management | Integration | Domain | UseCase | process-auto-jury_test ', function () {
   context('when it is a V3 certification', function () {

--- a/api/tests/certification/session-management/integration/infrastructure/utils/pdf/attendance-sheet-pdf_test.js
+++ b/api/tests/certification/session-management/integration/infrastructure/utils/pdf/attendance-sheet-pdf_test.js
@@ -5,7 +5,9 @@ import pdfLibUtils from 'pdf-lib/cjs/utils/index.js';
 
 import { getAttendanceSheetPdfBuffer } from '../../../../../../../src/certification/enrolment/infrastructure/utils/pdf/attendance-sheet-pdf.js';
 import { getI18n } from '../../../../../../../src/shared/infrastructure/i18n/i18n.js';
-import { domainBuilder, expect, isSameBinary, sinon } from '../../../../../../test-helper.js';
+import { domainBuilder, expect, sinon } from '../../../../../../test-helper.js';
+import { isSameBinary } from '../../../../../../tooling/test-utils/file.js';
+
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
 
 describe('Integration | Infrastructure | Utils | Pdf | Attendance sheet Pdf', function () {

--- a/api/tests/certification/session-management/integration/infrastructure/utils/pdf/invigilator-kit-pdf_test.js
+++ b/api/tests/certification/session-management/integration/infrastructure/utils/pdf/invigilator-kit-pdf_test.js
@@ -5,7 +5,8 @@ import pdfLibUtils from 'pdf-lib/cjs/utils/index.js';
 
 import { getInvigilatorKitPdfBuffer } from '../../../../../../../src/certification/session-management/infrastructure/utils/pdf/invigilator-kit-pdf.js';
 import { ENGLISH_SPOKEN, FRENCH_SPOKEN } from '../../../../../../../src/shared/domain/services/locale-service.js';
-import { domainBuilder, expect, isSameBinary, sinon } from '../../../../../../test-helper.js';
+import { domainBuilder, expect, sinon } from '../../../../../../test-helper.js';
+import { isSameBinary } from '../../../../../../tooling/test-utils/file.js';
 
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
 

--- a/api/tests/certification/shared/unit/domain/models/FlashAssessmentAlgorithmConfiguration_test.js
+++ b/api/tests/certification/shared/unit/domain/models/FlashAssessmentAlgorithmConfiguration_test.js
@@ -1,6 +1,7 @@
 import { FlashAssessmentAlgorithmConfiguration } from '../../../../../../src/certification/shared/domain/models/FlashAssessmentAlgorithmConfiguration.js';
 import { EntityValidationError } from '../../../../../../src/shared/domain/errors.js';
-import { catchErrSync, expect } from '../../../../../test-helper.js';
+import { expect } from '../../../../../test-helper.js';
+import { catchErrSync } from '../../../../../tooling/test-utils/error.js';
 
 describe('Unit | Domain | Models | FlashAssessmentAlgorithmConfiguration', function () {
   context('class invariants', function () {

--- a/api/tests/certification/shared/unit/domain/models/FlashAssessmentAlgorithm_test.js
+++ b/api/tests/certification/shared/unit/domain/models/FlashAssessmentAlgorithm_test.js
@@ -1,7 +1,8 @@
 import { FlashAssessmentAlgorithm } from '../../../../../../src/certification/evaluation/domain/models/FlashAssessmentAlgorithm.js';
 import { FlashAssessmentAlgorithmConfiguration } from '../../../../../../src/certification/shared/domain/models/FlashAssessmentAlgorithmConfiguration.js';
 import { AssessmentLackOfChallengesError } from '../../../../../../src/shared/domain/errors.js';
-import { catchErrSync, domainBuilder, expect, sinon } from '../../../../../test-helper.js';
+import { domainBuilder, expect, sinon } from '../../../../../test-helper.js';
+import { catchErrSync } from '../../../../../tooling/test-utils/error.js';
 
 const baseFlashAssessmentAlgorithmConfig = {
   challengesBetweenSameCompetence: 2,

--- a/api/tests/devcomp/acceptance/application/passages/passage-controller_test.js
+++ b/api/tests/devcomp/acceptance/application/passages/passage-controller_test.js
@@ -11,8 +11,8 @@ import {
   generateAuthenticatedUserRequestHeaders,
   knex,
   nock,
-  waitForStreamFinalizationToBeDone,
 } from '../../../../test-helper.js';
+import { waitForStreamFinalizationToBeDone } from '../../../../tooling/test-utils/wait.js';
 
 describe('Acceptance | Controller | passage-controller', function () {
   let server;

--- a/api/tests/devcomp/integration/domain/models/flashcard-events/answerable-element-events_test.js
+++ b/api/tests/devcomp/integration/domain/models/flashcard-events/answerable-element-events_test.js
@@ -13,7 +13,8 @@ import {
   QROCMRetriedEvent,
 } from '../../../../../../src/devcomp/domain/models/passage-events/answerable-element-events.js';
 import { DomainError } from '../../../../../../src/shared/domain/errors.js';
-import { catchErrSync, expect } from '../../../../../test-helper.js';
+import { expect } from '../../../../../test-helper.js';
+import { catchErrSync } from '../../../../../tooling/test-utils/error.js';
 
 describe('Integration | Devcomp | Domain | Models | passage-events | answerable-element-events', function () {
   describe('#CustomDraftRetriedEvent', function () {

--- a/api/tests/devcomp/integration/domain/models/flashcard-events/flashcard-events_test.js
+++ b/api/tests/devcomp/integration/domain/models/flashcard-events/flashcard-events_test.js
@@ -6,7 +6,8 @@ import {
   FlashcardsVersoSeenEvent,
 } from '../../../../../../src/devcomp/domain/models/passage-events/flashcard-events.js';
 import { DomainError } from '../../../../../../src/shared/domain/errors.js';
-import { catchErrSync, expect } from '../../../../../test-helper.js';
+import { expect } from '../../../../../test-helper.js';
+import { catchErrSync } from '../../../../../tooling/test-utils/error.js';
 
 describe('Integration | Devcomp | Domain | Models | passage-events | flashcard-events', function () {
   describe('#FlashcardsStartedEvent', function () {

--- a/api/tests/devcomp/integration/domain/models/passage-events/grain-events_test.js
+++ b/api/tests/devcomp/integration/domain/models/passage-events/grain-events_test.js
@@ -3,7 +3,8 @@ import {
   GrainSkippedEvent,
 } from '../../../../../../src/devcomp/domain/models/passage-events/grain-events.js';
 import { DomainError } from '../../../../../../src/shared/domain/errors.js';
-import { catchErrSync, expect } from '../../../../../test-helper.js';
+import { expect } from '../../../../../test-helper.js';
+import { catchErrSync } from '../../../../../tooling/test-utils/error.js';
 
 describe('Integration | Devcomp | Domain | Models | passage-events | grain-events', function () {
   describe('#GrainContinuedEvent', function () {

--- a/api/tests/devcomp/integration/domain/models/passage-events/passage-events_test.js
+++ b/api/tests/devcomp/integration/domain/models/passage-events/passage-events_test.js
@@ -3,7 +3,8 @@ import {
   PassageTerminatedEvent,
 } from '../../../../../../src/devcomp/domain/models/passage-events/passage-events.js';
 import { DomainError } from '../../../../../../src/shared/domain/errors.js';
-import { catchErrSync, expect } from '../../../../../test-helper.js';
+import { expect } from '../../../../../test-helper.js';
+import { catchErrSync } from '../../../../../tooling/test-utils/error.js';
 
 describe('Integration | Devcomp | Domain | Models | passage-events | passage-events', function () {
   describe('#PassageStartedEvent', function () {

--- a/api/tests/devcomp/integration/domain/models/passage-events/qab-events_test.js
+++ b/api/tests/devcomp/integration/domain/models/passage-events/qab-events_test.js
@@ -3,7 +3,8 @@ import {
   QABRetriedEvent,
 } from '../../../../../../src/devcomp/domain/models/passage-events/qab-events.js';
 import { DomainError } from '../../../../../../src/shared/domain/errors.js';
-import { catchErrSync, expect } from '../../../../../test-helper.js';
+import { expect } from '../../../../../test-helper.js';
+import { catchErrSync } from '../../../../../tooling/test-utils/error.js';
 
 describe('Integration | Devcomp | Domain | Models | passage-events | qab-events', function () {
   describe('#QABCardAnsweredEvent', function () {

--- a/api/tests/devcomp/integration/domain/models/passage-events/stepper-events_test.js
+++ b/api/tests/devcomp/integration/domain/models/passage-events/stepper-events_test.js
@@ -1,6 +1,7 @@
 import { StepperNextStepEvent } from '../../../../../../src/devcomp/domain/models/passage-events/stepper-events.js';
 import { DomainError } from '../../../../../../src/shared/domain/errors.js';
-import { catchErrSync, expect } from '../../../../../test-helper.js';
+import { expect } from '../../../../../test-helper.js';
+import { catchErrSync } from '../../../../../tooling/test-utils/error.js';
 
 describe('Integration | Devcomp | Domain | Models | passage-events | stepper-events', function () {
   describe('#StepperNextStepEvent', function () {

--- a/api/tests/devcomp/unit/domain/factories/passage-event-factory_test.js
+++ b/api/tests/devcomp/unit/domain/factories/passage-event-factory_test.js
@@ -47,7 +47,7 @@ import {
 } from '../../../../../src/devcomp/domain/models/passage-events/qab-events.js';
 import { StepperNextStepEvent } from '../../../../../src/devcomp/domain/models/passage-events/stepper-events.js';
 import { DomainError } from '../../../../../src/shared/domain/errors.js';
-import { catchErrSync } from '../../../../test-helper.js';
+import { catchErrSync } from '../../../../tooling/test-utils/error.js';
 
 describe('Unit | Devcomp | Domain | Models | Block | BlockInput', function () {
   describe('#build', function () {

--- a/api/tests/devcomp/unit/domain/models/ElementAnswer_test.js
+++ b/api/tests/devcomp/unit/domain/models/ElementAnswer_test.js
@@ -1,6 +1,7 @@
 import { ElementAnswer } from '../../../../../src/devcomp/domain/models/ElementAnswer.js';
 import { DomainError } from '../../../../../src/shared/domain/errors.js';
-import { catchErrSync, expect } from '../../../../test-helper.js';
+import { expect } from '../../../../test-helper.js';
+import { catchErrSync } from '../../../../tooling/test-utils/error.js';
 
 describe('Unit | Devcomp | Domain | Models | ElementAnswer', function () {
   describe('#constructor', function () {

--- a/api/tests/devcomp/unit/domain/models/EmbedCorrectionResponse_test.js
+++ b/api/tests/devcomp/unit/domain/models/EmbedCorrectionResponse_test.js
@@ -1,7 +1,8 @@
 import { EmbedCorrectionResponse } from '../../../../../src/devcomp/domain/models/EmbedCorrectionResponse.js';
 import { AnswerStatus } from '../../../../../src/devcomp/domain/models/validator/AnswerStatus.js';
 import { DomainError } from '../../../../../src/shared/domain/errors.js';
-import { catchErrSync, expect } from '../../../../test-helper.js';
+import { expect } from '../../../../test-helper.js';
+import { catchErrSync } from '../../../../tooling/test-utils/error.js';
 
 describe('Unit | Devcomp | Domain | Models | EmbedCorrectionResponse', function () {
   describe('#constructor', function () {

--- a/api/tests/devcomp/unit/domain/models/Feedbacks_test.js
+++ b/api/tests/devcomp/unit/domain/models/Feedbacks_test.js
@@ -1,6 +1,7 @@
 import { Feedbacks } from '../../../../../src/devcomp/domain/models/Feedbacks.js';
 import { DomainError } from '../../../../../src/shared/domain/errors.js';
-import { catchErrSync, expect } from '../../../../test-helper.js';
+import { expect } from '../../../../test-helper.js';
+import { catchErrSync } from '../../../../tooling/test-utils/error.js';
 
 describe('Unit | Devcomp | Domain | Models | Feedbacks', function () {
   describe('#constructor', function () {

--- a/api/tests/devcomp/unit/domain/models/Grain_test.js
+++ b/api/tests/devcomp/unit/domain/models/Grain_test.js
@@ -1,7 +1,8 @@
 import { ModuleInstantiationError } from '../../../../../src/devcomp/domain/errors.js';
 import { Grain } from '../../../../../src/devcomp/domain/models/Grain.js';
 import { DomainError } from '../../../../../src/shared/domain/errors.js';
-import { catchErrSync, expect } from '../../../../test-helper.js';
+import { expect } from '../../../../test-helper.js';
+import { catchErrSync } from '../../../../tooling/test-utils/error.js';
 
 describe('Unit | Devcomp | Domain | Models | Grain', function () {
   describe('#constructor', function () {

--- a/api/tests/devcomp/unit/domain/models/QcmCorrectionResponse_test.js
+++ b/api/tests/devcomp/unit/domain/models/QcmCorrectionResponse_test.js
@@ -1,7 +1,8 @@
 import { QcmCorrectionResponse } from '../../../../../src/devcomp/domain/models/QcmCorrectionResponse.js';
 import { AnswerStatus } from '../../../../../src/devcomp/domain/models/validator/AnswerStatus.js';
 import { DomainError } from '../../../../../src/shared/domain/errors.js';
-import { catchErrSync, expect } from '../../../../test-helper.js';
+import { expect } from '../../../../test-helper.js';
+import { catchErrSync } from '../../../../tooling/test-utils/error.js';
 
 describe('Unit | Devcomp | Domain | Models | QcmCorrectionResponse', function () {
   describe('#constructor', function () {

--- a/api/tests/devcomp/unit/domain/models/QcmProposal_test.js
+++ b/api/tests/devcomp/unit/domain/models/QcmProposal_test.js
@@ -1,6 +1,7 @@
 import { QcmProposal } from '../../../../../src/devcomp/domain/models/QcmProposal.js';
 import { DomainError } from '../../../../../src/shared/domain/errors.js';
-import { catchErrSync, expect } from '../../../../test-helper.js';
+import { expect } from '../../../../test-helper.js';
+import { catchErrSync } from '../../../../tooling/test-utils/error.js';
 
 describe('Unit | Devcomp | Domain | Models | QcmProposal', function () {
   describe('#constructor', function () {

--- a/api/tests/devcomp/unit/domain/models/QcuCorrectionResponse_test.js
+++ b/api/tests/devcomp/unit/domain/models/QcuCorrectionResponse_test.js
@@ -1,7 +1,8 @@
 import { QcuCorrectionResponse } from '../../../../../src/devcomp/domain/models/QcuCorrectionResponse.js';
 import { AnswerStatus } from '../../../../../src/devcomp/domain/models/validator/AnswerStatus.js';
 import { DomainError } from '../../../../../src/shared/domain/errors.js';
-import { catchErrSync, expect } from '../../../../test-helper.js';
+import { expect } from '../../../../test-helper.js';
+import { catchErrSync } from '../../../../tooling/test-utils/error.js';
 
 describe('Unit | Devcomp | Domain | Models | QcuCorrectionResponse', function () {
   describe('#constructor', function () {

--- a/api/tests/devcomp/unit/domain/models/QcuProposal_test.js
+++ b/api/tests/devcomp/unit/domain/models/QcuProposal_test.js
@@ -1,6 +1,7 @@
 import { QcuProposal } from '../../../../../src/devcomp/domain/models/QcuProposal.js';
 import { DomainError } from '../../../../../src/shared/domain/errors.js';
-import { catchErrSync, expect } from '../../../../test-helper.js';
+import { expect } from '../../../../test-helper.js';
+import { catchErrSync } from '../../../../tooling/test-utils/error.js';
 
 describe('Unit | Devcomp | Domain | Models | QcuProposal', function () {
   describe('#constructor', function () {

--- a/api/tests/devcomp/unit/domain/models/QrocmCorrectionResponse_test.js
+++ b/api/tests/devcomp/unit/domain/models/QrocmCorrectionResponse_test.js
@@ -1,7 +1,8 @@
 import { QrocmCorrectionResponse } from '../../../../../src/devcomp/domain/models/QrocmCorrectionResponse.js';
 import { AnswerStatus } from '../../../../../src/devcomp/domain/models/validator/AnswerStatus.js';
 import { DomainError } from '../../../../../src/shared/domain/errors.js';
-import { catchErrSync, expect } from '../../../../test-helper.js';
+import { expect } from '../../../../test-helper.js';
+import { catchErrSync } from '../../../../tooling/test-utils/error.js';
 
 describe('Unit | Devcomp | Domain | Models | QrocmCorrectionResponse', function () {
   describe('#constructor', function () {

--- a/api/tests/devcomp/unit/domain/models/QrocmSolutions_test.js
+++ b/api/tests/devcomp/unit/domain/models/QrocmSolutions_test.js
@@ -1,7 +1,8 @@
 import { ModuleInstantiationError } from '../../../../../src/devcomp/domain/errors.js';
 import { QrocmSolutions } from '../../../../../src/devcomp/domain/models/QrocmSolutions.js';
 import { DomainError } from '../../../../../src/shared/domain/errors.js';
-import { catchErrSync, expect } from '../../../../test-helper.js';
+import { expect } from '../../../../test-helper.js';
+import { catchErrSync } from '../../../../tooling/test-utils/error.js';
 
 describe('Unit | Devcomp | Domain | Models | QrocmSolutions', function () {
   describe('#constructor', function () {

--- a/api/tests/devcomp/unit/domain/models/block/BlockInput_test.js
+++ b/api/tests/devcomp/unit/domain/models/block/BlockInput_test.js
@@ -1,6 +1,7 @@
 import { BlockInput } from '../../../../../../src/devcomp/domain/models/block/BlockInput.js';
 import { DomainError } from '../../../../../../src/shared/domain/errors.js';
-import { catchErrSync, expect } from '../../../../../test-helper.js';
+import { expect } from '../../../../../test-helper.js';
+import { catchErrSync } from '../../../../../tooling/test-utils/error.js';
 
 describe('Unit | Devcomp | Domain | Models | Block | BlockInput', function () {
   describe('#constructor', function () {

--- a/api/tests/devcomp/unit/domain/models/block/BlockSelectOption_test.js
+++ b/api/tests/devcomp/unit/domain/models/block/BlockSelectOption_test.js
@@ -1,6 +1,7 @@
 import { BlockSelectOption } from '../../../../../../src/devcomp/domain/models/block/BlockSelectOption.js';
 import { DomainError } from '../../../../../../src/shared/domain/errors.js';
-import { catchErrSync, expect } from '../../../../../test-helper.js';
+import { expect } from '../../../../../test-helper.js';
+import { catchErrSync } from '../../../../../tooling/test-utils/error.js';
 
 describe('Unit | Devcomp | Domain | Models | Block | BlockSelectOption', function () {
   describe('#constructor', function () {

--- a/api/tests/devcomp/unit/domain/models/block/BlockSelect_test.js
+++ b/api/tests/devcomp/unit/domain/models/block/BlockSelect_test.js
@@ -1,6 +1,7 @@
 import { BlockSelect } from '../../../../../../src/devcomp/domain/models/block/BlockSelect.js';
 import { DomainError } from '../../../../../../src/shared/domain/errors.js';
-import { catchErrSync, expect } from '../../../../../test-helper.js';
+import { expect } from '../../../../../test-helper.js';
+import { catchErrSync } from '../../../../../tooling/test-utils/error.js';
 
 describe('Unit | Devcomp | Domain | Models | Block | BlockSelect', function () {
   describe('#constructor', function () {

--- a/api/tests/devcomp/unit/domain/models/block/BlockText_test.js
+++ b/api/tests/devcomp/unit/domain/models/block/BlockText_test.js
@@ -1,6 +1,7 @@
 import { BlockText } from '../../../../../../src/devcomp/domain/models/block/BlockText.js';
 import { DomainError } from '../../../../../../src/shared/domain/errors.js';
-import { catchErrSync, expect } from '../../../../../test-helper.js';
+import { expect } from '../../../../../test-helper.js';
+import { catchErrSync } from '../../../../../tooling/test-utils/error.js';
 
 describe('Unit | Devcomp | Domain | Models | Block | BlockText', function () {
   describe('#constructor', function () {

--- a/api/tests/devcomp/unit/domain/models/component/ComponentElement_test.js
+++ b/api/tests/devcomp/unit/domain/models/component/ComponentElement_test.js
@@ -1,6 +1,7 @@
 import { ComponentElement } from '../../../../../../src/devcomp/domain/models/component/ComponentElement.js';
 import { DomainError } from '../../../../../../src/shared/domain/errors.js';
-import { catchErrSync, expect } from '../../../../../test-helper.js';
+import { expect } from '../../../../../test-helper.js';
+import { catchErrSync } from '../../../../../tooling/test-utils/error.js';
 
 describe('Unit | Devcomp | Domain | Models | Component | ComponentElement', function () {
   describe('#constructor', function () {

--- a/api/tests/devcomp/unit/domain/models/component/ComponentStepper_test.js
+++ b/api/tests/devcomp/unit/domain/models/component/ComponentStepper_test.js
@@ -1,7 +1,8 @@
 import { ModuleInstantiationError } from '../../../../../../src/devcomp/domain/errors.js';
 import { ComponentStepper } from '../../../../../../src/devcomp/domain/models/component/ComponentStepper.js';
 import { DomainError } from '../../../../../../src/shared/domain/errors.js';
-import { catchErrSync, expect } from '../../../../../test-helper.js';
+import { expect } from '../../../../../test-helper.js';
+import { catchErrSync } from '../../../../../tooling/test-utils/error.js';
 
 describe('Unit | Devcomp | Domain | Models | Component | ComponentStepper', function () {
   describe('#constructor', function () {

--- a/api/tests/devcomp/unit/domain/models/component/Step_test.js
+++ b/api/tests/devcomp/unit/domain/models/component/Step_test.js
@@ -1,7 +1,8 @@
 import { ModuleInstantiationError } from '../../../../../../src/devcomp/domain/errors.js';
 import { Step } from '../../../../../../src/devcomp/domain/models/component/Step.js';
 import { DomainError } from '../../../../../../src/shared/domain/errors.js';
-import { catchErrSync, expect } from '../../../../../test-helper.js';
+import { expect } from '../../../../../test-helper.js';
+import { catchErrSync } from '../../../../../tooling/test-utils/error.js';
 
 describe('Unit | Devcomp | Domain | Models | Component | Step', function () {
   describe('#constructor', function () {

--- a/api/tests/devcomp/unit/domain/models/element/Audio_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/Audio_test.js
@@ -1,6 +1,7 @@
 import { Audio } from '../../../../../../src/devcomp/domain/models/element/Audio.js';
 import { DomainError } from '../../../../../../src/shared/domain/errors.js';
-import { catchErrSync, expect } from '../../../../../test-helper.js';
+import { expect } from '../../../../../test-helper.js';
+import { catchErrSync } from '../../../../../tooling/test-utils/error.js';
 
 describe('Unit | Devcomp | Domain | Models | Element | Audio', function () {
   describe('#constructor', function () {

--- a/api/tests/devcomp/unit/domain/models/element/CustomDraft_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/CustomDraft_test.js
@@ -1,6 +1,7 @@
 import { CustomDraft } from '../../../../../../src/devcomp/domain/models/element/CustomDraft.js';
 import { DomainError } from '../../../../../../src/shared/domain/errors.js';
-import { catchErrSync, expect } from '../../../../../test-helper.js';
+import { expect } from '../../../../../test-helper.js';
+import { catchErrSync } from '../../../../../tooling/test-utils/error.js';
 
 describe('Unit | Devcomp | Domain | Models | Element | CustomDraft', function () {
   describe('#constructor', function () {

--- a/api/tests/devcomp/unit/domain/models/element/CustomElement_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/CustomElement_test.js
@@ -1,6 +1,7 @@
 import { CustomElement } from '../../../../../../src/devcomp/domain/models/element/CustomElement.js';
 import { DomainError } from '../../../../../../src/shared/domain/errors.js';
-import { catchErrSync, expect } from '../../../../../test-helper.js';
+import { expect } from '../../../../../test-helper.js';
+import { catchErrSync } from '../../../../../tooling/test-utils/error.js';
 
 describe('Unit | Devcomp | Domain | Models | Element | CustomElement', function () {
   describe('#constructor', function () {

--- a/api/tests/devcomp/unit/domain/models/element/Download_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/Download_test.js
@@ -1,7 +1,8 @@
 import { ModuleInstantiationError } from '../../../../../../src/devcomp/domain/errors.js';
 import { Download } from '../../../../../../src/devcomp/domain/models/element/Download.js';
 import { DomainError } from '../../../../../../src/shared/domain/errors.js';
-import { catchErrSync, expect } from '../../../../../test-helper.js';
+import { expect } from '../../../../../test-helper.js';
+import { catchErrSync } from '../../../../../tooling/test-utils/error.js';
 
 describe('Unit | Devcomp | Domain | Models | Element | Download', function () {
   describe('#constructor', function () {

--- a/api/tests/devcomp/unit/domain/models/element/Embed-for-answer-verification_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/Embed-for-answer-verification_test.js
@@ -1,7 +1,8 @@
 import { EmbedForAnswerVerification } from '../../../../../../src/devcomp/domain/models/element/Embed-for-answer-verification.js';
 import { EmbedCorrectionResponse } from '../../../../../../src/devcomp/domain/models/EmbedCorrectionResponse.js';
 import { DomainError, EntityValidationError } from '../../../../../../src/shared/domain/errors.js';
-import { catchErrSync, expect, sinon } from '../../../../../test-helper.js';
+import { expect, sinon } from '../../../../../test-helper.js';
+import { catchErrSync } from '../../../../../tooling/test-utils/error.js';
 
 describe('Unit | Devcomp | Domain | Models | Element | EmbedForAnswerVerification', function () {
   describe('#constructor', function () {

--- a/api/tests/devcomp/unit/domain/models/element/Embed_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/Embed_test.js
@@ -1,6 +1,7 @@
 import { Embed } from '../../../../../../src/devcomp/domain/models/element/Embed.js';
 import { DomainError } from '../../../../../../src/shared/domain/errors.js';
-import { catchErrSync, expect } from '../../../../../test-helper.js';
+import { expect } from '../../../../../test-helper.js';
+import { catchErrSync } from '../../../../../tooling/test-utils/error.js';
 
 describe('Unit | Devcomp | Domain | Models | Element | Embed', function () {
   describe('#constructor', function () {

--- a/api/tests/devcomp/unit/domain/models/element/Expand_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/Expand_test.js
@@ -1,6 +1,7 @@
 import { Expand } from '../../../../../../src/devcomp/domain/models/element/Expand.js';
 import { DomainError } from '../../../../../../src/shared/domain/errors.js';
-import { catchErrSync, expect } from '../../../../../test-helper.js';
+import { expect } from '../../../../../test-helper.js';
+import { catchErrSync } from '../../../../../tooling/test-utils/error.js';
 
 describe('Unit | Devcomp | Domain | Models | Element | Expand', function () {
   describe('#constructor', function () {

--- a/api/tests/devcomp/unit/domain/models/element/Image_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/Image_test.js
@@ -1,7 +1,8 @@
 import { Image } from '../../../../../../src/devcomp/domain/models/element/Image.js';
 import { DomainError } from '../../../../../../src/shared/domain/errors.js';
 import { PixAssetImageInfos } from '../../../../../../src/shared/domain/models/PixAssetImageInfos.js';
-import { catchErrSync, expect } from '../../../../../test-helper.js';
+import { expect } from '../../../../../test-helper.js';
+import { catchErrSync } from '../../../../../tooling/test-utils/error.js';
 
 describe('Unit | Devcomp | Domain | Models | Element | Image', function () {
   describe('#constructor', function () {

--- a/api/tests/devcomp/unit/domain/models/element/QCM-for-answer-verification_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/QCM-for-answer-verification_test.js
@@ -3,7 +3,8 @@ import { Feedbacks } from '../../../../../../src/devcomp/domain/models/Feedbacks
 import { QcmCorrectionResponse } from '../../../../../../src/devcomp/domain/models/QcmCorrectionResponse.js';
 import { ValidatorQCM } from '../../../../../../src/devcomp/domain/models/validator/ValidatorQCM.js';
 import { DomainError, EntityValidationError } from '../../../../../../src/shared/domain/errors.js';
-import { catchErrSync, expect, sinon } from '../../../../../test-helper.js';
+import { expect, sinon } from '../../../../../test-helper.js';
+import { catchErrSync } from '../../../../../tooling/test-utils/error.js';
 
 describe('Unit | Devcomp | Domain | Models | Element | QcmForAnswerVerification', function () {
   describe('#constructor', function () {

--- a/api/tests/devcomp/unit/domain/models/element/QCM_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/QCM_test.js
@@ -1,7 +1,8 @@
 import { ModuleInstantiationError } from '../../../../../../src/devcomp/domain/errors.js';
 import { QCM } from '../../../../../../src/devcomp/domain/models/element/QCM.js';
 import { DomainError } from '../../../../../../src/shared/domain/errors.js';
-import { catchErrSync, expect } from '../../../../../test-helper.js';
+import { expect } from '../../../../../test-helper.js';
+import { catchErrSync } from '../../../../../tooling/test-utils/error.js';
 
 describe('Unit | Devcomp | Domain | Models | Element | QCM', function () {
   describe('#constructor', function () {

--- a/api/tests/devcomp/unit/domain/models/element/QCU-discovery_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/QCU-discovery_test.js
@@ -2,7 +2,8 @@ import { ModuleInstantiationError } from '../../../../../../src/devcomp/domain/e
 import { QCUDeclarative } from '../../../../../../src/devcomp/domain/models/element/QCU-declarative.js';
 import { QCUDiscovery } from '../../../../../../src/devcomp/domain/models/element/QCU-discovery.js';
 import { DomainError } from '../../../../../../src/shared/domain/errors.js';
-import { catchErrSync, expect } from '../../../../../test-helper.js';
+import { expect } from '../../../../../test-helper.js';
+import { catchErrSync } from '../../../../../tooling/test-utils/error.js';
 
 describe('Unit | Devcomp | Domain | Models | Element | QCU-discovery', function () {
   describe('#constructor', function () {

--- a/api/tests/devcomp/unit/domain/models/element/QCU-for-answer-verification_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/QCU-for-answer-verification_test.js
@@ -2,7 +2,8 @@ import { ModuleInstantiationError } from '../../../../../../src/devcomp/domain/e
 import { QCUForAnswerVerification } from '../../../../../../src/devcomp/domain/models/element/QCU-for-answer-verification.js';
 import { QcuCorrectionResponse } from '../../../../../../src/devcomp/domain/models/QcuCorrectionResponse.js';
 import { DomainError, EntityValidationError } from '../../../../../../src/shared/domain/errors.js';
-import { catchErrSync, expect, sinon } from '../../../../../test-helper.js';
+import { expect, sinon } from '../../../../../test-helper.js';
+import { catchErrSync } from '../../../../../tooling/test-utils/error.js';
 
 describe('Unit | Devcomp | Domain | Models | Element | QcuForAnswerVerification', function () {
   describe('#constructor', function () {

--- a/api/tests/devcomp/unit/domain/models/element/QCU_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/QCU_test.js
@@ -1,7 +1,8 @@
 import { ModuleInstantiationError } from '../../../../../../src/devcomp/domain/errors.js';
 import { QCU } from '../../../../../../src/devcomp/domain/models/element/QCU.js';
 import { DomainError } from '../../../../../../src/shared/domain/errors.js';
-import { catchErrSync, expect } from '../../../../../test-helper.js';
+import { expect } from '../../../../../test-helper.js';
+import { catchErrSync } from '../../../../../tooling/test-utils/error.js';
 
 describe('Unit | Devcomp | Domain | Models | Element | QCU', function () {
   describe('#constructor', function () {

--- a/api/tests/devcomp/unit/domain/models/element/QROCM-for-answer-verification_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/QROCM-for-answer-verification_test.js
@@ -1,7 +1,8 @@
 import { QROCMForAnswerVerification } from '../../../../../../src/devcomp/domain/models/element/QROCM-for-answer-verification.js';
 import { QrocmCorrectionResponse } from '../../../../../../src/devcomp/domain/models/QrocmCorrectionResponse.js';
 import { DomainError, EntityValidationError } from '../../../../../../src/shared/domain/errors.js';
-import { catchErrSync, expect, sinon } from '../../../../../test-helper.js';
+import { expect, sinon } from '../../../../../test-helper.js';
+import { catchErrSync } from '../../../../../tooling/test-utils/error.js';
 
 describe('Unit | Devcomp | Domain | Models | Element | QrocMForAnswerVerification', function () {
   describe('#constructor', function () {

--- a/api/tests/devcomp/unit/domain/models/element/QROCM_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/QROCM_test.js
@@ -1,7 +1,8 @@
 import { ModuleInstantiationError } from '../../../../../../src/devcomp/domain/errors.js';
 import { QROCM } from '../../../../../../src/devcomp/domain/models/element/QROCM.js';
 import { DomainError } from '../../../../../../src/shared/domain/errors.js';
-import { catchErrSync, expect } from '../../../../../test-helper.js';
+import { expect } from '../../../../../test-helper.js';
+import { catchErrSync } from '../../../../../tooling/test-utils/error.js';
 
 describe('Unit | Devcomp | Domain | Models | Element | QROCM', function () {
   describe('#constructor', function () {

--- a/api/tests/devcomp/unit/domain/models/element/Separator_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/Separator_test.js
@@ -1,6 +1,7 @@
 import { Separator } from '../../../../../../src/devcomp/domain/models/element/Separator.js';
 import { DomainError } from '../../../../../../src/shared/domain/errors.js';
-import { catchErrSync, expect } from '../../../../../test-helper.js';
+import { expect } from '../../../../../test-helper.js';
+import { catchErrSync } from '../../../../../tooling/test-utils/error.js';
 
 describe('Unit | Devcomp | Domain | Models | Element | Separator', function () {
   describe('#constructor', function () {

--- a/api/tests/devcomp/unit/domain/models/element/ShortVideo_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/ShortVideo_test.js
@@ -1,6 +1,7 @@
 import { ShortVideo } from '../../../../../../src/devcomp/domain/models/element/ShortVideo.js';
 import { DomainError } from '../../../../../../src/shared/domain/errors.js';
-import { catchErrSync, expect } from '../../../../../test-helper.js';
+import { expect } from '../../../../../test-helper.js';
+import { catchErrSync } from '../../../../../tooling/test-utils/error.js';
 
 describe('Unit | Devcomp | Domain | Models | Element | ShortVideo', function () {
   describe('#constructor', function () {

--- a/api/tests/devcomp/unit/domain/models/element/Text_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/Text_test.js
@@ -1,6 +1,7 @@
 import { Text } from '../../../../../../src/devcomp/domain/models/element/Text.js';
 import { DomainError } from '../../../../../../src/shared/domain/errors.js';
-import { catchErrSync, expect } from '../../../../../test-helper.js';
+import { expect } from '../../../../../test-helper.js';
+import { catchErrSync } from '../../../../../tooling/test-utils/error.js';
 
 describe('Unit | Devcomp | Domain | Models | Element | Text', function () {
   describe('#constructor', function () {

--- a/api/tests/devcomp/unit/domain/models/element/Video_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/Video_test.js
@@ -1,6 +1,7 @@
 import { Video } from '../../../../../../src/devcomp/domain/models/element/Video.js';
 import { DomainError } from '../../../../../../src/shared/domain/errors.js';
-import { catchErrSync, expect } from '../../../../../test-helper.js';
+import { expect } from '../../../../../test-helper.js';
+import { catchErrSync } from '../../../../../tooling/test-utils/error.js';
 
 describe('Unit | Devcomp | Domain | Models | Element | Video', function () {
   describe('#constructor', function () {

--- a/api/tests/devcomp/unit/domain/models/module/Details_test.js
+++ b/api/tests/devcomp/unit/domain/models/module/Details_test.js
@@ -1,7 +1,8 @@
 import { ModuleInstantiationError } from '../../../../../../src/devcomp/domain/errors.js';
 import { Details } from '../../../../../../src/devcomp/domain/models/module/Details.js';
 import { DomainError } from '../../../../../../src/shared/domain/errors.js';
-import { catchErrSync, expect } from '../../../../../test-helper.js';
+import { expect } from '../../../../../test-helper.js';
+import { catchErrSync } from '../../../../../tooling/test-utils/error.js';
 
 describe('Unit | Devcomp | Domain | Models | Module | Details', function () {
   describe('#constructor', function () {

--- a/api/tests/devcomp/unit/domain/models/module/GlossaryEntry_test.js
+++ b/api/tests/devcomp/unit/domain/models/module/GlossaryEntry_test.js
@@ -1,6 +1,7 @@
 import { GlossaryEntry } from '../../../../../../src/devcomp/domain/models/module/GlossaryEntry.js';
 import { DomainError } from '../../../../../../src/shared/domain/errors.js';
-import { catchErrSync, expect } from '../../../../../test-helper.js';
+import { expect } from '../../../../../test-helper.js';
+import { catchErrSync } from '../../../../../tooling/test-utils/error.js';
 
 describe('Unit | Devcomp | Domain | Models | Module | GlossaryEntry', function () {
   describe('#constructor', function () {

--- a/api/tests/devcomp/unit/domain/models/module/ModuleIssueReport_test.js
+++ b/api/tests/devcomp/unit/domain/models/module/ModuleIssueReport_test.js
@@ -1,6 +1,7 @@
 import { ModuleIssueReport } from '../../../../../../src/devcomp/domain/models/module/ModuleIssueReport.js';
 import { DomainError } from '../../../../../../src/shared/domain/errors.js';
-import { catchErrSync, expect } from '../../../../../test-helper.js';
+import { expect } from '../../../../../test-helper.js';
+import { catchErrSync } from '../../../../../tooling/test-utils/error.js';
 
 describe('Unit | Devcomp | Domain | Models | Module | ModuleIssueReport', function () {
   describe('#constructor', function () {

--- a/api/tests/devcomp/unit/domain/models/module/ModuleMetadata_test.js
+++ b/api/tests/devcomp/unit/domain/models/module/ModuleMetadata_test.js
@@ -1,6 +1,7 @@
 import { ModuleMetadata } from '../../../../../../src/devcomp/domain/models/module/ModuleMetadata.js';
 import { DomainError } from '../../../../../../src/shared/domain/errors.js';
-import { catchErrSync, expect } from '../../../../../test-helper.js';
+import { expect } from '../../../../../test-helper.js';
+import { catchErrSync } from '../../../../../tooling/test-utils/error.js';
 
 describe('Unit | Devcomp | Domain | Models | Module | ModuleMetadata', function () {
   let id, isBeta, slug, title, duration, image, shortId, visibility;

--- a/api/tests/devcomp/unit/domain/models/module/Module_test.js
+++ b/api/tests/devcomp/unit/domain/models/module/Module_test.js
@@ -1,6 +1,7 @@
 import { Module } from '../../../../../../src/devcomp/domain/models/module/Module.js';
 import { DomainError } from '../../../../../../src/shared/domain/errors.js';
-import { catchErrSync, expect } from '../../../../../test-helper.js';
+import { expect } from '../../../../../test-helper.js';
+import { catchErrSync } from '../../../../../tooling/test-utils/error.js';
 
 describe('Unit | Devcomp | Domain | Models | Module | Module', function () {
   describe('#constructor', function () {

--- a/api/tests/devcomp/unit/domain/models/module/PassageEventWithElementAnswered_test.js
+++ b/api/tests/devcomp/unit/domain/models/module/PassageEventWithElementAnswered_test.js
@@ -1,7 +1,8 @@
 import { PassageEventWithElementAnsweredInstantiationError } from '../../../../../../src/devcomp/domain/errors.js';
 import { PassageEventWithElementAnswered } from '../../../../../../src/devcomp/domain/models/passage-events/PassageEventWithElementAnswered.js';
 import { DomainError } from '../../../../../../src/shared/domain/errors.js';
-import { catchErrSync, expect } from '../../../../../test-helper.js';
+import { expect } from '../../../../../test-helper.js';
+import { catchErrSync } from '../../../../../tooling/test-utils/error.js';
 
 describe('Unit | Devcomp | Domain | Models | Module | PassageEventWithElementAnswered', function () {
   describe('#constructor', function () {

--- a/api/tests/devcomp/unit/domain/models/module/PassageEventWithElement_test.js
+++ b/api/tests/devcomp/unit/domain/models/module/PassageEventWithElement_test.js
@@ -1,7 +1,8 @@
 import { PassageEventWithElementInstantiationError } from '../../../../../../src/devcomp/domain/errors.js';
 import { PassageEventWithElement } from '../../../../../../src/devcomp/domain/models/passage-events/PassageEventWithElement.js';
 import { DomainError } from '../../../../../../src/shared/domain/errors.js';
-import { catchErrSync, expect } from '../../../../../test-helper.js';
+import { expect } from '../../../../../test-helper.js';
+import { catchErrSync } from '../../../../../tooling/test-utils/error.js';
 
 describe('Unit | Devcomp | Domain | Models | Module | PassageEventWithElement', function () {
   describe('#constructor', function () {

--- a/api/tests/devcomp/unit/domain/models/module/PassageEvent_test.js
+++ b/api/tests/devcomp/unit/domain/models/module/PassageEvent_test.js
@@ -1,7 +1,8 @@
 import { PassageEventInstantiationError } from '../../../../../../src/devcomp/domain/errors.js';
 import { PassageEvent } from '../../../../../../src/devcomp/domain/models/passage-events/PassageEvent.js';
 import { DomainError } from '../../../../../../src/shared/domain/errors.js';
-import { catchErrSync, expect } from '../../../../../test-helper.js';
+import { expect } from '../../../../../test-helper.js';
+import { catchErrSync } from '../../../../../tooling/test-utils/error.js';
 
 describe('Unit | Devcomp | Domain | Models | PassageEvent', function () {
   describe('#constructor', function () {

--- a/api/tests/devcomp/unit/domain/models/module/Section_test.js
+++ b/api/tests/devcomp/unit/domain/models/module/Section_test.js
@@ -1,7 +1,8 @@
 import { ModuleInstantiationError } from '../../../../../../src/devcomp/domain/errors.js';
 import { Section } from '../../../../../../src/devcomp/domain/models/module/Section.js';
 import { DomainError } from '../../../../../../src/shared/domain/errors.js';
-import { catchErrSync, expect } from '../../../../../test-helper.js';
+import { expect } from '../../../../../test-helper.js';
+import { catchErrSync } from '../../../../../tooling/test-utils/error.js';
 
 describe('Unit | Devcomp | Domain | Models | Module | Section', function () {
   describe('#constructor', function () {

--- a/api/tests/devcomp/unit/domain/models/module/UserModuleStatus_test.js
+++ b/api/tests/devcomp/unit/domain/models/module/UserModuleStatus_test.js
@@ -3,7 +3,8 @@ import dayjs from 'dayjs';
 import { UserModuleStatus } from '../../../../../../src/devcomp/domain/models/module/UserModuleStatus.js';
 import { Passage } from '../../../../../../src/devcomp/domain/models/Passage.js';
 import { DomainError } from '../../../../../../src/shared/domain/errors.js';
-import { catchErrSync, expect, sinon } from '../../../../../test-helper.js';
+import { expect, sinon } from '../../../../../test-helper.js';
+import { catchErrSync } from '../../../../../tooling/test-utils/error.js';
 
 describe('Unit | Devcomp | Domain | Models | Module | UserModuleStatus', function () {
   let userId, moduleId, passages;

--- a/api/tests/devcomp/unit/infrastructure/datasources/conversion/joi-to-json-schema_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/conversion/joi-to-json-schema_test.js
@@ -1,7 +1,8 @@
 import Joi from 'joi';
 
 import { convertJoiToJsonSchema } from '../../../../../../src/devcomp/infrastructure/datasources/conversion/joi-to-json-schema.js';
-import { catchErrSync, expect } from '../../../../../test-helper.js';
+import { expect } from '../../../../../test-helper.js';
+import { catchErrSync } from '../../../../../tooling/test-utils/error.js';
 
 describe('Unit | Infrastructure | Datasources | Conversion | joi-to-json-schema', function () {
   it('should throw if not Joi', function () {

--- a/api/tests/devcomp/unit/infrastructure/factories/element-for-verification-factory_test.js
+++ b/api/tests/devcomp/unit/infrastructure/factories/element-for-verification-factory_test.js
@@ -5,7 +5,8 @@ import { QCUForAnswerVerification } from '../../../../../src/devcomp/domain/mode
 import { QROCMForAnswerVerification } from '../../../../../src/devcomp/domain/models/element/QROCM-for-answer-verification.js';
 import { ElementForVerificationFactory } from '../../../../../src/devcomp/infrastructure/factories/element-for-verification-factory.js';
 import { logger } from '../../../../../src/shared/infrastructure/utils/logger.js';
-import { catchErrSync, expect, sinon } from '../../../../test-helper.js';
+import { expect, sinon } from '../../../../test-helper.js';
+import { catchErrSync } from '../../../../tooling/test-utils/error.js';
 
 describe('Unit | Devcomp | Infrastructure | Factories | ElementForVerification', function () {
   describe('#toDomain', function () {

--- a/api/tests/devcomp/unit/scripts/get-modules-csv_test.js
+++ b/api/tests/devcomp/unit/scripts/get-modules-csv_test.js
@@ -1,5 +1,6 @@
 import { _getTotalElementsCount } from '../../../../scripts/modulix/get-modules-csv.js';
-import { catchErrSync, expect } from '../../../test-helper.js';
+import { expect } from '../../../test-helper.js';
+import { catchErrSync } from '../../../tooling/test-utils/error.js';
 
 describe('Unit | Scripts | Get Modules as CSV', function () {
   describe('#getTotalElements', function () {

--- a/api/tests/evaluation/acceptance/application/assessments/assessment-controller_test.js
+++ b/api/tests/evaluation/acceptance/application/assessments/assessment-controller_test.js
@@ -28,8 +28,8 @@ import {
   learningContentBuilder,
   nock,
   sinon,
-  waitForStreamFinalizationToBeDone,
 } from '../../../../test-helper.js';
+import { waitForStreamFinalizationToBeDone } from '../../../../tooling/test-utils/wait.js';
 
 describe('Acceptance | Controller | assessment-controller', function () {
   let options;

--- a/api/tests/identity-access-management/unit/application/anonymization.admin.controller.test.js
+++ b/api/tests/identity-access-management/unit/application/anonymization.admin.controller.test.js
@@ -3,7 +3,8 @@ import { GarAnonymizationParser } from '../../../../src/identity-access-manageme
 import { usecases } from '../../../../src/identity-access-management/domain/usecases/index.js';
 import { anonymizeGarResultSerializer } from '../../../../src/identity-access-management/infrastructure/serializers/jsonapi/anonymize-gar-result.serializer.js';
 import { DomainTransaction } from '../../../../src/shared/domain/DomainTransaction.js';
-import { createTempFile, expect, hFake, sinon } from '../../../test-helper.js';
+import { expect, hFake, sinon } from '../../../test-helper.js';
+import { createTempFile } from '../../../tooling/test-utils/file.js';
 
 describe('Unit | Identity Access Management | Application | Controller | Admin | anonymization', function () {
   describe('anonymizeGarData', function () {

--- a/api/tests/identity-access-management/unit/domain/models/OrganizationLearnerIdentities.test.js
+++ b/api/tests/identity-access-management/unit/domain/models/OrganizationLearnerIdentities.test.js
@@ -1,6 +1,7 @@
 import { OrganizationLearnerNotBelongToOrganizationIdentityError } from '../../../../../src/identity-access-management/domain/errors.js';
 import { OrganizationLearnerIdentities } from '../../../../../src/identity-access-management/domain/models/OrganizationLearnerIdentities.js';
-import { catchErrSync, expect } from '../../../../test-helper.js';
+import { expect } from '../../../../test-helper.js';
+import { catchErrSync } from '../../../../tooling/test-utils/error.js';
 
 describe('Unit | Identity Access Management | Domain | Model | OrganizationIdentity', function () {
   describe('#constructor', function () {

--- a/api/tests/identity-access-management/unit/domain/services/oidc-authentication-service.test.js
+++ b/api/tests/identity-access-management/unit/domain/services/oidc-authentication-service.test.js
@@ -10,8 +10,9 @@ import { DomainTransaction } from '../../../../../src/shared/domain/DomainTransa
 import { OidcError, OidcMissingFieldsError } from '../../../../../src/shared/domain/errors.js';
 import { AuthenticationSessionContent } from '../../../../../src/shared/domain/models/AuthenticationSessionContent.js';
 import { logger } from '../../../../../src/shared/infrastructure/utils/logger.js';
-import { catchErr, catchErrSync, expect, sinon } from '../../../../test-helper.js';
+import { expect, sinon } from '../../../../test-helper.js';
 import { createOpenIdClientMock } from '../../../../tooling/mocks/openid-client.mock.js';
+import { catchErr, catchErrSync } from '../../../../tooling/test-utils/error.js';
 
 const uuidV4Regex = /^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i;
 

--- a/api/tests/identity-access-management/unit/domain/validators/add-oidc-provider.validator.test.js
+++ b/api/tests/identity-access-management/unit/domain/validators/add-oidc-provider.validator.test.js
@@ -1,6 +1,7 @@
 import { addOidcProviderValidator } from '../../../../../src/identity-access-management/domain/validators/add-oidc-provider.validator.js';
 import { EntityValidationError } from '../../../../../src/shared/domain/errors.js';
-import { catchErrSync, expect } from '../../../../test-helper.js';
+import { expect } from '../../../../test-helper.js';
+import { catchErrSync } from '../../../../tooling/test-utils/error.js';
 
 describe('Unit | Identity Access Management | Domain | Validator | AddOidcProvider', function () {
   context('when data is valid', function () {

--- a/api/tests/learning-content/unit/application/api/skills-api_test.js
+++ b/api/tests/learning-content/unit/application/api/skills-api_test.js
@@ -1,7 +1,8 @@
 import { SkillDTO } from '../../../../../src/learning-content/application/api/models/SkillDTO.js';
 import * as skillsApi from '../../../../../src/learning-content/application/api/skills-api.js';
 import { usecases } from '../../../../../src/learning-content/domain/usecases/index.js';
-import { domainBuilder, expect, preventStubsToBeCalledUnexpectedly, sinon } from '../../../../test-helper.js';
+import { domainBuilder, expect, sinon } from '../../../../test-helper.js';
+import { preventStubsToBeCalledUnexpectedly } from '../../../../tooling/test-utils/error.js';
 
 describe('LearningContent | Unit | Application | Api | skills', function () {
   describe('#findByIds', function () {

--- a/api/tests/llm/acceptance/application/llm-preview-route_test.js
+++ b/api/tests/llm/acceptance/application/llm-preview-route_test.js
@@ -8,8 +8,8 @@ import {
   generateValidRequestAuthorizationHeaderForApplication,
   knex,
   nock,
-  waitForStreamFinalizationToBeDone,
 } from '../../../test-helper.js';
+import { waitForStreamFinalizationToBeDone } from '../../../tooling/test-utils/wait.js';
 
 describe('Acceptance | Route | llm-preview', function () {
   let server;

--- a/api/tests/llm/integration/domain/usecases/prompt-chat_test.js
+++ b/api/tests/llm/integration/domain/usecases/prompt-chat_test.js
@@ -12,15 +12,8 @@ import { promptChat } from '../../../../../src/llm/domain/usecases/prompt-chat.j
 import { chatRepository, promptRepository } from '../../../../../src/llm/infrastructure/repositories/index.js';
 import { LLMResponseHandler } from '../../../../../src/llm/infrastructure/streaming/llm-response-handler.js';
 import { redisMutex } from '../../../../../src/shared/infrastructure/mutex/RedisMutex.js';
-import {
-  catchErr,
-  databaseBuilder,
-  expect,
-  knex,
-  nock,
-  sinon,
-  waitForStreamFinalizationToBeDone,
-} from '../../../../test-helper.js';
+import { catchErr, databaseBuilder, expect, knex, nock, sinon } from '../../../../test-helper.js';
+import { waitForStreamFinalizationToBeDone } from '../../../../tooling/test-utils/wait.js';
 
 describe('LLM | Integration | Domain | UseCases | prompt-chat', function () {
   let dependencies, chatId, llmResponseHandler, resultChunks;

--- a/api/tests/llm/integration/infrastructure/repositories/prompt-repository_test.js
+++ b/api/tests/llm/integration/infrastructure/repositories/prompt-repository_test.js
@@ -3,7 +3,8 @@ import { Readable } from 'node:stream';
 import { LLMApiError } from '../../../../../src/llm/domain/errors.js';
 import { Configuration } from '../../../../../src/llm/domain/models/Configuration.js';
 import { prompt } from '../../../../../src/llm/infrastructure/repositories/prompt-repository.js';
-import { catchErr, expect, nock, waitForStreamFinalizationToBeDone } from '../../../../test-helper.js';
+import { catchErr, expect, nock } from '../../../../test-helper.js';
+import { waitForStreamFinalizationToBeDone } from '../../../../tooling/test-utils/wait.js';
 
 describe('LLM | Integration | Infrastructure | Repositories | prompt-repository', function () {
   context('#prompt', function () {

--- a/api/tests/organizational-entities/integration/domain/usecases/add-organization-feature-in-batch.usecase.test.js
+++ b/api/tests/organizational-entities/integration/domain/usecases/add-organization-feature-in-batch.usecase.test.js
@@ -1,6 +1,7 @@
 import { usecases } from '../../../../../src/organizational-entities/domain/usecases/index.js';
 import { ORGANIZATION_FEATURE } from '../../../../../src/shared/domain/constants.js';
-import { createTempFile, databaseBuilder, expect, knex, removeTempFile, sinon } from '../../../../test-helper.js';
+import { databaseBuilder, expect, knex, sinon } from '../../../../test-helper.js';
+import { createTempFile, removeTempFile } from '../../../../tooling/test-utils/file.js';
 
 describe('Integration | Organizational Entities | Domain | UseCase | add-organization-feature-in-batch', function () {
   let learnerImportFeature,

--- a/api/tests/organizational-entities/integration/domain/usecases/update-organizations-in-batch.usecase.test.js
+++ b/api/tests/organizational-entities/integration/domain/usecases/update-organizations-in-batch.usecase.test.js
@@ -9,13 +9,14 @@ import {
 } from '../../../../../src/organizational-entities/domain/errors.js';
 import { usecases } from '../../../../../src/organizational-entities/domain/usecases/index.js';
 import { ORGANIZATION_FEATURE } from '../../../../../src/shared/domain/constants.js';
-import { catchErr, createTempFile, databaseBuilder, expect, knex, removeTempFile } from '../../../../test-helper.js';
+import { catchErr, databaseBuilder, expect, knex } from '../../../../test-helper.js';
+import { createTempFile, removeTempFile } from '../../../../tooling/test-utils/file.js';
 
 describe('Integration | Organizational Entities | Domain | UseCase | update-organizations-in-batch', function () {
   let filePath;
 
   afterEach(async function () {
-    if (filePath) await removeTempFile(filePath);
+    await removeTempFile(filePath);
   });
 
   context('when parsing a CSV file without organization', function () {

--- a/api/tests/organizational-entities/integration/domain/validators/organization-with-tags-and-target-profiles.test.js
+++ b/api/tests/organizational-entities/integration/domain/validators/organization-with-tags-and-target-profiles.test.js
@@ -2,7 +2,8 @@ import { Organization } from '../../../../../src/organizational-entities/domain/
 import { validate } from '../../../../../src/organizational-entities/domain/validators/organization-with-tags-and-target-profiles.js';
 import { EntityValidationError } from '../../../../../src/shared/domain/errors.js';
 import { getSupportedLocales } from '../../../../../src/shared/domain/services/locale-service.js';
-import { catchErrSync, expect } from '../../../../test-helper.js';
+import { expect } from '../../../../test-helper.js';
+import { catchErrSync } from '../../../../tooling/test-utils/error.js';
 
 const organizationTypes = [...Object.values(Organization.types)];
 const lowerCaseSupportedLocales = getSupportedLocales().map((supportedLocale) => supportedLocale.toLocaleLowerCase());

--- a/api/tests/organizational-entities/unit/domain/models/OrganizationFeature_test.js
+++ b/api/tests/organizational-entities/unit/domain/models/OrganizationFeature_test.js
@@ -1,7 +1,8 @@
 import { OrganizationFeature } from '../../../../../src/organizational-entities/domain/models/OrganizationFeature.js';
 import { ORGANIZATION_FEATURE } from '../../../../../src/shared/domain/constants.js';
 import { EntityValidationError } from '../../../../../src/shared/domain/errors.js';
-import { catchErrSync, expect } from '../../../../test-helper.js';
+import { expect } from '../../../../test-helper.js';
+import { catchErrSync } from '../../../../tooling/test-utils/error.js';
 
 describe('Unit | Organizational Entities | Domain | Model | OrganizationFeature', function () {
   let organizationFeature, featureName, organizationId, params, features;

--- a/api/tests/organizational-entities/unit/domain/usecases/update-organizations-in-batch.usecase.test.js
+++ b/api/tests/organizational-entities/unit/domain/usecases/update-organizations-in-batch.usecase.test.js
@@ -1,7 +1,8 @@
 import { OrganizationBatchUpdateError } from '../../../../../src/organizational-entities/domain/errors.js';
 import { updateOrganizationsInBatch } from '../../../../../src/organizational-entities/domain/usecases/update-organizations-in-batch.usecase.js';
 import { DomainTransaction } from '../../../../../src/shared/domain/DomainTransaction.js';
-import { catchErr, createTempFile, domainBuilder, expect, removeTempFile, sinon } from '../../../../test-helper.js';
+import { catchErr, domainBuilder, expect, sinon } from '../../../../test-helper.js';
+import { createTempFile, removeTempFile } from '../../../../tooling/test-utils/file.js';
 
 describe('Unit | Organizational Entities | Domain | UseCase | update-organizations-in-batch', function () {
   let filePath,
@@ -44,9 +45,7 @@ describe('Unit | Organizational Entities | Domain | UseCase | update-organizatio
   });
 
   afterEach(async function () {
-    if (filePath) {
-      await removeTempFile(filePath);
-    }
+    await removeTempFile(filePath);
   });
 
   context('when parsing a CSV file without organization', function () {

--- a/api/tests/organizational-entities/unit/infrastructure/parsers/csv/organization-tag-csv.parser.test.js
+++ b/api/tests/organizational-entities/unit/infrastructure/parsers/csv/organization-tag-csv.parser.test.js
@@ -1,7 +1,8 @@
 import { organizationTagCsvParser } from '../../../../../../src/organizational-entities/infrastructure/parsers/csv/organization-tag-csv.parser.js';
 import { ObjectValidationError } from '../../../../../../src/shared/domain/errors.js';
 import { CsvImportError } from '../../../../../../src/shared/domain/errors.js';
-import { catchErr, createTempFile, expect, removeTempFile } from '../../../../../test-helper.js';
+import { catchErr, expect } from '../../../../../test-helper.js';
+import { createTempFile, removeTempFile } from '../../../../../tooling/test-utils/file.js';
 
 const fileName = 'organizationTagCsvParser.test.csv';
 
@@ -9,9 +10,7 @@ describe('Unit | Organizational Entities | Domain | Service | organizationTagCsv
   let filePath;
 
   afterEach(async function () {
-    if (filePath) {
-      await removeTempFile(filePath);
-    }
+    await removeTempFile(filePath);
   });
 
   describe('when CSV file format is invalid: no header', function () {

--- a/api/tests/prescription/campaign/integration/infrastructure/serializer/csv-campaigns-ids-parser_test.js
+++ b/api/tests/prescription/campaign/integration/infrastructure/serializer/csv-campaigns-ids-parser_test.js
@@ -1,13 +1,14 @@
 import * as csvCampaignIdsParser from '../../../../../../src/prescription/campaign/infrastructure/serializers/csv/csv-campaigns-ids-parser.js';
 import { CsvImportError } from '../../../../../../src/shared/domain/errors.js';
-import { catchErr, createTempFile, expect, removeTempFile } from '../../../../../test-helper.js';
+import { catchErr, expect } from '../../../../../test-helper.js';
+import { createTempFile, removeTempFile } from '../../../../../tooling/test-utils/file.js';
 
 describe('Integration | Serializer | CSV | campaigns-administration | csv-campaigns-ids-parser', function () {
   describe('#extractCampaignsIds', function () {
     let file;
 
-    afterEach(function () {
-      removeTempFile(file);
+    afterEach(async function () {
+      await removeTempFile(file);
     });
 
     context('when the file is correctly parsed', function () {

--- a/api/tests/prescription/campaign/unit/application/api/campaigns-api_test.js
+++ b/api/tests/prescription/campaign/unit/application/api/campaigns-api_test.js
@@ -3,8 +3,9 @@ import { UserNotAuthorizedToCreateCampaignError } from '../../../../../../src/pr
 import { Campaign } from '../../../../../../src/prescription/campaign/domain/models/Campaign.js';
 import { CampaignReport } from '../../../../../../src/prescription/campaign/domain/read-models/CampaignReport.js';
 import { usecases } from '../../../../../../src/prescription/campaign/domain/usecases/index.js';
-import { catchErr, expect, preventStubsToBeCalledUnexpectedly, sinon } from '../../../../../test-helper.js';
+import { catchErr, expect, sinon } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
+import { preventStubsToBeCalledUnexpectedly } from '../../../../../tooling/test-utils/error.js';
 
 describe('Unit | API | Campaigns', function () {
   describe('#save', function () {

--- a/api/tests/prescription/learner-management/unit/domain/models/OrganizationLearnerList_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/models/OrganizationLearnerList_test.js
@@ -1,7 +1,8 @@
 import { CouldNotDeleteLearnersError } from '../../../../../../src/prescription/learner-management/domain/errors.js';
 import { OrganizationLearnerList } from '../../../../../../src/prescription/learner-management/domain/models/OrganizationLearnerList.js';
 import { logger } from '../../../../../../src/shared/infrastructure/utils/logger.js';
-import { catchErrSync, expect, sinon } from '../../../../../test-helper.js';
+import { expect, sinon } from '../../../../../test-helper.js';
+import { catchErrSync } from '../../../../../tooling/test-utils/error.js';
 
 describe('Unit | Models | OrganizationLearnerListFormat', function () {
   describe('#constructor', function () {

--- a/api/tests/prescription/learner-management/unit/domain/usecases/upload-csv-file_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/usecases/upload-csv-file_test.js
@@ -7,7 +7,8 @@ import { SupOrganizationLearnerImportHeader } from '../../../../../../src/prescr
 import { SupOrganizationLearnerParser } from '../../../../../../src/prescription/learner-management/infrastructure/serializers/csv/sup-organization-learner-parser.js';
 import { DomainTransaction } from '../../../../../../src/shared/domain/DomainTransaction.js';
 import { getI18n } from '../../../../../../src/shared/infrastructure/i18n/i18n.js';
-import { catchErr, createTempFile, expect, removeTempFile, sinon } from '../../../../../test-helper.js';
+import { catchErr, expect, sinon } from '../../../../../test-helper.js';
+import { createTempFile, removeTempFile } from '../../../../../tooling/test-utils/file.js';
 
 const i18n = getI18n();
 

--- a/api/tests/prescription/organization-learner/acceptance/application/organization-learners-route_test.js
+++ b/api/tests/prescription/organization-learner/acceptance/application/organization-learners-route_test.js
@@ -7,8 +7,8 @@ import {
   datamartBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
-  mockAttestationStorage,
 } from '../../../../test-helper.js';
+import { mockAttestationStorage } from '../../../../tooling/mocks/attestation-storage.mock.js';
 
 describe('Prescription | Organization Learner | Acceptance | Application | OrganizationLearnerRoute', function () {
   let server;

--- a/api/tests/prescription/organization-learner/integration/domain/usecases/find-paginated-filtered-attestation-participants-status_test.js
+++ b/api/tests/prescription/organization-learner/integration/domain/usecases/find-paginated-filtered-attestation-participants-status_test.js
@@ -1,6 +1,7 @@
 import { AttestationParticipantStatus } from '../../../../../../src/prescription/organization-learner/domain/read-models/AttestationParticipantStatus.js';
 import { usecases } from '../../../../../../src/prescription/organization-learner/domain/usecases/index.js';
-import { databaseBuilder, expect, mockAttestationStorage } from '../../../../../test-helper.js';
+import { databaseBuilder, expect } from '../../../../../test-helper.js';
+import { mockAttestationStorage } from '../../../../../tooling/mocks/attestation-storage.mock.js';
 
 describe('Integration | Prescription | Learner Management | Domain | UseCase | find-paginated-filtered-attestation-participant-status', function () {
   let attestation, organizationId, firstLearner, secondLearner;

--- a/api/tests/prescription/organization-learner/integration/domain/usecases/get-attestation-pdf-from-filters_test.js
+++ b/api/tests/prescription/organization-learner/integration/domain/usecases/get-attestation-pdf-from-filters_test.js
@@ -1,5 +1,6 @@
 import { usecases } from '../../../../../../src/prescription/organization-learner/domain/usecases/index.js';
-import { databaseBuilder, expect, mockAttestationStorage } from '../../../../../test-helper.js';
+import { databaseBuilder, expect } from '../../../../../test-helper.js';
+import { mockAttestationStorage } from '../../../../../tooling/mocks/attestation-storage.mock.js';
 
 describe('Integration | Prescription | Learner Management | Domain | UseCase | get-attestation-zip-for-divisions', function () {
   it('returns a pdf attestation', async function () {

--- a/api/tests/prescription/organization-learner/integration/infrastructure/repositories/organization-learner-repository_test.js
+++ b/api/tests/prescription/organization-learner/integration/infrastructure/repositories/organization-learner-repository_test.js
@@ -4,7 +4,8 @@ import { OrganizationLearner } from '../../../../../../src/prescription/organiza
 import { repositories } from '../../../../../../src/prescription/organization-learner/infrastructure/repositories/index.js';
 import { User } from '../../../../../../src/profile/domain/models/User.js';
 import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
-import { catchErr, databaseBuilder, expect, mockAttestationStorage } from '../../../../../test-helper.js';
+import { catchErr, databaseBuilder, expect } from '../../../../../test-helper.js';
+import { mockAttestationStorage } from '../../../../../tooling/mocks/attestation-storage.mock.js';
 
 const { organizationLearnerRepository } = repositories;
 

--- a/api/tests/prescription/target-profile/acceptance/application/admin-target-profile-route_test.js
+++ b/api/tests/prescription/target-profile/acceptance/application/admin-target-profile-route_test.js
@@ -6,7 +6,7 @@ import {
   generateAuthenticatedUserRequestHeaders,
   knex,
   learningContentBuilder,
-  MockDate,
+  sinon,
 } from '../../../../test-helper.js';
 
 describe('Acceptance | TargetProfile | Application | Route | admin-target-profile', function () {
@@ -274,7 +274,7 @@ describe('Acceptance | TargetProfile | Application | Route | admin-target-profil
     let targetProfileId;
 
     beforeEach(async function () {
-      MockDate.set(new Date('2020-11-01'));
+      sinon.useFakeTimers({ now: new Date('2020-11-01'), toFake: ['Date'] });
 
       const learningContent = learningContentBuilder([
         {
@@ -385,10 +385,6 @@ describe('Acceptance | TargetProfile | Application | Route | admin-target-profil
       databaseBuilder.factory.buildTargetProfileTube({ targetProfileId, tubeId: 'recTube2', level: 2 });
       user = databaseBuilder.factory.buildUser.withRole();
       return databaseBuilder.commit();
-    });
-
-    afterEach(function () {
-      MockDate.reset();
     });
 
     describe('GET /api/admin/target-profiles/{id}/content-json', function () {

--- a/api/tests/prescription/target-profile/integration/application/presenter/pdf/learning-content-pdf-presenter_test.js
+++ b/api/tests/prescription/target-profile/integration/application/presenter/pdf/learning-content-pdf-presenter_test.js
@@ -4,7 +4,8 @@ import * as url from 'node:url';
 import pdfLibUtils from 'pdf-lib/cjs/utils/index.js';
 
 import * as learningContentPDFPresenter from '../../../../../../../src/prescription/target-profile/application/presenter/pdf/learning-content-pdf-presenter.js';
-import { domainBuilder, expect, isSameBinary, MockDate, sinon } from '../../../../../../test-helper.js';
+import { domainBuilder, expect, MockDate, sinon } from '../../../../../../test-helper.js';
+import { isSameBinary } from '../../../../../../tooling/test-utils/file.js';
 
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
 

--- a/api/tests/prescription/target-profile/integration/application/presenter/pdf/learning-content-pdf-presenter_test.js
+++ b/api/tests/prescription/target-profile/integration/application/presenter/pdf/learning-content-pdf-presenter_test.js
@@ -4,7 +4,7 @@ import * as url from 'node:url';
 import pdfLibUtils from 'pdf-lib/cjs/utils/index.js';
 
 import * as learningContentPDFPresenter from '../../../../../../../src/prescription/target-profile/application/presenter/pdf/learning-content-pdf-presenter.js';
-import { domainBuilder, expect, MockDate, sinon } from '../../../../../../test-helper.js';
+import { domainBuilder, expect, sinon } from '../../../../../../test-helper.js';
 import { isSameBinary } from '../../../../../../tooling/test-utils/file.js';
 
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
@@ -16,11 +16,7 @@ describe('Integration | Application | Target-Profiles | Presenter | PDF | Learni
 
   beforeEach(function () {
     _makePdfLibPredictable();
-    MockDate.set(new Date('2020-12-01'));
-  });
-
-  afterEach(function () {
-    MockDate.reset();
+    sinon.useFakeTimers({ now: new Date('2020-12-01'), toFake: ['Date'] });
   });
 
   it('should generate full learning content PDF in french (non-regression test)', async function () {

--- a/api/tests/prescription/target-profile/unit/domain/usecases/get-target-profile-content-as-json_test.js
+++ b/api/tests/prescription/target-profile/unit/domain/usecases/get-target-profile-content-as-json_test.js
@@ -1,5 +1,5 @@
 import { getTargetProfileContentAsJson } from '../../../../../../src/prescription/target-profile/domain/usecases/get-target-profile-content-as-json.js';
-import { domainBuilder, expect, MockDate, sinon } from '../../../../../test-helper.js';
+import { domainBuilder, expect, sinon } from '../../../../../test-helper.js';
 
 describe('Unit | UseCase | get-target-profile-content-as-json', function () {
   let targetProfileAdministrationRepository;
@@ -9,13 +9,10 @@ describe('Unit | UseCase | get-target-profile-content-as-json', function () {
     learningContentConversionService = { findActiveSkillsForCappedTubes: sinon.stub() };
   });
 
-  afterEach(function () {
-    MockDate.reset();
-  });
-
   context('when the user has the authorization to get the content', function () {
     beforeEach(function () {
-      MockDate.set(new Date('2020-12-01'));
+      sinon.useFakeTimers({ now: new Date('2020-12-01'), toFake: ['Date'] });
+
       const area = domainBuilder.buildArea({ id: 'recArea', frameworkId: 'recFramework' });
       const targetProfileForAdmin = domainBuilder.buildTargetProfileForAdmin({
         name: 'Profil Rentrée scolaire',

--- a/api/tests/profile/acceptance/application/attestation-route_test.js
+++ b/api/tests/profile/acceptance/application/attestation-route_test.js
@@ -3,8 +3,8 @@ import {
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
-  mockAttestationStorage,
 } from '../../../test-helper.js';
+import { mockAttestationStorage } from '../../../tooling/mocks/attestation-storage.mock.js';
 
 describe('Profile | Acceptance | Application | Attestation Route ', function () {
   let server;

--- a/api/tests/profile/integration/domain/usecases/get-attestation-data-for-users_test.js
+++ b/api/tests/profile/integration/domain/usecases/get-attestation-data-for-users_test.js
@@ -2,7 +2,8 @@ import { AttestationNotFoundError } from '../../../../../src/profile/domain/erro
 import { User } from '../../../../../src/profile/domain/models/User.js';
 import { usecases } from '../../../../../src/profile/domain/usecases/index.js';
 import { normalizeAndRemoveAccents } from '../../../../../src/shared/infrastructure/utils/string-utils.js';
-import { catchErr, databaseBuilder, expect, mockAttestationStorage, sinon } from '../../../../test-helper.js';
+import { catchErr, databaseBuilder, expect, sinon } from '../../../../test-helper.js';
+import { mockAttestationStorage } from '../../../../tooling/mocks/attestation-storage.mock.js';
 
 describe('Profile | Integration | Domain | get-attestation-data-for-users', function () {
   let clock;

--- a/api/tests/profile/integration/domain/usecases/get-shared-attestations-for-organization-by-user-ids_test.js
+++ b/api/tests/profile/integration/domain/usecases/get-shared-attestations-for-organization-by-user-ids_test.js
@@ -2,17 +2,15 @@ import { AttestationNotFoundError, NoProfileRewardsFoundError } from '../../../.
 import { User } from '../../../../../src/profile/domain/models/User.js';
 import { usecases } from '../../../../../src/profile/domain/usecases/index.js';
 import { normalizeAndRemoveAccents } from '../../../../../src/shared/infrastructure/utils/string-utils.js';
-import { catchErr, databaseBuilder, expect, mockAttestationStorage, sinon } from '../../../../test-helper.js';
+import { catchErr, databaseBuilder, expect, sinon } from '../../../../test-helper.js';
+import { mockAttestationStorage } from '../../../../tooling/mocks/attestation-storage.mock.js';
 
 describe('Profile | Integration | Domain | get-shared-attestations-for-organization-by-user-ids', function () {
   let clock;
   const now = new Date('2022-12-25');
 
   beforeEach(function () {
-    clock = sinon.useFakeTimers({
-      now,
-      toFake: ['Date'],
-    });
+    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
   });
 
   afterEach(async function () {

--- a/api/tests/profile/integration/infrastructure/serializers/pdf/pdf-with-form-serializer_test.js
+++ b/api/tests/profile/integration/infrastructure/serializers/pdf/pdf-with-form-serializer_test.js
@@ -5,7 +5,8 @@ import * as url from 'node:url';
 import { PDFDocument } from 'pdf-lib';
 
 import { serializeStream } from '../../../../../../src/profile/infrastructure/serializers/pdf/pdf-with-form-serializer.js';
-import { expect, isSameBinary } from '../../../../../test-helper.js';
+import { expect } from '../../../../../test-helper.js';
+import { isSameBinary } from '../../../../../tooling/test-utils/file.js';
 
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
 

--- a/api/tests/quest/acceptance/application/attestation-route_test.js
+++ b/api/tests/quest/acceptance/application/attestation-route_test.js
@@ -8,9 +8,9 @@ import {
   expect,
   generateAuthenticatedUserRequestHeaders,
   knex,
-  mockAttestationStorageUpload,
 } from '../../../test-helper.js';
 import { AttestationTemplateFixture } from '../../../tooling/fixtures/index.js';
+import { mockAttestationStorageUpload } from '../../../tooling/mocks/attestation-storage.mock.js';
 
 describe('Quest | Acceptance | Application | Attestation Route ', function () {
   let server;

--- a/api/tests/quest/integration/domain/usecases/create-attestation_test.js
+++ b/api/tests/quest/integration/domain/usecases/create-attestation_test.js
@@ -1,6 +1,7 @@
 import { usecases } from '../../../../../src/quest/domain/usecases/index.js';
-import { expect, knex, mockAttestationStorageUpload } from '../../../../test-helper.js';
+import { expect, knex } from '../../../../test-helper.js';
 import { AttestationTemplateFixture } from '../../../../tooling/fixtures/index.js';
+import { mockAttestationStorageUpload } from '../../../../tooling/mocks/attestation-storage.mock.js';
 
 describe('Integration | Attestation | Domain | UseCases | create-attestation', function () {
   it('should create an attestation', async function () {

--- a/api/tests/quest/integration/domain/usecases/create-or-update-quests-in-batch_test.js
+++ b/api/tests/quest/integration/domain/usecases/create-or-update-quests-in-batch_test.js
@@ -1,7 +1,8 @@
 import { Quest } from '../../../../../src/quest/domain/models/Quest.js';
 import { usecases } from '../../../../../src/quest/domain/usecases/index.js';
 import { repositories } from '../../../../../src/quest/infrastructure/repositories/index.js';
-import { createTempFile, databaseBuilder, expect, removeTempFile, sinon } from '../../../../test-helper.js';
+import { databaseBuilder, expect, sinon } from '../../../../test-helper.js';
+import { createTempFile, removeTempFile } from '../../../../tooling/test-utils/file.js';
 
 describe('Integration | Quest | Domain | UseCases | create-or-update-quests-in-batch', function () {
   let filePath;

--- a/api/tests/quest/integration/infrastructure/repositories/attestation-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/attestation-repository_test.js
@@ -4,8 +4,9 @@ import { AttestationStorage } from '../../../../../src/quest/infrastructure/stor
 import { ORGANIZATION_FEATURE } from '../../../../../src/shared/domain/constants.js';
 import { AlreadyExistingEntityError } from '../../../../../src/shared/domain/errors.js';
 import { S3UploadError } from '../../../../../src/shared/domain/errors.js';
-import { catchErr, databaseBuilder, expect, knex, mockAttestationStorageUpload } from '../../../../test-helper.js';
+import { catchErr, databaseBuilder, expect, knex } from '../../../../test-helper.js';
 import { AttestationTemplateFixture } from '../../../../tooling/fixtures/index.js';
+import { mockAttestationStorageUpload } from '../../../../tooling/mocks/attestation-storage.mock.js';
 
 describe('Quest | Integration | Repository | attestation', function () {
   describe('#save', function () {

--- a/api/tests/quest/unit/infrastructure/repositories/success-repository_test.js
+++ b/api/tests/quest/unit/infrastructure/repositories/success-repository_test.js
@@ -2,7 +2,8 @@ import sinon from 'sinon';
 
 import { Success } from '../../../../../src/quest/domain/models/Success.js';
 import * as successRepository from '../../../../../src/quest/infrastructure/repositories/success-repository.js';
-import { expect, preventStubsToBeCalledUnexpectedly } from '../../../../test-helper.js';
+import { expect } from '../../../../test-helper.js';
+import { preventStubsToBeCalledUnexpectedly } from '../../../../tooling/test-utils/error.js';
 
 describe('Quest | Unit | Infrastructure | repositories | success', function () {
   describe('#find', function () {

--- a/api/tests/school/unit/domain/models/Mission_test.js
+++ b/api/tests/school/unit/domain/models/Mission_test.js
@@ -1,6 +1,7 @@
 import { Activity } from '../../../../../src/school/domain/models/Activity.js';
 import { ActivityInfo } from '../../../../../src/school/domain/models/ActivityInfo.js';
-import { catchErrSync, domainBuilder, expect } from '../../../../test-helper.js';
+import { domainBuilder, expect } from '../../../../test-helper.js';
+import { catchErrSync } from '../../../../tooling/test-utils/error.js';
 
 describe('Unit | Domain | School', function () {
   describe('#getChallengeId', function () {

--- a/api/tests/shared/integration/infrastructure/mutex/RedisMutex_test.js
+++ b/api/tests/shared/integration/infrastructure/mutex/RedisMutex_test.js
@@ -1,5 +1,6 @@
 import { redisMutex } from '../../../../../src/shared/infrastructure/mutex/RedisMutex.js';
-import { expect, wait } from '../../../../test-helper.js';
+import { expect } from '../../../../test-helper.js';
+import { wait } from '../../../../tooling/test-utils/wait.js';
 
 describe('Shared | Integration | Infrastructure | Mutex | RedisMutex', function () {
   describe('#lock', function () {

--- a/api/tests/shared/integration/infrastructure/repositories/jobs/job-repository_test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/jobs/job-repository_test.js
@@ -11,7 +11,8 @@ import {
   JobRepository,
   JobRetry,
 } from '../../../../../../src/shared/infrastructure/repositories/jobs/job-repository.js';
-import { catchErrSync, expect } from '../../../../../test-helper.js';
+import { expect } from '../../../../../test-helper.js';
+import { catchErrSync } from '../../../../../tooling/test-utils/error.js';
 
 describe('Integration | Infrastructure | Repositories | Jobs | job-repository', function () {
   it('create one job db with given config', async function () {

--- a/api/tests/shared/unit/application/domain-error-mapper_test.js
+++ b/api/tests/shared/unit/application/domain-error-mapper_test.js
@@ -2,7 +2,8 @@ import { DomainErrorMapper } from '../../../../src/shared/application/domain-err
 import { BaseHttpError, HttpErrors } from '../../../../src/shared/application/http-errors.js';
 import { config } from '../../../../src/shared/config.js';
 import { DomainError } from '../../../../src/shared/domain/errors.js';
-import { catchErrSync, expect, sinon } from '../../../test-helper.js';
+import { expect, sinon } from '../../../test-helper.js';
+import { catchErrSync } from '../../../tooling/test-utils/error.js';
 
 class DomainErrorName extends DomainError {}
 class DomainErrorNameWithMeta extends DomainError {

--- a/api/tests/shared/unit/application/jobs/job-controller_test.js
+++ b/api/tests/shared/unit/application/jobs/job-controller_test.js
@@ -1,7 +1,8 @@
 import { checkJobGroups, JobController, JobGroup } from '../../../../../src/shared/application/jobs/job-controller.js';
 import { EntityValidationError } from '../../../../../src/shared/domain/errors.js';
 import { JobExpireIn } from '../../../../../src/shared/infrastructure/repositories/jobs/job-repository.js';
-import { catchErr, catchErrSync, expect } from '../../../../test-helper.js';
+import { expect } from '../../../../test-helper.js';
+import { catchErr, catchErrSync } from '../../../../tooling/test-utils/error.js';
 
 describe('Unit | Shared | Application | Jobs | JobController', function () {
   it('should require a job name', async function () {

--- a/api/tests/shared/unit/application/scripts/script_test.js
+++ b/api/tests/shared/unit/application/scripts/script_test.js
@@ -1,5 +1,6 @@
 import { Script } from '../../../../../src/shared/application/scripts/script.js';
-import { catchErr, catchErrSync, expect, sinon } from '../../../../test-helper.js';
+import { expect, sinon } from '../../../../test-helper.js';
+import { catchErr, catchErrSync } from '../../../../tooling/test-utils/error.js';
 
 describe('Shared | Unit | Application | Script', function () {
   it('must be implemented with meta information', function () {

--- a/api/tests/shared/unit/domain/models/Assessment_test.js
+++ b/api/tests/shared/unit/domain/models/Assessment_test.js
@@ -5,7 +5,8 @@ import { CertificationAssessment } from '../../../../../src/shared/domain/read-m
 import { CompetenceEvaluationAssessment } from '../../../../../src/shared/domain/read-models/CompetenceEvaluationAssessment.js';
 import { DemoAssessment } from '../../../../../src/shared/domain/read-models/DemoAssessment.js';
 import { PreviewAssessment } from '../../../../../src/shared/domain/read-models/PreviewAssessment.js';
-import { catchErrSync, domainBuilder, expect, sinon } from '../../../../test-helper.js';
+import { domainBuilder, expect, sinon } from '../../../../test-helper.js';
+import { catchErrSync } from '../../../../tooling/test-utils/error.js';
 
 describe('Unit | Domain | Models | Assessment', function () {
   describe('#constructor', function () {

--- a/api/tests/shared/unit/domain/models/asserts_test.js
+++ b/api/tests/shared/unit/domain/models/asserts_test.js
@@ -7,7 +7,8 @@ import {
   assertNotNullOrUndefined,
   assertPositiveInteger,
 } from '../../../../../src/shared/domain/models/asserts.js';
-import { catchErrSync, expect } from '../../../../test-helper.js';
+import { expect } from '../../../../test-helper.js';
+import { catchErrSync } from '../../../../tooling/test-utils/error.js';
 
 describe('Unit | Shared | Models | asserts', function () {
   describe('#assertNotNullOrUndefined', function () {

--- a/api/tests/shared/unit/domain/usecases/update-assessment-with-next-challenge_test.js
+++ b/api/tests/shared/unit/domain/usecases/update-assessment-with-next-challenge_test.js
@@ -7,7 +7,8 @@ import {
 } from '../../../../../src/shared/domain/errors.js';
 import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
 import { updateAssessmentWithNextChallenge } from '../../../../../src/shared/domain/usecases/update-assessment-with-next-challenge.js';
-import { catchErr, domainBuilder, expect, preventStubsToBeCalledUnexpectedly, sinon } from '../../../../test-helper.js';
+import { catchErr, domainBuilder, expect, sinon } from '../../../../test-helper.js';
+import { preventStubsToBeCalledUnexpectedly } from '../../../../tooling/test-utils/error.js';
 
 describe('Shared | Unit | Domain | Use Cases | get-next-challenge', function () {
   describe('#getNextChallenge', function () {

--- a/api/tests/shared/unit/infrastructure/serializers/csv/csv-parser_test.js
+++ b/api/tests/shared/unit/infrastructure/serializers/csv/csv-parser_test.js
@@ -2,7 +2,8 @@ import iconv from 'iconv-lite';
 
 import { CsvColumn } from '../../../../../../src/shared/infrastructure/serializers/csv/csv-column.js';
 import { CsvParser } from '../../../../../../src/shared/infrastructure/serializers/csv/csv-parser.js';
-import { catchErr, catchErrSync, expect } from '../../../../../test-helper.js';
+import { expect } from '../../../../../test-helper.js';
+import { catchErr, catchErrSync } from '../../../../../tooling/test-utils/error.js';
 
 describe('Unit | Shared | Infrastructure | Serializer | CsvParser', function () {
   context('The header is correctly formed', function () {

--- a/api/tests/shared/unit/infrastructure/serializers/jsonapi/assessment-serializer_test.js
+++ b/api/tests/shared/unit/infrastructure/serializers/jsonapi/assessment-serializer_test.js
@@ -5,7 +5,8 @@ import { CampaignAssessment } from '../../../../../../src/shared/domain/read-mod
 import { CertificationAssessment } from '../../../../../../src/shared/domain/read-models/CertificationAssessment.js';
 import { CompetenceEvaluationAssessment } from '../../../../../../src/shared/domain/read-models/CompetenceEvaluationAssessment.js';
 import * as serializer from '../../../../../../src/shared/infrastructure/serializers/jsonapi/assessment-serializer.js';
-import { catchErrSync, domainBuilder, expect } from '../../../../../test-helper.js';
+import { domainBuilder, expect } from '../../../../../test-helper.js';
+import { catchErrSync } from '../../../../../tooling/test-utils/error.js';
 
 describe('Unit | Serializer | JSONAPI | assessment-serializer', function () {
   describe('#serialize', function () {

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -5,7 +5,6 @@ import chaiAsPromised from 'chai-as-promised';
 import chaiSorted from 'chai-sorted';
 import dayjs from 'dayjs';
 import localizedFormat from 'dayjs/plugin/localizedFormat.js';
-import MockDate from 'mockdate';
 import nock from 'nock';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
@@ -136,7 +135,6 @@ export {
   HttpTestServer,
   knex,
   learningContentBuilder,
-  MockDate,
   nock,
   sinon,
 };

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -44,7 +44,6 @@ import {
   generateInjectOptions,
   generateValidRequestAuthorizationHeaderForApplication,
 } from './tooling/test-utils/http-server.js';
-import { wait, waitForStreamFinalizationToBeDone } from './tooling/test-utils/wait.js';
 
 // Init Dayjs configuration
 dayjs.extend(localizedFormat);
@@ -145,6 +144,4 @@ export {
   nock,
   preventStubsToBeCalledUnexpectedly,
   sinon,
-  wait,
-  waitForStreamFinalizationToBeDone,
 };

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -38,7 +38,7 @@ import { increaseCurrentTestTimeout } from './tooling/mocha-tools.js';
 import { mockAttestationStorage, mockAttestationStorageUpload } from './tooling/mocks/attestation-storage.mock.js';
 import { hFake } from './tooling/mocks/hapi.mock.js';
 import { HttpTestServer } from './tooling/server/http-test-server.js';
-import { catchErr, catchErrSync, preventStubsToBeCalledUnexpectedly } from './tooling/test-utils/error.js';
+import { catchErr } from './tooling/test-utils/error.js';
 import {
   generateAuthenticatedUserRequestHeaders,
   generateInjectOptions,
@@ -122,7 +122,6 @@ after(async function () {
 // eslint-disable-next-line mocha/no-exports
 export {
   catchErr,
-  catchErrSync,
   createMaddoServer,
   createServer,
   databaseBuilder,
@@ -142,6 +141,5 @@ export {
   mockAttestationStorageUpload,
   MockDate,
   nock,
-  preventStubsToBeCalledUnexpectedly,
   sinon,
 };

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -35,7 +35,6 @@ import { jobChai } from './tooling/chai-custom-helpers/jobs/expect-job.js';
 import * as domainBuilder from './tooling/domain-builder/factory/index.js';
 import { buildLearningContent as learningContentBuilder } from './tooling/learning-content-builder/index.js';
 import { increaseCurrentTestTimeout } from './tooling/mocha-tools.js';
-import { mockAttestationStorage, mockAttestationStorageUpload } from './tooling/mocks/attestation-storage.mock.js';
 import { hFake } from './tooling/mocks/hapi.mock.js';
 import { HttpTestServer } from './tooling/server/http-test-server.js';
 import { catchErr } from './tooling/test-utils/error.js';
@@ -137,8 +136,6 @@ export {
   HttpTestServer,
   knex,
   learningContentBuilder,
-  mockAttestationStorage,
-  mockAttestationStorageUpload,
   MockDate,
   nock,
   sinon,

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -44,7 +44,6 @@ import {
   generateInjectOptions,
   generateValidRequestAuthorizationHeaderForApplication,
 } from './tooling/test-utils/http-server.js';
-import { parseNDJSON } from './tooling/test-utils/json.js';
 import { wait, waitForStreamFinalizationToBeDone } from './tooling/test-utils/wait.js';
 
 // Init Dayjs configuration
@@ -144,7 +143,6 @@ export {
   mockAttestationStorageUpload,
   MockDate,
   nock,
-  parseNDJSON,
   preventStubsToBeCalledUnexpectedly,
   sinon,
   wait,

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -39,7 +39,6 @@ import { mockAttestationStorage, mockAttestationStorageUpload } from './tooling/
 import { hFake } from './tooling/mocks/hapi.mock.js';
 import { HttpTestServer } from './tooling/server/http-test-server.js';
 import { catchErr, catchErrSync, preventStubsToBeCalledUnexpectedly } from './tooling/test-utils/error.js';
-import { createTempFile, isSameBinary, removeTempFile } from './tooling/test-utils/file.js';
 import {
   generateAuthenticatedUserRequestHeaders,
   generateInjectOptions,
@@ -128,7 +127,6 @@ export {
   catchErrSync,
   createMaddoServer,
   createServer,
-  createTempFile,
   databaseBuilder,
   datamartBuilder,
   datamartKnex,
@@ -140,7 +138,6 @@ export {
   generateValidRequestAuthorizationHeaderForApplication,
   hFake,
   HttpTestServer,
-  isSameBinary,
   knex,
   learningContentBuilder,
   mockAttestationStorage,
@@ -149,7 +146,6 @@ export {
   nock,
   parseNDJSON,
   preventStubsToBeCalledUnexpectedly,
-  removeTempFile,
   sinon,
   wait,
   waitForStreamFinalizationToBeDone,

--- a/api/tests/tooling/test-utils/file.js
+++ b/api/tests/tooling/test-utils/file.js
@@ -15,6 +15,7 @@ export async function createTempFile(file, data) {
 }
 
 export async function removeTempFile(filePath) {
+  if (!filePath) return;
   return (
     fs
       .access(filePath)

--- a/api/tests/unit/tooling/mocks/security-pre-handlers_test.js
+++ b/api/tests/unit/tooling/mocks/security-pre-handlers_test.js
@@ -1,6 +1,7 @@
 import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
-import { catchErrSync, expect, hFake, sinon } from '../../../test-helper.js';
+import { expect, hFake, sinon } from '../../../test-helper.js';
 import { getAdminRoleStub } from '../../../tooling/mocks/security-pre-handlers.mock.js';
+import { catchErrSync } from '../../../tooling/test-utils/error.js';
 
 describe('Unit | Tooling | Mocks | SecurityPreHandlersHelpers', function () {
   describe('#getAdminRoleStub', function () {


### PR DESCRIPTION
## 🌱 Problème

Pour la suite de la simplification du fichier `test-helper.js`, commencer à ne plus proxifier certains utilitaires depuis `test-helper.js`.

## 🐣 Proposition

- Utiliser directement `tooling/test-utils/file.js` dans les tests
- Utiliser directement `tooling/test-utils/json.js` dans les tests
- Utiliser directement `tooling/test-utils/wait.js` dans les tests
- Utiliser directement `tooling/test-utils/error.js` dans les tests (sauf `catchErr` pour le moment)
- Utiliser directement `tooling/mocks/attestation-storage.mock.js` dans les tests

## 🌷 Remarques

La librarie `MockDate` a été supprimée et replacée par l'utilisation de `sinon.useFakeTimers`

## 🐝 Pour tester

La CI doit passer.
