### PR TITLE
[FEATURE] Empêcher la création de session en doublon (PIX-12384).

### DIFF
--- a/api/src/certification/enrolment/domain/usecases/create-session.js
+++ b/api/src/certification/enrolment/domain/usecases/create-session.js
@@ -5,6 +5,7 @@
  * @typedef {import ("./index.js").SessionCodeService} SessionCodeService
  */
 
+import { AlreadyExistingEntityError } from '../../../../shared/domain/errors.js';
 import { SessionEnrolment } from '../models/SessionEnrolment.js';
 
 /**
@@ -25,6 +26,17 @@ const createSession = async function ({
   sessionValidator.validate(session);
 
   const certificationCenterId = session.certificationCenterId;
+
+  const sessionAlreadyExists = await sessionRepository.isSessionExistingByCertificationCenterId({
+    address: session.address,
+    room: session.room,
+    date: session.date,
+    time: session.time,
+    certificationCenterId,
+  });
+  if (sessionAlreadyExists) {
+    throw new AlreadyExistingEntityError('Une session avec les mêmes informations existe déjà.');
+  }
 
   const accessCode = sessionCodeService.getNewSessionCode();
   const { name: certificationCenterName } = await centerRepository.getById({

--- a/api/src/certification/enrolment/domain/usecases/create-session.js
+++ b/api/src/certification/enrolment/domain/usecases/create-session.js
@@ -35,7 +35,10 @@ const createSession = async function ({
     certificationCenterId,
   });
   if (sessionAlreadyExists) {
-    throw new AlreadyExistingEntityError('Une session avec les mêmes informations existe déjà.');
+    throw new AlreadyExistingEntityError(
+      'Une session avec les mêmes informations existe déjà.',
+      'SESSION_ALREADY_EXISTS',
+    );
   }
 
   const accessCode = sessionCodeService.getNewSessionCode();

--- a/api/src/certification/enrolment/domain/usecases/update-session.js
+++ b/api/src/certification/enrolment/domain/usecases/update-session.js
@@ -4,6 +4,8 @@
  * @typedef {import('./index.js').SessionValidator} SessionValidator
  */
 
+import { AlreadyExistingEntityError } from '../../../../shared/domain/errors.js';
+
 /**
  * @param {object} params
  * @param {SessionRepository} params.sessionRepository
@@ -11,6 +13,19 @@
  */
 const updateSession = async function ({ session, sessionRepository, sessionValidator }) {
   sessionValidator.validate(session);
+
+  const sessionAlreadyExists = await sessionRepository.isSessionExistingByCertificationCenterId({
+    address: session.address,
+    room: session.room,
+    date: session.date,
+    time: session.time,
+    certificationCenterId: session.certificationCenterId,
+    excludeSessionId: session.id,
+  });
+  if (sessionAlreadyExists) {
+    throw new AlreadyExistingEntityError('Une session avec les mêmes informations existe déjà.');
+  }
+
   const sessionToUpdate = await sessionRepository.get({ id: session.id });
   sessionToUpdate.updateInfo(session);
   await sessionRepository.update(sessionToUpdate);

--- a/api/src/certification/enrolment/domain/usecases/update-session.js
+++ b/api/src/certification/enrolment/domain/usecases/update-session.js
@@ -23,7 +23,10 @@ const updateSession = async function ({ session, sessionRepository, sessionValid
     excludeSessionId: session.id,
   });
   if (sessionAlreadyExists) {
-    throw new AlreadyExistingEntityError('Une session avec les mêmes informations existe déjà.');
+    throw new AlreadyExistingEntityError(
+      'Une session avec les mêmes informations existe déjà.',
+      'SESSION_ALREADY_EXISTS',
+    );
   }
 
   const sessionToUpdate = await sessionRepository.get({ id: session.id });

--- a/api/src/certification/enrolment/infrastructure/repositories/session-repository.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/session-repository.js
@@ -61,11 +61,23 @@ export async function get({ id }) {
  * @param {Date} params.date
  * @param {Date} params.time
  * @param {number} params.certificationCenterId
+ * @param {number} [params.excludeSessionId]
  * @returns {Promise<boolean>}
  */
-export async function isSessionExistingByCertificationCenterId({ address, room, date, time, certificationCenterId }) {
+export async function isSessionExistingByCertificationCenterId({
+  address,
+  room,
+  date,
+  time,
+  certificationCenterId,
+  excludeSessionId,
+}) {
   const knexConn = DomainTransaction.getConnection();
-  const sessions = await knexConn('sessions').where({ address, room, date, time }).andWhere({ certificationCenterId });
+  const query = knexConn('sessions').where({ address, room, date, time }).andWhere({ certificationCenterId });
+  if (excludeSessionId) {
+    query.andWhereNot({ id: excludeSessionId });
+  }
+  const sessions = await query;
   return sessions.length > 0;
 }
 

--- a/api/tests/certification/enrolment/acceptance/application/session-route_test.js
+++ b/api/tests/certification/enrolment/acceptance/application/session-route_test.js
@@ -103,6 +103,7 @@ describe('Certification | Enrolment | Acceptance | Routes | session-route', func
             time: '14:30',
             description: 'ahah',
             accessCode: 'ABCD12',
+            'certification-center-id': certificationCenter.id,
           },
         },
       };

--- a/api/tests/certification/enrolment/integration/infrastructure/repositories/session-repository_test.js
+++ b/api/tests/certification/enrolment/integration/infrastructure/repositories/session-repository_test.js
@@ -294,6 +294,33 @@ describe('Integration | Repository | certification | enrolment | SessionEnrolmen
       // then
       expect(result).to.equal(false);
     });
+
+    it('should return false if the only matching session is the excluded one', async function () {
+      // given
+      const session = {
+        address: 'rue de Bercy',
+        room: 'Salle A',
+        examiner: 'madame examinatrice',
+        date: '2018-02-23',
+        time: '12:00:00',
+      };
+      const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+      const existingSession = databaseBuilder.factory.buildSession({
+        ...session,
+        certificationCenterId,
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const result = await sessionRepository.isSessionExistingByCertificationCenterId({
+        ...session,
+        certificationCenterId,
+        excludeSessionId: existingSession.id,
+      });
+
+      // then
+      expect(result).to.equal(false);
+    });
   });
 
   describe('#isSessionExistingBySessionAndCertificationCenterIds', function () {

--- a/api/tests/certification/enrolment/unit/domain/usecases/create-session_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/create-session_test.js
@@ -2,8 +2,10 @@ import sinon from 'sinon';
 
 import { SessionEnrolment } from '../../../../../../src/certification/enrolment/domain/models/SessionEnrolment.js';
 import { createSession } from '../../../../../../src/certification/enrolment/domain/usecases/create-session.js';
+import { AlreadyExistingEntityError } from '../../../../../../src/shared/domain/errors.js';
 import { expect } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
+import { catchErr } from '../../../../../tooling/test-utils/error.js';
 
 describe('Unit | UseCase | create-session', function () {
   let centerRepository;
@@ -11,11 +13,20 @@ describe('Unit | UseCase | create-session', function () {
   const userId = 'userId';
   const certificationCenterId = 123;
   const certificationCenterName = 'certificationCenterName';
-  const sessionToSave = { certificationCenterId };
+  const sessionToSave = {
+    certificationCenterId,
+    address: '12 rue de Paris',
+    room: 'Salle 201',
+    date: '2025-05-15',
+    time: '10:00',
+  };
 
   beforeEach(function () {
     centerRepository = { getById: sinon.stub() };
-    sessionRepository = { save: sinon.stub() };
+    sessionRepository = {
+      save: sinon.stub(),
+      isSessionExistingByCertificationCenterId: sinon.stub(),
+    };
   });
 
   describe('#save', function () {
@@ -39,6 +50,34 @@ describe('Unit | UseCase | create-session', function () {
       });
     });
 
+    context('when a session with the same information already exists', function () {
+      it('should throw an AlreadyExistingEntityError', async function () {
+        // given
+        const sessionValidatorStub = { validate: sinon.stub().returns() };
+        sessionRepository.isSessionExistingByCertificationCenterId.resolves(true);
+
+        // when
+        const error = await catchErr(createSession)({
+          userId,
+          session: sessionToSave,
+          centerRepository,
+          sessionRepository,
+          sessionValidator: sessionValidatorStub,
+          sessionCodeService: { getNewSessionCode: sinon.stub() },
+        });
+
+        // then
+        expect(error).to.be.instanceOf(AlreadyExistingEntityError);
+        expect(sessionRepository.isSessionExistingByCertificationCenterId).to.have.been.calledWithExactly({
+          address: sessionToSave.address,
+          room: sessionToSave.room,
+          date: sessionToSave.date,
+          time: sessionToSave.time,
+          certificationCenterId,
+        });
+      });
+    });
+
     context('when session is valid', function () {
       let accessCode;
       let sessionValidatorStub;
@@ -51,6 +90,7 @@ describe('Unit | UseCase | create-session', function () {
         centerRepository.getById = sinon.stub();
         sessionRepository.save = sinon.stub();
         sessionRepository.save.resolves();
+        sessionRepository.isSessionExistingByCertificationCenterId.resolves(false);
       });
 
       it('should save the session with appropriate arguments', async function () {
@@ -74,7 +114,7 @@ describe('Unit | UseCase | create-session', function () {
 
         // then
         const expectedSession = new SessionEnrolment({
-          certificationCenterId,
+          ...sessionToSave,
           certificationCenter: certificationCenterName,
           accessCode,
           invigilatorPassword: sinon.match.string,

--- a/api/tests/certification/enrolment/unit/domain/usecases/update-session_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/update-session_test.js
@@ -1,8 +1,10 @@
 import sinon from 'sinon';
 
 import { updateSession } from '../../../../../../src/certification/enrolment/domain/usecases/update-session.js';
+import { AlreadyExistingEntityError } from '../../../../../../src/shared/domain/errors.js';
 import { expect } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
+import { catchErr } from '../../../../../tooling/test-utils/error.js';
 
 describe('Unit | UseCase | update-session', function () {
   let originalSession;
@@ -15,6 +17,7 @@ describe('Unit | UseCase | update-session', function () {
     sessionRepository = {
       get: sinon.stub(),
       update: sinon.stub(),
+      isSessionExistingByCertificationCenterId: sinon.stub(),
     };
     originalSession = domainBuilder.certification.enrolment.buildSession({
       id: 1,
@@ -30,8 +33,43 @@ describe('Unit | UseCase | update-session', function () {
     });
     sessionRepository.get.withArgs({ id: originalSession.id }).onCall(0).resolves(originalSession);
     sessionRepository.update.resolves();
+    sessionRepository.isSessionExistingByCertificationCenterId.resolves(false);
     sessionValidator = { validate: sinon.stub() };
     sessionValidator.validate.withArgs(originalSession).returns();
+  });
+
+  context('when the updated session would be a duplicate of an existing session', function () {
+    it('should throw an AlreadyExistingEntityError', async function () {
+      // given
+      const updatedSession = domainBuilder.certification.enrolment.buildSession({
+        id: 1,
+        certificationCenterId,
+        address: 'Lyon',
+        room: '28D',
+        date: '2017-12-08',
+        time: '10:00',
+      });
+      sessionValidator.validate.withArgs(updatedSession).returns();
+      sessionRepository.isSessionExistingByCertificationCenterId.resolves(true);
+
+      // when
+      const error = await catchErr(updateSession)({
+        session: updatedSession,
+        sessionRepository,
+        sessionValidator,
+      });
+
+      // then
+      expect(error).to.be.instanceOf(AlreadyExistingEntityError);
+      expect(sessionRepository.isSessionExistingByCertificationCenterId).to.have.been.calledWithExactly({
+        address: updatedSession.address,
+        room: updatedSession.room,
+        date: updatedSession.date,
+        time: updatedSession.time,
+        certificationCenterId,
+        excludeSessionId: updatedSession.id,
+      });
+    });
   });
 
   context('when session exists', function () {

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -22,6 +22,7 @@
       "CANDIDATE_NOT_ALLOWED_FOR_FINALIZED_SESSION": "This session has already been finalised and no new candidates may be added.",
       "CANDIDATE_NOT_FOUND": "An error has occurred, the candidate {firstName} {lastName} hasn't been found.",
       "INVALID_DOCUMENT": "This version of the document is unknown.<br />Please download and import the candidate list template again",
+      "SESSION_ALREADY_EXISTS": "A session with the same information (date, time, address and room) already exists.",
       "SESSION_ALREADY_FINALIZED": "Cannot finalise session more than once.",
       "SESSION_CANNOT_BE_FINALIZED": "Error during the finalisation of the session.",
       "SESSION_DOES_NOT_EXIST_OR_ACCESS_RESTRICTED": "The session doesn't exist or it's access is restricted.",

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -22,6 +22,7 @@
       "CANDIDATE_NOT_ALLOWED_FOR_FINALIZED_SESSION": "Cette session a déjà été finalisée, l'ajout de candidat n'est pas autorisé.",
       "CANDIDATE_NOT_FOUND": "Une erreur est survenue, le candidat {firstName} {lastName} n'a pas été trouvé.",
       "INVALID_DOCUMENT": "La version du document est inconnue.<br />Veuillez télécharger à nouveau le modèle de liste des candidats et l'importer à nouveau.",
+      "SESSION_ALREADY_EXISTS": "Une session avec les mêmes informations (date, horaire, adresse et salle) existe déjà.",
       "SESSION_ALREADY_FINALIZED": "La session a déjà été finalisée.",
       "SESSION_CANNOT_BE_FINALIZED": "Erreur lors de la finalisation de session.",
       "SESSION_DOES_NOT_EXIST_OR_ACCESS_RESTRICTED": "La session n'existe pas ou son accès est restreint.",


### PR DESCRIPTION
## 🌱 Problème

Actuellement sur Pix Certif, la création de session en masse évite la création de session en doublon en jetant une erreur spécifique.

Mais cette gestion du doublon n’est pas faite lors d’une création classique de session ou lors d’une modification de session existante.

## 🐣 Proposition

Empêcher les doublons de sessions : 

- lors de la création classique de session 
- lors de la modification d’une session

## 🐝 Pour tester

- Création une session en RA
- Tenter de créer une deuxième session avec le même centre et exactement les mêmes infos : ❌ une erreur devrait apparaître.
- Créer une session avec une info différente, puis modifier pour mettre cette info avec la même valeur que pour la première session créée : ❌ une erreur devrait apparaître.
