### PR TITLE
[TECH] :recycle: Réduit l'utilisation de LODASH

### DIFF
--- a/api/src/certification/evaluation/application/scenario-simulator-controller.js
+++ b/api/src/certification/evaluation/application/scenario-simulator-controller.js
@@ -1,7 +1,5 @@
 import { Readable } from 'node:stream';
 
-import _ from 'lodash';
-
 import { random } from '../../../shared/infrastructure/utils/random.js';
 import { DEFAULT_PROBABILITY_TO_PICK_CHALLENGE } from '../../shared/domain/constants.js';
 import { pickAnswerStatusService } from '../../shared/domain/services/pick-answer-status-service.js';
@@ -34,24 +32,20 @@ async function simulateFlashAssessmentScenario(
   const pickAnswerStatus = dependencies.pickAnswerStatusService.pickAnswerStatusForCapacity(capacity);
 
   async function* generate() {
-    const iterations = _.range(0, numberOfIterations);
-
-    for (const index of iterations) {
+    for (let index = 0; index < numberOfIterations; index++) {
       const pickChallenge = dependencies.pickChallengeService.getChallengePicker(challengePickProbability);
 
-      const usecaseParams = _.omitBy(
-        {
-          pickAnswerStatus,
-          pickChallenge,
-          locale,
-          initialCapacity,
-          variationPercent,
-          accessibilityAdjustmentNeeded,
-          stopAtChallenge,
-          versionId,
-        },
-        _.isUndefined,
-      );
+      const usecaseParams = {
+        pickAnswerStatus,
+        pickChallenge,
+        locale,
+        initialCapacity,
+        variationPercent,
+        accessibilityAdjustmentNeeded,
+        stopAtChallenge,
+        versionId,
+      };
+      Object.keys(usecaseParams).forEach((key) => usecaseParams[key] === undefined && delete usecaseParams[key]);
 
       const simulationReport = await usecases.simulateFlashAssessmentScenario(usecaseParams);
 

--- a/api/src/certification/evaluation/domain/models/CertificationAssessmentScore.js
+++ b/api/src/certification/evaluation/domain/models/CertificationAssessmentScore.js
@@ -1,5 +1,3 @@
-import _ from 'lodash';
-
 import { status } from '../../../../shared/domain/models/AssessmentResult.js';
 import { MINIMUM_REPRODUCIBILITY_RATE_TO_BE_CERTIFIED } from '../../../shared/domain/constants.js';
 
@@ -15,10 +13,7 @@ class CertificationAssessmentScore {
   }
 
   get nbPix() {
-    if (_.isEmpty(this.competenceMarks)) {
-      return 0;
-    }
-    return _.sumBy(this.competenceMarks, 'score');
+    return this.competenceMarks.reduce((pixCount, competenceMark) => pixCount + competenceMark.score, 0);
   }
 
   get status() {

--- a/api/src/certification/evaluation/domain/services/CertificationContract.js
+++ b/api/src/certification/evaluation/domain/services/CertificationContract.js
@@ -1,10 +1,8 @@
-import _ from 'lodash';
-
 import { CertificationComputeError } from '../errors.js';
 
-class CertificationContract {
+export class CertificationContract {
   static assertThatWeHaveEnoughAnswers(listAnswers, listChallenges) {
-    const someUnansweredChallenges = _.some(listChallenges, (challenge) => {
+    const someUnansweredChallenges = listChallenges.some((challenge) => {
       return (
         !challenge.hasBeenSkippedAutomatically &&
         !challenge.isNeutralized &&
@@ -33,7 +31,7 @@ class CertificationContract {
 
   static assertThatEveryAnswerHasMatchingChallenge(answersForCompetence, challengesForCompetence) {
     answersForCompetence.forEach((answer) => {
-      const challenge = _.find(challengesForCompetence, { challengeId: answer.challengeId });
+      const challenge = challengesForCompetence.find((challenge) => challenge.challengeId === answer.challengeId);
       if (!challenge) {
         throw new CertificationComputeError('Problème de chargement du challenge ' + answer.challengeId);
       }
@@ -41,12 +39,12 @@ class CertificationContract {
   }
 
   static assertThatNoChallengeHasMoreThanOneAnswer(answersForCompetence) {
-    const someChallengesHaveMoreThanOneAnswer = _(answersForCompetence)
-      .groupBy((answer) => answer.challengeId)
-      .some((answerGroup) => answerGroup.length > 1);
-
-    if (someChallengesHaveMoreThanOneAnswer) {
-      throw new CertificationComputeError('Plusieurs réponses pour une même épreuve');
+    const seenIds = new Set();
+    for (const answer of answersForCompetence) {
+      if (seenIds.has(answer.challengeId)) {
+        throw new CertificationComputeError('Plusieurs réponses pour une même épreuve');
+      }
+      seenIds.add(answer.challengeId);
     }
   }
 
@@ -55,5 +53,3 @@ class CertificationContract {
     return numberOfNonNeutralizedChallenges >= minimalNumberOfNonNeutralizedChallengesToBeTrusted;
   }
 }
-
-export { CertificationContract };

--- a/api/src/certification/session-management/domain/models/CertificationAssessment.js
+++ b/api/src/certification/session-management/domain/models/CertificationAssessment.js
@@ -5,7 +5,6 @@
 import JoiDate from '@joi/date';
 import BaseJoi from 'joi';
 const Joi = BaseJoi.extend(JoiDate);
-import _ from 'lodash';
 
 import { AnswerStatus } from '../../../../shared/domain/models/AnswerStatus.js';
 import { Assessment } from '../../../../shared/domain/models/Assessment.js';
@@ -73,7 +72,7 @@ export class CertificationAssessment {
   }
 
   getCertificationChallenge(challengeId) {
-    return _.find(this.certificationChallenges, { challengeId }) || null;
+    return this.certificationChallenges.find((challenge) => challenge.challengeId === challengeId) || null;
   }
 
   getAnswerByQuestionNumber(questionNumber) {
@@ -81,7 +80,7 @@ export class CertificationAssessment {
   }
 
   neutralizeChallengeByRecId(recId) {
-    const challengeToBeNeutralized = _.find(this.certificationChallenges, { challengeId: recId });
+    const challengeToBeNeutralized = this.certificationChallenges.find((challenge) => challenge.challengeId === recId);
     if (challengeToBeNeutralized) {
       challengeToBeNeutralized.neutralize();
     } else {
@@ -92,7 +91,7 @@ export class CertificationAssessment {
   endDueToFinalization() {
     if (this.state === Assessment.states.STARTED) {
       this.state = Assessment.states.ENDED_DUE_TO_FINALIZATION;
-      this.endedAt = this._getLastChallenge()?.createdAt || this.createdAt;
+      this.endedAt = this._getLastChallengeCreatedAt();
     }
   }
 
@@ -108,8 +107,8 @@ export class CertificationAssessment {
     }
 
     if (_isAnswerKoOrSkipped(toBeNeutralizedChallengeAnswer.result.status)) {
-      const challengeToBeNeutralized = _.find(this.certificationChallenges, {
-        challengeId: toBeNeutralizedChallengeAnswer.challengeId,
+      const challengeToBeNeutralized = this.certificationChallenges.find((certificationChallenge) => {
+        return certificationChallenge.challengeId === toBeNeutralizedChallengeAnswer.challengeId;
       });
       challengeToBeNeutralized.neutralize();
       return NeutralizationAttempt.neutralized(questionNumber);
@@ -119,7 +118,9 @@ export class CertificationAssessment {
   }
 
   deneutralizeChallengeByRecId(recId) {
-    const challengeToBeDeneutralized = _.find(this.certificationChallenges, { challengeId: recId });
+    const challengeToBeDeneutralized = this.certificationChallenges.find(
+      (certificationChallenge) => certificationChallenge.challengeId === recId,
+    );
     if (challengeToBeDeneutralized) {
       challengeToBeDeneutralized.deneutralize();
     } else {
@@ -142,10 +143,12 @@ export class CertificationAssessment {
   }
 
   findAnswersAndChallengesForCertifiableBadgeKey(certifiableBadgeKey) {
-    const certificationChallengesForBadge = _.filter(this.certificationChallenges, { certifiableBadgeKey });
+    const certificationChallengesForBadge = this.certificationChallenges.filter(
+      (certificationChallenge) => certificationChallenge.certifiableBadgeKey === certifiableBadgeKey,
+    );
     const challengeIds = certificationChallengesForBadge.map((ccfb) => ccfb.challengeId);
     const answersForBadge = this.certificationAnswersByDate.filter(({ challengeId }) =>
-      _.includes(challengeIds, challengeId),
+      challengeIds.includes(challengeId),
     );
     return {
       certificationChallenges: certificationChallengesForBadge,
@@ -193,8 +196,16 @@ export class CertificationAssessment {
     ];
   }
 
-  _getLastChallenge() {
-    return _.orderBy(this.certificationChallenges, 'createdAt', 'desc')[0];
+  _getLastChallengeCreatedAt() {
+    if (this.certificationChallenges.length === 0) {
+      return this.createdAt;
+    }
+    return new Date(
+      this.certificationChallenges
+        .map((cc) => cc.createdAt.getTime())
+        .sort()
+        .at(-1),
+    );
   }
 }
 

--- a/api/src/certification/session-management/domain/read-models/CertificationDetails.js
+++ b/api/src/certification/session-management/domain/read-models/CertificationDetails.js
@@ -1,5 +1,3 @@
-import _ from 'lodash';
-
 import { AnswerCollectionForScoring } from '../../../shared/domain/models/AnswerCollectionForScoring.js';
 import { ReproducibilityRate } from '../../../shared/domain/models/ReproducibilityRate.js';
 
@@ -38,13 +36,15 @@ export class CertificationDetails {
     const competencesWithMark = _buildCompetencesWithMark({ competenceMarks, placementProfile });
     const listChallengesAndAnswers = _buildListChallengesAndAnswers({ certificationAssessment, competencesWithMark });
 
+    const totalScore = competenceMarks.reduce((score, competenceMark) => score + competenceMark.score, 0);
+
     return new CertificationDetails({
       id: certificationAssessment.certificationCourseId,
       userId: certificationAssessment.userId,
       createdAt: certificationAssessment.createdAt,
       lastAnswerAt: certificationAssessment.lastAnswerAt,
       status: certificationAssessment.state,
-      totalScore: _.sumBy(competenceMarks, 'score'),
+      totalScore,
       percentageCorrectAnswers: reproducibilityRate.value,
       competencesWithMark,
       listChallengesAndAnswers,
@@ -103,7 +103,7 @@ function _buildListChallengesAndAnswers({ certificationAssessment, competencesWi
     };
   });
 
-  const unansweredChallengesAndAnswers = _(certificationAssessment.certificationChallenges)
+  const unansweredChallengesAndAnswers = certificationAssessment.certificationChallenges
     .map((challenge) => {
       const answer = certificationAssessment.certificationAnswersByDate.find(
         (answer) => answer.challengeId === challenge.challengeId,
@@ -122,14 +122,15 @@ function _buildListChallengesAndAnswers({ certificationAssessment, competencesWi
         value: undefined,
       };
     })
-    .compact()
-    .sortBy('competence')
-    .value();
+    .filter(Boolean)
+    .sort((a, b) => (a['competence'] > b['competence'] ? 1 : a['competence'] < b['competence'] ? -1 : 0));
 
-  return answeredChallengesAndAnswers.concat(unansweredChallengesAndAnswers);
+  return answeredChallengesAndAnswers.concat(Object.values(unansweredChallengesAndAnswers));
 }
 
 function _getCompetenceIndexForChallenge(certificationChallenge, competencesWithMark) {
-  const competenceWithMark = _.find(competencesWithMark, { id: certificationChallenge.competenceId });
+  const competenceWithMark = competencesWithMark?.find(
+    (competenceWithMark) => competenceWithMark.id === certificationChallenge.competenceId,
+  );
   return competenceWithMark ? competenceWithMark.index : '';
 }

--- a/api/src/certification/shared/domain/models/AnswerCollectionForScoring.js
+++ b/api/src/certification/shared/domain/models/AnswerCollectionForScoring.js
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 const qrocmDepChallenge = 'QROCM-dep';
 
 class AnswerCollectionForScoring {
@@ -46,7 +45,7 @@ class AnswerCollectionForScoring {
     const challengesForCompetence = this.challengesWithAnswers.filter(
       (challengeWithAnswer) => challengeWithAnswer.competenceId() === competenceId,
     );
-    const numberOfChallenges = _(challengesForCompetence)
+    const numberOfChallenges = challengesForCompetence
       .map((challenge) => {
         if (challengesForCompetence.length < 3 && challenge.isQROCMdep()) {
           return 2;
@@ -54,7 +53,7 @@ class AnswerCollectionForScoring {
           return 1;
         }
       })
-      .sum();
+      .reduce((challengeCount, challengeForCompetenceCount) => challengeCount + challengeForCompetenceCount, 0);
     return numberOfChallenges;
   }
 
@@ -73,14 +72,14 @@ class AnswerCollectionForScoring {
       }
     });
 
-    return _.min([nbOfCorrectAnswers, 3]);
+    return Math.min(nbOfCorrectAnswers, 3);
   }
 
   numberOfNeutralizedChallengesForCompetence(competenceId) {
     const answersForCompetence = this.challengesWithAnswers.filter(
       (challengeWithAnswer) => challengeWithAnswer.competenceId() === competenceId,
     );
-    return _(answersForCompetence)
+    return answersForCompetence
       .map((answer) => {
         if (answer.isNeutralized()) {
           if (answersForCompetence.length < 3 && answer.isQROCMdep()) {
@@ -92,7 +91,7 @@ class AnswerCollectionForScoring {
           return 0;
         }
       })
-      .sum();
+      .reduce((answerCount, answerForCompetenceCount) => answerCount + answerForCompetenceCount, 0);
   }
 }
 


### PR DESCRIPTION
## 🌱 Problème

Nous utilisons une librairie extérieure (`lodash`) pour faire des choses que nous pourrions faire en JavaScript natif.

## 🐣 Proposition

Réduire l'utilisation de `lodash`

## 🌷 Remarques

Une bizarrerie

```
> a = new Date('2020-01-01T00:00:00.000Z')
2020-01-01T00:00:00.000Z
> b = new Date('2020-01-02T00:00:00.000Z')
2020-01-02T00:00:00.000Z
> c = new Date('2020-12-31T10:02:00.000Z')
2020-12-31T10:02:00.000Z
> d  = new Date('2020-12-31T10:00:00.000Z')
2020-12-31T10:00:00.000Z
> [a,b,c,d].sort()
[
  2020-12-31T10:00:00.000Z,
  2020-12-31T10:02:00.000Z,
  2020-01-02T00:00:00.000Z,
  2020-01-01T00:00:00.000Z
]
```

Du coup, dans la fonction qui tri les `challenge.createdAt` pour mettre à jour la `endedAt` d'une certification, je suis passé par les timestamp (`date.getTime()`) pour faire le tri

## 🐝 Pour tester

Les tests sont verts