### PR TITLE
[BUGFIX] S'assurer de terminer le stream LLM une seule fois

### DIFF
--- a/api/src/llm/infrastructure/streaming/llm-response-handler.js
+++ b/api/src/llm/infrastructure/streaming/llm-response-handler.js
@@ -21,6 +21,8 @@ export class LLMResponseHandler {
   /** @type {ReadableStream=} */
   llmResponseStream;
 
+  #finished = false;
+
   /**
    * @param {WritableStream} responseStream
    */
@@ -100,6 +102,8 @@ export class LLMResponseHandler {
   }
 
   async finish() {
+    if (this.#finished) return;
+    this.#finished = true;
     try {
       await this.responseStream.close();
     } catch (err) {


### PR DESCRIPTION
## 🌱 Problème

On a souvent cette erreur 500 sur les appels LLM : 
```
TypeError [ERR_INVALID_STATE]: Invalid state: WritableStream is closed     
at writableStreamClose (node:internal/webstreams/writablestream:724:7)     
at InternalWritableStream.close (node:internal/webstreams/writablestream:234:12)     
at LLMResponseHandler.finish (file:///app/src/llm/infrastructure/streaming/llm-response-handler.js:104:33)     
at runFlow (file:///app/src/llm/domain/usecases/prompt-chat.js:151:30)
```

## 🐣 Proposition

En analysant, on voit que `src/llm/domain/usecases/prompt-chat.js` peut faire 2 appels à `LLMResponseHandler.finish` dans certains cas : 
https://github.com/1024pix/pix/blob/cc554dfadf663c9652825c9f16b35b7c4c761182/api/src/llm/domain/usecases/prompt-chat.js#L130-L151

Ce double appel en cas d'erreur, fait que le stream est clos 2 fois, d'où l'erreur `WritableStream is closed`.

**Rendre `finish()` indempotent en gérant un flag `#finished` dans `LLMResponseHandler`**

## 🌷 Remarques

N/A

## 🐝 Pour tester

Faire un appel ChatPix et ça doit fonctionner.
