### PR TITLE
[FEATURE] Autoriser le rôle métier à accéder à l'onglet Réseau d'une organisation (PIX-22118)

### DIFF
--- a/admin/app/components/organizations/head-information.gjs
+++ b/admin/app/components/organizations/head-information.gjs
@@ -11,9 +11,9 @@ import CopyButton from 'pix-admin/components/ui/copy-button';
 import ENV from 'pix-admin/config/environment';
 
 export default class HeadInformation extends Component {
-  @service currentUser;
   @service intl;
   @service pixToast;
+  @service accessControl;
 
   @action
   onLogoUpload(event) {
@@ -104,7 +104,7 @@ export default class HeadInformation extends Component {
 
         <ul class="organization-tags-list">
           {{#if this.belongsToNetwork}}
-            {{#if this.currentUser.adminMember.isSuperAdmin}}
+            {{#if this.accessControl.hasAccessToNetworkFeature}}
               <PixTag class="organization__child-tag" @color="success">
                 {{t "components.organizations.head-information.network"}}
                 <LinkTo @route="authenticated.networks.get" @model={{@organization.network.id}}>

--- a/admin/app/components/organizations/network/actions-section.gjs
+++ b/admin/app/components/organizations/network/actions-section.gjs
@@ -12,7 +12,7 @@ export default class ActionsSection extends Component {
   <template>
     <section class="page-section">
       <div class="content-text content-text--small organization-network__actions-section">
-        {{#if this.accessControl.hasAccessToAttachChildOrganizationActionsScope}}
+        {{#if this.accessControl.hasAccessToNetworkFeature}}
           <PixButtonLink
             @iconBefore="add"
             @variant="secondary"

--- a/admin/app/routes/authenticated/organizations/get/network.js
+++ b/admin/app/routes/authenticated/organizations/get/network.js
@@ -6,7 +6,7 @@ export default class Network extends Route {
   @service router;
 
   beforeModel() {
-    this.accessControl.restrictAccessTo(['isSuperAdmin'], 'authenticated.organizations.get.details');
+    this.accessControl.restrictAccessTo(['isSuperAdmin', 'isMetier'], 'authenticated.organizations.get.details');
 
     const organization = this.modelFor('authenticated.organizations.get');
 

--- a/admin/app/services/access-control.js
+++ b/admin/app/services/access-control.js
@@ -83,4 +83,8 @@ export default class AccessControlService extends Service {
       this.currentUser.adminMember.isCertif
     );
   }
+
+  get hasAccessToNetworkFeature() {
+    return Boolean(this.currentUser.adminMember.isSuperAdmin || this.currentUser.adminMember.isMetier);
+  }
 }

--- a/admin/app/templates/authenticated/organizations/get.gjs
+++ b/admin/app/templates/authenticated/organizations/get.gjs
@@ -70,7 +70,7 @@ import HeadInformation from 'pix-admin/components/organizations/head-information
         </LinkTo>
       {{/if}}
 
-      {{#if @controller.accessControl.currentUser.adminMember.isSuperAdmin}}
+      {{#if @controller.accessControl.hasAccessToNetworkFeature}}
         {{#if @model.network.id}}
           <LinkTo @route="authenticated.organizations.get.network" @model={{@model}}>
             {{t "pages.organization.navbar.network" nbrOfChildren=@model.children.length}}

--- a/admin/tests/acceptance/authenticated/organizations/get-test.js
+++ b/admin/tests/acceptance/authenticated/organizations/get-test.js
@@ -473,12 +473,14 @@ module('Acceptance | Organizations | Get', function (hooks) {
     });
   });
 
-  module('Network tab Access control (temporary tests, to be deleted at the end of epix PIX-21277)', function (hooks) {
+  module('Network tab Access control', function (hooks) {
     hooks.beforeEach(() => {
+      const network = server.create('network', { id: '42', name: 'Réseau Île-de-France' });
       server.create('organization', {
         id: 99,
         name: 'My Organization',
         features: { PLACES_MANAGEMENT: { active: true } },
+        network,
       });
     });
     test('should not be visible for Certif member', async function (assert) {
@@ -513,7 +515,7 @@ module('Acceptance | Organizations | Get', function (hooks) {
       );
     });
 
-    test('should not be visible for Metier member', async function (assert) {
+    test('should be visible for Metier member', async function (assert) {
       // given
       await authenticateAdminMemberWithRole({ isMetier: true })(server);
 
@@ -522,7 +524,7 @@ module('Acceptance | Organizations | Get', function (hooks) {
 
       // then
       const navigationTabs = screen.getByRole('navigation', { name: t('pages.organization.navbar.aria-label') });
-      assert.notOk(
+      assert.ok(
         within(navigationTabs).queryByRole('link', {
           name: t('pages.organization.navbar.network', { nbrOfChildren: 0 }),
         }),

--- a/admin/tests/integration/components/organizations/head-information-test.gjs
+++ b/admin/tests/integration/components/organizations/head-information-test.gjs
@@ -81,11 +81,11 @@ module('Integration | Component | organizations/header-information', function (h
             data: { id: '42', type: 'network', attributes: { name: 'Réseau Île-de-France' } },
           });
         });
-        module('when user is not super admin', function () {
+        module('when user has role CERTIF', function () {
           test('it does not display a network tag nor Head of network tag', async function (assert) {
             // given
             const currentUser = this.owner.lookup('service:currentUser');
-            currentUser.adminMember = { isSuperAdmin: false };
+            currentUser.adminMember = { isCertif: true };
             const headOrganization = store.createRecord('organization', { network });
 
             // when
@@ -96,6 +96,40 @@ module('Integration | Component | organizations/header-information', function (h
             assert
               .dom(screen.queryByText(t('components.organizations.head-information.head-organization-tag')))
               .doesNotExist();
+          });
+        });
+
+        module('when user has role SUPPORT', function () {
+          test('it does not display a network tag nor Head of network tag', async function (assert) {
+            // given
+            const currentUser = this.owner.lookup('service:currentUser');
+            currentUser.adminMember = { isSupport: true };
+            const headOrganization = store.createRecord('organization', { network });
+
+            // when
+            const screen = await render(<template><HeadInformation @organization={{headOrganization}} /></template>);
+
+            // then
+            assert.dom(screen.queryByRole('link', { name: 'Réseau Île-de-France' })).doesNotExist();
+            assert
+              .dom(screen.queryByText(t('components.organizations.head-information.head-organization-tag')))
+              .doesNotExist();
+          });
+        });
+
+        module('when user has role METIER', function () {
+          test('it displays network tags', async function (assert) {
+            // given
+            const currentUser = this.owner.lookup('service:currentUser');
+            currentUser.adminMember = { isMetier: true };
+            const headOrganization = store.createRecord('organization', { network });
+
+            // when
+            const screen = await render(<template><HeadInformation @organization={{headOrganization}} /></template>);
+
+            // then
+            assert.dom(screen.getByRole('link', { name: 'Réseau Île-de-France' })).exists();
+            assert.dom(screen.getByText(t('components.organizations.head-information.head-organization-tag'))).exists();
           });
         });
 

--- a/admin/tests/integration/components/organizations/network-test.gjs
+++ b/admin/tests/integration/components/organizations/network-test.gjs
@@ -17,6 +17,7 @@ module('Integration | Component | organizations/network', function (hooks) {
       class AccessControlStub extends Service {
         hasAccessToOrganizationActionsScope = true;
         hasAccessToAttachChildOrganizationActionsScope = true;
+        hasAccessToNetworkFeature = true;
       }
       this.owner.register('service:access-control', AccessControlStub);
 

--- a/admin/tests/integration/components/organizations/network/actions-section-test.gjs
+++ b/admin/tests/integration/components/organizations/network/actions-section-test.gjs
@@ -18,12 +18,12 @@ module('Integration | Component | organizations/network/actions-section', functi
   module('create child organization button', function (hooks) {
     hooks.beforeEach(async function () {
       class AccessControlStub extends Service {
-        hasAccessToAttachChildOrganizationActionsScope = true;
+        hasAccessToNetworkFeature = true;
       }
       this.owner.register('service:access-control', AccessControlStub);
     });
 
-    test('it should display create child organization button when user is superAdmin', async function (assert) {
+    test('it should display create child organization button when user has access to network feature', async function (assert) {
       // given
       const organization = store.createRecord('organization', {
         id: '1',
@@ -44,10 +44,10 @@ module('Integration | Component | organizations/network/actions-section', functi
       );
     });
 
-    test('it should not display create child organization button when user is not superAdmin', async function (assert) {
+    test('it should not display create child organization button when user does not have access to network feature', async function (assert) {
       // given
       class AccessControlStub extends Service {
-        hasAccessToAttachChildOrganizationActionsScope = false;
+        hasAccessToNetworkFeature = false;
       }
       this.owner.register('service:access-control', AccessControlStub);
 

--- a/admin/tests/unit/routes/authenticated/organizations/get/network-test.js
+++ b/admin/tests/unit/routes/authenticated/organizations/get/network-test.js
@@ -21,7 +21,7 @@ module('Unit | Route | authenticated/organizations/get/network', function (hooks
   });
 
   module('#beforeModel', function () {
-    test('it should check if current user is super admin', function (assert) {
+    test('it should check if current user is super admin or metier', function (assert) {
       // given
       const organization = EmberObject.create({ network: { id: 123, name: 'My Network' } });
       sinon.stub(route, 'modelFor').returns(organization);
@@ -30,7 +30,9 @@ module('Unit | Route | authenticated/organizations/get/network', function (hooks
       route.beforeModel();
 
       // then
-      assert.ok(restrictAccessToStub.calledWith(['isSuperAdmin'], 'authenticated.organizations.get.details'));
+      assert.ok(
+        restrictAccessToStub.calledWith(['isSuperAdmin', 'isMetier'], 'authenticated.organizations.get.details'),
+      );
     });
 
     test('it should transition to details route when organization does not belong to a network', async function (assert) {

--- a/admin/tests/unit/services/access-control-test.js
+++ b/admin/tests/unit/services/access-control-test.js
@@ -328,4 +328,24 @@ module('Unit | Service | access-control', function (hooks) {
       });
     });
   });
+
+  module('#hasAccessToNetworkFeature', function () {
+    [
+      { role: 'isSuperAdmin', hasAccess: true },
+      { role: 'isMetier', hasAccess: true },
+      { role: 'isSupport', hasAccess: false },
+      { role: 'isCertif', hasAccess: false },
+    ].forEach(function ({ role, hasAccess }) {
+      test(`should be ${hasAccess} if current admin member is ${role}`, function (assert) {
+        // given
+        const currentUser = this.owner.lookup('service:currentUser');
+        currentUser.adminMember = { [role]: true };
+
+        const service = this.owner.lookup('service:access-control');
+
+        // when / then
+        assert.deepEqual(service.hasAccessToNetworkFeature, hasAccess);
+      });
+    });
+  });
 });


### PR DESCRIPTION
## 🌱 Problème

Jusqu'à maintenant, seul le rôle super admin peut voir l'onglet **Réseau** sur la page d'une organisation.

## 🐣 Proposition

Ouvrir au rôle METIER l'accès à cet onglet, à la route, à la création d'organisation fille et la visibilité des tags relatifs aux réseaux.

## 🌷 Remarques
L'accès à l'onglet général **Réseaux** et à la liste des réseaux sera autorisé dans une future PR.

## 🐝 Pour tester
Sur Pix Admin, il faut tester successivement tous les rôles sur une orga faisant partie d'un réseau:
- SUPERADMIN: affichage des tags, accès à l'onglet Réseau + création d'orga fille 
- METIER: affichage des tags, accès à l'onglet Réseau + création d'orga fille
- SUPPORT: pas d'affichage des tags, pas d'accès à l'onglet Réseau (donc pas d'accès à la création d'orga fille)
- CERTIF:  pas d'affichage des tags, pas d'accès à l'onglet Réseau (donc pas d'accès à la création d'orga fille)
