### PR TITLE
[FEATURE] Modifier les URLs des fichiers de rapport de fraude (PIX-22291).

### DIFF
--- a/certif/app/services/url.js
+++ b/certif/app/services/url.js
@@ -65,9 +65,9 @@ export default class Url extends UrlBaseService {
 
   get fraudReportUrl() {
     if (this.locale.currentLanguage === 'fr') {
-      return 'https://cloud.pix.fr/s/AgDytb8yHxrmjFk/download';
+      return 'https://cloud.pix.fr/s/H3QdaLzdaap4zr8/download';
     }
-    return 'https://cloud.pix.fr/s/zka5JJqpbgWZLPr';
+    return 'https://cloud.pix.fr/s/iagftYbDFC8Wb4e/download';
   }
 
   get invigilatorDocumentationUrl() {

--- a/certif/tests/unit/services/url-test.js
+++ b/certif/tests/unit/services/url-test.js
@@ -154,7 +154,7 @@ module('Unit | Service | url', function (hooks) {
       const fraudReportUrl = service.fraudReportUrl;
 
       // then
-      assert.strictEqual(fraudReportUrl, 'https://cloud.pix.fr/s/AgDytb8yHxrmjFk/download');
+      assert.strictEqual(fraudReportUrl, 'https://cloud.pix.fr/s/H3QdaLzdaap4zr8/download');
     });
   });
 


### PR DESCRIPTION
## 🌱 Problème

Les documents de rapport de fraudes sont en format non open source `.docx`.

## 🐣 Proposition

Passer à des liens vers des fichiers `.odt`.

## 🐝 Pour tester

Vérifier les URLs dans les modifications : https://github.com/1024pix/pix/pull/15971/changes. 
