### PR TITLE
[TECH] Ajoute le requestId aux logs SQL.

### DIFF
--- a/api/db/knex-extensions.js
+++ b/api/db/knex-extensions.js
@@ -2,7 +2,7 @@ import Knex from 'knex';
 import QueryBuilder from 'knex/lib/query/querybuilder.js';
 import pg from 'pg';
 
-import { getInContext } from '../src/shared/infrastructure/execution-context-manager.js';
+import { getInContext, getRequestId } from '../src/shared/infrastructure/execution-context-manager.js';
 import { logger } from '../src/shared/infrastructure/utils/logger.js';
 
 const types = pg.types;
@@ -31,7 +31,10 @@ export function configureGlobalExtensions() {
   QueryBuilder.prototype.toSQL = function () {
     const ret = originalToSQL.apply(this);
     const request = getInContext('request');
-    ret.sql = `/* path:${request?.route?.path} | routeDomain:${request?.route?.realm?.plugin} */ `.concat(ret.sql);
+    ret.sql =
+      `/* path:${request?.route?.path} | routeDomain:${request?.route?.realm?.plugin} | request_id:${getRequestId()} */ `.concat(
+        ret.sql,
+      );
     return ret;
   };
 }


### PR DESCRIPTION
## 🌱 Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

Il n'est pas possible de faire le lien facilement entre une requête HTTP et les requêtes SQL déclenchées dans les logs.

## 🐣 Proposition

Ajouter en commentaire de chaque query SQL le `request_id`, à l'image de ce qui est fait pour le `path` et le `routeDomain`.

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 🌷 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

Les pipelines Datadog ont été adaptés pour mapper le request_id du log SQL au request_id standard.

## 🐝 Pour tester

Sur le dashboard de l'addon PG de Scalingo, regarder les requêtes SQL réalisées.
Elles doivent contenir le `request_id` en commentaire.

<img width="539" height="140" alt="Capture du dashboard scalingo montrant une requête SQL contenant le request_id en commentaire" src="https://github.com/user-attachments/assets/83d34d10-b31b-4203-aeff-5252f8988101" />

<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
