### PR TITLE
[FEATURE] Modifier la formulation d'organisation parente (PIX-22430)

### DIFF
--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -864,7 +864,7 @@
             "placeholder": "Sélectionner un public prescrit"
           }
         },
-        "parent-organization-name": "Organisation mère : {parentOrganizationName}",
+        "parent-organization-name": "Organisation parente : {parentOrganizationName}",
         "province-code": "Département (en 3 chiffres)",
         "type": {
           "label": "Type de l'organisation",


### PR DESCRIPTION
## 🌱 Problème

Sur le formulaire de création d'organisation fille, on ne veut plus de la formulation **Organisation mère**.

## 🐣 Proposition

Changer la formulation **Organisation mère** en **Organisation parente**.

## 🌷 Remarques

RAS

## 🐝 Pour tester
Sur Pix Admin, connecté en super admin:
- aller sur la page d'une organisation faisant partie d'un réseau
- sur l'onglet _Réseau_, cliquer sur **Créer une organisation fille**
- constater que le nom de l'organisation parente est maintenant précédé de la nouvelle formulation