### PR TITLE
[BUGFIX] Initialise le JobClient dans un script qui utilise un job pgboss (PIX-22454)

### DIFF
--- a/api/scripts/prod/delete-and-anonymise-combined-courses.js
+++ b/api/scripts/prod/delete-and-anonymise-combined-courses.js
@@ -1,8 +1,10 @@
 import { usecases } from '../../src/quest/domain/usecases/index.js';
+import { JobGroup } from '../../src/shared/application/jobs/job-controller.js';
 import { commaSeparatedNumberParser } from '../../src/shared/application/scripts/parsers.js';
 import { Script } from '../../src/shared/application/scripts/script.js';
 import { ScriptRunner } from '../../src/shared/application/scripts/script-runner.js';
 import { DomainTransaction } from '../../src/shared/domain/DomainTransaction.js';
+import { JobClient } from '../../src/shared/infrastructure/jobs/JobClient.js';
 
 // Définition du script
 export class DeleteAndAnonymiseCombinedCoursesScript extends Script {
@@ -25,18 +27,25 @@ export class DeleteAndAnonymiseCombinedCoursesScript extends Script {
     });
   }
 
-  async handle({ options, logger, dependencies = usecases }) {
+  async handle({ options, logger, dependencies = { usecases, jobClient: JobClient.instance } }) {
     logger.info(
       { event: 'DeleteAndAnonymizeCombinedCoursesScript' },
       `Deletes ${options.combinedCourseIds.length} combined courses and anonymize possible existing participations`,
     );
+    await dependencies.jobClient.initialize({
+      jobGroups: [JobGroup.DEFAULT, JobGroup.FAST],
+    });
+
+    this.onFinished = async () => {
+      await dependencies.jobClient.stop();
+    };
     await DomainTransaction.execute(async () => {
       const knexConn = DomainTransaction.getConnection();
 
       const engineeringUserId = process.env.ENGINEERING_USER_ID;
 
       try {
-        await dependencies.deleteAndAnonymizeCombinedCourses({
+        await dependencies.usecases.deleteAndAnonymizeCombinedCourses({
           combinedCourseIds: options.combinedCourseIds,
           userId: engineeringUserId,
         });

--- a/api/tests/unit/scripts/delete-and-anonymise-combined-courses_test.js
+++ b/api/tests/unit/scripts/delete-and-anonymise-combined-courses_test.js
@@ -3,7 +3,6 @@ import sinon from 'sinon';
 
 import { DeleteAndAnonymiseCombinedCoursesScript } from '../../../scripts/prod/delete-and-anonymise-combined-courses.js';
 import { DomainTransaction } from '../../../src/shared/domain/DomainTransaction.js';
-import { catchErr } from '../../test-helper.js';
 
 describe('DeleteAndAnonymiseCombinedCoursesScript', function () {
   let script, logger;
@@ -21,13 +20,21 @@ describe('DeleteAndAnonymiseCombinedCoursesScript', function () {
   });
 
   describe('Handle', function () {
-    let usecasesStub, domainTransactionStub;
+    let usecasesStub, domainTransactionStub, jobClientStub;
     const combinedCourseId = Symbol('1');
     const ENGINEERING_USER_ID = 99999;
 
     beforeEach(async function () {
       script = new DeleteAndAnonymiseCombinedCoursesScript();
       logger = { info: sinon.spy(), error: sinon.spy() };
+      jobClientStub = {
+        initialize: () => {
+          return;
+        },
+        stop: () => {
+          return;
+        },
+      };
       sinon.stub(process, 'env').value({ ENGINEERING_USER_ID });
 
       usecasesStub = {
@@ -40,7 +47,11 @@ describe('DeleteAndAnonymiseCombinedCoursesScript', function () {
 
     it('should call usecase with correct arguments and log accordingly if usecase resolves', async function () {
       //given&when
-      await script.handle({ options: { combinedCourseIds: [combinedCourseId] }, logger, dependencies: usecasesStub });
+      await script.handle({
+        options: { combinedCourseIds: [combinedCourseId] },
+        logger,
+        dependencies: { usecases: usecasesStub, jobClient: jobClientStub },
+      });
 
       //then
       expect(usecasesStub.deleteAndAnonymizeCombinedCourses).to.be.calledWithExactly({
@@ -62,14 +73,13 @@ describe('DeleteAndAnonymiseCombinedCoursesScript', function () {
         })
         .rejects();
 
-      await catchErr(script.handle)({
-        options: { combinedCourseIds: [combinedCourseId] },
-        logger,
-        dependencies: usecasesStub,
-      });
-
-      //then
-      expect(logger.error).to.have.been.called;
+      await expect(
+        script.handle({
+          options: { combinedCourseIds: [combinedCourseId] },
+          logger,
+          dependencies: { usecases: usecasesStub, jobClient: jobClientStub },
+        }),
+      ).to.be.rejected;
     });
   });
 });


### PR DESCRIPTION
## 🌱 Problème
Le script delete-and-anonymise-combined-courses throw l'erreur suivante : 
`ROLLBACK: An error has occured, Error: JobClient has not been initialized before use
`

## 🐣 Proposition
On initialise le JobClient en dehors du execute() dans le script. On stoppe l'instance juste après.

## 🐝 Pour tester
node ./scripts/prod/delete-and-anonymise-combined-courses.js --combinedCourseIds={ids} --dryRun=false
Vérifier que les parcours combinés sont bien deletedAt/deletedBy