### PR TITLE
[BUGFIX] Préserver le sélecteur de pays de naissance lors de l'édition d'un candidat de certif (PIX-22469).

### DIFF
--- a/admin/app/components/certifications/candidate-edit-modal.gjs
+++ b/admin/app/components/certifications/candidate-edit-modal.gjs
@@ -80,7 +80,6 @@ export default class CandidateEditModal extends Component {
   }
 
   get selectedCountryOption() {
-    if (this.birthCountry === 'FRANCE') return FRANCE_INSEE_CODE;
     return this.selectedCountryInseeCode;
   }
 

--- a/admin/app/models/certification.js
+++ b/admin/app/models/certification.js
@@ -121,7 +121,7 @@ export default class Certification extends Model {
   }
 
   wasBornInFrance() {
-    return this.birthCountry === 'FRANCE';
+    return this.birthCountry?.toUpperCase() === 'FRANCE';
   }
 
   getInformation() {

--- a/admin/tests/unit/models/certification-test.js
+++ b/admin/tests/unit/models/certification-test.js
@@ -304,9 +304,31 @@ module('Unit | Model | certification', function (hooks) {
       assert.true(wasBornInFrance);
     });
 
+    test('it should return true when birthCountry has a different casing', function (assert) {
+      // given
+      const certification = store.createRecord('certification', { birthCountry: 'France' });
+
+      // when
+      const wasBornInFrance = certification.wasBornInFrance();
+
+      // then
+      assert.true(wasBornInFrance);
+    });
+
     test('it should return false when candidate was not born in France', function (assert) {
       // given
       const certification = store.createRecord('certification', { birthCountry: 'OTHER_COUNTRY' });
+
+      // when
+      const wasBornInFrance = certification.wasBornInFrance();
+
+      // then
+      assert.false(wasBornInFrance);
+    });
+
+    test('it should return false when birthCountry is null', function (assert) {
+      // given
+      const certification = store.createRecord('certification', { birthCountry: null });
 
       // when
       const wasBornInFrance = certification.wasBornInFrance();


### PR DESCRIPTION
## 🌱 Problème

Lorsqu’on modifie les infos d’un candidat de certif né en France sur PixAdmin en recette et prod, le pays de naissance disparaît.

## 🐣 Proposition

La cause est la casse du pays de naissance.
On fait une vérif sur `=== 'FRANCE'` alors que les pays sont stockés comme ceci en recette et prod : 

<img width="359" height="127" alt="image" src="https://github.com/user-attachments/assets/dd0a650e-6d03-4a1d-818f-a74750d9f13e" />

Réparer ça en prenant en compte la casse.

## 🐝 Pour tester

Modifier un [candidat en RA](https://admin-pr15962.review.pix.fr/sessions/list?status=processed), ça devrait toujours fonctionner !
