### PR TITLE
[FEATURE] Ajouter les tubes aux collectes de profil dans l'API MADDO (PIX-22460)

### DIFF
--- a/api/db/seeds/data/team-prescription/build-organization-learners-with-multiple-participations.js
+++ b/api/db/seeds/data/team-prescription/build-organization-learners-with-multiple-participations.js
@@ -3,321 +3,171 @@ import { Assessment } from '../../../../src/shared/domain/models/Assessment.js';
 import { PRO_ORGANIZATION_ID } from '../common/constants.js';
 import { CAMPAIGN_PROASSMUL_ID, CAMPAIGN_PROCOLMUL_ID } from './constants.js';
 
-async function _buildMultipleParticipationsForPROASSMULCampaign(databaseBuilder) {
-  const firstUser = await databaseBuilder.factory.buildUser.withRawPassword({
+const PROASSMUL_USERS = [
+  {
     firstName: 'Alex',
     lastName: 'Terieur',
     email: 'alex-terieur@example.net',
-    cgu: true,
-    lang: 'fr',
-  });
-
-  const firstOrganizationLearner = await databaseBuilder.factory.buildOrganizationLearner({
-    firstName: 'Alex',
-    lastName: 'Terieur',
-    userId: firstUser.id,
-    organizationId: PRO_ORGANIZATION_ID,
-    division: null,
-  });
-
-  const { id: firstUserFirstCampaignParticipationId, createdAt } =
-    await databaseBuilder.factory.buildCampaignParticipation({
-      campaignId: CAMPAIGN_PROASSMUL_ID,
-      organizationLearnerId: firstOrganizationLearner.id,
-      userId: firstUser.id,
-      masteryRate: 0.1,
-      isImproved: true,
-      createdAt: '2023-12-27T15:07:57.376Z',
-      sharedAt: '2024-01-04T15:07:57.376Z',
-    });
-
-  await databaseBuilder.factory.buildAssessment({
-    userId: firstUser.id,
-    type: Assessment.types.CAMPAIGN,
-    createdAt,
-    state: Assessment.states.COMPLETED,
-    isImproving: false,
-    lastQuestionDate: new Date(),
-    lastQuestionState: Assessment.statesOfLastQuestion.ASKED,
-    competenceId: null,
-    campaignParticipationId: firstUserFirstCampaignParticipationId,
-  });
-
-  const { id: firstUserSecondCampaignParticipationId } = await databaseBuilder.factory.buildCampaignParticipation({
-    organizationLearnerId: firstOrganizationLearner.id,
-    userId: firstUser.id,
-    campaignId: CAMPAIGN_PROASSMUL_ID,
-    masteryRate: 0.3,
-    isImproved: true,
-    createdAt: '2024-03-12T15:07:57.376Z',
-    sharedAt: '2024-03-24T15:07:57.376Z',
-  });
-
-  await databaseBuilder.factory.buildAssessment({
-    userId: firstUser.id,
-    type: Assessment.types.CAMPAIGN,
-    createdAt,
-    state: Assessment.states.COMPLETED,
-    isImproving: false,
-    lastQuestionDate: new Date(),
-    lastQuestionState: Assessment.statesOfLastQuestion.ASKED,
-    competenceId: null,
-    campaignParticipationId: firstUserSecondCampaignParticipationId,
-  });
-
-  const { id: firstUserThirdCampaignParticipationId } = await databaseBuilder.factory.buildCampaignParticipation({
-    organizationLearnerId: firstOrganizationLearner.id,
-    userId: firstUser.id,
-    campaignId: CAMPAIGN_PROASSMUL_ID,
-    isImproved: false,
-    status: CampaignParticipationStatuses.SHARED,
-    sharedAt: '2024-06-10T15:07:57.376Z',
-    createdAt: '2024-06-01T15:07:57.376Z',
-  });
-
-  await databaseBuilder.factory.buildAssessment({
-    userId: firstUser.id,
-    type: Assessment.types.CAMPAIGN,
-    createdAt,
-    state: Assessment.states.COMPLETED,
-    isImproving: false,
-    lastQuestionDate: new Date(),
-    lastQuestionState: Assessment.statesOfLastQuestion.ASKED,
-    competenceId: null,
-    campaignParticipationId: firstUserThirdCampaignParticipationId,
-  });
-
-  const secondUser = await databaseBuilder.factory.buildUser.withRawPassword({
+    participations: [
+      {
+        masteryRate: 0.1,
+        isImproved: true,
+        createdAt: '2023-12-27T15:07:57.376Z',
+        sharedAt: '2024-01-04T15:07:57.376Z',
+      },
+      {
+        masteryRate: 0.3,
+        isImproved: true,
+        createdAt: '2024-03-12T15:07:57.376Z',
+        sharedAt: '2024-03-24T15:07:57.376Z',
+      },
+      {
+        isImproved: false,
+        status: CampaignParticipationStatuses.SHARED,
+        createdAt: '2024-06-01T15:07:57.376Z',
+        sharedAt: '2024-06-10T15:07:57.376Z',
+      },
+    ],
+  },
+  {
     firstName: 'Tata',
     lastName: 'Yoyo',
     email: 'tata-yoyo@example.net',
-    cgu: true,
-    lang: 'fr',
-  });
-
-  const secondOrganizationLearner = await databaseBuilder.factory.buildOrganizationLearner({
-    firstName: 'Tata',
-    lastName: 'Yoyo',
-    userId: secondUser.id,
-    organizationId: PRO_ORGANIZATION_ID,
-    division: null,
-  });
-  const { id: secondUserFirstCampaignParticipationId } = await databaseBuilder.factory.buildCampaignParticipation({
-    campaignId: CAMPAIGN_PROASSMUL_ID,
-    organizationLearnerId: secondOrganizationLearner.id,
-    userId: secondUser.id,
-    masteryRate: 0.5,
-    isImproved: true,
-    createdAt: '2023-12-27T15:07:57.376Z',
-    sharedAt: '2024-01-04T15:07:57.376Z',
-  });
-  await databaseBuilder.factory.buildAssessment({
-    userId: secondUser.id,
-    type: Assessment.types.CAMPAIGN,
-    createdAt,
-    state: Assessment.states.COMPLETED,
-    isImproving: false,
-    lastQuestionDate: new Date(),
-    lastQuestionState: Assessment.statesOfLastQuestion.ASKED,
-    competenceId: null,
-    campaignParticipationId: secondUserFirstCampaignParticipationId,
-  });
-
-  const { id: secondUserSecondCampaignParticipationId } = await databaseBuilder.factory.buildCampaignParticipation({
-    organizationLearnerId: secondOrganizationLearner.id,
-    userId: secondUser.id,
-    campaignId: CAMPAIGN_PROASSMUL_ID,
-    masteryRate: 0.1,
-    isImproved: false,
-    createdAt: '2024-03-12T15:07:57.376Z',
-    sharedAt: '2024-03-24T15:07:57.376Z',
-  });
-
-  await databaseBuilder.factory.buildAssessment({
-    userId: secondUser.id,
-    type: Assessment.types.CAMPAIGN,
-    createdAt,
-    state: Assessment.states.COMPLETED,
-    isImproving: false,
-    lastQuestionDate: new Date(),
-    lastQuestionState: Assessment.statesOfLastQuestion.ASKED,
-    competenceId: null,
-    campaignParticipationId: secondUserSecondCampaignParticipationId,
-  });
-
-  const thirdUser = await databaseBuilder.factory.buildUser.withRawPassword({
+    participations: [
+      {
+        masteryRate: 0.5,
+        isImproved: true,
+        createdAt: '2023-12-27T15:07:57.376Z',
+        sharedAt: '2024-01-04T15:07:57.376Z',
+      },
+      {
+        masteryRate: 0.1,
+        isImproved: false,
+        createdAt: '2024-03-12T15:07:57.376Z',
+        sharedAt: '2024-03-24T15:07:57.376Z',
+      },
+    ],
+  },
+  {
     firstName: 'Sarah',
     lastName: 'Croche',
     email: 'sarah-croche@example.net',
-    cgu: true,
-    lang: 'fr',
-  });
+    participations: [
+      {
+        masteryRate: 0.5,
+        isImproved: true,
+        createdAt: '2023-12-27T15:07:57.376Z',
+        sharedAt: '2024-01-04T15:07:57.376Z',
+      },
+      {
+        masteryRate: 0.5,
+        isImproved: false,
+        createdAt: '2024-03-12T15:07:57.376Z',
+        sharedAt: '2024-03-24T15:07:57.376Z',
+      },
+    ],
+  },
+];
 
-  const thirdOrganizationLearner = await databaseBuilder.factory.buildOrganizationLearner({
-    firstName: 'Sarah',
-    lastName: 'Croche',
-    userId: thirdUser.id,
-    organizationId: PRO_ORGANIZATION_ID,
-    division: null,
-  });
-  const { id: thirdUserFirstCampaignParticipationId } = await databaseBuilder.factory.buildCampaignParticipation({
-    campaignId: CAMPAIGN_PROASSMUL_ID,
-    organizationLearnerId: thirdOrganizationLearner.id,
-    userId: thirdUser.id,
-    masteryRate: 0.5,
-    isImproved: true,
-    createdAt: '2023-12-27T15:07:57.376Z',
-    sharedAt: '2024-01-04T15:07:57.376Z',
-  });
-  await databaseBuilder.factory.buildAssessment({
-    userId: thirdUser.id,
-    type: Assessment.types.CAMPAIGN,
-    createdAt,
-    state: Assessment.states.COMPLETED,
-    isImproving: false,
-    lastQuestionDate: new Date(),
-    lastQuestionState: Assessment.statesOfLastQuestion.ASKED,
-    competenceId: null,
-    campaignParticipationId: thirdUserFirstCampaignParticipationId,
-  });
-
-  const { id: thirdUserSecondCampaignParticipationId } = await databaseBuilder.factory.buildCampaignParticipation({
-    organizationLearnerId: thirdOrganizationLearner.id,
-    userId: thirdUser.id,
-    campaignId: CAMPAIGN_PROASSMUL_ID,
-    masteryRate: 0.5,
-    isImproved: false,
-    createdAt: '2024-03-12T15:07:57.376Z',
-    sharedAt: '2024-03-24T15:07:57.376Z',
-  });
-
-  await databaseBuilder.factory.buildAssessment({
-    userId: thirdUser.id,
-    type: Assessment.types.CAMPAIGN,
-    createdAt,
-    state: Assessment.states.COMPLETED,
-    isImproving: false,
-    lastQuestionDate: new Date(),
-    lastQuestionState: Assessment.statesOfLastQuestion.ASKED,
-    competenceId: null,
-    campaignParticipationId: thirdUserSecondCampaignParticipationId,
-  });
-}
-
-async function _buildMultipleParticipationsForPROCOLMULCampaign(databaseBuilder) {
-  const firstUser = await databaseBuilder.factory.buildUser.withRawPassword({
+const PROCOLMUL_USERS = [
+  {
     firstName: 'Martin',
     lastName: 'Sapin',
     email: 'martin-sapin@example.net',
-    cgu: true,
-    lang: 'fr',
-  });
-
-  const firstOrganizationLearner = await databaseBuilder.factory.buildOrganizationLearner({
-    firstName: 'Martin',
-    lastName: 'Sapin',
-    userId: firstUser.id,
-    organizationId: PRO_ORGANIZATION_ID,
-    division: null,
-  });
-
-  await databaseBuilder.factory.buildCampaignParticipation({
-    campaignId: CAMPAIGN_PROCOLMUL_ID,
-    organizationLearnerId: firstOrganizationLearner.id,
-    userId: firstUser.id,
-    pixScore: 20,
-    isImproved: true,
-    status: CampaignParticipationStatuses.SHARED,
-    createdAt: '2023-12-27T15:07:57.376Z',
-    sharedAt: '2024-01-04T15:07:57.376Z',
-  });
-
-  await databaseBuilder.factory.buildCampaignParticipation({
-    organizationLearnerId: firstOrganizationLearner.id,
-    userId: firstUser.id,
-    campaignId: CAMPAIGN_PROCOLMUL_ID,
-    pixScore: 50,
-    isImproved: false,
-    status: CampaignParticipationStatuses.SHARED,
-    createdAt: '2024-03-12T15:07:57.376Z',
-    sharedAt: '2024-03-24T15:07:57.376Z',
-  });
-
-  const secondUser = await databaseBuilder.factory.buildUser.withRawPassword({
+    participations: [
+      { pixScore: 20, isImproved: true, createdAt: '2023-12-27T15:07:57.376Z', sharedAt: '2024-01-04T15:07:57.376Z' },
+      { pixScore: 50, isImproved: false, createdAt: '2024-03-12T15:07:57.376Z', sharedAt: '2024-03-24T15:07:57.376Z' },
+    ],
+  },
+  {
     firstName: 'José',
     lastName: 'Lopez',
     email: 'jose-lopez@example.net',
-    cgu: true,
-    lang: 'fr',
-  });
-
-  const secondOrganizationLearner = await databaseBuilder.factory.buildOrganizationLearner({
-    firstName: 'José',
-    lastName: 'Lopez',
-    userId: secondUser.id,
-    organizationId: PRO_ORGANIZATION_ID,
-    division: null,
-  });
-
-  await databaseBuilder.factory.buildCampaignParticipation({
-    campaignId: CAMPAIGN_PROCOLMUL_ID,
-    organizationLearnerId: secondOrganizationLearner.id,
-    userId: secondUser.id,
-    pixScore: 50,
-    isImproved: true,
-    status: CampaignParticipationStatuses.SHARED,
-    createdAt: '2023-12-27T15:07:57.376Z',
-    sharedAt: '2024-01-04T15:07:57.376Z',
-  });
-
-  await databaseBuilder.factory.buildCampaignParticipation({
-    organizationLearnerId: secondOrganizationLearner.id,
-    userId: secondUser.id,
-    campaignId: CAMPAIGN_PROCOLMUL_ID,
-    pixScore: 45,
-    isImproved: false,
-    status: CampaignParticipationStatuses.SHARED,
-    createdAt: '2024-03-12T15:07:57.376Z',
-    sharedAt: '2024-03-24T15:07:57.376Z',
-  });
-
-  const thirdUser = await databaseBuilder.factory.buildUser.withRawPassword({
+    participations: [
+      { pixScore: 50, isImproved: true, createdAt: '2023-12-27T15:07:57.376Z', sharedAt: '2024-01-04T15:07:57.376Z' },
+      { pixScore: 45, isImproved: false, createdAt: '2024-03-12T15:07:57.376Z', sharedAt: '2024-03-24T15:07:57.376Z' },
+    ],
+  },
+  {
     firstName: 'Pierre',
     lastName: 'Quiroule',
     email: 'pierre-quiroule@example.net',
-    cgu: true,
-    lang: 'fr',
-  });
+    participations: [
+      { pixScore: 20, isImproved: true, createdAt: '2023-12-27T15:07:57.376Z', sharedAt: '2024-01-04T15:07:57.376Z' },
+      { pixScore: 20, isImproved: false, createdAt: '2024-03-12T15:07:57.376Z', sharedAt: '2024-03-24T15:07:57.376Z' },
+    ],
+  },
+];
 
-  const thirdOrganizationLearner = await databaseBuilder.factory.buildOrganizationLearner({
-    firstName: 'Pierre',
-    lastName: 'Quiroule',
-    userId: thirdUser.id,
-    organizationId: PRO_ORGANIZATION_ID,
-    division: null,
-  });
+async function _buildMultipleParticipationsForPROASSMULCampaign(databaseBuilder) {
+  for (const { firstName, lastName, email, participations } of PROASSMUL_USERS) {
+    const user = await databaseBuilder.factory.buildUser.withRawPassword({
+      firstName,
+      lastName,
+      email,
+      cgu: true,
+      lang: 'fr',
+    });
+    const organizationLearner = await databaseBuilder.factory.buildOrganizationLearner({
+      firstName,
+      lastName,
+      userId: user.id,
+      organizationId: PRO_ORGANIZATION_ID,
+      division: null,
+    });
 
-  await databaseBuilder.factory.buildCampaignParticipation({
-    campaignId: CAMPAIGN_PROCOLMUL_ID,
-    organizationLearnerId: thirdOrganizationLearner.id,
-    userId: thirdUser.id,
-    pixScore: 20,
-    isImproved: true,
-    status: CampaignParticipationStatuses.SHARED,
-    createdAt: '2023-12-27T15:07:57.376Z',
-    sharedAt: '2024-01-04T15:07:57.376Z',
-  });
+    for (const participation of participations) {
+      const { id: campaignParticipationId, createdAt } = await databaseBuilder.factory.buildCampaignParticipation({
+        campaignId: CAMPAIGN_PROASSMUL_ID,
+        organizationLearnerId: organizationLearner.id,
+        userId: user.id,
+        ...participation,
+      });
 
-  await databaseBuilder.factory.buildCampaignParticipation({
-    organizationLearnerId: thirdOrganizationLearner.id,
-    userId: thirdUser.id,
-    campaignId: CAMPAIGN_PROCOLMUL_ID,
-    pixScore: 20,
-    isImproved: false,
-    status: CampaignParticipationStatuses.SHARED,
-    createdAt: '2024-03-12T15:07:57.376Z',
-    sharedAt: '2024-03-24T15:07:57.376Z',
-  });
+      await databaseBuilder.factory.buildAssessment({
+        userId: user.id,
+        type: Assessment.types.CAMPAIGN,
+        createdAt,
+        state: Assessment.states.COMPLETED,
+        isImproving: false,
+        lastQuestionDate: new Date(),
+        lastQuestionState: Assessment.statesOfLastQuestion.ASKED,
+        competenceId: null,
+        campaignParticipationId,
+      });
+
+      databaseBuilder.factory.buildKnowledgeElementSnapshot({ campaignParticipationId, userId: user.id });
+    }
+  }
+}
+
+async function _buildMultipleParticipationsForPROCOLMULCampaign(databaseBuilder) {
+  for (const { firstName, lastName, email, participations } of PROCOLMUL_USERS) {
+    const user = await databaseBuilder.factory.buildUser.withRawPassword({
+      firstName,
+      lastName,
+      email,
+      cgu: true,
+      lang: 'fr',
+    });
+    const organizationLearner = await databaseBuilder.factory.buildOrganizationLearner({
+      firstName,
+      lastName,
+      userId: user.id,
+      organizationId: PRO_ORGANIZATION_ID,
+      division: null,
+    });
+
+    for (const participation of participations) {
+      await databaseBuilder.factory.buildCampaignParticipation({
+        campaignId: CAMPAIGN_PROCOLMUL_ID,
+        organizationLearnerId: organizationLearner.id,
+        userId: user.id,
+        status: CampaignParticipationStatuses.SHARED,
+        ...participation,
+      });
+    }
+  }
 }
 
 export async function buildOrganizationLearnersWithMultipleParticipations(databaseBuilder) {

--- a/api/src/maddo/application/campaigns-routes.js
+++ b/api/src/maddo/application/campaigns-routes.js
@@ -99,7 +99,7 @@ const register = async function (server) {
                         }).label('CampaignParticipationTube'),
                       )
                       .description(
-                        'Sujets évalués dans la campagne, null si le type de la campagne est `PROFILES_COLLECTION`',
+                        "Sujets évalués dans la campagne ou sujets liés au profil cible pour une campagne de collecte de profil, vide si la campagne n'est pas encore partagée",
                       )
                       .label('CampaignParticipationTubes'),
                   }).label('CampaignParticipation'),

--- a/api/src/prescription/campaign/application/api/models/CampaignParticipation.js
+++ b/api/src/prescription/campaign/application/api/models/CampaignParticipation.js
@@ -79,6 +79,7 @@ class ProfilesCollectionCampaignParticipation extends CampaignParticipation {
   constructor(args) {
     super(args);
     this.pixScore = args.pixScore;
+    this.tubes = args.tubes?.map((tube) => new TubeCoverage(tube));
   }
 }
 

--- a/api/src/prescription/campaign/domain/read-models/CampaignParticipation.js
+++ b/api/src/prescription/campaign/domain/read-models/CampaignParticipation.js
@@ -83,6 +83,7 @@ class ProfilesCollectionCampaignParticipation extends CampaignParticipation {
    */
   constructor(args) {
     super(args);
+    this.tubes = args.tubes;
     this.pixScore = args.pixScore;
   }
 }

--- a/api/src/prescription/campaign/domain/usecases/get-campaign-participations.js
+++ b/api/src/prescription/campaign/domain/usecases/get-campaign-participations.js
@@ -50,8 +50,8 @@ const getBadgesWithBadgesCalculationAndBadgesAcquisitions = async ({
 };
 
 const computeTubes = (campaignId, campaignParticipation, learningContent, knowledgeElementsByParticipation) => {
-  if (campaignParticipation.status !== CampaignParticipationStatuses.SHARED) {
-    return;
+  if (campaignParticipation.status !== CampaignParticipationStatuses.SHARED || !learningContent) {
+    return [];
   }
 
   const campaignResultLevelPerTubesAndCompetences = new CampaignResultLevelsPerTubesAndCompetences({
@@ -67,6 +67,20 @@ const computeTubes = (campaignId, campaignParticipation, learningContent, knowle
       reachedLevel: tube.meanLevel,
     });
   });
+};
+
+const getAcquisitionPercentage = (
+  participation,
+  badge,
+  isAcquired,
+  badgesForCalculation,
+  knowledgeElementsByParticipations,
+) => {
+  if (participation.status !== CampaignParticipationStatuses.SHARED) return 0;
+  if (isAcquired) return 100;
+  return badgesForCalculation
+    .find((badgeForCalculation) => badgeForCalculation.id === badge.id)
+    .getAcquisitionPercentage(knowledgeElementsByParticipations[participation.id] ?? []);
 };
 
 export const getCampaignParticipations = async function ({
@@ -93,12 +107,29 @@ export const getCampaignParticipations = async function ({
   const participationIds = participations.map(({ id }) => id);
 
   if (campaign.isProfilesCollection) {
-    return {
-      models: participations.map((participation) => {
-        return new ProfilesCollectionCampaignParticipation(participation);
+    const knowledgeElementsByParticipations = await knowledgeElementSnapshotRepository.findByCampaignParticipationIds(
+      participations.map((participation) => participation.id),
+    );
+
+    const models = await Promise.all(
+      participations.map(async (participation) => {
+        const participationKEs = knowledgeElementsByParticipations[participation.id] ?? [];
+        const participationSkillIds = participationKEs.map(({ skillId }) => skillId);
+
+        const learningContent =
+          participationSkillIds.length > 0
+            ? await learningContentRepository.findBySkillIds(participationSkillIds, locale)
+            : null;
+
+        const tubes = computeTubes(campaignId, participation, learningContent, {
+          [participation.id]: participationKEs,
+        });
+
+        return new ProfilesCollectionCampaignParticipation({ ...participation, tubes });
       }),
-      meta,
-    };
+    );
+
+    return { models, meta };
   }
   const { stages, acquiredStagesByParticipation } = await getStagesAndStageAcquisitions(
     stageRepository,
@@ -124,7 +155,7 @@ export const getCampaignParticipations = async function ({
   return {
     models: participations.map((participation) => {
       const tubes = computeTubes(campaignId, participation, learningContent, {
-        [participation.id]: knowledgeElementsByParticipations[participation.id],
+        [participation.id]: knowledgeElementsByParticipations[participation.id] ?? [],
       });
 
       const acquiredStagesForParticipation = acquiredStagesByParticipation[participation.id] || [];
@@ -166,17 +197,3 @@ export const getCampaignParticipations = async function ({
     meta,
   };
 };
-
-function getAcquisitionPercentage(
-  participation,
-  badge,
-  isAcquired,
-  badgesForCalculation,
-  knowledgeElementsByParticipations,
-) {
-  if (participation.status !== CampaignParticipationStatuses.SHARED) return 0;
-  if (isAcquired) return 100;
-  return badgesForCalculation
-    .find((badgeForCalculation) => badgeForCalculation.id === badge.id)
-    .getAcquisitionPercentage(knowledgeElementsByParticipations[participation.id] ?? []);
-}

--- a/api/src/prescription/shared/infrastructure/repositories/learning-content-repository.js
+++ b/api/src/prescription/shared/infrastructure/repositories/learning-content-repository.js
@@ -10,8 +10,15 @@ import { LearningContent } from '../../../../shared/domain/models/LearningConten
 import * as areaRepository from '../../../../shared/infrastructure/repositories/area-repository.js';
 import * as competenceRepository from '../../../../shared/infrastructure/repositories/competence-repository.js';
 import * as frameworkRepository from '../../../../shared/infrastructure/repositories/framework-repository.js';
+import * as skillRepository from '../../../../shared/infrastructure/repositories/skill-repository.js';
 import * as thematicRepository from '../../../../shared/infrastructure/repositories/thematic-repository.js';
 import * as tubeRepository from '../../../../shared/infrastructure/repositories/tube-repository.js';
+
+export const findBySkillIds = async (skillIds, locale) => {
+  const skills = await skillRepository.findByRecordIds(skillIds);
+  const frameworks = await _getLearningContentBySkills(skills, locale);
+  return new CampaignLearningContent(frameworks);
+};
 
 export async function findByCampaignParticipationId(campaignParticipationId, locale) {
   const campaignId = await campaignRepository.getCampaignIdByCampaignParticipationId(campaignParticipationId);
@@ -21,7 +28,7 @@ export async function findByCampaignParticipationId(campaignParticipationId, loc
 export async function findByCampaignId(campaignId, locale) {
   const skills = await campaignRepository.findSkills({ campaignId });
 
-  const frameworks = await _getLearningContentBySkillIds(skills, locale);
+  const frameworks = await _getLearningContentBySkills(skills, locale);
 
   return new CampaignLearningContent(frameworks);
 }
@@ -74,7 +81,7 @@ export async function findByOrganizationId({ organizationId, locale }) {
   });
 }
 
-async function _getLearningContentBySkillIds(skills, locale) {
+async function _getLearningContentBySkills(skills, locale) {
   if (_.isEmpty(skills)) {
     throw new NoSkillsInCampaignError();
   }

--- a/api/tests/maddo/application/acceptance/campaigns-routes_test.js
+++ b/api/tests/maddo/application/acceptance/campaigns-routes_test.js
@@ -172,7 +172,7 @@ describe('Acceptance | Maddo | Route | Campaigns', function () {
               numberOfStages: 0,
               reachedStage: 0,
             },
-            tubes: undefined,
+            tubes: [],
             badges: [
               {
                 altMessage: badge.altMessage,

--- a/api/tests/prescription/campaign/integration/application/api/campaigns-api_test.js
+++ b/api/tests/prescription/campaign/integration/application/api/campaigns-api_test.js
@@ -169,7 +169,7 @@ describe('Integration | Application | campaign-api', function () {
           sharedAt: null,
           masteryRate: null,
           status: CampaignParticipationStatuses.STARTED,
-          tubes: undefined,
+          tubes: [],
           stages: {
             numberOfStages: 0,
             reachedStage: 0,

--- a/api/tests/prescription/campaign/integration/domain/usecases/get-campaign-participations_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/get-campaign-participations_test.js
@@ -1,7 +1,4 @@
-import {
-  AssessmentCampaignParticipation,
-  ProfilesCollectionCampaignParticipation,
-} from '../../../../../../src/prescription/campaign/domain/read-models/CampaignParticipation.js';
+import { AssessmentCampaignParticipation } from '../../../../../../src/prescription/campaign/domain/read-models/CampaignParticipation.js';
 import { usecases } from '../../../../../../src/prescription/campaign/domain/usecases/index.js';
 import {
   CampaignParticipationStatuses,
@@ -213,8 +210,19 @@ describe('Integration | UseCase | get-campaign-participations', function () {
   });
 
   context('when campaign type is profile collection', function () {
-    it('should return all participations for given campaign', async function () {
+    it('should return all participations with tubes computed from knowledge element snapshots', async function () {
       // given
+      const frameworkId = learningContent.buildFramework().id;
+      const areaId = learningContent.buildArea({ frameworkId }).id;
+      const competence = learningContent.buildCompetence({ areaId });
+      const tube = learningContent.buildTube({ competenceId: competence.id });
+      const skill = learningContent.buildSkill({
+        tubeId: tube.id,
+        status: 'actif',
+        level: 1,
+        competenceId: competence.id,
+      });
+
       const campaign = buildCampaign({ type: CampaignTypes.PROFILES_COLLECTION });
       const organizationLearner1 = buildOrganizationLearner();
       const participation1 = buildCampaignParticipation({
@@ -225,20 +233,48 @@ describe('Integration | UseCase | get-campaign-participations', function () {
         pixScore: 42,
         validatedSkillsCount: 10,
       });
+
+      const firstParticipationKe = buildKnowledgeElement({
+        status: KnowledgeElement.StatusType.VALIDATED,
+        skillId: skill.id,
+        userId: participation1.userId,
+      });
+      buildKnowledgeElementSnapshot({
+        campaignParticipationId: participation1.id,
+        snapshot: new KnowledgeElementCollection([firstParticipationKe]).toSnapshot(),
+      });
+
       const organizationLearner2 = buildOrganizationLearner({
         organizationId: organizationLearner1.organizationId,
       });
       const participation2 = buildCampaignParticipation({
         campaignId: campaign.id,
-        status: CampaignParticipationStatuses.STARTED,
+        status: CampaignParticipationStatuses.SHARED,
         organizationLearnerId: organizationLearner2.id,
         masteryRate: 0.3,
         pixScore: 21,
         validatedSkillsCount: 10,
       });
-      buildCampaignParticipation({
+
+      const secondParticipationKe = buildKnowledgeElement({
+        status: KnowledgeElement.StatusType.INVALIDATED,
+        skillId: skill.id,
+        userId: participation2.userId,
+      });
+      buildKnowledgeElementSnapshot({
+        campaignParticipationId: participation2.id,
+        snapshot: new KnowledgeElementCollection([secondParticipationKe]).toSnapshot(),
+      });
+
+      const organizationLearner3 = buildOrganizationLearner({
+        organizationId: organizationLearner1.organizationId,
+      });
+      const participation3 = buildCampaignParticipation({
+        campaignId: campaign.id,
         status: CampaignParticipationStatuses.STARTED,
-        masteryRate: 0.5,
+        organizationLearnerId: organizationLearner3.id,
+        pixScore: null,
+        validatedSkillsCount: null,
       });
 
       await databaseBuilder.commit();
@@ -250,9 +286,7 @@ describe('Integration | UseCase | get-campaign-participations', function () {
       });
 
       //then
-      expect(models).to.have.lengthOf(2);
-      expect(models[0]).instanceOf(ProfilesCollectionCampaignParticipation);
-      expect(models[1]).instanceOf(ProfilesCollectionCampaignParticipation);
+      expect(models).to.have.lengthOf(3);
       expect(models).to.deep.members([
         {
           campaignParticipationId: participation1.id,
@@ -264,6 +298,17 @@ describe('Integration | UseCase | get-campaign-participations', function () {
           pixScore: participation1.pixScore,
           participantFirstName: organizationLearner1.firstName,
           participantLastName: organizationLearner1.lastName,
+          tubes: [
+            {
+              id: tube.id,
+              competenceId: competence.id,
+              competenceName: competence.name_i18n[FRENCH_SPOKEN],
+              title: tube.practicalTitle_i18n[FRENCH_SPOKEN],
+              description: tube.practicalDescription_i18n[FRENCH_SPOKEN],
+              maxLevel: 1,
+              reachedLevel: 1,
+            },
+          ],
         },
         {
           campaignParticipationId: participation2.id,
@@ -275,14 +320,113 @@ describe('Integration | UseCase | get-campaign-participations', function () {
           pixScore: participation2.pixScore,
           participantFirstName: organizationLearner2.firstName,
           participantLastName: organizationLearner2.lastName,
+          tubes: [
+            {
+              id: tube.id,
+              competenceId: competence.id,
+              competenceName: competence.name_i18n[FRENCH_SPOKEN],
+              title: tube.practicalTitle_i18n[FRENCH_SPOKEN],
+              description: tube.practicalDescription_i18n[FRENCH_SPOKEN],
+              maxLevel: 1,
+              reachedLevel: 0,
+            },
+          ],
+        },
+        {
+          campaignParticipationId: participation3.id,
+          userId: participation3.userId,
+          participantExternalId: participation3.participantExternalId,
+          status: participation3.status,
+          createdAt: participation3.createdAt,
+          sharedAt: participation3.sharedAt,
+          pixScore: participation3.pixScore,
+          participantFirstName: organizationLearner3.firstName,
+          participantLastName: organizationLearner3.lastName,
+          tubes: [],
         },
       ]);
       expect(meta).to.deep.equal({
         page: 1,
         pageCount: 1,
         pageSize: 10,
-        rowCount: 2,
+        rowCount: 3,
       });
+    });
+
+    it('should not include tubes from other participations', async function () {
+      // given
+      const frameworkId = learningContent.buildFramework({ id: 'recFrameworkIso' }).id;
+      const areaId = learningContent.buildArea({ id: 'recAreaIso', frameworkId }).id;
+      const competence1 = learningContent.buildCompetence({ id: 'recCompetenceIso1', areaId });
+      const tube1 = learningContent.buildTube({ id: 'recTubeIso1', competenceId: competence1.id });
+      const skill1 = learningContent.buildSkill({
+        id: 'recSkillIso1',
+        tubeId: tube1.id,
+        status: 'actif',
+        level: 1,
+        competenceId: competence1.id,
+      });
+
+      const competence2 = learningContent.buildCompetence({ id: 'recCompetenceIso2', areaId });
+      const tube2 = learningContent.buildTube({ id: 'recTubeIso2', competenceId: competence2.id });
+      const skill2 = learningContent.buildSkill({
+        id: 'recSkillIso2',
+        tubeId: tube2.id,
+        status: 'actif',
+        level: 2,
+        competenceId: competence2.id,
+      });
+
+      const campaign = buildCampaign({ type: CampaignTypes.PROFILES_COLLECTION });
+
+      const organizationLearner1 = buildOrganizationLearner();
+      const participation1 = buildCampaignParticipation({
+        campaignId: campaign.id,
+        status: CampaignParticipationStatuses.SHARED,
+        organizationLearnerId: organizationLearner1.id,
+      });
+      buildKnowledgeElementSnapshot({
+        campaignParticipationId: participation1.id,
+        snapshot: new KnowledgeElementCollection([
+          buildKnowledgeElement({
+            status: KnowledgeElement.StatusType.VALIDATED,
+            skillId: skill1.id,
+            userId: participation1.userId,
+          }),
+        ]).toSnapshot(),
+      });
+
+      const organizationLearner2 = buildOrganizationLearner({ organizationId: organizationLearner1.organizationId });
+      const participation2 = buildCampaignParticipation({
+        campaignId: campaign.id,
+        status: CampaignParticipationStatuses.SHARED,
+        organizationLearnerId: organizationLearner2.id,
+      });
+      buildKnowledgeElementSnapshot({
+        campaignParticipationId: participation2.id,
+        snapshot: new KnowledgeElementCollection([
+          buildKnowledgeElement({
+            status: KnowledgeElement.StatusType.VALIDATED,
+            skillId: skill2.id,
+            userId: participation2.userId,
+          }),
+        ]).toSnapshot(),
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const { models } = await usecases.getCampaignParticipations({
+        campaignId: campaign.id,
+        locale: FRENCH_SPOKEN,
+      });
+
+      // then
+      const result1 = models.find((m) => m.campaignParticipationId === participation1.id);
+      const result2 = models.find((m) => m.campaignParticipationId === participation2.id);
+
+      expect(result1.tubes.map((t) => t.id)).to.deep.equal([tube1.id]);
+      expect(result2.tubes.map((t) => t.id)).to.deep.equal([tube2.id]);
     });
   });
 });

--- a/api/tests/prescription/shared/integration/infrastructure/repositories/learning-content-repository_test.js
+++ b/api/tests/prescription/shared/integration/infrastructure/repositories/learning-content-repository_test.js
@@ -238,6 +238,41 @@ describe('Integration | Repository | learning-content', function () {
     [skill2Fr, skill3Fr] = _buildDomainSkillsFromDB([skill2DB, skill3DB], 'fr');
   });
 
+  describe('#findBySkillIds', function () {
+    it('should return frameworks, areas, competences, thematics and tubes of the skills hierarchy', async function () {
+      // given
+      framework1Fr.areas = [area1Fr];
+      area1Fr.competences = [competence2Fr];
+      competence2Fr.thematics = [thematic2Fr];
+      competence2Fr.tubes = [tube2Fr];
+      thematic2Fr.tubes = [tube2Fr];
+      tube2Fr.skills = [skill2Fr, skill3Fr];
+
+      // when
+      const learningContent = await learningContentRepository.findBySkillIds(['recSkill2', 'recSkill3']);
+
+      // then
+      expect(learningContent.areas).to.deep.equal([area1Fr]);
+      expect(learningContent.frameworks).to.deep.equal([framework1Fr]);
+    });
+
+    it('should translate names and descriptions when specifying a locale', async function () {
+      // given
+      framework1En.areas = [area1En];
+      area1En.competences = [competence2En];
+      competence2En.thematics = [thematic2En];
+      competence2En.tubes = [tube2En];
+      thematic2En.tubes = [tube2En];
+      tube2En.skills = [skill2Fr, skill3Fr];
+
+      // when
+      const learningContent = await learningContentRepository.findBySkillIds(['recSkill2', 'recSkill3'], 'en');
+
+      // then
+      expect(learningContent.frameworks).to.deep.equal([framework1En]);
+    });
+  });
+
   describe('#findByCampaignId', function () {
     let campaignId;
 

--- a/api/tests/tooling/domain-builder/factory/maddo/build-campaign-participation.js
+++ b/api/tests/tooling/domain-builder/factory/maddo/build-campaign-participation.js
@@ -13,7 +13,7 @@ export function buildCampaignParticipation({
   userId,
   clientId,
   masteryRate,
-  tubes,
+  tubes = [],
   badges,
   stages,
   pixScore,


### PR DESCRIPTION
## 🌱 Problème

Pour les campagnes de type **collecte de profil**, la route MADDO `GET /api/campaigns/{campaignId}/participations` ne retournait pas les tubes (sujets/compétences) associés aux participations partagées.

## 🐣 Proposition

- Ajout de la méthode `findBySkillIds` dans `learning-content-repository` pour récupérer le contenu pédagogique à partir d'une liste d'IDs de compétences issues des snapshots de knowledge elements
- Calcul des tubes par participation dans le usecase `get-campaign-participations` pour le chemin collecte de profil (les tubes sont calculés à partir des snapshots de KE)

## 🌷 Remarques

Le calcul des tubes pour une collecte de profil diffère d'une campagne d'évaluation : le contenu pédagogique est déterminé dynamiquement à partir des compétences présentes dans les snapshots, et non à partir des compétences cibles de la campagne.

## 🐝 Pour tester

```sh
API_URL="https://pix-api-maddo-review-pr15987.osc-fr1.scalingo.io"
CAMPAIGN_ID=6001

# Get AUTH SECRET

SECRET=$(scalingo --app pix-api-maddo-review-pr15987 env-get 'AUTH_SECRET')
EXPIRY=$(($(date +%s) + 360))

# JWT Header
HEADER='{"alg":"HS256","typ":"JWT"}'
HEADER_B64=$(echo -n "$HEADER" | base64 -w 0 | tr -d '=' | tr '+/' '-_')

# JWT Payload
PAYLOAD="{\"client_id\":\"maddo-client\",\"source\":\"pix-client\",\"scope\":\"campaigns\",\"exp\":$EXPIRY}"
PAYLOAD_B64=$(echo -n "$PAYLOAD" | base64 -w 0 | tr -d '=' | tr '+/' '-_')

# JWT Signature
SIGNATURE_B64=$(echo -n "${HEADER_B64}.${PAYLOAD_B64}" | openssl dgst -sha256 -hmac "$SECRET" -binary | base64 -w 0 | tr -d '=' | tr '+/' '-_')

# Complete JWT token
TOKEN="${HEADER_B64}.${PAYLOAD_B64}.${SIGNATURE_B64}"

curl -X GET "${API_URL}/api/campaigns/6001/participations" \
  -H "Authorization: Bearer ${TOKEN}" \
  -H "Content-Type: application/json" | jq
```
- [x] Creer un nouveau compte sur PixApp
- [x] Répondre a quelques questions en autonomie de parcours competences non autonomes non apprenant hors campagne modules apprenants 
- [x] Participer a la campagne de collecte de profil PROCOLMUL mais ne pas partager le profil 
- [x] Faire appel au curl si dessus pour vérifier la présence de la participation en cours dans le JSON
- [x] Partager le profil
- [x] Refaire l'appel et constater la presence des tubes qui correspondent aux questions auxquelles vous avez répondu.
