### PR TITLE
[BUGFIX] Éviter les problèmes de fuseau horaire sur PixAdmin (PIX-22515).

### DIFF
--- a/admin/app/components/certifications/certification/details-v3.gjs
+++ b/admin/app/components/certifications/certification/details-v3.gjs
@@ -331,7 +331,7 @@ export default class DetailsV3 extends Component {
             <:cell>
               {{#if certificationChallenge.answeredAt}}
                 <time>
-                  {{formatTime certificationChallenge.answeredAt hour="numeric" minute="numeric" second="numeric"}}
+                  {{formatTime certificationChallenge.answeredAt format="long"}}
                 </time>
               {{else}}
                 -

--- a/admin/app/ember-intl.js
+++ b/admin/app/ember-intl.js
@@ -7,6 +7,7 @@ export const formats = {
       day: 'numeric',
       hour: 'numeric',
       minute: 'numeric',
+      timeZone: 'UTC',
     },
     // DD/MM/YYYY HH:mm:ss
     long: {
@@ -16,6 +17,16 @@ export const formats = {
       hour: 'numeric',
       minute: 'numeric',
       second: 'numeric',
+      timeZone: 'UTC',
+    },
+  },
+  formatTime: {
+    // HH:mm:ss
+    long: {
+      hour: 'numeric',
+      minute: 'numeric',
+      second: 'numeric',
+      timeZone: 'UTC',
     },
   },
 };

--- a/admin/tests/integration/components/certifications/certification/details-v3-test.gjs
+++ b/admin/tests/integration/components/certifications/certification/details-v3-test.gjs
@@ -492,7 +492,7 @@ module('Integration | Component | Certifications | certification > details v3', 
 
         const expected = answers.map((answer) => [
           answer.questionNumber,
-          `${answer.answeredAt.getHours()}:${answer.answeredAt.getMinutes()}:00`,
+          `${answer.answeredAt.getUTCHours()}:${answer.answeredAt.getUTCMinutes()}:00`,
           answer.answerStatusName,
           `${answer.competenceIndex} ${answer.competenceName}`,
           answer.skillName,


### PR DESCRIPTION
## 🌱 Problème

Depuis le passage à l’heure d'été, des dates s’affichent avec la locale de l’utilisateur. Ce qui crée un décalage de 1h chez nous.
Ça casse les tests, et ça affiche des données fausses sur PixAdmin.

## 🐣 Proposition

En back, les données sont sauvegardées au format UTC.
Il faut le paramétrer côté front.

## 🐝 Pour tester

Tests verts ✅ 
