### PR TITLE
[TECH] :package: Fixe la version minimum de la bibliothèque `protobufs`

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -11232,9 +11232,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.0.1.tgz",
+      "integrity": "sha512-NWWCCscLjs+cOKF/s/XVNFRW7Yih0fdH+9brffR5NZCy8k42yRdl5KlWKMVXuI1vfCoy4o1z80XR/W/QUb3V3w==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/api/package.json
+++ b/api/package.json
@@ -195,7 +195,8 @@
     "handlebars": ">=4.7.9",
     "hapi-swagger": {
       "joi": "$joi"
-    }
+    },
+    "protobufjs": ">=7.5.5"
   },
   "engines": {
     "node": "^24.15.0"


### PR DESCRIPTION
## 🌱 Problème

Nous avons un risque critique sur une librairie utilisé par des librairies que nous utilisons.

https://github.com/1024pix/pix/security/dependabot/1820

> protobufjs compiles protobuf definitions into JS functions. Attackers can manipulate these definitions to execute arbitrary JS code.

## 🐣 Proposition

Fixer la version minimum de la bibliothèque `protobufjs`

Elle est utilisée 
- dans le cadre d'une bibliothèque ([`artillery`](https://www.npmjs.com/package/artillery)) les tests de charge de haut niveau (`high-level-tests/load-testing/`)
- par la bibliothèque [`google-translate`](https://www.npmjs.com/package/@google-cloud/translate) elle-même utilisé dans la librairie [`json-translate`](https://www.npmjs.com/package/json-translate) que nous utilisons dans le script de traduction dans l'API https://github.com/1024pix/pix/blob/dev/api/scripts/translate-language-files.js

## 🌷 Remarques

Je pense qu'Artillery est nécessaire (mais peut-être remplaçable par une autre bibliothèque ?).
Je ne suis pas sûr de comprendre le script de traduction par contre. Mais je n'ai pas pris le temps.

## 🐝 Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
