### PR TITLE
[TECH] Ne plus importer certains utilitaires depuis test-helper.js (part 3)

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -75,7 +75,7 @@
     "test:db:reset": "NODE_ENV=test run-p db:prepare datamart:prepare datawarehouse:prepare",
     "test:db:empty": "NODE_ENV=test run-p db:empty",
     "test:api": "for testType in 'unit' 'integration' 'acceptance'; do npm run test:api:$testType || status=1 ; done ; exit $status",
-    "test:api:path": "NODE_ENV=test node --env-file-if-exists=.env ./node_modules/mocha/bin/mocha --exit --recursive --reporter=${MOCHA_REPORTER:-dot} --retries=${MOCHA_RETRIES:-0}",
+    "test:api:path": "NODE_ENV=test node --env-file-if-exists=.env ./node_modules/mocha/bin/mocha --exit --recursive --reporter=${MOCHA_REPORTER:-dot} --retries=${MOCHA_RETRIES:-0} --timeout=5000",
     "test:api:scripts": "npm run test:api:path -- tests/integration/scripts",
     "test:api:unit": "TEST_DATABASE_URL=postgres://should.not.reach.db.in.unit.tests TEST_REDIS_URL= npm run test:api:path -- 'tests/**/unit/**/*test.js'",
     "test:api:integration": "npm run test:api:path -- 'tests/**/integration/**/*test.js'",

--- a/api/tests/acceptance/application/campaigns/campaign-controller_test.js
+++ b/api/tests/acceptance/application/campaigns/campaign-controller_test.js
@@ -1,9 +1,5 @@
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../test-helper.js';
+import { createServer } from '../../../../server.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../test-helper.js';
 
 describe('Acceptance | API | Campaign Controller', function () {
   let server;

--- a/api/tests/acceptance/application/campaigns/campaign-management-controller_test.js
+++ b/api/tests/acceptance/application/campaigns/campaign-management-controller_test.js
@@ -1,9 +1,5 @@
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../test-helper.js';
+import { createServer } from '../../../../server.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../test-helper.js';
 
 describe('Acceptance | API | Campaign Management Controller', function () {
   let server;

--- a/api/tests/acceptance/application/certification-centers/certification-center-controller_test.js
+++ b/api/tests/acceptance/application/certification-centers/certification-center-controller_test.js
@@ -1,12 +1,7 @@
 import _ from 'lodash';
 
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-  knex,
-} from '../../../test-helper.js';
+import { createServer } from '../../../../server.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders, knex } from '../../../test-helper.js';
 
 describe('Acceptance | API | Certification Center', function () {
   let server;

--- a/api/tests/acceptance/application/countries/countries-controller_test.js
+++ b/api/tests/acceptance/application/countries/countries-controller_test.js
@@ -1,4 +1,5 @@
-import { createServer, expect, generateAuthenticatedUserRequestHeaders } from '../../../test-helper.js';
+import { createServer } from '../../../../server.js';
+import { expect, generateAuthenticatedUserRequestHeaders } from '../../../test-helper.js';
 
 describe('Acceptance | API | countries-controller', function () {
   let server;

--- a/api/tests/acceptance/application/organizations/organization-controller_test.js
+++ b/api/tests/acceptance/application/organizations/organization-controller_test.js
@@ -1,11 +1,7 @@
 import lodash from 'lodash';
 
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../test-helper.js';
+import { createServer } from '../../../../server.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../test-helper.js';
 
 const { map: _map } = lodash;
 

--- a/api/tests/acceptance/application/scenario-simulator/scenario-simulator-controller_test.js
+++ b/api/tests/acceptance/application/scenario-simulator/scenario-simulator-controller_test.js
@@ -1,10 +1,6 @@
+import { createServer } from '../../../../server.js';
 import { PIX_ADMIN } from '../../../../src/authorization/domain/constants.js';
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../test-helper.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../test-helper.js';
 import { parseNDJSON } from '../../../tooling/test-utils/json.js';
 
 const {

--- a/api/tests/acceptance/application/session/jury-certification-summaries-route_test.js
+++ b/api/tests/acceptance/application/session/jury-certification-summaries-route_test.js
@@ -1,12 +1,8 @@
+import { createServer } from '../../../../server.js';
 import { PIX_PLUS_EDU_EXTERNAL_LEVELS } from '../../../../src/certification/shared/domain/constants/mesh-configuration.js';
 import { AlgorithmEngineVersion } from '../../../../src/certification/shared/domain/models/AlgorithmEngineVersion.js';
 import { Frameworks } from '../../../../src/certification/shared/domain/models/Frameworks.js';
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../test-helper.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../test-helper.js';
 
 describe('Acceptance | Controller | session-controller-get-jury-certification-summaries', function () {
   let server;

--- a/api/tests/acceptance/application/session/session-controller-delete-certification-candidate_test.js
+++ b/api/tests/acceptance/application/session/session-controller-delete-certification-candidate_test.js
@@ -1,9 +1,5 @@
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../test-helper.js';
+import { createServer } from '../../../../server.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../test-helper.js';
 
 describe('Acceptance | Controller | session-controller-delete-certification-candidate', function () {
   let server;

--- a/api/tests/acceptance/application/session/session-controller-get-supervisor-kit-PDF_test.js
+++ b/api/tests/acceptance/application/session/session-controller-get-supervisor-kit-PDF_test.js
@@ -1,9 +1,5 @@
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../test-helper.js';
+import { createServer } from '../../../../server.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../test-helper.js';
 
 describe('Acceptance | Controller | session-controller-get-invigilator-kit-pdf', function () {
   let server;

--- a/api/tests/acceptance/application/session/session-controller_test.js
+++ b/api/tests/acceptance/application/session/session-controller_test.js
@@ -1,11 +1,7 @@
 import _ from 'lodash';
 
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../test-helper.js';
+import { createServer } from '../../../../server.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../test-helper.js';
 
 describe('Acceptance | Controller | session-controller', function () {
   let server;

--- a/api/tests/acceptance/application/sup-organization-learners/sup-organization-learner-controller_test.js
+++ b/api/tests/acceptance/application/sup-organization-learners/sup-organization-learner-controller_test.js
@@ -1,10 +1,6 @@
+import { createServer } from '../../../../server.js';
 import { Membership } from '../../../../src/shared/domain/models/Membership.js';
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../test-helper.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../test-helper.js';
 
 describe('Acceptance | Controller | sup-organization-learners', function () {
   let server;

--- a/api/tests/acceptance/application/users/remember-user-has-seen-assessment-instructions_test.js
+++ b/api/tests/acceptance/application/users/remember-user-has-seen-assessment-instructions_test.js
@@ -1,9 +1,5 @@
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../test-helper.js';
+import { createServer } from '../../../../server.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../test-helper.js';
 
 describe('Acceptance | Controller | users-controller-remember-user-has-seen-assessment-instructions', function () {
   let server;

--- a/api/tests/acceptance/application/users/users-controller-find-users_test.js
+++ b/api/tests/acceptance/application/users/users-controller-find-users_test.js
@@ -1,9 +1,5 @@
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../test-helper.js';
+import { createServer } from '../../../../server.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../test-helper.js';
 
 describe('Acceptance | users-controller-find-users', function () {
   let server;

--- a/api/tests/acceptance/application/users/users-controller-get-user-profile-for-admin_test.js
+++ b/api/tests/acceptance/application/users/users-controller-get-user-profile-for-admin_test.js
@@ -1,10 +1,6 @@
+import { createServer } from '../../../../server.js';
 import { constants } from '../../../../src/shared/domain/constants.js';
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../test-helper.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../test-helper.js';
 
 describe('Acceptance | Controller | users-controller-get-user-profile-for-admin', function () {
   let options;

--- a/api/tests/acceptance/application/users/users-controller-get-user-profile_test.js
+++ b/api/tests/acceptance/application/users/users-controller-get-user-profile_test.js
@@ -1,10 +1,6 @@
+import { createServer } from '../../../../server.js';
 import { constants } from '../../../../src/shared/domain/constants.js';
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../test-helper.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../test-helper.js';
 
 describe('Acceptance | Controller | users-controller-get-user-profile', function () {
   let options;

--- a/api/tests/acceptance/application/users/users-controller-reset-scorecard_test.js
+++ b/api/tests/acceptance/application/users/users-controller-reset-scorecard_test.js
@@ -1,9 +1,9 @@
 import _ from 'lodash';
 import sinon from 'sinon';
 
+import { createServer } from '../../../../server.js';
 import { CampaignParticipationStatuses } from '../../../../src/prescription/shared/domain/constants.js';
 import {
-  createServer,
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,

--- a/api/tests/announcements/acceptance/application/announcement-route_test.js
+++ b/api/tests/announcements/acceptance/application/announcement-route_test.js
@@ -1,11 +1,6 @@
+import { createServer } from '../../../../server.js';
 import { announcementsStorage } from '../../../../src/shared/infrastructure/key-value-storages/index.js';
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-  knex,
-} from '../../../test-helper.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders, knex } from '../../../test-helper.js';
 
 const CONTENT = { fr: 'Contenu en français', en: 'Content in English' };
 

--- a/api/tests/banner/acceptance/application/banner-route_test.js
+++ b/api/tests/banner/acceptance/application/banner-route_test.js
@@ -1,5 +1,6 @@
+import { createServer } from '../../../../server.js';
 import { informationBannersStorage } from '../../../../src/shared/infrastructure/key-value-storages/index.js';
-import { createServer, expect } from '../../../test-helper.js';
+import { expect } from '../../../test-helper.js';
 
 let server;
 

--- a/api/tests/certification/complementary-certification/acceptance/application/attach-target-profile-controller_test.js
+++ b/api/tests/certification/complementary-certification/acceptance/application/attach-target-profile-controller_test.js
@@ -1,12 +1,7 @@
 import lodash from 'lodash';
 
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-  knex,
-} from '../../../../test-helper.js';
+import { createServer } from '../../../../../server.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders, knex } from '../../../../test-helper.js';
 
 const { omit } = lodash;
 

--- a/api/tests/certification/configuration/acceptance/application/certification-framework-route_test.js
+++ b/api/tests/certification/configuration/acceptance/application/certification-framework-route_test.js
@@ -1,15 +1,10 @@
 import sinon from 'sinon';
 
+import { createServer } from '../../../../../server.js';
 import { DEFAULT_SESSION_DURATION_MINUTES } from '../../../../../src/certification/shared/domain/constants.js';
 import { Frameworks } from '../../../../../src/certification/shared/domain/models/Frameworks.js';
 import { SCOPES } from '../../../../../src/certification/shared/domain/models/Scopes.js';
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-  knex,
-} from '../../../../test-helper.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders, knex } from '../../../../test-helper.js';
 import { buildLearningContent as learningContentBuilder } from '../../../../tooling/learning-content-builder/index.js';
 
 describe('Acceptance | Application | Certification | ComplementaryCertification | certification-framework-route', function () {

--- a/api/tests/certification/configuration/acceptance/application/certification-version-route_test.js
+++ b/api/tests/certification/configuration/acceptance/application/certification-version-route_test.js
@@ -1,7 +1,7 @@
+import { createServer } from '../../../../../server.js';
 import { DEFAULT_SESSION_DURATION_MINUTES } from '../../../../../src/certification/shared/domain/constants.js';
 import { SCOPES } from '../../../../../src/certification/shared/domain/models/Scopes.js';
 import {
-  createServer,
   databaseBuilder,
   domainBuilder,
   expect,

--- a/api/tests/certification/configuration/acceptance/application/complementary-certification-route_test.js
+++ b/api/tests/certification/configuration/acceptance/application/complementary-certification-route_test.js
@@ -1,8 +1,8 @@
 import _ from 'lodash';
 
+import { createServer } from '../../../../../server.js';
 import { ComplementaryCertificationKeys } from '../../../../../src/certification/shared/domain/models/ComplementaryCertificationKeys.js';
 import {
-  createServer,
   databaseBuilder,
   datamartBuilder,
   expect,

--- a/api/tests/certification/configuration/acceptance/application/sco-blocked-access-dates-route_test.js
+++ b/api/tests/certification/configuration/acceptance/application/sco-blocked-access-dates-route_test.js
@@ -1,11 +1,6 @@
+import { createServer } from '../../../../../server.js';
 import { ScoOrganizationTagName } from '../../../../../src/certification/configuration/domain/models/ScoOrganizationTagName.js';
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-  knex,
-} from '../../../../test-helper.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders, knex } from '../../../../test-helper.js';
 
 describe('Certification | Configuration | Acceptance | API | sco-blocked-access-dates-route', function () {
   let server;

--- a/api/tests/certification/configuration/acceptance/application/sco-whitelist-route_test.js
+++ b/api/tests/certification/configuration/acceptance/application/sco-whitelist-route_test.js
@@ -1,12 +1,7 @@
+import { createServer } from '../../../../../server.js';
 import { CenterTypes } from '../../../../../src/certification/configuration/domain/models/CenterTypes.js';
 import { CERTIFICATION_CENTER_TYPES } from '../../../../../src/shared/domain/constants.js';
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-  knex,
-} from '../../../../test-helper.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders, knex } from '../../../../test-helper.js';
 
 describe('Certification | Configuration | Acceptance | API | sco-whitelist-route', function () {
   let server;

--- a/api/tests/certification/enrolment/acceptance/application/attendance-sheet-controller_test.js
+++ b/api/tests/certification/enrolment/acceptance/application/attendance-sheet-controller_test.js
@@ -1,9 +1,5 @@
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../../test-helper.js';
+import { createServer } from '../../../../../server.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../../test-helper.js';
 
 describe('Acceptance | Controller | session-controller-get-attendance-sheet', function () {
   describe('GET /api/sessions/{sessionId}/attendance-sheet', function () {

--- a/api/tests/certification/enrolment/acceptance/application/certification-candidate-controller-post-certification-candidate_test.js
+++ b/api/tests/certification/enrolment/acceptance/application/certification-candidate-controller-post-certification-candidate_test.js
@@ -1,8 +1,8 @@
+import { createServer } from '../../../../../server.js';
 import { SUBSCRIPTION_TYPES } from '../../../../../src/certification/shared/domain/constants.js';
 import { CertificationCandidate } from '../../../../../src/certification/shared/domain/models/CertificationCandidate.js';
 import { ComplementaryCertificationKeys } from '../../../../../src/certification/shared/domain/models/ComplementaryCertificationKeys.js';
 import {
-  createServer,
   databaseBuilder,
   domainBuilder,
   expect,

--- a/api/tests/certification/enrolment/acceptance/application/certification-candidate-route_test.js
+++ b/api/tests/certification/enrolment/acceptance/application/certification-candidate-route_test.js
@@ -1,5 +1,6 @@
 import dayjs from 'dayjs';
 
+import { createServer } from '../../../../../server.js';
 import { PIX_ADMIN } from '../../../../../src/authorization/domain/constants.js';
 import { CandidateCreatedEvent } from '../../../../../src/certification/enrolment/domain/models/timeline/CandidateCreatedEvent.js';
 import { CandidateNotCertifiableEvent } from '../../../../../src/certification/enrolment/domain/models/timeline/CandidateNotCertifiableEvent.js';
@@ -7,13 +8,7 @@ import { CandidateReconciledEvent } from '../../../../../src/certification/enrol
 import { SUBSCRIPTION_TYPES } from '../../../../../src/certification/shared/domain/constants.js';
 import { CertificationCandidate } from '../../../../../src/certification/shared/domain/models/CertificationCandidate.js';
 import { ComplementaryCertificationKeys } from '../../../../../src/certification/shared/domain/models/ComplementaryCertificationKeys.js';
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-  knex,
-} from '../../../../test-helper.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders, knex } from '../../../../test-helper.js';
 
 const { ROLES } = PIX_ADMIN;
 

--- a/api/tests/certification/enrolment/acceptance/application/certification-center-controller_test.js
+++ b/api/tests/certification/enrolment/acceptance/application/certification-center-controller_test.js
@@ -1,11 +1,7 @@
 import _ from 'lodash';
 
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../../test-helper.js';
+import { createServer } from '../../../../../server.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../../test-helper.js';
 
 describe('Acceptance | API | Certification Center', function () {
   let server;

--- a/api/tests/certification/enrolment/acceptance/application/certification-centers-get-divisions_test.js
+++ b/api/tests/certification/enrolment/acceptance/application/certification-centers-get-divisions_test.js
@@ -1,9 +1,5 @@
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../../test-helper.js';
+import { createServer } from '../../../../../server.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../../test-helper.js';
 
 describe('Certification | Enrolment | Acceptance | Route | Certification Centers', function () {
   let server;

--- a/api/tests/certification/enrolment/acceptance/application/enrolment-route_test.js
+++ b/api/tests/certification/enrolment/acceptance/application/enrolment-route_test.js
@@ -3,17 +3,12 @@ import * as url from 'node:url';
 
 import sinon from 'sinon';
 
+import { createServer } from '../../../../../server.js';
 import { SUBSCRIPTION_TYPES } from '../../../../../src/certification/shared/domain/constants.js';
 import { ComplementaryCertificationKeys } from '../../../../../src/certification/shared/domain/models/ComplementaryCertificationKeys.js';
 import { Frameworks } from '../../../../../src/certification/shared/domain/models/Frameworks.js';
 import { clearResolveMx, setResolveMx } from '../../../../../src/shared/mail/infrastructure/services/mail-check.js';
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-  knex,
-} from '../../../../test-helper.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders, knex } from '../../../../test-helper.js';
 
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
 

--- a/api/tests/certification/enrolment/acceptance/application/session-mass-import-route_test.js
+++ b/api/tests/certification/enrolment/acceptance/application/session-mass-import-route_test.js
@@ -1,15 +1,10 @@
 import lodash from 'lodash';
 import sinon from 'sinon';
 
+import { createServer } from '../../../../../server.js';
 import * as temporarySessionsStorageForMassImportService from '../../../../../src/certification/enrolment/domain/services/temporary-sessions-storage-for-mass-import-service.js';
 import { CERTIFICATION_CENTER_TYPES } from '../../../../../src/shared/domain/constants.js';
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-  knex,
-} from '../../../../test-helper.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders, knex } from '../../../../test-helper.js';
 
 const { omit } = lodash;
 

--- a/api/tests/certification/enrolment/acceptance/application/session-route_test.js
+++ b/api/tests/certification/enrolment/acceptance/application/session-route_test.js
@@ -1,8 +1,8 @@
+import { createServer } from '../../../../../server.js';
 import { AlgorithmEngineVersion } from '../../../../../src/certification/shared/domain/models/AlgorithmEngineVersion.js';
 import { types } from '../../../../../src/organizational-entities/domain/models/Organization.js';
 import { CERTIFICATION_CENTER_TYPES } from '../../../../../src/shared/domain/constants.js';
 import {
-  createServer,
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,

--- a/api/tests/certification/enrolment/acceptance/application/subscription-route_test.js
+++ b/api/tests/certification/enrolment/acceptance/application/subscription-route_test.js
@@ -1,6 +1,6 @@
+import { createServer } from '../../../../../server.js';
 import { ComplementaryCertificationKeys } from '../../../../../src/certification/shared/domain/models/ComplementaryCertificationKeys.js';
 import {
-  createServer,
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,

--- a/api/tests/certification/enrolment/acceptance/application/user-route_test.js
+++ b/api/tests/certification/enrolment/acceptance/application/user-route_test.js
@@ -1,7 +1,7 @@
+import { createServer } from '../../../../../server.js';
 import { ComplementaryCertificationKeys } from '../../../../../src/certification/shared/domain/models/ComplementaryCertificationKeys.js';
 import { AssessmentResult } from '../../../../../src/shared/domain/models/AssessmentResult.js';
 import {
-  createServer,
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,

--- a/api/tests/certification/evaluation/acceptance/answer-route_test.js
+++ b/api/tests/certification/evaluation/acceptance/answer-route_test.js
@@ -1,10 +1,5 @@
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-  knex,
-} from '../../../test-helper.js';
+import { createServer } from '../../../../server.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders, knex } from '../../../test-helper.js';
 
 describe('Certification | Evaluation | Acceptance | answer-route', function () {
   let server;

--- a/api/tests/certification/evaluation/acceptance/application/certification-admin-route_test.js
+++ b/api/tests/certification/evaluation/acceptance/application/certification-admin-route_test.js
@@ -1,13 +1,8 @@
+import { createServer } from '../../../../../server.js';
 import { AlgorithmEngineVersion } from '../../../../../src/certification/shared/domain/models/AlgorithmEngineVersion.js';
 import { AnswerStatus } from '../../../../../src/shared/domain/models/AnswerStatus.js';
 import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-  knex,
-} from '../../../../test-helper.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders, knex } from '../../../../test-helper.js';
 
 describe('Certification | Evaluation | Acceptance | Application | certification admin routes', function () {
   let server;

--- a/api/tests/certification/evaluation/acceptance/application/certification-courses/certification-course-controller_test.js
+++ b/api/tests/certification/evaluation/acceptance/application/certification-courses/certification-course-controller_test.js
@@ -1,8 +1,8 @@
+import { createServer } from '../../../../../../server.js';
 import { AlgorithmEngineVersion } from '../../../../../../src/certification/shared/domain/models/AlgorithmEngineVersion.js';
 import { CertificationIssueReportCategory } from '../../../../../../src/certification/shared/domain/models/CertificationIssueReportCategory.js';
 import { KnowledgeElement } from '../../../../../../src/shared/domain/models/KnowledgeElement.js';
 import {
-  createServer,
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,

--- a/api/tests/certification/evaluation/acceptance/application/certification-courses/index_test.js
+++ b/api/tests/certification/evaluation/acceptance/application/certification-courses/index_test.js
@@ -1,5 +1,5 @@
+import { createServer } from '../../../../../../server.js';
 import {
-  createServer,
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,

--- a/api/tests/certification/evaluation/acceptance/application/certification-rescoring-route_test.js
+++ b/api/tests/certification/evaluation/acceptance/application/certification-rescoring-route_test.js
@@ -1,8 +1,8 @@
+import { createServer } from '../../../../../server.js';
 import { AlgorithmEngineVersion } from '../../../../../src/certification/shared/domain/models/AlgorithmEngineVersion.js';
 import { AnswerStatus } from '../../../../../src/shared/domain/models/AnswerStatus.js';
 import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
 import {
-  createServer,
   databaseBuilder,
   datamartBuilder,
   domainBuilder,

--- a/api/tests/certification/evaluation/acceptance/application/companion-alert-route_test.js
+++ b/api/tests/certification/evaluation/acceptance/application/companion-alert-route_test.js
@@ -1,12 +1,7 @@
+import { createServer } from '../../../../../server.js';
 import { CertificationCompanionLiveAlertStatus } from '../../../../../src/certification/shared/domain/models/CertificationCompanionLiveAlert.js';
 import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-  knex,
-} from '../../../../test-helper.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders, knex } from '../../../../test-helper.js';
 
 describe('Certification | Evaluation | Acceptance | Application | Routes | companion-alert', function () {
   describe('POST /api/assessments/{assessmentId}/companion-alert', function () {

--- a/api/tests/certification/evaluation/acceptance/scoring-and-capacity-simulator-route_test.js
+++ b/api/tests/certification/evaluation/acceptance/scoring-and-capacity-simulator-route_test.js
@@ -1,6 +1,6 @@
+import { createServer } from '../../../../server.js';
 import { PIX_ADMIN } from '../../../../src/authorization/domain/constants.js';
 import {
-  createServer,
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,

--- a/api/tests/certification/results/acceptance/application/certificate-route_test.js
+++ b/api/tests/certification/results/acceptance/application/certificate-route_test.js
@@ -1,5 +1,6 @@
 import dayjs from 'dayjs';
 
+import { createServer } from '../../../../../server.js';
 import { generateCertificateVerificationCode } from '../../../../../src/certification/evaluation/domain/services/verify-certificate-code-service.js';
 import {
   CERTIFICATE_STATUSES,
@@ -14,7 +15,6 @@ import { AssessmentResult } from '../../../../../src/shared/domain/models/Assess
 import * as AssesmentResult from '../../../../../src/shared/domain/models/AssessmentResult.js';
 import { Membership } from '../../../../../src/shared/domain/models/Membership.js';
 import {
-  createServer,
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,

--- a/api/tests/certification/results/acceptance/application/certification-reports-route_test.js
+++ b/api/tests/certification/results/acceptance/application/certification-reports-route_test.js
@@ -1,9 +1,5 @@
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../../test-helper.js';
+import { createServer } from '../../../../../server.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../../test-helper.js';
 
 describe('Acceptance | Route | Course | certification-reports-route', function () {
   let server;

--- a/api/tests/certification/results/acceptance/application/certification-results-route_test.js
+++ b/api/tests/certification/results/acceptance/application/certification-results-route_test.js
@@ -1,13 +1,9 @@
+import { createServer } from '../../../../../server.js';
 import { CertificationResultsLinkByEmailToken } from '../../../../../src/certification/results/domain/models/tokens/CertificationResultsLinkByEmailToken.js';
 import { CertificationResultsLinkToken } from '../../../../../src/certification/results/domain/models/tokens/CertificationResultsLinkToken.js';
 import { ComplementaryCertificationKeys } from '../../../../../src/certification/shared/domain/models/ComplementaryCertificationKeys.js';
 import { AutoJuryCommentKeys } from '../../../../../src/certification/shared/domain/models/JuryComment.js';
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../../test-helper.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../../test-helper.js';
 
 describe('Certification | Results | Acceptance | Application | Routes | certification results', function () {
   describe('GET /api/sessions/{sessionId}/certified-clea-candidate-data', function () {

--- a/api/tests/certification/results/acceptance/application/livret-scolaire-route_test.js
+++ b/api/tests/certification/results/acceptance/application/livret-scolaire-route_test.js
@@ -1,6 +1,6 @@
+import { createMaddoServer } from '../../../../../server.maddo.js';
 import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
 import {
-  createMaddoServer,
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,

--- a/api/tests/certification/results/acceptance/application/parcoursup-route_test.js
+++ b/api/tests/certification/results/acceptance/application/parcoursup-route_test.js
@@ -1,5 +1,5 @@
+import { createMaddoServer } from '../../../../../server.maddo.js';
 import {
-  createMaddoServer,
   datamartBuilder,
   expect,
   generateValidRequestAuthorizationHeaderForApplication,

--- a/api/tests/certification/results/acceptance/application/user-route_test.js
+++ b/api/tests/certification/results/acceptance/application/user-route_test.js
@@ -1,9 +1,5 @@
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../../test-helper.js';
+import { createServer } from '../../../../../server.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../../test-helper.js';
 
 describe('Certification | Results | Acceptance | Routes | User', function () {
   let server;

--- a/api/tests/certification/session-management/acceptance/application/cancellation-route_test.js
+++ b/api/tests/certification/session-management/acceptance/application/cancellation-route_test.js
@@ -1,10 +1,10 @@
+import { createServer } from '../../../../../server.js';
 import { PIX_ADMIN } from '../../../../../src/authorization/domain/constants.js';
 import { AlgorithmEngineVersion } from '../../../../../src/certification/shared/domain/models/AlgorithmEngineVersion.js';
 import { AnswerStatus } from '../../../../../src/shared/domain/models/AnswerStatus.js';
 import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
 import { AssessmentResult } from '../../../../../src/shared/domain/models/AssessmentResult.js';
 import {
-  createServer,
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,

--- a/api/tests/certification/session-management/acceptance/application/certification-candidate-route_test.js
+++ b/api/tests/certification/session-management/acceptance/application/certification-candidate-route_test.js
@@ -1,9 +1,5 @@
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../../test-helper.js';
+import { createServer } from '../../../../../server.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../../test-helper.js';
 
 describe('Certification | Session Management | Acceptance | Application | Routes | certification-candidate', function () {
   let server;

--- a/api/tests/certification/session-management/acceptance/application/certification-course-route_test.js
+++ b/api/tests/certification/session-management/acceptance/application/certification-course-route_test.js
@@ -1,9 +1,9 @@
+import { createServer } from '../../../../../server.js';
 import { PIX_PLUS_EDU_EXTERNAL_LEVELS } from '../../../../../src/certification/shared/domain/constants/mesh-configuration.js';
 import { AlgorithmEngineVersion } from '../../../../../src/certification/shared/domain/models/AlgorithmEngineVersion.js';
 import { Frameworks } from '../../../../../src/certification/shared/domain/models/Frameworks.js';
 import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
 import {
-  createServer,
   databaseBuilder,
   domainBuilder,
   expect,

--- a/api/tests/certification/session-management/acceptance/application/certification-details-route_test.js
+++ b/api/tests/certification/session-management/acceptance/application/certification-details-route_test.js
@@ -1,5 +1,5 @@
+import { createServer } from '../../../../../server.js';
 import {
-  createServer,
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,

--- a/api/tests/certification/session-management/acceptance/application/certification-issue-report-controller_test.js
+++ b/api/tests/certification/session-management/acceptance/application/certification-issue-report-controller_test.js
@@ -1,10 +1,5 @@
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-  knex,
-} from '../../../../test-helper.js';
+import { createServer } from '../../../../../server.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders, knex } from '../../../../test-helper.js';
 
 describe('Acceptance | Controller | certification-issue-report-controller', function () {
   describe('DELETE /api/certification-issue-reports/{id}', function () {

--- a/api/tests/certification/session-management/acceptance/application/certification-officer-route_test.js
+++ b/api/tests/certification/session-management/acceptance/application/certification-officer-route_test.js
@@ -1,9 +1,5 @@
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../../test-helper.js';
+import { createServer } from '../../../../../server.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../../test-helper.js';
 
 describe('Certification | Session Management | Acceptance | Application | Routes | certification-officer', function () {
   describe('PATCH /api/admin/sessions/{sessionId}/certification-officer-assignment', function () {

--- a/api/tests/certification/session-management/acceptance/application/certification-report-route_test.js
+++ b/api/tests/certification/session-management/acceptance/application/certification-report-route_test.js
@@ -1,9 +1,5 @@
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../../test-helper.js';
+import { createServer } from '../../../../../server.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../../test-helper.js';
 
 describe('Certification | Session Management | Acceptance | Application | Routes | certification-report', function () {
   let server, certificationCourseId, userId, sessionId, certificationCenterId;

--- a/api/tests/certification/session-management/acceptance/application/companion-alert-route_test.js
+++ b/api/tests/certification/session-management/acceptance/application/companion-alert-route_test.js
@@ -1,12 +1,7 @@
+import { createServer } from '../../../../../server.js';
 import { CertificationCompanionLiveAlertStatus } from '../../../../../src/certification/shared/domain/models/CertificationCompanionLiveAlert.js';
 import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-  knex,
-} from '../../../../test-helper.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders, knex } from '../../../../test-helper.js';
 
 describe('Certification | Session Management | Acceptance | Application | Routes | companion-alert', function () {
   let server;

--- a/api/tests/certification/session-management/acceptance/application/complementary-certification-course-results-controller_test.js
+++ b/api/tests/certification/session-management/acceptance/application/complementary-certification-course-results-controller_test.js
@@ -1,10 +1,6 @@
+import { createServer } from '../../../../../server.js';
 import { ComplementaryCertificationCourseResult } from '../../../../../src/certification/shared/domain/models/ComplementaryCertificationCourseResult.js';
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../../test-helper.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../../test-helper.js';
 
 describe('Certification | Session-management | Acceptance | complementary-certification-course-results-controller', function () {
   describe('POST /api/admin/complementary-certification-course-results', function () {

--- a/api/tests/certification/session-management/acceptance/application/finalize-route_test.js
+++ b/api/tests/certification/session-management/acceptance/application/finalize-route_test.js
@@ -1,3 +1,4 @@
+import { createServer } from '../../../../../server.js';
 import { AlgorithmEngineVersion } from '../../../../../src/certification/shared/domain/models/AlgorithmEngineVersion.js';
 import {
   CertificationIssueReportCategory,
@@ -8,7 +9,6 @@ import { AnswerStatus } from '../../../../../src/shared/domain/models/AnswerStat
 import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
 import { AssessmentResult } from '../../../../../src/shared/domain/models/AssessmentResult.js';
 import {
-  createServer,
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,

--- a/api/tests/certification/session-management/acceptance/application/finalized-session-controller_test.js
+++ b/api/tests/certification/session-management/acceptance/application/finalized-session-controller_test.js
@@ -1,9 +1,5 @@
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../../test-helper.js';
+import { createServer } from '../../../../../server.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../../test-helper.js';
 
 describe('Certification | Session-management | Acceptance | Application | finalized-session-controller', function () {
   let server, options, superAdmin;

--- a/api/tests/certification/session-management/acceptance/application/jury-certification-route_test.js
+++ b/api/tests/certification/session-management/acceptance/application/jury-certification-route_test.js
@@ -1,12 +1,8 @@
+import { createServer } from '../../../../../server.js';
 import { ComplementaryCertificationCourseResult } from '../../../../../src/certification/shared/domain/models/ComplementaryCertificationCourseResult.js';
 import { Frameworks } from '../../../../../src/certification/shared/domain/models/Frameworks.js';
 import { AutoJuryCommentKeys } from '../../../../../src/certification/shared/domain/models/JuryComment.js';
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../../test-helper.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../../test-helper.js';
 
 describe('Certification | Session Management | Acceptance | Application | Routes | jury-certification', function () {
   describe('GET /api/admin/certifications/{certificationCourseId}', function () {

--- a/api/tests/certification/session-management/acceptance/application/jury-comment-route_test.js
+++ b/api/tests/certification/session-management/acceptance/application/jury-comment-route_test.js
@@ -1,9 +1,5 @@
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../../test-helper.js';
+import { createServer } from '../../../../../server.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../../test-helper.js';
 
 describe('Certification | Session Management | Acceptance | Application | Routes| jury-comment', function () {
   describe('PUT /api/admin/sessions/{sessionId}/comment', function () {

--- a/api/tests/certification/session-management/acceptance/application/session-controller-publish-session-in-batch_test.js
+++ b/api/tests/certification/session-management/acceptance/application/session-controller-publish-session-in-batch_test.js
@@ -1,9 +1,5 @@
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../../test-helper.js';
+import { createServer } from '../../../../../server.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../../test-helper.js';
 
 describe('POST /api/admin/sessions/publish-in-batch', function () {
   let server;

--- a/api/tests/certification/session-management/acceptance/application/session-for-supervising-route_test.js
+++ b/api/tests/certification/session-management/acceptance/application/session-for-supervising-route_test.js
@@ -1,9 +1,5 @@
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../../test-helper.js';
+import { createServer } from '../../../../../server.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../../test-helper.js';
 
 describe('Certification | Session Management | Acceptance | Application | Routes | session-for-supervising', function () {
   let server;

--- a/api/tests/certification/session-management/acceptance/application/session-live-alert-route_test.js
+++ b/api/tests/certification/session-management/acceptance/application/session-live-alert-route_test.js
@@ -1,11 +1,6 @@
+import { createServer } from '../../../../../server.js';
 import { CertificationChallengeLiveAlertStatus } from '../../../../../src/certification/shared/domain/models/CertificationChallengeLiveAlert.js';
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-  knex,
-} from '../../../../test-helper.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders, knex } from '../../../../test-helper.js';
 
 describe('Certification | Session | Acceptance | Application | Routes | session-live-alert', function () {
   let server;

--- a/api/tests/certification/session-management/acceptance/application/session-publication-route_test.js
+++ b/api/tests/certification/session-management/acceptance/application/session-publication-route_test.js
@@ -1,13 +1,8 @@
 import sinon from 'sinon';
 
+import { createServer } from '../../../../../server.js';
 import { status } from '../../../../../src/shared/domain/models/AssessmentResult.js';
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-  knex,
-} from '../../../../test-helper.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders, knex } from '../../../../test-helper.js';
 
 describe('Certification | Session-Management | Acceptance | Application | Routes | session-publication', function () {
   describe('PATCH /api/admin/sessions/:id/publish', function () {

--- a/api/tests/certification/session-management/acceptance/application/session-route_test.js
+++ b/api/tests/certification/session-management/acceptance/application/session-route_test.js
@@ -1,9 +1,5 @@
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../../test-helper.js';
+import { createServer } from '../../../../../server.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../../test-helper.js';
 
 describe('Certification | Session Management | Acceptance | Application | Route | Session', function () {
   let server, options;

--- a/api/tests/certification/session-management/acceptance/application/supervise-controller-supervise_test.js
+++ b/api/tests/certification/session-management/acceptance/application/supervise-controller-supervise_test.js
@@ -1,10 +1,5 @@
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-  knex,
-} from '../../../../test-helper.js';
+import { createServer } from '../../../../../server.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders, knex } from '../../../../test-helper.js';
 
 describe('Acceptance | Controller | Certification | Session management | session-for-supervising-controller-supervise', function () {
   let server;

--- a/api/tests/certification/session-management/acceptance/application/unfinalize-route_test.js
+++ b/api/tests/certification/session-management/acceptance/application/unfinalize-route_test.js
@@ -1,9 +1,5 @@
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../../test-helper.js';
+import { createServer } from '../../../../../server.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../../test-helper.js';
 
 describe('Certification | Session Management | Acceptance | Application | Controller | unfinalize', function () {
   describe('PATCH /api/admin/sessions/{sessionId}/unfinalize', function () {

--- a/api/tests/certification/session-management/acceptance/application/update-cpf-import-status-controller_test.js
+++ b/api/tests/certification/session-management/acceptance/application/update-cpf-import-status-controller_test.js
@@ -4,12 +4,8 @@ import * as url from 'node:url';
 
 import nock from 'nock';
 
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../../test-helper.js';
+import { createServer } from '../../../../../server.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../../test-helper.js';
 
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
 

--- a/api/tests/devcomp/acceptance/application/campaign-participations/campaign-participation-controller_test.js
+++ b/api/tests/devcomp/acceptance/application/campaign-participations/campaign-participation-controller_test.js
@@ -1,9 +1,5 @@
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../../test-helper.js';
+import { createServer } from '../../../../../server.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../../test-helper.js';
 
 describe('Acceptance | API | Campaign Participations', function () {
   let server, user;

--- a/api/tests/devcomp/acceptance/application/module-issue-report/module-issue-report-route_test.js
+++ b/api/tests/devcomp/acceptance/application/module-issue-report/module-issue-report-route_test.js
@@ -1,4 +1,5 @@
-import { createServer, databaseBuilder, expect } from '../../../../test-helper.js';
+import { createServer } from '../../../../../server.js';
+import { databaseBuilder, expect } from '../../../../test-helper.js';
 
 describe('Acceptance | Route | module-issue-report', function () {
   let server;

--- a/api/tests/devcomp/acceptance/application/modules-metadata/module-metadata-route_test.js
+++ b/api/tests/devcomp/acceptance/application/modules-metadata/module-metadata-route_test.js
@@ -1,9 +1,5 @@
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../../test-helper.js';
+import { createServer } from '../../../../../server.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../../test-helper.js';
 
 describe('Acceptance | Controller | Modules Metadata | Route', function () {
   let server;

--- a/api/tests/devcomp/acceptance/application/modules/module-route_test.js
+++ b/api/tests/devcomp/acceptance/application/modules/module-route_test.js
@@ -1,8 +1,9 @@
 import nock from 'nock';
 
+import { createServer } from '../../../../../server.js';
 import { config } from '../../../../../src/shared/config.js';
 import { cryptoService } from '../../../../../src/shared/domain/services/crypto-service.js';
-import { createServer, expect } from '../../../../test-helper.js';
+import { expect } from '../../../../test-helper.js';
 
 describe('Acceptance | Controller | Modules | Route', function () {
   let server;

--- a/api/tests/devcomp/acceptance/application/passage-events/passage-event-controller_test.js
+++ b/api/tests/devcomp/acceptance/application/passage-events/passage-event-controller_test.js
@@ -1,4 +1,5 @@
-import { createServer, databaseBuilder, expect, knex } from '../../../../test-helper.js';
+import { createServer } from '../../../../../server.js';
+import { databaseBuilder, expect, knex } from '../../../../test-helper.js';
 
 describe('Acceptance | Controller | passage-event-controller', function () {
   let server;

--- a/api/tests/devcomp/acceptance/application/passages/passage-controller_test.js
+++ b/api/tests/devcomp/acceptance/application/passages/passage-controller_test.js
@@ -3,16 +3,11 @@ import { Readable } from 'node:stream';
 
 import nock from 'nock';
 
+import { createServer } from '../../../../../server.js';
 import { Chat } from '../../../../../src/llm/domain/models/Chat.js';
 import { Configuration } from '../../../../../src/llm/domain/models/Configuration.js';
 import { featureToggles } from '../../../../../src/shared/infrastructure/feature-toggles/index.js';
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-  knex,
-} from '../../../../test-helper.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders, knex } from '../../../../test-helper.js';
 import { waitForStreamFinalizationToBeDone } from '../../../../tooling/test-utils/wait.js';
 
 describe('Acceptance | Controller | passage-controller', function () {

--- a/api/tests/devcomp/acceptance/application/trainings/training-route_test.js
+++ b/api/tests/devcomp/acceptance/application/trainings/training-route_test.js
@@ -1,5 +1,5 @@
+import { createServer } from '../../../../../server.js';
 import {
-  createServer,
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,

--- a/api/tests/devcomp/acceptance/application/tutorial-evaluations/tutorial-evaluations-controller_test.js
+++ b/api/tests/devcomp/acceptance/application/tutorial-evaluations/tutorial-evaluations-controller_test.js
@@ -1,10 +1,6 @@
+import { createServer } from '../../../../../server.js';
 import { TutorialEvaluation } from '../../../../../src/devcomp/domain/models/TutorialEvaluation.js';
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../../test-helper.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../../test-helper.js';
 
 describe('Acceptance | Controller | tutorial-evaluations-controller', function () {
   let server;

--- a/api/tests/devcomp/acceptance/application/user-trainings/users-trainings-route_test.js
+++ b/api/tests/devcomp/acceptance/application/user-trainings/users-trainings-route_test.js
@@ -1,9 +1,5 @@
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../../test-helper.js';
+import { createServer } from '../../../../../server.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../../test-helper.js';
 
 describe('Acceptance | Routes | UserTrainingsRoute', function () {
   let options;

--- a/api/tests/devcomp/acceptance/application/user-tutorials/user-tutorials-controller_test.js
+++ b/api/tests/devcomp/acceptance/application/user-tutorials/user-tutorials-controller_test.js
@@ -1,6 +1,6 @@
+import { createServer } from '../../../../../server.js';
 import { KnowledgeElement } from '../../../../../src/shared/domain/models/KnowledgeElement.js';
 import {
-  createServer,
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,

--- a/api/tests/evaluation/acceptance/application/answers/answer-controller-find_test.js
+++ b/api/tests/evaluation/acceptance/application/answers/answer-controller-find_test.js
@@ -1,9 +1,5 @@
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../../test-helper.js';
+import { createServer } from '../../../../../server.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../../test-helper.js';
 
 describe('Acceptance | Controller | answer-controller-find', function () {
   describe('GET /api/answers?challengeId=Y&assessmentId=Z', function () {

--- a/api/tests/evaluation/acceptance/application/answers/answer-controller-get-correction_test.js
+++ b/api/tests/evaluation/acceptance/application/answers/answer-controller-get-correction_test.js
@@ -1,10 +1,6 @@
+import { createServer } from '../../../../../server.js';
 import { FRENCH_FRANCE } from '../../../../../src/shared/domain/services/locale-service.js';
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../../test-helper.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../../test-helper.js';
 
 const buildOptions = (answerId, userId) => ({
   method: 'GET',

--- a/api/tests/evaluation/acceptance/application/answers/answer-controller-get_test.js
+++ b/api/tests/evaluation/acceptance/application/answers/answer-controller-get_test.js
@@ -1,9 +1,5 @@
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../../test-helper.js';
+import { createServer } from '../../../../../server.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../../test-helper.js';
 
 describe('Acceptance | Controller | answer-controller-get', function () {
   describe('GET /api/answers/:id', function () {

--- a/api/tests/evaluation/acceptance/application/answers/answer-controller-save_test.js
+++ b/api/tests/evaluation/acceptance/application/answers/answer-controller-save_test.js
@@ -1,3 +1,4 @@
+import { createServer } from '../../../../../server.js';
 import {
   CRITERION_COMPARISONS,
   REQUIREMENT_COMPARISONS,
@@ -6,7 +7,6 @@ import {
 import { ENGLISH_SPOKEN, FRENCH_FRANCE } from '../../../../../src/shared/domain/services/locale-service.js';
 import { featureToggles } from '../../../../../src/shared/infrastructure/feature-toggles/index.js';
 import {
-  createServer,
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,

--- a/api/tests/evaluation/acceptance/application/answers/answer-controller-update_test.js
+++ b/api/tests/evaluation/acceptance/application/answers/answer-controller-update_test.js
@@ -1,9 +1,5 @@
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../../test-helper.js';
+import { createServer } from '../../../../../server.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../../test-helper.js';
 
 describe('Acceptance | Controller | answer-controller-update', function () {
   describe('PATCH /api/answers/:id', function () {

--- a/api/tests/evaluation/acceptance/application/assessments/assessment-controller_test.js
+++ b/api/tests/evaluation/acceptance/application/assessments/assessment-controller_test.js
@@ -6,6 +6,7 @@ import nock from 'nock';
 import sinon from 'sinon';
 
 import { USER_RECOMMENDED_TRAININGS_TABLE_NAME } from '../../../../../db/migrations/20221017085933_create-user-recommended-trainings.js';
+import { createServer } from '../../../../../server.js';
 import { CertificationCompletedJob } from '../../../../../src/certification/evaluation/domain/events/CertificationCompleted.js';
 import { TrainingTrigger } from '../../../../../src/devcomp/domain/models/TrainingTrigger.js';
 import * as badgeAcquisitionRepository from '../../../../../src/evaluation/infrastructure/repositories/badge-acquisition-repository.js';
@@ -22,7 +23,6 @@ import { CORRELATION_METADATA } from '../../../../../src/shared/infrastructure/e
 import { featureToggles } from '../../../../../src/shared/infrastructure/feature-toggles/index.js';
 import { SCOPES } from '../../../../../src/shared/infrastructure/utils/logger.js';
 import {
-  createServer,
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,

--- a/api/tests/evaluation/acceptance/application/autonomous-courses/autonomous-course-controller_test.js
+++ b/api/tests/evaluation/acceptance/application/autonomous-courses/autonomous-course-controller_test.js
@@ -1,8 +1,8 @@
 import sinon from 'sinon';
 
+import { createServer } from '../../../../../server.js';
 import { constants } from '../../../../../src/shared/domain/constants.js';
 import {
-  createServer,
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,

--- a/api/tests/evaluation/acceptance/application/badge-criteria/badge-criteria-controller_test.js
+++ b/api/tests/evaluation/acceptance/application/badge-criteria/badge-criteria-controller_test.js
@@ -1,10 +1,5 @@
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-  knex,
-} from '../../../../test-helper.js';
+import { createServer } from '../../../../../server.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders, knex } from '../../../../test-helper.js';
 
 describe('Acceptance | API | Badge Criteria', function () {
   let server;

--- a/api/tests/evaluation/acceptance/application/badges/index_test.js
+++ b/api/tests/evaluation/acceptance/application/badges/index_test.js
@@ -1,12 +1,7 @@
 import lodash from 'lodash';
 
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-  knex,
-} from '../../../../test-helper.js';
+import { createServer } from '../../../../../server.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders, knex } from '../../../../test-helper.js';
 
 const { omit } = lodash;
 

--- a/api/tests/evaluation/acceptance/application/competence-evaluations/competence-evaluation-controller_test.js
+++ b/api/tests/evaluation/acceptance/application/competence-evaluations/competence-evaluation-controller_test.js
@@ -1,6 +1,6 @@
+import { createServer } from '../../../../../server.js';
 import { MAX_REACHABLE_PIX_BY_COMPETENCE } from '../../../../../src/shared/domain/constants.js';
 import {
-  createServer,
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,

--- a/api/tests/evaluation/acceptance/application/courses/course-controller_test.js
+++ b/api/tests/evaluation/acceptance/application/courses/course-controller_test.js
@@ -1,5 +1,5 @@
+import { createServer } from '../../../../../server.js';
 import {
-  createServer,
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,

--- a/api/tests/evaluation/acceptance/application/feedbacks/feedback-controller_test.js
+++ b/api/tests/evaluation/acceptance/application/feedbacks/feedback-controller_test.js
@@ -1,4 +1,5 @@
-import { createServer, databaseBuilder, expect, knex } from '../../../../test-helper.js';
+import { createServer } from '../../../../../server.js';
+import { databaseBuilder, expect, knex } from '../../../../test-helper.js';
 import { domainBuilder } from '../../../../tooling/domain-builder/domain-builder.js';
 
 describe('Acceptance | Controller | feedback-controller', function () {

--- a/api/tests/evaluation/acceptance/application/progressions/progression-controller_test.js
+++ b/api/tests/evaluation/acceptance/application/progressions/progression-controller_test.js
@@ -1,5 +1,5 @@
+import { createServer } from '../../../../../server.js';
 import {
-  createServer,
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,

--- a/api/tests/evaluation/acceptance/application/scorecards/scorecard-controller_test.js
+++ b/api/tests/evaluation/acceptance/application/scorecards/scorecard-controller_test.js
@@ -1,11 +1,7 @@
+import { createServer } from '../../../../../server.js';
 import { KnowledgeElement } from '../../../../../src/shared/domain/models/KnowledgeElement.js';
 import { FRENCH_SPOKEN } from '../../../../../src/shared/domain/services/locale-service.js';
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../../test-helper.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../../test-helper.js';
 
 describe('Acceptance | Controller | scorecard-controller', function () {
   let options;

--- a/api/tests/evaluation/acceptance/application/smart-random-simulator/smart-random-simulator-controller_test.js
+++ b/api/tests/evaluation/acceptance/application/smart-random-simulator/smart-random-simulator-controller_test.js
@@ -1,9 +1,5 @@
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../../test-helper.js';
+import { createServer } from '../../../../../server.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../../test-helper.js';
 
 describe('Acceptance | API | Smart Random Simulator', function () {
   let userId;

--- a/api/tests/evaluation/acceptance/application/stage-collections/stage-collection-controller_test.js
+++ b/api/tests/evaluation/acceptance/application/stage-collections/stage-collection-controller_test.js
@@ -1,5 +1,5 @@
+import { createServer } from '../../../../../server.js';
 import {
-  createServer,
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,

--- a/api/tests/evaluation/acceptance/application/stages/stage-controller_test.js
+++ b/api/tests/evaluation/acceptance/application/stages/stage-controller_test.js
@@ -1,5 +1,5 @@
+import { createServer } from '../../../../../server.js';
 import {
-  createServer,
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,

--- a/api/tests/evaluation/acceptance/application/users/remember-user-has-seen-new-dashboard-info_test.js
+++ b/api/tests/evaluation/acceptance/application/users/remember-user-has-seen-new-dashboard-info_test.js
@@ -1,9 +1,5 @@
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../../test-helper.js';
+import { createServer } from '../../../../../server.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../../test-helper.js';
 
 describe('Acceptance | Controller | users-controller-has-seen-new-dashboard-info', function () {
   let server;

--- a/api/tests/identity-access-management/acceptance/application/account-recovery/account-recovery.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/account-recovery/account-recovery.route.test.js
@@ -1,7 +1,8 @@
 import sinon from 'sinon';
 
+import { createServer } from '../../../../../server.js';
 import { mailService } from '../../../../../src/shared/domain/services/mail-service.js';
-import { createServer, databaseBuilder, expect, knex } from '../../../../test-helper.js';
+import { databaseBuilder, expect, knex } from '../../../../test-helper.js';
 
 describe('Acceptance | Identity Access Management | Application | Route | account-recovery', function () {
   let server;

--- a/api/tests/identity-access-management/acceptance/application/anonymization.admin.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/anonymization.admin.route.test.js
@@ -1,9 +1,5 @@
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../test-helper.js';
+import { createServer } from '../../../../server.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../test-helper.js';
 
 describe('Acceptance | Identity Access Management | Application | Route | Admin | Anonymization', function () {
   let server;

--- a/api/tests/identity-access-management/acceptance/application/lti.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/lti.route.test.js
@@ -3,8 +3,9 @@ import querystring from 'node:querystring';
 import * as jose from 'jose';
 import nock from 'nock';
 
+import { createServer } from '../../../../server.js';
 import { cryptoService } from '../../../../src/shared/domain/services/crypto-service.js';
-import { createServer, databaseBuilder, domainBuilder, expect, knex } from '../../../test-helper.js';
+import { databaseBuilder, domainBuilder, expect, knex } from '../../../test-helper.js';
 
 describe('Acceptance | Identity Access Management | Route | Admin | lti', function () {
   let server;

--- a/api/tests/identity-access-management/acceptance/application/oidc-provider.admin.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/oidc-provider.admin.route.test.js
@@ -1,14 +1,9 @@
 import jsonwebtoken from 'jsonwebtoken';
 
+import { createServer } from '../../../../server.js';
 import { authenticationSessionService } from '../../../../src/identity-access-management/domain/services/authentication-session.service.js';
 import { tokenService } from '../../../../src/shared/domain/services/token-service.js';
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-  knex,
-} from '../../../test-helper.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders, knex } from '../../../test-helper.js';
 import { createMockedTestOidcProviders } from '../../../tooling/mocks/openid-client.mock.js';
 
 describe('Acceptance | Identity Access Management | Route | Admin | oidc-provider', function () {

--- a/api/tests/identity-access-management/acceptance/application/oidc-provider.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/oidc-provider.route.test.js
@@ -2,16 +2,11 @@ import querystring from 'node:querystring';
 
 import jsonwebtoken from 'jsonwebtoken';
 
+import { createServer } from '../../../../server.js';
 import { authenticationSessionService } from '../../../../src/identity-access-management/domain/services/authentication-session.service.js';
 import { AuthenticationSessionContent } from '../../../../src/shared/domain/models/AuthenticationSessionContent.js';
 import { tokenService } from '../../../../src/shared/domain/services/token-service.js';
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-  knex,
-} from '../../../test-helper.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders, knex } from '../../../test-helper.js';
 import { createMockedTestOidcProviders } from '../../../tooling/mocks/openid-client.mock.js';
 
 const UUID_PATTERN = new RegExp(/^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i);

--- a/api/tests/identity-access-management/acceptance/application/password/password.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/password/password.route.test.js
@@ -1,7 +1,8 @@
+import { createServer } from '../../../../../server.js';
 import { PasswordExpirationToken } from '../../../../../src/identity-access-management/domain/models/PasswordExpirationToken.js';
 import { resetPasswordService } from '../../../../../src/identity-access-management/domain/services/reset-password.service.js';
 import { config } from '../../../../../src/shared/config.js';
-import { createServer, databaseBuilder, expect } from '../../../../test-helper.js';
+import { databaseBuilder, expect } from '../../../../test-helper.js';
 
 describe('Acceptance | Identity Access Management | Application | Route | password', function () {
   const email = 'user@example.net';

--- a/api/tests/identity-access-management/acceptance/application/saml.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/saml.route.test.js
@@ -2,11 +2,12 @@ import _ from 'lodash';
 import samlify from 'samlify';
 import sinon from 'sinon';
 
+import { createServer } from '../../../../server.js';
 import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../../src/identity-access-management/domain/constants/identity-providers.js';
 import { UserReconciliationSamlIdToken } from '../../../../src/identity-access-management/domain/models/UserReconciliationSamlIdToken.js';
 import { config as settings } from '../../../../src/shared/config.js';
 import { tokenService } from '../../../../src/shared/domain/services/token-service.js';
-import { createServer, databaseBuilder, expect, knex } from '../../../test-helper.js';
+import { databaseBuilder, expect, knex } from '../../../test-helper.js';
 
 const testCertificate = `MIICCzCCAXQCCQD2MlHh/QmGmjANBgkqhkiG9w0BAQsFADBKMQswCQYDVQQGEwJG
 UjEPMA0GA1UECAwGRlJBTkNFMQ4wDAYDVQQHDAVQQVJJUzEMMAoGA1UECgwDUElY

--- a/api/tests/identity-access-management/acceptance/application/token.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/token.route.test.js
@@ -1,7 +1,8 @@
 import querystring from 'node:querystring';
 
+import { createServer } from '../../../../server.js';
 import { PIX_ADMIN } from '../../../../src/authorization/domain/constants.js';
-import { createServer, databaseBuilder, expect, generateInjectOptions, knex } from '../../../test-helper.js';
+import { databaseBuilder, expect, generateInjectOptions, knex } from '../../../test-helper.js';
 
 const { ROLES } = PIX_ADMIN;
 import { UserAccessToken } from '../../../../src/identity-access-management/domain/models/UserAccessToken.js';

--- a/api/tests/identity-access-management/acceptance/application/user/user.admin.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/user/user.admin.route.test.js
@@ -1,14 +1,9 @@
 import sinon from 'sinon';
 
+import { createServer } from '../../../../../server.js';
 import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../../../src/identity-access-management/domain/constants/identity-providers.js';
 import { QUERY_TYPES } from '../../../../../src/identity-access-management/domain/constants/user-query.js';
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-  knex,
-} from '../../../../test-helper.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders, knex } from '../../../../test-helper.js';
 
 describe('Acceptance | Identity Access Management | Application | Route | Admin | User', function () {
   let server;

--- a/api/tests/identity-access-management/acceptance/application/user/user.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/user/user.route.test.js
@@ -1,6 +1,7 @@
 import lodash from 'lodash';
 import sinon from 'sinon';
 
+import { createServer } from '../../../../../server.js';
 import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../../../src/identity-access-management/domain/constants/identity-providers.js';
 import { anonymousUserTokenRepository } from '../../../../../src/identity-access-management/infrastructure/repositories/anonymous-user-token.repository.js';
 import * as authenticationMethodRepository from '../../../../../src/identity-access-management/infrastructure/repositories/authentication-method.repository.js';
@@ -11,7 +12,6 @@ import { constants } from '../../../../../src/shared/domain/constants.js';
 import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
 import { featureToggles } from '../../../../../src/shared/infrastructure/feature-toggles/index.js';
 import {
-  createServer,
   databaseBuilder,
   domainBuilder,
   expect,

--- a/api/tests/identity-access-management/integration/routes.test.js
+++ b/api/tests/identity-access-management/integration/routes.test.js
@@ -2,8 +2,9 @@ import querystring from 'node:querystring';
 
 import sinon from 'sinon';
 
+import { createServer } from '../../../server.js';
 import { tokenController } from '../../../src/identity-access-management/application/token/token.controller.js';
-import { createServer, expect } from '../../test-helper.js';
+import { expect } from '../../test-helper.js';
 
 describe('Integration | Identity Access Management | Application | Router', function () {
   let headers;

--- a/api/tests/learning-content/acceptance/application/frameworks-controller_test.js
+++ b/api/tests/learning-content/acceptance/application/frameworks-controller_test.js
@@ -1,9 +1,5 @@
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../test-helper.js';
+import { createServer } from '../../../../server.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../test-helper.js';
 
 describe('Acceptance | Controller | frameworks-controller', function () {
   let server;

--- a/api/tests/learning-content/acceptance/application/learning-content-controller_test.js
+++ b/api/tests/learning-content/acceptance/application/learning-content-controller_test.js
@@ -1,4 +1,5 @@
-import { createServer, expect, generateAuthenticatedUserRequestHeaders } from '../../../test-helper.js';
+import { createServer } from '../../../../server.js';
+import { expect, generateAuthenticatedUserRequestHeaders } from '../../../test-helper.js';
 
 describe('Acceptance | Controller | lcms-controller', function () {
   let server;

--- a/api/tests/llm/acceptance/application/llm-preview-route_test.js
+++ b/api/tests/llm/acceptance/application/llm-preview-route_test.js
@@ -2,9 +2,9 @@ import { Readable } from 'node:stream';
 
 import nock from 'nock';
 
+import { createServer } from '../../../../server.js';
 import { featureToggles } from '../../../../src/shared/infrastructure/feature-toggles/index.js';
 import {
-  createServer,
   databaseBuilder,
   expect,
   generateValidRequestAuthorizationHeaderForApplication,

--- a/api/tests/maddo/application/acceptance/campaigns-routes_test.js
+++ b/api/tests/maddo/application/acceptance/campaigns-routes_test.js
@@ -1,8 +1,8 @@
+import { createMaddoServer } from '../../../../server.maddo.js';
 import { CampaignParticipationStatuses, CampaignTypes } from '../../../../src/prescription/shared/domain/constants.js';
 import { KnowledgeElementCollection } from '../../../../src/prescription/shared/domain/models/KnowledgeElementCollection.js';
 import { KnowledgeElement } from '../../../../src/shared/domain/models/KnowledgeElement.js';
 import {
-  createMaddoServer,
   databaseBuilder,
   domainBuilder,
   expect,

--- a/api/tests/maddo/application/acceptance/organizations-routes_test.js
+++ b/api/tests/maddo/application/acceptance/organizations-routes_test.js
@@ -1,10 +1,10 @@
+import { createMaddoServer } from '../../../../server.maddo.js';
 import { Campaign } from '../../../../src/maddo/domain/models/Campaign.js';
 import { Organization } from '../../../../src/maddo/domain/models/Organization.js';
 import { CampaignTypes } from '../../../../src/prescription/shared/domain/constants.js';
 import { KnowledgeElementCollection } from '../../../../src/prescription/shared/domain/models/KnowledgeElementCollection.js';
 import { KnowledgeElement } from '../../../../src/shared/domain/models/KnowledgeElement.js';
 import {
-  createMaddoServer,
   databaseBuilder,
   expect,
   generateValidRequestAuthorizationHeaderForApplication,

--- a/api/tests/organizational-entities/acceptance/application/administration-team/administration-team.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/administration-team/administration-team.admin.route.test.js
@@ -1,9 +1,5 @@
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../../test-helper.js';
+import { createServer } from '../../../../../server.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../../test-helper.js';
 
 describe('Acceptance | Organizational Entities | Application | Route | Admin | AdministrationTeam', function () {
   describe('GET /api/admin/administration-teams', function () {

--- a/api/tests/organizational-entities/acceptance/application/certification-center/certification-center.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/certification-center/certification-center.admin.route.test.js
@@ -1,10 +1,5 @@
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-  knex,
-} from '../../../../test-helper.js';
+import { createServer } from '../../../../../server.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders, knex } from '../../../../test-helper.js';
 
 describe('Acceptance | Organization Entities | Admin | Route | Certification Centers', function () {
   let superAdmin, request, server;

--- a/api/tests/organizational-entities/acceptance/application/network/network.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/network/network.admin.route.test.js
@@ -1,10 +1,5 @@
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-  knex,
-} from '../../../../test-helper.js';
+import { createServer } from '../../../../../server.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders, knex } from '../../../../test-helper.js';
 
 describe('Acceptance | Organizational Entities | Application | Route | Admin | Network', function () {
   let superAdmin;

--- a/api/tests/organizational-entities/acceptance/application/organization-learner-type/organization-learner-type.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/organization-learner-type/organization-learner-type.admin.route.test.js
@@ -1,9 +1,5 @@
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../../test-helper.js';
+import { createServer } from '../../../../../server.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../../test-helper.js';
 
 describe('Acceptance | Organizational Entities | Application | Route | Admin | OrganizationLearnerTypes', function () {
   describe('GET /api/admin/organization-learner-types', function () {

--- a/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
@@ -1,17 +1,12 @@
 import iconv from 'iconv-lite';
 import lodash from 'lodash';
 
+import { createServer } from '../../../../../server.js';
 import { PIX_ADMIN } from '../../../../../src/authorization/domain/constants.js';
 import { ORGANIZATIONS_UPDATE_HEADER } from '../../../../../src/organizational-entities/domain/constants.js';
 import { ORGANIZATION_FEATURE } from '../../../../../src/shared/domain/constants.js';
 import { Membership } from '../../../../../src/shared/domain/models/Membership.js';
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-  knex,
-} from '../../../../test-helper.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders, knex } from '../../../../test-helper.js';
 
 const { ROLES } = PIX_ADMIN;
 const { map: _map } = lodash;

--- a/api/tests/organizational-entities/acceptance/application/tag/tag.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/tag/tag.admin.route.test.js
@@ -1,11 +1,7 @@
 import _ from 'lodash';
 
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../../test-helper.js';
+import { createServer } from '../../../../../server.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../../test-helper.js';
 
 describe('Acceptance | Organizational Entities | Application | Route | Admin | Tag', function () {
   describe('GET /api/admin/tags', function () {

--- a/api/tests/prescription/campaign-participation/acceptance/application/admin-campaign-participation-route_test.js
+++ b/api/tests/prescription/campaign-participation/acceptance/application/admin-campaign-participation-route_test.js
@@ -2,13 +2,9 @@ import crypto from 'node:crypto';
 
 import sinon from 'sinon';
 
+import { createServer } from '../../../../../server.js';
 import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../../test-helper.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../../test-helper.js';
 
 describe('Acceptance | Controller | GET /api/admin/users/{userId}/participations', function () {
   let server, randomUUIDStub;

--- a/api/tests/prescription/campaign-participation/acceptance/application/campaign-participation-route_test.js
+++ b/api/tests/prescription/campaign-participation/acceptance/application/campaign-participation-route_test.js
@@ -1,11 +1,11 @@
 import times from 'lodash/times.js';
 import sinon from 'sinon';
 
+import { createServer } from '../../../../../server.js';
 import { constants } from '../../../../../src/shared/domain/constants.js';
 import { SCOPES } from '../../../../../src/shared/domain/models/BadgeDetails.js';
 import { Membership } from '../../../../../src/shared/domain/models/Membership.js';
 import {
-  createServer,
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,

--- a/api/tests/prescription/campaign-participation/acceptance/application/learner-participation-route_test.js
+++ b/api/tests/prescription/campaign-participation/acceptance/application/learner-participation-route_test.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 
+import { createServer } from '../../../../../server.js';
 import { ParticipationResultCalculationJob } from '../../../../../src/prescription/campaign-participation/domain/models/ParticipationResultCalculationJob.js';
 import { ParticipationSharedJob } from '../../../../../src/prescription/campaign-participation/domain/models/ParticipationSharedJob.js';
 import { CampaignParticipationStatuses } from '../../../../../src/prescription/shared/domain/constants.js';
@@ -7,7 +8,6 @@ import { MAX_REACHABLE_LEVEL, MAX_REACHABLE_PIX_SCORE } from '../../../../../src
 import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
 import { KnowledgeElement } from '../../../../../src/shared/domain/models/KnowledgeElement.js';
 import {
-  createServer,
   databaseBuilder,
   domainBuilder,
   expect,

--- a/api/tests/prescription/campaign-participation/acceptance/application/pole-emploi-controller_test.js
+++ b/api/tests/prescription/campaign-participation/acceptance/application/pole-emploi-controller_test.js
@@ -1,9 +1,6 @@
+import { createServer } from '../../../../../server.js';
 import { generateCursor } from '../../../../../src/prescription/campaign-participation/domain/services/pole-emploi-service.js';
-import {
-  createServer,
-  expect,
-  generateValidRequestAuthorizationHeaderForApplication,
-} from '../../../../test-helper.js';
+import { expect, generateValidRequestAuthorizationHeaderForApplication } from '../../../../test-helper.js';
 
 describe('Acceptance | Application | Pole Emploi Controller', function () {
   let server;

--- a/api/tests/prescription/campaign-participation/acceptance/application/pole-emploi-route_test.js
+++ b/api/tests/prescription/campaign-participation/acceptance/application/pole-emploi-route_test.js
@@ -1,5 +1,5 @@
+import { createServer } from '../../../../../server.js';
 import {
-  createServer,
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,

--- a/api/tests/prescription/campaign/acceptance/application/campaign-administration-route_test.js
+++ b/api/tests/prescription/campaign/acceptance/application/campaign-administration-route_test.js
@@ -1,8 +1,8 @@
+import { createServer } from '../../../../../server.js';
 import { PIX_ADMIN } from '../../../../../src/authorization/domain/constants.js';
 import { CAMPAIGN_FEATURES, ORGANIZATION_FEATURE } from '../../../../../src/shared/domain/constants.js';
 import { Membership } from '../../../../../src/shared/domain/models/Membership.js';
 import {
-  createServer,
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,

--- a/api/tests/prescription/campaign/acceptance/application/campaign-detail-route_test.js
+++ b/api/tests/prescription/campaign/acceptance/application/campaign-detail-route_test.js
@@ -1,9 +1,9 @@
+import { createServer } from '../../../../../server.js';
 import {
   CampaignExternalIdTypes,
   CampaignParticipationStatuses,
 } from '../../../../../src/prescription/shared/domain/constants.js';
 import {
-  createServer,
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,

--- a/api/tests/prescription/campaign/acceptance/application/campaign-results-route_test.js
+++ b/api/tests/prescription/campaign/acceptance/application/campaign-results-route_test.js
@@ -1,7 +1,7 @@
+import { createServer } from '../../../../../server.js';
 import { KnowledgeElementCollection } from '../../../../../src/prescription/shared/domain/models/KnowledgeElementCollection.js';
 import { Membership } from '../../../../../src/shared/domain/models/Membership.js';
 import {
-  createServer,
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,

--- a/api/tests/prescription/campaign/acceptance/application/campaign-route_test.js
+++ b/api/tests/prescription/campaign/acceptance/application/campaign-route_test.js
@@ -1,12 +1,8 @@
+import { createServer } from '../../../../../server.js';
 import { KnowledgeElementCollection } from '../../../../../src/prescription/shared/domain/models/KnowledgeElementCollection.js';
 import { KnowledgeElement } from '../../../../../src/shared/domain/models/KnowledgeElement.js';
 import { Membership } from '../../../../../src/shared/domain/models/Membership.js';
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../../test-helper.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../../test-helper.js';
 
 describe('Acceptance | API | Campaign Route', function () {
   let server;

--- a/api/tests/prescription/campaign/acceptance/application/campaign-stats-route_test.js
+++ b/api/tests/prescription/campaign/acceptance/application/campaign-stats-route_test.js
@@ -1,5 +1,5 @@
+import { createServer } from '../../../../../server.js';
 import {
-  createServer,
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,

--- a/api/tests/prescription/learner-management/acceptance/application/organization-controller-import-sco-organization-learners_test.js
+++ b/api/tests/prescription/learner-management/acceptance/application/organization-controller-import-sco-organization-learners_test.js
@@ -2,15 +2,11 @@ import { EventEmitter } from 'node:events';
 
 import iconv from 'iconv-lite';
 
+import { createServer } from '../../../../../server.js';
 import { OrganizationLearnerImportHeader } from '../../../../../src/prescription/learner-management/infrastructure/serializers/csv/organization-learner-import-header.js';
 import { Membership } from '../../../../../src/shared/domain/models/Membership.js';
 import { getI18n } from '../../../../../src/shared/infrastructure/i18n/i18n.js';
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../../test-helper.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../../test-helper.js';
 
 EventEmitter.defaultMaxListeners = 60;
 

--- a/api/tests/prescription/learner-management/acceptance/application/organization-import-route_test.js
+++ b/api/tests/prescription/learner-management/acceptance/application/organization-import-route_test.js
@@ -1,13 +1,9 @@
+import { createServer } from '../../../../../server.js';
 import { PIX_ADMIN } from '../../../../../src/authorization/domain/constants.js';
 import { ORGANIZATION_FEATURE } from '../../../../../src/shared/domain/constants.js';
 import { CsvImportError } from '../../../../../src/shared/domain/errors.js';
 import { Membership } from '../../../../../src/shared/domain/models/Membership.js';
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../../test-helper.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../../test-helper.js';
 
 describe('Acceptance | Application | organization-import', function () {
   let server;

--- a/api/tests/prescription/learner-management/acceptance/application/organization-learners-route_test.js
+++ b/api/tests/prescription/learner-management/acceptance/application/organization-learners-route_test.js
@@ -1,14 +1,10 @@
+import { createServer } from '../../../../../server.js';
 import { PIX_ADMIN } from '../../../../../src/authorization/domain/constants.js';
 import { IMPORT_KEY_FIELD } from '../../../../../src/prescription/learner-management/domain/constants.js';
 import { getLastByOrganizationId } from '../../../../../src/prescription/learner-management/infrastructure/repositories/organization-import-repository.js';
 import { ORGANIZATION_FEATURE } from '../../../../../src/shared/domain/constants.js';
 import { Membership } from '../../../../../src/shared/domain/models/Membership.js';
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../../test-helper.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../../test-helper.js';
 
 describe('Acceptance | Prescription | learner management | Application | organization-learners-management', function () {
   let server;

--- a/api/tests/prescription/learner-management/acceptance/application/sco-organization-management-route_test.js
+++ b/api/tests/prescription/learner-management/acceptance/application/sco-organization-management-route_test.js
@@ -1,10 +1,5 @@
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-  knex,
-} from '../../../../test-helper.js';
+import { createServer } from '../../../../../server.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders, knex } from '../../../../test-helper.js';
 
 describe('Acceptance | Route | sco-organization-management-route', function () {
   let server;

--- a/api/tests/prescription/learner-management/acceptance/application/sup-organization-management-route_test.js
+++ b/api/tests/prescription/learner-management/acceptance/application/sup-organization-management-route_test.js
@@ -1,13 +1,9 @@
+import { createServer } from '../../../../../server.js';
 import { UserAccessToken } from '../../../../../src/identity-access-management/domain/models/UserAccessToken.js';
 import { SupOrganizationLearnerImportHeader } from '../../../../../src/prescription/learner-management/infrastructure/serializers/csv/sup-organization-learner-import-header.js';
 import { Membership } from '../../../../../src/shared/domain/models/Membership.js';
 import { getI18n } from '../../../../../src/shared/infrastructure/i18n/i18n.js';
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../../test-helper.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../../test-helper.js';
 
 const i18n = getI18n();
 const supOrganizationLearnerImportHeader = new SupOrganizationLearnerImportHeader(i18n).columns

--- a/api/tests/prescription/organization-learner-feature/acceptance/application/organization-learner-features_test.js
+++ b/api/tests/prescription/organization-learner-feature/acceptance/application/organization-learner-features_test.js
@@ -1,11 +1,7 @@
+import { createServer } from '../../../../../server.js';
 import { ORGANIZATION_FEATURE } from '../../../../../src/shared/domain/constants.js';
 import { Membership } from '../../../../../src/shared/domain/models/Membership.js';
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../../test-helper.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../../test-helper.js';
 
 describe('Acceptance | Organization learner features', function () {
   describe('POST /api/organizations/{organizationId}/organization-learners/{organizationLearnerId}/features/{featureKey}', function () {

--- a/api/tests/prescription/organization-learner/acceptance/application/learner-activity-controller_test.js
+++ b/api/tests/prescription/organization-learner/acceptance/application/learner-activity-controller_test.js
@@ -1,10 +1,6 @@
+import { createServer } from '../../../../../server.js';
 import { Membership } from '../../../../../src/shared/domain/models/Membership.js';
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../../test-helper.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../../test-helper.js';
 
 describe('Acceptance | Controller | organization-learners-management', function () {
   let server;

--- a/api/tests/prescription/organization-learner/acceptance/application/organization-learner-controller_test.js
+++ b/api/tests/prescription/organization-learner/acceptance/application/organization-learner-controller_test.js
@@ -1,10 +1,6 @@
+import { createServer } from '../../../../../server.js';
 import { Membership } from '../../../../../src/shared/domain/models/Membership.js';
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../../test-helper.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../../test-helper.js';
 
 describe('Acceptance | Controller | organization-learner', function () {
   let server;

--- a/api/tests/prescription/organization-learner/acceptance/application/organization-learners-route_test.js
+++ b/api/tests/prescription/organization-learner/acceptance/application/organization-learners-route_test.js
@@ -1,8 +1,8 @@
+import { createServer } from '../../../../../server.js';
 import { REWARD_TYPES } from '../../../../../src/quest/domain/constants.js';
 import { ORGANIZATION_FEATURE } from '../../../../../src/shared/domain/constants.js';
 import { Membership } from '../../../../../src/shared/domain/models/Membership.js';
 import {
-  createServer,
   databaseBuilder,
   datamartBuilder,
   expect,

--- a/api/tests/prescription/organization-learner/acceptance/application/organization-to-join-route_test.js
+++ b/api/tests/prescription/organization-learner/acceptance/application/organization-to-join-route_test.js
@@ -1,4 +1,5 @@
-import { createServer, databaseBuilder, expect } from '../../../../test-helper.js';
+import { createServer } from '../../../../../server.js';
+import { databaseBuilder, expect } from '../../../../test-helper.js';
 
 describe('Acceptance | Application | organization-invitation-route', function () {
   let server;

--- a/api/tests/prescription/organization-learner/acceptance/application/sco-organization-learner-controller_test.js
+++ b/api/tests/prescription/organization-learner/acceptance/application/sco-organization-learner-controller_test.js
@@ -1,10 +1,5 @@
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-  knex,
-} from '../../../../test-helper.js';
+import { createServer } from '../../../../../server.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders, knex } from '../../../../test-helper.js';
 
 describe('Acceptance | Controller | sco-organization-learners', function () {
   let server;

--- a/api/tests/prescription/organization-learner/acceptance/application/sco-organization-learner-route_test.js
+++ b/api/tests/prescription/organization-learner/acceptance/application/sco-organization-learner-route_test.js
@@ -1,13 +1,8 @@
+import { createServer } from '../../../../../server.js';
 import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../../../src/identity-access-management/domain/constants/identity-providers.js';
 import { UserReconciliationSamlIdToken } from '../../../../../src/identity-access-management/domain/models/UserReconciliationSamlIdToken.js';
 import { Membership } from '../../../../../src/shared/domain/models/Membership.js';
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-  knex,
-} from '../../../../test-helper.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders, knex } from '../../../../test-helper.js';
 
 describe('Prescription | Organization Learner | Acceptance | Application | sco-organization-learner-route', function () {
   let server;

--- a/api/tests/prescription/organization-learner/acceptance/learner-list-route_test.js
+++ b/api/tests/prescription/organization-learner/acceptance/learner-list-route_test.js
@@ -1,10 +1,6 @@
+import { createServer } from '../../../../server.js';
 import { Membership } from '../../../../src/shared/domain/models/Membership.js';
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../test-helper.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../test-helper.js';
 
 describe('Acceptance | Application | learner-list-route', function () {
   let server;

--- a/api/tests/prescription/organization-learner/acceptance/registration-organization-learner-route_test.js
+++ b/api/tests/prescription/organization-learner/acceptance/registration-organization-learner-route_test.js
@@ -1,9 +1,5 @@
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../test-helper.js';
+import { createServer } from '../../../../server.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../test-helper.js';
 
 describe('Acceptance | Application | registration-organization-learner-route', function () {
   let server;

--- a/api/tests/prescription/organization-learner/acceptance/sco-learner-list-route_test.js
+++ b/api/tests/prescription/organization-learner/acceptance/sco-learner-list-route_test.js
@@ -1,10 +1,6 @@
+import { createServer } from '../../../../server.js';
 import { CampaignTypes } from '../../../../src/prescription/shared/domain/constants.js';
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../test-helper.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../test-helper.js';
 
 describe('Acceptance | Application | sco-leaner-list-route', function () {
   let server;

--- a/api/tests/prescription/organization-learner/acceptance/sup-learner-list-route_test.js
+++ b/api/tests/prescription/organization-learner/acceptance/sup-learner-list-route_test.js
@@ -1,9 +1,5 @@
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../test-helper.js';
+import { createServer } from '../../../../server.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../test-helper.js';
 
 describe('Acceptance | Application | sup-leaner-list-route', function () {
   let server;

--- a/api/tests/prescription/organization-place/acceptance/application/create-organization-places-lot_test.js
+++ b/api/tests/prescription/organization-place/acceptance/application/create-organization-places-lot_test.js
@@ -1,11 +1,7 @@
+import { createServer } from '../../../../../server.js';
 import * as organizationPlacesCategories from '../../../../../src/prescription/organization-place/domain/constants/organization-places-categories.js';
 import { ORGANIZATION_FEATURE } from '../../../../../src/shared/domain/constants.js';
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../../test-helper.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../../test-helper.js';
 
 describe('Acceptance | Route | Create Organization Places Lot', function () {
   describe('POST /api/admin/organizations/{id}/places', function () {

--- a/api/tests/prescription/organization-place/acceptance/application/delete-organization-places-lot_test.js
+++ b/api/tests/prescription/organization-place/acceptance/application/delete-organization-places-lot_test.js
@@ -1,9 +1,5 @@
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../../test-helper.js';
+import { createServer } from '../../../../../server.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../../test-helper.js';
 
 describe('Acceptance | Route | Delete Organizations Places Lot', function () {
   describe('DELETE /api/admin/organizations/{id}/places/{placeId}', function () {

--- a/api/tests/prescription/organization-place/acceptance/application/find-organization-places_test.js
+++ b/api/tests/prescription/organization-place/acceptance/application/find-organization-places_test.js
@@ -1,10 +1,6 @@
+import { createServer } from '../../../../../server.js';
 import * as organizationPlacesLotCategories from '../../../../../src/prescription/organization-place/domain/constants/organization-places-categories.js';
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../../test-helper.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../../test-helper.js';
 
 describe('Acceptance | Route | Find Organization Places', function () {
   describe('GET /api/admin/organizations/{id}/places', function () {

--- a/api/tests/prescription/organization-place/acceptance/application/get-data-organization-places_test.js
+++ b/api/tests/prescription/organization-place/acceptance/application/get-data-organization-places_test.js
@@ -1,8 +1,5 @@
-import {
-  createServer,
-  expect,
-  generateValidRequestAuthorizationHeaderForApplication,
-} from '../../../../test-helper.js';
+import { createServer } from '../../../../../server.js';
+import { expect, generateValidRequestAuthorizationHeaderForApplication } from '../../../../test-helper.js';
 
 describe('Acceptance | Route | Get Data Organization Places', function () {
   describe('GET /api/data/organization-places', function () {

--- a/api/tests/prescription/organization-place/acceptance/application/get-organization-places-lots_test.js
+++ b/api/tests/prescription/organization-place/acceptance/application/get-organization-places-lots_test.js
@@ -1,11 +1,7 @@
+import { createServer } from '../../../../../server.js';
 import { ORGANIZATION_FEATURE } from '../../../../../src/shared/domain/constants.js';
 import { Membership } from '../../../../../src/shared/domain/models/Membership.js';
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../../test-helper.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../../test-helper.js';
 
 describe('Acceptance | Route | Get Organizations Places Lots', function () {
   describe('GET /api/organizations/{id}/places-lots', function () {

--- a/api/tests/prescription/organization-place/acceptance/application/get-organization-places-statistics_test.js
+++ b/api/tests/prescription/organization-place/acceptance/application/get-organization-places-statistics_test.js
@@ -1,12 +1,8 @@
+import { createServer } from '../../../../../server.js';
 import * as categories from '../../../../../src/prescription/organization-place/domain/constants/organization-places-categories.js';
 import { ORGANIZATION_FEATURE } from '../../../../../src/shared/domain/constants.js';
 import { Membership } from '../../../../../src/shared/domain/models/Membership.js';
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../../test-helper.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../../test-helper.js';
 
 describe('Acceptance | Route | Get Organizations Places Statistics', function () {
   describe('GET /api/organizations/{id}/places-statistics', function () {

--- a/api/tests/prescription/target-profile/acceptance/application/admin-target-profile-route_test.js
+++ b/api/tests/prescription/target-profile/acceptance/application/admin-target-profile-route_test.js
@@ -1,8 +1,8 @@
 import sinon from 'sinon';
 
+import { createServer } from '../../../../../server.js';
 import * as TargetProfile from '../../../../../src/shared/domain/models/TargetProfile.js';
 import {
-  createServer,
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,

--- a/api/tests/prescription/target-profile/acceptance/application/target-profile-route_test.js
+++ b/api/tests/prescription/target-profile/acceptance/application/target-profile-route_test.js
@@ -1,5 +1,5 @@
+import { createServer } from '../../../../../server.js';
 import {
-  createServer,
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,

--- a/api/tests/profile/acceptance/application/attestation-route_test.js
+++ b/api/tests/profile/acceptance/application/attestation-route_test.js
@@ -1,9 +1,5 @@
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../test-helper.js';
+import { createServer } from '../../../../server.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../test-helper.js';
 import { mockAttestationStorage } from '../../../tooling/mocks/attestation-storage.mock.js';
 
 describe('Profile | Acceptance | Application | Attestation Route ', function () {

--- a/api/tests/quest/acceptance/application/attestation-route_test.js
+++ b/api/tests/quest/acceptance/application/attestation-route_test.js
@@ -1,14 +1,9 @@
 import FormData from 'form-data';
 
+import { createServer } from '../../../../server.js';
 import { PIX_ADMIN } from '../../../../src/authorization/domain/constants.js';
 import { ORGANIZATION_FEATURE } from '../../../../src/shared/domain/constants.js';
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-  knex,
-} from '../../../test-helper.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders, knex } from '../../../test-helper.js';
 import { AttestationTemplateFixture } from '../../../tooling/fixtures/index.js';
 import { mockAttestationStorageUpload } from '../../../tooling/mocks/attestation-storage.mock.js';
 

--- a/api/tests/quest/acceptance/application/combined-course-blueprint-route_test.js
+++ b/api/tests/quest/acceptance/application/combined-course-blueprint-route_test.js
@@ -1,11 +1,7 @@
+import { createServer } from '../../../../server.js';
 import { ATTESTATIONS } from '../../../../src/profile/domain/constants.js';
 import { AdminCombinedCourseBlueprint } from '../../../../src/quest/domain/models/AdminCombinedCourseBlueprint.js';
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../test-helper.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../test-helper.js';
 
 describe('Quest | Acceptance | Application | Combined course blueprint Route ', function () {
   let server;

--- a/api/tests/quest/acceptance/application/combined-course-route_test.js
+++ b/api/tests/quest/acceptance/application/combined-course-route_test.js
@@ -1,16 +1,12 @@
 import iconv from 'iconv-lite';
 
+import { createServer } from '../../../../server.js';
 import { PIX_ADMIN } from '../../../../src/authorization/domain/constants.js';
 import {
   OrganizationLearnerParticipationStatuses,
   OrganizationLearnerParticipationTypes,
 } from '../../../../src/quest/domain/models/OrganizationLearnerParticipation.js';
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../test-helper.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../test-helper.js';
 
 const ROLES = PIX_ADMIN.ROLES;
 

--- a/api/tests/quest/acceptance/application/quest-route_test.js
+++ b/api/tests/quest/acceptance/application/quest-route_test.js
@@ -1,17 +1,12 @@
 import iconv from 'iconv-lite';
 
+import { createServer } from '../../../../server.js';
 import {
   CRITERION_COMPARISONS,
   REQUIREMENT_COMPARISONS,
   REQUIREMENT_TYPES,
 } from '../../../../src/quest/domain/models/Quest.js';
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-  knex,
-} from '../../../test-helper.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders, knex } from '../../../test-helper.js';
 
 describe('Quest | Acceptance | Application | Quest Route ', function () {
   let server;

--- a/api/tests/quest/acceptance/application/verified-code-route_test.js
+++ b/api/tests/quest/acceptance/application/verified-code-route_test.js
@@ -1,4 +1,5 @@
-import { createServer, databaseBuilder, expect } from '../../../test-helper.js';
+import { createServer } from '../../../../server.js';
+import { databaseBuilder, expect } from '../../../test-helper.js';
 
 describe('Quest | Acceptance | Application | Verified Code Route ', function () {
   let server;

--- a/api/tests/school/acceptance/application/assessments/activity-answer-controller_test.js
+++ b/api/tests/school/acceptance/application/assessments/activity-answer-controller_test.js
@@ -1,5 +1,6 @@
+import { createServer } from '../../../../../server.js';
 import { Activity } from '../../../../../src/school/domain/models/Activity.js';
-import { createServer, databaseBuilder, expect } from '../../../../test-helper.js';
+import { databaseBuilder, expect } from '../../../../test-helper.js';
 import * as learningContentBuilder from '../../../../tooling/learning-content-builder/index.js';
 
 describe('Acceptance | Controller | activity-answer-controller', function () {

--- a/api/tests/school/acceptance/application/assessments/assessment-controller_test.js
+++ b/api/tests/school/acceptance/application/assessments/assessment-controller_test.js
@@ -1,5 +1,6 @@
+import { createServer } from '../../../../../server.js';
 import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
-import { createServer, databaseBuilder, expect, knex } from '../../../../test-helper.js';
+import { databaseBuilder, expect, knex } from '../../../../test-helper.js';
 import * as learningContentBuilder from '../../../../tooling/learning-content-builder/index.js';
 
 describe('Acceptance | Controller | assessment-controller', function () {

--- a/api/tests/school/acceptance/application/challenge-route_test.js
+++ b/api/tests/school/acceptance/application/challenge-route_test.js
@@ -1,4 +1,5 @@
-import { createServer, databaseBuilder, expect } from '../../../test-helper.js';
+import { createServer } from '../../../../server.js';
+import { databaseBuilder, expect } from '../../../test-helper.js';
 import * as learningContentBuilder from '../../../tooling/learning-content-builder/index.js';
 
 describe('Integration | Controller | challenge-controller', function () {

--- a/api/tests/shared/acceptance/application/assessments/assessment-controller-auto-validate-next-challenge_test.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-controller-auto-validate-next-challenge_test.js
@@ -1,7 +1,7 @@
+import { createServer } from '../../../../../server.js';
 import { config as settings } from '../../../../../src/shared/config.js';
 import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
 import {
-  createServer,
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,

--- a/api/tests/shared/acceptance/application/assessments/assessment-controller-find-competence-evaluations_test.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-controller-find-competence-evaluations_test.js
@@ -1,9 +1,5 @@
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../../test-helper.js';
+import { createServer } from '../../../../../server.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../../test-helper.js';
 
 describe('Acceptance | API | assessment-controller-find-competence-evaluations', function () {
   let server;

--- a/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-for-campaign-assessment_test.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-for-campaign-assessment_test.js
@@ -1,8 +1,8 @@
 import sinon from 'sinon';
 
+import { createServer } from '../../../../../server.js';
 import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
 import {
-  createServer,
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,

--- a/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-for-certification_test.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-for-certification_test.js
@@ -1,12 +1,12 @@
 import sinon from 'sinon';
 
+import { createServer } from '../../../../../server.js';
 import { AlgorithmEngineVersion } from '../../../../../src/certification/shared/domain/models/AlgorithmEngineVersion.js';
 import { CertificationChallengeLiveAlertStatus } from '../../../../../src/certification/shared/domain/models/CertificationChallengeLiveAlert.js';
 import { CertificationCompanionLiveAlertStatus } from '../../../../../src/certification/shared/domain/models/CertificationCompanionLiveAlert.js';
 import { SCOPES } from '../../../../../src/certification/shared/domain/models/Scopes.js';
 import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
 import {
-  createServer,
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,

--- a/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-for-competence-evaluation_test.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-for-competence-evaluation_test.js
@@ -1,9 +1,9 @@
 import sinon from 'sinon';
 
+import { createServer } from '../../../../../server.js';
 import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
 import { KnowledgeElement } from '../../../../../src/shared/domain/models/KnowledgeElement.js';
 import {
-  createServer,
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,

--- a/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-for-demo_test.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-for-demo_test.js
@@ -1,5 +1,6 @@
+import { createServer } from '../../../../../server.js';
 import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
-import { createServer, databaseBuilder, expect, learningContentBuilder } from '../../../../test-helper.js';
+import { databaseBuilder, expect, learningContentBuilder } from '../../../../test-helper.js';
 
 describe('Acceptance | API | assessment-controller-get-next-challenge-for-demo', function () {
   let server;

--- a/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-locale-management.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-locale-management.js
@@ -1,7 +1,7 @@
+import { createServer } from '../../../../../server.js';
 import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
 import { FRENCH_FRANCE } from '../../../../../src/shared/domain/services/locale-service.js';
 import {
-  createServer,
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,

--- a/api/tests/shared/acceptance/application/assessments/assessment-controller-get_test.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-controller-get_test.js
@@ -1,7 +1,7 @@
+import { createServer } from '../../../../../server.js';
 import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
 import { FRENCH_SPOKEN } from '../../../../../src/shared/domain/services/locale-service.js';
 import {
-  createServer,
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,

--- a/api/tests/shared/acceptance/application/assessments/assessment-controller-pause-assessment_test.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-controller-pause-assessment_test.js
@@ -1,11 +1,6 @@
+import { createServer } from '../../../../../server.js';
 import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-  knex,
-} from '../../../../test-helper.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders, knex } from '../../../../test-helper.js';
 
 describe('Acceptance | API | assessment-controller-pause-assessment', function () {
   describe('POST /api/assessments/{id}/alert', function () {

--- a/api/tests/shared/acceptance/application/assessments/assessment-controller-post_test.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-controller-post_test.js
@@ -1,10 +1,5 @@
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-  knex,
-} from '../../../../test-helper.js';
+import { createServer } from '../../../../../server.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders, knex } from '../../../../test-helper.js';
 
 describe('Acceptance | API | Assessments POST', function () {
   let server;

--- a/api/tests/shared/acceptance/application/assessments/assessment-controller-update-last-challenge-state_test.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-controller-update-last-challenge-state_test.js
@@ -1,6 +1,6 @@
+import { createServer } from '../../../../../server.js';
 import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
 import {
-  createServer,
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,

--- a/api/tests/shared/acceptance/application/badges/badge-controller_test.js
+++ b/api/tests/shared/acceptance/application/badges/badge-controller_test.js
@@ -1,9 +1,5 @@
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../../test-helper.js';
+import { createServer } from '../../../../../server.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../../test-helper.js';
 
 describe('Acceptance | API | Badges', function () {
   let server, options, badge, superAdmin;

--- a/api/tests/shared/acceptance/application/challenges/challenge-controller_test.js
+++ b/api/tests/shared/acceptance/application/challenges/challenge-controller_test.js
@@ -1,4 +1,5 @@
-import { createServer, databaseBuilder, expect, learningContentBuilder } from '../../../../test-helper.js';
+import { createServer } from '../../../../../server.js';
+import { databaseBuilder, expect, learningContentBuilder } from '../../../../test-helper.js';
 
 describe('Acceptance | API | ChallengeController', function () {
   let server;

--- a/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
+++ b/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
@@ -1,4 +1,5 @@
-import { createServer, expect } from '../../../../test-helper.js';
+import { createServer } from '../../../../../server.js';
+import { expect } from '../../../../test-helper.js';
 
 describe('Acceptance | Shared | Application | Controller | feature-toggle', function () {
   let server;

--- a/api/tests/shared/acceptance/application/healthcheck.route.test.js
+++ b/api/tests/shared/acceptance/application/healthcheck.route.test.js
@@ -1,4 +1,5 @@
-import { createServer, expect } from '../../../test-helper.js';
+import { createServer } from '../../../../server.js';
+import { expect } from '../../../test-helper.js';
 
 describe('Acceptance | Shared | Application | Route | healthcheck', function () {
   let server;

--- a/api/tests/shared/acceptance/application/security-pre-handlers_test.js
+++ b/api/tests/shared/acceptance/application/security-pre-handlers_test.js
@@ -1,3 +1,4 @@
+import { createServer } from '../../../../server.js';
 import {
   OrganizationLearnerParticipationStatuses,
   OrganizationLearnerParticipationTypes,
@@ -5,12 +6,7 @@ import {
 import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
 import { ORGANIZATION_FEATURE } from '../../../../src/shared/domain/constants.js';
 import { Membership } from '../../../../src/shared/domain/models/Membership.js';
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../test-helper.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../test-helper.js';
 
 describe('Acceptance | Application | SecurityPreHandlers', function () {
   const jsonApiError403 = {

--- a/api/tests/shared/acceptance/application/swaggers_test.js
+++ b/api/tests/shared/acceptance/application/swaggers_test.js
@@ -1,5 +1,7 @@
+import { createServer } from '../../../../server.js';
+import { createMaddoServer } from '../../../../server.maddo.js';
 import { config } from '../../../../src/shared/config.js';
-import { createMaddoServer, createServer, expect } from '../../../test-helper.js';
+import { expect } from '../../../test-helper.js';
 
 describe('Acceptance | Controller | Open Api', function () {
   let server;

--- a/api/tests/shared/integration/healthcheck.route.test.js
+++ b/api/tests/shared/integration/healthcheck.route.test.js
@@ -1,7 +1,8 @@
 import sinon from 'sinon';
 
 import { databaseConnections } from '../../../db/database-connections.js';
-import { createServer, expect } from '../../test-helper.js';
+import { createServer } from '../../../server.js';
+import { expect } from '../../test-helper.js';
 
 describe('Integration | Shared | Application | Route | healthcheck', function () {
   let server;

--- a/api/tests/team/acceptance/application/admin-member/admin-member.route.test.js
+++ b/api/tests/team/acceptance/application/admin-member/admin-member.route.test.js
@@ -1,10 +1,6 @@
+import { createServer } from '../../../../../server.js';
 import { PIX_ADMIN } from '../../../../../src/authorization/domain/constants.js';
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../../test-helper.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../../test-helper.js';
 
 const { ROLES } = PIX_ADMIN;
 

--- a/api/tests/team/acceptance/application/certification-center-invitation/certification-center-invitation.admin.route.test.js
+++ b/api/tests/team/acceptance/application/certification-center-invitation/certification-center-invitation.admin.route.test.js
@@ -1,12 +1,8 @@
 import sinon from 'sinon';
 
+import { createServer } from '../../../../../server.js';
 import { CertificationCenterInvitation } from '../../../../../src/team/domain/models/CertificationCenterInvitation.js';
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../../test-helper.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../../test-helper.js';
 
 describe('Acceptance | Team | Application | Route | Admin | Certification Center Invitation', function () {
   let server;

--- a/api/tests/team/acceptance/application/certification-center-invitation/certification-center-invitation.route.test.js
+++ b/api/tests/team/acceptance/application/certification-center-invitation/certification-center-invitation.route.test.js
@@ -1,6 +1,6 @@
+import { createServer } from '../../../../../server.js';
 import { CertificationCenterInvitation } from '../../../../../src/team/domain/models/CertificationCenterInvitation.js';
 import {
-  createServer,
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,

--- a/api/tests/team/acceptance/application/certification-center-membership/certification-center-membership.admin.route.test.js
+++ b/api/tests/team/acceptance/application/certification-center-membership/certification-center-membership.admin.route.test.js
@@ -1,11 +1,7 @@
 import _ from 'lodash';
 
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../../test-helper.js';
+import { createServer } from '../../../../../server.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../../test-helper.js';
 
 describe('Acceptance | Team | Application | Admin | Routes | certification-center-membership', function () {
   let server;

--- a/api/tests/team/acceptance/application/certification-center-membership/certification-center-membership.route.test.js
+++ b/api/tests/team/acceptance/application/certification-center-membership/certification-center-membership.route.test.js
@@ -1,11 +1,7 @@
 import _ from 'lodash';
 
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../../test-helper.js';
+import { createServer } from '../../../../../server.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../../test-helper.js';
 
 describe('Acceptance | Team | Application | Routes | certification-center-membership ', function () {
   let server, options;

--- a/api/tests/team/acceptance/application/membership/membership.admin.route.test.js
+++ b/api/tests/team/acceptance/application/membership/membership.admin.route.test.js
@@ -1,12 +1,8 @@
 import _ from 'lodash';
 
+import { createServer } from '../../../../../server.js';
 import { Membership } from '../../../../../src/shared/domain/models/Membership.js';
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../../test-helper.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../../test-helper.js';
 
 describe('Acceptance | Team | Admin | Route | membership', function () {
   let server;

--- a/api/tests/team/acceptance/application/membership/membership.route.test.js
+++ b/api/tests/team/acceptance/application/membership/membership.route.test.js
@@ -1,12 +1,8 @@
 import _ from 'lodash';
 
+import { createServer } from '../../../../../server.js';
 import { Membership } from '../../../../../src/shared/domain/models/Membership.js';
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../../test-helper.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../../test-helper.js';
 
 describe('Acceptance | Team | Application | Route | membership', function () {
   let server;

--- a/api/tests/team/acceptance/application/membership/organization-members-identities.route.test.js
+++ b/api/tests/team/acceptance/application/membership/organization-members-identities.route.test.js
@@ -1,9 +1,5 @@
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../../../tests/test-helper.js';
+import { createServer } from '../../../../../server.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../../../tests/test-helper.js';
 
 describe('Acceptance | Team | Application | Route | organization-member-identities', function () {
   let server;

--- a/api/tests/team/acceptance/application/organization-invitations/organization-invitation.admin.route.test.js
+++ b/api/tests/team/acceptance/application/organization-invitations/organization-invitation.admin.route.test.js
@@ -1,11 +1,7 @@
+import { createServer } from '../../../../../server.js';
 import { Membership } from '../../../../../src/shared/domain/models/Membership.js';
 import { OrganizationInvitation } from '../../../../../src/team/domain/models/OrganizationInvitation.js';
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../../../tests/test-helper.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../../../tests/test-helper.js';
 
 describe('Acceptance | Team | Route | Admin | organization-invitation', function () {
   describe('GET /api/admin/organizations/{id}/invitations', function () {

--- a/api/tests/team/acceptance/application/organization-invitations/organization-invitation.route.test.js
+++ b/api/tests/team/acceptance/application/organization-invitations/organization-invitation.route.test.js
@@ -1,10 +1,10 @@
 import lodash from 'lodash';
 import sinon from 'sinon';
 
+import { createServer } from '../../../../../server.js';
 import { Membership } from '../../../../../src/shared/domain/models/Membership.js';
 import { OrganizationInvitation } from '../../../../../src/team/domain/models/OrganizationInvitation.js';
 import {
-  createServer,
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,

--- a/api/tests/team/acceptance/application/prescriber-informations.controller.test.js
+++ b/api/tests/team/acceptance/application/prescriber-informations.controller.test.js
@@ -1,12 +1,8 @@
 import _ from 'lodash';
 
+import { createServer } from '../../../../server.js';
 import { ORGANIZATION_FEATURE } from '../../../../src/shared/domain/constants.js';
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../test-helper.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../test-helper.js';
 
 describe('Acceptance | Team | Application | Controller | prescriber-informations', function () {
   let user;

--- a/api/tests/team/acceptance/application/user-orga-settings.controller.test.js
+++ b/api/tests/team/acceptance/application/user-orga-settings.controller.test.js
@@ -1,9 +1,5 @@
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../test-helper.js';
+import { createServer } from '../../../../server.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../test-helper.js';
 
 describe('Acceptance | Controller | user-orga-settings-controller', function () {
   let server;

--- a/api/tests/team/integration/application/certification-center-membership/certification-center-membership.admin.route.test.js
+++ b/api/tests/team/integration/application/certification-center-membership/certification-center-membership.admin.route.test.js
@@ -1,9 +1,5 @@
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../../test-helper.js';
+import { createServer } from '../../../../../server.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../../test-helper.js';
 
 describe('Integration | Team | Application | Certification Center Membership | Admin | Route', function () {
   describe('GET /api/admin/users/{userId}/certification-center-memberships', function () {

--- a/api/tests/team/integration/application/certification-center-membership/certification-center-membership.route.test.js
+++ b/api/tests/team/integration/application/certification-center-membership/certification-center-membership.route.test.js
@@ -1,9 +1,5 @@
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateAuthenticatedUserRequestHeaders,
-} from '../../../../test-helper.js';
+import { createServer } from '../../../../../server.js';
+import { databaseBuilder, expect, generateAuthenticatedUserRequestHeaders } from '../../../../test-helper.js';
 
 describe('Integration | Team | Application | Certification Center Membership | Admin | Route', function () {
   let server;

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -13,8 +13,6 @@ import { knex as datamartKnex } from '../datamart/knex-database-connection.js';
 import { knex as datawarehouseKnex } from '../datawarehouse/knex-database-connection.js';
 import { DatabaseBuilder } from '../db/database-builder/database-builder.js';
 import { disconnect, knex } from '../db/knex-database-connection.js';
-import { createServer } from '../server.js';
-import { createMaddoServer } from '../server.maddo.js';
 import * as tutorialRepository from '../src/devcomp/infrastructure/repositories/tutorial-repository.js';
 import * as missionRepository from '../src/school/infrastructure/repositories/mission-repository.js';
 import { featureToggles } from '../src/shared/infrastructure/feature-toggles/index.js';
@@ -113,8 +111,6 @@ after(async function () {
 
 // eslint-disable-next-line mocha/no-exports
 export {
-  createMaddoServer,
-  createServer,
   databaseBuilder,
   datamartBuilder,
   datamartKnex,

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -38,8 +38,6 @@ import {
   generateValidRequestAuthorizationHeaderForApplication,
 } from './tooling/test-utils/http-server.js';
 
-const MOCHA_TIMEOUT = 5000;
-
 // Init Dayjs configuration
 dayjs.extend(localizedFormat);
 
@@ -68,10 +66,6 @@ before(async function () {
   } catch {
     // pgBoss is not available on unit tests
   }
-});
-
-beforeEach(function () {
-  this.timeout(MOCHA_TIMEOUT);
 });
 
 afterEach(async function () {


### PR DESCRIPTION
## 🌱 Problème

Pour la suite de la simplification du fichier `test-helper.js`, commencer à ne plus proxifier certains utilitaires depuis `test-helper.js`.


## 🐣 Proposition

- Utiliser directement `createServer` depuis `server.js` dans les tests au lieu du `test-helper.js`
- Utiliser directement `createMaddoServer` depuis `server.maddo.js` dans les tests au lieu du `test-helper.js`

_**Claude a été utilisé** pour générer un codemod car il y a avait beaucoup de fichiers à modifier._

## 🌷 Remarques

Mise en place du timeout mocha par défaut via le CLI sur `npm run test:api:path`.

## 🐝 Pour tester

La CI doit passer
