### PR TITLE
[FEATURE] Ajouter des logs sur l'ajout d'une adresse e-mail à un compte SSO (PIX-21989).

### DIFF
--- a/api/src/identity-access-management/domain/usecases/add-user-email-with-validation.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/add-user-email-with-validation.usecase.js
@@ -3,6 +3,7 @@ import {
   EmailModificationDemandNotFoundOrExpiredError,
   InvalidVerificationCodeError,
 } from '../../../shared/domain/errors.js';
+import { AuditLoggingJob } from '../../../shared/domain/models/jobs/AuditLoggingJob.js';
 import { NON_OIDC_IDENTITY_PROVIDERS } from '../constants/identity-providers.js';
 import { AuthenticationMethod } from '../models/AuthenticationMethod.js';
 
@@ -12,6 +13,7 @@ const addUserEmailWithValidation = async function ({
   userEmailRepository,
   userRepository,
   authenticationMethodRepository,
+  auditLoggingJobRepository,
 }) {
   const emailModificationDemand = await userEmailRepository.getEmailModificationDemandByUserId(userId);
   if (!emailModificationDemand || emailModificationDemand.action !== 'add-email') {
@@ -22,13 +24,15 @@ const addUserEmailWithValidation = async function ({
     throw new InvalidVerificationCodeError();
   }
 
-  await userRepository.checkIfEmailIsAvailable(emailModificationDemand.newEmail);
+  const { newEmail, password } = emailModificationDemand;
+
+  await userRepository.checkIfEmailIsAvailable(newEmail);
 
   const authenticationMethod = new AuthenticationMethod({
     userId,
     identityProvider: NON_OIDC_IDENTITY_PROVIDERS.PIX.code,
     authenticationComplement: new AuthenticationMethod.PixAuthenticationComplement({
-      password: emailModificationDemand.password,
+      password,
       shouldChangePassword: false,
     }),
   });
@@ -39,7 +43,7 @@ const addUserEmailWithValidation = async function ({
     await userRepository.updateWithEmailConfirmed({
       id: userId,
       userAttributes: {
-        email: emailModificationDemand.newEmail,
+        email: newEmail,
         emailConfirmedAt: new Date(),
       },
     });
@@ -47,7 +51,18 @@ const addUserEmailWithValidation = async function ({
 
   await userEmailRepository.deleteEmailModificationDemandByUserId(userId);
 
-  return { email: emailModificationDemand.newEmail };
+  await auditLoggingJobRepository.performAsync(
+    AuditLoggingJob.forUser({
+      client: 'PIX_APP',
+      action: 'EMAIL_ADDED',
+      role: 'USER',
+      userId,
+      updatedByUserId: userId,
+      data: { email: newEmail },
+    }),
+  );
+
+  return { email: newEmail };
 };
 
 export { addUserEmailWithValidation };

--- a/api/src/shared/domain/models/jobs/AuditLoggingJob.js
+++ b/api/src/shared/domain/models/jobs/AuditLoggingJob.js
@@ -10,6 +10,7 @@ const CLIENTS = ['PIX_ADMIN', 'PIX_APP', 'PIX_ORGA', 'SCRIPT'];
 const ACTIONS = [
   'ANONYMIZATION',
   'ANONYMIZATION_GAR',
+  'EMAIL_ADDED',
   'EMAIL_CHANGED',
   ...Object.values(CampaignParticipationLoggerContext),
   ...Object.values(OrganizationLearnerLoggerContext),

--- a/api/tests/identity-access-management/integration/domain/usecases/add-user-email-with-validation.usecase.test.js
+++ b/api/tests/identity-access-management/integration/domain/usecases/add-user-email-with-validation.usecase.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import sinon from 'sinon';
 
 import { InvalidOrAlreadyUsedEmailError } from '../../../../../src/identity-access-management/domain/errors.js';
 import { usecases } from '../../../../../src/identity-access-management/domain/usecases/index.js';
@@ -7,15 +7,21 @@ import {
   EmailModificationDemandNotFoundOrExpiredError,
   InvalidVerificationCodeError,
 } from '../../../../../src/shared/domain/errors.js';
+import { AuditLoggingJob } from '../../../../../src/shared/domain/models/jobs/AuditLoggingJob.js';
+import { EMPTY_CORRELATION_INFO } from '../../../../../src/shared/infrastructure/execution-context-manager.js';
 import { temporaryStorage } from '../../../../../src/shared/infrastructure/key-value-storages/index.js';
+import { expect } from '../../../../test-helper.js';
 import { databaseBuilder, knex } from '../../../../tooling/databases.js';
 import { catchErr } from '../../../../tooling/test-utils/error.js';
 
 const verifyEmailTemporaryStorage = temporaryStorage.withPrefix('verify-email:');
 
 describe('Integration | Identity Access Management | Domain | UseCase | addUserEmailWithValidation', function () {
+  const now = new Date('2024-04-05T03:04:05Z');
+
   beforeEach(async function () {
     await verifyEmailTemporaryStorage.flushAll();
+    sinon.useFakeTimers({ now, toFake: ['Date'] });
   });
 
   it('checks verification code and adds email', async function () {
@@ -46,6 +52,17 @@ describe('Integration | Identity Access Management | Domain | UseCase | addUserE
       .first();
     expect(pixAuthenticationMethod).to.not.be.null;
     expect(pixAuthenticationMethod.authenticationComplement.password).to.equal('1234ABCD');
+
+    await expect(AuditLoggingJob.name).to.have.been.performed.withJobPayload({
+      action: 'EMAIL_ADDED',
+      client: 'PIX_APP',
+      role: 'USER',
+      data: { email: newEmail },
+      userId: user.id,
+      targetUserIds: [user.id],
+      occurredAt: now.toISOString(),
+      correlationContext: EMPTY_CORRELATION_INFO,
+    });
   });
 
   context('when the verification code is invalid', function () {

--- a/mon-pix/tests/integration/components/authentication/oidc-reconciliation-test.js
+++ b/mon-pix/tests/integration/components/authentication/oidc-reconciliation-test.js
@@ -3,7 +3,7 @@ import Service from '@ember/service';
 import { hbs } from 'ember-cli-htmlbars';
 import { t } from 'ember-intl/test-support';
 import { module, test } from 'qunit';
-import Sinon from 'sinon';
+import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
@@ -19,7 +19,7 @@ module('Integration | Component |  authentication | oidc-reconciliation', functi
         { organizationName: 'Impots.gouv' },
         { organizationName: 'Nouveau partenaire' },
       ];
-      getIdentityProviderNamesByAuthenticationMethods = Sinon.stub().returns(['France Connect', 'Impots.gouv']);
+      getIdentityProviderNamesByAuthenticationMethods = sinon.stub().returns(['France Connect', 'Impots.gouv']);
     }
     this.owner.register('service:oidcIdentityProviders', OidcIdentityProvidersStub);
     this.set('fullNameFromPix', 'Lloyd Pix');


### PR DESCRIPTION
## 🌱 Problème
Pour clôturer l'Epix d'ajout d'une méthode de connexion par e-mail et mot de passe à un compte disposant jusqu'alors uniquement d'une méthode de connexion SSO, on souhaite ajouter des logs pour suivre les usages de cette nouvelle feature.

## 🐣 Proposition

- Ajouter une nouvelle action audit logger portant le nom d'action `EMAIL_ADDED`.
- Envoyer un job d'audit log quand l'utilisateur ajoute un email.

## 🐝 Pour tester
1. Activer le FT : 
   ```shell
   npm run toggles -- --key addEmailConnectionMethodEnabled --value true
   ```
2. Démarrer Pix App, l'api et audit-logger
3. Se connecter avec "Pro Connect"
4. Ajouter un nouvel email dans Mon Compte
5. Vérifier dans la BDD de l'audit logger l'action `EMAIL_ADDED` : `select * from "audit-log";`